### PR TITLE
Fix ternary op silent-garbage on program-cache hit

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_ternary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_ternary.py
@@ -432,3 +432,60 @@ def test_ternary_scalar_distinguishes_cache_entries(device):
     )
 
     device.disable_and_clear_program_cache()
+
+
+def test_ternary_addcmul_cache_hit_refreshes_operand_addresses(device):
+    """Regression guard for the ternary buffer-address static/dynamic contract (cache-hit bug).
+
+    Two same-shaped addcmul calls reuse the same cached program (correct), but the cache-hit path
+    must re-patch the runtime args holding the operand/output buffer ADDRESSES. Before the fix, the
+    second same-shaped call whose operand lived in a DIFFERENT buffer ran against the first call's
+    stale addresses and returned silent garbage (PCC ~0). Here the operands are distinct
+    ttnn.chunk() slices of a single parent tensor, so they are the same shape but different buffers.
+    TernaryDeviceOperation::get_dynamic_runtime_args() must refresh reader slots 0/1/2 and writer
+    slot 0 on every dispatch.
+    """
+    device.enable_program_cache()
+    device.clear_program_cache()
+
+    torch.manual_seed(0)
+    N, H = 32, 64
+
+    base_t = torch.rand((1, 1, N, H), dtype=torch.bfloat16)
+    chunks_t = torch.rand((1, 1, 1, 4 * H), dtype=torch.bfloat16)
+
+    base = ttnn.from_torch(base_t, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+    chunks = ttnn.from_torch(chunks_t, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+    chunk = ttnn.chunk(chunks, 4, -1)  # 4 shape-identical operands in different buffers
+
+    def reference(i):
+        return base_t + base_t * chunks_t[..., i * H : (i + 1) * H]
+
+    # Pre-allocate BOTH outputs and keep them alive across both calls, passing each via
+    # output_tensor. This forces the two dispatches to write to DISTINCT, simultaneously-live output
+    # buffers, so the second call's writer slot 0 must be re-patched to out1's address -- otherwise it
+    # writes into out0 and out1 stays zero. Without two live outputs the allocator could hand the
+    # second call out0's just-freed address, masking a missing writer-address patch.
+    out0 = ttnn.from_torch(
+        torch.zeros((1, 1, N, H), dtype=torch.bfloat16), device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT
+    )
+    out1 = ttnn.from_torch(
+        torch.zeros((1, 1, N, H), dtype=torch.bfloat16), device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT
+    )
+
+    # First call compiles the addcmul program.
+    ttnn.addcmul(base, base, chunk[0], value=1.0, output_tensor=out0)
+    entries_after_first = device.num_program_cache_entries()
+
+    # Cache hit with a different-buffer operand AND a different output buffer of identical shape: the
+    # addcmul program must be reused (no new cache entry), yet the stale-address regression made this
+    # return ~0 PCC.
+    ttnn.addcmul(base, base, chunk[2], value=1.0, output_tensor=out1)
+    assert (
+        device.num_program_cache_entries() == entries_after_first
+    ), "same-shaped addcmul must reuse the cached program (no new cache entry)"
+
+    assert_with_pcc(reference(0), ttnn.to_torch(out0).float(), 0.99)
+    assert_with_pcc(reference(2), ttnn.to_torch(out1).float(), 0.99)
+
+    device.disable_and_clear_program_cache()


### PR DESCRIPTION
https://github.com/tenstorrent/tt-metal/issues/49749


TernaryDeviceOperation registers the reader operand addresses (reader slots 0/1/2) and the writer output address (writer slot 0) as Buffer* bindings, expecting them re-patched each dispatch. On a program-cache HIT those addresses are NOT re-patched for this op, so a ternary call (e.g. ttnn.addcmul / ttnn.where) invoked with a differently-allocated operand of the SAME shape reuses the cached program and reads/writes STALE buffer addresses -> silent wrong results (no error).

It is program-cache-order-dependent: the first invocation of a given shape is correct; a later same-shaped call whose operand lives in a different buffer (classically two ttnn.chunk slices of one parent) gets garbage. Disabling the program cache makes it correct, confirming the compiled program is fine and only the cache-hit address re-patch is missing.

Fix: re-patch the reader operand addresses and the writer output address via get_dynamic_runtime_args() on every dispatch -- the same mechanism already used to re-apply the hash-excluded compute scalar.

Repro (Blackhole, single device):
  addcmul(base, base, chunk[2])                : 100%   (1st call)
  addcmul(base, base, chunk[0]); then chunk[2] : ~0%    (cache hit, stale addr)  -> FIXED to 100%
Real impact: a DiT transformer block whose AdaLN does addcmul(norm,norm,chunk_i)
dropped block PCC 0.9997 -> 0.85; restored to 0.9997 with this fix.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=cglagovich/fix-ternary-addcmul-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:cglagovich/fix-ternary-addcmul-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=cglagovich/fix-ternary-addcmul-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:cglagovich/fix-ternary-addcmul-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=cglagovich/fix-ternary-addcmul-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:cglagovich/fix-ternary-addcmul-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=cglagovich/fix-ternary-addcmul-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:cglagovich/fix-ternary-addcmul-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=cglagovich/fix-ternary-addcmul-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:cglagovich/fix-ternary-addcmul-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=cglagovich/fix-ternary-addcmul-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:cglagovich/fix-ternary-addcmul-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=cglagovich/fix-ternary-addcmul-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:cglagovich/fix-ternary-addcmul-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=cglagovich/fix-ternary-addcmul-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:cglagovich/fix-ternary-addcmul-cache)