### PR TITLE
[Test Only] emule: add wormhole+blackhole smoke-test script

### DIFF
--- a/tests/scripts/emule/README.md
+++ b/tests/scripts/emule/README.md
@@ -1,0 +1,64 @@
+<!-- SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# tt-emule smoke test
+
+[tt-emule](https://github.com/tenstorrent/tt-emule) is a C++ software emulator of
+the Tenstorrent device APIs. It lets tt-metal kernel and host code run on a plain
+x86-64 Linux host with no hardware, integrating through
+`-DTT_METAL_USE_EMULE=ON`. The host-side integration lives in this repo
+(`tt_metal/impl/emulation/`, plus the `TargetDevice::Emule` guards in
+`tt_metal/distributed/`).
+
+## What this catches
+
+A tt-metal change can break the emule integration while every silicon and mock
+test stays green — the emule path simply isn't exercised by tt-metal CI. (For
+example, a guard change routed `TargetDevice::Emule` through the RISC-V kernel
+compile path, which emule cannot satisfy; it was only caught downstream in the
+tt-emule regression, not on the tt-metal PR.) `run_emule_smoke.sh` runs a small
+emule build-and-run so that class of break fails on the tt-metal side.
+
+## Usage
+
+```bash
+# Build tt-metal with the emule backend and run wormhole + blackhole smoke sets.
+tests/scripts/emule/run_emule_smoke.sh
+
+# One arch only:
+tests/scripts/emule/run_emule_smoke.sh wormhole
+
+# Reuse an already-built tree and/or a local tt-emule checkout:
+EMULE_SKIP_BUILD=1 TT_EMULE_PATH=/path/to/tt-emule \
+  tests/scripts/emule/run_emule_smoke.sh
+```
+
+If `TT_EMULE_PATH` is not set, the script clones `tenstorrent/tt-emule@main`
+into `$HOME/.cache/tt-metal-emule-smoke/tt-emule` (refreshed on re-run). See the
+script header for all environment variables.
+
+**Prerequisites:** clang-20 + libstdc++ (gcc-13+), CMake ≥ 3.24, Ninja, ccache.
+The `ghcr.io/tenstorrent/tt-mlir/tt-mlir-ci-ubuntu-24-04` image has them all.
+
+## What it runs
+
+1. Resolves a tt-emule checkout (supplies `include/jit_hw` + `include/tt_emule`).
+2. Initializes the `umd` and `tracy` submodules.
+3. Builds tt-metal with `-DTT_METAL_USE_EMULE=ON` via tt-emule's maintained
+   `ci-build.sh` (clang-20 + libstdc++), falling back to an inline `cmake`
+   recipe if that script is absent.
+4. Runs the per-arch smoke sets **sequentially** (they share a JIT cache):
+   - **wormhole** — the curated PR tier (`CI_TIER=pr`): tilize/format, L1 + DRAM
+     buffers, a Tensix JIT kernel, DRAM channels, a DM loopback, a ttnn reduction.
+   - **blackhole** — the full (small) suite: host-only checks + INT32 ttnn ops.
+
+The build recipe and test lists are owned by tt-emule and reused as-is, so the
+smoke set tracks upstream automatically and this stays a thin driver.
+
+## Notes
+
+- Not wired into a GitHub Actions workflow yet — this is a runnable entry point
+  for local use and as the basis for a future CI job.
+- It builds tt-emule `main` against the current tt-metal checkout, so unrelated
+  drift between the two `main` branches can occasionally surface here. Pin
+  `TT_EMULE_REF` to a known-good ref if you need a stable baseline.

