### PR TITLE
[ttnn] sdpa_decode: drop redundant custom compute_program_hash

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
@@ -497,63 +497,6 @@ Tensor SdpaDecodeDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.q.device());
 }
 
-ttsl::hash::hash_t SdpaDecodeDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    // TensorSpec hashing uses logical_shape + tensor_layout only, not cached_padded_shape_
-    const ttsl::hash::hash_t qkv_logical_padded_shape_key = [&] {
-        ttsl::hash::hash_t h = ttsl::hash::hash_objects_with_default_seed(
-            tensor_args.q.logical_shape(),
-            tensor_args.q.padded_shape(),
-            tensor_args.k.logical_shape(),
-            tensor_args.k.padded_shape());
-        if (tensor_args.v.has_value()) {
-            h = ttsl::hash::hash_objects(h, tensor_args.v->logical_shape(), tensor_args.v->padded_shape());
-        }
-        return h;
-    }();
-
-    // Hash the full optional Tensor for layout/memory/placement; hash logical_shape separately
-    // so rank and extents always contribute to the program-cache key
-    const ttsl::hash::hash_t cur_pos_tensor_logical_shape_key =
-        tensor_args.cur_pos_tensor.has_value()
-            ? ttsl::hash::hash_objects_with_default_seed(true, tensor_args.cur_pos_tensor->logical_shape())
-            : ttsl::hash::hash_objects_with_default_seed(false);
-
-    // Encode optional share_cache as 0 = unset, 1 = false, 2 = true so all three differ in the program hash.
-    const uint8_t share_cache_hash_tag = operation_attributes.share_cache.has_value()
-                                             ? (operation_attributes.share_cache.value() ? uint8_t{2} : uint8_t{1})
-                                             : uint8_t{0};
-
-    return operation::hash_operation<SdpaDecodeDeviceOperation>(
-        operation_attributes.scale,
-        operation_attributes.output_mem_config,
-        operation_attributes.program_config,
-        operation_attributes.compute_kernel_config,
-        operation_attributes.k_chunk_size,
-        operation_attributes.paged_attention,
-        operation_attributes.is_causal,
-        share_cache_hash_tag,
-        operation_attributes.cur_pos,
-        operation_attributes.use_mla,
-        operation_attributes.head_dim_v,
-        operation_attributes.sliding_window_size,
-        // Enters compile-time args (page_block_size_t, DHt, St).
-        operation_attributes.block_size_override,
-        // Enters compile-time args via num_kv_heads (parallelization grid + strides).
-        operation_attributes.num_kv_heads_override,
-        // Enters compile-time args via capacity_t (per-tile page_table wrap).
-        operation_attributes.cache_position_modulo,
-        tensor_args.q,
-        tensor_args.k,
-        tensor_args.v,
-        qkv_logical_padded_shape_key,
-        tensor_args.page_table_tensor,
-        tensor_args.attention_sink,
-        tensor_args.attn_mask,
-        tensor_args.cur_pos_tensor,
-        cur_pos_tensor_logical_shape_key);
-}
-
 Tensor sdpa_decode(
     const Tensor& input_tensor_q,
     const Tensor& input_tensor_k,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.hpp
@@ -105,9 +105,6 @@ struct SdpaDecodeDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
-
-    static ttsl::hash::hash_t compute_program_hash(
-        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 };
 
 Tensor sdpa_decode(


### PR DESCRIPTION
SdpaDecodeDeviceOperation::compute_program_hash hashed every attribute + all seven
tensor_args, plus two derived-and-redundant extras (qkv_logical_padded_shape_key,
cur_pos_tensor_logical_shape_key) and a manual optional<bool> tri-state tag. Those
extras are functionally determined by data the default already hashes: padded_shape
is derived from TensorSpec, and hashing the full Tensor already keys on logical
shape + layout (incl. shard geometry via memory_config). The framework default
hashes the whole attrs struct + tensor_args, so it keys on exactly the same
distinctions and omits nothing.

Verified against the existing test_sdpa_decode_cache.py suite (7 tests incl.
test_q_shard_height_diff_same_logical_program_cache_distinct, the same-logical/
different-shard-padding case) -- identical entry counts before and after; sdpa_decode
functional (11) green.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/drop-hash-sdpa_decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/drop-hash-sdpa_decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/drop-hash-sdpa_decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/drop-hash-sdpa_decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/drop-hash-sdpa_decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/drop-hash-sdpa_decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/drop-hash-sdpa_decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/drop-hash-sdpa_decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/drop-hash-sdpa_decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/drop-hash-sdpa_decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/drop-hash-sdpa_decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/drop-hash-sdpa_decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/drop-hash-sdpa_decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/drop-hash-sdpa_decode)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/drop-hash-sdpa_decode)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/drop-hash-sdpa_decode)