### PR TITLE
LLK: fix llk_unpack_tilize_block cross-tile-row stride for tiny tiles

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_golden_impls.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_golden_impls.cpp
@@ -81,7 +81,9 @@ std::vector<uint32_t> gold_standard_tilize(const std::vector<uint32_t>& src_vec,
     // Half-face width in uint32 words: face_c_dim/2 elements × datum_bytes / 4 bytes per uint32
     // BF16: 16*2/4 = 8   FP8: 16*1/4 = 4
     const int half_face_w = config.face_c_dim * static_cast<int>(config.datum_bytes) / 4;
-    for (int x = 0; x < num_rows; x += 32) {
+    // Rows per tile-row: 32 for a full 32x32 tile (2 face-rows), 16 for a 16x32 tiny tile (1 face-row).
+    const int tile_r = config.face_r_dim * (config.num_faces > 2 ? 2 : 1);
+    for (int x = 0; x < num_rows; x += tile_r) {
         for (int y = 0; y < num_cols; y += 2 * half_face_w) {
             int start = (x * num_cols) + y;
 

--- a/tests/tt_metal/tt_metal/llk/test_golden_impls.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_golden_impls.cpp
@@ -87,10 +87,10 @@ std::vector<uint32_t> gold_standard_tilize(const std::vector<uint32_t>& src_vec,
         for (int y = 0; y < num_cols; y += 2 * half_face_w) {
             int start = (x * num_cols) + y;
 
-            // Top faces
+            // Top faces (face_r_dim rows each, not a hardcoded 16, so shortened faces work)
             for (int j = 0; j < 2; j++) {
                 int start_ = start + (half_face_w * j);
-                for (int k = 0; k < 16; k++) {
+                for (int k = 0; k < config.face_r_dim; k++) {
                     for (int i = 0; i < half_face_w; i++) {
                         int idx = start_ + (num_cols * k) + i;
                         dst_vec.push_back(src_vec.at(idx));
@@ -100,10 +100,10 @@ std::vector<uint32_t> gold_standard_tilize(const std::vector<uint32_t>& src_vec,
 
             if (config.num_faces > 2) {
                 // Bottom faces
-                start += 16 * num_cols;
+                start += config.face_r_dim * num_cols;
                 for (int j = 0; j < 2; j++) {
                     int start_ = start + (half_face_w * j);
-                    for (int k = 0; k < 16; k++) {
+                    for (int k = 0; k < config.face_r_dim; k++) {
                         for (int i = 0; i < half_face_w; i++) {
                             int idx = start_ + (num_cols * k) + i;
                             dst_vec.push_back(src_vec.at(idx));

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/constants.hpp>
 #include <tt-metalium/float8.hpp>
 #include <tt-metalium/int8.hpp>
 #include <tt-metalium/uint8.hpp>
@@ -867,9 +868,10 @@ TEST_F(LLKBlackholeSingleCardFixture, TensixComputeUnpackTilizeUInt8) {
 // Exercises llk_unpack_tilize_block with a 16x32 tiny tile across multiple tile-rows, using a
 // nonzero input_tile_index (tilize_across_tile_rows.cpp) so the cross-tile-row stride is hit.
 TEST_F(LLKBlackholeSingleCardFixture, TensixComputeUnpackTilizeTinyTile16x32) {
-    constexpr std::uint32_t face_r_dim = 16;
-    constexpr std::uint32_t face_c_dim = 16;
-    constexpr std::uint32_t num_faces = 2;  // 16x32 = two 16x16 faces laid horizontally
+    constexpr std::uint32_t face_r_dim = tt::constants::FACE_HEIGHT;
+    constexpr std::uint32_t face_c_dim = tt::constants::FACE_WIDTH;
+    // 16x32 tiny tile = one face-row, TILE_WIDTH/FACE_WIDTH face-columns.
+    constexpr std::uint32_t num_faces = tt::constants::TILE_WIDTH / tt::constants::FACE_WIDTH;
     constexpr std::uint32_t tile_bytes = num_faces * face_r_dim * face_c_dim * sizeof(std::uint16_t);
     // num_tiles_r >= 2 so the cross-tile-row stride in llk_unpack_tilize_block is exercised.
     vector<vector<std::uint32_t>> num_tiles = {{2, 1}, {2, 2}, {4, 1}};

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -82,6 +82,10 @@ struct TestConfig {
     // controlled with this flag:
     bool fp32_dest_acc_en = false;
     bool fast_tilize = false;
+    // UNPACK_A tilize only: tilize the whole block with a nonzero input_tile_index per tile-row
+    // (via tilize_across_tile_rows.cpp) so the cross-tile-row stride in llk_unpack_tilize_block is
+    // exercised, instead of the default tilize.cpp which uses input_tile_index=0 + pop_front.
+    bool tilize_cross_tile_rows = false;
     std::uint32_t input_single_tile_size;
     std::uint32_t output_single_tile_size;
     // Block height in tiles:
@@ -246,9 +250,10 @@ void run_single_core_tilize_program(
             tt::tt_metal::FaceGeometry{test_config.face_r_dim, test_config.num_faces_per_tile};
     } else if (
         test_config.tilize_type.has_value() && test_config.tilize_type == TilizeType::UNPACK_A &&
-        test_config.num_faces_per_tile != 4) {
-        // Tiny-tile tilize (e.g. 16x32): the unpack/pack LLKs read the tile's face geometry from the
-        // CB metadata, so tag both the input and output buffers with it.
+        (test_config.num_faces_per_tile != 4 || test_config.face_r_dim != 16)) {
+        // Tiny/shortened-face tilize (e.g. 16x32, or face_r_dim < 16): the unpack/pack LLKs read the
+        // tile's face geometry from the CB metadata, so tag both the input and output buffers with it.
+        // Gate on either fewer faces or a shorter face row dim so shortened four-face tiles are caught too.
         const auto fg = tt::tt_metal::FaceGeometry{test_config.face_r_dim, test_config.num_faces_per_tile};
         input_dfb_spec.unpack_face_geometry_metadata = fg;
         output_dfb_spec.unpack_face_geometry_metadata = fg;
@@ -319,7 +324,9 @@ void run_single_core_tilize_program(
         });
         compute_kernel = "tests/tt_metal/tt_metal/test_kernels/compute/" + untilize_type + "_untilize.cpp";
     } else if (is_unpack_a_tilize) {
-        compute_kernel = "tests/tt_metal/tt_metal/test_kernels/compute/tilize.cpp";
+        compute_kernel = test_config.tilize_cross_tile_rows
+                             ? "tests/tt_metal/tt_metal/test_kernels/compute/tilize_across_tile_rows.cpp"
+                             : "tests/tt_metal/tt_metal/test_kernels/compute/tilize.cpp";
     } else {
         log_fatal(tt::LogTest, "run_single_core_tilize_program: unsupported config (UNPACK_A_B uses dedicated helper)");
     }
@@ -857,19 +864,12 @@ TEST_F(LLKBlackholeSingleCardFixture, TensixComputeUnpackTilizeUInt8) {
     }
 }
 
-// Exercises llk_unpack_tilize_block (via tilize_block in tilize.cpp) with a 16x32 tiny tile.
-//
-// A 16x32 tile has num_faces=2, face_r_dim=16 (half the rows of a 32x32 tile). The block variant
-// llk_unpack_tilize_block (tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h)
-// computes the cross-tile-row L1 stride from the operand's tile_r_dim; it previously used the
-// compile-time TILE_R_DIM (32), wrong for a 16-row tile. We use num_tiles_r >= 2 so the cross-tile-row
-// stride is exercised (with num_tiles_r == 1 the offending term is multiplied by 0 and never hit).
-// The tiny-tile face geometry is tagged onto the input/output DFBs in run_single_core_tilize_program.
+// Exercises llk_unpack_tilize_block with a 16x32 tiny tile across multiple tile-rows, using a
+// nonzero input_tile_index (tilize_across_tile_rows.cpp) so the cross-tile-row stride is hit.
 TEST_F(LLKBlackholeSingleCardFixture, TensixComputeUnpackTilizeTinyTile16x32) {
     constexpr std::uint32_t face_r_dim = 16;
     constexpr std::uint32_t face_c_dim = 16;
     constexpr std::uint32_t num_faces = 2;  // 16x32 = two 16x16 faces laid horizontally
-    // bf16 16x32 tile = 2 faces * 16 * 16 * 2 bytes = 1024 bytes.
     constexpr std::uint32_t tile_bytes = num_faces * face_r_dim * face_c_dim * sizeof(std::uint16_t);
     // num_tiles_r >= 2 so the cross-tile-row stride in llk_unpack_tilize_block is exercised.
     vector<vector<std::uint32_t>> num_tiles = {{2, 1}, {2, 2}, {4, 1}};
@@ -877,6 +877,7 @@ TEST_F(LLKBlackholeSingleCardFixture, TensixComputeUnpackTilizeTinyTile16x32) {
         for (bool dst_full_sync_en : {false, true}) {
             unit_tests::compute::tilize::TestConfig test_config = {
                 .dst_full_sync_en = dst_full_sync_en,
+                .tilize_cross_tile_rows = true,
                 .input_single_tile_size = tile_bytes,
                 .output_single_tile_size = tile_bytes,
                 .num_tiles_r = num_tile[0],

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -244,6 +244,14 @@ void run_single_core_tilize_program(
         // DST untilize reads face geometry from the output CB metadata (no explicit kernel args).
         output_dfb_spec.unpack_face_geometry_metadata =
             tt::tt_metal::FaceGeometry{test_config.face_r_dim, test_config.num_faces_per_tile};
+    } else if (
+        test_config.tilize_type.has_value() && test_config.tilize_type == TilizeType::UNPACK_A &&
+        test_config.num_faces_per_tile != 4) {
+        // Tiny-tile tilize (e.g. 16x32): the unpack/pack LLKs read the tile's face geometry from the
+        // CB metadata, so tag both the input and output buffers with it.
+        const auto fg = tt::tt_metal::FaceGeometry{test_config.face_r_dim, test_config.num_faces_per_tile};
+        input_dfb_spec.unpack_face_geometry_metadata = fg;
+        output_dfb_spec.unpack_face_geometry_metadata = fg;
     }
 
     // Reader kernel: untilize types stream native tiles from DRAM (`reader_unary_2_0`);
@@ -843,6 +851,39 @@ TEST_F(LLKBlackholeSingleCardFixture, TensixComputeUnpackTilizeUInt8) {
                 .input_fmt = tt::DataFormat::UInt8,
                 .output_fmt = tt::DataFormat::UInt8,
                 .src0_data = src_data,
+                .golden_function = ::unit_tests::compute::gold_standard_tilize};
+            unit_tests::compute::tilize::run_single_core_tilize_program(this->devices_.at(0), test_config);
+        }
+    }
+}
+
+// Exercises llk_unpack_tilize_block (via tilize_block in tilize.cpp) with a 16x32 tiny tile.
+//
+// A 16x32 tile has num_faces=2, face_r_dim=16 (half the rows of a 32x32 tile). The block variant
+// llk_unpack_tilize_block (tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h)
+// computes the cross-tile-row L1 stride from the operand's tile_r_dim; it previously used the
+// compile-time TILE_R_DIM (32), wrong for a 16-row tile. We use num_tiles_r >= 2 so the cross-tile-row
+// stride is exercised (with num_tiles_r == 1 the offending term is multiplied by 0 and never hit).
+// The tiny-tile face geometry is tagged onto the input/output DFBs in run_single_core_tilize_program.
+TEST_F(LLKBlackholeSingleCardFixture, TensixComputeUnpackTilizeTinyTile16x32) {
+    constexpr std::uint32_t face_r_dim = 16;
+    constexpr std::uint32_t face_c_dim = 16;
+    constexpr std::uint32_t num_faces = 2;  // 16x32 = two 16x16 faces laid horizontally
+    // bf16 16x32 tile = 2 faces * 16 * 16 * 2 bytes = 1024 bytes.
+    constexpr std::uint32_t tile_bytes = num_faces * face_r_dim * face_c_dim * sizeof(std::uint16_t);
+    // num_tiles_r >= 2 so the cross-tile-row stride in llk_unpack_tilize_block is exercised.
+    vector<vector<std::uint32_t>> num_tiles = {{2, 1}, {2, 2}, {4, 1}};
+    for (auto num_tile : num_tiles) {
+        for (bool dst_full_sync_en : {false, true}) {
+            unit_tests::compute::tilize::TestConfig test_config = {
+                .dst_full_sync_en = dst_full_sync_en,
+                .input_single_tile_size = tile_bytes,
+                .output_single_tile_size = tile_bytes,
+                .num_tiles_r = num_tile[0],
+                .num_tiles_c = num_tile[1],
+                .num_faces_per_tile = num_faces,
+                .face_r_dim = face_r_dim,
+                .tilize_type = unit_tests::compute::tilize::TilizeType::UNPACK_A,
                 .golden_function = ::unit_tests::compute::gold_standard_tilize};
             unit_tests::compute::tilize::run_single_core_tilize_program(this->devices_.at(0), test_config);
         }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/tilize_across_tile_rows.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/tilize_across_tile_rows.cpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Tilize variant that exercises tilize_block with a NONZERO input_tile_index.
+//
+// Unlike tilize.cpp (which tilizes one tile-row at a time with input_tile_index=0 and advances the
+// input via pop_front), this kernel loads the whole block once and tilizes each tile-row using
+// input_tile_index = b * per_core_block_tile_cnt, without popping between rows. That drives the
+// cross-tile-row stride term in llk_unpack_tilize_block, so the test can distinguish the fixed
+// operand-derived stride from the old hardcoded TILE_R_DIM.
+
+#include <cstdint>
+
+#include "api/compute/tilize.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    constexpr uint32_t per_core_block_cnt = get_arg(args::per_core_block_cnt);
+    constexpr uint32_t per_core_block_tile_cnt = get_arg(args::per_core_block_tile_cnt);
+
+    DataflowBuffer dfb_in(dfb::in);
+    DataflowBuffer dfb_out(dfb::out);
+
+    compute_kernel_hw_startup(dfb::in, dfb::out);
+    tilize_init(dfb::in, per_core_block_tile_cnt, dfb::out);
+
+    const uint32_t total_tiles = per_core_block_cnt * per_core_block_tile_cnt;
+    dfb_in.wait_front(total_tiles);
+    dfb_out.reserve_back(total_tiles);
+
+    for (uint32_t b = 0; b < per_core_block_cnt; ++b) {
+        const uint32_t tile_index = b * per_core_block_tile_cnt;
+        tilize_block(dfb::in, per_core_block_tile_cnt, dfb::out, tile_index, tile_index);
+    }
+
+    dfb_in.pop_front(total_tiles);
+    dfb_out.push_back(total_tiles);
+
+    tilize_uninit(dfb::in, dfb::out);
+}

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
@@ -87,7 +87,10 @@ inline void llk_unpack_tilize(std::uint32_t operand, std::uint32_t tile_index) {
 inline void llk_unpack_tilize_block(std::uint32_t operand, std::uint32_t block_c_tiles, std::uint32_t input_tile_index = 0) {
     // Not sure if input_tile_index can be arbitrary but it works for moving across rows of files,
     // i.e. input_tile_index % block_c_tiles == 0
-    input_tile_index = input_tile_index % block_c_tiles + (input_tile_index / block_c_tiles) * block_c_tiles * TILE_R_DIM;
+    // Use the operand's actual rows-per-tile (e.g. 16 for a 16x32 tiny tile) for the cross-tile-row
+    // stride, not the compile-time TILE_R_DIM (32), which is wrong for tiles shorter than 32 rows.
+    const std::uint32_t tile_r_dim = get_operand_tile_r_dim(get_operand_id(operand));
+    input_tile_index = input_tile_index % block_c_tiles + (input_tile_index / block_c_tiles) * block_c_tiles * tile_r_dim;
     for (std::uint32_t tile_index = 0; tile_index < block_c_tiles; tile_index++) {
         llk_unpack_tilize(operand, input_tile_index + tile_index);
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
@@ -88,7 +88,9 @@ inline void llk_unpack_tilize_block(std::uint32_t operand, std::uint32_t block_c
     // Not sure if input_tile_index can be arbitrary but it works for moving across rows of files,
     // i.e. input_tile_index % block_c_tiles == 0
     const std::uint32_t tile_r_dim = get_operand_tile_r_dim(get_operand_id(operand));
-    input_tile_index = input_tile_index % block_c_tiles + (input_tile_index / block_c_tiles) * block_c_tiles * tile_r_dim;
+    const auto block = input_tile_index / block_c_tiles;
+    const auto offset = input_tile_index % block_c_tiles;
+    input_tile_index = block * (block_c_tiles * tile_r_dim) + offset;
     for (std::uint32_t tile_index = 0; tile_index < block_c_tiles; tile_index++) {
         llk_unpack_tilize(operand, input_tile_index + tile_index);
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
@@ -87,8 +87,6 @@ inline void llk_unpack_tilize(std::uint32_t operand, std::uint32_t tile_index) {
 inline void llk_unpack_tilize_block(std::uint32_t operand, std::uint32_t block_c_tiles, std::uint32_t input_tile_index = 0) {
     // Not sure if input_tile_index can be arbitrary but it works for moving across rows of files,
     // i.e. input_tile_index % block_c_tiles == 0
-    // Use the operand's actual rows-per-tile (e.g. 16 for a 16x32 tiny tile) for the cross-tile-row
-    // stride, not the compile-time TILE_R_DIM (32), which is wrong for tiles shorter than 32 rows.
     const std::uint32_t tile_r_dim = get_operand_tile_r_dim(get_operand_id(operand));
     input_tile_index = input_tile_index % block_c_tiles + (input_tile_index / block_c_tiles) * block_c_tiles * tile_r_dim;
     for (std::uint32_t tile_index = 0; tile_index < block_c_tiles; tile_index++) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
@@ -91,8 +91,6 @@ inline void llk_unpack_tilize_block(
     std::uint32_t operand, std::uint32_t block_c_tiles, std::uint32_t input_tile_index = 0) {
     // Not sure if input_tile_index can be arbitrary but it works for moving across rows of files,
     // i.e. input_tile_index % block_c_tiles == 0
-    // Use the operand's actual rows-per-tile (e.g. 16 for a 16x32 tiny tile) for the cross-tile-row
-    // stride, not the compile-time TILE_R_DIM (32), which is wrong for tiles shorter than 32 rows.
     const std::uint32_t tile_r_dim = get_operand_tile_r_dim(get_operand_id(operand));
     input_tile_index =
         input_tile_index % block_c_tiles + (input_tile_index / block_c_tiles) * block_c_tiles * tile_r_dim;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
@@ -92,8 +92,9 @@ inline void llk_unpack_tilize_block(
     // Not sure if input_tile_index can be arbitrary but it works for moving across rows of files,
     // i.e. input_tile_index % block_c_tiles == 0
     const std::uint32_t tile_r_dim = get_operand_tile_r_dim(get_operand_id(operand));
-    input_tile_index =
-        input_tile_index % block_c_tiles + (input_tile_index / block_c_tiles) * block_c_tiles * tile_r_dim;
+    const auto block = input_tile_index / block_c_tiles;
+    const auto offset = input_tile_index % block_c_tiles;
+    input_tile_index = block * (block_c_tiles * tile_r_dim) + offset;
     for (std::uint32_t tile_index = 0; tile_index < block_c_tiles; tile_index++) {
         llk_unpack_tilize(operand, input_tile_index + tile_index, block_c_tiles);
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_tilize_api.h
@@ -91,8 +91,11 @@ inline void llk_unpack_tilize_block(
     std::uint32_t operand, std::uint32_t block_c_tiles, std::uint32_t input_tile_index = 0) {
     // Not sure if input_tile_index can be arbitrary but it works for moving across rows of files,
     // i.e. input_tile_index % block_c_tiles == 0
+    // Use the operand's actual rows-per-tile (e.g. 16 for a 16x32 tiny tile) for the cross-tile-row
+    // stride, not the compile-time TILE_R_DIM (32), which is wrong for tiles shorter than 32 rows.
+    const std::uint32_t tile_r_dim = get_operand_tile_r_dim(get_operand_id(operand));
     input_tile_index =
-        input_tile_index % block_c_tiles + (input_tile_index / block_c_tiles) * block_c_tiles * TILE_R_DIM;
+        input_tile_index % block_c_tiles + (input_tile_index / block_c_tiles) * block_c_tiles * tile_r_dim;
     for (std::uint32_t tile_index = 0; tile_index < block_c_tiles; tile_index++) {
         llk_unpack_tilize(operand, input_tile_index + tile_index, block_c_tiles);
     }


### PR DESCRIPTION
Issue:  https://github.com/tenstorrent/tt-metal/issues/48198

llk_unpack_tilize_block computed the cross-tile-row L1 stride using the compile-time constant TILE_R_DIM (32). For tiles shorter than 32 rows (e.g. a 16x32 tiny tile, num_faces=2, face_r_dim=16) this over-shoots, so any block spanning >= 2 tile-rows reads the second tile-row from the wrong address and produces incorrect output. Use the operand's actual rows-per-tile via get_operand_tile_r_dim() instead; this resolves to 32 for full tiles, so 32x32 behavior is unchanged.

Test:
- Add TensixComputeUnpackTilizeTinyTile16x32 (Blackhole), exercising tilize_block -> llk_unpack_tilize_block with a 16x32 tile and num_tiles_r >= 2 so the cross-tile-row stride is exercised. run_single_core_tilize_program now tags the input/output DataflowBuffers with the tiny-tile FaceGeometry for the UNPACK_A tilize path (previously only DST untilize set it).
- gold_standard_tilize stepped rows by a hardcoded 32; step by the actual tile-row height (face_r_dim * (num_faces > 2 ? 2 : 1)) so multi-tile-row tiny tiles are modeled correctly. No-op for 32x32 (step stays 32).

Verified on Blackhole p100a: the new 16x32 test passes with the fix and fails without it; existing 32x32 UnpackTilize still passes.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rtawfik/llk-unpack-tilize-block-16x32)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rtawfik/llk-unpack-tilize-block-16x32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rtawfik/llk-unpack-tilize-block-16x32)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rtawfik/llk-unpack-tilize-block-16x32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=rtawfik/llk-unpack-tilize-block-16x32)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:rtawfik/llk-unpack-tilize-block-16x32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rtawfik/llk-unpack-tilize-block-16x32)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rtawfik/llk-unpack-tilize-block-16x32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rtawfik/llk-unpack-tilize-block-16x32)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rtawfik/llk-unpack-tilize-block-16x32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rtawfik/llk-unpack-tilize-block-16x32)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rtawfik/llk-unpack-tilize-block-16x32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rtawfik/llk-unpack-tilize-block-16x32)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rtawfik/llk-unpack-tilize-block-16x32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rtawfik/llk-unpack-tilize-block-16x32)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rtawfik/llk-unpack-tilize-block-16x32)