### PR TITLE
[Bugfix] Reject overflowing DFB sizes before runtime mutation

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
@@ -41,6 +41,7 @@
 #include <tt-metalium/experimental/mock_device/mock_device.hpp>
 
 #include "impl/kernels/kernel.hpp"
+#include "impl/dataflow_buffer/dataflow_buffer.hpp"
 #include "impl/program/program_impl.hpp"
 #include "test_helpers.hpp"
 
@@ -57,6 +58,16 @@ using test_helpers::MakeMinimalValidProgramSpec;
 using test_helpers::MakeMinimalWorkUnit;
 using test_helpers::MakeShardedTensorParameter;
 using test_helpers::ScopedSlowDispatchOverride;
+
+TEST(DataflowBufferCheckedSizeTest, AcceptsRepresentableBoundaryAndRejectsOverflow) {
+    EXPECT_EQ(dfb::detail::checked_total_size(0, 1, "test"), 0U);
+    EXPECT_EQ(
+        dfb::detail::checked_total_size(std::numeric_limits<uint32_t>::max(), 1, "test"),
+        std::numeric_limits<uint32_t>::max());
+    EXPECT_THAT(
+        [] { dfb::detail::checked_total_size(1U << 31, 2, "test"); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("DFB size overflow")));
+}
 
 // Shorthand for the per-node-override vararg type: a Table keyed by Nodes mapping to a
 // vararg count (matches KernelAdvancedOptions::num_runtime_varargs_per_node).
@@ -91,6 +102,15 @@ protected:
     std::shared_ptr<distributed::MeshDevice> mesh_device_;
     std::optional<ScopedSlowDispatchOverride> slow_dispatch_override_;
 };
+
+TEST_F(ProgramRunArgsTestQuasar, DirectDFBCreationRejectsSizeOverflow) {
+    Program program;
+    dfb::DataflowBufferConfig config{.entry_size = 1U << 31, .num_entries = 2};
+
+    EXPECT_THAT(
+        [&] { dfb::CreateDataflowBuffer(program, CoreCoord{0, 0}, config); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("DFB size overflow")));
+}
 
 // ============================================================================
 // Test Utilities
@@ -403,6 +423,23 @@ TEST_F(ProgramRunArgsTestQuasar, DFBNumEntriesOverrideZeroFails) {
             ::testing::HasSubstr("num_entries must be set to a non-zero value")));
 }
 
