### PR TITLE
[ttnn] outbound_socket_service_sync: drop redundant custom compute_program_hash

### DIFF
--- a/.github/workflows/blackhole-e2e-tests.yaml
+++ b/.github/workflows/blackhole-e2e-tests.yaml
@@ -37,6 +37,7 @@ on:
         type: choice
         options:
           - all
+          - bh-qb2-deepseek-d2d-socket-sync
       build-type:
         required: false
         type: choice

--- a/models/demos/deepseek_v3_d_p/tests/test_d2d_socket_sync.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_d2d_socket_sync.py
@@ -65,6 +65,15 @@ def _to_device(torch_u32, mesh, mapper):
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="mesh-8x4",
         ),
+        # 4-chip QuietBox variant: 2 rows -> 1 sender row + 1 receiver row, 2 cols. Per-shard
+        # page = (7168/2)*4 = 14336 B (< the 16384 B FIFO), so the same op path runs on a
+        # small multi-card box (no 32-chip Galaxy needed).
+        pytest.param(
+            (2, 2),
+            {"fabric_config": ttnn.FabricConfig.FABRIC_2D},
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
+            id="linear-2x2",
+        ),
     ],
     indirect=["mesh_device", "device_params"],
 )
@@ -152,6 +161,7 @@ def test_d2d_socket_sync(mesh_device, metadata_words):
 
             # Program cache: built once on iter 0, reused on iter 1 (input addr is a BufferBinding)
             n_cached = getattr(sender_mesh, "num_program_cache_entries", lambda: None)()
+            print(f"[d2d cache] iter {it}: sender program-cache entries = {n_cached}")
             if it == 0:
                 cache_after_first = n_cached
             elif n_cached is not None:

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -275,3 +275,19 @@
       timeout: 60
   owner_id: U094PKWHNJ0 # Petar Milojevic
   team: models
+
+- id: bh-qb2-deepseek-d2d-socket-sync
+  name: bh_qb2_DeepSeek_D2D_SOCKET_SYNC
+  model-name: deepseek_prefill
+  # Program-cache validation for outbound_socket_service_sync (D2D sender op) on a 4-chip
+  # QuietBox (linear-2x2 variant): 2 sender + 2 receiver chips over tt-fabric. Confirms the
+  # op is built once and cache-hits on the 2nd dispatch (input addr is a BufferBinding).
+  cmd: |
+    exit_code=0
+    pytest models/demos/deepseek_v3_d_p/tests/test_d2d_socket_sync.py -k "linear-2x2" -vvv --tb=short || exit_code=$?
+    exit $exit_code
+  skus:
+    bh_quietbox_2:
+      timeout: 10
+  owner_id: U094PKWHNJ0 # Petar Milojevic
+  team: models

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/outbound_socket_service_sync/device/outbound_socket_service_sync_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/outbound_socket_service_sync/device/outbound_socket_service_sync_device_operation.cpp
@@ -75,25 +75,6 @@ OutboundSocketServiceSyncOperation::tensor_return_value_t OutboundSocketServiceS
     return tensor_args.backing;
 }
 
-ttsl::hash::hash_t OutboundSocketServiceSyncOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    // Stable across calls for a given (service, config): the changing input address is
-    // a BufferBinding (patched on cache hit), NOT part of the hash.
-    return operation::hash_operation<OutboundSocketServiceSyncOperation>(
-        args.page_size,
-        args.num_pages,
-        args.scratch_cb_index,
-        args.metadata_size_bytes,
-        args.metadata_only,
-        args.worker_cores,
-        args.mesh_num_cols,
-        args.data_ready_addrs,
-        args.service_core_x,
-        args.service_core_y,
-        args.metadata_addrs,
-        tensor_args.input.dtype());
-}
-
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/outbound_socket_service_sync/device/outbound_socket_service_sync_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/outbound_socket_service_sync/device/outbound_socket_service_sync_device_operation.hpp
@@ -34,9 +34,6 @@ struct OutboundSocketServiceSyncOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    // Keys the program on (service identity + config), NOT on the per-call input
-    // buffer address (that is a BufferBinding, patched on cache hits).
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim


### PR DESCRIPTION
Removes `OutboundSocketServiceSyncOperation::compute_program_hash`, which duplicated the framework default. The default reflects over the whole `operation_attributes_t` plus the full input `TensorSpec`; the custom hash enumerated the same 11 attribute fields individually and narrowed the tensor to `.dtype()`, adding no distinction.

The default Tensor hash is address-independent (`Tensor::attribute_values = (storage, tensor_spec)` — storage type + spec, not the buffer address), so the per-dispatch changing input address (a `BufferBinding`, patched on cache hit) is never part of the key either way — no rebuild-per-dispatch. The default splitmix64 hash also carries the collision-free canonical key that a custom hash opts out of, so the default is strictly stronger.

**Validation.** The only coverage was `test_d2d_socket_sync.py`, hard-pinned to a 32-chip mesh-8x4 Galaxy. This PR adds a `linear-2x2` variant (2 sender + 2 receiver chips; per-shard page 14336 B < the 16384 B socket FIFO) so the same op path runs on a 4-chip BH QuietBox, and wires it into the `(Blackhole) e2e` pipeline (`bh-qb2-deepseek-d2d-socket-sync` on `bh_quietbox_2`; `models/e2e/bh_quietbox_2` budget 80→90).

CI on QuietBox, both `linear-2x2` variants (no_metadata + metadata):
- baseline (hash present): sender program-cache = 1 entry (built once, cache-hit on 2nd dispatch), byte-exact shards + metadata
- post (hash removed): **identical** — 1 entry, both variants PASS

Part of the campaign removing redundant custom `compute_program_hash` overrides from ttnn descriptor-migrated ops.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/drop-hash-outbound_socket_sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/drop-hash-outbound_socket_sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/drop-hash-outbound_socket_sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/drop-hash-outbound_socket_sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/drop-hash-outbound_socket_sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/drop-hash-outbound_socket_sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/drop-hash-outbound_socket_sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/drop-hash-outbound_socket_sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/drop-hash-outbound_socket_sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/drop-hash-outbound_socket_sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/drop-hash-outbound_socket_sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/drop-hash-outbound_socket_sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/drop-hash-outbound_socket_sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/drop-hash-outbound_socket_sync)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/drop-hash-outbound_socket_sync)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/drop-hash-outbound_socket_sync)