### PR TITLE
Bug fix: Clear stale remote CB configurations

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_global_circular_buffers.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_global_circular_buffers.cpp
@@ -23,6 +23,9 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <umd/device/types/xy_pair.hpp>
 
+#include "impl/program/program_impl.hpp"
+#include "tt_metal/impl/context/metal_context.hpp"
+
 namespace tt::tt_metal {
 
 TEST_F(MeshDispatchFixture, TensixProgramGlobalCircularBuffers) {
@@ -134,6 +137,84 @@ TEST_F(MeshDispatchFixture, TensixProgramGlobalCircularBuffers) {
         tt::tt_metal::SetRuntimeArgs(program_, compute_receiver_kernel, receiver_cores, receiver_runtime_args);
     }
     this->RunProgram(mesh_device, workload);
+}
+
+TEST_F(MeshDispatchFixture, TensixProgramClearsStaleRemoteCircularBufferConfig) {
+    const CoreCoord sender_core(0, 0);
+    const CoreCoord receiver_core(1, 0);
+    const CoreCoord idle_core(1, 1);
+    const CoreRangeSet sender_cores{CoreRange(sender_core)};
+    const CoreRangeSet receiver_cores{CoreRange(receiver_core)};
+    const CoreRangeSet all_cores(CoreRange({0, 0}, {1, 1}));
+    const CoreRangeSet all_receiver_cores = all_cores.subtract(sender_cores);
+    constexpr uint32_t cb_page_size = 32;
+    constexpr uint32_t remote_cb_index = 31;
+    constexpr uint32_t local_cb_index = 0;
+    constexpr tt::DataFormat tile_format = tt::DataFormat::Float16_b;
+
+    auto mesh_device = devices_[0];
+    auto* device = mesh_device->get_devices()[0];
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+
+    auto make_cb_config = [&]() {
+        CircularBufferConfig config(cb_page_size);
+        config.remote_index(remote_cb_index).set_page_size(cb_page_size).set_data_format(tile_format);
+        config.index(local_cb_index).set_page_size(cb_page_size).set_data_format(tile_format);
+        return config;
+    };
+    auto remote_config_address = [&](Program& program) {
+        const auto& hal = MetalContext::instance().hal();
+        const uint32_t programmable_core_index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+        return program.impl().get_cb_base_addr(device, idle_core, CoreType::WORKER) +
+               program.impl().get_program_config(programmable_core_index).local_cb_size;
+    };
+
+    // Create a valid config block that can be used as stale remote-CB state on idle_core.
+    std::vector<std::pair<CoreCoord, CoreRangeSet>> full_mapping = {{sender_core, all_receiver_cores}};
+    auto full_global_cb =
+        experimental::CreateGlobalCircularBuffer(mesh_device.get(), full_mapping, 3200, BufferType::L1);
+
+    // Run a rectangular kernel grid with a remote CB on only one receiver. Fast dispatch must overwrite stale config
+    // on idle_core with the zero sentinel that setup_remote_cb_interfaces() skips.
+    std::vector<std::pair<CoreCoord, CoreRangeSet>> sparse_mapping = {{sender_core, receiver_cores}};
+    auto sparse_global_cb =
+        experimental::CreateGlobalCircularBuffer(mesh_device.get(), sparse_mapping, 3200, BufferType::L1);
+    distributed::MeshWorkload sparse_workload;
+    Program sparse_program = CreateProgram();
+    experimental::CreateCircularBuffer(sparse_program, receiver_cores, make_cb_config(), sparse_global_cb);
+    CreateKernel(
+        sparse_program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/blank.cpp",
+        all_cores,
+        ReaderDataMovementConfig{});
+    sparse_workload.add_program(device_range, std::move(sparse_program));
+    auto& sparse_program_in_workload = sparse_workload.get_programs().at(device_range);
+    detail::CompileProgram(mesh_device.get(), sparse_program_in_workload);
+    sparse_program_in_workload.impl().finalize_offsets(mesh_device.get());
+
+    const uint32_t stale_remote_config_address = remote_config_address(sparse_program_in_workload);
+    std::vector<uint32_t> stale_remote_config = {full_global_cb.config_address(), cb_page_size};
+    detail::WriteToDeviceL1(device, idle_core, stale_remote_config_address, stale_remote_config);
+    std::vector<uint32_t> remote_config;
+    detail::ReadFromDeviceL1(
+        device,
+        idle_core,
+        stale_remote_config_address,
+        UINT32_WORDS_PER_REMOTE_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t),
+        remote_config);
+    ASSERT_EQ(remote_config, stale_remote_config);
+
+    this->RunProgram(mesh_device, sparse_workload);
+
+    remote_config.clear();
+    detail::ReadFromDeviceL1(
+        device,
+        idle_core,
+        remote_config_address(sparse_program_in_workload),
+        UINT32_WORDS_PER_REMOTE_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t),
+        remote_config);
+    EXPECT_EQ(remote_config, std::vector<uint32_t>(UINT32_WORDS_PER_REMOTE_CIRCULAR_BUFFER_CONFIG, 0));
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_global_circular_buffers.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_global_circular_buffers.cpp
@@ -162,8 +162,8 @@ TEST_F(MeshDispatchFixture, TensixProgramClearsStaleRemoteCircularBufferConfig) 
         config.index(local_cb_index).set_page_size(cb_page_size).set_data_format(tile_format);
         return config;
     };
