### PR TITLE
[DM] Misc. updates to DM test suite

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/README.md
@@ -34,29 +34,29 @@ Both API versions run the same test cases but use different underlying implement
 
 | Name                        | ID(s)                           | Description                                                                             |
 | ----------                  | -----                           | ----------------------------------------------------                                    |
-| DRAM Unary                  | 0-3, 40                         | Transactions between DRAM and a single Tensix core.                                     |
-| One to One                  | 4, 50, 150-151, 158             | Write transactions between two Tensix cores.                                            |
-| One From One                | 5, 51, 152-153, 159             | Read transactions between two Tensix cores.                                             |
+| DRAM Unary                  | 0-3, 40-43                         | Transactions between DRAM and a single Tensix core.                                     |
+| One to One                  | 4, 50, 150-151, 158, 160             | Write transactions between two Tensix cores.                                            |
+| One From One                | 5, 51, 152-153, 159, 161             | Read transactions between two Tensix cores.                                             |
 | One to all                  | 6-8, 52, 154-155, 170-172       | Writes transaction from one core to all cores.                                          |
 | One to all Multicast        | 9-14, 24-26, 53-54, 56, 100-102, 173-180 | Writes transaction from one core to all cores using multicast.                   |
-| One From All                | 15, 30, 156-157                 | Read transactions between one gatherer Tensix core and multiple sender Tensix cores.    |
-| Loopback                    | 16, 55                          | Does a loopback operation where one cores writes to itself.                             |
+| One From All                | 15, 30, 156-157, 162-165                 | Read transactions between one gatherer Tensix core and multiple sender Tensix cores.    |
+| Loopback                    | 16, 44-45, 55                          | Does a loopback operation where one cores writes to itself.                             |
 | Reshard Hardcoded           | 17-20                           | Uses existing reshard tests to analyse their bandwidth and latency. **(Slow Dispatch)** |
 | Conv Hardcoded              | 21-23                           | Uses existing conv tests to analyse their bandwidth and latency. **(Slow Dispatch)**    |
 | Interleaved Page Read/Write | 61-69, 71-75                    | Reads and writes pages between interleaved buffers and a Tensix core.                   |
-| One Packet Read/Write       | 80-83                           | Reads or writes packets between two Tensix cores.                                       |
-| DRAM Sharded Read           | 84-87                           | Reads from sharded DRAM into one core.                                                  |
-| Multi Interleaved           | 110-127                         | Reads and writes pages between interleaved DRAM buffers and multiple Tensix cores.      |
+| One Packet Read/Write       | 80-83, 90-93                           | Reads or writes packets between two Tensix cores.                                       |
+| DRAM Sharded Read           | 84-87, 94-97                           | Reads from sharded DRAM into one core.                                                  |
+| Multi Interleaved           | 110-130                         | Reads and writes pages between interleaved DRAM buffers and multiple Tensix cores.      |
 | Core Bidrectional           | 140-148                         | Tensix core reads from and writes to another Tensix core simultaneously.                |
 | Deinterleave                | 200-201                         | Tests deinterleaving. **(Slow Dispatch)**                                               |
-| All to all                  | 300-308                         | Write transactions from multiple cores to multiple cores.                               |
-| All from all                | 310-318                         | Read transactions from multiple cores to multiple cores.                                |
-| Atomic Semaphore Increment  | 319-320                         | Atomic semaphore increment + atomic barrier performance tests.                          |
-| Multicast Atomic Semaphore  | 321-328                         | Multicast atomic semaphore increment using `noc_semaphore_inc_multicast`.               |
+| All to all                  | 300-316                         | Write transactions from multiple cores to multiple cores.                               |
+| All from all                | 320-336                         | Read transactions from multiple cores to multiple cores.                                |
+| Atomic Semaphore Increment  | 340-341                         | Atomic semaphore increment + atomic barrier performance tests.                          |
+| Multicast Atomic Semaphore  | 342-353                         | Multicast atomic semaphore increment using `noc_semaphore_inc_multicast`.               |
 | I2S Hardcoded               | 400-405                         | Tests interleaved to sharded data movement operations for different memory layouts.     |
 | Inline Direct Write         | 500-501, 507                    | Inline DW transactions between two (unicast) or multiple (multicast) Tensix cores.      |
 | DRAM Neighbour Tests        | 502-505, 508-509                | Each core reads from its closest DRAM.                                                  |
-| Transaction ID              | 600-602, 610-611                | Tests the usage and effects of transaction IDs in NOC transactions.                     |
+| Transaction ID              | 600-602, 610-611, 620-622, 630-631                | Tests the usage and effects of transaction IDs in NOC transactions.                     |
 | PCIe Read Bandwidth         | 603, 605                        | Measures PCIe read bandwidth from host memory to L1 on a single Tensix core.            |
 | PCIe Write Bandwidth        | 604                             | Measures PCIe write bandwidth from L1 to host memory on a single Tensix core.           |
 | Matmul                      | 1000-1231                       | 1D v1, 1D v2, and 2D matmul DM tests across grid shapes, subblock dims, K depths, non-origin starts, and DRAM banks. Per-variant offsets: 1D v1 +0 (1000-1031), 1D v2 +100 (1100-1131), 2D +200 (1200-1231). 1D: in0 row multicast + in1 column multicast (row 0 reads its DRAM slice once, then multicasts down the column). 2D: in0 row multicast + in1 column multicast (all L1, no DRAM). Perf-characterization sweeps: 1029 (4x4 K=1 sub_r {1..256}), 1030 (4x4 K=8 (sub_r, sub_c) 2D), 1031 (8x7 K=8 (sub_r, sub_c) 2D). |

--- a/tests/tt_metal/tt_metal/data_movement/all_from_all/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/all_from_all/README.md
@@ -63,6 +63,8 @@ Each test case has multiple runs, and each run has a unique runtime host id, ass
    - 1x1 From 4x4: 1x1 master grid receiving from 4x4 subordinate grid
    - 2x2 From 2x2: 2x2 master grid receiving from 2x2 subordinate grid
 
+4. **Grid Sweep Packet Sizes**: Sweeps over packet sizes and all combinations of master and subordinate grid configurations (1x1, 2x2, 4x4, full compute grid). Master and subordinate grids are varied independently. Uses combined bandwidth mode to report aggregate bandwidth across all cores. The CSV report includes Master Grid Dimensions, Subordinate Grid Dimensions, and Number of Cores columns.
+
 ## Device 2.0 API Tests
 This test suite now includes tests using the new device 2.0 NOC API. These tests provide the same functionality as the original tests but use an updated API design:
 

--- a/tests/tt_metal/tt_metal/data_movement/all_from_all/kernels/requestor_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_from_all/kernels/requestor_2_0.cpp
@@ -60,8 +60,12 @@ void kernel_main() {
     }
 
     DeviceTimestampedData("Test id", test_id);
-    DeviceTimestampedData("Number of transactions", num_of_transactions * num_subordinates);
+    DeviceTimestampedData("Number of transactions", num_of_transactions);
     DeviceTimestampedData("Transaction size in bytes", bytes_per_transaction_per_subordinate);
     DeviceTimestampedData("NoC Index", noc.get_noc_id());
     DeviceTimestampedData("Number of Virtual Channels", num_virtual_channels);
+    DeviceTimestampedData("Master Grid Size X", get_arg(args::mst_grid_size_x));
+    DeviceTimestampedData("Master Grid Size Y", get_arg(args::mst_grid_size_y));
+    DeviceTimestampedData("Subordinate Grid Size X", get_arg(args::sub_grid_size_x));
+    DeviceTimestampedData("Subordinate Grid Size Y", get_arg(args::sub_grid_size_y));
 }

--- a/tests/tt_metal/tt_metal/data_movement/all_from_all/kernels/requestor_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_from_all/kernels/requestor_2_0.cpp
@@ -60,7 +60,7 @@ void kernel_main() {
     }
 
     DeviceTimestampedData("Test id", test_id);
-    DeviceTimestampedData("Number of transactions", num_of_transactions);
+    DeviceTimestampedData("Number of transactions", num_of_transactions * num_subordinates);
     DeviceTimestampedData("Transaction size in bytes", bytes_per_transaction_per_subordinate);
     DeviceTimestampedData("NoC Index", noc.get_noc_id());
     DeviceTimestampedData("Number of Virtual Channels", num_virtual_channels);

--- a/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
@@ -120,7 +120,11 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const AllFro
         {"mst_l1_addr", (uint32_t)mst_l1_base_address},
         {"sub_l1_addr", (uint32_t)sub_l1_base_address},
         {"num_subordinates", (uint32_t)num_subordinates},
-        {"num_vc", (uint32_t)test_config.num_virtual_channels}};
+        {"num_vc", (uint32_t)test_config.num_virtual_channels},
+        {"mst_grid_size_x", (uint32_t)test_config.mst_grid_size.x},
+        {"mst_grid_size_y", (uint32_t)test_config.mst_grid_size.y},
+        {"sub_grid_size_x", (uint32_t)test_config.sub_grid_size.x},
+        {"sub_grid_size_y", (uint32_t)test_config.sub_grid_size.y}};
 
     const uint32_t num_coord_varargs = (uint32_t)(num_subordinates * 2);
 
@@ -411,6 +415,55 @@ void custom_test(
     EXPECT_TRUE(run_dm(mesh_device, test_config));
 }
 
