### PR TITLE
[Feature] Always-dual tensor prefetcher with GCB-subset PREFETCH routing

### DIFF
--- a/tests/ttnn/unit_tests/operations/prefetcher_common.py
+++ b/tests/ttnn/unit_tests/operations/prefetcher_common.py
@@ -117,13 +117,13 @@ def make_recv_contig_weight(
 
 
 @contextlib.contextmanager
-def tensor_prefetcher_session(device, dual_senders_per_bank: bool = False):
+def tensor_prefetcher_session(device):
     """Open a Tensor prefetcher Start/Stop window. Stop (and a device sync)
     runs even on test failure so the next test sees a clean device, replacing the
     explicit ``start -> ... -> stop -> synchronize`` callers used to spell out at
     every test site.
     """
-    ttnn.experimental.start_tensor_prefetcher(device, dual_senders_per_bank=dual_senders_per_bank)
+    ttnn.experimental.start_tensor_prefetcher(device)
     try:
         yield
     finally:

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bench.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bench.py
@@ -676,7 +676,7 @@ def test_bench_dram_core_repeats_recv_contig(device, op_name, shape, distributio
     # Centralized recv-contig param + cross-check: returns the validated block_count
     # (== ring_size) and TT_FATALs on a weight/program_config/gcb mismatch.
     block_count = ttnn.experimental.tensor_prefetcher_block_count_for_matmul_1d(cc_program_config, tt_weight, gcb)
-    ttnn.experimental.start_tensor_prefetcher(device, dual_senders_per_bank=dual_senders)
+    ttnn.experimental.start_tensor_prefetcher(device)
     ttnn.experimental.queue_tensor_prefetcher_request(
         device,
         [(tt_weight, block_count)] * num_prefetch_layers,

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bw_bench.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bw_bench.py
@@ -338,7 +338,7 @@ def test_bw_tensor_prefetcher_recv_contig(device, op_name, shape):
         device, bank_to_receivers, gcb_size, dual_senders_per_bank=dual_senders
     )
 
-    ttnn.experimental.start_tensor_prefetcher(device, dual_senders_per_bank=dual_senders)
+    ttnn.experimental.start_tensor_prefetcher(device)
     ttnn.experimental.queue_tensor_prefetcher_request(
         device, [(tt_weight, num_receivers)] * num_prefetch_layers, global_cb=gcb
     )
@@ -430,7 +430,7 @@ def test_bw_tensor_prefetcher_streaming(device, op_name, shape):
         f"pages_per_layer={pages_per_layer} gcb_size={gcb_size} trace_repeats={trace_repeats}"
     )
 
-    ttnn.experimental.start_tensor_prefetcher(device, dual_senders_per_bank=dual_senders)
+    ttnn.experimental.start_tensor_prefetcher(device)
     # Identity rotation (rotation[r] = r) = natural topology ring order (reproduces old streaming=True).
     ttnn.experimental.queue_tensor_prefetcher_request(
         device, [(tt_weight, num_receivers, list(range(num_receivers)))] * num_prefetch_layers, global_cb=gcb

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_validator.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_validator.py
@@ -414,7 +414,7 @@ def test_validator_dram_sender_recv_contig(device, K, N, dtype, recv_per_bank, n
     # prefetcher actually slices by the supplied rotation values rather than the bare ring index.
     # Empty == batched. The same rotation is handed to the validator so it expects the matching order.
     rotation = [(g + 1) % ring_size for g in range(ring_size)] if streaming else []
-    with tensor_prefetcher_session(device, dual_senders_per_bank=dual_senders):
+    with tensor_prefetcher_session(device):
         ttnn.experimental.queue_tensor_prefetcher_request(
             device, [(tt_weight, ring_size, rotation)] * num_layers, global_cb=gcb
         )
@@ -464,7 +464,7 @@ def test_validator_dram_sender_recv_contig_shard_contiguous(
     # Cyclic shift by 1 (empty == batched); same rotation handed to the validator so it expects the
     # matching contiguous-order delivery.
     rotation = [(g + 1) % ring_size for g in range(ring_size)] if streaming else []
-    with tensor_prefetcher_session(device, dual_senders_per_bank=dual_senders):
+    with tensor_prefetcher_session(device):
         ttnn.experimental.queue_tensor_prefetcher_request(
             device, [(tt_weight, ring_size, rotation)] * num_layers, global_cb=gcb
         )

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_validator.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_validator.py
@@ -56,11 +56,16 @@ def _bank_receivers_row_major(bank_idx: int, recv_per_bank: int, ring_cols: int,
     return ttnn.CoreRangeSet(cores)
 
 
-def _setup_weight_and_gcb_dram_sender(device, K, N, dtype, recv_per_bank, num_layers, row_offset=0):
+def _setup_weight_and_gcb_dram_sender(device, K, N, dtype, recv_per_bank, num_layers, row_offset=0, dual_senders=False):
     """Build a DRAM-sender GCB sized to the prefetcher's per-receiver-per-block push.
 
     `row_offset` shifts the receiver grid down; the multi-GCB switching test uses
     it to place two GCBs on disjoint receiver rows for the same prefetcher.
+
+    `dual_senders` requests the two-sender-per-bank GCB variant. With recv_per_bank=1
+    each bank has a single receiver that cannot split, so every bank falls back to its
+    primary sender — the mapping is identical to a single-sender GCB and stays
+    K-row-major compatible.
 
     Returns (tt_weight, addrs, gcb, num_iters_total, push_page_size_bytes, ring_size).
     """
@@ -112,7 +117,9 @@ def _setup_weight_and_gcb_dram_sender(device, K, N, dtype, recv_per_bank, num_la
         for b in range(num_dram_banks)
     ]
     gcb_size = _GCB_DEPTH_PAGES * push_page_size
-    gcb = ttnn.experimental.create_global_circular_buffer_with_dram_senders(device, bank_to_receivers, gcb_size)
+    gcb = ttnn.experimental.create_global_circular_buffer_with_dram_senders(
+        device, bank_to_receivers, gcb_size, dual_senders_per_bank=dual_senders
+    )
 
     num_iters_total = num_layers * ring_size
     return tt_weight, addrs, gcb, num_iters_total, push_page_size, ring_size
@@ -426,6 +433,30 @@ def test_validator_dram_sender_recv_contig(device, K, N, dtype, recv_per_bank, n
             global_cb=gcb,
             streaming=streaming,
             rotation=rotation,
+        )
+
+
+@pytest.mark.parametrize("K,N,dtype,num_layers", [(448, 1792, ttnn.bfloat16, 2)])
+def test_validator_dram_sender_dual_single_receiver_bank(device, K, N, dtype, num_layers):
+    """dual_senders_per_bank=True with a single receiver per bank (recv_per_bank=1).
+
+    A single receiver cannot split across two senders, so every bank falls back to its
+    primary sender and the mapping is identical to a single-sender GCB — previously this
+    was rejected with a TT_FATAL. num_blocks == num_dram_banks keeps it on the K-row-major
+    path (which the validator addresses uniformly), so this validates the fallback end to
+    end. Same shape as test_validator_dram_sender[bench_default], only dual_senders flipped.
+    """
+    tt_weight, addrs, gcb, num_iters_total, push_page_size, ring_size = _setup_weight_and_gcb_dram_sender(
+        device, K, N, dtype, recv_per_bank=1, num_layers=num_layers, dual_senders=True
+    )
+    with tensor_prefetcher_session(device):
+        ttnn.experimental.queue_tensor_prefetcher_request(device, [(tt_weight, ring_size)] * num_layers, global_cb=gcb)
+        ttnn.experimental.test_dram_prefetcher_validator(
+            device,
+            tt_weight,
+            num_layers=num_layers,
+            print_stride=max(1, ring_size // 4),
+            global_cb=gcb,
         )
 
 

--- a/tt_metal/api/tt-metalium/experimental/global_circular_buffer.hpp
+++ b/tt_metal/api/tt-metalium/experimental/global_circular_buffer.hpp
@@ -42,12 +42,12 @@ enum class SenderCoreType : uint8_t {
 // sets across senders must be disjoint and must not collide with the resolved DRAM-sender
 // physical NOC coords.
 //
-// When `dual_senders_per_bank` is true, each bank is driven by two DRISC sender cores
-// (the free subchannel plus the bank's NOC1-endpoint subchannel, both on NOC0); the
-// bank's receivers are split ceil/floor across them. This is only valid for the
-// receiver-contiguous DRAM layout. Every bank must then have at least two receivers
-// (one receiver cannot be split across two senders); a single-receiver bank is rejected
-// with a TT_FATAL — use `dual_senders_per_bank = false` for such topologies. The Tensor
+// When `dual_senders_per_bank` is true, each bank with two or more receivers is driven by
+// two DRISC sender cores (the free subchannel plus the bank's NOC1-endpoint subchannel, both
+// on NOC0); the bank's receivers are split ceil/floor across them. This is only valid for the
+// receiver-contiguous DRAM layout. A single-receiver bank cannot split one receiver across two
+// senders, so it falls back to a single sender (the free subchannel) with its secondary core
+// left parked — single- and dual-sender banks may coexist in one dual-mode GCB. The Tensor
 // prefetcher always provisions both cores and routes PREFETCH requests only to this GCB's
 // mapped sender subset.
 //

--- a/tt_metal/api/tt-metalium/experimental/global_circular_buffer.hpp
+++ b/tt_metal/api/tt-metalium/experimental/global_circular_buffer.hpp
@@ -45,10 +45,11 @@ enum class SenderCoreType : uint8_t {
 // When `dual_senders_per_bank` is true, each bank is driven by two DRISC sender cores
 // (the free subchannel plus the bank's NOC1-endpoint subchannel, both on NOC0); the
 // bank's receivers are split ceil/floor across them. This is only valid for the
-// receiver-contiguous DRAM layout and must match the TensorPrefetcherConfig flag used
-// at StartTensorPrefetcher. Every bank must then have at least two receivers (one
-// receiver cannot be split across two senders); a single-receiver bank is rejected with
-// a TT_FATAL — use `dual_senders_per_bank = false` for such topologies.
+// receiver-contiguous DRAM layout. Every bank must then have at least two receivers
+// (one receiver cannot be split across two senders); a single-receiver bank is rejected
+// with a TT_FATAL — use `dual_senders_per_bank = false` for such topologies. The Tensor
+// prefetcher always provisions both cores and routes PREFETCH requests only to this GCB's
+// mapped sender subset.
 //
 // MeshDevice-only: the arena that backs this GCB's pages_sent allocation lives on
 // MeshDeviceImpl, so a bare IDevice cannot construct one.

--- a/tt_metal/api/tt-metalium/experimental/tensor_prefetcher.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor_prefetcher.hpp
@@ -33,16 +33,8 @@ namespace experimental {
 
 class GlobalCircularBuffer;
 
-struct TensorPrefetcherConfig {
-    // When true, drive each DRAM bank with two DRISC sender cores instead of one:
-    // the free non-endpoint subchannel plus the bank's NOC1-endpoint subchannel
-    // (both write on NOC0). The bank's receivers are split ceil/floor across the two
-    // cores, adding a second DMA engine + NoC initiator per bank. Only supported for
-    // the receiver-contiguous DRAM layout. The GlobalCircularBuffer must be created
-    // with the matching `dual_senders_per_bank` flag so its sender cores agree with
-    // the prefetcher's; a mismatch is rejected at QueueTensorPrefetcherRequest.
-    bool dual_senders_per_bank = false;
-};
+// Reserved for future prefetcher-wide options.
+struct TensorPrefetcherConfig {};
 
 // Returns true if the Tensor prefetcher is supported on `mesh_device`, i.e.
 // programmable DRAM cores are available (Blackhole with firmware >= 19.12.0.0 and
@@ -90,10 +82,14 @@ struct TensorPrefetcherInput {
     std::vector<uint32_t> rotation = {};
 };
 
-// Build per-device Programs (one DRISC kernel per DRAM sender core), allocate
+// Build per-device Programs (two DRISC kernels per DRAM bank), allocate
 // the per-(device, sender) H2D sockets, and spawn the host worker thread that
 // drains the request queue. Returns immediately. No prefetch work is scheduled
 // yet — kernels park on socket_wait_for_pages.
+//
+// Each queued GCB selects which of the provisioned senders receive its PREFETCH
+// requests. Single-sender GCBs leave the second sender for each bank idle; dual-sender
+// GCBs use both.
 //
 // Receiver count is owned by each GCB (read from the per-GCB sender state
 // block on every request), so a single prefetcher can serve GCBs with

--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -538,21 +538,21 @@ std::vector<std::pair<CoreCoord, CoreRangeSet>> build_dram_sender_mapping(
             continue;
         }
 
-        // Dual mode launches two senders per *every* bank (the prefetcher's enumerate_dram_senders
-        // does the same unconditionally), so a single-receiver bank can't be supported — splitting
-        // one receiver across two senders is impossible, and silently collapsing it to one sender
-        // would desync the GCB's sender count from the prefetcher's. Reject it with a clear message.
-        TT_FATAL(
-            n >= 2,
-            "DRAM bank {} has a single receiver, but dual_senders_per_bank requires at least 2 receivers per "
-            "bank. Use dual_senders_per_bank=false for this topology.",
-            bank_id);
+        // A single receiver cannot be split across two senders. Since the prefetcher always
+        // provisions both senders per bank and routes PREFETCH only to the senders this GCB
+        // actually maps, we can map just the primary sender for such a bank and leave the
+        // secondary parked — same as the single-sender path. Dual- and single-sender banks may
+        // therefore coexist in one dual-mode GCB.
+        const std::vector<CoreCoord> sender_cores = mesh_device->impl().dram_sender_logical_cores(bank_id);
+        if (n == 1) {
+            mapping.emplace_back(sender_cores.at(0), receivers);
+            continue;
+        }
 
         // Two sender cores per bank: split the bank's ordered receivers ceil/floor.
         // select_from_corerangeset indices are inclusive and traverse row-wise (matching
         // corerange_to_cores used elsewhere), so the receiver-table / bank-local slab
         // order is preserved.
-        const std::vector<CoreCoord> sender_cores = mesh_device->impl().dram_sender_logical_cores(bank_id);
         const uint32_t first_count = (n + 1) / 2;
         mapping.emplace_back(sender_cores.at(0), select_from_corerangeset(receivers, 0, first_count - 1, true));
         mapping.emplace_back(sender_cores.at(1), select_from_corerangeset(receivers, first_count, n - 1, true));

--- a/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
@@ -407,19 +407,35 @@ void TensorPrefetcherManager::enumerate_dram_senders() {
     const uint32_t num_banks = soc_desc.get_num_dram_views();
     num_banks_ = num_banks;
     sender_logical_cores_.clear();
-    sender_logical_cores_.reserve((dual_senders_per_bank_ ? 2 : 1) * num_banks);
+    sender_logical_cores_.reserve(2 * num_banks);
     for (uint32_t b = 0; b < num_banks; ++b) {
-        if (dual_senders_per_bank_) {
-            // Two senders per bank: the free subchannel then the NOC1-endpoint subchannel.
-            // Must match the GCB factory's build_dram_sender_mapping ordering.
-            for (const CoreCoord& core : mesh_device_->impl().dram_sender_logical_cores(b)) {
-                sender_logical_cores_.push_back(core);
-            }
-        } else {
-            sender_logical_cores_.push_back(mesh_device_->impl().pick_unused_dram_logical_core(b));
+        // Two senders per bank: the free subchannel then the NOC1-endpoint subchannel.
+        // A queued GCB may use the primary only or both; PREFETCH fan-out targets its mapping.
+        for (const CoreCoord& core : mesh_device_->impl().dram_sender_logical_cores(b)) {
+            sender_logical_cores_.push_back(core);
         }
     }
     num_senders_ = static_cast<uint32_t>(sender_logical_cores_.size());
+}
+
+std::vector<uint32_t> TensorPrefetcherManager::sender_indices_for_gcb(
+    const experimental::GlobalCircularBuffer& gcb) const {
+    const auto& mapping = gcb.sender_receiver_core_mapping();
+    TT_FATAL(!mapping.empty(), "Tensor prefetcher: GCB sender mapping must not be empty");
+
+    std::vector<uint32_t> sender_indices;
+    sender_indices.reserve(mapping.size());
+    for (const auto& [sender, _receivers] : mapping) {
+        const auto it = std::find(sender_logical_cores_.begin(), sender_logical_cores_.end(), sender);
+        TT_FATAL(
+            it != sender_logical_cores_.end(),
+            "Tensor prefetcher: GCB sender core ({}, {}) is not one of the {} provisioned DRAM sender cores",
+            sender.x,
+            sender.y,
+            num_senders_);
+        sender_indices.push_back(static_cast<uint32_t>(std::distance(sender_logical_cores_.begin(), it)));
+    }
+    return sender_indices;
 }
 
 void TensorPrefetcherManager::allocate_sockets() {
@@ -490,9 +506,8 @@ void TensorPrefetcherManager::build_and_launch_programs(uint32_t stage_ring_base
     }
 }
 
-void TensorPrefetcherManager::start(const experimental::TensorPrefetcherConfig& config) {
+void TensorPrefetcherManager::start() {
     auto lock = lock_api_function_();
-    dual_senders_per_bank_ = config.dual_senders_per_bank;
     TT_FATAL(!active_, "A Tensor prefetcher is already active on this mesh device. Call StopTensorPrefetcher first.");
 
     const auto& hal = MetalContext::instance(mesh_device_->impl().get_context_id()).hal();
@@ -600,14 +615,28 @@ std::vector<std::vector<std::vector<uint8_t>>> TensorPrefetcherManager::serializ
 
     // Derive the receiver counts from the GCB itself so each Queue call can target a
     // GCB with a different receiver count. total_receivers (== ring_size) and
-    // receivers_per_bank are independent of how many DRISC senders drive a bank; the
-    // per-sender split (when dual_senders_per_bank_) just partitions a bank's receivers.
+    // receivers_per_bank are independent of how many DRISC senders drive a bank.
     const auto& mapping = gcb.sender_receiver_core_mapping();
     uint32_t total_receivers = 0;
     for (const auto& [_sender, receivers] : mapping) {
         total_receivers += receivers.num_cores();
     }
     TT_FATAL(num_banks_ > 0, "Tensor prefetcher: num_banks must be > 0");
+    // K-row-major stores one complete per-bank shard, so all receivers for a bank must
+    // remain on its primary sender. Receiver-contiguous tensors may use either this
+    // topology or a dual-sender split.
+    bool krow_compatible_mapping = mapping.size() == num_banks_;
+    std::vector<bool> primary_bank_seen(num_banks_, false);
+    if (krow_compatible_mapping) {
+        for (const auto& [sender, _receivers] : mapping) {
+            const uint32_t bank = static_cast<uint32_t>(sender.x);
+            if (bank >= num_banks_ || primary_bank_seen[bank] || sender != sender_logical_cores_[2 * bank]) {
+                krow_compatible_mapping = false;
+                break;
+            }
+            primary_bank_seen[bank] = true;
+        }
+    }
     // receivers_per_bank is only consumed by the K-row-major layout (single sender per
     // bank). Recv-contig derives its geometry from the shard shape and ignores it, and
     // its receivers need not be uniform per bank — so the even-divisibility requirement
@@ -631,12 +660,11 @@ std::vector<std::vector<std::vector<uint8_t>>> TensorPrefetcherManager::serializ
     }
     const uint32_t layout_stride = kLayoutBytes + max_receivers * static_cast<uint32_t>(sizeof(uint32_t));
 
-    // Per-socket bank-local slab index map, needed only when a tensor streams. The GCB owns the
+    // Per-GCB-sender bank-local slab index map, needed only when a tensor streams. The GCB owns the
     // recv_index_base accounting, so the slab indices come from its experimental accessor (single
     // source of truth) rather than being re-derived here. It is order-agnostic: this function maps
     // each receiver's (bank, slab index) to a global receiver position per tensor using that
-    // tensor's shard distribution. Reindex from GCB-mapping order to socket (sender_logical_cores_)
-    // order.
+    // tensor's shard distribution.
     bool any_streaming = false;
     for (const auto& input : data_tensors) {
         if (!input.rotation.empty()) {
@@ -644,23 +672,14 @@ std::vector<std::vector<std::vector<uint8_t>>> TensorPrefetcherManager::serializ
             break;
         }
     }
-    std::vector<std::vector<uint32_t>> slab_idx_by_socket(num_senders_);
+    std::vector<std::vector<uint32_t>> slab_idx_by_sender;
     if (any_streaming) {
-        const std::vector<std::vector<uint32_t>> slab_by_sender = experimental::receiver_slab_indices(gcb);
-        for (uint32_t s = 0; s < num_senders_; ++s) {
-            for (size_t m = 0; m < mapping.size(); ++m) {
-                if (mapping[m].first == sender_logical_cores_[s]) {
-                    slab_idx_by_socket[s] = slab_by_sender[m];
-                    break;
-                }
-            }
-            TT_FATAL(
-                !slab_idx_by_socket[s].empty(),
-                "Tensor prefetcher: streaming request but sender core ({}, {}) is not in the GCB's sender "
-                "mapping, so it has no slab indices to slice the rotation by.",
-                sender_logical_cores_[s].x,
-                sender_logical_cores_[s].y);
-        }
+        slab_idx_by_sender = experimental::receiver_slab_indices(gcb);
+        TT_FATAL(
+            slab_idx_by_sender.size() == mapping.size(),
+            "Tensor prefetcher: GCB returned {} sender slab-index lists for {} sender mappings",
+            slab_idx_by_sender.size(),
+            mapping.size());
 
         // Both the strided and contiguous (bank, slab index) -> global position formulas are
         // bijections onto [0, total_receivers) only when the DRAM banks are dense 0..num_banks-1 and
@@ -765,13 +784,10 @@ std::vector<std::vector<std::vector<uint8_t>>> TensorPrefetcherManager::serializ
         // rotation participates in dedup (slot_equal), so tensors that differ only in rotation get
         // distinct slots.
         layout.streaming = streaming ? 1u : 0u;
-        // dual_senders_per_bank only makes sense for the receiver-contiguous layout (a K-row-major
-        // bank holds one shard, nothing to split). Reject the mismatch here rather than silently
-        // building wrong per-sender geometry.
         TT_FATAL(
-            !dual_senders_per_bank_ || layout.layout_mode == static_cast<uint32_t>(LayoutMode::ReceiverContiguous),
-            "Tensor prefetcher: dual_senders_per_bank is only supported for the receiver-contiguous "
-            "DRAM layout, but input tensor {} is K-row-major.",
+            layout.layout_mode != static_cast<uint32_t>(LayoutMode::KRowMajor) || krow_compatible_mapping,
+            "Tensor prefetcher: K-row-major input tensor {} requires exactly one primary sender per DRAM bank; "
+            "the supplied GCB uses a split or incompatible sender topology.",
             tensor_idx);
 
         // The sender's free-space poll counts whole per-receiver pages; if the GCB's per-receiver
@@ -827,9 +843,8 @@ std::vector<std::vector<std::vector<uint8_t>>> TensorPrefetcherManager::serializ
     // ---- Materialize each logical page into one byte buffer per sender ----
     // Header/entry/geometry bytes are identical across senders; only each slot's rotation region
     // differs (this sender's slice of the caller's global rotation). A page whose every slot is
-    // batched (no rotation) is byte-identical for all senders, so it is emitted once as a broadcast
-    // page (per_sender size 1; worker_loop sends that single buffer to every sender) rather than
-    // num_senders_ identical copies.
+    // batched (no rotation) is byte-identical for all mapped GCB senders, so it is emitted once
+    // rather than making identical copies.
     std::vector<std::vector<std::vector<uint8_t>>> pages;
     pages.reserve(plans.size());
     for (const auto& plan : plans) {
@@ -860,13 +875,13 @@ std::vector<std::vector<std::vector<uint8_t>>> TensorPrefetcherManager::serializ
             std::memcpy(templ.data() + slot_start, &plan.slots[i].geom, kLayoutBytes);
         }
 
-        const uint32_t num_variants = page_has_rotation ? num_senders_ : 1u;
+        const uint32_t num_variants = page_has_rotation ? static_cast<uint32_t>(mapping.size()) : 1u;
         std::vector<std::vector<uint8_t>> per_sender(num_variants);
         for (uint32_t s = 0; s < num_variants; ++s) {
             std::vector<uint8_t> page = templ;
-            const auto& slab = slab_idx_by_socket[s];
-            const uint32_t bank = static_cast<uint32_t>(sender_logical_cores_[s].x);
             if (page_has_rotation) {
+                const auto& slab = slab_idx_by_sender[s];
+                const uint32_t bank = static_cast<uint32_t>(mapping[s].first.x);
                 for (uint32_t i = 0; i < plan.slots.size(); ++i) {
                     if (plan.slots[i].rotation.empty()) {
                         continue;
@@ -904,17 +919,13 @@ void TensorPrefetcherManager::queue(
     TT_FATAL(
         experimental::sender_core_type(gcb) == experimental::SenderCoreType::Dram,
         "QueueTensorPrefetcherRequest requires a DRAM-sender GlobalCircularBuffer");
-    TT_FATAL(
-        gcb.sender_receiver_core_mapping().size() == num_senders_,
-        "GCB num_senders ({}) does not match prefetcher num_senders ({})",
-        gcb.sender_receiver_core_mapping().size(),
-        num_senders_);
+    const std::vector<uint32_t> target_sender_indices = sender_indices_for_gcb(gcb);
     TT_FATAL(!tensors.empty(), "QueueTensorPrefetcherRequest requires at least one tensor");
 
     // A Queue call may span more tensors than fit in one socket page; serialize into one
     // or more pages, each an independent request. The per-GCB fifo_wr_ptr persists across
-    // requests, so the split is invisible to the receiver. Each logical page is materialized
-    // per sender (different rotation slice), so `pages[p]` is a vector of num_senders_ buffers.
+    // requests, so the split is invisible to the receiver. A streaming logical page is materialized
+    // per mapped GCB sender because each carries a different rotation slice.
     std::vector<std::vector<std::vector<uint8_t>>> pages = serialize_request_pages(gcb, tensors);
 
     // Target devices: subset if given, else full mesh. Caller is responsible
@@ -946,6 +957,7 @@ void TensorPrefetcherManager::queue(
             Request req;
             req.sender_pages = std::move(sender_pages);
             req.target_devices = target_devices;
+            req.target_sender_indices = target_sender_indices;
             if (recording_trace_id.has_value()) {
                 trace_requests_[*recording_trace_id].push_back(std::move(req));
             } else {
@@ -1079,12 +1091,24 @@ void TensorPrefetcherManager::worker_loop() {
             pending_.pop_front();
         }
 
-        // Fan out: try_write to every target socket; round-robin until each succeeds. Each
-        // socket gets that sender's own page (sender_pages indexed by sender s); STOP / WAIT_CQ
-        // carry a single shared page (sender_pages size 1), broadcast to every sender.
-        const bool broadcast = req.sender_pages.size() == 1;
-        std::vector<uint32_t> remaining_target_sockets;
-        remaining_target_sockets.reserve(req.target_devices.size() * num_senders_);
+        // PREFETCH targets only the sender cores mapped by its GCB. STOP / WAIT_CQ leave
+        // target_sender_indices empty and broadcast to every provisioned sender.
+        const bool fanout_all_senders = req.target_sender_indices.empty();
+        TT_FATAL(!req.sender_pages.empty(), "Tensor prefetcher worker received a request with no socket page");
+        TT_FATAL(
+            fanout_all_senders || req.sender_pages.size() == 1 ||
+                req.sender_pages.size() == req.target_sender_indices.size(),
+            "Tensor prefetcher request has {} sender pages for {} target senders",
+            req.sender_pages.size(),
+            req.target_sender_indices.size());
+        struct TargetSocket {
+            uint32_t socket_index = 0;
+            uint32_t page_index = 0;
+        };
+        std::vector<TargetSocket> remaining_target_sockets;
+        const uint32_t senders_per_device =
+            fanout_all_senders ? num_senders_ : static_cast<uint32_t>(req.target_sender_indices.size());
+        remaining_target_sockets.reserve(req.target_devices.size() * senders_per_device);
         for (const auto& dev_coord : req.target_devices) {
             auto it = device_index_by_coord_.find(dev_coord);
             TT_FATAL(
@@ -1094,22 +1118,34 @@ void TensorPrefetcherManager::worker_loop() {
                 "on; would silently drop the request for that device",
                 dev_coord);
             const uint32_t d = it->second;
-            for (uint32_t s = 0; s < num_senders_; ++s) {
-                remaining_target_sockets.push_back(d * num_senders_ + s);
+            if (fanout_all_senders) {
+                for (uint32_t s = 0; s < num_senders_; ++s) {
+                    remaining_target_sockets.push_back(TargetSocket{d * num_senders_ + s, 0});
+                }
+            } else {
+                for (uint32_t page_index = 0; page_index < req.target_sender_indices.size(); ++page_index) {
+                    const uint32_t sender_index = req.target_sender_indices[page_index];
+                    TT_FATAL(
+                        sender_index < num_senders_,
+                        "Tensor prefetcher request targets sender index {} but only {} senders are provisioned",
+                        sender_index,
+                        num_senders_);
+                    remaining_target_sockets.push_back(
+                        TargetSocket{d * num_senders_ + sender_index, req.sender_pages.size() == 1 ? 0u : page_index});
+                }
             }
         }
 
         // Round-robin try_write with non-blocking attempts.
-        std::vector<uint32_t> still_pending = std::move(remaining_target_sockets);
+        std::vector<TargetSocket> still_pending = std::move(remaining_target_sockets);
         while (!still_pending.empty()) {
-            std::vector<uint32_t> next_pending;
-            for (uint32_t sock_idx : still_pending) {
-                const uint32_t s = sock_idx % num_senders_;
-                std::vector<uint8_t>& page = broadcast ? req.sender_pages[0] : req.sender_pages[s];
-                if (experimental::detail::try_write(*sockets_[sock_idx], page.data(), 1)) {
+            std::vector<TargetSocket> next_pending;
+            for (const TargetSocket& target : still_pending) {
+                std::vector<uint8_t>& page = req.sender_pages[target.page_index];
+                if (experimental::detail::try_write(*sockets_[target.socket_index], page.data(), 1)) {
                     // Wrote successfully.
                 } else {
-                    next_pending.push_back(sock_idx);
+                    next_pending.push_back(target);
                 }
             }
             // If no socket drained this pass, every remaining target is back-pressured;
@@ -1185,9 +1221,9 @@ bool IsTensorPrefetcherSupported(const distributed::MeshDevice& mesh_device) {
     return hal.has_programmable_core_type(HalProgrammableCoreType::DRAM);
 }
 
-void StartTensorPrefetcher(distributed::MeshDevice& mesh_device, const TensorPrefetcherConfig& config) {
+void StartTensorPrefetcher(distributed::MeshDevice& mesh_device, const TensorPrefetcherConfig&) {
     auto& manager = mesh_device.impl().tensor_prefetcher(&mesh_device);
-    manager.start(config);
+    manager.start();
 }
 
 void QueueTensorPrefetcherRequest(

--- a/tt_metal/impl/buffers/tensor_prefetcher_manager.hpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_manager.hpp
@@ -77,7 +77,7 @@ public:
     TensorPrefetcherManager(TensorPrefetcherManager&&) = delete;
     TensorPrefetcherManager& operator=(TensorPrefetcherManager&&) = delete;
 
-    void start(const experimental::TensorPrefetcherConfig& config);
+    void start();
 
     // When `cq_id`'s command queue is mid trace-capture, the serialized request pages are
     // captured into trace_requests_ keyed by that trace's MeshTraceId instead of being sent
@@ -127,24 +127,25 @@ private:
     static constexpr uint32_t kSocketFifoPages = 128;
 
     struct Request {
-        // One logical socket page, materialized per sender. Either size num_senders_ (a
-        // PREFETCH page — each sender carries only its own slice of the per-receiver streaming
-        // rotation table, so the bytes differ per sender) or size 1 (STOP / WAIT_CQ — no
-        // rotation, identical bytes broadcast to every sender). worker_loop indexes
-        // sender_pages[sender_pages.size() == 1 ? 0 : s].
+        // One logical socket page. For PREFETCH this is either one shared page or one page
+        // per entry in target_sender_indices (streaming rotations differ by sender).
+        // STOP / WAIT_CQ carry one shared page and leave target_sender_indices empty to
+        // broadcast to every provisioned sender.
         std::vector<std::vector<uint8_t>> sender_pages;
         std::vector<MeshCoordinate> target_devices;
+        std::vector<uint32_t> target_sender_indices;
     };
 
     void worker_loop();
     void enumerate_dram_senders();
+    std::vector<uint32_t> sender_indices_for_gcb(const experimental::GlobalCircularBuffer& gcb) const;
     void build_and_launch_programs(uint32_t stage_ring_base, uint32_t stage_ring_size);
     void allocate_sockets();
     // Serialize a Queue call's tensors into one or more socket pages, deduplicating
     // tensor layouts within each page and splitting when a page fills. Returns one entry per
-    // logical page; each entry is a per-sender vector (size num_senders_) of materialized page
-    // bytes — the header/entry/geometry bytes are identical across senders, while each sender's
-    // page carries only that sender's slice of the per-receiver streaming rotation table.
+    // logical page; each entry is either one shared page or a vector in GCB sender-mapping
+    // order. The header/entry/geometry bytes are identical across senders, while a streaming
+    // page carries only that GCB sender's slice of the per-receiver rotation table.
     std::vector<std::vector<std::vector<uint8_t>>> serialize_request_pages(
         const experimental::GlobalCircularBuffer& gcb,
         const std::vector<experimental::TensorPrefetcherInput>& data_tensors) const;
@@ -172,15 +173,12 @@ private:
     // write and the WAIT_CQ request value.
     std::array<uint32_t, kNumCqSignalSlots> cq_signal_counter_{};
 
-    // sender_logical_cores_[s] = logical DRAM core for sender s. Picked at start
-    // via pick_unused_dram_logical_core / dram_sender_logical_cores; GCBs queued
-    // must use the same picks (deterministic on bank_id), which they do because the
-    // GCB factory calls the same pickers with the same dual_senders_per_bank flag.
+    // sender_logical_cores_[s] = logical DRAM core for sender s. Both available
+    // sender cores per bank are provisioned at start. Each queued GCB may map either
+    // the primary sender only or both senders; PREFETCH requests target that subset.
     std::vector<CoreCoord> sender_logical_cores_;
     uint32_t num_senders_ = 0;
     uint32_t num_banks_ = 0;
-    // When true, each DRAM bank is driven by two sender cores (see TensorPrefetcherConfig).
-    bool dual_senders_per_bank_ = false;
 
     // One program per IDevice in the mesh; programs_[d].
     std::vector<std::unique_ptr<Program>> programs_;

--- a/tt_metal/impl/host_api/tt_metal.cpp
+++ b/tt_metal/impl/host_api/tt_metal.cpp
@@ -884,6 +884,27 @@ void LaunchProgram(
     LaunchProgram(device, *program, wait_until_cores_done, force_slow_dispatch);
 }
 
+// Returns true iff the program has kernels and every core it targets is a DRAM programmable core.
+// Such programs (e.g. the persistent tensor-prefetcher DRISC senders) are disjoint from the FD
+// worker grid and dispatch column, so launching them via slow dispatch does not perturb an active
+// FD session. Used to scope the force-slow-dispatch guard in LaunchProgram.
+bool program_targets_only_dram_cores(const Program& program) {
+    const auto& logical_cores_used_in_program = program.impl().logical_cores();
+    const auto& hal = MetalContext::instance().hal();
+    bool has_any_core = false;
+    for (uint32_t programmable_core_type_index = 0; programmable_core_type_index < logical_cores_used_in_program.size();
+         programmable_core_type_index++) {
+        if (logical_cores_used_in_program[programmable_core_type_index].empty()) {
+            continue;
+        }
+        has_any_core = true;
+        if (hal.get_programmable_core_type(programmable_core_type_index) != HalProgrammableCoreType::DRAM) {
+            return false;
+        }
+    }
+    return has_any_core;
+}
+
 void LaunchProgram(IDevice* device, Program& program, bool wait_until_cores_done, bool force_slow_dispatch) {
     {  // Profiler scope start
         ZoneScoped;
@@ -900,8 +921,13 @@ void LaunchProgram(IDevice* device, Program& program, bool wait_until_cores_done
             // Scope the service bypass to this device
             const bool service_active =
                 !tt::tt_metal::MetalContext::instance().get_service_core_manager().claimed_cores(device->id()).empty();
+            // DRAM-only programs (e.g. the persistent tensor-prefetcher DRISC senders) run on the DRAM
+            // programmable cores, which are disjoint from the FD worker grid and dispatch column. Launching
+            // them via slow dispatch does not touch FD-owned cores or the FD pipeline, so it is safe to mix
+            // with an active FD session regardless of profiler init state.
+            const bool dram_only = detail::program_targets_only_dram_cores(program);
             TT_ASSERT(
-                !(fd_active && rt_done) || service_active,
+                !(fd_active && rt_done) || service_active || dram_only,
                 "Cannot force slow dispatch while fast dispatch firmware is active and real-time profiler init has "
                 "completed on this device.");
         }

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1945,11 +1945,9 @@ void detail::ProgramImpl::populate_dispatch_data(IDevice* device) {
             } else {
                 // Non-multicast cores are dispatched via unicast. Historically this was only ETH, but
                 // DRAM programmable cores (e.g. the tensor-prefetcher DRISC senders) are also unicast-only
-                // and take the same path — extract_dst_noc_unicast_info handles either core type.
-                TT_ASSERT(
-                    core_type == CoreType::ETH || core_type == CoreType::DRAM,
-                    "Unexpected non-multicast core type {} in populate_dispatch_data",
-                    enchantum::to_string(core_type));
+                // and take the same path — extract_dst_noc_unicast_info handles either core type. The
+                // branch above (get_supports_receiving_multicasts) is the authoritative hal query, so no
+                // enumerated core-type check is needed here.
                 std::vector<std::pair<transfer_info_cores, uint32_t>> dst_noc_unicast_info =
                     extract_dst_noc_unicast_info(kernel_group->core_ranges.ranges(), core_type);
 

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1943,8 +1943,13 @@ void detail::ProgramImpl::populate_dispatch_data(IDevice* device) {
                     }
                 }
             } else {
-                // Below assumes ethernet dispatch class
-                TT_ASSERT(core_type == CoreType::ETH);
+                // Non-multicast cores are dispatched via unicast. Historically this was only ETH, but
+                // DRAM programmable cores (e.g. the tensor-prefetcher DRISC senders) are also unicast-only
+                // and take the same path — extract_dst_noc_unicast_info handles either core type.
+                TT_ASSERT(
+                    core_type == CoreType::ETH || core_type == CoreType::DRAM,
+                    "Unexpected non-multicast core type {} in populate_dispatch_data",
+                    enchantum::to_string(core_type));
                 std::vector<std::pair<transfer_info_cores, uint32_t>> dst_noc_unicast_info =
                     extract_dst_noc_unicast_info(kernel_group->core_ranges.ranges(), core_type);
 

--- a/ttnn/api/ttnn/global_circular_buffer.hpp
+++ b/ttnn/api/ttnn/global_circular_buffer.hpp
@@ -100,8 +100,8 @@ uint32_t tensor_prefetcher_block_count_for_matmul_1d(
 //   * `size` minimum is ring_size * largest per-receiver page (= (K_tiles/ring_size) * per_core_N * tile);
 //   * receivers need NOT be uniform per bank and the bank->ring mapping is the strided round-robin one,
 //     so no per-bank-count / contiguous-ring assertions (the matmul op asserts the strided walk);
-//   * `dual_senders_per_bank` may split each bank's receivers across two DRISC sender cores (must match
-//     the StartTensorPrefetcher flag).
+//   * `dual_senders_per_bank` may split each bank's receivers across two DRISC sender cores. The
+//     Tensor prefetcher always provisions both cores and targets the subset mapped by this GCB.
 //
 // Per (config, weight) it runs the same recv-contig cross-checks as
 // tensor_prefetcher_block_count_for_matmul_1d (num_shards == ring_size, weight K-tiles divisible by

--- a/ttnn/api/ttnn/global_circular_buffer.hpp
+++ b/ttnn/api/ttnn/global_circular_buffer.hpp
@@ -100,8 +100,9 @@ uint32_t tensor_prefetcher_block_count_for_matmul_1d(
 //   * `size` minimum is ring_size * largest per-receiver page (= (K_tiles/ring_size) * per_core_N * tile);
 //   * receivers need NOT be uniform per bank and the bank->ring mapping is the strided round-robin one,
 //     so no per-bank-count / contiguous-ring assertions (the matmul op asserts the strided walk);
-//   * `dual_senders_per_bank` may split each bank's receivers across two DRISC sender cores. The
-//     Tensor prefetcher always provisions both cores and targets the subset mapped by this GCB.
+//   * `dual_senders_per_bank` may split each bank's receivers across two DRISC sender cores
+//     (a single-receiver bank falls back to one sender, so mixed single/dual banks are allowed).
+//     The Tensor prefetcher always provisions both cores and targets the subset mapped by this GCB.
 //
 // Per (config, weight) it runs the same recv-contig cross-checks as
 // tensor_prefetcher_block_count_for_matmul_1d (num_shards == ring_size, weight K-tiles divisible by

--- a/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher.cpp
@@ -13,8 +13,8 @@ bool is_tensor_prefetcher_supported(tt::tt_metal::distributed::MeshDevice* mesh_
     return tt::tt_metal::experimental::IsTensorPrefetcherSupported(*mesh_device);
 }
 
-void start_tensor_prefetcher(tt::tt_metal::distributed::MeshDevice* mesh_device, bool dual_senders_per_bank) {
-    tt::tt_metal::experimental::StartTensorPrefetcher(*mesh_device, {.dual_senders_per_bank = dual_senders_per_bank});
+void start_tensor_prefetcher(tt::tt_metal::distributed::MeshDevice* mesh_device) {
+    tt::tt_metal::experimental::StartTensorPrefetcher(*mesh_device, {});
 }
 
 void queue_tensor_prefetcher_request(

--- a/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher.hpp
@@ -55,7 +55,7 @@ using TensorPrefetcherQueueTensor =
 // when start_tensor_prefetcher would otherwise raise.
 bool is_tensor_prefetcher_supported(tt::tt_metal::distributed::MeshDevice* mesh_device);
 
-void start_tensor_prefetcher(tt::tt_metal::distributed::MeshDevice* mesh_device, bool dual_senders_per_bank = false);
+void start_tensor_prefetcher(tt::tt_metal::distributed::MeshDevice* mesh_device);
 
 void queue_tensor_prefetcher_request(
     tt::tt_metal::distributed::MeshDevice* mesh_device,

--- a/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher_nanobind.cpp
@@ -48,14 +48,12 @@ void bind_tensor_prefetcher(nb::module_& mod) {
 
             Args:
                 mesh_device (ttnn.MeshDevice): the mesh device to launch on.
-                dual_senders_per_bank (bool): if True, run two DRISC sender kernels per DRAM
-                    bank (the free subchannel plus the NOC1-endpoint subchannel, both on NOC0)
-                    and split each bank's receivers across them. Recv-contig layout only; the
-                    GCB must be created with the matching flag. Defaults to False.
+
+            Two sender kernels are provisioned per DRAM bank. Each queued GCB selects one
+            or both senders per bank; unused senders remain parked on their sockets.
         )doc",
         &start_tensor_prefetcher,
-        nb::arg("mesh_device"),
-        nb::arg("dual_senders_per_bank") = false);
+        nb::arg("mesh_device"));
 
     ttnn::bind_function<"queue_tensor_prefetcher_request", "ttnn.experimental.">(
         mod,
@@ -157,7 +155,8 @@ void bind_tensor_prefetcher(nb::module_& mod) {
                 size: Per-receiver fifo size in bytes.
                 buffer_type: Buffer type (L1 or L1_SMALL).
                 dual_senders_per_bank: If True, split each bank's receivers across two DRISC
-                    sender cores (recv-contig layout only); must match the prefetcher config.
+                    sender cores (receiver-contiguous layout only). Otherwise, the GCB targets
+                    only the primary sender and the second provisioned prefetcher sender remains idle.
         )doc",
         &ttnn::global_circular_buffer::create_global_circular_buffer_with_dram_senders,
         nb::keep_alive<0, 1>(),
@@ -230,7 +229,7 @@ void bind_tensor_prefetcher(nb::module_& mod) {
                 size: GCB size in bytes (>= ring_size * largest per-receiver page).
                 buffer_type: Buffer type (L1 or L1_SMALL).
                 dual_senders_per_bank: If True, split each bank's receivers across two DRISC sender cores
-                    (must match the StartTensorPrefetcher flag).
+                    instead of targeting only the primary sender.
         )doc",
         &ttnn::global_circular_buffer::create_global_circular_buffer_for_matmul_1d_recv_contig,
         nb::keep_alive<0, 1>(),


### PR DESCRIPTION
### PR Category
Feature

### Summary
Always provision both DRISC sender cores per DRAM bank, while routing each PREFETCH request only to the sender cores present in its GlobalCircularBuffer (GCB). This preserves legacy single-sender width-sharded GCBs by leaving the secondary per-bank kernel parked on its socket, while retaining optional dual-sender GCBs for receiver-contiguous tensors — so a single prefetcher session can switch between single- and dual-sender GCBs.

- `TensorPrefetcherManager` always enumerates both `dram_sender_logical_cores(bank)` per bank. PREFETCH fan-out is decoupled from the control-message broadcast: each queued/captured request stores the active sender indices resolved from its GCB mapping and sends batched/streaming pages only to that subset, while WAIT_CQ and STOP still target all senders so idle kernels stay ordered and terminate cleanly.
- The start-time `dual_senders_per_bank` flag is removed from the Metal `TensorPrefetcherConfig` and the ttnn C++/Python bindings. The GCB-level `dual_senders_per_bank` option is kept — it now selects which subset of the always-provisioned sender pool drives that GCB. The sender-count equality check is replaced with validation that every GCB sender belongs to the provisioned pool.
- K-row-major legacy tensors are allowed when their GCB maps the single primary sender per bank; an incompatible split/dual GCB paired with K-row-major data is still clearly rejected.

Also loosen two debug-only asserts that the prefetcher's persistent slow-dispatch DRISC launch trips while FD firmware is active. These were never exercised before because `TT_ASSERT` is compiled out in release builds:

- `LaunchProgram` ("Cannot force slow dispatch while fast dispatch firmware is active…"): now permits `force_slow_dispatch` when the program targets only DRAM programmable cores, which are disjoint from the FD worker grid and dispatch column, so the launch cannot perturb an active FD session.
- `populate_dispatch_data` (`core_type == CoreType::ETH`): the non-multicast (unicast) branch assumed ETH; DRAM cores are also unicast-only and take the identical path.

Relates to #45751

### Notes for reviewers
- Focus on the PREFETCH-subset routing vs. the still-broadcast WAIT_CQ/STOP path in `tensor_prefetcher_manager.cpp`, and on the two loosened asserts (`tt_metal/impl/host_api/tt_metal.cpp`, `tt_metal/impl/program/program.cpp`). The asserts are widened only for DRAM-only programs; worker/ETH programs are unaffected.
- Validated on Blackhole in a debug (asserts-enabled) build: the full `test_prefetcher_BH_validator.py` suite passes (legacy width-sharded dram_sender, recv-contig single/dual/streaming, shard-contiguous, mixed-receiver, multi-GCB switching, worker_sender, page-size switch), plus `test_prefetcher_BH_bench.py` trace-replay smoke for `dram_core_repeats` and `dram_core_repeats_recv_contig` (round_robin + shard_contiguous) on the 1B_QKV shape.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/always-dual-prefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/always-dual-prefetcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/always-dual-prefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/always-dual-prefetcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jbauman/always-dual-prefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jbauman/always-dual-prefetcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/always-dual-prefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/always-dual-prefetcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/always-dual-prefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/always-dual-prefetcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/always-dual-prefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/always-dual-prefetcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/always-dual-prefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/always-dual-prefetcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/always-dual-prefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/always-dual-prefetcher)