### PR TITLE
Fix test_atan2_a test failure on BH P150

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/test_math_binary.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/test_math_binary.py
@@ -54,7 +54,14 @@ def run_math_binary_test_atan2(device, h, w, a1, a2, b1, b2, ttnn_function, pcc=
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    # bf16 linspace can quantize atan2 golden to a single value; use ULP instead of PCC in that case.
+    is_constant_golden = (
+        torch_output_tensor.numel() > 0 and (torch_output_tensor.max() == torch_output_tensor.min()).item()
+    )
+    if is_constant_golden:
+        assert_with_ulp(torch_output_tensor, output_tensor, ulp_threshold=1)
+    else:
+        assert_with_pcc(torch_output_tensor, output_tensor, pcc)
 
 
 @pytest.mark.parametrize("h", [64])

--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/test_math_binary.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/test_math_binary.py
@@ -9,7 +9,7 @@ import torch
 import ttnn
 import random
 from math import pi
-from tests.ttnn.utils_for_testing import assert_with_pcc, assert_with_ulp
+from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.common.utility_functions import torch_random
 
 
@@ -54,20 +54,15 @@ def run_math_binary_test_atan2(device, h, w, a1, a2, b1, b2, ttnn_function, pcc=
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    # bf16 linspace can quantize atan2 golden to a single value; use ULP instead of PCC in that case.
-    is_constant_golden = (
-        torch_output_tensor.numel() > 0 and (torch_output_tensor.max() == torch_output_tensor.min()).item()
-    )
-    if is_constant_golden:
-        assert_with_ulp(torch_output_tensor, output_tensor, ulp_threshold=1)
-    else:
-        assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
 
 
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_atan2_a(device, h, w):
-    run_math_binary_test_atan2(device, h, w, 20, 40, 40, 80, ttnn.atan2)
+    # Non-parallel ranges: parallel linspace (e.g. 20→40 / 40→80) quantizes a/b to one
+    # ratio in bf16, producing a constant golden where PCC is undefined.
+    run_math_binary_test_atan2(device, h, w, -10, 10, 20, 40, ttnn.atan2)
 
 
 @pytest.mark.parametrize("h", [64])


### PR DESCRIPTION
### Issue

https://github.com/tenstorrent/tt-metal/issues/49727

### PR category

Test only

### Summary

Fix nightly CI failure on **bh_p150b_civ2**:

`tests/ttnn/nightly/unit_tests/operations/eltwise/test_math_binary.py::test_atan2_a[w=128-h=64]`

```
AssertionError: 0.0
```

Not an `atan2` kernel bug. **`test_atan2_a` used parallel bf16 linspaces** (`20→40` and `40→80`) where `b` is exactly 2× `a`, so **`a/b = 0.5` for every element** and the golden output is constant (`0.462890625`). That makes PCC undefined; on branches with stricter `comp_pcc` handling ([#42848](https://github.com/tenstorrent/tt-metal/pull/42848), #48326 series), the allclose fallback rejects legitimate 1 bf16 ULP SFPU scatter on BH.

**Fix:** change input ranges to non-parallel distributions so the golden has real variance, and keep plain `assert_with_pcc`.

### Root cause

| | Old `test_atan2_a` | New `test_atan2_a` |
|--|-------------------|-------------------|
| `a` range | `20 → 40` | `-10 → 10` |
| `b` range | `40 → 80` | `20 → 40` |
| `a/b` unique (bf16) | **1** (always 0.5) | **445** |
| Golden unique | **1** (constant) | **440** |

`test_atan2_b` (`linspace(-1, 1)`) is unchanged and still covers the small-range case.

**Fix** is to update test_atan2_a to use non-parallel ranges (e.g. a: [-10, 10], b: [20, 40]) so the golden has real variance,

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/atan2_pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/atan2_pcc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/atan2_pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/atan2_pcc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=virdhatchani/atan2_pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:virdhatchani/atan2_pcc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/atan2_pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/atan2_pcc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/atan2_pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/atan2_pcc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/atan2_pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/atan2_pcc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/atan2_pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/atan2_pcc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/atan2_pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/atan2_pcc)