### PR TITLE
Use host assigned ID instead of hashing for zone name and source locations 

### DIFF
--- a/tests/tt_metal/tools/profiler/CMakeLists.txt
+++ b/tests/tt_metal/tools/profiler/CMakeLists.txt
@@ -11,6 +11,11 @@ foreach(TEST_SRC ${PROFILER_TEST_SRCS})
     add_executable(${TEST_TARGET} ${TEST_SRC})
     target_link_libraries(${TEST_TARGET} PRIVATE tt_metal)
 
+    # Reuse the shared precompiled header (heavy Metalium/STL includes) to cut clean-build time.
+    if(TARGET TT::CommonPCH)
+        target_precompile_headers(${TEST_TARGET} REUSE_FROM TT::CommonPCH)
+    endif()
+
     target_include_directories(
         ${TEST_TARGET}
         PRIVATE

--- a/tests/tt_metal/tools/profiler/CMakeLists.txt
+++ b/tests/tt_metal/tools/profiler/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(PROFILER_TEST_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/test_full_buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_timestamped_events.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_zone_id_budget.cpp
 )
 
 foreach(TEST_SRC ${PROFILER_TEST_SRCS})

--- a/tests/tt_metal/tools/profiler/kernels/zone_budget.cpp
+++ b/tests/tt_metal/tools/profiler/kernels/zone_budget.cpp
@@ -4,10 +4,12 @@
 
 // Test kernel for KERNEL_PROFILER structural zone-id budgeting. It emits many distinctly-named
 // device profiler zones in a single translation unit:
-//   - by default: 40 zones, comfortably under the per-TU budget (KERNEL_PROFILER_LOCAL_BITS = 6 =>
-//     64 zone ids per TU, minus the handful of internal/firmware zones);
-//   - with -DZONE_OVER_BUDGET: 80 zones, which pushes the per-TU local index past 63 and must trip
-//     the static_assert in TT_ZONE_META (kernel_profiler.hpp) so the kernel fails to compile.
+//   - by default: 40 zones, comfortably under the default per-TU budget (KERNEL_PROFILER_LOCAL_BITS = 6
+//     => 64 zone ids per TU, minus the handful of internal/firmware zones);
+//   - with -DZONE_OVER_BUDGET: 240 zones. That exceeds the default 64-zone budget, so in default mode
+//     it trips the static_assert in TT_ZONE_META (kernel_profiler.hpp) and the kernel fails to compile.
+//     In more-zone-names mode (TT_METAL_PROFILER_MORE_ZONE_NAMES set => LOCAL_BITS = 9 => 512 zones/TU)
+//     the same kernel is under budget, so it compiles and profiles -- exercising >64 zones in one file.
 //
 // This is a data-movement kernel, so the profiler macros are auto-injected by the JIT build and no
 // explicit profiler include is needed.
@@ -24,6 +26,10 @@
 #define ZONE10(p) \
     ZONE(p "0")   \
     ZONE(p "1") ZONE(p "2") ZONE(p "3") ZONE(p "4") ZONE(p "5") ZONE(p "6") ZONE(p "7") ZONE(p "8") ZONE(p "9")
+#define ZONE100(p) \
+    ZONE10(p "0")  \
+    ZONE10(p "1")  \
+    ZONE10(p "2") ZONE10(p "3") ZONE10(p "4") ZONE10(p "5") ZONE10(p "6") ZONE10(p "7") ZONE10(p "8") ZONE10(p "9")
 
 void kernel_main() {
     // 40 distinctly-named zones (4 groups of 10: a0..d9) -- comfortably under the 64-zone/TU budget
@@ -34,10 +40,9 @@ void kernel_main() {
     ZONE10("d")
 
 #if defined(ZONE_OVER_BUDGET)
-    // +40 -> 80 zones in this TU -> per-TU local index exceeds 63 -> static_assert must fire.
-    ZONE10("e")
-    ZONE10("f")
-    ZONE10("g")
-    ZONE10("h")
+    // +200 -> 240 zones in this TU. Over the default 64-zone budget (static_assert must fire in default
+    // mode); within the 512-zone more-zone-names budget (compiles + profiles there).
+    ZONE100("y")
+    ZONE100("z")
 #endif
 }

--- a/tests/tt_metal/tools/profiler/kernels/zone_budget.cpp
+++ b/tests/tt_metal/tools/profiler/kernels/zone_budget.cpp
@@ -4,9 +4,9 @@
 
 // Test kernel for KERNEL_PROFILER structural zone-id budgeting. It emits many distinctly-named
 // device profiler zones in a single translation unit:
-//   - by default: 120 zones, comfortably under the per-TU budget (KERNEL_PROFILER_LOCAL_BITS = 7 =>
-//     128 zone ids per TU, minus the 3 internal PROFILER-* zones);
-//   - with -DZONE_OVER_BUDGET: 130 zones, which pushes the per-TU local index past 127 and must trip
+//   - by default: 40 zones, comfortably under the per-TU budget (KERNEL_PROFILER_LOCAL_BITS = 6 =>
+//     64 zone ids per TU, minus the handful of internal/firmware zones);
+//   - with -DZONE_OVER_BUDGET: 80 zones, which pushes the per-TU local index past 63 and must trip
 //     the static_assert in TT_ZONE_META (kernel_profiler.hpp) so the kernel fails to compile.
 //
 // This is a data-movement kernel, so the profiler macros are auto-injected by the JIT build and no
@@ -26,22 +26,18 @@
     ZONE(p "1") ZONE(p "2") ZONE(p "3") ZONE(p "4") ZONE(p "5") ZONE(p "6") ZONE(p "7") ZONE(p "8") ZONE(p "9")
 
 void kernel_main() {
-    // 120 distinctly-named zones (12 groups of 10: a0..l9).
+    // 40 distinctly-named zones (4 groups of 10: a0..d9) -- comfortably under the 64-zone/TU budget
+    // (KERNEL_PROFILER_LOCAL_BITS = 6), even after the handful of firmware/internal zones in this TU.
     ZONE10("a")
     ZONE10("b")
     ZONE10("c")
     ZONE10("d")
+
+#if defined(ZONE_OVER_BUDGET)
+    // +40 -> 80 zones in this TU -> per-TU local index exceeds 63 -> static_assert must fire.
     ZONE10("e")
     ZONE10("f")
     ZONE10("g")
     ZONE10("h")
-    ZONE10("i")
-    ZONE10("j")
-    ZONE10("k")
-    ZONE10("l")
-
-#if defined(ZONE_OVER_BUDGET)
-    // 10 more -> 130 zones in this TU -> per-TU local index exceeds 127 -> static_assert must fire.
-    ZONE10("z")
 #endif
 }

--- a/tests/tt_metal/tools/profiler/kernels/zone_budget.cpp
+++ b/tests/tt_metal/tools/profiler/kernels/zone_budget.cpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Test kernel for KERNEL_PROFILER structural zone-id budgeting. It emits many distinctly-named
+// device profiler zones in a single translation unit:
+//   - by default: 120 zones, comfortably under the per-TU budget (KERNEL_PROFILER_LOCAL_BITS = 7 =>
+//     128 zone ids per TU, minus the 3 internal PROFILER-* zones);
+//   - with -DZONE_OVER_BUDGET: 130 zones, which pushes the per-TU local index past 127 and must trip
+//     the static_assert in TT_ZONE_META (kernel_profiler.hpp) so the kernel fails to compile.
+//
+// This is a data-movement kernel, so the profiler macros are auto-injected by the JIT build and no
+// explicit profiler include is needed.
+
+#include <cstdint>
+
+// One profiler zone in its own block scope, with a unique name via adjacent string-literal
+// concatenation. Distinct call sites get distinct __COUNTER__ values -> distinct structural ids.
+#define ZONE(nm)               \
+    {                          \
+        DeviceZoneScopedN(nm); \
+        asm volatile("nop");   \
+    }
+#define ZONE10(p) \
+    ZONE(p "0")   \
+    ZONE(p "1") ZONE(p "2") ZONE(p "3") ZONE(p "4") ZONE(p "5") ZONE(p "6") ZONE(p "7") ZONE(p "8") ZONE(p "9")
+
+void kernel_main() {
+    // 120 distinctly-named zones (12 groups of 10: a0..l9).
+    ZONE10("a")
+    ZONE10("b")
+    ZONE10("c")
+    ZONE10("d")
+    ZONE10("e")
+    ZONE10("f")
+    ZONE10("g")
+    ZONE10("h")
+    ZONE10("i")
+    ZONE10("j")
+    ZONE10("k")
+    ZONE10("l")
+
+#if defined(ZONE_OVER_BUDGET)
+    // 10 more -> 130 zones in this TU -> per-TU local index exceeds 127 -> static_assert must fire.
+    ZONE10("z")
+#endif
+}

--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -323,9 +323,9 @@ def test_full_buffer():
 
 @pytest.mark.skip_post_commit
 def test_zone_id_budget():
-    # The binary asserts (a) a 120-zone-per-TU kernel compiles and profiles, and (b) a >128-zone-per-TU
-    # kernel fails to compile via the TT_ZONE_META static_assert. A zero exit code means both held.
-    # Then verify the structural zone-id invariants directly from the zone-locations log.
+    # The binary asserts (a) a 40-zone-per-TU kernel compiles and profiles, and (b) a 240-zone-per-TU
+    # kernel (over the default 64-zone budget) fails to compile via the TT_ZONE_META static_assert. A
+    # zero exit code means both held. Then verify the structural zone-id invariants from the log.
     run_device_profiler_test(testName="build/test/tt_metal/tools/profiler/test_zone_id_budget", noPostProcess=True)
 
     LOCAL_BITS = 6  # keep in sync with KERNEL_PROFILER_LOCAL_BITS in profiler_common.h
@@ -356,6 +356,44 @@ def test_zone_id_budget():
     # not just that the run did not crash.
     max_zones_in_one_tu = max(len(ids) for ids in ids_per_file.values())
     assert max_zones_in_one_tu >= 40, f"expected a TU with >=40 zones, got max {max_zones_in_one_tu}"
+
+
+@pytest.mark.skip_post_commit
+def test_zone_id_budget_more_zone_names():
+    # With TT_METAL_PROFILER_MORE_ZONE_NAMES set, KERNEL_PROFILER_LOCAL_BITS becomes 9 (512 zone names
+    # per TU instead of 64), trading the file-id budget (512 instead of 4096). The binary detects the env
+    # var and builds a single-TU kernel with 240 zones -- which fails to compile in the default 64-zone
+    # mode -- and asserts it now compiles and profiles. A zero exit code means it held.
+    os.environ["TT_METAL_PROFILER_MORE_ZONE_NAMES"] = "1"
+    try:
+        run_device_profiler_test(testName="build/test/tt_metal/tools/profiler/test_zone_id_budget", noPostProcess=True)
+    finally:
+        del os.environ["TT_METAL_PROFILER_MORE_ZONE_NAMES"]
+
+    LOCAL_BITS = 9  # more-zone-names mode; keep in sync with KERNEL_PROFILER_LOCAL_BITS_MORE_ZONES
+    zone_log = PROFILER_LOGS_DIR / "new_zone_src_locations.log"
+    assert zone_log.exists(), f"zone source-location log not found: {zone_log}"
+
+    id_to_strings = {}  # zone id -> set of distinct source strings
+    ids_per_file = {}  # file_id -> set of zone ids
+    with open(zone_log) as f:
+        for line in f:
+            if "\t" not in line:
+                continue
+            id_str, src = line.rstrip("\n").split("\t", 1)
+            zid = int(id_str)
+            id_to_strings.setdefault(zid, set()).add(src)
+            ids_per_file.setdefault(zid >> LOCAL_BITS, set()).add(zid)
+
+    collisions = {zid: s for zid, s in id_to_strings.items() if len(s) > 1}
+    assert not collisions, f"zone id collisions detected: {collisions}"
+
+    # The 240-zone kernel put well over 64 zones in one TU -- impossible in the default (64-zone) mode,
+    # which is the whole point of more-zone-names mode.
+    max_zones_in_one_tu = max(len(ids) for ids in ids_per_file.values())
+    assert (
+        max_zones_in_one_tu > 64
+    ), f"expected a TU with >64 zones in more-zone-names mode, got max {max_zones_in_one_tu}"
 
 
 def wildcard_match(pattern, words):

--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -347,9 +347,10 @@ def test_zone_id_budget():
     collisions = {zid: s for zid, s in id_to_strings.items() if len(s) > 1}
     assert not collisions, f"zone id collisions detected: {collisions}"
 
-    # Cross-TU: the run spans many translation units (per-RISC firmware + kernels), each its own
-    # file_id partition -- exercises structural ids across >=10 TUs.
-    assert len(ids_per_file) >= 10, f"expected zones from >=10 translation units, got {len(ids_per_file)}"
+    # Cross-TU: the run spans multiple translation units (per-RISC firmware + the kernel), each its own
+    # file_id partition -- exercises structural ids across distinct TUs. The floor of 6 (>=5 Tensix
+    # firmware TUs + the kernel TU) is guaranteed on any arch; real runs typically span more.
+    assert len(ids_per_file) >= 6, f"expected zones from several translation units, got {len(ids_per_file)}"
 
     # One TU (the zone_budget kernel) holds ~120 zones -- confirms high per-TU counts really work,
     # not just that the run did not crash.

--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -321,6 +321,42 @@ def test_full_buffer():
         assert stats[statName]["stats"]["Count"] in REF_COUNT_DICT[ENV_VAR_ARCH_NAME], "Wrong Marker Repeat count"
 
 
+@pytest.mark.skip_post_commit
+def test_zone_id_budget():
+    # The binary asserts (a) a 120-zone-per-TU kernel compiles and profiles, and (b) a >128-zone-per-TU
+    # kernel fails to compile via the TT_ZONE_META static_assert. A zero exit code means both held.
+    # Then verify the structural zone-id invariants directly from the zone-locations log.
+    run_device_profiler_test(testName="build/test/tt_metal/tools/profiler/test_zone_id_budget", noPostProcess=True)
+
+    LOCAL_BITS = 7  # keep in sync with KERNEL_PROFILER_LOCAL_BITS in profiler_common.h
+    zone_log = PROFILER_LOGS_DIR / "new_zone_src_locations.log"
+    assert zone_log.exists(), f"zone source-location log not found: {zone_log}"
+
+    id_to_strings = {}  # zone id -> set of distinct source strings
+    ids_per_file = {}  # file_id -> set of zone ids
+    with open(zone_log) as f:
+        for line in f:
+            if "\t" not in line:
+                continue
+            id_str, src = line.rstrip("\n").split("\t", 1)
+            zid = int(id_str)
+            id_to_strings.setdefault(zid, set()).add(src)
+            ids_per_file.setdefault(zid >> LOCAL_BITS, set()).add(zid)
+
+    # Collision-free by construction: no id may map to two different source locations.
+    collisions = {zid: s for zid, s in id_to_strings.items() if len(s) > 1}
+    assert not collisions, f"zone id collisions detected: {collisions}"
+
+    # Cross-TU: the run spans many translation units (per-RISC firmware + kernels), each its own
+    # file_id partition -- exercises structural ids across >=10 TUs.
+    assert len(ids_per_file) >= 10, f"expected zones from >=10 translation units, got {len(ids_per_file)}"
+
+    # One TU (the zone_budget kernel) holds ~120 zones -- confirms high per-TU counts really work,
+    # not just that the run did not crash.
+    max_zones_in_one_tu = max(len(ids) for ids in ids_per_file.values())
+    assert max_zones_in_one_tu >= 120, f"expected a TU with >=120 zones, got max {max_zones_in_one_tu}"
+
+
 def wildcard_match(pattern, words):
     if not pattern.endswith("*"):
         return [word for word in words if pattern == word]

--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -328,7 +328,7 @@ def test_zone_id_budget():
     # Then verify the structural zone-id invariants directly from the zone-locations log.
     run_device_profiler_test(testName="build/test/tt_metal/tools/profiler/test_zone_id_budget", noPostProcess=True)
 
-    LOCAL_BITS = 7  # keep in sync with KERNEL_PROFILER_LOCAL_BITS in profiler_common.h
+    LOCAL_BITS = 6  # keep in sync with KERNEL_PROFILER_LOCAL_BITS in profiler_common.h
     zone_log = PROFILER_LOGS_DIR / "new_zone_src_locations.log"
     assert zone_log.exists(), f"zone source-location log not found: {zone_log}"
 
@@ -352,10 +352,10 @@ def test_zone_id_budget():
     # firmware TUs + the kernel TU) is guaranteed on any arch; real runs typically span more.
     assert len(ids_per_file) >= 6, f"expected zones from several translation units, got {len(ids_per_file)}"
 
-    # One TU (the zone_budget kernel) holds ~120 zones -- confirms high per-TU counts really work,
+    # One TU (the zone_budget kernel) holds ~40 zones -- confirms high per-TU counts really work,
     # not just that the run did not crash.
     max_zones_in_one_tu = max(len(ids) for ids in ids_per_file.values())
-    assert max_zones_in_one_tu >= 120, f"expected a TU with >=120 zones, got max {max_zones_in_one_tu}"
+    assert max_zones_in_one_tu >= 40, f"expected a TU with >=40 zones, got max {max_zones_in_one_tu}"
 
 
 def wildcard_match(pattern, words):

--- a/tests/tt_metal/tools/profiler/test_zone_id_budget.cpp
+++ b/tests/tt_metal/tools/profiler/test_zone_id_budget.cpp
@@ -28,6 +28,8 @@
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/distributed.hpp>
 
+#include "impl/context/metal_context.hpp"
+
 using namespace tt;
 using namespace tt::tt_metal;
 
@@ -61,35 +63,49 @@ int main() {
     try {
         std::shared_ptr<distributed::MeshDevice> mesh_device = distributed::MeshDevice::create_unit_mesh(0);
 
-        // Case 1: 40 zones in one TU must compile and profile (and the whole run stays collision-free
-        // across all the firmware/kernel TUs, else ReadMeshDeviceProfilerResults would throw).
-        RunZoneBudgetKernel(mesh_device, /*over_budget=*/false);
-        ReadMeshDeviceProfilerResults(*mesh_device);
+        // The zone-budget kernel is built with -DZONE_OVER_BUDGET = 240 zones in one TU. Whether that is
+        // "over budget" depends on the split: default LOCAL_BITS=6 allows 64/TU, more-zone-names mode
+        // (rtoptions TT_METAL_PROFILER_MORE_ZONE_NAMES) LOCAL_BITS=9 allows 512/TU. The JIT reads the same
+        // rtoptions flag, so the modes stay consistent.
+        const bool more_zone_names = tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_more_zone_names();
 
-        // Case 2: an over-budget kernel must fail to build via the TT_ZONE_META static_assert. The build
-        // errors logged next are EXPECTED -- the test verifies they happen and are the id-budget assert.
-        fmt::print(
-            "=== Building an over-budget kernel on purpose; the compiler/build errors that follow are "
-            "EXPECTED and are caught below. ===\n");
-        bool over_budget_threw = false;
-        std::string what;
-        try {
+        if (more_zone_names) {
+            // 512-zone/TU budget: the 240-zone kernel that overflows the default 64-zone budget must now
+            // COMPILE and profile. Reaching ReadMeshDeviceProfilerResults without throwing proves it.
             RunZoneBudgetKernel(mesh_device, /*over_budget=*/true);
-        } catch (const std::exception& e) {
-            over_budget_threw = true;
-            what = e.what();
+            ReadMeshDeviceProfilerResults(*mesh_device);
+            fmt::print("More-zone-names mode: 240-zone (>64) single-TU kernel compiled and profiled.\n");
+        } else {
+            // Case 1: 40 zones in one TU must compile and profile (and the whole run stays collision-free
+            // across all the firmware/kernel TUs, else ReadMeshDeviceProfilerResults would throw).
+            RunZoneBudgetKernel(mesh_device, /*over_budget=*/false);
+            ReadMeshDeviceProfilerResults(*mesh_device);
+
+            // Case 2: the 240-zone kernel must fail to build via the TT_ZONE_META static_assert. The
+            // build errors logged next are EXPECTED -- the test verifies they happen and are the assert.
+            fmt::print(
+                "=== Building an over-budget kernel on purpose; the compiler/build errors that follow are "
+                "EXPECTED and are caught below. ===\n");
+            bool over_budget_threw = false;
+            std::string what;
+            try {
+                RunZoneBudgetKernel(mesh_device, /*over_budget=*/true);
+            } catch (const std::exception& e) {
+                over_budget_threw = true;
+                what = e.what();
+            }
+            TT_FATAL(
+                over_budget_threw,
+                "Over-budget kernel (more zones than the per-TU budget) built successfully, but it must "
+                "have tripped the KERNEL_PROFILER_LOCAL_BITS static_assert and failed to compile");
+            // Confirm it failed for the RIGHT reason (the id-budget static_assert), not an unrelated error.
+            TT_FATAL(
+                what.find("too many KERNEL_PROFILER zones") != std::string::npos,
+                "Over-budget kernel failed to build, but not via the expected KERNEL_PROFILER_LOCAL_BITS "
+                "static_assert. Error was: {}",
+                what.substr(0, 500));
+            fmt::print("Over-budget kernel correctly failed to build via the id-budget static_assert.\n");
         }
-        TT_FATAL(
-            over_budget_threw,
-            "Over-budget kernel (more zones than the per-TU budget) built successfully, but it must have tripped the "
-            "KERNEL_PROFILER_LOCAL_BITS static_assert and failed to compile");
-        // Confirm it failed for the RIGHT reason (the id-budget static_assert), not some unrelated error.
-        TT_FATAL(
-            what.find("too many KERNEL_PROFILER zones") != std::string::npos,
-            "Over-budget kernel failed to build, but not via the expected KERNEL_PROFILER_LOCAL_BITS "
-            "static_assert. Error was: {}",
-            what.substr(0, 500));
-        fmt::print("Over-budget kernel correctly failed to build via the id-budget static_assert.\n");
 
         pass &= mesh_device->close();
 

--- a/tests/tt_metal/tools/profiler/test_zone_id_budget.cpp
+++ b/tests/tt_metal/tools/profiler/test_zone_id_budget.cpp
@@ -5,13 +5,16 @@
 // Unit test for KERNEL_PROFILER structural zone ids (id = (file_id << LOCAL_BITS) | local).
 //
 //   Case 1: a kernel with 120 profiler zones in one translation unit compiles and profiles -- the
-//           per-TU zone budget (128 with LOCAL_BITS=7) has headroom. Because this run also builds the
-//           per-RISC firmware (each its own TU with its own file_id), it exercises cross-TU id
-//           uniqueness: the run reaching ReadMeshDeviceProfilerResults without the host-side
-//           collision check firing proves the ids are collision-free across all those TUs.
+//           per-TU zone-id budget (128 with LOCAL_BITS=7) has headroom. Because this run also builds
+//           the per-RISC firmware (each its own TU with its own file_id), it exercises cross-TU id
+//           uniqueness: reaching ReadMeshDeviceProfilerResults without the host-side collision check
+//           firing proves the ids are collision-free across all those TUs. The kernel runs on RISCV_0
+//           (BRISC) because its code region is large (1.4 MB); NCRISC has only 16 KB of IRAM, a
+//           code-SIZE limit that is unrelated to the zone-id budget and would reject 120 zones' code.
 //   Case 2: a kernel with >128 zones in one TU must FAIL to compile -- the static_assert in
-//           TT_ZONE_META turns the overflow into a hard build error, which surfaces on the host as an
-//           exception. The test passes only if that build throws.
+//           TT_ZONE_META turns the id-budget overflow into a hard build error, which surfaces on the
+//           host as an exception. The test passes only if that build throws with the static_assert.
+//           The compiler/build errors it logs are INTENTIONAL (see the banner printed below).
 //
 // Requires profiling enabled (TT_METAL_DEVICE_PROFILER=1); otherwise the zone macros are no-ops and
 // there is no static_assert to trip. The pytest harness sets it.
@@ -28,8 +31,9 @@
 using namespace tt;
 using namespace tt::tt_metal;
 
-// Build + enqueue a program whose data-movement kernels are kernels/zone_budget.cpp. When over_budget
-// is set the kernel declares more zones than the per-TU budget allows, which must fail to compile.
+// Build + enqueue a program whose kernel is kernels/zone_budget.cpp on RISCV_0 (BRISC). When
+// over_budget is set the kernel declares more zones than the per-TU id budget allows, which must fail
+// to compile (arch-independently, at the static_assert, before any code-size/link check).
 void RunZoneBudgetKernel(const std::shared_ptr<distributed::MeshDevice>& mesh_device, bool over_budget) {
     distributed::MeshWorkload workload;
     distributed::MeshCoordinateRange device_range(mesh_device->shape());
@@ -40,24 +44,12 @@ void RunZoneBudgetKernel(const std::shared_ptr<distributed::MeshDevice>& mesh_de
         defines["ZONE_OVER_BUDGET"] = "1";
     }
 
-    const std::string kernel = "tests/tt_metal/tools/profiler/kernels/zone_budget.cpp";
-    const CoreCoord core = {0, 0};
-
     CreateKernel(
         program,
-        kernel,
-        core,
+        "tests/tt_metal/tools/profiler/kernels/zone_budget.cpp",
+        CoreCoord{0, 0},
         DataMovementConfig{
             .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .defines = defines});
-    if (!over_budget) {
-        // A second processor gives a second kernel TU (a distinct file_id) for the cross-TU check.
-        CreateKernel(
-            program,
-            kernel,
-            core,
-            DataMovementConfig{
-                .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .defines = defines});
-    }
 
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);
@@ -74,20 +66,30 @@ int main() {
         RunZoneBudgetKernel(mesh_device, /*over_budget=*/false);
         ReadMeshDeviceProfilerResults(*mesh_device);
 
-        // Case 2: >128 zones in one TU must fail to build via the TT_ZONE_META static_assert.
+        // Case 2: >128 zones in one TU must fail to build via the TT_ZONE_META static_assert. The build
+        // errors logged next are EXPECTED -- the test verifies they happen and are the id-budget assert.
+        fmt::print(
+            "=== Building an over-budget kernel on purpose; the compiler/build errors that follow are "
+            "EXPECTED and are caught below. ===\n");
         bool over_budget_threw = false;
+        std::string what;
         try {
             RunZoneBudgetKernel(mesh_device, /*over_budget=*/true);
         } catch (const std::exception& e) {
             over_budget_threw = true;
-            const std::string what = e.what();
-            // substr clamps when the string is shorter than the requested length.
-            fmt::print("Over-budget kernel correctly failed to build: {}\n", what.substr(0, 300));
+            what = e.what();
         }
         TT_FATAL(
             over_budget_threw,
             "Over-budget kernel (>128 zones in one TU) built successfully, but it must have tripped the "
             "KERNEL_PROFILER_LOCAL_BITS static_assert and failed to compile");
+        // Confirm it failed for the RIGHT reason (the id-budget static_assert), not some unrelated error.
+        TT_FATAL(
+            what.find("too many KERNEL_PROFILER zones") != std::string::npos,
+            "Over-budget kernel failed to build, but not via the expected KERNEL_PROFILER_LOCAL_BITS "
+            "static_assert. Error was: {}",
+            what.substr(0, 500));
+        fmt::print("Over-budget kernel correctly failed to build via the id-budget static_assert.\n");
 
         pass &= mesh_device->close();
 

--- a/tests/tt_metal/tools/profiler/test_zone_id_budget.cpp
+++ b/tests/tt_metal/tools/profiler/test_zone_id_budget.cpp
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Unit test for KERNEL_PROFILER structural zone ids (id = (file_id << LOCAL_BITS) | local).
+//
+//   Case 1: a kernel with 120 profiler zones in one translation unit compiles and profiles -- the
+//           per-TU zone budget (128 with LOCAL_BITS=7) has headroom. Because this run also builds the
+//           per-RISC firmware (each its own TU with its own file_id), it exercises cross-TU id
+//           uniqueness: the run reaching ReadMeshDeviceProfilerResults without the host-side
+//           collision check firing proves the ids are collision-free across all those TUs.
+//   Case 2: a kernel with >128 zones in one TU must FAIL to compile -- the static_assert in
+//           TT_ZONE_META turns the overflow into a hard build error, which surfaces on the host as an
+//           exception. The test passes only if that build throws.
+//
+// Requires profiling enabled (TT_METAL_DEVICE_PROFILER=1); otherwise the zone macros are no-ops and
+// there is no static_assert to trip. The pytest harness sets it.
+
+#include <cstdint>
+#include <cstring>
+#include <map>
+#include <string>
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/distributed.hpp>
+
+using namespace tt;
+using namespace tt::tt_metal;
+
+// Build + enqueue a program whose data-movement kernels are kernels/zone_budget.cpp. When over_budget
+// is set the kernel declares more zones than the per-TU budget allows, which must fail to compile.
+void RunZoneBudgetKernel(const std::shared_ptr<distributed::MeshDevice>& mesh_device, bool over_budget) {
+    distributed::MeshWorkload workload;
+    distributed::MeshCoordinateRange device_range(mesh_device->shape());
+    Program program = CreateProgram();
+
+    std::map<std::string, std::string> defines;
+    if (over_budget) {
+        defines["ZONE_OVER_BUDGET"] = "1";
+    }
+
+    const std::string kernel = "tests/tt_metal/tools/profiler/kernels/zone_budget.cpp";
+    const CoreCoord core = {0, 0};
+
+    CreateKernel(
+        program,
+        kernel,
+        core,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .defines = defines});
+    if (!over_budget) {
+        // A second processor gives a second kernel TU (a distinct file_id) for the cross-TU check.
+        CreateKernel(
+            program,
+            kernel,
+            core,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .defines = defines});
+    }
+
+    workload.add_program(device_range, std::move(program));
+    distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);
+}
+
+int main() {
+    bool pass = true;
+
+    try {
+        std::shared_ptr<distributed::MeshDevice> mesh_device = distributed::MeshDevice::create_unit_mesh(0);
+
+        // Case 1: 120 zones in one TU must compile and profile (and the whole run stays collision-free
+        // across all the firmware/kernel TUs, else ReadMeshDeviceProfilerResults would throw).
+        RunZoneBudgetKernel(mesh_device, /*over_budget=*/false);
+        ReadMeshDeviceProfilerResults(*mesh_device);
+
+        // Case 2: >128 zones in one TU must fail to build via the TT_ZONE_META static_assert.
+        bool over_budget_threw = false;
+        try {
+            RunZoneBudgetKernel(mesh_device, /*over_budget=*/true);
+        } catch (const std::exception& e) {
+            over_budget_threw = true;
+            const std::string what = e.what();
+            // substr clamps when the string is shorter than the requested length.
+            fmt::print("Over-budget kernel correctly failed to build: {}\n", what.substr(0, 300));
+        }
+        TT_FATAL(
+            over_budget_threw,
+            "Over-budget kernel (>128 zones in one TU) built successfully, but it must have tripped the "
+            "KERNEL_PROFILER_LOCAL_BITS static_assert and failed to compile");
+
+        pass &= mesh_device->close();
+
+    } catch (const std::exception& e) {
+        pass = false;
+        fmt::print(stderr, "{}\n", e.what());
+        fmt::print(stderr, "System error message: {}\n", std::strerror(errno));
+    }
+
+    if (pass) {
+        fmt::print("Test Passed\n");
+    } else {
+        TT_THROW("Test Failed");
+    }
+
+    return 0;
+}

--- a/tests/tt_metal/tools/profiler/test_zone_id_budget.cpp
+++ b/tests/tt_metal/tools/profiler/test_zone_id_budget.cpp
@@ -4,14 +4,14 @@
 
 // Unit test for KERNEL_PROFILER structural zone ids (id = (file_id << LOCAL_BITS) | local).
 //
-//   Case 1: a kernel with 120 profiler zones in one translation unit compiles and profiles -- the
-//           per-TU zone-id budget (128 with LOCAL_BITS=7) has headroom. Because this run also builds
+//   Case 1: a kernel with 40 profiler zones in one translation unit compiles and profiles -- the
+//           per-TU zone-id budget (64 with LOCAL_BITS=6) has headroom. Because this run also builds
 //           the per-RISC firmware (each its own TU with its own file_id), it exercises cross-TU id
 //           uniqueness: reaching ReadMeshDeviceProfilerResults without the host-side collision check
 //           firing proves the ids are collision-free across all those TUs. The kernel runs on RISCV_0
 //           (BRISC) because its code region is large (1.4 MB); NCRISC has only 16 KB of IRAM, a
-//           code-SIZE limit that is unrelated to the zone-id budget and would reject 120 zones' code.
-//   Case 2: a kernel with >128 zones in one TU must FAIL to compile -- the static_assert in
+//           code-SIZE limit that is unrelated to the zone-id budget; BRISC's large region fits it regardless.
+//   Case 2: a kernel with more zones than the per-TU budget must FAIL to compile -- the static_assert in
 //           TT_ZONE_META turns the id-budget overflow into a hard build error, which surfaces on the
 //           host as an exception. The test passes only if that build throws with the static_assert.
 //           The compiler/build errors it logs are INTENTIONAL (see the banner printed below).
@@ -61,12 +61,12 @@ int main() {
     try {
         std::shared_ptr<distributed::MeshDevice> mesh_device = distributed::MeshDevice::create_unit_mesh(0);
 
-        // Case 1: 120 zones in one TU must compile and profile (and the whole run stays collision-free
+        // Case 1: 40 zones in one TU must compile and profile (and the whole run stays collision-free
         // across all the firmware/kernel TUs, else ReadMeshDeviceProfilerResults would throw).
         RunZoneBudgetKernel(mesh_device, /*over_budget=*/false);
         ReadMeshDeviceProfilerResults(*mesh_device);
 
-        // Case 2: >128 zones in one TU must fail to build via the TT_ZONE_META static_assert. The build
+        // Case 2: an over-budget kernel must fail to build via the TT_ZONE_META static_assert. The build
         // errors logged next are EXPECTED -- the test verifies they happen and are the id-budget assert.
         fmt::print(
             "=== Building an over-budget kernel on purpose; the compiler/build errors that follow are "
@@ -81,7 +81,7 @@ int main() {
         }
         TT_FATAL(
             over_budget_threw,
-            "Over-budget kernel (>128 zones in one TU) built successfully, but it must have tripped the "
+            "Over-budget kernel (more zones than the per-TU budget) built successfully, but it must have tripped the "
             "KERNEL_PROFILER_LOCAL_BITS static_assert and failed to compile");
         // Confirm it failed for the RIGHT reason (the id-budget static_assert), not some unrelated error.
         TT_FATAL(

--- a/tt_metal/hostdevcommon/api/hostdevcommon/profiler_common.h
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/profiler_common.h
@@ -22,11 +22,24 @@
 //   zone id  = [ file id : (ZONE_ID_BITS - LOCAL_BITS) | local index : LOCAL_BITS ]
 //
 // Zone ids are structural, not hashed, so (file, local) pairs are unique by construction. The id is
-// 18 bits, widened from 16 by borrowing 2 bits from timestamp_hi (12 -> 10); with LOCAL_BITS=6 that
-// is 4096 file ids x 64 zones/TU. timestamp_hi is then 10 bits, so device timestamps wrap after
-// ~2^42 cycles (~54 min at 1.35 GHz / ~73 min at 1.0 GHz) -- ample for a profiling capture.
+// 18 bits, widened from 16 by borrowing 2 bits from timestamp_hi (12 -> 10); timestamp_hi is then 10
+// bits, so device timestamps wrap after ~2^42 cycles (~54 min at 1.35 GHz / ~73 min at 1.0 GHz) --
+// ample for a profiling capture.
+//
+// The 18-bit zone id is split file-id : local by KERNEL_PROFILER_LOCAL_BITS. Two modes, selected at
+// kernel-build time by the JIT (env var TT_METAL_PROFILER_MORE_ZONE_NAMES) which -D-overrides it:
+//   - default (LOCAL_BITS=6): 4096 file ids x 64 zones/TU  -- broad coverage (many kernels)
+//   - more-zone-names (LOCAL_BITS=9): 512 file ids x 512 zones/TU -- deep-dive on a heavily
+//     instrumented kernel; the 512 file-id budget suits focused profiling, clear the cache if exhausted.
+// The host decoder is split-agnostic (it keys on the whole 18-bit zone id), so only the device pack
+// and the file-id registry budget depend on this split. Switching modes changes the kernel compile
+// hash, so cached binaries rebuild rather than being reused with the wrong layout.
 #define KERNEL_PROFILER_ZONE_ID_BITS 18
-#define KERNEL_PROFILER_LOCAL_BITS 6
+#define KERNEL_PROFILER_LOCAL_BITS_DEFAULT 6
+#define KERNEL_PROFILER_LOCAL_BITS_MORE_ZONES 9
+#ifndef KERNEL_PROFILER_LOCAL_BITS
+#define KERNEL_PROFILER_LOCAL_BITS KERNEL_PROFILER_LOCAL_BITS_DEFAULT
+#endif
 #define KERNEL_PROFILER_PACKET_TYPE_BITS 3
 #define KERNEL_PROFILER_TIMER_ID_BITS (KERNEL_PROFILER_ZONE_ID_BITS + KERNEL_PROFILER_PACKET_TYPE_BITS)
 #define KERNEL_PROFILER_TIMESTAMP_HI_BITS (31 - KERNEL_PROFILER_TIMER_ID_BITS)

--- a/tt_metal/hostdevcommon/api/hostdevcommon/profiler_common.h
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/profiler_common.h
@@ -13,6 +13,12 @@
 // full; residual read via DRAM_AND_L1.
 #define PROFILER_OPT_DO_ACCUMULATE (1 << 4)
 
+// Zone ids are structural, not hashed: the low KERNEL_PROFILER_LOCAL_BITS hold a per-translation-unit
+// zone index and the remaining high bits hold a host-assigned file id, so (file, local) pairs are
+// unique by construction across the whole 16-bit id space. Shared by device (kernel_profiler.hpp),
+// the JIT build (build.cpp), and the host parser (profiler.cpp). 7 -> 128 zones/TU, 512 TUs.
+#define KERNEL_PROFILER_LOCAL_BITS 7
+
 namespace kernel_profiler {
 
 static constexpr int SUM_COUNT = 2;

--- a/tt_metal/hostdevcommon/api/hostdevcommon/profiler_common.h
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/profiler_common.h
@@ -13,11 +13,27 @@
 // full; residual read via DRAM_AND_L1.
 #define PROFILER_OPT_DO_ACCUMULATE (1 << 4)
 
-// Zone ids are structural, not hashed: the low KERNEL_PROFILER_LOCAL_BITS hold a per-translation-unit
-// zone index and the remaining high bits hold a host-assigned file id, so (file, local) pairs are
-// unique by construction across the whole 16-bit id space. Shared by device (kernel_profiler.hpp),
-// the JIT build (build.cpp), and the host parser (profiler.cpp). 7 -> 128 zones/TU, 512 TUs.
-#define KERNEL_PROFILER_LOCAL_BITS 7
+// Structural zone id + profiler marker-word bit layout. Single source of truth, shared by the device
+// (kernel_profiler.hpp), the JIT build (build.cpp), and the host parser (profiler.cpp).
+//
+// One profiler marker word is 32 bits:
+//   [ valid : 1 (bit 31) | timer_id : TIMER_ID_BITS | timestamp_hi : TIMESTAMP_HI_BITS ]
+//   timer_id = [ zone id : ZONE_ID_BITS | packet type : PACKET_TYPE_BITS ]
+//   zone id  = [ file id : (ZONE_ID_BITS - LOCAL_BITS) | local index : LOCAL_BITS ]
+//
+// Zone ids are structural, not hashed, so (file, local) pairs are unique by construction. The id is
+// 18 bits, widened from 16 by borrowing 2 bits from timestamp_hi (12 -> 10); with LOCAL_BITS=6 that
+// is 4096 file ids x 64 zones/TU. timestamp_hi is then 10 bits, so device timestamps wrap after
+// ~2^42 cycles (~54 min at 1.35 GHz / ~73 min at 1.0 GHz) -- ample for a profiling capture.
+#define KERNEL_PROFILER_ZONE_ID_BITS 18
+#define KERNEL_PROFILER_LOCAL_BITS 6
+#define KERNEL_PROFILER_PACKET_TYPE_BITS 3
+#define KERNEL_PROFILER_TIMER_ID_BITS (KERNEL_PROFILER_ZONE_ID_BITS + KERNEL_PROFILER_PACKET_TYPE_BITS)
+#define KERNEL_PROFILER_TIMESTAMP_HI_BITS (31 - KERNEL_PROFILER_TIMER_ID_BITS)
+#define KERNEL_PROFILER_ZONE_ID_MASK ((1u << KERNEL_PROFILER_ZONE_ID_BITS) - 1u)
+#define KERNEL_PROFILER_TIMER_ID_MASK ((1u << KERNEL_PROFILER_TIMER_ID_BITS) - 1u)
+#define KERNEL_PROFILER_TIMESTAMP_HI_MASK ((1u << KERNEL_PROFILER_TIMESTAMP_HI_BITS) - 1u)
+#define KERNEL_PROFILER_FILE_ID_COUNT (1u << (KERNEL_PROFILER_ZONE_ID_BITS - KERNEL_PROFILER_LOCAL_BITS))
 
 namespace kernel_profiler {
 

--- a/tt_metal/hw/toolchain/erisc-b0-app-sections.ld
+++ b/tt_metal/hw/toolchain/erisc-b0-app-sections.ld
@@ -24,6 +24,19 @@ SECTIONS
   PROVIDE (__global_pointer$ = __firmware_global_pointer);
   PROVIDE (__erisc_jump_table = ORIGIN(ERISC_JUMPTABLE));
 
+  /* KERNEL_PROFILER zone source-location table - file-only section, VMA = 0x6600000.
+     Active-ERISC firmware (active_erisc.cc) emits profiler zones, so it needs the same
+     non-loaded (INFO) placement as the other toolchain scripts; otherwise .tt_zone_meta
+     is an orphan allocatable section that consumes constrained ERISC memory. No region/PHDR
+     assignment keeps it out of any PT_LOAD segment. */
+  .tt_zone_meta 0x6600000 (INFO) :
+  {
+    __tt_zone_meta_start = .;
+    KEEP(*(.tt_zone_meta))
+    __tt_zone_meta_end = .;
+    . = ALIGN(4);
+  }
+
   .text :
   {
     *(.start)

--- a/tt_metal/hw/toolchain/erisc-b0-kernel.ld
+++ b/tt_metal/hw/toolchain/erisc-b0-kernel.ld
@@ -49,6 +49,17 @@ SECTIONS
     . = ALIGN(4);
   }
 
+  /* KERNEL_PROFILER zone source-location table – file-only section, VMA = 0x6600000.
+     (INFO) keeps the data in the ELF for the host to read via section headers while
+     stripping SHF_ALLOC, so it is never loaded to the device. */
+  .tt_zone_meta 0x6600000 (INFO) :
+  {
+    __tt_zone_meta_start = .;
+    KEEP(*(.tt_zone_meta))
+    __tt_zone_meta_end = .;
+    . = ALIGN(4);
+  }
+
   .text __firmware_start :
   {
     *(.start)

--- a/tt_metal/hw/toolchain/main.ld
+++ b/tt_metal/hw/toolchain/main.ld
@@ -152,6 +152,17 @@ SECTIONS
     . = ALIGN(4);
   }
 
+  /* KERNEL_PROFILER zone source-location table – file-only section, VMA = 0x6600000.
+     (INFO) keeps the data in the ELF for the host to read via section headers while
+     stripping SHF_ALLOC, so it is never loaded to the device. */
+  .tt_zone_meta 0x6600000 (INFO) :
+  {
+    __tt_zone_meta_start = .;
+    KEEP(*(.tt_zone_meta))
+    __tt_zone_meta_end = .;
+    . = ALIGN(4);
+  }
+
 #if defined(TYPE_FIRMWARE) || (defined(COMPILE_FOR_NCRISC) && defined(ARCH_WORMHOLE))
   .text TEXT_START :
 #else

--- a/tt_metal/hw/toolchain/script_tng.ld
+++ b/tt_metal/hw/toolchain/script_tng.ld
@@ -118,6 +118,17 @@ SECTIONS {
     . = ALIGN(4);
   }
 
+  /* KERNEL_PROFILER zone source-location table – file-only section, VMA = 0x6600000.
+     (INFO) keeps the data in the ELF for the host to read via section headers while
+     stripping SHF_ALLOC, so it is never loaded to the device. */
+  .tt_zone_meta 0x6600000 (INFO) :
+  {
+    __tt_zone_meta_start = .;
+    KEEP(*(.tt_zone_meta))
+    __tt_zone_meta_end = .;
+    . = ALIGN(4);
+  }
+
 /* Text-like */
 #if defined(TYPE_KERNEL)
   /DISCARD/ : { *_object.o(.text) }

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -210,6 +210,8 @@ void Kernel::register_kernel_elf_paths_with_watcher(IDevice& device, const std::
 
 std::string Kernel::name() const { return this->kernel_src_.name(); }
 
+std::string Kernel::get_profiler_zone_src_id() const { return this->kernel_src_.profiler_zone_src_id(); }
+
 const std::set<CoreCoord>& Kernel::logical_cores() const { return this->logical_cores_; }
 
 std::vector<CoreRange> Kernel::logical_coreranges() const {

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -190,6 +190,7 @@ public:
     uint64_t compute_hash() const;
 
     const std::string& get_full_kernel_name() const override;
+    std::string get_profiler_zone_src_id() const override;
     void process_defines(std::function<void(const std::string& define, const std::string& value)>) const override;
     void process_compile_time_args(std::function<void(const std::vector<uint32_t>& values)>) const override;
     void process_named_compile_time_args(

--- a/tt_metal/impl/kernels/kernel_source.hpp
+++ b/tt_metal/impl/kernels/kernel_source.hpp
@@ -6,6 +6,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <functional>
 #include <sstream>
 #include <string>
 
@@ -28,6 +29,17 @@ struct KernelSource {
             return this->path_.stem().string();
         }
         return "Kernel_Source_Code";
+    }
+
+    // Build-argument-independent identifier that is unique per distinct source: the full file path for
+    // file kernels, a content hash for inline source. Unlike name() (just the file stem, which recurs
+    // across ops), this uniquely identifies the source, so the profiler can assign one zone file-id per
+    // source instead of one per compile variant. Contains no tab/newline, so it is registry-line safe.
+    std::string profiler_zone_src_id() const {
+        if (this->source_type_ == SourceType::FILE_PATH) {
+            return this->path_.string();
+        }
+        return "inline:" + std::to_string(std::hash<std::string>{}(this->source_));
     }
 
     // Returns the actual source code (file content or source string)

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -248,56 +248,34 @@ tracy::TTDeviceMarkerType get_marker_type_from_packet_type(kernel_profiler::Pack
     }
 }
 
-uint32_t hash32CT(const char* str, size_t n, uint32_t basis) {
-    return n == 0 ? basis : hash32CT(str + 1, n - 1, (basis ^ str[0]) * UINT32_C(16777619));
-}
-
-uint16_t hash16CT(const std::string& str) {
-    uint32_t res = hash32CT(str.c_str(), str.length(), UINT32_C(2166136261));
-    return ((res & 0xFFFF) ^ ((res & 0xFFFF0000) >> 16)) & 0xFFFF;
-}
-
 void populateZoneSrcLocations(
     const std::string& new_log_name,
-    const std::string& log_name,
-    const bool push_new,
     std::unordered_map<uint16_t, tracy::MarkerDetails>& hash_to_zone_src_locations,
     std::unordered_set<std::string>& zone_src_locations) {
     std::ifstream log_file_read(new_log_name);
     std::string line;
-    static const std::string delimiter = "'#pragma message: ";
     while (std::getline(log_file_read, line)) {
-        std::string zone_src_location;
-        uint16_t hash_16bit = 0;
+        // Each line is "<id>\t<name,file,line,KERNEL_PROFILER>": the id is the device's resolved
+        // structural zone id, read straight from the ELF .tt_zone_meta section (see
+        // JitBuildState::extract_zone_src_locations), so it is used directly.
         auto tab = line.find('\t');
-        if (tab != std::string::npos) {
-            // Current format: "<id>\t<name,file,line,KERNEL_PROFILER>". The id is the device's
-            // resolved structural zone id, read straight from the ELF .tt_zone_meta section, so we
-            // use it directly rather than recomputing anything.
-            try {
-                hash_16bit = static_cast<uint16_t>(std::stoul(line.substr(0, tab)));
-            } catch (const std::exception&) {
-                continue;
-            }
-            zone_src_location = line.substr(tab + 1);
-        } else {
-            // Legacy fallbacks (persistent logs from older builds): recompute the 16-bit hash.
-            auto pos = line.find(delimiter);
-            if (pos != std::string::npos) {
-                // "'#pragma message: ...'" line: payload between the delimiter and the trailing quote.
-                size_t delimiter_index = pos + delimiter.length();
-                zone_src_location = line.substr(delimiter_index, line.length() - delimiter_index - 1);
-            } else if (line.find(",KERNEL_PROFILER") != std::string::npos) {
-                zone_src_location = line;
-            } else {
-                continue;
-            }
-            hash_16bit = hash16CT(zone_src_location);
+        if (tab == std::string::npos) {
+            continue;
         }
+        uint16_t hash_16bit = 0;
+        try {
+            hash_16bit = static_cast<uint16_t>(std::stoul(line.substr(0, tab)));
+        } catch (const std::exception&) {
+            continue;
+        }
+        std::string zone_src_location = line.substr(tab + 1);
 
         auto did_insert = zone_src_locations.insert(zone_src_location);
         if (did_insert.second && (hash_to_zone_src_locations.contains(hash_16bit))) {
-            TT_THROW("Source location hashes are colliding, two different locations are having the same hash");
+            TT_THROW(
+                "Profiler zone ids collide: two different source locations map to id {}. This should be "
+                "impossible with structural ids -- check KERNEL_PROFILER_FILE_ID assignment.",
+                hash_16bit);
         }
 
         std::stringstream ss(zone_src_location);
@@ -326,13 +304,7 @@ void populateZoneSrcLocations(
         }
         tracy::MarkerDetails details(zone_name, source_file, line_num);
 
-        auto ret = hash_to_zone_src_locations.emplace(hash_16bit, details);
-        if (ret.second && push_new) {
-            // Persist in the normalized "<id>\t<string>" form so re-reads take the fast path above.
-            std::ofstream log_file_write(log_name, std::ios::app);
-            log_file_write << hash_16bit << '\t' << zone_src_location << std::endl;
-            log_file_write.close();
-        }
+        hash_to_zone_src_locations.emplace(hash_16bit, details);
     }
     log_file_read.close();
 }
@@ -341,17 +313,11 @@ std::unordered_map<uint16_t, tracy::MarkerDetails> generateZoneSourceLocationsHa
     std::unordered_map<uint16_t, tracy::MarkerDetails> hash_to_zone_src_locations;
     std::unordered_set<std::string> zone_src_locations;
 
-    // Load existing zones from previous runs
-    populateZoneSrcLocations(
-        PROFILER_ZONE_SRC_LOCATIONS_LOG, "", false, hash_to_zone_src_locations, zone_src_locations);
-
-    // Load new zones from the current run
-    populateZoneSrcLocations(
-        NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG,
-        PROFILER_ZONE_SRC_LOCATIONS_LOG,
-        true,
-        hash_to_zone_src_locations,
-        zone_src_locations);
+    // The JIT build extracts every used kernel's zones fresh into the NEW log on each run (see
+    // JitBuildState::extract_zone_src_locations), so it is complete on its own. There is deliberately
+    // no cross-run accumulation: structural zone ids legitimately change across builds (source line
+    // shifts, file-id reassignment), so a persisted log would mix stale ids and spuriously collide.
+    populateZoneSrcLocations(NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG, hash_to_zone_src_locations, zone_src_locations);
 
     return hash_to_zone_src_locations;
 }

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -268,20 +268,32 @@ void populateZoneSrcLocations(
     static const std::string delimiter = "'#pragma message: ";
     while (std::getline(log_file_read, line)) {
         std::string zone_src_location;
-        auto pos = line.find(delimiter);
-        if (pos != std::string::npos) {
-            // Legacy "'#pragma message: ...'" line (e.g. persistent logs from older builds):
-            // take the payload between the delimiter and the trailing quote.
-            size_t delimiter_index = pos + delimiter.length();
-            zone_src_location = line.substr(delimiter_index, line.length() - delimiter_index - 1);
-        } else if (line.find(",KERNEL_PROFILER") != std::string::npos) {
-            // Bare "name,file,line,KERNEL_PROFILER" record read from the ELF .tt_zone_meta section.
-            zone_src_location = line;
+        uint16_t hash_16bit = 0;
+        auto tab = line.find('\t');
+        if (tab != std::string::npos) {
+            // Current format: "<id>\t<name,file,line,KERNEL_PROFILER>". The id is the device's
+            // resolved structural zone id, read straight from the ELF .tt_zone_meta section, so we
+            // use it directly rather than recomputing anything.
+            try {
+                hash_16bit = static_cast<uint16_t>(std::stoul(line.substr(0, tab)));
+            } catch (const std::exception&) {
+                continue;
+            }
+            zone_src_location = line.substr(tab + 1);
         } else {
-            continue;
+            // Legacy fallbacks (persistent logs from older builds): recompute the 16-bit hash.
+            auto pos = line.find(delimiter);
+            if (pos != std::string::npos) {
+                // "'#pragma message: ...'" line: payload between the delimiter and the trailing quote.
+                size_t delimiter_index = pos + delimiter.length();
+                zone_src_location = line.substr(delimiter_index, line.length() - delimiter_index - 1);
+            } else if (line.find(",KERNEL_PROFILER") != std::string::npos) {
+                zone_src_location = line;
+            } else {
+                continue;
+            }
+            hash_16bit = hash16CT(zone_src_location);
         }
-
-        uint16_t hash_16bit = hash16CT(zone_src_location);
 
         auto did_insert = zone_src_locations.insert(zone_src_location);
         if (did_insert.second && (hash_to_zone_src_locations.contains(hash_16bit))) {
@@ -316,9 +328,9 @@ void populateZoneSrcLocations(
 
         auto ret = hash_to_zone_src_locations.emplace(hash_16bit, details);
         if (ret.second && push_new) {
-            // Persist in the normalized bare-record form so re-reads take the fast path above.
+            // Persist in the normalized "<id>\t<string>" form so re-reads take the fast path above.
             std::ofstream log_file_write(log_name, std::ios::app);
-            log_file_write << zone_src_location << std::endl;
+            log_file_write << hash_16bit << '\t' << zone_src_location << std::endl;
             log_file_write.close();
         }
     }

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -69,7 +69,7 @@ namespace tt::tt_metal {
 
 namespace {
 kernel_profiler::PacketTypes get_packet_type(uint32_t timer_id) {
-    return static_cast<kernel_profiler::PacketTypes>((timer_id >> 16) & 0x7);
+    return static_cast<kernel_profiler::PacketTypes>((timer_id >> KERNEL_PROFILER_ZONE_ID_BITS) & 0x7);
 }
 
 void add_program_sub_device_meta_data(nlohmann::json& meta_data, tt::ChipId device_id, uint32_t runtime_id) {
@@ -250,7 +250,7 @@ tracy::TTDeviceMarkerType get_marker_type_from_packet_type(kernel_profiler::Pack
 
 void populateZoneSrcLocations(
     const std::string& new_log_name,
-    std::unordered_map<uint16_t, tracy::MarkerDetails>& hash_to_zone_src_locations,
+    std::unordered_map<uint32_t, tracy::MarkerDetails>& hash_to_zone_src_locations,
     std::unordered_set<std::string>& zone_src_locations) {
     std::ifstream log_file_read(new_log_name);
     std::string line;
@@ -262,9 +262,9 @@ void populateZoneSrcLocations(
         if (tab == std::string::npos) {
             continue;
         }
-        uint16_t hash_16bit = 0;
+        uint32_t hash_16bit = 0;
         try {
-            hash_16bit = static_cast<uint16_t>(std::stoul(line.substr(0, tab)));
+            hash_16bit = static_cast<uint32_t>(std::stoul(line.substr(0, tab)));
         } catch (const std::exception&) {
             continue;
         }
@@ -309,8 +309,8 @@ void populateZoneSrcLocations(
     log_file_read.close();
 }
 
-std::unordered_map<uint16_t, tracy::MarkerDetails> generateZoneSourceLocationsHashes() {
-    std::unordered_map<uint16_t, tracy::MarkerDetails> hash_to_zone_src_locations;
+std::unordered_map<uint32_t, tracy::MarkerDetails> generateZoneSourceLocationsHashes() {
+    std::unordered_map<uint32_t, tracy::MarkerDetails> hash_to_zone_src_locations;
     std::unordered_set<std::string> zone_src_locations;
 
     // The JIT build extracts every used kernel's zones fresh into the NEW log on each run (see
@@ -1601,8 +1601,9 @@ void DeviceProfiler::readRiscProfilerResults(
                     opTime_L = 0;
                 } else if (!oneStartFound) {
                     // Pre-sentinel data: capture TS_DATA and advance past its 4-slot layout.
-                    uint32_t timer_id = (data_buffer.at(index) >> 12) & 0x7FFFF;
-                    uint32_t time_H = data_buffer.at(index) & 0xFFF;
+                    uint32_t timer_id =
+                        (data_buffer.at(index) >> KERNEL_PROFILER_TIMESTAMP_HI_BITS) & KERNEL_PROFILER_TIMER_ID_MASK;
+                    uint32_t time_H = data_buffer.at(index) & KERNEL_PROFILER_TIMESTAMP_HI_MASK;
                     if (timer_id || time_H) {
                         kernel_profiler::PacketTypes pre_packet_type = get_packet_type(timer_id);
                         if (pre_packet_type == kernel_profiler::TS_DATA) {
@@ -1656,13 +1657,14 @@ void DeviceProfiler::readRiscProfilerResults(
                     pre_sentinel_markers.clear();
 
                 } else if (oneStartFound) {
-                    uint32_t timer_id = (data_buffer.at(index) >> 12) & 0x7FFFF;
+                    uint32_t timer_id =
+                        (data_buffer.at(index) >> KERNEL_PROFILER_TIMESTAMP_HI_BITS) & KERNEL_PROFILER_TIMER_ID_MASK;
                     kernel_profiler::PacketTypes packet_type = get_packet_type(timer_id);
 
                     switch (packet_type) {
                         case kernel_profiler::ZONE_START:
                         case kernel_profiler::ZONE_END: {
-                            uint32_t time_H = data_buffer.at(index) & 0xFFF;
+                            uint32_t time_H = data_buffer.at(index) & KERNEL_PROFILER_TIMESTAMP_HI_MASK;
                             if (timer_id || time_H) {
                                 uint32_t time_L = data_buffer.at(index + 1);
 
@@ -1726,7 +1728,7 @@ void DeviceProfiler::readRiscProfilerResults(
                             break;
                         }
                         case kernel_profiler::TS_DATA: {
-                            uint32_t time_H = data_buffer.at(index) & 0xFFF;
+                            uint32_t time_H = data_buffer.at(index) & KERNEL_PROFILER_TIMESTAMP_HI_MASK;
                             uint32_t time_L = data_buffer.at(index + 1);
                             index += kernel_profiler::PROFILER_L1_MARKER_UINT32_SIZE;
                             uint32_t data_H = data_buffer.at(index);
@@ -1748,7 +1750,7 @@ void DeviceProfiler::readRiscProfilerResults(
                             continue;
                         }
                         case kernel_profiler::TS_EVENT: {
-                            uint32_t time_H = data_buffer.at(index) & 0xFFF;
+                            uint32_t time_H = data_buffer.at(index) & KERNEL_PROFILER_TIMESTAMP_HI_MASK;
                             uint32_t time_L = data_buffer.at(index + 1);
                             readDeviceMarkerData(
                                 device_markers_for_core_risc,
@@ -1765,7 +1767,7 @@ void DeviceProfiler::readRiscProfilerResults(
                         }
                         case kernel_profiler::TS_DATA_16B: {
                             // Header
-                            uint32_t time_H = data_buffer.at(index) & 0xFFF;
+                            uint32_t time_H = data_buffer.at(index) & KERNEL_PROFILER_TIMESTAMP_HI_MASK;
                             uint32_t time_L = data_buffer.at(index + 1);
                             index += kernel_profiler::PROFILER_L1_MARKER_UINT32_SIZE;
 
@@ -1818,8 +1820,8 @@ void DeviceProfiler::updateFirstTimestamp(uint64_t timestamp) {
     smallest_timestamp = std::min(timestamp, smallest_timestamp);
 }
 
-tracy::MarkerDetails DeviceProfiler::getMarkerDetails(uint16_t timer_id) const {
-    auto marker_details_iter = hash_to_zone_src_locations.find(timer_id);
+tracy::MarkerDetails DeviceProfiler::getMarkerDetails(uint32_t timer_id) const {
+    auto marker_details_iter = hash_to_zone_src_locations.find(timer_id & KERNEL_PROFILER_ZONE_ID_MASK);
     if (marker_details_iter != hash_to_zone_src_locations.end()) {
         return marker_details_iter->second;
     }
@@ -1882,7 +1884,7 @@ void DeviceProfiler::readDeviceMarkerData(
         physical_core.x,
         physical_core.y,
         risc_type,
-        timer_id,
+        timer_id & KERNEL_PROFILER_ZONE_ID_MASK,  // marker_id = zone id (packet type stripped) so ZONE_START/END pair
         timestamp,
         data,
         tracy::TTDeviceMarker::INVALID_NUM,
@@ -1903,7 +1905,7 @@ void DeviceProfiler::readDeviceMarkerData(
     updateFirstTimestamp(timestamp);
 
 #if defined(TRACY_ENABLE)
-    if ((timer_id & 0xFFFF) == kernel_profiler::NOC_DEBUGGING_STATIC_ID) {
+    if ((timer_id & KERNEL_PROFILER_ZONE_ID_MASK) == kernel_profiler::NOC_DEBUGGING_STATIC_ID) {
         NOCDebugState* noc_debug_state = MetalContext::instance(context_id).noc_debug_state().get();
         if (noc_debug_state) {
             const metal_SocDescriptor& soc_desc =
@@ -1943,7 +1945,7 @@ void DeviceProfiler::readTsData16BMarkerData(
 
     nlohmann::json meta_data;
 #if defined(TRACY_ENABLE)
-    if ((timer_id & 0xFFFF) == kernel_profiler::NOC_TRACING_STATIC_ID) {
+    if ((timer_id & KERNEL_PROFILER_ZONE_ID_MASK) == kernel_profiler::NOC_TRACING_STATIC_ID) {
         using EMD = KernelProfilerNocEventMetadata;
 
         EMD event_metadata(data);
@@ -1999,7 +2001,7 @@ void DeviceProfiler::readTsData16BMarkerData(
         physical_core.x,
         physical_core.y,
         risc_type,
-        timer_id,
+        timer_id & KERNEL_PROFILER_ZONE_ID_MASK,  // marker_id = zone id (packet type stripped) so ZONE_START/END pair
         timestamp,
         data,
         trailer_data[0],

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -267,12 +267,19 @@ void populateZoneSrcLocations(
     std::string line;
     static const std::string delimiter = "'#pragma message: ";
     while (std::getline(log_file_read, line)) {
+        std::string zone_src_location;
         auto pos = line.find(delimiter);
-        if (pos == std::string::npos) {
+        if (pos != std::string::npos) {
+            // Legacy "'#pragma message: ...'" line (e.g. persistent logs from older builds):
+            // take the payload between the delimiter and the trailing quote.
+            size_t delimiter_index = pos + delimiter.length();
+            zone_src_location = line.substr(delimiter_index, line.length() - delimiter_index - 1);
+        } else if (line.find(",KERNEL_PROFILER") != std::string::npos) {
+            // Bare "name,file,line,KERNEL_PROFILER" record read from the ELF .tt_zone_meta section.
+            zone_src_location = line;
+        } else {
             continue;
         }
-        size_t delimiter_index = pos + delimiter.length();
-        std::string zone_src_location = line.substr(delimiter_index, line.length() - delimiter_index - 1);
 
         uint16_t hash_16bit = hash16CT(zone_src_location);
 
@@ -309,8 +316,9 @@ void populateZoneSrcLocations(
 
         auto ret = hash_to_zone_src_locations.emplace(hash_16bit, details);
         if (ret.second && push_new) {
+            // Persist in the normalized bare-record form so re-reads take the fast path above.
             std::ofstream log_file_write(log_name, std::ios::app);
-            log_file_write << line << std::endl;
+            log_file_write << zone_src_location << std::endl;
             log_file_write.close();
         }
     }

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -98,7 +98,7 @@ private:
     std::filesystem::path device_logs_output_dir;
 
     // Hash to zone source locations
-    std::unordered_map<uint16_t, tracy::MarkerDetails> hash_to_zone_src_locations;
+    std::unordered_map<uint32_t, tracy::MarkerDetails> hash_to_zone_src_locations;
 
     // Device-Core tracy context
     std::unordered_map<std::pair<ChipId, CoreCoord>, TracyTTCtx, pair_hash<ChipId, CoreCoord>> device_tracy_contexts;
@@ -335,7 +335,7 @@ public:
     void destroyTracyContexts();
 
     // Get marker details for the marker corresponding to the given timer id
-    tracy::MarkerDetails getMarkerDetails(uint16_t timer_id) const;
+    tracy::MarkerDetails getMarkerDetails(uint32_t timer_id) const;
 
     // Mark the beginning of a trace recording
     void markTraceBegin(uint32_t trace_id);

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -90,13 +90,28 @@ void hard_link_or_copy(const std::filesystem::path& target, const std::filesyste
     }
 }
 
-// Persistent, process-shared registry mapping a stable per-translation-unit key to a dense integer
-// "file id" used to build collision-free KERNEL_PROFILER structural zone ids. Stability matters: a
-// cached kernel keeps the id baked into its binary, so a freshly compiled TU must never be handed a
-// file id already in use elsewhere. The registry lives next to the JIT cache and is guarded by an OS
-// file lock for the whole read-modify-write, so parallel builds -- even across processes sharing the
-// cache -- assign disjoint ids. Best-effort: on any I/O failure it falls back to partition 0.
-uint32_t get_or_assign_profiler_file_id(const std::string& registry_path, const std::string& key) {
+// KERNEL_PROFILER_LOCAL_BITS for this run: more-zone-names mode (rtoptions, from
+// TT_METAL_PROFILER_MORE_ZONE_NAMES) trades file-id budget (4096 -> 512) for zone names per TU
+// (64 -> 512), for deep-diving a heavily instrumented kernel. Baked into the device -D and the JIT
+// build key (via defines_), so the two modes compile to separate cache roots -- no stale binary is
+// reused across a switch.
+uint32_t profiler_local_bits(const tt::llrt::RunTimeOptions& rtoptions) {
+    return rtoptions.get_profiler_more_zone_names() ? KERNEL_PROFILER_LOCAL_BITS_MORE_ZONES
+                                                    : KERNEL_PROFILER_LOCAL_BITS_DEFAULT;
+}
+
+// Persistent, process-shared registry mapping a kernel's source identity to a dense integer "file id"
+// used to build collision-free KERNEL_PROFILER structural zone ids (zone id = file_id << LOCAL_BITS |
+// local). All compile variants of one source share a file id, so the id space is bounded by distinct
+// sources, not by build variants. Line format: <source_id> \t <file_id>. Ids are assigned monotonically
+// and stay stable for a source (a cached binary keeps the id baked in); they are not reclaimed within a
+// cache, so clear the profiler cache (or the registry file) to reset. max_file_id is the current split's
+// file budget (see KERNEL_PROFILER_LOCAL_BITS -- default 4096, more-zones mode 512). The registry is
+// guarded by an OS file lock for the whole read-modify-write, so parallel builds -- even across
+// processes sharing the cache -- assign disjoint ids. I/O/lock failure is a hard build error, never a
+// silent (colliding) id.
+uint32_t get_or_assign_profiler_file_id(
+    const std::string& registry_path, const std::string& source_id, uint32_t max_file_id) {
     static std::mutex mtx;
     std::lock_guard<std::mutex> lk(mtx);
 
@@ -119,13 +134,12 @@ uint32_t get_or_assign_profiler_file_id(const std::string& registry_path, const 
         }
     } registry_lock(registry_path);
 
-    // zone id = (file_id << KERNEL_PROFILER_LOCAL_BITS) | local, so file_id has this many values.
-    constexpr uint32_t max_file_id = KERNEL_PROFILER_FILE_ID_COUNT;
-    std::vector<bool> reserved(max_file_id, false);  // ids owned by a still-present translation unit
+    std::vector<bool> reserved(max_file_id, false);  // ids already assigned to some source
 
     std::ifstream in(registry_path);
     std::string line;
     while (std::getline(in, line)) {
+        // <source_id> \t <file_id>; source_id contains no tab.
         auto tab = line.rfind('\t');
         if (tab == std::string::npos) {
             continue;
@@ -138,18 +152,13 @@ uint32_t get_or_assign_profiler_file_id(const std::string& registry_path, const 
             continue;  // ignore malformed lines
         }
         if (entry_id >= max_file_id) {
-            continue;
+            continue;  // e.g. an id assigned under a wider split (different LOCAL_BITS mode)
         }
-        if (entry_key == key) {
-            // This TU already has a stable id and is being (re)built now, so reuse it.
+        if (entry_key == source_id) {
+            // This source already has a stable id; reuse it so cached binaries stay consistent.
             return entry_id;
         }
-        // Reserve the id only while the owning TU's build directory is still cached; once that dir is
-        // evicted the binary (and its baked id) is gone, so the id can be reclaimed without a live
-        // collision. This bounds the id space against stale build keys / kernels / failed builds.
-        if (std::filesystem::exists(std::filesystem::path(entry_key).parent_path())) {
-            reserved[entry_id] = true;
-        }
+        reserved[entry_id] = true;
     }
 
     uint32_t id = 0;
@@ -158,13 +167,14 @@ uint32_t get_or_assign_profiler_file_id(const std::string& registry_path, const 
     }
     TT_FATAL(
         id < max_file_id,
-        "Profiler file-id space ({} ids) is exhausted by still-present translation units; clear the "
-        "profiler cache to reclaim ids. Registry: {}",
+        "Profiler file-id space ({} ids) is exhausted; clear the profiler cache (or the registry file) "
+        "to reset. In more-zones mode the budget is only 512; use it for focused profiling, not broad "
+        "multi-model runs. Registry: {}",
         max_file_id,
         registry_path);
 
     std::ofstream out(registry_path, std::ios::app);
-    out << key << '\t' << id << '\n';
+    out << source_id << '\t' << id << '\n';
     out.flush();
     TT_FATAL(out.good(), "Failed to persist profiler file-id registry entry to '{}'", registry_path);
     return id;
@@ -272,6 +282,11 @@ void JitBuildEnv::init(
 
         this->defines_ += "-DPROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC=" +
                           std::to_string(config.profiler_dram_bank_size_per_risc_bytes) + " ";
+
+        // Zone-id file/local split for this run (default 6, more-zones mode 9). In defines_, so it is
+        // folded into build_key_ below -- the two modes get distinct cache roots and never reuse each
+        // other's binaries.
+        this->defines_ += "-DKERNEL_PROFILER_LOCAL_BITS=" + std::to_string(profiler_local_bits(rtoptions)) + " ";
     }
     if (rtoptions.get_profiler_noc_events_enabled()) {
         // force profiler on if noc events are being profiled
@@ -612,11 +627,17 @@ void JitBuildState::compile_one(const string& out_dir, const JitBuildSettings* s
     // variants (e.g. CI running many models). Firmware TUs (settings == null) fall back to the
     // config-stable output path, which is already built once per config.
     if (env_.get_rtoptions().get_profiler_enabled()) {
-        const std::string registry_path = env_.get_out_root_path() + ".profiler_zone_file_ids";
-        const std::string key = (settings != nullptr)
-                                    ? settings->get_profiler_zone_src_id() + '\x1f' + this->target_name_
-                                    : out_dir + this->objs_[src_index];
-        const uint32_t file_id = get_or_assign_profiler_file_id(registry_path, key);
+        const uint32_t local_bits = profiler_local_bits(env_.get_rtoptions());
+        const uint32_t max_file_id = 1u << (KERNEL_PROFILER_ZONE_ID_BITS - local_bits);
+        // Separate registry per split so the two modes' id spaces (4096 vs 512) never interfere.
+        const std::string registry_path = env_.get_out_root_path() + ".profiler_zone_file_ids" +
+                                          (local_bits == KERNEL_PROFILER_LOCAL_BITS_DEFAULT ? "" : ".mz");
+        // Identity = kernel source path + processor (arg-independent, so all compile variants share one
+        // id); firmware TUs (no settings) fall back to their own object path.
+        const std::string source_id = (settings != nullptr)
+                                          ? settings->get_profiler_zone_src_id() + '\x1f' + this->target_name_
+                                          : out_dir + this->objs_[src_index];
+        const uint32_t file_id = get_or_assign_profiler_file_id(registry_path, source_id, max_file_id);
         defines += fmt::format("-DKERNEL_PROFILER_FILE_ID={} ", file_id);
     }
 

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -726,9 +726,36 @@ void JitBuildState::extract_zone_src_locations(const std::string& out_dir) const
             tt::jit_build::utils::create_file(tt::tt_metal::NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG);
         }
 
-        auto cmd = fmt::format("grep KERNEL_PROFILER {}*.o.log", out_dir);
-        tt::jit_build::utils::run_command(
-            cmd, tt::tt_metal::NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG, env_.get_rtoptions().get_dump_build_commands());
+        // Read the zone source-location strings straight out of the linked ELF's .tt_zone_meta
+        // section (populated by RecordZoneSrcLocation in kernel_profiler.hpp) instead of grepping
+        // the compiler logs, which keeps build logs clean. The section is a sequence of
+        // NUL-terminated "name,file,line,KERNEL_PROFILER" strings and is not loaded to the device.
+        const std::string elf_path = out_dir + this->target_name_ + ".elf";
+        if (!std::filesystem::exists(elf_path)) {
+            return;
+        }
+        try {
+            ll_api::ElfFile elf;
+            elf.ReadImage(elf_path);
+            uint64_t section_vaddr = 0;
+            auto zone_meta = elf.GetSectionContents(".tt_zone_meta", section_vaddr);
+            if (zone_meta.empty()) {
+                return;
+            }
+            std::ofstream zone_log(tt::tt_metal::NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG, std::ios::app);
+            const char* cursor = reinterpret_cast<const char*>(zone_meta.data());
+            const char* end = cursor + zone_meta.size();
+            while (cursor < end) {
+                size_t len = ::strnlen(cursor, static_cast<size_t>(end - cursor));
+                if (len > 0) {
+                    zone_log.write(cursor, static_cast<std::streamsize>(len));
+                    zone_log << '\n';
+                }
+                cursor += len + 1;  // skip the NUL terminator (ALIGN padding yields empty strings)
+            }
+        } catch (const std::exception& e) {
+            log_warning(tt::LogBuildKernels, "Failed to read .tt_zone_meta from '{}': {}", elf_path, e.what());
+        }
     }
 }
 

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -100,45 +100,73 @@ uint32_t get_or_assign_profiler_file_id(const std::string& registry_path, const 
     static std::mutex mtx;
     std::lock_guard<std::mutex> lk(mtx);
 
-    int fd = ::open(registry_path.c_str(), O_RDWR | O_CREAT, 0644);
-    if (fd < 0) {
-        return 0;
-    }
-    ::flock(fd, LOCK_EX);
+    // RAII exclusive lock held (and fd closed) for the whole read-modify-write, so parallel builds --
+    // even across processes sharing the cache -- assign disjoint ids. I/O/lock failure is a hard build
+    // error, never a silent (possibly colliding) fallback id.
+    struct RegistryLock {
+        int fd;
+        explicit RegistryLock(const std::string& path) : fd(::open(path.c_str(), O_RDWR | O_CREAT, 0644)) {
+            TT_FATAL(fd >= 0, "Failed to open profiler file-id registry '{}': {}", path, std::strerror(errno));
+            if (::flock(fd, LOCK_EX) != 0) {
+                int err = errno;
+                ::close(fd);
+                TT_THROW("Failed to lock profiler file-id registry '{}': {}", path, std::strerror(err));
+            }
+        }
+        ~RegistryLock() {
+            ::flock(fd, LOCK_UN);
+            ::close(fd);
+        }
+    } registry_lock(registry_path);
 
-    std::unordered_map<std::string, uint32_t> table;
-    uint32_t next_id = 0;
-    {
-        std::ifstream in(registry_path);
-        std::string line;
-        while (std::getline(in, line)) {
-            auto tab = line.rfind('\t');
-            if (tab == std::string::npos) {
-                continue;
-            }
-            try {
-                uint32_t id = static_cast<uint32_t>(std::stoul(line.substr(tab + 1)));
-                table.emplace(line.substr(0, tab), id);
-                if (id + 1 > next_id) {
-                    next_id = id + 1;
-                }
-            } catch (const std::exception&) {
-                // ignore malformed lines
-            }
+    // 16-bit zone id = (file_id << KERNEL_PROFILER_LOCAL_BITS) | local, so file_id has this many values.
+    constexpr uint32_t max_file_id = 1u << (16 - KERNEL_PROFILER_LOCAL_BITS);
+    std::vector<bool> reserved(max_file_id, false);  // ids owned by a still-present translation unit
+
+    std::ifstream in(registry_path);
+    std::string line;
+    while (std::getline(in, line)) {
+        auto tab = line.rfind('\t');
+        if (tab == std::string::npos) {
+            continue;
+        }
+        const std::string entry_key = line.substr(0, tab);
+        uint32_t entry_id = 0;
+        try {
+            entry_id = static_cast<uint32_t>(std::stoul(line.substr(tab + 1)));
+        } catch (const std::exception&) {
+            continue;  // ignore malformed lines
+        }
+        if (entry_id >= max_file_id) {
+            continue;
+        }
+        if (entry_key == key) {
+            // This TU already has a stable id and is being (re)built now, so reuse it.
+            return entry_id;
+        }
+        // Reserve the id only while the owning TU's build directory is still cached; once that dir is
+        // evicted the binary (and its baked id) is gone, so the id can be reclaimed without a live
+        // collision. This bounds the id space against stale build keys / kernels / failed builds.
+        if (std::filesystem::exists(std::filesystem::path(entry_key).parent_path())) {
+            reserved[entry_id] = true;
         }
     }
 
-    uint32_t id = next_id;
-    auto it = table.find(key);
-    if (it != table.end()) {
-        id = it->second;
-    } else {
-        std::ofstream out(registry_path, std::ios::app);
-        out << key << '\t' << id << '\n';
+    uint32_t id = 0;
+    while (id < max_file_id && reserved[id]) {
+        ++id;
     }
+    TT_FATAL(
+        id < max_file_id,
+        "Profiler file-id space ({} ids) is exhausted by still-present translation units; clear the "
+        "profiler cache to reclaim ids. Registry: {}",
+        max_file_id,
+        registry_path);
 
-    ::flock(fd, LOCK_UN);
-    ::close(fd);
+    std::ofstream out(registry_path, std::ios::app);
+    out << key << '\t' << id << '\n';
+    out.flush();
+    TT_FATAL(out.good(), "Failed to persist profiler file-id registry entry to '{}'", registry_path);
     return id;
 }
 

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -605,10 +605,18 @@ void JitBuildState::compile_one(const string& out_dir, const JitBuildSettings* s
 
     // Give this translation unit a stable, globally-unique file id so KERNEL_PROFILER zone ids are
     // (file_id << LOCAL_BITS) | local -- collision-free by construction (see kernel_profiler.hpp).
-    // Keyed on the config-specific object path so a cached kernel keeps the id baked into its binary.
+    // Key it on the kernel's source identity + processor, NOT the per-build output path: every compile
+    // variant of a source (different shapes/dtypes/compile-time args) has identical zone source
+    // locations, so they must share one id. Keying per output path instead assigns a fresh id to every
+    // variant, which exhausts the id space on machines whose kernel cache accumulates thousands of
+    // variants (e.g. CI running many models). Firmware TUs (settings == null) fall back to the
+    // config-stable output path, which is already built once per config.
     if (env_.get_rtoptions().get_profiler_enabled()) {
         const std::string registry_path = env_.get_out_root_path() + ".profiler_zone_file_ids";
-        const uint32_t file_id = get_or_assign_profiler_file_id(registry_path, out_dir + this->objs_[src_index]);
+        const std::string key = (settings != nullptr)
+                                    ? settings->get_profiler_zone_src_id() + '\x1f' + this->target_name_
+                                    : out_dir + this->objs_[src_index];
+        const uint32_t file_id = get_or_assign_profiler_file_id(registry_path, key);
         defines += fmt::format("-DKERNEL_PROFILER_FILE_ID={} ", file_id);
     }
 

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -119,8 +119,8 @@ uint32_t get_or_assign_profiler_file_id(const std::string& registry_path, const 
         }
     } registry_lock(registry_path);
 
-    // 16-bit zone id = (file_id << KERNEL_PROFILER_LOCAL_BITS) | local, so file_id has this many values.
-    constexpr uint32_t max_file_id = 1u << (16 - KERNEL_PROFILER_LOCAL_BITS);
+    // zone id = (file_id << KERNEL_PROFILER_LOCAL_BITS) | local, so file_id has this many values.
+    constexpr uint32_t max_file_id = KERNEL_PROFILER_FILE_ID_COUNT;
     std::vector<bool> reserved(max_file_id, false);  // ids owned by a still-present translation unit
 
     std::ifstream in(registry_path);
@@ -841,10 +841,11 @@ void JitBuildState::extract_zone_src_locations(const std::string& out_dir) const
             std::ofstream zone_log(tt::tt_metal::NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG, std::ios::app);
             const auto* cursor = reinterpret_cast<const unsigned char*>(zone_meta.data());
             const auto* end = cursor + zone_meta.size();
-            while (end - cursor >= 3) {  // at least a 2-byte id + 1 string byte
-                uint16_t id = static_cast<uint16_t>(cursor[0] | (cursor[1] << 8));
-                const char* str = reinterpret_cast<const char*>(cursor + 2);
-                size_t len = ::strnlen(str, static_cast<size_t>(end - (cursor + 2)));
+            while (end - cursor >= 5) {  // at least a 4-byte id + 1 string byte
+                uint32_t id = static_cast<uint32_t>(cursor[0]) | (static_cast<uint32_t>(cursor[1]) << 8) |
+                              (static_cast<uint32_t>(cursor[2]) << 16) | (static_cast<uint32_t>(cursor[3]) << 24);
+                const char* str = reinterpret_cast<const char*>(cursor + 4);
+                size_t len = ::strnlen(str, static_cast<size_t>(end - (cursor + 4)));
                 if (len == 0) {
                     break;  // trailing ALIGN padding (zero bytes)
                 }
@@ -852,8 +853,8 @@ void JitBuildState::extract_zone_src_locations(const std::string& out_dir) const
                 zone_log.write(str, static_cast<std::streamsize>(len));
                 zone_log << '\n';
                 // Each record is emitted 4-byte aligned (see RecordZoneMeta's aligned(4)); round the
-                // id(2) + string + NUL length up to the next 4-byte boundary to reach the next record.
-                size_t record_bytes = (2 + len + 1 + 3) & ~static_cast<size_t>(3);
+                // id(4) + string + NUL length up to the next 4-byte boundary to reach the next record.
+                size_t record_bytes = (4 + len + 1 + 3) & ~static_cast<size_t>(3);
                 cursor += record_bytes;
             }
         } catch (const std::exception& e) {

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -17,6 +17,11 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <unordered_map>
+
+#include <fcntl.h>
+#include <sys/file.h>
+#include <unistd.h>
 #include <iostream>
 #include <iterator>
 #include <mutex>
@@ -83,6 +88,58 @@ void hard_link_or_copy(const std::filesystem::path& target, const std::filesyste
     if (ec) {
         std::filesystem::copy_file(target, link, fs::copy_options::overwrite_existing);
     }
+}
+
+// Persistent, process-shared registry mapping a stable per-translation-unit key to a dense integer
+// "file id" used to build collision-free KERNEL_PROFILER structural zone ids. Stability matters: a
+// cached kernel keeps the id baked into its binary, so a freshly compiled TU must never be handed a
+// file id already in use elsewhere. The registry lives next to the JIT cache and is guarded by an OS
+// file lock for the whole read-modify-write, so parallel builds -- even across processes sharing the
+// cache -- assign disjoint ids. Best-effort: on any I/O failure it falls back to partition 0.
+uint32_t get_or_assign_profiler_file_id(const std::string& registry_path, const std::string& key) {
+    static std::mutex mtx;
+    std::lock_guard<std::mutex> lk(mtx);
+
+    int fd = ::open(registry_path.c_str(), O_RDWR | O_CREAT, 0644);
+    if (fd < 0) {
+        return 0;
+    }
+    ::flock(fd, LOCK_EX);
+
+    std::unordered_map<std::string, uint32_t> table;
+    uint32_t next_id = 0;
+    {
+        std::ifstream in(registry_path);
+        std::string line;
+        while (std::getline(in, line)) {
+            auto tab = line.rfind('\t');
+            if (tab == std::string::npos) {
+                continue;
+            }
+            try {
+                uint32_t id = static_cast<uint32_t>(std::stoul(line.substr(tab + 1)));
+                table.emplace(line.substr(0, tab), id);
+                if (id + 1 > next_id) {
+                    next_id = id + 1;
+                }
+            } catch (const std::exception&) {
+                // ignore malformed lines
+            }
+        }
+    }
+
+    uint32_t id = next_id;
+    auto it = table.find(key);
+    if (it != table.end()) {
+        id = it->second;
+    } else {
+        std::ofstream out(registry_path, std::ios::app);
+        out << key << '\t' << id << '\n';
+    }
+
+    ::flock(fd, LOCK_UN);
+    ::close(fd);
+    return id;
 }
 
 }  // namespace
@@ -518,6 +575,15 @@ void JitBuildState::compile_one(const string& out_dir, const JitBuildSettings* s
     string cmd{"cd " + out_dir + " && " + env_.gpp_};
     string defines = this->defines_;
 
+    // Give this translation unit a stable, globally-unique file id so KERNEL_PROFILER zone ids are
+    // (file_id << LOCAL_BITS) | local -- collision-free by construction (see kernel_profiler.hpp).
+    // Keyed on the config-specific object path so a cached kernel keeps the id baked into its binary.
+    if (env_.get_rtoptions().get_profiler_enabled()) {
+        const std::string registry_path = env_.get_out_root_path() + ".profiler_zone_file_ids";
+        const uint32_t file_id = get_or_assign_profiler_file_id(registry_path, out_dir + this->objs_[src_index]);
+        defines += fmt::format("-DKERNEL_PROFILER_FILE_ID={} ", file_id);
+    }
+
     if (env_.get_rtoptions().get_build_map_enabled()) {
         cmd += "-save-temps=obj -fdump-tree-all -fdump-rtl-all ";
     }
@@ -726,10 +792,12 @@ void JitBuildState::extract_zone_src_locations(const std::string& out_dir) const
             tt::jit_build::utils::create_file(tt::tt_metal::NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG);
         }
 
-        // Read the zone source-location strings straight out of the linked ELF's .tt_zone_meta
-        // section (populated by RecordZoneSrcLocation in kernel_profiler.hpp) instead of grepping
-        // the compiler logs, which keeps build logs clean. The section is a sequence of
-        // NUL-terminated "name,file,line,KERNEL_PROFILER" strings and is not loaded to the device.
+        // Read the zone metadata straight out of the linked ELF's .tt_zone_meta section (populated by
+        // RecordZoneMeta in kernel_profiler.hpp) instead of grepping the compiler logs, which keeps build
+        // logs clean. The section is a sequence of packed records -- a little-endian uint16 zone id
+        // followed by a NUL-terminated "name,file,line,KERNEL_PROFILER" string -- and is not loaded to the
+        // device. Each record is written to the log as "<id>\t<string>" so the host uses the device's
+        // resolved id directly rather than recomputing anything.
         const std::string elf_path = out_dir + this->target_name_ + ".elf";
         if (!std::filesystem::exists(elf_path)) {
             return;
@@ -743,15 +811,22 @@ void JitBuildState::extract_zone_src_locations(const std::string& out_dir) const
                 return;
             }
             std::ofstream zone_log(tt::tt_metal::NEW_PROFILER_ZONE_SRC_LOCATIONS_LOG, std::ios::app);
-            const char* cursor = reinterpret_cast<const char*>(zone_meta.data());
-            const char* end = cursor + zone_meta.size();
-            while (cursor < end) {
-                size_t len = ::strnlen(cursor, static_cast<size_t>(end - cursor));
-                if (len > 0) {
-                    zone_log.write(cursor, static_cast<std::streamsize>(len));
-                    zone_log << '\n';
+            const auto* cursor = reinterpret_cast<const unsigned char*>(zone_meta.data());
+            const auto* end = cursor + zone_meta.size();
+            while (end - cursor >= 3) {  // at least a 2-byte id + 1 string byte
+                uint16_t id = static_cast<uint16_t>(cursor[0] | (cursor[1] << 8));
+                const char* str = reinterpret_cast<const char*>(cursor + 2);
+                size_t len = ::strnlen(str, static_cast<size_t>(end - (cursor + 2)));
+                if (len == 0) {
+                    break;  // trailing ALIGN padding (zero bytes)
                 }
-                cursor += len + 1;  // skip the NUL terminator (ALIGN padding yields empty strings)
+                zone_log << id << '\t';
+                zone_log.write(str, static_cast<std::streamsize>(len));
+                zone_log << '\n';
+                // Each record is emitted 4-byte aligned (see RecordZoneMeta's aligned(4)); round the
+                // id(2) + string + NUL length up to the next 4-byte boundary to reach the next record.
+                size_t record_bytes = (2 + len + 1 + 3) & ~static_cast<size_t>(3);
+                cursor += record_bytes;
             }
         } catch (const std::exception& e) {
             log_warning(tt::LogBuildKernels, "Failed to read .tt_zone_meta from '{}': {}", elf_path, e.what());

--- a/tt_metal/jit_build/jit_build_settings.hpp
+++ b/tt_metal/jit_build/jit_build_settings.hpp
@@ -51,6 +51,11 @@ class JitBuildSettings {
 public:
     // Returns the full kernel name
     virtual const std::string& get_full_kernel_name() const = 0;
+    // Returns a build-argument-independent identifier for the kernel's source, stable across every
+    // compile variant. Used to assign a single profiler zone file-id per source rather than one per
+    // build-args hash (see JitBuildState::compile_one). Defaults to the full (hashed) name for settings
+    // with no distinct source identity.
+    virtual std::string get_profiler_zone_src_id() const { return this->get_full_kernel_name(); }
     // Returns the compiler optimization level
     virtual std::string_view get_compiler_opt_level() const = 0;
     // Returns the linker optimization level

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -133,6 +133,7 @@ enum class EnvVarID {
     TT_METAL_PROFILER_CPP_POST_PROCESS,            // Enable C++ post-processing for profiler
     TT_METAL_PROFILER_SUM,                         // Enable sum profiling
     TT_METAL_PROFILER_ACCUMULATE,                  // Accumulate multiple kernels in L1 before DRAM push
+    TT_METAL_PROFILER_MORE_ZONE_NAMES,             // More zone names per TU (512) at fewer file ids (512)
     TT_METAL_PROFILER_PROGRAM_SUPPORT_COUNT,       // Maximum number of programs supported by the profiler
     TT_METAL_TRACY_MID_RUN_PUSH,                   // Force Tracy mid-run pushes
     TT_METAL_PROFILER_DISABLE_DUMP_TO_FILES,       // Disable dumping collected device data to files
@@ -965,6 +966,18 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         case EnvVarID::TT_METAL_PROFILER_ACCUMULATE: {
             if (this->profiler_enabled && is_env_enabled(value)) {
                 this->profiler_accumulate = true;
+            }
+            break;
+        }
+
+        // TT_METAL_PROFILER_MORE_ZONE_NAMES
+        // Trade the zone-id file-id budget (4096 -> 512) for more zone names per translation unit
+        // (64 -> 512), by growing KERNEL_PROFILER_LOCAL_BITS from 6 to 9. For deep-diving a single
+        // heavily instrumented kernel; not for broad multi-model runs. Default: false
+        // Usage: export TT_METAL_PROFILER_MORE_ZONE_NAMES=1
+        case EnvVarID::TT_METAL_PROFILER_MORE_ZONE_NAMES: {
+            if (this->profiler_enabled && is_env_enabled(value)) {
+                this->profiler_more_zone_names = true;
             }
             break;
         }

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -215,6 +215,7 @@ class RunTimeOptions {
     bool profiler_cpp_post_process = false;
     bool profiler_sum = false;
     bool profiler_accumulate = false;
+    bool profiler_more_zone_names = false;
     bool profiler_buffer_usage_enabled = false;
     bool profiler_noc_events_enabled = false;
     uint32_t profiler_perf_counter_mode = 0;
@@ -624,6 +625,8 @@ public:
     bool get_profiler_cpp_post_process() const { return profiler_cpp_post_process; }
     bool get_profiler_sum() const { return profiler_sum; }
     bool get_profiler_accumulate() const { return profiler_accumulate; }
+    // Trade zone-id file-id budget (4096 -> 512) for zone names per translation unit (64 -> 512).
+    bool get_profiler_more_zone_names() const { return profiler_more_zone_names; }
     std::optional<uint32_t> get_profiler_program_support_count() const { return profiler_program_support_count; }
     void set_profiler_program_support_count(uint32_t profiler_program_support_count) {
         this->profiler_program_support_count = profiler_program_support_count;

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -31,25 +31,58 @@
 #define PROFILER_MSG __FILE__ "," $Line ",KERNEL_PROFILER"
 #define PROFILER_MSG_NAME(name) name "," PROFILER_MSG
 
-// Record the zone's source-location string in a file-only ELF section (.tt_zone_meta)
-// instead of emitting a #pragma message into the compiler log. The host reads this section
-// straight out of the kernel ELF (see JitBuildState::extract_zone_src_locations), which keeps
-// build logs clean. The section is non-loaded -- KEEP(...) (INFO) in the linker scripts strips
-// SHF_ALLOC -- so it costs zero device memory. The block gives each expansion its own scope so
-// the static never collides when multiple zones share a C++ scope; it emits no runtime code.
-#define RecordZoneSrcLocation(name)                                                                                 \
-    {                                                                                                               \
-        static const char zone_src_loc[] __attribute__((section(".tt_zone_meta"), used)) = PROFILER_MSG_NAME(name); \
-        (void)zone_src_loc;                                                                                         \
+// Fallback file id used when the host does not inject one (e.g. a non-JIT / host-tools compile).
+// The real per-translation-unit ids come from build.cpp's -DKERNEL_PROFILER_FILE_ID injection
+// (JitBuildState::compile_one); with the default, such TUs all share partition 0.
+#ifndef KERNEL_PROFILER_FILE_ID
+#define KERNEL_PROFILER_FILE_ID 0
+#endif
+
+// Emit one zone-metadata record -- the resolved 16-bit id followed by the
+// "name,file,line,KERNEL_PROFILER" source string -- as a packed struct in a file-only ELF section
+// (.tt_zone_meta), instead of a #pragma message in the compiler log. The host reads the id straight
+// from the section (JitBuildState::extract_zone_src_locations) and never recomputes it. The section
+// is non-loaded -- KEEP(...) (INFO) in the linker scripts strips SHF_ALLOC -- so it costs zero device
+// memory. The block scopes the static so it never collides when zones share a C++ scope.
+#define RecordZoneMeta(id, name)                                                                                     \
+    {                                                                                                                \
+        static const struct __attribute__((packed)) {                                                                \
+            uint16_t zid;                                                                                            \
+            char str[sizeof(PROFILER_MSG_NAME(name))];                                                               \
+        } zone_meta                                                                                                  \
+            __attribute__((section(".tt_zone_meta"), used, aligned(4))) = {(uint16_t)(id), PROFILER_MSG_NAME(name)}; \
+        (void)zone_meta;                                                                                             \
     }
 
-#define SrcLocNameToHash(name)   \
-    RecordZoneSrcLocation(name); \
-    auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name));
+// Local (within-TU) zone index, dense from 0: the per-TU __COUNTER__ minus the base captured once the
+// profiler namespace opens (kernel_profiler::zone_counter_base, below).
+#define TT_ZONE_LOCAL(ctr) ((uint32_t)((ctr) - kernel_profiler::zone_counter_base - 1u))
+
+// Compute this zone's collision-free 16-bit id = (host file id << LOCAL_BITS) | local index, declare it
+// as `hash`, and emit its metadata record. The static_asserts turn any budget overflow into a build
+// error instead of a silent id collision. `ctr` must be a single __COUNTER__ value (passed once by the
+// caller) so the numeric id and the emitted record agree.
+#define TT_ZONE_META(name, ctr)                                                                               \
+    static_assert(                                                                                            \
+        TT_ZONE_LOCAL(ctr) <= ((1u << KERNEL_PROFILER_LOCAL_BITS) - 1u),                                      \
+        "too many KERNEL_PROFILER zones in one translation unit for KERNEL_PROFILER_LOCAL_BITS");             \
+    static_assert(                                                                                            \
+        (uint32_t)(KERNEL_PROFILER_FILE_ID) < (1u << (16 - KERNEL_PROFILER_LOCAL_BITS)),                      \
+        "KERNEL_PROFILER_FILE_ID exceeds the file-id budget for KERNEL_PROFILER_LOCAL_BITS");                 \
+    auto constexpr hash =                                                                                     \
+        (uint16_t)(((uint32_t)(KERNEL_PROFILER_FILE_ID) << KERNEL_PROFILER_LOCAL_BITS) | TT_ZONE_LOCAL(ctr)); \
+    RecordZoneMeta(hash, name)
+
+#define SrcLocNameToHash(name) TT_ZONE_META(name, __COUNTER__)
 
 #if defined(PROFILE_KERNEL) && \
     (!defined(DISPATCH_KERNEL) || (defined(DISPATCH_KERNEL) && (PROFILE_KERNEL & PROFILER_OPT_DO_DISPATCH_CORES)))
 namespace kernel_profiler {
+
+// __COUNTER__ value captured once, right after this TU pulls in the profiler headers. TT_ZONE_LOCAL
+// subtracts it so per-TU zone indices count from ~0 regardless of how much __COUNTER__ the preceding
+// includes consumed, keeping them inside the LOCAL_BITS budget. Internal linkage: private per TU.
+constexpr uint32_t zone_counter_base = __COUNTER__;
 
 extern uint32_t wIndex;
 extern uint32_t stackSize;
@@ -891,16 +924,14 @@ __attribute__((noinline)) void trace_only_init() {
 // Not dispatch
 #if (!defined(DISPATCH_KERNEL))
 
-#define DeviceZoneScopedN(name)                                                \
-    RecordZoneSrcLocation(name);                                               \
-    auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name)); \
+#define DeviceZoneScopedN(name)      \
+    TT_ZONE_META(name, __COUNTER__); \
     kernel_profiler::profileScope<hash> zone = kernel_profiler::profileScope<hash>();
 
-#define DeviceTimestampedData(name, data)                                          \
-    {                                                                              \
-        RecordZoneSrcLocation(name);                                               \
-        auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name)); \
-        kernel_profiler::timeStampedData<hash>(data);                              \
+#define DeviceTimestampedData(name, data)             \
+    {                                                 \
+        TT_ZONE_META(name, __COUNTER__);              \
+        kernel_profiler::timeStampedData<hash>(data); \
     }
 
 #define DeviceRecordEvent(event_id) kernel_profiler::recordEvent(event_id);
@@ -909,15 +940,15 @@ __attribute__((noinline)) void trace_only_init() {
 #elif (defined(DISPATCH_KERNEL) && (PROFILE_KERNEL & PROFILER_OPT_DO_DISPATCH_CORES))
 
 #define DeviceZoneScopedN(name)                                                          \
-    RecordZoneSrcLocation(name);                                                         \
-    auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name));           \
+    TT_ZONE_META(name, __COUNTER__);                                                     \
+                                                                                         \
     kernel_profiler::profileScope<hash, kernel_profiler::DoingDispatch::DISPATCH> zone = \
         kernel_profiler::profileScope<hash, kernel_profiler::DoingDispatch::DISPATCH>();
 
 #define DeviceTimestampedData(name, data)                                                            \
     {                                                                                                \
-        RecordZoneSrcLocation(name);                                                                 \
-        auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name));                   \
+        TT_ZONE_META(name, __COUNTER__);                                                             \
+                                                                                                     \
         kernel_profiler::timeStampedData<hash, kernel_profiler::DoingDispatch::DISPATCH_META>(data); \
     }
 
@@ -945,24 +976,20 @@ __attribute__((noinline)) void trace_only_init() {
 #define PROFILER_MAIN_SCOPE kernel_profiler::profileScopeGuaranteed
 #endif
 
-#define DeviceZoneScopedMainN(name)                                            \
-    RecordZoneSrcLocation(name);                                               \
-    auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name)); \
+#define DeviceZoneScopedMainN(name)  \
+    TT_ZONE_META(name, __COUNTER__); \
     PROFILER_MAIN_SCOPE<hash, 0> zone = PROFILER_MAIN_SCOPE<hash, 0>();
 
-#define DeviceZoneScopedMainChildN(name)                                       \
-    RecordZoneSrcLocation(name);                                               \
-    auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name)); \
+#define DeviceZoneScopedMainChildN(name) \
+    TT_ZONE_META(name, __COUNTER__);     \
     PROFILER_MAIN_SCOPE<hash, 1> zone = PROFILER_MAIN_SCOPE<hash, 1>();
 
-#define DeviceZoneScopedSumN1(name)                                            \
-    RecordZoneSrcLocation(name);                                               \
-    auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name)); \
+#define DeviceZoneScopedSumN1(name)  \
+    TT_ZONE_META(name, __COUNTER__); \
     kernel_profiler::profileScopeAccumulate<hash, 0> zone = kernel_profiler::profileScopeAccumulate<hash, 0>();
 
-#define DeviceZoneScopedSumN2(name)                                            \
-    RecordZoneSrcLocation(name);                                               \
-    auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name)); \
+#define DeviceZoneScopedSumN2(name)  \
+    TT_ZONE_META(name, __COUNTER__); \
     kernel_profiler::profileScopeAccumulate<hash, 1> zone = kernel_profiler::profileScopeAccumulate<hash, 1>();
 
 #define DeviceZoneSetCounter(counter)                  \

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -47,10 +47,10 @@
 #define RecordZoneMeta(id, name)                                                                                     \
     {                                                                                                                \
         static const struct __attribute__((packed)) {                                                                \
-            uint16_t zid;                                                                                            \
+            uint32_t zid;                                                                                            \
             char str[sizeof(PROFILER_MSG_NAME(name))];                                                               \
         } zone_meta                                                                                                  \
-            __attribute__((section(".tt_zone_meta"), used, aligned(4))) = {(uint16_t)(id), PROFILER_MSG_NAME(name)}; \
+            __attribute__((section(".tt_zone_meta"), used, aligned(4))) = {(uint32_t)(id), PROFILER_MSG_NAME(name)}; \
         (void)zone_meta;                                                                                             \
     }
 
@@ -58,19 +58,20 @@
 // profiler namespace opens (kernel_profiler::zone_counter_base, below).
 #define TT_ZONE_LOCAL(ctr) ((uint32_t)((ctr) - kernel_profiler::zone_counter_base - 1u))
 
-// Compute this zone's collision-free 16-bit id = (host file id << LOCAL_BITS) | local index, declare it
-// as `hash`, and emit its metadata record. The static_asserts turn any budget overflow into a build
-// error instead of a silent id collision. `ctr` must be a single __COUNTER__ value (passed once by the
-// caller) so the numeric id and the emitted record agree.
+// Compute this zone's collision-free structural id = (host file id << LOCAL_BITS) | local index (18 bits;
+// see the layout in profiler_common.h), declare it as `hash`, and emit its metadata record. The
+// static_asserts turn any budget overflow into a build error instead of a silent id collision. `ctr`
+// must be a single __COUNTER__ value (passed once by the caller) so the numeric id and the emitted
+// record agree.
 #define TT_ZONE_META(name, ctr)                                                                               \
     static_assert(                                                                                            \
         TT_ZONE_LOCAL(ctr) <= ((1u << KERNEL_PROFILER_LOCAL_BITS) - 1u),                                      \
         "too many KERNEL_PROFILER zones in one translation unit for KERNEL_PROFILER_LOCAL_BITS");             \
     static_assert(                                                                                            \
-        (uint32_t)(KERNEL_PROFILER_FILE_ID) < (1u << (16 - KERNEL_PROFILER_LOCAL_BITS)),                      \
+        (uint32_t)(KERNEL_PROFILER_FILE_ID) < KERNEL_PROFILER_FILE_ID_COUNT,                                  \
         "KERNEL_PROFILER_FILE_ID exceeds the file-id budget for KERNEL_PROFILER_LOCAL_BITS");                 \
     auto constexpr hash =                                                                                     \
-        (uint16_t)(((uint32_t)(KERNEL_PROFILER_FILE_ID) << KERNEL_PROFILER_LOCAL_BITS) | TT_ZONE_LOCAL(ctr)); \
+        (uint32_t)(((uint32_t)(KERNEL_PROFILER_FILE_ID) << KERNEL_PROFILER_LOCAL_BITS) | TT_ZONE_LOCAL(ctr)); \
     RecordZoneMeta(hash, name)
 
 #define RecordDeviceZoneId(name) TT_ZONE_META(name, __COUNTER__)
@@ -199,10 +200,14 @@ __attribute__((noinline)) void init_profiler(
 #endif
 }
 
-constexpr uint32_t get_const_id(uint32_t id, PacketTypes type) { return ((id & 0xFFFF) | ((type << 16) & 0x7FFFF)); }
+constexpr uint32_t get_const_id(uint32_t id, PacketTypes type) {
+    return (
+        (id & KERNEL_PROFILER_ZONE_ID_MASK) | ((type << KERNEL_PROFILER_ZONE_ID_BITS) & KERNEL_PROFILER_TIMER_ID_MASK));
+}
 
 inline __attribute__((always_inline)) uint32_t get_id(uint32_t id, PacketTypes type) {
-    return ((id & 0xFFFF) | ((type << 16) & 0x7FFFF));
+    return (
+        (id & KERNEL_PROFILER_ZONE_ID_MASK) | ((type << KERNEL_PROFILER_ZONE_ID_BITS) & KERNEL_PROFILER_TIMER_ID_MASK));
 }
 
 template <DoingDispatch dispatch = DoingDispatch::NOT_DISPATCH>
@@ -222,14 +227,17 @@ inline __attribute__((always_inline)) bool bufferHasRoom(uint32_t additional_slo
 inline __attribute__((always_inline)) void mark_time_at_index_inlined(uint32_t index, uint32_t timer_id) {
     volatile tt_reg_ptr uint32_t* p_reg = reinterpret_cast<volatile tt_reg_ptr uint32_t*>(RISCV_DEBUG_REG_WALL_CLOCK_L);
     profiler_data_buffer[myRiscID].data[index] =
-        0x80000000 | ((timer_id & 0x7FFFF) << 12) | (p_reg[WALL_CLOCK_HIGH_INDEX] & 0xFFF);
+        0x80000000 | ((timer_id & KERNEL_PROFILER_TIMER_ID_MASK) << KERNEL_PROFILER_TIMESTAMP_HI_BITS) |
+        (p_reg[WALL_CLOCK_HIGH_INDEX] & KERNEL_PROFILER_TIMESTAMP_HI_MASK);
     profiler_data_buffer[myRiscID].data[index + 1] = p_reg[WALL_CLOCK_LOW_INDEX];
 }
 
 // Like mark_time_at_index_inlined but writes a pre-captured timestamp (time_h/time_l) instead of sampling now.
 inline __attribute__((always_inline)) void mark_time_at_index_with_stamp(
     uint32_t index, uint32_t timer_id, uint32_t time_h, uint32_t time_l) {
-    profiler_data_buffer[myRiscID].data[index] = 0x80000000 | ((timer_id & 0x7FFFF) << 12) | (time_h & 0xFFF);
+    profiler_data_buffer[myRiscID].data[index] =
+        0x80000000 | ((timer_id & KERNEL_PROFILER_TIMER_ID_MASK) << KERNEL_PROFILER_TIMESTAMP_HI_BITS) |
+        (time_h & KERNEL_PROFILER_TIMESTAMP_HI_MASK);
     profiler_data_buffer[myRiscID].data[index + 1] = time_l;
 }
 
@@ -270,7 +278,8 @@ inline __attribute__((always_inline)) void risc_finished_profiling() {
         if (sums[i] > 0) {
             if (wIndex < PROFILER_L1_VECTOR_SIZE) {
                 profiler_data_buffer[myRiscID].data[wIndex] =
-                    0x80000000 | ((get_id(sumIDs[i], ZONE_TOTAL) & 0x7FFFF) << 12);
+                    0x80000000 | ((get_id(sumIDs[i], ZONE_TOTAL) & KERNEL_PROFILER_TIMER_ID_MASK)
+                                  << KERNEL_PROFILER_TIMESTAMP_HI_BITS);
                 profiler_data_buffer[myRiscID].data[wIndex + 1] = sums[i];
                 wIndex += PROFILER_L1_MARKER_UINT32_SIZE;
             }

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -73,7 +73,7 @@
         (uint16_t)(((uint32_t)(KERNEL_PROFILER_FILE_ID) << KERNEL_PROFILER_LOCAL_BITS) | TT_ZONE_LOCAL(ctr)); \
     RecordZoneMeta(hash, name)
 
-#define SrcLocNameToHash(name) TT_ZONE_META(name, __COUNTER__)
+#define RecordDeviceZoneId(name) TT_ZONE_META(name, __COUNTER__)
 
 #if defined(PROFILE_KERNEL) && \
     (!defined(DISPATCH_KERNEL) || (defined(DISPATCH_KERNEL) && (PROFILE_KERNEL & PROFILER_OPT_DO_DISPATCH_CORES)))
@@ -155,16 +155,6 @@ constexpr uint32_t DRAM_PROFILER_ADDRESS = DRAM_PROFILER_ADDRESS_DEFAULT;
 #endif
 
 constexpr uint32_t HOST_BUFFER_END_INDEX = HOST_BUFFER_END_INDEX_BR_ER + myRiscID;
-
-constexpr uint32_t Hash32_CT(const char* str, size_t n, uint32_t basis = UINT32_C(2166136261)) {
-    return n == 0 ? basis : Hash32_CT(str + 1, n - 1, (basis ^ str[0]) * UINT32_C(16777619));
-}
-
-template <size_t N>
-constexpr uint32_t Hash16_CT(const char (&s)[N]) {
-    auto res = Hash32_CT(s, N - 1);
-    return ((res & 0xFFFF) ^ ((res & 0xFFFF0000) >> 16)) & 0xFFFF;
-}
 
 enum class DoingDispatch { DISPATCH, DISPATCH_META, NOT_DISPATCH };
 
@@ -459,7 +449,7 @@ __attribute__((noinline)) void finish_profiler(bool do_accumulate = DO_ACCUMULAT
             // Host pairs guaranteed markers by timestamp, so inner NOC-FLUSH end must be strictly before outer
             // DRAM-PUSH end: emit flush first, sample push_end after.
             {
-                SrcLocNameToHash("PROFILER-NOC-FLUSH");
+                RecordDeviceZoneId("PROFILER-NOC-FLUSH");
                 mark_time_at_index_with_stamp(
                     GUARANTEED_MARKER_3_H, get_const_id(hash, ZONE_START), flush_start_h, flush_start_l);
                 mark_time_at_index_with_stamp(
@@ -468,7 +458,7 @@ __attribute__((noinline)) void finish_profiler(bool do_accumulate = DO_ACCUMULAT
             uint32_t push_end_h = push_clk[WALL_CLOCK_HIGH_INDEX];
             uint32_t push_end_l = push_clk[WALL_CLOCK_LOW_INDEX];
             {
-                SrcLocNameToHash("PROFILER-DRAM-PUSH");
+                RecordDeviceZoneId("PROFILER-DRAM-PUSH");
                 mark_time_at_index_with_stamp(
                     GUARANTEED_MARKER_1_H, get_const_id(hash, ZONE_START), push_start_h, push_start_l);
                 mark_time_at_index_with_stamp(
@@ -591,7 +581,7 @@ __attribute__((noinline)) void quick_push() {
         return;
     }
 
-    SrcLocNameToHash("PROFILER-NOC-QUICK-PUSH");
+    RecordDeviceZoneId("PROFILER-NOC-QUICK-PUSH");
     mark_time_at_index_inlined(wIndex, hash);
     wIndex += PROFILER_L1_MARKER_UINT32_SIZE;
 

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -31,8 +31,20 @@
 #define PROFILER_MSG __FILE__ "," $Line ",KERNEL_PROFILER"
 #define PROFILER_MSG_NAME(name) name "," PROFILER_MSG
 
-#define SrcLocNameToHash(name)                   \
-    DO_PRAGMA(message(PROFILER_MSG_NAME(name))); \
+// Record the zone's source-location string in a file-only ELF section (.tt_zone_meta)
+// instead of emitting a #pragma message into the compiler log. The host reads this section
+// straight out of the kernel ELF (see JitBuildState::extract_zone_src_locations), which keeps
+// build logs clean. The section is non-loaded -- KEEP(...) (INFO) in the linker scripts strips
+// SHF_ALLOC -- so it costs zero device memory. The block gives each expansion its own scope so
+// the static never collides when multiple zones share a C++ scope; it emits no runtime code.
+#define RecordZoneSrcLocation(name)                                                                                 \
+    {                                                                                                               \
+        static const char zone_src_loc[] __attribute__((section(".tt_zone_meta"), used)) = PROFILER_MSG_NAME(name); \
+        (void)zone_src_loc;                                                                                         \
+    }
+
+#define SrcLocNameToHash(name)   \
+    RecordZoneSrcLocation(name); \
     auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name));
 
 #if defined(PROFILE_KERNEL) && \
@@ -880,13 +892,13 @@ __attribute__((noinline)) void trace_only_init() {
 #if (!defined(DISPATCH_KERNEL))
 
 #define DeviceZoneScopedN(name)                                                \
-    DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                               \
+    RecordZoneSrcLocation(name);                                               \
     auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name)); \
     kernel_profiler::profileScope<hash> zone = kernel_profiler::profileScope<hash>();
 
 #define DeviceTimestampedData(name, data)                                          \
     {                                                                              \
-        DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                               \
+        RecordZoneSrcLocation(name);                                               \
         auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name)); \
         kernel_profiler::timeStampedData<hash>(data);                              \
     }
@@ -897,14 +909,14 @@ __attribute__((noinline)) void trace_only_init() {
 #elif (defined(DISPATCH_KERNEL) && (PROFILE_KERNEL & PROFILER_OPT_DO_DISPATCH_CORES))
 
 #define DeviceZoneScopedN(name)                                                          \
-    DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                                         \
+    RecordZoneSrcLocation(name);                                                         \
     auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name));           \
     kernel_profiler::profileScope<hash, kernel_profiler::DoingDispatch::DISPATCH> zone = \
         kernel_profiler::profileScope<hash, kernel_profiler::DoingDispatch::DISPATCH>();
 
 #define DeviceTimestampedData(name, data)                                                            \
     {                                                                                                \
-        DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                                                 \
+        RecordZoneSrcLocation(name);                                                                 \
         auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name));                   \
         kernel_profiler::timeStampedData<hash, kernel_profiler::DoingDispatch::DISPATCH_META>(data); \
     }
@@ -934,22 +946,22 @@ __attribute__((noinline)) void trace_only_init() {
 #endif
 
 #define DeviceZoneScopedMainN(name)                                            \
-    DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                               \
+    RecordZoneSrcLocation(name);                                               \
     auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name)); \
     PROFILER_MAIN_SCOPE<hash, 0> zone = PROFILER_MAIN_SCOPE<hash, 0>();
 
 #define DeviceZoneScopedMainChildN(name)                                       \
-    DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                               \
+    RecordZoneSrcLocation(name);                                               \
     auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name)); \
     PROFILER_MAIN_SCOPE<hash, 1> zone = PROFILER_MAIN_SCOPE<hash, 1>();
 
 #define DeviceZoneScopedSumN1(name)                                            \
-    DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                               \
+    RecordZoneSrcLocation(name);                                               \
     auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name)); \
     kernel_profiler::profileScopeAccumulate<hash, 0> zone = kernel_profiler::profileScopeAccumulate<hash, 0>();
 
 #define DeviceZoneScopedSumN2(name)                                            \
-    DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                               \
+    RecordZoneSrcLocation(name);                                               \
     auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name)); \
     kernel_profiler::profileScopeAccumulate<hash, 1> zone = kernel_profiler::profileScopeAccumulate<hash, 1>();
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -34,9 +34,8 @@ struct MaybeProfileScope {
 template <uint32_t timer_id>
 struct MaybeProfileScope<true, timer_id> : kernel_profiler::profileScope<timer_id> {};
 
-#define MaybeDeviceZoneScopedN(ENABLED, name)                                  \
-    DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                               \
-    auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name)); \
+#define MaybeDeviceZoneScopedN(ENABLED, name) \
+    TT_ZONE_META(name, __COUNTER__);          \
     MaybeProfileScope<ENABLED, hash> zone;
 #else
 #define MaybeDeviceZoneScopedN(ENABLED, name)


### PR DESCRIPTION
### PR Category
Feature

### Summary

2 changes are coming in this PR to improve zone source location management in profiler. 

1) Instead of using build logs to store source location hash, unmapped elf location are used to store the id assigned to source location for device size profiler

2) Instead of hashing the entire concatenated string of zone_name+source_location into a 16bit value, host now assigns an ID per each translation unit and in each translation unit every zone gets a unique counter ID. 2 bit are taken away from timer high to have 12bits of TU ID + 6 bits of zones ID to gives a 18bit unique ID perzone.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mo/zonesrc_hash)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mo/zonesrc_hash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mo/zonesrc_hash)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mo/zonesrc_hash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mo/zonesrc_hash)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mo/zonesrc_hash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mo/zonesrc_hash)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mo/zonesrc_hash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mo/zonesrc_hash)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mo/zonesrc_hash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mo/zonesrc_hash)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mo/zonesrc_hash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mo/zonesrc_hash)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mo/zonesrc_hash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mo/zonesrc_hash)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mo/zonesrc_hash)