### PR TITLE
[LLK][WH] Remove dead unpacker writes of INT8 / SrcB word-1 config bits

### DIFF
--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h
@@ -197,13 +197,6 @@ inline void wait_for_idle()
     }
 }
 
-inline void enable_int8_fpu_math()
-{
-    alu_config_u alu_payload                     = {.val = 0};
-    alu_payload.f.ALU_ACC_CTRL_INT8_math_enabled = 1;
-    cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_ADDR32, 0, ALU_ACC_CTRL_INT8_math_enabled_MASK>(alu_payload.val);
-}
-
 /**
  * \brief Returns true if unpacker I/O uses 32-bit formats (Int32 or Float32).
  *

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_common.h
@@ -278,14 +278,6 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
 }
 
 /**
- * @brief Enable Int8 math on the FPU.
- */
-inline void _llk_enable_int8_fpu_math_()
-{
-    enable_int8_fpu_math();
-}
-
-/**
  * @brief Mark SrcA and SrcB as data-valid without unpacking real data.
  *
  * Issues zero-source UNPACR NOPs that set the data-valid flag on both source registers, e.g. to

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_reduce.h
@@ -69,7 +69,6 @@ inline void _llk_unpack_reduce_init_(
     LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
 
     // Configure SrcB format registers
-    cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG1_SrcB_RMW>(unpB_dst_format);
     cfg_reg_rmw_tensix<THCON_SEC1_REG0_TileDescriptor_ADDR32, 0, 0xf>(unpB_src_format);
     cfg_reg_rmw_tensix<THCON_SEC1_REG2_Out_data_format_RMW>(unpB_dst_format);
 


### PR DESCRIPTION
## What

Issue : https://github.com/tenstorrent/tt-llk/issues/1667

On Wormhole B0, remove three pieces of **dead unpacker code** that write two shared `ALU_FORMAT_SPEC` (word 1) config fields:

1. `enable_int8_fpu_math` (`cunpack_common.h`) — the only unpacker writer of `ALU_ACC_CTRL_INT8_math_enabled` (bit 31).
2. `_llk_enable_int8_fpu_math_` (`llk_unpack_common.h`) — its sole caller.
3. The `ALU_FORMAT_SPEC_REG1_SrcB` write (bits 21-24) in `_llk_unpack_reduce_init_` (`llk_unpack_reduce.h`).

## Why

A cross-thread audit of word-1 config sharing (tt-llk #1249 context) found that on WH these unpacker-side writers are **unreachable dead code**:

- `_llk_enable_int8_fpu_math_` / `enable_int8_fpu_math` have **zero callers** anywhere in the repo. `INT8_math_enabled` is written only by the MATH thread in the live paths.
- The single-operand reduce path (`llk_unpack_reduce_init` / `_llk_unpack_reduce_init_`) is **orphaned** on WH — the live reduce uses `_llk_unpack_AB_reduce_`. The SrcB ALU format is programmed by the MATH thread.

Removing them eliminates the latent unpack↔math cross-thread sharing of these word-1 fields (making the audit's "UNPACK+MATH" for INT8/SrcB MATH-only in fact as well as in practice).

## Scope / safety

- **Wormhole B0 only.** Blackhole intentionally untouched.
- The unpacker's own THCON SrcB format regs (tile descriptor / out-data-format) in `_llk_unpack_reduce_init_` are **kept** — only the ALU word-1 write is removed.
- Verified: no remaining references to the removed symbols; `ALU_ACC_CTRL_INT8_math_enabled` mask/bitfield still used by the MATH writer and `alu_config_u`.
- Pure dead-code deletion (16 lines, no callers) — no behavioral change on any live path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/llk-wh-drop-dead-unpacker-int8-srcb-writes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/llk-wh-drop-dead-unpacker-int8-srcb-writes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/llk-wh-drop-dead-unpacker-int8-srcb-writes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/llk-wh-drop-dead-unpacker-int8-srcb-writes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/llk-wh-drop-dead-unpacker-int8-srcb-writes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/llk-wh-drop-dead-unpacker-int8-srcb-writes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/llk-wh-drop-dead-unpacker-int8-srcb-writes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/llk-wh-drop-dead-unpacker-int8-srcb-writes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/llk-wh-drop-dead-unpacker-int8-srcb-writes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/llk-wh-drop-dead-unpacker-int8-srcb-writes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/llk-wh-drop-dead-unpacker-int8-srcb-writes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/llk-wh-drop-dead-unpacker-int8-srcb-writes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/llk-wh-drop-dead-unpacker-int8-srcb-writes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/llk-wh-drop-dead-unpacker-int8-srcb-writes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/llk-wh-drop-dead-unpacker-int8-srcb-writes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/llk-wh-drop-dead-unpacker-int8-srcb-writes)