### PR TITLE
[transformer/sdpa] exp_ring_joint_sdpa: re-apply hash-excluded global-semaphore addresses

### DIFF
--- a/tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py
@@ -173,6 +173,7 @@ def run_exp_ring_joint_sdpa_nightly(
     max_mse=DEFAULT_MAX_MSE,
     do_check=True,
     num_iterations=1,
+    check_program_cache_hit=False,
     num_links=2,
     num_workers_per_link=5,
     num_buffers_per_channel=32,
@@ -187,6 +188,15 @@ def run_exp_ring_joint_sdpa_nightly(
 
     When `num_iterations > 1`, checks that all outputs are bitwise equal (determinism).
     When `num_iterations == 1`, checks accuracy against PyTorch SDPA reference.
+
+    When `check_program_cache_hit=True`, runs the semaphore-realloc cache-hit regression instead:
+    program cache is enabled and each iteration is dispatched with a FRESHLY-ALLOCATED (distinct
+    address) global-semaphore set — all sets kept alive so their addresses never collide. It asserts
+    the program-cache entry count stays constant after the first dispatch (genuine cache hit — the
+    per-link GlobalSemaphore addresses are hash-excluded) AND that every iteration matches the PyTorch
+    reference (PCC/MSE). If a semaphore address froze on the cache-hit fast path, iterations 1+ would
+    sync on iteration 0's stale semaphore and either hang or produce a wrong result. This exercises
+    ExpRingJointSDPADeviceOperation::get_dynamic_runtime_args re-applying the addresses every dispatch.
     """
     num_devices = detect_devices_without_opening()
     sp_size, tp_size, arch_type = calculate_mesh_config(num_devices)
@@ -377,16 +387,41 @@ def run_exp_ring_joint_sdpa_nightly(
         main_row_dim = sdpa_input_shard_dims[0] if sdpa_input_shard_dims[0] is not None else -1
         main_col_dim = sdpa_input_shard_dims[1] if sdpa_input_shard_dims[1] is not None else -1
 
-        # Pre-create all semaphore sets before the loop to avoid device writes between iterations
+        # Pre-create all semaphore sets before the loop to avoid device writes between iterations.
+        # Every iteration gets its OWN set; keeping every set alive here guarantees the allocator
+        # hands out a distinct address per set (a live buffer's address is never reused), which is
+        # exactly the fresh-semaphore scenario the cache-hit freeze regression needs.
         ccl_semaphores_list = [
             [ttnn.create_global_semaphore(mesh_device, ccl_sub_device_crs, 0) for _ in range(num_links)]
             for _ in range(num_iterations)
         ]
 
+        if check_program_cache_hit:
+            # Program cache must be ON so iterations 1+ take the cache-HIT fast path (the path that
+            # re-applies the hash-excluded semaphore addresses); otherwise every dispatch is a miss
+            # and the regression is vacuous.
+            mesh_device.enable_program_cache()
+
+        # Cache-hit freeze regression bookkeeping.
+        seen_sem_addrs = []
+        program_cache_entries_baseline = None
+
         tt_out_list = []
 
         for i in range(num_iterations):
             ttnn.synchronize_device(mesh_device)
+
+            if check_program_cache_hit:
+                # Fresh semaphore set for this iteration must have addresses never seen before,
+                # otherwise we cannot prove the cache-hit path re-applied a NEW address.
+                iter_sem_addrs = [ttnn.get_global_semaphore_address(sem) for sem in ccl_semaphores_list[i]]
+                for addr in iter_sem_addrs:
+                    assert addr not in seen_sem_addrs, (
+                        f"Iteration {i}: fresh global semaphore reused a prior address ({addr}); "
+                        "cannot prove the cache-hit path re-applied a NEW semaphore address."
+                    )
+                seen_sem_addrs.extend(iter_sem_addrs)
+                logger.info(f"[cache-hit iter {i}] semaphore addresses: {iter_sem_addrs}")
 
             tt_out, _tt_joint_out, _tt_lse = ttnn.transformer.exp_ring_joint_scaled_dot_product_attention(
                 tt_Q,
@@ -414,6 +449,25 @@ def run_exp_ring_joint_sdpa_nightly(
 
             tt_out_list.append(tt_out)
 
+            if check_program_cache_hit:
+                # Program-cache entries are inserted host-side at enqueue time. The composite op may
+                # cache several programs, so we assert the count is STABLE after the first dispatch
+                # (not necessarily 1): a genuine cache hit adds nothing. If the hash-excluded
+                # semaphore addresses leaked into the key, the count would grow every iteration.
+                entries = mesh_device.num_program_cache_entries()
+                if program_cache_entries_baseline is None:
+                    program_cache_entries_baseline = entries
+                    assert entries > 0, (
+                        f"Expected >0 program-cache entries after the first dispatch, got {entries}; "
+                        "program cache may not be enabled, so the cache-hit fast path is never exercised."
+                    )
+                else:
+                    assert entries == program_cache_entries_baseline, (
+                        f"Iteration {i}: expected the program-cache entry count to stay "
+                        f"{program_cache_entries_baseline} (genuine cache hit — only the freshly-allocated "
+                        f"global-semaphore addresses changed, and they are hash-excluded), got {entries}."
+                    )
+
         # to_torch only after all iterations (avoids PCIe readback between launches)
         def to_torch_out(tt_tensor):
             out = ttnn.to_torch(
@@ -423,6 +477,27 @@ def run_exp_ring_joint_sdpa_nightly(
                 ),
             )
             return out[:, :, :total_seq, :]
+
+        if check_program_cache_hit:
+            # Correctness on EVERY dispatch. joint_seq_len==0 -> pure non-causal SDPA over Q/K/V, so
+            # the reference is identical every iteration. A frozen semaphore address on the cache-hit
+            # path would make iterations 1+ sync on iteration 0's stale semaphore and fail here
+            # (wrong output) — or hang before ever reaching this check.
+            gt = torch.nn.functional.scaled_dot_product_attention(Q, K, V, is_causal=False)
+            gt_out = gt[:, :, :total_seq, :]
+            for i in range(num_iterations):
+                tt_out_torch = to_torch_out(tt_out_list[i])
+                out_pass, out_pcc = comp_pcc(gt_out, tt_out_torch, pcc_threshold)
+                mse = ((gt_out - tt_out_torch) ** 2).mean().item()
+                logger.info(f"[cache-hit iter {i}] PCC: {out_pcc}, MSE: {mse:.2e}")
+                assert out_pass, (
+                    f"Iteration {i}: PCC {out_pcc} below threshold {pcc_threshold}. On a cache HIT the "
+                    "per-link GlobalSemaphore addresses must be re-applied via get_dynamic_runtime_args; "
+                    "a frozen (stale) address would sync on an earlier iteration's semaphore and corrupt "
+                    "the output."
+                )
+                assert mse <= max_mse, f"Iteration {i}: MSE {mse:.2e} exceeds threshold {max_mse:.2e}"
+            return
 
         if num_iterations > 1:
             N_local = total_seq // sp_size
@@ -601,6 +676,44 @@ def test_exp_ring_joint_attention_sdpa_determinism(
         dtype,
         num_iterations=4,
         max_payload_size=max_payload_size,
+    )
+
+
+# === TEST 3b: PROGRAM-CACHE-HIT SEMAPHORE-REALLOC REGRESSION ===
+@pytest.mark.skipif(len(TEST_CONFIGS) == 0, reason="No valid device configuration detected")
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bf16"])
+@pytest.mark.parametrize("b, nh, total_seq, d, q_chunk_size, k_chunk_size", TEST_CONFIGS, ids=TEST_CONFIG_IDS)
+def test_exp_ring_joint_attention_sdpa_semaphore_realloc_cache_hit(
+    b, nh, total_seq, d, q_chunk_size, k_chunk_size, dtype, reset_seeds
+):
+    """
+    Cache-hit freeze regression for the hash-excluded per-link GlobalSemaphore addresses.
+
+    The per-link GlobalSemaphore addresses are excluded from exp_ring_joint_sdpa's program-cache
+    hash, so calls that differ only in which semaphores they pass still cache-hit. That makes the
+    addresses DYNAMIC: the factory bakes them on the cache-miss build and
+    ExpRingJointSDPADeviceOperation::get_dynamic_runtime_args() must re-apply them on every dispatch.
+    If an address froze on the cache-hit fast path, a later dispatch reusing the cached program with
+    a freshly-allocated semaphore set would sync on the stale address and hang or produce garbage.
+
+    This test dispatches the SAME cached program num_iterations times, each with a fresh (distinct
+    address, all kept alive) global-semaphore set on fixed Q/K/V inputs, and asserts:
+      - the program-cache entry count is stable after the first dispatch (genuine cache hit), and
+      - every iteration matches the PyTorch SDPA reference (PCC/MSE).
+    A frozen semaphore address fails one or both.
+    """
+    run_exp_ring_joint_sdpa_nightly(
+        b,
+        nh,
+        total_seq,
+        d,
+        q_chunk_size,
+        k_chunk_size,
+        dtype,
+        pcc_threshold=DEFAULT_PCC_THRESHOLD,
+        max_mse=DEFAULT_MAX_MSE,
+        num_iterations=4,
+        check_program_cache_hit=True,
     )
 
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_device_operation.cpp
@@ -373,7 +373,7 @@ tt::tt_metal::operation::OpPerformanceModelGeneral<Tensors> ExpRingJointSDPADevi
 }
 
 std::vector<tt::tt_metal::DynamicRuntimeArg> ExpRingJointSDPADeviceOperation::get_dynamic_runtime_args(
-    const ExpRingJointSDPAParams& args,
+    const ExpRingJointSDPAParams& operation_attributes,
     const ExpRingJointSDPAInputs& tensor_args,
     ExpRingJointSDPAResult& /*tensor_return_value*/,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
@@ -388,22 +388,22 @@ std::vector<tt::tt_metal::DynamicRuntimeArg> ExpRingJointSDPADeviceOperation::ge
     auto* mesh_device = tensor_args.input_q.device();
     const auto device_grid = mesh_device->compute_with_storage_grid_size();
     const CoreCoord user_grid =
-        args.program_config.has_value() ? args.program_config->compute_with_storage_grid_size : device_grid;
+        operation_attributes.program_config.has_value() ? operation_attributes.program_config->compute_with_storage_grid_size : device_grid;
     const CoreCoord sdpa_grid = {user_grid.x - 1, user_grid.y};
     const uint32_t num_sdpa_cores = sdpa_grid.x * sdpa_grid.y;
 
     std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
-    dynamic_args.reserve(static_cast<std::size_t>(num_sdpa_cores) * (args.num_links + 1));
+    dynamic_args.reserve(static_cast<std::size_t>(num_sdpa_cores) * (operation_attributes.num_links + 1));
     for (uint32_t i = 0; i < num_sdpa_cores; ++i) {
         const CoreCoord core = {i % sdpa_grid.x, i / sdpa_grid.x};
 
         // Reader kernel: per-link semaphore addresses on every SDPA core.
-        for (uint32_t lnk = 0; lnk < args.num_links; ++lnk) {
+        for (uint32_t lnk = 0; lnk < operation_attributes.num_links; ++lnk) {
             dynamic_args.push_back(
                 {dyn::kReaderKernelIdx,
                  core,
                  dyn::kReaderSemaphoreArgBase + lnk,
-                 static_cast<uint32_t>(args.semaphore[lnk].address())});
+                 static_cast<uint32_t>(operation_attributes.semaphore[lnk].address())});
         }
 
         // Fabric-writer kernel: out_ready_sem_addr on the two MUX-writer columns. num_links is
@@ -416,7 +416,7 @@ std::vector<tt::tt_metal::DynamicRuntimeArg> ExpRingJointSDPADeviceOperation::ge
                 {dyn::kWriterFabricKernelIdx,
                  core,
                  dyn::kWriterFabricOutReadySemArg,
-                 static_cast<uint32_t>(args.semaphore[link].address())});
+                 static_cast<uint32_t>(operation_attributes.semaphore[link].address())});
         }
     }
     return dynamic_args;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_device_operation.cpp
@@ -372,6 +372,56 @@ tt::tt_metal::operation::OpPerformanceModelGeneral<Tensors> ExpRingJointSDPADevi
     return operation::OpPerformanceModelGeneral<Tensors>(input_tensors, output_tensors, ideal_cycles);
 }
 
+std::vector<tt::tt_metal::DynamicRuntimeArg> ExpRingJointSDPADeviceOperation::get_dynamic_runtime_args(
+    const ExpRingJointSDPAParams& args,
+    const ExpRingJointSDPAInputs& tensor_args,
+    ExpRingJointSDPAResult& /*tensor_return_value*/,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+    // Re-apply the hash-excluded per-link GlobalSemaphore addresses to the cached program on every
+    // cache hit (the non-Buffer analog of the BufferBinding fast path). The factory bakes these same
+    // slots on the cache-miss build; both paths use the shared exp_ring_joint_sdpa_dynamic constants so
+    // the slot layout cannot drift. Semaphore addresses are mesh-uniform, so they are coord-independent
+    // (mesh_dispatch_coordinate is unused).
+    namespace dyn = exp_ring_joint_sdpa_dynamic;
+
+    // Recompute the SDPA worker grid exactly as build_exp_ring_joint_sdpa_program_descriptor() does.
+    auto* mesh_device = tensor_args.input_q.device();
+    const auto device_grid = mesh_device->compute_with_storage_grid_size();
+    const CoreCoord user_grid =
+        args.program_config.has_value() ? args.program_config->compute_with_storage_grid_size : device_grid;
+    const CoreCoord sdpa_grid = {user_grid.x - 1, user_grid.y};
+    const uint32_t num_sdpa_cores = sdpa_grid.x * sdpa_grid.y;
+
+    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
+    dynamic_args.reserve(static_cast<std::size_t>(num_sdpa_cores) * (args.num_links + 1));
+    for (uint32_t i = 0; i < num_sdpa_cores; ++i) {
+        const CoreCoord core = {i % sdpa_grid.x, i / sdpa_grid.x};
+
+        // Reader kernel: per-link semaphore addresses on every SDPA core.
+        for (uint32_t lnk = 0; lnk < args.num_links; ++lnk) {
+            dynamic_args.push_back(
+                {dyn::kReaderKernelIdx,
+                 core,
+                 dyn::kReaderSemaphoreArgBase + lnk,
+                 static_cast<uint32_t>(args.semaphore[lnk].address())});
+        }
+
+        // Fabric-writer kernel: out_ready_sem_addr on the two MUX-writer columns. num_links is
+        // TT_FATAL-fixed to 2 (see validate_on_program_cache_miss), so link_in_range always holds in the
+        // factory and out_ready_sem_addr is present on every MUX-writer core — mirror that here.
+        const bool is_mux_writer = (core.x >= sdpa_grid.x - 2);
+        if (is_mux_writer) {
+            const uint32_t link = (core.x == sdpa_grid.x - 1) ? 1u : 0u;
+            dynamic_args.push_back(
+                {dyn::kWriterFabricKernelIdx,
+                 core,
+                 dyn::kWriterFabricOutReadySemArg,
+                 static_cast<uint32_t>(args.semaphore[link].address())});
+        }
+    }
+    return dynamic_args;
+}
+
 }  // namespace ttnn::prim
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_device_operation.hpp
@@ -6,9 +6,11 @@
 
 #include <optional>
 #include <variant>
+#include <vector>
 
 #include "ttnn/tensor/tensor.hpp"
 
+#include <tt-metalium/experimental/program_descriptor_patching.hpp>
 #include "ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_device_operation_types.hpp"
 #include "ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_program_factory.hpp"
 
@@ -25,6 +27,17 @@ struct ExpRingJointSDPADeviceOperation {
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static tt::tt_metal::operation::OpPerformanceModelGeneral<Tensors> create_op_performance_model(
         const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensors);
+
+    // The per-link GlobalSemaphore addresses are excluded from the program-cache hash
+    // (ExpRingJointSDPAParams::attribute_values omits `semaphore`), so they are DYNAMIC: the factory
+    // bakes them for the cache-miss build and this method re-applies them to the cached program on
+    // every dispatch, so a cache hit with a different semaphore set cannot reuse a frozen address.
+    // Slot layout mirrors the factory via the shared exp_ring_joint_sdpa_dynamic constants.
+    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 
 ExpRingJointSDPAResult exp_ring_joint_scaled_dot_product_attention(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_program_factory.cpp
@@ -1543,10 +1543,17 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
         }
         reader_args.push_back(static_cast<uint32_t>(is_mux_writer_valid));
 
-        // Per-link semaphore addresses for chunk-level sync
+        // Per-link semaphore addresses for chunk-level sync. These occupy per-core reader slots
+        // exp_ring_joint_sdpa_dynamic::kReaderSemaphoreArgBase .. +num_links-1. They are hash-excluded, so
+        // they are baked here for the cache-miss build and re-applied every dispatch by
+        // get_dynamic_runtime_args(); if you reorder the args above, update kReaderSemaphoreArgBase (and
+        // thus the re-apply target) accordingly.
         reader_args.push_back(args.num_links);
         for (uint32_t lnk = 0; lnk < args.num_links; ++lnk) {
-            reader_args.push_back(static_cast<uint32_t>(args.semaphore[lnk].address()));
+            reader_args.push_back(static_cast<uint32_t>(
+                args.semaphore[lnk]
+                    .address()));  // smuggled-rta-ok: hash-excluded global-semaphore address, re-applied every dispatch
+                                   // via ExpRingJointSDPADeviceOperation::get_dynamic_runtime_args
         }
 
         // Inject fused-op synchronization RT args: ring_size, ring_index, direction (3 values)
@@ -1621,10 +1628,17 @@ tt::tt_metal::ProgramDescriptor build_exp_ring_joint_sdpa_program_descriptor(
             }
             writer_args.append(mux_writer_args);
 
-            // MUX writer RT args: out_ready_sem, injector coords, AG params, op signaler
+            // MUX writer RT args: out_ready_sem, injector coords, AG params, op signaler.
             if (link_in_range) {
+                // out_ready_sem_addr occupies per-core fabric-writer slot
+                // exp_ring_joint_sdpa_dynamic::kWriterFabricOutReadySemArg. It is a hash-excluded
+                // global-semaphore address, so it is baked here for the cache-miss build and re-applied
+                // every dispatch by get_dynamic_runtime_args(); if you reorder the args above, update
+                // kWriterFabricOutReadySemArg (and thus the re-apply target) accordingly.
                 const uint32_t out_ready_sem_addr = args.semaphore[link].address();
-                writer_args.push_back(out_ready_sem_addr);
+                writer_args.push_back(
+                    out_ready_sem_addr);  // smuggled-rta-ok: hash-excluded global-semaphore address, re-applied every
+                                          // dispatch via ExpRingJointSDPADeviceOperation::get_dynamic_runtime_args
 
                 // Find the injector core for this MUX writer's (batch, head)
                 const auto& mux_head_work = core_work.at(i).head_work;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_program_factory.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <optional>
 
 #include <tt-metalium/constants.hpp>
@@ -19,6 +20,30 @@
 #include "ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_device_operation_types.hpp"
 
 namespace ttnn::prim {
+
+// Single source of truth for the DYNAMIC (hash-excluded) global-semaphore address runtime args.
+//
+// The per-link GlobalSemaphore addresses are excluded from the program-cache key
+// (ExpRingJointSDPAParams::attribute_values omits `semaphore`), so two calls that differ only in
+// which GlobalSemaphores they pass still cache-hit. That makes the addresses dynamic: the factory
+// bakes them for the cache-miss build, and ExpRingJointSDPADeviceOperation::get_dynamic_runtime_args()
+// re-applies them on every dispatch — otherwise a cache hit with a different semaphore set would
+// silently reuse the address frozen at the first miss (the frozen-runtime-arg bug).
+//
+// The kernel indices and per-core arg slots below are the shared reference for BOTH the factory's
+// cache-miss bake (build_exp_ring_joint_sdpa_program_descriptor) and the cache-hit patch
+// (get_dynamic_runtime_args); reorder the runtime args in the factory and these constants (and thus
+// the re-apply targets) must be updated in lockstep.
+namespace exp_ring_joint_sdpa_dynamic {
+// Kernel indices — must match the desc.kernels push order (reader, writer, writer_fabric, compute[, mux]).
+inline constexpr uint32_t kReaderKernelIdx = 0;
+inline constexpr uint32_t kWriterFabricKernelIdx = 2;
+// Per-core reader runtime-arg slot of the first per-link semaphore address; slots
+// kReaderSemaphoreArgBase .. +num_links-1 hold args.semaphore[lnk].address().
+inline constexpr uint32_t kReaderSemaphoreArgBase = 26;
+// Per-core fabric-writer runtime-arg slot of out_ready_sem_addr (= args.semaphore[link].address()).
+inline constexpr uint32_t kWriterFabricOutReadySemArg = 25;
+}  // namespace exp_ring_joint_sdpa_dynamic
 
 struct ExpRingJointSDPAProgramFactory {
     static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(


### PR DESCRIPTION
### What
The factory pushed per-link `GlobalSemaphore` L1 addresses into reader and fabric-writer runtime args as plain uint32_t. The semaphore set is excluded from `compute_program_hash`, so calls differing only in their semaphores cache-hit and reuse the first-miss address (frozen-runtime-arg bug). A `GlobalSemaphore` address is not a tensor `Buffer*` (not reachable from tensor_args, no public Buffer accessor), so it cannot be a BufferBinding — it is re-applied every dispatch via a new `get_dynamic_runtime_args` override. Tensor buffers were already bound.

### Why
A raw buffer/semaphore address pushed as a plain uint32_t is invisible to the descriptor framework, which cannot patch it on a program-cache hit (it either rebuilds the descriptor every dispatch or serves a stale address). Declaring it as a tracked binding — or, where a binding is impossible or the value is hash-excluded, re-applying it via `get_dynamic_runtime_args` — removes the smuggled pointer. Pointer-smuggle removal only; no intended behavior change on the miss path.

### Test
Build clean; op unit tests green on Wormhole (cache-hit / program-cache paths exercised where applicable). Multi-device CCL/SDPA paths validate in CI. Detector `scripts/detect_smuggled_rta.py` clean on changed files.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-exp-ring-joint-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/smuggle-exp-ring-joint-sdpa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-exp-ring-joint-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/smuggle-exp-ring-joint-sdpa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-exp-ring-joint-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/smuggle-exp-ring-joint-sdpa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/smuggle-exp-ring-joint-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/smuggle-exp-ring-joint-sdpa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/smuggle-exp-ring-joint-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/smuggle-exp-ring-joint-sdpa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/smuggle-exp-ring-joint-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/smuggle-exp-ring-joint-sdpa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/smuggle-exp-ring-joint-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/smuggle-exp-ring-joint-sdpa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/smuggle-exp-ring-joint-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/smuggle-exp-ring-joint-sdpa)
