### PR TITLE
[ttnn] binary_ng: re-apply program-cache-hit args via override_runtime_arguments (fixes SDXL in-place PCC)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,14 +259,14 @@ endif()
 # Descriptor cache-hit fast-path parity check: on every fast-path hit, rebuild the descriptor and
 # assert the patched runtime args + CB addresses match a full rebuild. A debug/CI regression net for
 # incomplete in-place re-application (SDXL silu / MorehAdamW). OFF by default (per-hit rebuild cost).
+# The check is compiled only in ttnn (mesh_device_operation_adapter.hpp), so the
+# TT_DESCRIPTOR_PATCHING_PARITY_CHECK definition is scoped to the ttnn target in ttnn/CMakeLists.txt
+# rather than applied globally.
 option(
     ENABLE_DESCRIPTOR_PATCHING_PARITY_CHECK
     "Assert descriptor cache-hit fast-path parity against a full rebuild (debug/CI)."
     OFF
 )
-if(ENABLE_DESCRIPTOR_PATCHING_PARITY_CHECK)
-    add_compile_definitions(TT_DESCRIPTOR_PATCHING_PARITY_CHECK)
-endif()
 
 add_library(metal_common_pch STATIC)
 add_library(TT::CommonPCH ALIAS metal_common_pch)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,6 +256,18 @@ if(ENABLE_CODE_TIMERS)
     add_compile_definitions(TT_ENABLE_CODE_TIMERS)
 endif()
 
+# Descriptor cache-hit fast-path parity check: on every fast-path hit, rebuild the descriptor and
+# assert the patched runtime args + CB addresses match a full rebuild. A debug/CI regression net for
+# incomplete in-place re-application (SDXL silu / MorehAdamW). OFF by default (per-hit rebuild cost).
+option(
+    ENABLE_DESCRIPTOR_PATCHING_PARITY_CHECK
+    "Assert descriptor cache-hit fast-path parity against a full rebuild (debug/CI)."
+    OFF
+)
+if(ENABLE_DESCRIPTOR_PATCHING_PARITY_CHECK)
+    add_compile_definitions(TT_DESCRIPTOR_PATCHING_PARITY_CHECK)
+endif()
+
 add_library(metal_common_pch STATIC)
 add_library(TT::CommonPCH ALIAS metal_common_pch)
 file(GENERATE OUTPUT metal_common_pch.cpp CONTENT "/*dummy pch file*/\n")

--- a/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
+++ b/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
@@ -653,8 +653,8 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_InputRegionDuplicate
 }
 
 // #48928: op(X, X, out=X) — X at two genuine input positions plus the in-place output_tensor slot.
-// The output-alias skip is granted ONCE; the extra input occurrence still bails, so a later
-// same-shape op(X, Y, out=X) cache hit can't patch input-b to X's address.
+// Even with the in-place opt-in ON, the output-alias skip is granted ONCE; the extra input
+// occurrence still bails, so a later same-shape op(X, Y, out=X) cache hit can't patch input-b to X.
 TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_OutputAliasRepeatedInInputs_ReturnsEmpty) {
     auto buf_a = MakeDramBuffer(device());
 
@@ -670,9 +670,55 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_OutputAliasRepeatedI
         program,
         desc,
         std::vector<Buffer*>{buf_a.get(), buf_a.get(), buf_a.get(), buf_a.get()},
-        /*num_input_buffers=*/3);
+        /*num_input_buffers=*/3,
+        /*allow_inplace_output_tensor_alias=*/true);
 
     EXPECT_TRUE(resolved.empty());
+}
+
+// #48928/#49573: an in-place op's output_tensor carried INSIDE tensor_args (input region) aliasing
+// an input — [input=X, output_tensor=X | return=X].  This is the SDXL-silu / MorehAdamW shape.
+//   - Default (opt-out): treated as an ambiguous input-region duplicate → BAIL to slow-path rebuild.
+//     This is the safe behavior for ops whose get_dynamic_runtime_args is incomplete.
+TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_InplaceOutputTensorInInputs_Default_ReturnsEmpty) {
+    auto buf_a = MakeDramBuffer(device());
+
+    KernelDescriptor kd = MakeBlankReaderKernel({0, 0});
+    kd.emplace_runtime_args({0, 0}, {buf_a.get()});
+
+    ProgramDescriptor desc;
+    desc.kernels = {kd};
+
+    Program program{desc};
+    // num_input_buffers=2 (input + output_tensor), 1 output (return). Default opt-in (false) → bail.
+    ResolvedBindings resolved = resolve_bindings(
+        program, desc, std::vector<Buffer*>{buf_a.get(), buf_a.get(), buf_a.get()}, /*num_input_buffers=*/2);
+
+    EXPECT_TRUE(resolved.empty());
+}
+
+//   - Opt-in (allow_inplace_output_tensor_alias=true): the op re-applies every cache-hit-varying arg
+//     itself (binary_ng), so the output_tensor is a safe in-place alias → KEEP the fast path.
+TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_InplaceOutputTensorInInputs_OptIn_KeepsFastPath) {
+    auto buf_a = MakeDramBuffer(device());
+
+    KernelDescriptor kd = MakeBlankReaderKernel({0, 0});
+    kd.emplace_runtime_args({0, 0}, {buf_a.get()});
+
+    ProgramDescriptor desc;
+    desc.kernels = {kd};
+
+    Program program{desc};
+    ResolvedBindings resolved = resolve_bindings(
+        program,
+        desc,
+        std::vector<Buffer*>{buf_a.get(), buf_a.get(), buf_a.get()},
+        /*num_input_buffers=*/2,
+        /*allow_inplace_output_tensor_alias=*/true);
+
+    EXPECT_FALSE(resolved.empty());
+    ASSERT_EQ(resolved.rt_args.size(), 1u);
+    EXPECT_EQ(resolved.rt_args[0].tensor_buffer_idx, 0u);
 }
 
 // resolve_bindings fires TT_FATAL when a runtime-arg binding buffer is not in

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_program_cache.py
@@ -105,7 +105,7 @@ def test_ng_cache_reuse_same_config(device, isolate_program_cache):
     ],
 )
 def test_ng_inplace_cache_reuse_different_shapes(device, isolate_program_cache, shape_first, shape_second):
