### PR TITLE
[Codegen][Spring-Cleaning] Quasar orchestrator

### DIFF
--- a/tt_metal/tt-llk/.gitignore
+++ b/tt_metal/tt-llk/.gitignore
@@ -31,3 +31,4 @@ compile_flags.txt
 
 # Codegen run logs/artifacts (in-repo LOG_DIR when /proj_sw is absent)
 codegen/logs/
+.codegen_run_state.json

--- a/tt_metal/tt-llk/codegen/CLAUDE.md
+++ b/tt_metal/tt-llk/codegen/CLAUDE.md
@@ -108,17 +108,18 @@ Exports two variables, passed to the orchestrator in Step 3:
 | **quasar** | `codegen/agents/quasar/orchestrator.md` |
 | **wormhole/blackhole** | Not yet supported — inform the user |
 
-**Mandatory:** pass the orchestrator this exact JSON structure:
-```json
-{
-  "KERNEL_NAME": "{kernel}",
-  "TARGET_ARCH": "{target_arch}",
-  "SFPI_MODE": "{SFPI_MODE}",
-  "WORKTREE_DIR": "{worktree_dir}",
-  "WORKTREE_BRANCH": "{worktree_branch}",
-  "LOG_DIR_BASE": "/proj_sw/user_dev/llk_code_gen"
-}
+**Mandatory:** before invoking the orchestrator, write its startup parameters
+via `state.py --worktree-dir` — do not hand-construct the state file path
+(`--worktree-dir` resolves it the same way for every caller):
+```bash
+python codegen/scripts/state.py --worktree-dir "{worktree_dir}" set KERNEL_NAME     "{kernel}"
+python codegen/scripts/state.py --worktree-dir "{worktree_dir}" set TARGET_ARCH     "{target_arch}"
+python codegen/scripts/state.py --worktree-dir "{worktree_dir}" set SFPI_MODE       "{SFPI_MODE}" --json
+python codegen/scripts/state.py --worktree-dir "{worktree_dir}" set WORKTREE_BRANCH "{worktree_branch}"
+python codegen/scripts/state.py --worktree-dir "{worktree_dir}" set LOG_DIR_BASE    "/proj_sw/user_dev/llk_code_gen"
 ```
+Then invoke the orchestrator, telling it only `WORKTREE_DIR={worktree_dir}` —
+it reads everything else back the same way, via `state.py --worktree-dir`.
 
 ### Solve Issue (`REQUEST_TYPE` = `issue`)
 

--- a/tt_metal/tt-llk/codegen/agents/quasar/orchestrator.md
+++ b/tt_metal/tt-llk/codegen/agents/quasar/orchestrator.md
@@ -6,439 +6,243 @@ Read-only git commands are allowed (`git rev-parse`, `git log`, `git status`, `g
 
 ---
 
-## Pipeline Overview
+## Input
 
-When a user asks to **"generate {kernel} for {target_arch}"**, run this pipeline:
+The caller (the `codegen/CLAUDE.md` router) tells you only `WORKTREE_DIR` in
+the prompt.
+
+All executable steps live as `execute_step_*` functions in
+`codegen/scripts/quasar/orchestrator_steps.sh`. Pass the values that vary
+per run as arguments; never hand-edit the function bodies. And never read `orchestrator_steps.sh`
+
+```bash
+source "{worktree_dir}/tt_metal/tt-llk/codegen/scripts/quasar/orchestrator_steps.sh"
+execute_step_validate_input "{worktree_dir}"
+```
+
+`execute_step_validate_input` prints `OK: ...`, or `REJECT: <what was wrong>`
+and returning non-zero. **If it rejects, report the reason and stop.**
+- `WORKTREE_DIR` — absolute path, must exist
+- `KERNEL_NAME` — non-empty string
+- `TARGET_ARCH` — must be `quasar` (this orchestrator is quasar-only)
+- `SFPI_MODE` — must be exactly `true` or `false`
+- `WORKTREE_BRANCH` — non-empty string
+- `LOG_DIR_BASE` — must be exactly `/proj_sw/user_dev/llk_code_gen`
+
+**CRITICAL: All code writes and file modifications MUST happen inside `$WORKTREE_DIR/tt_metal/tt-llk`, `$WORKTREE_DIR/tt_metal/hw/ckernels`, or `$WORKTREE_DIR/tt_metal/hw/inc/api`.** The worktree has `codegen/` populated with symlinks to the source branch (read-only: `agents/`, `scripts/`, `references/`, `config/`, `CLAUDE.md`, `skills/`) plus a real per-worktree `codegen/artifacts/` directory for this run's outputs. Anything you or a subagent writes outside the worktree leaks into the source branch.
+
+**EVERY BASH COMMAND GIVEN MUST BE EXECUTED AND IN THE ORDER GIVEN BELOW, EXCEPT BLOCKS THAT ONLY ILLUSTRATE USAGE.**
+
+---
+
+## Pipeline Overview
 
 ```
 analyzer  →  [ writer → tester → refiner ] × up to 3 cycles  →  optimizer  →  format  →  report
 ```
 
-- **analyzer** (`llk-analyzer.md`) — one-shot. Produces `codegen/artifacts/{op}_analysis.md` covering arch research, target-pattern survey, instruction mapping, solution approach, and format applicability.
-- **writer** (`llk-kernel-writer.md`) — transcribes the analysis into a kernel file and compile-checks.
-- **tester** (`llk-tester.md`) — writes/extends tests and runs them, with an **internal 5-attempt** test fix loop (simulator runs only; compile-time failures are excluded from the cap). Returns `PASS`, `STUCK`, or `ENV_ERROR` (infrastructure broken — never routed to the refiner).
-- **refiner** (`llk-analysis-refiner.md`) — invoked only when the writer fails compile or the tester returns `STUCK`. Archives the failed attempt, rewrites the analysis in place, returns `REFINED` or `ESCALATE`.
-- **Loop cap: 3 writer-tester cycles**. Cycles 1 and 2 can hand off to the refiner; cycle 3 cannot (the refiner itself caps at v2 = 2 refinements = 3 total cycles). If cycle 3 still fails, the run is reported `failed`.
-- **optimizer** and **format** only run on success.
+- **analyzer** (`llk-analyzer.md`) — returns `codegen/artifacts/{op}_analysis.md`.
+- **writer** (`llk-kernel-writer.md`) — returns `PASSED` or `FAILED`.
+- **tester** (`llk-tester.md`) — returns `PASS`, `STUCK`, or `ENV_ERROR` (never routed to the refiner).
+- **refiner** (`llk-analysis-refiner.md`) — returns `REFINED` or `ESCALATE`.
+- **Loop cap: 3 writer-tester cycles**. Cycles 1 and 2 can hand off to the refiner; cycle 3 CANNOT (the refiner itself caps at v2 = 2 refinements = 3 total cycles). If cycle 3 still fails, the run is reported `failed`.
+- **optimizer** and **format** only run on success of tester.
 
-Agent playbooks live in `codegen/agents/quasar/`. The system discovers architectural patterns from authoritative sources — not hardcoded knowledge.
+Agent playbooks live in `codegen/agents/quasar/`.
+
+### Agent I/O conventions
+
+- **An agent's status and report are its final message** — read them from the tool result, not from files.
+- **Prompt variables (`${CYCLE}`, `${KERNEL_NAME}`, …) are placeholders you fill in yourself** before spawning; the Agent tool does not expand them.
+- **The "first meaningful line" is a named field in the agent's report** (writer "Error summary", tester "Last failure signature") — copy it verbatim into the `execute_step_*` argument.
 
 ---
 
-## Input
+### Using `run_json_writer.py`
 
-The top-level routing (`codegen/CLAUDE.md`) creates an isolated worktree and passes you:
-
-- **KERNEL_NAME** — the kernel to generate (e.g., `gelu`)
-- **TARGET_ARCH** — target architecture (default: `quasar`)
-- **SFPI_MODE** — `true` if the user explicitly requested an SFPI version, else `false` (default). When `true` the optimizer runs in SFPI Conversion Mode instead of Replay Mode (see Step 3). Only meaningful for SFPU kernels.
-- **WORKTREE_DIR** — absolute path to the isolated git worktree (e.g., `/proj_sw/user_dev/llk-codegen-worktrees/branch-name`; parent overridable via `CODEGEN_WORKTREE_ROOT`)
-- **WORKTREE_BRANCH** — the branch name (e.g., `llk_code_gen/generated-gelu-quasar-v1`)
-
-**CRITICAL: All code writes and file modifications MUST happen inside `$WORKTREE_DIR/tt_metal/tt-llk`.** The worktree has `codegen/` populated with symlinks to the source branch (read-only: `agents/`, `scripts/`, `references/`, `config/`, `CLAUDE.md`, `skills/`) plus a real per-worktree `codegen/artifacts/` directory for this run's outputs. Anything you or a subagent writes outside the worktree leaks into the source branch.
-
-Before any other work, enter the worktree:
+Wherever this playbook tells you to update run status, that means calling
+`run_json_writer.py` — each call emits a progress/status entry for the run. Use
+`message` for a mid-step update that doesn't change the current step:
 
 ```bash
-cd "$WORKTREE_DIR/tt_metal/tt-llk"
+source codegen/scripts/quasar/orchestrator_steps.sh
+execute_step_message "Tester attempt 4/5 — DATA_MISMATCH on Int32 dest_acc=Yes; fixing LREG1 init ordering"
 ```
 
-Every `cd`, file path, and subagent prompt below assumes this as the starting CWD. Each agent you spawn MUST also operate inside the worktree — pass `WORKTREE_DIR` in every agent prompt and tell them to `cd` there before doing anything.
+Other subcommands (`init`, `advance`, `phase-start/-test/-end`, `failure`,
+`metric`, `finalize`) are used at their respective pipeline points below.
 
 ---
 
-## Step -1: Validate Environment
+## Step 0: Validate Environment and Setup
 
 Before starting, verify prerequisites:
 
 ```bash
-cd codegen
-PYTHONPATH=.. python -c "from codegen.config.settings import settings; issues = settings.validate(); [print(f'ISSUE: {i}') for i in issues]; exit(1) if issues else print('Environment OK')"
+source codegen/scripts/quasar/orchestrator_steps.sh
+execute_step_validate_env
 ```
 
-If any issues are reported, **stop and tell the user** what needs to be fixed before codegen can work.
+If any issues are reported, **stop and tell the caller** what needs to be fixed before codegen can work.
+
+EXECUTE the following (computes run identity + timing, `mkdir`s `$LOG_DIR`, and
+seeds both state files):
+
+```bash
+source codegen/scripts/quasar/orchestrator_steps.sh
+execute_step_setup_run
+```
+
+### Run JSON rules
+
+Part of your job is to keep the dashboard live by calling `run_json_writer.py`
+at every pipeline transition. Each status string you pass MUST:
+
+- **Name the artifact** produced or consumed — "produced `fill_analysis.md` (3
+  helpers, 8-row Semantic→Instruction table)", not "Analysis complete".
+- **Quantify** — counts, cycle number, compile attempts, refinement version.
+  "156/156 variants passed", not "tests passed".
+- **On failure, name the first meaningful error** (`file:line symbol`), not the
+  category — dashboard readers scan these for regressions.
+
+## Step 1: Identify Kernel Type and Architecture
+
+Do this **before** writing run.json — the init call below records the kernel
+type, reference file, and generated-file path, so they must already be in
+`state.py`.
+
+Don't guess the kernel category and reference path from keywords — run the
+script below:
+
+```bash
+source codegen/scripts/quasar/orchestrator_steps.sh
+execute_step_discover_kernels
+```
+Grep that output for `{op}` (and its synonyms) to find the matching line:
+- Blackhole/Wormhole use letter-based names (`llk_unpack_A.h`); Quasar uses
+  semantic names (`llk_unpack_unary_operand.h`) — expect to eyeball nearby
+  matches rather than get an exact string hit.
+- **tt-llk-layer match** → `{kernel_path}` is the part after `tt_llk_{arch}/`,
+  e.g. `common/inc/sfpu/ckernel_sfpu_gelu.h` or `llk_lib/llk_math_matmul.h`.
+- **Metal-layer match** → `{kernel_path}` does not apply. The reference path
+  is the repo-root-relative
+  `tt_metal/hw/ckernels/{ref_arch}/metal/llk_api/llk_sfpu/ckernel_sfpu_{op}.h`
+  instead.
+- **SFPU only — `ckernel_sfpu_{op}.h` exists for the same `{ref_arch}` in both
+  the tt-llk-layer and metal-layer loop output** → use the metal-layer file as
+  the reference, not the tt-llk one.
+
+Determine:
+- **Reference architecture** (default: blackhole; wormhole is also a valid
+  reference — check both when deciding, since one may have `{op}` and the
+  other may not) — the existing implementation to port from
+
+**Target architecture** IS **QUASAR** — where the kernel needs to run
+
+#### Where the generated kernel is written — `GENERATED_KERNEL`
+
+Pass the kernel type, reference arch, and reference path you determined above
+as arguments — the step records them and derives `GENERATED_KERNEL`:
+
+```bash
+source codegen/scripts/quasar/orchestrator_steps.sh
+execute_step_set_kernel_identity "{kernel_type}" "{ref_arch}" "{kernel_path}"
+```
+
+## Step 2: Write the initial run.json
+
+EXECUTE the following. It writes run.json (pipeline steps + kernel identity read
+from state), captures the session, seeds every counter, snapshots the agent
+playbooks into `$LOG_DIR/instructions/`, and refreshes cost:
+
+```bash
+source codegen/scripts/quasar/orchestrator_steps.sh
+execute_step_write_initial_run_json
+```
 
 ---
 
-## Step 0: Setup Metrics Logging
+## Step 3: Failure Tracking
 
-Record the start time and create a unique log directory for this run. Every
-variable that's later referenced by a Python heredoc (`os.environ[...]`) is
-`export`'d so the subprocess can read it.
-
-```bash
-export START_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-export RUN_ID=$(date +%Y-%m-%d)_{kernel}_{arch}_$(head -c 4 /dev/urandom | xxd -p)
-export LOG_DIR=/proj_sw/user_dev/llk_code_gen/quasar/$RUN_ID
-export GIT_COMMIT=$(git -C "$WORKTREE_DIR" rev-parse HEAD 2>/dev/null || echo "unknown")
-export CODEGEN_VERSION=$(cat codegen/agents/quasar/VERSION 2>/dev/null | tr -d '[:space:]' || echo "")
-mkdir -p $LOG_DIR/instructions
-```
-
-### Live run.json writing — MANDATORY
-
-Every step transition in this orchestrator MUST update `$LOG_DIR/run.json` via
-`codegen/scripts/run_json_writer.py`. The Activity Monitor tab on the dashboard
-reads this file while the run is in progress (status: "running") and relies on
-`current_step`, `current_step_started`, `current_step_message`, `steps_completed`,
-`step_history`, and `per_phase` staying current. The fields and writing cadence
-are specified by
-`/proj_sw/user_dev/llk_code_gen/dashboard/GEN_MONITOR_FIELDS.md` and
-`/proj_sw/user_dev/llk_code_gen/dashboard/RUN_JSON_SPEC.md`.
-
-**Rules (do NOT skip any):**
-
-1. Call `run_json_writer.py init` once, immediately after creating `$LOG_DIR`
-   (Step 0a below). Pass the `pipeline_steps` JSON so the dashboard knows the
-   canonical step set: `analyzer → writer → tester → refiner → optimizer → format`.
-2. Call `run_json_writer.py advance` at every pipeline step boundary.
-   **Reusing the same step ID across cycles is required and expected** — the
-   dashboard renders retries correctly when the same step appears multiple times
-   in `step_history`. The writer and tester will appear once per cycle
-   (up to 3 times each); the refiner appears at most twice.
-3. Call `run_json_writer.py phase-start / phase-test / phase-end` at the start,
-   during tester execution, and at the end of every writer-tester cycle. Each
-   cycle is represented as one phase in `per_phase[]` (phase 1 = cycle 1, …).
-4. Call `run_json_writer.py failure` whenever a failure is recorded (same
-   content as the `FAILURES` bash list — write both).
-5. Call `run_json_writer.py finalize` at the very end of Step 5 to flip `status`
-   to its terminal value (`success`, `compiled`, or `failed`) and close the last
-   `step_history` entry. **Never leave a run in status="running"**; even on early
-   exit, run `finalize --status failed --final-result ...` before returning.
-
-All writes are atomic (write-to-temp + rename) and safe to interleave with the
-dashboard's reads.
-
-### Authoring rule for `--new-message` / `--prev-message` / `--final-message`
-
-Every message passed to `run_json_writer.py advance / phase-end / finalize` MUST
-be a self-contained sentence a stranger reading only `step_history` can follow.
-These messages are the public record of what each step did — they land in the
-dashboard and in `$LOG_DIR/run.json` and are the only summary most viewers will
-ever see. Short placeholder strings force the viewer to open the agent log to
-understand anything. That is a defect, not a style preference.
-
-Rules:
-
-1. **Name the concrete artifact produced or consumed.** Not "Analysis complete"
-   but "Analysis produced `fill_analysis.md` with 3 enumerated helpers and an
-   8-row Semantic→Instruction table".
-2. **Quantify.** Helper count, test count, cycle number, compile attempts,
-   refinement version — whatever applies. "156/156 variants passed" beats
-   "tests passed".
-3. **When a failure is being recorded, name the first meaningful error line**
-   (file:line symbol), not just the category. Dashboard readers scan these for
-   regressions.
-4. **Mid-step progress**: long-running steps (analyzer Confluence sweeps,
-   tester simulator runs) SHOULD call `run_json_writer.py message` at natural
-   breakpoints so the dashboard's spinner has something to render instead of a
-   stale step-start message. Each `message` call costs one atomic rename —
-   call it freely; do not batch.
-
-Example call:
-```bash
-python codegen/scripts/run_json_writer.py message \
-    --log-dir "$LOG_DIR" \
-    --message "Tester attempt 4/5 — DATA_MISMATCH on Int32 dest_acc=Yes; fixing LREG1 init ordering"
-```
-
-### Step 0a: Write the initial run.json
-
-Right after `mkdir -p $LOG_DIR/instructions`, write the initial run.json so the
-dashboard immediately picks up this run as "running":
-
-```bash
-export PIPELINE_STEPS_JSON='[
-  {"id":"analyzer","name":"Analyze","desc":"Research arch + analyze reference, produce solution approach"},
-  {"id":"writer","name":"Write","desc":"Scaffold + fill kernel, compile-check"},
-  {"id":"tester","name":"Test","desc":"Write/extend tests, run, internal 5-attempt fix loop"},
-  {"id":"refiner","name":"Refine","desc":"Rewrite analysis after writer/tester failure (max 2 refinements)"},
-  {"id":"optimizer","name":"Optimize","desc":"Replay-buffer optimization (success only)"},
-  {"id":"format","name":"Format","desc":"Run pre-commit formatters on generated files"}
-]'
-
-python codegen/scripts/run_json_writer.py init \
-    --log-dir "$LOG_DIR" \
-    --run-id "$RUN_ID" \
-    --kernel "{op}" \
-    --kernel-type "{kernel_type}" \
-    --arch "{target_arch}" \
-    --reference-arch "{ref_arch}" \
-    --reference-file "tt_llk_{ref_arch}/{kernel_path}" \
-    --generated-file "{generated_kernel}" \
-    --start-time "$START_TIME" \
-    --first-step "analyzer" \
-    --first-message "Analyzing {ref_arch} reference and producing solution approach for {op}" \
-    --prompt "$PROMPT" \
-    --batch-id "${CODEGEN_BATCH_ID:-}" \
-    --model "$MODEL" \
-    --run-type "$RUN_TYPE" \
-    --git-commit "$GIT_COMMIT" \
-    --version "$CODEGEN_VERSION" \
-    --phases-total 1 \
-    --pipeline-steps "$PIPELINE_STEPS_JSON"
-
-# Persist key vars for refresh_cost.sh across Bash tool-call shells.
-# Each Bash tool call runs in a fresh shell — exported vars from prior calls
-# are gone. refresh_cost.sh sources this file as a fallback so cost tracking
-# works regardless of which shell block calls it.
-cat > /tmp/codegen_run_state.sh << _STATE_EOF
-export START_TIME="${START_TIME}"
-export LOG_DIR="${LOG_DIR}"
-export MODEL="${MODEL}"
-_STATE_EOF
-
-# Discover the session ID NOW — at startup it is still the most recently
-# started session, so the fallback in session_cost.py is reliable.  Saving it
-# here means refresh_cost.sh and extract_run_transcripts.py can pass it
-# explicitly on all later calls (hours later, other sessions may have started
-# and the fallback picks the wrong one).
-_SESSION_PAIR=$(python codegen/scripts/session_cost.py --print-session 2>/dev/null || echo "")
-SESSION_ID=$(echo "$_SESSION_PAIR" | awk '{print $1}')
-PROJECT_CWD=$(echo "$_SESSION_PAIR" | cut -d' ' -f2-)
-if [ -n "$SESSION_ID" ]; then
-    echo "export SESSION_ID=\"${SESSION_ID}\"" >> /tmp/codegen_run_state.sh
-    echo "export PROJECT_CWD=\"${PROJECT_CWD}\"" >> /tmp/codegen_run_state.sh
-fi
-```
-
-Note: `--phases-total` starts at `1` (we always run at least one writer-tester
-cycle). It is bumped to 2 / 3 via the `metric` subcommand each time the refiner
-enables another cycle.
-
-Track these variables throughout the run. **All of them must be
-`export`'d** because the `finalize` step reads them from a Python subprocess via
-`os.environ[...]`:
-
-```bash
-export PROMPT="Generate {kernel} for {arch}"       # the original user prompt verbatim
-export BATCH_ID="${CODEGEN_BATCH_ID:-}"             # empty string if not a batch run
-export MODEL="${CODEGEN_MODEL:-sonnet}"               # opus | sonnet | haiku
-export RUN_TYPE="$([ -n "$BATCH_ID" ] && echo ci || echo manual)"
-
-export CYCLE=1                                      # current writer-tester cycle (1..3)
-export MAX_CYCLES=3                                 # hard cap
-export REFINEMENT_COUNT=0                           # how many times the refiner ran
-
-export COMPILATION_ATTEMPTS=0                       # every compile across writer + tester's internal loop
-export DEBUG_CYCLES=0                               # refinement iterations (== REFINEMENT_COUNT at end)
-export PHASES_TOTAL=1                               # cycles attempted; bumped to 2/3 as refinements happen
-export PHASES_COMPLETED=0                           # 1 if a cycle passed, else 0
-export TESTS_TOTAL=0                                # total test variants run in the successful cycle
-export TESTS_PASSED=0
-export LINES_GENERATED=0
-export TESTS_GENERATED=false                        # true if the tester created new test files
-export OPTIMIZED=false                              # true if optimizer applied a change
-export OPTIMIZATION_TYPE=none                       # replay | sfpi | none
-export FORMATS_TESTED_JSON='[]'
-export FORMATS_EXCLUDED_JSON='{}'
-export AGENTS_JSON='[]'
-export TOKENS_JSON='{"input":0,"output":0,"cache_read":0,"cache_creation":0,"total":0,"cost_usd":0}'
-export OBSTACLE=                                    # set if the run is blocked
-```
-
-Two list-valued items stay in shell (too awkward as exported strings):
-- `PER_PHASE=[]` — build up per-cycle results as each cycle ends
-- `FAILURES=[]` — append every failure encountered during the run (see below)
-
-**Failure tracking**: Whenever an agent fails, a compilation fails, a test fails, or an infrastructure error occurs, append an entry to `FAILURES`:
+**Failure tracking**: whenever an agent fails, a compilation fails, a test fails, or an infrastructure error occurs, call `run_json_writer.py failure` with:
 ```json
 {
-  "step": "writer_cycle_1 | tester_cycle_2 | refiner_v1 | analyzer | optimizer | format",
-  "agent": "writer | tester | refiner | analyzer | optimizer",
+  "step": "analyzer | writer_cycle_{N} | tester_cycle_{N} | refiner_v{N}",
+  "agent": "analyzer | writer | tester | refiner",
   "type": "compile_error | test_failure | agent_error | infra_error",
   "message": "First meaningful line of the error (stderr, traceback, or test output)",
   "resolved": true
 }
 ```
