### PR TITLE
[Cleanup] Migrate all_gather_minimal_matmul_async set_remote to Semaphore::relay_unicast

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in0_sender.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in0_sender.cpp
@@ -128,8 +128,6 @@ void kernel_main() {
     Semaphore<> in0_sender_sem(in0_sender_semaphore_id);
     Semaphore<> in0_receiver_sem(in0_receiver_semaphore_id);
     Semaphore<> in0_valid_sem(in0_valid_semaphore_id);
-    uint32_t in0_valid_semaphore_addr = get_semaphore(in0_valid_semaphore_id);
-    uint32_t in0_receiver_semaphore_addr = get_semaphore(in0_receiver_semaphore_id);
     const uint32_t M_start_tile = get_arg_val<uint32_t>(argidx++);
     const uint32_t M_end_tile = get_arg_val<uint32_t>(argidx++);
     const uint32_t N_start_tile = get_arg_val<uint32_t>(argidx++);
@@ -257,8 +255,6 @@ void kernel_main() {
 
     in0_valid_sem.set(VALID);
 
-    const uint64_t in0_receiver_semaphore_noc_addr =
-        get_noc_addr(in0_dest_noc_x, in0_dest_noc_y, in0_receiver_semaphore_addr);
     // all gather
     volatile tt_l1_ptr uint32_t* out_ready_sem_backward_addr_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem_backward);
@@ -467,7 +463,7 @@ void kernel_main() {
                     noc_obj.async_writes_flushed();
 #endif
 
-                    noc_semaphore_set_remote(in0_valid_semaphore_addr, in0_receiver_semaphore_noc_addr);
+                    in0_valid_sem.relay_unicast(noc_obj, in0_receiver_sem, in0_dest_noc_x, in0_dest_noc_y);
                 }
 #ifdef USE_MUX
                 if (n_block_iter == 0) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in1_sender_out.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in1_sender_out.cpp
@@ -107,8 +107,6 @@ void kernel_main() {
     Semaphore<> in1_sender_sem(in1_sender_semaphore_id);
     Semaphore<> in1_receiver_sem(in1_receiver_semaphore_id);
     Semaphore<> in1_valid_sem(in1_valid_semaphore_id);
-    const uint32_t in1_valid_semaphore_addr = get_semaphore(in1_valid_semaphore_id);
-    const uint32_t in1_receiver_semaphore_addr = get_semaphore(in1_receiver_semaphore_id);
     const uint32_t M_start_tile = get_arg_val<uint32_t>(argidx++);
     const uint32_t M_end_tile = get_arg_val<uint32_t>(argidx++);
     const uint32_t N_start_tile = get_arg_val<uint32_t>(argidx++);
@@ -215,9 +213,6 @@ void kernel_main() {
 #endif
 
     in1_valid_sem.set(VALID);
-
-    const uint64_t in1_receiver_semaphore_noc_addr =
-        get_noc_addr(in1_dest_noc_x, in1_dest_noc_y, in1_receiver_semaphore_addr);
 
     const uint64_t in1_unicast_data_base_addr = get_noc_addr(in1_dest_noc_x, in1_dest_noc_y, 0);
 
@@ -537,7 +532,7 @@ void kernel_main() {
                     noc_obj.async_writes_flushed();
 #endif
 
-                    noc_semaphore_set_remote(in1_valid_semaphore_addr, in1_receiver_semaphore_noc_addr);
+                    in1_valid_sem.relay_unicast(noc_obj, in1_receiver_sem, in1_dest_noc_x, in1_dest_noc_y);
                 }
 #ifdef FSDP_FUSED
                 // Fabric relay (uni-ring, mirrors in0): on the first m-pass, relay the just-consumed


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

Contributes to #45003. Phase C of the free-function semaphore to Device 2.0 `Semaphore<>` migration: replace `noc_semaphore_set_remote(local_sem_addr, remote_noc_addr)` with `Semaphore<>::relay_unicast(noc, dst_sem, noc_x, noc_y)`

### Notes for reviewers

- `relay_unicast` writes into a different destination semaphore (asserts `src != dst` L1 offset), matching the original `set_remote` src/dst pairing. 
- Also drops the now-dead raw `*_semaphore_addr` / `*_receiver_semaphore_noc_addr` locals that only fed the old precomposed remote-NoC-address computation.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/d2-semaphore-phase-c)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/d2-semaphore-phase-c)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/d2-semaphore-phase-c)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/d2-semaphore-phase-c)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=iwrosz/d2-semaphore-phase-c)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:iwrosz/d2-semaphore-phase-c)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/d2-semaphore-phase-c)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/d2-semaphore-phase-c)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/d2-semaphore-phase-c)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/d2-semaphore-phase-c)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/d2-semaphore-phase-c)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/d2-semaphore-phase-c)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/d2-semaphore-phase-c)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/d2-semaphore-phase-c)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/d2-semaphore-phase-c)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/d2-semaphore-phase-c)
