### PR TITLE
[Feature] DRAMZeroFill: Support row-major FP8 pages

### DIFF
--- a/models/demos/deepseek_v3_b1/micro_ops/dram_zero_fill/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/dram_zero_fill/op.py
@@ -6,14 +6,12 @@
 DRAM Zero Fill micro op.
 
 Writes zeros to all pages of a DRAM tensor using a kernel on the device's full
-compute grid.  Each core zeroes a single L1 tile and then writes it to its
+compute grid.  Each core zeroes a single native L1 page and then writes it to its
 assigned slice of DRAM pages via noc_async_write_page + TensorAccessor.
 
 This replaces the host-side ttnn.from_torch / ttnn.zeros pattern for
 zero-initialization, avoiding the host-to-device transfer entirely.
 """
-
-import math
 
 import ttnn
 from models.demos.deepseek_v3_b1.micro_ops.flash_mla.op import FlashMLADecode
@@ -30,7 +28,7 @@ DEFAULT_K_CHUNK_SIZE = 128
 
 
 class DRAMZeroFill:
-    """Zero-fill a pre-allocated DRAM tensor using a device kernel."""
+    """Zero-fill a pre-allocated TILE or ROW_MAJOR DRAM tensor using a dataflow kernel."""
 
     @staticmethod
     def allocate_kv_cache_on_device(
@@ -119,7 +117,11 @@ class DRAMZeroFill:
         Returns:
             The same tensor, now filled with zeros.
         """
-        page_size = TILE_32x32.get_tile_size(output_tensor.dtype)
+        # Use the buffer's native page geometry. TILE pages are 32x32 tiles; ROW_MAJOR pages are one
+        # complete tensor row (including device alignment). TensorAccessor and noc_async_write_page
+        # use this same page table, so no dtype-specific arithmetic or format conversion is needed.
+        page_size = output_tensor.buffer_aligned_page_size()
+        total_pages = output_tensor.buffer_num_pages()
 
         # Use the device's full compute grid.  The kernel partitions pages
         # across whatever rectangle it is given, so this adapts to harvested
@@ -132,18 +134,12 @@ class DRAMZeroFill:
             raise ValueError(f"DRAMZeroFill requires a non-empty compute grid: actual=({grid_x}, {grid_y})")
 
         shape = output_tensor.shape
-        if shape[-2] % 32 != 0 or shape[-1] % 32 != 0:
+        if output_tensor.layout == ttnn.TILE_LAYOUT and (shape[-2] % 32 != 0 or shape[-1] % 32 != 0):
             raise ValueError(
-                "DRAMZeroFill requires the last two tensor dimensions to be multiples of 32: "
+                "DRAMZeroFill requires TILE tensor dimensions to be multiples of 32: "
                 f"got shape={list(shape)}, shape[-2]={shape[-2]}, shape[-1]={shape[-1]}"
             )
-        tile_rows = shape[-2] // 32
-        tile_cols = shape[-1] // 32
-        batch_tiles = 1
-        for d in range(len(shape) - 2):
-            batch_tiles *= shape[d]
-        total_pages = batch_tiles * tile_rows * tile_cols
-        pages_per_core = math.ceil(total_pages / num_cores)
+        pages_per_core = (total_pages + num_cores - 1) // num_cores
 
         core_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_x - 1, grid_y - 1))])
 
@@ -161,12 +157,14 @@ class DRAMZeroFill:
             ("grid_end_y", grid_y - 1),
         ]
 
