### PR TITLE
[skip ci] [CI] Support comma-separated model filter in All Model Tests dispatch

### DIFF
--- a/.github/workflows/all-model-tests.yaml
+++ b/.github/workflows/all-model-tests.yaml
@@ -209,10 +209,16 @@ jobs:
           }
 
           def model_matches(test_model, filter_str):
-              """Substring match: 'llama' matches 'llama3.1-8b', 'llama3.2-70b', etc."""
+              """Substring match, comma-separated OR-list.
+
+              'llama' matches 'llama3.1-8b', 'llama3.2-70b', etc.
+              'llama3.1-8b,qwen3-32b' matches a model containing either token.
+              """
               if filter_str == "all":
                   return True
-              return filter_str.lower() in test_model.lower()
+              tm = test_model.lower()
+              return any(tok.strip() and tok.strip().lower() in tm
+                         for tok in filter_str.split(","))
 
           github_output = os.environ.get("GITHUB_OUTPUT", "")
           results = {}

--- a/.github/workflows/models-e2e-tests-impl.yaml
+++ b/.github/workflows/models-e2e-tests-impl.yaml
@@ -76,7 +76,7 @@ jobs:
           # Filter by model (substring match, case-insensitive; comma-separated OR-list)
           if [ "${{ inputs.model }}" != "all" ]; then
             FILTERED=$(echo "$FILTERED" | jq -c --arg m "${{ inputs.model }}" '
-              ($m | ascii_downcase | split(",") | map(ltrimstr(" ") | rtrimstr(" ")) | map(select(length > 0))) as $toks
+              ($m | ascii_downcase | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))) as $toks
               | [ .[] | select((.model | ascii_downcase) as $mm | any($toks[]; . as $t | $mm | contains($t))) ]')
           fi
           if [ "$FILTERED" = "[]" ]; then

--- a/.github/workflows/models-e2e-tests-impl.yaml
+++ b/.github/workflows/models-e2e-tests-impl.yaml
@@ -73,9 +73,11 @@ jobs:
           MATRIX='${{ steps.build-matrix.outputs.matrix }}'
           # Filter by tier
           FILTERED=$(echo "$MATRIX" | jq -c --argjson tier ${{ inputs.tier }} '[.[] | select(.tier == $tier)]')
-          # Filter by model (substring match, case-insensitive)
+          # Filter by model (substring match, case-insensitive; comma-separated OR-list)
           if [ "${{ inputs.model }}" != "all" ]; then
-            FILTERED=$(echo "$FILTERED" | jq -c --arg m "${{ inputs.model }}" '[.[] | select(.model | test($m; "i"))]')
+            FILTERED=$(echo "$FILTERED" | jq -c --arg m "${{ inputs.model }}" '
+              ($m | ascii_downcase | split(",") | map(ltrimstr(" ") | rtrimstr(" ")) | map(select(length > 0))) as $toks
+              | [ .[] | select((.model | ascii_downcase) as $mm | any($toks[]; . as $t | $mm | contains($t))) ]')
           fi
           if [ "$FILTERED" = "[]" ]; then
             echo "::warning::No tests found for tier=${{ inputs.tier }}, model=${{ inputs.model }}. Pipeline will be skipped."

--- a/.github/workflows/models-sweep-tests-impl.yaml
+++ b/.github/workflows/models-sweep-tests-impl.yaml
@@ -76,7 +76,7 @@ jobs:
           # Filter by model (substring match, case-insensitive; comma-separated OR-list)
           if [ "${{ inputs.model }}" != "all" ]; then
             FILTERED=$(echo "$FILTERED" | jq -c --arg m "${{ inputs.model }}" '
-              ($m | ascii_downcase | split(",") | map(ltrimstr(" ") | rtrimstr(" ")) | map(select(length > 0))) as $toks
+              ($m | ascii_downcase | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))) as $toks
               | [ .[] | select((.model | ascii_downcase) as $mm | any($toks[]; . as $t | $mm | contains($t))) ]')
           fi
           if [ "$FILTERED" = "[]" ]; then

--- a/.github/workflows/models-sweep-tests-impl.yaml
+++ b/.github/workflows/models-sweep-tests-impl.yaml
@@ -73,9 +73,11 @@ jobs:
           MATRIX='${{ steps.build-matrix.outputs.matrix }}'
           # Filter by tier
           FILTERED=$(echo "$MATRIX" | jq -c --argjson tier ${{ inputs.tier }} '[.[] | select(.tier == $tier)]')
-          # Filter by model (substring match, case-insensitive)
+          # Filter by model (substring match, case-insensitive; comma-separated OR-list)
           if [ "${{ inputs.model }}" != "all" ]; then
