### PR TITLE
Qwen3.6-27B TP: fused DeltaNet decode wiring + batched decode + QKV/MLP fusion

### DIFF
--- a/QWEN36_BATCHED_DECODE_DESIGN.md
+++ b/QWEN36_BATCHED_DECODE_DESIGN.md
@@ -1,0 +1,100 @@
+# Qwen3.6-27B — Batched Decode (batch>1) 設計メモ（方針B）
+
+対象: `models/demos/blackhole/qwen36/`（main / worktree `yito/qwen36_27b_port_to_main`）
+出典: prototype branch `yito/qwen36_27b_p300x2_tp` の batched-decode 最適化を main へ移植（Task #2）。
+方針: **B（main 既存 python recurrent decode 経路で `max_batch_size>1` を有効化）**。C++ カーネル（#3）非依存。
+
+---
+
+## 0. 前提（調査で確定した事実）
+
+- **decode trace は既に存在**（B=1）。`demo/text_demo.py:577-593`（`begin/end_trace_capture` + `execute_trace`）、contract 経路 `ttnn_decode_forward`(model.py:1801)+`prepare_inputs_decode`(1790)、vLLM warmup。→ **trace 機構は移植不要**。batched 化は「同じ機構を B>1 の forward で capture する」だけ。
+- **decode forward は既に B 汎用に記述済み**:
+  - GDN `gdn/tp.py:356 forward_decode` — 全 slice/reshape が `B` 基準。再帰は `(B,1,Nv,Dk)`。
+  - Attention `attention/tp.py:210 forward_decode` — `B` 基準、per-user `cur_pos_tt`（位置テンソル）、`page_table`、SDPA-decode 対応済み。
+- **再帰カーネルは B=8 でスケール可能**: `recurrent_gated_delta_rule_decode_ttnn`（`models/experimental/gated_attention_gated_deltanet/tt/ttnn_delta_rule_ops.py`）は `[B*H,1,K]@[B*H,K,V]` で B·H を matmul M 次元へ畳み込み、グリッドを tile 数で自動選択（per_core_M は L1 安全域にクランプ）。branch の flattened-head カーネルの **B≤9(110コア)制約は無い**。B=8, Nv_tp=12 → B·H=96 行(3 tile) で問題なし。
+- **in-place fixed-buffer state（#4）は概ね実装済み**: `_stable_state` / `reset_state_inplace` / `conv_carry` / `_zero_conv0`（gdn/tp.py:144-216, 419-425）。#4 は別途「差分確認のみ」で足りる見込み。
+
+つまり **真のギャップは 2 点だけ**:
+1. **B>1 の静的 batched decode** を serving 経路に「配線」する（shape は既に B 対応。B=1 ハードコードを外す）。
+2. **continuous batching / per-slot state reseed**（1 スロットだけ GDN rec/conv + KV を reset して途中参加/離脱）。
+
+---
+
+## 1. ギャップ1: 静的 batched decode（B>1）の配線
+
+### 1.1 変更箇所
+
+| # | file:line | 現状 | 変更 |
+|---|-----------|------|------|
+| a | `tt/model_config.py:36` | `max_batch_size=1` (default) | default 維持。B は呼び出し側から渡す。`_init_tp_config` に `B*Nv_tp` の core 見積り assert を追加検討 |
+| b | `tt/model.py:140` `from_pretrained(..., max_batch_size=1)` | B=1 | 呼び出し側から B を透過（そのまま OK、値だけ >1 を許可） |
+| c | `tt/model.py:1475` `allocate_kv_caches(..., batch_size=1)` | B=1 ハードコード | 引数 B を実際に使う。KV/GDN 外部 state を `[B,...]` で確保 |
+| d | `tt/model.py:1417` `reset_state(batch_size=1)` | B=1 | B 透過 |
+| e | `tt/qwen36_vllm.py:129` `allocate_kv_caches(..., batch_size=1)` | B=1 | `max_batch_size` を透過（ギャップ2 と一体） |
+| f | `tt/model.py:220 decode_tp(token_id, pos)` | scalar token + scalar pos（demo oracle） | `token_ids: list[int]`, `positions: list[int]` を受ける batched 版を追加（下記 1.2） |
+| g | `tt/model.py:254 generate_tp` | 1 本の greedy | B 本同時 greedy（各系列 EOS 管理）。デモ検証用 |
+
+> 注: `prefill_tp`(177) と TP prefill(1581) の `assert B==1` は **prefill 側**。batched decode は「1 本ずつ prefill → 全スロットまとめて decode」でも成立するので、prefill の B=1 制約は**このタスクでは触らない**（別タスク）。continuous batching では各スロットを個別 prefill してスロットへ書き込む。
+
+### 1.2 `decode_tp` batched 版（デモ oracle 経路）
+
+現状 `decode_tp(token_id, pos)` は `torch.tensor([[int(token_id)]])` → `x=[1,1,1,dim_frac]`。
+batched 版:
+- 入力 `tok = torch.tensor([[t] for t in token_ids], int32)` → `[B,1]` → embed → `reshape (1,1,B,dim_frac)`（decode の batch 次元は dim=2、既存コードと整合: attention/gdn は `[1,B,dim]` へ reshape）。
+- `cur_pos_tt = ttnn.from_torch(torch.tensor(positions, int32))`（per-user 位置。attention SDPA-decode / paged_update_cache が既に位置テンソルを受ける）。
+- `rot_mats_decode` を per-user 位置で生成（現状 `torch.tensor([pos])` → `torch.tensor(positions)`）。
+- logits 読み出し: 現状 `lt[0].reshape(-1)[:vocab]`（1 本）→ `[B, vocab]` を返す。
+
+### 1.3 検証ポイント（実機）
+
+- SDPA-decode grid cap（attention/tp.py:239-243, 64 コア上限）が B>1 でオーバーフローしないか。B が増えると SDPA-decode は batch 方向に並ぶので `max_cores_per_head_batch` 相当の再検討が要る可能性。
+- `apply_partial_rope_decode(..., B, ...)`（attention/tp.py:236-237）は既に B 引数を取る → B>1 で shape 検証。
+- 再帰 `recurrent_gated_delta_rule_decode_ttnn` の per_core_M L1 クランプが B·H=96 で成立するか（設計上 OK、実測要）。
+- fp32 rec_state（default）のメモリ: `[B,Nv_tp,Dk,Dv]=[8,12,128,128]` fp32 ≈ 50MB/chip。KV `[B,1,max_seq,HD]` × NKV。B=8 で DRAM 収まるか。
+
+---
+
+## 2. ギャップ2: continuous batching / per-slot state reseed
+
+branch: 「staggered-join reseed」「continuous-batching conv_hist reseed」= 走行中の他スロットを保持したまま 1 スロットだけ新規系列で reseed。
+
+### 2.1 現状（全て whole-batch）
+- `gdn/tp.py:152 reset_state` / `:183 reset_state_inplace` — conv/rec 全体を zero（batch-index 引数なし）。
+- `attention/tp.py:120 reset_state` — KV 全体 zero。
+- `model.py:1386 _reset_gdn_state_for_new_sequence` / `:1419 _reset_dn_state_inplace` — 全体。
+- vLLM: `max_concurrency=1` 明言（qwen36_vllm.py docstring）。
+
+### 2.2 追加が必要な API
+- `TPGatedDeltaNet.reset_slot_inplace(b: int)`: `rec_state[b]` と各 `conv_states[k][:, b, :]` だけ zero（`ttnn.copy` を slot slice へ）。
+- `TPAttention.reset_slot_inplace(b: int)`: `k/v_caches[h][b]`（or paged: 該当 page_table 行）だけ zero。
+- `Qwen36Model.reset_slot(b)`: 上記を全 layer へ。
+- prefill→スロット書き込み: 単一系列 prefill 結果（GDN rec/conv, KV）を batched buffer の slot b へ `ttnn.copy`。
+- generator/vLLM: `max_num_seqs>1`、per-request `cur_pos`/page_table 行、スロット割当・解放。
+
+### 2.3 trace との整合（重要）
+- `_stable_state=True` で rec_state/KV のアドレスを固定 → decode trace は B 固定で 1 度だけ capture。
+- per-slot reseed は **trace 外**の `ttnn.copy`（固定バッファへの部分書き込み）で行えばアドレス不変 → 既存 trace を維持したままスロット差し替え可能。branch の staggered-join と同型。
+
+---
+
+## 3. 段階的インクリメント（PR 粒度の提案）
+
+1. **Step 1（最小・検証容易）**: `decode_tp` batched 版 + `generate_tp` B 本 greedy + `allocate/reset` の B 透過。デモ oracle 経路のみ。B=2 で 2 プロンプト同時生成が単発 B=1×2 と一致することを host-PCC/greedy 一致で検証（branch の `tp_batch2.py` 相当）。
+2. **Step 2**: batched decode trace（Step 1 の forward を `begin/execute_trace` で B 固定 capture）。B=8 スループット計測。
+3. **Step 3**: per-slot reseed API（2.2）+ 単発テスト（走行中 slot0 保持で slot1 reseed が正しいこと）。
+4. **Step 4**: vLLM `max_num_seqs>1` 配線（qwen36_vllm.py / generator_interface.py）。continuous batching E2E。
+
+各 Step は独立 PR 可能。Step 1〜2 が「batch=8 + trace」の中核、Step 3〜4 が continuous batching。
+
+---
+
+## 4. テスト
+- 新規 `tests/test_batched_decode_tp.py`: B=2 で「2 系列同時 decode」==「各系列 B=1 decode」を greedy トークン一致＋ logits PCC で検証。既存 `tests/test_generate_tp.py` の隣に。
+- `tests/pcc_thresholds.json` に batched decode の閾値追加。
+- 実機: device 2（空き、単一 Blackhole=P150 相当。TP=4 が要るなら P300x2 全4chip、他デバイス使用状況を要確認）。TP=4 実機は `MESH_DEVICE=P150x4` 相当の 4chip 確保が前提。
+
+## 5. 未解決 / 要判断
+- B の上限: 再帰は B=8 まで設計上 OK だが、SDPA-decode grid・DRAM 実測が上限を決める。branch は B≤9。まず B=8 目標。
+- Step 4（vLLM continuous batching）は工数大。#3（C++ decode カーネル）後に回す判断もあり得る。
+- prefill の B=1 制約（177/1581）は本タスク対象外。continuous batching では per-slot 個別 prefill で回避。

