### PR TITLE
Fix fabric fatal on inter-mesh (Z) links

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/fabric/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/control_plane.hpp
@@ -222,7 +222,7 @@ public:
 
     // Reserve `num_reserved` routing planes in `routing_direction` from `fabric_node_id` so they are excluded
     // from the usable count. Not intended as a query API. Set semantics: the latest call wins, so repeated
-    // invocation during fabric re-init is idempotent.
+    // invocation during fabric re-init is idempotent (reserving 0 is a no-op).
     void reserve_routing_planes(FabricNodeId fabric_node_id, RoutingDirection routing_direction, size_t num_reserved);
 
     std::set<std::pair<chan_id_t, eth_chan_directions>> get_active_fabric_eth_channels(

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -2008,6 +2008,9 @@ size_t ControlPlane::get_num_usable_routing_planes(
 
 void ControlPlane::reserve_routing_planes(
     FabricNodeId fabric_node_id, RoutingDirection routing_direction, size_t num_reserved) {
+    if (num_reserved == 0) {
+        return;
+    }
     TT_FATAL(
         this->router_port_directions_to_num_reserved_planes_map_.contains(fabric_node_id) &&
             this->router_port_directions_to_num_reserved_planes_map_.at(fabric_node_id).contains(routing_direction),


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes #49748.

`reserve_routing_planes` fataled when reserving planes for a `(node, direction)` absent from the routing-plane maps. In RELAXED mode the inter-mesh `Z` direction is never registered, so `discover_channels()`'s reserve fataled on multi-mesh MGDs. Furthermore `Z` doesn't actually carry dispatch links and always reserves 0.

**Fix:** `reserve_routing_planes` returns early when `num_reserved == 0` (a no-op, valid for any direction). Genuine `num_reserved > 0` reservations still assert as before.

### Notes for reviewers
`Z` is not registered in the routing-plane maps. If that needs to be done, register `Z` in `initialize_dynamic_routing_plane_counts`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=scardoza/fix-reserve-links)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:scardoza/fix-reserve-links)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=scardoza/fix-reserve-links)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:scardoza/fix-reserve-links)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=scardoza/fix-reserve-links)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:scardoza/fix-reserve-links)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=scardoza/fix-reserve-links)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:scardoza/fix-reserve-links)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=scardoza/fix-reserve-links)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:scardoza/fix-reserve-links)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=scardoza/fix-reserve-links)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:scardoza/fix-reserve-links)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=scardoza/fix-reserve-links)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:scardoza/fix-reserve-links)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=scardoza/fix-reserve-links)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:scardoza/fix-reserve-links)