### PR TITLE
[Feature] per_token_cast_to_fp8: Add power-of-two scaling

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_per_token_cast.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_per_token_cast.py
@@ -77,6 +77,14 @@ def _ref_scale(x_fp32):
     return amax / E4M3_MAX
 
 
+def _ref_power_of_two_scale(x_fp32):
+    """Sparse MLA KV scale: 2^ceil(log2(clamp(amax, 1e-4) / E4M3_MAX))."""
+    *leading, H = x_fp32.shape
+    blocks = x_fp32.reshape(*leading, H // BLOCK_W, BLOCK_W)
+    amax = blocks.abs().amax(dim=-1).clamp(min=1e-4)
+    return torch.pow(2.0, torch.ceil(torch.log2(amax / E4M3_MAX)))
+
+
 # ---------------------------------------------------------------------------
 # Quality assertion helper.
 # ---------------------------------------------------------------------------
@@ -150,6 +158,79 @@ def test_cast_to_fp8_scale_values(device, dtype, shape):
     max_rel = ((scale - ref).abs() / ref.abs().clamp_min(1e-9)).max().item()
     logger.info(f"scale {dtype} shape={shape}: max_rel={max_rel:.4f}")
     assert_quality(scale, ref, pcc_threshold=0.999, rtol=1e-2, atol=1e-9, label=f"scale {dtype} shape={shape}")
+
+
+@pytest.mark.parametrize("dtype", ["bfloat16", "float32"])
+@pytest.mark.parametrize("shape", [(1, 512), (30, 512), (2, 3, 32, 512)])
+def test_cast_to_fp8_power_of_two_scale_for_sparse_kv(device, dtype, shape):
+    """Opt-in sparse-KV mode keeps the existing op contract but emits TT-safe UE8M0-style scales."""
+    torch.manual_seed(23)
+    torch_dtype = getattr(torch, dtype)
+    ttnn_dtype = getattr(ttnn, dtype)
+    x = (torch.randn(*shape) * 0.01).to(torch_dtype)
+    # Give the four 128-wide blocks distinct dynamic ranges.
+    x = x * torch.tensor([1.0, 8.0, 64.0, 512.0], dtype=torch_dtype).repeat_interleave(BLOCK_W)
+    x_tt = ttnn.from_torch(
+        x, dtype=ttnn_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    e4m3_tt, scale_tt = ttnn.experimental.deepseek_prefill.per_token_cast_to_fp8(x_tt, round_scale_to_power_of_two=True)
+    scale = ttnn.to_torch(scale_tt).float()
+    ref_scale = _ref_power_of_two_scale(x.float())
+
+    assert tuple(e4m3_tt.shape) == shape
+    assert tuple(scale_tt.shape) == _scale_shape(shape)
+    # The device row-max reduction can quantize an FP32 amax at a power-of-two
+    # boundary. Its rounded scale must remain the same or an adjacent power.
+    scale_ratio = scale / ref_scale
+    assert torch.all((scale_ratio == 0.5) | (scale_ratio == 1.0) | (scale_ratio == 2.0)), (
+        f"Expected scale ratio to be 0.5, 1.0, or 2.0; got ratios={scale_ratio.tolist()}, "
+        f"scales={scale.tolist()}, reference_scales={ref_scale.tolist()}"
+    )
+    assert torch.all(
+        torch.log2(scale) == torch.round(torch.log2(scale))
+    ), f"Expected power-of-two scales; got scales={scale.tolist()}"
+
+    # Blackhole's truncating packer reserves normalized magnitudes >= 480 for
+    # 0x7F. Check the safety property against the unquantized host amax.
+    blocks = x.float().reshape(*x.shape[:-1], x.shape[-1] // BLOCK_W, BLOCK_W)
+    normalized_amax = blocks.abs().amax(dim=-1) / scale
+    assert torch.all(normalized_amax < 480.0), (
+        f"Normalized amax must be below 480; got max={normalized_amax.max().item()}, "
+        f"values={normalized_amax.tolist()}"
+    )
+
+    y_tt = ttnn.experimental.deepseek_prefill.per_token_cast_back(e4m3_tt, scale_tt, output_dtype=ttnn.float32)
+    y = ttnn.to_torch(y_tt).float()
+    assert_quality(y, x.float(), pcc_threshold=0.999, rtol=0.15, atol=1e-3, label=f"sparse KV {dtype} {shape}")
+
+
+def test_cast_to_fp8_power_of_two_scale_e4m3fn_boundary(device):
+    """Exponent-15 E4M3FN values through 448 are finite and must not increase the scale."""
+    block_maxima = torch.tensor([240.0, 256.0, 448.0, 449.0], dtype=torch.float32)
+    x = torch.zeros(1, 4 * BLOCK_W, dtype=torch.float32)
+    x[0, ::BLOCK_W] = block_maxima
+    x_tt = ttnn.from_torch(
+        x, dtype=ttnn.float32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    e4m3_tt, scale_tt = ttnn.experimental.deepseek_prefill.per_token_cast_to_fp8(x_tt, round_scale_to_power_of_two=True)
+
+    scale = ttnn.to_torch(scale_tt).float().reshape(-1)
+    expected_scale = torch.tensor([1.0, 1.0, 1.0, 2.0])
+    assert torch.equal(
+        scale, expected_scale
+    ), f"Unexpected boundary scales: got {scale.tolist()}, expected {expected_scale.tolist()}"
+
+    y_tt = ttnn.experimental.deepseek_prefill.per_token_cast_back(e4m3_tt, scale_tt, output_dtype=ttnn.float32)
+    y = ttnn.to_torch(y_tt).float()
+    # The hardware packer truncates instead of rounding to nearest. Values can
+    # therefore land one E4M3FN ULP below the mathematical result.
+    expected_output = torch.tensor([224.0, 240.0, 416.0, 448.0])
+    actual_output = y[0, ::BLOCK_W]
+    assert torch.equal(
+        actual_output, expected_output
+    ), f"Unexpected E4M3FN boundary outputs: got {actual_output.tolist()}, expected {expected_output.tolist()}"
 
 
 # ---------------------------------------------------------------------------

--- a/tt_metal/impl/data_format/float8.cpp
+++ b/tt_metal/impl/data_format/float8.cpp
@@ -13,11 +13,13 @@
 namespace {
 
 // Converts a float32 value to an FP8 E4M3 bit pattern.
-// E4M3: bias=7, exponent range [1,14] normal, [0] subnormal, [15] NaN.
-// Overflow (|val| > max representable ~240) clamps to max finite.
+// E4M3FN: bias=7, exponent range [1,15] normal, [0] subnormal. Only E=15,
+// M=7 is NaN; E=15, M=[0,6] extends the finite range through 448.
+// Overflow clamps to max finite.
 uint8_t fp32_to_fp8_e4m3_bits(float val) {
     constexpr int FP8_BIAS = 7;
-    constexpr int FP8_EXP_MAX = 14;  // E=15 is reserved for NaN
+    constexpr int FP8_EXP_MAX = 15;
+    constexpr uint8_t FP8_MAX_FINITE = 0x7E;
 
     if (std::isnan(val)) {
         return 0x7F;  // canonical NaN: S=0, E=1111, M=111
@@ -27,8 +29,8 @@ uint8_t fp32_to_fp8_e4m3_bits(float val) {
     uint8_t sign = static_cast<uint8_t>((u >> 31) & 1);
 
     if (std::isinf(val)) {
-        // No infinity in FP8 E4M3 — clamp to max finite: E=1110, M=111
-        return (sign << 7) | 0x77;
+        // No infinity in E4M3FN — clamp to max finite: E=1111, M=110
+        return (sign << 7) | FP8_MAX_FINITE;
     }
 
     int32_t fp32_biased_exp = static_cast<int32_t>((u >> 23) & 0xFF);
@@ -47,7 +49,7 @@ uint8_t fp32_to_fp8_e4m3_bits(float val) {
     int32_t fp8_biased_exp = exp_unbiased + FP8_BIAS;
 
     if (fp8_biased_exp > FP8_EXP_MAX) {
-        return (sign << 7) | 0x77;  // overflow → max finite
+        return (sign << 7) | FP8_MAX_FINITE;  // overflow → max finite
     }
 
     uint8_t fp8_exp;
@@ -66,11 +68,17 @@ uint8_t fp32_to_fp8_e4m3_bits(float val) {
             if (++fp8_man >= 8) {
                 fp8_man = 0;
                 if (++fp8_biased_exp > FP8_EXP_MAX) {
-                    return (sign << 7) | 0x77;  // overflow → max finite
+                    return (sign << 7) | FP8_MAX_FINITE;  // overflow → max finite
                 }
             }
         }
         fp8_exp = static_cast<uint8_t>(fp8_biased_exp);
+    }
+
+    // E=15, M=7 is the sole NaN encoding in E4M3FN. A finite value that
+    // rounds there saturates to the adjacent maximum finite value instead.
+    if (fp8_exp == FP8_EXP_MAX && fp8_man == 7) {
+        return (sign << 7) | FP8_MAX_FINITE;
     }
 
     return (sign << 7) | (fp8_exp << 3) | fp8_man;
@@ -86,7 +94,7 @@ float8_e4m3::operator float() const {
     uint8_t exp = (uint8_data >> 3) & 0xF;
     uint8_t man = uint8_data & 0x7;
 
-    if (exp == 15) {
+    if (exp == 15 && man == 7) {
         return std::numeric_limits<float>::quiet_NaN();
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/device/kernels/compute/compute_per_token_cast_to_fp8.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/device/kernels/compute/compute_per_token_cast_to_fp8.cpp
@@ -32,6 +32,34 @@
 #include "api/compute/eltwise_unary/binop_with_scalar.h"
 #include "api/dataflow/circular_buffer.h"
 
+#ifdef TRISC_MATH
+namespace ckernel::sfpu {
+
+// The input is positive and normal because the amax is clamped before this
+// helper runs. Preserve an exact power of two; otherwise increment its biased
+// exponent and clear the mantissa.
+template <int ITERATIONS = 8>
+inline void calculate_ceil_power_of_two() {
+    for (int d = 0; d < ITERATIONS; ++d) {
+        sfpi::vFloat value = sfpi::dst_reg[0];
+        sfpi::vInt exponent = sfpi::exexp(value, sfpi::ExponentMode::Biased);
+        sfpi::vFloat mantissa = sfpi::setexp(value, 127);
+        sfpi::vFloat result = sfpi::setexp(sfpi::vFloat(1.0f), exponent);
+        v_if(mantissa != 1.0f) { result = sfpi::setexp(sfpi::vFloat(1.0f), exponent + 1); }
+        v_endif;
+        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace ckernel::sfpu
+
+inline void ceil_power_of_two_tile(uint32_t idst) {
+    SFPU_UNARY_CALL(
+        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_ceil_power_of_two, (8 /* ITERATIONS */), idst, VectorMode::RC);
+}
+#endif
+
 void kernel_main() {
     constexpr uint32_t cb_in_id = get_compile_time_arg_val(0);
     CircularBuffer cb_in(cb_in_id);
@@ -56,6 +84,7 @@ void kernel_main() {
     // Tile width from the tensor's tile spec.
     constexpr uint32_t block_w = 128;  // BlockW
     constexpr uint32_t tile_w = get_compile_time_arg_val(11);
+    constexpr bool round_scale_to_power_of_two = get_compile_time_arg_val(12) != 0;
     constexpr uint32_t block_wt = block_w / tile_w;  // BlockWt
     constexpr uint32_t block_ht = 1;                 // BlockHt
     constexpr uint32_t tiles_per_block = block_ht * block_wt;
@@ -129,6 +158,11 @@ void kernel_main() {
                 clamp_tile(IDST0, clamp_min_bits, clamp_max_bits);  // slot 0 = clamp(amax)
                 binop_with_scalar_tile_init();
                 mul_unary_tile(IDST0, inv_448_bits);  // slot 0 = scale = clamp(amax)/448
+                if constexpr (round_scale_to_power_of_two) {
+                    // UE8M0-style scale: 2^ceil(log2(scale)), formed directly from the
+                    // float32 exponent and mantissa so power-of-two boundaries are exact.
+                    MATH((ceil_power_of_two_tile(IDST0)));
+                }
                 copy_dest_values_init();
                 copy_dest_values<DataFormat::Float32>(IDST0, IDST1);  // slot 1 = scale
                 recip_tile_init();

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/device/per_token_cast_to_fp8_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/device/per_token_cast_to_fp8_device_operation.cpp
@@ -66,7 +66,6 @@ void PerTokenCastToFp8DeviceOperation::validate_on_program_cache_miss(
         input.dtype() == tt::tt_metal::DataType::BFLOAT16 || input.dtype() == tt::tt_metal::DataType::FLOAT32,
         "per_token_cast_to_fp8: input dtype must be BFLOAT16 or FLOAT32, got {}",
         static_cast<int>(input.dtype()));
-
     const auto tile_shape = input.tensor_spec().tile().get_tile_shape();
     const uint32_t tile_h = tile_shape[0];
     const uint32_t tile_w = tile_shape[1];
@@ -170,9 +169,12 @@ ttsl::hash::hash_t PerTokenCastToFp8DeviceOperation::compute_program_hash(
 namespace ttnn::prim {
 
 std::tuple<ttnn::Tensor, ttnn::Tensor> per_token_cast_to_fp8(
-    const Tensor& input_tensor, const tt::tt_metal::MemoryConfig& output_memory_config) {
+    const Tensor& input_tensor,
+    const tt::tt_metal::MemoryConfig& output_memory_config,
+    bool round_scale_to_power_of_two) {
     using OperationType = ttnn::experimental::prim::per_token_cast_to_fp8::PerTokenCastToFp8DeviceOperation;
-    auto operation_attributes = OperationType::operation_attributes_t{.output_memory_config = output_memory_config};
+    auto operation_attributes = OperationType::operation_attributes_t{
+        .output_memory_config = output_memory_config, .round_scale_to_power_of_two = round_scale_to_power_of_two};
     auto tensor_args = OperationType::tensor_args_t{.input_tensor = input_tensor};
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/device/per_token_cast_to_fp8_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/device/per_token_cast_to_fp8_device_operation.hpp
@@ -32,5 +32,7 @@ struct PerTokenCastToFp8DeviceOperation {
 
 namespace ttnn::prim {
 std::tuple<ttnn::Tensor, ttnn::Tensor> per_token_cast_to_fp8(
-    const Tensor& input_tensor, const tt::tt_metal::MemoryConfig& output_memory_config);
+    const Tensor& input_tensor,
+    const tt::tt_metal::MemoryConfig& output_memory_config,
+    bool round_scale_to_power_of_two);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/device/per_token_cast_to_fp8_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/device/per_token_cast_to_fp8_device_operation_types.hpp
@@ -10,6 +10,7 @@ namespace ttnn::experimental::prim::per_token_cast_to_fp8 {
 
 struct PerTokenCastToFp8Params {
     tt::tt_metal::MemoryConfig output_memory_config;
+    bool round_scale_to_power_of_two;
 };
 
 struct PerTokenCastToFp8Inputs {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/device/per_token_cast_to_fp8_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/device/per_token_cast_to_fp8_program_factory.cpp
@@ -53,7 +53,7 @@ uint32_t rows_for_core_from_split(
 }  // namespace
 
 PerTokenCastToFp8ProgramFactory::cached_program_t PerTokenCastToFp8ProgramFactory::create(
-    const PerTokenCastToFp8Params& /*operation_attributes*/,
+    const PerTokenCastToFp8Params& operation_attributes,
     const PerTokenCastToFp8Inputs& tensor_args,
     tensor_return_value_t& tensor_return_value) {
     using namespace tt;
@@ -131,12 +131,12 @@ PerTokenCastToFp8ProgramFactory::cached_program_t PerTokenCastToFp8ProgramFactor
                                          .set_page_size(cb_in_idx, in_tile_bytes);
     CreateCircularBuffer(program, all_cores, cb_in_cfg);
 
-    make_fp32_tile_cb(cb_tile_idx, tiles_per_block);                  // tilized input
-    make_fp32_tile_cb(cb_scaler_idx, 1);                              // reduce scaler (1.0), reader-filled
-    make_fp32_tile_cb(cb_abs_idx, 2 * block_wt);                      // abs tiles for one block row
-    make_fp32_tile_cb(cb_scale_tiles_idx, 2 * block_ht);              // col0 = scale
-    make_fp32_tile_cb(cb_inv_scale_tiles_idx, 2 * block_ht);          // col0 = 1/scale
-    make_fp32_tile_cb(cb_out_tile_idx, tiles_per_block);              // divided tiles -> untilize
+    make_fp32_tile_cb(cb_tile_idx, tiles_per_block);          // tilized input
+    make_fp32_tile_cb(cb_scaler_idx, 1);                      // reduce scaler (1.0), reader-filled
+    make_fp32_tile_cb(cb_abs_idx, 2 * block_wt);              // abs tiles for one block row
+    make_fp32_tile_cb(cb_scale_tiles_idx, 2 * block_ht);      // col0 = scale
+    make_fp32_tile_cb(cb_inv_scale_tiles_idx, 2 * block_ht);  // col0 = 1/scale
+    make_fp32_tile_cb(cb_out_tile_idx, tiles_per_block);      // divided tiles -> untilize
 
     // cb_output_e4m3: output_e4m3 row-major output, one tile per page; tiles_per_block pages = one
     // block, double-buffered.
@@ -190,7 +190,7 @@ PerTokenCastToFp8ProgramFactory::cached_program_t PerTokenCastToFp8ProgramFactor
     // Compute (TRISC): tilize -> block amax scale + 1/scale -> divide -> untilize to output_e4m3.
     const uint32_t clamp_min_bits = std::bit_cast<uint32_t>(fp8::SCALE_CLAMP_MIN);
     const uint32_t clamp_max_bits = std::bit_cast<uint32_t>(3.0e38f);
-    const uint32_t inv_e4m3_max_bits = std::bit_cast<uint32_t>(1.0f / fp8::E4M3_MAX_NORMAL);
+    const uint32_t inv_448_bits = std::bit_cast<uint32_t>(1.0f / fp8::E4M3_MAX_NORMAL);
     std::vector<uint32_t> compute_ct_args = {
         cb_in_idx,
         cb_tile_idx,
@@ -202,8 +202,9 @@ PerTokenCastToFp8ProgramFactory::cached_program_t PerTokenCastToFp8ProgramFactor
         cb_output_e4m3_idx,
         clamp_min_bits,
         clamp_max_bits,
-        inv_e4m3_max_bits,
-        tile_w};
+        inv_448_bits,
+        tile_w,
+        static_cast<uint32_t>(operation_attributes.round_scale_to_power_of_two)};
     // fp32_dest_acc_en=True is required whenever an 8-bit-float CB (output_e4m3) is on the core (DEST in
     // 32-bit family-agnostic mode); it also gives fp32 precision for the reduce/divide stages.
     KernelHandle compute_kernel_id = CreateKernel(
@@ -215,20 +216,14 @@ PerTokenCastToFp8ProgramFactory::cached_program_t PerTokenCastToFp8ProgramFactor
 
     // Each core owns rows [row_offset, row_offset+rows_for_core). Its 128-element scale blocks
     // form a flat stream read/written in tile_h-block batches.
-    const uint32_t scale_blocks_per_core_row = scale_blocks_per_row;  // H / 128
     auto all_cores_vec = corerange_to_cores(all_cores, num_cores, true);
     uint32_t row_offset = 0;
     for (uint32_t i = 0; i < num_cores; ++i) {
         const auto& core = all_cores_vec[i];
         const uint32_t rows_for_core =
             rows_for_core_from_split(core, core_range_set_1, core_range_set_2, rows_per_core_g1, rows_per_core_g2);
-        const uint32_t total_scale_blocks = rows_for_core * scale_blocks_per_core_row;
+        const uint32_t total_scale_blocks = rows_for_core * scale_blocks_per_row;
         const uint32_t num_blocks = tt::div_up(total_scale_blocks, tile_h);  // last block may be partial
-
-        // Host-side invariant checks (no LLK investigation needed downstream if these hold).
-        TT_FATAL(
-            num_blocks == tt::div_up(rows_for_core * scale_blocks_per_core_row, tile_h),
-            "per_token_cast_to_fp8: num_blocks invariant violated on a core");
 
         SetRuntimeArgs(
             program, reader_kernel_id, core, {src_buffer->address(), num_blocks, row_offset, rows_for_core, H});

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/per_token_cast_to_fp8.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/per_token_cast_to_fp8.cpp
@@ -9,8 +9,11 @@
 namespace ttnn::operations::experimental::deepseek_prefill::per_token_cast_to_fp8 {
 
 std::tuple<ttnn::Tensor, ttnn::Tensor> per_token_cast_to_fp8(
-    const ttnn::Tensor& input_tensor, const std::optional<tt::tt_metal::MemoryConfig>& memory_config) {
-    return ttnn::prim::per_token_cast_to_fp8(input_tensor, memory_config.value_or(input_tensor.memory_config()));
+    const ttnn::Tensor& input_tensor,
+    const std::optional<tt::tt_metal::MemoryConfig>& memory_config,
+    bool round_scale_to_power_of_two) {
+    return ttnn::prim::per_token_cast_to_fp8(
+        input_tensor, memory_config.value_or(input_tensor.memory_config()), round_scale_to_power_of_two);
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::per_token_cast_to_fp8

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/per_token_cast_to_fp8.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/per_token_cast_to_fp8.hpp
@@ -18,7 +18,9 @@ inline constexpr float E4M3_MAX_NORMAL = 448.0f;
 inline constexpr float SCALE_CLAMP_MIN = 1.0e-4f;  // DeepEP clamps amax to >= 1e-4 before /448
 
 std::tuple<ttnn::Tensor, ttnn::Tensor> per_token_cast_to_fp8(
-    const ttnn::Tensor& input_tensor, const std::optional<tt::tt_metal::MemoryConfig>& memory_config = std::nullopt);
+    const ttnn::Tensor& input_tensor,
+    const std::optional<tt::tt_metal::MemoryConfig>& memory_config = std::nullopt,
+    bool round_scale_to_power_of_two = false);
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::per_token_cast_to_fp8
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/per_token_cast_to_fp8_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/per_token_cast_to_fp8_nanobind.cpp
@@ -26,18 +26,25 @@ void bind_experimental_per_token_cast_to_fp8_operation(nb::module_& mod) {
             e4m3 output is round(x / scale). The e4m3 packer rounds toward zero (truncates the
             mantissa), so results are within one e4m3 ULP of a round-to-nearest reference.
 
+            With ``round_scale_to_power_of_two=True``, the scale is rounded upward to a power of two
+            after division by the E4M3FN maximum finite magnitude, 448. Sparse MLA KV caching uses
+            this mode for UE8M0-style scaling.
+
             Args:
                 * :attr:`input_tensor`: BFLOAT16 or FLOAT32 ROW_MAJOR tensor of shape [..., M, H].
                   Requires H % 128 == 0, DRAM interleaved memory, and Blackhole hardware.
                 * :attr:`memory_config`: optional DRAM interleaved output memory config
                   (default: same as input).
+                * :attr:`round_scale_to_power_of_two`: round each scale upward to a power of two.
 
             Returns:
                 Tuple (e4m3, scale_fp32). Both are ROW_MAJOR.
         )doc",
         &per_token_cast_to_fp8,
         nb::arg("input_tensor").noconvert(),
-        nb::arg("memory_config") = std::nullopt);
+        nb::arg("memory_config") = std::nullopt,
+        nb::kw_only(),
+        nb::arg("round_scale_to_power_of_two") = false);
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::per_token_cast_to_fp8::detail


### PR DESCRIPTION
### PR Category
Feature

### Summary
Adds opt-in power-of-two scale rounding to `per_token_cast_to_fp8` for the scaled-FP8 sparse KV-cache path.

The scale is computed from the fixed E4M3FN maximum finite magnitude of 448, then rounded upward to an exact power of two when requested. The kernel derives that power directly from the FP32 exponent and mantissa, avoiding approximation at power-of-two boundaries.

This also fixes the host `float8_e4m3` conversion to match Blackhole E4M3FN semantics: exponent-15 encodings through 448 are finite, only mantissa 7 is NaN, and overflow saturates to ±448. The earlier configurable `e4m3_max` argument has been removed because the data format has one fixed maximum.

### Presentation

[Open the interactive FP8 scaling presentation](https://pavlejosipovic.github.io/fp8-scaling-presentation/)

[View the source on the public GitHub Gist](https://gist.github.com/pavlejosipovic/874170138cccd70fbda981e4a957eb66)

### Validation

- `per_token_cast_to_fp8` Python suite on Blackhole: 39 passed
- Release `ttnn` build and Blackhole kernel JIT compilation
- Repository pre-commit hooks

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/power-of-two-fp8-scaling)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/power-of-two-fp8-scaling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/power-of-two-fp8-scaling)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/power-of-two-fp8-scaling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pjosipovic/power-of-two-fp8-scaling)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pjosipovic/power-of-two-fp8-scaling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/power-of-two-fp8-scaling)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/power-of-two-fp8-scaling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/power-of-two-fp8-scaling)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/power-of-two-fp8-scaling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/power-of-two-fp8-scaling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/power-of-two-fp8-scaling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/power-of-two-fp8-scaling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/power-of-two-fp8-scaling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/power-of-two-fp8-scaling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/power-of-two-fp8-scaling)
### Motivation
This is a foundational change for scaled-FP8 KV-cache support in DSA/GLM. The complete feature integration is available on [pjosipovic/fp8-sparse-kv-cache](https://github.com/tenstorrent/tt-metal/tree/pjosipovic/fp8-sparse-kv-cache).