-    // Run a rectangular kernel grid with a remote CB on only one receiver. Fast dispatch must overwrite stale config
-    // on idle_core with the zero sentinel that setup_remote_cb_interfaces() skips.
+    // Run a rectangular kernel grid with a remote CB on only one receiver. Dispatch must overwrite stale config on
+    // idle_core with the zero sentinel that setup_remote_cb_interfaces() skips.
     std::vector<std::pair<CoreCoord, CoreRangeSet>> sparse_mapping = {{sender_core, receiver_cores}};
     auto sparse_global_cb =
         experimental::CreateGlobalCircularBuffer(mesh_device.get(), sparse_mapping, 3200, BufferType::L1);
@@ -180,17 +180,8 @@ TEST_F(MeshDispatchFixture, TensixProgramClearsStaleRemoteCircularBufferConfig) 
 
     const auto& hal = MetalContext::instance().hal();
     const uint32_t programmable_core_index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
-    uint32_t poison_base;
-    uint32_t poison_size;
-    if (this->IsSlowDispatch()) {
-        detail::CompileProgram(mesh_device.get(), sparse_program_in_workload);
-        sparse_program_in_workload.impl().finalize_offsets(mesh_device.get());
-        poison_base = sparse_program_in_workload.impl().get_cb_base_addr(device, idle_core, CoreType::WORKER);
-        poison_size = sparse_program_in_workload.impl().get_cb_size(device, idle_core, CoreType::WORKER);
-    } else {
-        poison_base = hal.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::KERNEL_CONFIG);
-        poison_size = mesh_device->allocator()->get_base_allocator_addr(HalMemType::L1) - poison_base;
-    }
+    const uint32_t poison_base = hal.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::KERNEL_CONFIG);
+    const uint32_t poison_size = mesh_device->allocator()->get_base_allocator_addr(HalMemType::L1) - poison_base;
     ASSERT_GT(poison_size, 0);
     ASSERT_EQ(poison_size % sizeof(uint32_t), 0);
     std::vector<uint32_t> poison(poison_size / sizeof(uint32_t), 0xffffffff);
@@ -198,11 +189,8 @@ TEST_F(MeshDispatchFixture, TensixProgramClearsStaleRemoteCircularBufferConfig) 
 
     this->RunProgram(mesh_device, sparse_workload);
 
-    const uint32_t selected_kernel_config_base =
-        this->IsSlowDispatch() ? poison_base
-                               : sparse_workload.get_cb_base_addr(mesh_device, idle_core, CoreType::WORKER);
     const uint32_t remote_config_address =
