### PR TITLE
[skip ci] [Models CI] move panoptic-deeplab and bevformer tests to tier-3 e2e pipeline

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -165,6 +165,10 @@ ttsim:
 shield:
   e2e:
     wh_llmbox: 110
+  e2e_tier3:
+    bh_p150b_civ2: 18
+  unit_tier3:
+    bh_p150b_civ2: 20
   unit:
     wh_n150: 90
     wh_n300: 115
@@ -288,7 +292,7 @@ models:
     wh_galaxy_perf: 500
   e2e:
     wh_llmbox: 198
-    bh_p150b_civ2: 63
+    bh_p150b_civ2: 8
     bh_p300: 20
     bh_loudbox: 190
     bh_quietbox_2: 80

--- a/.github/workflows/all-model-tests.yaml
+++ b/.github/workflows/all-model-tests.yaml
@@ -46,7 +46,7 @@ on:
 
       # ── SKU selection ─────────────────────────────────────────────
       skus:
-        description: "SKUs to test (comma-separated). Options: [all, wh_all, bh_all], [wh_n150, wh_n300, wh_llmbox, wh_llmbox_perf, wh_galaxy, wh_galaxy_perf], [bh_p150, bh_p300, bh_quietbox_2, bh_galaxy]"
+        description: "SKUs to test (comma-separated). Options: [all, wh_all, bh_all], [wh_n150, wh_n300, wh_llmbox, wh_llmbox_perf, wh_galaxy, wh_galaxy_perf], [bh_p150, bh_p150b_civ2, bh_p300, bh_quietbox_2, bh_galaxy]"
         required: false
         type: string
         default: "all"
@@ -118,9 +118,9 @@ jobs:
         id: resolve-skus
         run: |
           WH_SKUS="wh_n150,wh_n300,wh_llmbox,wh_llmbox_perf,wh_galaxy,wh_galaxy_perf"
-          BH_SKUS="bh_p150,bh_p300,bh_quietbox_2,bh_galaxy"
+          BH_SKUS="bh_p150,bh_p150b_civ2,bh_p300,bh_quietbox_2,bh_galaxy"
           ALL_SKUS="$WH_SKUS,$BH_SKUS"
-          VALID_SKUS="wh_n150 wh_n300 wh_llmbox wh_llmbox_perf wh_galaxy wh_galaxy_perf bh_p150 bh_p300 bh_quietbox_2 bh_galaxy wh_all bh_all"
+          VALID_SKUS="wh_n150 wh_n300 wh_llmbox wh_llmbox_perf wh_galaxy wh_galaxy_perf bh_p150 bh_p150b_civ2 bh_p300 bh_quietbox_2 bh_galaxy wh_all bh_all"
           SKU_INPUT="${{ inputs.skus || 'all' }}"
 
           # Trim leading/trailing whitespace from the entire input
@@ -137,7 +137,7 @@ jobs:
               # Skip empty tokens (e.g. from trailing commas)
               [[ -z "$item" ]] && continue
               if [[ ! " $VALID_SKUS " =~ " $item " ]]; then
-                echo "::error::Invalid SKU '$item'. Valid options: [all, wh_all, bh_all], [wh_n150, wh_n300, wh_llmbox, wh_llmbox_perf, wh_galaxy, wh_galaxy_perf], [bh_p150, bh_p300, bh_quietbox_2, bh_galaxy]"
+                echo "::error::Invalid SKU '$item'. Valid options: [all, wh_all, bh_all], [wh_n150, wh_n300, wh_llmbox, wh_llmbox_perf, wh_galaxy, wh_galaxy_perf], [bh_p150, bh_p150b_civ2, bh_p300, bh_quietbox_2, bh_galaxy]"
                 exit 1
               fi
               if [[ "$item" == "wh_all" ]]; then

