### PR TITLE
[QSR] Add 32bit dest TilizeA_B test

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -152,8 +152,21 @@ static void validate_result(
     bool pass = true;
     if (test_config.tilize_type.has_value() && test_config.tilize_type == TilizeType::UNPACK_A_B) {
         pass &= (golden.size() == result_vec.size());
-        pass &= is_close_packed_vectors<bfloat16, std::uint32_t>(
-            result_vec, golden, [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b, 0.01f); });
+        if (test_config.output_fmt == tt::DataFormat::Float32) {
+            std::vector<float> golden_f(golden.size());
+            std::vector<float> result_f(result_vec.size());
+            std::transform(golden.begin(), golden.end(), golden_f.begin(), [](std::uint32_t w) {
+                return std::bit_cast<float>(w);
+            });
+            std::transform(result_vec.begin(), result_vec.end(), result_f.begin(), [](std::uint32_t w) {
+                return std::bit_cast<float>(w);
+            });
+            pass &=
+                is_close_vectors<float>(result_f, golden_f, [&](float a, float b) { return is_close(a, b, 0.01f); });
+        } else {
+            pass &= is_close_packed_vectors<bfloat16, std::uint32_t>(
+                result_vec, golden, [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b, 0.01f); });
+        }
     } else {
         pass &= (golden.size() == result_vec.size());
         pass &= (golden == result_vec);

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -108,14 +108,6 @@ static void validate_result(
     const std::vector<std::uint32_t>& src0_vec,
     const std::vector<std::uint32_t>& src1_vec,
     const std::vector<std::uint32_t>& result_vec) {
-    // For 8-bit integers (Int8/UInt8) hardware keeps integers as-is in dest/CB even with fp32_dest_acc_en.
-    // For 8-bit floats (Fp8_e4m3, Lf8) the L1 CB stays at 8-bit — the packer gasket converts
-    // Float32 DEST → 8-bit at output. Converting the golden to Float32 in either case would mismatch
-    // actual hardware behavior.
-    bool is_8bit_format =
-        test_config.output_fmt == tt::DataFormat::Int8 || test_config.output_fmt == tt::DataFormat::UInt8 ||
-        test_config.output_fmt == tt::DataFormat::Fp8_e4m3 || test_config.output_fmt == tt::DataFormat::Lf8;
-
     vector<std::uint32_t> golden;
     ::unit_tests::compute::GoldenConfig config = {
         .num_tiles_r_dim = test_config.num_tiles_r,
@@ -148,7 +140,7 @@ static void validate_result(
         },
         test_config.golden_function);
 
-    if (test_config.fp32_dest_acc_en && !is_8bit_format) {
+    if (test_config.output_fmt == tt::DataFormat::Float32) {
         vector<bfloat16> golden_unpacked = unpack_vector<bfloat16, std::uint32_t>(golden);
         // Increasing the size since from BFP16 two times, since storing is in FP32
         golden.resize(golden.size() * 2);
@@ -215,15 +207,7 @@ void run_single_core_tilize_program(
     const std::uint32_t dram_buffer_src0_addr = src0_dram_buffer->address();
     const std::uint32_t dram_buffer_dst_addr = dst_dram_buffer->address();
 
-    // For 8-bit integer and 8-bit float formats, output CB format must remain as-is even with fp32_dest_acc_en.
-    // Integer data packed from dest to L1 CB should not be reinterpreted as Float32, otherwise we get garbage.
-    // For Fp8_e4m3/Lf8 the packer gasket converts Float32 DEST → Fp8 L1 internally; the CB must be sized and
-    // typed as Fp8, not Float32, so the gasket path is preserved.
-    const bool is_8bit_format =
-        test_config.output_fmt == tt::DataFormat::Int8 || test_config.output_fmt == tt::DataFormat::UInt8 ||
-        test_config.output_fmt == tt::DataFormat::Fp8_e4m3 || test_config.output_fmt == tt::DataFormat::Lf8;
-    const tt::DataFormat output_buf_format =
-        (test_config.fp32_dest_acc_en && !is_8bit_format) ? tt::DataFormat::Float32 : test_config.output_fmt;
+    const tt::DataFormat output_buf_format = test_config.output_fmt;
 
     const experimental::DFBSpecName INPUT_DFB{"input_dfb"};
     const experimental::DFBSpecName OUTPUT_DFB{"output_dfb"};
@@ -749,6 +733,7 @@ TEST_F(LLKMeshDeviceFixture, TensixComputeUnpackTilize) {
                     .num_tiles_r = num_tile[0],
                     .num_tiles_c = num_tile[1],
                     .tilize_type = unit_tests::compute::tilize::TilizeType::UNPACK_A,
+                    .output_fmt = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b,
                     .golden_function = ::unit_tests::compute::gold_standard_tilize};
                 unit_tests::compute::tilize::run_single_core_tilize_program(this->devices_.at(0), test_config);
             }
@@ -842,6 +827,7 @@ TEST_F(LLKMeshDeviceFixture, TensixComputeFastTilize) {
                     .num_tiles_r = num_tile[0],
                     .num_tiles_c = num_tile[1],
                     .tilize_type = unit_tests::compute::tilize::TilizeType::UNPACK_A,
+                    .output_fmt = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b,
                     .golden_function = ::unit_tests::compute::gold_standard_tilize};
                 unit_tests::compute::tilize::run_single_core_tilize_program(this->devices_.at(0), test_config);
             }
@@ -861,6 +847,7 @@ TEST_F(LLKMeshDeviceFixture, TensixComputeUnpackTilizeA_B) {
             .num_tiles_r = 2,
             .num_tiles_c = 8,
             .tilize_type = unit_tests::compute::tilize::TilizeType::UNPACK_A_B,
+            .output_fmt = tt::DataFormat::Float16_b,
             .golden_function = ::unit_tests::compute::gold_standard_tilize_w_elwadd};
         unit_tests::compute::tilize::run_single_core_unpack_tilizeA_B_program(this->devices_.at(0), test_config);
     }
@@ -877,23 +864,18 @@ static void run_quasar_tilize_untilize_test(
     std::uint32_t num_tiles_c,
     QuasarTestMode mode,
     bool dst_full_sync_en,
-    bool fp32_dest_acc_en = false,
-    tt::DataFormat data_format = tt::DataFormat::Float16_b) {
+    bool fp32_dest_acc_en,
+    tt::DataFormat input_data_format,
+    tt::DataFormat output_data_format) {
     bool is_tilize = (mode == QuasarTestMode::TILIZE);
 
     IDevice* dev = mesh_device->get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
     const experimental::NodeCoord node{0, 0};
 
-    bool is_8bit_integer = (data_format == tt::DataFormat::Int8 || data_format == tt::DataFormat::UInt8);
+    bool is_8bit_integer = (input_data_format == tt::DataFormat::Int8 || input_data_format == tt::DataFormat::UInt8);
     std::uint32_t num_tiles = num_tiles_r * num_tiles_c;
-    std::uint32_t input_single_tile_size = tt::tile_size(data_format);
-    tt::DataFormat output_data_format = data_format;
-    if (is_8bit_integer) {
-        output_data_format = tt::DataFormat::Int32;
-    } else if (fp32_dest_acc_en) {
-        output_data_format = tt::DataFormat::Float32;
-    }
+    std::uint32_t input_single_tile_size = tt::tile_size(input_data_format);
     std::uint32_t output_single_tile_size = tt::tile_size(output_data_format);
     std::uint32_t src_dram_buffer_size = input_single_tile_size * num_tiles;
     std::uint32_t dst_dram_buffer_size = output_single_tile_size * num_tiles;
@@ -925,7 +907,7 @@ static void run_quasar_tilize_untilize_test(
         .unique_id = INPUT_DFB,
         .entry_size = input_single_tile_size,
         .num_entries = dfb_num_entries,
-        .data_format_metadata = data_format,
+        .data_format_metadata = input_data_format,
     };
     experimental::DataflowBufferSpec output_dfb_spec{
         .unique_id = OUTPUT_DFB,
@@ -1034,16 +1016,16 @@ static void run_quasar_tilize_untilize_test(
     auto& program_run = workload.get_programs().at(device_range);
 
     std::vector<std::uint32_t> src_vec;
-    if (data_format == tt::DataFormat::Int8) {
+    if (input_data_format == tt::DataFormat::Int8) {
         src_vec = create_random_vector_of_int8(src_dram_buffer_size, /*seed=*/42);
-    } else if (data_format == tt::DataFormat::UInt8) {
+    } else if (input_data_format == tt::DataFormat::UInt8) {
         src_vec = create_random_vector_of_uint8(src_dram_buffer_size, /*seed=*/42);
-    } else if (data_format == tt::DataFormat::Int16) {
+    } else if (input_data_format == tt::DataFormat::Int16) {
         src_vec.resize(src_dram_buffer_size / sizeof(std::uint32_t));
         for (std::uint32_t i = 0; i < src_vec.size(); i++) {
             src_vec[i] = (static_cast<std::uint32_t>((2 * i) + 1) << 16) | static_cast<std::uint32_t>(2 * i);
         }
-    } else if (is_tilize && data_format == tt::DataFormat::Float32) {
+    } else if (is_tilize && input_data_format == tt::DataFormat::Float32) {
         src_vec.resize(src_dram_buffer_size / sizeof(std::uint32_t));
         for (std::uint32_t i = 0; i < src_vec.size(); i++) {
             src_vec[i] = std::bit_cast<std::uint32_t>(static_cast<float>(i));
@@ -1092,7 +1074,7 @@ static void run_quasar_tilize_untilize_test(
     ::unit_tests::compute::GoldenConfig golden_config = {
         .num_tiles_r_dim = static_cast<int>(num_tiles_r),
         .num_tiles_c_dim = static_cast<int>(num_tiles_c),
-        .datum_bytes = tt::datum_size(data_format)};
+        .datum_bytes = tt::datum_size(input_data_format)};
     auto golden = is_tilize ? ::unit_tests::compute::gold_standard_tilize(src_vec, golden_config)
                             : ::unit_tests::compute::gold_standard_untilize(src_vec, golden_config);
 
@@ -1100,7 +1082,7 @@ static void run_quasar_tilize_untilize_test(
         // Int8/UInt8 in dest is promoted to Int32. Expand each byte to a uint32_t word.
         // Hardware uses sign-magnitude representation for Int8:
         //   bit 31 = sign (MSB of the byte), bits [6:0] = magnitude (lower 7 bits of the byte)
-        bool is_signed = (data_format == tt::DataFormat::Int8);
+        bool is_signed = (input_data_format == tt::DataFormat::Int8);
         std::vector<std::uint32_t> golden_int32;
         golden_int32.reserve(golden.size() * 4);
         for (auto word : golden) {
@@ -1116,8 +1098,8 @@ static void run_quasar_tilize_untilize_test(
             }
         }
         golden = std::move(golden_int32);
-    } else if (fp32_dest_acc_en && data_format != tt::DataFormat::Float32) {
-        // For fp32_dest_acc_en with 16-bit float input: expand golden from bfloat16 to float32
+    } else if (output_data_format == tt::DataFormat::Float32 && input_data_format != tt::DataFormat::Float32) {
+        // For 32-bit output (fp32_dest_acc_en) with 16-bit float input: expand golden from bfloat16 to float32
         // For Float32 input: golden is already 32-bit, no expansion needed
         vector<bfloat16> golden_unpacked = unpack_vector<bfloat16, std::uint32_t>(golden);
         golden.resize(golden.size() * 2);
@@ -1136,8 +1118,8 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputePackUntilize) {
     for (auto& cfg : test_configs) {
         for (bool dst_full_sync_en : {true, false}) {
             for (bool fp32_dest_acc_en : {true, false}) {
-                for (tt::DataFormat data_format : {tt::DataFormat::Float16_b, tt::DataFormat::Int16}) {
-                    if (fp32_dest_acc_en && data_format == tt::DataFormat::Int16) {
+                for (tt::DataFormat input_data_format : {tt::DataFormat::Float16_b, tt::DataFormat::Int16}) {
+                    if (fp32_dest_acc_en && input_data_format == tt::DataFormat::Int16) {
                         continue;  // Int16 + 32-bit dest mode is not supported on Quasar
                     }
                     run_quasar_tilize_untilize_test(
@@ -1147,7 +1129,8 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputePackUntilize) {
                         QuasarTestMode::UNTILIZE,
                         dst_full_sync_en,
                         fp32_dest_acc_en,
-                        data_format);
+                        input_data_format,
+                        fp32_dest_acc_en ? tt::DataFormat::Float32 : input_data_format);
                 }
             }
         }
@@ -1160,8 +1143,8 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputePackUntilizeDst) {
     for (auto& cfg : test_configs) {
         for (bool dst_full_sync_en : {true, false}) {
             for (bool fp32_dest_acc_en : {true, false}) {
-                for (tt::DataFormat data_format : {tt::DataFormat::Float16_b, tt::DataFormat::Int16}) {
-                    if (fp32_dest_acc_en && data_format == tt::DataFormat::Int16) {
+                for (tt::DataFormat input_data_format : {tt::DataFormat::Float16_b, tt::DataFormat::Int16}) {
+                    if (fp32_dest_acc_en && input_data_format == tt::DataFormat::Int16) {
                         continue;  // Int16 + 32-bit dest mode is not supported on Quasar
                     }
                     run_quasar_tilize_untilize_test(
@@ -1171,7 +1154,8 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputePackUntilizeDst) {
                         QuasarTestMode::UNTILIZE_DST,
                         dst_full_sync_en,
                         fp32_dest_acc_en,
-                        data_format);
+                        input_data_format,
+                        fp32_dest_acc_en ? tt::DataFormat::Float32 : input_data_format);
                 }
             }
         }
@@ -1184,8 +1168,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeUnpackTilize) {
     for (auto& cfg : test_configs) {
         for (bool dst_full_sync_en : {true, false}) {
             for (bool fp32_dest_acc_en : {true, false}) {
-                for (tt::DataFormat data_format : {tt::DataFormat::Float16_b, tt::DataFormat::Int16}) {
-                    if (fp32_dest_acc_en && data_format == tt::DataFormat::Int16) {
+                for (tt::DataFormat input_data_format : {tt::DataFormat::Float16_b, tt::DataFormat::Int16}) {
+                    if (fp32_dest_acc_en && input_data_format == tt::DataFormat::Int16) {
                         continue;  // Int16 + 32-bit dest mode is not supported on Quasar
                     }
 
@@ -1196,7 +1180,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeUnpackTilize) {
                         QuasarTestMode::TILIZE,
                         dst_full_sync_en,
                         fp32_dest_acc_en,
-                        data_format);
+                        input_data_format,
+                        fp32_dest_acc_en ? tt::DataFormat::Float32 : input_data_format);
                 }
             }
         }
@@ -1207,10 +1192,11 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeUnpackTilize) {
 // Quasar's unpack_tilizeA_B is only compatible with the reduce math kernel.
 TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeUnpackTilizeA_B) {
     for (bool dst_full_sync_en : {true, false}) {
-        for (bool fp32_dest_acc_en : {false}) {  // TODO: Enable fp32_dest_acc_en=true once ISSUE #48504 is resolved
-            for (tt::DataFormat data_format : {tt::DataFormat::Float16_b}) {
-                std::uint32_t tile_size = tt::tile_size(data_format);
-                tt::DataFormat output_data_format = data_format;
+        for (bool fp32_dest_acc_en : {true, false}) {
+            for (tt::DataFormat input_data_format : {tt::DataFormat::Float16_b}) {
+                std::uint32_t tile_size = tt::tile_size(input_data_format);
+                tt::DataFormat output_data_format =
+                    fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
                 std::uint32_t output_tile_size = tt::tile_size(output_data_format);
                 unit_tests::compute::tilize::TestConfig test_config = {
                     .dst_full_sync_en = dst_full_sync_en,
@@ -1220,7 +1206,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeUnpackTilizeA_B) {
                     .num_tiles_r = 2,
                     .num_tiles_c = 10,
                     .tilize_type = unit_tests::compute::tilize::TilizeType::UNPACK_A_B,
-                    .input_fmt = data_format,
+                    .input_fmt = input_data_format,
                     .output_fmt = output_data_format,
                     .golden_function = ::unit_tests::compute::gold_standard_tilize_w_reduce_col_max};
                 unit_tests::compute::tilize::run_single_core_unpack_tilizeA_B_reduce_program(
@@ -1242,7 +1228,8 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputePackUntilizeInt32) {
                 QuasarTestMode::UNTILIZE,
                 dst_full_sync_en,
                 /*fp32_dest_acc_en=*/true,
-                tt::DataFormat::Int8);
+                tt::DataFormat::Int8,
+                /*output_data_format=*/tt::DataFormat::Int32);
         }
     }
 }
@@ -1259,7 +1246,8 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputePackUntilizeDstInt32) 
                 QuasarTestMode::UNTILIZE_DST,
                 dst_full_sync_en,
                 /*fp32_dest_acc_en=*/true,
-                tt::DataFormat::Int8);
+                tt::DataFormat::Int8,
+                /*output_data_format=*/tt::DataFormat::Int32);
         }
     }
 }
@@ -1281,6 +1269,7 @@ TEST_F(LLKMeshDeviceFixture, TensixComputePackUntilize) {
                     .num_tiles_r = num_tile[0],
                     .num_tiles_c = num_tile[1],
                     .untilize_type = unit_tests::compute::tilize::UntilizeType::PACK,
+                    .output_fmt = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b,
                     .golden_function = ::unit_tests::compute::gold_standard_untilize};
                 unit_tests::compute::tilize::run_single_core_tilize_program(this->devices_.at(0), test_config);
             }
@@ -1299,6 +1288,7 @@ TEST_F(LLKMeshDeviceFixture, TensixComputePackUntilizeDst) {
                 .num_tiles_r = num_tile[0],
                 .num_tiles_c = num_tile[1],
                 .untilize_type = unit_tests::compute::tilize::UntilizeType::DST,
+                .output_fmt = tt::DataFormat::Float16_b,
                 .golden_function = ::unit_tests::compute::gold_standard_untilize};
             unit_tests::compute::tilize::run_single_core_tilize_program(this->devices_.at(0), test_config);
         }
@@ -1394,6 +1384,7 @@ TEST_F(LLKMeshDeviceFixture, TensixComputePackUntilizeDstTinyTile) {
                 .num_faces_per_tile = num_faces_per_tile,
                 .face_r_dim = face_r_dim,
                 .untilize_type = unit_tests::compute::tilize::UntilizeType::DST,
+                .output_fmt = tt::DataFormat::Float16_b,
                 .golden_function = ::unit_tests::compute::gold_standard_untilize};
             unit_tests::compute::tilize::run_single_core_tilize_program(this->devices_.at(0), test_config);
         }

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_reduce_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_reduce_api.h
@@ -22,7 +22,7 @@
 template <ReduceDim reduce_dim, [[maybe_unused]] PackMode pack_mode = PackMode::Default>
 inline void llk_pack_reduce_mask_config(std::uint32_t ocb) {
     static_assert(pack_mode == PackMode::Default, "Quasar pack reduce mask does not support pack_mode != Default");
-    const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(ocb);
+    const ckernel::TensorShape tensor_shape = get_output_tensor_shape(ocb);
     _llk_pack_reduce_mask_config_<reduce_dim>(tensor_shape);
 }
 


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-metal/issues/45163

### PR Category
Test

### Summary
- Add 32bit dest test for Quasar TilizeA_B;
- Clean up untilize tilize test to pass output format explicitly as 32bit dest does not automatically mean Float32 output format;
- Use output tensor shape instead of operand tensor shape in reduce mask config, fixes compile error

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amokan/tilizeA_B_32b_dest_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amokan/tilizeA_B_32b_dest_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amokan/tilizeA_B_32b_dest_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amokan/tilizeA_B_32b_dest_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amokan/tilizeA_B_32b_dest_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amokan/tilizeA_B_32b_dest_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amokan/tilizeA_B_32b_dest_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amokan/tilizeA_B_32b_dest_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amokan/tilizeA_B_32b_dest_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amokan/tilizeA_B_32b_dest_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amokan/tilizeA_B_32b_dest_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amokan/tilizeA_B_32b_dest_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amokan/tilizeA_B_32b_dest_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amokan/tilizeA_B_32b_dest_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amokan/tilizeA_B_32b_dest_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amokan/tilizeA_B_32b_dest_test)