### PR TITLE
[ttnn] batch_norm RunningStatistics: drop redundant custom compute_program_hash

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_batch_norm_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_batch_norm_program_cache.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Program-cache regression tests for the RunningStatistics device op, exercised via
+ttnn.batch_norm(training=True) (which updates running_mean/running_var through it).
+
+Pins the cache-keying granularity so it can be verified BEFORE and AFTER removing
+RunningStatistics::compute_program_hash. The custom hash keyed on the whole attributes struct
+(momentum/memory_config/compute_kernel_config/input_dtype/dtype) + each tensor's TensorSpec plus a
+redundant padded_shape (derived from tensor_spec) and a redundant optional re-encoding. The framework
+default hashes the whole attrs struct + tensor_args, i.e. the same distinctions and the same
+logical-shape keying, so the TOTAL program-cache entry count for a batch_norm(training=True) call is
+unchanged.
+
+- Same config twice -> reuse (no new entries).
+- Different input shape / momentum -> extra entries (RunningStatistics re-keys).
+"""
+
+import pytest
+import torch
+
+import ttnn
+
+
+@pytest.fixture
+def isolate_program_cache(device):
+    device.disable_and_clear_program_cache()
+    device.enable_program_cache()
+    yield
+    device.disable_and_clear_program_cache()
+
+
+def run_bn_training(device, input_shape, momentum, seed=0):
+    """ttnn.batch_norm(training=True) inside the cache counter (updates running stats via RunningStatistics)."""
+    torch.manual_seed(seed)
+    channels = input_shape[1]
+    inp = ttnn.from_torch(torch.rand(input_shape, dtype=torch.bfloat16) * 5 + 5, device=device, layout=ttnn.TILE_LAYOUT)
+    mean = ttnn.from_torch(
+        torch.rand(channels, dtype=torch.bfloat16).view(1, channels, 1, 1) * 6 + 4,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+    )
+    var = ttnn.from_torch(
+        torch.rand(channels, dtype=torch.bfloat16).view(1, channels, 1, 1) * 16 + 4,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+    )
+    with device.cache_entries_counter.measure():
+        out = ttnn.batch_norm(inp, running_mean=mean, running_var=var, training=True, eps=1e-5, momentum=momentum)
+    return ttnn.to_torch(out)
+
+
+def test_bn_cache_reuse_same_config(device, isolate_program_cache):
+    """Same config twice -> the second run adds no new program-cache entries."""
+    run_bn_training(device, (1, 4, 32, 32), momentum=0.1, seed=0)
+    n_after_first = device.cache_entries_counter.total
+    run_bn_training(device, (1, 4, 32, 32), momentum=0.1, seed=1)
+    assert device.cache_entries_counter.total == n_after_first  # reuse: no growth
+
+
+def test_bn_cache_miss_different_shape(device, isolate_program_cache):
+    """Different input shape -> more entries than a pure reuse."""
+    run_bn_training(device, (1, 4, 32, 32), momentum=0.1)
+    n_after_first = device.cache_entries_counter.total
+    run_bn_training(device, (1, 4, 64, 64), momentum=0.1)
+    assert device.cache_entries_counter.total > n_after_first
+
+
+def test_bn_cache_miss_different_momentum(device, isolate_program_cache):
+    """momentum is a hashed RunningStatistics attribute -> at least one extra entry."""
+    run_bn_training(device, (1, 4, 32, 32), momentum=0.1)
+    n_after_first = device.cache_entries_counter.total
+    run_bn_training(device, (1, 4, 32, 32), momentum=0.5)
+    assert device.cache_entries_counter.total > n_after_first

--- a/tests/ttnn/unit_tests/operations/fused/test_batch_norm_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_batch_norm_program_cache.py
@@ -3,25 +3,115 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Program-cache regression tests for the RunningStatistics device op, exercised via
-ttnn.batch_norm(training=True) (which updates running_mean/running_var through it).
+Program-cache keying tests for ttnn.batch_norm(training=True).
 
-Pins the cache-keying granularity so it can be verified BEFORE and AFTER removing
-RunningStatistics::compute_program_hash. The custom hash keyed on the whole attributes struct
-(momentum/memory_config/compute_kernel_config/input_dtype/dtype) + each tensor's TensorSpec plus a
-redundant padded_shape (derived from tensor_spec) and a redundant optional re-encoding. The framework
-default hashes the whole attrs struct + tensor_args, i.e. the same distinctions and the same
-logical-shape keying, so the TOTAL program-cache entry count for a batch_norm(training=True) call is
-unchanged.
+In training mode batch_norm drives the RunningStatistics device op, which updates
+running_mean/running_var in place. These tests pin two invariants the suite must uphold:
 
-- Same config twice -> reuse (no new entries).
-- Different input shape / momentum -> extra entries (RunningStatistics re-keys).
+  * Cache-key granularity of RunningStatistics. Runs that share its program key (same
+    per-channel tensor specs, momentum, and optional-stat presence) must reuse a cached
+    program, while runs that differ in any keyed attribute must compile a distinct one. This
+    guards against under-keying (a cache hit reusing a program compiled for a different buffer
+    configuration) and over-keying (spurious recompiles).
+  * The running-statistics side effect. Each call must write the updated running_mean/
+    running_var for that call's own tensors, so a cache hit cannot silently leave a call's
+    buffers un-updated (or update someone else's). Every run therefore reads the stats back
+    and compares them against a torch reference.
+
+The RunningStatistics device op has no direct Python binding, so it is exercised through
+ttnn.batch_norm(training=True), which is its only public entry point.
 """
 
 import pytest
 import torch
