### PR TITLE
[ttnn] generalized_moe_gate: drop redundant custom compute_program_hash

### DIFF
--- a/tests/ttnn/unit_tests/operations/experimental/deepseek/test_generalized_moe_gate_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/experimental/deepseek/test_generalized_moe_gate_program_cache.py
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Program-cache regression tests for ttnn.experimental.deepseek.moe.generalized_moe_gate
+(GeneralizedMoeGateDeviceOperation).
+
+Pins the cache-keying granularity so it can be verified BEFORE and AFTER removing
+GeneralizedMoeGateDeviceOperation::compute_program_hash. The custom hash keyed on the six
+operation_attributes (eps/scaling_factor/enable_sigmoid/topk/output_softmax/grouped) and the
+TensorSpec (logical) of all five tensors. The framework default hashes the whole attrs struct +
+tensor_args (which hold exactly those five tensors), i.e. the same distinctions and the same
+logical-shape keying (the op's own hash comment states it is "same as the framework's default hash").
+
+Setup mirrors models/common/tests/modules/moe/test_generalized_moe_gate.py (ungrouped, 256 experts,
+one token/core, HEIGHT_SHARDED L1).
+
+- Same config -> reuse (1 entry).
+- topk / enable_sigmoid toggled (hashed attributes) -> distinct entries.
+"""
+
+import pytest
+import torch
+
+import ttnn
+
+
+def run_gate(device, batch_size, topk, enable_sigmoid, output_softmax, seed=42):
+    """Build the 5 height-sharded tensors, run generalized_moe_gate in the cache counter, return the
+    sorted device-selected expert indices. (Exact top-k correctness is covered by the dedicated
+    reference suite models/common/tests/modules/moe/test_generalized_moe_gate.py; here we assert the
+    op runs, selects valid experts, and is deterministic across a cache-reused program.)"""
+    input_shape = (batch_size, 8, 32)
+    reshaped_input_shape = (batch_size, 16, 16)
+    input_tile = ttnn.Tile((32, 32))
+    output_shape = (batch_size, 1, 16)
+    output_tile = ttnn.Tile((32, 32))
+    eps, scaling_factor = 1e-20, 2.5
+
+    torch.manual_seed(seed)
+    torch_input = (2 * torch.rand(input_shape, dtype=torch.bfloat16)) - 1
+    if enable_sigmoid or not output_softmax:
+        torch_input = torch.sigmoid(torch_input)
+    torch_bias = (2 * torch.rand(input_shape, dtype=torch.bfloat16)) - 1
+
+    grid = device.compute_with_storage_grid_size()
+    core_grid = ttnn.num_cores_to_corerangeset(batch_size, ttnn.CoreCoord(grid.x, grid.y), row_wise=True)
+    in_shard = ttnn.ShardSpec(core_grid, (32, 32), ttnn.ShardOrientation.ROW_MAJOR)
+    out_shard = ttnn.ShardSpec(core_grid, (32, 32), ttnn.ShardOrientation.ROW_MAJOR)
+    in_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, in_shard)
+    out_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, out_shard)
+
+    ttnn_input = ttnn.from_torch(
+        torch.reshape(torch_input, reshaped_input_shape),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=in_mem,
+        tile=input_tile,
+    )
+    ttnn_bias = ttnn.from_torch(
+        torch.transpose(torch.reshape(torch_bias, reshaped_input_shape), -2, -1),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=in_mem,
+        tile=input_tile,
+    )
+    idx = torch.arange(16 * 16, dtype=torch.int32).unsqueeze(0).expand(batch_size, -1).reshape(reshaped_input_shape)
+    idx = torch.transpose(idx, -2, -1).to(torch.uint16)
+    ttnn_input_indices = ttnn.from_torch(
+        idx,
+        dtype=ttnn.uint16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=in_mem,
+        tile=input_tile,
+    )
+    ttnn_output = ttnn.from_torch(
+        torch.zeros(output_shape, dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=out_mem,
+        tile=output_tile,
+    )
+    ttnn_output_indices = ttnn.from_torch(
+        torch.zeros(output_shape, dtype=torch.uint16),
+        dtype=ttnn.uint16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=out_mem,
+        tile=output_tile,
+    )
+
+    with device.cache_entries_counter.measure():
+        _, res_idx = ttnn.experimental.deepseek.moe.generalized_moe_gate(
+            ttnn_input,
+            bias_tensor=ttnn_bias,
+            input_indices_tensor=ttnn_input_indices,
+            output_tensor=ttnn_output,
+            output_indices_tensor=ttnn_output_indices,
+            eps=eps,
+            scaling_factor=scaling_factor,
+            enable_sigmoid=enable_sigmoid,
+            topk=topk,
+            output_softmax=output_softmax,
+        )
+    dev_idx = torch.sort(ttnn.to_torch(res_idx)[:, 0, :topk].to(torch.int64), dim=-1).values
+    return dev_idx
+
+
+@pytest.fixture
+def isolate_program_cache(device):
+    device.disable_and_clear_program_cache()
+    device.enable_program_cache()
+    yield
+    device.disable_and_clear_program_cache()
+
+
+def test_gate_cache_reuse_same_config(device, isolate_program_cache):
+    """Same config run twice -> 1 entry; identical (deterministic) valid selection across reuse."""
+    dev1 = run_gate(device, batch_size=1, topk=8, enable_sigmoid=True, output_softmax=False)
+    dev2 = run_gate(device, batch_size=1, topk=8, enable_sigmoid=True, output_softmax=False)
+    assert torch.equal(dev1, dev2)
+    assert dev1.min().item() >= 0 and dev1.max().item() < 256
+    assert device.cache_entries_counter.total == 1
+
+
+def test_gate_cache_miss_topk(device, isolate_program_cache):
+    """topk is a hashed compile-time attribute -> 2 entries."""
+    run_gate(device, batch_size=1, topk=8, enable_sigmoid=True, output_softmax=False)
+    run_gate(device, batch_size=1, topk=4, enable_sigmoid=True, output_softmax=False)
+    assert device.cache_entries_counter.total == 2
+
+
+def test_gate_cache_miss_enable_sigmoid(device, isolate_program_cache):
+    """enable_sigmoid is a hashed compile-time attribute -> 2 entries."""
+    run_gate(device, batch_size=1, topk=8, enable_sigmoid=True, output_softmax=False)
+    run_gate(device, batch_size=1, topk=8, enable_sigmoid=False, output_softmax=False)
+    assert device.cache_entries_counter.total == 2

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/generalized_moe_gate/device/generalized_moe_gate_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/generalized_moe_gate/device/generalized_moe_gate_device_operation.cpp
@@ -159,32 +159,6 @@ GeneralizedMoeGateDeviceOperation::tensor_return_value_t GeneralizedMoeGateDevic
     return {tensor_args.output_tensor, tensor_args.output_indices_tensor};
 }
 
-std::uint64_t GeneralizedMoeGateDeviceOperation::compute_program_hash(
-    const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
-    // Cheap structural hash. Everything that changes the compiled program — the kernel compile-time args
-    // (eps/scaling/enable_sigmoid/topk/output_softmax), the GMG_UNGROUPED_TOP8 define (grouped), and the
-    // CB sizes/grids — is a function of the op attributes plus the tensor specs (dtype + tile + shard
-    // grid/shape; num_blocks is derived from the input shard shape). Everything else the builder emits is
-    // constant (kernel path, CB indices, HiFi4, configs). So hash those inputs directly instead of building
-    // the full ProgramDescriptor: that path runs the builder's TT_FATALs + constructs every CB/kernel
-    // descriptor + strings on EVERY dispatch (including cache hits) just to derive a key. Validation lives in
-    // validate_on_program_cache_{hit,miss}; the build happens in create_program. hash_operation<> folds the op
-    // TYPE into the key (the per-device program cache is shared across op types) — same as the framework's
-    // default hash; previously this was carried implicitly by the kernel-source path in the full descriptor.
-    return tt::tt_metal::operation::hash_operation<GeneralizedMoeGateDeviceOperation>(
-        attrs.eps,
-        attrs.scaling_factor,
-        attrs.enable_sigmoid,
-        attrs.topk,
-        attrs.output_softmax,
-        attrs.grouped,
-        tensor_args.input_tensor.tensor_spec(),
-        tensor_args.bias_tensor.tensor_spec(),
-        tensor_args.input_indices_tensor.tensor_spec(),
-        tensor_args.output_tensor.tensor_spec(),
-        tensor_args.output_indices_tensor.tensor_spec());
-}
-
 std::tuple<GeneralizedMoeGateDeviceOperation::operation_attributes_t, GeneralizedMoeGateDeviceOperation::tensor_args_t>
 GeneralizedMoeGateDeviceOperation::invoke(
     const Tensor& input_tensor,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/generalized_moe_gate/device/generalized_moe_gate_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/generalized_moe_gate/device/generalized_moe_gate_device_operation.hpp
@@ -33,8 +33,6 @@ struct GeneralizedMoeGateDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 
-    static std::uint64_t compute_program_hash(const operation_attributes_t& attrs, const tensor_args_t& tensor_args);
-
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& input_tensor,
         const Tensor& bias_tensor,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/generalized_moe_gate/device/generalized_moe_gate_program_descriptor_builder.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/generalized_moe_gate/device/generalized_moe_gate_program_descriptor_builder.hpp
@@ -13,8 +13,8 @@
 namespace ttnn::operations::experimental::deepseek::moe::generalized_moe_gate {
 
 // Build the executable program descriptor from the current tensors / scalars. Called by create_program
-// (cache miss); the program-cache key is a cheap structural hash in compute_program_hash, so this is no
-// longer on the cache-hit path.
+// (cache miss) only; the program-cache key is the framework's default hash over the op attributes +
+// tensor_args, so building the descriptor is not on the cache-hit path.
 tt::tt_metal::ProgramDescriptor build_moe_gate_program_descriptor(
     const tensor_args_t& tensor_args, const operation_attributes_t& operation_attrs);
 


### PR DESCRIPTION
GeneralizedMoeGateDeviceOperation::compute_program_hash hashed the six
operation_attributes (eps/scaling_factor/enable_sigmoid/topk/output_softmax/
grouped) + the TensorSpec of all five tensor_args -- exactly what the framework
default hashes (whole attrs struct + tensor_args, keyed on logical shape). The
op's own comment already noted it was "same as the framework's default hash",
written only to avoid building the ProgramDescriptor on the key path; the default
reflection hash never builds a descriptor either. Reference-member tensor_args
reflect fine under the default (many sibling ops, incl. deepseek_moe_gate, rely
on it).

Adds test_generalized_moe_gate_program_cache.py pinning cache-entry counts
(reuse=1; miss on topk/enable_sigmoid=2), verified identical before and after;
functional reference suite (128) green.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/drop-hash-generalized_moe_gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/drop-hash-generalized_moe_gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/drop-hash-generalized_moe_gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/drop-hash-generalized_moe_gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/drop-hash-generalized_moe_gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/drop-hash-generalized_moe_gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/drop-hash-generalized_moe_gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/drop-hash-generalized_moe_gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/drop-hash-generalized_moe_gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/drop-hash-generalized_moe_gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/drop-hash-generalized_moe_gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/drop-hash-generalized_moe_gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/drop-hash-generalized_moe_gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/drop-hash-generalized_moe_gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/drop-hash-generalized_moe_gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/drop-hash-generalized_moe_gate)