### PR TITLE
[LLK] Fix Qwen3-32B Galaxy Top-1 0.0%: tilize_uninit restore to default tile shape (#45127 regression)

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
@@ -31,20 +31,18 @@ inline void llk_unpack_tilize_init(const std::uint32_t operand, const std::uint3
 /**
  * Tear down the tilize unpacker configuration so a subsequent operation can reprogram the unpacker.
  *
- * Face count and face row dimension are derived from the operand's CB metadata (mirroring
- * llk_unpack_tilize_init) so the canonical Tile_x_dim / SrcA stride restore matches the operand's
- * tile geometry. Deriving face_r_dim (rather than defaulting it to FACE_R_DIM) is what lets the
- * tiny-tile (face_r_dim < 16) restore reach the Compute API, whose tilize_uninit /
- * tilize_uninit_with_dt call this with the operand only.
+ * Restores the tile descriptor to the standard full-tile baseline (DEFAULT_TENSOR_SHAPE = 4 faces,
+ * 16-row faces) rather than the operand's own geometry. Deriving the operand geometry here (#45127)
+ * regressed Qwen3-32B on Galaxy to Top-1 0.0%: for a non-standard operand the teardown left the
+ * descriptor's num_faces/face_r_dim in a non-default state that polluted the following op. The
+ * default restore matches the proven pre-#45127 behavior; per-op init reprograms geometry anyway.
+ * See issue #49266.
  *
  * @param operand Input circular buffer / operand index.
  */
 inline void llk_unpack_tilize_uninit(const std::uint32_t operand) {
     std::uint32_t operand_id = get_operand_id(operand);
-    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
-    const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
-    _llk_unpack_tilize_uninit_(
-        (std::uint32_t)unpack_dst_format[operand_id], ckernel::tensor_shape_from_num_faces(num_faces, face_r_dim));
+    _llk_unpack_tilize_uninit_((std::uint32_t)unpack_dst_format[operand_id]);
 }
 
 /**

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
@@ -32,20 +32,18 @@ inline void llk_unpack_tilize_init(const std::uint32_t operand, const std::uint3
 /**
  * Tear down the tilize unpacker configuration so a subsequent operation can reprogram the unpacker.
  *
- * Face count and face row dimension are derived from the operand's CB metadata (mirroring
- * llk_unpack_tilize_init) so the canonical Tile_x_dim / SrcA stride restore matches the operand's
- * tile geometry. Deriving face_r_dim (rather than defaulting it to FACE_R_DIM) is what lets the
- * tiny-tile (face_r_dim < 16) restore reach the Compute API, whose tilize_uninit /
- * tilize_uninit_with_dt call this with the operand only.
+ * Restores the tile descriptor to the standard full-tile baseline (DEFAULT_TENSOR_SHAPE = 4 faces,
+ * 16-row faces) rather than the operand's own geometry. Deriving the operand geometry here (#45127)
+ * regressed Qwen3-32B on Galaxy to Top-1 0.0%: for a non-standard operand the teardown left the
+ * descriptor's num_faces/face_r_dim in a non-default state that polluted the following op. The
+ * default restore matches the proven pre-#45127 behavior; per-op init reprograms geometry anyway.
+ * See issue #49266.
  *
  * @param operand Input circular buffer / operand index.
  */
 inline void llk_unpack_tilize_uninit(const std::uint32_t operand) {
     std::uint32_t operand_id = get_operand_id(operand);
-    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
-    const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
-    _llk_unpack_tilize_uninit_(
-        (std::uint32_t)unpack_dst_format[operand_id], ckernel::tensor_shape_from_num_faces(num_faces, face_r_dim));
+    _llk_unpack_tilize_uninit_((std::uint32_t)unpack_dst_format[operand_id]);
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes the **Qwen3-32B e2e (Galaxy) Top-1 0.0%** regression (issue #49266) with a **targeted fix on top of #45127**, instead of reverting the whole commit.

`#45127` changed `llk_unpack_tilize_uninit` (WH + BH metal LLK API) to derive the operand's `num_faces`/`face_r_dim` from CB metadata and restore the tile descriptor to that operand-specific geometry, instead of the previous hardcoded full-tile default (4 faces, 16-row faces). For a **non-standard operand**, the tilize teardown then leaves the descriptor's `num_faces`/`face_r_dim` in a non-default state that pollutes the following op — the exact tilize→matmul pollution scenario the PR added tests for, but the restore value regressed on the Galaxy Qwen path.

**This change** reverts just that caller to `_llk_unpack_tilize_uninit_(dst_format)`, which uses `DEFAULT_TENSOR_SHAPE` (= the proven pre-#45127 teardown). Per-op init reprograms geometry regardless. **Everything else in #45127 is kept** — the canonical stride helpers, `configure_unpack_AB` / `reconfig_data_format` baselines, and the `bcastA_B` deterministic-restore feature.

Two files, WH + BH `llk_unpack_tilize_api.h`.

## Root-cause analysis
Walking the #45127 diff against ground-truth constants (`FACE_R_DIM == FACE_C_DIM == 16`), almost every change is **value-identical to before for standard tiles**:
- `REG_0_SHAMT`/`REG_1` template mix → harmless on WH (both SHAMT=12, mask 0xfff000).
- `canonical_unpA_y_stride` → matches the known-working `unpack_untilize` value.
- `FACE_DIM_16x16` GPR is actually `256|(256<<16)` (the `16|(16<<16)` comments are stale), so `canonical_unpA_tile_x_dim_cntx(16)` == the old value; Z-dim `4` == `configure_unpack_AB`'s default `num_faces`.

The **only** non-value-equivalent change on a common path is the tilize_uninit descriptor restore switching from the hardcoded default to operand geometry.

## Evidence
- **Bisect** (issue #49266, infra-aware wrapper): first-bad = `a4aefda` (#45127). Boundary directly tested — parent `9ab5767` = Top-1 92%, `a4aefda` = 0% (3 attempts). Run: https://github.com/tenstorrent/tt-metal/actions/runs/29004832619
- **Boundary A/B** on `wh_galaxy_perf`: parent branch → Top-1 92% (multiple runs).
- **This fix** on `wh_galaxy_perf` → **Top-1 92% / Top-5 100%** (2 clean runs; other 3 died on Galaxy infra flakiness, none an accuracy failure):
  - https://github.com/tenstorrent/tt-metal/actions/runs/29035628237
  - https://github.com/tenstorrent/tt-metal/actions/runs/29035632556

## For reviewers
@ldjurovicTT — this is your #45127 code. This fix restores the proven default teardown, which sacrifices the tiny-tile-aware (`face_r_dim < 16`) `tilize_uninit` restore path #45127 added for the Compute API. If that path is needed, a follow-up that keeps operand-aware geometry **without** corrupting the standard Galaxy path would be the better long-term fix — happy to test any variant on the same setup.

Fixes #49266

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/fix-45127-tilize-uninit-qwen-galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/fix-45127-tilize-uninit-qwen-galaxy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/fix-45127-tilize-uninit-qwen-galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/fix-45127-tilize-uninit-qwen-galaxy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mtairum/fix-45127-tilize-uninit-qwen-galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mtairum/fix-45127-tilize-uninit-qwen-galaxy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/fix-45127-tilize-uninit-qwen-galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/fix-45127-tilize-uninit-qwen-galaxy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/fix-45127-tilize-uninit-qwen-galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/fix-45127-tilize-uninit-qwen-galaxy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/fix-45127-tilize-uninit-qwen-galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/fix-45127-tilize-uninit-qwen-galaxy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/fix-45127-tilize-uninit-qwen-galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/fix-45127-tilize-uninit-qwen-galaxy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/fix-45127-tilize-uninit-qwen-galaxy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/fix-45127-tilize-uninit-qwen-galaxy)