### PR TITLE
[Performance] GDN: reshape heads in ROW_MAJOR; fuse typecast into tilize

### DIFF
--- a/models/demos/blackhole/qwen36/tt/gdn/tp.py
+++ b/models/demos/blackhole/qwen36/tt/gdn/tp.py
@@ -274,11 +274,13 @@ class TPGatedDeltaNet:
         ttnn.deallocate(qkv)
 
         kd = self.key_dim_tp
+        rf = Nv // Nk
+        # Head-split in ROW_MAJOR, so that the reshapes are free
+        conv = ttnn.to_layout(conv, ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
         q = ttnn.reshape(ttnn.slice(conv, (0, 0, 0), (1, T, kd)), (1, T, Nk, Dk))
         k = ttnn.reshape(ttnn.slice(conv, (0, 0, kd), (1, T, 2 * kd)), (1, T, Nk, Dk))
         v = ttnn.reshape(ttnn.slice(conv, (0, 0, 2 * kd), (1, T, self.qkv_dim_tp)), (1, T, Nv, Dv))
         ttnn.deallocate(conv)
-        rf = Nv // Nk
         q = ttnn.repeat_interleave(q, rf, dim=2)
         k = ttnn.repeat_interleave(k, rf, dim=2)
 

--- a/models/experimental/gated_attention_gated_deltanet/tt/ttnn_delta_rule_seq.py
+++ b/models/experimental/gated_attention_gated_deltanet/tt/ttnn_delta_rule_seq.py
@@ -81,33 +81,30 @@ def chunk_gated_delta_rule_seq_adapter(
     V = v.shape[3]
     BH = B * H
 
-    # L2-norm q/k (the seq kernel does NOT normalize; it only scales q internally).
-    q = l2_norm_ttnn(q, dim=-1)
-    k = l2_norm_ttnn(k, dim=-1)
+    def _tilize_f32(t):
+        # Tilize + fp32 cast in one op, which avoids a separate typecast pass.
+        return ttnn.to_layout(t, ttnn.TILE_LAYOUT, dtype=ttnn.float32, memory_config=_DRAM)
 
     def _to_bhtd(t, D):  # [B,T,H,D] -> [BH,T,D] float32 TILE/DRAM (ROW_MAJOR-correct)
         t = ttnn.to_layout(t, ttnn.ROW_MAJOR_LAYOUT, memory_config=_DRAM)
         t = ttnn.reshape(t, [B, T, H, D])
         t = ttnn.permute(t, (0, 2, 1, 3))  # [B,H,T,D]
         t = ttnn.reshape(t, [BH, T, D])
-        t = ttnn.to_layout(t, ttnn.TILE_LAYOUT, memory_config=_DRAM)
-        if t.dtype != ttnn.float32:
-            t = ttnn.typecast(t, ttnn.float32, memory_config=_DRAM)
-        return t
+        return _tilize_f32(t)
 
     def _to_bht(t):  # [B,T,H] -> [BH,T] float32 TILE/DRAM
         t = ttnn.to_layout(t, ttnn.ROW_MAJOR_LAYOUT, memory_config=_DRAM)
         t = ttnn.reshape(t, [B, T, H])
         t = ttnn.permute(t, (0, 2, 1))  # [B,H,T]
         t = ttnn.reshape(t, [BH, T])
-        t = ttnn.to_layout(t, ttnn.TILE_LAYOUT, memory_config=_DRAM)
-        if t.dtype != ttnn.float32:
-            t = ttnn.typecast(t, ttnn.float32, memory_config=_DRAM)
-        return t
+        return _tilize_f32(t)
 
     q_bh = _to_bhtd(q, K)
     k_bh = _to_bhtd(k, K)
     v_bh = _to_bhtd(v, V)
+
+    q_bh = l2_norm_ttnn(q_bh, dim=-1)
+    k_bh = l2_norm_ttnn(k_bh, dim=-1)
     g_bh = _to_bht(g)
     beta_bh = ttnn.reshape(_to_bht(beta), [BH, T, 1])
 


### PR DESCRIPTION
### PR Category
Performance

### Summary

Contributes to: https://github.com/tenstorrent/tt-metal/issues/42828

Two numerically-neutral tensor layout optimizations in the Gated DeltaNet (GDN) `forward_prefill` path:

- `models/demos/blackhole/qwen36/tt/gdn/tp.py`: perform the Q/K/V head-split on the conv output in `ROW_MAJOR_LAYOUT` so the subsequent `reshape`s are free views instead of forcing a re-tilize.
- `models/experimental/gated_attention_gated_deltanet/tt/ttnn_delta_rule_seq.py`: fuse `to_layout(TILE)` + `typecast(float32)` into a single `to_layout(TILE, dtype=float32)` op, avoiding a separate typecast pass. The q/k L2-norm is moved to after the `[BH,T,D]` reshape. It normalizes over the head dim, so it is numerically equivalent.

### Measured impact
Device time for one GDN block's `forward_prefill` (Qwen3.6-27B TP-4 shard simulated on a single Blackhole card, `T=4096` / 2048-window).

| Stage | baseline (ms) | this PR (ms) | Δ | code region |
|---|--:|--:|--:|---|
| proj | 1.82 | 1.82 | +0.00 | qkvz/ab linears |
| conv | 7.06 | 4.35 | **−2.71** | `_causal_conv1d_fir` + head-split |
| gdn_core | 17.87 | 16.92 | **−0.96** | `chunk_gated_delta_rule_seq_adapter` |
| state_carry | 0.01 | 0.01 | +0.00 | recurrent / conv-state carry |
| gate_norm | 2.96 | 3.00 | +0.04 | `rms_norm` + SiLU(z) gate |
| out_proj | 0.83 | 0.83 | −0.00 | out linear |
| all_reduce | 0.18 | 0.18 | −0.00 | `tt_all_reduce` (no-op under single-card sim) |
| **Total** | **30.90** | **27.27** | **−3.62 (−11.7%)** | |

### Correctness

  End-to-end text_demo.py -k traced_8k, PR (aa9947fdbf7) vs baseline (44fc8e231c8). Same prompt (8192-token prefill and 500 decode tokens).

  ```
┌───────────────────┬─────────────┬─────────────┬─────────────────┐
  │      Metric       │  Baseline   │     PR      │        Δ        │
  ├───────────────────┼─────────────┼─────────────┼─────────────────┤
  │ TTFT              │      4.34 s │      4.20 s │ −0.14 s (−3.2%) │
  ├───────────────────┼─────────────┼─────────────┼─────────────────┤
  │ Decode throughput │ 18.02 tok/s │ 18.03 tok/s │              ~0 │
  ├───────────────────┼─────────────┼─────────────┼─────────────────┤
  │ Result            │        PASS │        PASS │               — │
  └───────────────────┴─────────────┴─────────────┴─────────────────┘

```
  The change targets the prefill path (RM head-split + typecast-into-tilize fusion in the GDN block), so TTFT drops while decode is unchanged.

### Notes for reviewers
- The l2_norm relocation in `ttnn_delta_rule_seq.py` is the one non-mechanical part of the diff. It is intentional and equivalent: `dim=-1` is the head dim `D` both before (`[B,T,H,D]`) and after (`[BH,T,D]`) the permute/reshape.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/gdn-reshape-heads-fuse-typecast)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/gdn-reshape-heads-fuse-typecast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/gdn-reshape-heads-fuse-typecast)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/gdn-reshape-heads-fuse-typecast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=iwrosz/gdn-reshape-heads-fuse-typecast)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:iwrosz/gdn-reshape-heads-fuse-typecast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/gdn-reshape-heads-fuse-typecast)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/gdn-reshape-heads-fuse-typecast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/gdn-reshape-heads-fuse-typecast)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/gdn-reshape-heads-fuse-typecast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/gdn-reshape-heads-fuse-typecast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/gdn-reshape-heads-fuse-typecast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/gdn-reshape-heads-fuse-typecast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/gdn-reshape-heads-fuse-typecast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/gdn-reshape-heads-fuse-typecast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/gdn-reshape-heads-fuse-typecast)