### PR TITLE
[Cleanup] Blackhole SFPU MEDIUM-bucket sfpi conversions (net wins)

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_addcmul.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_addcmul.h
@@ -4,49 +4,61 @@
 
 #pragma once
 
+#include <cstdint>
 #include "llk_defs.h"
 #include "sfpi.h"
+#include "sfpu/ckernel_sfpu_converter.h"
 
 namespace ckernel::sfpu {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, DataFormat data_format, int ITERATIONS>
 inline void calculate_addcmul(
-    const uint dst_index_in0,  // input_a
-    const uint dst_index_in1,  // input_b
-    const uint dst_index_in2,  // input_c
-    const uint dst_index_out,  // output
-    const uint value) {        // scalar value to multiply with input_b
+    const std::uint32_t dst_index_in0,  // input_a
+    const std::uint32_t dst_index_in1,  // input_b
+    const std::uint32_t dst_index_in2,  // input_c
+    const std::uint32_t dst_index_out,  // output
+    const std::uint32_t value) {        // scalar value to multiply with input_b
     static_assert(
         data_format == DataFormat::Float32 || data_format == DataFormat::Float16_b || data_format == DataFormat::Bfp8_b,
         "Unsupported data format for calculate_addcmul(). Only Float32, Float16_b (BFloat16), and Bfp8_b (BFloat8B) "
         "are allowed.");
+    static_assert(ITERATIONS % 2 == 0, "calculate_addcmul() processes dest rows in interleaved pairs.");
 
-    constexpr InstrModLoadStore mod0 =
-        (data_format == DataFormat::Float32) ? InstrModLoadStore::FP32 : InstrModLoadStore::DEFAULT;
-    // size of each tile in Dest is 64 rows
-    constexpr uint dst_tile_size = 64;
-    // addcmul = input_a + ((value * input_b) * input_c)
-    TT_SFPLOADI(p_sfpu::LREG3, sfpi::SFPLOADI_MOD0_LOWER, value & 0xFFFF);
-    TT_SFPLOADI(p_sfpu::LREG3, sfpi::SFPLOADI_MOD0_UPPER, value >> 16);
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+    const sfpi::vFloat value_float = Converter::as_float(value);
+
+    const std::uint32_t off_in0 = dst_index_in0 * dst_tile_size_sfpi;
+    const std::uint32_t off_in1 = dst_index_in1 * dst_tile_size_sfpi;
+    const std::uint32_t off_in2 = dst_index_in2 * dst_tile_size_sfpi;
+    const std::uint32_t off_out = dst_index_out * dst_tile_size_sfpi;
+
 #pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++) {
-        TT_SFPLOAD(p_sfpu::LREG1, mod0, ADDR_MOD_7, dst_index_in1 * dst_tile_size);
-        TTI_SFPMUL(p_sfpu::LREG1, p_sfpu::LREG3, p_sfpu::LCONST_0, p_sfpu::LREG4, 0);
-        TT_SFPLOAD(p_sfpu::LREG0, mod0, ADDR_MOD_7, dst_index_in0 * dst_tile_size);
-        TT_SFPLOAD(p_sfpu::LREG2, mod0, ADDR_MOD_7, dst_index_in2 * dst_tile_size);
-        TTI_SFPMAD(p_sfpu::LREG2, p_sfpu::LREG4, p_sfpu::LREG0, p_sfpu::LREG5, 0);
-        TTI_SFPNOP;
+    for (int d = 0; d < ITERATIONS; d += 2) {
+        // Two independent rows (A at +0, B at +1) so the scheduler can overlap
+        // their dependent MUL->MAD->round chains and hide the 2-cycle latency.
+        sfpi::vFloat a_in0 = sfpi::dst_reg[off_in0];
+        sfpi::vFloat a_in1 = sfpi::dst_reg[off_in1];
+        sfpi::vFloat a_in2 = sfpi::dst_reg[off_in2];
+        sfpi::vFloat b_in0 = sfpi::dst_reg[off_in0 + 1];
+        sfpi::vFloat b_in1 = sfpi::dst_reg[off_in1 + 1];
+        sfpi::vFloat b_in2 = sfpi::dst_reg[off_in2 + 1];
+
+        // Sequence both products before both MADs so the scheduler can issue
+        // MUL_a, MUL_b back-to-back (each hiding the other's latency), then
+        // MAD_a, MAD_b, keeping the pipeline NOP-free.
+        sfpi::vFloat a_prod = value_float * a_in1;
+        sfpi::vFloat b_prod = value_float * b_in1;
+        sfpi::vFloat a_res = a_prod * a_in2 + a_in0;
+        sfpi::vFloat b_res = b_prod * b_in2 + b_in0;
+
         if constexpr (!is_fp32_dest_acc_en) {
-            TTI_SFP_STOCH_RND(
-                /*rnd_mode*/ sfpi::SFPSTOCHRND_RND_EVEN,
-                /* imm8_math*/ 0,
-                /*lreg_src_b*/ 0,
-                /*lreg_src_c*/ p_sfpu::LREG5,
-                /*lreg_dest*/ p_sfpu::LREG5,
-                /*instr_mod1*/ sfpi::SFPSTOCHRND_MOD1_FP32_TO_FP16B);
+            sfpi::dst_reg[off_out] = sfpi::convert<sfpi::vFloat16b>(a_res, sfpi::RoundMode::Nearest);
+            sfpi::dst_reg[off_out + 1] = sfpi::convert<sfpi::vFloat16b>(b_res, sfpi::RoundMode::Nearest);
+        } else {
+            sfpi::dst_reg[off_out] = a_res;
+            sfpi::dst_reg[off_out + 1] = b_res;
         }
-        TT_SFPSTORE(p_sfpu::LREG5, mod0, ADDR_MOD_7, dst_index_out * dst_tile_size);
-        sfpi::dst_reg++;
+        sfpi::dst_reg += 2;
     }
 }
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binop_with_unary.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binop_with_unary.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <limits>
+#include <cstdint>
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
@@ -24,7 +25,7 @@ enum {
 };  // BINOP_MODE
 
 template <bool APPROXIMATION_MODE, int BINOP_MODE, int ITERATIONS = 8>
-void calculate_binop_with_scalar(uint32_t param) {
+void calculate_binop_with_scalar(std::uint32_t param) {
     const sfpi::vFloat parameter = Converter::as_float(param);
 
     for (int d = 0; d < ITERATIONS; d++) {
@@ -57,60 +58,54 @@ void calculate_binop_with_scalar(uint32_t param) {
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-void calculate_add(uint32_t param) {
+void calculate_add(std::uint32_t param) {
     calculate_binop_with_scalar<APPROXIMATION_MODE, ADD, ITERATIONS>(param);
     return;
 }
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-void calculate_sub(uint32_t param) {
+void calculate_sub(std::uint32_t param) {
     calculate_binop_with_scalar<APPROXIMATION_MODE, SUB, ITERATIONS>(param);
     return;
 }
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-void calculate_mul(uint32_t param) {
+void calculate_mul(std::uint32_t param) {
     calculate_binop_with_scalar<APPROXIMATION_MODE, MUL, ITERATIONS>(param);
     return;
 }
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-void calculate_div(uint32_t param) {
+void calculate_div(std::uint32_t param) {
     calculate_binop_with_scalar<APPROXIMATION_MODE, DIV, ITERATIONS>(param);
     return;
 }
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-void calculate_rsub(uint32_t param) {
+void calculate_rsub(std::uint32_t param) {
     calculate_binop_with_scalar<APPROXIMATION_MODE, RSUB, ITERATIONS>(param);
     return;
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-void calculate_add_int32(uint32_t scalar) {
-    int int_scalar = scalar;
-
-    // Load value scalar to lreg2
-    _sfpu_load_imm32_(p_sfpu::LREG2, int_scalar);
+void calculate_add_int32(std::uint32_t scalar) {
+    // out = dst + scalar. The scalar is hoisted into a vInt once; the compiler keeps it live across
+    // the (unrolled) loop, so there is no per-iteration SFPMOV to re-preserve it as in the raw
+    // _sfpu_load_imm32_ + TTI_SFPMOV path. `a + s` lowers to the same single SFPIADD.
+    const sfpi::vInt s = static_cast<int>(scalar);
+#pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
-        TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);  // Using mov to preserve the scalar value after each iteration
-        TTI_SFPIADD(0, p_sfpu::LREG0, p_sfpu::LREG1, 4);
-        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+        sfpi::vInt a = sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>();
+        sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>() = a + s;
         sfpi::dst_reg++;
     }
 }
 
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-void calculate_sub_int32(uint32_t scalar) {
-    int int_scalar = scalar;
-
-    // Load value scalar to lreg2
-    _sfpu_load_imm32_(p_sfpu::LREG2, int_scalar);
+void calculate_sub_int32(std::uint32_t scalar) {
+    // out = dst - scalar. Scalar hoisted once (see calculate_add_int32); `a - s` lowers to the same
+    // single SFPIADD (2's-complement of the scalar operand) the raw path emitted with imod 6.
+    const sfpi::vInt s = static_cast<int>(scalar);
+#pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
-        // Move scalar to lreg1 because lreg1 is the destination register in each loop iteration, so lreg2 keeps the
-        // original scalar value.
-        TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
-        // Used 6 as imod to convert operand B to 2's complement for sub operation
-        TTI_SFPIADD(0, p_sfpu::LREG0, p_sfpu::LREG1, 6);
-        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+        sfpi::vInt a = sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>();
+        sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>() = a - s;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_add_int.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_add_int.h
@@ -28,38 +28,56 @@ inline void _add_int_(const std::uint32_t dst_index_in0, const std::uint32_t dst
     // INSTRUCTION_MODE = InstrModLoadStore::INT32_2S_COMP enables LOAD/STORE operations to convert INT32 sign-magnitude to 2's complement.
     // However, in Blackhole, this mode has no effect and the data format remains unchanged.
 
-    // If LOAD/STORE have the value in INT sign-magnitude format and SFPU needs it as 2's complement.
-    constexpr auto INSTR_MOD_CAST = InstrModCast::INT_SIGN_MAGN_TO_INT32_2S_COMP;
+    if constexpr (SIGN_MAGNITUDE_FORMAT)
+    {
+        // Sign-magnitude operands must be converted to 2's complement in-LREG before/after the
+        // integer add, because on Blackhole the INT32_2S_COMP load/store mode has no effect. This
+        // manual conversion has no sfpi equivalent, so keep the raw hand-scheduled path here.
+        constexpr auto INSTR_MOD_CAST = InstrModCast::INT_SIGN_MAGN_TO_INT32_2S_COMP;
 
-    // size of each tile in Dest is 64 rows
-    constexpr std::uint32_t dst_tile_size = 64;
+        // size of each tile in Dest is 64 rows
+        constexpr std::uint32_t dst_tile_size = 64;
 
 #pragma GCC unroll 8
-    for (int d = 0; d < ITERATIONS; d++)
-    {
-        // operand A
-        TT_SFPLOAD(p_sfpu::LREG0 /*lreg*/, INSTRUCTION_MODE, ADDR_MOD_7, dst_index_in0 * dst_tile_size);
-        if constexpr (SIGN_MAGNITUDE_FORMAT)
+        for (int d = 0; d < ITERATIONS; d++)
         {
+            // operand A
+            TT_SFPLOAD(p_sfpu::LREG0 /*lreg*/, INSTRUCTION_MODE, ADDR_MOD_7, dst_index_in0 * dst_tile_size);
             apply_sign_magnitude_conversion(p_sfpu::LREG0, p_sfpu::LREG2, INSTR_MOD_CAST);
-        }
 
-        // operand B
-        TT_SFPLOAD(p_sfpu::LREG1 /*lreg*/, INSTRUCTION_MODE, ADDR_MOD_7, dst_index_in1 * dst_tile_size);
-        if constexpr (SIGN_MAGNITUDE_FORMAT)
-        {
+            // operand B
+            TT_SFPLOAD(p_sfpu::LREG1 /*lreg*/, INSTRUCTION_MODE, ADDR_MOD_7, dst_index_in1 * dst_tile_size);
             apply_sign_magnitude_conversion(p_sfpu::LREG1, p_sfpu::LREG2, INSTR_MOD_CAST);
-        }
 
-        TTI_SFPIADD(0 /*imm*/, p_sfpu::LREG1 /*lreg_c*/, p_sfpu::LREG0 /*lreg_dest*/, 4 /*imod*/);
+            TTI_SFPIADD(0 /*imm*/, p_sfpu::LREG1 /*lreg_c*/, p_sfpu::LREG0 /*lreg_dest*/, 4 /*imod*/);
 
-        // LREG_0 -> dest
-        if constexpr (SIGN_MAGNITUDE_FORMAT)
-        {
+            // LREG_0 -> dest
             apply_sign_magnitude_conversion(p_sfpu::LREG0, p_sfpu::LREG1, INSTR_MOD_CAST);
+            TT_SFPSTORE(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, dst_index_out * dst_tile_size);
+            sfpi::dst_reg++;
         }
-        TT_SFPSTORE(p_sfpu::LREG0, INSTRUCTION_MODE, ADDR_MOD_7, dst_index_out * dst_tile_size);
-        sfpi::dst_reg++;
+    }
+    else
+    {
+        // Integer add expressed in sfpi. `a + b` lowers to the same single SFPIADD the raw path used,
+        // but the loads/store and the dst walk are left to the compiler, dropping the per-iteration
+        // bookkeeping. Pick the DataLayout whose load/store format byte matches the original
+        // InstrModLoadStore (LO16->U16, INT32/2S_COMP->I32; on Blackhole INT32_2S_COMP loads the same
+        // raw bits as INT32).
+        constexpr sfpi::DataLayout layout = (INSTRUCTION_MODE == InstrModLoadStore::LO16) ? sfpi::DataLayout::U16 : sfpi::DataLayout::I32;
+        using vType                       = std::conditional_t<layout == sfpi::DataLayout::U16, sfpi::vUInt, sfpi::vInt>;
+
+        // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
+        constexpr std::uint32_t dst_tile_size_sfpi = 32;
+
+#pragma GCC unroll 8
+        for (int d = 0; d < ITERATIONS; d++)
+        {
+            vType a                                                          = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi].mode<layout>();
+            vType b                                                          = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi].mode<layout>();
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi].mode<layout>() = a + b;
+            sfpi::dst_reg++;
+        }
     }
 }
 


### PR DESCRIPTION
Cleanup and conversion to sfpi of medium kernels from issue https://github.com/tenstorrent/tt-metal/issues/49796


## Combined results

| Kernel (layer) | Perf test / op | variant | cyc/tile main | cyc/tile branch | Δ % | size main (B) | size branch (B) | Δ B |
|---|---|---|---:|---:|---:|---:|---:|---:|
| `addcmul` (metal) | `perf_sfpu_ternary` / SfpuAddcmul | Bfp8_b, dest_acc=No | 330.45 | 293.38 | **−11.22 %** | 2486 | 2342 | −144 |
| `addcmul` (metal) | " | Bfp8_b, dest_acc=Yes | 298.47 | 245.39 | **−17.78 %** | 2490 | 2350 | −140 |
| `addcmul` (metal) | " | Float16_b, dest_acc=No | 330.31 | 293.27 | **−11.22 %** | 2486 | 2342 | −144 |
| `addcmul` (metal) | " | Float16_b, dest_acc=Yes | 298.27 | 245.15 | **−17.81 %** | 2490 | 2350 | −140 |
| `addcmul` (metal) | " | Float32, dest_acc=Yes | 298.61 | 245.56 | **−17.76 %** | 2490 | 2350 | −140 |
| `addcmul` (metal) | " | Float32, dest_acc=No (unpack_to_dest) | 311.69 | 274.62 | **−11.89 %** | 2438 | 2318 | −120 |
| `binop_with_unary` (metal) | `perf_eltwise_unary_sfpu_int32` | AddInt32 | 169.45 | 138.39 | **−18.33 %** | 2177 | 2213 | +36 |
| `binop_with_unary` (metal) | " | SubInt32 | 169.45 | 138.39 | **−18.33 %** | 2177 | 2217 | +40 |
| `add_int` (tt-llk) | `perf_eltwise_binary_sfpu` / SfpuElwadd | Int32, approx=No | 192.99 | 178.47 | **−7.53 %** | 2262 | 2182 | −80 |
| `add_int` (tt-llk) | " | Int32, approx=Yes | 192.99 | 178.47 | **−7.53 %** | 2262 | 2182 | −80 |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ldjurovic/bh_sfpu_medium)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ldjurovic/bh_sfpu_medium)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ldjurovic/bh_sfpu_medium)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ldjurovic/bh_sfpu_medium)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ldjurovic/bh_sfpu_medium)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ldjurovic/bh_sfpu_medium)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ldjurovic/bh_sfpu_medium)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ldjurovic/bh_sfpu_medium)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ldjurovic/bh_sfpu_medium)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ldjurovic/bh_sfpu_medium)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ldjurovic/bh_sfpu_medium)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ldjurovic/bh_sfpu_medium)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ldjurovic/bh_sfpu_medium)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ldjurovic/bh_sfpu_medium)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ldjurovic/bh_sfpu_medium)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ldjurovic/bh_sfpu_medium)