### PR TITLE
emule: deliver fused scatter-write + atomic-inc in __emule_fabric_deliver

### DIFF
--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -2542,15 +2542,38 @@ static void __emule_fabric_deliver(
             }
             break;
         }
-        case 4: {  // NOC_UNICAST_SCATTER_WRITE: noc_address[4]@0, chunk_size[3]@32, chunk_count@38
+        case 4: {  // NOC_UNICAST_SCATTER_WRITE: noc_address[4]@0, chunk_size[3]@32, chunk_count@38, chunk_encoding@39
+            // Also carries the fused scatter-write + atomic-inc: chunk_encoding holds a 2-bit code per chunk
+            // (silicon NocScatterWriteChunkEncoding: 0 = NOP, 1 = unicast write, 2/3 = semaphore increment).
+            // On silicon a scatter write is NOT left at 0 — to_noc_unicast_scatter_write fills every chunk with
+            // encoding 1, and a fused packet marks its trailing chunk as a seminc (2/3) with the writes at 1.
+            // Encoding 0 is CHUNK_ENCODING_NOP on the wire, so the write branch below handling enc 0 the same
+            // as enc 1 is an emulator compatibility fallback only: emule's own NocUnicastScatterCommandHeader
+            // defaults chunk_encoding to 0 for a plain scatter write. For a seminc chunk, fetch_add the value
+            // stored in that chunk's size slot instead of copying payload (the seminc chunk carries no bytes).
             const uint64_t* na = reinterpret_cast<const uint64_t*>(h + 0);
             const uint16_t* cs = reinterpret_cast<const uint16_t*>(h + 32);
             uint8_t chunk_count = *(h + 38);
+            uint8_t chunk_encoding = *(h + 39);
             uint32_t off = 0;
-            for (uint8_t i = 0; i < chunk_count && payload != nullptr; ++i) {
-                uint32_t csz = (i + 1 < chunk_count) ? cs[i] : (size - off);
+            for (uint8_t i = 0; i < chunk_count; ++i) {
+                const uint8_t enc = (chunk_encoding >> (i * 2)) & 0x3;
                 uint8_t* d = __emule_fabric_resolve_remote(dst_chip, na[i]);
-                if (d != nullptr && csz > 0) {
+                if (enc == 2 /*SEMINC_NO_FLUSH*/ || enc == 3 /*SEMINC_FLUSH*/) {
+                    uint32_t val = cs[i];  // seminc value packed into this chunk's size slot
+                    if (d != nullptr) {
+                        reinterpret_cast<std::atomic<uint32_t>*>(d)->fetch_add(val, std::memory_order_release);
+                        if (dbg) {
+                            fprintf(stderr, "[EMULE_FABRIC]   scatter_seminc chip=%u dst=%p val=%u\n",
+                                    dst_chip, (void*)d, val);
+                        }
+                        __emule_fiber_wake(d);
+                    }
+                    continue;  // no payload advance for a seminc chunk
+                }
+                // Write chunk. The last write chunk's size is implicit (remaining payload).
+                uint32_t csz = (i + 1 < chunk_count) ? cs[i] : (size - off);
+                if (payload != nullptr && d != nullptr && csz > 0) {
                     std::memcpy(d, static_cast<const uint8_t*>(payload) + off, csz);
                     __emule_fiber_wake(d);
                 }


### PR DESCRIPTION
## What

The emule software-emulator's fabric deliver hook (`__emule_fabric_deliver` in `emulated_program_runner.cpp`) handles the scatter-write send type (`NOC_UNICAST_SCATTER_WRITE`, case 4) by treating **every** chunk as a payload write. It never reads the packet's per-chunk `chunk_encoding`.

Silicon's scatter hardware reads that 2-bit-per-chunk encoding (`NocScatterWriteChunkEncoding`), and the fused scatter-write + atomic-inc header (`PacketHeader::to_noc_fused_unicast_scatter_write_atomic_inc`) packs its destinations as N unicast-write chunks followed by one **semaphore-increment** chunk (encoding `SEMINC_FLUSH`/`SEMINC_NO_FLUSH`). Under emule the increment was silently dropped, so a receiver blocked on `noc_semaphore_wait` for those increments deadlocked.

## Change

Decode `chunk_encoding` in case 4:
- A **SEMINC** chunk (encoding 2/3) `fetch_add`s the increment value (packed in that chunk's size slot) into the resolved semaphore address; it carries no payload and does not advance the payload cursor.
- **Write** chunks (encoding 0/1) are delivered exactly as before.

A plain scatter write leaves `chunk_encoding` 0, so every chunk stays a write — **byte-for-byte unchanged** legacy behavior.

## Why now

Needed by two blaze loudbox micro-ops driven through emule (`fabric_argmax_reduce_batch8`, `cross_device_top32_merge`), which fabric-gather a slot to two dst addresses fused with one atomic-inc on the receiver's gather semaphore. See tenstorrent/tt-emule-blaze#18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=emule-fused-scatter-atomic-inc-deliver)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:emule-fused-scatter-atomic-inc-deliver)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=emule-fused-scatter-atomic-inc-deliver)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:emule-fused-scatter-atomic-inc-deliver)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=emule-fused-scatter-atomic-inc-deliver)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:emule-fused-scatter-atomic-inc-deliver)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=emule-fused-scatter-atomic-inc-deliver)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:emule-fused-scatter-atomic-inc-deliver)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=emule-fused-scatter-atomic-inc-deliver)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:emule-fused-scatter-atomic-inc-deliver)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=emule-fused-scatter-atomic-inc-deliver)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:emule-fused-scatter-atomic-inc-deliver)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=emule-fused-scatter-atomic-inc-deliver)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:emule-fused-scatter-atomic-inc-deliver)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=emule-fused-scatter-atomic-inc-deliver)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:emule-fused-scatter-atomic-inc-deliver)