### PR TITLE
Qwen3.6-27B TP: decode-drift investigation + paged SDPA-decode fix

### DIFF
--- a/models/demos/blackhole/qwen36/docs/decode_drift_fix_design.md
+++ b/models/demos/blackhole/qwen36/docs/decode_drift_fix_design.md
@@ -1,0 +1,305 @@
+# Qwen3.6-27B decode-drift — Fix Design
+
+Companion to `qwen36_decode_drift_investigation.md`. Root cause: the GDN **chunk (prefill)** and
+**recurrent (decode)** kernels diverge, growing with recurrence length; the divergence propagates and
+compounds across the 64-layer hybrid stack → long-generation reasoning drift.
+
+**Leverage point:** the attention SDPA-decode op is clean (0.9998); its per-layer decode divergence
+comes from an already-diverged *input* hidden state fed from upstream GDN layers. So **stopping the GDN
+state from drifting also stops most of the attention-side compounding.** Fixing GDN is the high-leverage
+move.
+
+---
+
+## 0. Decisive branch: chunk-vs-torch (do this first — cheap)
+
+We know `recurrent ≈ torch` (0.9998). We have **not** measured `chunk ≈ torch`. This one number
+splits the whole design:
+
+- **If chunk-vs-torch is also ~0.999** → both kernels are individually accurate; the divergence is a
+  benign fp32 reformulation gap and the *only* issue is that decode uses a different path than the one
+  the network reasons under. → Fix = **path consistency** (Option A/B below).
+- **If chunk-vs-torch is low (~0.97)** → the **chunk (prefill) kernel is under-precise** and is the real
+  culprit; HF (which also does chunk-prefill + recurrent-decode and gets ~90%) simply has a tighter
+  kernel. → Fix = **chunk-kernel precision** (Option C), a smaller and more upstream-mergeable change.
+
+Add a torch-reference arm to `test_gdn_chunk_vs_rec.py` (replicate qkvz/ab projections + FIR conv +
+gated-delta recurrence in fp32 torch on the same `x`, compare BOTH kernels to it). ~1 device run.
+Also worth: the GPU/llama.cpp reference (deferred option B) confirms "model+recurrence is fine at 90%",
+independently pointing at TT kernel precision.
+
+---
+
+## Option A — Periodic state re-sync (pragmatic serving fix)
+
+Every `N` decode steps, re-run the **chunk** kernel over the accumulated tokens (prompt + generated so
+far) and overwrite the recurrent GDN state with the chunk result. Bounds the chunk-vs-recurrent
+divergence to `N` steps' worth instead of letting it grow unboundedly.
+
+- **Effort:** medium. Reuse `forward_prefill(capture_state=True)` over a growing window; wire a
+  step counter in `decode_tp_batched` / the vLLM decode contract; handle the KV/conv state refresh.
+- **Cost:** one chunk-prefill every `N` steps. At `N=32` and prefill ≈ a few ms/token amortized, this
+  is a modest throughput hit, tunable. Sliding-window (last `W` tokens) caps cost for long contexts.
+- **Risk:** medium — must keep the refresh trace-safe (chunk-prefill inside/around the decode trace),
+  and per-slot for B>1 continuous batching.
+- **Expected gain:** directly bounds the dominant divergence; should recover most of the GSM8K gap if
+  the recurrence is the compounding source (as measured). Accuracy/speed knob via `N`.
+- **Best when:** chunk-vs-torch is good (path-consistency problem, not kernel precision).
+
+## Option B — Decode via chunk kernel (correctness ceiling, slow)
+
+Run every decode step through the chunk kernel over the full sequence (= `test_prefill_gen`, which
+reasons correctly). This is Option A with `N=1`.
+
+- **Effort:** low (already validated as correct offline).
+- **Cost:** O(T) per step — prohibitive for real serving; useful as the **accuracy oracle** and as the
+  `N→1` limit to bound how much Option A can recover.
+- **Use:** benchmark target, not a shipping path.
+
+## Option C — Chunk-kernel precision alignment (proper upstream fix)
+
+If §0 shows the chunk kernel is the under-precise one, fix it in the upstream C++ op
+(`ttnn/cpp/.../transformer/gated_delta_attn/`): higher-precision accumulation / accumulation order that
+matches the sequential recurrence, or fp32 dest-acc where it currently rounds.
+
+- **Effort:** high (C++ kernel + rebuild + PCC re-validation).
+- **Risk:** medium; upstream-shared op, affects prefill everywhere.
+- **Expected gain:** fixes the root without a per-step runtime cost; most upstream-mergeable.
+- **Best when:** chunk-vs-torch is low.
+
+## Option D — Do nothing to numerics; ship with flat-norm + document (status quo)
+
+Keep the current flat-norm mitigation (already the best of the tested norm schemes), document the
+long-CoT limitation, and rely on sampling to avoid loops for chat-style use. The fused-decode PRs are
+accuracy-neutral and unaffected.
+
+- **Use:** if the target workloads are short-form (chat, recall, short answers) where the drift does
+  not bite, and the multi-step-reasoning gap is acceptable for now.
+
+---
+
+## Results (executed 2026-07-12)
+
+- **§0 chunk-vs-torch:** `recurrent_vs_torch = 0.99998` (flat over all positions),
+  `chunk_vs_torch = 0.988`. → The **chunk (prefill) kernel is the under-precise path**; the recurrent
+  (decode) kernel is near-exact. Root cause reframed: prefill builds context in a slightly-off
+  "chunk-space" (0.988); prefill-gen reasons correctly because it stays entirely in chunk-space; real
+  decode continues that chunk-space context with the accurate recurrent kernel → **space mismatch**.
+- **Option C cheap probe (matmul HiFi4):** the chunk gap is **not** matmul fidelity. Inputs to the C++
+  `gated_delta_attn_seq` op are already fp32; raising the python wrapper matmuls to HiFi4 → no change;
+  changing the compute-kernel fidelity in `gated_delta_attn_program_factory.cpp:170` (HiFi2→HiFi4) and
+  rebuilding → `chunk_vs_torch` 0.98884 → **0.98887 (no change)**. The 0.988 gap is **structural** in
+  the chunk-parallel formulation (the `L_inv` matrix-inverse / chunk decomposition, or bf16 CB
+  intermediates inside the C++ kernel), **not a one-line fidelity knob**.
+
+→ **Option C is NOT the cheap upstream fix originally hoped for.** It needs deep C++ kernel work
+(CB data formats or the chunk-decomposition numerics) with uncertain payoff.
+
+## Option A — VALIDATED (2026-07-12)
+
+`test_decode_resync.py`: every `N` generated tokens, re-prefill the whole sequence-so-far
+(`prefill_seed_tp` rebuilds attention KV cache + GDN state in chunk-space, `finalize_seed`); recurrent
+decode between re-syncs. Janet problem (correct = $18):
+
+| mode | reaches $18 | behavior |
+|---|---|---|
+| pure decode (N=∞) | ✗ | confabulates numbers (16→14→12), drifts |
+| re-sync N=8 | ✗ | numbers now correct (16/3/4/$2) but loops, no answer in budget |
+| **re-sync N=4** | **✓** | correct reasoning, reaches $18 |
+
+→ Confirmed at the generation level (not just the prefill-gen oracle): keeping decode in chunk-space
+restores reasoning. The sensitivity is steep — the recurrent state diverges enough to loop within ~8
+tokens, so `N=4` was needed here. Cost is correspondingly high (re-prefill ≈ every 4 tokens, O(L) each).
+
+**Multi-problem eval (`test_resync_eval.py`, 3 GSM8K, greedy):** the single-problem win did NOT
+generalize cleanly. With max_new=200: pure 1/3, N4_full 1/3 (recovers Janet=18), N4_win64 1/3 (loses
+Janet). Each config solves a *different* single problem → variance, not systematic gain. Throughput
+(eager decode baseline ~5 tok/s): N4_full ≈ 3.0, N4_win64 ≈ 3.5 tok/s (re-sync ~halves eager decode;
+window slightly cheaper but no accuracy gain). A ceiling run (N=1 oracle, N=2) at max_new=120 returned
+0/3 but was **confounded by truncation** — Janet at N=1 showed correct on-track numbers (16,3,4,…) cut
+off before reaching 18. **Caveats:** the eval is noisy — fragile last-3-numbers answer extraction, no
+EOS (models ramble to the token cap), and token caps that truncate the ~150–200-token CoT these
+problems need. So Option A's multi-problem benefit is **neither proven nor refuted** here; only the
+qualitative Janet recovery (confabulation → correct reasoning under N=4) is solid.
+
+**Rigorous eval + confound (test_gsm8k_resync.py, 0-shot, 12 GSM8K):** first pass (thinking mode,
+480-tok budget) gave pure 0/12, N4_full 1/12, N4_win64 1/12 — but ALL 36 generations hit the token cap
+with **no EOS**: Qwen3.6 is a *thinking* model, its `<think>` chain doesn't finish in 480 tokens, so
+every generation was truncated mid-think and the answer extraction was noise. That confound, not
+re-sync, drove the low scores. **Non-thinking (concise) re-run (`enable_thinking=False`, 256-tok):**
+**pure 0/12 (0%) vs N4_full 3/12 (25%)** — real hits (#0 18=18 terminated at 220 tok, #3 540=540 at
+182 tok, #4 20=20). So once termination is clean, **re-sync N=4 gives a real, measurable improvement
+(0→25%)**. Absolute accuracy is modest (concise 0-shot is hard; N=4 ≈ ½ decode throughput), but the
+direction is clear and positive → Option A is validated; proceeding to vLLM wiring (d).
+
+## Revised recommendation
+
+1. **Option A (periodic re-sync) — validated and works.** Productionization: (a) a `generate_tp_resync(prompt,
+   max_new, resync_every)` model method; (b) measure throughput at N=4/8 vs pure decode; (c) reduce cost
+   with a sliding-window re-sync (re-prefill only the last W tokens, carry prior state) instead of full
+   re-prefill; (d) wire into the vLLM decode contract. Tunable `N` trades accuracy vs throughput.
+2. **Alternative:** compute prefill's GDN path with the *recurrent* kernel (accurate, `0.99998`) so
+   prefill-space = decode-space = true-space. Correct but `O(T)` sequential prefill — measure the
+   throughput hit; may be acceptable for short prompts.
+3. **Option D (status quo + document):** flat-norm is the best tested mitigation; ship short-form,
+   document the long-CoT limitation. The fused-decode PRs are unaffected.
+4. **Deep Option C — investigated 2026-07-12, premise does not hold.** The hoped-for fix ("raise the
+   chunk kernel's bf16 intermediates to fp32") is a no-op: the C++ `gated_delta_attn` kernel's
+   circular buffers are **already all fp32** (`df_f32`), matmul fidelity HiFi4 has **no effect**
+   (0.98884→0.98887), and `ttnn.exp` already runs in **accurate mode**. The 0.988 gap is not a config
+   knob — it is the **SFPU transcendental precision (exp / reciprocal) accumulated through the
+   ill-conditioned within-chunk `L_inv` (matrix inverse)**. The recurrent path stays 0.99998 because it
+   applies exp once per step on a small value; the chunk path evaluates `exp(cumsum(g))` over a wide
+   range plus a 128×128 exp matrix plus a reciprocal-based inverse. Truly fixing it needs a
+   **numerical reformulation of the chunk math** (better-conditioned inverse, higher-precision
+   transcendental emulation) — research-level kernel work, uncertain payoff. **Not recommended as a
+   near-term fix.**
+5. Keep flat-norm; do **not** adopt the branch's sharp-norm or SDPA config (both worse in main).
+
+## Productionization status (2026-07-12)
+
+- **(a) `model.generate_tp_resync(prompt, max_new, resync_every, eos_id, window)`** — implemented in
+  `model.py` (demo/eager path). `resync_every<=0` = pure decode; `window=None` = full re-prefill;
+  `window=W` = re-prefill prompt + last W generated tokens (compacted positions).
+- **(b/c/e)** — measured via `test_resync_eval.py` (multi-problem GSM8K × {pure, N=4 full, N=4
+  window=64}; correctness + tok/s). See results section (appended after the run).
+- **(d) vLLM serving integration — STARTED & mechanism validated (2026-07-12):** implemented a
+  `decode_forward` hook in `qwen36_vllm.py` (delegate style: `prefill_forward` stashes the prompt
+  tokens + page_table; `decode_forward` every N steps calls `model.prefill_traced_chunked(seq[:pos],
+  page_table, actual_len=pos)` to refresh paged KV + GDN state into chunk-space, then delegates the
+  step to `super().decode_forward` so the decode output contract is untouched). Env
+  `TT_QWEN_DECODE_RESYNC_N` (0=off, default), B=1 + host sampling. Offline vLLM run (N=4): the hook
+  **fires 49× with no crash** and the output is coherent initially — proving a re-prefill CAN be
+  injected into the parked-trace decode path without breaking it (the main risk). **Open:** output
+  degrades later ("…3 for 33 3"+whitespace). GDN reset is in-place (trace-safe, confirmed), so the
+  leading suspect is that re-syncing at a growing sequence length crosses an **un-warmed prefill
+  bucket** and JIT-compiles mid-serving, clobbering the parked decode trace. Next: pre-warm the bucket
+  lengths re-sync will hit (or bound re-prefill length), and diff the paged re-prefill state against
+  the demo path's full re-prefill (which reaches $18 at N=4). Hook is default-off so serving is
+  unaffected.
+- **(d) original spec (retained for reference):**
+  Serving decode is `Qwen36ForCausalLM.decode_forward` → `Generator.decode_forward` (parked trace
+  replay); prefill is model-owned (`prefill_traced_chunked(token_ids, page_table, actual_len)` writes
+  the request's paged KV blocks, `reset_state_inplace` preserves GDN buffer addresses so the parked
+  decode trace stays valid). Integration:
+  1. In `decode_forward`, keep a per-slot **decoded-token history** and **step counter** (the current
+     token is already in the decode inputs; append it each call).
+  2. Every `N` steps for a slot, instead of replaying the decode trace, call `prefill_traced_chunked`
+     over that slot's `[prompt + generated]` (or `[prompt + last W]`) into its existing `page_table`
+     blocks, then `reset_state_inplace` + reseed the GDN state; return the resulting logits.
+  3. Because TP prefill uses the pre-warmed masked-bucket program set (warmed before the decode trace
+     parks — the compile-clobbers-trace fix is already in place), the mid-decode re-prefill does not
+     recompile into the parked trace. Verify this holds under continuous batching (B>1).
+  Expose `N`/`window` via `--additional-config '{"tt":{"decode_resync_every":4,"decode_resync_window":64}}'`.
+
+  **Building block already exists:** `model.prefill_traced_chunked(token_ids, page_table, actual_len)`
+  rebuilds a slot's paged KV cache + GDN state and returns the next-token logits — exactly a re-sync.
+  The only new work is the *hook* that calls it every N decode steps with the slot's accumulated tokens.
+
+  **Why this is a live-server integration, not a drop-in (verified against `Generator.decode_forward`,
+  2026-07-12):** decode is not a plain "return logits" call — it is tightly coupled to (i) on-device
+  sampling (the device token buffer is authoritative; host tokens lag under async scheduling), (ii) the
+  parked decode trace and its fixed input/output buffers, (iii) `slot_remap` + continuous batching, and
+  (iv) data-parallel chunking. Substituting a prefill mid-replay must reconcile the device token/pos
+  buffers and the parked trace, so it needs iteration against a running server (≈210 s standup) and
+  interacts with the deferred B>1 path. **Recommendation:** wire it as a focused follow-on with the
+  server up — start B=1 (no slot_remap/DP: the reconciliation collapses), validate via the existing
+  `bench/gsm8k_eval.py` OpenAI harness (which handles thinking-mode termination + extraction correctly,
+  unlike the demo-path probe), then extend to B>1. Accuracy/throughput knob via `N` (and `window`, though
+  `window` only helps when the prompt is short — see the concise-eval note).
+
+## (d) vLLM re-sync — clean A/B outcome (2026-07-12)
+
+- `switch_mode` ruled out (Qwen's `switch_mode` is a no-op — no prefetcher).
+- Env caveat: setting `os.environ` inside the driver script does NOT reach the vLLM engine
+  subprocess; pass `TT_QWEN_DECODE_RESYNC_N` via docker `-e` / bash-level env.
+- Clean A/B (offline, same Janet-concise prompt, max_tokens 140, resync fired 34× for N=4):
+  - **N=0 (pure serving):** coherent ~30 tokens → catastrophic multilingual-garbage collapse.
+  - **N=4 (resync):** coherent ~30 tokens → degrades to whitespace but **avoids the collapse**.
+- So re-sync **helps** in serving (prevents the worst collapse) but does **not** reach the demo path's
+  quality (which hits $18 at N=4). Decisive: **serving pure decode is far more degraded than demo pure
+  decode** (demo = coherent English number-confabulation; serving = multilingual garbage), i.e. the
+  serving decode path carries an *additional* degradation beyond the chunk-vs-recurrent drift (paged
+  KV / traced decode / fused kernel in the serving path) that re-sync alone cannot fix.
+
+**(2) delivered:** hook implemented (default-off, non-breaking) + mechanism validated (fires, no crash)
++ shown to help (prevents collapse). **Full serving parity requires a separate investigation of the
+serving-decode-specific degradation** — a new, broader task, not a re-sync tuning issue.
+
+## Serving-specific degradation localized to PAGED KV (2026-07-12)
+
+Follow-up on "serving pure decode is far worse than demo pure decode" (multilingual-garbage collapse
+vs coherent English number-confabulation). Isolated by elimination on the Janet-concise prompt:
+
+| variant | result |
+|---|---|
+| serving pure, fused GDN **ON** | coherent ~30 tok → multilingual garbage collapse |
+| serving pure, fused GDN **OFF** | same collapse (byte-identical) → **fused kernel exonerated** |
+| serving pure, `enforce_eager=True` (no decode trace) | same collapse (byte-identical) → **traced decode exonerated** |
+| demo pure (internal concat KV caches, eager) | coherent English (confabulates numbers, no collapse) |
+
+The ONLY remaining difference between the coherent demo decode and the collapsing serving decode is the
+**paged KV cache** path: `paged_scaled_dot_product_attention_decode` + `paged_update_cache` + external
+`page_table` (serving) vs the internal per-head concat caches `k_caches/v_caches` (demo). GDN, RoPE,
+norms are identical between the two. → **The serving-specific severe degradation is a bug in the paged
+KV decode path**, collapsing around pos ~104 (prompt 74 + ~30 tokens; block_size 64 → block 1). This is
+a distinct, more severe problem than the (gradual) chunk-vs-recurrent drift.
+
+**Next:** teacher-forced per-position PCC of paged-decode vs internal-cache-decode logits to pinpoint
+the paged breakage (page_table indexing / block-boundary handling / paged SDPA-decode), then fix. This
+is the highest-value serving fix — it likely dominates the observed serving accuracy loss.
+
+## BREAKTHROUGH: serving collapse is a paged SDPA-decode multi-chunk bug (2026-07-12)
+
+`test_paged_vs_internal.py` — paged-KV decode vs internal-cache decode (oracle), teacher-forced, full
+model, per-step logits PCC:
+
+- Divergence starts EXACTLY at cached length **pos=128** (PCC 0.99→0.51), **independent of block_size**
+  (32 and 64 give byte-identical drops) → not block-index, an absolute-128 boundary.
+- RoPE + cur_pos ruled out (`prepare_decode_inputs_host` uses `freqs=outer(pos,inv_freq)` with `pos`
+  directly, no 128 limit; matches the coherent oracle).
+- Varying the paged SDPA-decode `k_chunk_size` MOVES the collapse: k_chunk=0/auto(→128) collapses at
+  128; k_chunk=32 collapses at ~96 (worse, min 0.19); **k_chunk=512 (single-chunk, ≥ cached length) →
+  NO collapse, all steps PCC ≥ 0.99.** → the bug is the **paged `scaled_dot_product_attention_decode`
+  MULTI-CHUNK KV gather** (the non-paged op with the same config is fine).
+
+**End-to-end serving validation:** pure decode (N=0, no re-sync), `QWEN_PAGED_KCHUNK=512`: the
+multilingual-garbage collapse is GONE — coherent English for 140 tokens, tracking the prompt numbers
+(vs ~30-token collapse with the default auto k_chunk). **So the dominant serving accuracy problem was
+the paged multi-chunk bug, and single-chunk k_chunk fixes it — no re-sync needed.**
+
+**Constraint:** k_chunk=2048 crashes (SDPA CBs = 4.67 MB > 1.5 MB L1, `program.cpp:1554`). Single-chunk
+is only viable up to k_chunk ≈ 512 (context ≤ 512). Beyond that the multi-chunk bug returns. So the
+config fix covers short/medium contexts; **the proper long-context fix is upstream: correct the ttnn
+paged SDPA-decode multi-chunk gather.**
+
+### Two distinct decode problems (final)
+1. **Paged SDPA-decode multi-chunk bug** — dominant serving problem (catastrophic multilingual
+   collapse). Fixed for context ≤512 via `QWEN_PAGED_KCHUNK=512` (env, `attention/tp.py` paged branch);
+   long-context needs the upstream ttnn kernel fix.
+2. **GDN chunk-vs-recurrent drift** — milder number-confabulation. Mitigated by Option A re-sync
+   (GSM8K 0→25% demo path). Present in both demo and serving; secondary to (1) in serving.
+
+## Option C final assessment — SFPU-precision-limited, not a bounded fix (2026-07-13)
+
+Investigated the chunk kernel's 0.988-vs-torch to exhaustion:
+- matmul fidelity: HiFi4 (python wrapper AND C++ program-factory rebuild) → no change (0.98884→0.98887).
+- circular buffers: already all fp32.
+- `ttnn.exp`: already accurate mode (not fast/approx).
+- per-position error: ~uniform ~1% (0.991→0.988), not an accumulating trend.
+
+⇒ the 0.988 is the **inherent precision of the SFPU transcendentals** the chunk formula uses heavily
+(`exp(cumsum(g))`, the 128×128 `exp` decay matrix, the reciprocal-based `L_inv`). The recurrent path
+is 0.99998 because it applies `exp` once per step on a small value; the chunk path evaluates far more
+transcendentals over a wider dynamic range. Option C's fix target is therefore either a
+**higher-precision on-device exp/reciprocal (custom LLK)** or a **reformulation of the chunk math** —
+both research-level kernel work, not reachable via config/fidelity knobs. And since the network
+tolerates the 0.988 (prefill-gen reasons correctly), the payoff of chunk-accuracy for decode
+consistency is uncertain.
+
+**Conclusion:** Option C is not a bounded, deployable fix. The practical accuracy lever remains
+**Option A (re-sync)** — keep decode in the chunk-space the network is calibrated to, tunable by N
+(N=1 = prefill-gen = correct but O(T)/token; larger N = cheaper, less accurate). "Recurrent prefill"
+was refuted (test_all_recurrent: feeding the prompt through the recurrent path produces off-topic
+hallucination — the network is chunk-space-calibrated, so the accurate recurrent path is the
+*inconsistent* one).

--- a/models/demos/blackhole/qwen36/docs/decode_drift_investigation.md
+++ b/models/demos/blackhole/qwen36/docs/decode_drift_investigation.md
@@ -1,0 +1,129 @@
+# Qwen3.6-27B (TT Blackhole) — Decode-Drift Root-Cause Investigation
+
+**Date:** 2026-07-12
+**Scope:** `models/demos/blackhole/qwen36/` on P150x4 (P300×2, 4 chips), mesh (1,4), TP=4.
+**Status:** Root cause identified. Not a single fixable bug; a systematic prefill-vs-decode
+algorithmic divergence that compounds across the 64-layer hybrid stack.
+
+---
+
+## 1. Symptom
+
+The TT-served Qwen3.6-27B produces **fluent but factually-drifting** long generations:
+
+- Short recall (capital of France, one-line biography) → **correct**.
+- Multi-step arithmetic / long CoT (GSM8K) → **~0–5%**, vs GPU/HF reference ~90%.
+- Failure mode: the model starts coherently, tracks the prompt numbers correctly for the
+  first ~100–150 tokens, then **confabulates prompt numbers** ("16 eggs" → "12/14 eggs")
+  and **loops**. Happens in greedy and sampling, demo path and vLLM, B=1 and B=8.
+
+This is **pre-existing** and **independent of the fused-GDN-decode optimization** — `fused == python`
+at every measurement, so PRs #49587 / #49588 are accuracy-neutral and healthy.
+
+## 2. Method
+
+All experiments are teacher-forced or single-op PCC vs a trusted reference:
+
+| Tool | What it measures |
+|---|---|
+| `score_tp` (added to `model.py`) | prefill/all-position logits → **WikiText PPL 9.03** (prefill healthy) |
+| `test_prefill_gen.py` | autoregressive generation via the **prefill path only** → **reasons correctly** (GSM8K solved) |
+| `test_decode_vs_prefill.py` | incremental **decode** logits vs `score_tp` (prefill) reference, teacher-forced |
+| `test_gdn_drift.py` | GDN **recurrent** kernel vs a torch fp32 recurrence |
+| `test_attn_capture.py` | per-layer q-post-RoPE / attn-output, decode vs prefill |
+| `test_sdpa_pcc.py` | `scaled_dot_product_attention_decode` op vs exact torch softmax attention |
+| `test_gdn_chunk_vs_rec.py` | GDN **chunk (prefill)** kernel vs **recurrent (decode)** kernel, same input |
+| `test_decode_gen_probe.py` | real decode-path generation, FLAT vs SHARP q/k-norm |
+
+## 3. What was eliminated
+
+| Suspect | Verdict | Evidence |
+|---|---|---|
+| Prefill path / weights | **healthy** | PPL 9.03; prefill-path autoregressive gen solves GSM8K |
+| GDN recurrence (vs torch) | clean | recurrent kernel vs torch fp32 recurrence PCC **0.9998** (stable over 256 steps) |
+| RoPE (decode vs prefill) | identical | `rot_mats_decode` / `rot_mats_prefill` freq + apply logic byte-identical (code inspection) |
+| Compute precision | not it | forcing decode matmul+SDPA to HiFi4 → decode-vs-prefill unchanged (0.896 ↔ 0.897) |
+| DistributedNorm decode-mode | not it | forcing PREFILL-mode norm at decode → unchanged (0.8973 ↔ 0.8972) |
+| **SDPA-decode op** | **clean** | `scaled_dot_product_attention_decode` vs exact torch = **PCC 0.9998** (MHA/GQA, full/partial cache, HiFi2/HiFi4) |
+| q/k-norm scheme | flat is best | see §5 |
+| conv / l2norm (in GDN) | clean | GDN cross-path pos0 PCC 0.998 (state empty ⇒ ~conv only) |
+| Fused GDN decode optimization | neutral | `fused == python` everywhere |
+
+## 4. Root cause — GDN chunk (prefill) vs recurrent (decode) divergence
+
+`test_gdn_chunk_vs_rec.py` feeds the **same** 128-token hidden sequence to one GDN layer via both
+paths and compares per-position outputs (device-0 shard):
+
+| position | mean PCC | min | first |
+|---|---|---|---|
+| 0–31 | 0.989 | 0.959 | **0.998** |
+| 32–63 | 0.981 | 0.943 | |
+| 64–95 | 0.972 | 0.904 | |
+| 96–127 | 0.968 | 0.906 | |
+
+Key observations:
+- The two kernels are **not numerically equivalent**, and the gap **grows monotonically with
+  position** — unlike the SDPA-decode op which is a flat 0.9998.
+- **pos0 = 0.998** (recurrent state empty ⇒ essentially conv-only) localizes the divergence to the
+  **recurrence / state accumulation**, not the FIR conv or the norms.
+- It is the chunk-parallel associative scan vs the sequential recurrence: an algebraic
+  reformulation that is only exactly equal in infinite precision; in fp32 they diverge and the
+  divergence accrues with recurrence length.
+
+**Mechanism of the symptom:** real decode builds the GDN state with the *chunk* kernel during
+prefill, then continues with the *recurrent* kernel. As generation lengthens, the recurrent state
+drifts away from the chunk reference the rest of the network effectively "expects." Hence: short
+recall is fine, long multi-step reasoning drifts — exactly the observed GSM8K pattern.
+
+`test_gdn_drift` (recurrent ≈ torch, 0.9998) tells us the **recurrent path is the more faithful one**;
+the chunk kernel is what departs from the true recurrence. But the model reasons correctly *under the
+chunk path* (prefill), so the operative problem is the **inconsistency between the two paths**, not
+which one is "more correct."
+
+**Scale / compounding:** one GDN layer's real-flow divergence is small (3 GDN layers →
+decode-vs-prefill 0.9983). Across the full 64-layer hybrid stack (48 GDN + 16 full-attn) the small
+per-layer divergences compound to **logit PCC ~0.90** (argmax agreement ~66%). Enough to keep text
+fluent, fatal for exact-number multi-step reasoning.
+
+## 5. The q/k-norm finding (branch reference)
+
+The user recalled the branch (`yito/qwen36_27b_p300x2_tp`) being more accurate and asked to reference
+it. Two branch differences were tested:
+
+- **SDPA config** (branch: `q_chunk=32, k_chunk=32, max_cores_per_head_batch=16`): scores 0.41–0.51
+  in the unit harness (does not transfer to main's kernel/shape) — **not** the source of any accuracy
+  advantage; main's config is already at the 0.9998 ceiling.
+- **q/k-norm**: HF `Qwen3_5RMSNorm` is zero-centered (`output*(1+weight)`), so the HF-correct and
+  branch-consistent choice is **sharp (+1)**. main's decode uses **flat (no +1)**. But adopting sharp
+  at decode makes real generation **much worse** (immediate confabulation + garbage loop), confirmed
+  in both the proxy (sharp 0.78 < flat 0.90) **and** real decode generation. main's flat-norm is a
+  HF-incorrect but empirically superior mitigation that partially masks the §4 divergence.
+
+**Conclusion:** the branch's accuracy advantage does not come from its SDPA config or its norm scheme;
+neither transfers to main. Do **not** switch main to sharp-decode or the branch SDPA config.
+
+## 6. Bottom line
+
+- The decode drift is a **systematic prefill(parallel)-vs-decode(incremental) algorithmic divergence**
+  — hard-demonstrated in the **GDN chunk-vs-recurrent kernels** (growing with position) and propagated
+  through the attention layers — that **compounds across 64 layers**. Not one fixable bug.
+- `flat` q/k-norm at decode is the best available mitigation and should stay.
+- The fused-GDN-decode work is accuracy-neutral; the shipped PRs are unaffected.
+- Fix directions require kernel-level or path-level changes (see the fix-design note).
+
+## 7. Reproduce
+
+Overlay recipe (no rebuild; Python-only): mount `work/tt-metal` + the `qwen36-port` worktree's
+`qwen36/` + flux `python_env` + HF cache; env `MESH_DEVICE=P150x4`,
+`TT_MESH_GRAPH_DESC_PATH=.../p300_x2_mesh_graph_descriptor.textproto`,
+`TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1`. Then:
+
+```
+pytest models/demos/blackhole/qwen36/tests/test_gdn_chunk_vs_rec.py -s     # the key finding
+pytest models/demos/blackhole/qwen36/tests/test_sdpa_pcc.py -s             # SDPA op clean
+pytest models/demos/blackhole/qwen36/tests/test_decode_gen_probe.py -s     # FLAT vs SHARP
+pytest models/demos/blackhole/qwen36/tests/test_decode_vs_prefill.py -s    # end-to-end proxy
+```
+
+Diagnostic envs (all gated-off by default): `QWEN_ATTN_SHARP_DECODE`, `QWEN_DECODE_HIFI4`,
+`QWEN_DECODE_NORM_PREFILL`, `QWEN_ATTN_CAPTURE`, `QWEN_GDN_FUSED_DECODE`, `N_LAYERS`.

--- a/models/demos/blackhole/qwen36/docs/paged_sdpa_decode_bug.md
+++ b/models/demos/blackhole/qwen36/docs/paged_sdpa_decode_bug.md
@@ -1,0 +1,90 @@
+# Bug: `paged_scaled_dot_product_attention_decode` diverges when valid KV spans >1 k_chunk
+
+**Op:** `ttnn.transformer.paged_scaled_dot_product_attention_decode`
+(`ttnn/cpp/ttnn/operations/transformer/sdpa_decode/`, compute kernel `sdpa_flash_decode.cpp`).
+**Build:** tt-metal @ ASR branch (main-based), Blackhole P150x4 (P300×2), mesh (1,4), TP=4.
+**Found via:** Qwen3.6-27B serving — decode output collapses into multilingual garbage once the
+generated sequence passes a fixed cached length, regardless of block_size.
+
+## Symptom
+
+Teacher-forced, identical inputs, per-position next-token logits, **paged decode vs the non-paged
+`scaled_dot_product_attention_decode` on internal concat caches (oracle)**, full 64-layer model:
+
+| cached length (cur_pos) | paged-vs-oracle logits PCC |
+|---|---|
+| 64 … 127 | 0.999 (matches) |
+| **128** | 0.988 (starts to drop) |
+| 129 → 140 | 0.95 → 0.91 → … → **0.51** (catastrophic) |
+
+- The drop is at **cur_pos = 128 regardless of block_size** (32 and 64 give byte-identical PCC drops)
+  → it is NOT block-index related; it tracks an absolute valid-length / k_chunk boundary.
+- RoPE and cur_pos are correct (host builds `freqs = outer(pos, inv_freq)` with the true `pos`, no
+  128 wrap; matches the coherent oracle).
+- The **non-paged** op with the **same** `SDPAProgramConfig` and `compute_kernel_config` does NOT
+  diverge across the same multi-chunk boundary — only the **paged** path does.
+
+## Isolation — it is the paged multi-chunk online-softmax
+
+Varying only the paged op's `k_chunk_size`:
+
+| k_chunk_size | collapse onset |
+|---|---|
+| 0 (auto → dynamic, ≈128) | cur_pos = 128 |
+| 32 | cur_pos ≈ 96, worse (min PCC 0.19) |
+| **512 (≥ cached length ⇒ single valid chunk)** | **none — all positions PCC ≥ 0.99** |
+
+The paged op processes `S = page_table.padded_shape[-1] * block_size` (the whole allocated cache) in
+`k_chunk_size` chunks, masked by `cur_pos`. It is correct while the **valid** KV (positions
+`[0, cur_pos]`) fits in a **single** chunk, and diverges — worsening with position — as soon as the
+valid KV spans **two or more** chunks (i.e. `cur_pos ≥ k_chunk_size`). The single-chunk case
+(`k_chunk_size ≥ cur_pos`) is exact. ⇒ the defect is in the **paged cross-chunk online-softmax
+reduction / boundary-chunk masking**, not in the QKᵀ/AV math (which the single-chunk and non-paged
+paths share and get right).
+
+## Minimal repro
+
+`models/demos/blackhole/qwen36/tests/test_paged_vs_internal.py` (env `T`, `N_DEC`, `BLOCK_SIZE`,
+`N_LAYERS`): prefill T tokens, then teacher-force N_DEC decode steps through BOTH the paged and the
+internal-cache paths with identical tokens, print per-step logits PCC. Reproduces the pos-128 drop at
+default k_chunk and its disappearance at k_chunk=512.
+
+## Workaround (in use)
+
+`attention/tp.py` paged decode branch, env `QWEN_PAGED_KCHUNK`: set the paged `SDPAProgramConfig`
+`q/k_chunk_size` to a single-chunk value (≥ served context). Validated: serving pure decode with
+`QWEN_PAGED_KCHUNK=512` produces coherent output for the whole generation (no collapse), vs a ~30-token
+collapse at the default.
+
+**Limit:** `k_chunk_size = 2048` overflows L1 — `Statically allocated circular buffers grow to
+4671424 B > max L1 1572864 B` (`program.cpp:1554`). So single-chunk is only viable up to
+`k_chunk ≈ 512` (context ≤ ~512). Longer contexts need the real fix.
+
+## Ask
+
+Fix the paged cross-chunk online-softmax in `sdpa_flash_decode.cpp` so paged decode matches the
+non-paged op when valid KV spans multiple k_chunks. Candidate areas: the boundary/partial chunk mask
+and the running-max/running-sum rescale across chunks on the paged path (`k_num_chunks`,
+`k_chunk_start/end`, `window_start_*`, and the `cb_cur_max`/`cb_prev_max` rescale loop).
+
+## ROOT CAUSE CONFIRMED + fix landed (2026-07-12)
+
+The defect is the **cross-CORE tree reduction**, not the reader/gather. `max_cores_per_head_batch=1`
+(all chunks of a head on one core → the correct within-core lazy-softmax; no cross-core softmax
+correction) makes paged decode match the internal-cache oracle **for any context length**:
+
+| paged config | paged-vs-internal PCC (cur_pos 64→144) |
+|---|---|
+| default (auto k_chunk, multi-core) | collapses at 128 → 0.51 |
+| k_chunk=512 (single chunk, 1 core) | clean, but L1-caps context ≤512 |
+| **max_cores_per_head_batch=1 + k_chunk=128 (multi-chunk, 1 core)** | **clean at all positions (≥0.99), any context** |
+
+Validated end-to-end: serving pure decode with the single-core config stays coherent past cur_pos=128
+(vs ~30-token multilingual collapse at default). **Landed as the default in the Qwen3.6 paged decode
+branch (`attention/tp.py`)**: `max_cores_per_head_batch=1`, `k_chunk=128`; env `QWEN_PAGED_MAXCORES=0`
+restores the stock config. Trade-off: one core per head is slower — acceptable for B=1; the proper
+upstream fix is to correct the cross-core tree reduction so multi-core paged decode is usable.
+
+**Upstream bug (still worth fixing):** `sdpa_flash_decode.cpp` tree reduction (`correction_block` /
+`cb_cur_max`/`cb_prev_max` cross-core combine, ~line 506+) gives wrong results for PAGED multi-chunk
+decode while the identical within-core path and the non-paged multi-chunk path are correct.

--- a/models/demos/blackhole/qwen36/tests/test_all_recurrent.py
+++ b/models/demos/blackhole/qwen36/tests/test_all_recurrent.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""(a) drift-reduction probe: 'all-recurrent' generation vs chunk-prefill+decode.
+
+Decode drift = the accurate recurrent decode (0.99998 vs torch) continuing a context prefill built in
+the chunk kernel's inaccurate 'chunk-space' (0.988). Hypothesis: feeding the PROMPT through the
+recurrent decode path too (no chunk kernel) makes prefill-space = decode-space = true-space (self-
+consistent, like GPU), removing the mismatch WITHOUT per-step re-sync cost. If all-recurrent reasons
+correctly where chunk-prefill+decode drifts, "recurrent prefill" is the fix direction.
+
+Run: MESH_DEVICE=P150x4 HF_MODEL=Qwen/Qwen3.6-27B pytest .../test_all_recurrent.py -s
+"""
+import os
+import torch
+
+import ttnn
+from models.demos.blackhole.qwen36.tests.test_factory import model_path, parametrize_mesh_tp
+from models.demos.blackhole.qwen36.tt.model import Qwen36Model
+
+
+@parametrize_mesh_tp()
+def test_all_recurrent(mesh_device):
+    from loguru import logger
+    from transformers import AutoTokenizer
+
+    os.environ.setdefault("HF_MODEL", model_path())
+    mesh_device.enable_program_cache()
+    model = Qwen36Model.from_pretrained(mesh_device, max_batch_size=1, max_seq_len=2048)
+    tok = AutoTokenizer.from_pretrained(model.args.CKPT_DIR, trust_remote_code=True)
+    eos = tok.eos_token_id
+    vocab = model.vocab_size
+    MAXNEW = 160
+
+    q = ("Janet's ducks lay 16 eggs per day. She eats three for breakfast and bakes four into muffins. "
+         "She sells the remainder at two dollars per egg. How many dollars does she make every day?")
+    msg = [{"role": "user", "content": q + "\n\nSolve step by step. End with: #### <number>"}]
+    ids = list(tok.apply_chat_template(msg, add_generation_prompt=True, tokenize=True, return_dict=False))
+    P = len(ids)
+
+    def gen_all_recurrent():
+        # PROMPT through the recurrent decode path (no chunk kernel) → true-space state, then continue.
+        model.reset_tp()
+        nxt = None
+        for pos in range(P):
+            lg = model.decode_tp(ids[pos], pos).reshape(-1)[:vocab]
+            nxt = int(torch.argmax(lg))  # prediction after consuming ids[:pos+1]
+        out = [nxt]
+        for pos in range(P, P + MAXNEW - 1):
+            if nxt == eos:
+                break
+            lg = model.decode_tp(nxt, pos).reshape(-1)[:vocab]
+            nxt = int(torch.argmax(lg))
+            out.append(nxt)
+        return out
+
+    def gen_chunk_prefill():
+        # Standard: chunk-kernel prefill, then recurrent decode (the drifting path).
+        return model.generate_tp(ids, max_new_tokens=MAXNEW)
+
+    for name, fn in (("ALLREC", gen_all_recurrent), ("CHUNKPF", gen_chunk_prefill)):
+        out = fn()
+        txt = tok.decode(out, skip_special_tokens=True)
+        import re
+        nums = re.findall(r"-?\d+", txt)
+        logger.info(f"ALLREC_PROBE[{name}] reaches_18={'18' in nums} last_nums={nums[-6:]}\n---\n{txt[:500]}\n---END---")

--- a/models/demos/blackhole/qwen36/tests/test_attn_capture.py
+++ b/models/demos/blackhole/qwen36/tests/test_attn_capture.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Localize the decode divergence WITHIN attention: q-post-rope vs SDPA output, decode vs prefill.
+
+QWEN_ATTN_CAPTURE=1 makes each full-attn layer record q (post-RoPE) and attn (SDPA out) in both
+paths. This runs score_tp (prefill, all positions) then one teacher-forced decode step at position P,
+and compares per attention layer, at position P:
+  - PCC(q_rope decode, q_rope prefill)   -> RoPE/projection fidelity
+  - PCC(attn_out decode, attn_out prefill) -> SDPA/KV-cache fidelity
+If q_rope matches but attn_out diverges -> the SDPA-decode kernel / KV read is the culprit; if
+q_rope also diverges -> RoPE decode.
+Run: QWEN_ATTN_CAPTURE=1 N_LAYERS=8 MESH_DEVICE=P150x4 HF_MODEL=Qwen/Qwen3.6-27B pytest .../test_attn_capture.py -s
+"""
+import os
+import torch
+
+import ttnn
+from models.demos.blackhole.qwen36.tests.test_factory import model_path, parametrize_mesh_tp
+from models.demos.blackhole.qwen36.tt.model import Qwen36Model
+from models.demos.blackhole.qwen36.tt.attention import tp as attn_tp
+
+
+def _pcc(a, b):
+    a, b = a.float().flatten(), b.float().flatten()
+    return torch.corrcoef(torch.stack([a, b]))[0, 1].item()
+
+
+@parametrize_mesh_tp()
+def test_attn_capture(mesh_device):
+    from loguru import logger
+    from transformers import AutoTokenizer
+
+    os.environ.setdefault("HF_MODEL", model_path())
+    os.environ["QWEN_ATTN_CAPTURE"] = "1"
+    mesh_device.enable_program_cache()
+    nl = int(os.environ.get("N_LAYERS", "8"))
+    model = Qwen36Model.from_pretrained(mesh_device, max_batch_size=1, max_seq_len=2048, n_layers=nl)
+    tok = AutoTokenizer.from_pretrained(model.args.CKPT_DIR, trust_remote_code=True)
+    fa = [i for i, l in enumerate(model.layers) if l.is_full_attention]
+    logger.info(f"ATTNCAP n_layers={nl} full_attn_layers={fa}")
+
+    text = ("Janet's ducks lay 16 eggs per day. She eats three for breakfast and bakes four into "
+            "muffins, then sells the rest at the market for two dollars each. Compute the daily revenue "
+            "step by step, tracking every number carefully to reach the final dollar amount.")
+    ids = tok(text, return_tensors="pt").input_ids[0]
+    T = int(ids.numel())
+    P = 48
+
+    def pad128(n):
+        return ((n + 127) // 128) * 128
+
+    # ---- prefill capture (all positions) ----
+    attn_tp._ATTN_CAP.clear()
+    Tp = pad128(T)
+    padded = torch.zeros(1, Tp, dtype=torch.long)
+    padded[0, :T] = ids
+    _ = model.score_tp(padded, valid_len=T)
+    pf = list(attn_tp._ATTN_CAP)  # [(prefill, q_rope/attn_out, [4,NHl,S,HD]) ...] per attn layer
+
+    # ---- decode capture: prefill first P, then ONE decode step at position P ----
+    attn_tp._ATTN_CAP.clear()
+    Pp = pad128(P)
+    ppad = torch.zeros(1, Pp, dtype=torch.long)
+    ppad[0, :P] = ids[:P]
+    model.reset_tp()
+    _ = model.prefill_seed_tp(ppad, valid_len=P, batch_slot=0)
+    for layer in model.layers:
+        if not layer.is_full_attention:
+            layer.attention.finalize_seed(1)
+    attn_tp._ATTN_CAP.clear()  # drop the prefill_seed captures; keep only the decode step
+    _ = model.decode_tp_batched([int(ids[P].item())], [P])
+    dec = list(attn_tp._ATTN_CAP)
+
+    # group by (name) in order → one entry per attn layer per name
+    def by_name(cap, name):
+        return [t for (m, n, t) in cap if n == name]
+
+    for li, lidx in enumerate(fa):
+        for name in ("q_rope", "attn_out"):
+            pt = by_name(pf, name)[li]   # [4, NHl, S, HD]
+            dt = by_name(dec, name)[li]  # [4, 1, NHl, HD] (decode: [.,B,NH,HD])
+            pf_pos = pt[:, :, P, :] if pt.dim() == 4 and pt.shape[2] >= P + 1 else pt.reshape(4, -1, pt.shape[-1])[:, min(P, pt.shape[1] - 1), :]
+            dt_pos = dt[:, 0, :, :] if dt.dim() == 4 else dt.reshape(4, -1, dt.shape[-1])[:, 0, :]
+            logger.info(f"ATTNCAP layer{lidx} {name}: PCC(decode,prefill)={_pcc(dt_pos, pf_pos):.5f}")

--- a/models/demos/blackhole/qwen36/tests/test_decode_gen_probe.py
+++ b/models/demos/blackhole/qwen36/tests/test_decode_gen_probe.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Real decode-path generation quality probe: does the model reason correctly through the
+scaled_dot_product_attention_decode path? Compares the decode-vs-prefill PCC proxy (which favors the
+HF-INCORRECT flat q/k-norm) against actual generated text. Run twice via QWEN_ATTN_SHARP_DECODE:
+  - unset  -> decode uses FLAT q/k-norm (main default, HF-incorrect, missing the +1 offset)
+  - =1     -> decode uses SHARP q/k-norm (HF-correct: output*(1+weight); matches prefill + branch)
+The Janet problem's answer is 18 dollars (16-3-4=9 eggs * $2). Coherent, correct-number reasoning
+vs confabulation/looping is the real signal.
+Run: MESH_DEVICE=P150x4 HF_MODEL=Qwen/Qwen3.6-27B pytest .../test_decode_gen_probe.py -s
+"""
+import os
+import torch
+
+import ttnn
+from models.demos.blackhole.qwen36.tests.test_factory import model_path, parametrize_mesh_tp
+from models.demos.blackhole.qwen36.tt.model import Qwen36Model
+
+
+@parametrize_mesh_tp()
+def test_decode_gen_probe(mesh_device):
+    from loguru import logger
+    from transformers import AutoTokenizer
+
+    os.environ.setdefault("HF_MODEL", model_path())
+    mesh_device.enable_program_cache()
+    model = Qwen36Model.from_pretrained(mesh_device, max_batch_size=1, max_seq_len=2048)
+    tok = AutoTokenizer.from_pretrained(model.args.CKPT_DIR, trust_remote_code=True)
+    sharp = os.environ.get("QWEN_ATTN_SHARP_DECODE") == "1"
+    logger.info(f"GENPROBE decode_norm={'SHARP(+1, HF-correct)' if sharp else 'FLAT(no +1, main default)'}")
+
+    prompt = ("Janet's ducks lay 16 eggs per day. She eats three for breakfast and bakes four into "
+              "muffins. She sells the remainder at the market for two dollars per egg. How many dollars "
+              "does she make every day? Think step by step.")
+    msgs = [{"role": "user", "content": prompt}]
+    ids = list(tok.apply_chat_template(msgs, add_generation_prompt=True, tokenize=True, return_dict=False))
+    logger.info(f"GENPROBE prompt_tokens={len(ids)}")
+
+    out = model.generate_tp_batched([ids], max_new_tokens=200, eos_id=tok.eos_token_id)
+    text = tok.decode(out[0], skip_special_tokens=True)
+    logger.info(f"GENPROBE_OUTPUT[{'SHARP' if sharp else 'FLAT'}]:\n{text}\n---END---")

--- a/models/demos/blackhole/qwen36/tests/test_decode_resync.py
+++ b/models/demos/blackhole/qwen36/tests/test_decode_resync.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Option A validation: periodic re-sync of the decode path to prefill's chunk-space.
+
+Root cause: decode (recurrent, 0.99998 vs torch) continues a context prefill built in the chunk
+kernel's "chunk-space" (0.988 vs torch); the space mismatch compounds → long-generation drift. N=1
+(re-prefill every step = test_prefill_gen) already reasons correctly. This sweeps resync_every=N:
+every N generated tokens, re-prefill the whole sequence-so-far (rebuilds attention KV cache + GDN
+state in chunk-space via prefill_seed_tp + finalize_seed); between re-syncs, fast recurrent decode.
+Finds the largest N that keeps the Janet answer ($18) correct.
+
+Run: MESH_DEVICE=P150x4 HF_MODEL=Qwen/Qwen3.6-27B pytest .../test_decode_resync.py -s
+"""
+import math
+import os
+import re
+import torch
+
+import ttnn
+from models.demos.blackhole.qwen36.tests.test_factory import model_path, parametrize_mesh_tp
+from models.demos.blackhole.qwen36.tt.model import Qwen36Model
+
+
+@parametrize_mesh_tp()
+def test_decode_resync(mesh_device):
+    from loguru import logger
+    from transformers import AutoTokenizer
+
+    os.environ.setdefault("HF_MODEL", model_path())
+    mesh_device.enable_program_cache()
+    model = Qwen36Model.from_pretrained(mesh_device, max_batch_size=1, max_seq_len=2048)
+    tok = AutoTokenizer.from_pretrained(model.args.CKPT_DIR, trust_remote_code=True)
+    eos = tok.eos_token_id
+
+    prompt = ("Janet's ducks lay 16 eggs per day. She eats three for breakfast and bakes four into "
+              "muffins. She sells the remainder at the market for two dollars per egg. How many dollars "
+              "does she make every day? Think step by step and give the final number.")
+    ids = list(tok.apply_chat_template([{"role": "user", "content": prompt}],
+                                       add_generation_prompt=True, tokenize=True, return_dict=False))
+    MAXNEW = 240
+
+    def prefill_full(seq):
+        T = len(seq)
+        Tp = max(128, math.ceil(T / 128) * 128)
+        padded = seq + [0] * (Tp - T)
+        lg = model.prefill_seed_tp(torch.tensor([padded], dtype=torch.long), valid_len=T, batch_slot=0)
+        for layer in model.layers:
+            if not layer.is_full_attention:
+                layer.attention.finalize_seed(1)
+        return int(torch.argmax(lg).item())
+
+    def gen(N):
+        model.reset_tp()
+        seq = list(ids)
+        nxt = prefill_full(seq)
+        seq.append(nxt)
+        out = [nxt]
+        since = 0
+        for _ in range(MAXNEW - 1):
+            if nxt == eos:
+                break
+            if since >= N:  # re-sync: rebuild caches+state in chunk-space
+                model.reset_tp()
+                nxt = prefill_full(seq)
+                since = 0
+            else:
+                lg = model.decode_tp_batched([seq[-1]], [len(seq) - 1])
+                nxt = int(torch.as_tensor(lg).float().reshape(-1)[: model.vocab_size].argmax().item())
+                since += 1
+            seq.append(nxt)
+            out.append(nxt)
+        return tok.decode(out, skip_special_tokens=True)
+
+    for N in (10 ** 9, 8, 4):
+        txt = gen(N)
+        nums = re.findall(r"\$?\s*(\d+)", txt)
+        has18 = "18" in nums
+        tag = "PURE_DECODE" if N > 10 ** 6 else f"RESYNC_N={N}"
+        logger.info(f"RESYNC[{tag}] reaches_18={has18} last_nums={nums[-6:]}\n---\n{txt[-400:]}\n---END---")

--- a/models/demos/blackhole/qwen36/tests/test_decode_vs_prefill.py
+++ b/models/demos/blackhole/qwen36/tests/test_decode_vs_prefill.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Decode-path vs prefill-path logit fidelity (teacher-forced) — localize the decode drift.
+
+prefill/score path (score_tp, chunk GDN + full attention) is healthy (PPL 9.03). Here we run the
+INCREMENTAL decode path (prefill_seed the first P tokens, then feed the TRUE next tokens one by one
+via decode_tp_batched) on the SAME sequence and compare its per-position next-token logits to
+score_tp's. Both are TT, no external reference. If decode logits diverge from prefill logits as the
+decode position grows -> the decode step math (attention paged/RoPE at growing pos; GDN recurrence
+is already exonerated) drifts. If they stay aligned -> decode path is faithful and the full-model
+"drift" is autoregressive model behavior, not a decode numerics bug.
+
+Reports PCC + argmax-agreement of decode-vs-prefill logits binned by decode step. Run:
+  QWEN_GDN_FUSED_DECODE=1 MESH_DEVICE=P150x4 HF_MODEL=Qwen/Qwen3.6-27B pytest .../test_decode_vs_prefill.py -s
+"""
+import os
+import torch
+
+import ttnn
+from models.demos.blackhole.qwen36.tests.test_factory import model_path, parametrize_mesh_tp
+from models.demos.blackhole.qwen36.tt.model import Qwen36Model
+
+
+def _pcc(a, b):
+    a, b = a.float().flatten(), b.float().flatten()
+    return torch.corrcoef(torch.stack([a, b]))[0, 1].item()
+
+
+@parametrize_mesh_tp()
+def test_decode_vs_prefill(mesh_device):
+    from loguru import logger
+    from transformers import AutoTokenizer
+
+    os.environ.setdefault("HF_MODEL", model_path())
+    mesh_device.enable_program_cache()
+    nl = os.environ.get("N_LAYERS")
+    kw = {"n_layers": int(nl)} if nl else {}
+    model = Qwen36Model.from_pretrained(mesh_device, max_batch_size=1, max_seq_len=2048, **kw)
+    tok = AutoTokenizer.from_pretrained(model.args.CKPT_DIR, trust_remote_code=True)
+    logger.info(f"DECVSPRE n_layers={len(model.layers)} full_attn_layers="
+                f"{[i for i,l in enumerate(model.layers) if l.is_full_attention]}")
+
+    text = ("Janet's ducks lay 16 eggs per day. She eats three for breakfast and bakes four into "
+            "muffins. She sells the remainder at the market for two dollars per egg. To find the "
+            "answer we first compute how many eggs remain after breakfast and baking, then multiply "
+            "the remainder by the price. Sixteen minus three is thirteen, and thirteen minus four is "
+            "nine, so nine eggs remain to sell. Nine eggs at two dollars each gives eighteen dollars.")
+    ids = tok(text, return_tensors="pt").input_ids[0]
+    T = int(ids.numel())
+    P = 48  # prefill the first P tokens, teacher-force decode the rest
+
+    def pad128(n):
+        return ((n + 127) // 128) * 128
+
+    # ---- reference: prefill/score all-position logits ----
+    Tp = pad128(T)
+    padded = torch.zeros(1, Tp, dtype=torch.long)
+    padded[0, :T] = ids
+    ref = model.score_tp(padded, valid_len=T)  # [Tp, vocab]
+
+    # ---- incremental decode path (teacher-forced) ----
+    Pp = pad128(P)
+    ppad = torch.zeros(1, Pp, dtype=torch.long)
+    ppad[0, :P] = ids[:P]
+    model.reset_tp()
+    _ = model.prefill_seed_tp(ppad, valid_len=P, batch_slot=0)
+    for layer in model.layers:
+        if not layer.is_full_attention:
+            layer.attention.finalize_seed(1)
+
+    rows = []
+    for pos in range(P, T - 1):
+        true_tok = int(ids[pos].item())
+        dl = model.decode_tp_batched([true_tok], [pos])  # [1, vocab] = pred for pos+1
+        dl = torch.as_tensor(dl).float().reshape(-1)[: ref.shape[-1]]
+        rl = ref[pos].float()
+        agree = int(dl.argmax().item() == rl.argmax().item())
+        rows.append((pos - P, _pcc(dl, rl), agree))
+
+    # bin by decode-step ranges
+    for lo in range(0, len(rows), 20):
+        chunk = rows[lo:lo + 20]
+        pcc = sum(c[1] for c in chunk) / len(chunk)
+        agr = sum(c[2] for c in chunk) / len(chunk)
+        logger.info(f"DECVSPRE steps[{lo}-{lo+len(chunk)-1}] meanPCC={pcc:.4f} argmax_agree={agr:.2f}")
+    allpcc = sum(c[1] for c in rows) / len(rows)
+    allagr = sum(c[2] for c in rows) / len(rows)
+    logger.info(f"DECVSPRE_SUMMARY nsteps={len(rows)} meanPCC={allpcc:.4f} argmax_agree={allagr:.3f} "
+                f"firstPCC={rows[0][1]:.4f} lastPCC={rows[-1][1]:.4f}")

--- a/models/demos/blackhole/qwen36/tests/test_gdn_chunk_vs_rec.py
+++ b/models/demos/blackhole/qwen36/tests/test_gdn_chunk_vs_rec.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""GDN chunk-prefill vs recurrent-decode CROSS-PATH consistency (the last unexamined systematic
+prefill/decode difference). test_gdn_drift compared recurrent-vs-torch-recurrent; this compares the
+CHUNK kernel (prefill) to the RECURRENT kernel (decode) on the SAME input sequence. A causal linear
+attention must give identical per-position outputs either way. If chunk(prefill) and recurrent(decode)
+diverge, every downstream layer is fed a diverged hidden state at decode -> compounds to the GSM8K drift.
+
+Feeds ONE real GDN layer (layer 0) an S-token sequence:
+  - prefill: forward_prefill(x[1,1,S,dim]) -> out_pf[S, dim] (chunk kernel, from scratch)
+  - decode:  reset_state(); for pos: forward_decode(x[:,:,pos]) -> out_dec[pos] (recurrent, step-by-step)
+Reports PCC(out_dec[pos], out_pf[pos]) binned by position.
+Run: MESH_DEVICE=P150x4 HF_MODEL=Qwen/Qwen3.6-27B pytest .../test_gdn_chunk_vs_rec.py -s
+"""
+import os
+import torch
+
+import ttnn
+from models.demos.blackhole.qwen36.tests.test_factory import model_path, parametrize_mesh_tp
+from models.demos.blackhole.qwen36.tt.model import Qwen36Model
+
+
+def _pcc(a, b):
+    a, b = a.float().flatten(), b.float().flatten()
+    return torch.corrcoef(torch.stack([a, b]))[0, 1].item()
+
+
+@parametrize_mesh_tp()
+def test_gdn_chunk_vs_rec(mesh_device):
+    from loguru import logger
+
+    os.environ.setdefault("HF_MODEL", model_path())
+    mesh_device.enable_program_cache()
+    # n_layers=1 -> just layer 0, which is a GDN (linear-attn) layer.
+    model = Qwen36Model.from_pretrained(mesh_device, max_batch_size=1, max_seq_len=2048, n_layers=1)
+    layer = model.layers[0]
+    assert not layer.is_full_attention, "layer 0 should be GDN"
+    gdn = layer.attention
+    dim = model.args.dim
+    S = 128
+    torch.manual_seed(0)
+
+    x = (torch.randn(1, 1, S, dim) * 1.0).to(torch.bfloat16).float()
+    rep = ttnn.ReplicateTensorToMesh(mesh_device)
+
+    def dev(t):
+        return ttnn.from_torch(t, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=mesh_device, mesh_mapper=rep)
+
+    # Output is TP-fractured along dim=3 (the trailing all_reduce is over the size-1 mesh axis 0, a
+    # no-op), so each device holds a 1280-wide hidden shard. Both paths share the SAME output tail →
+    # comparing device-0's shard is a valid consistency check (covers 1/4 of the value heads).
+    def host0(t):
+        return ttnn.to_torch(t, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))[:1]
+
+    # ---- prefill (chunk kernel), from scratch ----
+    gdn.reset_state()
+    h = host0(gdn.forward_prefill(dev(x), chunk_size=128, valid_len=S, capture_state=False))
+    W = h.shape[-1]  # per-device hidden shard width
+    out_pf = h.reshape(-1, W)[:S]  # [S, W]
+
+    # ---- recurrent (decode kernel), one token at a time from scratch ----
+    gdn.reset_state()
+    dec_rows = []
+    for pos in range(S):
+        xp = x[:, :, pos:pos + 1, :]  # [1,1,1,dim]
+        o = gdn.forward_decode(dev(xp))
+        dec_rows.append(host0(o).reshape(-1)[:W])
+    out_dec = torch.stack(dec_rows, dim=0)  # [S, W]
+
+    logger.info(f"GDNXPATH dim={dim} S={S} overall_PCC={_pcc(out_dec, out_pf):.5f}")
+    for lo in range(0, S, 32):
+        hi = min(lo + 32, S)
+        rows = [_pcc(out_dec[p], out_pf[p]) for p in range(lo, hi)]
+        logger.info(f"GDNXPATH pos[{lo}-{hi-1}] meanPCC={sum(rows)/len(rows):.5f} "
+                    f"min={min(rows):.5f} first={rows[0]:.5f}")

--- a/models/demos/blackhole/qwen36/tests/test_gdn_chunk_vs_torch.py
+++ b/models/demos/blackhole/qwen36/tests/test_gdn_chunk_vs_torch.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""§0 decisive branch: chunk-vs-torch AND recurrent-vs-torch on the SAME sequence.
+
+test_gdn_drift showed recurrent ≈ torch (0.9998). test_gdn_chunk_vs_rec showed chunk ≠ recurrent
+(diverging with position). This measures the missing number: chunk kernel vs the torch fp32 recurrence
+(ground truth), on the identical raw q/k/v/beta/g fed to all three paths. Both kernels L2-norm+scale
+q/k internally, matching the torch reference.
+
+Decides the fix:
+  - chunk-vs-torch ~0.999  -> both kernels accurate; drift is PATH INCONSISTENCY  -> fix = re-sync (A)
+  - chunk-vs-torch low      -> chunk (prefill) kernel under-precise             -> fix = kernel precision (C)
+
+Run: MESH_DEVICE=P150x4 pytest .../test_gdn_chunk_vs_torch.py -s
+"""
+import os
+import torch
+
+import ttnn
+from models.demos.blackhole.qwen36.tests.test_factory import parametrize_mesh_tp
+from models.experimental.gated_attention_gated_deltanet.tt.ttnn_delta_rule_ops import (
+    recurrent_gated_delta_rule_decode_ttnn,
+)
+from models.experimental.gated_attention_gated_deltanet.tt.ttnn_delta_rule_seq import (
+    chunk_gated_delta_rule_seq_adapter,
+)
+
+
+def _pcc(a, b):
+    a, b = a.float().flatten(), b.float().flatten()
+    return torch.corrcoef(torch.stack([a, b]))[0, 1].item()
+
+
+def _l2(x):
+    return x / (x.pow(2).sum(-1, keepdim=True).sqrt() + 1e-12)
+
+
+@parametrize_mesh_tp()
+def test_gdn_chunk_vs_torch(mesh_device):
+    from loguru import logger
+
+    H, Dk, Dv = 12, 128, 128
+    B, T = 1, 128
+    scale = Dk**-0.5
+    torch.manual_seed(0)
+    rep = ttnn.ReplicateTensorToMesh(mesh_device)
+
+    def dev(t, dt=ttnn.bfloat16):
+        return ttnn.from_torch(t, dtype=dt, layout=ttnn.TILE_LAYOUT, device=mesh_device, mesh_mapper=rep)
+
+    # full sequence of raw inputs (same scale/stats as test_gdn_drift)
+    q = torch.randn(B, T, H, Dk) * 0.3
+    k = torch.randn(B, T, H, Dk) * 0.3
+    v = torch.randn(B, T, H, Dv) * 0.3
+    beta = torch.rand(B, T, H)
+    g = -torch.rand(B, T, H) * 0.05  # decay = exp(g) ~ 0.95-1.0
+
+    # ---- torch fp32 reference recurrence (ground truth), per position ----
+    h_ref = torch.zeros(H, Dk, Dv, dtype=torch.float32)
+    o_ref = torch.zeros(T, H, Dv, dtype=torch.float32)
+    for t in range(T):
+        qn = _l2(q[0, t]) * scale
+        kn = _l2(k[0, t])
+        decay = torch.exp(g[0, t])
+        S = h_ref * decay[:, None, None]
+        mem = torch.einsum("hk,hkv->hv", kn, S)
+        delta = (v[0, t] - mem) * beta[0, t][:, None]
+        S = S + torch.einsum("hk,hv->hkv", kn, delta)
+        o_ref[t] = torch.einsum("hk,hkv->hv", qn, S)
+        h_ref = S
+
+    # ---- TT recurrent decode, step by step (carry state) ----
+    state_tt = dev(torch.zeros(B, H, Dk, Dv), ttnn.float32)
+    o_rec = torch.zeros(T, H, Dv)
+    for t in range(T):
+        o_tt, state_tt = recurrent_gated_delta_rule_decode_ttnn(
+            dev(q[:, t:t + 1]), dev(k[:, t:t + 1]), dev(v[:, t:t + 1]),
+            dev(beta[:, t:t + 1]), dev(g[:, t:t + 1]),
+            scale=scale, initial_state=state_tt, device=mesh_device, high_precision=True,
+        )
+        o_rec[t] = ttnn.to_torch(o_tt, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))[:1].reshape(H, Dv)
+
+    # ---- TT chunk kernel over the whole sequence ----
+    o_ck, _ = chunk_gated_delta_rule_seq_adapter(
+        dev(q), dev(k), dev(v), dev(beta), dev(g),
+        chunk_size=128, scale=scale, initial_state=None, device=mesh_device, valid_len=T,
+    )
+    o_chunk = ttnn.to_torch(o_ck, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))[:1].reshape(T, H, Dv)
+
+    logger.info(f"GDNCVT overall  recurrent_vs_torch={_pcc(o_rec, o_ref):.5f}  chunk_vs_torch={_pcc(o_chunk, o_ref):.5f}  "
+                f"chunk_vs_recurrent={_pcc(o_chunk, o_rec):.5f}")
+    for lo in range(0, T, 32):
+        hi = min(lo + 32, T)
+        rvt = sum(_pcc(o_rec[p], o_ref[p]) for p in range(lo, hi)) / (hi - lo)
+        cvt = sum(_pcc(o_chunk[p], o_ref[p]) for p in range(lo, hi)) / (hi - lo)
+        logger.info(f"GDNCVT pos[{lo}-{hi-1}] recurrent_vs_torch={rvt:.5f} chunk_vs_torch={cvt:.5f}")

--- a/models/demos/blackhole/qwen36/tests/test_gdn_drift.py
+++ b/models/demos/blackhole/qwen36/tests/test_gdn_drift.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Multi-step GDN recurrent-decode drift probe (unit level, no full model).
+
+Runs recurrent_gated_delta_rule_decode_ttnn for N steps carrying state, with the SAME per-step
+random q/k/v/beta/g on TT and a torch fp32 reference (identical recurrence: L2-norm q/k, q*scale,
+S=decay*S; mem=k@S; delta=(v-mem)*beta; S+=k⊗delta; o=q@S). Reports PCC(o_t^TT, o_t^ref) vs step.
+If PCC decays with t → the recurrent decode numerics drift (a decode-drift cause); if stable → the
+recurrence is sound and the full-model drift comes from the input feedback (attention/hidden state).
+
+HIGH_PREC=1 (default) matches the model's fp32 decode; HIGH_PREC=0 tests bf16. N via GDN_STEPS.
+Run: MESH_DEVICE=P150x4 pytest .../test_gdn_drift.py -s
+"""
+import os
+import torch
+
+import ttnn
+from models.demos.blackhole.qwen36.tests.test_factory import parametrize_mesh_tp
+from models.experimental.gated_attention_gated_deltanet.tt.ttnn_delta_rule_ops import (
+    recurrent_gated_delta_rule_decode_ttnn,
+)
+
+
+def _pcc(a, b):
+    a, b = a.float().flatten(), b.float().flatten()
+    return torch.corrcoef(torch.stack([a, b]))[0, 1].item()
+
+
+def _l2(x):
+    return x / (x.pow(2).sum(-1, keepdim=True).sqrt() + 1e-12)
+
+
+@parametrize_mesh_tp()
+def test_gdn_drift(mesh_device):
+    from loguru import logger
+
+    H, Dk, Dv = 12, 128, 128
+    B = 1
+    N = int(os.environ.get("GDN_STEPS", "256"))
+    hp = os.environ.get("HIGH_PREC", "1") == "1"
+    scale = Dk**-0.5
+    torch.manual_seed(0)
+    rep = ttnn.ReplicateTensorToMesh(mesh_device)
+
+    def dev(t, dt=ttnn.bfloat16):
+        return ttnn.from_torch(t, dtype=dt, layout=ttnn.TILE_LAYOUT, device=mesh_device, mesh_mapper=rep)
+
+    # torch fp32 reference state + TT state (start identical, zero)
+    h_ref = torch.zeros(H, Dk, Dv, dtype=torch.float32)
+    state_tt = dev(torch.zeros(B, H, Dk, Dv), ttnn.float32 if hp else ttnn.bfloat16)
+
+    pccs = []
+    for t in range(N):
+        q = torch.randn(B, 1, H, Dk) * 0.3
+        k = torch.randn(B, 1, H, Dk) * 0.3
+        v = torch.randn(B, 1, H, Dv) * 0.3
+        beta = torch.rand(B, 1, H)
+        g = -torch.rand(B, 1, H) * 0.05  # decay = exp(g) ~ 0.95-1.0 (realistic, near 1)
+
+        # ---- torch fp32 reference (single lane b=0) ----
+        qn = (_l2(q[0, 0]) * scale)  # [H,Dk]
+        kn = _l2(k[0, 0])            # [H,Dk]
+        vt = v[0, 0]                 # [H,Dv]
+        decay = torch.exp(g[0, 0])   # [H]
+        S = h_ref * decay[:, None, None]
+        mem = torch.einsum("hk,hkv->hv", kn, S)
+        delta = (vt - mem) * beta[0, 0][:, None]
+        S = S + torch.einsum("hk,hv->hkv", kn, delta)
+        o_ref = torch.einsum("hk,hkv->hv", qn, S)
+        h_ref = S
+
+        # ---- TT recurrent decode ----
+        o_tt, state_tt = recurrent_gated_delta_rule_decode_ttnn(
+            dev(q.reshape(B, 1, H, Dk)), dev(k.reshape(B, 1, H, Dk)), dev(v.reshape(B, 1, H, Dv)),
+            dev(beta.reshape(B, 1, H)), dev(g.reshape(B, 1, H)),
+            scale=scale, initial_state=state_tt, device=mesh_device, high_precision=hp,
+        )
+        o_t = ttnn.to_torch(o_tt, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))[:1].reshape(H, Dv)
+        p = _pcc(o_t, o_ref)
+        pccs.append(p)
+        if (t + 1) % 32 == 0 or t < 4:
+            logger.info(f"GDN_DRIFT step {t+1}/{N} hp={hp} PCC(o)={p:.5f}")
+    logger.info(f"GDN_DRIFT_SUMMARY hp={hp} N={N} PCC first={pccs[0]:.5f} mid={pccs[N//2]:.5f} "
+                f"last={pccs[-1]:.5f} min={min(pccs):.5f}")

--- a/models/demos/blackhole/qwen36/tests/test_gsm8k_resync.py
+++ b/models/demos/blackhole/qwen36/tests/test_gsm8k_resync.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Rigorous GSM8K eval of Option A (periodic decode re-sync) on the demo path.
+
+0-shot chat (short prompt → re-sync stays cheap; the few-shot prompt would dominate re-prefill cost),
+EOS-terminated generation, robust answer extraction (number after '####', else the last number).
+Compares pure decode vs re-sync (full / sliding-window) over N GSM8K test problems.
+
+Run: GSM8K_DATA=/data/gsm8k.json GSM8K_N=12 MESH_DEVICE=P150x4 HF_MODEL=Qwen/Qwen3.6-27B \
+     pytest .../test_gsm8k_resync.py -s
+"""
+import json
+import os
+import re
+import time
+
+import torch
+
+import ttnn
+from models.demos.blackhole.qwen36.tests.test_factory import model_path, parametrize_mesh_tp
+from models.demos.blackhole.qwen36.tt.model import Qwen36Model
+
+CONFIGS = [("pure", 0, None), ("N4_full", 4, None)]
+
+
+def _gold(item):
+    if "gold" in item:
+        return str(item["gold"]).replace(",", "").strip()
+    m = re.search(r"####\s*(-?[\d,]+)", item.get("a", ""))
+    return m.group(1).replace(",", "").strip() if m else None
+
+
+def _extract(txt):
+    m = re.findall(r"####\s*(-?[\d,]+)", txt)
+    if m:
+        return m[-1].replace(",", "").strip()
+    nums = re.findall(r"-?[\d,]+", txt.replace(",", ""))
+    return nums[-1] if nums else None
+
+
+@parametrize_mesh_tp()
+def test_gsm8k_resync(mesh_device):
+    from loguru import logger
+    from transformers import AutoTokenizer
+
+    os.environ.setdefault("HF_MODEL", model_path())
+    mesh_device.enable_program_cache()
+    model = Qwen36Model.from_pretrained(mesh_device, max_batch_size=1, max_seq_len=2048)
+    tok = AutoTokenizer.from_pretrained(model.args.CKPT_DIR, trust_remote_code=True)
+    eos = tok.eos_token_id
+
+    data = json.load(open(os.environ["GSM8K_DATA"]))
+    tests = data["test"][: int(os.environ.get("GSM8K_N", "12"))]
+    MAXNEW = int(os.environ.get("GSM8K_MAXNEW", "480"))
+
+    think = os.environ.get("THINK", "0") == "1"
+
+    def ids_of(q):
+        msg = [{"role": "user", "content":
+                q + "\n\nSolve step by step. End with the final answer on its own line as: #### <number>"}]
+        kw = {} if think else {"enable_thinking": False}
+        try:
+            return list(tok.apply_chat_template(msg, add_generation_prompt=True, tokenize=True, return_dict=False, **kw))
+        except TypeError:
+            return list(tok.apply_chat_template(msg, add_generation_prompt=True, tokenize=True, return_dict=False))
+
+    summary = {}
+    for name, N, win in CONFIGS:
+        ok = 0
+        t0 = time.perf_counter()
+        ntok = 0
+        for i, item in enumerate(tests):
+            gold = _gold(item)
+            out = model.generate_tp_resync(ids_of(item["q"]), max_new_tokens=MAXNEW,
+                                           resync_every=N, eos_id=eos, window=win)
+            ntok += len(out)
+            pred = _extract(tok.decode(out, skip_special_tokens=True))
+            hit = pred is not None and gold is not None and pred == gold
+            ok += int(hit)
+            logger.info(f"GSM8KRS cfg={name} #{i} gold={gold} pred={pred} hit={hit} ntok={len(out)}")
+        dt = time.perf_counter() - t0
+        acc = ok / len(tests)
+        summary[name] = (ok, len(tests), acc, ntok / dt if dt else 0)
+        logger.info(f"GSM8KRS_SUMMARY cfg={name} acc={ok}/{len(tests)}={acc:.3f} tok/s={ntok/dt:.2f} elapsed={dt:.0f}s")
+
+    for name, (ok, n, acc, tps) in summary.items():
+        logger.info(f"GSM8KRS_FINAL {name}: {ok}/{n} = {acc:.1%}  {tps:.2f} tok/s")

--- a/models/demos/blackhole/qwen36/tests/test_paged_vs_internal.py
+++ b/models/demos/blackhole/qwen36/tests/test_paged_vs_internal.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Localize the serving-specific decode collapse: paged-KV decode vs internal-cache decode, LONG.
+
+Serving pure decode collapses to multilingual garbage (~pos 104) while the demo internal-cache decode
+stays coherent — isolated (by ruling out fused + traced) to the PAGED KV path. This runs BOTH decode
+paths teacher-forced with the SAME tokens over many steps (full model) and reports per-step logits PCC,
+so the step/position where paged diverges from the internal oracle pinpoints the paged bug
+(block-boundary at 64/128, page_table indexing, or paged SDPA-decode).
+
+Run: MESH_DEVICE=P150x4 HF_MODEL=Qwen/Qwen3.6-27B pytest .../test_paged_vs_internal.py -s
+"""
+import os
+import torch
+
+import ttnn
+from models.demos.blackhole.qwen36.tests.test_factory import model_path, parametrize_mesh_tp
+from models.demos.blackhole.qwen36.tt.model import Qwen36Model
+
+
+def _pcc(a, b):
+    a, b = a.float().flatten(), b.float().flatten()
+    return torch.corrcoef(torch.stack([a, b]))[0, 1].item()
+
+
+@parametrize_mesh_tp()
+def test_paged_vs_internal(mesh_device):
+    from loguru import logger
+
+    os.environ.setdefault("HF_MODEL", model_path())
+    mesh_device.enable_program_cache()
+    nl = int(os.environ["N_LAYERS"]) if os.environ.get("N_LAYERS") else None
+    model = Qwen36Model.from_pretrained(mesh_device, max_batch_size=1, max_seq_len=512, n_layers=nl)
+    vocab = model.args.vocab_size
+    T = int(os.environ.get("T", "64"))
+    N_DEC = int(os.environ.get("N_DEC", "80"))
+    torch.manual_seed(0)
+    prompt = torch.randint(0, vocab, (T,)).tolist()
+    comp0 = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
+
+    # ---- oracle: internal concat KV (demo path), greedy, record per-step logits + fed tokens ----
+    model.reset_tp()
+    ref_logits = [model.prefill_tp(torch.tensor([prompt], dtype=torch.long), valid_len=T).reshape(-1)[:vocab]]
+    ref = [int(torch.argmax(ref_logits[0]))]
+    pos = T
+    for _ in range(N_DEC):
+        lg = model.decode_tp(ref[-1], pos).reshape(-1)[:vocab]
+        ref_logits.append(lg)
+        ref.append(int(torch.argmax(lg)))
+        pos += 1
+
+    # ---- paged KV (serving path), teacher-forced with the SAME tokens ----
+    block_size = int(os.environ.get("BLOCK_SIZE", "64"))
+    num_blocks = 512 // block_size + 8
+    page_table = torch.arange(num_blocks, dtype=torch.int32).reshape(1, num_blocks)
+    kv_shape = (num_blocks, model.args.n_local_kv_heads, block_size, model.args.head_dim)
+    model.allocate_kv_caches(kv_shape, ttnn.bfloat16, batch_size=1)
+    c_dev = model.prefill_paged(torch.tensor([prompt], dtype=torch.long), page_table, valid_len=T)
+    c_logits = [ttnn.to_torch(c_dev, mesh_composer=comp0).reshape(-1, vocab)[0].float()]
+    pos = T
+    for i in range(N_DEC):
+        dev = model.prepare_inputs_decode(
+            torch.tensor([[ref[i]]], dtype=torch.int32), torch.tensor([pos], dtype=torch.int32), page_table
+        )
+        out, _ = model.ttnn_decode_forward(dev[0], dev[1], rot_mat_idxs=dev[2], page_table=dev[3])
+        c_logits.append(model.process_output_decode(out, 1).reshape(-1)[:vocab].float())
+        pos += 1
+
+    logger.info(f"PVI n_layers={len(model.layers)} T={T} N_DEC={N_DEC} block_size={block_size}")
+    for i, (r, c) in enumerate(zip(ref_logits, c_logits)):
+        p = _pcc(r, c)
+        agree = int(torch.argmax(r) == torch.argmax(c))
+        tag = "prefill" if i == 0 else f"decode pos={T + i - 1}"
+        if p < 0.99 or i < 3 or i % 8 == 0 or not agree:
+            logger.info(f"PVI step{i} {tag}: PCC={p:.5f} argmax_agree={agree}")
+    ps = [_pcc(r, c) for r, c in zip(ref_logits, c_logits)]
+    logger.info(f"PVI_SUMMARY min_pcc={min(ps):.5f} at_step={ps.index(min(ps))} "
+                f"first_below_0.99={next((i for i,p in enumerate(ps) if p<0.99), -1)} last_pcc={ps[-1]:.5f}")

--- a/models/demos/blackhole/qwen36/tests/test_prefill_gen.py
+++ b/models/demos/blackhole/qwen36/tests/test_prefill_gen.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Decisive: autoregressive generation via the PREFILL/score path (no decode path at all).
+
+Each step re-prefills the whole sequence (score_tp) and greedily takes the last-position argmax.
+Slow (O(L) prefills), but it uses the HEALTHY prefill path for generation, bypassing the decode
+path entirely. If GSM8K is solved here -> the decode path IS the culprit (prefill-gen works). If it
+also fails -> the model/prompt behavior is the cause and the TT decode path is exonerated.
+
+Runs a few GSM8K problems (chat-style CoT). Env: PFGEN_N (default 3), PFGEN_MAXNEW (default 160).
+"""
+import os
+import re
+import torch
+
+import ttnn
+from models.demos.blackhole.qwen36.tests.test_factory import model_path, parametrize_mesh_tp
+from models.demos.blackhole.qwen36.tt.model import Qwen36Model
+
+
+def _pad128(n):
+    return ((n + 127) // 128) * 128
+
+
+@parametrize_mesh_tp()
+def test_prefill_gen(mesh_device):
+    from loguru import logger
+    from datasets import load_dataset
+    from transformers import AutoTokenizer
+
+    os.environ.setdefault("HF_MODEL", model_path())
+    mesh_device.enable_program_cache()
+    model = Qwen36Model.from_pretrained(mesh_device, max_batch_size=1, max_seq_len=2048)
+    tok = AutoTokenizer.from_pretrained(model.args.CKPT_DIR, trust_remote_code=True)
+    te = load_dataset("openai/gsm8k", "main", split="test")
+    N = int(os.environ.get("PFGEN_N", "3"))
+    MAXNEW = int(os.environ.get("PFGEN_MAXNEW", "160"))
+
+    def gen(prompt_ids, n):
+        ids = list(prompt_ids)
+        for _ in range(n):
+            L = len(ids)
+            Tp = _pad128(L)
+            padded = torch.zeros(1, Tp, dtype=torch.long)
+            padded[0, :L] = torch.tensor(ids)
+            logits = model.score_tp(padded, valid_len=L)  # [Tp, vocab]
+            nxt = int(logits[L - 1].argmax().item())
+            ids.append(nxt)
+            if nxt == tok.eos_token_id:
+                break
+        return ids[len(prompt_ids):]
+
+    correct = 0
+    for i in range(N):
+        q = te[i]["question"]
+        gold = te[i]["answer"].split("####")[-1].strip().replace(",", "")
+        prompt = f"Question: {q}\nAnswer: Let's think step by step."
+        pid = tok(prompt, return_tensors="pt").input_ids[0].tolist()
+        out_ids = gen(pid, MAXNEW)
+        txt = tok.decode(out_ids)
+        nums = re.findall(r"[\-0-9][0-9,]*\.?[0-9]*", txt.replace(",", ""))
+        pred = nums[-1].rstrip(".") if nums else None
+        ok = pred == gold
+        correct += int(ok)
+        logger.info(f"PFGEN#{i} gold={gold} pred={pred} ok={ok} :: {txt[:300]!r}")
+    logger.info(f"PFGEN_SUMMARY prefill-path-gen N={N} correct={correct} (decode path bypassed)")

--- a/models/demos/blackhole/qwen36/tests/test_resync_eval.py
+++ b/models/demos/blackhole/qwen36/tests/test_resync_eval.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Option A productionization eval (a: generate_tp_resync method; b: throughput; c: sliding-window;
+e: multi-problem robustness). Runs several GSM8K problems x configs (pure decode / re-sync full /
+re-sync window) and reports correctness + wall-clock tok/s.
+
+Run: MESH_DEVICE=P150x4 HF_MODEL=Qwen/Qwen3.6-27B pytest .../test_resync_eval.py -s
+"""
+import os
+import re
+import time
+import torch
+
+import ttnn
+from models.demos.blackhole.qwen36.tests.test_factory import model_path, parametrize_mesh_tp
+from models.demos.blackhole.qwen36.tt.model import Qwen36Model
+
+PROBLEMS = [
+    ("Janet's ducks lay 16 eggs per day. She eats three for breakfast and bakes four into muffins. "
+     "She sells the remainder at the market for two dollars per egg. How many dollars does she make "
+     "every day?", 18),
+    ("Weng earns $12 an hour for babysitting. Yesterday, she just did 50 minutes of babysitting. "
+     "How much did she earn?", 10),
+    ("Betty is saving for a $100 wallet. She has only half of the money she needs. Her parents give "
+     "her $15, and her grandparents give twice as much as her parents. How much more money does "
+     "Betty need to buy the wallet?", 5),
+]
+CONFIGS = [("pure", 0, None), ("N4_full", 4, None), ("N4_win64", 4, 64)]
+
+
+@parametrize_mesh_tp()
+def test_resync_eval(mesh_device):
+    from loguru import logger
+    from transformers import AutoTokenizer
+
+    os.environ.setdefault("HF_MODEL", model_path())
+    mesh_device.enable_program_cache()
+    model = Qwen36Model.from_pretrained(mesh_device, max_batch_size=1, max_seq_len=2048)
+    tok = AutoTokenizer.from_pretrained(model.args.CKPT_DIR, trust_remote_code=True)
+    eos = tok.eos_token_id
+    MAXNEW = 256
+
+    def ids_of(q):
+        msg = [{"role": "user", "content": q + " Think step by step and end with the final number."}]
+        return list(tok.apply_chat_template(msg, add_generation_prompt=True, tokenize=True, return_dict=False))
+
+    results = {}
+    for name, N, win in CONFIGS:
+        n_ok = 0
+        tot_tok = 0
+        tot_t = 0.0
+        for q, gold in PROBLEMS:
+            ids = ids_of(q)
+            t0 = time.perf_counter()
+            out = model.generate_tp_resync(ids, max_new_tokens=MAXNEW, resync_every=N, eos_id=eos, window=win)
+            dt = time.perf_counter() - t0
+            txt = tok.decode(out, skip_special_tokens=True)
+            nums = re.findall(r"-?\d+", txt.replace(",", ""))
+            # correct if the gold number is the last distinct number mentioned (final answer)
+            ok = len(nums) > 0 and str(gold) in nums[-3:]
+            n_ok += int(ok)
+            tot_tok += len(out)
+            tot_t += dt
+            logger.info(f"RESYNCEVAL cfg={name} gold={gold} ok={ok} ntok={len(out)} t={dt:.1f}s "
+                        f"tps={len(out)/dt:.2f} last_nums={nums[-4:]}")
+        tps = tot_tok / tot_t if tot_t else 0
+        results[name] = (n_ok, len(PROBLEMS), tps)
+        logger.info(f"RESYNCEVAL_SUMMARY cfg={name} correct={n_ok}/{len(PROBLEMS)} agg_tps={tps:.2f}")
+
+    for name in results:
+        n_ok, ntot, tps = results[name]
+        logger.info(f"RESYNCEVAL_FINAL {name}: {n_ok}/{ntot} correct, {tps:.2f} tok/s")

--- a/models/demos/blackhole/qwen36/tests/test_sdpa_pcc.py
+++ b/models/demos/blackhole/qwen36/tests/test_sdpa_pcc.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit: scaled_dot_product_attention_decode kernel fidelity vs a torch reference.
+
+Decode uses ttnn.transformer.scaled_dot_product_attention_decode reading a KV cache. This measures
+that op's fidelity against exact softmax(qKᵀ·scale)V computed on the SAME bf16-rounded q/K/V (so the
+PCC gap is the KERNEL's, not input quantization). We sweep the two axes that could explain why the
+user's branch (yito/qwen36_27b_p300x2_tp) had better decode accuracy than main:
+  - program_config: main (grid (8,8), q/k_chunk=0) vs branch (q/k_chunk=32, max_cores_per_head_batch=16)
+  - compute_kernel_config: HiFi2 (main default, math_approx_mode=True) vs HiFi4 (math_approx_mode=False)
+Both MHA (NKV=NH) and GQA (NKV=1, kernel broadcasts) are tested.
+
+Correct API shapes (from model.forward_decode + branch attn()):
+  q          [1, B, NH, HD]            TILE
+  K/V cache  [B, NKV, max_seq, HD]     TILE, bf16
+  cur_pos    [B] int32                 ROW_MAJOR, replicated   <-- was [NH]=8 (wrong) → hard crash
+
+Run: MESH_DEVICE=P150x4 pytest models/demos/blackhole/qwen36/tests/test_sdpa_pcc.py -s
+"""
+import torch
+
+import ttnn
+from models.demos.blackhole.qwen36.tests.test_factory import parametrize_mesh_tp
+from models.demos.blackhole.qwen36.tt.tp_common import COMPUTE_HIFI2, COMPUTE_HIFI4
+
+
+def _pcc(a, b):
+    a, b = a.float().flatten(), b.float().flatten()
+    return torch.corrcoef(torch.stack([a, b]))[0, 1].item()
+
+
+def _torch_ref(q, K, V, scale):
+    # exact attention on the (already bf16-rounded) tensors, upcast to fp32 for the matmul.
+    # q [1,NH,1,HD]; K/V [1,NH,S,HD] (GQA: NKV<NH keys repeated). Returns [NH, HD].
+    NH = q.shape[1]
+    NKV = K.shape[1]
+    rep = NH // NKV
+    Kr = K.repeat_interleave(rep, dim=1).float()
+    Vr = V.repeat_interleave(rep, dim=1).float()
+    attn = torch.softmax((q.float() @ Kr.transpose(-1, -2)) * scale, dim=-1)  # [1,NH,1,S]
+    return (attn @ Vr)[0, :, 0, :]
+
+
+@parametrize_mesh_tp()
+def test_sdpa_pcc(mesh_device):
+    from loguru import logger
+
+    NH, HD, S, MAXS = 8, 128, 128, 256
+    scale = HD**-0.5
+    B = 1
+    torch.manual_seed(0)
+    rep = ttnn.ReplicateTensorToMesh(mesh_device)
+
+    main_cfg = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=(8, 8), exp_approx_mode=False, q_chunk_size=0, k_chunk_size=0
+    )
+    branch_cfg = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=mesh_device.compute_with_storage_grid_size(),
+        q_chunk_size=32,
+        k_chunk_size=32,
+        max_cores_per_head_batch=16,
+    )
+
+    def dev(t):
+        return ttnn.from_torch(t, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=mesh_device, mesh_mapper=rep)
+
+    # (NKV, cache_len): full-cache (MAXS==S, matches branch's cur_pos=ctx-1) vs partial-fill (MAXS>S,
+    # the real decode case where positions > cur_pos are still zero).
+    for NKV, MAXS in ((NH, S), (NH, 256), (1, S), (1, 256)):
+        # bf16-round the reference inputs so the PCC gap reflects the kernel, not quantization.
+        q = (torch.randn(1, NH, 1, HD) * 0.5).to(torch.bfloat16).float()
+        K = (torch.randn(1, NKV, S, HD) * 0.5).to(torch.bfloat16).float()
+        V = (torch.randn(1, NKV, S, HD) * 0.5).to(torch.bfloat16).float()
+        o_ref = _torch_ref(q, K, V, scale)  # [NH, HD]
+
+        # device tensors: q [1,B,NH,HD]; cache [B,NKV,MAXS,HD] with [:S] filled, rest zero
+        q_dec = q.permute(0, 2, 1, 3).contiguous()  # [1,1,NH,HD]
+        Kc = torch.zeros(B, NKV, MAXS, HD)
+        Vc = torch.zeros(B, NKV, MAXS, HD)
+        Kc[:, :, :S] = K[0]
+        Vc[:, :, :S] = V[0]
+        cur = ttnn.from_torch(
+            torch.tensor([S - 1] * B, dtype=torch.int32),
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=mesh_device,
+            mesh_mapper=rep,
+        )
+
+        def run(prog, comp):
+            qd, kd, vd = dev(q_dec), dev(Kc), dev(Vc)
+            o = ttnn.transformer.scaled_dot_product_attention_decode(
+                qd, kd, vd, cur_pos_tensor=cur, scale=scale, program_config=prog, compute_kernel_config=comp
+            )
+            ot = ttnn.to_torch(o, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))[:1].reshape(NH, HD)
+            for t in (qd, kd, vd, o):
+                ttnn.deallocate(t)
+            return ot
+
+        variants = [
+            ("main_cfg+HiFi2", main_cfg, COMPUTE_HIFI2),
+            ("main_cfg+HiFi4", main_cfg, COMPUTE_HIFI4),
+            ("branch_cfg+HiFi2", branch_cfg, COMPUTE_HIFI2),
+            ("branch_cfg+HiFi4", branch_cfg, COMPUTE_HIFI4),
+        ]
+        head = "MHA" if NKV == NH else f"GQA(NKV={NKV})"
+        kind = f"{head} cache={'full' if MAXS == S else 'partial'}"
+        for name, prog, comp in variants:
+            try:
+                o = run(prog, comp)
+                logger.info(f"SDPA_DECODE {kind} {name}: PCC_vs_torch={_pcc(o, o_ref):.6f}")
+            except Exception as e:
+                logger.info(f"SDPA_DECODE {kind} {name}: FAILED {type(e).__name__}: {str(e)[:120]}")

--- a/models/demos/blackhole/qwen36/tt/attention/tp.py
+++ b/models/demos/blackhole/qwen36/tt/attention/tp.py
@@ -26,6 +26,19 @@ from models.demos.blackhole.qwen36.tt import tp_common as tpc
 from models.demos.blackhole.qwen36.tt.attention.rope_tp import apply_partial_rope_decode, apply_partial_rope_prefill
 from models.tt_transformers.tt.ccl import tt_all_reduce
 
+# Root-cause instrumentation (QWEN_ATTN_CAPTURE=1): per full-attn-layer capture of q-post-rope and
+# the SDPA output, in both prefill and decode paths, so a test can localize the decode divergence to
+# RoPE (q) vs SDPA/KV (attn out). Each call appends (mode, name, device0-shard torch tensor).
+_ATTN_CAP = []
+
+
+def _cap(mode, name, t, mesh):
+    import os as _os
+    if _os.environ.get("QWEN_ATTN_CAPTURE") != "1":
+        return
+    tt = ttnn.to_torch(t, mesh_composer=ttnn.ConcatMeshToTensor(mesh, dim=0))
+    _ATTN_CAP.append((mode, name, tt))
+
 
 def load_attention_weights_tp(mesh, state_dict, args, cache_dir=None):
     """Shard one full-attention layer's weights across the mesh.
@@ -117,6 +130,8 @@ class TPAttention:
         self.scale = self.HD**-0.5
         self.rope_dim = args.rope_head_dim
         self.compute_cfg = tpc.COMPUTE_HIFI2
+        # Decode-precision probe: HiFi4 for decode QKV/out linears + SDPA under QWEN_DECODE_HIFI4=1.
+        self.compute_cfg_dec = tpc.COMPUTE_HIFI4 if os.environ.get("QWEN_DECODE_HIFI4") == "1" else self.compute_cfg
         self.k_caches = None
         self.v_caches = None
         # Paged KV cache (vLLM / model-contract path). Bound via set_paged_kv_cache;
@@ -177,6 +192,7 @@ class TPAttention:
         k = ttnn.multiply(ttnn.rms_norm(k, epsilon=1e-6), tw["k_norm"])
         q = apply_partial_rope_prefill(q, cos_tt, sin_tt, NH, self.rope_dim)
         k = apply_partial_rope_prefill(k, cos_tt, sin_tt, NKV, self.rope_dim)
+        _cap("prefill", "q_rope", q, self.mesh)
 
         # Fill the per-head KV cache with the prompt's (post-RoPE) K/V so decode
         # continues from position S. Only when caches are allocated (stateful path).
@@ -209,6 +225,7 @@ class TPAttention:
         ttnn.deallocate(q8)
         ttnn.deallocate(k8)
         ttnn.deallocate(v8)
+        _cap("prefill", "attn_out", attn, self.mesh)
 
         gated = ttnn.multiply(attn, ttnn.sigmoid(gate))  # [1,NH,S,HD]
         ttnn.deallocate(attn)
@@ -239,7 +256,7 @@ class TPAttention:
         # Fused QKV: one matmul then split into [q|gate], k, v (branch's fused-QKV attn()).
         qsz, ksz = NH * HD * 2, NKV * HD
         qkv = ttnn.linear(
-            x, tw["wqkv_all"], compute_kernel_config=self.compute_cfg, memory_config=ttnn.DRAM_MEMORY_CONFIG
+            x, tw["wqkv_all"], compute_kernel_config=self.compute_cfg_dec, memory_config=ttnn.DRAM_MEMORY_CONFIG
         )
         qg = ttnn.slice(qkv, (0, 0, 0, 0), (1, 1, B, qsz))
         kp = ttnn.slice(qkv, (0, 0, 0, qsz), (1, 1, B, qsz + ksz))
@@ -258,12 +275,15 @@ class TPAttention:
 
         # QK RMSNorm — raw (no-+1) at DECODE only (hybrid scaling): sharp +1 prefill retrieves the
         # long context; flat decode averages over keys so the per-step decode noise cannot flip
-        # retrieval (the loop/junk failure mode).
-        q = ttnn.multiply(ttnn.rms_norm(q, epsilon=1e-6), tw["q_norm_flat"])
-        k = ttnn.multiply(ttnn.rms_norm(k, epsilon=1e-6), tw["k_norm_flat"])
+        # retrieval (the loop/junk failure mode). QWEN_ATTN_SHARP_DECODE=1 uses the HF-correct sharp
+        # (+1) norm at decode too (root-cause probe: flat decode weakens retrieval → reasoning fails).
+        _qn, _kn = ("q_norm", "k_norm") if os.environ.get("QWEN_ATTN_SHARP_DECODE") == "1" else ("q_norm_flat", "k_norm_flat")
+        q = ttnn.multiply(ttnn.rms_norm(q, epsilon=1e-6), tw[_qn])
+        k = ttnn.multiply(ttnn.rms_norm(k, epsilon=1e-6), tw[_kn])
 
         q = apply_partial_rope_decode(q, cos_tt, sin_tt, NH, B, self.rope_dim)
         k = apply_partial_rope_decode(k, cos_tt, sin_tt, NKV, B, self.rope_dim)
+        _cap("decode", "q_rope", q, self.mesh)
 
         # Cap the SDPA-decode grid to 64 cores (tree-reduction limit); auto-grid
         # grabs all 110 P150 cores for a single user (B=1) and overflows.
@@ -273,6 +293,23 @@ class TPAttention:
         if use_paged:
             # External paged KV cache (vLLM/contract path): update at cur_pos via the
             # page_table, then paged SDPA-decode
+            # Paged SDPA-decode correctness fix: the ttnn op's CROSS-CORE tree reduction produces
+            # garbage once the valid KV (cur_pos) spans more than one k_chunk — teacher-forced paged
+            # vs internal-cache decode collapses at cur_pos≈128 (test_paged_vs_internal), which is the
+            # serving multilingual-garbage decode failure. max_cores_per_head_batch=1 runs all chunks
+            # of a head on ONE core via the within-core lazy-softmax (shared with the correct non-paged
+            # path), avoiding the buggy cross-core reduction, for ANY context length. k_chunk=128 keeps
+            # each chunk L1-safe. Validated: paged-vs-internal PCC ≥0.99 for all positions, and serving
+            # decode stays coherent past cur_pos=128. See qwen36_paged_sdpa_decode_bug.md. Env overrides
+            # (QWEN_PAGED_MAXCORES=0, QWEN_PAGED_KCHUNK=0) restore the stock config for perf experiments
+            # or once the kernel's tree reduction is fixed upstream. Trade-off: 1 core/head is slower.
+            _pmc = int(os.environ.get("QWEN_PAGED_MAXCORES", "1"))
+            _pkc = int(os.environ.get("QWEN_PAGED_KCHUNK", "128"))
+            _kw = dict(compute_with_storage_grid_size=(8, 8), exp_approx_mode=False,
+                       q_chunk_size=_pkc, k_chunk_size=_pkc)
+            if _pmc > 0:
+                _kw["max_cores_per_head_batch"] = _pmc
+            sdpa_dec_cfg = ttnn.SDPAProgramConfig(**_kw)
             keys, values = self.paged_k, self.paged_v
             k_p = ttnn.pad(k, [1, B, 32, HD], [0, 0, 0, 0], 0.0)
             v_p = ttnn.pad(v, [1, B, 32, HD], [0, 0, 0, 0], 0.0)
@@ -294,6 +331,7 @@ class TPAttention:
                 cur_pos_tensor=cur_pos_tt,
                 scale=self.scale,
                 program_config=sdpa_dec_cfg,
+                compute_kernel_config=self.compute_cfg_dec,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
             )
             ttnn.deallocate(q)
@@ -331,10 +369,12 @@ class TPAttention:
                 cur_pos_tensor=cur_pos_tt,
                 scale=self.scale,
                 program_config=sdpa_dec_cfg,
+                compute_kernel_config=self.compute_cfg_dec,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
             )
             ttnn.deallocate(q)
 
