### PR TITLE
Fix full ND sharded TILE test cases to use tile-aligned shard shapes

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_full.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_full.py
@@ -209,12 +209,26 @@ def test_full_nd_sharded(
         (
             ttnn.TILE_LAYOUT,
             [64, 64, 64],
+            [16, 32, 32],
+            ttnn.BufferType.DRAM,
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(4, 0))}),
+        ),
+        (
+            ttnn.ROW_MAJOR_LAYOUT,
+            [64, 64, 64],
             [16, 16, 16],
             ttnn.BufferType.DRAM,
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(4, 0))}),
         ),
         (
             ttnn.TILE_LAYOUT,
+            [8, 8, 8, 8, 8, 8, 8],
+            [4, 32, 32],
+            ttnn.BufferType.DRAM,
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(4, 0))}),
+        ),
+        (
+            ttnn.ROW_MAJOR_LAYOUT,
             [8, 8, 8, 8, 8, 8, 8],
             [4, 4, 4],
             ttnn.BufferType.DRAM,
@@ -223,7 +237,7 @@ def test_full_nd_sharded(
         (
             ttnn.TILE_LAYOUT,
             [17, 19, 41, 3, 44],
-            [10, 11, 13],
+            [10, 32, 32],
             ttnn.BufferType.DRAM,
             ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(4, 0))}),
         ),


### PR DESCRIPTION
### PR Category
Test Only

### Summary
`test_full_nd_sharded_manual_sharding` was failing for TILE layout cases whose manually specified physical shard shapes had trailing dimensions smaller than a tile, for example `[10, 11, 13]`. Recent tensor layout validation correctly rejects TILE sharded tensors unless the physical shard shape is tile-sized in the last two dimensions, so these success-path tests were constructing invalid TILE layouts. The test parameters now use tile-aligned trailing shard dimensions for TILE cases, while preserving the original irregular shard-shape coverage under valid ROW_MAJOR cases where applicable. This keeps the test focused on `ttnn.full` behavior for valid manual sharding configurations and avoids expecting invalid TILE shard specs to succeed.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/invalid-shard-shapes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/invalid-shard-shapes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/invalid-shard-shapes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/invalid-shard-shapes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/invalid-shard-shapes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/invalid-shard-shapes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/invalid-shard-shapes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/invalid-shard-shapes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/invalid-shard-shapes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/invalid-shard-shapes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/invalid-shard-shapes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/invalid-shard-shapes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/invalid-shard-shapes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/invalid-shard-shapes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/invalid-shard-shapes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/invalid-shard-shapes)