### PR TITLE
[LLK][Cleanup] Convert bcast circular buffer indices to template params

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/compute/bcast_h.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/bcast_h.cpp
@@ -10,7 +10,7 @@ void kernel_main() {
     uint32_t B = get_arg_val<uint32_t>(0);
     uint32_t Ht = get_arg_val<uint32_t>(1);
     uint32_t Wt = get_arg_val<uint32_t>(2);
-    init_bcast<BCAST_LLKOP, BCAST_DIM>(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
+    init_bcast<BCAST_LLKOP, BCAST_DIM, tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16>();
 
     for (uint32_t b = 0; b < B; b++) {
         for (uint32_t h = 0; h < Ht; h++) {

--- a/tests/tt_metal/tt_metal/test_kernels/compute/bcast_hw.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/bcast_hw.cpp
@@ -11,7 +11,7 @@ void kernel_main() {
     uint32_t B = get_arg_val<uint32_t>(0);
     uint32_t Ht = get_arg_val<uint32_t>(1);
     uint32_t Wt = get_arg_val<uint32_t>(2);
-    init_bcast<BCAST_LLKOP, BCAST_DIM>(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
+    init_bcast<BCAST_LLKOP, BCAST_DIM, tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16>();
 
 #ifdef BCAST_SCALAR
     cb_wait_front(tt::CBIndex::c_1, onetile);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/bcast_w.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/bcast_w.cpp
@@ -13,7 +13,7 @@ void kernel_main() {
     uint32_t Ht = get_arg_val<uint32_t>(1);
     uint32_t Wt = get_arg_val<uint32_t>(2);
 
-    init_bcast<BCAST_LLKOP, BCAST_DIM>(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
+    init_bcast<BCAST_LLKOP, BCAST_DIM, tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16>();
 
     for (uint32_t b = 0; b < B; b++) {
         for (uint32_t h = 0; h < Ht; h++) {

--- a/tests/tt_metal/tt_metal/test_kernels/compute/broadcast_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/broadcast_2_0.cpp
@@ -22,7 +22,7 @@ void kernel_main() {
     constexpr uint32_t ocb = dfb::out;
 
 #ifndef BCAST_OP_INIT
-    init_bcast<BCAST_LLKOP, BCAST_DIM>(icb0, icb1, ocb);
+    init_bcast<BCAST_LLKOP, BCAST_DIM, icb0, icb1, ocb>();
 #else
     binary_op_init_common(icb0, icb1, ocb);
     BCAST_OP_INIT(icb0, icb1);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/compute_kernel_sentinel.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/compute_kernel_sentinel.cpp
@@ -52,7 +52,7 @@ void kernel_main() {
     matmul_block_init(cb_in0, cb_in1);
     ASSERT(TEST_RECONFIG_CALLS(RECONFIG_CHANGED_SRCA | RECONFIG_CHANGED_SRCB | RECONFIG_CHANGED_PACK));
 
-    init_bcast<EltwiseBinaryType::ELWADD, BroadcastType::NONE>(cb_in2, cb_in1, cb_out1);
+    init_bcast<EltwiseBinaryType::ELWADD, BroadcastType::NONE, cb_in2, cb_in1, cb_out1>();
     ASSERT(TEST_RECONFIG_CALLS(RECONFIG_CHANGED_SRCA | RECONFIG_CHANGED_SRCB | RECONFIG_CHANGED_PACK));
 
     add_bcast_rows_init_short(cb_in1, cb_in2);

--- a/tt_metal/hw/inc/api/compute/bcast.h
+++ b/tt_metal/hw/inc/api/compute/bcast.h
@@ -338,6 +338,27 @@ void init_bcast(uint32_t icb0, uint32_t icb1, uint32_t ocb, uint32_t call_line =
 #endif
 }
 
+// clang-format off
+/**
+ * Compile-time circular-buffer overload of *init_bcast*. The input and output circular-buffer
+ * identifiers are supplied as non-type template parameters instead of runtime arguments, so they
+ * are constant-folded at the call site. Forwards to the runtime overload above; behaviour is
+ * otherwise identical.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                   | Type          | Valid Range | Required |
+ * |----------------|---------------------------------------------------------------|---------------|-------------|----------|
+ * | icb0           | The identifier of the circular buffer (CB) containing A       | uint32_t      | 0 to 31     | True     |
+ * | icb1           | The identifier of the circular buffer (CB) containing B       | uint32_t      | 0 to 31     | True     |
+ * | ocb            | The identifier of the circular buffer (CB) containing output  | uint32_t      | 0 to 31     | False    |
+ */
+// clang-format on
+template <EltwiseBinaryType tBcastOp, BroadcastType tBcastDim, uint32_t icb0, uint32_t icb1, uint32_t ocb>
+void init_bcast(uint32_t call_line = __builtin_LINE()) {
+    init_bcast<tBcastOp, tBcastDim>(icb0, icb1, ocb, call_line);
+}
+
 /*
 Internal helper function for all broadcast ops
 */

--- a/ttnn/cpp/ttnn/kernel/compute/bmm_tilize_untilize.cpp
+++ b/ttnn/cpp/ttnn/kernel/compute/bmm_tilize_untilize.cpp
@@ -135,7 +135,7 @@ void kernel_main() {
     uint32_t bias_ntiles_w = get_compile_time_arg_val(16);
     constexpr uint32_t bias_cb_id = tt::CBIndex::c_2;
     constexpr uint32_t out_for_bias_cb_id = tt::CBIndex::c_28;
-    init_bcast<EltwiseBinaryType::ELWADD, BroadcastType::ROW>(out_for_bias_cb_id, bias_cb_id, out_cb_id);
+    init_bcast<EltwiseBinaryType::ELWADD, BroadcastType::ROW, out_for_bias_cb_id, bias_cb_id, out_cb_id>();
 #endif
 
     compute_kernel_hw_startup<SrcOrder::Reverse>(in0_cb_id, in1_cb_id, out_cb_id);

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_h.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_h.cpp
@@ -19,7 +19,7 @@ void kernel_main() {
     uint32_t B = get_arg_val<uint32_t>(0);
     uint32_t Ht = get_arg_val<uint32_t>(1);
     uint32_t Wt = get_arg_val<uint32_t>(2);
-    init_bcast<BCAST_LLKOP, BCAST_DIM>(cb_a_id, cb_b_id, cb_out_id);
+    init_bcast<BCAST_LLKOP, BCAST_DIM, cb_a_id, cb_b_id, cb_out_id>();
 
     for (uint32_t b = 0; b < B; b++) {
         for (uint32_t h = 0; h < Ht; h++) {

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_h_sharded_optimised.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_h_sharded_optimised.cpp
@@ -23,7 +23,7 @@ void kernel_main() {
     uint32_t batch_b = get_arg_val<uint32_t>(4);
     uint32_t Ht_per_batch_b = get_arg_val<uint32_t>(5);
 
-    init_bcast<BCAST_LLKOP, BCAST_DIM>(cb_a_id, cb_b_id, cb_out_id);
+    init_bcast<BCAST_LLKOP, BCAST_DIM, cb_a_id, cb_b_id, cb_out_id>();
 
     cb_a.wait_front(Wt * Ht);
     cb_out.reserve_back(Wt * Ht);

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_hw.cpp
@@ -20,7 +20,7 @@ void kernel_main() {
     uint32_t B = get_arg_val<uint32_t>(0);
     uint32_t Ht = get_arg_val<uint32_t>(1);
     uint32_t Wt = get_arg_val<uint32_t>(2);
-    init_bcast<BCAST_LLKOP, BCAST_DIM>(cb_a_id, cb_b_id, cb_out_id);
+    init_bcast<BCAST_LLKOP, BCAST_DIM, cb_a_id, cb_b_id, cb_out_id>();
 
 #ifdef BCAST_SCALAR
     cb_b.wait_front(onetile);

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_w.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_w.cpp
@@ -22,7 +22,7 @@ void kernel_main() {
     uint32_t Ht = get_arg_val<uint32_t>(1);
     uint32_t Wt = get_arg_val<uint32_t>(2);
 
-    init_bcast<BCAST_LLKOP, BCAST_DIM>(cb_a_id, cb_b_id, cb_out_id);
+    init_bcast<BCAST_LLKOP, BCAST_DIM, cb_a_id, cb_b_id, cb_out_id>();
 
     for (uint32_t b = 0; b < B; b++) {
         for (uint32_t h = 0; h < Ht; h++) {

--- a/ttnn/cpp/ttnn/operations/experimental/multi_scale_deformable_attn/device/kernels/compute/msda_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/multi_scale_deformable_attn/device/kernels/compute/msda_compute.cpp
@@ -41,7 +41,7 @@ void kernel_main() {
     CircularBuffer scalar_cb(scalar_cb_index);
     CircularBuffer output_cb(output_cb_index);
 
-    init_bcast<EltwiseBinaryType::ELWMUL, BroadcastType::COL>(input_cb_index, scalar_cb_index, output_cb_index);
+    init_bcast<EltwiseBinaryType::ELWMUL, BroadcastType::COL, input_cb_index, scalar_cb_index, output_cb_index>();
 
     for (uint32_t out = 0; out < num_output_tiles; ++out) {
         // Reserve one output tile slot; we accumulate into it via L1 acc.

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/kernels/deepseek_moe_fast_reduce_nc_fused_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/device/kernels/deepseek_moe_fast_reduce_nc_fused_compute.cpp
@@ -41,8 +41,12 @@ void kernel_main() {
     constexpr uint32_t num_input_tiles_iter = reduction_dim_size / input_granularity;
 
     // Full PACK + UNPACK + hw_configure init for ELWMUL + COL-broadcast
-    init_bcast<EltwiseBinaryType::ELWMUL, BroadcastType::COL>(
-        compute_input_cb_id_0, compute_input_cb_id_1, compute_output_cb_id);
+    init_bcast<
+        EltwiseBinaryType::ELWMUL,
+        BroadcastType::COL,
+        compute_input_cb_id_0,
+        compute_input_cb_id_1,
+        compute_output_cb_id>();
 
     // Override MATH init to enable acc_to_dest=1 (hardware accumulate mode)
     // This makes each mul_tiles_bcast_cols call do: dst0 += act * score  (MAC)

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/kernels/moreh_dot_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/device/kernels/moreh_dot_backward.cpp
@@ -17,7 +17,7 @@ void kernel_main() {
     DataflowBuffer dfb_c16(tt::CBIndex::c_16);
     DataflowBuffer dfb_c17(tt::CBIndex::c_17);
 
-    init_bcast<EltwiseBinaryType::ELWMUL, BroadcastType::SCALAR>(tt::CBIndex::c_2, tt::CBIndex::c_0, tt::CBIndex::c_16);
+    init_bcast<EltwiseBinaryType::ELWMUL, BroadcastType::SCALAR, tt::CBIndex::c_2, tt::CBIndex::c_0, tt::CBIndex::c_16>();
     dfb_c0.wait_front(onetile);
     for (uint32_t block = 0; block < per_core_block_cnt; ++block) {
         if (has_input_grad) {


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

Circular buffer indices are known at compile time but were being passed to LLK broadcast APIs as runtime function arguments, adding unnecessary overhead. `init_bcast` in tt_metal/hw/inc/api/compute/bcast.h now takes the icb0, icb1, and ocb circular buffer indices as template parameters instead of runtime arguments, so the compiler can resolve them statically. All callers of this API across the bcast test kernels, ttnn bcast/tilize/reduction/moreh kernels, and the msda compute kernel were updated to pass the CB indices as template arguments.

Fixes #16974

### Notes for reviewers

Check that every call site consistently moved the CB indices from function arguments to the template parameter list and that no caller still passes them at runtime; this only covers init_bcast, not the other LLK APIs listed in the issue.

Diffstat: 14 files changed, 39 insertions(+), 14 deletions(-).

<sub>Opened by the LLK issue-triage board (AI-assisted, draft) — please review the diff before merging.</sub>

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-16974-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llk_code_gen/issue-16974-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-16974-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llk_code_gen/issue-16974-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-16974-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:llk_code_gen/issue-16974-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llk_code_gen/issue-16974-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llk_code_gen/issue-16974-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llk_code_gen/issue-16974-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llk_code_gen/issue-16974-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llk_code_gen/issue-16974-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llk_code_gen/issue-16974-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llk_code_gen/issue-16974-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llk_code_gen/issue-16974-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llk_code_gen/issue-16974-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llk_code_gen/issue-16974-v1)