### PR TITLE
[Fix BH Sanity] Run ring SDPA perf checks on the IOMMU-enabled QB2 runner

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -87,7 +87,7 @@ ttnn:
     bh_p100: 545
     bh_p150b_civ2: 545
     bh_quietbox_2: 35
-    bh_quietbox_2_iommu: 20 # sdpa nightly tests moved here from bh_quietbox_2 (IOMMU-enabled QB2)
+    bh_quietbox_2_iommu: 30 # sdpa nightly (20) + ring sdpa PERF (10); both need IOMMU for the RT profiler (IOMMU-enabled QB2)
     bh_p300: 15
     wh_llmbox: 25
     sim_wormhole_b0: 680

--- a/tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py
@@ -22,7 +22,7 @@ from loguru import logger
 from ttnn.operations.ccl import Topology
 
 import ttnn
-from models.common.utility_functions import skip_with_llk_assert
+from models.common.utility_functions import skip_with_llk_assert, skip_with_watcher
 from tests.nightly.sdpa_perf_utils import (
     compute_cores_used,
     compute_math_utilization,
@@ -821,6 +821,7 @@ EXP_RING_JOINT_PERF_CHECK_CONFIGS = [
     ids=[f"ring{cfg[0]}-{cfg[2]}" for cfg in EXP_RING_JOINT_PERF_CHECK_CONFIGS],
 )
 @skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
+@skip_with_watcher("Watcher perturbs kernel timing; perf checks are not meaningful with it enabled.")
 def test_exp_ring_joint_attention_perf_check(ring_size_expected, max_payload_size, payload_id, expected_util):
     """Measure exp ring joint SDPA math utilization via real-time device program records."""
     num_devices = detect_devices_without_opening()

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -33,7 +33,7 @@ from loguru import logger
 from ttnn.operations.ccl import Topology
 
 import ttnn
-from models.common.utility_functions import skip_with_llk_assert
+from models.common.utility_functions import skip_with_llk_assert, skip_with_watcher
 
 # ============================================================================
 # CONFIGURATION CONSTANTS
@@ -3503,6 +3503,7 @@ else:
     ids=[f"{cfg[0]}-q{cfg[1]}-k{cfg[2]}-ring{cfg[3]}" for cfg in RING_JOINT_PERF_CHECK_CONFIGS],
 )
 @skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
+@skip_with_watcher("Watcher perturbs kernel timing; perf checks are not meaningful with it enabled.")
 def test_ring_joint_attention_perf_check(
     model_name, q_chunk_size, k_chunk_size, ring_size_expected, expected_util, margin
 ):
@@ -3557,6 +3558,8 @@ def test_ring_joint_attention_perf_check(
     )
 
 
+@skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
+@skip_with_watcher("Watcher perturbs kernel timing; perf checks are not meaningful with it enabled.")
 def test_ring_mla_perf_better_than_separate_v_ring_joint():
     """Profile ring_mla against the existing separate-V MLA ring joint path and require a speedup."""
     model_name = "mla_100k"
@@ -4361,6 +4364,7 @@ else:
     ids=[f"{cfg[0]}-q{cfg[1]}-k{cfg[2]}-ring{cfg[3]}" for cfg in RING_MLA_CHUNKED_PERF_CHECK_CONFIGS],
 )
 @skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
