### PR TITLE
Map Blackhole pinned buffers via NOC-DMA so their IOVA is NOC-addressable

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -860,6 +860,65 @@ TEST_F(MeshBufferTestSuite, EnqueueReadShardsWithPinnedMemoryFullRange) {
     EXPECT_EQ(dst_aligned, src);
 }
 
+// Regression for the large pinned interleaved DRAM write hang (issue #49691).
+//
+// A pinned write reads the source from the buffer's device address. When PinnedMemory used the raw
+// DMA IOVA (map_for_dma) on Blackhole, the IOMMU could hand back a top-down 64-bit IOVA that the
+// NOC's 36-bit local address cannot express, so cq_prefetch's process_relay_linear_cmd read a
+// wrong/unmapped address and the device wedged. The fix maps pinned buffers via the NOC-DMA path
+// (map_buffer_to_noc), which the KMD allocates bottom-up in the NOC-addressable window. This
+// writes a > 512 MiB replicated (interleaved) DRAM buffer with pinned memory — large enough that
+// the old raw-IOVA path reliably landed a top-down, unreachable IOVA — and requires it to
+// complete and round-trip bit-exact.
+TEST_F(MeshBufferTestSuite, EnqueueWritePinnedMemoryLargeInterleavedBuffer) {
+    if (!experimental::GetMemoryPinningParameters(*mesh_device_).can_map_to_noc) {
+        GTEST_SKIP() << "Mapping host memory to NOC is not supported on this system";
+        return;
+    }
+    const uint32_t single_tile_size = ::tt::tile_size(DataFormat::UInt32);
+
+    // Replicated mesh buffer -> per-device buffers are interleaved (not sharded). 163840 * 4096 B
+    // = 640 MiB, well past the point where the old raw-IOVA path returned a NOC-unreachable IOVA.
+    DeviceLocalBufferConfig per_device_buffer_config{
+        .page_size = single_tile_size, .buffer_type = BufferType::DRAM, .bottom_up = true};
+    const uint32_t tiles_per_device = 163840;
+    const uint64_t bytes_per_device = static_cast<uint64_t>(tiles_per_device) * single_tile_size;
+
+    ReplicatedBufferConfig global_buffer_config{.size = bytes_per_device};
+    auto mesh_buffer = MeshBuffer::create(global_buffer_config, per_device_buffer_config, mesh_device_.get());
+
+    const size_t num_elems = bytes_per_device / sizeof(uint32_t);
+    auto src = std::make_shared<vector_aligned<uint32_t>>(num_elems, 0);
+    uint32_t* src_ptr = reinterpret_cast<uint32_t*>(src->data());
+    for (size_t i = 0; i < num_elems; ++i) {
+        src_ptr[i] = static_cast<uint32_t>(i);
+    }
+    HostBuffer host_buffer(ttsl::Span<uint32_t>(src_ptr, num_elems), MemoryPin(src));
+
+    const distributed::MeshCoordinate coord(0, 0);
+    auto coordinate_range_set = MeshCoordinateRangeSet(MeshCoordinateRange(coord, coord));
+    auto pinned_unique = experimental::PinnedMemory::Create(
+        *mesh_device_,
+        coordinate_range_set,
+        host_buffer,
+        /*map_to_noc=*/true);
+    std::shared_ptr<experimental::PinnedMemory> pinned_shared = std::move(pinned_unique);
+
+    auto write_transfer = distributed::ShardDataTransfer{coord}
+                              .host_data(static_cast<void*>(src_ptr))
+                              .region(BufferRegion(0, bytes_per_device));
+    experimental::ShardDataTransferSetPinnedMemory(write_transfer, pinned_shared);
+    mesh_device_->mesh_command_queue().enqueue_write_shards(mesh_buffer, {write_transfer}, /*blocking=*/true);
+
+    std::vector<uint32_t> dst(num_elems, 0);
+    auto read_transfer = distributed::ShardDataTransfer{coord}
+                             .host_data(static_cast<void*>(dst.data()))
+                             .region(BufferRegion(0, bytes_per_device));
+    mesh_device_->mesh_command_queue().enqueue_read_shards({read_transfer}, mesh_buffer, /*blocking=*/true);
+
+    EXPECT_EQ(0, std::memcmp(dst.data(), src_ptr, bytes_per_device));
+}
+
 TEST_F(MeshBufferTestSuite, EnqueueReadWithDistributedHostBufferAndPinnedMemory) {
     if (!experimental::GetMemoryPinningParameters(*mesh_device_).can_map_to_noc) {
         GTEST_SKIP() << "Mapping host memory to NOC is not supported on this system";

--- a/tt_metal/distributed/pinned_memory.cpp
+++ b/tt_metal/distributed/pinned_memory.cpp
@@ -123,9 +123,25 @@ void PinnedMemoryImpl::initialize_from_devices(
     // Create one buffer per unique MMIO device, all mapping the same aligned host memory
     std::unordered_map<ChipId, std::unique_ptr<tt::umd::SysmemBuffer>> mmio_buffers;
     if (MetalContext::instance().hal().get_supports_64_bit_pcie_addressing()) {
-        // On Blackhole, we can use 64-bit address space, so we don't need to use the iATU.
-        map_to_noc = false;
-        use_64bit_address_space_ = true;
+        // On Blackhole the NOC can address host memory directly (no iATU needed), so pinned host
+        // buffers used to be mapped with the raw DMA IOVA (map_for_dma) and that IOVA was reused as
+        // the NOC address (use_64bit_address_space_). That is unsafe: on an IOMMU host the kernel
+        // dma-iommu allocator can hand back a top-down 64-bit IOVA (near 2^64) that the NOC's 36-bit
+        // local address cannot express, so cq_prefetch's relay read targets a wrong/unmapped
+        // address and the device wedges (tenstorrent/tt-metal#49691).
+        //
+        // Prefer the NOC-DMA mapping (map_to_noc -> SysmemBuffer::map_buffer_to_noc), which the KMD
+        // allocates bottom-up inside the NOC-addressable window and returns a proper noc_address, so
+        // the device always gets a reachable address regardless of buffer size. Fall back to the raw
+        // 64-bit IOVA only when the KMD is too old to support NOC-DMA mapping (< 2.0), where the
+        // #49691 addressability guard in buffer_dispatch still protects the large-buffer case.
+        if (cluster.is_noc_mapping_enabled()) {
+            map_to_noc = true;
+            use_64bit_address_space_ = false;
+        } else {
+            map_to_noc = false;
+            use_64bit_address_space_ = true;
+        }
     }
 
     for (ChipId mmio_device_id : unique_mmio_devices) {

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -1188,10 +1188,39 @@ bool write_to_device_buffer(
                     reinterpret_cast<uintptr_t>(src_region_start),
                     reinterpret_cast<uintptr_t>(src_region_end));
             } else {
-                const uint64_t src_offset_base = static_cast<uintptr_t>(src_region_start - pinned_host_base);
-                pinned_src_addr = pinned_noc_base + src_offset_base;
-                pinned_src_noc_xy = noc_addr_pair_opt->pcie_xy_enc;
-                use_pinned_transfer = true;
+                const uint64_t candidate_src_addr =
+                    pinned_noc_base + static_cast<uint64_t>(src_region_start - pinned_host_base);
+                const uint64_t candidate_end = candidate_src_addr + region.size;
+                // Defensive guard (belt-and-suspenders): only use the pinned fast-path when the
+                // buffer's device IOVA range is within the NOC-addressable host window. The primary
+                // fix routes Blackhole pinned buffers through the NOC-DMA mapping (see
+                // PinnedMemory), which the KMD allocates bottom-up so the address is always
+                // reachable -- this guard then never triggers there. It still matters on KMDs too
+                // old for NOC-DMA (< 2.0), which fall back to the raw DMA IOVA: on an IOMMU host
+                // that IOVA can be a top-down 64-bit value (near 2^64) the NOC's 36-bit local
+                // address (NOC_ADDR_LOCAL_BITS = 36) cannot express, which would make cq_prefetch's
+                // process_relay_linear_cmd read a wrong/unmapped address and wedge the device. This
+                // is NOT a fixed size limit -- it depends on the IOMMU IOVA allocator -- so guard on
+                // addressability (the same [base, end] the firmware uses for noc_pcie_addr), not on
+                // transfer size. The non-pinned path below streams via the hugepage command queue,
+                // whose IOVA is always addressable.
+                const bool iova_noc_addressable = candidate_src_addr >= hal.get_pcie_addr_lower_bound() &&
+                                                  candidate_end >= candidate_src_addr &&  // no overflow
+                                                  candidate_end - 1 <= hal.get_pcie_addr_upper_bound();
+                if (iova_noc_addressable) {
+                    pinned_src_addr = candidate_src_addr;
+                    pinned_src_noc_xy = noc_addr_pair_opt->pcie_xy_enc;
+                    use_pinned_transfer = true;
+                } else {
+                    log_debug(
+                        tt::LogMetal,
+                        "Pinned source IOVA range [{:#x}, {:#x}) is outside the NOC-addressable PCIe "
+                        "window [{:#x}, {:#x}]; using the chunked hugepage path.",
+                        candidate_src_addr,
+                        candidate_end,
+                        hal.get_pcie_addr_lower_bound(),
+                        hal.get_pcie_addr_upper_bound());
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
Fixes the fast-dispatch hang on large pinned interleaved DRAM writes (#49691, root cause #49696). Two parts, one coherent fix:

1. **Primary — route Blackhole pinned buffers through NOC-DMA** (`pinned_memory.cpp`). Removes the cause.
2. **Defensive guard — old-KMD fallback** (`buffer_dispatch`). Belt-and-suspenders.

## Root cause
`PinnedMemory` forced the raw-IOVA path on Blackhole (`map_for_dma` + `use_64bit_address_space_`) and reused the DMA IOVA as the NOC address, assuming 64-bit PCIe addressing makes any IOVA reachable. It doesn't: on an IOMMU host the kernel dma-iommu allocator returns a **top-down 64-bit IOVA** (near 2⁶⁴) once a buffer no longer fits the low reserved region, and the NOC's **36-bit local address** (`NOC_ADDR_LOCAL_BITS = 36`) can't express it → `cq_prefetch::process_relay_linear_cmd` reads a wrong/unmapped address → `noc_async_read_barrier_with_trid` never returns → device wedge. (Measured IOVAs and full diagnosis in #49691.)

## Fix
1. **NOC-DMA (primary):** map pinned buffers via `map_buffer_to_noc`, which the KMD allocates bottom-up inside the NOC-addressable window and returns a proper `noc_address` — reachable regardless of size. Same mechanism the command-queue sysmem uses; user buffers get addresses above the reserved CQ base, so no collision. Gated on `Cluster::is_noc_mapping_enabled()` (KMD ≥ 2.0).
2. **Addressability guard (fallback):** in `buffer_dispatch`, only take the pinned fast-path when the IOVA range is within the NOC-addressable window (`hal.get_pcie_addr_lower_bound()..upper_bound()`), else fall back to the chunked hugepage path. With NOC-DMA this never triggers; it protects KMDs too old for NOC-DMA (< 2.0), which still use the raw IOVA.

## Verification (Blackhole, KMD 2.4.1)
- `from_torch` DRAM round-trips bit-exact from **1 MiB to 1 GiB** (previously hung > ~512 MiB); device/command-queue open normally.
- Regression gtest `MeshBufferTestSuite.EnqueueWritePinnedMemoryLargeInterleavedBuffer` (640 MiB pinned interleaved write + read-back): **PASS**. (Verified it hangs with the guard disabled + raw-IOVA path.)
- Ran the **`metal-iommu-unit-tests` job locally** on an IOMMU box (KMD 2.4.1): `distributed_unit_tests --gtest_filter=*PinnedMemory*` = **12 passed / 2 skipped / 0 failed**; `unit_tests_device --gtest_filter=*PinnedMemory*` (slow dispatch) = **1 passed**. The full PinnedMemory suite (read/write, sharded, cache, unaligned, large-page, wait-on-close) is green — no regression to other pinned-memory users.

## Why not fix it in UMD
Tried making UMD `map_for_dma` use NOC-DMA; it broke the command-queue sysmem (a non-NOC DMA buffer stole the reserved NOC base `pcie_base_`). `map_for_dma` is dual-use (PCIe DMA-engine IOVA and, via the old 64-bit path, a NOC address). UMD's NOC-DMA support is already correct — the fix belongs in this caller. Details in #49696 (closed).

## Note
Supersedes #49695 (which contained only the guard). Touches shared `PinnedMemory` (from_torch, H2D/D2H sockets, RT profiler) — wants the PinnedMemory owner's review + read-path/mesh validation.

## CI to run
The change is Blackhole-only and active only on IOMMU (viommu) runners. Relevant CI: `metal-iommu-unit-tests` (direct — the PinnedMemory unit tests; currently dormant/`workflow_call`-only, needs a `workflow_dispatch` to run), plus `tt-metal-l2-nightly` (viommu SKUs + the deepseek `test_deepseek_moe_post_combine_reduce` multi_chunk repro) and `blackhole-sanity-tests` (viommu profiler/umd/ops).

Closes #49691
Closes #49696


### CI Status
_Auto-generated. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/pinned-memory-noc-dma-bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/pinned-memory-noc-dma-bh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/pinned-memory-noc-dma-bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/pinned-memory-noc-dma-bh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-unit-tests.yaml/badge.svg?branch=pjosipovic/pinned-memory-noc-dma-bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-unit-tests.yaml?query=branch:pjosipovic/pinned-memory-noc-dma-bh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pjosipovic/pinned-memory-noc-dma-bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pjosipovic/pinned-memory-noc-dma-bh)