--- a/models/demos/blackhole/qwen36/tests/bench_decode_tps_tp.py
+++ b/models/demos/blackhole/qwen36/tests/bench_decode_tps_tp.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Decode throughput (TPS) benchmark for the batched-decode work (Steps 1/2/4).
+
+Two-point timing isolates steady-state decode: time generate_tp_batched at N1 and N2
+new tokens; per-step time = (t(N2) - t(N1)) / (N2 - N1) cancels the (identical) prefill,
+warmup, and one-time trace capture. Reports per-sequence and aggregate tokens/sec for
+eager vs traced decode at batch B = QWEN_BENCH_B.
+
+Run (per batch):
+    QWEN_BENCH_B=1 MESH_DEVICE=P150x4 HF_MODEL=Qwen/Qwen3.6-27B \
+      pytest models/demos/blackhole/qwen36/tests/bench_decode_tps_tp.py -v -s
+    QWEN_BENCH_B=8 ... (same)
+"""
+import os
+import time
+
+import torch
+
+import ttnn
+from models.demos.blackhole.qwen36.tests.test_factory import model_path, parametrize_mesh_tp
+from models.demos.blackhole.qwen36.tt.model import Qwen36Model
+
+N1, N2 = 8, 72  # two-point token counts (Δ = 64 steady-state decode steps)
+REPS = 2
+
+
+@parametrize_mesh_tp()
+def test_bench_decode_tps(mesh_device, ensure_gc):
+    from loguru import logger
+
+    os.environ.setdefault("HF_MODEL", model_path())
+    mesh_device.enable_program_cache()
+    B = int(os.environ.get("QWEN_BENCH_B", "8"))
+    eager_only = os.environ.get("EAGER_ONLY") == "1"
+    model = Qwen36Model.from_pretrained(mesh_device, max_batch_size=B, max_seq_len=2048)
+
+    from transformers import AutoTokenizer
+
+    tok = AutoTokenizer.from_pretrained(model.args.CKPT_DIR, trust_remote_code=True)
+    prompt = tok("The capital of France is", return_tensors="pt").input_ids[0].tolist()
+    prompts = [prompt] * B
+
+    def timed(n, use_trace):
+        best = float("inf")
+        for _ in range(REPS):
+            t0 = time.time()
+            model.generate_tp_batched(prompts, max_new_tokens=n, use_trace=use_trace)
+            ttnn.synchronize_device(mesh_device)
+            best = min(best, time.time() - t0)
+        return best
+
+    results = {}
+    _configs = [("eager", False)] if eager_only else [("eager", False), ("traced", True)]
+    for label, use_trace in _configs:
+        t_n1 = timed(N1, use_trace)
+        t_n2 = timed(N2, use_trace)
+        per_step = (t_n2 - t_n1) / (N2 - N1)
+        per_seq_tps = 1.0 / per_step
+        agg_tps = B / per_step
+        results[label] = (per_step * 1e3, per_seq_tps, agg_tps)
+        logger.info(
+            f"[B={B} {label}] {per_step*1e3:.2f} ms/step | per-seq {per_seq_tps:.1f} tok/s | "
+            f"aggregate {agg_tps:.1f} tok/s"
+        )
+
+    logger.info(f"DECODE_TPS_SUMMARY B={B}: " + "  ".join(
+        f"{k}={v[2]:.1f}tok/s(agg,{v[0]:.1f}ms/step)" for k, v in results.items()))
+    # Sanity: traced should be no slower than eager.
+    if "traced" in results:
+        assert results["traced"][2] >= results["eager"][2] * 0.9, "traced unexpectedly slower than eager"

--- a/models/demos/blackhole/qwen36/tests/bench_deltanet_kernel_progcache.py
+++ b/models/demos/blackhole/qwen36/tests/bench_deltanet_kernel_progcache.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Program-cache probe for the fused deltanet_decode_full op.
+
+Calls the op N times with IDENTICAL shapes and times each. If the program cache works,
+call 1 pays the JIT compile and calls 2..N are fast (cache hit). If every call is slow,
+the op is recompiling per step — the root cause of the fused-decode-path slowdown.
+"""
+import os
+import time
+
+import torch
+
+import ttnn
+from models.demos.blackhole.qwen36.tests.test_factory import parametrize_mesh_tp
+
+
+@parametrize_mesh_tp()
+def test_progcache_deltanet_decode_full(mesh_device, ensure_gc):
+    from loguru import logger
+
+    mesh_device.enable_program_cache()
+
+    Nk, Nv, Dk, Dv, K = 4, 12, 128, 128, 4
+    rf = Nv // Nk
+    key_dim, val_dim = Nk * Dk, Nv * Dv
+    conv_dim = 2 * key_dim + val_dim
+    rep = ttnn.ReplicateTensorToMesh(mesh_device)
+
+    def dev(t):
+        return ttnn.from_torch(t, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=mesh_device, mesh_mapper=rep)
+
+    torch.manual_seed(0)
+    qkv = dev(torch.randn(1, 1, 1, conv_dim) * 0.2)
+    z = dev(torch.randn(1, 1, 1, val_dim) * 0.2)
+    b = dev(torch.rand(1, 1, 1, Nv))
+    a = dev(torch.rand(1, 1, 1, Nv))
+    dummy = dev(torch.zeros(1, 1, conv_dim, 32))
+    rec = dev(torch.zeros(1, Nv, Dk, Dv))
+    zh = dev(torch.zeros(1, 1, 1, Nv))
+    nw = dev(torch.ones(1, 1, 1, Dv))
+
+    def call():
+        out = ttnn.experimental.deltanet_decode_full(
+            qkv, z, b, a, dummy, rec, dummy, zh, zh, nw,
+            num_heads=Nv, num_k_heads=Nk, k_head_dim=Dk, v_head_dim=Dv,
+            conv_dim=conv_dim, conv_kernel_size=K, head_expand_ratio=rf,
+        )
+        ttnn.synchronize_device(mesh_device)
+        for t in out:
+            ttnn.deallocate(t)
+
+    times = []
+    for i in range(12):
+        t0 = time.time()
+        call()
+        dt = (time.time() - t0) * 1e3
+        times.append(dt)
+        logger.info(f"call {i:2d}: {dt:8.1f} ms   (cache entries: {mesh_device.num_program_cache_entries()})")
+
+    warm = times[2:]
+    logger.info(f"PROGCACHE: call0={times[0]:.0f}ms  warm_median={sorted(warm)[len(warm)//2]:.1f}ms  "
+                f"cache_entries={mesh_device.num_program_cache_entries()}")
+    # If warm calls are ~compile-time (100s of ms) and cache_entries keeps growing → no caching.
+    assert sorted(warm)[len(warm) // 2] < 50.0, "op appears to recompile per call (no program-cache hit)"

--- a/models/demos/blackhole/qwen36/tests/measure_fused_weight_dram.py
+++ b/models/demos/blackhole/qwen36/tests/measure_fused_weight_dram.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Measure the per-device DRAM cost of the fused decode weights (MLP w13 + attention wqkv_all).
+
+Loads the 27B TP model and reports total DRAM allocated per device (num_banks ×
+total_bytes_allocated_per_bank). Run twice — once with the fused weights built (default) and
+once with QWEN_SKIP_FUSED_WEIGHTS=1 — and the delta is the DRAM these duplicate fused weights add
+(they coexist with the separate prefill weights). No forward is run (load + query only).
+
+Run:
+    MESH_DEVICE=P150x4 HF_MODEL=Qwen/Qwen3.6-27B QWEN_BENCH_B=8 \
+      pytest models/demos/blackhole/qwen36/tests/measure_fused_weight_dram.py -v -s
+    (repeat with QWEN_SKIP_FUSED_WEIGHTS=1)
+"""
+import os
+
+import ttnn
+from models.demos.blackhole.qwen36.tests.test_factory import model_path, parametrize_mesh_tp
+from models.demos.blackhole.qwen36.tt.model import Qwen36Model
+
+
+def _dram_allocated_bytes(dev):
+    v = ttnn.get_memory_view(dev, ttnn.BufferType.DRAM)
+    return int(v.num_banks) * int(v.total_bytes_allocated_per_bank)
+
+
+@parametrize_mesh_tp()
+def test_measure_fused_weight_dram(mesh_device, ensure_gc):
+    from loguru import logger
+
+    os.environ.setdefault("HF_MODEL", model_path())
+    B = int(os.environ.get("QWEN_BENCH_B", "8"))
+    skip = os.environ.get("QWEN_SKIP_FUSED_WEIGHTS") == "1"
+
+    _ = Qwen36Model.from_pretrained(mesh_device, max_batch_size=B, max_seq_len=2048)
+
+    # Per-device DRAM allocated after load.
+    try:
+        devs = list(mesh_device.get_devices())
+    except Exception:
+        devs = [mesh_device]
+    per_dev = [_dram_allocated_bytes(d) for d in devs]
+    gb = [b / (1024**3) for b in per_dev]
+    tag = "SKIP_FUSED" if skip else "WITH_FUSED"
+    logger.info(f"FUSED_WEIGHT_DRAM [{tag}] per-device GB: " + ", ".join(f"{x:.3f}" for x in gb))
+    logger.info(f"FUSED_WEIGHT_DRAM [{tag}] dev0={gb[0]:.3f} GB  mean={sum(gb)/len(gb):.3f} GB  ndev={len(devs)}")

--- a/models/demos/blackhole/qwen36/tests/test_batched_continuous_tp.py
+++ b/models/demos/blackhole/qwen36/tests/test_batched_continuous_tp.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Continuous-batching generation (generate_tp_batched_continuous) check (Step 4, Part A).
+
+Runs N=3 prompts through B=2 decode slots: the two slots fill with the first two prompts,
+and when they finish the freed slot is reused in place for the third prompt (reseed_slot_tp).
+Asserts:
+
+  * the first-batch sequences (slots 0/1) match a plain batched run — the continuous-batching
+    machinery does not perturb sequences already in flight;
+  * the third sequence, generated in a REUSED slot, follows its prompt correctly (oracle
+    first token 'Paris').
+
+On-device only; needs a 4-chip P150x4 mesh.
+
+Run:
+    MESH_DEVICE=P150x4 HF_MODEL=Qwen/Qwen3.6-27B \
+      pytest models/demos/blackhole/qwen36/tests/test_batched_continuous_tp.py -v -s
+"""
+import os
+
+from models.demos.blackhole.qwen36.tests.test_factory import model_path, parametrize_mesh_tp
+from models.demos.blackhole.qwen36.tt.model import Qwen36Model
+
+
+@parametrize_mesh_tp()
+def test_generate_tp_batched_continuous(mesh_device, ensure_gc):
+    from loguru import logger
+
+    os.environ.setdefault("HF_MODEL", model_path())
+    B = 2
+    model = Qwen36Model.from_pretrained(mesh_device, max_batch_size=B, max_seq_len=256)
+
+    from transformers import AutoTokenizer
+
+    tok = AutoTokenizer.from_pretrained(model.args.CKPT_DIR, trust_remote_code=True)
+    ids = lambda s: tok(s, return_tensors="pt").input_ids[0].tolist()
+    P0 = ids("The largest ocean on Earth is")
+    P1 = ids("Photosynthesis converts sunlight into")
+    P2 = ids("The capital of France is")  # reused slot → oracle 'Paris'
+    STEPS = 6
+
+    # Reference: first two prompts as a plain batched run.
+    ref = model.generate_tp_batched([P0, P1], max_new_tokens=STEPS, use_trace=False)
+
+    # Continuous: three prompts through two slots (slot reused for P2).
+    cont = model.generate_tp_batched_continuous([P0, P1, P2], max_new_tokens=STEPS)
+    assert len(cont) == 3
+
+    for i, seq in enumerate(cont):
+        logger.info(f"[seq {i}] {tok.decode(seq)!r}")
+        assert len(set(seq)) > 1, f"seq {i} degenerate: {seq}"
+
+    # First-batch sequences unperturbed by the continuous machinery.
+    assert cont[0] == ref[0], f"seq 0 differs from plain batched\n  ref={ref[0]}\n  cont={cont[0]}"
+    assert cont[1] == ref[1], f"seq 1 differs from plain batched\n  ref={ref[1]}\n  cont={cont[1]}"
+
+    # Reused slot ran P2 correctly.
+    first2 = tok.decode([cont[2][0]]).strip()
+    logger.info(f"[seq 2] first token (reused slot): {first2!r}")
+    assert first2 == "Paris", f"reused-slot seq 2 expected 'Paris', got {first2!r}"
+    logger.info("PASSED: continuous batching — first-batch unperturbed, reused slot correct")

--- a/models/demos/blackhole/qwen36/tests/test_batched_decode_tp.py
+++ b/models/demos/blackhole/qwen36/tests/test_batched_decode_tp.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Batched TP generation (``generate_tp_batched``) functional check (Step 1).
+
+Runs the full 27B TP model with B = max_batch_size = 2 sequences decoded in
+lockstep. Each prompt is prefilled into its own batch lane (``prefill_seed_tp``),
+the GDN recurrent/conv state is assembled with ``finalize_seed``, then all lanes
+decode together (one batched forward per step). Asserts:
+
+  * lane 0 (the France prompt) still yields the oracle first token 'Paris' —
+    i.e. batching did not corrupt lane 0's KV / GDN state, and cross-lane
+    contamination did not occur;
+  * every lane is non-degenerate;
+  * the two lanes produce different continuations (independent state).
+
+This anchors the batched oracle path against test_generate_tp.py (which proves the
+B=1 France prompt yields 'Paris'). On-device only; needs a 4-chip P150x4 mesh.
+
+Run:
+    MESH_DEVICE=P150x4 HF_MODEL=Qwen/Qwen3.6-27B \
+      pytest models/demos/blackhole/qwen36/tests/test_batched_decode_tp.py -v -s
+"""
+import os
+
+from models.demos.blackhole.qwen36.tests.test_factory import model_path, parametrize_mesh_tp
+from models.demos.blackhole.qwen36.tt.model import Qwen36Model
+
+
+@parametrize_mesh_tp()
+def test_generate_tp_batched(mesh_device, ensure_gc):
+    from loguru import logger
+
+    os.environ.setdefault("HF_MODEL", model_path())
+    B = 2
+    model = Qwen36Model.from_pretrained(mesh_device, max_batch_size=B, max_seq_len=256)
+
+    from transformers import AutoTokenizer
+
+    tok = AutoTokenizer.from_pretrained(model.args.CKPT_DIR, trust_remote_code=True)
+    prompts_text = [
+        "The capital of France is",
+        "Water is made of hydrogen and",
+    ]
+    prompts = [tok(p, return_tensors="pt").input_ids[0].tolist() for p in prompts_text]
+
+    out = model.generate_tp_batched(prompts, max_new_tokens=8)
+    assert len(out) == B
+
+    for b, new_ids in enumerate(out):
+        text = tok.decode(prompts[b] + new_ids)
+        logger.info(f"[lane {b}] GENERATED: {text!r}")
+        assert len(set(new_ids)) > 1, f"lane {b} degenerate: {new_ids}"
+
+    # Lane 0 must reproduce the B=1 oracle answer (see test_generate_tp.py).
+    first0 = tok.decode([out[0][0]]).strip()
+    logger.info(f"[lane 0] first generated token: {first0!r}")
+    assert first0 == "Paris", f"lane 0 expected 'Paris', got {first0!r} (batched seeding/decode corrupted lane 0)"
+
+    # The two lanes decode independently → different continuations.
+    assert out[0] != out[1], "lanes produced identical output — batch lanes are not independent"
+    logger.info("PASSED: batched generate_tp_batched — lane 0 correct, lanes independent")

--- a/models/demos/blackhole/qwen36/tests/test_batched_decode_trace_tp.py
+++ b/models/demos/blackhole/qwen36/tests/test_batched_decode_trace_tp.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Batched TP decode TRACE (generate_tp_batched use_trace=True) check (Step 2).
+
+Captures the B-lane batched decode step ONCE as a ttnn trace and replays it with
+DMA-updated inputs. The traced replay is bit-faithful to the eager batched decode (execute_trace re-issues
+the identical program, and the traced path uses the SAME rot_mats_decode rope as eager),
+so this asserts:
+
+  * traced output == eager output, token-for-token, for every lane;
+  * lane 0 reproduces the oracle first token 'Paris';
+  * lanes are non-degenerate and independent.
+
+Prompts have different lengths → the traced path carries per-user decode positions in a
+fixed buffer (updated in place each step). On-device only; needs a 4-chip P150x4 mesh.
+
+Run:
+    MESH_DEVICE=P150x4 HF_MODEL=Qwen/Qwen3.6-27B \
+      pytest models/demos/blackhole/qwen36/tests/test_batched_decode_trace_tp.py -v -s
+"""
+import os
+
+from models.demos.blackhole.qwen36.tests.test_factory import model_path, parametrize_mesh_tp
+from models.demos.blackhole.qwen36.tt.model import Qwen36Model
+
+
+@parametrize_mesh_tp()
+def test_generate_tp_batched_traced(mesh_device, ensure_gc):
+    from loguru import logger
+
+    os.environ.setdefault("HF_MODEL", model_path())
+    B = 2
+    model = Qwen36Model.from_pretrained(mesh_device, max_batch_size=B, max_seq_len=256)
+
+    from transformers import AutoTokenizer
+
+    tok = AutoTokenizer.from_pretrained(model.args.CKPT_DIR, trust_remote_code=True)
+    prompts_text = [
+        "The capital of France is",
+        "The largest ocean on Earth is",
+    ]
+    prompts = [tok(p, return_tensors="pt").input_ids[0].tolist() for p in prompts_text]
+    logger.info(f"prompt lengths: {[len(p) for p in prompts]}")
+
+    eager = model.generate_tp_batched(prompts, max_new_tokens=8, use_trace=False)
+    traced = model.generate_tp_batched(prompts, max_new_tokens=8, use_trace=True)
+
+    for b in range(B):
+        logger.info(f"[lane {b}] eager : {tok.decode(prompts[b] + eager[b])!r}")
+        logger.info(f"[lane {b}] traced: {tok.decode(prompts[b] + traced[b])!r}")
+        assert len(set(traced[b])) > 1, f"lane {b} traced degenerate: {traced[b]}"
+
+    # Core Step-2 assertion: the captured trace replay is bit-faithful to eager decode.
+    assert traced == eager, f"traced != eager\n  eager={eager}\n  traced={traced}"
+
+    # Lane 0 oracle + independence (same anchors as the eager Step-1 test).
+    first0 = tok.decode([traced[0][0]]).strip()
+    logger.info(f"[lane 0] first generated token: {first0!r}")
+    assert first0 == "Paris", f"lane 0 expected 'Paris', got {first0!r}"
+    assert traced[0] != traced[1], "lanes produced identical output — batch lanes not independent"
+    logger.info("PASSED: batched decode trace — traced==eager, lane 0 correct, lanes independent")

--- a/models/demos/blackhole/qwen36/tests/test_batched_reseed_tp.py
+++ b/models/demos/blackhole/qwen36/tests/test_batched_reseed_tp.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Per-slot state reseed (continuous-batching join) check (Step 3).
+
+Replaces ONE batch lane's sequence mid-generation (reseed_slot_tp) while the other
+lanes keep decoding, and verifies:
+
+  * the untouched lane (0) produces the EXACT same tokens whether or not lane 1 was
+    reseeded — i.e. reseeding lane 1's KV + GDN state does not perturb lane 0;
+  * the reseeded lane (1) follows its NEW prompt correctly (oracle first token 'Paris').
+
+Lanes are independent (per-lane KV cache + per-value-head GDN recurrence), so this
+proves the in-place per-lane reseed writes only the target lane. On-device only;
+needs a 4-chip P150x4 mesh.
+
+Run:
+    MESH_DEVICE=P150x4 HF_MODEL=Qwen/Qwen3.6-27B \
+      pytest models/demos/blackhole/qwen36/tests/test_batched_reseed_tp.py -v -s
+"""
+import math
+import os
+
+import torch
+
+from models.demos.blackhole.qwen36.tests.test_factory import model_path, parametrize_mesh_tp
+from models.demos.blackhole.qwen36.tt.model import Qwen36Model
+
+
+@parametrize_mesh_tp()
+def test_batched_reseed_slot(mesh_device, ensure_gc):
+    from loguru import logger
+
+    os.environ.setdefault("HF_MODEL", model_path())
+    B = 2
+    model = Qwen36Model.from_pretrained(mesh_device, max_batch_size=B, max_seq_len=256)
+
+    from transformers import AutoTokenizer
+
+    tok = AutoTokenizer.from_pretrained(model.args.CKPT_DIR, trust_remote_code=True)
+    ids = lambda s: tok(s, return_tensors="pt").input_ids[0].tolist()
+    A = ids("The largest ocean on Earth is")  # lane 0 (must stay unperturbed)
+    Bp = ids("Photosynthesis converts sunlight into")  # lane 1 (original)
+    C = ids("The capital of France is")  # lane 1 (reseeded → oracle 'Paris')
+
+    def seed(prompts):
+        model.reset_tp()
+        cur, pos = [], []
+        for b, p in enumerate(prompts):
+            T = len(p)
+            T_pad = max(128, math.ceil(T / 128) * 128)
+            padded = list(p) + [0] * (T_pad - T)
+            lg = model.prefill_seed_tp(torch.tensor([padded], dtype=torch.long), valid_len=T, batch_slot=b)
+            cur.append(int(torch.argmax(lg).item()))
+            pos.append(T)
+        for layer in model.layers:
+            if not layer.is_full_attention:
+                layer.attention.finalize_seed(B)
+        return cur, pos
+
+    STEPS = 8
+    RESEED_AT = 4
+
+    # Reference: no reseed — record lane 0's tokens.
+    cur, pos = seed([A, Bp])
+    ref0 = [cur[0]]
+    for _ in range(STEPS):
+        logits = model.decode_tp_batched(cur, pos)
+        nxt = [int(torch.argmax(logits[b]).item()) for b in range(B)]
+        for b in range(B):
+            pos[b] += 1
+            cur[b] = nxt[b]
+        ref0.append(nxt[0])
+
+    # Reseed run: swap lane 1 → C at RESEED_AT, keep decoding.
+    cur, pos = seed([A, Bp])
+    res0 = [cur[0]]
+    slot1_first = None
+    for step in range(STEPS):
+        if step == RESEED_AT:
+            slot1_first, newpos = model.reseed_slot_tp(C, slot=1)
+            cur[1], pos[1] = slot1_first, newpos
+        logits = model.decode_tp_batched(cur, pos)
+        nxt = [int(torch.argmax(logits[b]).item()) for b in range(B)]
+        for b in range(B):
+            pos[b] += 1
+            cur[b] = nxt[b]
+        res0.append(nxt[0])
+
+    logger.info(f"lane0 ref   : {tok.decode(ref0)!r}")
+    logger.info(f"lane0 reseed: {tok.decode(res0)!r}")
+    first_c = tok.decode([slot1_first]).strip()
+    logger.info(f"lane1 first token after reseed to C: {first_c!r}")
+
+    # Lane 0 is untouched by lane 1's reseed → identical tokens.
+    assert res0 == ref0, f"lane 0 perturbed by lane 1 reseed\n  ref={ref0}\n  got={res0}"
+    # Reseeded lane 1 follows the new prompt C → oracle first token.
+    assert first_c == "Paris", f"reseeded lane 1 expected 'Paris', got {first_c!r}"
+    logger.info("PASSED: per-slot reseed — lane 0 unperturbed, lane 1 follows new prompt")

--- a/models/demos/blackhole/qwen36/tests/test_deltanet_decode_kernel_pcc.py
+++ b/models/demos/blackhole/qwen36/tests/test_deltanet_decode_kernel_pcc.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit PCC: fused deltanet_decode_full kernel vs main's python GDN decode math (Stage 5).
+
+Small random single-token step (per-device GDN dims: Nk=4, Nv=12, Dk=Dv=128). Reference =
+exactly what gdn/tp.py forward_decode does with the python recurrence:
+  L2norm(q,k) + q*scale → recurrent_gated_delta_rule_decode_ttnn → rms_norm(Dv) → * silu(z).
+Kernel = ttnn.experimental.deltanet_decode_full with the equivalent inputs packed flat
+(q/k L2-normed+scaled and un-expanded; decay=exp(g); beta; z; norm_weight). Asserts the
+fused output and new recurrent state match the python path (PCC), validating the kernel +
+the host-side input packing before wiring it into the model (Stage 6).
+
+Run:
+    MESH_DEVICE=P150x4 pytest models/demos/blackhole/qwen36/tests/test_deltanet_decode_kernel_pcc.py -v -s
+"""
+import torch
+
+import ttnn
+from models.demos.blackhole.qwen36.tests.test_factory import parametrize_mesh_tp
+from models.experimental.gated_attention_gated_deltanet.tt.ttnn_delta_rule_ops import (
+    l2_norm_ttnn,
+    recurrent_gated_delta_rule_decode_ttnn,
+)
+
+
+def _pcc(a, b):
+    a, b = a.float().flatten(), b.float().flatten()
+    return torch.corrcoef(torch.stack([a, b]))[0, 1].item()
+
+
+@parametrize_mesh_tp()
+def test_deltanet_decode_full_pcc(mesh_device, ensure_gc):
+    from loguru import logger
+
+    import os as _os0
+
+    Nk = int(_os0.environ.get("TEST_NK", "4"))
+    Nv, Dk, Dv, K = 12, 128, 128, 4
+    rf = Nv // Nk
+    scale = Dk**-0.5
+    key_dim, val_dim = Nk * Dk, Nv * Dv
+    conv_dim = 2 * key_dim + val_dim
+    torch.manual_seed(0)
+
+    rep = ttnn.ReplicateTensorToMesh(mesh_device)
+
+    def dev(t):
+        return ttnn.from_torch(t, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=mesh_device, mesh_mapper=rep)
+
+    # Raw post-conv q/k/v (un-expanded), gate z, beta (already sigmoid'd), g (log-decay), state, norm.
+    q_nk = torch.randn(1, Nk, Dk) * 0.3
+    k_nk = torch.randn(1, Nk, Dk) * 0.3
+    if _os0.environ.get("QEQK") == "1":
+        k_nk = q_nk.clone()  # probe: if read-source (q vs k) is the bug, q==k makes output match
+    v_nv = torch.randn(1, Nv, Dv) * 0.3
+    beta = torch.rand(1, Nv)  # in (0,1) like sigmoid(b)
+    g = -torch.rand(1, Nv) * 0.1  # small negative log-decay
+    rec = torch.randn(1, Nv, Dk, Dv) * 0.1
+
+    # DIAGNOSTIC: isolate the output-path mismatch (new_state already matches). Try random vs
+    # constant z (gate) and norm_w (RMSNorm weight); a jump to ~1.0 pinpoints the culprit layout.
+    import os as _os
+
+    z_rand = torch.randn(1, Nv * Dv) * 0.3
+    nw_rand = torch.randn(Dv) * 0.2 + 1.0
+    z_const = torch.ones(1, Nv * Dv) * 0.5
+    nw_const = torch.ones(Dv)
+    zc = _os.environ.get("ZCONST") == "1"
+    nwc = _os.environ.get("NWCONST") == "1"
+    z = z_const if zc else z_rand
+    norm_w = nw_const if nwc else nw_rand
+    logger.info(f"DIAG z_const={zc} nw_const={nwc}")
+
+    # ---------- Reference: main's forward_decode math (python recurrence) ----------
+    q_exp = q_nk.repeat_interleave(rf, dim=1).reshape(1, 1, Nv, Dk)
+    k_exp = k_nk.repeat_interleave(rf, dim=1).reshape(1, 1, Nv, Dk)
+    v_r = v_nv.reshape(1, 1, Nv, Dv)
+    o, new_rec = recurrent_gated_delta_rule_decode_ttnn(
+        dev(q_exp), dev(k_exp), dev(v_r),
+        ttnn.reshape(dev(beta), [1, 1, Nv]), ttnn.reshape(dev(g), [1, 1, Nv]),
+        scale=scale, initial_state=dev(rec), device=mesh_device, high_precision=False,
+    )
+    out_r = ttnn.reshape(o, (1, Nv, Dv))
+    out_n = ttnn.rms_norm(out_r, weight=dev(norm_w.reshape(1, 1, Dv)), epsilon=1e-6)
+    ref_out = ttnn.multiply(ttnn.reshape(out_n, (1, 1, Nv * Dv)), ttnn.silu(dev(z.reshape(1, 1, Nv * Dv))))
+    ref_out_t = ttnn.to_torch(ref_out, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))[:1]
+    ref_rec_t = ttnn.to_torch(new_rec, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))[:1]
+
+    # ---------- Kernel: pack flat qkv (L2norm+scale folded into q,k; un-expanded) ----------
+    qn = ttnn.multiply(l2_norm_ttnn(dev(q_nk), dim=-1), scale)  # [1,Nk,Dk]
+    kn = l2_norm_ttnn(dev(k_nk), dim=-1)
+    qkv_flat = ttnn.concat(
+        [ttnn.reshape(qn, (1, 1, key_dim)), ttnn.reshape(kn, (1, 1, key_dim)), dev(v_nv.reshape(1, 1, val_dim))], dim=-1
+    )
+    qkv_proj = ttnn.reshape(qkv_flat, (1, 1, 1, conv_dim))
+    z_proj = dev(z.reshape(1, 1, 1, Nv * Dv))
+    b_proj = dev(beta.reshape(1, 1, 1, Nv))
+    a_proj = ttnn.exp(dev(g.reshape(1, 1, 1, Nv)))  # decay
+    dummy_conv = dev(torch.zeros(1, 1, conv_dim, 32))
+    a_log = dev(torch.zeros(1, 1, 1, Nv))
+    dt_bias = dev(torch.zeros(1, 1, 1, Nv))
+    norm_weight = dev(norm_w.reshape(1, 1, 1, Dv))
+    rec_state = dev(rec)  # [1,Nv,Dk,Dv]
+
+    out_list = ttnn.experimental.deltanet_decode_full(
+        qkv_proj, z_proj, b_proj, a_proj, dummy_conv, rec_state, dummy_conv, a_log, dt_bias, norm_weight,
+        num_heads=Nv, num_k_heads=Nk, k_head_dim=Dk, v_head_dim=Dv,
+        conv_dim=conv_dim, conv_kernel_size=K, head_expand_ratio=rf,
+    )
+    k_out_t = ttnn.to_torch(out_list[0], mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))[:1]
+    k_rec_t = ttnn.to_torch(out_list[1], mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))[:1]
+
+    # ---------- Pure-torch reference (ground truth) to arbitrate kernel vs ttnn-ref ----------
+    def _l2(x):
+        return x / (x.pow(2).sum(-1, keepdim=True).sqrt() + 1e-12)
+
+    qT = _l2(q_nk.repeat_interleave(rf, dim=1)[0]) * scale  # [Nv,Dk]
+    kT = _l2(k_nk.repeat_interleave(rf, dim=1)[0])  # [Nv,Dk]
+    vT = v_nv[0]  # [Nv,Dv]
+    hT = rec[0] * torch.exp(g[0]).reshape(Nv, 1, 1)  # decay state
+    v_read = torch.einsum("hk,hkv->hv", kT, hT)
+    delta = vT - v_read
+    hT = hT + beta[0].reshape(Nv, 1, 1) * torch.einsum("hk,hv->hkv", kT, delta)
+    oT = torch.einsum("hk,hkv->hv", qT, hT)  # [Nv,Dv]
+    # Probe variant: read with k instead of q (would indicate a read-source port bug).
+    o_kread = torch.einsum("hk,hkv->hv", kT, hT)
+    _rk = o_kread.pow(2).mean(-1, keepdim=True).add(1e-6).sqrt()
+    torch_out_kread = (((o_kread / _rk) * norm_w.reshape(1, Dv)) * torch.nn.functional.silu(z.reshape(Nv, Dv))).reshape(-1)
+    rms = oT.pow(2).mean(-1, keepdim=True).add(1e-6).sqrt()
+    torch_out = ((oT / rms) * norm_w.reshape(1, Dv)) * torch.nn.functional.silu(z.reshape(Nv, Dv))
+    torch_out = torch_out.reshape(-1)
+    torch_rec = hT.reshape(Nv, Dk, Dv)
+
+    pcc_out = _pcc(ref_out_t, k_out_t)
+    pcc_rec = _pcc(ref_rec_t, k_rec_t)
+    logger.info(f"deltanet_decode_full PCC: output={pcc_out:.5f}  new_state={pcc_rec:.5f}")
+    logger.info(
+        f"vs TORCH: kernel_out={_pcc(k_out_t, torch_out):.5f}  ttnnref_out={_pcc(ref_out_t, torch_out):.5f}  "
+        f"kernel_rec={_pcc(k_rec_t, torch_rec):.5f}  ttnnref_rec={_pcc(ref_rec_t, torch_rec):.5f}"
+    )
+    logger.info(f"PROBE kernel_out vs torch(k-read)={_pcc(k_out_t, torch_out_kread):.5f}")
+    logger.info(f"PROBE-RAW kernel_out vs torch_raw(pre-norm q@S)={_pcc(k_out_t, oT.reshape(-1)):.5f}")
+    assert pcc_out > 0.99, f"output PCC {pcc_out:.5f} too low (kernel packing/math mismatch)"
+    assert pcc_rec > 0.99, f"new_state PCC {pcc_rec:.5f} too low"
+    logger.info("PASSED: fused deltanet_decode_full matches python GDN decode math")