+@skip_with_watcher("Watcher perturbs kernel timing; perf checks are not meaningful with it enabled.")
 def test_ring_mla_chunked_perf_check(model_name, q_chunk_size, k_chunk_size, ring_size_expected, expected_util):
     """Measure ring_mla chunked-prefill math utilization for the kimi 50k+5k galaxy chunk (a 5k Q
     chunk against a 50k K/V prefix), simulated on the 4-device QuietBox, via realtime profiler and assert
@@ -4424,6 +4428,8 @@ def test_ring_mla_chunked_perf_check(model_name, q_chunk_size, k_chunk_size, rin
     MINIMAX3_GQA_CHUNKED_PERF_CHECK_CONFIGS,
     ids=[f"{cfg[0]}-q{cfg[1]}-k{cfg[2]}-ring{cfg[3]}" for cfg in MINIMAX3_GQA_CHUNKED_PERF_CHECK_CONFIGS],
 )
+@skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
+@skip_with_watcher("Watcher perturbs kernel timing; perf checks are not meaningful with it enabled.")
 def test_ring_joint_attention_minimax3_gqa_chunked_perf_check(
     model_name, q_chunk_size, k_chunk_size, ring_size_expected, expected_util
 ):

--- a/tests/nightly/blackhole/sdpa/test_scaled_dot_product_attention_sprint.py
+++ b/tests/nightly/blackhole/sdpa/test_scaled_dot_product_attention_sprint.py
@@ -13,6 +13,7 @@ from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
 import ttnn
 from loguru import logger
 import pytest
+from models.common.utility_functions import skip_with_llk_assert, skip_with_watcher
 
 
 def fa_rand(*shape):
@@ -435,6 +436,8 @@ SDPA_PERF_CHECK_CONFIGS = [
     SDPA_PERF_CHECK_CONFIGS,
     ids=[f"{cfg[0]}-q{cfg[1]}-k{cfg[2]}" for cfg in SDPA_PERF_CHECK_CONFIGS],
 )
+@skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
+@skip_with_watcher("Watcher perturbs kernel timing; perf checks are not meaningful with it enabled.")
 def test_sdpa_perf_check(sdpa_realtime_profiled_device, shape_id, q_chunk_size, k_chunk_size, expected_util):
     """Measure single-chip SDPA math utilization via real-time device program records."""
     idx = INPUT_IDS.index(shape_id)

--- a/tests/pipeline_reorg/blackhole_multi_card_sanity_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_multi_card_sanity_tests.yaml
@@ -55,13 +55,18 @@
   owner_id: U05ACKAJTHS # Naif Tarafdar
   team: ttnn
 
-- name: ring sdpa PERF tests (QB2 only)
+- name: ring sdpa PERF tests (QB2 IOMMU only)
+  # These perf checks measure device kernel duration via the realtime device profiler. On Blackhole
+  # the RT profiler's D2H socket uses 64-bit PCIe addressing, which requires host IOMMU (there is no
+  # hugepage fallback) — see evaluate_realtime_profiler_eligibility in realtime_profiler_manager.cpp.
+  # Without IOMMU the profiler never activates and the tests fail the guard (issue #49665), so this
+  # job must run on the IOMMU-enabled runner, matching the sdpa nightly job above.
   cmd: |
     pytest tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py::test_ring_joint_attention_perf_check -svv
     pytest tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py::test_ring_mla_chunked_perf_check -svv
     pytest tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py::test_exp_ring_joint_attention_perf_check -svv
   skus:
-    bh_quietbox_2:
+    bh_quietbox_2_iommu:
       timeout: 10
   owner_id: U05ACKAJTHS # Naif Tarafdar
   team: ttnn


### PR DESCRIPTION
## Summary
Fixes #49665. The ring SDPA perf checks now measure device kernel duration via the realtime device profiler (as of #48199), and hard-fail if it isn't active:

> `Failed: Real-time profiler must be active for SDPA perf checks`

On Blackhole the RT profiler's D2H socket uses 64-bit PCIe addressing, which requires host IOMMU (no hugepage fallback) — see `evaluate_realtime_profiler_eligibility` in `tt_metal/distributed/realtime_profiler_manager.cpp:139`. The job was still pinned to the non-IOMMU `bh_quietbox_2` runner, so the profiler never activated and every run since #48199 failed the guard. It has never passed in this form; the issue's "last passing" commit is the one right before #48199 (the old Tracy/`SDPA_PERF_CHECKS`-gated test).

## Changes
- Route "ring sdpa PERF tests" from SKU `bh_quietbox_2` → `bh_quietbox_2_iommu` (renamed "(QB2 IOMMU only)"), matching the nightly sdpa job that #49157 moved for the same reason.
- Bump `bh_quietbox_2_iommu` sanity time budget 20 → 30 min (nightly 20 + perf 10).
- Skip every SDPA perf-check test under watcher / LLK asserts. The "sdpa nightly tests (QB2 IOMMU only)" job runs the whole `tests/nightly/blackhole/sdpa/` dir, so with the profiler now active the perf checks execute there too. Under LLK asserts (or watcher) the added per-op instrumentation roughly halves measured math utilization, failing the perf-band assertions even though nothing regressed. Guard all perf-check tests with both `skip_with_llk_assert` and `skip_with_watcher` (`test_ring_joint_attention_perf_check`, `test_ring_mla_chunked_perf_check`, `test_exp_ring_joint_attention_perf_check` already had the LLK-assert guard; added watcher and covered `test_ring_mla_perf_better_than_separate_v_ring_joint`, `test_ring_joint_attention_minimax3_gqa_chunked_perf_check`, `test_sdpa_perf_check`).

Also fixes #49678, fixes #49679 (perf checks failing under LLK asserts on the IOMMU job), fixes #49670, fixes #49671 (profiler-not-active on the non-IOMMU PERF job, resolved by the runner routing above).

## Validation
- `verify_time_budget.py` passes for the sanity pipeline.
- Blackhole sanity tests workflow dispatched on this branch (see checks).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/ring-sdpa-perf-iommu-runner)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/ring-sdpa-perf-iommu-runner)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/ring-sdpa-perf-iommu-runner)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/ring-sdpa-perf-iommu-runner)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pjosipovic/ring-sdpa-perf-iommu-runner)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pjosipovic/ring-sdpa-perf-iommu-runner)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/ring-sdpa-perf-iommu-runner)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/ring-sdpa-perf-iommu-runner)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/ring-sdpa-perf-iommu-runner)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/ring-sdpa-perf-iommu-runner)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/ring-sdpa-perf-iommu-runner)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/ring-sdpa-perf-iommu-runner)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/ring-sdpa-perf-iommu-runner)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/ring-sdpa-perf-iommu-runner)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/ring-sdpa-perf-iommu-runner)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/ring-sdpa-perf-iommu-runner)
