### PR TITLE
[LLK] fast reduce unpack for 32x32 tiles

### DIFF
--- a/tt_metal/tt-llk/tests/sources/reduce_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/reduce_perf.cpp
@@ -24,7 +24,9 @@ using namespace ckernel;
 
 static constexpr std::uint32_t MAX_TILES_DEST = is_fp32_dest_acc_en ? 4 : 8;
 
-static constexpr bool IS_REDUCE_ROW = (REDUCE_DIM == ckernel::ReduceDim::REDUCE_ROW);
+static constexpr bool IS_REDUCE_ROW             = (REDUCE_DIM == ckernel::ReduceDim::REDUCE_ROW);
+static constexpr bool IS_FULL_TILE_REDUCE_ROW   = IS_REDUCE_ROW && (POOL_TYPE != ckernel::PoolType::MAX);
+static constexpr std::uint32_t DVALIDS_PER_TILE = IS_FULL_TILE_REDUCE_ROW ? 1 : TILE_NUM_FACES;
 
 #ifdef LLK_TRISC_UNPACK
 
@@ -63,7 +65,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
-            _perf_unpack_loop_set_valid<true, true>(TILE_CNT * TILE_NUM_FACES);
+            _perf_unpack_loop_set_valid<true, true>(TILE_CNT * DVALIDS_PER_TILE);
             return;
         }
         else
@@ -115,7 +117,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            _perf_math_loop_clear_valid<true, true>(TILE_CNT * TILE_NUM_FACES);
+            _perf_math_loop_clear_valid<true, true>(TILE_CNT * DVALIDS_PER_TILE);
             return;
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_reduce.h
@@ -154,51 +154,74 @@ inline void reduce_configure_mop(const ckernel::TensorShape& tensor_shape)
 
     if constexpr (dim == ReduceDim::REDUCE_ROW && type != PoolType::MAX)
     {
-        // MVMUL multiplies the scaler column (SrcA) by each data face (SrcB), accumulating the
-        // reduced column directly in dest. The replay buffer records all column faces so a single
-        // replay covers one row of faces; the MOP outer loop repeats it for each row.
-        constexpr std::uint32_t fid_count  = (math_fidelity == MathFidelity::LoFi) ? 1 : to_underlying(math_fidelity);
-        const std::uint32_t replay_buf_len = tensor_shape.num_faces_c_dim * 2 * fid_count;
+        if (tensor_shape.total_num_faces() == 4)
+        {
+            constexpr std::uint32_t replay_buf_len = 8;
+            constexpr std::uint32_t last_clr       = high_fidelity ? p_setrwc::CLR_NONE : p_setrwc::CLR_AB;
+            constexpr std::uint32_t inner_loops    = high_fidelity ? to_underlying(math_fidelity) : 1;
+            const std::uint32_t replay_start       = ckernel::math::replay_buf_offset;
 
-        const std::uint32_t replay_start = ckernel::math::replay_buf_offset;
-
-        load_replay_buf(
-            replay_start,
-            replay_buf_len,
-            [&tensor_shape]
-            {
-                for (std::uint32_t faces_remaining = tensor_shape.num_faces_c_dim; faces_remaining > 0; faces_remaining--)
+            load_replay_buf(
+                replay_start,
+                replay_buf_len,
+                []
                 {
-                    // Top half of face (dst=0): run fidelity phases, last phase advances SrcB by 8 rows
-                    for (std::uint32_t p = 0; p < fid_count - 1; p++)
-                    {
-                        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
-                    }
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
                     TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0);
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+                    TTI_MVMUL(last_clr, 0, ADDR_MOD_3, 0);
+                });
 
-                    // Bottom half of face (dst=8): run fidelity phases, last phase resets SrcB
-                    for (std::uint32_t p = 0; p < fid_count - 1; p++)
-                    {
-                        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 8);
-                    }
-                    if (faces_remaining == 1)
-                    {
-                        // Last face in row: reset SrcB, advance dest to next row
-                        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_3, 8);
-                    }
-                    else
-                    {
-                        // More faces remain: reset SrcB, clear sources for next face
-                        TTI_MVMUL(p_setrwc::CLR_AB, 0, ADDR_MOD_2, 8);
-                    }
-                }
-            });
+            ckernel_template tmp(1, inner_loops, lltt::replay_insn(replay_start, replay_buf_len));
+            if constexpr (high_fidelity)
+            {
+                tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_ABD_F));
+            }
+            tmp.program();
+        }
+        else
+        {
+            constexpr std::uint32_t fid_count  = (math_fidelity == MathFidelity::LoFi) ? 1 : to_underlying(math_fidelity);
+            const std::uint32_t replay_buf_len = tensor_shape.num_faces_c_dim * 2 * fid_count;
+            const std::uint32_t replay_start   = ckernel::math::replay_buf_offset;
 
-        const std::uint32_t replay_op = lltt::replay_insn(replay_start, replay_buf_len);
-        // Outer loop = num_faces_r_dim: replay the column face reduction for each row
-        ckernel_template tmp(tensor_shape.num_faces_r_dim, 1, replay_op);
-        tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_B));
-        tmp.program();
+            load_replay_buf(
+                replay_start,
+                replay_buf_len,
+                [&tensor_shape]
+                {
+                    for (std::uint32_t faces_remaining = tensor_shape.num_faces_c_dim; faces_remaining > 0; faces_remaining--)
+                    {
+                        for (std::uint32_t p = 0; p < fid_count - 1; p++)
+                        {
+                            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+                        }
+                        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
+
+                        for (std::uint32_t p = 0; p < fid_count - 1; p++)
+                        {
+                            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 8);
+                        }
+                        if (faces_remaining == 1)
+                        {
+                            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_3, 8);
+                        }
+                        else
+                        {
+                            TTI_MVMUL(p_setrwc::CLR_AB, 0, ADDR_MOD_2, 8);
+                        }
+                    }
+                });
+
+            const std::uint32_t replay_op = lltt::replay_insn(replay_start, replay_buf_len);
+            ckernel_template tmp(tensor_shape.num_faces_r_dim, 1, replay_op);
+            tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_B));
+            tmp.program();
+        }
     }
     else if constexpr (high_fidelity)
     {
@@ -263,7 +286,7 @@ inline void _llk_math_reduce_(const std::uint32_t dst_index, const ckernel::Tens
         else
         {
             ckernel_template::run();
-            TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_BD);
+            TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_ABD);
         }
     }
     else if constexpr (dim == ReduceDim::REDUCE_COL)