-- `step`: Which pipeline step failed, suffixed with the cycle or refinement number when relevant.
-- `agent`: Which agent was running when the failure occurred.
+- `step`/`agent`: `analyzer` has no cycle suffix. Elsewhere `{N}` is the current
+  `CYCLE` — `writer_cycle_{N}`/`tester_cycle_{N}` for `N` = 1, 2, or 3;
+  `refiner_v{N}` for `N` = 1 or 2 only (the refiner never runs on cycle 3). `optimizer`/`format` don't call `failure` — These
+  only run after tests pass, and record soft outcomes (`OPTIMIZED`,
+  `OPTIMIZATION_TYPE`), not hard failures.
 - `type`: Category — `"compile_error"` (compiler stderr), `"test_failure"` (pytest/simulator), `"agent_error"` (agent stuck/crashed), `"infra_error"` (simulator timeout, env issue).
 - `message`: The actual error — first meaningful line of compiler stderr, pytest failure, or agent error. Keep it concise but specific enough to diagnose.
 - `resolved`: `true` if the issue was fixed during the run (e.g., cycle 1 failed but cycle 2 passed), `false` if it blocked completion.
 
-Copy the agent playbooks used (snapshot for reproducibility):
-```bash
-cp codegen/agents/quasar/llk-analyzer.md         $LOG_DIR/instructions/
-cp codegen/agents/quasar/llk-kernel-writer.md    $LOG_DIR/instructions/
-cp codegen/agents/quasar/llk-tester.md           $LOG_DIR/instructions/
-cp codegen/agents/quasar/llk-analysis-refiner.md $LOG_DIR/instructions/
-cp codegen/agents/quasar/llk-optimizer.md        $LOG_DIR/instructions/
-```
+**You never call `run_json_writer.py failure` by hand.** The `execute_step_*` functions in Step 5 (`execute_step_writer_failed`, `execute_step_tester_stuck`, `execute_step_tester_env_error`, `execute_step_refiner_escalate`) emit this record for you from the arguments you pass. The JSON above just documents the shape they write, so you know what each argument feeds.
 
-Pass `LOG_DIR` to every agent prompt so they can self-log their reasoning.
+## Step 4: Analyzer
 
-### Step 0a.1: Live cost tracking — MANDATORY
-
-Claude Code writes every assistant turn to `~/.claude/projects/<cwd-mapped>/<sessionId>.jsonl`
-and every sub-agent (Agent tool) turn under `.../<sessionId>/subagents/*.jsonl`. Each
-`type: assistant` entry carries `message.usage` (`input_tokens`, `output_tokens`,
-`cache_read_input_tokens`, `cache_creation_input_tokens`) and `message.model`.
-`codegen/scripts/session_cost.py` aggregates these across the main jsonl + all
-subagent jsonls, filters to entries with `timestamp >= $START_TIME`, applies
-per-model Anthropic pricing, and atomically patches `$LOG_DIR/run.json` — both
-the `tokens` object and the top-level `cost_usd` field — so the dashboard
-reflects cumulative spend in real time.
-
-For batch runs (`claude -p ... --output-format json > cli_output.json`) the
-batch runner later drops `cli_output.json` into `$LOG_DIR` and the dashboard
-backfills the authoritative cumulative total from there — that supersedes
-anything `session_cost.py` wrote.
-
-**Accuracy note.** `cost_usd` in `run.json` is an estimate, same quality as
-the `/cost` slash command — both multiply token counts by a local pricing
-table. Anthropic itself says `/cost` "may differ from your actual bill; for
-authoritative billing see the Usage page in the Claude Console." Expect
-`session_cost.py` and `/cost` to agree within a few percent as long as
-`PRICING` in `session_cost.py` tracks current list prices. For billing-grade
-numbers use the Claude Console, or — for batch runs — `cli_output.json`'s
-`total_cost_usd`, which is the CLI-summed per-request cost and the closest
-non-Console equivalent. If Anthropic publishes a price change, update the
-`PRICING` table at the top of `codegen/scripts/session_cost.py`.
-
-Call `bash codegen/scripts/refresh_cost.sh` at every natural boundary below.
-The script is a thin wrapper around `session_cost.py` that reads `START_TIME`,
-`LOG_DIR`, and (optionally) `MODEL` from the environment. **Use the script, not
-a bash function**: `Bash` tool calls do not share shell state, so an
-in-shell `refresh_cost()` defined in one call is undefined in every subsequent
-call and silently no-ops — this caused historical runs to land in `run.json`
-with `cost_usd: null`. The script form survives across tool calls because it
-lives on disk.
-
-Call it after:
-- the analyzer returns (Step 1),
-- every `phase-end` in the writer-tester loop (Step 2),
-- the optimizer returns (Step 3),
-- the format step (Step 4),
-- the final `run_json_writer.py finalize` call (Step 5b).
-
-Each call takes <1s and reads the jsonl append-only, so it's safe to interleave
-with Claude Code writing new turns.
-
----
-
-## Step 0b: Identify Kernel Type and Architecture
-
-Determine the kernel category and architecture from the request:
-
-| Category | Keywords | `{kernel_path}` (relative to the arch's tt-llk dir) |
-|----------|----------|--------------|
-| **SFPU** | sigmoid, relu, exp, gelu, tanh, sqrt, recip | `common/inc/sfpu/ckernel_sfpu_{op}.h` |
-| **Math** | matmul, reduce, eltwise, binary, unary | `llk_lib/llk_math_{op}.h` |
-| **Pack** | pack, untilize | `llk_lib/llk_pack_{op}.h` |
-| **Unpack** | unpack, tilize | `llk_lib/llk_unpack_{op}.h` |
-
-Determine:
-- **Reference architecture** (default: blackhole) — the existing implementation to port from
-- **Target architecture** (default: quasar) — where the kernel needs to run
-
-### Where the generated kernel is written — `{generated_kernel}`
-
-The **reference** always lives in the tt-llk library at `tt_llk_{ref_arch}/{kernel_path}`.
-The **generated** target file path depends on category and arch, captured once as
-`{generated_kernel}` (a **repo-root-relative** path — i.e. relative to `$WORKTREE_DIR`):
-
-| Category + arch | `{generated_kernel}` |
-|---|---|
-| **SFPU + quasar** | `tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_{op}.h` |
-| everything else | `tt_metal/tt-llk/tt_llk_{target_arch}/{kernel_path}` |
-
-Quasar SFPU kernels are authored directly in the tt-metal **CKernels LLK API**
-folder (`llk_sfpu/`), not in the tt-llk library, and are pulled into the C++ test
-via the `llk_sfpu/` include prefix (see the tester's dispatcher registration). The
-kernel still defines `_calculate_{op}_` / `_init_{op}_` and the dispatcher still
-calls `_calculate_{op}_<ITERATIONS>` — only the file location and include prefix
-differ from a tt-llk-lib kernel. `kernel_template.py` already writes to the right
-place via `get_kernel_dest(...)`; you do not compute the path by hand.
-
-**Whenever a bash command below reads or writes the generated kernel, reference it
-as `$WORKTREE_DIR/{generated_kernel}`** (absolute, CWD-independent — the orchestrator
-CWD is `$WORKTREE_DIR/tt_metal/tt-llk`, and the SFPU target sits outside it).
-
----
-
-## Step 1: Analyzer
-
-Spawn the analyzer. This agent produces the single authoritative analysis document used by every downstream agent; it covers arch research, target-pattern survey, instruction discovery, semantic→instruction mapping, solution approach, format applicability, and complexity/phases.
+Spawn the analyzer. This agent produces the single authoritative analysis document used by every downstream agent
 
 ```
 Agent tool:
   subagent_type: "general-purpose"
   description: "Analyze {op} for {target_arch}"
   prompt: |
-    Read and follow codegen/agents/quasar/llk-analyzer.md to analyze the "{op}" kernel.
+    Read and follow codegen/agents/quasar/llk-analyzer.md to analyze this run's kernel.
     Flow: generation (new kernel).
-    Kernel: {op}
-    Kernel type: {kernel_type}
-    Reference architecture: {ref_arch}
-    Target architecture: {target_arch}
-    Reference path: tt_llk_{ref_arch}/{kernel_path}
-    Output your analysis to: codegen/artifacts/{op}_analysis.md
 
     The analyzer is the ONLY arch-research step in this pipeline — there is no
     separate arch-lookup agent. You own discovering target instructions,
     register layouts, and format constraints. Follow the
     llk-arch-lookup skill (via Skill tool) for Confluence fetches.
-
-    WORKTREE_DIR: {WORKTREE_DIR} — cd into {WORKTREE_DIR}/tt_metal/tt-llk before any
-    file I/O. All paths in this prompt resolve there, not in the source branch.
-    Never write outside the worktree.
-    LOG_DIR: {LOG_DIR}
 ```
 
-Wait for completion. **Verify** that `codegen/artifacts/{op}_analysis.md` exists and contains: Problem Statement, Target Pattern Survey, Available Instructions, Semantic→Instruction Mapping, Solution Approach (with §6a signatures and §6b pseudocode), Format Applicability, Complexity & Phases. If missing, record a failure and finalize as `failed`.
+- Now WAIT for AGENT completion!
+- THEN **Verify** the analysis doc exists and has all required sections:
+  ```bash
+  source codegen/scripts/quasar/orchestrator_steps.sh
+  execute_step_verify_analysis
+  ```
+  Prints `OK: ...`, or `MISSING`/`INCOMPLETE` and returns non-zero. If it fails,
+  treat the analyzer as FAILED (below).
 
-On analyzer failure:
+IF analyzer FAILED: pass the first meaningful line of the analyzer's failure —
+the step records it, writes the failure, and finalizes the run as `failed`:
 ```bash
-python codegen/scripts/run_json_writer.py failure \
-    --log-dir "$LOG_DIR" \
-    --step "analyzer" \
-    --agent "analyzer" \
-    --type "agent_error" \
-    --message "${ANALYZER_ERROR_LINE}" \
-    --resolved "false"
-
-python codegen/scripts/run_json_writer.py finalize \
-    --log-dir "$LOG_DIR" \
-    --status "failed" \
-    --final-result "compile_error" \
-    --final-message "Analyzer failed to produce {op}_analysis.md"
+source codegen/scripts/quasar/orchestrator_steps.sh
+execute_step_analyzer_failed "{first meaningful line of the analyzer's failure}"
 ```
 
-**LIVE LOG — analyzer passed, advance to writer (cycle 1), start phase 1:**
+**IF analyzer passed, advance to next stage by EXECUTING the following** (advance
+to writer cycle 1, phase-start, refresh cost):
+
 ```bash
-python codegen/scripts/run_json_writer.py advance \
-    --log-dir "$LOG_DIR" \
-    --new-step "writer" \
-    --new-message "Cycle 1 — writing kernel from analysis" \
-    --prev-result "success" \
-    --prev-message "Analysis complete — codegen/artifacts/{op}_analysis.md" \
-    --agent "writer"
-
-python codegen/scripts/run_json_writer.py phase-start \
-    --log-dir "$LOG_DIR" \
-    --phase 1 \
-    --name "cycle 1 (fresh analysis)"
-
-bash codegen/scripts/refresh_cost.sh   # capture analyzer spend in run.json
+source codegen/scripts/quasar/orchestrator_steps.sh
+execute_step_analyzer_passed
 ```
 
 ---
 
-## Step 2: Writer → Tester → Refiner Loop (max 3 cycles)
+## Step 5: Writer → Tester → Refiner Loop (max 3 cycles)
 
-Run this block for `CYCLE ∈ {1, 2, 3}`. Break out the moment the tester returns `PASS`. If the tester returns `STUCK` in cycle 3, finalize the run as `failed` — cycle 3 does NOT hand off to the refiner.
+This pseudocode is the required control flow for the loop, not an illustration — it specifies exactly what must happen for every outcome each agent can return (writer: `PASSED` / `FAILED`; tester: `PASS` / `STUCK` / `ENV_ERROR`; refiner: `REFINED` / `ESCALATE`). Run it for `CYCLE ∈ {1, 2, 3}`; break out the moment the tester returns `PASS`. Cycle 3 never hands off to the refiner, so a writer `FAILED` or tester `STUCK` result there finalizes the run as `failed` instead.
 
 ```
 while CYCLE <= MAX_CYCLES:
-    # Step 2a: Writer
+    # Writer
     result = run_writer()
     if result == PASSED:
-        # Step 2b: Tester
+        # Tester
         result = run_tester()
         if result == PASS:
             phase_end(CYCLE, "passed")
-            break                                   # -> Step 3 (optimizer)
+            break                                   # -> optimizer
         if result == ENV_ERROR:
             # Infrastructure, not the kernel. Refinement cannot fix a broken
             # simulator — do NOT consume a cycle or invoke the refiner.
@@ -451,7 +255,7 @@ while CYCLE <= MAX_CYCLES:
         if CYCLE == MAX_CYCLES:
             finalize("failed", "test_failure")
             return
-        # Step 2c: Refiner (only cycles 1 and 2)
+        # Refiner (only cycles 1 and 2)
         run_refiner()                               # REFINED or ESCALATE
         if escalated:
             finalize("failed", "test_failure")
@@ -473,920 +277,293 @@ while CYCLE <= MAX_CYCLES:
 
 The three sub-steps follow.
 
-### Step 2a: Writer
+### Step 5a: Writer
 
-Per-cycle counters:
+FIRST setup (reset the per-cycle counters):
 ```bash
-export PHASE_COMPILES=0
-export PHASE_TEST_DETAILS=""
-export PHASE_COMPILE_ERRORS_JSON='[]'
+source codegen/scripts/quasar/orchestrator_steps.sh
+execute_step_writer_setup
 ```
-
-Spawn the writer:
+THEN Spawn the writer:
 ```
 Agent tool:
   subagent_type: "general-purpose"
-  description: "Write {op} (cycle ${CYCLE})"
+  description: "Write kernel (cycle ${CYCLE})"
   prompt: |
-    Read and follow codegen/agents/quasar/llk-kernel-writer.md to generate the "{op}" kernel.
-    Kernel type: {kernel_type}
-    Target architecture: {target_arch}
-    Analysis: codegen/artifacts/{op}_analysis.md
-    Output to: {generated_kernel} (absolute: $WORKTREE_DIR/{generated_kernel})
+    Read and follow codegen/agents/quasar/llk-kernel-writer.md to generate this run's kernel.
 
-    You are running inside cycle ${CYCLE} of a max-3 writer-tester loop. If your
-    compile check fails, report FAILED and return — do NOT iterate internally.
-    The orchestrator will route the failure to the refiner, which will update
-    the analysis in place before the next cycle retries.
+    You are running inside cycle ${CYCLE} of a max-3 writer-tester loop.
 
-    If a prior refinement occurred (cycle > 1), the analysis at
-    codegen/artifacts/{op}_analysis.md has been rewritten in place and a
-    "Refinement History" section at the top lists what changed. Follow the
-    refined analysis; do not reintroduce approaches from the prior failed
-    attempt (archived under codegen/artifacts/{op}_failed_attempt_v*/).
-
-    WORKTREE_DIR: {WORKTREE_DIR} — cd into {WORKTREE_DIR}/tt_metal/tt-llk before any
-    file I/O. All paths in this prompt resolve there, not in the source branch.
-    Never write outside the worktree.
-    LOG_DIR: {LOG_DIR}
+    If a prior refinement occurred (cycle > 1), the analysis has been rewritten
+    in place and a "Refinement History" section at the top lists what changed.
+    Follow the refined analysis; do not reintroduce approaches from the prior
+    failed attempt (archived under codegen/artifacts/${KERNEL_NAME}_failed_attempt_v$((CYCLE - 1)).md).
 ```
 
-Wait for completion. The writer returns `PASSED` / `FAILED` on its final compile check.
+- Now WAIT for AGENT completion!
+- THEN writer returns `PASSED` / `FAILED` on its final compile check.
 
-**Metrics**: Increment `COMPILATION_ATTEMPTS` and `PHASE_COMPILES` by the number of compiles the writer ran (typically 2: scaffold + final). Append any compile-error messages to `PHASE_COMPILE_ERRORS_JSON`.
+**If writer reports PASSED**: go to Step 5b.
 
-**If writer reports PASSED**: go to Step 2b.
-
-**If writer reports FAILED** (compile broken):
+**If writer reports FAILED** (compile broken): pass two args — the first
+meaningful line from the writer's "Error summary", and how many compiles it
+ran (`2` if "Scaffold compiled: PASSED" and "Final compiled: FAILED"; `1` if
+the scaffold compile itself failed). The step records the error, updates the
+compile counters, writes the failure + phase-end, and refreshes cost:
 ```bash
-python codegen/scripts/run_json_writer.py failure \
-    --log-dir "$LOG_DIR" \
-    --step "writer_cycle_${CYCLE}" \
-    --agent "writer" \
-    --type "compile_error" \
-    --message "${FIRST_COMPILE_ERROR_LINE}" \
-    --resolved "false"
-
-python codegen/scripts/run_json_writer.py phase-end \
-    --log-dir "$LOG_DIR" \
-    --phase "${CYCLE}" \
-    --test-result "failed" \
-    --compilation-attempts "${PHASE_COMPILES}" \
-    --debug-cycles 0 \
-    --test-details "writer compile failed: ${FIRST_COMPILE_ERROR_LINE}" \
-    --compile-errors-json "${PHASE_COMPILE_ERRORS_JSON}"
-
-bash codegen/scripts/refresh_cost.sh
+source codegen/scripts/quasar/orchestrator_steps.sh
+execute_step_writer_failed "{first meaningful line from the writer's Error summary}" {2 or 1}
 ```
 
-If `CYCLE == MAX_CYCLES` (3): jump to Step 5 with `status=failed`, `final-result=compile_error`.
-Otherwise: go to Step 2c (refiner).
-
-### Step 2b: Tester
-
-**LIVE LOG — advance to tester:**
+If the step printed `AT_CAP=yes` (cycle 3): EXECUTE the following, then jump to Step 8:
 ```bash
-python codegen/scripts/run_json_writer.py advance \
-    --log-dir "$LOG_DIR" \
-    --new-step "tester" \
-    --new-message "Cycle ${CYCLE} — writing/running tests (internal 5-attempt loop)" \
-    --prev-result "success" \
-    --prev-message "Cycle ${CYCLE} writer compiled" \
-    --agent "tester"
+source codegen/scripts/quasar/orchestrator_steps.sh
+execute_step_mark_status failed compile_error
+```
+Otherwise (`AT_CAP=no`): go to Step 5c (refiner).
 
-python codegen/scripts/run_json_writer.py phase-test \
-    --log-dir "$LOG_DIR" \
-    --phase "${CYCLE}" \
-    --state "running"
+### Step 5b: Tester
+
+EXECUTE the following (advance to the tester, mark the phase running):
+```bash
+source codegen/scripts/quasar/orchestrator_steps.sh
+execute_step_tester_advance
 ```
 
 Spawn the tester:
 ```
 Agent tool:
   subagent_type: "general-purpose"
-  description: "Test {op} (cycle ${CYCLE})"
+  description: "Test kernel (cycle ${CYCLE})"
   prompt: |
-    Read and follow codegen/agents/quasar/llk-tester.md to validate the "{op}" kernel.
-    Kernel: {op}
-    Kernel type: {kernel_type}
-    Target architecture: {target_arch}
-    Kernel path: {generated_kernel} (absolute: $WORKTREE_DIR/{generated_kernel})
-    Flow: new-kernel
-    Spec: codegen/artifacts/{op}_analysis.md
-    Cycle: ${CYCLE}
+    Read and follow codegen/agents/quasar/llk-tester.md to validate this run's kernel.
 
     You own the full test-and-fix loop with a hard cap of 5 simulator test runs
     (compile-time failures are excluded from the cap). Each run = compile-producer
     + simulator-consumer. Diagnose and fix between runs. On attempt 5's failure,
     return STUCK — the orchestrator will route to the refiner.
-
-    WORKTREE_DIR: {WORKTREE_DIR} — cd into {WORKTREE_DIR}/tt_metal/tt-llk before any file I/O.
-    LOG_DIR: {LOG_DIR}
 ```
 
-Wait for the tester to return `PASS`, `STUCK`, or `ENV_ERROR`.
+- WAIT for the Tester finish and return `PASS`, `STUCK`, or `ENV_ERROR`.
 
-**Metrics from the tester's report** (the agent reports attempts used, variants, formats tested, test files created):
-- `COMPILATION_ATTEMPTS += tester_compile_count`
-- `PHASE_COMPILES += tester_compile_count`
-- `PHASE_DEBUGS = tester_attempts_used` (the tester's 5-attempt loop is effectively the per-cycle debug count)
-- `TESTS_TOTAL = variants_reported`
-- `TESTS_PASSED = variants_passed_on_final_run`
-- `TESTS_GENERATED = true` (set once, stays true)
-- `FORMATS_TESTED_JSON` — set from the tester's report
-- `FORMATS_EXCLUDED_JSON` — set from the tester's report
-
-**If tester reports PASS**:
+**If tester reports PASS**: EXECUTE the following. The step folds the tester's
+compiles into the counters, writes phase-end, sets `STATUS`/`FINAL_RESULT` (and
+`PHASES_COMPLETED=1`), and refreshes cost:
 ```bash
-python codegen/scripts/run_json_writer.py phase-end \
-    --log-dir "$LOG_DIR" \
-    --phase "${CYCLE}" \
-    --test-result "passed" \
-    --compilation-attempts "${PHASE_COMPILES}" \
-    --debug-cycles "${PHASE_DEBUGS}" \
-    --test-details "${TESTS_PASSED}/${TESTS_TOTAL} variants passed" \
-    --compile-errors-json "${PHASE_COMPILE_ERRORS_JSON}"
-
-bash codegen/scripts/refresh_cost.sh
+source codegen/scripts/quasar/orchestrator_steps.sh
+execute_step_tester_passed
 ```
-`PHASES_COMPLETED=1`. Break out of the cycle loop → Step 3 (optimizer).
+Break out of the cycle loop → Step 6 (optimizer).
 
-**If tester reports STUCK**:
+**If tester reports STUCK**: pass the tester's last failure signature. The step
+records it, folds in the tester's compiles, and writes the failure + phase-end:
 ```bash
-python codegen/scripts/run_json_writer.py failure \
-    --log-dir "$LOG_DIR" \
-    --step "tester_cycle_${CYCLE}" \
-    --agent "tester" \
-    --type "test_failure" \
-    --message "${TESTER_LAST_FAILURE_LINE}" \
-    --resolved "false"
-
-python codegen/scripts/run_json_writer.py phase-end \
-    --log-dir "$LOG_DIR" \
-    --phase "${CYCLE}" \
-    --test-result "failed" \
-    --compilation-attempts "${PHASE_COMPILES}" \
-    --debug-cycles "${PHASE_DEBUGS}" \
-    --test-details "tester STUCK after 5 attempts: ${TESTER_LAST_FAILURE_LINE}" \
-    --compile-errors-json "${PHASE_COMPILE_ERRORS_JSON}"
-
-bash codegen/scripts/refresh_cost.sh
+source codegen/scripts/quasar/orchestrator_steps.sh
+execute_step_tester_stuck "{tester's Last failure signature}"
 ```
 
-If `CYCLE == MAX_CYCLES` (3): jump to Step 5 with `status=failed`, `final-result=test_failure`.
-Otherwise: go to Step 2c (refiner).
-
-**If tester reports ENV_ERROR** (infrastructure broken — simulator down, flock timeout, missing venv; the kernel is not implicated):
+If the step printed `AT_CAP=yes` (cycle 3): EXECUTE the following, then jump to Step 8:
 ```bash
-python codegen/scripts/run_json_writer.py failure \
-    --log-dir "$LOG_DIR" \
-    --step "tester_cycle_${CYCLE}" \
-    --agent "tester" \
-    --type "infra_error" \
-    --message "${TESTER_ENV_DIAGNOSIS}" \
-    --resolved "false"
-
-python codegen/scripts/run_json_writer.py phase-end \
-    --log-dir "$LOG_DIR" \
-    --phase "${CYCLE}" \
-    --test-result "failed" \
-    --compilation-attempts "${PHASE_COMPILES}" \
-    --debug-cycles "${PHASE_DEBUGS}" \
-    --test-details "ENV_ERROR: ${TESTER_ENV_DIAGNOSIS}" \
-    --compile-errors-json "${PHASE_COMPILE_ERRORS_JSON}"
-
-bash codegen/scripts/refresh_cost.sh
+source codegen/scripts/quasar/orchestrator_steps.sh
+execute_step_mark_status compiled test_failure
 ```
-Set `OBSTACLE` to the tester's diagnosis and jump to Step 5 with `status=failed`, `final-result=test_failure` (finalize only accepts success/compile_error/test_failure; the `infra_error` failure entry plus `obstacle` carry the real cause). Do **not** invoke the refiner — refinement cannot fix a broken environment, and burning a cycle on it just wastes the cap.
+Otherwise (`AT_CAP=no`): go to Step 5c (refiner).
 
-### Step 2c: Refiner (only for CYCLE ∈ {1, 2})
-
-**LIVE LOG — advance to refiner:**
+**If tester reports ENV_ERROR** (infrastructure broken — simulator down, flock
+timeout, missing venv; the kernel is not implicated): pass the tester's
+diagnosis line. The step records it as the `OBSTACLE`, writes the infra failure
++ phase-end, and sets the terminal `compiled`/`test_failure` state itself:
 ```bash
-python codegen/scripts/run_json_writer.py advance \
-    --log-dir "$LOG_DIR" \
-    --new-step "refiner" \
-    --new-message "Cycle ${CYCLE} failed — refining analysis (v${CYCLE})" \
-    --prev-result "${PREV_RESULT}" \
-    --prev-message "Cycle ${CYCLE} failed: ${FAILURE_SUMMARY}" \
-    --agent "refiner"
+source codegen/scripts/quasar/orchestrator_steps.sh
+execute_step_tester_env_error "{tester's Diagnosis line}"
 ```
-(`PREV_RESULT` is `compile_error` if the writer failed, `test_failure` if the tester failed.)
+Jump to Step 8. Do **NOT** invoke the refiner.
 
-Collect inputs for the refiner. The test files the tester used must be passed verbatim so the refiner can archive them. SFPU ops are appended to a unified test (resolved by category from the analysis); non-SFPU kernels still use per-op files:
+### Step 5c: Refiner (only for CYCLE ∈ {1, 2})
+
+**Advance to refiner:** pass a short summary of why the cycle failed (the
+compile error line, or the tester's last failure signature):
 ```bash
-TEST_FILES=""
-add_if_exists() { for f in "$@"; do [ -f "$f" ] && TEST_FILES="$TEST_FILES $f"; done; }
-
-if [ "{kernel_type}" = "sfpu" ]; then
-    # Category written by the analyzer in the `## SFPU Category` section.
-    SFPU_CATEGORY=$(awk '/^## SFPU Category/{f=1;next} f&&/^## /{exit} f' \
-        codegen/artifacts/{op}_analysis.md 2>/dev/null | grep -oiE 'unary|binary|ternary' | head -1)
-    case "$SFPU_CATEGORY" in
-        binary)  add_if_exists "tests/sources/{target_arch}/eltwise_binary_sfpu_{target_arch}_test.cpp" \
-                                "tests/python_tests/{target_arch}/test_eltwise_binary_sfpu_{target_arch}.py" ;;
-        ternary) add_if_exists "tests/sources/{target_arch}/sfpu_where_{target_arch}_test.cpp" \
-                                "tests/python_tests/{target_arch}/test_sfpu_where_{target_arch}.py" ;;
-        *)       add_if_exists "tests/sources/{target_arch}/eltwise_unary_sfpu_{target_arch}_test.cpp" \
-                                "tests/python_tests/{target_arch}/test_eltwise_unary_sfpu_{target_arch}.py" ;;  # default: unary
-    esac
-    # The tester registers the op in the shared dispatcher header — archive it too.
-    add_if_exists "tests/helpers/include/sfpu_operations_{target_arch}.h"
-else
-    add_if_exists "tests/sources/{target_arch}/{op}_{target_arch}_test.cpp" \
-                  "tests/python_tests/{target_arch}/test_{op}_{target_arch}.py"
-fi
+source codegen/scripts/quasar/orchestrator_steps.sh
+execute_step_refiner_advance "{failure summary of the failed cycle}"
 ```
 
 Spawn the refiner:
 ```
 Agent tool:
   subagent_type: "general-purpose"
