### PR TITLE
[LLK] Fix #46769: Compute API gap: matmul after a binary op with asymmetric SrcA/SrcB tile sizes (same formats) can't be re-inited

### DIFF
--- a/tt_metal/hw/inc/api/compute/matmul.h
+++ b/tt_metal/hw/inc/api/compute/matmul.h
@@ -83,10 +83,12 @@ ALWI void matmul_block_math_dynamic_throttle(
  * Matmul maps in0 -> SrcB and in1 -> SrcA (the reverse of other ops), which is why
  * compute_kernel_hw_startup must use SrcOrder::Reverse.
  *
- * NOTE (known gap, #46769): if a preceding op left SrcA/SrcB with asymmetric tile sizes (i.e. different
- * data formats per source) and the following matmul uses the same formats, matmul_init cannot fix the
- * per-source tile sizes on its own. It does not re-program the tile descriptor, and a reconfig_data_format
- * is inappropriate when the data formats did not change. No current kernel hits this; tracked in #46769.
+ * NOTE: if a preceding op left SrcA/SrcB with asymmetric tile sizes (i.e. different data formats per
+ * source) and the following matmul uses the same formats, matmul_init cannot fix the per-source tile sizes
+ * on its own: it does not re-program the tile descriptor, and a reconfig_data_format is inappropriate when
+ * the data formats did not change. In that case, call reconfig_matmul_tile_dims(in0_cb_id, in1_cb_id) (from
+ * reconfig_data_format.h) immediately before matmul_init to re-assert the per-source tile sizes. It is
+ * opt-in, so the common symmetric-tile case pays nothing.
  *
  * Return value: None
  *
@@ -149,11 +151,12 @@ ALWI void matmul_tiles(
  * Matmul maps in0 -> SrcB and in1 -> SrcA (the reverse of other ops), which is why
  * compute_kernel_hw_startup must use SrcOrder::Reverse.
  *
- * NOTE (known gap, #46769): if a preceding op left SrcA/SrcB with asymmetric tile sizes (i.e. different
- * data formats per source) and the following matmul uses the same formats, matmul_block_init cannot fix
- * the per-source tile sizes on its own. It does not re-program the tile descriptor, and a
- * reconfig_data_format is inappropriate when the data formats did not change. No current kernel hits this;
- * tracked in #46769.
+ * NOTE: if a preceding op left SrcA/SrcB with asymmetric tile sizes (i.e. different data formats per
+ * source) and the following matmul uses the same formats, matmul_block_init cannot fix the per-source tile
+ * sizes on its own: it does not re-program the tile descriptor, and a reconfig_data_format is inappropriate
+ * when the data formats did not change. In that case, call reconfig_matmul_tile_dims(in0_cb_id, in1_cb_id)
+ * (from reconfig_data_format.h) immediately before matmul_block_init to re-assert the per-source tile sizes.
+ * It is opt-in, so the common symmetric-tile case pays nothing.
  *
  * Return value: None
  *

--- a/tt_metal/hw/inc/api/compute/reconfig_data_format.h
+++ b/tt_metal/hw/inc/api/compute/reconfig_data_format.h
@@ -142,6 +142,57 @@ ALWI void reconfig_data_format_srcb(const uint32_t srcb_old_operand, const uint3
 
 // clang-format off
 /**
+ * Re-programs the per-source matmul tile descriptors and TILE_SIZE_A/B GPRs from the given input CBs
+ * *without* changing data formats. Call it immediately before matmul_init / matmul_block_init when the
+ * preceding op left SrcA/SrcB with asymmetric tile sizes (i.e. different data formats per source) and the
+ * following matmul reuses the same formats.
+ *
+ * Why it is needed: matmul_init only reprograms the transpose Haloize mode, the matmul x_end SETADC, the
+ * KT_DIM GPR, and the MOP; it never re-writes the THCON tile descriptors or the TILE_SIZE_A/B GPRs. A plain
+ * reconfig_data_format is inappropriate here because the data formats did not change. This helper re-asserts
+ * only the tile-dimension / tile-size state, in matmul's reversed operand order (in0 -> SrcB, in1 -> SrcA),
+ * so the matmul addresses each source correctly. The reversal is kept local to this helper, so callers pass
+ * (in0_cb_id, in1_cb_id) in natural order.
+ *
+ * This matters only for multi-tile / multi-block matmuls: the per-tile base offsets are computed at runtime
+ * from fifo_page_size (always correct), but the MOP base-address auto-increment and the K-walk stride are
+ * driven by the TILE_SIZE_A/B GPRs this helper reprograms.
+ *
+ * It is opt-in and costs a few CFG writes, so the common symmetric-tile case pays nothing (do not call it).
+ * It performs no data-format change; it only re-asserts tile-dim / tile-size state.
+ *
+ * NOTE(ARCH_QUASAR): No-op on Quasar. Buffer descriptors are programmed into the unpack MOP at op init, so a
+ * separate tile-dim reconfig is neither needed nor sufficient (the MOP is what matters). On Quasar, simply
+ * call matmul_init(in0_cb_id, in1_cb_id) next, which reprograms the descriptors via the MOP.
+ *
+ * Return value: None
+ *
+ * | Param Type | Name      | Description                                          | Type     | Valid Range | Required |
+ * |------------|-----------|------------------------------------------------------|----------|-------------|----------|
+ * | Function   | in0_cb_id | First matmul input CB (feeds SrcB in matmul order)   | uint32_t | 0 to 31     | True     |
+ * | Function   | in1_cb_id | Second matmul input CB (feeds SrcA in matmul order)  | uint32_t | 0 to 31     | True     |
+ */
+// clang-format on
+ALWI void reconfig_matmul_tile_dims(const uint32_t in0_cb_id, const uint32_t in1_cb_id) {
+    LLK_SAN_FUNCTION();
+#ifdef ARCH_QUASAR
+    // NOTE(ARCH_QUASAR): intentional no-op. On Quasar the per-source tile descriptors live in the unpack MOP and
+    // are (re)programmed at op init, so re-asserting the descriptor / TILE_SIZE state here is neither needed nor
+    // sufficient. Call matmul_init(in0_cb_id, in1_cb_id) next to reprogram the descriptors via the MOP.
+    (void)in0_cb_id;
+    (void)in1_cb_id;
+#else
+    // Matmul maps in1 -> SrcA and in0 -> SrcB (the reverse of other ops), mirroring the swap in
+    // llk_unpack_AB_matmul_init. is_tile_dim_reconfig_en routes these single-operand wrappers to
+    // p_dim_stride_target::FACE_ROW_MAJOR, reprogramming the THCON tile descriptor + TILE_SIZE_A/B GPR +
+    // Z/Y-stride + x-end without changing the data format.
+    reconfig_data_format_srca<false /*to_from_int8*/, true /*is_tile_dim_reconfig_en*/>(in1_cb_id);  // in1 -> SrcA
+    reconfig_data_format_srcb<false /*to_from_int8*/, true /*is_tile_dim_reconfig_en*/>(in0_cb_id);  // in0 -> SrcB
+#endif
+}
+
+// clang-format off
+/**
  * Reconfigures the packer output data format by specifying the CB ID of the new operand. This function
  * call will always perform the reconfiguration, regardless of the data format of the old operand.
  * If the new CB ID is the same as the current one, reconfiguration will still occur.


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

[LLK] Compute API gap: matmul after a binary op with asymmetric SrcA/SrcB tile sizes (same formats) can't be re-inited

Add opt-in compute-API helper reconfig_matmul_tile_dims(in0_cb_id, in1_cb_id)
that re-programs the per-source THCON tile descriptors + TILE_SIZE_A/B GPRs from
the input CBs without changing data formats, in matmul's reversed operand order
(in1 -> SrcA, in0 -> SrcB). Closes the gap where a matmul that follows a binary
op with asymmetric SrcA/SrcB tile sizes (same formats) could not re-assert the
reversed per-source tile sizes. No-op on Quasar (descriptors live in the MOP).
Update matmul_init / matmul_block_init NOTE blocks to point at the new helper.

Fixes #46769

### Notes for reviewers

Diffstat: 2 files changed, 63 insertions(+), 9 deletions(-).

Files touched:
- `tt_metal/hw/inc/api/compute/matmul.h`
- `tt_metal/hw/inc/api/compute/reconfig_data_format.h`

<sub>Opened by the LLK issue-triage board (AI-assisted, draft) — please review the diff before merging.</sub>

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-46769-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llk_code_gen/issue-46769-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-46769-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llk_code_gen/issue-46769-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-46769-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:llk_code_gen/issue-46769-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llk_code_gen/issue-46769-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llk_code_gen/issue-46769-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llk_code_gen/issue-46769-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llk_code_gen/issue-46769-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llk_code_gen/issue-46769-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llk_code_gen/issue-46769-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llk_code_gen/issue-46769-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llk_code_gen/issue-46769-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llk_code_gen/issue-46769-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llk_code_gen/issue-46769-v2)