### PR TITLE
[experimental/ccl] ring_attention_all_gather_async: re-apply hash-excluded global-semaphore addresses

### DIFF
--- a/tests/nightly/t3000/ccl/test_ring_attention_all_gather.py
+++ b/tests/nightly/t3000/ccl/test_ring_attention_all_gather.py
@@ -60,8 +60,15 @@ def run_ring_attention_all_gather_impl(
     num_iters=1,
     enable_trace=True,
     pcc_threshold=0.99,
+    check_semaphore_realloc_cache_hit=False,
 ):
     torch.manual_seed(0)
+
+    if check_semaphore_realloc_cache_hit and enable_trace:
+        # The cache-hit freeze regression must re-apply the hash-excluded GlobalSemaphore addresses on
+        # every dispatch via override_runtime_arguments. A captured trace bakes the addresses at capture
+        # time and would never exercise the per-dispatch re-apply path, so it must run un-traced.
+        pytest.fail("check_semaphore_realloc_cache_hit requires enable_trace=False")
 
     sequence_index = 2
     head_index = 1
@@ -171,7 +178,22 @@ def run_ring_attention_all_gather_impl(
             tt_all_gather_out_tensor_list.append(tt_all_gather_out_tensors)
         logger.info(f"Done executing trace")
     else:
+        # Cache-hit freeze regression bookkeeping: every iteration gets its own freshly-allocated
+        # semaphore set (all kept alive above so the allocator never reuses an address). We assert the
+        # addresses are actually distinct across iterations, otherwise a cache HIT could reuse iter 0's
+        # stale address without the test noticing — the exact bug override_runtime_arguments must prevent.
+        seen_sem_addrs = []
         for i in range(num_iters):
+            if check_semaphore_realloc_cache_hit:
+                iter_sem_addrs = [ttnn.get_global_semaphore_address(sem) for sem in ccl_semaphore_handles[i]]
+                for addr in iter_sem_addrs:
+                    assert addr not in seen_sem_addrs, (
+                        f"Iteration {i}: fresh global semaphore reused a prior address ({addr}); "
+                        "cannot prove the cache-hit path re-applied a NEW semaphore address."
+                    )
+                seen_sem_addrs.extend(iter_sem_addrs)
+                logger.info(f"[cache-hit iter {i}] semaphore addresses: {iter_sem_addrs}")
+
             tt_all_gather_out_tensors = run_op(i)
             tt_all_gather_out_tensor_list.append(tt_all_gather_out_tensors)
 
@@ -407,4 +429,112 @@ def test_ring_attention_all_gather_program_cache(
         pcc_threshold=pcc_threshold,
     )
 
+    assert submesh_device.cache_entries_counter.total == 1
+
+
+@pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=True)
+@pytest.mark.parametrize("num_links", [1], ids=["1link"])
+@pytest.mark.parametrize(
+    "layout, ag_input_dtype, pcc_threshold",
+    [
+        (ttnn.TILE_LAYOUT, ttnn.bfloat16, 1.0),
+    ],
+    ids=[
+        "tile_bfloat16",
+    ],
+)
+@pytest.mark.parametrize(
+    "ag_output_shape, ag_num_inputs, rp_axis, rp_factor, up_factor",
+    [
+        ([1, 5, 4096, 64], 2, 1, 4, 1),
+    ],
+    ids=[
+        "shape2_2input_rp4",
+    ],
+)
+@pytest.mark.parametrize(
+    "mem_config_input, mem_config_ag",
+    [
+        (
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+        )
+    ],
+)
+@pytest.mark.parametrize(
+    "enable_trace, num_iters",
+    [
+        (False, 3),
+    ],
+    ids=["check"],
+)
+@pytest.mark.parametrize(
+    "device_params, all_gather_topology",
+    [
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Linear),
+    ],
+    ids=[
+        "line",
+    ],
+    indirect=["device_params"],
+)
+def test_ring_attention_all_gather_semaphore_realloc_cache_hit(
+    mesh_device,
+    ag_output_shape,
+    ag_num_inputs,
+    rp_axis,
+    rp_factor,
+    up_factor,
+    num_links,
+    ag_input_dtype,
+    layout,
+    pcc_threshold,
+    mem_config_input,
+    mem_config_ag,
+    enable_trace,
+    num_iters,
+    all_gather_topology,
+):
+    """
+    Cache-hit freeze regression for the hash-excluded out_ready GlobalSemaphore addresses.
+
+    ring_attention_all_gather_async excludes the per-link out_ready GlobalSemaphore L1 addresses from
+    its program-cache hash, so calls that differ only in which semaphores they pass still cache-HIT.
+    That makes the addresses DYNAMIC: the factory bakes them on the cache-miss build, and
+    RingAttentionAllGatherAsyncDeviceOperation::override_runtime_arguments() must re-apply them on every
+    dispatch. If an address froze on the cache-hit fast path, a later dispatch reusing the cached
+    program with a freshly-allocated semaphore set would sync on iteration 0's stale semaphore and
+    either hang or produce a wrong result.
+
+    This dispatches the SAME cached program num_iters times un-traced (so the cache-hit re-apply path
+    runs per dispatch), each with a fresh (distinct address, all kept alive) global-semaphore set, and
+    asserts:
+      - the semaphore addresses are distinct across iterations (the freeze scenario is real), and
+      - exactly one program-cache entry is created total (iterations 1+ genuinely cache-HIT — the
+        semaphore addresses are hash-excluded), and
+      - every iteration matches the reference output.
+    A frozen semaphore address fails one or both device checks.
+    """
+    submesh_device = create_ring_attention_submesh(mesh_device, rp_axis, rp_factor, up_factor)
+
+    run_ring_attention_all_gather_impl(
+        submesh_device,
+        ag_output_shape,
+        ag_num_inputs,
+        rp_axis,
+        rp_factor,
+        up_factor,
+        num_links,
+        ag_input_dtype,
+        layout,
+        mem_config_input,
+        mem_config_ag,
+        all_gather_topology=all_gather_topology,
+        enable_trace=enable_trace,
+        num_iters=num_iters,
+        pcc_threshold=pcc_threshold,
+        check_semaphore_realloc_cache_hit=True,
+    )
+
+    # Exactly one cache entry created across all dispatches → iterations 1+ were genuine cache HITs.
     assert submesh_device.cache_entries_counter.total == 1

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -650,10 +650,25 @@ public:
                             collect_tensor_buffers(tensor_args, tensor_return_value, sv.workload_descriptor);
                         tt::tt_metal::apply_resolved_bindings(program, sv.resolved_bindings, collected.buffers);
                     }
