### PR TITLE
DS Prefill: GLM-5.2 in prefill runner

### DIFF
--- a/models/demos/common/prefill/adapter.py
+++ b/models/demos/common/prefill/adapter.py
@@ -150,6 +150,15 @@ class PrefillModelAdapter(ABC):
         The engine OWNS the returned caches' lifetime — see ``KvCaches``. ``params`` carries the
         per-rank knobs (max_seq_len, mesh_shape, this rank's num_layers, num_users, …)."""
 
+    def layer_split_boundaries(self, num_layers: int) -> Optional[set]:
+        """Layer indices at which a pipeline rank may START (its ``first_layer_idx`` must be one of
+        these). ``None`` => unconstrained (dense models — any split is fine). A DSA cross-layer-reuse
+        model returns its ``full`` layer indices: each rank must begin on a layer that seeds that rank's
+        indexer-reuse chain (a rank starting on a ``shared`` layer has no prior top-k — see
+        ``tt_prefill_transformer``). The runner (``compute_layer_split``) snaps the default even split
+        onto these and rejects any split whose rank starts fall off them."""
+        return None
+
     @abstractmethod
     def build_runtime(self, *, mesh_device: "ttnn.MeshDevice", hf_config, params: PrefillRunParams):
         """Construct the model for this rank and return a runtime handle. The runtime

--- a/models/demos/common/prefill/adapter.py
+++ b/models/demos/common/prefill/adapter.py
@@ -238,6 +238,9 @@ ADAPTER_PATHS = {
     "glm_5_1": "models.demos.deepseek_v3_d_p.tt.runners.adapters.glm_5_1:GLM51Adapter",
     # DeepSeek-V3.2-Exp: DSA, still test-only (config + sparse-MLA reference parity; serving not wired).
     "deepseek_v32": "models.demos.deepseek_v3_d_p.tt.runners.adapters.sparse_mla:DeepSeekV32Adapter",
+    # GLM-5.2: DSA + cross-layer indexer reuse. Full prefill serving runtime (adapters/glm_5_2.py),
+    # mirrors glm_5_1.py two-cache serving; the reuse itself is config-driven (indexer_types).
+    "glm_5_2": "models.demos.deepseek_v3_d_p.tt.runners.adapters.glm_5_2:GLM52Adapter",
 }
 
 _ADAPTER_INSTANCES: dict = {}

--- a/models/demos/common/prefill/adapter.py
+++ b/models/demos/common/prefill/adapter.py
@@ -233,14 +233,12 @@ DEFAULT_MODEL = "deepseek_v3_d_p"
 
 ADAPTER_PATHS = {
     "deepseek_v3_d_p": "models.demos.deepseek_v3_d_p.tt.runners.adapters.deepseek_v3:DeepSeekV3Adapter",
-    "kimi_k2_6": "models.demos.deepseek_v3_d_p.tt.runners.adapters.kimi_k2_6:KimiK26Adapter",
-    # GLM-5.1: sparse-attention (DSA) variant with a full prefill serving runtime (adapters/glm_5_1.py).
-    "glm_5_1": "models.demos.deepseek_v3_d_p.tt.runners.adapters.glm_5_1:GLM51Adapter",
     # DeepSeek-V3.2-Exp: DSA, still test-only (config + sparse-MLA reference parity; serving not wired).
     "deepseek_v32": "models.demos.deepseek_v3_d_p.tt.runners.adapters.sparse_mla:DeepSeekV32Adapter",
-    # GLM-5.2: DSA + cross-layer indexer reuse. Full prefill serving runtime (adapters/glm_5_2.py),
-    # mirrors glm_5_1.py two-cache serving; the reuse itself is config-driven (indexer_types).
+    # GLM-5.1: sparse-attention (DSA) variant with a full prefill serving runtime (adapters/glm_5_1.py).
+    "glm_5_1": "models.demos.deepseek_v3_d_p.tt.runners.adapters.glm_5_1:GLM51Adapter",
     "glm_5_2": "models.demos.deepseek_v3_d_p.tt.runners.adapters.glm_5_2:GLM52Adapter",
+    "kimi_k2_6": "models.demos.deepseek_v3_d_p.tt.runners.adapters.kimi_k2_6:KimiK26Adapter",
 }
 
 _ADAPTER_INSTANCES: dict = {}

--- a/models/demos/common/prefill/runners/prefill_runner.py
+++ b/models/demos/common/prefill/runners/prefill_runner.py
@@ -188,10 +188,41 @@ def _handle_sigterm(signum, frame):
 # ---------------------------------------------------------------------------
 
 
-def compute_layer_split(num_layers: int, num_ranks: int) -> list[tuple[int, int]]:
+def _snap_counts_to_starts(counts, valid_starts, num_layers):
+    """Nudge an even split's interior rank boundaries onto the nearest valid start (preserving
+    sum == num_layers), for models that constrain where a rank may begin (layer_split_boundaries).
+    Nearest by |distance| then lower index; each boundary is used at most once and stays increasing."""
+    valid = sorted(valid_starts)
+    boundaries, s = [], 0
+    for c in counts[:-1]:
+        s += c
+        boundaries.append(s)
+    snapped, prev = [], 0
+    for b in boundaries:
+        cand = min(
+            (v for v in valid if prev < v < num_layers and v not in snapped),
+            key=lambda v: (abs(v - b), v),
+            default=None,
+        )
+        if cand is None:
+            raise ValueError(f"cannot place {len(counts)} pipeline ranks on valid layer boundaries {valid}")
+        snapped.append(cand)
+        prev = cand
+    out, prev = [], 0
+    for b in [*snapped, num_layers]:
+        out.append(b - prev)
+        prev = b
+    return out
+
+
+def compute_layer_split(num_layers: int, num_ranks: int, valid_starts=None) -> list[tuple[int, int]]:
     """Contiguous (first_layer_idx, count) per rank. PREFILL_PP_LAYER_COUNTS, a
     comma-separated count list summing to num_layers, overrides the default even