+void grid_packet_sizes_test(
+    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    uint32_t test_case_id,
+    CoreCoord mst_start_coord,
+    CoreCoord sub_start_coord,
+    CoreCoord mst_grid_size,
+    CoreCoord sub_grid_size) {
+    NOC noc_id = NOC::NOC_1;
+
+    auto [bytes_per_page, max_reservable_bytes, max_reservable_pages] =
+        unit_tests::dm::compute_physical_constraints(mesh_device);
+
+    uint32_t max_transactions_per_subordinate = 256;
+    uint32_t max_reservable_pages_per_transaction =
+        mesh_device->impl().get_device(0)->arch() == ARCH::BLACKHOLE ? 1024 : 2048;
+
+    if (mesh_device->impl().get_device(0)->arch() == ARCH::QUASAR) {
+        max_transactions_per_subordinate = 1;
+        max_reservable_pages_per_transaction = 1;
+    }
+
+    for (uint32_t num_of_transactions_per_subordinate = 1;
+         num_of_transactions_per_subordinate <= max_transactions_per_subordinate;
+         num_of_transactions_per_subordinate *= 16) {
+        for (uint32_t pages_reservable_per_transaction = 1;
+             pages_reservable_per_transaction <= max_reservable_pages_per_transaction;
+             pages_reservable_per_transaction *= 2) {
+            if (pages_reservable_per_transaction > max_reservable_pages) {
+                continue;
+            }
+
+            AllFromAllConfig test_config = {
+                .test_id = test_case_id,
+                .mst_logical_start_coord = mst_start_coord,
+                .sub_logical_start_coord = sub_start_coord,
+                .mst_grid_size = mst_grid_size,
+                .sub_grid_size = sub_grid_size,
+                .num_of_transactions_per_subordinate = num_of_transactions_per_subordinate,
+                .pages_reservable_per_transaction = pages_reservable_per_transaction,
+                .bytes_per_page = bytes_per_page,
+                .l1_data_format = DataFormat::Float16_b,
+                .noc_id = noc_id,
+            };
+
+            EXPECT_TRUE(run_dm(mesh_device, test_config));
+        }
+    }
+}
+
 }  // namespace unit_tests::dm::all_from_all
 
 /* =============================================================  /
@@ -680,6 +733,51 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll1x1From4x4DirectedI
 
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll2x2From2x2DirectedIdeal_2_0) {
     all_from_all_grid_directed_ideal_2_0(get_mesh_device(), 337, {0, 0}, {0, 0}, {2, 2}, {2, 2});
+}
+
+/* ======== GRID + PACKET SIZE SWEEP ======== */
+
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllGridSweepPacketSizes2_0) {
+    auto mesh_device = get_mesh_device();
+    auto* device = mesh_device->get_device(0);
+    auto grid = device->compute_with_storage_grid_size();
+
+    uint32_t test_case_id = 329;
+
+    struct GridConfig {
+        CoreCoord mst_grid;
+        CoreCoord sub_grid;
+    };
+
+    CoreCoord full = {grid.x, grid.y};
+
+    std::vector<GridConfig> grid_configs = {
+        // Symmetric
+        {{2, 2}, {2, 2}},
+        {{4, 4}, {4, 4}},
+        {full, full},
+        // Asymmetric
+        {{2, 2}, {1, 1}},
+        {{4, 4}, {2, 2}},
+        {{2, 2}, {4, 4}},
+        {{4, 4}, {1, 1}},
+        {full, {4, 4}},
+        {{4, 4}, full},
+    };
+
+    CoreCoord mst_start_coord = {0, 0};
+    CoreCoord sub_start_coord = {0, 0};
+
+    for (const auto& gc : grid_configs) {
+        uint32_t required_x = std::max(mst_start_coord.x + gc.mst_grid.x, sub_start_coord.x + gc.sub_grid.x);
+        uint32_t required_y = std::max(mst_start_coord.y + gc.mst_grid.y, sub_start_coord.y + gc.sub_grid.y);
+        if (grid.x < required_x || grid.y < required_y) {
+            continue;
+        }
+
+        unit_tests::dm::all_from_all::grid_packet_sizes_test(
+            mesh_device, test_case_id, mst_start_coord, sub_start_coord, gc.mst_grid, gc.sub_grid);
+    }
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_from_all/test_all_from_all.cpp
@@ -23,7 +23,7 @@ using namespace test_utils;
 
 namespace unit_tests::dm::all_from_all {
 
-constexpr uint32_t START_ID = 310;
+constexpr uint32_t START_ID = 320;
 
 // Test Config (i.e. test parameters)
 struct AllFromAllConfig {
@@ -470,17 +470,12 @@ void grid_packet_sizes_test(
 /  ========== TEST CASES FOR ALL-TO-ALL DATA MOVEMENT ==========  /
 /  ============================================================= */
 
-/*
-TO-DO:
-    - Implement a test case that shuffles through several grid sizes to test grids of different sizes
-*/
-
 /* ======== DIRECTED IDEAL ======== */
 
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllDirectedIdeal) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
-    uint32_t test_case_id = 310;
+    uint32_t test_case_id = 320;
 
     /* Parameters */
 
@@ -500,7 +495,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllPacketSizes) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
 
-    uint32_t test_case_id = 311;
+    uint32_t test_case_id = 321;
 
     /* Parameters */
     CoreCoord mst_start_coord = {0, 0};
@@ -515,7 +510,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllPacketSizes) {
 
 /* ======== 2x2 to 1x1 ======== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll2x2From1x1DirectedIdeal) {
-    uint32_t test_case_id = 312;
+    uint32_t test_case_id = 322;
 
     /* Parameters */
     CoreCoord mst_start_coord = {0, 0};
@@ -530,7 +525,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll2x2From1x1DirectedI
 
 /* ======== 4x4 to 1x1 ======== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll4x4From1x1DirectedIdeal) {
-    uint32_t test_case_id = 313;
+    uint32_t test_case_id = 323;
 
     /* Parameters */
     CoreCoord mst_start_coord = {0, 0};
@@ -545,7 +540,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll4x4From1x1DirectedI
 
 /* ======== 1x1 to 2x2 ======== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll1x1From2x2DirectedIdeal) {
-    uint32_t test_case_id = 314;
+    uint32_t test_case_id = 324;
 
     /* Parameters */
     CoreCoord mst_start_coord = {0, 0};
@@ -560,7 +555,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll1x1From2x2DirectedI
 
 /* ======== 1x1 to 4x4 ======== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll1x1From4x4DirectedIdeal) {
-    uint32_t test_case_id = 315;
+    uint32_t test_case_id = 325;
 
     /* Parameters */
     CoreCoord mst_start_coord = {0, 0};
@@ -575,7 +570,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll1x1From4x4DirectedI
 
 /* ======== 2x2 to 2x2 ======== */
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll2x2From2x2DirectedIdeal) {
-    uint32_t test_case_id = 316;
+    uint32_t test_case_id = 326;
 
     /* Parameters */
     CoreCoord mst_start_coord = {0, 0};
@@ -592,14 +587,14 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll2x2From2x2DirectedI
 
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllVirtualChannels) {
     GTEST_SKIP() << "Skipping test";
-    uint32_t test_case_id = 317;
+    uint32_t test_case_id = 327;
 
     unit_tests::dm::all_from_all::virtual_channels_test(get_mesh_device(), test_case_id);
 }
 
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllCustom) {
     GTEST_SKIP() << "Skipping test";
-    uint32_t test_case_id = 318;
+    uint32_t test_case_id = 328;
 
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->impl().get_device(0);
@@ -630,7 +625,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllPacketSizes2_0) {
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->get_device(0);
 
-    uint32_t test_case_id = 319;
+    uint32_t test_case_id = 329;
 
     CoreCoord mst_start_coord = {0, 0};
     CoreCoord sub_start_coord = {0, 0};
@@ -651,7 +646,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllPacketSizes2_0) {
 }
 
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllDirectedIdeal_2_0) {
-    uint32_t test_id = 320;
+    uint32_t test_id = 330;
 
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->get_device(0);
@@ -716,23 +711,23 @@ void all_from_all_grid_directed_ideal_2_0(
 }  // namespace
 
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll2x2From1x1DirectedIdeal_2_0) {
-    all_from_all_grid_directed_ideal_2_0(get_mesh_device(), 333, {0, 0}, {4, 4}, {2, 2}, {1, 1});
+    all_from_all_grid_directed_ideal_2_0(get_mesh_device(), 331, {0, 0}, {4, 4}, {2, 2}, {1, 1});
 }
 
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll4x4From1x1DirectedIdeal_2_0) {
-    all_from_all_grid_directed_ideal_2_0(get_mesh_device(), 334, {0, 0}, {0, 0}, {4, 4}, {1, 1});
+    all_from_all_grid_directed_ideal_2_0(get_mesh_device(), 332, {0, 0}, {0, 0}, {4, 4}, {1, 1});
 }
 
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll1x1From2x2DirectedIdeal_2_0) {
-    all_from_all_grid_directed_ideal_2_0(get_mesh_device(), 335, {0, 0}, {4, 4}, {1, 1}, {2, 2});
+    all_from_all_grid_directed_ideal_2_0(get_mesh_device(), 333, {0, 0}, {4, 4}, {1, 1}, {2, 2});
 }
 
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll1x1From4x4DirectedIdeal_2_0) {
-    all_from_all_grid_directed_ideal_2_0(get_mesh_device(), 336, {0, 0}, {0, 0}, {1, 1}, {4, 4});
+    all_from_all_grid_directed_ideal_2_0(get_mesh_device(), 334, {0, 0}, {0, 0}, {1, 1}, {4, 4});
 }
 
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAll2x2From2x2DirectedIdeal_2_0) {
-    all_from_all_grid_directed_ideal_2_0(get_mesh_device(), 337, {0, 0}, {0, 0}, {2, 2}, {2, 2});
+    all_from_all_grid_directed_ideal_2_0(get_mesh_device(), 335, {0, 0}, {0, 0}, {2, 2}, {2, 2});
 }
 
 /* ======== GRID + PACKET SIZE SWEEP ======== */
@@ -742,7 +737,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllFromAllGridSweepPacketSize
     auto* device = mesh_device->get_device(0);
     auto grid = device->compute_with_storage_grid_size();
 
