### PR TITLE
Fix: Make NumaAwareExecutor::shutdown_ atomic to avoid a data race

### DIFF
--- a/tt_metal/impl/threading/thread_pool.cpp
+++ b/tt_metal/impl/threading/thread_pool.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <atomic>
 #include <cstddef>
 #include <future>
 #include <type_traits>
@@ -269,7 +270,9 @@ private:
     TaskQueue tasks_;
     std::thread worker;
     std::atomic<int> task_counter_ = 0;
-    bool shutdown_ = false;
+    // Accessed from both the worker thread (read, worker loop) and the main thread (write, destructor).
+    // Atomic to avoid a data race; the surrounding task_counter_ operations provide the ordering.
+    std::atomic<bool> shutdown_ = false;
     mutable std::exception_ptr stored_exception_;
     // Variables managing the linear backoff strategy used by worker threads
     // when waiting on a task to be inserted in the queue


### PR DESCRIPTION
Child issue: #49555 (item 7 of the host-side race audit #48579).

`NumaAwareExecutor::shutdown_` is a plain `bool` written by the main thread in `~NumaAwareExecutor()` and read by the worker loop. A plain `bool` shared across threads is a data race by the C++ memory model (UB, TSan-flaggable). It's benign in the current code because the surrounding `task_counter_` (seq_cst) handshake already orders the accesses, but it's UB by the letter and fragile if that ordering ever changes.

Fix: make `shutdown_` a `std::atomic<bool>`. The existing `task_counter_` operations already provide the ordering, so no other changes are needed.

## Test plan

- [x] Incremental build of `libtt_metal.so` (clean).
- [x] `distributed_unit_tests --gtest_filter='ThreadPoolTest.*'` pass on hardware (`StressDeviceBound`, `Exception`) — `StressDeviceBound` floods a `DeviceBoundThreadPool` with 2x2^18 tasks and destroys it, exercising the `~NumaAwareExecutor()` shutdown handshake: clean shutdown, no hang, correct task count.
- [x] ThreadSanitizer on a faithful model of the handshake: atomic version is race-free and terminates cleanly (a positive-control with a genuine unsynchronized bool is correctly flagged).

## Notes

This is defensive hardening consistent with the audit's LOW severity rating ("likely benign today"): it satisfies the memory model strictly and removes reliance on the subtle `task_counter_` ordering. Not a fix for an observed crash.

Fixes #49555

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-48579-numa-executor-shutdown-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:msudumbrekar/fix-48579-numa-executor-shutdown-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-48579-numa-executor-shutdown-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:msudumbrekar/fix-48579-numa-executor-shutdown-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-48579-numa-executor-shutdown-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:msudumbrekar/fix-48579-numa-executor-shutdown-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=msudumbrekar/fix-48579-numa-executor-shutdown-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:msudumbrekar/fix-48579-numa-executor-shutdown-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=msudumbrekar/fix-48579-numa-executor-shutdown-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:msudumbrekar/fix-48579-numa-executor-shutdown-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=msudumbrekar/fix-48579-numa-executor-shutdown-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:msudumbrekar/fix-48579-numa-executor-shutdown-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=msudumbrekar/fix-48579-numa-executor-shutdown-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:msudumbrekar/fix-48579-numa-executor-shutdown-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=msudumbrekar/fix-48579-numa-executor-shutdown-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:msudumbrekar/fix-48579-numa-executor-shutdown-race)