### PR TITLE
[skip ci] Update ttsim CI to use org runners

### DIFF
--- a/.github/sku_config.yaml
+++ b/.github/sku_config.yaml
@@ -241,10 +241,10 @@ skus:
   # the ttsim binary (sim_wormhole_b0 → libttsim_wh.so, sim_blackhole → libttsim_bh.so).
   sim_wormhole_b0:
     runs_on:
-      - ubuntu-latest
+      - tt-ubuntu-2204-small-stable
   sim_blackhole:
     runs_on:
-      - ubuntu-latest
+      - tt-ubuntu-2204-small-stable
   sim_wormhole_b0_galaxy:
     runs_on:
       - tt-ubuntu-2204-large-stable

--- a/.github/sku_config.yaml
+++ b/.github/sku_config.yaml
@@ -241,10 +241,10 @@ skus:
   # the ttsim binary (sim_wormhole_b0 → libttsim_wh.so, sim_blackhole → libttsim_bh.so).
   sim_wormhole_b0:
     runs_on:
-      - tt-ubuntu-2204-small-stable
+      - tt-ubuntu-2204-medium-stable
   sim_blackhole:
     runs_on:
-      - tt-ubuntu-2204-small-stable
+      - tt-ubuntu-2204-medium-stable
   sim_wormhole_b0_galaxy:
     runs_on:
       - tt-ubuntu-2204-large-stable

--- a/tests/pipeline_reorg/ttsim_sanity_tests.yaml
+++ b/tests/pipeline_reorg/ttsim_sanity_tests.yaml
@@ -15,86 +15,28 @@
 
 # For max allowed timeout refer to .github/time_budget.yaml
 
-- name: "ttsim example: add_2_integers_in_compute"
+- name: "ttsim examples"
+  # Build and run every tt-metalium example in one job (was one job per example).
+  # set -e aborts on the first build/run failure so a broken example fails the test.
   cmd: >-
-    build_dir=$(mktemp -d) &&
-    cmake -G Ninja -S /usr/share/tt-metalium/examples/add_2_integers_in_compute -B "$build_dir" &&
-    cmake --build "$build_dir" &&
-    find "$build_dir" -maxdepth 2 -type f -executable -not -name '*.so' -exec {} \;
+    set -e;
+    for ex in
+    add_2_integers_in_compute
+    add_2_integers_in_riscv
+    eltwise_binary
+    eltwise_sfpu
+    hello_world_compute_kernel
+    hello_world_datamovement_kernel;
+    do
+    build_dir=$(mktemp -d);
+    cmake -G Ninja -S "/usr/share/tt-metalium/examples/$ex" -B "$build_dir";
+    cmake --build "$build_dir";
+    find "$build_dir" -maxdepth 2 -type f -executable -not -name '*.so' -exec {} \; ;
+    done
   skus:
     sim_wormhole_b0:
-      timeout: 5
+      timeout: 30
     sim_blackhole:
-      timeout: 5
+      timeout: 30
   team: ttsim
