### PR TITLE
perf(mla): make dense k_chunk=640 head-agnostic

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/mla/mla_config.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla_config.py
@@ -364,7 +364,7 @@ MLA_SDPA_CONFIG = {
     640: {
         "q_chunk_size": 32,
         "k_chunk_size": 640,
-        "num_heads": 64,
+        "num_heads": None,
         "chunked_only": True,
     },
 }


### PR DESCRIPTION
Dense MLA's `640` SDPA entry was tagged `num_heads=64`, which silently voided it for DeepSeek's 128 heads → `k_chunk` dropped to the 32 default (~220 flash iters vs ~11). `k_chunk=640` is head-agnostic, so `num_heads: None` applies it to any head count.

**dsv32 dense chunked-prefill** (LoudBox SP=2×TP=4 proxy, device-collapsed critical path):

| scenario | cache | before (k=32) | after (k=640) | speedup |
|----------|-------|---------------|---------------|---------|
| warm | 12.8k | 10.28 ms | 5.59 ms | 1.84× |
| long | 128k | 77.04 ms | 33.17 ms | 2.32× |

GLM-5.1 unaffected (64 heads already matched → already k=640).

### Validation run

[![(Galaxy) DeepSeek Prefill tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=skrstic/dense-mla-kchunk-head-agnostic&event=workflow_dispatch)](https://github.com/tenstorrent/tt-metal/actions/runs/29249248946)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/dense-mla-kchunk-head-agnostic)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/dense-mla-kchunk-head-agnostic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/dense-mla-kchunk-head-agnostic)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/dense-mla-kchunk-head-agnostic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=skrstic/dense-mla-kchunk-head-agnostic)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:skrstic/dense-mla-kchunk-head-agnostic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/dense-mla-kchunk-head-agnostic)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/dense-mla-kchunk-head-agnostic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/dense-mla-kchunk-head-agnostic)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/dense-mla-kchunk-head-agnostic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/dense-mla-kchunk-head-agnostic)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/dense-mla-kchunk-head-agnostic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/dense-mla-kchunk-head-agnostic)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/dense-mla-kchunk-head-agnostic)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/dense-mla-kchunk-head-agnostic)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/dense-mla-kchunk-head-agnostic)
