### PR TITLE
Fix ODR violation in dfb_test_common.hpp (missing inline)

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_test_common.hpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_test_common.hpp
@@ -209,7 +209,7 @@ constexpr uint32_t dfb_default_num_entries(uint32_t num_p, uint32_t num_c) {
 
 // ---- cross-category program drivers ----
 
-void run_single_dfb_program(
+inline void run_single_dfb_program(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     experimental::dfb::DataflowBufferConfig& dfb_config,
     DFBPorCType producer_type,


### PR DESCRIPTION
## Summary
- `run_single_dfb_program` in `tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_test_common.hpp` was defined without `inline`
- The header is included by multiple `.cpp` files compiled into the same `unit_tests_api_lib` target (`test_dataflow_buffer_base.cpp`, `test_dataflow_buffer_edge_cases.cpp`, `test_dataflow_buffer_multinode.cpp`, etc.), so the linker sees multiple definitions of the same symbol
- Marking it `inline` (consistent with every other function in this header) resolves the linker error

## Test plan
- [x] `./build_metal.sh -e -c --debug --build-tests --enable-fake-kernels-target --without-distributed` completes successfully with this change
- [x] Confirmed no other function in this header has the same missing-`inline` issue

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/dfb-test-common-odr-inline)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/dfb-test-common-odr-inline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/dfb-test-common-odr-inline)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/dfb-test-common-odr-inline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=fix/dfb-test-common-odr-inline)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:fix/dfb-test-common-odr-inline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/dfb-test-common-odr-inline)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/dfb-test-common-odr-inline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/dfb-test-common-odr-inline)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/dfb-test-common-odr-inline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/dfb-test-common-odr-inline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/dfb-test-common-odr-inline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/dfb-test-common-odr-inline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/dfb-test-common-odr-inline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/dfb-test-common-odr-inline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/dfb-test-common-odr-inline)