### PR TITLE
[Feature] pack_scaled_fp8_kv_cache: Add mixed-format row packing

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_pack_scaled_fp8_kv_cache.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_pack_scaled_fp8_kv_cache.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+
+import pytest
+import torch
+
+import ttnn
+from models.common.utility_functions import is_blackhole
+
+
+def _to_host_bytes(tensor, mesh_device):
+    composer = ttnn.ConcatMeshToTensor(mesh_device, dim=0)
+    return ttnn.to_torch(tensor, mesh_composer=composer).contiguous().view(torch.uint8)
+
+
+def _make_inputs(device, leading_shape):
+    latent_bf16 = ttnn.from_torch(
+        torch.randn(*leading_shape, 512, dtype=torch.bfloat16),
+        device=device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    latent, scales = ttnn.experimental.deepseek_prefill.per_token_cast_to_fp8(latent_bf16)
+    rope = ttnn.from_torch(
+        torch.randn(*leading_shape, 64, dtype=torch.bfloat16),
+        device=device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    return latent, scales, rope
+
+
+def _expected_packed_bytes(latent, scales, rope, device, rows):
+    return torch.cat(
+        [
+            _to_host_bytes(latent, device).reshape(rows, 512),
+            _to_host_bytes(scales, device).reshape(rows, 16),
+            _to_host_bytes(rope, device).reshape(rows, 128),
+        ],
+        dim=-1,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _require_blackhole():
+    if not is_blackhole():
+        pytest.skip("FP8_E4M3 path requires Blackhole")
+
+
+@pytest.mark.parametrize("leading_shape", [(1, 1, 1), (2, 3, 7)])
+def test_pack_scaled_fp8_kv_cache_preserves_mixed_format_bytes(device, leading_shape):
+    torch.manual_seed(17)
+    rows = math.prod(leading_shape)
+    latent, scales, rope = _make_inputs(device, leading_shape)
+    second_latent, second_scales, second_rope = _make_inputs(device, leading_shape)
+
+    device.enable_program_cache()
+    device.clear_program_cache()
+    try:
+        packed = ttnn.experimental.deepseek_prefill.pack_scaled_fp8_kv_cache(latent, scales, rope)
+        cache_entries = device.num_program_cache_entries()
+
+        second_packed = ttnn.experimental.deepseek_prefill.pack_scaled_fp8_kv_cache(
+            second_latent, second_scales, second_rope
+        )
+
+        assert cache_entries > 0
+        assert device.num_program_cache_entries() == cache_entries
+        assert packed.dtype == ttnn.fp8_e4m3
+        assert packed.layout == ttnn.ROW_MAJOR_LAYOUT
+        assert tuple(packed.shape) == (*leading_shape, 656)
+        assert torch.equal(
+            _to_host_bytes(packed, device).reshape(rows, 656),
+            _expected_packed_bytes(latent, scales, rope, device, rows),
+        )
+        assert torch.equal(
+            _to_host_bytes(second_packed, device).reshape(rows, 656),
+            _expected_packed_bytes(second_latent, second_scales, second_rope, device, rows),
+        )
+    finally:
+        device.disable_and_clear_program_cache()

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/CMakeLists.txt
@@ -10,6 +10,7 @@ add_subdirectory(moe_grouped_topk)
 add_subdirectory(moe_hash_gate)
 add_subdirectory(offset_cumsum)
 add_subdirectory(outbound_socket_service_sync)
+add_subdirectory(pack_scaled_fp8_kv_cache)
 add_subdirectory(per_token_cast_back)
 add_subdirectory(per_token_cast_to_fp8)
 add_subdirectory(post_combine_reduce)
@@ -35,6 +36,7 @@ target_link_libraries(
         TTNN::Ops::Experimental::DeepSeekPrefill::MoeHashGate
         TTNN::Ops::Experimental::DeepSeekPrefill::OffsetCumsum
         TTNN::Ops::Experimental::DeepSeekPrefill::D2dSocketSync
+        TTNN::Ops::Experimental::DeepSeekPrefill::PackScaledFp8KvCache
         TTNN::Ops::Experimental::DeepSeekPrefill::PerTokenCastBack
         TTNN::Ops::Experimental::DeepSeekPrefill::PerTokenCastToFp8
         TTNN::Ops::Experimental::DeepSeekPrefill::PostCombineReduce
@@ -67,6 +69,7 @@ target_sources(
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::DeepSeekPrefill::MoeHashGate>
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::DeepSeekPrefill::OffsetCumsum>
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::DeepSeekPrefill::D2dSocketSync>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::DeepSeekPrefill::PackScaledFp8KvCache>
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::DeepSeekPrefill::PerTokenCastBack>
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::DeepSeekPrefill::PerTokenCastToFp8>
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::DeepSeekPrefill::PostCombineReduce>

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/pack_scaled_fp8_kv_cache/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/pack_scaled_fp8_kv_cache/CMakeLists.txt
@@ -1,0 +1,62 @@
+include(sources.cmake)
+
+add_library(ttnn_op_experimental_deepseek_prefill_pack_scaled_fp8_kv_cache ${LIB_TYPE})
+add_library(
+    TTNN::Ops::Experimental::DeepSeekPrefill::PackScaledFp8KvCache
+    ALIAS ttnn_op_experimental_deepseek_prefill_pack_scaled_fp8_kv_cache
+)
+
+target_precompile_headers(ttnn_op_experimental_deepseek_prefill_pack_scaled_fp8_kv_cache REUSE_FROM TTNN::PCHFull)
+TT_ENABLE_UNITY_BUILD(ttnn_op_experimental_deepseek_prefill_pack_scaled_fp8_kv_cache)
+
+set_target_properties(
+    ttnn_op_experimental_deepseek_prefill_pack_scaled_fp8_kv_cache
+    PROPERTIES
+        INTERFACE_HEADER_SETS_TO_VERIFY
+            api
+)
+
+file(GLOB_RECURSE kernels device/kernels/*)
+
+target_sources(
+    ttnn_op_experimental_deepseek_prefill_pack_scaled_fp8_kv_cache
+    PUBLIC
+        FILE_SET api
+        TYPE HEADERS
+        BASE_DIRS ${FixmeOpAPIDir}
+        FILES ${TTNN_OP_EXPERIMENTAL_DEEPSEEK_PREFILL_PACK_SCALED_FP8_KV_CACHE_API_HEADERS}
+        FILE_SET kernels
+        TYPE HEADERS
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
+        FILES ${kernels}
+    PRIVATE
+        ${TTNN_OP_EXPERIMENTAL_DEEPSEEK_PREFILL_PACK_SCALED_FP8_KV_CACHE_SRCS}
+)
+
+target_link_libraries(
+    ttnn_op_experimental_deepseek_prefill_pack_scaled_fp8_kv_cache
+    PRIVATE
+        TT::Metalium
+    PUBLIC
+        TTNN::Core
+)
+
+install(
+    TARGETS
+        ttnn_op_experimental_deepseek_prefill_pack_scaled_fp8_kv_cache
+    FILE_SET
+    kernels
+        DESTINATION
+            ${CMAKE_INSTALL_LIBEXECDIR}/tt-metalium/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/pack_scaled_fp8_kv_cache
+        COMPONENT ttnn-runtime
+    FILE_SET
+    api
+        COMPONENT ttnn-dev
+    LIBRARY
+        COMPONENT tar
+)
+
+# Register this op's binding directly on the shared Python module target.
+if(TARGET ttnn)
+    target_sources(ttnn PRIVATE ${TTNN_OP_EXPERIMENTAL_DEEPSEEK_PREFILL_PACK_SCALED_FP8_KV_CACHE_NANOBIND_SRCS})
+endif()

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/pack_scaled_fp8_kv_cache/device/kernels/dataflow/pack_scaled_fp8_kv_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/pack_scaled_fp8_kv_cache/device/kernels/dataflow/pack_scaled_fp8_kv_cache.cpp
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/tensor/tensor_accessor.h"
+
+void kernel_main() {
+    const uint32_t latent_addr = get_arg_val<uint32_t>(0);
+    const uint32_t scale_addr = get_arg_val<uint32_t>(1);
+    const uint32_t rope_addr = get_arg_val<uint32_t>(2);
+    const uint32_t output_addr = get_arg_val<uint32_t>(3);
+    const uint32_t start_row = get_arg_val<uint32_t>(4);
+    const uint32_t num_rows = get_arg_val<uint32_t>(5);
+
+    constexpr uint32_t cb_scratch_id = get_compile_time_arg_val(0);
+    constexpr uint32_t latent_bytes = get_compile_time_arg_val(1);
+    constexpr uint32_t scale_bytes = get_compile_time_arg_val(2);
+    constexpr uint32_t rope_bytes = get_compile_time_arg_val(3);
+    constexpr uint32_t scale_offset = latent_bytes;
+    constexpr uint32_t rope_offset = latent_bytes + scale_bytes;
+
+    constexpr auto latent_args = TensorAccessorArgs<4>();
+    constexpr auto scale_args = TensorAccessorArgs<latent_args.next_compile_time_args_offset()>();
+    constexpr auto rope_args = TensorAccessorArgs<scale_args.next_compile_time_args_offset()>();
+    constexpr auto output_args = TensorAccessorArgs<rope_args.next_compile_time_args_offset()>();
+    const auto latent = TensorAccessor(latent_args, latent_addr);
+    const auto scales = TensorAccessor(scale_args, scale_addr);
+    const auto rope = TensorAccessor(rope_args, rope_addr);
+    const auto output = TensorAccessor(output_args, output_addr);
+
+    Noc noc;
+    CircularBuffer scratch(cb_scratch_id);
+    for (uint32_t row = start_row; row < start_row + num_rows; ++row) {
+        scratch.reserve_back(1);
+        noc.async_read(latent, scratch, latent_bytes, {.page_id = row}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        noc.async_write(
+            use<CircularBuffer::AddrSelector::WRITE_PTR>(scratch),
+            output,
+            latent_bytes,
+            {.offset_bytes = 0},
+            {.page_id = row});
+        noc.async_write_barrier();
+
+        noc.async_read(scales, scratch, scale_bytes, {.page_id = row}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        noc.async_write(
+            use<CircularBuffer::AddrSelector::WRITE_PTR>(scratch),
+            output,
+            scale_bytes,
+            {.offset_bytes = 0},
+            {.page_id = row, .offset_bytes = scale_offset});
+        noc.async_write_barrier();
+
+        noc.async_read(rope, scratch, rope_bytes, {.page_id = row}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        noc.async_write(
+            use<CircularBuffer::AddrSelector::WRITE_PTR>(scratch),
+            output,
+            rope_bytes,
+            {.offset_bytes = 0},
+            {.page_id = row, .offset_bytes = rope_offset});
+        noc.async_write_barrier();
+        scratch.push_back(1);
+        scratch.pop_front(1);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/pack_scaled_fp8_kv_cache/device/pack_scaled_fp8_kv_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/pack_scaled_fp8_kv_cache/device/pack_scaled_fp8_kv_cache_device_operation.cpp
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "pack_scaled_fp8_kv_cache_device_operation.hpp"
+
+#include <limits>
+
+#include <tt_stl/small_vector.hpp>
+
+#include <tt-metalium/hal.hpp>
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/experimental/deepseek_prefill/pack_scaled_fp8_kv_cache/pack_scaled_fp8_kv_cache.hpp"
+
+namespace ttnn::experimental::prim::pack_scaled_fp8_kv_cache {
+
+namespace packed = ttnn::operations::experimental::deepseek_prefill::pack_scaled_fp8_kv_cache;
+
+namespace {
+
+bool is_dram_interleaved(const tt::tt_metal::MemoryConfig& config) {
+    return config.buffer_type() == tt::tt_metal::BufferType::DRAM &&
+           config.memory_layout() == tt::tt_metal::TensorMemoryLayout::INTERLEAVED;
+}
+
+void validate_input(const Tensor& tensor, const char* name, tt::tt_metal::DataType dtype, uint32_t width) {
+    TT_FATAL(tensor.storage_type() == tt::tt_metal::StorageType::DEVICE, "{} must be on device", name);
+    TT_FATAL(tensor.buffer() != nullptr, "{} must have a buffer", name);
+    TT_FATAL(tensor.layout() == tt::tt_metal::Layout::ROW_MAJOR, "{} must be ROW_MAJOR", name);
+    TT_FATAL(is_dram_interleaved(tensor.memory_config()), "{} must be DRAM interleaved", name);
+    TT_FATAL(tensor.dtype() == dtype, "{} has the wrong dtype", name);
+    TT_FATAL(!tensor.logical_shape().empty(), "{} must have at least one dimension", name);
+    TT_FATAL(
+        tensor.logical_shape()[-1] == width, "{} last dim must be {}, got {}", name, width, tensor.logical_shape()[-1]);
+}
+
+}  // namespace
+
+PackScaledFp8KvCacheDeviceOperation::program_factory_t PackScaledFp8KvCacheDeviceOperation::select_program_factory(
+    const operation_attributes_t&, const tensor_args_t&) {
+    return PackScaledFp8KvCacheProgramFactory{};
+}
+
+void PackScaledFp8KvCacheDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& attrs, const tensor_args_t& args) {
+    validate_input(
+        args.latent, "pack_scaled_fp8_kv_cache: latent", tt::tt_metal::DataType::FP8_E4M3, packed::LATENT_WIDTH);
+    validate_input(
+        args.scales, "pack_scaled_fp8_kv_cache: scales", tt::tt_metal::DataType::FLOAT32, packed::SCALE_WIDTH);
+    validate_input(args.rope, "pack_scaled_fp8_kv_cache: rope", tt::tt_metal::DataType::BFLOAT16, packed::ROPE_WIDTH);
+    TT_FATAL(
+        is_dram_interleaved(attrs.output_memory_config), "pack_scaled_fp8_kv_cache: output must be DRAM interleaved");
+    TT_FATAL(tt::tt_metal::hal::get_arch() == tt::ARCH::BLACKHOLE, "pack_scaled_fp8_kv_cache requires Blackhole");
+    TT_FATAL(
+        args.latent.device() == args.scales.device() && args.latent.device() == args.rope.device(),
+        "all inputs must be on the same device");
+
+    const auto& shape = args.latent.logical_shape();
+    TT_FATAL(
+        shape.size() == args.scales.logical_shape().size() && shape.size() == args.rope.logical_shape().size(),
+        "all inputs must have the same rank");
+    uint64_t rows = 1;
+    for (size_t dim = 0; dim + 1 < shape.size(); ++dim) {
+        TT_FATAL(
+            shape[dim] == args.scales.logical_shape()[dim] && shape[dim] == args.rope.logical_shape()[dim],
+            "all inputs must have identical leading shapes");
+        rows *= static_cast<uint64_t>(shape[dim]);
+        TT_FATAL(rows <= std::numeric_limits<uint32_t>::max(), "folded row count exceeds uint32_t");
+    }
+    TT_FATAL(rows > 0, "row count must be positive");
+}
+
+void PackScaledFp8KvCacheDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& attrs, const tensor_args_t& args) {
+    validate_on_program_cache_miss(attrs, args);
+}
+
+PackScaledFp8KvCacheDeviceOperation::spec_return_value_t PackScaledFp8KvCacheDeviceOperation::compute_output_specs(
+    const operation_attributes_t& attrs, const tensor_args_t& args) {
+    const auto& input_shape = args.latent.logical_shape();
+    ttsl::SmallVector<uint32_t> dims;
+    dims.reserve(input_shape.size());
+    for (size_t dim = 0; dim + 1 < input_shape.size(); ++dim) {
+        dims.push_back(static_cast<uint32_t>(input_shape[dim]));
+    }
+    dims.push_back(packed::PACKED_ROW_BYTES);
+    return TensorSpec(
+        ttnn::Shape(dims),
+        tt::tt_metal::TensorLayout(
+            tt::tt_metal::DataType::FP8_E4M3,
+            tt::tt_metal::PageConfig(tt::tt_metal::Layout::ROW_MAJOR),
+            attrs.output_memory_config));
+}
+
+PackScaledFp8KvCacheDeviceOperation::tensor_return_value_t PackScaledFp8KvCacheDeviceOperation::create_output_tensors(
+    const operation_attributes_t& attrs, const tensor_args_t& args) {
+    return create_device_tensor(compute_output_specs(attrs, args), args.latent.device());
+}
+
+ttsl::hash::hash_t PackScaledFp8KvCacheDeviceOperation::compute_program_hash(
+    const operation_attributes_t& attrs, const tensor_args_t& args) {
+    return tt::tt_metal::operation::hash_operation<PackScaledFp8KvCacheDeviceOperation>(
+        attrs,
+        args.latent.memory_config(),
+        args.scales.memory_config(),
+        args.rope.memory_config(),
+        args.latent.logical_shape());
+}
+
+}  // namespace ttnn::experimental::prim::pack_scaled_fp8_kv_cache
+
+namespace ttnn::prim {
+
+ttnn::Tensor pack_scaled_fp8_kv_cache(
+    const Tensor& latent,
+    const Tensor& scales,
+    const Tensor& rope,
+    const tt::tt_metal::MemoryConfig& output_memory_config) {
+    using Operation = ttnn::experimental::prim::pack_scaled_fp8_kv_cache::PackScaledFp8KvCacheDeviceOperation;
+    return ttnn::device_operation::launch<Operation>(
+        Operation::operation_attributes_t{.output_memory_config = output_memory_config},
+        Operation::tensor_args_t{.latent = latent, .scales = scales, .rope = rope});
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/pack_scaled_fp8_kv_cache/device/pack_scaled_fp8_kv_cache_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/pack_scaled_fp8_kv_cache/device/pack_scaled_fp8_kv_cache_device_operation.hpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <variant>
+
+#include "pack_scaled_fp8_kv_cache_device_operation_types.hpp"
+#include "pack_scaled_fp8_kv_cache_program_factory.hpp"
+
+namespace ttnn::experimental::prim::pack_scaled_fp8_kv_cache {
+
+struct PackScaledFp8KvCacheDeviceOperation {
+    using operation_attributes_t = PackScaledFp8KvCacheParams;
+    using tensor_args_t = PackScaledFp8KvCacheInputs;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
+    using program_factory_t = std::variant<PackScaledFp8KvCacheProgramFactory>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+};
+
+}  // namespace ttnn::experimental::prim::pack_scaled_fp8_kv_cache
+
+namespace ttnn::prim {
+ttnn::Tensor pack_scaled_fp8_kv_cache(
+    const Tensor& latent,
+    const Tensor& scales,
+    const Tensor& rope,
+    const tt::tt_metal::MemoryConfig& output_memory_config);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/pack_scaled_fp8_kv_cache/device/pack_scaled_fp8_kv_cache_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/pack_scaled_fp8_kv_cache/device/pack_scaled_fp8_kv_cache_device_operation_types.hpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::experimental::prim::pack_scaled_fp8_kv_cache {
+
+struct PackScaledFp8KvCacheParams {
+    tt::tt_metal::MemoryConfig output_memory_config;
+};
+
+struct PackScaledFp8KvCacheInputs {
+    const Tensor& latent;
+    const Tensor& scales;
+    const Tensor& rope;
+};
+
+}  // namespace ttnn::experimental::prim::pack_scaled_fp8_kv_cache

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/pack_scaled_fp8_kv_cache/device/pack_scaled_fp8_kv_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/pack_scaled_fp8_kv_cache/device/pack_scaled_fp8_kv_cache_program_factory.cpp
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "pack_scaled_fp8_kv_cache_program_factory.hpp"
+
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/work_split.hpp>
+
+#include "ttnn/operations/experimental/deepseek_prefill/pack_scaled_fp8_kv_cache/pack_scaled_fp8_kv_cache.hpp"
+
+namespace ttnn::experimental::prim::pack_scaled_fp8_kv_cache {
+
+namespace packed = ttnn::operations::experimental::deepseek_prefill::pack_scaled_fp8_kv_cache;
+
+PackScaledFp8KvCacheProgramFactory::cached_program_t PackScaledFp8KvCacheProgramFactory::create(
+    const PackScaledFp8KvCacheParams&, const PackScaledFp8KvCacheInputs& args, Tensor& output) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+
+    auto* latent_buffer = args.latent.buffer();
+    auto* scale_buffer = args.scales.buffer();
+    auto* rope_buffer = args.rope.buffer();
+    auto* output_buffer = output.buffer();
+    const uint32_t rows = args.latent.logical_volume() / packed::LATENT_WIDTH;
+
+    Program program;
+    const auto grid = args.latent.device()->compute_with_storage_grid_size();
+    auto [num_cores, all_cores, group_1, group_2, rows_group_1, rows_group_2] = split_work_to_cores(grid, rows);
+    auto cores = corerange_to_cores(all_cores, num_cores, true);
+
+    constexpr uint32_t cb_scratch = CBIndex::c_0;
+    constexpr uint32_t scratch_bytes = packed::LATENT_WIDTH;
+    CreateCircularBuffer(
+        program,
+        all_cores,
+        CircularBufferConfig(scratch_bytes, {{cb_scratch, DataFormat::UInt8}})
+            .set_page_size(cb_scratch, scratch_bytes));
+
+    std::vector<uint32_t> compile_args = {
+        cb_scratch, packed::LATENT_WIDTH, packed::SCALE_WIDTH * sizeof(float), packed::ROPE_WIDTH * sizeof(uint16_t)};
+    TensorAccessorArgs(latent_buffer).append_to(compile_args);
+    TensorAccessorArgs(scale_buffer).append_to(compile_args);
+    TensorAccessorArgs(rope_buffer).append_to(compile_args);
+    TensorAccessorArgs(output_buffer).append_to(compile_args);
+
+    const auto kernel_id = CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/pack_scaled_fp8_kv_cache/device/kernels/"
+        "dataflow/pack_scaled_fp8_kv_cache.cpp",
+        all_cores,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = compile_args});
+
+    uint32_t start_row = 0;
+    for (const auto& core : cores) {
+        const uint32_t core_rows = group_1.contains(core) ? rows_group_1 : rows_group_2;
+        SetRuntimeArgs(
+            program,
+            kernel_id,
+            core,
+            {latent_buffer->address(),
+             scale_buffer->address(),
+             rope_buffer->address(),
+             output_buffer->address(),
+             start_row,
+             core_rows});
+        start_row += core_rows;
+    }
+
+    return cached_program_t{std::move(program), {kernel_id, std::move(cores)}};
+}
+
+void PackScaledFp8KvCacheProgramFactory::override_runtime_arguments(
+    cached_program_t& cached,
+    const PackScaledFp8KvCacheParams&,
+    const PackScaledFp8KvCacheInputs& args,
+    Tensor& output) {
+    for (const auto& core : cached.shared_variables.cores) {
+        auto& runtime_args = tt::tt_metal::GetRuntimeArgs(cached.program, cached.shared_variables.kernel_id, core);
+        runtime_args[0] = args.latent.buffer()->address();
+        runtime_args[1] = args.scales.buffer()->address();
+        runtime_args[2] = args.rope.buffer()->address();
+        runtime_args[3] = output.buffer()->address();
+    }
+}
+
+}  // namespace ttnn::experimental::prim::pack_scaled_fp8_kv_cache

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/pack_scaled_fp8_kv_cache/device/pack_scaled_fp8_kv_cache_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/pack_scaled_fp8_kv_cache/device/pack_scaled_fp8_kv_cache_program_factory.hpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "pack_scaled_fp8_kv_cache_device_operation_types.hpp"
+#include "ttnn/device_operation.hpp"
+
+namespace ttnn::experimental::prim::pack_scaled_fp8_kv_cache {
+
+struct PackScaledFp8KvCacheSharedVariables {
+    tt::tt_metal::KernelHandle kernel_id = 0;
+    std::vector<CoreCoord> cores;
+};
+
+struct PackScaledFp8KvCacheProgramFactory {
+    using shared_variables_t = PackScaledFp8KvCacheSharedVariables;
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const PackScaledFp8KvCacheParams& operation_attributes,
+        const PackScaledFp8KvCacheInputs& tensor_args,
+        Tensor& output);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const PackScaledFp8KvCacheParams& operation_attributes,
+        const PackScaledFp8KvCacheInputs& tensor_args,
+        Tensor& output);
+};
+
+}  // namespace ttnn::experimental::prim::pack_scaled_fp8_kv_cache

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/pack_scaled_fp8_kv_cache/pack_scaled_fp8_kv_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/pack_scaled_fp8_kv_cache/pack_scaled_fp8_kv_cache.cpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "pack_scaled_fp8_kv_cache.hpp"
+
+#include "device/pack_scaled_fp8_kv_cache_device_operation.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::pack_scaled_fp8_kv_cache {
+
+ttnn::Tensor pack_scaled_fp8_kv_cache(
+    const Tensor& latent,
+    const Tensor& scales,
+    const Tensor& rope,
+    const tt::tt_metal::MemoryConfig& output_memory_config) {
+    return ttnn::prim::pack_scaled_fp8_kv_cache(latent, scales, rope, output_memory_config);
+}
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::pack_scaled_fp8_kv_cache

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/pack_scaled_fp8_kv_cache/pack_scaled_fp8_kv_cache.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/pack_scaled_fp8_kv_cache/pack_scaled_fp8_kv_cache.hpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::pack_scaled_fp8_kv_cache {
+
+constexpr uint32_t LATENT_WIDTH = 512;
+constexpr uint32_t SCALE_WIDTH = 4;
+constexpr uint32_t ROPE_WIDTH = 64;
+constexpr uint32_t PACKED_ROW_BYTES = LATENT_WIDTH + SCALE_WIDTH * sizeof(float) + ROPE_WIDTH * sizeof(uint16_t);
+
+ttnn::Tensor pack_scaled_fp8_kv_cache(
+    const Tensor& latent,
+    const Tensor& scales,
+    const Tensor& rope,
+    const tt::tt_metal::MemoryConfig& output_memory_config = ttnn::DRAM_MEMORY_CONFIG);
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::pack_scaled_fp8_kv_cache
+
+namespace ttnn::experimental::deepseek_prefill {
+using operations::experimental::deepseek_prefill::pack_scaled_fp8_kv_cache::pack_scaled_fp8_kv_cache;
+}

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/pack_scaled_fp8_kv_cache/pack_scaled_fp8_kv_cache_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/pack_scaled_fp8_kv_cache/pack_scaled_fp8_kv_cache_nanobind.cpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "pack_scaled_fp8_kv_cache_nanobind.hpp"
+
+#include "ttnn-nanobind/bind_function.hpp"
+#include "pack_scaled_fp8_kv_cache.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::pack_scaled_fp8_kv_cache::detail {
+
+void bind_pack_scaled_fp8_kv_cache(nanobind::module_& mod) {
+    namespace nb = nanobind;
+    ttnn::bind_function<"pack_scaled_fp8_kv_cache", "ttnn.experimental.deepseek_prefill.">(
+        mod,
+        R"doc(Pack one sparse-MLA KV row as [512 FP8 latent bytes | 4 FP32 scales | 64 BF16 RoPE values].)doc",
+        &pack_scaled_fp8_kv_cache,
+        nb::arg("latent"),
+        nb::arg("scales"),
+        nb::arg("rope"),
+        nb::kw_only(),
+        nb::arg("memory_config") = ttnn::DRAM_MEMORY_CONFIG);
+}
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::pack_scaled_fp8_kv_cache::detail

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/pack_scaled_fp8_kv_cache/pack_scaled_fp8_kv_cache_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/pack_scaled_fp8_kv_cache/pack_scaled_fp8_kv_cache_nanobind.hpp
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <nanobind/nanobind.h>
+
+namespace ttnn::operations::experimental::deepseek_prefill::pack_scaled_fp8_kv_cache::detail {
+void bind_pack_scaled_fp8_kv_cache(nanobind::module_& mod);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/pack_scaled_fp8_kv_cache/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/pack_scaled_fp8_kv_cache/sources.cmake
@@ -1,0 +1,9 @@
+set(TTNN_OP_EXPERIMENTAL_DEEPSEEK_PREFILL_PACK_SCALED_FP8_KV_CACHE_API_HEADERS pack_scaled_fp8_kv_cache.hpp)
+
+set(TTNN_OP_EXPERIMENTAL_DEEPSEEK_PREFILL_PACK_SCALED_FP8_KV_CACHE_SRCS
+    device/pack_scaled_fp8_kv_cache_device_operation.cpp
+    device/pack_scaled_fp8_kv_cache_program_factory.cpp
+    pack_scaled_fp8_kv_cache.cpp
+)
+
+set(TTNN_OP_EXPERIMENTAL_DEEPSEEK_PREFILL_PACK_SCALED_FP8_KV_CACHE_NANOBIND_SRCS pack_scaled_fp8_kv_cache_nanobind.cpp)

--- a/ttnn/cpp/ttnn/operations/experimental/experimental_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/experimental_nanobind.cpp
@@ -82,6 +82,7 @@
 #include "ttnn/operations/experimental/deepseek_prefill/offset_cumsum/offset_cumsum_nanobind.hpp"
 #include "ttnn/operations/experimental/deepseek_prefill/outbound_socket_service_sync/outbound_socket_service_sync_nanobind.hpp"
 #include "ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/per_token_cast_to_fp8_nanobind.hpp"
+#include "ttnn/operations/experimental/deepseek_prefill/pack_scaled_fp8_kv_cache/pack_scaled_fp8_kv_cache_nanobind.hpp"
 #include "ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/per_token_cast_back_nanobind.hpp"
 #include "ttnn/operations/experimental/fusion/fusion_dispatch_op_nanobind.hpp"
 #include "ttnn/operations/experimental/deepseek_prefill/extract/extract_nanobind.hpp"
@@ -155,6 +156,7 @@ void py_module(nb::module_& mod) {
     deepseek_prefill::detail::bind_post_combine_reduce(mod);
     deepseek_prefill::moe_grouped_topk::detail::bind_moe_grouped_topk(mod);
     deepseek_prefill::moe_hash_gate::detail::bind_moe_hash_gate(mod);
+    deepseek_prefill::pack_scaled_fp8_kv_cache::detail::bind_pack_scaled_fp8_kv_cache(mod);
     deepseek_prefill::per_token_cast_to_fp8::detail::bind_experimental_per_token_cast_to_fp8_operation(mod);
     deepseek_prefill::per_token_cast_back::detail::bind_experimental_per_token_cast_back_operation(mod);
 


### PR DESCRIPTION
### PR Category
Feature

### Summary
Adds a Blackhole data-movement operation that packs the scaled-FP8 sparse MLA KV cache produced during DSA/GLM prefill into one row-major record per token.

KV-cache row format (656 bytes):
- bytes 0-511: 512 FP8 E4M3 latent values
- bytes 512-527: four FP32 scales, one per 128 latent values
- bytes 528-655: 64 BF16 RoPE values

The output is an opaque `fp8_e4m3` tensor used as byte-addressable storage; scale and RoPE regions retain their native representations and are interpreted by offset. Compared with the existing 576-value BF16 `[latent | RoPE]` row (1152 bytes), this format reduces KV-cache storage and transport by about 43%.

### Why DSA/GLM needs this
DSA/GLM sparse MLA prefill quantizes the 512-value latent portion to FP8, but sparse attention still needs its four dequantization scales and the 64-value RoPE portion at BF16 precision. Cache update, DRAM sharding, gather, disaggregated transfer, and FlashMLA consume a single cache record, so these mixed-format fields must be packed into one tensor without numerical conversion. This operation creates that persistent cache representation on device.

The complete DSA/GLM scaled-FP8 KV-cache integration is available on [pjosipovic/fp8-sparse-kv-cache](https://github.com/tenstorrent/tt-metal/tree/pjosipovic/fp8-sparse-kv-cache).

### Testing
- Release build: `cmake --build build_Release -j8`
- `pytest -q tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_pack_scaled_fp8_kv_cache.py`
- Result: 2 passed

### Notes for reviewers
Please focus on byte offsets, row/page sizing, shape validation, and modular CMake/nanobind registration. The test uses the existing default `per_token_cast_to_fp8` API, so this PR is independent of the power-of-two scaling PR.

### Recommended CI
- PR Gate
- Focused Custom test dispatch on Blackhole P150:
  `pytest tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_pack_scaled_fp8_kv_cache.py -xv --timeout=600`

### Nightly L2 experimental BH
Nightly L2 experimental BH was intentionally not dispatched. The pipeline runs the broad experimental directory with `pytest -x`, and existing failures occur before this test on both P100 and P150. It would therefore stop without compiling or executing this operation's device kernel and provide no signal for this change. A focused Custom test dispatch or dedicated L2 matrix entry is required.

Blackhole sanity does not include this focused test.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/pack-scaled-fp8-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/pack-scaled-fp8-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/pack-scaled-fp8-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/pack-scaled-fp8-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pjosipovic/pack-scaled-fp8-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pjosipovic/pack-scaled-fp8-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/pack-scaled-fp8-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/pack-scaled-fp8-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/pack-scaled-fp8-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/pack-scaled-fp8-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/pack-scaled-fp8-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/pack-scaled-fp8-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/pack-scaled-fp8-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/pack-scaled-fp8-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/pack-scaled-fp8-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/pack-scaled-fp8-kv-cache)
