### PR TITLE
[Performance] Improve GEMM FLOPS benchmark and matmul tuning

### DIFF
--- a/tech_reports/GEMM_FLOPS/GEMM_FLOPS.md
+++ b/tech_reports/GEMM_FLOPS/GEMM_FLOPS.md
@@ -14,16 +14,22 @@ Therefore, the peak achieved flops changes based on the datatype, the size of th
 
 ### Running Benchmarks
 
-The matrix multiply TFLOPS results can be tested on any Wormhole or Blackhole card using:
+The matrix multiply TFLOPS results can be tested on any Wormhole or Blackhole card. The benchmark is gated behind `TTNN_RUN_GEMM_FLOPS_BENCHMARK=1` (it skips otherwise) and runs a single unified test, `test_matmul_2d_host_perf`, that sweeps three modes and writes them all to one CSV (`generated/matmul_benchmark_report.csv`):
 
-**For manually selected matmul configurations (best performance):**
+- `oob` — out-of-box matmul configs (default auto-selected settings)
+- `tuned_2d_l1` — explicitly tuned 2D multicast config with L1-sharded in0 and output (best performance)
+- `tuned_2d_dram` — explicitly tuned 2D multicast config with DRAM-interleaved in0 and output
+
+The easiest way to run the full flow (benchmark + CSV placement + plot generation) is the provided runner, which sets all required env vars:
+
 ```bash
-TT_METAL_PROFILER_MID_RUN_DUMP=1 TT_METAL_DEVICE_PROFILER=1 pytest tests/ttnn/unit_tests/benchmarks/test_benchmark.py::test_matmul_2d_host_perf
+bash tech_reports/GEMM_FLOPS/run_bench.sh
 ```
 
-**For out-of-box matmul configurations (default settings):**
+To run only the benchmark without regenerating the plots, invoke the test directly (note the required env var):
+
 ```bash
-TT_METAL_PROFILER_MID_RUN_DUMP=1 TT_METAL_DEVICE_PROFILER=1 pytest tests/ttnn/unit_tests/benchmarks/test_benchmark.py::test_matmul_2d_host_perf_out_of_box
+TTNN_RUN_GEMM_FLOPS_BENCHMARK=1 TT_METAL_PROFILER_MID_RUN_DUMP=1 TT_METAL_DEVICE_PROFILER=1 pytest tests/ttnn/unit_tests/benchmarks/test_benchmark.py::test_matmul_2d_host_perf -xvs --timeout=7200
 ```
 
 Alternatively, to test on an N300 card, use ```WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml``` before each command.

--- a/tech_reports/GEMM_FLOPS/plot_aspect_ratio_by_dtype.py
+++ b/tech_reports/GEMM_FLOPS/plot_aspect_ratio_by_dtype.py
@@ -31,6 +31,8 @@ DEVICE_LABELS = {
     "P150": "P150 (Blackhole)",
 }
 
+BASE_SHAPE_COLUMNS = ["base_m", "base_k", "base_n"]
+
 
 def safe_read_csv(path):
     """Return the CSV as a DataFrame, or an empty DataFrame if the file is missing."""
@@ -45,12 +47,8 @@ def gcd_of_three(a, b, c):
     return reduce(gcd, [a, b, c])
 
 
-def calculate_aspect_ratio(m, k, n, grid_x, grid_y):
-    """Calculate aspect ratio from scaled dimensions by reversing grid scaling"""
-    base_m = m // grid_y
-    base_k = k // grid_x
-    base_n = n // grid_x
-
+def calculate_aspect_ratio(base_m, base_k, base_n):
+    """Calculate aspect ratio from base matrix dimensions."""
     divisor = gcd_of_three(base_m, base_k, base_n)
     ratio_m = base_m // divisor
     ratio_k = base_k // divisor
@@ -59,12 +57,26 @@ def calculate_aspect_ratio(m, k, n, grid_x, grid_y):
     return f"{ratio_m}:{ratio_k}:{ratio_n}"
 
 
-def extract_grid_dims(df):
+def parse_grid_size(raw):
     """Parse grid_x and grid_y from the grid_size column, e.g. '(12, 10)' → (12, 10)."""
-    raw = df["grid_size"].iloc[0]
     cleaned = str(raw).strip("() ")
