### PR TITLE
[Bug fix] Qwen3.5: prevent GatedDelta prefill L1 circular-buffer collisions

### DIFF
--- a/models/demos/blackhole/qwen36/tests/test_prefill.py
+++ b/models/demos/blackhole/qwen36/tests/test_prefill.py
@@ -67,12 +67,9 @@ def test_mask_bucket_rounding():
         assert f(length) == expected, f"_mask_bucket_for({length}) -> {f(length)}, want {expected}"
 
 
-# NOTE on reference lengths: the masked path is compared against `prefill_paged`, the
-# trusted non-traced path. `prefill_paged` itself has a PRE-EXISTING L1 circular-buffer
-# clash for real lengths in roughly (256, 512] (its GDN runs in L1 for seq_len<=512 and
-# overflows there: T=256/700 are fine, T=300/400/512 throw) — unrelated to masking. So
-# every actual_len below is one prefill_paged handles. The masked path is immune (it forces
-# the GDN to DRAM), which is also how it covers bucket 512: exercised via (256, bucket=512).
+# The exact-length reference and masked path both keep multi-token GDN activations in DRAM.
+# Include the lengths that previously collided with gated_delta_attn_seq's static L1 circular
+# buffers so this comparison also guards the eager prefill memory-planning contract.
 @pytest.mark.parametrize("device_params", DEVICE_PARAMS, indirect=True)
 @pytest.mark.parametrize(
     "actual_len, bucket",
@@ -80,7 +77,10 @@ def test_mask_bucket_rounding():
         (50, 128),  # natural bucket
         (137, 256),  # natural, padded
         (256, 256),  # exact boundary
-        (256, 512),  # forced 512 bucket (DRAM GDN): 256 real + 256 masked pad
+        (256, 512),  # forced 512 bucket: 256 real + 256 masked pad
+        (300, 512),  # exact reference previously hit the L1 circular-buffer clash
+        (400, 512),
+        (512, 512),
         (700, 1024),  # natural, padded
         (1024, 1024),  # exact boundary
         (700, 2048),  # forced 2048 bucket: 700 real + 1348 masked pad
@@ -92,6 +92,9 @@ def test_mask_bucket_rounding():
         "len137_b256",
         "len256_b256",
         "len256_b512",
+        "len300_b512",
+        "len400_b512",
+        "len512_b512",
         "len700_b1024",
         "len1024_b1024",
         "len700_b2048",
@@ -210,8 +213,14 @@ def test_masked_bucket_after_trace_capture(device):
 @pytest.mark.parametrize("device_params", DEVICE_PARAMS, indirect=True)
 @pytest.mark.parametrize(
     "actual_len",
-    [2098, 2748, 3548],
-    ids=["chunk1_tail50_b128", "chunk1_tail700_b1024", "chunk1_tail1500_b2048"],
+    [2098, 2337, 2546, 2748, 3548],
+    ids=[
+        "chunk1_tail50_b128",
+        "chunk1_tail289_b512",
+        "chunk1_tail498_b512",
+        "chunk1_tail700_b1024",
+        "chunk1_tail1500_b2048",
+    ],
 )
 def test_traced_chunked_tail_matches_reference(device, actual_len):
     """Long-prompt path: prefill_traced_chunked replays the parked chunk trace for the full

--- a/models/demos/blackhole/qwen36/tests/unit/test_gdn.py
+++ b/models/demos/blackhole/qwen36/tests/unit/test_gdn.py
@@ -17,6 +17,26 @@ from .conftest import DEVICE_PARAMS
 pytestmark = [run_for_blackhole(), pytest.mark.parametrize("device_params", DEVICE_PARAMS, indirect=True)]
 
 
+def test_l2_norm_memory_config_contract(device):
+    """L2 normalization inherits placement unless the caller requests an output placement."""
+    from models.experimental.gated_attention_gated_deltanet.tt.ttnn_delta_rule_ops import l2_norm_ttnn
+
+    torch.manual_seed(0)
+    x = torch.randn(1, 32, 1, 32, dtype=torch.float32)
+    ref = torch.nn.functional.normalize(x, dim=-1)
+
+    for input_mc in (ttnn.L1_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG):
+        x_tt = ttnn.from_torch(x, layout=ttnn.TILE_LAYOUT, device=device, memory_config=input_mc)
+        inherited = l2_norm_ttnn(x_tt, dim=-1)
+        assert inherited.memory_config() == input_mc
+        assert compute_pcc(ref, ttnn.to_torch(inherited)) > 0.999
+
+    x_l1 = ttnn.from_torch(x, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG)
+    in_dram = l2_norm_ttnn(x_l1, dim=-1, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    assert in_dram.memory_config() == ttnn.DRAM_MEMORY_CONFIG
+    assert compute_pcc(ref, ttnn.to_torch(in_dram)) > 0.999
+
+
 def test_deltanet_pcc(device, setup, request):
     """Compare TTNN deltanet against the torch reference for layer 0."""
     args, sd, raw = setup

--- a/models/demos/blackhole/qwen36/tt/model.py
+++ b/models/demos/blackhole/qwen36/tt/model.py
@@ -1223,7 +1223,8 @@ class Qwen36Model:
         return x
 
     # Fixed buckets for masked tail/short prefill. Lengths round up here -> bounded compile set.
-    # All 128-multiples (GDN sub-chunk). Masked GDN in DRAM avoids L1 clash at bucket 512.
+    # All 128-multiples (GDN sub-chunk). GDN prefill uses DRAM so the scan kernel owns the
+    # L1 space reserved for its static circular buffers.
     # Diverges from get_padded_prefill_len: 256/512 for short TTFT; GDN needs exact valid_len mask.
     _PREFILL_MASK_BUCKETS = (128, 256, 512, 1024, 2048)
 

--- a/models/experimental/gated_attention_gated_deltanet/README.md
+++ b/models/experimental/gated_attention_gated_deltanet/README.md
@@ -122,7 +122,7 @@ Results from Wormhole (single chip, DP=1), comparing torch CPU vs TTNN.
 
 **Memory config strategy:**
 - **Gated Attention:** DRAM everywhere (L1 provides zero benefit; see [analysis](#l1-memory-configuration-analysis))
-- **Gated DeltaNet:** Conditional — `L1_MEMORY_CONFIG` for T ≤ 256, DRAM for T > 256 (`_L1_SEQ_THRESHOLD = 256` in `ttnn_gated_deltanet.py`)
+- **Gated DeltaNet:** L1 for single-token recurrent decode; DRAM for multi-token chunked execution so the sequential scan kernel owns the L1 space reserved for its static circular buffers
 
 **Column key:** T = sequence length, B = batch size, PCC = Pearson Correlation Coefficient (1.0 = perfect match).
 
@@ -157,8 +157,10 @@ TTNN uses `ttnn.transformer.scaled_dot_product_attention` (fused FlashAttention-
 
 - **H** — attention heads, **K** — key/query head dim, **V** — value head dim, **chunk_size** — tokens processed in parallel per chunk
 - Recurrent state per head is a K×V = 128×256 matrix (fixed size, independent of T)
-- T < chunk_size: automatic fallback to recurrent mode
-- Memory: L1 for T ≤ 256 (layer ops), DRAM for T > 256 (avoids OOM)
+- 1 < T < chunk_size: padding to a full chunk before sequential-scan execution
+- Memory: L1 for single-token recurrent decode; DRAM for multi-token chunked execution
+
+The timing table below predates both the current short-sequence routing and the multi-token DRAM policy. Its mode labels and rows marked `chunk/L1` record the behavior used for those measurements.
 
 
 | T     | Torch (ms) | TTNN (ms) | Speedup | PCC    | Mode      |

--- a/models/experimental/gated_attention_gated_deltanet/tt/ttnn_delta_rule_ops.py
+++ b/models/experimental/gated_attention_gated_deltanet/tt/ttnn_delta_rule_ops.py
@@ -225,14 +225,12 @@ def _get_matmul_program_config(m, k, n, grid_size=None, in0_block_w=None):
         return None
 
 
-def l2_norm_ttnn(x, dim=-1, eps=1e-6):
-    """L2 norm along dim. Last dim: fused rms_norm path (~3 fewer kernels)."""
-    # L1 for T<=512; DRAM otherwise
-    T = x.shape[1] if len(x.shape) >= 3 else x.shape[0]
-    mc = ttnn.L1_MEMORY_CONFIG if T <= 512 else ttnn.DRAM_MEMORY_CONFIG
+def l2_norm_ttnn(x, dim=-1, eps=1e-6, memory_config=None):
+    """L2 norm along dim, preserving placement by default."""
+    mc = x.memory_config() if memory_config is None else memory_config
     if dim in (-1, len(x.shape) - 1):
         K = x.shape[-1]
-        normed = ttnn.rms_norm(x, epsilon=eps / K)
+        normed = ttnn.rms_norm(x, epsilon=eps / K, memory_config=mc)
         return ttnn.multiply(normed, K**-0.5, memory_config=mc)
     x_sq = ttnn.multiply(x, x, memory_config=mc)
     norm_sq = ttnn.sum(x_sq, dim=dim, keepdim=True, memory_config=mc)

--- a/models/experimental/gated_attention_gated_deltanet/tt/ttnn_delta_rule_seq.py
+++ b/models/experimental/gated_attention_gated_deltanet/tt/ttnn_delta_rule_seq.py
@@ -125,8 +125,8 @@ def chunk_gated_delta_rule_seq_adapter(
 
     # L2-norm q/k (kernel doesn't); deferred for flat inputs via _defer_l2.
     if not _defer_l2:
-        q = l2_norm_ttnn(q, dim=-1)
-        k = l2_norm_ttnn(k, dim=-1)
+        q = l2_norm_ttnn(q, dim=-1, memory_config=_DRAM)
+        k = l2_norm_ttnn(k, dim=-1, memory_config=_DRAM)
 
     # Relayout untilize/permute in L1; land kernel inputs in DRAM (CBs ~1.36MB/core clash with L1).
     _L1 = ttnn.L1_MEMORY_CONFIG
@@ -144,7 +144,7 @@ def chunk_gated_delta_rule_seq_adapter(
             # Per-head L2 on [BH,T,D] bf16 (before the fp32 cast) — bit-identical to pre-split norm,
             # so keep tilize/typecast separate here (fused f32 tilize would norm in fp32 instead).
             t = ttnn.to_layout(t, ttnn.TILE_LAYOUT, memory_config=_DRAM)  # kernel input in DRAM
-            t = l2_norm_ttnn(t, dim=-1)
+            t = l2_norm_ttnn(t, dim=-1, memory_config=_DRAM)
             if t.dtype != ttnn.float32:
                 t = ttnn.typecast(t, ttnn.float32, memory_config=_DRAM)
             return t
@@ -725,7 +725,7 @@ def chunk_gated_delta_rule_seq(
         dl_exp_4d,
         L_inv_4d,
         initial_state=S0_tt,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        memory_config=_DRAM,
     )
     ttnn.deallocate(L_inv_4d)
 

--- a/models/experimental/gated_attention_gated_deltanet/tt/ttnn_gated_deltanet.py
+++ b/models/experimental/gated_attention_gated_deltanet/tt/ttnn_gated_deltanet.py
@@ -17,13 +17,6 @@ from .ttnn_delta_rule_ops import (
 )
 from .ttnn_delta_rule_seq import chunk_gated_delta_rule_seq_adapter
 
-_L1_SEQ_THRESHOLD = 512
-
-
-def _seq_memory_config(seq_len):
-    """L1 for short sequences (faster), DRAM for long (avoids OOM)."""
-    return ttnn.L1_MEMORY_CONFIG if seq_len <= _L1_SEQ_THRESHOLD else None
-
 
 def rms_norm_gated_ttnn(x, gate, weight, eps=1e-5, memory_config=None):
     """RMSNorm + SiLU gate (trace-compatible). Clips gate to avoid overflow at long T."""
@@ -394,8 +387,17 @@ def gated_deltanet_forward_ttnn(
 
     B = hidden_states.shape[0]
     T = hidden_states.shape[1]
-    # valid_len path forces DRAM (bucket 512 hits L1 CB clash on _seq_memory_config threshold)
-    mc = None if valid_len is not None else _seq_memory_config(T)
+    # Chunk prefill launches gated_delta_attn_seq, whose large static circular buffers need
+    # the per-core L1 address space. Keep the surrounding sequence activations in DRAM
+    # regardless of sequence length. Single-token recurrent decode retains L1 placement;
+    # the general recurrent path preserves its caller's placement.
+    uses_seq_scan = mode == "chunk" and T > 1
+    if uses_seq_scan:
+        mc = ttnn.DRAM_MEMORY_CONFIG
+    elif T == 1:
+        mc = ttnn.L1_MEMORY_CONFIG
+    else:
+        mc = hidden_states.memory_config()
 
     ckc = compute_kernel_config
 
@@ -685,7 +687,7 @@ def gated_deltanet_forward_ttnn(
         g = ttnn.multiply(A_neg, sp, memory_config=mc)
 
     # Gated delta rule: chunk prefill (fp32 seq kernel) vs decode (optimized T=1) vs recurrent fallback
-    if mode == "chunk" and T > 1:
+    if uses_seq_scan:
         o, new_state = chunk_gated_delta_rule_seq_adapter(
             q=q,
             k=k,


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Qwen3.5 GDN prefill selected L1 for every sequence length at or below 512. That length heuristic did not account for `gated_delta_attn_seq`'s static circular buffers, so otherwise-valid short prefills and the short tail of a chunked long prompt could collide with the kernel's L1 region.

On Blackhole P150, `GatedDeltaAttnSeqDeviceOperation` reserves 305 FP32 tiles per core: 1,249,280 bytes in `[111360, 1360640)`. With the real Qwen3.5-9B checkpoint, the first long-prompt failure after a successful 2,048-token chunk is at 2,050 tokens:

- 2,049 passes because its one-token tail uses recurrent execution.
- 2,050 fails when its two-token tail launches the sequence scan. The 22nd GDN's new fused-convolution state occupies `[1357824, 1363968)`, overlapping the static-CB region by 2,816 bytes.

The original 2,546-token failure has the same ownership conflict. Its live `k`, `gate_raw`, `b_raw`, and `a_raw` L1 buffers occupy `[1271808, 1353728)`, inside the sequence kernel's static-CB region. Endpoint probes also show that the old policy's 512-token tail fails at a total length of 2,560, while a 513-token tail selects DRAM and passes at 2,561.

This change removes the capacity-style sequence-length threshold and assigns memory by execution semantics:

- multi-token chunk/sequence-scan activations, normalization intermediates, and output use DRAM;
- single-token recurrent decode retains L1;
- the generic recurrent path preserves the caller's placement;
- `l2_norm_ttnn` inherits input placement unless the caller explicitly requests a memory config.

This is an official GDN caller-side L1-planning issue, not a prefill chunk-setting issue or a regression from the separate depthwise Conv1D work. The C++ sequence kernel and Qwen's 2,048-token chunk size are unchanged.

Blackhole P150 hardware evidence with the real Qwen3.5-9B checkpoint, using the same Release native libraries for the clean `05b5201cc4` baseline and this change:

| Source | Prefill | Result |
| --- | ---: | --- |
| clean `05b5201cc4` | 2,049 | passes; finite logits |
| clean `05b5201cc4` | 2,050 | fails: dynamic L1 starts at 1,357,824; static CB ends at 1,360,640 |
| clean `05b5201cc4` | 2,546 | fails: dynamic L1 starts at 1,271,808; static CB ends at 1,360,640 |
| this change | 2,048 | passes; finite logits |
| this change | 2,546 | passes; finite logits |

Correctness and regression results on Blackhole P150:

- Complete Qwen3.5 prefill suite: 21 passed, 1 intentionally skipped by the suite's `--max-prefill=8192` limit.
- New exact-length and chunk-tail regressions at 300, 400, 512, 2,337, and 2,546 tokens: minimum logits/recurrent-state/conv-state PCC = 0.999258/0.999615/0.999663, with matching natural-bucket argmax tokens.
- GDN L2 memory contract and DeltaNet reference: 2 passed; DeltaNet PCC 0.999304.
- Eager and traced Qwen3.5 decode reference tests: 2 passed.
- Qwen2.5-0.5B 128-token decoder prefill with its real Hugging Face checkpoint: passed; PCC 0.999970.
- A disposable combined checkout with the separate depthwise Conv1D series passed 21 depthwise cases, 2 Quasar cases, 6 Qwen GDN cases, and a full 2,546-token Qwen3.5-9B prefill. Those depthwise commits are intentionally not included here.

A 32-layer Qwen3.5-9B prefill benchmark at 2,048 tokens (3 warmups, 7 measured iterations) was unchanged within run noise: baseline median 1,362.691 ms versus 1,363.196 ms with this change (+0.037%). The baseline cannot execute the 128-token benchmark because it hits the same L1 collision; the fixed path completes with a 543.416 ms median.

### Notes for reviewers
The standalone `gated_delta_attn_seq` device operation passes at 1,024 and 2,048 tokens, and the baseline full-model 2,048-token chunk also passes. The failure comes from caller-owned L1 tensors that remain live across the sequence-kernel launch, so the fix belongs in the GDN memory-placement contract rather than the C++ kernel.

Reducing prefill chunk size would only move or hide the vulnerable tail range and would not remove the overlapping ownership. This change therefore keeps the model's chunking and makes multi-token sequence-scan placement explicitly DRAM-backed instead.

## Current-main rebase validation (2026-07-21)

Rebased HEAD 3847becb8a5e8a7d93637b6b9c48fdafc2954433 onto upstream main 3218270556c5ff58eba1e68d112d09a11b37dc0e. The conflict resolution preserves the newer upstream RMSNorm, flat/GQA-head, relayout, and fused-tilize paths while retaining explicit DRAM placement for sequence-scan inputs and outputs.

- Exact-UMD Release build with TTNN tests: 546 targets passed.
- GDN memory contract and DeltaNet reference: 2 passed; DeltaNet PCC 0.999227.
- Full Qwen3.5 prefill file: 20 passed, 1 expected long-context skip, and 1 unchanged len2000/b2048 argmax assertion failure. The failure reproduces identically on clean upstream main with logit PCC 0.999919, ref token 12, test token 11, and intact recurrent/conv-state PCC; it is not introduced by this PR. All added L1 regression lengths and chunk tails passed.
- Eager decode reference: 1 passed.
- Traced decode reference: 1 passed.
- Real Qwen3.5-9B checkpoint, 32-layer, 2,546-token prefill: finite logits, argmax 238, no L1 collision.
- git diff --check, changed-file Python compilation, and Black formatting checks: passed.
