### PR TITLE
[LLK][Cleanup] Document init APIs in tile_move_copy.h and eltwise_unary.h

### DIFF
--- a/tt_metal/hw/inc/api/compute/eltwise_unary/eltwise_unary.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/eltwise_unary.h
@@ -15,6 +15,23 @@
 
 namespace ckernel {
 
+// clang-format off
+/**
+ * Performs the common hardware and op init for eltwise-unary / SFPU kernels: configures the
+ * unpacker, the packer, and the math unit for an A2D datacopy pipeline from the input CB to the
+ * output CB. Call once before issuing eltwise-unary / SFPU tile ops.
+ *
+ * Note: the hardware-configuration portion of this init is a candidate to move into
+ * compute_kernel_hw_startup in a future pass, leaving this as a slimmer op-only init.
+ *
+ * Return value: None
+ *
+ * | Argument | Description                                       | Type     | Valid Range | Required |
+ * |----------|---------------------------------------------------|----------|-------------|----------|
+ * | icb      | The identifier of the input circular buffer (CB)  | uint32_t | 0 to 31     | True     |
+ * | ocb      | The identifier of the output circular buffer (CB) | uint32_t | 0 to 31     | True     |
+ */
+// clang-format on
 ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
 #ifndef ARCH_QUASAR
     state_configure<Operand::SRCA, Operand::PACK>(icb, ocb, call_line);
@@ -50,6 +67,18 @@ ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb, uint32_t call_line = 
 #endif
 }
 
+// clang-format off
+/**
+ * Alias of unary_op_init_common, kept for SFPU-kernel readability. Performs the common hardware
+ * and op init for SFPU kernels; see unary_op_init_common for details.
+ * Return value: None
+ *
+ * | Argument | Description                                       | Type     | Valid Range | Required |
+ * |----------|---------------------------------------------------|----------|-------------|----------|
+ * | icb      | The identifier of the input circular buffer (CB)  | uint32_t | 0 to 31     | True     |
+ * | ocb      | The identifier of the output circular buffer (CB) | uint32_t | 0 to 31     | True     |
+ */
+// clang-format on
 ALWI void init_sfpu(uint32_t icb, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
     unary_op_init_common(icb, ocb, call_line);
 }

--- a/tt_metal/hw/inc/api/compute/tile_move_copy.h
+++ b/tt_metal/hw/inc/api/compute/tile_move_copy.h
@@ -20,7 +20,8 @@ namespace ckernel {
 
 // clang-format off
 /**
- * Perform the init short for copy tile. This does not reconfigure the unpacker data types.
+ * Perform the copy-tile init: configures the unpacker and the math datacopy unit for an A2D copy
+ * from the given input CB into DST. Does not reconfigure the unpacker data formats.
  * Return value: None
  *
  * | Argument    | Description                                       | Type     | Valid Range                                        | Required |
@@ -30,7 +31,7 @@ namespace ckernel {
  * | transpose_within_16x16_face | Flag to perform transpose within 16x16 face | uint32_t | Any positive value will indicate transpose within 16x16 face is set        | False    |
  */
 // clang-format on
-ALWI void copy_tile_to_dst_init_short(
+ALWI void copy_tile_init(
     uint32_t cbid,
     uint32_t transpose = 0,
     uint32_t transpose_within_16x16_face = false,
@@ -53,13 +54,27 @@ ALWI void copy_tile_to_dst_init_short(
         cbid)));
 #endif
 }
+
+// clang-format off
 /**
- * Perform a init for the copy tile operation. This calls the short init function and initializes packer dst offset
- * registers.
+ * Backward-compatible alias of copy_tile_init retained for existing callers; forwards all arguments
+ * unchanged. New code should prefer copy_tile_init.
+ * Return value: None
+ *
+ * | Argument    | Description                                       | Type     | Valid Range                                        | Required |
+ * |-------------|---------------------------------------------------|----------|----------------------------------------------------|----------|
+ * | cbid        | The identifier of the input circular buffer (CB)  | uint32_t | 0 to 31                                            | False    |
+ * | transpose   | Flag to perform transpose on SrcA                 | uint32_t | Any positive value will indicate transpose is set  | False    |
+ * | transpose_within_16x16_face | Flag to perform transpose within 16x16 face | uint32_t | Any positive value will indicate transpose within 16x16 face is set        | False    |
  */
