### PR TITLE
[Performance] GDN prefill: token-major scan output + composed per-head RMSNorm

### DIFF
--- a/models/demos/blackhole/qwen36/tt/gdn/tp.py
+++ b/models/demos/blackhole/qwen36/tt/gdn/tp.py
@@ -235,7 +235,15 @@ class TPGatedDeltaNet:
             )
             self._gn_G = mk(Gt)
             self._gn_E = mk(Et)
-            self._gn_wrep = ttnn.concat([ttnn.reshape(self.tw["norm_w"], [1, 1, V])] * H, dim=-1)
+            # Pin to TILE_LAYOUT + DRAM (matching _gn_G/_gn_E and the o/scale operands it
+            # multiplies in _gated_rmsnorm_tm) so this cached constant can't land in L1 or
+            # force an implicit relayout at use.
+            self._gn_wrep = ttnn.concat(
+                [ttnn.reshape(self.tw["norm_w"], [1, 1, V])] * H,
+                dim=-1,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            self._gn_wrep = ttnn.to_layout(self._gn_wrep, ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
             self._gn_cfg = ttnn.WormholeComputeKernelConfig(
                 math_fidelity=ttnn.MathFidelity.HiFi4,
                 math_approx_mode=False,

--- a/models/demos/blackhole/qwen36/tt/gdn/tp.py
+++ b/models/demos/blackhole/qwen36/tt/gdn/tp.py
@@ -11,6 +11,7 @@ local heads. Projections/conv are sharded; weights kept interleaved (auto matmul
 
 GDN output uses the *gated* RMSNorm (weight, NO +1) followed by a SiLU(z) gate — distinct from the +1 QK/layer norms.
 """
+
 import os
 
 import torch
@@ -215,6 +216,53 @@ class TPGatedDeltaNet:
         ttnn.copy(zcc, self.conv_carry)
         ttnn.deallocate(zcc)
 
+    def _gn_mats(self):
+        """Lazily build + cache the constant matrices for the token-major composed RMSNorm"""
+        if getattr(self, "_gn_G", None) is None:
+            H, V, HV = self.Nv, self.Dv, self.value_dim_tp
+            Gt = torch.zeros(HV, H, dtype=torch.float32)
+            Et = torch.zeros(H, HV, dtype=torch.float32)
+            for h in range(H):
+                Gt[h * V : (h + 1) * V, h] = 1.0 / V
+                Et[h, h * V : (h + 1) * V] = 1.0
+            mk = lambda t: ttnn.from_torch(
+                t,
+                dtype=ttnn.float32,
+                layout=ttnn.TILE_LAYOUT,
+                device=self.mesh,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh),
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            self._gn_G = mk(Gt)
+            self._gn_E = mk(Et)
+            self._gn_wrep = ttnn.concat([ttnn.reshape(self.tw["norm_w"], [1, 1, V])] * H, dim=-1)
+            self._gn_cfg = ttnn.WormholeComputeKernelConfig(
+                math_fidelity=ttnn.MathFidelity.HiFi4,
+                math_approx_mode=False,
+                fp32_dest_acc_en=True,
+                packer_l1_acc=False,
+            )
+        return self._gn_G, self._gn_E, self._gn_wrep, self._gn_cfg
+
+    def _gated_rmsnorm_tm(self, o, z, eps=1e-6):
+        """Per-head RMSNorm over Dv on token-major [1,T,H*V], avoids [.,H,V] tile-crossing reshape that is present with the fused rmsnorm."""
+        G, E, wrep, cfg = self._gn_mats()
+        DR = ttnn.DRAM_MEMORY_CONFIG
+        sq = ttnn.multiply(o, o)
+        ms = ttnn.matmul(sq, G, compute_kernel_config=cfg, memory_config=DR)  # [1,T,H] per-head mean-square
+        ttnn.deallocate(sq)
+        inv = ttnn.rsqrt(ttnn.add(ms, eps))
+        ttnn.deallocate(ms)
+        scale = ttnn.matmul(inv, E, compute_kernel_config=cfg, memory_config=DR)  # [1,T,H*V] broadcast
+        ttnn.deallocate(inv)
+        o_n = ttnn.multiply(ttnn.multiply(o, scale), wrep)
+        ttnn.deallocate(o)
+        ttnn.deallocate(scale)
+        gated = ttnn.multiply(o_n, ttnn.silu(z))
+        ttnn.deallocate(o_n)
+        ttnn.deallocate(z)
+        return gated
+
     def forward_prefill(self, x, chunk_size=128, valid_len=None, capture_state=False):
         """Causal chunk-prefill over a sequence (from scratch, zero init state).
 
@@ -301,6 +349,7 @@ class TPGatedDeltaNet:
             device=self.mesh,
             cached_masks=self.chunk_seq_masks,
             valid_len=valid_len,
+            token_major=True,
         )
         B, D = 1, self.qkv_dim_tp
         # ---- Carry recurrent + conv state for the NEXT chunk (chunk-outer prefill). ----
@@ -334,14 +383,8 @@ class TPGatedDeltaNet:
                 src = ttnn.reshape(ttnn.slice(conv_new_state, (0, j, 0), (1, j + 1, D)), (1, B, D))
                 ttnn.copy(src, self.conv_states[j + 1])
         ttnn.deallocate(conv_new_state)
-        # o: [1, T, Nv, Dv] -> gated RMSNorm over Dv + SiLU(z) gate
-        out_n = ttnn.rms_norm(o, weight=tw["norm_w"], epsilon=1e-6)
-        ttnn.deallocate(o)
-        out_f = ttnn.reshape(out_n, (1, T, self.value_dim_tp))
-        ttnn.deallocate(out_n)
-        gated = ttnn.multiply(out_f, ttnn.silu(z))
-        ttnn.deallocate(out_f)
-        ttnn.deallocate(z)
+
+        gated = self._gated_rmsnorm_tm(o, z)
         partial = ttnn.linear(gated, tw["out"], compute_kernel_config=self.cfg, memory_config=ttnn.DRAM_MEMORY_CONFIG)
         ttnn.deallocate(gated)
         partial = ttnn.reshape(partial, (1, 1, T, partial.shape[-1]))

--- a/models/experimental/gated_attention_gated_deltanet/tt/ttnn_delta_rule_seq.py
+++ b/models/experimental/gated_attention_gated_deltanet/tt/ttnn_delta_rule_seq.py
@@ -73,7 +73,9 @@ def chunk_gated_delta_rule_seq_adapter(
     output and this returns it without a head to token permute; the caller then runs the per-head
     RMS on that layout.
 
-    Same interface ([B,T,H,*] inputs, returns (o [B,T,H,V], new_state [B,H,K,V])).
+    Inputs are [B,T,H,*]; returns (o, new_state [B,H,K,V]). The output layout is
+    conditional: o is [B,T,H,V] by default, but [B,T,H*V] (token-major, already
+    head-flattened) when ``token_major=True``.
     Internally L2-norms q/k (matching the bf16 chunk path), converts to the seq
     kernel's [BH,T,*] float32 layout, runs the kernel, and converts the output
     and final state back. final_state is returned as bfloat16 to match the
@@ -328,7 +330,9 @@ def chunk_gated_delta_rule_seq(
 ):
     """Chunked gated delta rule using the C++ sequential scan kernel (Path A).
 
-    Returns (output [BH, T, V], final_state [BH, K, V]), both float32.
+    Returns (output, final_state [BH, K, V]), both float32. Output is [BH, T, V] by
+    default, but token-major [B, T, H*V] when ``token_major=True`` (requires
+    num_v_heads); in that mode the writer folds the head->token permute into the scan.
 
     valid_len: when set (< T), positions [valid_len, T) are treated as right-padding
     and zeroed in q/k/v/beta/g BEFORE the scan — exactly mirroring the function's own
@@ -615,6 +619,10 @@ def chunk_gated_delta_rule_seq(
     # ---- C++ sequential scan kernel (Path A) ----
     # Token-major output: when enabled and H known, the writer scatters heads straight into a
     # token-major [B, T, H*V] tensor, which folds the core.out permute.
+    # token_major is an explicit caller opt-in, so fail fast rather than silently emitting the
+    # legacy [BH, T, V] layout when num_v_heads is missing.
+    if token_major and not num_v_heads:
+        raise ValueError("token_major=True requires num_v_heads (v-heads per batch) to be set")
     _tm = bool(token_major and num_v_heads)
     out_4d, final_state = ttnn.transformer.gated_delta_attn_seq(
         L_unit_4d,

--- a/models/experimental/gated_attention_gated_deltanet/tt/ttnn_delta_rule_seq.py
+++ b/models/experimental/gated_attention_gated_deltanet/tt/ttnn_delta_rule_seq.py
@@ -64,9 +64,14 @@ def chunk_gated_delta_rule_seq_adapter(
     device=None,
     cached_masks=None,
     valid_len=None,
+    token_major=False,  # opt in to the token-major writer output ([B,T,H*V])
 ):
     """Drop-in replacement for chunk_gated_delta_rule_ttnn that runs the C++
     chunk-parallel `gated_delta_attn_seq` kernel.
+
+    When ``token_major`` (opt-in per caller), the scan writer emits a token-major ``[B,T,H*V]``
+    output and this returns it without a head to token permute; the caller then runs the per-head
+    RMS on that layout.
 
     Same interface ([B,T,H,*] inputs, returns (o [B,T,H,V], new_state [B,H,K,V])).
     Internally L2-norms q/k (matching the bf16 chunk path), converts to the seq
@@ -125,13 +130,19 @@ def chunk_gated_delta_rule_seq_adapter(
         mesh_device=device,
         cached_masks=cached_masks,
         valid_len=valid_len,
+        num_v_heads=H if token_major else None,
+        token_major=token_major,
     )
 
-    # o [BH,T,V] -> [B,T,H,V]
-    o = ttnn.to_layout(o_bh, ttnn.ROW_MAJOR_LAYOUT, memory_config=_DRAM)
-    o = ttnn.reshape(o, [B, H, T, V])
-    o = ttnn.permute(o, (0, 2, 1, 3))  # [B,T,H,V]
-    o = ttnn.to_layout(o, ttnn.TILE_LAYOUT, memory_config=_DRAM)
+    if token_major:
+        # Kernel already produced [B, T, H*V]. Hand it back as-is.
+        o = o_bh
+    else:
+        # o [BH,T,V] -> [B,T,H,V]
+        o = ttnn.to_layout(o_bh, ttnn.ROW_MAJOR_LAYOUT, memory_config=_DRAM)
+        o = ttnn.reshape(o, [B, H, T, V])
+        o = ttnn.permute(o, (0, 2, 1, 3))  # [B,T,H,V]
+        o = ttnn.to_layout(o, ttnn.TILE_LAYOUT, memory_config=_DRAM)
 
     # final_state [BH,K,V] -> [B,H,K,V] bf16 (matches recurrent_state)
     new_state = ttnn.reshape(final_state, [B, H, K, V])
@@ -312,6 +323,8 @@ def chunk_gated_delta_rule_seq(
     mesh_device=None,
     cached_masks=None,
     valid_len=None,
+    num_v_heads=None,  # H (v-heads per batch); required for the token-major writer
+    token_major=False,  # emit token-major
 ):
     """Chunked gated delta rule using the C++ sequential scan kernel (Path A).
 
@@ -531,9 +544,11 @@ def chunk_gated_delta_rule_seq(
     dl_exp_3d = ttnn.exp(ttnn.clip(decay_last_raw, min=-20.0, max=0.0), memory_config=_cmc)
     dl_exp_4d = ttnn.reshape(
         ttnn.to_layout(
-            ttnn.typecast(dl_exp_3d, ttnn.float32, memory_config=_cmc)
-            if dl_exp_3d.dtype != ttnn.float32
-            else dl_exp_3d,
+            (
+                ttnn.typecast(dl_exp_3d, ttnn.float32, memory_config=_cmc)
+                if dl_exp_3d.dtype != ttnn.float32
+                else dl_exp_3d
+            ),
             ttnn.TILE_LAYOUT,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
         ),
@@ -598,6 +613,9 @@ def chunk_gated_delta_rule_seq(
         )
 
     # ---- C++ sequential scan kernel (Path A) ----
+    # Token-major output: when enabled and H known, the writer scatters heads straight into a
+    # token-major [B, T, H*V] tensor, which folds the core.out permute.
+    _tm = bool(token_major and num_v_heads)
     out_4d, final_state = ttnn.transformer.gated_delta_attn_seq(
         L_unit_4d,
         v_beta_sc_4d,
@@ -608,8 +626,15 @@ def chunk_gated_delta_rule_seq(
         dl_exp_4d,
         L_inv_4d,
         initial_state=S0_tt,
+        token_major_output=_tm,
+        num_v_heads=int(num_v_heads) if _tm else 0,
+        seq_len=int(T) if _tm else 0,
     )
     ttnn.deallocate(L_inv_4d)
+
+    if _tm:
+        # No relayout here.
+        return out_4d, final_state
 
     out_4d = ttnn.to_layout(
         ttnn.typecast(out_4d, ttnn.float32, memory_config=None) if out_4d.dtype != ttnn.float32 else out_4d,

--- a/ttnn/cpp/ttnn/operations/transformer/gated_delta_attn/device/gated_delta_attn_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/gated_delta_attn/device/gated_delta_attn_device_operation.cpp
@@ -76,7 +76,7 @@ void GatedDeltaAttnSeqDeviceOperation::validate_on_program_cache_miss(
         TT_FATAL(attrs.num_v_heads > 0, "token_major_output requires num_v_heads > 0");
         TT_FATAL(
             BH % attrs.num_v_heads == 0,
-            "token_major_output: num_heads {} must be divisible by num_v_heads {}",
+            "token_major_output: BH (batch*heads) {} must be divisible by num_v_heads {}",
             BH,
             attrs.num_v_heads);
         TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/transformer/gated_delta_attn/device/gated_delta_attn_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/gated_delta_attn/device/gated_delta_attn_device_operation.cpp
@@ -71,6 +71,20 @@ void GatedDeltaAttnSeqDeviceOperation::validate_on_program_cache_miss(
     if (in.initial_state.has_value()) {
         check_shape(*in.initial_state, {BH, Dk, Dv}, "initial_state");
     }
+
+    if (attrs.token_major_output) {
+        TT_FATAL(attrs.num_v_heads > 0, "token_major_output requires num_v_heads > 0");
+        TT_FATAL(
+            BH % attrs.num_v_heads == 0,
+            "token_major_output: num_heads {} must be divisible by num_v_heads {}",
+            BH,
+            attrs.num_v_heads);
+        TT_FATAL(
+            attrs.seq_len > 0 && attrs.seq_len <= NC * C,
+            "token_major_output: seq_len {} must be in (0, NC*C={}]",
+            attrs.seq_len,
+            NC * C);
+    }
 }
 
 void GatedDeltaAttnSeqDeviceOperation::validate_on_program_cache_hit(
@@ -87,7 +101,13 @@ GatedDeltaAttnSeqDeviceOperation::spec_return_value_t GatedDeltaAttnSeqDeviceOpe
     const uint32_t Dv = attrs.val_dim;
     const auto& mc = attrs.output_mem_config;
 
-    TensorSpec out_spec(ttnn::Shape({BH, NC, C, Dv}), TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE), mc));
+    // Output layout: head-major or token-major
+    TensorSpec out_spec =
+        attrs.token_major_output
+            ? TensorSpec(
+                  ttnn::Shape({BH / attrs.num_v_heads, attrs.seq_len, attrs.num_v_heads * Dv}),
+                  TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE), mc))
+            : TensorSpec(ttnn::Shape({BH, NC, C, Dv}), TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE), mc));
     TensorSpec state_spec(ttnn::Shape({BH, Dk, Dv}), TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE), mc));
     return {out_spec, state_spec};
 }
@@ -111,6 +131,9 @@ ttsl::hash::hash_t GatedDeltaAttnSeqDeviceOperation::compute_program_hash(
         attrs.val_dim,
         attrs.output_mem_config,
         attrs.compute_kernel_config,
+        attrs.token_major_output,
+        attrs.num_v_heads,
+        attrs.seq_len,
         in.L_unit,
         in.v_beta_sc,
         in.k_bd_sc,
@@ -136,7 +159,10 @@ std::vector<Tensor> gated_delta_attn_seq(
     const Tensor& L_inv,
     const std::optional<Tensor>& initial_state,
     const tt::tt_metal::MemoryConfig& output_mem_config,
-    const DeviceComputeKernelConfig& compute_kernel_config) {
+    const DeviceComputeKernelConfig& compute_kernel_config,
+    bool token_major_output,
+    uint32_t num_v_heads,
+    uint32_t seq_len) {
     using Op = GatedDeltaAttnSeqDeviceOperation;
     auto shape = L_unit.logical_shape();
     return ttnn::device_operation::launch<Op>(
@@ -148,6 +174,9 @@ std::vector<Tensor> gated_delta_attn_seq(
             .val_dim = static_cast<uint32_t>(v_beta_sc.logical_shape()[3]),
             .output_mem_config = output_mem_config,
             .compute_kernel_config = compute_kernel_config,
+            .token_major_output = token_major_output,
+            .num_v_heads = num_v_heads,
+            .seq_len = seq_len,
         },
         Op::tensor_args_t{
             .L_unit = L_unit,

--- a/ttnn/cpp/ttnn/operations/transformer/gated_delta_attn/device/gated_delta_attn_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/gated_delta_attn/device/gated_delta_attn_device_operation.hpp
@@ -45,6 +45,9 @@ std::vector<Tensor> gated_delta_attn_seq(
     const Tensor& L_inv,
     const std::optional<Tensor>& initial_state,
     const tt::tt_metal::MemoryConfig& output_mem_config,
-    const DeviceComputeKernelConfig& compute_kernel_config);
+    const DeviceComputeKernelConfig& compute_kernel_config,
+    bool token_major_output = false,
+    uint32_t num_v_heads = 0,
+    uint32_t seq_len = 0);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/gated_delta_attn/device/gated_delta_attn_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/gated_delta_attn/device/gated_delta_attn_device_operation_types.hpp
@@ -18,6 +18,11 @@ struct GatedDeltaAttnSeqParams {
     uint32_t val_dim;     // Dv (e.g. 128)
     tt::tt_metal::MemoryConfig output_mem_config;
     DeviceComputeKernelConfig compute_kernel_config;
+    // Token-major output. When true, output[0] is [B, seq_len, num_v_heads*Dv] token-major instead of the
+    // [BH, NC, C, Dv] head-major layout.
+    bool token_major_output = false;
+    uint32_t num_v_heads = 0;  // H (value heads per batch); only used when token_major_output.
+    uint32_t seq_len = 0;      // T (logical seq length, pre-chunk-pad); only used when token_major_output.
 };
 
 // Input tensors for the sequential scan kernel (Path A — Python pre-computes L_inv).

--- a/ttnn/cpp/ttnn/operations/transformer/gated_delta_attn/device/gated_delta_attn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/gated_delta_attn/device/gated_delta_attn_program_factory.cpp
@@ -144,7 +144,10 @@ GatedDeltaAttnSeqProgramFactory::cached_program_t GatedDeltaAttnSeqProgramFactor
     TensorAccessorArgs(in.L_inv.buffer()).append_to(reader_ct_args);
     TensorAccessorArgs(in.initial_state.has_value() ? in.initial_state->buffer() : nullptr).append_to(reader_ct_args);
 
-    std::vector<uint32_t> writer_ct_args = ct_args;
+    const uint32_t token_major = attrs.token_major_output ? 1u : 0u;
+    const uint32_t num_v_heads = attrs.num_v_heads;
+    const uint32_t T_tiles = attrs.token_major_output ? ((attrs.seq_len + TILE_HEIGHT - 1) / TILE_HEIGHT) : 0u;
+    std::vector<uint32_t> writer_ct_args = {Ct, Kt, Vt, token_major, num_v_heads, T_tiles};
     TensorAccessorArgs(outputs[0].buffer()).append_to(writer_ct_args);
     TensorAccessorArgs(outputs[1].buffer()).append_to(writer_ct_args);
 

--- a/ttnn/cpp/ttnn/operations/transformer/gated_delta_attn/device/gated_delta_attn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/gated_delta_attn/device/gated_delta_attn_program_factory.cpp
@@ -126,13 +126,6 @@ GatedDeltaAttnSeqProgramFactory::cached_program_t GatedDeltaAttnSeqProgramFactor
 
     const std::vector<uint32_t> ct_args = {Ct, Kt, Vt};
 
-    // Reader/writer also carry per-tensor TensorAccessorArgs compile-time blocks,
-    // appended right after {Ct, Kt, Vt} in the SAME order the kernels consume them
-    // (reader: L_unit, v_beta_sc, k_bd_sc, intra_attn, q_decay, k_decay_t, dl_exp,
-    // L_inv, initial_state; writer: out, final_state). Each interleaved-DRAM tensor
-    // appends two args, so the device-side TensorAccessorArgs<3> chain stays aligned.
-    // initial_state is optional: a null buffer still appends two (zeroed) args so the
-    // s0 accessor's compile-time offset is unconditionally present.
     std::vector<uint32_t> reader_ct_args = ct_args;
     TensorAccessorArgs(in.L_unit.buffer()).append_to(reader_ct_args);
     TensorAccessorArgs(in.v_beta_sc.buffer()).append_to(reader_ct_args);

--- a/ttnn/cpp/ttnn/operations/transformer/gated_delta_attn/device/kernels/dataflow/writer_gated_delta_attn.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/gated_delta_attn/device/kernels/dataflow/writer_gated_delta_attn.cpp
@@ -6,10 +6,12 @@
 // Runtime args:
 //   0  head_idx
 //   1  num_chunks
-//   2  out_addr        (output [BH, NC, C, Dv])
+//   2  out_addr        (output: head-major [BH, NC, C, Dv] or token-major [B, T, H*Dv])
 //   3  final_state_addr (final_state [BH, Dk, Dv])
 //
-// Compile-time args: Ct, Kt, Vt
+// Compile-time args: Ct, Kt, Vt, TOKEN_MAJOR, H, T_tiles, then out + final_state accessor args.
+//   TOKEN_MAJOR=0 → head-major output; the {H, T_tiles} args are ignored.
+//   TOKEN_MAJOR=1 → scatter each head's chunk output into its token-major column range.
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
@@ -21,6 +23,9 @@ void kernel_main() {
     constexpr uint32_t Ct = get_compile_time_arg_val(0);
     constexpr uint32_t Kt = get_compile_time_arg_val(1);
     constexpr uint32_t Vt = get_compile_time_arg_val(2);
+    constexpr uint32_t TOKEN_MAJOR = get_compile_time_arg_val(3);
+    constexpr uint32_t H = get_compile_time_arg_val(4);        // v-heads per batch (token-major only)
+    constexpr uint32_t T_tiles = get_compile_time_arg_val(5);  // dest tile-rows = ceil(T/32) (token-major only)
 
     const uint32_t head_idx = get_arg_val<uint32_t>(0);
     const uint32_t NC = get_arg_val<uint32_t>(1);
@@ -37,14 +42,13 @@ void kernel_main() {
 
     // TensorAccessors for the interleaved fp32 DRAM outputs. The per-tensor
     // TensorAccessorArgs compile-time blocks are appended (in this order) by the
-    // program factory right after the {Ct, Kt, Vt} compile-time args, so the first
-    // block starts at compile-time-arg offset 3 and the second chains off it.
-    constexpr auto out_args = TensorAccessorArgs<3>();
+    // program factory right after the {Ct, Kt, Vt, TOKEN_MAJOR, H, T_tiles} compile-time
+    // args, so the first block starts at compile-time-arg offset 6 and the second chains off it.
+    constexpr auto out_args = TensorAccessorArgs<6>();
     const auto out_gen = TensorAccessor(out_args, out_addr, f32_tile);
     constexpr auto st_args = TensorAccessorArgs<out_args.next_compile_time_args_offset()>();
     const auto st_gen = TensorAccessor(st_args, st_addr, f32_tile);
 
-    const uint32_t h_off_out = head_idx * NC * out_tiles;
     const uint32_t h_off_st = head_idx * state_tiles;
 
     Noc noc;
@@ -52,14 +56,47 @@ void kernel_main() {
     CircularBuffer cb_final_state_o(cb_final_state);
 
     // Write output chunks as they become available.
-    for (uint32_t c = 0; c < NC; c++) {
-        cb_out_o.wait_front(out_tiles);
-        uint32_t tile_off = h_off_out + c * out_tiles;
-        for (uint32_t t = 0; t < out_tiles; t++) {
-            noc.async_write(cb_out_o, out_gen, f32_tile, {.offset_bytes = t * f32_tile}, {.page_id = tile_off + t});
+    if constexpr (TOKEN_MAJOR) {
+        // Scatter into token-major [B, T, H*Dv]. cb_out holds one chunk = Ct*Vt tiles ordered
+        // t = ct*Vt + vt. Destination page-id (interleaved, row-major):
+        //   page(c,ct,vt) = (b*T_tiles + c*Ct + ct)*(H*Vt) + h*Vt + vt.
+        // The Vt V-tiles of a row are contiguous (a Vt-tile burst); rows/chunks are strided.
+        constexpr uint32_t HVt = H * Vt;
+        const uint32_t b = head_idx / H;
+        const uint32_t h = head_idx % H;
+        const uint32_t head_page_base = b * T_tiles * HVt + h * Vt;  // page of (t_tile=0, vt=0) for this head
+        for (uint32_t c = 0; c < NC; c++) {
+            cb_out_o.wait_front(out_tiles);
+            for (uint32_t ct = 0; ct < Ct; ct++) {
+                const uint32_t t_tile = c * Ct + ct;
+                if (t_tile >= T_tiles) {
+                    continue;  // chunk-padding tail row: drop (CB is popped per chunk below)
+                }
+                const uint32_t row_page = head_page_base + t_tile * HVt;
+                for (uint32_t vt = 0; vt < Vt; vt++) {
+                    noc.async_write(
+                        cb_out_o,
+                        out_gen,
+                        f32_tile,
+                        {.offset_bytes = (ct * Vt + vt) * f32_tile},
+                        {.page_id = row_page + vt});
+                }
+            }
+            noc.async_write_barrier();
+            cb_out_o.pop_front(out_tiles);
         }
-        noc.async_write_barrier();
-        cb_out_o.pop_front(out_tiles);
+    } else {
+        // Legacy head-major [BH, NC, C, Dv]: chunk is a contiguous out_tiles run.
+        const uint32_t h_off_out = head_idx * NC * out_tiles;
+        for (uint32_t c = 0; c < NC; c++) {
+            cb_out_o.wait_front(out_tiles);
+            uint32_t tile_off = h_off_out + c * out_tiles;
+            for (uint32_t t = 0; t < out_tiles; t++) {
+                noc.async_write(cb_out_o, out_gen, f32_tile, {.offset_bytes = t * f32_tile}, {.page_id = tile_off + t});
+            }
+            noc.async_write_barrier();
+            cb_out_o.pop_front(out_tiles);
+        }
     }
 
     // Write final state (pushed by compute kernel after all chunks complete).

--- a/ttnn/cpp/ttnn/operations/transformer/gated_delta_attn/gated_delta_attn.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/gated_delta_attn/gated_delta_attn.cpp
@@ -19,7 +19,10 @@ std::tuple<ttnn::Tensor, ttnn::Tensor> gated_delta_attn_seq(
     const ttnn::Tensor& L_inv,
     const std::optional<ttnn::Tensor>& initial_state,
     const std::optional<ttnn::MemoryConfig>& memory_config,
-    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config) {
+    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
+    bool token_major_output,
+    uint32_t num_v_heads,
+    uint32_t seq_len) {
     auto mc = memory_config.value_or(tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
     auto kc = init_device_compute_kernel_config(
         L_unit.device()->arch(),
@@ -30,7 +33,20 @@ std::tuple<ttnn::Tensor, ttnn::Tensor> gated_delta_attn_seq(
         /*default_l1_acc=*/false);
 
     auto results = ttnn::prim::gated_delta_attn_seq(
-        L_unit, v_beta_sc, k_bd_sc, intra_attn, q_decay, k_decay_t, dl_exp, L_inv, initial_state, mc, kc);
+        L_unit,
+        v_beta_sc,
+        k_bd_sc,
+        intra_attn,
+        q_decay,
+        k_decay_t,
+        dl_exp,
+        L_inv,
+        initial_state,
+        mc,
+        kc,
+        token_major_output,
+        num_v_heads,
+        seq_len);
 
     return {results[0], results[1]};
 }

--- a/ttnn/cpp/ttnn/operations/transformer/gated_delta_attn/gated_delta_attn.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/gated_delta_attn/gated_delta_attn.hpp
@@ -45,6 +45,9 @@ std::tuple<ttnn::Tensor, ttnn::Tensor> gated_delta_attn_seq(
     const ttnn::Tensor& L_inv,
     const std::optional<ttnn::Tensor>& initial_state = std::nullopt,
     const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
-    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt);
+    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
+    bool token_major_output = false,
+    uint32_t num_v_heads = 0,
+    uint32_t seq_len = 0);
 
 }  // namespace ttnn::transformer

--- a/ttnn/cpp/ttnn/operations/transformer/gated_delta_attn/gated_delta_attn_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/gated_delta_attn/gated_delta_attn_nanobind.cpp
@@ -33,10 +33,16 @@ void bind_gated_delta_attn_seq(nb::module_& mod) {
             initial_state (ttnn.Tensor, optional): [BH, Dk, Dv] initial state (zeros if absent).
             memory_config (ttnn.MemoryConfig, optional): output memory config.
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional).
+            token_major_output (bool, optional): when True, the writer scatters heads directly into
+                a token-major output [B, seq_len, num_v_heads*Dv] (folds the head->token permute).
+                Requires num_v_heads and seq_len. Defaults to False (legacy [BH, NC, C, Dv]).
+            num_v_heads (int, optional): H (value heads per batch); B = BH / H. Used iff token_major_output.
+            seq_len (int, optional): T (logical sequence length, pre chunk-pad). Used iff token_major_output.
 
         Returns:
             tuple[ttnn.Tensor, ttnn.Tensor]:
-                output [BH, NC, C, Dv], final_state [BH, Dk, Dv]
+                output [BH, NC, C, Dv] (or [B, seq_len, num_v_heads*Dv] if token_major_output),
+                final_state [BH, Dk, Dv]
         )doc";
 
     ttnn::bind_function<"gated_delta_attn_seq", "ttnn.transformer.">(
@@ -54,7 +60,10 @@ void bind_gated_delta_attn_seq(nb::module_& mod) {
         nb::kw_only(),
         nb::arg("initial_state") = nb::none(),
         nb::arg("memory_config") = nb::none(),
-        nb::arg("compute_kernel_config") = nb::none());
+        nb::arg("compute_kernel_config") = nb::none(),
+        nb::arg("token_major_output") = false,
+        nb::arg("num_v_heads") = 0,
+        nb::arg("seq_len") = 0);
 }
 
 }  // namespace ttnn::operations::transformer


### PR DESCRIPTION
### Summary

Contributes to https://github.com/tenstorrent/tt-metal/issues/42828

Two changes that remove the head-major to token-major layout change on the Gated DeltaNet (GDN) `forward_prefill` path.

1. Token-major scan output: instead of the current head-major `[BH, NC, C, Dv]` output, the scan kernel writer scatters each head's chunk output directly into a token-major `[B, seq_len, H*Dv]` DRAM tensor.

2. Composed per-head RMSNorm: with token-major output on, `gate_norm` runs directly on the `[B, T, H*V]` tile layout using a sequence of ttnn ops, so the whole prefill tail stays token-major. This removes the `[B,T,H*V] -> [B,T,H,V]` costly reshape that the native `rms_norm` requires.

### Performance

One GDN block's `forward_prefill`, device-kernel time. **p150b, single card,
`GDN_PERF_SIM_TP=4`, ISL=4096 / window=2048, fp32 preprocessing.** 

| Stage | Baseline (ms) | PR (ms) | Delta | Code region |
|-------|--------------:|--------:|------:|-------------|
| proj | 1.806 | 1.804 | −0.00 | qkvz/ab linears |
| conv | 6.621 | 6.634 | +0.01 | `_causal_conv1d_fir` + SiLU |
| gdn_core | 16.730 | 15.919 | **−0.81** | `chunk_gated_delta_rule_seq_adapter` — core.out permute folded into the writer |
| state_carry | 0.011 | 0.011 | +0.00 | recurrent / conv-state carry |
| gate_norm | 3.350 | 1.288 | **−2.06** | per-head RMS + SiLU(z); composed norm drops the tile-crossing reshape |
| out_proj | 0.820 | 0.821 | +0.00 | out linear |
| all_reduce | 0.164 | 0.164 | +0.00 | `tt_all_reduce` (SIM_TP stub) |
| **Total** | **29.665** | **26.808** | **−2.857 (−9.6%)** | |

 **End-to-end demo (`text_demo.py -k traced_8k`, 4× p150b):**

  | metric | baseline (`cba375f1bc5`) | PR #49875 (`043b4b5d00a`) | Δ |
  |---|--:|--:|--:|
  | TTFT (8192-token prefill) | 4.67 s | 4.41 s | **−0.26 s (−5.6%)** |
  | Decode | 18.12 tok/s | 18.11 tok/s | ~0 (noise) |
  | Correctness | PASS | PASS | equivalent |


### Notes for reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/gdn-token-major-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/gdn-token-major-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/gdn-token-major-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/gdn-token-major-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=iwrosz/gdn-token-major-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:iwrosz/gdn-token-major-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/gdn-token-major-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/gdn-token-major-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/gdn-token-major-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/gdn-token-major-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/gdn-token-major-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/gdn-token-major-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/gdn-token-major-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/gdn-token-major-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/gdn-token-major-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/gdn-token-major-output)