### PR TITLE
#49283: Make ttnn.split consistent with torch

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_split.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_split.py
@@ -803,3 +803,33 @@ def test_native_single_core_sharded_input(device):
     tt_in = _from_torch(t, device, mc=in_cfg)
     tt_out = ttnn.split(tt_in, TILE, dim=-1)
     _check(tt_out, ref)
+
+
+# ---------------------------------------------------------------------------
+# 20. Single-chunk parity: split_size >= dim size returns the whole tensor as
+#     one chunk (matching torch.split). split_size == dim size exercises the
+#     native num_splits=1 device path for TILE layout; split_size > dim size
+#     clamps to a single chunk. Both layouts covered.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
+@pytest.mark.parametrize(
+    "torch_dtype, ttnn_dtype",
+    [
+        (torch.bfloat16, ttnn.bfloat16),
+        (torch.float32, ttnn.float32),
+    ],
+)
+@pytest.mark.parametrize("split_size", [64, 100])  # == dim size, and > dim size
+def test_split_single_chunk(device, layout, torch_dtype, ttnn_dtype, split_size):
+    """split_size >= dim size returns exactly one chunk equal to the input."""
+    torch.manual_seed(21)
+    t = torch.randn([64, 64]).to(torch_dtype)
+    ref = torch.split(t, split_size, dim=-1)
+    assert len(ref) == 1
+
+    tt_in = _from_torch(t, device, dtype=ttnn_dtype, layout=layout, mc=L1)
+    tt_out = ttnn.split(tt_in, split_size, dim=-1, memory_config=L1)
+    assert len(tt_out) == 1, f"Expected a single chunk, got {len(tt_out)}"
+    _check(tt_out, ref)

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_split.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_split.py
@@ -805,12 +805,7 @@ def test_native_single_core_sharded_input(device):
     _check(tt_out, ref)
 
 
-# ---------------------------------------------------------------------------
-# 20. Single-chunk parity: split_size >= dim size returns the whole tensor as
-#     one chunk (matching torch.split). split_size == dim size exercises the
-#     native num_splits=1 device path for TILE layout; split_size > dim size
-#     clamps to a single chunk. Both layouts covered.
-# ---------------------------------------------------------------------------
+# 20. Single-chunk parity — split_size >= dim size returns the whole tensor as one chunk; exercises num_splits=1 device path.
 
 
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
@@ -827,9 +822,53 @@ def test_split_single_chunk(device, layout, torch_dtype, ttnn_dtype, split_size)
     torch.manual_seed(21)
     t = torch.randn([64, 64]).to(torch_dtype)
     ref = torch.split(t, split_size, dim=-1)
-    assert len(ref) == 1
+    assert len(ref) == 1, f"Expected torch reference to produce 1 chunk, got {len(ref)} (split_size={split_size})"
 
     tt_in = _from_torch(t, device, dtype=ttnn_dtype, layout=layout, mc=L1)
     tt_out = ttnn.split(tt_in, split_size, dim=-1, memory_config=L1)
     assert len(tt_out) == 1, f"Expected a single chunk, got {len(tt_out)}"
