### PR TITLE
[quasar] Enable unity (jumbo) build

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/quasar/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/CMakeLists.txt
@@ -4,9 +4,8 @@ add_library(ttnn_op_experimental_quasar ${LIB_TYPE})
 add_library(TTNN::Ops::Experimental::Quasar ALIAS ttnn_op_experimental_quasar)
 
 tt_reuse_precompile_headers(ttnn_op_experimental_quasar TTNN::PCHFull)
-# NOTE: unity build intentionally NOT enabled here. The quasar ops are clones of ops that
-# originally live in separate libraries; combining them in one unity translation unit could
-# surface file-local-helper name collisions across ops. Compiling each file standalone avoids that.
+# Enable unity builds for faster compilation.
+TT_ENABLE_UNITY_BUILD(ttnn_op_experimental_quasar)
 
 set_target_properties(
     ttnn_op_experimental_quasar

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_device_operation.hpp
@@ -47,11 +47,10 @@ struct Conv2dDeviceOperation {
         const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensor);
 };
 
-// Only enable packer l1 accumulation when there are in0_num_blocks_w > 2, otherwise
-// unnecessary overhead for reconfigs are added. Last iteration of l1 accumulation
-// does a spill and reload, so need more than 2 blocks to use l1 acc for packer
-// For bias, last iteration of l1 acc remains in intermediate buffer, does not spill and reload
-bool determine_packer_l1_acc(bool packer_l1_acc, bool enable_bias, uint32_t in0_num_blocks_w);
+// NOTE: determine_packer_l1_acc is intentionally NOT declared here. The shared implementation lives
+// in ttnn::prim (ttnn/operations/conv/conv2d/conv2d_utils.cpp); the factories call that one directly.
+// A cloned qsr-namespace declaration here (with no definition) would hijack the unqualified call
+// under unity builds and produce an undefined ttnn::prim::qsr::determine_packer_l1_acc symbol.
 
 // L1 allocation is either for the output tensor or for Circular Buffers.
 // reader_indices_actual_page_size lets the program factory communicate the in-DRAM config tensor's

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -201,6 +201,7 @@ ActivationReuseConfig calculate_activation_reuse_params(
 }
 
 namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
 
 // ---- Metal 2.0 resource names (ProgramSpec scope) ----
 // DFB accessor names surface kernel-side as dfb::<name> tokens; the ported sharded kernels reference
@@ -231,10 +232,12 @@ const m2::KernelSpecName KERNEL_WRITER_SENDER{"writer_mcast_sender"};
 const m2::KernelSpecName KERNEL_WRITER_RECEIVER{"writer_mcast_receiver"};
 const m2::KernelSpecName KERNEL_COMPUTE{"compute"};
 
+}  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
 ttnn::device_operation::ProgramArtifacts Conv2dShardedProgramFactory::create_program_artifacts(
     const Conv2dParams& operation_attributes, const Conv2dInputs& tensor_args, Tensor& output_tensor) {
+    using namespace CMAKE_UNIQUE_NAMESPACE;  // resolve the file-local ids/helpers below
     const auto& a = tensor_args.a;
     const auto& b = tensor_args.b;
     const auto& ashape = ttnn::Shape(operation_attributes.input_tensor_shape);
@@ -702,7 +705,7 @@ ttnn::device_operation::ProgramArtifacts Conv2dShardedProgramFactory::create_pro
     const uint32_t tilized_act_tile_size = tt::tile_size(tilized_act_df);
 
     // Only enable packer l1 accumulation when there are in0_num_blocks_w > 2.
-    const bool packer_l1_acc_en = determine_packer_l1_acc(packer_l1_acc, has_bias, in0_num_blocks_w);
+    const bool packer_l1_acc_en = ttnn::prim::determine_packer_l1_acc(packer_l1_acc, has_bias, in0_num_blocks_w);
     const uint32_t batch = sliding_window_config.get_output_shape()[0];
     const uint32_t output_image_width = sliding_window_config.get_output_shape()[2];
     const uint32_t output_image_height = sliding_window_config.get_output_shape()[1];

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -62,6 +62,7 @@ std::pair<std::vector<uint32_t>, std::vector<uint32_t>> compute_opt_conv_activat
 }
 
 namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
 
 // ---- Metal 2.0 resource names (ProgramSpec scope) ----
 // DFB accessor names surface kernel-side as dfb::<name> tokens; the ported width-sharded kernels