--- a/models/demos/blackhole/qwen36/tests/test_deltanet_flat_pcc.py
+++ b/models/demos/blackhole/qwen36/tests/test_deltanet_flat_pcc.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Flattened-head (B>1) fused deltanet_decode_full probe — fast repro for the device hang.
+
+Packs B lanes into the head axis (num_heads = B*Nv, qkv = [all_q|all_k|all_v]) in ONE kernel
+call and compares the raw output + new_state to a per-lane torch reference. If the single call
+hangs, this reproduces it in ~seconds (no 27B). TEST_B selects the batch (default 2).
+
+Run: MESH_DEVICE=P150x4 TEST_B=2 pytest .../test_deltanet_flat_pcc.py -s
+"""
+import os
+import torch
+
+import ttnn
+from models.demos.blackhole.qwen36.tests.test_factory import parametrize_mesh_tp
+
+
+def _pcc(a, b):
+    a, b = a.float().flatten(), b.float().flatten()
+    return torch.corrcoef(torch.stack([a, b]))[0, 1].item()
+
+
+@parametrize_mesh_tp()
+def test_deltanet_flat(mesh_device, ensure_gc):
+    from loguru import logger
+
+    B = int(os.environ.get("TEST_B", "2"))
+    Nk, Nv, Dk, Dv, K = 4, 12, 128, 128, 4
+    rf = Nv // Nk
+    scale = Dk**-0.5
+    kd, vd = Nk * Dk, Nv * Dv
+    qkv_dim = 2 * kd + vd
+    H = B * Nv
+    rep = ttnn.ReplicateTensorToMesh(mesh_device)
+    torch.manual_seed(0)
+
+    def dev(t):
+        return ttnn.from_torch(t, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=mesh_device, mesh_mapper=rep)
+
+    def l2(x):
+        return x / (x.pow(2).sum(-1, keepdim=True).sqrt() + 1e-12)
+
+    q = torch.randn(B, Nk, Dk) * 0.3
+    k = torch.randn(B, Nk, Dk) * 0.3
+    v = torch.randn(B, Nv, Dv) * 0.3
+    beta = torch.rand(B, Nv)
+    g = -torch.rand(B, Nv) * 0.1
+    rec = torch.randn(B, Nv, Dk, Dv) * 0.1
+
+    # Host-fold L2norm+scale into q,k (un-expanded), pack [all_q | all_k | all_v] batch-major.
+    qn = l2(q) * scale  # [B,Nk,Dk]
+    kn = l2(k)
+    PACK = os.environ.get("PACK", "host")
+    if PACK == "host":  # known-good: pack on host, single dev()
+        qkv_proj = dev(
+            torch.cat([qn.reshape(1, 1, 1, B * kd), kn.reshape(1, 1, 1, B * kd), v.reshape(1, 1, 1, B * vd)], dim=-1)
+        )
+    else:  # build [B,Nk,Dk] device tensors, pack ON DEVICE (mimics gdn/tp.py)
+        qn_d, kn_d, v_d = dev(qn), dev(kn), dev(v)
+        if PACK == "device":  # naive device reshape (flattens tiled dims) — expected to mangle
+            q_f = ttnn.reshape(qn_d, (1, 1, B * kd))
+            k_f = ttnn.reshape(kn_d, (1, 1, B * kd))
+            v_f = ttnn.reshape(v_d, (1, 1, B * vd))
+            qkv_proj = ttnn.reshape(ttnn.concat([q_f, k_f, v_f], dim=-1), (1, 1, 1, B * qkv_dim))
+        elif PACK == "rm":  # reshape-safe: ROW_MAJOR detour, then back to TILE
+
+            def flat_rm(t, w):
+                return ttnn.reshape(ttnn.to_layout(t, ttnn.ROW_MAJOR_LAYOUT), (1, 1, 1, w))
+
+            qkv_rm = ttnn.concat([flat_rm(qn_d, B * kd), flat_rm(kn_d, B * kd), flat_rm(v_d, B * vd)], dim=-1)
+            qkv_proj = ttnn.to_layout(qkv_rm, ttnn.TILE_LAYOUT)
+    z_p = dev(torch.randn(1, 1, 1, B * vd) * 0.3)
+    b_p = dev(beta.reshape(1, 1, 1, H))
+    a_p = dev(torch.exp(g).reshape(1, 1, 1, H))  # decay
+    dummy = dev(torch.zeros(1, 1, B * qkv_dim, 32))
+    zh = dev(torch.zeros(1, 1, 1, H))
+    nw = dev(torch.ones(1, 1, 1, Dv))
+    ms = os.environ.get("MODEL_STATE", "0")
+    if ms == "1":  # fp32 [B,Nv,Dk,Dv] + device reshape (exact gdn path)
+        rec_bnv = ttnn.from_torch(rec, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=mesh_device, mesh_mapper=rep)
+        rec_flat = ttnn.reshape(rec_bnv, (1, H, Dk, Dv))
+    elif ms == "2":  # bf16 [B,Nv,Dk,Dv] + device reshape (isolate reshape vs dtype)
+        rec_bnv = ttnn.from_torch(rec, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=mesh_device, mesh_mapper=rep)
+        rec_flat = ttnn.reshape(rec_bnv, (1, H, Dk, Dv))
+    else:  # bf16, built directly as [1,H,Dk,Dv] on host (known-good)
+        rec_flat = dev(rec.reshape(1, H, Dk, Dv))
+
+    logger.info(f"calling deltanet_decode_full flattened: B={B} H={H} num_k_heads={B*Nk} conv_dim={B*qkv_dim}")
+    out = ttnn.experimental.deltanet_decode_full(
+        qkv_proj, z_p, b_p, a_p, dummy, rec_flat, dummy, zh, zh, nw,
+        num_heads=H, num_k_heads=B * Nk, k_head_dim=Dk, v_head_dim=Dv,
+        conv_dim=B * qkv_dim, conv_kernel_size=K, head_expand_ratio=rf,
+    )
+    ttnn.synchronize_device(mesh_device)
+    logger.info("kernel returned (no hang)")
+    k_out = ttnn.to_torch(out[0], mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))[:1].reshape(H, Dv)
+    k_rec = ttnn.to_torch(out[1], mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))[:1].reshape(H, Dk, Dv)
+
+    # Per-lane torch reference (raw q@S_new, no norm/gate).
+    outs, recs = [], []
+    for bi in range(B):
+        qT = (l2(q[bi]) * scale).repeat_interleave(rf, dim=0)  # [Nv,Dk] block-expand
+        kT = l2(k[bi]).repeat_interleave(rf, dim=0)
+        hT = rec[bi] * torch.exp(g[bi]).reshape(Nv, 1, 1)
+        vr = torch.einsum("hk,hkv->hv", kT, hT)
+        hT = hT + beta[bi].reshape(Nv, 1, 1) * torch.einsum("hk,hv->hkv", kT, vr.mul(-1).add(v[bi]))
+        outs.append(torch.einsum("hk,hkv->hv", qT, hT))
+        recs.append(hT)
+    torch_out = torch.cat(outs, dim=0)  # [H,Dv]
+    torch_rec = torch.cat(recs, dim=0)  # [H,Dk,Dv]
+    logger.info(f"FLAT PCC: raw={_pcc(k_out, torch_out):.5f}  new_state={_pcc(k_rec, torch_rec):.5f}")
+    # Tail reshape check: the shared gdn tail reshapes o [1,1,1,B*Nv*Dv] -> (B,Nv,Dv). Verify that
+    # device reshape (splitting the tiled row) preserves data at B>1 (vs a ROW_MAJOR detour).
+    tail_dev = ttnn.reshape(out[0], (B, Nv, Dv))
+    tail_t = ttnn.to_torch(tail_dev, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))[:B].reshape(H, Dv)
+    tail_rm = ttnn.to_layout(ttnn.reshape(ttnn.to_layout(out[0], ttnn.ROW_MAJOR_LAYOUT), (B, Nv, Dv)), ttnn.TILE_LAYOUT)
+    tail_rm_t = ttnn.to_torch(tail_rm, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))[:B].reshape(H, Dv)
+    logger.info(f"TAIL reshape vs raw: device={_pcc(tail_t, k_out):.5f}  rowmajor={_pcc(tail_rm_t, k_out):.5f}")
+    assert _pcc(k_out, torch_out) > 0.99 and _pcc(k_rec, torch_rec) > 0.99
+    logger.info("PASSED: flattened-head fused matches per-lane torch")

--- a/models/demos/blackhole/qwen36/tests/test_fused_gated_e2e.py
+++ b/models/demos/blackhole/qwen36/tests/test_fused_gated_e2e.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""E2E correctness + TPS for the fused GDN decode (raw kernel read + ttnn gated-RMSNorm/silu(z)).
+
+Validates the QWEN_GDN_FUSED_DECODE=1 path decodes coherent text (lane 0 → 'Paris' for
+"The capital of France is") AND measures B=8 traced TPS (two-point). NOTE: this test issues 3
+generate() calls, so its TPS is ~15 tok/s below the authoritative bench_decode_tps_tp two-point
+(the resident correctness-trace inflates ms/step); use it for CORRECTNESS, bench for the TPS number.
+
+Run: QWEN_GDN_FUSED_DECODE=1 QWEN_BENCH_B=8 MESH_DEVICE=P150x4 HF_MODEL=Qwen/Qwen3.6-27B \
+       pytest models/demos/blackhole/qwen36/tests/test_fused_gated_e2e.py -v -s
+"""
+import os
+import time
+
+import torch
+
+import ttnn
+from models.demos.blackhole.qwen36.tests.test_factory import model_path, parametrize_mesh_tp
+from models.demos.blackhole.qwen36.tt.model import Qwen36Model
+
+N1, N2 = 8, 72
+
+
+@parametrize_mesh_tp()
+def test_fused_gated_e2e(mesh_device, ensure_gc):
+    from loguru import logger
+
+    os.environ.setdefault("HF_MODEL", model_path())
+    os.environ["QWEN_GDN_FUSED_DECODE"] = "1"
+    mesh_device.enable_program_cache()
+    B = int(os.environ.get("QWEN_BENCH_B", "8"))
+    model = Qwen36Model.from_pretrained(mesh_device, max_batch_size=B, max_seq_len=2048)
+
+    from transformers import AutoTokenizer
+
+    tok = AutoTokenizer.from_pretrained(model.args.CKPT_DIR, trust_remote_code=True)
+    prompt = tok("The capital of France is", return_tensors="pt").input_ids[0].tolist()
+    prompts = [prompt] * B
+
+    # ---- Correctness: decode 16 tokens (traced) and print lane-0 text ----
+    outs = model.generate_tp_batched(prompts, max_new_tokens=16, use_trace=True)
+    text0 = tok.decode(outs[0])
+    logger.info(f"FUSED_GATED lane0 text: {text0!r}")
+    logger.info(f"FUSED_GATED lane1 text: {tok.decode(outs[1])!r}")
+
+    # ---- TPS: two-point traced ----
+    def timed(n):
+        best = float("inf")
+        for _ in range(2):
+            t0 = time.time()
+            model.generate_tp_batched(prompts, max_new_tokens=n, use_trace=True)
+            ttnn.synchronize_device(mesh_device)
+            best = min(best, time.time() - t0)
+        return best
+
+    per_step = (timed(N2) - timed(N1)) / (N2 - N1)
+    agg = B / per_step
+    logger.info(f"FUSED_GATED_TPS B={B}: traced={agg:.1f}tok/s(agg,{per_step*1e3:.1f}ms/step)  lane0={text0!r}")
+    assert "Paris" in text0, f"lane0 should mention Paris, got {text0!r}"

