### PR TITLE
[Clean up]: Add apis to get total dfb fifo size and local views that give size/num entries for active tile counter

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_apis.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_apis.cpp
@@ -2,12 +2,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //
-// Device-side DataflowBuffer API tests (read_tile_value / get_tile_address).
-// DM → Tensix, 1 producer × 1 consumer, 2-entry DFB, explicit sync (WH/BH).
-//
-// Quasar is skipped until read_tile_value / get_tile_address on 2xx DFB is debugged.
+// Device-side DataflowBuffer API tests:
+// - read_tile_value / get_tile_address (DM → Tensix, 1Sx1S, WH/BH; Quasar skipped)
+// - Static DFB extent getters (no DRAM); WH/BH 1Sx1S; Quasar multi-TC layout probes
 
+#include <algorithm>
+#include <array>
 #include <cstdint>
+#include <memory>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -189,6 +191,404 @@ TEST_F(MeshDeviceFixture, DataflowBufferReadTileValue) {
             expected_per_thread)
             << "TRISC thread slot " << thread;
     }
+}
+
+namespace {
+
+using ExtentRecord = std::array<uint32_t, 8>;
+
+enum ExtentField : uint32_t {
+    EntrySize = 0,
+    StrideSize,
+    TotalNumEntries,
+    TotalSizeBytes,
+    LocalNumEntries,
+    LocalSizeBytes,
+    RingSpanBytes,
+    RingSpanNumEntries,
+};
+
+inline uint32_t strided_num_tcs(bool is_producer, uint32_t num_producers, uint32_t num_consumers) {
+    if (is_producer) {
+        return num_consumers >= num_producers ? num_consumers / num_producers : 1u;
+    }
+    return num_producers >= num_consumers ? num_producers / num_consumers : 1u;
+}
+
+struct ExtentLayoutParams {
+    uint32_t capacity = 0;
+    uint32_t stride_in_entries = 0;
+    uint32_t ring_bytes = 0;
+    uint32_t num_tcs_on_risc = 0;
+};
+
+inline ExtentLayoutParams compute_strided_layout(
+    uint32_t num_entries, uint32_t entry_size, uint32_t num_producers, uint32_t num_consumers, bool is_producer) {
+    const uint32_t max_pc = std::max(num_producers, num_consumers);
+    return ExtentLayoutParams{
+        .capacity = num_entries / max_pc,
+        .stride_in_entries = max_pc,
+        .ring_bytes = entry_size * (max_pc * (num_entries / max_pc - 1u) + 1u),
+        .num_tcs_on_risc = strided_num_tcs(is_producer, num_producers, num_consumers),
+    };
+}
+
+inline uint32_t expected_strided_ring_span_bytes(
+    uint32_t entry_size, uint32_t local_ring_bytes, uint32_t num_tcs_on_risc, uint32_t num_endpoint_threads) {
+    if (num_tcs_on_risc <= 1) {
+        return local_ring_bytes;
+    }
+    // Host assigns bases per tc slot across all same-role RISCs on the node (base += entry_size
+    // per RISC). TC[t] on RISC p is at alloc + (t * num_endpoint_threads + p) * entry_size, so the
+    // bounding span on one RISC is local_ring + (num_tcs - 1) * num_endpoint_threads * entry_size.
+    return local_ring_bytes + (num_tcs_on_risc - 1u) * num_endpoint_threads * entry_size;
+}
+
+inline ExtentRecord expected_strided_extent(
+    uint32_t entry_size,
+    uint32_t num_entries,
+    uint32_t num_producers,
+    uint32_t num_consumers,
+    bool is_producer) {
+    const auto layout = compute_strided_layout(num_entries, entry_size, num_producers, num_consumers, is_producer);
+    const uint32_t total_bytes = num_entries * entry_size;
+    const uint32_t num_endpoint_threads = is_producer ? num_producers : num_consumers;
+    const uint32_t ring_span_bytes = expected_strided_ring_span_bytes(
+        entry_size, layout.ring_bytes, layout.num_tcs_on_risc, num_endpoint_threads);
+    return ExtentRecord{
+        entry_size,
+        entry_size * layout.stride_in_entries,
+        num_entries,
+        total_bytes,
+        layout.capacity,
+        layout.ring_bytes,
+        ring_span_bytes,
+        ring_span_bytes / entry_size,
+    };
+}
+
+// ALL consumer (cap=ALL): capacity/stride follow num_producers; TC counts match DMTensix ALL.
+inline ExtentRecord expected_all_extent(
+    uint32_t entry_size,
+    uint32_t num_entries,
+    uint32_t num_producers,
+    uint32_t num_consumers,
+    bool is_producer) {
+    (void)num_consumers;
+    const uint32_t capacity = num_entries / num_producers;
+    const uint32_t stride_in_entries = 1;
+    const uint32_t total_bytes = num_entries * entry_size;
+    const uint32_t ring_bytes = entry_size * (stride_in_entries * (capacity - 1u) + 1u);
+    const uint32_t num_tcs_on_risc = is_producer ? 1u : num_producers;
+    const uint32_t ring_span_bytes = num_tcs_on_risc <= 1 ? ring_bytes : total_bytes;
+    return ExtentRecord{
+        entry_size,
+        entry_size * stride_in_entries,
+        num_entries,
+        total_bytes,
+        capacity,
+        ring_bytes,
+        ring_span_bytes,
+        ring_span_bytes / entry_size,
+    };
+}
+
+inline ExtentRecord expected_extent(
+    uint32_t entry_size,
+    uint32_t num_entries,
+    uint32_t num_producers,
+    uint32_t num_consumers,
+    bool is_producer,
+    m2::DFBAccessPattern consumer_access_pattern) {
+    if (consumer_access_pattern == m2::DFBAccessPattern::ALL) {
+        return expected_all_extent(entry_size, num_entries, num_producers, num_consumers, is_producer);
+    }
+    return expected_strided_extent(entry_size, num_entries, num_producers, num_consumers, is_producer);
+}
+
+inline void expect_extent_record(const ExtentRecord& actual, const ExtentRecord& expected) {
+    EXPECT_EQ(actual[EntrySize], expected[EntrySize]) << "entry_size";
+    EXPECT_EQ(actual[StrideSize], expected[StrideSize]) << "stride_size";
+    EXPECT_EQ(actual[TotalNumEntries], expected[TotalNumEntries]) << "total_num_entries";
+    EXPECT_EQ(actual[TotalSizeBytes], expected[TotalSizeBytes]) << "total_size_bytes";
+    EXPECT_EQ(actual[LocalNumEntries], expected[LocalNumEntries]) << "local_num_entries";
+    EXPECT_EQ(actual[LocalSizeBytes], expected[LocalSizeBytes]) << "local_size_bytes";
+    EXPECT_EQ(actual[RingSpanBytes], expected[RingSpanBytes]) << "ring_span_bytes";
+    EXPECT_EQ(actual[RingSpanNumEntries], expected[RingSpanNumEntries]) << "ring_span_num_entries";
+}
+
+inline void expect_wh_bh_aliases(const ExtentRecord& rec) {
+    EXPECT_EQ(rec[LocalNumEntries], rec[TotalNumEntries]);
+    EXPECT_EQ(rec[LocalSizeBytes], rec[TotalSizeBytes]);
+    EXPECT_EQ(rec[RingSpanBytes], rec[TotalSizeBytes]);
+    EXPECT_EQ(rec[RingSpanNumEntries], rec[TotalNumEntries]);
+    EXPECT_EQ(rec[StrideSize], rec[EntrySize]);
+}
+
+inline uint32_t allocate_l1_result_region(IDevice* device, uint32_t bytes) {
+    const uint32_t alignment = device->allocator()->get_alignment(BufferType::L1);
+    const uint32_t aligned = (bytes + alignment - 1u) / alignment * alignment;
+    return static_cast<uint32_t>(device->l1_size_per_core()) - aligned;
+}
+
+inline ExtentRecord read_extent_record(IDevice* device, CoreCoord core, uint32_t l1_addr) {
+    constexpr uint32_t num_fields = 8;
+    constexpr uint32_t record_bytes = num_fields * sizeof(uint32_t);
+    std::vector<uint32_t> words(num_fields, 0u);
+    detail::ReadFromDeviceL1(device, core, l1_addr, record_bytes, words);
+    ExtentRecord rec{};
+    for (uint32_t i = 0; i < num_fields; ++i) {
+        rec[i] = words[i];
+    }
+    return rec;
+}
+
+struct ProducerProbeConfig {
+    uint32_t num_tc_snapshots = 1;
+    bool rotate_tc = false;
+    uint32_t credits_to_post = 0;
+};
+
+struct ConsumerProbeConfig {
+    uint32_t num_tc_snapshots = 1;
+    bool rotate_tc = false;
+    bool drain_producer_rotate_credits = false;
+    bool drain_last_tc_credit = false;
+};
+
+struct ExtentProbeParams {
+    uint32_t num_producers = 1;
+    uint32_t num_consumers = 1;
+    uint32_t entry_size = 1024;
+    uint32_t num_entries = 16;
+    m2::DFBAccessPattern consumer_access_pattern = m2::DFBAccessPattern::STRIDED;
+    ProducerProbeConfig producer{};
+    ConsumerProbeConfig consumer{};
+};
+
+void run_extent_probe(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const ExtentProbeParams& params) {
+    constexpr uint32_t extent_record_bytes = 8 * sizeof(uint32_t);
+
+    IDevice* device = mesh_device->get_devices()[0];
+    const bool is_quasar = device->arch() == ARCH::QUASAR;
+
+    if (!is_quasar && (params.num_producers > 1 || params.num_consumers > 1)) {
+        GTEST_SKIP() << "WH/BH supports 1Sx1S only";
+    }
+
+    const m2::NodeCoord node{0, 0};
+    const m2::DFBSpecName DFB{"dfb"};
+    const m2::KernelSpecName PRODUCER{"producer"};
+    const m2::KernelSpecName CONSUMER{"consumer"};
+
+    m2::DataflowBufferSpec dfb_spec{
+        .unique_id = DFB,
+        .entry_size = params.entry_size,
+        .num_entries = params.num_entries,
+        .data_format_metadata = DataFormat::Float16_b,
+    };
+
+    m2::DataMovementHardwareConfig producer_hw;
+    m2::ComputeHardwareConfig consumer_hw;
+    if (is_quasar) {
+        producer_hw = m2::DataMovementGen2Config{.disable_dfb_implicit_sync_for = {DFB}};
+        consumer_hw = m2::ComputeGen2Config{};
+    } else {
+        producer_hw = m2::DataMovementGen1Config{.processor = DataMovementProcessor::RISCV_0};
+        consumer_hw = m2::ComputeGen1Config{};
+    }
+
+    m2::KernelSpec producer{
+        .unique_id = PRODUCER,
+        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_extent_probe_dm.cpp",
+        .num_threads = static_cast<uint8_t>(params.num_producers),
+        .dfb_bindings =
+            {{.dfb_spec_name = DFB,
+              .accessor_name = "out",
+              .endpoint_type = m2::DFBEndpointType::PRODUCER,
+              .access_pattern = m2::DFBAccessPattern::STRIDED}},
+        .compile_time_args =
+            {
+                {"num_tc_snapshots", params.producer.num_tc_snapshots},
+                {"rotate_tc", params.producer.rotate_tc ? 1u : 0u},
+                {"credits_to_post", params.producer.credits_to_post},
+            },
+        .runtime_arg_schema = {.runtime_arg_names = {"result_l1_addr"}},
+        .hw_config = producer_hw,
+    };
+
+    m2::KernelSpec consumer{
+        .unique_id = CONSUMER,
+        .source = "tests/tt_metal/tt_metal/test_kernels/compute/dfb_extent_probe_compute.cpp",
+        .num_threads = static_cast<uint8_t>(params.num_consumers),
+        .dfb_bindings =
+            {{.dfb_spec_name = DFB,
+              .accessor_name = "in",
+              .endpoint_type = m2::DFBEndpointType::CONSUMER,
+              .access_pattern = params.consumer_access_pattern}},
+        .compile_time_args =
+            {
+                {"num_tc_snapshots", params.consumer.num_tc_snapshots},
+                {"rotate_tc", params.consumer.rotate_tc ? 1u : 0u},
+                {"drain_producer_rotate_credits", params.consumer.drain_producer_rotate_credits ? 1u : 0u},
+                {"drain_last_tc_credit", params.consumer.drain_last_tc_credit ? 1u : 0u},
+                {"num_producers", params.num_producers},
+            },
+        .runtime_arg_schema = {.runtime_arg_names = {"result_l1_addr"}},
+        .hw_config = consumer_hw,
+    };
+
+    m2::WorkUnitSpec wu{.name = "wu", .kernels = {PRODUCER, CONSUMER}, .target_nodes = node};
+
+    m2::ProgramSpec spec{
+        .name = "dfb_extent_probe",
+        .kernels = {producer, consumer},
+        .dataflow_buffers = {dfb_spec},
+        .work_units = {wu},
+    };
+
+    Program program = m2::MakeProgramFromSpec(*mesh_device, spec);
+
+    const uint32_t producer_records =
+        params.num_producers * params.producer.num_tc_snapshots;
+    const uint32_t consumer_records = params.consumer.num_tc_snapshots;
+    const uint32_t producer_result_l1 =
+        allocate_l1_result_region(device, (producer_records + consumer_records) * extent_record_bytes);
+    const uint32_t consumer_result_l1 = producer_result_l1 + producer_records * extent_record_bytes;
+
+    m2::ProgramRunArgs run_args;
+    run_args.kernel_run_args = {
+        m2::ProgramRunArgs::KernelRunArgs{
+            .kernel = PRODUCER,
+            .runtime_arg_values = m2::MakeRuntimeArgsForSingleNode(node, {{"result_l1_addr", producer_result_l1}}),
+        },
+        m2::ProgramRunArgs::KernelRunArgs{
+            .kernel = CONSUMER,
+            .runtime_arg_values = m2::MakeRuntimeArgsForSingleNode(node, {{"result_l1_addr", consumer_result_l1}}),
+        },
+    };
+    m2::SetProgramRunArgs(program, run_args);
+
+    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+    tt_driver_atomics::mfence();
+
+    const CoreCoord core{0, 0};
+    const ExtentRecord expected_producer = expected_extent(
+        params.entry_size,
+        params.num_entries,
+        params.num_producers,
+        params.num_consumers,
+        true,
+        params.consumer_access_pattern);
+    const ExtentRecord expected_consumer = expected_extent(
+        params.entry_size,
+        params.num_entries,
+        params.num_producers,
+        params.num_consumers,
+        false,
+        params.consumer_access_pattern);
+
+    for (uint32_t t = 0; t < params.num_producers; ++t) {
+        for (uint32_t s = 0; s < params.producer.num_tc_snapshots; ++s) {
+            const uint32_t l1_addr =
+                producer_result_l1 + (t * params.producer.num_tc_snapshots + s) * extent_record_bytes;
+            const ExtentRecord rec = read_extent_record(device, core, l1_addr);
+            if (is_quasar) {
+                expect_extent_record(rec, expected_producer);
+            } else {
+                expect_wh_bh_aliases(rec);
+                EXPECT_EQ(rec[EntrySize], params.entry_size);
+                EXPECT_EQ(rec[TotalNumEntries], params.num_entries);
+                EXPECT_EQ(rec[TotalSizeBytes], params.entry_size * params.num_entries);
+            }
+        }
+    }
+
+    for (uint32_t s = 0; s < params.consumer.num_tc_snapshots; ++s) {
+        const ExtentRecord rec = read_extent_record(device, core, consumer_result_l1 + s * extent_record_bytes);
+        if (is_quasar) {
+            expect_extent_record(rec, expected_consumer);
+        } else {
+            expect_wh_bh_aliases(rec);
+            EXPECT_EQ(rec[EntrySize], params.entry_size);
+            EXPECT_EQ(rec[TotalNumEntries], params.num_entries);
+            EXPECT_EQ(rec[TotalSizeBytes], params.entry_size * params.num_entries);
+        }
+    }
+
+    if (is_quasar && params.producer.num_tc_snapshots == 1 && params.num_producers > params.num_consumers) {
+        const ExtentRecord consumer_rec = read_extent_record(device, core, consumer_result_l1);
+        EXPECT_LT(consumer_rec[LocalSizeBytes], consumer_rec[RingSpanBytes])
+            << "multi-TC consumer RISC: local ring < bounding span";
+    }
+    if (is_quasar && params.producer.num_tc_snapshots == 1 && params.num_consumers > params.num_producers &&
+        params.consumer_access_pattern == m2::DFBAccessPattern::STRIDED) {
+        const ExtentRecord producer_rec = read_extent_record(device, core, producer_result_l1);
+        EXPECT_LT(producer_rec[LocalSizeBytes], producer_rec[RingSpanBytes])
+            << "multi-TC producer RISC: local ring < bounding span";
+    }
+    if (is_quasar && params.producer.num_tc_snapshots == 1 &&
+        params.consumer_access_pattern == m2::DFBAccessPattern::ALL && params.num_producers > 1) {
+        const ExtentRecord consumer_rec = read_extent_record(device, core, consumer_result_l1);
+        EXPECT_LT(consumer_rec[LocalSizeBytes], consumer_rec[RingSpanBytes])
+            << "ALL consumer multi-TC RISC: local ring < bounding span";
+    }
+}
+
+}  // namespace
+
+TEST_F(MeshDeviceFixture, DataflowBufferExtentApis_1Sx1S) {
+    run_extent_probe(devices_.at(0), {});
+}
+
+TEST_F(MeshDeviceFixture, DataflowBufferExtentApis_4Sx1S) {
+    run_extent_probe(
+        devices_.at(0),
+        {
+            .num_producers = 4,
+            .num_consumers = 1,
+        });
+}
+
+// 2Sx4S: each producer RISC round-robins 2 TCs (push advances tc_idx between snapshots).
+TEST_F(MeshDeviceFixture, DataflowBufferExtentApis_2Sx4S_ProducerEachTC) {
+    run_extent_probe(
+        devices_.at(0),
+        {
+            .num_producers = 2,
+            .num_consumers = 4,
+            .producer =
+                {
+                    .num_tc_snapshots = 2,
+                    .rotate_tc = true,
+                },
+            .consumer =
+                {
+                    .num_tc_snapshots = 1,
+                    .drain_producer_rotate_credits = true,
+                },
+        });
+}
+
+// 2Sx4A: each consumer RISC round-robins 2 TCs (pop advances tc_idx between snapshots).
+TEST_F(MeshDeviceFixture, DataflowBufferExtentApis_2Sx4A_ConsumerEachTC) {
+    run_extent_probe(
+        devices_.at(0),
+        {
+            .num_producers = 2,
+            .num_consumers = 4,
+            .consumer_access_pattern = m2::DFBAccessPattern::ALL,
+            .producer =
+                {
+                    .credits_to_post = 1,
+                },
+            .consumer =
+                {
+                    .num_tc_snapshots = 2,
+                    .rotate_tc = true,
+                    .drain_last_tc_credit = true,
+                },
+        });
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/test_kernels/compute/dfb_extent_probe_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dfb_extent_probe_compute.cpp
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Tensix consumer extent probe: snapshot getters on UNPACK. When rotate_tc is set,
+// advances tc_idx with wait_front + copy_tile + pop_front between snapshots (minimal
+// credits). When the producer rotates (push_back between TC snapshots), consumers
+// paired with producer TC0 must drain one credit each or finish() hangs in AAW.
+
+#include "api/compute/common.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/kernel_thread_globals.h"
+#include "dev_mem_map.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    constexpr uint32_t num_tc_snapshots = get_arg(args::num_tc_snapshots);
+    constexpr uint32_t rotate_tc = get_arg(args::rotate_tc);
+    constexpr uint32_t drain_producer_rotate_credits = get_arg(args::drain_producer_rotate_credits);
+    constexpr uint32_t drain_last_tc_credit = get_arg(args::drain_last_tc_credit);
+    constexpr uint32_t num_producers = get_arg(args::num_producers);
+
+    const uint32_t result_l1_addr = get_arg(args::result_l1_addr);
+    const uint32_t consumer_idx = get_my_thread_id();
+
+    DataflowBuffer dfb(dfb::in);
+
+    if constexpr (rotate_tc || drain_producer_rotate_credits || drain_last_tc_credit) {
+        unary_op_init_common(dfb.get_id(), dfb.get_id());
+    }
+
+    for (uint32_t tc = 0; tc < num_tc_snapshots; ++tc) {
+#ifdef TRISC_UNPACK
+        constexpr uint32_t extent_record_bytes = 8 * sizeof(uint32_t);
+#ifdef ARCH_QUASAR
+        const uint32_t result_l1_ptr_addr =
+            result_l1_addr + MEM_L1_UNCACHED_BASE + tc * extent_record_bytes;
+#else
+        const uint32_t result_l1_ptr_addr = result_l1_addr + tc * extent_record_bytes;
+#endif
+        volatile tt_l1_ptr uint32_t* const out =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(result_l1_ptr_addr);
+        out[0] = dfb.get_entry_size();
+        out[1] = dfb.get_stride_size();
+        out[2] = dfb.get_total_num_entries();
+        out[3] = dfb.get_total_size_bytes();
+        out[4] = dfb.get_local_num_entries();
+        out[5] = dfb.get_local_size_bytes();
+        out[6] = dfb.get_ring_span_bytes();
+        out[7] = dfb.get_ring_span_num_entries();
+#endif
+
+        if constexpr (rotate_tc) {
+            if (tc + 1 < num_tc_snapshots) {
+                tile_regs_acquire();
+                dfb.wait_front(1);
+                copy_tile(dfb.get_id(), 0, 0);
+                dfb.pop_front(1);
+                tile_regs_release();
+            }
+        }
+    }
+
+    // After rotating through all TCs, pop once more to drain credits posted to the last TC
+    // (e.g. 2Sx4A: producer[1] posts to consumer TC1 while rotate only pops between TC0→TC1).
+    if constexpr (drain_last_tc_credit) {
+        tile_regs_acquire();
+        dfb.wait_front(1);
+        copy_tile(dfb.get_id(), 0, 0);
+        dfb.pop_front(1);
+        tile_regs_release();
+    }
+
+    if constexpr (drain_producer_rotate_credits) {
+        if (consumer_idx < num_producers) {
+            tile_regs_acquire();
+            dfb.wait_front(1);
+            copy_tile(dfb.get_id(), 0, 0);
+            dfb.pop_front(1);
+            tile_regs_release();
+        }
+    }
+
+    dfb.finish();
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_extent_probe_dm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_extent_probe_dm.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// DM DFB extent probe: snapshot static layout getters to L1, optionally rotate tc_idx
+// via reserve_back/push_back (no DRAM / NoC). Multi-threaded: one record per thread at
+// tc_idx == 0 unless rotate_tc is set (single-thread only for rotation).
+
+#include "api/dataflow/dataflow_buffer.h"
+#include "dev_mem_map.h"
+#include "experimental/kernel_args.h"
+
+namespace {
+
+inline uint32_t l1_ptr_addr(uint32_t byte_addr) {
+#ifdef ARCH_QUASAR
+    return byte_addr + MEM_L1_UNCACHED_BASE;
+#else
+    return byte_addr;
+#endif
+}
+
+inline void snapshot_extent(DataflowBuffer& dfb, uint32_t result_l1_addr, uint32_t record_index) {
+    constexpr uint32_t extent_record_bytes = 8 * sizeof(uint32_t);
+    const uint32_t out_addr = l1_ptr_addr(result_l1_addr + record_index * extent_record_bytes);
+    volatile tt_l1_ptr uint32_t* const out = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_addr);
+    out[0] = dfb.get_entry_size();
+    out[1] = dfb.get_stride_size();
+    out[2] = dfb.get_total_num_entries();
+    out[3] = dfb.get_total_size_bytes();
+    out[4] = dfb.get_local_num_entries();
+    out[5] = dfb.get_local_size_bytes();
+    out[6] = dfb.get_ring_span_bytes();
+    out[7] = dfb.get_ring_span_num_entries();
+}
+
+}  // namespace
+
+void kernel_main() {
+    constexpr uint32_t num_tc_snapshots = get_arg(args::num_tc_snapshots);
+    constexpr uint32_t rotate_tc = get_arg(args::rotate_tc);
+    constexpr uint32_t credits_to_post = get_arg(args::credits_to_post);
+
+    const uint32_t result_l1_addr = get_arg(args::result_l1_addr);
+    const uint32_t thread_id = get_my_thread_id();
+
+    DataflowBuffer dfb(dfb::out);
+
+    const uint32_t base_record = thread_id * num_tc_snapshots;
+    for (uint32_t tc = 0; tc < num_tc_snapshots; ++tc) {
+        snapshot_extent(dfb, result_l1_addr, base_record + tc);
+        if constexpr (rotate_tc) {
+            if (tc + 1 < num_tc_snapshots) {
+                dfb.reserve_back(1);
+                dfb.push_back(1);
+            }
+        }
+    }
+
+    if constexpr (credits_to_post > 0) {
+        for (uint32_t i = 0; i < credits_to_post; ++i) {
+            dfb.reserve_back(1);
+            dfb.push_back(1);
+        }
+    }
+
+    dfb.finish();
+}