--- a/.github/workflows/models-e2e-tests-impl.yaml
+++ b/.github/workflows/models-e2e-tests-impl.yaml
@@ -130,7 +130,7 @@ jobs:
         # rw-ness: per-runner caches are :rw so first-use HF downloads can populate them;
         # shared NFS honors mlperf-read-only.
         - ${{ matrix.test-group['weights-cache-mode'] == 'cloud-mlperf' && format('/mnt/MLPerf/huggingface:/mnt/MLPerf/huggingface{0}', inputs.mlperf-read-only && ':ro' || ':rw') || (matrix.test-group['weights-cache-mode'] == 'yyz4-mnt-models' && format('/mnt/models/huggingface:/mnt/MLPerf/huggingface{0}', inputs.mlperf-read-only && ':ro' || ':rw')) || (matrix.test-group['weights-cache-mode'] == 'local-disk' || matrix.test-group['weights-cache-mode'] == 'lfc') && '/localdev/blackhole_demos/huggingface_data:/mnt/MLPerf/huggingface:rw' || format('/mnt/MLPerf:/mnt/MLPerf{0}', inputs.mlperf-read-only && ':ro' || ':rw') }}
-      options: "--device /dev/tenstorrent --privileged -v /sys:/sys"
+      options: "--device /dev/tenstorrent --privileged -v /sys:/sys -e TT_GH_CI_INFRA"
     defaults:
       run:
         shell: bash

--- a/.github/workflows/models-t3-e2e-tests.yaml
+++ b/.github/workflows/models-t3-e2e-tests.yaml
@@ -27,6 +27,7 @@ on:
           - mamba-2.8b
           - gemma-4-e2b
           - gemma-4-e4b
+          - panoptic-deeplab
       sku:
         description: "Select SKU to test (not all models are configured for all SKUs. If a combination is non-existent no test will be run)"
         required: false
@@ -41,6 +42,7 @@ on:
           - "wh_galaxy (WH Galaxy)"
           - "wh_galaxy_perf (WH Galaxy perf)"
           - "bh_p150 (P150)"
+          - "bh_p150b_civ2 (P150 CIv2)"
           - "bh_p300 (P300)"
           - "bh_quietbox_2 (BH QB2)"
           - "bh_galaxy (BH Galaxy)"
@@ -92,7 +94,7 @@ jobs:
       - name: Resolve SKU and model selection
         id: resolve
         run: |
-          ALL_SKUS="wh_n150,wh_n300,wh_llmbox,wh_llmbox_perf,wh_galaxy,wh_galaxy_perf,bh_p150,bh_p300,bh_quietbox_2,bh_galaxy"
+          ALL_SKUS="wh_n150,wh_n300,wh_llmbox,wh_llmbox_perf,wh_galaxy,wh_galaxy_perf,bh_p150,bh_p150b_civ2,bh_p300,bh_quietbox_2,bh_galaxy"
           EVENT="${{ github.event_name }}"
           if [[ "$EVENT" == "workflow_dispatch" ]]; then
             SKU_INPUT="${{ inputs.sku || 'all' }}"

--- a/.github/workflows/models-t3-unit-tests.yaml
+++ b/.github/workflows/models-t3-unit-tests.yaml
@@ -27,6 +27,8 @@ on:
           # mamba-2.8b: disabled — PCC failures (see #42163)
           - gemma-4-e2b
           - gemma-4-e4b
+          - panoptic-deeplab
+          - bevformer
       sku:
         description: "Select SKU to test (not all models are configured for all SKUs. If a combination is non-existent no test will be run)"
         required: false
@@ -41,6 +43,7 @@ on:
           - "wh_galaxy (WH Galaxy)"
           - "wh_galaxy_perf (WH Galaxy perf)"
           - "bh_p150 (P150)"
+          - "bh_p150b_civ2 (P150 CIv2)"
           - "bh_p300 (P300)"
           - "bh_quietbox_2 (BH QB2)"
           - "bh_galaxy (BH Galaxy)"
@@ -92,7 +95,7 @@ jobs:
       - name: Resolve SKU and model selection
         id: resolve
         run: |
-          ALL_SKUS="wh_n150,wh_n300,wh_llmbox,wh_llmbox_perf,wh_galaxy,wh_galaxy_perf,bh_p150,bh_p300,bh_quietbox_2,bh_galaxy"
+          ALL_SKUS="wh_n150,wh_n300,wh_llmbox,wh_llmbox_perf,wh_galaxy,wh_galaxy_perf,bh_p150,bh_p150b_civ2,bh_p300,bh_quietbox_2,bh_galaxy"
           EVENT="${{ github.event_name }}"
           if [[ "$EVENT" == "workflow_dispatch" ]]; then
             SKU_INPUT="${{ inputs.sku || 'all' }}"

