### PR TITLE
ds_prefill - Fuse tilize with unified routed expert for Blackhole

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ttnn_routed_expert.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ttnn_routed_expert.py
@@ -16,7 +16,7 @@ from loguru import logger
 from tracy import signpost
 
 import ttnn
-from models.common.utility_functions import profiler
+from models.common.utility_functions import is_blackhole, profiler
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.reference.deepseek_v4_flash_config import DeepSeekV4FlashConfig
 from models.demos.deepseek_v3_d_p.reference.deepseek_v4_pro_config import DeepSeekV4ProConfig
@@ -592,6 +592,8 @@ def test_ttnn_routed_expert_models(
 
 
 @torch.no_grad()
+# unified_routed_expert_ffn requires an 11x8 compute grid; only Blackhole (13x10) has it.
+@pytest.mark.skipif(not is_blackhole(), reason="unified_routed_expert_ffn is Blackhole-only (needs 11x8 grid)")
 @pytest.mark.parametrize(
     "mesh_device, device_params", [ROUTED_EXPERT_MESH_PARAMS[0]], indirect=["mesh_device", "device_params"]
 )
@@ -651,6 +653,8 @@ def test_ttnn_routed_expert_ffn_row_major(mesh_device, device_params):
 
 
 @torch.no_grad()
+# unified_routed_expert_ffn requires an 11x8 compute grid; only Blackhole (13x10) has it.
+@pytest.mark.skipif(not is_blackhole(), reason="unified_routed_expert_ffn is Blackhole-only (needs 11x8 grid)")
 @pytest.mark.parametrize(
     "mesh_device, device_params", [ROUTED_EXPERT_MESH_PARAMS[0]], indirect=["mesh_device", "device_params"]
 )

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ttnn_routed_expert.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ttnn_routed_expert.py
@@ -16,7 +16,7 @@ from loguru import logger
 from tracy import signpost
 
 import ttnn
-from models.common.utility_functions import is_blackhole, profiler
+from models.common.utility_functions import profiler
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.reference.deepseek_v4_flash_config import DeepSeekV4FlashConfig
 from models.demos.deepseek_v3_d_p.reference.deepseek_v4_pro_config import DeepSeekV4ProConfig
@@ -589,80 +589,3 @@ def test_ttnn_routed_expert_models(
         run_pcc_check,
         use_predictable_data,
     )
-
-
-@torch.no_grad()
-# unified_routed_expert_ffn requires an 11x8 compute grid; only Blackhole (13x10) has it.
-@pytest.mark.skipif(not is_blackhole(), reason="unified_routed_expert_ffn is Blackhole-only (needs 11x8 grid)")
-@pytest.mark.parametrize(
-    "mesh_device, device_params", [ROUTED_EXPERT_MESH_PARAMS[0]], indirect=["mesh_device", "device_params"]
-)
-@pytest.mark.parametrize("offset_tiles", [0, 2], ids=["no_offset", "offset2"])
-def test_ttnn_routed_expert_ffn_row_major(mesh_device, device_params, offset_tiles):
-    """Row-major x read (x_is_row_major), optionally at a region offset.
-
-    Models the fused MoE path: x is a shared ROW_MAJOR bf16 buffer whose region
-    for this expert starts at start[global_id] = offset_tiles * 32. The reader
-    reads that region (row-major) and the op tilizes it internally (bf16 ->
-    bf8_b) before the gate/up matmul, fusing the standalone to_layout; the writer
-    places the bf8 TILE result back at the same offset (direct-write). Also
-    exercises the D2 relaxation — bf8 TILE output while x is bf16 ROW_MAJOR.
-
-    offset_tiles=0 degenerates to a single-expert, no-padding buffer read at row
-    0; offset_tiles=2 puts the region behind 64 rows of padding.
-    """
-    torch.manual_seed(0)
-    emb = 1024  # K_gate_tiles = 32 -> 2 gate/up K-blocks
-    hidden = 512
-    max_tokens = 64  # this expert's region: 2 tile-rows
-    start_row = offset_tiles * 32
-    buf_rows = start_row + max_tokens  # shared buffer holds offset padding + region
-
-    # This expert's tokens (torch reference on the region only).
-    x_region = torch.randn(max_tokens, emb, dtype=torch.bfloat16)
-    scale = 0.05
-    gate = (torch.randn(emb, hidden) * scale).bfloat16()
-    up = (torch.randn(emb, hidden) * scale).bfloat16()
-    down = (torch.randn(hidden, emb) * scale).bfloat16()
-    xf = x_region.float()
-    ref = (torch.nn.functional.silu(xf @ gate.float()) * (xf @ up.float())) @ down.float()
-
-    # Shared row-major buffer: expert's rows live at [start_row, start_row+max_tokens).
-    # When offset_tiles=0 this is just the region itself (no padding).
-    x_full = torch.randn(buf_rows, emb, dtype=torch.bfloat16)
-    x_full[start_row : start_row + max_tokens] = x_region
-
-    dram = ttnn.DRAM_MEMORY_CONFIG
-
-    def to_tt(t, layout, dtype):
-        return ttnn.from_torch(t, layout=layout, dtype=dtype, device=mesh_device, memory_config=dram)
-
-    x_tt = to_tt(x_full, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16)
-    gate_tt = to_tt(gate, ttnn.TILE_LAYOUT, ttnn.bfloat8_b)
-    up_tt = to_tt(up, ttnn.TILE_LAYOUT, ttnn.bfloat8_b)
-    down_tt = to_tt(down, ttnn.TILE_LAYOUT, ttnn.bfloat8_b)
-    counts_tt = to_tt(torch.tensor([max_tokens], dtype=torch.int32), ttnn.ROW_MAJOR_LAYOUT, ttnn.uint32)
-    idx_tt = to_tt(torch.tensor([0], dtype=torch.int32), ttnn.ROW_MAJOR_LAYOUT, ttnn.uint32)
-    offsets_tt = to_tt(torch.tensor([start_row], dtype=torch.int32), ttnn.ROW_MAJOR_LAYOUT, ttnn.uint32)
-    # bf8 TILE output the size of the shared buffer; writer places the region at offset.
-    out_tt = to_tt(torch.zeros(buf_rows, emb, dtype=torch.bfloat16), ttnn.TILE_LAYOUT, ttnn.bfloat8_b)
-
-    ttnn.experimental.deepseek_prefill.unified_routed_expert_ffn(
-        x_tt,
-        gate_tt,
-        up_tt,
-        down_tt,
-        counts_tt,
-        idx_tt,
-        0,  # local_expert_id
-        output=out_tt,
-        expert_region_offsets=offsets_tt,
-        input_m_tiles=max_tokens // 32,
-        read_x_at_offset=True,
-        x_is_row_major=True,
-    )
-
-    out = ttnn.to_torch(out_tt).float()[start_row : start_row + max_tokens, :]
-    passing, pcc = comp_pcc(ref.float(), out, 0.97)
-    logger.info(f"[row-major FFN offset_tiles={offset_tiles}] PCC: {pcc}")
-    assert passing, f"row-major FFN (offset_tiles={offset_tiles}) PCC {pcc} below 0.97"

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ttnn_routed_expert.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ttnn_routed_expert.py
@@ -597,81 +597,24 @@ def test_ttnn_routed_expert_models(
 @pytest.mark.parametrize(
     "mesh_device, device_params", [ROUTED_EXPERT_MESH_PARAMS[0]], indirect=["mesh_device", "device_params"]
 )
-def test_ttnn_routed_expert_ffn_row_major(mesh_device, device_params):
-    """Direct unified_routed_expert_ffn test for x_is_row_major.
+@pytest.mark.parametrize("offset_tiles", [0, 2], ids=["no_offset", "offset2"])
+def test_ttnn_routed_expert_ffn_row_major(mesh_device, device_params, offset_tiles):
+    """Row-major x read (x_is_row_major), optionally at a region offset.
 
-    Feeds a ROW_MAJOR bf16 per-expert x; the op tilizes it internally (bf16 ->
-    bf8_b) before the gate/up matmul, fusing the standalone to_layout. One
-    expert, all rows valid, no region offset — isolates the row-major read +
-    compute tilize from the composite / insert-offset path. Output is TILE bf16
-    (must match x dtype per the op contract).
+    Models the fused MoE path: x is a shared ROW_MAJOR bf16 buffer whose region
+    for this expert starts at start[global_id] = offset_tiles * 32. The reader
+    reads that region (row-major) and the op tilizes it internally (bf16 ->
+    bf8_b) before the gate/up matmul, fusing the standalone to_layout; the writer
+    places the bf8 TILE result back at the same offset (direct-write). Also
+    exercises the D2 relaxation — bf8 TILE output while x is bf16 ROW_MAJOR.
+
+    offset_tiles=0 degenerates to a single-expert, no-padding buffer read at row
+    0; offset_tiles=2 puts the region behind 64 rows of padding.
     """
     torch.manual_seed(0)
     emb = 1024  # K_gate_tiles = 32 -> 2 gate/up K-blocks
     hidden = 512
-    max_tokens = 64  # 2 tile-rows
-
-    # Torch reference: silu(x @ gate) * (x @ up) @ down.
-    x = torch.randn(max_tokens, emb, dtype=torch.bfloat16)
-    scale = 0.05
-    gate = (torch.randn(emb, hidden) * scale).bfloat16()
-    up = (torch.randn(emb, hidden) * scale).bfloat16()
-    down = (torch.randn(hidden, emb) * scale).bfloat16()
-    xf = x.float()
-    ref = (torch.nn.functional.silu(xf @ gate.float()) * (xf @ up.float())) @ down.float()
-
-    dram = ttnn.DRAM_MEMORY_CONFIG
-
-    def to_tt(t, layout, dtype):
-        return ttnn.from_torch(t, layout=layout, dtype=dtype, device=mesh_device, memory_config=dram)
-
-    x_tt = to_tt(x, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16)
-    gate_tt = to_tt(gate, ttnn.TILE_LAYOUT, ttnn.bfloat8_b)
-    up_tt = to_tt(up, ttnn.TILE_LAYOUT, ttnn.bfloat8_b)
-    down_tt = to_tt(down, ttnn.TILE_LAYOUT, ttnn.bfloat8_b)
-    counts_tt = to_tt(torch.tensor([max_tokens], dtype=torch.int32), ttnn.ROW_MAJOR_LAYOUT, ttnn.uint32)
-    idx_tt = to_tt(torch.tensor([0], dtype=torch.int32), ttnn.ROW_MAJOR_LAYOUT, ttnn.uint32)
-    out_tt = to_tt(torch.zeros(max_tokens, emb, dtype=torch.bfloat16), ttnn.TILE_LAYOUT, ttnn.bfloat16)
-
-    ttnn.experimental.deepseek_prefill.unified_routed_expert_ffn(
-        x_tt,
-        gate_tt,
-        up_tt,
-        down_tt,
-        counts_tt,
-        idx_tt,
-        0,  # local_expert_id
-        output=out_tt,
-        input_m_tiles=max_tokens // 32,
-        x_is_row_major=True,
-    )
-
-    out = ttnn.to_torch(out_tt).float()[:max_tokens, :]
-    passing, pcc = comp_pcc(ref.float(), out, 0.97)
-    logger.info(f"[row-major FFN] PCC: {pcc}")
-    assert passing, f"row-major FFN PCC {pcc} below 0.97"
-
-
-@torch.no_grad()
-# unified_routed_expert_ffn requires an 11x8 compute grid; only Blackhole (13x10) has it.
-@pytest.mark.skipif(not is_blackhole(), reason="unified_routed_expert_ffn is Blackhole-only (needs 11x8 grid)")
-@pytest.mark.parametrize(
-    "mesh_device, device_params", [ROUTED_EXPERT_MESH_PARAMS[0]], indirect=["mesh_device", "device_params"]
-)
-def test_ttnn_routed_expert_ffn_row_major_offset(mesh_device, device_params):
-    """Row-major x read at a region offset (x_is_row_major + read_x_at_offset).
-
-    Models the fused MoE path: x is a shared ROW_MAJOR bf16 buffer whose region
-    for this expert starts at start[global_id]; the reader reads that region
-    (row-major), tilizes, and the writer places the bf8 TILE result back at the
-    same offset (direct-write). Also exercises the D2 relaxation — bf8 TILE
-    output while x is bf16 ROW_MAJOR.
-    """
-    torch.manual_seed(0)
-    emb = 1024
-    hidden = 512
     max_tokens = 64  # this expert's region: 2 tile-rows
-    offset_tiles = 2  # region starts at token row 64
     start_row = offset_tiles * 32
     buf_rows = start_row + max_tokens  # shared buffer holds offset padding + region
 
@@ -685,6 +628,7 @@ def test_ttnn_routed_expert_ffn_row_major_offset(mesh_device, device_params):
     ref = (torch.nn.functional.silu(xf @ gate.float()) * (xf @ up.float())) @ down.float()
 
     # Shared row-major buffer: expert's rows live at [start_row, start_row+max_tokens).
+    # When offset_tiles=0 this is just the region itself (no padding).
     x_full = torch.randn(buf_rows, emb, dtype=torch.bfloat16)
     x_full[start_row : start_row + max_tokens] = x_region
 
@@ -720,5 +664,5 @@ def test_ttnn_routed_expert_ffn_row_major_offset(mesh_device, device_params):
 
     out = ttnn.to_torch(out_tt).float()[start_row : start_row + max_tokens, :]
     passing, pcc = comp_pcc(ref.float(), out, 0.97)
-    logger.info(f"[row-major FFN offset] PCC: {pcc}")
-    assert passing, f"row-major FFN offset PCC {pcc} below 0.97"
+    logger.info(f"[row-major FFN offset_tiles={offset_tiles}] PCC: {pcc}")
+    assert passing, f"row-major FFN (offset_tiles={offset_tiles}) PCC {pcc} below 0.97"

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ttnn_routed_expert.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ttnn_routed_expert.py
@@ -589,3 +589,62 @@ def test_ttnn_routed_expert_models(
         run_pcc_check,
         use_predictable_data,
     )
+
+
+@torch.no_grad()
+@pytest.mark.parametrize(
+    "mesh_device, device_params", [ROUTED_EXPERT_MESH_PARAMS[0]], indirect=["mesh_device", "device_params"]
+)
+def test_ttnn_routed_expert_ffn_row_major(mesh_device, device_params):
+    """Direct unified_routed_expert_ffn test for x_is_row_major.
+
+    Feeds a ROW_MAJOR bf16 per-expert x; the op tilizes it internally (bf16 ->
+    bf8_b) before the gate/up matmul, fusing the standalone to_layout. One
+    expert, all rows valid, no region offset — isolates the row-major read +
+    compute tilize from the composite / insert-offset path. Output is TILE bf16
+    (must match x dtype per the op contract).
+    """
+    torch.manual_seed(0)
+    emb = 1024  # K_gate_tiles = 32 -> 2 gate/up K-blocks
+    hidden = 512
+    max_tokens = 64  # 2 tile-rows
+
+    # Torch reference: silu(x @ gate) * (x @ up) @ down.
+    x = torch.randn(max_tokens, emb, dtype=torch.bfloat16)
+    scale = 0.05
+    gate = (torch.randn(emb, hidden) * scale).bfloat16()
+    up = (torch.randn(emb, hidden) * scale).bfloat16()
+    down = (torch.randn(hidden, emb) * scale).bfloat16()
+    xf = x.float()
+    ref = (torch.nn.functional.silu(xf @ gate.float()) * (xf @ up.float())) @ down.float()
+
+    dram = ttnn.DRAM_MEMORY_CONFIG
+
+    def to_tt(t, layout, dtype):
+        return ttnn.from_torch(t, layout=layout, dtype=dtype, device=mesh_device, memory_config=dram)
+
+    x_tt = to_tt(x, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16)
+    gate_tt = to_tt(gate, ttnn.TILE_LAYOUT, ttnn.bfloat8_b)
+    up_tt = to_tt(up, ttnn.TILE_LAYOUT, ttnn.bfloat8_b)
+    down_tt = to_tt(down, ttnn.TILE_LAYOUT, ttnn.bfloat8_b)
+    counts_tt = to_tt(torch.tensor([max_tokens], dtype=torch.int32), ttnn.ROW_MAJOR_LAYOUT, ttnn.uint32)
+    idx_tt = to_tt(torch.tensor([0], dtype=torch.int32), ttnn.ROW_MAJOR_LAYOUT, ttnn.uint32)
+    out_tt = to_tt(torch.zeros(max_tokens, emb, dtype=torch.bfloat16), ttnn.TILE_LAYOUT, ttnn.bfloat16)
+
+    ttnn.experimental.deepseek_prefill.unified_routed_expert_ffn(
+        x_tt,
+        gate_tt,
+        up_tt,
+        down_tt,
+        counts_tt,
+        idx_tt,
+        0,  # local_expert_id
+        output=out_tt,
+        input_m_tiles=max_tokens // 32,
+        x_is_row_major=True,
+    )
+
+    out = ttnn.to_torch(out_tt).float()[:max_tokens, :]
+    passing, pcc = comp_pcc(ref.float(), out, 0.97)
+    logger.info(f"[row-major FFN] PCC: {pcc}")
+    assert passing, f"row-major FFN PCC {pcc} below 0.97"

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ttnn_routed_expert.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ttnn_routed_expert.py
@@ -648,3 +648,73 @@ def test_ttnn_routed_expert_ffn_row_major(mesh_device, device_params):
     passing, pcc = comp_pcc(ref.float(), out, 0.97)
     logger.info(f"[row-major FFN] PCC: {pcc}")
     assert passing, f"row-major FFN PCC {pcc} below 0.97"
+
+
+@torch.no_grad()
+@pytest.mark.parametrize(
+    "mesh_device, device_params", [ROUTED_EXPERT_MESH_PARAMS[0]], indirect=["mesh_device", "device_params"]
+)
+def test_ttnn_routed_expert_ffn_row_major_offset(mesh_device, device_params):
+    """Row-major x read at a region offset (x_is_row_major + read_x_at_offset).
+
+    Models the fused MoE path: x is a shared ROW_MAJOR bf16 buffer whose region
+    for this expert starts at start[global_id]; the reader reads that region
+    (row-major), tilizes, and the writer places the bf8 TILE result back at the
+    same offset (direct-write). Also exercises the D2 relaxation — bf8 TILE
+    output while x is bf16 ROW_MAJOR.
+    """
+    torch.manual_seed(0)
+    emb = 1024
+    hidden = 512
+    max_tokens = 64  # this expert's region: 2 tile-rows
+    offset_tiles = 2  # region starts at token row 64
+    start_row = offset_tiles * 32
+    buf_rows = start_row + max_tokens  # shared buffer holds offset padding + region
+
+    # This expert's tokens (torch reference on the region only).
+    x_region = torch.randn(max_tokens, emb, dtype=torch.bfloat16)
+    scale = 0.05
+    gate = (torch.randn(emb, hidden) * scale).bfloat16()
+    up = (torch.randn(emb, hidden) * scale).bfloat16()
+    down = (torch.randn(hidden, emb) * scale).bfloat16()
+    xf = x_region.float()
+    ref = (torch.nn.functional.silu(xf @ gate.float()) * (xf @ up.float())) @ down.float()
+
+    # Shared row-major buffer: expert's rows live at [start_row, start_row+max_tokens).
+    x_full = torch.randn(buf_rows, emb, dtype=torch.bfloat16)
+    x_full[start_row : start_row + max_tokens] = x_region
+
+    dram = ttnn.DRAM_MEMORY_CONFIG
+
+    def to_tt(t, layout, dtype):
+        return ttnn.from_torch(t, layout=layout, dtype=dtype, device=mesh_device, memory_config=dram)
+
+    x_tt = to_tt(x_full, ttnn.ROW_MAJOR_LAYOUT, ttnn.bfloat16)
+    gate_tt = to_tt(gate, ttnn.TILE_LAYOUT, ttnn.bfloat8_b)
+    up_tt = to_tt(up, ttnn.TILE_LAYOUT, ttnn.bfloat8_b)
+    down_tt = to_tt(down, ttnn.TILE_LAYOUT, ttnn.bfloat8_b)
+    counts_tt = to_tt(torch.tensor([max_tokens], dtype=torch.int32), ttnn.ROW_MAJOR_LAYOUT, ttnn.uint32)
+    idx_tt = to_tt(torch.tensor([0], dtype=torch.int32), ttnn.ROW_MAJOR_LAYOUT, ttnn.uint32)
+    offsets_tt = to_tt(torch.tensor([start_row], dtype=torch.int32), ttnn.ROW_MAJOR_LAYOUT, ttnn.uint32)
+    # bf8 TILE output the size of the shared buffer; writer places the region at offset.
+    out_tt = to_tt(torch.zeros(buf_rows, emb, dtype=torch.bfloat16), ttnn.TILE_LAYOUT, ttnn.bfloat8_b)
+
+    ttnn.experimental.deepseek_prefill.unified_routed_expert_ffn(
+        x_tt,
+        gate_tt,
+        up_tt,
+        down_tt,
+        counts_tt,
+        idx_tt,
+        0,  # local_expert_id
+        output=out_tt,
+        expert_region_offsets=offsets_tt,
+        input_m_tiles=max_tokens // 32,
+        read_x_at_offset=True,
+        x_is_row_major=True,
+    )
+
+    out = ttnn.to_torch(out_tt).float()[start_row : start_row + max_tokens, :]
+    passing, pcc = comp_pcc(ref.float(), out, 0.97)
+    logger.info(f"[row-major FFN offset] PCC: {pcc}")
+    assert passing, f"row-major FFN offset PCC {pcc} below 0.97"

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
@@ -50,7 +50,7 @@ def test_deepseek_v3_moe_perf_loudbox():
         # device fill). The 8x1 proxy (perf-host-64) is fill-dominated — it filled the
         # full capacity buffer for only 64 active tokens — so it drops the most:
         # 35.08 ms -> 27.59 ms. Was 35_082_637.
-        expected_ns_8x1=27_587_332,
+        expected_ns_8x1=17_151_588,
         model_name_8x1="deepseek_v3_moe_lb_8x1_dispatch_combine",
         command_2x4=_CMD_2X4,
         # Recalibrated 2026-06-24 on BH LoudBox 2x4 for the same in-place direct-write
@@ -75,7 +75,7 @@ def test_deepseek_v3_moe_perf_galaxy():
 
     run_model_device_perf_test_with_merge(
         command=_CMD_8X4_pad0,
-        expected_device_perf_ns_per_iteration=32_766_805,  # Recalibrated 2026-07-07 (perf improvement, was 41_294_210).
+        expected_device_perf_ns_per_iteration=22_492_126,  # Recalibrated 2026-07-20 (perf improvement, was 32_766_805).
         subdir="deepseek_v3_moe",
         model_name="deepseek_v3_moe_glx_8x4",
         num_iterations=1,

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py
@@ -73,7 +73,7 @@ _SUBTORUS_Y4_ENV = {
         ),
         (
             f"pytest {_TEST_PATH} -k 'mesh-2x4-2link and layer3 and gate_device and no_ref and isl_6k4'",
-            48_248_396,  # Re-centered 2026-07-09 for two stacked speedups now in the tree -- BOTH
+            50_810_785,  # Re-centered 2026-07-20 for two stacked speedups now in the tree -- BOTH
             # the in-place direct-write change (drop the separate output buffer + per-layer fill;
             # measured 50.61 ms alone) AND #47536 (update_padded_kv_cache RM/fp8; measured 51.29 ms
             # alone). The combined 2x4-2link number can't be measured on the galaxy, so the target is
@@ -111,7 +111,7 @@ _SUBTORUS_Y4_ENV = {
         ),
         (
             f"pytest {_TEST_PATH} -k 'fabric2d-mesh-2x4 and layer3 and gate_device and no_ref and isl_6k4'",
-            63_200_000,  # Re-centered 2026-06-25 for two stacked speedups now in the tree -- BOTH
+            65_161_594,  # Re-centered 2026-06-25 for two stacked speedups now in the tree -- BOTH
             # the in-place direct-write change (measured 64.30 ms alone) AND #47536
             # (update_padded_kv_cache RM/fp8; measured 64.80 ms alone). The combined 2x4-2link number
             # can't be measured on the galaxy, so the target is the midpoint of the plausible combined

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -24,7 +24,6 @@ from tracy import signpost
 
 import ttnn
 from models.common.lightweightmodule import LightweightModule
-from models.common.utility_functions import is_blackhole
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import ExpertMapping, get_ep_mesh_mapper
 from models.demos.deepseek_v3_d_p.tt.moe.tt_combine import TtCombineModule
 from models.demos.deepseek_v3_d_p.tt.moe.tt_dispatch import TtDispatchModule
@@ -583,42 +582,15 @@ class TtMoe(LightweightModule):
         # Routed expert expects (experts_per_chip, max_tokens, emb_dim)
         # Squeeze the first two dimensions
 
+        # TtRoutedExpert.forward owns the per-arch layout/dtype prep: Blackhole
+        # consumes the ROW_MAJOR bf16 buffer and returns a fresh output; Wormhole
+        # tiles it internally for the extract loop. Either way the ROW_MAJOR input
+        # is independent of the result and can be freed here, unless the PCC check
+        # needs it to compare against the bfloat16 torch reference.
         squeezed_dispatch = ttnn.squeeze(ttnn.squeeze(dispatched_buffer, dim=0), dim=0)
-        if is_blackhole():
-            # Blackhole fused path: hand the routed expert the ROW_MAJOR bf16 buffer
-            # directly. The op tilizes x and packs bf8 internally and allocates its
-            # own TILE bf8 output, so there is no up-front to_layout and no in-place
-            # aliasing — expert_outputs is a fresh buffer independent of the input.
-            expert_outputs = self.routed_expert(squeezed_dispatch, tt_expert_token_counts, tt_expert_region_offsets)
-            # The ROW_MAJOR input is fully consumed by the op; free it unless the PCC
-            # check needs it to compare against the bfloat16 torch reference.
-            if not return_intermediates:
-                dispatched_buffer = ttnn.deallocate(dispatched_buffer)
-        else:
-            # Wormhole fallback: tilize to bf8 up front for the per-expert extract
-            # loop (extract → routed_expert_ffn → insert).
-            dispatched_buffer_tiled = ttnn.to_layout(
-                squeezed_dispatch,
-                ttnn.TILE_LAYOUT,
-                dtype=self.routed_expert.activations_dtype,
-            )
-            # Free the original ROW_MAJOR DRAM buffer before entering routed_expert
-            # for clear state. When return_intermediates=True, keep it so the PCC
-            # check can compare against the bfloat16 torch reference (the tiled
-            # buffer may be bfloat8_b).
-            if not return_intermediates:
-                dispatched_buffer = ttnn.deallocate(dispatched_buffer)
-
-            logger.debug(f"[TtMoe.forward] dispatched_buffer_tiled shape: {dispatched_buffer_tiled.shape}")
-
-            # expert_outputs aliases dispatched_buffer_tiled — TtRoutedExpert.forward
-            # sets expert_outputs = dispatched_buffer and writes per-expert FFN
-            # results back in-place via deepseek_prefill.insert. Must NOT deallocate
-            # dispatched_buffer_tiled here; downstream ttnn.unsqueeze / combine still
-            # depend on that storage.
-            expert_outputs = self.routed_expert(
-                dispatched_buffer_tiled, tt_expert_token_counts, tt_expert_region_offsets
-            )
+        expert_outputs = self.routed_expert(squeezed_dispatch, tt_expert_token_counts, tt_expert_region_offsets)
+        if not return_intermediates:
+            dispatched_buffer = ttnn.deallocate(dispatched_buffer)
         logger.debug(f"[TtMoe.forward] expert_outputs shape: {expert_outputs.shape}")
 
         # Add back the batch dimensions for combine

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -24,6 +24,7 @@ from tracy import signpost
 
 import ttnn
 from models.common.lightweightmodule import LightweightModule
+from models.common.utility_functions import is_blackhole
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import ExpertMapping, get_ep_mesh_mapper
 from models.demos.deepseek_v3_d_p.tt.moe.tt_combine import TtCombineModule
 from models.demos.deepseek_v3_d_p.tt.moe.tt_dispatch import TtDispatchModule
@@ -582,28 +583,42 @@ class TtMoe(LightweightModule):
         # Routed expert expects (experts_per_chip, max_tokens, emb_dim)
         # Squeeze the first two dimensions
 
-        # Convert dispatched_buffer to TILE_LAYOUT for routed experts
-        dispatched_buffer_tiled = ttnn.to_layout(
-            ttnn.squeeze(ttnn.squeeze(dispatched_buffer, dim=0), dim=0),
-            ttnn.TILE_LAYOUT,
-            dtype=self.routed_expert.activations_dtype,
-        )
+        squeezed_dispatch = ttnn.squeeze(ttnn.squeeze(dispatched_buffer, dim=0), dim=0)
+        if is_blackhole():
+            # Blackhole fused path: hand the routed expert the ROW_MAJOR bf16 buffer
+            # directly. The op tilizes x and packs bf8 internally and allocates its
+            # own TILE bf8 output, so there is no up-front to_layout and no in-place
+            # aliasing — expert_outputs is a fresh buffer independent of the input.
+            expert_outputs = self.routed_expert(squeezed_dispatch, tt_expert_token_counts, tt_expert_region_offsets)
+            # The ROW_MAJOR input is fully consumed by the op; free it unless the PCC
+            # check needs it to compare against the bfloat16 torch reference.
+            if not return_intermediates:
+                dispatched_buffer = ttnn.deallocate(dispatched_buffer)
+        else:
+            # Wormhole fallback: tilize to bf8 up front for the per-expert extract
+            # loop (extract → routed_expert_ffn → insert).
+            dispatched_buffer_tiled = ttnn.to_layout(
+                squeezed_dispatch,
+                ttnn.TILE_LAYOUT,
+                dtype=self.routed_expert.activations_dtype,
+            )
+            # Free the original ROW_MAJOR DRAM buffer before entering routed_expert
+            # for clear state. When return_intermediates=True, keep it so the PCC
+            # check can compare against the bfloat16 torch reference (the tiled
+            # buffer may be bfloat8_b).
+            if not return_intermediates:
+                dispatched_buffer = ttnn.deallocate(dispatched_buffer)
 
-        # Free the original ROW_MAJOR DRAM buffer before entering routed_expert for clear state.
-        # When return_intermediates=True, keep it so the PCC check can compare against the
-        # bfloat16 torch reference (the tiled buffer may be bfloat8_b).
-        if not return_intermediates:
-            dispatched_buffer = ttnn.deallocate(dispatched_buffer)
+            logger.debug(f"[TtMoe.forward] dispatched_buffer_tiled shape: {dispatched_buffer_tiled.shape}")
 
-        logger.debug(f"[TtMoe.forward] dispatched_buffer_tiled shape: {dispatched_buffer_tiled.shape}")
-
-        # NOTE: expert_outputs aliases dispatched_buffer_tiled — TtRoutedExpert.forward sets
-        # expert_outputs = dispatched_buffer and then writes per-expert FFN results back
-        # in-place via deepseek_prefill.insert. The two names point at the same device buffer.
-        # Therefore we must NOT call ttnn.deallocate(dispatched_buffer_tiled) here; doing so
-        # would free the storage that expert_outputs still depends on, and the subsequent
-        # ttnn.unsqueeze / combine_module calls would raise "Tensor is not allocated".
-        expert_outputs = self.routed_expert(dispatched_buffer_tiled, tt_expert_token_counts, tt_expert_region_offsets)
+            # expert_outputs aliases dispatched_buffer_tiled — TtRoutedExpert.forward
+            # sets expert_outputs = dispatched_buffer and writes per-expert FFN
+            # results back in-place via deepseek_prefill.insert. Must NOT deallocate
+            # dispatched_buffer_tiled here; downstream ttnn.unsqueeze / combine still
+            # depend on that storage.
+            expert_outputs = self.routed_expert(
+                dispatched_buffer_tiled, tt_expert_token_counts, tt_expert_region_offsets
+            )
         logger.debug(f"[TtMoe.forward] expert_outputs shape: {expert_outputs.shape}")
 
         # Add back the batch dimensions for combine

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
@@ -412,14 +412,9 @@ class TtRoutedExpert(LightweightModule):
         """
         logger.debug(f"Forward pass: dispatched_buffer shape={dispatched_buffer.shape}")
 
-        # ROW_MAJOR input is the Blackhole fused path: the op tilizes x and packs
-        # bf8 internally, so it must stay bf16. Otherwise match the activations
-        # dtype for the per-expert extract loop.
-        if dispatched_buffer.layout != ttnn.ROW_MAJOR_LAYOUT and dispatched_buffer.dtype != self.activations_dtype:
-            logger.warning(f"{dispatched_buffer.dtype=} typecasting to {self.activations_dtype}")
-            dispatched_buffer = ttnn.typecast(dispatched_buffer, self.activations_dtype)
-
         if is_blackhole():
+            # Fused path: the op consumes the ROW_MAJOR bf16 buffer directly,
+            # tilizing x and packing bf8 internally, and returns a fresh output.
             signpost(header="UnifiedRoutedExpertMoe")
             expert_outputs = ttnn.experimental.deepseek_prefill.unified_routed_expert_moe(
                 dispatched_buffer,
@@ -436,7 +431,10 @@ class TtRoutedExpert(LightweightModule):
             logger.debug(f"Final expert_outputs shape: {expert_outputs.shape}")
             return expert_outputs
 
-        # Wormhole fallback: per-expert Python loop with extract → FFN → insert.
+        # Wormhole fallback: tile to the activation dtype for the per-expert
+        # extract → FFN → insert loop. expert_outputs aliases this buffer; the
+        # insert writes each expert's result back in place.
+        dispatched_buffer = ttnn.to_layout(dispatched_buffer, ttnn.TILE_LAYOUT, dtype=self.activations_dtype)
         expert_outputs = dispatched_buffer
         for local_expert in range(self.experts_per_chip):
             signpost(f"Expert {local_expert+1}/{self.experts_per_chip}")

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
@@ -412,8 +412,10 @@ class TtRoutedExpert(LightweightModule):
         """
         logger.debug(f"Forward pass: dispatched_buffer shape={dispatched_buffer.shape}")
 
-        # Convert input to activations dtype if needed
-        if dispatched_buffer.dtype != self.activations_dtype:
+        # ROW_MAJOR input is the Blackhole fused path: the op tilizes x and packs
+        # bf8 internally, so it must stay bf16. Otherwise match the activations
+        # dtype for the per-expert extract loop.
+        if dispatched_buffer.layout != ttnn.ROW_MAJOR_LAYOUT and dispatched_buffer.dtype != self.activations_dtype:
             logger.warning(f"{dispatched_buffer.dtype=} typecasting to {self.activations_dtype}")
             dispatched_buffer = ttnn.typecast(dispatched_buffer, self.activations_dtype)
 

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
@@ -413,8 +413,15 @@ class TtRoutedExpert(LightweightModule):
         logger.debug(f"Forward pass: dispatched_buffer shape={dispatched_buffer.shape}")
 
         if is_blackhole():
-            # Fused path: the op consumes the ROW_MAJOR bf16 buffer directly,
-            # tilizing x and packing bf8 internally, and returns a fresh output.
+            # Fused path. The composite op selects its strategy from the input
+            # layout: a ROW_MAJOR bf16 buffer is consumed directly (x tilized and
+            # bf8-packed internally, fresh output); a TILE buffer takes the
+            # non-fused read path and is written in place. TILE mode requires x to
+            # be bf8, so cast a mismatched TILE input; the ROW_MAJOR fast path is
+            # left untouched.
+            if dispatched_buffer.layout == ttnn.TILE_LAYOUT and dispatched_buffer.dtype != self.activations_dtype:
+                logger.warning(f"{dispatched_buffer.dtype=} typecasting to {self.activations_dtype}")
+                dispatched_buffer = ttnn.typecast(dispatched_buffer, self.activations_dtype)
             signpost(header="UnifiedRoutedExpertMoe")
             expert_outputs = ttnn.experimental.deepseek_prefill.unified_routed_expert_moe(
                 dispatched_buffer,
@@ -431,10 +438,17 @@ class TtRoutedExpert(LightweightModule):
             logger.debug(f"Final expert_outputs shape: {expert_outputs.shape}")
             return expert_outputs
 
-        # Wormhole fallback: tile to the activation dtype for the per-expert
-        # extract → FFN → insert loop. expert_outputs aliases this buffer; the
-        # insert writes each expert's result back in place.
-        dispatched_buffer = ttnn.to_layout(dispatched_buffer, ttnn.TILE_LAYOUT, dtype=self.activations_dtype)
+        # Wormhole fallback: the per-expert extract → FFN → insert loop needs a
+        # TILE activations_dtype buffer. A ROW_MAJOR input is tilized and cast in
+        # one to_layout; an already-TILE input only needs the dtype cast (to_layout
+        # would not cast a TILE→TILE tensor). expert_outputs aliases this buffer;
+        # the insert writes each expert's result back in place.
+        if dispatched_buffer.layout == ttnn.TILE_LAYOUT:
+            if dispatched_buffer.dtype != self.activations_dtype:
+                logger.warning(f"{dispatched_buffer.dtype=} typecasting to {self.activations_dtype}")
+                dispatched_buffer = ttnn.typecast(dispatched_buffer, self.activations_dtype)
+        else:
+            dispatched_buffer = ttnn.to_layout(dispatched_buffer, ttnn.TILE_LAYOUT, dtype=self.activations_dtype)
         expert_outputs = dispatched_buffer
         for local_expert in range(self.experts_per_chip):
             signpost(f"Expert {local_expert+1}/{self.experts_per_chip}")

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert.py
@@ -49,10 +49,11 @@ def run_single_routed_expert(
     num_tokens: int,
     emb_dim: int,
     hidden_dim: int,
+    x_row_major: bool = False,
 ):
     """
     Simplest scenario: 1 chip, 1 expert. Shared body for the per-model entrypoints below — they
-    differ only on the (emb_dim, hidden_dim) shape axis.
+    differ only on the (emb_dim, hidden_dim) shape axis and the x input layout.
 
     Perfect for profiling the core FFN computation without any mesh complexity.
     """
@@ -85,12 +86,15 @@ def run_single_routed_expert(
     logger.debug(f"Torch output shape: {torch_output.shape}")
 
     # Create TTNN input: 2D (num_tokens, emb_dim), replicated across the 1-device mesh.
+    # The composite op branches on x layout: ROW_MAJOR is bf16 (tilized and bf8-packed
+    # inside the op), TILE is consumed directly as bf8. Pair the dtype with the layout so
+    # each variation drives its real device path.
     tt_input = ttnn.from_torch(
         torch_input,
         mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
-        layout=ttnn.TILE_LAYOUT,
+        layout=ttnn.ROW_MAJOR_LAYOUT if x_row_major else ttnn.TILE_LAYOUT,
         device=mesh_device,
-        dtype=ttnn.bfloat8_b,
+        dtype=ttnn.bfloat16 if x_row_major else ttnn.bfloat8_b,
     )
     logger.debug(f"TTNN input shape: {tt_input.shape}")
 
@@ -212,8 +216,11 @@ def _xfail_blackhole_token_sweep(request, silicon_arch_name):
 @pytest.mark.parametrize(
     "mesh_device, device_params", SINGLE_CHIP_MESH_PARAMS, indirect=["mesh_device", "device_params"]
 )
-def test_single_routed_expert_models(mesh_device, device_params, num_tokens: int, emb_dim: int, hidden_dim: int):
-    run_single_routed_expert(mesh_device, device_params, num_tokens, emb_dim, hidden_dim)
+@pytest.mark.parametrize("x_row_major", [True, False], ids=["x_rm", "x_tile"])
+def test_single_routed_expert_models(
+    mesh_device, device_params, num_tokens: int, emb_dim: int, hidden_dim: int, x_row_major: bool
+):
+    run_single_routed_expert(mesh_device, device_params, num_tokens, emb_dim, hidden_dim, x_row_major)
 
 
 # (allocated_tokens, active_tokens, id) sweep for the count-aware sparsity test, applied per
@@ -231,6 +238,7 @@ def run_single_routed_expert_faked_token_count(
     active_tokens: int,
     emb_dim: int,
     hidden_dim: int,
+    x_row_major: bool = False,
 ):
     """
     Verifies the unified kernel honors expert_token_counts and skips work on
@@ -261,12 +269,15 @@ def run_single_routed_expert_faked_token_count(
     with torch.no_grad():
         torch_output_active = torch_expert(torch_active)
 
+    # ROW_MAJOR is bf16 (tilized + bf8-packed in-op), TILE is consumed directly as bf8.
+    # With active_tokens < allocated_tokens the ROW_MAJOR variant is what exercises the
+    # reader's clamp-read of the inactive rows past the runtime count.
     tt_input = ttnn.from_torch(
         torch_input,
         mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
-        layout=ttnn.TILE_LAYOUT,
+        layout=ttnn.ROW_MAJOR_LAYOUT if x_row_major else ttnn.TILE_LAYOUT,
         device=mesh_device,
-        dtype=ttnn.bfloat8_b,
+        dtype=ttnn.bfloat16 if x_row_major else ttnn.bfloat8_b,
     )
 
     def _make_idx_tensor(values):
@@ -338,10 +349,17 @@ def single_routed_expert_faked_params():
 @pytest.mark.parametrize(
     "mesh_device, device_params", SINGLE_CHIP_MESH_PARAMS, indirect=["mesh_device", "device_params"]
 )
+@pytest.mark.parametrize("x_row_major", [True, False], ids=["x_rm", "x_tile"])
 @pytest.mark.skipif(not is_blackhole(), reason="device-side count-aware sparsity is Blackhole-only")
 def test_single_routed_expert_faked_token_count_models(
-    mesh_device, device_params, allocated_tokens: int, active_tokens: int, emb_dim: int, hidden_dim: int
+    mesh_device,
+    device_params,
+    allocated_tokens: int,
+    active_tokens: int,
+    emb_dim: int,
+    hidden_dim: int,
+    x_row_major: bool,
 ):
     run_single_routed_expert_faked_token_count(
-        mesh_device, device_params, allocated_tokens, active_tokens, emb_dim, hidden_dim
+        mesh_device, device_params, allocated_tokens, active_tokens, emb_dim, hidden_dim, x_row_major
     )

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
@@ -59,6 +59,7 @@
 #include "api/compute/matmul.h"
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/tile_move_copy.h"
+#include "api/compute/tilize.h"
 #include "api/dataflow/circular_buffer.h"
 #include "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_fused_activation.hpp"
 
@@ -247,7 +248,8 @@ template <
     uint32_t out_subblock_h,
     uint32_t out_subblock_w,
     uint32_t out_subblock_num_tiles,
-    uint32_t out_block_num_tiles>
+    uint32_t out_block_num_tiles,
+    bool tilize_x = false>
 FORCE_INLINE void matmul_phase_fused_gu(
     uint32_t x_cb_id,
     uint32_t gate_cb_id,
@@ -255,7 +257,8 @@ FORCE_INLINE void matmul_phase_fused_gu(
     uint32_t partials_gu_cb_id,
     uint32_t partials_up_cb_id,
     uint32_t gate_intermed_cb_id,
-    uint32_t up_intermed_cb_id) {
+    uint32_t up_intermed_cb_id,
+    uint32_t x_rm_cb_id = 0) {
     PACK((pack_reconfig_data_format(partials_gu_cb_id)));
 #ifdef PACKER_L1_ACC
     PACK((llk_pack_reconfig_l1_acc(0)));
@@ -267,6 +270,7 @@ FORCE_INLINE void matmul_phase_fused_gu(
     CircularBuffer partials_gu_cb(partials_gu_cb_id);
     CircularBuffer partials_up_cb(partials_up_cb_id);
     CircularBuffer gate_intermed_cb(gate_intermed_cb_id);
+    CircularBuffer x_rm_cb(x_rm_cb_id);
 
     // Reserve both partials CBs once for the full per-core block. pack_tile
     // with output_tile_index writes to absolute slots; WrPtr doesn't advance
@@ -277,6 +281,39 @@ FORCE_INLINE void matmul_phase_fused_gu(
     partials_up_cb.reserve_back(out_block_num_tiles);
 
     for (uint32_t block = 0; block < num_blocks; ++block) {
+        if constexpr (tilize_x) {
+            // Row-major x: tilize this K-block's cb_x_rm strips (bf16) -> x_cb
+            // (cb_in0_x, bf8_b) before the matmul consumes it. Packer recipe
+            // mirrors conv's conv_bmm_tilize.cpp: reconfig packer to the tilize
+            // output + L1_ACC off for the overwrite, tilize each 32-row strip,
+            // then restore the matmul unpack (x->SrcB, gate->SrcA) and the
+            // partials packer + L1_ACC state for this block.
+            constexpr uint32_t n_strips = in0_block_num_tiles / in0_block_w;
+            x_rm_cb.wait_front(in0_block_num_tiles);
+            x_cb.reserve_back(in0_block_num_tiles);
+            PACK((pack_reconfig_data_format(partials_gu_cb_id, x_cb_id)));
+#ifdef PACKER_L1_ACC
+            PACK((llk_pack_reconfig_l1_acc(0)));
+#endif
+            // Point SrcA at the bf16 row-major input. The prior matmul left SrcA
+            // configured for the gate/up weights (bf4/bf8); without this the
+            // tilize unpacks bf16 with the wrong register datatype and stalls.
+            // (Mirrors compute_kernel_lib::tilize's UnpackReconfigure step.)
+            reconfig_data_format_srca(x_rm_cb_id);
+            tilize_init(x_rm_cb_id, in0_block_w, x_cb_id);
+            for (uint32_t s = 0; s < n_strips; ++s) {
+                tilize_block(x_rm_cb_id, in0_block_w, x_cb_id, s * in0_block_w, s * in0_block_w);
+            }
+            tilize_uninit(x_rm_cb_id, x_cb_id);
+            x_cb.push_back(in0_block_num_tiles);
+            x_rm_cb.pop_front(in0_block_num_tiles);
+            reconfig_data_format(gate_cb_id, x_cb_id);
+            matmul_block_init(x_cb_id, gate_cb_id, 0, out_subblock_w, out_subblock_h, in0_block_w);
+            PACK((pack_reconfig_data_format(x_cb_id, partials_gu_cb_id)));
+#ifdef PACKER_L1_ACC
+            PACK((llk_pack_reconfig_l1_acc(block == 0 ? 0 : 1)));
+#endif
+        }
         x_cb.wait_front(in0_block_num_tiles);
         gate_cb.wait_front(in1_block_num_tiles);
         up_cb.wait_front(in1_block_num_tiles);
@@ -681,8 +718,16 @@ void kernel_main() {
             gu_out_subblock_h,
             gu_out_subblock_w,
             gu_out_subblock_num_tiles,
-            gu_out_block_num_tiles>(
-            cb_in0_x, cb_in1_gate, cb_in1_up, cb_partials_gu, cb_partials_up, cb_gate_intermed, cb_up_intermed);
+            gu_out_block_num_tiles,
+            /*tilize_x=*/(x_is_row_major != 0)>(
+            cb_in0_x,
+            cb_in1_gate,
+            cb_in1_up,
+            cb_partials_gu,
+            cb_partials_up,
+            cb_gate_intermed,
+            cb_up_intermed,
+            cb_x_rm);
 
 #ifdef SWIGLU_OAI
         // Phase 3 (SwiGLU-OAI): fused clamp + alpha-sigmoid + (up+1) directly on

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
@@ -62,6 +62,7 @@
 #include "api/compute/tilize.h"
 #include "api/dataflow/circular_buffer.h"
 #include "tools/profiler/kernel_profiler.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
 #include "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_fused_activation.hpp"
 
 #ifdef SWIGLU_OAI
@@ -95,7 +96,7 @@ FORCE_INLINE void matmul_phase(uint32_t in0_cb_id, uint32_t in1_cb_id, uint32_t 
     // Reconfig packer for partials format (previous phase's final_cb format
     // would otherwise leak). pack_reconfig_data_format (the reconfig variant)
     // does NOT reset L1_ACC — we do that explicitly below.
-    PACK((pack_reconfig_data_format(partials_cb_id)));
+    pack_reconfig_data_format(partials_cb_id);
 #ifdef PACKER_L1_ACC
     PACK((llk_pack_reconfig_l1_acc(0)));  // block 0 must overwrite, not accumulate
 #endif
@@ -194,7 +195,7 @@ FORCE_INLINE void matmul_phase(uint32_t in0_cb_id, uint32_t in1_cb_id, uint32_t 
     // Packer was configured for partials_cb format during matmul. The final
     // pack lands in final_cb (different format) — reconfigure both packer
     // data format and SrcA before the copy/pack loop.
-    PACK((pack_reconfig_data_format(final_cb_id)));
+    pack_reconfig_data_format(final_cb_id);
     // matmul puts in1 → SrcA, in0 → SrcB. Reconfigure SrcA from in1 to
     // partials so copy_tile reads partials.
     copy_tile_to_dst_init_short_with_dt(in1_cb_id, partials_cb_id);
@@ -250,17 +251,19 @@ template <
     uint32_t out_subblock_w,
     uint32_t out_subblock_num_tiles,
     uint32_t out_block_num_tiles,
+    // x_cb_id / x_rm_cb_id are compile-time so the tilize helper (which takes the
+    // input/output CB as template args, like conv_bmm_tilize.cpp) can consume them.
+    uint32_t x_cb_id,
+    uint32_t x_rm_cb_id,
     bool tilize_x = false>
 FORCE_INLINE void matmul_phase_fused_gu(
-    uint32_t x_cb_id,
     uint32_t gate_cb_id,
     uint32_t up_cb_id,
     uint32_t partials_gu_cb_id,
     uint32_t partials_up_cb_id,
     uint32_t gate_intermed_cb_id,
-    uint32_t up_intermed_cb_id,
-    uint32_t x_rm_cb_id = 0) {
-    PACK((pack_reconfig_data_format(partials_gu_cb_id)));
+    uint32_t up_intermed_cb_id) {
+    pack_reconfig_data_format(partials_gu_cb_id);
 #ifdef PACKER_L1_ACC
     PACK((llk_pack_reconfig_l1_acc(0)));
 #endif
@@ -271,7 +274,6 @@ FORCE_INLINE void matmul_phase_fused_gu(
     CircularBuffer partials_gu_cb(partials_gu_cb_id);
     CircularBuffer partials_up_cb(partials_up_cb_id);
     CircularBuffer gate_intermed_cb(gate_intermed_cb_id);
-    CircularBuffer x_rm_cb(x_rm_cb_id);
 
     // Reserve both partials CBs once for the full per-core block. pack_tile
     // with output_tile_index writes to absolute slots; WrPtr doesn't advance
@@ -285,33 +287,30 @@ FORCE_INLINE void matmul_phase_fused_gu(
         if constexpr (tilize_x) {
             DeviceZoneScopedN("TILIZE");  // TEMP profiling: in-kernel row-major tilize cost
             // Row-major x: tilize this K-block's cb_x_rm strips (bf16) -> x_cb
-            // (cb_in0_x, bf8_b) before the matmul consumes it. Packer recipe
-            // mirrors conv's conv_bmm_tilize.cpp: reconfig packer to the tilize
-            // output + L1_ACC off for the overwrite, tilize each 32-row strip,
-            // then restore the matmul unpack (x->SrcB, gate->SrcA) and the
+            // (cb_in0_x, bf8_b) before the matmul consumes it. L1_ACC is turned
+            // off so the tilize packs OVERWRITE x_cb rather than accumulate; the
+            // shared tilize helper (same one conv_bmm_tilize.cpp uses) then
+            // reconfigures unpack SrcA + pack format, drives the per-strip
+            // wait/reserve/tilize/push/pop over the in0_block_num_tiles /
+            // in0_block_w tile-rows, and restores init on exit. The helper left
+            // SrcA pointing at the bf16 row-major input, so restore it to the
+            // gate/up weight format before resuming the matmul (SrcB still holds
+            // x_cb_id — the BH tilize path never touches it); then restore the
             // partials packer + L1_ACC state for this block.
             constexpr uint32_t n_strips = in0_block_num_tiles / in0_block_w;
-            x_rm_cb.wait_front(in0_block_num_tiles);
-            x_cb.reserve_back(in0_block_num_tiles);
-            PACK((pack_reconfig_data_format(partials_gu_cb_id, x_cb_id)));
 #ifdef PACKER_L1_ACC
             PACK((llk_pack_reconfig_l1_acc(0)));
 #endif
-            // Point SrcA at the bf16 row-major input. The prior matmul left SrcA
-            // configured for the gate/up weights (bf4/bf8); without this the
-            // tilize unpacks bf16 with the wrong register datatype and stalls.
-            // (Mirrors compute_kernel_lib::tilize's UnpackReconfigure step.)
-            reconfig_data_format_srca(x_rm_cb_id);
-            tilize_init(x_rm_cb_id, in0_block_w, x_cb_id);
-            for (uint32_t s = 0; s < n_strips; ++s) {
-                tilize_block(x_rm_cb_id, in0_block_w, x_cb_id, s * in0_block_w, s * in0_block_w);
-            }
-            tilize_uninit(x_rm_cb_id, x_cb_id);
-            x_cb.push_back(in0_block_num_tiles);
-            x_rm_cb.pop_front(in0_block_num_tiles);
-            reconfig_data_format(gate_cb_id, x_cb_id);
+            compute_kernel_lib::tilize<
+                in0_block_w,
+                x_rm_cb_id,
+                x_cb_id,
+                compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit,
+                compute_kernel_lib::tilize_config::WaitMode::WaitBlock,
+                compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::UnpackAndPackReconfigure>(n_strips);
+            reconfig_data_format_srca(gate_cb_id);
             matmul_block_init(x_cb_id, gate_cb_id, 0, out_subblock_w, out_subblock_h, in0_block_w);
-            PACK((pack_reconfig_data_format(x_cb_id, partials_gu_cb_id)));
+            pack_reconfig_data_format(x_cb_id, partials_gu_cb_id);
 #ifdef PACKER_L1_ACC
             PACK((llk_pack_reconfig_l1_acc(block == 0 ? 0 : 1)));
 #endif
@@ -423,7 +422,7 @@ FORCE_INLINE void matmul_phase_fused_gu(
     //     overlapping with the next subblock's UNPACK rather than gating the
     //     pack pipeline as apply_activation_from_pack would.
     //   * pack dst → gate_intermed without per-tile SFPU.
-    PACK((pack_reconfig_data_format(gate_intermed_cb_id)));
+    pack_reconfig_data_format(gate_intermed_cb_id);
     // SrcA was last configured for the up matmul's in1 (up_cb_id). Switch
     // to partials_gu so copy_tile reads the accumulator.
     copy_tile_to_dst_init_short_with_dt(up_cb_id, partials_gu_cb_id);
@@ -497,7 +496,7 @@ FORCE_INLINE void swiglu_oai_activation_phase(
     gate_partials_cb.wait_front(out_block_num_tiles);
     up_partials_cb.wait_front(out_block_num_tiles);
 
-    PACK((pack_reconfig_data_format(activated_cb_id)));
+    pack_reconfig_data_format(activated_cb_id);
     // SrcA was last configured for the up matmul's in1 weights (prev_srcA_cb_id,
     // e.g. bf4). Reconfig to the Float16_b partials so copy_tile reads the
     // accumulator with the right format. Both partials CBs are Float16_b, so this
@@ -549,7 +548,7 @@ FORCE_INLINE void multiply_phase(uint32_t gate_cb_id, uint32_t up_cb_id, uint32_
     // reprograms the unpack MOP, not the data formats. Without the
     // explicit reconfig SrcB reads bf16 up_intermed bytes as bf8 and the
     // multiply collapses to denormal magnitudes.
-    PACK((pack_reconfig_data_format(activated_cb_id)));
+    pack_reconfig_data_format(activated_cb_id);
     reconfig_data_format(gate_cb_id, up_cb_id);
     mul_tiles_init(gate_cb_id, up_cb_id);
 
@@ -620,8 +619,7 @@ void kernel_main() {
     constexpr uint32_t local_expert_id = get_compile_time_arg_val(31);
     constexpr uint32_t chunk_M_tiles = get_compile_time_arg_val(32);
     // x_is_row_major: tilize cb_x_rm -> cb_in0_x before the gate/up matmul.
-    // 0 => x already TILE in cb_in0_x. (Consumed by the tilize stage added in a
-    // later commit; unused when 0.)
+    // 0 => x already TILE in cb_in0_x.
     constexpr uint32_t x_is_row_major = get_compile_time_arg_val(33);
 
     // CBs
@@ -640,7 +638,7 @@ void kernel_main() {
     constexpr uint32_t cb_counts_scratch = get_named_compile_time_arg_val("cb_counts_scratch");
     constexpr uint32_t cb_idx_scratch = get_named_compile_time_arg_val("cb_idx_scratch");
     // Row-major bf16 x staging (x_is_row_major only); tilize input CB. Unused
-    // when x is TILE — the tilize stage that reads it lands in a later commit.
+    // when x is TILE.
     constexpr uint32_t cb_x_rm = get_named_compile_time_arg_val("cb_x_rm");
 
     CircularBuffer counts_scratch_cb(cb_counts_scratch);
@@ -721,15 +719,10 @@ void kernel_main() {
             gu_out_subblock_w,
             gu_out_subblock_num_tiles,
             gu_out_block_num_tiles,
+            /*x_cb_id=*/cb_in0_x,
+            /*x_rm_cb_id=*/cb_x_rm,
             /*tilize_x=*/(x_is_row_major != 0)>(
-            cb_in0_x,
-            cb_in1_gate,
-            cb_in1_up,
-            cb_partials_gu,
-            cb_partials_up,
-            cb_gate_intermed,
-            cb_up_intermed,
-            cb_x_rm);
+            cb_in1_gate, cb_in1_up, cb_partials_gu, cb_partials_up, cb_gate_intermed, cb_up_intermed);
 
 #ifdef SWIGLU_OAI
         // Phase 3 (SwiGLU-OAI): fused clamp + alpha-sigmoid + (up+1) directly on

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
@@ -580,6 +580,10 @@ void kernel_main() {
     constexpr uint32_t num_chunks = get_compile_time_arg_val(30);
     constexpr uint32_t local_expert_id = get_compile_time_arg_val(31);
     constexpr uint32_t chunk_M_tiles = get_compile_time_arg_val(32);
+    // x_is_row_major: tilize cb_x_rm -> cb_in0_x before the gate/up matmul.
+    // 0 => x already TILE in cb_in0_x. (Consumed by the tilize stage added in a
+    // later commit; unused when 0.)
+    constexpr uint32_t x_is_row_major = get_compile_time_arg_val(33);
 
     // CBs
     constexpr uint32_t cb_in0_x = get_named_compile_time_arg_val("cb_in0_x");
@@ -596,6 +600,9 @@ void kernel_main() {
     constexpr uint32_t cb_out = get_named_compile_time_arg_val("cb_out");
     constexpr uint32_t cb_counts_scratch = get_named_compile_time_arg_val("cb_counts_scratch");
     constexpr uint32_t cb_idx_scratch = get_named_compile_time_arg_val("cb_idx_scratch");
+    // Row-major bf16 x staging (x_is_row_major only); tilize input CB. Unused
+    // when x is TILE — the tilize stage that reads it lands in a later commit.
+    constexpr uint32_t cb_x_rm = get_named_compile_time_arg_val("cb_x_rm");
 
     CircularBuffer counts_scratch_cb(cb_counts_scratch);
     CircularBuffer idx_scratch_cb(cb_idx_scratch);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
@@ -61,6 +61,7 @@
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/tilize.h"
 #include "api/dataflow/circular_buffer.h"
+#include "tools/profiler/kernel_profiler.hpp"
 #include "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_fused_activation.hpp"
 
 #ifdef SWIGLU_OAI
@@ -282,6 +283,7 @@ FORCE_INLINE void matmul_phase_fused_gu(
 
     for (uint32_t block = 0; block < num_blocks; ++block) {
         if constexpr (tilize_x) {
+            DeviceZoneScopedN("TILIZE");  // TEMP profiling: in-kernel row-major tilize cost
             // Row-major x: tilize this K-block's cb_x_rm strips (bf16) -> x_cb
             // (cb_in0_x, bf8_b) before the matmul consumes it. Packer recipe
             // mirrors conv's conv_bmm_tilize.cpp: reconfig packer to the tilize

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
@@ -125,10 +125,14 @@ void kernel_main() {
     constexpr uint32_t read_x_at_offset = get_compile_time_arg_val(25);
     constexpr uint32_t cb_start_scratch = get_compile_time_arg_val(26);
     // x_is_row_major: x is ROW_MAJOR bf16 — stream sticks into cb_x_rm for the
-    // compute kernel to tilize. 0 => x is TILE bf8_b, read directly. (Consumed
-    // by the row-major read path added in a later commit; unused when 0.)
+    // compute kernel to tilize. 0 => x is TILE bf8_b, read directly.
     constexpr uint32_t x_is_row_major = get_compile_time_arg_val(27);
     constexpr uint32_t cb_x_rm = get_compile_time_arg_val(28);
+    // Tile height: rows (token-row sticks) per tile-row. Used to size row-major
+    // reads and to convert token counts to tile-rows.
+    constexpr uint32_t TILE_HEIGHT = get_compile_time_arg_val(29);
+    // Byte size of one row-major x element: x is bf16 in the row-major path.
+    constexpr uint32_t X_RM_ELEM_BYTES = get_compile_time_arg_val(30);
     // UP_SPLIT iff the reader multicasts up but does not read it from DRAM.
     constexpr bool up_split = (reader_mcasts_up != 0) && (reader_reads_up == 0);
 
@@ -139,15 +143,15 @@ void kernel_main() {
     constexpr uint32_t num_blocks_gu = K_gate_tiles / in0_block_w_gu;
     constexpr uint32_t num_blocks_d = K_down_tiles_padded / in0_block_w_d;
 
-    constexpr uint32_t x_accessor_offset = 29;
+    constexpr uint32_t x_accessor_offset = 31;
     constexpr auto x_args = TensorAccessorArgs<x_accessor_offset>();
     const auto x_acc = TensorAccessor(x_args, x_addr, get_tile_size(cb_in0_x));
     // Row-major x accessor (x_is_row_major): x is a ROW_MAJOR bf16 buffer whose
-    // page is one token-row stick = emb elements = K_gate_tiles*32 bf16 (2 B
-    // each). Partial-stick reads index page_id=token-row, offset_bytes=column
-    // window. Only used in the row-major path; the tile-page x_acc above serves
-    // the TILE path.
-    constexpr uint32_t x_rm_stick_bytes = K_gate_tiles * 32 * 2;
+    // page is one token-row stick = emb elements = K_gate_tiles*TILE_HEIGHT bf16
+    // (X_RM_ELEM_BYTES each). Partial-stick reads index page_id=token-row,
+    // offset_bytes=column window. Only used in the row-major path; the tile-page
+    // x_acc above serves the TILE path.
+    constexpr uint32_t x_rm_stick_bytes = K_gate_tiles * TILE_HEIGHT * X_RM_ELEM_BYTES;
     const auto x_acc_rm = TensorAccessor(x_args, x_addr, x_rm_stick_bytes);
 
     constexpr uint32_t gate_accessor_offset = x_args.next_compile_time_args_offset();
@@ -246,7 +250,7 @@ void kernel_main() {
     // For count=0 the loop is empty (no chunks processed). For count > 0 we
     // process ceil(count_tiles / chunk_M_tiles) chunks; the remaining chunks
     // (if any) are skipped — no DRAM reads, no mcasts, no compute.
-    const uint32_t count_tiles = (count_value + 31) / 32;
+    const uint32_t count_tiles = (count_value + TILE_HEIGHT - 1) / TILE_HEIGHT;
     const uint32_t effective_chunks_runtime = (count_tiles + chunk_M_tiles - 1) / chunk_M_tiles;
     // Clamp to compile-time num_chunks just in case (defensive against bad input).
     const uint32_t effective_chunks = effective_chunks_runtime < num_chunks ? effective_chunks_runtime : num_chunks;
@@ -286,7 +290,7 @@ void kernel_main() {
         cb_start_scratch_obj.push_back(1);
         const volatile tt_l1_ptr uint32_t* start_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(start_l1);
         const uint32_t start_value = start_ptr[global_expert_id];
-        x_start_tile_idx = (start_value / 32) * K_gate_tiles;
+        x_start_tile_idx = (start_value / TILE_HEIGHT) * K_gate_tiles;
         x_start_stick = start_value;
     }
 
@@ -420,21 +424,21 @@ void kernel_main() {
                     DeviceZoneScopedN("XREAD");
                     if constexpr (x_is_row_major != 0) {
                         // Row-major: read this K-block's column window (in0_block_w_gu
-                        // tiles wide) from each of the 32 token-row sticks of every
-                        // tile-row, laid contiguously so each tile-row forms one
-                        // 32 x (in0_block_w_gu*32) strip for tilize_block. page_id is
-                        // the token-row stick; offset_bytes is the K-block column
-                        // window within the emb-wide stick.
-                        constexpr uint32_t rm_kblock_bytes = in0_block_w_gu * 32 * 2;
+                        // tiles wide) from each of the TILE_HEIGHT token-row sticks of
+                        // every tile-row, laid contiguously so each tile-row forms one
+                        // TILE_HEIGHT x (in0_block_w_gu*32) strip for tilize_block.
+                        // page_id is the token-row stick; offset_bytes is the K-block
+                        // column window within the emb-wide stick.
+                        constexpr uint32_t rm_kblock_bytes = in0_block_w_gu * TILE_HEIGHT * X_RM_ELEM_BYTES;
                         const uint32_t col_off_bytes = kb * rm_kblock_bytes;
                         for (uint32_t m = 0; m < per_core_M; ++m) {
                             const uint32_t tile_row = this_core_first_row + m;
                             if (tile_row < count_tiles) {
-                                for (uint32_t r = 0; r < 32; ++r) {
+                                for (uint32_t r = 0; r < TILE_HEIGHT; ++r) {
                                     // x_start_stick offsets into this expert's region
                                     // of the shared row-major buffer (0 when x is a
                                     // standalone per-expert buffer).
-                                    const uint32_t stick = x_start_stick + tile_row * 32 + r;
+                                    const uint32_t stick = x_start_stick + tile_row * TILE_HEIGHT + r;
                                     noc_read.async_read(
                                         x_acc_rm,
                                         CoreLocalMem<uint32_t>(l1_x),
@@ -444,7 +448,8 @@ void kernel_main() {
                                     l1_x += rm_kblock_bytes;
                                 }
                             } else {
-                                l1_x += 32 * rm_kblock_bytes;
+                                // Pre-zero already covered these L1 bytes. Just advance.
+                                l1_x += TILE_HEIGHT * rm_kblock_bytes;
                             }
                         }
                     } else {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
@@ -123,6 +123,11 @@ void kernel_main() {
     // reads start at row 0. cb_start_scratch holds the fetched `start` page.
     constexpr uint32_t read_x_at_offset = get_compile_time_arg_val(25);
     constexpr uint32_t cb_start_scratch = get_compile_time_arg_val(26);
+    // x_is_row_major: x is ROW_MAJOR bf16 — stream sticks into cb_x_rm for the
+    // compute kernel to tilize. 0 => x is TILE bf8_b, read directly. (Consumed
+    // by the row-major read path added in a later commit; unused when 0.)
+    constexpr uint32_t x_is_row_major = get_compile_time_arg_val(27);
+    constexpr uint32_t cb_x_rm = get_compile_time_arg_val(28);
     // UP_SPLIT iff the reader multicasts up but does not read it from DRAM.
     constexpr bool up_split = (reader_mcasts_up != 0) && (reader_reads_up == 0);
 
@@ -133,7 +138,7 @@ void kernel_main() {
     constexpr uint32_t num_blocks_gu = K_gate_tiles / in0_block_w_gu;
     constexpr uint32_t num_blocks_d = K_down_tiles_padded / in0_block_w_d;
 
-    constexpr uint32_t x_accessor_offset = 27;
+    constexpr uint32_t x_accessor_offset = 29;
     constexpr auto x_args = TensorAccessorArgs<x_accessor_offset>();
     const auto x_acc = TensorAccessor(x_args, x_addr, get_tile_size(cb_in0_x));
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
@@ -141,6 +141,13 @@ void kernel_main() {
     constexpr uint32_t x_accessor_offset = 29;
     constexpr auto x_args = TensorAccessorArgs<x_accessor_offset>();
     const auto x_acc = TensorAccessor(x_args, x_addr, get_tile_size(cb_in0_x));
+    // Row-major x accessor (x_is_row_major): x is a ROW_MAJOR bf16 buffer whose
+    // page is one token-row stick = emb elements = K_gate_tiles*32 bf16 (2 B
+    // each). Partial-stick reads index page_id=token-row, offset_bytes=column
+    // window. Only used in the row-major path; the tile-page x_acc above serves
+    // the TILE path.
+    constexpr uint32_t x_rm_stick_bytes = K_gate_tiles * 32 * 2;
+    const auto x_acc_rm = TensorAccessor(x_args, x_addr, x_rm_stick_bytes);
 
     constexpr uint32_t gate_accessor_offset = x_args.next_compile_time_args_offset();
     constexpr auto gate_args = TensorAccessorArgs<gate_accessor_offset>();
@@ -187,7 +194,18 @@ void kernel_main() {
     CircularBuffer cb_counts_scratch_obj(cb_counts_scratch);
     CircularBuffer cb_idx_scratch_obj(cb_idx_scratch);
     CircularBuffer cb_start_scratch_obj(cb_start_scratch);
+    CircularBuffer cb_x_rm_obj(cb_x_rm);
     CircularBuffer cb_activated_obj(cb_activated);
+
+    // x staging CB for the in0 path. Row-major: the reader fills + mcasts
+    // cb_x_rm (bf16 row-major) and the compute kernel tilizes it into cb_in0_x.
+    // TILE: the reader fills + mcasts cb_in0_x directly. reserve / pre-zero /
+    // mcast / push all operate on x_stage_obj; only the DRAM read loop differs
+    // (partial-stick vs tile-page). In row-major mode the reader never touches
+    // cb_in0_x — compute produces it.
+    constexpr uint32_t x_stage_cb = (x_is_row_major != 0) ? cb_x_rm : cb_in0_x;
+    CircularBuffer x_stage_obj(x_stage_cb);
+    const uint32_t x_stage_tile_bytes = x_stage_obj.get_tile_size();
 
     // D2.0 Semaphore wrappers.
     Semaphore<> in1_ready_sem(in1_ready_sem_id);
@@ -302,11 +320,16 @@ void kernel_main() {
         if (is_in0_sender) {
             const uint32_t this_core_last_row = this_core_first_row + per_core_M;
             if (this_core_last_row > M_bound) {
-                const uint32_t slot_size_bytes = g_in0_block_num_tiles * cb_in0_x_obj.get_tile_size();
-                const uint32_t both_slots_bytes = 2 * slot_size_bytes;
+                // Zero the staging slots so invalid rows the read loop skips feed
+                // zeros to the matmul (row-major: zeros tilize to zero tiles;
+                // TILE: zeros are read directly). Both cb_x_rm and cb_in0_x are
+                // double-buffered.
+                constexpr uint32_t x_stage_slots = 2u;
+                const uint32_t slot_size_bytes = g_in0_block_num_tiles * x_stage_tile_bytes;
+                const uint32_t all_slots_bytes = x_stage_slots * slot_size_bytes;
                 volatile tt_l1_ptr uint64_t* zero_dst =
-                    reinterpret_cast<volatile tt_l1_ptr uint64_t*>(cb_in0_x_obj.get_write_ptr());
-                const size_t num_u64_words = both_slots_bytes / sizeof(uint64_t);
+                    reinterpret_cast<volatile tt_l1_ptr uint64_t*>(x_stage_obj.get_write_ptr());
+                const size_t num_u64_words = all_slots_bytes / sizeof(uint64_t);
                 for (size_t word = 0; word < num_u64_words; ++word) {
                     zero_dst[word] = 0;
                 }
@@ -327,7 +350,7 @@ void kernel_main() {
         //   per-K-block elapsed time at small per_core_M where mcast/handshake
         //   overhead dominates compute.
         for (uint32_t kb = 0; kb < num_blocks_gu; ++kb) {
-            cb_in0_x_obj.reserve_back(g_in0_block_num_tiles);
+            x_stage_obj.reserve_back(g_in0_block_num_tiles);
             cb_in1_gate_obj.reserve_back(g_in1_block_num_tiles);
             if constexpr (reader_mcasts_up) {
                 cb_in1_up_obj.reserve_back(g_in1_block_num_tiles);
@@ -364,37 +387,61 @@ void kernel_main() {
                 in0_ready_sem.wait(in0_num_receivers);
                 in0_ready_sem.set(0);
 
-                uint32_t l1_x = cb_in0_x_obj.get_write_ptr();
+                uint32_t l1_x = x_stage_obj.get_write_ptr();
                 const uint32_t block_start = l1_x;
-                for (uint32_t m = 0; m < per_core_M; ++m) {
-                    const uint32_t row = this_core_first_row + m;
-                    // count_tiles is the runtime tile-row count for this expert.
-                    // Rows past it are NOT filled by extract — they hold
-                    // uninitialized DRAM bytes. Reading them would feed garbage
-                    // (potentially NaN/Inf in bf8 representation) into the
-                    // matmul, which propagates through the per-K-block L1_ACC
-                    // accumulation and contaminates the FFN output. Zero-fill
-                    // the L1 region for those rows instead — silu(0) = 0,
-                    // 0 * up = 0, 0 @ W_down = 0 (safe and free of NaN).
-                    const bool row_valid = row < count_tiles;
-                    if (row_valid) {
-                        for (uint32_t k = 0; k < in0_block_w_gu; ++k) {
-                            const uint32_t col = kb * in0_block_w_gu + k;
-                            // x_start_tile_idx offsets into this expert's region
-                            // of a shared buffer (0 when x is per-expert).
-                            const uint32_t tile_idx = x_start_tile_idx + row * K_gate_tiles + col;
-                            noc_read.async_read(
-                                x_acc, CoreLocalMem<uint32_t>(l1_x), x_tile_bytes, {.page_id = tile_idx}, {});
-                            l1_x += x_tile_bytes;
+                // Rows past count_tiles are NOT valid — they hold uninitialized
+                // DRAM. Reading them would feed garbage (NaN/Inf) into the matmul.
+                // Skip them; the pre-zero above left those L1 bytes zero
+                // (silu(0)=0, 0*up=0, 0@W_down=0 — safe).
+                if constexpr (x_is_row_major != 0) {
+                    // Row-major: read this K-block's column window (in0_block_w_gu
+                    // tiles wide) from each of the 32 token-row sticks of every
+                    // tile-row, laid contiguously so each tile-row forms one
+                    // 32 x (in0_block_w_gu*32) strip for tilize_block. page_id is
+                    // the token-row stick; offset_bytes is the K-block column
+                    // window within the emb-wide stick.
+                    constexpr uint32_t rm_kblock_bytes = in0_block_w_gu * 32 * 2;
+                    const uint32_t col_off_bytes = kb * rm_kblock_bytes;
+                    for (uint32_t m = 0; m < per_core_M; ++m) {
+                        const uint32_t tile_row = this_core_first_row + m;
+                        if (tile_row < count_tiles) {
+                            for (uint32_t r = 0; r < 32; ++r) {
+                                const uint32_t stick = tile_row * 32 + r;
+                                noc_read.async_read(
+                                    x_acc_rm,
+                                    CoreLocalMem<uint32_t>(l1_x),
+                                    rm_kblock_bytes,
+                                    {.page_id = stick, .offset_bytes = col_off_bytes},
+                                    {});
+                                l1_x += rm_kblock_bytes;
+                            }
+                        } else {
+                            l1_x += 32 * rm_kblock_bytes;
                         }
-                    } else {
-                        // Pre-zero already covered these L1 bytes. Just advance.
-                        l1_x += in0_block_w_gu * x_tile_bytes;
+                    }
+                } else {
+                    for (uint32_t m = 0; m < per_core_M; ++m) {
+                        const uint32_t row = this_core_first_row + m;
+                        const bool row_valid = row < count_tiles;
+                        if (row_valid) {
+                            for (uint32_t k = 0; k < in0_block_w_gu; ++k) {
+                                const uint32_t col = kb * in0_block_w_gu + k;
+                                // x_start_tile_idx offsets into this expert's region
+                                // of a shared buffer (0 when x is per-expert).
+                                const uint32_t tile_idx = x_start_tile_idx + row * K_gate_tiles + col;
+                                noc_read.async_read(
+                                    x_acc, CoreLocalMem<uint32_t>(l1_x), x_tile_bytes, {.page_id = tile_idx}, {});
+                                l1_x += x_tile_bytes;
+                            }
+                        } else {
+                            // Pre-zero already covered these L1 bytes. Just advance.
+                            l1_x += in0_block_w_gu * x_tile_bytes;
+                        }
                     }
                 }
                 noc_read.async_read_barrier();
 
-                const uint32_t block_bytes = g_in0_block_num_tiles * x_tile_bytes;
+                const uint32_t block_bytes = g_in0_block_num_tiles * x_stage_tile_bytes;
                 // linked=true keeps the multicast path RESERVED so the in0_valid
                 // sem multicast below travels the SAME path and is delivered
                 // AFTER the data at every receiver. With linked=false the path is
@@ -417,7 +464,7 @@ void kernel_main() {
                      .noc_y_end = in0_mcast_ny_end,
                      .addr = block_start},
                     /*linked=*/true);
-                cb_in0_x_obj.push_back(g_in0_block_num_tiles);
+                x_stage_obj.push_back(g_in0_block_num_tiles);
 
                 noc.async_writes_flushed();
                 in0_valid_sem.set(IN0_VALID);
@@ -552,7 +599,7 @@ void kernel_main() {
             // Step 3: receivers wait for both valid semaphores and push.
             if (!is_in0_sender) {
                 in0_valid_sem.wait(IN0_VALID);
-                cb_in0_x_obj.push_back(g_in0_block_num_tiles);
+                x_stage_obj.push_back(g_in0_block_num_tiles);
             }
             if (!is_in1_sender) {
                 in1_valid_sem.wait(IN1_VALID);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
@@ -30,6 +30,7 @@
 #include "api/dataflow/noc_semaphore.h"
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
+#include "api/debug/dprint.h"  // TEMP: config dump
 
 void kernel_main() {
     // -------------------------- runtime args ------------------------------
@@ -250,6 +251,21 @@ void kernel_main() {
     // Clamp to compile-time num_chunks just in case (defensive against bad input).
     const uint32_t effective_chunks = effective_chunks_runtime < num_chunks ? effective_chunks_runtime : num_chunks;
 
+    // TEMP config dump (one core): understand RM vs TILE blocking difference.
+    if (is_in0_sender && my_mt == 0 && my_nt_gu == 0) {
+        DPRINT(
+            "CFG rm="
+            "{}"
+            " ibw_gu={} per_core_M={} chunk_M={} num_chunks={} eff={} K_gate={}\n",
+            (uint32_t)x_is_row_major,
+            in0_block_w_gu,
+            per_core_M,
+            chunk_M_tiles,
+            num_chunks,
+            effective_chunks,
+            K_gate_tiles);
+    }
+
     // x-read row offset. Zero unless read_x_at_offset: then x is a shared buffer
     // and this expert's rows begin at start[global_id]. Fetch the start page and
     // convert the token row to a tile-page offset (row_tile * K_gate_tiles), the
@@ -400,56 +416,59 @@ void kernel_main() {
                 // DRAM. Reading them would feed garbage (NaN/Inf) into the matmul.
                 // Skip them; the pre-zero above left those L1 bytes zero
                 // (silu(0)=0, 0*up=0, 0@W_down=0 — safe).
-                if constexpr (x_is_row_major != 0) {
-                    // Row-major: read this K-block's column window (in0_block_w_gu
-                    // tiles wide) from each of the 32 token-row sticks of every
-                    // tile-row, laid contiguously so each tile-row forms one
-                    // 32 x (in0_block_w_gu*32) strip for tilize_block. page_id is
-                    // the token-row stick; offset_bytes is the K-block column
-                    // window within the emb-wide stick.
-                    constexpr uint32_t rm_kblock_bytes = in0_block_w_gu * 32 * 2;
-                    const uint32_t col_off_bytes = kb * rm_kblock_bytes;
-                    for (uint32_t m = 0; m < per_core_M; ++m) {
-                        const uint32_t tile_row = this_core_first_row + m;
-                        if (tile_row < count_tiles) {
-                            for (uint32_t r = 0; r < 32; ++r) {
-                                // x_start_stick offsets into this expert's region
-                                // of the shared row-major buffer (0 when x is a
-                                // standalone per-expert buffer).
-                                const uint32_t stick = x_start_stick + tile_row * 32 + r;
-                                noc_read.async_read(
-                                    x_acc_rm,
-                                    CoreLocalMem<uint32_t>(l1_x),
-                                    rm_kblock_bytes,
-                                    {.page_id = stick, .offset_bytes = col_off_bytes},
-                                    {});
-                                l1_x += rm_kblock_bytes;
+                {  // TEMP profiling: time the x DRAM read (row-major strided vs tiled)
+                    DeviceZoneScopedN("XREAD");
+                    if constexpr (x_is_row_major != 0) {
+                        // Row-major: read this K-block's column window (in0_block_w_gu
+                        // tiles wide) from each of the 32 token-row sticks of every
+                        // tile-row, laid contiguously so each tile-row forms one
+                        // 32 x (in0_block_w_gu*32) strip for tilize_block. page_id is
+                        // the token-row stick; offset_bytes is the K-block column
+                        // window within the emb-wide stick.
+                        constexpr uint32_t rm_kblock_bytes = in0_block_w_gu * 32 * 2;
+                        const uint32_t col_off_bytes = kb * rm_kblock_bytes;
+                        for (uint32_t m = 0; m < per_core_M; ++m) {
+                            const uint32_t tile_row = this_core_first_row + m;
+                            if (tile_row < count_tiles) {
+                                for (uint32_t r = 0; r < 32; ++r) {
+                                    // x_start_stick offsets into this expert's region
+                                    // of the shared row-major buffer (0 when x is a
+                                    // standalone per-expert buffer).
+                                    const uint32_t stick = x_start_stick + tile_row * 32 + r;
+                                    noc_read.async_read(
+                                        x_acc_rm,
+                                        CoreLocalMem<uint32_t>(l1_x),
+                                        rm_kblock_bytes,
+                                        {.page_id = stick, .offset_bytes = col_off_bytes},
+                                        {});
+                                    l1_x += rm_kblock_bytes;
+                                }
+                            } else {
+                                l1_x += 32 * rm_kblock_bytes;
                             }
-                        } else {
-                            l1_x += 32 * rm_kblock_bytes;
+                        }
+                    } else {
+                        for (uint32_t m = 0; m < per_core_M; ++m) {
+                            const uint32_t row = this_core_first_row + m;
+                            const bool row_valid = row < count_tiles;
+                            if (row_valid) {
+                                for (uint32_t k = 0; k < in0_block_w_gu; ++k) {
+                                    const uint32_t col = kb * in0_block_w_gu + k;
+                                    // x_start_tile_idx offsets into this expert's region
+                                    // of a shared buffer (0 when x is per-expert).
+                                    const uint32_t tile_idx = x_start_tile_idx + row * K_gate_tiles + col;
+                                    noc_read.async_read(
+                                        x_acc, CoreLocalMem<uint32_t>(l1_x), x_tile_bytes, {.page_id = tile_idx}, {});
+                                    l1_x += x_tile_bytes;
+                                }
+                            } else {
+                                // Pre-zero already covered these L1 bytes. Just advance.
+                                l1_x += in0_block_w_gu * x_tile_bytes;
+                            }
                         }
                     }
-                } else {
-                    for (uint32_t m = 0; m < per_core_M; ++m) {
-                        const uint32_t row = this_core_first_row + m;
-                        const bool row_valid = row < count_tiles;
-                        if (row_valid) {
-                            for (uint32_t k = 0; k < in0_block_w_gu; ++k) {
-                                const uint32_t col = kb * in0_block_w_gu + k;
-                                // x_start_tile_idx offsets into this expert's region
-                                // of a shared buffer (0 when x is per-expert).
-                                const uint32_t tile_idx = x_start_tile_idx + row * K_gate_tiles + col;
-                                noc_read.async_read(
-                                    x_acc, CoreLocalMem<uint32_t>(l1_x), x_tile_bytes, {.page_id = tile_idx}, {});
-                                l1_x += x_tile_bytes;
-                            }
-                        } else {
-                            // Pre-zero already covered these L1 bytes. Just advance.
-                            l1_x += in0_block_w_gu * x_tile_bytes;
-                        }
-                    }
-                }
-                noc_read.async_read_barrier();
+                    noc_read.async_read_barrier();
+                }  // end TEMP XREAD profiling zone
 
                 const uint32_t block_bytes = g_in0_block_num_tiles * x_stage_tile_bytes;
                 // linked=true keeps the multicast path RESERVED so the in0_valid

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
@@ -256,6 +256,11 @@ void kernel_main() {
     // exact source rebase ttnn::extract used to perform. Must agree with the
     // writer's row_offset_tiles so x is read and y is written to the same region.
     uint32_t x_start_tile_idx = 0;
+    // Row-major stick (token-row) base for this expert's region. TILE mode uses
+    // x_start_tile_idx (tile-page offset); row-major mode uses x_start_stick to
+    // offset the token-row stick page. Both derive from start[global_id] (a
+    // tile-aligned token row) and must agree with the writer's row_offset_tiles.
+    uint32_t x_start_stick = 0;
     if constexpr (read_x_at_offset != 0) {
         cb_start_scratch_obj.reserve_back(1);
         const uint32_t start_l1 = cb_start_scratch_obj.get_write_ptr();
@@ -264,7 +269,9 @@ void kernel_main() {
         noc_read.async_read_barrier();
         cb_start_scratch_obj.push_back(1);
         const volatile tt_l1_ptr uint32_t* start_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(start_l1);
-        x_start_tile_idx = (start_ptr[global_expert_id] / 32) * K_gate_tiles;
+        const uint32_t start_value = start_ptr[global_expert_id];
+        x_start_tile_idx = (start_value / 32) * K_gate_tiles;
+        x_start_stick = start_value;
     }
 
     // Per-chunk pre-zero bookkeeping. For each chunk we decide whether
@@ -406,7 +413,10 @@ void kernel_main() {
                         const uint32_t tile_row = this_core_first_row + m;
                         if (tile_row < count_tiles) {
                             for (uint32_t r = 0; r < 32; ++r) {
-                                const uint32_t stick = tile_row * 32 + r;
+                                // x_start_stick offsets into this expert's region
+                                // of the shared row-major buffer (0 when x is a
+                                // standalone per-expert buffer).
+                                const uint32_t stick = x_start_stick + tile_row * 32 + r;
                                 noc_read.async_read(
                                     x_acc_rm,
                                     CoreLocalMem<uint32_t>(l1_x),

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.cpp
@@ -25,13 +25,25 @@ bool is_dram_interleaved(const ttnn::Tensor& t) {
 void UnifiedRoutedExpertFfnDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& op, const tensor_args_t& t) {
     TT_FATAL(t.x.storage_type() == tt::tt_metal::StorageType::DEVICE, "x must be on device");
-    // x is restricted to BFLOAT8_B — the only dtype the existing callers
-    // (TtRoutedExpert typecasts the dispatched buffer to BF8_B before this
-    // op) and tests exercise. The kernel CB-size config can also accept
-    // BFLOAT16, but that path is untested; reintroduce when a real caller
-    // + PCC test for BF16 lands.
-    TT_FATAL(t.x.dtype() == tt::tt_metal::DataType::BFLOAT8_B, "x must be BFLOAT8_B, got {}", t.x.dtype());
-    TT_FATAL(t.x.layout() == tt::tt_metal::Layout::TILE, "x must be TILE layout");
+    // x layout/dtype depends on x_is_row_major:
+    //   false (default): x is TILE BFLOAT8_B — the reader reads tile pages directly.
+    //   true: x is ROW_MAJOR BFLOAT16 (the dispatch output) — the reader streams
+    //     sticks and the compute kernel tilizes them to bf8_b before the matmul,
+    //     fusing the standalone to_layout. Off preserves the pre-fusion path for
+    //     standalone / Wormhole callers.
+    if (op.x_is_row_major) {
+        TT_FATAL(
+            t.x.dtype() == tt::tt_metal::DataType::BFLOAT16,
+            "x must be BFLOAT16 when x_is_row_major, got {}",
+            t.x.dtype());
+        TT_FATAL(
+            t.x.layout() == tt::tt_metal::Layout::ROW_MAJOR,
+            "x must be ROW_MAJOR when x_is_row_major, got {}",
+            t.x.layout());
+    } else {
+        TT_FATAL(t.x.dtype() == tt::tt_metal::DataType::BFLOAT8_B, "x must be BFLOAT8_B, got {}", t.x.dtype());
+        TT_FATAL(t.x.layout() == tt::tt_metal::Layout::TILE, "x must be TILE layout");
+    }
     TT_FATAL(is_dram_interleaved(t.x), "x must be DRAM-interleaved");
     TT_FATAL(t.x.logical_shape().rank() >= 2, "x must have rank >= 2, got rank {}", t.x.logical_shape().rank());
     // For rank > 2, all leading dims must be 1 — we treat x as effectively
@@ -241,6 +253,7 @@ ttnn::Tensor unified_routed_expert_ffn(
     uint32_t chunk_M_tiles,
     uint32_t m_tiles,
     bool read_x_at_offset,
+    bool x_is_row_major,
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
     const std::optional<ttnn::Tensor>& optional_output,
     const std::optional<ttnn::Tensor>& expert_region_offsets,
@@ -253,6 +266,7 @@ ttnn::Tensor unified_routed_expert_ffn(
             .m_tiles = m_tiles,
             .local_expert_id = local_expert_id,
             .read_x_at_offset = read_x_at_offset,
+            .x_is_row_major = x_is_row_major,
             .activation = activation,
             .compute_kernel_config = compute_kernel_config},
         OperationType::tensor_args_t{

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.cpp
@@ -172,8 +172,15 @@ void UnifiedRoutedExpertFfnDeviceOperation::validate_on_program_cache_miss(
         TT_FATAL(out.storage_type() == tt::tt_metal::StorageType::DEVICE, "optional_output must be on device");
         TT_FATAL(out.layout() == tt::tt_metal::Layout::TILE, "optional_output must be TILE layout");
         TT_FATAL(is_dram_interleaved(out), "optional_output must be DRAM-interleaved");
+        // Output dtype must match x EXCEPT in row-major mode: there x is bf16
+        // ROW_MAJOR but the tilized output is bf8_b TILE (for downstream
+        // combine), so the two legitimately differ. The tilize/down-matmul packs
+        // to the output's dtype regardless.
         TT_FATAL(
-            out.dtype() == t.x.dtype(), "optional_output dtype ({}) must match x dtype ({})", out.dtype(), t.x.dtype());
+            op.x_is_row_major || out.dtype() == t.x.dtype(),
+            "optional_output dtype ({}) must match x dtype ({})",
+            out.dtype(),
+            t.x.dtype());
         const auto& out_shape = out.padded_shape();
         TT_FATAL(
             out_shape.rank() == x_shape.rank(),

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.hpp
@@ -43,6 +43,7 @@ ttnn::Tensor unified_routed_expert_ffn(
     uint32_t chunk_M_tiles,
     uint32_t m_tiles,
     bool read_x_at_offset,
+    bool x_is_row_major,
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
     const std::optional<ttnn::Tensor>& optional_output,
     const std::optional<ttnn::Tensor>& expert_region_offsets = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
@@ -150,6 +150,11 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     // below. Bounds the short-seq GRID_X search to the known-good 2D footprint
     // so we never risk an L1 OOM.
     const uint32_t x_ts = tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(t.x.dtype()));
+    // Matmul input CB (cb_in0_x). On the row-major path the compute kernel
+    // tilizes bf16 x into it and packs bf8_b — keeping x bf8 through the matmul
+    // (as the TILE path does) instead of bf16, which halves this CB and frees L1
+    // for a larger per_core_M. cb_x_rm stays bf16 (the mcast/tilize source).
+    const uint32_t in0_x_ts = op.x_is_row_major ? tt::tile_size(tt::DataFormat::Bfp8_b) : x_ts;
     const uint32_t w_ts = tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(t.gate_proj.dtype()));
     const uint32_t p_ts = tt::tile_size(tt::DataFormat::Float16_b);
     const uint32_t im_ts = tt::tile_size(tt::DataFormat::Bfp8_b);
@@ -159,7 +164,7 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         const uint32_t pcN_d = (N_down_tiles_full + gx - 1) / gx;
         const uint32_t ibw_d = pcN_gu;
         uint64_t b = 0;
-        b += 2ull * pcM * ibw_gu * x_ts;     // CB_IN0_X (double-buffered)
+        b += 2ull * pcM * ibw_gu * in0_x_ts;  // CB_IN0_X (double-buffered)
         if (op.x_is_row_major) {
             b += 2ull * pcM * ibw_gu * p_ts;  // CB_X_RM bf16 staging (row-major only)
         }
@@ -277,7 +282,10 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     const tt::DataFormat partials_gu_df = tt::DataFormat::Float16_b;
     const tt::DataFormat partials_d_df = tt::DataFormat::Float16_b;
 
-    const uint32_t x_tile_size = tt::tile_size(x_df);
+    // See in0_x_ts above: cb_in0_x is bf8_b on the row-major path (tilize output),
+    // else it matches x's dtype (bf8_b on the TILE path).
+    const tt::DataFormat in0_x_df = op.x_is_row_major ? tt::DataFormat::Bfp8_b : x_df;
+    const uint32_t in0_x_tile_size = tt::tile_size(in0_x_df);
     const uint32_t gate_tile_size = tt::tile_size(gate_df);
     const uint32_t up_tile_size = tt::tile_size(up_df);
     const uint32_t down_tile_size = tt::tile_size(down_df);
@@ -302,7 +310,7 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     // in the "circular buffers" section below; keep the two in sync.
     const auto cb_footprint_bytes = [&](uint32_t M, uint32_t w_gu) -> uint64_t {
         uint64_t total = 0;
-        total += static_cast<uint64_t>(M * w_gu * 2) * x_tile_size;                               // cb_in0_x
+        total += static_cast<uint64_t>(M * w_gu * 2) * in0_x_tile_size;  // cb_in0_x
         if (op.x_is_row_major) {
             total += static_cast<uint64_t>(M * w_gu * 2) * partials_gu_tile_size;  // cb_x_rm (bf16 staging)
         }
@@ -505,7 +513,7 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     // while compute consumes K-block N. PM FPU util = 0 today says we're
     // memory-bound; bigger input CBs let the kernel pipeline DRAM I/O with
     // compute instead of serialising.
-    make_cb(CB_IN0_X, x_df, /*tiles=*/gu_in0_block_num_tiles * 2, x_tile_size);
+    make_cb(CB_IN0_X, in0_x_df, /*tiles=*/gu_in0_block_num_tiles * 2, in0_x_tile_size);
     // Row-major bf16 x staging (x_is_row_major only). Double-buffered like
     // cb_in0_x: it is a MULTICAST SOURCE, so the sender must fill K-block N+1
     // while N's posted mcast still drains — single-buffering reuses the slot

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
@@ -500,14 +500,16 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     // memory-bound; bigger input CBs let the kernel pipeline DRAM I/O with
     // compute instead of serialising.
     make_cb(CB_IN0_X, x_df, /*tiles=*/gu_in0_block_num_tiles * 2, x_tile_size);
-    // Row-major bf16 x staging (x_is_row_major only). One per-K-block block,
-    // single-buffered for stage 1 to bound L1. Skipped entirely when x is TILE
-    // so the bf8_b path's L1 footprint is unchanged.
+    // Row-major bf16 x staging (x_is_row_major only). Double-buffered like
+    // cb_in0_x: it is a MULTICAST SOURCE, so the sender must fill K-block N+1
+    // while N's posted mcast still drains — single-buffering reuses the slot
+    // mid-mcast and deadlocks. Skipped when x is TILE so the bf8_b path's L1 is
+    // unchanged.
     if (op.x_is_row_major) {
         make_cb(
             CB_X_RM,
             tt::DataFormat::Float16_b,
-            /*tiles=*/gu_in0_block_num_tiles,
+            /*tiles=*/gu_in0_block_num_tiles * 2,
             tt::tile_size(tt::DataFormat::Float16_b));
     }
     make_cb(CB_IN1_GATE, gate_df, /*tiles=*/gu_in1_block_num_tiles * 2, gate_tile_size);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
@@ -53,6 +53,13 @@ constexpr uint32_t CB_START_SCRATCH = tt::CBIndex::c_14;
 // Reader's own `start` scratch, used when read_x_at_offset (x is a shared
 // buffer). Separate from the writer's so the two RISCs don't share one L1 page.
 constexpr uint32_t CB_START_SCRATCH_READER = tt::CBIndex::c_15;
+// Row-major bf16 staging for x when x_is_row_major: the reader fills it with
+// row-major sticks and the compute kernel tilizes it to bf8_b into CB_IN0_X.
+// Allocated ONLY in row-major mode (unlike the tiny start scratches, this is a
+// full per-K-block bf16 block, so allocating it unconditionally would grow the
+// bf8_b path's L1). The CT-arg index is passed either way; the CB just isn't
+// created (and never touched by the kernels) when x is already TILE.
+constexpr uint32_t CB_X_RM = tt::CBIndex::c_16;
 }  // namespace
 
 UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnProgramFactory::create(
@@ -493,6 +500,16 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     // memory-bound; bigger input CBs let the kernel pipeline DRAM I/O with
     // compute instead of serialising.
     make_cb(CB_IN0_X, x_df, /*tiles=*/gu_in0_block_num_tiles * 2, x_tile_size);
+    // Row-major bf16 x staging (x_is_row_major only). One per-K-block block,
+    // single-buffered for stage 1 to bound L1. Skipped entirely when x is TILE
+    // so the bf8_b path's L1 footprint is unchanged.
+    if (op.x_is_row_major) {
+        make_cb(
+            CB_X_RM,
+            tt::DataFormat::Float16_b,
+            /*tiles=*/gu_in0_block_num_tiles,
+            tt::tile_size(tt::DataFormat::Float16_b));
+    }
     make_cb(CB_IN1_GATE, gate_df, /*tiles=*/gu_in1_block_num_tiles * 2, gate_tile_size);
     make_cb(CB_IN1_UP, up_df, /*tiles=*/gu_in1_block_num_tiles * 2, up_tile_size);
     make_cb(CB_IN1_DOWN, down_df, /*tiles=*/d_in1_block_num_tiles * 2, down_tile_size);
@@ -638,6 +655,11 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         static_cast<uint32_t>(op.read_x_at_offset),
         // CB_START_SCRATCH_READER — L1 page holding the fetched `start` vector.
         CB_START_SCRATCH_READER,
+        // x_is_row_major — 1 => x is ROW_MAJOR bf16; reader streams sticks into
+        // CB_X_RM and compute tilizes. 0 => x is TILE bf8_b, read directly.
+        static_cast<uint32_t>(op.x_is_row_major),
+        // CB_X_RM — row-major bf16 staging (only allocated/used in row-major mode).
+        CB_X_RM,
     };
     tt::tt_metal::TensorAccessorArgs(x_buffer).append_to(reader_ct_args);
     tt::tt_metal::TensorAccessorArgs(gate_buffer).append_to(reader_ct_args);
@@ -754,8 +776,13 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         // let compute convert count -> effective_chunks and bound the loop.
         op.local_expert_id,
         chunk_M_tiles,
+        // x_is_row_major — 1 => compute tilizes CB_X_RM -> CB_IN0_X before the
+        // gate/up matmul. 0 => x already TILE in CB_IN0_X (no tilize).
+        static_cast<uint32_t>(op.x_is_row_major),
     };
     std::unordered_map<std::string, uint32_t> compute_named_args = {
+        // Row-major bf16 x staging (x_is_row_major only); tilize input CB.
+        {"cb_x_rm", CB_X_RM},
         {"cb_in0_x", CB_IN0_X},
         {"cb_in1_gate", CB_IN1_GATE},
         {"cb_in1_up", CB_IN1_UP},

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
@@ -164,7 +164,7 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         const uint32_t pcN_d = (N_down_tiles_full + gx - 1) / gx;
         const uint32_t ibw_d = pcN_gu;
         uint64_t b = 0;
-        b += 2ull * pcM * ibw_gu * in0_x_ts;  // CB_IN0_X (double-buffered)
+        b += (op.x_is_row_major ? 1ull : 2ull) * pcM * ibw_gu * in0_x_ts;  // CB_IN0_X (single-buf on RM)
         if (op.x_is_row_major) {
             b += 2ull * pcM * ibw_gu * p_ts;  // CB_X_RM bf16 staging (row-major only)
         }
@@ -310,7 +310,8 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     // in the "circular buffers" section below; keep the two in sync.
     const auto cb_footprint_bytes = [&](uint32_t M, uint32_t w_gu) -> uint64_t {
         uint64_t total = 0;
-        total += static_cast<uint64_t>(M * w_gu * 2) * in0_x_tile_size;  // cb_in0_x
+        total += static_cast<uint64_t>(M * w_gu * (op.x_is_row_major ? 1 : 2)) *
+                 in0_x_tile_size;  // cb_in0_x (RM: single-buf)
         if (op.x_is_row_major) {
             total += static_cast<uint64_t>(M * w_gu * 2) * partials_gu_tile_size;  // cb_x_rm (bf16 staging)
         }
@@ -513,7 +514,12 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     // while compute consumes K-block N. PM FPU util = 0 today says we're
     // memory-bound; bigger input CBs let the kernel pipeline DRAM I/O with
     // compute instead of serialising.
-    make_cb(CB_IN0_X, in0_x_df, /*tiles=*/gu_in0_block_num_tiles * 2, in0_x_tile_size);
+    // Row-major path: cb_in0_x is compute-internal (tilize output -> matmul input,
+    // both on the compute threads sharing DST -> serial), so a second slot buys no
+    // pipelining. Single-buffer it to free L1 for a wider in0_block_w_gu. TILE path
+    // keeps double-buffering: the reader fills it and compute consumes it (cross-RISC
+    // overlap).
+    make_cb(CB_IN0_X, in0_x_df, /*tiles=*/gu_in0_block_num_tiles * (op.x_is_row_major ? 1u : 2u), in0_x_tile_size);
     // Row-major bf16 x staging (x_is_row_major only). Double-buffered like
     // cb_in0_x: it is a MULTICAST SOURCE, so the sender must fill K-block N+1
     // while N's posted mcast still drains — single-buffering reuses the slot

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
@@ -160,6 +160,9 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         const uint32_t ibw_d = pcN_gu;
         uint64_t b = 0;
         b += 2ull * pcM * ibw_gu * x_ts;     // CB_IN0_X (double-buffered)
+        if (op.x_is_row_major) {
+            b += 2ull * pcM * ibw_gu * p_ts;  // CB_X_RM bf16 staging (row-major only)
+        }
         b += 2ull * ibw_gu * pcN_gu * w_ts;  // CB_IN1_GATE
         b += 2ull * ibw_gu * pcN_gu * w_ts;  // CB_IN1_UP
         b += 2ull * ibw_d * pcN_d * w_ts;    // CB_IN1_DOWN
@@ -300,6 +303,9 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     const auto cb_footprint_bytes = [&](uint32_t M, uint32_t w_gu) -> uint64_t {
         uint64_t total = 0;
         total += static_cast<uint64_t>(M * w_gu * 2) * x_tile_size;                               // cb_in0_x
+        if (op.x_is_row_major) {
+            total += static_cast<uint64_t>(M * w_gu * 2) * partials_gu_tile_size;  // cb_x_rm (bf16 staging)
+        }
         total += static_cast<uint64_t>(w_gu * per_core_N_gu * 2) * gate_tile_size;                // cb_in1_gate
         total += static_cast<uint64_t>(w_gu * per_core_N_gu * 2) * up_tile_size;                  // cb_in1_up
         total += static_cast<uint64_t>(in0_block_w_d * per_core_N_d * 2) * down_tile_size;        // cb_in1_down

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
@@ -272,12 +272,15 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     const tt::DataFormat up_df = tt::tt_metal::datatype_to_dataformat_converter(t.up_proj.dtype());
     const tt::DataFormat down_df = tt::tt_metal::datatype_to_dataformat_converter(t.down_proj.dtype());
     const tt::DataFormat out_df = tt::tt_metal::datatype_to_dataformat_converter(tensor_return_value.dtype());
-    // Intermediate and partials share the same format — required by the
-    // compute kernel's mm_init pattern (mm_init's 3rd arg drives the packer's
-    // data-format config; mismatched formats need explicit pack reconfig that
-    // the kernel doesn't do). Use bfp8_b for both: 1KB/tile is half the bf16
-    // cost so we fit in L1 with both intermediates and partials sized to the
-    // full per-core block.
+    // Partials vs intermediates deliberately differ in format; the compute
+    // kernel pack-reconfigs between them (partials <-> intermed) explicitly.
+    //   * partials_gu/partials_d are Float16_b: they hold the K-loop matmul
+    //     accumulator (PACKER_L1_ACC adds each K-block's result into the same L1
+    //     tiles), so block-float bf8 would lose precision across K-blocks. bf16
+    //     keeps a per-element mantissa for the running sum.
+    //   * intermediates (gate/up_intermed, activated) are Bfp8_b: post-activation
+    //     per-element values feeding the next matmul, not accumulators, so
+    //     1KB/tile (half the bf16 cost) is enough and saves L1.
     const tt::DataFormat intermed_df = tt::DataFormat::Bfp8_b;
     const tt::DataFormat partials_gu_df = tt::DataFormat::Float16_b;
     const tt::DataFormat partials_d_df = tt::DataFormat::Float16_b;
@@ -682,6 +685,12 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         static_cast<uint32_t>(op.x_is_row_major),
         // CB_X_RM — row-major bf16 staging (only allocated/used in row-major mode).
         CB_X_RM,
+        // TILE_HEIGHT — rows (token-row sticks) per tile-row; sizes the reader's
+        // row-major x reads and its token-count -> tile-row conversion.
+        TILE,
+        // X_RM_ELEM_BYTES — byte size of one row-major x element (x is bf16 in
+        // the row-major path).
+        tt::datum_size(tt::DataFormat::Float16_b),
     };
     tt::tt_metal::TensorAccessorArgs(x_buffer).append_to(reader_ct_args);
     tt::tt_metal::TensorAccessorArgs(gate_buffer).append_to(reader_ct_args);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_types.hpp
@@ -64,6 +64,13 @@ struct UnifiedRoutedExpertFfnParams {
     // ttnn::extract did. Requires expert_region_offsets. False => x is per-expert.
     bool read_x_at_offset = false;
 
+    // When true, x is a ROW_MAJOR bf16 buffer: the reader streams row-major
+    // sticks and the compute kernel tilizes them (bf16 -> bf8_b) before the
+    // gate/up matmul, fusing the standalone to_layout. False => x is already
+    // TILE bf8_b (the reader reads tile pages directly). Off preserves the
+    // pre-fusion path for standalone / Wormhole callers.
+    bool x_is_row_major = false;
+
     // Per-expert FFN activation variant. Baked into the compute kernel as a
     // compile-time define, so each variant caches as a distinct program — hence
     // it is part of the program-cache key below.
@@ -71,10 +78,11 @@ struct UnifiedRoutedExpertFfnParams {
 
     std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config;
 
-    static constexpr auto attribute_names =
-        std::forward_as_tuple("chunk_M_tiles", "m_tiles", "local_expert_id", "read_x_at_offset", "activation");
+    static constexpr auto attribute_names = std::forward_as_tuple(
+        "chunk_M_tiles", "m_tiles", "local_expert_id", "read_x_at_offset", "x_is_row_major", "activation");
     auto attribute_values() const {
-        return std::forward_as_tuple(chunk_M_tiles, m_tiles, local_expert_id, read_x_at_offset, activation);
+        return std::forward_as_tuple(
+            chunk_M_tiles, m_tiles, local_expert_id, read_x_at_offset, x_is_row_major, activation);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.cpp
@@ -24,6 +24,7 @@ ttnn::Tensor unified_routed_expert_ffn(
     const std::optional<ttnn::Tensor>& expert_region_offsets,
     const std::optional<uint32_t>& input_m_tiles,
     bool read_x_at_offset,
+    bool x_is_row_major,
     RoutedExpertActivation activation) {
     // Single-op fused per-expert FFN. One device Program runs gate matmul,
     // up matmul, silu, multiply, down matmul as four phases inside the same
@@ -76,6 +77,7 @@ ttnn::Tensor unified_routed_expert_ffn(
         chunk_M_tiles,
         M_tiles_full,
         read_x_at_offset,
+        x_is_row_major,
         compute_kernel_config.has_value() ? std::optional<ttnn::DeviceComputeKernelConfig>(*compute_kernel_config)
                                           : std::nullopt,
         output,
@@ -149,6 +151,7 @@ ttnn::Tensor unified_routed_expert_moe(
             expert_region_offsets,
             m_tiles,
             /*read_x_at_offset=*/true,
+            /*x_is_row_major=*/false,
             activation);
     }
     return dispatched_buffer;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.cpp
@@ -105,39 +105,41 @@ ttnn::Tensor unified_routed_expert_moe(
     const uint32_t experts_per_chip = static_cast<uint32_t>(gate_projs.size());
     TT_FATAL(experts_per_chip > 0, "Need at least one expert per chip");
 
-    // Per-expert composite: run the unified FFN on this expert's slice of the
-    // dispatched buffer IN PLACE. The FFN reads x directly from the dispatched
-    // buffer at the expert's region offset (read_x_at_offset) and its writer
-    // places the result back into the SAME buffer at the same offset
-    // (expert_region_offsets). This fuses what used to be a separate
-    // ttnn::extract (input slice) + ttnn::insert (output placement) pair into
-    // the FFN's reader and writer — no per-expert temp buffer, no extra DRAM
-    // round-trip. Same loop regardless of `num_routed_experts`; the (mutated)
-    // dispatched buffer is returned.
+    // Per-expert composite: run the unified FFN on each expert's slice of the
+    // dispatched buffer at that expert's region offset (read_x_at_offset for the
+    // reader, expert_region_offsets for the writer). This fuses the old
+    // ttnn::extract (input slice) + ttnn::insert (output placement) pair into the
+    // FFN's reader and writer — no per-expert temp buffer, no extra DRAM round
+    // trip. Same loop regardless of `num_routed_experts`.
     //
     // x is the whole shared buffer, so pass this expert's row count
-    // (max_dispatched_tokens_per_expert in tiles) as input_m_tiles — the op
-    // sizes its grid/chunks to one expert, not the buffer.
+    // (max_dispatched_tokens_per_expert in tiles) as input_m_tiles — the op sizes
+    // its grid/chunks to one expert, not the buffer.
     //
-    // In-place read+write of one region is safe: within the op the reader reads
-    // x in phase 1 and the writer drains cb_out only after compute consumes it,
-    // so the write of a row is ordered after its read via the CB chain; chunks
-    // cover disjoint rows. Across the loop each expert touches only its own
-    // (non-overlapping) region, so the read/write of expert i cannot disturb
-    // expert j's rows.
-    //
-    // No separate output allocation or zero-fill: the FFN writes back into the
-    // existing dispatched buffer, so there is no per-call DRAM allocation and no
-    // up-front fill. Rows the writer does not touch (tile-aligned slack within a
-    // region, regions of zero-count experts, and the tail of the buffer) retain
-    // their original contents, which downstream `combine` never reads (bounded
-    // per expert to [offset, offset + ceil_tile(count))).
+    // The input layout selects the output strategy:
+    //   * TILE buffer -> write IN PLACE (output == dispatched_buffer). The reader
+    //     reads x in phase 1 and the writer drains cb_out only after compute
+    //     consumes it, so a row's write is ordered after its read via the CB
+    //     chain; chunks cover disjoint rows and experts touch disjoint regions,
+    //     so no expert can disturb another. No allocation, no up-front fill.
+    //   * ROW_MAJOR bf16 buffer -> the FFN tilizes x and packs bf8 internally, so
+    //     input and output differ in both layout and dtype and cannot alias. One
+    //     shared TILE bf8 output is allocated once for all experts; each writes
+    //     its own region. Left uninitialized (no fill): downstream `combine`
+    //     reads only written rows (bounded per expert to
+    //     [offset, offset + ceil_tile(count))).
+    const bool x_is_row_major = dispatched_buffer.layout() == tt::tt_metal::Layout::ROW_MAJOR;
+    const ttnn::Tensor output =
+        x_is_row_major ? ttnn::empty(
+                             dispatched_buffer.logical_shape(),
+                             tt::tt_metal::DataType::BFLOAT8_B,
+                             tt::tt_metal::Layout::TILE,
+                             dispatched_buffer.device(),
+                             tt::tt_metal::MemoryConfig{
+                                 tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM})
+                       : dispatched_buffer;
     const uint32_t m_tiles = (max_dispatched_tokens_per_expert + 31) / 32;
     for (uint32_t local_expert = 0; local_expert < experts_per_chip; ++local_expert) {
-        // output == dispatched_buffer with expert_region_offsets => writer
-        // offsets into this expert's region; read_x_at_offset => reader reads x
-        // from that same region. The op mutates dispatched_buffer in place; its
-        // return value is unused (the composite returns dispatched_buffer below).
         unified_routed_expert_ffn(
             dispatched_buffer,
             gate_projs[local_expert],
@@ -147,14 +149,14 @@ ttnn::Tensor unified_routed_expert_moe(
             global_expert_idx_table,
             local_expert,
             compute_kernel_config,
-            dispatched_buffer,
+            output,
             expert_region_offsets,
             m_tiles,
             /*read_x_at_offset=*/true,
-            /*x_is_row_major=*/false,
+            x_is_row_major,
             activation);
     }
-    return dispatched_buffer;
+    return output;
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::unified_routed_expert_ffn

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.hpp
@@ -29,8 +29,11 @@ namespace ttnn::operations::experimental::deepseek_prefill::unified_routed_exper
 // `unified_routed_expert_moe` below if you need the extract/insert glue.
 //
 // Args:
-//   x: (M_max, K=emb), TILE, DRAM interleaved, BFLOAT8_B. Only the first
-//      ceil_tile(count) rows are valid (the rest is dispatch padding).
+//   x: (M_max, K=emb), DRAM interleaved. Layout/dtype depend on x_is_row_major:
+//      false (default) => TILE, BFLOAT8_B (read as tile pages directly);
+//      true => ROW_MAJOR, BFLOAT16 (the reader streams sticks and the compute
+//      kernel tilizes+packs to bf8_b internally, see x_is_row_major). Only the
+//      first ceil_tile(count) rows are valid (the rest is dispatch padding).
 //   gate_proj: (K=emb, N=hidden), TILE, DRAM interleaved (any weights dtype).
 //   up_proj:   (K=emb, N=hidden), TILE, DRAM interleaved (any weights dtype).
 //   down_proj: (K=hidden, N=emb), TILE, DRAM interleaved (any weights dtype).
@@ -40,10 +43,14 @@ namespace ttnn::operations::experimental::deepseek_prefill::unified_routed_exper
 //      actual token count.
 //   local_expert_id: index into global_expert_idx_table.
 //   compute_kernel_config: optional matmul math fidelity / accumulator config.
-//   output: optional pre-allocated DRAM-interleaved output tensor to write
-//      into. Must match x.dtype(); shape must match x unless
-//      expert_region_offsets is set (direct-write mode), in which case it is
-//      the larger shared destination buffer.
+//   output: optional pre-allocated DRAM-interleaved, TILE-layout output tensor
+//      to write into. Dtype rule is mode-dependent: in the default mode
+//      (x_is_row_major=false) it must match x.dtype() (BFLOAT8_B); in row-major
+//      mode (x_is_row_major=true) x is BFLOAT16 ROW_MAJOR while the op emits a
+//      TILE result (typically BFLOAT8_B) — the compute kernel tilizes+packs to
+//      the output's dtype regardless, so output need not match x there. Shape
+//      must match x unless expert_region_offsets is set (direct-write mode), in
+//      which case it is the larger shared destination buffer.
 //   expert_region_offsets: optional UINT32 per-global-expert region start
 //      offsets (the same `start` tensor ttnn::insert consumes). When set, the
 //      writer places this expert's output directly into `output` (the shared

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.hpp
@@ -55,6 +55,9 @@ namespace ttnn::operations::experimental::deepseek_prefill::unified_routed_exper
 //   read_x_at_offset: when true, x is a shared buffer and the reader offsets
 //      its x reads by expert_region_offsets[global_id] (fusing ttnn::extract).
 //      Requires expert_region_offsets. False => x is per-expert (rows at 0).
+//   x_is_row_major: when true, x is ROW_MAJOR bf16; the reader streams sticks
+//      and the compute kernel tilizes them to bf8_b before the matmul (fusing
+//      the standalone to_layout). False => x is already TILE bf8_b.
 ttnn::Tensor unified_routed_expert_ffn(
     const ttnn::Tensor& x,
     const ttnn::Tensor& gate_proj,
@@ -68,6 +71,7 @@ ttnn::Tensor unified_routed_expert_ffn(
     const std::optional<ttnn::Tensor>& expert_region_offsets = std::nullopt,
     const std::optional<uint32_t>& input_m_tiles = std::nullopt,
     bool read_x_at_offset = false,
+    bool x_is_row_major = false,
     RoutedExpertActivation activation = RoutedExpertActivation::Silu);
 
 // MoE-level composite: takes the dispatched buffer + ALL local experts'

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn_nanobind.cpp
@@ -75,6 +75,9 @@ void bind_unified_routed_expert_ffn(nb::module_& mod) {
             read_x_at_offset (bool, optional): when True, x is a shared buffer
                 and the reader offsets x reads by expert_region_offsets[global_id]
                 (fusing ttnn::extract). Requires expert_region_offsets. Default False.
+            x_is_row_major (bool, optional): when True, x is ROW_MAJOR bf16; the
+                reader streams sticks and the compute kernel tilizes them to bf8_b
+                before the matmul (fusing to_layout). Default False (TILE bf8_b).
             activation (ttnn.RoutedExpertActivation, optional):
                 Silu (default, DeepSeek) or SwiGluOai (clamped, MiniMax-M3 / gpt-oss).
 
@@ -95,6 +98,7 @@ void bind_unified_routed_expert_ffn(nb::module_& mod) {
         nb::arg("expert_region_offsets") = nb::none(),
         nb::arg("input_m_tiles") = nb::none(),
         nb::arg("read_x_at_offset") = false,
+        nb::arg("x_is_row_major") = false,
         nb::arg("activation") = RoutedExpertActivation::Silu);
 
     ttnn::bind_function<"unified_routed_expert_moe", "ttnn.experimental.deepseek_prefill.">(

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn_nanobind.cpp
@@ -36,11 +36,16 @@ void bind_unified_routed_expert_ffn(nb::module_& mod) {
         tokens tensor (rows start at 0); use ``unified_routed_expert_moe`` below
         if you need the extract/insert glue.
 
-        Tensor requirements (enforced in validate_on_program_cache_miss):
-            * dtype: x must be BFLOAT8_B (BFLOAT16 path is untested and
-              rejected host-side; reintroduce when a real caller + PCC test
-              lands); gate/up/down any matmul-compatible weight dtype.
-            * layout: all tensors TILE.
+        Tensor requirements (enforced in validate_on_program_cache_miss),
+        conditional on ``x_is_row_major``:
+            * x dtype/layout: default mode (x_is_row_major=False) => BFLOAT8_B,
+              TILE (read as tile pages directly); row-major mode
+              (x_is_row_major=True) => BFLOAT16, ROW_MAJOR (streamed as sticks
+              and tilized + packed to bf8_b in-op before the matmul).
+            * gate/up/down: TILE, any matmul-compatible weight dtype.
+            * output: TILE. Its dtype must match x in the default mode, but in
+              row-major mode x is BFLOAT16 while output is TILE (typically
+              BFLOAT8_B) — the op packs its result to output's dtype regardless.
             * memory_config: all tensors DRAM-interleaved.
             * Blackhole-only — host expects 11x8 compute grid.
 
@@ -49,7 +54,9 @@ void bind_unified_routed_expert_ffn(nb::module_& mod) {
         cases land at ~0.98 on DS-V3 dims with LoFi math fidelity).
 
         Args:
-            x (ttnn.Tensor): (M_max, K=emb) DRAM-interleaved tile-layout input.
+            x (ttnn.Tensor): (M_max, K=emb) DRAM-interleaved input. Default mode:
+                TILE, BFLOAT8_B. Row-major mode (x_is_row_major=True): ROW_MAJOR,
+                BFLOAT16.
             gate_proj (ttnn.Tensor): (K=emb, N=hidden).
             up_proj (ttnn.Tensor): (K=emb, N=hidden).
             down_proj (ttnn.Tensor): (K=hidden, N=emb).
@@ -59,10 +66,13 @@ void bind_unified_routed_expert_ffn(nb::module_& mod) {
 
         Keyword Args:
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional)
-            output (ttnn.Tensor, optional): pre-allocated output buffer.
-                Must match x.dtype() and x.shape() unless expert_region_offsets
-                is set (direct-write mode), in which case it is the larger
-                shared destination buffer.
+            output (ttnn.Tensor, optional): pre-allocated TILE output buffer.
+                Its dtype must match x.dtype() in the default mode; in row-major
+                mode (x_is_row_major=True) x is BFLOAT16 ROW_MAJOR while output is
+                TILE (typically BFLOAT8_B) and need not match x — the op packs to
+                output's dtype. Shape must match x.shape() unless
+                expert_region_offsets is set (direct-write mode), in which case it
+                is the larger shared destination buffer.
             expert_region_offsets (ttnn.Tensor, optional): UINT32
                 per-global-expert region start offsets. When set, the writer
                 places this expert's output directly into ``output`` at


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/49008


### Problem description

Currently on Blackhole the routed expert runs a standalone to_layout (ROW_MAJOR bf16 → TILE bf8) on the whole dispatched_buffer before the unified routed expert OP. This tilizes the entire capacity buffer (max_dispatch_buffer_token_size rows × emb) even though only each expert's actual token region is used, and adds a full-buffer DRAM round-trip, which is not most efficient.

### What's changed

- Removed the standalone to_layout from the routed expert path. The unified routed expert OP now accepts a ROW_MAJOR bf16 x directly (new x_is_row_major attr); the reader kernel streams the row-major sticks into a staging CB (cb_x_rm), and the compute kernel tilizes each K-block (bf16 → bf8) in-kernel right before the gate/up matmul, so only each expert's real region is converted.
- Because ROW_MAJOR bf16 input and TILE bf8 output can't alias, the composite allocates one shared ttnn::empty TILE bf8 output for all experts (no fill — combine reads only the written regions); each expert writes its region via expert_region_offset.
- cb_x_rm is counted in both L1-budget estimators so full DSV3 dims (emb 7168) fit; per-core config shrinks to fit L1 when needed.
- Model wiring (tt_moe.py / tt_routed_expert.py): Blackhole passes the ROW_MAJOR bf16 dispatched_buffer straight to the routed expert; all per-arch layout/dtype prep is consolidated into TtRoutedExpert.forward. Wormhole keeps the to_layout + extract→FFN→insert fallback.
- Added direct row-major op tests (test_ttnn_routed_expert_ffn_row_major / _offset), skipped on non-Blackhole (the OP needs an 11×8 grid; Wormhole is 8×8).

## Performance - Everything is for 5K ISL so 640 ISL per expert per chip

### Galaxy
<img width="1208" height="756" alt="image" src="https://github.com/user-attachments/assets/b2a93691-beb0-430c-a6d4-e06067871b59" />

### TILE_LAYOUT input

<img width="2612" height="1262" alt="image" src="https://github.com/user-attachments/assets/c02a765b-accd-4c10-9b78-ed910d9e38ca" />
Reading block of tiles for 1 matmul block.

### ROW_MAJOR input

<img width="2588" height="626" alt="image" src="https://github.com/user-attachments/assets/d44fd2a3-222f-41d9-8e95-cdc76db47f89" />
Reading block of strided reading of ROW_MAJOR sticks for 1 matmul block.

<img width="3490" height="2514" alt="image" src="https://github.com/user-attachments/assets/6d360493-c0f9-4457-b9fb-a970068640fe" />
Tilize of 1 strided ROW_MAJOR block into TILE_LAYOUT for 1 matmul block.

Time between 2 consecutive TILIZE on same sender and receiver Tensix cores is 9.85us.

### DeepSeek CI

- [x] [![(T3K) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=pmilojevic/49008-routedexpert-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:pmilojevic/49008-routedexpert-tilize)
- [x] [![(BH) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pmilojevic/49008-routedexpert-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pmilojevic/49008-routedexpert-tilize)
- [x] [![Demo SP
Release](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=pmilojevic/49008-routedexpert-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:pmilojevic/49008-routedexpert-tilize)
- [x] [![(Galaxy) Blaze Models Prefill tests ](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=pmilojevic/49008-routedexpert-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml?query=branch:pmilojevic/49008-routedexpert-tilize)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pmilojevic/49008-routedexpert-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pmilojevic/49008-routedexpert-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pmilojevic/49008-routedexpert-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pmilojevic/49008-routedexpert-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pmilojevic/49008-routedexpert-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pmilojevic/49008-routedexpert-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilojevic/49008-routedexpert-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilojevic/49008-routedexpert-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pmilojevic/49008-routedexpert-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pmilojevic/49008-routedexpert-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pmilojevic/49008-routedexpert-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pmilojevic/49008-routedexpert-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pmilojevic/49008-routedexpert-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pmilojevic/49008-routedexpert-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pmilojevic/49008-routedexpert-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pmilojevic/49008-routedexpert-tilize)