### PR TITLE
[fused_rms_minimal] Guard optional-arg crashes and document the layout contract

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.cpp
@@ -191,6 +191,12 @@ TensorSpec RMSAllGatherDeviceOperation::compute_output_specs(
     auto output_shape = input_tensor.logical_shape();
     auto output_padded_shape = input_tensor.padded_shape();
 
+    // This runs before validate_on_program_cache_miss (create_output_tensors is called ahead of validation in
+    // device_operation::launch), so guard the dereference here too rather than relying on the check in validate.
+    TT_FATAL(
+        args.output_mem_config.shard_spec().has_value(),
+        "fused_rms_minimal requires a sharded output memory config (width-sharded in L1); an interleaved output "
+        "memory config is not supported.");
     auto output_shard_spec = args.output_mem_config.shard_spec().value();
     auto input_shard_spec = input_tensor.shard_spec().value();
     if (output_shard_spec != input_shard_spec) {
@@ -198,10 +204,6 @@ TensorSpec RMSAllGatherDeviceOperation::compute_output_specs(
     }
 
     auto mem_config = args.output_mem_config;
-    if (!mem_config.shard_spec().has_value()) {
-        mem_config =
-            tt::tt_metal::MemoryConfig(mem_config.memory_layout(), mem_config.buffer_type(), input_tensor.shard_spec());
-    }
 
     return ttnn::TensorSpec(
         output_shape,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.cpp
@@ -39,6 +39,32 @@ void RMSAllGatherDeviceOperation::validate_on_program_cache_miss(
         (tt::tt_metal::hal::get_arch_name() != "blackhole") || (a.memory_config().buffer_type() != BufferType::DRAM),
         "This kernel does not support blackhole dram as it does not use an accessor to get the noc address as needed "
         "by the fabric api");
+
+    // Input layout contract (see the fused_rms_minimal docstring). The op is width-sharded in L1 and does not reshard
+    // internally, so reject anything that would otherwise dereference an empty shard spec below with a bad optional.
+    TT_FATAL(
+        a.is_sharded(),
+        "fused_rms_minimal requires a width-sharded L1 input; an interleaved input is not supported. Reshard to "
+        "width-sharded L1 first.");
+    TT_FATAL(
+        a.memory_config().buffer_type() == BufferType::L1,
+        "fused_rms_minimal requires the input in L1 but got buffer type {}.",
+        a.memory_config().buffer_type());
+    TT_FATAL(
+        a.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED,
+        "fused_rms_minimal requires a width-sharded input but got memory layout {}.",
+        a.memory_config().memory_layout());
+    // The all-gather addresses the input on the same cores the caller built the global_semaphore on, so the input
+    // shard grid must be covered by the semaphore's core range.
+    // Copy by value: attribute_values() returns a temporary tuple, so a reference into it would dangle.
+    const auto semaphore_cores = std::get<0>(args.semaphore.attribute_values());
+    TT_FATAL(
+        semaphore_cores.contains(a.shard_spec().value().grid),
+        "fused_rms_minimal requires the input to be sharded on the grid the global_semaphore was created on; the "
+        "input shard grid {} is not contained within the semaphore grid {}.",
+        a.shard_spec().value().grid,
+        semaphore_cores);
+
     uint32_t input_width = a.tensor_spec().tile().get_tile_shape()[1];
     uint32_t input_height = a.tensor_spec().tile().get_tile_shape()[0];
     TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.cpp
@@ -23,6 +23,11 @@ void RMSAllGatherDeviceOperation::validate_on_program_cache_miss(
     const auto& b = tensor_args.residual_input_tensor;
     const auto& gamma = tensor_args.weight;
 
+    TT_FATAL(
+        tensor_args.stats.has_value(),
+        "fused_rms_minimal requires a pre-allocated stats tensor; passing stats=None is not supported. It backs "
+        "an internal globally-allocated circular buffer.");
+
     TT_FATAL(a.padded_shape().rank() == 4, "Input shape must be rank 4");
     TT_FATAL(
         a.logical_shape()[0] == 1 && a.logical_shape()[1] == 1 && a.logical_shape()[2] <= 32 &&
@@ -36,6 +41,10 @@ void RMSAllGatherDeviceOperation::validate_on_program_cache_miss(
         "by the fabric api");
     uint32_t input_width = a.tensor_spec().tile().get_tile_shape()[1];
     uint32_t input_height = a.tensor_spec().tile().get_tile_shape()[0];
+    TT_FATAL(
+        args.output_mem_config.shard_spec().has_value(),
+        "fused_rms_minimal requires a sharded output memory config (width-sharded in L1); an interleaved output "
+        "memory config is not supported.");
     TT_FATAL(
         args.output_mem_config.shard_spec().value().orientation == ShardOrientation::ROW_MAJOR,
         "Minimal version requires row major sharding orientation");
@@ -57,8 +66,8 @@ void RMSAllGatherDeviceOperation::validate_on_program_cache_miss(
         TT_FATAL(a.device() == b.value().device(), "device is not same!");
     }
     TT_FATAL(
-        gamma.has_value() and gamma.value().layout() == Layout::ROW_MAJOR,
-        "RMS all gather requires a weight which is row major");
+        gamma.has_value(), "fused_rms_minimal requires a weight (gamma) tensor; passing weight=None is not supported.");
+    TT_FATAL(gamma.value().layout() == Layout::ROW_MAJOR, "RMS all gather requires a weight which is row major");
 
     if (gamma.has_value()) {
         if (gamma.value().layout() == Layout::TILE) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/rms_allgather_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/rms_allgather_nanobind.cpp
@@ -16,10 +16,34 @@ void bind_fused_rms_minimal(nb::module_& mod) {
     ttnn::bind_function<"fused_rms_minimal">(
         mod,
         R"doc(
-            This fuses pre RMS, all gather, post rms, residual add, gamma operations, and output resharding into one.
-            Requires a pre-allocated persistent tensor for the intermediate all gather that is tiled,
-                shape per device (32,32) and sharded with a shard shape (32,32) on core (0,0)
-            Requires that input the tensor be of shape (1,1,32,M) where M is a multiple of 32
+            Fused distributed RMS normalization. Fuses the pre-RMS reduction, the cross-device
+            all-gather of the partial statistics, post-RMS normalization, optional residual add,
+            gamma (weight) scaling, and output resharding into a single op. The computation is
+            width-sharded across a core grid: each core owns a slice of the hidden dimension and
+            the per-shard statistics are gathered across cores and devices.
+
+            The op is intentionally sharding-specific and validates the following requirements;
+            it does not reshard inputs/outputs internally, so callers (and compilers) must satisfy
+            the layout contract:
+
+            - input_tensor: shape (1, 1, M, N) with M <= 32 and N a multiple of 32; TILE layout;
+              dtype FLOAT32, BFLOAT16, or BFLOAT8_B. Must be width-sharded in L1 with ROW_MAJOR
+              shard orientation, sharded on the same core grid that ``global_semaphore`` was created
+              on. Interleaved / DRAM inputs are not accepted (reshard to width-sharded L1 first), and
+              Blackhole DRAM is unsupported.
+            - weight (gamma): required. ROW_MAJOR layout with 2-D shape (N/32, 32); dtype FLOAT32 or
+              BFLOAT16. Passing weight=None is not supported.
+            - stats: required. A pre-allocated tiled, width-sharded tensor of shape
+              (1, 1, 32, num_devices) that backs the op's internal all-gather circular buffer.
+              Passing stats=None is not supported, and its dtype must be consistent with the compute
+              config accumulation (e.g. FLOAT32 when fp32_dest_acc_en is enabled).
+            - memory_config (output): must be a sharded config whose buffer type and memory layout
+              match the input's. Interleaved output configs are not accepted; reshard the result
+              afterward if a downstream consumer needs interleaved/DRAM.
+            - residual_input_tensor (if provided): must be sharded with the same shard spec and memory
+              config as input_tensor.
+            - persistent_output_tensor: a pre-allocated tiled tensor for the intermediate all-gather,
+              per-device shape (32, 32), sharded with a shard shape (32, 32) on core (0, 0).
         )doc",
         &ttnn::fused_rms_minimal,
         nb::arg("input_tensor"),


### PR DESCRIPTION
Addresses the ergonomic sub-issues of #37746 on `fused_rms_minimal` (the `rms_allgather` op), in two parts.

## Part 1 — turn optional-arg crashes into clear validation errors

Replaces three bad-`std::optional`-access crashes in validation with explicit `TT_FATAL` checks, so unsupported inputs are **clearly rejected instead of segfaulting** — which is what unblocks tt-mlir integration (it can act on an error, not a crash).

| Issue | Before | After |
|-------|--------|-------|
| **#38205** `stats=None` | program factory dereferences `stats.value()` unguarded → bad optional access | `validate` requires `stats.has_value()` with a clear message |
| **#38207** interleaved output config | `output_mem_config.shard_spec().value()` unguarded → bad optional access | guarded with a clear "requires a sharded output memory config" message |
| **#38211** `weight=None` | single combined `TT_FATAL` | split so `weight=None` gets its own distinct message |

Note on #38211: the issue's "evaluates both sides regardless of short-circuit" premise is **stale** — `&&` short-circuits, so it already failed cleanly rather than crashing. This just makes the rejection explicit.

## Part 2 — document the layout contract

The op is intentionally sharding-specific and does **not** reshard internally: the input sharding is coupled to the caller-provided `global_semaphore` grid, the residual shard spec, and the persistent all-gather tensor. So rather than an internal reshard (fragile + hides cost from the compiler), the layout requirements are now spelled out in the op docstring — the "document the requirement" resolution the issues explicitly offer, and what actually helps the compiler place tensors + build the semaphore correctly:

- input must be width-sharded L1, ROW_MAJOR orientation, on the semaphore's grid; interleaved/DRAM not accepted (**#38208**)
- weight must be ROW_MAJOR 2-D `(N/32, 32)` (**#38209**)
- output memory config must be sharded, matching the input (**#38210**)
- stats is required; its dtype must match the compute accumulation (**#38205**, **#38206**)
- residual (if provided) must match the input shard spec


Closes #38205, #38207, #38208, #38209, #38210, #38211. Part of #37746.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amorrison/rms-allgather-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amorrison/rms-allgather-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amorrison/rms-allgather-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amorrison/rms-allgather-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amorrison/rms-allgather-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amorrison/rms-allgather-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amorrison/rms-allgather-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amorrison/rms-allgather-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amorrison/rms-allgather-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amorrison/rms-allgather-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amorrison/rms-allgather-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amorrison/rms-allgather-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amorrison/rms-allgather-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amorrison/rms-allgather-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amorrison/rms-allgather-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amorrison/rms-allgather-guards)