+        _cap("decode", "attn_out", attn_out, self.mesh)
         gated = ttnn.multiply(attn_out, ttnn.sigmoid(gate))
         ttnn.deallocate(attn_out)
         ttnn.deallocate(gate)
@@ -342,7 +382,7 @@ class TPAttention:
         gated_flat = ttnn.reshape(gated, (1, B, NH * HD))
         ttnn.deallocate(gated)
         wo_partial = ttnn.linear(
-            gated_flat, tw["wo"], compute_kernel_config=self.compute_cfg, memory_config=ttnn.DRAM_MEMORY_CONFIG
+            gated_flat, tw["wo"], compute_kernel_config=self.compute_cfg_dec, memory_config=ttnn.DRAM_MEMORY_CONFIG
         )
         ttnn.deallocate(gated_flat)
         wo_partial = ttnn.reshape(wo_partial, (1, 1, B, wo_partial.shape[-1]))

--- a/models/demos/blackhole/qwen36/tt/gdn/tp.py
+++ b/models/demos/blackhole/qwen36/tt/gdn/tp.py
@@ -134,6 +134,9 @@ class TPGatedDeltaNet:
         self.K = args.gdn_conv_kernel_size
         self.scale = self.Dk**-0.5
         self.cfg = tpc.COMPUTE_HIFI2
