### PR TITLE
[cleanup] Pimpl GlobalSemaphore in tt-metalium API

### DIFF
--- a/tt_metal/api/tt-metalium/global_semaphore.hpp
+++ b/tt_metal/api/tt-metalium/global_semaphore.hpp
@@ -18,6 +18,7 @@
 namespace tt::tt_metal {
 class IDevice;
 class GlobalSemaphore;
+class GlobalSemaphoreImpl;
 
 namespace experimental {
 GlobalSemaphore CreateGlobalSemaphore(
@@ -39,11 +40,11 @@ public:
     GlobalSemaphore(
         IDevice* device, CoreRangeSet&& cores, uint32_t initial_value, BufferType buffer_type = BufferType::L1);
 
-    GlobalSemaphore(const GlobalSemaphore&) = default;
-    GlobalSemaphore& operator=(const GlobalSemaphore&) = default;
+    GlobalSemaphore(const GlobalSemaphore& other);
+    GlobalSemaphore& operator=(const GlobalSemaphore& other);
 
-    GlobalSemaphore(GlobalSemaphore&&) noexcept = default;
-    GlobalSemaphore& operator=(GlobalSemaphore&&) noexcept = default;
+    GlobalSemaphore(GlobalSemaphore&& other) noexcept;
+    GlobalSemaphore& operator=(GlobalSemaphore&& other) noexcept;
 
     ~GlobalSemaphore();
 
@@ -65,8 +66,7 @@ private:
         BufferType buffer_type,
         uint64_t address);
 
-    class Impl;
-    std::shared_ptr<Impl> impl_;
+    std::unique_ptr<GlobalSemaphoreImpl> pimpl_;
 
     friend GlobalSemaphore experimental::CreateGlobalSemaphore(
         IDevice* device,

--- a/tt_metal/api/tt-metalium/global_semaphore.hpp
+++ b/tt_metal/api/tt-metalium/global_semaphore.hpp
@@ -7,7 +7,6 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
-#include <optional>
 #include <tuple>
 
 #include <tt-metalium/buffer_types.hpp>
@@ -19,15 +18,6 @@ namespace tt::tt_metal {
 class IDevice;
 class GlobalSemaphore;
 class GlobalSemaphoreImpl;
-
-namespace experimental {
-GlobalSemaphore CreateGlobalSemaphore(
-    IDevice* device,
-    const CoreRangeSet& cores,
-    std::optional<uint32_t> initial_value,
-    BufferType buffer_type,
-    uint64_t address);
-}  // namespace experimental
 }  // namespace tt::tt_metal
 
 namespace tt::tt_metal {
@@ -39,6 +29,9 @@ public:
 
     GlobalSemaphore(
         IDevice* device, CoreRangeSet&& cores, uint32_t initial_value, BufferType buffer_type = BufferType::L1);
+
+    // Internal constructor (internal use only)
+    GlobalSemaphore(GlobalSemaphoreImpl&& impl);
 
     GlobalSemaphore(const GlobalSemaphore& other);
     GlobalSemaphore& operator=(const GlobalSemaphore& other);
@@ -58,22 +51,7 @@ public:
     std::tuple<CoreRangeSet, BufferType> attribute_values() const;
 
 private:
-    // private constructor used by experimental API
-    GlobalSemaphore(
-        IDevice* device,
-        const CoreRangeSet& cores,
-        std::optional<uint32_t> initial_value,
-        BufferType buffer_type,
-        uint64_t address);
-
     std::unique_ptr<GlobalSemaphoreImpl> pimpl_;
-
-    friend GlobalSemaphore experimental::CreateGlobalSemaphore(
-        IDevice* device,
-        const CoreRangeSet& cores,
-        std::optional<uint32_t> initial_value,
-        BufferType buffer_type,
-        uint64_t address);
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/global_semaphore.hpp
+++ b/tt_metal/api/tt-metalium/global_semaphore.hpp
@@ -4,16 +4,15 @@
 
 #pragma once
 
-#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <tuple>
 
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/hal_types.hpp>
-#include <tt-metalium/mesh_buffer.hpp>
 
 // forward declarations
 namespace tt::tt_metal {
@@ -21,7 +20,6 @@ class IDevice;
 class GlobalSemaphore;
 
 namespace experimental {
-// TODO: Move to impl when this class is PIMPLed
 GlobalSemaphore CreateGlobalSemaphore(
     IDevice* device,
     const CoreRangeSet& cores,
@@ -47,6 +45,8 @@ public:
     GlobalSemaphore(GlobalSemaphore&&) noexcept = default;
     GlobalSemaphore& operator=(GlobalSemaphore&&) noexcept = default;
 
+    ~GlobalSemaphore();
+
     IDevice* device() const;
 
     DeviceAddr address() const;
@@ -54,11 +54,10 @@ public:
     void reset_semaphore_value(uint32_t reset_value) const;
 
     static constexpr auto attribute_names = std::forward_as_tuple("cores", "buffer_type");
-    auto attribute_values() const { return std::make_tuple(this->cores_, this->buffer_.get_buffer()->buffer_type()); }
+    std::tuple<CoreRangeSet, BufferType> attribute_values() const;
 
 private:
     // private constructor used by experimental API
-    // TODO: Move to impl when this class is PIMPLed
     GlobalSemaphore(
         IDevice* device,
         const CoreRangeSet& cores,
@@ -66,14 +65,8 @@ private:
         BufferType buffer_type,
         uint64_t address);
 
-    void setup_buffer(
-        std::optional<uint32_t> initial_value, BufferType buffer_type, std::optional<uint64_t> address = std::nullopt);
-
-    // GlobalSemaphore is implemented as a wrapper around a sharded buffer
-    // This can be updated in the future to be its own container with optimized dispatch functions
-    distributed::AnyBuffer buffer_;
-    IDevice* device_;
-    CoreRangeSet cores_;
+    class Impl;
+    std::shared_ptr<Impl> impl_;
 
     friend GlobalSemaphore experimental::CreateGlobalSemaphore(
         IDevice* device,

--- a/tt_metal/impl/buffers/global_semaphore.cpp
+++ b/tt_metal/impl/buffers/global_semaphore.cpp
@@ -23,17 +23,90 @@
 
 namespace tt::tt_metal {
 
+// GlobalSemaphore is implemented as a wrapper around a sharded buffer
+// This can be updated in the future to be its own container with optimized dispatch functions
+class GlobalSemaphore::Impl {
+public:
+    Impl(IDevice* device, const CoreRangeSet& cores, std::optional<uint32_t> initial_value, BufferType buffer_type,
+         std::optional<uint64_t> address) :
+        device_(device), cores_(cores) {
+        this->setup_buffer(initial_value, buffer_type, address);
+    }
+
+    Impl(IDevice* device, CoreRangeSet&& cores, std::optional<uint32_t> initial_value, BufferType buffer_type,
+         std::optional<uint64_t> address) :
+        device_(device), cores_(std::move(cores)) {
+        this->setup_buffer(initial_value, buffer_type, address);
+    }
+
+    IDevice* device() const { return device_; }
+
+    const CoreRangeSet& cores() const { return cores_; }
+
+    BufferType buffer_type() const { return buffer_.get_buffer()->buffer_type(); }
+
+    DeviceAddr address() const { return buffer_.get_buffer()->address(); }
+
+    void reset_semaphore_value(uint32_t reset_value) const {
+        // Blocking write here to ensure that Global Semaphore reset value lands on
+        // each physical device before the next program runs.
+        // This is to ensure that cross-chip writes to the Global Semaphore are not
+        // lost due to device skew.
+        std::vector<uint32_t> host_buffer(cores_.num_cores(), reset_value);
+        auto mesh_buffer = buffer_.get_mesh_buffer();
+        bool using_fast_dispatch = MetalContext::instance().rtoptions().get_fast_dispatch();
+        bool using_simulator = MetalContext::instance().rtoptions().get_simulator_enabled();
+        if (using_fast_dispatch && !using_simulator) {
+            distributed::EnqueueWriteMeshBuffer(
+                mesh_buffer->device()->mesh_command_queue(), mesh_buffer, host_buffer, true);
+        } else {
+            auto* mesh_device = mesh_buffer->device();
+            for (const auto& coord : distributed::MeshCoordinateRange(mesh_device->shape())) {
+                if (!mesh_device->is_local(coord)) {
+                    continue;
+                }
+                tt::tt_metal::detail::WriteToBuffer(*mesh_buffer->get_device_buffer(coord), host_buffer);
+            }
+        }
+    }
+
+private:
+    void setup_buffer(
+        std::optional<uint32_t> initial_value, BufferType buffer_type, std::optional<uint64_t> address) {
+        TT_FATAL(
+            buffer_type == BufferType::L1 or buffer_type == BufferType::L1_SMALL,
+            "Global semaphore can only be created for L1 buffer types");
+        TT_FATAL(device_ != nullptr, "Device cannot be null");
+        TT_FATAL(cores_.num_cores() > 0, "CoreRangeSet must have at least one core");
+        uint32_t num_cores = cores_.num_cores();
+        auto shard_parameters = ShardSpecBuffer(cores_, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {num_cores, 1});
+        ShardedBufferConfig sem_shard_config = {
+            .device = device_,
+            .size = num_cores * sizeof(uint32_t),
+            .page_size = sizeof(uint32_t),
+            .buffer_type = buffer_type,
+            .buffer_layout = TensorMemoryLayout::HEIGHT_SHARDED,
+            .shard_parameters = std::move(shard_parameters),
+        };
+        buffer_ = distributed::AnyBuffer::create(sem_shard_config, address);
+
+        if (initial_value.has_value()) {
+            this->reset_semaphore_value(initial_value.value());
+        }
+    }
+
+    distributed::AnyBuffer buffer_;
+    IDevice* device_;
+    CoreRangeSet cores_;
+};
+
 GlobalSemaphore::GlobalSemaphore(
     IDevice* device, const CoreRangeSet& cores, uint32_t initial_value, BufferType buffer_type) :
-    device_(device), cores_(cores) {
-    this->setup_buffer(initial_value, buffer_type);
-}
+    impl_(std::make_shared<Impl>(device, cores, initial_value, buffer_type, std::nullopt)) {}
 
 GlobalSemaphore::GlobalSemaphore(
     IDevice* device, CoreRangeSet&& cores, uint32_t initial_value, BufferType buffer_type) :
-    device_(device), cores_(std::move(cores)) {
-    this->setup_buffer(initial_value, buffer_type);
-}
+    impl_(std::make_shared<Impl>(device, std::move(cores), initial_value, buffer_type, std::nullopt)) {}
 
 GlobalSemaphore::GlobalSemaphore(
     IDevice* device,
@@ -41,64 +114,23 @@ GlobalSemaphore::GlobalSemaphore(
     std::optional<uint32_t> initial_value,
     BufferType buffer_type,
     uint64_t address) :
-    device_(device), cores_(cores) {
-    this->setup_buffer(initial_value, buffer_type, address);
-}
+    impl_(std::make_shared<Impl>(device, cores, initial_value, buffer_type, address)) {}
 
-void GlobalSemaphore::setup_buffer(
-    std::optional<uint32_t> initial_value, BufferType buffer_type, std::optional<uint64_t> address) {
-    TT_FATAL(
-        buffer_type == BufferType::L1 or buffer_type == BufferType::L1_SMALL,
-        "Global semaphore can only be created for L1 buffer types");
-    TT_FATAL(device_ != nullptr, "Device cannot be null");
-    TT_FATAL(cores_.num_cores() > 0, "CoreRangeSet must have at least one core");
-    uint32_t num_cores = cores_.num_cores();
-    auto shard_parameters = ShardSpecBuffer(cores_, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {num_cores, 1});
-    ShardedBufferConfig sem_shard_config = {
-        .device = device_,
-        .size = num_cores * sizeof(uint32_t),
-        .page_size = sizeof(uint32_t),
-        .buffer_type = buffer_type,
-        .buffer_layout = TensorMemoryLayout::HEIGHT_SHARDED,
-        .shard_parameters = std::move(shard_parameters),
-    };
-    buffer_ = distributed::AnyBuffer::create(sem_shard_config, address);
+GlobalSemaphore::~GlobalSemaphore() = default;
 
-    if (initial_value.has_value()) {
-        this->reset_semaphore_value(initial_value.value());
-    }
-}
-
-IDevice* GlobalSemaphore::device() const { return device_; }
+IDevice* GlobalSemaphore::device() const { return impl_->device(); }
 
 std::ostream& operator<<(std::ostream& os, const GlobalSemaphore& global_semaphore) {
     ttsl::reflection::operator<<(os, global_semaphore);
     return os;
 }
 
-DeviceAddr GlobalSemaphore::address() const { return buffer_.get_buffer()->address(); }
+DeviceAddr GlobalSemaphore::address() const { return impl_->address(); }
 
-void GlobalSemaphore::reset_semaphore_value(uint32_t reset_value) const {
-    // Blocking write here to ensure that Global Semaphore reset value lands on
-    // each physical device before the next program runs.
-    // This is to ensure that cross-chip writes to the Global Semaphore are not
-    // lost due to device skew.
-    std::vector<uint32_t> host_buffer(cores_.num_cores(), reset_value);
-    auto mesh_buffer = buffer_.get_mesh_buffer();
-    bool using_fast_dispatch = MetalContext::instance().rtoptions().get_fast_dispatch();
-    bool using_simulator = MetalContext::instance().rtoptions().get_simulator_enabled();
-    if (using_fast_dispatch && !using_simulator) {
-        distributed::EnqueueWriteMeshBuffer(
-            mesh_buffer->device()->mesh_command_queue(), mesh_buffer, host_buffer, true);
-    } else {
-        auto* mesh_device = mesh_buffer->device();
-        for (const auto& coord : distributed::MeshCoordinateRange(mesh_device->shape())) {
-            if (!mesh_device->is_local(coord)) {
-                continue;
-            }
-            tt::tt_metal::detail::WriteToBuffer(*mesh_buffer->get_device_buffer(coord), host_buffer);
-        }
-    }
+void GlobalSemaphore::reset_semaphore_value(uint32_t reset_value) const { impl_->reset_semaphore_value(reset_value); }
+
+std::tuple<CoreRangeSet, BufferType> GlobalSemaphore::attribute_values() const {
+    return std::make_tuple(impl_->cores(), impl_->buffer_type());
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/buffers/global_semaphore.cpp
+++ b/tt_metal/impl/buffers/global_semaphore.cpp
@@ -101,24 +101,29 @@ void GlobalSemaphoreImpl::setup_buffer(
     }
 }
 
-// GlobalSemaphore implementation
-
-GlobalSemaphore::GlobalSemaphore(
-    IDevice* device, const CoreRangeSet& cores, uint32_t initial_value, BufferType buffer_type) :
-    pimpl_(std::make_unique<GlobalSemaphoreImpl>(device, cores, initial_value, buffer_type, std::nullopt)) {}
-
-GlobalSemaphore::GlobalSemaphore(
-    IDevice* device, CoreRangeSet&& cores, uint32_t initial_value, BufferType buffer_type) :
-    pimpl_(std::make_unique<GlobalSemaphoreImpl>(device, std::move(cores), initial_value, buffer_type, std::nullopt)) {
-}
-
-GlobalSemaphore::GlobalSemaphore(
+namespace experimental {
+GlobalSemaphore CreateGlobalSemaphore(
     IDevice* device,
     const CoreRangeSet& cores,
     std::optional<uint32_t> initial_value,
     BufferType buffer_type,
-    uint64_t address) :
-    pimpl_(std::make_unique<GlobalSemaphoreImpl>(device, cores, initial_value, buffer_type, address)) {}
+    uint64_t address) {
+    return GlobalSemaphore(GlobalSemaphoreImpl(device, cores, initial_value, buffer_type, address));
+}
+}  // namespace experimental
+
+// GlobalSemaphore implementation
+
+GlobalSemaphore::GlobalSemaphore(
+    IDevice* device, const CoreRangeSet& cores, uint32_t initial_value, BufferType buffer_type) :
+    GlobalSemaphore(GlobalSemaphoreImpl(device, cores, initial_value, buffer_type, std::nullopt)) {}
+
+GlobalSemaphore::GlobalSemaphore(
+    IDevice* device, CoreRangeSet&& cores, uint32_t initial_value, BufferType buffer_type) :
+    GlobalSemaphore(GlobalSemaphoreImpl(device, std::move(cores), initial_value, buffer_type, std::nullopt)) {}
+
+GlobalSemaphore::GlobalSemaphore(GlobalSemaphoreImpl&& impl) :
+    pimpl_(std::make_unique<GlobalSemaphoreImpl>(std::move(impl))) {}
 
 GlobalSemaphore::GlobalSemaphore(const GlobalSemaphore& other) :
     pimpl_(other.pimpl_ ? std::make_unique<GlobalSemaphoreImpl>(*other.pimpl_) : nullptr) {}

--- a/tt_metal/impl/buffers/global_semaphore.cpp
+++ b/tt_metal/impl/buffers/global_semaphore.cpp
@@ -27,22 +27,24 @@ namespace tt::tt_metal {
 // GlobalSemaphoreImpl implementation
 
 GlobalSemaphoreImpl::GlobalSemaphoreImpl(
-    IDevice* device,
-    const CoreRangeSet& cores,
-    std::optional<uint32_t> initial_value,
-    BufferType buffer_type,
-    std::optional<uint64_t> address) :
+    IDevice* device, const CoreRangeSet& cores, std::optional<uint32_t> initial_value, BufferType buffer_type) :
     device_(device), cores_(cores) {
-    this->setup_buffer(initial_value, buffer_type, address);
+    this->setup_buffer(initial_value, buffer_type, std::nullopt);
+}
+
+GlobalSemaphoreImpl::GlobalSemaphoreImpl(
+    IDevice* device, CoreRangeSet&& cores, std::optional<uint32_t> initial_value, BufferType buffer_type) :
+    device_(device), cores_(std::move(cores)) {
+    this->setup_buffer(initial_value, buffer_type, std::nullopt);
 }
 
 GlobalSemaphoreImpl::GlobalSemaphoreImpl(
     IDevice* device,
-    CoreRangeSet&& cores,
+    const CoreRangeSet& cores,
     std::optional<uint32_t> initial_value,
     BufferType buffer_type,
-    std::optional<uint64_t> address) :
-    device_(device), cores_(std::move(cores)) {
+    uint64_t address) :
+    device_(device), cores_(cores) {
     this->setup_buffer(initial_value, buffer_type, address);
 }
 
@@ -116,11 +118,11 @@ GlobalSemaphore CreateGlobalSemaphore(
 
 GlobalSemaphore::GlobalSemaphore(
     IDevice* device, const CoreRangeSet& cores, uint32_t initial_value, BufferType buffer_type) :
-    GlobalSemaphore(GlobalSemaphoreImpl(device, cores, initial_value, buffer_type, std::nullopt)) {}
+    GlobalSemaphore(GlobalSemaphoreImpl(device, cores, initial_value, buffer_type)) {}
 
 GlobalSemaphore::GlobalSemaphore(
     IDevice* device, CoreRangeSet&& cores, uint32_t initial_value, BufferType buffer_type) :
-    GlobalSemaphore(GlobalSemaphoreImpl(device, std::move(cores), initial_value, buffer_type, std::nullopt)) {}
+    GlobalSemaphore(GlobalSemaphoreImpl(device, std::move(cores), initial_value, buffer_type)) {}
 
 GlobalSemaphore::GlobalSemaphore(GlobalSemaphoreImpl&& impl) :
     pimpl_(std::make_unique<GlobalSemaphoreImpl>(std::move(impl))) {}

--- a/tt_metal/impl/buffers/global_semaphore.cpp
+++ b/tt_metal/impl/buffers/global_semaphore.cpp
@@ -104,6 +104,7 @@ void GlobalSemaphoreImpl::setup_buffer(
 }
 
 namespace experimental {
+// Forge backdoor API.
 GlobalSemaphore CreateGlobalSemaphore(
     IDevice* device,
     const CoreRangeSet& cores,

--- a/tt_metal/impl/buffers/global_semaphore.cpp
+++ b/tt_metal/impl/buffers/global_semaphore.cpp
@@ -17,96 +17,100 @@
 #include <variant>
 #include <vector>
 
+#include "global_semaphore_impl.hpp"
 #include "mesh_device.hpp"
 #include <tt_stl/reflection.hpp>
 #include "impl/context/metal_context.hpp"
 
 namespace tt::tt_metal {
 
-// GlobalSemaphore is implemented as a wrapper around a sharded buffer
-// This can be updated in the future to be its own container with optimized dispatch functions
-class GlobalSemaphore::Impl {
-public:
-    Impl(IDevice* device, const CoreRangeSet& cores, std::optional<uint32_t> initial_value, BufferType buffer_type,
-         std::optional<uint64_t> address) :
-        device_(device), cores_(cores) {
-        this->setup_buffer(initial_value, buffer_type, address);
-    }
+// GlobalSemaphoreImpl implementation
 
-    Impl(IDevice* device, CoreRangeSet&& cores, std::optional<uint32_t> initial_value, BufferType buffer_type,
-         std::optional<uint64_t> address) :
-        device_(device), cores_(std::move(cores)) {
-        this->setup_buffer(initial_value, buffer_type, address);
-    }
+GlobalSemaphoreImpl::GlobalSemaphoreImpl(
+    IDevice* device,
+    const CoreRangeSet& cores,
+    std::optional<uint32_t> initial_value,
+    BufferType buffer_type,
+    std::optional<uint64_t> address) :
+    device_(device), cores_(cores) {
+    this->setup_buffer(initial_value, buffer_type, address);
+}
 
-    IDevice* device() const { return device_; }
+GlobalSemaphoreImpl::GlobalSemaphoreImpl(
+    IDevice* device,
+    CoreRangeSet&& cores,
+    std::optional<uint32_t> initial_value,
+    BufferType buffer_type,
+    std::optional<uint64_t> address) :
+    device_(device), cores_(std::move(cores)) {
+    this->setup_buffer(initial_value, buffer_type, address);
+}
 
-    const CoreRangeSet& cores() const { return cores_; }
+IDevice* GlobalSemaphoreImpl::device() const { return device_; }
 
-    BufferType buffer_type() const { return buffer_.get_buffer()->buffer_type(); }
+const CoreRangeSet& GlobalSemaphoreImpl::cores() const { return cores_; }
 
-    DeviceAddr address() const { return buffer_.get_buffer()->address(); }
+BufferType GlobalSemaphoreImpl::buffer_type() const { return buffer_.get_buffer()->buffer_type(); }
 
-    void reset_semaphore_value(uint32_t reset_value) const {
-        // Blocking write here to ensure that Global Semaphore reset value lands on
-        // each physical device before the next program runs.
-        // This is to ensure that cross-chip writes to the Global Semaphore are not
-        // lost due to device skew.
-        std::vector<uint32_t> host_buffer(cores_.num_cores(), reset_value);
-        auto mesh_buffer = buffer_.get_mesh_buffer();
-        bool using_fast_dispatch = MetalContext::instance().rtoptions().get_fast_dispatch();
-        bool using_simulator = MetalContext::instance().rtoptions().get_simulator_enabled();
-        if (using_fast_dispatch && !using_simulator) {
-            distributed::EnqueueWriteMeshBuffer(
-                mesh_buffer->device()->mesh_command_queue(), mesh_buffer, host_buffer, true);
-        } else {
-            auto* mesh_device = mesh_buffer->device();
-            for (const auto& coord : distributed::MeshCoordinateRange(mesh_device->shape())) {
-                if (!mesh_device->is_local(coord)) {
-                    continue;
-                }
-                tt::tt_metal::detail::WriteToBuffer(*mesh_buffer->get_device_buffer(coord), host_buffer);
+DeviceAddr GlobalSemaphoreImpl::address() const { return buffer_.get_buffer()->address(); }
+
+void GlobalSemaphoreImpl::reset_semaphore_value(uint32_t reset_value) const {
+    // Blocking write here to ensure that Global Semaphore reset value lands on
+    // each physical device before the next program runs.
+    // This is to ensure that cross-chip writes to the Global Semaphore are not
+    // lost due to device skew.
+    std::vector<uint32_t> host_buffer(cores_.num_cores(), reset_value);
+    auto mesh_buffer = buffer_.get_mesh_buffer();
+    bool using_fast_dispatch = MetalContext::instance().rtoptions().get_fast_dispatch();
+    bool using_simulator = MetalContext::instance().rtoptions().get_simulator_enabled();
+    if (using_fast_dispatch && !using_simulator) {
+        distributed::EnqueueWriteMeshBuffer(
+            mesh_buffer->device()->mesh_command_queue(), mesh_buffer, host_buffer, true);
+    } else {
+        auto* mesh_device = mesh_buffer->device();
+        for (const auto& coord : distributed::MeshCoordinateRange(mesh_device->shape())) {
+            if (!mesh_device->is_local(coord)) {
+                continue;
             }
+            tt::tt_metal::detail::WriteToBuffer(*mesh_buffer->get_device_buffer(coord), host_buffer);
         }
     }
+}
 
-private:
-    void setup_buffer(
-        std::optional<uint32_t> initial_value, BufferType buffer_type, std::optional<uint64_t> address) {
-        TT_FATAL(
-            buffer_type == BufferType::L1 or buffer_type == BufferType::L1_SMALL,
-            "Global semaphore can only be created for L1 buffer types");
-        TT_FATAL(device_ != nullptr, "Device cannot be null");
-        TT_FATAL(cores_.num_cores() > 0, "CoreRangeSet must have at least one core");
-        uint32_t num_cores = cores_.num_cores();
-        auto shard_parameters = ShardSpecBuffer(cores_, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {num_cores, 1});
-        ShardedBufferConfig sem_shard_config = {
-            .device = device_,
-            .size = num_cores * sizeof(uint32_t),
-            .page_size = sizeof(uint32_t),
-            .buffer_type = buffer_type,
-            .buffer_layout = TensorMemoryLayout::HEIGHT_SHARDED,
-            .shard_parameters = std::move(shard_parameters),
-        };
-        buffer_ = distributed::AnyBuffer::create(sem_shard_config, address);
+void GlobalSemaphoreImpl::setup_buffer(
+    std::optional<uint32_t> initial_value, BufferType buffer_type, std::optional<uint64_t> address) {
+    TT_FATAL(
+        buffer_type == BufferType::L1 or buffer_type == BufferType::L1_SMALL,
+        "Global semaphore can only be created for L1 buffer types");
+    TT_FATAL(device_ != nullptr, "Device cannot be null");
+    TT_FATAL(cores_.num_cores() > 0, "CoreRangeSet must have at least one core");
+    uint32_t num_cores = cores_.num_cores();
+    auto shard_parameters = ShardSpecBuffer(cores_, {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {num_cores, 1});
+    ShardedBufferConfig sem_shard_config = {
+        .device = device_,
+        .size = num_cores * sizeof(uint32_t),
+        .page_size = sizeof(uint32_t),
+        .buffer_type = buffer_type,
+        .buffer_layout = TensorMemoryLayout::HEIGHT_SHARDED,
+        .shard_parameters = std::move(shard_parameters),
+    };
+    buffer_ = distributed::AnyBuffer::create(sem_shard_config, address);
 
-        if (initial_value.has_value()) {
-            this->reset_semaphore_value(initial_value.value());
-        }
+    if (initial_value.has_value()) {
+        this->reset_semaphore_value(initial_value.value());
     }
+}
 
-    distributed::AnyBuffer buffer_;
-    IDevice* device_;
-    CoreRangeSet cores_;
-};
+// GlobalSemaphore implementation
 
 GlobalSemaphore::GlobalSemaphore(
     IDevice* device, const CoreRangeSet& cores, uint32_t initial_value, BufferType buffer_type) :
-    impl_(std::make_shared<Impl>(device, cores, initial_value, buffer_type, std::nullopt)) {}
+    pimpl_(std::make_unique<GlobalSemaphoreImpl>(device, cores, initial_value, buffer_type, std::nullopt)) {}
 
 GlobalSemaphore::GlobalSemaphore(
     IDevice* device, CoreRangeSet&& cores, uint32_t initial_value, BufferType buffer_type) :
-    impl_(std::make_shared<Impl>(device, std::move(cores), initial_value, buffer_type, std::nullopt)) {}
+    pimpl_(std::make_unique<GlobalSemaphoreImpl>(device, std::move(cores), initial_value, buffer_type, std::nullopt)) {
+}
 
 GlobalSemaphore::GlobalSemaphore(
     IDevice* device,
@@ -114,23 +118,37 @@ GlobalSemaphore::GlobalSemaphore(
     std::optional<uint32_t> initial_value,
     BufferType buffer_type,
     uint64_t address) :
-    impl_(std::make_shared<Impl>(device, cores, initial_value, buffer_type, address)) {}
+    pimpl_(std::make_unique<GlobalSemaphoreImpl>(device, cores, initial_value, buffer_type, address)) {}
+
+GlobalSemaphore::GlobalSemaphore(const GlobalSemaphore& other) :
+    pimpl_(other.pimpl_ ? std::make_unique<GlobalSemaphoreImpl>(*other.pimpl_) : nullptr) {}
+
+GlobalSemaphore& GlobalSemaphore::operator=(const GlobalSemaphore& other) {
+    if (this != &other) {
+        pimpl_ = other.pimpl_ ? std::make_unique<GlobalSemaphoreImpl>(*other.pimpl_) : nullptr;
+    }
+    return *this;
+}
+
+GlobalSemaphore::GlobalSemaphore(GlobalSemaphore&& other) noexcept = default;
+
+GlobalSemaphore& GlobalSemaphore::operator=(GlobalSemaphore&& other) noexcept = default;
 
 GlobalSemaphore::~GlobalSemaphore() = default;
 
-IDevice* GlobalSemaphore::device() const { return impl_->device(); }
+IDevice* GlobalSemaphore::device() const { return pimpl_->device(); }
 
 std::ostream& operator<<(std::ostream& os, const GlobalSemaphore& global_semaphore) {
     ttsl::reflection::operator<<(os, global_semaphore);
     return os;
 }
 
-DeviceAddr GlobalSemaphore::address() const { return impl_->address(); }
+DeviceAddr GlobalSemaphore::address() const { return pimpl_->address(); }
 
-void GlobalSemaphore::reset_semaphore_value(uint32_t reset_value) const { impl_->reset_semaphore_value(reset_value); }
+void GlobalSemaphore::reset_semaphore_value(uint32_t reset_value) const { pimpl_->reset_semaphore_value(reset_value); }
 
 std::tuple<CoreRangeSet, BufferType> GlobalSemaphore::attribute_values() const {
-    return std::make_tuple(impl_->cores(), impl_->buffer_type());
+    return std::make_tuple(pimpl_->cores(), pimpl_->buffer_type());
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/buffers/global_semaphore_impl.hpp
+++ b/tt_metal/impl/buffers/global_semaphore_impl.hpp
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+#include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/hal_types.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
+
+namespace tt::tt_metal {
+
+class IDevice;
+
+// GlobalSemaphoreImpl is implemented as a wrapper around a sharded buffer
+// This can be updated in the future to be its own container with optimized dispatch functions
+class GlobalSemaphoreImpl {
+public:
+    GlobalSemaphoreImpl(
+        IDevice* device,
+        const CoreRangeSet& cores,
+        std::optional<uint32_t> initial_value,
+        BufferType buffer_type,
+        std::optional<uint64_t> address);
+
+    GlobalSemaphoreImpl(
+        IDevice* device,
+        CoreRangeSet&& cores,
+        std::optional<uint32_t> initial_value,
+        BufferType buffer_type,
+        std::optional<uint64_t> address);
+
+    // Copy/move semantics
+    GlobalSemaphoreImpl(const GlobalSemaphoreImpl&) = default;
+    GlobalSemaphoreImpl& operator=(const GlobalSemaphoreImpl&) = default;
+    GlobalSemaphoreImpl(GlobalSemaphoreImpl&&) noexcept = default;
+    GlobalSemaphoreImpl& operator=(GlobalSemaphoreImpl&&) noexcept = default;
+
+    IDevice* device() const;
+
+    const CoreRangeSet& cores() const;
+
+    BufferType buffer_type() const;
+
+    DeviceAddr address() const;
+
+    void reset_semaphore_value(uint32_t reset_value) const;
+
+private:
+    void setup_buffer(
+        std::optional<uint32_t> initial_value, BufferType buffer_type, std::optional<uint64_t> address);
+
+    distributed::AnyBuffer buffer_;
+    IDevice* device_;
+    CoreRangeSet cores_;
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/buffers/global_semaphore_impl.hpp
+++ b/tt_metal/impl/buffers/global_semaphore_impl.hpp
@@ -15,6 +15,7 @@
 namespace tt::tt_metal {
 
 class IDevice;
+class GlobalSemaphore;
 
 // GlobalSemaphoreImpl is implemented as a wrapper around a sharded buffer
 // This can be updated in the future to be its own container with optimized dispatch functions
@@ -58,5 +59,14 @@ private:
     IDevice* device_;
     CoreRangeSet cores_;
 };
+
+namespace experimental {
+GlobalSemaphore CreateGlobalSemaphore(
+    IDevice* device,
+    const CoreRangeSet& cores,
+    std::optional<uint32_t> initial_value,
+    BufferType buffer_type,
+    uint64_t address);
+}  // namespace experimental
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/buffers/global_semaphore_impl.hpp
+++ b/tt_metal/impl/buffers/global_semaphore_impl.hpp
@@ -27,7 +27,7 @@ public:
     GlobalSemaphoreImpl(
         IDevice* device, CoreRangeSet&& cores, std::optional<uint32_t> initial_value, BufferType buffer_type);
 
-    // Dedicated constructor for creating a global semaphore without allocation.
+    // Dedicated constructor for creating a global semaphore **without allocation**.
     // The instantiation of GlobalSemphore will be emplaced onto the address specified.
     GlobalSemaphoreImpl(
         IDevice* device,

--- a/tt_metal/impl/buffers/global_semaphore_impl.hpp
+++ b/tt_metal/impl/buffers/global_semaphore_impl.hpp
@@ -22,18 +22,19 @@ class GlobalSemaphore;
 class GlobalSemaphoreImpl {
 public:
     GlobalSemaphoreImpl(
+        IDevice* device, const CoreRangeSet& cores, std::optional<uint32_t> initial_value, BufferType buffer_type);
+
+    GlobalSemaphoreImpl(
+        IDevice* device, CoreRangeSet&& cores, std::optional<uint32_t> initial_value, BufferType buffer_type);
+
+    // Dedicated constructor for creating a global semaphore without allocation.
+    // The instantiation of GlobalSemphore will be emplaced onto the address specified.
+    GlobalSemaphoreImpl(
         IDevice* device,
         const CoreRangeSet& cores,
         std::optional<uint32_t> initial_value,
         BufferType buffer_type,
-        std::optional<uint64_t> address);
-
-    GlobalSemaphoreImpl(
-        IDevice* device,
-        CoreRangeSet&& cores,
-        std::optional<uint32_t> initial_value,
-        BufferType buffer_type,
-        std::optional<uint64_t> address);
+        uint64_t address);
 
     // Copy/move semantics
     GlobalSemaphoreImpl(const GlobalSemaphoreImpl&) = default;
@@ -59,14 +60,5 @@ private:
     IDevice* device_;
     CoreRangeSet cores_;
 };
-
-namespace experimental {
-GlobalSemaphore CreateGlobalSemaphore(
-    IDevice* device,
-    const CoreRangeSet& cores,
-    std::optional<uint32_t> initial_value,
-    BufferType buffer_type,
-    uint64_t address);
-}  // namespace experimental
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/host_api/tt_metal.cpp
+++ b/tt_metal/impl/host_api/tt_metal.cpp
@@ -1691,17 +1691,6 @@ GlobalSemaphore CreateGlobalSemaphore(
     return GlobalSemaphore(device, std::move(cores), initial_value, buffer_type);
 }
 
-namespace experimental {
-GlobalSemaphore CreateGlobalSemaphore(
-    IDevice* device,
-    const CoreRangeSet& cores,
-    std::optional<uint32_t> initial_value,
-    BufferType buffer_type,
-    uint64_t address) {
-    return GlobalSemaphore(device, cores, initial_value, buffer_type, address);
-}
-}  // namespace experimental
-
 std::shared_ptr<Buffer> CreateBuffer(const InterleavedBufferConfig& config) {
     return Buffer::create(config.device, config.size, config.page_size, config.buffer_type);
 }

--- a/ttnn/cpp/ttnn/operations/ccl/common/uops/ccl_host_commands.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/uops/ccl_host_commands.cpp
@@ -6,6 +6,7 @@
 
 #include "ttnn/operations/ccl/common/uops/ccl_command.hpp"
 #include <tt-metalium/global_semaphore.hpp>
+#include <tt_stl/assert.hpp>
 #include <tt_stl/overloaded.hpp>
 
 #include <variant>


### PR DESCRIPTION
## Summary
Pimpl idiom is highly used in API boundaries in tt-metal.

This is because we:
1. Need to hide implementation details from public declaration
2. Need to permit injections of experimental/ backdoor implementation into our implementation via friend functions and pimpl pattern.

This PR pimplifies `GlobalSemphore` and removes internal/ experimental feature from the public stable API.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=river/pimpl-global-semaphore)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:river/pimpl-global-semaphore)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=river/pimpl-global-semaphore)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:river/pimpl-global-semaphore)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=river/pimpl-global-semaphore)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:river/pimpl-global-semaphore)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=river/pimpl-global-semaphore)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:river/pimpl-global-semaphore)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=river/pimpl-global-semaphore)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:river/pimpl-global-semaphore)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=river/pimpl-global-semaphore)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:river/pimpl-global-semaphore)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=river/pimpl-global-semaphore)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:river/pimpl-global-semaphore)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=river/pimpl-global-semaphore)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:river/pimpl-global-semaphore)