-            FILTERED=$(echo "$FILTERED" | jq -c --arg m "${{ inputs.model }}" '[.[] | select(.model | test($m; "i"))]')
+            FILTERED=$(echo "$FILTERED" | jq -c --arg m "${{ inputs.model }}" '
+              ($m | ascii_downcase | split(",") | map(ltrimstr(" ") | rtrimstr(" ")) | map(select(length > 0))) as $toks
+              | [ .[] | select((.model | ascii_downcase) as $mm | any($toks[]; . as $t | $mm | contains($t))) ]')
           fi
           if [ "$FILTERED" = "[]" ]; then
             echo "::warning::No tests found for tier=${{ inputs.tier }}, model=${{ inputs.model }}. Pipeline will be skipped."

--- a/.github/workflows/models-unit-tests-impl.yaml
+++ b/.github/workflows/models-unit-tests-impl.yaml
@@ -76,7 +76,7 @@ jobs:
           # Filter by model (substring match, case-insensitive; comma-separated OR-list)
           if [ "${{ inputs.model }}" != "all" ]; then
             FILTERED=$(echo "$FILTERED" | jq -c --arg m "${{ inputs.model }}" '
-              ($m | ascii_downcase | split(",") | map(ltrimstr(" ") | rtrimstr(" ")) | map(select(length > 0))) as $toks
+              ($m | ascii_downcase | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))) as $toks
               | [ .[] | select((.model | ascii_downcase) as $mm | any($toks[]; . as $t | $mm | contains($t))) ]')
           fi
           if [ "$FILTERED" = "[]" ]; then

--- a/.github/workflows/models-unit-tests-impl.yaml
+++ b/.github/workflows/models-unit-tests-impl.yaml
@@ -73,9 +73,11 @@ jobs:
           MATRIX='${{ steps.build-matrix.outputs.matrix }}'
           # Filter by tier
           FILTERED=$(echo "$MATRIX" | jq -c --argjson tier ${{ inputs.tier }} '[.[] | select(.tier == $tier)]')
-          # Filter by model (substring match, case-insensitive)
+          # Filter by model (substring match, case-insensitive; comma-separated OR-list)
           if [ "${{ inputs.model }}" != "all" ]; then
-            FILTERED=$(echo "$FILTERED" | jq -c --arg m "${{ inputs.model }}" '[.[] | select(.model | test($m; "i"))]')
+            FILTERED=$(echo "$FILTERED" | jq -c --arg m "${{ inputs.model }}" '
+              ($m | ascii_downcase | split(",") | map(ltrimstr(" ") | rtrimstr(" ")) | map(select(length > 0))) as $toks
+              | [ .[] | select((.model | ascii_downcase) as $mm | any($toks[]; . as $t | $mm | contains($t))) ]')
           fi
           if [ "$FILTERED" = "[]" ]; then
             echo "::warning::No tests found for tier=${{ inputs.tier }}, model=${{ inputs.model }}. Pipeline will be skipped."


### PR DESCRIPTION
### PR Category
CI / QoL

### Summary
The `model` filter on the **All Model Tests** `workflow_dispatch` only accepted a
single substring. It is matched in two independent places and neither split on
commas, so a value like `llama3.1-8b,qwen3-32b` was treated as one literal token,
matched no model, and the run aborted at preflight with `No tests to run`.

This makes the `model` input accept a **comma-separated OR-list** in both places:

- **Preflight** (`all-model-tests.yaml`, `model_matches`): splits the filter on
  `,` and matches if **any** token is a case-insensitive substring of the model name.
- **Matrix build** (`models-{e2e,unit,sweep}-tests-impl.yaml`, jq `apply-filters`
  step): same OR-list behavior. Also switches from regex `test()` to literal
  `contains()`, so the `.` in model names (`llama3.1-8b`) is matched literally
  instead of as a regex wildcard.

Single-token filters (`llama`) and `all` are unchanged.

Now works:
```
model = "llama3.1-8b,llama3.3-70b,qwen3-32b"   -> runs all three
model = "llama"                                 -> runs all llama* (unchanged)
model = "all"                                   -> runs everything (unchanged)
```

### Notes for reviewers
- Both matcher edits validated locally (jq + Python) and live on a dispatch:
  preflight now passes and the matrix populates with the requested models
  (previously it failed at preflight).
- **Validation run** (tier 3, `wh_n150`, 3-model OR-list): [All Model Tests run 29103838813](https://github.com/tenstorrent/tt-metal/actions/runs/29103838813)
  — `Model[falcon-7b,phi-3-mini,mamba-2.8b]`. Of the 6 tier-3/N150 e2e models, the
  filter selects exactly those 3, confirming the OR-list narrows correctly (not all, not none).
- Whitespace trimming in the jq matrix filter uses `gsub("^\\s+|\\s+$"; "")` so it
  matches the preflight's Python `strip()` (addresses Copilot review re: multi-space/tab tokens).
- Discovered while running per-model repeat pipelines for the trace-region work
  (#47574 / #49072).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci-comma-separated-model-filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci-comma-separated-model-filter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci-comma-separated-model-filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci-comma-separated-model-filter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ci-comma-separated-model-filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ci-comma-separated-model-filter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci-comma-separated-model-filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci-comma-separated-model-filter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci-comma-separated-model-filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci-comma-separated-model-filter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci-comma-separated-model-filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci-comma-separated-model-filter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci-comma-separated-model-filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci-comma-separated-model-filter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci-comma-separated-model-filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci-comma-separated-model-filter)