-  description: "Refine {op} analysis (v${CYCLE})"
+  description: "Refine analysis (v${CYCLE})"
   prompt: |
-    Read and follow codegen/agents/quasar/llk-analysis-refiner.md to refine the "{op}" analysis.
-    Kernel: {op}
-    Kernel type: {kernel_type}
-    Target architecture: {target_arch}
-    Kernel path: {generated_kernel} (absolute: $WORKTREE_DIR/{generated_kernel})
-    Original analysis: codegen/artifacts/{op}_analysis.md
-    Tester log: {LOG_DIR}/agent_tester_cycle${CYCLE}.md
-    Writer log: {LOG_DIR}/agent_writer_cycle${CYCLE}.md
-    Raw test output: {LOG_DIR}/test_logs_cycle${CYCLE}/ (compile.log, run.log — full untruncated pytest stream)
-    Test files: ${TEST_FILES}
-    Previous failure: ${FAILURE_SUMMARY}
+    Read and follow codegen/agents/quasar/llk-analysis-refiner.md to refine this run's analysis.
 
     You are refinement iteration v${CYCLE}. Your own doc caps you at v2.
+    Previous failure: {failure summary of the failed cycle}
+
     Archive the failed attempt, identify the structural error in the analysis,
     rewrite the impeached sections in place, and return REFINED or ESCALATE.
-
-    WORKTREE_DIR: {WORKTREE_DIR} — cd into {WORKTREE_DIR}/tt_metal/tt-llk before any file I/O.
-    LOG_DIR: {LOG_DIR}
 ```
 
 Wait for the refiner to return `REFINED` or `ESCALATE`.
 
-**Metrics**:
-- `REFINEMENT_COUNT += 1`
-- `DEBUG_CYCLES = REFINEMENT_COUNT`
-- `PHASES_TOTAL = CYCLE + 1` (we now know another cycle will run)
-
-Patch `phases_total` so the dashboard shows the correct total:
+EXECUTE the following (bump refinement/debug/phase counters and patch run.json):
 ```bash
-python codegen/scripts/run_json_writer.py metric \
-    --log-dir "$LOG_DIR" \
-    --patch-json "{\"phases_total\": ${PHASES_TOTAL}, \"debug_cycles\": ${DEBUG_CYCLES}}"
+source codegen/scripts/quasar/orchestrator_steps.sh
+execute_step_refiner_bump
 ```
 
-**If refiner reports ESCALATE**:
+**If refiner reports ESCALATE**: pass why it escalated. The step writes the
+failure and sets the terminal `STATUS`/`FINAL_RESULT` (derived from the prior
+failure kind):
 ```bash
-python codegen/scripts/run_json_writer.py failure \
-    --log-dir "$LOG_DIR" \
-    --step "refiner_v${CYCLE}" \
-    --agent "refiner" \
-    --type "agent_error" \
-    --message "refiner escalated: ${REFINER_REASON}" \
-    --resolved "false"
+source codegen/scripts/quasar/orchestrator_steps.sh
+execute_step_refiner_escalate "{why the refiner escalated}"
 ```
-Jump to Step 5 with `status=failed`, `final-result=${PREV_RESULT}`.
+Jump to Step 8.
 
-**If refiner reports REFINED**:
+**If refiner reports REFINED**: EXECUTE the following (increment the cycle,
+advance back to the writer, phase-start the new cycle):
 ```bash
-CYCLE=$((CYCLE + 1))
-
-python codegen/scripts/run_json_writer.py advance \
-    --log-dir "$LOG_DIR" \
-    --new-step "writer" \
-    --new-message "Cycle ${CYCLE} — writing kernel from refined analysis" \
-    --prev-result "success" \
-    --prev-message "Refinement v$((CYCLE - 1)) complete — analysis rewritten in place" \
-    --agent "writer"
-
-python codegen/scripts/run_json_writer.py phase-start \
-    --log-dir "$LOG_DIR" \
-    --phase "${CYCLE}" \
-    --name "cycle ${CYCLE} (after refinement v$((CYCLE - 1)))"
+source codegen/scripts/quasar/orchestrator_steps.sh
+execute_step_refiner_refined
 ```
 
-Loop back to Step 2a.
+Loop back to Step 5a.
 
 ---
 
-## Step 3: Optimizer (success path only)
+## Step 6: Optimizer (success path only)
 
 Only run after a cycle returned `PASS`. Skip if the tester never passed.
 
-### Step 3a: Decide which optimization mode applies
-
-**If `SFPI_MODE=true` and the kernel is SFPU** → run the optimizer in **SFPI Conversion Mode** (Step 3b with `SFPI_MODE=true`), regardless of whether the reference uses replay buffers. The user explicitly opted into the SFPI rewrite and opted out of replay; do **not** run the replay applicability check below and do **not** apply replay. Skip to Step 3b.
-
-Otherwise (default → **Replay Mode**): only SFPU kernels whose Blackhole reference uses replay buffers are candidates:
-
-```bash
-REPLAY_USES=$(grep -c "replay\|load_replay_buf" "tt_llk_{ref_arch}/{kernel_path}" || echo 0)
-```
-
-If `REPLAY_USES == 0` or the kernel is not SFPU: set `OPTIMIZED=false`, `OPTIMIZATION_TYPE=none`, and skip to Step 4 (format). Do **not** advance to the optimizer step — the run stays on `tester` until format/finalize.
-
-### Step 3b: Run the optimizer
+### Step 6a: Run the optimizer
 
 Snapshot the pre-optimization kernel (for comparison / rollback reporting):
 ```bash
-cp "$WORKTREE_DIR/{generated_kernel}" "$LOG_DIR/pre_opt_$(basename {generated_kernel})"
+source codegen/scripts/quasar/orchestrator_steps.sh
+execute_step_optimizer_snapshot
 ```
 
-**LIVE LOG — advance to optimizer:**
+**LIVE LOG — advance to optimizer** (message picks SFPI vs replay-buffer by `SFPI_MODE`):
 ```bash
-OPT_MSG=$([ "$SFPI_MODE" = "true" ] \
-    && echo "Reimplementing {op} in SFPI and comparing instruction count vs the TTI baseline" \
-    || echo "Applying replay-buffer optimization to {op}")
-python codegen/scripts/run_json_writer.py advance \
-    --log-dir "$LOG_DIR" \
-    --new-step "optimizer" \
-    --new-message "$OPT_MSG" \
-    --prev-result "success" \
-    --prev-message "Cycle ${CYCLE} passed — entering optimization" \
-    --agent "optimizer"
+source codegen/scripts/quasar/orchestrator_steps.sh
+execute_step_optimizer_advance
 ```
 
-For SFPI mode the optimizer needs the unified test file/source for its count-compiles. Resolve them by SFPU category (same resolution as Step 4 / refiner): `{TEST_FILE}` is the unified Python test (e.g. `test_eltwise_unary_sfpu_quasar.py`) and `{TEST_CPP}` its C++ sibling (e.g. `eltwise_unary_sfpu_quasar_test.cpp`).
-
-Spawn the optimizer (the prompt differs by mode — send the SFPI block when `SFPI_MODE=true`, else the replay block):
-
-**Replay Mode prompt:**
+Start the Optimizer agent:
 ```
 Agent tool:
   subagent_type: "general-purpose"
-  description: "Optimize {op}"
+  description: "Optimize kernel"
   prompt: |
-    Read and follow codegen/agents/quasar/llk-optimizer.md to optimize the "{op}" kernel.
-    SFPI_MODE: false
-    Kernel path: {generated_kernel} (absolute: $WORKTREE_DIR/{generated_kernel})
-    Reference path: tt_llk_{ref_arch}/{kernel_path}
-    Analysis: codegen/artifacts/{op}_analysis.md
-    Kernel type: {kernel_type}
-    Target architecture: {target_arch}
+    Read and follow codegen/agents/quasar/llk-optimizer.md to optimize this run's kernel.
 
     The kernel already compiles and passes all tests. Optimize with replay
-    buffers without breaking correctness. If optimization fails, revert to the
-    pre-optimization version.
-
-    WORKTREE_DIR: {WORKTREE_DIR} — cd into {WORKTREE_DIR}/tt_metal/tt-llk before any file I/O.
-    LOG_DIR: {LOG_DIR}
+    buffers or sfpi code without breaking correctness. If optimization fails, revert to the pre-optimization version.
 ```
 
-**SFPI Mode prompt (`SFPI_MODE=true`):**
+Wait for AGENTS completion.
+
+THEN EXECUTE (capture optimizer spend):
+```bash
+source codegen/scripts/quasar/orchestrator_steps.sh
+execute_step_refresh_cost
+```
+
+---
+
+## Step 7: Format Generated Code
+
+**Advance to format:** EXECUTE the following:
+```bash
+source codegen/scripts/quasar/orchestrator_steps.sh
+execute_step_format_advance
+```
+
+Spawn the prettifier:
 ```
 Agent tool:
   subagent_type: "general-purpose"
-  description: "SFPI-optimize {op}"
+  description: "Prettify kernel"
   prompt: |
-    Read and follow codegen/agents/quasar/llk-optimizer.md to optimize the "{op}" kernel.
-    SFPI_MODE: true
-    Kernel path: {generated_kernel} (absolute: $WORKTREE_DIR/{generated_kernel})
-    Reference path: tt_llk_{ref_arch}/{kernel_path}
-    Analysis: codegen/artifacts/{op}_analysis.md
-    Kernel type: {kernel_type}
-    Target architecture: {target_arch}
-    TEST_FILE: {TEST_FILE}    # unified SFPU Python test for the category
-    TEST_CPP: {TEST_CPP}      # its C++ source (for invalidating the build cache)
-
-    Run SFPI Conversion Mode: the working kernel is the raw-TTI baseline (or
-    already SFPI — handle per Step S1). Reimplement it in the sfpi:: DSL, compare
-    generated-instruction count against the TTI baseline with
-    codegen/scripts/sfpi_instr_count.py, and KEEP SFPI only if it is no worse
-    (sfpi <= tti). Verify correctness with run_test.sh. Do NOT apply replay
-    buffers. Emit the op | TTI | SFPI comparison table.
-
-    WORKTREE_DIR: {WORKTREE_DIR} — cd into {WORKTREE_DIR}/tt_metal/tt-llk before any file I/O.
-    LOG_DIR: {LOG_DIR}
+    Read and follow codegen/agents/quasar/llk-prettifier.md to refactor this
+    run's kernel for maintainability.
 ```
 
-Wait for completion. Record the outcome:
-- **Replay Mode** — applied a change (compile + tests re-verified) → `OPTIMIZED=true`, `OPTIMIZATION_TYPE=replay`; reverted → `OPTIMIZED=false`, `OPTIMIZATION_TYPE=none`.
-- **SFPI Mode** — SFPI kept (no worse than TTI, tests pass) → `OPTIMIZED=true`, `OPTIMIZATION_TYPE=sfpi`; SFPI rejected (worse instruction count, or compile/test failure) or kernel was already SFPI → `OPTIMIZED=false`, `OPTIMIZATION_TYPE=none`. Capture the `op | TTI | SFPI` table from the optimizer's report and surface it in the final report (Step 5).
-
-```bash
-bash codegen/scripts/refresh_cost.sh   # capture optimizer spend
-```
+Wait for completion.
 
 ---
 
-## Step 4: Format Generated Code
+## Step 8: Finalize and Report
 
-Run the repo's pre-commit formatters on all generated files so they match CI.
-**Not optional** — generated code must pass pre-commit checks before reporting completion.
-
-**LIVE LOG — advance to format:**
-```bash
-python codegen/scripts/run_json_writer.py advance \
-    --log-dir "$LOG_DIR" \
-    --new-step "format" \
-    --new-message "Running pre-commit formatters on generated files" \
-    --prev-result "success" \
-    --prev-message "Optimization complete (optimized=${OPTIMIZED})" \
-    --agent "format"
-```
+### 8a: Gather final metrics
 
 ```bash
-source tests/.venv/bin/activate 2>/dev/null || true
-
-# Format the kernel plus the test files the run touched. SFPU ops live in a
-# unified test (resolved by category from the analysis) + the shared dispatcher
-# header; non-SFPU kernels use per-op files. Formatting the whole unified file is
-# safe — pre-commit is idempotent and only rewrites what actually changed.
-FILES="$WORKTREE_DIR/{generated_kernel}"
-add_if_exists() { for f in "$@"; do [ -f "$f" ] && FILES="$FILES $f"; done; }
-
-if [ "{kernel_type}" = "sfpu" ]; then
-    SFPU_CATEGORY=$(awk '/^## SFPU Category/{f=1;next} f&&/^## /{exit} f' \
-        codegen/artifacts/{op}_analysis.md 2>/dev/null | grep -oiE 'unary|binary|ternary' | head -1)
-    case "$SFPU_CATEGORY" in
-        binary)  add_if_exists "tests/sources/{target_arch}/eltwise_binary_sfpu_{target_arch}_test.cpp" \
-                                "tests/python_tests/{target_arch}/test_eltwise_binary_sfpu_{target_arch}.py" ;;
-        ternary) add_if_exists "tests/sources/{target_arch}/sfpu_where_{target_arch}_test.cpp" \
-                                "tests/python_tests/{target_arch}/test_sfpu_where_{target_arch}.py" ;;
-        *)       add_if_exists "tests/sources/{target_arch}/eltwise_unary_sfpu_{target_arch}_test.cpp" \
-                                "tests/python_tests/{target_arch}/test_eltwise_unary_sfpu_{target_arch}.py" ;;
-    esac
-    add_if_exists "tests/helpers/include/sfpu_operations_{target_arch}.h"
-else
-    add_if_exists "tests/sources/{target_arch}/{op}_{target_arch}_test.cpp" \
-                  "tests/python_tests/{target_arch}/test_{op}_{target_arch}.py"
-fi
-
-# Run pre-commit twice — some hooks need a second pass (e.g. trailing-whitespace after clang-format)
-pre-commit run --files $FILES || true
-pre-commit run --files $FILES || true
-
-bash codegen/scripts/refresh_cost.sh   # capture format spend
+source codegen/scripts/quasar/orchestrator_steps.sh
+execute_step_gather_metrics
 ```
 
-Verify compilation still passes after formatting. If the formatter broke the
-build (rare — usually a clang-format line-break edge case), inspect the diff
-and manually fix. Do NOT revert the formatting. If a manual fix is required,
-record a failure with `step=format`, `type=compile_error`.
-
-Set `FORMATTED=true` in the finalize patch.
-
----
-
-## Step 5: Finalize and Report
-
-### 5a: Gather final metrics
+### 8b: Finalize run.json
 
 ```bash
-export END_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-export LINES_GENERATED=$(wc -l < "$WORKTREE_DIR/{generated_kernel}")
+source codegen/scripts/quasar/orchestrator_steps.sh
+execute_step_finalize_run
 ```
 
-Determine the terminal status:
-- `success` — cycle passed AND `TESTS_PASSED == TESTS_TOTAL` AND `TESTS_TOTAL > 0`
-- `compiled` — writer compiled but tests failed, were skipped, or unavailable
-- `failed` — never compiled, or all 3 cycles exhausted, or refiner escalated
+The step re-reads every tracked value from state, calls `run_json_writer.py
+finalize`, does the final authoritative cost refresh, and appends the run's
+`run.json` to `runs.jsonl`.
 
-### 5b: Finalize run.json
+### 8c: Copy artifacts into LOG_DIR
+
+Each run must be self-contained under `$LOG_DIR`. Simulator logs must be
+copied before `cleanup_worktree` runs or they are gone permanently — copy
+them as-is:
 
 ```bash
