### PR TITLE
[deepseek_prefill] unified_routed_expert_ffn: expert-bias support (gpt-oss)

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
@@ -155,6 +155,57 @@ class TtRoutedExpert(LightweightModule):
         return (gate_tensors, up_tensors, down_tensors) if device else None
 
     @staticmethod
+    def _convert_expert_biases(
+        torch_biases: list[dict],
+        experts_per_chip: int,
+        mesh_device: ttnn.MeshDevice,
+        bias_dtype=ttnn.bfloat16,
+    ):
+        """Convert per-expert gate/up/down biases to mesh-distributed ttnn tensors.
+
+        Each torch bias dict has keys gate_proj_bias/up_proj_bias/down_proj_bias (1D,
+        length = projection N). Returns (gate, up, down) lists of one (1, N) TILE tensor
+        per local expert, distributed across the mesh exactly like the routed weights
+        (reusing the weight gather + mesh mapper by remapping the bias keys).
+        """
+        mesh_rows, mesh_cols = mesh_device.shape
+        mapper = ExpertMapping.get_weights_mesh_mapper(mesh_device)
+        # Remap bias keys so the weight-distribution gather can be reused verbatim.
+        as_weights = [
+            {
+                "gate_proj": d["gate_proj_bias"],
+                "up_proj": d["up_proj_bias"],
+                "down_proj": d["down_proj_bias"],
+            }
+            for d in torch_biases
+        ]
+
+        def _to_tt(per_pos_biases):
+            # each entry is 1D (N,) -> (1, N); stack per mesh position -> (rows, cols, 1, N)
+            stacked = torch.stack([b.reshape(1, -1) for b in per_pos_biases], dim=0)
+            n = stacked.shape[-1]
+            stacked = stacked.reshape(mesh_rows, mesh_cols, 1, n)
+            tt = ttnn.as_tensor(
+                stacked,
+                mesh_mapper=mapper,
+                layout=ttnn.TILE_LAYOUT,
+                device=mesh_device,
+                dtype=bias_dtype,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            return ttnn.squeeze(ttnn.squeeze(tt, dim=0), dim=0)  # per device: (1, N)
+
+        gate_biases, up_biases, down_biases = [], [], []
+        for local_expert_idx in range(experts_per_chip):
+            gb, ub, db = ExpertMapping.gather_weights_for_mesh_distribution(
+                as_weights, local_expert_idx, mesh_rows, mesh_cols, experts_per_chip
+            )
+            gate_biases.append(_to_tt(gb))
+            up_biases.append(_to_tt(ub))
+            down_biases.append(_to_tt(db))
+        return gate_biases, up_biases, down_biases
+
+    @staticmethod
     def build_ttnn_cache(
         torch_weights: list[dict],
         experts_per_chip: int,
@@ -257,18 +308,11 @@ class TtRoutedExpert(LightweightModule):
             )
         self.activation = activation
 
-        # Optional per-expert projection biases (gpt-oss). WIP: the op accepts,
-        # validates, and caches bias inputs, but the fused kernel does not add
-        # them yet (program-factory CBs + reader reads + compute broadcast-add
-        # are the remaining work — PR #49619). Guard so a caller can't silently
-        # get bias-free results. Wire the conversion + forward pass-through once
-        # the kernel supports bias.
-        if torch_biases is not None:
-            raise NotImplementedError(
-                "TtRoutedExpert expert-bias support is WIP (gpt-oss): the fused kernel does not add gate/up/down "
-                "biases yet. Tracked in PR #49619."
-            )
-        self.torch_biases = None
+        # Optional per-expert projection biases (gpt-oss). Only supported with
+        # SwiGluOai (the kernel adds gate/up bias before the clamp and down bias
+        # after the down matmul). Converted + distributed like the weights below.
+        if torch_biases is not None and activation != ttnn.RoutedExpertActivation.SwiGluOai:
+            raise ValueError("TtRoutedExpert expert biases are only supported with RoutedExpertActivation.SwiGluOai")
 
         total_experts = self.num_devices * experts_per_chip
         logger.debug(f"Initializing TtRoutedExpert with experts_per_chip={experts_per_chip}")
@@ -336,6 +380,19 @@ class TtRoutedExpert(LightweightModule):
 
         assert result is not None, "Expected weight tensors to be returned when device is provided"
         self.gate_projs, self.up_projs, self.down_projs = result
+
+        # Convert + distribute optional per-expert biases (gpt-oss), one (1, N)
+        # tensor per local expert, mesh-distributed like the weights.
+        self.gate_biases = None
+        self.up_biases = None
+        self.down_biases = None
+        if torch_biases is not None:
+            assert (
+                len(torch_biases) == total_experts
+            ), f"Expected {total_experts} expert biases, got {len(torch_biases)}"
+            self.gate_biases, self.up_biases, self.down_biases = self._convert_expert_biases(
+                torch_biases, experts_per_chip, self.mesh_device
+            )
 
     @staticmethod
     def shard_expert_token_counts(
@@ -448,9 +505,15 @@ class TtRoutedExpert(LightweightModule):
                 max_dispatched_tokens_per_expert=self.max_tokens,
                 compute_kernel_config=self.compute_kernel_config,
                 activation=self.activation,
+                gate_biases=self.gate_biases,
+                up_biases=self.up_biases,
+                down_biases=self.down_biases,
             )
             logger.debug(f"Final expert_outputs shape: {expert_outputs.shape}")
             return expert_outputs
+
+        if self.gate_biases is not None:
+            raise NotImplementedError("Expert bias is only supported on the Blackhole fused path")
 
         # Wormhole fallback: the per-expert extract → FFN → insert loop needs a
         # TILE activations_dtype buffer. A ROW_MAJOR input is tilized and cast in

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
@@ -196,6 +196,7 @@ class TtRoutedExpert(LightweightModule):
         hidden_dim: int = 2 * 1024,
         max_tokens: int = 1600,
         torch_weights: list[dict] = None,
+        torch_biases: list[dict] = None,
         activations_dtype=ttnn.bfloat8_b,
         weights_dtype=ttnn.bfloat4_b,
         compute_kernel_config: ttnn.WormholeComputeKernelConfig = COMPUTE_KERNEL_CONFIG_LOFI,
@@ -255,6 +256,19 @@ class TtRoutedExpert(LightweightModule):
                 "TtRoutedExpert requires an explicit `activation` (ttnn.RoutedExpertActivation.Silu or .SwiGluOai)"
             )
         self.activation = activation
+
+        # Optional per-expert projection biases (gpt-oss). WIP: the op accepts,
+        # validates, and caches bias inputs, but the fused kernel does not add
+        # them yet (program-factory CBs + reader reads + compute broadcast-add
+        # are the remaining work — PR #49619). Guard so a caller can't silently
+        # get bias-free results. Wire the conversion + forward pass-through once
+        # the kernel supports bias.
+        if torch_biases is not None:
+            raise NotImplementedError(
+                "TtRoutedExpert expert-bias support is WIP (gpt-oss): the fused kernel does not add gate/up/down "
+                "biases yet. Tracked in PR #49619."
+            )
+        self.torch_biases = None
 
         total_experts = self.num_devices * experts_per_chip
         logger.debug(f"Initializing TtRoutedExpert with experts_per_chip={experts_per_chip}")

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_routed_expert_bias.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_routed_expert_bias.py
@@ -244,6 +244,94 @@ def test_gptoss_bias_multi_expert(mesh_device, device_params, counts):
     run_multi_expert_bias(mesh_device, counts=counts, emb_dim=GPT_OSS_EMB, hidden_dim=GPT_OSS_HIDDEN)
 
 
