### PR TITLE
[Cleanup] Remove MeshTensor backdoor for ttnn

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
@@ -185,25 +185,6 @@ private:
     // to build a MeshTensor.
     explicit MeshTensor(std::shared_ptr<distributed::MeshBuffer> mesh_buffer, TensorSpec spec, TensorTopology topology);
 
-    // TODO(#43693): Remove once DeviceStorage no longer keeps a shared_ptr<MeshBuffer>
-    // in its DeallocatedTombStone state.
-    // DeviceStorage is the sole caller — it uses mesh_buffer_invariant_breaking() to
-    // populate the tombstone when a tensor is deallocated, so the device pointer
-    // remains accessible on aliased tensors (e.g. after a zero-copy reshape).
-    // This breaks MeshTensor's core invariant: that it is the sole owner of the
-    // underlying MeshBuffer. Shared ownership leaks out, allowing the MeshBuffer to
-    // outlive the MeshTensor.
-    friend struct DeviceStorage;
-
-    /**
-     * Returns shared ownership of the underlying MeshBuffer.
-     *
-     * WARNING: Breaks MeshTensor's sole-ownership invariant. The caller becomes a
-     * shared owner of the MeshBuffer, which can outlive the MeshTensor.
-     * Only accessible to DeviceStorage. See #43693 for removal plan.
-     */
-    std::shared_ptr<distributed::MeshBuffer> mesh_buffer_invariant_breaking() const;
-
     // impl_ could be a nullptr if MeshTensor is in a moved-from state.
     // Avoid using impl_ pointer directly, use the impl() accessor instead.
     // Otherwise, please add manual TT_FATAL checks for nullptr.

--- a/tt_metal/impl/tensor/mesh_tensor.cpp
+++ b/tt_metal/impl/tensor/mesh_tensor.cpp
@@ -31,10 +31,6 @@ const MeshTensorImpl& MeshTensor::impl() const {
 
 const distributed::MeshBuffer& MeshTensor::mesh_buffer() const { return impl().mesh_buffer(); }
 
-std::shared_ptr<distributed::MeshBuffer> MeshTensor::mesh_buffer_invariant_breaking() const {
-    return impl().raw_mesh_buffer();
-}
-
 const distributed::MeshDevice& MeshTensor::device() const { return mutable_device(); }
 
 distributed::MeshDevice& MeshTensor::mutable_device() const { return *mesh_buffer().device(); }


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

`mesh_buffer_invariant_breaking()` and the accompanying `DeviceStorage` friend grant were a backdoor added during tensor lowering to let ttnn bypass MeshTensor's sole-ownership invariant. Two gaps motivated it, and both are now closed:

- ttnn::Tensor needed shared ownership of the underlying memory to interoperate with existing systems, which conflicted with MeshTensor's guarantee of being the sole owner of its MeshBuffer. That need is now served by DeviceStorage, which owns the memory jointly by design — callers wanting shared ownership should hold a Tensor or DeviceStorage rather than reaching into MeshTensor.
- ttnn::Tensor used to have to keep the deallocated MeshBuffer as its tombstone value. For more details please see #47291.

With both use cases gone, the backdoor has no remaining callers, so this is a mechanical removal.

Contributes to #38375

### Notes for reviewers

- Grepped the repo to confirm `mesh_buffer_invariant_breaking()` and the `DeviceStorage` friend relationship have zero remaining references.
- Verified locally with `./build_metal.sh --enable-ccache` (warnings-as-errors on).