### PR TITLE
fix hangs in Wan on quad and realign ccl multihost ring geometry introduced from PR#46138

### DIFF
--- a/models/tt_dit/encoders/gemma/encoder_pair.py
+++ b/models/tt_dit/encoders/gemma/encoder_pair.py
@@ -222,6 +222,7 @@ class GemmaTokenizerEncoderPair:
             subfolder="text_encoder",
             parallel_config=self.parallel_config,
             mesh_shape=tuple(self.mesh_device.shape),
+            mesh_device=self.mesh_device,
             get_torch_state_dict=lambda: _gemma_state_dict(gemma_path),
         )
         logger.info(f"Loaded TTNN Gemma encoder ({self._num_layers}L) in {time.time()-t0:.0f}s")
@@ -267,6 +268,7 @@ class GemmaTokenizerEncoderPair:
             subfolder="feature_extractor",
             parallel_config=self.parallel_config,
             mesh_shape=tuple(self.mesh_device.shape),
+            mesh_device=self.mesh_device,
             get_torch_state_dict=lambda: _feature_extractor_state_dict(
                 ckpt(), mode=self.mode, gemma_hidden_size=gemma_hidden_size, gemma_num_layers=gemma_num_layers
             ),
@@ -299,6 +301,7 @@ class GemmaTokenizerEncoderPair:
             subfolder=f"{axis}_connector",
             parallel_config=self.parallel_config,
             mesh_shape=tuple(self.mesh_device.shape),
+            mesh_device=self.mesh_device,
             dtype="float32",
             get_torch_state_dict=lambda: _connector_state_dict(ckpt(), axis, num_blocks),
         )

--- a/models/tt_dit/encoders/qwen25vl/encoder_pair.py
+++ b/models/tt_dit/encoders/qwen25vl/encoder_pair.py
@@ -108,6 +108,7 @@ class Qwen25VlTokenizerEncoderPair:
             subfolder=subfolder if subfolder is not None else "",
             parallel_config=self._parallel_config,
             mesh_shape=tuple(self._device.shape),
+            mesh_device=self._device,
             is_fsdp=self._is_fsdp,
         )
 
@@ -129,6 +130,7 @@ class Qwen25VlTokenizerEncoderPair:
             subfolder=self._encoder_subfolder if self._encoder_subfolder is not None else "",
             parallel_config=self._parallel_config,
             mesh_shape=tuple(self._device.shape),
+            mesh_device=self._device,
             is_fsdp=self._is_fsdp,
         )
 

--- a/models/tt_dit/encoders/t5/encoder_pair.py
+++ b/models/tt_dit/encoders/t5/encoder_pair.py
@@ -93,6 +93,7 @@ class T5TokenizerEncoderPair:
             subfolder="",
             parallel_config=self._parallel_config,
             mesh_shape=tuple(self._device.shape),
+            mesh_device=self._device,
         )
 
         return model

--- a/models/tt_dit/experimental/pipelines/pipeline_anisora.py
+++ b/models/tt_dit/experimental/pipelines/pipeline_anisora.py
@@ -81,6 +81,7 @@ class AniSoraPipeline(WanPipelineI2V):
                 subfolder=state.checkpoint.subfolder,
                 parallel_config=self.parallel_config,
                 mesh_shape=tuple(self.mesh_device.shape),
+                mesh_device=self.mesh_device,
                 is_fsdp=self.is_fsdp,
                 get_torch_state_dict=lambda s=state: s.checkpoint.state_dict(),
             )
@@ -93,6 +94,7 @@ class AniSoraPipeline(WanPipelineI2V):
             subfolder=state.checkpoint.subfolder,
             parallel_config=self.parallel_config,
             mesh_shape=tuple(self.mesh_device.shape),
+            mesh_device=self.mesh_device,
             is_fsdp=self.is_fsdp,
             get_torch_state_dict=lambda f=filename: load_lightx2v_state_dict(
                 self.HF_REPO,

--- a/models/tt_dit/experimental/pipelines/pipeline_wan_distill.py
+++ b/models/tt_dit/experimental/pipelines/pipeline_wan_distill.py
@@ -144,6 +144,7 @@ class WanDistillPipelineI2V(WanPipelineI2V):
                 subfolder=state.checkpoint.subfolder,
                 parallel_config=self.parallel_config,
                 mesh_shape=tuple(self.mesh_device.shape),
+                mesh_device=self.mesh_device,
                 is_fsdp=self.is_fsdp,
                 get_torch_state_dict=lambda s=state: s.checkpoint.state_dict(),
             )