+def run_bias_cache_hit(mesh_device, emb_dim, hidden_dim, num_tokens=256):
+    """Two invocations with IDENTICAL op attributes (same expert id, dims, token count,
+    and weights) but DIFFERENT bias tensors. The second call is a program-cache HIT, so
+    the reused program must patch the bias buffer addresses via runtime args; a stale
+    address would silently re-apply the first call's bias. Each output is checked against
+    its own reference, and the two outputs must differ (proving the second bias took effect)."""
+    torch.manual_seed(7)
+
+    # Shared weights across both calls — only the biases change, so the compare isolates
+    # bias-address patching rather than weight-address patching.
+    weights = {
+        "gate_proj": torch.randn(hidden_dim, emb_dim, dtype=torch.float32) * 0.08,
+        "up_proj": torch.randn(hidden_dim, emb_dim, dtype=torch.float32) * 0.08,
+        "down_proj": torch.randn(emb_dim, hidden_dim, dtype=torch.float32) * 0.05,
+    }
+
+    def _biases(scale):
+        return {
+            "gate_proj_bias": torch.randn(hidden_dim, dtype=torch.float32) * scale,
+            "up_proj_bias": torch.randn(hidden_dim, dtype=torch.float32) * scale,
+            "down_proj_bias": torch.randn(emb_dim, dtype=torch.float32) * scale,
+        }
+
+    biases_a = _biases(0.5)
+    biases_b = _biases(0.9)  # different magnitude + different values
+
+    torch_input = torch.randn(num_tokens, emb_dim, dtype=torch.float32)
+    with torch.no_grad():
+        ref_a = _torch_swigluoai_expert_with_bias(torch_input, weights, biases_a)
+        ref_b = _torch_swigluoai_expert_with_bias(torch_input, weights, biases_b)
+
+    def _idx(values):
+        return ttnn.from_torch(
+            torch.tensor(values, dtype=torch.int32),
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=mesh_device,
+            dtype=ttnn.uint32,
+        )
+
+    def run_once(biases):
+        # A fresh TtRoutedExpert each call → new bias buffers, but IDENTICAL op attributes
+        # (expert id / dims / max_tokens / counts / dtypes / activation / fuse_bias), so the
+        # second invocation reuses the cached program and exercises the address override.
+        tt_expert = TtRoutedExpert(
+            mesh_device=mesh_device,
+            experts_per_chip=1,
+            global_expert_idx_table=_idx([0]),
+            emb_dim=emb_dim,
+            hidden_dim=hidden_dim,
+            max_tokens=num_tokens,
+            torch_weights=[weights],
+            torch_biases=[biases],
+            activations_dtype=ttnn.bfloat8_b,
+            weights_dtype=ttnn.bfloat4_b,
+            activation=ttnn.RoutedExpertActivation.SwiGluOai,
+        )
+        tt_input = ttnn.from_torch(
+            torch_input,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+            layout=ttnn.TILE_LAYOUT,
+            device=mesh_device,
+            dtype=ttnn.bfloat8_b,
+        )
+        out = tt_expert(tt_input, _idx([num_tokens]), _idx([0]))
+        return ttnn.to_torch(out, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))[:num_tokens]
+
+    out_a = run_once(biases_a)
+    out_b = run_once(biases_b)  # program-cache hit on identical attrs → must patch bias addrs
+
+    pass_a, pcc_a = comp_pcc(ref_a, out_a, 0.97)
+    pass_b, pcc_b = comp_pcc(ref_b, out_b, 0.97)
+    logger.info(f"cache-hit bias: call A PCC={pcc_a}, call B (cache hit) PCC={pcc_b}")
+    assert pass_a, f"call A PCC below threshold: {pcc_a}"
+    assert pass_b, f"call B (cache hit) PCC below threshold: {pcc_b} — stale bias address on program-cache hit?"
+    # Sanity: the two biases genuinely produce different outputs, so B's pass is not a
+    # vacuous match against A's (still-resident) bias.
+    assert not torch.allclose(out_a, out_b, atol=1e-2), "outputs identical — second bias did not take effect"
+
+
+@pytest.mark.skipif(not is_blackhole(), reason="unified_routed_expert op is Blackhole-only")
+@pytest.mark.parametrize(
+    "mesh_device, device_params", SINGLE_CHIP_MESH_PARAMS, indirect=["mesh_device", "device_params"]
+)
+def test_gptoss_bias_cache_hit(mesh_device, device_params):
+    """Program-cache hit must patch bias buffer addresses (no stale bias), gpt-oss dims."""
+    run_bias_cache_hit(mesh_device, emb_dim=GPT_OSS_EMB, hidden_dim=GPT_OSS_HIDDEN)
+
+
 def test_gptoss_bias_torch_reference_smoke():
     """Host-only (no device): guards the bias SwiGLU-OAI reference math and documents the gpt-oss
     expert formula. Not skipped — proves bias actually changes the output vs the bias-free path, so

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_routed_expert_bias.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_routed_expert_bias.py
@@ -3,12 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-[DRAFT / WIP — gpt-oss] Single-device PCC *spec* test for **expert biases** in the fused
+[gpt-oss] Single-device PCC tests for **expert biases** in the fused
 ``unified_routed_expert_ffn`` op.
 
 gpt-oss MoE experts add a learned bias to the gate, up, AND down projections — unlike
-DeepSeek-V3 / MiniMax-M3, which are bias-free (so the fused op was never given bias support).
-Target behaviour (clamped SwiGLU-OAI, limit=7.0, alpha=1.702):
+DeepSeek-V3 / MiniMax-M3, which are bias-free. The fused kernel adds gate/up bias BEFORE the
+SwiGLU-OAI clamp and down bias AFTER the down matmul. Target behaviour (clamped SwiGLU-OAI,
+limit=7.0, alpha=1.702):
 
     gate = x @ gate_proj.T + gate_bias
     up   = x @ up_proj.T   + up_bias
@@ -17,10 +18,17 @@ Target behaviour (clamped SwiGLU-OAI, limit=7.0, alpha=1.702):
     act  = (up + 1) * gate * sigmoid(alpha * gate)
     out  = act @ down_proj.T + down_bias
 
-The fused op currently has NO bias support. The device test below *specifies* the target so
-the kernel work has a golden to hit; it is SKIPPED until bias fusion (and the ``TtRoutedExpert``
-bias API shown here) land — tracked in this PR. The host-only reference smoke test is NOT
-skipped, so the reference math (and the exact gpt-oss expert formula) is guarded meanwhile.
+Coverage (all single-chip; no multi-device mesh required):
+  - ``test_gptoss_bias_routed_expert``   — 1 expert, gate/up/down bias vs a torch reference.
+  - ``test_gptoss_bias_multi_expert``    — several experts on one chip, each with its own
+    weights+biases and a *different* token count, laid out ``max_tokens`` apart like the real
+    dispatch buffer. Exercises the per-expert bias-list wiring (``gate_biases[i]`` <-> expert i)
+    and the device-side per-expert count bounding.
+  - ``test_gptoss_bias_torch_reference_smoke`` — host-only; guards the reference math.
+
+Cross-device EP (mesh > 1) is intentionally not covered here (needs a Galaxy / multi-Blackhole
+box); the kernel is per-core / EP-agnostic and the bias mesh-distribution reuses the proven
+weight gather + mapper.
 """
 
 import pytest
@@ -132,6 +140,108 @@ def run_bias_routed_expert(mesh_device, num_tokens, emb_dim, hidden_dim):
 def test_gptoss_bias_routed_expert(mesh_device, device_params, num_tokens):
     """gpt-oss expert biases (gate/up/down) + SwiGLU-OAI vs torch. SPEC — skipped until kernel support lands."""
     run_bias_routed_expert(mesh_device, num_tokens=num_tokens, emb_dim=GPT_OSS_EMB, hidden_dim=GPT_OSS_HIDDEN)
+
+
+# Multiple experts on ONE chip. Different real token count per expert (all multiples of TILE=32,
+# all < max) so the device-side count bounding is exercised alongside the per-expert bias wiring.
+MULTI_EXPERT_PARAMS = [
+    pytest.param([128, 256, 64, 160], id="e4"),
+]
+
+
+def run_multi_expert_bias(mesh_device, counts, emb_dim, hidden_dim):
+    """N experts on 1 chip, each with its own weights+biases and token count.
+
+    Regions are laid out ``max_tokens`` apart (the production dispatch-buffer layout): expert e's
+    real tokens occupy the first ``counts[e]`` rows of its region, the rest is slack (random here,
+    to prove it is never read). The op mutates the shared buffer in place; each expert's output
+    lands back in ``[offset_e, offset_e + counts[e])`` and is compared to its own torch reference.
+    """
+    torch.manual_seed(123)
+    num_experts = len(counts)
+    max_tokens = max(counts)
+    offsets = [e * max_tokens for e in range(num_experts)]
+    total_rows = num_experts * max_tokens
+
+    weights_list, biases_list, inputs = [], [], []
+    for _ in range(num_experts):
+        weights_list.append(
+            {
+                "gate_proj": torch.randn(hidden_dim, emb_dim, dtype=torch.float32) * 0.08,
+                "up_proj": torch.randn(hidden_dim, emb_dim, dtype=torch.float32) * 0.08,
+                "down_proj": torch.randn(emb_dim, hidden_dim, dtype=torch.float32) * 0.05,
+            }
+        )
+        biases_list.append(
+            {
+                "gate_proj_bias": torch.randn(hidden_dim, dtype=torch.float32) * 0.5,
+                "up_proj_bias": torch.randn(hidden_dim, dtype=torch.float32) * 0.5,
+                "down_proj_bias": torch.randn(emb_dim, dtype=torch.float32) * 0.5,
+            }
+        )
+
+    # Shared dispatched buffer: random slack (must be ignored) + each expert's input tokens.
+    buf = torch.randn(total_rows, emb_dim, dtype=torch.float32)
+    for e in range(num_experts):
+        x_e = torch.randn(counts[e], emb_dim, dtype=torch.float32)
+        inputs.append(x_e)
+        buf[offsets[e] : offsets[e] + counts[e]] = x_e
+
+    with torch.no_grad():
+        expected = [
+            _torch_swigluoai_expert_with_bias(inputs[e], weights_list[e], biases_list[e]) for e in range(num_experts)
+        ]
+
+    tt_buf = ttnn.from_torch(
+        buf,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        dtype=ttnn.bfloat8_b,
+    )
+
+    def _idx(values):
+        return ttnn.from_torch(
+            torch.tensor(values, dtype=torch.int32),
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=mesh_device,
+            dtype=ttnn.uint32,
+        )
+
+    tt_expert = TtRoutedExpert(
+        mesh_device=mesh_device,
+        experts_per_chip=num_experts,
+        global_expert_idx_table=_idx(list(range(num_experts))),
+        emb_dim=emb_dim,
+        hidden_dim=hidden_dim,
+        max_tokens=max_tokens,
+        torch_weights=weights_list,
+        torch_biases=biases_list,
+        activations_dtype=ttnn.bfloat8_b,
+        weights_dtype=ttnn.bfloat4_b,
+        activation=ttnn.RoutedExpertActivation.SwiGluOai,
+    )
+
+    tt_out = tt_expert(tt_buf, _idx(counts), _idx(offsets))
+    out_torch = ttnn.to_torch(tt_out, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))
+
+    for e in range(num_experts):
+        region = out_torch[offsets[e] : offsets[e] + counts[e]]
+        passing, pcc = comp_pcc(expected[e], region, 0.97)
+        logger.info(f"multi-expert bias: expert {e} count={counts[e]} PCC={pcc}")
+        assert not torch.isnan(region).any(), f"expert {e} output contains NaN"
+        assert not torch.isinf(region).any(), f"expert {e} output contains Inf"
+        assert passing, f"expert {e} PCC below threshold: {pcc}"
+
+
+@pytest.mark.skipif(not is_blackhole(), reason="unified_routed_expert op is Blackhole-only")
+@pytest.mark.parametrize("counts", MULTI_EXPERT_PARAMS)
+@pytest.mark.parametrize(
+    "mesh_device, device_params", SINGLE_CHIP_MESH_PARAMS, indirect=["mesh_device", "device_params"]
+)
+def test_gptoss_bias_multi_expert(mesh_device, device_params, counts):
+    """Several experts on one chip (per-expert bias wiring + count bounding), gpt-oss dims."""
+    run_multi_expert_bias(mesh_device, counts=counts, emb_dim=GPT_OSS_EMB, hidden_dim=GPT_OSS_HIDDEN)
 
 
 def test_gptoss_bias_torch_reference_smoke():

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_routed_expert_bias.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_routed_expert_bias.py
@@ -124,10 +124,6 @@ def run_bias_routed_expert(mesh_device, num_tokens, emb_dim, hidden_dim):
     assert passing, f"PCC below threshold: {pcc}"
 
 