-                    // The WorkloadDescriptor variant never rebuilds, so a value a custom hash
-                    // excluded would stay frozen at first miss — re-apply declared dynamic args.
-                    apply_dynamic_runtime_args_if_declared(
-                        program, attrs, tensor_args, tensor_return_value, coordinate_range);
+                    // Cache hit never rebuilds; re-apply hash-excluded args via the override hook.
+                    if constexpr (factory_has_override_runtime_arguments()) {
+                        DescriptorFactory::override_runtime_arguments(
+                            program,
+                            attrs,
+                            tensor_args,
+                            tensor_return_value,
+                            std::optional<ttnn::MeshCoordinate>(coordinate_range.start_coord()));
+                    } else if constexpr (device_op_has_override_runtime_arguments()) {
+                        DeviceOperation::override_runtime_arguments(
+                            program,
+                            attrs,
+                            tensor_args,
+                            tensor_return_value,
+                            std::optional<ttnn::MeshCoordinate>(coordinate_range.start_coord()));
+                    } else {
+                        apply_dynamic_runtime_args_if_declared(
+                            program, attrs, tensor_args, tensor_return_value, coordinate_range);
+                    }
                 } else if constexpr (has_override_runtime_arguments()) {
                     // ProgramDescriptor variant, op owns its cache-hit re-derivation (the descriptor-era
                     // override_runtime_arguments()): re-apply ALL per-dispatch state — every runtime arg

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -662,15 +662,8 @@ public:
                         tt::tt_metal::apply_resolved_bindings(program, sv.resolved_bindings, collected.buffers);
                     }
                     // Cache hit never rebuilds; re-apply hash-excluded args via the override hook.
