### PR TITLE
Derive index_fill output alignment from output memory config

### DIFF
--- a/ttnn/cpp/ttnn/operations/index_fill/device/index_fill_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/index_fill/device/index_fill_device_operation.cpp
@@ -102,8 +102,7 @@ IndexFillOperation::spec_return_value_t IndexFillOperation::compute_output_specs
         tt::tt_metal::TensorLayout(
             old_spec.tensor_layout().get_data_type(),
             old_spec.tensor_layout().get_page_config(),
-            operation_attributes.memory_config,
-            old_spec.tensor_layout().get_alignment()));
+            operation_attributes.memory_config));
 }
 IndexFillOperation::tensor_return_value_t IndexFillOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
`test_index_fill_cross_layout_to_col_sharded[height_to_block_dim3]` failed when converting a row-major height-sharded input to a block-sharded output because `index_fill` constructed the output `TensorLayout` with the requested output memory config but reused the input tensor's alignment. For a height-sharded input that carried width alignment 64, this produced an invalid block-sharded output whose physical shard width was only 16, causing row-major layout validation to fail before the op could run. The output spec now lets `TensorLayout` derive the default alignment from the output memory config, so cross-layout sharded outputs use alignment consistent with their own shard geometry instead of inheriting incompatible input layout metadata.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/index-fill-alignment)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/index-fill-alignment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/index-fill-alignment)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/index-fill-alignment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/index-fill-alignment)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/index-fill-alignment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/index-fill-alignment)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/index-fill-alignment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/index-fill-alignment)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/index-fill-alignment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/index-fill-alignment)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/index-fill-alignment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/index-fill-alignment)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/index-fill-alignment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/index-fill-alignment)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/index-fill-alignment)