### PR TITLE
[Cleanup] Migrate precomposed NoC addresses to UnicastEndpoints (CCL)

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/root2_receive_reader_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/root2_receive_reader_kernel.cpp
@@ -4,6 +4,9 @@
 ///
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
 #include "cpp/ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "ttnn/cpp/ttnn/operations/point_to_point/device/kernels/common.hpp"
@@ -22,6 +25,7 @@
 using tt::data_movement::common::tt_memmove;
 
 inline void read_from_local(
+    const Noc& noc,
     uint32_t src_addr_l,  // source address for l tensor
     uint32_t src_addr_s,  // source address for s tensor
     uint32_t src_addr_m,  // source address for m tensor
@@ -35,22 +39,34 @@ inline void read_from_local(
     uint32_t input_num_tiles) {
     cb_reserve_back(cb_id_in_l, input_num_tiles);
     uint32_t l1_write_addr = get_write_ptr(cb_id_in_l);
-    uint64_t read_addr = get_noc_addr(core_noc_x, core_noc_y, src_addr_l);
-    noc_async_read(read_addr, l1_write_addr, input_num_tiles * page_bytes);
+    noc.async_read(
+        UnicastEndpoint{},
+        CoreLocalMem<uint32_t>(l1_write_addr),
+        input_num_tiles * page_bytes,
+        {.noc_x = core_noc_x, .noc_y = core_noc_y, .addr = src_addr_l},
+        {});
     cb_push_back(cb_id_in_l, input_num_tiles);
 
     // for tensor s
     cb_reserve_back(cb_id_in_s, onetile);
     l1_write_addr = get_write_ptr(cb_id_in_s);
-    read_addr = get_noc_addr(core_noc_x, core_noc_y, src_addr_s);
-    noc_async_read(read_addr, l1_write_addr, onetile * page_bytes);
+    noc.async_read(
+        UnicastEndpoint{},
+        CoreLocalMem<uint32_t>(l1_write_addr),
+        onetile * page_bytes,
+        {.noc_x = core_noc_x, .noc_y = core_noc_y, .addr = src_addr_s},
+        {});
     cb_push_back(cb_id_in_s, onetile);
 
     // for tensor m
     cb_reserve_back(cb_id_in_m, onetile);
     l1_write_addr = get_write_ptr(cb_id_in_m);
-    read_addr = get_noc_addr(core_noc_x, core_noc_y, src_addr_m);
-    noc_async_read(read_addr, l1_write_addr, onetile * page_bytes);
+    noc.async_read(
+        UnicastEndpoint{},
+        CoreLocalMem<uint32_t>(l1_write_addr),
+        onetile * page_bytes,
+        {.noc_x = core_noc_x, .noc_y = core_noc_y, .addr = src_addr_m},
+        {});
     noc_async_read_barrier();
     cb_push_back(cb_id_in_m, onetile);
 }
@@ -152,6 +168,7 @@ void kernel_main() {
 
     //  read local data from own device and push to compute cbs
     read_from_local(
+        noc,
         src_addr_l,
         src_addr_s,
         src_addr_m,
@@ -186,8 +203,12 @@ void kernel_main() {
     cb_reserve_back(receiver_cb_id_l, input_num_tiles);
     uint32_t dest_page_base_addr = get_write_ptr(receiver_cb_id_l);
 
-    const uint64_t packet_noc_addr = get_noc_addr(core_noc_x, core_noc_y, intermediate_base_addr);
-    noc_async_read(packet_noc_addr, packet_l1_addr, new_packet_size_bytes);
+    noc.async_read(
+        UnicastEndpoint{},
+        CoreLocalMem<uint32_t>(packet_l1_addr),
+        new_packet_size_bytes,
+        {.noc_x = core_noc_x, .noc_y = core_noc_y, .addr = intermediate_base_addr},
+        {});
     noc_async_read_barrier();
 
     tt_memmove<true, false, false, 0>(noc, dest_page_base_addr, packet_l1_addr, packet_size_bytes);

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/root2_receive_reader_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/root2_receive_reader_kernel.cpp
@@ -67,7 +67,7 @@ inline void read_from_local(
         onetile * page_bytes,
         {.noc_x = core_noc_x, .noc_y = core_noc_y, .addr = src_addr_m},
         {});
-    noc_async_read_barrier();
+    noc.async_read_barrier();
     cb_push_back(cb_id_in_m, onetile);
 }
 
@@ -209,7 +209,7 @@ void kernel_main() {
         new_packet_size_bytes,
         {.noc_x = core_noc_x, .noc_y = core_noc_y, .addr = intermediate_base_addr},
         {});
-    noc_async_read_barrier();
+    noc.async_read_barrier();
 
     tt_memmove<true, false, false, 0>(noc, dest_page_base_addr, packet_l1_addr, packet_size_bytes);
     cb_push_back(receiver_cb_id_l, input_num_tiles);

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/root2_receive_reader_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/root2_receive_reader_kernel.cpp
@@ -6,6 +6,7 @@
 #include "api/dataflow/noc_semaphore.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/endpoints.h"
+#include "api/dataflow/circular_buffer.h"
 #include "api/core_local_mem.h"
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
 #include "cpp/ttnn/operations/data_movement/common/kernels/common.hpp"
@@ -37,30 +38,34 @@ inline void read_from_local(
     uint32_t cb_id_in_m,  // compute cb for m
     uint32_t onetile,
     uint32_t input_num_tiles) {
-    cb_reserve_back(cb_id_in_l, input_num_tiles);
-    uint32_t l1_write_addr = get_write_ptr(cb_id_in_l);
+    CircularBuffer cb_in_l(cb_id_in_l);
+    CircularBuffer cb_in_s(cb_id_in_s);
+    CircularBuffer cb_in_m(cb_id_in_m);
+
+    cb_in_l.reserve_back(input_num_tiles);
+    uint32_t l1_write_addr = cb_in_l.get_write_ptr();
     noc.async_read(
         UnicastEndpoint{},
         CoreLocalMem<uint32_t>(l1_write_addr),
         input_num_tiles * page_bytes,
         {.noc_x = core_noc_x, .noc_y = core_noc_y, .addr = src_addr_l},
         {});
-    cb_push_back(cb_id_in_l, input_num_tiles);
+    cb_in_l.push_back(input_num_tiles);
 
     // for tensor s
-    cb_reserve_back(cb_id_in_s, onetile);
-    l1_write_addr = get_write_ptr(cb_id_in_s);
+    cb_in_s.reserve_back(onetile);
+    l1_write_addr = cb_in_s.get_write_ptr();
     noc.async_read(
         UnicastEndpoint{},
         CoreLocalMem<uint32_t>(l1_write_addr),
         onetile * page_bytes,
         {.noc_x = core_noc_x, .noc_y = core_noc_y, .addr = src_addr_s},
         {});
-    cb_push_back(cb_id_in_s, onetile);
+    cb_in_s.push_back(onetile);
 
     // for tensor m
-    cb_reserve_back(cb_id_in_m, onetile);
-    l1_write_addr = get_write_ptr(cb_id_in_m);
+    cb_in_m.reserve_back(onetile);
+    l1_write_addr = cb_in_m.get_write_ptr();
     noc.async_read(
         UnicastEndpoint{},
         CoreLocalMem<uint32_t>(l1_write_addr),
@@ -68,7 +73,7 @@ inline void read_from_local(
         {.noc_x = core_noc_x, .noc_y = core_noc_y, .addr = src_addr_m},
         {});
     noc.async_read_barrier();
-    cb_push_back(cb_id_in_m, onetile);
+    cb_in_m.push_back(onetile);
 }
 
 void kernel_main() {
@@ -150,9 +155,16 @@ void kernel_main() {
         fabric_mux_x, fabric_mux_y, fabric_mux_status_address, local_fabric_mux_status_address);
 
     tt::tt_fabric::fabric_client_connect(*mux_connection_handle);
-    cb_reserve_back(packet_header_cb_id, 1);
-    const uint32_t sem_header_addr = get_write_ptr(packet_header_cb_id);
-    cb_push_back(packet_header_cb_id, 1);
+
+    CircularBuffer packet_header_cb(packet_header_cb_id);
+    CircularBuffer packet_cb(packet_cb_id);
+    CircularBuffer receiver_cb_l(receiver_cb_id_l);
+    CircularBuffer receiver_cb_s(receiver_cb_id_s);
+    CircularBuffer receiver_cb_m(receiver_cb_id_m);
+
+    packet_header_cb.reserve_back(1);
+    const uint32_t sem_header_addr = packet_header_cb.get_write_ptr();
+    packet_header_cb.push_back(1);
 
     const uint64_t sender_sem_noc_addr = get_noc_addr(core_noc_x, core_noc_y, sender_semaphore_addr);
 
@@ -162,9 +174,9 @@ void kernel_main() {
 
     mux_connection.wait_for_empty_write_slot();
     mux_connection.send_payload_flush_blocking_from_address((uint32_t)sem_header_ptr, packet_header_size_bytes);
-    cb_reserve_back(packet_cb_id, 1);
+    packet_cb.reserve_back(1);
 
-    const uint32_t packet_l1_addr = get_write_ptr(packet_cb_id);
+    const uint32_t packet_l1_addr = packet_cb.get_write_ptr();
 
     //  read local data from own device and push to compute cbs
     read_from_local(
@@ -200,8 +212,8 @@ void kernel_main() {
     const uint32_t aligned_page_size_bytes = align(page_size_bytes, alignment);
     uint32_t packet_idx = 0;
 
-    cb_reserve_back(receiver_cb_id_l, input_num_tiles);
-    uint32_t dest_page_base_addr = get_write_ptr(receiver_cb_id_l);
+    receiver_cb_l.reserve_back(input_num_tiles);
+    uint32_t dest_page_base_addr = receiver_cb_l.get_write_ptr();
 
     noc.async_read(
         UnicastEndpoint{},
@@ -212,13 +224,13 @@ void kernel_main() {
     noc.async_read_barrier();
 
     tt_memmove<true, false, false, 0>(noc, dest_page_base_addr, packet_l1_addr, packet_size_bytes);
-    cb_push_back(receiver_cb_id_l, input_num_tiles);
+    receiver_cb_l.push_back(input_num_tiles);
 
-    cb_reserve_back(receiver_cb_id_s, 1);
-    cb_reserve_back(receiver_cb_id_m, 1);
+    receiver_cb_s.reserve_back(1);
+    receiver_cb_m.reserve_back(1);
 
-    const uint32_t dest_page_base_addr_s = get_write_ptr(receiver_cb_id_s);
-    const uint32_t dest_page_base_addr_m = get_write_ptr(receiver_cb_id_m);
+    const uint32_t dest_page_base_addr_s = receiver_cb_s.get_write_ptr();
+    const uint32_t dest_page_base_addr_m = receiver_cb_m.get_write_ptr();
 
     tt_memmove<true, false, false, 0>(
         noc, dest_page_base_addr_s, packet_l1_addr + packet_size_bytes, aligned_page_size_bytes);
@@ -227,7 +239,7 @@ void kernel_main() {
         dest_page_base_addr_m,
         packet_l1_addr + packet_size_bytes + aligned_page_size_bytes,
         aligned_page_size_bytes);
-    cb_push_back(receiver_cb_id_s, 1);
-    cb_push_back(receiver_cb_id_m, 1);
-    cb_push_back(packet_cb_id, 1);
+    receiver_cb_s.push_back(1);
+    receiver_cb_m.push_back(1);
+    packet_cb.push_back(1);
 }

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/root_receive_reader_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/root_receive_reader_kernel.cpp
@@ -68,7 +68,7 @@ inline void read_from_local(
         onetile * page_bytes,
         {.noc_x = core_noc_x, .noc_y = core_noc_y, .addr = src_addr_m},
         {});
-    noc_async_read_barrier();
+    noc.async_read_barrier();
     cb_push_back(cb_id_in_m, onetile);
 }
 
@@ -219,7 +219,7 @@ void kernel_main() {
     // Drain the inbound read before the tt_memmove consumers below: each tt_memmove is itself a NoC
     // op whose SOURCE is packet_l1_addr, and on the weak NoC there is no read->read landing order, so
     // the memmove could forward stale/partial packet data. Mirrors root2_receive_reader_kernel.cpp.
-    noc_async_read_barrier();
+    noc.async_read_barrier();
 
     // moving l tensor
     tt_memmove<true, false, false, 0>(noc, dest_page_base_addr, packet_l1_addr, packet_size_bytes);
@@ -333,7 +333,7 @@ void kernel_main() {
         {.noc_x = core_noc_x, .noc_y = core_noc_y, .addr = intermediate_base_addr},
         {});
     // Drain the inbound read before the tt_memmove consumers (see first occurrence above).
-    noc_async_read_barrier();
+    noc.async_read_barrier();
 
     tt_memmove<true, false, false, 0>(noc, dest_page_base_addr, packet_l1_addr, packet_size_bytes);
     cb_push_back(receiver_cb_id_l, input_num_tiles);

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/root_receive_reader_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/root_receive_reader_kernel.cpp
@@ -6,6 +6,7 @@
 #include "api/dataflow/noc_semaphore.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/endpoints.h"
+#include "api/dataflow/circular_buffer.h"
 #include "api/core_local_mem.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
@@ -37,31 +38,34 @@ inline void read_from_local(
     uint32_t cb_id_in_m,  // compute cb for m
     uint32_t onetile,
     uint32_t input_num_tiles) {
+    CircularBuffer cb_in_l(cb_id_in_l);
+    CircularBuffer cb_in_s(cb_id_in_s);
+    CircularBuffer cb_in_m(cb_id_in_m);
     // read l, s, m data from own device and push it to compute cbs
-    cb_reserve_back(cb_id_in_l, input_num_tiles);
-    uint32_t l1_write_addr = get_write_ptr(cb_id_in_l);
+    cb_in_l.reserve_back(input_num_tiles);
+    uint32_t l1_write_addr = cb_in_l.get_write_ptr();
     noc.async_read(
         UnicastEndpoint{},
         CoreLocalMem<uint32_t>(l1_write_addr),
         input_num_tiles * page_bytes,
         {.noc_x = core_noc_x, .noc_y = core_noc_y, .addr = src_addr_l},
         {});
-    cb_push_back(cb_id_in_l, input_num_tiles);
+    cb_in_l.push_back(input_num_tiles);
 
     // for tensor s
-    cb_reserve_back(cb_id_in_s, onetile);
-    l1_write_addr = get_write_ptr(cb_id_in_s);
+    cb_in_s.reserve_back(onetile);
+    l1_write_addr = cb_in_s.get_write_ptr();
     noc.async_read(
         UnicastEndpoint{},
         CoreLocalMem<uint32_t>(l1_write_addr),
         onetile * page_bytes,
         {.noc_x = core_noc_x, .noc_y = core_noc_y, .addr = src_addr_s},
         {});
-    cb_push_back(cb_id_in_s, onetile);
+    cb_in_s.push_back(onetile);
 
     // for tensor m
-    cb_reserve_back(cb_id_in_m, onetile);
-    l1_write_addr = get_write_ptr(cb_id_in_m);
+    cb_in_m.reserve_back(onetile);
+    l1_write_addr = cb_in_m.get_write_ptr();
     noc.async_read(
         UnicastEndpoint{},
         CoreLocalMem<uint32_t>(l1_write_addr),
@@ -69,7 +73,7 @@ inline void read_from_local(
         {.noc_x = core_noc_x, .noc_y = core_noc_y, .addr = src_addr_m},
         {});
     noc.async_read_barrier();
-    cb_push_back(cb_id_in_m, onetile);
+    cb_in_m.push_back(onetile);
 }
 
 void kernel_main() {
@@ -86,6 +90,13 @@ void kernel_main() {
     constexpr uint32_t input_num_tiles = get_compile_time_arg_val(10);
     constexpr uint32_t page_size_bytes = get_compile_time_arg_val(11);
     constexpr uint32_t packet_size_bytes = get_compile_time_arg_val(12);
+
+    // Kernel-level circular buffers (reused across both device-1 and device-2 receive phases).
+    CircularBuffer packet_header_cb(packet_header_cb_id);
+    CircularBuffer packet_cb(packet_cb_id);
+    CircularBuffer receiver_cb_l(receiver_cb_id_l);
+    CircularBuffer receiver_cb_s(receiver_cb_id_s);
+    CircularBuffer receiver_cb_m(receiver_cb_id_m);
 
     constexpr size_t packet_header_size_bytes = sizeof(PACKET_HEADER_TYPE);
 
@@ -154,9 +165,9 @@ void kernel_main() {
 
     tt::tt_fabric::fabric_client_connect(*mux_connection_handle);
 
-    cb_reserve_back(packet_header_cb_id, 1);
-    const uint32_t sem_header_addr = get_write_ptr(packet_header_cb_id);
-    cb_push_back(packet_header_cb_id, 1);
+    packet_header_cb.reserve_back(1);
+    const uint32_t sem_header_addr = packet_header_cb.get_write_ptr();
+    packet_header_cb.push_back(1);
 
     const uint64_t sender_sem_noc_addr = get_noc_addr(core_noc_x, core_noc_y, sender_semaphore_addr);
 
@@ -168,8 +179,8 @@ void kernel_main() {
     mux_connection.wait_for_empty_write_slot();
     mux_connection.send_payload_flush_blocking_from_address((uint32_t)sem_header_ptr, packet_header_size_bytes);
 
-    cb_reserve_back(packet_cb_id, 1);
-    uint32_t packet_l1_addr = get_write_ptr(packet_cb_id);
+    packet_cb.reserve_back(1);
+    uint32_t packet_l1_addr = packet_cb.get_write_ptr();
 
     // read local data from own device and push to compute cbs
     read_from_local(
@@ -207,8 +218,8 @@ void kernel_main() {
     const uint32_t aligned_page_size_bytes = align(page_size_bytes, alignment);
     uint32_t packet_idx = 0;
 
-    cb_reserve_back(receiver_cb_id_l, input_num_tiles);
-    uint32_t dest_page_base_addr = get_write_ptr(receiver_cb_id_l);
+    receiver_cb_l.reserve_back(input_num_tiles);
+    uint32_t dest_page_base_addr = receiver_cb_l.get_write_ptr();
 
     noc.async_read(
         UnicastEndpoint{},
@@ -223,25 +234,25 @@ void kernel_main() {
 
     // moving l tensor
     tt_memmove<true, false, false, 0>(noc, dest_page_base_addr, packet_l1_addr, packet_size_bytes);
-    cb_push_back(receiver_cb_id_l, input_num_tiles);
+    receiver_cb_l.push_back(input_num_tiles);
     //  now s and m
-    cb_reserve_back(receiver_cb_id_s, 1);
-    cb_reserve_back(receiver_cb_id_m, 1);
+    receiver_cb_s.reserve_back(1);
+    receiver_cb_m.reserve_back(1);
 
-    uint32_t dest_page_base_addr_s = get_write_ptr(receiver_cb_id_s);
+    uint32_t dest_page_base_addr_s = receiver_cb_s.get_write_ptr();
     tt_memmove<true, false, false, 0>(
         noc, dest_page_base_addr_s, packet_l1_addr + packet_size_bytes, aligned_page_size_bytes);
-    cb_push_back(receiver_cb_id_s, 1);
+    receiver_cb_s.push_back(1);
 
-    uint32_t dest_page_base_addr_m = get_write_ptr(receiver_cb_id_m);
+    uint32_t dest_page_base_addr_m = receiver_cb_m.get_write_ptr();
     tt_memmove<true, false, false, 0>(
         noc,
         dest_page_base_addr_m,
         packet_l1_addr + packet_size_bytes + aligned_page_size_bytes,
         aligned_page_size_bytes);
-    cb_push_back(receiver_cb_id_m, 1);
+    receiver_cb_m.push_back(1);
 
-    cb_push_back(packet_cb_id, 1);
+    packet_cb.push_back(1);
 
     // now the similar behaviour when device 2 is sending data to device 1
     // will be waiting on another semaphore, and fabric is for the other 2 muxes
@@ -289,9 +300,9 @@ void kernel_main() {
         fabric_mux_x2, fabric_mux_y2, fabric_mux_status_address, local_fabric_mux_status_address);
     tt::tt_fabric::fabric_client_connect(*mux_connection_handle2);
 
-    cb_reserve_back(packet_header_cb_id, 1);
-    const uint32_t sem_header_addr_2 = get_write_ptr(packet_header_cb_id);
-    cb_push_back(packet_header_cb_id, 1);
+    packet_header_cb.reserve_back(1);
+    const uint32_t sem_header_addr_2 = packet_header_cb.get_write_ptr();
+    packet_header_cb.push_back(1);
 
     const uint64_t sender_sem_noc_addr_2 = get_noc_addr(core_noc_x, core_noc_y, sender_semaphore_addr2);
     auto* sem_header_ptr_2 = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(sem_header_addr_2);
@@ -319,13 +330,13 @@ void kernel_main() {
         noc_async_atomic_barrier();
     }
 
-    cb_reserve_back(packet_cb_id, 1);
-    packet_l1_addr = get_write_ptr(packet_cb_id);
+    packet_cb.reserve_back(1);
+    packet_l1_addr = packet_cb.get_write_ptr();
 
     packet_idx = 0;
 
-    cb_reserve_back(receiver_cb_id_l, input_num_tiles);
-    dest_page_base_addr = get_write_ptr(receiver_cb_id_l);
+    receiver_cb_l.reserve_back(input_num_tiles);
+    dest_page_base_addr = receiver_cb_l.get_write_ptr();
     noc.async_read(
         UnicastEndpoint{},
         CoreLocalMem<uint32_t>(packet_l1_addr),
@@ -336,12 +347,12 @@ void kernel_main() {
     noc.async_read_barrier();
 
     tt_memmove<true, false, false, 0>(noc, dest_page_base_addr, packet_l1_addr, packet_size_bytes);
-    cb_push_back(receiver_cb_id_l, input_num_tiles);
+    receiver_cb_l.push_back(input_num_tiles);
 
-    cb_reserve_back(receiver_cb_id_s, 1);
-    cb_reserve_back(receiver_cb_id_m, 1);
-    dest_page_base_addr_s = get_write_ptr(receiver_cb_id_s);
-    dest_page_base_addr_m = get_write_ptr(receiver_cb_id_m);
+    receiver_cb_s.reserve_back(1);
+    receiver_cb_m.reserve_back(1);
+    dest_page_base_addr_s = receiver_cb_s.get_write_ptr();
+    dest_page_base_addr_m = receiver_cb_m.get_write_ptr();
 
     tt_memmove<true, false, false, 0>(
         noc, dest_page_base_addr_s, packet_l1_addr + packet_size_bytes, aligned_page_size_bytes);
@@ -350,7 +361,7 @@ void kernel_main() {
         dest_page_base_addr_m,
         packet_l1_addr + packet_size_bytes + aligned_page_size_bytes,
         aligned_page_size_bytes);
-    cb_push_back(receiver_cb_id_s, 1);
-    cb_push_back(receiver_cb_id_m, 1);
-    cb_push_back(packet_cb_id, 1);
+    receiver_cb_s.push_back(1);
+    receiver_cb_m.push_back(1);
+    packet_cb.push_back(1);
 }

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/root_receive_reader_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/root_receive_reader_kernel.cpp
@@ -4,6 +4,9 @@
 ///
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
 #include "cpp/ttnn/operations/data_movement/common/kernels/common.hpp"
@@ -22,6 +25,7 @@
 using tt::data_movement::common::tt_memmove;
 
 inline void read_from_local(
+    const Noc& noc,
     uint32_t src_addr_l,
     uint32_t src_addr_s,
     uint32_t src_addr_m,
@@ -36,22 +40,34 @@ inline void read_from_local(
     // read l, s, m data from own device and push it to compute cbs
     cb_reserve_back(cb_id_in_l, input_num_tiles);
     uint32_t l1_write_addr = get_write_ptr(cb_id_in_l);
-    uint64_t read_addr = get_noc_addr(core_noc_x, core_noc_y, src_addr_l);
-    noc_async_read(read_addr, l1_write_addr, input_num_tiles * page_bytes);
+    noc.async_read(
+        UnicastEndpoint{},
+        CoreLocalMem<uint32_t>(l1_write_addr),
+        input_num_tiles * page_bytes,
+        {.noc_x = core_noc_x, .noc_y = core_noc_y, .addr = src_addr_l},
+        {});
     cb_push_back(cb_id_in_l, input_num_tiles);
 
     // for tensor s
     cb_reserve_back(cb_id_in_s, onetile);
     l1_write_addr = get_write_ptr(cb_id_in_s);
-    read_addr = get_noc_addr(core_noc_x, core_noc_y, src_addr_s);
-    noc_async_read(read_addr, l1_write_addr, onetile * page_bytes);
+    noc.async_read(
+        UnicastEndpoint{},
+        CoreLocalMem<uint32_t>(l1_write_addr),
+        onetile * page_bytes,
+        {.noc_x = core_noc_x, .noc_y = core_noc_y, .addr = src_addr_s},
+        {});
     cb_push_back(cb_id_in_s, onetile);
 
     // for tensor m
     cb_reserve_back(cb_id_in_m, onetile);
     l1_write_addr = get_write_ptr(cb_id_in_m);
-    read_addr = get_noc_addr(core_noc_x, core_noc_y, src_addr_m);
-    noc_async_read(read_addr, l1_write_addr, onetile * page_bytes);
+    noc.async_read(
+        UnicastEndpoint{},
+        CoreLocalMem<uint32_t>(l1_write_addr),
+        onetile * page_bytes,
+        {.noc_x = core_noc_x, .noc_y = core_noc_y, .addr = src_addr_m},
+        {});
     noc_async_read_barrier();
     cb_push_back(cb_id_in_m, onetile);
 }
@@ -157,6 +173,7 @@ void kernel_main() {
 
     // read local data from own device and push to compute cbs
     read_from_local(
+        noc,
         src_addr_l,
         src_addr_s,
         src_addr_m,
@@ -193,8 +210,12 @@ void kernel_main() {
     cb_reserve_back(receiver_cb_id_l, input_num_tiles);
     uint32_t dest_page_base_addr = get_write_ptr(receiver_cb_id_l);
 
-    uint64_t packet_noc_addr = get_noc_addr(core_noc_x, core_noc_y, intermediate_base_addr);
-    noc_async_read(packet_noc_addr, packet_l1_addr, new_packet_size_bytes);
+    noc.async_read(
+        UnicastEndpoint{},
+        CoreLocalMem<uint32_t>(packet_l1_addr),
+        new_packet_size_bytes,
+        {.noc_x = core_noc_x, .noc_y = core_noc_y, .addr = intermediate_base_addr},
+        {});
     // Drain the inbound read before the tt_memmove consumers below: each tt_memmove is itself a NoC
     // op whose SOURCE is packet_l1_addr, and on the weak NoC there is no read->read landing order, so
     // the memmove could forward stale/partial packet data. Mirrors root2_receive_reader_kernel.cpp.
@@ -305,8 +326,12 @@ void kernel_main() {
 
     cb_reserve_back(receiver_cb_id_l, input_num_tiles);
     dest_page_base_addr = get_write_ptr(receiver_cb_id_l);
-    packet_noc_addr = get_noc_addr(core_noc_x, core_noc_y, intermediate_base_addr);
-    noc_async_read(packet_noc_addr, packet_l1_addr, new_packet_size_bytes);
+    noc.async_read(
+        UnicastEndpoint{},
+        CoreLocalMem<uint32_t>(packet_l1_addr),
+        new_packet_size_bytes,
+        {.noc_x = core_noc_x, .noc_y = core_noc_y, .addr = intermediate_base_addr},
+        {});
     // Drain the inbound read before the tt_memmove consumers (see first occurrence above).
     noc_async_read_barrier();
 

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/sender_reader_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/sender_reader_kernel.cpp
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
 void kernel_main() {
@@ -20,10 +21,12 @@ void kernel_main() {
     const uint32_t core_noc_y = get_arg_val<uint32_t>(4);
     constexpr uint32_t onetile = 1;
 
+    CircularBuffer packet_cb(packet_cb_id);
+
     Noc noc;
 
-    cb_reserve_back(packet_cb_id, 1);
-    uint32_t l1_write_addr = get_write_ptr(packet_cb_id);
+    packet_cb.reserve_back(1);
+    uint32_t l1_write_addr = packet_cb.get_write_ptr();
     noc.async_read(
         UnicastEndpoint{},
         CoreLocalMem<uint32_t>(l1_write_addr),
@@ -43,5 +46,5 @@ void kernel_main() {
         {.noc_x = core_noc_x, .noc_y = core_noc_y, .addr = src_addr_m},
         {});
     noc.async_read_barrier();
-    cb_push_back(packet_cb_id, 1);
+    packet_cb.push_back(1);
 }

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/sender_reader_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/sender_reader_kernel.cpp
@@ -42,6 +42,6 @@ void kernel_main() {
         onetile * page_bytes,
         {.noc_x = core_noc_x, .noc_y = core_noc_y, .addr = src_addr_m},
         {});
-    noc_async_read_barrier();
+    noc.async_read_barrier();
     cb_push_back(packet_cb_id, 1);
 }

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/sender_reader_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/sender_reader_kernel.cpp
@@ -5,6 +5,9 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
 void kernel_main() {
     constexpr uint32_t num_tiles_l = get_compile_time_arg_val(0);
     constexpr uint32_t page_bytes = get_compile_time_arg_val(1);
@@ -17,14 +20,28 @@ void kernel_main() {
     const uint32_t core_noc_y = get_arg_val<uint32_t>(4);
     constexpr uint32_t onetile = 1;
 
+    Noc noc;
+
     cb_reserve_back(packet_cb_id, 1);
     uint32_t l1_write_addr = get_write_ptr(packet_cb_id);
-    uint64_t read_addr = get_noc_addr(core_noc_x, core_noc_y, src_addr_l);
-    noc_async_read(read_addr, l1_write_addr, num_tiles_l * page_bytes);
-    read_addr = get_noc_addr(core_noc_x, core_noc_y, src_addr_s);
-    noc_async_read(read_addr, l1_write_addr + num_tiles_l * page_bytes, onetile * page_bytes);
-    read_addr = get_noc_addr(core_noc_x, core_noc_y, src_addr_m);
-    noc_async_read(read_addr, l1_write_addr + (num_tiles_l + onetile) * page_bytes, onetile * page_bytes);
+    noc.async_read(
+        UnicastEndpoint{},
+        CoreLocalMem<uint32_t>(l1_write_addr),
+        num_tiles_l * page_bytes,
+        {.noc_x = core_noc_x, .noc_y = core_noc_y, .addr = src_addr_l},
+        {});
+    noc.async_read(
+        UnicastEndpoint{},
+        CoreLocalMem<uint32_t>(l1_write_addr + num_tiles_l * page_bytes),
+        onetile * page_bytes,
+        {.noc_x = core_noc_x, .noc_y = core_noc_y, .addr = src_addr_s},
+        {});
+    noc.async_read(
+        UnicastEndpoint{},
+        CoreLocalMem<uint32_t>(l1_write_addr + (num_tiles_l + onetile) * page_bytes),
+        onetile * page_bytes,
+        {.noc_x = core_noc_x, .noc_y = core_noc_y, .addr = src_addr_m},
+        {});
     noc_async_read_barrier();
     cb_push_back(packet_cb_id, 1);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in0_sender.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in0_sender.cpp
@@ -7,6 +7,7 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
 #include "matmul_dataflow_common.hpp"
 
@@ -455,13 +456,16 @@ void kernel_main() {
                     in0_sender_sem.wait(1);
                     in0_sender_sem.set(0);
 
-                    uint64_t in0_unicast_data_addr = get_noc_addr(in0_dest_noc_x, in0_dest_noc_y, in0_start_address);
-
                     /**
                      * in0 is M_block_tiles x K_block_tiles. When M block is partial, we don't need to write the
                      * padded tiles. Use `current_block_bytes`.
                      */
-                    noc_async_write(in0_start_address, in0_unicast_data_addr, current_block_bytes);
+                    noc_obj.async_write(
+                        CoreLocalMem<uint32_t>(in0_start_address),
+                        UnicastEndpoint{},
+                        current_block_bytes,
+                        {},
+                        {.noc_x = in0_dest_noc_x, .noc_y = in0_dest_noc_y, .addr = in0_start_address});
 
 #ifdef ARCH_BLACKHOLE
                     noc_obj.async_writes_flushed();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/kernels/dataflow/reader_llama_reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/kernels/dataflow/reader_llama_reduce_scatter.cpp
@@ -114,11 +114,15 @@ void kernel_main() {
                 const uint32_t x = input_core_xy[curr_core][x_index];
                 const uint32_t y = input_core_xy[curr_core][y_index];
                 const uint32_t offset_address = bank_base_address + (read_offset * page_size_bytes);
-                const uint64_t shard_noc_addr = get_noc_addr(x, y, offset_address);
                 const uint32_t transfer_size = read_size * page_size_bytes;
 
                 cb_fabric_sender.reserve_back(num_pages_reserve_push);
-                noc_async_read(shard_noc_addr, sender_read_addr, transfer_size);
+                noc_obj.async_read(
+                    UnicastEndpoint{},
+                    CoreLocalMem<uint32_t>(sender_read_addr),
+                    transfer_size,
+                    {.noc_x = x, .noc_y = y, .addr = offset_address},
+                    {});
 
                 if (num_pages_reserve_push >= curr_packet_num_pages) {
                     noc_obj.async_read_barrier();
@@ -149,10 +153,14 @@ void kernel_main() {
             const uint32_t core_y = input_core_xy[linear_input_core_idcs][y_index];
             const uint32_t tile_offset = linear_input_tile_offsets * page_size_bytes;
 
-            const uint64_t output_noc_address = get_noc_addr(core_x, core_y, base_input_tensor_addr + tile_offset);
             const uint32_t receiver_l1_address = base_receiver_l1_addresses + i * page_size_bytes;
 
-            noc_async_read(output_noc_address, receiver_l1_address, page_size_bytes);
+            noc_obj.async_read(
+                UnicastEndpoint{},
+                CoreLocalMem<uint32_t>(receiver_l1_address),
+                page_size_bytes,
+                {.noc_x = core_x, .noc_y = core_y, .addr = base_input_tensor_addr + tile_offset},
+                {});
         }
 
         noc_semaphore_wait((uint32_t*)receiver_semaphore_address, other_devices);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
@@ -95,7 +95,7 @@ void print_tile_rows(
 // 3. Parallel dispatch remaining copies at max efficiency
 // 4. Handle remainder rows
 //
-// Caller must call noc_async_read_barrier() before using the buffer.
+// Caller must call noc.async_read_barrier() before using the buffer.
 template <uint32_t selected_experts_k, uint32_t tokens, uint32_t experts_per_device, uint32_t l1_alignment>
 FORCE_INLINE void init_expert_activation_buffer_async(Noc& noc, CircularBuffer& cb) {
     constexpr uint32_t row_elements = 2 * experts_per_device + 1;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
@@ -6,6 +6,8 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/noc.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
 #include "api/dataflow/noc_semaphore.h"
 #include "ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp"
 #include "api/tensor/noc_traits.h"
@@ -497,19 +499,22 @@ void kernel_main() {
         // Calculate drain core's source addresses
         // Note: CB addresses are allocated at same L1 offset on all cores, so we use local get_read_ptr
         // and apply it to drain core's NOC address
-        uint64_t drain_indices_noc_addr = get_noc_addr(drain_core_noc_x, drain_core_noc_y, local_indices_addr);
-        uint64_t drain_scores_noc_addr = get_noc_addr(drain_core_noc_x, drain_core_noc_y, local_scores_addr);
 
         // NOC read indices and scores for this core's token range
 
         if (num_tokens_this_core > 0) {
-            // Device 2.0 migration: legacy primitive retained: src is a precomposed uint64_t
-            // cross-core NoC address from get_noc_addr(x,y,addr)
-            noc_async_read(
-                drain_indices_noc_addr, local_indices_addr, num_tokens_this_core * aligned_indices_page_size);
-            // Device 2.0 migration: legacy primitive retained: src is a precomposed uint64_t
-            // cross-core NoC address from get_noc_addr(x,y,addr)
-            noc_async_read(drain_scores_noc_addr, local_scores_addr, num_tokens_this_core * aligned_scores_page_size);
+            noc_obj.async_read(
+                UnicastEndpoint{},
+                CoreLocalMem<uint32_t>(local_indices_addr),
+                num_tokens_this_core * aligned_indices_page_size,
+                {.noc_x = drain_core_noc_x, .noc_y = drain_core_noc_y, .addr = local_indices_addr},
+                {});
+            noc_obj.async_read(
+                UnicastEndpoint{},
+                CoreLocalMem<uint32_t>(local_scores_addr),
+                num_tokens_this_core * aligned_scores_page_size,
+                {.noc_x = drain_core_noc_x, .noc_y = drain_core_noc_y, .addr = local_scores_addr},
+                {});
         }
     }
 
@@ -736,15 +741,17 @@ void kernel_main() {
                     if (remote_count > 0) {
                         // Source: remote core's e_t buffer, expert e's section starts at 0
                         uint32_t remote_e_t_addr = cb_e_t.get_write_ptr() + e * (tokens + 1) * e_t_entry_size;
-                        uint64_t remote_e_t_noc_addr = get_noc_addr(remote_noc_x, remote_noc_y, remote_e_t_addr);
 
                         // Destination: drain's e_t buffer, after current entries for this expert
                         uint32_t local_e_t_dst =
                             e_t_buffer_base + (e * (tokens + 1) + num_activated_tokens_per_expert[e]) * e_t_entry_size;
 
-                        // Device 2.0 migration: legacy primitive retained: src is a precomposed
-                        // uint64_t cross-core NoC address from get_noc_addr(x,y,addr)
-                        noc_async_read(remote_e_t_noc_addr, local_e_t_dst, remote_count * e_t_entry_size);
+                        noc_obj.async_read(
+                            UnicastEndpoint{},
+                            CoreLocalMem<uint32_t>(local_e_t_dst),
+                            remote_count * e_t_entry_size,
+                            {.noc_x = remote_noc_x, .noc_y = remote_noc_y, .addr = remote_e_t_addr},
+                            {});
 
                         // Update drain's count for this expert
                         num_activated_tokens_per_expert[e] += remote_count;
@@ -755,19 +762,17 @@ void kernel_main() {
                 if (remote_activated_count > 0) {
                     // Source: remote core's expert_activation buffer, rows start at 0
                     uint32_t remote_activation_addr = cb_expert_activation.get_write_ptr();
-                    uint64_t remote_activation_noc_addr =
-                        get_noc_addr(remote_noc_x, remote_noc_y, remote_activation_addr);
 
                     // Destination: drain's expert_activation buffer, after current rows
                     uint32_t local_activation_dst =
                         expert_activation_base + num_activated_tokens * aligned_activation_row_bytes;
 
-                    // Device 2.0 migration: legacy primitive retained: src is a precomposed
-                    // uint64_t cross-core NoC address from get_noc_addr(x,y,addr)
-                    noc_async_read(
-                        remote_activation_noc_addr,
-                        local_activation_dst,
-                        remote_activated_count * aligned_activation_row_bytes);
+                    noc_obj.async_read(
+                        UnicastEndpoint{},
+                        CoreLocalMem<uint32_t>(local_activation_dst),
+                        remote_activated_count * aligned_activation_row_bytes,
+                        {.noc_x = remote_noc_x, .noc_y = remote_noc_y, .addr = remote_activation_addr},
+                        {});
 
                     // Update drain's total activated count
                     num_activated_tokens += remote_activated_count;
@@ -933,8 +938,6 @@ void kernel_main() {
 
         // Get drain core's remote_counts_cb address
         uint32_t local_counts_addr = cb_remote_counts.get_read_ptr();
-        uint64_t drain_counts_noc_addr =
-            get_noc_addr(drain_core_noc_x, drain_core_noc_y, local_counts_addr + remote_counts_offset);
 
         // Pack counts into local buffer first (we can use the local remote_counts_cb space temporarily)
         uint32_t* counts_ptr = reinterpret_cast<uint32_t*>(local_counts_addr);
@@ -944,9 +947,12 @@ void kernel_main() {
         counts_ptr[experts_per_device] = num_activated_tokens;
 
         // Write counts to drain core's remote_counts_cb
-        // Device 2.0 migration: legacy primitive retained: dst is a precomposed uint64_t
-        // cross-core NoC address from get_noc_addr(x,y,addr)
-        noc_async_write(local_counts_addr, drain_counts_noc_addr, remote_counts_entry_size);
+        noc_obj.async_write(
+            CoreLocalMem<uint32_t>(local_counts_addr),
+            UnicastEndpoint{},
+            remote_counts_entry_size,
+            {},
+            {.noc_x = drain_core_noc_x, .noc_y = drain_core_noc_y, .addr = local_counts_addr + remote_counts_offset});
         noc_obj.async_write_barrier();
 
         // Signal drain core via semaphore increment

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_writer.cpp
@@ -6,6 +6,8 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/noc.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
 #include "api/dataflow/noc_semaphore.h"
 #include "ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp"
 
@@ -652,20 +654,14 @@ void kernel_main() {
                     // send to proper offset on our initial mcast gather core
                     uint32_t target_l1_initial_gather_addr =
                         l1_read_addr + mcast_group_tile_offset * tilize_output_page_size;
-                    // Device 2.0 migration: legacy primitive retained: initial_gather_noc_addr is a
-                    // precomposed uint64_t NoC unicast address. Noc::async_write takes a typed Dst
-                    // (UnicastEndpoint with .noc_x/.noc_y/.addr args, or TensorAccessor) — there is no
-                    // wrapper for a raw uint64_t address today
-                    uint64_t initial_gather_noc_addr = get_noc_addr(
-                        initial_mcast_gather_core_nox_x,
-                        initial_mcast_gather_core_nox_y,
-                        target_l1_initial_gather_addr,
-                        noc_index);
-                    noc_async_write(
-                        l1_read_addr,
-                        initial_gather_noc_addr,
+                    noc_obj.async_write(
+                        CoreLocalMem<uint32_t>(l1_read_addr),
+                        UnicastEndpoint{},
                         tiles_per_local_chunk * tilize_output_page_size,
-                        noc_index);
+                        {},
+                        {.noc_x = initial_mcast_gather_core_nox_x,
+                         .noc_y = initial_mcast_gather_core_nox_y,
+                         .addr = target_l1_initial_gather_addr});
                     noc_obj.async_write_barrier();
 
                     // == 4a ==
@@ -707,17 +703,12 @@ void kernel_main() {
                     // == 3b ==
                     // send to proper offset on global mmcast gather core (the drain-sync core)
                     uint32_t gather_addr = l1_read_addr + global_tile_offset * tilize_output_page_size;
-                    // Device 2.0 migration: legacy primitive retained: drain_gather_noc_addr is a
-                    // precomposed uint64_t NoC unicast address. Noc::async_write takes a typed Dst
-                    // (UnicastEndpoint with .noc_x/.noc_y/.addr args, or TensorAccessor) — there is no
-                    // wrapper for a raw uint64_t address today
-                    uint64_t drain_gather_noc_addr =
-                        get_noc_addr(drain_core_noc_x, drain_core_noc_y, gather_addr, noc_index);
-                    noc_async_write(
-                        l1_read_addr,
-                        drain_gather_noc_addr,
+                    noc_obj.async_write(
+                        CoreLocalMem<uint32_t>(l1_read_addr),
+                        UnicastEndpoint{},
                         tiles_per_local_chunk * tilize_output_page_size,
-                        noc_index);
+                        {},
+                        {.noc_x = drain_core_noc_x, .noc_y = drain_core_noc_y, .addr = gather_addr});
                     noc_obj.async_write_barrier();
 
                     // == 4b ==

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_reader.cpp
@@ -6,6 +6,9 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
 #include "ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp"
 #include "api/tensor/noc_traits.h"
 
@@ -366,18 +369,18 @@ void kernel_main() {
     // the dispatch drain core.  Use aligned_page_size so we copy the full buffer allocation.
     // Note: drain_core_noc_x/y refer to tilize_cores[0] (tilize drain) for cross-tilize semaphores.
     {
-        // Device 2.0 migration: legacy primitives retained: precomposed uint64_t NoC addresses
-        // built via NOC_XY_ADDR with DYNAMIC_NOC_X/Y macros
-        uint64_t src_indices = NOC_XY_ADDR(
-            DYNAMIC_NOC_X(noc_index, dispatch_drain_noc_x),
-            DYNAMIC_NOC_Y(noc_index, dispatch_drain_noc_y),
-            indices_tensor_address);
-        noc_async_read(src_indices, cb_indices_tensor.get_read_ptr(), aligned_indices_page_size * indices_pages);
-        uint64_t src_scores = NOC_XY_ADDR(
-            DYNAMIC_NOC_X(noc_index, dispatch_drain_noc_x),
-            DYNAMIC_NOC_Y(noc_index, dispatch_drain_noc_y),
-            scores_tensor_address);
-        noc_async_read(src_scores, cb_scores_tensor.get_read_ptr(), aligned_scores_page_size * scores_pages);
+        noc_obj.async_read(
+            UnicastEndpoint{},
+            CoreLocalMem<uint32_t>(cb_indices_tensor.get_read_ptr()),
+            aligned_indices_page_size * indices_pages,
+            {.noc_x = dispatch_drain_noc_x, .noc_y = dispatch_drain_noc_y, .addr = indices_tensor_address},
+            {});
+        noc_obj.async_read(
+            UnicastEndpoint{},
+            CoreLocalMem<uint32_t>(cb_scores_tensor.get_read_ptr()),
+            aligned_scores_page_size * scores_pages,
+            {.noc_x = dispatch_drain_noc_x, .noc_y = dispatch_drain_noc_y, .addr = scores_tensor_address},
+            {});
     }
 
     // Wait for all reads to complete (mapping + indices/scores)
@@ -615,15 +618,17 @@ void kernel_main() {
                     if (remote_count > 0) {
                         // Source: remote core's e_t buffer, expert e's section starts at 0
                         uint32_t remote_e_t_addr = cb_e_t.get_write_ptr() + e * (tokens + 1) * e_t_entry_size;
-                        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC
-                        // address (remote tilize core)
-                        uint64_t remote_e_t_noc_addr = get_noc_addr(remote_noc_x, remote_noc_y, remote_e_t_addr);
 
                         // Destination: drain's e_t buffer, after current entries for this expert
                         uint32_t local_e_t_dst =
                             e_t_buffer_base + (e * (tokens + 1) + num_activated_tokens_per_expert[e]) * e_t_entry_size;
 
-                        noc_async_read(remote_e_t_noc_addr, local_e_t_dst, remote_count * e_t_entry_size);
+                        noc_obj.async_read(
+                            UnicastEndpoint{},
+                            CoreLocalMem<uint32_t>(local_e_t_dst),
+                            remote_count * e_t_entry_size,
+                            {.noc_x = remote_noc_x, .noc_y = remote_noc_y, .addr = remote_e_t_addr},
+                            {});
 
                         // Update drain's count for this expert
                         num_activated_tokens_per_expert[e] += remote_count;
@@ -634,19 +639,17 @@ void kernel_main() {
                 if (remote_activated_count > 0) {
                     // Source: remote core's expert_activation buffer, rows start at 0
                     uint32_t remote_activation_addr = cb_expert_activation.get_read_ptr();
-                    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC
-                    // address (remote tilize core)
-                    uint64_t remote_activation_noc_addr =
-                        get_noc_addr(remote_noc_x, remote_noc_y, remote_activation_addr);
 
                     // Destination: drain's expert_activation buffer, after current rows
                     uint32_t local_activation_dst =
                         expert_activation_base + num_activated_tokens * aligned_activation_row_bytes;
 
-                    noc_async_read(
-                        remote_activation_noc_addr,
-                        local_activation_dst,
-                        remote_activated_count * aligned_activation_row_bytes);
+                    noc_obj.async_read(
+                        UnicastEndpoint{},
+                        CoreLocalMem<uint32_t>(local_activation_dst),
+                        remote_activated_count * aligned_activation_row_bytes,
+                        {.noc_x = remote_noc_x, .noc_y = remote_noc_y, .addr = remote_activation_addr},
+                        {});
 
                     // Update drain's total activated count
                     num_activated_tokens += remote_activated_count;
@@ -829,10 +832,6 @@ void kernel_main() {
 
         // Get drain core's remote_counts_cb address
         uint32_t local_counts_addr = cb_remote_counts.get_read_ptr();
-        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
-        // (drain tilize core target)
-        uint64_t drain_counts_noc_addr =
-            get_noc_addr(drain_core_noc_x, drain_core_noc_y, local_counts_addr + remote_counts_offset);
 
         // Pack counts into local buffer first (we can use the local remote_counts_cb space temporarily)
         uint32_t* counts_ptr = reinterpret_cast<uint32_t*>(local_counts_addr);
@@ -842,9 +841,12 @@ void kernel_main() {
         counts_ptr[experts_per_device] = num_activated_tokens;
 
         // Write counts to drain core's remote_counts_cb
-        // Device 2.0 migration: legacy primitive retained: dst is a precomposed uint64_t
-        // cross-core NoC address from get_noc_addr(x,y,addr)
-        noc_async_write(local_counts_addr, drain_counts_noc_addr, remote_counts_entry_size);
+        noc_obj.async_write(
+            CoreLocalMem<uint32_t>(local_counts_addr),
+            UnicastEndpoint{},
+            remote_counts_entry_size,
+            {},
+            {.noc_x = drain_core_noc_x, .noc_y = drain_core_noc_y, .addr = local_counts_addr + remote_counts_offset});
         noc_obj.async_write_barrier();
 
         // Signal drain core via semaphore increment

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_writer.cpp
@@ -6,6 +6,9 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
 #include "ttnn/cpp/ttnn/operations/ccl/common/kernels/moe_utils.hpp"
 
 using namespace ttnn::operations::ccl::common;
@@ -559,14 +562,12 @@ void kernel_main() {
                 // == 3b ==
                 // send to proper offset on global mmcast gather core (the drain-sync core)
                 uint32_t gather_addr = l1_read_addr + global_tile_offset * tilize_output_page_size;
-                // Device 2.0 migration: legacy primitive retained: drain_gather_noc_addr is a
-                // precomposed uint64_t NoC unicast address. Noc::async_write takes a typed Dst
-                // (UnicastEndpoint with .noc_x/.noc_y/.addr args, or TensorAccessor) — there is no
-                // wrapper for a raw uint64_t address today
-                uint64_t drain_gather_noc_addr =
-                    get_noc_addr(drain_core_noc_x, drain_core_noc_y, gather_addr, noc_index);
-                noc_async_write(
-                    l1_read_addr, drain_gather_noc_addr, tiles_per_local_chunk * tilize_output_page_size, noc_index);
+                noc_obj.async_write(
+                    CoreLocalMem<uint32_t>(l1_read_addr),
+                    UnicastEndpoint{},
+                    tiles_per_local_chunk * tilize_output_page_size,
+                    {},
+                    {.noc_x = drain_core_noc_x, .noc_y = drain_core_noc_y, .addr = gather_addr});
                 noc_obj.async_write_barrier();
 
                 // == 4b ==


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

Contributes to #45003. Migrates the precomposed cross-core NoC address idiom to the Device 2.0 `UnicastEndpoint` API across CCL kernels. A same-chip cross-core `get_noc_addr(noc_x, noc_y, addr)` supplied to `noc_async_read`/`noc_async_write` becomes:

```cpp
Noc noc;  // (or the file's existing noc object)
noc.async_read (UnicastEndpoint{}, CoreLocalMem<uint32_t>(local_dst), size, {.noc_x = X, .noc_y = Y, .addr = ADDR}, {});
noc.async_write(CoreLocalMem<uint32_t>(local_src), UnicastEndpoint{}, size, {}, {.noc_x = X, .noc_y = Y, .addr = ADDR});
```

Additionally:
- `reduce_to_root` readers now barrier on the `Noc` object (`noc.async_read_barrier()`) instead of the free function
- legacy circular-buffer free-functions in `reduce_to_root` reader kernels migrated to the Device 2.0 `CircularBuffer`

### Notes for reviewers

- The (x, y, addr) ingredients move into `src_args`/`dst_args`; the endpoint is an empty placeholder
- the per-iteration striding coords in `all_gather_concat_heads_fused` and `llama_reduce_scatter` aren't available at the call site, postponed

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/d2-ccl-xcore-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/d2-ccl-xcore-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/d2-ccl-xcore-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/d2-ccl-xcore-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=iwrosz/d2-ccl-xcore-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:iwrosz/d2-ccl-xcore-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/d2-ccl-xcore-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/d2-ccl-xcore-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/d2-ccl-xcore-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/d2-ccl-xcore-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/d2-ccl-xcore-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/d2-ccl-xcore-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/d2-ccl-xcore-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/d2-ccl-xcore-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/d2-ccl-xcore-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/d2-ccl-xcore-migration)
