### PR TITLE
[Feature] copy: Support row-major FP8 tensors

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_copy.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_copy.py
@@ -11,6 +11,7 @@ import torch
 import ttnn
 import math
 
+from models.common.utility_functions import is_blackhole
 from tests.ttnn.utils_for_testing import assert_equal, assert_allclose, assert_with_pcc
 
 pytestmark = pytest.mark.use_module_device
@@ -47,6 +48,42 @@ def test_copy_uint16(shape, device):
     ttnn.copy(input_tensor, output_tensor)
     assert output_tensor.shape == input_tensor.shape
     assert_equal(ttnn.to_torch(input_tensor), ttnn.to_torch(output_tensor))
+
+
+def test_copy_fp8_e4m3_row_major_sharded_to_interleaved(device):
+    """FP8 copy is an opaque row-page move; compare exactly after widening both sides to BF16."""
+    if not is_blackhole():
+        pytest.skip("FP8_E4M3 is Blackhole-only")
+
+    torch.manual_seed(2005)
+    shape = [1, 1, 32, 64]
+    source = torch.randn(shape, dtype=torch.bfloat16)
+    shard_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))])
+    shard_spec = ttnn.ShardSpec(shard_grid, (32, 64), ttnn.ShardOrientation.ROW_MAJOR)
+    sharded_memory_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
+
+    source_bf16 = ttnn.from_torch(
+        source,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=sharded_memory_config,
+    )
+    source_fp8 = ttnn.typecast(source_bf16, ttnn.fp8_e4m3)
+    destination_bf16 = ttnn.from_torch(
+        torch.zeros_like(source),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    destination_fp8 = ttnn.typecast(destination_bf16, ttnn.fp8_e4m3)
+
+    ttnn.copy(source_fp8, destination_fp8)
+
+    expected = ttnn.to_torch(ttnn.typecast(source_fp8, ttnn.bfloat16))
+    actual = ttnn.to_torch(ttnn.typecast(destination_fp8, ttnn.bfloat16))
+    assert_equal(expected, actual)
 
 
 # Test for block sharding

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.cpp
@@ -82,8 +82,9 @@ void CopyDeviceOperation::validate_on_program_cache_miss(
         input_tensor_a.dtype() == DataType::BFLOAT16 or input_tensor_a.dtype() == DataType::BFLOAT8_B or
             input_tensor_a.dtype() == DataType::FLOAT32 or input_tensor_a.dtype() == DataType::BFLOAT4_B or
             input_tensor_a.dtype() == DataType::UINT32 or input_tensor_a.dtype() == DataType::INT32 or
-            input_tensor_a.dtype() == DataType::UINT16 or input_tensor_a.dtype() == DataType::UINT8,
-        "ttnn.copy only supports float, bfloat, int32, uint32, uint16 and uint8 inputs but got {}",
+            input_tensor_a.dtype() == DataType::UINT16 or input_tensor_a.dtype() == DataType::UINT8 or
+            input_tensor_a.dtype() == DataType::FP8_E4M3,
+        "ttnn.copy only supports float, bfloat, fp8_e4m3, int32, uint32, uint16 and uint8 inputs but got {}",
         input_tensor_a.dtype());
     TT_FATAL(
         operation_attributes.output_dtype == DataType::BFLOAT16 or
@@ -93,8 +94,9 @@ void CopyDeviceOperation::validate_on_program_cache_miss(
             operation_attributes.output_dtype == DataType::UINT32 or
             operation_attributes.output_dtype == DataType::INT32 or
             operation_attributes.output_dtype == DataType::UINT16 or
-            operation_attributes.output_dtype == DataType::UINT8,
-        "ttnn.copy only supports float, bfloat, int32, uint32, uint16 and uint8 output tensors but got {}",
+            operation_attributes.output_dtype == DataType::UINT8 or
+            operation_attributes.output_dtype == DataType::FP8_E4M3,
+        "ttnn.copy only supports float, bfloat, fp8_e4m3, int32, uint32, uint16 and uint8 output tensors but got {}",
         operation_attributes.output_dtype);
     TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands to copy need to be on device!");
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands to copy need to be allocated in buffers on device!");


### PR DESCRIPTION
### PR Category
Feature

### Summary
Allows ttnn.copy to accept FP8 E4M3 input and output tensors. This enables row-major FP8 sharded-to-interleaved copies while retaining the existing dtype validation for unsupported formats.


### Motivation
This is a foundational change for scaled-FP8 KV-cache support in DSA/GLM. The complete feature integration is available on [pjosipovic/fp8-sparse-kv-cache](https://github.com/tenstorrent/tt-metal/tree/pjosipovic/fp8-sparse-kv-cache).


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/row-major-fp8-copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/row-major-fp8-copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/row-major-fp8-copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/row-major-fp8-copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pjosipovic/row-major-fp8-copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pjosipovic/row-major-fp8-copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/row-major-fp8-copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/row-major-fp8-copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/row-major-fp8-copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/row-major-fp8-copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/row-major-fp8-copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/row-major-fp8-copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/row-major-fp8-copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/row-major-fp8-copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/row-major-fp8-copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/row-major-fp8-copy)