### PR TITLE
[profiler] disable device profiler for mock device

### DIFF
--- a/tests/tt_metal/tt_metal/context/test_integration.cpp
+++ b/tests/tt_metal/tt_metal/context/test_integration.cpp
@@ -33,6 +33,8 @@
 #include "context/metal_env_accessor.hpp"
 #include "device/mock_device_util.hpp"
 #include "impl/context/metal_context.hpp"
+#include "impl/profiler/profiler_state.hpp"
+#include "impl/profiler/profiler_state_manager.hpp"
 
 #include <ttnn/graph/graph_query_op_constraints.hpp>
 #include <ttnn/operations/ccl/all_gather/all_gather.hpp>
@@ -45,6 +47,7 @@
 
 #include <limits>
 #include <optional>
+#include <string>
 
 namespace tt::tt_metal {
 
@@ -191,6 +194,192 @@ struct LegacyMockFabricCleanup {
     }
 };
 
+std::optional<std::string> SaveEnv(const char* name) {
+    const char* value = getenv(name);
+    if (value == nullptr) {
+        return std::nullopt;
+    }
+    return std::string(value);
+}
+
+void RestoreEnv(const char* name, const std::optional<std::string>& value) {
+    if (value.has_value()) {
+        setenv(name, value->c_str(), /*overwrite=*/1);
+    } else {
+        unsetenv(name);
+    }
+}
+
+// Enables the device profiler + host-device sync env flags for the object's lifetime, restoring
+// them on destruction. The flags are read when a context's RunTimeOptions is constructed, so drop
+// any existing context here and on teardown.
+struct ScopedProfilerSyncEnv {
+    ScopedProfilerSyncEnv() {
+        prev_device_profiler_ = SaveEnv("TT_METAL_DEVICE_PROFILER");
+        prev_profiler_sync_ = SaveEnv("TT_METAL_PROFILER_SYNC");
+        setenv("TT_METAL_DEVICE_PROFILER", "1", /*overwrite=*/1);
+        setenv("TT_METAL_PROFILER_SYNC", "1", /*overwrite=*/1);
+        if (MetalContext::instance_exists()) {
+            tt::tt_metal::detail::ReleaseOwnership();
+        }
+    }
+    ~ScopedProfilerSyncEnv() {
+        RestoreEnv("TT_METAL_PROFILER_SYNC", prev_profiler_sync_);
+        RestoreEnv("TT_METAL_DEVICE_PROFILER", prev_device_profiler_);
+        if (MetalContext::instance_exists()) {
+            tt::tt_metal::detail::ReleaseOwnership();
+        }
+    }
+
+    std::optional<std::string> prev_device_profiler_;
+    std::optional<std::string> prev_profiler_sync_;
+};
+
+// Enqueues a single no-op kernel on one worker core of `target`, exercising the full
+// create-program / create-kernel / JIT-compile / enqueue-workload pipeline for that context.
+void RunNoOpProgram(distributed::MeshDevice& target, const std::string& label) {
+    auto program = CreateProgram();
+    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(target.shape());
+    // Single worker core; see comment in PerformDeviceWork.
+    auto core_range = CoreRange({0, 0}, {0, 0});
+
+    CreateKernelFromString(program, "void kernel_main() {}", core_range, DataMovementConfig{});
+
+    distributed::MeshWorkload workload;
+    workload.add_program(device_range, std::move(program));
+    distributed::EnqueueMeshWorkload(target.mesh_command_queue(), workload, true);
+    log_info(tt::LogTest, "Successfully enqueued no-op program on {}", label);
+}
+
+// The real (silicon) device takes DEFAULT_CONTEXT_ID and must keep the device profiler active when
+// profiling + host-device sync were requested.
+void ExpectDeviceProfilerActiveOnSilicon(distributed::MeshDevice& silicon_mesh_device) {
+    const ContextId silicon_context_id = silicon_mesh_device.impl().get_context_id();
+    EXPECT_EQ(silicon_context_id, DEFAULT_CONTEXT_ID);
+    EXPECT_TRUE(MetalContext::instance(silicon_context_id).rtoptions().get_profiler_enabled())
+        << "Test expects device profiler option to be enabled.";
+    EXPECT_TRUE(MetalContext::instance(silicon_context_id).rtoptions().get_profiler_sync_enabled())
+        << "Test expects profiler host-device sync to be enabled.";
+    EXPECT_TRUE(getDeviceProfilerState(silicon_context_id)) << "Device profiler must remain enabled on the real device";
+}
+
+// Even though profiling + sync were requested, the device profiler must never be started on a
+// mock/emulated context.
+void ExpectDeviceProfilerSkippedOnMock(distributed::MeshDevice& mock_mesh_device) {
+    const ContextId mock_context_id = mock_mesh_device.impl().get_context_id();
+    ASSERT_NE(mock_context_id, DEFAULT_CONTEXT_ID);
+    ASSERT_TRUE(MetalContext::instance(mock_context_id).get_cluster().is_mock_or_emulated());
+    EXPECT_FALSE(getDeviceProfilerState(mock_context_id))
+        << "getDeviceProfilerState() must be false for a mock context even when profiling is requested";
+    const auto& profiler_state_manager = MetalContext::instance(mock_context_id).profiler_state_manager();
+    ASSERT_NE(profiler_state_manager, nullptr);
+    for (auto* dev : mock_mesh_device.get_devices()) {
+        EXPECT_FALSE(profiler_state_manager->device_profiler_map.contains(dev->id()))
+            << "Device profiler was started on mock device " << dev->id()
+            << " -- it must be skipped for mock/emulated clusters";
+    }
+}
+
+// Shared body: open a real silicon mesh first, then two mock meshes on the same arch. When
+// `expect_profiler` is set, also check the profiler stays on for silicon but is skipped for mock.
+void RunCoexistingMockAndSiliconDevice(bool expect_profiler) {
+    // Create silicon mesh
+    MetalEnv silicon_env;
+    const tt::ARCH silicon_arch = silicon_env.get_arch();
+
+    auto mesh_shape = silicon_env.get_system_mesh().shape();
+    auto mesh_device_config = distributed::MeshDeviceConfig(mesh_shape);
+    std::shared_ptr<distributed::MeshDevice> mesh_device = silicon_env.create_mesh_device(mesh_device_config);
+    log_info(tt::LogTest, "Created silicon mesh device with shape {}", mesh_device->shape().dims());
+
+    if (expect_profiler) {
+        ExpectDeviceProfilerActiveOnSilicon(*mesh_device);
+    }
+
+    // Create mock mesh device with 1 chip on the silicon arch
+    MetalEnv mock_env_1{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(silicon_arch, 1))};
+    auto mock_mesh_shape_1 = mock_env_1.get_system_mesh().shape();
+    auto mock_mesh_device_config_1 = distributed::MeshDeviceConfig(mock_mesh_shape_1);
+    auto mock_mesh_device_1 = mock_env_1.create_mesh_device(mock_mesh_device_config_1);
+    log_info(tt::LogTest, "Created mock mesh device with shape {}", mock_mesh_device_1->shape().dims());
+
+    // Create mock mesh device with 2 chips on the silicon arch
+    MetalEnv mock_env_2{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(silicon_arch, 2))};
+    auto mock_mesh_shape_2 = mock_env_2.get_system_mesh().shape();
+    auto mock_mesh_device_config_2 = distributed::MeshDeviceConfig(mock_mesh_shape_2);
+    auto mock_mesh_device_2 = mock_env_2.create_mesh_device(mock_mesh_device_config_2);
+    log_info(tt::LogTest, "Created mock mesh device with shape {}", mock_mesh_device_2->shape().dims());
+
+    ASSERT_EQ(mock_mesh_device_1->get_devices().size(), 1);
+    ASSERT_EQ(mock_mesh_device_2->get_devices().size(), 2);
+
+    if (expect_profiler) {
+        ExpectDeviceProfilerSkippedOnMock(*mock_mesh_device_1);
+        ExpectDeviceProfilerSkippedOnMock(*mock_mesh_device_2);
+    }
+
+    // Run a no-op program on both the silicon and mock devices in this reversed-creation-order
+    // case to confirm the JIT/compile/enqueue pipeline does not depend on which context was
+    // opened first.
+    RunNoOpProgram(*mesh_device, "silicon_mesh_device");
+    RunNoOpProgram(*mock_mesh_device_1, "mock_mesh_device_1");
+}
+
+// Shared body: open two mock meshes first, then the real silicon mesh last. When `expect_profiler`
+// is set, also check the profiler stays on for silicon but is skipped for mock.
+void RunCoexistingSiliconAndMockDevice(bool expect_profiler) {
+    // BuildEnvManager is a process-global singleton whose kernel/firmware build-state index tables
+    // are sized once from the HAL of whichever context first triggers add_build_env(). When the
+    // mock arch differs from the silicon arch (e.g. mock-BH on a WH runner), the second context
+    // ends up indexing a wrong-sized table and JIT'd kernels reference incorrect dispatch
+    // addresses, causing silicon dispatch to hang. Forge's real flow is same-arch coexistence
+    // (mock used as a compile-time stand-in for the live silicon), so probe the silicon arch and
+    // create the mock to match. Cross-arch coexistence is a separate `BuildEnvManager`-singleton
+    // limitation tracked outside #38445.
+    tt::ARCH silicon_arch;
+    {
+        MetalEnv probe;
+        silicon_arch = probe.get_arch();
+    }
+
+    // Create mock mesh device with 1 chip on the silicon arch
+    MetalEnv mock_env_1{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(silicon_arch, 1))};
+    auto mock_mesh_shape_1 = mock_env_1.get_system_mesh().shape();
+    auto mock_mesh_device_config_1 = distributed::MeshDeviceConfig(mock_mesh_shape_1);
+    std::shared_ptr<distributed::MeshDevice> mock_mesh_device_1 =
+        mock_env_1.create_mesh_device(mock_mesh_device_config_1);
+    log_info(tt::LogTest, "Created mock mesh device with shape {}", mock_mesh_device_1->shape().dims());
+
+    // Create mock mesh device with 2 chips on the silicon arch
+    MetalEnv mock_env_2{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(silicon_arch, 2))};
+    auto mock_mesh_shape_2 = mock_env_2.get_system_mesh().shape();
+    auto mock_mesh_device_config_2 = distributed::MeshDeviceConfig(mock_mesh_shape_2);
+    auto mock_mesh_device_2 = mock_env_2.create_mesh_device(mock_mesh_device_config_2);
+    log_info(tt::LogTest, "Created mock mesh device with shape {}", mock_mesh_device_2->shape().dims());
+
+    // Create silicon mesh
+    MetalEnv env;
+    auto mesh_shape = env.get_system_mesh().shape();
+    auto mesh_device_config = distributed::MeshDeviceConfig(mesh_shape);
+    std::shared_ptr<distributed::MeshDevice> mesh_device = env.create_mesh_device(mesh_device_config);
+    log_info(tt::LogTest, "Created silicon mesh device with shape {}", mesh_device->shape().dims());
+
+    ASSERT_EQ(mock_mesh_device_1->get_devices().size(), 1);
+    ASSERT_EQ(mock_mesh_device_2->get_devices().size(), 2);
+
+    if (expect_profiler) {
+        ExpectDeviceProfilerActiveOnSilicon(*mesh_device);
+        ExpectDeviceProfilerSkippedOnMock(*mock_mesh_device_1);
+        ExpectDeviceProfilerSkippedOnMock(*mock_mesh_device_2);
+    }
+
+    // Run a no-op program on both the mock and silicon devices side-by-side. This exercises the
+    // full create-program / create-kernel / JIT-compile / enqueue-workload pipeline through both
+    // contexts in the same process to validate mock+silicon coexistence (issue #38445).
+    RunNoOpProgram(*mock_mesh_device_1, "mock_mesh_device_1");
+    RunNoOpProgram(*mesh_device, "silicon_mesh_device");
+}
+
 }  // namespace
 
 TEST(MetalContextIntegrationTest, Legacy) {
@@ -300,115 +489,33 @@ TEST(MetalContextIntegrationTest, MockDeviceOnly) {
 }
 
 TEST(MetalContextIntegrationTest, CoexistingSiliconAndMockDevice) {
-    // BuildEnvManager is a process-global singleton whose kernel/firmware build-state index tables
-    // are sized once from the HAL of whichever context first triggers add_build_env(). When the
-    // mock arch differs from the silicon arch (e.g. mock-BH on a WH runner), the second context
-    // ends up indexing a wrong-sized table and JIT'd kernels reference incorrect dispatch
-    // addresses, causing silicon dispatch to hang. Forge's real flow is same-arch coexistence
-    // (mock used as a compile-time stand-in for the live silicon), so probe the silicon arch and
-    // create the mock to match. Cross-arch coexistence is a separate `BuildEnvManager`-singleton
-    // limitation tracked outside #38445.
-    tt::ARCH silicon_arch;
-    {
-        MetalEnv probe;
-        silicon_arch = probe.get_arch();
-    }
+    RunCoexistingSiliconAndMockDevice(/*expect_profiler=*/false);
+}
 
-    // Create mock mesh device with 1 chip on the silicon arch
-    MetalEnv mock_env_1{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(silicon_arch, 1))};
-    auto mock_mesh_shape_1 = mock_env_1.get_system_mesh().shape();
-    auto mock_mesh_device_config_1 = distributed::MeshDeviceConfig(mock_mesh_shape_1);
-    std::shared_ptr<distributed::MeshDevice> mock_mesh_device_1 =
-        mock_env_1.create_mesh_device(mock_mesh_device_config_1);
-    log_info(tt::LogTest, "Created mock mesh device with shape {}", mock_mesh_device_1->shape().dims());
-
-    // Create mock mesh device with 2 chips on the silicon arch
-    MetalEnv mock_env_2{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(silicon_arch, 2))};
-    auto mock_mesh_shape_2 = mock_env_2.get_system_mesh().shape();
-    auto mock_mesh_device_config_2 = distributed::MeshDeviceConfig(mock_mesh_shape_2);
-    auto mock_mesh_device_2 = mock_env_2.create_mesh_device(mock_mesh_device_config_2);
-    log_info(tt::LogTest, "Created mock mesh device with shape {}", mock_mesh_device_2->shape().dims());
-
-    // Create silicon mesh
-    MetalEnv env;
-    auto mesh_shape = env.get_system_mesh().shape();
-    auto mesh_device_config = distributed::MeshDeviceConfig(mesh_shape);
-    std::shared_ptr<distributed::MeshDevice> mesh_device = env.create_mesh_device(mesh_device_config);
-    log_info(tt::LogTest, "Created silicon mesh device with shape {}", mesh_device->shape().dims());
-
-    ASSERT_EQ(mock_mesh_device_1->get_devices().size(), 1);
-    ASSERT_EQ(mock_mesh_device_2->get_devices().size(), 2);
-
-    // Run a no-op program on both the mock and silicon devices side-by-side. This exercises the
-    // full create-program / create-kernel / JIT-compile / enqueue-workload pipeline through both
-    // contexts in the same process to validate mock+silicon coexistence (issue #38445).
-    auto run_noop_program = [](distributed::MeshDevice& target, const std::string& label) {
-        auto program = CreateProgram();
-        distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(target.shape());
-        // Single worker core; see comment in PerformDeviceWork.
-        auto core_range = CoreRange({0, 0}, {0, 0});
-
-        CreateKernelFromString(program, "void kernel_main() {}", core_range, DataMovementConfig{});
-
-        distributed::MeshWorkload workload;
-        workload.add_program(device_range, std::move(program));
-        distributed::EnqueueMeshWorkload(target.mesh_command_queue(), workload, true);
-        log_info(tt::LogTest, "Successfully enqueued no-op program on {}", label);
-    };
-
-    run_noop_program(*mock_mesh_device_1, "mock_mesh_device_1");
-    run_noop_program(*mesh_device, "silicon_mesh_device");
+// Same as CoexistingSiliconAndMockDevice, with the device profiler + host-device sync enabled
+// (regression for #48564).
+TEST(MetalContextIntegrationTest, CoexistingSiliconAndMockDeviceWithProfilerSync) {
+#if !defined(TRACY_ENABLE)
+    GTEST_SKIP() << "Requires a Tracy-enabled build (ENABLE_TRACY=ON).";
+#endif
+    ScopedProfilerSyncEnv profiler_env;
+    RunCoexistingSiliconAndMockDevice(/*expect_profiler=*/true);
 }
 
 // Same test as above but reverse the order to ensure no hangs due to unexpected internal objects created for the
 // incorrect context id. See `CoexistingSiliconAndMockDevice` for why mock arch is matched to silicon arch.
 TEST(MetalContextIntegrationTest, CoexistingMockAndSiliconDevice) {
-    // Create silicon mesh
-    MetalEnv silicon_env;
-    const tt::ARCH silicon_arch = silicon_env.get_arch();
+    RunCoexistingMockAndSiliconDevice(/*expect_profiler=*/false);
+}
 
