### PR TITLE
Use Metal2 data movement role hints for binary_ng sharded kernels

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_metal_v2_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_metal_v2_factory.cpp
@@ -234,9 +234,7 @@ ProgramArtifacts create_sharded_artifacts(
         .num_threads = 1,
         .dfb_bindings = {m2::ProducerOf(IN0, "in0"), m2::ProducerOf(IN1, "in1")},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles"}},
-        .hw_config =
-            m2::DataMovementHardwareConfig{
-                .gen1_config = m2::DataMovementHardwareConfig::Gen1Config{.processor = DataMovementProcessor::RISCV_1}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::READER},
     };
 
     m2::KernelSpec writer_spec{
@@ -245,9 +243,7 @@ ProgramArtifacts create_sharded_artifacts(
         .num_threads = 1,
         .dfb_bindings = {m2::ConsumerOf(OUT, "out")},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles"}},
-        .hw_config =
-            m2::DataMovementHardwareConfig{
-                .gen1_config = m2::DataMovementHardwareConfig::Gen1Config{.processor = DataMovementProcessor::RISCV_0}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::WRITER},
     };
 
     // bf8/bf16 outputs do not need fp32 dest accumulation (matches descriptor factory: false unless


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
The binary_ng Metal2 sharded path failed on WH/BH because the reader and writer data movement kernels were explicitly configured with only their Gen1 RISC-V processor, leaving the NOC selection at its default and allowing both kernels to be treated as dedicated-NOC users of NOC_0 on the same node. This conflicted with the intended reader/writer split and caused Metal2 program validation to reject the program before launch. The factory now uses the Metal2 READER and WRITER role hints instead of hand-rolled partial Gen1 configs, letting the host API derive the standard Gen1 placements of reader on RISCV_1/NOC_0 and writer on RISCV_0/NOC_1. This keeps the kernel specs aligned with the API abstraction, fixes the WH/BH placement conflict, and does not affect Quasar code generation because Gen2 ignores these role hints when building its data movement processor assignments.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/data-movement-roles)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/data-movement-roles)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/data-movement-roles)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/data-movement-roles)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/data-movement-roles)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/data-movement-roles)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/data-movement-roles)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/data-movement-roles)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/data-movement-roles)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/data-movement-roles)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/data-movement-roles)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/data-movement-roles)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/data-movement-roles)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/data-movement-roles)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/data-movement-roles)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/data-movement-roles)