@@ -156,6 +157,7 @@ class WanDistillPipelineI2V(WanPipelineI2V):
             subfolder=state.checkpoint.subfolder,
             parallel_config=self.parallel_config,
             mesh_shape=tuple(self.mesh_device.shape),
+            mesh_device=self.mesh_device,
             is_fsdp=self.is_fsdp,
             get_torch_state_dict=lambda f=filename: load_lightx2v_state_dict(
                 self.LIGHTX2V_REPO,

--- a/models/tt_dit/experimental/pipelines/pipeline_wan_lora.py
+++ b/models/tt_dit/experimental/pipelines/pipeline_wan_lora.py
@@ -377,6 +377,7 @@ class WanPipelineI2VLora(WanPipelineI2V):
             subfolder=state.checkpoint.subfolder,
             parallel_config=self.parallel_config,
             mesh_shape=tuple(self.mesh_device.shape),
+            mesh_device=self.mesh_device,
             is_fsdp=self.is_fsdp,
             get_torch_state_dict=_get_state_dict,
         )

--- a/models/tt_dit/models/audio_vae/audio_decoder_ltx.py
+++ b/models/tt_dit/models/audio_vae/audio_decoder_ltx.py
@@ -261,6 +261,7 @@ class LTXAudioDecoderAdapter:
                 subfolder=dec_subfolder,
                 parallel_config=self._dit_parallel_config,
                 mesh_shape=tuple(self._mesh_device.shape),
+                mesh_device=self._mesh_device,
                 get_torch_state_dict=self._audio_decoder_state_provider,
             )
 
@@ -271,6 +272,7 @@ class LTXAudioDecoderAdapter:
                 subfolder=voc_subfolder,
                 parallel_config=self._dit_parallel_config,
                 mesh_shape=tuple(self._mesh_device.shape),
+                mesh_device=self._mesh_device,
                 get_torch_state_dict=self._vocoder_state_provider,
             )
 

--- a/models/tt_dit/models/transformers/ltx/transformer_ltx.py
+++ b/models/tt_dit/models/transformers/ltx/transformer_ltx.py
@@ -1156,6 +1156,7 @@ class LTXTransformerCheckpoint:
             subfolder="transformer",
             parallel_config=parallel_config,
             mesh_shape=mesh_shape,
+            mesh_device=model.mesh_device,
             is_fsdp=is_fsdp,
             get_torch_state_dict=lambda: self.state_dict(lora_specs),
         )

--- a/models/tt_dit/models/transformers/transformer_flux1.py
+++ b/models/tt_dit/models/transformers/transformer_flux1.py
@@ -491,5 +491,6 @@ class Flux1Checkpoint:
             subfolder="transformer",
             parallel_config=parallel_config,
             mesh_shape=tuple(device.shape),
+            mesh_device=device,
         )
         return model

--- a/models/tt_dit/models/transformers/transformer_mochi.py
+++ b/models/tt_dit/models/transformers/transformer_mochi.py
@@ -802,4 +802,5 @@ class MochiCheckpoint:
             subfolder="transformer",
             parallel_config=parallel_config,
             mesh_shape=tuple(mesh_device.shape),
+            mesh_device=mesh_device,
         )

--- a/models/tt_dit/models/transformers/transformer_motif.py
+++ b/models/tt_dit/models/transformers/transformer_motif.py
@@ -557,6 +557,7 @@ class MotifCheckpoint:
             subfolder="transformer",
             parallel_config=parallel_config,
             mesh_shape=tuple(device.shape),
+            mesh_device=device,
         )
         return model
 

--- a/models/tt_dit/models/transformers/transformer_qwenimage.py
+++ b/models/tt_dit/models/transformers/transformer_qwenimage.py
@@ -294,5 +294,6 @@ class QwenImageCheckpoint:
             subfolder="transformer",
             parallel_config=parallel_config,
             mesh_shape=tuple(mesh_device.shape),
+            mesh_device=mesh_device,
             is_fsdp=is_fsdp,
         )

--- a/models/tt_dit/models/transformers/transformer_sd35.py
+++ b/models/tt_dit/models/transformers/transformer_sd35.py
@@ -571,5 +571,6 @@ class SD35Checkpoint:
             subfolder="transformer",
             parallel_config=parallel_config,
             mesh_shape=tuple(device.shape),