-    """binary_ng opts in to the in-place program-cache fast path (allow_inplace_program_cache_alias,
+    """binary_ng opts in to the in-place program-cache fast path (UNSAFE_optin_inplace_program_cache_alias,
     #48928). An in-place add (output_tensor aliases input) with different logical shapes shares one
     cache entry (volume is excluded from the hash), so the second call is a cache HIT that reuses the
     first program WITHOUT rebuild. binary_ng's get_dynamic_runtime_args must re-derive every per-core
@@ -121,6 +121,9 @@ def test_ng_inplace_cache_reuse_different_shapes(device, isolate_program_cache, 
         tt_b = ttnn.from_torch(b, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
         with device.cache_entries_counter.measure():
             tt_c = ttnn.add(tt_a, tt_b, output_tensor=tt_a)  # in-place
+        # Prove the op is ACTUALLY in-place: if a future change ignored output_tensor or allocated a
+        # fresh output, PCC + single-cache-entry would still pass while no longer testing the alias.
+        assert tt_c.buffer_address() == tt_a.buffer_address()
         return a + b, ttnn.to_torch(tt_c)
 
     ref1, out1 = inplace_add(shape_first, 0)
@@ -151,7 +154,8 @@ def test_ng_inplace_cache_hit_sharded_readdresses(device, isolate_program_cache)
         tt_a = ttnn.from_torch(a, layout=ttnn.TILE_LAYOUT, device=device, memory_config=mem)
         tt_b = ttnn.from_torch(b, layout=ttnn.TILE_LAYOUT, device=device, memory_config=mem)
         with device.cache_entries_counter.measure():
-            tt_c = ttnn.add(tt_a, tt_b, output_tensor=tt_a, memory_config=mem)  # in-place, sharded
+            tt_c = ttnn.add(tt_a, tt_b, output_tensor=tt_a)  # in-place, sharded (output preallocated)
+        assert tt_c.buffer_address() == tt_a.buffer_address()  # prove it's actually in-place
         keep_alive += [tt_a, tt_b, tt_c]
         assert_with_pcc(a + b, ttnn.to_torch(tt_c), 0.999)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_program_cache.py
@@ -105,13 +105,12 @@ def test_ng_cache_reuse_same_config(device, isolate_program_cache):
     ],
 )
 def test_ng_inplace_cache_reuse_different_shapes(device, isolate_program_cache, shape_first, shape_second):
-    """binary_ng opts in to the in-place program-cache fast path (UNSAFE_optin_inplace_program_cache_alias,
-    #48928). An in-place add (output_tensor aliases input) with different logical shapes shares one
+    """binary_ng re-applies all per-dispatch state on a cache hit via override_runtime_arguments
+    (#48928). An in-place add (output_tensor aliases input) with different logical shapes shares one
     cache entry (volume is excluded from the hash), so the second call is a cache HIT that reuses the
-    first program WITHOUT rebuild. binary_ng's get_dynamic_runtime_args must re-derive every per-core
+    first program WITHOUT rebuild. binary_ng's override_runtime_arguments must re-derive every per-core
     arg for the current shape or the reused program corrupts the result. Regression guard for the
-    in-place fast path that #49573 protects for ops WITHOUT a complete get_dynamic (SDXL silu / moreh)
-    but that binary_ng is allowed to take."""
+    in-place cache-hit path (the SDXL silu / moreh class of bug)."""
 
     def inplace_add(shape, seed):
         torch.manual_seed(seed)
@@ -137,11 +136,11 @@ def test_ng_inplace_cache_reuse_different_shapes(device, isolate_program_cache, 
 
 def test_ng_inplace_cache_hit_sharded_readdresses(device, isolate_program_cache):
     """binary_ng in-place add on SHARDED tensors — the sharding mode SDXL exercised (silu) — driven
-    through binary_ng's opt-in fast path. Repeated at the SAME shard config (sharded binary_ng keys
-    shard_volume into the hash, so a different shape would MISS, not hit) but with freshly-allocated
-    operands kept alive, so each cache HIT sees a DIFFERENT buffer address. binary_ng's tensor-backed
-    CB / rt-arg addresses must be re-patched on the hit (no rebuild) or the result is stale. Guards
-    the sharded in-place path that is now binary_ng's responsibility as the sole opt-in op."""
+    through binary_ng's override_runtime_arguments cache-hit path. Repeated at the SAME shard config
+    (sharded binary_ng keys shard_volume into the hash, so a different shape would MISS, not hit) but
+    with freshly-allocated operands kept alive, so each cache HIT sees a DIFFERENT buffer address.
+    binary_ng's tensor-backed CB / rt-arg addresses must be re-applied on the hit (no rebuild) or the
+    result is stale."""
     shape = [1, 1, 256, 256]
     mem = ttnn.create_sharded_memory_config(
         shape, core_grid=ttnn.CoreGrid(y=8, x=1), strategy=ttnn.ShardStrategy.HEIGHT
@@ -163,6 +162,77 @@ def test_ng_inplace_cache_hit_sharded_readdresses(device, isolate_program_cache)
         assert_with_pcc(a + b, ttnn.to_torch(tt_c), 0.999)
 
     # One shared program reused across all four differently-addressed in-place hits.
+    assert device.cache_entries_counter.total == 1
+
+
+@pytest.mark.parametrize("first_inplace", [True, False], ids=["inplace_first", "outofplace_first"])
+def test_ng_cache_mixed_inplace_outofplace_interleaved(device, isolate_program_cache, first_inplace):
+    """REGRESSION (aliased address re-derivation): one cached INTERLEAVED program reused across a MIX of
+    in-place (output_tensor aliases an input) and out-of-place calls sharing a single cache entry
+    (logical shape is excluded from the hash). The legacy resolve_bindings maps an aliased buffer to its
+    FIRST occurrence, so a program built under one aliasing pattern and reused under another would patch
+    the writer's output address from the wrong tensor slot. binary_ng's override_runtime_arguments
+    re-derives every rt-arg address for the actual current tensors, so it MUST survive both orders —
+    this proves the rt-arg axis is re-applied, not just that a cache hit occurred."""
+
+    def do(seed, inplace):
+        torch.manual_seed(seed)
+        a = torch.rand([1, 1, 32, 64], dtype=torch.bfloat16)
+        b = torch.rand([1, 1, 32, 64], dtype=torch.bfloat16)
+        tt_a = ttnn.from_torch(a, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        tt_b = ttnn.from_torch(b, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        out = tt_a if inplace else None
+        with device.cache_entries_counter.measure():
+            tt_c = ttnn.add(tt_a, tt_b, output_tensor=out)
+        if inplace:
+            assert tt_c.buffer_address() == tt_a.buffer_address()
+        return a + b, ttnn.to_torch(tt_c)
+
+    # Alternate aliasing across the SAME cache entry, in both orders.
+    for i, inplace in enumerate([first_inplace, not first_inplace, first_inplace, not first_inplace]):
+        ref, out = do(i, inplace)
+        assert_with_pcc(ref, out, 0.999)
+    assert device.cache_entries_counter.total == 1
+
+
+@pytest.mark.parametrize("first_inplace", [True, False], ids=["inplace_first", "outofplace_first"])
+def test_ng_cache_mixed_inplace_outofplace_sharded(device, isolate_program_cache, first_inplace):
+    """REGRESSION (SDXL-class, the axis that actually broke): one cached SHARDED program reused across
+    a MIX of in-place and out-of-place calls sharing a single cache entry. For sharded ops the input/
+    output addresses ride on tensor-backed CB base addresses. Under the legacy path these were patched
+    by resolved_bindings.cbs via first-occurrence resolution (and get_dynamic could not touch CBs at
+    all), so a program built under one aliasing pattern and reused under another mis-resolved the output
+    CB to the wrong tensor slot with NOTHING to correct it — the exact PCC~0 behind SDXL in-place silu.
+    binary_ng's override_runtime_arguments re-applies the CB addresses by CBIndex from the current
+    tensors, so both orders must stay correct."""
+    shape = [1, 1, 256, 256]
+    mem = ttnn.create_sharded_memory_config(
+        shape, core_grid=ttnn.CoreGrid(y=8, x=1), strategy=ttnn.ShardStrategy.HEIGHT
+    )
+    keep_alive = []  # hold refs so successive calls see fresh (different) buffer addresses
+
+    def do(seed, inplace):
+        torch.manual_seed(seed)
+        a = torch.rand(shape, dtype=torch.bfloat16)
+        b = torch.rand(shape, dtype=torch.bfloat16)
+        tt_a = ttnn.from_torch(a, layout=ttnn.TILE_LAYOUT, device=device, memory_config=mem)
+        tt_b = ttnn.from_torch(b, layout=ttnn.TILE_LAYOUT, device=device, memory_config=mem)
+        if inplace:
+            out = tt_a
+        else:
+            out = ttnn.from_torch(
+                torch.zeros(shape, dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device, memory_config=mem
+            )
+        with device.cache_entries_counter.measure():
+            tt_c = ttnn.add(tt_a, tt_b, output_tensor=out)
+        assert tt_c.buffer_address() == out.buffer_address()
+        keep_alive.extend([tt_a, tt_b, tt_c, out])
+        return a + b, ttnn.to_torch(tt_c)
+
+    for i, inplace in enumerate([first_inplace, not first_inplace, first_inplace, not first_inplace]):
+        ref, out = do(i, inplace)
+        assert_with_pcc(ref, out, 0.999)
+    # Same shard config across all calls (sharded binary_ng keys shard_volume) → one shared cache entry.
     assert device.cache_entries_counter.total == 1
 
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_program_cache.py
@@ -155,7 +155,10 @@ def test_ng_inplace_cache_hit_sharded_readdresses(device, isolate_program_cache)
         tt_b = ttnn.from_torch(b, layout=ttnn.TILE_LAYOUT, device=device, memory_config=mem)
         with device.cache_entries_counter.measure():
             tt_c = ttnn.add(tt_a, tt_b, output_tensor=tt_a)  # in-place, sharded (output preallocated)
-        assert tt_c.buffer_address() == tt_a.buffer_address()  # prove it's actually in-place
+        # prove it's actually in-place. NOTE: buffer_address() requires a single-address buffer, which
+        # standard create_sharded_memory_config gives; a per-core-allocation config would TT_FATAL here
+        # (use experimental_per_core_buffer_address if this test is ever parametrized onto one).
+        assert tt_c.buffer_address() == tt_a.buffer_address()
         keep_alive += [tt_a, tt_b, tt_c]
         assert_with_pcc(a + b, ttnn.to_torch(tt_c), 0.999)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_program_cache.py
@@ -97,6 +97,41 @@ def test_ng_cache_reuse_same_config(device, isolate_program_cache):
     assert not torch.equal(tt_out1, tt_out2)
 
 
+@pytest.mark.parametrize(
+    "shape_first, shape_second",
+    [
+        ([1, 1, 32, 64], [1, 1, 128, 256]),  # grow volume
+        ([1, 1, 128, 256], [1, 1, 32, 64]),  # shrink volume
+    ],
+)
+def test_ng_inplace_cache_reuse_different_shapes(device, isolate_program_cache, shape_first, shape_second):
+    """binary_ng opts in to the in-place program-cache fast path (allow_inplace_program_cache_alias,
+    #48928). An in-place add (output_tensor aliases input) with different logical shapes shares one
+    cache entry (volume is excluded from the hash), so the second call is a cache HIT that reuses the
+    first program WITHOUT rebuild. binary_ng's get_dynamic_runtime_args must re-derive every per-core
+    arg for the current shape or the reused program corrupts the result. Regression guard for the
+    in-place fast path that #49573 protects for ops WITHOUT a complete get_dynamic (SDXL silu / moreh)
+    but that binary_ng is allowed to take."""
+
+    def inplace_add(shape, seed):
+        torch.manual_seed(seed)
+        a = torch.rand(shape, dtype=torch.bfloat16)
+        b = torch.rand(shape, dtype=torch.bfloat16)
+        tt_a = ttnn.from_torch(a, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        tt_b = ttnn.from_torch(b, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        with device.cache_entries_counter.measure():
+            tt_c = ttnn.add(tt_a, tt_b, output_tensor=tt_a)  # in-place
+        return a + b, ttnn.to_torch(tt_c)
+
+    ref1, out1 = inplace_add(shape_first, 0)
+    assert_with_pcc(ref1, out1, 0.999)
+
+    ref2, out2 = inplace_add(shape_second, 1)  # cache HIT on the differently-shaped program
+    assert_with_pcc(ref2, out2, 0.999)
+
+    assert device.cache_entries_counter.total == 1  # proves it was a hit, not a rebuild masking the bug
+
+
 def test_ng_cache_reuse_scalar_different_values(device, isolate_program_cache):
     """Different scalar values but same op -> 1 cache entry, different outputs."""
     shape = [1, 1, 32, 64]

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_program_cache.py
@@ -132,6 +132,33 @@ def test_ng_inplace_cache_reuse_different_shapes(device, isolate_program_cache, 
     assert device.cache_entries_counter.total == 1  # proves it was a hit, not a rebuild masking the bug
 
 
+def test_ng_inplace_cache_hit_sharded_readdresses(device, isolate_program_cache):
+    """binary_ng in-place add on SHARDED tensors — the sharding mode SDXL exercised (silu) — driven
+    through binary_ng's opt-in fast path. Repeated at the SAME shard config (sharded binary_ng keys
+    shard_volume into the hash, so a different shape would MISS, not hit) but with freshly-allocated
+    operands kept alive, so each cache HIT sees a DIFFERENT buffer address. binary_ng's tensor-backed
+    CB / rt-arg addresses must be re-patched on the hit (no rebuild) or the result is stale. Guards
+    the sharded in-place path that is now binary_ng's responsibility as the sole opt-in op."""
+    shape = [1, 1, 256, 256]
+    mem = ttnn.create_sharded_memory_config(
+        shape, core_grid=ttnn.CoreGrid(y=8, x=1), strategy=ttnn.ShardStrategy.HEIGHT
+    )
+    keep_alive = []  # hold refs so each iteration's tensors get fresh (different) addresses
+    for i in range(4):
+        torch.manual_seed(i)
+        a = torch.rand(shape, dtype=torch.bfloat16)
+        b = torch.rand(shape, dtype=torch.bfloat16)
+        tt_a = ttnn.from_torch(a, layout=ttnn.TILE_LAYOUT, device=device, memory_config=mem)
+        tt_b = ttnn.from_torch(b, layout=ttnn.TILE_LAYOUT, device=device, memory_config=mem)
+        with device.cache_entries_counter.measure():
+            tt_c = ttnn.add(tt_a, tt_b, output_tensor=tt_a, memory_config=mem)  # in-place, sharded
+        keep_alive += [tt_a, tt_b, tt_c]
+        assert_with_pcc(a + b, ttnn.to_torch(tt_c), 0.999)
+
+    # One shared program reused across all four differently-addressed in-place hits.
+    assert device.cache_entries_counter.total == 1
+
+
 def test_ng_cache_reuse_scalar_different_values(device, isolate_program_cache):
     """Different scalar values but same op -> 1 cache entry, different outputs."""
     shape = [1, 1, 32, 64]

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_program_cache.py
@@ -293,3 +293,48 @@ def test_unary_sharded_cache_correctness_different_grids(device):
         tt_out = ttnn.to_torch(output)
         torch_ref = torch.abs(torch_tensor)
         assert_equal(torch_ref, tt_out)
+
+
+@pytest.mark.parametrize("first_inplace", [True, False], ids=["inplace_first", "outofplace_first"])
+def test_unary_sharded_mixed_inplace_outofplace(device, first_inplace):
+    """REGRESSION (the exact SDXL failure): sharded unary reused across a MIX of in-place
+    (output_tensor aliases the input) and out-of-place calls sharing ONE cache entry (same shape/
+    config). For sharded ops the input/output addresses ride on tensor-backed CB base addresses,
+    re-patched only by resolved_bindings.cbs — get_dynamic returns rt-args and cannot touch CBs.
+    Combined with first-occurrence alias resolution, a program built under one aliasing pattern and
+    reused under another mis-resolves the output CB to the wrong slot with nothing to correct it →
+    PCC ~0 (SDXL in-place silu). With the parity check built in, this ALSO trips the framework's
+    fast-path-vs-rebuild assertion at the exact stale CB. Both orders must stay correct."""
+    device.cache_entries_counter.reset()
+    shape = (256, 256)
+    mem = ttnn.create_sharded_memory_config(
+        shape=shape,
+        core_grid=ttnn.CoreGrid(x=1, y=8),
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    keep_alive = []
+
+    def do(seed, inplace):
+        torch.manual_seed(seed)
+        t = torch.rand(shape, dtype=torch.bfloat16) + 0.1
+        tt_in = ttnn.from_torch(t, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=mem)
+        if inplace:
+            out = tt_in
+        else:
+            out = ttnn.from_torch(
+                torch.zeros(shape, dtype=torch.bfloat16),
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                device=device,
+                memory_config=mem,
+            )
+        with device.cache_entries_counter.measure():
+            tt_out = ttnn.relu(tt_in, output_tensor=out)
+        assert tt_out.buffer_address() == out.buffer_address()
+        keep_alive.extend([tt_in, tt_out, out])
+        assert_equal(torch.relu(t), ttnn.to_torch(tt_out))
+
+    for i, inplace in enumerate([first_inplace, not first_inplace, first_inplace, not first_inplace]):
+        do(i, inplace)
+    assert device.cache_entries_counter.total == 1

--- a/tt_metal/api/tt-metalium/experimental/program_descriptor_patching.hpp
+++ b/tt_metal/api/tt-metalium/experimental/program_descriptor_patching.hpp
@@ -25,10 +25,10 @@
  *   args.push_back(num_tiles);    // uint32_t
  *   kernel_desc.emplace_runtime_args(core, std::move(args));
  *
- *   // In the adapter (cache miss): store resolved bindings.  Pass num_input_buffers and, for an op
- *   // that re-applies every cache-hit-varying arg itself, allow_inplace_output_tensor_alias=true to
- *   // keep the fast path when its output_tensor is carried in tensor_args and aliases an input
- *   // (surfaced from the op via the ttnn trait UNSAFE_optin_inplace_program_cache_alias; see below).
+ *   // In the adapter (cache miss): store resolved bindings.  NOTE: this is the LEGACY address-inference
+ *   // path, being migrated out.  An op that needs correct in-place / mixed-aliasing behavior should
+ *   // instead define override_runtime_arguments() (re-derives all per-dispatch state itself, correct by
+ *   // construction) — the adapter then bypasses resolve_bindings entirely for that op.
  *   auto tensor_buffers = collect_tensor_buffers(tensor_args, tensor_return_value);
  *   auto resolved = tt::tt_metal::resolve_bindings(program, desc, tensor_buffers);
  *
@@ -168,5 +168,27 @@ struct DynamicRuntimeArg {
 // Uses GetRuntimeArgs / GetCommonRuntimeArgs for the same pre/post-first-enqueue correctness as
 // apply_resolved_bindings.
 void apply_dynamic_runtime_args(Program& program, std::span<const DynamicRuntimeArg> dynamic_args);
+
+// ---------------------------------------------------------------------------
+// Fast-path parity check (debug / CI regression net)
+// ---------------------------------------------------------------------------
+
+// Universal, op-agnostic correctness invariant for the cache-hit fast path.  After the fast path
+// has patched the cached program (apply_resolved_bindings + apply_dynamic_runtime_args), the caller
+// rebuilds the descriptor for the CURRENT tensors into a scratch Program and passes both here.  This
+// asserts the fast path reproduced EXACTLY what a full rebuild would: every per-core and common
+// runtime arg (enumerated from `desc`) and every circular-buffer base address must match.
+//
+// A mismatch means resolved_bindings + get_dynamic_runtime_args is INCOMPLETE for this op — a stale
+// runtime arg or (for sharded ops) a stale CB address survives on a differently-aliased or
+// differently-allocated cache hit (the SDXL in-place silu / MorehAdamW failure mode).  It fires a
+// TT_FATAL naming the op, kernel, core, arg, and both values, turning silent PCC garbage into a loud,
+// pinpointed failure.  The rebuild is the oracle, so no per-op assertions have to be hand-maintained.
+//
+// Intended to be called only under -DTT_DESCRIPTOR_PATCHING_PARITY_CHECK (CI/debug); it is a no-cost
+// helper otherwise since the caller guards the call site.  The check makes the in-place fast path a
+// verified framework invariant rather than a per-op trust assertion.
+void assert_fastpath_parity(
+    const Program& fast, const Program& rebuilt, const ProgramDescriptor& desc, std::string_view op_name);
 
 }  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/experimental/program_descriptor_patching.hpp
+++ b/tt_metal/api/tt-metalium/experimental/program_descriptor_patching.hpp
@@ -25,7 +25,10 @@
  *   args.push_back(num_tiles);    // uint32_t
  *   kernel_desc.emplace_runtime_args(core, std::move(args));
  *
- *   // In the adapter (cache miss): store resolved bindings
+ *   // In the adapter (cache miss): store resolved bindings.  Pass num_input_buffers and, for an op
+ *   // that re-applies every cache-hit-varying arg itself, allow_inplace_output_tensor_alias=true to
+ *   // keep the fast path when its output_tensor is carried in tensor_args and aliases an input
+ *   // (surfaced from the op via the ttnn trait allow_inplace_program_cache_alias; see below).
  *   auto tensor_buffers = collect_tensor_buffers(tensor_args, tensor_return_value);
  *   auto resolved = tt::tt_metal::resolve_bindings(program, desc, tensor_buffers);
  *

--- a/tt_metal/api/tt-metalium/experimental/program_descriptor_patching.hpp
+++ b/tt_metal/api/tt-metalium/experimental/program_descriptor_patching.hpp
@@ -106,18 +106,29 @@ struct ResolvedBindings {
 //   - the SAME buffer appearing twice WITHIN the inputs (e.g. matmul(X, X)) is ambiguous —
 //     a future call with distinct same-shape tensors would miscompute — so we bail to the
 //     slow path.
-//   - an OUTPUT buffer that aliases an INPUT buffer (an in-place op writing back into its
-//     input) is safe: every binding for that buffer resolves to the one shared address,
-//     which is correct on every dispatch — so we keep the fast path.
+//   - an OUTPUT buffer (from the output/workload region) that aliases an INPUT buffer (an
+//     in-place op writing back into its input) is safe: every binding for that buffer resolves
+//     to the one shared address, correct on every dispatch — so we keep the fast path.
 // num_input_buffers defaults to SIZE_MAX, which treats every entry as an input (the original
 // conservative behavior: bail on any duplicate).
+//
+// allow_inplace_output_tensor_alias (default false): when an op carries its own output INSIDE
+// tensor_args (an optional output_tensor in the INPUT region) and it aliases an input, the output
+// buffer appears in the input region.  That looks like the ambiguous matmul(X, X) duplicate, so by
+// default we BAIL to the slow-path rebuild (correct for every op).  An op may set this true ONLY if
+// it re-applies EVERY cache-hit-varying runtime arg itself (via get_dynamic_runtime_args + Buffer*
+// bindings) so reusing the cached program for a differently-shaped/-allocated in-place call is
+// correct.  binary_ng qualifies (its get_dynamic re-derives all per-core args).  unary/ternary/
+// moreh_* do NOT — their get_dynamic is partial, so they must keep bailing (see #49573, #48928,
+// SDXL in-place silu / MorehAdamW).  The op opts in via the adapter, keyed on a static trait.
 //
 // Call immediately after Program{desc} on cache miss; store in shared_variables.
 ResolvedBindings resolve_bindings(
     Program& program,
     const ProgramDescriptor& desc,
     std::span<Buffer* const> tensor_buffers,
-    size_t num_input_buffers = std::numeric_limits<size_t>::max());
+    size_t num_input_buffers = std::numeric_limits<size_t>::max(),
+    bool allow_inplace_output_tensor_alias = false);
 
 // Apply resolved bindings to the cached program on a cache hit.
 // current_buffers must be the output of collect_tensor_buffers() for the

--- a/tt_metal/api/tt-metalium/experimental/program_descriptor_patching.hpp
+++ b/tt_metal/api/tt-metalium/experimental/program_descriptor_patching.hpp
@@ -28,7 +28,7 @@
  *   // In the adapter (cache miss): store resolved bindings.  Pass num_input_buffers and, for an op
  *   // that re-applies every cache-hit-varying arg itself, allow_inplace_output_tensor_alias=true to
  *   // keep the fast path when its output_tensor is carried in tensor_args and aliases an input
- *   // (surfaced from the op via the ttnn trait allow_inplace_program_cache_alias; see below).
+ *   // (surfaced from the op via the ttnn trait UNSAFE_optin_inplace_program_cache_alias; see below).
  *   auto tensor_buffers = collect_tensor_buffers(tensor_args, tensor_return_value);
  *   auto resolved = tt::tt_metal::resolve_bindings(program, desc, tensor_buffers);
  *

--- a/tt_metal/impl/program/program_descriptor_patching.cpp
+++ b/tt_metal/impl/program/program_descriptor_patching.cpp
@@ -23,6 +23,8 @@
 #include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/program.hpp>
+#include "impl/buffers/circular_buffer.hpp"
+#include "program_impl.hpp"
 #include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
 #include <tt_stl/assert.hpp>
@@ -262,6 +264,87 @@ void apply_resolved_bindings(
     for (const auto& cb : bindings.cbs) {
         UpdateDynamicCircularBufferAddress(
             program, cb.cb_id, *current_buffers[cb.tensor_buffer_idx], cb.address_offset);
+    }
+}
+
+void assert_fastpath_parity(
+    const Program& fast, const Program& rebuilt, const ProgramDescriptor& desc, std::string_view op_name) {
+    // Per-core and common runtime args, enumerated from the descriptor (same kernel push order in
+    // both programs, so the kernel index doubles as the KernelHandle here).
+    for (uint32_t k = 0; k < static_cast<uint32_t>(desc.kernels.size()); ++k) {
+        for (const auto& core_rt : desc.kernels[k].runtime_args) {
+            const CoreCoord& core = core_rt.first;
+            const auto& f = GetRuntimeArgs(fast, k, core);
+            const auto& r = GetRuntimeArgs(rebuilt, k, core);
+            TT_FATAL(
+                f.size() == r.size(),
+                "descriptor fast-path parity FAILED for op {}: kernel {} core ({},{}) has {} runtime args "
+                "on the cache-hit fast path but {} on a fresh rebuild.",
+                op_name,
+                k,
+                core.x,
+                core.y,
+                f.size(),
+                r.size());
+            for (uint32_t i = 0; i < static_cast<uint32_t>(f.size()); ++i) {
+                TT_FATAL(
+                    f[i] == r[i],
+                    "descriptor fast-path parity FAILED for op {}: kernel {} core ({},{}) arg[{}] "
+                    "fast=0x{:x} rebuild=0x{:x}. The cache-hit fast path did not reproduce a full rebuild — "
+                    "resolved_bindings + get_dynamic_runtime_args re-application is incomplete for this op "
+                    "(stale runtime arg on a differently-aliased/-allocated hit).",
+                    op_name,
+                    k,
+                    core.x,
+                    core.y,
+                    i,
+                    f[i],
+                    r[i]);
+            }
+        }
+        if (!desc.kernels[k].common_runtime_args.empty()) {
+            const auto& f = GetCommonRuntimeArgs(fast, k);
+            const auto& r = GetCommonRuntimeArgs(rebuilt, k);
+            for (uint32_t i = 0; i < static_cast<uint32_t>(std::min(f.size(), r.size())); ++i) {
+                TT_FATAL(
+                    f[i] == r[i],
+                    "descriptor fast-path parity FAILED for op {}: kernel {} common arg[{}] fast=0x{:x} "
+                    "rebuild=0x{:x}. Fast-path common runtime arg is stale on a cache hit.",
+                    op_name,
+                    k,
+                    i,
+                    f[i],
+                    r[i]);
+            }
+        }
+    }
+
+    // Circular-buffer base addresses — the axis get_dynamic_runtime_args cannot reach (it re-applies
+    // runtime args only). For sharded ops the tensor buffer address rides on the CB, so a mis-resolved
+    // in-place alias leaves a stale CB address here with nothing to correct it (SDXL silu).
+    const auto fast_cbs = fast.impl().circular_buffers();
+    const auto rebuilt_cbs = rebuilt.impl().circular_buffers();
+    TT_FATAL(
+        fast_cbs.size() == rebuilt_cbs.size(),
+        "descriptor fast-path parity FAILED for op {}: {} circular buffers on the fast path vs {} on rebuild.",
+        op_name,
+        fast_cbs.size(),
+        rebuilt_cbs.size());
+    for (size_t i = 0; i < fast_cbs.size(); ++i) {
+        // Only globally-allocated (tensor-pinned) CBs carry a buffer address that must be re-patched on
+        // a cache hit; locally-allocated scratch CBs are per-program and not comparable across builds.
+        if (!fast_cbs[i]->globally_allocated()) {
+            continue;
+        }
+        TT_FATAL(
+            fast_cbs[i]->address() == rebuilt_cbs[i]->address(),
+            "descriptor fast-path parity FAILED for op {}: circular buffer #{} base address fast=0x{:x} "
+            "rebuild=0x{:x}. CB address is stale on the cache hit — get_dynamic_runtime_args cannot patch "
+            "CBs, and resolved_bindings.cbs mis-resolved the in-place alias (SDXL sharded in-place case).",
+            op_name,
+            i,
+            fast_cbs[i]->address(),
+            rebuilt_cbs[i]->address());
     }
 }
 

--- a/tt_metal/impl/program/program_descriptor_patching.cpp
+++ b/tt_metal/impl/program/program_descriptor_patching.cpp
@@ -40,7 +40,8 @@ ResolvedBindings resolve_bindings(
     Program& program,
     const ProgramDescriptor& desc,
     std::span<Buffer* const> tensor_buffers,
-    size_t num_input_buffers) {
+    size_t num_input_buffers,
+    bool allow_inplace_output_tensor_alias) {
     ResolvedBindings result;
 
     // If the same Buffer* appears more than once, every binding for that buffer maps to the
@@ -58,14 +59,22 @@ ResolvedBindings resolve_bindings(
     //
     // tensor_buffers is ordered inputs-first; the first num_input_buffers entries are inputs.
     {
-        // Buffers in the output/workload region. An input-region entry that also appears here is the
-        // op's own output carried inside tensor_args (e.g. an in-place op's optional output_tensor
-        // aliasing an input) — a same-buffer-by-construction alias, NOT the ambiguous matmul(X, X)
-        // case — so it must not bail. (#48928: binary_ng in-place residual add.)
+        // Buffers in the output/workload region.  When the op opts in via
+        // allow_inplace_output_tensor_alias, an input-region entry that also appears here is the op's
+        // own output carried inside tensor_args (e.g. an in-place op's optional output_tensor aliasing
+        // an input) — a same-buffer-by-construction alias, NOT the ambiguous matmul(X, X) case — so it
+        // must not bail.  This is UNSAFE unless the op re-applies every cache-hit-varying runtime arg
+        // itself: otherwise the shared cached program is reused for a differently-shaped/-allocated
+        // in-place call with stale args (SDXL in-place silu, MorehAdamW → PCC garbage; see #48928 /
+        // #49573).  So it is OPT-IN: default false ⇒ such a duplicate bails to the safe slow-path
+        // rebuild.  binary_ng opts in (#48928: in-place residual add; its get_dynamic re-derives all
+        // per-core args).  When false, output_region stays empty and every in-place duplicate bails.
         std::unordered_set<Buffer*> output_region;
-        for (size_t i = num_input_buffers; i < tensor_buffers.size(); ++i) {
-            if (tensor_buffers[i]) {
-                output_region.insert(tensor_buffers[i]);
+        if (allow_inplace_output_tensor_alias) {
+            for (size_t i = num_input_buffers; i < tensor_buffers.size(); ++i) {
+                if (tensor_buffers[i]) {
+                    output_region.insert(tensor_buffers[i]);
+                }
             }
         }
         std::unordered_set<Buffer*> input_buffers;   // buffers seen in the input region
@@ -82,9 +91,10 @@ ResolvedBindings resolve_bindings(
                 continue;
             }
             // An output buffer carried in the input region (the op's output_tensor) is an in-place
-            // alias, not a distinct input — skip it ONCE. A second input-region occurrence means the
-            // buffer genuinely repeats across input positions (e.g. op(X, X, out=X)); fall through so
-            // it still bails, else a later same-shape op(X, Y, out=X) hit would patch input-b to X.
+            // alias, not a distinct input — skip it ONCE (opt-in only; output_region is empty
+            // otherwise).  A second input-region occurrence means the buffer genuinely repeats across
+            // input positions (e.g. op(X, X, out=X)); fall through so it still bails, else a later
+            // same-shape op(X, Y, out=X) hit would patch input-b to X.
             if (is_input && output_region.contains(buf) && inplace_alias_used.insert(buf).second) {
                 continue;
             }

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -96,6 +96,14 @@ add_library(TTNN::Core ALIAS ttnn_core)
 TT_ENABLE_UNITY_BUILD(ttnn_core)
 
 target_compile_definitions(ttnn_core PUBLIC "$<$<CXX_COMPILER_ID:GNU>:DISABLE_NAMESPACE_STATIC_ASSERT>")
+
+# Descriptor cache-hit fast-path parity check (opt-in via -DENABLE_DESCRIPTOR_PATCHING_PARITY_CHECK).
+# The #ifdef lives in ttnn/api/ttnn/mesh_device_operation_adapter.hpp, so scope the definition to the
+# ttnn target (PUBLIC so header consumers see it consistently) instead of defining it globally.
+if(ENABLE_DESCRIPTOR_PATCHING_PARITY_CHECK)
+    target_compile_definitions(ttnn_core PUBLIC TT_DESCRIPTOR_PATCHING_PARITY_CHECK)
+endif()
+
 tt_reuse_precompile_headers(ttnn_core TTNN::PCHFull)
 
 set(TENSOR_FLATBUFFER_SCHEMAS

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -446,14 +446,16 @@ public:
         }
 
         // Whether this op may take the program-cache fast path for an in-place output_tensor carried
-        // in tensor_args that aliases an input (see resolve_bindings' allow_inplace_output_tensor_alias).
+        // in tensor_args that aliases an input (drives resolve_bindings' allow_inplace_output_tensor_alias).
         // Default false — such a duplicate bails to the safe slow-path rebuild. An op opts in with
-        // `static constexpr bool allow_inplace_program_cache_alias = true;` ONLY if it re-applies every
-        // cache-hit-varying runtime arg itself (get_dynamic_runtime_args + Buffer* bindings); otherwise
-        // the shared cached program would be reused in-place with stale args (SDXL silu, MorehAdamW).
-        static consteval bool allow_inplace_program_cache_alias() {
-            if constexpr (requires { DeviceOperation::allow_inplace_program_cache_alias; }) {
-                return DeviceOperation::allow_inplace_program_cache_alias;
+        // `static constexpr bool UNSAFE_optin_inplace_program_cache_alias = true;` ONLY if it re-applies
+        // every cache-hit-varying runtime arg itself (get_dynamic_runtime_args + Buffer* bindings) AND
+        // ships an in-place cache-hit regression test; otherwise the shared cached program is reused
+        // in-place with stale args (SDXL silu, MorehAdamW). The UNSAFE_ name is the hazard marker — the
+        // flag is an unverified per-op waiver, not a tuning knob.
+        static consteval bool unsafe_optin_inplace_program_cache_alias() {
+            if constexpr (requires { DeviceOperation::UNSAFE_optin_inplace_program_cache_alias; }) {
+                return DeviceOperation::UNSAFE_optin_inplace_program_cache_alias;
             } else {
                 return false;
             }
@@ -510,7 +512,7 @@ public:
                         desc,
                         collected.buffers,
                         collected.num_input_buffers,
-                        allow_inplace_program_cache_alias());
+                        unsafe_optin_inplace_program_cache_alias());
                     mesh_workload.add_program(device_range, std::move(program));
                     shared_variables[device_range] = shared_variables_t{
                         .workload_descriptor = workload_descriptor, .resolved_bindings = std::move(bindings)};
@@ -536,7 +538,7 @@ public:
                             desc,
                             collected.buffers,
                             collected.num_input_buffers,
-                            allow_inplace_program_cache_alias());
+                            unsafe_optin_inplace_program_cache_alias());
                         mesh_workload.add_program(device_range, std::move(program));
                         shared_variables[device_range] = shared_variables_t{.resolved_bindings = std::move(bindings)};
                     };

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -507,12 +507,19 @@ public:
                 for (auto& [device_range, desc] : programs) {
                     tt::tt_metal::Program program{desc};
                     auto collected = collect_tensor_buffers(tensor_args, tensor_return_value, workload_descriptor);
+                    // The WorkloadDescriptor variant has NO slow-path rebuild (apply_descriptor only
+                    // re-applies resolved bindings + dynamic args), so it must ALWAYS allow the in-place
+                    // output_tensor alias — otherwise resolve_bindings bails to an EMPTY ResolvedBindings
+                    // and the fast path skips address patching, leaving stale addresses on a cache hit
+                    // (breaks supported cross-device p2p where output_tensor aliases input). This restores
+                    // the pre-opt-in behavior for this branch; the unsafe_optin gate only applies to the
+                    // ProgramDescriptor branch below, which CAN fall back to a safe slow-path rebuild.
                     auto bindings = tt::tt_metal::resolve_bindings(
                         program,
                         desc,
                         collected.buffers,
                         collected.num_input_buffers,
-                        unsafe_optin_inplace_program_cache_alias());
+                        /*allow_inplace_output_tensor_alias=*/true);
                     mesh_workload.add_program(device_range, std::move(program));
                     shared_variables[device_range] = shared_variables_t{
                         .workload_descriptor = workload_descriptor, .resolved_bindings = std::move(bindings)};

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -445,21 +445,42 @@ public:
             }
         }
 
-        // Whether this op may take the program-cache fast path for an in-place output_tensor carried
-        // in tensor_args that aliases an input (drives resolve_bindings' allow_inplace_output_tensor_alias).
-        // Default false — such a duplicate bails to the safe slow-path rebuild. An op opts in with
-        // `static constexpr bool UNSAFE_optin_inplace_program_cache_alias = true;` ONLY if it re-applies
-        // every cache-hit-varying runtime arg itself (get_dynamic_runtime_args + Buffer* bindings) AND
-        // ships an in-place cache-hit regression test; otherwise the shared cached program is reused
-        // in-place with stale args (SDXL silu, MorehAdamW). The UNSAFE_ name is the hazard marker — the
-        // flag is an unverified per-op waiver, not a tuning knob.
-        static consteval bool unsafe_optin_inplace_program_cache_alias() {
-            if constexpr (requires { DeviceOperation::UNSAFE_optin_inplace_program_cache_alias; }) {
-                return DeviceOperation::UNSAFE_optin_inplace_program_cache_alias;
-            } else {
-                return false;
-            }
+        // Whether the op re-applies ALL per-dispatch state itself on a program-cache hit via
+        // override_runtime_arguments() — the descriptor-era analog of the legacy
+        // override_runtime_arguments().  When present, the adapter calls it on every hit and uses
+        // NEITHER resolve_bindings (address inference) NOR get_dynamic_runtime_args: the op owns the
+        // full re-derivation, correct by construction.  This is the target mechanism; resolve_bindings
+        // and get_dynamic are the legacy paths being migrated out (and, eventually, deleted with
+        // Metal 2.0 native bindings).
+        static consteval bool has_override_runtime_arguments() {
+            return requires(
+                tt::tt_metal::Program& program,
+                const operation_attributes_t& attrs,
+                const tensor_args_t& tensor_args,
+                tensor_return_value_t& tensor_return_value,
+                const std::optional<ttnn::MeshCoordinate>& coord) {
+                DeviceOperation::override_runtime_arguments(program, attrs, tensor_args, tensor_return_value, coord);
+            };
         }
+
+        static consteval bool has_get_dynamic_runtime_args() {
+            return requires(
+                const operation_attributes_t& attrs,
+                const tensor_args_t& tensor_args,
+                tensor_return_value_t& tensor_return_value,
+                const std::optional<ttnn::MeshCoordinate>& coord) {
+                DeviceOperation::get_dynamic_runtime_args(attrs, tensor_args, tensor_return_value, coord);
+            };
+        }
+
+        // An op that owns its cache-hit re-derivation via override_runtime_arguments() must NOT also
+        // declare the legacy get_dynamic_runtime_args() — override supersedes it, and having both is
+        // ambiguous (which one re-applies?).  This assert forces porting an op to DROP get_dynamic.
+        static_assert(
+            !(has_override_runtime_arguments() && has_get_dynamic_runtime_args()),
+            "A DeviceOperation must not declare BOTH override_runtime_arguments() and "
+            "get_dynamic_runtime_args(): override_runtime_arguments supersedes the legacy hook. "
+            "Delete get_dynamic_runtime_args() from this op.");
 
         // Build a ProgramDescriptor for one mesh coordinate (the ProgramDescriptor variant).
         // The declarative WorkloadDescriptor path (the WorkloadDescriptor variant) does NOT go through
@@ -539,15 +560,19 @@ public:
                             return;
                         }
                         tt::tt_metal::Program program{desc};
-                        auto collected = collect_tensor_buffers(tensor_args, tensor_return_value, empty_descriptor);
-                        auto bindings = tt::tt_metal::resolve_bindings(
-                            program,
-                            desc,
-                            collected.buffers,
-                            collected.num_input_buffers,
-                            unsafe_optin_inplace_program_cache_alias());
-                        mesh_workload.add_program(device_range, std::move(program));
-                        shared_variables[device_range] = shared_variables_t{.resolved_bindings = std::move(bindings)};
+                        if constexpr (has_override_runtime_arguments()) {
+                            // The op re-derives all per-dispatch state on every hit via
+                            // override_runtime_arguments(); no resolve_bindings needed.
+                            mesh_workload.add_program(device_range, std::move(program));
+                            shared_variables[device_range] = shared_variables_t{};
+                        } else {
+                            auto collected = collect_tensor_buffers(tensor_args, tensor_return_value, empty_descriptor);
+                            auto bindings = tt::tt_metal::resolve_bindings(
+                                program, desc, collected.buffers, collected.num_input_buffers);
+                            mesh_workload.add_program(device_range, std::move(program));
+                            shared_variables[device_range] =
+                                shared_variables_t{.resolved_bindings = std::move(bindings)};
+                        }
                     };
 
                 if constexpr (create_descriptor_uses_mesh_dispatch_coordinate()) {
@@ -611,6 +636,33 @@ public:
                     // excluded would stay frozen at first miss — re-apply declared dynamic args.
                     apply_dynamic_runtime_args_if_declared(
                         program, attrs, tensor_args, tensor_return_value, coordinate_range);
+                } else if constexpr (has_override_runtime_arguments()) {
+                    // ProgramDescriptor variant, op owns its cache-hit re-derivation (the descriptor-era
+                    // override_runtime_arguments()): re-apply ALL per-dispatch state — every runtime arg
+                    // AND every tensor-backed CB address — for the current tensors.  No resolve_bindings
+                    // (address inference) and no get_dynamic; correct by construction for in-place,
+                    // mixed-aliasing, and work-set shifts.
+                    DeviceOperation::override_runtime_arguments(
+                        program,
+                        attrs,
+                        tensor_args,
+                        tensor_return_value,
+                        std::optional<ttnn::MeshCoordinate>(coordinate_range.start_coord()));
+#ifdef TT_DESCRIPTOR_PATCHING_PARITY_CHECK
+                    // Same regression net as the legacy fast path: assert the op's override reproduced a
+                    // full rebuild exactly (rt-args AND CB addresses).
+                    {
+                        auto parity_desc = invoke_per_coord(
+                            attrs,
+                            tensor_args,
+                            tensor_return_value,
+                            std::optional<ttnn::MeshCoordinate>(coordinate_range.start_coord()));
+                        tt::tt_metal::Program parity_scratch{parity_desc};
+                        tt::tt_metal::apply_descriptor_runtime_args(parity_scratch, parity_desc);
+                        tt::tt_metal::assert_fastpath_parity(
+                            program, parity_scratch, parity_desc, ttsl::get_type_name<DeviceOperation>());
+                    }
+#endif
                 } else {
                     // ProgramDescriptor variant — simple per-coord factory.  Fast-path when the
                     // factory declared rt-arg buffer bindings via emplace_runtime_args(), OR the op
@@ -649,6 +701,22 @@ public:
                             collect_tensor_buffers(tensor_args, tensor_return_value, sv.workload_descriptor);
                         tt::tt_metal::apply_resolved_bindings(program, sv.resolved_bindings, collected.buffers);
                         tt::tt_metal::apply_dynamic_runtime_args(program, dynamic_args);
+#ifdef TT_DESCRIPTOR_PATCHING_PARITY_CHECK
+                        // Regression net: assert the fast path reproduced a full rebuild exactly (rt-args
+                        // AND CB addresses). Fires loudly at the exact stale arg for any op whose cache-hit
+                        // re-application is incomplete (SDXL in-place silu / MorehAdamW). Debug/CI only.
+                        {
+                            auto parity_desc = invoke_per_coord(
+                                attrs,
+                                tensor_args,
+                                tensor_return_value,
+                                std::optional<ttnn::MeshCoordinate>(coordinate_range.start_coord()));
+                            tt::tt_metal::Program parity_scratch{parity_desc};
+                            tt::tt_metal::apply_descriptor_runtime_args(parity_scratch, parity_desc);
+                            tt::tt_metal::assert_fastpath_parity(
+                                program, parity_scratch, parity_desc, ttsl::get_type_name<DeviceOperation>());
+                        }
+#endif
                     } else {
                         const ttnn::MeshCoordinate mesh_coord = coordinate_range.start_coord();
                         const std::optional<ttnn::MeshCoordinate> mesh_dispatch_coordinate(mesh_coord);

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -445,6 +445,20 @@ public:
             }
         }
 
+        // Whether this op may take the program-cache fast path for an in-place output_tensor carried
+        // in tensor_args that aliases an input (see resolve_bindings' allow_inplace_output_tensor_alias).
+        // Default false — such a duplicate bails to the safe slow-path rebuild. An op opts in with
+        // `static constexpr bool allow_inplace_program_cache_alias = true;` ONLY if it re-applies every
+        // cache-hit-varying runtime arg itself (get_dynamic_runtime_args + Buffer* bindings); otherwise
+        // the shared cached program would be reused in-place with stale args (SDXL silu, MorehAdamW).
+        static consteval bool allow_inplace_program_cache_alias() {
+            if constexpr (requires { DeviceOperation::allow_inplace_program_cache_alias; }) {
+                return DeviceOperation::allow_inplace_program_cache_alias;
+            } else {
+                return false;
+            }
+        }
+
         // Build a ProgramDescriptor for one mesh coordinate (the ProgramDescriptor variant).
         // The declarative WorkloadDescriptor path (the WorkloadDescriptor variant) does NOT go through
         // this — it iterates `workload_descriptor.programs` directly.
@@ -491,8 +505,12 @@ public:
                 for (auto& [device_range, desc] : programs) {
                     tt::tt_metal::Program program{desc};
                     auto collected = collect_tensor_buffers(tensor_args, tensor_return_value, workload_descriptor);
-                    auto bindings =
-                        tt::tt_metal::resolve_bindings(program, desc, collected.buffers, collected.num_input_buffers);
+                    auto bindings = tt::tt_metal::resolve_bindings(
+                        program,
+                        desc,
+                        collected.buffers,
+                        collected.num_input_buffers,
+                        allow_inplace_program_cache_alias());
                     mesh_workload.add_program(device_range, std::move(program));
                     shared_variables[device_range] = shared_variables_t{
                         .workload_descriptor = workload_descriptor, .resolved_bindings = std::move(bindings)};
@@ -514,7 +532,11 @@ public:
                         tt::tt_metal::Program program{desc};
                         auto collected = collect_tensor_buffers(tensor_args, tensor_return_value, empty_descriptor);
                         auto bindings = tt::tt_metal::resolve_bindings(
-                            program, desc, collected.buffers, collected.num_input_buffers);
+                            program,
+                            desc,
+                            collected.buffers,
+                            collected.num_input_buffers,
+                            allow_inplace_program_cache_alias());
                         mesh_workload.add_program(device_range, std::move(program));
                         shared_variables[device_range] = shared_variables_t{.resolved_bindings = std::move(bindings)};
                     };

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
@@ -98,11 +98,13 @@ struct BinaryNgDeviceOperation {
     // cached program stays correct for a differently-shaped/-allocated in-place call. Ops without a
     // complete get_dynamic (unary/ternary/moreh_*) must NOT set this — they keep bailing (see #49573).
     //
-    // POLICY: this flag IS the correctness argument and nothing verifies it. Set it true ONLY with an
-    // accompanying in-place cache-hit regression test that varies shape/allocation across the hit and
+    // POLICY: this flag IS the correctness argument and nothing verifies it — the UNSAFE_ prefix is a
+    // deliberate hazard marker at the declaration site, not a normal tuning knob. Set it true ONLY with
+    // an accompanying in-place cache-hit regression test that varies shape/allocation across the hit and
     // asserts a single cache entry + PCC (test_binary_ng_program_cache.py: the interleaved cross-shape
-    // and sharded-readdress cases). No test → do not opt in.
-    static constexpr bool allow_inplace_program_cache_alias = true;
+    // and sharded-readdress cases). No test → do not opt in. (Removed once get_dynamic is made complete
+    // for all in-place ops, or a debug parity check lands, or descriptors move to Metal 2.0.)
+    static constexpr bool UNSAFE_optin_inplace_program_cache_alias = true;
 };
 
 }  // namespace ttnn::operations::binary_ng

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
@@ -92,10 +92,16 @@ struct BinaryNgDeviceOperation {
 
     // Opt in to the in-place output_tensor program-cache fast path (#48928: in-place residual add):
     // an output_tensor carried in tensor_args that aliases input_a is treated as a safe in-place
-    // alias instead of bailing to slow-path rebuild. Safe here because get_dynamic_runtime_args()
+    // alias instead of bailing to slow-path rebuild (drives resolve_bindings'
+    // allow_inplace_output_tensor_alias via the adapter). Safe here because get_dynamic_runtime_args()
     // above re-derives EVERY per-core arg for the current tensors on each cache hit, so the shared
     // cached program stays correct for a differently-shaped/-allocated in-place call. Ops without a
     // complete get_dynamic (unary/ternary/moreh_*) must NOT set this — they keep bailing (see #49573).
+    //
+    // POLICY: this flag IS the correctness argument and nothing verifies it. Set it true ONLY with an
+    // accompanying in-place cache-hit regression test that varies shape/allocation across the hit and
+    // asserts a single cache entry + PCC (test_binary_ng_program_cache.py: the interleaved cross-shape
+    // and sharded-readdress cases). No test → do not opt in.
     static constexpr bool allow_inplace_program_cache_alias = true;
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
@@ -89,6 +89,14 @@ struct BinaryNgDeviceOperation {
         const tensor_args_t& tensor_args,
         tensor_return_value_t& c,
         const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
+
+    // Opt in to the in-place output_tensor program-cache fast path (#48928: in-place residual add):
+    // an output_tensor carried in tensor_args that aliases input_a is treated as a safe in-place
+    // alias instead of bailing to slow-path rebuild. Safe here because get_dynamic_runtime_args()
+    // above re-derives EVERY per-core arg for the current tensors on each cache hit, so the shared
+    // cached program stays correct for a differently-shaped/-allocated in-place call. Ops without a
+    // complete get_dynamic (unary/ternary/moreh_*) must NOT set this — they keep bailing (see #49573).
+    static constexpr bool allow_inplace_program_cache_alias = true;
 };
 
 }  // namespace ttnn::operations::binary_ng

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
@@ -81,30 +81,21 @@ struct BinaryNgDeviceOperation {
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static bool skip_launch(const operation_attributes_t&, const tensor_args_t&, const tensor_return_value_t&);
 
-    // compute_program_hash EXCLUDES the tensor volume, so one cached program is reused across
-    // differently-shaped calls.  All shape-/work-split-dependent per-core runtime args are therefore
-    // re-applied on every cache hit here.  Mirrors create_descriptor()'s shared builder.
-    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+    // Re-apply ALL per-dispatch state to the cached program on every program-cache hit — the
+    // descriptor-era analog of the legacy override_runtime_arguments().  compute_program_hash
+    // EXCLUDES the tensor volume, so one cached program is reused across differently-shaped and
+    // differently-allocated (incl. in-place, out=x) calls; this re-derives every per-core runtime
+    // arg AND every tensor-backed circular-buffer base address for the CURRENT tensors, via the same
+    // shared builder create_descriptor() uses.  Correct by construction — no address inference, so
+    // in-place / mixed-aliasing / matmul(X,X)-style cases can't be mis-patched.  An op that defines
+    // this MUST NOT also define get_dynamic_runtime_args (the adapter static_asserts it); override
+    // supersedes both it and resolve_bindings, which this op no longer uses.
+    static void override_runtime_arguments(
+        tt::tt_metal::Program& program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& c,
         const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
-
-    // Opt in to the in-place output_tensor program-cache fast path (#48928: in-place residual add):
-    // an output_tensor carried in tensor_args that aliases input_a is treated as a safe in-place
-    // alias instead of bailing to slow-path rebuild (drives resolve_bindings'
-    // allow_inplace_output_tensor_alias via the adapter). Safe here because get_dynamic_runtime_args()
-    // above re-derives EVERY per-core arg for the current tensors on each cache hit, so the shared
-    // cached program stays correct for a differently-shaped/-allocated in-place call. Ops without a
-    // complete get_dynamic (unary/ternary/moreh_*) must NOT set this — they keep bailing (see #49573).
-    //
-    // POLICY: this flag IS the correctness argument and nothing verifies it — the UNSAFE_ prefix is a
-    // deliberate hazard marker at the declaration site, not a normal tuning knob. Set it true ONLY with
-    // an accompanying in-place cache-hit regression test that varies shape/allocation across the hit and
-    // asserts a single cache entry + PCC (test_binary_ng_program_cache.py: the interleaved cross-shape
-    // and sharded-readdress cases). No test → do not opt in. (Removed once get_dynamic is made complete
-    // for all in-place ops, or a debug parity check lands, or descriptors move to Metal 2.0.)
-    static constexpr bool UNSAFE_optin_inplace_program_cache_alias = true;
 };
 
 }  // namespace ttnn::operations::binary_ng

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -11,6 +11,9 @@
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/experimental/program_descriptor_patching.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/circular_buffer.hpp>
 
 #include <algorithm>
 #include <variant>
@@ -396,17 +399,17 @@ struct BinaryNgPerCoreArgs {
 };
 
 // SINGLE SOURCE OF TRUTH for binary_ng per-core runtime args.  Run by BOTH create_descriptor()
-// (cache miss) and BinaryNgDeviceOperation::get_dynamic_runtime_args() (cache hit).
+// (cache miss) and BinaryNgDeviceOperation::override_runtime_arguments() (cache hit).
 //
 // binary_ng's compute_program_hash intentionally EXCLUDES the tensor volume, so one cached program
 // is shared across differently-shaped calls.  On a cache hit the descriptor is NOT rebuilt, so every
 // shape/work-split-dependent per-core arg (c_start_id, per-core tile counts, strides, D/N/C/Ht/Wt,
 // compute_tiles, freq/counter, packed scalar, ...) would otherwise stay frozen at the first-miss
-// shape and corrupt results.  get_dynamic_runtime_args() re-runs THIS builder for the current tensors
-// and re-applies each arg every dispatch.  Because the work-core set itself changes with volume (a
-// core can flip between work and noop across hits), the builder emits args for ALL num_cores_total
-// cores -- noop cores get zero-filled lists sized to match the work-core layout -- and
-// get_dynamic_runtime_args re-applies every slot (buffer slots via their current address), so nothing
+// shape and corrupt results.  override_runtime_arguments() re-runs THIS builder for the current
+// tensors and re-applies each arg every dispatch.  Because the work-core set itself changes with
+// volume (a core can flip between work and noop across hits), the builder emits args for ALL
+// num_cores_total cores -- noop cores get zero-filled lists sized to match the work-core layout -- and
+// override_runtime_arguments re-applies every slot (buffer slots via their current address), so nothing
 // is left frozen regardless of how the partition shifts.
 BinaryNgPerCoreArgs build_per_core_runtime_args(
     const BinaryNgDeviceOperation::operation_attributes_t& operation_attributes,
@@ -1328,7 +1331,7 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
 
     // === Per-core runtime arguments ===
     // Built via the shared single-source-of-truth builder so create_descriptor() (cache miss, here)
-    // and BinaryNgDeviceOperation::get_dynamic_runtime_args() (cache hit) stay byte-identical.
+    // and BinaryNgDeviceOperation::override_runtime_arguments() (cache hit) stay byte-identical.
     {
         auto per_core = build_per_core_runtime_args(operation_attributes, a, b, c);
         for (size_t i = 0; i < per_core.cores.size(); ++i) {
@@ -1345,27 +1348,27 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
     return desc;
 }
 
-std::vector<tt::tt_metal::DynamicRuntimeArg> BinaryNgDeviceOperation::get_dynamic_runtime_args(
+void BinaryNgDeviceOperation::override_runtime_arguments(
+    tt::tt_metal::Program& program,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& c,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    // binary_ng's compute_program_hash EXCLUDES the tensor volume, so one cached program is reused
-    // across differently-shaped calls.  On a cache hit the descriptor is never rebuilt, so every
-    // shape-/work-split-dependent per-core arg baked at the first miss would stay frozen and corrupt a
-    // later, differently-shaped call.  Re-run the SAME builder create_descriptor() uses and re-apply
-    // every per-core arg for the CURRENT tensors.
+    // Re-apply ALL per-dispatch state to the cached program on a program-cache hit (the descriptor-era
+    // override_runtime_arguments()).  compute_program_hash EXCLUDES the tensor volume, so one cached
+    // program is reused across differently-shaped and differently-allocated (incl. in-place, out=x)
+    // calls; every shape-/work-split-dependent per-core arg AND every tensor-backed CB base address
+    // would otherwise stay frozen at the first miss.  We re-derive them for the CURRENT tensors from
+    // the SAME shared builder create_descriptor() uses, so the two stay byte-identical by construction.
     //
-    // Kernel push order in create_descriptor(): reader(0), writer(1), compute(2).
+    // This is correct where address inference (resolve_bindings' std::find) was not: nothing is guessed
+    // from Buffer* identity, so an in-place alias (input_a == output) or a mixed in-place/out-of-place
+    // reuse of one cache entry writes each slot from the tensor it actually belongs to.
     //
-    // The work-core partition itself shifts with the volume (a core can flip between work and noop), so
-    // we re-apply ALL cores' args, not just the work cores: noop cores get zero-filled lists (harmless,
-    // they do no work), and any core that becomes a work core on this hit gets its full args here.  For
-    // that reason we ALSO re-apply the buffer-address slots (via the current Buffer address) rather than
-    // relying solely on the Buffer* bindings: bindings are resolved once at cache-miss time and only
-    // cover the cores that were work cores THEN, so a core promoted to a work core on a later hit would
-    // otherwise be left with a stale/zero base address.  Indices match create_descriptor() by
-    // construction because both walk the identical builder output.
+    // Kernel push order in create_descriptor(): reader(0), writer(1), compute(2).  The work-core
+    // partition shifts with the volume (a core can flip between work and noop), so the builder emits
+    // args for ALL cores; we re-apply every one, buffer-address slots included (via the current Buffer
+    // address), so a core promoted to a work core on this hit is never left with a stale base address.
     const auto& a = tensor_args.input_tensor_a;
     const auto& b = tensor_args.input_tensor_b;
 
@@ -1375,34 +1378,45 @@ std::vector<tt::tt_metal::DynamicRuntimeArg> BinaryNgDeviceOperation::get_dynami
     constexpr uint32_t kWriterKernelIdx = 1;
     constexpr uint32_t kComputeKernelIdx = 2;
 
-    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
-    // Reserve the exact number of args we're about to emit (reader + writer + compute per core).
-    size_t total_args = 0;
-    for (size_t i = 0; i < per_core.cores.size(); ++i) {
-        total_args += per_core.reader[i].size() + per_core.writer[i].size() + per_core.compute[i].size();
-    }
-    dynamic_args.reserve(total_args);
-
-    auto emit = [&](uint32_t kernel_idx,
-                    const CoreCoord& core,
-                    const std::vector<std::variant<uint32_t, tt::tt_metal::Buffer*>>& args) {
-        for (uint32_t arg_idx = 0; arg_idx < args.size(); ++arg_idx) {
+    auto apply = [&](uint32_t kernel_idx,
+                     const CoreCoord& core,
+                     const std::vector<std::variant<uint32_t, tt::tt_metal::Buffer*>>& args) {
+        auto& data = tt::tt_metal::GetRuntimeArgs(program, kernel_idx, core);
+        for (uint32_t arg_idx = 0; arg_idx < static_cast<uint32_t>(args.size()); ++arg_idx) {
             const auto& slot = args[arg_idx];
-            uint32_t value = std::holds_alternative<tt::tt_metal::Buffer*>(slot)
-                                 ? static_cast<uint32_t>(std::get<tt::tt_metal::Buffer*>(slot)->address())
-                                 : std::get<uint32_t>(slot);
-            dynamic_args.push_back({kernel_idx, core, arg_idx, value});
+            data[arg_idx] = std::holds_alternative<tt::tt_metal::Buffer*>(slot)
+                                ? static_cast<uint32_t>(std::get<tt::tt_metal::Buffer*>(slot)->address())
+                                : std::get<uint32_t>(slot);
         }
     };
 
     for (size_t i = 0; i < per_core.cores.size(); ++i) {
         const auto& core = per_core.cores[i];
-        emit(kReaderKernelIdx, core, per_core.reader[i]);
-        emit(kWriterKernelIdx, core, per_core.writer[i]);
-        emit(kComputeKernelIdx, core, per_core.compute[i]);
+        apply(kReaderKernelIdx, core, per_core.reader[i]);
+        apply(kWriterKernelIdx, core, per_core.writer[i]);
+        apply(kComputeKernelIdx, core, per_core.compute[i]);
     }
 
-    return dynamic_args;
+    // Re-point tensor-backed (globally-allocated) circular buffers at the CURRENT buffers, by CBIndex.
+    // binary_ng convention: c_0 = input_a, c_1 = input_b, c_2 = output.  Addressing by CBIndex (not by
+    // enumeration order) is what makes the in-place alias correct: the output CB always tracks the
+    // output buffer even when it shares a Buffer* with an input.
+    tt::tt_metal::Buffer* a_buffer = a.buffer();
+    tt::tt_metal::Buffer* b_buffer = b.has_value() ? b->buffer() : nullptr;
+    tt::tt_metal::Buffer* c_buffer = c.buffer();
+    for (const auto& cb : program.circular_buffers()) {
+        if (!cb->globally_allocated()) {
+            continue;
+        }
+        const auto& indices = cb->buffer_indices();
+        if (indices.contains(static_cast<uint8_t>(tt::CBIndex::c_0)) && a_buffer != nullptr) {
+            tt::tt_metal::UpdateDynamicCircularBufferAddress(program, cb->id(), *a_buffer);
+        } else if (indices.contains(static_cast<uint8_t>(tt::CBIndex::c_1)) && b_buffer != nullptr) {
+            tt::tt_metal::UpdateDynamicCircularBufferAddress(program, cb->id(), *b_buffer);
+        } else if (indices.contains(static_cast<uint8_t>(tt::CBIndex::c_2)) && c_buffer != nullptr) {
+            tt::tt_metal::UpdateDynamicCircularBufferAddress(program, cb->id(), *c_buffer);
+        }
+    }
 }
 
 }  // namespace ttnn::operations::binary_ng


### PR DESCRIPTION
### What

Fixes the program-cache-hit correctness regression that produced garbage output (PCC ~0) for in-place ops — surfaced as SDXL UNet `test_sdxl_perf` (in-place `ttnn.silu(x, output_tensor=x)`) and the MorehAdamW in-place case — by replacing binary_ng's fragile cache-hit patching with a single, correct-by-construction `override_runtime_arguments` hook (the descriptor-era analog of the legacy `override_runtime_arguments`).

### Root cause

The descriptor cache-hit fast path re-derived per-dispatch state through two half-mechanisms:
- `resolve_bindings` patched **buffer addresses**, but mapped an aliased `Buffer*` to its **first occurrence** (`std::find`). For an in-place alias (`out=x`) input and output are the same `Buffer*`, so a program built under one aliasing pattern and reused under another (or reused out-of-place) mis-patched the output slot.
- `get_dynamic_runtime_args` re-applied some runtime args but **cannot touch circular-buffer base addresses** — and sharded ops carry their input/output addresses on CBs. That is the axis SDXL's sharded in-place silu actually failed on.

A newly-added descriptor fast-path **parity check** (rebuild + byte-compare on every hit) pinpointed it: `parity FAILED for op BinaryNgDeviceOperation: circular buffer #2 base address fast=0x162000 rebuild=0x15a000`.

### Fix

binary_ng implements `override_runtime_arguments`, which on every cache hit re-derives **all** per-dispatch state — every per-core runtime arg **and** every tensor-backed CB base address — for the current tensors, from the same single-source-of-truth builder `create_descriptor` uses. Nothing is inferred from `Buffer*` identity, so in-place / mixed in-place↔out-of-place / work-set-shift are all correct by construction.

- The `ProgramDescriptor` adapter calls `override_runtime_arguments` when the op declares it, and uses **neither** `resolve_bindings` **nor** `get_dynamic` for that op (and skips `resolve_bindings` on the miss).
- A `static_assert` forbids declaring both `override_runtime_arguments` and `get_dynamic_runtime_args`, so porting an op must drop the legacy hook.
- **Deleted** binary_ng's `get_dynamic_runtime_args` and the `UNSAFE_optin_inplace_program_cache_alias` trait (no op-facing infra knob).
- Legacy `resolve_bindings` / `get_dynamic` paths remain for un-ported ops — this is a **staged** migration (unary/moreh/ternary and the rest follow; the machinery is deleted when Metal 2.0 native bindings land).

### Perf — same-or-better (better)

Cache-hit dispatch is **~2x faster** than the `get_dynamic` path (in-place add, Wormhole B0, host-bound micro-benchmark; median of 3):

| case | override | get_dynamic (before) |
|---|---|---|
| in-place interleaved | ~32 µs | ~65 µs |
| in-place sharded | ~31.5 µs | ~62 µs |

override derives args once and writes in place, vs the old path double-applying addresses (bindings + get_dynamic) with per-entry lookups and a full intermediate arg vector.

### Optional CI regression net

`-DENABLE_DESCRIPTOR_PATCHING_PARITY_CHECK` (default OFF): on a cache-hit fast path, rebuild the descriptor and assert the patched runtime args + CB addresses are byte-identical to a full rebuild — op-agnostic, catches any incomplete cache-hit re-application. With it ON, the whole matrix below is green (0 parity failures).

### Validation (Wormhole B0, parity check ON)

- binary_ng program-cache suite incl. **new** mixed in-place↔out-of-place reuse, interleaved **and sharded**, both orders — the sharded/mixed case failed before, passes now.
- unary program-cache suite incl. **new** sharded mixed in-place (the SDXL analog), both orders.
- `moreh_adamw ... test_moreh_adamw_inplace_cache_hit` (#49573) still passes.
- 40/40 passed, 0 parity failures. Same 40/40 in the release config (parity OFF).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/fix-binaryng-sdxl-pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/fix-binaryng-sdxl-pcc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/fix-binaryng-sdxl-pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/fix-binaryng-sdxl-pcc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/fix-binaryng-sdxl-pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/fix-binaryng-sdxl-pcc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/fix-binaryng-sdxl-pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/fix-binaryng-sdxl-pcc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/fix-binaryng-sdxl-pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/fix-binaryng-sdxl-pcc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/fix-binaryng-sdxl-pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/fix-binaryng-sdxl-pcc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/fix-binaryng-sdxl-pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/fix-binaryng-sdxl-pcc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/fix-binaryng-sdxl-pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/fix-binaryng-sdxl-pcc)