### PR TITLE
[ttnn] concat: drop redundant custom compute_program_hash

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_concat_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_concat_program_cache.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Program-cache regression tests for ttnn.concat (ConcatDeviceOperation).
+
+Pins the cache-keying granularity so it can be verified BEFORE and AFTER
+removing ConcatDeviceOperation::compute_program_hash. The custom hash keyed on
+dim, groups, output_mem_config, sub_core_grids, factory.index(),
+input_tensors.size() and each input/output TensorSpec (full shapes). The
+framework default hashes all attributes plus the entire input_tensors vector
+(count + each TensorSpec), so entry counts must be identical:
+
+- Same config -> reuse (1 entry); different data alone must NOT re-key.
+- Different dim / shape / dtype / number-of-inputs -> distinct entries.
+
+Concat's custom hash was originally added for the weak-boost-hash collision
+(PR #45144 / issue #47602); the default combiner is now splitmix64 plus a
+collision-free canonical key, so the default is strictly stronger.
+"""
+
+import pytest
+import torch
+
+import ttnn
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+@pytest.fixture
+def isolate_program_cache(device):
+    device.disable_and_clear_program_cache()
+    device.enable_program_cache()
+    yield
+    device.disable_and_clear_program_cache()
+
+
+def run_concat(device, shapes, dim, dtype=ttnn.bfloat16, seed=0):
+    """Concat a list of tensors inside the cache counter; return (torch_ref, tt_out)."""
+    torch.manual_seed(seed)
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    torch_inputs = [torch.rand(s, dtype=torch_dtype) for s in shapes]
+    torch_ref = torch.cat(torch_inputs, dim=dim)
+
+    tt_inputs = [ttnn.from_torch(t, layout=ttnn.TILE_LAYOUT, dtype=dtype, device=device) for t in torch_inputs]
+    with device.cache_entries_counter.measure():
+        tt_out = ttnn.concat(tt_inputs, dim=dim)
+    tt_out = ttnn.to_torch(tt_out)
+    return torch_ref, tt_out
+
+
+def test_concat_cache_reuse_same_config(device, isolate_program_cache):
+    """Same shapes/dim/dtype twice with different data -> 1 entry, different outputs."""
+    shapes = [(1, 1, 32, 64), (1, 1, 32, 64)]
+
+    ref1, out1 = run_concat(device, shapes, dim=3, seed=0)
+    assert_with_pcc(ref1, out1, 0.9999)
+    ref2, out2 = run_concat(device, shapes, dim=3, seed=42)
+    assert_with_pcc(ref2, out2, 0.9999)
+
+    assert device.cache_entries_counter.total == 1
+    assert not torch.equal(out1, out2)
+
+
+def test_concat_cache_miss_different_dim(device, isolate_program_cache):
+    """Different concat dim -> 2 entries."""
+    shapes = [(1, 1, 32, 64), (1, 1, 32, 64)]
+
+    ref1, out1 = run_concat(device, shapes, dim=3)
+    assert_with_pcc(ref1, out1, 0.9999)
+    ref2, out2 = run_concat(device, shapes, dim=2)
+    assert_with_pcc(ref2, out2, 0.9999)
+
+    assert device.cache_entries_counter.total == 2
+
+
+def test_concat_cache_miss_different_shape(device, isolate_program_cache):
+    """Same dim, different input shapes -> 2 entries."""
+    ref1, out1 = run_concat(device, [(1, 1, 32, 64), (1, 1, 32, 64)], dim=3)
+    assert_with_pcc(ref1, out1, 0.9999)
+    ref2, out2 = run_concat(device, [(1, 1, 64, 64), (1, 1, 64, 64)], dim=3)
+    assert_with_pcc(ref2, out2, 0.9999)
+
+    assert device.cache_entries_counter.total == 2
+
+
+def test_concat_cache_miss_different_dtype(device, isolate_program_cache):
+    """Same shapes/dim, different dtype -> 2 entries."""
+    shapes = [(1, 1, 32, 64), (1, 1, 32, 64)]
+
+    ref1, out1 = run_concat(device, shapes, dim=3, dtype=ttnn.bfloat16)
+    assert_with_pcc(ref1, out1, 0.9999)
+    ref2, out2 = run_concat(device, shapes, dim=3, dtype=ttnn.float32)
+    assert_with_pcc(ref2, out2, 0.9999)
+
+    assert device.cache_entries_counter.total == 2
+
+
+def test_concat_cache_miss_different_num_inputs(device, isolate_program_cache):
+    """Different number of input tensors -> 2 entries (input_tensors vector length keyed)."""
+    ref1, out1 = run_concat(device, [(1, 1, 32, 64), (1, 1, 32, 64)], dim=3)
+    assert_with_pcc(ref1, out1, 0.9999)
+    ref2, out2 = run_concat(device, [(1, 1, 32, 64), (1, 1, 32, 64), (1, 1, 32, 64)], dim=3)
+    assert_with_pcc(ref2, out2, 0.9999)
+
+    assert device.cache_entries_counter.total == 2

--- a/tests/ttnn/unit_tests/operations/data_movement/test_concat_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_concat_program_cache.py
@@ -74,13 +74,20 @@ def test_concat_cache_miss_different_dim(device, isolate_program_cache):
     assert device.cache_entries_counter.total == 2
 
 
-def test_concat_cache_miss_different_shape(device, isolate_program_cache):
-    """Same dim, different input shapes -> 2 entries."""
-    ref1, out1 = run_concat(device, [(1, 1, 32, 64), (1, 1, 32, 64)], dim=3)
+def test_concat_cache_miss_different_input_partition_same_output(device, isolate_program_cache):
+    """Different input partitioning, SAME concatenated output shape -> 2 entries.
+
+    Both invocations concat along dim=3 to the identical output (1, 1, 32, 128),
+    but partition the inputs differently: [96]+[32] vs [64]+[64]. A key derived
+    only from the output spec would collide here; distinct entries prove each
+    input TensorSpec (per-input geometry) is part of the cache key.
+    """
+    ref1, out1 = run_concat(device, [(1, 1, 32, 96), (1, 1, 32, 32)], dim=3)
     assert_with_pcc(ref1, out1, 0.9999)
-    ref2, out2 = run_concat(device, [(1, 1, 64, 64), (1, 1, 64, 64)], dim=3)
+    ref2, out2 = run_concat(device, [(1, 1, 32, 64), (1, 1, 32, 64)], dim=3)
     assert_with_pcc(ref2, out2, 0.9999)
 
+    assert out1.shape == out2.shape  # identical output spec
     assert device.cache_entries_counter.total == 2
 
 
@@ -96,11 +103,19 @@ def test_concat_cache_miss_different_dtype(device, isolate_program_cache):
     assert device.cache_entries_counter.total == 2
 
 
-def test_concat_cache_miss_different_num_inputs(device, isolate_program_cache):
-    """Different number of input tensors -> 2 entries (input_tensors vector length keyed)."""
+def test_concat_cache_miss_different_num_inputs_same_output(device, isolate_program_cache):
+    """Different input COUNT, SAME concatenated output shape -> 2 entries.
+
+    Both invocations concat along dim=3 to the identical output (1, 1, 32, 128),
+    but differ only in the number of inputs: 2 tensors ([64]+[64]) vs 3 tensors
+    ([32]+[32]+[64]). Holding the output constant isolates input-vector LENGTH:
+    distinct entries prove the full input_tensors vector (including its size) is
+    keyed, not just the derived output.
+    """
     ref1, out1 = run_concat(device, [(1, 1, 32, 64), (1, 1, 32, 64)], dim=3)
     assert_with_pcc(ref1, out1, 0.9999)
-    ref2, out2 = run_concat(device, [(1, 1, 32, 64), (1, 1, 32, 64), (1, 1, 32, 64)], dim=3)
+    ref2, out2 = run_concat(device, [(1, 1, 32, 32), (1, 1, 32, 32), (1, 1, 32, 64)], dim=3)
     assert_with_pcc(ref2, out2, 0.9999)
 
+    assert out1.shape == out2.shape  # identical output spec
     assert device.cache_entries_counter.total == 2

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.cpp
@@ -185,44 +185,6 @@ Tensor ConcatDeviceOperation::create_output_tensors(
     return create_device_tensor(output_spec, tensor_args.input_tensors[0].device());
 }
 
-ttsl::hash::hash_t ConcatDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    auto factory = select_program_factory(operation_attributes, tensor_args);
-    auto hash = tt::tt_metal::operation::hash_operation<ConcatDeviceOperation>(
-        operation_attributes.dim,
-        operation_attributes.groups,
-        operation_attributes.output_mem_config,
-        operation_attributes.sub_core_grids,
-        factory.index(),
-        tensor_args.input_tensors.size());
-
-    for (std::size_t tensor_index = 0; tensor_index < tensor_args.input_tensors.size(); ++tensor_index) {
-        const auto& tensor = tensor_args.input_tensors[tensor_index];
-        hash = ttsl::hash::hash_objects(
-            hash,
-            tensor_index,
-            tensor.logical_shape().rank(),
-            tensor.logical_shape(),
-            tensor.padded_shape(),
-            tensor.layout(),
-            tensor.dtype(),
-            tensor.memory_config());
-    }
-
-    const auto output_spec = compute_output_specs(operation_attributes, tensor_args);
-    hash = ttsl::hash::hash_objects(
-        hash,
-        tensor_args.input_tensors.size(),
-        output_spec.logical_shape().rank(),
-        output_spec.logical_shape(),
-        output_spec.padded_shape(),
-        output_spec.layout(),
-        output_spec.data_type(),
-        output_spec.memory_config());
-
-    return hash;
-}
-
 tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>>
 ConcatDeviceOperation::create_op_performance_model(
     const std::vector<Tensor>& input_tensors,

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/concat_device_operation.hpp
@@ -43,8 +43,6 @@ struct ConcatDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
 
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
-
     static tt::tt_metal::operation::OpPerformanceModelGeneral<std::vector<Tensor>> create_op_performance_model(
         const std::vector<Tensor>& input_tensors,
         const std::vector<std::optional<const Tensor>>& optional_input_tensors,


### PR DESCRIPTION
ConcatDeviceOperation::compute_program_hash keyed on dim/groups/output_mem_config/
sub_core_grids + per-tensor full logical/padded specs + input_tensors.size().
The framework default hashes all attributes plus the entire input_tensors vector
(count + each TensorSpec), so it keys on the same distinctions. The custom hash
was originally added to dodge the weak boost::hash_combine collision
(PR #45144 / issue #47602); the default combiner is now splitmix64 with a
collision-free canonical key, which a custom hash opts out of, so the default is
strictly stronger.

Adds test_concat_program_cache.py pinning cache-entry counts (reuse=1; miss on
dim/shape/dtype/num-inputs=2), verified identical before and after removal.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/drop-hash-concat)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/drop-hash-concat)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/drop-hash-concat)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/drop-hash-concat)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/drop-hash-concat)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/drop-hash-concat)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/drop-hash-concat)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/drop-hash-concat)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/drop-hash-concat)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/drop-hash-concat)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/drop-hash-concat)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/drop-hash-concat)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/drop-hash-concat)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/drop-hash-concat)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/drop-hash-concat)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/drop-hash-concat)