### PR TITLE
tt-metal#49028: fix fused norm-chain compute kernel overflowing TENSIX kernel-config buffer

### DIFF
--- a/models/experimental/ops/descriptors/fusion/codegen/builder.py
+++ b/models/experimental/ops/descriptors/fusion/codegen/builder.py
@@ -45,6 +45,15 @@ from models.experimental.ops.descriptors.fusion.codegen.args import (
     _validate_fp32_consistency,
 )
 
+# Fused compute kernels concatenate multiple phases into a single binary, so binary
+# size scales with phase count. The C++ default for TENSIX compute kernels is O3;
+# override to O2 to keep fused compute binaries within the TENSIX kernel-config ring
+# buffer as phase count grows. (Os was tried first but triggers a GCC/LTO inline-asm
+# "impossible constraint" failure in the LLK pack code on Blackhole; O2 avoids it
+# while still dropping the aggressive O3 inlining that inflates the fused binary.)
+# Data-movement roles already default to O2 (program.cpp opt_level.value_or), so no override needed there.
+_FUSED_COMPUTE_KERNEL_OPT_LEVEL = ttnn.KernelBuildOptLevel.O2
+
 
 # =============================================================================
 # Compute Config Validation
@@ -445,6 +454,8 @@ def _build_fused_descriptor(
         desc.defines = must_match_defs
         desc.runtime_args = rt_args
         desc.common_runtime_args = _concatenate_common_runtime_args(phase_kernels, role_key)
+        if risc_type == "compute":
+            desc.opt_level = _FUSED_COMPUTE_KERNEL_OPT_LEVEL
         desc.config = role_config
         fused_kernels.append(desc)
 

--- a/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential.py
+++ b/tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential.py
@@ -249,12 +249,7 @@ class TestSequentialExecution:
         [
             2,
             3,
-            # TT_METAL_LLK_ASSERTS run overflows the TENSIX kernel config buffer
-            # for this fused 4-phase LN/RMS chain (70800 > 70656 bytes).
-            pytest.param(
-                4,
-                marks=skip_with_llk_assert("4-phase norm chain exceeds kernel config buffer with LLK asserts enabled."),
-            ),
+            4,
         ],
     )
     @stress_test_program_cache

