### PR TITLE
Remove TT_METAL_SIMULATOR checks from tests

### DIFF
--- a/tests/pipeline_reorg/ttsim-skip-list.yaml
+++ b/tests/pipeline_reorg/ttsim-skip-list.yaml
@@ -6,7 +6,13 @@
 
 wormhole_b0:
   # Job-level timeouts -- can be cut down still
+  - tests/ttnn/unit_tests/base_functionality/test_copy.py::test_copy_rm_interleaved_to_nd_sharded_large_row
+  - tests/ttnn/unit_tests/base_functionality/test_copy.py::test_copy_rm_interleaved_to_legacy_2D_sharded_large_row
+  - tests/ttnn/unit_tests/base_functionality/test_copy.py::test_copy_rm_nd_sharded_to_interleaved_large_row
   - tests/ttnn/unit_tests/base_functionality/test_graph_report.py::test_resnet50_e2e_graph_capture
+  - tests/ttnn/unit_tests/base_functionality/test_to_memory_config.py::test_to_memory_config_rm_interleaved_to_nd_sharded_large_row
+  - tests/ttnn/unit_tests/base_functionality/test_to_memory_config.py::test_to_memory_config_rm_interleaved_to_legacy_2D_sharded_large_row
+  - tests/ttnn/unit_tests/base_functionality/test_to_memory_config.py::test_to_memory_config_rm_nd_sharded_to_interleaved_large_row
   - tests/ttnn/unit_tests/operations/conv/test_conv2d.py
   - tests/ttnn/unit_tests/operations/conv/test_conv3d.py
   - tests/ttnn/unit_tests/operations/fused/test_layer_norm_sharded.py

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_compute_single_card.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_compute_single_card.py
@@ -414,15 +414,7 @@ def _run_moe_compute_single_card_test(
     )
 
     base_pcc_threshold = _get_base_pcc_threshold(activation_type, has_bias)