+    _check(tt_out, ref)
+
+
+# 21. Strict list-size validation — under- and over-covering lists must raise; negative dims exercised.
+
+
+@pytest.mark.parametrize(
+    "shape, split_sizes, dim",
+    [
+        ([64, 64], [32], -1),  # under-covers: 32 < 64
+        ([64, 64], [32, 64], -1),  # over-covers: 32 + 64 > 64
+        ([64, 64], [16, 16], 0),  # under-covers on dim 0: 32 < 64
+        ([2, 64, 64], [32, 40], -2),  # over-covers via negative dim: 72 > 64
+    ],
+)
+def test_split_list_size_must_cover_dim(device, expect_error, shape, split_sizes, dim):
+    """A split_sizes list that does not sum exactly to the split dim must raise."""
+    torch.manual_seed(22)
+    t = torch.randn(shape, dtype=torch.bfloat16)
+    tt_in = _from_torch(t, device, mc=L1)
+    with expect_error(RuntimeError, "split_sizes must sum exactly to the size of dimension"):
+        ttnn.split(tt_in, split_sizes, dim=dim, memory_config=L1)
+
+
+# 22. Integer-overload remainder path — non-divisible dim produces [split_size, remainder] chunks with correct shapes/values.
+
+
+@pytest.mark.parametrize(
+    "shape, split_size, dim",
+    [
+        ([2 * TILE, 3 * TILE // 2], TILE, -1),  # 48 / 32 = 1 rem 16 → chunks [32, 16]
+        ([3 * TILE // 2, 2 * TILE], TILE, 0),  # 48 / 32 = 1 rem 16 → chunks [32, 16]
+    ],
+)
+def test_split_int_remainder(device, shape, split_size, dim):
+    """Non-divisible dim size produces ceil(dim/split_size) chunks; last chunk is the remainder."""
+    torch.manual_seed(23)
+    t = torch.randn(shape, dtype=torch.bfloat16)
+    ref = torch.split(t, split_size, dim=dim)
+    assert len(ref) == 2, f"Expected 2 reference chunks, got {len(ref)}"
+
+    tt_in = _from_torch(t, device, layout=ttnn.ROW_MAJOR_LAYOUT, mc=L1)
+    tt_out = ttnn.split(tt_in, split_size, dim=dim, memory_config=L1)
+    assert len(tt_out) == 2, f"Expected 2 output chunks, got {len(tt_out)}"
     _check(tt_out, ref)

--- a/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
@@ -63,9 +63,9 @@ std::vector<ttnn::Tensor> split_with_slice_impl(
     // dimension size. This internal check guards against a malformed size list reaching the slicer.
     TT_FATAL(
         std::accumulate(split_sizes.begin(), split_sizes.end(), int64_t{0}) == static_cast<int64_t>(input_shape[dim]),
-        "Split sizes should sum exactly to dimension size. Split sizes: {} dimension {}",
-        split_sizes,
-        input_shape[dim]);
+        "Split sizes should sum exactly to dimension size {}. Split sizes: {}",
+        input_shape[dim],
+        split_sizes);
 
     const auto num_chunks = static_cast<uint32_t>(split_sizes.size());
 

--- a/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
@@ -128,6 +128,42 @@ std::vector<ttnn::Tensor> split(
     const ttsl::SmallVector<int64_t>& split_sizes,
     int64_t dim,
     const std::optional<MemoryConfig>& memory_config_arg) {
+    const auto& input_shape = input_tensor.logical_shape();
+
+    // Normalize negative dimension to positive index.
+    const int64_t normalized_dim = input_shape.get_normalized_index(dim);
+    const int64_t dim_size = static_cast<int64_t>(input_shape[normalized_dim]);
+
+    // Validate the requested sizes BEFORE deriving the output memory config: the desired_mem_cfg
+    // lambda dereferences split_sizes[0] and computes padded_dim % split_sizes.size(), which are
+    // undefined behavior / divide-by-zero for an empty list.
+    TT_FATAL(!split_sizes.empty(), "split_sizes must not be empty");
+    TT_FATAL(
+        std::all_of(split_sizes.begin(), split_sizes.end(), [](const auto& x) { return x > 0; }),
+        "split_size should be greater than 0, instead got: {}",
+        split_sizes);
+
+    // Coverage: the sizes must cover the split dim exactly. Subtract each (positive) size from the
+    // remaining extent instead of summing, so an oversized list cannot overflow int64_t; remaining
+    // stays >= 0 because the per-size check rejects any entry that would exceed it.
+    int64_t remaining = dim_size;
+    for (const auto& s : split_sizes) {
+        TT_FATAL(
+            s <= remaining,
+            "split_sizes must sum exactly to the size of dimension {} ({}), but sizes {} over-cover it",
+            normalized_dim,
+            dim_size,
+            split_sizes);
+        remaining -= s;
+    }
+    TT_FATAL(
+        remaining == 0,
+        "split_sizes must sum exactly to the size of dimension {} ({}), but sizes {} under-cover it by {}",
+        normalized_dim,
+        dim_size,
+        split_sizes,
+        remaining);
+
     // Default output MC: mirror input; rescale shard_spec per-chunk; DRAM on rescale fail or L1 overflow.
     const MemoryConfig desired_mem_cfg = [&]() -> MemoryConfig {
         const auto& in_mc = input_tensor.memory_config();
@@ -263,28 +299,6 @@ std::vector<ttnn::Tensor> split(
         return in_mc;
     }();
 
-    TT_FATAL(!split_sizes.empty(), "split_sizes must not be empty");
-    TT_FATAL(
-        std::all_of(split_sizes.begin(), split_sizes.end(), [](const auto& x) { return x > 0; }),
-        "split_size should be greater than 0, instead got: {}",
-        split_sizes);
-
-    const auto& input_shape = input_tensor.logical_shape();
-
-    // Normalize negative dimension to positive index
-    int64_t normalized_dim = input_shape.get_normalized_index(dim);
-
-    // Match torch.split semantics: the requested chunk sizes must sum exactly to the size of
-    // the split dimension. torch raises for both under- and over-covering size lists.
-    const int64_t split_sizes_sum = std::accumulate(split_sizes.begin(), split_sizes.end(), int64_t{0});
-    TT_FATAL(
-        split_sizes_sum == static_cast<int64_t>(input_shape[normalized_dim]),
-        "split_sizes must sum exactly to the size of dimension {} ({}), but got sizes {} summing to {}",
-        normalized_dim,
-        input_shape[normalized_dim],
-        split_sizes,
-        split_sizes_sum);
-
     std::vector<ttnn::Tensor> results;
 
     const uint32_t num_chunks = static_cast<uint32_t>(split_sizes.size());
@@ -414,12 +428,13 @@ std::vector<ttnn::Tensor> split(
     const auto& input_shape = input_tensor.logical_shape();
     int64_t normalized_dim = input_shape.get_normalized_index(dim);
 
-    // Match torch.split: ceil(dim_size / split_size) chunks of size split_size, with a
-    // smaller final chunk when the dimension is not evenly divisible. Build the size list
-    // so it sums exactly to the dimension (the last entry holds the remainder), which keeps
-    // the list overload's strict torch-parity sum check satisfied.
+    // ceil(dim_size / split_size) chunks of size split_size, with a smaller final chunk when the
+    // dimension is not evenly divisible. Build the size list so it sums exactly to the dimension
+    // (the last entry holds the remainder), which keeps the list overload's strict sum check
+    // satisfied. Compute the quotient and remainder separately to avoid overflowing
+    // dim_size + split_size for a large split_size.
     const int64_t dim_size = static_cast<int64_t>(input_shape[normalized_dim]);
-    const int64_t num_chunks = (dim_size + split_size - 1) / split_size;
+    const int64_t num_chunks = dim_size / split_size + (dim_size % split_size != 0 ? 1 : 0);
 
     ttsl::SmallVector<int64_t> split_sizes(num_chunks, split_size);
     if (num_chunks > 0) {

--- a/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
@@ -62,7 +62,7 @@ std::vector<ttnn::Tensor> split_with_slice_impl(
     // Callers (both public split overloads) enforce torch-parity: split sizes sum exactly to the
     // dimension size. This internal check guards against a malformed size list reaching the slicer.
     TT_FATAL(
-        std::accumulate(split_sizes.begin(), split_sizes.end(), 0L) == input_shape[dim],
+        std::accumulate(split_sizes.begin(), split_sizes.end(), int64_t{0}) == static_cast<int64_t>(input_shape[dim]),
         "Split sizes should sum exactly to dimension size. Split sizes: {} dimension {}",
         split_sizes,
         input_shape[dim]);
@@ -114,7 +114,7 @@ std::vector<ttnn::Tensor> split_with_slice_impl(
 
     ends[dim] = 0;
     for (const auto& s : split_sizes) {
-        ends[dim] = std::min(ends[dim] + s, static_cast<int64_t>(input_shape[dim]));
+        ends[dim] += s;
         results.emplace_back(ttnn::slice(input_tensor, sbegins, sends, ssteps, memory_config));
         begins[dim] += s;
     }
@@ -269,11 +269,9 @@ std::vector<ttnn::Tensor> split(
         "split_size should be greater than 0, instead got: {}",
         split_sizes);
 
-    // Sharded I/O handled natively by device kernels and slice via TensorAccessor (no de-shard).
-    const Tensor& working_input = input_tensor;
-    const MemoryConfig& op_mem_cfg = desired_mem_cfg;
+    const auto& input_shape = input_tensor.logical_shape();
 
-    const auto& input_shape = working_input.logical_shape();
+    // Normalize negative dimension to positive index
     int64_t normalized_dim = input_shape.get_normalized_index(dim);
 
     // Match torch.split semantics: the requested chunk sizes must sum exactly to the size of
@@ -291,21 +289,36 @@ std::vector<ttnn::Tensor> split(
 
     const uint32_t num_chunks = static_cast<uint32_t>(split_sizes.size());
 
-    // Equal N-way split fully covering the dim.
+    // True when all requested chunk sizes are equal. The exact-sum check above already
+    // guarantees they cover the full dimension, so no product check is needed here.
     bool is_equal_n_way_split =
-        std::all_of(split_sizes.begin(), split_sizes.end(), [&](auto s) { return s == split_sizes[0]; }) &&
-        split_sizes[0] * static_cast<int64_t>(num_chunks) == static_cast<int64_t>(input_shape[normalized_dim]);
+        std::all_of(split_sizes.begin(), split_sizes.end(), [&](auto s) { return s == split_sizes[0]; });
 
-    // TILE fast path (native N-chunk kernel): equal split on last dim, TILE, rank≥2, ≥2 tiles/dim, N-divisible, fits
-    // grid, shape4d[0]==1 for N>2; else N slice calls.
-    tt::tt_metal::IDevice* device = working_input.device();
+    // ---------------------------------------------------------------------------
+    // Fast path 1: TILE layout, equal N-way split on the last dim.
+    // Uses the native N-chunk TILE device kernel (single-pass, no slice overhead).
+    //
+    // The native TILE kernel is selected only when ALL of the following hold (see
+    // can_use_tile_kernel below); otherwise the split falls back to N independent
+    // ttnn::slice calls (split_with_slice_impl), which handle every other case
+    // (ROW_MAJOR, unequal sizes, non-last-dim, batch>1 for N>2, etc.):
+    //   - equal N-way split that exactly covers the dimension (is_equal_n_way_split)
+    //   - split dim is the last dim (normalized_dim == rank - 1)
+    //   - input is TILE layout, rank >= 2
+    //   - at least 2 tiles in each of the last two dims
+    //   - padded tile count in the split dim is divisible by num_chunks
+    //   - it all fits the core grid: z_4d <= grid_dim_x and num_chunks <= grid_dim_y
+    //   - shape4d[0] == 1 for N>2 (the N==2 path collapses batch via reshape instead)
+    // Sharded input/output are handled natively on both paths (no de-shard step).
+    // ---------------------------------------------------------------------------
+    tt::tt_metal::IDevice* device = input_tensor.device();
     const uint32_t grid_dim_x = device->compute_with_storage_grid_size().x;
     const uint32_t grid_dim_y = device->compute_with_storage_grid_size().y;
 
     // Compute the 4D shape the kernel sees: rank<4 pads with 1s, rank>4 merges leading dims into [0].
     std::array<uint32_t, 4> shape4d = {1, 1, 1, 1};
     if (input_shape.rank() > static_cast<size_t>(detail::RANK_FOUR)) {
-        const auto s4 = ttnn::operations::data_movement::squeeze_shape_to_4D(working_input.logical_shape());
+        const auto s4 = ttnn::operations::data_movement::squeeze_shape_to_4D(input_tensor.logical_shape());
         for (int i = 0; i < 4; i++) {
             shape4d[i] = s4[i];
         }
@@ -319,8 +332,10 @@ std::vector<ttnn::Tensor> split(
     const uint32_t z_4d = (num_chunks == detail::TWO_CHUNKS) ? shape4d[0] * shape4d[1] : shape4d[1];
     bool fits_in_core_grid = input_shape.rank() >= 2 && z_4d < grid_dim_x + 1;
 
-    // Program factory requires padded tile count in split dim divisible by num_chunks.
-    uint32_t padded_tiles_in_split_dim = working_input.padded_shape()[-1] / tt::constants::TILE_WIDTH;
+    // The program factory requires the padded tile count in the split dim to be
+    // divisible by num_chunks (otherwise the Y-core grouping doesn't work out).
+    // This is only evaluated when normalized_dim == rank-1, so [-1] is always correct.
+    uint32_t padded_tiles_in_split_dim = input_tensor.padded_shape()[-1] / tt::constants::TILE_WIDTH;
     bool tiles_divisible_by_chunks = (padded_tiles_in_split_dim % num_chunks == 0);
 
     // prim::split hard-requires shape4d[0]==1 for N>2 (N==2 handles batch>1 via reshape).
@@ -330,7 +345,7 @@ std::vector<ttnn::Tensor> split(
     bool chunks_fit_in_y_grid = (num_chunks <= grid_dim_y);
 
     bool can_use_tile_kernel = is_equal_n_way_split && normalized_dim == static_cast<int64_t>(input_shape.rank()) - 1 &&
-                               working_input.layout() == Layout::TILE && input_shape.rank() >= 2 && fits_in_core_grid &&
+                               input_tensor.layout() == Layout::TILE && input_shape.rank() >= 2 && fits_in_core_grid &&
                                input_shape[-2] / tt::constants::TILE_HEIGHT >= 2 &&
                                input_shape[-1] / tt::constants::TILE_WIDTH >= 2 && tiles_divisible_by_chunks &&
                                batch_ok_for_n_gt2 && chunks_fit_in_y_grid;
@@ -338,18 +353,18 @@ std::vector<ttnn::Tensor> split(
     if (can_use_tile_kernel) {
         ttnn::Tensor input_tensor_4d;
         if (input_shape.rank() > detail::RANK_FOUR) {
-            input_tensor_4d = operations::data_movement::squeeze_from_ND_to_4D(working_input);
+            input_tensor_4d = operations::data_movement::squeeze_from_ND_to_4D(input_tensor);
         } else if (input_shape.rank() < detail::RANK_FOUR) {
-            input_tensor_4d = unsqueeze_to_4D(working_input);
+            input_tensor_4d = unsqueeze_to_4D(input_tensor);
         } else {
-            input_tensor_4d = working_input;
+            input_tensor_4d = input_tensor;
         }
         // N>2: prim::split directly. N==2: split_last_dim_two_chunks_tiled handles batch>1 reshape.
         std::vector<Tensor> outputs_4d;
         if (num_chunks == detail::TWO_CHUNKS) {
-            outputs_4d = detail::split_last_dim_two_chunks_tiled(input_tensor_4d, op_mem_cfg);
+            outputs_4d = detail::split_last_dim_two_chunks_tiled(input_tensor_4d, desired_mem_cfg);
         } else {
-            outputs_4d = ttnn::prim::split(input_tensor_4d, static_cast<int>(num_chunks), 3, op_mem_cfg);
+            outputs_4d = ttnn::prim::split(input_tensor_4d, static_cast<int>(num_chunks), 3, desired_mem_cfg);
         }
         results.reserve(num_chunks);
         for (const auto& t : outputs_4d) {
@@ -358,10 +373,14 @@ std::vector<ttnn::Tensor> split(
             results.emplace_back(ttnn::view(t, ttnn::Shape(final_shape)));
         }
     } else {
-        // Slice fallback: if outputs downgraded to DRAM, migrate L1 input too so per-slice CBs don't clash.
-        Tensor slice_input = working_input;
+        // Fallback: unequal splits, ROW_MAJOR, batch>1 for N>2, or anything not
+        // handled by the TILE fast path above. Uses N independent slice calls.
+        //
+        // If the outputs were downgraded to DRAM, migrate an L1 input to DRAM too so the
+        // per-slice CBs (stamped on core [0,0] by each slice call) don't clash in L1.
+        Tensor slice_input = input_tensor;
         if (slice_input.memory_config().buffer_type() == tt::tt_metal::BufferType::L1 &&
-            op_mem_cfg.buffer_type() == tt::tt_metal::BufferType::DRAM && split_sizes.size() > 2) {
+            desired_mem_cfg.buffer_type() == tt::tt_metal::BufferType::DRAM && split_sizes.size() > 2) {
             const MemoryConfig dram_interleaved{
                 tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM};
             // Padded volume + tile_size(DataFormat) so bfp8_b/bfp4_b exponents are counted.
@@ -377,7 +396,8 @@ std::vector<ttnn::Tensor> split(
             log_warning(tt::LogOp, "ttnn.split: migrating L1 input ({} B) to DRAM before slice fallback.", input_bytes);
             slice_input = ttnn::to_memory_config(slice_input, dram_interleaved, std::nullopt);
         }
-        results = detail::split_with_slice_impl(slice_input, split_sizes, normalized_dim, op_mem_cfg);
+        results = detail::split_with_slice_impl(
+            slice_input, split_sizes, static_cast<int32_t>(normalized_dim), desired_mem_cfg);
     }
 
     return results;

--- a/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/split.cpp
@@ -59,10 +59,11 @@ std::vector<ttnn::Tensor> split_with_slice_impl(
     const MemoryConfig& memory_config) {
     const auto& input_shape = input_tensor.logical_shape();
 
-    // torch requires split size to sum to dim size but since we are using slice we can be more permissive.
+    // Callers (both public split overloads) enforce torch-parity: split sizes sum exactly to the
+    // dimension size. This internal check guards against a malformed size list reaching the slicer.
     TT_FATAL(
-        std::accumulate(split_sizes.begin(), split_sizes.end(), 0L) >= input_shape[dim],
-        "Split sizes should sum to at least dimension size. Split sizes: {} dimension {}",
+        std::accumulate(split_sizes.begin(), split_sizes.end(), 0L) == input_shape[dim],
+        "Split sizes should sum exactly to dimension size. Split sizes: {} dimension {}",
         split_sizes,
         input_shape[dim]);
 
@@ -274,6 +275,18 @@ std::vector<ttnn::Tensor> split(
 
     const auto& input_shape = working_input.logical_shape();
     int64_t normalized_dim = input_shape.get_normalized_index(dim);
+
+    // Match torch.split semantics: the requested chunk sizes must sum exactly to the size of
+    // the split dimension. torch raises for both under- and over-covering size lists.
+    const int64_t split_sizes_sum = std::accumulate(split_sizes.begin(), split_sizes.end(), int64_t{0});
+    TT_FATAL(
+        split_sizes_sum == static_cast<int64_t>(input_shape[normalized_dim]),
+        "split_sizes must sum exactly to the size of dimension {} ({}), but got sizes {} summing to {}",
+        normalized_dim,
+        input_shape[normalized_dim],
+        split_sizes,
+        split_sizes_sum);
+
     std::vector<ttnn::Tensor> results;
 
     const uint32_t num_chunks = static_cast<uint32_t>(split_sizes.size());
@@ -381,9 +394,17 @@ std::vector<ttnn::Tensor> split(
     const auto& input_shape = input_tensor.logical_shape();
     int64_t normalized_dim = input_shape.get_normalized_index(dim);
 
-    const auto num_chunks = std::ceil(static_cast<float>(input_shape[normalized_dim]) / static_cast<float>(split_size));
+    // Match torch.split: ceil(dim_size / split_size) chunks of size split_size, with a
+    // smaller final chunk when the dimension is not evenly divisible. Build the size list
+    // so it sums exactly to the dimension (the last entry holds the remainder), which keeps
+    // the list overload's strict torch-parity sum check satisfied.
+    const int64_t dim_size = static_cast<int64_t>(input_shape[normalized_dim]);
+    const int64_t num_chunks = (dim_size + split_size - 1) / split_size;
 
-    const ttsl::SmallVector<int64_t> split_sizes(num_chunks, split_size);
+    ttsl::SmallVector<int64_t> split_sizes(num_chunks, split_size);
+    if (num_chunks > 0) {
+        split_sizes.back() = dim_size - split_size * (num_chunks - 1);
+    }
     // Pass memory_config_arg directly so the split_sizes overload applies the
     // same sharding-default logic (sharded input → DRAM output when no explicit config).
     return ttnn::split(input_tensor, split_sizes, normalized_dim, memory_config_arg);

--- a/ttnn/cpp/ttnn/operations/data_movement/split/split_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/split_nanobind.cpp
@@ -22,21 +22,51 @@ namespace ttnn::operations::data_movement::detail {
 void bind_split(nb::module_& mod) {
     const auto* doc =
         R"doc(
-            Returns a tensor that is in num_splits ways on dim.
+            Splits :attr:`input_tensor` into chunks along dimension :attr:`dim` and returns them as a list of tensors.
+
+            This matches the semantics of :func:`torch.split`:
+
+            * If :attr:`split_size` is an ``int``, the tensor is split into equally sized chunks of
+              ``split_size`` along :attr:`dim`. If the dimension is not evenly divisible by
+              ``split_size``, the last chunk is smaller. The number of outputs is
+              ``ceil(input_tensor.shape[dim] / split_size)``.
+            * If :attr:`split_size` is a ``list[int]``, the tensor is split into ``len(split_size)``
+              chunks whose sizes along :attr:`dim` are given by the list entries. The sizes must sum
+              exactly to ``input_tensor.shape[dim]``; an error is raised otherwise.
+
+            .. note::
+                The following degenerate cases differ from :func:`torch.split` (they involve
+                zero-volume tensors, which are not supported by the device kernels):
+
+                * A zero-size split dimension (``input_tensor.shape[dim] == 0``) with an integer
+                  :attr:`split_size` raises an error instead of returning a single empty chunk.
+                * Zero-size entries in a :attr:`split_size` list (e.g. ``[0, 10]``) raise an error;
+                  every chunk size must be greater than 0.
 
             Equivalent pytorch code:
 
             .. code-block:: python
 
-                output_tensor = torch.split(input_tensor, 2, 1)
+                # split_size as an int
+                output_tensors = ttnn.split(input_tensor, 2, dim=1)
+                # equivalent to
+                output_tensors = torch.split(input_tensor, 2, dim=1)
+
+                # split_size as a list
+                output_tensors = ttnn.split(input_tensor, [2, 3], dim=1)
+                # equivalent to
+                output_tensors = torch.split(input_tensor, [2, 3], dim=1)
 
             Args:
                 * :attr:`input_tensor`: Input Tensor.
-                * :attr:`split_size` (Union[int, list[int]]): Single chunk size or list of chunk sizes. Output may be smaller if dim not evenly divisible.
-                * :attr:`dim2`: Dim to split. Defaults to 0.
+                * :attr:`split_size` (Union[int, list[int]]): Size of a single chunk, or a list of per-chunk sizes.
+                * :attr:`dim` (int): Dimension along which to split. Negative indexing is supported. Defaults to 0.
 
             Keyword Args:
-                * :attr:`memory_config`: Memory Config of the output tensor
+                * :attr:`memory_config`: Memory Config of the output tensors.
+
+            Returns:
+                List[ttnn.Tensor]: The list of output tensors.
         )doc";
 
     ttnn::bind_function<"split">(

--- a/ttnn/cpp/ttnn/operations/data_movement/split/split_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/split/split_nanobind.cpp
@@ -24,38 +24,33 @@ void bind_split(nb::module_& mod) {
         R"doc(
             Splits :attr:`input_tensor` into chunks along dimension :attr:`dim` and returns them as a list of tensors.
 
-            This matches the semantics of :func:`torch.split`:
+            The behavior depends on the type of :attr:`split_size`:
 
-            * If :attr:`split_size` is an ``int``, the tensor is split into equally sized chunks of
-              ``split_size`` along :attr:`dim`. If the dimension is not evenly divisible by
-              ``split_size``, the last chunk is smaller. The number of outputs is
-              ``ceil(input_tensor.shape[dim] / split_size)``.
+            * If :attr:`split_size` is an ``int``, the tensor is split into contiguous chunks of
+              ``split_size`` elements along :attr:`dim`. When ``input_tensor.shape[dim]`` is not an
+              exact multiple of ``split_size``, the final chunk holds the remainder and is smaller.
+              The number of outputs is ``ceil(input_tensor.shape[dim] / split_size)``.
             * If :attr:`split_size` is a ``list[int]``, the tensor is split into ``len(split_size)``
-              chunks whose sizes along :attr:`dim` are given by the list entries. The sizes must sum
-              exactly to ``input_tensor.shape[dim]``; an error is raised otherwise.
+              contiguous chunks whose sizes along :attr:`dim` are the list entries, in order. The
+              entries must sum exactly to ``input_tensor.shape[dim]``.
 
-            .. note::
-                The following degenerate cases differ from :func:`torch.split` (they involve
-                zero-volume tensors, which are not supported by the device kernels):
+            Constraints:
 
-                * A zero-size split dimension (``input_tensor.shape[dim] == 0``) with an integer
-                  :attr:`split_size` raises an error instead of returning a single empty chunk.
-                * Zero-size entries in a :attr:`split_size` list (e.g. ``[0, 10]``) raise an error;
-                  every chunk size must be greater than 0.
+            * Every chunk size must be greater than 0 (both a zero entry in a :attr:`split_size`
+              list and a zero-size split dimension raise an error; zero-volume tensors are not
+              supported by the device kernels).
+            * For a :attr:`split_size` list, the entries must sum exactly to ``input_tensor.shape[dim]``;
+              an error is raised for both under- and over-covering lists.
 
-            Equivalent pytorch code:
+            Example:
 
             .. code-block:: python
 
-                # split_size as an int
-                output_tensors = ttnn.split(input_tensor, 2, dim=1)
-                # equivalent to
-                output_tensors = torch.split(input_tensor, 2, dim=1)
+                # int split_size: 6 along dim=1 -> chunks of size 2
+                a, b, c = ttnn.split(input_tensor, 2, dim=1)  # input_tensor.shape[1] == 6
 
-                # split_size as a list
-                output_tensors = ttnn.split(input_tensor, [2, 3], dim=1)
-                # equivalent to
-                output_tensors = torch.split(input_tensor, [2, 3], dim=1)
+                # list split_size: explicit per-chunk sizes summing to shape[1]
+                a, b = ttnn.split(input_tensor, [2, 4], dim=1)  # input_tensor.shape[1] == 6
 
             Args:
                 * :attr:`input_tensor`: Input Tensor.


### PR DESCRIPTION
### Ticket
#49283 

### PR Category
Bug fix

### What this PR does
Aligns ttnn.split semantics exactly with torch.split:

- Strict size validation: a split_sizes list must sum exactly to the split dimension. Previously the internal slice path was permissive (sum >= dim_size), silently dropping or mis-covering data; both under- and over-covering lists now raise, matching torch.
- Integer split_size remainder fix: the int overload now produces ceil(dim/size) chunks whose last entry holds the remainder (summing exactly to the dim), instead of emitting all-equal sizes and relying on downstream std::min clamping.
- Docstring rewrite covering both the int and list[int] forms, negative-dim support, and the two documented deviations from torch (a zero-length split dim and zero-size list entries raise, since the device kernels don't support zero-volume tensors).
- Cleanup: removed the redundant working_input/op_mem_cfg aliases in favor of input_tensor/desired_mem_cfg, and simplified the is_equal_n_way_split check (the exact-sum guarantee makes the old product check unnecessary).
- Test: adds a single-chunk parity case (split_size >= dim_size returns the whole tensor as one chunk) across TILE/ROW_MAJOR and bf16/fp32.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abdulla/split_universal_I/O)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abdulla/split_universal_I/O)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=abdulla/split_universal_I/O)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:abdulla/split_universal_I/O)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=abdulla/split_universal_I/O)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:abdulla/split_universal_I/O)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abdulla/split_universal_I/O)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abdulla/split_universal_I/O)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=abdulla/split_universal_I/O)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:abdulla/split_universal_I/O)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=abdulla/split_universal_I/O)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:abdulla/split_universal_I/O)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=abdulla/split_universal_I/O)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:abdulla/split_universal_I/O)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=abdulla/split_universal_I/O)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:abdulla/split_universal_I/O)