-        selected_kernel_config_base +
+        sparse_workload.get_cb_base_addr(mesh_device, idle_core, CoreType::WORKER) +
         sparse_program_in_workload.impl().get_program_config(programmable_core_index).local_cb_size;
     std::vector<uint32_t> remote_config;
     detail::ReadFromDeviceL1(

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_global_circular_buffers.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_global_circular_buffers.cpp
@@ -141,10 +141,6 @@ TEST_F(MeshDispatchFixture, TensixProgramGlobalCircularBuffers) {
 }
 
 TEST_F(MeshDispatchFixture, TensixProgramClearsStaleRemoteCircularBufferConfig) {
-    if (this->IsSlowDispatch()) {
-        GTEST_SKIP() << "This test exercises fast-dispatch CB configuration commands.";
-    }
-
     const CoreCoord sender_core(0, 0);
     const CoreCoord receiver_core(1, 0);
     const CoreCoord idle_core(1, 1);
@@ -183,19 +179,30 @@ TEST_F(MeshDispatchFixture, TensixProgramClearsStaleRemoteCircularBufferConfig) 
     auto& sparse_program_in_workload = sparse_workload.get_programs().at(device_range);
 
     const auto& hal = MetalContext::instance().hal();
-    const uint32_t kernel_config_base =
-        hal.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::KERNEL_CONFIG);
-    const uint32_t kernel_config_end = mesh_device->allocator()->get_base_allocator_addr(HalMemType::L1);
-    ASSERT_GT(kernel_config_end, kernel_config_base);
-    ASSERT_EQ((kernel_config_end - kernel_config_base) % sizeof(uint32_t), 0);
-    std::vector<uint32_t> poison((kernel_config_end - kernel_config_base) / sizeof(uint32_t), 0xffffffff);
-    detail::WriteToDeviceL1(device, idle_core, kernel_config_base, poison);
+    const uint32_t programmable_core_index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+    uint32_t poison_base;
+    uint32_t poison_size;
+    if (this->IsSlowDispatch()) {
+        detail::CompileProgram(mesh_device.get(), sparse_program_in_workload);
+        sparse_program_in_workload.impl().finalize_offsets(mesh_device.get());
+        poison_base = sparse_program_in_workload.impl().get_cb_base_addr(device, idle_core, CoreType::WORKER);
+        poison_size = sparse_program_in_workload.impl().get_cb_size(device, idle_core, CoreType::WORKER);
+    } else {
+        poison_base = hal.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::KERNEL_CONFIG);
+        poison_size = mesh_device->allocator()->get_base_allocator_addr(HalMemType::L1) - poison_base;
+    }
+    ASSERT_GT(poison_size, 0);
+    ASSERT_EQ(poison_size % sizeof(uint32_t), 0);
+    std::vector<uint32_t> poison(poison_size / sizeof(uint32_t), 0xffffffff);
+    detail::WriteToDeviceL1(device, idle_core, poison_base, poison);
 
     this->RunProgram(mesh_device, sparse_workload);
 
-    const uint32_t programmable_core_index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+    const uint32_t selected_kernel_config_base =
+        this->IsSlowDispatch() ? sparse_program_in_workload.impl().get_cb_base_addr(device, idle_core, CoreType::WORKER)
+                               : sparse_workload.get_cb_base_addr(mesh_device, idle_core, CoreType::WORKER);
     const uint32_t remote_config_address =
