### PR TITLE
Enable true INT32 for relu_min/relu_max/relu6

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -763,6 +763,35 @@ def test_relu_min_int32_full_range(device, input_shapes, value_ranges, lower_lim
     assert torch.equal(output_tensor, torch_output_tensor)
 
 
+@pytest.mark.parametrize(
+    "op, limit, values",
+    [
+        (ttnn.relu_max, 2**24 + 1, [2**24, 2**24 + 1, 2**24 + 2, 2**26, -5]),
+        (ttnn.relu_max, 2**31 - 1, [2**31 - 3, 2**31 - 2, 2**31 - 1, 0, -5]),
+        (ttnn.relu_min, 2**24 + 1, [2**24, 2**24 + 1, 2**24 + 2, -100, 2**26]),
+        (ttnn.relu_min, 2**31 - 1, [2**31 - 3, 2**31 - 2, 2**31 - 1, -(2**31), 0]),
+    ],
+)
+def test_relu_min_max_int32_edge_cases(device, op, limit, values):
+    n = 32 * 32
+    filled = (values * (n // len(values) + 1))[:n]
+    torch_input_tensor = torch.tensor(filled, dtype=torch.int32).reshape(1, 1, 32, 32)
+
+    golden_function = ttnn.get_golden_function(op)
+    torch_output_tensor = golden_function(torch_input_tensor.to(torch.int64), limit).to(torch.int32)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    output_tensor = ttnn.to_torch(op(input_tensor, limit), dtype=torch.int32)
+
+    assert torch.equal(output_tensor, torch_output_tensor)
+
+
 @pytest.mark.parametrize("input_shapes", [torch.Size([1, 2, 32, 128])])
 @pytest.mark.parametrize("value_ranges", [INT32_BANDED_RANGES])
 def test_relu6_int32_full_range(device, input_shapes, value_ranges):

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -255,7 +255,7 @@ def create_banded_range_tensor(input_shape, value_ranges, dtype=torch.uint32):
     return torch.cat(segments).to(dtype).reshape(input_shape)
 
 
-# Shared banded coverage of the full uint32 range, used by the relu-family full-range tests.
+# Shared banded coverage of the full uint32 range, used by the relu-family tests.
 UINT32_BANDED_RANGES = [
     (0, 300),
     (300, 1000),
@@ -267,6 +267,21 @@ UINT32_BANDED_RANGES = [
     (1e8, 1e9),
     (1e9, 2147483647),
     (2147483648, 4294967295),
+]
+
+
+# Shared banded coverage of the full int32 range, used by the relu-family tests.
+INT32_BANDED_RANGES = [
+    (-2147483648, -1e9),
+    (-1e9, -1e7),
+    (-1e7, -1e5),
+    (-1e5, -300),
+    (-300, 0),
+    (0, 300),
+    (300, 1e5),
+    (1e5, 1e7),
+    (1e7, 1e9),
+    (1e9, 2147483647),
 ]
 
 
@@ -671,17 +686,11 @@ def test_pow(device, h, w, scalar, layout):
 @pytest.mark.parametrize("lower_limit", [0, 1.0, 2, -5.5])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
 def test_relu_min(device, h, w, lower_limit, dtype):
     torch.manual_seed(0)
 
-    if dtype == ttnn.bfloat16:
-        torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
-    elif dtype == ttnn.int32:
-        torch_input_tensor = torch.randint(
-            torch.iinfo(torch.int32).min, torch.iinfo(torch.int32).max, (h, w), dtype=torch.int32
-        )
-        lower_limit = int(lower_limit)
+    torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
 
     golden_function = ttnn.get_golden_function(ttnn.relu_min)
     torch_output_tensor = golden_function(torch_input_tensor, lower_limit=lower_limit)
@@ -696,17 +705,11 @@ def test_relu_min(device, h, w, lower_limit, dtype):
 @pytest.mark.parametrize("upper_limit", [0, 1.0, 2, -5.5])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
 def test_relu_max(device, h, w, upper_limit, dtype):
     torch.manual_seed(0)
 
-    if dtype == ttnn.bfloat16:
-        torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
-    elif dtype == ttnn.int32:
-        torch_input_tensor = torch.randint(
-            torch.iinfo(torch.int32).min, torch.iinfo(torch.int32).max, (h, w), dtype=torch.int32
-        )
-        upper_limit = int(upper_limit)
+    torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
 
     golden_function = ttnn.get_golden_function(ttnn.relu_max)
     torch_output_tensor = golden_function(torch_input_tensor, upper_limit=upper_limit)
@@ -718,27 +721,67 @@ def test_relu_max(device, h, w, upper_limit, dtype):
     assert torch.equal(torch_output_tensor, output_tensor)
 
 
-@pytest.mark.parametrize("h", [64])
-@pytest.mark.parametrize("w", [128])
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32])
-def test_relu6(device, h, w, dtype):
-    torch.manual_seed(0)
+@pytest.mark.parametrize("input_shapes", [torch.Size([1, 2, 32, 128])])
+@pytest.mark.parametrize("value_ranges", [INT32_BANDED_RANGES])
+@pytest.mark.parametrize("upper_limit", [-(2**31), -(2**30), -7, 0, 7, 1000, 2**24 + 1, 2**30, 2147483647])
+def test_relu_max_int32_full_range(device, input_shapes, value_ranges, upper_limit):
+    torch_input_tensor = create_banded_range_tensor(input_shapes, value_ranges, dtype=torch.int32)
 
-    if dtype == ttnn.bfloat16:
-        torch_input_tensor = torch.randn((h, w), dtype=torch.bfloat16) * 10 - 2
-    elif dtype == ttnn.int32:
-        torch_input_tensor = torch.randint(
-            torch.iinfo(torch.int32).min, torch.iinfo(torch.int32).max, (h, w), dtype=torch.int32
-        )
+    golden_function = ttnn.get_golden_function(ttnn.relu_max)
+    torch_output_tensor = golden_function(torch_input_tensor.to(torch.int64), upper_limit).to(torch.int32)
 
-    golden_function = ttnn.get_golden_function(ttnn.relu6)
-    torch_output_tensor = golden_function(torch_input_tensor)
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    output_tensor = ttnn.to_torch(ttnn.relu_max(input_tensor, upper_limit), dtype=torch.int32)
 
-    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
-    output_tensor = ttnn.relu6(input_tensor)
-    output_tensor = ttnn.to_torch(output_tensor)
+    assert torch.equal(output_tensor, torch_output_tensor)
 
-    assert torch.equal(torch_output_tensor, output_tensor)
+
+@pytest.mark.parametrize("input_shapes", [torch.Size([1, 2, 32, 128])])
+@pytest.mark.parametrize("value_ranges", [INT32_BANDED_RANGES])
+@pytest.mark.parametrize("lower_limit", [-(2**31), -(2**30), -7, 0, 7, 1000, 2**24 + 1, 2**30, 2147483647])
+def test_relu_min_int32_full_range(device, input_shapes, value_ranges, lower_limit):
+    torch_input_tensor = create_banded_range_tensor(input_shapes, value_ranges, dtype=torch.int32)
+
+    golden_function = ttnn.get_golden_function(ttnn.relu_min)
+    torch_output_tensor = golden_function(torch_input_tensor.to(torch.int64), lower_limit).to(torch.int32)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    output_tensor = ttnn.to_torch(ttnn.relu_min(input_tensor, lower_limit), dtype=torch.int32)
+
+    assert torch.equal(output_tensor, torch_output_tensor)
+
+
+@pytest.mark.parametrize("input_shapes", [torch.Size([1, 2, 32, 128])])
+@pytest.mark.parametrize("value_ranges", [INT32_BANDED_RANGES])
+def test_relu6_int32_full_range(device, input_shapes, value_ranges):
+    torch_input_tensor = create_banded_range_tensor(input_shapes, value_ranges, dtype=torch.int32)
+
+    # torch.nn.functional.relu6 (the ttnn.relu6 golden) has no integer kernel; relu6 clamps to
+    # [0, 6], so compute the golden manually
+    torch_output_tensor = torch.clamp(torch_input_tensor, min=0, max=6)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    output_tensor = ttnn.to_torch(ttnn.relu6(input_tensor), dtype=torch.int32)
+
+    assert torch.equal(output_tensor, torch_output_tensor)
 
 
 @pytest.mark.parametrize("input_shapes", [torch.Size([1, 2, 32, 128])])

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_relu.h
@@ -15,7 +15,7 @@ namespace ckernel {
 namespace sfpu {
 
 // Full-range unsigned clamp against a threshold, shared by relu_min and relu_max/relu6.
-// IS_LOWER_BOUND selects the direction using the user-facing op's semantics:
+// IS_LOWER_BOUND selects the path:
 //   IS_LOWER_BOUND == true -> relu_min: result = max(x, threshold)
 //   IS_LOWER_BOUND == false -> relu_max/relu6: result = min(x, threshold)
 //
@@ -71,6 +71,68 @@ inline void relu_clamp_uint(uint threshold) {
             }
             dst_reg[0].mode<LAYOUT>() = x;
             dst_reg++;
+        }
+    }
+}
+
+// Signed int32 clamp against a threshold, shared by relu_min and relu_max/relu6.
+// IS_LOWER_BOUND selects the path:
+//   IS_LOWER_BOUND == true -> relu_min: result = max(x, threshold)
+//   IS_LOWER_BOUND == false -> relu_max/relu6: result = max(0, min(x, threshold))
+//
+// Load/store as signed 2's complement (DataLayout::I32). Since the sign-magnitude SFPSWAP path cannot
+// represent -2^31 (0x80000000 is -0), we use the plain int32 compare.
+template <bool APPROXIMATION_MODE, bool IS_LOWER_BOUND, int ITERATIONS = 8>
+inline void relu_clamp_int(uint threshold) {
+    const vInt t = static_cast<int>(threshold);
+    const bool is_pos_threshold = static_cast<int>(threshold) >= 0;
+    if constexpr (IS_LOWER_BOUND) {
+        // relu_min: max(x, threshold)
+        if (is_pos_threshold) {
+#pragma GCC unroll 8
+            for (int d = 0; d < ITERATIONS; d++) {
+                vInt x = dst_reg[0].mode<sfpi::DataLayout::I32>();
+                v_if(x < 0) { x = t; }
+                v_endif;
+                v_if(x < t) { x = t; }
+                v_endif;
+                dst_reg[0].mode<sfpi::DataLayout::I32>() = x;
+                dst_reg++;
+            }
+        } else {
+#pragma GCC unroll 8
+            for (int d = 0; d < ITERATIONS; d++) {
+                vInt x = dst_reg[0].mode<sfpi::DataLayout::I32>();
+                v_if(x < 0) {
+                    v_if(x < t) { x = t; }
+                    v_endif;
+                }
+                v_endif;
+                dst_reg[0].mode<sfpi::DataLayout::I32>() = x;
+                dst_reg++;
+            }
+        }
+    } else {
+        // relu_max/relu6: max(0, min(x, threshold))
+        if (is_pos_threshold) {
+#pragma GCC unroll 8
+            for (int d = 0; d < ITERATIONS; d++) {
+                vInt x = dst_reg[0].mode<sfpi::DataLayout::I32>();
+                v_if(x < 0) { x = 0; }
+                v_endif;
+                v_if(x > t) { x = t; }
+                v_endif;
+                dst_reg[0].mode<sfpi::DataLayout::I32>() = x;
+                dst_reg++;
+            }
+        } else {
+            // threshold < 0: max(0, min(x, threshold)) == 0 for every lane
+            const vInt zero = 0;
+#pragma GCC unroll 8
+            for (int d = 0; d < ITERATIONS; d++) {
+                dst_reg[0].mode<sfpi::DataLayout::I32>() = zero;
+                dst_reg++;
+            }
         }
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_relu.h
@@ -92,6 +92,9 @@ inline void relu_clamp_int(uint threshold) {
 #pragma GCC unroll 8
             for (int d = 0; d < ITERATIONS; d++) {
                 vInt x = dst_reg[0].mode<sfpi::DataLayout::I32>();
+                // v_if(x < 0) is NOT redundant: the SFPU signed compare subtracts and tests the sign,
+                // which overflows when x and t are >= 2^31 apart and wrongly gives x>=t. Lifting negatives
+                // up to t first leaves only non-negative lanes for the x < t compare, which then cannot overflow.
                 v_if(x < 0) { x = t; }
                 v_endif;
                 v_if(x < t) { x = t; }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_relu.h
@@ -15,8 +15,8 @@ namespace ckernel {
 namespace sfpu {
 
 // Full-range unsigned clamp against a threshold, shared by relu_min and relu_max/relu6.
-// IS_LOWER_BOUND selects the direction using the user-facing op's semantics:
-//   IS_LOWER_BOUND == true  -> relu_min:        result = max(x, threshold)
+// IS_LOWER_BOUND selects the path:
+//   IS_LOWER_BOUND == true -> relu_min: result = max(x, threshold)
 //   IS_LOWER_BOUND == false -> relu_max/relu6:  result = min(x, threshold)
 //
 // For U32 we can't do a plain vUInt compare (it subtracts and tests the sign, which overflows for
@@ -71,6 +71,68 @@ inline void relu_clamp_uint(uint threshold) {
             }
             dst_reg[0].mode<LAYOUT>() = x;
             dst_reg++;
+        }
+    }
+}
+
+// Signed int32 clamp against a threshold, shared by relu_min and relu_max/relu6.
+// IS_LOWER_BOUND selects the direction using the user-facing op's semantics:
+//   IS_LOWER_BOUND == true  -> relu_min:       result = max(x, threshold)
+//   IS_LOWER_BOUND == false -> relu_max/relu6: result = max(0, min(x, threshold))  (relu built in)
+//
+// Load/store as signed 2's complement (DataLayout::I32). Since the sign-magnitude SFPSWAP path cannot
+// represent -2^31 (0x80000000 is -0), we use the plain int32 compare.
+template <bool APPROXIMATION_MODE, bool IS_LOWER_BOUND, int ITERATIONS = 8>
+inline void relu_clamp_int(uint threshold) {
+    const vInt t = static_cast<int>(threshold);
+    const bool is_pos_threshold = static_cast<int>(threshold) >= 0;
+    if constexpr (IS_LOWER_BOUND) {
+        // relu_min: max(x, threshold)
+        if (is_pos_threshold) {
+#pragma GCC unroll 8
+            for (int d = 0; d < ITERATIONS; d++) {
+                vInt x = dst_reg[0].mode<sfpi::DataLayout::I32>();
+                v_if(x < 0) { x = t; }
+                v_endif;
+                v_if(x < t) { x = t; }
+                v_endif;
+                dst_reg[0].mode<sfpi::DataLayout::I32>() = x;
+                dst_reg++;
+            }
+        } else {
+#pragma GCC unroll 8
+            for (int d = 0; d < ITERATIONS; d++) {
+                vInt x = dst_reg[0].mode<sfpi::DataLayout::I32>();
+                v_if(x < 0) {
+                    v_if(x < t) { x = t; }
+                    v_endif;
+                }
+                v_endif;  // x >= 0 > t, so max is x (keep)
+                dst_reg[0].mode<sfpi::DataLayout::I32>() = x;
+                dst_reg++;
+            }
+        }
+    } else {
+        // relu_max/relu6: max(0, min(x, threshold))
+        if (is_pos_threshold) {
+#pragma GCC unroll 8
+            for (int d = 0; d < ITERATIONS; d++) {
+                vInt x = dst_reg[0].mode<sfpi::DataLayout::I32>();
+                v_if(x < 0) { x = 0; }
+                v_endif;
+                v_if(x > t) { x = t; }
+                v_endif;
+                dst_reg[0].mode<sfpi::DataLayout::I32>() = x;
+                dst_reg++;
+            }
+        } else {
+            // threshold < 0: max(0, min(x, threshold)) == 0 for every lane
+            const vInt zero = 0;
+#pragma GCC unroll 8
+            for (int d = 0; d < ITERATIONS; d++) {
+                dst_reg[0].mode<sfpi::DataLayout::I32>() = zero;
+                dst_reg++;
+            }
         }
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_relu.h
@@ -92,6 +92,9 @@ inline void relu_clamp_int(uint threshold) {
 #pragma GCC unroll 8
             for (int d = 0; d < ITERATIONS; d++) {
                 vInt x = dst_reg[0].mode<sfpi::DataLayout::I32>();
+                // v_if(x < 0) is NOT redundant: the SFPU signed compare subtracts and tests the sign,
+                // which overflows when x and t are >= 2^31 apart and wrongly gives x>=t. Lifting negatives
+                // up to t first leaves only non-negative lanes for the x < t compare, which then cannot overflow.
                 v_if(x < 0) { x = t; }
                 v_endif;
                 v_if(x < t) { x = t; }

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/relu.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/relu.h
@@ -92,8 +92,8 @@ ALWI void relu_max_tile_int32(uint32_t idst, uint32_t param0) {
     MATH(SFPU_UNARY_CALL(
         DST_SYNC_MODE,
         DST_ACCUM_MODE,
-        _relu_max_,
-        (sfpi::vInt /*VectorType*/, APPROX /*APPROXIMATION_MODE*/, 8 /*ITERATIONS*/, uint32_t /*T*/),
+        relu_clamp_int,
+        (APPROX /*APPROXIMATION_MODE*/, false /*IS_LOWER_BOUND*/, 8 /*ITERATIONS*/),
         idst,
         VectorMode::RC,
         param0 /*threshold*/));
@@ -155,8 +155,8 @@ ALWI void relu_min_tile_int32(uint32_t idst, uint32_t param0) {
     MATH(SFPU_UNARY_CALL(
         DST_SYNC_MODE,
         DST_ACCUM_MODE,
-        _relu_min_,
-        (sfpi::vInt /*VectorType*/, APPROX /*APPROXIMATION_MODE*/, 8 /*ITERATIONS*/, uint32_t /*T*/),
+        relu_clamp_int,
+        (APPROX /*APPROXIMATION_MODE*/, true /*IS_LOWER_BOUND*/, 8 /*ITERATIONS*/),
         idst,
         VectorMode::RC,
         param0 /*threshold*/));

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -204,7 +204,8 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
             if (input_dtype == DataType::INT32) {
                 return {
                     "relu_max_tile_init();",
-                    fmt::format("relu_max_tile_int32({}, {:#x}u);", idst, std::bit_cast<uint32_t>(param0))};
+                    fmt::format(
+                        "relu_max_tile_int32({}, {}u);", idst, static_cast<uint32_t>(static_cast<int32_t>(params[0])))};
             }
             return {
                 "relu_max_tile_init();",
@@ -893,9 +894,7 @@ std::pair<std::string, std::string> get_op_init_and_func_default(
                 return {"relu_max_tile_init();", fmt::format("relu_max_tile_uint32({}, 6u);", idst)};
             }
             if (input_dtype == DataType::INT32) {
-                // 0x40c00000u == bit_cast<float>(6.0f); the _relu_max_ int32 path reinterprets the
-                // threshold via Converter::as_float, so this decodes back to the integer limit 6.
-                return {"relu_max_tile_init();", fmt::format("relu_max_tile_int32({}, 0x40c00000u);", idst)};
+                return {"relu_max_tile_init();", fmt::format("relu_max_tile_int32({}, 6u);", idst)};
             }
             return {"relu_max_tile_init();", fmt::format("relu_max_tile({}, 0x40c00000u);", idst)};
         case UnaryOpType::NEG:


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/49491

### PR Category
Bug

### Problem
The current int32 path reuse the float/sign-magnitude kernels which gave wrong results:
- **relu_max**: signed `x > threshold` compare subtracts and tests the sign, which overflows when operands are ≥ 2³¹ apart. The threshold was also passed as a float bit-pattern, so any value > 2²⁴ lost precision.
- **relu_min**:  input is converted to sign-magnitude via SFPSWAP, which cannot represent -2³¹ (it collapses to -0), so `relu_min(INT32_MIN, t<0)` returns 0 instead of t.
- **relu6**: clamped everything to [0, 0].

### Summary
- Added new metal-side SFPU kernel `relu_clamp_int`
- relu_max first clamps x into [0, 2³¹), so the subsequent x > threshold compare is always between two non-negative values and can't overflow.
- relu_min computes max(x, threshold) with plain int32 2's-complement compares (no sign-magnitude conversion, so -2³¹ is exact). 
- unary_op_utils.cpp now emits raw int32 threshold value to relu_max and `6u` to relu6.

Kernel Duration (ttnn.relu_max) for UINT32 and INT32:
Shape | UInt32 [ns] | Int32 [ns]
-- | -- | -- 
[1, 1, 32, 32] | 2254 | 2319 
[1, 1, 1024, 1024] | 54748 | 53794 
[1, 1, 4096, 4096] | 717759 | 731676

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=anasuya/relu_max_min_int)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:anasuya/relu_max_min_int)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=anasuya/relu_max_min_int)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:anasuya/relu_max_min_int)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=anasuya/relu_max_min_int)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:anasuya/relu_max_min_int)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=anasuya/relu_max_min_int)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:anasuya/relu_max_min_int)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=anasuya/relu_max_min_int)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:anasuya/relu_max_min_int)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=anasuya/relu_max_min_int)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:anasuya/relu_max_min_int)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=anasuya/relu_max_min_int)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:anasuya/relu_max_min_int)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=anasuya/relu_max_min_int)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:anasuya/relu_max_min_int)