### PR TITLE
[Bug fix] emule: exclude Emule from mock-only SD compile + fix ASAN symbolizer debuginfod hang

### DIFF
--- a/tt_metal/distributed/distributed.cpp
+++ b/tt_metal/distributed/distributed.cpp
@@ -118,10 +118,11 @@ void EnqueueMeshWorkload(MeshCommandQueue& mesh_cq, MeshWorkload& mesh_workload,
         mesh_workload.impl().compile(mesh_cq.device());
         mesh_workload.impl().load_binaries(mesh_cq);
         mesh_workload.impl().generate_dispatch_commands(mesh_cq);
-    } else if (ctx.get_cluster().is_mock_or_emulated()) {
+    } else if (ctx.get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
         // Slow dispatch normally JIT-compiles inside LaunchProgram, but the SD mesh CQ
         // short-circuits for mock devices (no hardware to dispatch to). Compile here so
         // kernel artifacts are still produced; the SD CQ then no-ops the skipped dispatch.
+        // Mock only, not is_mock_or_emulated(): Emule builds kernels via its own host-JIT path.
         mesh_workload.impl().compile(mesh_cq.device());
     }
     mesh_cq.enqueue_mesh_workload(mesh_workload, blocking);

--- a/tt_metal/impl/emulation/emule_asan_panic.cpp
+++ b/tt_metal/impl/emulation/emule_asan_panic.cpp
@@ -61,12 +61,19 @@ bool emule_asan_symbolize(const char* module, uintptr_t file_offset, char* out, 
     module = modbuf;
     // Prefer llvm-symbolizer (reads clang's DWARF5; addr2line only yields "??:?"),
     // trying versioned names; addr2line is the last-ditch fallback.
+    // `DEBUGINFOD_URLS=` is load-bearing: llvm-symbolizer otherwise does a blocking debuginfod
+    // NETWORK lookup (the inherited DEBUGINFOD_URLS, e.g. https://debuginfod.ubuntu.com) when the
+    // local DWARF is incomplete; on a host with no route it blocks forever in poll(), wedging
+    // __emule_asan_panic before its abort() so the death never fires. Only bites where
+    // DEBUGINFOD_URLS is set AND unreachable (dev boxes) — not CI. Disabling it keeps the trace
+    // fully local. `</dev/null` additionally guards llvm-symbolizer's interactive-stdin path.
+    // Keep in sync with the tt-emule mirror in include/jit_hw/asan/emule_asan.h.
     const char* tools[] = {
-        "llvm-symbolizer --obj=\"%s\" --pretty-print --inlines --demangle 0x%lx 2>/dev/null",
-        "llvm-symbolizer-20 --obj=\"%s\" --pretty-print --inlines --demangle 0x%lx 2>/dev/null",
-        "llvm-symbolizer-19 --obj=\"%s\" --pretty-print --inlines --demangle 0x%lx 2>/dev/null",
-        "llvm-symbolizer-18 --obj=\"%s\" --pretty-print --inlines --demangle 0x%lx 2>/dev/null",
-        "addr2line -f -C -i -p -e \"%s\" 0x%lx 2>/dev/null",
+        "DEBUGINFOD_URLS= llvm-symbolizer --obj=\"%s\" --pretty-print --inlines --demangle 0x%lx </dev/null 2>/dev/null",
+        "DEBUGINFOD_URLS= llvm-symbolizer-20 --obj=\"%s\" --pretty-print --inlines --demangle 0x%lx </dev/null 2>/dev/null",
+        "DEBUGINFOD_URLS= llvm-symbolizer-19 --obj=\"%s\" --pretty-print --inlines --demangle 0x%lx </dev/null 2>/dev/null",
+        "DEBUGINFOD_URLS= llvm-symbolizer-18 --obj=\"%s\" --pretty-print --inlines --demangle 0x%lx </dev/null 2>/dev/null",
+        "DEBUGINFOD_URLS= addr2line -f -C -i -p -e \"%s\" 0x%lx </dev/null 2>/dev/null",
     };
     for (size_t t = 0; t < sizeof(tools) / sizeof(tools[0]); ++t) {
         char cmd[1100];


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Two independent emule-integration host-side fixes (both in `tt_metal/impl/emulation/`), surfaced running the
tt-emule regression against a recent main.

**1. `EnqueueMeshWorkload` slow-dispatch compile — exclude Emule (`distributed.cpp`).**
Follow-up to #49440, which un-skipped `EnqueueMeshWorkload`'s SD compile for mock devices so MockChip
(tt-blaze) produces kernel artifacts, but guarded the new branch on `cluster.is_mock_or_emulated()`:

```cpp
} else if (ctx.get_cluster().is_mock_or_emulated()) {
    mesh_workload.impl().compile(mesh_cq.device());   // real Program::compile -> RISC-V jit_build
}
```

`is_mock_or_emulated()` is `target_type_ == Mock || Emule`, so this also matches **SWEmuleChip**
(`TargetDevice::Emule`). Emule is *not* MockChip — it JIT-compiles kernels to host `.so` in its own
`execute_program_emulated` path. Routing it through the real `Program::compile` → RISC-V `jit_build` is
redundant and unsatisfiable: emule generates no RISC-V linker scripts, so every kernel build dies with
`ld: cannot open linker script file .../runtime/hw/toolchain/<arch>/kernel_*.ld`. Fix: restrict the branch to
`TargetDevice::Mock`. MockChip keeps its compile; Emule falls back to its prior, working path. No change for
silicon or fast dispatch. (Same over-generalization the sibling hunks in #49440 flag with `// TODO(emule)`.)

**2. ASAN panic backtrace symbolizer hangs on debuginfod (`emule_asan_panic.cpp`).**
The emule ASAN sanitizers call `__emule_asan_panic`, which prints a symbolized backtrace via
`popen("llvm-symbolizer …")` *before* `abort()`. `llvm-symbolizer` inherits `DEBUGINFOD_URLS` and does a
blocking debuginfod **network** lookup when local DWARF is incomplete; on a host with no route it blocks
forever in `poll()`, so `abort()` is never reached and the emule ASAN death tests
(`MeshDeviceFixture.*_SanityCheck`) hang instead of dying. Fix: prefix the symbolizer commands with
`DEBUGINFOD_URLS=` (+ `</dev/null` stdin guard) so the trace stays fully local and a violation always aborts
fast with its `[ASAN ERROR]` message. Only affects the ASAN abort path (ASAN off = untouched). Mirrors the
tt-emule copy `include/jit_hw/asan/emule_asan.h`.

### Notes for reviewers
- Fix 1: one-guard change in `distributed.cpp` (`is_mock_or_emulated()` → `== TargetDevice::Mock`).
- Fix 2: `DEBUGINFOD_URLS=` / `</dev/null` prefix on the symbolizer commands in `emule_asan_panic.cpp`.
- Verified downstream in tt-emule: fix 1 takes the BH smoke set from `riscv-tt-elf-g++` = 4859 (0 passed / 23
  failed on missing `kernel_*.ld`) to **0 real builds, 45 passed / 0 failed**; with both fixes the full C++
  regression at CI-default config (K=64, fast death-test style — no env crutches) is **WH 54/0, BH 19/0**, the
  ASAN death tests passing.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=arminale/emule-mesh-compile-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:arminale/emule-mesh-compile-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=arminale/emule-mesh-compile-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:arminale/emule-mesh-compile-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=arminale/emule-mesh-compile-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:arminale/emule-mesh-compile-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=arminale/emule-mesh-compile-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:arminale/emule-mesh-compile-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=arminale/emule-mesh-compile-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:arminale/emule-mesh-compile-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=arminale/emule-mesh-compile-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:arminale/emule-mesh-compile-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=arminale/emule-mesh-compile-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:arminale/emule-mesh-compile-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=arminale/emule-mesh-compile-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:arminale/emule-mesh-compile-guard)
