### PR TITLE
[LLK] Fix #46325: Remove default CB id values from unpack and pack thread LLK APIs

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_pack.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_pack.cpp
@@ -89,9 +89,9 @@ inline void pack_block(
 
 void kernel_main() {
     uint32_t in0_block_w = get_compile_time_arg_val(0);
-    llk_pack_init();
-    llk_pack_dest_init<DST_ACCUM_MODE, PackMode::Default>();
-    llk_init_packer_dest_offset_registers<PackMode::Default>();
+    llk_pack_init(16 /* pack_output */);
+    llk_pack_dest_init<DST_ACCUM_MODE, PackMode::Default>(16 /* pack_output */);
+    llk_init_packer_dest_offset_registers<PackMode::Default>(16 /* pack_output */);
     llk_pack_hw_configure<DST_ACCUM_MODE>(16);
     // inner block size in tiles
     uint32_t in0_num_subblocks = get_compile_time_arg_val(1);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_3m.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_3m.cpp
@@ -34,9 +34,9 @@ void core_agnostic_main() {
 
 void core_agnostic_main() {
     int __outer_loop_iter;
-    llk_pack_init();
+    llk_pack_init(16 /* pack_output */);
     llk_pack_hw_configure<DST_ACCUM_MODE>(16);
-    llk_pack_dest_init<DST_ACCUM_MODE, PackMode::Default>();
+    llk_pack_dest_init<DST_ACCUM_MODE, PackMode::Default>(16 /* pack_output */);
     constexpr uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
     for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
         llk_packer_wait_for_math_done();
@@ -51,7 +51,8 @@ void core_agnostic_main() {
 #ifdef TRISC_UNPACK
 void core_agnostic_main() {
     int __outer_loop_iter;
-    UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE>()));
+    UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE>(
+        0 /*transpose_of_faces*/, 0 /*within_face_16x16_transpose*/, 0 /*operand*/)));
     UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(0)));
     constexpr uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
     for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_common_api.h
