### PR TITLE
[Feature]: Make read_tile_value templated and add test for read_tile_value/get_tile_address

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_apis.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_apis.cpp
@@ -1,0 +1,194 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Device-side DataflowBuffer API tests (read_tile_value / get_tile_address).
+// DM → Tensix, 1 producer × 1 consumer, 2-entry DFB, explicit sync (WH/BH).
+//
+// Quasar is skipped until read_tile_value / get_tile_address on 2xx DFB is debugged.
+
+#include <cstdint>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+#include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
+#include <tt-metalium/experimental/tensor/topology/tensor_topology.hpp>
+#include <tt-metalium/experimental/tensor/spec/tensor_spec.hpp>
+#include <tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp>
+#include <tt-metalium/experimental/tensor/spec/layout/page_config.hpp>
+
+#include "dfb_test_common.hpp"
+#include "device_fixture.hpp"
+#include "tt_metal/test_utils/stimulus.hpp"
+#include "umd/device/driver_atomics.hpp"
+
+namespace tt::tt_metal {
+
+namespace m2 = experimental;
+
+TEST_F(MeshDeviceFixture, DataflowBufferReadTileValue) {
+    using DataT = std::uint32_t;
+
+    auto mesh_device = devices_.at(0);
+    IDevice* device = mesh_device->get_devices()[0];
+    if (device->arch() == ARCH::QUASAR) {
+        GTEST_SKIP() << "Quasar read_tile_value / get_tile_address on DFB is under debug; run on WH/BH";
+    }
+
+    constexpr uint32_t num_producers = 1;
+    constexpr uint32_t num_consumers = 1;
+    constexpr uint32_t entry_size = 1024;
+    constexpr uint32_t num_entries = 2;
+
+    constexpr uint32_t num_results_per_thread = 7;
+    constexpr uint32_t num_trisc_threads = 3;
+
+    // Tile 0 / tile 1 scalars at element offsets 0 and 1 within each entry.
+    constexpr DataT tile0_val0 = 0xA5A5A5A5u;
+    constexpr DataT tile0_val1 = 0x11111111u;
+    // Distinct low/high halfwords so uint16 reads can distinguish T-indexing from uint32-indexing + truncate.
+    constexpr DataT tile1_val0 = 0xABCD1234u;
+    constexpr DataT tile1_val1 = 0x33333333u;
+    constexpr uint16_t tile1_val0_lo = 0x1234u;
+    constexpr uint16_t tile1_val0_hi = 0xABCDu;
+    // Both entries stay at the front; tile_index 0/1 address fifo_rd_ptr + {0, fifo_page_size}.
+    // Per thread: {tile0[0], tile0[1], tile1[0], tile1[1], get_tile_address(1)[0],
+    //             read_tile_value<uint16_t>(1)[0], read_tile_value<uint16_t>(1)[1]}
+    const std::vector<DataT> expected_per_thread = {
+        tile0_val0,
+        tile0_val1,
+        tile1_val0,
+        tile1_val1,
+        tile1_val0,
+        tile1_val0_lo,
+        tile1_val0_hi};
+    // UNPACK, MATH, and PACK each write expected_per_thread to a distinct L1 slot.
+    std::vector<DataT> expected_scalar_reads;
+    expected_scalar_reads.reserve(num_results_per_thread * num_trisc_threads);
+    for (uint32_t thread = 0; thread < num_trisc_threads; ++thread) {
+        expected_scalar_reads.insert(
+            expected_scalar_reads.end(), expected_per_thread.begin(), expected_per_thread.end());
+    }
+
+    const m2::NodeCoord node{0, 0};
+    const m2::DFBSpecName DFB{"dfb"};
+    const m2::KernelSpecName PRODUCER{"producer"};
+    const m2::KernelSpecName CONSUMER{"consumer"};
+    const m2::TensorParamName IN_TENSOR{"in_tensor"};
+
+    const uint32_t words_per_entry = entry_size / sizeof(DataT);
+
+    const auto tensor_spec = make_flat_dram_tensor_spec(entry_size, num_entries);
+    auto in_tensor = MeshTensor::allocate_on_device(*mesh_device, tensor_spec, TensorTopology{});
+
+    m2::DataflowBufferSpec dfb_spec{
+        .unique_id = DFB,
+        .entry_size = entry_size,
+        .num_entries = num_entries,
+        .data_format_metadata = DataFormat::Float16_b,
+    };
+
+    m2::KernelSpec producer{
+        .unique_id = PRODUCER,
+        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp",
+        .num_threads = num_producers,
+        .dfb_bindings =
+            {{.dfb_spec_name = DFB,
+              .accessor_name = "out",
+              .endpoint_type = m2::DFBEndpointType::PRODUCER,
+              .access_pattern = m2::DFBAccessPattern::STRIDED}},
+        .tensor_bindings = {{.tensor_parameter_name = IN_TENSOR, .accessor_name = "src_tensor"}},
+        .compile_time_args =
+            {
+                {"num_entries_per_producer", num_entries},
+                {"implicit_sync", 0u},
+                {"num_producers", num_producers},
+            },
+        .runtime_arg_schema = {.runtime_arg_names = {"chunk_offset", "entries_per_core"}},
+        .hw_config = m2::DataMovementGen1Config{.processor = DataMovementProcessor::RISCV_0},
+    };
+
+    m2::KernelSpec consumer{
+        .unique_id = CONSUMER,
+        .source = "tests/tt_metal/tt_metal/test_kernels/compute/dfb_read_tile_value_compute.cpp",
+        .num_threads = num_consumers,
+        .dfb_bindings =
+            {{.dfb_spec_name = DFB,
+              .accessor_name = "in",
+              .endpoint_type = m2::DFBEndpointType::CONSUMER,
+              .access_pattern = m2::DFBAccessPattern::STRIDED}},
+        .compile_time_args = {{"num_entries_per_consumer", num_entries}},
+        .runtime_arg_schema = {.runtime_arg_names = {"result_l1_addr"}},
+        .hw_config = m2::ComputeGen1Config{},
+    };
+
+    m2::WorkUnitSpec wu{.name = "wu", .kernels = {PRODUCER, CONSUMER}, .target_nodes = node};
+
+    m2::ProgramSpec spec{
+        .name = "dfb_read_tile_value_2tiles",
+        .kernels = {producer, consumer},
+        .dataflow_buffers = {dfb_spec},
+        .tensor_parameters = {{.unique_id = IN_TENSOR, .spec = in_tensor.tensor_spec()}},
+        .work_units = {wu},
+    };
+
+    Program program = m2::MakeProgramFromSpec(*mesh_device, spec);
+
+    const uint32_t result_size_bytes = static_cast<uint32_t>(expected_scalar_reads.size() * sizeof(DataT));
+    const uint32_t l1_alignment = device->allocator()->get_alignment(BufferType::L1);
+    const uint32_t aligned_result_size = (result_size_bytes + l1_alignment - 1) / l1_alignment * l1_alignment;
+    const uint32_t result_l1_addr = static_cast<uint32_t>(device->l1_size_per_core()) - aligned_result_size;
+
+    m2::ProgramRunArgs params;
+    params.kernel_run_args = {
+        m2::ProgramRunArgs::KernelRunArgs{
+            .kernel = PRODUCER,
+            .runtime_arg_values =
+                {{.node = node, .args = {{"chunk_offset", 0u}, {"entries_per_core", num_entries}}}},
+        },
+        m2::ProgramRunArgs::KernelRunArgs{
+            .kernel = CONSUMER,
+            .runtime_arg_values = {{.node = node, .args = {{"result_l1_addr", result_l1_addr}}}},
+        },
+    };
+    params.tensor_args = {{IN_TENSOR, std::cref(in_tensor)}};
+    m2::SetProgramRunArgs(program, params);
+
+    const uint32_t total_words = num_entries * words_per_entry;
+    auto input = tt::test_utils::generate_uniform_random_vector<DataT>(0, 1000000, total_words);
+    input[0] = tile0_val0;
+    input[1] = tile0_val1;
+    input[words_per_entry + 0] = tile1_val0;
+    input[words_per_entry + 1] = tile1_val1;
+    detail::WriteToBuffer(*in_tensor.mesh_buffer().get_reference_buffer(), input);
+
+    std::vector<DataT> result_init(expected_scalar_reads.size(), 0u);
+    detail::WriteToDeviceL1(device, CoreCoord(0, 0), result_l1_addr, result_init);
+
+    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+
+    tt_driver_atomics::mfence();
+    std::vector<DataT> scalar_results;
+    detail::ReadFromDeviceL1(device, CoreCoord(0, 0), result_l1_addr, result_size_bytes, scalar_results);
+    ASSERT_EQ(scalar_results.size(), expected_scalar_reads.size());
+    for (uint32_t thread = 0; thread < num_trisc_threads; ++thread) {
+        const auto begin = scalar_results.begin() + thread * num_results_per_thread;
+        EXPECT_EQ(
+            std::vector<DataT>(begin, begin + num_results_per_thread),
+            expected_per_thread)
+            << "TRISC thread slot " << thread;
+    }
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -20,6 +20,7 @@ set(UNIT_TESTS_API_SOURCES
     core_coord/test_CoreRangeSet_intersects.cpp
     core_coord/test_CoreRangeSet_merge.cpp
     dataflow_buffer/test_alias_dataflow_buffer.cpp
+    dataflow_buffer/test_dataflow_buffer_apis.cpp
     dataflow_buffer/test_dataflow_buffer_base.cpp
     dataflow_buffer/test_dataflow_buffer_multinode.cpp
     dataflow_buffer/test_dataflow_buffer_intra.cpp

--- a/tests/tt_metal/tt_metal/test_kernels/compute/dfb_read_tile_value_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dfb_read_tile_value_compute.cpp
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/compute/common.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "dev_mem_map.h"
+#include "experimental/kernel_args.h"
+
+#include <cstdint>
+
+void kernel_main() {
+    constexpr uint32_t num_entries_per_consumer = get_arg(args::num_entries_per_consumer);
+    const uint32_t result_l1_addr = get_arg(args::result_l1_addr);
+
+    DataflowBuffer dfb(dfb::in);
+    unary_op_init_common(dfb.get_id(), dfb.get_id());
+
+    // Keep both entries at the front so tile_index 1 exercises fifo_page_size stride.
+    // Each TRISC thread writes the same mailbox-broadcast results to its own L1 slot so
+    // the host can verify UNPACK/MATH/PACK all received the same values.
+    constexpr uint32_t k_num_results = 7;
+    uint32_t results[k_num_results] = {};
+
+    dfb.wait_front(num_entries_per_consumer);
+
+    results[0] = dfb.read_tile_value<uint32_t>(0, 0);
+    results[1] = dfb.read_tile_value<uint32_t>(0, 1);
+    results[2] = dfb.read_tile_value<uint32_t>(1, 0);
+    results[3] = dfb.read_tile_value<uint32_t>(1, 1);
+
+    const uint32_t tile_addr = dfb.get_tile_address(1);
+    results[4] = *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(tile_addr);
+    results[5] = static_cast<uint32_t>(dfb.read_tile_value<uint16_t>(1, 0));
+    results[6] = static_cast<uint32_t>(dfb.read_tile_value<uint16_t>(1, 1));
+
+    tile_regs_acquire();
+    for (uint32_t i = 0; i < num_entries_per_consumer; ++i) {
+        copy_tile(dfb.get_id(), 0, 0);  // dummy copy to avoid UNPACK wait -> pop trap on Quasar
+        dfb.pop_front(1);
+    }
+    tile_regs_release();
+
+#if defined(TRISC_UNPACK) || defined(TRISC_MATH) || defined(TRISC_PACK)
+#ifdef ARCH_QUASAR
+    const uint32_t result_l1_ptr_addr = result_l1_addr + MEM_L1_UNCACHED_BASE;
+#else
+    const uint32_t result_l1_ptr_addr = result_l1_addr;
+#endif
+    volatile tt_l1_ptr uint32_t* const out =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(result_l1_ptr_addr);
+#if defined(TRISC_UNPACK)
+    constexpr uint32_t slot_base = 0 * k_num_results;
+#elif defined(TRISC_MATH)
+    constexpr uint32_t slot_base = 1 * k_num_results;
+#elif defined(TRISC_PACK)
+    constexpr uint32_t slot_base = 2 * k_num_results;
+#endif
+    for (uint32_t i = 0; i < k_num_results; ++i) {
+        out[slot_base + i] = results[i];
+    }
+#endif
+
+    dfb.finish();
+}

--- a/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
@@ -212,9 +212,16 @@ public:
 #endif // DFB_DESCRIPTORS_DEFINED
 
 #ifdef COMPILE_FOR_TRISC
+// This can be enabled on Quasar once GH issue #49608 is resolved.
 #ifndef ARCH_QUASAR
     uint32_t get_tile_address(uint32_t tile_index);
-    uint32_t read_tile_value(uint32_t tile_index, uint32_t element_offset);
+
+    // Reads one scalar element from a tile at specified tile_index. element_offset is an index into the tile as a T[]
+    // array from its L1 base address (not a byte offset); each step is sizeof(T) bytes
+    // (default T=uint32_t → 4-byte words).
+    // Values are mailbox-broadcast to all TRISC threads as a zero-extended uint32_t; MATH/PACK cast back to T.
+    template <typename T = uint32_t>
+    T read_tile_value(uint32_t tile_index, uint32_t element_offset);
 #endif
 #endif
 

--- a/tt_metal/hw/inc/internal/tt-1xx/dataflow_buffer.inl
+++ b/tt_metal/hw/inc/internal/tt-1xx/dataflow_buffer.inl
@@ -10,6 +10,7 @@
 #ifdef COMPILE_FOR_TRISC
 #include "api/compute/common_globals.h"  // defines PACK/UNPACK/MATH macros
 #include "internal/circular_buffer_interface.h"
+#include <type_traits>
 #ifdef TRISC_PACK
 #include "llk_io_pack.h"
 #endif
@@ -107,6 +108,7 @@ inline uint32_t DataflowBuffer::get_read_ptr_impl() const {
 }
 
 #ifdef COMPILE_FOR_TRISC
+
 inline uint32_t DataflowBuffer::get_tile_address(uint32_t tile_index) {
     uint32_t address = 0;
 
@@ -125,22 +127,28 @@ inline uint32_t DataflowBuffer::get_tile_address(uint32_t tile_index) {
     return address;
 }
 
-inline uint32_t DataflowBuffer::read_tile_value(uint32_t tile_index, uint32_t element_offset) {
-    uint32_t value = 0;
+template <typename T>
+T DataflowBuffer::read_tile_value(uint32_t tile_index, uint32_t element_offset) {
+    static_assert(sizeof(T) == 1 || sizeof(T) == 2 || sizeof(T) == 4, "read_tile_value: T must be 1, 2, or 4 bytes");
+    static_assert(
+        (std::is_integral_v<T> && std::is_unsigned_v<T> && !std::is_same_v<T, bool>),
+        "read_tile_value: T must be an unsigned integral type");
+
+    T value = T{};
 
     UNPACK({
-        uint32_t base_address = local_dfb_interface_.fifo_rd_ptr;
-        uint32_t offset_address = local_dfb_interface_.fifo_page_size * tile_index;
-        uint32_t byte_address = (base_address + offset_address) << 4;  // Convert to byte address
+        const uint32_t base_address = local_dfb_interface_.fifo_rd_ptr;
+        const uint32_t offset_address = local_dfb_interface_.fifo_page_size * tile_index;
+        const uint32_t byte_address = (base_address + offset_address) << 4;
 
-        value = reinterpret_cast<volatile uint32_t*>(byte_address)[element_offset];
+        value = reinterpret_cast<volatile T*>(byte_address)[element_offset];
 
-        mailbox_write(ckernel::ThreadId::MathThreadId, value);
-        mailbox_write(ckernel::ThreadId::PackThreadId, value);
+        mailbox_write(ckernel::ThreadId::MathThreadId, static_cast<uint32_t>(value));
+        mailbox_write(ckernel::ThreadId::PackThreadId, static_cast<uint32_t>(value));
     })
 
-    MATH(value = mailbox_read(ckernel::ThreadId::UnpackThreadId);)
-    PACK(value = mailbox_read(ckernel::ThreadId::UnpackThreadId);)
+    MATH(value = static_cast<T>(mailbox_read(ckernel::ThreadId::UnpackThreadId));)
+    PACK(value = static_cast<T>(mailbox_read(ckernel::ThreadId::UnpackThreadId));)
 
     return value;
 }


### PR DESCRIPTION
### Summary
Ops have a read_tile_value_u16 variant but this can be consolidated into a templated read_tile_value on DFB. This will help clean up op porting from CBs to DFBs. 

A follow up PR will be posted to extend these APIs on Quasar once https://github.com/tenstorrent/tt-metal/issues/49608 is addressed. 

https://github.com/tenstorrent/tt-metal/actions/runs/29117144023
https://github.com/tenstorrent/tt-metal/actions/runs/29117176617

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abhullar/dfb-tile-val-addr)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/dfb-tile-val-addr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=abhullar/dfb-tile-val-addr)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:abhullar/dfb-tile-val-addr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=abhullar/dfb-tile-val-addr)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:abhullar/dfb-tile-val-addr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abhullar/dfb-tile-val-addr)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abhullar/dfb-tile-val-addr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=abhullar/dfb-tile-val-addr)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:abhullar/dfb-tile-val-addr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=abhullar/dfb-tile-val-addr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:abhullar/dfb-tile-val-addr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=abhullar/dfb-tile-val-addr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:abhullar/dfb-tile-val-addr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=abhullar/dfb-tile-val-addr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:abhullar/dfb-tile-val-addr)