@@ -89,10 +90,12 @@ const m2::KernelSpecName KERNEL_ACT{"act_reader"};
 const m2::KernelSpecName KERNEL_WEIGHTS{"weights_reader"};
 const m2::KernelSpecName KERNEL_COMPUTE{"compute"};
 
+}  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
 ttnn::device_operation::ProgramArtifacts Conv2dWidthShardedProgramFactory::create_program_artifacts(
     const Conv2dParams& operation_attributes, const Conv2dInputs& tensor_args, Tensor& output_tensor) {
+    using namespace CMAKE_UNIQUE_NAMESPACE;  // resolve the file-local ids/helpers below
     const auto& a = tensor_args.a;
     const auto& b = tensor_args.b;
     const auto& bias = tensor_args.bias;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_program_factory.cpp
@@ -19,6 +19,7 @@ using namespace tt::tt_metal::experimental;
 namespace ttnn::prim::qsr {
 
 namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
 
 // Spec/binding names. The DFB accessor names surface kernel-side as dfb::in0 / dfb::in1 / dfb::out;
 // the tensor accessor names surface as tensor::in0 / tensor::in1 / tensor::out.
@@ -35,12 +36,14 @@ const KernelSpecName WRITER_KERNEL{"writer"};
 const KernelSpecName COMPUTE_KERNEL_G1{"compute_g1"};
 const KernelSpecName COMPUTE_KERNEL_G2{"compute_g2"};
 
+}  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
 ttnn::device_operation::ProgramArtifacts MatmulMultiCoreProgramFactory::create_program_artifacts(
     const ttnn::prim::qsr::MatmulParams& operation_attributes,
     const ttnn::prim::qsr::MatmulInputs& tensor_args,
     std::vector<ttnn::Tensor>& tensor_return_value) {
+    using namespace CMAKE_UNIQUE_NAMESPACE;  // resolve the file-local ids below
     if (!tensor_args.optional_input_tensors.empty()) {
         TT_FATAL(!tensor_args.optional_input_tensors[0].has_value(), "Bias is not supported for matmul multi core");
     }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -1071,7 +1071,8 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
                 mm_in1_sender_writer_args.push_back(0);
             }
 
-            mm_in1_sender_writer_args.push_back(bias_tensor.has_value() ? (std::uint32_t)bias_tensor->address() : 0);
+            mm_in1_sender_writer_args.push_back(
+                bias_tensor.has_value() ? (std::uint32_t)bias_tensor->address() : 0);  // smuggled-rta-ok
             mm_in1_sender_writer_args.push_back(
                 bias_tensor.has_value() ? (std::uint32_t)per_core_N * output_idx_x : 0);  // in3_tensor_start_tile_id
             if (!output_is_sharded) {
@@ -1845,7 +1846,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
                 (std::uint32_t)0};
 
             if (bias_tensor.has_value()) {
-                mm_in1_sender_writer_args.push_back((std::uint32_t)bias_tensor->address());
+                mm_in1_sender_writer_args.push_back((std::uint32_t)bias_tensor->address());  // smuggled-rta-ok
                 mm_in1_sender_writer_args.push_back(
                     (std::uint32_t)per_core_N * output_idx_x);  // in3_tensor_start_tile_id
             } else {
@@ -3887,7 +3888,8 @@ void override_program_parameters(
                 mm_in1_sender_writer_args.push_back(0);
             }
 
-            mm_in1_sender_writer_args.push_back(bias_tensor.has_value() ? (std::uint32_t)bias_tensor->address() : 0);
+            mm_in1_sender_writer_args.push_back(
+                bias_tensor.has_value() ? (std::uint32_t)bias_tensor->address() : 0);  // smuggled-rta-ok
             mm_in1_sender_writer_args.push_back(
                 bias_tensor.has_value() ? (std::uint32_t)per_core_N * output_idx_x : 0);  // in3_tensor_start_tile_id
             if (!output_is_sharded) {
@@ -5123,6 +5125,7 @@ void MatmulMultiCoreReuseMcast1DProgramFactory::override_runtime_arguments(
 }
 
 namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
 
 // ===========================================================================================
 // Metal 2.0 (ProgramArtifacts) port of the resnet50 mcast_1d paths.
@@ -7263,6 +7266,7 @@ ttnn::device_operation::ProgramArtifacts create_program_mcast_in1_artifacts(
     };
 }
 
+}  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
 ttnn::device_operation::ProgramArtifacts MatmulMultiCoreReuseMcast1DProgramFactory::create_program_artifacts(
@@ -7380,7 +7384,7 @@ ttnn::device_operation::ProgramArtifacts MatmulMultiCoreReuseMcast1DProgramFacto
     }
 
     if (mcast_in0) {
-        return create_program_mcast_in0_artifacts(
+        return CMAKE_UNIQUE_NAMESPACE::create_program_mcast_in0_artifacts(
             a,
             device,
             math_fidelity,
@@ -7425,7 +7429,7 @@ ttnn::device_operation::ProgramArtifacts MatmulMultiCoreReuseMcast1DProgramFacto
             fused_matmul_bias_row_broadcastable(bias),
             sub_device_start_core);
     }
-    return create_program_mcast_in1_artifacts(
+    return CMAKE_UNIQUE_NAMESPACE::create_program_mcast_in1_artifacts(
         a,
         device,
         math_fidelity,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
@@ -1307,7 +1307,8 @@ namespace reuse_mcast_optimized_helpers {
                     mm_in1_sender_writer_args.push_back(0);
                 }
 
-                mm_in1_sender_writer_args.push_back(bias_mesh.has_value() ? (std::uint32_t)bias_mesh->address() : 0);
+                mm_in1_sender_writer_args.push_back(
+                    bias_mesh.has_value() ? (std::uint32_t)bias_mesh->address() : 0);  // smuggled-rta-ok
                 mm_in1_sender_writer_args.push_back(
                     bias_mesh.has_value() ? (std::uint32_t)per_core_N * in1_idx : 0);  // in1_tensor_start_tile_id
                 if (!output_is_sharded) {
@@ -2761,7 +2762,8 @@ create_program_mcast_in0_in1(
                     mm_in1_sender_writer_args.push_back(0);
                 }
 
-                mm_in1_sender_writer_args.push_back(bias_mesh.has_value() ? (std::uint32_t)bias_mesh->address() : 0);
+                mm_in1_sender_writer_args.push_back(
+                    bias_mesh.has_value() ? (std::uint32_t)bias_mesh->address() : 0);  // smuggled-rta-ok
                 mm_in1_sender_writer_args.push_back(
                     bias_mesh.has_value() ? (std::uint32_t)per_core_N * in1_idx : 0);  // in1_tensor_start_tile_id
                 if (!output_is_sharded) {
@@ -3052,6 +3054,7 @@ void override_runtime_arguments_impl(
 }  // namespace reuse_mcast_optimized_helpers
 
 namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
 
 // ===========================================================================================
 // Metal 2.0 (ProgramArtifacts) port of the resnet50 mcast_2d path.
@@ -4660,6 +4663,7 @@ ttnn::device_operation::ProgramArtifacts create_program_mcast_in0_in1_artifacts(
     };
 }
 
+}  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
 static ttnn::device_operation::CachedProgram<MatmulMultiCoreReuseMcast2DProgramFactory::shared_variables_t>
@@ -5008,7 +5012,7 @@ ttnn::device_operation::ProgramArtifacts MatmulMultiCoreReuseMcast2DProgramFacto
     }
 
     (void)dst_full_sync_en;
-    return create_program_mcast_in0_in1_artifacts(
+    return CMAKE_UNIQUE_NAMESPACE::create_program_mcast_in0_in1_artifacts(
         a,
         device,
         math_fidelity,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_overlap_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_overlap_program_factory.cpp
@@ -26,6 +26,7 @@ using namespace tt::tt_metal;
 namespace m2 = tt::tt_metal::experimental;
 
 namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
 
 std::vector<CoreRange> get_multicast_regions(const CoreRangeSet& all_cores, const CoreCoord& logical_controller) {
     TT_ASSERT(!all_cores.ranges().empty() and all_cores.ranges().size() <= 2);
@@ -73,12 +74,14 @@ const m2::SemaphoreSpecName SEM{"sem"};
 const m2::TensorParamName INPUT{"input"};
 const m2::TensorParamName OUTPUT{"output"};
 
+}  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
 ttnn::device_operation::ProgramArtifacts MoveOverlapProgramFactory::create_program_artifacts(
     const MoveOperationAttributes& /*operation_attributes*/,
     const MoveTensorArgs& tensor_args,
     Tensor& tensor_return_value) {
+    using namespace CMAKE_UNIQUE_NAMESPACE;  // resolve the file-local ids/helpers below
     using namespace tt::constants;
 
     const Tensor& input = tensor_args.input_tensor;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/move_sharded_program_factory.cpp
@@ -24,18 +24,21 @@ using namespace tt::tt_metal;
 namespace m2 = tt::tt_metal::experimental;
 
 namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
 
 // Metal 2.0 resource names (ProgramSpec scope).
 const m2::KernelSpecName READER{"reader"};
 const m2::TensorParamName INPUT{"input"};
 const m2::TensorParamName OUTPUT{"output"};
 
+}  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
 ttnn::device_operation::ProgramArtifacts MoveShardedProgramFactory::create_program_artifacts(
     const MoveOperationAttributes& /*operation_attributes*/,
     const MoveTensorArgs& tensor_args,
     Tensor& tensor_return_value) {
+    using namespace CMAKE_UNIQUE_NAMESPACE;  // resolve the file-local ids/helpers below
     using namespace tt::constants;
 
     const Tensor& input = tensor_args.input_tensor;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_reader_writer_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_reader_writer_multi_core_program_factory.cpp
@@ -28,6 +28,7 @@ using ttnn::operations::data_movement::float_to_uint16;
 using ttnn::operations::data_movement::pack_two_uint16_into_uint32;
 
 namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
 
 // This is currently mostly hardcoded for resnet shapes
 inline std::tuple<uint32_t, uint32_t, uint32_t, CoreRangeSet, CoreRangeSet, uint32_t, uint32_t, uint32_t, uint32_t>
@@ -185,10 +186,12 @@ MeshTensor build_pad_value_const_mesh_tensor(const PadInputs& tensor_args, float
     return tt::tt_metal::enqueue_write_tensor(cq, host_pad.host_tensor(), *device, mem_cfg);
 }
 
+}  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
 ttnn::device_operation::ProgramArtifacts PadRmReaderWriterMultiCoreProgramFactory::create_program_artifacts(
     const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& output) {
+    using namespace CMAKE_UNIQUE_NAMESPACE;  // resolve the file-local ids/helpers below
     // Metal 2.0 named resource handles (locals to avoid unity-build name collisions).
     const DFBSpecName CB_IN0{"cb_in0"};  // legacy c_0: input stream (reader produces, writer consumes)
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_reader_writer_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_rm_reader_writer_program_factory.cpp
@@ -27,6 +27,7 @@ using ttnn::operations::data_movement::float_to_uint16;
 using ttnn::operations::data_movement::pack_two_uint16_into_uint32;
 
 namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
 
 // Allocate and fill the op-owned pad-value const tensor.  Mirrors the legacy
 // build_pad_value_const_tensor_sc(): build a host tensor holding the pad value, then write it to
@@ -49,10 +50,12 @@ MeshTensor build_pad_value_const_mesh_tensor(const PadInputs& tensor_args, float
     return tt::tt_metal::enqueue_write_tensor(cq, host_pad.host_tensor(), *device, mem_cfg);
 }
 
+}  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
 ttnn::device_operation::ProgramArtifacts PadRmReaderWriterProgramFactory::create_program_artifacts(
     const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& tensor_return_value) {
+    using namespace CMAKE_UNIQUE_NAMESPACE;  // resolve the file-local ids/helpers below
     // Metal 2.0 named resource handles (locals to avoid unity-build name collisions).
     const DFBSpecName CB_IN0{"cb_in0"};  // legacy c_0: input stream (reader produces, writer consumes)
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_tile_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_tile_program_factory.cpp
@@ -18,6 +18,7 @@ using ttnn::operations::data_movement::float_to_uint16;
 using ttnn::operations::data_movement::pack_two_uint16_into_uint32;
 
 namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
 // Metal 2.0 named resource ids for this factory.
 const KernelSpecName READER{"reader"};
 const KernelSpecName WRITER{"writer"};
@@ -26,10 +27,12 @@ const DFBSpecName PAD{"pad"};    // c_1: writer-only scratch (fake CB -> self-lo
 const TensorParamName INPUT{"input"};
 const TensorParamName OUTPUT{"output"};
 const std::string WU{"wu"};
+}  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
 ttnn::device_operation::ProgramArtifacts PadTileCoreProgramFactory::create_program_artifacts(
     const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& tensor_return_value) {
+    using namespace CMAKE_UNIQUE_NAMESPACE;  // resolve the file-local ids below
     const auto& a = tensor_args.input;
     Tensor& output = tensor_return_value;
     const auto& pad_value = operation_attributes.pad_value;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/reshard_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshard/device/reshard_device_operation.cpp
@@ -18,6 +18,7 @@ using namespace tt::tt_metal;
 
 namespace ttnn::prim::qsr {
 
+namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
 bool is_valid_for_legacy_reshard(const Tensor& input_tensor, const MemoryConfig& out_mem_config) {
     auto inp_mem_layout = input_tensor.memory_config().memory_layout();
@@ -50,6 +51,7 @@ bool is_valid_for_legacy_reshard(const Tensor& input_tensor, const MemoryConfig&
     return true;
 }
 }  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
 
 ReshardDeviceOperation::program_factory_t ReshardDeviceOperation::select_program_factory(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_multi_core_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_multi_core_sharded_program_factory.cpp
@@ -16,6 +16,7 @@ using namespace tt::tt_metal::experimental;
 namespace ttnn::prim::qsr {
 
 namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
 const TensorParamName INPUT_TENSOR{"input"};
 const TensorParamName OUTPUT_TENSOR{"output"};
 const DFBSpecName INPUT_DFB{"in"};
@@ -23,10 +24,12 @@ const DFBSpecName OUTPUT_DFB{"out"};
 const KernelSpecName READER_KERNEL{"reader"};
 const KernelSpecName WRITER_KERNEL{"writer"};
 const KernelSpecName COMPUTE_KERNEL{"compute"};
+}  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
 ttnn::device_operation::ProgramArtifacts TilizeMultiCoreShardedProgramFactory::create_program_artifacts(
     const TilizeParams& /*operation_attributes*/, const TilizeInputs& tensor_args, Tensor& tensor_return_value) {
+    using namespace CMAKE_UNIQUE_NAMESPACE;  // resolve the file-local ids below
     const Tensor& input = tensor_args.input_tensor;
     const Tensor& output = tensor_return_value;
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_cn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_cn_program_factory.cpp
@@ -19,6 +19,7 @@ using namespace tt::tt_metal::experimental;
 namespace ttnn::prim::qsr {
 
 namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
 
 // DFB / kernel / tensor names for the CN factory's ProgramSpec.
 const DFBSpecName CN_CB{"cn_cb"};
@@ -27,10 +28,12 @@ const KernelSpecName CN_WRITER{"cn_writer"};
 const TensorParamName INPUT{"input"};
 const TensorParamName OUTPUT{"output"};
 
+}  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
 ttnn::device_operation::ProgramArtifacts TransposeCNProgramFactory::create_program_artifacts(
     const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
+    using namespace CMAKE_UNIQUE_NAMESPACE;  // resolve the file-local ids/helpers below
     const auto& input_tensor = tensor_args.input;
     const auto& input_mesh_tensor = input_tensor.mesh_tensor();
     const auto& output_mesh_tensor = output_tensor.mesh_tensor();

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
@@ -27,6 +27,7 @@ using ttnn::operations::data_movement::pack_two_uint16_into_uint32;
 namespace ttnn::prim::qsr {
 
 namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
 
 // DFB / kernel / tensor names for the HC tiled interleaved factory's ProgramSpec.
 const DFBSpecName SRC_CB{"src_cb"};
@@ -36,10 +37,12 @@ const KernelSpecName HCTI_WRITER{"hcti_writer"};
 const TensorParamName INPUT{"input"};
 const TensorParamName OUTPUT{"output"};
 
+}  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
 ttnn::device_operation::ProgramArtifacts TransposeHCTiledInterleavedProgramFactory::create_program_artifacts(
     const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor) {
+    using namespace CMAKE_UNIQUE_NAMESPACE;  // resolve the file-local ids/helpers below
     const auto& input_tensor = tensor_args.input;
     const auto& input_mesh_tensor = input_tensor.mesh_tensor();
     const auto& output_mesh_tensor = output_tensor.mesh_tensor();


### PR DESCRIPTION
## What

Enables the unity (jumbo) build for `ttnn_op_experimental_quasar`, previously disabled.

A prior note in this CMakeLists reasoned unity had to stay off because the cloned ops would collide with their **originals** in a merged translation unit. That doesn't hold — unity build is per-library, so the quasar clones never share a TU with the original ops. The real collisions are between **sibling quasar factories**, from code these Metal 2.0 (DFB) ports introduced that diverges from the originals: file-scope named-id constants (`const m2::TensorParamName INPUT{"input"}`, …) and a few file-local helpers the originals never had.

## How

Rename each colliding file's anonymous `namespace {` to `namespace CMAKE_UNIQUE_NAMESPACE {` (CMake assigns a unique value per source file under unity builds), plus a function-local `using namespace CMAKE_UNIQUE_NAMESPACE;` in the methods that reference those ids. The matmul mcast factories, whose create logic lives in the anon block, qualify their external entry-calls instead. **No new headers; no files opt out of unity.**

## Fixes surfaced by enabling unity

- **Latent unity-only link failure (`import ttnn`):** `conv2d_device_operation.hpp` cloned a `determine_packer_l1_acc` *declaration* into `ttnn::prim::qsr` with no definition (the real one lives in `ttnn::prim`, `conv2d_utils.cpp`). In non-unity the factory's unqualified call resolved to `ttnn::prim::`; under unity a sibling TU leaked the qsr declaration and the call bound to the undefined `ttnn::prim::qsr::determine_packer_l1_acc`. Dropped the orphaned decl and qualified the call. Verified: `import ttnn` OK, `nm` shows 0 undefined `qsr::` symbols.
- **Pre-commit `detect-smuggled-rta`:** the matmul mcast factories carry pre-existing bias-address RTAs (from the original quasar copy, `fe163380087`) that the hook re-scans once these files are touched. They are patched on program-cache hit via `override_runtime_arguments` (`arg[18]`), so ported the original op's `// smuggled-rta-ok` annotation onto the corresponding lines.

## Build-time impact

Clean compile of `ttnn_op_experimental_quasar` (134 sources, AMD Ryzen 5 7600X 6-Core, `-j12`):

| Scenario | unity ON | unity OFF | Δ |
|---|---|---|---|
| Clean build | 21.8s (17 TUs) | 53.7s (134 TUs) | **−59% / 2.46× faster** |
| Incremental (1 file touched) | 6.6s | 2.5s | +4.1s (batch recompile — the usual unity trade-off) |

## Test coverage

- **Compile**: exercised on every CI build — `TT_UNITY_BUILDS` defaults ON (unity path); the clang-tidy job forces it off (non-unity path). The `CMAKE_UNIQUE_NAMESPACE` code compiles both ways.
- **Functional**: pre-existing and thin — only `test_binary_ng_resnet_add.py` (`quasar.add_`) covers the ttnn quasar ops. The ops touched here (conv2d/matmul/move/pad/tilize/transpose) have no functional test; that gap is pre-existing and orthogonal to this build-only change (no logic changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/quasar-unity-build)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/quasar-unity-build)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/quasar-unity-build)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/quasar-unity-build)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pjosipovic/quasar-unity-build)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pjosipovic/quasar-unity-build)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/quasar-unity-build)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/quasar-unity-build)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/quasar-unity-build)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/quasar-unity-build)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/quasar-unity-build)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/quasar-unity-build)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/quasar-unity-build)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/quasar-unity-build)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/quasar-unity-build)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/quasar-unity-build)