### PR TITLE
[tt-triage] Update tt-exalens version to 0.3.27

### DIFF
--- a/tools/tests/triage/test_triage.py
+++ b/tools/tests/triage/test_triage.py
@@ -275,11 +275,11 @@ class TestTriage:
         )
         assert len(result.stderr) == 0
 
-    def test_triage_initialize_with_noc0(self):
+    def test_triage_with_noc_0(self):
         global triage_script
 
         result = subprocess.run(
-            [triage_script, "--initialize-with-noc0", "--run=test_output"],
+            [triage_script, "--noc-id=0", "--run=test_output"],
             check=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/tools/tests/triage/test_triage.py
+++ b/tools/tests/triage/test_triage.py
@@ -275,11 +275,11 @@ class TestTriage:
         )
         assert len(result.stderr) == 0
 
-    def test_triage_initialize_with_noc1(self):
+    def test_triage_initialize_with_noc0(self):
         global triage_script
 
         result = subprocess.run(
-            [triage_script, "--initialize-with-noc1", "--run=test_output"],
+            [triage_script, "--initialize-with-noc0", "--run=test_output"],
             check=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/tools/triage/callstack_provider.py
+++ b/tools/triage/callstack_provider.py
@@ -39,7 +39,7 @@ from ttexalens.context import Context
 from ttexalens.gdb.gdb_server import GdbServer, ServerSocket
 from ttexalens.gdb.gdb_client import get_gdb_callstack
 from ttexalens.elf import ElfFile
-from ttexalens.hardware.risc_debug import CallstackEntry
+from ttexalens.elf import CallstackEntry
 from ttexalens.tt_exalens_lib import top_callstack, callstack
 from ttexalens.umd_device import TimeoutDeviceRegisterError
 from utils import WARN
@@ -79,7 +79,7 @@ def get_callstack(
     full_callstack: bool,
     rewind_pc_for_ebreak: bool,
 ) -> KernelCallstackWithMessage:
-    context = location._device._context
+    context = location.device._context
     elfs: list[ElfFile] = [elfs_cache[dispatcher_core_data.firmware_path]]
     offsets: list[int | None] = [None]
     if dispatcher_core_data.kernel_path is not None:
@@ -87,7 +87,7 @@ def get_callstack(
         offsets.append(dispatcher_core_data.kernel_offset)
     try:
         if not full_callstack:
-            pc = location._device.get_block(location).get_risc_debug(risc_name).get_pc()
+            pc = location.device.get_block(location).get_risc_debug(risc_name).get_pc()
             if rewind_pc_for_ebreak:
                 pc = pc - 4
             try:
@@ -113,7 +113,7 @@ def get_callstack(
                 error_message = str(e) + " - defaulting to top callstack"
                 try:
                     # If full callstack failed, we default to top callstack
-                    pc = location._device.get_block(location).get_risc_debug(risc_name).get_pc()
+                    pc = location.device.get_block(location).get_risc_debug(risc_name).get_pc()
                     if rewind_pc_for_ebreak:
                         pc = pc - 4
                     cs = top_callstack(pc, elfs, offsets, context)
@@ -230,7 +230,7 @@ class CallstackProvider:
         gdb = use_gdb_callstack if use_gdb_callstack is not None else self.gdb_callstack
 
         cache_key = (
-            location._device.id,
+            location.device.id,
             location.to_str("noc0"),
             risc_name,
             full,
@@ -341,7 +341,7 @@ class CallstackProvider:
                 if len(callstack_with_message.callstack) > 0 and callstack_with_message.callstack[0].pc is None:
                     try:
                         callstack_with_message.callstack[0].pc = (
-                            location._device.get_block(location).get_risc_debug(risc_name).get_pc()
+                            location.device.get_block(location).get_risc_debug(risc_name).get_pc()
                         )
                     except TimeoutDeviceRegisterError:
                         raise

--- a/tools/triage/check_cb_inactive.py
+++ b/tools/triage/check_cb_inactive.py
@@ -34,7 +34,6 @@ def generate_cb_reg_name(cb_index: int) -> str:
 
 
 def check_cb_idle(location: OnChipCoordinate, noc_id: NocId):
-    noc_str = f"noc{noc_id}"
     noc_block = location.device.get_block(location)
     register_store = noc_block.get_register_store(noc_id)
     # Read all CB command control registers and emit errors immediately
@@ -44,17 +43,19 @@ def check_cb_idle(location: OnChipCoordinate, noc_id: NocId):
         log_check_location(
             location,
             value == 0,
-            f"{noc_str} CB{cb_index} active (0x{value:08X}). NoC is likely hung.",
+            f"{noc_id.name} CB{cb_index} active (0x{value:08X}). NoC is likely hung.",
         )
 
 
 def run(args, context: Context):
     BLOCK_TYPES_TO_CHECK = ["tensix", "eth"]
     run_checks = get_run_checks(args, context)
-    for noc_id in run_checks.devices[0].available_nocs:
-        run_checks.run_per_block_check(
-            lambda location: check_cb_idle(location, noc_id), block_filter=BLOCK_TYPES_TO_CHECK
-        )
+    run_checks.run_per_block_check(
+        lambda location: check_cb_idle(location, NocId.NOC0), block_filter=BLOCK_TYPES_TO_CHECK
+    )
+    run_checks.run_per_block_check(
+        lambda location: check_cb_idle(location, NocId.NOC1), block_filter=BLOCK_TYPES_TO_CHECK
+    )
 
 
 if __name__ == "__main__":

--- a/tools/triage/check_cb_inactive.py
+++ b/tools/triage/check_cb_inactive.py
@@ -18,7 +18,7 @@ Owner:
 
 from ttexalens.coordinate import OnChipCoordinate
 from run_checks import run as get_run_checks
-from ttexalens.context import Context
+from ttexalens.context import Context, NocId
 from triage import ScriptConfig, log_check_location, run_script
 
 script_config = ScriptConfig(
@@ -33,9 +33,9 @@ def generate_cb_reg_name(cb_index: int) -> str:
     return f"NOC_CMD_CTRL_CB{cb_index}"
 
 
-def check_cb_idle(location: OnChipCoordinate, noc_id: int):
+def check_cb_idle(location: OnChipCoordinate, noc_id: NocId):
     noc_str = f"noc{noc_id}"
-    noc_block = location._device.get_block(location)
+    noc_block = location.device.get_block(location)
     register_store = noc_block.get_register_store(noc_id)
     # Read all CB command control registers and emit errors immediately
     for cb_index in range(4):  # CB indices 0-3
@@ -51,12 +51,10 @@ def check_cb_idle(location: OnChipCoordinate, noc_id: int):
 def run(args, context: Context):
     BLOCK_TYPES_TO_CHECK = ["tensix", "eth"]
     run_checks = get_run_checks(args, context)
-    run_checks.run_per_block_check(
-        lambda location: check_cb_idle(location, noc_id=0), block_filter=BLOCK_TYPES_TO_CHECK
-    )
-    run_checks.run_per_block_check(
-        lambda location: check_cb_idle(location, noc_id=1), block_filter=BLOCK_TYPES_TO_CHECK
-    )
+    for noc_id in run_checks.devices[0].available_nocs:
+        run_checks.run_per_block_check(
+            lambda location: check_cb_idle(location, noc_id), block_filter=BLOCK_TYPES_TO_CHECK
+        )
 
 
 if __name__ == "__main__":

--- a/tools/triage/check_eth_status.py
+++ b/tools/triage/check_eth_status.py
@@ -213,7 +213,7 @@ def run(args, context: Context):
     run_checks = get_run_checks(args, context)
     BLOCK_TYPES_TO_CHECK = ["active_eth"]
     run_checks.run_per_block_check(
-        lambda location: get_eth_core_data(location._device, location, context), block_filter=BLOCK_TYPES_TO_CHECK
+        lambda location: get_eth_core_data(location.device, location, context), block_filter=BLOCK_TYPES_TO_CHECK
     )
 
 

--- a/tools/triage/check_l1_status.py
+++ b/tools/triage/check_l1_status.py
@@ -29,7 +29,7 @@ script_config = ScriptConfig(
 
 
 def check_worker_l1_launch_value(location: OnChipCoordinate, tensix_fw_launch_values: dict[int, int]) -> None:
-    expected_fw_launch_value = tensix_fw_launch_values.get(location._device.unique_id)
+    expected_fw_launch_value = tensix_fw_launch_values.get(location.device.unique_id)
     if expected_fw_launch_value is None:
         raise RuntimeError(f"Missing Inspector build env data for {location}")
 

--- a/tools/triage/check_noc_locations.py
+++ b/tools/triage/check_noc_locations.py
@@ -25,7 +25,7 @@ script_config = ScriptConfig(
 
 
 def check_noc_location(location: OnChipCoordinate, noc_id: NocId):
-    noc_str = f"noc{noc_id.value}"
+    noc_str = noc_id.name.lower()
     noc_block = location.device.get_block(location)
     register_store = noc_block.get_register_store(noc_id)
     data = register_store.read_register("NOC_NODE_ID")
@@ -42,10 +42,12 @@ def check_noc_location(location: OnChipCoordinate, noc_id: NocId):
 def run(args, context: Context):
     BLOCK_TYPES_TO_CHECK = ["tensix", "eth"]
     run_checks = get_run_checks(args, context)
-    for noc_id in run_checks.devices[0].available_nocs:
-        run_checks.run_per_block_check(
-            lambda location: check_noc_location(location, noc_id), block_filter=BLOCK_TYPES_TO_CHECK
-        )
+    run_checks.run_per_block_check(
+        lambda location: check_noc_location(location, NocId.NOC0), block_filter=BLOCK_TYPES_TO_CHECK
+    )
+    run_checks.run_per_block_check(
+        lambda location: check_noc_location(location, NocId.NOC1), block_filter=BLOCK_TYPES_TO_CHECK
+    )
 
 
 if __name__ == "__main__":

--- a/tools/triage/check_noc_locations.py
+++ b/tools/triage/check_noc_locations.py
@@ -16,7 +16,7 @@ Owner:
 
 from ttexalens.coordinate import OnChipCoordinate
 from run_checks import run as get_run_checks
-from ttexalens.context import Context
+from ttexalens.context import Context, NocId
 from triage import ScriptConfig, log_check_location, run_script
 
 script_config = ScriptConfig(
@@ -24,9 +24,9 @@ script_config = ScriptConfig(
 )
 
 
-def check_noc_location(location: OnChipCoordinate, noc_id: int):
-    noc_str = f"noc{noc_id}"
-    noc_block = location._device.get_block(location)
+def check_noc_location(location: OnChipCoordinate, noc_id: NocId):
+    noc_str = f"noc{noc_id.value}"
+    noc_block = location.device.get_block(location)
     register_store = noc_block.get_register_store(noc_id)
     data = register_store.read_register("NOC_NODE_ID")
     n_x = data & 0x3F
@@ -42,12 +42,10 @@ def check_noc_location(location: OnChipCoordinate, noc_id: int):
 def run(args, context: Context):
     BLOCK_TYPES_TO_CHECK = ["tensix", "eth"]
     run_checks = get_run_checks(args, context)
-    run_checks.run_per_block_check(
-        lambda location: check_noc_location(location, noc_id=0), block_filter=BLOCK_TYPES_TO_CHECK
-    )
-    run_checks.run_per_block_check(
-        lambda location: check_noc_location(location, noc_id=1), block_filter=BLOCK_TYPES_TO_CHECK
-    )
+    for noc_id in run_checks.devices[0].available_nocs:
+        run_checks.run_per_block_check(
+            lambda location: check_noc_location(location, noc_id), block_filter=BLOCK_TYPES_TO_CHECK
+        )
 
 
 if __name__ == "__main__":

--- a/tools/triage/check_noc_status.py
+++ b/tools/triage/check_noc_status.py
@@ -15,7 +15,7 @@ Owner:
     jbaumanTT
 """
 
-from ttexalens.context import Context
+from ttexalens.context import Context, NocId
 from ttexalens.coordinate import OnChipCoordinate
 from ttexalens.memory_access import create_memory_access
 from ttexalens.tt_exalens_lib import read_register
@@ -37,7 +37,7 @@ def check_noc_status(
     dispatcher_data: DispatcherData,
     var_to_reg_map: dict[str, str],
     elfs_cache: ElfsCache,
-    noc_id: int = 0,
+    noc_id: NocId = NocId.NOC0,
 ):
     """
     Checks for mismatches between variables and registers that store number of NOC transactions
@@ -52,7 +52,7 @@ def check_noc_status(
     if dispatcher_core_data.kernel_path is not None:
         kernel_elf = elfs_cache[dispatcher_core_data.kernel_path]
 
-    message = f"{risc_name} NOC{noc_id}: "
+    message = f"{risc_name} NOC{noc_id.value}: "
     passed = True
 
     loc_mem_access = create_memory_access(location.noc_block.get_risc_debug(risc_name))
@@ -69,7 +69,7 @@ def check_noc_status(
 
         # Also validate that BRISC's runtime-selected NOC matches the NOC being checked.
         active_noc_index = fw_elf.get_global("noc_index", loc_mem_access).read_value()
-        if active_noc_index != noc_id:
+        if active_noc_index != noc_id.value:
             return
     elif kernel_elf is not None:
         # On erisc, the firmware doesn't necessarily select a NOC, so we need to check the kernel ELF.
@@ -79,7 +79,7 @@ def check_noc_status(
             log_check_location(location, True, message)
             return
         noc_index = kernel_elf.get_global("noc_index", loc_mem_access).read_value()
-        if noc_index != noc_id:
+        if noc_index != noc_id.value:
             return
 
     # Check if variables match with corresponding register
@@ -88,7 +88,7 @@ def check_noc_status(
         # If reading fails, write error message and skip to next core
         try:
             reg_val = read_register(location=location, register=reg, noc_id=noc_id)
-            var_val = fw_elf.get_global(var, loc_mem_access)[noc_id]
+            var_val = fw_elf.get_global(var, loc_mem_access)[noc_id.value]
         except TimeoutDeviceRegisterError:
             raise
         except Exception as e:
@@ -113,7 +113,6 @@ def check_noc_status(
 def run(args, context: Context):
     BLOCK_TYPES_TO_CHECK = ["tensix", "idle_eth"]
     RISC_CORES_TO_CHECK = ["brisc", "erisc", "erisc0", "erisc1"]
-    NOC_IDS = [0, 1]
     # Dictionary of corresponding variables and registers to check
     VAR_TO_REG_MAP = {
         "noc_reads_num_issued": "NIU_MST_RD_RESP_RECEIVED",
@@ -126,7 +125,7 @@ def run(args, context: Context):
     dispatcher_data = get_dispatcher_data(args, context)
     elfs_cache = get_elfs_cache(args, context)
     run_checks = get_run_checks(args, context)
-    for noc_id in NOC_IDS:
+    for noc_id in run_checks.devices[0].available_nocs:
         run_checks.run_per_core_check(
             lambda location, risc_name, _noc_id=noc_id: check_noc_status(
                 location, risc_name, dispatcher_data, VAR_TO_REG_MAP, elfs_cache, _noc_id

--- a/tools/triage/check_noc_status.py
+++ b/tools/triage/check_noc_status.py
@@ -15,7 +15,7 @@ Owner:
     jbaumanTT
 """
 
-from ttexalens.context import Context, NocId
+from ttexalens.context import Context, NocId, to_noc_id
 from ttexalens.coordinate import OnChipCoordinate
 from ttexalens.memory_access import create_memory_access
 from ttexalens.tt_exalens_lib import read_register
@@ -52,7 +52,7 @@ def check_noc_status(
     if dispatcher_core_data.kernel_path is not None:
         kernel_elf = elfs_cache[dispatcher_core_data.kernel_path]
 
-    message = f"{risc_name} NOC{noc_id.value}: "
+    message = f"{risc_name} {noc_id.name}: "
     passed = True
 
     loc_mem_access = create_memory_access(location.noc_block.get_risc_debug(risc_name))
@@ -68,8 +68,8 @@ def check_noc_status(
             return
 
         # Also validate that BRISC's runtime-selected NOC matches the NOC being checked.
-        active_noc_index = fw_elf.get_global("noc_index", loc_mem_access).read_value()
-        if active_noc_index != noc_id.value:
+        active_noc_index = to_noc_id(int(fw_elf.get_global("noc_index", loc_mem_access).read_value()))
+        if active_noc_index != noc_id:
             return
     elif kernel_elf is not None:
         # On erisc, the firmware doesn't necessarily select a NOC, so we need to check the kernel ELF.
@@ -78,8 +78,8 @@ def check_noc_status(
             message += "    Skipping NOC status check: noc_mode != DM_DEDICATED_NOC\n"
             log_check_location(location, True, message)
             return
-        noc_index = kernel_elf.get_global("noc_index", loc_mem_access).read_value()
-        if noc_index != noc_id.value:
+        noc_index = to_noc_id(int(kernel_elf.get_global("noc_index", loc_mem_access).read_value()))
+        if noc_index != noc_id:
             return
 
     # Check if variables match with corresponding register
@@ -125,7 +125,7 @@ def run(args, context: Context):
     dispatcher_data = get_dispatcher_data(args, context)
     elfs_cache = get_elfs_cache(args, context)
     run_checks = get_run_checks(args, context)
-    for noc_id in run_checks.devices[0].available_nocs:
+    for noc_id in (NocId.NOC0, NocId.NOC1):
         run_checks.run_per_core_check(
             lambda location, risc_name, _noc_id=noc_id: check_noc_status(
                 location, risc_name, dispatcher_data, VAR_TO_REG_MAP, elfs_cache, _noc_id

--- a/tools/triage/dispatcher_data.py
+++ b/tools/triage/dispatcher_data.py
@@ -382,7 +382,7 @@ class DispatcherData:
                 raise TTTriageError(f"Unsupported block type: {block_type}")
         # Get the build_env for the device to get the correct firmware path
         # Each device may have different firmware paths based on its build configuration
-        device_unique_id = location._device.unique_id
+        device_unique_id = location.device.unique_id
         build_env = self._get_build_env_for_device(device_unique_id)
         proc_name = risc_name.upper()
         proc_type = enum_values["ProcessorTypes"][proc_name]
@@ -449,8 +449,8 @@ class DispatcherData:
         try:
             kernel = self.find_kernel(watcher_kernel_id)
         except Exception:
-            if watcher_kernel_id != -1 and self.metal_device_id_mapping.has_unique_id(location._device.unique_id):
-                metal_device_id = self.metal_device_id_mapping.get_metal_device_id(location._device.unique_id)
+            if watcher_kernel_id != -1 and self.metal_device_id_mapping.has_unique_id(location.device.unique_id):
+                metal_device_id = self.metal_device_id_mapping.get_metal_device_id(location.device.unique_id)
                 kernel_lookup_warning = self._kernel_missing_hint_for_device(metal_device_id)
         try:
             previous_kernel = self.find_kernel(watcher_previous_kernel_id)

--- a/tools/triage/dump_aggregated_callstacks.py
+++ b/tools/triage/dump_aggregated_callstacks.py
@@ -136,7 +136,7 @@ class AggregationBucket:
         self.core_locations.add(f"{device_label}:{coord_str}")
         self.device_labels.add(device_label)
 
-        dev_id = location._device.id
+        dev_id = location.device.id
         x, y = location._noc0_coord
         self.per_core_hits[dev_id].add((x, y))
 

--- a/tools/triage/dump_fast_dispatch.py
+++ b/tools/triage/dump_fast_dispatch.py
@@ -274,7 +274,7 @@ def read_wait_globals(
     # Get virtual coordinate for this specific core
     virtual_coord = location.to("translated")
     # Use unique_id instead of device.id to avoid mapping issues with TT_METAL_VISIBLE_DEVICES
-    chip_id = location._device.unique_id
+    chip_id = location.device.unique_id
     x, y = virtual_coord
 
     # Lookup core info for the given kernel name based on virtual coordinates
@@ -344,7 +344,7 @@ def run(args, context: Context):
         # Check RISC core with risc_name at this location for dispatcher kernels
         if location not in locations_to_check:
             return None
-        noc_block = location._device.get_block(location)
+        noc_block = location.device.get_block(location)
         dispatch_core_pairs = []
         for risc_name in noc_block.risc_names:
             dispatcher_core_data = dispatcher_data.get_cached_core_data(location, risc_name)

--- a/tools/triage/dump_lightweight_asserts.py
+++ b/tools/triage/dump_lightweight_asserts.py
@@ -29,7 +29,7 @@ from run_checks import run as get_run_checks
 from ttexalens.coordinate import OnChipCoordinate
 from ttexalens.context import Context
 from ttexalens.tt_exalens_lib import read_word_from_device
-from ttexalens.hardware.risc_debug import CallstackEntryVariable
+from ttexalens.elf import CallstackEntryVariable
 from ttexalens.umd_device import TimeoutDeviceRegisterError
 
 
@@ -175,7 +175,7 @@ def dump_lightweight_asserts(
         if not dispatcher_data.risc_enabled(risc_name):
             return None
 
-        risc_debug = location._device.get_block(location).get_risc_debug(risc_name)
+        risc_debug = location.device.get_block(location).get_risc_debug(risc_name)
 
         # We don't care about cores that are in reset
         if risc_debug.is_in_reset():

--- a/tools/triage/dump_risc_debug_signals.py
+++ b/tools/triage/dump_risc_debug_signals.py
@@ -73,7 +73,7 @@ def collect_debug_bus_signals(
     location: OnChipCoordinate, failed_riscs: list[str], dispatcher_data: DispatcherData, elfs_cache: ElfsCache
 ) -> dict | None:
     """Collect debug bus signals for a block with known broken RISC cores."""
-    noc_block = location._device.get_block(location)
+    noc_block = location.device.get_block(location)
 
     debug_bus = noc_block.debug_bus
     assert debug_bus is not None, "Block does not have a debug bus"

--- a/tools/triage/requirements.txt
+++ b/tools/triage/requirements.txt
@@ -1,3 +1,3 @@
 pycapnp==2.0.0
 tt-umd==0.9.6
-tt-exalens==0.3.21
+tt-exalens==0.3.27

--- a/tools/triage/requirements.txt
+++ b/tools/triage/requirements.txt
@@ -1,3 +1,3 @@
 pycapnp==2.0.0
-tt-umd==0.9.6
+tt-umd==0.9.9
 tt-exalens==0.3.27

--- a/tools/triage/run_checks.py
+++ b/tools/triage/run_checks.py
@@ -421,7 +421,7 @@ class RunChecks:
             result: list[PerCoreCheckResult] = []
 
             # Get the block and its available RISC cores
-            noc_block = location._device.get_block(location)
+            noc_block = location.device.get_block(location)
             risc_names = noc_block.risc_names
 
             for risc_name in risc_names:
@@ -444,7 +444,7 @@ class RunChecks:
                     result,
                     check_result,
                     PerCoreCheckResult,
-                    device_description=DeviceDescription(location._device, self._use_unique_id),
+                    device_description=DeviceDescription(location.device, self._use_unique_id),
                     location=location,
                     risc_name=risc_name,
                 )

--- a/tools/triage/triage.py
+++ b/tools/triage/triage.py
@@ -5,13 +5,13 @@
 
 """
 Usage:
-    triage [--initialize-with-noc1] [--remote-exalens] [--remote-server=<remote-server>] [--remote-port=<remote-port>] [--verbosity=<verbosity>] [--run=<script>]... [--skip-version-check] [--print-script-times] [-v ...] [--disable-colors] [--disable-progress] [--disable-elf-cache] [--triage-summary-path=<path>] [--llm-output] [--llm-output-path=<path>]
+    triage [--initialize-with-noc0] [--remote-exalens] [--remote-server=<remote-server>] [--remote-port=<remote-port>] [--verbosity=<verbosity>] [--run=<script>]... [--skip-version-check] [--print-script-times] [-v ...] [--disable-colors] [--disable-progress] [--disable-elf-cache] [--triage-summary-path=<path>] [--llm-output] [--llm-output-path=<path>]
 
 Options:
     --remote-exalens                 Connect to remote exalens server.
     --remote-server=<remote-server>  Specify the remote server to connect to. [default: localhost]
     --remote-port=<remote-port>      Specify the remote server port. [default: 5555]
-    --initialize-with-noc1           Initialize debugger context with NOC1 enabled. [default: False]
+    --initialize-with-noc0           Initialize debugger context with NOC0 instead of the default NOC1. [default: False]
     --verbosity=<verbosity>          Choose output verbosity. 1: ERROR, 2: WARN, 3: INFO, 4: VERBOSE, 5: DEBUG. [default: 3]
     --run=<script>                   Run specific script(s) by name. If not provided, all scripts will be run. [default: all]
     --skip-version-check             Do not enforce debugger version check. [default: False]
@@ -79,7 +79,7 @@ import importlib.metadata as importlib_metadata
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TimeElapsedColumn, TimeRemainingColumn, BarColumn, TextColumn
 import sys
-from ttexalens.context import Context
+from ttexalens.context import Context, NocId
 from ttexalens.device import Device
 from ttexalens.coordinate import OnChipCoordinate
 from ttexalens.elf import ElfVariable
@@ -830,7 +830,8 @@ def _init_ttexalens(args: ScriptArguments) -> Context:
     if args["--remote-exalens"]:
         context = init_ttexalens_remote(ip_address=args["--remote-server"], port=args["--remote-port"])
     else:
-        context = init_ttexalens(use_noc1=args["--initialize-with-noc1"])
+        noc_id = NocId.NOC0 if args["--initialize-with-noc0"] else NocId.NOC1
+        context = init_ttexalens(noc_id=noc_id)
 
     _patch_risc_debug()
     return context

--- a/tools/triage/triage.py
+++ b/tools/triage/triage.py
@@ -5,13 +5,13 @@
 
 """
 Usage:
-    triage [--initialize-with-noc0] [--remote-exalens] [--remote-server=<remote-server>] [--remote-port=<remote-port>] [--verbosity=<verbosity>] [--run=<script>]... [--skip-version-check] [--print-script-times] [-v ...] [--disable-colors] [--disable-progress] [--disable-elf-cache] [--triage-summary-path=<path>] [--llm-output] [--llm-output-path=<path>]
+    triage [--noc-id=<id>] [--remote-exalens] [--remote-server=<remote-server>] [--remote-port=<remote-port>] [--verbosity=<verbosity>] [--run=<script>]... [--skip-version-check] [--print-script-times] [-v ...] [--disable-colors] [--disable-progress] [--disable-elf-cache] [--triage-summary-path=<path>] [--llm-output] [--llm-output-path=<path>]
 
 Options:
     --remote-exalens                 Connect to remote exalens server.
     --remote-server=<remote-server>  Specify the remote server to connect to. [default: localhost]
     --remote-port=<remote-port>      Specify the remote server port. [default: 5555]
-    --initialize-with-noc0           Initialize debugger context with NOC0 instead of the default NOC1. [default: False]
+    --noc-id=<id>                    NOC used for device communication (0/NOC0, 1/NOC1, 2/SYSTEM_NOC, case-insensitive). Defaults to the tt-exalens default.
     --verbosity=<verbosity>          Choose output verbosity. 1: ERROR, 2: WARN, 3: INFO, 4: VERBOSE, 5: DEBUG. [default: 3]
     --run=<script>                   Run specific script(s) by name. If not provided, all scripts will be run. [default: all]
     --skip-version-check             Do not enforce debugger version check. [default: False]
@@ -79,7 +79,7 @@ import importlib.metadata as importlib_metadata
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TimeElapsedColumn, TimeRemainingColumn, BarColumn, TextColumn
 import sys
-from ttexalens.context import Context, NocId
+from ttexalens.context import Context, to_noc_id
 from ttexalens.device import Device
 from ttexalens.coordinate import OnChipCoordinate
 from ttexalens.elf import ElfVariable
@@ -830,8 +830,10 @@ def _init_ttexalens(args: ScriptArguments) -> Context:
     if args["--remote-exalens"]:
         context = init_ttexalens_remote(ip_address=args["--remote-server"], port=args["--remote-port"])
     else:
-        noc_id = NocId.NOC0 if args["--initialize-with-noc0"] else NocId.NOC1
-        context = init_ttexalens(noc_id=noc_id)
+        if args["--noc-id"]:
+            context = init_ttexalens(noc_id=to_noc_id(args["--noc-id"]))
+        else:
+            context = init_ttexalens()
 
     _patch_risc_debug()
     return context


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
/
### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Bumps exalens version to latest, contains two important additions from exalens - using noc1 as default and support for booting up even if some devices deemed unhealthy by umd.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
/

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=onenezicTT-patch-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:onenezicTT-patch-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=onenezicTT-patch-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:onenezicTT-patch-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=onenezicTT-patch-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:onenezicTT-patch-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=onenezicTT-patch-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:onenezicTT-patch-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=onenezicTT-patch-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:onenezicTT-patch-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=onenezicTT-patch-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:onenezicTT-patch-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=onenezicTT-patch-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:onenezicTT-patch-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=onenezicTT-patch-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:onenezicTT-patch-2)