-    auto mesh_shape = silicon_env.get_system_mesh().shape();
-    auto mesh_device_config = distributed::MeshDeviceConfig(mesh_shape);
-    std::shared_ptr<distributed::MeshDevice> mesh_device = silicon_env.create_mesh_device(mesh_device_config);
-    log_info(tt::LogTest, "Created silicon mesh device with shape {}", mesh_device->shape().dims());
-
-    // Create mock mesh device with 1 chip on the silicon arch
-    MetalEnv mock_env_1{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(silicon_arch, 1))};
-    auto mock_mesh_shape_1 = mock_env_1.get_system_mesh().shape();
-    auto mock_mesh_device_config_1 = distributed::MeshDeviceConfig(mock_mesh_shape_1);
-    auto mock_mesh_device_1 = mock_env_1.create_mesh_device(mock_mesh_device_config_1);
-    log_info(tt::LogTest, "Created mock mesh device with shape {}", mock_mesh_device_1->shape().dims());
-
-    // Create mock mesh device with 2 chips on the silicon arch
-    MetalEnv mock_env_2{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(silicon_arch, 2))};
-
-    auto mock_mesh_shape_2 = mock_env_2.get_system_mesh().shape();
-    auto mock_mesh_device_config_2 = distributed::MeshDeviceConfig(mock_mesh_shape_2);
-    auto mock_mesh_device_2 = mock_env_2.create_mesh_device(mock_mesh_device_config_2);
-    log_info(tt::LogTest, "Created mock mesh device with shape {}", mock_mesh_device_2->shape().dims());
-
-    ASSERT_EQ(mock_mesh_device_1->get_devices().size(), 1);
-    ASSERT_EQ(mock_mesh_device_2->get_devices().size(), 2);
-
-    // Run a no-op program on both the silicon and mock devices in this reversed-creation-order
-    // case to confirm the JIT/compile/enqueue pipeline does not depend on which context was
-    // opened first.
-    auto run_noop_program = [](distributed::MeshDevice& target, const std::string& label) {
-        auto program = CreateProgram();
-        distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(target.shape());
-        // Single worker core; see comment in PerformDeviceWork.
-        auto core_range = CoreRange({0, 0}, {0, 0});
-
-        CreateKernelFromString(program, "void kernel_main() {}", core_range, DataMovementConfig{});
-
-        distributed::MeshWorkload workload;
-        workload.add_program(device_range, std::move(program));
-        distributed::EnqueueMeshWorkload(target.mesh_command_queue(), workload, true);
-        log_info(tt::LogTest, "Successfully enqueued no-op program on {}", label);
-    };
-
-    run_noop_program(*mesh_device, "silicon_mesh_device");
-    run_noop_program(*mock_mesh_device_1, "mock_mesh_device_1");
+// Same as CoexistingMockAndSiliconDevice, with the device profiler + host-device sync enabled
+// (regression for #48564).
+TEST(MetalContextIntegrationTest, CoexistingMockAndSiliconDeviceWithProfilerSync) {
+#if !defined(TRACY_ENABLE)
+    GTEST_SKIP() << "Requires a Tracy-enabled build (ENABLE_TRACY=ON).";
+#endif
+    ScopedProfilerSyncEnv profiler_env;
+    RunCoexistingMockAndSiliconDevice(/*expect_profiler=*/true);
 }
 
 TEST(MetalContextIntegrationTest, ForkMockAndRealDevice) {

--- a/tests/tt_metal/tt_metal/device/test_mock_device_api.cpp
+++ b/tests/tt_metal/tt_metal/device/test_mock_device_api.cpp
@@ -5,9 +5,16 @@
 #include <gtest/gtest.h>
 #include <tt-metalium/experimental/mock_device/mock_device.hpp>
 #include <tt-metalium/distributed.hpp>
+#include <tt-metalium/tt_metal.hpp>
 #include <umd/device/types/arch.hpp>
 
+#include <cstdlib>
+#include <optional>
+#include <string>
+
 #include "impl/context/metal_context.hpp"
+#include "impl/profiler/profiler_state.hpp"
+#include "impl/profiler/profiler_state_manager.hpp"
 #include "llrt/get_platform_architecture.hpp"
 #include "llrt/tt_cluster.hpp"
 
@@ -117,6 +124,72 @@ TEST_F(MockDeviceAPIFixture, SwitchFromMockToRealHardware) {
     auto desc = experimental::get_mock_cluster_desc();
     ASSERT_TRUE(desc.has_value());
     EXPECT_EQ(*desc, "wormhole_N300.yaml");
+}
+
+class MockDeviceProfilerFixture : public ::testing::Test {
+protected:
+    void SetUp() override {
+#if !defined(TRACY_ENABLE)
+        GTEST_SKIP() << "Requires a Tracy-enabled build (ENABLE_TRACY=ON).";
+#endif
+        // The profiler-enabled flag is parsed from the environment when RunTimeOptions is
+        // constructed (i.e. when the MetalContext is first created). Set it now and drop any
+        // pre-existing context so the mock context created by the test picks the flag up.
+        const char* prev = getenv("TT_METAL_DEVICE_PROFILER");
+        prev_device_profiler_ = prev != nullptr ? std::optional<std::string>(prev) : std::nullopt;
+        setenv("TT_METAL_DEVICE_PROFILER", "1", /*overwrite=*/1);
+        if (MetalContext::instance_exists()) {
+            detail::ReleaseOwnership();
+        }
+    }
+
+    void TearDown() override {
+#if !defined(TRACY_ENABLE)
+        return;
+#endif
+        experimental::disable_mock_mode();
+        // Restore the flag to whatever it was before the test rather than clobbering a value the
+        // surrounding environment may have set.
+        if (prev_device_profiler_.has_value()) {
+            setenv("TT_METAL_DEVICE_PROFILER", prev_device_profiler_->c_str(), /*overwrite=*/1);
+        } else {
+            unsetenv("TT_METAL_DEVICE_PROFILER");
+        }
+        // Drop the profiler-enabled context so later tests start from a clean state.
+        if (MetalContext::instance_exists()) {
+            detail::ReleaseOwnership();
+        }
+    }
+
+    std::optional<std::string> prev_device_profiler_;
+};
+
+// Verify that the device profiler is not enabled on mock device.
+TEST_F(MockDeviceProfilerFixture, DeviceProfilerIsNotStartedOnMockDevice) {
+    experimental::configure_mock_mode(tt::ARCH::WORMHOLE_B0, 1);
+
+    ASSERT_TRUE(MetalContext::instance().rtoptions().get_profiler_enabled())
+        << "Test expects device profiler option to be enabled.";
+    ASSERT_TRUE(MetalContext::instance().get_cluster().is_mock_or_emulated()) << "Test should run on mock device.";
+
+    // Even though profiling was requested, getDeviceProfilerState() must report it as disabled for
+    // a mock/emulated context.
+    EXPECT_FALSE(getDeviceProfilerState(MetalContext::instance().get_context_id()))
+        << "getDeviceProfilerState() must be false for a mock context even when profiling is "
+           "requested";
+
+    auto devices = detail::CreateDevices({0});
+    ASSERT_FALSE(devices.empty());
+    const ChipId mock_device_id = devices.begin()->first;
+
+    // The device profiler must never register a mock device.
+    const auto& profiler_state_manager = MetalContext::instance().profiler_state_manager();
+    ASSERT_NE(profiler_state_manager, nullptr);
+    EXPECT_FALSE(profiler_state_manager->device_profiler_map.contains(mock_device_id))
+        << "Device profiler was started on mock device " << mock_device_id
+        << " -- the profiler must be skipped for mock/emulated clusters";
+
+    detail::CloseDevices(devices);
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -3010,7 +3010,14 @@ void DeviceProfiler::pollDebugDumpResults(
 }
 
 bool getDeviceProfilerState(ContextId context_id) {
-    return MetalContext::instance(context_id).rtoptions().get_profiler_enabled();
+    auto& ctx = MetalContext::instance(context_id);
+
+    // Device profiler cannot be enabled on mock device.
+    if (ctx.get_cluster().is_mock_or_emulated()) {
+        return false;
+    }
+
+    return ctx.rtoptions().get_profiler_enabled();
 }
 
 bool getDeviceDebugDumpEnabled(ContextId context_id) {

--- a/tt_metal/impl/profiler/profiler_state.hpp
+++ b/tt_metal/impl/profiler/profiler_state.hpp
@@ -8,7 +8,7 @@
 
 namespace tt::tt_metal {
 
-// Get global device profiling state based on build flag and environment variables
+// Get global device profiling state for the given context.
 bool getDeviceProfilerState(ContextId context_id = DEFAULT_CONTEXT_ID);
 
 // Get if the device debug dump is enabled


### PR DESCRIPTION
This fixes an issue observed in `tt-xla`. Namely, the compiler uses the mock device when running the optimizer - this created a problem when running model benchmarks through `tracy` with device profiling (#48564).

The failure happens in following scenario:
- `tracy` is used with `--sync-host-device`
- we open a device mesh
- we then run the compilation, which uses mock device profiler sync (during mock device open) hits either hang or `TT_FATAL(false, "Fast dispatch read from control buffer requires mesh device support");`

Since enabling device profiler on mock device is non-sensical, disable the device profiler whenever we are in `mock` mode.

Also, adding few regression unit tests:
- verify that the profiler isn't enabled when creating a mock device.
- extend `CoexistingSiliconAndMockDevice` and `CoexistingMockAndSiliconDevice` with variants where the device profiler + profiler sync is enabled

Closes #48564

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pilkic/fix-profiler-mock)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pilkic/fix-profiler-mock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pilkic/fix-profiler-mock)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pilkic/fix-profiler-mock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pilkic/fix-profiler-mock)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pilkic/fix-profiler-mock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pilkic/fix-profiler-mock)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pilkic/fix-profiler-mock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pilkic/fix-profiler-mock)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pilkic/fix-profiler-mock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pilkic/fix-profiler-mock)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pilkic/fix-profiler-mock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pilkic/fix-profiler-mock)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pilkic/fix-profiler-mock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pilkic/fix-profiler-mock)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pilkic/fix-profiler-mock)