--- a/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
@@ -81,6 +81,62 @@ public:
     uint32_t get_stride_size() const;
     // Returns the total number of entries that can be stored in the DFB
     uint32_t get_total_num_entries() const;
+    // Total L1 backing for the global ring (num_entries * entry_size), in bytes.
+    uint32_t get_total_size_bytes() const;
+
+    // --- Quasar (tt-2xx) depth / L1 extent queries ---------------------------------
+    //
+    // A logical DFB on Quasar may use multiple hardware tile counters (TCs) on one RISC
+    // (round-robin via tc_idx over tc_slots[0..num_tcs_to_rr-1]). Each TC has its own
+    // base_addr and ring extent (limit on DM; ring_size on TRISC). These getters expose
+    // three measurement scopes; see also DFB L1 layout diagrams (STRIDED vs ALL).
+    //
+    //  (1) get_total_*     — entire DFB: num_entries credits, num_entries * entry_size L1.
+    //
+    //  (2) get_local_*     — active TC only (tc_slots[tc_idx]):
+    //        get_local_num_entries()  HW credit depth (buf_capacity) for this TC.
+    //        get_local_size_bytes()   linear address interval [base, limit) / ring_size
+    //                                 for this TC alone.
+    //
+    //      local_size_bytes is ONE contiguous L1 interval, but the entries *owned* by this
+    //      TC are often NOT adjacent inside it — tile counters can have discontiguous L1:
+    //
+    //      STRIDED (e.g. 4Sx1S: stride_in_entries = num_producers):
+    //        Global ring is interleaved: physical slot (e, p) = e*P + p.
+    //        Each TC walks its column with stride_size (= entry_size * P):
+    //
+    //          L1:  [P0@e0][P1@e0][P2@e0][P3@e0][P0@e1][P1@e1]...
+    //          TC0:  ^              ^              ^         (every P-th entry)
+    //
+    //        TC0's [base0, limit0) spans the full linear ring byte length, but its owned
+    //        tiles sit P-1 foreign slots apart — discontiguous within that interval.
+    //
+    //      ALL (e.g. 4Sx1A: stride_in_entries = 1):
+    //        Each TC owns a contiguous block of capacity entries; bases step by
+    //        capacity * entry_size:
+    //
+    //          L1:  [ TC0: cap entries ][ TC1: cap entries ][ TC2: ... ][ TC3: ... ]
+    //
+    //        Here each TC's owned tiles ARE contiguous within its local interval.
+    //
+    //  (3) get_ring_span_* — bounding box across ALL TC slots on this RISC:
+    //        Contiguous L1 from tc_slots[0].base through the end of the last TC ring
+    //        (limit[last] - base[0] on DM; base[last] + ring_size[last] - base[0] on TRISC).
+    //        get_ring_span_num_entries() = ring_span_bytes / entry_size (address slots in
+    //        that bounding interval, not per-TC owned entry count).
+    //
+    //        ring_span is the minimal contiguous L1 interval covering every TC window.
+    //        In STRIDED layouts TC bases are staggered by entry_size with overlapping
+    //        windows; in ALL layouts TC blocks are disjoint and packed. Neither layout
+    //        guarantees that every byte in ring_span belongs to one TC's owned entries
+    //        (STRIDED: foreign interleaved slots; ALL: only the active TC's block is
+    //        "yours" at a given time during round-robin).
+    //
+    // On tt-1xx (WH/BH) there is no per-TC view; all four getters alias get_total_*.
+    uint32_t get_local_num_entries() const;
+    uint32_t get_local_size_bytes() const;
+    uint32_t get_ring_span_bytes() const;
+    uint32_t get_ring_span_num_entries() const;
 
     // Explicit sync APIs
     void reserve_back(uint16_t num_entries) { reserve_back_impl(num_entries); }
