### PR TITLE
Blank inconsistent device kernel timing in ops perf CSV

### DIFF
--- a/tests/ttnn/tracy/test_process_ops_logs.py
+++ b/tests/ttnn/tracy/test_process_ops_logs.py
@@ -200,3 +200,72 @@ def test_generate_reports_writes_multicast_noc_util_column(tmp_path):
         row = next(reader)
         assert "MULTICAST NOC UTIL (%)" in reader.fieldnames
         assert row["MULTICAST NOC UTIL (%)"] == "25.0"
+
+
+def test_generate_reports_blanks_inconsistent_device_kernel_timing(tmp_path):
+    log_folder = tmp_path / "logs"
+    report_folder = tmp_path / "reports"
+    log_folder.mkdir(parents=True, exist_ok=True)
+
+    def perf_row(op_id, kernel_start, kernel_end, kernel_duration):
+        return {
+            "GLOBAL CALL COUNT": op_id,
+            "DEVICE ID": 0,
+            "DEVICE FW START CYCLE": 0,
+            "DEVICE FW END CYCLE": 1000,
+            "DEVICE FW DURATION [ns]": 1000,
+            "DEVICE KERNEL START CYCLE": kernel_start,
+            "DEVICE KERNEL END CYCLE": kernel_end,
+            "DEVICE KERNEL DURATION [ns]": kernel_duration,
+            "OP TO OP LATENCY [ns]": "",
+        }
+
+    ops = {
+        1: {
+            "global_call_count": 1,
+            "device_id": 0,
+            "op_code": "MatmulDeviceOperation",
+            "host_time": {"ns_since_start": 10, "exec_time_ns": 20},
+            "metal_trace_id": None,
+            "input_tensors": [],
+            "output_tensors": [],
+            "_device_perf_row": perf_row(1, 6923883220, 6923884220, 1000),
+        },
+        2: {
+            "global_call_count": 2,
+            "device_id": 0,
+            "op_code": "LayerNormDeviceOperation",
+            "host_time": {"ns_since_start": 30, "exec_time_ns": 40},
+            "metal_trace_id": None,
+            "input_tensors": [],
+            "output_tensors": [],
+            # Kernel appears to start ~6.9s before the previous op finished: a stale start cycle whose
+            # measured duration and op-to-op gap are not trustworthy.
+            "_device_perf_row": perf_row(2, 1000, 6923884220, 6923883220),
+        },
+    }
+
+    process_ops_logs.generate_reports(
+        ops=ops,
+        deviceOps={},
+        traceOps={},
+        signposts={},
+        logFolder=log_folder,
+        outputFolder=report_folder,
+        date=False,
+        nameAppend=None,
+    )
+
+    report_csv = Path(report_folder) / "ops_perf_results.csv"
+    assert report_csv.is_file()
+
+    with report_csv.open("r", newline="") as csv_file:
+        rows = {row["OP CODE"]: row for row in csv.DictReader(csv_file)}
+
+    valid_row = rows["MatmulDeviceOperation"]
+    assert valid_row["DEVICE KERNEL DURATION [ns]"] == "1000"
+    assert valid_row["OP TO OP LATENCY [ns]"] == "0"
+
+    invalid_row = rows["LayerNormDeviceOperation"]
+    assert invalid_row["DEVICE KERNEL DURATION [ns]"] == ""
+    assert invalid_row["OP TO OP LATENCY [ns]"] == ""

--- a/tools/tracy/process_ops_logs.py
+++ b/tools/tracy/process_ops_logs.py
@@ -1663,7 +1663,24 @@ def generate_reports(
                         "OP TO OP LATENCY BR/NRISC START [ns]",
                     }
                     if kernel_timing_invalid:
-                        skip_headers.add("DEVICE KERNEL DURATION [ns]")
+                        # Every kernel-duration column is derived from the same per-RISC *-KERNEL zone
+                        # timestamps that produced the invalid aggregate start/end, so blank the whole
+                        # family rather than leaving stale per-RISC values next to a blanked aggregate.
+                        skip_headers.update(
+                            {
+                                "DEVICE KERNEL DURATION [ns]",
+                                "DEVICE KERNEL DURATION DM START [ns]",
+                                "DEVICE KERNEL DURATION PER CORE MIN [ns]",
+                                "DEVICE KERNEL DURATION PER CORE MAX [ns]",
+                                "DEVICE KERNEL DURATION PER CORE AVG [ns]",
+                                "DEVICE BRISC KERNEL DURATION [ns]",
+                                "DEVICE NCRISC KERNEL DURATION [ns]",
+                                "DEVICE TRISC0 KERNEL DURATION [ns]",
+                                "DEVICE TRISC1 KERNEL DURATION [ns]",
+                                "DEVICE TRISC2 KERNEL DURATION [ns]",
+                                "DEVICE ERISC KERNEL DURATION [ns]",
+                            }
+                        )
                     for header, value in device_perf_row.items():
                         if header in skip_headers:
                             continue

--- a/tools/tracy/process_ops_logs.py
+++ b/tools/tracy/process_ops_logs.py
@@ -1588,12 +1588,28 @@ def generate_reports(
                     dm_start_cycle = device_perf_row.get("DEVICE KERNEL DM START CYCLE")
                     dm_end_cycle = device_perf_row.get("DEVICE KERNEL DM END CYCLE")
 
+                    # A traced/replayed op whose kernel appears to end before it started, or to start before the
+                    # previous op on the same device finished, has an unmeasurable device duration (e.g. a stale
+                    # start cycle on Blackhole). Mark such rows invalid instead of emitting a stale multi-second
+                    # duration with a compensating negative op-to-op gap.
+                    prev_kernel_end_cycle = prev_device_kernel_end_cycle.get(perf_device_id)
+                    kernel_timing_invalid = (
+                        kernel_start_cycle is not None
+                        and kernel_end_cycle is not None
+                        and (
+                            kernel_end_cycle < kernel_start_cycle
+                            or (prev_kernel_end_cycle is not None and kernel_start_cycle < prev_kernel_end_cycle)
+                        )
+                    )
+
                     # Prefer the C++-computed op-to-op latency if it is present in the perf row.
                     # The Python recomputation uses host ordering which can diverge from device ordering
                     # under async/multi-device execution; using the authoritative device-side value keeps
                     # python and cpp reports consistent.
                     perf_kernel_latency = device_perf_row.get("OP TO OP LATENCY [ns]")
-                    if perf_kernel_latency not in (None, ""):
+                    if kernel_timing_invalid:
+                        csv_row["OP TO OP LATENCY [ns]"] = ""
+                    elif perf_kernel_latency not in (None, ""):
                         csv_row["OP TO OP LATENCY [ns]"] = perf_kernel_latency
                     elif (
                         ns_per_cycle
@@ -1646,6 +1662,8 @@ def generate_reports(
                         "OP TO OP LATENCY [ns]",
                         "OP TO OP LATENCY BR/NRISC START [ns]",
                     }
+                    if kernel_timing_invalid:
+                        skip_headers.add("DEVICE KERNEL DURATION [ns]")
                     for header, value in device_perf_row.items():
                         if header in skip_headers:
                             continue

--- a/tools/tracy/process_ops_logs.py
+++ b/tools/tracy/process_ops_logs.py
@@ -1668,12 +1668,28 @@ def generate_reports(
                     dm_start_cycle = device_perf_row.get("DEVICE KERNEL DM START CYCLE")
                     dm_end_cycle = device_perf_row.get("DEVICE KERNEL DM END CYCLE")
 
+                    # A traced/replayed op whose kernel appears to end before it started, or to start before the
+                    # previous op on the same device finished, has an unmeasurable device duration (e.g. a stale
+                    # start cycle on Blackhole). Mark such rows invalid instead of emitting a stale multi-second
+                    # duration with a compensating negative op-to-op gap.
+                    prev_kernel_end_cycle = prev_device_kernel_end_cycle.get(perf_device_id)
+                    kernel_timing_invalid = (
+                        kernel_start_cycle is not None
+                        and kernel_end_cycle is not None
+                        and (
+                            kernel_end_cycle < kernel_start_cycle
+                            or (prev_kernel_end_cycle is not None and kernel_start_cycle < prev_kernel_end_cycle)
+                        )
+                    )
+
                     # Prefer the C++-computed op-to-op latency if it is present in the perf row.
                     # The Python recomputation uses host ordering which can diverge from device ordering
                     # under async/multi-device execution; using the authoritative device-side value keeps
                     # python and cpp reports consistent.
                     perf_kernel_latency = device_perf_row.get("OP TO OP LATENCY [ns]")
-                    if perf_kernel_latency not in (None, ""):
+                    if kernel_timing_invalid:
+                        csv_row["OP TO OP LATENCY [ns]"] = ""
+                    elif perf_kernel_latency not in (None, ""):
                         csv_row["OP TO OP LATENCY [ns]"] = perf_kernel_latency
                     elif (
                         ns_per_cycle
@@ -1759,6 +1775,8 @@ def generate_reports(
                         "OP TO OP LATENCY [ns]",
                         "OP TO OP LATENCY BR/NRISC START [ns]",
                     }
+                    if kernel_timing_invalid:
+                        skip_headers.add("DEVICE KERNEL DURATION [ns]")
                     for header, value in device_perf_row.items():
                         if header in skip_headers:
                             continue

--- a/tools/tracy/process_ops_logs.py
+++ b/tools/tracy/process_ops_logs.py
@@ -1704,8 +1704,10 @@ def generate_reports(
                         else:
                             csv_row["OP TO OP LATENCY [ns]"] = 0
 
-                    # Track end cycle for fallback computation.
-                    if perf_device_id is not None and kernel_end_cycle is not None:
+                    # Track end cycle for fallback computation. Skip on an invalid row: its end cycle is
+                    # itself untrustworthy, and storing it would keep flagging every subsequent op on this
+                    # device as invalid too.
+                    if perf_device_id is not None and kernel_end_cycle is not None and not kernel_timing_invalid:
                         prev_device_kernel_end_cycle[perf_device_id] = kernel_end_cycle
 
                     perf_dm_latency = device_perf_row.get("OP TO OP LATENCY BR/NRISC START [ns]")

--- a/tools/tracy/process_ops_logs.py
+++ b/tools/tracy/process_ops_logs.py
@@ -1776,7 +1776,24 @@ def generate_reports(
                         "OP TO OP LATENCY BR/NRISC START [ns]",
                     }
                     if kernel_timing_invalid:
-                        skip_headers.add("DEVICE KERNEL DURATION [ns]")
+                        # Every kernel-duration column is derived from the same per-RISC *-KERNEL zone
+                        # timestamps that produced the invalid aggregate start/end, so blank the whole
+                        # family rather than leaving stale per-RISC values next to a blanked aggregate.
+                        skip_headers.update(
+                            {
+                                "DEVICE KERNEL DURATION [ns]",
+                                "DEVICE KERNEL DURATION DM START [ns]",
+                                "DEVICE KERNEL DURATION PER CORE MIN [ns]",
+                                "DEVICE KERNEL DURATION PER CORE MAX [ns]",
+                                "DEVICE KERNEL DURATION PER CORE AVG [ns]",
+                                "DEVICE BRISC KERNEL DURATION [ns]",
+                                "DEVICE NCRISC KERNEL DURATION [ns]",
+                                "DEVICE TRISC0 KERNEL DURATION [ns]",
+                                "DEVICE TRISC1 KERNEL DURATION [ns]",
+                                "DEVICE TRISC2 KERNEL DURATION [ns]",
+                                "DEVICE ERISC KERNEL DURATION [ns]",
+                            }
+                        )
                     for header, value in device_perf_row.items():
                         if header in skip_headers:
                             continue


### PR DESCRIPTION
The op perf CSV was reporting multi-second device kernel durations and compensating negative op-to-op latencies for traced Blackhole ops whose kernel start cycle was stale. I updated the CSV writer to detect when a kernel appears to end before it started, or to start before the previous op on the same device finished, and to leave the device kernel duration and op-to-op latency blank for those rows instead of emitting the bogus values. Fixes #48043.

My environment could not install everything, so I kept this tightly scoped; the changed-file checks pass and CI can cover the rest.