-                    if constexpr (factory_has_override_runtime_arguments()) {
+                    if constexpr (has_override_runtime_arguments()) {
                         DescriptorFactory::override_runtime_arguments(
-                            program,
-                            attrs,
-                            tensor_args,
-                            tensor_return_value,
-                            std::optional<ttnn::MeshCoordinate>(coordinate_range.start_coord()));
-                    } else if constexpr (device_op_has_override_runtime_arguments()) {
-                        DeviceOperation::override_runtime_arguments(
                             program,
                             attrs,
                             tensor_args,

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -661,10 +661,25 @@ public:
                             collect_tensor_buffers(tensor_args, tensor_return_value, sv.workload_descriptor);
                         tt::tt_metal::apply_resolved_bindings(program, sv.resolved_bindings, collected.buffers);
                     }
-                    // The WorkloadDescriptor variant never rebuilds, so a value a custom hash
-                    // excluded would stay frozen at first miss — re-apply declared dynamic args.
-                    apply_dynamic_runtime_args_if_declared(
-                        program, attrs, tensor_args, tensor_return_value, coordinate_range);
+                    // Cache hit never rebuilds; re-apply hash-excluded args via the override hook.
+                    if constexpr (factory_has_override_runtime_arguments()) {
+                        DescriptorFactory::override_runtime_arguments(
+                            program,
+                            attrs,
+                            tensor_args,
+                            tensor_return_value,
+                            std::optional<ttnn::MeshCoordinate>(coordinate_range.start_coord()));
+                    } else if constexpr (device_op_has_override_runtime_arguments()) {
+                        DeviceOperation::override_runtime_arguments(
+                            program,
+                            attrs,
+                            tensor_args,
+                            tensor_return_value,
+                            std::optional<ttnn::MeshCoordinate>(coordinate_range.start_coord()));
+                    } else {
+                        apply_dynamic_runtime_args_if_declared(
+                            program, attrs, tensor_args, tensor_return_value, coordinate_range);
+                    }
                 } else if constexpr (has_override_runtime_arguments()) {
                     // ProgramDescriptor variant, factory owns its cache-hit re-derivation (the
                     // descriptor-era override_runtime_arguments()): re-apply ALL per-dispatch state —

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_device_operation.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <optional>
 #include <tuple>
 #include <vector>
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
@@ -101,6 +101,36 @@ RingAttentionAllGatherAsyncMultiCoreWithWorkersProgramFactory::create_workload_d
     return wd;
 }
 
+void RingAttentionAllGatherAsyncMultiCoreWithWorkersProgramFactory::override_runtime_arguments(
+    tt::tt_metal::Program& program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& /*tensor_args*/,
+    tensor_return_value_t& /*tensor_return_value*/,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+    namespace dyn = ring_attention_all_gather_async_dynamic;
+
+    // Kernel identity fixes the semaphore, so the sender cores need not be re-derived here.
+    const auto patch_semaphore_arg = [&program](uint32_t kernel_idx, uint32_t arg_idx, uint32_t address) {
+        auto& args_by_core = tt::tt_metal::GetRuntimeArgs(program, kernel_idx);
+        for (auto& args_by_y : args_by_core) {
+            for (auto& args : args_by_y) {
+                if (arg_idx < args.size()) {
+                    args[arg_idx] = address;
+                }
+            }
+        }
+    };
+
+    const auto& semaphore = operation_attributes.semaphore;
+    const auto forward_sem_addr = static_cast<uint32_t>(semaphore.at(dyn::kForwardSemaphoreIdx).address());
+    const auto backward_sem_addr = static_cast<uint32_t>(semaphore.at(dyn::kBackwardSemaphoreIdx).address());
+
+    patch_semaphore_arg(dyn::kReaderForwardKernelIdx, dyn::kReaderSemaphoreArg, forward_sem_addr);
+    patch_semaphore_arg(dyn::kWriterForwardKernelIdx, dyn::kWriterSemaphoreArg, forward_sem_addr);
+    patch_semaphore_arg(dyn::kReaderBackwardKernelIdx, dyn::kReaderSemaphoreArg, backward_sem_addr);
+    patch_semaphore_arg(dyn::kWriterBackwardKernelIdx, dyn::kWriterSemaphoreArg, backward_sem_addr);
+}
+
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn {
@@ -413,7 +443,9 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         std::swap(num_targets_forward, num_targets_backward);
     }
     // Get worker cores
-    const uint32_t num_senders_per_link = 2;
+    // 2 sender (forward/backward, each with a reader/writer)
+    uint32_t num_senders_per_link =
+        ttnn::experimental::prim::ring_attention_all_gather_async_dynamic::kNumSendersPerLink;
     const auto [sender_worker_core_range, sender_worker_cores] = ttnn::ccl::choose_worker_cores(
         num_links,
         num_senders_per_link,
@@ -790,8 +822,9 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         KernelDescriptor::RTArgList reader_forward_rt_args;
         reader_forward_rt_args.push_back(static_cast<uint32_t>(dim));  // dim to gather on
         reader_forward_rt_args.push_back(ring_size);                   // ring_size
-        reader_forward_rt_args.push_back(
-            static_cast<uint32_t>(semaphore.at(1).address()));  // smuggled-rta-ok: persistent GlobalSemaphore address
+        reader_forward_rt_args.push_back(static_cast<uint32_t>(
+            semaphore.at(ttnn::experimental::prim::ring_attention_all_gather_async_dynamic::kForwardSemaphoreIdx)
+                .address()));  // smuggled-rta-ok: re-applied via override_runtime_arguments()
         reader_forward_rt_args.append(tensor_descriptor_args);
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             reader_forward_rt_args.push_back(input_tensor[input_idx].buffer());
@@ -817,8 +850,9 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         KernelDescriptor::RTArgList reader_backward_rt_args;
         reader_backward_rt_args.push_back(static_cast<uint32_t>(dim));  // dim to gather on
         reader_backward_rt_args.push_back(ring_size);                   // ring_size
-        reader_backward_rt_args.push_back(
-            static_cast<uint32_t>(semaphore.at(0).address()));  // smuggled-rta-ok: persistent GlobalSemaphore address
+        reader_backward_rt_args.push_back(static_cast<uint32_t>(
+            semaphore.at(ttnn::experimental::prim::ring_attention_all_gather_async_dynamic::kBackwardSemaphoreIdx)
+                .address()));  // smuggled-rta-ok: re-applied via override_runtime_arguments()
         reader_backward_rt_args.append(tensor_descriptor_args);
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             reader_backward_rt_args.push_back(input_tensor[input_idx].buffer());
@@ -854,8 +888,9 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         writer_forward_rt_args.push_back(static_cast<uint32_t>(sender_forward_worker_core.x));  // out_ready_sem_noc0_x
         writer_forward_rt_args.push_back(static_cast<uint32_t>(sender_forward_worker_core.y));  // out_ready_sem_noc0_y
         writer_forward_rt_args.push_back(ring_size);                                            // ring_size
-        writer_forward_rt_args.push_back(
-            static_cast<uint32_t>(semaphore.at(1).address()));  // smuggled-rta-ok: persistent GlobalSemaphore address
+        writer_forward_rt_args.push_back(static_cast<uint32_t>(
+            semaphore.at(ttnn::experimental::prim::ring_attention_all_gather_async_dynamic::kForwardSemaphoreIdx)
+                .address()));  // smuggled-rta-ok: re-applied via override_runtime_arguments()
         writer_forward_rt_args.append(tensor_descriptor_args);
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             writer_forward_rt_args.push_back(output_tensor[input_idx].buffer());
@@ -894,8 +929,9 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         writer_backward_rt_args.push_back(
             static_cast<uint32_t>(sender_backward_worker_core.y));  // out_ready_sem_noc0_y
         writer_backward_rt_args.push_back(ring_size);               // ring_size
-        writer_backward_rt_args.push_back(
-            static_cast<uint32_t>(semaphore.at(0).address()));  // smuggled-rta-ok: persistent GlobalSemaphore address
+        writer_backward_rt_args.push_back(static_cast<uint32_t>(
+            semaphore.at(ttnn::experimental::prim::ring_attention_all_gather_async_dynamic::kBackwardSemaphoreIdx)
+                .address()));  // smuggled-rta-ok: re-applied via override_runtime_arguments()
         writer_backward_rt_args.append(tensor_descriptor_args);
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             writer_backward_rt_args.push_back(output_tensor[input_idx].buffer());

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
@@ -101,6 +101,36 @@ RingAttentionAllGatherAsyncMultiCoreWithWorkersProgramFactory::create_workload_d
     return wd;
 }
 
+void RingAttentionAllGatherAsyncMultiCoreWithWorkersProgramFactory::override_runtime_arguments(
+    tt::tt_metal::Program& program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& /*tensor_args*/,
+    tensor_return_value_t& /*tensor_return_value*/,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+    namespace dyn = ring_attention_all_gather_async_dynamic;
+
+    // Kernel identity fixes the semaphore, so the sender cores need not be re-derived here.
+    const auto patch_semaphore_arg = [&program](uint32_t kernel_idx, uint32_t arg_idx, uint32_t address) {
+        auto& args_by_core = tt::tt_metal::GetRuntimeArgs(program, kernel_idx);
+        for (auto& args_by_y : args_by_core) {
+            for (auto& args : args_by_y) {
+                if (arg_idx < args.size()) {
+                    args[arg_idx] = address;
+                }
+            }
+        }
+    };
+
+    const auto& semaphore = operation_attributes.semaphore;
+    const auto forward_sem_addr = static_cast<uint32_t>(semaphore.at(dyn::kForwardSemaphoreIdx).address());
+    const auto backward_sem_addr = static_cast<uint32_t>(semaphore.at(dyn::kBackwardSemaphoreIdx).address());
+
+    patch_semaphore_arg(dyn::kReaderForwardKernelIdx, dyn::kReaderSemaphoreArg, forward_sem_addr);
+    patch_semaphore_arg(dyn::kWriterForwardKernelIdx, dyn::kWriterSemaphoreArg, forward_sem_addr);
+    patch_semaphore_arg(dyn::kReaderBackwardKernelIdx, dyn::kReaderSemaphoreArg, backward_sem_addr);
+    patch_semaphore_arg(dyn::kWriterBackwardKernelIdx, dyn::kWriterSemaphoreArg, backward_sem_addr);
+}
+
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn {
@@ -413,7 +443,9 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         std::swap(num_targets_forward, num_targets_backward);
     }
     // Get worker cores
-    const uint32_t num_senders_per_link = 2;
+    // 2 sender (forward/backward, each with a reader/writer)
+    uint32_t num_senders_per_link =
+        ttnn::experimental::prim::ring_attention_all_gather_async_dynamic::kNumSendersPerLink;
     const auto [sender_worker_core_range, sender_worker_cores] = ttnn::ccl::choose_worker_cores(
         num_links,
         num_senders_per_link,
@@ -793,8 +825,9 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         KernelDescriptor::RTArgList reader_forward_rt_args;
         reader_forward_rt_args.push_back(static_cast<uint32_t>(dim));  // dim to gather on
         reader_forward_rt_args.push_back(ring_size);                   // ring_size
-        reader_forward_rt_args.push_back(
-            static_cast<uint32_t>(semaphore.at(1).address()));  // smuggled-rta-ok: persistent GlobalSemaphore address
+        reader_forward_rt_args.push_back(static_cast<uint32_t>(
+            semaphore.at(ttnn::experimental::prim::ring_attention_all_gather_async_dynamic::kForwardSemaphoreIdx)
+                .address()));  // smuggled-rta-ok: re-applied via override_runtime_arguments()
         reader_forward_rt_args.append(tensor_descriptor_args);
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             reader_forward_rt_args.push_back(input_tensor[input_idx].buffer());
@@ -820,8 +853,9 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         KernelDescriptor::RTArgList reader_backward_rt_args;
         reader_backward_rt_args.push_back(static_cast<uint32_t>(dim));  // dim to gather on
         reader_backward_rt_args.push_back(ring_size);                   // ring_size
-        reader_backward_rt_args.push_back(
-            static_cast<uint32_t>(semaphore.at(0).address()));  // smuggled-rta-ok: persistent GlobalSemaphore address
+        reader_backward_rt_args.push_back(static_cast<uint32_t>(
+            semaphore.at(ttnn::experimental::prim::ring_attention_all_gather_async_dynamic::kBackwardSemaphoreIdx)
+                .address()));  // smuggled-rta-ok: re-applied via override_runtime_arguments()
         reader_backward_rt_args.append(tensor_descriptor_args);
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             reader_backward_rt_args.push_back(input_tensor[input_idx].buffer());
@@ -857,8 +891,9 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         writer_forward_rt_args.push_back(static_cast<uint32_t>(sender_forward_worker_core.x));  // out_ready_sem_noc0_x
         writer_forward_rt_args.push_back(static_cast<uint32_t>(sender_forward_worker_core.y));  // out_ready_sem_noc0_y
         writer_forward_rt_args.push_back(ring_size);                                            // ring_size
-        writer_forward_rt_args.push_back(
-            static_cast<uint32_t>(semaphore.at(1).address()));  // smuggled-rta-ok: persistent GlobalSemaphore address
+        writer_forward_rt_args.push_back(static_cast<uint32_t>(
+            semaphore.at(ttnn::experimental::prim::ring_attention_all_gather_async_dynamic::kForwardSemaphoreIdx)
+                .address()));  // smuggled-rta-ok: re-applied via override_runtime_arguments()
         writer_forward_rt_args.append(tensor_descriptor_args);
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             writer_forward_rt_args.push_back(output_tensor[input_idx].buffer());
@@ -897,8 +932,9 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         writer_backward_rt_args.push_back(
             static_cast<uint32_t>(sender_backward_worker_core.y));  // out_ready_sem_noc0_y
         writer_backward_rt_args.push_back(ring_size);               // ring_size
-        writer_backward_rt_args.push_back(
-            static_cast<uint32_t>(semaphore.at(0).address()));  // smuggled-rta-ok: persistent GlobalSemaphore address
+        writer_backward_rt_args.push_back(static_cast<uint32_t>(
+            semaphore.at(ttnn::experimental::prim::ring_attention_all_gather_async_dynamic::kBackwardSemaphoreIdx)
+                .address()));  // smuggled-rta-ok: re-applied via override_runtime_arguments()
         writer_backward_rt_args.append(tensor_descriptor_args);
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             writer_backward_rt_args.push_back(output_tensor[input_idx].buffer());

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.hpp
@@ -15,6 +15,20 @@
 
 namespace ttnn::experimental::prim {
 
+// These indices/arg-slots must track the factory's kernel push order and runtime-arg layout in
+// lockstep; override_runtime_arguments() re-applies the semaphore address at these positions.
+namespace ring_attention_all_gather_async_dynamic {
+inline constexpr uint32_t kNumSendersPerLink = 2;
+inline constexpr uint32_t kReaderForwardKernelIdx = 0;
+inline constexpr uint32_t kWriterForwardKernelIdx = 1;
+inline constexpr uint32_t kReaderBackwardKernelIdx = 2;
+inline constexpr uint32_t kWriterBackwardKernelIdx = 3;
+inline constexpr uint32_t kReaderSemaphoreArg = 2;
+inline constexpr uint32_t kWriterSemaphoreArg = 4;
+inline constexpr uint32_t kForwardSemaphoreIdx = 1;
+inline constexpr uint32_t kBackwardSemaphoreIdx = 0;
+}  // namespace ring_attention_all_gather_async_dynamic
+
 struct RingAttentionAllGatherAsyncMultiCoreWithWorkersProgramFactory {
     using operation_attributes_t = RingAttentionAllGatherAsyncParams;
 
@@ -27,6 +41,13 @@ struct RingAttentionAllGatherAsyncMultiCoreWithWorkersProgramFactory {
         const tensor_args_t& tensor_args,
         tensor_return_value_t& tensor_return_value,
         const ttnn::MeshCoordinateRangeSet& tensor_coords);
+
+    static void override_runtime_arguments(
+        tt::tt_metal::Program& program,
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 }  // namespace ttnn::experimental::prim
 


### PR DESCRIPTION
### What

**This restores behavior the descriptor migration deleted.** Before descriptors, this op's program
factory had `override_runtime_arguments`, and it re-applied the four out_ready `GlobalSemaphore` L1
addresses on every program-cache hit:

```cpp
worker_reader_sender_forward_runtime_args[kWorkerReaderSemaphoreRtArgIndex]  = semaphore.at(1).address();
worker_reader_sender_backward_runtime_args[kWorkerReaderSemaphoreRtArgIndex] = semaphore.at(0).address();
worker_writer_sender_forward_runtime_args[kWorkerWriterSemaphoreRtArgIndex]  = semaphore.at(1).address();
worker_writer_sender_backward_runtime_args[kWorkerWriterSemaphoreRtArgIndex] = semaphore.at(0).address();
```

`ec563655bc8` (#44755, "Migrate transformer/sdpa family + ring_attention_all_gather to
ProgramDescriptor") dropped that override and kept the address bake. Nothing replaced it: `main` has
no `override_runtime_arguments` and no `get_dynamic_runtime_args` in this op — only
`// smuggled-rta-ok:` markers, which silence the detector without re-applying anything.

This PR puts the hook back, on the program factory (its canonical home, per
`ProgramFactoryConcept`).

### Why it is a live bug on main

`semaphore` is excluded from the cache key, and always was — the custom `compute_program_hash` that
#47559 replaced with a narrowed `attribute_names` also omitted it. That exclusion was *safe* only
because the override re-applied the addresses each dispatch. Without it, two calls that differ only in
which `GlobalSemaphore`s they pass still cache-hit, and the second silently reuses the address baked
at the first miss.

The framework cannot cover this on its own: a `GlobalSemaphore` is not a tensor `Buffer*` (it exposes
no public `Buffer` accessor), so it cannot be a `BufferBinding` and the binding auto-patch never sees
it. The factory header's claim that "the descriptor framework auto-patches buffer addresses on cache
hits so callers do not need to implement an override_runtime_arguments path" does not hold for a
semaphore.

### Test

Builds clean; the detector (`scripts/detect_smuggled_rta.py`) is clean on the changed files. The op's
functional test is T3K-only, so it runs in CI rather than locally — the local evidence is the clean
compile plus a symbol check that the factory override is present and the operation-level one is gone.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-ring-attention-ag)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/smuggle-ring-attention-ag)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/smuggle-ring-attention-ag)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/smuggle-ring-attention-ag)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/smuggle-ring-attention-ag)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/smuggle-ring-attention-ag)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/smuggle-ring-attention-ag)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/smuggle-ring-attention-ag)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/smuggle-ring-attention-ag)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/smuggle-ring-attention-ag)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/smuggle-ring-attention-ag)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/smuggle-ring-attention-ag)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/smuggle-ring-attention-ag)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/smuggle-ring-attention-ag)

