### PR TITLE
[Cleanup] Migrate remote semaphore increments to Semaphore<>::up()

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
@@ -368,7 +368,6 @@ void kernel_main() {
     // Device 2.0 migration: legacy primitives retained: these raw L1 semaphore addresses are
     // used as bases for multicast destinations (set_multicast / get_safe_multicast_noc_addr /
     // get_noc_addr) and for inter-core semaphore inc with precomposed uint64_t addresses.
-    uint32_t partial_metadata_ready_semaphore_addr = get_semaphore(partial_metadata_ready_semaphore_id);
     uint32_t metadata_ready_semaphore_addr = get_semaphore(metadata_ready_semaphore_id);
     const uint32_t combine_sync_addr = get_semaphore(combine_sync_semaphore_id);
 
@@ -950,11 +949,7 @@ void kernel_main() {
         noc_obj.async_write_barrier();
 
         // Signal drain core via semaphore increment
-        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address cannot
-        // be wrapped by Semaphore<>::inc which binds to a per-program id
-        uint64_t drain_semaphore_noc_addr =
-            get_noc_addr(drain_core_noc_x, drain_core_noc_y, partial_metadata_ready_semaphore_addr);
-        noc_semaphore_inc(drain_semaphore_noc_addr, 1);
+        partial_metadata_ready_sem.up(noc_obj, drain_core_noc_x, drain_core_noc_y, 1);
 
         // ========== NON-DRAIN tilize CORE: Wait for drain core to multicast data ==========
         // Wait for the semaphore signal from drain core

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_writer.cpp
@@ -195,7 +195,6 @@ void kernel_main() {
     uint32_t matmul_chunk_available_semaphore_addr = get_semaphore(matmul_chunk_available_semaphore_id);
     uint32_t tilize_chunk_ready_semaphore_addr = get_semaphore(tilize_chunk_ready_semaphore_id);
     uint32_t matmul_chunk_ready_semaphore_addr = get_semaphore(matmul_chunk_ready_semaphore_id);
-    uint32_t initial_gather_semaphore_addr = get_semaphore(initial_gather_semaphore_id);
 
     // Noc typed wrappers
     Noc noc_obj(noc_index);
@@ -670,14 +669,7 @@ void kernel_main() {
 
                     // == 4a ==
                     // signal to our initial mcast gather core that we've delivered our sub-chunk
-                    // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
-                    // (initial_gather_semaphore_noc_addr) cannot be wrapped by Semaphore<>::inc
-                    uint64_t initial_gather_semaphore_noc_addr = get_noc_addr(
-                        initial_mcast_gather_core_nox_x,
-                        initial_mcast_gather_core_nox_y,
-                        initial_gather_semaphore_addr,
-                        noc_index);
-                    noc_semaphore_inc(initial_gather_semaphore_noc_addr, 1, noc_index);
+                    initial_gather_sem.up(noc_obj, initial_mcast_gather_core_nox_x, initial_mcast_gather_core_nox_y, 1);
                 }
             } else {
                 // ALL SUBSEQUENT ITERATIONS

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/dm1.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/dm1.cpp
@@ -346,16 +346,12 @@ void kernel_main() {
     }
 
     // Signal combine cores that all expert data is written
-    uint32_t combine_semaphore_addr = get_semaphore(combine_semaphore_id);
+    Semaphore<> combine_sem(combine_semaphore_id);
     for (uint32_t y = 0; y < height_shard_dim; ++y) {
         uint32_t idx = combine_core_x + y * width_shard_dim;
-        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address
-        // (combine destination semaphore) cannot be wrapped by Semaphore<>::inc
-        uint64_t dest_sem_noc_addr =
-            get_noc_addr(output_shard_core_map[2 * idx], output_shard_core_map[2 * idx + 1], combine_semaphore_addr);
-        noc_semaphore_inc(dest_sem_noc_addr, 1, 1, vchannel);
+        combine_sem.up(noc1_obj, output_shard_core_map[2 * idx], output_shard_core_map[2 * idx + 1], 1, vchannel);
     }
-    // The noc_semaphore_inc calls above issue on NoC 1 (matching the original
+    // The combine_sem.up() calls above issue on NoC 1 (matching the original
     // noc_async_atomic_barrier(/*noc=*/1) call), so barrier on noc1_obj.
     noc1_obj.async_atomic_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/tilize_reader.cpp
@@ -243,7 +243,6 @@ void kernel_main() {
     Semaphore<> metadata_ready_sem(metadata_ready_semaphore_id);
     Semaphore<> previous_chunk_sent_sem(previous_chunk_sent_semaphore_id);
 
-    uint32_t partial_metadata_ready_semaphore_addr = get_semaphore(partial_metadata_ready_semaphore_id);
     uint32_t metadata_ready_semaphore_addr = get_semaphore(metadata_ready_semaphore_id);
     uint32_t previous_chunk_sent_semaphore_addr = get_semaphore(previous_chunk_sent_semaphore_id);
 
@@ -848,11 +847,7 @@ void kernel_main() {
         noc_obj.async_write_barrier();
 
         // Signal drain core via semaphore increment
-        // Device 2.0 migration: legacy primitive retained: precomposed uint64_t NoC address used
-        // for cross-core semaphore increment
-        uint64_t drain_semaphore_noc_addr =
-            get_noc_addr(drain_core_noc_x, drain_core_noc_y, partial_metadata_ready_semaphore_addr);
-        noc_semaphore_inc(drain_semaphore_noc_addr, 1);
+        partial_metadata_ready_sem.up(noc_obj, drain_core_noc_x, drain_core_noc_y, 1);
 
         // ========== NON-DRAIN tilize CORE: Wait for drain core to multicast data ==========
         // Wait for the semaphore signal from drain core

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_untilize.cpp
@@ -172,7 +172,6 @@ void kernel_main() {
         get_noc_addr(sender_noc_x, sender_noc_y, get_semaphore(data_ready_semaphore_id));
     uint32_t credits_sem_l1 = get_semaphore(credits_semaphore_id);
     volatile tt_l1_ptr uint32_t* credits_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(credits_sem_l1);
-    uint64_t self_credits_noc_addr = get_noc_addr(my_x[noc_index], my_y[noc_index], credits_sem_l1);
 
     // Wait on the same counter_ready sem reader_untilize waits on (neither kernel resets it,
     // so both see the single increment from the sender's multicast).  Then read the sender's
@@ -281,7 +280,9 @@ void kernel_main() {
                     if (local_credits == 0) {
                         credits_sem.wait_min(1);
                         uint32_t n = *credits_sem_ptr;
-                        noc_semaphore_inc(self_credits_noc_addr, (uint32_t)(-(int32_t)n));
+                        // Atomic credit return: up() with a wrapped -n. Semaphore<>::down() is a
+                        // local, non-atomic decrement that would race the sender's credit increments.
+                        credits_sem.up(noc, my_x[noc_index], my_y[noc_index], (uint32_t)(-(int32_t)n));
                         noc.async_atomic_barrier();
                         local_credits += n;
                     }
@@ -330,7 +331,8 @@ void kernel_main() {
 
     credits_sem.wait_min(SLOTS_PER_UNTILIZER - local_credits);
     uint32_t n = *credits_sem_ptr;
-    noc_semaphore_inc(self_credits_noc_addr, (uint32_t)(-(int32_t)n));
+    // Atomic credit return (see note above): up() with a wrapped -n.
+    credits_sem.up(noc, my_x[noc_index], my_y[noc_index], (uint32_t)(-(int32_t)n));
     counter_ready_sem.set(0);
     noc.async_atomic_barrier();
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_untilize.cpp
@@ -339,7 +339,8 @@ void kernel_main() {
     uint64_t done_meta_noc = our_metadata_slice_noc_addr + write_slot * aligned_dispatched_metadata_page_size;
     noc_inline_dw_write(done_meta_noc, ROUTE_INFO_SENTINEL);
     noc.async_write_barrier();
-    noc_semaphore_inc(sender_data_ready_noc_addr, 1);
+    Semaphore<> sender_data_ready_sem(data_ready_semaphore_id);
+    sender_data_ready_sem.up(noc, sender_noc_x, sender_noc_y, 1);
     noc.async_atomic_barrier();
     cb_experts_tok_counter.pop_front(cb_counter_total_pages);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_untilize.cpp
@@ -57,17 +57,11 @@ void kernel_main() {
     uint32_t page_end = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t output_init_done_semaphore_id = get_arg_val<uint32_t>(rt_args_idx++);
 
-    // The semaphore was created on all worker cores (including this one),
-    // so get_semaphore gives the correct L1 offset for any core with this ID.
-    uint32_t output_init_done_sem_l1_offset = get_semaphore(output_init_done_semaphore_id);
-
-    // Read sender core NOC coordinates for semaphore signaling
-    uint64_t sender_sem_noc_addrs[num_sender_cores];
-    for (uint32_t c = 0; c < num_sender_cores; c++) {
-        uint32_t noc_x = get_arg_val<uint32_t>(rt_args_idx++);
-        uint32_t noc_y = get_arg_val<uint32_t>(rt_args_idx++);
-        sender_sem_noc_addrs[c] = get_noc_addr(noc_x, noc_y, output_init_done_sem_l1_offset);
-    }
+    // The semaphore is created on all worker cores (including this one) at a uniform L1
+    // offset, so Semaphore<>::up() resolves the correct remote address on any target core.
+    // The per-sender NOC coordinates are the last INIT_ZEROS runtime args; they are read
+    // below in the signaling loop.
+    Semaphore<> output_init_done_sem(output_init_done_semaphore_id);
 #endif
 
     const auto output_addr_gen = TensorAccessor(output_args, output_addr);
@@ -75,9 +69,13 @@ void kernel_main() {
 #if INIT_ZEROS
     zero_pages(cb_zero_buffer_id, page_start, page_end, aligned_output_page_size, output_addr_gen);
 
-    // Signal all sender/reader cores that output-zeroing is complete
+    // Signal all sender/reader cores that output-zeroing is complete. Each core's NOC
+    // coordinates are read here (the last INIT_ZEROS runtime args) and passed to
+    // Semaphore<>::up().
     for (uint32_t c = 0; c < num_sender_cores; c++) {
-        noc_semaphore_inc(sender_sem_noc_addrs[c], 1);
+        uint32_t noc_x = get_arg_val<uint32_t>(rt_args_idx++);
+        uint32_t noc_y = get_arg_val<uint32_t>(rt_args_idx++);
+        output_init_done_sem.up(noc, noc_x, noc_y, 1);
     }
 
     noc.async_atomic_barrier();
@@ -138,7 +136,7 @@ void kernel_main() {
     constexpr uint32_t tile_height = read_batch_size;
     constexpr uint32_t tiles_per_batch = full_ct_dim;
 
-    // Runtime args appended after the sender_sem_noc_addrs loop above:
+    // Runtime args appended after the INIT_ZEROS sender NOC-coordinate args above:
     //   counter_ready_semaphore_id   - sem the sender increments once after its counter multicast
     //   sender_noc_x / sender_noc_y  - NOC coords of the owning sender core
     //   data_ready_semaphore_id      - sender-side sem dedicated to THIS untilizer core (one per

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_worker_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_worker_dispatch.cpp
@@ -43,6 +43,7 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "api/debug/dprint.h"
 #include "ttnn/operations/ccl/common/kernels/moe_utils.hpp"
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
@@ -207,7 +208,7 @@ void kernel_main() {
     const uint32_t offsets_bytes = offsets_pages * aligned_offsets_page_size;
     volatile tt_l1_ptr uint32_t* turn_sem_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(turn_semaphore_id));
-    uint64_t next_turn_sem_noc_addr = get_noc_addr(next_noc_x, next_noc_y, get_semaphore(turn_semaphore_id));
+    Semaphore<> next_turn_sem(turn_semaphore_id);
     if constexpr (IS_OWNER) {
         noc_semaphore_set(turn_sem_ptr, 1);
     }
@@ -442,7 +443,7 @@ void kernel_main() {
             noc_async_write_barrier();
         }
         if (batch_idx + 1 < effective_total_batches) {
-            noc_semaphore_inc(next_turn_sem_noc_addr, 1);
+            next_turn_sem.up(noc, next_noc_x, next_noc_y, 1);
             DPRINT_DISPATCH(
                 "[R s={} c={}] b={} RELEASE baton -> signaled next (entries={})\n",
                 (uint32_t)sender_core_idx,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_sender_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_sender_dispatch.cpp
@@ -12,6 +12,7 @@
 
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "api/debug/dprint.h"
 #include "api/debug/assert.h"
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
@@ -165,7 +166,8 @@ void kernel_main() {
     uint32_t ring_route_base[num_workers];
     uint32_t ring_payload_base[num_workers];
     uint32_t ring_meta_base[num_workers];
-    uint32_t addr_ready_sem_l1_offset = get_semaphore(addr_ready_semaphore_id);
+    Noc noc;
+    Semaphore<> addr_ready_sem(addr_ready_semaphore_id);
     uint32_t cross_addr_sem_l1_offset = get_semaphore(cross_addr_semaphore_id);
     for (uint32_t s = 0; s < num_workers; s++) {
         ring_route_base[s] = get_write_ptr(ring_route_cb[s]);
@@ -176,7 +178,7 @@ void kernel_main() {
         noc_inline_dw_write(mailbox + 1 * sizeof(uint32_t), ring_payload_base[s]);
         noc_inline_dw_write(mailbox + 2 * sizeof(uint32_t), ring_meta_base[s]);
         noc_async_write_barrier();  // all three addresses must land before addr_ready wakes worker s
-        noc_semaphore_inc(get_noc_addr(ring_noc_x[s], ring_noc_y[s], addr_ready_sem_l1_offset), 1);
+        addr_ready_sem.up(noc, ring_noc_x[s], ring_noc_y[s], 1);
         noc_async_atomic_barrier();
         DPRINT_DISPATCH("Sender writer: addr handshake done ring={} u=({},{})\n", s, ring_noc_x[s], ring_noc_y[s]);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_worker_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_worker_dispatch.cpp
@@ -154,6 +154,7 @@ void kernel_main() {
     uint64_t sender_c6_base_noc_addr = get_noc_addr(sender_noc_x, sender_noc_y, sender_c6_l1_addr);
     uint64_t sender_data_avail_noc_addr =
         get_noc_addr(sender_noc_x, sender_noc_y, get_semaphore(data_avail_semaphore_id));
+    Semaphore<> data_avail_sem(data_avail_semaphore_id);
 
     // space_avail lives in our local L1; the sender increments it remotely once per slot it has
     // finished forwarding.  We poll it as a per-entry credit (wait for produced_count+1) before
@@ -397,7 +398,7 @@ void kernel_main() {
     noc_async_write_one_packet_with_trid(
         route_info_scratch_addr, sentinel_c4_slot, route_info_slot_stride, TRID_NON_LOCAL_WRITE);
     noc_async_write_barrier_with_trid(TRID_NON_LOCAL_WRITE);
-    noc_semaphore_inc(sender_data_avail_noc_addr, 1);
+    data_avail_sem.up(noc, sender_noc_x, sender_noc_y, 1);
 
     // noc_async_full_barrier flushes everything in-flight (including the inc) before exit.
     noc_async_full_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in0_sender.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in0_sender.cpp
@@ -201,9 +201,6 @@ void kernel_main() {
 
     in0_valid_sem.set(VALID);
 
-    const uint64_t in0_sender_semaphore_noc_addr =
-        get_noc_addr(in0_sender_noc_x, in0_sender_noc_y, in0_sender_semaphore_addr);
-
     const uint64_t in0_receiver_semaphore_noc_addr =
         get_noc_addr(in0_dest_noc_x, in0_dest_noc_y, in0_receiver_semaphore_addr);
 
@@ -335,7 +332,7 @@ void kernel_main() {
                 } else {
                     // Get from previous device
                     in0_receiver_sem.set(INVALID);
-                    noc_semaphore_inc(in0_sender_semaphore_noc_addr, 1);
+                    in0_sender_sem.up(noc, in0_sender_noc_x, in0_sender_noc_y, 1);
                     in0_receiver_sem.wait(VALID);
                 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in1_sender_out.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/dm_in1_sender_out.cpp
@@ -170,9 +170,6 @@ void kernel_main() {
 
     in1_valid_sem.set(VALID);
 
-    const uint64_t in1_sender_semaphore_noc_addr =
-        get_noc_addr(in1_sender_noc_x, in1_sender_noc_y, in1_sender_semaphore_addr);
-
     const uint64_t in1_receiver_semaphore_noc_addr =
         get_noc_addr(in1_dest_noc_x, in1_dest_noc_y, in1_receiver_semaphore_addr);
 
@@ -288,7 +285,7 @@ void kernel_main() {
                         n_tile_end);
                 } else {
                     in1_receiver_sem.set(INVALID);
-                    noc_semaphore_inc(in1_sender_semaphore_noc_addr, 1);
+                    in1_sender_sem.up(noc, in1_sender_noc_x, in1_sender_noc_y, 1);
                     in1_receiver_sem.wait(VALID);
                 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/topk_router_gpt/device/kernels/dm1.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_router_gpt/device/kernels/dm1.cpp
@@ -158,8 +158,8 @@ void kernel_main() {
         noc.async_write_barrier();
 
         // Signal worker that this sender's partial is ready
-        uint64_t worker_sem_noc = get_noc_addr(worker_phys_x, worker_phys_y, get_semaphore(sem_partial_ready));
-        noc_semaphore_inc(worker_sem_noc, 1);
+        Semaphore<> worker_sem(sem_partial_ready);
+        worker_sem.up(noc, worker_phys_x, worker_phys_y, 1);
         noc_async_atomic_barrier();
 
         cb_local_out.pop_front(1);
@@ -254,8 +254,8 @@ void kernel_main() {
         noc.async_write_barrier();
 
         // Signal collector
-        uint64_t coll_sem_noc = get_noc_addr(collector_phys_x, collector_phys_y, get_semaphore(sem_topk_ready));
-        noc_semaphore_inc(coll_sem_noc, 1);
+        Semaphore<> coll_sem(sem_topk_ready);
+        coll_sem.up(noc, collector_phys_x, collector_phys_y, 1);
         noc_async_atomic_barrier();
 
         cb_topk_val.pop_front(1);


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

Contributes to #45003. Phase B of the free-function semaphore Device 2.0 migration, follows #49598

### Notes for reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/d2-semaphore-phase-b)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/d2-semaphore-phase-b)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/d2-semaphore-phase-b)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/d2-semaphore-phase-b)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=iwrosz/d2-semaphore-phase-b)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:iwrosz/d2-semaphore-phase-b)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/d2-semaphore-phase-b)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/d2-semaphore-phase-b)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/d2-semaphore-phase-b)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/d2-semaphore-phase-b)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/d2-semaphore-phase-b)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/d2-semaphore-phase-b)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/d2-semaphore-phase-b)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/d2-semaphore-phase-b)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/d2-semaphore-phase-b)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/d2-semaphore-phase-b)
