### PR TITLE
[Cleanup] Enable NoC sanitize in FD on QSR

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
@@ -138,11 +138,8 @@ protected:
         tt::tt_metal::MetalContext::instance().rtoptions().set_test_mode_enabled(true);
 
         const auto detected_arch = tt::tt_metal::MetalContext::instance().get_cluster().arch();
-        // Watcher NOC sanitization currently only works on Quasar in slow dispatch.
-        // TODO: Remove the slow dispatch check once NOC sanitization is supported on Quasar in fast dispatch (#45878)
-        const bool slow_dispatch = !tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch();
         tt::tt_metal::MetalContext::instance().rtoptions().set_watcher_noc_sanitize_linked_transaction(
-            detected_arch == tt::ARCH::BLACKHOLE || (detected_arch == tt::ARCH::QUASAR && slow_dispatch));
+            detected_arch == tt::ARCH::BLACKHOLE || (detected_arch == tt::ARCH::QUASAR));
 
         // Parent class initializes devices and any necessary flags
         DebugToolsMeshFixture::SetUp();

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize_delays.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize_delays.cpp
@@ -175,6 +175,9 @@ TEST_F(MeshWatcherDelayFixture, TensixTestWatcherSanitizeInsertDelays) {
     if (this->slow_dispatch_) {
         GTEST_SKIP();
     }
+    if (tt::tt_metal::MetalContext::instance().rtoptions().watcher_noc_sanitize_disabled()) {
+        GTEST_SKIP();
+    }
 
     this->RunTestOnDevice(
         [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize_delays.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize_delays.cpp
@@ -175,9 +175,6 @@ TEST_F(MeshWatcherDelayFixture, TensixTestWatcherSanitizeInsertDelays) {
     if (this->slow_dispatch_) {
         GTEST_SKIP();
     }
-    if (tt::tt_metal::MetalContext::instance().rtoptions().watcher_noc_sanitize_disabled()) {
-        GTEST_SKIP();
-    }
 
     this->RunTestOnDevice(
         [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -110,7 +110,7 @@ void RunTestOnCore(
 
     // IDLE_ETH cores only support SD (FD not yet implemented)
     // TENSIX/ACTIVE_ETH cores: SD only used for Quasar watcher tests (TODO: Remove once FD enabled on Quasar)
-    if (fixture->IsSlowDispatch() && !is_idle_eth_core && !is_quasar) {
+    if (fixture->IsSlowDispatch() && !is_idle_eth_core) {
         GTEST_SKIP() << "Slow Dispatch tests only run on Quasar or IDLE_ETH cores";
     }
     if (multi_dm_race && !is_quasar) {
@@ -449,16 +449,16 @@ void RunTestOnCore(
     }
     workload.add_program(device_range, std::move(program));
 
-    // Run the kernel, expect an exception here
+    // Run the kernel; its illegal NoC transaction trips watcher test mode. Whether that reaches the
+    // host as an exception here is a race with the watcher poll (fires on the slow Quasar sim via
+    // #48842's fast-dispatch rethrow; usually not on fast HW), so this catch is best-effort. The
+    // watcher-log check below always runs (regardless of this catch) and is the real verification.
     try {
         fixture->RunProgram(mesh_device, workload);
     } catch (std::runtime_error& e) {
-        std::string expected =
-            "Command Queue could not finish: device hang due to illegal NoC transaction. See {} for details.\n";
-        expected += MetalContext::instance().watcher_server()->log_file_name();
         const std::string error = std::string(e.what());
         log_info(tt::LogTest, "Caught exception (one is expected in this test)");
-        EXPECT_TRUE(error.find(expected) != std::string::npos);
+        EXPECT_TRUE(error.find("Aborting wait due to watcher error") != std::string::npos) << error;
     }
 
     // We should be able to find the expected watcher error in the log as well.

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -108,10 +108,14 @@ void RunTestOnCore(
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
     bool is_quasar = hal.get_arch() == tt::ARCH::QUASAR;
 
-    // IDLE_ETH cores only support SD (FD not yet implemented)
-    // TENSIX/ACTIVE_ETH cores: SD only used for Quasar watcher tests (TODO: Remove once FD enabled on Quasar)
+    if (tt::tt_metal::MetalContext::instance().rtoptions().watcher_noc_sanitize_disabled()) {
+        GTEST_SKIP();
+    }
+
+    // IDLE_ETH cores only support slow dispatch (FD not yet implemented for them).
+    // All other cores (TENSIX/ACTIVE_ETH, including Quasar) run under fast dispatch.
     if (fixture->IsSlowDispatch() && !is_idle_eth_core) {
-        GTEST_SKIP() << "Slow Dispatch tests only run on Quasar or IDLE_ETH cores";
+        GTEST_SKIP() << "Slow Dispatch only runs IDLE_ETH core tests";
     }
     if (multi_dm_race && !is_quasar) {
         GTEST_SKIP() << "Multi-DM race test only runs on Quasar";

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -108,10 +108,6 @@ void RunTestOnCore(
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
     bool is_quasar = hal.get_arch() == tt::ARCH::QUASAR;
 
-    if (tt::tt_metal::MetalContext::instance().rtoptions().watcher_noc_sanitize_disabled()) {
-        GTEST_SKIP();
-    }
-
     // IDLE_ETH cores only support SD (FD not yet implemented)
     // TENSIX/ACTIVE_ETH cores: SD only used for Quasar watcher tests (TODO: Remove once FD enabled on Quasar)
     if (fixture->IsSlowDispatch() && !is_idle_eth_core && !is_quasar) {

--- a/tt_metal/impl/context/metal_env.cpp
+++ b/tt_metal/impl/context/metal_env.cpp
@@ -179,9 +179,6 @@ void MetalEnvImpl::initialize_base_objects() {
                 "Enabling DRAM-backed command queues for Quasar simulator because host hugepages are not available");
             this->rtoptions_->set_dram_backed_cq(true);
         }
-        // Watcher NOC sanitization currently only works on Quasar in slow dispatch.
-        // TODO: Remove this once NOC sanitization is supported on Quasar in fast dispatch (#45878)
-        this->rtoptions_->disable_watcher_noc_sanitize();
     }
 
     // Get is_base_routing_fw_enabled from the already-constructed Cluster instead of running

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -122,13 +122,6 @@ void WatcherServer::Impl::attach_devices() {
         return;
     }
 
-    // TODO: Remove this once NOC sanitization is supported on Quasar in fast dispatch (#45878)
-    if (env_.get_hal().get_arch() == tt::ARCH::QUASAR && rtoptions.get_fast_dispatch()) {
-        log_warning(
-            tt::LogMetal,
-            "Watcher NOC sanitization has been disabled as it is currently not supported on Quasar in fast dispatch.");
-    }
-
     {
         const std::lock_guard<std::mutex> lock(watch_mutex_);
         create_log_file();

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -466,10 +466,7 @@ public:
     bool watcher_eth_link_status_disabled() const { return watcher_feature_disabled(watcher_eth_link_status_str); }
     bool watcher_cb_sanitize_disabled() const { return watcher_feature_disabled(watcher_cb_sanitize_str); }
 
-    // TODO: Remove these Watcher NOC sanitize functions once NOC sanitization is supported on Quasar in fast dispatch
-    // (#45878)
     bool watcher_noc_sanitize_disabled() const { return watcher_feature_disabled(watcher_noc_sanitize_str); }
-    void disable_watcher_noc_sanitize() { watcher_disabled_features.insert(watcher_noc_sanitize_str); }
 
     bool get_lightweight_kernel_asserts() const { return lightweight_kernel_asserts; }
     void set_lightweight_kernel_asserts(bool enabled) { lightweight_kernel_asserts = enabled; }


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Enables watcher NOC sanitization in fast-dispatch (FD) mode on Quasar, which was disabled in https://github.com/tenstorrent/tt-metal/pull/47892. It was disabled because the NOC sanitize with_state path read the destination coordinate from the legacy WH/BH command-buffer registers, which on Quasar held garbage -- triggering false positive sanitize errors. That root cause was fixed in https://github.com/tenstorrent/tt-metal/pull/46234, which reads the NoC cmd_buf registers via the RoCC overlay API on Quasar. Since correct values are read now, the with_state sanitize check no longer sees garbage, so FD sanitization can be safely re-enabled. This removes the Quasar-FD force-disable (and its startup warning) and updates the watcher sanitize tests to run on Quasar FD.

### Notes for reviewers
The one thing worth a look is the assertion change in test_sanitize.cpp. Enabling these tests on Quasar FD surfaced a latent, stale assertion: the try/catch around RunProgram checked for "Command Queue could not finish: device hang due to illegal NoC transaction…", a message that no longer exists in the runtime (removed when HWCommandQueue was replaced by the mesh command queue). That catch only fires when the watcher error propagates to the host - a race with the watcher poll:
- Actual non-sim HW (WH/BH): Finish() returns before the watcher poll notices --> catch never entered --> the stale assertion was never evaluated (why it stayed invisible there).
- Quasar sim (slow): Finish() is still waiting when the watcher trips --> https://github.com/tenstorrent/tt-metal/pull/48842 's FD rethrow throws out of Finish() --> catch fires --> stale assertion failed.

Fix: assert on the message the runtime actually throws ("Aborting wait due to watcher error"). The detailed verification (addr/size/error-type/coords) lives in the unconditional EXPECT_EQ against the watcher log, which runs on every arch regardless of the race.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadkarni/enable_noc_sanitization_fd)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadkarni/enable_noc_sanitization_fd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=snadkarni/enable_noc_sanitization_fd)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:snadkarni/enable_noc_sanitization_fd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=snadkarni/enable_noc_sanitization_fd)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:snadkarni/enable_noc_sanitization_fd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/enable_noc_sanitization_fd)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/enable_noc_sanitization_fd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=snadkarni/enable_noc_sanitization_fd)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:snadkarni/enable_noc_sanitization_fd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/enable_noc_sanitization_fd)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/enable_noc_sanitization_fd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/enable_noc_sanitization_fd)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/enable_noc_sanitization_fd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/enable_noc_sanitization_fd)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/enable_noc_sanitization_fd)