-        sparse_workload.get_cb_base_addr(mesh_device, idle_core, CoreType::WORKER) +
+        selected_kernel_config_base +
         sparse_program_in_workload.impl().get_program_config(programmable_core_index).local_cb_size;
     std::vector<uint32_t> remote_config;
     detail::ReadFromDeviceL1(

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_global_circular_buffers.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_global_circular_buffers.cpp
@@ -199,7 +199,7 @@ TEST_F(MeshDispatchFixture, TensixProgramClearsStaleRemoteCircularBufferConfig) 
     this->RunProgram(mesh_device, sparse_workload);
 
     const uint32_t selected_kernel_config_base =
-        this->IsSlowDispatch() ? sparse_program_in_workload.impl().get_cb_base_addr(device, idle_core, CoreType::WORKER)
+        this->IsSlowDispatch() ? poison_base
                                : sparse_workload.get_cb_base_addr(mesh_device, idle_core, CoreType::WORKER);
     const uint32_t remote_config_address =
         selected_kernel_config_base +

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_global_circular_buffers.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_global_circular_buffers.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 #include <cstdint>
+#include <tt-metalium/allocator.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/global_circular_buffer.hpp>
 #include <tt-metalium/host_api.hpp>
@@ -140,13 +141,15 @@ TEST_F(MeshDispatchFixture, TensixProgramGlobalCircularBuffers) {
 }
 
 TEST_F(MeshDispatchFixture, TensixProgramClearsStaleRemoteCircularBufferConfig) {
+    if (this->IsSlowDispatch()) {
+        GTEST_SKIP() << "This test exercises fast-dispatch CB configuration commands.";
+    }
+
     const CoreCoord sender_core(0, 0);
     const CoreCoord receiver_core(1, 0);
     const CoreCoord idle_core(1, 1);
-    const CoreRangeSet sender_cores{CoreRange(sender_core)};
     const CoreRangeSet receiver_cores{CoreRange(receiver_core)};
     const CoreRangeSet all_cores(CoreRange({0, 0}, {1, 1}));
-    const CoreRangeSet all_receiver_cores = all_cores.subtract(sender_cores);
     constexpr uint32_t cb_page_size = 32;
     constexpr uint32_t remote_cb_index = 31;
     constexpr uint32_t local_cb_index = 0;
@@ -163,18 +166,6 @@ TEST_F(MeshDispatchFixture, TensixProgramClearsStaleRemoteCircularBufferConfig) 
         config.index(local_cb_index).set_page_size(cb_page_size).set_data_format(tile_format);
         return config;
     };
-    auto remote_config_address = [&](Program& program) {
-        const auto& hal = MetalContext::instance().hal();
-        const uint32_t programmable_core_index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
-        return program.impl().get_cb_base_addr(device, idle_core, CoreType::WORKER) +
-               program.impl().get_program_config(programmable_core_index).local_cb_size;
-    };
-
-    // Create a valid config block that can be used as stale remote-CB state on idle_core.
-    std::vector<std::pair<CoreCoord, CoreRangeSet>> full_mapping = {{sender_core, all_receiver_cores}};
-    auto full_global_cb =
-        experimental::CreateGlobalCircularBuffer(mesh_device.get(), full_mapping, 3200, BufferType::L1);
-
     // Run a rectangular kernel grid with a remote CB on only one receiver. Fast dispatch must overwrite stale config
     // on idle_core with the zero sentinel that setup_remote_cb_interfaces() skips.
     std::vector<std::pair<CoreCoord, CoreRangeSet>> sparse_mapping = {{sender_core, receiver_cores}};
@@ -190,28 +181,27 @@ TEST_F(MeshDispatchFixture, TensixProgramClearsStaleRemoteCircularBufferConfig) 
         ReaderDataMovementConfig{});
     sparse_workload.add_program(device_range, std::move(sparse_program));
     auto& sparse_program_in_workload = sparse_workload.get_programs().at(device_range);
-    detail::CompileProgram(mesh_device.get(), sparse_program_in_workload);
-    sparse_program_in_workload.impl().finalize_offsets(mesh_device.get());
 