-python codegen/scripts/run_json_writer.py finalize \
-    --log-dir "$LOG_DIR" \
-    --end-time "$END_TIME" \
-    --status "$STATUS" \
-    --final-result "$FINAL_RESULT" \
-    --final-message "Run complete — {op} on {target_arch} (${CYCLE}/${MAX_CYCLES} cycles)" \
-    --patch-json "$(python - <<'PY'
-import json, os
-patch = {
-    "phases_total": int(os.environ["PHASES_TOTAL"]),
-    "phases_completed": int(os.environ["PHASES_COMPLETED"]),
-    "compilation_attempts": int(os.environ["COMPILATION_ATTEMPTS"]),
-    "debug_cycles": int(os.environ["DEBUG_CYCLES"]),
-    "tests_total": int(os.environ["TESTS_TOTAL"]),
-    "tests_passed": int(os.environ["TESTS_PASSED"]),
-    "lines_generated": int(os.environ["LINES_GENERATED"]),
-    "tests_generated": os.environ["TESTS_GENERATED"].lower() == "true",
-    "prettified": False,
-    "formatted": True,
-    "optimized": os.environ.get("OPTIMIZED", "false").lower() == "true",
-    "optimization_type": os.environ.get("OPTIMIZATION_TYPE", "none"),
-    "formats_tested": json.loads(os.environ.get("FORMATS_TESTED_JSON", "[]")),
-    "formats_excluded": json.loads(os.environ.get("FORMATS_EXCLUDED_JSON", "{}")),
-    "obstacle": os.environ.get("OBSTACLE") or None,
-    # Derive agents from steps_completed in run.json — AGENTS_JSON env var is unreliable
-    # across Bash tool calls (each call runs in a fresh shell, so exported vars reset).
-    # steps_completed is written atomically by run_json_writer.py and is always current.
-    "agents": json.loads(open(os.environ["LOG_DIR"] + "/run.json").read()).get("steps_completed", []),
-    "tokens": json.loads(os.environ.get("TOKENS_JSON", "{\"input\":0,\"output\":0,\"cache_read\":0,\"cache_creation\":0,\"total\":0}")),
-    "refinement_count": int(os.environ.get("REFINEMENT_COUNT", "0")),
-    "cycles_attempted": int(os.environ.get("CYCLE", "1")),
-    "cycles_cap": int(os.environ.get("MAX_CYCLES", "3")),
-    # Base commit the worktree branch was cut from (origin/main at Step 0). The
-    # `generated.patch` archived in Step 5d applies cleanly on top of this commit.
-    "base_commit": os.environ.get("GIT_COMMIT", "unknown"),
-    "artifact_patch": "generated.patch",
-}
-print(json.dumps(patch))
-PY
-)"
+source codegen/scripts/quasar/orchestrator_steps.sh
+execute_step_copy_sim_logs
 ```
 
-The finalize call closes the last `step_history` entry, flips `status` from
-`"running"` to its terminal value, sets `end_time`, and merges the summary
-fields. The run.json on disk is now the authoritative record.
+Everything else this run created or modified — the generated kernel, the
+reference kernel, analysis/refinement artifacts, and test files — is captured
+by the `generated.patch` git diff below. Do **not** also snapshot them
+individually: enumerating expected filenames misses anything the run touched
+that you did not predict, and copying a shared file whole (instead of
+diffing it) would clobber unrelated upstream edits on re-apply. The worktree
+is dedicated to this single run and was branched from `origin/main`, so
+*every* uncommitted change under `tt_llk_${TARGET_ARCH}/`, `tests/`, and
+`codegen/artifacts/` is, by definition, this run's output. Let git enumerate
+it:
 
 ```bash
-bash codegen/scripts/refresh_cost.sh   # final authoritative refresh — overwrites the TOKENS_JSON
-                                       # in the --patch-json above with live-measured spend
+source codegen/scripts/quasar/orchestrator_steps.sh
+execute_step_write_generated_patch
 ```
 
-For batch runs this will later be superseded when `cli_output.json` lands in
-`$LOG_DIR` and the dashboard backfills from Anthropic's cumulative
-`total_cost_usd`; for interactive runs this is the final number.
+### 8d: Extract subagent transcripts
 
-### 5c: Append a runs.jsonl entry
+EXECUTE the following:
+```bash
+source codegen/scripts/quasar/orchestrator_steps.sh
+execute_step_extract_transcripts
+```
 
-`$LOG_DIR/run.json` is the authoritative per-run record — derive the runs.jsonl
-entry from it so the two artifacts stay in sync:
+### 8e: Write and print the report
+
+The report is built from `run.json` + the agent self-logs + the transcripts (it
+aggregates each agent's Assumptions / Reasoning / tool+command summary and all
+the run metrics). EXECUTE the following — it writes
+`codegen/artifacts/{KERNEL_NAME}_report.md` and prints it:
 
 ```bash
-python -c "import json; d=json.load(open('$LOG_DIR/run.json')); print(json.dumps(d))" \
-    >> /proj_sw/user_dev/llk_code_gen/quasar/runs.jsonl
+source codegen/scripts/quasar/orchestrator_steps.sh
+execute_step_write_report
 ```
 
-Do not rebuild the entry from shell variables — that would let run.json and runs.jsonl drift.
-
-### 5d: Copy artifacts into LOG_DIR
-
-Each run must be self-contained under `$LOG_DIR`:
-
+THEN copy it into `$LOG_DIR`:
 ```bash
-cp codegen/artifacts/{op}_analysis.md       "$LOG_DIR/" 2>/dev/null || true
-cp codegen/artifacts/{op}_arch_research.md  "$LOG_DIR/" 2>/dev/null || true   # present only if analyzer produced a separate file
-cp codegen/artifacts/{op}_refinement_v*.md  "$LOG_DIR/" 2>/dev/null || true
-cp -r codegen/artifacts/{op}_failed_attempt_v*  "$LOG_DIR/" 2>/dev/null || true
-cp "$WORKTREE_DIR/{generated_kernel}"       "$LOG_DIR/"
-cp tt_llk_{ref_arch}/{kernel_path}          "$LOG_DIR/ref_$(basename tt_llk_{ref_arch}/{kernel_path})"
-
-# Test files snapshot for easy reading (silent-fail if absent). For SFPU ops the
-# unified test + dispatcher are modified in place — the patch capture below is the
-# authoritative record; these copies are just convenience reads of the relevant
-# unified file. Non-SFPU kernels use per-op files.
-if [ "{kernel_type}" = "sfpu" ]; then
-    SFPU_CATEGORY=$(awk '/^## SFPU Category/{f=1;next} f&&/^## /{exit} f' \
-        codegen/artifacts/{op}_analysis.md 2>/dev/null | grep -oiE 'unary|binary|ternary' | head -1)
-    case "$SFPU_CATEGORY" in
-        binary)  cp tests/sources/{target_arch}/eltwise_binary_sfpu_{target_arch}_test.cpp "$LOG_DIR/" 2>/dev/null || true
-                 cp tests/python_tests/{target_arch}/test_eltwise_binary_sfpu_{target_arch}.py "$LOG_DIR/" 2>/dev/null || true ;;
-        ternary) cp tests/sources/{target_arch}/sfpu_where_{target_arch}_test.cpp "$LOG_DIR/" 2>/dev/null || true
-                 cp tests/python_tests/{target_arch}/test_sfpu_where_{target_arch}.py "$LOG_DIR/" 2>/dev/null || true ;;
-        *)       cp tests/sources/{target_arch}/eltwise_unary_sfpu_{target_arch}_test.cpp "$LOG_DIR/" 2>/dev/null || true
-                 cp tests/python_tests/{target_arch}/test_eltwise_unary_sfpu_{target_arch}.py "$LOG_DIR/" 2>/dev/null || true ;;
-    esac
-    cp tests/helpers/include/sfpu_operations_{target_arch}.h "$LOG_DIR/" 2>/dev/null || true
-else
-    cp tests/sources/{target_arch}/{op}_{target_arch}_test.cpp     "$LOG_DIR/" 2>/dev/null || true
-    cp tests/python_tests/{target_arch}/test_{op}_{target_arch}.py "$LOG_DIR/" 2>/dev/null || true
-fi
-
-# Simulator logs — copy BEFORE cleanup_worktree or they are gone permanently
-cp tests/python_tests/{target_arch}/emu_*_.log      "$LOG_DIR/" 2>/dev/null || true
-cp tests/python_tests/{target_arch}/tt-exalens.log  "$LOG_DIR/" 2>/dev/null || true
-```
-
-The copies above snapshot the **new** files (kernel + tests) for easy reading,
-but they do **not** capture changes to files the run *modified in place* —
-shared helpers like `tests/python_tests/helpers/golden_generators.py`,
-`tests/python_tests/helpers/llk_params.py`, `tt_llk_{target_arch}/llk_lib/llk_defs.h`,
-the unified SFPU test files, and the `tests/helpers/include/sfpu_operations_{target_arch}.h` dispatcher.
-Copying those whole is wrong: it duplicates a large shared file and, on re-apply
-over a newer `origin/main`, would clobber unrelated upstream edits.
-
-Instead capture the **entire change set as one apply-able patch**. Do **not**
-enumerate expected filenames — that misses anything the run touched that you did
-not predict. The worktree is dedicated to this single run and was branched from
-`origin/main`, so *every* uncommitted change under `tt_llk_{target_arch}/` and
-`tests/` is, by definition, this run's output. Let git enumerate it:
-
-```bash
-# CWD is $WORKTREE_DIR/tt_metal/tt-llk.
-# `git add -AN` records intent-to-add for every NEW (untracked) file so it shows
-# in the diff as a new-file diff; modified tracked files already diff as hunks.
-# The :(exclude) pathspecs drop env junk that is untracked but not part of the
-# run's output (the venv, the SFPI toolchain, bytecode caches).
-# `git reset` reverses the intent-to-add — this only ever touches the throwaway
-# per-run worktree index (never committed, never pushed), so the
-# read-only-source-branch policy is not violated.
-# `:(top)...` anchors at the worktree (tt-metal) root regardless of CWD, so the
-# CKernels LLK API folder is captured even though it lives outside tt-llk — this
-# is where Quasar SFPU kernels are now authored. For non-SFPU runs nothing changes
-# there, so it contributes an empty diff.
-PATHSPEC="tt_llk_{target_arch} tests :(top)tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu :(exclude)tests/.venv :(exclude)tests/sfpi :(exclude)**/__pycache__/**"
-git add -AN -- $PATHSPEC 2>/dev/null || true
-git diff --binary HEAD -- $PATHSPEC > "$LOG_DIR/generated.patch"
-git reset -q -- $PATHSPEC 2>/dev/null || true
-```
-
-New files land as full `new file` diffs (there is no base to dedup against);
-modified shared files (`golden_generators.py`, `llk_params.py`, `llk_defs.h`,
-and anything else the run edited) land as **hunks only** — the precise delta to
-re-apply, never a full copy.
-
-Reapply later from the tt-metal repo root with:
-`git checkout <base_commit> && git apply <LOG_DIR>/generated.patch`
-where `<base_commit>` is the `base_commit` field written into `run.json` (Step 5b).
-
-### 5e: Verify agent logs exist
-
-The following files MUST be present in `$LOG_DIR` (write a placeholder noting
-`"Agent ran but did not produce a log"` if any expected file is missing, so
-missing logs are visible rather than silently absent):
-
-- `agent_analyzer.md` (always)
-- `agent_writer_cycle1.md` (always — cycle 1 writer)
-- `agent_writer_cycle2.md`, `agent_writer_cycle3.md` (only when those cycles ran)
-- `agent_tester_cycle1.md` (always — cycle 1 tester)
-- `agent_tester_cycle2.md`, `agent_tester_cycle3.md` (only when those cycles ran)
-- `agent_analysis_refiner_v1.md`, `agent_analysis_refiner_v2.md` (only when the refiner ran)
-- `agent_optimizer.md` (only if the optimizer was invoked)
-- `test_logs_cycle{N}/compile.log` + `run.log` (full untruncated test output — written live by `run_test.sh --log-dir`; one dir per cycle that reached the tester)
-- `test_logs_optimizer/run.log` (only if the optimizer ran tests)
-
-Each agent log MUST follow the structured template defined in the agent
-playbooks — **Assumptions**, **Reasoning summary**, **Decisions & trade-offs**,
-**Commands run**, **Artifacts read / written**, **Open questions**. If a log is
-present but the structured sections are missing, record an `agent_error`
-failure (`type: "agent_error"`, `message: "agent_<role>.md missing required
-structured sections"`, `resolved: false`) — the dashboard flags these so we can
-chase the agent that skipped its contract. Do NOT try to rewrite the log
-yourself; the agent owns its own reasoning capture.
-
-### Step 5e.1: Extract subagent transcripts
-
-Dump each subagent's raw Claude Code jsonl transcript into
-`$LOG_DIR/transcripts/` as per-agent reasoning / tools / commands markdown,
-plus an `INDEX.md` that summarizes tool counts and timing. This makes the
-model's chronological reasoning (assistant text, thinking blocks if emitted,
-tool calls, trimmed results) auditable after the run without opening raw jsonl
-files.
-
-The extractor uses the same session-discovery logic as `session_cost.py` —
-it reads `$CLAUDE_SESSION_PID` / `$PPID` to find the active session under
-`~/.claude/sessions/<pid>.json`, then walks the subagents directory.
-Non-fatal: if no session is found (e.g., running outside the claude CLI),
-the extractor logs and exits 1 without blocking the run.
-
-```bash
-source /tmp/codegen_run_state.sh 2>/dev/null || true
-python codegen/scripts/extract_run_transcripts.py --log-dir "$LOG_DIR" \
-    ${SESSION_ID:+--session-id "$SESSION_ID" --project-cwd "$PROJECT_CWD"} \
-    || echo "extract_run_transcripts: skipped (non-fatal)"
-```
-
-The extractor produces:
-
-- `$LOG_DIR/transcripts/INDEX.md` — one row per agent (type, description,
-  start/end timestamps, tool count) + per-agent links.
-- `$LOG_DIR/transcripts/NN_{slug}_reasoning.md` — full chronology:
-  assistant narration, thinking blocks (when present), every tool call with
-  its rendered input, trimmed tool result.
-- `$LOG_DIR/transcripts/NN_{slug}_tools.md` — histogram of tool calls and a
-  sequence table with sequence #, tool, target, result status, byte count.
-- `$LOG_DIR/transcripts/NN_{slug}_commands.md` — flat listings of Bash
-  commands (verbatim + description), Confluence page IDs / CQL searches,
-  DeepWiki questions, files read / written / edited, glob + grep patterns.
-
-These artifacts make the run reproducible and auditable: the commands file is
-a recipe the next engineer can replay; the reasoning file explains *why* each
-step was taken without forcing them to rerun the whole pipeline.
-
-### 5f: Write and print the report
-
-Write `codegen/artifacts/{op}_report.md` AND print it to the terminal. The
-report is a superset of what the dashboard shows — it MUST aggregate the
-agents' structured self-logs (Assumptions / Reasoning / Commands) so the
-generated file is self-contained enough that a reader never has to chase
-sibling files to understand what happened.
-
-Aggregation rules:
-
-- **Assumptions**: concatenate the `## Assumptions` section from
-  `agent_analyzer.md`, `agent_writer_cycle*.md`, and `agent_tester_cycle*.md` (plus
-  refiner / optimizer when they ran). If an agent wrote "none", skip that
-  agent's section entry. Preserve the agent-origin prefix (e.g., `[analyzer] ...`).
-- **Reasoning highlights**: first paragraph (up to 5 sentences) of each
-  agent's `## Reasoning summary` section. This is the executive summary.
-- **Commands & tools summary**: top-5 Bash commands by length (verbatim, with
-  description) from each agent's `transcripts/NN_{slug}_commands.md`, plus the
-  per-agent tool histogram from `transcripts/NN_{slug}_tools.md`. If
-  extraction failed in Step 5e.1, write "(transcript extraction skipped)"
-  under each heading instead of leaving them blank.
-- **Artifacts inventory**: every file written or modified inside the worktree
-  during the run, with its final path under `$LOG_DIR/` if copied in Step 5d.
-
-Template:
-
-```
-========================================
-  LLK CodeGen — Generation Complete
-========================================
-Prompt:           {PROMPT}
-Kernel:           {op}
-Kernel Type:      {kernel_type}
-Target Arch:      {target_arch}
-Reference:        tt_llk_{ref_arch}/{kernel_path}
-Generated File:   {generated_kernel}
-Lines Generated:  {N}
-----------------------------------------
-Timing:
-  Start:          {START_TIME}
-  End:            {END_TIME}
-  Duration:       {H}h{M}m{S}s
-----------------------------------------
-Tokens:
-  Input:          {N}
-  Output:         {N}
-  Cache Read:     {N}
-  Cache Creation: {N}
-  Total:          {N}
-  Cost:           ${X.XX} USD  (estimate; see Claude Console for billing)
-----------------------------------------
-Flow:
-  Cycles Used:       {CYCLE}/{MAX_CYCLES}
-  Refinements:       {REFINEMENT_COUNT}
-  Status:            {STATUS}
-----------------------------------------
-Quality:
-  Compile Attempts:  {COMPILATION_ATTEMPTS} (across writer + tester internal loop)
-  Compilation:       PASSED/FAILED
-  Functional Tests:  PASSED/FAILED/NOT_AVAILABLE ({TESTS_PASSED}/{TESTS_TOTAL})
-  Tests Source:      GENERATED/PRE-EXISTING/NONE
-  Formatted:         YES/NO
-  Optimized:         YES/NO ({OPTIMIZATION_TYPE})
-----------------------------------------
-SFPI vs TTI:   (include this block only when SFPI_MODE was true; copy the
-               optimizer's op | TTI | SFPI table and keep/reject verdict)
-  | op    | TTI (original) | SFPI (implementation) | kept |
-  |-------|----------------|-----------------------|------|
-  | {op}  | {TTI_COUNT}    | {SFPI_COUNT}          | SFPI \| TTI |
-----------------------------------------
-Per Cycle:
-  Cycle 1 ({name}): compiles={N}, tester_attempts={N}, result={passed/failed}
-  Cycle 2 ({name}): compiles={N}, tester_attempts={N}, result={passed/failed}
-  Cycle 3 ({name}): compiles={N}, tester_attempts={N}, result={passed/failed}
-----------------------------------------
-Failures: {total_failures} ({resolved} resolved, {unresolved} unresolved)
-  [compile_error] writer_cycle_1 (writer): unknown type 'vFloat' — RESOLVED
-  [test_failure] tester_cycle_2 (tester): mismatch at idx 42 — UNRESOLVED
-  ...
-  (omit this section if FAILURES is empty)
-----------------------------------------
-Assumptions made during the run:
-  [analyzer] Used ADDR_MOD_7 because every existing Quasar SFPU kernel does;
-             would break if the parent wrapper switches to ADDR_MOD_3.
-  [writer]   LREG1 reserved for the fill constant (lrelu convention);
-             the scaffold's LREG0 remains unused.
-  [tester]   UInt16 excluded from the test matrix; VALID_QUASAR_DEST_REG_FORMATS
-             rejects it before the kernel runs — kernel code is still correct
-             (SFPSTORE mode 6 is ISA-valid).
-  ...
-  (one line per assumption; prefix with agent origin; omit section if empty)
-----------------------------------------
-Reasoning highlights:
-  [analyzer] {first paragraph of agent_analyzer.md § Reasoning summary}
-  [writer]   {first paragraph of agent_writer_cycle{N}.md § Reasoning summary (per cycle)}
-  [tester]   {first paragraph of agent_tester_cycle{N}.md § Reasoning summary (per cycle)}
-  [refiner]  {...}  (if it ran)
-  [optimizer]{...}  (if it ran)
-----------------------------------------
-Commands & tools summary:
-  analyzer:
-    Tool histogram: Read×18, Glob×9, Bash×4, Grep×4, Write×2,
-                    mcp__atlassian__getConfluencePage×2, ...
-    Key bash:
-      - grep -n "^SFPLOADI:\|^SFPSTORE:" tt_llk_quasar/instructions/assembly.yaml
-      - (verify target instructions exist on Quasar)
-      - ...
-  writer:
-    Tool histogram: Read×12, Bash×8, Write×3, Edit×2
-    Key bash:
-      - python -m scripts.agent_tools.kernel_template fill --type sfpu --arch quasar
-      - CHIP_ARCH=quasar python scripts/compiler.py ...
-  tester:
-    Tool histogram: Bash×28, Read×14, Edit×6, Write×2
-    Key bash:
-      - bash "$WORKTREE_DIR/tt_metal/tt-llk/.claude/scripts/run_test.sh" compile --worktree "$WORKTREE_DIR/tt_metal/tt-llk" --arch quasar --test test_eltwise_unary_sfpu_quasar.py --k "gelu"
-      - bash "$WORKTREE_DIR/tt_metal/tt-llk/.claude/scripts/run_test.sh" simulate --worktree "$WORKTREE_DIR/tt_metal/tt-llk" --arch quasar --test test_eltwise_unary_sfpu_quasar.py --k "gelu" --maxfail 0
-  (full per-agent detail in {LOG_DIR}/transcripts/NN_{slug}_{tools,commands}.md)
-----------------------------------------
-Formats Tested:
-  Float16, Float16_b, Float32 (156 variants total)
-  Excluded: UInt16 (not in VALID_QUASAR_DEST_REG_FORMATS — infrastructure limit, not kernel defect)
-----------------------------------------
-Key Changes:
-  1. {generated_kernel} — NEW ({N} helpers)
-  2. {additional files touched}
-----------------------------------------
-Artifacts:
-  Analysis:
-    - codegen/artifacts/{op}_analysis.md
-    - codegen/artifacts/{op}_refinement_v*.md (if refinement occurred)
-    - codegen/artifacts/{op}_failed_attempt_v*/ (if refinement occurred)
-  Agent self-logs:
-    - {LOG_DIR}/agent_analyzer.md
-    - {LOG_DIR}/agent_writer_cycle*.md (one per cycle that ran: cycle1, cycle2, cycle3)
-    - {LOG_DIR}/agent_tester_cycle*.md (one per cycle that ran)
-    - {LOG_DIR}/agent_analysis_refiner_v*.md (if refinement occurred)
-    - {LOG_DIR}/agent_optimizer.md (if optimizer ran)
-  Subagent transcripts (raw chronology — assistant text + tool calls + results):
-    - {LOG_DIR}/transcripts/INDEX.md
-    - {LOG_DIR}/transcripts/NN_{slug}_reasoning.md  (one per agent)
-    - {LOG_DIR}/transcripts/NN_{slug}_tools.md       (one per agent)
-    - {LOG_DIR}/transcripts/NN_{slug}_commands.md    (one per agent)
-  Generated File:
-    - {generated_kernel}
-Metrics:
-  - /proj_sw/user_dev/llk_code_gen/quasar/runs.jsonl
-  - {LOG_DIR}/
-Branch:
-  - {WORKTREE_BRANCH}
-========================================
-```
-
-Copy the written report into `$LOG_DIR`:
-```bash
-cp codegen/artifacts/{op}_report.md "$LOG_DIR/"
+source codegen/scripts/quasar/orchestrator_steps.sh
+execute_step_copy_report
 ```
 
 ---