--- a/models/demos/blackhole/qwen36/tests/test_fused_longdecode_drift.py
+++ b/models/demos/blackhole/qwen36/tests/test_fused_longdecode_drift.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Long-decode drift check for the fused GDN decode (bf16 recurrent state).
+
+The fused kernel carries the gated-delta recurrent state in bf16 (the python path keeps fp32 for
+decode-drift mitigation). Over a long decode, coarse bf16 quantization of decay=exp(g)~1.0 can
+accumulate and cause late-generation repetition collapse. This generates N tokens (traced) and
+reports a repetition metric over the tail so we can see whether the fused bf16-state path holds up
+for serving-length decodes. Set QWEN_GDN_FUSED_DECODE=1 for fused; unset for the fp32 python path.
+
+Run: QWEN_GDN_FUSED_DECODE=1 QWEN_LONGDECODE_N=256 QWEN_BENCH_B=8 MESH_DEVICE=P150x4 \
+       HF_MODEL=Qwen/Qwen3.6-27B pytest .../test_fused_longdecode_drift.py -v -s
+"""
+import os
+
+import ttnn
+from models.demos.blackhole.qwen36.tests.test_factory import model_path, parametrize_mesh_tp
+from models.demos.blackhole.qwen36.tt.model import Qwen36Model
+
+
+def _tail_repetition(ids, window=64):
+    """Fraction of REPEATED tokens in the last `window` (1 - unique/len). ~0=diverse, ~1=collapsed."""
+    tail = ids[-window:]
+    if not tail:
+        return 0.0
+    return 1.0 - len(set(tail)) / len(tail)
+
+
+def _max_run(ids):
+    """Longest run of an identical token (collapse indicator)."""
+    best = run = 1
+    for i in range(1, len(ids)):
+        run = run + 1 if ids[i] == ids[i - 1] else 1
+        best = max(best, run)
+    return best
+
+
+@parametrize_mesh_tp()
+def test_fused_longdecode_drift(mesh_device, ensure_gc):
+    from loguru import logger
+
+    os.environ.setdefault("HF_MODEL", model_path())
+    mesh_device.enable_program_cache()
+    B = int(os.environ.get("QWEN_BENCH_B", "8"))
+    N = int(os.environ.get("QWEN_LONGDECODE_N", "256"))
+    fused = os.environ.get("QWEN_GDN_FUSED_DECODE") == "1"
+    tag = "FUSED_bf16" if fused else "PYTHON_fp32"
+
+    model = Qwen36Model.from_pretrained(mesh_device, max_batch_size=B, max_seq_len=2048)
+    from transformers import AutoTokenizer
+
+    tok = AutoTokenizer.from_pretrained(model.args.CKPT_DIR, trust_remote_code=True)
+    prompt = tok("Write a short story about a robot learning to paint.", return_tensors="pt").input_ids[0].tolist()
+    prompts = [prompt] * B
+
+    outs = model.generate_tp_batched(prompts, max_new_tokens=N, use_trace=True)
+    ids0 = outs[0]
+    rep = _tail_repetition(ids0, 64)
+    mx = _max_run(ids0)
+    text = tok.decode(ids0)
+    logger.info(f"LONGDECODE[{tag}] N={len(ids0)} tail_rep(64)={rep:.3f} max_run={mx}")
+    logger.info(f"LONGDECODE[{tag}] head: {tok.decode(ids0[:60])!r}")
+    logger.info(f"LONGDECODE[{tag}] tail: {tok.decode(ids0[-60:])!r}")
+    # Collapse guard: a healthy decode has diverse tail (rep < ~0.6) and no long identical run.
+    logger.info(f"LONGDECODE_SUMMARY[{tag}] tail_rep={rep:.3f} max_run={mx} verdict={'COLLAPSE' if (rep>0.7 or mx>=12) else 'OK'}")

--- a/models/demos/blackhole/qwen36/tt/attention/tp.py
+++ b/models/demos/blackhole/qwen36/tt/attention/tp.py
@@ -130,9 +130,13 @@ class TPAttention:
         self.k_caches = [z() for _ in range(self.NKV)]
         self.v_caches = [z() for _ in range(self.NKV)]
 
-    def forward_prefill(self, x, cos_tt, sin_tt):
+    def forward_prefill(self, x, cos_tt, sin_tt, batch_slot=0):
         """Causal prefill over a full sequence. x: [1,1,S,dim] replicated;
-        cos/sin: [1,1,S,rope_dim]. Output fractured along dim=3 (reduce-scatter)."""
+        cos/sin: [1,1,S,rope_dim]. Output fractured along dim=3 (reduce-scatter).
+
+        batch_slot: which lane of the [B,1,seq,HD] internal KV cache to fill. For
+        batched decode (Step 1) each of the B sequences is prefilled into its own
+        lane; the default 0 preserves the single-sequence (B=1) behavior exactly."""
         tw, NH, NKV, HD = self.tw, self.NH, self.NKV, self.HD
         S = x.shape[-2]
 
@@ -161,8 +165,8 @@ class TPAttention:
             # Don't deallocate the slices — for NKV==1 they alias k/v, which are
             # still needed for SDPA below.
             for h in range(NKV):
-                ttnn.fill_cache(self.k_caches[h], ttnn.slice(k, (0, h, 0, 0), (1, h + 1, S, HD)), 0)
-                ttnn.fill_cache(self.v_caches[h], ttnn.slice(v, (0, h, 0, 0), (1, h + 1, S, HD)), 0)
+                ttnn.fill_cache(self.k_caches[h], ttnn.slice(k, (0, h, 0, 0), (1, h + 1, S, HD)), batch_slot)
+                ttnn.fill_cache(self.v_caches[h], ttnn.slice(v, (0, h, 0, 0), (1, h + 1, S, HD)), batch_slot)
 
         # Keep Q/K/V bf16 into SDPA. The unconditional bf8 cast here was inconsistent with the documented bf16-Q fix and degraded
         # the bespoke prefill_tp oracle vs the paged path. QWEN_SDPA_BF8_Q=1 restores the old bf8.

--- a/models/demos/blackhole/qwen36/tt/attention/tp.py
+++ b/models/demos/blackhole/qwen36/tt/attention/tp.py
@@ -65,6 +65,21 @@ def load_attention_weights_tp(mesh, state_dict, args, cache_dir=None):
         cache_path=c("wv"),
         dtype=ttnn.bfloat8_b,
     )
