### PR TITLE
[skip ci] [Models CI] Feature: QoL - add the perf/acc measurements in the CI step

### DIFF
--- a/.github/scripts/utils/validate_perf_targets.py
+++ b/.github/scripts/utils/validate_perf_targets.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import os
 import sys
 from enum import Enum
 from pathlib import Path
@@ -74,6 +75,14 @@ PREFILL_TIME_TO_FIRST_TOKEN_KEY = "prefill_time_to_first_token"
 # forcing artifacts (not real perf), and eval runs do not measure token accuracy.
 ACCURACY_TARGET_METRIC_NAMES = {"top1", "top5"}
 ACCURACY_MEASUREMENT_NAMES = {"top1_token_accuracy", "top5_token_accuracy"}
+
+# Reverse lookup from a benchmark (step_name, measurement_name) pair back to a canonical
+# target metric name. Used to report measured values that have no matching target entry so
+# the summary can still surface them. The first key wins for pairs shared by multiple metric
+# names (e.g. prefill_time_to_token / prefill_time_to_first_token both map to time_to_token).
+_MEASUREMENT_TO_METRIC_NAME: dict[tuple[str, str], str] = {}
+for _metric_name, _pair in METRIC_NAME_MAP.items():
+    _MEASUREMENT_TO_METRIC_NAME.setdefault(_pair, _metric_name)
 
 
 def _is_number(value: Any) -> bool:
@@ -211,6 +220,56 @@ def _check_metric(
         f"{metric_name}: measured={measured_value} < lower_bound={lower_bound} "
         f"(expected={expected_value}, tolerance={tolerance}) [{note}]"
     )
+
+
+def _display_values(
+    metric_name: str,
+    measured: float | None,
+    expected: float | None,
+) -> tuple[float | None, float | None, str]:
+    """Return (display_measured, display_expected, unit) for the human summary.
+
+    `prefill_time_to_first_token` targets are normalized to seconds for comparison, so both
+    measured and expected are converted back to milliseconds here to match how the target is
+    authored and read. Every other metric is reported in its raw benchmark unit.
+    """
+    if metric_name == PREFILL_TIME_TO_FIRST_TOKEN_KEY:
+        disp_measured = round(measured * 1000.0, 4) if measured is not None else None
+        disp_expected = round(expected * 1000.0, 4) if expected is not None else None
+        return disp_measured, disp_expected, "ms"
+
+    unit = METRIC_NAME_MAP.get(metric_name, (None, ""))[1]
+    disp_measured = round(measured, 4) if measured is not None else None
+    disp_expected = round(expected, 4) if expected is not None else None
+    return disp_measured, disp_expected, unit
+
+
+def _make_report_record(
+    *,
+    model_name: str,
+    sku: str,
+    batch_size: int | None,
+    seq_len: int | None,
+    metric_name: str,
+    measured: float | None,
+    expected: float | None,
+    tolerance: float | None,
+    status: str,
+) -> dict[str, Any]:
+    """Build one row of the perf/accuracy report."""
+    disp_measured, disp_expected, unit = _display_values(metric_name, measured, expected)
+    return {
+        "model": model_name,
+        "sku": sku,
+        "batch_size": batch_size,
+        "seq_len": seq_len,
+        "metric_name": metric_name,
+        "measured": disp_measured,
+        "expected": disp_expected,
+        "tolerance": tolerance,
+        "unit": unit,
+        "status": status,
+    }
 
 
 def _benchmark_files(benchmark_dir: Path) -> list[Path]:
@@ -416,6 +475,7 @@ class ValidationResult:
         self.gap_warnings: list[str] = []
         self.hard_failures: list[str] = []
         self.missing_entries: list[str] = []
+        self.reported_metrics: list[dict[str, Any]] = []
         self.num_benchmark_files: int = 0
 
 
@@ -517,6 +577,9 @@ def validate(
             f"{benchmark_file.name}, model={model_name}, sku={sku}, batch_size={batch_size}, seq_len={seq_len}"
         )
 