-
-## Inter-Agent Contracts
-
-| From → To | Artifact | Required Contents |
-|-----------|----------|-------------------|
-| Analyzer → Writer, Tester, Refiner | `artifacts/{op}_analysis.md` | Problem Statement, Target Pattern Survey, Available Instructions, Semantic→Instruction Mapping, Instruction Encoding Constraints, Solution Approach (§6a–§6e), Format Applicability, Complexity & Phases |
-| Writer → Tester | kernel file at `{generated_kernel}` (Quasar SFPU: `tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_{op}.h`) | File must exist and compile successfully |
-| Writer → Refiner (on compile failure) | kernel file + `$LOG_DIR/agent_writer_cycle{N}.md` + compile stderr | Refiner reads the writer log to distinguish faithful-writer-bad-plan from unfaithful-writer-OK-plan |
-| Tester → Optimizer (on PASS) | tested kernel + test files | Kernel passes every variant |
-| Tester → Refiner (on STUCK) | `$LOG_DIR/agent_tester_cycle{N}.md` (5-attempt fix log) + test files | Refiner forensically reconstructs what structural assumption in the analysis misled the writer |
-| Refiner → Writer | `artifacts/{op}_analysis.md` overwritten in place, with `Refinement History` section at the top | Writer follows the refined plan; prior attempt archived under `artifacts/{op}_failed_attempt_v*/` |
-| Optimizer → Report | optimized (or reverted) kernel file | Kernel compiles and all tests still pass |
-
----
-
-## Key Paths
-
-| Path | Purpose |
-|------|---------|
-| `tt_llk_blackhole/` | Blackhole LLK (reference architecture) |
-| `tt_llk_quasar/` | Quasar LLK (target architecture) |
-| `tt_llk_{arch}/instructions/assembly.yaml` | ISA definition (cross-check, use grep — large file) |
-| `codegen/references/common-errors.md` | Known error patterns |
-| `codegen/agents/quasar/` | All agent playbooks (co-located with this orchestrator) |
-| `.claude/skills/llk-arch-lookup/SKILL.md` | Confluence page index and arch-research protocol (invoked via `Skill: llk-arch-lookup`) |
-
-## Commands
-
-```bash
-# Compilation check (syntax/type errors)
-# -t flags generate constexpr defines (compile-time); -r flags generate RuntimeParams struct fields
-# Find correct flags from the Python test's TestConfig(templates=[...], runtimes=[...])
-# or map C++ symbols to param classes in tests/python_tests/helpers/test_variant_parameters.py
-# See codegen/agents/quasar/llk-kernel-writer.md Step 4 for the full symbol→flag mapping.
-cd codegen
-source ../tests/.venv/bin/activate
-CHIP_ARCH={target_arch} python scripts/compiler.py {path_to_test_source} \
-    -t "PARAM(...)" -r "PARAM(...)" -v
-
-# Functional tests — use .claude/scripts/run_test.sh (handles flock, venv,
-# simulator path, stale-process cleanup, and a hang watchdog). Never call
-# pytest or flock directly.
-# SFPU ops live in a unified test selected by category; {TEST_FILE} is
-# test_eltwise_unary_sfpu_quasar.py / test_eltwise_binary_sfpu_quasar.py /
-# test_sfpu_where_quasar.py, and --k "{op}" isolates the op (see llk-tester.md 2.0).
-# Non-SFPU kernels use the per-op file test_{kernel_name}_quasar.py and omit --k.
-# Count variants (determines --maxfail from the 2.1 table in llk-tester.md).
-VARIANT_COUNT=$(bash {WORKTREE_DIR}/tt_metal/tt-llk/.claude/scripts/run_test.sh count \
-    --worktree {WORKTREE_DIR}/tt_metal/tt-llk --arch quasar --test {TEST_FILE} --k "{op}")
-
-# Compile-producer step (parallel, no flock).
-bash {WORKTREE_DIR}/tt_metal/tt-llk/.claude/scripts/run_test.sh compile \
-    --worktree {WORKTREE_DIR}/tt_metal/tt-llk --arch quasar --test {TEST_FILE} --k "{op}"
-
-# Simulator-consumer step (flock-serialised per arch, blocks until done).
-# Invoke via Bash tool with timeout: 1800000 — never run_in_background.
-bash {WORKTREE_DIR}/tt_metal/tt-llk/.claude/scripts/run_test.sh simulate \
-    --worktree {WORKTREE_DIR}/tt_metal/tt-llk --arch quasar --test {TEST_FILE} --k "{op}" \
-    --maxfail 5 \
-    --log-dir "$LOG_DIR/test_logs_cycle${CYCLE}"   # --maxfail 0 for verification runs; --log-dir
-                                                   # persists the full pytest stream under LOG_DIR
-TEST_EXIT=$?
-
-# Or compile + simulate in one call:
-# exit 0=pass, 1=test fail, 2=compile fail, 3=env error, 5=hang (watchdog).
-# The script tails with a "=== RUN_LLK_TESTS_VERDICT ===" line on stderr.
-bash {WORKTREE_DIR}/tt_metal/tt-llk/.claude/scripts/run_test.sh run \
-    --worktree {WORKTREE_DIR}/tt_metal/tt-llk --arch quasar --test {TEST_FILE} --k "{op}"
-
-# List available tests
-ls ../tests/python_tests/quasar/test_*_quasar.py
-```

--- a/tt_metal/tt-llk/codegen/hooks/post_bash_hook.py
+++ b/tt_metal/tt-llk/codegen/hooks/post_bash_hook.py
@@ -20,8 +20,9 @@ Behaviour:
   run_test.sh exit 2     → compile_failures++, compile_failure_{N}.txt
   run_test.sh exit 1/3/5 → run_failures++, failed_attempt_{N}/test_run.txt
 
-LOG_DIR is read from /tmp/codegen_run_state.sh (written by the orchestrator Step 0).
-If the state file is absent or LOG_DIR does not exist, the hook exits silently.
+LOG_DIR is read from .codegen_run_state.json in the tool call's cwd (written
+by the orchestrator Step 0 via state.py). If the state file is absent or
+LOG_DIR does not exist, the hook exits silently.
 """
 
 from __future__ import annotations
@@ -38,21 +39,22 @@ from pathlib import Path
 # ---------------------------------------------------------------------------
 
 
-def _load_run_state() -> dict[str, str]:
-    state_file = Path("/tmp/codegen_run_state.sh")
+def _load_run_state(cwd: str) -> dict[str, str]:
+    if not cwd:
+        return {}
+    state_file = Path(cwd) / ".codegen_run_state.json"
     if not state_file.exists():
         return {}
-    state: dict[str, str] = {}
-    for line in state_file.read_text().splitlines():
-        m = re.match(r'^export\s+(\w+)="([^"]*)"', line)
-        if m:
-            state[m.group(1)] = m.group(2)
-    return state
+    try:
+        data = json.loads(state_file.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+    return data if isinstance(data, dict) else {}
 
 
-def _log_dir() -> Path | None:
-    state = _load_run_state()
-    raw = state.get("LOG_DIR", "").strip()
+def _log_dir(cwd: str) -> Path | None:
+    state = _load_run_state(cwd)
+    raw = str(state.get("LOG_DIR", "")).strip()
     if not raw:
         return None
     p = Path(raw)
@@ -222,7 +224,7 @@ def main() -> None:
     output = _tool_output(payload)
     exit_code = _exit_code(output)
 
-    log_dir = _log_dir()
+    log_dir = _log_dir(payload.get("cwd", ""))
     if log_dir is None:
         return  # not inside a codegen run
 

--- a/tt_metal/tt-llk/codegen/hooks/test_post_bash_hook.sh
+++ b/tt_metal/tt-llk/codegen/hooks/test_post_bash_hook.sh
@@ -23,15 +23,13 @@ setup() {
   "run_failures": 0
 }
 JSON
-    # Write state file so the hook can find LOG_DIR
-    cat > /tmp/codegen_run_state.sh <<EOF
-export LOG_DIR="$LOG_DIR"
+    cat > "$LOG_DIR/.codegen_run_state.json" <<EOF
+{"LOG_DIR": "$LOG_DIR"}
 EOF
 }
 
 teardown() {
     rm -rf "$LOG_DIR"
-    rm -f /tmp/codegen_run_state.sh
 }
 
 # Feed a JSON payload to the hook; capture stdout
@@ -65,13 +63,15 @@ assert_no_file() {
 # Wrap a command+output into the PostToolUse JSON the hook expects.
 # $1 = command, $2 = output (may include "Exit code: N")
 make_payload() {
+    local cwd="${3:-$LOG_DIR}"
     python3 -c "
 import json, sys
 print(json.dumps({
     'tool_name': 'Bash',
     'tool_input': {'command': sys.argv[1]},
     'tool_response': sys.argv[2],
-}))" "$1" "$2"
+    'cwd': sys.argv[3],
+}))" "$1" "$2" "$cwd"
 }
 
 # ── test cases ─────────────────────────────────────────────────────────────
@@ -188,7 +188,6 @@ teardown
 
 echo ""
 echo "=== no state file — hook exits silently ==="
-rm -f /tmp/codegen_run_state.sh
 LOG_DIR=$(mktemp -d)
 # Should exit 0 and produce no output
 out=$(run_hook "$(make_payload "python scripts/compiler.py foo.cpp" "Exit code: 1")")

--- a/tt_metal/tt-llk/codegen/references/state_contract.md
+++ b/tt_metal/tt-llk/codegen/references/state_contract.md
@@ -1,0 +1,41 @@
+# Quasar CodeGen — `state.py` Dependency Graph
+
+`boot` = `--worktree-dir` file · `run` = `--log-dir "$LOG_DIR"` file.
+`★` = agent must write those keys back into `run`.
+
+## Orchestrator ⇄ agents
+
+Left box into an agent = what it consumes · right box out = what it produces.
+
+```mermaid
+flowchart LR
+  ROUTER["router"] --> RB["KERNEL_NAME, TARGET_ARCH, SFPI_MODE,<br/>WORKTREE_BRANCH, LOG_DIR_BASE"] --> ORCH(["orchestrator"])
+
+  ORCH --> aI["kernel identity"] --> ANA["analyzer"] --> aO["analysis.md,<br/>error line"] --> ORCH
+  ORCH --> wI["analysis, CYCLE,<br/>GENERATED_KERNEL"] --> WR["writer"] --> wO["PASSED / FAILED,<br/>error line, compile count"] --> ORCH
+  ORCH --> tI["compiled kernel,<br/>CYCLE, LOG_DIR"] --> TST["tester ★"] --> tO["PASS / STUCK / ENV_ERROR,<br/>TESTS_TOTAL, TESTS_PASSED, TESTS_GENERATED,<br/>TESTER_COMPILE_COUNT, PHASE_DEBUGS,<br/>FORMATS_TESTED_JSON, FORMATS_EXCLUDED_JSON"] --> ORCH
+  ORCH --> rI["PREV_RESULT,<br/>failure summary, CYCLE"] --> RE["refiner"] --> rO["REFINED / ESCALATE,<br/>reason"] --> ORCH
+  ORCH --> oI["passing kernel,<br/>SFPI_MODE"] --> OP["optimizer ★"] --> oO["OPTIMIZED,<br/>OPTIMIZATION_TYPE"] --> ORCH
+  ORCH --> fI["kernel"] --> FM["format"] --> ORCH
+
+  ORCH --> FIN["finalize → run.json + runs.jsonl"]
+
+  classDef inb fill:#eef,stroke:#88a;
+  classDef outb fill:#efe,stroke:#8a8;
+  classDef star fill:#fde,stroke:#c39,stroke-width:2px;
+  class RB,aI,wI,tI,rI,oI,fI inb;
+  class aO,wO,tO,rO,oO outb;
+  class TST,OP star;
+```
+
+## Orchestrator internal state (run file, in order)
+
+```mermaid
+flowchart TB
+  A["setup_run<br/>LOG_DIR, WORKTREE_DIR, RUN_ID, START_TIME, GIT_COMMIT,<br/>CODEGEN_VERSION, PROMPT, BATCH_ID, MODEL, RUN_TYPE"]
+  B["set_kernel_identity<br/>KERNEL_TYPE, REF_ARCH, KERNEL_PATH, GENERATED_KERNEL"]
+  C["write_initial_run_json (seeds)<br/>SESSION_ID, PROJECT_CWD, CYCLE, MAX_CYCLES, REFINEMENT_COUNT,<br/>COMPILATION_ATTEMPTS, DEBUG_CYCLES, PHASES_TOTAL, PHASES_COMPLETED,<br/>LINES_GENERATED, TOKENS_JSON, OBSTACLE, +★ defaults"]
+  D["writer/tester/refiner loop<br/>PHASE_COMPILES, PHASE_COMPILE_ERRORS_JSON, PHASE_TEST_DETAILS,<br/>PREV_RESULT, STATUS, FINAL_RESULT, error/diagnosis/reason lines"]
+  E["finalize → run.json + runs.jsonl"]
+  A --> B --> C --> D --> E
+```

--- a/tt_metal/tt-llk/codegen/scripts/extract_run_transcripts.py
+++ b/tt_metal/tt-llk/codegen/scripts/extract_run_transcripts.py
@@ -37,11 +37,12 @@ produce human-readable per-agent markdown files that survive past the session:
 ``INDEX.md``   — one-line-per-agent summary with tool call counts and time
                  range, plus relative links to the three per-agent files.
 
-Session discovery mirrors ``session_cost.py``: pass ``--session-id`` +
-``--project-cwd`` explicitly, or let the script read
-``~/.claude/sessions/<pid>.json`` using ``$CLAUDE_SESSION_PID`` / ``$PPID``
-(falling back to the most-recently-started session). Run once from the
-orchestrator at the end of Step 5e; all writes are idempotent.
+Session discovery mirrors ``session_cost.py``: pass ``--session-id`` (resolved
+by globbing ``~/.claude/projects/``, falling back to ``$CLAUDE_CODE_SESSION_ID``
+when omitted), or let the script read ``~/.claude/sessions/<pid>.json`` using
+``$CLAUDE_SESSION_PID`` / ``$PPID`` (falling back to the most-recently-started
+session). Run once from the orchestrator at the end of Step 5e; all writes are
+idempotent.
 """
 
 from __future__ import annotations
@@ -65,6 +66,16 @@ def _build_paths(session_id: str, cwd: str) -> tuple[Path, Path]:
     proj_name = cwd.replace("_", "-").replace("/", "-")
     proj_dir = home / ".claude" / "projects" / proj_name
     return proj_dir / f"{session_id}.jsonl", proj_dir / session_id / "subagents"
