### PR TITLE
[ttnn] inbound_socket_service_sync: drop redundant custom compute_program_hash

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/inbound_socket_service_sync/device/inbound_socket_service_sync_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/inbound_socket_service_sync/device/inbound_socket_service_sync_device_operation.cpp
@@ -68,27 +68,6 @@ InboundSocketServiceSyncOperation::tensor_return_value_t InboundSocketServiceSyn
     return outputs;
 }
 
-ttsl::hash::hash_t InboundSocketServiceSyncOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    // Stable across calls for a given (service, config): the changing output
-    // address is a BufferBinding (patched on cache hit), NOT part of the hash.
-    auto program_factory = select_program_factory(args, tensor_args);
-    return operation::hash_operation<InboundSocketServiceSyncOperation>(
-        program_factory.index(),
-        args.data_ready_sem_addr,
-        args.page_size,
-        args.num_pages,
-        args.scratch_cb_index,
-        args.metadata_size_bytes,
-        args.metadata_l1_addr,
-        args.worker_cores,
-        args.mesh_num_cols,
-        args.consumed_addrs,
-        args.service_core_x,
-        args.service_core_y,
-        tensor_args.backing.dtype());
-}
-
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/inbound_socket_service_sync/device/inbound_socket_service_sync_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/inbound_socket_service_sync/device/inbound_socket_service_sync_device_operation.hpp
@@ -30,9 +30,6 @@ struct InboundSocketServiceSyncOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    // Keys the program on (service identity + config), NOT on the per-call output
-    // buffer address (that is a BufferBinding, patched on cache hits).
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim


### PR DESCRIPTION
InboundSocketServiceSyncOperation::compute_program_hash duplicated the framework
default. The default reflects over the whole operation_attributes_t plus the full
input TensorSpec; the custom hash enumerated the same 11 attribute fields
individually and narrowed the tensor to .dtype(), adding no distinction, plus a
redundant program_factory.index() (a pure function of the already-hashed attrs).

The default Tensor hash is address-independent (Tensor::attribute_values =
(storage, tensor_spec) — storage type + spec, not the buffer address), so the
per-dispatch changing output address (carried as a BufferBinding, patched on
cache hit) is never part of the key either way — no rebuild-per-dispatch. The
default splitmix64 hash also carries the collision-free canonical key that a
custom hash opts out of, so the default is strictly stronger.

Verified on Blackhole (single chip): test_h2d_socket_sync_single_device pins
program-cache deltas [1, 0, 0] (built once, cache-hits after) — identical before
and after removal, tokens byte-exact, metadata round-trips.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/drop-hash-inbound_socket_sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/drop-hash-inbound_socket_sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/drop-hash-inbound_socket_sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/drop-hash-inbound_socket_sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/drop-hash-inbound_socket_sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/drop-hash-inbound_socket_sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/drop-hash-inbound_socket_sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/drop-hash-inbound_socket_sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/drop-hash-inbound_socket_sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/drop-hash-inbound_socket_sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/drop-hash-inbound_socket_sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/drop-hash-inbound_socket_sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/drop-hash-inbound_socket_sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/drop-hash-inbound_socket_sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/drop-hash-inbound_socket_sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/drop-hash-inbound_socket_sync)