### PR TITLE
sparse_sdpa: use compile-time args for block-cyclic remap

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
@@ -191,7 +191,7 @@ ttsl::hash::hash_t IndexerScoreDeviceOperation::compute_program_hash(
         attrs.cluster_axis.value_or(0u),
         attrs.has_indexed_kv_cache(),
         attrs.has_runtime_kv_len(),
-        // The block-cyclic layout bakes invP divisors into the reader as compile-time defines, so sp/chunk_local
+        // The block-cyclic layout bakes invP divisors into the reader as compile-time arguments, so sp/chunk_local
         // must be hashed (a contiguous vs block-cyclic read, or a different layout shape, is a different binary).
         attrs.has_block_cyclic(),
         attrs.block_cyclic.has_value() ? attrs.block_cyclic->sp : 0u,

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
@@ -79,7 +79,7 @@ struct operation_attributes_t {
     bool has_runtime_kv_len() const { return kv_len.has_value(); }
     // Resolved block-cyclic (per-SP-shard) K layout. When set, the reader remaps each logical k-tile to its
     // physical (permuted) tile, presenting K in natural token order. HASHED (sp/chunk_local shape the reader
-    // binary via compile-time defines, so the contiguous path stays byte-identical). nullopt == contiguous K
+    // binary via compile-time arguments). nullopt == contiguous K
     // (which is also what sp == 1 resolves to, since that is the identity permutation).
     std::optional<BlockCyclicLayout> block_cyclic{std::nullopt};
     bool has_block_cyclic() const { return block_cyclic.has_value(); }

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
@@ -6,7 +6,6 @@
 
 #include <algorithm>
 #include <array>
-#include <map>
 #include <string>
 #include <utility>
 #include <vector>
@@ -15,7 +14,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
-#include <tt-logger/tt-logger.hpp>         // log_info: per-program schedule/mcast summary
+#include <tt-logger/tt-logger.hpp>  // log_info: per-program schedule/mcast summary
 #include <tt-metalium/mesh_workload.hpp>
 #include "hostdevcommon/kernel_structs.h"  // tt::CBIndex
 
@@ -43,8 +42,8 @@ constexpr uint32_t mcast_args_per_dir = 8;      // role, rect (xs,ys,xe,ye), sen
 constexpr uint32_t reader_num_mcast_dirs = 2;   // K column, then Q/W row
 constexpr uint32_t reader_k_batch_offset = reader_num_scalars + reader_num_mcast_dirs * mcast_args_per_dir;  // 25
 constexpr uint32_t reader_kv_len_tiles = reader_k_batch_offset + 1;                                          // 26
-constexpr uint32_t compute_kv_len_tiles = 6;     // after the 6 schedule scalars {row_group0..max_bands}
-constexpr uint32_t writer_kv_len_tiles = 1 + 6;  // out_addr + the 6 schedule scalars {row_group0..max_bands}
+constexpr uint32_t compute_kv_len_tiles = 6;          // after the 6 schedule scalars {row_group0..max_bands}
+constexpr uint32_t writer_kv_len_tiles = 1 + 6;       // out_addr + the 6 schedule scalars {row_group0..max_bands}
 constexpr uint32_t writer_chunk_start_tiles = 1 + 7;  // after out_addr + 6 sched scalars + kv_len[7]; match writer
 constexpr uint32_t writer_straddle_q_tile = 1 + 8;    // mid-slab forced-local block jump (block-pool only)
 constexpr uint32_t writer_straddle_jump_tiles = 1 + 9;
@@ -82,7 +81,8 @@ inline DeviceCausalGeometry device_causal_geometry(
     if (args.cluster_axis.has_value()) {
         TT_FATAL(
             device_index < sp,
-            "indexer_score: device_index {} out of range for block-cyclic sp={} (check cluster_axis vs block_cyclic_sp_axis)",
+            "indexer_score: device_index {} out of range for block-cyclic sp={} (check cluster_axis vs "
+            "block_cyclic_sp_axis)",
             device_index,
             sp);
         // SP-only block-cyclic: device_index is the SP-ring index and owns ONE block (Sq == chunk_local).
@@ -414,25 +414,26 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
     reader_ct.push_back(q_valid_sem);
     // Fused single-head: reader reads q+w FIRST (the matmul gate needs them), then streams k (when no mcast).
     reader_ct.push_back(fuse_single ? 1u : 0u);
-    reader_ct.push_back(fused_stream_k ? 1u : 0u);  // fused: stream k (no mcast) vs whole mcast block
+    reader_ct.push_back(fused_stream_k ? 1u : 0u);        // fused: stream k (no mcast) vs whole mcast block
     reader_ct.push_back(args.synthesize_gate ? 1u : 0u);  // fill cb_w with gate_scale in L1 vs read DRAM
     reader_ct.push_back(gate_scale_bits);                 // bf16 pair, the in-kernel gate fill value
-
-    // Block-cyclic (per-SP-shard) K: bake invP's divisors as reader defines (only when a block-cyclic layout
-    // is present, so the contiguous path emits no defines -> byte-identical reader binary). cl_t = per-shard
-    // chunk in tiles; the kernel maps logical tile L -> L + shard*BC_SHARD_STRIDE_GAP - slab*BC_SLAB_STRIDE_GAP.
-    // sp/chunk_local/T are all hashed, so the gaps are pure compile-time constants (no per-dispatch arg).
-    std::map<std::string, std::string> reader_defines;
-    if (args.has_block_cyclic()) {
+    const auto block_cyclic_ct = [&args, Tt]() {
+        std::array<uint32_t, 5> ct{0, 1, 1, 0, 0};
+        if (!args.has_block_cyclic()) {
+            return ct;
+        }
         const uint32_t sp = args.block_cyclic->sp;
-        const uint32_t cl_t = args.block_cyclic->chunk_local / tt::constants::TILE_WIDTH;  // per-shard chunk (tiles)
-        const uint32_t chunk_tiles = sp * cl_t;                                            // global chunk (tiles)
-        reader_defines["BC_ENABLE"] = "1";
-        reader_defines["BC_SP"] = std::to_string(sp);
-        reader_defines["BC_CHUNK_LOCAL_T"] = std::to_string(cl_t);
-        reader_defines["BC_SLAB_STRIDE_GAP"] = std::to_string(cl_t * (sp - 1));
-        reader_defines["BC_SHARD_STRIDE_GAP"] = std::to_string((Tt - chunk_tiles) / sp);
-    }
+        const uint32_t chunk_local = args.block_cyclic->chunk_local / tt::constants::TILE_WIDTH;
+        ct = {
+            1,
+            chunk_local,
+            sp,
+            (Tt / sp) - chunk_local,
+            chunk_local * (sp - 1),
+        };
+        return ct;
+    }();
+    reader_ct.insert(reader_ct.end(), block_cyclic_ct.begin(), block_cyclic_ct.end());
 
     std::vector<uint32_t> writer_ct = common_ct;
     const uint32_t out_elem_bytes = out.element_size();  // bf16 today
@@ -453,10 +454,7 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
 
     const std::string kdir = "ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/";
     auto reader_id = tt::tt_metal::CreateKernel(
-        program,
-        kdir + "reader_indexer_score.cpp",
-        core_ranges,
-        tt::tt_metal::ReaderDataMovementConfig(reader_ct, reader_defines));
+        program, kdir + "reader_indexer_score.cpp", core_ranges, tt::tt_metal::ReaderDataMovementConfig(reader_ct));
     auto writer_id = tt::tt_metal::CreateKernel(
         program, kdir + "writer_indexer_score.cpp", core_ranges, tt::tt_metal::WriterDataMovementConfig(writer_ct));
     auto compute_id = tt::tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
@@ -48,29 +48,29 @@ constexpr uint32_t fused_stream_k = get_compile_time_arg_val(mc_ct_base + 9);
 // MSA constant gate: fill cb_w with gate_scale in L1 (no DRAM read, no mcast) instead of reading weights.
 constexpr uint32_t synthesize_gate = get_compile_time_arg_val(mc_ct_base + 10);
 constexpr uint32_t gate_scale_bits = get_compile_time_arg_val(mc_ct_base + 11);  // bf16 pair (two per word)
+constexpr uint32_t bc_ct_base = mc_ct_base + 12;
+constexpr bool block_cyclic = get_compile_time_arg_val(bc_ct_base) != 0;
+constexpr uint32_t bc_chunk_local = get_compile_time_arg_val(bc_ct_base + 1);
+constexpr uint32_t bc_sp = get_compile_time_arg_val(bc_ct_base + 2);
+constexpr uint32_t bc_shard_stride_gap = get_compile_time_arg_val(bc_ct_base + 3);
+constexpr uint32_t bc_slab_stride_gap = get_compile_time_arg_val(bc_ct_base + 4);
 
-// Block-cyclic (per-SP-shard) K layout: the gathered cache stores each SP shard's per-chunk slab back-to-back,
-// so logical token tile L physically lives at invP(L). invP, in tiles, is
-// page = L + shard*BC_SHARD_STRIDE_GAP - slab*BC_SLAB_STRIDE_GAP, with block_idx = L/BC_CHUNK_LOCAL_T,
-// slab = block_idx/BC_SP (which global chunk), shard = block_idx%BC_SP (which SP shard). The factory bakes the
-// divisors as compile-time defines (BC_CHUNK_LOCAL_T / BC_SP / BC_SHARD_STRIDE_GAP / BC_SLAB_STRIDE_GAP) only
-// when a block-cyclic layout is present (sp > 1), so the contiguous path emits no defines and BC_KTILE is the
-// identity -> byte-identical reader binary. Reading K in logical order keeps the causal mask + block-max-pool
-// (both keyed on the logical column) unchanged and yields score columns in natural token order.
-#ifdef BC_ENABLE
-// TODO: unify with ttnn.transformer.sparse_sdpa's logical_to_chunked_physical (sparse_sdpa_gather.hpp) -- same
-// block-cyclic invP; share via a common header later (units differ: tiles here, rows there).
-inline uint32_t logical_to_chunked_physical(
-    uint32_t logical, uint32_t chunk_local, uint32_t sp, uint32_t shard_stride_gap, uint32_t slab_stride_gap) {
-    const uint32_t block_idx = logical / chunk_local;
-    const uint32_t slab = block_idx / sp;          // which global chunk (high part)
-    const uint32_t shard = block_idx - slab * sp;  // which SP shard within the chunk (low part)
-    return logical + shard * shard_stride_gap - slab * slab_stride_gap;
+template <uint32_t ChunkLocal, uint32_t Sp, uint32_t ShardStrideGap, uint32_t SlabStrideGap>
+FORCE_INLINE uint32_t logical_to_chunked_physical(uint32_t n) {
+    const uint32_t block_idx = n / ChunkLocal;
+    const uint32_t slab = block_idx / Sp;
+    const uint32_t shard = block_idx - slab * Sp;
+    return n + shard * ShardStrideGap - slab * SlabStrideGap;
 }
-#define BC_KTILE(L) logical_to_chunked_physical(L, BC_CHUNK_LOCAL_T, BC_SP, BC_SHARD_STRIDE_GAP, BC_SLAB_STRIDE_GAP)
-#else
-#define BC_KTILE(L) (L)
-#endif
+
+template <bool BlockCyclic, uint32_t ChunkLocal, uint32_t Sp, uint32_t ShardStrideGap, uint32_t SlabStrideGap>
+FORCE_INLINE uint32_t logical_to_physical_page(uint32_t page) {
+    if constexpr (BlockCyclic) {
+        return logical_to_chunked_physical<ChunkLocal, Sp, ShardStrideGap, SlabStrideGap>(page);
+    } else {
+        return page;
+    }
+}
 
 // Receiver rectangle / sender coords for one mcast direction (physical NoC), set per core on host.
 struct McastDir {
@@ -266,8 +266,12 @@ inline void read_k_chunk(
         noc, k_chunk_tiles, k_chunk_tiles * k_tile_bytes, k_dir, [&](uint32_t addr) {
             uint32_t ptr = addr;
             for (uint32_t k_col = 0; k_col < k_tiles_in_unit; ++k_col) {
-                // BC_KTILE: identity for contiguous K; invP(logical seq tile) for the per-SP-shard block-cyclic layout.
-                const uint32_t seq_tile = BC_KTILE(k_tile_start + k_col);
+                const uint32_t seq_tile = logical_to_physical_page<
+                    block_cyclic,
+                    bc_chunk_local,
+                    bc_sp,
+                    bc_shard_stride_gap,
+                    bc_slab_stride_gap>(k_tile_start + k_col);
                 for (uint32_t dim_tile = 0; dim_tile < head_dim_tiles; ++dim_tile) {
                     noc.async_read(
                         k_acc,
@@ -298,7 +302,12 @@ inline void read_k_chunk_streaming(
         uint32_t ptr = cb.get_write_ptr();
         for (uint32_t c = cbase; c < c_end; ++c) {
             if (c < k_tiles_in_unit) {
-                const uint32_t seq_tile = BC_KTILE(k_tile_start + c);  // identity unless block-cyclic layout
+                const uint32_t seq_tile = logical_to_physical_page<
+                    block_cyclic,
+                    bc_chunk_local,
+                    bc_sp,
+                    bc_shard_stride_gap,
+                    bc_slab_stride_gap>(k_tile_start + c);
                 for (uint32_t d = 0; d < head_dim_tiles; ++d) {
                     noc.async_read(
                         k_acc,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_gather.hpp
@@ -15,43 +15,31 @@ namespace sparse_sdpa {
 // NoC's load, a shallow ring beats both the plain burst and the old deep single-NoC ring).
 constexpr uint32_t K_TRID_RING = 4;
 
-// Gather the K rows for chunk index positions [lo, hi) on `noc`, capping outstanding reads with a depth-D
-// trid ring: idx_ptr[base + p] -> k_cb at byte offset p * k_row_bytes, for p in [lo, hi). Used by the
-// reader for its half [half, valid) and by the writer for its half [0, half). `page_offset` selects the
-// batch slot of an indexed KV cache (cache_batch_idx * T); 0 for a single [1,1,T,K_DIM] cache.
-//
-// When BC_ENABLE is defined, the kv cache is stored block-cyclic across SP shards (the DeepSeek
-// chunked-prefill KVPE cache), so the natural-position index n is remapped to its physical page on the fly via
-// invP (the inverse of blockcyclic_positions). Natural order is slab-major (chunk after chunk, shard-within);
-// the physical buffer is shard-major (each shard's whole region, slabs-within). Decompose n into its block,
-// then re-encode by adjusting the per-shard and per-slab strides:
-//   block_idx = n / BC_CHUNK_LOCAL;  slab = block_idx / BC_SP;  shard = block_idx % BC_SP
-//   page = n + shard*BC_SHARD_STRIDE_GAP - slab*BC_SLAB_STRIDE_GAP
-// All factory compile-time defines (the cache length T is folded into the program hash for this path, so the
-// whole remap is compile-time-constant arithmetic — no runtime arg):
-//   BC_SP               = sp (number of SP shards)
-//   BC_CHUNK_LOCAL      = chunk_local (rows one chunk writes into one shard = chunk_size_global / sp)
-//   BC_SHARD_STRIDE_GAP = shard_len - chunk_local : the physical buffer reserves shard_len (= T/sp) rows per
-//                         shard, so consecutive shards sit that much further apart than in natural order
-//                         (chunk_local) -> push shard s forward by shard*gap.
-//   BC_SLAB_STRIDE_GAP  = chunk_global - chunk_local = chunk_local*(sp-1) : consecutive chunks (slabs) are
-//                         chunk_global apart in natural order but only chunk_local apart physically -> pull
-//                         slab s back by slab*gap.
-// Sentinels (0xFFFFFFFF) never reach here — the reader only gathers the valid (< nv) prefix.
-
-// natural (logical) index n -> block-cyclic physical row (invP). See the file header for the layout
-// reasoning. Parameterized (rather than reading the BC_* defines directly) so other block-cyclic gather
-// kernels (e.g. the indexer) can reuse the same remap. All args are compile-time constants at the call
-// site, so this folds to one compile-time divide (mul+shift) + shift/mask.
-FORCE_INLINE uint32_t logical_to_chunked_physical(
-    uint32_t n, uint32_t chunk_local, uint32_t sp, uint32_t shard_stride_gap, uint32_t slab_stride_gap) {
-    const uint32_t block_idx = n / chunk_local;  // = slab*sp + shard (natural-order block index)
-    const uint32_t slab = block_idx / sp;
-    const uint32_t shard = block_idx - slab * sp;
-    return n + shard * shard_stride_gap - slab * slab_stride_gap;
+// Maps a natural KV index to its physical page in a shard-major, block-cyclic cache.
+template <uint32_t ChunkLocal, uint32_t Sp, uint32_t ShardStrideGap, uint32_t SlabStrideGap>
+FORCE_INLINE uint32_t logical_to_chunked_physical(uint32_t n) {
+    const uint32_t block_idx = n / ChunkLocal;
+    const uint32_t slab = block_idx / Sp;
+    const uint32_t shard = block_idx - slab * Sp;
+    return n + shard * ShardStrideGap - slab * SlabStrideGap;
 }
 
-template <typename Accessor>
+template <bool BlockCyclic, uint32_t ChunkLocal, uint32_t Sp, uint32_t ShardStrideGap, uint32_t SlabStrideGap>
+FORCE_INLINE uint32_t logical_to_physical_page(uint32_t page) {
+    if constexpr (BlockCyclic) {
+        return logical_to_chunked_physical<ChunkLocal, Sp, ShardStrideGap, SlabStrideGap>(page);
+    } else {
+        return page;
+    }
+}
+
+template <
+    bool BlockCyclic,
+    uint32_t ChunkLocal,
+    uint32_t Sp,
+    uint32_t ShardStrideGap,
+    uint32_t SlabStrideGap,
+    typename Accessor>
 FORCE_INLINE void trid_ring_gather(
     Noc& noc,
     const Accessor& kv,
@@ -71,12 +59,8 @@ FORCE_INLINE void trid_ring_gather(
             experimental::async_read_barrier_with_trid(noc, trid);  // free this trid slot before reuse
         }
         experimental::set_read_trid(noc, trid);
-        uint32_t page = idx_ptr[base + p];
-#ifdef BC_ENABLE
-        // natural index n -> block-cyclic physical row (invP). All terms compile-time (T is hashed), so this is
-        // one compile-time divide (mul+shift) + shift/mask. See the header comment for the layout reasoning.
-        page = logical_to_chunked_physical(page, BC_CHUNK_LOCAL, BC_SP, BC_SHARD_STRIDE_GAP, BC_SLAB_STRIDE_GAP);
-#endif
+        const uint32_t page =
+            logical_to_physical_page<BlockCyclic, ChunkLocal, Sp, ShardStrideGap, SlabStrideGap>(idx_ptr[base + p]);
         noc.async_read(kv, k_cb, k_row_bytes, {.page_id = page_offset + page}, {.offset_bytes = p * k_row_bytes});
     }
     const uint32_t to_drain = (cnt < D) ? cnt : D;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_reader.cpp
@@ -16,7 +16,7 @@
 #include <tt-metalium/constants.hpp>  // tt::constants::TILE_HEIGHT
 #include "api/dataflow/dataflow_api.h"
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
-#include "sparse_sdpa_gather.hpp"              // dual-NoC trid-ring gather helper (shared with the writer)
+#include "sparse_sdpa_gather.hpp"  // dual-NoC trid-ring gather helper (shared with the writer)
 
 constexpr uint32_t sentinel = 0xFFFFFFFFu;
 constexpr uint16_t neg_inf_bf16 = 0xFF80u;
@@ -40,10 +40,15 @@ void kernel_main() {
     constexpr uint32_t q_elem_bytes = get_compile_time_arg_val(10);    // bf16
     constexpr uint32_t kv_elem_bytes = get_compile_time_arg_val(11);   // bf16 or fp8_e4m3
     constexpr uint32_t idx_elem_bytes = get_compile_time_arg_val(12);  // uint32
+    constexpr bool block_cyclic = get_compile_time_arg_val(13) != 0;
+    constexpr uint32_t bc_chunk_local = get_compile_time_arg_val(14);
+    constexpr uint32_t bc_sp = get_compile_time_arg_val(15);
+    constexpr uint32_t bc_shard_stride_gap = get_compile_time_arg_val(16);
+    constexpr uint32_t bc_slab_stride_gap = get_compile_time_arg_val(17);
 
     // kv carries a RUNTIME tensor shape (its T dim is common runtime args, not compile-time), so its accessor
     // spans both the compile-time AND common-runtime arg streams. Thread both offsets through all three.
-    constexpr auto q_args = TensorAccessorArgs<13, 0>();
+    constexpr auto q_args = TensorAccessorArgs<18, 0>();
     constexpr auto kv_args =
         TensorAccessorArgs<q_args.next_compile_time_args_offset(), q_args.next_common_runtime_args_offset()>();
     constexpr auto idx_args =
@@ -56,8 +61,6 @@ void kernel_main() {
     const uint32_t tok_count = get_arg_val<uint32_t>(4);
     // Indexed KV cache: page offset (cache_batch_idx * T) selecting the cache's batch slot; 0 if not indexed.
     const uint32_t kv_batch_page_offset = get_arg_val<uint32_t>(5);
-    // Block-cyclic remap (BC_ENABLE): all its constants are compile-time defines (the cache length T is hashed
-    // for this path), so there is no runtime arg to read here. See sparse_sdpa_gather.hpp for the remap.
 
     constexpr uint32_t q_row_bytes = k_dim * q_elem_bytes;     // Q row (bf16)
     constexpr uint32_t k_row_bytes = k_dim * kv_elem_bytes;    // K row (native dtype: fp8 or bf16)
@@ -137,8 +140,9 @@ void kernel_main() {
                 }
                 kreq_cb.push_back(1);
                 // Reader gathers its half [half, valid) on its NoC (depth-4 trid ring, shared helper).
-                sparse_sdpa::trid_ring_gather(
-                    noc, kv, k_cb, idx_ptr, base, half, valid, k_row_bytes, kv_batch_page_offset);
+                sparse_sdpa::
+                    trid_ring_gather<block_cyclic, bc_chunk_local, bc_sp, bc_shard_stride_gap, bc_slab_stride_gap>(
+                        noc, kv, k_cb, idx_ptr, base, half, valid, k_row_bytes, kv_batch_page_offset);
                 kack_cb.wait_front(1);  // writer's half landed in cb_k_rm L1
                 kack_cb.pop_front(1);
                 // Zero-fill the sentinel suffix: masked-key scores become a defined 0 (compute adds -inf).

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_writer.cpp
@@ -30,7 +30,12 @@ void kernel_main() {
     constexpr uint32_t cb_col_identity = get_compile_time_arg_val(5);
     constexpr uint32_t cb_neginf = get_compile_time_arg_val(6);
     constexpr uint32_t out_elem_bytes = get_compile_time_arg_val(7);  // bf16 (from the output tensor's dtype)
-    constexpr auto out_args = TensorAccessorArgs<8, 0>();
+    constexpr bool block_cyclic = get_compile_time_arg_val(8) != 0;
+    constexpr uint32_t bc_chunk_local = get_compile_time_arg_val(9);
+    constexpr uint32_t bc_sp = get_compile_time_arg_val(10);
+    constexpr uint32_t bc_shard_stride_gap = get_compile_time_arg_val(11);
+    constexpr uint32_t bc_slab_stride_gap = get_compile_time_arg_val(12);
+    constexpr auto out_args = TensorAccessorArgs<13, 0>();
     // kv carries a RUNTIME tensor shape (T dim in common runtime args), so its accessor spans both arg streams.
     constexpr auto kv_args =
         TensorAccessorArgs<out_args.next_compile_time_args_offset(), out_args.next_common_runtime_args_offset()>();
@@ -41,8 +46,6 @@ void kernel_main() {
     const uint32_t kv_addr = get_arg_val<uint32_t>(3);  // dual-NoC K-half gather
     // Indexed KV cache: page offset (cache_batch_idx * T) selecting the cache's batch slot; 0 if not indexed.
     const uint32_t kv_batch_page_offset = get_arg_val<uint32_t>(4);
-    // Block-cyclic remap (BC_ENABLE): all its constants are compile-time defines (the cache length T is hashed
-    // for this path) — no runtime arg here. See sparse_sdpa_gather.hpp for the remap.
 
     constexpr uint32_t row_bytes = vDHt * tt::constants::TILE_WIDTH * out_elem_bytes;  // V_DIM bytes per head-row
     constexpr uint32_t block_tiles = (H / tt::constants::TILE_HEIGHT) * vDHt;          // Sqt*vDHt: the [H,V_DIM] block
@@ -100,7 +103,8 @@ void kernel_main() {
             }
             kreq_cb.pop_front(1);
             // Writer gathers its half [0, half) on its NoC (depth-4 trid ring, shared helper).
-            sparse_sdpa::trid_ring_gather(noc, kv, k_cb, idx_ptr, base, 0, half, k_row_bytes, kv_batch_page_offset);
+            sparse_sdpa::trid_ring_gather<block_cyclic, bc_chunk_local, bc_sp, bc_shard_stride_gap, bc_slab_stride_gap>(
+                noc, kv, k_cb, idx_ptr, base, 0, half, k_row_bytes, kv_batch_page_offset);
             kack_cb.reserve_back(1);
             kack_cb.push_back(1);
         }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.cpp
@@ -208,17 +208,16 @@ ttsl::hash::hash_t SparseSDPAOperation::compute_program_hash(const SparseSDPAPar
         // kv.memory_config(): an ND-sharded kv produces different TensorAccessor compile-time args than an
         // interleaved one, so they must be distinct programs.
         t.kv.memory_config(),
-        // kv.logical_shape() when sharded (see above) OR block-cyclic: the block-cyclic remap bakes BC_SHARD_STRIDE_GAP
-        // (= T/sp - chunk_local) as a compile-time define, so the cache length T must be in the hash (a
+        // kv.logical_shape() when sharded (see above) OR block-cyclic: the block-cyclic remap bakes its
+        // T-dependent stride gap as a compile-time argument, so the cache length T must be in the hash (a
         // different cache size is a distinct program). A plain interleaved kv keeps T out of the hash (sentinel
         // shape) so changing T does not recompile.
         (t.kv.memory_config().is_sharded() || attrs.has_block_cyclic()) ? t.kv.logical_shape() : tt::tt_metal::Shape{},
         // Only whether kv is indexed (not which slot): cache_batch_idx's VALUE is a dynamic runtime arg
         // (see get_dynamic_runtime_args), so indexing into a different slot reuses the same program.
         attrs.has_indexed_kv_cache(),
-        // Block-cyclic remap: enable gates a compile-time #ifdef; sp, chunk_local and the two T-derived stride
-        // gaps are ALL compile-time defines (so distinct sp/chunk_local/cache-size are distinct programs — T is
-        // hashed above). No runtime remap arg.
+        // Block-cyclic remap configuration is compile-time; distinct sp/chunk_local/cache-size values produce
+        // distinct programs (T is hashed above). No runtime remap arg.
         attrs.has_block_cyclic(),
         attrs.block_cyclic.has_value() ? attrs.block_cyclic->sp : 0u,
         attrs.block_cyclic.has_value() ? attrs.block_cyclic->chunk_local : 0u,
@@ -234,8 +233,7 @@ std::vector<tt::tt_metal::DynamicRuntimeArg> SparseSDPAOperation::get_dynamic_ru
     // kv_batch_page_offset = cache_batch_idx*T depends on the runtime SLOT (and T, which is NOT hashed for an
     // interleaved kv), so the same program is reused across slots/T — create_descriptor bakes it at build time
     // and on a program-cache HIT it would be STALE, so re-apply it from the current slot/T every dispatch. The
-    // block-cyclic remap needs NOTHING here: all its constants are compile-time defines (T is hashed for that
-    // path, so a different cache size is a different program). Non-indexed programs have nothing to re-apply.
+    // Block-cyclic remap configuration is compile-time, so only indexed programs need dynamic patching.
     const bool indexed = attrs.has_indexed_kv_cache();
     if (!indexed) {
         return {};

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.hpp
@@ -21,8 +21,7 @@ namespace ttnn::prim {
 // args in create_descriptor) and get_dynamic_runtime_args (which RE-APPLIES the indexed-cache page offset to
 // the cached program). kv_batch_page_offset sits at the fixed index below and is the only re-applied arg. If
 // the order before kv_batch_page_offset changes in the factory, update these indices here, or the dynamic
-// re-apply silently writes the wrong slot. (The block-cyclic remap constants are all compile-time defines, with
-// the cache length T folded into the program hash, so there is no block-cyclic runtime arg to track.)
+// re-apply silently writes the wrong slot. Block-cyclic remap configuration is compile-time.
 namespace sparse_sdpa_rt {
 inline constexpr uint32_t kReaderKernelIdx = 0;
 inline constexpr uint32_t kWriterKernelIdx = 1;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation_types.hpp
@@ -16,10 +16,8 @@ namespace ttnn::prim {
 // id on the fly (invP, the inverse of the cache writer's blockcyclic_positions), so the host does NOT have to
 // reorder the kv buffer back to natural order before the op.
 //
-// Both fields are resolved+validated at the ttnn entry (ttnn::transformer::sparse_sdpa): `sp` is read from the
-// mesh axis the cache was striped over (so the caller cannot pass an sp that disagrees with the device), and
-// `chunk_local` is cross-checked against q's per-chip seq length. `sp` is folded into the program hash here
-// (BC_SP is a compile-time define), so it must be the resolved value, not a mesh axis index.
+// `sp` is resolved from the cache's mesh axis and `chunk_local` is cross-checked against q's local sequence length
+// at the ttnn entry. Both are compile-time kernel arguments, so `sp` is the resolved shard count, not a mesh axis.
 struct BlockCyclicLayout {
     uint32_t sp;           // SP shard count the cache was written across (resolved from the mesh)
     uint32_t chunk_local;  // per-shard chunk length (chunk_size_global / sp == per-chip seq_len_local)
@@ -36,10 +34,7 @@ struct SparseSDPAParams {
     // (excluded from the program hash, re-applied every dispatch), so changing it does NOT recompile.
     std::optional<uint32_t> cache_batch_idx = std::nullopt;
     bool has_indexed_kv_cache() const { return cache_batch_idx.has_value(); }
-    // Block-cyclic index remap (see BlockCyclicLayout). Fully compile-time: the enable bit, sp, chunk_local,
-    // and the T-derived BC_SHARD_STRIDE_GAP (= T/sp - chunk_local) are all program defines, and the cache length T is
-    // folded into the hash for this path — so a different cache size is a distinct program (no runtime remap
-    // arg). Assumes a consistent-size preallocated cache (per-size recompile, once, is acceptable).
+    // The remap configuration is compile-time; T is part of the program hash for this path.
     std::optional<BlockCyclicLayout> block_cyclic = std::nullopt;
     bool has_block_cyclic() const { return block_cyclic.has_value(); }
 };

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_program_factory.cpp
@@ -9,6 +9,7 @@
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <array>
 #include <bit>
 #include <map>
 #include <string>
@@ -145,6 +146,24 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
     reader_ct.push_back(q_elem_bytes);
     reader_ct.push_back(kv_elem_bytes);
     reader_ct.push_back(idx_elem_bytes);
+    // The cache layout is compile-time so the remap is fully optimized out for natural-order KV.
+    const auto block_cyclic_ct = [&attrs, &t]() {
+        std::array<uint32_t, 5> args{0, 1, 1, 0, 0};
+        if (!attrs.has_block_cyclic()) {
+            return args;
+        }
+        const auto& bc = attrs.block_cyclic.value();
+        const uint32_t seq_len_local = t.kv.logical_shape()[2] / bc.sp;
+        args = {
+            1,
+            bc.chunk_local,
+            bc.sp,
+            seq_len_local - bc.chunk_local,
+            bc.chunk_local * (bc.sp - 1),
+        };
+        return args;
+    }();
+    reader_ct.insert(reader_ct.end(), block_cyclic_ct.begin(), block_cyclic_ct.end());
     // kv (the K cache) uses a RUNTIME tensor shape: its T dimension (the cache length) is passed as common
     // runtime args, NOT compile-time args, so changing T reuses the same program (no recompile). q/indices
     // stay compile-time — their dims define the program. The accessor's runtime metadata is the same on
@@ -157,6 +176,7 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
 
     // The writer is the lighter dataflow kernel, so it builds the three persistent compute-input tiles.
     std::vector<uint32_t> writer_ct = {H, S, vDHt, cb_out_rm, cb_scale, cb_col_identity, cb_neginf, out_elem_bytes};
+    writer_ct.insert(writer_ct.end(), block_cyclic_ct.begin(), block_cyclic_ct.end());
     std::vector<uint32_t> writer_crt;
     tt::tt_metal::TensorAccessorArgs(output.buffer()).append_to(writer_ct, writer_crt);
     tt::tt_metal::TensorAccessorArgs(t.kv.buffer(), tensor_accessor::ArgConfig::RuntimeTensorShape)
@@ -197,30 +217,9 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
     reader_desc.compile_time_args = reader_ct;
     reader_desc.common_runtime_args = reader_crt;  // kv runtime tensor-shape metadata (same on every core)
     reader_desc.config = tt::tt_metal::ReaderConfigDescriptor{};
-    // Dual-NoC K gather: reader + writer each gather half the rows on their own NoC. The new CB ids are
-    // passed as defines (kept off the positional compile-arg blocks, which the kernels index tightly).
-    // Gate the natural->block-cyclic page-id remap (see sparse_sdpa_gather.hpp). The reader and writer take the
-    // SAME defines, so one helper populates both to keep them in lockstep. ALL constants are compile-time (the
-    // cache length T is folded into the program hash for this path), so the remap is one mul+shift divide +
-    // shift/mask. Stride gaps: BC_SHARD_STRIDE_GAP = T/sp - chunk_local (= shard_len - chunk_local);
-    // BC_SLAB_STRIDE_GAP = chunk_local*(sp-1).
-    const auto add_bc_defines = [&attrs, &t](std::map<std::string, std::string>& defs) {
-        if (!attrs.has_block_cyclic()) {
-            return;
-        }
-        const uint32_t bc_sp = attrs.block_cyclic->sp;
-        const uint32_t bc_chunk_local = attrs.block_cyclic->chunk_local;
-        const uint32_t bc_seq_len_local = t.kv.logical_shape()[2] / bc_sp;
-        defs["BC_ENABLE"] = "1";
-        defs["BC_CHUNK_LOCAL"] = std::to_string(bc_chunk_local);
-        defs["BC_SP"] = std::to_string(bc_sp);
-        defs["BC_SLAB_STRIDE_GAP"] = std::to_string(bc_chunk_local * (bc_sp - 1));
-        defs["BC_SHARD_STRIDE_GAP"] = std::to_string(bc_seq_len_local - bc_chunk_local);
-    };
     {
         std::map<std::string, std::string> rdefs{
             {"CB_KREQ", std::to_string(cb_kreq)}, {"CB_KACK", std::to_string(cb_kack)}};
-        add_bc_defines(rdefs);
         reader_desc.defines = tt::tt_metal::KernelDescriptor::Defines(rdefs.begin(), rdefs.end());
     }
 
@@ -239,7 +238,6 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
             {"CB_IDX", std::to_string(cb_idx)},
             {"K_DIM", std::to_string(k_dim)},
             {"KV_ELEM_BYTES", std::to_string(kv_elem_bytes)}};
-        add_bc_defines(wdefs);  // same block-cyclic remap defines as the reader
         writer_desc.defines = tt::tt_metal::KernelDescriptor::Defines(wdefs.begin(), wdefs.end());
     }
 
@@ -299,8 +297,6 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
     // (so changing the slot doesn't recompile). 0 when not indexed (kv is a single [1,1,T,K_DIM] cache).
     const uint32_t kv_T = t.kv.logical_shape()[2];
     const uint32_t kv_batch_page_offset = attrs.cache_batch_idx.value_or(0) * kv_T;
-    // Block-cyclic remap needs NO runtime arg: all its constants are compile-time defines (the cache length T
-    // is hashed for the block-cyclic path; see the define blocks above).
     for (uint32_t i = 0; i < num_cores; ++i) {
         tt::tt_metal::CoreCoord core = {i % grid.x, i / grid.x};
         uint32_t tok_start = i * base + std::min(i, extra);


### PR DESCRIPTION
## Summary
- replace block-cyclic kernel macros with compile-time arguments and `if constexpr` specializations
- remove per-op runtime remap constants and avoid the dead non-BC page store
- apply the same compile-time remap treatment to experimental `indexer_score`
- keep the small kernel remap helpers local to their operations

## Validation
- `./build_metal.sh --release`
- focused sparse SDPA and indexer_score tests locally: 2 passed; multi-device cases skipped because this host has one Blackhole device
- Blackhole L2 (`sdpa,experimental`) and Blackhole sanity workflows dispatched

Related: #48428, #48772

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/sparse-sdpa-bc-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/sparse-sdpa-bc-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/sparse-sdpa-bc-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/sparse-sdpa-bc-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pjosipovic/sparse-sdpa-bc-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pjosipovic/sparse-sdpa-bc-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/sparse-sdpa-bc-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/sparse-sdpa-bc-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/sparse-sdpa-bc-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/sparse-sdpa-bc-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/sparse-sdpa-bc-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/sparse-sdpa-bc-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/sparse-sdpa-bc-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/sparse-sdpa-bc-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/sparse-sdpa-bc-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/sparse-sdpa-bc-cleanup)