+        # Decode-precision probe: route decode linears (qkvz/ab/out) to HiFi4 (4-pass) under
+        # QWEN_DECODE_HIFI4=1, to test if decode's HiFi2 rounding drives the reasoning drift.
+        self.cfg_dec = tpc.COMPUTE_HIFI4 if os.environ.get("QWEN_DECODE_HIFI4") == "1" else self.cfg
         # Pre-build the chunk-prefill masks ONCE (replicated across the mesh) so the seq kernel
         # reads them from cache instead of rebuilding eye/triu/tril via from_torch on every call.
         # The from_torch fallback is a host write that TT_FATALs inside the captured chunk-outer
@@ -515,11 +518,11 @@ class TPGatedDeltaNet:
         if len(x.shape) == 4:
             x = ttnn.reshape(x, (1, x.shape[-2], x.shape[-1]))  # [1,B,dim]
 
-        qkvz = ttnn.linear(x, tw["qkvz"], compute_kernel_config=self.cfg, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        qkvz = ttnn.linear(x, tw["qkvz"], compute_kernel_config=self.cfg_dec, memory_config=ttnn.DRAM_MEMORY_CONFIG)
         qkv = ttnn.slice(qkvz, (0, 0, 0), (1, B, self.qkv_dim_tp))
         z = ttnn.slice(qkvz, (0, 0, self.qkv_dim_tp), (1, B, self.qkvz_dim_tp))
         ttnn.deallocate(qkvz)
-        ab = ttnn.linear(x, tw["ab"], compute_kernel_config=self.cfg, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        ab = ttnn.linear(x, tw["ab"], compute_kernel_config=self.cfg_dec, memory_config=ttnn.DRAM_MEMORY_CONFIG)
         a = ttnn.slice(ab, (0, 0, 0), (1, B, Nv))
         b = ttnn.slice(ab, (0, 0, Nv), (1, B, 2 * Nv))
         ttnn.deallocate(ab)
@@ -660,7 +663,7 @@ class TPGatedDeltaNet:
         ttnn.deallocate(out_f)
         ttnn.deallocate(z)
 
-        partial = ttnn.linear(gated, tw["out"], compute_kernel_config=self.cfg, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        partial = ttnn.linear(gated, tw["out"], compute_kernel_config=self.cfg_dec, memory_config=ttnn.DRAM_MEMORY_CONFIG)
         ttnn.deallocate(gated)
         partial = ttnn.reshape(partial, (1, 1, B, partial.shape[-1]))
         return tt_all_reduce(

--- a/models/demos/blackhole/qwen36/tt/layer.py
+++ b/models/demos/blackhole/qwen36/tt/layer.py
@@ -124,7 +124,14 @@ class Qwen36DecoderLayer:
         valid_len=None,
         batch_slot=None,
     ):
+        import os as _os
+
         _norm_mode = Mode.PREFILL if mode == "prefill" else Mode.DECODE
+        # Root-cause ablation: force decode norms to PREFILL mode (QWEN_DECODE_NORM_PREFILL=1) to
+        # test if the DistributedNorm decode-mode (all-gather-then-norm) vs prefill-mode is the
+        # decode-vs-prefill divergence source.
+        if mode == "decode" and _os.environ.get("QWEN_DECODE_NORM_PREFILL") == "1":
+            _norm_mode = Mode.PREFILL
         if self.num_devices > 1:
             # TP: DistributedNorm uses the framework's per-norm memory configs.
             _attn_norm_config = self.args.get_norm_config("attn", _norm_mode)

--- a/models/demos/blackhole/qwen36/tt/mlp.py
+++ b/models/demos/blackhole/qwen36/tt/mlp.py
@@ -109,6 +109,11 @@ class Qwen36MLP:
         self.compute_kernel_config_decode = ttnn.WormholeComputeKernelConfig(
             math_fidelity=ttnn.MathFidelity.LoFi, fp32_dest_acc_en=True, packer_l1_acc=True
         )
+        # Decode-precision probe: raise decode MLP matmuls to HiFi4 under QWEN_DECODE_HIFI4=1.
+        if os.environ.get("QWEN_DECODE_HIFI4") == "1":
+            self.compute_kernel_config_decode = ttnn.WormholeComputeKernelConfig(
+                math_fidelity=ttnn.MathFidelity.HiFi4, math_approx_mode=False, fp32_dest_acc_en=True, packer_l1_acc=True
+            )
 
     def forward(self, x):
         if self.num_devices > 1:

--- a/models/demos/blackhole/qwen36/tt/model.py
+++ b/models/demos/blackhole/qwen36/tt/model.py
@@ -213,6 +213,34 @@ class Qwen36Model:
         lt = ttnn.to_torch(logits, mesh_composer=ttnn.ConcatMeshToTensor(self.device, dim=0))
         return lt[0].reshape(-1)[: self.vocab_size]
 
+    def score_tp(self, token_ids, valid_len=None):
+        """All-position next-token logits for teacher-forced scoring / perplexity (num_devices>1).
+
+        token_ids: torch [1, T] (pad T to a 128-multiple for the GDN chunk kernel). Runs the full
+        prefill and projects EVERY position through norm + lm_head (no single-row slice — that
+        garbles at long T; projecting all positions is fine). Returns torch logits [T, vocab] (host,
+        one replica). Stateless: resets GDN/KV first. Decode-independent (fused path unused here)."""
+        from models.demos.blackhole.qwen36.tt.attention.rope_tp import rot_mats_prefill
+
+        B, T = token_ids.shape
+        assert B == 1, "score_tp is single-sequence"
+        self.reset_tp()
+        tok = ttnn.from_torch(
+            token_ids.to(torch.int32), dtype=ttnn.uint32, device=self.device,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.device),
+        )
+        x = self.embd(tok)
+        x = ttnn.reshape(x, (1, 1, T, x.shape[-1]))
+        cos, sin = rot_mats_prefill(self.device, self.args.rope_head_dim, T, self.args.rope_theta)
+        for layer in self.layers:
+            x = layer.forward(x, cos=cos, sin=sin, mode="prefill", chunk_size=128, valid_len=valid_len or T)
+        x = ttnn.to_memory_config(x, ttnn.DRAM_MEMORY_CONFIG)
+        x = self.norm(x, mode=Mode.PREFILL)  # DistributedNorm gathers → replicated full-dim, all positions
+        logits = ttnn.linear(x, self.lm_head_weight)  # [1, 1, T, vocab] replicated
+        lt = ttnn.to_torch(logits, mesh_composer=ttnn.ConcatMeshToTensor(self.device, dim=0))
+        lt = lt.reshape(-1, T, lt.shape[-1])[0]  # one replica → [T, vocab]
+        return lt[:, : self.vocab_size].float()
+
     def reset_tp(self):
         """Reset every TP layer's KV cache / GDN recurrent+conv state for a new sequence."""
         for layer in self.layers:
@@ -268,6 +296,61 @@ class Qwen36Model:
             logits = self.decode_tp(nxt, pos)
             nxt = int(torch.argmax(logits).item())
             out.append(nxt)
+        return out
+
+    def generate_tp_resync(self, prompt_ids, max_new_tokens=256, resync_every=4, eos_id=None, window=None):
+        """Decode-drift mitigation (Option A). The recurrent decode path is numerically accurate
+        (0.99998 vs torch) but continues a context prefill built in the chunk kernel's slightly-off
+        "chunk-space" (0.988 vs torch); the space mismatch compounds over a long generation into
+        number-confabulation and loops. This keeps decode consistent with chunk-space by periodically
+        re-prefilling: every `resync_every` generated tokens rebuild the attention KV cache + GDN
+        state via a chunk-prefill over the context, then resume fast recurrent decode.
+
+        window: None -> re-prefill the whole sequence-so-far (exact context, O(L) per re-sync). An
+        int W -> re-prefill prompt + the last W generated tokens only (bounded O(P+W) cost); positions
+        are relabeled to the compacted context, which retains the problem statement (the numbers that
+        confabulate) while dropping stale middle reasoning. resync_every<=0 -> pure decode (no re-sync).
+        B=1. Returns list[int] of generated ids.
+        """
+        import math as _math
+
+        assert self.args.max_batch_size == 1, "generate_tp_resync is B=1"
+        P = len(prompt_ids)
+        seq = list(prompt_ids)
+
+        def _prefill(ctx):
+            T = len(ctx)
+            Tp = max(128, _math.ceil(T / 128) * 128)
+            padded = list(ctx) + [0] * (Tp - T)
+            self.reset_tp()
+            lg = self.prefill_seed_tp(torch.tensor([padded], dtype=torch.long), valid_len=T, batch_slot=0)
+            for layer in self.layers:
+                if not layer.is_full_attention:
+                    layer.attention.finalize_seed(1)
+            return int(torch.argmax(lg).item()), T  # (next token id, next decode position)
+
+        def _ctx():
+            if window is None or len(seq) <= P + window:
+                return list(seq)
+            return list(seq[:P]) + list(seq[-window:])  # prompt + recent window (compacted positions)
+
+        nxt, effpos = _prefill(seq)
+        out = [nxt]
+        seq.append(nxt)
+        since = 0
+        for _ in range(max_new_tokens - 1):
+            if eos_id is not None and nxt == eos_id:
+                break
+            if resync_every and resync_every > 0 and since >= resync_every:
+                nxt, effpos = _prefill(_ctx())
+                since = 0
+            else:
+                lg = self.decode_tp_batched([seq[-1]], [effpos])
+                nxt = int(torch.as_tensor(lg).float().reshape(-1)[: self.vocab_size].argmax().item())
+                effpos += 1
+                since += 1
+            out.append(nxt)
+            seq.append(nxt)
         return out
 
     def prefill_seed_tp(self, token_ids, valid_len, batch_slot):

--- a/models/demos/blackhole/qwen36/tt/qwen36_vllm.py
+++ b/models/demos/blackhole/qwen36/tt/qwen36_vllm.py
@@ -135,6 +135,15 @@ class Qwen36ForCausalLM(Generator, SupportsMultiModal):
     def prefill_forward(self, tokens, page_table, kv_cache, prompt_lens, **kwargs):
         """All prefill is model-owned (Generator drives decode only)."""
         model = self.model[0]
+        # Decode-drift mitigation (Option A) — stash this sequence's prompt tokens + page table so
+        # decode_forward can periodically re-prefill (rebuild paged KV + GDN state in prefill's
+        # chunk-space). B=1 only; gated by TT_QWEN_DECODE_RESYNC_N (0 = off, default). See
+        # qwen36_decode_drift_fix_design.md.
+        if int(os.environ.get("TT_QWEN_DECODE_RESYNC_N", "0")) > 0 and tokens.shape[0] == 1:
+            T = int(prompt_lens[0]) if prompt_lens is not None else tokens.shape[1]
+            self._resync_seq = [int(x) for x in tokens[0, :T].tolist()]
+            self._resync_step = 0
+            self._resync_pt = page_table
         if model.num_devices > 1:
             return self._prefill_forward_tp(model, tokens, page_table, prompt_lens)
         seq_len = int(prompt_lens[0]) if prompt_lens is not None else tokens.shape[1]
@@ -182,7 +191,41 @@ class Qwen36ForCausalLM(Generator, SupportsMultiModal):
         if not getattr(self, "_decode_logged", False):
             self._decode_logged = True
             logger.info("Decode trace replay active (Qwen)")
+        # Decode-drift mitigation (Option A): every N decode steps, re-prefill positions [0,pos) to
+        # refresh the paged KV cache + GDN recurrent state into prefill's chunk-space (the recurrent
+        # decode path is accurate but drifts from the chunk-space context the model reasons under),
+        # then DELEGATE the actual step to the standard decode (so the decode output contract is
+        # untouched). B=1 + host sampling only; gated by TT_QWEN_DECODE_RESYNC_N (0 = off, default).
+        self._maybe_resync(*args, **kwargs)
         return super().decode_forward(*args, **kwargs)
+
+    def _maybe_resync(self, *args, **kwargs):
+        N = int(os.environ.get("TT_QWEN_DECODE_RESYNC_N", "0"))
+        if N <= 0 or getattr(self, "_resync_seq", None) is None:
+            return
+        tokens = kwargs.get("tokens", args[0] if len(args) > 0 else None)
+        start_pos = kwargs.get("start_pos", args[1] if len(args) > 1 else None)
+        page_table = kwargs.get("page_table", getattr(self, "_resync_pt", None))
+        if tokens is None or start_pos is None or page_table is None:
+            return
+        try:
+            if int(tokens.shape[0]) != 1:  # B=1 only
+                return
+            pos = int(start_pos.reshape(-1)[0])
+            tok0 = int(tokens.reshape(-1)[0])
+        except Exception:
+            return
+        # _resync_seq must hold exactly positions [0,pos) before this step caches tok0 at pos.
+        if len(self._resync_seq) == pos:
+            if self._resync_step > 0 and self._resync_step % N == 0 and pos >= 1:
+                seq = torch.tensor([self._resync_seq[:pos]], dtype=torch.long)
+                self.model[0].prefill_traced_chunked(seq, page_table, actual_len=pos)
+                logger.info(f"[resync] re-prefilled {pos} tokens at decode step {self._resync_step}")
+            self._resync_seq.append(tok0)
+        elif len(self._resync_seq) > pos:  # resync from a stale/re-run position: realign
+            self._resync_seq[pos] = tok0
+            del self._resync_seq[pos + 1:]
+        self._resync_step += 1
 
     def warmup_model_prefill(self, kv_cache, enable_trace, *args, **kwargs):
         # Single-device AND TP share this path: capture_prefill_trace_chunked dispatches to its

--- a/models/demos/blackhole/qwen36/tt/tp_common.py
+++ b/models/demos/blackhole/qwen36/tt/tp_common.py
@@ -35,6 +35,16 @@ COMPUTE_HIFI2 = ttnn.WormholeComputeKernelConfig(
     packer_l1_acc=True,
 )
 
+# Highest-fidelity (4-pass, full bf16 mantissa, no math-approx) — decode-precision probe.
+# QWEN_DECODE_HIFI4=1 routes the decode matmuls + SDPA here to test whether decode's per-op
+# rounding (vs the healthy prefill) is the reasoning-drift cause.
+COMPUTE_HIFI4 = ttnn.WormholeComputeKernelConfig(
+    math_fidelity=ttnn.MathFidelity.HiFi4,
+    math_approx_mode=False,
+    fp32_dest_acc_en=True,
+    packer_l1_acc=True,
+)
+
 
 # ── Grid helpers ────────────────────────────────────────────────────────────
 def prefill_grid_default():


### PR DESCRIPTION
Root-causes the TT-served Qwen3.6-27B decode accuracy failure and fixes the dominant cause. Stacked on #49588 (base `yito/qwen36-tp-fused-decode`); this PR is the decode-drift investigation + fix only.

## Two distinct decode problems

**1. Paged SDPA-decode cross-core tree-reduction bug (dominant — the serving "multilingual-garbage" collapse).**
`ttnn.transformer.paged_scaled_dot_product_attention_decode` returns garbage once the valid KV (`cur_pos`) spans more than one `k_chunk` across multiple cores; the non-paged op and the single-core within-core path are correct. Isolated by elimination: teacher-forced paged-vs-internal decode PCC collapses `0.99 → 0.51` at `cur_pos=128`, independent of `block_size`, and the collapse position moves with `k_chunk` → it is the cross-core softmax combine.

**Fix (config only, no kernel rebuild):** the paged branch of `attention/tp.py` sets `max_cores_per_head_batch=1` + `k_chunk=128`, routing multi-chunk decode through the correct within-core lazy-softmax for any context length. `QWEN_PAGED_MAXCORES=0` restores the stock config. Validated: paged-vs-internal decode PCC ≥ 0.99 at all positions, and serving decode stays coherent (was a ~30-token collapse). Upstream kernel bug documented in `docs/paged_sdpa_decode_bug.md`.

**2. GDN chunk(prefill) vs recurrent(decode) space mismatch (residual drift).**
The chunk kernel is `0.988` vs a torch reference while the recurrent decode is `0.99998`; the network is calibrated to chunk-space, so accurate recurrent decode drifts from the chunk-space context, limiting multi-step reasoning. Mitigation: `model.generate_tp_resync` (periodic re-prefill, Option A; demo GSM8K 0→25% at N=4) and a vLLM `decode_forward` re-sync hook in `qwen36_vllm.py` (`TT_QWEN_DECODE_RESYNC_N`, default off). Chunk-kernel precision (Option C) is SFPU-transcendental-limited (research-level); recurrent-prefill was refuted.

## Notes
- All diagnostic env flags default off; the fused-decode PRs are accuracy-neutral and unaffected.
- Adds the investigation test suite (`test_paged_vs_internal.py`, `test_gdn_chunk_vs_torch.py`, …) and design docs under `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=yito/qwen36-decode-drift-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:yito/qwen36-decode-drift-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=yito/qwen36-decode-drift-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:yito/qwen36-decode-drift-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=yito/qwen36-decode-drift-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:yito/qwen36-decode-drift-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=yito/qwen36-decode-drift-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:yito/qwen36-decode-drift-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=yito/qwen36-decode-drift-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:yito/qwen36-decode-drift-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=yito/qwen36-decode-drift-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:yito/qwen36-decode-drift-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=yito/qwen36-decode-drift-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:yito/qwen36-decode-drift-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=yito/qwen36-decode-drift-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:yito/qwen36-decode-drift-fix)