### PR TITLE
[deepseek_prefill] fix GPT-OSS routed-expert general-path K-block divisibility

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
@@ -413,9 +413,15 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         chunk_M_tiles = per_core_M * GRID_Y;
     }
 
-    // in0_block_w_gu must divide K_gate_tiles (the gate/up K-loop bound); holds
-    // for every value the guard above picks and for the default 16 on all
-    // shipped models (emb a multiple of 512 => K_gate_tiles a multiple of 16).
+    // in0_block_w_gu must divide K_gate_tiles (the gate/up K-loop bound). The default 16 holds for
+    // shipped models with emb a multiple of 512, but NOT for gpt-oss (emb=2880 => K_gate_tiles=90,
+    // not a multiple of 16); and the adaptive L1 guard above only narrows in0_block_w_gu to a
+    // divisor when it actually fires (under L1 pressure). Clamp here on every path to the largest
+    // divisor of K_gate_tiles <= the current value, so the gate/up K-loop tiling is always exact
+    // (this is the same divisor set the L1 guard selects from; 1 always divides, so it terminates).
+    while (K_gate_tiles % in0_block_w_gu != 0) {
+        --in0_block_w_gu;
+    }
     TT_FATAL(
         K_gate_tiles % in0_block_w_gu == 0,
         "K_gate_tiles ({}) must be divisible by in0_block_w_gu ({})",


### PR DESCRIPTION
## Summary
On the routed-expert **general (2D) path**, `in0_block_w_gu` defaulted to 16, which does not divide GPT-OSS's `K_gate_tiles = 90` (emb 2880) — the gate/up K-loop then trips its divisibility `TT_FATAL`. This picks the largest legal width at or below the default (15 for GPT-OSS) **before** the L1-fit check.

## Why this is still needed after main's adaptive L1 guard
Main's adaptive guard already picks a K-dividing width — **but only when the per-core CBs overflow L1** (it runs inside the "shrink to fit" branch). That covers the *large* GPT-OSS cases (e.g. 25k tokens, which overflow and trigger the guard), which is why main has already dropped the `gptoss_120b-25k` xfails.

It does **not** cover a general-path config that **fits** L1: the guard never runs, so the width stays at the default 16 and the K-loop asserts. This PR closes exactly that gap by choosing a divisor on the general path unconditionally, before the L1 check.

## Scope (narrowed vs. when opened)
Main has since resolved the 25k GPT-OSS and the dsv4_pro L1 failures via the adaptive guard and removed their strict xfails. This PR is now the focused fix for the **fits-L1 general path** only; the xfail registry is taken from main (empty).

## Test plan (single Blackhole card)
- `./build_metal.sh --release`
- `pytest tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert.py::test_gptoss_general_path_k_block_width -q`
  - New regression: **1056 allocated tokens forces the general path while 32 active tokens keeps it fast** — i.e. a general-path config that fits L1, which the L1 guard would not touch. PCC ~0.98.
- `pytest .../test_single_routed_expert.py -k gptoss_120b -q` — full sweep green (25k now covered by main's guard + this fix).

Rebased on latest `main` (xfail-table conflict resolved in main's favour).

## CI
gpt-oss `linear-4` routed-expert op-test passes on P150 / P300 / LoudBox / QuietBox → **#49559 resolved**; only failure is the pre-existing `DeepSeek_DSA` flake (also red on `main`).

_Live per-branch status — click a badge to filter runs by this branch (bh-e2e + l2-nightly dispatched per @mbezuljTT / @pmilojevicTT):_

- [![bh-e2e](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=mdragula/fix-routed-expert-k-block-divisibility)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:mdragula/fix-routed-expert-k-block-divisibility)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mdragula/fix-routed-expert-k-block-divisibility)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mdragula/fix-routed-expert-k-block-divisibility)
