### PR TITLE
[Bug fix] Report raw L1 overflow address on QSR watcher

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -53,6 +53,7 @@ enum watcher_features_t {
     SanitizeNOCAlignmentL1Read,
     SanitizeNOCZeroL1Write,
     SanitizeNOCMailboxWrite,
+    SanitizeNOCMailboxWriteUncachedAlias,
     SanitizeNOCInlineWriteDram,
     SanitizeNOCLinkedTransaction,
     SanitizeL1Overflow,
@@ -112,13 +113,16 @@ void RunTestOnCore(
         GTEST_SKIP();
     }
 
+    // Non-IDLE_ETH cores (TENSIX/ACTIVE_ETH, all archs) run under both fast and slow dispatch.
     // IDLE_ETH cores only support slow dispatch (FD not yet implemented for them).
-    // All other cores (TENSIX/ACTIVE_ETH, including Quasar) run under fast dispatch.
-    if (fixture->IsSlowDispatch() && !is_idle_eth_core) {
-        GTEST_SKIP() << "Slow Dispatch only runs IDLE_ETH core tests";
+    if (is_idle_eth_core && !fixture->IsSlowDispatch()) {
+        GTEST_SKIP() << "IDLE_ETH core tests only run under Slow Dispatch";
     }
     if (multi_dm_race && !is_quasar) {
         GTEST_SKIP() << "Multi-DM race test only runs on Quasar";
+    }
+    if (feature == SanitizeNOCMailboxWriteUncachedAlias && (!is_quasar || is_eth_core)) {
+        GTEST_SKIP() << "Uncached mailbox alias only applies to Quasar DM cores";
     }
 
     // TENSIX cores use the Metal 2.0 variant; ETH cores stay on the legacy kernel/API.
@@ -328,6 +332,14 @@ void RunTestOnCore(
         case SanitizeNOCMailboxWrite:
             // This is illegal because we'd be writing to the mailbox memory
             buffer_addr = get_address_for_test(is_eth_core, HalL1MemAddrType::MAILBOX);
+            break;
+        case SanitizeNOCMailboxWriteUncachedAlias:
+            // Quasar-only (skipped at the top otherwise): the mailbox is aliased into the uncached L1
+            // window (upper 4 MB, same physical memory as the cached view). Target the alias so a NoC
+            // access landing in the mailbox through it is still flagged. Complements
+            // SanitizeNOCMailboxWrite, which covers the cached view.
+            buffer_addr = get_address_for_test(is_eth_core, HalL1MemAddrType::MAILBOX) +
+                          hal.get_dev_size(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE);
             break;
         case SanitizeNOCInlineWriteDram: use_inline_dw_write = true; break;
         case SanitizeNOCLinkedTransaction: bad_linked_transaction = true; break;
@@ -559,6 +571,7 @@ void RunTestOnCore(
                 input_core_virtual_coords,
                 output_buffer_addr);
         } break;
+        case SanitizeNOCMailboxWriteUncachedAlias:
         case SanitizeNOCMailboxWrite: {
             expected = fmt::format(
                 "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} using noc{} tried to unicast read {} "
@@ -833,6 +846,15 @@ TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeNOCMailboxWrite) {
         [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
             CoreCoord core{0, 0};
             RunTestOnCore(fixture, mesh_device, core, false, SanitizeNOCMailboxWrite);
+        },
+        this->devices_[0]);
+}
+
+TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeNOCMailboxWriteUncachedAlias) {
+    this->RunTestOnDevice(
+        [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+            CoreCoord core{0, 0};
+            RunTestOnCore(fixture, mesh_device, core, false, SanitizeNOCMailboxWriteUncachedAlias);
         },
         this->devices_[0]);
 }

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -57,6 +57,7 @@ enum watcher_features_t {
     SanitizeNOCInlineWriteDram,
     SanitizeNOCLinkedTransaction,
     SanitizeL1Overflow,
+    SanitizeL1OverflowStraddle,
     SanitizeEthSrcL1Overflow,
     SanitizeEthDestL1Overflow,
     SanitizeNOCMulticastInvalidRange,
@@ -121,8 +122,10 @@ void RunTestOnCore(
     if (multi_dm_race && !is_quasar) {
         GTEST_SKIP() << "Multi-DM race test only runs on Quasar";
     }
-    if (feature == SanitizeNOCMailboxWriteUncachedAlias && (!is_quasar || is_eth_core)) {
-        GTEST_SKIP() << "Uncached mailbox alias only applies to Quasar DM cores";
+    // Both exercise Quasar's uncached L1 alias, which only exists on Quasar DM cores.
+    if ((feature == SanitizeNOCMailboxWriteUncachedAlias || feature == SanitizeL1OverflowStraddle) &&
+        (!is_quasar || is_eth_core)) {
+        GTEST_SKIP() << "Uncached-alias tests only apply to Quasar DM cores";
     }
 
     // TENSIX cores use the Metal 2.0 variant; ETH cores stay on the legacy kernel/API.
@@ -344,6 +347,10 @@ void RunTestOnCore(
         case SanitizeNOCInlineWriteDram: use_inline_dw_write = true; break;
         case SanitizeNOCLinkedTransaction: bad_linked_transaction = true; break;
         case SanitizeL1Overflow: l1_overflow_addr = 0xDDDDDDDD; break;
+        case SanitizeL1OverflowStraddle:
+            // 4-byte access starting 2 bytes below the top of L1, straddling the cached/uncached-alias seam.
+            l1_overflow_addr = hal.get_dev_size(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE) - 2;
+            break;
         case SanitizeEthSrcL1Overflow: eth_src_overflow_addr_words = 0xAAAAAAAA; break;
         case SanitizeEthDestL1Overflow: eth_dest_overflow_addr_words = 0xBBBBBBBB; break;
         case SanitizeNOCMulticastInvalidRange: {
@@ -624,6 +631,7 @@ void RunTestOnCore(
                 output_core_virtual_coords.str(),
                 output_buffer_addr);
         } break;
+        case SanitizeL1OverflowStraddle:
         case SanitizeL1Overflow: {
             expected = fmt::format(
                 "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} core overflowed L1 with access to {:#x} "
@@ -930,6 +938,15 @@ TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeL1Overflow) {
         [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
             CoreCoord core{0, 0};
             RunTestOnCore(fixture, mesh_device, core, false, SanitizeL1Overflow);
+        },
+        this->devices_[0]);
+}
+
+TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeL1OverflowStraddle) {
+    this->RunTestOnDevice(
+        [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+            CoreCoord core{0, 0};
+            RunTestOnCore(fixture, mesh_device, core, false, SanitizeL1OverflowStraddle);
         },
         this->devices_[0]);
 }

--- a/tt_metal/hw/inc/internal/debug/sanitize.h
+++ b/tt_metal/hw/inc/internal/debug/sanitize.h
@@ -46,6 +46,19 @@ using debug_sanitize_noc_cast_t = bool;
 #define DEBUG_SANITIZE_NOC_LOCAL false
 using debug_sanitize_noc_which_core_t = bool;
 
+#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
+// Quasar DM reaches L1 through two aliased views of the same physical memory: the cached view
+// [MEM_L1_BASE, +MEM_L1_SIZE) and the uncached alias [MEM_L1_UNCACHED_BASE, +MEM_L1_SIZE).
+// A valid access lies wholly within one view. Crossing the seam is not a contiguous transfer:
+// the bytes below the seam hit the top of physical L1 and the bytes at or above it hit the bottom,
+// so such an access is illegal. Returns true when [addr, addr+len) is entirely contained in a single view.
+inline bool debug_l1_access_within_single_view(uint64_t addr, uint64_t len) {
+    bool in_cached_view = (addr + len <= MEM_L1_BASE + MEM_L1_SIZE);
+    bool in_uncached_view = (addr >= MEM_L1_UNCACHED_BASE) && (addr + len <= MEM_L1_UNCACHED_BASE + MEM_L1_SIZE);
+    return in_cached_view || in_uncached_view;
+}
+#endif
+
 // Helper function to get the core type from noc coords.
 AddressableCoreType get_core_type(uint8_t noc_id, uint8_t x, uint8_t y, bool& is_virtual_coord) {
     core_info_msg_t tt_l1_ptr* core_info = GET_MAILBOX_ADDRESS_DEV(core_info);
@@ -175,11 +188,10 @@ inline uint16_t debug_valid_worker_addr(uint64_t addr, uint64_t len, bool write,
         return DebugSanitizeNocAddrUnderflow;
     }
 #if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
-    // Quasar DM local buffers may use the cached view or the uncached alias (valid up to the top of
-    // the alias). Remote NOC target offsets are always physical (cached-range) and must stay within
-    // MEM_L1_SIZE.
+    // Local buffers may use the cached view or the uncached alias (and must not straddle the seam).
+    // Remote NOC target offsets are always physical (cached-range) and must stay within MEM_L1_SIZE.
     if (is_local_buffer) {
-        if (addr + len > MEM_L1_UNCACHED_BASE + MEM_L1_SIZE) {
+        if (!debug_l1_access_within_single_view(addr, len)) {
             return DebugSanitizeNocAddrOverflow;
         }
     } else {
@@ -635,19 +647,19 @@ void debug_throw_on_dram_addr(uint8_t noc_id, uint64_t addr, uint32_t len) {
 }
 
 void debug_sanitize_l1_access(uint64_t addr, uint32_t len) {
+    bool illegal = (addr + len <= addr);  // zero length / wraparound
 #if defined(COMPILE_FOR_ERISC)
-    constexpr uint64_t l1_overflow_addr = MEM_ETH_SIZE;
+    illegal = illegal || (addr + len > MEM_ETH_SIZE);
 #elif defined(COMPILE_FOR_DRISC)
-    constexpr uint64_t l1_overflow_addr = MEM_DRISC_L1_SIZE;
+    illegal = illegal || (addr + len > MEM_DRISC_L1_SIZE);
 #elif defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
-    // Quasar DM kernels can access TL1 via the cached view or the uncached alias (same physical
-    // memory), so the valid range spans up to the top of the alias. Report the raw address, not a
-    // normalized one, so error messages reflect what the kernel actually used.
-    constexpr uint64_t l1_overflow_addr = MEM_L1_UNCACHED_BASE + MEM_L1_SIZE;
+    // Access must lie wholly within the cached view or the uncached alias (not straddle the seam).
+    // Report the raw address (not a normalized one) so errors reflect what the kernel used.
+    illegal = illegal || !debug_l1_access_within_single_view(addr, len);
 #else
-    constexpr uint64_t l1_overflow_addr = MEM_L1_SIZE;
+    illegal = illegal || (addr + len > MEM_L1_SIZE);
 #endif
-    if (addr + len <= addr || addr + len > l1_overflow_addr) {
+    if (illegal) {
         debug_sanitize_post_addr_and_hang(
             0,  // unused (not a noc transaction)
             0,  // unused (not a noc transaction)

--- a/tt_metal/hw/inc/internal/debug/sanitize.h
+++ b/tt_metal/hw/inc/internal/debug/sanitize.h
@@ -46,19 +46,6 @@ using debug_sanitize_noc_cast_t = bool;
 #define DEBUG_SANITIZE_NOC_LOCAL false
 using debug_sanitize_noc_which_core_t = bool;
 
-#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
-// Quasar DM cores access L1 through an uncached alias at MEM_L1_UNCACHED_BASE. Normalize
-// uncached addresses to their physical (cached) offset for bounds checks.
-inline uint64_t debug_normalize_l1_addr(uint64_t addr) {
-    if (addr >= MEM_L1_UNCACHED_BASE) {
-        return addr - MEM_L1_UNCACHED_BASE;
-    }
-    return addr;
-}
-#else
-inline uint64_t debug_normalize_l1_addr(uint64_t addr) { return addr; }
-#endif
-
 // Helper function to get the core type from noc coords.
 AddressableCoreType get_core_type(uint8_t noc_id, uint8_t x, uint8_t y, bool& is_virtual_coord) {
     core_info_msg_t tt_l1_ptr* core_info = GET_MAILBOX_ADDRESS_DEV(core_info);
@@ -180,17 +167,31 @@ inline bool debug_valid_reg_addr(
            (len == 4);
 }
 
-inline uint16_t debug_valid_worker_addr(uint64_t addr, uint64_t len, bool write) {
+inline uint16_t debug_valid_worker_addr(uint64_t addr, uint64_t len, bool write, bool is_local_buffer = false) {
     if (addr + len <= addr) {
         return DebugSanitizeNocAddrZeroLength;
     }
-    addr = debug_normalize_l1_addr(addr);
     if (addr < MEM_L1_BASE) {
         return DebugSanitizeNocAddrUnderflow;
     }
+#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
+    // Quasar DM local buffers may use the cached view or the uncached alias (valid up to the top of
+    // the alias). Remote NOC target offsets are always physical (cached-range) and must stay within
+    // MEM_L1_SIZE.
+    if (is_local_buffer) {
+        if (addr + len > MEM_L1_UNCACHED_BASE + MEM_L1_SIZE) {
+            return DebugSanitizeNocAddrOverflow;
+        }
+    } else {
+        if (addr + len > MEM_L1_BASE + MEM_L1_SIZE) {
+            return DebugSanitizeNocAddrOverflow;
+        }
+    }
+#else
     if (addr + len > MEM_L1_BASE + MEM_L1_SIZE) {
         return DebugSanitizeNocAddrOverflow;
     }
+#endif
 
 #if !defined(DISPATCH_KERNEL) || (DISPATCH_KERNEL == 0)
     if (write && (addr < MEM_MAP_READ_ONLY_END)) {
@@ -278,7 +279,6 @@ inline uint16_t debug_valid_drisc_addr(uint64_t addr, uint64_t len, bool write) 
 // BRISC/NCRISC where cb_addr_shift == 0 (addresses are in bytes).
 // Relies on unused CBs having fifo_size == 0 (cleared at kernel startup).
 inline uint16_t debug_valid_cb_addr(uint32_t l1_addr, uint32_t len) {
-    l1_addr = static_cast<uint32_t>(debug_normalize_l1_addr(l1_addr));
     for (uint32_t i = 0; i < NUM_CIRCULAR_BUFFERS; i++) {
         LocalCBInterface& cb = get_local_cb_interface(i);
         if (cb.fifo_size == 0) {
@@ -529,7 +529,8 @@ uint32_t debug_sanitize_noc_addr(
             multicast,
             dir,
             DEBUG_SANITIZE_NOC_TARGET,
-            debug_valid_worker_addr(noc_local_addr, noc_len, dir == DEBUG_SANITIZE_NOC_WRITE));
+            debug_valid_worker_addr(
+                noc_local_addr, noc_len, dir == DEBUG_SANITIZE_NOC_WRITE, false));  // remote NOC target
     } else {
         // Bad XY
         debug_sanitize_post_addr_and_hang(
@@ -565,7 +566,8 @@ void debug_sanitize_noc_and_worker_addr(
 #elif defined(COMPILE_FOR_DRISC)
         uint16_t return_code = debug_valid_drisc_addr(worker_addr, len, dir == DEBUG_SANITIZE_NOC_READ);
 #else
-        uint16_t return_code = debug_valid_worker_addr(worker_addr, len, dir == DEBUG_SANITIZE_NOC_READ);
+        uint16_t return_code =
+            debug_valid_worker_addr(worker_addr, len, dir == DEBUG_SANITIZE_NOC_READ, true);  // local buffer
 #endif
         debug_sanitize_post_addr_and_hang(
             noc_id, noc_addr, worker_addr, len, multicast, dir, DEBUG_SANITIZE_NOC_LOCAL, return_code);
@@ -626,10 +628,14 @@ void debug_sanitize_l1_access(uint64_t addr, uint32_t len) {
     constexpr uint64_t l1_overflow_addr = MEM_ETH_SIZE;
 #elif defined(COMPILE_FOR_DRISC)
     constexpr uint64_t l1_overflow_addr = MEM_DRISC_L1_SIZE;
+#elif defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
+    // Quasar DM kernels can access TL1 via the cached view or the uncached alias (same physical
+    // memory), so the valid range spans up to the top of the alias. Report the raw address, not a
+    // normalized one, so error messages reflect what the kernel actually used.
+    constexpr uint64_t l1_overflow_addr = MEM_L1_UNCACHED_BASE + MEM_L1_SIZE;
 #else
     constexpr uint64_t l1_overflow_addr = MEM_L1_SIZE;
 #endif
-    addr = debug_normalize_l1_addr(addr);
     if (addr + len <= addr || addr + len > l1_overflow_addr) {
         debug_sanitize_post_addr_and_hang(
             0,  // unused (not a noc transaction)

--- a/tt_metal/hw/inc/internal/debug/sanitize.h
+++ b/tt_metal/hw/inc/internal/debug/sanitize.h
@@ -197,6 +197,15 @@ inline uint16_t debug_valid_worker_addr(uint64_t addr, uint64_t len, bool write,
     if (write && (addr < MEM_MAP_READ_ONLY_END)) {
         return DebugSanitizeNocAddrMailbox;
     }
+#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
+    // The read-only region is aliased into the uncached view; a write there hits the same reserved
+    // memory. Only local buffers use the alias (remote targets are physical, bounded above). Raw
+    // address kept for reporting.
+    if (is_local_buffer && write && addr >= MEM_L1_UNCACHED_BASE &&
+        addr < MEM_L1_UNCACHED_BASE + MEM_MAP_READ_ONLY_END) {
+        return DebugSanitizeNocAddrMailbox;
+    }
+#endif
 #endif
     return DebugSanitizeOK;
 }
@@ -278,6 +287,8 @@ inline uint16_t debug_valid_drisc_addr(uint64_t addr, uint64_t len, bool write) 
 // circular buffer stays within that buffer's allocated region.  Only runs on
 // BRISC/NCRISC where cb_addr_shift == 0 (addresses are in bytes).
 // Relies on unused CBs having fifo_size == 0 (cleared at kernel startup).
+// Effectively BH/WH-only: Quasar uses DFBs (separate g_dfb_interface) and never populates
+// cb_interface[], so every slot is fifo_size == 0 and this returns OK -- no alias handling needed.
 inline uint16_t debug_valid_cb_addr(uint32_t l1_addr, uint32_t len) {
     for (uint32_t i = 0; i < NUM_CIRCULAR_BUFFERS; i++) {
         LocalCBInterface& cb = get_local_cb_interface(i);


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes https://github.com/tenstorrent/tt-metal/issues/49616

`TensixTestWatcherSanitizeL1Overflow` fails on Quasar: writing sentinel `0xDDDDDDDD` is reported by the watcher as `0xDD9DDDDD` ( `0xDDDDDDDD` - `0x400000`). This can be confusing to users and can make it hard to debug illegal accesses.

Root cause: `debug_sanitize_l1_access` and `debug_valid_worker_addr` normalized addresses via `debug_normalize_l1_addr` (subtracting `MEM_L1_UNCACHED_BASE`) before bounds checking and reporting the normalized out of bounds addresses accessed.

Fix: drop normalization, check the real valid range, and report the raw address. On Quasar DMs a local buffer may use the cached view or the contiguous uncached alias, so the local-buffer bound spans both but remote NOC targets stay bounded at `MEM_L1_SIZE` (new `is_local_buffer` flag distinguishes them).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadkarni/fix_sanitize_l1_overflow_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadkarni/fix_sanitize_l1_overflow_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=snadkarni/fix_sanitize_l1_overflow_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:snadkarni/fix_sanitize_l1_overflow_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=snadkarni/fix_sanitize_l1_overflow_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:snadkarni/fix_sanitize_l1_overflow_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/fix_sanitize_l1_overflow_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/fix_sanitize_l1_overflow_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=snadkarni/fix_sanitize_l1_overflow_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:snadkarni/fix_sanitize_l1_overflow_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/fix_sanitize_l1_overflow_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/fix_sanitize_l1_overflow_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/fix_sanitize_l1_overflow_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/fix_sanitize_l1_overflow_qsr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/fix_sanitize_l1_overflow_qsr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/fix_sanitize_l1_overflow_qsr)