-@pytest.mark.skip(
-    reason="WIP: unified_routed_expert_ffn has no expert-bias support yet (needed for gpt-oss). "
-    "Spec test — enable once bias fusion + the TtRoutedExpert bias API land (tracked in this PR)."
-)
 @pytest.mark.skipif(not is_blackhole(), reason="unified_routed_expert op is Blackhole-only")
 @pytest.mark.parametrize("num_tokens", [128, 1024], ids=["t128", "t1k"])
 @pytest.mark.parametrize(

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_routed_expert_bias.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_routed_expert_bias.py
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+[DRAFT / WIP — gpt-oss] Single-device PCC *spec* test for **expert biases** in the fused
+``unified_routed_expert_ffn`` op.
+
+gpt-oss MoE experts add a learned bias to the gate, up, AND down projections — unlike
+DeepSeek-V3 / MiniMax-M3, which are bias-free (so the fused op was never given bias support).
+Target behaviour (clamped SwiGLU-OAI, limit=7.0, alpha=1.702):
+
+    gate = x @ gate_proj.T + gate_bias
+    up   = x @ up_proj.T   + up_bias
+    gate = clamp(gate, max=limit)
+    up   = clamp(up, -limit, limit)
+    act  = (up + 1) * gate * sigmoid(alpha * gate)
+    out  = act @ down_proj.T + down_bias
+
+The fused op currently has NO bias support. The device test below *specifies* the target so
+the kernel work has a golden to hit; it is SKIPPED until bias fusion (and the ``TtRoutedExpert``
+bias API shown here) land — tracked in this PR. The host-only reference smoke test is NOT
+skipped, so the reference math (and the exact gpt-oss expert formula) is guarded meanwhile.
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import is_blackhole
+from models.demos.deepseek_v3_d_p.tt.moe.tt_routed_expert import TtRoutedExpert
+from tests.ttnn.utils_for_testing import comp_pcc
+
+
+SINGLE_CHIP_MESH_PARAMS = [
+    pytest.param(1, {"fabric_config": ttnn.FabricConfig.DISABLED}, id="single-chip"),
+]
+
+SWIGLU_ALPHA = 1.702
+SWIGLU_LIMIT = 7.0
+
+# gpt-oss-120b / 20b MoE expert dims (hidden_size / intermediate_size).
+GPT_OSS_EMB = 2880
+GPT_OSS_HIDDEN = 2880
+
+
+def _torch_swigluoai_expert_with_bias(x, w, b, alpha=SWIGLU_ALPHA, limit=SWIGLU_LIMIT):
+    """Clamped SwiGLU-OAI FFN WITH gate/up/down biases (gpt-oss), fp32. Weights HF (out, in)."""
+    gate = F.linear(x, w["gate_proj"], b["gate_proj_bias"])
+    up = F.linear(x, w["up_proj"], b["up_proj_bias"])
+    gate_c = gate.clamp(max=limit)
+    up_c = up.clamp(min=-limit, max=limit)
+    glu = gate_c * torch.sigmoid(alpha * gate_c)
+    activated = (up_c + 1.0) * glu
+    return F.linear(activated, w["down_proj"], b["down_proj_bias"])
+
+
+def run_bias_routed_expert(mesh_device, num_tokens, emb_dim, hidden_dim):
+    """1 chip, 1 expert. Compares the fused op (SwiGLU-OAI + biases) vs a torch reference."""
+    torch.manual_seed(42)
+
+    weights = {
+        "gate_proj": torch.randn(hidden_dim, emb_dim, dtype=torch.float32) * 0.08,
+        "up_proj": torch.randn(hidden_dim, emb_dim, dtype=torch.float32) * 0.08,
+        "down_proj": torch.randn(emb_dim, hidden_dim, dtype=torch.float32) * 0.05,
+    }
+    # Biases scaled to a meaningful magnitude relative to the pre-activation std so they
+    # actually shift the clamp/activation (a no-op bias would make this test vacuous).
+    biases = {
+        "gate_proj_bias": torch.randn(hidden_dim, dtype=torch.float32) * 0.5,
+        "up_proj_bias": torch.randn(hidden_dim, dtype=torch.float32) * 0.5,
+        "down_proj_bias": torch.randn(emb_dim, dtype=torch.float32) * 0.5,
+    }
+
+    torch_input = torch.randn(num_tokens, emb_dim, dtype=torch.float32)
+    with torch.no_grad():
+        torch_output = _torch_swigluoai_expert_with_bias(torch_input, weights, biases)
+
+    tt_input = ttnn.from_torch(
+        torch_input,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        dtype=ttnn.bfloat8_b,
+    )
+
+    def _idx(values):
+        return ttnn.from_torch(
+            torch.tensor(values, dtype=torch.int32),
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=mesh_device,
+            dtype=ttnn.uint32,
+        )
+
+    # PROPOSED bias API: TtRoutedExpert takes a per-expert list of bias dicts, mirroring
+    # `torch_weights`. Kernel contract: gate/up bias added BEFORE the SwiGLU-OAI clamp, down
+    # bias added AFTER the down matmul. (Does not exist yet — this is the spec.)
+    tt_expert = TtRoutedExpert(
+        mesh_device=mesh_device,
+        experts_per_chip=1,
+        global_expert_idx_table=_idx([0]),
+        emb_dim=emb_dim,
+        hidden_dim=hidden_dim,
+        max_tokens=num_tokens,
+        torch_weights=[weights],
+        torch_biases=[biases],  # PROPOSED — bias support is the subject of this PR
+        activations_dtype=ttnn.bfloat8_b,
+        weights_dtype=ttnn.bfloat4_b,
+        activation=ttnn.RoutedExpertActivation.SwiGluOai,
+    )
+
+    tt_output = tt_expert(tt_input, _idx([num_tokens]), _idx([0]))
+    tt_output_torch = ttnn.to_torch(
+        tt_output,
+        mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0),
+    )[:num_tokens]
+
+    passing, pcc = comp_pcc(torch_output, tt_output_torch, 0.97)
+    logger.info(f"bias routed expert num_tokens={num_tokens}: PCC={pcc}")
+    assert not torch.isnan(tt_output_torch).any(), "Output contains NaN"
+    assert not torch.isinf(tt_output_torch).any(), "Output contains Inf"
+    assert passing, f"PCC below threshold: {pcc}"
+
+
+@pytest.mark.skip(
+    reason="WIP: unified_routed_expert_ffn has no expert-bias support yet (needed for gpt-oss). "
+    "Spec test — enable once bias fusion + the TtRoutedExpert bias API land (tracked in this PR)."
+)
+@pytest.mark.skipif(not is_blackhole(), reason="unified_routed_expert op is Blackhole-only")
+@pytest.mark.parametrize("num_tokens", [128, 1024], ids=["t128", "t1k"])
+@pytest.mark.parametrize(
+    "mesh_device, device_params", SINGLE_CHIP_MESH_PARAMS, indirect=["mesh_device", "device_params"]
+)
+def test_gptoss_bias_routed_expert(mesh_device, device_params, num_tokens):
+    """gpt-oss expert biases (gate/up/down) + SwiGLU-OAI vs torch. SPEC — skipped until kernel support lands."""
+    run_bias_routed_expert(mesh_device, num_tokens=num_tokens, emb_dim=GPT_OSS_EMB, hidden_dim=GPT_OSS_HIDDEN)
+
+
+def test_gptoss_bias_torch_reference_smoke():
+    """Host-only (no device): guards the bias SwiGLU-OAI reference math and documents the gpt-oss
+    expert formula. Not skipped — proves bias actually changes the output vs the bias-free path, so
+    the skipped device spec above is meaningful even before the kernel lands."""
+    torch.manual_seed(0)
+    emb, hidden, n = 256, 512, 32
+    x = torch.randn(n, emb)
+    w = {
+        "gate_proj": torch.randn(hidden, emb) * 0.08,
+        "up_proj": torch.randn(hidden, emb) * 0.08,
+        "down_proj": torch.randn(emb, hidden) * 0.05,
+    }
+    b = {
+        "gate_proj_bias": torch.randn(hidden) * 0.5,
+        "up_proj_bias": torch.randn(hidden) * 0.5,
+        "down_proj_bias": torch.randn(emb) * 0.5,
+    }
+    zero_b = {k: torch.zeros_like(v) for k, v in b.items()}
+    with torch.no_grad():
+        out_bias = _torch_swigluoai_expert_with_bias(x, w, b)
+        out_nobias = _torch_swigluoai_expert_with_bias(x, w, zero_b)
+    assert out_bias.shape == (n, emb)
+    assert not torch.allclose(out_bias, out_nobias), "bias must change the expert output"

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
@@ -65,6 +65,13 @@
 #include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
 #include "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_fused_activation.hpp"
 
+#ifdef FUSE_BIAS
+// Row-broadcast bias add (gpt-oss). Bias is a (1, N) tensor tiled to one
+// tile-row; add_tiles_bcast_rows adds its row 0 to every row of the output
+// tile. Same primitive the canonical matmul FUSE_BIAS path uses.
+#include "api/compute/bcast.h"
+#endif
+
 #ifdef SWIGLU_OAI
 // SwiGLU-OAI (gpt-oss / MiniMax-M3) activation: reuse the proven binary SFPU op.
 // Computes (clamp(up,±L)+1) * clamp(gate,max=L) * sigmoid(alpha*clamp(gate,max=L)).
@@ -91,8 +98,14 @@ template <
     uint32_t out_subblock_w,
     uint32_t out_subblock_num_tiles,
     uint32_t out_block_num_tiles,