-  owner_id: U08PR765YJ1 Matt Craighead
-
-- name: "ttsim example: add_2_integers_in_riscv"
-  cmd: >-
-    build_dir=$(mktemp -d) &&
-    cmake -G Ninja -S /usr/share/tt-metalium/examples/add_2_integers_in_riscv -B "$build_dir" &&
-    cmake --build "$build_dir" &&
-    find "$build_dir" -maxdepth 2 -type f -executable -not -name '*.so' -exec {} \;
-  skus:
-    sim_wormhole_b0:
-      timeout: 5
-    sim_blackhole:
-      timeout: 5
-  team: ttsim
-  owner_id: U08PR765YJ1 Matt Craighead
-
-- name: "ttsim example: eltwise_binary"
-  cmd: >-
-    build_dir=$(mktemp -d) &&
-    cmake -G Ninja -S /usr/share/tt-metalium/examples/eltwise_binary -B "$build_dir" &&
-    cmake --build "$build_dir" &&
-    find "$build_dir" -maxdepth 2 -type f -executable -not -name '*.so' -exec {} \;
-  skus:
-    sim_wormhole_b0:
-      timeout: 5
-    sim_blackhole:
-      timeout: 5
-  team: ttsim
-  owner_id: U08PR765YJ1 Matt Craighead
-
-- name: "ttsim example: eltwise_sfpu"
-  cmd: >-
-    build_dir=$(mktemp -d) &&
-    cmake -G Ninja -S /usr/share/tt-metalium/examples/eltwise_sfpu -B "$build_dir" &&
-    cmake --build "$build_dir" &&
-    find "$build_dir" -maxdepth 2 -type f -executable -not -name '*.so' -exec {} \;
-  skus:
-    sim_wormhole_b0:
-      timeout: 5
-    sim_blackhole:
-      timeout: 5
-  team: ttsim
-  owner_id: U08PR765YJ1 Matt Craighead
-
-- name: "ttsim example: hello_world_compute_kernel"
-  cmd: >-
-    build_dir=$(mktemp -d) &&
-    cmake -G Ninja -S /usr/share/tt-metalium/examples/hello_world_compute_kernel -B "$build_dir" &&
-    cmake --build "$build_dir" &&
-    find "$build_dir" -maxdepth 2 -type f -executable -not -name '*.so' -exec {} \;
-  skus:
-    sim_wormhole_b0:
-      timeout: 5
-    sim_blackhole:
-      timeout: 5
-  team: ttsim
-  owner_id: U08PR765YJ1 Matt Craighead
-
-- name: "ttsim example: hello_world_datamovement_kernel"
-  cmd: >-
-    build_dir=$(mktemp -d) &&
-    cmake -G Ninja -S /usr/share/tt-metalium/examples/hello_world_datamovement_kernel -B "$build_dir" &&
-    cmake --build "$build_dir" &&
-    find "$build_dir" -maxdepth 2 -type f -executable -not -name '*.so' -exec {} \;
-  skus:
-    sim_wormhole_b0:
-      timeout: 5
-    sim_blackhole:
-      timeout: 5
-  team: ttsim
-  owner_id: U08PR765YJ1 Matt Craighead
+  owner_id: U08PR765YJ1 # Matt Craighead

--- a/tests/pipeline_reorg/ttsim_sanity_tests.yaml
+++ b/tests/pipeline_reorg/ttsim_sanity_tests.yaml
@@ -16,10 +16,7 @@
 # For max allowed timeout refer to .github/time_budget.yaml
 
 - name: "ttsim examples"
-  # Build and run every tt-metalium example in one job (was one job per example).
-  # set -e aborts on the first build/run failure so a broken example fails the test.
   cmd: >-
-    set -e;
     for ex in
     add_2_integers_in_compute
     add_2_integers_in_riscv
@@ -28,10 +25,11 @@
     hello_world_compute_kernel
     hello_world_datamovement_kernel;
     do
-    build_dir=$(mktemp -d);
-    cmake -G Ninja -S "/usr/share/tt-metalium/examples/$ex" -B "$build_dir";
-    cmake --build "$build_dir";
-    find "$build_dir" -maxdepth 2 -type f -executable -not -name '*.so' -exec {} \; ;
+    build_dir=$(mktemp -d) || exit 1;
+    cmake -G Ninja -S "/usr/share/tt-metalium/examples/$ex" -B "$build_dir" || exit 1;
+    cmake --build "$build_dir" || exit 1;
+    for exe in $(find "$build_dir" -maxdepth 2 -type f -executable -not -name '*.so');
+    do "$exe" || exit 1; done;
     done
   skus:
     sim_wormhole_b0:


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Set ttsim `wormhole_b0` and `blackhole` skus to use org runner `tt-ubuntu-2204-medium-stable` to prevent accumulating cost of Github CPU runners.

Additionally, update the `ttsim-sanity-tests` to use one test matrix entry instead of two. This change reduces the large setup overhead on these quick tests.

### Test plan

- [x] Confirm CI consistency with `main`:
   - [x] [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=tdowdall/ttsim-sku-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:tdowdall/ttsim-sku-fix) (ttsim sanity tests)


### Note for Reviewers

- Many jobs run out of memory, does this mean sim jobs should instead run on medium runners?

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=tdowdall/ttsim-sku-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:tdowdall/ttsim-sku-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=tdowdall/ttsim-sku-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:tdowdall/ttsim-sku-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=tdowdall/ttsim-sku-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:tdowdall/ttsim-sku-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=tdowdall/ttsim-sku-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:tdowdall/ttsim-sku-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=tdowdall/ttsim-sku-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:tdowdall/ttsim-sku-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=tdowdall/ttsim-sku-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:tdowdall/ttsim-sku-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=tdowdall/ttsim-sku-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:tdowdall/ttsim-sku-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=tdowdall/ttsim-sku-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:tdowdall/ttsim-sku-fix)