--- a/.github/workflows/models-unit-tests-impl.yaml
+++ b/.github/workflows/models-unit-tests-impl.yaml
@@ -130,7 +130,7 @@ jobs:
         # rw-ness: per-runner caches are :rw so first-use HF downloads can populate them;
         # shared NFS honors mlperf-read-only.
         - ${{ matrix.test-group['weights-cache-mode'] == 'cloud-mlperf' && format('/mnt/MLPerf/huggingface:/mnt/MLPerf/huggingface{0}', inputs.mlperf-read-only && ':ro' || ':rw') || (matrix.test-group['weights-cache-mode'] == 'yyz4-mnt-models' && format('/mnt/models/huggingface:/mnt/MLPerf/huggingface{0}', inputs.mlperf-read-only && ':ro' || ':rw')) || (matrix.test-group['weights-cache-mode'] == 'local-disk' || matrix.test-group['weights-cache-mode'] == 'lfc') && '/localdev/blackhole_demos/huggingface_data:/mnt/MLPerf/huggingface:rw' || format('/mnt/MLPerf:/mnt/MLPerf{0}', inputs.mlperf-read-only && ':ro' || ':rw') }}
-      options: "--device /dev/tenstorrent --privileged -v /sys:/sys"
+      options: "--device /dev/tenstorrent --privileged -v /sys:/sys -e TT_GH_CI_INFRA"
     defaults:
       run:
         shell: bash

--- a/models/model_ci_tiers.md
+++ b/models/model_ci_tiers.md
@@ -85,6 +85,8 @@ The initial release of the 3-tier model CI includes models owned by the models-t
 | Qwen2.5-VL-32B | WH LLMBox, BH QuietBox 2 |
 | Mamba-2.8B | WH N150 |
 | Phi-3-mini | WH N150 |
+| Panoptic-DeepLab | BH P150 |
+| BEVFormer | BH P150 |
 
 
 # Pipelines

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -16,16 +16,6 @@
 
 # For max allowed timeout refer to .github/time_budget.yaml
 
-# --- e2e ---
-- id: bh-grid-110-cores-panoptic-deeplab-demo
-  name: 110 cores panoptic-deeplab demo
-  cmd: TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="10,9" pytest models/experimental/panoptic_deeplab/demo/demo.py::test_panoptic_deeplab_demo_pipeline --timeout=1800
-  skus:
-    bh_p150b_civ2:
-      timeout: 30
-  owner_id: U09LK84G4TF # Nikola Milicevic
-  team: models
-
 # --- integration ---
 - id: bh-fabric-infra-integration
   name: fabric infra unit tests
@@ -55,24 +45,6 @@
       timeout: 60
   owner_id: U05ACKAJTHS # Naif Tarafdar
   team: ttnn
-
-- id: bh-grid-110-cores-panoptic-deeplab
-  name: 110 cores panoptic-deeplab
-  cmd: TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="10,9" pytest models/experimental/panoptic_deeplab/tests/pcc/
-  skus:
-    bh_p150b_civ2:
-      timeout: 10
-  owner_id: U09LK84G4TF # Nikola Milicevic
-  team: models
-
-- id: bh-grid-110-cores-bevformer
-  name: 110 cores bevformer
-  cmd: TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="10,9" pytest models/experimental/bevformer/tests/pcc/
-  skus:
-    bh_p150b_civ2:
-      timeout: 15
-  owner_id: U08E1JCMAJF # Marko Bezulj
-  team: models
 
 # --- perf ---
 - id: bh-fabric-sanity-benchmark

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -699,3 +699,14 @@
       tier: 1
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+
+# ── Panoptic DeepLab ───────────────────────────────────────────────
+- name: panoptic-deeplab e2e tests
+  cmd: TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="10,9" pytest models/experimental/panoptic_deeplab/demo/demo.py::test_panoptic_deeplab_demo_pipeline --timeout=1020
+  model: panoptic-deeplab
+  skus:
+    bh_p150b_civ2:
+      timeout: 18
+      tier: 3
+  owner_id: U09LK84G4TF # Nikola Milicevic
+  team: shield

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -727,3 +727,23 @@
       tier: 1
   owner_id: U0ATR08RCQ0 # James Lee
   team: models