-    const uint32_t stale_remote_config_address = remote_config_address(sparse_program_in_workload);
-    std::vector<uint32_t> stale_remote_config = {full_global_cb.config_address(), cb_page_size};
-    detail::WriteToDeviceL1(device, idle_core, stale_remote_config_address, stale_remote_config);
+    const auto& hal = MetalContext::instance().hal();
+    const uint32_t kernel_config_base =
+        hal.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::KERNEL_CONFIG);
+    const uint32_t kernel_config_end = mesh_device->allocator()->get_base_allocator_addr(HalMemType::L1);
+    ASSERT_GT(kernel_config_end, kernel_config_base);
+    ASSERT_EQ((kernel_config_end - kernel_config_base) % sizeof(uint32_t), 0);
+    std::vector<uint32_t> poison((kernel_config_end - kernel_config_base) / sizeof(uint32_t), 0xffffffff);
+    detail::WriteToDeviceL1(device, idle_core, kernel_config_base, poison);
+
+    this->RunProgram(mesh_device, sparse_workload);
+
+    const uint32_t programmable_core_index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+    const uint32_t remote_config_address =
+        sparse_workload.get_cb_base_addr(mesh_device, idle_core, CoreType::WORKER) +
+        sparse_program_in_workload.impl().get_program_config(programmable_core_index).local_cb_size;
     std::vector<uint32_t> remote_config;
     detail::ReadFromDeviceL1(
         device,
         idle_core,
-        stale_remote_config_address,
-        UINT32_WORDS_PER_REMOTE_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t),
-        remote_config);
-    ASSERT_EQ(remote_config, stale_remote_config);
-
-    this->RunProgram(mesh_device, sparse_workload);
-
-    remote_config.clear();
-    detail::ReadFromDeviceL1(
-        device,
-        idle_core,
-        remote_config_address(sparse_program_in_workload),
+        remote_config_address,
         UINT32_WORDS_PER_REMOTE_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t),
         remote_config);
     EXPECT_EQ(remote_config, std::vector<uint32_t>(UINT32_WORDS_PER_REMOTE_CIRCULAR_BUFFER_CONFIG, 0));