+TEST_F(ProgramRunArgsTestQuasar, DFBSizeOverflowFailsWithoutMutation) {
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeSpecWithRTAs(node, 0, 0);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    auto dfb = program.impl().get_dataflow_buffer(program.impl().get_dfb_handle("dfb_0"));
+    const auto original_config = dfb->config;
+
+    auto params = MakeRunArgsForMinimalSpec(node, {}, {});
+    params.dfb_run_overrides.push_back({.dfb = DFBSpecName{"dfb_0"}, .entry_size = 1U << 31, .num_entries = 2});
+
+    EXPECT_THAT(
+        [&] { SetProgramRunArgs(program, params); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("DFB size overflow")));
+    EXPECT_EQ(dfb->config.entry_size, original_config.entry_size);
+    EXPECT_EQ(dfb->config.num_entries, original_config.num_entries);
+}
+
 TEST_F(ProgramRunArgsTestQuasar, DFBSizeOverrideUnknownNameFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithRTAs(node, 0, 0);
@@ -510,6 +547,52 @@ TEST_F(ProgramRunArgsTestQuasar, AliasGroupDisagreeResizeFails) {
     EXPECT_THAT(
         [&] { SetProgramRunArgs(program, params); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("different total sizes")));
+}
+
+TEST_F(ProgramRunArgsTestQuasar, AliasGroupOverflowFailsWithoutMutation) {
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeSpecWithAliasedDfbs(/*es_a=*/512, /*ne_a=*/8, /*es_b=*/1024, /*ne_b=*/4);
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    auto a = program.impl().get_dataflow_buffer(program.impl().get_dfb_handle("dfb_a"));
+    auto b = program.impl().get_dataflow_buffer(program.impl().get_dfb_handle("dfb_b"));
+    const auto original_a = a->config;
+    const auto original_b = b->config;
+
+    auto params = MakeRunArgsForMinimalSpec(node, {}, {});
+    params.dfb_run_overrides.push_back({.dfb = DFBSpecName{"dfb_a"}, .entry_size = 1U << 31, .num_entries = 2});
+    params.dfb_run_overrides.push_back({.dfb = DFBSpecName{"dfb_b"}, .entry_size = 1U << 31, .num_entries = 2});
+
+    EXPECT_THAT(
+        [&] { SetProgramRunArgs(program, params); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("DFB size overflow")));
+    EXPECT_EQ(a->config.entry_size, original_a.entry_size);
+    EXPECT_EQ(a->config.num_entries, original_a.num_entries);
+    EXPECT_EQ(b->config.entry_size, original_b.entry_size);
+    EXPECT_EQ(b->config.num_entries, original_b.num_entries);
+}
+
+TEST_F(ProgramRunArgsTestQuasar, MixedDFBOverrideFailureLeavesCompleteBatchUnchanged) {
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeSpecWithAliasedDfbs(/*es_a=*/512, /*ne_a=*/8, /*es_b=*/1024, /*ne_b=*/4);
+    spec.dataflow_buffers[0].advanced_options.alias_with.clear();
+    spec.dataflow_buffers[1].advanced_options.alias_with.clear();
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    auto a = program.impl().get_dataflow_buffer(program.impl().get_dfb_handle("dfb_a"));
+    auto b = program.impl().get_dataflow_buffer(program.impl().get_dfb_handle("dfb_b"));
+    const auto original_a = a->config;
+    const auto original_b = b->config;
+
+    auto params = MakeRunArgsForMinimalSpec(node, {}, {});
+    params.dfb_run_overrides.push_back({.dfb = DFBSpecName{"dfb_a"}, .num_entries = 16});
+    params.dfb_run_overrides.push_back({.dfb = DFBSpecName{"dfb_b"}, .entry_size = 1U << 31, .num_entries = 2});
+
+    EXPECT_THAT(
+        [&] { SetProgramRunArgs(program, params); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("DFB size overflow")));
+    EXPECT_EQ(a->config.entry_size, original_a.entry_size);
+    EXPECT_EQ(a->config.num_entries, original_a.num_entries);
+    EXPECT_EQ(b->config.entry_size, original_b.entry_size);
+    EXPECT_EQ(b->config.num_entries, original_b.num_entries);
 }
 
 // ============================================================================
@@ -1236,6 +1319,38 @@ inline ProgramSpec MakeBorrowedDFBProgramSpecForRunArgs(
     return spec;
 }
 
+// Build two borrowed DFBs. The sharded backing has 4096 bytes in total but only
+// 2048 bytes per bank, so dfb_b passes ProgramSpec's coarse total-size check and
+// fails the precise runtime fit check.
+inline ProgramSpec MakeTwoBorrowedDFBProgramSpecForAtomicityTest() {
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.name = "two_borrowed_dfb_atomicity_test";
+
+    auto producer = MakeMinimalDMKernel("producer");
+    auto consumer = MakeMinimalDMKernel("consumer");
+    auto dfb_a = MakeMinimalDFB("dfb_a", /*entry_size=*/16, /*num_entries=*/2);
+    auto dfb_b = MakeMinimalDFB("dfb_b", /*entry_size=*/1536, /*num_entries=*/2);
+    dfb_a.borrowed_from = TensorParamName{"tensor_a"};
+    dfb_b.borrowed_from = TensorParamName{"tensor_b"};
+
+    producer.dfb_bindings = {ProducerOf(DFBSpecName{"dfb_a"}, "out_a"), ProducerOf(DFBSpecName{"dfb_b"}, "out_b")};
+    consumer.dfb_bindings = {ConsumerOf(DFBSpecName{"dfb_a"}, "in_a"), ConsumerOf(DFBSpecName{"dfb_b"}, "in_b")};
+
+    auto tensor_a = MakeMinimalTensorParameter("tensor_a", tt::tt_metal::BufferType::L1);
+    auto tensor_b =
+        MakeShardedTensorParameter("tensor_b", tt::tt_metal::Shape{1, 1, 64, 32}, {32, 32}, /*num_cores=*/2);
+    BindTensorParameterToKernel(producer, "tensor_a", "borrowed_a");
+    BindTensorParameterToKernel(producer, "tensor_b", "borrowed_b");
+
+    spec.kernels = {producer, consumer};
+    spec.dataflow_buffers = {dfb_a, dfb_b};
+    spec.tensor_parameters = {tensor_a, tensor_b};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
+    return spec;
+}
+
 // Helper: build minimal ProgramRunArgs for the borrowed-DFB spec above. Both kernels are
 // MakeMinimalDMKernel (no per-node or common args required), so kernel_run_args entries
 // are empty schemas. Caller supplies the tensor_args entry separately.
@@ -1378,12 +1493,103 @@ TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_ResizingBorrowedDFBBeyondB
     setup.tensor_args = {{TensorParamName{"borrowed_tensor"}, TensorArgument{tensor}}};
     SetProgramRunArgs(program, setup);
 
+    const auto dfb = program.impl().get_dataflow_buffer(program.impl().get_dfb_handle("dfb"));
+    const auto original_config = dfb->config;
+
     ProgramRunArgs upd;
     upd.dfb_run_overrides.push_back({.dfb = DFBSpecName{"dfb"}, .num_entries = 64});
     upd.tensor_args = {{TensorParamName{"borrowed_tensor"}, TensorArgument{tensor}}};
     EXPECT_THAT(
         [&] { UpdateProgramRunArgs(program, upd); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("exceeds the borrowed")));
+    EXPECT_EQ(dfb->config.entry_size, original_config.entry_size);
+    EXPECT_EQ(dfb->config.num_entries, original_config.num_entries);
+}
+
+TEST_F(ProgramRunArgsTestQuasar, SetProgramRunArgs_InvalidSecondBorrowedDFBLeavesAllDFBStateUnchanged) {
+    ProgramSpec spec = MakeTwoBorrowedDFBProgramSpecForAtomicityTest();
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    program.impl().finalize_dataflow_buffer_configs();
+
+    MeshTensor tensor_a =
+        MeshTensor::allocate_on_device(*mesh_device_, spec.tensor_parameters[0].spec, TensorTopology{});
+    MeshTensor tensor_b =
+        MeshTensor::allocate_on_device(*mesh_device_, spec.tensor_parameters[1].spec, TensorTopology{});
+
+    auto dfb_a = program.impl().get_dataflow_buffer(program.impl().get_dfb_handle("dfb_a"));
+    auto dfb_b = program.impl().get_dataflow_buffer(program.impl().get_dfb_handle("dfb_b"));
+    const auto original_a = dfb_a->config;
+    const auto original_b = dfb_b->config;
+    ASSERT_EQ(PeekBorrowedDFBAddress(program, "dfb_a"), 0U);
+    ASSERT_EQ(PeekBorrowedDFBAddress(program, "dfb_b"), 0U);
+
+    ProgramRunArgs params = MakeBorrowedDFBRunArgs();
+    params.dfb_run_overrides.push_back({.dfb = DFBSpecName{"dfb_a"}, .num_entries = 4});
+    params.tensor_args = {
+        {TensorParamName{"tensor_a"}, TensorArgument{tensor_a}},
+        {TensorParamName{"tensor_b"}, TensorArgument{tensor_b}},
+    };
+
+    EXPECT_THAT(
+        [&] { SetProgramRunArgs(program, params); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("exceeds the borrowed")));
+    EXPECT_EQ(dfb_a->config.entry_size, original_a.entry_size);
+    EXPECT_EQ(dfb_a->config.num_entries, original_a.num_entries);
+    EXPECT_EQ(dfb_b->config.entry_size, original_b.entry_size);
+    EXPECT_EQ(dfb_b->config.num_entries, original_b.num_entries);
+    EXPECT_EQ(PeekBorrowedDFBAddress(program, "dfb_a"), 0U);
+    EXPECT_EQ(PeekBorrowedDFBAddress(program, "dfb_b"), 0U);
+}
+
+TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_BorrowedDFBOverflowFailsWithoutMutation) {
+    ProgramSpec spec = MakeBorrowedDFBProgramSpecForRunArgs();
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    program.impl().finalize_dataflow_buffer_configs();
+
+    MeshTensor tensor = MeshTensor::allocate_on_device(*mesh_device_, spec.tensor_parameters[0].spec, TensorTopology{});
+    ProgramRunArgs setup = MakeBorrowedDFBRunArgs();
+    setup.tensor_args = {{TensorParamName{"borrowed_tensor"}, TensorArgument{tensor}}};
+    SetProgramRunArgs(program, setup);
+
+    const auto dfb = program.impl().get_dataflow_buffer(program.impl().get_dfb_handle("dfb"));
+    const auto original_config = dfb->config;
+    const uint32_t original_address = PeekBorrowedDFBAddress(program, "dfb");
+
+    ProgramRunArgs update;
+    update.dfb_run_overrides.push_back({.dfb = DFBSpecName{"dfb"}, .entry_size = 1U << 31, .num_entries = 2});
+    update.tensor_args = {{TensorParamName{"borrowed_tensor"}, TensorArgument{tensor}}};
+    EXPECT_THAT(
+        [&] { UpdateProgramRunArgs(program, update); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("DFB size overflow")));
+    EXPECT_EQ(dfb->config.entry_size, original_config.entry_size);
+    EXPECT_EQ(dfb->config.num_entries, original_config.num_entries);
+    EXPECT_EQ(PeekBorrowedDFBAddress(program, "dfb"), original_address);
+}
+
+TEST_F(ProgramRunArgsTestQuasar, PostFinalizeResizeFailureLeavesSizeDerivedStateUnchanged) {
+    ProgramSpec spec = MakeBorrowedDFBProgramSpecForRunArgs();
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    program.impl().finalize_dataflow_buffer_configs();
+
+    MeshTensor tensor = MeshTensor::allocate_on_device(*mesh_device_, spec.tensor_parameters[0].spec, TensorTopology{});
+    ProgramRunArgs setup = MakeBorrowedDFBRunArgs();
+    setup.tensor_args = {{TensorParamName{"borrowed_tensor"}, TensorArgument{tensor}}};
+    SetProgramRunArgs(program, setup);
+
+    const auto dfb = program.impl().get_dataflow_buffer(program.impl().get_dfb_handle("dfb"));
+    const auto original_config = dfb->config;
+    const uint16_t original_capacity = dfb->capacity;
+    const uint32_t original_stride = dfb->stride_in_entries;
+
+    ProgramRunArgs update;
+    update.dfb_run_overrides.push_back({.dfb = DFBSpecName{"dfb"}, .num_entries = 3});
+    update.tensor_args = {{TensorParamName{"borrowed_tensor"}, TensorArgument{tensor}}};
+    EXPECT_THROW(UpdateProgramRunArgs(program, update), std::runtime_error);
+
+    EXPECT_EQ(dfb->config.entry_size, original_config.entry_size);
+    EXPECT_EQ(dfb->config.num_entries, original_config.num_entries);
+    EXPECT_EQ(dfb->capacity, original_capacity);
+    EXPECT_EQ(dfb->stride_in_entries, original_stride);
 }
 
 // Regression: a kernel that binds a tensor but declares no scalar args (no named/vararg RTAs or

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
@@ -1278,7 +1278,7 @@ TEST_F(ProgramRunArgsTestQuasar, NamedAndVarargRTAsCoexistSucceeds) {
 //   2. finalize_dataflow_buffer_configs (would normally run inside the dispatch pipeline at
 //                                first enqueue) populates per-DFB `groups[].l1_by_core`
 //                                entries with placeholder addr = 0.
-//   3. SetProgramRunArgs / UpdateTensorArgs → AttachBorrowedDFBBuffers resolves the
+//   3. SetProgramRunArgs / UpdateTensorArgs → borrowed-attachment preparation resolves the
 //                                bound MeshTensor, extracts its reference-buffer address, and
 //                                calls dfb->set_borrowed_memory_base_addr(addr), which
 //                                overwrites every `groups[].l1_by_core` entry (and any
@@ -1437,7 +1437,7 @@ TEST_F(ProgramRunArgsTestQuasar, BorrowedDFB_UpdateTensorArgsRefreshesAddress) {
 }
 
 // Guard: resizing a borrowed-memory DFB on the partial-update path without supplying its backing
-// tensor is rejected — otherwise the per-bank fit check in AttachBorrowedDFBBuffers never re-runs
+// tensor is rejected — otherwise borrowed-attachment preparation never re-runs the per-bank fit check
 // against the new size, and a grown DFB could silently overflow its borrowed buffer at execution.
 TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_ResizingBorrowedDFBWithoutTensorFails) {
     ProgramSpec spec = MakeBorrowedDFBProgramSpecForRunArgs();
@@ -1459,7 +1459,7 @@ TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_ResizingBorrowedDFBWithout
 }
 
 // Supplying the backing tensor alongside the resize is accepted: the fit check re-runs and the new