-        cb_format = ttnn.CBFormatDescriptor(
+        cb_format_kwargs = dict(
             buffer_index=OUTPUT_CB,
             data_format=output_tensor.dtype,
             page_size=page_size,
-            tile=ttnn.TileDescriptor(TILE_32x32),
         )
+        if output_tensor.layout == ttnn.TILE_LAYOUT:
+            cb_format_kwargs["tile"] = ttnn.TileDescriptor(TILE_32x32)
+        cb_format = ttnn.CBFormatDescriptor(**cb_format_kwargs)
         cb_descriptor = ttnn.CBDescriptor(
             total_size=page_size,
             core_ranges=core_grid,
@@ -181,6 +179,12 @@ class DRAMZeroFill:
             ncrisc_compile_time_args=ncrisc_compile_time_args,
             ncrisc_named_compile_time_args=ncrisc_named,
             ncrisc_common_runtime_args=ncrisc_common_runtime_args,
+            # UnifiedKernelDescriptor emits a no-op TRISC alongside the NCRISC writer. Blackhole
+            # requires 32-bit DEST mode whenever any CB on that core is FP8, even when TRISC never
+            # consumes it.
+            trisc_compute_config=ttnn.ComputeConfigDescriptor(
+                fp32_dest_acc_en=output_tensor.dtype == ttnn.fp8_e4m3,
+            ),
         )
 
         kernel_result = kernel_desc.get_kernel_descriptors()

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_zero_fill.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_zero_fill.py
@@ -51,6 +51,31 @@ def _build_reference_kv_tensor(submesh, num_users, max_seq_len):
 
 
 @pytest.mark.parametrize(
+    "dtype,layout",
+    [
+        (ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT),
+        (ttnn.fp8_e4m3, ttnn.ROW_MAJOR_LAYOUT),
+    ],
+    ids=["bf16_row_major", "fp8_e4m3_row_major"],
+)
+def test_dram_zero_fill_row_major_formats(bh_2d_mesh_device, dtype, layout):
+    """Exercise native row pages directly; FP8 is widened only for host readback."""
+    output = ttnn.allocate_tensor_on_device(
+        ttnn.Shape([1, 1, 128, KVPE_DIM]),
+        dtype,
+        layout,
+        bh_2d_mesh_device,
+        ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    DRAMZeroFill.op(output)
+    ttnn.synchronize_device(bh_2d_mesh_device)
+
+    result = ttnn.to_torch(output, mesh_composer=ttnn.ConcatMeshToTensor(bh_2d_mesh_device, dim=0))
+    assert torch.equal(result.float(), torch.zeros_like(result, dtype=torch.float32))
+
+
+@pytest.mark.parametrize(
     "device_params",
     [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
     indirect=True,


### PR DESCRIPTION
### PR Category
Feature

### Summary
Extends the DeepSeek DRAMZeroFill micro-op to initialize row-major FP8 E4M3 pages. Page sizing and kernel configuration now follow the tensor layout instead of assuming tiled storage.



### Motivation
This is a foundational change for scaled-FP8 KV-cache support in DSA/GLM. The complete feature integration is available on [pjosipovic/fp8-sparse-kv-cache](https://github.com/tenstorrent/tt-metal/tree/pjosipovic/fp8-sparse-kv-cache).

The GLM prefill runtime [allocates its scaled-FP8 cache through `init_sparse_kv_cache`](https://github.com/tenstorrent/tt-metal/blob/pjosipovic/fp8-sparse-kv-cache/models/demos/deepseek_v3_d_p/tt/runners/adapters/glm_5_1.py#L54-L84), whose [shared cache initializer invokes `DRAMZeroFill.op`](https://github.com/tenstorrent/tt-metal/blob/pjosipovic/fp8-sparse-kv-cache/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py#L470-L480).

### Testing
- Release build: cmake --build build_Release -j8
- pytest -q models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_zero_fill.py -k row_major_formats
- Result: 2 passed, 9 deselected

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/row-major-fp8-dram-zero-fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/row-major-fp8-dram-zero-fill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/row-major-fp8-dram-zero-fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/row-major-fp8-dram-zero-fill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pjosipovic/row-major-fp8-dram-zero-fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pjosipovic/row-major-fp8-dram-zero-fill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/row-major-fp8-dram-zero-fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/row-major-fp8-dram-zero-fill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/row-major-fp8-dram-zero-fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/row-major-fp8-dram-zero-fill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/row-major-fp8-dram-zero-fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/row-major-fp8-dram-zero-fill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/row-major-fp8-dram-zero-fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/row-major-fp8-dram-zero-fill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/row-major-fp8-dram-zero-fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/row-major-fp8-dram-zero-fill)
