### PR TITLE
[Bug Fix]  Align debug_pause_msg_t on QSR

### DIFF
--- a/tt_metal/hw/inc/hostdev/dev_msgs.h
+++ b/tt_metal/hw/inc/hostdev/dev_msgs.h
@@ -294,8 +294,10 @@ enum debug_transaction_type_t { TransactionRead = 0, TransactionWrite = 1, Trans
 
 struct debug_pause_msg_t {
     volatile uint8_t flags[MaxProcessorsPerCoreType];
-    uint8_t pad[3];  // CODEGEN:skip
+    uint8_t pad[(4 - (MaxProcessorsPerCoreType % 4)) % 4];  // CODEGEN:skip
 };
+// Needs to be 32b-divisible, since the host clears pause flags from host using read_core()/write_core().
+static_assert(sizeof(debug_pause_msg_t) % sizeof(uint32_t) == 0);
 
 constexpr static int DEBUG_RING_BUFFER_ELEMENTS = 32;
 constexpr static int DEBUG_RING_BUFFER_SIZE = DEBUG_RING_BUFFER_ELEMENTS * sizeof(uint32_t);


### PR DESCRIPTION
### PR Category
Bug Fix

### Summary
Fixes https://github.com/tenstorrent/tt-metal/issues/43583. On Quasar, `debug_pause_msg_t` size was 27 bytes (not a multiple of 4), since the padding was hardcoded to `pad[3]` for WH/BH's 5 processors whereas Quasar has 24 processors. Watcher clears pause flags via read/write_core API and so this needs to be word-aligned (`sizeof(uint32_t)`). Tests were failing due to this.

### Notes for reviewers
Fixed by padding `flags[]` up to a 32b boundary on all arches, plus a `static_assert` guard:  `pad[(4 - (MaxProcessorsPerCoreType % 4)) % 4]` --> sizeof is always 4-divisible. WH/BH unchanged (5+3 = 8); Quasar 24+0 = 24 (was 27).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadkarni/fix_qsr_pause_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadkarni/fix_qsr_pause_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=snadkarni/fix_qsr_pause_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:snadkarni/fix_qsr_pause_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=snadkarni/fix_qsr_pause_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:snadkarni/fix_qsr_pause_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/fix_qsr_pause_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/fix_qsr_pause_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=snadkarni/fix_qsr_pause_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:snadkarni/fix_qsr_pause_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/fix_qsr_pause_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/fix_qsr_pause_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/fix_qsr_pause_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/fix_qsr_pause_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/fix_qsr_pause_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/fix_qsr_pause_test)