### PR TITLE
[Bugfix] reduce_to_root root_receive reader: fix stale-packet race + wrong 2nd-connection status sem

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/root_receive_reader_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/root_receive_reader_kernel.cpp
@@ -193,6 +193,8 @@ void kernel_main() {
 
     uint64_t packet_noc_addr = get_noc_addr(core_noc_x, core_noc_y, intermediate_base_addr);
     noc_async_read(packet_noc_addr, packet_l1_addr, new_packet_size_bytes);
+    // Wait for the packet to arrive before the tt_memmove copies consume packet_l1_addr.
+    noc_async_read_barrier();
 
     // moving l tensor
     tt_memmove<true, false, false, 0>(noc, dest_page_base_addr, packet_l1_addr, packet_size_bytes);
@@ -215,8 +217,6 @@ void kernel_main() {
     cb_push_back(receiver_cb_id_m, 1);
 
     cb_push_back(packet_cb_id, 1);
-
-    noc_async_read_barrier();
 
     // now the similar behaviour when device 2 is sending data to device 1
     // will be waiting on another semaphore, and fabric is for the other 2 muxes
@@ -260,7 +260,7 @@ void kernel_main() {
     mux_connection_handle2 = &mux_connection2;
 
     tt::tt_fabric::wait_for_fabric_endpoint_ready(
-        fabric_mux_x2, fabric_mux_y2, fabric_mux_status_address, local_fabric_mux_status_address);
+        fabric_mux_x2, fabric_mux_y2, fabric_mux_status_address, local_fabric_mux_status_address2);
     tt::tt_fabric::fabric_client_connect(*mux_connection_handle2);
 
     cb_reserve_back(packet_header_cb_id, 1);
@@ -302,6 +302,8 @@ void kernel_main() {
     dest_page_base_addr = get_write_ptr(receiver_cb_id_l);
     packet_noc_addr = get_noc_addr(core_noc_x, core_noc_y, intermediate_base_addr);
     noc_async_read(packet_noc_addr, packet_l1_addr, new_packet_size_bytes);
+    // Wait for the packet to arrive before the tt_memmove copies consume packet_l1_addr.
+    noc_async_read_barrier();
 
     tt_memmove<true, false, false, 0>(noc, dest_page_base_addr, packet_l1_addr, packet_size_bytes);
     cb_push_back(receiver_cb_id_l, input_num_tiles);
@@ -321,6 +323,4 @@ void kernel_main() {
     cb_push_back(receiver_cb_id_s, 1);
     cb_push_back(receiver_cb_id_m, 1);
     cb_push_back(packet_cb_id, 1);
-
-    noc_async_read_barrier();
 }


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Fixes two latent bugs in `ccl/reduce_to_root`'s `root_receive_reader_kernel.cpp`, in both the device-1 and device-2 receive phases:

1. **Stale-packet read-after-async-read race.** The packet `noc_async_read(... packet_l1_addr ...)` was barriered only at the *end* of the block, so the following synchronous `tt_memmove` copies could consume `packet_l1_addr` before the packet arrived — publishing stale / partially-received L/S/M data to the compute circular buffers. `tt_memmove<…, copy_async=false, …>` barriers only its own transfer, not the prior packet read. Fix: move `noc_async_read_barrier()` to immediately after each packet read (before the copies), matching the correct pattern already in `root2_receive_reader_kernel.cpp`.
2. **Wrong local status semaphore for the 2nd fabric connection.** The second `wait_for_fabric_endpoint_ready(...)` passed the first connection's `local_fabric_mux_status_address` instead of `local_fabric_mux_status_address2`, so the second connection polled the wrong local status semaphore (and could disturb the already-used first-connection state). Fix: use the `_2` variant. (The remote `fabric_mux_status_address` is a shared compile-time constant with no `_2` variant and is correctly reused.)

### Notes for reviewers

- These are **pre-existing** bugs (they predate the in-flight Device 2.0 migration in #49577); Copilot surfaced them while reviewing that PR. Fixed here on a `main`-based branch so they can land and be validated independently of the cleanup work.
- The barrier change is behavior-affecting and lives in multi-chip fabric code — **needs T3K / multi-chip validation** (the affected op is `reduce_to_root`). Draft until CI is green.
- The fix mirrors the known-good `root2_receive_reader_kernel.cpp` ordering; diff is intentionally minimal (5 lines).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/fix-reduce-to-root-reader)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/fix-reduce-to-root-reader)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/fix-reduce-to-root-reader)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/fix-reduce-to-root-reader)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=iwrosz/fix-reduce-to-root-reader)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:iwrosz/fix-reduce-to-root-reader)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/fix-reduce-to-root-reader)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/fix-reduce-to-root-reader)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/fix-reduce-to-root-reader)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/fix-reduce-to-root-reader)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/fix-reduce-to-root-reader)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/fix-reduce-to-root-reader)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/fix-reduce-to-root-reader)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/fix-reduce-to-root-reader)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/fix-reduce-to-root-reader)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/fix-reduce-to-root-reader)