@@ -109,10 +109,10 @@ inline void llk_pack_dest_section_done() {
  *
  * @tparam pack_mode   Packer program mode (Default or Untilize; Tilize is not used on this path).
  * @tparam diagonal    Diagonal packing flag (unused on Blackhole).
- * @param  pack_output Output circular buffer / operand index (defaults to 16).
+ * @param  pack_output Output circular buffer / operand index.
  */
 template <PackMode pack_mode = PackMode::Default, bool diagonal = false>
-inline void llk_init_packer_dest_offset_registers([[maybe_unused]] const std::uint32_t pack_output = 16) {
+inline void llk_init_packer_dest_offset_registers([[maybe_unused]] const std::uint32_t pack_output) {
     static_assert(
         pack_mode == PackMode::Default || pack_mode == PackMode::Untilize,
         "Blackhole llk_init_packer_dest_offset_registers: PackMode::Tilize is not used on this path");
@@ -125,10 +125,10 @@ inline void llk_init_packer_dest_offset_registers([[maybe_unused]] const std::ui
  *
  * @tparam is_fp32_dest_acc_en Enable FP32 accumulation in the destination register.
  * @tparam pack_mode           Packer program mode (Default or Untilize; Tilize is not used on this path).
- * @param  pack_output         Output circular buffer / operand index (defaults to 16).
+ * @param  pack_output         Output circular buffer / operand index.
  */
 template <bool is_fp32_dest_acc_en, PackMode pack_mode = PackMode::Default>
-inline void llk_pack_dest_init([[maybe_unused]] const std::uint32_t pack_output = 16) {
+inline void llk_pack_dest_init([[maybe_unused]] const std::uint32_t pack_output) {
     static_assert(
         pack_mode == PackMode::Default || pack_mode == PackMode::Untilize,
         "Blackhole llk_pack_dest_init: PackMode::Tilize is not used on this path");

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_tile_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_tile_api.h
@@ -16,7 +16,7 @@ template <
     bool skip_addrmod_config = false,
     bool skip_packer_strides = false>
 inline void llk_pack_init(
-    const std::uint32_t pack_output = 16, std::uint32_t num_tiles = 1, const std::uint32_t input_operand = 0) {
+    const std::uint32_t pack_output, std::uint32_t num_tiles = 1, const std::uint32_t input_operand = 0) {
     // TODO (https://github.com/tenstorrent/tt-metal/issues/18948): Revisit for narrow_tile
     const std::uint32_t output_id = get_output_id(pack_output);
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
@@ -16,9 +16,9 @@ template <
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
     bool unpack_to_dest = false>
 inline void llk_unpack_A_init(
-    const std::uint32_t transpose_of_faces = 0,
-    const std::uint32_t within_face_16x16_transpose = 0,
-    const std::uint32_t operand = 0) {
+    const std::uint32_t transpose_of_faces,
+    const std::uint32_t within_face_16x16_transpose,
+    const std::uint32_t operand) {
     const std::uint32_t operand_id = get_operand_id(operand);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_untilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_untilize_api.h
@@ -16,7 +16,7 @@
  * compute API and are scheduled for removal; see tt-metal#22904.
  *************************************************************************/
 
-inline void llk_unpack_untilize_init(std::uint32_t operand = 0) {
+inline void llk_unpack_untilize_init(std::uint32_t operand) {
     const std::uint32_t operand_id = get_operand_id(operand);
     const std::uint32_t face_r_dim = 1;
 

--- a/tt_metal/hw/inc/api/compute/bcast.h
+++ b/tt_metal/hw/inc/api/compute/bcast.h
@@ -56,7 +56,7 @@ ALWI void unary_bcast_init(uint32_t icb, uint32_t ocb, uint32_t call_line = __bu
 
     PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(ocb)));
     PACK((llk_pack_init(ocb)));
-    PACK((llk_pack_dest_init<DST_ACCUM_MODE, PackMode::Default>()));
+    PACK((llk_pack_dest_init<DST_ACCUM_MODE, PackMode::Default>(ocb)));
 #else
     UNPACK((llk_unpack_hw_configure(icb)));
 #if defined(TRISC_UNPACK) || defined(TRISC_MATH)
@@ -321,7 +321,7 @@ void init_bcast(uint32_t icb0, uint32_t icb1, uint32_t ocb, uint32_t call_line =
 
     PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(ocb)));
     PACK((llk_pack_init(ocb)));
-    PACK((llk_pack_dest_init<DST_ACCUM_MODE, PackMode::Default>()));
+    PACK((llk_pack_dest_init<DST_ACCUM_MODE, PackMode::Default>(ocb)));
 
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
     MATH((llk_math_hw_configure<DST_ACCUM_MODE>(icb0, icb1)));

--- a/tt_metal/hw/inc/api/compute/eltwise_binary.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_binary.h
@@ -40,7 +40,7 @@ ALWI void binary_op_init_common(uint32_t icb0, uint32_t icb1, uint32_t ocb, uint
 
     PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(ocb)));
     PACK((llk_pack_init(ocb)));
-    PACK((llk_pack_dest_init<DST_ACCUM_MODE, PackMode::Default>()));
+    PACK((llk_pack_dest_init<DST_ACCUM_MODE, PackMode::Default>(ocb)));
 #else
     UNPACK((llk_unpack_hw_configure(icb0, icb1)));
     UNPACK((llk_unpack_AB_init<BroadcastType::NONE>(icb0, icb1)));

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/eltwise_unary.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/eltwise_unary.h
@@ -25,7 +25,7 @@ ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb, uint32_t call_line = 
 
     PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(ocb)));
     PACK((llk_pack_init(ocb)));
-    PACK((llk_pack_dest_init<DST_ACCUM_MODE, PackMode::Default>()));
+    PACK((llk_pack_dest_init<DST_ACCUM_MODE, PackMode::Default>(ocb)));
 
     MATH((llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));

--- a/tt_metal/hw/inc/api/compute/experimental/fast_untilize.h
+++ b/tt_metal/hw/inc/api/compute/experimental/fast_untilize.h
@@ -167,7 +167,7 @@ ALWI void fast_untilize_uninit(uint32_t ocb) {
     if constexpr (DST_SYNC_MODE != FAST_UNTILIZE_INTERNAL_DST_SYNC_MODE) {
         MATH((_llk_math_pack_sync_init_<DST_SYNC_MODE, DST_ACCUM_MODE>()));
     }
-    PACK((llk_init_packer_dest_offset_registers<PackMode::Default>()));
+    PACK((llk_init_packer_dest_offset_registers<PackMode::Default>(ocb)));
     PACK((llk_pack_reconfig_data_format<DST_ACCUM_MODE>(ocb)));
     PACK((llk_pack_init(ocb)));
     PACK((llk_pack_fast_untilize_uninit<FAST_UNTILIZE_MAX_UNIT_DIM, full_ct_dim>(ocb)));

--- a/tt_metal/hw/inc/api/compute/matmul.h
+++ b/tt_metal/hw/inc/api/compute/matmul.h
@@ -291,7 +291,7 @@ mm_init(
     MATH((llk_math_matmul_init<MATH_FIDELITY, MM_THROTTLE>(in0_cb_id, in1_cb_id, transpose)));
 
     PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(out_cb_id)));
-    PACK((llk_pack_dest_init<DST_ACCUM_MODE, PackMode::Default>()));
+    PACK((llk_pack_dest_init<DST_ACCUM_MODE, PackMode::Default>(out_cb_id)));
     PACK((llk_pack_init(out_cb_id)));
 #else
     LLK_ASSERT(transpose == 0, "non-default transpose not supported on Quasar");
@@ -414,7 +414,7 @@ mm_block_init(
 #endif
 
     PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(out_cb_id)));
-    PACK((llk_pack_dest_init<DST_ACCUM_MODE, PackMode::Default>()));
+    PACK((llk_pack_dest_init<DST_ACCUM_MODE, PackMode::Default>(out_cb_id)));
     PACK((llk_pack_init<PackMode::Default, false /* zero_output */>(out_cb_id)));
 #else
     LLK_ASSERT(transpose == 0, "non-default transpose not supported on Quasar");

--- a/tt_metal/hw/inc/api/compute/pack_untilize.h
+++ b/tt_metal/hw/inc/api/compute/pack_untilize.h
@@ -41,7 +41,7 @@ ALWI void pack_untilize_dest_init_impl(uint32_t ocb, uint32_t call_line = __buil
     PACK((llk_pack_reconfig_data_format<DST_ACCUM_MODE>(ocb)));
     PACK((
         llk_pack_untilize_init<block_ct_dim, full_ct_dim, false /*diagonal*/, narrow_row, row_num_datums, dense>(ocb)));
-    PACK((llk_init_packer_dest_offset_registers<PackMode::Untilize, false /*diagonal*/>()));
+    PACK((llk_init_packer_dest_offset_registers<PackMode::Untilize, false /*diagonal*/>(ocb)));
 #else
     static_assert(narrow_row == false, "non-default narrow_row not supported on Quasar");
     static_assert(row_num_datums == TILE_C_DIM, "non-default row_num_datums not supported on Quasar");
@@ -337,7 +337,7 @@ ALWI void pack_untilize_uninit(uint32_t ocb) {
     // Init is called to ensure special untilize init overrides are cleaned up.
     {
         LLK_SAN_SILENT_ZONE();
-        PACK((llk_init_packer_dest_offset_registers<PackMode::Default>()));
+        PACK((llk_init_packer_dest_offset_registers<PackMode::Default>(ocb)));
         PACK((llk_pack_reconfig_data_format<DST_ACCUM_MODE>(ocb)));
         PACK((llk_pack_init(ocb)));
     }

--- a/tt_metal/hw/inc/api/compute/transpose_wh.h
+++ b/tt_metal/hw/inc/api/compute/transpose_wh.h
@@ -100,7 +100,7 @@ transpose_wh_init(uint32_t icb, uint32_t ocb, uint32_t call_line = __builtin_LIN
 #ifndef ARCH_QUASAR
     PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(ocb)));
     PACK((llk_pack_init(ocb)));
-    PACK((llk_pack_dest_init<DST_ACCUM_MODE, PackMode::Default>()));
+    PACK((llk_pack_dest_init<DST_ACCUM_MODE, PackMode::Default>(ocb)));
 #else
     PACK((llk_pack_hw_configure(ocb)));
     PACK((llk_pack_init(ocb)));


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Remove default CB id values from unpack and pack thread LLK APIs

Fixes #46325

### Notes for reviewers

Diffstat: 13 files changed, 26 insertions(+), 25 deletions(-).

Files touched:
- `tests/tt_metal/tt_metal/test_kernels/compute/3T/matmul_large_block_zm/zm_3m_pack.cpp`
- `tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_3m.cpp`
- `tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_common_api.h`
- `tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_tile_api.h`
- `tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h`
- `tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_untilize_api.h`
- `tt_metal/hw/inc/api/compute/bcast.h`
- `tt_metal/hw/inc/api/compute/eltwise_binary.h`
- `tt_metal/hw/inc/api/compute/eltwise_unary/eltwise_unary.h`
- `tt_metal/hw/inc/api/compute/experimental/fast_untilize.h`
- `tt_metal/hw/inc/api/compute/matmul.h`
- `tt_metal/hw/inc/api/compute/pack_untilize.h`
- `tt_metal/hw/inc/api/compute/transpose_wh.h`

<sub>Opened by the LLK issue-triage board (AI-assisted, draft) — please review the diff before merging.</sub>

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-46325-v4)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llk_code_gen/issue-46325-v4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-46325-v4)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llk_code_gen/issue-46325-v4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-46325-v4)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:llk_code_gen/issue-46325-v4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llk_code_gen/issue-46325-v4)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llk_code_gen/issue-46325-v4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llk_code_gen/issue-46325-v4)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llk_code_gen/issue-46325-v4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llk_code_gen/issue-46325-v4)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llk_code_gen/issue-46325-v4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llk_code_gen/issue-46325-v4)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llk_code_gen/issue-46325-v4)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llk_code_gen/issue-46325-v4)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llk_code_gen/issue-46325-v4)