### PR TITLE
Fix: Host-side races: async-signal-unsafe SHM cleanup handler and unsynchronized thread-pool affinity statics

### DIFF
--- a/tests/tt_metal/distributed/test_thread_pool.cpp
+++ b/tests/tt_metal/distributed/test_thread_pool.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <atomic>
+#include <thread>
+#include <vector>
 #include "tt_metal/impl/threading/thread_pool.hpp"
 #include "impl/context/metal_context.hpp"
 #include "impl/context/context_types.hpp"
@@ -50,6 +53,44 @@ TEST(ThreadPoolTest, Exception) {
     auto exception_fn = []() { TT_THROW("Failed"); };
     thread_pool->enqueue(exception_fn);
     EXPECT_THROW(thread_pool->wait(), std::exception);
+}
+
+// Regression test for the data race fixed in get_cpu_core_for_physical_device (issue #48579, item 10).
+// Constructing a device-bound pool invokes get_cpu_core_for_physical_device once per worker, which
+// reads and mutates function-local static NUMA-affinity maps and a round-robin counter. These were
+// previously accessed without synchronization, so building pools concurrently could corrupt the maps
+// or produce torn counter reads. This test builds many pools in parallel and drives a small workload
+// through each, asserting every construction completes and executes correctly. It is most sensitive
+// under ThreadSanitizer, but can also crash/hang without the fix.
+TEST(ThreadPoolTest, ConcurrentDeviceBoundConstruction) {
+    const int num_threads_per_pool = MetalContext::instance(DEFAULT_CONTEXT_ID).get_cluster().number_of_user_devices();
+    constexpr uint32_t num_concurrent_builders = 16;
+    constexpr uint32_t tasks_per_pool = 256;
+
+    std::atomic<uint64_t> counter = 0;
+    std::atomic<uint32_t> failures = 0;
+
+    std::vector<std::thread> builders;
+    builders.reserve(num_concurrent_builders);
+    for (uint32_t b = 0; b < num_concurrent_builders; b++) {
+        builders.emplace_back([&]() {
+            try {
+                auto thread_pool = create_device_bound_thread_pool(DEFAULT_CONTEXT_ID, num_threads_per_pool);
+                for (uint32_t i = 0; i < tasks_per_pool; i++) {
+                    thread_pool->enqueue([&counter]() { counter.fetch_add(1, std::memory_order_relaxed); });
+                }
+                thread_pool->wait();
+            } catch (...) {
+                failures.fetch_add(1, std::memory_order_relaxed);
+            }
+        });
+    }
+    for (auto& builder : builders) {
+        builder.join();
+    }
+
+    EXPECT_EQ(failures.load(), 0u);
+    EXPECT_EQ(counter.load(), static_cast<uint64_t>(num_concurrent_builders) * tasks_per_pool);
 }
 
 }  // namespace

--- a/tt_metal/distributed/shm_resource_tracker.cpp
+++ b/tt_metal/distributed/shm_resource_tracker.cpp
@@ -81,11 +81,14 @@ void invoke_previous_handler(int sig, const struct sigaction& prev) {
 }
 
 void signal_handler(int sig) {
-    // Use try_lock to avoid deadlock if the signal interrupted a thread
-    // holding mutex_. If we can't acquire the lock, the manifest file
-    // ensures the next process will clean up via stale-PID scan.
-    ShmResourceTracker::instance().cleanup_from_signal();
-
+    // Intentionally do NOT clean up shm/files here. In-handler cleanup would require
+    // async-signal-unsafe operations (locking a std::mutex, iterating and clearing a
+    // std::set<std::string> -> free()), which is undefined behavior if the signal
+    // interrupts libc/pthread/allocator internals. Resources belonging to a process that
+    // terminates abnormally are reclaimed by the on-disk manifest + the next process's
+    // stale-PID scan (see cleanup_stale_resources()), exactly as for SIGKILL/crashes.
+    // The only work done here is chaining to the previously-installed handler, which is
+    // async-signal-safe.
     const struct sigaction& prev = (sig == SIGINT) ? prev_sigint : prev_sigterm;
     invoke_previous_handler(sig, prev);
 }