+import torch.nn.functional as F
 
 import ttnn
+from tests.ttnn.utils_for_testing import assert_numeric_metrics
+
+# (N, C, H, W); H and W are tile-aligned and C > 1 so the per-channel running-stat tensors
+# are non-degenerate.
+BASE_SHAPE = (1, 4, 32, 32)
+
+# The initial running-stat values sit well above the batch statistics of the input (which
+# lie in [0, 1)). A momentum-weighted update therefore moves each value away from its initial
+# value by a clearly observable amount, so a cache hit that leaves a call's buffers un-updated
+# (i.e. still at the initial value) is detectable.
+INIT_RUNNING_MEAN = 10.0
+INIT_RUNNING_VAR = 10.0
+
+
+def _stat_tensor(value, channels, device):
+    return ttnn.from_torch(
+        torch.full((1, channels, 1, 1), value, dtype=torch.bfloat16),
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+
+def _assert_running_stats_updated(input_torch, channels, momentum, eps, updated_mean, updated_var):
+    """Assert the read-back running stats match a torch reference update from the known initial
+    values, i.e. the op wrote this call's buffers instead of leaving them at their initial value."""
+    # torch.nn.functional.batch_norm updates the running tensors in place. PyTorch requires both
+    # to be provided together, so a neutral stand-in is supplied for an absent stat and only the
+    # requested stats are asserted.
+    ref_mean = torch.full((channels,), INIT_RUNNING_MEAN, dtype=torch.float32)
+    ref_var = torch.full((channels,), INIT_RUNNING_VAR, dtype=torch.float32)
+    F.batch_norm(
+        input_torch.float(),
+        running_mean=ref_mean,
+        running_var=ref_var,
+        training=True,
+        momentum=momentum,
+        eps=eps,
+    )
+    if updated_mean is not None:
+        # The update must have moved the value off its initial state (catches a stale-binding
+        # cache hit that never wrote this call's buffer).
+        assert not torch.allclose(updated_mean, torch.full_like(updated_mean, INIT_RUNNING_MEAN), atol=0.1)
+        assert_numeric_metrics(
+            ref_mean.view(1, channels, 1, 1),
+            updated_mean,
+            rtol=0.05,
+            atol=0.1,
+            frobenius_threshold=0.05,
+            check_pcc=False,
+        )
+    if updated_var is not None:
+        assert not torch.allclose(updated_var, torch.full_like(updated_var, INIT_RUNNING_VAR), atol=0.1)
+        assert_numeric_metrics(
+            ref_var.view(1, channels, 1, 1),
+            updated_var,
+            rtol=0.05,
+            atol=0.1,
+            frobenius_threshold=0.05,
+            check_pcc=False,
+        )
+
+
+def _run_bn_training(device, input_shape, momentum, *, with_mean=True, with_var=True, seed=0, eps=1e-5):
+    """Run ttnn.batch_norm(training=True) under the program-cache entry counter, then read back
+    and validate the in-place running-stat update for this call."""
+    torch.manual_seed(seed)
+    channels = input_shape[1]
+    input_torch = torch.rand(input_shape, dtype=torch.bfloat16)
+    input_tt = ttnn.from_torch(input_torch, device=device, layout=ttnn.TILE_LAYOUT)
+    mean_tt = _stat_tensor(INIT_RUNNING_MEAN, channels, device) if with_mean else None
+    var_tt = _stat_tensor(INIT_RUNNING_VAR, channels, device) if with_var else None
+
+    with device.cache_entries_counter.measure():
+        ttnn.batch_norm(
+            input_tt,
+            running_mean=mean_tt,
+            running_var=var_tt,
+            training=True,
+            eps=eps,
+            momentum=momentum,
+        )
+
+    updated_mean = ttnn.to_torch(mean_tt) if with_mean else None
+    updated_var = ttnn.to_torch(var_tt) if with_var else None
+    _assert_running_stats_updated(input_torch, channels, momentum, eps, updated_mean, updated_var)
 
 
 @pytest.fixture
@@ -32,45 +122,49 @@ def isolate_program_cache(device):
     device.disable_and_clear_program_cache()
 
 
-def run_bn_training(device, input_shape, momentum, seed=0):
-    """ttnn.batch_norm(training=True) inside the cache counter (updates running stats via RunningStatistics)."""
-    torch.manual_seed(seed)
-    channels = input_shape[1]
-    inp = ttnn.from_torch(torch.rand(input_shape, dtype=torch.bfloat16) * 5 + 5, device=device, layout=ttnn.TILE_LAYOUT)
-    mean = ttnn.from_torch(
-        torch.rand(channels, dtype=torch.bfloat16).view(1, channels, 1, 1) * 6 + 4,
-        device=device,
-        layout=ttnn.TILE_LAYOUT,
-    )
-    var = ttnn.from_torch(
-        torch.rand(channels, dtype=torch.bfloat16).view(1, channels, 1, 1) * 16 + 4,
-        device=device,
-        layout=ttnn.TILE_LAYOUT,
-    )
-    with device.cache_entries_counter.measure():
-        out = ttnn.batch_norm(inp, running_mean=mean, running_var=var, training=True, eps=1e-5, momentum=momentum)
-    return ttnn.to_torch(out)
-
-
 def test_bn_cache_reuse_same_config(device, isolate_program_cache):
-    """Same config twice -> the second run adds no new program-cache entries."""
-    run_bn_training(device, (1, 4, 32, 32), momentum=0.1, seed=0)
+    """Identical config across calls must reuse cached programs: the second run adds no entries."""
+    _run_bn_training(device, BASE_SHAPE, momentum=0.1, seed=0)
     n_after_first = device.cache_entries_counter.total
-    run_bn_training(device, (1, 4, 32, 32), momentum=0.1, seed=1)
+    _run_bn_training(device, BASE_SHAPE, momentum=0.1, seed=1)
     assert device.cache_entries_counter.total == n_after_first  # reuse: no growth
 
 
-def test_bn_cache_miss_different_shape(device, isolate_program_cache):
-    """Different input shape -> more entries than a pure reuse."""
-    run_bn_training(device, (1, 4, 32, 32), momentum=0.1)
+def test_bn_cache_miss_different_channels(device, isolate_program_cache):
+    """Changing the channel count changes the RunningStatistics per-channel tensor specs, which
+    must key a distinct program (new entries). H/W alone would not re-key RunningStatistics."""
+    _run_bn_training(device, (1, 4, 32, 32), momentum=0.1)
     n_after_first = device.cache_entries_counter.total
-    run_bn_training(device, (1, 4, 64, 64), momentum=0.1)
+    _run_bn_training(device, (1, 8, 32, 32), momentum=0.1)
     assert device.cache_entries_counter.total > n_after_first
 
 
 def test_bn_cache_miss_different_momentum(device, isolate_program_cache):
-    """momentum is a hashed RunningStatistics attribute -> at least one extra entry."""
-    run_bn_training(device, (1, 4, 32, 32), momentum=0.1)
+    """momentum is a hashed RunningStatistics attribute, so changing it must key a distinct program."""
+    _run_bn_training(device, BASE_SHAPE, momentum=0.1)
     n_after_first = device.cache_entries_counter.total
-    run_bn_training(device, (1, 4, 32, 32), momentum=0.5)
+    _run_bn_training(device, BASE_SHAPE, momentum=0.5)
     assert device.cache_entries_counter.total > n_after_first
+
+
+def test_bn_cache_optional_stat_presence(device, isolate_program_cache):
+    """running_mean/running_var presence is baked into the RunningStatistics program, so each
+    present/absent combination must key a distinct program while a repeated combination reuses it.
+    Only RunningStatistics depends on this presence, so the entry growth is attributable to it
+    (the upstream reduction/batch-norm programs are identical across combinations)."""
+    # Both stats present.
+    _run_bn_training(device, BASE_SHAPE, momentum=0.1, with_mean=True, with_var=True, seed=0)
+    n_both = device.cache_entries_counter.total
+    _run_bn_training(device, BASE_SHAPE, momentum=0.1, with_mean=True, with_var=True, seed=1)
+    assert device.cache_entries_counter.total == n_both  # same combo -> reuse
+
+    # running_var absent -> distinct presence bits -> new program.
+    _run_bn_training(device, BASE_SHAPE, momentum=0.1, with_mean=True, with_var=False, seed=2)
+    n_mean_only = device.cache_entries_counter.total
+    assert n_mean_only > n_both
+    _run_bn_training(device, BASE_SHAPE, momentum=0.1, with_mean=True, with_var=False, seed=3)
+    assert device.cache_entries_counter.total == n_mean_only  # same combo -> reuse
+
+    # running_mean absent (var present) -> another distinct combination -> new program.
+    _run_bn_training(device, BASE_SHAPE, momentum=0.1, with_mean=False, with_var=True, seed=4)
+    assert device.cache_entries_counter.total > n_mean_only

--- a/tests/ttnn/unit_tests/operations/fused/test_batch_norm_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_batch_norm_program_cache.py
@@ -41,9 +41,9 @@ INIT_RUNNING_MEAN = 10.0
 INIT_RUNNING_VAR = 10.0
 
 
-def _stat_tensor(value, channels, device):
+def _stat_tensor(value, channels, device, torch_dtype=torch.bfloat16):
     return ttnn.from_torch(
-        torch.full((1, channels, 1, 1), value, dtype=torch.bfloat16),
+        torch.full((1, channels, 1, 1), value, dtype=torch_dtype),
         device=device,
         layout=ttnn.TILE_LAYOUT,
     )
@@ -89,15 +89,17 @@ def _assert_running_stats_updated(input_torch, channels, momentum, eps, updated_
         )
 
 
-def _run_bn_training(device, input_shape, momentum, *, with_mean=True, with_var=True, seed=0, eps=1e-5):
+def _run_bn_training(
+    device, input_shape, momentum, *, with_mean=True, with_var=True, seed=0, eps=1e-5, torch_dtype=torch.bfloat16
+):
     """Run ttnn.batch_norm(training=True) under the program-cache entry counter, then read back
     and validate the in-place running-stat update for this call."""
     torch.manual_seed(seed)
     channels = input_shape[1]
-    input_torch = torch.rand(input_shape, dtype=torch.bfloat16)
+    input_torch = torch.rand(input_shape, dtype=torch_dtype)
     input_tt = ttnn.from_torch(input_torch, device=device, layout=ttnn.TILE_LAYOUT)
-    mean_tt = _stat_tensor(INIT_RUNNING_MEAN, channels, device) if with_mean else None
-    var_tt = _stat_tensor(INIT_RUNNING_VAR, channels, device) if with_var else None
+    mean_tt = _stat_tensor(INIT_RUNNING_MEAN, channels, device, torch_dtype) if with_mean else None
+    var_tt = _stat_tensor(INIT_RUNNING_VAR, channels, device, torch_dtype) if with_var else None
 
     with device.cache_entries_counter.measure():
         ttnn.batch_norm(
@@ -147,6 +149,20 @@ def test_bn_cache_miss_different_momentum(device, isolate_program_cache):
     assert device.cache_entries_counter.total > n_after_first
 
 
+def test_bn_cache_miss_different_dtype(device, isolate_program_cache):
+    """dtype drives the RunningStatistics compile-time `any_float32` path, which selects a different
+    compute kernel (sfpu vs non-sfpu). A bfloat16 run and a float32 run must therefore key distinct
+    programs, and a repeated dtype must reuse. This pins the dtype keying (input_dtype/dtype) that
+    the default hash must preserve now that the op no longer keys on it explicitly."""
+    _run_bn_training(device, BASE_SHAPE, momentum=0.1, torch_dtype=torch.bfloat16, seed=0)
+    n_bf16 = device.cache_entries_counter.total
+    _run_bn_training(device, BASE_SHAPE, momentum=0.1, torch_dtype=torch.float32, seed=1)
+    n_fp32 = device.cache_entries_counter.total
+    assert n_fp32 > n_bf16  # dtype flip -> distinct program
+    _run_bn_training(device, BASE_SHAPE, momentum=0.1, torch_dtype=torch.float32, seed=2)
+    assert device.cache_entries_counter.total == n_fp32  # same dtype -> reuse
+
+
 def test_bn_cache_optional_stat_presence(device, isolate_program_cache):
     """running_mean/running_var presence is baked into the RunningStatistics program, so each
     present/absent combination must key a distinct program while a repeated combination reuses it.
@@ -167,4 +183,15 @@ def test_bn_cache_optional_stat_presence(device, isolate_program_cache):
 
     # running_mean absent (var present) -> another distinct combination -> new program.
     _run_bn_training(device, BASE_SHAPE, momentum=0.1, with_mean=False, with_var=True, seed=4)
-    assert device.cache_entries_counter.total > n_mean_only
+    n_var_only = device.cache_entries_counter.total
+    assert n_var_only > n_mean_only
+    _run_bn_training(device, BASE_SHAPE, momentum=0.1, with_mean=False, with_var=True, seed=5)
+    assert device.cache_entries_counter.total == n_var_only  # same combo -> reuse
+
+    # Neither stat present -> a fourth distinct combination. In training mode RunningStatistics
+    # still runs (it just has no buffers to update), so this presence combo keys its own program.
+    _run_bn_training(device, BASE_SHAPE, momentum=0.1, with_mean=False, with_var=False, seed=6)
+    n_neither = device.cache_entries_counter.total
+    assert n_neither > n_var_only
+    _run_bn_training(device, BASE_SHAPE, momentum=0.1, with_mean=False, with_var=False, seed=7)
+    assert device.cache_entries_counter.total == n_neither  # same combo -> reuse

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_device_operation.cpp
@@ -100,27 +100,6 @@ RunningStatistics::tensor_return_value_t RunningStatistics::create_output_tensor
         compute_output_specs(operation_attributes, tensor_args), tensor_args.batch_mean.device());
 }
 
-ttsl::hash::hash_t RunningStatistics::compute_program_hash(
-    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
-    const auto& [batch_mean, batch_var, running_mean, running_var] = tensor_args;
-
-    auto hash_optional_tensor = [](const std::optional<Tensor>& t) -> ttsl::hash::hash_t {
-        if (!t.has_value()) {
-            return ttsl::hash::hash_objects_with_default_seed(false);
-        }
-        return ttsl::hash::hash_objects_with_default_seed(true, t->tensor_spec(), t->padded_shape());
-    };
-
-    return operation::hash_operation<RunningStatistics>(
-        attributes,
-        batch_mean.tensor_spec(),
-        batch_mean.padded_shape(),
-        batch_var.tensor_spec(),
-        batch_var.padded_shape(),
-        hash_optional_tensor(running_mean),
-        hash_optional_tensor(running_var));
-}
-
 }  // namespace ttnn::operations::normalization
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_device_operation.hpp
@@ -45,7 +45,6 @@ struct RunningStatistics {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 }  // namespace ttnn::operations::normalization
 


### PR DESCRIPTION
RunningStatistics::compute_program_hash hashed the whole attributes struct
(momentum/memory_config/compute_kernel_config/input_dtype/dtype) + each tensor's
TensorSpec plus a redundant padded_shape (derived from TensorSpec) and a redundant
optional re-encoding. The framework default hashes the whole attrs struct +
tensor_args, keying on the same (logical-shape) distinctions.

Adds test_batch_norm_program_cache.py (via batch_norm training path) pinning
that reuse adds no entries and shape/momentum re-key, identical before and after;
functional test_batch_norm.py (1539) green.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/drop-hash-batch_norm)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/drop-hash-batch_norm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/drop-hash-batch_norm)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/drop-hash-batch_norm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/drop-hash-batch_norm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/drop-hash-batch_norm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/drop-hash-batch_norm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/drop-hash-batch_norm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/drop-hash-batch_norm)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/drop-hash-batch_norm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/drop-hash-batch_norm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/drop-hash-batch_norm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/drop-hash-batch_norm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/drop-hash-batch_norm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/drop-hash-batch_norm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/drop-hash-batch_norm)