### PR TITLE
sparse_mla: fold single-shot onto the block-cyclic path (persist indexer cache)

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_cache.py
@@ -114,7 +114,7 @@ def cleanup_cache():
     report_and_clear()
 
 
-def _forward(mla, mesh_device, rope_tensors, kvpe_cache, hidden):
+def _forward(mla, mesh_device, rope_tensors, kvpe_cache, index_kv_cache, hidden):
     """Single-shot sparse MLA forward, mirroring run_mla_inference's SP×TP input sharding."""
     shard_dims = [None, None]
     shard_dims[TP_AXIS], shard_dims[SP_AXIS] = -1, -2
@@ -126,13 +126,17 @@ def _forward(mla, mesh_device, rope_tensors, kvpe_cache, hidden):
         layout=ttnn.TILE_LAYOUT,
         mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims),
     )
-    out = mla.forward(hidden_states=tt_hidden, rope_tensors=rope_tensors, kvpe_cache=kvpe_cache)
+    out = mla.forward(
+        hidden_states=tt_hidden, rope_tensors=rope_tensors, kvpe_cache=kvpe_cache, index_kv_cache=index_kv_cache
+    )
     return ttnn.to_torch(
         out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=shard_dims, mesh_shape=mesh_device.shape)
     ).to(torch.bfloat16)
 
 
 def _new_kvpe(config, mesh_device, mesh_shape):
+    # Sparse attention (sparse_sdpa) reads the KVPE cache natively: it must be uncompressed bf16 and
+    # ROW_MAJOR (the sparse forward asserts this), not the init_kvpe_cache bf8/TILE default.
     return init_kvpe_cache(
         kvpe_cache_head_dim=config.kv_lora_rank + config.qk_rope_head_dim,
         mesh_device=mesh_device,
@@ -140,6 +144,23 @@ def _new_kvpe(config, mesh_device, mesh_shape):
         mesh_shape=mesh_shape,
         sp_axis=SP_AXIS,
         num_kvpe_cache_layers=1,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+    )
+
+
+def _new_index_kv(config, mesh_device, mesh_shape):
+    # Caller-owned indexer key cache for the folded single-shot (block-cyclic) path: 1 layer / 1 user, so
+    # update_padded_kv_cache's num_slots = cache_batch / layer_num stays >= 1 with the MLA's layer_num=1.
+    return init_kvpe_cache(
+        kvpe_cache_head_dim=config.index_head_dim,
+        mesh_device=mesh_device,
+        seq_len=SEQ_LEN,
+        mesh_shape=mesh_shape,
+        sp_axis=SP_AXIS,
+        num_kvpe_cache_layers=1,
+        num_users=1,
+        dtype=ttnn.bfloat8_b,
     )
 
 
@@ -153,6 +174,10 @@ def _build_mla(config, state_dict, mesh_device, weight_cache_path):
         sp_axis=SP_AXIS,
         tp_axis=TP_AXIS,
         weight_cache_path=weight_cache_path,
+        # Single-shot folds onto block-cyclic: the sparse indexer/KVPE write goes through
+        # update_padded_kv_cache (num_slots = cache_batch / layer_num). The test caches are 1 layer / 1 user,
+        # so layer_num must be 1 (matches test_mla.py) or num_slots collapses to 0 and the write asserts.
+        layer_num=1,
     )
 
 
