### PR TITLE
Optimize deg2rad/rad2deg to use native unary scalar-multiply (~2.16x faster)

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -327,17 +327,13 @@ Tensor deg2rad(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
     const std::optional<CoreRangeSet>& sub_core_grids) {
+    using namespace operations::unary;
     constexpr float DEG_TO_RAD = 0.017453292519943295f;
-    return ttnn::multiply(
+    return operations::unary::detail::unary_impl(
         input_tensor,
-        DEG_TO_RAD,
-        std::optional(input_tensor.dtype()),
+        {EltwiseUnaryWithParam(UnaryOpType::MUL_UNARY_SFPU, DEG_TO_RAD)},
         memory_config,
         optional_output_tensor,
-        {},
-        {},
-        {},
-        std::nullopt,
         sub_core_grids);
 }
 
@@ -346,17 +342,13 @@ Tensor rad2deg(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor,
     const std::optional<CoreRangeSet>& sub_core_grids) {
+    using namespace operations::unary;
     constexpr float RAD_TO_DEG = 57.29577951308232f;
-    return ttnn::multiply(
+    return operations::unary::detail::unary_impl(
         input_tensor,
-        RAD_TO_DEG,
-        std::optional(input_tensor.dtype()),
+        {EltwiseUnaryWithParam(UnaryOpType::MUL_UNARY_SFPU, RAD_TO_DEG)},
         memory_config,
         optional_output_tensor,
-        {},
-        {},
-        {},
-        std::nullopt,
         sub_core_grids);
 }
 


### PR DESCRIPTION
## Summary

`ttnn.deg2rad` and `ttnn.rad2deg` are just a multiply by a compile-time constant (`π/180` and `180/π`), yet they were dispatched through the full **binary** multiply op, making them ~2x slower than necessary. This PR re-implements both as a single-pass **unary** scalar multiply.

## Root cause

Both ops routed through `ttnn::multiply(input_tensor, const, ...)`, which dispatches `BinaryNgDeviceOperation` and pulls in binary-op setup/broadcast overhead that a native unary scalar-multiply does not pay.

## Change

`deg2rad` / `rad2deg` now call `operations::unary::detail::unary_impl` with a single `EltwiseUnaryWithParam(UnaryOpType::MUL_UNARY_SFPU, <const>)` activation, baking the constant into the existing unary SFPU multiply path (the same path already used by `mul_unary`). The op now dispatches as `UnaryDeviceOperation`.

The constants (`DEG_TO_RAD = 0.017453292519943295f`, `RAD_TO_DEG = 57.29577951308232f`) are unchanged, so this is a pure dispatch/kernel-path change — no new math or approximation.

## Performance

Measured on Wormhole N150 (bf16, DRAM, via Tracy `DEVICE KERNEL DURATION`), across shapes `[1,1,32,32]`, `[1,1,256,256]`, `[1,4,512,512]` (204 calls each):

| | Op dispatched | median | min | max |
|---|---|---|---|---|
| Before | `BinaryNgDeviceOperation` | 5428 ns | 4649 ns | 29190 ns |
| After  | `UnaryDeviceOperation`    | 2509 ns | 1633 ns | 28228 ns |

**2.16x speedup** (5428 ns → 2509 ns median; min 4649 ns → 1633 ns).

<img width="924" height="281" alt="image" src="https://github.com/user-attachments/assets/e7c2a289-90e4-4b03-bd2b-ebde2dad0f74" />

## Accuracy

Bit-accurate: PCC ≥ 0.9999 vs both the previous impl and the torch reference (`torch.deg2rad` / `torch.rad2deg`) for fp32 and bf16. The constant is exact, so there is no accuracy risk.

## Scope

- Only `deg2rad` / `rad2deg` in `ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp` changed.
- Function signatures unchanged; Python bindings and golden functions (`torch.deg2rad` / `torch.rad2deg`) unaffected.

## Issue Link:
Closed: #49631

## Test plan

- [x] `test_math.py`: 2 passed
- [x] `test_unary.py`: 10 passed (incl. edge-case `[2,1024,1024]` and fp32 + bf16 angle-conversion tests)

## References

- Precedent: #41030 "Optimise signbit" (8 cyc → 1 cyc)
- Eltwise performance tracker: https://ttnn-eltwise-performance.aswincloud.com/