-    parts = [int(x.strip()) for x in cleaned.split(",")]
-    return parts[0], parts[1]
+    grid_x, grid_y = [int(x.strip()) for x in cleaned.split(",")]
+    return grid_x, grid_y
+
+
+def extract_grid_dims(df):
+    return parse_grid_size(df["grid_size"].iloc[0])
+
+
+def add_base_shape_columns(df):
+    """Ensure base_m/base_k/base_n exist while preserving full scaled m/k/n."""
+    if not all(col in df.columns for col in BASE_SHAPE_COLUMNS):
+        grid_dims = df["grid_size"].apply(parse_grid_size)
+        df["base_m"] = [m // grid_y for m, (_, grid_y) in zip(df["m"], grid_dims)]
+        df["base_k"] = [k // grid_x for k, (grid_x, _) in zip(df["k"], grid_dims)]
+        df["base_n"] = [n // grid_x for n, (grid_x, _) in zip(df["n"], grid_dims)]
+    df["base_shape"] = list(zip(df["base_m"], df["base_k"], df["base_n"]))
+    return df
 
 
 def load_and_prepare(path, source):
@@ -84,6 +96,7 @@ def load_and_prepare(path, source):
         + "_"
         + df["math_fidelity"].astype(str).str.replace("MathFidelity.", "")
     )
+    df = add_base_shape_columns(df)
 
     gx, gy = extract_grid_dims(df)
     df["grid_x"] = gx
@@ -91,7 +104,7 @@ def load_and_prepare(path, source):
     print(f"{source} grid: {gx}x{gy}")
 
     df["aspect_ratio"] = df.apply(
-        lambda row: calculate_aspect_ratio(row["m"], row["k"], row["n"], row["grid_x"], row["grid_y"]), axis=1
+        lambda row: calculate_aspect_ratio(row["base_m"], row["base_k"], row["base_n"]), axis=1
     )
     return df
 
@@ -156,8 +169,8 @@ for source in available_sources:
 
             # Group by matrix size and get best TFLOPs for each size
             size_tflops = []
-            for matrix_size, group in filtered.groupby(["m", "k", "n"]):
-                total_elements = matrix_size[0] * matrix_size[1] * matrix_size[2]
+            for _, group in filtered.groupby("base_shape"):
+                total_elements = group["m"].iloc[0] * group["k"].iloc[0] * group["n"].iloc[0]
                 best_tflops = group["tflops"].max()
                 size_tflops.append((total_elements, best_tflops))
 

--- a/tech_reports/GEMM_FLOPS/plot_aspect_ratio_by_dtype.py
+++ b/tech_reports/GEMM_FLOPS/plot_aspect_ratio_by_dtype.py
@@ -2,25 +2,39 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
+Aspect ratio comparison: TFLOPs by matrix shape aspect ratio per device.
+
 Usage:
-1. Generate performance data using manually selected GEMM configurations
-2. Rename output files to n150-manual.csv and p150-manual.csv
-3. Place the CSV files in tech_reports/GEMM_FLOPS/
-4. Run this script from the tt-metal root directory
+1. Run the benchmark via run_bench.sh on both devices
+2. CSVs are placed in tech_reports/GEMM_FLOPS/data/{wh,bh}.csv
+3. Run this script from the tt-metal root directory
 """
 
-import os
+from pathlib import Path
+from functools import reduce
+from math import gcd
 
+import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
-import numpy as np
-from math import gcd
-from functools import reduce
+
+DATA_DIR = Path("tech_reports/GEMM_FLOPS/data")
+IMG_DIR = Path("tech_reports/GEMM_FLOPS/images")
+
+DEVICE_FILES = {
+    "N150": DATA_DIR / "wh.csv",
+    "P150": DATA_DIR / "bh.csv",
+}
+
+DEVICE_LABELS = {
+    "N150": "N150 (Wormhole)",
+    "P150": "P150 (Blackhole)",
+}
 
 
 def safe_read_csv(path):
     """Return the CSV as a DataFrame, or an empty DataFrame if the file is missing."""
-    if os.path.exists(path):
+    if path.exists():
         return pd.read_csv(path)
     print(f"WARNING: {path} not found — skipping that device.")
     return pd.DataFrame()
@@ -53,45 +67,47 @@ def extract_grid_dims(df):
     return parts[0], parts[1]
 
 
-# Load N150 and P150 data
-df_n150 = safe_read_csv("tech_reports/GEMM_FLOPS/n150-manual.csv")
-if not df_n150.empty:
-    df_n150["source"] = "N150"
-    gx, gy = extract_grid_dims(df_n150)
-    df_n150["grid_x"] = gx
-    df_n150["grid_y"] = gy
-    print(f"N150 grid: {gx}x{gy}")
-
-df_p150 = safe_read_csv("tech_reports/GEMM_FLOPS/p150-manual.csv")
-if not df_p150.empty:
-    df_p150["source"] = "P150"
-    gx, gy = extract_grid_dims(df_p150)
-    df_p150["grid_x"] = gx
-    df_p150["grid_y"] = gy
-    print(f"P150 grid: {gx}x{gy}")
-
-# Standardize column names and derive computed columns per device
-print("Calculating aspect ratios...")
-for _df in [df_n150, df_p150]:
-    if _df.empty:
-        continue
-    if "TFLOPs (avg)" in _df.columns:
-        _df.rename(columns={"TFLOPs (avg)": "tflops"}, inplace=True)
-    _df["tflops"] = pd.to_numeric(_df["tflops"], errors="coerce")
-    _df["dtype_fidelity"] = (
-        _df["dtype"].astype(str).str.replace("DataType.", "")
+def load_and_prepare(path, source):
+    """Load CSV and prepare derived columns."""
+    df = safe_read_csv(path)
+    if df.empty:
+        return df
+    df["source"] = source
+    # Use best performance across all tuned modes
+    if "mode" in df.columns:
+        df = df[df["mode"] != "oob"].copy()
+    if "TFLOPs (avg)" in df.columns:
+        df.rename(columns={"TFLOPs (avg)": "tflops"}, inplace=True)
+    df["tflops"] = pd.to_numeric(df["tflops"], errors="coerce")
+    df["dtype_fidelity"] = (
+        df["dtype"].astype(str).str.replace("DataType.", "")
         + "_"
-        + _df["math_fidelity"].astype(str).str.replace("MathFidelity.", "")
+        + df["math_fidelity"].astype(str).str.replace("MathFidelity.", "")
     )
-    _df["aspect_ratio"] = _df.apply(
+
+    gx, gy = extract_grid_dims(df)
+    df["grid_x"] = gx
+    df["grid_y"] = gy
+    print(f"{source} grid: {gx}x{gy}")
+
+    df["aspect_ratio"] = df.apply(
         lambda row: calculate_aspect_ratio(row["m"], row["k"], row["n"], row["grid_x"], row["grid_y"]), axis=1
     )
+    return df
 
-df = pd.concat([df_n150, df_p150], ignore_index=True)
 
-if df.empty:
+# Load data
+frames = []
+for source, path in DEVICE_FILES.items():
+    loaded = load_and_prepare(path, source)
+    if not loaded.empty:
+        frames.append(loaded)
+
+if not frames:
     print("ERROR: No data available for any device. Exiting.")
     raise SystemExit(1)
+
+df = pd.concat(frames, ignore_index=True)
 
 # Define dtype-fidelity pairs and aspect ratios (colors match scatter/bar plots)
 dtype_configs = [
@@ -104,28 +120,29 @@ aspect_ratios = ["1:1:1", "1:2:4"]
 aspect_labels = {"1:1:1": "Square\n(1:1:1)", "1:2:4": "Rectangular\n(1:2:4)"}
 
 # Create plot for each device that has data
-available_sources = [s for s in ["N150", "P150"] if s in df["source"].values]
+IMG_DIR.mkdir(parents=True, exist_ok=True)
+print("Calculating aspect ratios...")
+
+available_sources = [s for s in DEVICE_FILES if s in df["source"].values]
 for source in available_sources:
     device_data = df[df["source"] == source].copy()
 
     if device_data.empty:
-        print(f"\n❌ No data for {source}")
+        print(f"\nNo data for {source}")
         continue
 
     # Collect data: for each aspect ratio, get all 3 dtypes
-    # Use balanced sampling: select top N matrix sizes for fair comparison
-    TOP_N_SIZES = 3  # Use the 3 largest matrix sizes from each aspect ratio
+    TOP_N_SIZES = 3
     summary_data = []
 
     for aspect_ratio in aspect_ratios:
         for dtype_fidelity, dtype_label, color in dtype_configs:
-            # Filter for this specific dtype and aspect ratio
             filtered = device_data[
                 (device_data["dtype_fidelity"] == dtype_fidelity) & (device_data["aspect_ratio"] == aspect_ratio)
             ]
 
             if filtered.empty:
-                print(f"  ⚠️  No data for {source} {dtype_fidelity} with aspect {aspect_ratio}")
+                print(f"  No data for {source} {dtype_fidelity} with aspect {aspect_ratio}")
                 summary_data.append(
                     {
                         "aspect_ratio": aspect_ratio,
@@ -164,24 +181,22 @@ for source in available_sources:
             )
 
             print(
-                f"  ✓ {source} {dtype_fidelity} ({aspect_ratio}): {avg_tflops:.1f} TFLOPs (avg of top {len(top_n_tflops)} sizes out of {len(size_tflops)} total)"
+                f"  {source} {dtype_fidelity} ({aspect_ratio}): {avg_tflops:.1f} TFLOPs "
+                f"(avg of top {len(top_n_tflops)} sizes out of {len(size_tflops)} total)"
             )
 
     # Create grouped bar chart
     fig, ax = plt.subplots(figsize=(16, 8))
 
-    # Set up positions: 3 aspect ratios, each with 3 dtypes
     n_dtypes = len(dtype_configs)
     bar_width = 0.22
-    group_gap = 0.5  # Larger gap between aspect ratio groups
+    group_gap = 0.5
 
     aspect_positions = []
     current_pos = 0
 
     for aspect_idx, aspect_ratio in enumerate(aspect_ratios):
-        # Plot 3 bars for this aspect ratio (one per dtype)
         for dtype_idx, (dtype_fidelity, dtype_label, color) in enumerate(dtype_configs):
-            # Find the data for this combination
             data_point = next(
                 (
                     d
@@ -204,17 +219,14 @@ for source in available_sources:
                     edgecolor="black",
                     linewidth=1.3,
                     label=dtype_label if aspect_idx == 0 else "",
-                )  # Only label once
+                )
 
-                # Add value label
                 if value > 0:
                     ax.text(bar_pos, value, f"{value:.1f}", ha="center", va="bottom", fontsize=10, fontweight="bold")
 
-        # Store center position for this aspect ratio group
         aspect_center = current_pos + (n_dtypes * bar_width) / 2 - bar_width / 2
         aspect_positions.append(aspect_center)
 
-        # Move to next group
         current_pos += n_dtypes * bar_width + group_gap
 
     ax.set_ylabel("Average TFLOPs", fontsize=14, fontweight="bold", labelpad=10)
@@ -224,7 +236,6 @@ for source in available_sources:
         fontweight="bold",
         labelpad=10,
     )
-    # Add explanation below x-axis (smaller, non-bold)
     ax.text(
         0.5,
         -0.12,
@@ -235,16 +246,13 @@ for source in available_sources:
         fontsize=10,
     )
 
-    # Title matching our other plots
-    device_name = "N150 (Wormhole)" if source == "N150" else "P150 (Blackhole)"
+    device_name = DEVICE_LABELS.get(source, source)
     fig.suptitle(f"Performance Comparison: {device_name}", fontsize=18, fontweight="bold", y=0.98)
     ax.set_title("TFLOPs by Matrix Aspect Ratio and Data Type", fontsize=14, pad=10, fontweight="bold")
 
-    # Set x-axis labels for aspect ratios
     ax.set_xticks(aspect_positions)
     ax.set_xticklabels([aspect_labels[r] for r in aspect_ratios], fontsize=12)
 
-    # Add legend for dtypes - position to avoid overlap with bars
     ax.legend(
         fontsize=11,
         loc="upper right",
@@ -260,11 +268,9 @@ for source in available_sources:
     ax.set_ylim(bottom=0)
 
     plt.tight_layout()
-    plt.savefig(
-        f"tech_reports/GEMM_FLOPS/images/aspect_ratio_by_dtype_{source.lower()}.png", dpi=300, bbox_inches="tight"
-    )
+    plt.savefig(IMG_DIR / f"aspect_ratio_by_dtype_{source.lower()}.png", dpi=300, bbox_inches="tight")
     plt.close()
 
-    print(f"\n✅ Saved: aspect_ratio_by_dtype_{source.lower()}.png")
+    print(f"\nSaved: aspect_ratio_by_dtype_{source.lower()}.png")
 
-print("\n✅ Aspect ratio by dtype comparison complete!")
+print("\nAspect ratio by dtype comparison complete!")

--- a/tech_reports/GEMM_FLOPS/plot_aspect_ratio_by_dtype.py
+++ b/tech_reports/GEMM_FLOPS/plot_aspect_ratio_by_dtype.py
@@ -9,11 +9,21 @@ Usage:
 4. Run this script from the tt-metal root directory
 """
 
+import os
+
 import pandas as pd
 import matplotlib.pyplot as plt
 import numpy as np
 from math import gcd
 from functools import reduce
+
+
+def safe_read_csv(path):
+    """Return the CSV as a DataFrame, or an empty DataFrame if the file is missing."""
+    if os.path.exists(path):
+        return pd.read_csv(path)
+    print(f"WARNING: {path} not found — skipping that device.")
+    return pd.DataFrame()
 
 
 def gcd_of_three(a, b, c):
@@ -35,48 +45,53 @@ def calculate_aspect_ratio(m, k, n, grid_x, grid_y):
     return f"{ratio_m}:{ratio_k}:{ratio_n}"
 
 
+def extract_grid_dims(df):
+    """Parse grid_x and grid_y from the grid_size column, e.g. '(12, 10)' → (12, 10)."""
+    raw = df["grid_size"].iloc[0]
+    cleaned = str(raw).strip("() ")
+    parts = [int(x.strip()) for x in cleaned.split(",")]
+    return parts[0], parts[1]
+
+
 # Load N150 and P150 data
-df_n150 = pd.read_csv("tech_reports/GEMM_FLOPS/n150-manual.csv")
-df_n150["source"] = "N150"
-df_n150["grid_x"] = 8
-df_n150["grid_y"] = 8
+df_n150 = safe_read_csv("tech_reports/GEMM_FLOPS/n150-manual.csv")
+if not df_n150.empty:
+    df_n150["source"] = "N150"
+    gx, gy = extract_grid_dims(df_n150)
+    df_n150["grid_x"] = gx
+    df_n150["grid_y"] = gy
+    print(f"N150 grid: {gx}x{gy}")
 
-df_p150 = pd.read_csv("tech_reports/GEMM_FLOPS/p150-manual.csv")
-df_p150["source"] = "P150"
-df_p150["grid_x"] = 13
-df_p150["grid_y"] = 10
+df_p150 = safe_read_csv("tech_reports/GEMM_FLOPS/p150-manual.csv")
+if not df_p150.empty:
+    df_p150["source"] = "P150"
+    gx, gy = extract_grid_dims(df_p150)
+    df_p150["grid_x"] = gx
+    df_p150["grid_y"] = gy
+    print(f"P150 grid: {gx}x{gy}")
 
-# Standardize column names
-if "TFLOPs (avg)" in df_n150.columns:
-    df_n150.rename(columns={"TFLOPs (avg)": "tflops"}, inplace=True)
-if "TFLOPs (avg)" in df_p150.columns:
-    df_p150.rename(columns={"TFLOPs (avg)": "tflops"}, inplace=True)
-
-df_n150["tflops"] = pd.to_numeric(df_n150["tflops"], errors="coerce")
-df_p150["tflops"] = pd.to_numeric(df_p150["tflops"], errors="coerce")
-
-# Create dtype_fidelity column
-df_n150["dtype_fidelity"] = (
-    df_n150["dtype"].astype(str).str.replace("DataType.", "")
-    + "_"
-    + df_n150["math_fidelity"].astype(str).str.replace("MathFidelity.", "")
-)
-df_p150["dtype_fidelity"] = (
-    df_p150["dtype"].astype(str).str.replace("DataType.", "")
-    + "_"
-    + df_p150["math_fidelity"].astype(str).str.replace("MathFidelity.", "")
-)
-
-# Calculate aspect ratios
+# Standardize column names and derive computed columns per device
 print("Calculating aspect ratios...")
-df_n150["aspect_ratio"] = df_n150.apply(
-    lambda row: calculate_aspect_ratio(row["m"], row["k"], row["n"], row["grid_x"], row["grid_y"]), axis=1
-)
-df_p150["aspect_ratio"] = df_p150.apply(
-    lambda row: calculate_aspect_ratio(row["m"], row["k"], row["n"], row["grid_x"], row["grid_y"]), axis=1
-)
+for _df in [df_n150, df_p150]:
+    if _df.empty:
+        continue
+    if "TFLOPs (avg)" in _df.columns:
+        _df.rename(columns={"TFLOPs (avg)": "tflops"}, inplace=True)
+    _df["tflops"] = pd.to_numeric(_df["tflops"], errors="coerce")
+    _df["dtype_fidelity"] = (
+        _df["dtype"].astype(str).str.replace("DataType.", "")
+        + "_"
+        + _df["math_fidelity"].astype(str).str.replace("MathFidelity.", "")
+    )
+    _df["aspect_ratio"] = _df.apply(
+        lambda row: calculate_aspect_ratio(row["m"], row["k"], row["n"], row["grid_x"], row["grid_y"]), axis=1
+    )
 
 df = pd.concat([df_n150, df_p150], ignore_index=True)
+
+if df.empty:
+    print("ERROR: No data available for any device. Exiting.")
+    raise SystemExit(1)
 
 # Define dtype-fidelity pairs and aspect ratios (colors match scatter/bar plots)
 dtype_configs = [
@@ -88,8 +103,9 @@ dtype_configs = [
 aspect_ratios = ["1:1:1", "1:2:4"]
 aspect_labels = {"1:1:1": "Square\n(1:1:1)", "1:2:4": "Rectangular\n(1:2:4)"}
 
-# Create plot for each device
-for source in ["N150", "P150"]:
+# Create plot for each device that has data
+available_sources = [s for s in ["N150", "P150"] if s in df["source"].values]
+for source in available_sources:
     device_data = df[df["source"] == source].copy()
 
     if device_data.empty:

--- a/tech_reports/GEMM_FLOPS/plot_bar.py
+++ b/tech_reports/GEMM_FLOPS/plot_bar.py
@@ -26,6 +26,8 @@ DEVICE_FILES = {
     "P150": DATA_DIR / "bh.csv",
 }
 
+BASE_SHAPE_COLUMNS = ["base_m", "base_k", "base_n"]
+
 
 def safe_read_csv(path):
     """Return the CSV as a DataFrame, or an empty DataFrame if the file is missing."""
@@ -33,6 +35,23 @@ def safe_read_csv(path):
         return pd.read_csv(path)
     print(f"WARNING: {path} not found — skipping that device.")
     return pd.DataFrame()
+
+
+def parse_grid_size(raw):
+    cleaned = str(raw).strip("() ")
+    grid_x, grid_y = [int(x.strip()) for x in cleaned.split(",")]
+    return grid_x, grid_y
+
+
+def add_base_shape_columns(df):
+    """Ensure base_m/base_k/base_n exist while preserving full scaled m/k/n."""
+    if not all(col in df.columns for col in BASE_SHAPE_COLUMNS):
+        grid_dims = df["grid_size"].apply(parse_grid_size)
+        df["base_m"] = [m // grid_y for m, (_, grid_y) in zip(df["m"], grid_dims)]
+        df["base_k"] = [k // grid_x for k, (grid_x, _) in zip(df["k"], grid_dims)]
+        df["base_n"] = [n // grid_x for n, (grid_x, _) in zip(df["n"], grid_dims)]
+    df["base_shape"] = list(zip(df["base_m"], df["base_k"], df["base_n"]))
+    return df
 
 
 def load_and_prepare(path, source):
@@ -52,6 +71,7 @@ def load_and_prepare(path, source):
         + "_"
         + df["math_fidelity"].astype(str).str.replace("MathFidelity.", "")
     )
+    df = add_base_shape_columns(df)
     return df
 
 
@@ -73,10 +93,10 @@ if df_n150.empty or df_p150.empty:
 
 df = pd.concat([df_n150, df_p150], ignore_index=True)
 
-# Filter for square matrices and get best performance per (m, source, dtype_fidelity)
-df_square = df[df["k"] == df["n"]].copy()
+# Filter for square base matrices and get best performance per base shape/source/dtype.
+df_square = df[df["base_k"] == df["base_n"]].copy()
 best_data = []
-for (m_val, source, dtype_fidelity), group in df_square.groupby(["m", "source", "dtype_fidelity"]):
+for (_, source, dtype_fidelity), group in df_square.groupby(["base_shape", "source", "dtype_fidelity"]):
     best_row = group.loc[group["tflops"].idxmax()]
     best_data.append(best_row)
 
@@ -88,15 +108,22 @@ dtype_configs = [
     ("BFLOAT4_B_LoFi", "BFLOAT4_B (LoFi)"),
 ]
 
-# Pair N150 and P150 M values for x-axis labels
-n150_m_values = sorted(df_best[df_best["source"] == "N150"]["m"].unique())
-p150_m_values = sorted(df_best[df_best["source"] == "P150"]["m"].unique())
+# Pair N150 and P150 by base shape; use scaled M values only for display.
+n150_shapes = set(df_best[df_best["source"] == "N150"]["base_shape"])
+p150_shapes = set(df_best[df_best["source"] == "P150"]["base_shape"])
+paired_base_shapes = sorted(n150_shapes & p150_shapes)
 
 combined_labels = []
-all_m_values = []
-for n150_m, p150_m in zip(n150_m_values, p150_m_values):
+all_base_shapes = []
+for base_shape in paired_base_shapes:
+    n150_m = df_best[(df_best["source"] == "N150") & (df_best["base_shape"] == base_shape)]["m"].iloc[0]
+    p150_m = df_best[(df_best["source"] == "P150") & (df_best["base_shape"] == base_shape)]["m"].iloc[0]
     combined_labels.append(f"{n150_m} / {p150_m}")
-    all_m_values.append((n150_m, p150_m))
+    all_base_shapes.append(base_shape)
+
+if not all_base_shapes:
+    print("ERROR: No paired base matrix shapes available for N150/P150 comparison. Exiting.")
+    raise SystemExit(1)
 
 print(f"✓ Matrix sizes: {len(combined_labels)} pairs")
 print(f"✓ Total configurations: {len(df_best)}")
@@ -123,13 +150,15 @@ bar_info = []
 
 current_pos = 0
 
-for pair_idx, (n150_m, p150_m) in enumerate(all_m_values):
+for pair_idx, base_shape in enumerate(all_base_shapes):
     cluster_start = current_pos
 
     # N150 bars (lighter)
     for dtype_fidelity, label in dtype_configs:
         n150_data = df_best[
-            (df_best["m"] == n150_m) & (df_best["source"] == "N150") & (df_best["dtype_fidelity"] == dtype_fidelity)
+            (df_best["base_shape"] == base_shape)
+            & (df_best["source"] == "N150")
+            & (df_best["dtype_fidelity"] == dtype_fidelity)
         ]
         if len(n150_data) > 0:
             val = n150_data["tflops"].values[0]
@@ -146,7 +175,9 @@ for pair_idx, (n150_m, p150_m) in enumerate(all_m_values):
     # P150 bars (darker)
     for dtype_fidelity, label in dtype_configs:
         p150_data = df_best[
-            (df_best["m"] == p150_m) & (df_best["source"] == "P150") & (df_best["dtype_fidelity"] == dtype_fidelity)
+            (df_best["base_shape"] == base_shape)
+            & (df_best["source"] == "P150")
+            & (df_best["dtype_fidelity"] == dtype_fidelity)
         ]
         if len(p150_data) > 0:
             val = p150_data["tflops"].values[0]
@@ -165,7 +196,7 @@ ax.bar(positions, heights, width=bar_width, color=colors_list, edgecolor="black"
 
 # Add performance multiplier annotations (baseline: N150 BFLOAT16-HiFi4 per matrix size)
 max_height = max(heights)
-for pair_idx in range(len(all_m_values)):
+for pair_idx in range(len(all_base_shapes)):
     baseline = None
     for info in bar_info:
         if info["pair_idx"] == pair_idx and info["dtype"] == "BFLOAT16_HiFi4" and info["source"] == "N150":

--- a/tech_reports/GEMM_FLOPS/plot_bar.py
+++ b/tech_reports/GEMM_FLOPS/plot_bar.py
@@ -2,69 +2,74 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
+Bar chart: paired N150 vs P150 TFLOPs comparison for square-ish matrices.
+
 Usage:
-1. Generate performance data using manually selected GEMM configurations
-2. Rename output files to n150-manual.csv and p150-manual.csv
-3. Place the CSV files in tech_reports/GEMM_FLOPS/
-4. Run this script from the tt-metal root directory
+1. Run the benchmark via run_bench.sh on both devices
+2. CSVs are placed in tech_reports/GEMM_FLOPS/data/{wh,bh}.csv
+3. Run this script from the tt-metal root directory
 """
 
-import os
+from pathlib import Path
 
+import matplotlib.colors as mcolors
 import pandas as pd
 import matplotlib.pyplot as plt
-import matplotlib.colors as mcolors
+from matplotlib.lines import Line2D
+from matplotlib.patches import Rectangle
+
+DATA_DIR = Path("tech_reports/GEMM_FLOPS/data")
+IMG_DIR = Path("tech_reports/GEMM_FLOPS/images")
+
+DEVICE_FILES = {
+    "N150": DATA_DIR / "wh.csv",
+    "P150": DATA_DIR / "bh.csv",
+}
 
 
 def safe_read_csv(path):
     """Return the CSV as a DataFrame, or an empty DataFrame if the file is missing."""
-    if os.path.exists(path):
+    if path.exists():
         return pd.read_csv(path)
     print(f"WARNING: {path} not found — skipping that device.")
     return pd.DataFrame()
 
 
-# Load N150 and P150 data
-df_n150 = safe_read_csv("tech_reports/GEMM_FLOPS/n150-manual.csv")
-if not df_n150.empty:
-    df_n150["source"] = "N150"
+def load_and_prepare(path, source):
+    """Load CSV and prepare derived columns."""
+    df = safe_read_csv(path)
+    if df.empty:
+        return df
+    df["source"] = source
+    # Use best performance across all tuned modes
+    if "mode" in df.columns:
+        df = df[df["mode"] != "oob"].copy()
+    if "TFLOPs (avg)" in df.columns:
+        df.rename(columns={"TFLOPs (avg)": "tflops"}, inplace=True)
+    df["tflops"] = pd.to_numeric(df["tflops"], errors="coerce")
+    df["dtype_fidelity"] = (
+        df["dtype"].astype(str).str.replace("DataType.", "")
+        + "_"
+        + df["math_fidelity"].astype(str).str.replace("MathFidelity.", "")
+    )
+    return df
 
-df_p150 = safe_read_csv("tech_reports/GEMM_FLOPS/p150-manual.csv")
-if not df_p150.empty:
-    df_p150["source"] = "P150"
+
+# Load data
+df_n150 = load_and_prepare(DEVICE_FILES["N150"], "N150")
+df_p150 = load_and_prepare(DEVICE_FILES["P150"], "P150")
 
 if df_n150.empty or df_p150.empty:
     missing = []
     if df_n150.empty:
-        missing.append("n150-manual.csv")
+        missing.append("wh.csv")
     if df_p150.empty:
-        missing.append("p150-manual.csv")
+        missing.append("bh.csv")
     print(
         f"NOTE: plot_bar.py produces a paired N150/P150 comparison chart and "
         f"requires both device CSVs. Missing: {', '.join(missing)}. Skipping."
     )
     raise SystemExit(0)
-
-# Standardize column names
-if "TFLOPs (avg)" in df_n150.columns:
-    df_n150.rename(columns={"TFLOPs (avg)": "tflops"}, inplace=True)
-if "TFLOPs (avg)" in df_p150.columns:
-    df_p150.rename(columns={"TFLOPs (avg)": "tflops"}, inplace=True)
-
-df_n150["tflops"] = pd.to_numeric(df_n150["tflops"], errors="coerce")
-df_p150["tflops"] = pd.to_numeric(df_p150["tflops"], errors="coerce")
-
-# Create dtype_fidelity column
-df_n150["dtype_fidelity"] = (
-    df_n150["dtype"].astype(str).str.replace("DataType.", "")
-    + "_"
-    + df_n150["math_fidelity"].astype(str).str.replace("MathFidelity.", "")
-)
-df_p150["dtype_fidelity"] = (
-    df_p150["dtype"].astype(str).str.replace("DataType.", "")
-    + "_"
-    + df_p150["math_fidelity"].astype(str).str.replace("MathFidelity.", "")
-)
 
 df = pd.concat([df_n150, df_p150], ignore_index=True)
 
@@ -197,10 +202,7 @@ ax.grid(True, axis="y", linestyle="--", alpha=0.4)
 ax.set_axisbelow(True)
 ax.set_ylim(0, max_height * 1.2)
 
-# Legend - cleaner format like scatter plots
-from matplotlib.patches import Rectangle
-from matplotlib.lines import Line2D
-
+# Legend
 legend_elements = []
 
 # Dtype section header
@@ -237,9 +239,10 @@ ax.legend(
     handlelength=3.5,
 )
 
+IMG_DIR.mkdir(parents=True, exist_ok=True)
 plt.subplots_adjust(left=0.03, right=0.97, bottom=0.12, top=0.93)
 plt.xlim(min(positions) - bar_width * 2, max(positions) + bar_width * 2)
-plt.savefig("tech_reports/GEMM_FLOPS/images/flops_by_matrix_size_and_type_sorted.png", dpi=300, bbox_inches="tight")
+plt.savefig(IMG_DIR / "flops_by_matrix_size_and_type_sorted.png", dpi=300, bbox_inches="tight")
 plt.close()
 
 print(f"✓ Bar chart saved!")

--- a/tech_reports/GEMM_FLOPS/plot_bar.py
+++ b/tech_reports/GEMM_FLOPS/plot_bar.py
@@ -9,16 +9,41 @@ Usage:
 4. Run this script from the tt-metal root directory
 """
 
+import os
+
 import pandas as pd
 import matplotlib.pyplot as plt
 import matplotlib.colors as mcolors
 
-# Load N150 and P150 data
-df_n150 = pd.read_csv("tech_reports/GEMM_FLOPS/n150-manual.csv")
-df_n150["source"] = "N150"
 
-df_p150 = pd.read_csv("tech_reports/GEMM_FLOPS/p150-manual.csv")
-df_p150["source"] = "P150"
+def safe_read_csv(path):
+    """Return the CSV as a DataFrame, or an empty DataFrame if the file is missing."""
+    if os.path.exists(path):
+        return pd.read_csv(path)
+    print(f"WARNING: {path} not found — skipping that device.")
+    return pd.DataFrame()
+
+
+# Load N150 and P150 data
+df_n150 = safe_read_csv("tech_reports/GEMM_FLOPS/n150-manual.csv")
+if not df_n150.empty:
+    df_n150["source"] = "N150"
+
+df_p150 = safe_read_csv("tech_reports/GEMM_FLOPS/p150-manual.csv")
+if not df_p150.empty:
+    df_p150["source"] = "P150"
+
+if df_n150.empty or df_p150.empty:
+    missing = []
+    if df_n150.empty:
+        missing.append("n150-manual.csv")
+    if df_p150.empty:
+        missing.append("p150-manual.csv")
+    print(
+        f"NOTE: plot_bar.py produces a paired N150/P150 comparison chart and "
+        f"requires both device CSVs. Missing: {', '.join(missing)}. Skipping."
+    )
+    raise SystemExit(0)
 
 # Standardize column names
 if "TFLOPs (avg)" in df_n150.columns:

--- a/tech_reports/GEMM_FLOPS/plot_scatter_performance.py
+++ b/tech_reports/GEMM_FLOPS/plot_scatter_performance.py
@@ -24,6 +24,8 @@ DEVICE_FILES = {
     "P150": DATA_DIR / "bh.csv",
 }
 
+BASE_SHAPE_COLUMNS = ["base_m", "base_k", "base_n"]
+
 
 def safe_read_csv(path):
     """Return the CSV as a DataFrame, or an empty DataFrame if the file is missing."""
@@ -31,6 +33,23 @@ def safe_read_csv(path):
         return pd.read_csv(path)
     print(f"WARNING: {path} not found — skipping that device.")
     return pd.DataFrame()
+
+
+def parse_grid_size(raw):
+    cleaned = str(raw).strip("() ")
+    grid_x, grid_y = [int(x.strip()) for x in cleaned.split(",")]
+    return grid_x, grid_y
+
+
+def add_base_shape_columns(df):
+    """Ensure base_m/base_k/base_n exist while preserving full scaled m/k/n."""
+    if not all(col in df.columns for col in BASE_SHAPE_COLUMNS):
+        grid_dims = df["grid_size"].apply(parse_grid_size)
+        df["base_m"] = [m // grid_y for m, (_, grid_y) in zip(df["m"], grid_dims)]
+        df["base_k"] = [k // grid_x for k, (grid_x, _) in zip(df["k"], grid_dims)]
+        df["base_n"] = [n // grid_x for n, (grid_x, _) in zip(df["n"], grid_dims)]
+    df["base_shape"] = list(zip(df["base_m"], df["base_k"], df["base_n"]))
+    return df
 
 
 def load_and_prepare(path, source):
@@ -51,7 +70,17 @@ def load_and_prepare(path, source):
         + df["math_fidelity"].astype(str).str.replace("MathFidelity.", "")
     )
     df["matrix_elements"] = df["m"] * df["k"] * df["n"]
+    df = add_base_shape_columns(df)
     return df
+
+
+def get_best_by_base_shape(df_slice):
+    best_rows = []
+    for _, group in df_slice.groupby("base_shape", sort=True):
+        best_rows.append(group.loc[group["tflops"].idxmax()])
+    if not best_rows:
+        return pd.DataFrame()
+    return pd.DataFrame(best_rows).sort_values("matrix_elements")
 
 
 frames = []
@@ -81,13 +110,8 @@ for dtype_fidelity, color, label_short in dtype_configs:
     p150_data = df[(df["dtype_fidelity"] == dtype_fidelity) & (df["source"] == "P150")].copy()
 
     if not p150_data.empty:
-        # Get best (max tflops) for each matrix size
-        p150_best = (
-            p150_data.groupby("matrix_elements")
-            .agg({"tflops": "max", "m": "first", "k": "first", "n": "first"})
-            .reset_index()
-            .sort_values("matrix_elements")
-        )
+        # Get best (max tflops) for each base shape; plot its scaled matrix size.
+        p150_best = get_best_by_base_shape(p150_data)
 
         # Plot P150: solid line with filled upward triangles
         ax.plot(
@@ -110,13 +134,8 @@ for dtype_fidelity, color, label_short in dtype_configs:
     n150_data = df[(df["dtype_fidelity"] == dtype_fidelity) & (df["source"] == "N150")].copy()
 
     if not n150_data.empty:
-        # Get best (max tflops) for each matrix size
-        n150_best = (
-            n150_data.groupby("matrix_elements")
-            .agg({"tflops": "max", "m": "first", "k": "first", "n": "first"})
-            .reset_index()
-            .sort_values("matrix_elements")
-        )
+        # Get best (max tflops) for each base shape; plot its scaled matrix size.
+        n150_best = get_best_by_base_shape(n150_data)
 
         # Plot N150: dashed line with hollow downward triangles
         ax.plot(

--- a/tech_reports/GEMM_FLOPS/plot_scatter_performance.py
+++ b/tech_reports/GEMM_FLOPS/plot_scatter_performance.py
@@ -9,48 +9,55 @@ Usage:
 4. Run this script from the tt-metal root directory
 """
 
+import os
+
 import pandas as pd
 import matplotlib.pyplot as plt
 from matplotlib.lines import Line2D
 
+
+def safe_read_csv(path):
+    """Return the CSV as a DataFrame, or an empty DataFrame if the file is missing."""
+    if os.path.exists(path):
+        return pd.read_csv(path)
+    print(f"WARNING: {path} not found — skipping that device.")
+    return pd.DataFrame()
+
+
 # Load N150 and P150 data
-df_n150 = pd.read_csv("tech_reports/GEMM_FLOPS/n150-manual.csv")
-df_n150["source"] = "N150"
+df_n150 = safe_read_csv("tech_reports/GEMM_FLOPS/n150-manual.csv")
+if not df_n150.empty:
+    df_n150["source"] = "N150"
 
-df_p150 = pd.read_csv("tech_reports/GEMM_FLOPS/p150-manual.csv")
-df_p150["source"] = "P150"
+df_p150 = safe_read_csv("tech_reports/GEMM_FLOPS/p150-manual.csv")
+if not df_p150.empty:
+    df_p150["source"] = "P150"
 
-# Standardize column names
-if "TFLOPs (avg)" in df_n150.columns:
-    df_n150.rename(columns={"TFLOPs (avg)": "tflops"}, inplace=True)
-if "TFLOPs (avg)" in df_p150.columns:
-    df_p150.rename(columns={"TFLOPs (avg)": "tflops"}, inplace=True)
+# Standardize column names and derive computed columns (safe for empty DataFrames)
+for _df in [df_n150, df_p150]:
+    if _df.empty:
+        continue
+    if "TFLOPs (avg)" in _df.columns:
+        _df.rename(columns={"TFLOPs (avg)": "tflops"}, inplace=True)
+    _df["tflops"] = pd.to_numeric(_df["tflops"], errors="coerce")
+    _df["dtype_fidelity"] = (
+        _df["dtype"].astype(str).str.replace("DataType.", "")
+        + "_"
+        + _df["math_fidelity"].astype(str).str.replace("MathFidelity.", "")
+    )
+    _df["matrix_elements"] = _df["m"] * _df["k"] * _df["n"]
 
-# Convert tflops to numeric
-df_n150["tflops"] = pd.to_numeric(df_n150["tflops"], errors="coerce")
-df_p150["tflops"] = pd.to_numeric(df_p150["tflops"], errors="coerce")
+if not df_n150.empty:
+    df_n150 = df_n150[~((df_n150["m"] == 3328) & (df_n150["k"] == 2560) & (df_n150["n"] == 2560))].copy()
+if not df_p150.empty:
+    df_p150 = df_p150[~((df_p150["m"] == 4160) & (df_p150["k"] == 4160) & (df_p150["n"] == 4160))].copy()
 
-# Create dtype_fidelity column
-df_n150["dtype_fidelity"] = (
-    df_n150["dtype"].astype(str).str.replace("DataType.", "")
-    + "_"
-    + df_n150["math_fidelity"].astype(str).str.replace("MathFidelity.", "")
-)
-df_p150["dtype_fidelity"] = (
-    df_p150["dtype"].astype(str).str.replace("DataType.", "")
-    + "_"
-    + df_p150["math_fidelity"].astype(str).str.replace("MathFidelity.", "")
-)
-
-# Calculate matrix elements (M × K × N)
-df_n150["matrix_elements"] = df_n150["m"] * df_n150["k"] * df_n150["n"]
-df_p150["matrix_elements"] = df_p150["m"] * df_p150["k"] * df_p150["n"]
-
-df_n150 = df_n150[~((df_n150["m"] == 3328) & (df_n150["k"] == 2560) & (df_n150["n"] == 2560))].copy()
-df_p150 = df_p150[~((df_p150["m"] == 4160) & (df_p150["k"] == 4160) & (df_p150["n"] == 4160))].copy()
-
-# Combine dataframes
+# Combine dataframes — works correctly when either DataFrame is empty
 df = pd.concat([df_n150, df_p150], ignore_index=True)
+
+if df.empty:
+    print("ERROR: No data available for any device. Exiting.")
+    raise SystemExit(1)
 
 # dtype-fidelity configurations to plot with colors
 dtype_configs = [

--- a/tech_reports/GEMM_FLOPS/plot_scatter_performance.py
+++ b/tech_reports/GEMM_FLOPS/plot_scatter_performance.py
@@ -2,62 +2,69 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
+Performance scatter plot: TFLOPs comparison N150 vs P150.
+
 Usage:
-1. Generate performance data using manually selected GEMM configurations
-2. Rename output files to n150-manual.csv and p150-manual.csv
-3. Place the CSV files in tech_reports/GEMM_FLOPS/
-4. Run this script from the tt-metal root directory
+1. Run the benchmark via run_bench.sh on both devices
+2. CSVs are placed in tech_reports/GEMM_FLOPS/data/{wh,bh}.csv
+3. Run this script from the tt-metal root directory
 """
 
-import os
+from pathlib import Path
 
 import pandas as pd
 import matplotlib.pyplot as plt
 from matplotlib.lines import Line2D
 
+DATA_DIR = Path("tech_reports/GEMM_FLOPS/data")
+IMG_DIR = Path("tech_reports/GEMM_FLOPS/images")
+
+DEVICE_FILES = {
+    "N150": DATA_DIR / "wh.csv",
+    "P150": DATA_DIR / "bh.csv",
+}
+
 
 def safe_read_csv(path):
     """Return the CSV as a DataFrame, or an empty DataFrame if the file is missing."""
-    if os.path.exists(path):
+    if path.exists():
         return pd.read_csv(path)
     print(f"WARNING: {path} not found — skipping that device.")
     return pd.DataFrame()
 
 
-# Load N150 and P150 data
-df_n150 = safe_read_csv("tech_reports/GEMM_FLOPS/n150-manual.csv")
-if not df_n150.empty:
-    df_n150["source"] = "N150"
-
-df_p150 = safe_read_csv("tech_reports/GEMM_FLOPS/p150-manual.csv")
-if not df_p150.empty:
-    df_p150["source"] = "P150"
-
-# Standardize column names and derive computed columns (safe for empty DataFrames)
-for _df in [df_n150, df_p150]:
-    if _df.empty:
-        continue
-    if "TFLOPs (avg)" in _df.columns:
-        _df.rename(columns={"TFLOPs (avg)": "tflops"}, inplace=True)
-    _df["tflops"] = pd.to_numeric(_df["tflops"], errors="coerce")
-    _df["dtype_fidelity"] = (
-        _df["dtype"].astype(str).str.replace("DataType.", "")
+def load_and_prepare(path, source):
+    """Load CSV and prepare derived columns."""
+    df = safe_read_csv(path)
+    if df.empty:
+        return df
+    df["source"] = source
+    # Use best performance across all tuned modes
+    if "mode" in df.columns:
+        df = df[df["mode"] != "oob"].copy()
+    if "TFLOPs (avg)" in df.columns:
+        df.rename(columns={"TFLOPs (avg)": "tflops"}, inplace=True)
+    df["tflops"] = pd.to_numeric(df["tflops"], errors="coerce")
+    df["dtype_fidelity"] = (
+        df["dtype"].astype(str).str.replace("DataType.", "")
         + "_"
-        + _df["math_fidelity"].astype(str).str.replace("MathFidelity.", "")
+        + df["math_fidelity"].astype(str).str.replace("MathFidelity.", "")
     )
-    _df["matrix_elements"] = _df["m"] * _df["k"] * _df["n"]
+    df["matrix_elements"] = df["m"] * df["k"] * df["n"]
+    return df
 
-if not df_n150.empty:
-    df_n150 = df_n150[~((df_n150["m"] == 3328) & (df_n150["k"] == 2560) & (df_n150["n"] == 2560))].copy()
-if not df_p150.empty:
-    df_p150 = df_p150[~((df_p150["m"] == 4160) & (df_p150["k"] == 4160) & (df_p150["n"] == 4160))].copy()
 
-# Combine dataframes — works correctly when either DataFrame is empty
-df = pd.concat([df_n150, df_p150], ignore_index=True)
+frames = []
+for source, path in DEVICE_FILES.items():
+    loaded = load_and_prepare(path, source)
+    if not loaded.empty:
+        frames.append(loaded)
 
-if df.empty:
+if not frames:
     print("ERROR: No data available for any device. Exiting.")
     raise SystemExit(1)
+
+df = pd.concat(frames, ignore_index=True)
 
 # dtype-fidelity configurations to plot with colors
 dtype_configs = [
@@ -210,11 +217,14 @@ ax.legend(
     handlelength=3.5,
 )
 
+IMG_DIR.mkdir(parents=True, exist_ok=True)
 plt.tight_layout()
-plt.savefig("tech_reports/GEMM_FLOPS/images/flops_vs_matrix_elements_comparison.png", dpi=300, bbox_inches="tight")
+plt.savefig(IMG_DIR / "flops_vs_matrix_elements_comparison.png", dpi=300, bbox_inches="tight")
 plt.close()
 
 print("✓ Performance scatter plot saved!")
-print(f"  - N150: {df[df['source'] == 'N150'].groupby(['m','k','n']).ngroups} unique matrix sizes")
-print(f"  - P150: {df[df['source'] == 'P150'].groupby(['m','k','n']).ngroups} unique matrix sizes")
+n150_count = df[df["source"] == "N150"].groupby(["m", "k", "n"]).ngroups
+p150_count = df[df["source"] == "P150"].groupby(["m", "k", "n"]).ngroups
+print(f"  - N150: {n150_count} unique matrix sizes")
+print(f"  - P150: {p150_count} unique matrix sizes")
 print(f"  - Configurations plotted: BFLOAT4_B_LoFi, BFLOAT8_B_HiFi2, BFLOAT16_HiFi4")

--- a/tech_reports/GEMM_FLOPS/plot_scatter_tracing.py
+++ b/tech_reports/GEMM_FLOPS/plot_scatter_tracing.py
@@ -9,9 +9,20 @@ Usage:
 4. Run this script from the tt-metal root directory
 """
 
+import os
+
 import pandas as pd
 import matplotlib.pyplot as plt
 from matplotlib.lines import Line2D
+
+
+def safe_read_csv(path):
+    """Return the CSV as a DataFrame, or an empty DataFrame if the file is missing."""
+    if os.path.exists(path):
+        return pd.read_csv(path)
+    print(f"WARNING: {path} not found — skipping that device.")
+    return pd.DataFrame()
+
 
 dtype_configs = [
     ("BFLOAT4_B_LoFi", "BFLOAT4_B (LoFi)", "#2ca02c"),  # Green
@@ -19,20 +30,25 @@ dtype_configs = [
     ("BFLOAT16_HiFi4", "BFLOAT16 (HiFi4)", "#1f77b4"),  # Blue
 ]
 
-df_n150 = pd.read_csv("tech_reports/GEMM_FLOPS/n150-manual.csv")
-df_n150["source"] = "n150"
-df_p150 = pd.read_csv("tech_reports/GEMM_FLOPS/p150-manual.csv")
-df_p150["source"] = "p150"
+df_n150 = safe_read_csv("tech_reports/GEMM_FLOPS/n150-manual.csv")
+if not df_n150.empty:
+    df_n150["source"] = "n150"
+df_p150 = safe_read_csv("tech_reports/GEMM_FLOPS/p150-manual.csv")
+if not df_p150.empty:
+    df_p150["source"] = "p150"
 
-if "TFLOPs (avg)" in df_n150.columns:
-    df_n150.rename(columns={"TFLOPs (avg)": "tflops"}, inplace=True)
-if "TFLOPs (avg)" in df_p150.columns:
-    df_p150.rename(columns={"TFLOPs (avg)": "tflops"}, inplace=True)
-
-df_n150["tflops"] = pd.to_numeric(df_n150["tflops"], errors="coerce")
-df_p150["tflops"] = pd.to_numeric(df_p150["tflops"], errors="coerce")
+for _df in [df_n150, df_p150]:
+    if not _df.empty:
+        if "TFLOPs (avg)" in _df.columns:
+            _df.rename(columns={"TFLOPs (avg)": "tflops"}, inplace=True)
+        _df["tflops"] = pd.to_numeric(_df["tflops"], errors="coerce")
 
 df = pd.concat([df_n150, df_p150], ignore_index=True)
+
+if df.empty:
+    print("ERROR: No data available for any device. Exiting.")
+    raise SystemExit(1)
+
 df["dtype_fidelity"] = (
     df["dtype"].astype(str).str.replace("DataType.", "")
     + "_"
@@ -49,7 +65,8 @@ if df["use_trace"].dtype == object:
 df = df[~((df["m"] == 3328) & (df["k"] == 2560) & (df["n"] == 2560))].copy()  # N150 square
 df = df[~((df["m"] == 4160) & (df["k"] == 4160) & (df["n"] == 4160))].copy()  # P150 square
 
-for source in ["n150", "p150"]:
+available_sources = [s for s in ["n150", "p150"] if s in df["source"].values]
+for source in available_sources:
     fig, ax = plt.subplots(figsize=(16, 10))
     device_data = df[df["source"] == source].copy()
 

--- a/tech_reports/GEMM_FLOPS/plot_scatter_tracing.py
+++ b/tech_reports/GEMM_FLOPS/plot_scatter_tracing.py
@@ -29,6 +29,8 @@ DEVICE_LABELS = {
     "p150": "P150 (Blackhole)",
 }
 
+BASE_SHAPE_COLUMNS = ["base_m", "base_k", "base_n"]
+
 dtype_configs = [
     ("BFLOAT4_B_LoFi", "BFLOAT4_B (LoFi)", "#2ca02c"),  # Green
     ("BFLOAT8_B_HiFi2", "BFLOAT8_B (HiFi2)", "#ff7f0e"),  # Orange
@@ -42,6 +44,23 @@ def safe_read_csv(path):
         return pd.read_csv(path)
     print(f"WARNING: {path} not found — skipping that device.")
     return pd.DataFrame()
+
+
+def parse_grid_size(raw):
+    cleaned = str(raw).strip("() ")
+    grid_x, grid_y = [int(x.strip()) for x in cleaned.split(",")]
+    return grid_x, grid_y
+
+
+def add_base_shape_columns(df):
+    """Ensure base_m/base_k/base_n exist while preserving full scaled m/k/n."""
+    if not all(col in df.columns for col in BASE_SHAPE_COLUMNS):
+        grid_dims = df["grid_size"].apply(parse_grid_size)
+        df["base_m"] = [m // grid_y for m, (_, grid_y) in zip(df["m"], grid_dims)]
+        df["base_k"] = [k // grid_x for k, (grid_x, _) in zip(df["k"], grid_dims)]
+        df["base_n"] = [n // grid_x for n, (grid_x, _) in zip(df["n"], grid_dims)]
+    df["base_shape"] = list(zip(df["base_m"], df["base_k"], df["base_n"]))
+    return df
 
 
 def load_and_prepare(path, source):
@@ -64,30 +83,31 @@ def load_and_prepare(path, source):
     df["matrix_elements"] = df["m"] * df["k"] * df["n"]
     if df["use_trace"].dtype == object:
         df["use_trace"] = df["use_trace"].astype(str).str.lower() == "true"
+    df = add_base_shape_columns(df)
     return df
 
 
 def get_best_trace_pairs(df_slice):
-    """Return plotted series and ratio points keyed by exact matrix shape."""
+    """Return plotted series and ratio points keyed by exact base matrix shape."""
     traced_perf = []
     nontraced_perf = []
     ratio_points = []
 
-    for shape, shape_group in df_slice.groupby(["m", "k", "n"], sort=True):
-        m, k, n = shape
-        matrix_elements = m * k * n
-
+    for _, shape_group in df_slice.groupby("base_shape", sort=True):
         traced_group = shape_group[shape_group["use_trace"]]
         nontraced_group = shape_group[~shape_group["use_trace"]]
 
         best_traced_tflops = None
         best_nontraced_tflops = None
+        matrix_elements = shape_group["matrix_elements"].iloc[0]
         if not traced_group.empty:
-            best_traced_tflops = traced_group["tflops"].max()
-            traced_perf.append((matrix_elements, best_traced_tflops))
+            best_traced_row = traced_group.loc[traced_group["tflops"].idxmax()]
+            best_traced_tflops = best_traced_row["tflops"]
+            traced_perf.append((best_traced_row["matrix_elements"], best_traced_tflops))
         if not nontraced_group.empty:
-            best_nontraced_tflops = nontraced_group["tflops"].max()
-            nontraced_perf.append((matrix_elements, best_nontraced_tflops))
+            best_nontraced_row = nontraced_group.loc[nontraced_group["tflops"].idxmax()]
+            best_nontraced_tflops = best_nontraced_row["tflops"]
+            nontraced_perf.append((best_nontraced_row["matrix_elements"], best_nontraced_tflops))
 
         if (
             best_traced_tflops is not None

--- a/tech_reports/GEMM_FLOPS/plot_scatter_tracing.py
+++ b/tech_reports/GEMM_FLOPS/plot_scatter_tracing.py
@@ -67,6 +67,43 @@ def load_and_prepare(path, source):
     return df
 
 
+def get_best_trace_pairs(df_slice):
+    """Return plotted series and ratio points keyed by exact matrix shape."""
+    traced_perf = []
+    nontraced_perf = []
+    ratio_points = []
+
+    for shape, shape_group in df_slice.groupby(["m", "k", "n"], sort=True):
+        m, k, n = shape
+        matrix_elements = m * k * n
+
+        traced_group = shape_group[shape_group["use_trace"]]
+        nontraced_group = shape_group[~shape_group["use_trace"]]
+
+        best_traced_tflops = None
+        best_nontraced_tflops = None
+        if not traced_group.empty:
+            best_traced_tflops = traced_group["tflops"].max()
+            traced_perf.append((matrix_elements, best_traced_tflops))
+        if not nontraced_group.empty:
+            best_nontraced_tflops = nontraced_group["tflops"].max()
+            nontraced_perf.append((matrix_elements, best_nontraced_tflops))
+
+        if (
+            best_traced_tflops is not None
+            and best_nontraced_tflops is not None
+            and pd.notna(best_traced_tflops)
+            and pd.notna(best_nontraced_tflops)
+            and best_nontraced_tflops > 0
+        ):
+            ratio_points.append((matrix_elements, best_traced_tflops, best_nontraced_tflops))
+
+    traced_perf.sort()
+    nontraced_perf.sort()
+    ratio_points.sort()
+    return traced_perf, nontraced_perf, ratio_points
+
+
 frames = []
 for source, path in DEVICE_FILES.items():
     loaded = load_and_prepare(path, source)
@@ -87,22 +124,8 @@ for source in available_sources:
     device_data = df[df["source"] == source].copy()
 
     for dtype_fidelity, dtype_label, color in dtype_configs:
-        traced_perf = []
-        nontraced_perf = []
         df_slice = device_data[device_data["dtype_fidelity"] == dtype_fidelity]
-
-        for matrix_size in sorted(df_slice["matrix_elements"].unique()):
-            size_group = df_slice[df_slice["matrix_elements"] == matrix_size]
-
-            traced_group = size_group[size_group["use_trace"] == True]
-            if not traced_group.empty:
-                best_traced_tflops = traced_group.groupby(["m", "k", "n"])["tflops"].max().max()
-                traced_perf.append((matrix_size, best_traced_tflops))
-
-            nontraced_group = size_group[size_group["use_trace"] == False]
-            if not nontraced_group.empty:
-                best_nontraced_tflops = nontraced_group.groupby(["m", "k", "n"])["tflops"].max().max()
-                nontraced_perf.append((matrix_size, best_nontraced_tflops))
+        traced_perf, nontraced_perf, ratio_points = get_best_trace_pairs(df_slice)
 
         if not traced_perf or not nontraced_perf:
             continue
@@ -136,23 +159,21 @@ for source in available_sources:
             zorder=4,
         )
 
-        for i, (x, y_trace) in enumerate(zip(traced_x, traced_y)):
-            if i < len(nontraced_y):
-                y_nontrace = nontraced_y[i]
-                ratio = y_trace / y_nontrace
-                y_pos = max(y_trace, y_nontrace)
-                ax.annotate(
-                    f"{ratio:.2f}×",
-                    (x, y_pos),
-                    xytext=(0, 12),
-                    textcoords="offset points",
-                    ha="center",
-                    va="bottom",
-                    fontsize=9,
-                    fontweight="bold",
-                    bbox=dict(boxstyle="round,pad=0.3", fc="white", ec=color, alpha=0.85, linewidth=1),
-                    zorder=5,
-                )
+        for x, y_trace, y_nontrace in ratio_points:
+            ratio = y_trace / y_nontrace
+            y_pos = max(y_trace, y_nontrace)
+            ax.annotate(
+                f"{ratio:.2f}×",
+                (x, y_pos),
+                xytext=(0, 12),
+                textcoords="offset points",
+                ha="center",
+                va="bottom",
+                fontsize=9,
+                fontweight="bold",
+                bbox=dict(boxstyle="round,pad=0.3", fc="white", ec=color, alpha=0.85, linewidth=1),
+                zorder=5,
+            )
 
     ax.set_xscale("log")
     ax.text(

--- a/tech_reports/GEMM_FLOPS/plot_scatter_tracing.py
+++ b/tech_reports/GEMM_FLOPS/plot_scatter_tracing.py
@@ -2,27 +2,32 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
+Trace comparison plot: traced vs non-traced TFLOPs per device.
+
 Usage:
-1. Generate performance data using manually selected GEMM configurations
-2. Rename output files to n150-manual.csv and p150-manual.csv
-3. Place the CSV files in tech_reports/GEMM_FLOPS/
-4. Run this script from the tt-metal root directory
+1. Run the benchmark via run_bench.sh on both devices
+2. CSVs are placed in tech_reports/GEMM_FLOPS/data/{wh,bh}.csv
+3. Run this script from the tt-metal root directory
 """
 
-import os
+from pathlib import Path
 
 import pandas as pd
 import matplotlib.pyplot as plt
 from matplotlib.lines import Line2D
 
+DATA_DIR = Path("tech_reports/GEMM_FLOPS/data")
+IMG_DIR = Path("tech_reports/GEMM_FLOPS/images")
 
-def safe_read_csv(path):
-    """Return the CSV as a DataFrame, or an empty DataFrame if the file is missing."""
-    if os.path.exists(path):
-        return pd.read_csv(path)
-    print(f"WARNING: {path} not found — skipping that device.")
-    return pd.DataFrame()
+DEVICE_FILES = {
+    "n150": DATA_DIR / "wh.csv",
+    "p150": DATA_DIR / "bh.csv",
+}
 
+DEVICE_LABELS = {
+    "n150": "N150 (Wormhole)",
+    "p150": "P150 (Blackhole)",
+}
 
 dtype_configs = [
     ("BFLOAT4_B_LoFi", "BFLOAT4_B (LoFi)", "#2ca02c"),  # Green
@@ -30,42 +35,53 @@ dtype_configs = [
     ("BFLOAT16_HiFi4", "BFLOAT16 (HiFi4)", "#1f77b4"),  # Blue
 ]
 
-df_n150 = safe_read_csv("tech_reports/GEMM_FLOPS/n150-manual.csv")
-if not df_n150.empty:
-    df_n150["source"] = "n150"
-df_p150 = safe_read_csv("tech_reports/GEMM_FLOPS/p150-manual.csv")
-if not df_p150.empty:
-    df_p150["source"] = "p150"
 
-for _df in [df_n150, df_p150]:
-    if not _df.empty:
-        if "TFLOPs (avg)" in _df.columns:
-            _df.rename(columns={"TFLOPs (avg)": "tflops"}, inplace=True)
-        _df["tflops"] = pd.to_numeric(_df["tflops"], errors="coerce")
+def safe_read_csv(path):
+    """Return the CSV as a DataFrame, or an empty DataFrame if the file is missing."""
+    if path.exists():
+        return pd.read_csv(path)
+    print(f"WARNING: {path} not found — skipping that device.")
+    return pd.DataFrame()
 
-df = pd.concat([df_n150, df_p150], ignore_index=True)
 
-if df.empty:
+def load_and_prepare(path, source):
+    """Load CSV and prepare derived columns."""
+    df = safe_read_csv(path)
+    if df.empty:
+        return df
+    df["source"] = source
+    # Use best performance across all tuned modes (exclude OOB for peak comparison)
+    if "mode" in df.columns:
+        df = df[df["mode"] != "oob"].copy()
+    if "TFLOPs (avg)" in df.columns:
+        df.rename(columns={"TFLOPs (avg)": "tflops"}, inplace=True)
+    df["tflops"] = pd.to_numeric(df["tflops"], errors="coerce")
+    df["dtype_fidelity"] = (
+        df["dtype"].astype(str).str.replace("DataType.", "")
+        + "_"
+        + df["math_fidelity"].astype(str).str.replace("MathFidelity.", "")
+    )
+    df["matrix_elements"] = df["m"] * df["k"] * df["n"]
+    if df["use_trace"].dtype == object:
+        df["use_trace"] = df["use_trace"].astype(str).str.lower() == "true"
+    return df
+
+
+frames = []
+for source, path in DEVICE_FILES.items():
+    loaded = load_and_prepare(path, source)
+    if not loaded.empty:
+        frames.append(loaded)
+
+if not frames:
     print("ERROR: No data available for any device. Exiting.")
     raise SystemExit(1)
 
-df["dtype_fidelity"] = (
-    df["dtype"].astype(str).str.replace("DataType.", "")
-    + "_"
-    + df["math_fidelity"].astype(str).str.replace("MathFidelity.", "")
-)
-df["matrix_elements"] = df["m"] * df["k"] * df["n"]
+df = pd.concat(frames, ignore_index=True)
 
-if df["use_trace"].dtype == object:
-    df["use_trace"] = df["use_trace"].astype(str).str.lower() == "true"
+IMG_DIR.mkdir(parents=True, exist_ok=True)
 
-# Filter out the 416×320×320 base shape (square) to avoid dips in trace comparison
-# N150: 3328×2560×2560, P150: 4160×4160×4160
-# Keep this shape only in aspect_ratio plot for 1:1:1 comparison
-df = df[~((df["m"] == 3328) & (df["k"] == 2560) & (df["n"] == 2560))].copy()  # N150 square
-df = df[~((df["m"] == 4160) & (df["k"] == 4160) & (df["n"] == 4160))].copy()  # P150 square
-
-available_sources = [s for s in ["n150", "p150"] if s in df["source"].values]
+available_sources = [s for s in DEVICE_FILES if s in df["source"].values]
 for source in available_sources:
     fig, ax = plt.subplots(figsize=(16, 10))
     device_data = df[df["source"] == source].copy()
@@ -160,7 +176,7 @@ for source in available_sources:
     )
     ax.set_ylabel("Performance (TFLOPs)", fontsize=14, fontweight="bold", labelpad=10)
 
-    device_name = "N150 (Wormhole)" if source == "n150" else "P150 (Blackhole)"
+    device_name = DEVICE_LABELS.get(source, source)
     fig.suptitle(f"Performance Comparison: {device_name}", fontsize=18, fontweight="bold", y=0.98)
     ax.set_title(
         "Traced vs Non-Traced Execution Performance (All Matrix Sizes)", fontsize=14, pad=10, fontweight="bold"
@@ -231,9 +247,9 @@ for source in available_sources:
     )
 
     plt.tight_layout()
-    plt.savefig(f"tech_reports/GEMM_FLOPS/images/trace_comparison_{source}.png", dpi=300, bbox_inches="tight")
+    plt.savefig(IMG_DIR / f"trace_comparison_{source}.png", dpi=300, bbox_inches="tight")
     plt.close()
 
-    print(f"✅ Saved: trace_comparison_{source}.png")
+    print(f"Saved: trace_comparison_{source}.png")
 
-print("\n✅ Tracing comparison plots complete!")
+print("\nTracing comparison plots complete!")

--- a/tech_reports/GEMM_FLOPS/plot_util_grid.py
+++ b/tech_reports/GEMM_FLOPS/plot_util_grid.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Generate per-dtype 2x2 utilization grid plots from a single benchmark CSV.
 

--- a/tech_reports/GEMM_FLOPS/plot_util_grid.py
+++ b/tech_reports/GEMM_FLOPS/plot_util_grid.py
@@ -33,6 +33,8 @@ DEVICE_MAP = {
     "wh": "N150 (Wormhole)",
 }
 
+BASE_SHAPE_COLUMNS = ["base_m", "base_k", "base_n"]
+
 DTYPE_MAP = {
     "BFLOAT16": "bf16",
     "BFLOAT8_B": "bf8_b",
@@ -79,6 +81,23 @@ def _read_csv(path):
     return pd.DataFrame()
 
 
+def _parse_grid_size(raw):
+    cleaned = str(raw).strip("() ")
+    grid_x, grid_y = [int(x.strip()) for x in cleaned.split(",")]
+    return grid_x, grid_y
+
+
+def _add_base_shape_columns(df):
+    """Ensure base_m/base_k/base_n exist while preserving full scaled m/k/n."""
+    if not all(col in df.columns for col in BASE_SHAPE_COLUMNS):
+        grid_dims = df["grid_size"].apply(_parse_grid_size)
+        df["base_m"] = [m // grid_y for m, (_, grid_y) in zip(df["m"], grid_dims)]
+        df["base_k"] = [k // grid_x for k, (grid_x, _) in zip(df["k"], grid_dims)]
+        df["base_n"] = [n // grid_x for n, (grid_x, _) in zip(df["n"], grid_dims)]
+    df["base_shape"] = list(zip(df["base_m"], df["base_k"], df["base_n"]))
+    return df
+
+
 def _parse_dtype(raw):
     full = str(raw).split(".")[-1]
     return DTYPE_MAP.get(full, full.lower())
@@ -105,7 +124,20 @@ def _load_csv(path):
     df["dtype_short"] = df["dtype"].apply(_parse_dtype)
     df["fidelity"] = df["math_fidelity"].apply(_parse_fidelity)
     df["matrix_elements"] = df["m"] * df["k"] * df["n"]
+    if df["use_trace"].dtype == object:
+        df["use_trace"] = df["use_trace"].astype(str).str.lower() == "true"
+    df = _add_base_shape_columns(df)
     return df
+
+
+def _get_best_line_by_base_shape(line_data, util_col_name):
+    best_rows = []
+    line_data = line_data.dropna(subset=[util_col_name])
+    for _, group in line_data.groupby("base_shape", sort=True):
+        best_rows.append(group.loc[group[util_col_name].idxmax()])
+    if not best_rows:
+        return pd.DataFrame()
+    return pd.DataFrame(best_rows).sort_values("matrix_elements")
 
 
 def _plot_dtype_grid(df_all, dtype_short, device_prefix, device_label):
@@ -159,7 +191,9 @@ def _plot_dtype_grid(df_all, dtype_short, device_prefix, device_label):
                 line_data = subset[(subset["mode"] == mode) & (subset["fidelity"] == fidelity)]
                 if line_data.empty:
                     continue
-                line_data = line_data.sort_values("matrix_elements")
+                line_data = _get_best_line_by_base_shape(line_data, util_col_name)
+                if line_data.empty:
+                    continue
                 ax.plot(
                     line_data["matrix_elements"],
                     line_data[util_col_name],

--- a/tech_reports/GEMM_FLOPS/plot_util_grid.py
+++ b/tech_reports/GEMM_FLOPS/plot_util_grid.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""
+Generate per-dtype 2x2 utilization grid plots.
+
+One PNG per (device, dtype) combination.  Each PNG has 4 subplots:
+  {host, device} x {no-trace, trace}.
+
+Encoding:
+  Line color -> memory config:
+                 DRAM=blue, L1=red, OOB=black
+  Marker     -> math fidelity (fixed across all plots):
+                 HiFi4=square, HiFi3=diamond, HiFi2=circle, LoFi=triangle
+
+OOB lines are per-fidelity (one black line per fidelity level).
+
+Reads CSVs from tech_reports/GEMM_FLOPS/data/:
+  {bh,wh}-tuned.csv  -- from test_matmul_2d_host_perf
+  {bh,wh}-oob.csv    -- from test_matmul_2d_host_perf_out_of_box
+"""
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from matplotlib.lines import Line2D
+
+DATA_DIR = Path("tech_reports/GEMM_FLOPS/data")
+IMG_DIR = Path("tech_reports/GEMM_FLOPS/images")
+
+DEVICE_MAP = {
+    "bh": "P150 (Blackhole)",
+    "wh": "N150 (Wormhole)",
+}
+
+DTYPE_MAP = {
+    "BFLOAT16": "bf16",
+    "BFLOAT8_B": "bf8_b",
+    "BFLOAT4_B": "bf4_b",
+}
+
+DTYPE_DISPLAY = {
+    "bf16": "BFloat16",
+    "bf8_b": "BFloat8_B",
+    "bf4_b": "BFloat4_B",
+}
+
+MEM_COLORS = {
+    "DRAM": "#1f77b4",
+    "L1": "#d62728",
+    "OOB": "black",
+}
+
+FIDELITY_MARKERS = {
+    "HiFi4": "s",
+    "HiFi3": "D",
+    "HiFi2": "o",
+    "LoFi": "^",
+}
+
+FIDELITY_ORDER = ["HiFi4", "HiFi3", "HiFi2", "LoFi"]
+
+
+def _read_csv(path):
+    if path.exists():
+        return pd.read_csv(path)
+    return pd.DataFrame()
+
+
+def _parse_dtype(raw):
+    full = str(raw).split(".")[-1]
+    return DTYPE_MAP.get(full, full.lower())
+
+
+def _parse_fidelity(raw):
+    return str(raw).split(".")[-1]
+
+
+def _find_util_col(df, kind, grid_keyword="user selected grid"):
+    """Find a utilization column. kind is 'Host' or 'Device'."""
+    prefix = f"{kind} based utilization"
+    for col in df.columns:
+        if col.startswith(prefix) and grid_keyword in col:
+            if df[col].notna().any():
+                return col
+    return None
+
+
+def _load_tuned(path):
+    df = _read_csv(path)
+    if df.empty:
+        return df
+    df["dtype_short"] = df["dtype"].apply(_parse_dtype)
+    df["fidelity"] = df["math_fidelity"].apply(_parse_fidelity)
+    df["mem"] = df["in0_sharded"].apply(lambda x: "L1" if x else "DRAM")
+    df["matrix_elements"] = df["m"] * df["k"] * df["n"]
+    df["source"] = "tuned"
+    return df
+
+
+def _load_oob(path):
+    df = _read_csv(path)
+    if df.empty:
+        return df
+    df["dtype_short"] = df["dtype"].apply(_parse_dtype)
+    df["fidelity"] = df["math_fidelity"].apply(_parse_fidelity)
+    df["mem"] = "OOB"
+    df["matrix_elements"] = df["m"] * df["k"] * df["n"]
+    df["source"] = "oob"
+    return df
+
+
+def _plot_dtype_grid(df_all, dtype_short, device_prefix, device_label):
+    """Generate one 2x2 PNG for a given device and dtype."""
+    df = df_all[df_all["dtype_short"] == dtype_short].copy()
+    if df.empty:
+        print(f"    No data for {dtype_short} — skipping.")
+        return
+
+    host_col = _find_util_col(df, "Host")
+    device_col = _find_util_col(df, "Device")
+
+    fig, axes = plt.subplots(2, 2, figsize=(16, 12), sharey=True, sharex=True)
+
+    panel_defs = [
+        (0, 0, "Host", False, host_col),
+        (0, 1, "Host", True, host_col),
+        (1, 0, "Device", False, device_col),
+        (1, 1, "Device", True, device_col),
+    ]
+
+    all_fidelities = [f for f in FIDELITY_ORDER if f in df["fidelity"].unique()]
+
+    for row, col_idx, util_kind, use_trace, util_col_name in panel_defs:
+        ax = axes[row][col_idx]
+        subset = df[df["use_trace"] == use_trace]
+
+        if util_col_name is None:
+            ax.text(
+                0.5,
+                0.5,
+                f"No {util_kind} data",
+                transform=ax.transAxes,
+                ha="center",
+                va="center",
+                fontsize=12,
+            )
+            trace_label = "With Trace" if use_trace else "Without Trace"
+            ax.set_title(f"{util_kind} | {trace_label}", fontsize=11, fontweight="bold")
+            ax.grid(True, alpha=0.3, linestyle="--")
+            continue
+
+        for fidelity in all_fidelities:
+            marker = FIDELITY_MARKERS.get(fidelity, "x")
+
+            for mem in ["DRAM", "L1"]:
+                color = MEM_COLORS[mem]
+                linestyle = "-" if mem == "DRAM" else "--"
+                line_data = subset[
+                    (subset["mem"] == mem) & (subset["fidelity"] == fidelity) & (subset["source"] == "tuned")
+                ]
+                if line_data.empty:
+                    continue
+                line_data = line_data.sort_values("matrix_elements")
+                ax.plot(
+                    line_data["matrix_elements"],
+                    line_data[util_col_name],
+                    marker=marker,
+                    linestyle=linestyle,
+                    color=color,
+                    markersize=7,
+                    markerfacecolor=color,
+                    markeredgecolor=color,
+                    markeredgewidth=1,
+                    linewidth=2,
+                    alpha=0.85,
+                )
+
+            oob_data = subset[(subset["source"] == "oob") & (subset["fidelity"] == fidelity)]
+            if not oob_data.empty:
+                oob_color = MEM_COLORS["OOB"]
+                oob_data = oob_data.sort_values("matrix_elements")
+                ax.plot(
+                    oob_data["matrix_elements"],
+                    oob_data[util_col_name],
+                    marker=marker,
+                    linestyle="-",
+                    color=oob_color,
+                    markersize=7,
+                    markerfacecolor=oob_color,
+                    markeredgecolor=oob_color,
+                    markeredgewidth=1,
+                    linewidth=2,
+                    alpha=0.9,
+                )
+
+        trace_label = "With Trace" if use_trace else "Without Trace"
+        ax.set_title(f"{util_kind} | {trace_label}", fontsize=11, fontweight="bold")
+        ax.set_xscale("log")
+        ax.grid(True, alpha=0.3, linestyle="--")
+        ax.set_ylim(0, 110)
+
+    axes[1][0].set_xlabel("Total Matrix Elements (M x K x N)", fontsize=11, fontweight="bold")
+    axes[1][1].set_xlabel("Total Matrix Elements (M x K x N)", fontsize=11, fontweight="bold")
+    axes[0][0].set_ylabel("Utilization (%)", fontsize=11, fontweight="bold")
+    axes[1][0].set_ylabel("Utilization (%)", fontsize=11, fontweight="bold")
+
+    dtype_display = DTYPE_DISPLAY.get(dtype_short, dtype_short)
+    fig.suptitle(
+        f"Matmul Utilization — {device_label} — {dtype_display}",
+        fontsize=15,
+        fontweight="bold",
+        y=0.98,
+    )
+
+    legend_elements = []
+
+    legend_elements.append(Line2D([0], [0], color="none", marker="none", label="Memory"))
+    legend_elements.append(
+        Line2D(
+            [0], [0], color=MEM_COLORS["DRAM"], linewidth=2.5, linestyle="-", marker="none", label="DRAM (interleaved)"
+        )
+    )
+    legend_elements.append(
+        Line2D([0], [0], color=MEM_COLORS["L1"], linewidth=2.5, linestyle="--", marker="none", label="L1 (sharded)")
+    )
+    legend_elements.append(
+        Line2D([0], [0], color=MEM_COLORS["OOB"], linewidth=2.5, linestyle="-", marker="none", label="OOB (auto)")
+    )
+
+    legend_elements.append(Line2D([0], [0], color="none", marker="none", label=""))
+    legend_elements.append(Line2D([0], [0], color="none", marker="none", label="Fidelity"))
+    for fid in all_fidelities:
+        marker = FIDELITY_MARKERS.get(fid, "x")
+        legend_elements.append(
+            Line2D(
+                [0],
+                [0],
+                color="gray",
+                linewidth=0,
+                marker=marker,
+                markersize=9,
+                markerfacecolor="gray",
+                markeredgecolor="gray",
+                label=fid,
+            )
+        )
+
+    fig.legend(
+        handles=legend_elements,
+        loc="lower center",
+        ncol=len(legend_elements),
+        fontsize=9,
+        framealpha=0.95,
+        edgecolor="black",
+        handlelength=3.5,
+        bbox_to_anchor=(0.5, 0.01),
+    )
+
+    plt.tight_layout(rect=[0, 0.06, 1, 0.96])
+    out_path = IMG_DIR / f"{device_prefix}-util-{dtype_short}.png"
+    plt.savefig(out_path, dpi=300, bbox_inches="tight")
+    print(f"    Saved: {out_path}")
+    plt.close()
+
+
+def main():
+    IMG_DIR.mkdir(parents=True, exist_ok=True)
+
+    for device_prefix, device_label in DEVICE_MAP.items():
+        tuned_path = DATA_DIR / f"{device_prefix}-tuned.csv"
+        oob_path = DATA_DIR / f"{device_prefix}-oob.csv"
+
+        df_tuned = _load_tuned(tuned_path)
+        df_oob = _load_oob(oob_path)
+
+        if df_tuned.empty and df_oob.empty:
+            print(f"No data for {device_label} — skipping.")
+            continue
+
+        df_all = pd.concat([df_tuned, df_oob], ignore_index=True)
+        print(f"{device_label}:")
+
+        all_dtypes = sorted(df_all["dtype_short"].unique())
+        for dtype_short in all_dtypes:
+            _plot_dtype_grid(df_all, dtype_short, device_prefix, device_label)
+
+
+if __name__ == "__main__":
+    main()

--- a/tech_reports/GEMM_FLOPS/plot_util_grid.py
+++ b/tech_reports/GEMM_FLOPS/plot_util_grid.py
@@ -1,21 +1,21 @@
 #!/usr/bin/env python3
 """
-Generate per-dtype 2x2 utilization grid plots.
+Generate per-dtype 2x2 utilization grid plots from a single benchmark CSV.
 
 One PNG per (device, dtype) combination.  Each PNG has 4 subplots:
   {host, device} x {no-trace, trace}.
 
 Encoding:
-  Line color -> memory config:
-                 DRAM=blue, L1=red, OOB=black
+  Line color -> mode:
+                 DRAM (tuned_2d_dram) = blue
+                 L1 (tuned_2d_l1) = red
+                 OOB = black
+  Line style -> tuned modes use solid (DRAM) / dashed (L1); OOB is solid
   Marker     -> math fidelity (fixed across all plots):
                  HiFi4=square, HiFi3=diamond, HiFi2=circle, LoFi=triangle
 
-OOB lines are per-fidelity (one black line per fidelity level).
-
-Reads CSVs from tech_reports/GEMM_FLOPS/data/:
-  {bh,wh}-tuned.csv  -- from test_matmul_2d_host_perf
-  {bh,wh}-oob.csv    -- from test_matmul_2d_host_perf_out_of_box
+Reads a single CSV from tech_reports/GEMM_FLOPS/data/:
+  {bh,wh}.csv  -- from test_matmul_2d_host_perf (unified benchmark)
 """
 
 from pathlib import Path
@@ -45,10 +45,22 @@ DTYPE_DISPLAY = {
     "bf4_b": "BFloat4_B",
 }
 
-MEM_COLORS = {
-    "DRAM": "#1f77b4",
-    "L1": "#d62728",
-    "OOB": "black",
+MODE_COLORS = {
+    "tuned_2d_dram": "#1f77b4",
+    "tuned_2d_l1": "#d62728",
+    "oob": "black",
+}
+
+MODE_LINESTYLES = {
+    "tuned_2d_dram": "-",
+    "tuned_2d_l1": "--",
+    "oob": "-",
+}
+
+MODE_DISPLAY = {
+    "tuned_2d_dram": "DRAM (tuned)",
+    "tuned_2d_l1": "L1 (tuned)",
+    "oob": "OOB (auto)",
 }
 
 FIDELITY_MARKERS = {
@@ -86,27 +98,13 @@ def _find_util_col(df, kind, grid_keyword="user selected grid"):
     return None
 
 
-def _load_tuned(path):
+def _load_csv(path):
     df = _read_csv(path)
     if df.empty:
         return df
     df["dtype_short"] = df["dtype"].apply(_parse_dtype)
     df["fidelity"] = df["math_fidelity"].apply(_parse_fidelity)
-    df["mem"] = df["in0_sharded"].apply(lambda x: "L1" if x else "DRAM")
     df["matrix_elements"] = df["m"] * df["k"] * df["n"]
-    df["source"] = "tuned"
-    return df
-
-
-def _load_oob(path):
-    df = _read_csv(path)
-    if df.empty:
-        return df
-    df["dtype_short"] = df["dtype"].apply(_parse_dtype)
-    df["fidelity"] = df["math_fidelity"].apply(_parse_fidelity)
-    df["mem"] = "OOB"
-    df["matrix_elements"] = df["m"] * df["k"] * df["n"]
-    df["source"] = "oob"
     return df
 
 
@@ -130,6 +128,7 @@ def _plot_dtype_grid(df_all, dtype_short, device_prefix, device_label):
     ]
 
     all_fidelities = [f for f in FIDELITY_ORDER if f in df["fidelity"].unique()]
+    all_modes = [m for m in MODE_COLORS if m in df["mode"].unique()]
 
     for row, col_idx, util_kind, use_trace, util_col_name in panel_defs:
         ax = axes[row][col_idx]
@@ -153,12 +152,11 @@ def _plot_dtype_grid(df_all, dtype_short, device_prefix, device_label):
         for fidelity in all_fidelities:
             marker = FIDELITY_MARKERS.get(fidelity, "x")
 
-            for mem in ["DRAM", "L1"]:
-                color = MEM_COLORS[mem]
-                linestyle = "-" if mem == "DRAM" else "--"
-                line_data = subset[
-                    (subset["mem"] == mem) & (subset["fidelity"] == fidelity) & (subset["source"] == "tuned")
-                ]
+            for mode in all_modes:
+                color = MODE_COLORS[mode]
+                linestyle = MODE_LINESTYLES[mode]
+
+                line_data = subset[(subset["mode"] == mode) & (subset["fidelity"] == fidelity)]
                 if line_data.empty:
                     continue
                 line_data = line_data.sort_values("matrix_elements")
@@ -174,24 +172,6 @@ def _plot_dtype_grid(df_all, dtype_short, device_prefix, device_label):
                     markeredgewidth=1,
                     linewidth=2,
                     alpha=0.85,
-                )
-
-            oob_data = subset[(subset["source"] == "oob") & (subset["fidelity"] == fidelity)]
-            if not oob_data.empty:
-                oob_color = MEM_COLORS["OOB"]
-                oob_data = oob_data.sort_values("matrix_elements")
-                ax.plot(
-                    oob_data["matrix_elements"],
-                    oob_data[util_col_name],
-                    marker=marker,
-                    linestyle="-",
-                    color=oob_color,
-                    markersize=7,
-                    markerfacecolor=oob_color,
-                    markeredgecolor=oob_color,
-                    markeredgewidth=1,
-                    linewidth=2,
-                    alpha=0.9,
                 )
 
         trace_label = "With Trace" if use_trace else "Without Trace"
@@ -213,20 +193,17 @@ def _plot_dtype_grid(df_all, dtype_short, device_prefix, device_label):
         y=0.98,
     )
 
+    # Legend
     legend_elements = []
 
-    legend_elements.append(Line2D([0], [0], color="none", marker="none", label="Memory"))
-    legend_elements.append(
-        Line2D(
-            [0], [0], color=MEM_COLORS["DRAM"], linewidth=2.5, linestyle="-", marker="none", label="DRAM (interleaved)"
+    legend_elements.append(Line2D([0], [0], color="none", marker="none", label="Mode"))
+    for mode in all_modes:
+        color = MODE_COLORS[mode]
+        linestyle = MODE_LINESTYLES[mode]
+        display = MODE_DISPLAY.get(mode, mode)
+        legend_elements.append(
+            Line2D([0], [0], color=color, linewidth=2.5, linestyle=linestyle, marker="none", label=display)
         )
-    )
-    legend_elements.append(
-        Line2D([0], [0], color=MEM_COLORS["L1"], linewidth=2.5, linestyle="--", marker="none", label="L1 (sharded)")
-    )
-    legend_elements.append(
-        Line2D([0], [0], color=MEM_COLORS["OOB"], linewidth=2.5, linestyle="-", marker="none", label="OOB (auto)")
-    )
 
     legend_elements.append(Line2D([0], [0], color="none", marker="none", label=""))
     legend_elements.append(Line2D([0], [0], color="none", marker="none", label="Fidelity"))
@@ -268,22 +245,17 @@ def main():
     IMG_DIR.mkdir(parents=True, exist_ok=True)
 
     for device_prefix, device_label in DEVICE_MAP.items():
-        tuned_path = DATA_DIR / f"{device_prefix}-tuned.csv"
-        oob_path = DATA_DIR / f"{device_prefix}-oob.csv"
+        csv_path = DATA_DIR / f"{device_prefix}.csv"
+        df = _load_csv(csv_path)
 
-        df_tuned = _load_tuned(tuned_path)
-        df_oob = _load_oob(oob_path)
-
-        if df_tuned.empty and df_oob.empty:
-            print(f"No data for {device_label} — skipping.")
+        if df.empty:
+            print(f"No data for {device_label} ({csv_path}) — skipping.")
             continue
 
-        df_all = pd.concat([df_tuned, df_oob], ignore_index=True)
         print(f"{device_label}:")
-
-        all_dtypes = sorted(df_all["dtype_short"].unique())
+        all_dtypes = sorted(df["dtype_short"].unique())
         for dtype_short in all_dtypes:
-            _plot_dtype_grid(df_all, dtype_short, device_prefix, device_label)
+            _plot_dtype_grid(df, dtype_short, device_prefix, device_label)
 
 
 if __name__ == "__main__":

--- a/tech_reports/GEMM_FLOPS/plot_utilization.py
+++ b/tech_reports/GEMM_FLOPS/plot_utilization.py
@@ -27,6 +27,8 @@ DEVICE_FILES = {
     "P150": DATA_DIR / "bh.csv",
 }
 
+BASE_SHAPE_COLUMNS = ["base_m", "base_k", "base_n"]
+
 MODE_ORDER = ["tuned_2d_l1", "tuned_2d_dram", "oob"]
 
 MODE_DISPLAY = {
@@ -55,6 +57,23 @@ def safe_read_csv(path):
     return pd.DataFrame()
 
 
+def parse_grid_size(raw):
+    cleaned = str(raw).strip("() ")
+    grid_x, grid_y = [int(x.strip()) for x in cleaned.split(",")]
+    return grid_x, grid_y
+
+
+def add_base_shape_columns(df):
+    """Ensure base_m/base_k/base_n exist while preserving full scaled m/k/n."""
+    if not all(col in df.columns for col in BASE_SHAPE_COLUMNS):
+        grid_dims = df["grid_size"].apply(parse_grid_size)
+        df["base_m"] = [m // grid_y for m, (_, grid_y) in zip(df["m"], grid_dims)]
+        df["base_k"] = [k // grid_x for k, (grid_x, _) in zip(df["k"], grid_dims)]
+        df["base_n"] = [n // grid_x for n, (grid_x, _) in zip(df["n"], grid_dims)]
+    df["base_shape"] = list(zip(df["base_m"], df["base_k"], df["base_n"]))
+    return df
+
+
 def find_util_col(df, kind):
     """Find the utilization column that has data. kind is 'Host' or 'Device'."""
     prefix = f"{kind} based utilization"
@@ -76,6 +95,7 @@ def load_device_data(path, device_name):
         print(f"WARNING: No utilization column found in {path}")
     else:
         df["device_utilization"] = pd.to_numeric(df[util_col], errors="coerce")
+    df = add_base_shape_columns(df)
     return df
 
 
@@ -130,6 +150,16 @@ def build_legend_elements():
     return legend_elements
 
 
+def get_best_utilization_by_base_shape(df_slice):
+    best_rows = []
+    df_slice = df_slice.dropna(subset=["device_utilization"])
+    for _, group in df_slice.groupby("base_shape", sort=True):
+        best_rows.append(group.loc[group["device_utilization"].idxmax()])
+    if not best_rows:
+        return pd.DataFrame()
+    return pd.DataFrame(best_rows).sort_values("matrix_elements")
+
+
 def plot_mode_panel(ax, df_mode):
     """Plot utilization curves for one benchmark mode."""
     for dtype_label, dtype_color in dtype_configs:
@@ -138,7 +168,9 @@ def plot_mode_panel(ax, df_mode):
             if subset.empty:
                 continue
 
-            subset_sorted = subset.sort_values("matrix_elements")
+            subset_sorted = get_best_utilization_by_base_shape(subset)
+            if subset_sorted.empty:
+                continue
             if device_name == "N150":
                 markerfacecolor = "white"
                 markeredgewidth = 2

--- a/tech_reports/GEMM_FLOPS/plot_utilization.py
+++ b/tech_reports/GEMM_FLOPS/plot_utilization.py
@@ -5,6 +5,8 @@
 """
 Utilization Scatter Plot - Device-based utilization comparison between N150 and P150
 
+One subplot per benchmark mode (L1 tuned, DRAM tuned, OOB). No stitching across modes.
+
 Usage:
 1. Run the benchmark via run_bench.sh on both devices
 2. CSVs are placed in tech_reports/GEMM_FLOPS/data/{wh,bh}.csv
@@ -13,7 +15,6 @@ Usage:
 
 from pathlib import Path
 
-import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 from matplotlib.lines import Line2D
@@ -26,7 +27,14 @@ DEVICE_FILES = {
     "P150": DATA_DIR / "bh.csv",
 }
 
-# Configuration
+MODE_ORDER = ["tuned_2d_l1", "tuned_2d_dram", "oob"]
+
+MODE_DISPLAY = {
+    "tuned_2d_l1": "L1 (tuned)",
+    "tuned_2d_dram": "DRAM (tuned)",
+    "oob": "OOB (auto)",
+}
+
 dtype_configs = [
     ("BFLOAT4_B-LoFi", "#2ca02c"),  # Green
     ("BFLOAT8_B-HiFi2", "#ff7f0e"),  # Orange
@@ -47,10 +55,11 @@ def safe_read_csv(path):
     return pd.DataFrame()
 
 
-def find_device_util_col(df):
-    """Find the 'Device based utilization[%] (vs user selected grid ...)' column."""
+def find_util_col(df, kind):
+    """Find the utilization column that has data. kind is 'Host' or 'Device'."""
+    prefix = f"{kind} based utilization"
     for col in df.columns:
-        if col.startswith("Device based utilization") and "user selected grid" in col:
+        if col.startswith(prefix) and "user selected grid" in col and df[col].notna().any():
             return col
     return None
 
@@ -61,74 +70,80 @@ def load_device_data(path, device_name):
     if df.empty:
         return df
     df["device"] = device_name
-    # Filter to tuned_2d_l1 mode (equivalent to old sharded benchmark data)
-    if "mode" in df.columns:
-        df = df[df["mode"] == "tuned_2d_l1"].copy()
+
+    util_col = find_util_col(df, "Device") or find_util_col(df, "Host")
+    if util_col is None:
+        print(f"WARNING: No utilization column found in {path}")
+    else:
+        df["device_utilization"] = pd.to_numeric(df[util_col], errors="coerce")
     return df
 
 
-# Load data
-df_n150 = load_device_data(DEVICE_FILES["N150"], "N150")
-df_p150 = load_device_data(DEVICE_FILES["P150"], "P150")
-
-# Combine data
-df = pd.concat([df_n150, df_p150], ignore_index=True)
-
-if df.empty:
-    print("ERROR: No data available for any device. Exiting.")
-    raise SystemExit(1)
-
-# Filter: only non-traced data for clarity
-if df["use_trace"].dtype == object:
-    df["use_trace"] = df["use_trace"].astype(str).str.lower() == "true"
-df = df[df["use_trace"] == False]
-
-
-# Create dtype-fidelity labels
 def get_dtype_label(row):
     dtype = str(row["dtype"]).split(".")[-1]
     fidelity = str(row["math_fidelity"]).split(".")[-1]
     return f"{dtype}-{fidelity}"
 
 
-df["dtype_label"] = df.apply(get_dtype_label, axis=1)
+def build_legend_elements():
+    """Shared legend for dtype and device encodings."""
+    legend_elements = [
+        Line2D([0], [0], color="none", marker="", linestyle="", label="Dtype (Math Fidelity)"),
+    ]
+    for dtype_label, color in dtype_configs:
+        parts = dtype_label.split("-")
+        formatted_label = f"{parts[0]} ({parts[1]})"
+        legend_elements.append(Line2D([0], [0], color=color, linewidth=3, label=formatted_label))
 
-# Calculate total matrix elements
-df["matrix_elements"] = df["m"] * df["k"] * df["n"]
+    legend_elements.append(Line2D([0], [0], color="none", marker="", linestyle="", label=""))
+    legend_elements.append(Line2D([0], [0], color="none", marker="", linestyle="", label="Device"))
+    legend_elements.append(
+        Line2D(
+            [0],
+            [0],
+            color="gray",
+            linewidth=2.5,
+            linestyle="-",
+            marker="^",
+            markersize=8,
+            markerfacecolor="gray",
+            markeredgecolor="black",
+            markeredgewidth=1,
+            label="P150",
+        )
+    )
+    legend_elements.append(
+        Line2D(
+            [0],
+            [0],
+            color="gray",
+            linewidth=2.5,
+            linestyle="--",
+            marker="v",
+            markersize=8,
+            markerfacecolor="white",
+            markeredgecolor="gray",
+            markeredgewidth=2,
+            label="N150",
+        )
+    )
+    return legend_elements
 
-# Find the device utilization column dynamically
-device_util_col = find_device_util_col(df)
-if device_util_col is None:
-    print("WARNING: No device-based utilization column found. Using host-based.")
-    for col in df.columns:
-        if col.startswith("Host based utilization") and "user selected grid" in col:
-            device_util_col = col
-            break
 
-if device_util_col is None:
-    print("ERROR: No utilization column found at all. Exiting.")
-    raise SystemExit(1)
+def plot_mode_panel(ax, df_mode):
+    """Plot utilization curves for one benchmark mode."""
+    for dtype_label, dtype_color in dtype_configs:
+        for device_name, marker, linestyle in device_configs:
+            subset = df_mode[(df_mode["dtype_label"] == dtype_label) & (df_mode["device"] == device_name)]
+            if subset.empty:
+                continue
 
-df["device_utilization"] = pd.to_numeric(df[device_util_col], errors="coerce")
-
-# Create plot
-fig, ax = plt.subplots(figsize=(14, 8))
-
-# Plot each combination of dtype and device
-for dtype_label, dtype_color in dtype_configs:
-    for device_name, marker, linestyle in device_configs:
-        subset = df[(df["dtype_label"] == dtype_label) & (df["device"] == device_name)]
-
-        if len(subset) > 0:
-            # Sort by matrix size for line plot
             subset_sorted = subset.sort_values("matrix_elements")
-
-            # Determine marker properties
             if device_name == "N150":
-                markerfacecolor = "white"  # Hollow for N150
+                markerfacecolor = "white"
                 markeredgewidth = 2
             else:
-                markerfacecolor = dtype_color  # Filled for P150
+                markerfacecolor = dtype_color
                 markeredgewidth = 1
 
             ax.plot(
@@ -145,103 +160,84 @@ for dtype_label, dtype_color in dtype_configs:
                 alpha=0.8,
             )
 
-# Formatting
-ax.set_xlabel("Total Matrix Elements (M × K × N)", fontsize=12, fontweight="bold")
-# Add explanation below x-axis (smaller, non-bold)
-ax.text(
+    ax.set_xscale("log")
+    ax.grid(True, alpha=0.3, linestyle="--")
+    ax.set_ylim(0, 110)
+    ax.set_ylabel("Utilization (%)", fontsize=11, fontweight="bold")
+
+
+# Load data
+df_n150 = load_device_data(DEVICE_FILES["N150"], "N150")
+df_p150 = load_device_data(DEVICE_FILES["P150"], "P150")
+df = pd.concat([df_n150, df_p150], ignore_index=True)
+
+if df.empty:
+    print("ERROR: No data available for any device. Exiting.")
+    raise SystemExit(1)
+
+if "device_utilization" not in df.columns or df["device_utilization"].isna().all():
+    print("ERROR: No utilization data found for any device. Exiting.")
+    raise SystemExit(1)
+
+if df["use_trace"].dtype == object:
+    df["use_trace"] = df["use_trace"].astype(str).str.lower() == "true"
+df = df[df["use_trace"] == False].copy()
+
+df["dtype_label"] = df.apply(get_dtype_label, axis=1)
+df["matrix_elements"] = df["m"] * df["k"] * df["n"]
+
+available_modes = [mode for mode in MODE_ORDER if mode in df["mode"].values and not df[df["mode"] == mode].empty]
+if not available_modes:
+    print("ERROR: No mode data available after filtering. Exiting.")
+    raise SystemExit(1)
+
+n_modes = len(available_modes)
+fig, axes = plt.subplots(n_modes, 1, figsize=(14, 5.5 * n_modes), sharex=True)
+if n_modes == 1:
+    axes = [axes]
+
+for ax, mode in zip(axes, available_modes):
+    df_mode = df[df["mode"] == mode]
+    plot_mode_panel(ax, df_mode)
+    ax.set_title(
+        f"Mode: {MODE_DISPLAY.get(mode, mode)}",
+        fontsize=12,
+        fontweight="bold",
+        pad=8,
+    )
+
+axes[-1].set_xlabel("Total Matrix Elements (M × K × N)", fontsize=12, fontweight="bold")
+fig.text(
     0.5,
-    -0.10,
+    0.02,
     "[(M,K) = input matrix size, (K,N) = weight matrix size]",
-    transform=ax.transAxes,
     ha="center",
-    va="top",
+    va="bottom",
     fontsize=9,
 )
-ax.set_ylabel("Utilization (%)", fontsize=12, fontweight="bold")
 
-# Set main title and subtitle
 fig.suptitle(
     "Utilization Comparison: N150 (Wormhole) vs P150 (Blackhole)",
     fontsize=16,
     fontweight="bold",
-    y=0.98,
+    y=0.995,
 )
-ax.set_title(
-    "Utilization vs Matrix Size for Different Data Types and Math Fidelities",
-    fontsize=12,
-    fontweight="bold",
-    pad=10,
+fig.subplots_adjust(top=0.94, bottom=0.06, hspace=0.28)
+
+legend = axes[0].legend(
+    handles=build_legend_elements(),
+    loc="upper right",
+    fontsize=10,
+    framealpha=0.95,
+    edgecolor="black",
+    handlelength=3.5,
 )
-
-ax.set_xscale("log")
-ax.grid(True, alpha=0.3, linestyle="--")
-ax.set_ylim(0, 110)
-
-# Create legend with bold headers
-legend_elements = []
-
-# Dtype section header (bold)
-legend_elements.append(Line2D([0], [0], color="none", marker="", linestyle="", label="Dtype (Math Fidelity)"))
-
-# Dtype entries (just colored lines, no markers)
-for dtype_label, color in dtype_configs:
-    parts = dtype_label.split("-")
-    dtype_part = parts[0]  # Keep uppercase format
-    fidelity_part = parts[1]
-    formatted_label = f"{dtype_part} ({fidelity_part})"
-    legend_elements.append(Line2D([0], [0], color=color, linewidth=3, label=f"{formatted_label}"))
-
-# Empty line for spacing
-legend_elements.append(Line2D([0], [0], color="none", marker="", linestyle="", label=""))
-
-# Device section header (bold)
-legend_elements.append(Line2D([0], [0], color="none", marker="", linestyle="", label="Device"))
-
-# Device entries with markers and line styles
-legend_elements.append(
-    Line2D(
-        [0],
-        [0],
-        color="gray",
-        linewidth=2.5,
-        linestyle="-",
-        marker="^",
-        markersize=8,
-        markerfacecolor="gray",
-        markeredgecolor="black",
-        markeredgewidth=1,
-        label="P150",
-    )
-)
-legend_elements.append(
-    Line2D(
-        [0],
-        [0],
-        color="gray",
-        linewidth=2.5,
-        linestyle="--",
-        marker="v",
-        markersize=8,
-        markerfacecolor="white",
-        markeredgecolor="gray",
-        markeredgewidth=2,
-        label="N150",
-    )
-)
-
-# Create legend with custom handler to make headers bold
-legend = ax.legend(
-    handles=legend_elements, loc="lower right", fontsize=10, framealpha=0.95, edgecolor="black", handlelength=3.5
-)
-
-# Make the headers bold
 header_labels = {"Dtype (Math Fidelity)", "Device"}
 for text in legend.get_texts():
     if text.get_text() in header_labels:
         text.set_weight("bold")
 
 IMG_DIR.mkdir(parents=True, exist_ok=True)
-plt.tight_layout()
 plt.savefig(IMG_DIR / "utilization_comparison.png", dpi=300, bbox_inches="tight")
 print("✓ Utilization scatter plot saved: tech_reports/GEMM_FLOPS/images/utilization_comparison.png")
 plt.close()

--- a/tech_reports/GEMM_FLOPS/plot_utilization.py
+++ b/tech_reports/GEMM_FLOPS/plot_utilization.py
@@ -6,27 +6,25 @@
 Utilization Scatter Plot - Device-based utilization comparison between N150 and P150
 
 Usage:
-1. Generate performance data using manually selected GEMM configurations
-2. Rename output files to n150-manual.csv and p150-manual.csv
-3. Place the CSV files in tech_reports/GEMM_FLOPS/
-4. Run this script from the tt-metal root directory
+1. Run the benchmark via run_bench.sh on both devices
+2. CSVs are placed in tech_reports/GEMM_FLOPS/data/{wh,bh}.csv
+3. Run this script from the tt-metal root directory
 """
 
-import os
+from pathlib import Path
 
+import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
-import numpy as np
 from matplotlib.lines import Line2D
 
+DATA_DIR = Path("tech_reports/GEMM_FLOPS/data")
+IMG_DIR = Path("tech_reports/GEMM_FLOPS/images")
 
-def safe_read_csv(path):
-    """Return the CSV as a DataFrame, or an empty DataFrame if the file is missing."""
-    if os.path.exists(path):
-        return pd.read_csv(path)
-    print(f"WARNING: {path} not found — skipping that device.")
-    return pd.DataFrame()
-
+DEVICE_FILES = {
+    "N150": DATA_DIR / "wh.csv",
+    "P150": DATA_DIR / "bh.csv",
+}
 
 # Configuration
 dtype_configs = [
@@ -40,15 +38,38 @@ device_configs = [
     ("N150", "v", "--"),  # Downward triangle, dashed line
 ]
 
-# Load data
-df_n150 = safe_read_csv("tech_reports/GEMM_FLOPS/n150-manual.csv")
-df_p150 = safe_read_csv("tech_reports/GEMM_FLOPS/p150-manual.csv")
 
-# Add device column
-if not df_n150.empty:
-    df_n150["device"] = "N150"
-if not df_p150.empty:
-    df_p150["device"] = "P150"
+def safe_read_csv(path):
+    """Return the CSV as a DataFrame, or an empty DataFrame if the file is missing."""
+    if path.exists():
+        return pd.read_csv(path)
+    print(f"WARNING: {path} not found — skipping that device.")
+    return pd.DataFrame()
+
+
+def find_device_util_col(df):
+    """Find the 'Device based utilization[%] (vs user selected grid ...)' column."""
+    for col in df.columns:
+        if col.startswith("Device based utilization") and "user selected grid" in col:
+            return col
+    return None
+
+
+def load_device_data(path, device_name):
+    """Load and preprocess a device CSV."""
+    df = safe_read_csv(path)
+    if df.empty:
+        return df
+    df["device"] = device_name
+    # Filter to tuned_2d_l1 mode (equivalent to old sharded benchmark data)
+    if "mode" in df.columns:
+        df = df[df["mode"] == "tuned_2d_l1"].copy()
+    return df
+
+
+# Load data
+df_n150 = load_device_data(DEVICE_FILES["N150"], "N150")
+df_p150 = load_device_data(DEVICE_FILES["P150"], "P150")
 
 # Combine data
 df = pd.concat([df_n150, df_p150], ignore_index=True)
@@ -58,10 +79,9 @@ if df.empty:
     raise SystemExit(1)
 
 # Filter: only non-traced data for clarity
+if df["use_trace"].dtype == object:
+    df["use_trace"] = df["use_trace"].astype(str).str.lower() == "true"
 df = df[df["use_trace"] == False]
-
-df = df[~((df["m"] == 3328) & (df["k"] == 2560) & (df["n"] == 2560))].copy()
-df = df[~((df["m"] == 4160) & (df["k"] == 4160) & (df["n"] == 4160))].copy()
 
 
 # Create dtype-fidelity labels
@@ -76,21 +96,20 @@ df["dtype_label"] = df.apply(get_dtype_label, axis=1)
 # Calculate total matrix elements
 df["matrix_elements"] = df["m"] * df["k"] * df["n"]
 
+# Find the device utilization column dynamically
+device_util_col = find_device_util_col(df)
+if device_util_col is None:
+    print("WARNING: No device-based utilization column found. Using host-based.")
+    for col in df.columns:
+        if col.startswith("Host based utilization") and "user selected grid" in col:
+            device_util_col = col
+            break
 
-# Extract device utilization - handle different grid size column names
-def get_device_utilization(row):
-    if row["device"] == "N150":
-        col_name = "Device based utilization[%] (vs user selected grid 8x8)"
-    else:  # P150
-        col_name = "Device based utilization[%] (vs user selected grid 13x10)"
+if device_util_col is None:
+    print("ERROR: No utilization column found at all. Exiting.")
+    raise SystemExit(1)
 
-    if col_name in row.index:
-        return row[col_name]
-    else:
-        return np.nan
-
-
-df["device_utilization"] = df.apply(get_device_utilization, axis=1)
+df["device_utilization"] = pd.to_numeric(df[device_util_col], errors="coerce")
 
 # Create plot
 fig, ax = plt.subplots(figsize=(14, 8))
@@ -221,7 +240,8 @@ for text in legend.get_texts():
     if text.get_text() in header_labels:
         text.set_weight("bold")
 
+IMG_DIR.mkdir(parents=True, exist_ok=True)
 plt.tight_layout()
-plt.savefig("tech_reports/GEMM_FLOPS/images/utilization_comparison.png", dpi=300, bbox_inches="tight")
+plt.savefig(IMG_DIR / "utilization_comparison.png", dpi=300, bbox_inches="tight")
 print("✓ Utilization scatter plot saved: tech_reports/GEMM_FLOPS/images/utilization_comparison.png")
 plt.close()

--- a/tech_reports/GEMM_FLOPS/plot_utilization.py
+++ b/tech_reports/GEMM_FLOPS/plot_utilization.py
@@ -12,10 +12,21 @@ Usage:
 4. Run this script from the tt-metal root directory
 """
 
+import os
+
 import pandas as pd
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.lines import Line2D
+
+
+def safe_read_csv(path):
+    """Return the CSV as a DataFrame, or an empty DataFrame if the file is missing."""
+    if os.path.exists(path):
+        return pd.read_csv(path)
+    print(f"WARNING: {path} not found — skipping that device.")
+    return pd.DataFrame()
+
 
 # Configuration
 dtype_configs = [
@@ -30,15 +41,21 @@ device_configs = [
 ]
 
 # Load data
-df_n150 = pd.read_csv("tech_reports/GEMM_FLOPS/n150-manual.csv")
-df_p150 = pd.read_csv("tech_reports/GEMM_FLOPS/p150-manual.csv")
+df_n150 = safe_read_csv("tech_reports/GEMM_FLOPS/n150-manual.csv")
+df_p150 = safe_read_csv("tech_reports/GEMM_FLOPS/p150-manual.csv")
 
 # Add device column
-df_n150["device"] = "N150"
-df_p150["device"] = "P150"
+if not df_n150.empty:
+    df_n150["device"] = "N150"
+if not df_p150.empty:
+    df_p150["device"] = "P150"
 
 # Combine data
 df = pd.concat([df_n150, df_p150], ignore_index=True)
+
+if df.empty:
+    print("ERROR: No data available for any device. Exiting.")
+    raise SystemExit(1)
 
 # Filter: only non-traced data for clarity
 df = df[df["use_trace"] == False]

--- a/tech_reports/GEMM_FLOPS/run_bench.sh
+++ b/tech_reports/GEMM_FLOPS/run_bench.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+export TT_METAL_HOME="$(pwd)"
+export TT_METAL_RUNTIME_ROOT="$(pwd)"
+export PYTHONPATH="${TT_METAL_HOME}:${PYTHONPATH:-}"
+source python_env/bin/activate
+
+export TT_METAL_DEVICE_PROFILER=1
+export ENABLE_TRACY=1
+export TT_METAL_PROFILER_MID_RUN_DUMP=1
+
+mkdir -p generated
+
+BENCH=tests/ttnn/unit_tests/benchmarks/test_benchmark.py
+
+pytest "${BENCH}::test_matmul_2d_host_perf" -xvs --timeout=7200
+pytest "${BENCH}::test_matmul_2d_host_perf_out_of_box" -xvs --timeout=7200
+
+ARCH=$(python -c "from models.common.utility_functions import is_blackhole; print('bh' if is_blackhole() else 'wh')")
+mkdir -p tech_reports/GEMM_FLOPS/data
+cp generated/matmul_2d_host_perf_report.csv "tech_reports/GEMM_FLOPS/data/${ARCH}-tuned.csv"
+cp generated/matmul_2d_host_perf_out_of_box_report.csv "tech_reports/GEMM_FLOPS/data/${ARCH}-oob.csv"
+
+python tech_reports/GEMM_FLOPS/plot_util_grid.py

--- a/tech_reports/GEMM_FLOPS/run_bench.sh
+++ b/tech_reports/GEMM_FLOPS/run_bench.sh
@@ -22,3 +22,8 @@ mkdir -p tech_reports/GEMM_FLOPS/data
 cp generated/matmul_benchmark_report.csv "tech_reports/GEMM_FLOPS/data/${ARCH}.csv"
 
 python tech_reports/GEMM_FLOPS/plot_util_grid.py
+python tech_reports/GEMM_FLOPS/plot_utilization.py
+python tech_reports/GEMM_FLOPS/plot_scatter_tracing.py
+python tech_reports/GEMM_FLOPS/plot_scatter_performance.py
+python tech_reports/GEMM_FLOPS/plot_bar.py
+python tech_reports/GEMM_FLOPS/plot_aspect_ratio_by_dtype.py

--- a/tech_reports/GEMM_FLOPS/run_bench.sh
+++ b/tech_reports/GEMM_FLOPS/run_bench.sh
@@ -10,6 +10,7 @@ source python_env/bin/activate
 export TT_METAL_DEVICE_PROFILER=1
 export ENABLE_TRACY=1
 export TT_METAL_PROFILER_MID_RUN_DUMP=1
+export TTNN_RUN_GEMM_FLOPS_BENCHMARK=1
 
 mkdir -p generated
 

--- a/tech_reports/GEMM_FLOPS/run_bench.sh
+++ b/tech_reports/GEMM_FLOPS/run_bench.sh
@@ -16,11 +16,9 @@ mkdir -p generated
 BENCH=tests/ttnn/unit_tests/benchmarks/test_benchmark.py
 
 pytest "${BENCH}::test_matmul_2d_host_perf" -xvs --timeout=7200
-pytest "${BENCH}::test_matmul_2d_host_perf_out_of_box" -xvs --timeout=7200
 
 ARCH=$(python -c "from models.common.utility_functions import is_blackhole; print('bh' if is_blackhole() else 'wh')")
 mkdir -p tech_reports/GEMM_FLOPS/data
-cp generated/matmul_2d_host_perf_report.csv "tech_reports/GEMM_FLOPS/data/${ARCH}-tuned.csv"
-cp generated/matmul_2d_host_perf_out_of_box_report.csv "tech_reports/GEMM_FLOPS/data/${ARCH}-oob.csv"
+cp generated/matmul_benchmark_report.csv "tech_reports/GEMM_FLOPS/data/${ARCH}.csv"
 
 python tech_reports/GEMM_FLOPS/plot_util_grid.py

--- a/tech_reports/GEMM_FLOPS/run_bench.sh
+++ b/tech_reports/GEMM_FLOPS/run_bench.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"

--- a/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
+++ b/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
@@ -150,12 +150,22 @@ matmul_shapes_bfloat16 = [
     (256, 256, 384, True, True, 1, 1, 1),
     (256, 384, 384, True, True, 2, 1, 1),
     (384, 384, 384, True, True, 4, 1, 1),
-    (384, 384, 512, False, False, 2, 1, 1),
-    (384, 512, 512, False, False, 2, 1, 1),
-    (416, 320, 320, False, False, 1, 1, 1),  # P150 square: 4160x4160x4160
-    (512, 512, 512, False, False, 1, 2, 2),
-    (1024, 1024, 1024, False, False, 2, 4, 4),
-    (2048, 2048, 2048, False, False, 4, 8, 8),
+    (64, 64, 64, False, False, 1, 1, 1),
+    (64, 128, 128, False, False, 1, 1, 1),
+    (64, 128, 256, False, False, 1, 1, 1),
+    (128, 128, 128, False, False, 1, 1, 1),
+    (128, 128, 256, False, False, 1, 1, 1),
+    (128, 256, 256, False, False, 1, 1, 1),
+    (256, 256, 256, False, False, 1, 1, 1),
+    (256, 256, 384, False, False, 1, 1, 1),
+    (256, 384, 384, False, False, 2, 1, 1),
+    (384, 384, 384, False, False, 4, 1, 1),
+    # (384, 384, 512, False, False, 2, 1, 1),
+    # (384, 512, 512, False, False, 2, 1, 1),
+    # (416, 320, 320, False, False, 1, 1, 1),  # P150 square: 4160x4160x4160
+    # (512, 512, 512, False, False, 1, 2, 2),
+    # (1024, 1024, 1024, False, False, 2, 4, 4),
+    # (2048, 2048, 2048, False, False, 4, 8, 8),
 ]
 
 matmul_shapes_bfloat8_b = [
@@ -169,11 +179,21 @@ matmul_shapes_bfloat8_b = [
     (256, 256, 384, True, True, 1, 1, 1),
     (256, 384, 384, True, True, 1, 1, 1),
     (384, 384, 384, True, True, 2, 1, 1),
-    (384, 384, 512, True, True, 2, 1, 1),
-    (416, 320, 320, False, False, 1, 1, 1),
-    (512, 512, 512, False, False, 1, 2, 2),
-    (1024, 1024, 1024, False, False, 2, 4, 4),
-    (2048, 2048, 2048, False, False, 4, 8, 8),
+    (64, 64, 64, False, False, 1, 1, 1),
+    (64, 128, 128, False, False, 1, 1, 1),
+    (64, 128, 256, False, False, 1, 1, 1),
+    (128, 128, 128, False, False, 1, 1, 1),
+    (128, 128, 256, False, False, 1, 1, 1),
+    (128, 256, 256, False, False, 1, 1, 1),
+    (256, 256, 256, False, False, 1, 1, 1),
+    (256, 256, 384, False, False, 1, 1, 1),
+    (256, 384, 384, False, False, 1, 1, 1),
+    (384, 384, 384, False, False, 2, 1, 1),
+    # (384, 384, 512, True, True, 2, 1, 1),
+    # (416, 320, 320, False, False, 1, 1, 1),
+    # (512, 512, 512, False, False, 1, 2, 2),
+    # (1024, 1024, 1024, False, False, 2, 4, 4),
+    # (2048, 2048, 2048, False, False, 4, 8, 8),
 ]
 
 matmul_shapes_bfloat4_b = [
@@ -187,35 +207,45 @@ matmul_shapes_bfloat4_b = [
     (256, 256, 384, True, True, 1, 1, 1),
     (256, 384, 384, True, True, 1, 1, 1),
     (384, 384, 384, True, True, 1, 1, 1),
-    (384, 384, 512, True, True, 1, 1, 1),
-    (384, 512, 512, True, True, 2, 1, 1),
-    (416, 320, 320, False, False, 1, 1, 1),
-    (512, 512, 512, True, True, 2, 1, 1),
-    (1024, 1024, 1024, False, False, 2, 2, 2),
-    (2048, 2048, 2048, False, False, 4, 4, 4),
+    (64, 64, 64, False, False, 1, 1, 1),
+    (64, 128, 128, False, False, 1, 1, 1),
+    (64, 128, 256, False, False, 1, 1, 1),
+    (128, 128, 128, False, False, 1, 1, 1),
+    (128, 128, 256, False, False, 1, 1, 1),
+    (128, 256, 256, False, False, 1, 1, 1),
+    (256, 256, 256, False, False, 1, 1, 1),
+    (256, 256, 384, False, False, 1, 1, 1),
+    (256, 384, 384, False, False, 1, 1, 1),
+    (384, 384, 384, False, False, 1, 1, 1),
+    # (384, 384, 512, True, True, 1, 1, 1),
+    # (384, 512, 512, True, True, 2, 1, 1),
+    # (416, 320, 320, False, False, 1, 1, 1),
+    # (512, 512, 512, True, True, 2, 1, 1),
+    # (1024, 1024, 1024, False, False, 2, 2, 2),
+    # (2048, 2048, 2048, False, False, 4, 4, 4),
 ]
 
 # (dtype, math_fidelity, use_trace)
 matmul_configs = [
     (ttnn.bfloat16, ttnn.MathFidelity.HiFi2, False),
-    (ttnn.bfloat16, ttnn.MathFidelity.HiFi4, False),
-    (ttnn.bfloat8_b, ttnn.MathFidelity.HiFi2, False),
-    (ttnn.bfloat8_b, ttnn.MathFidelity.LoFi, False),
-    (ttnn.bfloat4_b, ttnn.MathFidelity.LoFi, False),
+    # (ttnn.bfloat16, ttnn.MathFidelity.HiFi4, False),
+    # (ttnn.bfloat8_b, ttnn.MathFidelity.HiFi2, False),
+    # (ttnn.bfloat8_b, ttnn.MathFidelity.LoFi, False),
+    # (ttnn.bfloat4_b, ttnn.MathFidelity.LoFi, False),
     (ttnn.bfloat16, ttnn.MathFidelity.HiFi2, True),
-    (ttnn.bfloat16, ttnn.MathFidelity.HiFi4, True),
-    (ttnn.bfloat8_b, ttnn.MathFidelity.HiFi2, True),
-    (ttnn.bfloat8_b, ttnn.MathFidelity.LoFi, True),
-    (ttnn.bfloat4_b, ttnn.MathFidelity.LoFi, True),
+    # (ttnn.bfloat16, ttnn.MathFidelity.HiFi4, True),
+    # (ttnn.bfloat8_b, ttnn.MathFidelity.HiFi2, True),
+    # (ttnn.bfloat8_b, ttnn.MathFidelity.LoFi, True),
+    # (ttnn.bfloat4_b, ttnn.MathFidelity.LoFi, True),
 ]
 
 
-@pytest.mark.skip(reason="Benchmark is not intended to be run as part of CI and can be manually run locally")
+# @pytest.mark.skip(reason="Benchmark is not intended to be run as part of CI and can be manually run locally")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576, "trace_region_size": 3855488}], indirect=True)
 @pytest.mark.parametrize("tile_h", [32])
 @pytest.mark.parametrize("tile_w", [32])
 @pytest.mark.parametrize("num_warmup_iterations", [5])
-@pytest.mark.parametrize("num_measurement_iterations", [100])
+@pytest.mark.parametrize("num_measurement_iterations", [25])
 def test_matmul_2d_host_perf(
     device,
     grid_size,
@@ -522,27 +552,27 @@ matmul_shapes_oob = [
     (256, 256, 384),
     (256, 384, 384),
     (384, 384, 384),
-    (384, 384, 512),
-    (384, 512, 512),
-    (512, 512, 512),
+    # (384, 384, 512),
+    # (384, 512, 512),
+    # (512, 512, 512),
 ]
 
 matmul_configs_oob = [
     (ttnn.bfloat16, False),
     (ttnn.bfloat16, True),
-    (ttnn.bfloat8_b, False),
-    (ttnn.bfloat8_b, True),
-    (ttnn.bfloat4_b, False),
-    (ttnn.bfloat4_b, True),
+    # (ttnn.bfloat8_b, False),
+    # (ttnn.bfloat8_b, True),
+    # (ttnn.bfloat4_b, False),
+    # (ttnn.bfloat4_b, True),
 ]
 
 
-@pytest.mark.skip(reason="Benchmark is not intended to be run as part of CI and can be manually run locally")
+# @pytest.mark.skip(reason="Benchmark is not intended to be run as part of CI and can be manually run locally")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576, "trace_region_size": 3855488}], indirect=True)
 @pytest.mark.parametrize("tile_h", [32])
 @pytest.mark.parametrize("tile_w", [32])
 @pytest.mark.parametrize("num_warmup_iterations", [5])
-@pytest.mark.parametrize("num_measurement_iterations", [100])
+@pytest.mark.parametrize("num_measurement_iterations", [25])
 def test_matmul_2d_host_perf_out_of_box(
     device,
     grid_size,

--- a/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
+++ b/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
@@ -2,20 +2,24 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-# This test runs different shapes for matmul_2d, with possibly the best configurations for performance.
+# This test benchmarks matmul_2d across different program configs (modes) and math fidelities.
+#
+# Modes:
+#   - oob: Out-of-box (auto-selected program config, DRAM inputs)
+#   - tuned_2d_l1: Explicit 2D multicast program config with L1-sharded in0 and output
+#   - tuned_2d_dram: Explicit 2D multicast program config with DRAM-interleaved in0 and output
 #
 # The inputs include:
-#   - m, k, n: Dimensions of the input tensors.
-#   - in0_sharded, out_sharded: Flags indicating whether the in0 (activation) and output tensors are sharded or not.
+#   - m, k, n: Dimensions of the input tensors (before grid scaling).
 #   - in0_block_w_div: A parameter to divide an in0 block into multiple chunks, helping to reduce L1 cache usage.
-#   - num_out_blocks_h: A parameter to divide an output block into multiple chunks on height dim, helping to reduce L1 cache usage.
-#   - num_out_blocks_w: A parameter to divide an output block into multiple chunks on width dim, helping to reduce L1 cache usage.
+#   - num_out_blocks_h: A parameter to divide an output block into multiple chunks on height dim.
+#   - num_out_blocks_w: A parameter to divide an output block into multiple chunks on width dim.
 #
-# Test is measuring and calculating following performance metrics:
+# Performance metrics:
 #   - Inference time: The average time taken for inference in nanoseconds.
 #   - TFLOPs: The number of tera floating-point operations per second.
-#   - Host based utilization: The ratio of ideal cycles to inference cycles, calculated for both user selected and full available grid size.
-#   - Device based utilization: The ratio of ideal cycles to TRISC1 kernel duration, calculated for both user selected and full available grid size.
+#   - Host based utilization: The ratio of ideal cycles to inference cycles.
+#   - Device based utilization: The ratio of ideal cycles to TRISC1 kernel duration (requires profiler build).
 #
 # Important notes regarding performance metrics calculation:
 #   - If profiler build is not enabled (TT_METAL_DEVICE_PROFILER environment variable is not set) only host based utilization is calculated.
@@ -40,23 +44,26 @@
 #   - Device based utilization is calculated using formula: ideal_cycle / trisc1_kernel_duration
 #       - trisc1_kernel_duration is read from profiler log and it is average duration of TRISC1 kernel in number of cycles.
 
-import time
-
-from loguru import logger
 import csv
+import os
+from pathlib import Path
+
+import numpy as np
 import pytest
 import torch
 import ttnn
-from models.common.utility_functions import profiler, is_wormhole_b0, is_blackhole
-from pathlib import Path
-import os
-import numpy as np
+from loguru import logger
+from models.common.utility_functions import is_blackhole, is_wormhole_b0, profiler
+from tracy.common import PROFILER_DEVICE_SIDE_LOG, PROFILER_LOGS_DIR, rm
+from tracy.device_post_proc_config import default_setup
 from tracy.process_device_log import import_log_run_stats
-import tracy.device_post_proc_config as device_post_proc_config
-from tracy.common import PROFILER_LOGS_DIR, PROFILER_DEVICE_SIDE_LOG, rm
 
 profiler_log_path = PROFILER_LOGS_DIR / PROFILER_DEVICE_SIDE_LOG
 
+
+# ---------------------------------------------------------------------------
+# Utility functions
+# ---------------------------------------------------------------------------
 
 SUBBLOCK_HW_CHOICES = [
     (4, 2),
@@ -81,6 +88,13 @@ SUBBLOCK_HW_CHOICES = [
     (1, 1),  # subblock_hw = 1
 ]
 
+FIDELITY_CYCLES = {
+    ttnn.MathFidelity.LoFi: 16,
+    ttnn.MathFidelity.HiFi2: 32,
+    ttnn.MathFidelity.HiFi3: 48,
+    ttnn.MathFidelity.HiFi4: 64,
+}
+
 
 def get_subblock_sizes(m_tiles_per_core, n_tiles_per_core, out_sharded=False, fp32_dest_acc_en=False):
     for subblock_hw in SUBBLOCK_HW_CHOICES:
@@ -101,11 +115,8 @@ def get_subblock_sizes(m_tiles_per_core, n_tiles_per_core, out_sharded=False, fp
     return (1, 1)
 
 
-# Get default value of device frequency[MHz] based on architecture.
-# Hardcoded values are used until there is python support to read freq
-# value from device. Please note that this needs to be updated if device
-# runs at different frequency.
 def get_device_frequency():
+    """Get default device frequency[MHz] based on architecture."""
     if is_wormhole_b0():
         return 1000
     elif is_blackhole():
@@ -115,8 +126,8 @@ def get_device_frequency():
 
 
 def get_profiler_data():
-    # Import profiler log file and run perf related statistic calculation
-    setup = device_post_proc_config.default_setup()
+    """Import profiler log and return device freq + TRISC1 kernel duration."""
+    setup = default_setup()
     setup.deviceInputLog = profiler_log_path
     deviceData = import_log_run_stats(setup)
     data = {}
@@ -131,113 +142,173 @@ def get_profiler_data():
     return data
 
 
-# Check if test is run with profiler build enabled.
 def get_profiler_build_enabled():
-    return os.getenv("TT_METAL_DEVICE_PROFILER") != None
+    return os.getenv("TT_METAL_DEVICE_PROFILER") is not None
 
 
-# These configs are all based on a 1x1 compute grid, and will be scaled by the benchmark according to the max grid size
-# M will be scaled by Y (num cols), N and K will be scaled by X (num rows)
-# (m, k, n, in0_sharded, out_sharded, in0_block_w_div, num_out_blocks_h, num_out_blocks_w)
-matmul_shapes_bfloat16 = [
-    (64, 64, 64, True, True, 1, 1, 1),
-    (64, 128, 128, True, True, 1, 1, 1),
-    (64, 128, 256, True, True, 1, 1, 1),
-    (128, 128, 128, True, True, 1, 1, 1),
-    (128, 128, 256, True, True, 1, 1, 1),
-    (128, 256, 256, True, True, 1, 1, 1),
-    (256, 256, 256, True, True, 1, 1, 1),
-    (256, 256, 384, True, True, 1, 1, 1),
-    (256, 384, 384, True, True, 2, 1, 1),
-    (384, 384, 384, True, True, 4, 1, 1),
-    (64, 64, 64, False, False, 1, 1, 1),
-    (64, 128, 128, False, False, 1, 1, 1),
-    (64, 128, 256, False, False, 1, 1, 1),
-    (128, 128, 128, False, False, 1, 1, 1),
-    (128, 128, 256, False, False, 1, 1, 1),
-    (128, 256, 256, False, False, 1, 1, 1),
-    (256, 256, 256, False, False, 1, 1, 1),
-    (256, 256, 384, False, False, 1, 1, 1),
-    (256, 384, 384, False, False, 2, 1, 1),
-    (384, 384, 384, False, False, 4, 1, 1),
-    # (384, 384, 512, False, False, 2, 1, 1),
-    # (384, 512, 512, False, False, 2, 1, 1),
-    # (416, 320, 320, False, False, 1, 1, 1),  # P150 square: 4160x4160x4160
-    # (512, 512, 512, False, False, 1, 2, 2),
-    # (1024, 1024, 1024, False, False, 2, 4, 4),
-    # (2048, 2048, 2048, False, False, 4, 8, 8),
+# ---------------------------------------------------------------------------
+# Benchmark measurement helpers
+# ---------------------------------------------------------------------------
+
+
+def run_matmul_measurement(
+    device,
+    in0_t,
+    in1_t,
+    matmul_fn,
+    use_trace,
+    num_warmup_iterations,
+    num_measurement_iterations,
+    calc_device_utilization,
+):
+    """Run warmup + timed measurement loop, return (inference_time_avg, trisc1_kernel_duration or None)."""
+
+    # Initial run to compile
+    output_t = matmul_fn(in0_t, in1_t)
+
+    # Warmup
+    for _ in range(num_warmup_iterations):
+        output_t = matmul_fn(in0_t, in1_t)
+
+    if calc_device_utilization:
+        ttnn.ReadDeviceProfiler(device)
+        rm(profiler_log_path)
+
+    ttnn.synchronize_device(device)
+
+    # Measurement
+    if use_trace:
+        tid = ttnn.begin_trace_capture(device, cq_id=0)
+        for _ in range(num_measurement_iterations):
+            output_t = matmul_fn(in0_t, in1_t)
+        ttnn.end_trace_capture(device, tid, cq_id=0)
+        profiler.start("run")
+        ttnn.execute_trace(device, tid, cq_id=0, blocking=False)
+        ttnn.synchronize_device(device)
+        profiler.end("run")
+        ttnn.release_trace(device, tid)
+    else:
+        profiler.start("run")
+        for _ in range(num_measurement_iterations):
+            output_t = matmul_fn(in0_t, in1_t)
+        ttnn.synchronize_device(device)
+        profiler.end("run")
+
+    trisc1_kernel_duration = None
+    if calc_device_utilization:
+        ttnn.ReadDeviceProfiler(device)
+        profiler_data = get_profiler_data()
+        trisc1_kernel_duration = profiler_data["trisc1_kernel_duration"]
+
+    inference_time_avg = profiler.get("run") / num_measurement_iterations
+    return inference_time_avg, trisc1_kernel_duration, output_t
+
+
+def compute_utilization(
+    m, k, n, tile_h, tile_w, math_fidelity, inference_time_avg, trisc1_kernel_duration, grid_size, compute_grid_size
+):
+    """Compute all utilization metrics. Returns a dict."""
+    cycle_per_tile = FIDELITY_CYCLES[math_fidelity]
+    device_freq = get_device_frequency()
+    num_cores_user_grid = grid_size[0] * grid_size[1]
+    num_cores_full_grid = compute_grid_size.x * compute_grid_size.y
+
+    ideal_cycle_full_grid = m * k * n / tile_h / tile_w / 32 * cycle_per_tile / num_cores_full_grid
+    ideal_cycle_user_grid = m * k * n / tile_h / tile_w / 32 * cycle_per_tile / num_cores_user_grid
+    inference_cycle = inference_time_avg * device_freq * 1e6
+
+    tflops = 2 * m * k * n / 1e12 / inference_time_avg
+    utilization_full_grid = ideal_cycle_full_grid / inference_cycle
+    utilization_user_grid = ideal_cycle_user_grid / inference_cycle
+
+    result = {
+        "tflops": tflops,
+        "inference_time_avg": inference_time_avg,
+        "utilization_user_grid": utilization_user_grid,
+        "utilization_full_grid": utilization_full_grid,
+    }
+
+    if trisc1_kernel_duration is not None:
+        result["utilization_user_grid_device"] = ideal_cycle_user_grid / np.mean(trisc1_kernel_duration)
+        result["utilization_full_grid_device"] = ideal_cycle_full_grid / np.mean(trisc1_kernel_duration)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Shape and configuration data
+# ---------------------------------------------------------------------------
+
+# Base shapes before grid scaling: (m, k, n)
+matmul_shapes = [
+    (64, 64, 64),
+    (64, 128, 128),
+    (64, 128, 256),
+    (128, 128, 128),
+    (128, 128, 256),
+    (128, 256, 256),
+    (256, 256, 256),
+    (256, 256, 384),
+    (256, 384, 384),
+    (384, 384, 384),
+    (384, 384, 512),
+    (384, 512, 512),
+    (512, 512, 512),
+    (1024, 1024, 1024),
+    (2048, 2048, 2048),
 ]
 
-matmul_shapes_bfloat8_b = [
-    (64, 64, 64, True, True, 1, 1, 1),
-    (64, 128, 128, True, True, 1, 1, 1),
-    (64, 128, 256, True, True, 1, 1, 1),
-    (128, 128, 128, True, True, 1, 1, 1),
-    (128, 128, 256, True, True, 1, 1, 1),
-    (128, 256, 256, True, True, 1, 1, 1),
-    (256, 256, 256, True, True, 1, 1, 1),
-    (256, 256, 384, True, True, 1, 1, 1),
-    (256, 384, 384, True, True, 1, 1, 1),
-    (384, 384, 384, True, True, 2, 1, 1),
-    (64, 64, 64, False, False, 1, 1, 1),
-    (64, 128, 128, False, False, 1, 1, 1),
-    (64, 128, 256, False, False, 1, 1, 1),
-    (128, 128, 128, False, False, 1, 1, 1),
-    (128, 128, 256, False, False, 1, 1, 1),
-    (128, 256, 256, False, False, 1, 1, 1),
-    (256, 256, 256, False, False, 1, 1, 1),
-    (256, 256, 384, False, False, 1, 1, 1),
-    (256, 384, 384, False, False, 1, 1, 1),
-    (384, 384, 384, False, False, 2, 1, 1),
-    # (384, 384, 512, True, True, 2, 1, 1),
-    # (416, 320, 320, False, False, 1, 1, 1),
-    # (512, 512, 512, False, False, 1, 2, 2),
-    # (1024, 1024, 1024, False, False, 2, 4, 4),
-    # (2048, 2048, 2048, False, False, 4, 8, 8),
-]
+# Per-dtype overrides for tuning params: (in0_block_w_div, num_out_blocks_h, num_out_blocks_w)
+# Default is (1, 1, 1) for shapes not listed here.
+tuning_overrides = {
+    ttnn.bfloat16: {
+        (256, 384, 384): (2, 1, 1),
+        (384, 384, 384): (4, 1, 1),
+        (384, 384, 512): (2, 1, 1),
+        (384, 512, 512): (2, 1, 1),
+        (512, 512, 512): (1, 2, 2),
+        (1024, 1024, 1024): (2, 4, 4),
+        (2048, 2048, 2048): (4, 8, 8),
+    },
+    ttnn.bfloat8_b: {
+        (384, 384, 384): (2, 1, 1),
+        (384, 384, 512): (2, 1, 1),
+        (512, 512, 512): (1, 2, 2),
+        (1024, 1024, 1024): (2, 4, 4),
+        (2048, 2048, 2048): (4, 8, 8),
+    },
+    ttnn.bfloat4_b: {
+        (384, 384, 512): (1, 1, 1),
+        (384, 512, 512): (2, 1, 1),
+        (512, 512, 512): (2, 1, 1),
+        (1024, 1024, 1024): (2, 2, 2),
+        (2048, 2048, 2048): (4, 4, 4),
+    },
+}
 
-matmul_shapes_bfloat4_b = [
-    (64, 64, 64, True, True, 1, 1, 1),
-    (64, 128, 128, True, True, 1, 1, 1),
-    (64, 128, 256, True, True, 1, 1, 1),
-    (128, 128, 128, True, True, 1, 1, 1),
-    (128, 128, 256, True, True, 1, 1, 1),
-    (128, 256, 256, True, True, 1, 1, 1),
-    (256, 256, 256, True, True, 1, 1, 1),
-    (256, 256, 384, True, True, 1, 1, 1),
-    (256, 384, 384, True, True, 1, 1, 1),
-    (384, 384, 384, True, True, 1, 1, 1),
-    (64, 64, 64, False, False, 1, 1, 1),
-    (64, 128, 128, False, False, 1, 1, 1),
-    (64, 128, 256, False, False, 1, 1, 1),
-    (128, 128, 128, False, False, 1, 1, 1),
-    (128, 128, 256, False, False, 1, 1, 1),
-    (128, 256, 256, False, False, 1, 1, 1),
-    (256, 256, 256, False, False, 1, 1, 1),
-    (256, 256, 384, False, False, 1, 1, 1),
-    (256, 384, 384, False, False, 1, 1, 1),
-    (384, 384, 384, False, False, 1, 1, 1),
-    # (384, 384, 512, True, True, 1, 1, 1),
-    # (384, 512, 512, True, True, 2, 1, 1),
-    # (416, 320, 320, False, False, 1, 1, 1),
-    # (512, 512, 512, True, True, 2, 1, 1),
-    # (1024, 1024, 1024, False, False, 2, 2, 2),
-    # (2048, 2048, 2048, False, False, 4, 4, 4),
-]
+# Valid math fidelities per dtype
+dtype_fidelities = {
+    ttnn.bfloat16: [ttnn.MathFidelity.HiFi4, ttnn.MathFidelity.HiFi2],
+    ttnn.bfloat8_b: [ttnn.MathFidelity.HiFi2, ttnn.MathFidelity.LoFi],
+    ttnn.bfloat4_b: [ttnn.MathFidelity.LoFi],
+}
 
-# (dtype, math_fidelity, use_trace)
-matmul_configs = [
-    (ttnn.bfloat16, ttnn.MathFidelity.HiFi2, False),
-    # (ttnn.bfloat16, ttnn.MathFidelity.HiFi4, False),
-    # (ttnn.bfloat8_b, ttnn.MathFidelity.HiFi2, False),
-    # (ttnn.bfloat8_b, ttnn.MathFidelity.LoFi, False),
-    # (ttnn.bfloat4_b, ttnn.MathFidelity.LoFi, False),
-    (ttnn.bfloat16, ttnn.MathFidelity.HiFi2, True),
-    # (ttnn.bfloat16, ttnn.MathFidelity.HiFi4, True),
-    # (ttnn.bfloat8_b, ttnn.MathFidelity.HiFi2, True),
-    # (ttnn.bfloat8_b, ttnn.MathFidelity.LoFi, True),
-    # (ttnn.bfloat4_b, ttnn.MathFidelity.LoFi, True),
-]
+# Benchmark modes
+#   oob: auto-selected program config (DRAM inputs, no explicit program_config)
+#   tuned_2d_l1: explicit 2D multicast program config with L1-sharded in0 and output
+#   tuned_2d_dram: explicit 2D multicast program config with DRAM-interleaved in0 and output
+matmul_modes = ["oob", "tuned_2d_l1", "tuned_2d_dram"]
+
+
+def get_tuning_params(dtype, shape):
+    """Get (in0_block_w_div, num_out_blocks_h, num_out_blocks_w) for a given dtype and shape."""
+    overrides = tuning_overrides.get(dtype, {})
+    return overrides.get(shape, (1, 1, 1))
+
+
+# ---------------------------------------------------------------------------
+# Main benchmark test
+# ---------------------------------------------------------------------------
 
 
 # @pytest.mark.skip(reason="Benchmark is not intended to be run as part of CI and can be manually run locally")
@@ -245,7 +316,7 @@ matmul_configs = [
 @pytest.mark.parametrize("tile_h", [32])
 @pytest.mark.parametrize("tile_w", [32])
 @pytest.mark.parametrize("num_warmup_iterations", [5])
-@pytest.mark.parametrize("num_measurement_iterations", [25])
+@pytest.mark.parametrize("num_measurement_iterations", [20])
 def test_matmul_2d_host_perf(
     device,
     grid_size,
@@ -257,7 +328,7 @@ def test_matmul_2d_host_perf(
     ENVS = dict(os.environ)
     TT_METAL_HOME = Path(ENVS["TT_METAL_HOME"])
     ARTIFACTS_DIR = TT_METAL_HOME / "generated"
-    FILE_NAME = ARTIFACTS_DIR / "matmul_2d_host_perf_report.csv"
+    FILE_NAME = ARTIFACTS_DIR / "matmul_benchmark_report.csv"
 
     # Calculate device utilization only when profiler build is enabled.
     # If profiler build is enabled, kernel execution time is available in profiler log by default.
@@ -274,17 +345,13 @@ def test_matmul_2d_host_perf(
             f"Skipping test as requested compute grid size {grid_size} exceeds available compute grid {compute_grid_size}"
         )
 
-    LoFi_cycle = 16
-    HiFi2_cycle = LoFi_cycle * 2
-    HiFi3_cycle = LoFi_cycle * 3
-    HiFi4_cycle = LoFi_cycle * 4
-
     with open(FILE_NAME, mode="w", newline="") as file:
         writer = csv.writer(file)
         header = [
             "m",
             "k",
             "n",
+            "mode",
             "use_trace",
             "grid_size",
             "in0_sharded",
@@ -308,464 +375,205 @@ def test_matmul_2d_host_perf(
             )
         writer.writerow(header)
 
-        for dtype, math_fidelity, use_trace in matmul_configs:
-            if dtype == ttnn.bfloat16:
-                matmul_shapes = matmul_shapes_bfloat16
-            elif dtype == ttnn.bfloat8_b:
-                matmul_shapes = matmul_shapes_bfloat8_b
-            elif dtype == ttnn.bfloat4_b:
-                matmul_shapes = matmul_shapes_bfloat4_b
-            for m, k, n, in0_sharded, out_sharded, in0_block_w_div, num_out_blocks_h, num_out_blocks_w in matmul_shapes:
-                profiler.clear()
+        for mode in matmul_modes:
+            for use_trace in [False, True]:
+                for dtype, fidelities in dtype_fidelities.items():
+                    for base_m, base_k, base_n in matmul_shapes:
+                        for math_fidelity in fidelities:
+                            profiler.clear()
 
-                # Scale the input shapes by the grid size
-                m = m * grid_size[1]
-                k = k * grid_size[0]
-                n = n * grid_size[0]
+                            m = base_m * grid_size[1]
+                            k = base_k * grid_size[0]
+                            n = base_n * grid_size[0]
 
-                in0_shape = [1, 1, m, k]
-                in1_shape = [1, 1, k, n]
+                            in0_block_w_div, num_out_blocks_h, num_out_blocks_w = get_tuning_params(
+                                dtype, (base_m, base_k, base_n)
+                            )
 
-                in0_block_w = k // grid_size[0] // 32 // in0_block_w_div
-                per_core_M = m // grid_size[1] // tile_h
-                per_core_N = n // grid_size[0] // tile_w
-                out_block_h = per_core_M // num_out_blocks_h
-                out_block_w = per_core_N // num_out_blocks_w
-                out_subblock_h, out_subblock_w = get_subblock_sizes(out_block_h, out_block_w, out_sharded)
+                            in0_sharded = mode == "tuned_2d_l1"
+                            out_sharded = mode == "tuned_2d_l1"
 
-                logger.info(f"M*K*N = {m}*{k}*{n} out_subblock_h: {out_subblock_h}, out_subblock_w: {out_subblock_w}")
+                            try:
+                                # --- Prepare inputs ---
+                                in0 = torch.ones([1, 1, m, k]).bfloat16()
+                                in1 = torch.randn([1, 1, k, n]).bfloat16()
 
-                in0 = torch.ones(in0_shape).bfloat16()
-                in1 = torch.randn(in1_shape).bfloat16()
+                                if in0_sharded:
+                                    in0_memory_config = ttnn.create_sharded_memory_config(
+                                        (1, 1, m, k),
+                                        core_grid=ttnn.CoreGrid(y=grid_size[1], x=grid_size[0]),
+                                        strategy=ttnn.ShardStrategy.BLOCK,
+                                        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+                                    )
+                                else:
+                                    in0_memory_config = ttnn.DRAM_MEMORY_CONFIG
 
-                if in0_sharded:
-                    in0_storage_type = "L1"
-                else:
-                    in0_storage_type = "DRAM"
+                                in0_t = ttnn.from_torch(
+                                    in0,
+                                    tile=ttnn.Tile((tile_h, 32)),
+                                    dtype=dtype,
+                                    layout=ttnn.TILE_LAYOUT,
+                                    device=device,
+                                    memory_config=in0_memory_config,
+                                )
+                                in1_t = ttnn.from_torch(
+                                    in1,
+                                    tile=ttnn.Tile((32, tile_w)),
+                                    dtype=dtype,
+                                    layout=ttnn.TILE_LAYOUT,
+                                    device=device,
+                                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                                )
 
-                in1_storage_type = "DRAM"
+                                # --- Build matmul callable ---
+                                compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+                                    math_fidelity=math_fidelity,
+                                    math_approx_mode=True,
+                                    fp32_dest_acc_en=False,
+                                    packer_l1_acc=True,
+                                    throttle_level=ttnn.ThrottleLevel.NO_THROTTLE,
+                                )
 
-                if out_sharded:
-                    out_storage_type = "L1"
-                else:
-                    out_storage_type = "DRAM"
+                                if mode == "oob":
 
-                if in0_sharded:
-                    in0_memory_config = ttnn.create_sharded_memory_config(
-                        (1, 1, m, k),
-                        core_grid=ttnn.CoreGrid(y=grid_size[1], x=grid_size[0]),
-                        strategy=ttnn.ShardStrategy.BLOCK,
-                        orientation=ttnn.ShardOrientation.ROW_MAJOR,
-                    )
-                else:
-                    in0_memory_config = ttnn.DRAM_MEMORY_CONFIG
-                in0_t = ttnn.from_torch(
-                    in0,
-                    tile=ttnn.Tile((tile_h, 32)),
-                    dtype=dtype,
-                    layout=ttnn.TILE_LAYOUT,
-                    device=device,
-                    memory_config=in0_memory_config,
-                )
+                                    def matmul_fn(a, b):
+                                        return ttnn.matmul(a, b, compute_kernel_config=compute_kernel_config)
 
-                in1_t = ttnn.from_torch(
-                    in1,
-                    tile=ttnn.Tile((32, tile_w)),
-                    dtype=dtype,
-                    layout=ttnn.TILE_LAYOUT,
-                    device=device,
-                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                )
+                                else:
+                                    in0_block_w = k // grid_size[0] // 32 // in0_block_w_div
+                                    per_core_M = m // grid_size[1] // tile_h
+                                    per_core_N = n // grid_size[0] // tile_w
+                                    out_block_h = per_core_M // num_out_blocks_h
+                                    out_block_w = per_core_N // num_out_blocks_w
+                                    out_subblock_h, out_subblock_w = get_subblock_sizes(
+                                        out_block_h, out_block_w, out_sharded
+                                    )
 
-                program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
-                    compute_with_storage_grid_size=grid_size,
-                    in0_block_w=in0_block_w,
-                    out_subblock_h=out_subblock_h,
-                    out_subblock_w=out_subblock_w,
-                    out_block_h=out_block_h,
-                    out_block_w=out_block_w,
-                    per_core_M=per_core_M,
-                    per_core_N=per_core_N,
-                    transpose_mcast=False,
-                    fused_activation=None,
-                )
+                                    program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                                        compute_with_storage_grid_size=grid_size,
+                                        in0_block_w=in0_block_w,
+                                        out_subblock_h=out_subblock_h,
+                                        out_subblock_w=out_subblock_w,
+                                        out_block_h=out_block_h,
+                                        out_block_w=out_block_w,
+                                        per_core_M=per_core_M,
+                                        per_core_N=per_core_N,
+                                        transpose_mcast=False,
+                                        fused_activation=None,
+                                    )
 
-                compute_kernel_config = ttnn.WormholeComputeKernelConfig(
-                    math_fidelity=math_fidelity,
-                    math_approx_mode=True,
-                    fp32_dest_acc_en=False,
-                    packer_l1_acc=True,
-                    throttle_level=ttnn.ThrottleLevel.NO_THROTTLE,
-                )
+                                    if out_sharded:
+                                        out_mem_config = ttnn.MemoryConfig(
+                                            memory_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+                                            buffer_type=ttnn.BufferType.L1,
+                                        )
+                                        output_tile = (
+                                            ttnn.Tile([tile_h, 32]) if tile_h <= 16 else ttnn.Tile([tile_h, tile_w])
+                                        )
+                                    else:
+                                        out_mem_config = ttnn.DRAM_MEMORY_CONFIG
+                                        output_tile = ttnn.Tile([tile_h, tile_w])
 
-                if out_sharded:
-                    out_mem_config = ttnn.MemoryConfig(
-                        memory_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
-                        buffer_type=ttnn.BufferType.L1,
-                    )
-                else:
-                    out_mem_config = ttnn.DRAM_MEMORY_CONFIG
+                                    def matmul_fn(a, b):
+                                        return ttnn.matmul(
+                                            a,
+                                            b,
+                                            program_config=program_config,
+                                            memory_config=out_mem_config,
+                                            dtype=dtype,
+                                            compute_kernel_config=compute_kernel_config,
+                                            output_tile=output_tile,
+                                        )
 
-                if out_sharded:
-                    output_tile = ttnn.Tile([tile_h, 32]) if tile_h <= 16 else ttnn.Tile([tile_h, tile_w])
-                else:
-                    output_tile = ttnn.Tile([tile_h, tile_w])
+                                # --- Measure ---
+                                inference_time_avg, trisc1_dur, output_t = run_matmul_measurement(
+                                    device,
+                                    in0_t,
+                                    in1_t,
+                                    matmul_fn,
+                                    use_trace,
+                                    num_warmup_iterations,
+                                    num_measurement_iterations,
+                                    calc_device_utilization,
+                                )
 
-                output_t = ttnn.matmul(
-                    in0_t,
-                    in1_t,
-                    program_config=program_config,
-                    memory_config=out_mem_config,
-                    dtype=dtype,
-                    compute_kernel_config=compute_kernel_config,
-                    output_tile=output_tile,
-                )
+                                # --- Compute utilization ---
+                                metrics = compute_utilization(
+                                    m,
+                                    k,
+                                    n,
+                                    tile_h,
+                                    tile_w,
+                                    math_fidelity,
+                                    inference_time_avg,
+                                    trisc1_dur,
+                                    grid_size,
+                                    compute_grid_size,
+                                )
 
-                for iter in range(0, num_warmup_iterations):
-                    output_t = ttnn.matmul(
-                        in0_t,
-                        in1_t,
-                        program_config=program_config,
-                        memory_config=out_mem_config,
-                        dtype=dtype,
-                        compute_kernel_config=compute_kernel_config,
-                        output_tile=output_tile,
-                    )
+                                device_util_str = ""
+                                if "utilization_user_grid_device" in metrics:
+                                    device_util_str = (
+                                        f", device util (user grid {grid_size[0]}x{grid_size[1]}): "
+                                        f"{metrics['utilization_user_grid_device']*100:.2f}%, "
+                                        f"device util (full grid {compute_grid_size.x}x{compute_grid_size.y}): "
+                                        f"{metrics['utilization_full_grid_device']*100:.2f}%"
+                                    )
+                                logger.info(
+                                    f"[{mode}] {dtype} {math_fidelity} trace={use_trace} "
+                                    f"M*K*N={m}*{k}*{n} — "
+                                    f"inference time (avg): {inference_time_avg:.9f}, "
+                                    f"tflops (avg): {metrics['tflops']:.2f}, "
+                                    f"utilization (vs user selected grid {grid_size[0]}x{grid_size[1]}): "
+                                    f"{metrics['utilization_user_grid']*100:.2f}%, "
+                                    f"utilization (vs full available grid {compute_grid_size.x}x{compute_grid_size.y}): "
+                                    f"{metrics['utilization_full_grid']*100:.2f}%"
+                                    f"{device_util_str}"
+                                )
 
-                if calc_device_utilization:
-                    # Clear profiler log and read profiler data after warmup iterations
-                    ttnn.ReadDeviceProfiler(device)
-                    rm(profiler_log_path)
+                                # --- Cleanup and write CSV ---
+                                ttnn.to_torch(output_t)
+                                ttnn.deallocate(output_t)
+                                ttnn.deallocate(in0_t)
+                                ttnn.deallocate(in1_t)
 
-                # Synchronize device to ensure all warmup iterations are completed and device is in clean state
-                ttnn.synchronize_device(device)
+                                in0_storage_type = "L1" if in0_sharded else "DRAM"
+                                out_storage_type = "L1" if out_sharded else "DRAM"
 
-                if use_trace:
-                    tid = ttnn.begin_trace_capture(device, cq_id=0)
-                    for iter in range(0, num_measurement_iterations):
-                        output_t = ttnn.matmul(
-                            in0_t,
-                            in1_t,
-                            program_config=program_config,
-                            memory_config=out_mem_config,
-                            dtype=dtype,
-                            compute_kernel_config=compute_kernel_config,
-                            output_tile=output_tile,
-                        )
-                    ttnn.end_trace_capture(device, tid, cq_id=0)
-                    profiler.start(f"run")
-                    ttnn.execute_trace(device, tid, cq_id=0, blocking=False)
-                    ttnn.synchronize_device(device)
-                    profiler.end(f"run")
-                    ttnn.release_trace(device, tid)
-                else:
-                    profiler.start(f"run")
-                    for iter in range(0, num_measurement_iterations):
-                        output_t = ttnn.matmul(
-                            in0_t,
-                            in1_t,
-                            program_config=program_config,
-                            memory_config=out_mem_config,
-                            dtype=dtype,
-                            compute_kernel_config=compute_kernel_config,
-                            output_tile=output_tile,
-                        )
-                    ttnn.synchronize_device(device)
-                    profiler.end(f"run")
+                                csv_data = [
+                                    m,
+                                    k,
+                                    n,
+                                    mode,
+                                    f"{use_trace}",
+                                    grid_size,
+                                    in0_sharded,
+                                    out_sharded,
+                                    in0_storage_type,
+                                    "DRAM",
+                                    out_storage_type,
+                                    dtype,
+                                    math_fidelity,
+                                    f"{inference_time_avg * 1e9:.2f}",
+                                    f"{metrics['tflops']:.2f}",
+                                    f"{metrics['utilization_user_grid'] * 100:.2f}",
+                                    f"{metrics['utilization_full_grid'] * 100:.2f}",
+                                ]
+                                if calc_device_utilization:
+                                    csv_data.extend(
+                                        [
+                                            f"{metrics['utilization_user_grid_device'] * 100:.2f}",
+                                            f"{metrics['utilization_full_grid_device'] * 100:.2f}",
+                                        ]
+                                    )
+                                writer.writerow(csv_data)
+                                file.flush()
 
-                if calc_device_utilization:
-                    # Read profiler log data
-                    ttnn.ReadDeviceProfiler(device)
-                    profiler_data = get_profiler_data()
-                    trisc1_kernel_duration = profiler_data["trisc1_kernel_duration"]
-
-                # Read device frequency
-                device_freq = get_device_frequency()
-
-                inference_time_avg = profiler.get("run") / num_measurement_iterations
-                tflops = 2 * m * k * n / 1e12 / inference_time_avg
-                if math_fidelity == ttnn.MathFidelity.LoFi:
-                    cycle_per_tile = LoFi_cycle
-                elif math_fidelity == ttnn.MathFidelity.HiFi2:
-                    cycle_per_tile = HiFi2_cycle
-                elif math_fidelity == ttnn.MathFidelity.HiFi3:
-                    cycle_per_tile = HiFi3_cycle
-                elif math_fidelity == ttnn.MathFidelity.HiFi4:
-                    cycle_per_tile = HiFi4_cycle
-                num_cores_user_grid = grid_size[0] * grid_size[1]
-                num_cores_full_grid = compute_grid_size.x * compute_grid_size.y
-                ideal_cycle_full_grid = m * k * n / tile_h / tile_w / 32 * cycle_per_tile / num_cores_full_grid
-                ideal_cycle_user_grid = m * k * n / tile_h / tile_w / 32 * cycle_per_tile / num_cores_user_grid
-                inference_cycle = inference_time_avg * device_freq * 1e6
-                utilization_full_grid = ideal_cycle_full_grid / inference_cycle
-                utilization_user_grid = ideal_cycle_user_grid / inference_cycle
-                if calc_device_utilization:
-                    # Calculate device utilization based on TRISC1 kernel duration
-                    utilization_full_grid_device = ideal_cycle_full_grid / np.mean(trisc1_kernel_duration)
-                    utilization_user_grid_device = ideal_cycle_user_grid / np.mean(trisc1_kernel_duration)
-
-                logger.info(
-                    f"M*K*N = {m}*{k}*{n} == inference time (avg): {inference_time_avg}, tflops (avg): {tflops}, utilization (vs user selected grid {grid_size[0]}x{grid_size[1]}): {utilization_user_grid * 100:.2f}%, utilization (vs full available grid {compute_grid_size.x}x{compute_grid_size.y}): {utilization_full_grid * 100:.2f}%"
-                )
-
-                output_tensor = ttnn.to_torch(output_t)
-                ttnn.deallocate(output_t)
-                ttnn.deallocate(in0_t)
-                ttnn.deallocate(in1_t)
-                csv_data = [
-                    m,
-                    k,
-                    n,
-                    f"{True}" if use_trace else f"{False}",
-                    grid_size,
-                    in0_sharded,
-                    out_sharded,
-                    in0_storage_type,
-                    in1_storage_type,
-                    out_storage_type,
-                    dtype,
-                    math_fidelity,
-                    f"{inference_time_avg * 1e9:.2f}",
-                    f"{tflops:.2f}",
-                    f"{utilization_user_grid * 100:.2f}",
-                    f"{utilization_full_grid * 100:.2f}",
-                ]
-                if calc_device_utilization:
-                    csv_data.extend(
-                        [
-                            f"{utilization_user_grid_device * 100:.2f}",
-                            f"{utilization_full_grid_device * 100:.2f}",
-                        ]
-                    )
-                writer.writerow(csv_data)
-                file.flush()
-
-
-matmul_shapes_oob = [
-    (64, 64, 64),
-    (64, 128, 128),
-    (64, 128, 256),
-    (128, 128, 128),
-    (128, 128, 256),
-    (128, 256, 256),
-    (256, 256, 256),
-    (256, 256, 384),
-    (256, 384, 384),
-    (384, 384, 384),
-    # (384, 384, 512),
-    # (384, 512, 512),
-    # (512, 512, 512),
-]
-
-matmul_configs_oob = [
-    (ttnn.bfloat16, False),
-    (ttnn.bfloat16, True),
-    # (ttnn.bfloat8_b, False),
-    # (ttnn.bfloat8_b, True),
-    # (ttnn.bfloat4_b, False),
-    # (ttnn.bfloat4_b, True),
-]
-
-
-# @pytest.mark.skip(reason="Benchmark is not intended to be run as part of CI and can be manually run locally")
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576, "trace_region_size": 3855488}], indirect=True)
-@pytest.mark.parametrize("tile_h", [32])
-@pytest.mark.parametrize("tile_w", [32])
-@pytest.mark.parametrize("num_warmup_iterations", [5])
-@pytest.mark.parametrize("num_measurement_iterations", [25])
-def test_matmul_2d_host_perf_out_of_box(
-    device,
-    grid_size,
-    tile_h,
-    tile_w,
-    num_warmup_iterations,
-    num_measurement_iterations,
-):
-    ENVS = dict(os.environ)
-    TT_METAL_HOME = Path(ENVS["TT_METAL_HOME"])
-    ARTIFACTS_DIR = TT_METAL_HOME / "generated"
-    FILE_NAME = ARTIFACTS_DIR / "matmul_2d_host_perf_out_of_box_report.csv"
-
-    # Calculate device utilization only when profiler build is enabled.
-    # If profiler build is enabled, kernel execution time is available in profiler log by default.
-    calc_device_utilization = get_profiler_build_enabled()
-
-    # Get maximum available grid size for compute from device
-    compute_grid_size = device.compute_with_storage_grid_size()
-    # If user did not specify grid size, use maximum available grid size for compute
-    if grid_size is None:
-        grid_size = (compute_grid_size.x, compute_grid_size.y)
-    # Check if requested grid size is within available compute grid size, skip test if not
-    if compute_grid_size.y < grid_size[1] or compute_grid_size.x < grid_size[0]:
-        pytest.skip(
-            f"Skipping test as requested compute grid size {grid_size} exceeds available compute grid {compute_grid_size}"
-        )
-
-    LoFi_cycle = 16
-    HiFi2_cycle = LoFi_cycle * 2
-    HiFi3_cycle = LoFi_cycle * 3
-    HiFi4_cycle = LoFi_cycle * 4
-
-    with open(FILE_NAME, mode="w", newline="") as file:
-        writer = csv.writer(file)
-        header = [
-            "m",
-            "k",
-            "n",
-            "use_trace",
-            "grid_size",
-            "in0_storage_type",
-            "in1_storage_type",
-            "out_storage_type",
-            "dtype",
-            "math_fidelity",
-            "inference_time_avg [ns]",
-            "TFLOPs (avg)",
-            f"Host based utilization[%] (vs user selected grid {grid_size[0]}x{grid_size[1]})",
-            f"Host based utilization[%] (vs full available grid {compute_grid_size.x}x{compute_grid_size.y})",
-        ]
-        if calc_device_utilization:
-            header.extend(
-                [
-                    f"Device based utilization[%] (vs user selected grid {grid_size[0]}x{grid_size[1]})",
-                    f"Device based utilization[%] (vs full available grid {compute_grid_size.x}x{compute_grid_size.y})",
-                ]
-            )
-        writer.writerow(header)
-
-        for dtype, use_trace in matmul_configs_oob:
-            matmul_shapes = matmul_shapes_oob
-            if dtype == ttnn.bfloat16:
-                math_fidelity = ttnn.MathFidelity.HiFi2
-            elif dtype == ttnn.bfloat8_b:
-                math_fidelity = ttnn.MathFidelity.LoFi
-            elif dtype == ttnn.bfloat4_b:
-                math_fidelity = ttnn.MathFidelity.LoFi
-            for m, k, n in matmul_shapes:
-                profiler.clear()
-
-                # Scale the input shapes by the grid size
-                m = m * grid_size[1]
-                k = k * grid_size[0]
-                n = n * grid_size[0]
-
-                in0_shape = [1, 1, m, k]
-                in1_shape = [1, 1, k, n]
-
-                in0 = torch.ones(in0_shape).bfloat16()
-                in1 = torch.randn(in1_shape).bfloat16()
-
-                in0_storage_type = "DRAM"
-                in1_storage_type = "DRAM"
-                out_storage_type = "DRAM"
-
-                in0_t = ttnn.from_torch(
-                    in0,
-                    tile=ttnn.Tile((tile_h, 32)),
-                    dtype=dtype,
-                    layout=ttnn.TILE_LAYOUT,
-                    device=device,
-                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                )
-                in1_t = ttnn.from_torch(
-                    in1,
-                    tile=ttnn.Tile((32, tile_w)),
-                    dtype=dtype,
-                    layout=ttnn.TILE_LAYOUT,
-                    device=device,
-                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                )
-
-                output_t = in0_t @ in1_t
-
-                for iter in range(0, num_warmup_iterations):
-                    output_t = in0_t @ in1_t
-
-                if calc_device_utilization:
-                    # Clear profiler log and read profiler data after warmup iterations
-                    ttnn.ReadDeviceProfiler(device)
-                    rm(profiler_log_path)
-
-                # Synchronize device to ensure all warmup iterations are completed and device is in clean state
-                ttnn.synchronize_device(device)
-
-                if use_trace:
-                    tid = ttnn.begin_trace_capture(device, cq_id=0)
-                    for iter in range(0, num_measurement_iterations):
-                        output_t = in0_t @ in1_t
-                    ttnn.end_trace_capture(device, tid, cq_id=0)
-                    profiler.start(f"run")
-                    ttnn.execute_trace(device, tid, cq_id=0, blocking=False)
-                    ttnn.synchronize_device(device)
-                    profiler.end(f"run")
-                    ttnn.release_trace(device, tid)
-                else:
-                    profiler.start(f"run")
-                    for iter in range(0, num_measurement_iterations):
-                        output_t = in0_t @ in1_t
-                    ttnn.synchronize_device(device)
-                    profiler.end(f"run")
-
-                if calc_device_utilization:
-                    # Read profiler log data
-                    ttnn.ReadDeviceProfiler(device)
-                    profiler_data = get_profiler_data()
-                    trisc1_kernel_duration = profiler_data["trisc1_kernel_duration"]
-
-                # Read device frequency
-                device_freq = get_device_frequency()
-
-                inference_time_avg = profiler.get("run") / num_measurement_iterations
-                tflops = 2 * m * k * n / 1e12 / inference_time_avg
-                if math_fidelity == ttnn.MathFidelity.LoFi:
-                    cycle_per_tile = LoFi_cycle
-                elif math_fidelity == ttnn.MathFidelity.HiFi2:
-                    cycle_per_tile = HiFi2_cycle
-                elif math_fidelity == ttnn.MathFidelity.HiFi3:
-                    cycle_per_tile = HiFi3_cycle
-                elif math_fidelity == ttnn.MathFidelity.HiFi4:
-                    cycle_per_tile = HiFi4_cycle
-                num_cores_user_grid = grid_size[0] * grid_size[1]
-                num_cores_full_grid = compute_grid_size.x * compute_grid_size.y
-                ideal_cycle_full_grid = m * k * n / tile_h / tile_w / 32 * cycle_per_tile / num_cores_full_grid
-                ideal_cycle_user_grid = m * k * n / tile_h / tile_w / 32 * cycle_per_tile / num_cores_user_grid
-                inference_cycle = inference_time_avg * device_freq * 1e6
-                utilization_full_grid = ideal_cycle_full_grid / inference_cycle
-                utilization_user_grid = ideal_cycle_user_grid / inference_cycle
-                if calc_device_utilization:
-                    # Calculate device utilization based on TRISC1 kernel duration
-                    utilization_full_grid_device = ideal_cycle_full_grid / np.mean(trisc1_kernel_duration)
-                    utilization_user_grid_device = ideal_cycle_user_grid / np.mean(trisc1_kernel_duration)
-                logger.info(
-                    f"M*K*N = {m}*{k}*{n} == inference time (avg): {inference_time_avg}, tflops (avg): {tflops}, utilization (vs user selected grid {grid_size[0]}x{grid_size[1]}): {utilization_user_grid * 100:.2f}%, utilization (vs full available grid {compute_grid_size.x}x{compute_grid_size.y}): {utilization_full_grid * 100:.2f}%"
-                )
-
-                output_tensor = ttnn.to_torch(output_t)
-                ttnn.deallocate(output_t)
-                ttnn.deallocate(in0_t)
-                ttnn.deallocate(in1_t)
-                csv_data = [
-                    m,
-                    k,
-                    n,
-                    f"{True}" if use_trace else f"{False}",
-                    grid_size,
-                    in0_storage_type,
-                    in1_storage_type,
-                    out_storage_type,
-                    dtype,
-                    math_fidelity,
-                    f"{inference_time_avg * 1e9:.2f}",
-                    f"{tflops:.2f}",
-                    f"{utilization_user_grid * 100:.2f}",
-                    f"{utilization_full_grid * 100:.2f}",
-                ]
-                if calc_device_utilization:
-                    csv_data.extend(
-                        [
-                            f"{utilization_user_grid_device * 100:.2f}",
-                            f"{utilization_full_grid_device * 100:.2f}",
-                        ]
-                    )
-                writer.writerow(csv_data)
-                file.flush()
+                            except RuntimeError as e:
+                                if "L1" in str(e) or "out of memory" in str(e).lower():
+                                    logger.warning(
+                                        f"Skipping [{mode}] {dtype} {math_fidelity} "
+                                        f"({base_m},{base_k},{base_n}) — L1 exceeded: {e}"
+                                    )
+                                    continue
+                                raise

--- a/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
+++ b/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
@@ -252,18 +252,37 @@ matmul_shapes = [
     (256, 384, 384),
     (384, 384, 384),
     (384, 384, 512),
+    (416, 320, 320),  # P150 square: 4160x4160x4160
     (384, 512, 512),
     (512, 512, 512),
     (1024, 1024, 1024),
     (2048, 2048, 2048),
 ]
 
-# Per-dtype overrides for tuning params: (in0_block_w_div, num_out_blocks_h, num_out_blocks_w)
+# Per-dtype, per-mode overrides for tuning params: (in0_block_w_div, num_out_blocks_h, num_out_blocks_w)
 # Default is (1, 1, 1) for shapes not listed here.
-tuning_overrides = {
+#
+# L1-sharded output (tuned_2d_l1) must satisfy matmul validation:
+#   out_block_w == per_core_N or out_block_h == 1
+# so only one of num_out_blocks_h / num_out_blocks_w may be > 1 (and only when it yields out_block_h == 1).
+# DRAM output (tuned_2d_dram) can use more aggressive multi-block splits to reduce L1 pressure.
+tuning_overrides_l1 = {
     ttnn.bfloat16: {
         (256, 384, 384): (2, 1, 1),
         (384, 384, 384): (4, 1, 1),
+    },
+    ttnn.bfloat8_b: {
+        (384, 384, 384): (2, 1, 1),
+        (384, 384, 512): (2, 1, 1),
+    },
+    ttnn.bfloat4_b: {
+        (384, 512, 512): (2, 1, 1),
+        (512, 512, 512): (2, 1, 1),
+    },
+}
+
+tuning_overrides_dram = {
+    ttnn.bfloat16: {
         (384, 384, 512): (2, 1, 1),
         (384, 512, 512): (2, 1, 1),
         (512, 512, 512): (1, 2, 2),
@@ -271,16 +290,11 @@ tuning_overrides = {
         (2048, 2048, 2048): (4, 8, 8),
     },
     ttnn.bfloat8_b: {
-        (384, 384, 384): (2, 1, 1),
-        (384, 384, 512): (2, 1, 1),
         (512, 512, 512): (1, 2, 2),
         (1024, 1024, 1024): (2, 4, 4),
         (2048, 2048, 2048): (4, 8, 8),
     },
     ttnn.bfloat4_b: {
-        (384, 384, 512): (1, 1, 1),
-        (384, 512, 512): (2, 1, 1),
-        (512, 512, 512): (2, 1, 1),
         (1024, 1024, 1024): (2, 2, 2),
         (2048, 2048, 2048): (4, 4, 4),
     },
@@ -300,9 +314,14 @@ dtype_fidelities = {
 matmul_modes = ["oob", "tuned_2d_l1", "tuned_2d_dram"]
 
 
-def get_tuning_params(dtype, shape):
-    """Get (in0_block_w_div, num_out_blocks_h, num_out_blocks_w) for a given dtype and shape."""
-    overrides = tuning_overrides.get(dtype, {})
+def get_tuning_params(dtype, shape, mode):
+    """Get (in0_block_w_div, num_out_blocks_h, num_out_blocks_w) for a given dtype, shape, and mode."""
+    if mode == "tuned_2d_l1":
+        overrides = tuning_overrides_l1.get(dtype, {})
+    elif mode == "tuned_2d_dram":
+        overrides = tuning_overrides_dram.get(dtype, {})
+    else:
+        return (1, 1, 1)
     return overrides.get(shape, (1, 1, 1))
 
 
@@ -387,7 +406,7 @@ def test_matmul_2d_host_perf(
                             n = base_n * grid_size[0]
 
                             in0_block_w_div, num_out_blocks_h, num_out_blocks_w = get_tuning_params(
-                                dtype, (base_m, base_k, base_n)
+                                dtype, (base_m, base_k, base_n), mode
                             )
 
                             in0_sharded = mode == "tuned_2d_l1"

--- a/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
+++ b/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
@@ -63,6 +63,7 @@ GEMM_FLOPS_BENCHMARK_ENV = "TTNN_RUN_GEMM_FLOPS_BENCHMARK"
 
 
 SKIPPABLE_RUNTIME_ERROR_SUBSTRINGS = (
+    "clash with l1 buffers",
     "does not fit",
     "failed to allocate",
     "insufficient",

--- a/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
+++ b/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
@@ -201,15 +201,28 @@ def run_matmul_measurement(
 
     # Measurement
     if use_trace:
-        tid = ttnn.begin_trace_capture(device, cq_id=0)
-        for _ in range(num_measurement_iterations):
-            output_t = matmul_fn(in0_t, in1_t)
-        ttnn.end_trace_capture(device, tid, cq_id=0)
-        profiler.start("run")
-        ttnn.execute_trace(device, tid, cq_id=0, blocking=False)
-        ttnn.synchronize_device(device)
-        profiler.end("run")
-        ttnn.release_trace(device, tid)
+        tid = None
+        trace_capture_ended = False
+        try:
+            tid = ttnn.begin_trace_capture(device, cq_id=0)
+            for _ in range(num_measurement_iterations):
+                output_t = matmul_fn(in0_t, in1_t)
+            ttnn.end_trace_capture(device, tid, cq_id=0)
+            trace_capture_ended = True
+
+            profiler.start("run")
+            try:
+                ttnn.execute_trace(device, tid, cq_id=0, blocking=False)
+                ttnn.synchronize_device(device)
+            finally:
+                profiler.end("run")
+        finally:
+            if tid is not None:
+                try:
+                    if not trace_capture_ended:
+                        ttnn.end_trace_capture(device, tid, cq_id=0)
+                finally:
+                    ttnn.release_trace(device, tid)
     else:
         profiler.start("run")
         for _ in range(num_measurement_iterations):

--- a/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
+++ b/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
@@ -63,6 +63,7 @@ GEMM_FLOPS_BENCHMARK_ENV = "TTNN_RUN_GEMM_FLOPS_BENCHMARK"
 
 
 SKIPPABLE_RUNTIME_ERROR_SUBSTRINGS = (
+    "beyond max l1 size",
     "clash with l1 buffers",
     "does not fit",
     "failed to allocate",

--- a/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
+++ b/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
@@ -570,10 +570,8 @@ def test_matmul_2d_host_perf(
                                 file.flush()
 
                             except RuntimeError as e:
-                                if "L1" in str(e) or "out of memory" in str(e).lower():
-                                    logger.warning(
-                                        f"Skipping [{mode}] {dtype} {math_fidelity} "
-                                        f"({base_m},{base_k},{base_n}) — L1 exceeded: {e}"
-                                    )
-                                    continue
-                                raise
+                                logger.warning(
+                                    f"Skipping [{mode}] {dtype} {math_fidelity} "
+                                    f"({base_m},{base_k},{base_n}) trace={use_trace} — {e}"
+                                )
+                                continue

--- a/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
+++ b/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
@@ -59,6 +59,21 @@ from tracy.device_post_proc_config import default_setup
 from tracy.process_device_log import import_log_run_stats
 
 profiler_log_path = PROFILER_LOGS_DIR / PROFILER_DEVICE_SIDE_LOG
+GEMM_FLOPS_BENCHMARK_ENV = "TTNN_RUN_GEMM_FLOPS_BENCHMARK"
+
+
+SKIPPABLE_RUNTIME_ERROR_SUBSTRINGS = (
+    "does not fit",
+    "failed to allocate",
+    "insufficient",
+    "invalid",
+    "l1 memory",
+    "not enough l1",
+    "out of memory",
+    "unable to find subblock",
+    "unsupported",
+    "validation",
+)
 
 
 # ---------------------------------------------------------------------------
@@ -144,6 +159,12 @@ def get_profiler_data():
 
 def get_profiler_build_enabled():
     return os.getenv("TT_METAL_DEVICE_PROFILER") is not None
+
+
+def is_skippable_benchmark_runtime_error(error):
+    """Return whether a benchmark config failed because it is not runnable for this shape/device."""
+    message = str(error).lower()
+    return any(substring in message for substring in SKIPPABLE_RUNTIME_ERROR_SUBSTRINGS)
 
 
 # ---------------------------------------------------------------------------
@@ -330,7 +351,10 @@ def get_tuning_params(dtype, shape, mode):
 # ---------------------------------------------------------------------------
 
 
-# @pytest.mark.skip(reason="Benchmark is not intended to be run as part of CI and can be manually run locally")
+@pytest.mark.skipif(
+    os.getenv(GEMM_FLOPS_BENCHMARK_ENV) != "1",
+    reason=f"Benchmark is manual-only; set {GEMM_FLOPS_BENCHMARK_ENV}=1 to run",
+)
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576, "trace_region_size": 3855488}], indirect=True)
 @pytest.mark.parametrize("tile_h", [32])
 @pytest.mark.parametrize("tile_w", [32])
@@ -370,6 +394,9 @@ def test_matmul_2d_host_perf(
             "m",
             "k",
             "n",
+            "base_m",
+            "base_k",
+            "base_n",
             "mode",
             "use_trace",
             "grid_size",
@@ -411,6 +438,9 @@ def test_matmul_2d_host_perf(
 
                             in0_sharded = mode == "tuned_2d_l1"
                             out_sharded = mode == "tuned_2d_l1"
+                            in0_t = None
+                            in1_t = None
+                            output_t = None
 
                             try:
                                 # --- Prepare inputs ---
@@ -552,9 +582,6 @@ def test_matmul_2d_host_perf(
 
                                 # --- Cleanup and write CSV ---
                                 ttnn.to_torch(output_t)
-                                ttnn.deallocate(output_t)
-                                ttnn.deallocate(in0_t)
-                                ttnn.deallocate(in1_t)
 
                                 in0_storage_type = "L1" if in0_sharded else "DRAM"
                                 out_storage_type = "L1" if out_sharded else "DRAM"
@@ -563,6 +590,9 @@ def test_matmul_2d_host_perf(
                                     m,
                                     k,
                                     n,
+                                    base_m,
+                                    base_k,
+                                    base_n,
                                     mode,
                                     f"{use_trace}",
                                     grid_size,
@@ -589,8 +619,14 @@ def test_matmul_2d_host_perf(
                                 file.flush()
 
                             except RuntimeError as e:
+                                if not is_skippable_benchmark_runtime_error(e):
+                                    raise
                                 logger.warning(
                                     f"Skipping [{mode}] {dtype} {math_fidelity} "
                                     f"({base_m},{base_k},{base_n}) trace={use_trace} — {e}"
                                 )
                                 continue
+                            finally:
+                                for tensor in (output_t, in0_t, in1_t):
+                                    if tensor is not None:
+                                        ttnn.deallocate(tensor)

--- a/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
@@ -132,29 +132,51 @@ std::vector<uint32_t> get_multi_dim_per_core_factor(
         }
     }
 
-    // Find what fits, going from largest to smallest m*n. Have k in outer loop to
-    // try to maintain per_core_factor_k.
+    // Find what fits, going from largest to smallest m*n.
+    // When adjust_in0_block_w is true (all-DRAM 2D path), prefer keeping the output
+    // block large and shrinking in0_block_w first — this matches hand-tuned configs
+    // that stream K in smaller chunks rather than chopping out_block.
+    // Otherwise keep k in the outer loop to preserve in0_block_w when possible.
     uint32_t min_per_core_factor_k = adjust_in0_block_w ? 1 : in0_block_w;
-    for (uint32_t per_core_factor_k = in0_block_w; per_core_factor_k >= min_per_core_factor_k; per_core_factor_k--) {
-        if (in0_block_w % per_core_factor_k != 0) {
-            continue;
-        }
+    auto try_config = [&](uint32_t per_core_factor_m, uint32_t per_core_factor_n, uint32_t per_core_factor_k) {
+        return utilities::get_estimated_size_of_cbs(
+                   per_core_factor_m,
+                   per_core_factor_n,
+                   per_core_factor_k,
+                   input_tensor_a,
+                   input_tensor_b,
+                   transpose_a,
+                   transpose_b,
+                   interm_cb_size,
+                   bias_single_tile_size) < max_l1_space;
+    };
+
+    if (adjust_in0_block_w) {
         for (const auto& factor : std::ranges::reverse_view(factors)) {
             uint32_t per_core_factor_m = std::get<0>(factor.second);
             uint32_t per_core_factor_n = std::get<1>(factor.second);
-
-            size = utilities::get_estimated_size_of_cbs(
-                per_core_factor_m,
-                per_core_factor_n,
-                per_core_factor_k,
-                input_tensor_a,
-                input_tensor_b,
-                transpose_a,
-                transpose_b,
-                interm_cb_size,
-                bias_single_tile_size);
-            if (size < max_l1_space) {
-                return {per_core_factor_m, per_core_factor_n, per_core_factor_k};
+            for (uint32_t per_core_factor_k = in0_block_w; per_core_factor_k >= min_per_core_factor_k;
+                 per_core_factor_k--) {
+                if (in0_block_w % per_core_factor_k != 0) {
+                    continue;
+                }
+                if (try_config(per_core_factor_m, per_core_factor_n, per_core_factor_k)) {
+                    return {per_core_factor_m, per_core_factor_n, per_core_factor_k};
+                }
+            }
+        }
+    } else {
+        for (uint32_t per_core_factor_k = in0_block_w; per_core_factor_k >= min_per_core_factor_k;
+             per_core_factor_k--) {
+            if (in0_block_w % per_core_factor_k != 0) {
+                continue;
+            }
+            for (const auto& factor : std::ranges::reverse_view(factors)) {
+                uint32_t per_core_factor_m = std::get<0>(factor.second);
+                uint32_t per_core_factor_n = std::get<1>(factor.second);
+                if (try_config(per_core_factor_m, per_core_factor_n, per_core_factor_k)) {
+                    return {per_core_factor_m, per_core_factor_n, per_core_factor_k};
+                }
             }
         }
     }
@@ -1199,7 +1221,14 @@ MatmulProgramConfig create_simple_matmul_program_config(
             all_dram_interleaved or (core_range.y == 0 and mem_config.is_sharded() and
                                      mem_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED and
                                      not block_sharded_on_1d_column_grid and not block_sharded_on_1d_row_grid);
-        if ((core_range.y == 1 and not a_batch_broadcast) or use_mcast_1d_in0_config) {
+        // For all-DRAM interleaved matmuls, do not treat a provisional single-row/column
+        // block grid (core_range.y/x == 1) as a 1D signal. That heuristic is based on a
+        // fixed per_core_factor (~16) and mis-routes non-narrow shapes such as
+        // 512x1024x1024 onto 1D mcast instead of the preferred 2D path. Narrow shapes
+        // still take 1D via is_wide / is_tall above.
+        const bool single_row_blocks_prefer_1d = core_range.y == 1 and not all_dram_interleaved;
+        const bool single_col_blocks_prefer_1d = core_range.x == 1 and not all_dram_interleaved;
+        if ((single_row_blocks_prefer_1d and not a_batch_broadcast) or use_mcast_1d_in0_config) {
             // Pass user's shard_spec when BLOCK_SHARDED on 1D row grid
             std::optional<tt::tt_metal::ShardSpec> user_shard_spec =
                 (block_sharded_on_1d_row_grid && mem_config.shard_spec().has_value())
@@ -1225,7 +1254,7 @@ MatmulProgramConfig create_simple_matmul_program_config(
                 all_dram_interleaved,
                 user_shard_spec);
         }
-        if (core_range.x == 1 or use_mcast_1d_in1_config) {
+        if (single_col_blocks_prefer_1d or use_mcast_1d_in1_config) {
             // Pass user's shard_spec when BLOCK_SHARDED on 1D column grid
             std::optional<tt::tt_metal::ShardSpec> user_shard_spec =
                 (block_sharded_on_1d_column_grid && mem_config.shard_spec().has_value())

--- a/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
@@ -137,8 +137,10 @@ std::vector<uint32_t> get_multi_dim_per_core_factor(
     // block large and shrinking in0_block_w first — this matches hand-tuned configs
     // that stream K in smaller chunks rather than chopping out_block.
     // Otherwise keep k in the outer loop to preserve in0_block_w when possible.
+    // factors is keyed by per_core_factor_m * per_core_factor_n, so reverse iteration
+    // visits larger output blocks first for maximizing L1 utilization.
     uint32_t min_per_core_factor_k = adjust_in0_block_w ? 1 : in0_block_w;
-    auto try_config = [&](uint32_t per_core_factor_m, uint32_t per_core_factor_n, uint32_t per_core_factor_k) {
+    auto fits_in_l1 = [&](uint32_t per_core_factor_m, uint32_t per_core_factor_n, uint32_t per_core_factor_k) {
         return utilities::get_estimated_size_of_cbs(
                    per_core_factor_m,
                    per_core_factor_n,
@@ -160,7 +162,7 @@ std::vector<uint32_t> get_multi_dim_per_core_factor(
                 if (in0_block_w % per_core_factor_k != 0) {
                     continue;
                 }
-                if (try_config(per_core_factor_m, per_core_factor_n, per_core_factor_k)) {
+                if (fits_in_l1(per_core_factor_m, per_core_factor_n, per_core_factor_k)) {
                     return {per_core_factor_m, per_core_factor_n, per_core_factor_k};
                 }
             }
@@ -174,7 +176,7 @@ std::vector<uint32_t> get_multi_dim_per_core_factor(
             for (const auto& factor : std::ranges::reverse_view(factors)) {
                 uint32_t per_core_factor_m = std::get<0>(factor.second);
                 uint32_t per_core_factor_n = std::get<1>(factor.second);
-                if (try_config(per_core_factor_m, per_core_factor_n, per_core_factor_k)) {
+                if (fits_in_l1(per_core_factor_m, per_core_factor_n, per_core_factor_k)) {
                     return {per_core_factor_m, per_core_factor_n, per_core_factor_k};
                 }
             }


### PR DESCRIPTION
### Issue
Incremental improvements toward #23279.

### Summary
* Updates the GEMM FLOPS benchmark flow so it can compare out-of-box, tuned 2D L1, and tuned 2D DRAM matmul modes across Wormhole and Blackhole data
* Fixes matmul program config selection for all-DRAM interleaved cases that were being mis-routed onto 1D multicast based on provisional single-row/column block grids. This improves OOB matmul perf for some small sizes.
* Adjusts static CB sizing behavior so large tuned GEMM configs can reduce K blocking before shrinking output blocks. This improves OOB matmul perf for larger sizes.
* NOTE: I am NOT updating the images in GEMM_FLOPS.md. It's not really changing anything much except for the 3x1 utilization sub-plot for oob/l1 tuned /dram tuned data instead of a single "stitched" l1/dram tuned utilization one

| Before | After |
| --- | --- |
| <img width="3485" height="4886" alt="image" src="https://github.com/user-attachments/assets/c452f705-5991-42d5-be57-09b65cefa91f" /> | <img width="3485" height="4886" alt="image" src="https://github.com/user-attachments/assets/a29e49df-beaf-41d6-b3a0-ccc31979e01e" /> |
| Wormhole (look at OOB/black lines) <img width="4770" height="3533" alt="image" src="https://github.com/user-attachments/assets/76f26eae-f4af-4c2f-aae3-c2d3c7ad2dd4" /> | Wormhole (look at OOB/black lines) <img width="4770" height="3533" alt="image" src="https://github.com/user-attachments/assets/5e6191b6-2ad8-43ef-a7c6-ac70ff50f3eb" /> |
| Blackhole (look at OOB/black lines) <img width="4770" height="3533" alt="image" src="https://github.com/user-attachments/assets/b512612e-dafc-4d97-932f-8054fde51d0d" /> | Blackhole (look at OOB/black lines) <img width="4770" height="3533" alt="image" src="https://github.com/user-attachments/assets/85f0d6ed-43ba-46d7-95bd-01644d0066fc" /> |


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=gchoudhary/23279/small-matrix-matmul-performance)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:gchoudhary/23279/small-matrix-matmul-performance)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=gchoudhary/23279/small-matrix-matmul-performance)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:gchoudhary/23279/small-matrix-matmul-performance)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=gchoudhary/23279/small-matrix-matmul-performance)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:gchoudhary/23279/small-matrix-matmul-performance)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gchoudhary/23279/small-matrix-matmul-performance)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gchoudhary/23279/small-matrix-matmul-performance)