-    bool apply_silu_on_final>
-FORCE_INLINE void matmul_phase(uint32_t in0_cb_id, uint32_t in1_cb_id, uint32_t partials_cb_id, uint32_t final_cb_id) {
+    bool apply_silu_on_final,
+    uint32_t d_per_core_N = 0>
+FORCE_INLINE void matmul_phase(
+    uint32_t in0_cb_id,
+    uint32_t in1_cb_id,
+    uint32_t partials_cb_id,
+    uint32_t final_cb_id,
+    uint32_t down_bias_cb_id = 0) {
     // Reconfig packer for partials format (previous phase's final_cb format
     // would otherwise leak). pack_reconfig_data_format (the reconfig variant)
     // does NOT reset L1_ACC — we do that explicitly below.
@@ -196,15 +209,34 @@ FORCE_INLINE void matmul_phase(uint32_t in0_cb_id, uint32_t in1_cb_id, uint32_t 
     // pack lands in final_cb (different format) — reconfigure both packer
     // data format and SrcA before the copy/pack loop.
     pack_reconfig_data_format(final_cb_id);
+#ifdef FUSE_BIAS
+    // Down bias (gpt-oss): add the (1, emb) bias (broadcast across rows) to the
+    // down-matmul output as it is drained from partials -> final. down_bias_cb
+    // holds this core's per_core_N_d columns (read once by the reader). d out
+    // subblock height is 1, so the flat tile index gives col = flat % d_per_core_N.
+    (void)in1_cb_id;
+    cb_wait_front(down_bias_cb_id, d_per_core_N);
+    // Down matmul left SrcA on down weights (bf4), SrcB on activated (bf8).
+    // Reconfig SrcA=partials (Float16_b), SrcB=down_bias before the bcast init.
+    reconfig_data_format(partials_cb_id, down_bias_cb_id);
+    add_bcast_rows_init_short(partials_cb_id, down_bias_cb_id);
+#else
+    (void)down_bias_cb_id;
     // matmul puts in1 → SrcA, in0 → SrcB. Reconfigure SrcA from in1 to
     // partials so copy_tile reads partials.
     copy_tile_to_dst_init_short_with_dt(in1_cb_id, partials_cb_id);
+#endif
 
     for (uint32_t sb = 0; sb < (out_block_num_tiles / out_subblock_num_tiles); ++sb) {
         tile_regs_acquire();
         partials_cb.wait_front(out_subblock_num_tiles);
         for (uint32_t i = 0; i < out_subblock_num_tiles; ++i) {
+#ifdef FUSE_BIAS
+            const uint32_t flat = sb * out_subblock_num_tiles + i;
+            add_tiles_bcast_rows(partials_cb_id, down_bias_cb_id, i, flat % d_per_core_N, i);
+#else
             copy_tile(partials_cb_id, i, i);
+#endif
         }
         partials_cb.pop_front(out_subblock_num_tiles);
 
@@ -477,9 +509,14 @@ FORCE_INLINE void matmul_phase_fused_gu(
 // chunks of <=4 output tiles (<=8 dst). The activated CB is drained count-based by
 // the reader (cb_activated_obj.wait_front(d_in0_block_num_tiles)), so the push
 // granularity here is free and need not match out_subblock_num_tiles.
-template <uint32_t out_block_num_tiles>
+template <uint32_t out_block_num_tiles, uint32_t per_core_N_gu = 0>
 FORCE_INLINE void swiglu_oai_activation_phase(
-    uint32_t prev_srcA_cb_id, uint32_t gate_partials_cb_id, uint32_t up_partials_cb_id, uint32_t activated_cb_id) {
+    uint32_t prev_srcA_cb_id,
+    uint32_t gate_partials_cb_id,
+    uint32_t up_partials_cb_id,
+    uint32_t activated_cb_id,
+    uint32_t gate_bias_cb_id = 0,
+    uint32_t up_bias_cb_id = 0) {
     // Dst budget derived from the host ComputeConfig (via -DFP32_DEST_ACC_EN) so
     // it and the SFPU op's fp32-dest template below stay in sync with the
     // program factory's DST_CAPACITY / fp32_dest_acc_en (no silent drift). The
@@ -502,16 +539,39 @@ FORCE_INLINE void swiglu_oai_activation_phase(
     // accumulator with the right format. Both partials CBs are Float16_b, so this
     // single init covers reads from gate AND up partials. (Passing a Float16_b CB
     // as the "old" operand would no-op the reconfig and leave SrcA on bf4.)
+#ifdef FUSE_BIAS
+    // gpt-oss: add gate/up bias (broadcast across rows) before the clamp. The
+    // bias CBs were read once by the reader (per_core_N_gu tiles each) and are
+    // NOT popped here (reused across chunks). add_bcast_rows sets SrcA=partials,
+    // SrcB=bias — same format for gate and up, so one init covers both.
+    (void)prev_srcA_cb_id;
+    cb_wait_front(gate_bias_cb_id, per_core_N_gu);
+    cb_wait_front(up_bias_cb_id, per_core_N_gu);
+    // The gate/up matmul left SrcA on the up weights (bf4) and SrcB on x (bf8).
+    // The bcast add reads SrcA=partials (Float16_b), SrcB=bias — reconfig both
+    // before the init (add_bcast uses both operands, unlike the copy path).
+    reconfig_data_format(gate_partials_cb_id, gate_bias_cb_id);
+    add_bcast_rows_init_short(gate_partials_cb_id, gate_bias_cb_id);
+#else
+    (void)gate_bias_cb_id;
+    (void)up_bias_cb_id;
     copy_tile_to_dst_init_short_with_dt(prev_srcA_cb_id, gate_partials_cb_id);
+#endif
 
     for (uint32_t base = 0; base < out_block_num_tiles; base += kActChunk) {
         const uint32_t remaining = out_block_num_tiles - base;
         const uint32_t c = remaining < kActChunk ? remaining : kActChunk;
         tile_regs_acquire();
-        // gate -> dst[0..c), up -> dst[c..2c)
+        // gate -> dst[0..c), up -> dst[c..2c) (with gpt-oss bias when FUSE_BIAS)
         for (uint32_t j = 0; j < c; ++j) {
+#ifdef FUSE_BIAS
+            const uint32_t ncol = (base + j) % per_core_N_gu;
+            add_tiles_bcast_rows(gate_partials_cb_id, gate_bias_cb_id, base + j, ncol, j);
+            add_tiles_bcast_rows(up_partials_cb_id, up_bias_cb_id, base + j, ncol, c + j);
+#else
             copy_tile(gate_partials_cb_id, base + j, j);
             copy_tile(up_partials_cb_id, base + j, c + j);
+#endif
         }
         // Fused clamp + alpha-sigmoid + (up+1) multiply; result written in place to
         // dst[j] (out == gate slot, mirroring moe_gpt's swiglu(0,1,0)).
@@ -640,6 +700,15 @@ void kernel_main() {
     // Row-major bf16 x staging (x_is_row_major only); tilize input CB. Unused
     // when x is TILE.
     constexpr uint32_t cb_x_rm = get_named_compile_time_arg_val("cb_x_rm");
+#ifdef FUSE_BIAS
+    constexpr uint32_t cb_gate_bias = get_named_compile_time_arg_val("cb_gate_bias");
+    constexpr uint32_t cb_up_bias = get_named_compile_time_arg_val("cb_up_bias");
+    constexpr uint32_t cb_down_bias = get_named_compile_time_arg_val("cb_down_bias");
+#else
+    constexpr uint32_t cb_gate_bias = 0;
+    constexpr uint32_t cb_up_bias = 0;
+    constexpr uint32_t cb_down_bias = 0;
+#endif
 
     CircularBuffer counts_scratch_cb(cb_counts_scratch);
     CircularBuffer idx_scratch_cb(cb_idx_scratch);
@@ -730,7 +799,8 @@ void kernel_main() {
         // gate-silu pass (skipped above) and the plain multiply_phase. cb_in1_up is
         // the unpacker's last SrcA operand (up matmul in1), passed so the partials
         // reconfig (weights df -> Float16_b) actually fires.
-        swiglu_oai_activation_phase<gu_out_block_num_tiles>(cb_in1_up, cb_partials_gu, cb_partials_up, cb_activated);
+        swiglu_oai_activation_phase<gu_out_block_num_tiles, g_in1_per_core_w>(
+            cb_in1_up, cb_partials_gu, cb_partials_up, cb_activated, cb_gate_bias, cb_up_bias);
         (void)cb_gate_intermed;
         (void)cb_up_intermed;
 #else
@@ -769,6 +839,7 @@ void kernel_main() {
             d_out_subblock_w,
             d_out_subblock_num_tiles,
             d_out_block_num_tiles,
-            /*apply_silu_on_final=*/false>(cb_in0_down_full, cb_in1_down, cb_partials_d, cb_out);
+            /*apply_silu_on_final=*/false,
+            /*d_per_core_N=*/d_in1_per_core_w>(cb_in0_down_full, cb_in1_down, cb_partials_d, cb_out, cb_down_bias);
     }  // end chunk loop
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
@@ -215,7 +215,8 @@ FORCE_INLINE void matmul_phase(
     // holds this core's per_core_N_d columns (read once by the reader). d out
     // subblock height is 1, so the flat tile index gives col = flat % d_per_core_N.
     (void)in1_cb_id;
-    cb_wait_front(down_bias_cb_id, d_per_core_N);
+    CircularBuffer down_bias_cb(down_bias_cb_id);
+    down_bias_cb.wait_front(d_per_core_N);
     // Down matmul left SrcA on down weights (bf4), SrcB on activated (bf8).
     // Reconfig SrcA=partials (Float16_b), SrcB=down_bias before the bcast init.
     reconfig_data_format(partials_cb_id, down_bias_cb_id);
@@ -545,8 +546,10 @@ FORCE_INLINE void swiglu_oai_activation_phase(
     // NOT popped here (reused across chunks). add_bcast_rows sets SrcA=partials,
     // SrcB=bias — same format for gate and up, so one init covers both.
     (void)prev_srcA_cb_id;
-    cb_wait_front(gate_bias_cb_id, per_core_N_gu);
-    cb_wait_front(up_bias_cb_id, per_core_N_gu);
+    CircularBuffer gate_bias_cb(gate_bias_cb_id);
+    CircularBuffer up_bias_cb(up_bias_cb_id);
+    gate_bias_cb.wait_front(per_core_N_gu);
+    up_bias_cb.wait_front(per_core_N_gu);
     // The gate/up matmul left SrcA on the up weights (bf4) and SrcB on x (bf8).
     // The bcast add reads SrcA=partials (Float16_b), SrcB=bias — reconfig both
     // before the init (add_bcast uses both operands, unlike the copy path).

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
@@ -182,6 +182,31 @@ void kernel_main() {
     constexpr auto start_args = TensorAccessorArgs<start_accessor_offset>();
     const auto start_acc = TensorAccessor(start_args, start_addr);
 
+#ifdef FUSE_BIAS
+    // gpt-oss expert biases. RT addrs immediately follow start_addr; CT bias CB
+    // ids + accessors follow the start accessor. Read once (below), added by the
+    // compute kernel (gate/up before the activation, down after the down matmul).
+    const uint32_t gate_bias_addr = get_arg_val<uint32_t>(M_ROW_NOC_RT_OFFSET + 2 * GRID_X_NOC + 1);
+    const uint32_t up_bias_addr = get_arg_val<uint32_t>(M_ROW_NOC_RT_OFFSET + 2 * GRID_X_NOC + 2);
+    const uint32_t down_bias_addr = get_arg_val<uint32_t>(M_ROW_NOC_RT_OFFSET + 2 * GRID_X_NOC + 3);
+    constexpr uint32_t bias_cb_offset = start_args.next_compile_time_args_offset();
+    constexpr uint32_t cb_gate_bias = get_compile_time_arg_val(bias_cb_offset + 0);
+    constexpr uint32_t cb_up_bias = get_compile_time_arg_val(bias_cb_offset + 1);
+    constexpr uint32_t cb_down_bias = get_compile_time_arg_val(bias_cb_offset + 2);
+    constexpr uint32_t gate_bias_accessor_offset = bias_cb_offset + 3;
+    constexpr auto gate_bias_args = TensorAccessorArgs<gate_bias_accessor_offset>();
+    const auto gate_bias_acc = TensorAccessor(gate_bias_args, gate_bias_addr, get_tile_size(cb_gate_bias));
+    constexpr uint32_t up_bias_accessor_offset = gate_bias_args.next_compile_time_args_offset();
+    constexpr auto up_bias_args = TensorAccessorArgs<up_bias_accessor_offset>();
+    const auto up_bias_acc = TensorAccessor(up_bias_args, up_bias_addr, get_tile_size(cb_up_bias));
+    constexpr uint32_t down_bias_accessor_offset = up_bias_args.next_compile_time_args_offset();
+    constexpr auto down_bias_args = TensorAccessorArgs<down_bias_accessor_offset>();
+    const auto down_bias_acc = TensorAccessor(down_bias_args, down_bias_addr, get_tile_size(cb_down_bias));
+    CircularBuffer cb_gate_bias_obj(cb_gate_bias);
+    CircularBuffer cb_up_bias_obj(cb_up_bias);
+    CircularBuffer cb_down_bias_obj(cb_down_bias);
+#endif
+
     // D2.0 NoC handles. `noc` uses default noc_index for mcasts/sem ops.
     // `noc_read` forces NoC 0 for DRAM weight/page reads — the kernel issues
     // those concurrently with mcast traffic on the kernel's default NoC for
@@ -330,6 +355,56 @@ void kernel_main() {
 
     // UP_SPLIT handshake counter, kept in lockstep with the writer's.
     uint32_t up_seq = 0;
+
+#ifdef FUSE_BIAS
+    // Read this core's N-column slice of the (1, N) biases ONCE (constant across
+    // chunks; the compute kernel wait_fronts without popping). Bias is a single
+    // tile-row tensor, so the DRAM page index == tile column. Phantom columns
+    // (col >= actual N) are zero-filled — their output columns are dropped by
+    // the writer / are already zero.
+    {
+        const uint32_t gbias_tb = get_tile_size(cb_gate_bias);
+        cb_gate_bias_obj.reserve_back(per_core_N_gu);
+        cb_up_bias_obj.reserve_back(per_core_N_gu);
+        uint32_t lg = cb_gate_bias_obj.get_write_ptr();
+        uint32_t lu = cb_up_bias_obj.get_write_ptr();
+        for (uint32_t n = 0; n < per_core_N_gu; ++n) {
+            const uint32_t col = my_nt_gu * per_core_N_gu + n;
+            if (col < N_gate_tiles_full) {
+                noc_read.async_read(gate_bias_acc, CoreLocalMem<uint32_t>(lg), gbias_tb, {.page_id = col}, {});
+                noc_read.async_read(up_bias_acc, CoreLocalMem<uint32_t>(lu), gbias_tb, {.page_id = col}, {});
+            } else {
+                volatile tt_l1_ptr uint64_t* pg = reinterpret_cast<volatile tt_l1_ptr uint64_t*>(lg);
+                volatile tt_l1_ptr uint64_t* pu = reinterpret_cast<volatile tt_l1_ptr uint64_t*>(lu);
+                for (uint32_t i = 0; i < gbias_tb / 8; ++i) {
+                    pg[i] = 0;
+                    pu[i] = 0;
+                }
+            }
+            lg += gbias_tb;
+            lu += gbias_tb;
+        }
+        const uint32_t dbias_tb = get_tile_size(cb_down_bias);
+        cb_down_bias_obj.reserve_back(per_core_N_d);
+        uint32_t ld = cb_down_bias_obj.get_write_ptr();
+        for (uint32_t n = 0; n < per_core_N_d; ++n) {
+            const uint32_t col = my_nt_d * per_core_N_d + n;
+            if (col < N_down_tiles_full) {
+                noc_read.async_read(down_bias_acc, CoreLocalMem<uint32_t>(ld), dbias_tb, {.page_id = col}, {});
+            } else {
+                volatile tt_l1_ptr uint64_t* pd = reinterpret_cast<volatile tt_l1_ptr uint64_t*>(ld);
+                for (uint32_t i = 0; i < dbias_tb / 8; ++i) {
+                    pd[i] = 0;
+                }
+            }
+            ld += dbias_tb;
+        }
+        noc_read.async_read_barrier();
+        cb_gate_bias_obj.push_back(per_core_N_gu);
+        cb_up_bias_obj.push_back(per_core_N_gu);
+        cb_down_bias_obj.push_back(per_core_N_d);
+    }
+#endif
 
     // Bound the chunk loop by effective_chunks (= ceil_div(count, chunk_M_tiles))
     // so this expert only does work proportional to its actual token count,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.cpp
@@ -246,15 +246,13 @@ void UnifiedRoutedExpertFfnDeviceOperation::validate_on_program_cache_miss(
                 b.padded_shape()[-1],
                 expected_n);
         }
-        // WIP (gpt-oss): the host plumbing (API/prim/inputs/cache-key/validation)
-        // is in place, but the fused kernel does not add biases yet — the
-        // program-factory bias CBs, reader bias reads, and the compute-kernel
-        // broadcast-add are the remaining work. Fail loudly rather than silently
-        // dropping the bias. Tracked in PR #49619.
+        // Bias fusion is implemented only for the SwiGLU-OAI activation (gpt-oss):
+        // the kernel adds gate/up bias before the clamp and down bias after the
+        // down matmul. The SiLU path has no bias branch.
         TT_FATAL(
-            !op.fuse_bias,
-            "unified_routed_expert_ffn: expert-bias fusion is not implemented yet (gpt-oss WIP). Bias tensors are "
-            "accepted and validated, but the fused kernel does not add them — do not rely on this path yet.");
+            op.activation == RoutedExpertActivation::SwiGluOai,
+            "unified_routed_expert_ffn: expert biases are only supported with RoutedExpertActivation::SwiGluOai "
+            "(got the SiLU path).");
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.cpp
@@ -5,6 +5,7 @@
 #include "unified_routed_expert_ffn_device_operation.hpp"
 
 #include <initializer_list>
+#include <tuple>
 #include <utility>
 
 #include <tt-metalium/constants.hpp>
@@ -219,6 +220,42 @@ void UnifiedRoutedExpertFfnDeviceOperation::validate_on_program_cache_miss(
                 out_shape[-2] == x_shape[-2], "optional_output M ({}) must match x M ({})", out_shape[-2], x_shape[-2]);
         }
     }
+
+    // Optional expert biases (gpt-oss). All-or-none: gate/up/down together or
+    // none. gate/up bias last dim == gate/up N (hidden); down bias last dim ==
+    // down N (emb). Same device / TILE / DRAM-interleaved contract as weights.
+    const int bias_count = static_cast<int>(t.gate_bias.has_value()) + static_cast<int>(t.up_bias.has_value()) +
+                           static_cast<int>(t.down_bias.has_value());
+    TT_FATAL(
+        bias_count == 0 || bias_count == 3,
+        "gate/up/down biases must all be provided together or all omitted (got {} of 3)",
+        bias_count);
+    if (bias_count == 3) {
+        for (const auto& [name, b, expected_n] :
+             std::initializer_list<std::tuple<const char*, const ttnn::Tensor&, uint32_t>>{
+                 {"gate_bias", *t.gate_bias, static_cast<uint32_t>(gate_shape[-1])},
+                 {"up_bias", *t.up_bias, static_cast<uint32_t>(up_shape[-1])},
+                 {"down_bias", *t.down_bias, static_cast<uint32_t>(down_shape[-1])}}) {
+            TT_FATAL(b.storage_type() == tt::tt_metal::StorageType::DEVICE, "{} must be on device", name);
+            TT_FATAL(b.layout() == tt::tt_metal::Layout::TILE, "{} must be TILE layout", name);
+            TT_FATAL(is_dram_interleaved(b), "{} must be DRAM-interleaved", name);
+            TT_FATAL(
+                static_cast<uint32_t>(b.padded_shape()[-1]) == expected_n,
+                "{} last dim ({}) must match its projection N ({})",
+                name,
+                b.padded_shape()[-1],
+                expected_n);
+        }
+        // WIP (gpt-oss): the host plumbing (API/prim/inputs/cache-key/validation)
+        // is in place, but the fused kernel does not add biases yet — the
+        // program-factory bias CBs, reader bias reads, and the compute-kernel
+        // broadcast-add are the remaining work. Fail loudly rather than silently
+        // dropping the bias. Tracked in PR #49619.
+        TT_FATAL(
+            !op.fuse_bias,
+            "unified_routed_expert_ffn: expert-bias fusion is not implemented yet (gpt-oss WIP). Bias tensors are "
+            "accepted and validated, but the fused kernel does not add them — do not rely on this path yet.");
+    }
 }
 
 void UnifiedRoutedExpertFfnDeviceOperation::validate_on_program_cache_hit(
@@ -264,7 +301,10 @@ ttnn::Tensor unified_routed_expert_ffn(
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
     const std::optional<ttnn::Tensor>& optional_output,
     const std::optional<ttnn::Tensor>& expert_region_offsets,
-    ttnn::operations::experimental::deepseek_prefill::unified_routed_expert_ffn::RoutedExpertActivation activation) {
+    ttnn::operations::experimental::deepseek_prefill::unified_routed_expert_ffn::RoutedExpertActivation activation,
+    const std::optional<ttnn::Tensor>& gate_bias,
+    const std::optional<ttnn::Tensor>& up_bias,
+    const std::optional<ttnn::Tensor>& down_bias) {
     using OperationType =
         ttnn::operations::experimental::deepseek_prefill::unified_routed_expert_ffn::UnifiedRoutedExpertFfnDeviceOperation;
     return ttnn::device_operation::launch<OperationType>(
@@ -275,6 +315,7 @@ ttnn::Tensor unified_routed_expert_ffn(
             .read_x_at_offset = read_x_at_offset,
             .x_is_row_major = x_is_row_major,
             .activation = activation,
+            .fuse_bias = gate_bias.has_value(),
             .compute_kernel_config = compute_kernel_config},
         OperationType::tensor_args_t{
             .x = x,
@@ -284,7 +325,10 @@ ttnn::Tensor unified_routed_expert_ffn(
             .counts = counts,
             .global_expert_idx_table = global_expert_idx_table,
             .optional_output = optional_output,
-            .expert_region_offsets = expert_region_offsets});
+            .expert_region_offsets = expert_region_offsets,
+            .gate_bias = gate_bias,
+            .up_bias = up_bias,
+            .down_bias = down_bias});
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.cpp
@@ -239,13 +239,34 @@ void UnifiedRoutedExpertFfnDeviceOperation::validate_on_program_cache_miss(
             TT_FATAL(b.storage_type() == tt::tt_metal::StorageType::DEVICE, "{} must be on device", name);
             TT_FATAL(b.layout() == tt::tt_metal::Layout::TILE, "{} must be TILE layout", name);
             TT_FATAL(is_dram_interleaved(b), "{} must be DRAM-interleaved", name);
+            // Exact LOGICAL shape: a single row of exactly `expected_n` columns. The
+            // padded-width check below is necessary (the kernel/reader address tiles by
+            // padded width) but not sufficient: shapes like (2, N) or (1, N-1) tile-pad
+            // to the same width and would otherwise be accepted and silently mis-applied
+            // (the reader loads only tile-row 0 and the compute kernel row-broadcasts it).
+            const auto& lshape = b.logical_shape();
+            TT_FATAL(
+                static_cast<uint32_t>(lshape[-1]) == expected_n && lshape.volume() == expected_n,
+                "{} logical shape {} must be a single row of its projection N ({})",
+                name,
+                lshape,
+                expected_n);
             TT_FATAL(
                 static_cast<uint32_t>(b.padded_shape()[-1]) == expected_n,
-                "{} last dim ({}) must match its projection N ({})",
+                "{} padded last dim ({}) must match its projection N ({})",
                 name,
                 b.padded_shape()[-1],
                 expected_n);
         }
+        // All three bias CBs are configured from the gate-bias dtype (and the compute
+        // kernel reuses one unpack format across gate/up), so the three biases must share
+        // a single dtype; a mixed-dtype call would read the wrong byte counts/formats.
+        TT_FATAL(
+            t.up_bias->dtype() == t.gate_bias->dtype() && t.down_bias->dtype() == t.gate_bias->dtype(),
+            "gate/up/down biases must share one dtype (got gate={}, up={}, down={})",
+            t.gate_bias->dtype(),
+            t.up_bias->dtype(),
+            t.down_bias->dtype());
         // Bias fusion is implemented only for the SwiGLU-OAI activation (gpt-oss):
         // the kernel adds gate/up bias before the clamp and down bias after the
         // down matmul. The SiLU path has no bias branch.

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.hpp
@@ -48,6 +48,9 @@ ttnn::Tensor unified_routed_expert_ffn(
     const std::optional<ttnn::Tensor>& optional_output,
     const std::optional<ttnn::Tensor>& expert_region_offsets = std::nullopt,
     ttnn::operations::experimental::deepseek_prefill::unified_routed_expert_ffn::RoutedExpertActivation activation =
-        ttnn::operations::experimental::deepseek_prefill::unified_routed_expert_ffn::RoutedExpertActivation::Silu);
+        ttnn::operations::experimental::deepseek_prefill::unified_routed_expert_ffn::RoutedExpertActivation::Silu,
+    const std::optional<ttnn::Tensor>& gate_bias = std::nullopt,
+    const std::optional<ttnn::Tensor>& up_bias = std::nullopt,
+    const std::optional<ttnn::Tensor>& down_bias = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
@@ -60,6 +60,13 @@ constexpr uint32_t CB_START_SCRATCH_READER = tt::CBIndex::c_15;
 // bf8_b path's L1). The CT-arg index is passed either way; the CB just isn't
 // created (and never touched by the kernels) when x is already TILE.
 constexpr uint32_t CB_X_RM = tt::CBIndex::c_16;
+// Optional per-expert projection biases (gpt-oss, FUSE_BIAS). Each holds this
+// core's N-column slice of the (1, N) bias, read once by the reader and added
+// by the compute kernel (gate/up before the activation, down after the down
+// matmul). Allocated only when op.fuse_bias.
+constexpr uint32_t CB_GATE_BIAS = tt::CBIndex::c_17;
+constexpr uint32_t CB_UP_BIAS = tt::CBIndex::c_18;
+constexpr uint32_t CB_DOWN_BIAS = tt::CBIndex::c_19;
 }  // namespace
 
 UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnProgramFactory::create(
@@ -638,6 +645,18 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
             .set_page_size(CB_START_SCRATCH_READER, start_scratch_bytes);
     tt::tt_metal::CreateCircularBuffer(program, core_range_set, start_reader_cb_cfg);
 
+    // Bias CBs (FUSE_BIAS): one full per-core N-column slice each; single-buffered
+    // (read once, reused across all chunks). gate/up: per_core_N_gu tiles; down:
+    // per_core_N_d tiles. Bias broadcast across rows in the compute kernel.
+    const bool fuse_bias = op.fuse_bias;
+    if (fuse_bias) {
+        const tt::DataFormat bias_df = tt::tt_metal::datatype_to_dataformat_converter(t.gate_bias->dtype());
+        const uint32_t bias_tile_size = tt::tile_size(bias_df);
+        make_cb(CB_GATE_BIAS, bias_df, /*tiles=*/per_core_N_gu, bias_tile_size);
+        make_cb(CB_UP_BIAS, bias_df, /*tiles=*/per_core_N_gu, bias_tile_size);
+        make_cb(CB_DOWN_BIAS, bias_df, /*tiles=*/per_core_N_d, bias_tile_size);
+    }
+
     // -------------------------- kernel build ------------------------------
     // Reader compile-time args. Order must exactly match the layout the reader
     // kernel reads via get_compile_time_arg_val(idx) and the TensorAccessor
@@ -703,12 +722,27 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     // (unread when read_x_at_offset is 0), keeping the CT-arg layout stable.
     tt::tt_metal::TensorAccessorArgs(start_buffer).append_to(reader_ct_args);
 
+    // FUSE_BIAS: after the `start` accessor, append the 3 bias CB ids then the 3
+    // bias tensor accessors (gate, up, down). The reader reads them at the
+    // offset after start_args.next_compile_time_args_offset(). Only present when
+    // fuse_bias — a distinct program (FUSE_BIAS define is in the cache key).
+    std::map<std::string, std::string> reader_defines{};
+    if (fuse_bias) {
+        reader_ct_args.push_back(CB_GATE_BIAS);
+        reader_ct_args.push_back(CB_UP_BIAS);
+        reader_ct_args.push_back(CB_DOWN_BIAS);
+        tt::tt_metal::TensorAccessorArgs(t.gate_bias->buffer()).append_to(reader_ct_args);
+        tt::tt_metal::TensorAccessorArgs(t.up_bias->buffer()).append_to(reader_ct_args);
+        tt::tt_metal::TensorAccessorArgs(t.down_bias->buffer()).append_to(reader_ct_args);
+        reader_defines["FUSE_BIAS"] = "1";
+    }
+
     auto reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/"
         "unified_routed_expert_ffn_reader.cpp",
         core_range_set,
-        tt::tt_metal::ReaderDataMovementConfig(reader_ct_args));
+        tt::tt_metal::ReaderDataMovementConfig(reader_ct_args, reader_defines));
 
     // Writer compile-time args (must match writer's get_compile_time_arg_val order).
     std::vector<uint32_t> writer_ct_args = {
@@ -831,6 +865,11 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         {"cb_counts_scratch", CB_COUNTS_SCRATCH},
         {"cb_idx_scratch", CB_IDX_SCRATCH},
     };
+    if (fuse_bias) {
+        compute_named_args["cb_gate_bias"] = CB_GATE_BIAS;
+        compute_named_args["cb_up_bias"] = CB_UP_BIAS;
+        compute_named_args["cb_down_bias"] = CB_DOWN_BIAS;
+    }
 
     // PACKER_L1_ACC controls cross-K-block accumulation via packer L1 RMW.
     std::map<std::string, std::string> compute_defines{};
@@ -844,6 +883,11 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         // clamp(up,±L), (up+1)*gate*sigmoid(alpha*gate). Bakes alpha=1.702,
         // limit=7.0 (SwiGLUConfigGPTOSS) in the kernel.
         compute_defines["SWIGLU_OAI"] = "1";
+    }
+    if (fuse_bias) {
+        // FUSE_BIAS: add gate/up bias (broadcast across rows) before the
+        // SwiGLU-OAI activation and down bias after the down matmul (gpt-oss).
+        compute_defines["FUSE_BIAS"] = "1";
     }
 
     auto compute_kernel_id = tt::tt_metal::CreateKernel(
@@ -976,9 +1020,17 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
             reader_args.push_back(static_cast<uint32_t>(noc.x));
             reader_args.push_back(static_cast<uint32_t>(noc.y));
         }
-        // start_addr — last reader arg (see layout comment). Same buffer the
-        // writer gets; read by the reader only when read_x_at_offset.
+        // start_addr — reader arg at M_ROW_NOC_RT_OFFSET + 2*GRID_X (see layout
+        // comment). Same buffer the writer gets; read by the reader only when
+        // read_x_at_offset.
         reader_args.push_back(start_buffer->address());
+        // FUSE_BIAS: 3 bias addrs immediately after start_addr (read by the
+        // reader at start_offset + 1..3). Kept last so override can update them.
+        if (fuse_bias) {
+            reader_args.push_back(t.gate_bias->buffer()->address());
+            reader_args.push_back(t.up_bias->buffer()->address());
+            reader_args.push_back(t.down_bias->buffer()->address());
+        }
         tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
 
         // Writer runtime arg layout (must match unified_routed_expert_ffn_writer.cpp):
@@ -1029,6 +1081,9 @@ void UnifiedRoutedExpertFfnProgramFactory::override_runtime_arguments(
     const uint32_t out_addr = tensor_return_value.buffer()->address();
     const uint32_t start_addr =
         t.expert_region_offsets.has_value() ? t.expert_region_offsets->buffer()->address() : out_addr;
+    // FUSE_BIAS appends 3 bias addrs after start_addr, so start is no longer the
+    // last reader arg. Recover its index from the presence of the bias tensors.
+    const bool has_bias = t.gate_bias.has_value();
 
     for (const auto& core : cores) {
         auto& reader_args = tt::tt_metal::GetRuntimeArgs(program, reader_id, core);
@@ -1038,8 +1093,14 @@ void UnifiedRoutedExpertFfnProgramFactory::override_runtime_arguments(
         reader_args[3] = down_addr;
         reader_args[4] = counts_addr;
         reader_args[5] = idx_addr;
-        // start_addr is the last reader arg (after the M-row NoC table).
-        reader_args[reader_args.size() - 1] = start_addr;
+        // start_addr sits before the (optional) 3 trailing bias addrs.
+        const size_t start_idx = reader_args.size() - 1 - (has_bias ? 3 : 0);
+        reader_args[start_idx] = start_addr;
+        if (has_bias) {
+            reader_args[reader_args.size() - 3] = t.gate_bias->buffer()->address();
+            reader_args[reader_args.size() - 2] = t.up_bias->buffer()->address();
+            reader_args[reader_args.size() - 1] = t.down_bias->buffer()->address();
+        }
 
         auto& writer_args = tt::tt_metal::GetRuntimeArgs(program, writer_id, core);
         writer_args[0] = out_addr;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
@@ -166,6 +166,11 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     const uint32_t p_ts = tt::tile_size(tt::DataFormat::Float16_b);
     const uint32_t im_ts = tt::tile_size(tt::DataFormat::Bfp8_b);
     const uint32_t out_ts = tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(tensor_return_value.dtype()));
+    // Bias tile size (FUSE_BIAS): all three bias CBs share the gate-bias dtype
+    // (enforced in validation). Zero when unused so the estimators are unchanged
+    // on the bias-free path.
+    const uint32_t bias_ts =
+        op.fuse_bias ? tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(t.gate_bias->dtype())) : 0;
     auto est_l1_bytes = [&](uint32_t gx, uint32_t pcM, uint32_t ibw_gu) -> uint64_t {
         const uint32_t pcN_gu = (N_gate_tiles_full + gx - 1) / gx;
         const uint32_t pcN_d = (N_down_tiles_full + gx - 1) / gx;
@@ -186,6 +191,10 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         b += 2ull * 8 * out_ts;              // CB_OUT (subblock <= 8 tiles, staged x2)
         b += 2ull * pcM * ibw_d * im_ts;     // CB_IN0_DOWN_FULL
         b += 8192;                           // counts + idx scratch
+        // Bias CBs (single-buffered, one full per-core N-slice each): gate/up use
+        // pcN_gu tiles, down uses pcN_d. Must be accounted here or a shape near the
+        // L1 limit can pass GRID_X selection and then overflow at program build.
+        b += 1ull * (2 * pcN_gu + pcN_d) * bias_ts;
         return b;
     };
 
@@ -335,6 +344,9 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         total += static_cast<uint64_t>(M * per_core_N_d) * partials_d_tile_size;                  // cb_mm_partials_d
         total += static_cast<uint64_t>(d_out_subblock_h * d_out_subblock_w * 2) * out_tile_size;  // cb_out
         total += static_cast<uint64_t>(M * in0_block_w_d * 2) * intermed_tile_size;               // cb_in0_down_full
+        // Bias CBs (FUSE_BIAS): single-buffered, per_core_N_gu (gate/up) + per_core_N_d
+        // (down) tiles. Keep in sync with the CB allocations in the "Bias CBs" section.
+        total += static_cast<uint64_t>(2 * per_core_N_gu + per_core_N_d) * bias_ts;
         return total;
     };
 
@@ -650,6 +662,8 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     // per_core_N_d tiles. Bias broadcast across rows in the compute kernel.
     const bool fuse_bias = op.fuse_bias;
     if (fuse_bias) {
+        // Validation enforces gate/up/down biases share one dtype, so all three CBs
+        // (and the compute kernel's single unpack reconfig for gate/up) use it safely.
         const tt::DataFormat bias_df = tt::tt_metal::datatype_to_dataformat_converter(t.gate_bias->dtype());
         const uint32_t bias_tile_size = tt::tile_size(bias_df);
         make_cb(CB_GATE_BIAS, bias_df, /*tiles=*/per_core_N_gu, bias_tile_size);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_types.hpp
@@ -76,13 +76,26 @@ struct UnifiedRoutedExpertFfnParams {
     // it is part of the program-cache key below.
     RoutedExpertActivation activation = RoutedExpertActivation::Silu;
 
+    // Whether the (optional) gate/up/down expert biases are fused. Derived from
+    // the presence of the bias tensors in the inputs. Drives a compile-time
+    // FUSE_BIAS define in the compute/reader kernels, so a bias vs no-bias
+    // program caches distinctly — hence it is part of the program-cache key.
+    // (gpt-oss experts have gate/up/down biases; DeepSeek / MiniMax-M3 do not.)
+    bool fuse_bias = false;
+
     std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config;
 
     static constexpr auto attribute_names = std::forward_as_tuple(
-        "chunk_M_tiles", "m_tiles", "local_expert_id", "read_x_at_offset", "x_is_row_major", "activation");
+        "chunk_M_tiles",
+        "m_tiles",
+        "local_expert_id",
+        "read_x_at_offset",
+        "x_is_row_major",
+        "activation",
+        "fuse_bias");
     auto attribute_values() const {
         return std::forward_as_tuple(
-            chunk_M_tiles, m_tiles, local_expert_id, read_x_at_offset, x_is_row_major, activation);
+            chunk_M_tiles, m_tiles, local_expert_id, read_x_at_offset, x_is_row_major, activation, fuse_bias);
     }
 };
 
@@ -114,6 +127,14 @@ struct UnifiedRoutedExpertFfnInputs {
     // buffer) at start[global_id]/TILE tile-rows, fusing the ttnn::insert step.
     // Requires optional_output to also be set.
     std::optional<Tensor> expert_region_offsets;
+    // Optional per-expert projection biases (gpt-oss). All three are present or
+    // all absent (validated host-side). gate_bias/up_bias are (1, N=hidden);
+    // down_bias is (1, N=emb). When set, the fused kernel adds gate/up bias
+    // before the activation and down bias after the down matmul. Absent for the
+    // bias-free DeepSeek / MiniMax-M3 path (byte-identical).
+    std::optional<Tensor> gate_bias;
+    std::optional<Tensor> up_bias;
+    std::optional<Tensor> down_bias;
 };
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::unified_routed_expert_ffn

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.cpp
@@ -25,7 +25,10 @@ ttnn::Tensor unified_routed_expert_ffn(
     const std::optional<uint32_t>& input_m_tiles,
     bool read_x_at_offset,
     bool x_is_row_major,
-    RoutedExpertActivation activation) {
+    RoutedExpertActivation activation,
+    const std::optional<ttnn::Tensor>& gate_bias,
+    const std::optional<ttnn::Tensor>& up_bias,
+    const std::optional<ttnn::Tensor>& down_bias) {
     // Single-op fused per-expert FFN. One device Program runs gate matmul,
     // up matmul, silu, multiply, down matmul as four phases inside the same
     // kernel. The kernel reads counts[global_expert_idx_table[local_expert_id]]
@@ -82,7 +85,10 @@ ttnn::Tensor unified_routed_expert_ffn(
                                           : std::nullopt,
         output,
         expert_region_offsets,
-        activation);
+        activation,
+        gate_bias,
+        up_bias,
+        down_bias);
 }
 
 ttnn::Tensor unified_routed_expert_moe(
@@ -95,7 +101,10 @@ ttnn::Tensor unified_routed_expert_moe(
     const std::vector<ttnn::Tensor>& down_projs,
     uint32_t max_dispatched_tokens_per_expert,
     const std::optional<const ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
-    RoutedExpertActivation activation) {
+    RoutedExpertActivation activation,
+    const std::optional<std::vector<ttnn::Tensor>>& gate_biases,
+    const std::optional<std::vector<ttnn::Tensor>>& up_biases,
+    const std::optional<std::vector<ttnn::Tensor>>& down_biases) {
     TT_FATAL(
         gate_projs.size() == up_projs.size() && gate_projs.size() == down_projs.size(),
         "gate/up/down projection lists must have the same length (got {}, {}, {})",
@@ -104,6 +113,26 @@ ttnn::Tensor unified_routed_expert_moe(
         down_projs.size());
     const uint32_t experts_per_chip = static_cast<uint32_t>(gate_projs.size());
     TT_FATAL(experts_per_chip > 0, "Need at least one expert per chip");
+
+    // Optional per-expert biases (gpt-oss): all three lists together or none,
+    // each the same length as the weight lists (one bias per local expert).
+    const int bias_lists = static_cast<int>(gate_biases.has_value()) + static_cast<int>(up_biases.has_value()) +
+                           static_cast<int>(down_biases.has_value());
+    TT_FATAL(
+        bias_lists == 0 || bias_lists == 3,
+        "gate/up/down bias lists must all be provided together or all omitted (got {} of 3)",
+        bias_lists);
+    const bool has_bias = bias_lists == 3;
+    if (has_bias) {
+        TT_FATAL(
+            gate_biases->size() == experts_per_chip && up_biases->size() == experts_per_chip &&
+                down_biases->size() == experts_per_chip,
+            "bias lists must have one entry per local expert ({}), got ({}, {}, {})",
+            experts_per_chip,
+            gate_biases->size(),
+            up_biases->size(),
+            down_biases->size());
+    }
 
     // Per-expert composite: run the unified FFN on each expert's slice of the
     // dispatched buffer at that expert's region offset (read_x_at_offset for the
@@ -154,7 +183,10 @@ ttnn::Tensor unified_routed_expert_moe(
             m_tiles,
             /*read_x_at_offset=*/true,
             x_is_row_major,
-            activation);
+            activation,
+            has_bias ? std::optional<ttnn::Tensor>((*gate_biases)[local_expert]) : std::nullopt,
+            has_bias ? std::optional<ttnn::Tensor>((*up_biases)[local_expert]) : std::nullopt,
+            has_bias ? std::optional<ttnn::Tensor>((*down_biases)[local_expert]) : std::nullopt);
     }
     return output;
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.hpp
@@ -79,7 +79,14 @@ ttnn::Tensor unified_routed_expert_ffn(
     const std::optional<uint32_t>& input_m_tiles = std::nullopt,
     bool read_x_at_offset = false,
     bool x_is_row_major = false,
-    RoutedExpertActivation activation = RoutedExpertActivation::Silu);
+    RoutedExpertActivation activation = RoutedExpertActivation::Silu,
+    // Optional per-expert projection biases (gpt-oss). All three together or
+    // none. gate_bias/up_bias: (1, hidden); down_bias: (1, emb). When set, the
+    // kernel adds gate/up bias before the activation and down bias after the
+    // down matmul. Omit for the bias-free DeepSeek / MiniMax-M3 path.
+    const std::optional<ttnn::Tensor>& gate_bias = std::nullopt,
+    const std::optional<ttnn::Tensor>& up_bias = std::nullopt,
+    const std::optional<ttnn::Tensor>& down_bias = std::nullopt);
 
 // MoE-level composite: takes the dispatched buffer + ALL local experts'
 // weights and loops over local experts in C++, calling
@@ -102,7 +109,13 @@ ttnn::Tensor unified_routed_expert_moe(
     const std::vector<ttnn::Tensor>& down_projs,
     uint32_t max_dispatched_tokens_per_expert,
     const std::optional<const ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
-    RoutedExpertActivation activation = RoutedExpertActivation::Silu);
+    RoutedExpertActivation activation = RoutedExpertActivation::Silu,
+    // Optional per-expert biases (gpt-oss), one entry per local expert (same
+    // length/order as gate_projs). All three lists together or none. Omit for
+    // the bias-free DeepSeek / MiniMax-M3 path.
+    const std::optional<std::vector<ttnn::Tensor>>& gate_biases = std::nullopt,
+    const std::optional<std::vector<ttnn::Tensor>>& up_biases = std::nullopt,
+    const std::optional<std::vector<ttnn::Tensor>>& down_biases = std::nullopt);
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::unified_routed_expert_ffn
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn_nanobind.cpp
@@ -109,7 +109,10 @@ void bind_unified_routed_expert_ffn(nb::module_& mod) {
         nb::arg("input_m_tiles") = nb::none(),
         nb::arg("read_x_at_offset") = false,
         nb::arg("x_is_row_major") = false,
-        nb::arg("activation") = RoutedExpertActivation::Silu);
+        nb::arg("activation") = RoutedExpertActivation::Silu,
+        nb::arg("gate_bias") = nb::none(),
+        nb::arg("up_bias") = nb::none(),
+        nb::arg("down_bias") = nb::none());
 
     ttnn::bind_function<"unified_routed_expert_moe", "ttnn.experimental.deepseek_prefill.">(
         mod,
@@ -157,7 +160,10 @@ void bind_unified_routed_expert_ffn(nb::module_& mod) {
         nb::arg("max_dispatched_tokens_per_expert"),
         nb::kw_only(),
         nb::arg("compute_kernel_config") = nb::none(),
-        nb::arg("activation") = RoutedExpertActivation::Silu);
+        nb::arg("activation") = RoutedExpertActivation::Silu,
+        nb::arg("gate_biases") = nb::none(),
+        nb::arg("up_biases") = nb::none(),
+        nb::arg("down_biases") = nb::none());
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::unified_routed_expert_ffn::detail


### PR DESCRIPTION
## Summary
Fuses gpt-oss gate/up/down **expert biases** into `unified_routed_expert_ffn` (SwiGLU-OAI), so gpt-oss prefill can move onto the DeepSeek / MiniMax-M3 dispatch + fused-expert scheme (as M3 does in #49300). DeepSeek-V3 / MiniMax-M3 are bias-free, so the fused kernel never had bias; this adds it.

## Target behaviour (SwiGLU-OAI, `limit=7.0`, `alpha=1.702`)
```
gate = x @ gate_proj.T + gate_bias
up   = x @ up_proj.T   + up_bias
gate = clamp(gate, max=limit);  up = clamp(up, -limit, limit)
act  = (up + 1) * gate * sigmoid(alpha * gate)
out  = act @ down_proj.T + down_bias
```
gate/up bias added **before** the SwiGLU-OAI clamp; down bias added **after** the down matmul.

## Implemented
- **Op API / host** — optional `gate_bias`/`up_bias`/`down_bias` on `unified_routed_expert_ffn` + per-expert `*_biases` lists on `unified_routed_expert_moe`; prim + device-op inputs + `fuse_bias` in the program-cache key; nanobind kwargs. Bias-free path byte-identical when unset.
- **Kernel** — gate/up bias-add before the clamp/activation SFPU, down bias-add after the down matmul (extra CBs, guarded under `SwiGluOai`).
- **Python** — `TtRoutedExpert` takes an optional per-expert `torch_biases` list mirroring `torch_weights`.
- **Validation** — all-or-none, per-projection N-dim checks; biases require `SwiGluOai` (guarded so the SiLU path can't silently accept them).

## Scope (why single-chip is sufficient here)
- **Cross-device EP (mesh > 1) is intentionally not covered in this op PR.** The kernel is per-core / EP-agnostic, and bias mesh-distribution reuses the already-proven expert-weight gather + mesh mapper (biases are distributed exactly like the per-expert weights). Cross-device EP=32 is exercised downstream by the gpt-oss full-model prefill bring-up.
- **MXFP4 is upstream weight-prep, not this op.** The op consumes `bfloat4_b` weights; HF mxfp4 → bf16 → bf4 conversion happens in the model's weight preparation, so it is out of scope here.

## Test plan (single Blackhole card)
- `./build_metal.sh --release` (after `git submodule update --init --recursive`).
- `pytest tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_routed_expert_bias.py`
  - `test_gptoss_bias_routed_expert[t128]` / `[t1k]` — 1 expert, gate/up/down bias vs torch. **t1k PCC 0.9804.**
  - `test_gptoss_bias_multi_expert[e4]` — 4 experts/chip, per-expert bias wiring + count bounding.
  - `test_gptoss_bias_torch_reference_smoke` — host-only reference guard.
  - **4 passed.**
- Regression: `test_swigluoai_routed_expert.py` (non-bias path) — **7 passed**, unchanged.

Rebased on latest `main` (clean merge).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mdragula/unified_routed_expert_ffn_bias)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mdragula/unified_routed_expert_ffn_bias)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mdragula/unified_routed_expert_ffn_bias)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mdragula/unified_routed_expert_ffn_bias)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mdragula/unified_routed_expert_ffn_bias)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mdragula/unified_routed_expert_ffn_bias)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mdragula/unified_routed_expert_ffn_bias)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mdragula/unified_routed_expert_ffn_bias)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mdragula/unified_routed_expert_ffn_bias)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mdragula/unified_routed_expert_ffn_bias)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mdragula/unified_routed_expert_ffn_bias)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mdragula/unified_routed_expert_ffn_bias)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mdragula/unified_routed_expert_ffn_bias)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mdragula/unified_routed_expert_ffn_bias)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mdragula/unified_routed_expert_ffn_bias)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mdragula/unified_routed_expert_ffn_bias)