### PR TITLE
[LLK] Quasar: derive addrmod thread id from COMPILE_FOR_TRISC 

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_common_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_template.h"
@@ -121,7 +122,7 @@ inline void llk_math_dest_section_done() {
     // no-real-work unpack-to-dest forwarder.
     _llk_sync_post_<p_stall::MATH, p_stall::WAIT_SFPU>(semaphore::MATH_PACK);
     if constexpr (DST_SYNC_MODE == DstSync::SyncHalf && !UnpackToDestEn) {
-        _llk_sync_advance_dest_section_<ckernel::math::TRISC_ID, EN_32BIT_DEST, p_stall::WAIT_SFPU, p_stall::MATH>();
+        _llk_sync_advance_dest_section_<ckernel::TRISC_ID, EN_32BIT_DEST, p_stall::WAIT_SFPU, p_stall::MATH>();
     }
 }
 

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_common_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_common_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "ckernel.h"
 #include "llk_outputs.h"
 #include "llk_pack_common.h"
@@ -117,7 +118,7 @@ inline void llk_pack_dest_section_done() {
     if constexpr (UnpackToDestEn) {
         _llk_sync_get_<p_stall::PACK0>(semaphore::MATH_PACK);
         if constexpr (DST_SYNC_MODE == DstSync::SyncHalf) {
-            _llk_sync_advance_dest_section_<ckernel::pack::TRISC_ID, true /*EN_32BIT_DEST*/, p_stall::PACK0>();
+            _llk_sync_advance_dest_section_<ckernel::TRISC_ID, true /*EN_32BIT_DEST*/, p_stall::PACK0>();
         }
     } else {
         _llk_pack_dest_semaphore_section_done_<p_pacr::PACK0, DST_SYNC_MODE, is_fp32_dest_acc_en>();

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_tile_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_tile_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "llk_pack_common_api.h"
 #include "llk_pack.h"
 #include "tensor_shape.h"
@@ -25,12 +26,12 @@ inline void llk_pack_init(const std::uint32_t pack_output) {
 
     _llk_pack_init_(output_id, tensor_shape);
 
-    // 32-bit unpack-to-dest path: PACR addresses dest via SEC{pack::TRISC_ID}_Offset.
+    // 32-bit unpack-to-dest path: PACR addresses dest via SEC{TRISC_ID}_Offset (pack thread).
     // Initialize the section base to bank 0 for SyncHalf so the first PACR reads bank 0.
     if constexpr (UnpackToDestEn) {
         if constexpr (DST_SYNC_MODE == DstSync::SyncHalf) {
             _reset_dest_register_offset_();
-            _set_dest_section_base_<ckernel::pack::TRISC_ID>(_get_dest_buffer_base_());
+            _set_dest_section_base_<ckernel::TRISC_ID>(_get_dest_buffer_base_());
         }
     }
 }
@@ -103,11 +104,11 @@ inline void llk_pack(
  * output buffer identified by pack_output starting from output_tile_index
  */
 // TODO: AM; Optimize block calls by using ntiles per pack, issue #40798
-inline void llk_pack_block(std::uint32_t start_tile_index, std::uint32_t pack_output, uint32_t ntiles) {
+inline void llk_pack_block(std::uint32_t start_tile_index, std::uint32_t pack_output, std::uint32_t ntiles) {
     std::uint8_t output_id = get_output_id(pack_output);
     const ckernel::TensorShape tensor_shape = get_output_tensor_shape(output_id);
 
-    for (uint32_t tile_index = start_tile_index; tile_index < start_tile_index + ntiles; tile_index++) {
+    for (std::uint32_t tile_index = start_tile_index; tile_index < start_tile_index + ntiles; tile_index++) {
         std::uint32_t l1_tile_index = get_output_tile_index<false /* out_of_order_output */, false /* untilize */>(
             output_id, 0 /* output_tile_index */);
 

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_max_min.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_max_min.h
@@ -37,7 +37,7 @@ inline void _init_binary_max_min_() {
         .srcb = {.incr = 0},
         .dest = {.incr = 2},
     }
-        .set(ADDR_MOD_6, csr_read<CSR::TRISC_ID>());
+        .set(ADDR_MOD_6);
 }
 
 // Unified element-wise max/min over two Dest tile regions.

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
@@ -162,7 +162,7 @@ inline void init_zero_comp() {
         .srcb = {.incr = 0},
         .dest = {.incr = 2},
     }
-        .set(ADDR_MOD_6, csr_read<CSR::TRISC_ID>());
+        .set(ADDR_MOD_6);
 }
 
 /**

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_square.h
@@ -25,7 +25,7 @@ inline void init_square() {
         .srcb = {.incr = 0},
         .dest = {.incr = 2},
     }
-        .set(ADDR_MOD_6, csr_read<CSR::TRISC_ID>());
+        .set(ADDR_MOD_6);
 }
 
 /**
@@ -37,7 +37,7 @@ inline void init_square() {
  * @note ADDR_MOD_6 must already be programmed by @ref init_square.
  */
 inline void _calculate_square_sfp_rows_() {
-    sfpi::vFloat v = sfpi::dst_reg[0];  // load x from dest (SFPLOAD)
+    sfpi::vFloat v = sfpi::dst_reg[0];                     // load x from dest (SFPLOAD)
     sfpi::dst_reg[0].mode<>(ckernel::ADDR_MOD_6) = v * v;  // x * x via SFPMUL, store back to dest (SFPSTORE)
 }
 

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_topk.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_topk.h
@@ -36,7 +36,7 @@ enum SortDir : bool {
 // need to program that TRISC's section base instead.
 inline void set_dst_write_addr(std::uint32_t addr) {
     std::uint32_t dst_index = addr + ckernel::trisc::_get_dest_buffer_base_();
-    ckernel::trisc::_set_dest_section_base_<ckernel::math::TRISC_ID>(dst_index);
+    ckernel::trisc::_set_dest_section_base_<ckernel::TRISC_ID>(dst_index);
 }
 
 // Advance the dest RWC counter by `inc` rows in groups of 8.

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_topk.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_topk.h
@@ -82,7 +82,7 @@ inline void init_topk_addr_mod() {
         .srcb = {.incr = 0},
         .dest = {.incr = 32},
     }
-        .set(ADDR_MOD_6, csr_read<CSR::TRISC_ID>());
+        .set(ADDR_MOD_6);
 }
 
 /**

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_typecast.h
@@ -53,7 +53,7 @@ inline void init_typecast() {
         .srcb = {.incr = 0},
         .dest = {.incr = ckernel::math::SFP_ROWS},
     }
-        .set(ADDR_MOD_6, csr_read<CSR::TRISC_ID>());
+        .set(ADDR_MOD_6);
 }
 
 // Load one SFPU pass worth of rows from Dest as VTYPE (vFloat for floats, vSMag/vInt for ints —

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -1257,11 +1257,12 @@ class TestConfig:
             )
 
             def build_kernel_part(name: str):
-                optional_kernel_flags = ""
-                if TestConfig.CHIP_ARCH != ChipArchitecture.QUASAR:
-                    optional_kernel_flags = "-DCOMPILE_FOR_TRISC=" + str(
-                        TestConfig.KERNEL_COMPONENTS.index(name)
-                    )
+                # COMPILE_FOR_TRISC is the single source of truth for the compute thread id on every
+                # arch (unpack=0/math=1/pack=2/sfpu=3). Quasar also gets -DLLK_TRISC_<NAME> below, but the
+                # LLK headers now require COMPILE_FOR_TRISC (see ckernel_addrmod.h), so pass it for Quasar too.
+                optional_kernel_flags = "-DCOMPILE_FOR_TRISC=" + str(
+                    TestConfig.KERNEL_COMPONENTS.index(name)
+                )
 
                 if not self.compile_time_formats:
                     optional_kernel_flags += " -DRUNTIME_FORMATS"

--- a/tt_metal/tt-llk/tests/sources/quasar/matmul_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/matmul_quasar_test.cpp
@@ -34,14 +34,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     // Setup sync for unpack
     set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
-    set_ttsync_enables<TRACK_ALL>(ckernel::unpack::TRISC_ID);
+    set_ttsync_enables<TRACK_ALL>(ckernel::TRISC_ID);
     // src A input configuration
     tdma_descriptor_t tdma_desc_src_a;
     tdma_desc_src_a.buf_desc.f.l1_addr_16B  = L1_ADDRESS(params.buffer_A[0]);
     tdma_desc_src_a.buf_desc.f.format       = static_cast<std::uint8_t>(formats.unpack_A_src);
     tdma_desc_src_a.buf_desc.f.lmt_addr_16B = 0;
-    tdma_desc_src_a.buf_desc.f.x_dim        = FACE_C_DIM;  // Default face dimension is 16, tiny tiles not supported for quasar
-    tdma_desc_src_a.buf_desc.f.y_dim        = FACE_R_DIM;  // Default face dimension is 16, tiny tiles not supported for quasar
+    tdma_desc_src_a.buf_desc.f.x_dim        = FACE_C_DIM;         // Default face dimension is 16, tiny tiles not supported for quasar
+    tdma_desc_src_a.buf_desc.f.y_dim        = FACE_R_DIM;         // Default face dimension is 16, tiny tiles not supported for quasar
     tdma_desc_src_a.buf_desc.f.z_dim        = params.num_faces_A; // Number of faces = 4, tiny tiles not supported for quasar
     tdma_desc_src_a.buf_desc_id             = buf_desc_id_src_a;
     tdma_desc_src_a.reg_data_format         = static_cast<std::uint32_t>(formats.unpack_A_dst);
@@ -51,8 +51,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     tdma_desc_src_b.buf_desc.f.l1_addr_16B  = L1_ADDRESS(params.buffer_B[0]);
     tdma_desc_src_b.buf_desc.f.format       = static_cast<std::uint8_t>(formats.unpack_B_src);
     tdma_desc_src_b.buf_desc.f.lmt_addr_16B = 0;
-    tdma_desc_src_b.buf_desc.f.x_dim        = FACE_C_DIM;  // Default face dimension is 16, tiny tiles not supported for quasar
-    tdma_desc_src_b.buf_desc.f.y_dim        = FACE_R_DIM;  // Default face dimension is 16, tiny tiles not supported for quasar
+    tdma_desc_src_b.buf_desc.f.x_dim        = FACE_C_DIM;         // Default face dimension is 16, tiny tiles not supported for quasar
+    tdma_desc_src_b.buf_desc.f.y_dim        = FACE_R_DIM;         // Default face dimension is 16, tiny tiles not supported for quasar
     tdma_desc_src_b.buf_desc.f.z_dim        = params.num_faces_B; // Number of faces = 4, tiny tiles not supported for quasar
     tdma_desc_src_b.buf_desc_id             = buf_desc_id_src_b;
     tdma_desc_src_b.reg_data_format         = static_cast<std::uint32_t>(formats.unpack_B_dst);

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_exp_parallel_matmul_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_exp_parallel_matmul_quasar_test.cpp
@@ -32,7 +32,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
     set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
-    set_ttsync_enables<TRACK_ALL>(ckernel::unpack::TRISC_ID);
+    set_ttsync_enables<TRACK_ALL>(ckernel::TRISC_ID);
 
     tdma_descriptor_t tdma_desc_src_a;
     tdma_desc_src_a.buf_desc.f.l1_addr_16B  = L1_ADDRESS(params.buffer_A[0]);

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_addrmod.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_addrmod.h
@@ -150,24 +150,11 @@ behave like the Bias counter.
 
 #include <cstdint>
 
+#include "ckernel_trisc_id.h" // ckernel::TRISC_ID (compile-time thread id), used as the default addrmod thread
 #include "tensix.h"
-
-// The compute thread this kernel is compiled for. On Quasar every thread's addrmods live in one config
-// region indexed by thread id, so addr_mod_t::set() must know its own thread. This is the single source
-// of truth for the thread id (0=unpack, 1=math, 2=pack, 3=isolate-SFPU), replacing the per-namespace
-// TRISC_ID constants that used to live in c{unpack,math,pack}_common.h. It is derived from the
-// -DCOMPILE_FOR_TRISC=<n> the build already bakes into every compute compilation (metal:
-// llrt/hal/tt-2xx/hal_2xx_common.cpp; tt-llk tests: test_config.py) -- a compiler-provided macro, so it
-// needs no include and forms no cycle. ckernel_addrmod.h is only ever compiled in compute (trisc)
-// translation units, so the guard below never fires on data-movement/BRISC/NCRISC builds.
-#ifndef COMPILE_FOR_TRISC
-#error "COMPILE_FOR_TRISC must be defined for compute (trisc) builds; the addrmod thread id derives from it"
-#endif
 
 namespace ckernel
 {
-
-constexpr std::uint32_t TRISC_ID = COMPILE_FOR_TRISC;
 
 constexpr std::uint8_t ADDR_MOD_0 = 0;
 constexpr std::uint8_t ADDR_MOD_1 = 1;

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_addrmod.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_addrmod.h
@@ -152,8 +152,22 @@ behave like the Bias counter.
 
 #include "tensix.h"
 
+// The compute thread this kernel is compiled for. On Quasar every thread's addrmods live in one config
+// region indexed by thread id, so addr_mod_t::set() must know its own thread. This is the single source
+// of truth for the thread id (0=unpack, 1=math, 2=pack, 3=isolate-SFPU), replacing the per-namespace
+// TRISC_ID constants that used to live in c{unpack,math,pack}_common.h. It is derived from the
+// -DCOMPILE_FOR_TRISC=<n> the build already bakes into every compute compilation (metal:
+// llrt/hal/tt-2xx/hal_2xx_common.cpp; tt-llk tests: test_config.py) -- a compiler-provided macro, so it
+// needs no include and forms no cycle. ckernel_addrmod.h is only ever compiled in compute (trisc)
+// translation units, so the guard below never fires on data-movement/BRISC/NCRISC builds.
+#ifndef COMPILE_FOR_TRISC
+#error "COMPILE_FOR_TRISC must be defined for compute (trisc) builds; the addrmod thread id derives from it"
+#endif
+
 namespace ckernel
 {
+
+constexpr std::uint32_t TRISC_ID = COMPILE_FOR_TRISC;
 
 constexpr std::uint8_t ADDR_MOD_0 = 0;
 constexpr std::uint8_t ADDR_MOD_1 = 1;
@@ -257,8 +271,10 @@ struct addr_mod_t
 
 #define NUM_MATH_ADDR_MODS 8
 
-    // Program source and dest registers
-    __attribute__((always_inline)) inline addr_mod_t const& set(const std::uint8_t mod_index, std::uint32_t thread_id = 1) const
+    // Program source and dest registers. thread_id defaults to TRISC_ID (the thread this kernel is
+    // compiled for); a hard-coded default silently programmed another thread's addrmod slot -- the pack
+    // path (_llk_pack_dest_semaphore_section_done_) was writing into the math thread's slot. See tt-llk #1665.
+    __attribute__((always_inline)) inline addr_mod_t const& set(const std::uint8_t mod_index, std::uint32_t thread_id = TRISC_ID) const
     {
         auto cfg                                                                = (volatile std::uint32_t*)TENSIX_CFG_BASE;
         cfg[addr_mod_src_reg_addr[mod_index] + NUM_MATH_ADDR_MODS * thread_id]  = src_val();

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_sfpu.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_sfpu.h
@@ -39,7 +39,7 @@ inline void _sfpu_configure_addrmod_()
         .srcb = {.incr = 0},
         .dest = {.incr = 0},
     }
-        .set(ADDR_MOD_7, csr_read<CSR::TRISC_ID>());
+        .set(ADDR_MOD_7);
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_common.h
@@ -18,6 +18,18 @@
 
 namespace ckernel::trisc
 {
+// Fixed hardware thread ids, matching the DEST section register layout (SEC0..SEC3) and the
+// -DCOMPILE_FOR_TRISC=<n> the build assigns per thread. Use these when a call must address a specific
+// thread's slot rather than the compile-time thread it runs on -- e.g. the unpack-to-dest path, where
+// the unpack thread programs the UNP_DEST producer slot (Unpack) regardless of what it is compiled as.
+enum class TriscID : std::uint8_t
+{
+    Unpack = 0,
+    Math   = 1,
+    Pack   = 2,
+    Sfpu   = 3, // isolate-SFPU
+};
+
 // Num of words in buffer descriptor struct
 constexpr static std::uint32_t BD_NUM_WORDS = 3;
 

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_id.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_id.h
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <cstdint>
+
+// The compute thread this kernel is compiled for. On Quasar every thread's addrmods live in one config
+// region indexed by thread id, so addr_mod_t::set() must know its own thread. This is the single source
+// of truth for the thread id (0=unpack, 1=math, 2=pack, 3=isolate-SFPU), replacing the per-namespace
+// TRISC_ID constants that used to live in c{unpack,math,pack}_common.h. It is derived from the
+// -DCOMPILE_FOR_TRISC=<n> the build already bakes into every compute compilation (metal:
+// llrt/hal/tt-2xx/hal_2xx_common.cpp; tt-llk tests: test_config.py) -- a compiler-provided macro, so it
+// needs no other include and forms no cycle.
+//
+// This header is included only from ckernel_addrmod.h, which is compiled solely in compute (trisc)
+// translation units. Keep it that way: it must NOT be pulled into data-movement/BRISC/NCRISC builds
+// (e.g. dataflow reader/writer kernels), which do not define COMPILE_FOR_TRISC and would trip the guard.
+#ifndef COMPILE_FOR_TRISC
+#error "COMPILE_FOR_TRISC must be defined for compute (trisc) builds; the addrmod thread id derives from it"
+#endif
+
+namespace ckernel
+{
+
+constexpr std::uint32_t TRISC_ID = COMPILE_FOR_TRISC;
+
+} // namespace ckernel

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/cmath_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/cmath_common.h
@@ -11,19 +11,13 @@ namespace ckernel::math
 {
 
 // Number of rows for MATH functions
-constexpr static std::uint32_t ELTWISE_MATH_ROWS       = MATH_ROWS; // 8 for quasar, 4 for trinity
-constexpr static std::uint32_t MOVE_MATH_ROWS[3]       = {8, 4, 1};
-constexpr static unsigned int SFP_ROWS                 = 2;
+constexpr static std::uint32_t ELTWISE_MATH_ROWS = MATH_ROWS; // 8 for quasar, 4 for trinity
+constexpr static std::uint32_t MOVE_MATH_ROWS[3] = {8, 4, 1};
+constexpr static unsigned int SFP_ROWS           = 2;
 
 // SFPU register-file base addresses: dest region vs SrcS (used by SFPU load/store)
 constexpr static unsigned int SFPU_DEST_BASE_ADDR = 0x0;
 constexpr static unsigned int SFPU_SRCS_BASE_ADDR = 0x400;
-
-#if defined(LLK_TRISC_ISOLATE_SFPU)
-constexpr static std::uint32_t TRISC_ID = 3;
-#else
-constexpr static std::uint32_t TRISC_ID = 1;
-#endif
 
 // Struct for the ALU addresses
 constexpr std::uint32_t NUM_WORDS_ALU_FORMAT = 3;
@@ -66,9 +60,9 @@ typedef union
 // List of possible data format config states
 enum class DataFormatConfigSet : std::uint8_t
 {
-    UNCONFIGURED          = 0,
-    DEFAULT               = 1,
-    MOV_OPS_EXPLICIT_FMT  = 2
+    UNCONFIGURED         = 0,
+    DEFAULT              = 1,
+    MOV_OPS_EXPLICIT_FMT = 2
 };
 
 // /**

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/cpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/cpack_common.h
@@ -34,7 +34,6 @@ union pack_untilize_stride_cfg_u
     pack_untilize_stride_cfg_t f;
 };
 
-constexpr static std::uint32_t TRISC_ID = 2;
 static std::uint32_t clear_dest_bank_id = 0;
 
 inline void _update_clear_dest_bank_id_()

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/cunpack_common.h
@@ -40,7 +40,6 @@ union unpack_tilize_cfg_u
 
 // Number of rows for Unpack functions
 constexpr static std::uint32_t UNPACR_STRIDE_MAX_ROWS = 8;
-constexpr static std::uint32_t TRISC_ID               = 0;
 
 /**
  * Whether reprogramming OUT_DATA_FORMAT from buffer-descriptor \p unpack_src_format (L1) to

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_sync.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_sync.h
@@ -123,8 +123,8 @@ inline void _llk_stall_cfg_on_()
  * old base to drain, and (3) reprogram its per-TRISC dest section base before
  * the next op issues. This helper performs those three steps in order.
  *
- * @tparam TRISC_ID       The calling thread (ckernel::math::TRISC_ID,
- *                        ckernel::pack::TRISC_ID, or ckernel::unpack::TRISC_ID).
+ * @tparam TRISC_ID       The calling thread's id (ckernel::TRISC_ID = COMPILE_FOR_TRISC:
+ *                        0=unpack, 1=math, 2=pack, 3=isolate-SFPU).
  * @tparam EN_32BIT_DEST  True if the math destination register is in
  *                        Float32/Int32 (32-bit) mode, false for 16-bit.
  * @tparam DrainRes0      Primary stall resource to drain before reprogramming

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_unary_operand.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_unary_operand.h
@@ -324,9 +324,9 @@ inline void _llk_unpack_unary_operand_init_(const std::uint32_t buf_desc_id, con
         // producer (UNP_DEST), so it programs the per-TRISC section base itself rather than
         // letting the math middleman set it on its behalf
         // Establish the initial bank-0 base here; the per-tile call flips
-        // it in SyncHalf. unpack::TRISC_ID == 0 selects the same SEC slot the UNP_DEST client reads.
+        // it in SyncHalf. TriscID::Unpack selects the same SEC slot the UNP_DEST client reads.
         ckernel::trisc::_reset_dest_register_offset_();
-        ckernel::trisc::_set_dest_section_base_<ckernel::unpack::TRISC_ID>(ckernel::trisc::_get_dest_buffer_base_());
+        ckernel::trisc::_set_dest_section_base_<to_underlying(ckernel::trisc::TriscID::Unpack)>(ckernel::trisc::_get_dest_buffer_base_());
 
         cfg_rmw(THCON_UNPACKER0_REG0_TRANSPOSE_RMW, 0 /*TRANSPOSE_EN forced false for UNP_DEST*/);
         cfg_rmw(THCON_UNPACKER1_REG0_TRANSPOSE_RMW, 0);
@@ -412,7 +412,7 @@ inline void _llk_unpack_unary_operand_(const std::uint32_t l1_tile_idx, const Te
         // Unpack owns the DEST section base, so it flips to the other bank for the next iteration
         if constexpr (DEST_SYNC_MODE == ckernel::DstSync::SyncHalf)
         {
-            _llk_sync_advance_dest_section_<ckernel::unpack::TRISC_ID, true /*EN_32BIT_DEST*/, p_stall::UNPACK0>();
+            _llk_sync_advance_dest_section_<to_underlying(ckernel::trisc::TriscID::Unpack), true /*EN_32BIT_DEST*/, p_stall::UNPACK0>();
         }
         return;
     }


### PR DESCRIPTION
Issue: https://github.com/tenstorrent/tt-llk/issues/1665

On Quasar all threads' addrmod registers share one config region indexed by thread id. addr_mod_t::set() hard-defaulted thread_id to 1 (math), so the pack path (_llk_pack_dest_semaphore_section_done_) programmed the math thread's slot.

Make COMPILE_FOR_TRISC the single source of truth for the compute thread id (as on WH/BH): define ckernel::TRISC_ID = COMPILE_FOR_TRISC, default set()'s thread_id to it, and #error if COMPILE_FOR_TRISC is undefined in a compute build. Delete the per-namespace TRISC_ID constants and cmath's LLK_TRISC_ISOLATE_SFPU special-case (COMPILE_FOR_TRISC=3 covers it). Quasar pytest now also passes -DCOMPILE_FOR_TRISC=<index>.

Add a TriscID enum (all four threads) in ckernel_trisc_common.h and use it in the unpack-to-dest path, which must address the fixed UNP_DEST producer slot rather than the compile-time thread id.

Validated: 16 passed on test_unpack_unary_operand_quasar.py (UNP_DEST/SyncHalf) on the Quasar emulator.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rtawfik/tt-llk-1665-addrmod-trisc-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rtawfik/tt-llk-1665-addrmod-trisc-id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rtawfik/tt-llk-1665-addrmod-trisc-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rtawfik/tt-llk-1665-addrmod-trisc-id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=rtawfik/tt-llk-1665-addrmod-trisc-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:rtawfik/tt-llk-1665-addrmod-trisc-id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rtawfik/tt-llk-1665-addrmod-trisc-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rtawfik/tt-llk-1665-addrmod-trisc-id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rtawfik/tt-llk-1665-addrmod-trisc-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rtawfik/tt-llk-1665-addrmod-trisc-id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rtawfik/tt-llk-1665-addrmod-trisc-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rtawfik/tt-llk-1665-addrmod-trisc-id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rtawfik/tt-llk-1665-addrmod-trisc-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rtawfik/tt-llk-1665-addrmod-trisc-id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rtawfik/tt-llk-1665-addrmod-trisc-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rtawfik/tt-llk-1665-addrmod-trisc-id)