### PR TITLE
[cleanup] Remove `TensorAccessor::get_bank_base_address()`

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -1147,12 +1147,14 @@ TEST_F(ProgramSpecHWTest, CrtaAllFourSectionsSetAndPartialUpdate) {
     auto producer = MakeMinimalGen1DMKernel("producer", DataMovementProcessor::RISCV_0);
     producer.source = KernelSpec::SourceCode{R"(
 #include "api/dataflow/dataflow_api.h"
+#include "api/tensor/local_tensor_accessor.h"
 #include "experimental/kernel_args.h"
 void kernel_main() {
     const uint32_t named0 = get_arg(args::named0);
     const uint32_t named1 = get_arg(args::named1);
+    LocalTensorAccessor<uint32_t> local_acc(tensor::io);
+    const uint32_t tensor_base = local_acc.get_bank_base_address();
     TensorAccessor acc(tensor::io);
-    const uint32_t tensor_base = acc.get_bank_base_address();
     const uint32_t page_size = acc.get_aligned_page_size();  // binding's 2nd CRTA word (dynamic_tensor_shape)
     Scratchpad<uint32_t> pad(scratch::pad);
     const uint32_t scratch_base = pad.get_base_address();

--- a/tests/ttnn/unit_tests/gtests/accessor/kernels/copy_local_via_bank_base.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/kernels/copy_local_via_bank_base.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
 #include "api/tensor/tensor_accessor.h"
+#include "api/tensor/local_tensor_accessor.h"
 
 void kernel_main() {
     // This test uses legacy RTA indices to get the bank base addresses.
@@ -23,9 +24,11 @@ void kernel_main() {
     auto tensor_accessor_src = TensorAccessor(args_src, input_base_address);
     auto tensor_accessor_dst = TensorAccessor(args_dst, output_base_address);
 
-    // If you needed the pointer, you could pull it out of the TensorAccessor:
-    const uint32_t src_l1 = tensor_accessor_src.get_bank_base_address();
-    const uint32_t dst_l1 = tensor_accessor_dst.get_bank_base_address();
+    // If you needed the pointer, use LocalTensorAccessor's legacy raw-address ctor:
+    LocalTensorAccessor<uint32_t> local_accessor_src(input_base_address);
+    LocalTensorAccessor<uint32_t> local_accessor_dst(output_base_address);
+    const uint32_t src_l1 = local_accessor_src.get_bank_base_address();
+    const uint32_t dst_l1 = local_accessor_dst.get_bank_base_address();
     const uint32_t shard_size_bytes =
         tensor_accessor_src.get_aligned_page_size() * tensor_accessor_src.dspec().shard_volume();
     const uint32_t total_bytes = shard_size_bytes * n_shards;

--- a/tt_metal/hw/inc/api/tensor/tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor.h
@@ -161,11 +161,6 @@ public:
         return get_shard_noc_addr(shard_id, offset, noc);
     }
 
-    // Returns the bank-relative base address (offset) used by this accessor.
-    // (For L1-sharded tensors, this is the local L1 base address of the shard region.)
-    FORCE_INLINE
-    constexpr uint32_t get_bank_base_address() const { return bank_base_address; }
-
     // Helpers
     struct PageMapping {
         size_t bank_id;
@@ -466,11 +461,6 @@ struct TensorAccessor<tensor_accessor::DistributionSpec<
             "TensorAccessor::is_local_shard is not supported by the interleaved tensor accessor");
         return false;
     }
-
-    // Returns the bank-relative base address (offset) used by this accessor.
-    // (For L1-sharded tensors, this is the local L1 base address of the shard region.)
-    FORCE_INLINE
-    constexpr uint32_t get_bank_base_address() const { return this->bank_base_address; }
 
     // Returns a proxy for shard pages iterator
     tensor_accessor::ShardPages<TensorAccessor> shard_pages(

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/halo/device/kernels/dataflow/halo_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/halo/device/kernels/dataflow/halo_gather.cpp
@@ -9,7 +9,7 @@
 //
 // Resource model (see untilize_with_halo_program_factory.cpp):
 //   tensor::out             - output shard (borrowed-memory address source via
-//                             get_bank_base_address(); both readers scatter-write it).
+//                             LocalTensorAccessor::get_bank_base_address(); both readers scatter-write it).
 //   tensor::in              - input shard (skip_untilize path only): read directly by
 //                             base pointer.
 //   tensor::gather_config   - gather config (L1 path): read by base pointer.
@@ -32,6 +32,7 @@
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/tensor_accessor.h"
+#include "api/tensor/local_tensor_accessor.h"
 #include "api/tensor/noc_traits.h"
 #include "experimental/kernel_args.h"
 
@@ -248,7 +249,7 @@ void kernel_main() {
     Noc noc;
 
     // Output shard base (borrowed-memory address source; both readers scatter-write here).
-    TensorAccessor out_acc(tensor::out);
+    LocalTensorAccessor<uint32_t> out_acc(tensor::out);
     const uint32_t out_base_l1_addr = out_acc.get_bank_base_address();
 
     // Gather/padding config base L1 addresses.
@@ -280,10 +281,10 @@ void kernel_main() {
     noc.async_read_barrier();
 #else
     // L1 config: the config tensor is sharded one shard per core; read the local shard directly.
-    TensorAccessor gather_config_acc(tensor::gather_config);
+    LocalTensorAccessor<uint32_t> gather_config_acc(tensor::gather_config);
     gather_config_l1_addr = gather_config_acc.get_bank_base_address();
 #ifdef ENABLE_PADDING
-    TensorAccessor padding_config_acc(tensor::padding_config);
+    LocalTensorAccessor<uint32_t> padding_config_acc(tensor::padding_config);
     padding_config_l1_addr = padding_config_acc.get_bank_base_address();
 #endif
 #endif
@@ -398,7 +399,7 @@ void kernel_main() {
 #else
         {
             // skip_untilize: the resident input shard is the gather source (read directly).
-            TensorAccessor in_acc(tensor::in);
+            LocalTensorAccessor<uint32_t> in_acc(tensor::in);
             in_base_l1_addr = in_acc.get_bank_base_address();
             while (number_of_segments_remaining) {
                 const uint16_t destination_noc_x = config[current_config_index++];

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/halo/device/untilize_with_halo_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/halo/device/untilize_with_halo_program_factory.cpp
@@ -40,9 +40,9 @@ namespace {
 //   IN          - input tensor.  On the tiled (untilize) path it backs the
 //                 borrowed SRC dataflow buffer the compute kernel consumes; on
 //                 the ROW_MAJOR (skip_untilize) path both readers read it
-//                 directly via TensorAccessor(tensor::in).get_bank_base_address().
+//                 directly via LocalTensorAccessor(tensor::in).get_bank_base_address().
 //   OUT         - output tensor.  BOTH readers NoC-scatter-write disjoint
-//                 regions into it via TensorAccessor(tensor::out).get_bank_base_address().
+//                 regions into it via LocalTensorAccessor(tensor::out).get_bank_base_address().
 //                 (This binding on both readers is legal — a TensorParameter
 //                 has no endpoint-exclusivity constraint, unlike a DFB.)
 //   PAD_CONFIG0/1, GATHER_CONFIG0/1 - op-owned sliding-window config tensors.

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/kernels/dataflow/reshard_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/kernels/dataflow/reshard_reader.cpp
@@ -6,7 +6,7 @@
 //
 // Gathers strided page ranges from the input tensor (read on remote cores via UnicastEndpoint) into
 // the local output sharded buffer.
-//   - The input tensor base address comes from TensorAccessor(tensor::input).get_bank_base_address().
+//   - The input tensor base address comes from LocalTensorAccessor(tensor::input).get_bank_base_address().
 //   - The local output buffer base L1 address comes from DataflowBuffer(dfb::shard_cb).get_write_ptr()
 //     (the DFB borrows the output tensor's buffer; it is used here purely as an address source).
 //
@@ -15,7 +15,7 @@
 //   then: num_output_pages, num_ranges, output_page_offset, followed by the range stride blocks.
 
 #include <stdint.h>
-#include "api/tensor/tensor_accessor.h"
+#include "api/tensor/local_tensor_accessor.h"
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
@@ -33,7 +33,7 @@ void kernel_main() {
     uint32_t y_offset = num_x_cores;
 
     uint32_t arg_index = num_x_cores + num_y_cores;
-    TensorAccessor input(tensor::input);
+    LocalTensorAccessor<uint32_t> input(tensor::input);
     const uint32_t input_shard_addr = input.get_bank_base_address();
     const uint32_t num_output_pages = get_vararg(arg_index++);
     const uint32_t num_ranges = get_vararg(arg_index++);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/kernels/dataflow/reshard_reader_diff_width.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/kernels/dataflow/reshard_reader_diff_width.cpp
@@ -6,7 +6,7 @@
 //
 // Gathers strided page ranges from the input tensor (read on remote cores via UnicastEndpoint) into
 // the local output sharded buffer.
-//   - The input tensor base address comes from TensorAccessor(tensor::input).get_bank_base_address().
+//   - The input tensor base address comes from LocalTensorAccessor(tensor::input).get_bank_base_address().
 //   - The local output buffer base L1 address comes from DataflowBuffer(dfb::shard_cb).get_write_ptr()
 //     (the DFB borrows the output tensor's buffer; it is used here purely as an address source).
 //
@@ -15,7 +15,7 @@
 //   then: num_output_pages, num_blocks, output_page_offset, followed by compressed stride blocks.
 
 #include <stdint.h>
-#include "api/tensor/tensor_accessor.h"
+#include "api/tensor/local_tensor_accessor.h"
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
@@ -33,7 +33,7 @@ void kernel_main() {
     uint32_t y_offset = num_x_cores;
 
     uint32_t arg_index = num_x_cores + num_y_cores;
-    TensorAccessor input(tensor::input);
+    LocalTensorAccessor<uint32_t> input(tensor::input);
     const uint32_t input_shard_addr = input.get_bank_base_address();
     const uint32_t num_output_pages = get_vararg(arg_index++);
     const uint32_t num_blocks = get_vararg(arg_index++);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/kernels/dataflow/reshard_same_height_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/kernels/dataflow/reshard_same_height_reader.cpp
@@ -5,7 +5,7 @@
 // Metal 2.0 reshard same-height (WIDTH_SHARDED -> WIDTH_SHARDED) reader.
 //
 // Reads contiguous segments from the remote tensor into the local sharded buffer.
-//   - The remote tensor base address comes from TensorAccessor(tensor::remote).get_bank_base_address().
+//   - The remote tensor base address comes from LocalTensorAccessor(tensor::remote).get_bank_base_address().
 //   - The local sharded buffer base L1 address comes from DataflowBuffer(dfb::shard_cb).get_write_ptr()
 //     (the DFB borrows the local tensor's buffer; it is used here purely as an address source).
 //
@@ -14,7 +14,7 @@
 //   (padded by the host to a uniform max; only the first num_segments*4 entries are read.)
 
 #include <stdint.h>
-#include "api/tensor/tensor_accessor.h"
+#include "api/tensor/local_tensor_accessor.h"
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
@@ -31,7 +31,7 @@ void kernel_main() {
     const uint32_t remote_stride_bytes = get_arg(args::remote_stride_bytes);
     const uint32_t num_segments = get_arg(args::num_segments);
 
-    TensorAccessor remote(tensor::remote);
+    LocalTensorAccessor<uint32_t> remote(tensor::remote);
     DataflowBuffer shard_cb(dfb::shard_cb);
     Noc noc;
     AllocatorBank<bank_type> bank;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/kernels/dataflow/reshard_same_height_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/kernels/dataflow/reshard_same_height_writer.cpp
@@ -5,7 +5,7 @@
 // Metal 2.0 reshard same-height (WIDTH_SHARDED -> WIDTH_SHARDED) writer.
 //
 // Writes contiguous segments from the local sharded buffer out to the remote tensor.
-//   - The remote tensor base address comes from TensorAccessor(tensor::remote).get_bank_base_address().
+//   - The remote tensor base address comes from LocalTensorAccessor(tensor::remote).get_bank_base_address().
 //   - The local sharded buffer base L1 address comes from DataflowBuffer(dfb::shard_cb).get_read_ptr()
 //     (the DFB borrows the local tensor's buffer; it is used here purely as an address source).
 //
@@ -14,7 +14,7 @@
 //   (padded by the host to a uniform max; only the first num_segments*4 entries are read.)
 
 #include <stdint.h>
-#include "api/tensor/tensor_accessor.h"
+#include "api/tensor/local_tensor_accessor.h"
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
@@ -31,7 +31,7 @@ void kernel_main() {
     const uint32_t remote_stride_bytes = get_arg(args::remote_stride_bytes);
     const uint32_t num_segments = get_arg(args::num_segments);
 
-    TensorAccessor remote(tensor::remote);
+    LocalTensorAccessor<uint32_t> remote(tensor::remote);
     DataflowBuffer shard_cb(dfb::shard_cb);
     Noc noc;
     AllocatorBank<bank_type> bank;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/kernels/dataflow/reshard_same_width_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/kernels/dataflow/reshard_same_width_reader.cpp
@@ -5,7 +5,7 @@
 // Metal 2.0 reshard same-width (HEIGHT_SHARDED -> HEIGHT_SHARDED) reader.
 //
 // Reads units from the remote tensor into the local sharded buffer.
-//   - The remote tensor base address comes from TensorAccessor(tensor::remote).get_bank_base_address().
+//   - The remote tensor base address comes from LocalTensorAccessor(tensor::remote).get_bank_base_address().
 //   - The local sharded buffer base L1 address comes from DataflowBuffer(dfb::shard_cb).get_write_ptr()
 //     (the DFB borrows the local tensor's buffer; it is used here purely as an address source).
 //   - When UNALIGNED is defined, a scratch DFB (dfb::scratch_cb) stages padded remote reads before
@@ -16,7 +16,7 @@
 //   (padded by the host to a uniform max; only the first num_reads*3 entries are read.)
 
 #include <stdint.h>
-#include "api/tensor/tensor_accessor.h"
+#include "api/tensor/local_tensor_accessor.h"
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
@@ -39,7 +39,7 @@ void kernel_main() {
         return;
     }
 
-    TensorAccessor remote(tensor::remote);
+    LocalTensorAccessor<uint32_t> remote(tensor::remote);
     Noc noc;
     AllocatorBank<bank_type> bank;
     DataflowBuffer shard_cb(dfb::shard_cb);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/kernels/dataflow/reshard_same_width_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/kernels/dataflow/reshard_same_width_writer.cpp
@@ -5,7 +5,7 @@
 // Metal 2.0 reshard same-width (HEIGHT_SHARDED -> HEIGHT_SHARDED) writer.
 //
 // Writes units from the local sharded buffer out to the remote tensor.
-//   - The remote tensor base address comes from TensorAccessor(tensor::remote).get_bank_base_address().
+//   - The remote tensor base address comes from LocalTensorAccessor(tensor::remote).get_bank_base_address().
 //   - The local sharded buffer base L1 address comes from DataflowBuffer(dfb::shard_cb).get_read_ptr()
 //     (the DFB borrows the local tensor's buffer; it is used here purely as an address source).
 //
@@ -14,7 +14,7 @@
 //   (padded by the host to a uniform max; only the first num_writes*3 entries are read.)
 
 #include <stdint.h>
-#include "api/tensor/tensor_accessor.h"
+#include "api/tensor/local_tensor_accessor.h"
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
@@ -33,7 +33,7 @@ void kernel_main() {
         return;
     }
 
-    TensorAccessor remote(tensor::remote);
+    LocalTensorAccessor<uint32_t> remote(tensor::remote);
     DataflowBuffer shard_cb(dfb::shard_cb);
     Noc noc;
     AllocatorBank<bank_type> bank;


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Cleanup

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Removes `TensorAccessor::get_bank_base_address()` and migrates use sites to `LocalTensorAccessor::get_bank_base_address()`.

Motivation:
[[ Audrey please fill in this ]].

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/rm-get-bank-base-addr)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/rm-get-bank-base-addr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/rm-get-bank-base-addr)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/rm-get-bank-base-addr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=riverwu/rm-get-bank-base-addr)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:riverwu/rm-get-bank-base-addr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/rm-get-bank-base-addr)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/rm-get-bank-base-addr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/rm-get-bank-base-addr)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/rm-get-bank-base-addr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/rm-get-bank-base-addr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/rm-get-bank-base-addr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/rm-get-bank-base-addr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/rm-get-bank-base-addr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/rm-get-bank-base-addr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/rm-get-bank-base-addr)