### PR TITLE
[LLK] Complete destination-register bank-switching coverage

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/param_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/param_config.py
@@ -647,11 +647,11 @@ def get_num_blocks_and_num_tiles_in_block(
         processed with blocks of the same size. Opposite is possible but not recommended.
     """
 
-    num_rows_tensor, num_cols_tensor = input_dimensions
-    num_rows_tile, num_cols_tile = tile_dimensions
-
     if tile_dimensions is None:
         tile_dimensions = TILE_DIMENSIONS
+
+    num_rows_tensor, num_cols_tensor = input_dimensions
+    num_rows_tile, num_cols_tile = tile_dimensions
 
     is_outlier = is_format_combination_outlier(
         formats.input_format, formats.output_format, dest_acc

--- a/tt_metal/tt-llk/tests/python_tests/test_dense_pack_untilize.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_dense_pack_untilize.py
@@ -6,6 +6,7 @@ from conftest import skip_for_wormhole
 from helpers.format_config import DataFormat
 from helpers.llk_params import DestAccumulation, DestSync, format_dict
 from helpers.param_config import (
+    get_num_blocks_and_num_tiles_in_block,
     input_output_formats,
     parametrize,
 )
@@ -15,7 +16,9 @@ from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import (
     DEST_SYNC,
     IN_TILE_DIMS,
+    NUM_BLOCKS,
     NUM_FACES,
+    NUM_TILES_IN_BLOCK,
     generate_input_dim,
 )
 from helpers.utils import passed_test
@@ -73,7 +76,7 @@ def print_stimuli_and_golden(src_A, golden, input_dimensions, r_dim):
 @parametrize(
     formats=input_output_formats([DataFormat.Float16_b]),
     dest_acc=[DestAccumulation.No],
-    input_dimensions=[[32, 32], [32, 64], [32, 128], [32, 256]],
+    input_dimensions=[[32, 32], [32, 64], [32, 128], [32, 256], [128, 256]],
     r_dim=[1, 2, 4, 8, 16],
     dest_sync=[DestSync.Half],
 )
@@ -96,8 +99,21 @@ def test_pack_untilize(
     )
 
     # src_A = generate_specific_stimuli(input_dimensions, r_dim, formats.input_format)
-    golden_tensor = generate_golden_output(
-        src_A, input_dimensions, r_dim, formats.input_format
+    num_blocks, num_tiles_in_block = get_num_blocks_and_num_tiles_in_block(
+        dest_sync, dest_acc, formats, input_dimensions
+    )
+    elements_per_block = num_tiles_in_block * 32 * 32
+    block_dimensions = [32, input_dimensions[1]]
+    golden_tensor = torch.cat(
+        [
+            generate_golden_output(
+                src_A[block * elements_per_block : (block + 1) * elements_per_block],
+                block_dimensions,
+                r_dim,
+                formats.input_format,
+            )
+            for block in range(num_blocks)
+        ]
     )
     # print_stimuli_and_golden(src_A, golden_tensor, input_dimensions, r_dim)
 
@@ -111,7 +127,12 @@ def test_pack_untilize(
             ),
             DEST_SYNC(dest_sync),
         ],
-        runtimes=[NUM_FACES(4), IN_TILE_DIMS(r_dim, 32, 32, 32)],
+        runtimes=[
+            NUM_FACES(4),
+            IN_TILE_DIMS(r_dim, 32, 32, 32),
+            NUM_BLOCKS(num_blocks),
+            NUM_TILES_IN_BLOCK(num_tiles_in_block),
+        ],
         variant_stimuli=StimuliConfig(
             src_A,
             formats.input_format,
@@ -131,7 +152,18 @@ def test_pack_untilize(
     # Since input and output shapes are identical we always specify r_dim of 16 for stimulus
     # because stimulus must have 4 faces and 16 is only valid r_dim for 4 faces
     # In output for smaller actual r_dims lower portion is unused and therefore truncated
-    res_from_L1 = res_from_L1[0 : r_dim * input_dimensions[1] * 2]
+    valid_elements_per_block = r_dim * input_dimensions[1] * 2
+    res_from_L1 = torch.cat(
+        [
+            torch.tensor(
+                res_from_L1[
+                    block * elements_per_block : block * elements_per_block
+                    + valid_elements_per_block
+                ]
+            )
+            for block in range(num_blocks)
+        ]
+    ).tolist()
 
     assert len(res_from_L1) == len(
         golden_tensor

--- a/tt_metal/tt-llk/tests/python_tests/test_dense_pack_untilize.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_dense_pack_untilize.py
@@ -21,6 +21,7 @@ from helpers.test_variant_parameters import (
     NUM_TILES_IN_BLOCK,
     generate_input_dim,
 )
+from helpers.tile_constants import FACE_C_DIM, MAX_FACE_ELEMENTS, MAX_TILE_ELEMENTS
 from helpers.utils import passed_test
 
 
@@ -46,12 +47,12 @@ def generate_specific_stimuli(input_dimensions, r_dim, data_format):
 def generate_golden_output(src_A, input_dimensions, r_dim, data_format):
     """Generate expected golden output for pack untilize test."""
     golden = []
-    row_offset = 16
-    block_offset = 16 * 16
-    num_blocks = (input_dimensions[1] // 16) * 2
+    row_offset = FACE_C_DIM
+    block_offset = MAX_FACE_ELEMENTS
+    num_blocks = (input_dimensions[1] // FACE_C_DIM) * 2
     for i in range(r_dim):
         for j in range(num_blocks):
-            for k in range(16):
+            for k in range(FACE_C_DIM):
                 golden.append(src_A[i * row_offset + j * block_offset + k])
     golden_tensor = torch.tensor(golden, dtype=format_dict[data_format])
     return golden_tensor
@@ -102,7 +103,7 @@ def test_pack_untilize(
     num_blocks, num_tiles_in_block = get_num_blocks_and_num_tiles_in_block(
         dest_sync, dest_acc, formats, input_dimensions
     )
-    elements_per_block = num_tiles_in_block * 32 * 32
+    elements_per_block = num_tiles_in_block * MAX_TILE_ELEMENTS
     block_dimensions = [32, input_dimensions[1]]
     golden_tensor = torch.cat(
         [

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_bcast_col_custom.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_bcast_col_custom.py
@@ -16,11 +16,16 @@ from helpers.golden_generators import (
 from helpers.llk_params import (
     BroadcastType,
     DestAccumulation,
+    DestSync,
     MathFidelity,
     MathOperation,
     format_dict,
 )
-from helpers.param_config import input_output_formats, parametrize
+from helpers.param_config import (
+    get_num_blocks_and_num_tiles_in_block,
+    input_output_formats,
+    parametrize,
+)
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import TestConfig
@@ -29,7 +34,9 @@ from helpers.test_variant_parameters import (
     INPUT_DIMENSIONS,
     MATH_FIDELITY,
     MATH_OP,
+    NUM_BLOCKS,
     NUM_FACES,
+    NUM_TILES_IN_BLOCK,
     TEST_FACE_DIMS,
     TILE_COUNT,
     TemplateParameter,
@@ -73,7 +80,9 @@ _TILE_ROWS = [32, 16]
     ],
     broadcast_type=[BroadcastType.Column],
     tile_rows=_TILE_ROWS,
-    input_width=list(range(32, 257, 32)),
+    # Widths up to 256 fit a single dest section; 1024 (32 tiles) spans multiple
+    # sections, exercising destination bank switching in the custom pipeline.
+    input_width=list(range(32, 257, 32)) + [1024],
 )
 def test_eltwise_bcast_col_custom(
     cpp_source,
@@ -168,6 +177,10 @@ def test_eltwise_bcast_col_custom(
         mathop, src_A, src_B_golden_expanded, formats.output_format, math_fidelity
     )
 
+    num_blocks, num_tiles_in_block = get_num_blocks_and_num_tiles_in_block(
+        DestSync.Half, dest_acc, formats, input_dimensions_A, tile_dimensions=tile_dims
+    )
+
     configuration = TestConfig(
         cpp_source,
         formats,
@@ -187,6 +200,8 @@ def test_eltwise_bcast_col_custom(
             TILE_COUNT(tile_cnt_A),
             NUM_FACES(num_faces, num_faces, num_faces),
             TEST_FACE_DIMS(face_r_dim),
+            NUM_BLOCKS(num_blocks),
+            NUM_TILES_IN_BLOCK(num_tiles_in_block),
         ],
         variant_stimuli=StimuliConfig(
             src_A_tilized,

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_datacopy_custom.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_unary_datacopy_custom.py
@@ -4,14 +4,24 @@
 import torch
 from conftest import skip_for_wormhole
 from helpers.format_config import DataFormat
-from helpers.golden_generators import DataCopyGolden, get_golden_generator
-from helpers.llk_params import DestAccumulation, format_dict
-from helpers.param_config import input_output_formats, parametrize
+from helpers.golden_generators import (
+    TILE_DIMENSIONS,
+    DataCopyGolden,
+    get_golden_generator,
+)
+from helpers.llk_params import DestAccumulation, DestSync, format_dict
+from helpers.param_config import (
+    get_num_blocks_and_num_tiles_in_block,
+    input_output_formats,
+    parametrize,
+)
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import (
+    NUM_BLOCKS,
     NUM_FACES,
+    NUM_TILES_IN_BLOCK,
     TILE_COUNT,
     generate_input_dim,
 )
@@ -27,9 +37,8 @@ def test_unary_datacopy_custom(
     formats,
     dest_acc,
 ):
-    input_dimensions = [32, 32]
+    input_dimensions = [128, 256]
     num_faces = 4
-    tile_cnt = 1
 
     src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
         stimuli_format_A=formats.input_format,
@@ -43,13 +52,22 @@ def test_unary_datacopy_custom(
         src_A, formats.output_format, num_faces, input_dimensions
     )
 
+    num_blocks, num_tiles_in_block = get_num_blocks_and_num_tiles_in_block(
+        DestSync.Half, dest_acc, formats, input_dimensions, TILE_DIMENSIONS
+    )
+
     configuration = TestConfig(
         "sources/eltwise_unary_datacopy_custom_test.cpp",
         formats,
         templates=[
             generate_input_dim(input_dimensions, input_dimensions),
         ],
-        runtimes=[TILE_COUNT(tile_cnt_A), NUM_FACES(num_faces)],
+        runtimes=[
+            TILE_COUNT(tile_cnt_A),
+            NUM_FACES(num_faces),
+            NUM_BLOCKS(num_blocks),
+            NUM_TILES_IN_BLOCK(num_tiles_in_block),
+        ],
         variant_stimuli=StimuliConfig(
             src_A,
             formats.input_format,

--- a/tt_metal/tt-llk/tests/python_tests/test_math_matmul.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_math_matmul.py
@@ -30,7 +30,9 @@ from helpers.test_variant_parameters import (
     DEST_SYNC,
     IN_TILE_DIMS,
     MATH_FIDELITY,
+    NUM_BLOCKS,
     NUM_FACES,
+    NUM_TILES_IN_BLOCK,
     PARTIAL_FACE,
     STOCHASTIC_ROUNDING,
     THROTTLE_LEVEL,
@@ -179,6 +181,12 @@ def test_math_matmul(
         tilized_in1, in1_dimensions, tile_dimensions=[in1_tile_r_dim, in1_tile_c_dim]
     )
 
+    # Matmul sweep shapes deliberately fit one destination section. Repeat the
+    # complete matmul block four times so the same test also validates section
+    # hand-off without changing the operation's RT/CT/KT contract.
+    num_blocks = 4
+    num_tiles_in_block = matmul_config.tile_dimensions.tile_cnt
+
     configuration = TestConfig(
         "sources/math_matmul_test.cpp",
         formats,
@@ -190,6 +198,8 @@ def test_math_matmul(
         ],
         runtimes=[
             TILE_COUNT(matmul_config.tile_dimensions.tile_cnt),
+            NUM_BLOCKS(num_blocks),
+            NUM_TILES_IN_BLOCK(num_tiles_in_block),
             NUM_FACES(num_faces, num_faces_in0, num_faces_in1),
             UNPACK_TRANS_FACES(transpose),
             UNPACK_TRANS_WITHIN_FACE(transpose),
@@ -220,15 +230,11 @@ def test_math_matmul(
             formats.output_format,
             tile_count_A=matmul_config.tile_dimensions.tile_cnt_in0,
             tile_count_B=matmul_config.tile_dimensions.tile_cnt_in1,
-            tile_count_res=matmul_config.tile_dimensions.tile_cnt,
+            tile_count_res=matmul_config.tile_dimensions.tile_cnt * num_blocks,
         ),
         dest_acc=matmul_config.dest_acc,
     )
     res_from_L1 = configuration.run().result
-
-    assert len(res_from_L1) == len(
-        golden_tensor
-    ), "Result tensor and golden tensor are not of the same length"
 
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
 
@@ -238,10 +244,15 @@ def test_math_matmul(
         (in0_dimensions[0], in1_dimensions[1]),
         tile_dimensions=[in0_tile_r_dim, in1_tile_c_dim],
     )
+    golden_tensor = golden_tensor.repeat(num_blocks)
+
+    assert len(res_from_L1) == len(
+        golden_tensor
+    ), "Result tensor and golden tensor are not of the same length"
 
     if num_faces < 4:
         num_elements_per_tile = in0_tile_r_dim * in1_tile_c_dim
-        tile_cnt = matmul_config.tile_dimensions.output_tile_cnt
+        tile_cnt = matmul_config.tile_dimensions.output_tile_cnt * num_blocks
 
         # Compare each tile separately
         TILE_R_DIM, TILE_C_DIM = 32, 32

--- a/tt_metal/tt-llk/tests/python_tests/test_matmul_pack_untilize.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_matmul_pack_untilize.py
@@ -12,6 +12,8 @@ from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import (
     MATH_FIDELITY,
+    NUM_BLOCKS,
+    NUM_TILES_IN_BLOCK,
     generate_input_dim,
 )
 from helpers.tilize_untilize import tilize
@@ -64,6 +66,8 @@ def test_matmul_pack_untilize(
         input_A_format=formats.input_format,
         input_B_format=formats.input_format,
     )
+    num_blocks = 32
+    golden_tensor = golden_tensor.repeat(num_blocks)
 
     configuration = TestConfig(
         "sources/matmul_pack_untilize_test.cpp",
@@ -72,7 +76,7 @@ def test_matmul_pack_untilize(
             generate_input_dim(input_dimensions, input_dimensions),
             MATH_FIDELITY(math_fidelity),
         ],
-        runtimes=[],
+        runtimes=[NUM_BLOCKS(num_blocks), NUM_TILES_IN_BLOCK(1)],
         variant_stimuli=StimuliConfig(
             tilize(src_A, formats.input_format),
             formats.input_format,
@@ -81,7 +85,7 @@ def test_matmul_pack_untilize(
             formats.output_format,
             tile_count_A=tile_cnt_A,
             tile_count_B=tile_cnt_B,
-            tile_count_res=tile_cnt_A,
+            tile_count_res=tile_cnt_A * num_blocks,
         ),
         dest_acc=dest_acc,
     )

--- a/tt_metal/tt-llk/tests/python_tests/test_matmul_unpack_tilize.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_matmul_unpack_tilize.py
@@ -11,6 +11,8 @@ from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import (
     MATH_FIDELITY,
+    NUM_BLOCKS,
+    NUM_TILES_IN_BLOCK,
     generate_input_dim,
 )
 from helpers.tilize_untilize import tilize
@@ -64,6 +66,8 @@ def test_matmul_unpack_tilize(
         )
     )
     golden_tensor = golden_tensor.to(torch_format)
+    num_blocks = 32
+    golden_tensor = golden_tensor.repeat(num_blocks)
 
     L1_to_L1_iterations = 2
     configuration = TestConfig(
@@ -73,7 +77,7 @@ def test_matmul_unpack_tilize(
             generate_input_dim(input_dimensions, input_dimensions),
             MATH_FIDELITY(math_fidelity),
         ],
-        runtimes=[],
+        runtimes=[NUM_BLOCKS(num_blocks), NUM_TILES_IN_BLOCK(1)],
         variant_stimuli=StimuliConfig(
             src_A,
             formats.input_format,
@@ -82,7 +86,7 @@ def test_matmul_unpack_tilize(
             formats.output_format,
             tile_count_A=tile_cnt_A,
             tile_count_B=tile_cnt_B,
-            tile_count_res=tile_cnt_A,
+            tile_count_res=tile_cnt_A * num_blocks,
         ),
         dest_acc=dest_acc,
         L1_to_L1_iterations=L1_to_L1_iterations,

--- a/tt_metal/tt-llk/tests/python_tests/test_risc_compute.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_risc_compute.py
@@ -3,22 +3,32 @@
 
 import torch
 from helpers.format_config import DataFormat
-from helpers.golden_generators import EltwiseBinaryGolden, get_golden_generator
+from helpers.golden_generators import (
+    TILE_DIMENSIONS,
+    EltwiseBinaryGolden,
+    get_golden_generator,
+)
 from helpers.llk_params import (
+    DestAccumulation,
+    DestSync,
     MathFidelity,
     MathOperation,
     format_dict,
 )
-from helpers.param_config import input_output_formats
+from helpers.param_config import (
+    get_num_blocks_and_num_tiles_in_block,
+    input_output_formats,
+)
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import NUM_BLOCKS, NUM_TILES_IN_BLOCK
 from helpers.utils import passed_test
 
 
 def test_risc_compute():
     formats = input_output_formats([DataFormat.Int32])[0]
-    input_dimensions = [32, 96]
+    input_dimensions = [128, 256]
 
     src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
         stimuli_format_A=formats.input_format,
@@ -32,9 +42,21 @@ def test_risc_compute():
         MathOperation.Elwadd, src_A, src_B, formats.output_format, MathFidelity.LoFi
     )
 
+    num_blocks, num_tiles_in_block = get_num_blocks_and_num_tiles_in_block(
+        DestSync.Half,
+        DestAccumulation.No,
+        formats,
+        input_dimensions,
+        TILE_DIMENSIONS,
+    )
+
     configuration = TestConfig(
         "sources/risc_compute_test.cpp",
         formats,
+        runtimes=[
+            NUM_BLOCKS(num_blocks),
+            NUM_TILES_IN_BLOCK(num_tiles_in_block),
+        ],
         variant_stimuli=StimuliConfig(
             src_A,
             formats.input_format,

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_binary.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_binary.py
@@ -11,13 +11,18 @@ from helpers.chip_architecture import ChipArchitecture
 from helpers.data_format_inference import is_format_combination_outlier
 from helpers.format_config import DataFormat
 from helpers.golden_generators import (
+    TILE_DIMENSIONS,
     BinarySFPUGolden,
     BroadcastGolden,
     get_golden_generator,
 )
 from helpers.llk_params import BroadcastType as LlkBroadcastType
-from helpers.llk_params import DestAccumulation, MathOperation, format_dict
-from helpers.param_config import input_output_formats, parametrize
+from helpers.llk_params import DestAccumulation, DestSync, MathOperation, format_dict
+from helpers.param_config import (
+    get_num_blocks_and_num_tiles_in_block,
+    input_output_formats,
+    parametrize,
+)
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import DistributionKind, StimuliSpec, generate_stimuli
 from helpers.test_config import TestConfig
@@ -25,6 +30,8 @@ from helpers.test_variant_parameters import (
     APPROX_MODE,
     BROADCAST_TYPE,
     MATH_OP,
+    NUM_BLOCKS,
+    NUM_TILES_IN_BLOCK,
     TILE_COUNT,
     TemplateParameter,
     generate_input_dim,
@@ -713,6 +720,10 @@ def test_sfpu_binary_add_top_row(formats, dest_acc, mathop):
         else golden_tensor.view(input_dimensions)
     )
 
+    num_blocks, num_tiles_in_block = get_num_blocks_and_num_tiles_in_block(
+        DestSync.Half, dest_acc, formats, input_dimensions, TILE_DIMENSIONS
+    )
+
     configuration = TestConfig(
         "sources/sfpu_binary_test.cpp",
         formats,
@@ -722,7 +733,11 @@ def test_sfpu_binary_add_top_row(formats, dest_acc, mathop):
             APPROX_MODE(),
             BROADCAST_TYPE(LlkBroadcastType.None_),
         ],
-        runtimes=[TILE_COUNT(tile_cnt_A)],
+        runtimes=[
+            TILE_COUNT(tile_cnt_A),
+            NUM_BLOCKS(num_blocks),
+            NUM_TILES_IN_BLOCK(num_tiles_in_block),
+        ],
         variant_stimuli=StimuliConfig(
             src_A,
             formats.input_format,
@@ -763,7 +778,9 @@ def sfpu_binary(
     twos_complement=False,
 ):
 
-    input_dimensions = [64, 32]
+    # FP32 destination tiles occupy twice the register space. Keep four full destination
+    # blocks for those formats and four blocks of eight tiles for the remaining formats.
+    input_dimensions = [128, 128] if formats.input_format.is_32_bit() else [256, 128]
 
     src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
         stimuli_format_A=formats.input_format,
@@ -777,7 +794,12 @@ def sfpu_binary(
     # The kernel only consumes buffer_A (operand 0 = tile 0, operand 1 = tile 1), so an
     # explicit src_A fully controls inputs for edge cases; src_B stays random but unused.
     if src_A_override is not None:
-        src_A = src_A_override.to(src_A.dtype).flatten()
+        override = src_A_override.to(src_A.dtype).flatten()
+        if src_A.numel() % override.numel() != 0:
+            raise ValueError(
+                "SFPU binary override must contain a whole number of tile pairs"
+            )
+        src_A = override.repeat(src_A.numel() // override.numel())
 
     golden_src = src_A
     if broadcast_type is not None and broadcast_type != LlkBroadcastType.None_:
@@ -794,20 +816,27 @@ def sfpu_binary(
         )
 
     generate_golden = get_golden_generator(BinarySFPUGolden)
-    golden_tensor = generate_golden(
-        mathop,
-        golden_src,
-        0,  # src1_idx: use tile 0
-        1,  # src2_idx: use tile 1
-        0,  # dst_idx: write to tile 0
-        32,  # num_iterations: 32 rows
-        input_dimensions,  # [64, 32] = 2 tiles
-        (
-            DataFormat.Float16_b
-            if formats.input_format == DataFormat.Bfp8_b
-            else formats.input_format
-        ),
-    ).flatten()
+    golden_format = (
+        DataFormat.Float16_b
+        if formats.input_format == DataFormat.Bfp8_b
+        else formats.input_format
+    )
+    elements_per_pair = 2 * 32 * 32
+    golden_tensor = torch.cat(
+        [
+            generate_golden(
+                mathop,
+                golden_src[offset : offset + elements_per_pair],
+                0,
+                1,
+                0,
+                32,
+                [64, 32],
+                golden_format,
+            ).flatten()
+            for offset in range(0, golden_src.numel(), elements_per_pair)
+        ]
+    )
 
     # ONLY Blackhole needs this for some reason
     if (
@@ -818,6 +847,10 @@ def sfpu_binary(
 
     bcast = broadcast_type if broadcast_type else LlkBroadcastType.None_
 
+    num_blocks, num_tiles_in_block = get_num_blocks_and_num_tiles_in_block(
+        DestSync.Half, dest_acc, formats, input_dimensions, TILE_DIMENSIONS
+    )
+
     configuration = TestConfig(
         "sources/sfpu_binary_test.cpp",
         formats,
@@ -827,7 +860,11 @@ def sfpu_binary(
             APPROX_MODE(),
             BROADCAST_TYPE(bcast),
         ],
-        runtimes=[TILE_COUNT(tile_cnt_A)],
+        runtimes=[
+            TILE_COUNT(tile_cnt_A),
+            NUM_BLOCKS(num_blocks),
+            NUM_TILES_IN_BLOCK(num_tiles_in_block),
+        ],
         variant_stimuli=StimuliConfig(
             src_A,
             formats.input_format,

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_reduce_sdpa.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_reduce_sdpa.py
@@ -4,18 +4,26 @@
 import torch
 from conftest import skip_for_coverage
 from helpers.format_config import DataFormat
+from helpers.golden_generators import TILE_DIMENSIONS
 from helpers.llk_params import (
     DestAccumulation,
+    DestSync,
     MathOperation,
     ReducePool,
     format_dict,
 )
-from helpers.param_config import input_output_formats, parametrize
+from helpers.param_config import (
+    get_num_blocks_and_num_tiles_in_block,
+    input_output_formats,
+    parametrize,
+)
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import (
     MATH_OP,
+    NUM_BLOCKS,
+    NUM_TILES_IN_BLOCK,
     TILE_COUNT,
     generate_input_dim,
 )
@@ -34,7 +42,7 @@ from helpers.utils import passed_test
     mathop=[MathOperation.ReduceColumn],
     reduce_pool=[ReducePool.Max],  # Only MAX is supported for SDPA reduce
     input_dimensions=[
-        [128, 64],  # 4x2 subblock
+        [512, 64],  # four independent 4x2 subblocks
     ],
 )
 def test_sfpu_reduce_sdpa(
@@ -60,12 +68,17 @@ def test_sfpu_reduce_sdpa(
     # Undo tilization so src_A is standard [32, 32]
     src_A_untilized = untilize_block(src_A, formats.input_format, input_dimensions)
 
-    # Take max along the height (dim=0) for each column
-    col_max = torch.max(src_A_untilized, dim=0).values
-
-    # Construct golden tensor: first row is column max, others are zero
+    # Each destination block is an independent 4x2 SDPA reduction subblock.
     golden_tensor = torch.zeros_like(src_A_untilized)
-    golden_tensor[0, :] = col_max
+    subblock_rows = 4 * 32
+    for row in range(0, input_dimensions[0], subblock_rows):
+        golden_tensor[row, :] = torch.max(
+            src_A_untilized[row : row + subblock_rows, :], dim=0
+        ).values
+
+    num_blocks, num_tiles_in_block = get_num_blocks_and_num_tiles_in_block(
+        DestSync.Half, dest_acc, formats, input_dimensions, TILE_DIMENSIONS
+    )
 
     # *******************************************************
 
@@ -73,10 +86,16 @@ def test_sfpu_reduce_sdpa(
         "sources/sfpu_reduce_sdpa_test.cpp",
         formats,
         templates=[
-            generate_input_dim(input_dimensions, input_dimensions),
+            generate_input_dim(
+                input_dimensions, input_dimensions, block_ct_dim=2, block_rt_dim=4
+            ),
             MATH_OP(mathop=mathop, pool_type=reduce_pool),
         ],
-        runtimes=[TILE_COUNT(tile_cnt_A)],
+        runtimes=[
+            TILE_COUNT(tile_cnt_A),
+            NUM_BLOCKS(num_blocks),
+            NUM_TILES_IN_BLOCK(num_tiles_in_block),
+        ],
         variant_stimuli=StimuliConfig(
             src_A,
             formats.input_format,
@@ -95,5 +114,5 @@ def test_sfpu_reduce_sdpa(
     res_tensor = torch.tensor(res_from_L1, dtype=format_dict[formats.output_format])
     res_tensor = untilize_block(res_tensor, formats.output_format, input_dimensions)
 
-    # Check only the first row for correctness, not full tensors
-    assert passed_test(golden_tensor[0], res_tensor[0], formats.output_format)
+    for row in range(0, input_dimensions[0], subblock_rows):
+        assert passed_test(golden_tensor[row], res_tensor[row], formats.output_format)

--- a/tt_metal/tt-llk/tests/python_tests/test_tilize_calculate_untilize_L1.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_tilize_calculate_untilize_L1.py
@@ -17,6 +17,8 @@ from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import (
     MATH_FIDELITY,
     MATH_OP,
+    NUM_BLOCKS,
+    NUM_TILES_IN_BLOCK,
     TILE_COUNT,
     generate_input_dim,
 )
@@ -61,6 +63,8 @@ def test_tilize_calculate_untilize_L1(
     golden_tensor = generate_golden(
         mathop, tilize(src_A), tilize(src_B), formats.output_format, math_fidelity
     )
+    num_blocks = 32
+    golden_tensor = golden_tensor.repeat(num_blocks)
 
     configuration = TestConfig(
         "sources/tilize_calculate_untilize_L1.cpp",
@@ -70,7 +74,11 @@ def test_tilize_calculate_untilize_L1(
             MATH_FIDELITY(math_fidelity),
             MATH_OP(mathop=mathop),
         ],
-        runtimes=[TILE_COUNT(tile_cnt_A)],
+        runtimes=[
+            TILE_COUNT(tile_cnt_A),
+            NUM_BLOCKS(num_blocks),
+            NUM_TILES_IN_BLOCK(1),
+        ],
         variant_stimuli=StimuliConfig(
             src_A,
             formats.input_format,
@@ -79,7 +87,7 @@ def test_tilize_calculate_untilize_L1(
             formats.output_format,
             tile_count_A=tile_cnt_A,
             tile_count_B=tile_cnt_B,
-            tile_count_res=tile_cnt_A,
+            tile_count_res=tile_cnt_A * num_blocks,
         ),
         dest_acc=dest_acc,
         L1_to_L1_iterations=2,

--- a/tt_metal/tt-llk/tests/python_tests/test_transpose_dest.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_transpose_dest.py
@@ -6,12 +6,14 @@ from itertools import product
 import torch
 from helpers.format_config import DataFormat, is_dest_acc_needed
 from helpers.golden_generators import (
+    TILE_DIMENSIONS,
     DataCopyGolden,
     TransposeGolden,
     get_golden_generator,
 )
-from helpers.llk_params import DestAccumulation, Transpose, format_dict
+from helpers.llk_params import DestAccumulation, DestSync, Transpose, format_dict
 from helpers.param_config import (
+    get_num_blocks_and_num_tiles_in_block,
     input_output_formats,
     parametrize,
 )
@@ -20,7 +22,9 @@ from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import BuildMode, TestConfig
 from helpers.test_variant_parameters import (
     MATH_TRANSPOSE_FACES,
+    NUM_BLOCKS,
     NUM_FACES,
+    NUM_TILES_IN_BLOCK,
     TILE_COUNT,
     UNPACK_TRANS_FACES,
 )
@@ -257,7 +261,10 @@ def transpose_dest_int8(
 
 def transpose_dest(formats, dest_acc, math_transpose_faces, unpack_to_dest):
 
-    input_dimensions = [64, 64]
+    # 16 tiles (4x4) forces the input to span several destination-register banks
+    # for both 16-bit (8 tiles/bank -> 2 banks) and 32-bit (4 tiles/bank -> 4 banks)
+    # dest modes, so the kernel's DEST bank switching is exercised.
+    input_dimensions = [128, 128]
 
     src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
         stimuli_format_A=formats.input_format,
@@ -295,6 +302,17 @@ def transpose_dest(formats, dest_acc, math_transpose_faces, unpack_to_dest):
     else:
         golden_tensor = []
 
+    # Partition the tiles into destination-register banks. transpose is applied
+    # per tile, so the block size only controls how many tiles share a DEST bank
+    # before it is packed out and reused.
+    num_blocks, num_tiles_in_block = get_num_blocks_and_num_tiles_in_block(
+        DestSync.Half,
+        dest_acc,
+        formats,
+        input_dimensions,
+        TILE_DIMENSIONS,
+    )
+
     configuration = TestConfig(
         "sources/transpose_dest_test.cpp",
         formats,
@@ -312,6 +330,8 @@ def transpose_dest(formats, dest_acc, math_transpose_faces, unpack_to_dest):
             ),
             TILE_COUNT(tile_cnt_A),
             NUM_FACES(),
+            NUM_BLOCKS(num_blocks),
+            NUM_TILES_IN_BLOCK(num_tiles_in_block),
         ],
         variant_stimuli=StimuliConfig(
             src_A,

--- a/tt_metal/tt-llk/tests/python_tests/test_transpose_dest.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_transpose_dest.py
@@ -261,10 +261,13 @@ def transpose_dest_int8(
 
 def transpose_dest(formats, dest_acc, math_transpose_faces, unpack_to_dest):
 
-    # 16 tiles (4x4) forces the input to span several destination-register banks
-    # for both 16-bit (8 tiles/bank -> 2 banks) and 32-bit (4 tiles/bank -> 4 banks)
-    # dest modes, so the kernel's DEST bank switching is exercised.
-    input_dimensions = [128, 128]
+    # Exercise four destination-register usages. FP32 destination modes hold four
+    # tiles per half, while 16-bit modes hold eight tiles per half.
+    input_dimensions = (
+        [128, 128]
+        if dest_acc == DestAccumulation.Yes or formats.input_format.is_32_bit()
+        else [256, 128]
+    )
 
     src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
         stimuli_format_A=formats.input_format,

--- a/tt_metal/tt-llk/tests/python_tests/test_ttnn_where.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_ttnn_where.py
@@ -14,6 +14,8 @@ from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import (
     DISABLE_SRC_ZERO_FLAG,
     MATH_OP,
+    NUM_BLOCKS,
+    NUM_TILES_IN_BLOCK,
 )
 
 
@@ -52,7 +54,7 @@ def test_ttnn_where(
     ) and dest_acc == DestAccumulation.Yes:
         pytest.skip("DataFormat.Float16_b not supported with DestAccumulation.Yes")
 
-    input_dimensions = [32, 32]  # Single tile dimensions
+    input_dimensions = [256, 128]
     sfpu_false_spec = StimuliSpec.uniform(low=0.0, high=1.0)
     src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
         stimuli_format_A=formats.input_format,
@@ -86,7 +88,7 @@ def test_ttnn_where(
         "sources/ttnn_where_test.cpp",
         formats,
         templates=[MATH_OP(mathop), DISABLE_SRC_ZERO_FLAG(True)],
-        runtimes=[],
+        runtimes=[NUM_BLOCKS(tile_cnt_A), NUM_TILES_IN_BLOCK(1)],
         variant_stimuli=StimuliConfig(
             src_A.flatten(),
             formats.input_format,
@@ -107,7 +109,6 @@ def test_ttnn_where(
 
     res_from_L1 = configuration.run().result
 
-    res_from_L1 = res_from_L1[:1024]
     assert len(res_from_L1) == len(
         golden
     ), "Result tensor and golden tensor are not of the same length"
@@ -145,8 +146,8 @@ def test_ttnn_where(
     ),
     dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
     mathop=MathOperation.TTNNWhere,
-    height=[32],
-    width=[32],
+    height=[256],
+    width=[128],
 )
 def test_ttnn_where_mcw(
     formats,
@@ -177,24 +178,25 @@ def test_ttnn_where_mcw(
 
     golden_generator = get_golden_generator(WhereGolden)
     golden = golden_generator(C, T, F)
+    tile_count = height * width // (32 * 32)
 
     configuration = TestConfig(
         "sources/ttnn_where_test.cpp",
         formats,
         templates=[MATH_OP(mathop), DISABLE_SRC_ZERO_FLAG(True)],
-        runtimes=[],
+        runtimes=[NUM_BLOCKS(tile_count), NUM_TILES_IN_BLOCK(1)],
         variant_stimuli=StimuliConfig(
             C.flatten(),
             formats.input_format,
             T.flatten(),
             formats.input_format,
             formats.output_format,
-            tile_count_A=1,
-            tile_count_B=1,
-            tile_count_res=1,
+            tile_count_A=tile_count,
+            tile_count_B=tile_count,
+            tile_count_res=tile_count,
             buffer_C=F.flatten(),
             stimuli_C_format=formats.input_format,
-            tile_count_C=1,
+            tile_count_C=tile_count,
         ),
         unpack_to_dest=formats.input_format.is_32_bit(),
         dest_acc=dest_acc,
@@ -202,8 +204,6 @@ def test_ttnn_where_mcw(
     )
 
     res_from_L1 = configuration.run().result
-
-    res_from_L1 = res_from_L1[:1024]
 
     golden_tensor = torch.tensor(
         golden,
@@ -214,7 +214,7 @@ def test_ttnn_where_mcw(
         ),
     )
 
-    golden_tensor = golden_tensor.flatten()[:1024]  # Ensure it matches the result size
+    golden_tensor = golden_tensor.flatten()
 
     res_tensor = torch.tensor(
         res_from_L1,

--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_a_bcast_eltwise.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_a_bcast_eltwise.py
@@ -5,13 +5,19 @@ import pytest
 import torch
 from conftest import skip_for_blackhole
 from helpers.format_config import DataFormat
+from helpers.golden_generators import TILE_DIMENSIONS
 from helpers.llk_params import (
     DestAccumulation,
+    DestSync,
     MathFidelity,
     MathOperation,
     format_dict,
 )
-from helpers.param_config import input_output_formats, parametrize
+from helpers.param_config import (
+    get_num_blocks_and_num_tiles_in_block,
+    input_output_formats,
+    parametrize,
+)
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import TestConfig
@@ -19,6 +25,8 @@ from helpers.test_variant_parameters import (
     DEST_SYNC,
     MATH_FIDELITY,
     MATH_OP,
+    NUM_BLOCKS,
+    NUM_TILES_IN_BLOCK,
     SRCA_REUSE_COUNT,
     TILE_COUNT,
     generate_input_dim,
@@ -44,6 +52,7 @@ from helpers.utils import passed_test
         [128, 32],
         [32, 128],
         [64, 128],
+        [128, 256],
     ],
 )
 def test_unp_bcast_sub_sdpa(
@@ -115,9 +124,11 @@ def test_unp_bcast_sub_sdpa(
 
                 golden.append(result)
 
-    golden_tensor = torch.cat(golden).to(dtype=format_dict[formats.output_format])[
-        : 1024 * reuse_factor
-    ]
+    golden_tensor = torch.cat(golden).to(dtype=format_dict[formats.output_format])
+
+    num_blocks, num_tiles_in_block = get_num_blocks_and_num_tiles_in_block(
+        DestSync.Half, dest_acc, formats, input_dimensions, TILE_DIMENSIONS
+    )
 
     configuration = TestConfig(
         "sources/unpack_a_bcast_eltwise_test.cpp",
@@ -131,6 +142,8 @@ def test_unp_bcast_sub_sdpa(
         runtimes=[
             TILE_COUNT(tile_cnt_A),
             SRCA_REUSE_COUNT(srca_reuse_count),
+            NUM_TILES_IN_BLOCK(num_tiles_in_block),
+            NUM_BLOCKS(num_blocks),
         ],
         variant_stimuli=StimuliConfig(
             src_A,
@@ -139,8 +152,8 @@ def test_unp_bcast_sub_sdpa(
             formats.input_format,
             formats.output_format,
             tile_count_A=reuse_factor,
-            tile_count_B=reuse_factor,
-            tile_count_res=reuse_factor,
+            tile_count_B=input_tiles,
+            tile_count_res=input_tiles,
         ),
         dest_acc=dest_acc,
     )

--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_sweep.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_sweep.py
@@ -8,19 +8,26 @@ from helpers.format_config import DataFormat
 from helpers.golden_generators import TilizeGolden, get_golden_generator
 from helpers.llk_params import (
     DestAccumulation,
+    DestSync,
     NarrowTile,
     StochasticRounding,
     Transpose,
     format_dict,
 )
-from helpers.param_config import input_output_formats, parametrize
+from helpers.param_config import (
+    get_num_blocks_and_num_tiles_in_block,
+    input_output_formats,
+    parametrize,
+)
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import (
     INPUT_DIMENSIONS,
     NARROW_TILE,
+    NUM_BLOCKS,
     NUM_FACES,
+    NUM_TILES_IN_BLOCK,
     STOCHASTIC_ROUNDING,
     TILE_COUNT,
     UNPACK_TRANS_FACES,
@@ -95,9 +102,9 @@ def _regular_path(src_A, input_dimensions, formats, num_faces, torch_format):
     dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
     num_faces=lambda narrow_tile: ([4, 2, 1] if narrow_tile == NarrowTile.No else [2]),
     input_dimensions=lambda narrow_tile: (
-        [[32, 32], [64, 64], [32, 64], [32, 128], [128, 32]]
+        [[32, 32], [64, 64], [32, 64], [32, 128], [128, 32], [128, 256]]
         if narrow_tile == NarrowTile.No
-        else [[32, 16], [64, 16], [128, 16]]
+        else [[32, 16], [64, 16], [128, 16], [1024, 16]]
     ),
 )
 def test_unpack_tilize_comprehensive(
@@ -163,6 +170,15 @@ def test_unpack_tilize_comprehensive(
         else _regular_path(src_A, input_dimensions, formats, num_faces, torch_format)
     )
 
+    block_tile_dimensions = tile_dimensions if tile_dimensions is not None else [32, 32]
+    num_blocks, num_tiles_in_block = get_num_blocks_and_num_tiles_in_block(
+        DestSync.Half,
+        dest_acc,
+        formats,
+        input_dimensions,
+        block_tile_dimensions,
+    )
+
     configuration = TestConfig(
         "sources/unpack_tilize_sweep_test.cpp",
         formats,
@@ -176,6 +192,8 @@ def test_unpack_tilize_comprehensive(
             NARROW_TILE(narrow_tile),
             NUM_FACES(num_faces),
             TILE_COUNT(tile_cnt_A),
+            NUM_BLOCKS(num_blocks),
+            NUM_TILES_IN_BLOCK(num_tiles_in_block),
         ],
         variant_stimuli=StimuliConfig(
             src_A,

--- a/tt_metal/tt-llk/tests/sources/dense_pack_untilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/dense_pack_untilize_test.cpp
@@ -33,10 +33,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
         formats.unpack_A_src,
         formats.unpack_A_dst);
 
-    for (std::uint32_t tile_index_within_block = 0; tile_index_within_block < BLOCK_CT_DIM; ++tile_index_within_block) // Loop over tiles in the block
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
     {
-        _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-            L1_ADDRESS(params.buffer_A[tile_index_within_block]), formats.unpack_A_src, formats.unpack_A_dst);
+        for (std::uint32_t tile = 0; tile < params.NUM_TILES_IN_BLOCK; ++tile)
+        {
+            const std::uint32_t input_tile = block * params.NUM_TILES_IN_BLOCK + tile;
+            _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+                L1_ADDRESS(params.buffer_A[input_tile]), formats.unpack_A_src, formats.unpack_A_dst);
+        }
     }
 }
 #endif
@@ -60,16 +64,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
     _llk_math_reconfig_remap_(true);
 
-    _llk_math_wait_for_dest_available_<dest_sync>();
-    for (std::uint32_t tile_index_within_block = 0; tile_index_within_block < BLOCK_CT_DIM; ++tile_index_within_block) // Loop over tiles in the block
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
     {
-        LLK_ASSERT(
-            (tile_index_within_block < get_dest_max_tiles<dest_sync, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()),
-            "Block tile index exceeds maximum destination tiles");
-        _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, dest_sync, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
-            tile_index_within_block, formats.math, formats.math);
+        _llk_math_wait_for_dest_available_<dest_sync>();
+        for (std::uint32_t tile = 0; tile < params.NUM_TILES_IN_BLOCK; ++tile)
+        {
+            _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, dest_sync, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
+                tile, formats.math, formats.math);
+        }
+        _llk_math_dest_section_done_<dest_sync, is_fp32_dest_acc_en>();
     }
-    _llk_math_dest_section_done_<dest_sync, is_fp32_dest_acc_en>();
 }
 
 #endif
@@ -92,9 +96,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_untilize_init_<BLOCK_CT_DIM * 2, FULL_CT_DIM * 2, false, TILE_C_DIM, true>(
         formats.pack_src, formats.pack_dst, params.in0_tile_r_dim, params.num_faces / 2);
 
-    _llk_packer_wait_for_math_done_();
-    _llk_pack_untilize_<BLOCK_CT_DIM * 2, FULL_CT_DIM * 2, false, 0, true>(L1_ADDRESS(params.buffer_Res[0]), params.num_faces / 2, 0 /* tile_dst_rt_offset */);
-    _llk_pack_dest_section_done_<dest_sync, is_fp32_dest_acc_en>();
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
+    {
+        _llk_packer_wait_for_math_done_();
+        _llk_pack_untilize_<BLOCK_CT_DIM * 2, FULL_CT_DIM * 2, false, 0, true>(
+            L1_ADDRESS(params.buffer_Res[block * params.NUM_TILES_IN_BLOCK]), params.num_faces / 2, 0 /* tile_dst_rt_offset */);
+        _llk_pack_dest_section_done_<dest_sync, is_fp32_dest_acc_en>();
+    }
 }
 
 #endif

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_datacopy_custom_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_datacopy_custom_test.cpp
@@ -49,12 +49,15 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_math_pack_sync_init_<DstSync::SyncHalf, false>();
     _llk_math_hw_configure_<false>(formats.math, formats.math);
 
-    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
-    for (std::uint32_t tile_num = 0; tile_num < params.TILE_CNT; ++tile_num)
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
     {
-        _llk_math_eltwise_unary_datacopy_custom_(tile_num);
+        _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+        for (std::uint32_t tile = 0; tile < params.NUM_TILES_IN_BLOCK; ++tile)
+        {
+            _llk_math_eltwise_unary_datacopy_custom_(tile);
+        }
+        _llk_math_dest_section_done_<DstSync::SyncHalf, false>();
     }
-    _llk_math_dest_section_done_<DstSync::SyncHalf, false>();
 }
 
 #endif
@@ -75,11 +78,15 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, 4 /* num_faces */);
     _llk_pack_dest_init_<DstSync::SyncHalf, false>();
 
-    _llk_packer_wait_for_math_done_();
-    for (std::uint32_t tile_num = 0; tile_num < params.TILE_CNT; ++tile_num)
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
     {
-        _llk_pack_<DstSync::SyncHalf, false, ckernel::PackMode::Default>(tile_num, L1_ADDRESS(params.buffer_Res[tile_num]));
+        _llk_packer_wait_for_math_done_();
+        for (std::uint32_t tile = 0; tile < params.NUM_TILES_IN_BLOCK; ++tile)
+        {
+            const std::uint32_t result_tile = block * params.NUM_TILES_IN_BLOCK + tile;
+            _llk_pack_<DstSync::SyncHalf, false, ckernel::PackMode::Default>(tile, L1_ADDRESS(params.buffer_Res[result_tile]));
+        }
+        _llk_pack_dest_section_done_<DstSync::SyncHalf, false>();
     }
-    _llk_pack_dest_section_done_<DstSync::SyncHalf, false>();
 }
 #endif

--- a/tt_metal/tt-llk/tests/sources/math_matmul_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/math_matmul_test.cpp
@@ -47,20 +47,23 @@ void run_kernel(RUNTIME_PARAMETERS params)
         params.num_faces_A,     // in0
         params.PARTIAL_FACE_B,  // in1
         params.PARTIAL_FACE_A); // in0
-    for (std::uint32_t j = 0; j < params.KT_DIM; j++)
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
     {
-        _llk_unpack_AB_matmul_<>(
-            L1_ADDRESS(params.buffer_A[0]),
-            L1_ADDRESS(params.buffer_B[0]),
-            j,
-            j * params.CT_DIM,
-            params.TILE_SIZE_UNPACK_B,
-            params.TILE_SIZE_UNPACK_A,
-            params.PARTIAL_FACE_B, // in1
-            params.PARTIAL_FACE_A, // in0
-            params.CT_DIM,
-            params.RT_DIM,
-            params.KT_DIM);
+        for (std::uint32_t j = 0; j < params.KT_DIM; j++)
+        {
+            _llk_unpack_AB_matmul_<>(
+                L1_ADDRESS(params.buffer_A[0]),
+                L1_ADDRESS(params.buffer_B[0]),
+                j,
+                j * params.CT_DIM,
+                params.TILE_SIZE_UNPACK_B,
+                params.TILE_SIZE_UNPACK_A,
+                params.PARTIAL_FACE_B,
+                params.PARTIAL_FACE_A,
+                params.CT_DIM,
+                params.RT_DIM,
+                params.KT_DIM);
+        }
     }
 }
 
@@ -88,17 +91,19 @@ void run_kernel(RUNTIME_PARAMETERS params)
         params.RT_DIM);
     _llk_math_pack_sync_init_<dest_sync, is_fp32_dest_acc_en>();
     _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
-    _llk_math_wait_for_dest_available_<dest_sync>();
-    LLK_ASSERT(
-        (get_dest_max_matmul_tiles(params.DST_INDEX, params.CT_DIM, params.RT_DIM) <
-         get_dest_max_tiles<dest_sync, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()),
-        "Block tile index exceeds maximum destination tiles for matmul");
-    for (std::uint32_t j = 0; j < params.KT_DIM; j++)
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
     {
-        _llk_math_matmul_<MATH_FIDELITY, THROTTLE_LEVEL>(params.DST_INDEX, params.CT_DIM, params.RT_DIM);
-    }
+        _llk_math_wait_for_dest_available_<dest_sync>();
+        LLK_ASSERT(
+            (params.NUM_TILES_IN_BLOCK <= get_dest_max_tiles<dest_sync, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()),
+            "Matmul block exceeds destination capacity");
+        for (std::uint32_t j = 0; j < params.KT_DIM; j++)
+        {
+            _llk_math_matmul_<MATH_FIDELITY, THROTTLE_LEVEL>(params.DST_INDEX, params.CT_DIM, params.RT_DIM);
+        }
 
-    _llk_math_dest_section_done_<dest_sync, is_fp32_dest_acc_en>();
+        _llk_math_dest_section_done_<dest_sync, is_fp32_dest_acc_en>();
+    }
 }
 
 #endif
@@ -125,14 +130,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(
         formats.pack_dst, params.in0_tile_r_dim < FACE_R_DIM ? params.in0_tile_r_dim : FACE_R_DIM, TILE_C_DIM, params.num_faces);
     _llk_pack_dest_init_<dest_sync, is_fp32_dest_acc_en>();
-    _llk_packer_wait_for_math_done_();
-    for (std::uint32_t i = 0; i < params.TILE_CNT; i++)
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
     {
-        const std::uint32_t tile_index = params.DST_INDEX + i;
-        LLK_ASSERT((tile_index < get_dest_max_tiles<dest_sync, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()), "tile_index exceeds max dest tiles");
-        _llk_pack_<dest_sync, is_fp32_dest_acc_en, ckernel::PackMode::Default>(tile_index, L1_ADDRESS(params.buffer_Res[i]));
+        _llk_packer_wait_for_math_done_();
+        for (std::uint32_t tile = 0; tile < params.NUM_TILES_IN_BLOCK; ++tile)
+        {
+            const std::uint32_t result_tile = block * params.NUM_TILES_IN_BLOCK + tile;
+            _llk_pack_<dest_sync, is_fp32_dest_acc_en, ckernel::PackMode::Default>(params.DST_INDEX + tile, L1_ADDRESS(params.buffer_Res[result_tile]));
+        }
+        _llk_pack_dest_section_done_<dest_sync, is_fp32_dest_acc_en>();
     }
-    _llk_pack_dest_section_done_<dest_sync, is_fp32_dest_acc_en>();
 }
 
 #endif

--- a/tt_metal/tt-llk/tests/sources/matmul_pack_untilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_pack_untilize_test.cpp
@@ -33,7 +33,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, 4 /* num_faces */, 4 /* num_faces */);
     _llk_unpack_AB_matmul_init_<>();
-    _llk_unpack_AB_matmul_<>(L1_ADDRESS(params.buffer_A[0]), L1_ADDRESS(params.buffer_B[0]), 0, 0, face_size, face_size);
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
+    {
+        _llk_unpack_AB_matmul_<>(L1_ADDRESS(params.buffer_A[0]), L1_ADDRESS(params.buffer_B[0]), 0, 0, face_size, face_size);
+    }
 }
 
 #endif
@@ -53,9 +56,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_math_pack_sync_init_<sync, is_fp32_dest_acc_en>();
     _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
     _llk_math_reconfig_remap_wrapper_(true);
-    _llk_math_wait_for_dest_available_<sync>();
-    _llk_math_matmul_<MATH_FIDELITY>(0);
-    _llk_math_dest_section_done_<sync, is_fp32_dest_acc_en>();
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
+    {
+        _llk_math_wait_for_dest_available_<sync>();
+        _llk_math_matmul_<MATH_FIDELITY>(0);
+        _llk_math_dest_section_done_<sync, is_fp32_dest_acc_en>();
+    }
 }
 
 #endif
@@ -74,9 +80,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, llk_test_pack_mode_v<UNTILIZE, false>>(formats.pack_src, formats.pack_dst, tile_size);
     _llk_pack_dest_init_wrapper_<sync, is_fp32_dest_acc_en, llk_test_pack_mode_v<UNTILIZE, false>>();
     _llk_pack_untilize_init_wrapper_<ct_dim>(formats.pack_src, formats.pack_dst, FACE_R_DIM, 4 /* num_faces */);
-    _llk_packer_wait_for_math_done_();
-    _llk_pack_untilize_wrapper_<ct_dim>(L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst, FACE_R_DIM, 4 /* num_faces */, 0 /* tile_dst_rt_offset */);
-    _llk_pack_dest_section_done_<sync, is_fp32_dest_acc_en>();
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
+    {
+        _llk_packer_wait_for_math_done_();
+        _llk_pack_untilize_wrapper_<ct_dim>(L1_ADDRESS(params.buffer_Res[block]), formats.pack_dst, FACE_R_DIM, 4 /* num_faces */, 0 /* tile_dst_rt_offset */);
+        _llk_pack_dest_section_done_<sync, is_fp32_dest_acc_en>();
+    }
 }
 
 #endif

--- a/tt_metal/tt-llk/tests/sources/matmul_unpack_tilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_unpack_tilize_test.cpp
@@ -16,8 +16,9 @@ std::uint32_t math_sync_tile_dst_index = 0;
 std::uint32_t tile_size                = 128;
 
 // Remove later
-constexpr std::uint32_t buffer_A_tilized = 0xA0000;
-constexpr std::uint32_t buffer_B_tilized = 0xA1000;
+constexpr std::uint32_t buffer_A_tilized         = 0x30000;
+constexpr std::uint32_t buffer_B_tilized         = 0x50000;
+constexpr std::uint32_t intermediate_tile_stride = 0x1000;
 
 // Translation of these lines:
 // const FormatConfig(&formats_array)[2] = params.formats;
@@ -51,26 +52,18 @@ void run_kernel(RUNTIME_PARAMETERS params)
         4 /* num_faces */);
 
     _llk_unpack_tilize_init_wrapper_(formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, 1 /* ct_dim */, FACE_R_DIM, false /* narrow_tile */);
-    _llk_unpack_tilize_wrapper_(
-        L1_ADDRESS(params.buffer_A[0]),
-        0 /* tile_index */,
-        formats_array[run].unpack_A_src,
-        formats_array[run].unpack_A_dst,
-        block_ct_dim,
-        FACE_R_DIM,
-        4 /* num_faces */,
-        false);
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
+    {
+        _llk_unpack_tilize_wrapper_(
+            L1_ADDRESS(params.buffer_A[0]), 0, formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, block_ct_dim, FACE_R_DIM, 4, false);
+    }
 
     _llk_unpack_tilize_init_wrapper_(formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, 1 /* ct_dim */, FACE_R_DIM, false /* narrow_tile */);
-    _llk_unpack_tilize_wrapper_(
-        L1_ADDRESS(params.buffer_B[0]),
-        0 /* tile_index */,
-        formats_array[run].unpack_B_src,
-        formats_array[run].unpack_B_dst,
-        block_ct_dim,
-        FACE_R_DIM,
-        4 /* num_faces */,
-        false);
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
+    {
+        _llk_unpack_tilize_wrapper_(
+            L1_ADDRESS(params.buffer_B[0]), 0, formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, block_ct_dim, FACE_R_DIM, 4, false);
+    }
 
     t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(
         semaphore::PACK_DONE); // Unpacker waits on signal when packer will increment semaphore to 1 (waits while semaphore == 0), utilizing SEMWAIT.
@@ -86,7 +79,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, tile_size);
     _llk_unpack_tilize_uninit_wrapper_(formats_array[run].unpack_A_dst, 4 /* num_faces */);
     _llk_unpack_AB_matmul_init_<>();
-    _llk_unpack_AB_matmul_<>(L1_ADDRESS(buffer_A_tilized), L1_ADDRESS(buffer_B_tilized), 0, 0, tile_size, tile_size);
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
+    {
+        const std::uint32_t offset = block * intermediate_tile_stride;
+        _llk_unpack_AB_matmul_<>(L1_ADDRESS(buffer_A_tilized + offset), L1_ADDRESS(buffer_B_tilized + offset), 0, 0, tile_size, tile_size);
+    }
 }
 
 #endif
@@ -123,15 +120,21 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats_array[run].math, formats_array[run].math);
 
     // copy tilized inputs to dest indexes 0 and 1
-    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
-    _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, false>(
-        operand_A_dst_index, formats_array[run].math, formats_array[run].math);
-    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
+    {
+        _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+        _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, false>(
+            operand_A_dst_index, formats_array[run].math, formats_array[run].math);
+        _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    }
 
-    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
-    _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, false>(
-        operand_B_dst_index, formats_array[run].math, formats_array[run].math);
-    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
+    {
+        _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+        _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, false>(
+            operand_B_dst_index, formats_array[run].math, formats_array[run].math);
+        _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    }
 
     // Start of second math kernel to perform matmul on now tilized input data
     run = 1; // second L1-to-L1 run, we access the second set of formats_array in our array
@@ -139,9 +142,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
         formats_array[run].math); // have to reconfigure math kernel data formats_array if they change in this run
     _llk_math_reconfig_data_format_srcb_<is_fp32_dest_acc_en, false>(formats_array[run].math);
     _llk_math_matmul_init_<MATH_FIDELITY>();
-    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
-    _llk_math_matmul_<MATH_FIDELITY>(0);
-    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
+    {
+        _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+        _llk_math_matmul_<MATH_FIDELITY>(0);
+        _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    }
 }
 
 #endif
@@ -169,14 +175,21 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_init_wrapper_<llk_unpack_tilize_sweep_pack_cfg_mode_v<UNTILIZE, TILIZE>, false /* zero_output */>(formats_array[run].pack_dst);
     _llk_pack_dest_init_wrapper_<DstSync::SyncHalf, is_fp32_dest_acc_en, llk_test_pack_mode_v<UNTILIZE, false>>();
 
-    _llk_packer_wait_for_math_done_();
-    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, pack_exec_mode_v<UNTILIZE>>(operand_A_dst_index, L1_ADDRESS(buffer_A_tilized));
-    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
+    {
+        _llk_packer_wait_for_math_done_();
+        _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, pack_exec_mode_v<UNTILIZE>>(
+            operand_A_dst_index, L1_ADDRESS(buffer_A_tilized + block * intermediate_tile_stride));
+        _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    }
 
-    _llk_packer_wait_for_math_done_();
-    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, pack_exec_mode_v<UNTILIZE>>(operand_B_dst_index, L1_ADDRESS(buffer_B_tilized));
-    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>(); // Packer will execute _llk_pack_dest_section_done_ function which ensures the write
-                                                                            // to L1 is fully is complete.
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
+    {
+        _llk_packer_wait_for_math_done_();
+        _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, pack_exec_mode_v<UNTILIZE>>(
+            operand_B_dst_index, L1_ADDRESS(buffer_B_tilized + block * intermediate_tile_stride));
+        _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    }
     t6_semaphore_post<>(semaphore::PACK_DONE); // The packer signals to the unpacker that it has finished writing to L1 by posting (incrementing) the semaphore.
                                                // Now unpacker's wait condition is satisfied, allowing it to begin processing data from L1.
 
@@ -193,9 +206,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
         formats_array[run].pack_src, FACE_R_DIM, TILE_C_DIM, 4 /* num_faces */, 1 /* num_tiles */, false /* skip_bh_tilize_workaround */);
 #endif
 
-    _llk_packer_wait_for_math_done_();
-    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, ckernel::PackMode::Default>(res_dst_index, L1_ADDRESS(params.buffer_Res[0]));
-    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
+    {
+        _llk_packer_wait_for_math_done_();
+        _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, ckernel::PackMode::Default>(res_dst_index, L1_ADDRESS(params.buffer_Res[block]));
+        _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    }
 }
 
 #endif

--- a/tt_metal/tt-llk/tests/sources/matmul_unpack_tilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_unpack_tilize_test.cpp
@@ -15,10 +15,18 @@ std::uint32_t pack_sync_tile_dst_ptr   = 0;
 std::uint32_t math_sync_tile_dst_index = 0;
 std::uint32_t tile_size                = 128;
 
-// Remove later
-constexpr std::uint32_t buffer_A_tilized         = 0x30000;
-constexpr std::uint32_t buffer_B_tilized         = 0x50000;
+// Stride between consecutive staged tiles in the L1 scratch region. 0x1000 is one fp32 32x32
+// tile, the largest tile among the supported formats, so it is a safe upper bound for all of them.
 constexpr std::uint32_t intermediate_tile_stride = 0x1000;
+
+// L1 scratch that stages the tilized operands between the two fused pipeline runs is placed
+// immediately above the framework-allocated operands: buffer_Res is the highest operand (no
+// buffer_C/buffer_S here) and holds tile_count_res == NUM_BLOCKS tiles (tile_cnt_A == 1), so
+// buffer_Res[NUM_BLOCKS] is the first free byte above it. Deriving the base from the real
+// allocations keeps the scratch clear of the result buffer in the normal layout and of the
+// linker-reserved TRISC code/GCOV regions in the coverage layout, where a fixed address would
+// collide with one or the other. buffer_A_tilized/buffer_B_tilized are computed locally in the
+// unpack and pack kernels from these same expressions, so both threads agree on the addresses.
 
 // Translation of these lines:
 // const FormatConfig(&formats_array)[2] = params.formats;
@@ -38,7 +46,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig(&formats_array)[2] = params.formats;
 #endif
 
-    const std::uint32_t block_ct_dim = _llk_unpack_tilize_block_ct_dim_wrapper_(BLOCK_CT_DIM);
+    const std::uint32_t block_ct_dim     = _llk_unpack_tilize_block_ct_dim_wrapper_(BLOCK_CT_DIM);
+    const std::uint32_t buffer_A_tilized = params.buffer_Res[params.NUM_BLOCKS];
+    const std::uint32_t buffer_B_tilized = buffer_A_tilized + params.NUM_BLOCKS * intermediate_tile_stride;
 
     int run = 0; // first L1-to-L1 run, we access the first set of formats_array in our array
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
@@ -55,14 +65,28 @@ void run_kernel(RUNTIME_PARAMETERS params)
     for (int block = 0; block < params.NUM_BLOCKS; ++block)
     {
         _llk_unpack_tilize_wrapper_(
-            L1_ADDRESS(params.buffer_A[0]), 0, formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, block_ct_dim, FACE_R_DIM, 4, false);
+            L1_ADDRESS(params.buffer_A[0]),
+            0 /* tile_index */,
+            formats_array[run].unpack_A_src,
+            formats_array[run].unpack_A_dst,
+            block_ct_dim,
+            FACE_R_DIM,
+            4 /* num_faces */,
+            false /* narrow_tile */);
     }
 
     _llk_unpack_tilize_init_wrapper_(formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, 1 /* ct_dim */, FACE_R_DIM, false /* narrow_tile */);
     for (int block = 0; block < params.NUM_BLOCKS; ++block)
     {
         _llk_unpack_tilize_wrapper_(
-            L1_ADDRESS(params.buffer_B[0]), 0, formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, block_ct_dim, FACE_R_DIM, 4, false);
+            L1_ADDRESS(params.buffer_B[0]),
+            0 /* tile_index */,
+            formats_array[run].unpack_B_src,
+            formats_array[run].unpack_B_dst,
+            block_ct_dim,
+            FACE_R_DIM,
+            4 /* num_faces */,
+            false /* narrow_tile */);
     }
 
     t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(
@@ -167,6 +191,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t operand_B_dst_index = 2;
     const std::uint32_t res_dst_index       = 0;
     static constexpr bool UNTILIZE          = false;
+
+    const std::uint32_t buffer_A_tilized = params.buffer_Res[params.NUM_BLOCKS];
+    const std::uint32_t buffer_B_tilized = buffer_A_tilized + params.NUM_BLOCKS * intermediate_tile_stride;
 
     int run                      = 0; // first L1-to-L1 run, we access the first set of formats_array in our array
     static constexpr bool TILIZE = true;

--- a/tt_metal/tt-llk/tests/sources/multiple_tiles_eltwise_custom_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/multiple_tiles_eltwise_custom_test.cpp
@@ -35,9 +35,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
         params.TEST_FACE_R_DIM,
         params.num_faces,
         params.num_faces);
-    _llk_unpack_AB_sub_bcast_col_init_custom_(tensor_shape);
-
-    _llk_unpack_AB_sub_bcast_col_custom_(L1_ADDRESS(params.buffer_A[0]), L1_ADDRESS(params.buffer_B[0]), CT_DIM);
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
+    {
+        _llk_unpack_AB_sub_bcast_col_init_custom_(tensor_shape);
+        _llk_unpack_AB_sub_bcast_col_custom_(
+            L1_ADDRESS(params.buffer_A[block * params.NUM_TILES_IN_BLOCK]), L1_ADDRESS(params.buffer_B[0]), params.NUM_TILES_IN_BLOCK);
+    }
 }
 
 #endif
@@ -57,19 +60,19 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const ckernel::TensorShape tensor_shape = ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces);
     _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
     _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
-    _llk_math_eltwise_binary_init_custom_<ELTWISE_BINARY_OP, BROADCAST_TYPE>(params.num_faces);
-
-    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
-
-    // call custom LLK. The templated MUL/SUB scaffold is Blackhole-only; Wormhole has only the
-    // SUB-named wrapper, so MUL is exercised on BH alone (the test skips the MUL variant on non-BH).
+    // Call the custom LLK once per destination section. The templated MUL/SUB scaffold is
+    // Blackhole-only; Wormhole has only the SUB-named wrapper.
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
+    {
+        _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+        _llk_math_eltwise_binary_init_custom_<ELTWISE_BINARY_OP, BROADCAST_TYPE>(params.num_faces);
 #ifdef ARCH_BLACKHOLE
-    _llk_math_bcast_cols_reuse_custom_<ELTWISE_BINARY_OP>(CT_DIM, tensor_shape);
+        _llk_math_bcast_cols_reuse_custom_<ELTWISE_BINARY_OP>(params.NUM_TILES_IN_BLOCK, tensor_shape);
 #else
-    _llk_math_sub_bcast_cols_reuse_custom_(CT_DIM, tensor_shape);
+        _llk_math_sub_bcast_cols_reuse_custom_(params.NUM_TILES_IN_BLOCK, tensor_shape);
 #endif
-
-    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+        _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    }
 }
 
 #endif
@@ -97,15 +100,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     _llk_pack_dest_init_wrapper_<DstSync::SyncHalf, is_fp32_dest_acc_en, PackMode::Default>(params.TEST_FACE_R_DIM);
 
-    // wait for math to finish
-    _llk_packer_wait_for_math_done_();
-
-    // pack the result
-    for (std::uint32_t i = 0; i < params.TILE_CNT; i++)
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
     {
-        _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, ckernel::PackMode::Default>(i, L1_ADDRESS(params.buffer_Res[i]));
+        _llk_packer_wait_for_math_done_();
+        for (std::uint32_t tile = 0; tile < params.NUM_TILES_IN_BLOCK; ++tile)
+        {
+            const std::uint32_t result_tile = block * params.NUM_TILES_IN_BLOCK + tile;
+            _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, ckernel::PackMode::Default>(tile, L1_ADDRESS(params.buffer_Res[result_tile]));
+        }
+        _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
     }
-    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 }
 
 #endif

--- a/tt_metal/tt-llk/tests/sources/risc_compute_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/risc_compute_test.cpp
@@ -18,11 +18,14 @@ std::uint32_t math_sync_tile_dst_index = 0;
 
 void run_kernel(RUNTIME_PARAMETERS params)
 {
-    std::int32_t* A = reinterpret_cast<std::int32_t*>(params.buffer_A[0]);
-    std::int32_t* B = reinterpret_cast<std::int32_t*>(params.buffer_B[0]);
-    std::int32_t* C = reinterpret_cast<std::int32_t*>(params.buffer_Res[0]);
-
-    std::transform(A, A + 1024, B, C, std::plus<std::int32_t>());
+    const std::uint32_t total_tiles = params.NUM_BLOCKS * params.NUM_TILES_IN_BLOCK;
+    for (std::uint32_t tile = 0; tile < total_tiles; tile += 3)
+    {
+        const auto* A = reinterpret_cast<const std::int32_t*>(params.buffer_A[tile]);
+        const auto* B = reinterpret_cast<const std::int32_t*>(params.buffer_B[tile]);
+        auto* C       = reinterpret_cast<std::int32_t*>(params.buffer_Res[tile]);
+        std::transform(A, A + 1024, B, C, std::plus<std::int32_t>());
+    }
 }
 
 #endif
@@ -31,11 +34,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 void run_kernel(RUNTIME_PARAMETERS params)
 {
-    std::int32_t* A = reinterpret_cast<std::int32_t*>(params.buffer_A[1]);
-    std::int32_t* B = reinterpret_cast<std::int32_t*>(params.buffer_B[1]);
-    std::int32_t* C = reinterpret_cast<std::int32_t*>(params.buffer_Res[1]);
-
-    std::transform(A, A + 1024, B, C, std::plus<std::int32_t>());
+    const std::uint32_t total_tiles = params.NUM_BLOCKS * params.NUM_TILES_IN_BLOCK;
+    for (std::uint32_t tile = 1; tile < total_tiles; tile += 3)
+    {
+        const auto* A = reinterpret_cast<const std::int32_t*>(params.buffer_A[tile]);
+        const auto* B = reinterpret_cast<const std::int32_t*>(params.buffer_B[tile]);
+        auto* C       = reinterpret_cast<std::int32_t*>(params.buffer_Res[tile]);
+        std::transform(A, A + 1024, B, C, std::plus<std::int32_t>());
+    }
 }
 
 #endif
@@ -44,11 +50,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 void run_kernel(RUNTIME_PARAMETERS params)
 {
-    std::int32_t* A = reinterpret_cast<std::int32_t*>(params.buffer_A[2]);
-    std::int32_t* B = reinterpret_cast<std::int32_t*>(params.buffer_B[2]);
-    std::int32_t* C = reinterpret_cast<std::int32_t*>(params.buffer_Res[2]);
-
-    std::transform(A, A + 1024, B, C, std::plus<std::int32_t>());
+    const std::uint32_t total_tiles = params.NUM_BLOCKS * params.NUM_TILES_IN_BLOCK;
+    for (std::uint32_t tile = 2; tile < total_tiles; tile += 3)
+    {
+        const auto* A = reinterpret_cast<const std::int32_t*>(params.buffer_A[tile]);
+        const auto* B = reinterpret_cast<const std::int32_t*>(params.buffer_B[tile]);
+        auto* C       = reinterpret_cast<std::int32_t*>(params.buffer_Res[tile]);
+        std::transform(A, A + 1024, B, C, std::plus<std::int32_t>());
+    }
 }
 
 #endif

--- a/tt_metal/tt-llk/tests/sources/sfpu_binary_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_binary_test.cpp
@@ -57,23 +57,28 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
     _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
 
-    _llk_math_eltwise_unary_datacopy_init_wrapper_<copy_type, is_fp32_dest_acc_en, BROADCAST_TYPE, is_int_fpu_en, PackMode::Default>(
-        4 /* num_faces */, formats.math);
-
-    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
-    for (std::uint32_t i = 0; i < params.TILE_CNT; i++)
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
     {
-        LLK_ASSERT(
-            (i < get_dest_max_tiles<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()), "Block tile index exceeds maximum destination tiles");
-        _llk_math_eltwise_unary_datacopy_<copy_type, DstSync::SyncHalf, is_fp32_dest_acc_en, BROADCAST_TYPE, unpack_to_dest>(i, formats.math, formats.math);
+        _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+        _llk_math_eltwise_unary_datacopy_init_wrapper_<copy_type, is_fp32_dest_acc_en, BROADCAST_TYPE, is_int_fpu_en, PackMode::Default>(
+            4 /* num_faces */, formats.math);
+        for (std::uint32_t tile = 0; tile < params.NUM_TILES_IN_BLOCK; ++tile)
+        {
+            _llk_math_eltwise_unary_datacopy_<copy_type, DstSync::SyncHalf, is_fp32_dest_acc_en, BROADCAST_TYPE, unpack_to_dest>(
+                tile, formats.math, formats.math);
+        }
+        _llk_math_eltwise_unary_datacopy_uninit_<BROADCAST_TYPE, unpack_to_dest>();
+
+        test_utils::call_binary_sfpu_operation_init<APPROX_MODE, is_fp32_dest_acc_en, SFPU_BINARY_OPERATION, 32 /* iterations */, formats.math>();
+
+        for (std::uint32_t tile = 0; tile < params.NUM_TILES_IN_BLOCK; tile += 2)
+        {
+            test_utils::
+                call_binary_sfpu_operation<DstSync::SyncHalf, is_fp32_dest_acc_en, APPROX_MODE, SFPU_BINARY_OPERATION, 32 /* iterations */, formats.math>(
+                    tile, tile + 1, tile);
+        }
+        _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
     }
-    _llk_math_eltwise_unary_datacopy_uninit_<BROADCAST_TYPE, unpack_to_dest>();
-
-    test_utils::call_binary_sfpu_operation_init<APPROX_MODE, is_fp32_dest_acc_en, SFPU_BINARY_OPERATION, 32 /* iterations */, formats.math>();
-
-    test_utils::call_binary_sfpu_operation<DstSync::SyncHalf, is_fp32_dest_acc_en, APPROX_MODE, SFPU_BINARY_OPERATION, 32 /* iterations */, formats.math>(
-        0 /* dst_index_in0 */, 1 /* dst_index_in1 */, 0 /* dst_index_out */);
-    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 }
 
 #endif
@@ -92,14 +97,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     _llk_pack_dest_init_wrapper_<DstSync::SyncHalf, is_fp32_dest_acc_en, PackMode::Default>();
 
-    _llk_packer_wait_for_math_done_();
-    for (std::uint32_t i = 0; i < params.TILE_CNT; i++)
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
     {
-        LLK_ASSERT(
-            (i < get_dest_max_tiles<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()), "Block tile index exceeds maximum destination tiles");
-        _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, ckernel::PackMode::Default>(i, L1_ADDRESS(params.buffer_Res[i]));
+        _llk_packer_wait_for_math_done_();
+        for (std::uint32_t tile = 0; tile < params.NUM_TILES_IN_BLOCK; ++tile)
+        {
+            const std::uint32_t result_tile = block * params.NUM_TILES_IN_BLOCK + tile;
+            _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, ckernel::PackMode::Default>(tile, L1_ADDRESS(params.buffer_Res[result_tile]));
+        }
+        _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
     }
-    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 }
 
 #endif

--- a/tt_metal/tt-llk/tests/sources/sfpu_reduce_sdpa_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_reduce_sdpa_test.cpp
@@ -58,25 +58,26 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    // Initialize datacopy from srcA to dest
-    _llk_math_eltwise_unary_datacopy_init_wrapper_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false /* is_int_fpu_en */, PackMode::Default>(
-        4 /* num_faces */, formats.math);
     _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
     _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
 
-    // Wait for destination to be available
-    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
-    // Process each tile
-    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
     {
-        LLK_ASSERT(
-            (i < get_dest_max_tiles<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()), "Block tile index exceeds maximum destination tiles");
-        // Copy from srcA to dest
-        _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
-            i, formats.math, formats.math);
-    }
+        _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+        _llk_math_eltwise_unary_datacopy_init_wrapper_<
+            DataCopyType::A2D,
+            is_fp32_dest_acc_en,
+            BroadcastType::NONE,
+            false /* is_int_fpu_en */,
+            PackMode::Default>(4 /* num_faces */, formats.math);
+        for (std::uint32_t tile = 0; tile < params.NUM_TILES_IN_BLOCK; ++tile)
+        {
+            _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
+                tile, formats.math, formats.math);
+        }
 
-    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+        _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    }
 }
 
 #endif
@@ -103,31 +104,25 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // Initialize destination for packing
     _llk_pack_dest_init_wrapper_<DstSync::SyncHalf, is_fp32_dest_acc_en, PackMode::Default>();
 
-    _llk_packer_wait_for_math_done_();
-
-    // SFPU part
-    // Initialize SFPU for reduce operation
-    _llk_math_eltwise_unary_sfpu_init_<SfpuType::reduce>();
-
-    ckernel::sfpu::_init_reduce_max_col_subblock_4x2_<DataFormat::Float16_b>();
-
-    _llk_math_eltwise_sfpu_start_(0);
-    ckernel::sfpu::_reduce_max_col_subblock_4x2_prologue_();
-    ckernel::sfpu::_calculate_reduce_max_col_subblock_4x2_<PoolType::MAX, ReduceDim::REDUCE_COL, DataFormat::Float16_b>(BLOCK_RT_DIM);
-
-    ckernel::sfpu::_reduce_max_col_subblock_4x2_epilogue_();
-
-    _llk_math_eltwise_sfpu_done_();
-
-    // Wait for math to finish and pack tiles back to L1
-
-    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
     {
-        LLK_ASSERT(
-            (i < get_dest_max_tiles<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()), "Block tile index exceeds maximum destination tiles");
-        _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, ckernel::PackMode::Default>(i, L1_ADDRESS(params.buffer_Res[i]));
+        _llk_packer_wait_for_math_done_();
+
+        _llk_math_eltwise_unary_sfpu_init_<SfpuType::reduce>();
+        ckernel::sfpu::_init_reduce_max_col_subblock_4x2_<DataFormat::Float16_b>();
+        _llk_math_eltwise_sfpu_start_(0);
+        ckernel::sfpu::_reduce_max_col_subblock_4x2_prologue_();
+        ckernel::sfpu::_calculate_reduce_max_col_subblock_4x2_<PoolType::MAX, ReduceDim::REDUCE_COL, DataFormat::Float16_b>(BLOCK_RT_DIM);
+        ckernel::sfpu::_reduce_max_col_subblock_4x2_epilogue_();
+        _llk_math_eltwise_sfpu_done_();
+
+        for (std::uint32_t tile = 0; tile < params.NUM_TILES_IN_BLOCK; ++tile)
+        {
+            const std::uint32_t result_tile = block * params.NUM_TILES_IN_BLOCK + tile;
+            _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, ckernel::PackMode::Default>(tile, L1_ADDRESS(params.buffer_Res[result_tile]));
+        }
+        _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
     }
-    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 }
 
 #endif

--- a/tt_metal/tt-llk/tests/sources/tilize_calculate_untilize_L1.cpp
+++ b/tt_metal/tt-llk/tests/sources/tilize_calculate_untilize_L1.cpp
@@ -17,6 +17,10 @@ std::uint32_t math_sync_tile_dst_index = 0;
 
 using namespace ckernel;
 
+constexpr std::uint32_t buffer_A_tilized         = 0x30000;
+constexpr std::uint32_t buffer_B_tilized         = 0x50000;
+constexpr std::uint32_t intermediate_tile_stride = 0x1000;
+
 // Translation of these lines:
 // const FormatConfig(&formats_array)[2] = params.formats;
 // to English:
@@ -50,26 +54,18 @@ void run_kernel(RUNTIME_PARAMETERS params)
         4 /* num_faces */);
 
     _llk_unpack_tilize_init_wrapper_(formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, 1 /* ct_dim */, FACE_R_DIM, false /* narrow_tile */);
-    _llk_unpack_tilize_wrapper_(
-        L1_ADDRESS(params.buffer_A[0]),
-        0 /* tile_index */,
-        formats_array[run].unpack_A_src,
-        formats_array[run].unpack_A_dst,
-        block_ct_dim,
-        FACE_R_DIM,
-        4 /* num_faces */,
-        false /* narrow_tile */);
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
+    {
+        _llk_unpack_tilize_wrapper_(
+            L1_ADDRESS(params.buffer_A[0]), 0, formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, block_ct_dim, FACE_R_DIM, 4, false);
+    }
 
     _llk_unpack_tilize_init_wrapper_(formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, 1 /* ct_dim */, FACE_R_DIM, false /* narrow_tile */);
-    _llk_unpack_tilize_wrapper_(
-        L1_ADDRESS(params.buffer_B[0]),
-        0 /* tile_index */,
-        formats_array[run].unpack_B_src,
-        formats_array[run].unpack_B_dst,
-        block_ct_dim,
-        FACE_R_DIM,
-        4 /* num_faces */,
-        false /* narrow_tile */);
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
+    {
+        _llk_unpack_tilize_wrapper_(
+            L1_ADDRESS(params.buffer_B[0]), 0, formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, block_ct_dim, FACE_R_DIM, 4, false);
+    }
 
     /*
     In this test we fuse two LLK pipeline runs, one is to unpack untilized buffers/operands from L1 (39-45) and pack them in tilized format(130-145).
@@ -101,7 +97,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
         4 /* num_faces */,
         4 /* num_faces */);
     _llk_unpack_AB_init_<>(DEFAULT_TENSOR_SHAPE);
-    _llk_unpack_AB_<>(L1_ADDRESS(params.buffer_A[0]), L1_ADDRESS(params.buffer_B[0]));
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
+    {
+        _llk_unpack_AB_<>(L1_ADDRESS(buffer_A_tilized + block * intermediate_tile_stride), L1_ADDRESS(buffer_B_tilized + block * intermediate_tile_stride));
+    }
 }
 
 #endif
@@ -119,11 +118,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig(&formats_array)[2] = params.formats;
 #endif
-    const bool is_int_fpu_en                = false;
-    const std::uint32_t operand_A_dst_index = 1;
-    const std::uint32_t operand_B_dst_index = 2;
-    const std::uint32_t res_dst_index       = 0;
-    int run                                 = 0; // first L1-to-L1 run, we access the first set of formats_array in our array
+    const bool is_int_fpu_en = false;
+    int run                  = 0; // first L1-to-L1 run, we access the first set of formats_array in our array
 
     // copy srca to dest
     const bool TILIZE = true;
@@ -138,22 +134,31 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats_array[run].math, formats_array[run].math);
 
     // copy tilized inputs to dest indexes 0 and 1
-    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
-    _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, false>(
-        operand_A_dst_index, formats_array[run].math, formats_array[run].math);
-    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
+    {
+        _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+        _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, false>(
+            0, formats_array[run].math, formats_array[run].math);
+        _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    }
 
-    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
-    _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, false>(
-        operand_B_dst_index, formats_array[run].math, formats_array[run].math);
-    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
+    {
+        _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+        _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, false>(
+            0, formats_array[run].math, formats_array[run].math);
+        _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    }
 
     run = 1; // second L1-to-L1 run, we access the second set of formats_array in our array
     _llk_math_eltwise_binary_init_<ELTWISE_BINARY_OP, BroadcastType::NONE>(DEFAULT_TENSOR_SHAPE, 0 /* acc_to_dest */);
-    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
-    _llk_math_eltwise_binary_<ELTWISE_BINARY_OP, BroadcastType::NONE, DstSync::SyncHalf, is_fp32_dest_acc_en>(
-        DEFAULT_TENSOR_SHAPE, res_dst_index, false /* clear_fp32_dst_acc */);
-    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
+    {
+        _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+        _llk_math_eltwise_binary_<ELTWISE_BINARY_OP, BroadcastType::NONE, DstSync::SyncHalf, is_fp32_dest_acc_en>(
+            DEFAULT_TENSOR_SHAPE, 0, false /* clear_fp32_dst_acc */);
+        _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    }
 }
 
 #endif
@@ -169,11 +174,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig(&formats_array)[2] = params.formats;
 #endif
-    const std::uint32_t operand_A_dst_index = 1;
-    const std::uint32_t operand_B_dst_index = 2;
-    const std::uint32_t res_dst_index       = 0;
-    static constexpr bool UNTILIZE          = false;
-    int run                                 = 0;
+    static constexpr bool UNTILIZE = false;
+    int run                        = 0;
 
     static constexpr bool TILIZE = true;
     _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, llk_unpack_tilize_sweep_pack_cfg_mode_v<UNTILIZE, TILIZE>>(
@@ -181,14 +183,19 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_init_wrapper_<llk_unpack_tilize_sweep_pack_cfg_mode_v<UNTILIZE, TILIZE>, false /* zero_output */>(formats_array[run].pack_dst);
     _llk_pack_dest_init_wrapper_<DstSync::SyncHalf, is_fp32_dest_acc_en, llk_test_pack_mode_v<UNTILIZE, false>>();
 
-    _llk_packer_wait_for_math_done_();
-    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, pack_exec_mode_v<UNTILIZE>>(operand_A_dst_index, L1_ADDRESS(params.buffer_A[0]));
-    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
+    {
+        _llk_packer_wait_for_math_done_();
+        _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, pack_exec_mode_v<UNTILIZE>>(0, L1_ADDRESS(buffer_A_tilized + block * intermediate_tile_stride));
+        _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    }
 
-    _llk_packer_wait_for_math_done_();
-    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, pack_exec_mode_v<UNTILIZE>>(operand_B_dst_index, L1_ADDRESS(params.buffer_B[0]));
-    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>(); // Packer will execute _llk_pack_dest_section_done_ function which ensures the write
-                                                                            // to L1 is fully is complete.
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
+    {
+        _llk_packer_wait_for_math_done_();
+        _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, pack_exec_mode_v<UNTILIZE>>(0, L1_ADDRESS(buffer_B_tilized + block * intermediate_tile_stride));
+        _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    }
     t6_semaphore_post<>(semaphore::PACK_DONE); // The packer signals to the unpacker that it has finished writing to L1 by posting (incrementing) the semaphore.
                                                // Now unpacker's wait condition is satisfied, allowing it to begin processing data from L1.
     run = 1;                                   // second L1-to-L1 run, we access the second set of formats_array in our array
@@ -200,9 +207,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
         formats_array[run].pack_src, FACE_R_DIM, TILE_C_DIM, 4 /* num_faces */, 1 /* num_tiles */, false /* skip_bh_tilize_workaround */);
 #endif
 
-    _llk_packer_wait_for_math_done_();
-    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, pack_exec_mode_v<UNTILIZE>>(res_dst_index, L1_ADDRESS(params.buffer_Res[0]));
-    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
+    {
+        _llk_packer_wait_for_math_done_();
+        _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, pack_exec_mode_v<UNTILIZE>>(0, L1_ADDRESS(params.buffer_Res[block]));
+        _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    }
 }
 
 #endif

--- a/tt_metal/tt-llk/tests/sources/tilize_calculate_untilize_L1.cpp
+++ b/tt_metal/tt-llk/tests/sources/tilize_calculate_untilize_L1.cpp
@@ -17,9 +17,18 @@ std::uint32_t math_sync_tile_dst_index = 0;
 
 using namespace ckernel;
 
-constexpr std::uint32_t buffer_A_tilized         = 0x30000;
-constexpr std::uint32_t buffer_B_tilized         = 0x50000;
+// Stride between consecutive staged tiles in the L1 scratch region. 0x1000 is one fp32 32x32
+// tile, the largest tile among the supported formats, so it is a safe upper bound for all of them.
 constexpr std::uint32_t intermediate_tile_stride = 0x1000;
+
+// L1 scratch that stages the tilized operands between the two fused pipeline runs is placed
+// immediately above the framework-allocated operands: buffer_Res is the highest operand (no
+// buffer_C/buffer_S here) and holds tile_count_res == NUM_BLOCKS tiles (tile_cnt_A == 1), so
+// buffer_Res[NUM_BLOCKS] is the first free byte above it. Deriving the base from the real
+// allocations keeps the scratch clear of the result buffer in the normal layout and of the
+// linker-reserved TRISC code/GCOV regions in the coverage layout, where a fixed address would
+// collide with one or the other. buffer_A_tilized/buffer_B_tilized are computed locally in the
+// unpack and pack kernels from these same expressions, so both threads agree on the addresses.
 
 // Translation of these lines:
 // const FormatConfig(&formats_array)[2] = params.formats;
@@ -40,7 +49,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig(&formats_array)[2] = params.formats;
 #endif
 
-    const std::uint32_t block_ct_dim = _llk_unpack_tilize_block_ct_dim_wrapper_(BLOCK_CT_DIM);
+    const std::uint32_t block_ct_dim     = _llk_unpack_tilize_block_ct_dim_wrapper_(BLOCK_CT_DIM);
+    const std::uint32_t buffer_A_tilized = params.buffer_Res[params.NUM_BLOCKS];
+    const std::uint32_t buffer_B_tilized = buffer_A_tilized + params.NUM_BLOCKS * intermediate_tile_stride;
 
     int run = 0; // first L1-to-L1 run, we access the first set of formats_array in our array
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
@@ -57,14 +68,28 @@ void run_kernel(RUNTIME_PARAMETERS params)
     for (int block = 0; block < params.NUM_BLOCKS; ++block)
     {
         _llk_unpack_tilize_wrapper_(
-            L1_ADDRESS(params.buffer_A[0]), 0, formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, block_ct_dim, FACE_R_DIM, 4, false);
+            L1_ADDRESS(params.buffer_A[0]),
+            0 /* tile_index */,
+            formats_array[run].unpack_A_src,
+            formats_array[run].unpack_A_dst,
+            block_ct_dim,
+            FACE_R_DIM,
+            4 /* num_faces */,
+            false /* narrow_tile */);
     }
 
     _llk_unpack_tilize_init_wrapper_(formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, 1 /* ct_dim */, FACE_R_DIM, false /* narrow_tile */);
     for (int block = 0; block < params.NUM_BLOCKS; ++block)
     {
         _llk_unpack_tilize_wrapper_(
-            L1_ADDRESS(params.buffer_B[0]), 0, formats_array[run].unpack_B_src, formats_array[run].unpack_B_dst, block_ct_dim, FACE_R_DIM, 4, false);
+            L1_ADDRESS(params.buffer_B[0]),
+            0 /* tile_index */,
+            formats_array[run].unpack_B_src,
+            formats_array[run].unpack_B_dst,
+            block_ct_dim,
+            FACE_R_DIM,
+            4 /* num_faces */,
+            false /* narrow_tile */);
     }
 
     /*
@@ -176,6 +201,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
     static constexpr bool UNTILIZE = false;
     int run                        = 0;
+
+    const std::uint32_t buffer_A_tilized = params.buffer_Res[params.NUM_BLOCKS];
+    const std::uint32_t buffer_B_tilized = buffer_A_tilized + params.NUM_BLOCKS * intermediate_tile_stride;
 
     static constexpr bool TILIZE = true;
     _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, llk_unpack_tilize_sweep_pack_cfg_mode_v<UNTILIZE, TILIZE>>(

--- a/tt_metal/tt-llk/tests/sources/transpose_dest_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/transpose_dest_test.cpp
@@ -33,14 +33,21 @@ void run_kernel(RUNTIME_PARAMETERS params)
         formats.unpack_A_src,
         formats.unpack_A_dst);
 
-    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+    // Feed SrcA (for the MATH datacopy) then dummy-valid SrcB (for the transpose)
+    // one DEST bank (block) at a time, matching the MATH thread's per-block
+    // datacopy+transpose. Doing all SrcA feeds up front would withhold a block's
+    // SrcB valids behind later blocks' SrcA feeds and stall the transpose.
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
     {
-        _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-            L1_ADDRESS(params.buffer_A[i]), formats.unpack_A_src, formats.unpack_A_dst);
-    }
-    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
-    {
-        _llk_unpack_set_srcb_dummy_valid_();
+        for (std::uint32_t tile = 0; tile < params.NUM_TILES_IN_BLOCK; ++tile)
+        {
+            _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+                L1_ADDRESS(params.buffer_A[block * params.NUM_TILES_IN_BLOCK + tile]), formats.unpack_A_src, formats.unpack_A_dst);
+        }
+        for (std::uint32_t tile = 0; tile < params.NUM_TILES_IN_BLOCK; ++tile)
+        {
+            _llk_unpack_set_srcb_dummy_valid_();
+        }
     }
 }
 
@@ -59,30 +66,38 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
     constexpr bool is32 = is_fp32_dest_acc_en;
 
-    _llk_math_eltwise_unary_datacopy_init_wrapper_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false /* is_int_fpu_en */, PackMode::Default>(
-        params.num_faces, formats.math);
-
     _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
     _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
 
-    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
-    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+    // Process the input one DEST bank (block) at a time so inputs with more
+    // tiles than fit in DEST exercise DEST bank switching. Each block datacopies
+    // its tiles into DEST, transposes them in place, then hands the bank to the
+    // packer via the wait/section_done pair.
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
     {
-        LLK_ASSERT(
-            (i < get_dest_max_tiles<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()), "Block tile index exceeds maximum destination tiles");
-        _llk_math_eltwise_unary_datacopy_wrapper_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
-            i, formats.math, formats.math);
-    }
+        _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
 
-    _llk_math_transpose_dest_init_<MATH_TRANSPOSE_FACES, is32>();
+        // A2D datacopy and transpose_dest need different ALU data-format state,
+        // so (re)configure datacopy at the start of each block's copy phase.
+        _llk_math_eltwise_unary_datacopy_init_wrapper_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false /* is_int_fpu_en */, PackMode::Default>(
+            params.num_faces, formats.math);
+        for (std::uint32_t tile = 0; tile < params.NUM_TILES_IN_BLOCK; ++tile)
+        {
+            LLK_ASSERT(
+                (tile < get_dest_max_tiles<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()),
+                "Block tile index exceeds maximum destination tiles");
+            _llk_math_eltwise_unary_datacopy_wrapper_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
+                tile, formats.math, formats.math);
+        }
 
-    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
-    {
-        LLK_ASSERT(
-            (i < get_dest_max_tiles<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()), "Block tile index exceeds maximum destination tiles");
-        _llk_math_transpose_dest_wrapper_<is_fp32_dest_acc_en, MATH_TRANSPOSE_FACES, is32>(i);
+        _llk_math_transpose_dest_init_<MATH_TRANSPOSE_FACES, is32>();
+        for (std::uint32_t tile = 0; tile < params.NUM_TILES_IN_BLOCK; ++tile)
+        {
+            _llk_math_transpose_dest_wrapper_<is_fp32_dest_acc_en, MATH_TRANSPOSE_FACES, is32>(tile);
+        }
+
+        _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
     }
-    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 }
 
 #endif
@@ -102,13 +117,20 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, params.num_faces);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 
-    _llk_packer_wait_for_math_done_();
-    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+    // Pack one DEST bank (block) at a time, mirroring the MATH thread's bank
+    // switching; the block-local DEST tile index maps to the global result tile.
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
     {
-        LLK_ASSERT(
-            (i < get_dest_max_tiles<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()), "Block tile index exceeds maximum destination tiles");
-        _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, ckernel::PackMode::Default>(i, L1_ADDRESS(params.buffer_Res[i]));
+        _llk_packer_wait_for_math_done_();
+        for (std::uint32_t tile = 0; tile < params.NUM_TILES_IN_BLOCK; ++tile)
+        {
+            LLK_ASSERT(
+                (tile < get_dest_max_tiles<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()),
+                "Block tile index exceeds maximum destination tiles");
+            _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, ckernel::PackMode::Default>(
+                tile, L1_ADDRESS(params.buffer_Res[block * params.NUM_TILES_IN_BLOCK + tile]));
+        }
+        _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
     }
-    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 }
 #endif

--- a/tt_metal/tt-llk/tests/sources/transpose_dest_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/transpose_dest_test.cpp
@@ -79,8 +79,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         // A2D datacopy and transpose_dest need different ALU data-format state,
         // so (re)configure datacopy at the start of each block's copy phase.
-        _llk_math_eltwise_unary_datacopy_init_wrapper_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false /* is_int_fpu_en */, PackMode::Default>(
-            params.num_faces, formats.math);
+        _llk_math_eltwise_unary_datacopy_init_wrapper_<
+            DataCopyType::A2D,
+            is_fp32_dest_acc_en,
+            BroadcastType::NONE,
+            false /* is_int_fpu_en */,
+            PackMode::Default>(params.num_faces, formats.math);
         for (std::uint32_t tile = 0; tile < params.NUM_TILES_IN_BLOCK; ++tile)
         {
             LLK_ASSERT(

--- a/tt_metal/tt-llk/tests/sources/ttnn_where_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/ttnn_where_test.cpp
@@ -47,9 +47,19 @@ void run_kernel(RUNTIME_PARAMETERS params)
         UNPACK_FMT, UNPACK_FMT, UNPACK_FMT, UNPACK_FMT, FACE_R_DIM, FACE_R_DIM, 4 /* num_faces */, 4 /* num_faces */);
     _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
         0 /* transpose_of_faces */, 0 /* within_face_16x16_transpose */, ckernel::DEFAULT_TENSOR_SHAPE, UNPACK_FMT, UNPACK_FMT);
-    _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(L1_ADDRESS(params.buffer_A[0]), UNPACK_FMT, UNPACK_FMT);
-    _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(L1_ADDRESS(params.buffer_B[0]), UNPACK_FMT, UNPACK_FMT);
-    _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(L1_ADDRESS(params.buffer_C[0]), UNPACK_FMT, UNPACK_FMT);
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
+    {
+        for (std::uint32_t tile = 0; tile < params.NUM_TILES_IN_BLOCK; ++tile)
+        {
+            const std::uint32_t input_tile = block * params.NUM_TILES_IN_BLOCK + tile;
+            _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+                L1_ADDRESS(params.buffer_A[input_tile]), UNPACK_FMT, UNPACK_FMT);
+            _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+                L1_ADDRESS(params.buffer_B[input_tile]), UNPACK_FMT, UNPACK_FMT);
+            _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+                L1_ADDRESS(params.buffer_C[input_tile]), UNPACK_FMT, UNPACK_FMT);
+        }
+    }
 }
 
 #endif
@@ -72,7 +82,7 @@ static constexpr bool DST_ACCUM_MODE            = is_fp32_dest_acc_en;
 
 // using namespace sfpu;
 
-void run_kernel(RUNTIME_PARAMETERS)
+void run_kernel(RUNTIME_PARAMETERS params)
 {
     using DataFormatUT = std::underlying_type_t<DataFormat>;
     auto to_ufmt       = [](DataFormat fmt) constexpr { return static_cast<DataFormatUT>(fmt); };
@@ -95,37 +105,44 @@ void run_kernel(RUNTIME_PARAMETERS)
         MATH_FMT = to_ufmt(DataFormat::UInt16);
     }
 
-    // copy srca to dest
-    _llk_math_eltwise_unary_datacopy_init_wrapper_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false /* is_int_fpu_en */, PackMode::Default>(
-        4 /* num_faces */, MATH_FMT);
     _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
     _llk_math_hw_configure_<is_fp32_dest_acc_en>(MATH_FMT, MATH_FMT);
-    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
-    _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
-        0, MATH_FMT, MATH_FMT); // buffer condition
-    _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
-        1, MATH_FMT, MATH_FMT); // buffer true
-    _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
-        2, MATH_FMT, MATH_FMT); // buffer false
-
-    // calculation of sfpu operation on dest
-    _llk_math_eltwise_ternary_sfpu_init_<SfpuType::where>();
-    ckernel::sfpu::_init_where_<false>();
 
     // One SFPU replay advances one row of 32 lanes; 8 rows per face (matches llk_math_eltwise_ternary_sfpu_where).
     constexpr int k_where_iterations = 8;
-    SFPU_TERNARY_CALL(
-        DST_SYNC_MODE,
-        DST_ACCUM_MODE,
-        _calculate_where_,
-        (false /*APPROXIMATE*/, static_cast<DataFormat>(UNPACK_A_IN), k_where_iterations),
-        0 /*DST_IN0*/,
-        1 /*DST_IN1*/,
-        2 /*DST_IN2*/,
-        0 /*DST_OUT*/,
-        VectorMode::RC);
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
+    {
+        for (std::uint32_t tile = 0; tile < params.NUM_TILES_IN_BLOCK; ++tile)
+        {
+            _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+            _llk_math_eltwise_unary_datacopy_init_wrapper_<
+                DataCopyType::A2D,
+                is_fp32_dest_acc_en,
+                BroadcastType::NONE,
+                false /* is_int_fpu_en */,
+                PackMode::Default>(4 /* num_faces */, MATH_FMT);
+            _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
+                0, MATH_FMT, MATH_FMT);
+            _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
+                1, MATH_FMT, MATH_FMT);
+            _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
+                2, MATH_FMT, MATH_FMT);
 
-    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+            _llk_math_eltwise_ternary_sfpu_init_<SfpuType::where>();
+            ckernel::sfpu::_init_where_<false>();
+            SFPU_TERNARY_CALL(
+                DST_SYNC_MODE,
+                DST_ACCUM_MODE,
+                _calculate_where_,
+                (false /*APPROXIMATE*/, static_cast<DataFormat>(UNPACK_A_IN), k_where_iterations),
+                0,
+                1,
+                2,
+                0,
+                VectorMode::RC);
+            _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+        }
+    }
 }
 
 #endif
@@ -165,9 +182,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     _llk_pack_dest_init_wrapper_<DstSync::SyncHalf, is_fp32_dest_acc_en, PackMode::Default>();
 
-    _llk_packer_wait_for_math_done_();
-    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, ckernel::PackMode::Default>(0, L1_ADDRESS(params.buffer_Res[0]));
-    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
+    {
+        for (std::uint32_t tile = 0; tile < params.NUM_TILES_IN_BLOCK; ++tile)
+        {
+            const std::uint32_t result_tile = block * params.NUM_TILES_IN_BLOCK + tile;
+            _llk_packer_wait_for_math_done_();
+            _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, ckernel::PackMode::Default>(0, L1_ADDRESS(params.buffer_Res[result_tile]));
+            _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+        }
+    }
 }
 
 #endif

--- a/tt_metal/tt-llk/tests/sources/unpack_a_bcast_eltwise_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_a_bcast_eltwise_test.cpp
@@ -30,10 +30,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, 4 /* num_faces */, 4 /* num_faces */);
     _llk_unpack_bcastA_B_init_();
 
-    // Single call works on 1 tile that goes to srcA and then reuses it for 4 srcB tiles that are changeable
-    for (std::uint32_t i = 0; i < params.TILE_CNT / params.SRCA_REUSE_COUNT; i++)
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
     {
-        _llk_unpack_bcastA_B_(L1_ADDRESS(params.buffer_A[i]), L1_ADDRESS(params.buffer_B[i * params.SRCA_REUSE_COUNT]), params.SRCA_REUSE_COUNT);
+        for (std::uint32_t tile = 0; tile < params.NUM_TILES_IN_BLOCK; tile += params.SRCA_REUSE_COUNT)
+        {
+            const std::uint32_t srca_index = (block * params.NUM_TILES_IN_BLOCK + tile) / params.SRCA_REUSE_COUNT;
+            const std::uint32_t srcb_index = block * params.NUM_TILES_IN_BLOCK + tile;
+            _llk_unpack_bcastA_B_(L1_ADDRESS(params.buffer_A[srca_index]), L1_ADDRESS(params.buffer_B[srcb_index]), params.SRCA_REUSE_COUNT);
+        }
     }
 }
 
@@ -54,16 +58,15 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
     _llk_math_eltwise_binary_init_<ELTWISE_BINARY_OP, ckernel::MathFidelity::LoFi>(params.SRCA_REUSE_COUNT);
 
-    _llk_math_wait_for_dest_available_<dest_sync>();
-
-    for (std::uint32_t i = 0; i < params.TILE_CNT / params.SRCA_REUSE_COUNT; i++)
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
     {
-        const std::uint32_t tile_index = i * params.SRCA_REUSE_COUNT;
-        LLK_ASSERT((tile_index < get_dest_max_tiles<dest_sync, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()), "tile_index exceeds max dest tiles");
-        _llk_math_eltwise_binary_(tile_index /* dst_index */);
+        _llk_math_wait_for_dest_available_<dest_sync>();
+        for (std::uint32_t tile = 0; tile < params.NUM_TILES_IN_BLOCK; tile += params.SRCA_REUSE_COUNT)
+        {
+            _llk_math_eltwise_binary_(tile /* dst_index */);
+        }
+        _llk_math_dest_section_done_<dest_sync, is_fp32_dest_acc_en>();
     }
-
-    _llk_math_dest_section_done_<dest_sync, is_fp32_dest_acc_en>();
 }
 
 #endif
@@ -85,13 +88,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     _llk_pack_dest_init_wrapper_<dest_sync, is_fp32_dest_acc_en, PackMode::Default>();
 
-    _llk_packer_wait_for_math_done_();
-    for (std::uint32_t i = 0; i < params.TILE_CNT; i++)
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
     {
-        LLK_ASSERT((i < get_dest_max_tiles<dest_sync, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()), "i exceeds max dest tiles");
-        _llk_pack_<dest_sync, is_fp32_dest_acc_en, ckernel::PackMode::Default>(i, L1_ADDRESS(params.buffer_Res[i]));
+        _llk_packer_wait_for_math_done_();
+        for (std::uint32_t tile = 0; tile < params.NUM_TILES_IN_BLOCK; ++tile)
+        {
+            const std::uint32_t result_tile = block * params.NUM_TILES_IN_BLOCK + tile;
+            _llk_pack_<dest_sync, is_fp32_dest_acc_en, ckernel::PackMode::Default>(tile, L1_ADDRESS(params.buffer_Res[result_tile]));
+        }
+        _llk_pack_dest_section_done_<dest_sync, is_fp32_dest_acc_en>();
     }
-    _llk_pack_dest_section_done_<dest_sync, is_fp32_dest_acc_en>();
 }
 
 #endif

--- a/tt_metal/tt-llk/tests/sources/unpack_tilize_sweep_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_tilize_sweep_test.cpp
@@ -79,15 +79,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
     _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
-    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
-    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
     {
-        LLK_ASSERT(
-            (i < get_dest_max_tiles<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()), "Block tile index exceeds maximum destination tiles");
-        _llk_math_eltwise_unary_datacopy_wrapper_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
-            i, formats.math, formats.math, params.num_faces);
+        _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+        for (std::uint32_t tile = 0; tile < params.NUM_TILES_IN_BLOCK; ++tile)
+        {
+            _llk_math_eltwise_unary_datacopy_wrapper_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
+                tile, formats.math, formats.math, params.num_faces);
+        }
+        _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
     }
-    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 }
 
 #endif
@@ -113,14 +114,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_dest_init_wrapper_<DstSync::SyncHalf, is_fp32_dest_acc_en, llk_unpack_tilize_sweep_pack_cfg_mode_v<UNTILIZE, TILIZE>>(
         FACE_R_DIM, params.NARROW_TILE);
 
-    _llk_packer_wait_for_math_done_();
-    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+    for (int block = 0; block < params.NUM_BLOCKS; ++block)
     {
-        LLK_ASSERT(
-            (i < get_dest_max_tiles<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()), "Block tile index exceeds maximum destination tiles");
-        _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, pack_exec_mode_v<UNTILIZE>>(i, L1_ADDRESS(params.buffer_Res[i]));
+        _llk_packer_wait_for_math_done_();
+        for (std::uint32_t tile = 0; tile < params.NUM_TILES_IN_BLOCK; ++tile)
+        {
+            const std::uint32_t result_tile = block * params.NUM_TILES_IN_BLOCK + tile;
+            _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, pack_exec_mode_v<UNTILIZE>>(tile, L1_ADDRESS(params.buffer_Res[result_tile]));
+        }
+        _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
     }
-    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 }
 
 #endif


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Completes the remaining work from `tenstorrent/tt-llk#1162` after the LLK tests moved into tt-metal. The original version of this PR covered only `transpose_dest`; this branch now carries the full current-repository solution.

The tests use `NUM_BLOCKS` and `NUM_TILES_IN_BLOCK`, process one destination section at a time on unpack/math/pack, and generate 16 or 32 tiles so every applicable path performs at least four destination-register handoffs. The shared capacity helper is used consistently, including a fix for its default `tile_dimensions=None` path.

New coverage in this PR includes:

- transpose and custom unary datacopy
- regular and custom column-broadcast pipelines
- dense pack-untilize and regular/narrow unpack-tilize
- general matmul plus fused matmul/tilize/untilize pipelines
- RISC compute
- SFPU binary and SDPA reduce
- TTNN where
- unpack-A broadcast/reuse
- fused tilize-calculate-untilize

### Why this is larger than the original PR

`tenstorrent/tt-llk#1174` was an early, closed implementation. Several of its changes subsequently landed through other PRs and are already on `main` (`eltwise_binary`, unary datacopy, SFPU unary, pack, pack_rows, reduce, SFPU reduce, and unpack_A). Other old test files were deleted or replaced during test cleanup. Reapplying that diff verbatim would duplicate merged work and restore obsolete tests.

This PR therefore ports only the still-missing current equivalents and also covers the fused/custom L1-to-L1 tests introduced after #1174. Tests that are deleted/deprecated, redundant single-API sweeps, or skipped on both supported BH/WH architectures are not resurrected.

### Validation

Blackhole ttsim:

- transpose + custom datacopy: 29 passed
- matmul unpack-tilize + tilize-calculate-untilize: 96 passed
- matmul pack-untilize: 96 passed, 32 skipped
- general matmul sampling: 227 passed across varied shapes, offsets, faces, and formats
- TTNN where: 16 passed, 8 skipped
- custom column broadcast 32-tile cases: 5 passed, 3 skipped
- dense pack-untilize 32-tile cases: 5 passed
- representative regular/narrow tilize and SFPU broadcast/accumulation cases passed

Wormhole ttsim:

- fused matmul/tilize/untilize suites: 192 passed, 32 skipped
- unpack-A broadcast/reuse: 30 passed, 6 skipped
- custom column broadcast 32-tile cases: 1 passed, 7 architecture/operation skips
- representative regular and narrow tilize cases passed

Additional checks:

- 153,817 modified-suite test variants collected successfully
- all repository pre-commit hooks passed
- `git diff --check` passed

The remaining WH simulator failures are pre-existing unsupported direct-unpack-to-destination instruction cases; the equivalent Blackhole coverage passes and no new skip was added.

Fixes tenstorrent/tt-llk#1162

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-1162-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llk_code_gen/issue-1162-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-1162-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llk_code_gen/issue-1162-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-1162-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:llk_code_gen/issue-1162-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llk_code_gen/issue-1162-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llk_code_gen/issue-1162-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llk_code_gen/issue-1162-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llk_code_gen/issue-1162-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llk_code_gen/issue-1162-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llk_code_gen/issue-1162-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llk_code_gen/issue-1162-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llk_code_gen/issue-1162-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llk_code_gen/issue-1162-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llk_code_gen/issue-1162-v1)