### PR TITLE
[Cleanup] Remove WH-only LLK workarounds

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor.cpp
@@ -76,6 +76,7 @@ void kernel_main() {
     CircularBuffer cb_out(cb_out_id);
     CircularBuffer cb_gamma(cb_gamma_id);
     CircularBuffer cb_beta(cb_beta_id);
+    CircularBuffer cb_xmm(cb_xmm_id);
     CircularBuffer cb_ex(cb_ex_id);
     CircularBuffer cb_ex2(cb_ex2_id);
     CircularBuffer cb_xmm2(cb_xmm2_id);
@@ -312,19 +313,29 @@ void kernel_main() {
                     cb_inb_id, i, i);
             }
             cb_inb.pop_front(block.full_block_size());
-            // SrcA last held cb_inb (the pre-add operand); switch it to cb_ex2pe's format.
-            reconfig_data_format_srca(cb_inb_id, cb_ex2pe_id);
-#else
-            // SrcA last held cb_in (the x-E[x] operand); switch it to cb_ex2pe's format.
-            reconfig_data_format_srca(cb_in_id, cb_ex2pe_id);
 #endif
-            // Multiply by 1/(√(Var(X) + ε)) in place: the (x-E[x]) values are reused from DEST as
-            // SrcB while cb_ex2pe is unpacked into SrcA.
-            binary_dest_reuse_tiles_init<EltwiseBinaryType::ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(
-                cb_ex2pe_id);
+            tile_regs_commit();
+            tile_regs_wait();
+            // Note: We shouldn't have to pack to
+            // intermediate CB. We should be able to
+            // do a binary dest with reuse (as we used
+            // to). However, tt-llk #868 is preventing
+            // that from working at the moment.
+            cb_xmm.reserve_back(block.full_block_size());
+            pack_reconfig_data_format(cb_xmm_id);
             for (auto i : block.local()) {
-                binary_dest_reuse_tiles<EltwiseBinaryType::ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(
-                    cb_ex2pe_id, 0, i);
+                pack_tile(i, cb_xmm_id);
+            }
+            cb_xmm.push_back(block.full_block_size());
+            tile_regs_release();
+
+            cb_xmm.wait_front(block.full_block_size());
+            reconfig_data_format(cb_xmm_id, cb_ex2pe_id);
+            tile_regs_acquire();
+
+            mul_tiles_init(cb_xmm_id, cb_ex2pe_id);
+            for (auto i : block.local()) {
+                mul_tiles(cb_xmm_id, cb_ex2pe_id, i, 0, i);
 #ifdef SFPU_OP_INIT_ACTIVATION
                 // Activation must be applied last. If do_gamma != 0 or do_beta != 0 then
                 // activation will be applied after the gamma/beta multiplication/addition.
@@ -348,6 +359,7 @@ void kernel_main() {
             }
             tile_regs_release();
             CircularBuffer(cb_fusion).push_back(block.full_block_size());
+            cb_xmm.pop_front(block.full_block_size());
 
             if constexpr (do_gamma == 1) {
                 tile_regs_acquire();

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor.cpp
@@ -76,7 +76,6 @@ void kernel_main() {
     CircularBuffer cb_out(cb_out_id);
     CircularBuffer cb_gamma(cb_gamma_id);
     CircularBuffer cb_beta(cb_beta_id);
-    CircularBuffer cb_xmm(cb_xmm_id);
     CircularBuffer cb_ex(cb_ex_id);
     CircularBuffer cb_ex2(cb_ex2_id);
     CircularBuffer cb_xmm2(cb_xmm2_id);
@@ -313,29 +312,19 @@ void kernel_main() {
                     cb_inb_id, i, i);
             }
             cb_inb.pop_front(block.full_block_size());
+            // SrcA last held cb_inb (the pre-add operand); switch it to cb_ex2pe's format.
+            reconfig_data_format_srca(cb_inb_id, cb_ex2pe_id);
+#else
+            // SrcA last held cb_in (the x-E[x] operand); switch it to cb_ex2pe's format.
+            reconfig_data_format_srca(cb_in_id, cb_ex2pe_id);
 #endif
-            tile_regs_commit();
-            tile_regs_wait();
-            // Note: We shouldn't have to pack to
-            // intermediate CB. We should be able to
-            // do a binary dest with reuse (as we used
-            // to). However, tt-llk #868 is preventing
-            // that from working at the moment.
-            cb_xmm.reserve_back(block.full_block_size());
-            pack_reconfig_data_format(cb_xmm_id);
+            // Multiply by 1/(√(Var(X) + ε)) in place: the (x-E[x]) values are reused from DEST as
+            // SrcB while cb_ex2pe is unpacked into SrcA.
+            binary_dest_reuse_tiles_init<EltwiseBinaryType::ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(
+                cb_ex2pe_id);
             for (auto i : block.local()) {
-                pack_tile(i, cb_xmm_id);
-            }
-            cb_xmm.push_back(block.full_block_size());
-            tile_regs_release();
-
-            cb_xmm.wait_front(block.full_block_size());
-            reconfig_data_format(cb_xmm_id, cb_ex2pe_id);
-            tile_regs_acquire();
-
-            mul_tiles_init(cb_xmm_id, cb_ex2pe_id);
-            for (auto i : block.local()) {
-                mul_tiles(cb_xmm_id, cb_ex2pe_id, i, 0, i);
+                binary_dest_reuse_tiles<EltwiseBinaryType::ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(
+                    cb_ex2pe_id, 0, i);
 #ifdef SFPU_OP_INIT_ACTIVATION
                 // Activation must be applied last. If do_gamma != 0 or do_beta != 0 then
                 // activation will be applied after the gamma/beta multiplication/addition.
@@ -359,7 +348,6 @@ void kernel_main() {
             }
             tile_regs_release();
             CircularBuffer(cb_fusion).push_back(block.full_block_size());
-            cb_xmm.pop_front(block.full_block_size());
 
             if constexpr (do_gamma == 1) {
                 tile_regs_acquire();

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor_welford.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor_welford.cpp
@@ -549,10 +549,10 @@ void kernel_main() {
                         cb_inb, i, i);
                 }
                 cb_inb_obj.pop_front(block.full_block_size());
-                reconfig_data_format_srca(cb_inb, cb_ex2pe);
             }
 
-            // Multiply by 1/(√(Var(X) + ε))
+            // Multiply by 1/(√(Var(X) + ε)). SrcA currently holds cb_inb (fused) or cb_in
+            // (non-fused), the last operand read above; switch it to cb_ex2pe's format.
             reconfig_data_format_srca(fuse_pre_add ? cb_inb : cb_in, cb_ex2pe);
             binary_dest_reuse_tiles_init<EltwiseBinaryType::ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(cb_ex2pe);
             for (auto i : block.local()) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor_welford.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor_welford.cpp
@@ -552,67 +552,14 @@ void kernel_main() {
                 reconfig_data_format_srca(cb_inb, cb_ex2pe);
             }
 
-            // Multiply by 1/(√(Var(X) + ε)).
-            //
-            // On Wormhole, binary_dest_reuse_tiles<ELWMUL, DEST_TO_SRCB> on c_0 (cb_in)
-            // silently corrupts when an earlier unpack op in this kernel routed through an
-            // UnpackToDestFp32 CB. The two triggers are different in each path:
-            //   * non-fuse welford (welford_fp32_alias): transpose_tile reads cb_x_welford
-            //     (c_29, UnpackToDestFp32 alias of cb_x).
-            //   * fuse_pre_add welford state (welford_state_fp32_alias): copy_tile reads
-            //     cb_ex_welford / cb_ex2_welford (c_30 / c_31, UnpackToDestFp32 aliases of
-            //     cb_ex / cb_ex2). cb_interm_pre_add (c_23) is kept in Default mode and the
-            //     fuse path's transpose_tile on it does not contribute to the trigger.
-            // The leaked unpacker state survives across the welford -> eltwise boundary;
-            // even-indexed DEST half blocks accumulate (output = (1+rsqrt)*(x-mean), ~1.286x),
-            // odd-indexed blocks produce mostly zeros. The standard reconfig_data_format(...,
-            // IGNORE) skip-optimization at the start of the eltwise block does not reset
-            // whatever state needs resetting. Blackhole is unaffected.
-            //
-            // If we're on Wormhole and any UnpackToDestFp32 alias is active in
-            // this kernel, stage (x - mean) through cb_xmm and use the mul_tiles_bcast_cols
-            // path so the multiply reads through SrcA instead of reusing DEST.
-            // In all other cases, use the DEST_TO_SRCB reuse path, to avoid an extra pack/unpack
-            // round-trip. Tracked in Issue #45216.
-            constexpr bool wh_dest_reuse_workaround_needed =
-#if defined(ARCH_WORMHOLE)
-                (welford_fp32_alias || welford_state_fp32_alias);
-#else
-                false;
-#endif
-            if constexpr (wh_dest_reuse_workaround_needed) {
-                tile_regs_commit();
-
-                const uint32_t cb_xmm_intermediate = get_named_compile_time_arg_val("cb_xmm");
-                CircularBuffer cb_xmm_intermediate_obj(cb_xmm_intermediate);
-                pack_reconfig_data_format(cb_xmm_intermediate);
-                cb_xmm_intermediate_obj.reserve_back(block.full_block_size());
-                tile_regs_wait();
-                for (auto i : block.local()) {
-                    pack_tile(i, cb_xmm_intermediate);
-                }
-                cb_xmm_intermediate_obj.push_back(block.full_block_size());
-                tile_regs_release();
-
-                reconfig_data_format(cb_xmm_intermediate, cb_ex2pe);
-                mul_bcast_cols_init_short(cb_xmm_intermediate, cb_ex2pe);
-                cb_xmm_intermediate_obj.wait_front(block.full_block_size());
-                tile_regs_acquire();
-                for (auto i : block.local()) {
-                    mul_tiles_bcast_cols(cb_xmm_intermediate, cb_ex2pe, i, 0, i);
-                }
-                cb_xmm_intermediate_obj.pop_front(block.full_block_size());
-                tile_regs_commit();
-            } else {
-                reconfig_data_format_srca(fuse_pre_add ? cb_inb : cb_in, cb_ex2pe);
-                binary_dest_reuse_tiles_init<EltwiseBinaryType::ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(
-                    cb_ex2pe);
-                for (auto i : block.local()) {
-                    binary_dest_reuse_tiles<EltwiseBinaryType::ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(
-                        cb_ex2pe, 0, i);
-                }
-                tile_regs_commit();
+            // Multiply by 1/(√(Var(X) + ε))
+            reconfig_data_format_srca(fuse_pre_add ? cb_inb : cb_in, cb_ex2pe);
+            binary_dest_reuse_tiles_init<EltwiseBinaryType::ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(cb_ex2pe);
+            for (auto i : block.local()) {
+                binary_dest_reuse_tiles<EltwiseBinaryType::ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(
+                    cb_ex2pe, 0 /*in_tile_index*/, i);
             }
+            tile_regs_commit();
 
             if constexpr (!(do_gamma == 1 or do_beta == 1)) {
                 cb_xmm = cb_out;


### PR DESCRIPTION
### Summary
LLK issue #45216 has been fixed, so this PR removes the workaround that is no longer needed.
With the workaround removed, the code once again uses `binary_dest_reuse_tiles`, which is more efficient than using intermediate CBs.

Relevant issue #45600

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fplavec/45600_remove_workarounds)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fplavec/45600_remove_workarounds)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fplavec/45600_remove_workarounds)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fplavec/45600_remove_workarounds)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=fplavec/45600_remove_workarounds)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:fplavec/45600_remove_workarounds)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fplavec/45600_remove_workarounds)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fplavec/45600_remove_workarounds)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fplavec/45600_remove_workarounds)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fplavec/45600_remove_workarounds)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fplavec/45600_remove_workarounds)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fplavec/45600_remove_workarounds)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fplavec/45600_remove_workarounds)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fplavec/45600_remove_workarounds)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fplavec/45600_remove_workarounds)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fplavec/45600_remove_workarounds)