### PR TITLE
fix(sort): correct sort_barrier leader broadcast loop bound

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/cross_core_data_exchange_common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/cross_core_data_exchange_common.hpp
@@ -192,7 +192,7 @@ void sort_barrier(
         sem_barrier.set(0);
 
         // Broadcast to all other cores
-        for (uint32_t core_id = start_core_id; core_id < num_cores; core_id++) {
+        for (uint32_t core_id = start_core_id; core_id < start_core_id + num_cores; core_id++) {
             if (core_id == this_core_id) {
                 continue;
             }


### PR DESCRIPTION
## Summary
Fixes the leader-core broadcast loop in `sort_barrier` so it covers the full participating core range `[start_core_id, start_core_id + num_cores)`.

The previous upper bound `core_id < num_cores` is only correct when `start_core_id == 0`. Any future caller passing a non-zero `start_core_id` would release the wrong cores (missing high-end participants, potentially waking unrelated cores).

Closes #48488 (sub-issue of the kernel race sweep in #48393).

## Changes
- `cross_core_data_exchange_common.hpp`: change loop bound from `num_cores` to `start_core_id + num_cores`

## Test plan
- [x] Existing sort unit tests exercise `sort_barrier` with `start_core_id == 0` (current sole caller in `reader_cross_core_data_exchange.cpp`) — no behavior change on main paths
- [ ] CI: `tests/ttnn/unit_tests/operations/data_movement/test_sort.py` (smoke subset runs in PR gate)

## Notes
Current production caller still passes `start_core_id = 0`; this is a latent correctness fix ahead of reuse. Happy to add a dedicated non-zero `start_core_id` regression once a factory path needs it.