### PR TITLE
[skip ci] ci: add copilot-pr-labeler job to pr-gate

### DIFF
--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -380,7 +380,9 @@ jobs:
   # on open, using the GitHub Copilot CLI.
   #
   # Job-level permissions (following the llk-label-pr convention above) — the
-  # composite action needs contents:read, pull-requests:write, copilot-requests:write.
+  # composite action needs contents:read, pull-requests:write, copilot-requests:write,
+  # plus issues:write for the `gh label create` fallback when a type label doesn't
+  # already exist in the repo.
   copilot-pr-labeler:
     # Only act on newly opened PRs. The workflow also triggers on reopened,
     # synchronize and ready_for_review, so gate on 'opened' to avoid running
@@ -388,11 +390,12 @@ jobs:
     if: ${{ github.event_name == 'pull_request' && github.event.action == 'opened' }}
     permissions:
       contents: read
+      issues: write
       pull-requests: write
       copilot-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: tenstorrent/tt-github-actions/.github/actions/copilot-pr-labeler@main
+      - uses: tenstorrent/tt-github-actions/.github/actions/copilot-pr-labeler@629b4727fa0dff3d43895601dd538e303880ecbc # main (tt-github-actions#144)
 
   # PR-gate LLK python_tests matrix (tests/pipeline_reorg/llk_pr_gate_tests.yaml).
   # SKU coverage is narrowed below based on find-changed-files outputs.

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -379,12 +379,6 @@ jobs:
   # Copilot PR type labeler — auto-label PRs by change type (feat/fix/docs/etc.)
   # on open, using the GitHub Copilot CLI.
   #
-  # TEST/DRAFT: this references the composite action at a specific branch ref
-  # (brain/copilot-pr-type-labeler) because the upstream PR that adds it is not
-  # yet merged: https://github.com/tenstorrent/tt-github-actions/pull/144
-  # TODO: switch the ref to @main once #144 merges (or revert this job if the
-  # test doesn't need to stay).
-  #
   # Job-level permissions (following the llk-label-pr convention above) — the
   # composite action needs contents:read, pull-requests:write, copilot-requests:write.
   copilot-pr-labeler:
@@ -398,7 +392,7 @@ jobs:
       copilot-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: tenstorrent/tt-github-actions/.github/actions/copilot-pr-labeler@brain/copilot-pr-type-labeler
+      - uses: tenstorrent/tt-github-actions/.github/actions/copilot-pr-labeler@main
 
   # PR-gate LLK python_tests matrix (tests/pipeline_reorg/llk_pr_gate_tests.yaml).
   # SKU coverage is narrowed below based on find-changed-files outputs.

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -376,6 +376,30 @@ jobs:
               ));
             }
 
+  # Copilot PR type labeler — auto-label PRs by change type (feat/fix/docs/etc.)
+  # on open, using the GitHub Copilot CLI.
+  #
+  # TEST/DRAFT: this references the composite action at a specific branch ref
+  # (brain/copilot-pr-type-labeler) because the upstream PR that adds it is not
+  # yet merged: https://github.com/tenstorrent/tt-github-actions/pull/144
+  # TODO: switch the ref to @main once #144 merges (or revert this job if the
+  # test doesn't need to stay).
+  #
+  # Job-level permissions (following the llk-label-pr convention above) — the
+  # composite action needs contents:read, pull-requests:write, copilot-requests:write.
+  copilot-pr-labeler:
+    # Only act on newly opened PRs. The workflow also triggers on reopened,
+    # synchronize and ready_for_review, so gate on 'opened' to avoid running
+    # this labeler redundantly on every push.
+    if: ${{ github.event_name == 'pull_request' && github.event.action == 'opened' }}
+    permissions:
+      contents: read
+      pull-requests: write
+      copilot-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tenstorrent/tt-github-actions/.github/actions/copilot-pr-labeler@brain/copilot-pr-type-labeler
+
   # PR-gate LLK python_tests matrix (tests/pipeline_reorg/llk_pr_gate_tests.yaml).
   # SKU coverage is narrowed below based on find-changed-files outputs.
   llk-smoke-tests:

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -377,16 +377,7 @@ jobs:
             }
 
   # Copilot PR type labeler — auto-label PRs by change type (feat/fix/docs/etc.)
-  # on open, using the GitHub Copilot CLI.
-  #
-  # Job-level permissions (following the llk-label-pr convention above) — the
-  # composite action needs contents:read, pull-requests:write, copilot-requests:write,
-  # plus issues:write for the `gh label create` fallback when a type label doesn't
-  # already exist in the repo.
   copilot-pr-labeler:
-    # Only act on newly opened PRs. The workflow also triggers on reopened,
-    # synchronize and ready_for_review, so gate on 'opened' to avoid running
-    # this labeler redundantly on every push.
     if: ${{ github.event_name == 'pull_request' && github.event.action == 'opened' }}
     permissions:
       contents: read


### PR DESCRIPTION
## What this does

Adds a `copilot-pr-labeler` job to `pr-gate.yaml` that auto-labels PRs by change type (`feat`/`fix`/`docs`/`style`/`refactor`/`perf`/`test`/`build`/`ci`/`chore`/`revert`) using the GitHub Copilot CLI, via the composite action from `tenstorrent/tt-github-actions`:
https://github.com/tenstorrent/tt-github-actions/blob/main/.github/actions/copilot-pr-labeler/README.md

- Runs once, only on `pull_request: opened` (guarded with an `if`, since `pr-gate` also triggers on `reopened`/`synchronize`/`ready_for_review` — no need to re-run on every push).
- Job-scoped `permissions: contents: read, pull-requests: write, copilot-requests: write`, following the existing `llk-label-pr` job's convention of scoping permissions per-job rather than widening the whole workflow.
- References the action at `@main` (tenstorrent/tt-github-actions#144, which added this action, is now merged).

## Validation

This started as a test PR referencing the action on its pre-merge branch. The job ran successfully on open and applied the `CI` label to this PR itself:
https://github.com/tenstorrent/tt-metal/actions/runs/29317567907/job/87035005302

Now that tenstorrent/tt-github-actions#144 has merged, this PR has been updated to reference `@main` and is ready to land as a real integration rather than a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=wilder/test-copilot-pr-labeler)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:wilder/test-copilot-pr-labeler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=wilder/test-copilot-pr-labeler)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:wilder/test-copilot-pr-labeler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=wilder/test-copilot-pr-labeler)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:wilder/test-copilot-pr-labeler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=wilder/test-copilot-pr-labeler)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:wilder/test-copilot-pr-labeler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=wilder/test-copilot-pr-labeler)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:wilder/test-copilot-pr-labeler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=wilder/test-copilot-pr-labeler)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:wilder/test-copilot-pr-labeler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=wilder/test-copilot-pr-labeler)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:wilder/test-copilot-pr-labeler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=wilder/test-copilot-pr-labeler)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:wilder/test-copilot-pr-labeler)