### PR TITLE
Accept allocator DRAM bank validation in pad unsupported test

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_pad_universal_input.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_pad_universal_input.py
@@ -490,7 +490,7 @@ def test_pad_dram_block_sharded_composite_fallback_unsupported(device, expect_er
         buffer_type=ttnn.BufferType.DRAM,
     )
     torch_input = torch.randn([1, 1, 64, 128], dtype=torch.bfloat16)
-    with expect_error(RuntimeError, "Logical DRAM core"):
+    with expect_error(RuntimeError, "Logical DRAM core|No DRAM bank exists for core"):
         ttnn.from_torch(
             torch_input,
             layout=ttnn.ROW_MAJOR_LAYOUT,


### PR DESCRIPTION
### PR Category
Test Only

### Summary
`test_pad_dram_block_sharded_composite_fallback_unsupported` intentionally verifies that DRAM block-sharded input created with compute-core-style shard coordinates is rejected before `pad` runs. The test previously expected only the soc-descriptor bounds message containing `Logical DRAM core`, but current WH/BH validation can reject the same invalid configuration earlier in allocator lookup with `No DRAM bank exists for core`. The expected error regex was broadened to accept both equivalent validation paths, preserving the test's intent without depending on which layer reports the unsupported DRAM bank coordinate first.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/no-dram-bank-exists)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/no-dram-bank-exists)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/no-dram-bank-exists)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/no-dram-bank-exists)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/no-dram-bank-exists)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/no-dram-bank-exists)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/no-dram-bank-exists)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/no-dram-bank-exists)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/no-dram-bank-exists)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/no-dram-bank-exists)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/no-dram-bank-exists)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/no-dram-bank-exists)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/no-dram-bank-exists)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/no-dram-bank-exists)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/no-dram-bank-exists)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/no-dram-bank-exists)