### PR TITLE
MINFRA-1077: Read civ2 annotations to set host name into superset

### DIFF
--- a/infra/data_collection/github/download_cicd_logs_and_artifacts.sh
+++ b/infra/data_collection/github/download_cicd_logs_and_artifacts.sh
@@ -88,18 +88,22 @@ download_logs_for_all_jobs() {
     jobs_data=$(get_jobs_with_pagination_fallback "$repo" "$workflow_run_id" "$attempt_number")
 
     # Process the jobs data
-    echo "$jobs_data" | jq -c '.jobs[] | {id: .id, conclusion: .conclusion}' | while read -r job; do
+    # is_civ2 is true when any runs-on label starts with tt-ubuntu- (CIv2 runners)
+    echo "$jobs_data" | jq -c '.jobs[] | {id: .id, conclusion: .conclusion, is_civ2: ([.labels[]? | select(startswith("tt-ubuntu-"))] | length > 0)}' | while read -r job; do
         job_id=$(echo "$job" | jq -r '.id')
         job_conclusion=$(echo "$job" | jq -r '.conclusion')
+        is_civ2=$(echo "$job" | jq -r '.is_civ2')
         echo "[info] download logs for job with id $job_id, attempt number $attempt_number"
         # https://github.com/tenstorrent/tt-metal/issues/12966
         # We bypass any log download that returned a non-zero exit code so the downloader doesn't crash midway.
         # williamly: We may want to check http status code for robustness in the future again but it may be costly in terms of api calls used.
         gh api /repos/$repo/actions/jobs/$job_id/logs > generated/cicd/$workflow_run_id/logs/$job_id.log || true
 
-        # Only download annotations for failed jobs
-        if [[ "$job_conclusion" == "failure" ]]; then
-            echo "[info] downloading annotations for failed job $job_id"
+        # Download annotations for failed jobs (failure reason) and for CIv2 runner jobs.
+        # CIv2 runners emit node-name and card-serial notice annotations at job start
+        # (see tenstorrent/github-ci-infra#1408) which we use to identify the physical node/card.
+        if [[ "$job_conclusion" == "failure" || "$is_civ2" == "true" ]]; then
+            echo "[info] downloading annotations for job $job_id (conclusion=$job_conclusion, civ2=$is_civ2)"
             gh api /repos/$repo/check-runs/$job_id/annotations > generated/cicd/$workflow_run_id/logs/${job_id}_annotations.json
         fi
     done

--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -247,40 +247,36 @@ def get_job_row_from_github_job(github_job, github_job_id_to_annotations, workfl
     else:
         ubuntu_version = None
 
-    # Clean up ephemeral runner names
+    # Resolve the host_name for CIv2 (tt-ubuntu) runners. The ephemeral runner identity is
+    # not useful for data analysis since it changes every pod, so prefer the physical
+    # <node name>_<serial> emitted by the job-start hook annotations, falling back to the
+    # job log when annotations are unavailable (e.g. not downloaded).
     if host_name and host_name.startswith("tt-ubuntu"):
-        parts = host_name.split("-")
-        # Issue: https://github.com/tenstorrent/tt-metal/issues/21694
-        # Issue: https://github.com/tenstorrent/tt-metal/issues/26445
-        # Remove non-constant ephemeral runner suffix from tt-beta/tt-ubuntu runner names only if the second last part is "runner"
-        # We don't want to remove the suffix for non-ephemeral runners (e.g. tt-beta-ubuntu-2204-xlarge)
-        # E.g. tt-beta-ubuntu-2204-n150-large-stable-nk6pd-runner-5g5f9 -> tt-beta-ubuntu-2204-n150-large-stable-nk6pd
-        if len(parts) >= 2 and parts[-2] == "runner":
-            host_name = "-".join(parts[:-1])
-
-        # For CIv2 runners (tt-ubuntu), the ephemeral runner identity is not useful for data
-        # analysis since it changes every pod. Instead, identify the physical node/card that ran
-        # the job using the <node name>_<serial> emitted by the job-start hook annotations
-        # Fall back to the truncated name above when the
-        # annotations are unavailable (e.g. not downloaded)
-        if host_name.startswith("tt-ubuntu"):
-            node_name, serial = get_civ2_node_name_and_serial_from_annotations(
-                github_job_id_to_annotations.get(github_job_id)
+        node_name, serial = get_civ2_node_name_and_serial_from_annotations(
+            github_job_id_to_annotations.get(github_job_id)
+        )
+        if not (node_name and serial):
+            log_node_name, log_serial = get_civ2_node_name_and_serial_from_job_log(
+                workflow_outputs_dir, github_job["run_id"], github_job_id
             )
-            # When annotations are unavailable, fall back to parsing the job log
-            if not (node_name and serial):
-                log_node_name, log_serial = get_civ2_node_name_and_serial_from_job_log(
-                    workflow_outputs_dir, github_job["run_id"], github_job_id
-                )
-                node_name = node_name or log_node_name
-                serial = serial or log_serial
-            # Prefer <node>_<serial>; if only the node name is available (e.g. CPU-only
-            # runners have no card serial), use the node name alone. Otherwise keep the
-            # truncated name above.
-            if node_name and serial:
-                host_name = f"{node_name}_{serial}"
-            elif node_name:
-                host_name = node_name
+            node_name = node_name or log_node_name
+            serial = serial or log_serial
+
+        if node_name and serial:
+            host_name = f"{node_name}_{serial}"
+        elif node_name:
+            # CPU-only runners have no card serial; the node name alone identifies the host
+            host_name = node_name
+        else:
+            # No node/serial info: strip the non-constant ephemeral suffix so host aggregation
+            # stays stable, but only when the second-last part is "runner" so we don't touch
+            # non-ephemeral runners (e.g. tt-ubuntu-2204-xlarge).
+            # E.g. tt-ubuntu-2204-n150-large-stable-nk6pd-runner-5g5f9 -> tt-ubuntu-2204-n150-large-stable-nk6pd
+            # Issues: https://github.com/tenstorrent/tt-metal/issues/21694
+            #         https://github.com/tenstorrent/tt-metal/issues/26445
+            parts = host_name.split("-")
+            if len(parts) >= 2 and parts[-2] == "runner":
+                host_name = "-".join(parts[:-1])
 
     # Cleanup GitHub-hosted runner names because we're sending the whole thing, which is unnecessary
     # and clogs up the data with 1000s of hosts

--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -12,7 +12,10 @@ from typing import Optional, Union
 import yaml
 from loguru import logger
 
-from infra.data_collection.github.workflows import is_job_hanging_from_job_log
+from infra.data_collection.github.workflows import (
+    is_job_hanging_from_job_log,
+    get_civ2_node_name_and_serial_from_job_log,
+)
 from infra.data_collection.models import InfraErrorV1, TestErrorV1, CodeQualityErrorV1
 from infra.data_collection.pydantic_models import CompleteBenchmarkRun
 
@@ -285,6 +288,14 @@ def get_job_row_from_github_job(github_job, github_job_id_to_annotations, workfl
             node_name, serial = get_civ2_node_name_and_serial_from_annotations(
                 github_job_id_to_annotations.get(github_job_id)
             )
+            # When annotations are unavailable
+            # Fall back to parsing the job log
+            if not (node_name and serial):
+                log_node_name, log_serial = get_civ2_node_name_and_serial_from_job_log(
+                    workflow_outputs_dir, github_job["run_id"], github_job_id
+                )
+                node_name = node_name or log_node_name
+                serial = serial or log_serial
             if node_name and serial:
                 host_name = f"{node_name}_{serial}"
 

--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -232,6 +232,7 @@ def get_civ2_node_name_and_serial_from_annotations(annotation_info):
             node_name = message.rsplit("Kubernetes node:", 1)[-1].strip() or None
         elif title == "tt-card-serial" and "serial number(s):" in message:
             serial = message.rsplit("serial number(s):", 1)[-1].strip() or None
+    logger.info(f"Extracted node name and serial from annotations: {node_name}, {serial}")
     return node_name, serial
 
 

--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -262,13 +262,12 @@ def get_job_row_from_github_job(github_job, github_job_id_to_annotations, workfl
         # analysis since it changes every pod. Instead, identify the physical node/card that ran
         # the job using the <node name>_<serial> emitted by the job-start hook annotations
         # Fall back to the truncated name above when the
-        # annotations are unavailable (e.g. not downloaded, or CPU-only runners without a serial).
+        # annotations are unavailable (e.g. not downloaded)
         if host_name.startswith("tt-ubuntu"):
             node_name, serial = get_civ2_node_name_and_serial_from_annotations(
                 github_job_id_to_annotations.get(github_job_id)
             )
-            # When annotations are unavailable
-            # Fall back to parsing the job log
+            # When annotations are unavailable, fall back to parsing the job log
             if not (node_name and serial):
                 log_node_name, log_serial = get_civ2_node_name_and_serial_from_job_log(
                     workflow_outputs_dir, github_job["run_id"], github_job_id

--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -14,6 +14,7 @@ from loguru import logger
 
 from infra.data_collection.github.workflows import (
     is_job_hanging_from_job_log,
+    get_civ2_node_name_and_serial_from_annotations,
     get_civ2_node_name_and_serial_from_job_log,
 )
 from infra.data_collection.models import InfraErrorV1, TestErrorV1, CodeQualityErrorV1
@@ -211,29 +212,6 @@ def get_failure_signature_and_description_from_annotations(
                     )
                     return failure_signature, failure_description
     return failure_signature, failure_description
-
-
-def get_civ2_node_name_and_serial_from_annotations(annotation_info):
-    """Extract the (node_name, serial) a CIv2 runner emitted at job start.
-
-    CIv2 runners emit GitHub Actions notice annotations at job start
-    (see tenstorrent/github-ci-infra#1408):
-        ::notice title=k8s-node-name::CIV2 runner <name> is running on Kubernetes node: <node>
-        ::notice title=tt-card-serial::CIV2 runner <name> has serial number(s): <serial>
-
-    Returns (node_name, serial), each None if its annotation is absent (e.g. CPU-only
-    runners have no card serial).
-    """
-    node_name, serial = None, None
-    for _annot in annotation_info or []:
-        title = _annot.get("title") or ""
-        message = _annot.get("message") or ""
-        if title == "k8s-node-name" and "Kubernetes node:" in message:
-            node_name = message.rsplit("Kubernetes node:", 1)[-1].strip() or None
-        elif title == "tt-card-serial" and "serial number(s):" in message:
-            serial = message.rsplit("serial number(s):", 1)[-1].strip() or None
-    logger.info(f"Extracted node name and serial from annotations: {node_name}, {serial}")
-    return node_name, serial
 
 
 def get_job_row_from_github_job(github_job, github_job_id_to_annotations, workflow_outputs_dir):

--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -274,8 +274,13 @@ def get_job_row_from_github_job(github_job, github_job_id_to_annotations, workfl
                 )
                 node_name = node_name or log_node_name
                 serial = serial or log_serial
+            # Prefer <node>_<serial>; if only the node name is available (e.g. CPU-only
+            # runners have no card serial), use the node name alone. Otherwise keep the
+            # truncated name above.
             if node_name and serial:
                 host_name = f"{node_name}_{serial}"
+            elif node_name:
+                host_name = node_name
 
     # Cleanup GitHub-hosted runner names because we're sending the whole thing, which is unnecessary
     # and clogs up the data with 1000s of hosts

--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -210,6 +210,28 @@ def get_failure_signature_and_description_from_annotations(
     return failure_signature, failure_description
 
 
+def get_civ2_node_name_and_serial_from_annotations(annotation_info):
+    """Extract the (node_name, serial) a CIv2 runner emitted at job start.
+
+    CIv2 runners emit GitHub Actions notice annotations at job start
+    (see tenstorrent/github-ci-infra#1408):
+        ::notice title=k8s-node-name::CIV2 runner <name> is running on Kubernetes node: <node>
+        ::notice title=tt-card-serial::CIV2 runner <name> has serial number(s): <serial>
+
+    Returns (node_name, serial), each None if its annotation is absent (e.g. CPU-only
+    runners have no card serial).
+    """
+    node_name, serial = None, None
+    for _annot in annotation_info or []:
+        title = _annot.get("title") or ""
+        message = _annot.get("message") or ""
+        if title == "k8s-node-name" and "Kubernetes node:" in message:
+            node_name = message.rsplit("Kubernetes node:", 1)[-1].strip() or None
+        elif title == "tt-card-serial" and "serial number(s):" in message:
+            serial = message.rsplit("serial number(s):", 1)[-1].strip() or None
+    return node_name, serial
+
+
 def get_job_row_from_github_job(github_job, github_job_id_to_annotations, workflow_outputs_dir):
     github_job_id = github_job["id"]
 
@@ -244,7 +266,7 @@ def get_job_row_from_github_job(github_job, github_job_id_to_annotations, workfl
         ubuntu_version = None
 
     # Clean up ephemeral runner names
-    if host_name and (host_name.startswith("tt-beta") or host_name.startswith("tt-ubuntu")):
+    if host_name and host_name.startswith("tt-ubuntu"):
         parts = host_name.split("-")
         # Issue: https://github.com/tenstorrent/tt-metal/issues/21694
         # Issue: https://github.com/tenstorrent/tt-metal/issues/26445
@@ -253,6 +275,18 @@ def get_job_row_from_github_job(github_job, github_job_id_to_annotations, workfl
         # E.g. tt-beta-ubuntu-2204-n150-large-stable-nk6pd-runner-5g5f9 -> tt-beta-ubuntu-2204-n150-large-stable-nk6pd
         if len(parts) >= 2 and parts[-2] == "runner":
             host_name = "-".join(parts[:-1])
+
+        # For CIv2 runners (tt-ubuntu), the ephemeral runner identity is not useful for data
+        # analysis since it changes every pod. Instead, identify the physical node/card that ran
+        # the job using the <node name>_<serial> emitted by the job-start hook annotations
+        # Fall back to the truncated name above when the
+        # annotations are unavailable (e.g. not downloaded, or CPU-only runners without a serial).
+        if host_name.startswith("tt-ubuntu"):
+            node_name, serial = get_civ2_node_name_and_serial_from_annotations(
+                github_job_id_to_annotations.get(github_job_id)
+            )
+            if node_name and serial:
+                host_name = f"{node_name}_{serial}"
 
     # Cleanup GitHub-hosted runner names because we're sending the whole thing, which is unnecessary
     # and clogs up the data with 1000s of hosts

--- a/infra/data_collection/github/workflows.py
+++ b/infra/data_collection/github/workflows.py
@@ -386,6 +386,43 @@ def get_github_job_id_to_test_reports(workflow_outputs_dir, workflow_run_id: int
     return github_job_id_to_test_reports
 
 
+# Markers printed by the CIv2 runner job-start hook (tenstorrent/github-ci-infra#1408).
+# The same strings appear both as GitHub notice annotations and as plain stdout in the
+# "Set up runner" step of the job log.
+_CIV2_NODE_NAME_LOG_MARKER = "is running on Kubernetes node:"
+_CIV2_SERIAL_LOG_MARKER = "serial number(s):"
+
+
+def get_civ2_node_name_and_serial_from_job_log(workflow_outputs_dir, workflow_run_id: int, github_job_id: int):
+    """Fallback parser for the CIv2 (node_name, serial) read from the job log.
+
+    Annotations may be absent. The job-start hook also prints these lines to stdout e.g.:
+        CIV2 runner <name> is running on Kubernetes node: <node>
+        CIV2 runner <name> has serial number(s): <serial>
+
+    Returns (node_name, serial), each None if not found (CPU-only runners have no serial).
+    """
+    log_dir = workflow_outputs_dir / str(workflow_run_id) / "logs"
+    assert str(github_job_id).isdigit()
+    matching_logs = list(log_dir.glob(f"{github_job_id}.log"))
+    if not matching_logs or not matching_logs[0].exists():
+        logger.warning(f"Unable to find github job log file for job: {github_job_id}")
+        return None, None
+
+    ansi_pattern = re.compile(r"\x1B[@-_][0-?]*[ -/]*[@-~]")
+    node_name, serial = None, None
+    with open(matching_logs[0], "r", encoding="utf-8-sig") as log_f:
+        for line in log_f:
+            line = ansi_pattern.sub("", line)
+            if node_name is None and _CIV2_NODE_NAME_LOG_MARKER in line:
+                node_name = line.rsplit(_CIV2_NODE_NAME_LOG_MARKER, 1)[-1].strip() or None
+            elif serial is None and _CIV2_SERIAL_LOG_MARKER in line:
+                serial = line.rsplit(_CIV2_SERIAL_LOG_MARKER, 1)[-1].strip() or None
+            if node_name is not None and serial is not None:
+                break
+    return node_name, serial
+
+
 def get_github_job_id_to_annotations(workflow_outputs_dir, workflow_run_id: int):
     # Read <job_id>_annotations.json inside the logs dir
     logs_dir = workflow_outputs_dir / str(workflow_run_id) / "logs"

--- a/infra/data_collection/github/workflows.py
+++ b/infra/data_collection/github/workflows.py
@@ -169,8 +169,9 @@ def search_for_tt_smi_reset_in_log_file_(log_file):
 
 
 def get_github_job_ids_to_tt_smi_versions(workflow_outputs_dir, workflow_run_id: int, workflow_attempt: int):
-    logs_dir = workflow_outputs_dir / str(workflow_run_id) / "logs"
+    logs_dir = _safe_logs_dir(workflow_outputs_dir, workflow_run_id)
 
+    assert logs_dir is not None, f"Invalid or unsafe workflow_run_id: {workflow_run_id}"
     assert logs_dir.exists(), f"Logs dir does not exist: {logs_dir}"
     assert logs_dir.is_dir(), f"Logs path is not a dir: {logs_dir}"
 

--- a/infra/data_collection/github/workflows.py
+++ b/infra/data_collection/github/workflows.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import pathlib
 import re
 from datetime import datetime, timedelta
 from functools import partial
@@ -19,6 +20,9 @@ timestamp_pattern = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z")
 
 
 def search_for_tt_smi_version_in_log_file_(log_file):
+    # Defense-in-depth: resolve and confirm this is a real file before opening.
+    log_file = pathlib.Path(log_file).resolve()
+    assert log_file.is_file(), f"Not a readable log file: {log_file}"
     with open(log_file, "r") as log_f:
         for line in log_f:
             regex_match = smi_pattern.match(line)
@@ -28,6 +32,9 @@ def search_for_tt_smi_version_in_log_file_(log_file):
 
 
 def search_for_tt_smi_reset_in_log_file_(log_file):
+    # Defense-in-depth: resolve and confirm this is a real file before opening.
+    log_file = pathlib.Path(log_file).resolve()
+    assert log_file.is_file(), f"Not a readable log file: {log_file}"
     ts_pattern = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z\s*")
     # Strip GitHub Actions annotation prefixes like ##[error], ##[warning]
     gh_annotation_pattern = re.compile(r"^##\[[a-z]+\]", re.IGNORECASE)

--- a/infra/data_collection/github/workflows.py
+++ b/infra/data_collection/github/workflows.py
@@ -393,6 +393,29 @@ _CIV2_NODE_NAME_LOG_MARKER = "is running on Kubernetes node:"
 _CIV2_SERIAL_LOG_MARKER = "serial number(s):"
 
 
+def get_civ2_node_name_and_serial_from_annotations(annotation_info):
+    """Extract the (node_name, serial) a CIv2 runner emitted at job start.
+
+    CIv2 runners emit GitHub Actions notice annotations at job start
+    (see tenstorrent/github-ci-infra#1408):
+        ::notice title=k8s-node-name::CIV2 runner <name> is running on Kubernetes node: <node>
+        ::notice title=tt-card-serial::CIV2 runner <name> has serial number(s): <serial>
+
+    Returns (node_name, serial), each None if its annotation is absent (e.g. CPU-only
+    runners have no card serial).
+    """
+    node_name, serial = None, None
+    for _annot in annotation_info or []:
+        title = _annot.get("title") or ""
+        message = _annot.get("message") or ""
+        if title == "k8s-node-name" and "Kubernetes node:" in message:
+            node_name = message.rsplit("Kubernetes node:", 1)[-1].strip() or None
+        elif title == "tt-card-serial" and _CIV2_SERIAL_LOG_MARKER in message:
+            serial = message.rsplit(_CIV2_SERIAL_LOG_MARKER, 1)[-1].strip() or None
+    logger.info(f"Extracted node name and serial from annotations: {node_name}, {serial}")
+    return node_name, serial
+
+
 def get_civ2_node_name_and_serial_from_job_log(workflow_outputs_dir, workflow_run_id: int, github_job_id: int):
     """Fallback parser for the CIv2 (node_name, serial) read from the job log.
 

--- a/infra/data_collection/github/workflows.py
+++ b/infra/data_collection/github/workflows.py
@@ -386,7 +386,7 @@ def get_github_job_id_to_test_reports(workflow_outputs_dir, workflow_run_id: int
     return github_job_id_to_test_reports
 
 
-# Markers printed by the CIv2 runner job-start hook (tenstorrent/github-ci-infra#1408).
+# Markers printed by the CIv2 runner job-start hook.
 # The same strings appear both as GitHub notice annotations and as plain stdout in the
 # "Set up runner" step of the job log.
 _CIV2_NODE_NAME_LOG_MARKER = "is running on Kubernetes node:"

--- a/infra/data_collection/github/workflows.py
+++ b/infra/data_collection/github/workflows.py
@@ -189,14 +189,19 @@ def get_github_job_ids_to_tt_smi_versions(workflow_outputs_dir, workflow_run_id:
         github_job_id = int(filename)
         assert github_job_id > 0
 
-        tt_smi_version = search_for_tt_smi_version_in_log_file_(log_file)
+        # Re-derive the path from the validated integer ids (containment-checked) so the
+        # path handed to the file readers below is sanitized, not the raw globbed path.
+        safe_log_file = _safe_job_log_file(workflow_outputs_dir, workflow_run_id, github_job_id)
+        assert safe_log_file is not None and safe_log_file.is_file(), f"Unsafe or missing log file: {log_file}"
+
+        tt_smi_version = search_for_tt_smi_version_in_log_file_(safe_log_file)
         if tt_smi_version:
             github_job_ids_to_tt_smi_versions[github_job_id] = tt_smi_version
 
-        tt_smi_reset = search_for_tt_smi_reset_in_log_file_(log_file)
+        tt_smi_reset = search_for_tt_smi_reset_in_log_file_(safe_log_file)
         for reset in tt_smi_reset:
             reset["workflow_attempt"] = workflow_attempt
-        assert tt_smi_reset is not None, f"Parser returned None for {log_file}"
+        assert tt_smi_reset is not None, f"Parser returned None for {safe_log_file}"
 
         assert github_job_id not in github_job_ids_to_tt_smi_resets, f"Duplicate reset key detected: {github_job_id}"
 

--- a/infra/data_collection/github/workflows.py
+++ b/infra/data_collection/github/workflows.py
@@ -212,6 +212,33 @@ def parse_github_log_timestamp(line):
     return datetime.fromisoformat(timestamp_str[:26])
 
 
+def _resolve_within(base_dir, *parts):
+    """Resolve base_dir / *parts, returning the path only if it stays within base_dir.
+
+    Guards against path traversal from dynamic path components: returns None if the
+    resolved path escapes base_dir (e.g. a component containing "..").
+    """
+    base = base_dir.resolve()
+    candidate = base.joinpath(*parts).resolve()
+    return candidate if candidate.is_relative_to(base) else None
+
+
+def _safe_logs_dir(workflow_outputs_dir, workflow_run_id):
+    """Resolved <workflow_outputs_dir>/<run_id>/logs, or None if run_id is not a plain
+    integer or the path escapes workflow_outputs_dir."""
+    if not str(workflow_run_id).isdigit():
+        return None
+    return _resolve_within(workflow_outputs_dir, str(workflow_run_id), "logs")
+
+
+def _safe_job_log_file(workflow_outputs_dir, workflow_run_id, github_job_id):
+    """Resolved <workflow_outputs_dir>/<run_id>/logs/<job_id>.log, or None if either id is
+    not a plain integer or the path escapes workflow_outputs_dir."""
+    if not (str(workflow_run_id).isdigit() and str(github_job_id).isdigit()):
+        return None
+    return _resolve_within(workflow_outputs_dir, str(workflow_run_id), "logs", f"{github_job_id}.log")
+
+
 def is_job_hanging_from_job_log(error_snippet, workflow_outputs_dir, workflow_run_id: int, workflow_job_id: int):
     """
     Read the job output log to determine if a job is hanging or genuinely timed out.
@@ -227,19 +254,11 @@ def is_job_hanging_from_job_log(error_snippet, workflow_outputs_dir, workflow_ru
 
     ** Threshold may be reduced in the future
     """
-    log_dir = workflow_outputs_dir / str(workflow_run_id) / "logs"
-    assert str(workflow_job_id).isdigit()
-    matching_logs = list(log_dir.glob(f"{workflow_job_id}.log"))
-
-    if not matching_logs:
-        logger.warning(f"Unable to find github job log file for job: {workflow_job_id}")
-        return False
-
-    log_file = matching_logs[0]
+    log_file = _safe_job_log_file(workflow_outputs_dir, workflow_run_id, workflow_job_id)
     max_time_delta_seconds = 300
 
-    if not log_file.exists():
-        logger.warning(f"Unable to find github job log file: {log_file}")
+    if log_file is None or not log_file.is_file():
+        logger.warning(f"Unable to find github job log file for job: {workflow_job_id}")
         return False
 
     log_lines = []
@@ -425,16 +444,14 @@ def get_civ2_node_name_and_serial_from_job_log(workflow_outputs_dir, workflow_ru
 
     Returns (node_name, serial), each None if not found (CPU-only runners have no serial).
     """
-    log_dir = workflow_outputs_dir / str(workflow_run_id) / "logs"
-    assert str(github_job_id).isdigit()
-    matching_logs = list(log_dir.glob(f"{github_job_id}.log"))
-    if not matching_logs or not matching_logs[0].exists():
+    log_file = _safe_job_log_file(workflow_outputs_dir, workflow_run_id, github_job_id)
+    if log_file is None or not log_file.is_file():
         logger.warning(f"Unable to find github job log file for job: {github_job_id}")
         return None, None
 
     ansi_pattern = re.compile(r"\x1B[@-_][0-?]*[ -/]*[@-~]")
     node_name, serial = None, None
-    with open(matching_logs[0], "r", encoding="utf-8-sig") as log_f:
+    with open(log_file, "r", encoding="utf-8-sig") as log_f:
         for line in log_f:
             line = ansi_pattern.sub("", line)
             if node_name is None and _CIV2_NODE_NAME_LOG_MARKER in line:
@@ -448,8 +465,12 @@ def get_civ2_node_name_and_serial_from_job_log(workflow_outputs_dir, workflow_ru
 
 
 def get_github_job_id_to_annotations(workflow_outputs_dir, workflow_run_id: int):
-    # Read <job_id>_annotations.json inside the logs dir
-    logs_dir = workflow_outputs_dir / str(workflow_run_id) / "logs"
+    # Read <job_id>_annotations.json inside the (sanitized) logs dir.
+    logs_dir = _safe_logs_dir(workflow_outputs_dir, workflow_run_id)
+    if logs_dir is None or not logs_dir.is_dir():
+        logger.warning(f"Annotations logs dir not found for run: {workflow_run_id}")
+        return {}
+
     annot_json_files = logs_dir.glob("*_annotations.json")
 
     github_job_ids_to_annotation_jsons = {}

--- a/infra/data_collection/github/workflows.py
+++ b/infra/data_collection/github/workflows.py
@@ -420,6 +420,7 @@ def get_civ2_node_name_and_serial_from_job_log(workflow_outputs_dir, workflow_ru
                 serial = line.rsplit(_CIV2_SERIAL_LOG_MARKER, 1)[-1].strip() or None
             if node_name is not None and serial is not None:
                 break
+    logger.info(f"Extracted node name and serial from job log: {node_name}, {serial}")
     return node_name, serial
 
 

--- a/infra/data_collection/github/workflows.py
+++ b/infra/data_collection/github/workflows.py
@@ -455,6 +455,19 @@ def get_civ2_node_name_and_serial_from_job_log(workflow_outputs_dir, workflow_ru
         CIV2 runner <name> is running on Kubernetes node: <node>
         CIV2 runner <name> has serial number(s): <serial>
 
+    Notes:
+    I thought there was an instance where this happens,
+    but it was actually because annotations don't get "reissued" on passing jobs when another attempt is launched
+    (because the job doesn't get rerun)
+
+    So on subsequent workflow run attempts, it looks like passing jobs don't have annotations;
+    the annotations are actually still present, but only visible on the prior run attempt on the UI.
+    From the API, we can always see the annotations.
+    E.g. https://api.github.com/repos/tenstorrent/tt-metal/check-runs/<job id>/annotations
+
+    So we should never have to exercise this fallback parser because we always generate pipeline data on each run attempt's jobs only.
+    (Unless github has an outage and doesn't upload annotations for some reason)
+
     Returns (node_name, serial), each None if not found (CPU-only runners have no serial).
     """
     log_file = _safe_job_log_file(workflow_outputs_dir, workflow_run_id, github_job_id)

--- a/infra/tests/data_collection/test_cicd.py
+++ b/infra/tests/data_collection/test_cicd.py
@@ -7,7 +7,6 @@ from infra.data_collection.models import InfraErrorV1, TestErrorV1
 from infra.data_collection.github.utils import (
     get_job_failure_signature_,
     get_job_row_from_github_job,
-    get_civ2_node_name_and_serial_from_annotations,
     _card_type_from_job_labels,
     _generic_runner_labels,
     _load_sku_config_skus,
@@ -391,7 +390,10 @@ def test_get_civ2_node_name_and_serial_from_annotations():
         {"title": "tt-card-serial", "message": "CIV2 runner foo has serial number(s): TT-BH-00111:TT-BH-00222"},
         {"title": "", "message": "some unrelated infra annotation"},
     ]
-    assert get_civ2_node_name_and_serial_from_annotations(annotations) == ("aus-glx-03", "TT-BH-00111:TT-BH-00222")
+    assert workflows.get_civ2_node_name_and_serial_from_annotations(annotations) == (
+        "aus-glx-03",
+        "TT-BH-00111:TT-BH-00222",
+    )
 
     # CPU-only runner: a tt-card-serial notice is still emitted, but with a
     # "Not a Tenstorrent card runner" message that carries no serial
@@ -405,10 +407,10 @@ def test_get_civ2_node_name_and_serial_from_annotations():
             "message": "CIV2 runner tt-ubuntu-2204-large-stable-w77km-runner-djpn9 is running on Kubernetes node: f10-cpu-01",
         },
     ]
-    assert get_civ2_node_name_and_serial_from_annotations(cpu_annotations) == ("f10-cpu-01", None)
+    assert workflows.get_civ2_node_name_and_serial_from_annotations(cpu_annotations) == ("f10-cpu-01", None)
 
     # No annotations at all
-    assert get_civ2_node_name_and_serial_from_annotations(None) == (None, None)
+    assert workflows.get_civ2_node_name_and_serial_from_annotations(None) == (None, None)
 
 
 def _make_completed_civ2_job(job_id, runner_name, labels):

--- a/infra/tests/data_collection/test_cicd.py
+++ b/infra/tests/data_collection/test_cicd.py
@@ -514,6 +514,30 @@ def test_civ2_host_name_uses_job_log_when_annotations_missing(tmp_path):
     assert row["host_name"] == "f06cs19_010001451172A025"
 
 
+def test_civ2_host_name_uses_node_name_only_when_serial_missing(tmp_path):
+    # CPU-only runner: node name present but no card serial -> use node name alone,
+    # never "<node>_None".
+    run_id, job_id = 666, 4
+    logs_dir = tmp_path / str(run_id) / "logs"
+    logs_dir.mkdir(parents=True)
+    (logs_dir / f"{job_id}.log").write_text(
+        "2026-07-10T00:01:02.1Z CIV2 runner tt-ubuntu-2204-large-stable-w77km-runner-djpn9 "
+        "is running on Kubernetes node: f10-cpu-01\n"
+        "2026-07-10T00:01:03.1Z Not a Tenstorrent card runner "
+        "(runner name: tt-ubuntu-2204-large-stable-w77km-runner-djpn9)\n"
+    )
+
+    job = _make_completed_civ2_job(
+        job_id,
+        "tt-ubuntu-2204-large-stable-w77km-runner-djpn9",
+        ["tt-ubuntu-2204-large-stable"],
+    )
+    job["run_id"] = run_id
+
+    row = get_job_row_from_github_job(job, {}, tmp_path)
+    assert row["host_name"] == "f10-cpu-01"
+
+
 def test_create_pipeline_json_assigns_sku_card_type_to_n300_job(workflow_run_gh_environment):
     pipeline = _load_pipeline(workflow_run_gh_environment, "all_post_commit_passing_10662355710")
 

--- a/infra/tests/data_collection/test_cicd.py
+++ b/infra/tests/data_collection/test_cicd.py
@@ -376,7 +376,7 @@ def test_generic_runner_labels_derived_from_sim_skus():
         # legacy partial wh_n300 labels
         (["N300", "in-service"], "wh_n300"),
         (["build", "in-service"], None),
-        (["tt-ubuntu-2204-medium-stable"], "tt-ubuntu-2204-medium-stable"),
+        (["tt-ubuntu-2204-medium-stable"], "cpu_medium"),
         (["tt-ubuntu-2204-large-stable"], "tt-ubuntu-2204-large-stable"),
     ],
 )
@@ -461,9 +461,55 @@ def test_civ2_host_name_falls_back_to_truncation_without_annotations():
         "tt-ubuntu-2204-n300-viommu-stable-abcde-runner-fghij",
         ["tt-ubuntu-2204-n300-viommu-stable"],
     )
-    # No node/serial annotations -> keep current ephemeral-suffix truncation behavior
+    # No node/serial annotations and no matching job log -> keep ephemeral-suffix truncation
     row = get_job_row_from_github_job(job, {}, INFRA_TESTS_DIR)
     assert row["host_name"] == "tt-ubuntu-2204-n300-viommu-stable-abcde-runner"
+
+
+def test_get_civ2_node_name_and_serial_from_job_log(tmp_path):
+    logs_dir = tmp_path / "777" / "logs"
+    logs_dir.mkdir(parents=True)
+
+    # Card runner: plain stdout lines plus the ::notice duplicates
+    (logs_dir / "9.log").write_text(
+        "2026-07-10T00:01:02.1Z CIV2 runner foo is running on Kubernetes node: f06cs19\n"
+        "2026-07-10T00:01:02.2Z ::notice title=k8s-node-name::CIV2 runner foo is running on Kubernetes node: f06cs19\n"
+        "2026-07-10T00:01:03.1Z CIV2 runner with ephemeral name foo has serial number(s): 010001451172A025\n"
+    )
+    assert workflows.get_civ2_node_name_and_serial_from_job_log(tmp_path, 777, 9) == ("f06cs19", "010001451172A025")
+
+    # CPU-only runner: node present, serial line reports it is not a TT card
+    (logs_dir / "10.log").write_text(
+        "2026-07-10T00:01:02.1Z CIV2 runner bar is running on Kubernetes node: cpu-node-1\n"
+        "2026-07-10T00:01:03.1Z Not a Tenstorrent card runner (runner name: bar)\n"
+    )
+    assert workflows.get_civ2_node_name_and_serial_from_job_log(tmp_path, 777, 10) == ("cpu-node-1", None)
+
+    # Missing log file
+    assert workflows.get_civ2_node_name_and_serial_from_job_log(tmp_path, 777, 999) == (None, None)
+
+
+def test_civ2_host_name_uses_job_log_when_annotations_missing(tmp_path):
+    run_id, job_id = 555, 3
+    logs_dir = tmp_path / str(run_id) / "logs"
+    logs_dir.mkdir(parents=True)
+    (logs_dir / f"{job_id}.log").write_text(
+        "2026-07-10T00:01:02.1Z CIV2 runner tt-ubuntu-2204-n300-stable-88b76-runner-clpfm "
+        "is running on Kubernetes node: f06cs19\n"
+        "2026-07-10T00:01:03.1Z CIV2 runner with ephemeral name tt-ubuntu-2204-n300-stable-88b76-runner-clpfm "
+        "has serial number(s): 010001451172A025\n"
+    )
+
+    job = _make_completed_civ2_job(
+        job_id,
+        "tt-ubuntu-2204-n300-stable-88b76-runner-clpfm",
+        ["tt-ubuntu-2204-n300-stable"],
+    )
+    job["run_id"] = run_id
+
+    # Empty annotations -> falls back to the job log
+    row = get_job_row_from_github_job(job, {}, tmp_path)
+    assert row["host_name"] == "f06cs19_010001451172A025"
 
 
 def test_create_pipeline_json_assigns_sku_card_type_to_n300_job(workflow_run_gh_environment):

--- a/infra/tests/data_collection/test_cicd.py
+++ b/infra/tests/data_collection/test_cicd.py
@@ -6,6 +6,8 @@ from infra.data_collection.cicd import create_cicd_json_for_data_analysis
 from infra.data_collection.models import InfraErrorV1, TestErrorV1
 from infra.data_collection.github.utils import (
     get_job_failure_signature_,
+    get_job_row_from_github_job,
+    get_civ2_node_name_and_serial_from_annotations,
     _card_type_from_job_labels,
     _generic_runner_labels,
     _load_sku_config_skus,
@@ -380,6 +382,88 @@ def test_generic_runner_labels_derived_from_sim_skus():
 )
 def test_card_type_from_job_labels(labels, expected_card_type):
     assert _card_type_from_job_labels(labels) == expected_card_type
+
+
+def test_get_civ2_node_name_and_serial_from_annotations():
+    # Card runner: both node name and (possibly composite) serial present
+    annotations = [
+        {"title": "k8s-node-name", "message": "CIV2 runner foo is running on Kubernetes node: aus-glx-03"},
+        {"title": "tt-card-serial", "message": "CIV2 runner foo has serial number(s): TT-BH-00111:TT-BH-00222"},
+        {"title": "", "message": "some unrelated infra annotation"},
+    ]
+    assert get_civ2_node_name_and_serial_from_annotations(annotations) == ("aus-glx-03", "TT-BH-00111:TT-BH-00222")
+
+    # CPU-only runner: a tt-card-serial notice is still emitted, but with a
+    # "Not a Tenstorrent card runner" message that carries no serial
+    cpu_annotations = [
+        {
+            "title": "tt-card-serial",
+            "message": "Not a Tenstorrent card runner (runner name: tt-ubuntu-2204-large-stable-w77km-runner-djpn9)",
+        },
+        {
+            "title": "k8s-node-name",
+            "message": "CIV2 runner tt-ubuntu-2204-large-stable-w77km-runner-djpn9 is running on Kubernetes node: f10-cpu-01",
+        },
+    ]
+    assert get_civ2_node_name_and_serial_from_annotations(cpu_annotations) == ("f10-cpu-01", None)
+
+    # No annotations at all
+    assert get_civ2_node_name_and_serial_from_annotations(None) == (None, None)
+
+
+def _make_completed_civ2_job(job_id, runner_name, labels):
+    return {
+        "id": job_id,
+        "run_id": 999,
+        "runner_name": runner_name,
+        "labels": labels,
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-07-10T00:00:00Z",
+        "started_at": "2026-07-10T00:01:00Z",
+        "completed_at": "2026-07-10T00:05:00Z",
+        "name": "some test job",
+        "html_url": "https://github.com/tenstorrent/tt-metal/actions/runs/999/job/1",
+        "run_attempt": 1,
+        "steps": [],
+    }
+
+
+def test_civ2_host_name_replaced_with_node_and_serial():
+    job = _make_completed_civ2_job(
+        1,
+        "tt-ubuntu-2204-n300-viommu-stable-abcde-runner-fghij",
+        ["tt-ubuntu-2204-n300-viommu-stable"],
+    )
+    annotations = {
+        1: [
+            {
+                "title": "k8s-node-name",
+                "message": "CIV2 runner foo is running on Kubernetes node: aus-glx-03",
+                "annotation_level": "notice",
+                "path": ".github",
+            },
+            {
+                "title": "tt-card-serial",
+                "message": "CIV2 runner foo has serial number(s): TT-BH-02345",
+                "annotation_level": "notice",
+                "path": ".github",
+            },
+        ]
+    }
+    row = get_job_row_from_github_job(job, annotations, INFRA_TESTS_DIR)
+    assert row["host_name"] == "aus-glx-03_TT-BH-02345"
+
+
+def test_civ2_host_name_falls_back_to_truncation_without_annotations():
+    job = _make_completed_civ2_job(
+        2,
+        "tt-ubuntu-2204-n300-viommu-stable-abcde-runner-fghij",
+        ["tt-ubuntu-2204-n300-viommu-stable"],
+    )
+    # No node/serial annotations -> keep current ephemeral-suffix truncation behavior
+    row = get_job_row_from_github_job(job, {}, INFRA_TESTS_DIR)
+    assert row["host_name"] == "tt-ubuntu-2204-n300-viommu-stable-abcde-runner"
 
 
 def test_create_pipeline_json_assigns_sku_card_type_to_n300_job(workflow_run_gh_environment):

--- a/infra/tests/data_collection/test_cicd.py
+++ b/infra/tests/data_collection/test_cicd.py
@@ -376,7 +376,7 @@ def test_generic_runner_labels_derived_from_sim_skus():
         # legacy partial wh_n300 labels
         (["N300", "in-service"], "wh_n300"),
         (["build", "in-service"], None),
-        (["ubuntu-latest"], "ubuntu-latest"),
+        (["tt-ubuntu-2204-medium-stable"], "tt-ubuntu-2204-medium-stable"),
         (["tt-ubuntu-2204-large-stable"], "tt-ubuntu-2204-large-stable"),
     ],
 )


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Feature
https://tenstorrent.atlassian.net/browse/MINFRA-1077

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Ephemeral runner host name and serial numbers (for non-cpu runners) are now visible for data analysis.

This PR takes that data and concatenates the host name and serial into the `cicd_host.host_name` column for superset. Previously this column contained ephemeral host names only which made tracing CI issues back to the node difficult. 

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
CI run annotation data is now downloaded for failing + civ2 ephemeral runner jobs.
When annotation data is not available, we fall back to parsing the host and serial via the job stdout log.

Sanity test, data production on branch:  
https://github.com/tenstorrent/tt-metal/actions/runs/29782499564/job/88486712531
https://github.com/tenstorrent/tt-metal/actions/runs/29942542372/job/88999774052
```
2026-07-20 22:05:08.360 | INFO     | infra.data_collection.github.workflows:get_civ2_node_name_and_serial_from_annotations:447 - Extracted node name and serial from annotations: e10cs05, 0100014611905006

```

Also contains cycode scan remediations

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=williamly/civ2-runner-info)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:williamly/civ2-runner-info)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=williamly/civ2-runner-info)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:williamly/civ2-runner-info)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=williamly/civ2-runner-info)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:williamly/civ2-runner-info)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=williamly/civ2-runner-info)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:williamly/civ2-runner-info)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=williamly/civ2-runner-info)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:williamly/civ2-runner-info)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=williamly/civ2-runner-info)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:williamly/civ2-runner-info)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=williamly/civ2-runner-info)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:williamly/civ2-runner-info)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=williamly/civ2-runner-info)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:williamly/civ2-runner-info)