### PR TITLE
Fix fast-dispatch hang on pinned interleaved DRAM writes (unaddressable IOVA)

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -860,6 +860,72 @@ TEST_F(MeshBufferTestSuite, EnqueueReadShardsWithPinnedMemoryFullRange) {
     EXPECT_EQ(dst_aligned, src);
 }
 
+// Regression for the fast-dispatch large single-buffer DRAM write hang (issue #49691).
+//
+// The pinned-memory write path emits a single unchunked CQ_PREFETCH_CMD_RELAY_LINEAR for the whole
+// buffer (write_to_device_buffer / write_interleaved_buffer_to_device does not iterate for pinned
+// transfers), reading the source directly from the buffer's device IOVA. On an IOMMU host, once a
+// buffer no longer fits the low reserved IOVA region, map_for_dma returns a top-down 64-bit IOVA
+// (near 2^64) that the NOC's PCIe address encoding cannot express (NOC_ADDR_LOCAL_BITS = 36).
+// cq_prefetch's process_relay_linear_cmd then reads a wrong/unmapped address, its
+// noc_async_read_barrier_with_trid never returns, and the device wedges. The threshold is NOT a
+// fixed size -- it depends on the IOMMU IOVA allocator; a large buffer is just the reliable way to
+// land a top-down IOVA. The fix only uses the pinned fast-path when the buffer's IOVA range is
+// within the NOC-addressable window, else falls back to the chunked hugepage path.
+TEST_F(MeshBufferTestSuite, EnqueueWritePinnedMemoryLargeInterleavedBuffer) {
+    if (!experimental::GetMemoryPinningParameters(*mesh_device_).can_map_to_noc) {
+        GTEST_SKIP() << "Mapping host memory to NOC is not supported on this system";
+        return;
+    }
+    const uint32_t single_tile_size = ::tt::tile_size(DataFormat::UInt32);
+
+    // Replicated mesh buffer -> per-device buffers are interleaved (not sharded), i.e. the path
+    // that emits the single pinned relay_linear. Make it large enough to reliably land a top-down
+    // (NOC-unaddressable) IOVA on an IOMMU host: 163840 * 4096 B = 640 MiB.
+    DeviceLocalBufferConfig per_device_buffer_config{
+        .page_size = single_tile_size, .buffer_type = BufferType::DRAM, .bottom_up = true};
+    const uint32_t tiles_per_device = 163840;
+    const uint64_t bytes_per_device = static_cast<uint64_t>(tiles_per_device) * single_tile_size;
+
+    ReplicatedBufferConfig global_buffer_config{.size = bytes_per_device};
+    auto mesh_buffer = MeshBuffer::create(global_buffer_config, per_device_buffer_config, mesh_device_.get());
+
+    // Pinned host source buffer with distinct values so a partial/wrong transfer is caught.
+    const size_t num_elems = bytes_per_device / sizeof(uint32_t);
+    auto src = std::make_shared<vector_aligned<uint32_t>>(num_elems, 0);
+    uint32_t* src_ptr = reinterpret_cast<uint32_t*>(src->data());
+    for (size_t i = 0; i < num_elems; ++i) {
+        src_ptr[i] = static_cast<uint32_t>(i);
+    }
+    HostBuffer host_buffer(ttsl::Span<uint32_t>(src_ptr, num_elems), MemoryPin(src));
+
+    const distributed::MeshCoordinate coord(0, 0);
+    auto coordinate_range_set = MeshCoordinateRangeSet(MeshCoordinateRange(coord, coord));
+    auto pinned_unique = experimental::PinnedMemory::Create(
+        *mesh_device_,
+        coordinate_range_set,
+        host_buffer,
+        /*map_to_noc=*/true);
+    std::shared_ptr<experimental::PinnedMemory> pinned_shared = std::move(pinned_unique);
+
+    // Pinned write of the full > 512 MiB buffer. Pre-fix this wedges the device; post-fix it
+    // completes via the chunked fallback.
+    auto write_transfer = distributed::ShardDataTransfer{coord}
+                              .host_data(static_cast<void*>(src_ptr))
+                              .region(BufferRegion(0, bytes_per_device));
+    experimental::ShardDataTransferSetPinnedMemory(write_transfer, pinned_shared);
+    mesh_device_->mesh_command_queue().enqueue_write_shards(mesh_buffer, {write_transfer}, /*blocking=*/true);
+
+    // Bit-exact round trip.
+    std::vector<uint32_t> dst(num_elems, 0);
+    auto read_transfer = distributed::ShardDataTransfer{coord}
+                             .host_data(static_cast<void*>(dst.data()))
+                             .region(BufferRegion(0, bytes_per_device));
+    mesh_device_->mesh_command_queue().enqueue_read_shards({read_transfer}, mesh_buffer, /*blocking=*/true);
+
+    EXPECT_EQ(0, std::memcmp(dst.data(), src_ptr, bytes_per_device));
+}
+
 TEST_F(MeshBufferTestSuite, EnqueueReadWithDistributedHostBufferAndPinnedMemory) {
     if (!experimental::GetMemoryPinningParameters(*mesh_device_).can_map_to_noc) {
         GTEST_SKIP() << "Mapping host memory to NOC is not supported on this system";

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -1188,10 +1188,38 @@ bool write_to_device_buffer(
                     reinterpret_cast<uintptr_t>(src_region_start),
                     reinterpret_cast<uintptr_t>(src_region_end));
             } else {
-                const uint64_t src_offset_base = static_cast<uintptr_t>(src_region_start - pinned_host_base);
-                pinned_src_addr = pinned_noc_base + src_offset_base;
-                pinned_src_noc_xy = noc_addr_pair_opt->pcie_xy_enc;
-                use_pinned_transfer = true;
+                const uint64_t candidate_src_addr =
+                    pinned_noc_base + static_cast<uint64_t>(src_region_start - pinned_host_base);
+                const uint64_t candidate_end = candidate_src_addr + region.size;
+                // Only use the pinned fast-path when the buffer's device IOVA range is within the
+                // NOC-addressable host window. On an IOMMU host, map_for_dma returns a kernel-
+                // assigned IOVA; once a buffer no longer fits the low reserved IOVA region the
+                // IOMMU hands back a top-down 64-bit IOVA (near 2^64) that the NOC's PCIe address
+                // encoding cannot express (NOC_ADDR_LOCAL_BITS = 36). cq_prefetch's
+                // process_relay_linear_cmd would then read a wrong/unmapped address, its
+                // noc_async_read_barrier_with_trid never returns, and the device wedges. This is
+                // NOT a fixed size limit -- it depends on the IOMMU IOVA allocator -- so guard on
+                // addressability (the same [base, end] the firmware uses for noc_pcie_addr), not on
+                // transfer size. The non-pinned path below streams via the hugepage command queue,
+                // whose IOVA is always addressable. Root fix: constrain the device DMA mask so the
+                // IOMMU never allocates unreachable IOVAs (tenstorrent/tt-metal#49696).
+                const bool iova_noc_addressable = candidate_src_addr >= hal.get_pcie_addr_lower_bound() &&
+                                                  candidate_end >= candidate_src_addr &&  // no overflow
+                                                  candidate_end - 1 <= hal.get_pcie_addr_upper_bound();
+                if (iova_noc_addressable) {
+                    pinned_src_addr = candidate_src_addr;
+                    pinned_src_noc_xy = noc_addr_pair_opt->pcie_xy_enc;
+                    use_pinned_transfer = true;
+                } else {
+                    log_debug(
+                        tt::LogMetal,
+                        "Pinned source IOVA range [{:#x}, {:#x}) is outside the NOC-addressable PCIe "
+                        "window [{:#x}, {:#x}]; using the chunked hugepage path.",
+                        candidate_src_addr,
+                        candidate_end,
+                        hal.get_pcie_addr_lower_bound(),
+                        hal.get_pcie_addr_upper_bound());
+                }
             }
         }
     }