@@ -270,6 +326,10 @@ private:
 
     void release_scoped_lock() {
         // TODO: Unregister with the debugger
+    }
+
+    constexpr uint32_t address_units_to_bytes(uint32_t units) const {
+        return units << cb_addr_shift;
     }
 
     uint16_t logical_dfb_id_;

--- a/tt_metal/hw/inc/internal/tt-1xx/dataflow_buffer.inl
+++ b/tt_metal/hw/inc/internal/tt-1xx/dataflow_buffer.inl
@@ -36,7 +36,7 @@ inline uint32_t DataflowBuffer::get_entry_size() const {
 #if DFB_IS_COMPUTE_MATH
     return 0;
 #else
-    return local_dfb_interface_.fifo_page_size;
+    return address_units_to_bytes(local_dfb_interface_.fifo_page_size);
 #endif
 }
 
@@ -44,7 +44,7 @@ inline uint32_t DataflowBuffer::get_stride_size() const {
 #if DFB_IS_COMPUTE_MATH
     return 0;
 #else
-    return local_dfb_interface_.fifo_page_size;
+    return address_units_to_bytes(local_dfb_interface_.fifo_page_size);
 #endif
 }
 
@@ -52,10 +52,27 @@ inline uint32_t DataflowBuffer::get_total_num_entries() const {
 #if DFB_IS_COMPUTE_MATH
     return 0;
 #else
-    return local_dfb_interface_.fifo_num_pages;
+    // Only writers populate fifo_num_pages
+    const uint32_t page_size = local_dfb_interface_.fifo_page_size;
+    return local_dfb_interface_.fifo_num_pages ? local_dfb_interface_.fifo_num_pages : (local_dfb_interface_.fifo_size / page_size);
 #endif
 }
 