--- a/tt_metal/hw/inc/api/remote_circular_buffer.h
+++ b/tt_metal/hw/inc/api/remote_circular_buffer.h
@@ -416,6 +416,14 @@ FORCE_INLINE void align_local_cbs_to_remote_cb(
     // We assert that the offset of sender and receiver common attributes are the same
     // so we can use either interface here
     const RemoteReceiverCBInterface& remote_cb = get_remote_receiver_cb_interface(remote_cb_index);
+    // The align define is emitted per-kernel, so a kernel spanning a core range where only some cores
+    // own this remote CB also runs here on cores that don't. setup_remote_cb_interfaces zeroes
+    // fifo_start_addr on those cores, so fifo_start_addr == 0 means "remote CB not present here" (a real
+    // start is an L1 buffer address, never 0): nothing to align, and the interface may hold stale state
+    // from a prior program, so skip.
+    if (remote_cb.fifo_start_addr == 0) {
+        return;
+    }
     uint32_t fifo_limit = remote_cb.fifo_limit_page_aligned >> cb_addr_shift;
     uint32_t fifo_size = fifo_limit - (remote_cb.fifo_start_addr >> cb_addr_shift);
     uint32_t fifo_ptr = remote_cb.fifo_rd_ptr >> cb_addr_shift;

--- a/tt_metal/hw/inc/internal/circular_buffer_init.h
+++ b/tt_metal/hw/inc/internal/circular_buffer_init.h
@@ -176,8 +176,13 @@ inline void setup_remote_cb_interfaces(
         uint32_t config_addr = circular_buffer_config_addr[0];
         uint32_t page_size = circular_buffer_config_addr[1];
         circular_buffer_config_addr += UINT32_WORDS_PER_REMOTE_CIRCULAR_BUFFER_CONFIG;
-        // Skip unconfigured remote CBs - config_addr will be 0 if no remote CB was configured at this index
+        // Unconfigured remote CB at this index on this core (config_addr == 0). Zero the interface's
+        // fifo_start_addr so a stale value from a prior program can't be picked up: the align define is
+        // emitted per-kernel and may run align_local_cbs_to_remote_cb for this index on a core that
+        // doesn't own the CB, which treats fifo_start_addr == 0 as "not present" (a real remote CB start
+        // is an L1 buffer address, never 0). sender and receiver views alias the same interface word.
         if (config_addr == 0) {
+            get_remote_receiver_cb_interface(cb_id).fifo_start_addr = 0;
             continue;
         }
         volatile tt_l1_ptr uint32_t* l1_remote_cb_config_addr =

--- a/tt_metal/impl/host_api/tt_metal.cpp
+++ b/tt_metal/impl/host_api/tt_metal.cpp
@@ -1055,7 +1055,9 @@ bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool force_sl
                     hal.get_dev_addr(hal.get_programmable_core_type(index), HalL1MemAddrType::KERNEL_CONFIG);
                 const auto& cbs_on_core = program.impl().circular_buffers_on_core(logical_core);
                 const auto& dfbs_on_core = program.impl().dataflow_buffers_on_core(logical_core);
-                if (!cbs_on_core.empty()) {
+                const bool scans_remote_cb_configs =
+                    kernel_group->launch_msg.view().kernel_config().min_remote_cb_start_index() < max_cbs;
+                if (!cbs_on_core.empty() || scans_remote_cb_configs) {
                     // CircularBufferConfigVec -- common across all kernels, so written once to the core
                     std::vector<uint32_t> circular_buffer_config_vec(
                         program.impl().get_program_config(index).cb_size / sizeof(uint32_t));

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -1238,8 +1238,26 @@ public:
         uint32_t max_cbs = hal.get_arch_num_circular_buffers();
         uint32_t index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
 
-        const auto& circular_buffers_unique_coreranges = program.circular_buffers_unique_coreranges();
-        const uint16_t num_multicast_cb_sub_cmds = circular_buffers_unique_coreranges.size();
+        auto cb_config_coreranges = program.circular_buffers_unique_coreranges();
+        CoreRangeSet covered_cb_cores;
+        for (const auto& core_range : cb_config_coreranges) {
+            covered_cb_cores = covered_cb_cores.merge(CoreRangeSet(core_range));
+        }
+        const auto& kernel_groups = program.get_kernel_groups(index);
+        for (const auto& kernel_group : kernel_groups) {
+            const auto kernel_config = kernel_group->launch_msg.view().kernel_config();
+            if (kernel_config.min_remote_cb_start_index() >= max_cbs) {
+                continue;
+            }
+            // Firmware scans remote CB configs down through min_remote_cb_start_index. Include cores with no CBs so
+            // fast dispatch explicitly clears stale configs there instead of leaving a prior program's remote CB.
+            const auto uncovered_cores = kernel_group->core_ranges.subtract(covered_cb_cores);
+            cb_config_coreranges.insert(
+                cb_config_coreranges.end(), uncovered_cores.ranges().begin(), uncovered_cores.ranges().end());
+            covered_cb_cores = covered_cb_cores.merge(uncovered_cores);
+        }
+
+        const uint16_t num_multicast_cb_sub_cmds = cb_config_coreranges.size();
         cb_config_payloads = std::vector<std::vector<uint32_t>>(
             num_multicast_cb_sub_cmds,
             std::vector<uint32_t>(program.get_program_config(index).cb_size / sizeof(uint32_t), 0));
@@ -1247,7 +1265,7 @@ public:
             uint32_t i = 0;
             uint32_t remote_offset_index = program.get_program_config(index).local_cb_size / sizeof(uint32_t);
             auto index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
-            for (const CoreRange& core_range : circular_buffers_unique_coreranges) {
+            for (const CoreRange& core_range : cb_config_coreranges) {
                 const CoreCoord& virtual_start =
                     device->virtual_core_from_logical_core(core_range.start_coord, CoreType::WORKER);
                 const CoreCoord& virtual_end =
@@ -1255,6 +1273,19 @@ public:
 
                 auto& cb_config_payload = cb_config_payloads[i];
                 uint32_t max_index = 0;
+                for (const auto& kernel_group : kernel_groups) {
+                    if (!kernel_group->core_ranges.intersects(core_range)) {
+                        continue;
+                    }
+                    const auto kernel_config = kernel_group->launch_msg.view().kernel_config();
+                    const uint32_t min_remote_cb_start_index = kernel_config.min_remote_cb_start_index();
+                    if (min_remote_cb_start_index < max_cbs) {
+                        max_index = std::max(
+                            max_index,
+                            remote_offset_index +
+                                (max_cbs - min_remote_cb_start_index) * UINT32_WORDS_PER_REMOTE_CIRCULAR_BUFFER_CONFIG);
+                    }
+                }
                 const auto& circular_buffers_on_corerange = program.circular_buffers_on_corerange(core_range);
                 for (const std::shared_ptr<CircularBufferImpl>& cb : circular_buffers_on_corerange) {
                     const uint32_t cb_address = cb->address();

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -1239,10 +1239,8 @@ public:
         uint32_t index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
 
         auto cb_config_coreranges = program.circular_buffers_unique_coreranges();
-        CoreRangeSet covered_cb_cores;
-        for (const auto& core_range : cb_config_coreranges) {
-            covered_cb_cores = covered_cb_cores.merge(CoreRangeSet(core_range));
-        }
+        // circular_buffers_unique_coreranges() returns non-overlapping ranges, so this is a single build.
+        CoreRangeSet covered_cb_cores(cb_config_coreranges);
         const auto& kernel_groups = program.get_kernel_groups(index);
         for (const auto& kernel_group : kernel_groups) {
             const auto kernel_config = kernel_group->launch_msg.view().kernel_config();
@@ -1264,7 +1262,6 @@ public:
         if (num_multicast_cb_sub_cmds > 0) {
             uint32_t i = 0;
             uint32_t remote_offset_index = program.get_program_config(index).local_cb_size / sizeof(uint32_t);
-            auto index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
             for (const CoreRange& core_range : cb_config_coreranges) {
                 const CoreCoord& virtual_start =
                     device->virtual_core_from_logical_core(core_range.start_coord, CoreType::WORKER);

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -2128,7 +2128,15 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
             .set_page_size(in1_block_size_bytes)
             .set_data_format(in1_data_format);
         remote_cb_config.index(src1_cb_index).set_page_size(in1_single_tile_size).set_data_format(in1_data_format);
-        cb_src1 = tt_metal::experimental::CreateCircularBuffer(program, all_cores, remote_cb_config, *global_cb);
+        // Keep the rectangular kernel/CB placement used for efficient dispatch, but associate the remote CB only
+        // with cores backed by the GCB. Fast dispatch explicitly clears that remote slot on the remaining cores.
+        const auto global_cb_cores = all_cores.intersection(global_cb->all_cores());
+        TT_FATAL(
+            global_cb_cores.contains(all_worker_cores),
+            "GlobalCircularBuffer cores {} do not contain all gather-in0 worker cores {}",
+            global_cb->all_cores(),
+            all_worker_cores);
+        cb_src1 = tt_metal::experimental::CreateCircularBuffer(program, global_cb_cores, remote_cb_config, *global_cb);
     } else {
         tt_metal::CircularBufferConfig src1_cb_config =
             tt_metal::CircularBufferConfig(in1_CB_size, {{src1_cb_index, in1_data_format}})
@@ -2871,10 +2879,10 @@ inline void override_gather_in0_program_parameters(
     if (src0_sharded) {
         UpdateDynamicCircularBufferAddress(program, override_variables.cbs[0], src_a_tensor);
     }
-    if (src1_sharded) {
-        if (!global_cb.has_value() && !src_b_tensor.memory_config().is_dram()) {
-            UpdateDynamicCircularBufferAddress(program, override_variables.cbs[1], src_b_tensor);
-        }
+    if (global_cb.has_value()) {
+        tt::tt_metal::experimental::UpdateDynamicCircularBufferAddress(program, override_variables.cbs[1], *global_cb);
+    } else if (src1_sharded && !src_b_tensor.memory_config().is_dram()) {
+        UpdateDynamicCircularBufferAddress(program, override_variables.cbs[1], src_b_tensor);
     }
     if (out_sharded) {
         for (uint32_t i = 0; i < override_variables.cbs.size() - 2; ++i) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -2128,15 +2128,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
             .set_page_size(in1_block_size_bytes)
             .set_data_format(in1_data_format);
         remote_cb_config.index(src1_cb_index).set_page_size(in1_single_tile_size).set_data_format(in1_data_format);
-        // Keep the rectangular kernel/CB placement used for efficient dispatch, but associate the remote CB only
-        // with cores backed by the GCB. Fast dispatch explicitly clears that remote slot on the remaining cores.
-        const auto global_cb_cores = all_cores.intersection(global_cb->all_cores());
-        TT_FATAL(
-            global_cb_cores.contains(all_worker_cores),
-            "GlobalCircularBuffer cores {} do not contain all gather-in0 worker cores {}",
-            global_cb->all_cores(),
-            all_worker_cores);
-        cb_src1 = tt_metal::experimental::CreateCircularBuffer(program, global_cb_cores, remote_cb_config, *global_cb);
+        cb_src1 = tt_metal::experimental::CreateCircularBuffer(program, all_cores, remote_cb_config, *global_cb);
     } else {
         tt_metal::CircularBufferConfig src1_cb_config =
             tt_metal::CircularBufferConfig(in1_CB_size, {{src1_cb_index, in1_data_format}})
@@ -2879,10 +2871,10 @@ inline void override_gather_in0_program_parameters(
     if (src0_sharded) {
         UpdateDynamicCircularBufferAddress(program, override_variables.cbs[0], src_a_tensor);
     }
-    if (global_cb.has_value()) {
-        tt::tt_metal::experimental::UpdateDynamicCircularBufferAddress(program, override_variables.cbs[1], *global_cb);
-    } else if (src1_sharded && !src_b_tensor.memory_config().is_dram()) {
-        UpdateDynamicCircularBufferAddress(program, override_variables.cbs[1], src_b_tensor);
+    if (src1_sharded) {
+        if (!global_cb.has_value() && !src_b_tensor.memory_config().is_dram()) {
+            UpdateDynamicCircularBufferAddress(program, override_variables.cbs[1], src_b_tensor);
+        }
     }
     if (out_sharded) {
         for (uint32_t i = 0; i < override_variables.cbs.size() - 2; ++i) {


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
A rectangular kernel group can include worker cores that do not have the group's sparse GlobalCircularBuffer. Because the kernel group still advertises a remote-CB range, firmware scans those cores' remote-CB configuration and can interpret stale data from an earlier program as a valid remote CB.

- In fast dispatch, include uncovered cores from remote-CB kernel groups in CB configuration writes and zero every scanned remote-CB slot that is not configured on that core.
- In slow dispatch, write the zero-initialized CB configuration to cores whose kernel group scans remote CBs even when the core has no configured CB.
- Preserve configured local and remote CB entries; only absent entries use the zero-address sentinel already skipped by firmware.
- Add a dispatch-neutral regression test that poisons the worker kernel-config region, runs a sparse GCB on a rectangular kernel grid, and verifies the idle core's selected remote-CB slot is cleared.

### Notes for reviewers
The runtime change is confined to CB configuration delivery; it does not split kernel groups or alter matmul core selection.

For fast dispatch, `CircularBufferCommandGenerator::construct_commands` extends multicast targets only to uncovered cores in kernel groups with `min_remote_cb_start_index < max_cbs`. Remote CB entries are stored in descending CB-index order, so the emitted zeroed range covers every slot firmware scans from the highest CB index through that minimum.

Slow dispatch writes the same zero-initialized CB vector for such cores at the fixed kernel-config address.

Validation:
- `~/bin-metal/build_metal_cpp.sh`
- `MeshDispatchFixture.TensixProgramClearsStaleRemoteCircularBufferConfig` with fast dispatch
- `MeshDispatchFixture.TensixProgramClearsStaleRemoteCircularBufferConfig` with `TT_METAL_SLOW_DISPATCH_MODE=1`

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/remote-cb-invalidation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/remote-cb-invalidation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/remote-cb-invalidation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/remote-cb-invalidation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jbauman/remote-cb-invalidation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jbauman/remote-cb-invalidation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/remote-cb-invalidation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/remote-cb-invalidation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/remote-cb-invalidation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/remote-cb-invalidation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/remote-cb-invalidation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/remote-cb-invalidation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/remote-cb-invalidation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/remote-cb-invalidation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/remote-cb-invalidation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/remote-cb-invalidation)