### PR TITLE
Bug Fix: Skip cross-host eth cores in deployment eth tests

### DIFF
--- a/tests/tt_metal/tt_metal/deployment/eth/common.hpp
+++ b/tests/tt_metal/tt_metal/deployment/eth/common.hpp
@@ -865,6 +865,20 @@ static std::string get_connector(IDevice* sdev, CoreCoord score) {
     return "unknown";
 }
 
+// Returns true if the ethernet core connects to another chip within this cluster (i.e. it is safe to
+// call get_connected_ethernet_core on it). Cross-host cores (e.g. QSFP cables wired to another
+// Galaxy) show up as active/linked-up but live in the remote-device connection map, so calling
+// get_connected_ethernet_core on them fatals with "connects to a remote mmio device".
+[[maybe_unused]]
+static bool eth_core_connects_within_cluster(IDevice* device, const CoreCoord& logical_core) {
+    const auto& cluster = MetalContext::instance().get_cluster();
+    const auto& soc_desc = cluster.get_soc_desc(device->id());
+    EthernetChannel eth_chan = soc_desc.logical_eth_core_to_chan_map.at(logical_core);
+    const auto& within_cluster = cluster.get_ethernet_connections();
+    auto it = within_cluster.find(device->id());
+    return it != within_cluster.end() && it->second.contains(eth_chan);
+}
+
 [[maybe_unused]]
 static std::string get_ubb(IDevice* device) {
     const auto& cluster = MetalContext::instance().get_cluster();

--- a/tests/tt_metal/tt_metal/deployment/eth/test_eth_bandwidth.cpp
+++ b/tests/tt_metal/tt_metal/deployment/eth/test_eth_bandwidth.cpp
@@ -131,6 +131,9 @@ TEST_F(MeshDispatchFixture, TensixDeploymentEthernet01Bandwidth) {
                 get_ubb(receiver_device));
 
             for (const auto& sender_core : sender_device->get_active_ethernet_cores(true)) {
+                if (!eth_core_connects_within_cluster(sender_device, sender_core)) {
+                    continue;
+                }
                 auto [device_id, receiver_core] = sender_device->get_connected_ethernet_core(sender_core);
                 if (receiver_device->id() != device_id) {
                     continue;

--- a/tests/tt_metal/tt_metal/deployment/eth/test_eth_bandwidth_bidir.cpp
+++ b/tests/tt_metal/tt_metal/deployment/eth/test_eth_bandwidth_bidir.cpp
@@ -142,6 +142,9 @@ TEST_F(MeshDispatchFixture, TensixDeploymentEthernet02BandwidthBidir) {
                 get_ubb(receiver_device));
 
             for (const auto& sender_core : sender_device->get_active_ethernet_cores(true)) {
+                if (!eth_core_connects_within_cluster(sender_device, sender_core)) {
+                    continue;
+                }
                 auto [device_id, receiver_core] = sender_device->get_connected_ethernet_core(sender_core);
                 if (receiver_device->id() != device_id) {
                     continue;

--- a/tests/tt_metal/tt_metal/deployment/eth/test_eth_data_integrity_dram.cpp
+++ b/tests/tt_metal/tt_metal/deployment/eth/test_eth_data_integrity_dram.cpp
@@ -267,6 +267,9 @@ TEST_F(MeshDispatchFixture, TensixDeploymentEthernet03DataIntegrityDram) {
                 get_ubb(receiver_device));
 
             for (const auto& sender_core : sender_device->get_active_ethernet_cores(true)) {
+                if (!eth_core_connects_within_cluster(sender_device, sender_core)) {
+                    continue;
+                }
                 auto [device_id, receiver_core] = sender_device->get_connected_ethernet_core(sender_core);
                 if (receiver_device->id() != device_id) {
                     continue;

--- a/tests/tt_metal/tt_metal/deployment/eth/test_eth_data_integrity_dram_bidir.cpp
+++ b/tests/tt_metal/tt_metal/deployment/eth/test_eth_data_integrity_dram_bidir.cpp
@@ -229,6 +229,9 @@ TEST_F(MeshDispatchFixture, TensixDeploymentEthernet04DataIntegrityDramBidir) {
                 get_ubb(receiver_device));
 
             for (const auto& sender_core : sender_device->get_active_ethernet_cores(true)) {
+                if (!eth_core_connects_within_cluster(sender_device, sender_core)) {
+                    continue;
+                }
                 auto [device_id, receiver_core] = sender_device->get_connected_ethernet_core(sender_core);
                 if (receiver_device->id() != device_id) {
                     continue;

--- a/tests/tt_metal/tt_metal/deployment/eth/test_eth_link_up.cpp
+++ b/tests/tt_metal/tt_metal/deployment/eth/test_eth_link_up.cpp
@@ -126,6 +126,9 @@ TEST_F(MeshDispatchFixture, TensixDeploymentEthernet00LinkUp) {
                 get_ubb(receiver_device));
 
             for (const auto& sender_core : sender_device->get_active_ethernet_cores(true)) {
+                if (!eth_core_connects_within_cluster(sender_device, sender_core)) {
+                    continue;
+                }
                 auto [device_id, receiver_core] = sender_device->get_connected_ethernet_core(sender_core);
                 if (receiver_device->id() != device_id) {
                     continue;

--- a/tests/tt_metal/tt_metal/deployment/eth/test_eth_stress_test.cpp
+++ b/tests/tt_metal/tt_metal/deployment/eth/test_eth_stress_test.cpp
@@ -147,6 +147,9 @@ TEST_F(MeshDispatchFixture, TensixDeploymentEthernet05StressTest) {
             std::set<CoreCoord> tested;
 
             for (const auto& sender_core : sender_device->get_active_ethernet_cores(true)) {
+                if (!eth_core_connects_within_cluster(sender_device, sender_core)) {
+                    continue;
+                }
                 auto [device_id, receiver_core] = sender_device->get_connected_ethernet_core(sender_core);
                 if (receiver_device->id() != device_id) {
                     continue;


### PR DESCRIPTION
The eth deployment tests called get_connected_ethernet_core() on every active ethernet core, but cross-host QSFP cores connect to a remote MMIO device and live in the remote-device connection map, tripping the "connects to a remote mmio device" TT_FATAL. Add an eth_core_connects_within_cluster() helper and skip those cores before the call, since the tests only pair a sender with a local receiver device.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix-eth-deployment-cross-host-cores)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix-eth-deployment-cross-host-cores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix-eth-deployment-cross-host-cores)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix-eth-deployment-cross-host-cores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=fix-eth-deployment-cross-host-cores)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:fix-eth-deployment-cross-host-cores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix-eth-deployment-cross-host-cores)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix-eth-deployment-cross-host-cores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix-eth-deployment-cross-host-cores)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix-eth-deployment-cross-host-cores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix-eth-deployment-cross-host-cores)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix-eth-deployment-cross-host-cores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix-eth-deployment-cross-host-cores)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix-eth-deployment-cross-host-cores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix-eth-deployment-cross-host-cores)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix-eth-deployment-cross-host-cores)