+        # Benchmark measurement pairs already covered by a target so the no-target pass below
+        # does not re-report them.
+        covered_pairs: set[tuple[str, str]] = set()
         for metric_name, expected in thresholds.items():
             if model_targets.is_tolerance_key(metric_name):
                 continue
@@ -528,6 +591,13 @@ def validate(
             # targets (and vice versa).
             if (metric_name in ACCURACY_TARGET_METRIC_NAMES) != is_accuracy_run:
                 continue
+            if metric_name in METRIC_NAME_MAP:
+                covered_pairs.add(METRIC_NAME_MAP[metric_name])
+            tolerance = model_targets.resolve_metric_tolerance(
+                metric_name=metric_name,
+                thresholds=thresholds,
+                default_tolerance=model_targets.DEFAULT_PERF_TOLERANCE,
+            )
             try:
                 measured_value = _extract_metric_value(metric_name, measured)
             except ValueError as exc:
@@ -537,12 +607,20 @@ def validate(
                 result.hard_failures.append(
                     f"{hard_failures_prefix}: metric '{metric_name}' missing in benchmark payload for measured={measured}"
                 )
+                result.reported_metrics.append(
+                    _make_report_record(
+                        model_name=model_name,
+                        sku=sku,
+                        batch_size=batch_size,
+                        seq_len=seq_len,
+                        metric_name=metric_name,
+                        measured=None,
+                        expected=float(expected),
+                        tolerance=tolerance,
+                        status="missing-measurement",
+                    )
+                )
                 continue
-            tolerance = model_targets.resolve_metric_tolerance(
-                metric_name=metric_name,
-                thresholds=thresholds,
-                default_tolerance=model_targets.DEFAULT_PERF_TOLERANCE,
-            )
             metric_failure = _check_metric(
                 metric_name=metric_name,
                 expected_value=float(expected),
@@ -551,8 +629,102 @@ def validate(
             )
             if metric_failure:
                 result.hard_failures.append(f"{hard_failures_prefix}: {metric_failure}")
+            result.reported_metrics.append(
+                _make_report_record(
+                    model_name=model_name,
+                    sku=sku,
+                    batch_size=batch_size,
+                    seq_len=seq_len,
+                    metric_name=metric_name,
+                    measured=float(measured_value),
+                    expected=float(expected),
+                    tolerance=tolerance,
+                    status="fail" if metric_failure else "pass",
+                )
+            )
+
+        # Always surface measured e2e numbers, even when no target exists for them, so the
+        # report is a single place to read results. Only known metrics are reported (service
+        # measurements are skipped), and the accuracy/perf run split is respected.
+        for pair, value in measured.items():
+            if pair in covered_pairs:
+                continue
+            metric_name = _MEASUREMENT_TO_METRIC_NAME.get(pair)
+            if metric_name is None:
+                continue
+            if (metric_name in ACCURACY_TARGET_METRIC_NAMES) != is_accuracy_run:
+                continue
+            covered_pairs.add(pair)
+            result.reported_metrics.append(
+                _make_report_record(
+                    model_name=model_name,
+                    sku=sku,
+                    batch_size=batch_size,
+                    seq_len=seq_len,
+                    metric_name=metric_name,
+                    measured=float(value),
+                    expected=None,
+                    tolerance=None,
+                    status="no-target",
+                )
+            )
 
     return result
+
+
+_SUMMARY_HEADER = "| Model | SKU | batch | seq | Metric | Measured | Target | Tolerance | Unit | Status |"
+_SUMMARY_SEPARATOR = "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |"
+
+
+def _render_summary(result: ValidationResult) -> str:
+    """Render measured perf/accuracy numbers (and targets, when present) as a Markdown table.
+
+    Always includes every reported metric so results are readable from a single CI step
+    instead of scanning the full run log. Deterministically ordered for stable output.
+    """
+    lines = ["## Report and Validate Perf and Accuracy targets", ""]
+    if not result.reported_metrics:
+        lines.append("_No perf/accuracy measurements reported._")
+        return "\n".join(lines) + "\n"
+
+    def _fmt(value: Any) -> str:
+        return "-" if value is None else str(value)
+
+    lines.append(_SUMMARY_HEADER)
+    lines.append(_SUMMARY_SEPARATOR)
+    for record in sorted(
+        result.reported_metrics,
+        key=lambda r: (str(r["model"]), str(r["sku"]), str(r["metric_name"])),
+    ):
+        tolerance = record["tolerance"]
+        tolerance_disp = "-" if tolerance is None else f"±{round(float(tolerance) * 100, 2)}%"
+        lines.append(
+            "| {model} | {sku} | {batch} | {seq} | {metric} | {measured} | {target} | {tol} | {unit} | {status} |".format(
+                model=_fmt(record["model"]),
+                sku=_fmt(record["sku"]),
+                batch=_fmt(record["batch_size"]),
+                seq=_fmt(record["seq_len"]),
+                metric=record["metric_name"],
+                measured=_fmt(record["measured"]),
+                target=_fmt(record["expected"]),
+                tol=tolerance_disp,
+                unit=_fmt(record["unit"]),
+                status=record["status"],
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _write_step_summary(summary: str) -> None:
+    """Append the summary to the GitHub Actions step summary file when running in CI."""
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    try:
+        with open(summary_path, "a", encoding="utf-8") as summary_file:
+            summary_file.write(summary)
+    except OSError as exc:
+        print(f"::warning::Failed to write GITHUB_STEP_SUMMARY: {exc}")
 
 
 def main() -> int:
@@ -575,6 +747,12 @@ def main() -> int:
 
     for warning in result.gap_warnings:
         print(f"::warning::{warning}")
+
+    # Always report measured perf/accuracy numbers so they are visible directly in the CI
+    # step output (and the GitHub step summary) without scanning the full run log.
+    summary = _render_summary(result)
+    print(summary)
+    _write_step_summary(summary)
 
     if result.num_benchmark_files == 0:
         print(f"::warning::No benchmark JSON files found under {benchmark_dir}")

--- a/.github/workflows/models-e2e-tests-impl.yaml
+++ b/.github/workflows/models-e2e-tests-impl.yaml
@@ -155,7 +155,7 @@ jobs:
           log-file: generated/test_logs/${{ matrix.test-group.name }}.log
           run: |
             mkdir -p generated/test_reports
-            # Perf/accuracy are enforced by the "Validate perf and accuracy targets"
+            # Perf/accuracy are enforced by the "Report and Validate Perf and Accuracy targets"
             # step below; the in-test checks are warning-only, so the tests write
             # complete benchmark JSON before validation runs.
             ${{ matrix.test-group.cmd }}
@@ -180,7 +180,7 @@ jobs:
           path: /work
           username: ${{ secrets.SFTP_BENCHMARK_WRITER_USERNAME }}
           hostname: ${{ secrets.SFTP_BENCHMARK_WRITER_HOSTNAME }}
-      - name: Validate perf and accuracy targets
+      - name: Report and Validate Perf and Accuracy targets
         if: ${{ !cancelled() && steps.save-environment-data.conclusion == 'success' && steps.save-environment-data.outputs.has_benchmark_data == 'true' }}
         shell: bash
         run: |

--- a/tools/tests/github_scripts/test_validate_perf_targets.py
+++ b/tools/tests/github_scripts/test_validate_perf_targets.py
@@ -588,6 +588,133 @@ def test_verify_perf_respects_metric_specific_tolerance(monkeypatch):
     )
 
 
+def _write_single_target(tmp_path: Path, perf: dict, accuracy: dict | None = None) -> None:
+    """Write a minimal targets + tests YAML pair for a demo-model/wh_n150 entry."""
+    targets = {
+        "version": 1,
+        "targets": {
+            "demo-model": {
+                "aliases": [],
+                "skus": {
+                    "wh_n150": {
+                        "entries": [
+                            {
+                                "batch_size": 1,
+                                "seq_len": 128,
+                                "status": "active",
+                                "perf": perf,
+                                "accuracy": accuracy or {},
+                            }
+                        ]
+                    }
+                },
+            }
+        },
+    }
+    (tmp_path / "models/model_targets.yaml").write_text(yaml.safe_dump(targets), encoding="utf-8")
+    tests_yaml = [{"model": "demo-model", "skus": {"wh_n150": {"tier": 1}}, "team": "models"}]
+    (tmp_path / "tests/pipeline_reorg/models_e2e_tests.yaml").write_text(yaml.safe_dump(tests_yaml), encoding="utf-8")
+
+
+def test_report_shows_measured_and_target_on_pass(tmp_path):
+    (tmp_path / "generated/benchmark_data").mkdir(parents=True)
+    (tmp_path / "models").mkdir(parents=True)
+    (tmp_path / "tests/pipeline_reorg").mkdir(parents=True)
+
+    _write_complete_run(
+        tmp_path / "generated/benchmark_data/complete_run_1.json",
+        model="demo-model",
+        batch_size=1,
+        seq_len=128,
+        decode_tsu=110.0,
+    )
+    _write_single_target(tmp_path, perf={"decode_t/s/u": 100.0})
+
+    result = _run_validator(tmp_path)
+    assert result.returncode == 0, result.stdout + result.stderr
+    # Both the measured value and the target are surfaced in the report table.
+    assert "decode_t/s/u" in result.stdout
+    assert "110.0" in result.stdout
+    assert "100.0" in result.stdout
+    assert "pass" in result.stdout
+
+
+def test_report_shows_measurement_without_target(tmp_path):
+    (tmp_path / "generated/benchmark_data").mkdir(parents=True)
+    (tmp_path / "models").mkdir(parents=True)
+    (tmp_path / "tests/pipeline_reorg").mkdir(parents=True)
+
+    # decode has a target; prefill_decode t/s/u is measured but has no target entry.
+    _write_complete_run(
+        tmp_path / "generated/benchmark_data/complete_run_1.json",
+        model="demo-model",
+        batch_size=1,
+        seq_len=128,
+        decode_tsu=100.0,
+        extra_measurements=[
+            {"step_name": "inference_prefill_decode", "name": "tokens/s/user", "value": 55.0},
+        ],
+    )
+    _write_single_target(tmp_path, perf={"decode_t/s/u": 100.0})
+
+    result = _run_validator(tmp_path)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "no-target" in result.stdout
+    assert "55.0" in result.stdout
+
+
+def test_report_written_to_github_step_summary(tmp_path):
+    (tmp_path / "generated/benchmark_data").mkdir(parents=True)
+    (tmp_path / "models").mkdir(parents=True)
+    (tmp_path / "tests/pipeline_reorg").mkdir(parents=True)
+
+    _write_complete_run(
+        tmp_path / "generated/benchmark_data/complete_run_1.json",
+        model="demo-model",
+        batch_size=1,
+        seq_len=128,
+        decode_tsu=110.0,
+    )
+    _write_single_target(tmp_path, perf={"decode_t/s/u": 100.0})
+
+    summary_path = tmp_path / "summary.md"
+    result = _run_validator(tmp_path, extra_env={"GITHUB_STEP_SUMMARY": str(summary_path)})
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "Report and Validate Perf and Accuracy targets" in summary
+    assert "decode_t/s/u" in summary
+    assert "110.0" in summary
+
+
+def test_report_present_on_regression(tmp_path):
+    (tmp_path / "generated/benchmark_data").mkdir(parents=True)
+    (tmp_path / "models").mkdir(parents=True)
+    (tmp_path / "tests/pipeline_reorg").mkdir(parents=True)
+
+    _write_complete_run(
+        tmp_path / "generated/benchmark_data/complete_run_1.json",
+        model="demo-model",
+        batch_size=1,
+        seq_len=128,
+        decode_tsu=40.0,
+    )
+    _write_single_target(tmp_path, perf={"decode_t/s/u": 100.0})
+
+    result = _run_validator(tmp_path)
+    # Regression still fails the step, but the measured value is reported too.
+    assert result.returncode == 1
+    assert "40.0" in result.stdout
+    assert "fail" in result.stdout
+
+
+def test_render_summary_empty_reports_placeholder():
+    validator = _load_validator_module()
+    empty_result = validator.ValidationResult()
+    summary = validator._render_summary(empty_result)
+    assert "No perf/accuracy measurements reported" in summary
+
+
 def test_extract_metric_value_fails_for_ambiguous_unqualified_metric_name():
     validator = _load_validator_module()
     lookup = {


### PR DESCRIPTION

### PR Category

Feature

### Summary
 
Closes #49757


The Models CI pipeline has a step that compares measured performance/accuracy
against centralized targets in `models/model_targets.yaml`. Until now it only
emitted problems (`::warning::` for missing targets, `::error::` for regressions)
and never printed the actual measured numbers when everything passed. As a result,
developers and AI agents had to scan the full run log to find perf/accuracy data,
which is slow and wasteful.

This PR makes the step **always report** the measured end-to-end perf/accuracy
numbers alongside their targets (when present) as a concise summary, so results are
readable from a single CI step instead of parsing the log.

Changes:
- **`.github/scripts/utils/validate_perf_targets.py`**: collect every relevant
  measurement into the validation result (status `pass` / `fail` /
  `missing-measurement`), plus a pass over measurements that have no matching
  target (`no-target`) so measured numbers are always shown. Render the result as
  a deterministic Markdown table printed to stdout and appended to
  `$GITHUB_STEP_SUMMARY` when running in CI.
- **`.github/workflows/models-e2e-tests-impl.yaml`**: rename the CI step
  `Validate perf and accuracy targets` → `Report and Validate Perf and Accuracy targets`
  (and update the comment that references it).
- **`tools/tests/github_scripts/test_validate_perf_targets.py`**: add tests for
  the report (measured + target on pass, measurement without target, writing to
  `GITHUB_STEP_SUMMARY`, report still present on regression, empty-report placeholder).

### Notes for reviewers

- The reporting is **strictly additive** — exit codes, the `::error::`/`::warning::`
  output, the `--strict-missing` logic, and the accuracy-run vs perf-run metric
  split are all unchanged. The summary table is extra output layered on top.
- `prefill_time_to_first_token` targets are stored/normalized in different units
  (ms authored, seconds compared). In the table both measured and target are shown
  in **milliseconds** so the two columns are directly comparable, rather than
  showing only the target in ms.
- Measurements with no target still fail nothing; they are surfaced with a
  `no-target` status purely for visibility. Only known e2e metrics are reported —
  service measurements are skipped to avoid noise.
- No workflow input changes were needed: GitHub Actions sets `GITHUB_STEP_SUMMARY`
  automatically, and the script writes to it when present (falling back to stdout
  for local runs).


### CI Status

Pipeline runs:
- https://github.com/tenstorrent/tt-metal/actions/runs/29328600250

_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=49757-QoL-add-the-perf-acc-measurements-in-the-CI-step)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:49757-QoL-add-the-perf-acc-measurements-in-the-CI-step)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=49757-QoL-add-the-perf-acc-measurements-in-the-CI-step)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:49757-QoL-add-the-perf-acc-measurements-in-the-CI-step)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=49757-QoL-add-the-perf-acc-measurements-in-the-CI-step)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:49757-QoL-add-the-perf-acc-measurements-in-the-CI-step)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=49757-QoL-add-the-perf-acc-measurements-in-the-CI-step)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:49757-QoL-add-the-perf-acc-measurements-in-the-CI-step)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=49757-QoL-add-the-perf-acc-measurements-in-the-CI-step)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:49757-QoL-add-the-perf-acc-measurements-in-the-CI-step)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=49757-QoL-add-the-perf-acc-measurements-in-the-CI-step)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:49757-QoL-add-the-perf-acc-measurements-in-the-CI-step)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=49757-QoL-add-the-perf-acc-measurements-in-the-CI-step)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:49757-QoL-add-the-perf-acc-measurements-in-the-CI-step)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=49757-QoL-add-the-perf-acc-measurements-in-the-CI-step)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:49757-QoL-add-the-perf-acc-measurements-in-the-CI-step)