--- a/ttnn/cpp/ttnn-nanobind/program_descriptors.cpp
+++ b/ttnn/cpp/ttnn-nanobind/program_descriptors.cpp
@@ -619,6 +619,10 @@ void py_module_types(nb::module_& mod) {
 
     export_enum<tt::tt_metal::UnpackToDestMode>(mod, "UnpackToDestMode");
 
+    export_enum<tt::tt_metal::KernelBuildOptLevel>(mod, "KernelBuildOptLevel", R"pbdoc(
+        Optimization level for kernel compilation.
+    )pbdoc");
+
     // nanobind bind_vector docs:
     // the item accessor __getitem__ copies the accessed element by default.
     // Consequently, writes to elements may not propagate in the expected way.
@@ -807,6 +811,7 @@ void py_module_types(nb::module_& mod) {
             "common_runtime_args",
             &tt::tt_metal::KernelDescriptor::common_runtime_args,
             "Common runtime arguments shared across all cores")
+        .def_rw("opt_level", &tt::tt_metal::KernelDescriptor::opt_level, "Optimization level for kernel compilation")
         .def_rw("config", &tt::tt_metal::KernelDescriptor::config, "Configuration descriptor for the kernel")
         .def_rw(
             "compiler_include_paths",

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -303,6 +303,7 @@ from ttnn.types import (
     cb_descriptor_from_sharded_tensor,
     get_cb_address,
     UnpackToDestMode,
+    KernelBuildOptLevel,
     FaceGeometry,
     compute_program_descriptor_hash,
     TensorAccessorArgs,

--- a/ttnn/ttnn/types.py
+++ b/ttnn/ttnn/types.py
@@ -115,6 +115,7 @@ merge_program_descriptors = ttnn._ttnn.program_descriptor.merge_program_descript
 cb_descriptor_from_sharded_tensor = ttnn._ttnn.program_descriptor.cb_descriptor_from_sharded_tensor
 get_cb_address = ttnn._ttnn.program_descriptor.get_cb_address
 UnpackToDestMode = ttnn._ttnn.program_descriptor.UnpackToDestMode
+KernelBuildOptLevel = ttnn._ttnn.program_descriptor.KernelBuildOptLevel
 FaceGeometry = ttnn._ttnn.program_descriptor.FaceGeometry
 compute_program_descriptor_hash = ttnn._ttnn.operations.generic.compute_program_descriptor_hash
 


### PR DESCRIPTION
## Summary
- Fused kernels never set `opt_level` on their generated `KernelDescriptor`s, so the compute kernel role built at the C++ default (`O3`) — at `num_phases=4`, the mixed LN/RMS fused compute binary overflows the TENSIX kernel-config ring buffer by 144 bytes (70800 vs 70656-byte limit).
- Bind `KernelBuildOptLevel` as a settable Python enum (nanobind) and override `opt_level = O2` for fused **compute**-role kernels only. Data-movement/reader roles already default to `O2` in `program.cpp`, so they need no override.
- `Os` was tried first (more aggressive size reduction) but triggers a GCC 15 + `-flto=auto` "impossible constraint in 'asm'" compile failure in the LLK pack code (`tt_llk_blackhole/common/inc/ckernel_addrmod.h`) — `O2` avoids this while still shrinking the binary enough.
- Un-skips `test_norm_chain[num_phases=4]`, which had been marked `skip_with_llk_assert` as a stopgap.

## Review
- Pre-build debate: consensus after 1 round (security/correctness/acceptance all approved the initial mechanism)
- Build: ✅
- Verification: see caveat below — not a straightforward ttsim pass
- Final review: ✅ approved after 1 reverify (comment-only correction)

## Verification caveat — please read before merging
**ttsim cannot exercise the actual overflow check for this bug.** `tt_metal/impl/program/dispatch.cpp` (`finalize_kernel_bins`) explicitly zeroes `kernel_text_size` when the device `is_mock_or_emulated()` — which ttsim always is — so the `TT_FATAL("Program size... too large...")` assertion this issue is about can never fire under simulation. Confirmed empirically: the **unmodified baseline** also "passes" under ttsim at `num_phases=4`, which is the exact regression this PR fixes.

Verification was instead done by directly measuring the compiled kernel ELF sizes with `riscv-tt-elf-size` (the real toolchain, not simulated) for the 3 compute-engine binaries (trisc0/1/2 = unpack/math/pack) at `num_phases=4`:

| kernel | baseline (`O3`) | with fix (`O2`) | delta |
|---|---|---|---|
| trisc0 (unpack) | 16140 | 16604 | +464 |
| trisc1 (math) | 14652 | 12760 | -1892 |
| trisc2 (pack) | 15324 | 11820 | -3504 |
| **sum** | **46116** | **41184** | **-4932** |

Net reduction of ~4.9KB across the 3 compute binaries comfortably covers the 144-byte overage. Full `test_parallel_sequential.py` suite (89 tests) passes under ttsim with functional PCC checks intact — confirms no regression, but **a real Blackhole CI run with `TT_METAL_LLK_ASSERTS=1` is the true confirmation gate** for the original `TT_FATAL`, since this sandbox has no physical hardware.

## Notes for reviewers
- `test_sharded_three_phase` (same file) carries an identical "Program too large... Will not fix" skip reason. This fix reduces compute binary size generally, so that test *may* now pass too, but it was deliberately left untouched/unevaluated — this issue only covers `test_norm_chain[num_phases=4]`. Worth a follow-up look if you're touching this area again.
- The pre-build debate round initially approved a diff that set `opt_level = Os` uniformly on all fused kernel roles. That broke the build (see the LTO/asm failure above) — none of the 3 independent reviewers caught it since they reviewed the diff without building it. Caught and fixed during the Verify step.

Closes #49028

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=assign-tt-metal-issue-49028-norm-chain-program-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:assign-tt-metal-issue-49028-norm-chain-program-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=assign-tt-metal-issue-49028-norm-chain-program-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:assign-tt-metal-issue-49028-norm-chain-program-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=assign-tt-metal-issue-49028-norm-chain-program-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:assign-tt-metal-issue-49028-norm-chain-program-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=assign-tt-metal-issue-49028-norm-chain-program-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:assign-tt-metal-issue-49028-norm-chain-program-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=assign-tt-metal-issue-49028-norm-chain-program-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:assign-tt-metal-issue-49028-norm-chain-program-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=assign-tt-metal-issue-49028-norm-chain-program-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:assign-tt-metal-issue-49028-norm-chain-program-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=assign-tt-metal-issue-49028-norm-chain-program-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:assign-tt-metal-issue-49028-norm-chain-program-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=assign-tt-metal-issue-49028-norm-chain-program-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:assign-tt-metal-issue-49028-norm-chain-program-size)