### PR TITLE
[Cleanup] Migrate local free-function semaphores to Device 2.0 Semaphore API

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/root2_receive_reader_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/root2_receive_reader_kernel.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 ///
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
 #include "cpp/ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "ttnn/cpp/ttnn/operations/point_to_point/device/kernels/common.hpp"
@@ -100,7 +101,8 @@ void kernel_main() {
     const size_t fabric_mux_buffer_index_address = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t fabric_mux_channel_id = get_arg_val<uint32_t>(arg_idx++);
 
-    uint32_t termination_sync_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+    uint32_t termination_sync_id = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t termination_sync_address = get_semaphore(termination_sync_id);
     uint32_t local_fabric_mux_status_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t local_flow_control_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t local_teardown_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
@@ -169,8 +171,8 @@ void kernel_main() {
     tt::tt_fabric::fabric_client_disconnect(*mux_connection_handle);
 
     if (is_termination_master) {
-        auto* termination_sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_address);
-        noc_semaphore_wait(termination_sync_ptr, num_mux_clients - 1);
+        Semaphore<> termination_sync(termination_sync_id);
+        termination_sync.wait(num_mux_clients - 1);
         tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x, fabric_mux_y, fabric_mux_termination_signal_address);
     } else {
         uint64_t dest_addr =

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/root2_writer_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/root2_writer_kernel.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 ///
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "cpp/ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "ttnn/cpp/ttnn/operations/point_to_point/device/kernels/common.hpp"
@@ -59,7 +60,8 @@ void kernel_main() {
     const size_t fabric_mux_buffer_index_address = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t fabric_mux_channel_id = get_arg_val<uint32_t>(arg_idx++);
 
-    uint32_t termination_sync_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+    uint32_t termination_sync_id = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t termination_sync_address = get_semaphore(termination_sync_id);
     uint32_t local_fabric_mux_status_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t local_flow_control_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t local_teardown_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
@@ -149,8 +151,8 @@ void kernel_main() {
 
     tt::tt_fabric::fabric_client_disconnect(*mux_connection_handle);
     if (is_termination_master) {
-        auto* termination_sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_address);
-        noc_semaphore_wait(termination_sync_ptr, num_mux_clients - 1);
+        Semaphore<> termination_sync(termination_sync_id);
+        termination_sync.wait(num_mux_clients - 1);
         tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x, fabric_mux_y, fabric_mux_termination_signal_address);
     } else {
         uint64_t dest_addr =

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/root_receive_reader_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/root_receive_reader_kernel.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 ///
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
 #include "cpp/ttnn/operations/data_movement/common/kernels/common.hpp"
@@ -103,7 +104,8 @@ void kernel_main() {
     const size_t fabric_mux_buffer_index_address = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t fabric_mux_channel_id = get_arg_val<uint32_t>(arg_idx++);
 
-    uint32_t termination_sync_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+    uint32_t termination_sync_id = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t termination_sync_address = get_semaphore(termination_sync_id);
     uint32_t local_fabric_mux_status_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t local_flow_control_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t local_teardown_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
@@ -175,8 +177,8 @@ void kernel_main() {
     tt::tt_fabric::fabric_client_disconnect(*mux_connection_handle);
 
     if (is_termination_master) {
-        auto* termination_sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_address);
-        noc_semaphore_wait(termination_sync_ptr, num_mux_clients - 1);
+        Semaphore<> termination_sync(termination_sync_id);
+        termination_sync.wait(num_mux_clients - 1);
         tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x, fabric_mux_y, fabric_mux_termination_signal_address);
     } else {
         uint64_t dest_addr =
@@ -231,7 +233,8 @@ void kernel_main() {
     const size_t fabric_mux_buffer_index_address2 = get_arg_val<uint32_t>(fabric_idx_2_ref++);
     const uint8_t fabric_mux_channel_id2 = get_arg_val<uint32_t>(fabric_idx_2_ref++);
 
-    uint32_t termination_sync_address2 = get_semaphore(get_arg_val<uint32_t>(fabric_idx_2_ref++));
+    uint32_t termination_sync_id2 = get_arg_val<uint32_t>(fabric_idx_2_ref++);
+    uint32_t termination_sync_address2 = get_semaphore(termination_sync_id2);
     uint32_t local_fabric_mux_status_address2 = get_semaphore(get_arg_val<uint32_t>(fabric_idx_2_ref++));
     uint32_t local_flow_control_address2 = get_semaphore(get_arg_val<uint32_t>(fabric_idx_2_ref++));
     uint32_t local_teardown_address2 = get_semaphore(get_arg_val<uint32_t>(fabric_idx_2_ref++));
@@ -283,8 +286,8 @@ void kernel_main() {
     tt::tt_fabric::fabric_client_disconnect(*mux_connection_handle2);
 
     if (is_termination_master) {
-        auto* termination_sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_address2);
-        noc_semaphore_wait(termination_sync_ptr, num_mux_clients - 1);
+        Semaphore<> termination_sync2(termination_sync_id2);
+        termination_sync2.wait(num_mux_clients - 1);
         tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x2, fabric_mux_y2, fabric_mux_termination_signal_address);
     } else {
         uint64_t dest_addr =

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/sender_writer_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/sender_writer_kernel.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 ///
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "cpp/ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "ttnn/cpp/ttnn/operations/point_to_point/device/kernels/common.hpp"
@@ -62,7 +63,8 @@ void kernel_main() {
     const size_t fabric_mux_buffer_index_address = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t fabric_mux_channel_id = get_arg_val<uint32_t>(arg_idx++);
 
-    uint32_t termination_sync_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+    uint32_t termination_sync_id = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t termination_sync_address = get_semaphore(termination_sync_id);
     uint32_t local_fabric_mux_status_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t local_flow_control_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t local_teardown_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
@@ -126,8 +128,8 @@ void kernel_main() {
 
     tt::tt_fabric::fabric_client_disconnect(*mux_connection_handle);
     if (is_termination_master) {
-        auto* termination_sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_address);
-        noc_semaphore_wait(termination_sync_ptr, num_mux_clients - 1);
+        Semaphore<> termination_sync(termination_sync_id);
+        termination_sync.wait(num_mux_clients - 1);
         tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x, fabric_mux_y, fabric_mux_termination_signal_address);
     } else {
         uint64_t dest_addr =

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_writer.cpp
@@ -134,7 +134,8 @@ void kernel_main() {
     const size_t fabric_mux_buffer_index_address = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t fabric_mux_channel_id = get_arg_val<uint32_t>(arg_idx++);
 
-    uint32_t termination_sync_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+    uint32_t termination_sync_id = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t termination_sync_address = get_semaphore(termination_sync_id);
     uint32_t local_fabric_mux_status_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t local_flow_control_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t local_teardown_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
@@ -673,8 +674,8 @@ void kernel_main() {
         tt::tt_fabric::fabric_client_disconnect(*fabric_direction_connection);
 
         if (is_termination_master) {
-            auto* termination_sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_address);
-            noc_semaphore_wait(termination_sync_ptr, num_mux_clients - 1);
+            Semaphore<> termination_sync(termination_sync_id);
+            termination_sync.wait(num_mux_clients - 1);
             tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x, fabric_mux_y, fabric_mux_termination_signal_address);
         } else {
             uint64_t dest_addr =

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in0_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/reader_bmm_tile_layout_in0_ring_all_gather.cpp
@@ -12,11 +12,11 @@
 
 enum class CORE_TYPE : uint8_t { IDLE_CORE = 0, WORKER_CORE = 1, HOP_CORE = 2 };
 void kernel_main() {
-    std::array<uint32_t, 4> fused_op_receiver_signal_semaphore_addr = {
-        get_semaphore(get_compile_time_arg_val(7)),
-        get_semaphore(get_compile_time_arg_val(8)),
-        get_semaphore(get_compile_time_arg_val(9)),
-        get_semaphore(get_compile_time_arg_val(10)),
+    std::array<uint32_t, 4> fused_op_receiver_signal_semaphore_id = {
+        get_compile_time_arg_val(7),
+        get_compile_time_arg_val(8),
+        get_compile_time_arg_val(9),
+        get_compile_time_arg_val(10),
     };
     std::array<uint32_t, 4> chunk_indices = {
         get_compile_time_arg_val(11),
@@ -62,12 +62,9 @@ void kernel_main() {
 
     cb_in0.reserve_back(multicast_chunk_size_in_tiles * num_multicast_steps);
     for (uint32_t istep = 0; istep < num_multicast_steps; istep++) {
-        volatile tt_l1_ptr uint32_t* fused_op_receiver_signal_semaphore_addr_ptr =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
-                fused_op_receiver_signal_semaphore_addr[chunk_indices[istep]]);
-
-        noc_semaphore_wait_min(fused_op_receiver_signal_semaphore_addr_ptr, 1);
-        noc_semaphore_set(fused_op_receiver_signal_semaphore_addr_ptr, 0);
+        Semaphore<> fused_op_receiver_signal_semaphore(fused_op_receiver_signal_semaphore_id[chunk_indices[istep]]);
+        fused_op_receiver_signal_semaphore.wait_min(1);
+        fused_op_receiver_signal_semaphore.set(0);
         cb_in0.push_back(multicast_chunk_size_in_tiles);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/worker_receiver.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/worker_receiver.cpp
@@ -17,11 +17,17 @@ void kernel_main() {
     constexpr uint32_t inter_cb_index = get_compile_time_arg_val(1);
     constexpr uint32_t tensor0_page_size = get_compile_time_arg_val(2);
     constexpr uint32_t ring_size = get_compile_time_arg_val(3);
+    std::array<uint32_t, 4> fused_op_receiver_signal_semaphore_id = {
+        get_compile_time_arg_val(4),
+        get_compile_time_arg_val(5),
+        get_compile_time_arg_val(6),
+        get_compile_time_arg_val(7),
+    };
     std::array<uint32_t, 4> fused_op_receiver_signal_semaphore_addr = {
-        get_semaphore(get_compile_time_arg_val(4)),
-        get_semaphore(get_compile_time_arg_val(5)),
-        get_semaphore(get_compile_time_arg_val(6)),
-        get_semaphore(get_compile_time_arg_val(7)),
+        get_semaphore(fused_op_receiver_signal_semaphore_id[0]),
+        get_semaphore(fused_op_receiver_signal_semaphore_id[1]),
+        get_semaphore(fused_op_receiver_signal_semaphore_id[2]),
+        get_semaphore(fused_op_receiver_signal_semaphore_id[3]),
     };
     // runtime args
     size_t arg_idx = 0;
@@ -48,12 +54,11 @@ void kernel_main() {
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(signal_semaphore_addr);
 
     // Set up for mcasting to mm workers
-    volatile tt_l1_ptr uint32_t* fused_op_receiver_signal_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(fused_op_receiver_signal_semaphore_addr[core_id]);
-    noc_semaphore_set(fused_op_receiver_signal_semaphore_addr_ptr, VALID);
+    Semaphore<> fused_op_receiver_signal_semaphore(fused_op_receiver_signal_semaphore_id[core_id]);
+    fused_op_receiver_signal_semaphore.set(VALID);
 
-    volatile tt_l1_ptr uint32_t* fused_op_receiver_signal_semaphore_addr_ptr_next_core_right =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(fused_op_receiver_signal_semaphore_addr[next_core_id_to_right]);
+    Semaphore<> fused_op_receiver_signal_semaphore_next_core_right(
+        fused_op_receiver_signal_semaphore_id[next_core_id_to_right]);
 
     // 1. Wait for global signal
     {
@@ -65,8 +70,8 @@ void kernel_main() {
     // 2. multicast data to mm cores
     // 2.1. Wait for local signal, if it's not the first core
     if (core_id != ring_index) {  // don't need to wait if it's the first core
-        noc_semaphore_wait_min(fused_op_receiver_signal_semaphore_addr_ptr_next_core_right, 1);
-        noc_semaphore_set(fused_op_receiver_signal_semaphore_addr_ptr_next_core_right, 0);
+        fused_op_receiver_signal_semaphore_next_core_right.wait_min(1);
+        fused_op_receiver_signal_semaphore_next_core_right.set(0);
     }
 
     size_t l1_read_addr = cb_inter.get_read_ptr();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_line_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_line_reduce_scatter_minimal_async_reader.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
 #include "cpp/ttnn/operations/ccl/ccl_host_types.hpp"
 #include "cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
@@ -49,7 +50,7 @@ void kernel_main() {
     address_t intermediate_tensor_address = get_arg_val<address_t>(arg_idx++);
     address_t output_tensor_address = get_arg_val<address_t>(arg_idx++);
     size_t out_ready_sem = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t fwd_bwd_sem_addr = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+    Semaphore<> fwd_bwd_sem(get_arg_val<uint32_t>(arg_idx++));
     const bool is_forward = get_arg_val<uint32_t>(arg_idx++);
     const bool is_first_device_in_direction = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t num_targets_in_direction = get_arg_val<uint32_t>(arg_idx++);
@@ -265,8 +266,7 @@ void kernel_main() {
             while (tiles_read < tiles_to_read) {
                 // Wait for FWD writer to signal that it has done its final reduction
                 if (detail::do_accumulate_output(is_forward)) {
-                    noc_semaphore_wait_min(
-                        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(fwd_bwd_sem_addr), ++fwd_sync_cnt);
+                    fwd_bwd_sem.wait_min(++fwd_sync_cnt);
                 }
 
                 uint32_t tiles_remaining_to_read = tiles_to_read - tiles_read;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_line_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_line_reduce_scatter_minimal_async_writer.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
@@ -105,7 +106,8 @@ void kernel_main() {
     const size_t fabric_mux_flow_control_address = get_arg_val<uint32_t>(arg_idx++);
     const size_t fabric_mux_buffer_index_address = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t fabric_mux_channel_id = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t termination_sync_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+    uint32_t termination_sync_id = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t termination_sync_address = get_semaphore(termination_sync_id);
     uint32_t local_fabric_mux_status_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t local_flow_control_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t local_teardown_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
@@ -396,8 +398,8 @@ void kernel_main() {
         tt::tt_fabric::fabric_client_disconnect(*mux_connection_handle);
 
         if (is_termination_master) {
-            auto* termination_sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_address);
-            noc_semaphore_wait(termination_sync_ptr, num_mux_clients - 1);
+            Semaphore<> termination_sync(termination_sync_id);
+            termination_sync.wait(num_mux_clients - 1);
             tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x, fabric_mux_y, fabric_mux_termination_signal_address);
         } else {
             uint64_t dest_addr =

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_ring_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_ring_reduce_scatter_minimal_async_writer.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_routing_utils.hpp"
@@ -91,7 +92,8 @@ void kernel_main() {
     const size_t fabric_mux_flow_control_address = get_arg_val<uint32_t>(arg_idx++);
     const size_t fabric_mux_buffer_index_address = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t fabric_mux_channel_id = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t termination_sync_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+    uint32_t termination_sync_id = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t termination_sync_address = get_semaphore(termination_sync_id);
     uint32_t local_fabric_mux_status_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t local_flow_control_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t local_teardown_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
@@ -390,8 +392,8 @@ void kernel_main() {
 #ifdef USE_WORKER_MUX
     tt::tt_fabric::fabric_client_disconnect(mux_connection_handle);
     if (is_termination_master) {
-        auto* termination_sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_address);
-        noc_semaphore_wait(termination_sync_ptr, num_mux_clients - 1);
+        Semaphore<> termination_sync(termination_sync_id);
+        termination_sync.wait(num_mux_clients - 1);
         tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x, fabric_mux_y, fabric_mux_termination_signal_address);
     } else {
         uint64_t dest_addr =

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_reader.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
 #include "cpp/ttnn/operations/ccl/ccl_host_types.hpp"
 #include "cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
@@ -48,7 +49,7 @@ void kernel_main() {
     address_t intermediate_tensor_address = get_arg_val<address_t>(arg_idx++);
     address_t output_tensor_address = get_arg_val<address_t>(arg_idx++);
     size_t out_ready_sem = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t fwd_bwd_sem_addr = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+    Semaphore<> fwd_bwd_sem(get_arg_val<uint32_t>(arg_idx++));
     const bool is_forward = get_arg_val<uint32_t>(arg_idx++);
     const bool is_first_device_in_direction = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t num_targets_in_direction = get_arg_val<uint32_t>(arg_idx++);
@@ -356,8 +357,7 @@ void kernel_main() {
                 while (tiles_read < tiles_to_read) {
                     // Wait for FWD writer to signal that it has done its final reduction
                     if (accumulate_output) {
-                        noc_semaphore_wait_min(
-                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(fwd_bwd_sem_addr), ++fwd_sync_cnt);
+                        fwd_bwd_sem.wait_min(++fwd_sync_cnt);
                     }
 
                     uint32_t tiles_remaining_to_read = tiles_to_read - tiles_read;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/line_reduce_scatter_minimal_async_writer.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
@@ -110,7 +111,8 @@ void kernel_main() {
     const size_t fabric_mux_flow_control_address = get_arg_val<uint32_t>(arg_idx++);
     const size_t fabric_mux_buffer_index_address = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t fabric_mux_channel_id = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t termination_sync_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+    uint32_t termination_sync_id = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t termination_sync_address = get_semaphore(termination_sync_id);
     uint32_t local_fabric_mux_status_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t local_flow_control_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t local_teardown_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
@@ -430,8 +432,8 @@ void kernel_main() {
         tt::tt_fabric::fabric_client_disconnect(*mux_connection_handle);
 
         if (is_termination_master) {
-            auto* termination_sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_address);
-            noc_semaphore_wait(termination_sync_ptr, num_mux_clients - 1);
+            Semaphore<> termination_sync(termination_sync_id);
+            termination_sync.wait(num_mux_clients - 1);
             tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x, fabric_mux_y, fabric_mux_termination_signal_address);
         } else {
             uint64_t dest_addr =

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_routing_utils.hpp"
@@ -101,7 +102,8 @@ void kernel_main() {
     const size_t fabric_mux_flow_control_address = get_arg_val<uint32_t>(arg_idx++);
     const size_t fabric_mux_buffer_index_address = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t fabric_mux_channel_id = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t termination_sync_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+    uint32_t termination_sync_id = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t termination_sync_address = get_semaphore(termination_sync_id);
     uint32_t local_fabric_mux_status_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t local_flow_control_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t local_teardown_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
@@ -556,8 +558,8 @@ void kernel_main() {
 #ifdef USE_WORKER_MUX
     tt::tt_fabric::fabric_client_disconnect(mux_connection_handle);
     if (is_termination_master) {
-        auto* termination_sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_address);
-        noc_semaphore_wait(termination_sync_ptr, num_mux_clients - 1);
+        Semaphore<> termination_sync(termination_sync_id);
+        termination_sync.wait(num_mux_clients - 1);
         tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x, fabric_mux_y, fabric_mux_termination_signal_address);
     } else {
         uint64_t dest_addr =

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/minimal_default_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_async/device/kernels/minimal_default_writer.cpp
@@ -5,6 +5,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "tt_metal/fabric/hw/inc/packet_header_pool.h"
@@ -95,7 +96,8 @@ void kernel_main() {
     }
 
     bool mux_connection_valid = get_arg_val<uint32_t>(arg_idx++) == 1;
-    uint32_t termination_sync_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+    uint32_t termination_sync_id = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t termination_sync_address = get_semaphore(termination_sync_id);
     uint32_t local_fabric_mux_status_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t local_flow_control_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     uint32_t local_teardown_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
@@ -297,8 +299,8 @@ void kernel_main() {
         tt::tt_fabric::fabric_client_disconnect(*mux_connection_handle);
 
         if constexpr (is_termination_master) {
-            auto* termination_sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_address);
-            noc_semaphore_wait(termination_sync_ptr, num_mux_clients - 1);
+            Semaphore<> termination_sync(termination_sync_id);
+            termination_sync.wait(num_mux_clients - 1);
             tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x, fabric_mux_y, fabric_mux_termination_signal_address);
         } else {
             uint64_t dest_addr =

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_strided_reduce_scatter_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_strided_reduce_scatter_async_reader.cpp
@@ -26,6 +26,7 @@
  */
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc_semaphore.h"
 #include <tt-metalium/buffer_types.hpp>
 #include "ttnn/operations/ccl/ccl_host_types.hpp"
 #include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
@@ -125,7 +126,7 @@ void kernel_main() {
     auto intermediate_tensor_addrgen = TensorAccessor(intermediate_tensor_args, intermediate_tensor_address);
 #endif
 #ifdef FUSE_MM_OP_SIGNALER
-    size_t mm_op_ready_sem = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+    Semaphore<> mm_op_ready_sem(get_arg_val<uint32_t>(arg_idx++));
     uint32_t mm_sem_target = 0;
 #endif
 
@@ -192,7 +193,7 @@ void kernel_main() {
                 // signals guarantees all N-full-blocks covering this chunk are ready.
                 const uint32_t sem_increment = (effective_chunk_width_in_tiles + mm_block_wt - 1) / mm_block_wt;
                 mm_sem_target += sem_increment;
-                noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(mm_op_ready_sem), mm_sem_target);
+                mm_op_ready_sem.wait_min(mm_sem_target);
 #endif
                 // Run a full bidirectional ring reduce-scatter for the current chunk.
                 // i=0: read input -> reader_output_cb (writer forwards to neighbor, no compute).
@@ -356,7 +357,7 @@ void kernel_main() {
         out_ready_sem_target = 0;
 
 #ifdef FUSE_MM_OP_SIGNALER
-        noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(mm_op_ready_sem), 0);
+        mm_op_ready_sem.set(0);
         mm_sem_target = 0;
 #endif
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_strided_reduce_scatter_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_strided_reduce_scatter_async_writer.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_routing_utils.hpp"
@@ -117,7 +118,8 @@ void kernel_main() {
     const size_t fabric_mux_flow_control_address = get_arg_val<uint32_t>(arg_idx++);
     const size_t fabric_mux_buffer_index_address = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t fabric_mux_channel_id = get_arg_val<uint32_t>(arg_idx++);
-    const uint32_t termination_sync_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+    const uint32_t termination_sync_id = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t termination_sync_address = get_semaphore(termination_sync_id);
     const uint32_t local_fabric_mux_status_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     const uint32_t local_flow_control_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     const uint32_t local_teardown_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
@@ -475,8 +477,8 @@ void kernel_main() {
         tt::tt_fabric::fabric_client_disconnect(mux_connection_handle);
 
         if (is_termination_master) {
-            auto* termination_sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_address);
-            noc_semaphore_wait(termination_sync_ptr, num_mux_clients - 1);
+            Semaphore<> termination_sync(termination_sync_id);
+            termination_sync.wait(num_mux_clients - 1);
             tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x, fabric_mux_y, fabric_mux_termination_signal_address);
         } else {
             const uint64_t dest_addr =

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/mla/matmul_wo/device/kernels/dm1_collector.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/mla/matmul_wo/device/kernels/dm1_collector.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "matmul_wo_ring_common.h"
 
 void kernel_main() {
@@ -32,15 +33,14 @@ void kernel_main() {
     //-------------------------------------------------------------------------
     // Collector core
     //-------------------------------------------------------------------------
-    uint32_t semaphore_addr = get_semaphore(reduce_semaphore_id);
-    volatile tt_l1_ptr uint32_t* my_semaphore_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(semaphore_addr);
+    Semaphore<> my_semaphore(reduce_semaphore_id);
     uint32_t semaphore_value = num_cores;
 
     for (uint32_t iter_id = 0; iter_id < num_iters; ++iter_id) {
         cb_s2c_in2.reserve_back(num_cores);
 
         // Wait for all 12 cores to send their data to this core
-        noc_semaphore_wait_min(my_semaphore_ptr, semaphore_value);
+        my_semaphore.wait_min(semaphore_value);
         cb_s2c_in2.push_back(num_cores);
         semaphore_value += num_cores;
     }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc_semaphore.h"
 #include <tt-metalium/constants.hpp>
 #include "api/debug/dprint.h"
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
@@ -127,8 +128,6 @@ void kernel_main() {
     uint32_t num_cores = get_arg_val<uint32_t>(rt_args++);
     uint32_t expert_start_idx = get_arg_val<uint32_t>(rt_args++);
     uint32_t expert_end_idx = get_arg_val<uint32_t>(rt_args++);
-    uint32_t output_init_complete_semaphore_address = get_semaphore(output_init_complete_semaphore_id);
-    uint32_t output_init_barrier_address = get_semaphore(output_init_barrier_semaphore_id);
 
     DPRINT_COMBINE(
         "Combine Reader: experts=[{}, {}) linearized_mesh_coord={}\n",
@@ -144,17 +143,15 @@ void kernel_main() {
         uint32_t page_start = get_arg_val<uint32_t>(rt_args++);
         uint32_t page_end = get_arg_val<uint32_t>(rt_args++);
         uint32_t output_init_done_semaphore_id = get_arg_val<uint32_t>(rt_args++);
-        uint32_t output_init_done_sem_address = get_semaphore(output_init_done_semaphore_id);
 
         {
             // DeviceZoneScopedN("combine-output-zeroing-SENDER-writing");
             zero_pages(cb_zero_buffer_id, page_start, page_end, aligned_output_page_size, output_addr_gen);
         }
 
-        volatile tt_l1_ptr uint32_t* output_init_done_sem_ptr =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(output_init_done_sem_address);
-        noc_semaphore_wait(output_init_done_sem_ptr, num_total_untilizer_cores);
-        noc_semaphore_set(output_init_done_sem_ptr, 0);
+        Semaphore<> output_init_done_sem(output_init_done_semaphore_id);
+        output_init_done_sem.wait(num_total_untilizer_cores);
+        output_init_done_sem.set(0);
     }
 #endif
 
@@ -197,17 +194,15 @@ void kernel_main() {
 
 #if INIT_ZEROS
     // Signal writer that output-zeroing is complete
-    volatile tt_l1_ptr uint32_t* output_init_complete_sem_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(output_init_complete_semaphore_address);
-    noc_semaphore_set(output_init_complete_sem_ptr, 1);
+    Semaphore<> output_init_complete_sem(output_init_complete_semaphore_id);
+    output_init_complete_sem.set(1);
 
     // Wait for ALL writers (all cores) to complete init exchange.
     // Each writer signals all readers' barrier sems via noc_semaphore_inc,
     // so this reader waits for num_cores signals before proceeding.
-    volatile tt_l1_ptr uint32_t* barrier_sem_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(output_init_barrier_address);
-    noc_semaphore_wait(barrier_sem_ptr, num_cores);
-    noc_semaphore_set(barrier_sem_ptr, 0);
+    Semaphore<> barrier_sem(output_init_barrier_semaphore_id);
+    barrier_sem.wait(num_cores);
+    barrier_sem.set(0);
 #endif
 
     // Read expert token counts

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_combine.cpp
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "api/debug/assert.h"
 #include "api/debug/dprint.h"
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
@@ -119,7 +120,6 @@ void kernel_main() {
     uint32_t expert_start_idx = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t expert_end_idx = get_arg_val<uint32_t>(rt_args_idx++);
 
-    uint32_t output_init_complete_semaphore_address = get_semaphore(output_init_complete_semaphore_id);
     uint32_t output_init_barrier_l1_offset = get_semaphore(output_init_barrier_semaphore_id);
 
     // Read NOC coordinates for all cores (for inter-core barrier signaling).
@@ -149,10 +149,9 @@ void kernel_main() {
 
 #if INIT_ZEROS
     // Wait for reader to complete output-zeroing
-    volatile tt_l1_ptr uint32_t* output_init_complete_sem_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(output_init_complete_semaphore_address);
-    noc_semaphore_wait(output_init_complete_sem_ptr, 1);
-    noc_semaphore_set(output_init_complete_sem_ptr, 0);
+    Semaphore<> output_init_complete_sem(output_init_complete_semaphore_id);
+    output_init_complete_sem.wait(1);
+    output_init_complete_sem.set(0);
 #endif
 
 #ifdef DEST_CHIP_ID

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in0_sender.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in0_sender.cpp
@@ -31,6 +31,9 @@ void kernel_main() {
     uint32_t in0_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(14));
     uint32_t in0_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(15));
     uint32_t in0_valid_semaphore_addr = get_semaphore(get_compile_time_arg_val(16));
+    Semaphore<> in0_sender_sem(get_compile_time_arg_val(14));
+    Semaphore<> in0_receiver_sem(get_compile_time_arg_val(15));
+    Semaphore<> in0_valid_sem(get_compile_time_arg_val(16));
     constexpr uint32_t is_output_writer = get_compile_time_arg_val(17);
     constexpr uint32_t is_injector_core = get_compile_time_arg_val(18);
     constexpr uint32_t N_chunks = get_compile_time_arg_val(19);
@@ -195,12 +198,7 @@ void kernel_main() {
     }
 #endif
 
-    volatile tt_l1_ptr uint32_t* in0_valid_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_valid_semaphore_addr);
-    *(in0_valid_semaphore_addr_ptr) = VALID;
-
-    Semaphore<> in0_receiver_sem(get_compile_time_arg_val(15));
-    Semaphore<> in0_sender_sem(get_compile_time_arg_val(14));
+    in0_valid_sem.set(VALID);
 
     const uint64_t in0_sender_semaphore_noc_addr =
         get_noc_addr(in0_sender_noc_x, in0_sender_noc_y, in0_sender_semaphore_addr);

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in0_sender.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in0_sender.cpp
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
@@ -197,11 +198,10 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* in0_valid_semaphore_addr_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_valid_semaphore_addr);
     *(in0_valid_semaphore_addr_ptr) = VALID;
-    volatile tt_l1_ptr uint32_t* in0_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_receiver_semaphore_addr);
 
-    volatile tt_l1_ptr uint32_t* in0_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_sender_semaphore_addr);
+    Semaphore<> in0_receiver_sem(get_compile_time_arg_val(15));
+    Semaphore<> in0_sender_sem(get_compile_time_arg_val(14));
+
     const uint64_t in0_sender_semaphore_noc_addr =
         get_noc_addr(in0_sender_noc_x, in0_sender_noc_y, in0_sender_semaphore_addr);
 
@@ -335,9 +335,9 @@ void kernel_main() {
                         (k_block + 1) * K_block_tiles);
                 } else {
                     // Get from previous device
-                    noc_semaphore_set(in0_receiver_semaphore_addr_ptr, INVALID);
+                    in0_receiver_sem.set(INVALID);
                     noc_semaphore_inc(in0_sender_semaphore_noc_addr, 1);
-                    noc_semaphore_wait(in0_receiver_semaphore_addr_ptr, VALID);
+                    in0_receiver_sem.wait(VALID);
                 }
 
                 // Critical to performance for sender to push data to compute before mcasting
@@ -345,8 +345,8 @@ void kernel_main() {
                 cb_in0.push_back(in0_block_num_tiles);
 
                 if (!is_sink_core) {
-                    noc_semaphore_wait(in0_sender_semaphore_addr_ptr, 1);
-                    noc_semaphore_set(in0_sender_semaphore_addr_ptr, 0);
+                    in0_sender_sem.wait(1);
+                    in0_sender_sem.set(0);
 
                     uint64_t in0_unicast_data_addr = get_noc_addr(in0_dest_noc_x, in0_dest_noc_y, in0_start_address);
 

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in1_sender_out.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in1_sender_out.cpp
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
@@ -167,10 +168,10 @@ void kernel_main() {
     volatile tt_l1_ptr uint32_t* in1_valid_semaphore_addr_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in1_valid_semaphore_addr);
     *(in1_valid_semaphore_addr_ptr) = VALID;
-    volatile tt_l1_ptr uint32_t* in1_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in1_receiver_semaphore_addr);
-    volatile tt_l1_ptr uint32_t* in1_sender_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in1_sender_semaphore_addr);
+
+    Semaphore<> in1_receiver_sem(get_compile_time_arg_val(15));
+    Semaphore<> in1_sender_sem(get_compile_time_arg_val(14));
+
     const uint64_t in1_sender_semaphore_noc_addr =
         get_noc_addr(in1_sender_noc_x, in1_sender_noc_y, in1_sender_semaphore_addr);
 
@@ -288,9 +289,9 @@ void kernel_main() {
                         n_tile,
                         n_tile_end);
                 } else {
-                    noc_semaphore_set(in1_receiver_semaphore_addr_ptr, INVALID);
+                    in1_receiver_sem.set(INVALID);
                     noc_semaphore_inc(in1_sender_semaphore_noc_addr, 1);
-                    noc_semaphore_wait(in1_receiver_semaphore_addr_ptr, VALID);
+                    in1_receiver_sem.wait(VALID);
                 }
 
                 // Critical to performance for sender to push data to compute before mcasting
@@ -298,8 +299,8 @@ void kernel_main() {
                 cb_in1.push_back(in1_block_num_tiles);
 
                 if (!is_sink_core) {
-                    noc_semaphore_wait(in1_sender_semaphore_addr_ptr, 1);
-                    noc_semaphore_set(in1_sender_semaphore_addr_ptr, 0);
+                    in1_sender_sem.wait(1);
+                    in1_sender_sem.set(0);
 
                     /**
                      * in1 is K_block_tiles x N_block_tiles. When N block is partial, we don't need to write the

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in1_sender_out.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in1_sender_out.cpp
@@ -31,6 +31,9 @@ void kernel_main() {
     uint32_t in1_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(14));
     uint32_t in1_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(15));
     uint32_t in1_valid_semaphore_addr = get_semaphore(get_compile_time_arg_val(16));
+    Semaphore<> in1_sender_sem(get_compile_time_arg_val(14));
+    Semaphore<> in1_receiver_sem(get_compile_time_arg_val(15));
+    Semaphore<> in1_valid_sem(get_compile_time_arg_val(16));
     constexpr uint32_t is_output_writer = get_compile_time_arg_val(17);
     constexpr uint32_t is_injector_core = get_compile_time_arg_val(18);
     constexpr uint32_t N_chunks = get_compile_time_arg_val(19);
@@ -165,12 +168,7 @@ void kernel_main() {
     }
 #endif
 
-    volatile tt_l1_ptr uint32_t* in1_valid_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in1_valid_semaphore_addr);
-    *(in1_valid_semaphore_addr_ptr) = VALID;
-
-    Semaphore<> in1_receiver_sem(get_compile_time_arg_val(15));
-    Semaphore<> in1_sender_sem(get_compile_time_arg_val(14));
+    in1_valid_sem.set(VALID);
 
     const uint64_t in1_sender_semaphore_noc_addr =
         get_noc_addr(in1_sender_noc_x, in1_sender_noc_y, in1_sender_semaphore_addr);

--- a/ttnn/cpp/ttnn/operations/experimental/topk_router_gpt/device/kernels/dm1.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_router_gpt/device/kernels/dm1.cpp
@@ -18,6 +18,7 @@
 #include <cstring>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
@@ -212,10 +213,9 @@ void kernel_main() {
     cb_partial_recv.reserve_back(2);
 
     // Wait for both senders' partials to arrive
-    volatile tt_l1_ptr uint32_t* partial_sem =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(sem_partial_ready));
-    noc_semaphore_wait(partial_sem, 2);
-    noc_semaphore_set(partial_sem, 0);
+    Semaphore<> partial_sem(sem_partial_ready);
+    partial_sem.wait(2);
+    partial_sem.set(0);
 
     cb_partial_recv.push_back(2);
 
@@ -282,10 +282,9 @@ void kernel_main() {
     }
 
     // 5. Wait for other 3 workers' topk results
-    volatile tt_l1_ptr uint32_t* topk_sem =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(sem_topk_ready));
-    noc_semaphore_wait(topk_sem, num_groups - 1);
-    noc_semaphore_set(topk_sem, 0);
+    Semaphore<> topk_sem(sem_topk_ready);
+    topk_sem.wait(num_groups - 1);
+    topk_sem.set(0);
 
     cb_gathered_val.push_back(num_groups);
     cb_gathered_ind.push_back(num_groups);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/kernels/dataflow/reduction_receiver.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/kernels/dataflow/reduction_receiver.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "internal/risc_attribs.h"
 #include <tt-metalium/constants.hpp>
 #include "tools/profiler/kernel_profiler.hpp"
@@ -56,8 +57,8 @@ void kernel_main() {
         (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx + 2 * q_num_cores + 2 * q_num_cores + q_num_cores));
 
     // rt args for reduction receiver kernel
-    const uint32_t signal_semaphore_addr =
-        get_semaphore(get_arg_val<uint32_t>(arg_idx + 2 * q_num_cores + 2 * q_num_cores + 2 * q_num_cores));
+    const uint32_t signal_semaphore_id =
+        get_arg_val<uint32_t>(arg_idx + 2 * q_num_cores + 2 * q_num_cores + 2 * q_num_cores);
 
     uint32_t device_batch_offset = 0;
     if constexpr (PHASES_TO_READ == 2) {
@@ -84,12 +85,11 @@ void kernel_main() {
 
     if constexpr (PHASES_TO_READ == 1) {  // only do the semaphore in reading kernel(NCRISC), as all reduce reduction
                                           // only has reading kernel
-        volatile tt_l1_ptr uint32_t* signal_semaphore_addr_ptr =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(signal_semaphore_addr);
+        Semaphore<> signal_semaphore(signal_semaphore_id);
 
         // 1. Wait for signal from All-Gather worker
-        noc_semaphore_wait(signal_semaphore_addr_ptr, VALID);
-        noc_semaphore_set(signal_semaphore_addr_ptr, 0);
+        signal_semaphore.wait(VALID);
+        signal_semaphore.set(0);
 
         // 2. Signal compute kernel to start processing
         cb_push_back(cb_id, total_num_reduction_tiles);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/kernels/dataflow/worker_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/kernels/dataflow/worker_writer.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc_semaphore.h"
 #include <tt-metalium/buffer_types.hpp>
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
@@ -45,14 +46,14 @@ void kernel_main() {
     const uint8_t out_ready_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t out_ready_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
     uint32_t out_ready_sem_wait_value = get_arg_val<uint32_t>(arg_idx++);
-    const uint32_t reduction_semaphore_send_addr = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+    const uint32_t reduction_semaphore_send_id = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t reduction_semaphore_send_addr = get_semaphore(reduction_semaphore_send_id);
     const uint32_t num_mcast_ranges = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t link = get_arg_val<uint32_t>(arg_idx++);
 
     // Set up for mcasting to reduction workers
-    volatile tt_l1_ptr uint32_t* reduction_semaphore_send_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduction_semaphore_send_addr);
-    noc_semaphore_set(reduction_semaphore_send_addr_ptr, VALID);
+    Semaphore<> reduction_semaphore_send(reduction_semaphore_send_id);
+    reduction_semaphore_send.set(VALID);
 
     tt_l1_ptr uint32_t* core_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
     arg_idx += num_cores;


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

Contributes to #45003. First phase of the free-function semaphore to Device 2.0 `Semaphore` migration sequence: replace local, id-derived `noc_semaphore_wait` etc. calls with the wrapper `Semaphore s(id); s.wait(v)`.

### Notes for reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/d2-semaphore-phase-a)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/d2-semaphore-phase-a)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/d2-semaphore-phase-a)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/d2-semaphore-phase-a)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=iwrosz/d2-semaphore-phase-a)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:iwrosz/d2-semaphore-phase-a)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/d2-semaphore-phase-a)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/d2-semaphore-phase-a)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/d2-semaphore-phase-a)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/d2-semaphore-phase-a)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/d2-semaphore-phase-a)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/d2-semaphore-phase-a)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/d2-semaphore-phase-a)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/d2-semaphore-phase-a)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/d2-semaphore-phase-a)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/d2-semaphore-phase-a)