-    split (remainder handed to the earlier ranks)."""
+    split (remainder handed to the earlier ranks).
+
+    ``valid_starts`` (from the adapter's ``layer_split_boundaries``): layer indices at which a rank may
+    begin. None => unconstrained. When set, the default even split is auto-snapped onto valid
+    boundaries, and any split (explicit or snapped) whose rank starts fall off them is rejected early."""
     override = os.environ.get("PREFILL_PP_LAYER_COUNTS")
     if override:
         counts = [int(x) for x in override.split(",")]
@@ -203,12 +234,24 @@ def compute_layer_split(num_layers: int, num_ranks: int) -> list[tuple[int, int]
     else:
         base, rem = divmod(num_layers, num_ranks)
         counts = [base + (1 if r < rem else 0) for r in range(num_ranks)]
+        if valid_starts is not None:
+            counts = _snap_counts_to_starts(counts, valid_starts, num_layers)
 
     ranges = []
     start = 0
     for count in counts:
         ranges.append((start, count))
         start += count
+
+    if valid_starts is not None:
+        for first_idx, _ in ranges:
+            if first_idx not in valid_starts:
+                near = sorted(b for b in valid_starts if abs(b - first_idx) <= 4)
+                raise ValueError(
+                    f"pipeline rank starts at layer {first_idx}, not a valid boundary for this model "
+                    f"(nearest valid: {near}). Set PREFILL_PP_LAYER_COUNTS so every cumulative boundary "
+                    f"is a valid start."
+                )
     return ranges
 
 
@@ -614,7 +657,7 @@ def main() -> None:
     rank = int(ttnn.distributed_context_get_rank())
     num_ranks = int(ttnn.distributed_context_get_size())
 
-    layer_split = compute_layer_split(NUM_LAYERS, num_ranks)
+    layer_split = compute_layer_split(NUM_LAYERS, num_ranks, ADAPTER.layer_split_boundaries(NUM_LAYERS))
     first_layer_idx, num_my_layers = layer_split[rank]
     is_first_rank = rank == 0
     is_last_rank = rank == num_ranks - 1

--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -250,14 +250,13 @@ class TtIndexer:
         # match BF16 within bf16 noise, ~5e-4 PCC — so it can be allocated BF8 to halve the memory).
         # self._index_kbuf below is the NATURAL (single-shot) path's internal concat-grown cache only.
         self._index_kbuf = None
-        # GLM-5.2 cross-layer indexer reuse: only "full" layers own a TtIndexer (shared layers bind
-        # ReuseIndexer and never write), so the index key cache is allocated full-layers-only and THIS
-        # layer writes/reads its COMPACTED rank among full layers, not its global layer index. Gated by
-        # _index_compact; absent an indexer_types map (v3.1 / v3.2 / GLM-5.1) the per-call (all-layers)
-        # coords passed into forward() are used unchanged.
+        # GLM-5.2 cross-layer indexer reuse: the index key cache is allocated for full layers only, so this
+        # layer writes/reads its compacted rank among full layers, and the folded (user-major) slot stride
+        # is num_full, not all layers. _index_cache_layers is that stride.
         self._num_index_layers = num_full_indexer_layers(config)
-        self._index_compact = self._num_index_layers is not None
-        self._index_layer_idx = full_indexer_rank(config, layer_idx) if self._index_compact else layer_idx
+        self._is_index_compact = self._num_index_layers is not None
+        self._index_layer_idx = full_indexer_rank(config, layer_idx) if self._is_index_compact else layer_idx
+        self._index_cache_layers = self._num_index_layers if self._is_index_compact else self.layer_num
         self._upload_weights(idx_host)
         self._build_rope_tables()
         # DS block-cyclic uses the interleaved rotary_embedding_indexed op, but DS weights emit the
@@ -478,7 +477,7 @@ class TtIndexer:
                 k,
                 slot_idx=cache_user_id,
                 layer_idx=cache_layer_idx,
-                num_layers=self.layer_num,
+                num_layers=self._index_cache_layers,
                 kv_actual_global=start_pos,
                 cluster_axis=self.sp_axis,
             )