### PR DESCRIPTION
## Problem
Writing an interleaved DRAM buffer via fast dispatch on the pinned-memory write path (`ttnn.from_torch(..., DRAM)` and any pinned `EnqueueWrite`) can wedge the device.

## Root cause (fully diagnosed — not a size limit)
The pinned write path emits a single unchunked `CQ_PREFETCH_CMD_RELAY_LINEAR` that reads the source from the buffer's device **IOVA**. On an IOMMU host, `map_for_dma` returns a kernel-assigned IOVA; once a buffer no longer fits the low reserved IOVA region, the IOMMU hands back a **top-down 64-bit IOVA** (near 2^64). The Blackhole NOC only expresses a **36-bit local address** for PCIe reads (`NOC_ADDR_LOCAL_BITS = 36`), so `cq_prefetch::process_relay_linear_cmd` reads a wrong/unmapped address, `noc_async_read_barrier_with_trid` never returns, and the device hangs.

Measured on a fresh BH P100:

| buffer size | IOVA base | NOC-reachable? | result |
|---|---|---|---|
| 448–500 MiB | `0x2000_0040` | yes | OK |
| 508–512 MiB | `0xffffffff_e0000040` | no | hang |

The ~512 MiB threshold is **not** a hardware limit — it is where this host's IOMMU allocator switches to top-down IOVAs, and it depends on the allocator/kernel/occupancy (a smaller buffer can also hang if the low region is occupied). Diagnosed via watcher + tt-triage (NOC1) + IOVA instrumentation. Full write-up in #49691.

## Fix
Only take the pinned fast-path when the buffer's IOVA range lies within the NOC-addressable PCIe window (`hal.get_pcie_addr_lower_bound()..get_pcie_addr_upper_bound()` — the same bounds the firmware uses for `noc_pcie_addr`); otherwise fall back to the non-pinned chunked hugepage path (always-addressable command-queue IOVA). The guard is on **IOVA addressability, not transfer size**.

## Regression test
`distributed_unit_tests` → `MeshBufferTestSuite.EnqueueWritePinnedMemoryLargeInterleavedBuffer`: a 640 MiB pinned interleaved DRAM write + read-back (large enough to reliably land a top-down IOVA on an IOMMU runner). **Verified: hangs without the guard, passes with it.**

## CI note
The pinned path only activates on **IOMMU (viommu)** runners. The gtest name matches the `*PinnedMemory*` filter used by the `metal-iommu-unit-tests` job (viommu-stable runners) — but that workflow isn't currently wired into an active pipeline. Follow-up: wire it in so this has standing CI coverage.

## Root fix (separate)
Constrain the device DMA mask so the IOMMU never allocates unreachable IOVAs — **#49696**. With that, large pinned writes work directly and this guard becomes a redundant safety net.

## Follow-ups
- Once merged, the `_skip_multi_chunk_hangs` skip on `pjosipovic/topk-large-indices-realtime-perf` can be removed.

Closes #49691
