### PR TITLE
Fix bf8 scalar outer nightly tests

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/test_outer.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/test_outer.py
@@ -28,9 +28,13 @@ import ttnn
 
 from models.common.utility_functions import torch_random
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_allclose, assert_with_pcc
 
 pytestmark = pytest.mark.use_module_device
+
+# Scalar bf8 outer: looser than comp_pcc fallback; seed=0 ~1.125 abs diff, atol covers near-zero products.
+_BF8_SCALAR_OUTER_RTOL = 0.05
+_BF8_SCALAR_OUTER_ATOL = 2.0
 
 
 # ---------------------------------------------------------------------------
@@ -163,7 +167,12 @@ def _check(a_pt, b_pt, out_tt, dtype):
     out_pt = ttnn.to_torch(out_tt)
     golden = _golden(a_pt, b_pt)
     assert tuple(out_pt.shape) == tuple(golden.shape), f"shape mismatch: tt={out_pt.shape}, golden={golden.shape}"
-    assert_with_pcc(golden, out_pt, pcc=_pcc(dtype))
+    # PCC falls back to allclose on constant tensor; but its bounds is too tight for bfloat8_b.
+    # We use a relaxed allclose outside instead.
+    if dtype == ttnn.bfloat8_b and out_pt.numel() == 1:
+        assert_allclose(golden, out_pt, rtol=_BF8_SCALAR_OUTER_RTOL, atol=_BF8_SCALAR_OUTER_ATOL)
+    else:
+        assert_with_pcc(golden, out_pt, pcc=_pcc(dtype))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-metal/issues/49798

### PR category
Test only

### Summary

Port the unit-test BFLOAT8_B `[1]×[1]` outer assertion fix to nightly `test_outer.py`.

`ttnn.outer` on scalar bf8 inputs produces a 1-element output where PCC is undefined. Nightly was still using plain `assert_with_pcc`; this matches unit `#49455` by routing that case through `assert_allclose` with the same named tolerances.

Not an `ttnn.outer` kernel bug — **test metric / tolerance** only.

**Observed values (seed=0):** golden `-40.125`, device `-39.0`, abs diff `1.125` (~2.8%).

### Relationship to `comp_pcc` / #42848
**On current `main`**, `comp_pcc` still treats NaN PCC (zero-variance / single-element) as a pass:

```python
if math.isnan(cal_pcc):
    return True, 1.0
```

So bf8 `[1]×[1]` can **false-pass** under plain `assert_with_pcc` on `main` today, even when device and golden differ by ~1.125.

**CI failure / need for this check shows up** on a stricter `comp_pcc` branch ([#42848](https://github.com/tenstorrent/tt-metal/pull/42848)), where NaN PCC falls back to `torch.allclose(rtol=1e-5, atol=1e-4)`. Default `atol=1e-4` rejects normal bf8 block-float noise on this scalar product → `AssertionError: 0.0`.

This PR **hardens nightly against that silent false-pass** and keeps nightly aligned with unit once stricter `comp_pcc` lands 


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/outer_nightly)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/outer_nightly)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/outer_nightly)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/outer_nightly)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=virdhatchani/outer_nightly)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:virdhatchani/outer_nightly)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/outer_nightly)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/outer_nightly)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/outer_nightly)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/outer_nightly)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/outer_nightly)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/outer_nightly)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/outer_nightly)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/outer_nightly)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/outer_nightly)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/outer_nightly)