### PR TITLE
Drop stochastic-rounding variants from LLK unpack regression sweeps

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_A.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_A.py
@@ -261,12 +261,6 @@ def filter_params_with_constraints(all_params):
             # when unpack_to_dest=True. Block this combination.
             continue
 
-        # Format-specific checks (most expensive, do last)
-        # Block Bfp8_b output with stochastic rounding (Pack or All)
-        if formats.output_format == DataFormat.Bfp8_b:
-            if stochastic_rnd in (StochasticRounding.Pack, StochasticRounding.All):
-                continue
-
         # Block Float16/Float16_b transpose combinations that produce garbage values on CI runners
         if (
             formats.input_format in (DataFormat.Float16_b, DataFormat.Float16)

--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_A.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_A.py
@@ -71,12 +71,7 @@ dest_acc = [DestAccumulation.Yes, DestAccumulation.No]
 # single value to preserve the test-variant wiring; full removal of the parameter is tracked in #47001.
 disable_src_zero_flags = [False]
 acc_to_dest_flags = [False, True]
-stochastic_rnd = [
-    StochasticRounding.No,
-    StochasticRounding.Fpu,
-    StochasticRounding.Pack,
-    StochasticRounding.All,
-]
+stochastic_rnd = [StochasticRounding.No]
 reuse_dest_types = [
     EltwiseBinaryReuseDestType.NONE,
     EltwiseBinaryReuseDestType.DEST_TO_SRCA,

--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_sweep.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_sweep.py
@@ -140,21 +140,6 @@ def test_unpack_tilize_comprehensive(
             "MOP_OUTER_LOOP=2 and PACK_INTF_SEL values that don't adapt to tiny tiles"
         )
 
-    # Bfp8_b output + Stochastic Rounding Pack/All causes output corruption (value -508 becomes 0)
-    if formats.output_format == DataFormat.Bfp8_b and stoch_rnd_type in [
-        StochasticRounding.Pack,
-        StochasticRounding.All,
-    ]:
-        pytest.skip(
-            "Bfp8_b output with StochasticRounding.Pack/All causes the resulting value to be 0 when input is -508"
-        )
-
-    if (
-        formats.input_format == DataFormat.Int32
-        and stoch_rnd_type != StochasticRounding.No
-    ):
-        pytest.skip("StochasticRounding does not apply to Int32")
-
     is_narrow = narrow_tile == NarrowTile.Yes
     # Narrow tile: 2 vertical 16x16 faces (num_faces=2).
     tile_dimensions = [DEFAULT_TILE_R_DIM, FACE_C_DIM] if is_narrow else None

--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_sweep.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_sweep.py
@@ -89,16 +89,7 @@ def _regular_path(src_A, input_dimensions, formats, num_faces, torch_format):
         )
         + input_output_formats([DataFormat.Int32], same=True)
     ),
-    stoch_rnd_type=lambda narrow_tile: (
-        [
-            StochasticRounding.No,
-            StochasticRounding.Fpu,
-            StochasticRounding.Pack,
-            StochasticRounding.All,
-        ]
-        if narrow_tile == NarrowTile.No
-        else [StochasticRounding.No]
-    ),
+    stoch_rnd_type=[StochasticRounding.No],
     transpose=[Transpose.No],
     narrow_tile=[NarrowTile.No, NarrowTile.Yes],
     dest_acc=[DestAccumulation.No, DestAccumulation.Yes],


### PR DESCRIPTION
### PR Category
Test Only

### Summary
The LLK unpack and unpack-tilize regression sweeps were multiplying their coverage across stochastic-rounding modes, but these cases are not providing useful validation of the stochastic-rounding behavior itself. The PRNG-backed stochastic path is difficult to make deterministic, has known hardware-quality limitations, and is not used by higher-level software paths such as ttnn; in this test matrix specifically, the stochastic variants still pass when the stochastic-rounding result bits are ignored, so they do not even reliably catch whether the requested mode was exercised. This change keeps the explicit `StochasticRounding.No` template setting while removing the `Fpu`, `Pack`, and `All` parameter variants from both `test_unpack_A.py` and `test_unpack_tilize_sweep.py`, preserving the unpack coverage without carrying low-signal stochastic-rounding cases or introducing run-mode-specific skips.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/llk-stoch-rnd)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/llk-stoch-rnd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/llk-stoch-rnd)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/llk-stoch-rnd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/llk-stoch-rnd)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/llk-stoch-rnd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/llk-stoch-rnd)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/llk-stoch-rnd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/llk-stoch-rnd)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/llk-stoch-rnd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/llk-stoch-rnd)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/llk-stoch-rnd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/llk-stoch-rnd)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/llk-stoch-rnd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/llk-stoch-rnd)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/llk-stoch-rnd)