@@ -346,43 +369,75 @@ inline void reduce_configure_addrmod(const ckernel::TensorShape& tensor_shape)
 
     if constexpr (dim == ReduceDim::REDUCE_ROW && type != PoolType::MAX)
     {
-        if constexpr (high_fidelity)
+        if (tensor_shape.total_num_faces() == 4)
         {
             addr_mod_t {
-                .fidelity = {.incr = 1},
+                .srcb = {.incr = 8},
+                .dest = {.incr = 8},
             }
                 .set(ADDR_MOD_0);
-        }
 
-        addr_mod_t {
-            .srcb     = {.incr = 8},
-            .fidelity = {.clr = 1},
-        }
-            .set(ADDR_MOD_1);
-
-        addr_mod_t {
-            .srcb     = {.cr = 1},
-            .fidelity = {.clr = 1},
-        }
-            .set(ADDR_MOD_2);
-
-        if (tensor_shape.num_faces_c_dim == 2)
-        {
             addr_mod_t {
-                .srcb     = {.cr = 1},
-                .dest     = {.incr = 32},
-                .fidelity = {.clr = 1},
+                .srcb = {.incr = 24},
+                .dest = {.incr = 24},
+            }
+                .set(ADDR_MOD_1);
+
+            addr_mod_t {
+                .srca = {.incr = 16},
+                .srcb = {.incr = 16, .cr = 1},
+                .dest = {.cr = 1},
+            }
+                .set(ADDR_MOD_2);
+
+            addr_mod_t {
+                .srca     = {.clr = 1, .cr = 1},
+                .srcb     = {.clr = 1, .cr = 1},
+                .dest     = {.clr = 1, .cr = 1},
+                .fidelity = {.incr = high_fidelity ? 1u : 0u},
             }
                 .set(ADDR_MOD_3);
         }
         else
         {
+            if constexpr (high_fidelity)
+            {
+                addr_mod_t {
+                    .fidelity = {.incr = 1},
+                }
+                    .set(ADDR_MOD_0);
+            }
+
             addr_mod_t {
-                .srcb     = {.cr = 1},
-                .dest     = {.incr = 16},
+                .srcb     = {.incr = 8},
                 .fidelity = {.clr = 1},
             }
-                .set(ADDR_MOD_3);
+                .set(ADDR_MOD_1);
+
+            addr_mod_t {
+                .srcb     = {.cr = 1},
+                .fidelity = {.clr = 1},
+            }
+                .set(ADDR_MOD_2);
+
+            if (tensor_shape.num_faces_c_dim == 2)
+            {
+                addr_mod_t {
+                    .srcb     = {.cr = 1},
+                    .dest     = {.incr = 32},
+                    .fidelity = {.clr = 1},
+                }
+                    .set(ADDR_MOD_3);
+            }
+            else
+            {
+                addr_mod_t {
+                    .srcb     = {.cr = 1},
+                    .dest     = {.incr = 16},
+                    .fidelity = {.clr = 1},
+                }
+                    .set(ADDR_MOD_3);
+            }
         }
     }
     else

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_reduce.h
@@ -37,55 +37,45 @@ inline void _llk_unpack_AB_reduce_mop_config_(const ckernel::TensorShape &tensor
     // Validate tensor shape for tile-dependent operations
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
-    // Data valid for clear instructions is set to 0 since the MATH kernel should not process this data.
-    // pool_type == PoolType::MAX sets the clear value to neginf if the pool-type is MAX and 0 if the pool-type is AVG/SUM
-    static constexpr std::uint32_t clear_pool_dep_srca =
-        TT_OP_UNPACR_NOP(Srcs::SrcA, 0, 0, 0 /* dvalid */, 0, 0 /* Stall_Clr_Cntrl */, 0, pool_type == PoolType::MAX /* 0 or neginf */, p_unpacr_nop::CLR_SRC);
-    static constexpr std::uint32_t clear_pool_dep_srcb =
-        TT_OP_UNPACR_NOP(Srcs::SrcB, 0, 0, 0 /* dvalid */, 0, 0 /* Stall_Clr_Cntrl */, 0, pool_type == PoolType::MAX /* 0 or neginf */, p_unpacr_nop::CLR_SRC);
-    static constexpr std::uint32_t clear_zero_srca =
-        TT_OP_UNPACR_NOP(Srcs::SrcA, 0, 0, 0 /* dvalid */, 0, 0 /* Stall_Clr_Cntrl */, 0, p_unpacr_nop::CLR_SRC_0, p_unpacr_nop::CLR_SRC);
-
+    constexpr bool is_max                  = pool_type == PoolType::MAX;
+    constexpr bool swap_operands           = (reduce_dim == ReduceDim::REDUCE_ROW) && !is_max;
+    constexpr bool is_scalar               = reduce_dim == ReduceDim::REDUCE_SCALAR;
     constexpr std::uint32_t REPLAY_BUF_LEN = 2;
+    constexpr std::uint32_t clear_src      = swap_operands ? Srcs::SrcB : Srcs::SrcA;
+
+    const bool full_tile          = swap_operands && (tensor_shape.total_num_faces() == 4);
+    const bool is_tiny            = tensor_shape.face_r_dim < FACE_R_DIM;
+    const std::uint32_t innerloop = full_tile ? 1 : tensor_shape.total_num_faces();
+    const std::uint32_t clear_val = is_max ? 1 : p_unpacr_nop::CLR_SRC_0;
 
     load_replay_buf(
         0,
         REPLAY_BUF_LEN,
-        []
+        [full_tile]
         {
-            // Configure unpacker instruction for Src{A,B}. These instructions always increment L1 by 1 face.
-            TTI_UNPACR(Srcs::SrcA, 0b01, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1); // Unpack SrcA
-            TTI_UNPACR(Srcs::SrcB, 0b01, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1); // Unpack SrcB
+            if (full_tile)
+            {
+                TTI_UNPACR(Srcs::SrcA, 0, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
+                TTI_UNPACR(Srcs::SrcB, 0, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
+            }
+            else
+            {
+                TTI_UNPACR(Srcs::SrcA, 0b01, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
+                TTI_UNPACR(Srcs::SrcB, 0b01, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
+            }
         });
 
-    // MOP constants
-    constexpr std::uint32_t outerloop = 1;
-    const std::uint32_t innerloop     = tensor_shape.total_num_faces();
+    const std::uint32_t replay = lltt::replay_insn(0, REPLAY_BUF_LEN);
 
-    constexpr bool swap_operands = (reduce_dim == ReduceDim::REDUCE_ROW) && (pool_type != PoolType::MAX);
-
-    // Padding should only be done when using tiny tiles otherwise the entire face overwrites the data read in Math
-    if (tensor_shape.face_r_dim < FACE_R_DIM) // Using tiny faces
+    if (is_tiny || is_scalar)
     {
-        // Swapped REDUCE_ROW: data is in SrcB, pad SrcB; otherwise data is in SrcA, pad SrcA
-        static constexpr std::uint32_t clear_pool_dep = swap_operands ? clear_pool_dep_srcb : clear_pool_dep_srca;
-        ckernel_template tmp(outerloop, innerloop, clear_pool_dep, lltt::replay_insn(0, REPLAY_BUF_LEN));
+        ckernel_template tmp(1, innerloop, TT_OP_UNPACR_NOP(clear_src, 0, 0, 0, 0, 0, 0, clear_val, p_unpacr_nop::CLR_SRC), replay);
         tmp.program();
     }
-    else // Using standard faces (face_r_dim = FACE_R_DIM)
+    else
     {
-        if constexpr (reduce_dim == ReduceDim::REDUCE_SCALAR)
-        {
-            // For scalar reduction, clear SrcA to zero before unpacking. SrcA is clobbered in Math kernel.
-            ckernel_template tmp(outerloop, innerloop, clear_zero_srca, lltt::replay_insn(0, REPLAY_BUF_LEN));
-            tmp.program();
-        }
-        else
-        {
-            // For row/column reduction, no clearing needed
-            ckernel_template tmp(outerloop, innerloop, lltt::replay_insn(0, REPLAY_BUF_LEN));
-            tmp.program();
-        }
+        ckernel_template tmp(1, innerloop, replay);
+        tmp.program();
     }
 }
 
@@ -115,16 +105,24 @@ inline void _llk_unpack_AB_reduce_init_(const ckernel::TensorShape &tensor_shape
     // Validate tensor shape for tile-dependent operations
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
-    // SUM/AVG REDUCE_ROW swaps operands (scaler→SrcA, data→SrcB), no transpose needed.
-    // MAX REDUCE_ROW keeps original layout (data→SrcA transposed, scaler→SrcB) — GMPOOL only reads SrcA.
-    constexpr bool swap_operands = (reduce_dim == ReduceDim::REDUCE_ROW) && (pool_type != PoolType::MAX);
+    constexpr bool is_max        = pool_type == PoolType::MAX;
+    constexpr bool swap_operands = (reduce_dim == ReduceDim::REDUCE_ROW) && !is_max;
+
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>((reduce_dim == ReduceDim::REDUCE_ROW));
 
-    config_unpacker_x_end<p_setadc::UNP_A>(tensor_shape.face_r_dim);
+    const bool full_tile = swap_operands && (tensor_shape.total_num_faces() == 4);
 
-    // UNP_B reads data faces (face_r_dim rows) in swapped mode, or a single
-    // scaler row in the non-swapped (MAX / COL / SCALAR) mode.
-    config_unpacker_x_end<p_setadc::UNP_B>(swap_operands ? tensor_shape.face_r_dim : 1);
+    if (full_tile)
+    {
+        const std::uint32_t x_end = tensor_shape.total_num_faces() * FACE_R_DIM * FACE_C_DIM - 1;
+        TT_SETADCXX(p_setadc::UNP_A, x_end, 0x0);
+        TT_SETADCXX(p_setadc::UNP_B, x_end, 0x0);
+    }
+    else
+    {
+        config_unpacker_x_end<p_setadc::UNP_A>(tensor_shape.face_r_dim);
+        config_unpacker_x_end<p_setadc::UNP_B>(swap_operands ? tensor_shape.face_r_dim : 1);
+    }
 
     // Configure unpack MOP
     _llk_unpack_AB_reduce_mop_config_<pool_type, reduce_dim>(tensor_shape);
@@ -162,17 +160,14 @@ inline void _llk_unpack_AB_reduce_(const std::uint32_t address_a, const std::uin
     // Wait for free context
     wait_for_next_context(2);
 
-    // SUM/AVG REDUCE_ROW: swap operands so scaler→SrcA, data→SrcB
-    // MAX REDUCE_ROW: keep original order (data→SrcA, scaler→SrcB)
-    constexpr bool swap_operands = (reduce_dim == ReduceDim::REDUCE_ROW) && (pool_type != PoolType::MAX);
-    if constexpr (swap_operands)
-    {
-        _llk_unpack_configure_addresses_(address_b, address_a, cfg);
-    }
-    else
-    {
-        _llk_unpack_configure_addresses_(address_a, address_b, cfg);
-    }
+    constexpr bool is_max        = pool_type == PoolType::MAX;
+    constexpr bool swap_operands = (reduce_dim == ReduceDim::REDUCE_ROW) && !is_max;
+
+    // SUM/AVG REDUCE_ROW swaps operands (scaler→SrcA, data→SrcB), no transpose needed.
+    // MAX REDUCE_ROW keeps original layout (data→SrcA transposed, scaler→SrcB) — GMPOOL only reads SrcA.
+    const std::uint32_t addr_unp_a = swap_operands ? address_b : address_a;
+    const std::uint32_t addr_unp_b = swap_operands ? address_a : address_b;
+    _llk_unpack_configure_addresses_(addr_unp_a, addr_unp_b, cfg);
 
     // Trisc::SEMPOST for context acquire
     semaphore_post(semaphore::UNPACK_SYNC);

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_reduce.h
@@ -24,6 +24,8 @@ using namespace ckernel::unpacker;
 /**
  * @brief Configures the unpacker MOP for reduction operations. Handles both tiny tiles (face_r_dim < 16) and standard tiles.
  *
+ * @note For full 4-face SUM/AVG REDUCE_ROW, a single UNPACR path unpacks all faces in a single instruction.
+ *
  * @tparam pool_type: Type of pooling operation, values = <SUM/AVG/MAX>
  * @tparam reduce_dim: Dimension along which to reduce, values = <REDUCE_ROW/REDUCE_COL/REDUCE_SCALAR>
  * @param tensor_shape: Shape of the tensor, including face_r_dim and num_faces.
@@ -46,7 +48,7 @@ inline void _llk_unpack_AB_reduce_mop_config_(const ckernel::TensorShape &tensor
     const bool full_tile          = swap_operands && (tensor_shape.total_num_faces() == 4);
     const bool is_tiny            = tensor_shape.face_r_dim < FACE_R_DIM;
     const std::uint32_t innerloop = full_tile ? 1 : tensor_shape.total_num_faces();
-    const std::uint32_t clear_val = is_max ? 1 : p_unpacr_nop::CLR_SRC_0;
+    const std::uint32_t clear_val = is_max ? p_unpacr_nop::CLR_SRC_NEGINF : p_unpacr_nop::CLR_SRC_0;
 
     load_replay_buf(
         0,

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
@@ -155,38 +155,64 @@ inline void reduce_configure_mop(const ckernel::TensorShape& tensor_shape)
 
     if constexpr (dim == ReduceDim::REDUCE_ROW && type != PoolType::MAX)
     {
-        constexpr std::uint32_t fid_count  = (math_fidelity == MathFidelity::LoFi) ? 1 : to_underlying(math_fidelity);
-        const std::uint32_t replay_buf_len = tensor_shape.num_faces_c_dim * 2 * fid_count;
-
-        const std::uint32_t replay_start = ckernel::math::replay_buf_offset;
-
-        lltt::record<lltt::NoExec>(replay_start, replay_buf_len);
-        for (std::uint32_t faces_remaining = tensor_shape.num_faces_c_dim; faces_remaining > 0; faces_remaining--)
+        if (tensor_shape.total_num_faces() == 4)
         {
-            for (std::uint32_t p = 0; p < fid_count - 1; p++)
-            {
-                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
-            }
+            constexpr std::uint32_t replay_buf_len = 8;
+            constexpr std::uint32_t last_clr       = high_fidelity ? p_setrwc::CLR_NONE : p_setrwc::CLR_AB;
+            constexpr std::uint32_t inner_loops    = high_fidelity ? to_underlying(math_fidelity) : 1;
+            const std::uint32_t replay_start       = ckernel::math::replay_buf_offset;
+
+            lltt::record(replay_start, replay_buf_len);
+            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
             TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
+            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0);
+            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
+            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+            TTI_MVMUL(last_clr, 0, ADDR_MOD_3, 0);
 
-            for (std::uint32_t p = 0; p < fid_count - 1; p++)
+            ckernel_template tmp(1, inner_loops, lltt::replay_insn(replay_start, replay_buf_len));
+            if constexpr (high_fidelity)
             {
-                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 8);
+                tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_ABD_F));
             }
-            if (faces_remaining == 1)
-            {
-                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_3, 8);
-            }
-            else
-            {
-                TTI_MVMUL(p_setrwc::CLR_AB, 0, ADDR_MOD_2, 8);
-            }
+            tmp.program();
         }
+        else
+        {
+            constexpr std::uint32_t fid_count  = (math_fidelity == MathFidelity::LoFi) ? 1 : to_underlying(math_fidelity);
+            const std::uint32_t replay_buf_len = tensor_shape.num_faces_c_dim * 2 * fid_count;
+            const std::uint32_t replay_start   = ckernel::math::replay_buf_offset;
 
-        const std::uint32_t replay_op = lltt::replay_insn(replay_start, replay_buf_len);
-        ckernel_template tmp(tensor_shape.num_faces_r_dim, 1, replay_op);
-        tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_B));
-        tmp.program();
+            lltt::record<lltt::NoExec>(replay_start, replay_buf_len);
+            for (std::uint32_t faces_remaining = tensor_shape.num_faces_c_dim; faces_remaining > 0; faces_remaining--)
+            {
+                for (std::uint32_t p = 0; p < fid_count - 1; p++)
+                {
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
+                }
+                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
+
+                for (std::uint32_t p = 0; p < fid_count - 1; p++)
+                {
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 8);
+                }
+                if (faces_remaining == 1)
+                {
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_3, 8);
+                }
+                else
+                {
+                    TTI_MVMUL(p_setrwc::CLR_AB, 0, ADDR_MOD_2, 8);
+                }
+            }
+
+            const std::uint32_t replay_op = lltt::replay_insn(replay_start, replay_buf_len);
+            ckernel_template tmp(tensor_shape.num_faces_r_dim, 1, replay_op);
+            tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_B));
+            tmp.program();
+        }
     }
     else if constexpr (high_fidelity)
     {
@@ -251,7 +277,7 @@ inline void _llk_math_reduce_(const std::uint32_t dst_index, const ckernel::Tens
         else
         {
             ckernel_template::run();
-            TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_BD);
+            TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_ABD);
         }
     }
     else if constexpr (dim == ReduceDim::REDUCE_COL)
@@ -334,43 +360,75 @@ inline void reduce_configure_addrmod(const ckernel::TensorShape& tensor_shape)
 
     if constexpr (dim == ReduceDim::REDUCE_ROW && type != PoolType::MAX)
     {
-        if constexpr (high_fidelity)
+        if (tensor_shape.total_num_faces() == 4)
         {
             addr_mod_t {
-                .fidelity = {.incr = 1},
+                .srcb = {.incr = 8},
+                .dest = {.incr = 8},
             }
                 .set(ADDR_MOD_0);
-        }
 
-        addr_mod_t {
-            .srcb     = {.incr = 8},
-            .fidelity = {.clr = 1},
-        }
-            .set(ADDR_MOD_1);
-
-        addr_mod_t {
-            .srcb     = {.cr = 1},
-            .fidelity = {.clr = 1},
-        }
-            .set(ADDR_MOD_2);
-
-        if (tensor_shape.num_faces_c_dim == 2)
-        {
             addr_mod_t {
-                .srcb     = {.cr = 1},
-                .dest     = {.incr = 32},
-                .fidelity = {.clr = 1},
+                .srcb = {.incr = 24},
+                .dest = {.incr = 24},
+            }
+                .set(ADDR_MOD_1);
+
+            addr_mod_t {
+                .srca = {.incr = 16},
+                .srcb = {.incr = 16, .cr = 1},
+                .dest = {.cr = 1},
+            }
+                .set(ADDR_MOD_2);
+
+            addr_mod_t {
+                .srca     = {.clr = 1, .cr = 1},
+                .srcb     = {.clr = 1, .cr = 1},
+                .dest     = {.clr = 1, .cr = 1},
+                .fidelity = {.incr = high_fidelity ? 1u : 0u},
             }
                 .set(ADDR_MOD_3);
         }
         else
         {
+            if constexpr (high_fidelity)
+            {
+                addr_mod_t {
+                    .fidelity = {.incr = 1},
+                }
+                    .set(ADDR_MOD_0);
+            }
+
             addr_mod_t {
-                .srcb     = {.cr = 1},
-                .dest     = {.incr = 16},
+                .srcb     = {.incr = 8},
                 .fidelity = {.clr = 1},
             }
-                .set(ADDR_MOD_3);
+                .set(ADDR_MOD_1);
+
+            addr_mod_t {
+                .srcb     = {.cr = 1},
+                .fidelity = {.clr = 1},
+            }
+                .set(ADDR_MOD_2);
+
+            if (tensor_shape.num_faces_c_dim == 2)
+            {
+                addr_mod_t {
+                    .srcb     = {.cr = 1},
+                    .dest     = {.incr = 32},
+                    .fidelity = {.clr = 1},
+                }
+                    .set(ADDR_MOD_3);
+            }
+            else
+            {
+                addr_mod_t {
+                    .srcb     = {.cr = 1},
+                    .dest     = {.incr = 16},
+                    .fidelity = {.clr = 1},
+                }
+                    .set(ADDR_MOD_3);
+            }
         }
     }
     else

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB_reduce.h
@@ -32,6 +32,8 @@ using namespace ckernel::unpacker;
 /**
  * @brief Configures the unpacker MOP for reduction operations. Handles both tiny tiles (face_r_dim < 16) and standard tiles.
  *
+ * @note For full 4-face SUM/AVG REDUCE_ROW, a single UNPACR path unpacks all faces in a single instruction.
+ *
  * @tparam pool_type: Type of pooling operation, values = <SUM/AVG/MAX>
  * @tparam reduce_dim: Dimension along which to reduce, values = <REDUCE_ROW/REDUCE_COL/REDUCE_SCALAR>
  * @param tensor_shape: Shape of the tensor, including face_r_dim and num_faces.

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB_reduce.h
@@ -45,56 +45,40 @@ inline void _llk_unpack_AB_reduce_mop_config_(const ckernel::TensorShape &tensor
     // Validate tensor shape for tile-dependent operations
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
-    // Data valid for clear instructions is set to 0 since the MATH kernel should not process this data.
-    // pool_type == PoolType::MAX sets the clear value to neginf if the pool-type is MAX and 0 if the pool-type is AVG/SUM
-    static constexpr std::uint32_t clear_pool_dep_srca =
-        TT_OP_UNPACR_NOP(p_unpacr_nop::UNP0, (pool_type == PoolType::MAX) ? p_unpacr_nop::UNP_NEGINFSRC : p_unpacr_nop::UNP_ZEROSRC);
-    static constexpr std::uint32_t clear_pool_dep_srcb =
-        TT_OP_UNPACR_NOP(p_unpacr_nop::UNP1, (pool_type == PoolType::MAX) ? p_unpacr_nop::UNP_NEGINFSRC : p_unpacr_nop::UNP_ZEROSRC);
-    static constexpr std::uint32_t clear_zero_srca = TT_OP_UNPACR_NOP(p_unpacr_nop::UNP0, p_unpacr_nop::UNP_ZEROSRC);
-
+    constexpr bool is_max                  = pool_type == PoolType::MAX;
+    constexpr bool swap_operands           = (reduce_dim == ReduceDim::REDUCE_ROW) && !is_max;
+    constexpr bool is_scalar               = reduce_dim == ReduceDim::REDUCE_SCALAR;
     constexpr std::uint32_t REPLAY_BUF_LEN = 2;
+    constexpr std::uint32_t clear_src      = swap_operands ? p_unpacr_nop::UNP1 : p_unpacr_nop::UNP0;
 
-    // Configure unpacker instruction for Src{A,B}. These instructions always increment L1 by 1 face.
+    const bool full_tile          = swap_operands && (tensor_shape.total_num_faces() == 4);
+    const bool is_tiny            = tensor_shape.face_r_dim < FACE_R_DIM;
+    const std::uint32_t innerloop = full_tile ? 1 : tensor_shape.total_num_faces();
+    const std::uint32_t clear_val = is_max ? p_unpacr_nop::UNP_NEGINFSRC : p_unpacr_nop::UNP_ZEROSRC;
+
     lltt::record<lltt::NoExec>(0, REPLAY_BUF_LEN);
-    TTI_UNPACR(Srcs::SrcA, 0b01, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1); // Unpack SrcA
-    TTI_UNPACR(Srcs::SrcB, 0b01, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1); // Unpack SrcB
-
-    // MOP constants
-    constexpr std::uint32_t outerloop = 1;
-    const std::uint32_t innerloop     = tensor_shape.total_num_faces();
-
-    constexpr bool swap_operands = (reduce_dim == ReduceDim::REDUCE_ROW) && (pool_type != PoolType::MAX);
-
-    // Padding should only be done when using tiny tiles otherwise the entire face overwrites the data read in Math
-    if (tensor_shape.face_r_dim < FACE_R_DIM) // Using tiny faces
+    if (full_tile)
     {
-        // Swapped REDUCE_ROW: data is in SrcB, pad SrcB; otherwise data is in SrcA, pad SrcA
-        if constexpr (swap_operands)
-        {
-            ckernel_template tmp(outerloop, innerloop, clear_pool_dep_srcb, lltt::replay_insn(0, REPLAY_BUF_LEN));
-            tmp.program();
-        }
-        else
-        {
-            ckernel_template tmp(outerloop, innerloop, clear_pool_dep_srca, lltt::replay_insn(0, REPLAY_BUF_LEN));
-            tmp.program();
-        }
+        TTI_UNPACR(Srcs::SrcA, 0, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
+        TTI_UNPACR(Srcs::SrcB, 0, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
     }
-    else // Using standard faces (face_r_dim = FACE_R_DIM)
+    else
     {
-        if constexpr (reduce_dim == ReduceDim::REDUCE_SCALAR)
-        {
-            // For scalar reduction, clear SrcA to zero before unpacking. SrcA is clobbered in Math kernel.
-            ckernel_template tmp(outerloop, innerloop, clear_zero_srca, lltt::replay_insn(0, REPLAY_BUF_LEN));
-            tmp.program();
-        }
-        else
-        {
-            // For row/column reduction, no clearing needed
-            ckernel_template tmp(outerloop, innerloop, lltt::replay_insn(0, REPLAY_BUF_LEN));
-            tmp.program();
-        }
+        TTI_UNPACR(Srcs::SrcA, 0b01, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
+        TTI_UNPACR(Srcs::SrcB, 0b01, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
+    }
+
+    const std::uint32_t replay = lltt::replay_insn(0, REPLAY_BUF_LEN);
+
+    if (is_tiny || is_scalar)
+    {
+        ckernel_template tmp(1, innerloop, TT_OP_UNPACR_NOP(clear_src, clear_val), replay);
+        tmp.program();
+    }
+    else
+    {
+        ckernel_template tmp(1, innerloop, replay);
+        tmp.program();
     }
 }
 
@@ -124,22 +108,23 @@ inline void _llk_unpack_AB_reduce_init_(const ckernel::TensorShape &tensor_shape
     // Validate tensor shape for tile-dependent operations
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
-    // SUM/AVG REDUCE_ROW swaps operands (scaler→SrcA, data→SrcB), no transpose needed.
-    // MAX REDUCE_ROW keeps original layout (data→SrcA transposed, scaler→SrcB) — GMPOOL only reads SrcA.
-    constexpr bool swap_operands = (reduce_dim == ReduceDim::REDUCE_ROW) && (pool_type != PoolType::MAX);
+    constexpr bool is_max        = pool_type == PoolType::MAX;
+    constexpr bool swap_operands = (reduce_dim == ReduceDim::REDUCE_ROW) && !is_max;
+
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>((reduce_dim == ReduceDim::REDUCE_ROW));
 
-    config_unpacker_x_end<p_setadc::UNP_A>(tensor_shape.face_r_dim);
+    const bool full_tile = swap_operands && (tensor_shape.total_num_faces() == 4);
 
-    // UNP_B reads data faces (face_r_dim rows) in swapped mode, or a single
-    // scaler row in the non-swapped (MAX / COL / SCALAR) mode.
-    if constexpr (swap_operands)
+    if (full_tile)
     {
-        config_unpacker_x_end<p_setadc::UNP_B>(tensor_shape.face_r_dim);
+        const std::uint32_t x_end = tensor_shape.total_num_faces() * FACE_R_DIM * FACE_C_DIM - 1;
+        TT_SETADCXX(p_setadc::UNP_A, x_end, 0x0);
+        TT_SETADCXX(p_setadc::UNP_B, x_end, 0x0);
     }
     else
     {
-        config_unpacker_x_end<p_setadc::UNP_B>(1);
+        config_unpacker_x_end<p_setadc::UNP_A>(tensor_shape.face_r_dim);
+        config_unpacker_x_end<p_setadc::UNP_B>(swap_operands ? tensor_shape.face_r_dim : 1);
     }
 
     // Configure unpack MOP
@@ -178,17 +163,14 @@ inline void _llk_unpack_AB_reduce_(const std::uint32_t address_a, const std::uin
     // Wait for free context
     wait_for_next_context(2);
 
-    // SUM/AVG REDUCE_ROW: swap operands so scaler→SrcA, data→SrcB
-    // MAX REDUCE_ROW: keep original order (data→SrcA, scaler→SrcB)
-    constexpr bool swap_operands = (reduce_dim == ReduceDim::REDUCE_ROW) && (pool_type != PoolType::MAX);
-    if constexpr (swap_operands)
-    {
-        _llk_unpack_configure_addresses_(address_b, address_a, cfg);
-    }
-    else
-    {
-        _llk_unpack_configure_addresses_(address_a, address_b, cfg);
-    }
+    constexpr bool is_max        = pool_type == PoolType::MAX;
+    constexpr bool swap_operands = (reduce_dim == ReduceDim::REDUCE_ROW) && !is_max;
+
+    // SUM/AVG REDUCE_ROW swaps operands (scaler→SrcA, data→SrcB), no transpose needed.
+    // MAX REDUCE_ROW keeps original layout (data→SrcA transposed, scaler→SrcB) — GMPOOL only reads SrcA.
+    const std::uint32_t addr_unp_a = swap_operands ? address_b : address_a;
+    const std::uint32_t addr_unp_b = swap_operands ? address_a : address_b;
+    _llk_unpack_configure_addresses_(addr_unp_a, addr_unp_b, cfg);
 
     // Trisc::SEMPOST for context acquire
     semaphore_post(semaphore::UNPACK_SYNC);


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Performance

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Closes #49779

This PR adds a full tile fast path for standard 32x32 tiles in both the unpack and math reduce kernels on Wormhole and Blackhole. For reduce_row SUM/AVG with 4 faces, the unpack now uses a single contiguous UNPACR per operand, and the math only has to clear dvalid once instead of 4 times per tile.

The SDPA perf test expected math utilization is lowered because the reduce is now faster, so the math spends less time waiting on dvalid. The overall L1 to L1 time is shorter, but the math utilization percentage drops because the math is no longer stalling doing nothing.

### Perf results

**Wormhole before:**

| formats.input_A | formats.input_B | formats.output | unpack_to_dest | dest_acc            | mathop                  | reduce_pool_type | tile_cnt | loop_factor | marker    | mean(L1_TO_L1) | mean(UNPACK_ISOLATE) | mean(MATH_ISOLATE) | mean(PACK_ISOLATE) | mean(L1_CONGESTION[UNPACK]) | mean(L1_CONGESTION[PACK]) | TEXT_SIZE(L1_TO_L1) | TEXT_SIZE(UNPACK_ISOLATE) | TEXT_SIZE(MATH_ISOLATE) | TEXT_SIZE(PACK_ISOLATE) |
| --------------- | --------------- | -------------- | -------------- | ------------------- | ----------------------- | ---------------- | -------- | ----------- | --------- | -------------- | -------------------- | ------------------ | ------------------ | --------------------------- | ------------------------- | ------------------- | ------------------------- | ----------------------- | ----------------------- |
| Float32         | Float32         | Float32        |          False | DestAccumulation.No | MathOperation.ReduceRow | ReducePool.Sum   |       16 |        True | INIT      |          572.0 |                437.0 |              254.0 |              571.0 |                       438.0 |                     563.0 |              12,601 |                     3,777 |                   3,434 |                   5,258 |
| Float32         | Float32         | Float32        |          False | DestAccumulation.No | MathOperation.ReduceRow | ReducePool.Sum   |       16 |        True | KERNEL    |        3,927.0 |              2,862.0 |            3,150.0 |            1,987.0 |                     3,151.0 |                   3,051.0 |              12,601 |                     3,777 |                   3,434 |                   5,258 |
| Float32         | Float32         | Float32        |          False | DestAccumulation.No | MathOperation.ReduceRow | ReducePool.Sum   |       16 |        True | TILE_LOOP |          207.5 |                140.5 |              168.7 |               77.1 |                       158.8 |                     144.2 |              12,601 |                     3,777 |                   3,434 |                   5,258 |

**Wormhole after:**

| formats.input_A | formats.input_B | formats.output | unpack_to_dest | dest_acc            | mathop                  | reduce_pool_type | tile_cnt | loop_factor | marker    | mean(L1_TO_L1) | mean(UNPACK_ISOLATE) | mean(MATH_ISOLATE) | mean(PACK_ISOLATE) | mean(L1_CONGESTION[UNPACK]) | mean(L1_CONGESTION[PACK]) | TEXT_SIZE(L1_TO_L1) | TEXT_SIZE(UNPACK_ISOLATE) | TEXT_SIZE(MATH_ISOLATE) | TEXT_SIZE(PACK_ISOLATE) |
| --------------- | --------------- | -------------- | -------------- | ------------------- | ----------------------- | ---------------- | -------- | ----------- | --------- | -------------- | -------------------- | ------------------ | ------------------ | --------------------------- | ------------------------- | ------------------- | ------------------------- | ----------------------- | ----------------------- |
| Float32         | Float32         | Float32        |          False | DestAccumulation.No | MathOperation.ReduceRow | ReducePool.Sum   |       16 |        True | INIT      |          575.0 |                440.0 |              232.0 |              562.0 |                       444.0 |                     567.0 |              12,809 |                     3,789 |                   3,630 |                   5,258 |
| Float32         | Float32         | Float32        |          False | DestAccumulation.No | MathOperation.ReduceRow | ReducePool.Sum   |       16 |        True | KERNEL    |        3,683.0 |              2,816.0 |            1,520.0 |            1,977.0 |                     3,191.0 |                   2,997.0 |              12,809 |                     3,789 |                   3,630 |                   5,258 |
| Float32         | Float32         | Float32        |          False | DestAccumulation.No | MathOperation.ReduceRow | ReducePool.Sum   |       16 |        True | TILE_LOOP |          191.9 |                137.6 |               68.2 |               77.2 |                       160.8 |                     140.6 |              12,809 |                     3,789 |                   3,630 |                   5,258 |

**Blackhole before:**

| formats.input_A | formats.input_B | formats.output | unpack_to_dest | dest_acc            | mathop                  | reduce_pool_type | tile_cnt | loop_factor | marker    | mean(L1_TO_L1) | mean(UNPACK_ISOLATE) | mean(MATH_ISOLATE) | mean(PACK_ISOLATE) | mean(L1_CONGESTION[UNPACK]) | mean(L1_CONGESTION[PACK]) | TEXT_SIZE(L1_TO_L1) | TEXT_SIZE(UNPACK_ISOLATE) | TEXT_SIZE(MATH_ISOLATE) | TEXT_SIZE(PACK_ISOLATE) |
| --------------- | --------------- | -------------- | -------------- | ------------------- | ----------------------- | ---------------- | -------- | ----------- | --------- | -------------- | -------------------- | ------------------ | ------------------ | --------------------------- | ------------------------- | ------------------- | ------------------------- | ----------------------- | ----------------------- |
| Float32         | Float32         | Float32        |          False | DestAccumulation.No | MathOperation.ReduceRow | ReducePool.Sum   |       16 |        True | INIT      |          484.0 |                461.0 |              209.0 |              482.0 |                       461.0 |                     473.0 |              11,721 |                     3,861 |                   3,326 |                   4,386 |
| Float32         | Float32         | Float32        |          False | DestAccumulation.No | MathOperation.ReduceRow | ReducePool.Sum   |       16 |        True | KERNEL    |        3,553.0 |              1,347.0 |            3,129.0 |            1,302.0 |                     1,345.0 |                   1,307.0 |              11,721 |                     3,861 |                   3,326 |                   4,386 |
| Float32         | Float32         | Float32        |          False | DestAccumulation.No | MathOperation.ReduceRow | ReducePool.Sum   |       16 |        True | TILE_LOOP |          184.0 |               46.1   |              173.1 |               41.4 |                        46.0 |                      42.3 |              11,721 |                     3,861 |                   3,326 |                   4,386 |

**Blackhole after:**

| formats.input_A | formats.input_B | formats.output | unpack_to_dest | dest_acc            | mathop                  | reduce_pool_type | tile_cnt | loop_factor | marker    | mean(L1_TO_L1) | mean(UNPACK_ISOLATE) | mean(MATH_ISOLATE) | mean(PACK_ISOLATE) | mean(L1_CONGESTION[UNPACK]) | mean(L1_CONGESTION[PACK]) | TEXT_SIZE(L1_TO_L1) | TEXT_SIZE(UNPACK_ISOLATE) | TEXT_SIZE(MATH_ISOLATE) | TEXT_SIZE(PACK_ISOLATE) |
| --------------- | --------------- | -------------- | -------------- | ------------------- | ----------------------- | ---------------- | -------- | ----------- | --------- | -------------- | -------------------- | ------------------ | ------------------ | --------------------------- | ------------------------- | ------------------- | ------------------------- | ----------------------- | ----------------------- |
| Float32         | Float32         | Float32        |          False | DestAccumulation.No | MathOperation.ReduceRow | ReducePool.Sum   |       16 |        True | INIT      |          487.0 |                468.0 |              196.0 |              484.0 |                       468.0 |                     474.0 |              11,929 |                     3,873 |                   3,522 |                   4,386 |
| Float32         | Float32         | Float32        |          False | DestAccumulation.No | MathOperation.ReduceRow | ReducePool.Sum   |       16 |        True | KERNEL    |        1,873.0 |              1,350.0 |            1,429.0 |            1,304.0 |                     1,351.0 |                   1,314.0 |              11,929 |                     3,873 |                   3,522 |                   4,386 |
| Float32         | Float32         | Float32        |          False | DestAccumulation.No | MathOperation.ReduceRow | ReducePool.Sum   |       16 |        True | TILE_LOOP |           78.7 |               45.8   |               67.1 |               41.4 |                        45.8 |                      42.7 |              11,929 |                     3,873 |                   3,522 |                   4,386 |


### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=marko/reduce-full-tile-unpack)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:marko/reduce-full-tile-unpack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=marko/reduce-full-tile-unpack)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:marko/reduce-full-tile-unpack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=marko/reduce-full-tile-unpack)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:marko/reduce-full-tile-unpack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=marko/reduce-full-tile-unpack)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:marko/reduce-full-tile-unpack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=marko/reduce-full-tile-unpack)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:marko/reduce-full-tile-unpack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=marko/reduce-full-tile-unpack)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:marko/reduce-full-tile-unpack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=marko/reduce-full-tile-unpack)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:marko/reduce-full-tile-unpack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=marko/reduce-full-tile-unpack)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:marko/reduce-full-tile-unpack)