### PR TITLE
Use separate DRAM and L1 shard grids in tilize regression test

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_tilize.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_tilize.py
@@ -556,10 +556,12 @@ def test_tilize_width_sharded_dram_input_to_l1_sharded_output_49107(device):
 
     torch_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16)
 
-    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_cores - 1, 0))})
-    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
-    input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, shard_spec)
-    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec)
+    input_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_cores - 1, 0))})
+    output_shard_grid = ttnn.num_cores_to_corerangeset(num_cores, device.compute_with_storage_grid_size(), True)
+    input_shard_spec = ttnn.ShardSpec(input_shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    output_shard_spec = ttnn.ShardSpec(output_shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, input_shard_spec)
+    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, output_shard_spec)
 
     tt_input = ttnn.from_torch(
         torch_tensor,


### PR DESCRIPTION
### PR Category
Test Only

### Summary
`test_tilize_width_sharded_dram_input_to_l1_sharded_output_49107` was reusing the input `ShardSpec` for both a DRAM-sharded input tensor and an L1-sharded output tensor. On devices where the DRAM bank grid is wider than the logical TENSIX worker grid, this caused the L1 output shard grid to include coordinates such as `(8, 0)` that are valid for DRAM banking but invalid as TENSIX worker coordinates, failing during coordinate translation before tilize could run. The test now builds separate shard specs: the input remains sharded across the DRAM bank grid, while the output uses `ttnn.num_cores_to_corerangeset` over `device.compute_with_storage_grid_size()`. This preserves the intended DRAM-input to L1-output coverage while keeping each memory config in the coordinate space appropriate for its buffer type.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/tilize-shard-grids)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/tilize-shard-grids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/tilize-shard-grids)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/tilize-shard-grids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/tilize-shard-grids)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/tilize-shard-grids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/tilize-shard-grids)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/tilize-shard-grids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/tilize-shard-grids)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/tilize-shard-grids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/tilize-shard-grids)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/tilize-shard-grids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/tilize-shard-grids)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/tilize-shard-grids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/tilize-shard-grids)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/tilize-shard-grids)