### PR TITLE
[Feature] Add `--op` flag to filter tests by SFPU op

### DIFF
--- a/tt_metal/tt-llk/docs/tests/accuracy_tests.md
+++ b/tt_metal/tt-llk/docs/tests/accuracy_tests.md
@@ -14,12 +14,15 @@ These are ordinary pytest tests. Just set the device arch via `CHIP_ARCH`.
 The examples below use paths relative to `tests/python_tests/` and `CHIP_ARCH = wormhole`.
 
 ```bash
-# one op
-CHIP_ARCH=wormhole pytest accuracy/test_sfpu_accuracy.py -k Reciprocal -s
+# one op (--op selects by MathOperation name; repeatable for several)
+CHIP_ARCH=wormhole pytest accuracy/test_sfpu_accuracy.py --op=Reciprocal -s
 
 # runs every op in the given test file
 CHIP_ARCH=wormhole pytest accuracy/test_examples_accuracy.py -s
 ```
+
+`--op` takes a `MathOperation` name (case-insensitive, exact), is repeatable
+(`--op=Exp --op=Log`), and composes with `-k`/`-m`.
 
 ## Output
 
@@ -36,7 +39,7 @@ source of truth. Parquet isn't human-readable, so there are two ways to get CSV:
 
 ```bash
 # 1. Write CSV directly instead of Parquet:
-CHIP_ARCH=wormhole pytest accuracy/test_sfpu_accuracy.py -k Reciprocal --csv
+CHIP_ARCH=wormhole pytest accuracy/test_sfpu_accuracy.py --op=Reciprocal --csv
 
 # 2. Convert an existing Parquet file to CSV (no hardware run needed):
 python -m accuracy.to_csv accuracy/_csv_output/wh/exp.parquet   # one file

--- a/tt_metal/tt-llk/docs/tests/getting_started.md
+++ b/tt_metal/tt-llk/docs/tests/getting_started.md
@@ -475,6 +475,7 @@ There are few custom `pytest` command line arguments exposed that enable alterin
 | `--no-debug-symbols` | Compile elfs without debug symbols (`-g` sfpi flag) to save disk space |
 | `--logging-level [TRACE \| DEBUG \| INFO \| WARNING \| ERROR \| CRITICAL]` | Sets loguru log level. Overrides `LOGURU_LEVEL` env var. Default: INFO |
 | `--detailed-artefacts` | Adds `-save-temps=obj -fdump-tree-all -fdump-rtl-all -v` compilation flags when compiling kernel elfs, allowing generation of compiler level debug information, used when debugging compiler bugs |
+| `--op=OP` | Run only tests for the given op(s), matched by `MathOperation` name (case-insensitive, exact). Repeatable: `--op=exp --op=log` |
 
 ## Usage examples
 

--- a/tt_metal/tt-llk/tests/python_tests/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/conftest.py
@@ -479,26 +479,75 @@ def _collapse_runtime_only_variants(config, items):
         items[:] = keep
 
 
-_SFPU_OPS_HEADER = (
-    Path(__file__).resolve().parent.parent / "helpers" / "include" / "sfpu_operations.h"
+# SFPU ops that --op accepts, as lowercased MathOperation names. These are the
+# ops with a `SfpuType::<name>` case in tests/helpers/include/sfpu_operations.h.
+# Keep this in sync with that header: when you add a new `SfpuType::` case there,
+# add its MathOperation name here too, otherwise `--op <op>` errors out (by
+# design: it forces the table to stay current with the header).
+SUPPORTED_SFPU_OPS = frozenset(
+    {
+        "abs",
+        "atanh",
+        "asinh",
+        "acosh",
+        "celu",
+        "cos",
+        "elu",
+        "exp",
+        "exp2",
+        "fill",
+        "gelu",
+        "gelutanh",
+        "hardsigmoid",
+        "log",
+        "log1p",
+        "neg",
+        "reciprocal",
+        "rsqrt",
+        "sigmoid",
+        "sin",
+        "silu",
+        "signbit",
+        "sqrt",
+        "square",
+        "erfinv",
+        "heaviside",
+        "softshrink",
+        "softsign",
+        "mish",
+        "selu",
+        "i0",
+        "rdiv",
+        "clamp",
+        "hardtanh",
+        "tanhshrink",
+        "floor",
+        "ceil",
+        "trunc",
+        "frac",
+        "equalzero",
+        "notequalzero",
+        "lessthanzero",
+        "greaterthanzero",
+        "lessthanequalzero",
+        "greaterthanequalzero",
+        "tanh",
+        "typecast",
+        "threshold",
+        "relumax",
+        "relumin",
+        "lrelu",
+        "addint32",
+        "subint32",
+        "topklocalsort",
+        "topkmerge",
+        "topkrebuild",
+        "sfpuaddcmul",
+        "sfpuaddcdiv",
+        "sfpulerp",
+        "sfpusnakebeta",
+    }
 )
-
-
-def _sfpu_operations_header_text() -> str:
-    try:
-        return _SFPU_OPS_HEADER.read_text()
-    except OSError:
-        return ""
-
-
-def _op_defined_in_header(cpp_enum_value: str, header_text: str) -> bool:
-    """Whether an op's C++ enum name is referenced in sfpu_operations.h.
-
-    If the header can't be read we return True so we never emit false warnings.
-    """
-    if not header_text:
-        return True
-    return re.search(rf"\b{re.escape(cpp_enum_value)}\b", header_text) is not None
 
 
 def _item_op_names(item) -> set:
@@ -526,38 +575,25 @@ def _select_tests_by_op(config, items):
     """Run only the tests for the op(s) passed with --op.
 
     Matching is case-insensitive and exact, so "exp" selects Exp but not Exp2.
-    If op isn't listed in sfpu_operations.h it is still run, just with a warning
-    that it may not work. A name that isn't an SFPU op at all is skipped with a warning.
+    Each op must be listed in SUPPORTED_SFPU_OPS; an op that isn't (a typo, or a
+    new op added to sfpu_operations.h but not to the table) raises an error.
     Does nothing when --op isn't given.
     """
     requested = config.getoption("--op") or []
     if not requested:
         return
 
-    from helpers.llk_params import MathOperation
-
-    by_name = {op.name.lower(): op for op in MathOperation}
-    header_text = _sfpu_operations_header_text()
-
     wanted = set()
     for raw in requested:
-        op = by_name.get(raw.lower())
-        if op is None:
-            logger.warning(
-                f"--op {raw!r}: not a known SFPU op (MathOperation) — ignoring. "
-                f"Names are case-insensitive, e.g. Exp, Reciprocal, Gelu."
+        key = raw.lower()
+        if key not in SUPPORTED_SFPU_OPS:
+            raise pytest.UsageError(
+                f"--op {raw!r}: not a supported SFPU op. Supported ops are listed "
+                f"in SUPPORTED_SFPU_OPS in tests/python_tests/conftest.py. If you "
+                f"added this op to sfpu_operations.h, add its MathOperation name "
+                f"to that table too."
             )
-            continue
-        cpp = op.value.cpp_enum_value
-        if not _op_defined_in_header(cpp, header_text):
-            logger.warning(
-                f"--op {raw!r}: '{op.name}' (C++ '{cpp}') is not defined in "
-                f"sfpu_operations.h; its tests may not build or run."
-            )
-        wanted.add(op.name.lower())
-
-    if not wanted:
-        return
+        wanted.add(key)
 
     selected, deselected = [], []
     for item in items:

--- a/tt_metal/tt-llk/tests/python_tests/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/conftest.py
@@ -280,6 +280,18 @@ def pytest_addoption(parser):
         "setting TT_METAL_DISABLE_SFPLOADMACRO=1).",
     )
 
+    parser.addoption(
+        "--op",
+        action="append",
+        default=[],
+        metavar="OP",
+        help="Run only tests for the given SFPU op(s), matched by MathOperation "
+        "name (case-insensitive, EXACT — so '--op exp' does not also select "
+        "Exp2). Repeatable: --op exp --op log. Every SFPU op is accepted, but "
+        "ops not defined in helpers/include/sfpu_operations.h are still selected "
+        "with a warning (their tests may not build/run).",
+    )
+
 
 _RECORD_TEST_ORDER: bool = False
 _UNIFIED_ORDER_FILE: str = "DEFAULT"
@@ -467,8 +479,102 @@ def _collapse_runtime_only_variants(config, items):
         items[:] = keep
 
 
+_SFPU_OPS_HEADER = (
+    Path(__file__).resolve().parent.parent / "helpers" / "include" / "sfpu_operations.h"
+)
+
+
+def _sfpu_operations_header_text() -> str:
+    try:
+        return _SFPU_OPS_HEADER.read_text()
+    except OSError:
+        return ""
+
+
+def _op_defined_in_header(cpp_enum_value: str, header_text: str) -> bool:
+    """Whether an op's C++ enum name is referenced in sfpu_operations.h.
+
+    If the header can't be read we return True so we never emit false warnings.
+    """
+    if not header_text:
+        return True
+    return re.search(rf"\b{re.escape(cpp_enum_value)}\b", header_text) is not None
+
+
+def _item_op_names(item) -> set:
+    """Return the SFPU op name(s) a test covers, lowercased (e.g. {"exp"}).
+
+    First looks for a MathOperation in the test's parameters. If there isn't
+    one, it reads the op name from the test id instead (e.g. "MathOperation.Exp").
+    """
+    from helpers.llk_params import MathOperation
+
+    names = set()
+    callspec = getattr(item, "callspec", None)
+    if callspec is not None:
+        for val in callspec.params.values():
+            if isinstance(val, MathOperation):
+                names.add(val.name.lower())
+    if not names:
+        names.update(
+            m.lower() for m in re.findall(r"MathOperation\.(\w+)", item.nodeid)
+        )
+    return names
+
+
+def _select_tests_by_op(config, items):
+    """Run only the tests for the op(s) passed with --op.
+
+    Matching is case-insensitive and exact, so "exp" selects Exp but not Exp2.
+    If op isn't listed in sfpu_operations.h it is still run, just with a warning
+    that it may not work. A name that isn't an SFPU op at all is skipped with a warning.
+    Does nothing when --op isn't given.
+    """
+    requested = config.getoption("--op") or []
+    if not requested:
+        return
+
+    from helpers.llk_params import MathOperation
+
+    by_name = {op.name.lower(): op for op in MathOperation}
+    header_text = _sfpu_operations_header_text()
+
+    wanted = set()
+    for raw in requested:
+        op = by_name.get(raw.lower())
+        if op is None:
+            logger.warning(
+                f"--op {raw!r}: not a known SFPU op (MathOperation) — ignoring. "
+                f"Names are case-insensitive, e.g. Exp, Reciprocal, Gelu."
+            )
+            continue
+        cpp = op.value.cpp_enum_value
+        if not _op_defined_in_header(cpp, header_text):
+            logger.warning(
+                f"--op {raw!r}: '{op.name}' (C++ '{cpp}') is not defined in "
+                f"sfpu_operations.h; its tests may not build or run."
+            )
+        wanted.add(op.name.lower())
+
+    if not wanted:
+        return
+
+    selected, deselected = [], []
+    for item in items:
+        (selected if _item_op_names(item) & wanted else deselected).append(item)
+
+    if deselected:
+        config.hook.pytest_deselected(items=deselected)
+        items[:] = selected
+    logger.info(
+        f"--op kept {len(selected)} test(s) for op(s): {', '.join(sorted(wanted))}"
+    )
+
+
 @pytest.hookimpl(tryfirst=True)
 def pytest_collection_modifyitems(config, items):
+    _select_tests_by_op(config, items)
+
     if TestConfig.BUILD_MODE == BuildMode.PRODUCE and not TestConfig.SPEED_OF_LIGHT:
         _collapse_runtime_only_variants(config, items)
 

--- a/tt_metal/tt-llk/tests/python_tests/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/conftest.py
@@ -285,11 +285,8 @@ def pytest_addoption(parser):
         action="append",
         default=[],
         metavar="OP",
-        help="Run only tests for the given SFPU op(s), matched by MathOperation "
-        "name (case-insensitive, EXACT — so '--op exp' does not also select "
-        "Exp2). Repeatable: --op exp --op log. Every SFPU op is accepted, but "
-        "ops not defined in helpers/include/sfpu_operations.h are still selected "
-        "with a warning (their tests may not build/run).",
+        help="Run only tests for the given SFPU op(s), by MathOperation name "
+        "(case-insensitive, exact). Repeatable: --op=exp --op=log.",
     )
 
 
@@ -479,82 +476,10 @@ def _collapse_runtime_only_variants(config, items):
         items[:] = keep
 
 
-# SFPU ops that --op accepts, as lowercased MathOperation names. These are the
-# ops with a `SfpuType::<name>` case in tests/helpers/include/sfpu_operations.h.
-# Keep this in sync with that header: when you add a new `SfpuType::` case there,
-# add its MathOperation name here too, otherwise `--op <op>` errors out (by
-# design: it forces the table to stay current with the header).
-SUPPORTED_SFPU_OPS = frozenset(
-    {
-        "abs",
-        "atanh",
-        "asinh",
-        "acosh",
-        "celu",
-        "cos",
-        "elu",
-        "exp",
-        "exp2",
-        "fill",
-        "gelu",
-        "gelutanh",
-        "hardsigmoid",
-        "log",
-        "log1p",
-        "neg",
-        "reciprocal",
-        "rsqrt",
-        "sigmoid",
-        "sin",
-        "silu",
-        "signbit",
-        "sqrt",
-        "square",
-        "erfinv",
-        "heaviside",
-        "softshrink",
-        "softsign",
-        "mish",
-        "selu",
-        "i0",
-        "rdiv",
-        "clamp",
-        "hardtanh",
-        "tanhshrink",
-        "floor",
-        "ceil",
-        "trunc",
-        "frac",
-        "equalzero",
-        "notequalzero",
-        "lessthanzero",
-        "greaterthanzero",
-        "lessthanequalzero",
-        "greaterthanequalzero",
-        "tanh",
-        "typecast",
-        "threshold",
-        "relumax",
-        "relumin",
-        "lrelu",
-        "addint32",
-        "subint32",
-        "topklocalsort",
-        "topkmerge",
-        "topkrebuild",
-        "sfpuaddcmul",
-        "sfpuaddcdiv",
-        "sfpulerp",
-        "sfpusnakebeta",
-    }
-)
-
-
 def _item_op_names(item) -> set:
-    """Return the SFPU op name(s) a test covers, lowercased (e.g. {"exp"}).
+    """Return the op name(s) a test covers, lowercased.
 
-    First looks for a MathOperation in the test's parameters. If there isn't
-    one, it reads the op name from the test id instead (e.g. "MathOperation.Exp").
+    Reads the MathOperation from the test's parameters, falling back to the op name in the test id.
     """
     from helpers.llk_params import MathOperation
 
@@ -574,24 +499,24 @@ def _item_op_names(item) -> set:
 def _select_tests_by_op(config, items):
     """Run only the tests for the op(s) passed with --op.
 
-    Matching is case-insensitive and exact, so "exp" selects Exp but not Exp2.
-    Each op must be listed in SUPPORTED_SFPU_OPS; an op that isn't (a typo, or a
-    new op added to sfpu_operations.h but not to the table) raises an error.
-    Does nothing when --op isn't given.
+    Each op is a MathOperation name, matched case-insensitively and exactly. An
+    unknown name raises an error; a valid op with no matching test selects
+    nothing. Does nothing without --op.
     """
     requested = config.getoption("--op") or []
     if not requested:
         return
 
+    from helpers.llk_params import MathOperation
+
+    valid = {op.name.lower() for op in MathOperation}
     wanted = set()
     for raw in requested:
         key = raw.lower()
-        if key not in SUPPORTED_SFPU_OPS:
+        if key not in valid:
             raise pytest.UsageError(
-                f"--op {raw!r}: not a supported SFPU op. Supported ops are listed "
-                f"in SUPPORTED_SFPU_OPS in tests/python_tests/conftest.py. If you "
-                f"added this op to sfpu_operations.h, add its MathOperation name "
-                f"to that table too."
+                f"--op {raw!r}: not a known SFPU op. Expected a MathOperation "
+                f"name (case-insensitive), e.g. Exp, Reciprocal, Gelu."
             )
         wanted.add(key)
 


### PR DESCRIPTION
### Summary
Selecting a single op with `-k` is error-prone: `-k Exp` also matches
`Exp2` (substring match), so we have to write `-k "Exp and not Exp2"`.

This adds an `--op` pytest option (in the top-level `python_tests/conftest.py`,
so it works for all python tests) that filters by **exact** MathOperation name,
case-insensitive (`--op Exp` selects Exp, not Exp2). It's repeatable
(`--op Exp --op Log`) and composes with `-k`/`-m`.

An op is validated against the `MathOperation` enum: an unknown name errors out;
a valid op with no matching test simply selects nothing.

### Notes for reviewers
- `--op` takes **MathOperation** names (case-insensitive), which is what the
  test IDs use — e.g. `--op Exp`, `--op SfpuSnakeBeta`. Not the C++ `SfpuType`
  spellings (`exponential`, `snake_beta`).
- Filtering reads each test's op from its parametrized `MathOperation`, falling
  back to the `MathOperation.<Name>` token in the node id for tests where the op
  isn't a direct parameter.
- Validation only checks that the name is a real `MathOperation`; it does not
  check whether the op has a test or is implemented on the current arch.
- No behavior change when `--op` isn't passed.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jmacanovic/accuracy-op-filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jmacanovic/accuracy-op-filter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jmacanovic/accuracy-op-filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jmacanovic/accuracy-op-filter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jmacanovic/accuracy-op-filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jmacanovic/accuracy-op-filter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jmacanovic/accuracy-op-filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jmacanovic/accuracy-op-filter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jmacanovic/accuracy-op-filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jmacanovic/accuracy-op-filter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jmacanovic/accuracy-op-filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jmacanovic/accuracy-op-filter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jmacanovic/accuracy-op-filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jmacanovic/accuracy-op-filter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jmacanovic/accuracy-op-filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jmacanovic/accuracy-op-filter)