-
-    # Arch- and sim-aware PCC floor (see #41827).
-    # ttsim has known partial fidelity (e.g. pack_untilize_dest), so the floor on sim is
-    # lower than on real silicon. Take the min with the helper's default so we don't
-    # accidentally relax a tighter threshold that might land later.
-    # WH and BH currently share the same floor; differentiate here when they diverge.
-    _on_simulator = bool(os.environ.get("TT_METAL_SIMULATOR"))
-    _arch_floor = 0.84 if _on_simulator else 0.984
-    base_pcc_threshold = min(base_pcc_threshold, _arch_floor)
+    base_pcc_threshold = min(base_pcc_threshold, 0.984)
 
     per_expert_tokens_all_passed = validate_per_expert_tokens(
         mesh_device,

--- a/tests/ttnn/unit_tests/base_functionality/test_copy.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_copy.py
@@ -2042,8 +2042,6 @@ def test_copy_rm_legacy_2d_sharded_to_interleaved(
 def test_copy_rm_interleaved_to_nd_sharded_large_row(
     device, tensor_shape, shard_shape, grid, shard_orientation, buffer_type
 ):
-    if os.environ.get("TT_METAL_SIMULATOR"):
-        pytest.skip("Skipping large row test on ttsim to avoid timeout")
     num_device_dram_banks = device.dram_grid_size().x
     required_banks = grid.num_cores()
     if required_banks > num_device_dram_banks:
@@ -2081,8 +2079,6 @@ def test_copy_rm_interleaved_to_nd_sharded_large_row(
 def test_copy_rm_interleaved_to_legacy_2D_sharded_large_row(
     device, tensor_shape, shard_shape, grid, shard_orientation, buffer_type
 ):
-    if os.environ.get("TT_METAL_SIMULATOR"):
-        pytest.skip("Skipping large row test on ttsim to avoid timeout")
     num_device_dram_banks = device.dram_grid_size().x
     required_banks = grid.num_cores()
     if required_banks > num_device_dram_banks:
@@ -2129,8 +2125,6 @@ def test_copy_rm_interleaved_to_legacy_2D_sharded_large_row(
 def test_copy_rm_nd_sharded_to_interleaved_large_row(
     device, tensor_shape, shard_shape, grid, shard_orientation, buffer_type
 ):
-    if os.environ.get("TT_METAL_SIMULATOR"):
-        pytest.skip("Skipping large row test on ttsim to avoid timeout")
     num_device_dram_banks = device.dram_grid_size().x
     required_banks = grid.num_cores()
     if required_banks > num_device_dram_banks:

--- a/tests/ttnn/unit_tests/base_functionality/test_to_memory_config.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_to_memory_config.py
@@ -2042,8 +2042,6 @@ def test_to_memory_config_rm_legacy_2d_sharded_to_interleaved(
 def test_to_memory_config_rm_interleaved_to_nd_sharded_large_row(
     device, tensor_shape, shard_shape, grid, shard_orientation, buffer_type
 ):
-    if os.environ.get("TT_METAL_SIMULATOR"):
-        pytest.skip("Skipping large row test on ttsim to avoid timeout")
     num_device_dram_banks = device.dram_grid_size().x
     required_banks = grid.num_cores()
     if required_banks > num_device_dram_banks:
@@ -2081,8 +2079,6 @@ def test_to_memory_config_rm_interleaved_to_nd_sharded_large_row(
 def test_to_memory_config_rm_interleaved_to_legacy_2D_sharded_large_row(
     device, tensor_shape, shard_shape, grid, shard_orientation, buffer_type
 ):
-    if os.environ.get("TT_METAL_SIMULATOR"):
-        pytest.skip("Skipping large row test on ttsim to avoid timeout")
     num_device_dram_banks = device.dram_grid_size().x
     required_banks = grid.num_cores()
     if required_banks > num_device_dram_banks:
@@ -2129,8 +2125,6 @@ def test_to_memory_config_rm_interleaved_to_legacy_2D_sharded_large_row(
 def test_to_memory_config_rm_nd_sharded_to_interleaved_large_row(
     device, tensor_shape, shard_shape, grid, shard_orientation, buffer_type
 ):
-    if os.environ.get("TT_METAL_SIMULATOR"):
-        pytest.skip("Skipping large row test on ttsim to avoid timeout")
     num_device_dram_banks = device.dram_grid_size().x
     required_banks = grid.num_cores()
     if required_banks > num_device_dram_banks:

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint8.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_uint8.py
@@ -25,10 +25,6 @@ from models.common.utility_functions import is_blackhole
     [ttnn.ne, ttnn.eq, ttnn.lt, ttnn.gt, ttnn.le, ttnn.ge],
 )
 def test_binary_relational_uint8(a_shape, b_shape, ttnn_op, device):
-    # TODO: Remove this when typecasting uint8 to uint16 support is added to the BH simulator
-    # issue: https://github.com/tenstorrent/tt-metal/issues/44988
-    if is_blackhole() and os.environ.get("TT_METAL_SIMULATOR"):
-        pytest.skip("Skipping on BH tt-sim: UINT8->UINT16 typecast not supported")
     low, high = 0, 255
     num_elements = max(int(torch.prod(torch.tensor(a_shape)).item()), 1)
     torch_input_tensor_a = torch.linspace(high, low, num_elements, dtype=torch.int32)
@@ -72,10 +68,6 @@ def test_binary_relational_uint8(a_shape, b_shape, ttnn_op, device):
     [ttnn.lt, ttnn.gt, ttnn.le, ttnn.ge, ttnn.ne, ttnn.eq],
 )
 def test_binary_relational_uint8_tensor_scalar(shape, scalar, ttnn_op, device):
-    # TODO: Remove this when typecasting uint8 to uint16 support is added to the BH simulator
-    # issue: https://github.com/tenstorrent/tt-metal/issues/44988
-    if is_blackhole() and os.environ.get("TT_METAL_SIMULATOR"):
-        pytest.skip("Skipping on BH tt-sim: UINT8->UINT16 typecast not supported")
     # scalar must be in [0, 255] to stay within the UINT8 value range
     num_elements = int(torch.prod(torch.tensor(shape)).item())
     torch_input = torch.arange(num_elements, dtype=torch.int32).remainder(256).reshape(shape)

--- a/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
@@ -498,10 +498,6 @@ def test_batch_norm_output_Default(input_shapes, device):
     "input_dtype, param_dtype", [("bfloat16", "bfloat16"), ("bfloat16", "float32"), ("float32", "float32")]
 )
 def test_batch_norm_compute_config(input_shapes, training, weight, bias, input_dtype, param_dtype, device):
-    if input_dtype == "float32" and os.environ.get("TT_METAL_SIMULATOR"):
-        pytest.skip(
-            "Skipping float32 batch_norm compute_config on ttsim - fp16a untested functionality (ttsim-private issue #324)"
-        )
     N, H, W, C = input_shapes
     torch.manual_seed(0)
 

--- a/tests/ttnn/unit_tests/operations/sdpa/test_windowed_sdpa.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_windowed_sdpa.py
@@ -63,13 +63,6 @@ def windowed_mask(seq_len, cu_window_seqlens):
 def test_windowed_sdpa_smoke(
     device, dtype, pcc_threshold, num_heads, seq_len, chunk, cu_window_seqlens, fp32_dest_acc_en
 ):
-    # fp32_dest_acc_en=True takes the STANDARD compute path, whose reduce issues a MOVD2B with
-    # (use_dst32b=0, dest_32b_lo=1). Real Blackhole tolerates this; ttsim correctly rejects it as
-    # UndefinedBehavior (tenstorrent#47164). fp32_dest_acc_en=False (the Blackhole default, and what
-    # Qwen2.5-VL uses) takes the streaming path and is clean on the simulator, so only skip the
-    # standard-path variant under ttsim.
-    if fp32_dest_acc_en and os.environ.get("TT_METAL_SIMULATOR"):
-        pytest.skip("STANDARD-path MOVD2B is HW-tolerated UB rejected by ttsim (#47164); streaming path covers sim")
     torch.manual_seed(42)
     b, dh = 1, 128
     scale = dh**-0.5


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Tests should not examine the TT_METAL_SIMULATOR env var, as this invalidates simulator testing as a valid proxy for silicon. Most of these were for issues that are already fixed. A small remainder are for timeouts; move these into the timeout section of ttsim-skip-list.yaml.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/no-sim-detection)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/no-sim-detection)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/no-sim-detection)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/no-sim-detection)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/no-sim-detection)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/no-sim-detection)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/no-sim-detection)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/no-sim-detection)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/no-sim-detection)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/no-sim-detection)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/no-sim-detection)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/no-sim-detection)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/no-sim-detection)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/no-sim-detection)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/no-sim-detection)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/no-sim-detection)