@@ -543,13 +542,8 @@ class TtIndexer:
         scoring. Scoring currently spans the full preallocated cache width (see the kv_len TODO below).
         Natural path ignores rope_tensors/cache_user_id."""
         a = self.index_args
-        # GLM-5.2 reuse: write/score this layer's keys at its COMPACTED full-layer slot of the
-        # full-layers-only index cache. cache_layer_idx / num_cache_layers feed ONLY the index cache
-        # (write_k + cache_batch_idx below), so overriding them here is self-contained. No-op (passed
-        # all-layers coords used) for models without an indexer_types map.
-        if self._index_compact:
+        if self._is_index_compact:
             cache_layer_idx = self._index_layer_idx
-            num_cache_layers = self._num_index_layers
         glob = seq_len * self.sp_factor  # global query/key count this chunk
         end_pos = start_pos + glob
         # Block-cyclic key cache is caller-owned (like the KVPE cache) — required, never self-allocated.
@@ -558,10 +552,7 @@ class TtIndexer:
                 "block-cyclic indexer requires an externally-allocated index_kv_cache passed to forward() "
                 "(same ownership as the MLA KVPE cache); none was provided"
             )
-        # Flat user-major slot into the shared [num_users*layer_num, 1, T, D_idx] cache — same formula as
-        # ttMLA._cache_batch_idx for the KVPE cache (cache_layer_idx is the LOCAL per-rank cache slot).
-        # Written by write_k and sliced by _gather_index_kbuf.
-        cache_batch_idx = cache_user_id * self.layer_num + cache_layer_idx
+        cache_batch_idx = cache_user_id * self._index_cache_layers + cache_layer_idx
         self.write_k(
             hidden_states,
             seq_len,
@@ -739,11 +730,8 @@ def indexer_layer_is_reused(config, layer_idx: int) -> bool:
 
 
 def num_full_indexer_layers(config):
-    """GLM-5.2 reuse: number of ``full`` DSA layers — the ones that own an indexer and write the index
-    key cache (``shared`` layers reuse a prior full layer's top-k and never write). The index cache and
-    its migration-table config are sized to this instead of the full layer count. Returns ``None`` when
-    there is no ``indexer_types`` map (v3.1 / v3.2 / GLM-5.1: every sparse layer is full), so callers fall
-    back to the all-layers count."""
+    """Count how many entries equal ``"full"`` in ``config.indexer_types``. Returns ``None`` when the list
+    is absent or empty."""
     types = getattr(config, "indexer_types", None)
     if not types:
         return None
@@ -751,9 +739,9 @@ def num_full_indexer_layers(config):
 
 
 def full_indexer_rank(config, layer_idx: int) -> int:
-    """GLM-5.2 reuse: a ``full`` layer's compacted slot in the full-layers-only index cache — its rank
-    among the full layers before it (count of ``full`` in ``indexer_types[:layer_idx]``). Absent the map,
-    identity (``layer_idx``), so the index cache stays per-(all-)layer as on GLM-5.1."""
+    """Prefix rank over ``config.indexer_types``: count how many entries equal ``"full"`` before position
+    ``layer_idx`` (exclusive), renumbering the matching positions into dense 0-based ranks. Returns
+    ``layer_idx`` unchanged when the list is absent or empty."""
     types = getattr(config, "indexer_types", None)
     if not types:
         return layer_idx

--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -250,6 +250,14 @@ class TtIndexer:
         # match BF16 within bf16 noise, ~5e-4 PCC — so it can be allocated BF8 to halve the memory).
         # self._index_kbuf below is the NATURAL (single-shot) path's internal concat-grown cache only.
         self._index_kbuf = None
+        # GLM-5.2 cross-layer indexer reuse: only "full" layers own a TtIndexer (shared layers bind
+        # ReuseIndexer and never write), so the index key cache is allocated full-layers-only and THIS
+        # layer writes/reads its COMPACTED rank among full layers, not its global layer index. Gated by
+        # _index_compact; absent an indexer_types map (v3.1 / v3.2 / GLM-5.1) the per-call (all-layers)
+        # coords passed into forward() are used unchanged.
+        self._num_index_layers = num_full_indexer_layers(config)
+        self._index_compact = self._num_index_layers is not None
+        self._index_layer_idx = full_indexer_rank(config, layer_idx) if self._index_compact else layer_idx
         self._upload_weights(idx_host)
         self._build_rope_tables()
         # DS block-cyclic uses the interleaved rotary_embedding_indexed op, but DS weights emit the
@@ -535,6 +543,13 @@ class TtIndexer:
         scoring. Scoring currently spans the full preallocated cache width (see the kv_len TODO below).
         Natural path ignores rope_tensors/cache_user_id."""
         a = self.index_args
+        # GLM-5.2 reuse: write/score this layer's keys at its COMPACTED full-layer slot of the
+        # full-layers-only index cache. cache_layer_idx / num_cache_layers feed ONLY the index cache
+        # (write_k + cache_batch_idx below), so overriding them here is self-contained. No-op (passed
+        # all-layers coords used) for models without an indexer_types map.
+        if self._index_compact:
+            cache_layer_idx = self._index_layer_idx
+            num_cache_layers = self._num_index_layers
         glob = seq_len * self.sp_factor  # global query/key count this chunk
         end_pos = start_pos + glob
         # Block-cyclic key cache is caller-owned (like the KVPE cache) — required, never self-allocated.
@@ -721,3 +736,25 @@ def indexer_layer_is_reused(config, layer_idx: int) -> bool:
     device construction (ReuseIndexer binding) and the cache build (skip the indexer tensorbins)."""
     types = getattr(config, "indexer_types", None)
     return bool(types) and layer_idx < len(types) and types[layer_idx] == "shared"
+
+
+def num_full_indexer_layers(config):
+    """GLM-5.2 reuse: number of ``full`` DSA layers — the ones that own an indexer and write the index
+    key cache (``shared`` layers reuse a prior full layer's top-k and never write). The index cache and
+    its migration-table config are sized to this instead of the full layer count. Returns ``None`` when
+    there is no ``indexer_types`` map (v3.1 / v3.2 / GLM-5.1: every sparse layer is full), so callers fall
+    back to the all-layers count."""
+    types = getattr(config, "indexer_types", None)
+    if not types:
+        return None
+    return sum(1 for t in types if t == "full")
+
+
+def full_indexer_rank(config, layer_idx: int) -> int:
+    """GLM-5.2 reuse: a ``full`` layer's compacted slot in the full-layers-only index cache — its rank
+    among the full layers before it (count of ``full`` in ``indexer_types[:layer_idx]``). Absent the map,
+    identity (``layer_idx``), so the index cache stays per-(all-)layer as on GLM-5.1."""
+    types = getattr(config, "indexer_types", None)
+    if not types:
+        return layer_idx
+    return sum(1 for t in types[:layer_idx] if t == "full")

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/__init__.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/__init__.py
@@ -12,11 +12,11 @@ imports this package at module load.
 
 from models.demos.deepseek_v3_d_p.tt.runners.adapters.deepseek_v3 import DeepSeekV3Adapter
 from models.demos.deepseek_v3_d_p.tt.runners.adapters.glm_5_1 import GLM51Adapter
+from models.demos.deepseek_v3_d_p.tt.runners.adapters.glm_5_2 import GLM52Adapter
 from models.demos.deepseek_v3_d_p.tt.runners.adapters.kimi_k2_6 import KimiK26Adapter
 from models.demos.deepseek_v3_d_p.tt.runners.adapters.mla import MLAPrefillAdapter
 from models.demos.deepseek_v3_d_p.tt.runners.adapters.sparse_mla import (
     DeepSeekV32Adapter,
-    GLM52Adapter,
     SparseMLAPrefillAdapter,
 )
 

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/glm_5_2.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/glm_5_2.py
@@ -76,24 +76,27 @@ class GLM52Adapter(MLAPrefillAdapter):
         )
 
     def allocate_index_kv_cache(self, *, mesh_device, hf_config, params):
-        """The lightning-indexer block-cyclic KEY cache (bfp8 TILE, ``index_head_dim`` wide), one shared
-        folded cache of num_users * num_layers user-major slots — same layout as the KVPE cache so the
-        merged migration table addresses both identically.
+        """The lightning-indexer block-cyclic KEY cache (bfp8 TILE, ``index_head_dim`` wide), a folded
+        per-user cache with the same block-cyclic layout as the KVPE cache.
 
-        GLM-5.2 note: with cross-layer reuse only ``full`` layers run the indexer and write their slot;
-        ``shared`` layers reuse indices and never touch this cache, so their slots go unused. That is
-        CORRECT (no layer reads an unwritten slot); allocating full-layer-only slots is a future memory
-        optimization, and migration must then enumerate full layers for the index config (see NOTES)."""
+        GLM-5.2 cross-layer reuse: only ``full`` layers own an indexer and write this cache (``shared``
+        layers reuse a prior full layer's top-k and never write), so it is sized to the FULL-layer count
+        (``num_full_indexer_layers``), not all layers — each full layer writes its compacted rank slot
+        (see ``TtIndexer``). The merged migration table's index config sizes itself from this tensor's
+        shape, so it too holds only full-layer entries. Falls back to ``num_layers`` when there is no
+        ``indexer_types`` map (GLM-5.1: every layer is full)."""
         import ttnn
+        from models.demos.deepseek_v3_d_p.tt.mla.indexer import num_full_indexer_layers
         from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
 
+        num_index_layers = num_full_indexer_layers(hf_config) or params.num_layers
         return init_kvpe_cache(
             kvpe_cache_head_dim=hf_config.index_head_dim,
             mesh_device=mesh_device,
             seq_len=params.max_seq_len,
             mesh_shape=list(params.mesh_shape),
             sp_axis=params.sp_axis,
-            num_kvpe_cache_layers=params.num_layers,
+            num_kvpe_cache_layers=num_index_layers,
             num_users=params.num_users,
             dtype=ttnn.bfloat8_b,
         )

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/glm_5_2.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/glm_5_2.py
@@ -97,6 +97,13 @@ class GLM52Adapter(MLAPrefillAdapter):
         )
         return KvCaches([kvpe_cache, index_cache])
 
+    def layer_split_boundaries(self, num_layers):
+        """GLM-5.2 cross-layer reuse: a pipeline rank must start on a ``full`` layer (it seeds that
+        rank's indexer-reuse chain; a ``shared`` first layer has no prior top-k to reuse). So the valid
+        rank-start boundaries are the ``full`` layer indices. ``None`` absent an ``indexer_types`` map."""
+        types = getattr(self.load_hf_config(), "indexer_types", None)
+        return None if not types else {i for i in range(num_layers) if types[i] == "full"}
+
     # --- test metadata (HF download coordinates + PCC thresholds + golden trace) ---
     # FP8 repo, mirroring GLM-5.1 (a bf16 checkout would diverge from an FP8-derived trace).
     hf_repo_id = "zai-org/GLM-5.2-FP8"

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/glm_5_2.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/glm_5_2.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""GLM-5.2 prefill adapter.
+
+Same serving shape as GLM-5.1 (``adapters/glm_5_1.py``): a DSA (sparse-attention) MLA + MoE model, so
+it subclasses ``MLAPrefillAdapter``, allocates the uncompressed bf16/ROW_MAJOR MLA KVPE cache plus the
+block-cyclic lightning-indexer KEY cache, and inherits ``build_runtime`` / ``weight_cache_path``. GLM
+diverges from the dense family the same two ways GLM-5.1 does — a DSA indexer (resolved from the
+config's ``index_*`` attrs at model-build time) and a hand-built config (``glm_moe_dsa`` isn't
+AutoConfig-loadable).
+
+GLM-5.2 delta vs 5.1 = **cross-layer DSA indexer reuse**: only ``full`` layers run the indexer; the
+following ``shared`` layers reuse the most recent full layer's top-k selection. That is entirely
+CONFIG-DRIVEN — ``glm_5_2_hf_config`` carries the ``indexer_types`` full/shared map, and the transformer
+/ ttMLA read it to bind ``TtIndexer`` (full) vs ``ReuseIndexer`` (shared) and to inject the reused
+indices — so no reuse-specific wiring lives in the adapter.
+
+Like GLM-5.1 (and Kimi) it has a single expert group with a device gate, so the MoE routing all-gather's
+semaphores go to L1_SMALL (needs the L1_SMALL carve-out at mesh-open). Run with
+``PREFILL_KV_ONLY_LAST_LAYER=0`` (the sparse path can't run a kv-only last layer); the glm52 manifest
+sets it.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Callable
+
+from models.demos.deepseek_v3_d_p.reference.glm_5_2_config import GLM52Config, glm_5_2_hf_config
+from models.demos.deepseek_v3_d_p.tt.runners.adapters.mla import MLAPrefillAdapter
+
+
+class GLM52Adapter(MLAPrefillAdapter):
+    # --- identity & runner defaults ---
+    name = "glm_5_2"
+    model_config = GLM52Config
+    # Config is hand-built (see load_hf_config); this stays empty so an accidental AutoConfig read
+    # yields an obvious empty path. Real weights come from the TTNN cache.
+    hf_model_default = ""
+    # GLM-5.2 staged TTNN weight cache. PLACEHOLDER — confirm/override with PREFILL_TTNN_CACHE /
+    # TT_GLM52_PREFILL_TTNN_CACHE. (5.2 weights differ from 5.1, so this is NOT glm_5_1's cache.)
+    ttnn_cache_default = "/data/nmilicevic/glm52_tp4_cache"
+    default_gate_mode = "DEVICE_FP32"  # GLM: single expert group
+    prefill_trace_default = "/mnt/models/deepseek-prefill-cache/golden/structured_traces/glm_52_55k_vllm"
+
+    # Single expert group + device gate: route routing-all-gather semaphores to L1_SMALL.
+    l1_small_size = 512
+    routing_use_l1_small_for_semaphores = True
+
+    def load_hf_config(self):
+        """GLM's ``glm_moe_dsa`` isn't AutoConfig-loadable, so return the hand-built HF-attribute config
+        (dims + the DSA ``index_*`` attrs + the ``indexer_types`` full/shared reuse map the sparse path
+        resolves against). The runner overwrites ``max_seq_len`` after; seed the builder with it so rope
+        config is consistent."""
+        max_seq = int(os.environ.get("PREFILL_MAX_SEQ_LEN", 8192))
+        return glm_5_2_hf_config(max_seq=max_seq)
+
+    def allocate_kv_cache(self, *, mesh_device, hf_config, params):
+        """GLM is sparse (DSA): sparse_sdpa reads the KVPE cache natively and requires it UNCOMPRESSED —
+        bf16 ROW_MAJOR — not the dense bf8/TILE cache the base MLA adapter allocates. One shared cache of
+        num_users * num_layers user-major slots. Identical to GLM-5.1."""
+        import ttnn
+        from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
+
+        return init_kvpe_cache(
+            kvpe_cache_head_dim=hf_config.qk_rope_head_dim + hf_config.kv_lora_rank,
+            mesh_device=mesh_device,
+            seq_len=params.max_seq_len,
+            mesh_shape=list(params.mesh_shape),
+            sp_axis=params.sp_axis,
+            num_kvpe_cache_layers=params.num_layers,
+            num_users=params.num_users,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+
+    def allocate_index_kv_cache(self, *, mesh_device, hf_config, params):
+        """The lightning-indexer block-cyclic KEY cache (bfp8 TILE, ``index_head_dim`` wide), one shared
+        folded cache of num_users * num_layers user-major slots — same layout as the KVPE cache so the
+        merged migration table addresses both identically.
+
+        GLM-5.2 note: with cross-layer reuse only ``full`` layers run the indexer and write their slot;
+        ``shared`` layers reuse indices and never touch this cache, so their slots go unused. That is
+        CORRECT (no layer reads an unwritten slot); allocating full-layer-only slots is a future memory
+        optimization, and migration must then enumerate full layers for the index config (see NOTES)."""
+        import ttnn
+        from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
+
+        return init_kvpe_cache(
+            kvpe_cache_head_dim=hf_config.index_head_dim,
+            mesh_device=mesh_device,
+            seq_len=params.max_seq_len,
+            mesh_shape=list(params.mesh_shape),
+            sp_axis=params.sp_axis,
+            num_kvpe_cache_layers=params.num_layers,
+            num_users=params.num_users,
+            dtype=ttnn.bfloat8_b,
+        )
+
+    # --- test metadata (HF download coordinates + PCC thresholds + golden trace) ---
+    # FP8 repo, mirroring GLM-5.1 (a bf16 checkout would diverge from an FP8-derived trace).
+    hf_repo_id = "zai-org/GLM-5.2-FP8"
+    env_var = "GLM52_HF_MODEL"
+    mla_ref_cache_env = "GLM52_MLA_REF_CACHE"
+    ref_cache_env = "TT_GLM52_PREFILL_HOST_REF_CACHE"
+    ttnn_cache_env = "TT_GLM52_PREFILL_TTNN_CACHE"
+    supports_pretrained = True
+    mla_pcc_threshold = 0.995
+    moe_pcc_threshold = 0.971
+    prefill_trace_layout = "chunked_group_a_v1"
+    test_prefill_trace_default = "/mnt/models/deepseek-prefill-cache/golden/structured_traces/glm_52_55k_vllm"
+
+    @property
+    def config_builder(self) -> Callable:
+        """The sparse-MLA reference tests resolve GLM's config through this (conftest
+        _resolve_config_only); serving goes through load_hf_config. Both hand off to glm_5_2_hf_config."""
+        return glm_5_2_hf_config

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/glm_5_2.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/glm_5_2.py
@@ -36,13 +36,9 @@ class GLM52Adapter(MLAPrefillAdapter):
     # --- identity & runner defaults ---
     name = "glm_5_2"
     model_config = GLM52Config
-    # Config is hand-built (see load_hf_config); this stays empty so an accidental AutoConfig read
-    # yields an obvious empty path. Real weights come from the TTNN cache.
-    hf_model_default = ""
-    # GLM-5.2 staged TTNN weight cache. PLACEHOLDER — confirm/override with PREFILL_TTNN_CACHE /
-    # TT_GLM52_PREFILL_TTNN_CACHE. (5.2 weights differ from 5.1, so this is NOT glm_5_1's cache.)
-    ttnn_cache_default = "/data/nmilicevic/glm52_tp4_cache"
-    default_gate_mode = "DEVICE_FP32"  # GLM: single expert group
+    hf_model_default = "/mnt/models/deepseek-prefill-cache/GLM-5.2-FP8"
+    ttnn_cache_default = "/mnt/models/deepseek-prefill-cache/glm52_ttnn_cache"
+    default_gate_mode = "DEVICE_FP32"
     prefill_trace_default = "/mnt/models/deepseek-prefill-cache/golden/structured_traces/glm_52_55k_vllm"
 
     # Single expert group + device gate: route routing-all-gather semaphores to L1_SMALL.

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/glm_5_2.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/glm_5_2.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import os
 from typing import Callable
 
+from models.demos.common.prefill.adapter import KvCaches
 from models.demos.deepseek_v3_d_p.reference.glm_5_2_config import GLM52Config, glm_5_2_hf_config
 from models.demos.deepseek_v3_d_p.tt.runners.adapters.mla import MLAPrefillAdapter
 
@@ -56,14 +57,27 @@ class GLM52Adapter(MLAPrefillAdapter):
         max_seq = int(os.environ.get("PREFILL_MAX_SEQ_LEN", 8192))
         return glm_5_2_hf_config(max_seq=max_seq)
 
-    def allocate_kv_cache(self, *, mesh_device, hf_config, params):
-        """GLM is sparse (DSA): sparse_sdpa reads the KVPE cache natively and requires it UNCOMPRESSED —
-        bf16 ROW_MAJOR — not the dense bf8/TILE cache the base MLA adapter allocates. One shared cache of
-        num_users * num_layers user-major slots. Identical to GLM-5.1."""
+    def allocate_kv_cache(self, *, mesh_device, hf_config, params) -> KvCaches:
+        """GLM is sparse (DSA), so it owns TWO device caches, returned as a KvCaches tuple (the runner
+        hands the whole tuple to every runtime call; the runtime pulls index 0 as the primary KV cache
+        and index 1 as the secondary index cache). Mirrors glm_5_1.py:
+
+          * index 0 — the MLA KVPE cache. sparse_sdpa reads it natively and requires it UNCOMPRESSED
+            (bf16 ROW_MAJOR), not the dense bf8/TILE cache the base MLA adapter allocates. All layers.
+          * index 1 — the lightning-indexer's per-user block-cyclic KEY cache (bfp8 TILE, ``index_head_dim``
+            wide). GLM-5.2 cross-layer reuse: only ``full`` layers own an indexer and write this cache
+            (``shared`` layers reuse a prior full layer's top-k and never write), so it is sized to the
+            FULL-layer count (``num_full_indexer_layers``), not all layers — each full layer writes its
+            compacted rank slot (see ``TtIndexer``), and the merged migration table's index config sizes
+            itself from this tensor's shape. Falls back to ``num_layers`` when there is no ``indexer_types``
+            map (GLM-5.1: every layer is full).
+
+        The engine owns both, exactly like the dense KVPE cache."""
         import ttnn
+        from models.demos.deepseek_v3_d_p.tt.mla.indexer import num_full_indexer_layers
         from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
 
-        return init_kvpe_cache(
+        kvpe_cache = init_kvpe_cache(
             kvpe_cache_head_dim=hf_config.qk_rope_head_dim + hf_config.kv_lora_rank,
             mesh_device=mesh_device,
             seq_len=params.max_seq_len,
@@ -74,23 +88,8 @@ class GLM52Adapter(MLAPrefillAdapter):
             dtype=ttnn.bfloat16,
             layout=ttnn.ROW_MAJOR_LAYOUT,
         )
-
-    def allocate_index_kv_cache(self, *, mesh_device, hf_config, params):
-        """The lightning-indexer block-cyclic KEY cache (bfp8 TILE, ``index_head_dim`` wide), a folded
-        per-user cache with the same block-cyclic layout as the KVPE cache.
-
-        GLM-5.2 cross-layer reuse: only ``full`` layers own an indexer and write this cache (``shared``
-        layers reuse a prior full layer's top-k and never write), so it is sized to the FULL-layer count
-        (``num_full_indexer_layers``), not all layers — each full layer writes its compacted rank slot
-        (see ``TtIndexer``). The merged migration table's index config sizes itself from this tensor's
-        shape, so it too holds only full-layer entries. Falls back to ``num_layers`` when there is no
-        ``indexer_types`` map (GLM-5.1: every layer is full)."""
-        import ttnn
-        from models.demos.deepseek_v3_d_p.tt.mla.indexer import num_full_indexer_layers
-        from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
-
         num_index_layers = num_full_indexer_layers(hf_config) or params.num_layers
-        return init_kvpe_cache(
+        index_cache = init_kvpe_cache(
             kvpe_cache_head_dim=hf_config.index_head_dim,
             mesh_device=mesh_device,
             seq_len=params.max_seq_len,
@@ -100,6 +99,7 @@ class GLM52Adapter(MLAPrefillAdapter):
             num_users=params.num_users,
             dtype=ttnn.bfloat8_b,
         )
+        return KvCaches([kvpe_cache, index_cache])
 
     # --- test metadata (HF download coordinates + PCC thresholds + golden trace) ---
     # FP8 repo, mirroring GLM-5.1 (a bf16 checkout would diverge from an FP8-derived trace).

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/sparse_mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/sparse_mla.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 
-"""Sparse-attention (DSA) prefill adapters: DeepSeek-V3.2-Exp and GLM-5.2.
+"""Sparse-attention (DSA) prefill adapters: the shared ``SparseMLAPrefillAdapter`` base + DeepSeek-V3.2-Exp.
 
-(GLM-5.1 has a full serving runtime and lives in its own ``glm_5_1.py``; the test-only DSA
-variants stay here.) Both add a lightning indexer (DeepSeek Sparse Attention) on top of the MLA
-+ MoE family. Two things set them apart from the dense ``DeepSeekV3Adapter`` / ``KimiK26Adapter``:
+GLM-5.1 / GLM-5.2 have their own serving adapters (``adapters/glm_5_1.py`` / ``adapters/glm_5_2.py``);
+what remains here is the test-only base + DeepSeek-V3.2-Exp.
+
+Both add a lightning indexer (DeepSeek Sparse Attention) on top of the MLA + MoE
+family. Two things set them apart from the dense ``DeepSeekV3Adapter`` / ``KimiK26Adapter``:
 
   * Their HF ``model_type`` (``deepseek_v32`` / ``glm_moe_dsa``) is NOT registered with
     transformers, so ``AutoConfig`` cannot load them — the config is HAND-BUILT via
@@ -26,7 +28,6 @@ from typing import Callable
 
 from models.demos.common.prefill.adapter import PrefillRunParams
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
-from models.demos.deepseek_v3_d_p.reference.glm_5_2_config import GLM52Config
 from models.demos.deepseek_v3_d_p.tt.runners.adapters.mla import MLAPrefillAdapter
 
 
@@ -79,34 +80,3 @@ class DeepSeekV32Adapter(SparseMLAPrefillAdapter):
         from models.demos.deepseek_v3_d_p.reference.deepseek_v3_2_config import deepseek_v32_hf_config
 
         return deepseek_v32_hf_config
-
-
-class GLM52Adapter(SparseMLAPrefillAdapter):
-    # --- identity ---
-    name = "glm_5_2"
-    model_config = GLM52Config
-
-    # --- test metadata ---
-    # GLM-5.2 adds cross-layer DSA indexer reuse; geometry otherwise matches 5.1. FP8 repo, mirroring
-    # GLM-5.1 (a bf16 checkout would diverge from an FP8-derived trace).
-    hf_repo_id = "zai-org/GLM-5.2-FP8"
-    env_var = "GLM52_HF_MODEL"
-    mla_ref_cache_env = "GLM52_MLA_REF_CACHE"
-    mla_pcc_threshold = 0.995
-    moe_pcc_threshold = 0.971
-
-    # Pretrained path: the cache build is per-layer indexer-aware (full layers cache MLA+indexer;
-    # shared layers cache MLA only — they own no indexer weights). No reference_model_cls (the HF
-    # glm_moe_dsa indexer is a numerical outlier vs the vLLM/device lineage), so PCC validation uses a
-    # vLLM trace, as GLM-5.1 does.
-    supports_pretrained = True
-    ttnn_cache_env = "TT_GLM52_PREFILL_TTNN_CACHE"
-    ref_cache_env = "TT_GLM52_PREFILL_HOST_REF_CACHE"
-    prefill_trace_layout = "chunked_group_a_v1"
-    test_prefill_trace_default = "/mnt/models/deepseek-prefill-cache/golden/structured_traces/glm_52_55k_vllm"
-
-    @property
-    def config_builder(self) -> Callable:
-        from models.demos.deepseek_v3_d_p.reference.glm_5_2_config import glm_5_2_hf_config
-
-        return glm_5_2_hf_config

--- a/models/demos/deepseek_v3_d_p/tt/runners/kv_chunk_table.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/kv_chunk_table.py
@@ -60,7 +60,7 @@ def _num_layers_from_cache(cache, num_users: int) -> int:
     """Layer count a KV cache holds, recovered from its folded batch dim. init_kvpe_cache lays caches
     out user-major with shape[0] = num_users * num_layers, so dividing the batch dim by num_users gives
     this cache's layer count — all layers for the KVPE cache, full-layers-only for the GLM-5.2 index
-    cache (which allocate_index_kv_cache sizes to num_full)."""
+    cache (which allocate_kv_cache sizes to num_full)."""
     return cache.shape[0] // num_users
 
 

--- a/models/demos/deepseek_v3_d_p/tt/runners/kv_chunk_table.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/kv_chunk_table.py
@@ -56,6 +56,14 @@ def _dram_chunk_size_bytes(cache) -> int:
     raise ValueError(f"unsupported KV cache dtype for chunk sizing: {cache.dtype}")
 
 
+def _num_layers_from_cache(cache, num_users: int) -> int:
+    """Layer count a KV cache holds, recovered from its folded batch dim. init_kvpe_cache lays caches
+    out user-major with shape[0] = num_users * num_layers, so dividing the batch dim by num_users gives
+    this cache's layer count — all layers for the KVPE cache, full-layers-only for the GLM-5.2 index
+    cache (which allocate_index_kv_cache sizes to num_full)."""
+    return cache.shape[0] // num_users
+
+
 def build_and_serialize_kv_chunk_table(
     *,
     mesh_device,
@@ -137,7 +145,10 @@ def _build_and_serialize_merged_kv_chunk_table(
 
     def _table_config(cache):
         cfg = disagg.KvChunkAddressTableConfig()
-        cfg.num_layers = num_layers
+        # KVPE = all layers; the GLM-5.2 index cache = full-layers-only, so config 1 holds only num_full
+        # entries and populate_kv_chunk_address_table_kimi (which iterates config.num_layers) skips the
+        # shared-layer slots. GLM-5.1 / dense: index cache is all-layers, so this equals num_layers.
+        cfg.num_layers = _num_layers_from_cache(cache, num_users)
         cfg.max_sequence_length = seq_len
         cfg.num_slots = num_users
         cfg.chunk_n_tokens = NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK

--- a/models/demos/deepseek_v3_d_p/tt/runners/manifests/glm52.json
+++ b/models/demos/deepseek_v3_d_p/tt/runners/manifests/glm52.json
@@ -1,0 +1,7 @@
+{
+  "env": {
+    "PREFILL_MODEL": "glm_5_2",
+    "PREFILL_KV_ONLY_LAST_LAYER": "0",
+    "PREFILL_GATE_FALLBACK_MODE": "DEVICE_FP32"
+  }
+}

--- a/models/demos/deepseek_v3_d_p/tt/runners/manifests/glm52.json
+++ b/models/demos/deepseek_v3_d_p/tt/runners/manifests/glm52.json
@@ -1,6 +1,7 @@
 {
   "env": {
     "PREFILL_MODEL": "glm_5_2",
+    "PREFILL_NUM_LAYERS": "78",
     "PREFILL_KV_ONLY_LAST_LAYER": "0",
     "PREFILL_GATE_FALLBACK_MODE": "DEVICE_FP32"
   }

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
@@ -477,16 +477,22 @@ class TtPrefillBlock(LightweightModule):
         # across pipeline ranks); cache_layer_idx is the LOCAL per-rank cache slot.
         if on_layer_complete is not None:
             assert actual_end is not None, "actual_end required when on_layer_complete is set"
-            ttnn.experimental.deepseek_prefill.zero_padded_kv_cache(
-                kvpe_cache,
-                cache_user_id,
-                cache_layer_idx,
-                self.mla.layer_num,
-                actual_end,
-                seq_len_local * self.mla.sp_factor,
-                self.mla.sp_axis,
-            )
-            ttnn.synchronize_device(self.mesh_device)
+            # zero_padded_kv_cache is a DENSE (TILE) kvpe-cache op. A DSA-sparse model's kvpe cache is
+            # bf16/fp8 ROW_MAJOR (sparse_sdpa reads it natively) and the op asserts TILE, so skip it for
+            # sparse. Consequence: the tile-pad window past actual_end keeps stale data — harmless without
+            # migration (never read), but sparse migration needs a ROW_MAJOR pad-zero (P1). The per-layer
+            # ack still fires below.
+            if kvpe_cache.layout == ttnn.TILE_LAYOUT:
+                ttnn.experimental.deepseek_prefill.zero_padded_kv_cache(
+                    kvpe_cache,
+                    cache_user_id,
+                    cache_layer_idx,
+                    self.mla.layer_num,
+                    actual_end,
+                    seq_len_local * self.mla.sp_factor,
+                    self.mla.sp_axis,
+                )
+                ttnn.synchronize_device(self.mesh_device)
             on_layer_complete(self.mla.layer_idx)
 
         if self.kv_only:

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
@@ -490,7 +490,7 @@ class TtPrefillBlock(LightweightModule):
                     seq_len_local * self.mla.sp_factor,
                     self.mla.sp_axis,
                 )
-                ttnn.synchronize_device(self.mesh_device)
+            ttnn.synchronize_device(self.mesh_device)
             on_layer_complete(self.mla.layer_idx)
 
         if self.kv_only:

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
@@ -479,9 +479,7 @@ class TtPrefillBlock(LightweightModule):
             assert actual_end is not None, "actual_end required when on_layer_complete is set"
             # zero_padded_kv_cache is a DENSE (TILE) kvpe-cache op. A DSA-sparse model's kvpe cache is
             # bf16/fp8 ROW_MAJOR (sparse_sdpa reads it natively) and the op asserts TILE, so skip it for
-            # sparse. Consequence: the tile-pad window past actual_end keeps stale data — harmless without
-            # migration (never read), but sparse migration needs a ROW_MAJOR pad-zero (P1). The per-layer
-            # ack still fires below.
+            # sparse.
             if kvpe_cache.layout == ttnn.TILE_LAYOUT:
                 ttnn.experimental.deepseek_prefill.zero_padded_kv_cache(
                     kvpe_cache,


### PR DESCRIPTION
### PR Category

Feature

### Summary

Closes https://github.com/tenstorrent/tt-metal/issues/49602

Wires **GLM-5.2** into the model-agnostic prefill runner as a first-class serving variant (selectable with `PREFILL_MODEL=glm_5_2`), building on the GLM-5.1 serving adapter + multi-config migration table and the GLM-5.2 cross-layer indexer-reuse model that already landed on `main`.

GLM-5.2 is the same DSA (sparse-attention) MLA + MoE family as GLM-5.1, with one delta: **cross-layer indexer reuse** — only `full` layers run the lightning indexer and write the index-key cache; `shared` layers reuse the most recent full layer's top-k. That is fully config-driven (`indexer_types`), so this PR adds no reuse wiring — only the serving adapter, a full-layers-only index-cache compaction, and two contract fixes surfaced during bring-up.

**New GLM-5.2 serving adapter**
- `adapters/glm_5_2.py` — `GLM52Adapter(MLAPrefillAdapter)`, mirroring `glm_5_1.py`. `allocate_kv_cache` returns a `KvCaches([kvpe, index])` tuple: the KVPE cache is bf16 ROW_MAJOR (sparse_sdpa reads it uncompressed), the lightning-indexer key cache is bf8 TILE. Single expert group + device gate → L1_SMALL carve-out, `DEVICE_FP32`.
- `manifests/glm52.json` — `PREFILL_MODEL=glm_5_2`, `PREFILL_NUM_LAYERS=78`, `PREFILL_KV_ONLY_LAST_LAYER=0` (the sparse path can't run a kv-only last layer), `DEVICE_FP32`.
- Registry (`adapter.py`) + `adapters/__init__.py`: register `glm_5_2 → GLM52Adapter`; drop the old test-only `GLM52Adapter` stub from `sparse_mla.py`.

**Full-layers-only index-cache compaction (reuse-aware)**
- `indexer.py` — `num_full_indexer_layers` / `full_indexer_rank` helpers; `TtIndexer` writes/reads the index cache at its **compacted rank** among full layers, with the folded-slot **stride = num_full** (not all layers). No-op for models without an `indexer_types` map (GLM-5.1 / dense keep one slot per layer).
- `kv_chunk_table.py` — the merged migration table's index config (config 1) derives its layer count from the index tensor's folded batch dim, so it enumerates only the full layers, consistent with the compacted cache.

**Contract fixes**
- `tt_prefill_block.py` — guard `zero_padded_kv_cache` (a dense TILE op) behind `kvpe_cache.layout == TILE`; a sparse ROW_MAJOR kvpe cache skips it (was `TT_FATAL: cache must be TILE layout` in request mode). The per-layer LayerAck still fires. Affects GLM-5.1 too.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nbabin/glm_5_2_runner_main)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nbabin/glm_5_2_runner_main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nbabin/glm_5_2_runner_main)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nbabin/glm_5_2_runner_main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nbabin/glm_5_2_runner_main)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nbabin/glm_5_2_runner_main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nbabin/glm_5_2_runner_main)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nbabin/glm_5_2_runner_main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nbabin/glm_5_2_runner_main)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nbabin/glm_5_2_runner_main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nbabin/glm_5_2_runner_main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nbabin/glm_5_2_runner_main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nbabin/glm_5_2_runner_main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nbabin/glm_5_2_runner_main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nbabin/glm_5_2_runner_main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nbabin/glm_5_2_runner_main)