+
+- name: panoptic-deeplab unit tests
+  cmd: TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="10,9" pytest models/experimental/panoptic_deeplab/tests/pcc/ --timeout=420
+  model: panoptic-deeplab
+  skus:
+    bh_p150b_civ2:
+      timeout: 8
+      tier: 3
+  owner_id: U09LK84G4TF # Nikola Milicevic
+  team: shield
+
+- name: bevformer unit tests
+  cmd: TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="10,9" pytest models/experimental/bevformer/tests/pcc/ --timeout=660
+  model: bevformer
+  skus:
+    bh_p150b_civ2:
+      timeout: 12
+      tier: 3
+  owner_id: U08E1JCMAJF # Marko Bezulj
+  team: shield


### PR DESCRIPTION
## What
Looking at [this sheet](https://docs.google.com/spreadsheets/d/1Z3TlwgkUFbUw3mRgvb2EeVetbZCCM8baTtySK7U7pCw/edit?gid=402790993#gid=402790993) rows 30, 31 ---> 

Relocates the Shield-owned, 110-core-grid Blackhole tests from `(Blackhole) e2e tests` into the **Tier-3 models pipelines**, on the CIv2 SKU **`bh_p150b_civ2`**:

- **e2e** (`models_e2e_tests.yaml`): `panoptic-deeplab e2e tests` (demo)
- **unit** (`models_unit_tests.yaml`): `panoptic-deeplab unit tests` + `bevformer unit tests` (PCC)

Removed from `blackhole_e2e_tests.yaml`; `team: shield`, `tier: 3`; added to the `model` dispatch dropdowns.

## Wiring `bh_p150b_civ2` into Tier 3

The SKU is used by other pipelines but wasn't wired into the tier-3 ones:

1. `models-t3-e2e-tests.yaml` / `models-t3-unit-tests.yaml` — added to `resolve-skus` `ALL_SKUS` + `sku` dropdown.
2. `all-model-tests.yaml` — added to the aggregate dispatcher's `BH_SKUS`/`VALID_SKUS`/options.
3. `models-e2e-tests-impl.yaml` / `models-unit-tests-impl.yaml` — container `options` now forwards `-e TT_GH_CI_INFRA`. Panoptic weights download only when `model_location_generator` sees that var inside the container (`download_if_ci_v2`); without the forward it never fires, even on a CIv2 runner. (bevformer PCC uses synthetic weights.)

## Timeouts & budget

Sized from green-run test-step wall times; each `--timeout` sits 1 min under its step cap.

| Test | pipeline | observed | step cap | `--timeout` |
|---|---|---|---|---|
| panoptic-deeplab e2e | e2e | ~14.6 min | 18 | 17 |
| panoptic-deeplab unit | unit | ~5.5 min | 8 | 7 |
| bevformer unit | unit | ~10.3 min | 12 | 11 |

`.github/time_budget.yaml`: `models.e2e.bh_p150b_civ2` 63→8 (panoptic + bevformer leave; DeepSeek prefill op tests remain); added `shield.e2e_tier3.bh_p150b_civ2: 18` and `shield.unit_tier3.bh_p150b_civ2: 20`.

## Validation

`verify_time_budget.py` + `prepare_test_matrix.py` pass for both tier-3 pipelines; rows resolve to `bh_p150b_civ2` (runner `tt-ubuntu-2204-P150b-stable`); Blackhole-e2e has zero panoptic/bevformer rows left.

[BEVFormer PASS](https://github.com/tenstorrent/tt-metal/actions/runs/29376920248)
[Panoptic-Deeplab PASS](https://github.com/tenstorrent/tt-metal/actions/runs/29376907494)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nmilicevic/pdl-tiered-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nmilicevic/pdl-tiered-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nmilicevic/pdl-tiered-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nmilicevic/pdl-tiered-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nmilicevic/pdl-tiered-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nmilicevic/pdl-tiered-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nmilicevic/pdl-tiered-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nmilicevic/pdl-tiered-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nmilicevic/pdl-tiered-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nmilicevic/pdl-tiered-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nmilicevic/pdl-tiered-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nmilicevic/pdl-tiered-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nmilicevic/pdl-tiered-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nmilicevic/pdl-tiered-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nmilicevic/pdl-tiered-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nmilicevic/pdl-tiered-ci)