--- a/tests/scripts/emule/README.md
+++ b/tests/scripts/emule/README.md
@@ -34,8 +34,8 @@ EMULE_SKIP_BUILD=1 TT_EMULE_PATH=/path/to/tt-emule \
 ```
 
 If `TT_EMULE_PATH` is not set, the script clones `tenstorrent/tt-emule@main`
-into `$HOME/.cache/tt-metal-emule-smoke/tt-emule` (refreshed on re-run). See the
-script header for all environment variables.
+into `$HOME/.cache/tt-metal-emule-smoke/tt-emule` (override with `TT_EMULE_CACHE`;
+refreshed on re-run). See the script header for all environment variables.
 
 **Prerequisites:** clang-20 + libstdc++ (gcc-13+), CMake ≥ 3.24, Ninja, ccache.
 The `ghcr.io/tenstorrent/tt-mlir/tt-mlir-ci-ubuntu-24-04` image has them all.
@@ -48,12 +48,13 @@ The `ghcr.io/tenstorrent/tt-mlir/tt-mlir-ci-ubuntu-24-04` image has them all.
    `ci-build.sh` (clang-20 + libstdc++), falling back to an inline `cmake`
    recipe if that script is absent.
 4. Runs the per-arch smoke sets **sequentially** (they share a JIT cache):
-   - **wormhole** — the curated PR tier (`CI_TIER=pr`): tilize/format, L1 + DRAM
-     buffers, a Tensix JIT kernel, DRAM channels, a DM loopback, a ttnn reduction.
-   - **blackhole** — the full (small) suite: host-only checks + INT32 ttnn ops.
+   - **wormhole** — the curated PR tier (`CI_TIER=pr`).
+   - **blackhole** — the full (small) suite.
 
-The build recipe and test lists are owned by tt-emule and reused as-is, so the
-smoke set tracks upstream automatically and this stays a thin driver.
+The build recipe and per-arch test lists are owned by tt-emule
+(`scripts/run_regression_<arch>.sh`) and reused as-is, so the smoke set tracks
+upstream automatically and this stays a thin driver. The exact tests are
+deliberately not restated here — check those scripts for the current set.
 
 ## Notes
 

--- a/tests/scripts/emule/run_emule_smoke.sh
+++ b/tests/scripts/emule/run_emule_smoke.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# tt-emule smoke test — build tt-metal (the current checkout) with the tt-emule
+# software backend and run the curated wormhole + blackhole smoke sets.
+#
+# Why this exists
+# ---------------
+# The emule host-integration lives in this repo (tt_metal/impl/emulation/, the
+# TargetDevice::Emule guards in tt_metal/distributed/). A tt-metal change can
+# break it while every silicon/mock test stays green, because tt-metal CI runs
+# no emule tests — the dependency is one-way (the tt-emule repo pins and tests a
+# tt-metal SHA, not the reverse). This script is the minimal signal in the other
+# direction: run it against a tt-metal change to catch an emule-integration
+# break here, instead of downstream in the tt-emule regression.
+#
+# The actual build recipe and test lists are owned by tt-emule and reused as-is
+# (its .github/scripts/ci-build.sh and scripts/run_regression_<arch>.sh), so the
+# smoke set tracks upstream automatically and this script stays a thin driver.
+#
+# Usage
+# -----
+#   tests/scripts/emule/run_emule_smoke.sh [arch ...]
+#
+#   arch            wormhole | blackhole (default: both, run sequentially —
+#                   they share a JIT cache and cannot run concurrently)
+#
+# Environment
+# -----------
+#   TT_METAL_HOME     tt-metal source root         (default: git root of this script)
+#   TT_EMULE_PATH     existing tt-emule checkout    (default: clone TT_EMULE_REPO@TT_EMULE_REF)
+#   TT_EMULE_REPO     repo to clone if no checkout  (default: https://github.com/tenstorrent/tt-emule)
+#   TT_EMULE_REF      ref to clone / fetch          (default: main)
+#   BUILD_DIR         build tree                    (default: $TT_METAL_HOME/build_emule)
+#   EMULE_SKIP_BUILD  =1 to reuse an existing build (skip configure + compile)
+#
+# Prerequisites: clang-20 + libstdc++ (gcc-13+), CMake >= 3.24, Ninja, ccache,
+# and network access to clone tt-emule when TT_EMULE_PATH is not supplied. The
+# tt-mlir CI docker image (ghcr.io/tenstorrent/tt-mlir/tt-mlir-ci-ubuntu-24-04)
+# ships all of these.
+
+set -euo pipefail
+
+log()  { printf '\n\033[1;34m== %s ==\033[0m\n' "$*"; }
+warn() { printf '\033[1;33mWARN: %s\033[0m\n' "$*" >&2; }
+die()  { printf '\033[1;31mERROR: %s\033[0m\n' "$*" >&2; exit 1; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ---------------------------------------------------------------------------
+# Inputs
+# ---------------------------------------------------------------------------
+TT_METAL_HOME="${TT_METAL_HOME:-$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null)}"
+[ -n "${TT_METAL_HOME:-}" ] && [ -d "$TT_METAL_HOME" ] || die "cannot locate tt-metal root; set TT_METAL_HOME"
+TT_METAL_HOME="$(cd "$TT_METAL_HOME" && pwd)"
+
+BUILD_DIR="${BUILD_DIR:-$TT_METAL_HOME/build_emule}"
+TT_EMULE_REPO="${TT_EMULE_REPO:-https://github.com/tenstorrent/tt-emule}"
+TT_EMULE_REF="${TT_EMULE_REF:-main}"
+EMULE_SKIP_BUILD="${EMULE_SKIP_BUILD:-0}"
+
+# Arches: positional args override the default of both, in the required order.
+if [ "$#" -gt 0 ]; then
+    ARCHES=("$@")
+else
+    ARCHES=(wormhole blackhole)
+fi
+for a in "${ARCHES[@]}"; do
+    case "$a" in
+        wormhole|blackhole) ;;
+        *) die "unknown arch '$a' (expected: wormhole | blackhole)" ;;
+    esac
+done
+
+log "tt-emule smoke test"
+echo "  TT_METAL_HOME: $TT_METAL_HOME"
+echo "  BUILD_DIR:     $BUILD_DIR"
+echo "  arches:        ${ARCHES[*]}"
+
+# ---------------------------------------------------------------------------
+# Resolve a tt-emule checkout (supplies include/jit_hw + include/tt_emule and
+# the build/test scripts). Use TT_EMULE_PATH if given; otherwise clone/refresh
+# a cached checkout under $HOME/.cache.
+# ---------------------------------------------------------------------------
+if [ -n "${TT_EMULE_PATH:-}" ]; then
+    [ -d "$TT_EMULE_PATH" ] || die "TT_EMULE_PATH does not exist: $TT_EMULE_PATH"
+    TT_EMULE_PATH="$(cd "$TT_EMULE_PATH" && pwd)"
+    log "Using tt-emule at $TT_EMULE_PATH"
+else
+    TT_EMULE_PATH="${TT_EMULE_CACHE:-$HOME/.cache/tt-metal-emule-smoke/tt-emule}"
+    log "Fetching tt-emule ($TT_EMULE_REPO @ $TT_EMULE_REF) into $TT_EMULE_PATH"
+    if [ -d "$TT_EMULE_PATH/.git" ]; then
+        git -C "$TT_EMULE_PATH" fetch --depth=1 origin "$TT_EMULE_REF"
+        git -C "$TT_EMULE_PATH" checkout -q FETCH_HEAD
+    else
+        mkdir -p "$(dirname "$TT_EMULE_PATH")"
+        git clone --depth=1 --branch "$TT_EMULE_REF" "$TT_EMULE_REPO" "$TT_EMULE_PATH"
+    fi
+fi
+
+CI_BUILD="$TT_EMULE_PATH/.github/scripts/ci-build.sh"
+WH_SCRIPT="$TT_EMULE_PATH/scripts/run_regression_wormhole.sh"
+BH_SCRIPT="$TT_EMULE_PATH/scripts/run_regression_blackhole.sh"
+[ -f "$WH_SCRIPT" ] || die "missing $WH_SCRIPT — is $TT_EMULE_PATH a tt-emule checkout?"
+[ -f "$BH_SCRIPT" ] || die "missing $BH_SCRIPT — is $TT_EMULE_PATH a tt-emule checkout?"
+
+# ---------------------------------------------------------------------------
+# Submodules: emule needs UMD (SWEmuleChip + the cluster_descriptor_examples the
+# regression scripts read) and tracy. Init shallow; no-op if already present.
+# ---------------------------------------------------------------------------
+log "Initializing tt-metal submodules (umd, tracy)"
+git -C "$TT_METAL_HOME" submodule update --init --depth=1 tt_metal/third_party/umd tt_metal/third_party/tracy
+
+CLUSTER_EXAMPLES="$TT_METAL_HOME/tt_metal/third_party/umd/tests/cluster_descriptor_examples"
+[ -f "$CLUSTER_EXAMPLES/wormhole_N150.yaml" ] || warn "wormhole_N150.yaml not found under $CLUSTER_EXAMPLES"
+[ -f "$CLUSTER_EXAMPLES/blackhole_P100.yaml" ] || warn "blackhole_P100.yaml not found under $CLUSTER_EXAMPLES"
+
+# ---------------------------------------------------------------------------
+# Build tt-metal with the emule backend. Delegate to tt-emule's maintained
+# recipe when present (single source of truth); otherwise inline an equivalent.
+# ---------------------------------------------------------------------------
+if [ "$EMULE_SKIP_BUILD" = "1" ]; then
+    log "EMULE_SKIP_BUILD=1 — reusing existing build at $BUILD_DIR"
+elif [ -f "$CI_BUILD" ]; then
+    log "Building via tt-emule ci-build.sh"
+    TT_EMULE_DIR="$TT_EMULE_PATH" TT_METAL_DIR="$TT_METAL_HOME" BUILD_DIR="$BUILD_DIR" \
+        bash "$CI_BUILD"
+else
+    warn "ci-build.sh not found in tt-emule checkout — using inline build recipe"
+    log "Configuring tt-metal (emule ON, clang-20 + libstdc++)"
+    cmake -B "$BUILD_DIR" -S "$TT_METAL_HOME" -G Ninja \
+        -DCMAKE_TOOLCHAIN_FILE="$TT_METAL_HOME/cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DTT_METAL_USE_EMULE=ON \
+        -DTT_EMULE_PATH="$TT_EMULE_PATH" \
+        -DWITH_PYTHON_BINDINGS=ON \
+        -DENABLE_TRACY=OFF \
+        -DENABLE_DISTRIBUTED=OFF \
+        -DTT_METAL_BUILD_TESTS=ON \
+        -DTTNN_BUILD_TESTS=ON \
+        -DTT_INSTALL=OFF \
+        -DTT_USE_SYSTEM_SFPI=OFF
+    log "Building smoke-test binaries"
+    cmake --build "$BUILD_DIR" -j"$(nproc)" --target \
+        unit_tests_api unit_tests_data_movement unit_tests_ttnn ttnn
+fi
+
+# ---------------------------------------------------------------------------
+# Run the per-arch smoke sets sequentially (shared JIT cache). Wormhole runs its
+# curated PR tier (CI_TIER=pr); blackhole runs its full suite (small — Tier 1 +
+# INT32 Tier 4). A failure in either arch fails the whole run.
+# ---------------------------------------------------------------------------
+declare -A RESULT
+overall=0
+
+run_arch() {
+    local arch="$1" script="$2"; shift 2
+    log "Regression: $arch"
+    if TT_METAL_DIR="$TT_METAL_HOME" BUILD_DIR="$BUILD_DIR" "$@" bash "$script"; then
+        RESULT[$arch]=PASS
+    else
+        RESULT[$arch]=FAIL
+        overall=1
+    fi
+}
+
+for arch in "${ARCHES[@]}"; do
+    case "$arch" in
+        wormhole)  run_arch wormhole  "$WH_SCRIPT" env CI_TIER=pr ;;
+        blackhole) run_arch blackhole "$BH_SCRIPT" env ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+log "tt-emule smoke summary"
+for arch in "${ARCHES[@]}"; do
+    printf '  %-10s %s\n' "$arch" "${RESULT[$arch]:-SKIP}"
+done
+
+if [ "$overall" -ne 0 ]; then
+    die "tt-emule smoke test FAILED"
+fi
+echo "tt-emule smoke test PASSED"

--- a/tests/scripts/emule/run_emule_smoke.sh
+++ b/tests/scripts/emule/run_emule_smoke.sh
@@ -32,7 +32,8 @@
 #   TT_METAL_HOME     tt-metal source root         (default: git root of this script)
 #   TT_EMULE_PATH     existing tt-emule checkout    (default: clone TT_EMULE_REPO@TT_EMULE_REF)
 #   TT_EMULE_REPO     repo to clone if no checkout  (default: https://github.com/tenstorrent/tt-emule)
-#   TT_EMULE_REF      ref to clone / fetch          (default: main)
+#   TT_EMULE_REF      ref to clone / fetch          (default: main; branch, tag or SHA)
+#   TT_EMULE_CACHE    cache dir for the clone       (default: $HOME/.cache/tt-metal-emule-smoke/tt-emule)
 #   BUILD_DIR         build tree                    (default: $TT_METAL_HOME/build_emule)
 #   EMULE_SKIP_BUILD  =1 to reuse an existing build (skip configure + compile)
 #
@@ -52,7 +53,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # ---------------------------------------------------------------------------
 # Inputs
 # ---------------------------------------------------------------------------
-TT_METAL_HOME="${TT_METAL_HOME:-$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null)}"
+TT_METAL_HOME="${TT_METAL_HOME:-$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || true)}"
 [ -n "${TT_METAL_HOME:-}" ] && [ -d "$TT_METAL_HOME" ] || die "cannot locate tt-metal root; set TT_METAL_HOME"
 TT_METAL_HOME="$(cd "$TT_METAL_HOME" && pwd)"
 
@@ -91,20 +92,22 @@ if [ -n "${TT_EMULE_PATH:-}" ]; then
 else
     TT_EMULE_PATH="${TT_EMULE_CACHE:-$HOME/.cache/tt-metal-emule-smoke/tt-emule}"
     log "Fetching tt-emule ($TT_EMULE_REPO @ $TT_EMULE_REF) into $TT_EMULE_PATH"
-    if [ -d "$TT_EMULE_PATH/.git" ]; then
-        git -C "$TT_EMULE_PATH" fetch --depth=1 origin "$TT_EMULE_REF"
-        git -C "$TT_EMULE_PATH" checkout -q FETCH_HEAD
-    else
-        mkdir -p "$(dirname "$TT_EMULE_PATH")"
-        git clone --depth=1 --branch "$TT_EMULE_REF" "$TT_EMULE_REPO" "$TT_EMULE_PATH"
+    # Init-then-fetch works identically cold or warm, and (unlike
+    # `git clone --branch`) accepts a branch, tag *or* commit SHA — so a
+    # SHA pin in TT_EMULE_REF bootstraps a fresh cache the same way it
+    # refreshes an existing one.
+    if [ ! -d "$TT_EMULE_PATH/.git" ]; then
+        mkdir -p "$TT_EMULE_PATH"
+        git -C "$TT_EMULE_PATH" init -q
+        git -C "$TT_EMULE_PATH" remote add origin "$TT_EMULE_REPO"
     fi
+    git -C "$TT_EMULE_PATH" fetch --depth=1 origin "$TT_EMULE_REF"
+    git -C "$TT_EMULE_PATH" checkout -q FETCH_HEAD
 fi
 
 CI_BUILD="$TT_EMULE_PATH/.github/scripts/ci-build.sh"
 WH_SCRIPT="$TT_EMULE_PATH/scripts/run_regression_wormhole.sh"
 BH_SCRIPT="$TT_EMULE_PATH/scripts/run_regression_blackhole.sh"
-[ -f "$WH_SCRIPT" ] || die "missing $WH_SCRIPT — is $TT_EMULE_PATH a tt-emule checkout?"
-[ -f "$BH_SCRIPT" ] || die "missing $BH_SCRIPT — is $TT_EMULE_PATH a tt-emule checkout?"
 
 # ---------------------------------------------------------------------------
 # Submodules: emule needs UMD (SWEmuleChip + the cluster_descriptor_examples the
@@ -122,6 +125,7 @@ CLUSTER_EXAMPLES="$TT_METAL_HOME/tt_metal/third_party/umd/tests/cluster_descript
 # recipe when present (single source of truth); otherwise inline an equivalent.
 # ---------------------------------------------------------------------------
 if [ "$EMULE_SKIP_BUILD" = "1" ]; then
+    [ -d "$BUILD_DIR" ] || die "EMULE_SKIP_BUILD=1 but no build tree at $BUILD_DIR"
     log "EMULE_SKIP_BUILD=1 — reusing existing build at $BUILD_DIR"
 elif [ -f "$CI_BUILD" ]; then
     log "Building via tt-emule ci-build.sh"
@@ -143,20 +147,28 @@ else
         -DTT_INSTALL=OFF \
         -DTT_USE_SYSTEM_SFPI=OFF
     log "Building smoke-test binaries"
+    # Mirror the target set ci-build.sh builds (the source of truth). Kept in
+    # sync as a best-effort fallback for checkouts without that script; the
+    # regression runners report a clear "binary not found" for any target a
+    # newer upstream test list needs that this list has not yet picked up.
     cmake --build "$BUILD_DIR" -j"$(nproc)" --target \
-        unit_tests_api unit_tests_data_movement unit_tests_ttnn ttnn
+        unit_tests_api unit_tests_integration unit_tests_legacy \
+        unit_tests_data_movement unit_tests_per_core_allocation \
+        unit_tests_ttnn ttnn
 fi
 
 # ---------------------------------------------------------------------------
 # Run the per-arch smoke sets sequentially (shared JIT cache). Wormhole runs its
-# curated PR tier (CI_TIER=pr); blackhole runs its full suite (small — Tier 1 +
-# INT32 Tier 4). A failure in either arch fails the whole run.
+# curated PR tier (CI_TIER=pr); blackhole runs its full suite. The exact test
+# lists live in tt-emule's run_regression_<arch>.sh and are tracked upstream, so
+# they are not restated here. A failure in either arch fails the whole run.
 # ---------------------------------------------------------------------------
 declare -A RESULT
 overall=0
 
 run_arch() {
     local arch="$1" script="$2"; shift 2
+    [ -f "$script" ] || die "missing $script — is $TT_EMULE_PATH a tt-emule checkout?"
     log "Regression: $arch"
     if TT_METAL_DIR="$TT_METAL_HOME" BUILD_DIR="$BUILD_DIR" "$@" bash "$script"; then
         RESULT[$arch]=PASS


### PR DESCRIPTION
### PR Category
Test Only

### Summary
tt-metal has no CI or local coverage of the **tt-emule** software-emulation
backend, so a tt-metal change can break the emule host integration
(`tt_metal/impl/emulation/`, the `TargetDevice::Emule` guards in
`tt_metal/distributed/`) while every silicon and mock test stays green. The
dependency is one-way today — the tt-emule repo pins and tests a tt-metal SHA,
not the reverse.

This adds a runnable smoke-test entry point, `tests/scripts/emule/run_emule_smoke.sh`,
that builds tt-metal with `-DTT_METAL_USE_EMULE=ON` and runs the curated
wormhole + blackhole smoke sets, so that class of break can be caught on the
tt-metal side.

### What it does
1. Resolves a tt-emule checkout — `TT_EMULE_PATH` if set, else clones
   `tenstorrent/tt-emule@main` into `$HOME/.cache`.
2. Initializes the `umd` + `tracy` submodules.
3. Builds tt-metal with the emule backend via tt-emule's maintained
   `ci-build.sh` (clang-20 + libstdc++), with an inline `cmake` fallback.
4. Runs, sequentially (shared JIT cache): **wormhole** curated PR tier
   (`CI_TIER=pr`) and **blackhole** full suite. Any arch failure fails the run.




### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mkamran/emule-smoke-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mkamran/emule-smoke-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mkamran/emule-smoke-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mkamran/emule-smoke-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mkamran/emule-smoke-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mkamran/emule-smoke-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mkamran/emule-smoke-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mkamran/emule-smoke-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mkamran/emule-smoke-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mkamran/emule-smoke-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mkamran/emule-smoke-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mkamran/emule-smoke-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mkamran/emule-smoke-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mkamran/emule-smoke-tests)