@@ -182,14 +207,25 @@ def test_sparse_mla_cache_only_stays_sparse(mesh_device, device_params, variant,
     weights = random_mla_weights(config)  # device-vs-device round-trip: config-shaped weights suffice
     mesh_shape = list(mesh_device.shape)
 
-    rope_tensors = RotarySetup(config, mesh_device, sp_axis=SP_AXIS, is_balanced=False).get_rope_tensors(SEQ_LEN)
+    # Sparse single-shot is folded onto the block-cyclic path (one full-seq chunk at offset 0): indexed rope
+    # tables + a caller-owned indexer key cache, exactly like the chunked path.
+    rope_tensors = RotarySetup(config, mesh_device, sp_axis=SP_AXIS, is_balanced=False).get_rope_tensors_indexed(
+        cache_seq_len_global=SEQ_LEN, chunk_size_global=SEQ_LEN
+    )
     torch.manual_seed(42)
     hidden = torch.randn(1, SEQ_LEN, config.hidden_size, dtype=torch.bfloat16)
 
     # === from weights (no cache) ===
     mla_w = _build_mla(config, weights, mesh_device, weight_cache_path=None)
     assert mla_w._has_indexer, f"{variant.name}: from-weights construction must be sparse"
-    out_weights = _forward(mla_w, mesh_device, rope_tensors, _new_kvpe(config, mesh_device, mesh_shape), hidden)
+    out_weights = _forward(
+        mla_w,
+        mesh_device,
+        rope_tensors,
+        _new_kvpe(config, mesh_device, mesh_shape),
+        _new_index_kv(config, mesh_device, mesh_shape),
+        hidden,
+    )
 
     # === offline cache build: dense + indexer tensorbins ===
     init_checker(CACHE_DIR)
@@ -202,7 +238,14 @@ def test_sparse_mla_cache_only_stays_sparse(mesh_device, device_params, variant,
     mla_c = _build_mla(config, {}, mesh_device, weight_cache_path=CACHE_DIR)
     assert mla_c._has_indexer, f"{variant.name}: cache-only construction must stay sparse, not fall back to dense"
     assert type(mla_c._indexer).__name__ == "TtIndexer", "cache-only must bind TtIndexer, not NullIndexer"
-    out_cache = _forward(mla_c, mesh_device, rope_tensors, _new_kvpe(config, mesh_device, mesh_shape), hidden)
+    out_cache = _forward(
+        mla_c,
+        mesh_device,
+        rope_tensors,
+        _new_kvpe(config, mesh_device, mesh_shape),
+        _new_index_kv(config, mesh_device, mesh_shape),
+        hidden,
+    )
 
     passed, pcc = comp_pcc(out_weights, out_cache, 0.999)
     logger.info(f"[{variant.name}] sparse cache-only vs from-weights PCC: {pcc}")

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_vs_trace.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_vs_trace.py
@@ -307,7 +307,15 @@ def _make_mla(model, config, layer, mesh_device, is_chunked=False):
     config.max_seq_len = SEQ_LEN  # rope-table length (same hack as v3 run_model / test_mla)
     weights = _weights_for(model, config, layer)  # canonical dict — same tensors the CPU truth uses
     return ttMLA(
-        config, weights, mesh_device, layer_idx=0, seq_len=SEQ_LEN, sp_axis=0, tp_axis=1, is_chunked=is_chunked
+        config,
+        weights,
+        mesh_device,
+        layer_idx=0,
+        seq_len=SEQ_LEN,
+        sp_axis=0,
+        tp_axis=1,
+        is_chunked=is_chunked,
+        layer_num=1,
     )
 
 
@@ -350,7 +358,23 @@ def test_indexer_device_vs_reference(mesh_device, model, layer, device_params, m
     xs = _shard_idx_input(x, mesh_device)
     sl = SEQ_LEN // mesh_device.shape[0]
     qr = mla._q_a_latent(xs, sl, mla._get_act_mem_config("q_b_proj", sl))
-    idx = mla._indexer.forward(xs, qr, sl)
+    # The indexer is always block-cyclic now (single-shot = one full-seq chunk at offset 0): feed it the
+    # indexed rope tables + a caller-owned index_kv_cache, matching the MLA forward path.
+    cfg = _config_for(model)
+    idx_kv_cache = init_kvpe_cache(
+        kvpe_cache_head_dim=cfg.index_head_dim,
+        mesh_device=mesh_device,
+        seq_len=SEQ_LEN,
+        mesh_shape=list(mesh_device.shape),
+        sp_axis=0,
+        num_kvpe_cache_layers=1,
+        num_users=1,
+        dtype=ttnn.bfloat8_b,
+    )
+    idx_rope = RotarySetup(cfg, mesh_device, sp_axis=0, is_balanced=False).get_rope_tensors_indexed(
+        cache_seq_len_global=SEQ_LEN, chunk_size_global=SEQ_LEN
+    )
+    idx = mla._indexer.forward(xs, qr, sl, rope_tensors=idx_rope, index_kv_cache=idx_kv_cache)
 
     # The indexer is now query-SP-sharded: top-k input is [1,1,S/sp,end_pos] (TP-replicated) and idx is
     # [1,1,S/sp,k]. Reassemble the full S by concatenating the SP shards (tp=0 column) along the query dim.
@@ -379,6 +403,8 @@ def _run_device_forward(model, config, layer, mesh_device):
     ref = load_reference(model, layer)
     mla = _make_mla(model, config, layer, mesh_device)
     sp_axis, tp_axis = 0, 1
+    # Sparse: uncompressed bf16/ROW_MAJOR KVPE cache + indexed rope + a caller-owned indexer key cache.
+    # Single-shot is folded onto the block-cyclic path (one full-seq chunk at offset 0).
     kvpe_cache = init_kvpe_cache(
         kvpe_cache_head_dim=config.kv_lora_rank + config.qk_rope_head_dim,
         mesh_device=mesh_device,
@@ -386,8 +412,22 @@ def _run_device_forward(model, config, layer, mesh_device):
         mesh_shape=list(mesh_device.shape),
         sp_axis=sp_axis,
         num_kvpe_cache_layers=1,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
     )
-    rope_tensors = RotarySetup(config, mesh_device, sp_axis=sp_axis, is_balanced=False).get_rope_tensors(SEQ_LEN)
+    index_kv_cache = init_kvpe_cache(
+        kvpe_cache_head_dim=config.index_head_dim,
+        mesh_device=mesh_device,
+        seq_len=SEQ_LEN,
+        mesh_shape=list(mesh_device.shape),
+        sp_axis=sp_axis,
+        num_kvpe_cache_layers=1,
+        num_users=1,
+        dtype=ttnn.bfloat8_b,
+    )
+    rope_tensors = RotarySetup(config, mesh_device, sp_axis=sp_axis, is_balanced=False).get_rope_tensors_indexed(
+        cache_seq_len_global=SEQ_LEN, chunk_size_global=SEQ_LEN
+    )
 
     shard_dims = [None, None]
     shard_dims[tp_axis], shard_dims[sp_axis] = -1, -2
@@ -399,7 +439,7 @@ def _run_device_forward(model, config, layer, mesh_device):
         layout=ttnn.TILE_LAYOUT,
         mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims),
     )
-    out = mla.forward(tt_x, rope_tensors, kvpe_cache)
+    out = mla.forward(tt_x, rope_tensors, kvpe_cache, index_kv_cache=index_kv_cache)
     out_t = ttnn.to_torch(
         out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=shard_dims, mesh_shape=mesh_device.shape)
     ).to(torch.bfloat16)[

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -20,6 +20,7 @@ from models.common.utility_functions import hf_cache_layer_kv
 from models.demos.deepseek_v3_d_p.reference.mla_reference import create_mla_reference
 from models.demos.deepseek_v3_d_p.tests.reference_runners import run_reference_mla
 from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
+from models.demos.deepseek_v3_d_p.tt.mla.indexer import num_full_indexer_layers, resolve_has_indexer
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
 from models.demos.deepseek_v3_d_p.tt.mla.utils import (
     blockcyclic_cache_host,
@@ -93,7 +94,28 @@ def run_mla_inference(
         layer_num=1,
     )
     rope_setup = RotarySetup(config, mesh_device, sp_axis=sp_axis, is_balanced=is_balanced)
-    rope_tensors = rope_setup.get_rope_tensors(seq_len)
+    # Sparse (DSA) single-shot is folded onto the block-cyclic path (one full-seq chunk at offset 0):
+    # it uses the indexed rope tables and a caller-owned indexer key cache, exactly like the chunked
+    # path. Dense keeps natural rope + no index cache.
+    has_indexer = resolve_has_indexer(config)
+    index_kv_cache = None
+    if has_indexer:
+        rope_tensors = rope_setup.get_rope_tensors_indexed(cache_seq_len_global=seq_len, chunk_size_global=seq_len)
+        # Layer-slot count mirrors the serving adapter: the indexer strides the folded user-major cache by
+        # num_full_indexer_layers (GLM-5.2 cross-layer reuse), so the cache must carry that many slots for
+        # update_padded_kv_cache's cache_batch % num_layers check. Falls back to 1 (no indexer_types).
+        index_kv_cache = init_kvpe_cache(
+            kvpe_cache_head_dim=config.index_head_dim,
+            mesh_device=mesh_device,
+            seq_len=seq_len,
+            mesh_shape=mesh_shape,
+            sp_axis=sp_axis,
+            num_kvpe_cache_layers=num_full_indexer_layers(config) or 1,
+            num_users=1,
+            dtype=ttnn.bfloat8_b,
+        )
+    else:
+        rope_tensors = rope_setup.get_rope_tensors(seq_len)
 
     # Verify TT MLA exists
     assert mla_tt is not None, "TT MLA should exist"
@@ -134,6 +156,7 @@ def run_mla_inference(
         kvpe_cache=tt_kvpe_cache,
         indexer_indices=inject_indices,
         return_indexer_indices=return_indices,
+        index_kv_cache=index_kv_cache,
     )
     indices = None
     if return_indices:

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
@@ -32,6 +32,7 @@ from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
 from models.demos.deepseek_v3_d_p.reference.tt.moe.moe import load_moe_weights_from_hf
 from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_reference import build_weights
+from models.demos.deepseek_v3_d_p.tt.mla.indexer import num_full_indexer_layers
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
 from models.demos.deepseek_v3_d_p.tt.mla.utils import (
     create_balanced_chunk_order,
@@ -1005,8 +1006,9 @@ def test_glm_prefill_block(
     )
     # Sparse (DSA) MLA single-shot is folded onto the block-cyclic path (one full-seq chunk at offset 0):
     # it uses the indexed rope tables and a caller-owned indexer key cache, exactly like the chunked path.
-    # GLM attention is always sparse, so this is unconditional here; the 1-layer/1-user index cache matches
-    # the layer_num=1 above (update_padded_kv_cache's num_slots = cache_batch / layer_num must be >= 1).
+    # GLM attention is always sparse, so this is unconditional here. The cache is strided by the compacted
+    # full-indexer count (num_full_indexer_layers) — >1 for glm_5_2 cross-layer reuse — matching the
+    # indexer's cache_batch stride; falls back to 1 when there is no indexer_types map (glm_5_1).
     rope_tensors = RotarySetup(config, mesh_device, sp_axis=sp_axis, is_balanced=False).get_rope_tensors_indexed(
         cache_seq_len_global=seq_len, chunk_size_global=seq_len
     )
@@ -1016,7 +1018,7 @@ def test_glm_prefill_block(
         seq_len=seq_len,
         mesh_shape=mesh_shape,
         sp_axis=sp_axis,
-        num_kvpe_cache_layers=1,
+        num_kvpe_cache_layers=num_full_indexer_layers(config) or 1,
         num_users=1,
         dtype=ttnn.bfloat8_b,
     )

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
@@ -1003,7 +1003,23 @@ def test_glm_prefill_block(
         dtype=ttnn.bfloat16,
         layout=ttnn.ROW_MAJOR_LAYOUT,
     )
-    rope_tensors = RotarySetup(config, mesh_device, sp_axis=sp_axis, is_balanced=False).get_rope_tensors(seq_len)
+    # Sparse (DSA) MLA single-shot is folded onto the block-cyclic path (one full-seq chunk at offset 0):
+    # it uses the indexed rope tables and a caller-owned indexer key cache, exactly like the chunked path.
+    # GLM attention is always sparse, so this is unconditional here; the 1-layer/1-user index cache matches
+    # the layer_num=1 above (update_padded_kv_cache's num_slots = cache_batch / layer_num must be >= 1).
+    rope_tensors = RotarySetup(config, mesh_device, sp_axis=sp_axis, is_balanced=False).get_rope_tensors_indexed(
+        cache_seq_len_global=seq_len, chunk_size_global=seq_len
+    )
+    index_kv_cache = init_kvpe_cache(
+        kvpe_cache_head_dim=config.index_head_dim,
+        mesh_device=mesh_device,
+        seq_len=seq_len,
+        mesh_shape=mesh_shape,
+        sp_axis=sp_axis,
+        num_kvpe_cache_layers=1,
+        num_users=1,
+        dtype=ttnn.bfloat8_b,
+    )
 
     # --- input (full, host) + sharded device copy ---
     torch.manual_seed(7)
@@ -1021,7 +1037,9 @@ def test_glm_prefill_block(
     )
 
     logger.info(f"[glm block {layer_type}] running device block")
-    out = block.forward(tt_x, rope_tensors=rope_tensors, kvpe_cache=kvpe_cache, actual_isl=seq_len)
+    out = block.forward(
+        tt_x, rope_tensors=rope_tensors, kvpe_cache=kvpe_cache, actual_isl=seq_len, index_kv_cache=index_kv_cache
+    )
     if isinstance(out, tuple):
         out = out[0]
     tt_out = ttnn.to_torch(

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
@@ -458,6 +458,22 @@ def run_model(
         layout=kvpe_layout,
     )
 
+    # Sparse single-shot is folded onto the block-cyclic path, so (like chunked) it needs the caller-owned,
+    # user-major layer-stacked indexer key cache [num_users*num_layers, 1, T, D_idx], allocated with the
+    # SAME num_kvpe_cache_layers=num_layers as the KVPE cache. Dense variants use no index cache.
+    tt_index_kv_cache = None
+    if has_indexer:
+        tt_index_kv_cache = init_kvpe_cache(
+            kvpe_cache_head_dim=config.index_head_dim,
+            mesh_device=mesh_device,
+            seq_len=isl_total,
+            mesh_shape=mesh_shape,
+            sp_axis=sp_axis,
+            num_kvpe_cache_layers=num_layers,
+            num_users=1,
+            dtype=ttnn.bfloat8_b,
+        )
+
     # --- Shard token_ids to device ---
     # Reshape [1, isl_total] -> [sp_factor, 1, isl_per_chip] for SP sharding
     if is_balanced == True:
@@ -502,6 +518,7 @@ def run_model(
                 return_intermediates=True,
                 read_profiler=False,
                 temperature=temperature,
+                index_kv_cache=tt_index_kv_cache,
             )
             ttnn.synchronize_device(mesh_device)
             if i == 0:
@@ -560,6 +577,7 @@ def run_model(
             return_intermediates=pcc_validation,
             read_profiler=False,
             temperature=temperature,
+            index_kv_cache=tt_index_kv_cache,
         )
         logger.info(f"Starting completion sync on iteration: {i}")
         ttnn.synchronize_device(mesh_device)
@@ -826,7 +844,10 @@ def run_model(
             "threshold": threshold,
         }
         write_pcc_summary(summary_result, threshold=threshold)
-        if not os.getenv("GITHUB_ACTIONS") and trace_dir is not None:
+        # PCC plots are opt-in (TT_PREFILL_PCC_PLOTS=1). generate_pcc_plots renders a PNG into trace_dir,
+        # which for a pinned golden is a read-only shared mount (/mnt/models/...) -> PermissionError. Off by
+        # default so trace-backed runs don't crash on artifact write; still skipped under GitHub Actions.
+        if os.getenv("TT_PREFILL_PCC_PLOTS") == "1" and not os.getenv("GITHUB_ACTIONS") and trace_dir is not None:
             generate_pcc_plots(summary_result, output_dir=str(trace_dir))
 
     # Deferred PCC failure check (after timing report)

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
@@ -33,6 +33,7 @@ import ttnn
 from conftest import is_galaxy
 from models.common.utility_functions import is_blackhole, profiler
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
+from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
 from models.demos.deepseek_v3_d_p.tests.conftest import FABRIC_2D_PREFILL_BLOCK_MESH_PARAMS
 from models.demos.deepseek_v3_d_p.tt.mla.indexer import num_full_indexer_layers, resolve_has_indexer
@@ -1149,9 +1150,17 @@ def test_kimi_prefill_transformer(
 @pytest.mark.parametrize(
     "mesh_device, device_params, num_links, topology",
     [
-        # FABRIC_2D variants — shared list defined in conftest.py (also used by the deepseek_v3
-        # transformer test). Covers (4,2) BH LoudBox, (2,4) asymmetric, (8,4) BH Galaxy.
-        *FABRIC_2D_PREFILL_BLOCK_MESH_PARAMS,
+        pytest.param(
+            (8, 4),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=GLM51Config.FABRIC_PAYLOAD_SIZE),
+            },
+            2,
+            ttnn.Topology.Linear,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
+            id="mesh-8x4",
+        ),
     ],
     indirect=["mesh_device", "device_params"],
 )

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
@@ -36,7 +36,7 @@ from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3
 from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
 from models.demos.deepseek_v3_d_p.tests.conftest import FABRIC_2D_PREFILL_BLOCK_MESH_PARAMS
-from models.demos.deepseek_v3_d_p.tt.mla.indexer import resolve_has_indexer
+from models.demos.deepseek_v3_d_p.tt.mla.indexer import num_full_indexer_layers, resolve_has_indexer
 from models.demos.deepseek_v3_d_p.tt.mla.utils import (
     create_balanced_chunk_order,
     reorder_tensor_chunks,
@@ -459,17 +459,20 @@ def run_model(
     )
 
     # Sparse single-shot is folded onto the block-cyclic path, so (like chunked) it needs the caller-owned,
-    # user-major layer-stacked indexer key cache [num_users*num_layers, 1, T, D_idx], allocated with the
-    # SAME num_kvpe_cache_layers=num_layers as the KVPE cache. Dense variants use no index cache.
+    # user-major layer-stacked indexer key cache [num_users*index_cache_layers, 1, T, D_idx]. Unlike the
+    # per-layer KVPE cache, the indexer stride is the COMPACTED full-indexer count (num_full_indexer_layers)
+    # for GLM-5.2 cross-layer reuse — "shared" layers reuse a "full" layer's cache and get no slot of their
+    # own — falling back to num_layers when there is no indexer_types map. Dense variants use no index cache.
     tt_index_kv_cache = None
     if has_indexer:
+        index_cache_layers = num_full_indexer_layers(config) or num_layers
         tt_index_kv_cache = init_kvpe_cache(
             kvpe_cache_head_dim=config.index_head_dim,
             mesh_device=mesh_device,
             seq_len=isl_total,
             mesh_shape=mesh_shape,
             sp_axis=sp_axis,
-            num_kvpe_cache_layers=num_layers,
+            num_kvpe_cache_layers=index_cache_layers,
             num_users=1,
             dtype=ttnn.bfloat8_b,
         )

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
@@ -33,7 +33,6 @@ import ttnn
 from conftest import is_galaxy
 from models.common.utility_functions import is_blackhole, profiler
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
-from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
 from models.demos.deepseek_v3_d_p.tests.conftest import FABRIC_2D_PREFILL_BLOCK_MESH_PARAMS
 from models.demos.deepseek_v3_d_p.tt.mla.indexer import num_full_indexer_layers, resolve_has_indexer
@@ -1150,17 +1149,9 @@ def test_kimi_prefill_transformer(
 @pytest.mark.parametrize(
     "mesh_device, device_params, num_links, topology",
     [
-        pytest.param(
-            (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=GLM51Config.FABRIC_PAYLOAD_SIZE),
-            },
-            2,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
-        ),
+        # FABRIC_2D variants — shared list defined in conftest.py (also used by the deepseek_v3
+        # transformer test). Covers (4,2) BH LoudBox, (2,4) asymmetric, (8,4) BH Galaxy.
+        *FABRIC_2D_PREFILL_BLOCK_MESH_PARAMS,
     ],
     indirect=["mesh_device", "device_params"],
 )

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -478,7 +478,8 @@ def run_chunked_transformer(
     # Sparse (DSA) requires an UNCOMPRESSED bf16/fp8_e4m3 ROW_MAJOR KVPE cache (sparse_sdpa reads it
     # natively; mla.forward asserts) — NOT the init_kvpe_cache bfloat8_b/TILE default that dense
     # ring_mla wants. Match the cache format to the path.
-    kvpe_dtype_layout = dict(dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT) if resolve_has_indexer(config) else {}
+    has_indexer = resolve_has_indexer(config)
+    kvpe_dtype_layout = dict(dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT) if has_indexer else {}
     tt_kvpe_cache = init_kvpe_cache(
         kvpe_cache_head_dim=kvpe_dim,
         mesh_device=mesh_device,
@@ -496,7 +497,7 @@ def run_chunked_transformer(
     # allocate it with the SAME num_kvpe_cache_layers=num_layers as the KVPE cache. bf8 (half the memory,
     # top-k within bf16 noise). Dense (non-sparse) variants get None (natural-path / dense MLA use no cache).
     tt_index_kv_cache = None
-    if resolve_has_indexer(config):
+    if has_indexer:
         # A sparse config must carry index_head_dim; assert rather than silently defaulting so a
         # misconfigured (missing-field) sparse setup fails loudly with a clear message.
         assert getattr(config, "index_head_dim", None) is not None, "sparse config must provide index_head_dim"

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -40,7 +40,7 @@ from models.common.utility_functions import is_blackhole, profiler
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
-from models.demos.deepseek_v3_d_p.tt.mla.indexer import resolve_has_indexer
+from models.demos.deepseek_v3_d_p.tt.mla.indexer import num_full_indexer_layers, resolve_has_indexer
 from models.demos.deepseek_v3_d_p.tt.mla.utils import blockcyclic_positions, rotated_chip_positions
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
@@ -493,21 +493,24 @@ def run_chunked_transformer(
 
     # Sparse (DSA) layers read a block-cyclic indexer key cache that is caller-owned and passed into
     # forward, exactly like the KVPE cache. It is user-major layer-stacked
-    # [num_users*num_layers, 1, T, D_idx], so the indexer addresses slot user*num_layers + cache_layer_idx —
-    # allocate it with the SAME num_kvpe_cache_layers=num_layers as the KVPE cache. bf8 (half the memory,
-    # top-k within bf16 noise). Dense (non-sparse) variants get None (natural-path / dense MLA use no cache).
+    # [num_users*index_cache_layers, 1, T, D_idx], so the indexer addresses slot
+    # user*index_cache_layers + cache_layer_idx. Unlike the per-layer KVPE cache, the indexer stride is the
+    # COMPACTED full-indexer count (num_full_indexer_layers) for GLM-5.2 cross-layer reuse — "shared" layers
+    # reuse a "full" layer's cache and get no slot of their own — falling back to num_layers when there is no
+    # indexer_types map. bf8 (half the memory, top-k within bf16 noise). Dense variants get None.
     tt_index_kv_cache = None
     if has_indexer:
         # A sparse config must carry index_head_dim; assert rather than silently defaulting so a
         # misconfigured (missing-field) sparse setup fails loudly with a clear message.
         assert getattr(config, "index_head_dim", None) is not None, "sparse config must provide index_head_dim"
+        index_cache_layers = num_full_indexer_layers(config) or num_layers
         tt_index_kv_cache = init_kvpe_cache(
             kvpe_cache_head_dim=config.index_head_dim,
             mesh_device=mesh_device,
             seq_len=SEQ_CACHE,
             mesh_shape=mesh_shape,
             sp_axis=sp_axis,
-            num_kvpe_cache_layers=num_layers,
+            num_kvpe_cache_layers=index_cache_layers,
             num_users=1,
             dtype=ttnn.bfloat8_b,
         )

--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -20,7 +20,7 @@ from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3_d_p.tt.mla.mla_config import get_indexer_key_chunk
-from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup, interleaved_perm_matrix
+from models.demos.deepseek_v3_d_p.tt.mla.rope import interleaved_perm_matrix
 
 # DSA indexer weight names are owned by TtIndexer.WEIGHT_NAMES (single source of truth). A
 # module-level INDEXER_WEIGHT_NAMES alias is defined at the bottom of this file for back-compat.
@@ -106,8 +106,12 @@ class TtIndexer:
         Returns the device-tensor dict keyed by short name (wq_b/wk/weights_proj/k_norm/k_norm_bias),
         or None when device is None. Cache filenames stay byte-compatible with the previously
         opportunistic `layer_{i}.mla.indexer_*` files (same dtype/layout/mapper)."""
-        index_n_heads = getattr(config, "index_n_heads", 64)
-        index_head_dim = getattr(config, "index_head_dim", 128)
+        # A sparse config must carry the indexer geometry; assert loudly rather than silently defaulting
+        # to garbage shapes.
+        _missing = [f for f in ("index_n_heads", "index_head_dim") if not hasattr(config, f)]
+        assert not _missing, f"indexer weight conversion requires config field(s) {_missing}"
+        index_n_heads = config.index_n_heads
+        index_head_dim = config.index_head_dim
         q_lora_rank = config.q_lora_rank
         hidden_size = config.hidden_size
 
@@ -203,11 +207,11 @@ class TtIndexer:
         seq_len: int = 1024,
         slot_num: int = 1,
         layer_num: int = 1,
-        is_chunked: bool = False,
     ):
-        """Architecture constants are read from the HF config (DS defaults below; GLM sets
-        index_rope_interleave / index_n_heads etc.). θ / YaRN / rope table length come from the
-        same config — single source of truth. Device index-key cache is grown by concat per chunk.
+        """Architecture constants are read from the HF config with no defaults (index_n_heads,
+        index_head_dim, index_topk, index_rope_interleave — a sparse config that omits any of them
+        fails loudly). θ / YaRN / rope table length come from the same config — single source of
+        truth. Device index-key cache is grown by concat per chunk.
 
         Injected from ttMLA (the indexer keeps no back-reference): the SP×TP mesh + axes,
         compute-kernel configs, weight-cache location, and the CCL handles used by the inlined
@@ -235,28 +239,34 @@ class TtIndexer:
         self.tt_ccl = tt_ccl
         self.ccl_num_links = ccl_num_links
         self.ccl_topology = ccl_topology
+        # Indexer geometry comes from the config with no defaults: a sparse config that omits any of these
+        # fields fails loudly here rather than silently binding a wrong-shaped indexer.
+        _required = ("index_n_heads", "index_head_dim", "index_topk", "index_rope_interleave")
+        _missing = [f for f in _required if not hasattr(config, f)]
+        assert not _missing, f"sparse MLA config is missing indexer field(s) {_missing}; must define all of {_required}"
         self.index_args = SimpleNamespace(
-            index_n_heads=getattr(config, "index_n_heads", 64),
-            index_head_dim=getattr(config, "index_head_dim", 128),
-            index_topk=getattr(config, "index_topk", 2048),
-            index_rope_interleave=getattr(config, "index_rope_interleave", False),
+            index_n_heads=config.index_n_heads,
+            index_head_dim=config.index_head_dim,
+            index_topk=config.index_topk,
+            index_rope_interleave=config.index_rope_interleave,
         )
         self.seq_len = seq_len
-        self.is_chunked = is_chunked
-        # Block-cyclic key-cache path (chunked prefill): mirrors the MLA KVPE cache — a persistent,
-        # per-user, block-cyclic ND-sharded key cache written by update_padded_kv_cache and scored by
-        # indexer_score_dsa's block-cyclic reader. Both variants use it; the rope is always the interleaved
-        # on-device INDEXED op (rotary_embedding_indexed). GLM is natively interleaved; DS-v3.2's half-split
-        # rope is reconciled by _rope_perm below (permute q/k rope halves so the interleaved op matches the
-        # DS reference). Single-shot (all variants) stays on the natural gather+concat path.
-        self._blockcyclic = is_chunked
-        # Block-cyclic key cache (persistent [num_users,1,S/sp,D_idx]) is NOT owned here: exactly like the
-        # MLA KVPE cache, the caller allocates it and passes it into forward(index_kv_cache=...) every call;
-        # the indexer never self-allocates it. write_k typecasts the roped key to the cache's dtype before
-        # the in-place write, so the caller controls the dtype (BF8 is validated — rotated + accuracy suites
-        # match BF16 within bf16 noise, ~5e-4 PCC — so it can be allocated BF8 to halve the memory).
-        # self._index_kbuf below is the NATURAL (single-shot) path's internal concat-grown cache only.
-        self._index_kbuf = None
+        # Block-cyclic key-cache path: mirrors the MLA KVPE cache — a persistent, per-user/layer,
+        # block-cyclic ND-sharded key cache written by update_padded_kv_cache and scored by
+        # indexer_score_dsa's block-cyclic reader. The rope is always the interleaved on-device INDEXED op
+        # (rotary_embedding_indexed). GLM is natively interleaved; DS-v3.2's half-split rope is reconciled
+        # by _rope_perm below (permute q/k rope halves so the interleaved op matches the DS reference).
+        # ALWAYS block-cyclic: single-shot is folded onto this path as one full-seq chunk at start_pos=0
+        # (numerically identical to natural order — the block-cyclic reorder degenerates to a contiguous
+        # per-chip SP shard), so the key cache persists layer-stacked and migrates to decode. The MLA that
+        # owns this indexer feeds it the indexed rope tables and a caller-allocated index_kv_cache in both
+        # modes.
+        # Block-cyclic key cache (persistent [num_users*_index_cache_layers,1,S/sp,D_idx]) is NOT owned
+        # here: exactly like the MLA KVPE cache, the caller allocates it and passes it into
+        # forward(index_kv_cache=...) every call; the indexer never self-allocates it. write_k typecasts the
+        # roped key to the cache's dtype before the in-place write, so the caller controls the dtype (BF8
+        # validated — rotated + chunked suites match BF16 within bf16 noise, ~5e-4 PCC — so it can be
+        # allocated BF8 to halve mem).
         # GLM-5.2 cross-layer indexer reuse: the index key cache is allocated for full layers only, so this
         # layer writes/reads its compacted rank among full layers, and the folded (user-major) slot stride
         # is num_full, not all layers. _index_cache_layers is that stride.
@@ -265,7 +275,6 @@ class TtIndexer:
         self._index_layer_idx = full_indexer_rank(config, layer_idx) if self._is_index_compact else layer_idx
         self._index_cache_layers = self._num_index_layers if self._is_index_compact else self.layer_num
         self._upload_weights(idx_host)
-        self._build_rope_tables()
         # DS block-cyclic uses the interleaved rotary_embedding_indexed op, but DS weights emit the
         # half-split (rotate_half) rope arrangement. Permute the rope half (half-split -> interleaved) so
         # the interleaved op pairs the right dims with each frequency; applied to BOTH q and k, the
@@ -273,7 +282,7 @@ class TtIndexer:
         # is natively interleaved -> no permute. NOTE: the stored key is then in interleaved layout —
         # reindex by rope.interleaved_to_halfsplit_perm to compare it against a half-split reference.
         self._rope_perm = None
-        if self._blockcyclic and not self.index_args.index_rope_interleave:
+        if not self.index_args.index_rope_interleave:
             # rope.interleaved_perm_matrix owns the half-split -> interleaved convention (single source).
             self._rope_perm = ttnn.from_torch(
                 interleaved_perm_matrix(64).to(torch.bfloat16),
@@ -345,18 +354,6 @@ class TtIndexer:
             cluster_axis=self.tp_axis,
         )
 
-    def _build_rope_tables(self):
-        """Precompute the indexer's natural-path RoPE tables via RotarySetup.get_indexer_rope_tables
-        (single source of rope-convention logic). ``index_rope_interleave`` picks the layout + matching
-        device op in ``_device_rope_pe``: DS (False) -> rotate_half, no trans_mat -> rotary_embedding_hf;
-        GLM (True) -> interleaved + trans_mat -> rotary_embedding_llama (matches the MLA's own rope).
-        Full-length replicated pure rotations (no mscale); ``_device_rope_pe`` slices per chunk. (The
-        block-cyclic path instead reuses ttMLA's block-cyclic rope_tensors passed into forward.)"""
-        tables = RotarySetup(self.config, self.mesh_device, sp_axis=self.sp_axis).get_indexer_rope_tables(
-            interleave=self.index_args.index_rope_interleave
-        )
-        self._idx_cos, self._idx_sin, self._idx_trans = tables["cos"], tables["sin"], tables["trans"]
-
     def _upload_weights(self, idx_host):
         """Indexer weights → device via the shared converter. `idx_host` may be a full host dict
         (from-weights) or falsy (cache-only: the converter builds placeholders and reads the
@@ -377,28 +374,6 @@ class TtIndexer:
         self._idx_wproj = w["weights_proj"]
         self._idx_knorm_w = w["k_norm"]
         self._idx_knorm_b = w["k_norm_bias"]
-
-    def _device_rope_pe(self, x: ttnn.Tensor, glob: int, start_pos: int, sp_shard: bool = False) -> ttnn.Tensor:
-        """On-device RoPE on the rope half (first 64) of the last dim.
-        x [1, n_heads, S, D_idx]; cos/sin sliced to this chunk's global positions [start_pos,
-        start_pos+glob). With sp_shard the cos/sin are mesh-partitioned across SP so each chip
-        ropes its own contiguous query block (positions start_pos + sp_rank*S_local) — used for the
-        SP-sharded indexer queries (the K cache stays full/gathered, so it ropes unsharded)."""
-        h, n = x.shape[1], x.shape[2]
-        pe = ttnn.slice(x, [0, 0, 0, 0], [1, h, n, 64])
-        nope = ttnn.slice(x, [0, 0, 0, 64], [1, h, n, self.index_args.index_head_dim])
-        cos = ttnn.slice(self._idx_cos, [0, 0, start_pos, 0], [1, 1, start_pos + glob, 64])
-        sin = ttnn.slice(self._idx_sin, [0, 0, start_pos, 0], [1, 1, start_pos + glob, 64])
-        if sp_shard and self.sp_factor > 1:  # each SP chip keeps its block's cos/sin (natural-order shard)
-            cos = ttnn.mesh_partition(cos, dim=2, cluster_axis=self.sp_axis)
-            sin = ttnn.mesh_partition(sin, dim=2, cluster_axis=self.sp_axis)
-        if self._idx_trans is not None:  # GLM: interleaved RoPE (Meta-style + trans_mat)
-            pe = ttnn.experimental.rotary_embedding_llama(pe, cos, sin, self._idx_trans, is_decode_mode=False)
-        else:  # DS: non-interleaved (rotate_half)
-            pe = ttnn.experimental.rotary_embedding_hf(
-                pe, cos, sin, is_decode_mode=False, compute_kernel_config=self.hifi4_fp32_compute_kernel_config
-            )
-        return ttnn.concat([pe, nope], dim=-1)
 
     def _bc_rope_pe(self, x: ttnn.Tensor, rope_tensors: dict, kv_actual_global: int) -> ttnn.Tensor:
         """Block-cyclic INDEXED RoPE on the rope half (first 64) of the last dim (block-cyclic path only).
@@ -468,11 +443,10 @@ class TtIndexer:
         """Device K stem (wk + TP all-reduce + k_norm + device rope) written into the device index-key
         cache. forward() calls this on every chunk so the key-cache stays complete — else later chunks
         score against missing keys for the early prefix. (Dense v3.1 binds a NullIndexer, so write_k never
-        runs there.) Two paths, fixed by self._blockcyclic:
-          - block-cyclic (GLM/DS chunked): rope the PER-CHIP shard at its block-cyclic positions, then write
-            it in place via update_padded_kv_cache (per-user slot, pad-aware kv_actual_global offset) — no
-            SP all-gather, no O(n^2) concat; the cache stays SP-sharded.
-          - natural (single-shot, all variants): SP all-gather to full-glob + natural rope + concat-grow."""
+        runs there.) Always block-cyclic (single-shot is folded onto it as one full-seq chunk at
+        start_pos=0): rope the PER-CHIP shard at its block-cyclic positions, then write it in place via
+        update_padded_kv_cache (per-(user,layer) slot, pad-aware kv_actual_global offset) — no SP
+        all-gather, no O(n^2) concat; the cache stays SP-sharded."""
         k = ttnn.linear(
             hidden_states,
             self._idx_wk,
@@ -489,52 +463,24 @@ class TtIndexer:
             compute_kernel_config=self.default_compute_kernel_config,
         )
 
-        if self._blockcyclic:
-            # Rope the per-chip shard at its block-cyclic positions (kv_actual_global=start_pos), then
-            # write it into this user's slot. update_padded_kv_cache places each chip's rows at the
-            # block-cyclic offset (pad-aware) — the same math the query/key rope above uses.
-            k = self._bc_rope_pe(k, rope_tensors, start_pos)  # [1, 1, S/sp, D_idx] bf16
-            if k.dtype != index_kbuf.dtype:  # write dtype must match the cache (update_padded_kv_cache asserts)
-                k = ttnn.typecast(k, index_kbuf.dtype)
-            ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
-                index_kbuf,
-                k,
-                slot_idx=cache_user_id,
-                layer_idx=cache_layer_idx,
-                num_layers=self._index_cache_layers,
-                kv_actual_global=start_pos,
-                cluster_axis=self.sp_axis,
-            )
-            ttnn.deallocate(k)
-            return
-
-        # Natural path (single-shot, all variants): SP all-gather to a full/replicated cache. write_k runs
-        # once here (start_pos==0), so the concat-grow below is dead for current configs -- it only fired in
-        # the retired non-block-cyclic chunked mode. The live cost is the all-gather + full replication
-        # (glob keys/chip vs glob/sp block-cyclic).
-        #
-        # TODO(refactor, drop natural path): fold single-shot onto the block-cyclic
-        # path (treat it as one full-seq chunk at start_pos=0): SP-sharded cache + in-place
-        # update_padded_kv_cache, no all-gather / no replication / no concat -- then delete this branch,
-        # _device_rope_pe's natural use, and _sp_all_gather. Dependency: single-shot must supply the
-        # block-cyclic INDEXED rope tables (mla.py builds natural-order tables via _apply_rope_one_shot in
-        # single-shot; _bc_rope_pe needs get_rope_tensors_indexed). Verify block-cyclic alignment holds for
-        # single-shot seq lengths and that test_sparse_mla_vs_trace.py (is_chunked=False) passes unified.
-        glob = seq_len * self.sp_factor
-        k = self._sp_all_gather(k, dim=2)  # [1, 1, glob, D_idx] full, replicated, natural order
-        k = self._device_rope_pe(k, glob, start_pos)  # on-device rope
-        # The rest of this MLA code manually deallocates intermediate device tensors, so free the device
-        # buffers we drop here too rather than relying on Python ref-loss (which would accumulate device
-        # allocations over a long chunked prefill or across repeated requests).
-        if start_pos == 0 or self._index_kbuf is None:
-            if self._index_kbuf is not None:  # start_pos==0 reset: drop the prior request's full cache
-                ttnn.deallocate(self._index_kbuf)
-            self._index_kbuf = k
-        else:
-            old = self._index_kbuf
-            self._index_kbuf = ttnn.concat([old, k], dim=2)  # concat copies into a fresh buffer...
-            ttnn.deallocate(old)  # ...so the old cache and this chunk's keys are both free to drop
-            ttnn.deallocate(k)
+        # Rope the per-chip shard at its block-cyclic positions (kv_actual_global=start_pos), then write it
+        # into this (user, layer) slot. update_padded_kv_cache places each chip's rows at the block-cyclic
+        # offset (pad-aware) — the same math the query/key rope above uses. Single-shot is folded onto this
+        # path as one full-seq chunk at start_pos=0, so the indexer is always block-cyclic. num_layers is the
+        # compacted stride (_index_cache_layers) so it matches the cache_batch_idx computed in forward().
+        k = self._bc_rope_pe(k, rope_tensors, start_pos)  # [1, 1, S/sp, D_idx] bf16
+        if k.dtype != index_kbuf.dtype:  # write dtype must match the cache (update_padded_kv_cache asserts)
+            k = ttnn.typecast(k, index_kbuf.dtype)
+        ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
+            index_kbuf,
+            k,
+            slot_idx=cache_user_id,
+            layer_idx=cache_layer_idx,
+            num_layers=self._index_cache_layers,
+            kv_actual_global=start_pos,
+            cluster_axis=self.sp_axis,
+        )
+        ttnn.deallocate(k)
 
     def forward(
         self,
@@ -551,9 +497,10 @@ class TtIndexer:
         on the query axis (each chip scores its own S/sp rows; no Q/W all-gather). Fully on-device:
         stems, RoPE, cache, logits, topk — no host.
 
-        ``index_kv_cache`` (block-cyclic path): the persistent per-user key cache, allocated by the caller and
-        passed in every call — the same ownership as ttMLA's KVPE ``kvpe_cache``. Required for the block-cyclic
-        path (the indexer never self-allocates it); ignored by the natural (single-shot) path.
+        ``index_kv_cache``: the persistent per-user key cache, allocated by the caller and passed in every
+        call — the same ownership as ttMLA's KVPE ``kvpe_cache``. ALWAYS required (the indexer never
+        self-allocates it): the indexer is always block-cyclic, and single-shot is folded onto that path as
+        one full-seq chunk at offset 0, so there is no natural path that skips the cache.
 
         ``qr`` is the shared q_a latent (q_a_proj + TP all-reduce + q_a_layernorm) — ttMLA computes it once
         and passes it in; the indexer applies wq_b to it (no q_a stem of its own). ``qr`` is NOT deallocated
@@ -561,21 +508,23 @@ class TtIndexer:
         (write_k) and the per-head weights (weights_proj). (write_k is called internally here; ttMLA.forward
         only ever calls self._indexer.forward — it never calls write_k directly.)
 
-        Block-cyclic path (GLM/DS chunked): ``rope_tensors`` (the MLA's block-cyclic indexed cos/sin/trans)
-        and ``cache_user_id`` (per-user slot) drive the per-user block-cyclic key cache + block-cyclic
-        scoring. Scoring currently spans the full preallocated cache width (see the kv_len TODO below).
-        Natural path ignores rope_tensors/cache_user_id."""
+        ``rope_tensors`` (the MLA's block-cyclic indexed cos/sin/trans) and ``cache_user_id`` (per-user slot)
+        drive the per-user block-cyclic key cache + block-cyclic scoring. Scoring currently spans the full
+        preallocated cache width (see the kv_len TODO below)."""
         a = self.index_args
         if self._is_index_compact:
             cache_layer_idx = self._index_layer_idx
         glob = seq_len * self.sp_factor  # global query/key count this chunk
         end_pos = start_pos + glob
         # Block-cyclic key cache is caller-owned (like the KVPE cache) — required, never self-allocated.
-        if self._blockcyclic:
-            assert index_kv_cache is not None, (
-                "block-cyclic indexer requires an externally-allocated index_kv_cache passed to forward() "
-                "(same ownership as the MLA KVPE cache); none was provided"
-            )
+        assert index_kv_cache is not None, (
+            "block-cyclic indexer requires an externally-allocated index_kv_cache passed to forward() "
+            "(same ownership as the MLA KVPE cache); none was provided"
+        )
+        # Flat user-major slot into the shared [num_users*_index_cache_layers, 1, T, D_idx] cache — same
+        # formula as ttMLA._cache_batch_idx for the KVPE cache (cache_layer_idx is the LOCAL per-rank cache
+        # slot, compacted to the full-layer rank above for GLM-5.2 cross-layer reuse). Written by write_k
+        # and sliced by _gather_index_kbuf.
         cache_batch_idx = cache_user_id * self._index_cache_layers + cache_layer_idx
         self.write_k(
             hidden_states,
@@ -597,10 +546,8 @@ class TtIndexer:
         q, _, _ = ttnn.experimental.nlp_create_qkv_heads(
             q, num_heads=a.index_n_heads, num_kv_heads=0, transpose_k_heads=False, memory_config=ttnn.DRAM_MEMORY_CONFIG
         )  # [1, H_idx, S/sp, D_idx] — all heads resident
-        if self._blockcyclic:  # block-cyclic indexed rope (same op/tables as the key rope + MLA q_pe)
-            q_dev = self._bc_rope_pe(q, rope_tensors, start_pos)
-        else:
-            q_dev = self._device_rope_pe(q, glob, start_pos, sp_shard=True)  # per-chip natural query positions
+        # block-cyclic indexed rope (same op/tables as the key rope + MLA q_pe)
+        q_dev = self._bc_rope_pe(q, rope_tensors, start_pos)
 
         # weights_proj: device stem -> FULL all-reduce over tp (all H_idx heads, matching the replicated
         # wq_b heads) -> scale -> [1, 1, S/sp, H_idx].
@@ -626,7 +573,7 @@ class TtIndexer:
         # seq_subshard_axis below, so its EXACT block-cyclic geometry adds each device's tp_rank*Sq' sub-offset
         # (rotation-safe). topk runs on the sub-rows; indices are all-gathered back over TP to the [1,1,S/sp,k]
         # contract so mla.py / sparse_sdpa are unchanged (both DeepSeek and GLM ride this one path).
-        tpsp = self._blockcyclic and self.tp_factor > 1
+        tpsp = self.tp_factor > 1
         if tpsp:
             q_full, weights_full = (
                 q_dev,
@@ -650,46 +597,36 @@ class TtIndexer:
         # cache, with a per-device causal offset from cluster_axis=sp_axis (chip r: chunk_start = start_pos
         # + r*Sq, Sq=S/sp=seq_len). All H_idx heads on-chip -> the logit is COMPLETE (no partial-logit
         # all-reduce). topk stays SP-sharded ([1,1,S/sp,k]) -> fed straight to sparse_mla.
-        if self._blockcyclic:
-            # _gather_index_kbuf slices this (user, layer) slot then gathers it to replicated full-T; the op
-            # reads it back in logical order via invP (batch-1, so cache_batch_idx=None) and applies the
-            # straddle for a non-slab-aligned start_pos (padded chunk). Scores the FULL preallocated width T:
-            # positions past each query are causally -inf, and top-k below drops those (-inf -> sentinel).
-            #
-            # Bound the score to the real written prefix (kv_len=end_pos) rather than the full preallocated
-            # width T: end_pos = start_pos + chunk_global is the tightest legal value (the pad query rows
-            # push the fullest-device causal window to end_pos; the op TT_FATALs on kv_len < that). kv_len
-            # only WRITES logits[:, :, :, :end_pos] and leaves the tail [end_pos, T) STALE (not -inf); the
-            # top-k below is told the valid length (valid_length=end_pos) so it never reads or ranks that
-            # stale tail — which is the future top-k would drop anyway (causally -inf), so the selection is
-            # unchanged.
-            k_full = self._gather_index_kbuf(index_kv_cache, cache_batch_idx)  # [1,1,T,D_idx] bf16 TILE, block-cyclic
-            logits = ttnn.experimental.indexer_score_dsa(
-                q_dev,
-                k_full,
-                weights,
-                chunk_start_idx=start_pos,
-                program_config=cfg,
-                cluster_axis=self.sp_axis,
-                # TP×SP: name the TP axis the query was sub-sharded over so the score adds each device's
-                # tp_rank*Sq' block-cyclic sub-offset — rotation-EXACT (vs the flat cluster_axis=None path,
-                # which is linear-approximate under a mid-slab start). None when the query stays SP-only.
-                seq_subshard_axis=self.tp_axis if tpsp else None,
-                cache_batch_idx=None,  # k_full is already sliced to this slot (batch-1) → no in-kernel select
-                block_cyclic_sp_axis=self.sp_axis,
-                block_cyclic_chunk_local=seq_len,  # cache slab == chunk_size_global / sp (== Sq'·tp when TP-split)
-                kv_len=end_pos,
-            )
-            ttnn.deallocate(k_full)
-        else:
-            logits = ttnn.experimental.indexer_score_dsa(
-                q_dev,
-                self._index_kbuf,
-                weights,
-                chunk_start_idx=start_pos,
-                program_config=cfg,
-                cluster_axis=self.sp_axis,
-            )
+        # _gather_index_kbuf slices this (user, layer) slot then gathers it to replicated full-T; the op
+        # reads it back in logical order via invP (batch-1, so cache_batch_idx=None) and applies the
+        # straddle for a non-slab-aligned start_pos (padded chunk). Scores the FULL preallocated width T:
+        # positions past each query are causally -inf, and top-k below drops those (-inf -> sentinel).
+        #
+        # Bound the score to the real written prefix (kv_len=end_pos) rather than the full preallocated
+        # width T: end_pos = start_pos + chunk_global is the tightest legal value (the pad query rows
+        # push the fullest-device causal window to end_pos; the op TT_FATALs on kv_len < that). kv_len
+        # only WRITES logits[:, :, :, :end_pos] and leaves the tail [end_pos, T) STALE (not -inf); the
+        # top-k below is told the valid length (valid_length=end_pos) so it never reads or ranks that
+        # stale tail — which is the future top-k would drop anyway (causally -inf), so the selection is
+        # unchanged.
+        k_full = self._gather_index_kbuf(index_kv_cache, cache_batch_idx)  # [1,1,T,D_idx] bf16 TILE, block-cyclic
+        logits = ttnn.experimental.indexer_score_dsa(
+            q_dev,
+            k_full,
+            weights,
+            chunk_start_idx=start_pos,
+            program_config=cfg,
+            cluster_axis=self.sp_axis,
+            # TP×SP: name the TP axis the query was sub-sharded over so the score adds each device's
+            # tp_rank*Sq' block-cyclic sub-offset — rotation-EXACT (vs the flat cluster_axis=None path,
+            # which is linear-approximate under a mid-slab start). None when the query stays SP-only.
+            seq_subshard_axis=self.tp_axis if tpsp else None,
+            cache_batch_idx=None,  # k_full is already sliced to this slot (batch-1) → no in-kernel select
+            block_cyclic_sp_axis=self.sp_axis,
+            block_cyclic_chunk_local=seq_len,  # cache slab == chunk_size_global / sp (== Sq'·tp when TP-split)
+            kv_len=end_pos,
+        )
+        ttnn.deallocate(k_full)
         # wq_b replicated -> each chip already holds the COMPLETE head-summed logit, so there is NO
         # partial-logit all-reduce over tp. This is the win: the removed step was a 2-CCL (RS+AG) all-reduce
         # spanning the full end_pos-wide logit (+ a TILE<->ROW_MAJOR round-trip), the indexer's dominant cost.
@@ -700,8 +637,7 @@ class TtIndexer:
         assert end_pos % 16 == 0, f"indexer top-k requires a tile-aligned key count; got end_pos={end_pos}"
         # Block-cyclic logits are the full preallocated width T with a stale [end_pos, T) tail (kv_len only
         # wrote the real prefix); valid_length bounds top-k to that prefix so the tail is never read or ranked.
-        # The natural path's cache is exact-sized (no tail), so it needs no bound.
-        topk_valid_length = end_pos if self._blockcyclic else None
+        topk_valid_length = end_pos
         idx = ttnn.experimental.topk_large_indices(
             logits, k=min(self.index_args.index_topk, end_pos), valid_length=topk_valid_length
         )

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -280,9 +280,22 @@ class ttMLA:
         self.slot_num = slot_num
         self.layer_num = layer_num
 
-        # The RoPE op is fixed by the configured mode: chunked prefill uses the indexed op,
-        # single-shot uses rotary_embedding_llama. Bind once here so forward doesn't re-decide.
-        self._apply_rope = self._apply_rope_padded if is_chunked else self._apply_rope_one_shot
+        # DSA indexer (v3.2 / GLM): resolve sparse mode EXPLICITLY — config DSA fields, then live host
+        # weights, then a complete indexer cache — never from bool(idx_host), which silently went dense
+        # for cache-only construction. Resolved here (before buffer alloc + rope/attention binding) so all
+        # three can key off it. Inert for dense v3.1.
+        self._has_indexer = resolve_has_indexer(
+            config,
+            state_dict=state_dict,
+            explicit=has_indexer,
+            weight_cache_path=self.weight_cache_path,
+            cache_name_prefix=f"layer_{layer_idx}.mla",
+        )
+
+        # The RoPE op is fixed by the configured mode. It is bound AFTER self._has_indexer is resolved
+        # (below), because sparse always runs the block-cyclic path (single-shot is one full-seq chunk at
+        # offset 0) and so needs the indexed op even when not chunked. Dense keeps: chunked -> indexed,
+        # single-shot -> rotary_embedding_llama.
 
         self.sp_axis = sp_axis
         self.tp_axis = tp_axis
@@ -353,8 +366,10 @@ class ttMLA:
         # every layer's MLA (uniform across layers, scratch / no per-layer state) instead of
         # re-allocated per layer.
         #
-        # kv_only (last layer) never reaches SDPA, so it needs no ring/gather buffers at all.
-        if kv_only:
+        # kv_only (last layer) never reaches SDPA, so it needs no ring/gather buffers. Sparse (DSA) uses
+        # sparse_sdpa + the transient _gather_kvpe_prefix gather — neither the ring_mla chunked scratch nor
+        # the ring-joint-SDPA buffers — so it allocates none of these regardless of is_chunked.
+        if kv_only or self._has_indexer:
             pass
         elif self.is_chunked:
             # Single combined gathered-KV scratch buffer for ring_mla: K and V both come from the
@@ -412,21 +427,13 @@ class ttMLA:
             self.o_proj_weight = weights["o_proj"]
         logger.info(f"Loaded {len(weights)} weights in MLA layer {layer_idx} (kv_only={kv_only})")
 
-        # DSA indexer (v3.2 / GLM): resolve sparse mode EXPLICITLY — config DSA fields, then live host
-        # weights, then a complete indexer cache — never from bool(idx_host), which silently went dense
-        # for cache-only construction. The TtIndexer owns the indexer stems / RoPE tables / device
-        # key-cache and reuses this MLA's q_a stem + collectives. Inert for dense v3.1.
-        self._has_indexer = resolve_has_indexer(
-            config,
-            state_dict=state_dict,
-            explicit=has_indexer,
-            weight_cache_path=self.weight_cache_path,
-            cache_name_prefix=f"layer_{layer_idx}.mla",
-        )
-        # DSA *family* (config carries the indexer fields), independent of whether the indexer is
-        # active this layer. V3.1's dense config lacks them; V3.2's config has them even when a
-        # benchmark forces the attention dense (has_indexer=False). Dense-path tuning gates that must
-        # tell V3.1 from a dense-run V3.2 key on this, not _has_indexer (see _get_sdpa_program_config).
+        # DSA indexer (v3.2 / GLM): self._has_indexer was resolved above (before the buffer alloc). The
+        # TtIndexer owns the indexer stems / RoPE tables / device key-cache and reuses this MLA's q_a stem
+        # + collectives. Inert for dense v3.1.
+        # DSA *family* (config carries the indexer fields), independent of whether the indexer is active
+        # this layer. V3.1's dense config lacks them; V3.2's config has them even when a benchmark forces
+        # the attention dense (has_indexer=False). Dense-path tuning gates that must tell V3.1 from a
+        # dense-run V3.2 key on this, not _has_indexer (see _get_sdpa_program_config).
         self._is_dsa_family = TtIndexer.matches_config(config)
         # GLM-5.2 indexer reuse: a "shared" layer is sparse but owns no indexer weights — it reuses the
         # most recent "full" layer's top-k indices, injected at forward, and binds a weight-less
@@ -463,17 +470,24 @@ class ttMLA:
                     seq_len=seq_len,
                     slot_num=slot_num,
                     layer_num=self.layer_num,
-                    is_chunked=is_chunked,
                 )
         else:
             self._indexer = NullIndexer()  # dense v3.1: forward calls .forward() -> None (dense path)
             self._indexer_reuse = False
 
-        # Bind the attention core once, by config — sparsity (self._has_indexer) × chunking
-        # (self.is_chunked) — exactly as self._apply_rope is bound above. forward() then calls
-        # self._attention(...) with no mode ladder: the decision is made here, not per call.
+        # Bind the RoPE op now that self._has_indexer is known: sparse always uses the indexed
+        # (block-cyclic) op — single-shot is folded onto the block-cyclic path as one full-seq chunk at
+        # offset 0 — so its key cache persists layer-stacked (migratable to decode). Dense: chunked ->
+        # indexed, single-shot -> rotary_embedding_llama.
+        self._apply_rope = (
+            self._apply_rope_padded if (self.is_chunked or self._has_indexer) else self._apply_rope_one_shot
+        )
+
+        # Bind the attention core once, by config. Sparse ALWAYS uses the block-cyclic
+        # _sparse_chunked_attn (single-shot = one full-seq chunk); dense splits by chunking. forward()
+        # then calls self._attention(...) with no mode ladder: the decision is made here, not per call.
         if self._has_indexer:
-            self._attention = self._sparse_chunked_attn if self.is_chunked else self._sparse_single_attn
+            self._attention = self._sparse_chunked_attn
         else:
             self._attention = self._dense_chunked_attn if self.is_chunked else self._dense_single_attn
 
@@ -978,7 +992,8 @@ class ttMLA:
         helper). Blocked on the single-chip case: test_prefill_block_loop[mesh-1x1] runs dense single-shot
         on a (1,1) mesh, where fill_cache_for_user_ is mesh-agnostic but update_padded_kv_cache's SP
         cluster_axis / block-cyclic / tile-aligned-kv_actual_global path is not yet validated. Confirm
-        update_padded handles 1x1 (and sp=1), then switch _dense_single_attn like _sparse_single_attn."""
+        update_padded handles 1x1 (and sp=1), then switch _dense_single_attn onto it too (the sparse path
+        already folded its single-shot onto the block-cyclic update_padded write)."""
         ttnn.kv_cache.fill_cache_for_user_(kvpe_cache, tt_kvpe, cache_layer_idx)
 
     def _o_proj_epilogue(self, attn_out: ttnn.Tensor, seq_len_local: int) -> ttnn.Tensor:
@@ -1039,6 +1054,12 @@ class ttMLA:
         seq_len_local = hidden_states.shape[2]
         kv_actual_isl = actual_start
         is_chunked = self.is_chunked
+
+        # Sparse always runs the block-cyclic path (indexed rope + kvpe cache read-back), which treats
+        # single-shot as one full-seq chunk at offset 0. Coerce the None single-shot offset to 0 so the
+        # indexed rope op, the cache write, and the indexer all get a concrete kv_actual_global.
+        if self._has_indexer and kv_actual_isl is None:
+            kv_actual_isl = 0
 
         # Sparse attention (sparse_sdpa) reads the KVPE cache natively and only accepts bf16 / fp8_e4m3,
         # ROW_MAJOR. Require the cache to already be in that op-wanted format so the whole path is a single
@@ -1183,33 +1204,6 @@ class ttMLA:
             cache_user_id=cache_user_id,
             seq_len_local=seq_len_local,
         )
-
-    def _sparse_single_attn(
-        self, *, tt_q, tt_kvpe, indices, kvpe_cache, kv_actual_isl, cache_layer_idx, cache_user_id, seq_len_local, **_
-    ):
-        assert indices is not None, "sparse MLA forward requires indexer top-k indices"
-        # Single-shot: write the cache via the SAME op as chunked (update_padded_kv_cache), so the sparse
-        # cache is uniformly bf16/fp8 ROW_MAJOR and the TILE-only fill_cache_for_user_ is avoided. The whole
-        # sequence is one chunk (kv_actual_global=0). The live kvpe IS the whole sequence (natural order,
-        # contiguous SP shard), already in the op's format, so attend on it directly — no cache read-back.
-        ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
-            kvpe_cache,
-            tt_kvpe,
-            slot_idx=cache_user_id,
-            layer_idx=cache_layer_idx,
-            num_layers=self.layer_num,
-            kv_actual_global=kv_actual_isl or 0,
-            cluster_axis=self.sp_axis,
-        )
-        kvpe_dev = self._all_gather(tt_kvpe, dim=2, cluster_axis=self.sp_axis)  # [1,1,T,576] repl, natural
-
-        # Sparse attention runs over latent V; project to v_head_dim afterwards.
-        attn_out = self._sparse_mla(tt_q, kvpe_dev, indices)
-        if kvpe_dev is not tt_kvpe:  # all_gather made a new buffer (sp>1); else it IS tt_kvpe itself
-            ttnn.deallocate(kvpe_dev)
-        ttnn.deallocate(tt_kvpe)
-        ttnn.deallocate(tt_q)
-        return self._apply_wkv_b2(attn_out, seq_len_local)
 
     def _sparse_chunked_attn(
         self,

--- a/models/demos/deepseek_v3_d_p/tt/mla/rope.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/rope.py
@@ -259,24 +259,3 @@ class RotarySetup:
         )
 
         return {"cos_matrix": cos_matrix, "sin_matrix": sin_matrix, "trans_matrix": trans_matrix}
-
-    def get_indexer_rope_tables(self, interleave: bool) -> dict[str, ttnn.Tensor]:
-        """Full-length REPLICATED cos/sin (+ trans_matrix iff ``interleave``) for the DSA lightning
-        indexer's natural-path RoPE. Distinct from ``get_rope_tensors`` (SP-sharded, interleaved-only,
-        for the MLA q_pe/k_pe): the indexer keeps a replicated full/gathered key cache, chooses its
-        convention per config (GLM interleaved -> ``rotary_embedding_llama``; DeepSeek half-split ->
-        ``rotary_embedding_hf``), and slices the tables per chunk itself. Pure rotations (no mscale),
-        same theta/YaRN as the MLA. Returns ``{"cos", "sin", "trans"}`` with ``trans=None`` for the
-        half-split (DeepSeek) convention."""
-        cos, sin = get_cos_sin_matrix(self.hf_config, interleave=interleave)
-
-        def repl(t):
-            return ttnn.from_torch(
-                t.to(torch.bfloat16),
-                device=self.mesh_device,
-                layout=ttnn.TILE_LAYOUT,
-                dtype=ttnn.bfloat16,
-                mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
-            )
-
-        return {"cos": repl(cos), "sin": repl(sin), "trans": repl(get_rot_transformation_mat()) if interleave else None}

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
@@ -21,6 +21,7 @@ from transformers.configuration_utils import PretrainedConfig
 
 import ttnn
 from models.common.lightweightmodule import LightweightModule
+from models.demos.deepseek_v3_d_p.tt.mla.indexer import resolve_has_indexer
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
 from models.demos.deepseek_v3_d_p.tt.mla.utils import create_balanced_chunk_order, reverse_reorder_tensor_chunks
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
@@ -246,12 +247,18 @@ class TtPrefillTransformer(LightweightModule):
         # Chunked prefill uses the KV-pad-aware indexed rotated path: whole-cache cos/sin/trans built
         # once here and reused for every chunk (only the runtime kv_actual offset varies). seq_len is
         # the per-chunk size and max_seq_len the full per-user cache length.
+        #
+        # SPARSE (DSA) layers ALWAYS use the indexed rotated path — single-shot is folded onto the
+        # block-cyclic path as one full-seq chunk (chunk_size_global == seq_len), so build the indexed
+        # tables whenever the model is sparse too, not only when chunked. Dense single-shot keeps None
+        # (rotary_embedding_llama via get_rope_tensors).
+        self._has_indexer = resolve_has_indexer(config)
         self.indexed_rope = (
             self.rope_setup.get_rope_tensors_indexed(
                 cache_seq_len_global=max_seq_len if max_seq_len is not None else seq_len,
                 chunk_size_global=seq_len,
             )
-            if is_chunked
+            if (is_chunked or self._has_indexer)
             else None
         )
 
@@ -314,8 +321,11 @@ class TtPrefillTransformer(LightweightModule):
                 emb_dim/tp] hidden-state activation handed over from the previous rank.
             kvpe_cache: externally created KVPE cache [num_layers, 1, seq_len_local, head_dim];
                         each layer writes to its own slot via cache_layer_idx
-            index_kv_cache: sparse-DSA chunked only — per-layer list of block-cyclic indexer key caches
-                        (the indexer is single-layer, so layers can't share one tensor). None otherwise.
+            index_kv_cache: sparse-DSA (v3.2 / GLM) — the caller-owned, layer-stacked block-cyclic indexer
+                        key cache [num_users * num_layers, 1, T, D_idx] (SP-sharded on the seq axis), same
+                        ownership as kvpe_cache. Required for EVERY sparse forward — chunked AND single-shot
+                        (folded onto the block-cyclic path); the indexer never self-allocates it. None only
+                        for dense (non-sparse) variants.
             return_intermediates: if True, sync + snapshot to host after each stage
             read_profiler: if True, read TTNN profiler after each layer to avoid profiler buffer overflows
             temperature: Temperature for sampling. Can be a single float or list of floats.
@@ -344,6 +354,10 @@ class TtPrefillTransformer(LightweightModule):
         # is returned, but the chunked caller ignores it (the populated cache is the output).
         if actual_start is not None:
             assert self.is_chunked, "actual_start requires the transformer to be built with is_chunked=True"
+            rope_tensors = self.indexed_rope
+        elif self._has_indexer:
+            # Sparse single-shot is folded onto the block-cyclic path (one full-seq chunk at offset 0),
+            # so it uses the indexed rope tables just like the chunked path.
             rope_tensors = self.indexed_rope
         else:
             rope_tensors = self.rope_setup.get_rope_tensors(self.seq_len)


### PR DESCRIPTION
## What

Sparse (DSA) single-shot MLA ran a **natural** indexer path (transient `self._index_kbuf`, SP all-gather + concat-grow) that never wrote the caller-owned indexer key cache, so the indexer keys could not migrate to decode. This folds single-shot onto the **block-cyclic** (chunked) path — treating it as one full-seq chunk at `start_pos=0`.

This is numerically identical to the old natural order: for a single full-seq chunk the block-cyclic reorder degenerates to a contiguous per-chip SP shard and `invP` is the identity. So the fold is a code-unification, not a numerics change — and it makes the indexer key cache persist layer-stacked, exactly like the KVPE cache, so it can migrate to decode.

## Changes

**Core**
- **indexer.py** — `self._blockcyclic = True` unconditionally (the indexer only exists for sparse). Delete the now-dead natural `write_k` branch, natural forward scoring branch, natural query-rope, the orphaned `_device_rope_pe` / `_build_rope_tables` helpers (and the rope tables they built), the transient `self._index_kbuf`, and the unused `RotarySetup` import. `_bc_rope_pe` / `_rope_perm` / `_sp_all_gather` stay.
- **mla.py** — resolve `_has_indexer` *before* the buffer alloc so the sparse path skips both the `ring_mla` chunked scratch and the ring-joint-SDPA buffers (sparse uses `sparse_sdpa` + the transient `_gather_kvpe_prefix` gather) — the sparse path is now fully `is_chunked`-agnostic for buffers. Bind `self._apply_rope = _apply_rope_padded` when sparse **or** chunked; bind sparse `self._attention = _sparse_chunked_attn` always; coerce the `None` single-shot offset to `kv_actual_isl=0`; delete `_sparse_single_attn`.
- **tt_prefill_transformer.py** — build + select `self.indexed_rope` when sparse (`resolve_has_indexer`), not only when chunked; single-shot sparse uses the indexed tables.
- **rope.py** — delete the now-orphaned `get_indexer_rope_tables` (only the deleted natural indexer path used it).

`is_chunked=False` is **not** retired — dense v3.1 single-shot still uses `_dense_single_attn` + `fill_cache_for_user_`. Only the sparse single-shot special-case is folded.

**Tests** — sparse single-shot callers now allocate a caller-owned, layer-stacked `index_kv_cache` + indexed rope, exactly like the chunked path: `test_mla` (`run_mla_inference`), `test_prefill_block` (`test_glm_prefill_block`), `test_prefill_transformer`, `test_sparse_mla_cache`, `test_sparse_mla_vs_trace` (and `test_prefill_transformer_chunked` for parity).
- The index cache is strided by the **compacted full-indexer count** (`num_full_indexer_layers(config)`, falling back to 1 / `num_layers` without an `indexer_types` map) — >1 under glm_5_2 cross-layer reuse — so it matches the indexer's `cache_batch` stride and satisfies `update_padded_kv_cache`'s `cache_batch % num_layers` check.
- Drop the silent `getattr(config, "index_head_dim", 128)` fallback in favor of `config.index_head_dim` (fail loudly).
- Unrelated: gate the trace PCC-plot render behind `TT_PREFILL_PCC_PLOTS=1` so trace-backed runs don't crash writing a PNG into a read-only golden mount.

## Validation

Device accuracy on an 8-chip Blackhole box (LoudBox-equivalent), mesh **2×4 (TP=4)**, seq 5120, `fabric2d`:

| variant | Output PCC | KVPE cache PCC (kv / pe) |
|---|---|---|
| `glm_5_1` | 0.9966235 | 0.999909 / 0.999915 |
| `deepseek_v32` | 0.996181 | 0.999902 / 0.999909 |
| `glm_5_2` | 0.9966356 | 0.999909 / 0.999916 |

All Output PCCs are bit-identical to the pre-fold baselines, confirming the fold is numerically inert. `deepseek_v32` exercises the `_rope_perm` (half-split→interleaved) path; `glm_5_2` exercises the GLM-5.2 cross-layer indexer-reuse path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/sparse-singleshot-blockcyclic-fold)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/sparse-singleshot-blockcyclic-fold)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/sparse-singleshot-blockcyclic-fold)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/sparse-singleshot-blockcyclic-fold)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ipotkonjak/sparse-singleshot-blockcyclic-fold)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ipotkonjak/sparse-singleshot-blockcyclic-fold)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/sparse-singleshot-blockcyclic-fold)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/sparse-singleshot-blockcyclic-fold)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/sparse-singleshot-blockcyclic-fold)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/sparse-singleshot-blockcyclic-fold)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/sparse-singleshot-blockcyclic-fold)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/sparse-singleshot-blockcyclic-fold)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/sparse-singleshot-blockcyclic-fold)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/sparse-singleshot-blockcyclic-fold)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/sparse-singleshot-blockcyclic-fold)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/sparse-singleshot-blockcyclic-fold)