-ALWI void copy_tile_init(uint32_t cbid, uint32_t call_line = __builtin_LINE()) {
+// clang-format on
+ALWI void copy_tile_to_dst_init_short(
+    uint32_t cbid,
+    uint32_t transpose = 0,
+    uint32_t transpose_within_16x16_face = false,
+    uint32_t call_line = __builtin_LINE()) {
     LLK_SAN_FUNCTION();
-    copy_tile_to_dst_init_short(cbid, 0, false, call_line);
+    copy_tile_init(cbid, transpose, transpose_within_16x16_face, call_line);
 }
 
 // clang-format off
@@ -115,6 +130,24 @@ ALWI void copy_tile(uint32_t in_cb_id, uint32_t in_tile_index, uint32_t dst_tile
         dst_tile_index, in_cb_id)));
 }
 
+// clang-format off
+/**
+ * Copies ntiles consecutive tiles from the input CB into consecutive DST register slots
+ * (block datacopy for matmul partials). The unpacker unpacks the tiles into SRC and the math
+ * unit moves them into DST, starting at the given DST index. The DST register buffer must be in
+ * acquired state via an acquire_dst call. This call is blocking and is only available on the
+ * compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument             | Description                                            | Type     | Valid Range                                         | Required |
+ * |----------------------|--------------------------------------------------------|----------|-----------------------------------------------------|----------|
+ * | in_cb_id             | The identifier of the source circular buffer (CB)      | uint32_t | 0 to 31                                             | True     |
+ * | start_in_tile_index  | The index of the first tile to copy from the input CB  | uint32_t | Must be less than the size of the CB                | True     |
+ * | start_dst_tile_index | The index of the first DST slot to copy into           | uint32_t | Must be less than the size of the DST register (16) | True     |
+ * | ntiles               | The number of consecutive tiles to copy                | uint32_t | 1 to the DST register size                          | True     |
+ */
+// clang-format on
 ALWI void copy_block_matmul_partials(
     uint32_t in_cb_id, uint32_t start_in_tile_index, uint32_t start_dst_tile_index, uint32_t ntiles) {
 #ifndef ARCH_QUASAR


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

The copy and eltwise-unary init APIs were unclear and not documented, making it hard to follow the intended hw_start_init -> op_init -> op_tile compute kernel programming model. This first-pass change adds documentation comments to the init and tile/block functions in tile_move_copy.h and eltwise_unary.h to clarify their purpose and usage ahead of further consolidation work.

Fixes #22948

### Notes for reviewers

This is explicitly a first pass per the commit message; the broader consolidation items from issue #22948 (merging copy_tile_init/copy_tile_to_dst_init_short, shrinking unary_op_init_common, removing unused APIs) are not yet done and likely need follow-up PRs.

Diffstat: 2 files changed, 68 insertions(+), 6 deletions(-).

<sub>Opened by the LLK issue-triage board (AI-assisted, draft) — please review the diff before merging.</sub>

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-22948-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llk_code_gen/issue-22948-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-22948-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llk_code_gen/issue-22948-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-22948-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:llk_code_gen/issue-22948-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llk_code_gen/issue-22948-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llk_code_gen/issue-22948-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llk_code_gen/issue-22948-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llk_code_gen/issue-22948-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llk_code_gen/issue-22948-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llk_code_gen/issue-22948-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llk_code_gen/issue-22948-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llk_code_gen/issue-22948-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llk_code_gen/issue-22948-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llk_code_gen/issue-22948-v1)