+            mesh_device=device,
         )
         return model

--- a/models/tt_dit/models/transformers/wan2_2/transformer_wan.py
+++ b/models/tt_dit/models/transformers/wan2_2/transformer_wan.py
@@ -774,5 +774,6 @@ class WanCheckpoint:
             subfolder=self._subfolder,
             parallel_config=parallel_config,
             mesh_shape=tuple(mesh_device.shape),
+            mesh_device=mesh_device,
             is_fsdp=is_fsdp,
         )

--- a/models/tt_dit/models/upsampler/latent_upsampler_ltx.py
+++ b/models/tt_dit/models/upsampler/latent_upsampler_ltx.py
@@ -327,6 +327,7 @@ class LTXLatentUpsampler(Module):
             subfolder=subfolder,
             parallel_config=self._dit_parallel_config,
             mesh_shape=tuple(self.mesh_device.shape),
+            mesh_device=self.mesh_device,
             get_torch_state_dict=_state_provider,
         )
         logger.info("Loaded TTNN latent upsampler")

--- a/models/tt_dit/models/vae/vae_ltx.py
+++ b/models/tt_dit/models/vae/vae_ltx.py
@@ -1469,6 +1469,7 @@ class LTXVideoVAEAdapter:
             subfolder=subfolder,
             parallel_config=self._dit_parallel_config,
             mesh_shape=tuple(self._mesh_device.shape),
+            mesh_device=self._mesh_device,
             get_torch_state_dict=_state_provider,
         )
         logger.info(f"Loaded TTNN VAE decoder ({len(self.decoder_blocks)} blocks)")
@@ -1500,6 +1501,7 @@ class LTXVideoVAEAdapter:
             subfolder=subfolder,
             parallel_config=self._dit_parallel_config,
             mesh_shape=tuple(self._mesh_device.shape),
+            mesh_device=self._mesh_device,
             get_torch_state_dict=_state_provider,
         )
         logger.info(f"Loaded TTNN VAE encoder ({len(self.encoder_blocks)} blocks)")

--- a/models/tt_dit/models/vae/vae_wan2_1.py
+++ b/models/tt_dit/models/vae/vae_wan2_1.py
@@ -1997,6 +1997,7 @@ class WanVAEDecoderAdapter:
             subfolder=subfolder,
             parallel_config=self._parallel_config,
             mesh_shape=tuple(self.device.shape),
+            mesh_device=self.device,
             get_torch_state_dict=lambda: self._torch_vae.state_dict(),
         )
 

--- a/models/tt_dit/pipelines/flux1/text_encoder.py
+++ b/models/tt_dit/pipelines/flux1/text_encoder.py
@@ -113,6 +113,7 @@ class TextEncoder:
                     subfolder="t5_text_encoder",
                     parallel_config=parallel_config,
                     mesh_shape=tuple(device.shape),
+                    mesh_device=device,
                 )
                 self._t5_tracer = Tracer(self._t5_text_encoder.forward, device=device, prep_run=False)
         else:

--- a/models/tt_dit/pipelines/wan/pipeline_wan.py
+++ b/models/tt_dit/pipelines/wan/pipeline_wan.py
@@ -694,7 +694,7 @@ class WanPipeline(PipelineAPIMixin):
         permuted_latent_tt = ts.model.ccl_manager.all_gather_persistent_buffer(
             permuted_latent_tt, dim=2, mesh_axis=sp_axis
         )
-        permuted_latent = ttnn.to_torch(ttnn.get_device_tensors(permuted_latent_tt)[0])
+        permuted_latent = tensor.local_device_to_torch(permuted_latent_tt)
 
         # Postprocess spatial output
         latents = ts.model.postprocess_spatial_output_host(

--- a/models/tt_dit/pipelines/wan/pipeline_wan_i2v.py
+++ b/models/tt_dit/pipelines/wan/pipeline_wan_i2v.py
@@ -53,6 +53,7 @@ class WanPipelineI2V(WanPipeline):
             subfolder="vae_encoder",
             parallel_config=self.vae_parallel_config,
             mesh_shape=tuple(self.mesh_device.shape),
+            mesh_device=self.mesh_device,
             get_torch_state_dict=lambda: self._vae.torch_state_dict(),
         )
 