+    # Fused QKV: concat the three column-parallel shards along the output dim (per-device concat
+    # preserves each device's [q|gate], k, v slice) → ONE matmul instead of three. Matches the
+    # branch's fused-QKV attn(). ALL paths (prefill/prefill_paged/decode) use wqkv_all, so the
+    # separate wqkv/wk/wv are freed here — the fused weight replaces (not duplicates) them.
+    # QWEN_SKIP_FUSED_WEIGHTS skips building it (DRAM-cost A/B measurement only; forward needs it).
+    if os.environ.get("QWEN_SKIP_FUSED_WEIGHTS") == "1":
+        tw["wqkv_all"] = None
+    else:
+        tw["wqkv_all"] = ttnn.concat(
+            [tw["wqkv"], tw["wk"], tw["wv"]], dim=-1, memory_config=ttnn.DRAM_MEMORY_CONFIG
+        )
+        ttnn.deallocate(tw["wqkv"])
+        ttnn.deallocate(tw["wk"])
+        ttnn.deallocate(tw["wv"])
+        tw["wqkv"] = tw["wk"] = tw["wv"] = None
     # Row-parallel: shard input dim → reduce-scatter after
     tw["wo"] = tpc.shard_w(
         state_dict["o_proj.weight"],
@@ -140,9 +155,13 @@ class TPAttention:
         tw, NH, NKV, HD = self.tw, self.NH, self.NKV, self.HD
         S = x.shape[-2]
 
-        qg = ttnn.linear(x, tw["wqkv"], compute_kernel_config=self.compute_cfg, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-        kp = ttnn.linear(x, tw["wk"], compute_kernel_config=self.compute_cfg, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-        vp = ttnn.linear(x, tw["wv"], compute_kernel_config=self.compute_cfg, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        # Fused QKV (shares the decode-fused weight; separate wqkv/wk/wv are freed at load).
+        qsz, ksz = NH * HD * 2, NKV * HD
+        qkv = ttnn.linear(x, tw["wqkv_all"], compute_kernel_config=self.compute_cfg, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        qg = ttnn.slice(qkv, (0, 0, 0, 0), (1, 1, S, qsz))
+        kp = ttnn.slice(qkv, (0, 0, 0, qsz), (1, 1, S, qsz + ksz))
+        vp = ttnn.slice(qkv, (0, 0, 0, qsz + ksz), (1, 1, S, qsz + 2 * ksz))
+        ttnn.deallocate(qkv)
 
         # [1,1,S,NH*HD*2] -> [1,S,NH,2*HD] -> split -> [1,NH,S,HD]
         qg = ttnn.reshape(qg, (1, S, NH, 2 * HD))
@@ -217,9 +236,15 @@ class TPAttention:
         if not use_paged and self.k_caches is None:
             self.reset_state()
 
-        qg = ttnn.linear(x, tw["wqkv"], compute_kernel_config=self.compute_cfg, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-        kp = ttnn.linear(x, tw["wk"], compute_kernel_config=self.compute_cfg, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-        vp = ttnn.linear(x, tw["wv"], compute_kernel_config=self.compute_cfg, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        # Fused QKV: one matmul then split into [q|gate], k, v (branch's fused-QKV attn()).
+        qsz, ksz = NH * HD * 2, NKV * HD
+        qkv = ttnn.linear(
+            x, tw["wqkv_all"], compute_kernel_config=self.compute_cfg, memory_config=ttnn.DRAM_MEMORY_CONFIG
+        )
+        qg = ttnn.slice(qkv, (0, 0, 0, 0), (1, 1, B, qsz))
+        kp = ttnn.slice(qkv, (0, 0, 0, qsz), (1, 1, B, qsz + ksz))
+        vp = ttnn.slice(qkv, (0, 0, 0, qsz + ksz), (1, 1, B, qsz + 2 * ksz))
+        ttnn.deallocate(qkv)
 
         qg_r = ttnn.reshape(qg, (1, B, NH, HD * 2))
         ttnn.deallocate(qg)
@@ -364,9 +389,13 @@ class TPAttention:
             chunk_start_idx = 0
         S = x.shape[-2]
 
-        qg = ttnn.linear(x, tw["wqkv"], compute_kernel_config=self.compute_cfg, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-        kp = ttnn.linear(x, tw["wk"], compute_kernel_config=self.compute_cfg, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-        vp = ttnn.linear(x, tw["wv"], compute_kernel_config=self.compute_cfg, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        # Fused QKV (shares the decode-fused weight; separate wqkv/wk/wv are freed at load).
+        qsz, ksz = NH * HD * 2, NKV * HD
+        qkv = ttnn.linear(x, tw["wqkv_all"], compute_kernel_config=self.compute_cfg, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        qg = ttnn.slice(qkv, (0, 0, 0, 0), (1, 1, S, qsz))
+        kp = ttnn.slice(qkv, (0, 0, 0, qsz), (1, 1, S, qsz + ksz))
+        vp = ttnn.slice(qkv, (0, 0, 0, qsz + ksz), (1, 1, S, qsz + 2 * ksz))
+        ttnn.deallocate(qkv)
 
         qg = ttnn.reshape(qg, (1, S, NH, 2 * HD))
         q = ttnn.transpose(ttnn.slice(qg, (0, 0, 0, 0), (1, S, NH, HD)), 1, 2)

--- a/models/demos/blackhole/qwen36/tt/gdn/tp.py
+++ b/models/demos/blackhole/qwen36/tt/gdn/tp.py
@@ -148,6 +148,14 @@ class TPGatedDeltaNet:
         self._stable_state = False
         self.conv_carry = None  # [1, K-1, qkv_dim_tp] cross-chunk prefill conv carry
         self._zero_conv0 = None  # persistent zero source for conv_states[0] (trace-safe)
+        # Batched-decode seeding (Step 1): when B>1, each of the B sequences is
+        # prefilled independently and its captured recurrent/conv state is stashed
+        # per batch slot here (kept ON DEVICE — the state's per-device head shards
+        # differ across the mesh, so a host round-trip would collapse the mesh dim),
+        # then concatenated into the [B,...] decode buffers by finalize_seed().
+        # Seeding happens once per sequence, not in the decode hot loop.
+        self._seed_rec = {}  # slot -> device rec state  [1, Nv, Dk, Dv]
+        self._seed_conv = {}  # slot -> list of K-1 device conv windows, each [1, 1, qkv_dim_tp]
 
     def reset_state(self):
         def z(shape):
@@ -215,7 +223,64 @@ class TPGatedDeltaNet:
         ttnn.copy(zcc, self.conv_carry)
         ttnn.deallocate(zcc)
 
-    def forward_prefill(self, x, chunk_size=128, valid_len=None, capture_state=False):
+    def finalize_seed(self, batch_size):
+        """Assemble the per-slot stashed prefill state (see forward_prefill seed_slot)
+        into the [B,...] decode buffers. Call once after all `batch_size` sequences
+        have been prefilled with their seed_slot. Clears the stash.
+
+        Everything stays on device: ttnn.concat runs per-device, so each device's own
+        GDN head shard is preserved (the recurrent/conv state is NOT replicated — it is
+        computed independently per device). Concatenation is along the batch (slot) axis.
+        """
+        assert len(self._seed_rec) == batch_size, f"seeded {len(self._seed_rec)} slots, expected {batch_size}"
+        if self.conv_states is None:
+            self.reset_state()
+        # Recurrent state: [B, Nv, Dk, Dv] over the batch axis (dim=0). Match the demo
+        # semantics (self.rec_state = final_state) by reassigning; copy in place only when
+        # the buffer address must stay fixed (trace path, Step 2).
+        slots = [self._seed_rec[b] for b in range(batch_size)]
+        rec = slots[0] if batch_size == 1 else ttnn.concat(slots, dim=0)
+        if self._stable_state:
+            ttnn.copy(rec, self.rec_state)  # data → fixed buffer; rec itself no longer needed
+            ttnn.deallocate(rec)
+        else:
+            self.rec_state = rec  # rec becomes the buffer
+        for s in slots:
+            if s is not rec and s is not self.rec_state:
+                ttnn.deallocate(s)
+        # Conv window: conv_states[0] = zero; conv_states[j+1] = the j-th window over all slots.
+        D = self.qkv_dim_tp
+        zc = ttnn.from_torch(
+            torch.zeros(1, batch_size, D, dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=self.mesh,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh),
+        )
+        ttnn.copy(zc, self.conv_states[0])
+        ttnn.deallocate(zc)
+        for j in range(self.K - 1):
+            wins = [self._seed_conv[b][j] for b in range(batch_size)]  # each [1, 1, D]
+            if batch_size == 1:
+                win = wins[0]
+            else:
+                # Concat along the batch axis (dim=1). That is a TILE sub-dim, so detour
+                # through ROW_MAJOR where a size-1 stack is unambiguous, then back to TILE.
+                rm = [ttnn.to_layout(w, ttnn.ROW_MAJOR_LAYOUT) for w in wins]
+                win_rm = ttnn.concat(rm, dim=1)  # [1, B, D] row-major
+                win = ttnn.to_layout(win_rm, ttnn.TILE_LAYOUT)
+                ttnn.deallocate(win_rm)
+                for r in rm:
+                    ttnn.deallocate(r)
+            ttnn.copy(win, self.conv_states[j + 1])
+            if win is not wins[0]:
+                ttnn.deallocate(win)
+            for w in wins:
+                ttnn.deallocate(w)
+        self._seed_rec.clear()
+        self._seed_conv.clear()
+
+    def forward_prefill(self, x, chunk_size=128, valid_len=None, capture_state=False, seed_slot=None):
         """Causal chunk-prefill over a sequence (from scratch, zero init state).
 
         x: [1,1,T,dim] replicated. Reuses the shared gated_delta_attn_seq kernel
@@ -301,10 +366,28 @@ class TPGatedDeltaNet:
             valid_len=valid_len,
         )
         B, D = 1, self.qkv_dim_tp
+        # ---- Batched-decode seeding (Step 1): stash this sequence's state per slot. ----
+        # When seed_slot is set we are prefilling ONE of B sequences whose decode buffers
+        # are [B,...]; a single-pass prefill produces batch-1 state, so we stash it (keyed
+        # by slot, kept on device) and DON'T touch the shared [B,...] buffers here.
+        # finalize_seed() concats all B slots into rec_state/conv_states once every
+        # sequence is prefilled. Falls through to the shared output tail below.
+        if seed_slot is not None:
+            # Keep the state ON DEVICE (per-device head shards differ across the mesh;
+            # a host round-trip would collapse the mesh dim). finalize_seed concats these
+            # per-slot device tensors along the batch axis — ttnn.concat is per-device, so
+            # each device's own head shard is preserved. Slices are fresh tensors, so the
+            # shared tail's deallocate(conv_new_state) is still correct.
+            self._seed_rec[seed_slot] = final_state  # [1, Nv, Dk, Dv]; NOT freed here
+            windows = []
+            for j in range(self.K - 1):
+                windows.append(ttnn.reshape(ttnn.slice(conv_new_state, (0, j, 0), (1, j + 1, D)), (1, B, D)))
+            self._seed_conv[seed_slot] = windows  # K-1 tensors, each [1, 1, D]
+            # conv_new_state is freed by the shared tail below; final_state is retained.
         # ---- Carry recurrent + conv state for the NEXT chunk (chunk-outer prefill). ----
         # In place (ttnn.copy) when _stable_state so the addresses the prefill/decode traces
         # baked in stay valid across execute_trace replays and across sequences.
-        if carry:
+        elif carry:
             ttnn.copy(final_state, self.rec_state)
             ttnn.deallocate(final_state)
             ttnn.copy(conv_new_state, self.conv_carry)  # [1, K-1, D] last-K-1 conv inputs
@@ -313,7 +396,7 @@ class TPGatedDeltaNet:
         # ---- Finalize the decode conv window (last chunk / short prompt). ----
         # conv_states[1..K-1] = the last K-1 real conv inputs; [0] is the (shifted-out) zero.
         # Harmless to refresh every chunk — the last chunk's values are the ones decode reads.
-        if capture_state:
+        if seed_slot is None and capture_state:
             if self.conv_states is None:
                 self.reset_state()
             if self._zero_conv0 is not None:

--- a/models/demos/blackhole/qwen36/tt/gdn/tp.py
+++ b/models/demos/blackhole/qwen36/tt/gdn/tp.py
@@ -18,6 +18,7 @@ import torch
 import ttnn
 from models.demos.blackhole.qwen36.tt import tp_common as tpc
 from models.experimental.gated_attention_gated_deltanet.tt.ttnn_delta_rule_ops import (
+    l2_norm_ttnn,
     recurrent_gated_delta_rule_decode_ttnn,
 )
 from models.experimental.gated_attention_gated_deltanet.tt.ttnn_delta_rule_seq import (
@@ -540,44 +541,116 @@ class TPGatedDeltaNet:
         v = ttnn.reshape(ttnn.slice(conv, (0, 0, 2 * kd), (1, B, self.qkv_dim_tp)), (B, Nv, Dv))
         ttnn.deallocate(conv)
 
-        # expand Q/K from Nk to Nv heads (GQA); recurrence fn L2-norms + scales internally
         rf = Nv // Nk
-        q = ttnn.repeat_interleave(q, rf, dim=1)
-        k = ttnn.repeat_interleave(k, rf, dim=1)
-        q = ttnn.reshape(q, (B, 1, Nv, Dk))
-        k = ttnn.reshape(k, (B, 1, Nv, Dk))
-        v = ttnn.reshape(v, (B, 1, Nv, Dv))
-
-        beta = ttnn.reshape(ttnn.sigmoid(b), (B, 1, Nv))
-        ttnn.deallocate(b)
-        g = ttnn.multiply(tw["neg_exp_A"], ttnn.softplus(ttnn.add(a, tw["dt_bias"])))
-        ttnn.deallocate(a)
-        g = ttnn.reshape(g, (B, 1, Nv))
-
-        # fp32 decode step DEFAULT (decode-drift mitigation). The per-step gated-delta recurrence
-        # h = decay*h + beta*(k⊗delta) compounds every token; in bf16, `decay = exp(g)` (near 1.0)
-        # quantizes coarsely and the error accumulates over a long decode → late-generation
-        # repetition collapse. high_precision runs the whole step in fp32 (pairs with the fp32
-        # rec_state default). QWEN35_GDN_DECODE_BF16=1 reverts to the bf16 step.
-        o, new_rec = recurrent_gated_delta_rule_decode_ttnn(
-            q,
-            k,
-            v,
-            beta,
-            g,
-            scale=self.scale,
-            initial_state=self.rec_state,
-            device=self.mesh,
-            high_precision=(os.environ.get("QWEN35_GDN_DECODE_BF16") != "1"),
-        )
-        if self._stable_state:
-            # In-place update keeps rec_state's address fixed so the decode trace
-            # (captured at pos 0) replays correctly across steps and sequences.
-            ttnn.copy(new_rec, self.rec_state)
-            ttnn.deallocate(new_rec)
+        if os.environ.get("QWEN_GDN_FUSED_DECODE") == "1":
+            # ---- Fused C++ kernel: gated-delta STATE update + raw read, both bit-exact vs torch
+            # (test_deltanet_decode_kernel_pcc: state 1.0, PROBE-RAW 0.99998). The op outputs the
+            # RAW pre-norm o (its internal norm/gate is unused); the gated-RMSNorm + silu(z) run in
+            # ttnn in the shared tail below — matching recurrent_gated_delta_rule_decode_ttnn's
+            # raw-o contract. FLATTENED-HEAD batching (Stage 7): the B decode lanes are folded into
+            # the head axis (H = B*Nv heads, ONE kernel call, one core per (batch,head)), so batching
+            # is ~free. qkv_proj is packed [all_q | all_k | all_v] (batch-major within each block) so
+            # the op's per-head offset math (k_head_idx = h/head_expand_ratio) addresses batch b's
+            # block; state / z / beta / decay are batch-major [.., B*..] = free reshapes. ----
+            H = B * Nv
+            qn = ttnn.multiply(l2_norm_ttnn(q, dim=-1), self.scale)  # [B, Nk, Dk]
+            kn = l2_norm_ttnn(k, dim=-1)
+            qkv_proj = ttnn.reshape(
+                ttnn.concat(
+                    [ttnn.reshape(qn, (1, 1, B * kd)), ttnn.reshape(kn, (1, 1, B * kd)),
+                     ttnn.reshape(v, (1, 1, B * self.value_dim_tp))], dim=-1,
+                ), (1, 1, 1, B * self.qkv_dim_tp),
+            )
+            z_p = ttnn.reshape(z, (1, 1, 1, B * self.value_dim_tp))
+            beta_p = ttnn.reshape(ttnn.sigmoid(b), (1, 1, 1, H))
+            ttnn.deallocate(b)
+            decay_p = ttnn.reshape(
+                ttnn.exp(ttnn.multiply(tw["neg_exp_A"], ttnn.softplus(ttnn.add(a, tw["dt_bias"])))), (1, 1, 1, H)
+            )
+            ttnn.deallocate(a)
+            # Pass-through / unused kernel args (kept in the op signature) — allocate once and reuse
+            # (a per-step from_torch would be a host write, killing decode perf + breaking trace).
+            if getattr(self, "_kdummy_conv", None) is None:
+                rep = ttnn.ReplicateTensorToMesh(self.mesh)
+                self._kdummy_conv = ttnn.from_torch(
+                    torch.zeros(1, 1, B * self.qkv_dim_tp, 32, dtype=torch.bfloat16),
+                    dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=self.mesh, mesh_mapper=rep,
+                )
+                self._kdummy_h = ttnn.from_torch(
+                    torch.zeros(1, 1, 1, H, dtype=torch.bfloat16),
+                    dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=self.mesh, mesh_mapper=rep,
+                )
+                self._knorm_w = ttnn.reshape(tw["norm_w"], (1, 1, 1, Dv))
+            # State: the batch-flatten reshape [B,Nv,Dk,Dv] -> [1,B*Nv,Dk,Dv] mangles an fp32 TILE
+            # tensor (yields NaNs); bf16 reshapes correctly. The kernel's recurrence + output are bf16
+            # regardless (CBs are bf16; output dtype = qkv_proj.dtype), so a bf16 fused-path state is
+            # not a precision regression vs the kernel itself — only the pure-python path keeps the
+            # fp32 high_precision carry. After step 1, self.rec_state is bf16 (reassigned below).
+            rec_src = self.rec_state
+            if rec_src.dtype != ttnn.bfloat16:
+                rec_src = ttnn.typecast(rec_src, ttnn.bfloat16)
+            rec_flat = ttnn.reshape(rec_src, (1, H, Dk, Dv))
+            _out, new_rec, _cs = ttnn.experimental.deltanet_decode_full(
+                qkv_proj, z_p, beta_p, decay_p, self._kdummy_conv, rec_flat, self._kdummy_conv,
+                self._kdummy_h, self._kdummy_h, self._knorm_w,
+                num_heads=H, num_k_heads=B * Nk, k_head_dim=Dk, v_head_dim=Dv,
+                conv_dim=B * self.qkv_dim_tp, conv_kernel_size=self.K, head_expand_ratio=rf,
+            )
+            ttnn.deallocate(_cs)
+            if rec_src is not self.rec_state:
+                ttnn.deallocate(rec_src)
+            # Kernel outputs the RAW pre-norm read (q @ S_new); the gated-RMSNorm(norm_w) + silu(z)
+            # runs in the ttnn tail below. Folding norm/gate into the kernel was measured SLOWER on
+            # Blackhole (one-core-per-head serializes the RMSNorm reduce: +8.4ms/step at B=8 vs the
+            # parallel ttnn tail) — see memory note. So we keep the raw-o contract + ttnn norm/gate.
+            o = _out  # [1,1,1,B*Nv*Dv] RAW; shared tail does norm/gate + reshape to (B,Nv,Dv)
+            new_rec = ttnn.reshape(new_rec, (B, Nv, Dk, Dv))  # bf16
+            if self._stable_state:
+                ttnn.copy(new_rec, self.rec_state)
+                ttnn.deallocate(new_rec)
+            else:
+                self.rec_state = new_rec
         else:
-            self.rec_state = new_rec
+            # expand Q/K from Nk to Nv heads (GQA); recurrence fn L2-norms + scales internally
+            q = ttnn.repeat_interleave(q, rf, dim=1)
+            k = ttnn.repeat_interleave(k, rf, dim=1)
+            q = ttnn.reshape(q, (B, 1, Nv, Dk))
+            k = ttnn.reshape(k, (B, 1, Nv, Dk))
+            v = ttnn.reshape(v, (B, 1, Nv, Dv))
 
+            beta = ttnn.reshape(ttnn.sigmoid(b), (B, 1, Nv))
+            ttnn.deallocate(b)
+            g = ttnn.multiply(tw["neg_exp_A"], ttnn.softplus(ttnn.add(a, tw["dt_bias"])))
+            ttnn.deallocate(a)
+            g = ttnn.reshape(g, (B, 1, Nv))
+
+            # fp32 decode step DEFAULT (decode-drift mitigation). The per-step gated-delta recurrence
+            # h = decay*h + beta*(k⊗delta) compounds every token; in bf16, `decay = exp(g)` (near 1.0)
+            # quantizes coarsely and the error accumulates over a long decode → late-generation
+            # repetition collapse. high_precision runs the whole step in fp32 (pairs with the fp32
+            # rec_state default). QWEN35_GDN_DECODE_BF16=1 reverts to the bf16 step.
+            o, new_rec = recurrent_gated_delta_rule_decode_ttnn(
+                q,
+                k,
+                v,
+                beta,
+                g,
+                scale=self.scale,
+                initial_state=self.rec_state,
+                device=self.mesh,
+                high_precision=(os.environ.get("QWEN35_GDN_DECODE_BF16") != "1"),
+            )
+            if self._stable_state:
+                # In-place update keeps rec_state's address fixed so the decode trace
+                # (captured at pos 0) replays correctly across steps and sequences.
+                ttnn.copy(new_rec, self.rec_state)
+                ttnn.deallocate(new_rec)
+            else:
+                self.rec_state = new_rec
+
+        # Gated-RMSNorm(norm_w) over Dv + silu(z) gate, in ttnn (both the fused-kernel raw-o path
+        # and the recurrent_gated_delta_rule_decode_ttnn path output raw o). Folding this into the
+        # kernel is a NET LOSS on Blackhole (one-core-per-head serializes the reduce) — see memory.
         out_r = ttnn.reshape(o, (B, Nv, Dv))
         out_n = ttnn.rms_norm(out_r, weight=tw["norm_w"], epsilon=1e-6)  # gated norm: weight only (no +1)
         ttnn.deallocate(out_r)

--- a/models/demos/blackhole/qwen36/tt/gdn/tp.py
+++ b/models/demos/blackhole/qwen36/tt/gdn/tp.py
@@ -280,6 +280,72 @@ class TPGatedDeltaNet:
         self._seed_rec.clear()
         self._seed_conv.clear()
 
+    def reseed_slot(self, b):
+        """Replace ONLY batch lane b's recurrent + conv state with the sequence stashed
+        for slot b (a prior forward_prefill(seed_slot=b)), leaving the other B-1 lanes'
+        running state untouched. In-place (ttnn.copy into the fixed buffers) so a captured
+        decode trace's baked addresses survive — this is the continuous-batching join.
+
+        Slice-per-lane + concat (per-device, so each device keeps its own head shard),
+        replacing lane b with the seed. Clears the slot's stash.
+        """
+        assert b in self._seed_rec, f"call forward_prefill(seed_slot={b}) before reseed_slot({b})"
+        B = self.B
+
+        def _match(t, ref):
+            # After decode steps the running buffers may be a different dtype (fp32 recurrent
+            # default) than the freshly-prefilled seed pieces; concat requires uniform dtype.
+            return t if t.dtype == ref.dtype else ttnn.typecast(t, ref.dtype)
+
+        # Recurrent state [B, Nv, Dk, Dv]: replace lane b along dim 0.
+        seed_rec = _match(self._seed_rec[b], self.rec_state)
+        lanes = [
+            seed_rec if i == b else ttnn.slice(self.rec_state, (i, 0, 0, 0), (i + 1, self.Nv, self.Dk, self.Dv))
+            for i in range(B)
+        ]
+        new = lanes[0] if B == 1 else ttnn.concat(lanes, dim=0)
+        ttnn.copy(new, self.rec_state)
+        if new is not lanes[0]:
+            ttnn.deallocate(new)
+        for i, s in enumerate(lanes):
+            if i != b:  # slices we made; the seed (i==b) is freed with the stash below
+                ttnn.deallocate(s)
+        if seed_rec is not self._seed_rec[b]:
+            ttnn.deallocate(seed_rec)
+        # Conv window [1, B, D]: conv_states[0] lane b = 0; conv_states[j+1] lane b = window j.
+        D = self.qkv_dim_tp
+        zero_b = ttnn.from_torch(
+            torch.zeros(1, 1, D, dtype=torch.bfloat16),
+            dtype=self.conv_states[0].dtype, layout=ttnn.TILE_LAYOUT, device=self.mesh, mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh),
+        )
+        for k in range(self.K):
+            seed_lane = zero_b if k == 0 else _match(self._seed_conv[b][k - 1], self.conv_states[k])  # [1,1,D]
+            wins = [seed_lane if i == b else ttnn.slice(self.conv_states[k], (0, i, 0), (1, i + 1, D)) for i in range(B)]
+            if B == 1:
+                new_c = wins[0]
+            else:
+                rm = [ttnn.to_layout(w, ttnn.ROW_MAJOR_LAYOUT) for w in wins]
+                new_rm = ttnn.concat(rm, dim=1)
+                new_c = ttnn.to_layout(new_rm, ttnn.TILE_LAYOUT)
+                ttnn.deallocate(new_rm)
+                for r in rm:
+                    ttnn.deallocate(r)
+            ttnn.copy(new_c, self.conv_states[k])
+            if new_c is not wins[0]:
+                ttnn.deallocate(new_c)
+            for i, w in enumerate(wins):
+                if i != b:  # slices; seed windows freed with the stash below
+                    ttnn.deallocate(w)
+            if k > 0 and seed_lane is not self._seed_conv[b][k - 1]:
+                ttnn.deallocate(seed_lane)  # a typecast temp (not the stashed window)
+        ttnn.deallocate(zero_b)
+        # Free the slot's stashed device tensors and clear it.
+        ttnn.deallocate(self._seed_rec[b])
+        for w in self._seed_conv[b]:
+            ttnn.deallocate(w)
+        del self._seed_rec[b]
+        del self._seed_conv[b]
+
     def forward_prefill(self, x, chunk_size=128, valid_len=None, capture_state=False, seed_slot=None):
         """Causal chunk-prefill over a sequence (from scratch, zero init state).
 
@@ -308,7 +374,12 @@ class TPGatedDeltaNet:
         # state continue from the persistent buffers (zeroed at sequence start by
         # reset_state_inplace, so a from-scratch single pass reads zeros == None). The demo
         # path (_stable_state False) is unchanged: no carry, reassign state.
-        carry = self._stable_state
+        # seed_slot prefills a fresh single sequence into a batch lane; it is always
+        # from-scratch (initial_state=None), even while the batch runs in-place-state
+        # (_stable_state) mode — a running batch reseeds a slot via prefill(seed_slot=b)
+        # while _stable_state is True, and self.rec_state is then [B,...] (wrong shape for
+        # this batch-1 prefill). So force no-carry when seeding.
+        carry = self._stable_state and seed_slot is None
         if carry and self.conv_carry is None:
             self.reset_state()
 

--- a/models/demos/blackhole/qwen36/tt/layer.py
+++ b/models/demos/blackhole/qwen36/tt/layer.py
@@ -122,6 +122,7 @@ class Qwen36DecoderLayer:
         chunk_start_idx=None,
         chunk_start_idx_tensor=None,
         valid_len=None,
+        batch_slot=None,
     ):
         _norm_mode = Mode.PREFILL if mode == "prefill" else Mode.DECODE
         if self.num_devices > 1:
@@ -154,7 +155,9 @@ class Qwen36DecoderLayer:
                             chunk_start_idx_tensor=chunk_start_idx_tensor,
                         )
                     else:
-                        attn_output = self.attention.forward_prefill(attn_input, cos, sin)
+                        attn_output = self.attention.forward_prefill(
+                            attn_input, cos, sin, batch_slot=(batch_slot if batch_slot is not None else 0)
+                        )
                 else:
                     attn_output = self.attention.forward_decode(
                         attn_input, position_tensor, cos, sin, page_table=page_table
@@ -163,9 +166,17 @@ class Qwen36DecoderLayer:
                 # GDN carries its recurrent/conv state internally (capture_state on
                 # prefill, read on decode); it has no paged KV, so page_table is N/A.
                 if mode == "prefill":
-                    attn_output = self.attention.forward_prefill(
-                        attn_input, chunk_size=chunk_size, valid_len=valid_len, capture_state=True
-                    )
+                    # batch_slot set → batched-decode seeding: stash this sequence's state
+                    # for the given lane (finalize_seed assembles [B,...] later). Otherwise
+                    # the single-sequence capture_state path (unchanged).
+                    if batch_slot is not None:
+                        attn_output = self.attention.forward_prefill(
+                            attn_input, chunk_size=chunk_size, valid_len=valid_len, seed_slot=batch_slot
+                        )
+                    else:
+                        attn_output = self.attention.forward_prefill(
+                            attn_input, chunk_size=chunk_size, valid_len=valid_len, capture_state=True
+                        )
                 else:
                     attn_output = self.attention.forward_decode(attn_input)
         elif self.is_full_attention:

--- a/models/demos/blackhole/qwen36/tt/mlp.py
+++ b/models/demos/blackhole/qwen36/tt/mlp.py
@@ -18,6 +18,7 @@ class MLPWeights:
     w1: ttnn.Tensor  # gate_proj  [in, out], bfloat4_b
     w2: ttnn.Tensor  # down_proj  [in, out], bfloat8_b
     w3: ttnn.Tensor  # up_proj    [in, out], bfloat4_b
+    w13: ttnn.Tensor = None  # TP-only fused [gate|up] = concat(w1,w3,dim=-1); one decode matmul
 
 
 def load_mlp_weights(mesh_device, state_dict, tensor_cache_path=None, args=None) -> MLPWeights:
@@ -36,32 +37,42 @@ def load_mlp_weights(mesh_device, state_dict, tensor_cache_path=None, args=None)
         # each device's shard INTERLEAVED in DRAM so a regular ttnn.linear serves
         # both decode (M=1) and prefill (M=seq_len). DRAM-width-sharding the
         # weights for a faster decode matmul is a later optimization.
-        return MLPWeights(
-            w1=tpc.shard_w(
-                state_dict["gate_proj.weight"],
-                mesh_device,
-                dim=-1,
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                cache_path=cache("gate_proj"),
-                dtype=ttnn.bfloat4_b,
-            ),
-            w3=tpc.shard_w(
-                state_dict["up_proj.weight"],
-                mesh_device,
-                dim=-1,
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                cache_path=cache("up_proj"),
-                dtype=ttnn.bfloat4_b,
-            ),
-            w2=tpc.shard_w(
-                state_dict["down_proj.weight"],
-                mesh_device,
-                dim=0,
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                cache_path=cache("down_proj"),
-                dtype=ttnn.bfloat8_b,
-            ),
+        w1 = tpc.shard_w(
+            state_dict["gate_proj.weight"],
+            mesh_device,
+            dim=-1,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            cache_path=cache("gate_proj"),
+            dtype=ttnn.bfloat4_b,
         )
+        w3 = tpc.shard_w(
+            state_dict["up_proj.weight"],
+            mesh_device,
+            dim=-1,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            cache_path=cache("up_proj"),
+            dtype=ttnn.bfloat4_b,
+        )
+        w2 = tpc.shard_w(
+            state_dict["down_proj.weight"],
+            mesh_device,
+            dim=0,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            cache_path=cache("down_proj"),
+            dtype=ttnn.bfloat8_b,
+        )
+        # Fused gate|up: concat each device's column-parallel shards along the output dim
+        # (per-device concat preserves each shard) → ONE decode matmul instead of two.
+        # Branch's mlp() uses a single fused gate/up matmul; saves ~64 dispatches/step.
+        # QWEN_SKIP_FUSED_WEIGHTS skips building it (DRAM-cost A/B measurement only; forward needs it).
+        if os.environ.get("QWEN_SKIP_FUSED_WEIGHTS") == "1":
+            return MLPWeights(w1=w1, w3=w3, w2=w2, w13=None)
+        w13 = ttnn.concat([w1, w3], dim=-1, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        # TP _forward_tp uses ONLY w13 (both prefill and decode) — w1/w3 are dead once w13 exists.
+        # Free them so the fused weight replaces (not duplicates) the separate gate/up (~DRAM saved).
+        ttnn.deallocate(w1)
+        ttnn.deallocate(w3)
+        return MLPWeights(w1=None, w3=None, w2=w2, w13=w13)
 
     def load(name, dtype):
         t = state_dict[f"{name}.weight"].T.contiguous()  # [in, out] for ttnn.linear
@@ -133,10 +144,14 @@ class Qwen36MLP:
         ckc = self.compute_kernel_config_decode if T <= 1 else self.compute_kernel_config
 
         # Interleaved weights → let ttnn auto-select the matmul program (serves
-        # both decode and prefill). SILU applied separately, then gate * up.
+        # both decode and prefill). Fused gate|up matmul (w13), then split + SwiGLU.
         mc = ttnn.DRAM_MEMORY_CONFIG
-        w1_out = ttnn.linear(x, w.w1, compute_kernel_config=ckc, memory_config=mc)
-        w3_out = ttnn.linear(x, w.w3, compute_kernel_config=ckc, memory_config=mc)
+        gu = ttnn.linear(x, w.w13, compute_kernel_config=ckc, memory_config=mc)
+        Ip = gu.shape[-1] // 2  # per-device gate/up shard width
+        Bt = gu.shape[-2]
+        w1_out = ttnn.slice(gu, (0, 0, 0, 0), (1, 1, Bt, Ip))
+        w3_out = ttnn.slice(gu, (0, 0, 0, Ip), (1, 1, Bt, 2 * Ip))
+        ttnn.deallocate(gu)
         w1_act = ttnn.silu(w1_out, memory_config=mc)
         ttnn.deallocate(w1_out)
         hidden = ttnn.mul(w1_act, w3_out, memory_config=mc)

--- a/models/demos/blackhole/qwen36/tt/model.py
+++ b/models/demos/blackhole/qwen36/tt/model.py
@@ -269,6 +269,133 @@ class Qwen36Model:
             out.append(nxt)
         return out
 
+    def prefill_seed_tp(self, token_ids, valid_len, batch_slot):
+        """Batched-decode seeding prefill (num_devices>1): run one sequence's prompt
+        through the TP layers and write its state into lane `batch_slot` — attention
+        KV cache lane, GDN state stashed for finalize_seed. Mirrors prefill_tp but
+        threads batch_slot. Returns torch next-token logits [vocab_size] at valid_len-1.
+        """
+        from models.demos.blackhole.qwen36.tt.attention.rope_tp import rot_mats_prefill
+
+        B, T = token_ids.shape
+        assert B == 1, "prefill_seed_tp takes one sequence at a time (its slot is batch_slot)"
+
+        tok = ttnn.from_torch(
+            token_ids.to(torch.int32),
+            dtype=ttnn.uint32,
+            device=self.device,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.device),
+        )
+        x = self.embd(tok)
+        x = ttnn.reshape(x, (1, 1, T, x.shape[-1]))
+        cos, sin = rot_mats_prefill(self.device, self.args.rope_head_dim, T, self.args.rope_theta)
+
+        for layer in self.layers:
+            x = layer.forward(
+                x, cos=cos, sin=sin, mode="prefill", chunk_size=128, valid_len=valid_len, batch_slot=batch_slot
+            )
+
+        sel = torch.zeros(1, 1, 1, T, dtype=torch.float32)
+        sel[0, 0, 0, valid_len - 1] = 1.0
+        sel_tt = ttnn.from_torch(
+            sel, dtype=x.dtype, layout=ttnn.TILE_LAYOUT, device=self.device, mesh_mapper=ttnn.ReplicateTensorToMesh(self.device)
+        )
+        x_last = ttnn.matmul(sel_tt, x)
+        ttnn.deallocate(sel_tt)
+        ttnn.deallocate(x)
+        x_last = ttnn.to_memory_config(x_last, ttnn.DRAM_MEMORY_CONFIG)
+        x_last = self.norm(x_last, mode=Mode.PREFILL)
+        logits = ttnn.linear(x_last, self.lm_head_weight)
+        lt = ttnn.to_torch(logits, mesh_composer=ttnn.ConcatMeshToTensor(self.device, dim=0))
+        return lt[0].reshape(-1)[: self.vocab_size]
+
+    def decode_tp_batched(self, token_ids, positions):
+        """Single-step TP decode for B sequences at once (B = args.max_batch_size).
+
+        token_ids: list[int] length B (one current token per sequence).
+        positions: list[int] length B (each sequence's absolute decode position).
+        Returns torch logits [B, vocab_size]. Continues from the batched KV + GDN
+        state left by prefill_seed_tp / finalize_seed / prior batched decode steps.
+        """
+        from models.demos.blackhole.qwen36.tt.attention.rope_tp import rot_mats_decode
+
+        B = len(token_ids)
+        tok = ttnn.from_torch(
+            torch.tensor([token_ids], dtype=torch.int32),  # [1, B]
+            dtype=ttnn.uint32,
+            device=self.device,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.device),
+        )
+        x = self.embd(tok)  # [1, B, dim_frac]
+        x = ttnn.reshape(x, (1, 1, B, x.shape[-1]))  # [1,1,B,dim_frac]
+        cos, sin = rot_mats_decode(
+            self.device,
+            self.args.rope_head_dim,
+            self.args.max_seq_len,
+            self.args.rope_theta,
+            torch.tensor(positions, dtype=torch.int32),
+        )
+        cur_pos_tt = ttnn.from_torch(
+            torch.tensor(positions, dtype=torch.int32),
+            dtype=ttnn.int32,
+            device=self.device,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.device),
+        )
+        for layer in self.layers:
+            x = layer.forward(x, cos=cos, sin=sin, mode="decode", position_tensor=cur_pos_tt)
+        x = self.norm(x, mode=Mode.DECODE)
+        logits = ttnn.linear(x, self.lm_head_weight)  # [1,1,B,vocab] replicated
+        lt = ttnn.to_torch(logits, mesh_composer=ttnn.ConcatMeshToTensor(self.device, dim=0))
+        return lt[0].reshape(B, -1)[:, : self.vocab_size]
+
+    def generate_tp_batched(self, prompts, max_new_tokens=20, eos_id=None):
+        """Stateful batched TP generation for B = len(prompts) sequences (num_devices>1).
+
+        Each prompt is prefilled independently into its own batch lane (prefill_seed_tp),
+        the GDN state is assembled with finalize_seed, then all B sequences decode in
+        lockstep — one batched forward per step. Returns list[list[int]] of new ids.
+
+        B must equal args.max_batch_size (the module buffers are sized to it).
+        """
+        import math as _math
+
+        B = len(prompts)
+        assert B == self.args.max_batch_size, (
+            f"generate_tp_batched expects len(prompts)=={self.args.max_batch_size} (args.max_batch_size); got {B}"
+        )
+        self.reset_tp()
+
+        positions = []
+        cur = []
+        for b, prompt_ids in enumerate(prompts):
+            T = len(prompt_ids)
+            T_pad = max(128, _math.ceil(T / 128) * 128)
+            padded = list(prompt_ids) + [0] * (T_pad - T)
+            logits = self.prefill_seed_tp(torch.tensor([padded], dtype=torch.long), valid_len=T, batch_slot=b)
+            cur.append(int(torch.argmax(logits).item()))
+            positions.append(T)
+
+        # Assemble the per-slot GDN state into the [B,...] decode buffers.
+        for layer in self.layers:
+            if not layer.is_full_attention:
+                layer.attention.finalize_seed(B)
+
+        out = [[c] for c in cur]
+        done = [False] * B
+        for _ in range(max_new_tokens - 1):
+            logits = self.decode_tp_batched(cur, positions)  # [B, vocab]
+            nxt = [int(torch.argmax(logits[b]).item()) for b in range(B)]
+            for b in range(B):
+                positions[b] += 1
+                if not done[b]:
+                    out[b].append(nxt[b])
+                    if eos_id is not None and nxt[b] == eos_id:
+                        done[b] = True
+                cur[b] = nxt[b]
+            if all(done):
+                break
+        return out
+
     def prefill(self, token_ids):
         B, T = token_ids.shape
 

--- a/models/demos/blackhole/qwen36/tt/model.py
+++ b/models/demos/blackhole/qwen36/tt/model.py
@@ -309,11 +309,26 @@ class Qwen36Model:
         lt = ttnn.to_torch(logits, mesh_composer=ttnn.ConcatMeshToTensor(self.device, dim=0))
         return lt[0].reshape(-1)[: self.vocab_size]
 
+    def _decode_forward_batched(self, tokens_tt, cur_pos_tt, cos, sin, B):
+        """Core batched decode forward (B lanes) on device. Consumes device tensors:
+        tokens_tt (B tokens, either [1,B] or [B,1]), cur_pos_tt [B] int32, cos/sin
+        rope_tp-format [1,B,1,rd]. Returns logits device tensor [1,1,B,vocab] (replicated).
+        Shared by the eager (decode_tp_batched) and traced (generate_tp_batched use_trace)
+        paths so the captured trace is bit-identical to the eager step. Lane order is
+        preserved: flattening either token layout puts lane b at dim-2 index b."""
+        x = self.embd(tokens_tt)  # [.,.,dim_frac], B*dim_frac elements
+        x = ttnn.reshape(x, (1, 1, B, x.shape[-1]))  # [1,1,B,dim_frac]
+        for layer in self.layers:
+            x = layer.forward(x, cos=cos, sin=sin, mode="decode", position_tensor=cur_pos_tt)
+        x = self.norm(x, mode=Mode.DECODE)
+        return ttnn.linear(x, self.lm_head_weight)  # [1,1,B,vocab] replicated
+
     def decode_tp_batched(self, token_ids, positions):
-        """Single-step TP decode for B sequences at once (B = args.max_batch_size).
+        """Single-step eager TP decode for B sequences at once (B = args.max_batch_size).
 
         token_ids: list[int] length B (one current token per sequence).
-        positions: list[int] length B (each sequence's absolute decode position).
+        positions: list[int] length B (each sequence's absolute decode position; may
+        differ across lanes — per-user rope via rot_mats_decode).
         Returns torch logits [B, vocab_size]. Continues from the batched KV + GDN
         state left by prefill_seed_tp / finalize_seed / prior batched decode steps.
         """
@@ -326,8 +341,6 @@ class Qwen36Model:
             device=self.device,
             mesh_mapper=ttnn.ReplicateTensorToMesh(self.device),
         )
-        x = self.embd(tok)  # [1, B, dim_frac]
-        x = ttnn.reshape(x, (1, 1, B, x.shape[-1]))  # [1,1,B,dim_frac]
         cos, sin = rot_mats_decode(
             self.device,
             self.args.rope_head_dim,
@@ -341,14 +354,11 @@ class Qwen36Model:
             device=self.device,
             mesh_mapper=ttnn.ReplicateTensorToMesh(self.device),
         )
-        for layer in self.layers:
-            x = layer.forward(x, cos=cos, sin=sin, mode="decode", position_tensor=cur_pos_tt)
-        x = self.norm(x, mode=Mode.DECODE)
-        logits = ttnn.linear(x, self.lm_head_weight)  # [1,1,B,vocab] replicated
+        logits = self._decode_forward_batched(tok, cur_pos_tt, cos, sin, B)
         lt = ttnn.to_torch(logits, mesh_composer=ttnn.ConcatMeshToTensor(self.device, dim=0))
         return lt[0].reshape(B, -1)[:, : self.vocab_size]
 
-    def generate_tp_batched(self, prompts, max_new_tokens=20, eos_id=None):
+    def generate_tp_batched(self, prompts, max_new_tokens=20, eos_id=None, use_trace=False):
         """Stateful batched TP generation for B = len(prompts) sequences (num_devices>1).
 
         Each prompt is prefilled independently into its own batch lane (prefill_seed_tp),
@@ -356,6 +366,12 @@ class Qwen36Model:
         lockstep — one batched forward per step. Returns list[list[int]] of new ids.
 
         B must equal args.max_batch_size (the module buffers are sized to it).
+
+        use_trace: capture the batched decode step ONCE as a ttnn trace and replay it
+        (DMA-updating the fixed input buffers each step) — ~large decode speedup. Requires
+        EQUAL-length prompts: the traced path packs a single shared decode position for all
+        lanes (ragged per-user positions would need per-step re-capture). The eager path
+        (default) has no such restriction.
         """
         import math as _math
 
@@ -380,6 +396,9 @@ class Qwen36Model:
             if not layer.is_full_attention:
                 layer.attention.finalize_seed(B)
 
+        if use_trace:
+            return self._generate_tp_batched_traced(cur, positions, max_new_tokens, eos_id, B)
+
         out = [[c] for c in cur]
         done = [False] * B
         for _ in range(max_new_tokens - 1):
@@ -394,6 +413,113 @@ class Qwen36Model:
                 cur[b] = nxt[b]
             if all(done):
                 break
+        return out
+
+    def _generate_tp_batched_traced(self, cur, positions, max_new_tokens, eos_id, B):
+        """Captured-trace batched decode replay (B lanes, supports per-user positions).
+
+        Mirrors the demo's single-sequence traced decode (text_demo._run_tp_generation) but
+        for B lanes: fixed input buffers (token / cur_pos / cos / sin) built once via the SAME
+        rot_mats_decode the eager decode_tp_batched uses, so the captured forward is bit-identical
+        to the eager step (execute_trace replay == eager re-issue). Each step DMA-updates the fixed
+        buffers in place (ttnn.copy) and replays the trace. The throwaway capture run advances the
+        GDN recurrent/conv state non-idempotently, so we snapshot it before and restore after
+        (preserving the buffer addresses the trace baked in). GDN state is switched to in-place
+        (_stable_state) so the decode's recurrent write lands in the captured fixed buffer.
+        """
+        from models.demos.blackhole.qwen36.tt.attention.rope_tp import rot_mats_decode
+
+        mesh = self.mesh_device
+        gdn = [layer.attention for layer in self.layers if not layer.is_full_attention]
+        for dn in gdn:
+            dn._stable_state = True  # in-place recurrent write → trace-safe fixed address
+
+        rep = ttnn.ReplicateTensorToMesh(self.device)
+
+        def _rope(pos_list):
+            return rot_mats_decode(
+                self.device, self.args.rope_head_dim, self.args.max_seq_len, self.args.rope_theta,
+                torch.tensor(pos_list, dtype=torch.int32),
+            )
+
+        # Fixed input buffers (persist across replays; updated in place by _update).
+        tok_buf = ttnn.from_torch(
+            torch.tensor([cur], dtype=torch.int32), dtype=ttnn.uint32, device=self.device, mesh_mapper=rep
+        )
+        cur_pos_buf = ttnn.from_torch(
+            torch.tensor(positions, dtype=torch.int32), dtype=ttnn.int32, device=self.device, mesh_mapper=rep
+        )
+        cos_buf, sin_buf = _rope(positions)
+
+        def _update(cur_tokens, pos_list):
+            t = ttnn.from_torch(
+                torch.tensor([cur_tokens], dtype=torch.int32), dtype=ttnn.uint32, device=self.device, mesh_mapper=rep
+            )
+            ttnn.copy(t, tok_buf)
+            ttnn.deallocate(t)
+            p = ttnn.from_torch(
+                torch.tensor(pos_list, dtype=torch.int32), dtype=ttnn.int32, device=self.device, mesh_mapper=rep
+            )
+            ttnn.copy(p, cur_pos_buf)
+            ttnn.deallocate(p)
+            c, s = _rope(pos_list)
+            ttnn.copy(c, cos_buf)
+            ttnn.copy(s, sin_buf)
+            ttnn.deallocate(c)
+            ttnn.deallocate(s)
+
+        def _forward():
+            return self._decode_forward_batched(tok_buf, cur_pos_buf, cos_buf, sin_buf, B)
+
+        def _read(out_tt):
+            lt = ttnn.to_torch(out_tt, mesh_composer=ttnn.ConcatMeshToTensor(self.device, dim=0))
+            return lt[0].reshape(B, -1)[:, : self.vocab_size]
+
+        # Per-device GDN state snapshot/restore around the throwaway capture.
+        def _snapshot():
+            comp = ttnn.ConcatMeshToTensor(mesh, dim=0)
+            return [
+                (ttnn.to_torch(dn.rec_state, mesh_composer=comp), [ttnn.to_torch(c, mesh_composer=comp) for c in dn.conv_states])
+                for dn in gdn
+            ]
+
+        def _restore(snap):
+            mapper = ttnn.ShardTensorToMesh(mesh, dim=0)
+            for dn, (rec, convs) in zip(gdn, snap):
+                r = ttnn.from_torch(rec, dtype=dn.rec_state.dtype, layout=ttnn.TILE_LAYOUT, device=mesh, mesh_mapper=mapper)
+                ttnn.copy(r, dn.rec_state)
+                ttnn.deallocate(r)
+                for j, c in enumerate(convs):
+                    cc = ttnn.from_torch(c, dtype=dn.conv_states[j].dtype, layout=ttnn.TILE_LAYOUT, device=mesh, mesh_mapper=mapper)
+                    ttnn.copy(cc, dn.conv_states[j])
+                    ttnn.deallocate(cc)
+
+        snap = _snapshot()
+        _forward()  # eager compile of the decode programs (advances GDN state)
+        trace_id = ttnn.begin_trace_capture(mesh, cq_id=0)
+        tt_logits = _forward()
+        ttnn.end_trace_capture(mesh, trace_id, cq_id=0)
+        _restore(snap)  # rewind GDN state to exact post-prefill values
+
+        out = [[c] for c in cur]
+        done = [False] * B
+        pos = list(positions)
+        for _ in range(max_new_tokens - 1):
+            _update(cur, pos)  # feed the current tokens at their per-user positions
+            ttnn.execute_trace(mesh, trace_id, cq_id=0, blocking=False)
+            ttnn.synchronize_device(mesh)
+            logits = _read(tt_logits)  # [B, vocab]
+            nxt = [int(torch.argmax(logits[b]).item()) for b in range(B)]
+            for b in range(B):
+                if not done[b]:
+                    out[b].append(nxt[b])
+                    if eos_id is not None and nxt[b] == eos_id:
+                        done[b] = True
+                cur[b] = nxt[b]
+                pos[b] += 1
+            if all(done):
+                break
+        ttnn.release_trace(mesh, trace_id)
         return out
 
     def prefill(self, token_ids):

--- a/models/demos/blackhole/qwen36/tt/model.py
+++ b/models/demos/blackhole/qwen36/tt/model.py
@@ -433,6 +433,77 @@ class Qwen36Model:
                 break
         return out
 
+    def generate_tp_batched_continuous(self, prompts, max_new_tokens=20, eos_id=None):
+        """Continuous-batching generation: N prompts through B = max_batch_size decode slots.
+
+        Fills the B slots with the first B prompts, decodes all lanes in lockstep, and as each
+        slot's sequence completes (max_new_tokens or EOS) reseeds that slot in place with the
+        next queued prompt (reseed_slot_tp) — the running lanes are never perturbed (Step 3).
+        Returns list[list[int]] of the N sequences' generated ids, in prompt order.
+
+        This is the model-level demonstration of continuous batching; the vLLM plugin
+        (qwen36_vllm.py) drives the same primitives from the serving scheduler.
+        """
+        import math as _math
+
+        B = self.args.max_batch_size
+        N = len(prompts)
+        assert N >= 1
+
+        def _seed(prompt_ids):
+            T = len(prompt_ids)
+            T_pad = max(128, _math.ceil(T / 128) * 128)
+            padded = list(prompt_ids) + [0] * (T_pad - T)
+            return padded, T
+
+        self.reset_tp()
+        outputs = [[] for _ in range(N)]
+        slot_pidx = [i if i < N else -1 for i in range(B)]  # prompt in each slot; -1 = filler/idle
+        cur = [0] * B
+        positions = [0] * B
+        produced = [0] * B
+        # Initial fill: prompts 0..B-1 (a filler prompt occupies any extra slots when N<B).
+        for s in range(B):
+            padded, T = _seed(prompts[slot_pidx[s]] if slot_pidx[s] >= 0 else prompts[0])
+            lg = self.prefill_seed_tp(torch.tensor([padded], dtype=torch.long), valid_len=T, batch_slot=s)
+            cur[s] = int(torch.argmax(lg).item())
+            positions[s] = T
+            if slot_pidx[s] >= 0:
+                outputs[slot_pidx[s]].append(cur[s])
+                produced[s] = 1
+        for layer in self.layers:
+            if not layer.is_full_attention:
+                layer.attention.finalize_seed(B)
+
+        next_prompt = B  # next queued prompt index
+        active = sum(1 for s in slot_pidx if s >= 0)
+        while active > 0:
+            logits = self.decode_tp_batched(cur, positions)  # [B, vocab]
+            nxt = [int(torch.argmax(logits[s]).item()) for s in range(B)]
+            for s in range(B):
+                if slot_pidx[s] < 0:
+                    continue
+                pidx = slot_pidx[s]
+                outputs[pidx].append(nxt[s])
+                produced[s] += 1
+                cur[s] = nxt[s]
+                positions[s] += 1
+                finished = produced[s] >= max_new_tokens or (eos_id is not None and nxt[s] == eos_id)
+                if finished:
+                    if next_prompt < N:
+                        # Continuous-batching join: reuse this slot for the next queued prompt.
+                        tok, newpos = self.reseed_slot_tp(prompts[next_prompt], slot=s)
+                        slot_pidx[s] = next_prompt
+                        cur[s] = tok
+                        positions[s] = newpos
+                        produced[s] = 1
+                        outputs[next_prompt].append(tok)
+                        next_prompt += 1
+                    else:
+                        slot_pidx[s] = -1
+                        active -= 1
+        return outputs
+
     def _generate_tp_batched_traced(self, cur, positions, max_new_tokens, eos_id, B):
         """Captured-trace batched decode replay (B lanes, supports per-user positions).
 

--- a/models/demos/blackhole/qwen36/tt/model.py
+++ b/models/demos/blackhole/qwen36/tt/model.py
@@ -6,6 +6,7 @@ Assembly: tok_embeddings -> 32 x Qwen36DecoderLayer -> RMSNorm -> LM Head
 Manages hybrid state: KV cache (8 attention layers) + recurrent state (24 DeltaNet layers).
 """
 import math
+import os
 
 import torch
 from loguru import logger
@@ -520,8 +521,17 @@ class Qwen36Model:
 
         mesh = self.mesh_device
         gdn = [layer.attention for layer in self.layers if not layer.is_full_attention]
+        _fused = os.environ.get("QWEN_GDN_FUSED_DECODE") == "1"
         for dn in gdn:
             dn._stable_state = True  # in-place recurrent write → trace-safe fixed address
+            # Fused decode keeps its recurrent state in bf16 (the kernel + its batch-flatten reshape
+            # are bf16). Under trace the buffer address is baked in, and the fused step copies a bf16
+            # new_rec into it in place — so materialize a bf16 fixed buffer here (the eager path
+            # tolerates fp32 by re-casting per step, but the traced in-place copy needs matching dtype).
+            if _fused and dn.rec_state is not None and dn.rec_state.dtype != ttnn.bfloat16:
+                _old = dn.rec_state
+                dn.rec_state = ttnn.typecast(_old, ttnn.bfloat16)
+                ttnn.deallocate(_old)
 
         rep = ttnn.ReplicateTensorToMesh(self.device)
 

--- a/models/demos/blackhole/qwen36/tt/model.py
+++ b/models/demos/blackhole/qwen36/tt/model.py
@@ -309,6 +309,24 @@ class Qwen36Model:
         lt = ttnn.to_torch(logits, mesh_composer=ttnn.ConcatMeshToTensor(self.device, dim=0))
         return lt[0].reshape(-1)[: self.vocab_size]
 
+    def reseed_slot_tp(self, prompt_ids, slot):
+        """Continuous-batching join: replace batch lane `slot` with a new sequence mid-flight,
+        leaving the other lanes' running KV / GDN state untouched. Prefills the new prompt into
+        lane `slot` (attention KV via fill_cache(batch_slot), GDN state stashed) then writes the
+        GDN state into lane `slot` in place (reseed_slot). Returns (first_token_id, next_position)
+        for the new sequence; the caller resets that lane's decode position to next_position.
+        """
+        import math as _math
+
+        T = len(prompt_ids)
+        T_pad = max(128, _math.ceil(T / 128) * 128)
+        padded = list(prompt_ids) + [0] * (T_pad - T)
+        logits = self.prefill_seed_tp(torch.tensor([padded], dtype=torch.long), valid_len=T, batch_slot=slot)
+        for layer in self.layers:
+            if not layer.is_full_attention:
+                layer.attention.reseed_slot(slot)
+        return int(torch.argmax(logits).item()), T
+
     def _decode_forward_batched(self, tokens_tt, cur_pos_tt, cos, sin, B):
         """Core batched decode forward (B lanes) on device. Consumes device tensors:
         tokens_tt (B tokens, either [1,B] or [B,1]), cur_pos_tt [B] int32, cos/sin

--- a/models/demos/blackhole/qwen36/tt/qwen36_vllm.py
+++ b/models/demos/blackhole/qwen36/tt/qwen36_vllm.py
@@ -76,16 +76,14 @@ class Qwen36ForCausalLM(Generator, SupportsMultiModal):
         max_num_seqs: int | None = None,
         **kwargs,
     ) -> int:
-        """All-user KV-cache token capacity = served context length (B=1).
+        """All-user KV-cache token capacity = served context length × max_num_seqs.
 
-        Qwen3.5/3.6 serve one sequence at a time (max_concurrency=1), so the whole
-        paged KV cache belongs to a single user and its capacity is exactly the
-        served context length — max_model_len, i.e. the catalog's max_context.
-        Deriving from max_model_len, instead of the inherited 131072 fallback, lets
-        these models serve at the full requested ISL (e.g. 256K = 262144): the
-        chunk-outer prefill and the full-KV page-table sizing in
-        warmup_model_prefill already scale to whatever KV cache vLLM allocates.
-        The * max_num_seqs keeps the all-user semantics correct if B ever grows.
+        Per-user capacity is the served context length — max_model_len, i.e. the catalog's
+        max_context. Deriving from max_model_len, instead of the inherited 131072 fallback,
+        lets these models serve at the full requested ISL (e.g. 256K = 262144): the
+        chunk-outer prefill and the full-KV page-table sizing in warmup_model_prefill already
+        scale to whatever KV cache vLLM allocates. The × max_num_seqs gives the all-user total
+        for continuous batching (max_num_seqs decode slots; B=1 → single-sequence serving).
         """
         if max_model_len is not None:
             return int(max_model_len) * int(max_num_seqs or 1)
@@ -125,8 +123,14 @@ class Qwen36ForCausalLM(Generator, SupportsMultiModal):
         return cls([model], [args], mesh_device)
 
     def allocate_kv_cache(self, kv_cache_shape, dtype, num_layers):
-        """Allocate paged KV (8 attn layers) + external GDN state; returns the 8 KV pairs."""
-        return self.model[0].allocate_kv_caches(kv_cache_shape, ttnn.bfloat16, batch_size=1)
+        """Allocate paged KV (8 attn layers) + external GDN state; returns the 8 KV pairs.
+
+        Sized to args.max_batch_size (= vLLM's max_num_seqs, threaded through
+        initialize_vllm_model → create_tt_model). At max_batch_size=1 this is the original
+        single-sequence serving; >1 allocates B-wide KV + GDN state for continuous batching
+        (the model-level loop is model.generate_tp_batched_continuous; the batched decode /
+        per-slot reseed primitives it uses are on-device validated)."""
+        return self.model[0].allocate_kv_caches(kv_cache_shape, ttnn.bfloat16, batch_size=self.model[0].args.max_batch_size)
 
     def prefill_forward(self, tokens, page_table, kv_cache, prompt_lens, **kwargs):
         """All prefill is model-owned (Generator drives decode only)."""


### PR DESCRIPTION
## Summary

Qwen3.6-27B (hybrid Gated-DeltaNet + full-attention) decode optimizations for Blackhole
**P300×2 (4-chip TP)** in `models/demos/blackhole/qwen36/`. Batched/traced decode path (Steps
1–4) + fused DeltaNet decode kernel wiring + QKV/MLP matmul fusion.

> **Stacked on** the ttnn op PR (`ttnn: experimental deltanet_decode_full`). Review/merge that
> first — the fused decode path calls `ttnn.experimental.deltanet_decode_full`.
> `models/tt_transformers/` is **not** modified (only imported: DistributedNorm / Generator / ccl).

**Draft** — the fused kernel is opt-in (`QWEN_GDN_FUSED_DECODE=1`); the default python recurrence
path is unchanged.

## Contents
- **Steps 1–4** (batched decode, validated on 4-chip P150x4): B>1 demo/oracle path + per-lane
  prefill seeding, fixed-buffer decode trace (traced == eager), per-slot state reseed, vLLM
  continuous-batching wiring.
- **Fused DeltaNet decode**: wire `deltanet_decode_full` into `TPGatedDeltaNet.forward_decode`
  (flattened-head H=B·Nv); raw read + ttnn gated-RMSNorm/silu(z).
- **QKV / gate-up fusion (decode & prefill)**: concat the column-parallel q|gate/k/v and gate/up
  shards per-device → one matmul + slice; free the separate weights at load so the fused weight
  **replaces** (does not duplicate) them.

## Results (B=8, P300×2, two-point traced decode)

| | tok/s (agg) | ms/step |
|---|---|---|
| python decode (Steps 1–4) | 89.1 | 90 |
| + fused DeltaNet kernel | 116.4 | 68.7 |
| + QKV/MLP matmul fusion | **117.8** | **67.9** |

- **+32%** decode throughput over the python path.
- **DRAM**: the fused-weight duplication (+1.784 GB/device) is fully recovered by freeing the
  separate weights → 6.596 GB/device (baseline), leaving DRAM for the vLLM KV cache.
- **Accuracy**: E2E coherent; vLLM decode contract (paged KV, `ttnn_decode_forward`) matches the
  concat-KV oracle at **PCC 0.9999 / argmax token-match**; 256-token decode drift-safe (bf16 state
  no worse than the fp32 python path).
- TTFT (prefill-bound, unchanged): 4k 1.79s · 16k 9.42s · 64k 43.7s · ~103k 76.5s.

## vLLM integration
- MLP/attention fusion is **transparent** (same replicated-in / fractured-out contract) — no vLLM
  wiring change, no DRAM cost after weight dedup.
- Fused GDN kernel is **opt-in**. To enable in serving: build the deltanet op into the serving
  `_ttnn.so` (stacked PR), set `QWEN_GDN_FUSED_DECODE=1`, pad decode batch to `max_num_seqs`
  (already the Step-4 batched design).

## Not reproduced: the prototype's 142 tok/s
Per-step is dispatch/latency-bound (LoFi fidelity = 0 gain); the one-core-per-head kernel makes
further op-fusion counterproductive, and CCL-count / matmul fusion each yield only a few tok/s.
The prototype's 142 came from its whole-model lower-precision/leaner design and does not transfer
via these levers.

## Tests
`test_batched_decode_tp` / `_trace_tp` / `_reseed_tp` / `_continuous_tp` ·
`test_deltanet_decode_kernel_pcc` · `test_deltanet_flat_pcc` · `test_fused_gated_e2e` ·
`test_fused_longdecode_drift` · `test_model_tp::test_model_tp_contract` · `bench_decode_tps_tp` ·
`measure_fused_weight_dram`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=yito/qwen36-tp-fused-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:yito/qwen36-tp-fused-decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=yito/qwen36-tp-fused-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:yito/qwen36-tp-fused-decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=yito/qwen36-tp-fused-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:yito/qwen36-tp-fused-decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=yito/qwen36-tp-fused-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:yito/qwen36-tp-fused-decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=yito/qwen36-tp-fused-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:yito/qwen36-tp-fused-decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=yito/qwen36-tp-fused-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:yito/qwen36-tp-fused-decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=yito/qwen36-tp-fused-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:yito/qwen36-tp-fused-decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=yito/qwen36-tp-fused-decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:yito/qwen36-tp-fused-decode)