### PR TITLE
[tt-metal] Add per-device optimal DRAM worker assignment on MeshDevice (Feature)

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device.cpp
@@ -5,6 +5,7 @@
 #include <fmt/base.h>
 #include <gtest/gtest.h>
 #include <tt-metalium/allocator.hpp>
+#include <map>
 #include <memory>
 #include <optional>
 #include <vector>
@@ -33,6 +34,15 @@ namespace {
 
 using ::testing::IsEmpty;
 using ::testing::SizeIs;
+
+// Builds the expected bank id -> worker core map from a per-bank list (indexed by DRAM bank id).
+std::map<uint32_t, CoreCoord> to_bank_map(const std::vector<CoreCoord>& per_bank) {
+    std::map<uint32_t, CoreCoord> assignment;
+    for (uint32_t bank_id = 0; bank_id < per_bank.size(); ++bank_id) {
+        assignment.emplace(bank_id, per_bank[bank_id]);
+    }
+    return assignment;
+}
 
 TEST(MeshDeviceInitTest, Init1x1Mesh) {
     MeshDeviceConfig config(MeshShape(1, 1));
@@ -139,12 +149,13 @@ TEST(GetOptimalDramBankToLogicalWorkerAssignmentAPI, UnitMeshes) {
     const MeshCoordinate coord(0, 0);
     for (auto& [_, dev] : devs) {
         for (auto noc : {NOC::NOC_0, NOC::NOC_1}) {
-            std::vector<CoreCoord> per_device;
+            std::map<uint32_t, CoreCoord> per_device;
             EXPECT_NO_THROW(per_device = dev->get_optimal_dram_bank_to_logical_worker_assignment(noc, coord));
             // On a 1x1 mesh the single local device is the queried device, so the per-coordinate overload
-            // must match querying that device directly.
-            EXPECT_EQ(
-                per_device, dev->impl().get_device(coord)->get_optimal_dram_bank_to_logical_worker_assignment(noc));
+            // must match querying that device directly (bank id -> the same per-bank worker core).
+            const auto expected =
+                dev->impl().get_device(coord)->get_optimal_dram_bank_to_logical_worker_assignment(noc);
+            EXPECT_EQ(per_device, to_bank_map(expected));
         }
     }
 }
@@ -152,12 +163,12 @@ TEST(GetOptimalDramBankToLogicalWorkerAssignmentAPI, UnitMeshes) {
 TEST_F(MeshDevice2x4Test, GetOptimalDramBankToLogicalWorkerAssignmentPerDevice) {
     for (auto noc : {NOC::NOC_0, NOC::NOC_1}) {
         for (const auto& coord : MeshCoordinateRange(mesh_device_->shape())) {
-            std::vector<CoreCoord> per_device;
+            std::map<uint32_t, CoreCoord> per_device;
             EXPECT_NO_THROW(per_device = mesh_device_->get_optimal_dram_bank_to_logical_worker_assignment(noc, coord));
             // The per-coordinate result must match querying that specific device directly.
             auto* device = mesh_device_->impl().get_device(coord);
             ASSERT_NE(device, nullptr);
-            EXPECT_EQ(per_device, device->get_optimal_dram_bank_to_logical_worker_assignment(noc));
+            EXPECT_EQ(per_device, to_bank_map(device->get_optimal_dram_bank_to_logical_worker_assignment(noc)));
         }
     }
 }

--- a/tests/tt_metal/distributed/test_mesh_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device.cpp
@@ -5,7 +5,7 @@
 #include <fmt/base.h>
 #include <gtest/gtest.h>
 #include <tt-metalium/allocator.hpp>
-#include <map>
+#include <unordered_map>
 #include <memory>
 #include <optional>
 #include <vector>
@@ -36,8 +36,8 @@ using ::testing::IsEmpty;
 using ::testing::SizeIs;
 
 // Builds the expected bank id -> worker core map from a per-bank list (indexed by DRAM bank id).
-std::map<uint32_t, CoreCoord> to_bank_map(const std::vector<CoreCoord>& per_bank) {
-    std::map<uint32_t, CoreCoord> assignment;
+std::unordered_map<uint32_t, CoreCoord> to_bank_map(const std::vector<CoreCoord>& per_bank) {
+    std::unordered_map<uint32_t, CoreCoord> assignment;
     for (uint32_t bank_id = 0; bank_id < per_bank.size(); ++bank_id) {
         assignment.emplace(bank_id, per_bank[bank_id]);
     }
@@ -149,7 +149,7 @@ TEST(GetOptimalDramBankToLogicalWorkerAssignmentAPI, UnitMeshes) {
     const MeshCoordinate coord(0, 0);
     for (auto& [_, dev] : devs) {
         for (auto noc : {NOC::NOC_0, NOC::NOC_1}) {
-            std::map<uint32_t, CoreCoord> per_device;
+            std::unordered_map<uint32_t, CoreCoord> per_device;
             EXPECT_NO_THROW(per_device = dev->get_optimal_dram_bank_to_logical_worker_assignment(noc, coord));
             // On a 1x1 mesh the single local device is the queried device, so the per-coordinate overload
             // must match querying that device directly (bank id -> the same per-bank worker core).
@@ -163,7 +163,7 @@ TEST(GetOptimalDramBankToLogicalWorkerAssignmentAPI, UnitMeshes) {
 TEST_F(MeshDevice2x4Test, GetOptimalDramBankToLogicalWorkerAssignmentPerDevice) {
     for (auto noc : {NOC::NOC_0, NOC::NOC_1}) {
         for (const auto& coord : MeshCoordinateRange(mesh_device_->shape())) {
-            std::map<uint32_t, CoreCoord> per_device;
+            std::unordered_map<uint32_t, CoreCoord> per_device;
             EXPECT_NO_THROW(per_device = mesh_device_->get_optimal_dram_bank_to_logical_worker_assignment(noc, coord));
             // The per-coordinate result must match querying that specific device directly.
             auto* device = mesh_device_->impl().get_device(coord);

--- a/tests/tt_metal/distributed/test_mesh_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device.cpp
@@ -136,9 +136,29 @@ TEST(GetOptimalDramBankToLogicalWorkerAssignmentAPI, UnitMeshes) {
     auto device_ids_set = tt::tt_metal::MetalContext::instance().get_cluster().user_exposed_chip_ids();
     std::vector<int> device_ids(device_ids_set.begin(), device_ids_set.end());
     auto devs = tt::tt_metal::distributed::MeshDevice::create_unit_meshes(device_ids);
+    const MeshCoordinate coord(0, 0);
     for (auto& [_, dev] : devs) {
-        EXPECT_NO_THROW(dev->get_optimal_dram_bank_to_logical_worker_assignment(NOC::NOC_0));
-        EXPECT_NO_THROW(dev->get_optimal_dram_bank_to_logical_worker_assignment(NOC::NOC_1));
+        for (auto noc : {NOC::NOC_0, NOC::NOC_1}) {
+            std::vector<CoreCoord> per_device;
+            EXPECT_NO_THROW(per_device = dev->get_optimal_dram_bank_to_logical_worker_assignment(noc, coord));
+            // On a 1x1 mesh the single local device is the queried device, so the per-coordinate overload
+            // must match querying that device directly.
+            EXPECT_EQ(
+                per_device, dev->impl().get_device(coord)->get_optimal_dram_bank_to_logical_worker_assignment(noc));
+        }
+    }
+}
+
+TEST_F(MeshDevice2x4Test, GetOptimalDramBankToLogicalWorkerAssignmentPerDevice) {
+    for (auto noc : {NOC::NOC_0, NOC::NOC_1}) {
+        for (const auto& coord : MeshCoordinateRange(mesh_device_->shape())) {
+            std::vector<CoreCoord> per_device;
+            EXPECT_NO_THROW(per_device = mesh_device_->get_optimal_dram_bank_to_logical_worker_assignment(noc, coord));
+            // The per-coordinate result must match querying that specific device directly.
+            auto* device = mesh_device_->impl().get_device(coord);
+            ASSERT_NE(device, nullptr);
+            EXPECT_EQ(per_device, device->get_optimal_dram_bank_to_logical_worker_assignment(noc));
+        }
     }
 }
 

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -131,7 +131,7 @@ public:
     // per device on a heterogeneous mesh. If `coord` maps to a remote device, this falls back to an
     // arbitrary local device's assignment (best-effort, exact only on homogeneous meshes); it throws only
     // when the mesh has no local device to fall back to.
-    std::map<uint32_t, CoreCoord> get_optimal_dram_bank_to_logical_worker_assignment(
+    std::unordered_map<uint32_t, CoreCoord> get_optimal_dram_bank_to_logical_worker_assignment(
         NOC noc, const MeshCoordinate& coord);
 
     CoreCoord virtual_core_from_logical_core(const CoreCoord& logical_coord, const CoreType& core_type) const override;

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -125,12 +125,14 @@ public:
         "meshes. Use get_optimal_dram_bank_to_logical_worker_assignment(noc, coord) instead.")]]
     std::vector<CoreCoord> get_optimal_dram_bank_to_logical_worker_assignment(NOC noc) override;
 
-    // Returns the optimal DRAM-bank-to-logical-worker assignment for the device at `coord`. The assignment
-    // is a device-local physical property (it depends on that device's harvesting and DRAM configuration),
-    // so it may differ per device on a heterogeneous mesh. If `coord` maps to a remote device, this falls
-    // back to an arbitrary local device's assignment (best-effort, exact only on homogeneous meshes); it
-    // throws only when the mesh has no local device to fall back to.
-    std::vector<CoreCoord> get_optimal_dram_bank_to_logical_worker_assignment(NOC noc, const MeshCoordinate& coord);
+    // Returns the optimal DRAM-bank-to-logical-worker assignment for the device at `coord` as a map from
+    // DRAM bank id to the logical worker core that should service it. The assignment is a device-local
+    // physical property (it depends on that device's harvesting and DRAM configuration), so it may differ
+    // per device on a heterogeneous mesh. If `coord` maps to a remote device, this falls back to an
+    // arbitrary local device's assignment (best-effort, exact only on homogeneous meshes); it throws only
+    // when the mesh has no local device to fall back to.
+    std::map<uint32_t, CoreCoord> get_optimal_dram_bank_to_logical_worker_assignment(
+        NOC noc, const MeshCoordinate& coord);
 
     CoreCoord virtual_core_from_logical_core(const CoreCoord& logical_coord, const CoreType& core_type) const override;
     CoreCoord worker_core_from_logical_core(const CoreCoord& logical_core) const override;

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -116,7 +116,21 @@ public:
     std::vector<CoreCoord> worker_cores_from_logical_cores(const std::vector<CoreCoord>& logical_cores) const override;
     std::vector<CoreCoord> ethernet_cores_from_logical_cores(
         const std::vector<CoreCoord>& logical_cores) const override;
+    // Deprecated: returns the assignment of the mesh's reference (front) device only. On a mesh with
+    // heterogeneous harvesting the optimal placement differs per device, so this silently returns the
+    // wrong cores for every device but the reference one. Use the MeshCoordinate overload below to get
+    // the assignment for a specific device.
+    [[deprecated(
+        "Returns only the reference device's assignment, which is incorrect on heterogeneously-harvested "
+        "meshes. Use get_optimal_dram_bank_to_logical_worker_assignment(noc, coord) instead.")]]
     std::vector<CoreCoord> get_optimal_dram_bank_to_logical_worker_assignment(NOC noc) override;
+
+    // Returns the optimal DRAM-bank-to-logical-worker assignment for the device at `coord`. The assignment
+    // is a device-local physical property (it depends on that device's harvesting and DRAM configuration),
+    // so it may differ per device on a heterogeneous mesh. If `coord` maps to a remote device, this falls
+    // back to an arbitrary local device's assignment (best-effort, exact only on homogeneous meshes); it
+    // throws only when the mesh has no local device to fall back to.
+    std::vector<CoreCoord> get_optimal_dram_bank_to_logical_worker_assignment(NOC noc, const MeshCoordinate& coord);
 
     CoreCoord virtual_core_from_logical_core(const CoreCoord& logical_coord, const CoreType& core_type) const override;
     CoreCoord worker_core_from_logical_core(const CoreCoord& logical_core) const override;

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -1144,6 +1144,26 @@ std::vector<CoreCoord> MeshDeviceImpl::worker_cores_from_logical_cores(
 std::vector<CoreCoord> MeshDeviceImpl::get_optimal_dram_bank_to_logical_worker_assignment(NOC noc) {
     return get_devices().front()->get_optimal_dram_bank_to_logical_worker_assignment(noc);
 }
+std::vector<CoreCoord> MeshDeviceImpl::get_optimal_dram_bank_to_logical_worker_assignment(
+    NOC noc, const MeshCoordinate& coord) {
+    // The assignment is a device-local physical property that can only be queried for a local device.
+    // If `coord` maps to a local device, use it. Otherwise (a remote device) fall back to an arbitrary
+    // local device's assignment; this is a best-effort approximation that is exact only when the mesh
+    // is homogeneously harvested. Fail only when there is no local device to fall back to.
+    IDevice* device = nullptr;
+    if (view_->impl().is_local(coord)) {
+        device = view_->impl().get_device(coord);
+    } else {
+        const auto local_devices = this->get_devices();
+        TT_FATAL(
+            !local_devices.empty(),
+            "get_optimal_dram_bank_to_logical_worker_assignment: MeshCoordinate {} maps to a remote device and this "
+            "mesh has no local devices to fall back to.",
+            coord);
+        device = local_devices.front();
+    }
+    return device->get_optimal_dram_bank_to_logical_worker_assignment(noc);
+}
 CoreCoord MeshDeviceImpl::virtual_core_from_logical_core(
     const CoreCoord& logical_coord, const CoreType& core_type) const {
     return validate_and_get_reference_value(this->get_devices(), [logical_coord, core_type](const auto* device) {
@@ -1725,6 +1745,10 @@ std::vector<CoreCoord> MeshDevice::ethernet_cores_from_logical_cores(
 }
 std::vector<CoreCoord> MeshDevice::get_optimal_dram_bank_to_logical_worker_assignment(NOC noc) {
     return pimpl_->get_optimal_dram_bank_to_logical_worker_assignment(noc);
+}
+std::vector<CoreCoord> MeshDevice::get_optimal_dram_bank_to_logical_worker_assignment(
+    NOC noc, const MeshCoordinate& coord) {
+    return pimpl_->get_optimal_dram_bank_to_logical_worker_assignment(noc, coord);
 }
 CoreCoord MeshDevice::virtual_core_from_logical_core(const CoreCoord& logical_coord, const CoreType& core_type) const {
     return pimpl_->virtual_core_from_logical_core(logical_coord, core_type);

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -1144,7 +1144,7 @@ std::vector<CoreCoord> MeshDeviceImpl::worker_cores_from_logical_cores(
 std::vector<CoreCoord> MeshDeviceImpl::get_optimal_dram_bank_to_logical_worker_assignment(NOC noc) {
     return get_devices().front()->get_optimal_dram_bank_to_logical_worker_assignment(noc);
 }
-std::vector<CoreCoord> MeshDeviceImpl::get_optimal_dram_bank_to_logical_worker_assignment(
+std::map<uint32_t, CoreCoord> MeshDeviceImpl::get_optimal_dram_bank_to_logical_worker_assignment(
     NOC noc, const MeshCoordinate& coord) {
     // The assignment is a device-local physical property that can only be queried for a local device.
     // If `coord` maps to a local device, use it. Otherwise (a remote device) fall back to an arbitrary
@@ -1162,7 +1162,14 @@ std::vector<CoreCoord> MeshDeviceImpl::get_optimal_dram_bank_to_logical_worker_a
             coord);
         device = local_devices.front();
     }
-    return device->get_optimal_dram_bank_to_logical_worker_assignment(noc);
+    // The underlying assignment is a per-bank list indexed by DRAM bank id; expose it as an explicit
+    // bank-id -> worker-core map so consumers do not treat the position in a flat list as incidental.
+    const auto per_bank = device->get_optimal_dram_bank_to_logical_worker_assignment(noc);
+    std::map<uint32_t, CoreCoord> assignment;
+    for (uint32_t bank_id = 0; bank_id < per_bank.size(); ++bank_id) {
+        assignment.emplace(bank_id, per_bank[bank_id]);
+    }
+    return assignment;
 }
 CoreCoord MeshDeviceImpl::virtual_core_from_logical_core(
     const CoreCoord& logical_coord, const CoreType& core_type) const {
@@ -1746,7 +1753,7 @@ std::vector<CoreCoord> MeshDevice::ethernet_cores_from_logical_cores(
 std::vector<CoreCoord> MeshDevice::get_optimal_dram_bank_to_logical_worker_assignment(NOC noc) {
     return pimpl_->get_optimal_dram_bank_to_logical_worker_assignment(noc);
 }
-std::vector<CoreCoord> MeshDevice::get_optimal_dram_bank_to_logical_worker_assignment(
+std::map<uint32_t, CoreCoord> MeshDevice::get_optimal_dram_bank_to_logical_worker_assignment(
     NOC noc, const MeshCoordinate& coord) {
     return pimpl_->get_optimal_dram_bank_to_logical_worker_assignment(noc, coord);
 }

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -1144,7 +1144,7 @@ std::vector<CoreCoord> MeshDeviceImpl::worker_cores_from_logical_cores(
 std::vector<CoreCoord> MeshDeviceImpl::get_optimal_dram_bank_to_logical_worker_assignment(NOC noc) {
     return get_devices().front()->get_optimal_dram_bank_to_logical_worker_assignment(noc);
 }
-std::map<uint32_t, CoreCoord> MeshDeviceImpl::get_optimal_dram_bank_to_logical_worker_assignment(
+std::unordered_map<uint32_t, CoreCoord> MeshDeviceImpl::get_optimal_dram_bank_to_logical_worker_assignment(
     NOC noc, const MeshCoordinate& coord) {
     // The assignment is a device-local physical property that can only be queried for a local device.
     // If `coord` maps to a local device, use it. Otherwise (a remote device) fall back to an arbitrary
@@ -1165,7 +1165,7 @@ std::map<uint32_t, CoreCoord> MeshDeviceImpl::get_optimal_dram_bank_to_logical_w
     // The underlying assignment is a per-bank list indexed by DRAM bank id; expose it as an explicit
     // bank-id -> worker-core map so consumers do not treat the position in a flat list as incidental.
     const auto per_bank = device->get_optimal_dram_bank_to_logical_worker_assignment(noc);
-    std::map<uint32_t, CoreCoord> assignment;
+    std::unordered_map<uint32_t, CoreCoord> assignment;
     for (uint32_t bank_id = 0; bank_id < per_bank.size(); ++bank_id) {
         assignment.emplace(bank_id, per_bank[bank_id]);
     }
@@ -1753,7 +1753,7 @@ std::vector<CoreCoord> MeshDevice::ethernet_cores_from_logical_cores(
 std::vector<CoreCoord> MeshDevice::get_optimal_dram_bank_to_logical_worker_assignment(NOC noc) {
     return pimpl_->get_optimal_dram_bank_to_logical_worker_assignment(noc);
 }
-std::map<uint32_t, CoreCoord> MeshDevice::get_optimal_dram_bank_to_logical_worker_assignment(
+std::unordered_map<uint32_t, CoreCoord> MeshDevice::get_optimal_dram_bank_to_logical_worker_assignment(
     NOC noc, const MeshCoordinate& coord) {
     return pimpl_->get_optimal_dram_bank_to_logical_worker_assignment(noc, coord);
 }

--- a/tt_metal/distributed/mesh_device_impl.hpp
+++ b/tt_metal/distributed/mesh_device_impl.hpp
@@ -245,7 +245,8 @@ public:
     std::vector<CoreCoord> ethernet_cores_from_logical_cores(
         const std::vector<CoreCoord>& logical_cores) const override;
     std::vector<CoreCoord> get_optimal_dram_bank_to_logical_worker_assignment(NOC noc) override;
-    std::vector<CoreCoord> get_optimal_dram_bank_to_logical_worker_assignment(NOC noc, const MeshCoordinate& coord);
+    std::map<uint32_t, CoreCoord> get_optimal_dram_bank_to_logical_worker_assignment(
+        NOC noc, const MeshCoordinate& coord);
     CoreCoord virtual_core_from_logical_core(const CoreCoord& logical_coord, const CoreType& core_type) const override;
     CoreCoord worker_core_from_logical_core(const CoreCoord& logical_core) const override;
     CoreCoord ethernet_core_from_logical_core(const CoreCoord& logical_core) const override;

--- a/tt_metal/distributed/mesh_device_impl.hpp
+++ b/tt_metal/distributed/mesh_device_impl.hpp
@@ -245,7 +245,7 @@ public:
     std::vector<CoreCoord> ethernet_cores_from_logical_cores(
         const std::vector<CoreCoord>& logical_cores) const override;
     std::vector<CoreCoord> get_optimal_dram_bank_to_logical_worker_assignment(NOC noc) override;
-    std::map<uint32_t, CoreCoord> get_optimal_dram_bank_to_logical_worker_assignment(
+    std::unordered_map<uint32_t, CoreCoord> get_optimal_dram_bank_to_logical_worker_assignment(
         NOC noc, const MeshCoordinate& coord);
     CoreCoord virtual_core_from_logical_core(const CoreCoord& logical_coord, const CoreType& core_type) const override;
     CoreCoord worker_core_from_logical_core(const CoreCoord& logical_core) const override;

--- a/tt_metal/distributed/mesh_device_impl.hpp
+++ b/tt_metal/distributed/mesh_device_impl.hpp
@@ -245,6 +245,7 @@ public:
     std::vector<CoreCoord> ethernet_cores_from_logical_cores(
         const std::vector<CoreCoord>& logical_cores) const override;
     std::vector<CoreCoord> get_optimal_dram_bank_to_logical_worker_assignment(NOC noc) override;
+    std::vector<CoreCoord> get_optimal_dram_bank_to_logical_worker_assignment(NOC noc, const MeshCoordinate& coord);
     CoreCoord virtual_core_from_logical_core(const CoreCoord& logical_coord, const CoreType& core_type) const override;
     CoreCoord worker_core_from_logical_core(const CoreCoord& logical_core) const override;
     CoreCoord ethernet_core_from_logical_core(const CoreCoord& logical_core) const override;

--- a/ttnn/core/distributed/distributed_nanobind.cpp
+++ b/ttnn/core/distributed/distributed_nanobind.cpp
@@ -516,17 +516,59 @@ void py_module(nb::module_& mod) {
                     >>> logical_core = ttnn.CoreCoord(0, 0)
                     >>> worker_core = device.worker_core_from_logical_core(logical_core)
                     >>> print(f"Worker core: x={worker_core.x}, y={worker_core.y}")
-            )doc")
-        .def(
-            "get_optimal_dram_bank_to_logical_worker_assignment",
-            &MeshDevice::get_optimal_dram_bank_to_logical_worker_assignment,
-            nb::arg("noc"),
-            R"doc(
-                Returns the optimal DRAM bank to logical worker assignment based on the NOC.
+            )doc");
 
-                This function returns a list of logical worker coordinates that are optimally
-                mapped to DRAM banks for the specified NOC. The mapping is optimized for
-                minimizing NOC hops when reading/writing to DRAM.
+    // Per-device optimal DRAM-bank-to-logical-worker assignment. Bound as an overload of the same
+    // Python name; dispatched by argument count (coord present -> this overload).
+    nb_mesh_device.def(
+        "get_optimal_dram_bank_to_logical_worker_assignment",
+        [](MeshDevice& self, NOC noc, const MeshCoordinate& coord) {
+            return self.get_optimal_dram_bank_to_logical_worker_assignment(noc, coord);
+        },
+        nb::arg("noc"),
+        nb::arg("coord"),
+        R"doc(
+                Returns the optimal DRAM bank to logical worker assignment for the device at ``coord``.
+
+                The assignment is a device-local physical property (it depends on that device's
+                harvesting and DRAM configuration), so it may differ per device on a heterogeneous
+                mesh. If ``coord`` maps to a remote device, this falls back to an arbitrary local
+                device's assignment (best-effort, exact only on homogeneous meshes); it raises only
+                when the mesh has no local device to fall back to.
+
+                Args:
+                    noc (NOC): The NOC to use for optimal assignment (ttnn.NOC.NOC_0 or ttnn.NOC.NOC_1).
+                    coord (MeshCoordinate): The mesh coordinate of the device to query.
+
+                Returns:
+                    List[CoreCoord]: List of logical worker coordinates optimally mapped to DRAM banks.
+
+                Example:
+                    >>> mesh_device = ttnn.open_mesh_device(...)
+                    >>> coord = ttnn.MeshCoordinate(0, 0)
+                    >>> worker_cores = mesh_device.get_optimal_dram_bank_to_logical_worker_assignment(
+                    ...     ttnn.NOC.NOC_0, coord)
+                    >>> for i, core in enumerate(worker_cores):
+                    ...     print(f"DRAM bank {i} -> worker core ({core.x}, {core.y})")
+            )doc");
+
+    // Deprecated overload: returns only the mesh's reference (front) device assignment, which is
+    // incorrect on heterogeneously-harvested meshes. Kept for backwards compatibility; prefer the
+    // (noc, coord) overload above. The lambda calls a [[deprecated]] method, so suppress the warning.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    nb_mesh_device.def(
+        "get_optimal_dram_bank_to_logical_worker_assignment",
+        [](MeshDevice& self, NOC noc) { return self.get_optimal_dram_bank_to_logical_worker_assignment(noc); },
+        nb::arg("noc"),
+        R"doc(
+                Deprecated: prefer ``get_optimal_dram_bank_to_logical_worker_assignment(noc, coord)``.
+
+                Returns the optimal DRAM bank to logical worker assignment for the mesh's reference
+                (front) device only. On a mesh with heterogeneous harvesting the optimal placement
+                differs per device, so this returns the correct cores only for the reference device.
+
+                The mapping is optimized for minimizing NOC hops when reading/writing to DRAM.
 
                 Args:
                     noc (NOC): The NOC to use for optimal assignment (ttnn.NOC.NOC_0 or ttnn.NOC.NOC_1).
@@ -542,6 +584,7 @@ void py_module(nb::module_& mod) {
                     >>> for i, core in enumerate(worker_cores):
                     ...     print(f"DRAM bank {i} -> worker core ({core.x}, {core.y})")
             )doc");
+#pragma GCC diagnostic pop
     auto py_mesh_device_view = static_cast<nb::class_<MeshDeviceView>>(mod.attr("MeshDeviceView"));
     py_mesh_device_view.def("shape", &MeshDeviceView::shape, nb::rv_policy::reference_internal)
         .def("num_devices", &MeshDeviceView::num_devices)

--- a/ttnn/core/distributed/distributed_nanobind.cpp
+++ b/ttnn/core/distributed/distributed_nanobind.cpp
@@ -14,7 +14,7 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/make_iterator.h>
 #include <nanobind/operators.h>
-#include <nanobind/stl/map.h>
+#include <nanobind/stl/unordered_map.h>
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/unique_ptr.h>
 #include <nanobind/stl/shared_ptr.h>

--- a/ttnn/core/distributed/distributed_nanobind.cpp
+++ b/ttnn/core/distributed/distributed_nanobind.cpp
@@ -14,6 +14,7 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/make_iterator.h>
 #include <nanobind/operators.h>
+#include <nanobind/stl/map.h>
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/unique_ptr.h>
 #include <nanobind/stl/shared_ptr.h>
@@ -541,15 +542,16 @@ void py_module(nb::module_& mod) {
                     coord (MeshCoordinate): The mesh coordinate of the device to query.
 
                 Returns:
-                    List[CoreCoord]: List of logical worker coordinates optimally mapped to DRAM banks.
+                    Dict[int, CoreCoord]: Map from DRAM bank id to the logical worker coordinate
+                    optimally mapped to that bank.
 
                 Example:
                     >>> mesh_device = ttnn.open_mesh_device(...)
                     >>> coord = ttnn.MeshCoordinate(0, 0)
-                    >>> worker_cores = mesh_device.get_optimal_dram_bank_to_logical_worker_assignment(
+                    >>> assignment = mesh_device.get_optimal_dram_bank_to_logical_worker_assignment(
                     ...     ttnn.NOC.NOC_0, coord)
-                    >>> for i, core in enumerate(worker_cores):
-                    ...     print(f"DRAM bank {i} -> worker core ({core.x}, {core.y})")
+                    >>> for bank_id, core in assignment.items():
+                    ...     print(f"DRAM bank {bank_id} -> worker core ({core.x}, {core.y})")
             )doc");
 
     // Deprecated overload: returns only the mesh's reference (front) device assignment, which is


### PR DESCRIPTION
### PR Category
Feature

### Summary
`MeshDevice::get_optimal_dram_bank_to_logical_worker_assignment(NOC)` only ever
returned the mesh's reference (front) device's assignment. That assignment is a
device-local physical property — it depends on the device's harvesting and DRAM
configuration — so on a heterogeneously-harvested mesh the returned cores are
correct only for the reference device and silently wrong for every other device.

This PR adds an overload that takes a `MeshCoordinate` and returns the optimal
assignment for that specific device, making it possible to get a different value
per device:

- Local coordinate → that device's own assignment.
- Remote coordinate → best-effort fallback to an arbitrary local device's
  assignment (exact only on homogeneous meshes); throws only when the mesh has
  no local device to fall back to.

The original `NOC`-only overload is marked `[[deprecated]]` but kept (it still
satisfies the `IDevice` interface and all existing callers; the repo builds with
`-Wno-deprecated-declarations`, so this is an IDE/documentation-level deprecation
consistent with the existing `get_device`/`is_local` deprecations).

The overload is wired up to ttnn under the same Python method name
`get_optimal_dram_bank_to_logical_worker_assignment`, dispatched by argument
count (`(noc, coord)` → new overload, `(noc)` → deprecated overload).

### Notes for reviewers
- `MeshDeviceViewImpl::get_device()` throws on remote coordinates, so the impl
  checks locality with the non-deprecated `view_->impl().is_local(coord)` before
  resolving the device.
- Tests: `GetOptimalDramBankToLogicalWorkerAssignmentAPI.UnitMeshes` now also
  exercises the `(noc, coord)` overload and asserts it matches a direct
  per-device query (runs on any device count). A new
  `MeshDevice2x4Test.GetOptimalDramBankToLogicalWorkerAssignmentPerDevice`
  iterates all mesh coordinates and asserts the same (self-skips on <8-device
  systems).
- The existing plural binding `get_optimal_dram_bank_to_logical_worker_assignments`
  is untouched.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/mesh-per-device-dram-worker-assignment)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/mesh-per-device-dram-worker-assignment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/mesh-per-device-dram-worker-assignment)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/mesh-per-device-dram-worker-assignment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jbauman/mesh-per-device-dram-worker-assignment)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jbauman/mesh-per-device-dram-worker-assignment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/mesh-per-device-dram-worker-assignment)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/mesh-per-device-dram-worker-assignment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/mesh-per-device-dram-worker-assignment)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/mesh-per-device-dram-worker-assignment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/mesh-per-device-dram-worker-assignment)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/mesh-per-device-dram-worker-assignment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/mesh-per-device-dram-worker-assignment)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/mesh-per-device-dram-worker-assignment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/mesh-per-device-dram-worker-assignment)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/mesh-per-device-dram-worker-assignment)