+
+
+def _find_by_session_id(session_id: str) -> Path | None:
+    home = Path(os.path.expanduser("~"))
+    matches = sorted(
+        (home / ".claude" / "projects").glob(f"*/{session_id}.jsonl"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    return matches[0].parent / session_id / "subagents" if matches else None
 
 
 def _discover_session(preferred_pid: str | None) -> tuple[str, str] | None:
@@ -628,18 +639,21 @@ def run(
     transcripts_dir = log_dir_path / "transcripts"
     transcripts_dir.mkdir(parents=True, exist_ok=True)
 
-    if session_id and project_cwd:
-        _, subs_dir = _build_paths(session_id, project_cwd)
-    else:
-        found = _discover_session(session_pid)
-        if not found:
-            print(
-                "extract_run_transcripts: no claude session discovered via ~/.claude/sessions",
-                file=sys.stderr,
-            )
-            return 1
-        sid, cwd = found
-        _, subs_dir = _build_paths(sid, cwd)
+    sid = session_id or os.environ.get("CLAUDE_CODE_SESSION_ID")
+    subs_dir = _find_by_session_id(sid) if sid else None
+    if subs_dir is None:
+        if session_id and project_cwd:
+            _, subs_dir = _build_paths(session_id, project_cwd)
+        else:
+            found = _discover_session(session_pid)
+            if not found:
+                print(
+                    "extract_run_transcripts: no claude session discovered via ~/.claude/sessions",
+                    file=sys.stderr,
+                )
+                return 1
+            fsid, cwd = found
+            _, subs_dir = _build_paths(fsid, cwd)
 
     if not subs_dir.is_dir():
         print(
@@ -724,12 +738,12 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument(
         "--session-id",
         default=None,
-        help="Explicit session UUID (overrides PID discovery). Requires --project-cwd.",
+        help="Explicit session UUID; resolved by globbing ~/.claude/projects/ (overrides PID discovery).",
     )
     ap.add_argument(
         "--project-cwd",
         default=None,
-        help="CWD mapped under ~/.claude/projects/ (required with --session-id).",
+        help="CWD mapped under ~/.claude/projects/ (optional with --session-id).",
     )
     ap.add_argument(
         "--session-pid",

--- a/tt_metal/tt-llk/codegen/scripts/quasar/build_report.py
+++ b/tt_metal/tt-llk/codegen/scripts/quasar/build_report.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""Build the human-readable codegen run report from a run's artifacts.
+
+Everything the orchestrator used to hand-assemble for §5f is derived here:
+the fixed sections come straight from run.json; Assumptions / Reasoning are
+pulled from the per-agent self-logs (agent_*.md); the tool histogram and top
+commands come from the extracted transcripts. Writes the report to --out and
+prints it to stdout.
+
+Usage: build_report.py --log-dir <LOG_DIR> --out <path/to/report.md>
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import re
+import sys
+
+
+def _d(v) -> dict:
+    """Return v if it's a dict, else {} — run.json fields can be the wrong type."""
+    return v if isinstance(v, dict) else {}
+
+
+def _l(v) -> list:
+    return v if isinstance(v, list) else []
+
+
+def _i(v, default=0) -> int:
+    """Coerce to int; None / missing / non-numeric -> default (run.json fields
+    are frequently null before a step populates them)."""
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return default
+
+
+def _f(v, default=0.0) -> float:
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return default
+
+
+def _dur(seconds) -> str:
+    try:
+        s = int(seconds)
+    except (TypeError, ValueError):
+        return "?"
+    return f"{s // 3600}h{(s % 3600) // 60}m{s % 60}s"
+
+
+def _section(text: str, header_re: str) -> str:
+    """Return the body between a `## <header>` line and the next `## ` line."""
+    m = re.search(rf"^#{{2,3}}\s*{header_re}.*$", text, re.M | re.I)
+    if not m:
+        return ""
+    start = m.end()
+    nxt = re.search(r"^#{2,3}\s", text[start:], re.M)
+    body = text[start : start + nxt.start()] if nxt else text[start:]
+    return body.strip()
+
+
+def _agent_label(stem: str) -> str:
+    """agent_writer_cycle1 -> 'writer cycle1'; agent_analysis_refiner_v1 -> 'refiner v1'."""
+    name = stem[len("agent_") :]
+    name = name.replace("analysis_refiner", "refiner")
+    return name.replace("_", " ")
+
+
+def _first_paragraph(body: str) -> str:
+    para = body.split("\n\n", 1)[0].strip() if body else ""
+    return " ".join(para.split())
+
+
+def _collect_agent_logs(log_dir: str):
+    logs = []
+    for path in sorted(glob.glob(os.path.join(log_dir, "agent_*.md"))):
+        stem = os.path.splitext(os.path.basename(path))[0]
+        try:
+            text = open(path, encoding="utf-8", errors="replace").read()
+        except OSError:
+            continue
+        logs.append((_agent_label(stem), text))
+    return logs
+
+
+def _assumptions(logs) -> list[str]:
+    out = []
+    bullet = re.compile(r"^\s*(?:[-*]\s+|\d+\.\s+)")
+    for label, text in logs:
+        body = _section(text, r"Assumptions")
+        if not body or body.strip().lower() in {"none", "none.", "n/a"}:
+            continue
+        # Group wrapped continuation lines back into one bullet each.
+        entries: list[str] = []
+        cur = ""
+        for line in body.splitlines():
+            s = line.strip()
+            if not s:
+                continue
+            if bullet.match(line):
+                if cur:
+                    entries.append(cur)
+                cur = bullet.sub("", line).strip()
+            else:
+                cur = f"{cur} {s}".strip()
+        if cur:
+            entries.append(cur)
+        for e in entries:
+            out.append(f"  [{label}] {' '.join(e.split())}")
+    return out
+
+
+def _reasoning(logs) -> list[str]:
+    out = []
+    for label, text in logs:
+        para = _first_paragraph(_section(text, r"Reasoning summary"))
+        if para:
+            out.append(f"  [{label}] {para}")
+    return out
+
+
+def _transcripts(log_dir: str) -> list[str]:
+    tdir = os.path.join(log_dir, "transcripts")
+    if not os.path.isdir(tdir):
+        return ["  (transcript extraction skipped)"]
+    out = []
+    for tools in sorted(glob.glob(os.path.join(tdir, "*_tools.md"))):
+        base = os.path.basename(tools)[: -len("_tools.md")]
+        slug = re.sub(r"^\d+_", "", base).replace("_", " ")
+        hist = re.findall(
+            r"^\|\s*`([^`]+)`\s*\|\s*(\d+)\s*\|",
+            open(tools, errors="replace").read(),
+            re.M,
+        )
+        hist_str = ", ".join(f"{t}×{n}" for t, n in hist[:10]) or "(none)"
+        out.append(f"  {slug}:")
+        out.append(f"    Tool histogram: {hist_str}")
+        cmds_path = os.path.join(tdir, base + "_commands.md")
+        if os.path.isfile(cmds_path):
+            blocks = re.findall(
+                r"###\s*\d+\.\s*(.+?)\n+```bash\n(.*?)\n```",
+                open(cmds_path, errors="replace").read(),
+                re.S,
+            )
+            top = sorted(blocks, key=lambda b: len(b[1]), reverse=True)[:5]
+            if top:
+                out.append("    Key bash:")
+                for title, cmd in top:
+                    out.append(f"      - {cmd.strip().splitlines()[0][:200]}")
+                    out.append(f"        ({title.strip()})")
+    return out or ["  (no transcripts found)"]
+
+
+def build(d: dict, log_dir: str) -> str:
+    logs = _collect_agent_logs(log_dir)
+    tok = _d(d.get("tokens"))
+    L = []
+    A = L.append
+
+    A("========================================")
+    A("  LLK CodeGen — Generation Complete")
+    A("========================================")
+    A(f"Prompt:           {d.get('prompt', '')}")
+    A(f"Kernel:           {d.get('kernel', '')}")
+    A(f"Kernel Type:      {d.get('kernel_type', '')}")
+    A(f"Target Arch:      {d.get('arch', '')}")
+    A(f"Reference:        {d.get('reference_file', '')}")
+    A(f"Generated File:   {d.get('generated_file', '')}")
+    A(f"Lines Generated:  {_i(d.get('lines_generated'))}")
+    A("----------------------------------------")
+    A("Timing:")
+    A(f"  Start:          {d.get('start_time', '')}")
+    A(f"  End:            {d.get('end_time', '')}")
+    A(f"  Duration:       {_dur(d.get('duration_seconds'))}")
+    A("----------------------------------------")
+    A("Tokens:")
+    A(f"  Input:          {_i(tok.get('input'))}")
+    A(f"  Output:         {_i(tok.get('output'))}")
+    A(f"  Cache Read:     {_i(tok.get('cache_read'))}")
+    A(f"  Cache Creation: {_i(tok.get('cache_creation'))}")
+    A(f"  Total:          {_i(tok.get('total'))}")
+    A(
+        f"  Cost:           ${_f(d.get('cost_usd')):.2f} USD  (estimate; see Claude Console for billing)"
+    )
+    A("----------------------------------------")
+    A("Flow:")
+    A(
+        f"  Cycles Used:       {_i(d.get('cycles_attempted'), 1)}/{_i(d.get('cycles_cap'), 3)}"
+    )
+    A(f"  Refinements:       {_i(d.get('refinement_count'))}")
+    A(f"  Status:            {d.get('status', '')}")
+    A("----------------------------------------")
+    tt, tp = _i(d.get("tests_total")), _i(d.get("tests_passed"))
+    tests = "NOT_AVAILABLE" if not tt else ("PASSED" if tp == tt else "FAILED")
+    A("Quality:")
+    A(
+        f"  Compile Attempts:  {_i(d.get('compilation_attempts'))} (across writer + tester internal loop)"
+    )
+    A(
+        f"  Compilation:       {'PASSED' if d.get('status') in ('success', 'compiled') else 'FAILED'}"
+    )
+    A(f"  Functional Tests:  {tests} ({tp}/{tt})")
+    A(
+        f"  Tests Source:      {'GENERATED' if d.get('tests_generated') else 'PRE-EXISTING'}"
+    )
+    A(f"  Formatted:         {'YES' if d.get('formatted') else 'NO'}")
+    A(
+        f"  Optimized:         {'YES' if d.get('optimized') else 'NO'} ({d.get('optimization_type', 'none')})"
+    )
+    A("----------------------------------------")
+    A("Per Cycle:")
+    for ph in _l(d.get("per_phase")):
+        if not isinstance(ph, dict):
+            continue
+        A(
+            f"  Cycle {ph.get('phase')} ({ph.get('name', '')}): "
+            f"compiles={_i(ph.get('compilation_attempts'))}, "
+            f"debug_cycles={_i(ph.get('debug_cycles'))}, "
+            f"result={ph.get('test_result', '')}"
+        )
+    A("----------------------------------------")
+    failures = [f for f in _l(d.get("failures")) if isinstance(f, dict)]
+    if failures:
+        resolved = sum(1 for f in failures if f.get("resolved"))
+        A(
+            f"Failures: {len(failures)} ({resolved} resolved, {len(failures) - resolved} unresolved)"
+        )
+        for f in failures:
+            tag = "RESOLVED" if f.get("resolved") else "UNRESOLVED"
+            A(
+                f"  [{f.get('type')}] {f.get('step')} ({f.get('agent')}): {f.get('message')} — {tag}"
+            )
+        A("----------------------------------------")
+    assumptions = _assumptions(logs)
+    if assumptions:
+        A("Assumptions made during the run:")
+        L.extend(assumptions)
+        A("----------------------------------------")
+    reasoning = _reasoning(logs)
+    if reasoning:
+        A("Reasoning highlights:")
+        L.extend(reasoning)
+        A("----------------------------------------")
+    A("Commands & tools summary:")
+    L.extend(_transcripts(log_dir))
+    A("----------------------------------------")
+    ft = _l(d.get("formats_tested"))
+    fx = _d(d.get("formats_excluded"))
+    if ft or fx:
+        A("Formats Tested:")
+        A(f"  {', '.join(str(x) for x in ft) if ft else '(none recorded)'}")
+        if fx:
+            A(f"  Excluded: {', '.join(f'{k} ({v})' for k, v in fx.items())}")
+        A("----------------------------------------")
+    A("Artifacts:")
+    A(f"  Generated File: {d.get('generated_file', '')}")
+    A(f"  Metrics:        {log_dir}/  (run.json, generated.patch)")
+    A(f"  Branch:         {d.get('git_branch', '')}")
+    if d.get("obstacle"):
+        A("----------------------------------------")
+        A(f"Obstacle: {d['obstacle']}")
+    A("========================================")
+    return "\n".join(L) + "\n"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--log-dir", required=True)
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    run_json = os.path.join(args.log_dir, "run.json")
+    try:
+        with open(run_json, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError) as exc:
+        print(f"build_report: cannot read {run_json}: {exc}", file=sys.stderr)
+        return 1
+
+    report = build(data, args.log_dir)
+    os.makedirs(os.path.dirname(os.path.abspath(args.out)), exist_ok=True)
+    with open(args.out, "w", encoding="utf-8") as fh:
+        fh.write(report)
+    print(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tt_metal/tt-llk/codegen/scripts/quasar/orchestrator_steps.sh
+++ b/tt_metal/tt-llk/codegen/scripts/quasar/orchestrator_steps.sh
@@ -1,0 +1,706 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# orchestrator_steps.sh — the executable steps of the Quasar codegen orchestrator.
+#
+# Every pipeline step the orchestrator (agents/quasar/orchestrator.md) runs is a
+# function here. The playbook just sources this file and calls one function per
+# step, passing per-run values as arguments — so no bash is hand-assembled in
+# the prompt and no state is trusted to survive between Bash calls.
+#
+# Usage: run with cwd = $WORKTREE_DIR/tt_metal/tt-llk, then
+#     source codegen/scripts/quasar/orchestrator_steps.sh
+#     execute_step_writer_failed "unknown type 'vFloat'" 2
+
+# Physical scripts dir (…/codegen/scripts), resolved from this file's location
+# so python helpers are found regardless of cwd. `codegen` is a symlink in the
+# worktree; following it to the source copy is fine — same code.
+_ORCH_SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# --- env-free state/run-json helpers ---------------------------------------
+# Worktree root from cwd (cwd == <wt>/tt_metal/tt-llk). Subshell: no cwd change.
+_wt()  { ( cd ../.. && pwd ); }
+# LOG_DIR is the one bootstrap key kept in the worktree file.
+_LOG() { python "$_ORCH_SCRIPTS/state.py" --worktree-dir "$(_wt)" get LOG_DIR; }
+# Run-state accessors — `_L` is set once at the top of each function below.
+sg()   { python "$_ORCH_SCRIPTS/state.py" --log-dir "$_L" get "$1"; }
+ss()   { python "$_ORCH_SCRIPTS/state.py" --log-dir "$_L" set "$@"; }
+rj()   { local sub="$1"; shift; python "$_ORCH_SCRIPTS/run_json_writer.py" "$sub" --log-dir "$_L" "$@"; }
+# refresh_cost.sh recovers everything itself; hand it LOG_DIR to skip a lookup.
+refresh_cost() { LOG_DIR="${_L:-$(_LOG)}" bash "$_ORCH_SCRIPTS/refresh_cost.sh"; }
+
+# ===========================================================================
+# Any step — emit a mid-step progress message (does not change the step).
+# Arg: <message>.
+# ===========================================================================
+execute_step_message() {
+    local _L; _L="$(_LOG)"
+    rj message --message "$1"
+}
+
+# ===========================================================================
+# Input — validate the router's handoff. Arg: absolute worktree dir.
+# ===========================================================================
+execute_step_validate_input() {
+    local wt="$1"
+    [ -n "$wt" ] && [ -d "$wt" ] || { echo "REJECT: WORKTREE_DIR missing or not a directory: '$wt'"; return 1; }
+    cd "$wt/tt_metal/tt-llk" || { echo "REJECT: cannot cd into $wt/tt_metal/tt-llk"; return 1; }
+
+    local S="$_ORCH_SCRIPTS" kn ta sm wb ldb ok=1
+    kn="$(python "$S/state.py" --worktree-dir "$wt" get KERNEL_NAME)"
+    ta="$(python "$S/state.py" --worktree-dir "$wt" get TARGET_ARCH)"
+    sm="$(python "$S/state.py" --worktree-dir "$wt" get SFPI_MODE)"
+    wb="$(python "$S/state.py" --worktree-dir "$wt" get WORKTREE_BRANCH)"
+    ldb="$(python "$S/state.py" --worktree-dir "$wt" get LOG_DIR_BASE)"
+
+    [ -n "$kn" ] || { echo "REJECT: KERNEL_NAME is empty"; ok=0; }
+    [ "$ta" = "quasar" ] || { echo "REJECT: TARGET_ARCH must be 'quasar' (got '$ta')"; ok=0; }
+    { [ "$sm" = "true" ] || [ "$sm" = "false" ]; } || { echo "REJECT: SFPI_MODE must be exactly true/false (got '$sm')"; ok=0; }
+    [ -n "$wb" ] || { echo "REJECT: WORKTREE_BRANCH is empty"; ok=0; }
+    [ "$ldb" = "/proj_sw/user_dev/llk_code_gen" ] || { echo "REJECT: LOG_DIR_BASE must be /proj_sw/user_dev/llk_code_gen (got '$ldb')"; ok=0; }
+    [ "$ok" = 1 ] || return 1
+    echo "OK: KERNEL_NAME=$kn TARGET_ARCH=$ta SFPI_MODE=$sm WORKTREE_BRANCH=$wb LOG_DIR_BASE=$ldb"
+}
+
+# ===========================================================================
+# Step 0 — validate environment prerequisites (settings.validate()).
+# ===========================================================================
+execute_step_validate_env() {
+    ( cd "$_ORCH_SCRIPTS/../.." \
+        && PYTHONPATH=.. python -c "from codegen.config.settings import settings; issues = settings.validate(); [print(f'ISSUE: {i}') for i in issues]; exit(1) if issues else print('Environment OK')" )
+}
+
+# ===========================================================================
+# Step 0 — compute run identity + timing and seed both state files.
+# ===========================================================================
+execute_step_setup_run() {
+    local S="$_ORCH_SCRIPTS" wt
+    wt="$(_wt)"
+
+    local START_TIME KERNEL_NAME TARGET_ARCH WORKTREE_BRANCH SFPI_MODE LOG_DIR_BASE
+    local RUN_ID LOG_DIR GIT_COMMIT CODEGEN_VERSION PROMPT BATCH_ID MODEL RUN_TYPE
+    START_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    KERNEL_NAME="$(python "$S/state.py" --worktree-dir "$wt" get KERNEL_NAME)"
+    TARGET_ARCH="$(python "$S/state.py" --worktree-dir "$wt" get TARGET_ARCH)"
+    WORKTREE_BRANCH="$(python "$S/state.py" --worktree-dir "$wt" get WORKTREE_BRANCH)"
+    SFPI_MODE="$(python "$S/state.py" --worktree-dir "$wt" get SFPI_MODE)"
+    LOG_DIR_BASE="$(python "$S/state.py" --worktree-dir "$wt" get LOG_DIR_BASE)"
+    RUN_ID="$(date +%Y-%m-%d)_${KERNEL_NAME}_${TARGET_ARCH}_$(head -c 4 /dev/urandom | xxd -p)"
+    LOG_DIR="$LOG_DIR_BASE/quasar/$RUN_ID"
+    GIT_COMMIT="$(git -C "$wt" rev-parse HEAD 2>/dev/null || echo unknown)"
+    CODEGEN_VERSION="$(cat "$S/../agents/quasar/VERSION" 2>/dev/null | tr -d '[:space:]' || echo "")"
+    PROMPT="Generate ${KERNEL_NAME} for ${TARGET_ARCH}"   # the original user prompt, verbatim
+    BATCH_ID="${CODEGEN_BATCH_ID:-}"                       # empty string if not a batch run
+    MODEL="${CODEGEN_MODEL:-$(python "$S/session_cost.py" --print-model 2>/dev/null)}"
+    MODEL="${MODEL:-sonnet}"
+    RUN_TYPE="$([ -n "$BATCH_ID" ] && echo ci || echo manual)"
+    mkdir -p "$LOG_DIR/instructions"
+
+    # LOG_DIR is the bootstrap key — write it to the worktree file so every
+    # later step (and refresh_cost.sh) can recover it with no env vars.
+    python "$S/state.py" --worktree-dir "$wt" set LOG_DIR "$LOG_DIR"
+
+    # Everything else lives in the run-state file ($LOG_DIR/state.json).
+    local _L="$LOG_DIR"
+    ss WORKTREE_DIR    "$wt"
+    ss KERNEL_NAME     "$KERNEL_NAME"
+    ss TARGET_ARCH     "$TARGET_ARCH"
+    ss WORKTREE_BRANCH "$WORKTREE_BRANCH"
+    ss SFPI_MODE       "$SFPI_MODE" --json
+    ss RUN_ID          "$RUN_ID"
+    ss START_TIME      "$START_TIME"
+    ss GIT_COMMIT      "$GIT_COMMIT"
+    ss CODEGEN_VERSION "$CODEGEN_VERSION"
+    ss PROMPT          "$PROMPT"
+    ss BATCH_ID        "$BATCH_ID"
+    ss MODEL           "$MODEL"
+    ss RUN_TYPE        "$RUN_TYPE"
+    echo "LOG_DIR=$LOG_DIR RUN_ID=$RUN_ID"
+}
+
+# ===========================================================================
+# Step 1 — print candidate kernel files across arches for the agent to grep.
+# ===========================================================================
+execute_step_discover_kernels() {
+    local arch f
+    # SFPU kernels in the tt-llk library (path - arch)
+    for arch in blackhole wormhole_b0 quasar; do
+        for f in tt_llk_$arch/common/inc/sfpu/ckernel_sfpu_*.h; do
+            [ -e "$f" ] && echo "$f - $arch"
+        done
+    done
+    # hw SFPU ops (path - arch)
+    for arch in blackhole wormhole_b0 quasar; do
+        for f in ../hw/ckernels/$arch/metal/llk_api/llk_sfpu/ckernel_sfpu_*.h; do
+            [ -e "$f" ] && echo "$f - $arch"
+        done
+    done
+    # Math/Pack/Unpack kernels (path - arch)
+    for arch in blackhole wormhole_b0 quasar; do
+        for f in tt_llk_$arch/llk_lib/llk_math_*.h tt_llk_$arch/llk_lib/llk_pack*.h tt_llk_$arch/llk_lib/llk_unpack*.h; do
+            [ -e "$f" ] && echo "$f - $arch"
+        done
+    done
+}
+
+# ===========================================================================
+# Step 1 — record the chosen kernel identity + derived generated-file path.
+# Args: <kernel_type> <ref_arch> <kernel_path>
+# ===========================================================================
+execute_step_set_kernel_identity() {
+    local _L; _L="$(_LOG)"
+    local kernel_type="$1" ref_arch="$2" kernel_path="$3" kn gen
+    kn="$(sg KERNEL_NAME)"
+    ss KERNEL_TYPE "$kernel_type"
+    ss REF_ARCH    "$ref_arch"
+    ss KERNEL_PATH "$kernel_path"
+    if [ "$kernel_type" = "sfpu" ]; then
+        gen="tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_${kn}.h"
+    else
+        gen="tt_metal/tt-llk/tt_llk_quasar/${kernel_path}"
+    fi
+    ss GENERATED_KERNEL "$gen"
+    echo "KERNEL_TYPE=$kernel_type REF_ARCH=$ref_arch GENERATED_KERNEL=$gen"
+}
+
+# ===========================================================================
+# Step 2 — write the initial run.json, capture the session, seed all counters,
+#          and snapshot the agent playbooks.
+# ===========================================================================
+execute_step_write_initial_run_json() {
+    local _L; _L="$(_LOG)"
+    local S="$_ORCH_SCRIPTS" wt; wt="$(_wt)"
+
+    local PIPELINE_STEPS_JSON='[
+  {"id":"analyzer","name":"Analyze","desc":"Research arch + analyze reference, produce solution approach"},
+  {"id":"writer","name":"Write","desc":"Scaffold + fill kernel, compile-check"},
+  {"id":"tester","name":"Test","desc":"Write/extend tests, run, internal 5-attempt fix loop"},
+  {"id":"refiner","name":"Refine","desc":"Rewrite analysis after writer/tester failure (max 2 refinements)"},
+  {"id":"optimizer","name":"Optimize","desc":"Replay-buffer optimization (success only)"},
+  {"id":"format","name":"Format","desc":"Run pre-commit formatters on generated files"}
+]'
+
+    local RUN_ID START_TIME GIT_COMMIT CODEGEN_VERSION PROMPT BATCH_ID MODEL RUN_TYPE
+    local KERNEL_NAME KERNEL_TYPE TARGET_ARCH REF_ARCH KERNEL_PATH GENERATED_KERNEL
+    RUN_ID="$(sg RUN_ID)"
+    START_TIME="$(sg START_TIME)"
+    GIT_COMMIT="$(sg GIT_COMMIT)"
+    CODEGEN_VERSION="$(sg CODEGEN_VERSION)"
+    PROMPT="$(sg PROMPT)"
+    BATCH_ID="$(sg BATCH_ID)"
+    MODEL="$(sg MODEL)"
+    RUN_TYPE="$(sg RUN_TYPE)"
+    KERNEL_NAME="$(sg KERNEL_NAME)"
+    KERNEL_TYPE="$(sg KERNEL_TYPE)"
+    TARGET_ARCH="$(sg TARGET_ARCH)"
+    REF_ARCH="$(sg REF_ARCH)"
+    KERNEL_PATH="$(sg KERNEL_PATH)"
+    GENERATED_KERNEL="$(sg GENERATED_KERNEL)"
+
+    python "$S/run_json_writer.py" init \
+        --log-dir "$_L" \
+        --run-id "$RUN_ID" \
+        --kernel "$KERNEL_NAME" \
+        --kernel-type "$KERNEL_TYPE" \
+        --arch "$TARGET_ARCH" \
+        --reference-arch "$REF_ARCH" \
+        --reference-file "tt_llk_${REF_ARCH}/${KERNEL_PATH}" \
+        --generated-file "$GENERATED_KERNEL" \
+        --start-time "$START_TIME" \
+        --first-step "analyzer" \
+        --first-message "Analyzing ${REF_ARCH} reference and producing solution approach for ${KERNEL_NAME}" \
+        --prompt "$PROMPT" \
+        --batch-id "$BATCH_ID" \
+        --model "$MODEL" \
+        --run-type "$RUN_TYPE" \
+        --git-commit "$GIT_COMMIT" \
+        --version "$CODEGEN_VERSION" \
+        --phases-total 1 \
+        --pipeline-steps "$PIPELINE_STEPS_JSON"
+
+    local _SESSION_PAIR SESSION_ID PROJECT_CWD
+    _SESSION_PAIR="$(python "$S/session_cost.py" --print-session 2>/dev/null || echo "")"
+    SESSION_ID="$(echo "$_SESSION_PAIR" | awk '{print $1}')"
+    PROJECT_CWD="$(echo "$_SESSION_PAIR" | cut -d' ' -f2-)"
+    if [ -n "$SESSION_ID" ]; then
+        ss SESSION_ID  "$SESSION_ID"
+        ss PROJECT_CWD "$PROJECT_CWD"
+    fi
+
+    # Counters + soft-outcome fields, all seeded to their zero values.
+    ss CYCLE                1        --json   # current writer-tester cycle (1..3)
+    ss MAX_CYCLES           3        --json   # hard cap
+    ss REFINEMENT_COUNT     0        --json   # how many times the refiner ran
+    ss COMPILATION_ATTEMPTS 0        --json   # every compile across writer + tester loop
+    ss DEBUG_CYCLES         0        --json   # refinement iterations (== REFINEMENT_COUNT at end)
+    ss PHASES_TOTAL         1        --json   # cycles attempted; bumped to 2/3 as refinements happen
+    ss PHASES_COMPLETED     0        --json   # 1 if a cycle passed, else 0
+    ss TESTS_TOTAL          0        --json   # total test variants run in the successful cycle
+    ss TESTS_PASSED         0        --json
+    ss LINES_GENERATED      0        --json
+    ss TESTS_GENERATED      false    --json   # true if the tester created new test files
+    ss OPTIMIZED            false    --json   # true if optimizer applied a change
+    ss OPTIMIZATION_TYPE    none              # replay | sfpi | none
+    ss FORMATS_TESTED_JSON   '[]'    --json
+    ss FORMATS_EXCLUDED_JSON '{}'    --json
+    ss TOKENS_JSON '{"input":0,"output":0,"cache_read":0,"cache_creation":0,"total":0,"cost_usd":0}' --json
+    ss OBSTACLE             ""
+
+    # Agent playbook snapshot (frozen copy of what actually ran).
+    local SRC="$wt/tt_metal/tt-llk/codegen/agents/quasar"
+    cp "$SRC/llk-analyzer.md"         "$_L/instructions/"
+    cp "$SRC/llk-kernel-writer.md"    "$_L/instructions/"
+    cp "$SRC/llk-tester.md"           "$_L/instructions/"
+    cp "$SRC/llk-analysis-refiner.md" "$_L/instructions/"
+    cp "$SRC/llk-optimizer.md"        "$_L/instructions/"
+
+    refresh_cost   # capture the initial spend in run.json
+}
+
+# ===========================================================================
+# Step 4 — verify the analyzer produced a complete analysis doc. Prints
+# OK / MISSING / INCOMPLETE and returns non-zero if the doc is unusable.
+# ===========================================================================
+execute_step_verify_analysis() {
+    local _L; _L="$(_LOG)"
+    local kn f h missing=""; kn="$(sg KERNEL_NAME)"
+    f="codegen/artifacts/${kn}_analysis.md"
+    [ -f "$f" ] || { echo "MISSING: $f does not exist"; return 1; }
+    for h in "Problem Statement" "Target Pattern Survey" "Available Instructions" \
+             "Semantic.*Instruction Mapping" "Solution Approach" "Format Applicability" \
+             "Complexity & Phases"; do
+        grep -qiE "^#{1,4}.*${h}" "$f" || missing="${missing}; ${h}"
+    done
+    [ -z "$missing" ] || { echo "INCOMPLETE: $f missing sections${missing}"; return 1; }
+    echo "OK: $f has all required sections"
+}
+
+# ===========================================================================
+# Step 4 — analyzer failed. Arg: <first meaningful error line>.
+# ===========================================================================
+execute_step_analyzer_failed() {
+    local _L; _L="$(_LOG)"
+    local err="$1" kn; kn="$(sg KERNEL_NAME)"
+    ss ANALYZER_ERROR_LINE "$err"
+    rj failure --step "analyzer" --agent "analyzer" --type "agent_error" \
+        --message "$err" --resolved "false"
+    rj finalize --status "failed" --final-result "compile_error" \
+        --final-message "Analyzer failed to produce ${kn}_analysis.md"
+}
+
+# ===========================================================================
+# Step 4 — analyzer passed; advance to writer cycle 1.
+# ===========================================================================
+execute_step_analyzer_passed() {
+    local _L; _L="$(_LOG)"
+    local kn; kn="$(sg KERNEL_NAME)"
+    rj advance --new-step "writer" --new-message "Cycle 1 — writing kernel from analysis" \
+        --prev-result "success" \
+        --prev-message "Analysis complete — codegen/artifacts/${kn}_analysis.md" \
+        --agent "writer"
+    rj phase-start --phase 1 --name "cycle 1 (fresh analysis)"
+    refresh_cost   # capture analyzer spend in run.json
+}
+
+# ===========================================================================
+# Step 5a — reset per-cycle counters before spawning the writer.
+# ===========================================================================
+execute_step_writer_setup() {
+    local _L; _L="$(_LOG)"
+    ss PHASE_COMPILES           0    --json
+    ss PHASE_TEST_DETAILS        ""
+    ss PHASE_COMPILE_ERRORS_JSON '[]' --json
+    # Safe per-cycle defaults for the two values the tester subagent produces —
+    # so a tester that returns without writing them can't crash phase-end
+    # (--debug-cycles "" is an argparse int error) or the compile-count math.
+    ss PHASE_DEBUGS             0    --json
+    ss TESTER_COMPILE_COUNT     0    --json
+}
+
+# ===========================================================================
+# Step 5a — writer reported FAILED. Args: <first_compile_error_line> <compiles_this_attempt(1|2)>
+# ===========================================================================
+execute_step_writer_failed() {
+    local _L; _L="$(_LOG)"
+    local err="$1" n="$2" cycle ca pc pcej
+    cycle="$(sg CYCLE)"
+    ss FIRST_COMPILE_ERROR_LINE "$err"
+    ss COMPILES_THIS_ATTEMPT     "$n" --json
+    ss PREV_RESULT               "compile_error"
+
+    ca="$(sg COMPILATION_ATTEMPTS)"
+    pc="$(sg PHASE_COMPILES)"
+    pcej="$(sg PHASE_COMPILE_ERRORS_JSON)"
+    ca=$((ca + n))
+    pc=$((pc + n))
+    pcej="$(python -c "
+import json, sys
+errors = json.loads(sys.argv[1])
+errors.append(sys.argv[2])
+print(json.dumps(errors))
+" "$pcej" "$err")"
+    ss COMPILATION_ATTEMPTS      "$ca"   --json
+    ss PHASE_COMPILES            "$pc"   --json
+    ss PHASE_COMPILE_ERRORS_JSON "$pcej" --json
+
+    rj failure --step "writer_cycle_${cycle}" --agent "writer" --type "compile_error" \
+        --message "$err" --resolved "false"
+    rj phase-end --phase "$cycle" --test-result "failed" \
+        --compilation-attempts "$pc" --debug-cycles 0 \
+        --test-details "writer compile failed: $err" \
+        --compile-errors-json "$pcej"
+    refresh_cost
+
+    # Tell the orchestrator which branch to take (so it need not track CYCLE).
+    local mc; mc="$(sg MAX_CYCLES)"
+    if [ "$cycle" -ge "$mc" ]; then
+        echo "AT_CAP=yes (cycle ${cycle}/${mc}) — next: execute_step_mark_status failed compile_error, then Step 8"
+    else
+        echo "AT_CAP=no (cycle ${cycle}/${mc}) — next: Step 5c refiner"
+    fi
+}
+
+# ===========================================================================
+# Set the terminal STATUS/FINAL_RESULT pair. Args: <status> <final_result>
+# (e.g. failed compile_error  |  compiled test_failure)
+# ===========================================================================
+execute_step_mark_status() {
+    local _L; _L="$(_LOG)"
+    ss STATUS       "$1"
+    ss FINAL_RESULT "$2"
+}
+
+# ===========================================================================
+# Step 5b — advance to the tester.
+# ===========================================================================
+execute_step_tester_advance() {
+    local _L; _L="$(_LOG)"
+    local cycle; cycle="$(sg CYCLE)"
+    rj advance --new-step "tester" \
+        --new-message "Cycle ${cycle} — writing/running tests (internal 5-attempt loop)" \
+        --prev-result "success" --prev-message "Cycle ${cycle} writer compiled" --agent "tester"
+    rj phase-test --phase "$cycle" --state "running"
+}
+
+# ===========================================================================
+# Step 5b — tester reported PASS.
+# ===========================================================================
+execute_step_tester_passed() {
+    local _L; _L="$(_LOG)"
+    local cycle ca pc tcc pd tt tp pcej
+    cycle="$(sg CYCLE)"
+    ca="$(sg COMPILATION_ATTEMPTS)"; pc="$(sg PHASE_COMPILES)"; tcc="$(sg TESTER_COMPILE_COUNT)"
+    ca=$((ca + tcc)); pc=$((pc + tcc))
+    ss COMPILATION_ATTEMPTS "$ca" --json
+    ss PHASE_COMPILES       "$pc" --json
+
+    pd="$(sg PHASE_DEBUGS)"; tt="$(sg TESTS_TOTAL)"; tp="$(sg TESTS_PASSED)"; pcej="$(sg PHASE_COMPILE_ERRORS_JSON)"
+    rj phase-end --phase "$cycle" --test-result "passed" \
+        --compilation-attempts "$pc" --debug-cycles "$pd" \
+        --test-details "${tp}/${tt} variants passed" --compile-errors-json "$pcej"
+
+    if [ "$tp" = "$tt" ] && [ "$tt" -gt 0 ] 2>/dev/null; then
+        ss STATUS "success"; ss FINAL_RESULT "success"
+    else
+        ss STATUS "compiled"; ss FINAL_RESULT "test_failure"
+    fi
+    ss PHASES_COMPLETED 1 --json   # a cycle passed
+    refresh_cost
+}
+
+# ===========================================================================
+# Step 5b — tester reported STUCK. Arg: <last failure signature>.
+# ===========================================================================
+execute_step_tester_stuck() {
+    local _L; _L="$(_LOG)"
+    local last="$1" cycle ca pc tcc pd pcej
+    cycle="$(sg CYCLE)"
+    ss TESTER_LAST_FAILURE_LINE "$last"
+    ss PREV_RESULT              "test_failure"
+    ca="$(sg COMPILATION_ATTEMPTS)"; pc="$(sg PHASE_COMPILES)"; tcc="$(sg TESTER_COMPILE_COUNT)"
+    ca=$((ca + tcc)); pc=$((pc + tcc))
+    ss COMPILATION_ATTEMPTS "$ca" --json
+    ss PHASE_COMPILES       "$pc" --json
+    pd="$(sg PHASE_DEBUGS)"; pcej="$(sg PHASE_COMPILE_ERRORS_JSON)"
+    rj failure --step "tester_cycle_${cycle}" --agent "tester" --type "test_failure" \
+        --message "$last" --resolved "false"
+    rj phase-end --phase "$cycle" --test-result "failed" \
+        --compilation-attempts "$pc" --debug-cycles "$pd" \
+        --test-details "tester STUCK after 5 attempts: $last" --compile-errors-json "$pcej"
+    refresh_cost
+
+    # Tell the orchestrator which branch to take (so it need not track CYCLE).
+    local mc; mc="$(sg MAX_CYCLES)"
+    if [ "$cycle" -ge "$mc" ]; then
+        echo "AT_CAP=yes (cycle ${cycle}/${mc}) — next: execute_step_mark_status compiled test_failure, then Step 8"
+    else
+        echo "AT_CAP=no (cycle ${cycle}/${mc}) — next: Step 5c refiner"
+    fi
+}
+
+# ===========================================================================
+# Step 5b — tester reported ENV_ERROR (infra broken; kernel innocent). Arg: <diagnosis>.
+# Sets the terminal state itself — the refiner is NOT invoked.
+# ===========================================================================
+execute_step_tester_env_error() {
+    local _L; _L="$(_LOG)"
+    local diag="$1" cycle ca pc tcc pd pcej
+    cycle="$(sg CYCLE)"
+    ss TESTER_ENV_DIAGNOSIS "$diag"
+    ca="$(sg COMPILATION_ATTEMPTS)"; pc="$(sg PHASE_COMPILES)"; tcc="$(sg TESTER_COMPILE_COUNT)"
+    ca=$((ca + tcc)); pc=$((pc + tcc))
+    ss COMPILATION_ATTEMPTS "$ca" --json
+    ss PHASE_COMPILES       "$pc" --json
+    pd="$(sg PHASE_DEBUGS)"; pcej="$(sg PHASE_COMPILE_ERRORS_JSON)"
+    rj failure --step "tester_cycle_${cycle}" --agent "tester" --type "infra_error" \
+        --message "$diag" --resolved "false"
+    rj phase-end --phase "$cycle" --test-result "failed" \
+        --compilation-attempts "$pc" --debug-cycles "$pd" \
+        --test-details "ENV_ERROR: $diag" --compile-errors-json "$pcej"
+    ss OBSTACLE     "$diag"
+    ss STATUS       "compiled"
+    ss FINAL_RESULT "test_failure"
+    refresh_cost
+}
+
+# ===========================================================================
+# Step 5c — advance to the refiner. Arg: <failure summary of the failed cycle>.
+# ===========================================================================
+execute_step_refiner_advance() {
+    local _L; _L="$(_LOG)"
+    local summary="$1" cycle prev
+    cycle="$(sg CYCLE)"; prev="$(sg PREV_RESULT)"
+    rj advance --new-step "refiner" \
+        --new-message "Cycle ${cycle} failed — refining analysis (v${cycle})" \
+        --prev-result "$prev" --prev-message "Cycle ${cycle} failed: ${summary}" --agent "refiner"
+}
+
+# ===========================================================================
+# Step 5c — bump refinement counters after the refiner ran.
+# ===========================================================================
+execute_step_refiner_bump() {
+    local _L; _L="$(_LOG)"
+    local cycle rc dc pt
+    cycle="$(sg CYCLE)"; rc="$(sg REFINEMENT_COUNT)"
+    rc=$((rc + 1)); dc=$rc; pt=$((cycle + 1))
+    ss REFINEMENT_COUNT "$rc" --json
+    ss DEBUG_CYCLES     "$dc" --json
+    ss PHASES_TOTAL     "$pt" --json
+    rj metric --patch-json "{\"phases_total\": ${pt}, \"debug_cycles\": ${dc}}"
+}
+
+# ===========================================================================
+# Step 5c — refiner reported ESCALATE. Arg: <reason>.
+# ===========================================================================
+execute_step_refiner_escalate() {
+    local _L; _L="$(_LOG)"
+    local reason="$1" cycle prev
+    cycle="$(sg CYCLE)"; prev="$(sg PREV_RESULT)"
+    ss REFINER_REASON "$reason"
+    rj failure --step "refiner_v${cycle}" --agent "refiner" --type "agent_error" \
+        --message "refiner escalated: ${reason}" --resolved "false"
+    if [ "$prev" = "compile_error" ]; then
+        ss STATUS "failed"
+    else
+        ss STATUS "compiled"
+    fi
+    ss FINAL_RESULT "$prev"
+}
+
+# ===========================================================================
+# Step 5c — refiner reported REFINED; bump the cycle and re-enter the writer.
+# ===========================================================================
+execute_step_refiner_refined() {
+    local _L; _L="$(_LOG)"
+    local cycle
+    cycle="$(sg CYCLE)"; cycle=$((cycle + 1))
+    ss CYCLE "$cycle" --json
+    rj advance --new-step "writer" \
+        --new-message "Cycle ${cycle} — writing kernel from refined analysis" \
+        --prev-result "success" \
+        --prev-message "Refinement v$((cycle - 1)) complete — analysis rewritten in place" \
+        --agent "writer"
+    rj phase-start --phase "$cycle" --name "cycle ${cycle} (after refinement v$((cycle - 1)))"
+}
+
+# ===========================================================================
+# Step 6a — snapshot the pre-optimization kernel for comparison/rollback.
+# ===========================================================================
+execute_step_optimizer_snapshot() {
+    local _L; _L="$(_LOG)"
+    local wt gen; wt="$(_wt)"; gen="$(sg GENERATED_KERNEL)"
+    cp "$wt/$gen" "$_L/pre_opt_$(basename "$gen")"
+}
+
+# ===========================================================================
+# Step 6a — advance to the optimizer (message depends on SFPI_MODE).
+# ===========================================================================
+execute_step_optimizer_advance() {
+    local _L; _L="$(_LOG)"
+    local sfpi kn cycle msg
+    sfpi="$(sg SFPI_MODE)"; kn="$(sg KERNEL_NAME)"; cycle="$(sg CYCLE)"
+    if [ "$sfpi" = "true" ]; then
+        msg="Reimplementing ${kn} in SFPI and comparing instruction count vs the TTI baseline"
+    else
+        msg="Applying replay-buffer optimization to ${kn}"
+    fi
+    rj advance --new-step "optimizer" --new-message "$msg" \
+        --prev-result "success" --prev-message "Cycle ${cycle} passed — entering optimization" \
+        --agent "optimizer"
+}
+
+# ===========================================================================
+# Refresh live cost into run.json (call at any boundary that lacks its own).
+# ===========================================================================
+execute_step_refresh_cost() {
+    local _L; _L="$(_LOG)"
+    refresh_cost
+}
+
+# ===========================================================================
+# Step 7 — advance to the format/prettify step.
+# ===========================================================================
+execute_step_format_advance() {
+    local _L; _L="$(_LOG)"
+    local opt; opt="$(sg OPTIMIZED)"
+    rj advance --new-step "format" \
+        --new-message "Running pre-commit formatters on generated files" \
+        --prev-result "success" --prev-message "Optimization complete (optimized=${opt})" \
+        --agent "format"
+}
+
+# ===========================================================================
+# Step 8a — record final line count of the generated kernel.
+# ===========================================================================
+execute_step_gather_metrics() {
+    local _L; _L="$(_LOG)"
+    local wt gen n; wt="$(_wt)"; gen="$(sg GENERATED_KERNEL)"
+    n="$(wc -l < "$wt/$gen")"
+    ss LINES_GENERATED "$n" --json
+    echo "LINES_GENERATED=$n"
+}
+
+# ===========================================================================
+# Step 8b — finalize run.json and append the runs.jsonl entry.
+# ===========================================================================
+execute_step_finalize_run() {
+    local _L; _L="$(_LOG)"
+    local S="$_ORCH_SCRIPTS"
+    export END_TIME GIT_COMMIT CYCLE MAX_CYCLES REFINEMENT_COUNT PHASES_TOTAL PHASES_COMPLETED
+    export COMPILATION_ATTEMPTS DEBUG_CYCLES TESTS_TOTAL TESTS_PASSED LINES_GENERATED TESTS_GENERATED
+    export OPTIMIZED OPTIMIZATION_TYPE FORMATS_TESTED_JSON FORMATS_EXCLUDED_JSON TOKENS_JSON OBSTACLE
+    export STATUS FINAL_RESULT KERNEL_NAME TARGET_ARCH LOG_DIR
+    END_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    LOG_DIR="$_L"
+    GIT_COMMIT="$(sg GIT_COMMIT)"
+    CYCLE="$(sg CYCLE)"; MAX_CYCLES="$(sg MAX_CYCLES)"; REFINEMENT_COUNT="$(sg REFINEMENT_COUNT)"
+    PHASES_TOTAL="$(sg PHASES_TOTAL)"; PHASES_COMPLETED="$(sg PHASES_COMPLETED)"
+    COMPILATION_ATTEMPTS="$(sg COMPILATION_ATTEMPTS)"; DEBUG_CYCLES="$(sg DEBUG_CYCLES)"
+    TESTS_TOTAL="$(sg TESTS_TOTAL)"; TESTS_PASSED="$(sg TESTS_PASSED)"; LINES_GENERATED="$(sg LINES_GENERATED)"
+    TESTS_GENERATED="$(sg TESTS_GENERATED)"; OPTIMIZED="$(sg OPTIMIZED)"; OPTIMIZATION_TYPE="$(sg OPTIMIZATION_TYPE)"
+    FORMATS_TESTED_JSON="$(sg FORMATS_TESTED_JSON)"; FORMATS_EXCLUDED_JSON="$(sg FORMATS_EXCLUDED_JSON)"
+    TOKENS_JSON="$(sg TOKENS_JSON)"; OBSTACLE="$(sg OBSTACLE)"
+    STATUS="$(sg STATUS)"; FINAL_RESULT="$(sg FINAL_RESULT)"
+    KERNEL_NAME="$(sg KERNEL_NAME)"; TARGET_ARCH="$(sg TARGET_ARCH)"
+
+    python "$S/run_json_writer.py" finalize \
+        --log-dir "$_L" \
+        --end-time "$END_TIME" \
+        --status "$STATUS" \
+        --final-result "$FINAL_RESULT" \
+        --final-message "Run complete — ${KERNEL_NAME} on ${TARGET_ARCH} (${CYCLE}/${MAX_CYCLES} cycles)" \
+        --patch-json "$(python - <<'PY'
+import json, os
+patch = {
+    "phases_total": int(os.environ["PHASES_TOTAL"]),
+    "phases_completed": int(os.environ["PHASES_COMPLETED"]),
+    "compilation_attempts": int(os.environ["COMPILATION_ATTEMPTS"]),
+    "debug_cycles": int(os.environ["DEBUG_CYCLES"]),
+    "tests_total": int(os.environ["TESTS_TOTAL"]),
+    "tests_passed": int(os.environ["TESTS_PASSED"]),
+    "lines_generated": int(os.environ["LINES_GENERATED"]),
+    "tests_generated": os.environ["TESTS_GENERATED"].lower() == "true",
+    "prettified": False,
+    "formatted": True,
+    "optimized": os.environ.get("OPTIMIZED", "false").lower() == "true",
+    "optimization_type": os.environ.get("OPTIMIZATION_TYPE", "none"),
+    "formats_tested": json.loads(os.environ.get("FORMATS_TESTED_JSON", "[]")),
+    "formats_excluded": json.loads(os.environ.get("FORMATS_EXCLUDED_JSON", "{}")),
+    "obstacle": os.environ.get("OBSTACLE") or None,
+    # Derived from steps_completed in run.json (always current, written
+    # atomically by run_json_writer.py) rather than tracked as a separate value.
+    "agents": json.loads(open(os.environ["LOG_DIR"] + "/run.json").read()).get("steps_completed", []),
+    "tokens": json.loads(os.environ.get("TOKENS_JSON", "{\"input\":0,\"output\":0,\"cache_read\":0,\"cache_creation\":0,\"total\":0}")),
+    "refinement_count": int(os.environ.get("REFINEMENT_COUNT", "0")),
+    "cycles_attempted": int(os.environ.get("CYCLE", "1")),
+    "cycles_cap": int(os.environ.get("MAX_CYCLES", "3")),
+    # Base commit the worktree branch was cut from (origin/main at Step 0). The
+    # generated.patch archived below applies cleanly on top of this commit.
+    "base_commit": os.environ.get("GIT_COMMIT", "unknown"),
+    "artifact_patch": "generated.patch",
+}
+print(json.dumps(patch))
+PY
+)"
+
+    refresh_cost   # final authoritative refresh — overwrites the TOKENS_JSON
+
+    # $LOG_DIR/run.json is the authoritative per-run record — derive the
+    # runs.jsonl entry from it so the two artifacts stay in sync.
+    python -c "import json; d=json.load(open('$_L/run.json')); print(json.dumps(d))" \
+        >> /proj_sw/user_dev/llk_code_gen/quasar/runs.jsonl
+}
+
+# ===========================================================================
+# Step 8 — copy simulator logs into LOG_DIR (before worktree cleanup).
+# ===========================================================================
+execute_step_copy_sim_logs() {
+    local _L; _L="$(_LOG)"
+    local ta; ta="$(sg TARGET_ARCH)"
+    cp tests/python_tests/${ta}/emu_*_.log     "$_L/" 2>/dev/null || true
+    cp tests/python_tests/${ta}/tt-exalens.log "$_L/" 2>/dev/null || true
+}
+
+# ===========================================================================
+# Step 8 — capture every run-touched file as a single git diff.
+# ===========================================================================
+execute_step_write_generated_patch() {
+    local _L; _L="$(_LOG)"
+    local ta; ta="$(sg TARGET_ARCH)"
+    local PATHSPEC="tt_llk_${ta} tests codegen/artifacts :(top)tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu"
+    git add -AN -- $PATHSPEC 2>/dev/null || true
+    git diff --binary HEAD -- $PATHSPEC > "$_L/generated.patch"
+    git reset -q -- $PATHSPEC 2>/dev/null || true
+}
+
+# ===========================================================================
+# Step 8 — extract subagent transcripts into LOG_DIR (non-fatal).
+# ===========================================================================
+execute_step_extract_transcripts() {
+    local _L; _L="$(_LOG)"
+    local S="$_ORCH_SCRIPTS" sid pcwd
+    sid="$(sg SESSION_ID)"; pcwd="$(sg PROJECT_CWD)"
+    python "$S/extract_run_transcripts.py" --log-dir "$_L" \
+        ${sid:+--session-id "$sid" --project-cwd "$pcwd"} \
+        || echo "extract_run_transcripts: skipped (non-fatal)"
+}
+
+# ===========================================================================
+# Step 8 — build the report from run.json + agent logs + transcripts, write it
+# to codegen/artifacts/<kernel>_report.md, and print it.
+# ===========================================================================
+execute_step_write_report() {
+    local _L; _L="$(_LOG)"
+    local S="$_ORCH_SCRIPTS" kn; kn="$(sg KERNEL_NAME)"
+    python "$S/quasar/build_report.py" --log-dir "$_L" --out "codegen/artifacts/${kn}_report.md"
+}
+
+# ===========================================================================
+# Step 8 — copy the final report into LOG_DIR.
+# ===========================================================================
+execute_step_copy_report() {
+    local _L; _L="$(_LOG)"
+    local kn; kn="$(sg KERNEL_NAME)"
+    cp "codegen/artifacts/${kn}_report.md" "$_L/"
+}

--- a/tt_metal/tt-llk/codegen/scripts/refresh_cost.sh
+++ b/tt_metal/tt-llk/codegen/scripts/refresh_cost.sh
@@ -11,34 +11,32 @@
 # not persist between Bash tool calls, which caused run.json to never get
 # patched on past runs.
 #
-# Required env vars (exported by the orchestrator):
-#   START_TIME  — ISO 8601 timestamp, only usage at/after this is counted
-#   LOG_DIR     — run directory containing run.json
-# Optional:
-#   MODEL       — opus | sonnet | haiku (default: derived per-message from jsonl)
-#
 # Env vars do NOT persist across separate Bash tool-call shells in Claude Code.
-# The orchestrator writes /tmp/codegen_run_state.sh in Step 0; this script
-# sources it as a fallback so refresh_cost calls after the first Bash block
-# still have the values they need.
+# LOG_DIR is recovered via state.py --worktree-dir (this script always runs
+# from $WORKTREE_DIR/tt_metal/tt-llk, written by Step 0); START_TIME, MODEL,
+# SESSION_ID, and PROJECT_CWD are then read from $LOG_DIR/state.json.
 #
 # Fail-silent by design: a transient read-during-append must never abort the
 # run; the next refresh catches up. Stderr is discarded for the same reason.
 set -u
 
-# Fall back to state file if env vars were lost across Bash tool-call shells.
-if [[ -z "${LOG_DIR:-}" || -z "${START_TIME:-}" ]]; then
-    source /tmp/codegen_run_state.sh 2>/dev/null || true
-fi
-
-: "${START_TIME:?START_TIME not exported and /tmp/codegen_run_state.sh not found}"
-: "${LOG_DIR:?LOG_DIR not exported and /tmp/codegen_run_state.sh not found}"
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Pass the session ID explicitly when the orchestrator saved it at startup.
-# Without this, session_cost.py falls back to PID-based discovery, which picks
-# the wrong session after a few hours when other claude sessions have started.
+if [[ -z "${LOG_DIR:-}" ]]; then
+    _WORKTREE_DIR="$(cd ../.. && pwd)"
+    LOG_DIR=$(python "${SCRIPT_DIR}/state.py" --worktree-dir "${_WORKTREE_DIR}" get LOG_DIR 2>/dev/null || echo "")
+fi
+: "${LOG_DIR:?LOG_DIR not exported and not found via state.py --worktree-dir}"
+
+if [[ -z "${START_TIME:-}" ]]; then
+    START_TIME=$(python "${SCRIPT_DIR}/state.py" --log-dir "${LOG_DIR}" get START_TIME 2>/dev/null || echo "")
+fi
+: "${START_TIME:?START_TIME not exported and not found in ${LOG_DIR}/state.json}"
+
+MODEL="${MODEL:-$(python "${SCRIPT_DIR}/state.py" --log-dir "${LOG_DIR}" get MODEL 2>/dev/null || echo "")}"
+SESSION_ID="${SESSION_ID:-$(python "${SCRIPT_DIR}/state.py" --log-dir "${LOG_DIR}" get SESSION_ID 2>/dev/null || echo "")}"
+PROJECT_CWD="${PROJECT_CWD:-$(python "${SCRIPT_DIR}/state.py" --log-dir "${LOG_DIR}" get PROJECT_CWD 2>/dev/null || echo "")}"
+
 _SESSION_ARGS=""
 if [[ -n "${SESSION_ID:-}" && -n "${PROJECT_CWD:-}" ]]; then
     _SESSION_ARGS="--session-id ${SESSION_ID} --project-cwd ${PROJECT_CWD}"

--- a/tt_metal/tt-llk/codegen/scripts/run_json_writer.py
+++ b/tt_metal/tt-llk/codegen/scripts/run_json_writer.py
@@ -35,9 +35,17 @@ Subcommands:
                     status to a terminal value, merge in any remaining summary
                     fields passed via --patch-json.
 
-Every subcommand is idempotent in the sense that running it twice with the
-same arguments produces the same final document (modulo timestamps the
-caller passes explicitly).
+Idempotency:
+    State-replacing subcommands are idempotent — running one twice with the
+    same arguments yields the same final document (modulo timestamps the caller
+    passes explicitly): init, message, phase-start, phase-test, metric,
+    link-siblings, finalize.
+
+    Append/counter subcommands are intentionally NOT idempotent, per
+    RUN_JSON_SPEC.md: advance and finalize's closeout append one step_history
+    entry per invocation (the timeline records retries), failure appends to the
+    append-only failures[] log, and phase-end increments phases_completed.
+    Callers must emit these exactly once per real event.
 """
 
 from __future__ import annotations

--- a/tt_metal/tt-llk/codegen/scripts/session_cost.py
+++ b/tt_metal/tt-llk/codegen/scripts/session_cost.py
@@ -38,6 +38,9 @@ Usage:
 
     # Or just print JSON to stdout (no patch)
     python codegen/scripts/session_cost.py --since "$START_TIME"
+
+    # Print the running session's full model id (e.g. claude-opus-4-8) and exit
+    python codegen/scripts/session_cost.py --print-model
 """
 
 from __future__ import annotations
@@ -84,6 +87,30 @@ def _tier(model_str: str | None) -> str:
     return "opus"
 
 
+def _last_model(jsonl_path: Path) -> str | None:
+    """Return the raw model id of the most recent real assistant turn.
+
+    Claude Code stamps each ``type: assistant`` entry with ``message.model``
+    (e.g. ``claude-opus-4-8``). Synthetic/system turns carry ``<synthetic>`` —
+    skip them. Returns None when the transcript has no model-bearing turn.
+    """
+    if not jsonl_path.exists():
+        return None
+    last: str | None = None
+    with jsonl_path.open() as fh:
+        for line in fh:
+            try:
+                d = json.loads(line)
+            except Exception:
+                continue
+            if d.get("type") != "assistant":
+                continue
+            m = (d.get("message") or {}).get("model")
+            if m and m != "<synthetic>":
+                last = m
+    return last
+
+
 def _parse_ts(ts: str | None) -> datetime | None:
     if not ts:
         return None
@@ -99,6 +126,19 @@ def _build_paths(session_id: str, cwd: str) -> tuple[Path, Path]:
     proj_name = cwd.replace("_", "-").replace("/", "-")
     proj_dir = home / ".claude" / "projects" / proj_name
     return proj_dir / f"{session_id}.jsonl", proj_dir / session_id / "subagents"
+
+
+def _find_by_session_id(session_id: str) -> tuple[Path, Path] | None:
+    home = Path(os.path.expanduser("~"))
+    matches = sorted(
+        (home / ".claude" / "projects").glob(f"*/{session_id}.jsonl"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    if not matches:
+        return None
+    jsonl = matches[0]
+    return jsonl, jsonl.parent / session_id / "subagents"
 
 
 def _discover_session(preferred_pid: str | None) -> tuple[str, Path, Path] | None:
@@ -268,12 +308,12 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument(
         "--session-id",
         default=None,
-        help="Explicit session UUID (overrides PID discovery).",
+        help="Explicit session UUID; resolved by globbing ~/.claude/projects/ (overrides PID discovery).",
     )
     ap.add_argument(
         "--project-cwd",
         default=None,
-        help="CWD that maps to the project dir under ~/.claude/projects/ (required with --session-id).",
+        help="CWD that maps to the project dir under ~/.claude/projects/ (optional with --session-id).",
     )
     ap.add_argument(
         "--log-dir",
@@ -288,19 +328,37 @@ def main(argv: list[str] | None = None) -> int:
         "to capture the session identity at startup so refresh_cost.sh can pass it "
         "explicitly on later calls (when PID-based discovery may pick the wrong session).",
     )
+    ap.add_argument(
+        "--print-model",
+        action="store_true",
+        default=False,
+        help="Print the running session's full model id (e.g. claude-opus-4-8) from its "
+        "most recent turn and exit; prints nothing if undeterminable. Used by the "
+        "orchestrator to record the model actually running in run.json instead of a "
+        "hard-coded default.",
+    )
     args = ap.parse_args(argv)
 
     since_dt = _parse_ts(args.since) if args.since else None
 
-    if args.session_id and args.project_cwd:
+    session_id = args.session_id or os.environ.get("CLAUDE_CODE_SESSION_ID")
+    found_by_id = _find_by_session_id(session_id) if session_id else None
+
+    if found_by_id:
+        main_jsonl, subs_dir = found_by_id
+        discovered_sid = session_id
+        discovered_cwd = args.project_cwd or os.getcwd()
+    elif args.session_id and args.project_cwd:
         main_jsonl, subs_dir = _build_paths(args.session_id, args.project_cwd)
-        discovered_cwd = args.project_cwd
         discovered_sid = args.session_id
+        discovered_cwd = args.project_cwd
     else:
         found = _discover_session(args.session_pid)
         if not found:
             if args.print_session:
                 print(" ")  # empty pair — caller checks for blank
+            elif args.print_model:
+                print("")  # undeterminable — caller falls back to its default
             else:
                 print(
                     json.dumps(
@@ -317,28 +375,23 @@ def main(argv: list[str] | None = None) -> int:
             return 0
         discovered_sid, main_jsonl, subs_dir = found
         discovered_cwd = str(main_jsonl.parent.parent.name).replace("-", "/")
+        home = Path(os.path.expanduser("~"))
+        sessions_dir = home / ".claude" / "sessions"
+        for f in sessions_dir.glob("*.json"):
+            try:
+                meta = json.loads(f.read_text())
+                if meta.get("sessionId") == discovered_sid and meta.get("cwd"):
+                    discovered_cwd = meta["cwd"]
+                    break
+            except Exception:
+                pass
 
     if args.print_session:
-        # Recover the original cwd string from the project dir name.
-        # _build_paths maps cwd → proj_name via cwd.replace("_","-").replace("/","-"),
-        # so we cannot perfectly invert it for all paths — instead we read it
-        # from the session file directly when we did PID discovery.
-        if not (args.session_id and args.project_cwd):
-            # Re-read the cwd from the session metadata for accuracy.
-            home = Path(os.path.expanduser("~"))
-            sessions_dir = home / ".claude" / "sessions"
-            real_cwd = discovered_cwd
-            for f in sessions_dir.glob("*.json"):
-                try:
-                    meta = json.loads(f.read_text())
-                    if meta.get("sessionId") == discovered_sid and meta.get("cwd"):
-                        real_cwd = meta["cwd"]
-                        break
-                except Exception:
-                    pass
-        else:
-            real_cwd = args.project_cwd
-        print(f"{discovered_sid} {real_cwd}")
+        print(f"{discovered_sid} {discovered_cwd}")
+        return 0
+
+    if args.print_model:
+        print(_last_model(main_jsonl) or "")
         return 0
 
     totals = dict(

--- a/tt_metal/tt-llk/codegen/scripts/state.py
+++ b/tt_metal/tt-llk/codegen/scripts/state.py
@@ -1,0 +1,229 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+JSON-backed key-value store for passing values between separate shell calls.
+
+Backing file resolution (highest precedence first):
+    --file <path>           explicit path — edge cases only, prefer the modes below
+    --log-dir <dir>         <dir>/state.json
+    $LOG_DIR                $LOG_DIR/state.json
+    --worktree-dir <dir>    <dir>/tt_metal/tt-llk/.codegen_run_state.json
+    $WORKTREE_DIR           $WORKTREE_DIR/tt_metal/tt-llk/.codegen_run_state.json
+
+Subcommands:
+    set K V         Store string value V under key K.
+    set K V --json  Store V parsed as JSON (typed: numbers, bools, objects).
+    get K           Print value of K (raw for strings, JSON otherwise).
+                    Missing key -> print --default (empty string) and exit 0.
+    del K           Remove key K (no error if absent).
+    keys            Print all keys, one per line.
+    dump            Print the whole store as pretty JSON.
+
+Usage:
+    python state.py --log-dir "$DIR" set RUN_ID "$RUN_ID"
+    VALUE=$(python state.py --log-dir "$DIR" get RUN_ID --default unknown)
+    python state.py --worktree-dir "$WORKTREE_DIR" set KERNEL_NAME "gelu"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+# --------------------------------------------------------------------------
+# Backing-file resolution
+# --------------------------------------------------------------------------
+
+
+def _resolve_path(
+    file_arg: str | None, log_dir_arg: str | None, worktree_dir_arg: str | None
+) -> Path:
+    # Explicit flags always win over ambient env vars — an explicit
+    # --worktree-dir must not be silently redirected by a $LOG_DIR that
+    # happens to already be exported in the same shell (e.g. orchestrator
+    # Step 0, which exports LOG_DIR before writing WORKTREE_DIR-scoped keys).
+    if file_arg:
+        return Path(file_arg)
+    if log_dir_arg:
+        return Path(log_dir_arg) / "state.json"
+    if worktree_dir_arg:
+        return (
+            Path(worktree_dir_arg) / "tt_metal" / "tt-llk" / ".codegen_run_state.json"
+        )
+    log_dir = os.environ.get("LOG_DIR")
+    if log_dir:
+        return Path(log_dir) / "state.json"
+    worktree_dir = os.environ.get("WORKTREE_DIR")
+    if worktree_dir:
+        return Path(worktree_dir) / "tt_metal" / "tt-llk" / ".codegen_run_state.json"
+    raise SystemExit(
+        "state.py: no backing file — pass --file, --log-dir, --worktree-dir, "
+        "or set $LOG_DIR/$WORKTREE_DIR"
+    )
+
+
+# --------------------------------------------------------------------------
+# Low-level IO (mirrors run_json_writer.py)
+# --------------------------------------------------------------------------
+
+
+def _load(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _atomic_write(path: Path, store: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=".state.json.", suffix=".tmp", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(store, f, indent=2)
+            f.write("\n")
+        # Match run_json_writer.py: mkstemp is 0o600, which locks out the shared
+        # group; relax to 0o664 so the same readers can see this store.
+        os.chmod(tmp, 0o664)
+        os.replace(tmp, path)
+    except Exception:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+        raise
+
+
+def _emit(value: Any) -> None:
+    """Print a value for shell capture: strings raw, everything else as JSON."""
+    if isinstance(value, str):
+        print(value)
+    else:
+        print(json.dumps(value))
+
+
+# --------------------------------------------------------------------------
+# Subcommands
+# --------------------------------------------------------------------------
+
+
+def _cmd_set(path: Path, key: str, value: str, as_json: bool) -> int:
+    if as_json:
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise SystemExit(f"state.py: --json value is not valid JSON: {exc}")
+        store = _load(path)
+        store[key] = parsed
+    else:
+        store = _load(path)
+        store[key] = value
+    _atomic_write(path, store)
+    return 0
+
+
+def _cmd_get(path: Path, key: str, default: str) -> int:
+    store = _load(path)
+    if key in store:
+        _emit(store[key])
+    else:
+        print(default)
+    return 0
+
+
+def _cmd_del(path: Path, key: str) -> int:
+    store = _load(path)
+    if key in store:
+        del store[key]
+        _atomic_write(path, store)
+    return 0
+
+
+def _cmd_keys(path: Path) -> int:
+    for key in _load(path):
+        print(key)
+    return 0
+
+
+def _cmd_dump(path: Path) -> int:
+    print(json.dumps(_load(path), indent=2))
+    return 0
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument(
+        "--file",
+        default=None,
+        help="Explicit path to the state file. Edge cases only — prefer "
+        "--log-dir or --worktree-dir so every caller resolves the same file.",
+    )
+    ap.add_argument(
+        "--log-dir",
+        default=None,
+        help="Run LOG_DIR; state lives at <log-dir>/state.json (default: $LOG_DIR).",
+    )
+    ap.add_argument(
+        "--worktree-dir",
+        default=None,
+        help="Worktree root; state lives at <worktree-dir>/tt_metal/tt-llk/"
+        ".codegen_run_state.json (default: $WORKTREE_DIR).",
+    )
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p_set = sub.add_parser("set", help="Store a value under a key.")
+    p_set.add_argument("key")
+    p_set.add_argument("value")
+    p_set.add_argument(
+        "--json",
+        action="store_true",
+        dest="as_json",
+        help="Parse VALUE as JSON (store typed: number, bool, object, array).",
+    )
+
+    p_get = sub.add_parser("get", help="Print the value of a key.")
+    p_get.add_argument("key")
+    p_get.add_argument(
+        "--default",
+        default="",
+        help="Printed when the key is absent (default: empty string).",
+    )
+
+    p_del = sub.add_parser("del", help="Remove a key.")
+    p_del.add_argument("key")
+
+    sub.add_parser("keys", help="Print all keys, one per line.")
+    sub.add_parser("dump", help="Print the whole store as pretty JSON.")
+
+    args = ap.parse_args(argv)
+    path = _resolve_path(args.file, args.log_dir, args.worktree_dir)
+
+    if args.cmd == "set":
+        return _cmd_set(path, args.key, args.value, args.as_json)
+    if args.cmd == "get":
+        return _cmd_get(path, args.key, args.default)
+    if args.cmd == "del":
+        return _cmd_del(path, args.key)
+    if args.cmd == "keys":
+        return _cmd_keys(path)
+    if args.cmd == "dump":
+        return _cmd_dump(path)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Overview

Spring-cleaning of the Quasar kernel-generation orchestrator.

`orchestrator.md` shrinks by ~1200 lines: every inline bash blob and hand-built `run_json_writer.py` call is replaced by a named `execute_step_*` function. The prose that remains is the pipeline spec and control flow only.

### Changes by section

- **`scripts/state.py` (new)** — JSON-backed key-value store for passing values between separate shell calls.

- **`scripts/quasar/orchestrator_steps.sh` (new)** — the executable body of the pipeline. All per-step mechanics (`execute_step_validate_input`, `_setup_run`, `_analyzer_passed`, `_writer_failed`, `_tester_passed`, `_refiner_bump`, `_finalize_run`, …)

- **`scripts/quasar/build_report.py` (new)** — builds the final run report from `run.json` + agent self-logs + transcripts. Invoked by `execute_step_write_report`. (Force-added past an over-broad `build_*` entry in `.gitignore`.)

- **`agents/quasar/orchestrator.md`** — rewritten to be a thin control-flow spec over the step-library. ~1200 lines of inline mechanics removed. Adds explicit I/O conventions (agent status/report is its final message; named "first meaningful line" fields) and forbids reading/editing `orchestrator_steps.sh`.

- **`CLAUDE.md` (codegen router)** — the router now seeds startup params via `state.py --worktree-dir set …` instead of passing a JSON blob in the orchestrator prompt; the orchestrator is told only `WORKTREE_DIR` and reads the rest back.

- **`scripts/{run_json_writer,session_cost,extract_run_transcripts}.py`, `scripts/refresh_cost.sh`, `hooks/{post_bash_hook.py,test_post_bash_hook.sh}`** — adjusted to read/write run state through the new `state.py` contract and the in-repo `LOG_DIR` fallback.

- **`.gitignore`** — ignore the per-worktree `.codegen_run_state.json` boot file.

- **`references/state_contract.md` (new)** — mermaid dependency graph documenting the state contract: what each agent consumes/produces via `state.py`, the orchestrator's internal state written in order, and `★` markers for agents that must write keys back into the run file.
  - This is not part of the pipeline, it's only used for visual tracking of the states

### General decisions

- **State lives in files, not prompts.** Values that vary per run are written once via `state.py` and read back by whoever needs them. Sub-agent prompts are stripped of anything derivable from state (no `WORKTREE_DIR`/`LOG_DIR` lines, no explicit fetch commands) — keeping only genuinely behavior-affecting instructions.
- **Mechanics are hidden behind named steps.** The orchestrator (and any human reading it) reasons about control flow; the step-library owns side effects, counters, and `run.json` writes. `execute_step_*` functions print `OK:`/`REJECT:`/`AT_CAP=…` on stdout for the orchestrator to branch on.
- **The contract is documented, not implied** (`state_contract.md`), so the boundary between orchestrator and agents is auditable.

## Leading changes for other subagents to adopt

The orchestrator and router are converted; the **agent playbooks still need to be brought onto the same contract**. When updating `agents/quasar/*.md`, adopt these:

- **Read/write run state via `state.py`, not prompt text.** Consume inputs with `python state.py --log-dir "$LOG_DIR" get KEY` (or `--worktree-dir`); do not expect them inlined in the prompt.
- **`★` agents must write their outputs back.** Per `state_contract.md`, the **tester** (`TESTS_TOTAL`, `TESTS_PASSED`, `TESTS_GENERATED`, `TESTER_COMPILE_COUNT`, `PHASE_DEBUGS`, `FORMATS_TESTED_JSON`, `FORMATS_EXCLUDED_JSON`) and the **optimizer** (`OPTIMIZED`, `OPTIMIZATION_TYPE`) self-report via `state.py set` rather than relying on the orchestrator to parse their prose. These are the two agents pending their own refactor.
- **Return contract stays in the playbook.** Each agent's final-message format (writer `PASSED`/`FAILED` + `Error summary`; tester `PASS`/`STUCK`/`ENV_ERROR` + `Last failure signature`/`Diagnosis`; refiner `REFINED`/`ESCALATE`) is the orchestrator's parsing surface — keep the named fields stable when editing.
- **Minimal prompts.** Strip any `state.py`-derivable info and explicit fetch commands from prompts; keep only instructions that change behavior.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=njokovic/quasar-orch-wash)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:njokovic/quasar-orch-wash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=njokovic/quasar-orch-wash)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:njokovic/quasar-orch-wash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=njokovic/quasar-orch-wash)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:njokovic/quasar-orch-wash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=njokovic/quasar-orch-wash)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:njokovic/quasar-orch-wash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=njokovic/quasar-orch-wash)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:njokovic/quasar-orch-wash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=njokovic/quasar-orch-wash)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:njokovic/quasar-orch-wash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=njokovic/quasar-orch-wash)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:njokovic/quasar-orch-wash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=njokovic/quasar-orch-wash)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:njokovic/quasar-orch-wash)