### PR TITLE
[Feature] Adds fused full-tile bias support to MatmulMultiCoreReuse

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_linear.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_linear.py
@@ -1099,24 +1099,29 @@ def test_linear_bias_broadcast_with_optional_shape(device, a_shape, b_shape, bia
                 assert result.shape == expected.shape
 
 
-def test_linear_bias_rejected_on_multicore_reuse_program_config(device, expect_error):
-    """Bias is not supported for MatmulMultiCoreReuseProgramConfig — validate-time check."""
+def test_linear_bias_multi_n_block_rejected_on_multicore_reuse_program_config(device, expect_error):
+    """The fused bias on MatmulMultiCoreReuseProgramConfig requires a single N block.
+
+    The whole per-batch [M, N] bias is loaded once and reused, so N must fit one block
+    (N == per_core_N). This config already requires N == per_core_N for the matmul itself, so a
+    linear with fused bias and N spanning two blocks is rejected at validation.
+    """
     torch.manual_seed(0)
-    m, k, n = 64, 64, 64
-    in0 = ttnn.from_torch(torch.randn(1, 1, m, k, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
-    in1 = ttnn.from_torch(torch.randn(1, 1, k, n, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
-    bias = ttnn.from_torch(torch.randn(1, 1, 32, n, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    batch, m, k, n = 8, 32, 64, 64  # N == 2 tiles, per_core_N == 1 below -> N spans two blocks
+    in0 = ttnn.from_torch(torch.randn(batch, 1, m, k, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    in1 = ttnn.from_torch(torch.randn(batch, 1, k, n, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    bias = ttnn.from_torch(torch.randn(1, 1, m, n, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
 
     program_config = ttnn.MatmulMultiCoreReuseProgramConfig(
-        compute_with_storage_grid_size=(1, 1),
+        compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
         in0_block_w=k // 32,
         out_subblock_h=1,
         out_subblock_w=1,
         per_core_M=m // 32,
-        per_core_N=n // 32,
+        per_core_N=1,  # < N/32 == 2
     )
 
-    with expect_error(RuntimeError, "Bias is not supported for this matmul program config:"):
+    with expect_error(RuntimeError, r"N \(2\) must equal per_core_N \(1\)"):
         ttnn.linear(in0, in1, bias=bias, program_config=program_config)
 
 
@@ -1414,3 +1419,111 @@ def test_linear_with_batched(device, a_shape, b_shape, bias_shape):
         frobenius_threshold=0.002,
         pcc_threshold=0.99,
     )
+
+
+def _reuse_program_config(device, m, k, n):
+    """MatmulMultiCoreReuseProgramConfig
+
+    Each batch element's matrix is a single program block
+    (per_core_M/per_core_N is the whole [M, N]).
+    It's the requirement for the fused-bias path: the full [M, N] bias is loaded once and reused across the batch.
+    """
+    tile = 32
+    return ttnn.MatmulMultiCoreReuseProgramConfig(
+        compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
+        in0_block_w=k // tile,
+        out_subblock_h=1,
+        out_subblock_w=n // tile,
+        per_core_M=m // tile,
+        per_core_N=n // tile,
+    )
+
+
+@pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16])
+@pytest.mark.parametrize("batch", [8, 24])
+@pytest.mark.parametrize(
+    "m, k, n",
+    [
+        (32, 32, 32),  # GDN shape: square single tile, per_core_M == per_core_N == 1
+        (32, 128, 32),  # larger K
+        (32, 32, 64),  # per_core_N == 2 within one N block, single M tile-row
+        (64, 64, 64),  # M == 2 tiles: genuine full [M, N] bias, varies per M-row
+        (128, 128, 128),  # M == N == 4 tiles: multi-tile block in both M and N
+    ],
+)
+def test_linear_batched_reuse_fused_elementwise_bias(device, dtype, batch, m, k, n):
+    """Fused full-tile (elementwise) bias on the batched MatmulMultiCoreReuseProgramConfig path."""
+    torch.manual_seed(0)
+    torch_a = torch_random((batch, 1, m, k), -0.1, 0.1, dtype=torch.float32)
+    torch_b = torch_random((batch, 1, k, n), -0.1, 0.1, dtype=torch.float32)
+    torch_bias = torch_random((1, 1, m, n), -0.1, 0.1, dtype=torch.float32)  # full-tile, broadcast over batch
+    torch_output = torch.matmul(torch_a, torch_b) + torch_bias
+
+    a = ttnn.from_torch(torch_a, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    b = ttnn.from_torch(torch_b, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    bias = ttnn.from_torch(torch_bias, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output = ttnn.linear(a, b, bias=bias, program_config=_reuse_program_config(device, m, k, n))
+    output = ttnn.to_torch(output)
+
+    pcc = 0.9997 if dtype == ttnn.float32 else 0.99
+    assert_with_pcc(torch_output, output, pcc)
+
+
+def _captured_device_op_names(fn):
+    """Device-op names recorded while running `fn` under graph capture (no device dispatch)."""
+    ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NO_DISPATCH)
+    try:
+        fn()
+    finally:
+        captured = ttnn.graph.end_graph_capture()
+    return [
+        node["params"]["name"]
+        for node in captured
+        if node.get("node_type") == "function_start" and "name" in node.get("params", {})
+    ]
+
+
+@pytest.mark.parametrize(
+    "m, k, n, bias_shape, expect_fused",
+    [
+        (64, 64, 64, (1, 1, 64, 64), True),  # full [M, N] bias -> fused into the matmul
+        (128, 128, 128, (1, 1, 128, 128), True),  # full [M, N], M = N = 4 tiles -> fused
+        (64, 64, 64, (1, 64), False),  # row-vector bias -> post-processed via add()
+    ],
+)
+def test_linear_batched_reuse_bias_routing(device, m, k, n, bias_shape, expect_fused):
+    """A full [M, N] bias fuses into the matmul; other biases fall back to post-processed add."""
+    torch.manual_seed(0)
+    a = ttnn.from_torch(torch.randn(8, 1, m, k) * 0.1, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    b = ttnn.from_torch(torch.randn(8, 1, k, n) * 0.1, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    bias = ttnn.from_torch(torch.randn(*bias_shape) * 0.1, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    pc = _reuse_program_config(device, m, k, n)
+
+    names = _captured_device_op_names(lambda: ttnn.linear(a, b, bias=bias, program_config=pc))
+
+    assert any("Matmul" in nm for nm in names), f"no matmul op captured: {names}"
+    has_binary = any("Binary" in nm for nm in names)
+    if expect_fused:
+        assert not has_binary, f"expected fused bias (no post-process add), captured: {names}"
+    else:
+        assert has_binary, f"expected a post-process add, captured: {names}"
+
+
+@pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16])
+def test_linear_batched_reuse_row_vector_bias_post_processed_correct(device, dtype):
+    """A row-vector bias on the batched reuse config is post-processed (not fused) and stays correct."""
+    batch, m, k, n = 8, 64, 64, 64  # M = 2 tiles; row-vector bias does not cover it
+    torch.manual_seed(0)
+    torch_a = torch_random((batch, 1, m, k), -0.1, 0.1, dtype=torch.float32)
+    torch_b = torch_random((batch, 1, k, n), -0.1, 0.1, dtype=torch.float32)
+    torch_bias = torch_random((n,), -0.1, 0.1, dtype=torch.float32)
+    torch_output = torch.matmul(torch_a, torch_b) + torch_bias
+
+    a = ttnn.from_torch(torch_a, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    b = ttnn.from_torch(torch_b, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    bias = ttnn.from_torch(torch_bias.reshape(1, n), dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output = ttnn.to_torch(ttnn.linear(a, b, bias=bias, program_config=_reuse_program_config(device, m, k, n)))
+    pcc = 0.9997 if dtype == ttnn.float32 else 0.99
+    assert_with_pcc(torch_output, output, pcc)

--- a/tests/ttnn/unit_tests/operations/matmul/test_linear.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_linear.py
@@ -1099,29 +1099,29 @@ def test_linear_bias_broadcast_with_optional_shape(device, a_shape, b_shape, bia
                 assert result.shape == expected.shape
 
 
-def test_linear_bias_multi_n_block_rejected_on_multicore_reuse_program_config(device, expect_error):
-    """The fused bias on MatmulMultiCoreReuseProgramConfig requires a single N block.
+def test_linear_bias_wrong_height_rejected_on_multicore_reuse_program_config(device, expect_error):
+    """Fused bias on MatmulMultiCoreReuseProgramConfig must be the full [M, N] block.
 
-    The whole per-batch [M, N] bias is loaded once and reused, so N must fit one block
-    (N == per_core_N). This config already requires N == per_core_N for the matmul itself, so a
-    linear with fused bias and N spanning two blocks is rejected at validation.
+    The factory reads M*N bias tiles, so a shorter bias would read past the buffer. This shape is
+    valid for the matmul (N == per_core_N) but not for the bias, so it must be rejected at bias
+    validation.
     """
     torch.manual_seed(0)
-    batch, m, k, n = 8, 32, 64, 64  # N == 2 tiles, per_core_N == 1 below -> N spans two blocks
-    in0 = ttnn.from_torch(torch.randn(batch, 1, m, k, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
-    in1 = ttnn.from_torch(torch.randn(batch, 1, k, n, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
-    bias = ttnn.from_torch(torch.randn(1, 1, m, n, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    m, k, n = 64, 64, 64  # M == 2 tiles; a single-tile-row bias does not cover it
+    in0 = ttnn.from_torch(torch.randn(1, 1, m, k, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    in1 = ttnn.from_torch(torch.randn(1, 1, k, n, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+    bias = ttnn.from_torch(torch.randn(1, 1, 32, n, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
 
     program_config = ttnn.MatmulMultiCoreReuseProgramConfig(
-        compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
+        compute_with_storage_grid_size=(1, 1),
         in0_block_w=k // 32,
         out_subblock_h=1,
         out_subblock_w=1,
         per_core_M=m // 32,
-        per_core_N=1,  # < N/32 == 2
+        per_core_N=n // 32,
     )
 
-    with expect_error(RuntimeError, r"N \(2\) must equal per_core_N \(1\)"):
+    with expect_error(RuntimeError, r"padded second last dimension of bias, 32, not equal to expected bias height, 64"):
         ttnn.linear(in0, in1, bias=bias, program_config=program_config)
 
 
@@ -1527,3 +1527,42 @@ def test_linear_batched_reuse_row_vector_bias_post_processed_correct(device, dty
     output = ttnn.to_torch(ttnn.linear(a, b, bias=bias, program_config=_reuse_program_config(device, m, k, n)))
     pcc = 0.9997 if dtype == ttnn.float32 else 0.99
     assert_with_pcc(torch_output, output, pcc)
+
+
+def test_linear_batched_reuse_fused_bias_program_cache(device):
+    """Fused bias stays correct across a program-cache hit with a different bias buffer.
+
+    The bias buffer address is a runtime-arg binding. A second launch with the same program key
+    but a distinct bias tensor must re-patch that binding; Launch twice with different bias buffers,
+    assert the second is a cache hit, and verify both outputs (a stale binding fails the second PCC).
+    """
+    batch, m, k, n = 8, 64, 64, 64  # M = 2 tiles: full [M, N] fused bias
+    torch.manual_seed(0)
+    torch_a = torch_random((batch, 1, m, k), -0.1, 0.1, dtype=torch.float32)
+    torch_b = torch_random((batch, 1, k, n), -0.1, 0.1, dtype=torch.float32)
+    # Distinct value ranges -> distinct buffers; a retained first binding corrupts the second result.
+    torch_biases = [
+        torch_random((1, 1, m, n), -0.1, 0.1, dtype=torch.float32),
+        torch_random((1, 1, m, n), 0.5, 1.0, dtype=torch.float32),
+    ]
+    pc = _reuse_program_config(device, m, k, n)
+    a = ttnn.from_torch(torch_a, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    b = ttnn.from_torch(torch_b, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    biases = [ttnn.from_torch(tb, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device) for tb in torch_biases]
+
+    before = device.num_program_cache_entries()
+    out0 = ttnn.linear(a, b, bias=biases[0], program_config=pc)
+    after_first = device.num_program_cache_entries()
+    out1 = ttnn.linear(a, b, bias=biases[1], program_config=pc)
+    after_second = device.num_program_cache_entries()
+
+    assert after_first == before + 1, (
+        f"first launch should add exactly one program-cache entry, added {after_first - before} "
+        f"(is the program cache enabled?)"
+    )
+    assert after_second == after_first, (
+        f"second launch recompiled instead of hitting the program cache "
+        f"({after_first - before} then {after_second - after_first} new entries)"
+    )
+    assert_with_pcc(torch.matmul(torch_a, torch_b) + torch_biases[0], ttnn.to_torch(out0), 0.9997)
+    assert_with_pcc(torch.matmul(torch_a, torch_b) + torch_biases[1], ttnn.to_torch(out1), 0.9997)

--- a/tests/ttnn/unit_tests/operations/matmul/test_linear.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_linear.py
@@ -1550,6 +1550,9 @@ def test_linear_batched_reuse_fused_bias_program_cache(device):
     b = ttnn.from_torch(torch_b, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
     biases = [ttnn.from_torch(tb, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device) for tb in torch_biases]
 
+    device.enable_program_cache()
+    device.clear_program_cache()
+
     before = device.num_program_cache_entries()
     out0 = ttnn.linear(a, b, bias=biases[0], program_config=pc)
     after_first = device.num_program_cache_entries()

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
@@ -163,6 +163,32 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
     uint32_t out_CB_size = out_CB_tiles * output_single_tile_size;
     uint32_t interm0_CB_size = out_CB_tiles * interm0_single_tile_size;
 
+    // Optional fused full-tile bias. The whole per-batch [M, N] bias block
+    // is loaded once and reused across the core's batch iterations.
+    const auto bias = tt::tt_metal::as_optional_mesh_tensor(tensor_args.optional_input_tensors.at(0));
+    tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;
+    tt::tt_metal::Tile bias_tile = output_tile;
+    uint32_t bias_single_tile_size = 0;
+    if (bias.has_value()) {
+        // Defence in depth: guarantees the whole [M, N] bias fits one block so the load-once and
+        // reuse-over-batch scheme is correct. Unreachable via ttnn.linear: get_post_process_bias
+        // only routes a bias here when this precondition already holds.
+        TT_FATAL(
+            N == per_core_N && per_core_M_per_batch == M,
+            "Fused bias in matmul_multicore_reuse requires each batch element's matrix to be a single "
+            "block: N ({}) == per_core_N ({}) and M ({}) == per_core_M_per_batch ({}).",
+            N,
+            per_core_N,
+            M,
+            per_core_M_per_batch);
+        bias_data_format = tt_metal::datatype_to_dataformat_converter(bias->dtype());
+        bias_tile = bias->tensor_spec().tile();
+        bias_single_tile_size = bias_tile.get_tile_size(bias_data_format);
+    }
+    // Full [M, N] per-batch bias block
+    uint32_t in3_block_tiles = per_core_M_per_batch * per_core_N;
+    uint32_t in3_CB_size = in3_block_tiles * bias_single_tile_size;
+
     // Compute kernel args
     uint32_t in0_num_subblocks = (per_core_M_per_batch / out_subblock_h);
     uint32_t in0_subblock_num_tiles = out_subblock_h * in0_block_w;
@@ -286,6 +312,10 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
     };
     tt::tt_metal::TensorAccessorArgs(in1_buffer).append_to(reader_writer_compile_time_args);
     tt::tt_metal::TensorAccessorArgs(output).append_to(reader_writer_compile_time_args);
+    if (bias.has_value()) {
+        // Bias accessor CT args follow the output accessor
+        tt::tt_metal::TensorAccessorArgs(bias.value()).append_to(reader_writer_compile_time_args);
+    }
 
     // Reader defines
     KernelDescriptor::Defines reader_defines;
@@ -299,6 +329,9 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
     if (output_is_sharded) {
         reader_writer_defines.emplace_back("OUT_SHARDED", "1");
     }
+    if (bias.has_value()) {
+        reader_writer_defines.emplace_back("FUSE_BIAS", "1");
+    }
 
     // Named compile-time args for CB indices (enables fusion/chaining)
     KernelDescriptor::NamedCompileTimeArgs cb_named_args = {
@@ -309,6 +342,11 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
         {"cb_intermed0", tt::CBIndex::c_5},
         {"cb_in0_transposed", tt::CBIndex::c_10},
     };
+
+    KernelDescriptor::NamedCompileTimeArgs compute_named_args = cb_named_args;
+    if (bias.has_value()) {
+        compute_named_args.push_back({"bias_ntiles", per_core_M_per_batch * per_core_N});
+    }
 
     // Compute kernel compile time args (group 1)
     std::vector<uint32_t> compute_kernel_args_group_1 = {
@@ -331,6 +369,9 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
         false,  // get_batch_from_reader
         in0_transpose_tile,
     };
+    if (bias.has_value()) {
+        compute_kernel_args_group_1.push_back(0u);  // arg 18: row_broadcast_bias=false (full-tile bias)
+    }
 
     // Compute defines
     std::map<std::string, std::string> mm_kernel_defines;
@@ -342,6 +383,12 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
     }
     if (in1_transpose_tile) {
         mm_kernel_defines["IN1_TRANSPOSE_TILE"] = "1";
+    }
+    if (bias.has_value()) {
+        mm_kernel_defines["FUSE_BIAS"] = "1";
+        // This factory loads the whole per-batch [M, N] bias block, so the compute indexes the bias
+        // by (M-tile-row, N-tile). Other callers of this shared kernel load a single bias row.
+        mm_kernel_defines["BIAS_FULL_BLOCK"] = "1";
     }
     const auto throttle_level = ttnn::get_throttle_level(operation_attributes.compute_kernel_config);
     ttnn::operations::compute_throttle_utils::add_stagger_defines_if_needed(
@@ -414,8 +461,19 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
 
         uint32_t out_start_tile_id =
             (start_batch * M * N) + (start_m_block * per_core_M_per_batch * N) + (start_n_block * per_core_N);
-        reader_writer_kernel_desc.emplace_runtime_args(
-            core, {in1_buffer, in1_start_tile_id, num_output_blocks_per_core, output, out_start_tile_id});
+        KernelDescriptor::RTArgList rw_args;
+        rw_args.push_back(in1_buffer);
+        rw_args.push_back(in1_start_tile_id);
+        rw_args.push_back(num_output_blocks_per_core);
+        rw_args.push_back(output);
+        rw_args.push_back(out_start_tile_id);
+        if (bias.has_value()) {
+            rw_args.push_back(*bias);
+            // Broadcast over batch, single block per element (start_m_block == start_n_block == 0
+            // under the bias FATAL): the whole [M, N] bias starts at tile 0.
+            rw_args.push_back(0u);  // bias_start_tile_id
+        }
+        reader_writer_kernel_desc.emplace_runtime_args(core, rw_args);
 
         // Compute kernels have no per-core runtime args
         if (i < g1_numcores) {
@@ -437,7 +495,7 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
     compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     compute_kernel_desc.core_ranges = core_group_1;
     compute_kernel_desc.compile_time_args = compute_kernel_args_group_1;
-    compute_kernel_desc.named_compile_time_args = cb_named_args;
+    compute_kernel_desc.named_compile_time_args = compute_named_args;
     compute_kernel_desc.defines = compute_defines;
     compute_kernel_desc.runtime_args = std::move(compute_runtime_args_g1);
     compute_kernel_desc.config = ComputeConfigDescriptor{
@@ -469,6 +527,9 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
             false,  // get_batch_from_reader
             in0_transpose_tile,
         };
+        if (bias.has_value()) {
+            compute_kernel_args_group_2.push_back(0u);  // arg 18: row_broadcast_bias=false
+        }
 
         KernelDescriptor compute_kernel_desc_g2;
         compute_kernel_desc_g2.kernel_source =
@@ -477,7 +538,7 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
         compute_kernel_desc_g2.source_type = KernelDescriptor::SourceType::FILE_PATH;
         compute_kernel_desc_g2.core_ranges = core_group_2;
         compute_kernel_desc_g2.compile_time_args = compute_kernel_args_group_2;
-        compute_kernel_desc_g2.named_compile_time_args = cb_named_args;
+        compute_kernel_desc_g2.named_compile_time_args = compute_named_args;
         compute_kernel_desc_g2.defines = compute_defines;
         compute_kernel_desc_g2.runtime_args = std::move(compute_runtime_args_g2);
         compute_kernel_desc_g2.config = ComputeConfigDescriptor{
@@ -525,6 +586,12 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
         in1_aligned_tile_size,
         in1_tile,
         in1_is_sharded ? &in1_buffer : nullptr));
+
+    // CB 3: Bias (fused elementwise, optional)
+    if (bias.has_value()) {
+        program_descriptor.cbs.push_back(
+            make_cb_descriptor(in3_CB_size, tt::CBIndex::c_3, bias_data_format, bias_single_tile_size, bias_tile));
+    }
 
     // CB 4 and CB 5: Output and intermediate accumulator
     if ((interm0_data_format != output_data_format) || (untilize_out && (in1_num_subblocks > 1))) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -488,7 +488,17 @@ void kernel_main() {
                         mm_partials_cb.wait_front(out_subblock_num_tiles);
                         tile_regs_acquire();
                         for (uint32_t i = 0, j = 0; j < out_subblock_h; j++) {
+#ifdef BIAS_FULL_BLOCK
+                            // The bias CB holds a full [M, N] tile block. m_tile is this output tile's
+                            // row within that block; bias_tile_idx is the position of the matching bias
+                            // tile in the CB (row m_tile, column in1_index_subblock_offset). Only
+                            // matmul_multicore_reuse_optimized loads the full block; other callers load a
+                            // single bias row and use the N-only index below.
+                            const uint32_t m_tile = in0_subblock * out_subblock_h + j;
+                            uint32_t bias_tile_idx = m_tile * in1_block_w + in1_index_subblock_offset;
+#else
                             uint32_t bias_tile_idx = in1_index_subblock_offset;
+#endif
                             for (uint32_t k = 0; k < out_subblock_w; k++, i++) {
                                 const uint32_t safe_bias_tile_idx =
                                     (is_last_in1_subblock_padded && k >= last_subblock_w_valid)

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_writer_bmm_tile_layout_in1.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_writer_bmm_tile_layout_in1.cpp
@@ -24,6 +24,12 @@ void kernel_main() {
     const uint32_t out_tensor_addr = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t out_tensor_start_tile_id = get_arg_val<uint32_t>(rt_args_idx++);
 
+#ifdef FUSE_BIAS
+    // bias tensor args
+    const uint32_t in3_tensor_addr = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t in3_tensor_start_tile_id = get_arg_val<uint32_t>(rt_args_idx++);
+#endif
+
     // COMPILE TIME ARGS
     // READER
     // in1 tensor args
@@ -60,10 +66,39 @@ void kernel_main() {
 
     constexpr auto in1_args = TensorAccessorArgs<19>();
     constexpr auto out_args = TensorAccessorArgs<in1_args.next_compile_time_args_offset()>();
+#ifdef FUSE_BIAS
+    // bias accessor CT args follow the output accessor
+    constexpr auto bias_args = TensorAccessorArgs<out_args.next_compile_time_args_offset()>();
+    constexpr uint32_t cb_id_in3 = get_named_compile_time_arg_val("cb_bias");
+#endif
 
     Noc noc;
     CircularBuffer cb_in1(cb_id_in1);
     CircularBuffer cb_out(cb_id_out0);
+
+#ifdef FUSE_BIAS
+    // Load the whole per-batch [M, N] bias block once.
+    // It's reused across all of this core's batch iterations (broadcast over batch).
+    constexpr uint32_t bias_block_ntiles = out_subblock_h * out_num_subblocks_h * in1_block_w;  // M*N tiles
+    const uint32_t bias_single_tile_size_bytes = get_tile_size(cb_id_in3);
+    CircularBuffer cb_in3(cb_id_in3);
+    const auto s3 = TensorAccessor(bias_args, in3_tensor_addr);
+    cb_in3.reserve_back(bias_block_ntiles);
+    uint32_t in3_write_offset = 0;
+    uint32_t in3_tensor_tile_id = in3_tensor_start_tile_id;
+    for (uint32_t t = 0; t < bias_block_ntiles; ++t) {
+        noc.async_read(
+            s3,
+            cb_in3,
+            bias_single_tile_size_bytes,
+            {.page_id = in3_tensor_tile_id},
+            {.offset_bytes = in3_write_offset});
+        in3_write_offset += bias_single_tile_size_bytes;
+        in3_tensor_tile_id += 1;  // [M, N] bias is row-major contiguous (stride 1)
+    }
+    noc.async_read_barrier();
+    cb_in3.push_back(bias_block_ntiles);
+#endif
 
 #ifdef IN1_SHARDED
     const uint32_t in1_num_tiles = batch * num_blocks * in1_block_h * in1_block_w;

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -362,15 +362,14 @@ void validate_matmul_input_count(
     }
 }
 
-// Bias Shape: runs only when a bias is present. Checks the bias is a single tile-row,
-// N-wide, batch-1, tilized row vector whose tile size and width line up with the
-// matmul output.
 void validate_matmul_bias_shape(
     const std::optional<const Tensor>& optional_bias,
     const tt::tt_metal::Tile& in0_tile,
     const tt::tt_metal::Tile& in1_tile,
+    const ttnn::Shape& a_shape_padded,
     const ttnn::Shape& b_shape,
-    const ttnn::Shape& b_shape_padded) {
+    const ttnn::Shape& b_shape_padded,
+    const operations::matmul::MatmulProgramConfig& chosen_program_config) {
     if (!optional_bias.has_value()) {
         return;
     }
@@ -388,12 +387,20 @@ void validate_matmul_bias_shape(
     const auto& bias_shape_padded = bias.padded_shape();
     uint32_t bias_batch_size = get_batch_size(bias_shape);
     TT_FATAL(bias_batch_size == 1, "Unsupported bias shape: batch size must be 1, got {}", bias_batch_size);
+    // MatmulMultiCoreReuseProgramConfig fuses a full per-batch [M, N] bias block, so its height must
+    // cover exactly M; every other config indexes a single bias tile-row.
+    const bool is_reuse_config =
+        std::holds_alternative<operations::matmul::MatmulMultiCoreReuseProgramConfig>(chosen_program_config);
+    const uint32_t Mt = operations::matmul::utilities::get_M_dim(a_shape_padded, in0_tile, /*fuse_batch=*/false);
+    const uint32_t expected_bias_height = (is_reuse_config ? Mt : 1) * in0_tile.get_height();
     TT_FATAL(
-        bias_shape_padded[-2] % in0_tile.get_height() == 0,
-        "Unsupported bias shape: padded second last dimension of bias, "
-        "{}, not a multiple of tile height, {}",
+        bias_shape_padded[-2] == expected_bias_height,
+        "Unsupported bias shape: padded second last dimension of bias, {}, not equal to expected bias height, "
+        "{} (tile height {} x {} bias tile-row(s))",
         bias_shape_padded[-2],
-        in0_tile.get_height());
+        expected_bias_height,
+        in0_tile.get_height(),
+        is_reuse_config ? Mt : 1);
     TT_FATAL(
         bias_shape_padded[-1] == b_shape_padded[-1],
         "Unsupported bias shape: padded last dimension of bias, {}, not "
@@ -2160,7 +2167,8 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
         attributes, input_tensor_a, input_tensor_b, a_shape, b_shape, chosen_program_config);
     validate_matmul_mcast1d_subdevice_worker_grid(input_tensor_a, attributes, chosen_program_config);
     validate_matmul_input_count(attributes, input_tensors, input_tensor_b, chosen_program_config);
-    validate_matmul_bias_shape(optional_bias, in0_tile, in1_tile, b_shape, b_shape_padded);
+    validate_matmul_bias_shape(
+        optional_bias, in0_tile, in1_tile, a_shape_padded, b_shape, b_shape_padded, chosen_program_config);
     validate_matmul_untilize_out(attributes, chosen_program_config);
 
     // ---- per-config validation: one std::visit over the chosen program config ----

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -389,9 +389,9 @@ void validate_matmul_bias_shape(
     uint32_t bias_batch_size = get_batch_size(bias_shape);
     TT_FATAL(bias_batch_size == 1, "Unsupported bias shape: batch size must be 1, got {}", bias_batch_size);
     TT_FATAL(
-        bias_shape_padded[-2] == in0_tile.get_height(),
+        bias_shape_padded[-2] % in0_tile.get_height() == 0,
         "Unsupported bias shape: padded second last dimension of bias, "
-        "{}, not equal to tile height, {}",
+        "{}, not a multiple of tile height, {}",
         bias_shape_padded[-2],
         in0_tile.get_height());
     TT_FATAL(
@@ -877,30 +877,6 @@ void validate_matmul_reuse_sharded_output_block_divisibility(
             }
         },
         chosen_program_config);
-}
-
-// Bias Support: checks bias support by config. Reuse rejects bias; other configs allow it.
-void validate_matmul_bias(
-    const std::optional<const Tensor>& optional_bias,
-    const operations::matmul::MatmulProgramConfig& chosen_program_config) {
-    // Determine which program configs support bias.
-    bool config_supports_bias = false;
-    std::visit(
-        [&config_supports_bias](const auto& program_config) {
-            using ProgramConfigType = std::decay_t<decltype(program_config)>;
-            // MatmulMultiCoreReuseProgramConfig has no bias kernel path and the wrapper
-            // does not post-process bias for it. All other configs either support bias in
-            // the kernel or have it handled by get_post_process_bias() in matmul.cpp.
-            // gather_in0 on 1D multicast rejects bias separately in its dedicated check.
-            config_supports_bias =
-                !std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig>;
-        },
-        chosen_program_config);
-
-    TT_FATAL(
-        !optional_bias.has_value() || config_supports_bias,
-        "Bias is not supported for this matmul program config: {}",
-        ttsl::get_active_type_name_in_variant(chosen_program_config));
 }
 
 // Helper: cross-validate a DRAM-sender global_cb's geometry against the matmul + weight shape.
@@ -2164,7 +2140,6 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
     validate_matmul_tiny_tile_constraints(input_tensor_b, in0_tile, in1_tile, chosen_program_config);
     validate_matmul_compute_grid_and_per_core_dims(input_tensor_a, chosen_program_config);
     validate_matmul_block_and_subblock_configuration(attributes, a_shape_padded, in0_tile, chosen_program_config);
-    validate_matmul_bias(optional_bias, chosen_program_config);
     validate_matmul_sharded_operand_grids_within_program_compute_grid(
         input_tensor_a, input_tensor_b, chosen_program_config);
     validate_matmul_reuse_sharded_output_block_divisibility(

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
@@ -96,6 +96,46 @@ std::optional<UnaryWithParam> get_fused_activation(const std::optional<const Act
     return std::get<UnaryWithParam>(act);
 }
 
+// The reuse-optimized program factory can fuse a full [M, N] elementwise bias,
+// but only when each batch element's matrix is a single block.
+// Returns true if and only if `bias` matches that precondition exactly for the given reuse config; every
+// other bias (row-vector, etc.) returns false and falls through to a post-processed add.
+static bool reuse_config_fuses_full_block_bias(
+    const std::optional<const MatmulProgramConfig>& program_config,
+    const ttnn::Tensor& input_tensor_a_adjusted,
+    const ttnn::Tensor& input_tensor_b_adjusted,
+    const ttnn::Tensor& bias,
+    const bool transpose_a,
+    const bool transpose_b) {
+    // The fused reader assumes untransposed operands and an explicit reuse program config.
+    if (transpose_a || transpose_b || !program_config.has_value() ||
+        !std::holds_alternative<MatmulMultiCoreReuseProgramConfig>(program_config.value())) {
+        return false;
+    }
+    // Bias must broadcast over the batch dim: a single [M, N] block reused across batch elements.
+    if (detail::is_input_batched(bias.logical_shape())) {
+        return false;
+    }
+    const auto& cfg = std::get<MatmulMultiCoreReuseProgramConfig>(program_config.value());
+    const auto a_tile = utilities::get_matmul_tile(input_tensor_a_adjusted, transpose_a);
+    const auto b_tile = utilities::get_matmul_tile(input_tensor_b_adjusted, transpose_b);
+    const uint32_t M_t = utilities::get_M_dim(
+        utilities::get_matmul_tensor_padded_shape(input_tensor_a_adjusted, transpose_a), a_tile, /*fuse_batch=*/false);
+    const uint32_t N_t =
+        utilities::get_N_dim(utilities::get_matmul_tensor_padded_shape(input_tensor_b_adjusted, transpose_b), b_tile);
+    const uint32_t per_core_M_per_batch = cfg.per_core_M > M_t ? M_t : cfg.per_core_M;
+
+    // Single block per element (N and each element's M fit one block).
+    if (N_t != cfg.per_core_N || per_core_M_per_batch != M_t) {
+        return false;
+    }
+    // The bias must be the *full* [M, N] block. Use the LOGICAL shape so a row-vector [1, N] (which
+    // pads up to a full tile) is excluded and falls through to a broadcast/post-processed add.
+    const auto& bias_logical = bias.logical_shape();
+    return static_cast<uint32_t>(bias_logical[-2]) == M_t * a_tile.get_height() &&
+           static_cast<uint32_t>(bias_logical[-1]) == N_t * b_tile.get_width();
+}
+
 static bool get_post_process_bias(
     const std::optional<const ttnn::Tensor>& bias,
     const std::optional<const MatmulProgramConfig>& program_config,
@@ -103,11 +143,24 @@ static bool get_post_process_bias(
     const MemoryConfig& output_mem_config,
     const ttnn::Tensor& input_tensor_a_adjusted,
     const ttnn::Tensor& input_tensor_b_adjusted,
-    const bool transpose_a) {
+    const bool transpose_a,
+    const bool transpose_b) {
     // Determine if we should post-process bias based on the program config
     // MatmulMultiCoreProgramConfig doesn't support bias fusion, so we need to apply it as a post-process
     bool post_process_bias = false;
     if (bias.has_value()) {
+        // The reuse-optimized factory fuses a full [M, N] bias (broadcast over batch) for a
+        // single-block-per-element config; route exactly those to fusion. Everything else (including
+        // batched weights with any other bias) falls through to a post-processed add.
+        if (reuse_config_fuses_full_block_bias(
+                program_config,
+                input_tensor_a_adjusted,
+                input_tensor_b_adjusted,
+                bias.value(),
+                transpose_a,
+                transpose_b)) {
+            return false;
+        }
         // Fused matmul+bias does not support batched weights; apply bias via add().
         if (detail::is_input_batched(input_tensor_b_adjusted.logical_shape())) {
             return true;
@@ -242,7 +295,8 @@ static ttnn::Tensor bound_matmul(
         parameters.output_mem_config,
         input_tensor_a_adjusted,
         input_tensor_b_adjusted,
-        parameters.transpose_a);
+        parameters.transpose_a,
+        parameters.transpose_b);
 
     auto attributes = ttnn::prim::create_matmul_attributes(
         input_tensor_a_adjusted, input_tensor_b_adjusted, parameters, {optional_output_tensor});

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -152,6 +152,8 @@ static bool get_post_process_bias(
         // The reuse-optimized factory fuses a full [M, N] bias (broadcast over batch) for a
         // single-block-per-element config; route exactly those to fusion. Everything else (including
         // batched weights with any other bias) falls through to a post-processed add.
+        const bool is_reuse_config = program_config.has_value() &&
+                                     std::holds_alternative<MatmulMultiCoreReuseProgramConfig>(program_config.value());
         if (reuse_config_fuses_full_block_bias(
                 program_config,
                 input_tensor_a_adjusted,
@@ -160,6 +162,10 @@ static bool get_post_process_bias(
                 transpose_a,
                 transpose_b)) {
             return false;
+        }
+        // A row-broadcastable ([1, N]) bias on the reuse config must be post-processed.
+        if (is_reuse_config && utilities::fused_matmul_bias_row_broadcastable(bias)) {
+            return true;
         }
         // Fused matmul+bias does not support batched weights; apply bias via add().
         if (detail::is_input_batched(input_tensor_b_adjusted.logical_shape())) {

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -863,6 +863,9 @@ void py_module(nb::module_& mod) {
 
         Keyword Args:
             bias (ttnn.Tensor, optional): the bias tensor to be added. If specified, needs to be on the device. Defaults to `None`.
+                Most program configs take a row-vector bias of shape ``[1, N]`` (or ``[1, 1, 1, N]``), broadcast across the output rows.
+                The batched ``MatmulMultiCoreReuseProgramConfig`` path additionally supports a full-tile bias of shape ``[M, N]``,
+                added to the output and broadcast over the batch dimension.
             transpose_a (bool, optional): Whether to transpose input_tensor_a. Defaults to `False`.
             transpose_b (bool, optional): Whether to transpose input_tensor_b. Defaults to `False`.
             memory_config (ttnn.MemoryConfig, optional): the memory configuration of the output tensor. Defaults to `None`, which will result in using `ttnn.DRAM_MEMORY_CONFIG`.


### PR DESCRIPTION
### PR Category
Feature

### Summary
Contributes to GDN prefill perf: https://github.com/tenstorrent/tt-metal/issues/42828

Adds a fused full-tile (elementwise) bias path to matmul_multicore_reuse_optimized (MatmulMultiCoreReuseProgramConfig). The compute kernel bmm_large_block_zm_fused_bias_activation already implemented the elementwise add; this wires it up on the host + dataflow and extends it to a full per-batch [M, N] bias with broadcast over the batch dimension.

This PR enables adding a full [M, N] elementwise bias, broadcast over batch. Adds ttnn.linear tests plus a negative test for the multi-N-block guard.


### Notes for reviewers
- Requires each batch element's matrix to be a single program block (N == per_core_N and per_core_M_per_batch == M), guarded by a TT_FATAL
- matmul_device_operation.cpp: remove the now-vacuous validate_matmul_bias. It only rejected bias on MatmulMultiCoreReuseProgramConfig; that config now fuses bias, so every config supports bias (fused or post-processed via get_post_process_bias).
- matmul.cpp: route batched bias to the fused prim for this config (previously always post-processed via ttnn.add when the weights were batched).
- factory: bias CB (c_3) sized to the whole [M, N] block (per_core_M_per_batch*per_core_N)
- reader_writer_bmm_tile_layout_in1.cpp: load the whole [M, N] bias block once, reused across the core's batch iterations.
- compute kernel: BIAS_FULL_BLOCK indexes the bias by (M-tile-row, N-tile); the define is set only by this factory, so mcast callers (single bias row) behave the same as previously.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/matmul-fused-elementwise-bias)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/matmul-fused-elementwise-bias)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/matmul-fused-elementwise-bias)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/matmul-fused-elementwise-bias)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=iwrosz/matmul-fused-elementwise-bias)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:iwrosz/matmul-fused-elementwise-bias)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/matmul-fused-elementwise-bias)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/matmul-fused-elementwise-bias)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/matmul-fused-elementwise-bias)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/matmul-fused-elementwise-bias)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/matmul-fused-elementwise-bias)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/matmul-fused-elementwise-bias)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/matmul-fused-elementwise-bias)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/matmul-fused-elementwise-bias)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/matmul-fused-elementwise-bias)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/matmul-fused-elementwise-bias)