### PR TITLE
[Bug Fix] Program-cache-hit Fast Path with In-Place Ops

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_adamw.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_adamw.py
@@ -263,6 +263,160 @@ def test_moreh_adamw_compute_kernel_options(
     )
 
 
+def torch_adamw_step(param, grad, exp_avg, exp_avg_sq, max_exp_avg_sq, lr, betas, eps, weight_decay, amsgrad, step):
+    """CPU reference for one moreh_adamw step (decoupled weight decay).
+
+    Runs entirely on the host, so it is IMMUNE to the device program cache and is
+    a trustworthy oracle even when the device path is buggy. Verified against the
+    kernel to within bf16 rounding (~5e-3 max abs error) on a cache-miss dispatch.
+    """
+    beta1, beta2 = betas
+    p = param.float()
+    g = grad.float()
+    m = exp_avg.float()
+    v = exp_avg_sq.float()
+
+    p = p - lr * weight_decay * p
+    m = beta1 * m + (1 - beta1) * g
+    v = beta2 * v + (1 - beta2) * g * g
+
+    bias_correction1 = 1 - beta1**step
+    bias_correction2 = 1 - beta2**step
+    if amsgrad:
+        vmax = torch.maximum(max_exp_avg_sq.float(), v)
+        denom = (vmax.sqrt() / (bias_correction2**0.5)) + eps
+        new_max = vmax
+    else:
+        denom = (v.sqrt() / (bias_correction2**0.5)) + eps
+        new_max = None
+    p = p - (lr / bias_correction1) * (m / denom)
+    return p, m, v, new_max
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [[32, 32], [2, 3, 64, 64]],
+)
+@pytest.mark.parametrize("lr", [1e-2])
+@pytest.mark.parametrize("betas", [[0.5, 0.555]])
+@pytest.mark.parametrize("eps", [1e-08])
+@pytest.mark.parametrize("weight_decay", [0.3])
+@pytest.mark.parametrize("amsgrad", [True, False])
+def test_moreh_adamw_inplace_cache_hit(shape, lr, betas, eps, weight_decay, amsgrad, device):
+    """Regression for the descriptor cache-hit fast-path bug (#48928 / a38e756c933).
+
+    tt-train's optimizer calls moreh_adamw IN-PLACE: param_out == param_in and the
+    moment outputs alias their inputs (see tt-train/sources/ttml/optimizers/
+    adamw_composite.cpp:75-92). Because the optional _out tensors live in tensor_args,
+    the aliased buffers appear twice within the input region, so resolve_bindings
+    bails to EMPTY bindings. moreh_adamw also declares get_dynamic_runtime_args
+    (step/lr), so on a program-cache hit the buggy fast-path gate fires with empty
+    bindings, patches NO buffer addresses, and leaves the cached program pointing at
+    the PREVIOUS dispatch's DRAM addresses -> the update lands in stale memory and
+    the current output tensors are left UNCHANGED (equal to their inputs).
+
+    The test primes the program cache with one in-place step, keeps those tensors
+    ALIVE so the next in-place step's fresh allocations get DIFFERENT addresses,
+    then runs an in-place step on the cache HIT and compares against a CPU torch
+    reference. The reference runs on the host, so it is unaffected by the device
+    cache -- unlike an on-device out-of-place run, which shares the same faulty
+    cache entry and would return the same stale values (comparing stale-vs-stale
+    would spuriously pass). The exp_avg / exp_avg_sq moment updates move far more
+    than the tiny single-step param update, so they are the sharp discriminator:
+    when the fast path skips the write they stay at their (random) input values,
+    which are ~0.5 off the correct result -- well beyond the tolerance below.
+    """
+    torch.manual_seed(2024)
+
+    def dev(t):
+        return None if t is None else ttnn.from_torch(t, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    def rand_state():
+        return {
+            "param": torch.rand(shape, dtype=torch.bfloat16),
+            "grad": torch.rand(shape, dtype=torch.bfloat16),
+            "exp_avg": torch.rand(shape, dtype=torch.bfloat16),
+            "exp_avg_sq": torch.rand(shape, dtype=torch.bfloat16),
+            "max_exp_avg_sq": torch.rand(shape, dtype=torch.bfloat16) if amsgrad else None,
+        }
+
+    def run_inplace(state, step):
+        # Alias every _out to its _in (exactly what the tt-train optimizer does).
+        p = dev(state["param"])
+        g = dev(state["grad"])
+        m = dev(state["exp_avg"])
+        v = dev(state["exp_avg_sq"])
+        mx = dev(state["max_exp_avg_sq"])
+        ttnn.operations.moreh.adamw(
+            p,
+            g,
+            m,
+            v,
+            lr,
+            betas[0],
+            betas[1],
+            eps,
+            weight_decay,
+            step,
+            amsgrad,
+            max_exp_avg_sq_in=mx,
+            param_out=p,
+            exp_avg_out=m,
+            exp_avg_sq_out=v,
+            max_exp_avg_sq_out=mx,
+        )
+        # Return the (aliased) input==output tensors; the caller keeps them alive so
+        # the next allocation lands at a different address.
+        return p, m, v, mx
+
+    # Prime the program cache; HOLD these tensors so the cache-hit step's fresh
+    # allocations get different DRAM addresses (the condition that surfaces the bug).
+    keep_prime = run_inplace(rand_state(), step=1)
+
+    # Cache HIT: in-place step on fresh (differently-addressed) tensors.
+    state = rand_state()
+    ip_param, ip_exp_avg, ip_exp_avg_sq, ip_max = run_inplace(state, step=2)
+    assert device.num_program_cache_entries() > 0, "expected a cached program to hit"
+
+    # CPU reference (host-side, immune to the device program cache).
+    ref_param, ref_exp_avg, ref_exp_avg_sq, ref_max = torch_adamw_step(
+        state["param"],
+        state["grad"],
+        state["exp_avg"],
+        state["exp_avg_sq"],
+        state["max_exp_avg_sq"],
+        lr,
+        betas,
+        eps,
+        weight_decay,
+        amsgrad,
+        step=2,
+    )
+
+    # atol=0.05 separates a correct update (bf16 error ~5e-3) from a stale/skipped
+    # write (moments off by ~0.5). Assert max abs error directly for an unambiguous
+    # signal that the in-place cache-hit write actually happened.
+    atol = 0.05
+    checks = [
+        ("param", ref_param, ip_param),
+        ("exp_avg", ref_exp_avg, ip_exp_avg),
+        ("exp_avg_sq", ref_exp_avg_sq, ip_exp_avg_sq),
+    ]
+    if amsgrad:
+        checks.append(("max_exp_avg_sq", ref_max, ip_max))
+
+    del keep_prime  # done holding the priming tensors
+    for name, ref, got in checks:
+        got_host = ttnn.to_torch(got).reshape(shape).float()
+        max_err = (got_host - ref.reshape(shape)).abs().max().item()
+        logger.debug(f"in-place cache-hit {name}: max|err| vs CPU reference = {max_err}")
+        assert max_err < atol, (
+            f"in-place moreh_adamw '{name}' wrong on a program-cache hit "
+            f"(max|err|={max_err} >= {atol}); the fast path likely skipped patching "
+            f"the aliased buffer addresses and wrote to stale memory."
+        )
+
+
 @pytest.mark.parametrize(
     "shape",
     [[32, 32]],  # single

--- a/tt_metal/impl/program/program_descriptor_patching.cpp
+++ b/tt_metal/impl/program/program_descriptor_patching.cpp
@@ -57,23 +57,9 @@ ResolvedBindings resolve_bindings(
     //     mapping them to the one shared address is always correct.  Keep the fast path.
     //
     // tensor_buffers is ordered inputs-first; the first num_input_buffers entries are inputs.
-    //
-    // A within-inputs repeat is only the ambiguous matmul(X, X) hazard when the repeated buffer
-    // is NOT also an output. If it IS an output, the repeat is an in-place op that carries its
-    // output tensor(s) in tensor_args (e.g. moreh_adamw's optional param_out/exp_avg_out): the
-    // aliasing slots are the SAME buffer by construction on every dispatch, so mapping them all to
-    // the one shared address is always correct — keep the fast path. We therefore need to know the
-    // output-region buffers up front, hence the two passes below.
     {
-        std::unordered_set<Buffer*> output_buffers;  // buffers appearing in the output/workload region
-        for (size_t i = num_input_buffers; i < tensor_buffers.size(); ++i) {
-            if (tensor_buffers[i] != nullptr) {
-                output_buffers.insert(tensor_buffers[i]);
-            }
-        }
-
-        std::unordered_set<Buffer*> input_seen;   // buffers seen in the input region
-        std::unordered_set<Buffer*> output_seen;  // buffers seen in the output/workload region
+        std::unordered_set<Buffer*> input_buffers;   // buffers seen in the input region
+        std::unordered_set<Buffer*> output_buffers;  // buffers seen in the output/workload region
         for (size_t i = 0; i < tensor_buffers.size(); ++i) {
             Buffer* buf = tensor_buffers[i];
             if (!buf) {
@@ -81,17 +67,11 @@ ResolvedBindings resolve_bindings(
             }
             const bool is_input = i < num_input_buffers;
             // An output/workload buffer that aliases an input is the safe in-place case — skip it.
-            if (!is_input && input_seen.contains(buf)) {
-                continue;
-            }
-            // A within-inputs repeat that is also an output is the safe in-place case (input written
-            // back out); the buffer is identical across dispatches, so patching the shared slot is
-            // correct. Skip it instead of bailing.
-            if (is_input && input_seen.contains(buf) && output_buffers.contains(buf)) {
+            if (!is_input && input_buffers.contains(buf)) {
                 continue;
             }
             // Otherwise a repeat is ambiguous (matmul(X, X), or a repeated output) — bail to slow path.
-            auto& seen = is_input ? input_seen : output_seen;
+            auto& seen = is_input ? input_buffers : output_buffers;
             if (!seen.insert(buf).second) {
                 return ResolvedBindings{};
             }

--- a/tt_metal/impl/program/program_descriptor_patching.cpp
+++ b/tt_metal/impl/program/program_descriptor_patching.cpp
@@ -57,9 +57,23 @@ ResolvedBindings resolve_bindings(
     //     mapping them to the one shared address is always correct.  Keep the fast path.
     //
     // tensor_buffers is ordered inputs-first; the first num_input_buffers entries are inputs.
+    //
+    // A within-inputs repeat is only the ambiguous matmul(X, X) hazard when the repeated buffer
+    // is NOT also an output. If it IS an output, the repeat is an in-place op that carries its
+    // output tensor(s) in tensor_args (e.g. moreh_adamw's optional param_out/exp_avg_out): the
+    // aliasing slots are the SAME buffer by construction on every dispatch, so mapping them all to
+    // the one shared address is always correct — keep the fast path. We therefore need to know the
+    // output-region buffers up front, hence the two passes below.
     {
-        std::unordered_set<Buffer*> input_buffers;   // buffers seen in the input region
-        std::unordered_set<Buffer*> output_buffers;  // buffers seen in the output/workload region
+        std::unordered_set<Buffer*> output_buffers;  // buffers appearing in the output/workload region
+        for (size_t i = num_input_buffers; i < tensor_buffers.size(); ++i) {
+            if (tensor_buffers[i] != nullptr) {
+                output_buffers.insert(tensor_buffers[i]);
+            }
+        }
+
+        std::unordered_set<Buffer*> input_seen;   // buffers seen in the input region
+        std::unordered_set<Buffer*> output_seen;  // buffers seen in the output/workload region
         for (size_t i = 0; i < tensor_buffers.size(); ++i) {
             Buffer* buf = tensor_buffers[i];
             if (!buf) {
@@ -67,11 +81,17 @@ ResolvedBindings resolve_bindings(
             }
             const bool is_input = i < num_input_buffers;
             // An output/workload buffer that aliases an input is the safe in-place case — skip it.
-            if (!is_input && input_buffers.contains(buf)) {
+            if (!is_input && input_seen.contains(buf)) {
+                continue;
+            }
+            // A within-inputs repeat that is also an output is the safe in-place case (input written
+            // back out); the buffer is identical across dispatches, so patching the shared slot is
+            // correct. Skip it instead of bailing.
+            if (is_input && input_seen.contains(buf) && output_buffers.contains(buf)) {
                 continue;
             }
             // Otherwise a repeat is ambiguous (matmul(X, X), or a repeated output) — bail to slow path.
-            auto& seen = is_input ? input_buffers : output_buffers;
+            auto& seen = is_input ? input_seen : output_seen;
             if (!seen.insert(buf).second) {
                 return ResolvedBindings{};
             }

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -581,12 +581,23 @@ public:
                     apply_dynamic_runtime_args_if_declared(
                         program, attrs, tensor_args, tensor_return_value, coordinate_range);
                 } else {
-                    // ProgramDescriptor variant — simple per-coord factory.  Fast-path when the factory
-                    // declared rt-arg buffer bindings via emplace_runtime_args(), OR the op declares
-                    // get_dynamic_runtime_args() to re-apply its per-dispatch args — in which case the
-                    // framework also patches the op's `.buffer = ...` CB bindings (covers CB-bound sharded
-                    // ops).  With neither, a `.buffer` CB mixed with raw uint32 rt-args could go stale, so
-                    // fall through to the slow-path rebuild instead. (#48928)
+                    // ProgramDescriptor variant — simple per-coord factory.  Fast-path when the
+                    // factory declared rt-arg buffer bindings via emplace_runtime_args(), OR the op
+                    // declares get_dynamic_runtime_args() to re-apply its per-dispatch args — in which
+                    // case the framework also patches the op's `.buffer = ...` CB bindings (covers
+                    // CB-bound sharded ops).  With neither, a `.buffer` CB mixed with raw uint32
+                    // rt-args could go stale, so fall through to the slow-path rebuild instead.
+                    //
+                    // The get_dynamic_runtime_args() opt-in additionally requires that
+                    // resolve_bindings actually produced bindings (!resolved_bindings.empty()):
+                    // get_dynamic_runtime_args() only re-applies hash-excluded SCALAR runtime args
+                    // (seed/step/lr), so buffer addresses still ride on the resolved bindings.
+                    // resolve_bindings returns an EMPTY ResolvedBindings when it bails on ambiguous
+                    // buffer aliasing — notably moreh_adamw, called in-place so its optional
+                    // param_out == param_in etc. appear twice within the input region.  Fast-pathing
+                    // such a bailed op would apply_resolved_bindings() nothing and leave the cached
+                    // program pointing at stale first-miss addresses; route it to the slow-path
+                    // rebuild instead, which re-derives all addresses AND scalars. (#48928)
                     std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
                     if constexpr (requires {
                                       DeviceOperation::get_dynamic_runtime_args(
@@ -601,7 +612,8 @@ public:
                             tensor_return_value,
                             std::optional<ttnn::MeshCoordinate>(coordinate_range.start_coord()));
                     }
-                    if (!sv.resolved_bindings.rt_args.empty() || !dynamic_args.empty()) {
+                    if (!sv.resolved_bindings.rt_args.empty() ||
+                        (!dynamic_args.empty() && !sv.resolved_bindings.empty())) {
                         auto collected =
                             collect_tensor_buffers(tensor_args, tensor_return_value, sv.workload_descriptor);
                         tt::tt_metal::apply_resolved_bindings(program, sv.resolved_bindings, collected.buffers);


### PR DESCRIPTION

### PR Category
Bug Fix 

## Summary

Fixes a correctness regression introduced by #49159 (commit `a38e756c9332527a77e2ef6581611ef7c9421fa8`) that broke the MorehAdamW op with caching. This broke GRPO training in tt-train (Llama and Qwen3): the model produced garbage and stopped learning. The root cause is that the program-cache-hit fast-path gate could fire for an in-place op whose `resolve_bindings` bailed to **empty** bindings, so no buffer addresses were re-patched and the cached program kept pointing at the previous dispatch's (stale) DRAM addresses. The fix tightens the fast-path gate so `get_dynamic_runtime_args()` alone can no longer trip it — bindings must actually have been resolved.

The change is one condition in the mesh device-op adapter, plus a regression test. `resolve_bindings` is unchanged.

## Background

`a38e756c933` widened the ProgramDescriptor cache-hit fast-path gate in `ttnn/api/ttnn/mesh_device_operation_adapter.hpp` so that ops declaring `get_dynamic_runtime_args()` (used to re-apply hash-excluded **scalar** runtime args — an RNG seed, an Adam `step`/`lr`) also take the fast path:

```cpp
// before:  if (!sv.resolved_bindings.rt_args.empty())
// after:   if (!sv.resolved_bindings.rt_args.empty() || !dynamic_args.empty())
```

On the fast path the framework calls `apply_resolved_bindings(...)` to re-patch buffer addresses on the cached program, then `apply_dynamic_runtime_args(...)` to re-apply the scalars — it never rebuilds the descriptor.

## The bug

`MorehAdamWDeviceOperation` is invoked **in-place** by the tt-train optimizer (`tt-train/sources/ttml/optimizers/adamw_composite.cpp:75-92`): `param_out`/`exp_avg_out`/`exp_avg_sq_out` are the same tensors as `param_in`/`exp_avg_in`/`exp_avg_sq_in`. AdamW's `tensor_args_t` also carries the optional `_out` tensors, so `collect_tensor_buffers` counts them within `num_input_buffers` — i.e. the same buffer appears twice **inside the input region**.

`resolve_bindings` has an aliasing guard that bails to the slow-path rebuild for the genuinely ambiguous `matmul(X, X)` case (two distinct logical inputs that merely coincide on one call — a later `matmul(Y, Z)` reusing the cached program would miscompute). It detects that from a duplicate within the input region and returns an **empty** `ResolvedBindings{}`. AdamW's in-place aliasing trips exactly this guard.

The interaction:

- **Before `a38e756c933`:** empty `resolved_bindings.rt_args` → AdamW took the **slow-path rebuild** (`create_descriptor` re-derives all buffer addresses and scalars each dispatch). Correct.
- **After `a38e756c933`:** AdamW's `get_dynamic_runtime_args()` returns non-empty (`step`/`lr`), so `!dynamic_args.empty()` is true → AdamW takes the **fast path**. But its `resolved_bindings` is empty (the bail), so `apply_resolved_bindings` patches **no** buffer addresses and the descriptor is never rebuilt. On a cache hit with freshly-allocated tensors the op then reads/writes the **first-miss** iteration's DRAM addresses; the current output tensors are left untouched. From the next step onward the optimizer corrupts memory → the model diverges to garbage and does not learn.

This is why disabling the program cache made training healthy (no cache hit → always rebuild), and why the failure is gated exactly on the `|| !dynamic_args.empty()` term.

## Root cause

The gate treated a non-empty `get_dynamic_runtime_args()` as sufficient to take the fast path. But `get_dynamic_runtime_args()` only re-applies **scalar** runtime args; buffer addresses still need either resolved bindings (`apply_resolved_bindings`) or a full descriptor rebuild. When `resolve_bindings` bails to empty, neither happens on the fast path, so the addresses silently go stale.

## Fix

Tighten the ProgramDescriptor fast-path gate in `mesh_device_operation_adapter.hpp` so the `get_dynamic_runtime_args()` opt-in additionally requires that `resolve_bindings` produced bindings:

```cpp
if (!sv.resolved_bindings.rt_args.empty() ||
    (!dynamic_args.empty() && !sv.resolved_bindings.empty())) {
    // fast path: apply_resolved_bindings + apply_dynamic_runtime_args
} else {
    // slow path: rebuild create_descriptor (re-derives all addresses AND scalars)
}
```

`resolve_bindings` itself is unchanged — the `matmul(X, X)` bail is preserved exactly.

### Why this is safe and preserves the `a38e756c933` speedup

The new condition is `R || (D && ¬empty)`, where `R = !rt_args.empty()`, `D = !dynamic_args.empty()`, and `¬empty` means `rt_args` OR `cbs` is non-empty. This is a **strict subset** of the shipped `a38e756c933` gate `R || D`: whenever this fires, `R || D` also fired, so no op that the commit fast-pathed is newly broken. The only case removed from the fast path is `D && empty` (an op with dynamic args whose bindings bailed) — i.e. exactly in-place AdamW.

- **tilize / pad / transpose / slice (the ops `a38e756c933` sped up):** their I/O addresses ride on tensor-backed CB `.buffer` bindings, so `resolve_bindings` records them in `resolved_bindings.cbs` → `¬empty` is true and `D` is true → **fast path preserved**. (Verified by auditing every ProgramDescriptor op with a tensor-backed CB: none carries a per-dispatch buffer address as an unpatched raw uint32 rt-arg; all addresses ride on CBs or `Buffer*` bindings that `apply_resolved_bindings` re-patches.)
- **moreh_adamw in-place:** `resolve_bindings` bails → empty → routed to the slow-path rebuild → correct.
- **matmul(X, X):** still bails → slow path (unchanged).
- **rand, and plain `Buffer*`-rt-arg ops:** `R` is true → fast path (unchanged).

## Testing

- **New regression test** `test_moreh_adamw_inplace_cache_hit` (`tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_adamw.py`): calls `moreh_adamw` **in-place** (outputs aliased to inputs, matching the tt-train optimizer), primes the program cache with one step, holds those tensors alive so the next step's fresh allocations get different DRAM addresses, then runs an in-place step on the cache hit and checks the results against a **host-side CPU reference** (immune to the device program cache) with `atol=0.05`. The moment tensors are the discriminator: on the bug they stay at their input values (~0.5 off) while a correct bf16 update is ~5e-3 off.
  - On broken `main`: **fails** (`exp_avg max|err| ≈ 0.5`).
  - On this branch: **passes**.
- GRPO Llama training on Tenstorrent: garbage/no-learning before → healthy after, with the program cache **enabled** (the fix does not rely on disabling caching).

## Notes

`mesh_device_operation_adapter.hpp` / `program_descriptor_patching.cpp` are a temporary shim pending the Metal 2.0 native Tensor/Buffer bindings; this is a bug fix in that shim, not new API surface built on top of it.

## Results

Currently on main, GRPO training is broken, and looks like:
<img width="2134" height="590" alt="image" src="https://github.com/user-attachments/assets/6a76aa83-7fe5-4019-b374-9140400c52c4" />

With the fixes in this PR, GRPO training is fixed and returns to what it looked like before:
<img width="2136" height="598" alt="image" src="https://github.com/user-attachments/assets/13e816d4-8c2a-486a-97b5-9f76340e2627" />

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
- [x] [T3K Perf](https://github.com/tenstorrent/tt-metal/actions/runs/29085475789) compared to [main results](https://github.com/tenstorrent/tt-metal/actions/runs/29093874128/job/86370795254)
- [x] [L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/runs/29085230730) compared to [main results](https://github.com/tenstorrent/tt-metal/actions/runs/29075690204)
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=awliu/program_descriptor_fix_MorehAdamW)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:awliu/program_descriptor_fix_MorehAdamW)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=awliu/program_descriptor_fix_MorehAdamW)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:awliu/program_descriptor_fix_MorehAdamW)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=awliu/program_descriptor_fix_MorehAdamW)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:awliu/program_descriptor_fix_MorehAdamW)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=awliu/program_descriptor_fix_MorehAdamW)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:awliu/program_descriptor_fix_MorehAdamW)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=awliu/program_descriptor_fix_MorehAdamW)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:awliu/program_descriptor_fix_MorehAdamW)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=awliu/program_descriptor_fix_MorehAdamW)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:awliu/program_descriptor_fix_MorehAdamW)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=awliu/program_descriptor_fix_MorehAdamW)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:awliu/program_descriptor_fix_MorehAdamW)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=awliu/program_descriptor_fix_MorehAdamW)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:awliu/program_descriptor_fix_MorehAdamW)