-// size (48 B) still fits the 64 B backing.
+// size (64 B) still fits the 64 B backing.
 TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_ResizingBorrowedDFBWithTensorSucceeds) {
     ProgramSpec spec = MakeBorrowedDFBProgramSpecForRunArgs();
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
@@ -1539,6 +1539,28 @@ TEST_F(ProgramRunArgsTestQuasar, SetProgramRunArgs_InvalidSecondBorrowedDFBLeave
     EXPECT_EQ(dfb_b->config.num_entries, original_b.num_entries);
     EXPECT_EQ(PeekBorrowedDFBAddress(program, "dfb_a"), 0U);
     EXPECT_EQ(PeekBorrowedDFBAddress(program, "dfb_b"), 0U);
+}
+
+TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_BeforeInitialSetFailureLeavesBorrowedDFBStateUnchanged) {
+    ProgramSpec spec = MakeBorrowedDFBProgramSpecForRunArgs();
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    program.impl().finalize_dataflow_buffer_configs();
+
+    MeshTensor tensor = MeshTensor::allocate_on_device(*mesh_device_, spec.tensor_parameters[0].spec, TensorTopology{});
+    auto dfb = program.impl().get_dataflow_buffer(program.impl().get_dfb_handle("dfb"));
+    const auto original_config = dfb->config;
+    ASSERT_EQ(PeekBorrowedDFBAddress(program, "dfb"), 0U);
+
+    ProgramRunArgs update;
+    update.dfb_run_overrides.push_back({.dfb = DFBSpecName{"dfb"}, .num_entries = 4});
+    update.tensor_args = {{TensorParamName{"borrowed_tensor"}, TensorArgument{tensor}}};
+
+    EXPECT_THAT(
+        [&] { UpdateProgramRunArgs(program, update); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("CRTA buffer not allocated")));
+    EXPECT_EQ(dfb->config.entry_size, original_config.entry_size);
+    EXPECT_EQ(dfb->config.num_entries, original_config.num_entries);
+    EXPECT_EQ(PeekBorrowedDFBAddress(program, "dfb"), 0U);
 }
 
 TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_BorrowedDFBOverflowFailsWithoutMutation) {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -1188,6 +1188,16 @@ TEST_F(ProgramSpecTestQuasar, BorrowedMemoryDFBOversizedFails) {
             ::testing::HasSubstr("is larger than its borrowed TensorParameter")));
 }
 