-    uint32_t test_case_id = 329;
+    uint32_t test_case_id = 336;
 
     struct GridConfig {
         CoreCoord mst_grid;

--- a/tests/tt_metal/tt_metal/data_movement/all_to_all/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/all_to_all/README.md
@@ -63,6 +63,8 @@ Each test case has multiple runs, and each run has a unique runtime host id, ass
    - 4x4 To 1x1: 4x4 master grid sending to 1x1 subordinate grid
    - 2x2 To 2x2: 2x2 master grid sending to 2x2 subordinate grid
 
+4. **Grid Sweep Packet Sizes**: Sweeps over packet sizes and combinations of master and subordinate grid configurations (1x1, 2x2, 4x4, full compute grid). Master and subordinate grids are varied independently. Uses combined bandwidth mode to report aggregate bandwidth across all cores. The CSV report includes Master Grid Dimensions, Subordinate Grid Dimensions, and Number of Cores columns.
+
 ## Device 2.0 API Tests
 This test suite now includes tests using the new device 2.0 NOC API. These tests provide the same functionality as the original tests but use an updated API design:
 

--- a/tests/tt_metal/tt_metal/data_movement/all_to_all/kernels/sender_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_to_all/kernels/sender_2_0.cpp
@@ -62,7 +62,7 @@ void kernel_main() {
 
     DeviceTimestampedData("Test id", test_id);
     DeviceTimestampedData("NoC Index", noc.get_noc_id());
-    DeviceTimestampedData("Number of transactions", num_of_transactions);
+    DeviceTimestampedData("Number of transactions", num_of_transactions * num_subordinates);
     DeviceTimestampedData("Transaction size in bytes", bytes_per_transaction_per_master);
     DeviceTimestampedData("Number of Virtual Channels", num_virtual_channels);
     DeviceTimestampedData("Master Grid Size X", get_arg(args::mst_grid_size_x));

--- a/tests/tt_metal/tt_metal/data_movement/all_to_all/kernels/sender_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_to_all/kernels/sender_2_0.cpp
@@ -62,7 +62,11 @@ void kernel_main() {
 
     DeviceTimestampedData("Test id", test_id);
     DeviceTimestampedData("NoC Index", noc.get_noc_id());
-    DeviceTimestampedData("Number of transactions", num_of_transactions * num_subordinates);
+    DeviceTimestampedData("Number of transactions", num_of_transactions);
     DeviceTimestampedData("Transaction size in bytes", bytes_per_transaction_per_master);
     DeviceTimestampedData("Number of Virtual Channels", num_virtual_channels);
+    DeviceTimestampedData("Master Grid Size X", get_arg(args::mst_grid_size_x));
+    DeviceTimestampedData("Master Grid Size Y", get_arg(args::mst_grid_size_y));
+    DeviceTimestampedData("Subordinate Grid Size X", get_arg(args::sub_grid_size_x));
+    DeviceTimestampedData("Subordinate Grid Size Y", get_arg(args::sub_grid_size_y));
 }

--- a/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
@@ -477,11 +477,6 @@ void grid_packet_sizes_test(
 /  ========== TEST CASES FOR ALL-TO-ALL DATA MOVEMENT ==========  /
 /  ============================================================= */
 
-/*
-TO-DO:
-    - Implement a test case that shuffles through several grid sizes to test grids of different sizes
-*/
-
 /* ======== DIRECTED IDEAL ======== */
 
 /* ======== All to All ======== */
@@ -736,7 +731,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAllGridSweepPacketSizes2
     auto* device = mesh_device->get_device(0);
     auto grid = device->compute_with_storage_grid_size();
 
-    uint32_t test_case_id = 330;
+    uint32_t test_case_id = 316;
 
     struct GridConfig {
         CoreCoord mst_grid;

--- a/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/all_to_all/test_all_to_all.cpp
@@ -126,7 +126,11 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const AllToA
         {"mst_l1_addr", (uint32_t)mst_l1_base_address},
         {"sub_l1_addr", (uint32_t)sub_l1_base_address},
         {"num_subordinates", (uint32_t)num_subordinates},
-        {"num_vc", (uint32_t)test_config.num_virtual_channels}};
+        {"num_vc", (uint32_t)test_config.num_virtual_channels},
+        {"mst_grid_size_x", (uint32_t)test_config.mst_grid_size.x},
+        {"mst_grid_size_y", (uint32_t)test_config.mst_grid_size.y},
+        {"sub_grid_size_x", (uint32_t)test_config.sub_grid_size.x},
+        {"sub_grid_size_y", (uint32_t)test_config.sub_grid_size.y}};
 
     const uint32_t num_coord_varargs = (uint32_t)(num_subordinates * 2);
 
@@ -419,6 +423,54 @@ void custom_test(
     EXPECT_TRUE(run_dm(mesh_device, test_config));
 }
 
+void grid_packet_sizes_test(
+    const shared_ptr<distributed::MeshDevice>& mesh_device,
+    uint32_t test_case_id,
+    CoreCoord mst_start_coord,
+    CoreCoord sub_start_coord,
+    CoreCoord mst_grid_size,
+    CoreCoord sub_grid_size) {
+    NOC noc_id = NOC::NOC_0;
+
+    auto [bytes_per_page, max_reservable_bytes, max_reservable_pages] =
+        unit_tests::dm::compute_physical_constraints(mesh_device);
+
+    uint32_t max_transactions_per_master = 256;
+    uint32_t max_reservable_pages_per_transaction =
+        mesh_device->impl().get_device(0)->arch() == ARCH::BLACKHOLE ? 1024 : 2048;
+
+    if (mesh_device->impl().get_device(0)->arch() == ARCH::QUASAR) {
+        max_transactions_per_master = 1;
+        max_reservable_pages_per_transaction = 1;
+    }
+
+    for (uint32_t num_of_transactions_per_master = 1; num_of_transactions_per_master <= max_transactions_per_master;
+         num_of_transactions_per_master *= 16) {
+        for (uint32_t pages_reservable_per_transaction = 1;
+             pages_reservable_per_transaction <= max_reservable_pages_per_transaction;
+             pages_reservable_per_transaction *= 2) {
+            if (pages_reservable_per_transaction > max_reservable_pages) {
+                continue;
+            }
+
+            AllToAllConfig test_config = {
+                .test_id = test_case_id,
+                .mst_logical_start_coord = mst_start_coord,
+                .sub_logical_start_coord = sub_start_coord,
+                .mst_grid_size = mst_grid_size,
+                .sub_grid_size = sub_grid_size,
+                .num_of_transactions_per_master = num_of_transactions_per_master,
+                .pages_reservable_per_transaction = pages_reservable_per_transaction,
+                .bytes_per_page = bytes_per_page,
+                .l1_data_format = DataFormat::Float16_b,
+                .noc_id = noc_id,
+            };
+
+            EXPECT_TRUE(run_dm(mesh_device, test_config));
+        }
+    }
+}
+
 }  // namespace unit_tests::dm::all_to_all
 
 /* =============================================================  /
@@ -675,6 +727,51 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAll1x1To4x4DirectedIdeal
 
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAll2x2To2x2DirectedIdeal_2_0) {
     all_to_all_grid_directed_ideal_2_0(get_mesh_device(), 315, {0, 0}, {0, 0}, {2, 2}, {2, 2});
+}
+
+/* ======== GRID + PACKET SIZE SWEEP ======== */
+
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementAllToAllGridSweepPacketSizes2_0) {
+    auto mesh_device = get_mesh_device();
+    auto* device = mesh_device->get_device(0);
+    auto grid = device->compute_with_storage_grid_size();
+
+    uint32_t test_case_id = 330;
+
+    struct GridConfig {
+        CoreCoord mst_grid;
+        CoreCoord sub_grid;
+    };
+
+    CoreCoord full = {grid.x, grid.y};
+
+    std::vector<GridConfig> grid_configs = {
+        // Symmetric
+        {{2, 2}, {2, 2}},
+        {{4, 4}, {4, 4}},
+        {full, full},
+        // Asymmetric
+        {{2, 2}, {1, 1}},
+        {{4, 4}, {2, 2}},
+        {{2, 2}, {4, 4}},
+        {{4, 4}, {1, 1}},
+        {full, {4, 4}},
+        {{4, 4}, full},
+    };
+
+    CoreCoord mst_start_coord = {0, 0};
+    CoreCoord sub_start_coord = {0, 0};
+
+    for (const auto& gc : grid_configs) {
+        uint32_t required_x = std::max(mst_start_coord.x + gc.mst_grid.x, sub_start_coord.x + gc.sub_grid.x);
+        uint32_t required_y = std::max(mst_start_coord.y + gc.mst_grid.y, sub_start_coord.y + gc.sub_grid.y);
+        if (grid.x < required_x || grid.y < required_y) {
+            continue;
+        }
+
+        unit_tests::dm::all_to_all::grid_packet_sizes_test(
+            mesh_device, test_case_id, mst_start_coord, sub_start_coord, gc.mst_grid, gc.sub_grid);
+    }
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/atomics/test_atomic_semaphore_bandwidth.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/atomics/test_atomic_semaphore_bandwidth.cpp
@@ -258,7 +258,7 @@ void directed_performance_test(
 /* ========== TEST CASES ========== */
 
 TEST_F(GenericMeshDeviceFixture, AtomicSemaphoreAdjacentIncrementValueSweep) {
-    uint32_t test_id = 319;
+    uint32_t test_id = 340;
 
     unit_tests::dm::atomics::increment_value_sweep_test(
         get_mesh_device(),
@@ -269,7 +269,7 @@ TEST_F(GenericMeshDeviceFixture, AtomicSemaphoreAdjacentIncrementValueSweep) {
 }
 
 TEST_F(GenericMeshDeviceFixture, AtomicSemaphoreNonAdjacentIncrementValueSweep) {
-    uint32_t test_id = 320;
+    uint32_t test_id = 341;
 
     auto logical_grid_size = get_mesh_device()->logical_grid_size();
 

--- a/tests/tt_metal/tt_metal/data_movement/dram_neighbour/kernels/dram_neighbour_read.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_neighbour/kernels/dram_neighbour_read.cpp
@@ -24,11 +24,13 @@ void kernel_main() {
     constexpr uint32_t pages_per_bank = get_compile_time_arg_val(1);
     constexpr uint32_t page_size_bytes = get_compile_time_arg_val(2);
     constexpr uint32_t test_id = get_compile_time_arg_val(3);
+    constexpr uint32_t num_banks = get_compile_time_arg_val(4);
 
     DeviceTimestampedData("Number of transactions", num_of_transactions);
     DeviceTimestampedData("Transaction size in bytes", pages_per_bank * page_size_bytes);
     DeviceTimestampedData("Bank id", bank_id);
     DeviceTimestampedData("Test id", test_id);
+    DeviceTimestampedData("Number of Banks", num_banks);
 
     uint32_t dst_addr = l1_addr;
 

--- a/tests/tt_metal/tt_metal/data_movement/dram_neighbour/test_dram_neighbour.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_neighbour/test_dram_neighbour.cpp
@@ -119,7 +119,8 @@ bool run_dm_neighbour(const shared_ptr<distributed::MeshDevice>& mesh_device, co
         (uint32_t)test_config.num_of_transactions,
         (uint32_t)test_config.pages_per_bank,
         (uint32_t)test_config.page_size_bytes,
-        (uint32_t)test_config.test_id};
+        (uint32_t)test_config.test_id,
+        (uint32_t)test_config.num_banks};
 
     // Worker cores
     vector<CoreCoord> worker_cores;

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
@@ -319,7 +319,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMShardedReadDirectedIdeal2
     CoreRangeSet core_range_set({core_range});
 
     unit_tests::dm::dram_sharded::DramShardedConfig test_config = {
-        .test_id = 90,
+        .test_id = 94,
         .num_of_transactions = num_of_transactions,
         .num_banks = mesh_device->num_dram_channels(),
         .pages_per_bank = 32,
@@ -329,37 +329,6 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMShardedReadDirectedIdeal2
     };
 
     EXPECT_TRUE(run_dm(mesh_device, test_config));
-}
-
-TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMShardedReadBankNumbers2_0) {
-    auto mesh_device = get_mesh_device();
-
-    DataFormat l1_data_format = DataFormat::Float16_b;
-    uint32_t page_size_bytes = tt::tile_size(l1_data_format);
-    uint32_t max_num_banks = mesh_device->num_dram_channels();
-    uint32_t num_pages = 32;
-
-    const bool is_quasar = MetalContext::instance().get_cluster().arch() == ARCH::QUASAR;
-    uint32_t max_transactions = is_quasar ? 16u : 256u;
-
-    CoreRange core_range({0, 0}, {0, 0});
-    CoreRangeSet core_range_set({core_range});
-
-    for (uint32_t num_of_transactions = 1; num_of_transactions <= max_transactions; num_of_transactions *= 4) {
-        for (uint32_t num_banks = 1; num_banks <= max_num_banks; num_banks++) {
-            unit_tests::dm::dram_sharded::DramShardedConfig test_config = {
-                .test_id = 91,
-                .num_of_transactions = num_of_transactions,
-                .num_banks = num_banks,
-                .pages_per_bank = num_pages,
-                .page_size_bytes = page_size_bytes,
-                .l1_data_format = l1_data_format,
-                .cores = core_range_set,
-            };
-
-            EXPECT_TRUE(run_dm(mesh_device, test_config));
-        }
-    }
 }
 
 TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMShardedReadTileNumbers2_0) {
@@ -383,7 +352,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMShardedReadTileNumbers2_0
         for (uint32_t num_pages = 1; num_pages <= max_num_pages; num_pages *= 2) {
             // Test config
             unit_tests::dm::dram_sharded::DramShardedConfig test_config = {
-                .test_id = 88,
+                .test_id = 95,
                 .num_of_transactions = num_of_transactions,
                 .num_banks = num_banks,
                 .pages_per_bank = num_pages,
@@ -393,6 +362,37 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMShardedReadTileNumbers2_0
             };
 
             // Run
+            EXPECT_TRUE(run_dm(mesh_device, test_config));
+        }
+    }
+}
+
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMShardedReadBankNumbers2_0) {
+    auto mesh_device = get_mesh_device();
+
+    DataFormat l1_data_format = DataFormat::Float16_b;
+    uint32_t page_size_bytes = tt::tile_size(l1_data_format);
+    uint32_t max_num_banks = mesh_device->num_dram_channels();
+    uint32_t num_pages = 32;
+
+    const bool is_quasar = MetalContext::instance().get_cluster().arch() == ARCH::QUASAR;
+    uint32_t max_transactions = is_quasar ? 16u : 256u;
+
+    CoreRange core_range({0, 0}, {0, 0});
+    CoreRangeSet core_range_set({core_range});
+
+    for (uint32_t num_of_transactions = 1; num_of_transactions <= max_transactions; num_of_transactions *= 4) {
+        for (uint32_t num_banks = 1; num_banks <= max_num_banks; num_banks++) {
+            unit_tests::dm::dram_sharded::DramShardedConfig test_config = {
+                .test_id = 96,
+                .num_of_transactions = num_of_transactions,
+                .num_banks = num_banks,
+                .pages_per_bank = num_pages,
+                .page_size_bytes = page_size_bytes,
+                .l1_data_format = l1_data_format,
+                .cores = core_range_set,
+            };
+
             EXPECT_TRUE(run_dm(mesh_device, test_config));
         }
     }
@@ -412,7 +412,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementDRAMShardedReadTridDirectedId
 
     // Test config
     unit_tests::dm::dram_sharded::DramShardedConfig test_config = {
-        .test_id = 89,
+        .test_id = 97,
         .num_of_transactions = num_of_transactions,
         .num_banks = mesh_device->num_dram_channels(),
         .pages_per_bank = 32,

--- a/tests/tt_metal/tt_metal/data_movement/loopback/test_loopback.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/loopback/test_loopback.cpp
@@ -269,7 +269,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementLoopbackPacketSizes_2_0) {
         // Single small config on Quasar emulator to fit within 3-min timeout while still
         // exercising the Metal 2.0 host path (MakeProgramFromSpec + named RTAs + SemaphoreSpec).
         unit_tests::dm::core_loopback::LoopbackConfig test_config = {
-            .test_id = unit_tests::dm::core_loopback::START_ID + 100,
+            .test_id = 44,
             .master_core_coord = {0, 0},
             .num_of_transactions = 4,
             .transaction_size_pages = 4,
@@ -292,7 +292,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementLoopbackPacketSizes_2_0) {
         for (uint32_t transaction_size_pages = 1; transaction_size_pages <= max_transaction_size_pages;
              transaction_size_pages *= 2) {
             unit_tests::dm::core_loopback::LoopbackConfig test_config = {
-                .test_id = unit_tests::dm::core_loopback::START_ID + 100,
+                .test_id = 44,
                 .master_core_coord = master_core_coord,
                 .num_of_transactions = num_of_transactions,
                 .transaction_size_pages = transaction_size_pages,
@@ -309,7 +309,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementLoopbackDirectedIdeal_2_0) {
     auto mesh_device = get_mesh_device();
     auto arch_ = mesh_device->impl().get_device(0)->arch();
 
-    uint32_t test_id = 155;
+    uint32_t test_id = 45;
 
     auto [page_size_bytes, max_transmittable_bytes, max_transmittable_pages] =
         tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);

--- a/tests/tt_metal/tt_metal/data_movement/multi_interleaved/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/multi_interleaved/README.md
@@ -45,3 +45,8 @@ Each test case has multiple runs, and each run has a unique runtime host id, ass
 3. Read tests: Run only the reader kernel.
 4. Write tests: Run only the writer kernel.
 5. Grid configuration tests: Run kernel(s) on a 2x2 or on a 6x6 grid of Tensix cores.
+
+6. **Grid Sweep Sizes**: Sweeps over packet sizes across multiple grid configurations (2x2, 6x6, full compute grid) in a single test. Grid dimensions are stamped by the kernel and appear as a filterable "Grid Dimensions" column in the CSV report. Uses combined bandwidth mode to report aggregate bandwidth across all cores. Three variants:
+   - **Grid Sweep Sizes** (read+write): Synchronized reader and writer pipeline.
+   - **Grid Sweep Read Sizes** (read-only): DRAM-to-L1 read bandwidth in isolation.
+   - **Grid Sweep Write Sizes** (write-only): L1-to-DRAM write bandwidth in isolation.

--- a/tests/tt_metal/tt_metal/data_movement/multi_interleaved/kernels/multi_interleaved_read.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multi_interleaved/kernels/multi_interleaved_read.cpp
@@ -26,16 +26,18 @@ void kernel_main() {
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(3);
     constexpr uint32_t test_id = get_compile_time_arg_val(4);
     constexpr bool sync = get_compile_time_arg_val(5) == 1;
+    constexpr uint32_t grid_size_x = get_compile_time_arg_val(6);
+    constexpr uint32_t grid_size_y = get_compile_time_arg_val(7);
 
-    // Tensor accessor compile time args appended to kernel's compile time args
-    // so the index is offset to start at 6
-    auto args = TensorAccessorArgs<6>();
+    auto args = TensorAccessorArgs<8>();
     auto s = TensorAccessor(args, src_addr);
 
     constexpr uint32_t transaction_size_bytes = page_size_bytes;
     DeviceTimestampedData("Number of transactions", num_of_transactions * num_pages);
     DeviceTimestampedData("Transaction size in bytes", transaction_size_bytes);
     DeviceTimestampedData("Test id", test_id);
+    DeviceTimestampedData("Grid Size X", grid_size_x);
+    DeviceTimestampedData("Grid Size Y", grid_size_y);
 
     // Wait for all cores to reach this point before starting data movement
     barrier_sync(barrier_sem_id, barrier_coord_x, barrier_coord_y, num_cores, local_barrier_addr);

--- a/tests/tt_metal/tt_metal/data_movement/multi_interleaved/kernels/multi_interleaved_write.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multi_interleaved/kernels/multi_interleaved_write.cpp
@@ -26,16 +26,18 @@ void kernel_main() {
     constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(3);
     constexpr uint32_t test_id = get_compile_time_arg_val(4);
     constexpr bool sync = get_compile_time_arg_val(5) == 1;
+    constexpr uint32_t grid_size_x = get_compile_time_arg_val(6);
+    constexpr uint32_t grid_size_y = get_compile_time_arg_val(7);
 
-    // Tensor accessor compile time args appended to kernel's compile time args
-    // so the index is offset to start at 6
-    auto args = TensorAccessorArgs<6>();
+    auto args = TensorAccessorArgs<8>();
     auto s = TensorAccessor(args, dst_addr);
 
     constexpr uint32_t transaction_size_bytes = page_size_bytes;
     DeviceTimestampedData("Number of transactions", num_of_transactions * num_pages);
     DeviceTimestampedData("Transaction size in bytes", transaction_size_bytes);
     DeviceTimestampedData("Test id", test_id);
+    DeviceTimestampedData("Grid Size X", grid_size_x);
+    DeviceTimestampedData("Grid Size Y", grid_size_y);
 
     // Wait for all cores to reach this point before starting data movement
     barrier_sync(barrier_sem_id, barrier_coord_x, barrier_coord_y, num_cores, local_barrier_addr);

--- a/tests/tt_metal/tt_metal/data_movement/multi_interleaved/test_multi_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multi_interleaved/test_multi_interleaved.cpp
@@ -27,6 +27,7 @@ struct MultiInterleavedConfig {
     uint32_t page_size_bytes = 0;
     DataFormat l1_data_format = DataFormat::Invalid;
     CoreRangeSet cores;
+    CoreCoord grid_size = {0, 0};
     bool read_kernel = true;
     bool write_kernel = true;
 };
@@ -89,7 +90,9 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const MultiI
         (uint32_t)test_config.page_size_bytes,
         (uint32_t)l1_cb_index,
         (uint32_t)test_config.test_id,
-        (uint32_t)sync};
+        (uint32_t)sync,
+        (uint32_t)test_config.grid_size.x,
+        (uint32_t)test_config.grid_size.y};
 
     vector<uint32_t> writer_compile_args = {
         (uint32_t)test_config.num_of_transactions,
@@ -97,7 +100,9 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const MultiI
         (uint32_t)test_config.page_size_bytes,
         (uint32_t)l1_cb_index,
         (uint32_t)test_config.test_id,
-        (uint32_t)sync};
+        (uint32_t)sync,
+        (uint32_t)test_config.grid_size.x,
+        (uint32_t)test_config.grid_size.y};
 
     if (sync) {
         // Create circular buffers - each core only needs space for its own data
@@ -295,6 +300,7 @@ void directed_ideal_test(
         .page_size_bytes = page_size_bytes,
         .l1_data_format = DataFormat::Float16_b,
         .cores = core_range_set,
+        .grid_size = mst_grid_size,
         .read_kernel = read,
         .write_kernel = write};
 
@@ -341,11 +347,59 @@ void packet_sizes_test(
                 .page_size_bytes = page_size_bytes,
                 .l1_data_format = DataFormat::Float16_b,
                 .cores = core_range_set,
+                .grid_size = mst_grid_size,
                 .read_kernel = read,
                 .write_kernel = write};
 
             // Run
             EXPECT_TRUE(run_dm(mesh_device, test_config));
+        }
+    }
+}
+
+void grid_packet_sizes_test(
+    const shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t test_case_id, bool read, bool write) {
+    auto* device = mesh_device->impl().get_device(0);
+
+    auto [flit_size_bytes, max_transmittable_bytes, max_transmittable_flits] =
+        tt::tt_metal::unit_tests::dm::compute_physical_constraints(mesh_device);
+
+    uint32_t max_page_size_bytes = 256 * flit_size_bytes;
+    uint32_t max_num_pages = 256;
+
+    CoreCoord full_grid = {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y};
+    std::vector<CoreCoord> grid_sizes = {{2, 2}, {6, 6}, full_grid};
+
+    for (auto& grid_size : grid_sizes) {
+        CoreCoord start_coord = {0, 0};
+        CoreCoord end_coord = CoreCoord(start_coord.x + grid_size.x - 1, start_coord.y + grid_size.y - 1);
+        CoreRangeSet core_range_set({CoreRange(start_coord, end_coord)});
+
+        for (uint32_t pages = 1; pages <= max_num_pages; pages *= 4) {
+            uint32_t num_of_transactions;
+            uint32_t num_pages;
+            if (pages > 16) {
+                num_of_transactions = pages / 16;
+                num_pages = 16;
+            } else {
+                num_of_transactions = 1;
+                num_pages = pages;
+            }
+            for (uint32_t page_size_bytes = flit_size_bytes; page_size_bytes <= max_page_size_bytes;
+                 page_size_bytes *= 2) {
+                MultiInterleavedConfig test_config = {
+                    .test_id = test_case_id,
+                    .num_of_transactions = num_of_transactions,
+                    .num_pages = num_pages,
+                    .page_size_bytes = page_size_bytes,
+                    .l1_data_format = DataFormat::Float16_b,
+                    .cores = core_range_set,
+                    .grid_size = grid_size,
+                    .read_kernel = read,
+                    .write_kernel = write};
+
+                EXPECT_TRUE(run_dm(mesh_device, test_config));
+            }
         }
     }
 }
@@ -522,6 +576,23 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovement6x6MultiInterleavedWriteSizes
     CoreCoord mst_grid_size = {6, 6};
     unit_tests::dm::multi_interleaved::packet_sizes_test(
         get_mesh_device(), test_case_id, mst_start_coord, mst_grid_size, false, true);
+}
+
+/* ========== GRID SWEEP TESTS ========== */
+
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedGridSweepSizes) {
+    uint32_t test_case_id = 128;
+    unit_tests::dm::multi_interleaved::grid_packet_sizes_test(get_mesh_device(), test_case_id, true, true);
+}
+
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedReadGridSweepSizes) {
+    uint32_t test_case_id = 129;
+    unit_tests::dm::multi_interleaved::grid_packet_sizes_test(get_mesh_device(), test_case_id, true, false);
+}
+
+TEST_F(GenericMeshDeviceFixture, TensixDataMovementMultiInterleavedWriteGridSweepSizes) {
+    uint32_t test_case_id = 130;
+    unit_tests::dm::multi_interleaved::grid_packet_sizes_test(get_mesh_device(), test_case_id, false, true);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/multicast_atomics/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/multicast_atomics/README.md
@@ -27,26 +27,30 @@ This test suite includes tests using both the standard NOC API and the Device 2.
 
 ## Test Cases
 
-| Test Name                          | ID  | Description |
-| ---------------------------------- | --- | ----------- |
-| MulticastAtomicSingleSource        | 321 | Single sender core multicasts atomic increment to 12 destinations (NOC_0) |
-| MulticastAtomicMultiSource         | 322 | 4 sender cores multicast atomic increment to 12 destinations (NOC_0)      |
-| MulticastAtomicSingleSourceNOC1    | 323 | Single sender core multicasts atomic increment to 12 destinations (NOC_1) |
-| MulticastAtomicMultiSourceNOC1     | 324 | 4 sender cores multicast atomic increment to 12 destinations (NOC_1)      |
-| MulticastAtomicLargerIncrement     | 325 | 4 senders, 3 transactions each, increment value 5 (NOC_0)                 |
-| MulticastAtomicLargerIncrementNOC1 | 326 | 4 senders, 3 transactions each, increment value 5 (NOC_1)                 |
-| MulticastAtomicSingleSource_2_0    | 327 | Single sender using API                                      |
-| MulticastAtomicLargerIncrement_2_0 | 328 | 4 senders, 3 transactions each, increment value 5 using API  |
+| Test Name                              | ID  | Description |
+| ----------------------------------     | --- | ----------- |
+| MulticastAtomicSingleSource            | 342 | Single sender core multicasts atomic increment to 12 destinations (NOC_0) |
+| MulticastAtomicMultiSource             | 343 | 4 sender cores multicast atomic increment to 12 destinations (NOC_0)      |
+| MulticastAtomicSingleSourceNOC1        | 344 | Single sender core multicasts atomic increment to 12 destinations (NOC_1) |
+| MulticastAtomicMultiSourceNOC1         | 345 | 4 sender cores multicast atomic increment to 12 destinations (NOC_1)      |
+| MulticastAtomicLargerIncrement         | 346 | 4 senders, 3 transactions each, increment value 5 (NOC_0)                 |
+| MulticastAtomicLargerIncrementNOC1     | 347 | 4 senders, 3 transactions each, increment value 5 (NOC_1)                 |
+| MulticastAtomicSingleSource_2_0        | 348 | Single sender using 2.0 API                                      |
+| MulticastAtomicLargerIncrement_2_0     | 349 | 4 senders, 3 transactions each, increment value 5 using 2.0 API  |
+| MulticastAtomicMultiSource_2_0         | 350 | MulticastAtomicMultiSource using 2.0 API |
+| MulticastAtomicSingleSourceNOC1_2_0    | 351 | Single sender (NOC_1) using 2.0 API |
+| MulticastAtomicMultiSourceNOC1_2_0     | 352 | MulticastAtomicMultiSource (NOC_1) using 2.0 API |
+| MulticastAtomicLargerIncrementNOC1_2_0 | 353 | 4 senders, 3 transactions each, increment value 5 (NOC_1) using 2.0 API |
 
-### SingleSourceMulticastAtomic (IDs 321, 323, 327)
+### SingleSourceMulticastAtomic (IDs 342, 344, 348, 351)
 - **Description**: Single sender core multicasts atomic increment to a 3x4 grid of 12 destination cores
 - **Expected Result**: All 12 destination cores have semaphore value = 1
 
-### MultiSourceMulticastAtomic (IDs 322, 324)
+### MultiSourceMulticastAtomic (IDs 343, 345, 350, 352)
 - **Description**: 4 sender cores each multicast atomic increment to the same 3x4 grid of 12 destination cores
 - **Expected Result**: All 12 destination cores have semaphore value = 4 (one increment from each sender)
 
-### LargerIncrementMulticastAtomic (IDs 325, 326, 328)
+### LargerIncrementMulticastAtomic (IDs 346, 347, 349, 353)
 - **Description**: 4 sender cores each perform 3 multicast atomic increments with value 5 to a 3x4 grid of 12 destination cores
 - **Expected Result**: All 12 destination cores have semaphore value = 60 (4 senders × 3 transactions × 5 increment)
 

--- a/tests/tt_metal/tt_metal/data_movement/multicast_atomics/test_multicast_atomic_semaphore.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/multicast_atomics/test_multicast_atomic_semaphore.cpp
@@ -211,7 +211,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const Multic
 /* ========== TEST CASES ========== */
 
 TEST_F(GenericMeshDeviceFixture, MulticastAtomicSingleSource) {
-    uint32_t test_id = 321;
+    uint32_t test_id = 342;
 
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->get_device(0);
@@ -234,7 +234,7 @@ TEST_F(GenericMeshDeviceFixture, MulticastAtomicSingleSource) {
 }
 
 TEST_F(GenericMeshDeviceFixture, MulticastAtomicMultiSource) {
-    uint32_t test_id = 322;
+    uint32_t test_id = 343;
 
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->get_device(0);
@@ -257,7 +257,7 @@ TEST_F(GenericMeshDeviceFixture, MulticastAtomicMultiSource) {
 }
 
 TEST_F(GenericMeshDeviceFixture, MulticastAtomicSingleSourceNOC1) {
-    uint32_t test_id = 323;
+    uint32_t test_id = 344;
 
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->get_device(0);
@@ -280,7 +280,7 @@ TEST_F(GenericMeshDeviceFixture, MulticastAtomicSingleSourceNOC1) {
 }
 
 TEST_F(GenericMeshDeviceFixture, MulticastAtomicMultiSourceNOC1) {
-    uint32_t test_id = 324;
+    uint32_t test_id = 345;
 
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->get_device(0);
@@ -303,7 +303,7 @@ TEST_F(GenericMeshDeviceFixture, MulticastAtomicMultiSourceNOC1) {
 }
 
 TEST_F(GenericMeshDeviceFixture, MulticastAtomicLargerIncrement) {
-    uint32_t test_id = 325;
+    uint32_t test_id = 346;
 
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->get_device(0);
@@ -328,7 +328,7 @@ TEST_F(GenericMeshDeviceFixture, MulticastAtomicLargerIncrement) {
 }
 
 TEST_F(GenericMeshDeviceFixture, MulticastAtomicLargerIncrementNOC1) {
-    uint32_t test_id = 326;
+    uint32_t test_id = 347;
 
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->get_device(0);
@@ -355,7 +355,7 @@ TEST_F(GenericMeshDeviceFixture, MulticastAtomicLargerIncrementNOC1) {
 /* ========== NOC 2.0 API TEST CASES ========== */
 
 TEST_F(GenericMeshDeviceFixture, MulticastAtomicSingleSource_2_0) {
-    uint32_t test_id = 327;
+    uint32_t test_id = 348;
 
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->get_device(0);
@@ -379,7 +379,7 @@ TEST_F(GenericMeshDeviceFixture, MulticastAtomicSingleSource_2_0) {
 }
 
 TEST_F(GenericMeshDeviceFixture, MulticastAtomicLargerIncrement_2_0) {
-    uint32_t test_id = 328;
+    uint32_t test_id = 349;
 
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->get_device(0);
@@ -405,7 +405,7 @@ TEST_F(GenericMeshDeviceFixture, MulticastAtomicLargerIncrement_2_0) {
 }
 
 TEST_F(GenericMeshDeviceFixture, MulticastAtomicMultiSource_2_0) {
-    uint32_t test_id = 329;
+    uint32_t test_id = 350;
 
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->get_device(0);
@@ -429,7 +429,7 @@ TEST_F(GenericMeshDeviceFixture, MulticastAtomicMultiSource_2_0) {
 }
 
 TEST_F(GenericMeshDeviceFixture, MulticastAtomicSingleSourceNOC1_2_0) {
-    uint32_t test_id = 330;
+    uint32_t test_id = 351;
 
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->get_device(0);
@@ -453,7 +453,7 @@ TEST_F(GenericMeshDeviceFixture, MulticastAtomicSingleSourceNOC1_2_0) {
 }
 
 TEST_F(GenericMeshDeviceFixture, MulticastAtomicMultiSourceNOC1_2_0) {
-    uint32_t test_id = 331;
+    uint32_t test_id = 352;
 
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->get_device(0);
@@ -477,7 +477,7 @@ TEST_F(GenericMeshDeviceFixture, MulticastAtomicMultiSourceNOC1_2_0) {
 }
 
 TEST_F(GenericMeshDeviceFixture, MulticastAtomicLargerIncrementNOC1_2_0) {
-    uint32_t test_id = 332;
+    uint32_t test_id = 353;
 
     auto mesh_device = get_mesh_device();
     auto* device = mesh_device->get_device(0);

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/reader.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/reader.cpp
@@ -58,13 +58,13 @@ void kernel_main() {
                 DeviceZoneScopedN("RISCV1");
                 for (uint32_t i = 0; i < num_of_transactions; i++) {
                     uint32_t vc = i % num_virtual_channels;
-                    noc.async_read(
+                    noc.async_read<NocOptions::CUSTOM_VC>(
                         unicast_ep,
                         unicast_ep,
                         bytes_per_transaction,
                         {.noc_x = src_x, .noc_y = src_y, .addr = local_addr},
                         {.addr = local_addr},
-                        vc);
+                        NocOptVals{.vc = vc});
                 }
                 noc.async_read_barrier();
             }
@@ -106,13 +106,13 @@ void kernel_main() {
                 } else {
                     for (uint32_t i = 0; i < num_of_transactions; i++) {
                         uint32_t vc = i % num_virtual_channels;
-                        noc.async_read(
+                        noc.async_read<NocOptions::CUSTOM_VC>(
                             unicast_ep,
                             unicast_ep,
                             bytes_per_transaction,
                             {.noc_x = src_x, .noc_y = src_y, .addr = local_addr},
                             {.addr = local_addr},
-                            vc);
+                            NocOptVals{.vc = vc});
                     }
                 }
             }

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/writer.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/kernels/writer.cpp
@@ -70,13 +70,13 @@ void kernel_main() {
                 DeviceZoneScopedN("RISCV0");
                 for (uint32_t i = 0; i < num_of_transactions; i++) {
                     uint32_t vc = i % num_virtual_channels;
-                    noc.async_write(
+                    noc.async_write<NocOptions::CUSTOM_VC>(
                         unicast_ep,
                         unicast_ep,
                         bytes_per_transaction,
                         {.addr = src_addr},
                         {.noc_x = dest_x, .noc_y = dest_y, .addr = dst_addr},
-                        vc);
+                        NocOptVals{.vc = vc});
                 }
                 noc.async_write_barrier();
             }
@@ -123,8 +123,7 @@ void kernel_main() {
                             unicast_ep,
                             bytes_per_transaction,
                             {.addr = src_addr},
-                            {.noc_x = dest_x, .noc_y = dest_y, .addr = dst_addr},
-                            0);
+                            {.noc_x = dest_x, .noc_y = dest_y, .addr = dst_addr});
                     }
                 }
             }

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/test_noc_estimator.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/test_noc_estimator.cpp
@@ -838,7 +838,10 @@ static void sweep_one_to_all(const shared_ptr<distributed::MeshDevice>& mesh_dev
     struct GridConfig {
         CoreCoord size;
     };
-    vector<GridConfig> grids = {{{2, 2}}, {{3, 3}}, {{5, 5}}, {{8, 8}}, {device_grid}};
+    vector<GridConfig> grids = {{{2, 2}}, {{3, 3}}, {{5, 5}}, {{8, 8}}};
+    if (device_grid.x > 8 || device_grid.y > 8) {
+        grids.push_back({device_grid});
+    }
 
     for (auto& grid : grids) {
         // Skip grid sizes larger than device grid
@@ -924,7 +927,10 @@ static void sweep_all_to_all(const shared_ptr<distributed::MeshDevice>& mesh_dev
     IDevice* device = mesh_device->impl().get_device(0);
     CoreCoord device_grid = device->compute_with_storage_grid_size();
 
-    vector<CoreCoord> grid_sizes = {{2, 2}, {3, 3}, {5, 5}, {8, 8}, device_grid};
+    vector<CoreCoord> grid_sizes = {{2, 2}, {3, 3}, {5, 5}, {8, 8}};
+    if (device_grid.x > 8 || device_grid.y > 8) {
+        grid_sizes.push_back({device_grid});
+    }
 
     for (auto& grid_size : grid_sizes) {
         // Skip grid sizes larger than device grid
@@ -950,7 +956,10 @@ static void sweep_all_from_all(const shared_ptr<distributed::MeshDevice>& mesh_d
     IDevice* device = mesh_device->impl().get_device(0);
     CoreCoord device_grid = device->compute_with_storage_grid_size();
 
-    vector<CoreCoord> grid_sizes = {{2, 2}, {3, 3}, {5, 5}, {8, 8}, device_grid};
+    vector<CoreCoord> grid_sizes = {{2, 2}, {3, 3}, {5, 5}, {8, 8}};
+    if (device_grid.x > 8 || device_grid.y > 8) {
+        grid_sizes.push_back({device_grid});
+    }
 
     for (auto& grid_size : grid_sizes) {
         // Skip grid sizes larger than device grid

--- a/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/test_noc_estimator.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/noc_estimator_tests/test_noc_estimator.cpp
@@ -839,7 +839,10 @@ static void sweep_one_to_all(const shared_ptr<distributed::MeshDevice>& mesh_dev
         CoreCoord size;
     };
     vector<GridConfig> grids = {{{2, 2}}, {{3, 3}}, {{5, 5}}, {{8, 8}}};
-    if (device_grid.x > 8 || device_grid.y > 8) {
+    // Add the full device grid if not already included
+    if (std::none_of(grids.begin(), grids.end(), [&](const GridConfig& g) {
+            return g.size.x == device_grid.x && g.size.y == device_grid.y;
+        })) {
         grids.push_back({device_grid});
     }
 
@@ -928,7 +931,10 @@ static void sweep_all_to_all(const shared_ptr<distributed::MeshDevice>& mesh_dev
     CoreCoord device_grid = device->compute_with_storage_grid_size();
 
     vector<CoreCoord> grid_sizes = {{2, 2}, {3, 3}, {5, 5}, {8, 8}};
-    if (device_grid.x > 8 || device_grid.y > 8) {
+    // Add the full device grid if not already included
+    if (std::none_of(grid_sizes.begin(), grid_sizes.end(), [&](const CoreCoord& g) {
+            return g.x == device_grid.x && g.y == device_grid.y;
+        })) {
         grid_sizes.push_back({device_grid});
     }
 
@@ -957,7 +963,10 @@ static void sweep_all_from_all(const shared_ptr<distributed::MeshDevice>& mesh_d
     CoreCoord device_grid = device->compute_with_storage_grid_size();
 
     vector<CoreCoord> grid_sizes = {{2, 2}, {3, 3}, {5, 5}, {8, 8}};
-    if (device_grid.x > 8 || device_grid.y > 8) {
+    // Add the full device grid if not already included
+    if (std::none_of(grid_sizes.begin(), grid_sizes.end(), [&](const CoreCoord& g) {
+            return g.x == device_grid.x && g.y == device_grid.y;
+        })) {
         grid_sizes.push_back({device_grid});
     }
 

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
@@ -495,7 +495,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllPacketSizes_2_0) {
         auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
             unit_tests::dm::compute_physical_constraints(mesh_device);
         unit_tests::dm::core_from_all::OneFromAllConfig test_config = {
-            .test_id = 160,
+            .test_id = 162,
             .master_core_coord = {0, 0},
             .sub_start_core_coord = {0, 0},
             .sub_grid_size = {2, 1},
@@ -509,7 +509,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllPacketSizes_2_0) {
     }
 
     // WH/BH full sweep.
-    uint32_t test_id = 160;
+    uint32_t test_id = 162;
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_start_coord = {0, 0};
     CoreCoord subordinate_grid_size = {
@@ -556,7 +556,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllDirectedIdeal_2_0) 
         auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
             unit_tests::dm::compute_physical_constraints(mesh_device);
         unit_tests::dm::core_from_all::OneFromAllConfig test_config = {
-            .test_id = 161,
+            .test_id = 163,
             .master_core_coord = {0, 0},
             .sub_start_core_coord = {0, 0},
             .sub_grid_size = {2, 1},
@@ -570,7 +570,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllDirectedIdeal_2_0) 
     }
 
     // WH/BH ideal config.
-    uint32_t test_id = 161;
+    uint32_t test_id = 163;
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_start_coord = {0, 0};
     CoreCoord subordinate_grid_size = {
@@ -607,7 +607,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllVirtualChannels_2_0
         auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
             unit_tests::dm::compute_physical_constraints(mesh_device);
         unit_tests::dm::core_from_all::OneFromAllConfig test_config = {
-            .test_id = 162,
+            .test_id = 164,
             .master_core_coord = {0, 0},
             .sub_start_core_coord = {0, 0},
             .sub_grid_size = {2, 1},
@@ -624,7 +624,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllVirtualChannels_2_0
 
     unit_tests::dm::core_from_all::virtual_channels_test(
         mesh_device,
-        162,
+        164,
         {0, 0},
         {0, 0},
         {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y});
@@ -638,13 +638,13 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllCustom_2_0) {
         if (device->compute_with_storage_grid_size().x < 2) {
             GTEST_SKIP() << "Skipping: sub_grid_size {2, 1} requires >= 2 columns.";
         }
-        unit_tests::dm::core_from_all::custom_test(mesh_device, 163, {0, 0}, {0, 0}, {2, 1}, 4, 1, 2, NOC::NOC_0);
+        unit_tests::dm::core_from_all::custom_test(mesh_device, 165, {0, 0}, {0, 0}, {2, 1}, 4, 1, 2, NOC::NOC_0);
         return;
     }
 
     unit_tests::dm::core_from_all::custom_test(
         mesh_device,
-        163,
+        165,
         {0, 0},
         {0, 0},
         {device->compute_with_storage_grid_size().x, device->compute_with_storage_grid_size().y},

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
@@ -495,7 +495,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllPacketSizes_2_0) {
         auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
             unit_tests::dm::compute_physical_constraints(mesh_device);
         unit_tests::dm::core_from_all::OneFromAllConfig test_config = {
-            .test_id = 115,
+            .test_id = 160,
             .master_core_coord = {0, 0},
             .sub_start_core_coord = {0, 0},
             .sub_grid_size = {2, 1},
@@ -509,7 +509,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllPacketSizes_2_0) {
     }
 
     // WH/BH full sweep.
-    uint32_t test_id = 115;
+    uint32_t test_id = 160;
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_start_coord = {0, 0};
     CoreCoord subordinate_grid_size = {
@@ -556,7 +556,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllDirectedIdeal_2_0) 
         auto [bytes_per_page, max_transmittable_bytes, max_transmittable_pages] =
             unit_tests::dm::compute_physical_constraints(mesh_device);
         unit_tests::dm::core_from_all::OneFromAllConfig test_config = {
-            .test_id = 130,
+            .test_id = 161,
             .master_core_coord = {0, 0},
             .sub_start_core_coord = {0, 0},
             .sub_grid_size = {2, 1},
@@ -570,7 +570,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOneFromAllDirectedIdeal_2_0) 
     }
 
     // WH/BH ideal config.
-    uint32_t test_id = 130;
+    uint32_t test_id = 161;
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_start_coord = {0, 0};
     CoreCoord subordinate_grid_size = {

--- a/tests/tt_metal/tt_metal/data_movement/one_from_one/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_one/README.md
@@ -47,6 +47,8 @@ Each test case has multiple runs, and each run has a unique runtime host id, ass
 
 5. **TensixDataMovementOneFromOnePacketSizes2_0** (Test ID: 159) - Device 2.0 API version of the packet sizes test. Tests the same packet size variations as test ID 5 but uses the NOC API with structured endpoints and virtual channel support for async read operations.
 
+6. **TensixDataMovementOneFromOneDirectedIdeal2_0** (Test ID: 161) - Device 2.0 API version of the directed ideal test.
+
 ## Device 2.0 API Tests
 This test suite now includes tests using the new device 2.0 NOC API. These tests provide the same functionality as the original tests but use an updated API design:
 

--- a/tests/tt_metal/tt_metal/data_movement/one_packet/test_one_packet.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_packet/test_one_packet.cpp
@@ -391,7 +391,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOnePacketReadSizes_2_0) {
             GTEST_SKIP() << "Skipping: need at least a 1x2 or 2x1 grid, got " << grid.x << "x" << grid.y;
         }
         unit_tests::dm::one_packet::OnePacketConfig test_config = {
-            .test_id = 84,
+            .test_id = 90,
             .master_core_coord = {0, 0},
             .subordinate_core_coord = subordinate,
             .num_packets = 4,
@@ -412,7 +412,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOnePacketReadSizes_2_0) {
         for (uint32_t packet_size_bytes = page_size_bytes; packet_size_bytes <= max_packet_size_bytes;
              packet_size_bytes *= 2) {
             unit_tests::dm::one_packet::OnePacketConfig test_config = {
-                .test_id = 84,
+                .test_id = 90,
                 .master_core_coord = master_core_coord,
                 .subordinate_core_coord = subordinate_core_coord,
                 .num_packets = num_packets,
@@ -441,7 +441,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOnePacketWriteSizes_2_0) {
             GTEST_SKIP() << "Skipping: need at least a 1x2 or 2x1 grid, got " << grid.x << "x" << grid.y;
         }
         unit_tests::dm::one_packet::OnePacketConfig test_config = {
-            .test_id = 85,
+            .test_id = 91,
             .master_core_coord = {0, 0},
             .subordinate_core_coord = subordinate,
             .num_packets = 4,
@@ -462,7 +462,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOnePacketWriteSizes_2_0) {
         for (uint32_t packet_size_bytes = page_size_bytes; packet_size_bytes <= max_packet_size_bytes;
              packet_size_bytes *= 2) {
             unit_tests::dm::one_packet::OnePacketConfig test_config = {
-                .test_id = 85,
+                .test_id = 91,
                 .master_core_coord = master_core_coord,
                 .subordinate_core_coord = subordinate_core_coord,
                 .num_packets = num_packets,
@@ -493,7 +493,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOnePacketReadDirectedIdeal_2_
             GTEST_SKIP() << "Skipping: need at least a 1x2 or 2x1 grid, got " << grid.x << "x" << grid.y;
         }
         unit_tests::dm::one_packet::OnePacketConfig test_config = {
-            .test_id = 86,
+            .test_id = 92,
             .master_core_coord = master_core_coord,
             .subordinate_core_coord = subordinate_core_coord,
             .num_packets = 4,
@@ -508,7 +508,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOnePacketReadDirectedIdeal_2_
     uint32_t num_packets = max_transmittable_bytes / packet_size_bytes;
 
     unit_tests::dm::one_packet::OnePacketConfig test_config = {
-        .test_id = 86,
+        .test_id = 92,
         .master_core_coord = master_core_coord,
         .subordinate_core_coord = subordinate_core_coord,
         .num_packets = num_packets,
@@ -537,7 +537,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOnePacketWriteDirectedIdeal_2
             GTEST_SKIP() << "Skipping: need at least a 1x2 or 2x1 grid, got " << grid.x << "x" << grid.y;
         }
         unit_tests::dm::one_packet::OnePacketConfig test_config = {
-            .test_id = 87,
+            .test_id = 93,
             .master_core_coord = master_core_coord,
             .subordinate_core_coord = subordinate_core_coord,
             .num_packets = 4,
@@ -552,7 +552,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementOnePacketWriteDirectedIdeal_2
     uint32_t num_packets = max_transmittable_bytes / packet_size_bytes;
 
     unit_tests::dm::one_packet::OnePacketConfig test_config = {
-        .test_id = 87,
+        .test_id = 93,
         .master_core_coord = master_core_coord,
         .subordinate_core_coord = subordinate_core_coord,
         .num_packets = num_packets,

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/README.md
@@ -54,7 +54,7 @@ Each test case has multiple runs, and each run has a unique runtime host id, ass
    - Support for linked/chained transactions
    - Support for loopback operations
 
-3. **Advanced Multicast Schemes**: Tests different multicast implementation strategies for optimal performance across various grid sizes and communication patterns.
+3. **Advanced Multicast Schemes**: Tests different multicast implementation strategies for optimal performance across various grid sizes and communication patterns. A description of the multicast schemes tested can be found [here](https://github.com/tenstorrent/tt-low-level-documentation/blob/main/data_movement_doc/multicast_schemes/Multicast%20Schemes.md).
 
 ## Device 2.0 API Tests
 This test suite now includes tests using the new device 2.0 NOC API. These tests provide the same functionality as the original tests but use an updated API design.

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender_multicast.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender_multicast.cpp
@@ -68,4 +68,5 @@ void kernel_main() {
         DeviceTimestampedData("Subordinate Grid Size Y", sub_grid_size_y);
     }
     DeviceTimestampedData("Number of subordinates", num_subordinates);
+    DeviceTimestampedData("Loopback", loopback ? 1 : 0);
 }

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender_multicast_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender_multicast_2_0.cpp
@@ -83,4 +83,5 @@ void kernel_main() {
     }
 
     DeviceTimestampedData("Number of subordinates", num_subordinates);
+    DeviceTimestampedData("Loopback", loopback ? 1 : 0);
 }

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender_unicast.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender_unicast.cpp
@@ -15,6 +15,7 @@ void kernel_main() {
     constexpr uint32_t test_id = get_named_compile_time_arg_val("test_id");
     constexpr uint32_t num_subordinates = get_named_compile_time_arg_val("num_subordinates");
     constexpr uint32_t num_virtual_channels = get_named_compile_time_arg_val("num_vc");
+    constexpr uint32_t loopback = get_named_compile_time_arg_val("loopback");
 
     // Derivative values
     constexpr uint32_t bytes_per_transaction = pages_per_transaction * bytes_per_page;
@@ -47,4 +48,5 @@ void kernel_main() {
     DeviceTimestampedData("Number of Virtual Channels", num_virtual_channels);
     DeviceTimestampedData("NoC Index", noc_index);
     DeviceTimestampedData("Number of subordinates", num_subordinates);
+    DeviceTimestampedData("Loopback", loopback);
 }

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender_unicast_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender_unicast_2_0.cpp
@@ -15,6 +15,7 @@ void kernel_main() {
     constexpr uint32_t test_id = get_arg(args::test_id);
     constexpr uint32_t num_subordinates = get_arg(args::num_subordinates);
     constexpr uint32_t num_virtual_channels = get_arg(args::num_vc);
+    constexpr uint32_t loopback = get_arg(args::loopback);
 
     // Packed subordinate coords are truly variadic (one per subordinate).
     const uint32_t num_of_transactions = get_arg(args::num_of_transactions);
@@ -60,4 +61,5 @@ void kernel_main() {
     DeviceTimestampedData("Number of Virtual Channels", num_virtual_channels);
     DeviceTimestampedData("NoC Index", noc_index);
     DeviceTimestampedData("Number of subordinates", num_subordinates);
+    DeviceTimestampedData("Loopback", loopback);
 }

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/test_one_to_all.cpp
@@ -201,11 +201,11 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const OneToA
         {"pages_per_tx", (uint32_t)test_config.pages_per_transaction},
         {"bytes_per_page", (uint32_t)test_config.bytes_per_page},
         {"test_id", (uint32_t)test_config.test_id},
-        {"num_subordinates", (uint32_t)num_subordinates}};
+        {"num_subordinates", (uint32_t)num_subordinates},
+        {"loopback", (uint32_t)test_config.loopback}};
 
     if (test_config.is_multicast) {
         sender_named_args["is_linked"] = (uint32_t)test_config.is_linked;
-        sender_named_args["loopback"] = (uint32_t)test_config.loopback;
         sender_named_args["start_x"] = (uint32_t)sub_worker_start_coord.x;
         sender_named_args["start_y"] = (uint32_t)sub_worker_start_coord.y;
         sender_named_args["end_x"] = (uint32_t)sub_worker_end_coord.x;

--- a/tests/tt_metal/tt_metal/data_movement/one_to_one/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_one/README.md
@@ -48,6 +48,8 @@ Each test case has multiple runs, and each run has a unique runtime host id, ass
 
 5. **TensixDataMovementOneToOnePacketSizes2_0** (Test ID: 158) - Device 2.0 API version of the packet sizes test. Tests the same packet size variations as test ID 4 but uses the NOC API with structured endpoints and virtual channel support.
 
+6. **TensixDataMovementOneToOneDirectedIdeal2_0** (Test ID: 160) - Device 2.0 API version of the directed ideal test.
+
 ## Device 2.0 API Tests
 This test suite now includes tests using the new device 2.0 NOC API. These tests provide the same functionality as the original tests but use an updated API design:
 

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
@@ -229,6 +229,12 @@ tests:
   43:
     name: "DRAM Channels 2.0"
 
+  44:
+    name: "Loopback Packet Sizes 2.0"
+
+  45:
+    name: "Loopback Directed Ideal 2.0"
+
   50:
     name: "One to One Directed Ideal"
 
@@ -494,15 +500,21 @@ tests:
     name: "One from One Packet Sizes 2.0"
 
   160:
-    name: "One from All Packet Sizes 2.0"
+    name: "One to One Directed Ideal 2.0"
 
   161:
-    name: "One from All Directed Ideal 2.0"
+    name: "One from One Directed Ideal 2.0"
 
   162:
-    name: "One from All Virtual Channels 2.0"
+    name: "One from All Packet Sizes 2.0"
 
   163:
+    name: "One from All Directed Ideal 2.0"
+
+  164:
+    name: "One from All Virtual Channels 2.0"
+
+  165:
     name: "One from All Custom 2.0"
 
   170:
@@ -585,86 +597,137 @@ tests:
 
   309:
     name: "All to All Packet Sizes 2.0"
+    memory_type: "l1"
+    mechanism: "unicast"
+    pattern: "all_to_all"
 
   310:
-    name: "All from All Directed Ideal"
+    name: "All to All Directed Ideal 2.0"
 
   311:
-    name: "All from All Packet Sizes"
-    memory_type: "l1"
-    mechanism: "unicast"
-    pattern: "all_from_all"
+    name: "All to All 2x2 to 1x1 Directed Ideal 2.0"
 
   312:
-    name: "All from All 2x2 From 1x1 Directed Ideal"
+    name: "All to All 4x4 to 1x1 Directed Ideal 2.0"
 
   313:
-    name: "All from All 4x4 From 1x1 Directed Ideal"
+    name: "All to All 1x1 to 2x2 Directed Ideal 2.0"
 
   314:
-    name: "All from All 1x1 From 2x2 Directed Ideal"
+    name: "All to All 1x1 to 4x4 Directed Ideal 2.0"
 
   315:
-    name: "All from All 1x1 From 4x4 Directed Ideal"
+    name: "All to All 2x2 to 2x2 Directed Ideal 2.0"
 
   316:
-    name: "All from All 2x2 From 2x2 Directed Ideal"
-
-  317:
-    name: "All from All Virtual Channels"
-
-  318:
-    name: "All from All Custom"
-
-  319:
-    name: "Atomic Semaphore Adjacent Bandwidth Sweep"
-
-  320:
-    name: "Atomic Semaphore Non Adjacent Bandwidth Sweep"
-
-  321:
-    name: "Single source Multicast Atomic Increment"
-
-  322:
-    name: "Multi source Multicast Atomic Increment"
-
-  323:
-    name: "Single source Multicast Atomic Increment - NOC 1"
-
-  324:
-    name: "Multi source Multicast Atomic Increment - NOC 1"
-
-  325:
-    name: "Multicast Atomic Larger Increment"
-
-  326:
-    name: "Multicast Atomic Larger Increment - NOC 1"
-
-  327:
-    name: "Single source Multicast Atomic Increment 2.0 API"
-
-  328:
-    name: "Multicast Atomic Larger Increment 2.0 API"
-
-  329:
-    name: "All from All Grid Sweep Packet Sizes 2.0"
-    memory_type: "l1"
-    mechanism: "unicast"
-    pattern: "all_from_all"
-    bandwidth_mode: "combined"
-
-  330:
     name: "All to All Grid Sweep Packet Sizes 2.0"
     memory_type: "l1"
     mechanism: "unicast"
     pattern: "all_to_all"
     bandwidth_mode: "combined"
 
+  320:
+    name: "All from All Directed Ideal"
+
+  321:
+    name: "All from All Packet Sizes"
+    memory_type: "l1"
+    mechanism: "unicast"
+    pattern: "all_from_all"
+
+  322:
+    name: "All from All 2x2 From 1x1 Directed Ideal"
+
+  323:
+    name: "All from All 4x4 From 1x1 Directed Ideal"
+
+  324:
+    name: "All from All 1x1 From 2x2 Directed Ideal"
+
+  325:
+    name: "All from All 1x1 From 4x4 Directed Ideal"
+
+  326:
+    name: "All from All 2x2 From 2x2 Directed Ideal"
+
+  327:
+    name: "All from All Virtual Channels"
+
+  328:
+    name: "All from All Custom"
+
+  329:
+    name: "All from All Packet Sizes 2.0"
+    memory_type: "l1"
+    mechanism: "unicast"
+    pattern: "all_from_all"
+
+  330:
+    name: "All from All Directed Ideal 2.0"
+
   331:
-    name: "Multi source Multicast Atomic Increment - NOC 1 2.0 API"
+    name: "All from All 2x2 From 1x1 Directed Ideal 2.0"
 
   332:
-    name: "Multicast Atomic Larger Increment - NOC 1 2.0 API"
+    name: "All from All 4x4 From 1x1 Directed Ideal 2.0"
+
+  333:
+    name: "All from All 1x1 From 2x2 Directed Ideal 2.0"
+
+  334:
+    name: "All from All 1x1 From 4x4 Directed Ideal 2.0"
+
+  335:
+    name: "All from All 2x2 From 2x2 Directed Ideal 2.0"
+
+  336:
+    name: "All from All Grid Sweep Packet Sizes 2.0"
+    memory_type: "l1"
+    mechanism: "unicast"
+    pattern: "all_from_all"
+    bandwidth_mode: "combined"
+
+  340:
+    name: "Atomic Semaphore Adjacent Bandwidth Sweep"
+
+  341:
+    name: "Atomic Semaphore Non Adjacent Bandwidth Sweep"
+
+  342:
+    name: "Single source Multicast Atomic Increment"
+
+  343:
+    name: "Multi source Multicast Atomic Increment"
+
+  344:
+    name: "Single source Multicast Atomic Increment - NOC 1"
+
+  345:
+    name: "Multi source Multicast Atomic Increment - NOC 1"
+
+  346:
+    name: "Multicast Atomic Larger Increment"
+
+  347:
+    name: "Multicast Atomic Larger Increment - NOC 1"
+
+  348:
+    name: "Single source Multicast Atomic Increment 2.0"
+
+  349:
+    name: "Multicast Atomic Larger Increment 2.0"
+
+  350:
+    name: "Multi source Multicast Atomic Increment 2.0"
+
+  351:
+    name: "Single source Multicast Atomic Increment - NOC 1 2.0"
+
+  352:
+    name: "Multi source Multicast Atomic Increment - NOC 1 2.0"
+
+  353:
+    name: "Multicast Atomic Larger Increment - NOC 1 2.0"
 
   400:
     name: "I2S - DRAM Sharded Row Major Writer"

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
@@ -220,6 +220,15 @@ tests:
   40:
     name: "DRAM Packet Sizes 2.0"
 
+  41:
+    name: "DRAM Directed Ideal 2.0"
+
+  42:
+    name: "DRAM Core Locations 2.0"
+
+  43:
+    name: "DRAM Channels 2.0"
+
   50:
     name: "One to One Directed Ideal"
 
@@ -307,6 +316,30 @@ tests:
   87:
     name: "DRAM Sharded Read Transaction ID Directed Ideal"
 
+  90:
+    name: "One Packet Read Sizes 2.0"
+
+  91:
+    name: "One Packet Write Sizes 2.0"
+
+  92:
+    name: "One Packet Read Directed Ideal 2.0"
+
+  93:
+    name: "One Packet Write Directed Ideal 2.0"
+
+  94:
+    name: "DRAM Sharded Read Directed Ideal 2.0"
+
+  95:
+    name: "DRAM Sharded Read Tile Numbers 2.0"
+
+  96:
+    name: "DRAM Sharded Read Bank Numbers 2.0"
+
+  97:
+    name: "DRAM Sharded Read Transaction ID Directed Ideal 2.0"
+
   100:
     name: "Multicast Schemes (Loopback Enabled)"
 
@@ -391,6 +424,18 @@ tests:
     name: "Multi Interleaved 6x6 Write Sizes"
     bandwidth_mode: "combined"
 
+  128:
+    name: "Multi Interleaved Grid Sweep Sizes"
+    bandwidth_mode: "combined"
+
+  129:
+    name: "Multi Interleaved Read Grid Sweep Sizes"
+    bandwidth_mode: "combined"
+
+  130:
+    name: "Multi Interleaved Write Grid Sweep Sizes"
+    bandwidth_mode: "combined"
+
   140:
     name: "Core Bidirectional Directed Ideal Same Kernel"
 
@@ -447,6 +492,18 @@ tests:
 
   159:
     name: "One from One Packet Sizes 2.0"
+
+  160:
+    name: "One from All Packet Sizes 2.0"
+
+  161:
+    name: "One from All Directed Ideal 2.0"
+
+  162:
+    name: "One from All Virtual Channels 2.0"
+
+  163:
+    name: "One from All Custom 2.0"
 
   170:
     name: "One to All Unicast 2x2 Packet Sizes 2.0"
@@ -589,6 +646,26 @@ tests:
   328:
     name: "Multicast Atomic Larger Increment 2.0 API"
 
+  329:
+    name: "All from All Grid Sweep Packet Sizes 2.0"
+    memory_type: "l1"
+    mechanism: "unicast"
+    pattern: "all_from_all"
+    bandwidth_mode: "combined"
+
+  330:
+    name: "All to All Grid Sweep Packet Sizes 2.0"
+    memory_type: "l1"
+    mechanism: "unicast"
+    pattern: "all_to_all"
+    bandwidth_mode: "combined"
+
+  331:
+    name: "Multi source Multicast Atomic Increment - NOC 1 2.0 API"
+
+  332:
+    name: "Multicast Atomic Larger Increment - NOC 1 2.0 API"
+
   400:
     name: "I2S - DRAM Sharded Row Major Writer"
     comment: |
@@ -648,13 +725,23 @@ tests:
       Evaluates the performance impact of stateful versus stateless approaches under scenarios
       involving both identical and differing values and destinations.
 
+  502:
+    name: "DRAM Neighbour Directed Ideal"
+
   503:
     name: "Number of Pages Sweep for DRAM Closest Neighbour"
+    bandwidth_mode: "combined"
+
+  504:
+    name: "Number of Banks Sweep for DRAM Closest Neighbour"
     bandwidth_mode: "combined"
 
   505:
     name: "Number of Pages Sweep for Single Row DRAM"
     bandwidth_mode: "combined"
+
+  507:
+    name: "Inline Direct Write Multicast"
 
   508:
     name: "Number of Pages Sweep for DRAM One Hop"
@@ -705,6 +792,21 @@ tests:
       has an input and output port. We have a core that is sending and receiving data at the same time,
       with packets circulating around the torus. This does not happen in Read After Write tests because
       the read requests get stuck behind the larger write requests.
+
+  620:
+    name: "Transaction ID - Read After Write 2.0"
+
+  621:
+    name: "Transaction ID - Read After Write One Packet 2.0"
+
+  622:
+    name: "Transaction ID - Read After Write One Packet Stateful 2.0"
+
+  630:
+    name: "Transaction ID - Write After Read 2.0"
+
+  631:
+    name: "Transaction ID - Write After Read One Packet Stateful 2.0"
 
   700:
     name: "NOC API Latency - Unicast Write"

--- a/tests/tt_metal/tt_metal/data_movement/transaction_id/test_transaction_id.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/transaction_id/test_transaction_id.cpp
@@ -513,7 +513,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdReadAfterWrite_2
             GTEST_SKIP() << "Skipping: need 3 distinct cores but grid is only " << grid_dbg.x << "x" << grid_dbg.y;
         }
         unit_tests::dm::transaction_id::TransactionIdConfig test_config = {
-            .test_id = 700,
+            .test_id = 620,
             .master_core_coord = master_core_coord,
             .sub0_core_coord = sub0_core_coord,
             .sub1_core_coord = sub1_core_coord,
@@ -535,7 +535,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdReadAfterWrite_2
                 continue;
             }
             unit_tests::dm::transaction_id::TransactionIdConfig test_config = {
-                .test_id = 700,
+                .test_id = 620,
                 .master_core_coord = master_core_coord,
                 .sub0_core_coord = sub0_core_coord,
                 .sub1_core_coord = sub1_core_coord,
@@ -566,7 +566,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdReadAfterWriteOn
             GTEST_SKIP() << "Skipping: need 3 distinct cores on Quasar emulator";
         }
         unit_tests::dm::transaction_id::TransactionIdConfig test_config = {
-            .test_id = 701,
+            .test_id = 621,
             .master_core_coord = master_core_coord,
             .sub0_core_coord = sub0_core_coord,
             .sub1_core_coord = sub1_core_coord,
@@ -588,7 +588,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdReadAfterWriteOn
                 continue;
             }
             unit_tests::dm::transaction_id::TransactionIdConfig test_config = {
-                .test_id = 701,
+                .test_id = 621,
                 .master_core_coord = master_core_coord,
                 .sub0_core_coord = sub0_core_coord,
                 .sub1_core_coord = sub1_core_coord,
@@ -620,7 +620,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdReadAfterWriteOn
             GTEST_SKIP() << "Skipping: need 3 distinct cores on Quasar emulator";
         }
         unit_tests::dm::transaction_id::TransactionIdConfig test_config = {
-            .test_id = 702,
+            .test_id = 622,
             .master_core_coord = master_core_coord,
             .sub0_core_coord = sub0_core_coord,
             .sub1_core_coord = sub1_core_coord,
@@ -643,7 +643,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdReadAfterWriteOn
                 continue;
             }
             unit_tests::dm::transaction_id::TransactionIdConfig test_config = {
-                .test_id = 702,
+                .test_id = 622,
                 .master_core_coord = master_core_coord,
                 .sub0_core_coord = sub0_core_coord,
                 .sub1_core_coord = sub1_core_coord,
@@ -676,7 +676,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdWriteAfterRead_2
             GTEST_SKIP() << "Skipping: need 3 distinct cores on Quasar emulator";
         }
         unit_tests::dm::transaction_id::TransactionIdConfig test_config = {
-            .test_id = 710,
+            .test_id = 630,
             .master_core_coord = master_core_coord,
             .sub0_core_coord = sub0_core_coord,
             .sub1_core_coord = sub1_core_coord,
@@ -698,7 +698,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdWriteAfterRead_2
                 continue;
             }
             unit_tests::dm::transaction_id::TransactionIdConfig test_config = {
-                .test_id = 710,
+                .test_id = 630,
                 .master_core_coord = master_core_coord,
                 .sub0_core_coord = sub0_core_coord,
                 .sub1_core_coord = sub1_core_coord,
@@ -730,7 +730,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdWriteAfterReadOn
             GTEST_SKIP() << "Skipping: need 3 distinct cores on Quasar emulator";
         }
         unit_tests::dm::transaction_id::TransactionIdConfig test_config = {
-            .test_id = 711,
+            .test_id = 631,
             .master_core_coord = master_core_coord,
             .sub0_core_coord = sub0_core_coord,
             .sub1_core_coord = sub1_core_coord,
@@ -754,7 +754,7 @@ TEST_F(GenericMeshDeviceFixture, TensixDataMovementTransactionIdWriteAfterReadOn
                 continue;
             }
             unit_tests::dm::transaction_id::TransactionIdConfig test_config = {
-                .test_id = 711,
+                .test_id = 631,
                 .master_core_coord = master_core_coord,
                 .sub0_core_coord = sub0_core_coord,
                 .sub1_core_coord = sub1_core_coord,


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Testing/bug fixes

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
https://github.com/tenstorrent/tt-metal/issues/47277
Miscellaneous updates to the Data Movement tests, as part of the web viewer effort, mostly either small additions for the sake of pipelining information or bug fixes.
- Adds tests to the `all_from_all`, `all_to_all`, and `multi_interleaved` test suites which simultaneously sweep over grid sizes and transaction sizes
- Removes duplicate run of full grid size in certain NOC Estimator sweep tests for Wormhole architecture, which has an 8x8 grid
- Updates NOC estimator test kernels to use current APIs (previously was broken)
- Assigns new test IDs to some DM tests which were missing them or had a duplicate
- Stamps a few parameters (loopback, num_banks) in kernels where it was determined useful for the web viewer (which is under development)
### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ryanzhu/dm-updates)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ryanzhu/dm-updates)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ryanzhu/dm-updates)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ryanzhu/dm-updates)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ryanzhu/dm-updates)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ryanzhu/dm-updates)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ryanzhu/dm-updates)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ryanzhu/dm-updates)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ryanzhu/dm-updates)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ryanzhu/dm-updates)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ryanzhu/dm-updates)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ryanzhu/dm-updates)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ryanzhu/dm-updates)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ryanzhu/dm-updates)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ryanzhu/dm-updates)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ryanzhu/dm-updates)