### PR TITLE
Route LOADMACRO-disabled SFPU MAX/MIN reductions through manual paths

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
@@ -1237,10 +1237,8 @@ inline void init_reduce_max_min_int32() {
 template <InstrModLoadStore INSTRUCTION_MODE, PoolType pool_type, bool clear_high_bits>
 inline void init_reduce_max_min(std::uint32_t num_cols) {
 #ifdef DISABLE_SFPLOADMACRO
-    if constexpr (INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP && !clear_high_bits) {
-        init_reduce_max_min_int32<INSTRUCTION_MODE, pool_type>();
-        return;
-    }
+    init_reduce_max_min_int32<INSTRUCTION_MODE, pool_type>();
+    return;
 #endif
 
     // Initialize SFPU config and set swap direction before defining LOADMACRO sequences
@@ -1854,6 +1852,17 @@ inline void calculate_reduce(std::uint32_t block_ct_dim = 1, std::uint32_t block
                 "Row MAX/MIN reduction supports FP32, FP16B, and INT32 (sign-magnitude) instruction modes");
             perform_reduce_row_max_min<pool_type, INSTRUCTION_MODE, clear_high_bits, pack_low16>(
                 block_ct_dim, block_rt_dim);
+#ifdef DISABLE_SFPLOADMACRO
+        } else if constexpr (INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP) {
+            // Int32 column reduce already has a manual load/cast/swap path. Use it when LOADMACRO is
+            // disabled, since the generic column MAX/MIN path records SFPLOADMACRO instructions.
+            calculate_reduce_max_min_int32<pool_type, reduce_dim, INSTRUCTION_MODE, false, pack_low16>();
+        } else {
+            // LOADMACRO-disabled builds use the manual load/swap column reducer. With
+            // clear_high_bits=false it is just the unfused equivalent of the LOADMACRO
+            // compare-and-swap pipeline.
+            calculate_reduce_max_min_uint16<pool_type, reduce_dim, INSTRUCTION_MODE, clear_high_bits, pack_low16>();
+#else
         } else if constexpr (clear_high_bits) {
             // UInt16 in 32-bit dest: manual load/mask/swap path (LOADMACRO cannot mask between load and swap).
             calculate_reduce_max_min_uint16<pool_type, reduce_dim, INSTRUCTION_MODE, clear_high_bits, pack_low16>();
@@ -1864,6 +1873,7 @@ inline void calculate_reduce(std::uint32_t block_ct_dim = 1, std::uint32_t block
             calculate_reduce_max_min_int32<pool_type, reduce_dim, INSTRUCTION_MODE, false, pack_low16>();
         } else {
             calculate_reduce_max_min<pool_type, reduce_dim, INSTRUCTION_MODE, false, pack_low16>(block_rt_dim);
+#endif
         }
     } else if constexpr (pool_type == PoolType::SUM || pool_type == PoolType::AVG) {
         calculate_reduce_sum_avg<pool_type, reduce_dim, INSTRUCTION_MODE, clear_high_bits, pack_low16>(

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
@@ -1235,7 +1235,7 @@ inline void init_reduce_max_min_int32() {
  * operations)
  */
 template <InstrModLoadStore INSTRUCTION_MODE, PoolType pool_type, bool clear_high_bits>
-inline void init_reduce_max_min(std::uint32_t num_cols) {
+inline void init_reduce_max_min([[maybe_unused]] std::uint32_t num_cols) {
 #ifdef DISABLE_SFPLOADMACRO
     init_reduce_max_min_int32<INSTRUCTION_MODE, pool_type>();
     return;
@@ -1799,7 +1799,7 @@ template <
     DataFormat format,
     bool is_fp32_dest_acc_en,
     DataFormat output_format = format>
-inline void calculate_reduce(std::uint32_t block_ct_dim = 1, std::uint32_t block_rt_dim = 1) {
+inline void calculate_reduce([[maybe_unused]] std::uint32_t block_ct_dim = 1, [[maybe_unused]] std::uint32_t block_rt_dim = 1) {
     // Row reduction supports SUM/MAX/MIN for every supported format; AVG is row-supported only for
     // float formats, because the row divisor is the runtime column count and only the float
     // reciprocal-multiply divides exactly (integer AVG stays column-only with its fixed /32 divisor).

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
@@ -1198,7 +1198,7 @@ inline void init_reduce_max_min_int32_signed() {
  * operations)
  */
 template <InstrModLoadStore INSTRUCTION_MODE, PoolType pool_type, bool clear_high_bits>
-inline void init_reduce_max_min(std::uint32_t num_cols) {
+inline void init_reduce_max_min([[maybe_unused]] std::uint32_t num_cols) {
 #ifdef DISABLE_SFPLOADMACRO
     init_reduce_max_min_int32<INSTRUCTION_MODE, pool_type>();
     return;
@@ -1520,7 +1520,7 @@ template <
     InstrModLoadStore INSTRUCTION_MODE,
     bool clear_high_bits,
     bool pack_low16>
-inline void calculate_reduce_max_min(const std::uint32_t block_ct_dim = 1, const std::uint32_t block_rt_dim = 1) {
+inline void calculate_reduce_max_min([[maybe_unused]] const std::uint32_t block_ct_dim = 1, [[maybe_unused]] const std::uint32_t block_rt_dim = 1) {
     static_assert(
         reduce_dim == ReduceDim::REDUCE_COL ||
             ((pool_type == PoolType::MAX || pool_type == PoolType::MIN) && reduce_dim == ReduceDim::REDUCE_ROW),

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reduce.h
@@ -1200,10 +1200,8 @@ inline void init_reduce_max_min_int32_signed() {
 template <InstrModLoadStore INSTRUCTION_MODE, PoolType pool_type, bool clear_high_bits>
 inline void init_reduce_max_min(std::uint32_t num_cols) {
 #ifdef DISABLE_SFPLOADMACRO
-    if constexpr (INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP && !clear_high_bits) {
-        init_reduce_max_min_int32<INSTRUCTION_MODE, pool_type>();
-        return;
-    }
+    init_reduce_max_min_int32<INSTRUCTION_MODE, pool_type>();
+    return;
 #endif
 
     // Initialize SFPU config and set swap direction before defining LOADMACRO sequences
@@ -1529,10 +1527,10 @@ inline void calculate_reduce_max_min(const std::uint32_t block_ct_dim = 1, const
         "Only column reduction (REDUCE_COL) and row MAX/MIN reduction (REDUCE_ROW with MAX/MIN) are supported");
 
 #ifdef DISABLE_SFPLOADMACRO
-    if constexpr (
-        reduce_dim == ReduceDim::REDUCE_COL && INSTRUCTION_MODE == InstrModLoadStore::INT32_2S_COMP &&
-        !clear_high_bits) {
-        calculate_reduce_max_min_uint16<pool_type, reduce_dim, INSTRUCTION_MODE, false, pack_low16>();
+    if constexpr (reduce_dim == ReduceDim::REDUCE_COL) {
+        // LOADMACRO-disabled builds use the manual load/swap column reducer instead of recording
+        // SFPLOADMACRO instructions in the generic column MAX/MIN path.
+        calculate_reduce_max_min_uint16<pool_type, reduce_dim, INSTRUCTION_MODE, clear_high_bits, pack_low16>();
         return;
     }
 #endif


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
`test_sfpu_reduce.py` was still emitting `SFPLOADMACRO` for several MAX/MIN column-reduction cases when `DISABLE_SFPLOADMACRO` was set, including UInt16 reduced-extent cases on Blackhole and the equivalent path on Wormhole. The reduce helpers already had manual load/swap implementations for the relevant column compare pipeline, but the fallback was only selected for a narrow subset of modes, so callers using the public reduce API could still reach the LOADMACRO-backed generic path. This change makes the WH and BH reduce kernels initialize and select the manual column MAX/MIN path whenever LOADMACRO is disabled, while leaving the normal LOADMACRO-enabled path unchanged. That keeps the API abstraction intact for debug builds that disable LOADMACRO and avoids requiring individual callers to know which internal reduction modes record macro loads.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/reduce-loadmacro)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/reduce-loadmacro)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/reduce-loadmacro)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/reduce-loadmacro)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/reduce-loadmacro)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/reduce-loadmacro)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/reduce-loadmacro)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/reduce-loadmacro)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/reduce-loadmacro)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/reduce-loadmacro)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/reduce-loadmacro)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/reduce-loadmacro)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/reduce-loadmacro)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/reduce-loadmacro)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/reduce-loadmacro)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/reduce-loadmacro)