+TEST_F(ProgramSpecTestQuasar, DFBTotalSizeOverflowFailsBeforeLowering) {
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+    spec.dataflow_buffers[0].entry_size = 1U << 31;
+    spec.dataflow_buffers[0].num_entries = 2;
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("DFB size overflow")));
+}
+
 TEST_F(ProgramSpecTestQuasar, SemaphoresSucceed) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -1623,7 +1623,7 @@ void ProgramImpl::apply_dfb_size_overrides(const std::vector<DfbSizeOverride>& o
     std::vector<ValidatedSizeOverride> validated;
     validated.reserve(overrides.size());
 
-    std::unordered_map<uint32_t, uint64_t> new_total_by_id;
+    std::unordered_map<uint32_t, uint32_t> new_total_by_id;
     new_total_by_id.reserve(overrides.size());
     for (const auto& o : overrides) {
         auto dfb = get_dataflow_buffer(o.dfb_id);
@@ -1657,7 +1657,7 @@ void ProgramImpl::apply_dfb_size_overrides(const std::vector<DfbSizeOverride>& o
         group.push_back(primary_id);
         group.insert(group.end(), primary->alias_secondary_ids.begin(), primary->alias_secondary_ids.end());
 
-        std::optional<uint64_t> agreed_total;
+        std::optional<uint32_t> agreed_total;
         for (uint32_t member_id : group) {
             auto it = new_total_by_id.find(member_id);
             TT_FATAL(

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -384,10 +384,10 @@ std::vector<uint8_t> DataflowBufferImpl::serialize_for_core(const CoreCoord& cor
         std::vector<uint8_t> data;
         data.reserve(4 * sizeof(uint32_t));
         const uint32_t words[4] = {
-            alloc_addr,                                     // fifo_addr (base)
-            this->config.entry_size * this->config.num_entries,  // fifo_size
-            this->config.num_entries,                       // fifo_num_pages
-            this->config.entry_size,                        // fifo_page_size
+            alloc_addr,                // fifo_addr (base)
+            this->total_size(),        // fifo_size
+            this->config.num_entries,  // fifo_num_pages
+            this->config.entry_size,   // fifo_page_size
         };
         const auto* bytes = reinterpret_cast<const uint8_t*>(words);
         data.insert(data.end(), bytes, bytes + sizeof(words));
@@ -667,6 +667,7 @@ void DataflowBufferImpl::update_size(std::optional<uint32_t> new_entry_size, std
     const uint32_t ne = new_num_entries.value_or(config.num_entries);
     TT_FATAL(es > 0, "DFB {}: entry_size override must be > 0", id);
     TT_FATAL(ne > 0, "DFB {}: num_entries override must be > 0", id);
+    checked_total_size(es, ne, fmt::format("DFB {} size override", id));
 
     // The kernel-config dfb_size region is frozen after the first launch (finalize_offsets runs once).
     // A size override must never change the serialized size.
@@ -755,13 +756,6 @@ void DataflowBufferImpl::update_size(std::optional<uint32_t> new_entry_size, std
             *serialized_size_before,
             serialized_size());
     }
-
-    log_debug(
-        tt::LogMetal,
-        "DFB {} size override applied: entry_size={} num_entries={}",
-        id,
-        config.entry_size,
-        config.num_entries);
 }
 
 uint32_t finalize_dfbs(
@@ -824,6 +818,10 @@ uint32_t ProgramImpl::add_dataflow_buffer(const CoreRangeSet& core_range_set, co
 
     TT_FATAL(config.entry_size > 0, "Entry size must be > 0");
     TT_FATAL(config.num_entries > 0, "Num entries must be > 0");
+    checked_total_size(
+        config.entry_size,
+        config.num_entries,
+        fmt::format("ProgramImpl::add_dataflow_buffer DFB {}", this->dataflow_buffers_.size()));
 
     TT_FATAL(config.pap != dfb::AccessPattern::ALL, "ALL producer pattern not supported");
 
@@ -1615,15 +1613,27 @@ void ProgramImpl::apply_dfb_size_overrides(const std::vector<DfbSizeOverride>& o
         return;
     }
 
-    // (a) Resolve each override to its new total_size (entry_size * num_entries), filling unset fields
-    //     from the current config. Indexed by dfb_id for the alias-group agreement check below.
+    // (a) Validate every candidate config on a detached copy. update_size() checks all size-derived
+    //     constraints and may mutate its receiver before a later check fails, so it must never run on
+    //     live program state until the complete batch has passed validation.
+    struct ValidatedSizeOverride {
+        std::shared_ptr<DataflowBufferImpl> live;
+        DataflowBufferImpl candidate;
+    };
+    std::vector<ValidatedSizeOverride> validated;
+    validated.reserve(overrides.size());
+
     std::unordered_map<uint32_t, uint64_t> new_total_by_id;
     new_total_by_id.reserve(overrides.size());
     for (const auto& o : overrides) {
         auto dfb = get_dataflow_buffer(o.dfb_id);
-        uint32_t es = o.entry_size.value_or(dfb->config.entry_size);
-        uint32_t ne = o.num_entries.value_or(dfb->config.num_entries);
-        new_total_by_id[o.dfb_id] = static_cast<uint64_t>(es) * ne;
+        TT_FATAL(
+            !new_total_by_id.contains(o.dfb_id), "DFB {} has more than one size override in the same batch.", o.dfb_id);
+
+        DataflowBufferImpl candidate = *dfb;
+        candidate.update_size(o.entry_size, o.num_entries);
+        new_total_by_id.emplace(o.dfb_id, candidate.total_size());
+        validated.push_back({std::move(dfb), std::move(candidate)});
     }
 
     // (b) Alias-group coherence gate. Aliased DFBs total-size change is only safe if the whole group
@@ -1673,9 +1683,21 @@ void ProgramImpl::apply_dfb_size_overrides(const std::vector<DfbSizeOverride>& o
         }
     }
 
-    // (c) Apply: mutate each DFB's size.
-    for (const auto& o : overrides) {
-        get_dataflow_buffer(o.dfb_id)->update_size(o.entry_size, o.num_entries);
+    // (c) Commit only the fields derived by update_size(). Every candidate above has passed all
+    //     checks, so no validation can fail after live state starts changing.
+    for (const auto& update : validated) {
+        update.live->config.entry_size = update.candidate.config.entry_size;
+        update.live->config.num_entries = update.candidate.config.num_entries;
+        update.live->capacity = update.candidate.capacity;
+        update.live->stride_in_entries = update.candidate.stride_in_entries;
+        update.live->producer_txn_descriptor = update.candidate.producer_txn_descriptor;
+        update.live->consumer_txn_descriptor = update.candidate.consumer_txn_descriptor;
+        log_debug(
+            tt::LogMetal,
+            "DFB {} size override applied: entry_size={} num_entries={}",
+            update.live->id,
+            update.live->config.entry_size,
+            update.live->config.num_entries);
     }
 
     // (d) Force allocate_dataflow_buffers() to recompute the L1 layout for the new total_size() on the next

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.hpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.hpp
@@ -5,10 +5,13 @@
 #pragma once
 
 #include <cstdint>
+#include <limits>
 #include <optional>
+#include <string_view>
 #include <utility>
 #include <variant>
 
+#include <tt_stl/assert.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/face_geometry.hpp>
 #include <tt-metalium/tile.hpp>
@@ -67,6 +70,23 @@ struct DataflowBufferConfig {
     // supplied before launch via DataflowBufferImpl::set_borrowed_memory_base_addr.
     bool borrows_memory = false;
 };
+
+namespace detail {
+
+inline uint32_t checked_total_size(uint32_t entry_size, uint32_t num_entries, std::string_view context) {
+    const uint64_t total_size = static_cast<uint64_t>(entry_size) * num_entries;
+    TT_FATAL(
+        total_size <= std::numeric_limits<uint32_t>::max(),
+        "{}: DFB size overflow: entry_size {} * num_entries {} = {} bytes exceeds UINT32_MAX ({} bytes).",
+        context,
+        entry_size,
+        num_entries,
+        total_size,
+        std::numeric_limits<uint32_t>::max());
+    return static_cast<uint32_t>(total_size);
+}
+
+}  // namespace detail
 
 // Note: This API and the DataflowBufferConfig are placeholder only, the final DataflowBuffer APIs will conform with
 // host API redesign. Returns logical DFB id

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
@@ -103,7 +103,9 @@ struct DataflowBufferImpl {
         }
     }
 
-    uint32_t total_size() const { return config.entry_size * config.num_entries; }
+    uint32_t total_size() const {
+        return checked_total_size(config.entry_size, config.num_entries, "DataflowBufferImpl");
+    }
     uint32_t serialized_size() const;
     std::vector<uint8_t> serialize_for_core(const CoreCoord& core) const;
 

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -2766,7 +2766,7 @@ static std::vector<DFBAllocInfo> allocate_dfbs_on_core(
     for (auto& dfb_impl : dfb_impls) {
         uint32_t dfb_id = dfb_impl->id;
         auto& cfg = dfb_impl->config;
-        uint32_t total = cfg.entry_size * cfg.num_entries;
+        uint32_t total = dfb_impl->total_size();
         uint64_t dim_key = (static_cast<uint64_t>(cfg.entry_size) << 32) | cfg.num_entries;
         bool compute_is_consumer = (cfg.consumer_risc_mask & TENSIX_MASK) != 0;
         bool compute_is_producer = (cfg.producer_risc_mask & TENSIX_MASK) != 0;
@@ -2882,7 +2882,8 @@ static void setup_core_state(
 static void populate_dfb_interface_slots(
     tt_emule::EmuleDFBInterface& iface, const DFBAllocInfo& alloc, uint8_t proc_id, bool is_tensix) {
     const auto& cfg = *alloc.cfg;
-    const uint32_t total = cfg.entry_size * cfg.num_entries;
+    const uint32_t total = tt::tt_metal::experimental::dfb::detail::checked_total_size(
+        cfg.entry_size, cfg.num_entries, "Emulated DFB interface");
 
     // Compute proc_bit per-alloc: WH/BH ComputeKernel sets bit 2,
     // Quasar uses bits 8+ (detect by presence of high mask bits).

--- a/tt_metal/impl/metal2_host_api/program_run_args.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_args.cpp
@@ -9,6 +9,7 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include <fmt/format.h>
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/runtime_args_data.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
@@ -402,81 +403,88 @@ void EmitBindingCrtaValues(const TensorBindingHandle& handle, const MeshTensor& 
     }
 }
 
-// Attach the actual L1 Buffer to every borrowed-memory DFB, by resolving each DFB's named
-// TensorParameter to the corresponding MeshTensor passed in tensor_args and extracting its
-// MeshBuffer's reference buffer. Under the lockstep mesh allocation invariant, any one of the
-// per-device buffers is a valid representative — same convention used by dynamic CB via
-// `MeshTensor::mesh_buffer().get_reference_buffer()`.
-//
-// How this works:
-//   - The ProgramSpec declares that the DFB borrows from a named TensorParameter.
-//   - At each runtime attach point (this function) we extract the Buffer from the bound
-//     MeshTensor, validate it, and hand it to the device-side DFB.
-//   - Re-entry (a subsequent run-params call with a different MeshTensor) just re-attaches.
-//
-// Pre-condition: ValidateTensorArgs has enforced that every declared TensorParameter
-// has a corresponding TensorArgument, so the lookup below cannot miss for any registered binding.
-void AttachBorrowedDFBBuffers(
+uint32_t ValidateBorrowedDFBBackingBuffer(
+    uint32_t dfb_id,
+    const std::string& tp_name,
+    uint32_t entry_size,
+    uint32_t num_entries,
+    const tt::tt_metal::Buffer& buffer) {
+    TT_FATAL(
+        buffer.is_l1(),
+        "Borrowed-memory DFB id {} (from TensorParameter '{}') requires an L1-resident backing memory.",
+        dfb_id,
+        tp_name);
+    const uint64_t dfb_total_bytes = dfb::detail::checked_total_size(
+        entry_size, num_entries, fmt::format("Borrowed-memory DFB {} from TensorParameter '{}'", dfb_id, tp_name));
+    TT_FATAL(
+        dfb_total_bytes <= buffer.aligned_size_per_bank(),
+        "Borrowed-memory DFB id {} (from TensorParameter '{}') has total size {} B, which exceeds the borrowed "
+        "Buffer's per-bank size of {} B.",
+        dfb_id,
+        tp_name,
+        dfb_total_bytes,
+        buffer.aligned_size_per_bank());
+
+    const auto address = buffer.address();
+    TT_FATAL(
+        address <= std::numeric_limits<uint32_t>::max(),
+        "Borrowed Buffer base address {} for DFB id {} (TensorParameter '{}') exceeds uint32_t max.",
+        address,
+        dfb_id,
+        tp_name);
+    return static_cast<uint32_t>(address);
+}
+
+struct ValidatedBorrowedAttachment {
+    std::shared_ptr<dfb::detail::DataflowBufferImpl> dfb;
+    uint32_t address;
+};
+
+std::vector<ValidatedBorrowedAttachment> PrepareBorrowedDFBAttachments(
     detail::ProgramImpl& program_impl,
     const std::unordered_map<std::string, const MeshTensor*>& tensor_by_param,
+    const std::vector<detail::ProgramImpl::DfbSizeOverride>& overrides,
     bool require_all = true) {
-    const auto& borrowed_bindings = program_impl.get_dfb_borrowed_bindings();
-    if (borrowed_bindings.empty()) {
-        return;
+    std::unordered_map<uint32_t, const detail::ProgramImpl::DfbSizeOverride*> override_by_id;
+    override_by_id.reserve(overrides.size());
+    for (const auto& override : overrides) {
+        auto [it, inserted] = override_by_id.emplace(override.dfb_id, &override);
+        TT_FATAL(inserted, "DFB {} has more than one size override in the same batch.", override.dfb_id);
     }
 
-    // tensor_by_param is the param_name -> MeshTensor lookup the caller already built to fill the
-    // binding CRTA sections; reuse it here rather than rebuilding an identical map per enqueue.
-    for (const auto& [dfb_id, tp_name] : borrowed_bindings) {
-        auto it = tensor_by_param.find(tp_name);
-        if (it == tensor_by_param.end()) {
-            // Partial update (require_all=false): the borrowed TensorParameter is enqueue-invariant
-            // and was omitted; the DFB keeps its previously-attached backing buffer. On the full
-            // path (require_all=true) every borrowed binding must have been supplied.
+    std::vector<ValidatedBorrowedAttachment> attachments;
+    attachments.reserve(program_impl.get_dfb_borrowed_bindings().size());
+
+    for (const auto& [dfb_id, tp_name] : program_impl.get_dfb_borrowed_bindings()) {
+        auto tensor = tensor_by_param.find(tp_name);
+        if (tensor == tensor_by_param.end()) {
             TT_FATAL(
-                !require_all,
-                "Internal error: DFB id {} borrows from TensorParameter '{}' but no TensorArgument supplied it "
-                "(validation should have caught this).",
+                !require_all && !override_by_id.contains(dfb_id),
+                "Internal error: borrowed-memory DFB {} was resized or required without supplying TensorParameter "
+                "'{}'.",
                 dfb_id,
                 tp_name);
             continue;
         }
-        const MeshTensor& tensor = *it->second;
-        const tt::tt_metal::Buffer* buffer = tensor.mesh_buffer().get_reference_buffer();
 
-        // Attach-time legality checks (analogous to dynamic CB's
-        // CircularBufferConfig::set_globally_allocated_address_and_total_size validations).
-        //   - L1-residency: only L1 buffers may back a DFB.
-        //   - Sizing: the DFB's total bytes must fit in the buffer's per-bank allocation.
-        // ProgramSpec-time validation already enforced the TensorSpec-level analogs; these
-        // refine the check now that a concrete Buffer is in hand.
-        TT_FATAL(
-            buffer->is_l1(),
-            "Borrowed-memory DFB id {} (from TensorParameter '{}') requires an L1-resident backing memory.",
-            dfb_id,
-            tp_name);
         auto dfb_impl = program_impl.get_dataflow_buffer(dfb_id);
-        const uint32_t dfb_total_bytes = dfb_impl->config.entry_size * dfb_impl->config.num_entries;
-        TT_FATAL(
-            dfb_total_bytes <= buffer->aligned_size_per_bank(),
-            "Borrowed-memory DFB id {} (from TensorParameter '{}') has total size {} B, which exceeds the borrowed "
-            "Buffer's per-bank size of {} B.",
-            dfb_id,
-            tp_name,
-            dfb_total_bytes,
-            buffer->aligned_size_per_bank());
+        const auto override = override_by_id.find(dfb_id);
+        const uint32_t entry_size = override == override_by_id.end()
+                                        ? dfb_impl->config.entry_size
+                                        : override->second->entry_size.value_or(dfb_impl->config.entry_size);
+        const uint32_t num_entries = override == override_by_id.end()
+                                         ? dfb_impl->config.num_entries
+                                         : override->second->num_entries.value_or(dfb_impl->config.num_entries);
+        const tt::tt_metal::Buffer* buffer = tensor->second->mesh_buffer().get_reference_buffer();
+        const uint32_t address = ValidateBorrowedDFBBackingBuffer(dfb_id, tp_name, entry_size, num_entries, *buffer);
+        attachments.push_back({std::move(dfb_impl), address});
+    }
+    return attachments;
+}
 
-        // Attach the address to the device-side DFB. Per-enqueue update_program_dispatch_commands
-        // reads from the cache this populates, so no further dispatch-command invalidation is
-        // needed for either first-call or re-entry.
-        const auto address = buffer->address();
-        TT_FATAL(
-            address <= std::numeric_limits<uint32_t>::max(),
-            "Borrowed Buffer base address {} for DFB id {} (TensorParameter '{}') exceeds uint32_t max.",
-            address,
-            dfb_id,
-            tp_name);
-        dfb_impl->set_borrowed_memory_base_addr(static_cast<uint32_t>(address));
+void CommitBorrowedDFBAttachments(const std::vector<ValidatedBorrowedAttachment>& attachments) {
+    for (const auto& attachment : attachments) {
+        attachment.dfb->set_borrowed_memory_base_addr(attachment.address);
     }
 }
 
@@ -751,12 +759,8 @@ void SetProgramRunArgs(Program& program, const ProgramRunArgs& params, bool skip
         install_crtas(kernel, combined_crtas, kernel_name);
     }
 
-    // Process DFB runtime parameters:
-    //   - DFB size overrides (entry_size / num_entries)
-    //   - Borrowed-memory DFB backing L1 Buffer*
-    // Apply size overrides BEFORE attaching borrowed buffers so the borrowed per-bank fit check in
-    // AttachBorrowedDFBBuffers validates the NEW size. Overrides are applied as a single batch so an alias
-    // group can be validated for size agreement before any DFB is mutated.
+    // Resolve and validate every borrowed attachment against the requested candidate sizes before
+    // mutating either live DFB sizes or borrowed addresses. The two commit phases below cannot fail.
     std::vector<detail::ProgramImpl::DfbSizeOverride> size_overrides;
     size_overrides.reserve(params.dfb_run_overrides.size());
     for (const auto& dfb_params : params.dfb_run_overrides) {
@@ -766,8 +770,9 @@ void SetProgramRunArgs(Program& program, const ProgramRunArgs& params, bool skip
         size_overrides.push_back(
             {program_impl.get_dfb_handle(*dfb_params.dfb), dfb_params.entry_size, dfb_params.num_entries});
     }
+    const auto borrowed_attachments = PrepareBorrowedDFBAttachments(program_impl, tensor_by_param, size_overrides);
     program_impl.apply_dfb_size_overrides(size_overrides);
-    AttachBorrowedDFBBuffers(program_impl, tensor_by_param);
+    CommitBorrowedDFBAttachments(borrowed_attachments);
 }
 
 void UpdateTensorArgs(Program& program, const Table<TensorParamName, ProgramRunArgs::TensorArgument>& tensor_args) {
@@ -786,6 +791,7 @@ void UpdateTensorArgs(Program& program, const Table<TensorParamName, ProgramRunA
     for (const auto& [param_name, tensor_arg] : tensor_args) {
         tensor_by_param.emplace(param_name.get(), &mesh_tensor_of(tensor_arg));
     }
+    const auto borrowed_attachments = PrepareBorrowedDFBAttachments(program_impl, tensor_by_param, {});
 
     // For every kernel with tensor bindings, patch the binding slots in its CRTA buffer in
     // place. Each binding occupies (1 + num_runtime_field_crta_words) words starting at
@@ -824,8 +830,7 @@ void UpdateTensorArgs(Program& program, const Table<TensorParamName, ProgramRunA
         }
     }
 
-    // Process DFB runtime parameters to update borrowed-memory DFB backing L1 Buffer*s.
-    AttachBorrowedDFBBuffers(program_impl, tensor_by_param);
+    CommitBorrowedDFBAttachments(borrowed_attachments);
 }
 
 // Union the args of `src` into `dst` for a single kernel (same kernel name). Used by
@@ -1088,7 +1093,7 @@ void ValidateUpdateProgramRunArgs(const Program& program, const ProgramRunArgs& 
 
     // DFB run overrides: same checks as the full path (duplicates; non-zero size overrides), plus a
     // partial-path-only guard for borrowed-memory DFBs (below). A resized borrowed DFB must have its
-    // backing TensorParameter supplied in this same update, so AttachBorrowedDFBBuffers re-runs the
+    // backing TensorParameter supplied in this same update, so borrowed-attachment preparation re-runs the
     // per-bank fit check against the new size. The full Set path gets this for free (require_all=true);
     // on the partial path an invariant backing tensor may be omitted, which would otherwise let a grown
     // DFB overflow its borrowed buffer's per-bank region unchecked at execution.
@@ -1118,7 +1123,7 @@ void ValidateUpdateProgramRunArgs(const Program& program, const ProgramRunArgs& 
                 dfb_params.dfb);
         }
         // A resized borrowed-memory DFB needs its backing tensor supplied here so the per-bank fit check
-        // in AttachBorrowedDFBBuffers re-runs against the new size (see the block comment above).
+        // during borrowed-attachment preparation re-runs against the new size (see the block comment above).
         const bool resizes = dfb_params.entry_size.has_value() || dfb_params.num_entries.has_value();
         if (resizes) {
             if (auto b = borrowed_backing.find(program_impl.get_dfb_handle(dfb_params.dfb.get()));
@@ -1240,9 +1245,13 @@ void UpdateProgramRunArgs(Program& program, const ProgramRunArgs& params, bool s
         }
     }
 
-    // ---- DFB size overrides (stateful: an unspecified DFB retains its current size) ----
-    // Apply BEFORE re-attaching borrowed buffers below, so the borrowed per-bank fit check sees the
-    // new size. Mirrors the SetProgramRunArgs path.
+    std::unordered_map<std::string, const MeshTensor*> tensor_by_param;
+    tensor_by_param.reserve(params.tensor_args.size());
+    for (const auto& [param_name, tensor_arg] : params.tensor_args) {
+        tensor_by_param.emplace(param_name.get(), &mesh_tensor_of(tensor_arg));
+    }
+
+    // Resolve candidate DFB sizes and every supplied borrowed attachment before either live state changes.
     std::vector<detail::ProgramImpl::DfbSizeOverride> size_overrides;
     size_overrides.reserve(params.dfb_run_overrides.size());
     for (const auto& dfb_params : params.dfb_run_overrides) {
@@ -1252,17 +1261,13 @@ void UpdateProgramRunArgs(Program& program, const ProgramRunArgs& params, bool s
         size_overrides.push_back(
             {program_impl.get_dfb_handle(*dfb_params.dfb), dfb_params.entry_size, dfb_params.num_entries});
     }
+    const auto borrowed_attachments =
+        PrepareBorrowedDFBAttachments(program_impl, tensor_by_param, size_overrides, /*require_all=*/false);
     program_impl.apply_dfb_size_overrides(size_overrides);
 
     // ---- Tensor bindings: patch CRTA address slots for SUPPLIED tensors only ----
     // (Invariant tensors omitted from params keep their previously-patched binding slots.)
     if (!params.tensor_args.empty()) {
-        std::unordered_map<std::string, const MeshTensor*> tensor_by_param;
-        tensor_by_param.reserve(params.tensor_args.size());
-        for (const auto& [param_name, tensor_arg] : params.tensor_args) {
-            tensor_by_param.emplace(param_name.get(), &mesh_tensor_of(tensor_arg));
-        }
-
         for (const auto& kernel_name : program_impl.get_registered_kernel_names()) {
             std::shared_ptr<Kernel> kernel = program_impl.get_kernel_by_spec_name(kernel_name);
             const auto& binding_handles = kernel->tensor_binding_handles();
@@ -1294,10 +1299,8 @@ void UpdateProgramRunArgs(Program& program, const ProgramRunArgs& params, bool s
                 EmitBindingCrtaValues(handle, *t_it->second, [&dst](uint32_t w) { *dst++ = w; });
             }
         }
-
-        // Re-attach borrowed-memory DFBs for the supplied tensors (skip omitted invariant ones).
-        AttachBorrowedDFBBuffers(program_impl, tensor_by_param, /*require_all=*/false);
     }
+    CommitBorrowedDFBAttachments(borrowed_attachments);
 }
 
 ProgramRunArgs MergeProgramRunArgs(ProgramRunArgs base, std::span<const ProgramRunArgs> rest, bool skip_validation) {

--- a/tt_metal/impl/metal2_host_api/program_run_args.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_args.cpp
@@ -414,7 +414,7 @@ uint32_t ValidateBorrowedDFBBackingBuffer(
         "Borrowed-memory DFB id {} (from TensorParameter '{}') requires an L1-resident backing memory.",
         dfb_id,
         tp_name);
-    const uint64_t dfb_total_bytes = dfb::detail::checked_total_size(
+    const uint32_t dfb_total_bytes = dfb::detail::checked_total_size(
         entry_size, num_entries, fmt::format("Borrowed-memory DFB {} from TensorParameter '{}'", dfb_id, tp_name));
     TT_FATAL(
         dfb_total_bytes <= buffer.aligned_size_per_bank(),
@@ -468,6 +468,10 @@ std::vector<ValidatedBorrowedAttachment> PrepareBorrowedDFBAttachments(
         }
 
         auto dfb_impl = program_impl.get_dataflow_buffer(dfb_id);
+        TT_FATAL(
+            dfb_impl->borrows_memory(),
+            "Internal error: borrowed-memory binding for DFB {} refers to a DFB that does not borrow memory.",
+            dfb_id);
         const auto override = override_by_id.find(dfb_id);
         const uint32_t entry_size = override == override_by_id.end()
                                         ? dfb_impl->config.entry_size
@@ -1251,7 +1255,8 @@ void UpdateProgramRunArgs(Program& program, const ProgramRunArgs& params, bool s
         tensor_by_param.emplace(param_name.get(), &mesh_tensor_of(tensor_arg));
     }
 
-    // Resolve candidate DFB sizes and every supplied borrowed attachment before either live state changes.
+    // Resolve candidate DFB sizes and every supplied borrowed attachment before changing either live DFB sizes or
+    // borrowed addresses.
     std::vector<detail::ProgramImpl::DfbSizeOverride> size_overrides;
     size_overrides.reserve(params.dfb_run_overrides.size());
     for (const auto& dfb_params : params.dfb_run_overrides) {
@@ -1263,7 +1268,6 @@ void UpdateProgramRunArgs(Program& program, const ProgramRunArgs& params, bool s
     }
     const auto borrowed_attachments =
         PrepareBorrowedDFBAttachments(program_impl, tensor_by_param, size_overrides, /*require_all=*/false);
-    program_impl.apply_dfb_size_overrides(size_overrides);
 
     // ---- Tensor bindings: patch CRTA address slots for SUPPLIED tensors only ----
     // (Invariant tensors omitted from params keep their previously-patched binding slots.)
@@ -1300,6 +1304,10 @@ void UpdateProgramRunArgs(Program& program, const ProgramRunArgs& params, bool s
             }
         }
     }
+    // Keep the DFB size and borrowed-address commits adjacent. Tensor-binding CRTA patching above can reject an
+    // UpdateProgramRunArgs call made before the initial SetProgramRunArgs; that failure must not leave a new DFB size
+    // paired with the old borrowed address.
+    program_impl.apply_dfb_size_overrides(size_overrides);
     CommitBorrowedDFBAttachments(borrowed_attachments);
 }
 

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -1486,10 +1486,11 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             tp_name);
         // Coarse spec-time sizing check against the TensorSpec's full packed size. No Buffer is
         // available at spec time, so we can't query the per-bank allocation; the precise per-bank
-        // check fires at attach time in AttachBorrowedDFBBuffers (program_run_args.cpp), where
+        // check runs during borrowed-attachment preparation (program_run_args.cpp), where
         // a Buffer is in hand. For sharded L1 tensors the two checks differ — a DFB can pass
         // here against the full-tensor size and still fail per-bank later. By design.
-        const size_t dfb_bytes = static_cast<size_t>(dfb.entry_size) * static_cast<size_t>(dfb.num_entries);
+        const uint32_t dfb_bytes = dfb::detail::checked_total_size(
+            dfb.entry_size, dfb.num_entries, fmt::format("Borrowed-memory DFB '{}'", dfb.unique_id.get()));
         const size_t tensor_bytes = tensor_spec.compute_packed_buffer_size_bytes();
         TT_FATAL(
             dfb_bytes <= tensor_bytes,
@@ -1539,7 +1540,8 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             if (dfb_alias_with(dfb).empty()) {
                 continue;
             }
-            const size_t total_size_a = static_cast<size_t>(dfb.entry_size) * static_cast<size_t>(dfb.num_entries);
+            const uint32_t total_size_a = dfb::detail::checked_total_size(
+                dfb.entry_size, dfb.num_entries, fmt::format("Aliased DFB '{}'", dfb.unique_id.get()));
             const auto group_a = extended_group(dfb);
             const auto& nodes_a = collected.dfb_node_set.at(dfb.unique_id);
 
@@ -1557,8 +1559,10 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                 }
 
                 // Rule 2: same total size.
-                const size_t total_size_b =
-                    static_cast<size_t>(alias_spec->entry_size) * static_cast<size_t>(alias_spec->num_entries);
+                const uint32_t total_size_b = dfb::detail::checked_total_size(
+                    alias_spec->entry_size,
+                    alias_spec->num_entries,
+                    fmt::format("Aliased DFB '{}'", alias_spec->unique_id.get()));
                 TT_FATAL(
                     total_size_a == total_size_b,
                     "Aliased DFBs '{}' and '{}' have different total sizes ({} vs {} bytes). "

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -11,6 +11,7 @@
 #include <string_view>
 #include <unordered_set>
 
+#include <fmt/format.h>
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/program.hpp>
@@ -28,6 +29,7 @@
 #include "impl/program/program_impl.hpp"
 #include "impl/context/metal_context.hpp"
 #include "impl/context/metal_env_accessor.hpp"
+#include "impl/dataflow_buffer/dataflow_buffer.hpp"
 #include "impl/dispatch/dispatch_core_manager.hpp"
 #include <core_descriptor.hpp>
 #include <llrt/tt_cluster.hpp>
@@ -1189,6 +1191,8 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             dfb.num_entries > 0,
             "DataflowBufferSpec '{}' has num_entries = 0. num_entries must be set to a non-zero value.",
             dfb.unique_id);
+        dfb::detail::checked_total_size(
+            dfb.entry_size, dfb.num_entries, fmt::format("DataflowBufferSpec '{}'", dfb.unique_id.get()));
     }
 
     // Validate local DFB endpoint placement and multi-binding consistency.

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -2536,7 +2536,7 @@ void update_program_dispatch_commands(
                     uint32_t base_index = dfb->id * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG;
                     uint32_t* words = reinterpret_cast<uint32_t*>(dfb_config_payload) + base_index;
                     words[0] = dfb->uniform_alloc_addr();
-                    words[1] = dfb->config.entry_size * dfb->config.num_entries;
+                    words[1] = dfb->total_size();
                     words[2] = dfb->config.num_entries;
                     words[3] = dfb->config.entry_size;
                 }
@@ -3006,7 +3006,7 @@ TraceNode create_trace_node(
                 size_t byte_offset = base_index * sizeof(uint32_t);
                 uint32_t* words = reinterpret_cast<uint32_t*>(dfb_config_payload.data()) + base_index;
                 words[0] = dfb->uniform_alloc_addr();
-                words[1] = dfb->config.entry_size * dfb->config.num_entries;
+                words[1] = dfb->total_size();
                 words[2] = dfb->config.num_entries;
                 words[3] = dfb->config.entry_size;
                 first_unused_byte = std::max(


### PR DESCRIPTION
PR Category

Bug fix

Summary

Fixes #49653.

DFB total size is stored, serialized, and dispatched as uint32_t. The existing host paths multiply entry_size and num_entries in uint32_t. An input such as entry_size = 0x80000000 and num_entries = 2 wraps from 4294967296 bytes to 0. The borrowed-memory per-bank fit check then accepts the wrapped value.

Runtime resize has a second failure mode. DataflowBufferImpl::update_size() changes live fields before capacity, ring-extent, and transaction-divisibility checks finish. ProgramImpl applies batch overrides one DFB at a time, so a later failure can leave an earlier DFB updated.

The partial UpdateProgramRunArgs path also committed DFB sizes before patching tensor-binding CRTAs. Calling it before the initial SetProgramRunArgs could fail in the CRTA precondition and leave the new DFB size paired with the old borrowed address.

This change adds one checked total-size calculation with a uint64_t intermediate and rejects products above UINT32_MAX at the ProgramSpec, direct DFB creation, and runtime resize boundaries. Serialization, dispatch, and emulation use the same checked result.

ProgramImpl validates each requested resize on a detached candidate, checks alias-group coherence for the complete batch, and then commits the size-derived fields. Borrowed-memory attachments use a prepare/commit split: the runtime validates all candidate sizes, L1 placement, per-bank fit, and addresses before changing live DFB sizes or borrowed addresses. UpdateProgramRunArgs now keeps the size and borrowed-address commits adjacent after tensor-binding CRTA patching.

Validation

Release unit_tests_api build with TT_METAL_BUILD_TESTS=ON, ENABLE_DISTRIBUTED=OFF, WITH_PYTHON_BINDINGS=OFF, and TT_UMD_BUILD_SIMULATION=ON.

- Focused overflow, resize, alias, and borrowed-memory matrix: 11/11 passed.
- ProgramSpecReflectionTest, ProgramSpecTestQuasar, ProgramSpecTestGen1, DataflowBufferCheckedSizeTest, ProgramRunArgsTestQuasar, and ProgramRunArgsTestGen1: 261/261 passed.
- Repository pre-commit hooks and validate-metalium-includes: passed.

The mock tests assert host/runtime metadata and mutation behavior. They do not claim payload execution or physical-device coverage.

Notes for reviewers

The atomicity guarantee covers DFB size-derived state and borrowed-memory addresses for one DFB override batch. It does not make unrelated RTA or CRTA updates in SetProgramRunArgs transactional.

A dedicated PreparedDfbSizeUpdate value could replace the whole-object detached candidates and give borrowed-buffer validation the same prepared state. I kept that refactor out of this PR so the change stays on the checked-size and mutation-order boundary.