--- a/models/tt_dit/pipelines/wan/text_encoder.py
+++ b/models/tt_dit/pipelines/wan/text_encoder.py
@@ -88,6 +88,7 @@ class TextEncoder:
             subfolder="text_encoder",
             parallel_config=self._encoder_parallel_config,
             mesh_shape=tuple(self._device.shape),
+            mesh_device=self._device,
             get_torch_state_dict=lambda: self._torch_text_encoder.state_dict(),
         )
 

--- a/models/tt_dit/pipelines/wan/text_encoder.py
+++ b/models/tt_dit/pipelines/wan/text_encoder.py
@@ -162,7 +162,7 @@ class TextEncoder:
         mesh_mapper = ttnn.ShardTensor2dMesh(self._device, mesh_shape=tuple(self._device.shape), dims=dims)
         tt_prompt = ttnn.from_torch(
             text_input_ids,
-            layout=ttnn.TILE_LAYOUT,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
             device=self._device,
             mesh_mapper=mesh_mapper,
         )
@@ -183,4 +183,4 @@ class TextEncoder:
 
         _, seq_len, _ = prompt_embeds.shape
         prompt_embeds = ttnn.repeat(prompt_embeds, (1, num_videos_per_prompt, 1))
-        return ttnn.view(prompt_embeds, (1, batch_size * num_videos_per_prompt, seq_len, -1))
+        return ttnn.reshape(prompt_embeds, (1, batch_size * num_videos_per_prompt, seq_len, -1))

--- a/models/tt_dit/tests/encoders/umt5/test_umt5.py
+++ b/models/tt_dit/tests/encoders/umt5/test_umt5.py
@@ -273,6 +273,7 @@ def test_umt5_encoder(
         subfolder="text_encoder",
         parallel_config=parallel_config,
         mesh_shape=tuple(mesh_device.shape),
+        mesh_device=mesh_device,
         get_torch_state_dict=lambda: hf_model.state_dict(),
     )
 

--- a/models/tt_dit/tests/models/mochi/test_transformer_accuracy.py
+++ b/models/tt_dit/tests/models/mochi/test_transformer_accuracy.py
@@ -130,6 +130,7 @@ def test_transformer_accuracy(
         subfolder="transformer",
         parallel_config=parallel_config,
         mesh_shape=tuple(mesh_device.shape),
+        mesh_device=mesh_device,
     )
 
     # Get list of step directories

--- a/models/tt_dit/tests/models/mochi/test_transformer_mochi.py
+++ b/models/tt_dit/tests/models/mochi/test_transformer_mochi.py
@@ -364,6 +364,7 @@ def test_mochi_transformer_model(
                 subfolder="transformer",
                 parallel_config=parallel_config,
                 mesh_shape=tuple(mesh_device.shape),
+                mesh_device=mesh_device,
             )
         except cache.MissingCacheError as err:
             msg = "Cache path does not exist. Run test_mochi_transformer_model_caching first with the desired parallel config."
@@ -474,6 +475,7 @@ def test_mochi_transformer_model_caching(
         subfolder="transformer",
         parallel_config=parallel_config,
         mesh_shape=tuple(mesh_device.shape),
+        mesh_device=mesh_device,
     )
 
     logger.info(f"Cache path {cache_dir}")

--- a/models/tt_dit/tests/models/mochi/test_vae_mochi.py
+++ b/models/tt_dit/tests/models/mochi/test_vae_mochi.py
@@ -798,6 +798,7 @@ def load_dit(
             subfolder="transformer",
             parallel_config=parallel_config,
             mesh_shape=tuple(mesh_device.shape),
+            mesh_device=mesh_device,
             dtype="bf16",
         )
     else:

--- a/models/tt_dit/tests/models/motif/test_transformer_motif.py
+++ b/models/tt_dit/tests/models/motif/test_transformer_motif.py
@@ -165,6 +165,7 @@ def test_transformer_motif(
         subfolder="transformer",
         parallel_config=parallel_config,
         mesh_shape=submesh_device.shape,
+        mesh_device=submesh_device,
         get_torch_state_dict=get_state_dict,
     )
 