+inline uint32_t DataflowBuffer::get_total_size_bytes() const {
+#if DFB_IS_COMPUTE_MATH
+    return 0;
+#else
+    return address_units_to_bytes(local_dfb_interface_.fifo_size);
+#endif
+}
+
+inline uint32_t DataflowBuffer::get_local_num_entries() const { return get_total_num_entries(); }
+
+inline uint32_t DataflowBuffer::get_local_size_bytes() const { return get_total_size_bytes(); }
+
+inline uint32_t DataflowBuffer::get_ring_span_bytes() const { return get_total_size_bytes(); }
+
+inline uint32_t DataflowBuffer::get_ring_span_num_entries() const { return get_total_num_entries(); }
 
 inline void DataflowBuffer::reserve_back_impl(uint16_t num_entries) {
 #ifdef COMPILE_FOR_TRISC

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer.inl
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer.inl
@@ -28,14 +28,14 @@
 inline DataflowBuffer::DataflowBuffer(uint16_t logical_dfb_id) : logical_dfb_id_(logical_dfb_id) {}
 #else
 inline DataflowBuffer::DataflowBuffer(uint16_t logical_dfb_id)
-    : logical_dfb_id_(logical_dfb_id), local_dfb_interface_(g_dfb_interface[logical_dfb_id]) {}
+    : logical_dfb_id_(logical_dfb_id), local_dfb_interface_(get_local_dfb_interface(logical_dfb_id)) {}
 #endif
 
 inline uint32_t DataflowBuffer::get_entry_size() const {
 #if DFB_IS_COMPUTE_MATH
     return 0;
 #else
-    return local_dfb_interface_.entry_size;
+    return address_units_to_bytes(local_dfb_interface_.entry_size);
 #endif
 }
 
@@ -43,7 +43,7 @@ inline uint32_t DataflowBuffer::get_stride_size() const {
 #if DFB_IS_COMPUTE_MATH
     return 0;
 #else
-    return local_dfb_interface_.stride_size;
+    return address_units_to_bytes(local_dfb_interface_.stride_size);
 #endif
 }
 
@@ -52,6 +52,78 @@ inline uint32_t DataflowBuffer::get_total_num_entries() const {
     return 0;
 #else
     return local_dfb_interface_.num_entries;
+#endif
+}
+
+inline uint32_t DataflowBuffer::get_total_size_bytes() const {
+#if DFB_IS_COMPUTE_MATH
+    return 0;
+#else
+    return get_total_num_entries() * address_units_to_bytes(local_dfb_interface_.entry_size);
+#endif
+}
+
+inline uint32_t DataflowBuffer::get_local_num_entries() const {
+#if DFB_IS_COMPUTE_MATH
+    return 0;
+#else
+    const dfb::PackedTileCounter packed_tc =
+        local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].packed_tile_counter;
+    const uint8_t tc_id = dfb::get_counter_id(packed_tc);
+#if defined(COMPILE_FOR_TRISC)
+    return static_cast<uint32_t>(ckernel::trisc::tile_counters[tc_id].f.buf_capacity);
+#else
+    const uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
+    return static_cast<uint32_t>(overlay::llk_intf_get_capacity(tensix_id, tc_id));
+#endif
+#endif
+}
+
+inline uint32_t DataflowBuffer::get_local_size_bytes() const {
+#if DFB_IS_COMPUTE_MATH
+    return 0;
+#else
+    const auto& slot = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx];
+#if defined(COMPILE_FOR_TRISC)
+    return address_units_to_bytes(slot.ring_size);
+#else
+    return slot.limit - slot.base_addr;
+#endif
+#endif
+}
+
+namespace {
+
+#if !DFB_IS_COMPUTE_MATH
+
+inline uint32_t dfb_ring_span_address_units(const LocalDFBInterface& intf) {
+    const uint8_t last = static_cast<uint8_t>(intf.num_tcs_to_rr - 1);
+#if defined(COMPILE_FOR_TRISC)
+    const auto& first = intf.tc_slots[0];
+    const auto& last_slot = intf.tc_slots[last];
+    return (last_slot.base_addr + last_slot.ring_size) - first.base_addr;
+#else
+    return intf.tc_slots[last].limit - intf.tc_slots[0].base_addr;
+#endif
+}
+#endif  // !DFB_IS_COMPUTE_MATH
+
+}  // namespace
+
+inline uint32_t DataflowBuffer::get_ring_span_bytes() const {
+#if DFB_IS_COMPUTE_MATH
+    return 0;
+#else
+    return address_units_to_bytes(dfb_ring_span_address_units(local_dfb_interface_));
+#endif
+}
+
+inline uint32_t DataflowBuffer::get_ring_span_num_entries() const {
+#if DFB_IS_COMPUTE_MATH
+    return 0;
+#else
+    const uint32_t entry_bytes = get_entry_size();
+    return address_units_to_bytes(dfb_ring_span_address_units(local_dfb_interface_)) / entry_bytes;
 #endif
 }
 


### PR DESCRIPTION
### Summary
Adding some missing getters on DFB to query total backing size. Also added size / num entries for the current active tile counter and the entire span in bytes + entries that a particular thread would see 


### Notes for reviewers
triscs return sizes in bytes and not in 16B units 


[Runtime sanity](https://github.com/tenstorrent/tt-metal/actions/runs/29140803039)
[Runtime unit](https://github.com/tenstorrent/tt-metal/actions/runs/29287230377)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abhullar/dfb-size-bytes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/dfb-size-bytes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=abhullar/dfb-size-bytes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:abhullar/dfb-size-bytes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=abhullar/dfb-size-bytes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:abhullar/dfb-size-bytes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abhullar/dfb-size-bytes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abhullar/dfb-size-bytes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=abhullar/dfb-size-bytes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:abhullar/dfb-size-bytes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=abhullar/dfb-size-bytes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:abhullar/dfb-size-bytes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=abhullar/dfb-size-bytes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:abhullar/dfb-size-bytes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=abhullar/dfb-size-bytes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:abhullar/dfb-size-bytes)