### PR TITLE
[Feature] Add pimpl utility to tt_stl

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
@@ -19,6 +19,8 @@
 #include <tt-metalium/memory_pin.hpp>
 #include <tt-metalium/distributed_host_buffer.hpp>
 
+#include <tt_stl/pimpl.hpp>
+
 // It is intentional to not reflect the experimental status of this header in its namespace,
 // as most of the code movements are based on implementations in TTNN that are well tested and production ready for a
 // long time, it is expected for the implementation to graduate out of experimental really quickly.
@@ -45,7 +47,7 @@ class HostTensorImpl;
  * Note: A moved-from HostTensor is in a valid but unspecified state. All member functions except destruction and
  * assignment will fail on a moved-from instance.
  */
-class HostTensor {
+class HostTensor : public ttsl::PimplBase<HostTensorImpl> {
 public:
     using volume_type = std::uint64_t;
 
@@ -199,22 +201,9 @@ public:
     // Updates the topology of the HostTensor post construction.
     void update_tensor_topology(TensorTopology tensor_topology);
 
-    /**
-     * Access to the implementation.
-     *
-     * pre-condition: The HostTensor must be initialized.
-     */
-    HostTensorImpl& impl();
-    const HostTensorImpl& impl() const;
-
 private:
     // Internal constructors. Use the from_buffer factories to build a HostTensor from a backing buffer.
     explicit HostTensor(DistributedHostBuffer buffer, TensorSpec spec, TensorTopology topology);
-
-    // impl_ could be a nullptr if HostTensor is in a moved-from state.
-    // Avoid using impl_ pointer directly, use the impl() accessor instead.
-    // Otherwise, please add manual TT_FATAL checks for nullptr.
-    std::unique_ptr<HostTensorImpl> impl_;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
@@ -172,13 +172,6 @@ public:
      */
     void update_tensor_topology(TensorTopology tensor_topology);
 
-    /**
-     * Access to the implementation.
-     *
-     * pre-condition: The MeshTensor must not be in a moved-from (valueless) state.
-     */
-    using PimplBase::impl;
-
 private:
     // Internal constructor for transition. Use the from_buffer factory or allocate_on_device
     // to build a MeshTensor.

--- a/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/experimental/tensor/topology/tensor_topology.hpp>
 
 #include <tt_stl/optional_reference.hpp>
+#include <tt_stl/pimpl.hpp>
 
 // It is intentional to not reflect the experimental status of this header in its namespace,
 // as most of the code movements are based on implementations in TTNN that are well tested and production ready for a
@@ -48,7 +49,7 @@ class MeshBuffer;
  * Note: A moved-from MeshTensor is in a valid but unspecified state. All member functions except destruction and
  * assignment will fail on a moved-from instance.
  */
-class MeshTensor {
+class MeshTensor : public ttsl::PimplBase<MeshTensorImpl> {
 public:
     using volume_type = std::uint64_t;
 
@@ -174,10 +175,9 @@ public:
     /**
      * Access to the implementation.
      *
-     * pre-condition: The MeshTensor must not be in a default constructed state.
+     * pre-condition: The MeshTensor must not be in a moved-from (valueless) state.
      */
-    MeshTensorImpl& impl();
-    const MeshTensorImpl& impl() const;
+    using PimplBase::impl;
 
 private:
     // Internal constructor for transition. Use the from_buffer factory or allocate_on_device

--- a/tt_metal/impl/tensor/host_tensor.cpp
+++ b/tt_metal/impl/tensor/host_tensor.cpp
@@ -8,9 +8,8 @@
 
 namespace tt::tt_metal {
 
-
 HostTensor::HostTensor(DistributedHostBuffer buffer, TensorSpec spec, TensorTopology topology) :
-    impl_(std::make_unique<HostTensorImpl>(std::move(buffer), std::move(spec), std::move(topology))) {}
+    PimplBase(std::in_place, std::move(buffer), std::move(spec), std::move(topology)) {}
 
 HostTensor HostTensor::from_buffer(DistributedHostBuffer buffer, TensorSpec spec, TensorTopology topology) {
     return HostTensor(std::move(buffer), std::move(spec), std::move(topology));
@@ -26,41 +25,21 @@ HostTensor HostTensor::from_buffer(HostBuffer buffer, TensorSpec spec, TensorTop
     return HostTensor(std::move(distributed_buffer), std::move(spec), std::move(topology));
 }
 
-HostTensor::HostTensor(const HostTensor& other) :
-    impl_(other.impl_ ? std::make_unique<HostTensorImpl>(*other.impl_) : nullptr) {}
+HostTensor::HostTensor(const HostTensor& other) = default;
 
-HostTensor& HostTensor::operator=(const HostTensor& other) {
-    if (this == &other) {
-        return *this;
-    }
-    impl_ = other.impl_ ? std::make_unique<HostTensorImpl>(*other.impl_) : nullptr;
-    return *this;
-}
+HostTensor& HostTensor::operator=(const HostTensor& other) = default;
 
-HostTensor::HostTensor(HostTensor&& other) noexcept : impl_(std::move(other.impl_)) {}
+HostTensor::HostTensor(HostTensor&& other) noexcept = default;
 
-HostTensor& HostTensor::operator=(HostTensor&& other) noexcept {
-    impl_ = std::move(other.impl_);
-    return *this;
-}
+HostTensor& HostTensor::operator=(HostTensor&& other) noexcept = default;
 
 HostTensor::~HostTensor() = default;
-
-HostTensorImpl& HostTensor::impl() {
-    TT_FATAL(impl_ != nullptr, "HostTensor is in a moved-from state.");
-    return *impl_;
-}
-
-const HostTensorImpl& HostTensor::impl() const {
-    TT_FATAL(impl_ != nullptr, "HostTensor is in a moved-from state.");
-    return *impl_;
-}
 
 const TensorSpec& HostTensor::tensor_spec() const { return impl().spec(); }
 
 const TensorTopology& HostTensor::tensor_topology() const { return impl().topology(); }
 
-bool HostTensor::is_valueless_after_move() const { return impl_ == nullptr; }
+bool HostTensor::is_valueless_after_move() const { return valueless_after_move(); }
 
 const DistributedHostBuffer& HostTensor::buffer() const { return impl().buffer(); }
 

--- a/tt_metal/impl/tensor/mesh_tensor.cpp
+++ b/tt_metal/impl/tensor/mesh_tensor.cpp
@@ -15,19 +15,9 @@ MeshTensor::MeshTensor(MeshTensor&& other) noexcept = default;
 MeshTensor& MeshTensor::operator=(MeshTensor&& other) noexcept = default;
 
 MeshTensor::MeshTensor(std::shared_ptr<distributed::MeshBuffer> mesh_buffer, TensorSpec spec, TensorTopology topology) :
-    impl_(std::make_unique<MeshTensorImpl>(std::move(mesh_buffer), std::move(spec), std::move(topology))) {}
+    PimplBase(std::in_place, std::move(mesh_buffer), std::move(spec), std::move(topology)) {}
 
 MeshTensor::~MeshTensor() = default;
-
-MeshTensorImpl& MeshTensor::impl() {
-    TT_FATAL(impl_ != nullptr, "MeshTensor is in a moved-from state.");
-    return *impl_;
-}
-
-const MeshTensorImpl& MeshTensor::impl() const {
-    TT_FATAL(impl_ != nullptr, "MeshTensor is in a moved-from state.");
-    return *impl_;
-}
 
 const distributed::MeshBuffer& MeshTensor::mesh_buffer() const { return impl().mesh_buffer(); }
 
@@ -39,7 +29,7 @@ const TensorSpec& MeshTensor::tensor_spec() const { return impl().spec(); }
 
 const TensorTopology& MeshTensor::tensor_topology() const { return impl().topology(); }
 
-bool MeshTensor::is_valueless_after_move() const { return impl_ == nullptr; }
+bool MeshTensor::is_valueless_after_move() const { return valueless_after_move(); }
 
 DeviceAddr MeshTensor::address() const { return mesh_buffer().address(); }
 

--- a/tt_stl/CMakeLists.txt
+++ b/tt_stl/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(
             tt_stl/indestructible.hpp
             tt_stl/optional_reference.hpp
             tt_stl/overloaded.hpp
+            tt_stl/pimpl.hpp
             tt_stl/reflection.hpp
             tt_stl/small_vector.hpp
             tt_stl/llvm/llvm_small_vector.hpp

--- a/tt_stl/tests/CMakeLists.txt
+++ b/tt_stl/tests/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Split-TU fixture used by test_pimpl.cpp to test against an incomplete type.
+add_subdirectory(test_indirect_util)
+
 # Smoke tests (fast, not necessarily thorough)
 add_library(unit_tests_stl_smoke OBJECT)
 add_library(TT::Metalium::Test::STL::Smoke ALIAS unit_tests_stl_smoke)
@@ -10,7 +13,9 @@ target_sources(
         test_fmt.cpp
         test_hash.cpp
         test_indestructible.cpp
+        test_indirect.cpp
         test_optional_reference.cpp
+        test_pimpl.cpp
         test_reflection.cpp
         test_span.cpp
         test_strong_type.cpp
@@ -25,6 +30,7 @@ target_link_libraries(
         gtest
         gtest_main
         TT::STL
+        test_indirect_util
 )
 
 add_executable(unit_tests_stl)

--- a/tt_stl/tests/test_indirect.cpp
+++ b/tt_stl/tests/test_indirect.cpp
@@ -1,0 +1,265 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <tt_stl/pimpl.hpp>
+
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace ttsl {
+namespace {
+
+// Helper class for testing.
+struct TestValue {
+    int value{};
+
+    TestValue() = default;
+    explicit TestValue(int v) : value(v) {}
+};
+
+TEST(IndirectTest, InPlaceConstruction) {
+    indirect<std::string> s(std::in_place, "hello");
+    EXPECT_FALSE(s.valueless_after_move());
+    EXPECT_EQ(*s, "hello");
+}
+
+TEST(IndirectTest, InPlaceConstructionMultipleArgs) {
+    indirect<std::string> s(std::in_place, 5, 'x');
+    EXPECT_FALSE(s.valueless_after_move());
+    EXPECT_EQ(*s, "xxxxx");
+}
+
+TEST(IndirectTest, CopyConstruction) {
+    indirect<TestValue> i1(std::in_place, 42);
+    indirect<TestValue> i2(i1);
+
+    EXPECT_FALSE(i1.valueless_after_move());
+    EXPECT_FALSE(i2.valueless_after_move());
+    EXPECT_EQ(i1->value, 42);
+    EXPECT_EQ(i2->value, 42);
+
+    // Value semantics: modifying one doesn't affect the other.
+    i1->value = 100;
+    EXPECT_EQ(i1->value, 100);
+    EXPECT_EQ(i2->value, 42);
+}
+
+TEST(IndirectTest, CopyConstructionFromValueless) {
+    indirect<int> i1(std::in_place, 42);
+    indirect<int> i2(std::move(i1));
+
+    // NOLINTNEXTLINE(bugprone-use-after-move)
+    EXPECT_TRUE(i1.valueless_after_move());
+
+    // Copying a valueless indirect produces another valueless indirect.
+    indirect<int> i3(i1);
+    EXPECT_TRUE(i3.valueless_after_move());
+}
+
+TEST(IndirectTest, MoveConstruction) {
+    indirect<TestValue> i1(std::in_place, 42);
+    indirect<TestValue> i2(std::move(i1));
+
+    // NOLINTNEXTLINE(bugprone-use-after-move)
+    EXPECT_TRUE(i1.valueless_after_move());
+    EXPECT_FALSE(i2.valueless_after_move());
+    EXPECT_EQ(i2->value, 42);
+}
+
+TEST(IndirectTest, CopyAssignment) {
+    indirect<TestValue> i1(std::in_place, 42);
+    indirect<TestValue> i2(std::in_place, 100);
+
+    i2 = i1;
+
+    EXPECT_FALSE(i1.valueless_after_move());
+    EXPECT_FALSE(i2.valueless_after_move());
+    EXPECT_EQ(i1->value, 42);
+    EXPECT_EQ(i2->value, 42);
+}
+
+TEST(IndirectTest, CopyAssignmentFromValueless) {
+    indirect<int> i1(std::in_place, 42);
+    indirect<int> i2(std::move(i1));
+
+    // NOLINTNEXTLINE(bugprone-use-after-move)
+    EXPECT_TRUE(i1.valueless_after_move());
+
+    indirect<int> i3(std::in_place, 100);
+    i3 = i1;
+
+    EXPECT_TRUE(i3.valueless_after_move());
+}
+
+TEST(IndirectTest, CopyAssignmentToValueless) {
+    indirect<int> i1(std::in_place, 42);
+    indirect<int> i2(std::move(i1));
+
+    // NOLINTNEXTLINE(bugprone-use-after-move)
+    EXPECT_TRUE(i1.valueless_after_move());
+
+    indirect<int> i3(std::in_place, 100);
+    i1 = i3;
+
+    EXPECT_FALSE(i1.valueless_after_move());
+    EXPECT_EQ(*i1, 100);
+}
+
+TEST(IndirectTest, CopyAssignmentStrongExceptionGuarantee) {
+    // Copy-constructing from an instance with throw_on_copy set simulates a T whose copy
+    // constructor can fail (e.g. due to an allocation failure inside T itself).
+    struct ThrowingCopy {
+        int value{};
+        bool throw_on_copy{};
+
+        ThrowingCopy(int v, bool throw_on_copy_) : value(v), throw_on_copy(throw_on_copy_) {}
+        ThrowingCopy(const ThrowingCopy& other) : value(other.value), throw_on_copy(other.throw_on_copy) {
+            if (other.throw_on_copy) {
+                throw std::runtime_error("ThrowingCopy: simulated copy failure");
+            }
+        }
+    };
+
+    indirect<ThrowingCopy> i1(std::in_place, 1, /*throw_on_copy=*/true);
+    indirect<ThrowingCopy> i2(std::in_place, 2, /*throw_on_copy=*/false);
+
+    EXPECT_THROW(i2 = i1, std::runtime_error);
+
+    // Strong guarantee: a failed copy-assignment leaves the target untouched (the new T is
+    // allocated before p is replaced).
+    EXPECT_FALSE(i2.valueless_after_move());
+    EXPECT_EQ(i2->value, 2);
+}
+
+TEST(IndirectTest, SelfCopyAssignment) {
+    indirect<int> i(std::in_place, 42);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wself-assign-overloaded"
+    i = i;
+#pragma clang diagnostic pop
+    EXPECT_FALSE(i.valueless_after_move());
+    EXPECT_EQ(*i, 42);
+}
+
+TEST(IndirectTest, MoveAssignment) {
+    indirect<TestValue> i1(std::in_place, 42);
+    indirect<TestValue> i2(std::in_place, 100);
+
+    i2 = std::move(i1);
+
+    // NOLINTNEXTLINE(bugprone-use-after-move)
+    EXPECT_TRUE(i1.valueless_after_move());
+    EXPECT_FALSE(i2.valueless_after_move());
+    EXPECT_EQ(i2->value, 42);
+}
+
+TEST(IndirectTest, MoveAssignmentFromValueless) {
+    indirect<int> i1(std::in_place, 42);
+    indirect<int> i2(std::move(i1));  // i1 is now valueless.
+
+    indirect<int> i3(std::in_place, 100);
+    // NOLINTNEXTLINE(bugprone-use-after-move)
+    i3 = std::move(i1);
+
+    EXPECT_TRUE(i3.valueless_after_move());
+    // NOLINTNEXTLINE(bugprone-use-after-move)
+    EXPECT_TRUE(i1.valueless_after_move());
+}
+
+TEST(IndirectTest, MoveAssignmentToValueless) {
+    indirect<int> i1(std::in_place, 42);
+    indirect<int> i2(std::move(i1));  // i1 is now valueless.
+
+    indirect<int> i3(std::in_place, 100);
+    i1 = std::move(i3);
+
+    EXPECT_FALSE(i1.valueless_after_move());
+    EXPECT_EQ(*i1, 100);
+    // NOLINTNEXTLINE(bugprone-use-after-move)
+    EXPECT_TRUE(i3.valueless_after_move());
+}
+
+TEST(IndirectTest, SelfMoveAssignment) {
+    indirect<int> i(std::in_place, 42);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wself-move"
+    i = std::move(i);
+#pragma clang diagnostic pop
+    EXPECT_FALSE(i.valueless_after_move());
+    EXPECT_EQ(*i, 42);
+}
+
+TEST(IndirectTest, DereferenceOperators) {
+    indirect<int> i(std::in_place, 42);
+
+    // Non-const lvalue reference.
+    EXPECT_EQ(*i, 42);
+    *i = 100;
+    EXPECT_EQ(*i, 100);
+
+    // Const lvalue reference.
+    const indirect<int>& ci = i;
+    EXPECT_EQ(*ci, 100);
+}
+
+TEST(IndirectTest, ArrowOperator) {
+    struct Point {
+        int x, y;
+        int sum() const { return x + y; }
+    };
+
+    indirect<Point> p(std::in_place, Point{3, 4});
+    EXPECT_EQ(p->x, 3);
+    EXPECT_EQ(p->y, 4);
+    EXPECT_EQ(p->sum(), 7);
+
+    p->x = 10;
+    EXPECT_EQ(p->x, 10);
+}
+
+// Templated on the indirect (or reference-to-indirect) type so the requires-clause below is
+// checked via genuine template substitution -- a plain `requires { cm->modify(); }` outside of a
+// template is not a SFINAE-friendly context and would hard-error instead of evaluating to false.
+template <typename Ind>
+concept CanCallModifyThroughArrow = requires(Ind& i) { i->modify(); };
+
+TEST(IndirectTest, ConstPropagation) {
+    struct Mutable {
+        int value;
+        void modify() { value = 100; }
+        int get() const { return value; }
+    };
+
+    indirect<Mutable> m(std::in_place, Mutable{42});
+    EXPECT_EQ(m->get(), 42);
+
+    m->modify();
+    EXPECT_EQ(m->get(), 100);
+
+    const indirect<Mutable>& cm = m;
+    EXPECT_EQ(cm->get(), 100);
+
+    // Const propagation: operator-> on a const indirect returns a const Mutable*, so calling a
+    // non-const member function through it should not compile.
+    static_assert(CanCallModifyThroughArrow<indirect<Mutable>>);
+    static_assert(!CanCallModifyThroughArrow<const indirect<Mutable>>);
+}
+
+TEST(IndirectTest, CheckedDerefOnValuelessFatals) {
+    indirect<int> i1(std::in_place, 42);
+    indirect<int> i2(std::move(i1));
+
+    // NOLINTNEXTLINE(bugprone-use-after-move)
+    EXPECT_TRUE(i1.valueless_after_move());
+    // Unlike std::indirect (UB on valueless), our checked observers TT_FATAL instead.
+    // NOLINTNEXTLINE(bugprone-use-after-move)
+    EXPECT_ANY_THROW((void)*i1);
+    // NOLINTNEXTLINE(bugprone-use-after-move)
+    EXPECT_ANY_THROW((void)i1.operator->());
+}
+
+}  // namespace
+}  // namespace ttsl

--- a/tt_stl/tests/test_indirect_util/CMakeLists.txt
+++ b/tt_stl/tests/test_indirect_util/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Split-TU fixture for testing ttsl::indirect / ttsl::PimplBase against an incomplete type.
+# Built as its own library (not folded into the smoke OBJECT library) so a unity/jumbo build
+# cannot merge widget.cpp into the same TU as the tests and silently defeat the incomplete-type
+# coverage.
+add_library(test_indirect_util STATIC widget.cpp)
+target_link_libraries(test_indirect_util PRIVATE TT::STL)

--- a/tt_stl/tests/test_indirect_util/widget.cpp
+++ b/tt_stl/tests/test_indirect_util/widget.cpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "widget.hpp"
+
+namespace ttsl {
+
+// Full WidgetImpl definition -- only visible in this translation unit.
+class WidgetImpl {
+public:
+    int value;
+
+    explicit WidgetImpl(int v) : value(v) {}
+};
+
+Widget::Widget(int value) : PimplBase(std::in_place, value) {}
+Widget::~Widget() = default;
+Widget::Widget(const Widget&) = default;
+Widget& Widget::operator=(const Widget&) = default;
+Widget::Widget(Widget&&) noexcept = default;
+Widget& Widget::operator=(Widget&&) noexcept = default;
+
+int Widget::value() const { return impl().value; }
+void Widget::set_value(int value) { impl().value = value; }
+
+MoveOnlyWidget::MoveOnlyWidget(int value) : PimplBase(std::in_place, value) {}
+MoveOnlyWidget::~MoveOnlyWidget() = default;
+MoveOnlyWidget::MoveOnlyWidget(MoveOnlyWidget&&) noexcept = default;
+MoveOnlyWidget& MoveOnlyWidget::operator=(MoveOnlyWidget&&) noexcept = default;
+
+int MoveOnlyWidget::value() const { return impl().value; }
+
+}  // namespace ttsl

--- a/tt_stl/tests/test_indirect_util/widget.hpp
+++ b/tt_stl/tests/test_indirect_util/widget.hpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt_stl/pimpl.hpp>
+
+namespace ttsl {
+
+// WidgetImpl is only forward-declared here; its full definition lives in widget.cpp.
+class WidgetImpl;
+
+// Widget follows the pimpl idiom: it derives from PimplBase<WidgetImpl> and forward-declares its
+// copy/move special members here; they are defined (= default) out-of-line in widget.cpp, where
+// WidgetImpl is complete. WidgetImpl remains an INCOMPLETE TYPE in this header -- and therefore in
+// any consumer TU that only includes this header, such as test_pimpl.cpp -- which is exactly the
+// header/.cpp (and, in a real build, linker) boundary the pimpl idiom exists to support.
+// widget.hpp + test_pimpl.cpp form one such TU; widget.hpp + widget.cpp form the other, where
+// WidgetImpl is complete (see test_indirect_util/CMakeLists.txt for how the two are compiled and
+// linked separately).
+class Widget : public PimplBase<WidgetImpl> {
+public:
+    explicit Widget(int value);
+
+    ~Widget();
+    Widget(const Widget&);
+    Widget& operator=(const Widget&);
+    Widget(Widget&&) noexcept;
+    Widget& operator=(Widget&&) noexcept;
+
+    int value() const;
+    void set_value(int value);
+};
+
+// Move-only sibling of Widget: mirrors the common case (e.g. MeshTensor), where copy is deleted
+// and WidgetImpl's copy constructor is never instantiated.
+class MoveOnlyWidget : public PimplBase<WidgetImpl> {
+public:
+    explicit MoveOnlyWidget(int value);
+
+    ~MoveOnlyWidget();
+    MoveOnlyWidget(const MoveOnlyWidget&) = delete;
+    MoveOnlyWidget& operator=(const MoveOnlyWidget&) = delete;
+    MoveOnlyWidget(MoveOnlyWidget&&) noexcept;
+    MoveOnlyWidget& operator=(MoveOnlyWidget&&) noexcept;
+
+    int value() const;
+};
+
+}  // namespace ttsl

--- a/tt_stl/tests/test_pimpl.cpp
+++ b/tt_stl/tests/test_pimpl.cpp
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <tt_stl/pimpl.hpp>
+
+#include <type_traits>
+#include <utility>
+
+#include "test_indirect_util/widget.hpp"
+
+namespace ttsl {
+namespace {
+
+// Widget/MoveOnlyWidget derive from PimplBase<WidgetImpl>, where WidgetImpl is only
+// forward-declared in widget.hpp and defined in widget.cpp -- proving PimplBase (not just
+// indirect) preserves the incomplete-type/linker firewall.
+
+TEST(PimplBaseTest, DeepCopy) {
+    Widget w1(42);
+    Widget w2(w1);
+
+    EXPECT_EQ(w1.value(), 42);
+    EXPECT_EQ(w2.value(), 42);
+
+    // Value semantics: modifying one doesn't affect the other.
+    w1.set_value(100);
+    EXPECT_EQ(w1.value(), 100);
+    EXPECT_EQ(w2.value(), 42);
+}
+
+TEST(PimplBaseTest, CopyAssignmentDeepCopies) {
+    Widget w1(42);
+    Widget w2(100);
+
+    w2 = w1;
+    EXPECT_EQ(w2.value(), 42);
+
+    w1.set_value(200);
+    EXPECT_EQ(w1.value(), 200);
+    EXPECT_EQ(w2.value(), 42);
+}
+
+TEST(PimplBaseTest, MoveLeavesSourceValueless) {
+    Widget w1(42);
+    Widget w2(std::move(w1));
+
+    // NOLINTNEXTLINE(bugprone-use-after-move)
+    EXPECT_TRUE(w1.valueless_after_move());
+    EXPECT_FALSE(w2.valueless_after_move());
+    EXPECT_EQ(w2.value(), 42);
+}
+
+TEST(PimplBaseTest, MoveAssignmentLeavesSourceValueless) {
+    Widget w1(42);
+    Widget w2(100);
+
+    w2 = std::move(w1);
+
+    // NOLINTNEXTLINE(bugprone-use-after-move)
+    EXPECT_TRUE(w1.valueless_after_move());
+    EXPECT_EQ(w2.value(), 42);
+}
+
+TEST(PimplBaseTest, CheckedImplAccessOnValuelessFatals) {
+    Widget w1(42);
+    Widget w2(std::move(w1));
+
+    // NOLINTNEXTLINE(bugprone-use-after-move)
+    EXPECT_ANY_THROW(w1.value());
+}
+
+TEST(PimplBaseTest, MoveOnlyWidgetCompilesAndMoves) {
+    static_assert(!std::is_copy_constructible_v<MoveOnlyWidget>);
+    static_assert(std::is_move_constructible_v<MoveOnlyWidget>);
+
+    MoveOnlyWidget w1(7);
+    MoveOnlyWidget w2(std::move(w1));
+
+    // NOLINTNEXTLINE(bugprone-use-after-move)
+    EXPECT_TRUE(w1.valueless_after_move());
+    EXPECT_EQ(w2.value(), 7);
+}
+
+}  // namespace
+}  // namespace ttsl

--- a/tt_stl/tt_stl/pimpl.hpp
+++ b/tt_stl/tt_stl/pimpl.hpp
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+#include <tt_stl/assert.hpp>
+
+/**
+ * @file pimpl.hpp
+ * @brief ttsl::indirect<T> (a checked, no-allocator subset of C++26 std::indirect) and
+ * ttsl::PimplBase<Impl> (a base class that uses it to implement the pimpl idiom).
+ *
+ * `indirect<T>` originates from a no-allocator implementation of C++26's std::indirect authored for this
+ * codebase; the subset kept here is what the pimpl idiom needs. Unlike std::indirect (UB on valueless
+ * access), `indirect<T>`'s observers are CHECKED: they TT_FATAL instead of dereferencing a null pointer.
+ * Because of that behavioral difference, this is intentionally NOT a drop-in alias for std::indirect --
+ * a future C++26 migration should keep this wrapper rather than `using indirect = std::indirect<T>;`.
+ *
+ * For background on std::indirect, see:
+ * - https://en.cppreference.com/w/cpp/memory/indirect
+ * - https://eel.is/c++draft/indirect
+ */
+
+namespace ttsl {
+
+// No-allocator, trimmed subset of C++26 std::indirect, sufficient for the pimpl idiom.
+// Value semantics: copy deep-copies the owned T; move leaves the source valueless.
+// Access is CHECKED: operator*/operator-> TT_FATAL if valueless, so we never dereference a
+// null unique_ptr. This deliberately deviates from std::indirect (which is UB on valueless).
+// T may be INCOMPLETE where indirect<T> is declared; it must be complete only where the
+// copy/move/destroy members are instantiated (the enclosing class's .cpp).
+template <typename T>
+class indirect {
+public:
+    using value_type = T;
+
+    // In-place construction (the pimpl entry point): owns make_unique<T>(forward(us)...). The
+    // leading std::in_place_t tag disambiguates this constructor from the copy/move constructors
+    // below (and from any other single/zero-argument constructor T might have), preventing it from
+    // accidentally participating in overload resolution as a generic converting constructor.
+    template <class... Us>
+        requires(std::is_constructible_v<T, Us...>)
+    explicit indirect(std::in_place_t, Us&&... us) :  // NOLINT(readability-named-parameter)
+        p(std::make_unique<T>(std::forward<Us>(us)...)) {}
+
+    // Deep copy: allocates a new T from *other (nullptr-safe -- a valueless other yields a valueless copy).
+    // Only requires T to be copy-constructible.
+    indirect(const indirect& other) {
+        if (other.p) {
+            p = std::make_unique<T>(*other.p);
+        }
+    }
+
+    // Deep copy assignment: reallocates from *other.p (nullptr-safe). Deliberately reallocates rather than
+    // reusing **this = *other (as the upstream std::indirect implementation does), so this only requires T
+    // to be copy-constructible, not copy-assignable.
+    indirect& operator=(const indirect& other) {
+        if (this == &other) {
+            return *this;
+        }
+        if (other.p) {
+            p = std::make_unique<T>(*other.p);
+        } else {
+            p.reset();
+        }
+        return *this;
+    }
+
+    // Transfers ownership; other becomes valueless. The pointee itself is not moved.
+    indirect(indirect&& other) noexcept : p(std::move(other.p)) {}
+
+    indirect& operator=(indirect&& other) noexcept {
+        if (this == &other) {
+            return *this;
+        }
+        p = std::move(other.p);
+        return *this;
+    }
+
+    ~indirect() = default;
+
+    // Observers (CHECKED: TT_FATAL if valueless). Not noexcept, since TT_FATAL throws.
+    T& operator*() & {
+        TT_FATAL(p != nullptr, "The object is in a moved-from state and does not hold value. Cannot dereference.");
+        return *p;
+    }
+    const T& operator*() const& {
+        TT_FATAL(p != nullptr, "The object is in a moved-from state and does not hold value. Cannot dereference.");
+        return *p;
+    }
+    T* operator->() {
+        TT_FATAL(p != nullptr, "The object is in a moved-from state and does not hold value. Cannot dereference.");
+        return p.get();
+    }
+    const T* operator->() const {
+        TT_FATAL(p != nullptr, "The object is in a moved-from state and does not hold value. Cannot dereference.");
+        return p.get();
+    }
+
+    // The only observer safe to call in the valueless state.
+    bool valueless_after_move() const noexcept { return p == nullptr; }
+
+private:
+    std::unique_ptr<T> p;
+};
+
+// Base class for the pimpl idiom. Holds a value-semantic ttsl::indirect<Impl> and exposes it to
+// the derived class via protected impl(). Impl may be INCOMPLETE in the header
+// (see the contract below); it only needs to be complete in the .cpp that defines the derived
+// class's special members.
+//
+// Contract for the DERIVED class: declare all used special members in the header and define them
+// (= default) out-of-line in the .cpp; never = default or implicitly generate them in the header.
+// Violating this instantiates Impl-completeness-requiring code (indirect<Impl>'s special members)
+// in consumer translation units, where Impl is only forward-declared -- this fails to compile
+// rather than silently leaking, but avoid it by following the contract.
+template <typename Impl>
+class PimplBase {
+public:
+    // The only part of the pimpl machinery that is intentionally part of the derived class's PUBLIC
+    // API: derived types inherit this name directly (the shared convention), so e.g. a new pimpl
+    // class exposes valueless_after_move() with no wrapper and no redundant alias.
+    bool valueless_after_move() const noexcept { return impl_.valueless_after_move(); }
+
+protected:
+    // The rest is derived-class-only machinery (protected), so it does not leak into the public API.
+    // Derived special members can still reach these (protected base ctor/SMFs are accessible to the
+    // derived class); the base ctor is usable from the derived initializer list.
+
+    // Forwarding constructor: build the Impl in place (forwards to indirect's in_place ctor).
+    template <typename... Args>
+    explicit PimplBase(std::in_place_t, Args&&... args) :  // NOLINT(readability-named-parameter)
+        impl_(std::in_place, std::forward<Args>(args)...) {}
+
+    // Value semantics come from the indirect member, so these are defaulted (still instantiated
+    // lazily, in the derived class's .cpp).
+    PimplBase(const PimplBase&) = default;
+    PimplBase& operator=(const PimplBase&) = default;
+    PimplBase(PimplBase&&) noexcept = default;
+    PimplBase& operator=(PimplBase&&) noexcept = default;
+    ~PimplBase() = default;  // non-virtual: not a polymorphic base (protected prevents delete-through-base)
+
+    // Reference access; indirect::operator* already TT_FATALs on the valueless state. Check
+    // valueless_after_move() first if a non-fataling presence check is needed.
+    Impl& impl() { return *impl_; }
+    const Impl& impl() const { return *impl_; }
+
+private:
+    ttsl::indirect<Impl> impl_;
+};
+
+}  // namespace ttsl

--- a/tt_stl/tt_stl/pimpl.hpp
+++ b/tt_stl/tt_stl/pimpl.hpp
@@ -12,53 +12,89 @@
 
 /**
  * @file pimpl.hpp
- * @brief ttsl::indirect<T> (a checked, no-allocator subset of C++26 std::indirect) and
- * ttsl::PimplBase<Impl> (a base class that uses it to implement the pimpl idiom).
+ * @brief This header provides two helper utilities specifically for pimpling:
+ *   1. ttsl::PimplBase<Impl> -- a base class that implements the pimpl idiom with minimal boilerplate.
+ *   2. ttsl::indirect<T> -- a value-semantic wrapper (a checked, no-allocator subset of C++26 std::indirect)
+ *      that gives pimpl'd classes consistent move, null-Impl, and copy behavior.
  *
- * `indirect<T>` originates from a no-allocator implementation of C++26's std::indirect authored for this
- * codebase; the subset kept here is what the pimpl idiom needs. Unlike std::indirect (UB on valueless
- * access), `indirect<T>`'s observers are CHECKED: they TT_FATAL instead of dereferencing a null pointer.
- * Because of that behavioral difference, this is intentionally NOT a drop-in alias for std::indirect --
- * a future C++26 migration should keep this wrapper rather than `using indirect = std::indirect<T>;`.
+ * Pimpl ("pointer to implementation") lets a class type-erase its internal implementation object by
+ * introducing a level of indirection, so a library maintainer can change the class layout of the
+ * implementation without updating the public declaration. This is an often-used pattern in this codebase,
+ * commonly implemented with a bare `std::unique_ptr<Impl>` member. The two utilities above alleviate the
+ * common pain points of that hand-rolled `unique_ptr` approach, each of which centers on the `Impl` pointer
+ * going null:
  *
- * For background on std::indirect, see:
- * - https://en.cppreference.com/w/cpp/memory/indirect
- * - https://eel.is/c++draft/indirect
+ *   1. CONSISTENT MOVE BEHAVIOR. A pimpl'd class's move should always use pointer move semantics -- transfer
+ *      the `Impl` pointer and leave the source null -- because the move ctor/assignment should always be
+ *      `noexcept`, and only moving the pointer (never touching `Impl` itself) can guarantee that. These
+ *      utilities enforce that convention (and handle self-move / ctor-assignment consistency) once.
+ *
+ *   2. CONSISTENT NULL-IMPL HANDLING. Because the `Impl` pointer is nullable (a moved-from source is null),
+ *      accessing the `Impl` needs to be guarded with special care. These utilities centrally guard that
+ *      null behavior to TT_FATAL instead of being UB: the common case accesses the `Impl` by reference
+ *      through a null-checked `impl()`, and a consistent `valueless_after_move()` observer lets callers
+ *      check for valuelessness up front.
+ *
+ *   3. VALUE-SEMANTIC COPY. A copyable pimpl'd class usually wants copy to deep-copy the `Impl` (bubbling up
+ *      `Impl`'s own copy semantics), not the pointer semantics of `unique_ptr` (which is non-copyable). With
+ *      these utilities, a derived class that declares its copy ctor/assignment and `= default`s them gets
+ *      that deep copy for free -- no hand-written copy logic.
+ *
+ * See the individual class documentation below for more details.
  */
 
 namespace ttsl {
 
-// No-allocator, trimmed subset of C++26 std::indirect, sufficient for the pimpl idiom.
-// Value semantics: copy deep-copies the owned T; move leaves the source valueless.
-// Access is CHECKED: operator*/operator-> TT_FATAL if valueless, so we never dereference a
-// null unique_ptr. This deliberately deviates from std::indirect (which is UB on valueless).
-// T may be INCOMPLETE where indirect<T> is declared; it must be complete only where the
-// copy/move/destroy members are instantiated (the enclosing class's .cpp).
+/*
+ * `indirect<T>` is a wrapper holding a uniquely-owned, dynamically-allocated T with value-like semantics:
+ *   1. Constructing an indirect<T> allocates and owns a T, so a live indirect is never null -- it only
+ *      becomes valueless (null) after being moved from.
+ *   2. Copying an indirect<T> propagates as a deep copy -- the copy owns a fresh T copy-constructed from the
+ *      source's T (as if `indirect{std::in_place, *old}`); only requires T to be copy-constructible.
+ *   3. Moving an indirect<T> transfers ownership of the T (no copy); the source is left valueless (null).
+ *   4. Const propagates to the owned T: a const indirect<T> hands out only const access to T.
+ *
+ * Access is always guarded: operator* / operator-> TT_FATAL if you attempt to dereference a valueless object.
+ * T may be INCOMPLETE where indirect<T> is declared; it must be complete when the
+ * copy/move/destroy members are instantiated.
+ *
+ * This implementation is a trimmed subset of C++26's std::indirect tailored to our codebase:
+ *   - Omitted allocator support.
+ *   - Defined valueless access: observers TT_FATAL on a valueless dereference instead of being UB.
+ * For background on std::indirect, see:
+ * - https://en.cppreference.com/w/cpp/memory/indirect
+ * - https://eel.is/c++draft/indirect
+ */
 template <typename T>
 class indirect {
 public:
     using value_type = T;
 
-    // In-place construction (the pimpl entry point): owns make_unique<T>(forward(us)...). The
-    // leading std::in_place_t tag disambiguates this constructor from the copy/move constructors
-    // below (and from any other single/zero-argument constructor T might have), preventing it from
-    // accidentally participating in overload resolution as a generic converting constructor.
+    /*
+     * In-place construction (the pimpl entry point): owns make_unique<T>(forward(us)...). The
+     * leading std::in_place_t tag disambiguates this constructor from the copy/move constructors
+     * below (and from any other single/zero-argument constructor T might have), preventing it from
+     * accidentally participating in overload resolution as a generic converting constructor.
+     */
     template <class... Us>
         requires(std::is_constructible_v<T, Us...>)
     explicit indirect(std::in_place_t, Us&&... us) :  // NOLINT(readability-named-parameter)
         p(std::make_unique<T>(std::forward<Us>(us)...)) {}
 
-    // Deep copy: allocates a new T from *other (nullptr-safe -- a valueless other yields a valueless copy).
-    // Only requires T to be copy-constructible.
+    /*
+     * Copy constructor: copy-constructs a new indirect<T> by allocating a new T and copying the contents of
+     * `other` (or propagates valuelessness). Requires T to be copy-constructible.
+     */
     indirect(const indirect& other) {
         if (other.p) {
             p = std::make_unique<T>(*other.p);
         }
     }
 
-    // Deep copy assignment: reallocates from *other.p (nullptr-safe). Deliberately reallocates rather than
-    // reusing **this = *other (as the upstream std::indirect implementation does), so this only requires T
-    // to be copy-constructible, not copy-assignable.
+    /*
+     * Copy assignment: replaces the contents by allocating a new T and copying the contents of `other` (or
+     * propagates valuelessness). Requires T to be copy-constructible.
+     */
     indirect& operator=(const indirect& other) {
         if (this == &other) {
             return *this;
@@ -71,9 +107,10 @@ public:
         return *this;
     }
 
-    // Transfers ownership; other becomes valueless. The pointee itself is not moved.
+    /* Move constructor: transfers ownership of the T to *this; other is left valueless. */
     indirect(indirect&& other) noexcept : p(std::move(other.p)) {}
 
+    /* Move assignment: transfers ownership of the T to *this; other is left valueless. */
     indirect& operator=(indirect&& other) noexcept {
         if (this == &other) {
             return *this;
@@ -82,9 +119,10 @@ public:
         return *this;
     }
 
+    /* Destructor: releases ownership of the owned T (destroys it, if any). */
     ~indirect() = default;
 
-    // Observers (CHECKED: TT_FATAL if valueless). Not noexcept, since TT_FATAL throws.
+    /* Observers. */
     T& operator*() & {
         TT_FATAL(p != nullptr, "The object is in a moved-from state and does not hold value. Cannot dereference.");
         return *p;
@@ -102,52 +140,111 @@ public:
         return p.get();
     }
 
-    // The only observer safe to call in the valueless state.
+    /* Returns true if the object is in a valueless state. The only observer safe to call when valueless. */
     bool valueless_after_move() const noexcept { return p == nullptr; }
 
 private:
     std::unique_ptr<T> p;
 };
 
-// Base class for the pimpl idiom. Holds a value-semantic ttsl::indirect<Impl> and exposes it to
-// the derived class via protected impl(). Impl may be INCOMPLETE in the header
-// (see the contract below); it only needs to be complete in the .cpp that defines the derived
-// class's special members.
-//
-// Contract for the DERIVED class: declare all used special members in the header and define them
-// (= default) out-of-line in the .cpp; never = default or implicitly generate them in the header.
-// Violating this instantiates Impl-completeness-requiring code (indirect<Impl>'s special members)
-// in consumer translation units, where Impl is only forward-declared -- this fails to compile
-// rather than silently leaking, but avoid it by following the contract.
+/*
+ * `PimplBase<Impl>` is a base class that implements the pimpl idiom for a derived class. It holds the
+ * implementation object in a value-semantic ttsl::indirect<Impl> and exposes it to the derived class through
+ * the protected impl() accessor, which the derived class's public API forwards to.
+ *
+ * Impl needs to be COMPLETE only in the translation unit that instantiates PimplBase's special members
+ * (indirect<Impl>'s copy/move/destroy). It may stay INCOMPLETE (forward-declared) in the header and in every
+ * consumer that only includes the header -- which is the whole point of the pimpl idiom.
+ *
+ * USAGE (a copyable Widget; for a move-only type, delete the copy members instead):
+ *
+ *   // widget.hpp -- WidgetImpl is only forward-declared, so it stays INCOMPLETE for consumers.
+ *   class WidgetImpl;
+ *   class Widget : public ttsl::PimplBase<WidgetImpl> {
+ *   public:
+ *       explicit Widget(int value);
+ *       // Declared here, defined out-of-line in widget.cpp:
+ *       ~Widget();
+ *       Widget(const Widget&);
+ *       Widget& operator=(const Widget&);
+ *       Widget(Widget&&) noexcept;
+ *       Widget& operator=(Widget&&) noexcept;
+ *       int value() const;
+ *       // impl() is protected; re-expose it as public API if desired (valueless_after_move() is
+ *       // already public):
+ *       using PimplBase::impl;
+ *   };
+ *
+ *   // widget.cpp -- WidgetImpl is COMPLETE here, so the defaulted members can be instantiated.
+ *   class WidgetImpl { public: int value; explicit WidgetImpl(int v) : value(v) {} };
+ *   Widget::Widget(int value) : PimplBase(std::in_place, value) {}  // forwards to WidgetImpl(value)
+ *   Widget::~Widget() = default;
+ *   Widget::Widget(const Widget&) = default;                 // deep-copies WidgetImpl
+ *   Widget& Widget::operator=(const Widget&) = default;
+ *   Widget::Widget(Widget&&) noexcept = default;             // transfers Impl; source left valueless
+ *   Widget& Widget::operator=(Widget&&) noexcept = default;
+ *   int Widget::value() const { return impl().value; }       // impl() TT_FATALs if valueless
+ *
+ */
 template <typename Impl>
 class PimplBase {
 public:
-    // The only part of the pimpl machinery that is intentionally part of the derived class's PUBLIC
-    // API: derived types inherit this name directly (the shared convention), so e.g. a new pimpl
-    // class exposes valueless_after_move() with no wrapper and no redundant alias.
+    /*
+     * Returns true if this class is in a valueless state after a move. A valueless instance may only be
+     * assigned to; all other access will TT_FATAL.
+     */
     bool valueless_after_move() const noexcept { return impl_.valueless_after_move(); }
 
 protected:
-    // The rest is derived-class-only machinery (protected), so it does not leak into the public API.
-    // Derived special members can still reach these (protected base ctor/SMFs are accessible to the
-    // derived class); the base ctor is usable from the derived initializer list.
-
-    // Forwarding constructor: build the Impl in place (forwards to indirect's in_place ctor).
+    /* Forwarding constructor: build the Impl in place (forwards to indirect's in_place ctor). */
     template <typename... Args>
     explicit PimplBase(std::in_place_t, Args&&... args) :  // NOLINT(readability-named-parameter)
         impl_(std::in_place, std::forward<Args>(args)...) {}
 
-    // Value semantics come from the indirect member, so these are defaulted (still instantiated
-    // lazily, in the derived class's .cpp).
+    /*
+     * Copy constructor: propagates the copy behavior of Impl (deep-copies the Impl), or propagates valuelessness if
+     * other is valueless.
+     *
+     * Note: If Impl is on a different linker boundary than the declaration, declare this function in the header
+     * and give it a default implementation (e.g. `Derived::Derived(const Derived&) = default;`) in the .cpp,
+     * where Impl is complete.
+     */
     PimplBase(const PimplBase&) = default;
-    PimplBase& operator=(const PimplBase&) = default;
-    PimplBase(PimplBase&&) noexcept = default;
-    PimplBase& operator=(PimplBase&&) noexcept = default;
-    ~PimplBase() = default;  // non-virtual: not a polymorphic base (protected prevents delete-through-base)
 
-    // Reference access; indirect::operator* already TT_FATALs on the valueless state. Check
-    // valueless_after_move() first if a non-fataling presence check is needed.
+    /*
+     * Copy assignment: propagates the copy behavior of Impl (deep-copies the Impl), or propagates valuelessness if
+     * other is valueless.
+     *
+     * Note: If Impl is on a different linker boundary than the declaration, declare this function in the header
+     * and give it a default implementation (e.g. `Derived& Derived::operator=(const Derived&) = default;`) in
+     * the .cpp, where Impl is complete.
+     */
+    PimplBase& operator=(const PimplBase&) = default;
+
+    /* Move constructor: transfers ownership of the Impl to *this; other is left valueless. */
+    PimplBase(PimplBase&&) noexcept = default;
+
+    /* Move assignment: transfers ownership of the Impl to *this; other is left valueless. */
+    PimplBase& operator=(PimplBase&&) noexcept = default;
+
+    /*
+     * Destructor: destroys the owned Impl (if any).
+     *
+     * Note: If Impl is on a different linker boundary than the declaration, declare this function in the header
+     * and give it a default implementation (e.g. `Derived::~Derived() = default;`) in the .cpp, where Impl is
+     * complete. This is the most common case: even a move-only pimpl'd type needs its destructor defined
+     * out-of-line, since destroying the Impl requires it to be complete.
+     */
+    ~PimplBase() = default;
+
+    /*
+     * Access the internal Impl object by reference. TT_FATALs if the object is in a valueless (moved-from) state.
+     */
     Impl& impl() { return *impl_; }
+
+    /*
+     * Access the internal Impl object by reference. TT_FATALs if the object is in a valueless (moved-from) state.
+     */
     const Impl& impl() const { return *impl_; }
 
 private:

--- a/tt_stl/tt_stl/pimpl.hpp
+++ b/tt_stl/tt_stl/pimpl.hpp
@@ -85,11 +85,7 @@ public:
      * Copy constructor: copy-constructs a new indirect<T> by allocating a new T and copying the contents of
      * `other` (or propagates valuelessness). Requires T to be copy-constructible.
      */
-    indirect(const indirect& other) {
-        if (other.p) {
-            p = std::make_unique<T>(*other.p);
-        }
-    }
+    indirect(const indirect& other) : p(other.p ? std::make_unique<T>(*other.p) : nullptr) {}
 
     /*
      * Copy assignment: replaces the contents by allocating a new T and copying the contents of `other` (or
@@ -150,7 +146,7 @@ private:
 /*
  * `PimplBase<Impl>` is a base class that implements the pimpl idiom for a derived class. It holds the
  * implementation object in a value-semantic ttsl::indirect<Impl> and exposes it to the derived class through
- * the protected impl() accessor, which the derived class's public API forwards to.
+ * the public impl() accessor.
  *
  * Impl needs to be COMPLETE only in the translation unit that instantiates PimplBase's special members
  * (indirect<Impl>'s copy/move/destroy). It may stay INCOMPLETE (forward-declared) in the header and in every
@@ -170,9 +166,6 @@ private:
  *       Widget(Widget&&) noexcept;
  *       Widget& operator=(Widget&&) noexcept;
  *       int value() const;
- *       // impl() is protected; re-expose it as public API if desired (valueless_after_move() is
- *       // already public):
- *       using PimplBase::impl;
  *   };
  *
  *   // widget.cpp -- WidgetImpl is COMPLETE here, so the defaulted members can be instantiated.
@@ -194,6 +187,16 @@ public:
      * assigned to; all other access will TT_FATAL.
      */
     bool valueless_after_move() const noexcept { return impl_.valueless_after_move(); }
+
+    /*
+     * Access the internal Impl object by reference. TT_FATALs if the object is in a valueless (moved-from) state.
+     */
+    Impl& impl() { return *impl_; }
+
+    /*
+     * Access the internal Impl object by reference. TT_FATALs if the object is in a valueless (moved-from) state.
+     */
+    const Impl& impl() const { return *impl_; }
 
 protected:
     /* Forwarding constructor: build the Impl in place (forwards to indirect's in_place ctor). */
@@ -236,16 +239,6 @@ protected:
      * out-of-line, since destroying the Impl requires it to be complete.
      */
     ~PimplBase() = default;
-
-    /*
-     * Access the internal Impl object by reference. TT_FATALs if the object is in a valueless (moved-from) state.
-     */
-    Impl& impl() { return *impl_; }
-
-    /*
-     * Access the internal Impl object by reference. TT_FATALs if the object is in a valueless (moved-from) state.
-     */
-    const Impl& impl() const { return *impl_; }
 
 private:
     ttsl::indirect<Impl> impl_;

--- a/tt_stl/tt_stl/pimpl.hpp
+++ b/tt_stl/tt_stl/pimpl.hpp
@@ -199,6 +199,9 @@ public:
     const Impl& impl() const { return *impl_; }
 
 protected:
+    /* Take over an existing Impl object. */
+    explicit PimplBase(Impl impl) : PimplBase(std::in_place, std::move(impl)) {}
+
     /* Forwarding constructor: build the Impl in place (forwards to indirect's in_place ctor). */
     template <typename... Args>
     explicit PimplBase(std::in_place_t, Args&&... args) :  // NOLINT(readability-named-parameter)


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Feature

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

This PR introduces `ttsl::PimplBase<Impl>` to `tt_stl/tt_stl/pimpl.hpp`.

This should aid in uniform implementation of the pimpl pattern, specifically in regards to the special member functions. `PimplBase` allows convenient pass through of copy constructor/ assignment when enabled, and uniform sane move semantic to the surface object. It also handles when the underlying pointer is nullptr gracefully.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

- Usage examples are given in the docs (see the header comments in `tt_stl/tt_stl/pimpl.hpp`).
- `MeshTensor` and `HostTensor` (`tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp` / `tt_metal/impl/tensor/mesh{/host}_tensor.cpp`) is converted in this PR to use `PimplBase<MeshTensorImpl>`.
- This utility has been tested.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/ttsl-pimpl)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/ttsl-pimpl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/ttsl-pimpl)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/ttsl-pimpl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=riverwu/ttsl-pimpl)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:riverwu/ttsl-pimpl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/ttsl-pimpl)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/ttsl-pimpl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/ttsl-pimpl)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/ttsl-pimpl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/ttsl-pimpl)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/ttsl-pimpl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/ttsl-pimpl)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/ttsl-pimpl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/ttsl-pimpl)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/ttsl-pimpl)