--- a/models/tt_dit/tests/models/qwenimage/test_transformer_qwenimage.py
+++ b/models/tt_dit/tests/models/qwenimage/test_transformer_qwenimage.py
@@ -110,6 +110,7 @@ def test_transformer(
         subfolder="transformer",
         parallel_config=parallel_config,
         mesh_shape=tuple(mesh_device.shape),
+        mesh_device=mesh_device,
     )
 
     spatial_seq_len = (latents_height // patch_size) * (latents_width // patch_size)

--- a/models/tt_dit/tests/models/sd35/test_transformer_sd35.py
+++ b/models/tt_dit/tests/models/sd35/test_transformer_sd35.py
@@ -276,6 +276,7 @@ def test_sd35_transformer2d_model(
                 subfolder="transformer",
                 parallel_config=parallel_config,
                 mesh_shape=tuple(mesh_device.shape),
+                mesh_device=mesh_device,
             )
         except cache.MissingCacheError as err:
             msg = "Cache path does not exist. Run test_sd35_transformer_model_caching first with the desired parallel config."
@@ -432,6 +433,7 @@ def test_sd35_transformer_model_caching(
         subfolder="transformer",
         parallel_config=parallel_config,
         mesh_shape=tuple(mesh_device.shape),
+        mesh_device=mesh_device,
     )
 
     # Create padding config if needed for tensor parallelism

--- a/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
@@ -22,7 +22,7 @@ from models.tt_dit.utils.video import export_to_video
 
 from ....utils.test import line_params, ring_params, ring_params_8k
 
-DEVICE_PARAMS = {"trace_region_size": 120000000}
+DEVICE_PARAMS = {"trace_region_size": 150000000}
 
 # BH 4x8 linear topology is expected to be slower than ring; relax assert/CI targets by this factor.
 BH_4X8_LINEAR_EXPECTED_METRICS_SLACK = 1.10

--- a/models/tt_dit/utils/cache.py
+++ b/models/tt_dit/utils/cache.py
@@ -47,6 +47,7 @@ def load_model(
     subfolder: str,
     parallel_config: NamedTuple,
     mesh_shape: Sequence[int],
+    mesh_device: ttnn.MeshDevice,
     dtype: str = "bf16",
     is_fsdp: bool = False,
     get_torch_state_dict: Callable[[], dict] | None = None,
@@ -65,6 +66,7 @@ def load_model(
         `subfolder`: Subfolder within model cache directory (e.g., "transformer", "vae").
         `parallel_config`: Parallelism configuration (tensor/sequence parallel).
         `mesh_shape`: Device mesh shape.
+        `mesh_device`: Mesh device used to derive the multi-host ownership cache suffix.
         `dtype`: Data type for cached weights (default: "bf16").
         `is_fsdp`: Whether FSDP is used (default: False).
         `get_torch_state_dict`: Optional callable returning PyTorch state dict. Enables lazy
@@ -84,6 +86,7 @@ def load_model(
         subfolder=subfolder,
         parallel_config=parallel_config,
         mesh_shape=mesh_shape,
+        mesh_device=mesh_device,
         dtype=dtype,
         is_fsdp=is_fsdp,
         required=get_torch_state_dict is None,
@@ -128,6 +131,7 @@ def model_cache_dir(
     subfolder: str,
     parallel_config: NamedTuple,
     mesh_shape: Sequence[int],
+    mesh_device: ttnn.MeshDevice,
     dtype: str = "bf16",
     is_fsdp: bool = False,
     required: bool = True,
@@ -148,10 +152,30 @@ def model_cache_dir(
 
     path = Path(cache_dir) / model_name / subfolder / key
 
-    if _distributed_world_size() > 1:
-        path = path / f"rank_{int(ttnn.distributed_context_world_rank())}"
+    ownership_suffix = _cache_ownership_suffix(mesh_device)
+    if ownership_suffix:
+        path = path / ownership_suffix
 
     return path
+
+
+def _cache_ownership_suffix(mesh_device: ttnn.MeshDevice) -> str:
+    """Multi-host cache dir suffix keyed by local mesh-coordinate ownership.
+
+    Single-host / no distributed context: empty (same unsuffixed path as before).
+    Multi-host: ``host_coords_r{r0}-{r1}_c{c0}-{c1}`` for the local coord bounding box.
+    """
+    if _distributed_world_size() <= 1:
+        return ""
+
+    view = mesh_device.get_view()
+    rows = []
+    cols = []
+    for coord in ttnn.MeshCoordinateRange(view.shape()):
+        if view.is_local(coord):
+            rows.append(int(coord[0]))
+            cols.append(int(coord[1]))
+    return f"host_coords_r{min(rows)}-{max(rows)}_c{min(cols)}-{max(cols)}"
 
 
 def _cache_is_complete(cache_dir: str | Path) -> bool:

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -42,24 +42,26 @@ tt::tt_metal::distributed::MeshCoordinate::BoundaryMode get_boundary_mode(
     if (topology == tt::tt_fabric::Topology::Linear || topology == tt::tt_fabric::Topology::Mesh) {
         return tt::tt_metal::distributed::MeshCoordinate::BoundaryMode::NONE;
     }
-    // ring is possible if device coordinates along our cluster axis are the same as the last coordinate in the mesh
-    // shape first_index = 0 last index = mesh_shape[cluster_axis] - 1
+    // For the cluster_axis API the collective spans the entire mesh axis by definition, so the
+    // ring geometry is determined by the GLOBAL mesh shape, not the local shard coordinates.
+    // In multi-host distributed setups device_storage().get_coords() only contains the coordinates
+    // of the shards owned by this host (e.g. columns 8-15 for the second host of a 4x32 mesh).
+    // Deciding WRAP/NONE from those local coordinates would incorrectly return NONE for every
+    // host whose shard does not begin at global index 0. A ring wraps iff the global axis extent
+    // is > 2; the local slice is always a contiguous sub-ring of the full global ring.
     if (cluster_axis.has_value()) {
         if (mesh_shape[cluster_axis.value()] == 2) {
             return tt::tt_metal::distributed::MeshCoordinate::BoundaryMode::NONE;
         }
-        bool first_index_is_0 = device_coords[0][cluster_axis.value()] == 0;
-        bool last_index_is_mesh_shape_minus_1 =
-            device_coords[device_coords.size() - 1][cluster_axis.value()] == mesh_shape[cluster_axis.value()] - 1;
-        if (first_index_is_0 && last_index_is_mesh_shape_minus_1) {
-            return tt::tt_metal::distributed::MeshCoordinate::BoundaryMode::WRAP;
-        }
-        return tt::tt_metal::distributed::MeshCoordinate::BoundaryMode::NONE;
+        return tt::tt_metal::distributed::MeshCoordinate::BoundaryMode::WRAP;
     }
+    // Without a cluster_axis the ring is formed over the tensor's own device list via linear
+    // index arithmetic (see get_physical_neighbor_from_physical_coord). Keep the boundary decision
+    // consistent with that list: only wrap when the tensor's devices span the full mesh from
+    // (0,..,0) to (max,..,max).
     if (mesh_shape[0] == 2 || mesh_shape[1] == 2) {
         return tt::tt_metal::distributed::MeshCoordinate::BoundaryMode::NONE;
     }
-    TT_FATAL(!device_coords.empty(), "device_coords is empty");
     for (int i = 0; i < device_coords.front().dims(); i++) {
         if (device_coords.front()[i] != 0) {
             return tt::tt_metal::distributed::MeshCoordinate::BoundaryMode::NONE;
@@ -93,32 +95,30 @@ tt::tt_fabric::Topology get_usable_topology(
 }
 
 uint32_t get_topological_dimension(const Tensor& tensor, const std::optional<uint32_t>& cluster_axis) {
-    const auto device_coords = tensor.device_storage().get_coords();
-    TT_FATAL(!device_coords.empty(), "device_coords is empty");
+    // For cluster_axis ops, ring_size is the global extent of the mesh along that axis.
+    // Using local device_coords (which only covers this host's shard) would undercount the ring
+    // in multi-host setups — e.g. max(local col)+1 = 16 instead of the true global 32.
     if (cluster_axis.has_value()) {
         log_debug(tt::LogOp, "Cluster axis has value {}", cluster_axis.value());
-        TT_FATAL(!device_coords.empty(), "device_coords is empty");
+        const auto mesh_shape = tensor.device()->shape();
         TT_FATAL(
-            device_coords[0].dims() > cluster_axis.value(),
-            "cluster axis {} is out of range for device coords rank {} ",
+            mesh_shape.dims() > cluster_axis.value(),
+            "cluster axis {} is out of range for mesh shape rank {}",
             cluster_axis.value(),
-            device_coords[0].dims());
-        uint32_t ring_size = 0;
-        for (const auto& device_coord : device_coords) {
-            ring_size = std::max(ring_size, device_coord[cluster_axis.value()] + 1);
-        }
+            mesh_shape.dims());
+        const uint32_t ring_size = mesh_shape[cluster_axis.value()];
         TT_FATAL(ring_size > 0, "ring_size is 0");
         log_debug(tt::LogOp, "Topological dimension {}", ring_size);
         return ring_size;
     }
+    const auto device_coords = tensor.device_storage().get_coords();
+    TT_FATAL(!device_coords.empty(), "device_coords is empty");
     log_debug(tt::LogOp, "Topological dimension {}", device_coords.size());
     return device_coords.size();
 }
 
 uint32_t get_linearized_index_from_physical_coord(
     const Tensor& tensor, const MeshCoordinate& physical_coord, const std::optional<uint32_t>& cluster_axis) {
-    const auto device_coords = tensor.device_storage().get_coords();
-    TT_FATAL(!device_coords.empty(), "device_coords is empty");
     if (cluster_axis.has_value()) {
         log_debug(tt::LogOp, "Cluster axis has value {}", cluster_axis.value());
         TT_FATAL(
@@ -126,24 +126,16 @@ uint32_t get_linearized_index_from_physical_coord(
             "cluster axis {} is out of range for physical coord rank {} ",
             cluster_axis.value(),
             physical_coord.dims());
-        // find minimum value along the cluster axis
-        uint32_t min_value = std::numeric_limits<uint32_t>::max();
-        for (const auto& device_coord : device_coords) {
-            min_value = std::min(min_value, device_coord[cluster_axis.value()]);
-        }
-        TT_FATAL(
-            physical_coord[cluster_axis.value()] >= min_value,
-            "physical_coord[{}] {} is less than min_value {}",
-            cluster_axis.value(),
-            physical_coord[cluster_axis.value()],
-            min_value);
-        log_debug(
-            tt::LogOp,
-            "Physical linearized index for physical_coord: {} is {}",
-            physical_coord,
-            physical_coord[cluster_axis.value()] - min_value);
-        return physical_coord[cluster_axis.value()] - min_value;
+        // The global ring index is the coordinate value itself — the global origin along any
+        // mesh axis is always 0. Subtracting a local min_value (derived from this host's shard)
+        // would produce indices that are only locally-relative (e.g. 0-7 instead of 8-15),
+        // which breaks ring ordering and CCL program indexing in multi-host setups.
+        const uint32_t ring_index = physical_coord[cluster_axis.value()];
+        log_debug(tt::LogOp, "Physical linearized index for physical_coord: {} is {}", physical_coord, ring_index);
+        return ring_index;
     }
+    const auto device_coords = tensor.device_storage().get_coords();
+    TT_FATAL(!device_coords.empty(), "device_coords is empty");
     auto it = std::find(device_coords.begin(), device_coords.end(), physical_coord);
     TT_FATAL(it != device_coords.end(), "physical_coord not found in device_coords");
     log_debug(
@@ -165,33 +157,42 @@ std::optional<MeshCoordinate> get_physical_neighbor_from_physical_coord(
     auto boundary_mode = get_boundary_mode(tensor, topology, cluster_axis);
     if (cluster_axis.has_value()) {
         TT_FATAL(
-            device_coords[0][cluster_axis.value()] == 0,
-            "Currently, we only support CCLs with physical coordinates starting from 0 along the cluster axis {}, we "
-            "got {}",
-            cluster_axis.value(),
-            device_coords[0][cluster_axis.value()]);
-        TT_FATAL(
             physical_coord.dims() > cluster_axis.value(),
             "cluster axis {} is out of range for physical coord rank {} ",
             cluster_axis.value(),
             physical_coord.dims());
         log_debug(tt::LogOp, "Boundary mode: {}", boundary_mode);
+        // Compute neighbor in the global coordinate space. get_neighbor() operates on the global
+        // mesh shape and returns nullopt only when boundary_mode==NONE and we are at the edge of
+        // the full ring — i.e. a genuine topology boundary, not merely the edge of this host's
+        // local shard.
         auto potential_neighbor =
             physical_coord.get_neighbor(tensor.device()->shape(), offset, cluster_axis.value(), boundary_mode);
-        auto it = std::find(device_coords.begin(), device_coords.end(), potential_neighbor);
-        if (it != device_coords.end()) {
+        if (!potential_neighbor.has_value()) {
             log_debug(
                 tt::LogOp,
-                "Physical coord {} Potential neighbor {} is found in device_coords",
+                "Physical coord {} has no neighbor at offset {} along axis {} (topology boundary)",
                 physical_coord,
-                potential_neighbor);
+                offset,
+                cluster_axis.value());
+            return std::nullopt;
+        }
+        // Validate against the global mesh view rather than the local device_coords list.
+        // In multi-host setups device_coords only contains this host's shard; a neighbor on
+        // another host is still a valid ring participant and reachable via the fabric.
+        if (tensor.device()->get_view().contains(*potential_neighbor)) {
+            log_debug(
+                tt::LogOp,
+                "Physical coord {} Potential neighbor {} is valid in global mesh",
+                physical_coord,
+                *potential_neighbor);
             return potential_neighbor;
         }
         log_debug(
             tt::LogOp,
-            "Physical coord {} Potential neighbor {} is not found in device_coords",
+            "Physical coord {} Potential neighbor {} is not in global mesh",
             physical_coord,
-            potential_neighbor);
+            *potential_neighbor);
         return std::nullopt;
     }
     uint32_t physical_linearized_index = get_linearized_index_from_physical_coord(tensor, physical_coord, cluster_axis);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
@@ -280,6 +280,10 @@ void kernel_main() {
             }
         }
     }
+
+    if constexpr (fuse_op) {
+        noc_obj.async_atomic_barrier();
+    }
     // Device 2.0 migration: legacy primitive retained, out_ready_sem is a GlobalSemaphore address.
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), 0);
 }


### PR DESCRIPTION
### PR Category
Bug Fix

### Summary

- Fixes a multi-host CCL hang/assertion on cluster_axis collectives (e.g. WAN on a BH quad-galaxy). Since PR #46138, DeviceStorage::get_coords() returns only the local shard coordinates owned by each host (e.g. columns 8–15 for host 1 of a 4×32 mesh) rather than the full global list. Four topology helpers in ccl_common.cpp were written when get_coords() was global and silently conflated "local shard coords" with "global ring coords", so any host whose shard doesn't start at global index 0 computed the wrong ring geometry:

- TT_FATAL @ ccl_common.cpp:172: device_coords[0][cluster_axis] == 0 (got 8/16/24 on the non-origin hosts).

This PR reworks the cluster_axis path of the four helpers to derive ring geometry from the global mesh (tensor.device()->shape() and tensor.device()->get_view()) instead of the local device_storage().get_coords() list:

- The single-host path is unchanged: when one rank owns the full mesh, local coords equal global coords and all four changes are mathematically identical to the previous behavior.

- Relates to the WAN quad-galaxy hang investigation, after addressing some of the causes for the hang.

### Notes for reviewers

- Behavioral change is scoped to the cluster_axis branch. The non-cluster_axis path still linearizes over the local device_coords list and is intentionally left as-is (it has the same latent local-vs-global limitation, but non-cluster_axis ring CCL is effectively single-host/1D; flagged as a follow-up, not fixed here to keep the change small).

### Relevant CI tests(some tracked from auto generated below)
- [![Fabric Test on a BH Quad](https://github.com/tenstorrent/tt-metal/actions/workflows/fabric-multihost-exabox.yaml/badge.svg?branch=sadesoye/fix_WAN_quad_hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/fabric-multihost-exabox.yaml?query=branch%3Asadesoye%2Ffix_WAN_quad_hang)

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sadesoye/fix_WAN_quad_hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sadesoye/fix_WAN_quad_hang) -[Same failure on main](https://github.com/tenstorrent/tt-metal/actions/runs/29357557133/job/87216177692)

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=sadesoye/fix_WAN_quad_hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:sadesoye/fix_WAN_quad_hang) - [Same failure on main](https://github.com/tenstorrent/tt-metal/actions/runs/29372074141/attempts/1). Passes locally on BH-QBAE-16

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sadesoye/fix_WAN_quad_hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sadesoye/fix_WAN_quad_hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sadesoye/fix_WAN_quad_hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sadesoye/fix_WAN_quad_hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=sadesoye/fix_WAN_quad_hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:sadesoye/fix_WAN_quad_hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sadesoye/fix_WAN_quad_hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sadesoye/fix_WAN_quad_hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sadesoye/fix_WAN_quad_hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sadesoye/fix_WAN_quad_hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sadesoye/fix_WAN_quad_hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sadesoye/fix_WAN_quad_hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sadesoye/fix_WAN_quad_hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sadesoye/fix_WAN_quad_hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sadesoye/fix_WAN_quad_hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sadesoye/fix_WAN_quad_hang)