@@ -198,30 +201,6 @@ void ShmResourceTracker::cleanup_all() {
     file_paths_.clear();
 
     std::remove(manifest_path_.c_str());
-}
-
-void ShmResourceTracker::cleanup_from_signal() {
-    // try_lock avoids deadlock if the signal interrupted a thread holding mutex_.
-    // If we can't lock, leave the manifest intact so the next process can
-    // discover and clean up all resources via stale-PID scan.
-    if (!mutex_.try_lock()) {
-        return;
-    }
-
-    // Lock acquired. shm_unlink and unlink are async-signal-safe.
-    // Avoid logging here (not async-signal-safe).
-    for (const auto& name : shm_names_) {
-        shm_unlink(name.c_str());
-    }
-    shm_names_.clear();
-
-    for (const auto& path : file_paths_) {
-        ::unlink(path.c_str());
-    }
-    file_paths_.clear();
-
-    ::unlink(manifest_path_.c_str());
-    mutex_.unlock();
 }
 
 void ShmResourceTracker::cleanup_stale_resources() {

--- a/tt_metal/distributed/shm_resource_tracker.hpp
+++ b/tt_metal/distributed/shm_resource_tracker.hpp
@@ -17,11 +17,13 @@ namespace tt::tt_metal::distributed {
  * Ensures that /dev/shm resources created by H2D/D2H sockets are cleaned up even
  * when the process exits abnormally. Two complementary mechanisms:
  *
- *  1. destructor / signal handler – cleans up resources on normal exit,
- *     std::exit(), SIGINT, SIGTERM.
+ *  1. destructor – cleans up resources on normal exit / std::exit().
  *
  *  2. Stale-PID cleanup – on first use, scans /dev/shm for resources whose owning
- *     PID is no longer alive (handles SIGKILL, hard crashes, power loss).
+ *     PID is no longer alive (handles SIGINT, SIGTERM, SIGKILL, hard crashes,
+ *     power loss). This is the reclamation path for any abnormal termination: the
+ *     SIGINT/SIGTERM handler intentionally does no cleanup itself because that would
+ *     require async-signal-unsafe work; it only chains to the previous handler.
  *
  * A manifest file /dev/shm/tt_socket_manifest_<pid> is maintained so that the
  * stale cleanup can discover descriptor files (whose names don't embed a PID).
@@ -42,7 +44,6 @@ public:
     void untrack_file(const std::string& file_path);
 
     void cleanup_all();
-    void cleanup_from_signal();
 
     static void cleanup_stale_resources();
 

--- a/tt_metal/impl/threading/thread_pool.cpp
+++ b/tt_metal/impl/threading/thread_pool.cpp
@@ -4,6 +4,7 @@
 
 #include <cstddef>
 #include <future>
+#include <mutex>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -48,6 +49,12 @@ bool balanced_physical_device_numa(ContextId context_id) {
 }
 
 uint32_t get_cpu_core_for_physical_device(ContextId context_id, uint32_t physical_device_id) {
+    // The statics below are shared across all thread-pool builds. Serialize the whole function so
+    // that thread pools constructed concurrently (e.g. parallel context/device init) cannot corrupt
+    // the maps or read a torn round-robin counter. This is a cold path (called once per worker at
+    // pool construction), so a coarse lock is fine, and none of the calls below re-enter here.
+    static std::mutex affinity_mutex;
+    const std::lock_guard<std::mutex> lock(affinity_mutex);
     static std::unordered_map<int, std::vector<uint32_t>> cpu_cores_per_numa_node = get_cpu_cores_per_numa_node();
     static std::unordered_map<int, int> logical_cpu_id_per_numa_node = {};
     // Initialize to an invalid value. Determine the NUMA Node based on the physical device id.

--- a/tt_metal/impl/threading/thread_pool.cpp
+++ b/tt_metal/impl/threading/thread_pool.cpp
@@ -49,10 +49,7 @@ bool balanced_physical_device_numa(ContextId context_id) {
 }
 
 uint32_t get_cpu_core_for_physical_device(ContextId context_id, uint32_t physical_device_id) {
-    // The statics below are shared across all thread-pool builds. Serialize the whole function so
-    // that thread pools constructed concurrently (e.g. parallel context/device init) cannot corrupt
-    // the maps or read a torn round-robin counter. This is a cold path (called once per worker at
-    // pool construction), so a coarse lock is fine, and none of the calls below re-enter here.
+    // Serialize access to the shared statics below; pools may be constructed concurrently.
     static std::mutex affinity_mutex;
     const std::lock_guard<std::mutex> lock(affinity_mutex);
     static std::unordered_map<int, std::vector<uint32_t>> cpu_cores_per_numa_node = get_cpu_cores_per_numa_node();


### PR DESCRIPTION
Fixes https://github.com/tenstorrent/tt-metal/issues/49556
Part of the host-side race-condition audit (#48579), item 10.

### (a) Async-signal-unsafe SHM cleanup handler
`tt_metal/distributed/shm_resource_tracker.cpp` installs a SIGINT/SIGTERM handler that, on signal, locks a `std::mutex` and iterates/`clear()`s `std::set<std::string>` members (which calls `free()`). None of these are async-signal-safe. If the signal
interrupts libc/pthread/allocator internals, the handler invokes undefined behavior (deadlock or heap corruption).

### (b) Unsynchronized static maps in thread-pool affinity
`get_cpu_core_for_physical_device` in `tt_metal/impl/threading/thread_pool.cpp` reads and mutates function-local `static std::unordered_map`s plus a round-robin counter with no synchronization. When thread pools are constructed concurrently (e.g. parallel context/device init), this corrupts the maps and produces torn counter reads.

### Proposed fix
- (a) Make the handler async-signal-safe: do no cleanup in-handler, only chain to the previously-installed handler. Rely on the existing on-disk manifest + next-process stale-PID scan for reclamation (identical to the already-relied-upon SIGKILL path).
- (b) Serialize the function with a function-local `static std::mutex` (cold path, called once per worker at pool construction).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-48579-signal-affinity-races)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:msudumbrekar/fix-48579-signal-affinity-races)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-48579-signal-affinity-races)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:msudumbrekar/fix-48579-signal-affinity-races)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-48579-signal-affinity-races)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:msudumbrekar/fix-48579-signal-affinity-races)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=msudumbrekar/fix-48579-signal-affinity-races)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:msudumbrekar/fix-48579-signal-affinity-races)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=msudumbrekar/fix-48579-signal-affinity-races)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:msudumbrekar/fix-48579-signal-affinity-races)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=msudumbrekar/fix-48579-signal-affinity-races)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:msudumbrekar/fix-48579-signal-affinity-races)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=msudumbrekar/fix-48579-signal-affinity-races)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:msudumbrekar/fix-48579-signal-affinity-races)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=msudumbrekar/fix-48579-signal-affinity-races)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:msudumbrekar/fix-48579-signal-affinity-races)