### PR TITLE
[Feature] zero_padded_kv_cache: Support row-major caches

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/test_zero_padded_kv_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_zero_padded_kv_cache.py
@@ -7,6 +7,7 @@ Seeds a block-cyclic cache with all-ones, runs the op, reconstructs natural orde
   * [valid_global, ceil_128(v))    zero  (pad window)
   * [ceil_128(v), :)               real (==1)  -- nothing past the window
 """
+
 import math
 
 import pytest
@@ -14,6 +15,7 @@ import torch
 from loguru import logger
 
 import ttnn
+from models.common.utility_functions import is_blackhole
 from models.demos.deepseek_v3_d_p.tt.mla.utils import blockcyclic_positions
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
 
@@ -31,31 +33,198 @@ _CASES = [
 ]
 _IDS = [f"v{v}_chip{ch}" if ch is not None else f"v{v}_aligned" for (_c, _s, v, ch) in _CASES]
 
+_FORMATS = [
+    (ttnn.bfloat8_b, ttnn.TILE_LAYOUT),
+    (ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT),
+    (ttnn.fp8_e4m3, ttnn.ROW_MAJOR_LAYOUT),
+]
+_FORMAT_IDS = ["bfp8_tile", "bf16_rm", "fp8_rm"]
+
+
+def _init_cache_filled_with_ones(
+    mesh_device,
+    *,
+    head_dim,
+    seq_len_cache,
+    chunk_size_global,
+    sp_axis,
+    dtype,
+    layout,
+    num_layers=1,
+    num_users=1,
+):
+    """Initialize a block-cyclic cache and overwrite every physical row with one."""
+    mesh_shape = list(mesh_device.shape)
+    cache = init_kvpe_cache(
+        head_dim,
+        mesh_device,
+        seq_len_cache,
+        mesh_shape,
+        sp_axis,
+        num_kvpe_cache_layers=num_layers,
+        num_users=num_users,
+        dtype=dtype,
+        layout=layout,
+    )
+    assert cache.dtype == dtype
+    assert cache.layout == layout
+
+    # FP8 cannot enter through this mesh-mapper path directly, so create BF16 row-major and typecast
+    # on device, matching the production MLA path.
+    ones = torch.ones(1, 1, chunk_size_global, head_dim, dtype=torch.bfloat16)
+    tt_ones = ttnn.from_torch(
+        ones,
+        device=mesh_device,
+        dtype=ttnn.bfloat16 if dtype == ttnn.fp8_e4m3 else dtype,
+        layout=layout,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_shape), dims=(2, None)),
+    )
+    if dtype == ttnn.fp8_e4m3:
+        tt_ones = ttnn.typecast(tt_ones, ttnn.fp8_e4m3)
+
+    assert seq_len_cache % chunk_size_global == 0
+    for slot_idx in range(num_users):
+        for layer_idx in range(num_layers):
+            for kv_actual_global in range(0, seq_len_cache, chunk_size_global):
+                ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
+                    cache,
+                    tt_ones,
+                    slot_idx=slot_idx,
+                    layer_idx=layer_idx,
+                    num_layers=num_layers,
+                    kv_actual_global=kv_actual_global,
+                    cluster_axis=sp_axis,
+                )
+    ttnn.synchronize_device(mesh_device)
+    return cache
+
+
+def _cache_in_natural_order(cache, mesh_device, *, chunk_size_global, seq_len_cache, sp_axis):
+    """Gather a block-cyclic mesh cache and restore natural token order."""
+    mesh_shape = list(mesh_device.shape)
+    cache_shard_order = ttnn.to_torch(
+        cache,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape),
+    ).to(torch.bfloat16)[:, :1]
+    positions = blockcyclic_positions(mesh_shape[sp_axis], chunk_size_global, seq_len_cache)
+    natural = torch.empty(cache_shard_order.shape[0], seq_len_cache, cache_shard_order.shape[-1], dtype=torch.bfloat16)
+    for batch_idx in range(cache_shard_order.shape[0]):
+        natural[batch_idx, positions] = cache_shard_order[batch_idx, 0]
+    return natural
+
+
+def _assert_cache_windows(
+    cache,
+    mesh_device,
+    *,
+    chunk_size_global,
+    seq_len_cache,
+    sp_axis,
+    num_layers,
+    windows,
+):
+    """Check exact zero windows while requiring every other cache element to remain one."""
+    natural = _cache_in_natural_order(
+        cache,
+        mesh_device,
+        chunk_size_global=chunk_size_global,
+        seq_len_cache=seq_len_cache,
+        sp_axis=sp_axis,
+    )
+    expected = torch.ones_like(natural)
+    for (slot_idx, layer_idx), (start, end) in windows.items():
+        expected[slot_idx * num_layers + layer_idx, start:end] = 0
+    assert torch.equal(natural, expected), (
+        f"cache mismatch: {torch.count_nonzero(natural != expected).item()} elements differ; "
+        f"actual range=[{natural.min().item()}, {natural.max().item()}]"
+    )
+
+
+@pytest.mark.parametrize("mesh_device", [(2, 4)], ids=["2x4"], indirect=True)
+@pytest.mark.parametrize("dtype,layout", _FORMATS, ids=_FORMAT_IDS)
+@pytest.mark.timeout(0)
+def test_zero_padded_kv_cache_program_cache_cross_chip(mesh_device, dtype, layout):
+    """Cover one cross-chip window and a program-cache hit with new runtime args."""
+    if dtype == ttnn.fp8_e4m3 and not is_blackhole():
+        pytest.skip("FP8_E4M3 is Blackhole-only")
+
+    sp_axis = 0
+    chunk_size_global = 384  # local=192: [180,256) crosses chip0 -> chip1
+    seq_len_cache = 384
+    head_dim = 64
+    num_users = 2
+    num_layers = 1
+
+    cache = _init_cache_filled_with_ones(
+        mesh_device,
+        head_dim=head_dim,
+        seq_len_cache=seq_len_cache,
+        chunk_size_global=chunk_size_global,
+        sp_axis=sp_axis,
+        dtype=dtype,
+        layout=layout,
+        num_layers=num_layers,
+        num_users=num_users,
+    )
+
+    mesh_device.enable_program_cache()
+    cache_entries_before = mesh_device.num_program_cache_entries()
+    windows = {
+        (0, 0): (180, 256),  # crosses chip0 -> chip1
+        (1, 0): (350, 384),  # same program, different slot and valid_global
+    }
+    for (slot_idx, layer_idx), (valid_global, _pad_end) in windows.items():
+        ttnn.experimental.deepseek_prefill.zero_padded_kv_cache(
+            cache,
+            slot_idx,
+            layer_idx,
+            num_layers,
+            valid_global,
+            chunk_size_global,
+            sp_axis,
+            128,
+        )
+    ttnn.synchronize_device(mesh_device)
+
+    _assert_cache_windows(
+        cache,
+        mesh_device,
+        chunk_size_global=chunk_size_global,
+        seq_len_cache=seq_len_cache,
+        sp_axis=sp_axis,
+        num_layers=num_layers,
+        windows=windows,
+    )
+
+    # Both calls share structural args, so slot/valid changes must reuse one program.
+    assert mesh_device.num_program_cache_entries() == cache_entries_before + 1
+
 
 @pytest.mark.parametrize("mesh_device", [(8, 4)], ids=["8x4"], indirect=True)
+@pytest.mark.parametrize("dtype,layout", _FORMATS, ids=_FORMAT_IDS)
 @pytest.mark.parametrize("chunk_size_global,seq_len_cache,valid_global,expected_chip", _CASES, ids=_IDS)
 @pytest.mark.timeout(0)
-def test_zero_padded_kv_cache(mesh_device, chunk_size_global, seq_len_cache, valid_global, expected_chip):
+def test_zero_padded_kv_cache(
+    mesh_device, dtype, layout, chunk_size_global, seq_len_cache, valid_global, expected_chip
+):
+    if dtype == ttnn.fp8_e4m3 and not is_blackhole():
+        pytest.skip("FP8_E4M3 is Blackhole-only")
+
     mesh_shape = list(mesh_device.shape)
     sp_axis = 0
     sp = mesh_shape[sp_axis]
-    tp = mesh_shape[1]
-    kvpe = 64
-    seq_len_local = seq_len_cache // sp
+    head_dim = 64
 
-    cache = init_kvpe_cache(kvpe, mesh_device, seq_len_cache, mesh_shape, sp_axis, num_kvpe_cache_layers=1)
-
-    # seed all-ones across the whole cache
-    ones = torch.ones(1, 1, seq_len_local, kvpe, dtype=torch.bfloat16)
-    tt_ones = ttnn.from_torch(
-        ones,
-        dtype=ttnn.bfloat8_b,
-        layout=ttnn.TILE_LAYOUT,
-        device=mesh_device,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    cache = _init_cache_filled_with_ones(
+        mesh_device,
+        head_dim=head_dim,
+        seq_len_cache=seq_len_cache,
+        chunk_size_global=chunk_size_global,
+        sp_axis=sp_axis,
+        dtype=dtype,
+        layout=layout,
     )
-    ttnn.fill_cache(cache, tt_ones, 0, update_idx=0)
-    ttnn.synchronize_device(mesh_device)
 
     if expected_chip is not None:
         tile_start = (valid_global // 32) * 32
@@ -69,29 +238,17 @@ def test_zero_padded_kv_cache(mesh_device, chunk_size_global, seq_len_cache, val
     )
     ttnn.synchronize_device(mesh_device)
 
-    # ---- reconstruct natural order ----
-    positions = blockcyclic_positions(sp, chunk_size_global, seq_len_cache)
-    natural = torch.zeros(seq_len_cache)
-    for di, dt in enumerate(ttnn.get_device_tensors(cache)):
-        if di % tp != 0:
-            continue
-        sp_coord = di // tp
-        rows = ttnn.to_torch(dt).float()[0, 0, :, :].mean(dim=-1)
-        for lr in range(seq_len_local):
-            natural[int(positions[sp_coord * seq_len_local + lr].item())] = rows[lr].item()
-
     ceil_v = math.ceil(valid_global / 128) * 128
-    real, pad, rest = natural[:valid_global], natural[valid_global:ceil_v], natural[ceil_v:]
-    logger.info(
-        f"v={valid_global} ceil128={ceil_v}: real.min={real.min():.2f} "
-        f"pad.max={pad.max() if len(pad) else 0:.2f} rest.min={rest.min() if len(rest) else 1:.2f}"
+    _assert_cache_windows(
+        cache,
+        mesh_device,
+        chunk_size_global=chunk_size_global,
+        seq_len_cache=seq_len_cache,
+        sp_axis=sp_axis,
+        num_layers=1,
+        windows={(0, 0): (valid_global, ceil_v)},
     )
-    assert real.min() > 0.9, f"real [0,{valid_global}) clobbered (min={real.min()})"
-    if len(pad):
-        assert pad.max() < 0.1, f"pad [{valid_global},{ceil_v}) not zeroed (max={pad.max()})"
-    if len(rest):
-        assert rest.min() > 0.9, f"rows past window [{ceil_v},:) touched (min={rest.min()})"
-    logger.success(f"zero_padded_kv_cache v={valid_global} PASSED")
+    logger.success(f"zero_padded_kv_cache {layout} {dtype} v={valid_global} PASSED")
 
 
 # (num_layers, num_users, slot_idx, layer_idx, valid_global, expected_chip) -- exercises the cache

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/kernels/compute/zero_padded_kv_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/kernels/compute/zero_padded_kv_cache.cpp
@@ -7,7 +7,7 @@
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/common.h"
 #include "api/dataflow/circular_buffer.h"
-#include "../zero_padded_kv_cache_common.hpp"
+#include "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/kernels/zero_padded_kv_cache_common.hpp"
 
 // Multiplies the boundary (partial) pad tile by the row-mask, zeroing the pad rows while preserving
 // the real rows. Only runs on the chip that owns the partial tile. The mask is a single tile reused

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/kernels/dataflow/reader_zero_padded_kv_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/kernels/dataflow/reader_zero_padded_kv_cache.cpp
@@ -8,7 +8,7 @@
 #include "api/dataflow/circular_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
-#include "../zero_padded_kv_cache_common.hpp"
+#include "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/kernels/zero_padded_kv_cache_common.hpp"
 
 // Reads the boundary (partial) pad tile from the cache into the src CB, and builds the bf16 row-mask
 // tile (rows [0,row_start) = 1.0, rows [row_start,32) = 0.0) into the mask CB. Only runs on the chip

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/kernels/dataflow/writer_zero_padded_kv_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/kernels/dataflow/writer_zero_padded_kv_cache.cpp
@@ -7,7 +7,7 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
-#include "../zero_padded_kv_cache_common.hpp"
+#include "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/kernels/zero_padded_kv_cache_common.hpp"
 
 // Writes this chip's share of the pad window back to the cache: the masked partial tile (from the
 // compute out CB) goes back to the boundary seq-tile, and every fully-pad seq-tile is zeroed in

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/kernels/dataflow/writer_zero_padded_kv_cache_row_major.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/kernels/dataflow/writer_zero_padded_kv_cache_row_major.cpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/kernels/zero_padded_kv_cache_common.hpp"
+
+// Dataflow-only ROW_MAJOR pad cleanup. A cache page is one token row (including aligned row padding),
+// so stream an all-zero L1 row to exactly [valid_global, ceil_pad(valid_global)). This works for BF16
+// and FP8_E4M3 because the unpack/compute engine never touches the payload.
+void kernel_main() {
+    constexpr uint32_t zero_cb = get_compile_time_arg_val(0);
+    constexpr uint32_t row_page_bytes = get_compile_time_arg_val(1);
+    constexpr auto cache_args = TensorAccessorArgs<2>();
+
+    const uint32_t cache_addr = get_arg_val<uint32_t>(0);
+    const ZeroPadRowMajorChipWork w = zero_pad_compute_row_major_chip_work();
+    if (w.count == 0) {
+        return;
+    }
+
+    const auto cache = TensorAccessor(cache_args, cache_addr, row_page_bytes);
+    CircularBuffer zero(zero_cb);
+    zero.reserve_back(1);
+
+    Noc noc;
+    noc.async_write_zeros(zero, row_page_bytes);
+    noc.write_zeros_l1_barrier();
+
+    const uint32_t first_page = w.batch_page_base + w.base_local_row;
+    const uint32_t last_page = first_page + w.count;
+    for (uint32_t page = first_page; page < last_page; ++page) {
+        noc.async_write_zeros(cache, row_page_bytes, {.page_id = page}, zero);
+    }
+    noc.write_zeros_dram_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/kernels/zero_padded_kv_cache_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/kernels/zero_padded_kv_cache_common.hpp
@@ -11,7 +11,40 @@
 //
 // Common runtime arg layout (set in create_descriptor; indices 3 and 9 patched per call):
 //   0 my_sp_coord  1 sp_factor  2 chunk_local(tokens)  3 valid_global  4 pad_align
-//   5 layer_idx    6 num_layers 7 Wt                   8 cache_CHtWt   9 slot_idx
+//   5 layer_idx    6 num_layers 7 Wt                   8 cache_CH_pages 9 slot_idx
+struct ZeroPadTokenRange {
+    uint32_t count;
+    uint32_t base_local_token;
+};
+
+// Validation guarantees that [valid_global, ceil_pad(valid_global)) remains in one block-cyclic slab.
+// Intersect that window with this chip's contiguous slice of the slab, then map the intersection to the
+// chip-local cache rows. Both TILE and ROW_MAJOR paths derive their native page ranges from this result.
+inline ZeroPadTokenRange zero_pad_compute_token_range() {
+    const uint32_t my = get_common_arg_val<uint32_t>(0);
+    const uint32_t sp = get_common_arg_val<uint32_t>(1);
+    const uint32_t chunk_local = get_common_arg_val<uint32_t>(2);
+    const uint32_t valid_global = get_common_arg_val<uint32_t>(3);
+    const uint32_t pad_align = get_common_arg_val<uint32_t>(4);
+
+    const uint32_t pad_end = ((valid_global + pad_align - 1) / pad_align) * pad_align;
+    if (pad_end == valid_global) {
+        return {0, 0};
+    }
+
+    const uint32_t chunk_global = sp * chunk_local;
+    const uint32_t slab = valid_global / chunk_global;
+    const uint32_t chip_begin = slab * chunk_global + my * chunk_local;
+    const uint32_t chip_end = chip_begin + chunk_local;
+    const uint32_t begin = valid_global > chip_begin ? valid_global : chip_begin;
+    const uint32_t end = pad_end < chip_end ? pad_end : chip_end;
+    if (begin >= end) {
+        return {0, 0};
+    }
+
+    return {end - begin, slab * chunk_local + begin - chip_begin};
+}
+
 struct ZeroPadChipWork {
     uint32_t count;            // number of seq-tiles this chip zeroes (0 => nothing to do)
     uint32_t base_local_tile;  // first owned local seq-tile index
@@ -22,11 +55,6 @@ struct ZeroPadChipWork {
 };
 
 inline ZeroPadChipWork zero_pad_compute_chip_work() {
-    const uint32_t my = get_common_arg_val<uint32_t>(0);
-    const uint32_t sp = get_common_arg_val<uint32_t>(1);
-    const uint32_t chunk_local = get_common_arg_val<uint32_t>(2);
-    const uint32_t v = get_common_arg_val<uint32_t>(3);
-    const uint32_t pad = get_common_arg_val<uint32_t>(4);
     const uint32_t layer = get_common_arg_val<uint32_t>(5);
     const uint32_t num_layers = get_common_arg_val<uint32_t>(6);
     const uint32_t Wt = get_common_arg_val<uint32_t>(7);
@@ -34,31 +62,35 @@ inline ZeroPadChipWork zero_pad_compute_chip_work() {
     const uint32_t slot = get_common_arg_val<uint32_t>(9);
 
     ZeroPadChipWork w{0, 0, 0, 0, Wt, (slot * num_layers + layer) * cache_CHtWt};
+    const ZeroPadTokenRange range = zero_pad_compute_token_range();
+    if (range.count == 0) {
+        return w;
+    }
 
-    const uint32_t pad_end = ((v + pad - 1) / pad) * pad;  // ceil_pad(v)
-    if (pad_end == v) {
-        return w;  // valid_global pad-aligned: no pad tail
-    }
-    const uint32_t csg = sp * chunk_local;
-    const uint32_t first_gt = v / 32;       // first window seq-tile (global)
-    const uint32_t last_gt = pad_end / 32;  // exclusive
-    const uint32_t row_start = v % 32;
-    bool found = false;
-    for (uint32_t gt = first_gt; gt < last_gt; ++gt) {
-        const uint32_t token = gt * 32;
-        const uint32_t chip = (token % csg) / chunk_local;
-        if (chip != my) {
-            continue;
-        }
-        const uint32_t local_token = (token / csg) * chunk_local + (token % csg) % chunk_local;
-        const uint32_t local_tile = local_token / 32;
-        if (!found) {
-            w.base_local_tile = local_tile;
-            w.first_partial = (gt == first_gt && row_start != 0) ? 1u : 0u;
-            w.row_start = row_start;
-            found = true;
-        }
-        ++w.count;
-    }
+    constexpr uint32_t tile_height = 32;
+    w.base_local_tile = range.base_local_token / tile_height;
+    w.count = (range.base_local_token + range.count) / tile_height - range.base_local_token / tile_height;
+    w.row_start = range.base_local_token % tile_height;
+    w.first_partial = w.row_start != 0 ? 1u : 0u;
     return w;
+}
+
+// ROW_MAJOR counterpart: one page is one token row, so the exact window [valid_global, pad_end) can
+// be zeroed without reading or masking a boundary tile. Validation keeps the window within one
+// block-cyclic slab; therefore each chip's owned rows form one contiguous local page range even when
+// the global window crosses a chip boundary.
+struct ZeroPadRowMajorChipWork {
+    uint32_t count;
+    uint32_t base_local_row;
+    uint32_t batch_page_base;
+};
+
+inline ZeroPadRowMajorChipWork zero_pad_compute_row_major_chip_work() {
+    const uint32_t layer = get_common_arg_val<uint32_t>(5);
+    const uint32_t num_layers = get_common_arg_val<uint32_t>(6);
+    const uint32_t cache_CH_pages = get_common_arg_val<uint32_t>(8);
+    const uint32_t slot = get_common_arg_val<uint32_t>(9);
+
+    const ZeroPadTokenRange range = zero_pad_compute_token_range();
+    return {range.count, range.base_local_token, (slot * num_layers + layer) * cache_CH_pages};
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/zero_padded_kv_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/zero_padded_kv_cache_device_operation.cpp
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 #include <utility>
+#include <vector>
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
@@ -35,6 +36,9 @@ constexpr auto kComputeKernelPath =
 constexpr auto kWriterKernelPath =
     "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/kernels/dataflow/"
     "writer_zero_padded_kv_cache.cpp";
+constexpr auto kRowMajorWriterKernelPath =
+    "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/kernels/dataflow/"
+    "writer_zero_padded_kv_cache_row_major.cpp";
 
 constexpr uint32_t kSrcCbIndex = 0;   // partial tile read from cache (cache dtype)
 constexpr uint32_t kMaskCbIndex = 1;  // row-mask tile built in the reader (bf16)
@@ -105,7 +109,19 @@ void ZeroPaddedKvCacheDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& cache = tensor_args.cache;
     TT_FATAL(cache.storage_type() == StorageType::DEVICE, "cache must be on device");
-    TT_FATAL(cache.layout() == Layout::TILE, "cache must be TILE layout");
+    TT_FATAL(cache.buffer()->buffer_type() == BufferType::DRAM, "zero_padded_kv_cache requires a DRAM-backed cache");
+    TT_FATAL(
+        cache.layout() == Layout::TILE || cache.layout() == Layout::ROW_MAJOR,
+        "cache layout must be TILE or ROW_MAJOR");
+    if (cache.layout() == Layout::ROW_MAJOR) {
+        TT_FATAL(
+            cache.dtype() == DataType::BFLOAT16 || cache.dtype() == DataType::FP8_E4M3,
+            "ROW_MAJOR zero_padded_kv_cache supports bfloat16 or fp8_e4m3 (got {})",
+            cache.dtype());
+    }
+    if (cache.dtype() == DataType::FP8_E4M3) {
+        TT_FATAL(cache.layout() == Layout::ROW_MAJOR, "fp8_e4m3 cache must be ROW_MAJOR");
+    }
     const auto& cache_shape = cache.padded_shape();
     TT_FATAL(cache_shape.rank() == 4, "cache must be 4D (got rank {})", cache_shape.rank());
     TT_FATAL(cache_shape[1] == 1, "cache num-heads dim must be 1 (got {})", cache_shape[1]);
@@ -150,6 +166,7 @@ ttsl::hash::hash_t ZeroPaddedKvCacheDeviceOperation::compute_program_hash(
         args.chunk_size_global,
         args.pad_align,
         cache.dtype(),
+        cache.layout(),
         cache.memory_config(),
         cache.padded_shape());
 }
@@ -167,13 +184,10 @@ tt::tt_metal::ProgramDescriptor ZeroPaddedKvCacheDeviceOperation::ProgramFactory
     const auto& cache_shape = cache.padded_shape();
 
     const tt::DataFormat cache_format = datatype_to_dataformat_converter(cache.dtype());
-    const uint32_t cache_tile_size = tt::tile_size(cache_format);
-    const tt::DataFormat mask_format = tt::DataFormat::Float16_b;
-    const uint32_t mask_tile_size = tt::tile_size(mask_format);
-
-    const uint32_t Wt = cache_shape[-1] / TILE_WIDTH;
-    const uint32_t cache_HtWt = cache_shape[-2] * Wt / TILE_HEIGHT;
-    const uint32_t cache_CHtWt = cache_shape[1] * cache_HtWt;
+    const bool is_row_major = cache.layout() == Layout::ROW_MAJOR;
+    const uint32_t Wt = is_row_major ? 1 : cache_shape[-1] / TILE_WIDTH;
+    const uint32_t cache_H_pages = is_row_major ? cache_shape[-2] : cache_shape[-2] * Wt / TILE_HEIGHT;
+    const uint32_t cache_CH_pages = cache_shape[1] * cache_H_pages;
 
     const auto& mesh_view = device->get_view();
     const uint32_t sp_factor = (args.cluster_axis == 0) ? mesh_view.num_rows() : mesh_view.num_cols();
@@ -184,6 +198,52 @@ tt::tt_metal::ProgramDescriptor ZeroPaddedKvCacheDeviceOperation::ProgramFactory
     CoreRangeSet all_cores(CoreRange({0, 0}, {0, 0}));
 
     tt::tt_metal::ProgramDescriptor desc;
+
+    // Keep one common-argument layout for both descriptors. Page units are native to the layout:
+    // width-tiles for TILE, one complete token row for ROW_MAJOR.
+    const std::vector<uint32_t> common_runtime_args = {
+        my_sp_coord,
+        sp_factor,
+        chunk_local,
+        args.valid_global,
+        args.pad_align,
+        args.layer_idx,
+        args.num_layers,
+        Wt,
+        cache_CH_pages,
+        args.slot_idx,
+    };
+
+    if (is_row_major) {
+        // A row is one opaque DRAM page. Use a dataflow-only zero writer so FP8 never enters the
+        // unpack/compute engine (and therefore needs no fp32 destination accumulator setting).
+        const uint32_t row_page_size = cache.buffer()->aligned_page_size();
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = row_page_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = kZeroCbIndex,
+                .data_format = cache_format,
+                .page_size = row_page_size,
+            }}},
+        });
+
+        KernelDescriptor writer;
+        writer.kernel_source = kRowMajorWriterKernelPath;
+        writer.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        writer.core_ranges = all_cores;
+        writer.compile_time_args = {kZeroCbIndex, row_page_size};
+        TensorAccessorArgs(cache.buffer()).append_to(writer.compile_time_args);
+        writer.config = WriterConfigDescriptor{};
+        writer.common_runtime_args = common_runtime_args;
+        writer.emplace_runtime_args(CoreCoord{0, 0}, {cache.buffer()});
+        desc.kernels.push_back(std::move(writer));
+        return desc;
+    }
+
+    const uint32_t cache_tile_size = tt::tile_size(cache_format);
+    const tt::DataFormat mask_format = tt::DataFormat::Float16_b;
+    const uint32_t mask_tile_size = tt::tile_size(mask_format);
 
     // CBs: src (partial tile read), mask (bf16 row-mask), out (masked partial), zero (write scratch).
     auto add_cb = [&](uint32_t index, tt::DataFormat fmt, uint32_t page, uint32_t npages) {
@@ -198,23 +258,6 @@ tt::tt_metal::ProgramDescriptor ZeroPaddedKvCacheDeviceOperation::ProgramFactory
     add_cb(kOutCbIndex, cache_format, cache_tile_size, Wt);
     add_cb(kZeroCbIndex, cache_format, cache_tile_size, 1);
 
-    // Common runtime args, shared layout across all three kernels (each recomputes its share of the
-    // window from these). Index 3 = valid_global, 9 = slot_idx are the per-call scalars patched on
-    // cache hits by override_runtime_arguments.
-    // Layout: 0 my_sp_coord, 1 sp_factor, 2 chunk_local(tokens), 3 valid_global, 4 pad_align,
-    //         5 layer_idx, 6 num_layers, 7 Wt, 8 cache_CHtWt, 9 slot_idx.
-#define ZP_COMMON_ARGS  \
-    {my_sp_coord,       \
-     sp_factor,         \
-     chunk_local,       \
-     args.valid_global, \
-     args.pad_align,    \
-     args.layer_idx,    \
-     args.num_layers,   \
-     Wt,                \
-     cache_CHtWt,       \
-     args.slot_idx}
-
     // Reader: reads cache (TensorAccessor) + builds mask.
     KernelDescriptor reader;
     reader.kernel_source = kReaderKernelPath;
@@ -223,7 +266,7 @@ tt::tt_metal::ProgramDescriptor ZeroPaddedKvCacheDeviceOperation::ProgramFactory
     reader.compile_time_args = {kSrcCbIndex, kMaskCbIndex, cache_tile_size};
     TensorAccessorArgs(cache.buffer()).append_to(reader.compile_time_args);
     reader.config = ReaderConfigDescriptor{};
-    reader.emplace_common_runtime_args(ZP_COMMON_ARGS);
+    reader.common_runtime_args = common_runtime_args;
     reader.emplace_runtime_args(CoreCoord{0, 0}, {cache.buffer()});
 
     // Compute: partial x mask -> out.
@@ -233,7 +276,7 @@ tt::tt_metal::ProgramDescriptor ZeroPaddedKvCacheDeviceOperation::ProgramFactory
     compute.core_ranges = all_cores;
     compute.compile_time_args = {kSrcCbIndex, kMaskCbIndex, kOutCbIndex};
     compute.config = ComputeConfigDescriptor{};
-    compute.emplace_common_runtime_args(ZP_COMMON_ARGS);
+    compute.common_runtime_args = common_runtime_args;
     compute.emplace_runtime_args(CoreCoord{0, 0}, {0u});  // compute reads only common args; dummy per-core arg
 
     // Writer: masked partial back + zero full tiles from the zero scratch.
@@ -244,10 +287,8 @@ tt::tt_metal::ProgramDescriptor ZeroPaddedKvCacheDeviceOperation::ProgramFactory
     writer.compile_time_args = {kOutCbIndex, kZeroCbIndex, cache_tile_size};
     TensorAccessorArgs(cache.buffer()).append_to(writer.compile_time_args);
     writer.config = WriterConfigDescriptor{};
-    writer.emplace_common_runtime_args(ZP_COMMON_ARGS);
+    writer.common_runtime_args = common_runtime_args;
     writer.emplace_runtime_args(CoreCoord{0, 0}, {cache.buffer()});
-#undef ZP_COMMON_ARGS
-
     desc.kernels.push_back(std::move(reader));
     desc.kernels.push_back(std::move(compute));
     desc.kernels.push_back(std::move(writer));
@@ -269,10 +310,11 @@ void ZeroPaddedKvCacheDeviceOperation::MeshWorkloadFactory::override_runtime_arg
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output) {
     descriptor_adapter_t::apply_descriptor(cached_workload, args, tensor_args, output);
-    // Patch the per-call valid_global/slot_idx scalars in the reader (kernel 0) and writer (kernel 2)
-    // common args; the compute (kernel 1) also reads them. Same value on every program (chip).
+    // TILE has reader/compute/writer; ROW_MAJOR is a dataflow-only writer. Patch every kernel in the
+    // selected descriptor without assuming one fixed kernel count.
+    const uint32_t num_kernels = tensor_args.cache.layout() == Layout::ROW_MAJOR ? 1u : 3u;
     for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
-        for (uint32_t kernel_handle : {0u, 1u, 2u}) {
+        for (uint32_t kernel_handle = 0; kernel_handle < num_kernels; ++kernel_handle) {
             auto& common = GetCommonRuntimeArgs(program, kernel_handle);
             TT_FATAL(kSlotIdxCommonArgIdx < common.size(), "zero_padded_kv_cache kernel missing per-call common args");
             common[kValidGlobalCommonArgIdx] = args.valid_global;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/zero_padded_kv_cache.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/zero_padded_kv_cache.hpp
@@ -17,8 +17,11 @@ namespace ttnn::operations::experimental::deepseek_prefill::zero_padded_kv_cache
 // pad_align-1 tokens (1-4 tiles) and may straddle a chip boundary -- each chip zeroes its own share,
 // derived from valid_global + chunk_size_global + the device's coordinate along cluster_axis.
 //
-// The boundary (partial) tile is read, multiplied by an in-kernel row-mask and written back; the
-// fully-pad tiles are written from the L1 zeros buffer.
+// Cache must be DRAM-backed. TILE layout uses the existing mask/compute path: the boundary
+// (partial) tile is read, multiplied by an in-kernel row-mask and written back; fully-pad tiles are
+// written from an L1 zeros buffer. ROW_MAJOR layout supports BF16 and FP8_E4M3 and uses a
+// dataflow-only path that writes zeroed token rows directly, so its payload never enters the
+// unpack/compute engine.
 //
 // Cache slot is addressed users-outer, layers-inner: batch_idx = slot_idx * num_layers + layer_idx.
 // valid_global and slot_idx are per-call scalars (patched on cache hits, out of the program hash).

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/zero_padded_kv_cache_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/zero_padded_kv_cache_nanobind.cpp
@@ -25,16 +25,19 @@ void bind_zero_padded_kv_cache(nb::module_& mod) {
             pad_align boundary hold stale data; this op clears them so the decode side reads
             clean zeros. The window is up to pad_align-1 tokens (1-4 tiles) and may straddle a
             chip boundary -- each device zeroes its own share, derived from valid_global,
-            chunk_size_global and its coordinate along cluster_axis. The boundary (partial)
-            tile is read, multiplied by an in-kernel row-mask and written back; the fully-pad
-            tiles are written from the L1 zeros buffer.
+            chunk_size_global and its coordinate along cluster_axis. TILE layout uses the
+            mask/compute path: the boundary (partial) tile is read, multiplied by an in-kernel
+            row-mask and written back; fully-pad tiles are written from an L1 zeros buffer.
+            ROW_MAJOR BF16 and FP8_E4M3 caches use a dataflow-only path that zeroes complete
+            token rows directly, so the payload never enters the unpack/compute engine.
 
             Cache slot is linearized users-outer, layers-inner: batch_idx = slot_idx*num_layers
             + layer_idx. ``valid_global`` and ``slot_idx`` are per-call scalars patched on cache
             hits, out of the program hash.
 
             Args:
-                cache (ttnn.Tensor): 4D KV cache tensor on device, TILE layout, head dim 1.
+                cache (ttnn.Tensor): 4D, DRAM-backed KV cache tensor with head dim 1. Supports
+                    TILE layout, or ROW_MAJOR layout with BF16 or FP8_E4M3 dtype.
                 slot_idx (int): user slot in the batched prefill cache.
                 layer_idx (int): Transformer layer index for this call (hashed/structural).
                 num_layers (int): Total layers folded into the cache batch dim (structural).


### PR DESCRIPTION
### PR Category
Feature

### Summary
Extends zero_padded_kv_cache to support row-major BF16 and FP8 E4M3 caches while preserving the existing tiled path. The row-major implementation uses a dataflow-only zero writer so FP8 data does not enter the unpack/compute engine.

The existing semantic test is now parameterized by dtype and layout, with shared cache-seeding and natural-order validation helpers. One compact 2x4 case covers an SP-boundary-crossing window and program-cache runtime-argument updates.

### Motivation
This is a foundational change for scaled-FP8 KV-cache support in DSA/GLM. The complete feature integration is available on [pjosipovic/fp8-sparse-kv-cache](https://github.com/tenstorrent/tt-metal/tree/pjosipovic/fp8-sparse-kv-cache).

### Testing
- Release build: cmake --build build_Release -j8
- pytest -q models/demos/deepseek_v3_d_p/tests/test_zero_padded_kv_cache.py
- Local result on an 8-device Blackhole host: 3 passed, 22 skipped
- The three compact tiled BFP8, row-major BF16, and row-major FP8 cases passed. The inherited 8x4 semantic matrix, including its 18 format variants, requires 32 devices and was collected but skipped locally.

No hardware CI workflow was triggered because this op and test file currently have no CI coverage.

### Notes for reviewers
Please focus on native row-page indexing, descriptor-specific program-cache runtime argument updates, and preservation of the tiled implementation. Initial FP8 cache zero-fill behavior belongs to the separate DRAMZeroFill change.

### Recommended CI
No existing workflow executes this exact test. The appropriate future coverage is the (Blackhole) e2e tests workflow, in the bh-lb-deepseek-prefill-op-tests group, after wiring this test into that matrix.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/row-major-zero-padded-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/row-major-zero-padded-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/row-major-zero-padded-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/row-major-zero-padded-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pjosipovic/row-major-zero-padded-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pjosipovic/row-major-zero-padded-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/row-major-zero-padded-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/row-major-zero-padded-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/row-major-zero-padded-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/row-major-zero-padded-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/row-major-zero-padded-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/row-major-zero-padded-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/row-major-zero-padded-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/row-major-zero-padded-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/row-major-zero-padded-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/row-major-zero-padded-kv-cache)