### PR TITLE
[Cleanup] Migrate precomposed NoC addresses to Device 2.0 UnicastEndpoint

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_untilize_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_untilize_dispatch.cpp
@@ -37,6 +37,9 @@
 #include "tools/profiler/kernel_profiler.hpp"
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
 #include "api/debug/dprint.h"
 #include "ttnn/operations/ccl/common/kernels/moe_utils.hpp"
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
@@ -56,6 +59,8 @@ constexpr uint32_t ROUTE_INFO_SENTINEL = 0xFFFFFFFF;
 
 void kernel_main() {
     using namespace ttnn::operations::ccl::common;
+
+    Noc noc;
 
     // ===== Compile-time args =====
     constexpr uint32_t cb_input_id = get_compile_time_arg_val(0);
@@ -179,7 +184,6 @@ void kernel_main() {
     const uint32_t offsets_bytes = offsets_pages * aligned_offsets_page_size;
     volatile tt_l1_ptr uint32_t* turn_sem_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(turn_semaphore_id));
-    uint64_t owner_offsets_noc_addr = get_noc_addr(owner_noc_x, owner_noc_y, offsets_base_addr);
     uint64_t next_turn_sem_noc_addr = get_noc_addr(next_noc_x, next_noc_y, get_semaphore(turn_semaphore_id));
     if constexpr (IS_OWNER) {
         noc_semaphore_set(turn_sem_ptr, 1);
@@ -281,7 +285,12 @@ void kernel_main() {
         DPRINT_DISPATCH("[R s={} c={}] b={} GOT baton\n", (uint32_t)dispatch_core_idx, (uint32_t)core_id, batch_idx);
         turn_expected++;
         if constexpr (!IS_OWNER) {
-            noc_async_read(owner_offsets_noc_addr, offsets_base_addr, offsets_bytes);
+            noc.async_read(
+                UnicastEndpoint{},
+                CoreLocalMem<uint32_t>(offsets_base_addr),
+                offsets_bytes,
+                {.noc_x = owner_noc_x, .noc_y = owner_noc_y, .addr = offsets_base_addr},
+                {});
             noc_async_read_barrier();
         }
 
@@ -350,7 +359,12 @@ void kernel_main() {
         }
 
         if constexpr (!IS_OWNER) {
-            noc_async_write(offsets_base_addr, owner_offsets_noc_addr, offsets_bytes);
+            noc.async_write(
+                CoreLocalMem<uint32_t>(offsets_base_addr),
+                UnicastEndpoint{},
+                offsets_bytes,
+                {},
+                {.noc_x = owner_noc_x, .noc_y = owner_noc_y, .addr = offsets_base_addr});
             noc_async_write_barrier();
         }
         if (batch_idx + 1 < effective_total_batches) {

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in0_sender.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in0_sender.cpp
@@ -6,6 +6,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/endpoints.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
@@ -346,13 +347,16 @@ void kernel_main() {
                     in0_sender_sem.wait(1);
                     in0_sender_sem.set(0);
 
-                    uint64_t in0_unicast_data_addr = get_noc_addr(in0_dest_noc_x, in0_dest_noc_y, in0_start_address);
-
                     /**
                      * in0 is M_block_tiles x K_block_tiles. When M block is partial, we don't need to write the
                      * padded tiles. Use `current_block_bytes`.
                      */
-                    noc_async_write(in0_start_address, in0_unicast_data_addr, current_block_bytes);
+                    noc.async_write(
+                        CoreLocalMem<uint32_t>(in0_start_address),
+                        UnicastEndpoint{},
+                        current_block_bytes,
+                        {},
+                        {.noc_x = in0_dest_noc_x, .noc_y = in0_dest_noc_y, .addr = in0_start_address});
 
 #ifdef ARCH_BLACKHOLE
                     noc.async_writes_flushed();

--- a/ttnn/cpp/ttnn/operations/experimental/topk_router_gpt/device/kernels/dm1.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_router_gpt/device/kernels/dm1.cpp
@@ -19,6 +19,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/endpoints.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
@@ -147,10 +148,14 @@ void kernel_main() {
         // NOC write partial tile to worker's CB2 at our sender_slot.
         // cb2_base_addr is the same L1 address on all cores due to uniform CB layout.
         uint32_t worker_recv_l1 = cb2_base_addr + sender_slot * tile_size;
-        uint64_t worker_recv_noc = get_noc_addr(worker_phys_x, worker_phys_y, worker_recv_l1);
 
-        noc_async_write(local_out_l1, worker_recv_noc, tile_size);
-        noc_async_write_barrier();
+        noc.async_write(
+            CoreLocalMem<uint32_t>(local_out_l1),
+            UnicastEndpoint{},
+            tile_size,
+            {},
+            {.noc_x = worker_phys_x, .noc_y = worker_phys_y, .addr = worker_recv_l1});
+        noc.async_write_barrier();
 
         // Signal worker that this sender's partial is ready
         uint64_t worker_sem_noc = get_noc_addr(worker_phys_x, worker_phys_y, get_semaphore(sem_partial_ready));
@@ -230,15 +235,23 @@ void kernel_main() {
         // Use our own CB8/CB9 base addresses — identical L1 layout on all worker cores
         uint32_t coll_val_base = cb_gathered_val.get_write_ptr();
         uint32_t coll_val_dst_l1 = coll_val_base + worker_gather_slot * tile_size;
-        uint64_t coll_val_noc = get_noc_addr(collector_phys_x, collector_phys_y, coll_val_dst_l1);
-        noc_async_write(val_l1, coll_val_noc, tile_size);
+        noc.async_write(
+            CoreLocalMem<uint32_t>(val_l1),
+            UnicastEndpoint{},
+            tile_size,
+            {},
+            {.noc_x = collector_phys_x, .noc_y = collector_phys_y, .addr = coll_val_dst_l1});
 
         uint32_t coll_ind_base = cb_gathered_ind.get_write_ptr();
         uint32_t coll_ind_dst_l1 = coll_ind_base + worker_gather_slot * tile_size;
-        uint64_t coll_ind_noc = get_noc_addr(collector_phys_x, collector_phys_y, coll_ind_dst_l1);
-        noc_async_write(ind_l1, coll_ind_noc, tile_size);
+        noc.async_write(
+            CoreLocalMem<uint32_t>(ind_l1),
+            UnicastEndpoint{},
+            tile_size,
+            {},
+            {.noc_x = collector_phys_x, .noc_y = collector_phys_y, .addr = coll_ind_dst_l1});
 
-        noc_async_write_barrier();
+        noc.async_write_barrier();
 
         // Signal collector
         uint64_t coll_sem_noc = get_noc_addr(collector_phys_x, collector_phys_y, get_semaphore(sem_topk_ready));

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/kernels/dataflow/reduction_receiver.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/kernels/dataflow/reduction_receiver.cpp
@@ -5,6 +5,9 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
 #include "internal/risc_attribs.h"
 #include <tt-metalium/constants.hpp>
 #include "tools/profiler/kernel_profiler.hpp"
@@ -12,6 +15,7 @@
 using namespace tt::constants;
 
 void kernel_main() {
+    Noc noc;
     ///////////////////////////////////////////////////
     // ARGS
     ///////////////////////////////////////////////////
@@ -122,7 +126,7 @@ void kernel_main() {
 
             uint32_t read_addr =
                 get_read_ptr(cb_id_reduction_out) + in_tile_offset_by_batch + i_tile_per_core * TILE_ELEMENTS * 2;
-            uint64_t write_addr = 0;
+            uint32_t write_noc_x = 0, write_noc_y = 0, write_addr = 0;
             uint32_t head_index = 0, tile_index = 0, wptr_offset = 0;
             if (tile_index_all_cores < num_q_heads * head_size_num_tiles) {
                 // read Q
@@ -131,9 +135,9 @@ void kernel_main() {
                 tile_index =
                     tile_index_all_cores % head_size_num_tiles;  // tile index of current tile(sits in current core)
                 wptr_offset = head_index * SUBTILE_LINE_BYTES + tile_index * tile_size;
-                write_addr =
-                    get_noc_addr(q_in0_mcast_noc_x[i_output_core], q_in0_mcast_noc_y[i_output_core], q_start_addr) +
-                    wptr_offset;
+                write_noc_x = q_in0_mcast_noc_x[i_output_core];
+                write_noc_y = q_in0_mcast_noc_y[i_output_core];
+                write_addr = q_start_addr + wptr_offset;
             } else if (tile_index_all_cores < (num_q_heads + num_kv_heads) * head_size_num_tiles) {
                 // read K
                 head_index = 0;  // head index of current tile(sits in current core)
@@ -141,9 +145,9 @@ void kernel_main() {
                     tile_index_all_cores % head_size_num_tiles;  // tile index of current tile(sits in current core)
                 wptr_offset = head_index * SUBTILE_LINE_BYTES + tile_index * tile_size;
                 uint32_t tile_index_in_output_core = tile_index_all_cores - num_q_heads * head_size_num_tiles;
-                write_addr =
-                    get_noc_addr(k_in0_mcast_noc_x[i_output_core], k_in0_mcast_noc_y[i_output_core], k_start_addr) +
-                    wptr_offset;
+                write_noc_x = k_in0_mcast_noc_x[i_output_core];
+                write_noc_y = k_in0_mcast_noc_y[i_output_core];
+                write_addr = k_start_addr + wptr_offset;
             } else {
                 // read V
                 head_index = 0;  // head index of current tile(sits in current core)
@@ -152,19 +156,28 @@ void kernel_main() {
                 wptr_offset = head_index * SUBTILE_LINE_BYTES + tile_index * tile_size;
                 uint32_t tile_index_in_output_core =
                     tile_index_all_cores - (num_q_heads + num_kv_heads) * head_size_num_tiles;
-                write_addr =
-                    get_noc_addr(v_in0_mcast_noc_x[i_output_core], v_in0_mcast_noc_y[i_output_core], v_start_addr) +
-                    wptr_offset;
+                write_noc_x = v_in0_mcast_noc_x[i_output_core];
+                write_noc_y = v_in0_mcast_noc_y[i_output_core];
+                write_addr = v_start_addr + wptr_offset;
             }
 
             if constexpr (PHASES_TO_READ == 1) {  // reader kernel (NCRISC)
 
-                noc_async_write(read_addr, write_addr, SUBTILE_LINE_BYTES);
+                noc.async_write(
+                    CoreLocalMem<uint32_t>(read_addr),
+                    UnicastEndpoint{},
+                    SUBTILE_LINE_BYTES,
+                    {},
+                    {.noc_x = write_noc_x, .noc_y = write_noc_y, .addr = write_addr});
             }
             if constexpr (PHASES_TO_READ == 2) {  // writer kernel(BRISC)
 
-                noc_async_write(
-                    read_addr + FACE_HW * ELEMENT_SIZE, write_addr + FACE_HW * ELEMENT_SIZE, SUBTILE_LINE_BYTES);
+                noc.async_write(
+                    CoreLocalMem<uint32_t>(read_addr + FACE_HW * ELEMENT_SIZE),
+                    UnicastEndpoint{},
+                    SUBTILE_LINE_BYTES,
+                    {},
+                    {.noc_x = write_noc_x, .noc_y = write_noc_y, .addr = write_addr + FACE_HW * ELEMENT_SIZE});
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/kernels/dataflow/worker_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/kernels/dataflow/worker_reader.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
 #include <tt-metalium/buffer_types.hpp>
 #include <cstdint>
 #include <utility>
@@ -18,6 +21,7 @@ constexpr uint32_t cb0_id = get_compile_time_arg_val(1);
 constexpr uint32_t tensor0_page_size = get_compile_time_arg_val(2);
 
 void kernel_main() {
+    Noc noc;
     ///////////////////////////////////////////////////
     // ARGS
     ///////////////////////////////////////////////////
@@ -43,10 +47,14 @@ void kernel_main() {
             std::min(num_tiles_per_core - shard_tile_id, num_tiles_to_read - tiles_read);
         cb_reserve_back(cb0_id, num_tiles_to_read_this_core);
         const uint32_t l1_write_addr = get_write_ptr(cb0_id);
-        uint64_t read_addr = get_noc_addr(core_noc_x[core_id], core_noc_y[core_id], tensor_address0);
-        read_addr += shard_tile_id * tensor0_page_size;
+        uint32_t read_addr = tensor_address0 + shard_tile_id * tensor0_page_size;
 
-        noc_async_read(read_addr, l1_write_addr, num_tiles_to_read_this_core * tensor0_page_size);
+        noc.async_read(
+            UnicastEndpoint{},
+            CoreLocalMem<uint32_t>(l1_write_addr),
+            num_tiles_to_read_this_core * tensor0_page_size,
+            {.noc_x = core_noc_x[core_id], .noc_y = core_noc_y[core_id], .addr = read_addr},
+            {});
         noc_async_read_barrier();
 
         cb_push_back(cb0_id, num_tiles_to_read_this_core);


### PR DESCRIPTION
## PR Category

Cleanup

Migrates the free-function noc calls using a precomposed NoC address to the Device 2.0 `Noc`/`UnicastEndpoint` API across 8 dataflow kernels. An address built as `get_noc_addr(noc_x, noc_y, addr)` and provided to `noc_async_read`/`noc_async_write` becomes:

```cpp
Noc noc;
// read: remote core is the source
noc.async_read(UnicastEndpoint{}, CoreLocalMem<uint32_t>(local_dst), size,
               {.noc_x = x, .noc_y = y, .addr = addr}, {});
// write: remote core is the destination
noc.async_write(CoreLocalMem<uint32_t>(local_src), UnicastEndpoint{}, size,
                {}, {.noc_x = x, .noc_y = y, .addr = addr});
```

The composed address ingredients move into the `src_args`/`dst_args` struct.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/d2-precomposed-xcore-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/d2-precomposed-xcore-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/d2-precomposed-xcore-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/d2-precomposed-xcore-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=iwrosz/d2-precomposed-xcore-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:iwrosz/d2-precomposed-xcore-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/d2-precomposed-xcore-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/d2-precomposed-xcore-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/d2-precomposed-xcore-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/d2-precomposed-xcore-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/d2-precomposed-xcore-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/d2-precomposed-xcore-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/d2-precomposed-xcore-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/d2-precomposed-xcore-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/d2-precomposed-xcore-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/d2-precomposed-xcore-migration)