### PR TITLE
[SDPA] Move sparse_sdpa / indexer_score perf checks to the realtime device profiler

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -96,7 +96,7 @@ ttnn:
     bh_p150b_civ2: 1045
     wh_n150_civ2: 1185
     wh_n300_civ2: 1175
-    bh_p150b_civ2_viommu: 125
+    bh_p150b_civ2_viommu: 115
   e2e:
     wh_llmbox: 90
     wh_galaxy: 120

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -96,7 +96,7 @@ ttnn:
     bh_p150b_civ2: 1045
     wh_n150_civ2: 1185
     wh_n300_civ2: 1175
-    bh_p150b_civ2_viommu: 115
+    bh_p150b_civ2_viommu: 125
   e2e:
     wh_llmbox: 90
     wh_galaxy: 120

--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -397,7 +397,6 @@ jobs:
           device_perf_model_name: "ops-perf-tests"
           commands: |
             pytest tests/ttnn/perf_tests/operations/conv -m models_device_performance_bare_metal --timeout=300
-            ${{ matrix.test-info.arch == 'blackhole' && 'INDEXER_SCORE_PERF_CHECKS=1 pytest tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py::test_indexer_score_math_util -svv' || '' }}
         if: ${{ !cancelled() && matrix.test-info.civ2-compatible && (!matrix.test-info.job-set1 || matrix.test-info.job-blackhole-set1) && fromJSON(needs.define-models.outputs.models-to-run)['ops-perf-tests'] }}
         timeout-minutes: ${{ matrix.test-info.timeout }}
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -18,6 +18,7 @@ markers =
     model_perf_t3000: mark model silicon tests for performance on t3000 bare metal
     model_perf_tg: mark model silicon tests for performance on tg bare metal
     requires_fast_runtime_mode_off: mark tests which require fast runtime mode to be off: validation, logging, tracing
+    requires_host_iommu: mark tests that require a host-IOMMU runner, including realtime-profiler and 64-bit PCIe socket tests
     requires_grid_size(min_x, min_y) or min_cores: skip if device worker grid (compute_with_storage_grid_size) is smaller; pass (min_x, min_y) tuple or single int for min total cores
     use_module_device(device_params): use module-scoped device fixture for faster test execution. Pass device_params as positional dict or keyword arg.
     timeout: per-test timeout in seconds (enforced by pytest-timeout when installed; registered here to silence unknown-mark warnings in envs without the plugin)

--- a/tests/pipeline_reorg/ops_unit_tests.yaml
+++ b/tests/pipeline_reorg/ops_unit_tests.yaml
@@ -90,7 +90,9 @@
   category: experimental
 
 - name: ttnn nightly experimental tests (blackhole)
-  cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/experimental -xv -k "not performance and not test_h2d_socket_sync" --timeout=600'
+  # test_indexer_score_math_util is an RT-profiler perf check: it needs host IOMMU and is pinned to the viommu
+  # sku below, so exclude it by name here or it fails its profiler-active guard on this non-IOMMU sku.
+  cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/experimental -xv -k "not performance and not test_h2d_socket_sync and not test_indexer_score_math_util" --timeout=600'
   skus:
     bh_p100:
       timeout: 35
@@ -106,6 +108,18 @@
     bh_p150b_civ2_viommu:
       timeout: 5
   owner_id: U09L76N1MAT  # Nenad Babin
+  team: ttnn
+  category: experimental
+
+- name: ttnn nightly indexer_score perf checks (blackhole - viommu)
+  # indexer_score math-util bands via the realtime device profiler. The profiler's D2H socket uses 64-bit
+  # PCIe addressing, which needs host IOMMU, so this runs on the IOMMU sku. It is excluded by name from the
+  # broad non-IOMMU experimental glob above and fails if the profiler is inactive.
+  cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py::test_indexer_score_math_util -xv --timeout=600'
+  skus:
+    bh_p150b_civ2_viommu:
+      timeout: 5
+  owner_id: U085GDCAZTN # Pavle Josipovic
   team: ttnn
   category: experimental
 
@@ -233,12 +247,15 @@
   category: misc
 
 - name: ttnn nightly sdpa tests
-  # MLA decode / prefill stress are split out into the sdpa stress entry below;
-  # this entry runs the rest of the sdpa nightly suite.
+  # MLA decode / prefill stress are split out into the sdpa stress entry below; this entry runs the rest of the
+  # sdpa nightly suite. The sparse_sdpa / sparse_sdpa_msa perf checks are RT-profiler tests needing host IOMMU
+  # (pinned to the viommu sku below); exclude them by name here or they fail their profiler-active guard.
   cmd: |
     pytest tests/ttnn/nightly/unit_tests/operations/sdpa \
       --ignore=tests/ttnn/nightly/unit_tests/operations/sdpa/test_mla_decode_stress.py \
       --ignore=tests/ttnn/nightly/unit_tests/operations/sdpa/test_mla_prefill_stress.py \
+      --ignore=tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa_msa_perf.py \
+      --deselect tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa.py::test_sparse_sdpa_perf \
       -xv --timeout=600
   skus:
     wh_n150_civ2:
@@ -263,6 +280,22 @@
       timeout: 55
     bh_p150b_civ2:
       timeout: 55
+  owner_id: U085GDCAZTN # Pavle Josipovic
+  team: ttnn
+  category: sdpa
+
+- name: ttnn nightly sparse_sdpa perf checks (blackhole - viommu)
+  # Realtime-device-profiler perf bands for sparse_sdpa / sparse_sdpa_msa. The profiler's D2H socket uses
+  # 64-bit PCIe addressing, which needs host IOMMU, so these run on the IOMMU sku. They are excluded by name
+  # from the broad non-IOMMU sdpa glob above and fail if the profiler is inactive. The rest of the sdpa suite
+  # runs on the non-IOMMU sku above.
+  cmd: |
+    pytest tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa.py::test_sparse_sdpa_perf \
+           tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa_msa_perf.py \
+           -xv --timeout=600
+  skus:
+    bh_p150b_civ2_viommu:
+      timeout: 5
   owner_id: U085GDCAZTN # Pavle Josipovic
   team: ttnn
   category: sdpa

--- a/tests/pipeline_reorg/ops_unit_tests.yaml
+++ b/tests/pipeline_reorg/ops_unit_tests.yaml
@@ -103,23 +103,19 @@
   category: experimental
 
 - name: ttnn nightly experimental tests (blackhole - viommu)
-  cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_h2d_socket_sync.py -xv --timeout=600'
+  # These tests require host IOMMU: the H2D socket sync exercises 64-bit PCIe addressing, while the
+  # indexer_score and sparse_sdpa perf checks require the realtime device profiler's D2H socket.
+  cmd: |
+    pytest \
+      tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_h2d_socket_sync.py \
+      tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py::test_indexer_score_math_util \
+      tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa.py::test_sparse_sdpa_perf \
+      tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa_msa_perf.py \
+      -xv --timeout=600
   skus:
     bh_p150b_civ2_viommu:
       timeout: 5
   owner_id: U09L76N1MAT  # Nenad Babin
-  team: ttnn
-  category: experimental
-
-- name: ttnn nightly indexer_score perf checks (blackhole - viommu)
-  # indexer_score math-util bands via the realtime device profiler. The profiler's D2H socket uses 64-bit
-  # PCIe addressing, which needs host IOMMU, so this runs on the IOMMU sku. It is excluded by name from the
-  # broad non-IOMMU experimental glob above and fails if the profiler is inactive.
-  cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py::test_indexer_score_math_util -xv --timeout=600'
-  skus:
-    bh_p150b_civ2_viommu:
-      timeout: 5
-  owner_id: U085GDCAZTN # Pavle Josipovic
   team: ttnn
   category: experimental
 
@@ -280,22 +276,6 @@
       timeout: 55
     bh_p150b_civ2:
       timeout: 55
-  owner_id: U085GDCAZTN # Pavle Josipovic
-  team: ttnn
-  category: sdpa
-
-- name: ttnn nightly sparse_sdpa perf checks (blackhole - viommu)
-  # Realtime-device-profiler perf bands for sparse_sdpa / sparse_sdpa_msa. The profiler's D2H socket uses
-  # 64-bit PCIe addressing, which needs host IOMMU, so these run on the IOMMU sku. They are excluded by name
-  # from the broad non-IOMMU sdpa glob above and fail if the profiler is inactive. The rest of the sdpa suite
-  # runs on the non-IOMMU sku above.
-  cmd: |
-    pytest tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa.py::test_sparse_sdpa_perf \
-           tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa_msa_perf.py \
-           -xv --timeout=600
-  skus:
-    bh_p150b_civ2_viommu:
-      timeout: 5
   owner_id: U085GDCAZTN # Pavle Josipovic
   team: ttnn
   category: sdpa

--- a/tests/pipeline_reorg/ops_unit_tests.yaml
+++ b/tests/pipeline_reorg/ops_unit_tests.yaml
@@ -79,7 +79,7 @@
 
 - name: ttnn nightly experimental tests (wormhole)
   # test_moe_grouped_topk hangs on Wormhole (TODO: file issue + restore). Exclude on WH only.
-  cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/experimental -xv -k "not performance and not test_moe_grouped_topk and not test_h2d_socket_sync" --timeout=600'
+  cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/experimental -xv -k "not performance and not test_moe_grouped_topk" -m "not requires_host_iommu" --timeout=600'
   skus:
     wh_n150_civ2:
       timeout: 65
@@ -90,9 +90,8 @@
   category: experimental
 
 - name: ttnn nightly experimental tests (blackhole)
-  # test_indexer_score_math_util is an RT-profiler perf check: it needs host IOMMU and is pinned to the viommu
-  # sku below, so exclude it by name here or it fails its profiler-active guard on this non-IOMMU sku.
-  cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/experimental -xv -k "not performance and not test_h2d_socket_sync and not test_indexer_score_math_util" --timeout=600'
+  # Host-IOMMU tests are selected by the viommu job below and excluded from these non-IOMMU SKUs.
+  cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/experimental -xv -k "not performance" -m "not requires_host_iommu" --timeout=600'
   skus:
     bh_p100:
       timeout: 35
@@ -103,15 +102,13 @@
   category: experimental
 
 - name: ttnn nightly experimental tests (blackhole - viommu)
-  # These tests require host IOMMU: the H2D socket sync exercises 64-bit PCIe addressing, while the
-  # indexer_score and sparse_sdpa perf checks require the realtime device profiler's D2H socket.
+  # Tests opt in with @pytest.mark.requires_host_iommu, allowing operation developers to add IOMMU coverage
+  # without changing this infra-owned command. Keep the search roots aligned with the non-IOMMU suites above.
   cmd: |
     pytest \
-      tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_h2d_socket_sync.py \
-      tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py::test_indexer_score_math_util \
-      tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa.py::test_sparse_sdpa_perf \
-      tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa_msa_perf.py \
-      -xv --timeout=600
+      tests/ttnn/nightly/unit_tests/operations/experimental \
+      tests/ttnn/nightly/unit_tests/operations/sdpa \
+      -m requires_host_iommu -xv --timeout=600
   skus:
     bh_p150b_civ2_viommu:
       timeout: 5
@@ -244,15 +241,12 @@
 
 - name: ttnn nightly sdpa tests
   # MLA decode / prefill stress are split out into the sdpa stress entry below; this entry runs the rest of the
-  # sdpa nightly suite. The sparse_sdpa / sparse_sdpa_msa perf checks are RT-profiler tests needing host IOMMU
-  # (pinned to the viommu sku below); exclude them by name here or they fail their profiler-active guard.
+  # sdpa nightly suite. Host-IOMMU tests are selected by marker in the viommu job above.
   cmd: |
     pytest tests/ttnn/nightly/unit_tests/operations/sdpa \
       --ignore=tests/ttnn/nightly/unit_tests/operations/sdpa/test_mla_decode_stress.py \
       --ignore=tests/ttnn/nightly/unit_tests/operations/sdpa/test_mla_prefill_stress.py \
-      --ignore=tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa_msa_perf.py \
-      --deselect tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa.py::test_sparse_sdpa_perf \
-      -xv --timeout=600
+      -m "not requires_host_iommu" -xv --timeout=600
   skus:
     wh_n150_civ2:
       timeout: 90

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_h2d_socket_sync.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_h2d_socket_sync.py
@@ -21,6 +21,7 @@ import ttnn
 from models.common.utility_functions import is_blackhole, skip_for_slow_dispatch
 
 pytestmark = [
+    pytest.mark.requires_host_iommu,
     skip_for_slow_dispatch(),
     pytest.mark.skipif(
         not is_blackhole(),

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
@@ -1287,7 +1287,7 @@ _MATH_UTIL_CASES = [
         "minimax_m3",
         run_indexer_m3,
         lambda: m3_valid_tiles() * (32 * 32) * (2 * M3_DIM),
-        43.55,
+        42.9,
     ),
     # Block-split grid fill: GLM5/DSv32 resharded TP=1/SP=32 -- a short 160-query chunk (QC=1, 5 q-groups) the
     # scheduler spreads across num_blocks=2 row-blocks (110 cores); without the fill these would use only 55

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
@@ -1314,6 +1314,7 @@ _MATH_UTIL_CASES = [
     _MATH_UTIL_CASES,
     ids=[c[0] for c in _MATH_UTIL_CASES],
 )
+@pytest.mark.requires_host_iommu
 @skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
 @skip_with_watcher("Watcher perturbs kernel timing; perf checks are not meaningful with it enabled.")
 def test_indexer_score_math_util(device, case_id, run_fn, mm_flops_thunk, expected_util):
@@ -1321,10 +1322,10 @@ def test_indexer_score_math_util(device, case_id, run_fn, mm_flops_thunk, expect
     asserted within +/- INDEXER_PERF_MARGIN: GLM5 / DSv32 / MiniMax-M3 at the deployed TP=4/SP=8, plus
     glm5_tp1 / dsv32_tp1 at the resharded TP=1/SP=32 grid-fill shapes. Profiles one dispatch of the case's op
     with the real-time device profiler and compares the achieved math_util to the expected value (measured on
-    a BH dev board). Pinned to the IOMMU-enabled BH sku (see ops_unit_tests.yaml) and excluded by name from the
-    broad non-IOMMU globs, so an inactive profiler here is a regression -> fail."""
+    a BH dev board). Marked requires_host_iommu so the marker-selected IOMMU job runs it and broad non-IOMMU
+    jobs exclude it; an inactive profiler here is therefore a regression -> fail."""
     if not ttnn.device.IsProgramRealtimeProfilerActive():
-        # This runs only on the IOMMU-pinned sku (the broad non-IOMMU globs exclude it by name), so an inactive
+        # This runs only on the IOMMU-pinned sku (the broad non-IOMMU globs exclude it by marker), so an inactive
         # profiler means it regressed on a sku that should have it -- fail (not skip), matching the sprint /
         # ring-joint perf checks.
         pytest.fail("Real-time profiler must be active for indexer_score perf checks (needs IOMMU)")

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
@@ -22,19 +22,20 @@ Deployments are Galaxy chunked prefill (50K history + 5K chunk = 55K keys; the c
 block-max-pooled). Most cases run on one chip with explicit ``chunk_start`` (``sp_rank`` =
 ring position); the QuietBox tests derive ``chunk_start`` per device from the mesh coordinate.
 
-Run all (perf/tracy self-skip unless INDEXER_SCORE_PERF_CHECKS=1):
+Run all (the perf-check needs the real-time profiler, i.e. a host-IOMMU sku; it fails fast otherwise):
     scripts/run_safe_pytest.sh --run-all <this file>
 """
 
 import os
 import time
-from unittest import mock
 
 import pytest
 import torch
 from loguru import logger
 
 import ttnn
+from models.common.utility_functions import skip_with_llk_assert, skip_with_watcher
+from tests.ttnn.profiling.realtime_profiler_utils import profile_realtime_program
 
 pytestmark = pytest.mark.skipif(not ttnn.device.is_blackhole(), reason="indexer_score is Blackhole-only")
 
@@ -797,9 +798,9 @@ def test_indexer_score_perf(device, case_id, heads):
 
 
 # ---------------------------------------------------------------------------
-# sp_rank 7 perf helpers (tracy device profiler; no accuracy check). math_util = matmul FLOPs /
-# (cores x device cycles x matmul peak); duration from tracy, FLOPs from shape. Consumed by the DSA
-# band checks in test_indexer_score_math_util (run with INDEXER_SCORE_PERF_CHECKS=1).
+# sp_rank 7 perf helpers (real-time device profiler; no accuracy check). math_util = matmul FLOPs /
+# (cores x device cycles x matmul peak); duration from the RT profiler, FLOPs from shape. Consumed by the DSA
+# band checks in test_indexer_score_math_util (runs only on the IOMMU BH sku; fails where the RT profiler is off).
 # ---------------------------------------------------------------------------
 SP7_CHUNK_START = GLX_HISTORY + 7 * GLX_SQ  # fullest causal case (99.5% valid)
 
@@ -823,23 +824,20 @@ def indexer_mm_flops(valid_tiles, heads):
     return valid_tiles * heads * (32 * 32) * (2 * GLX_DIM)
 
 
-# perf_impl inner targets profiled by tracy, at the deployed HiFi2 dtypes (bf16 q + bfp8 k). One node per
-# model deployment; test_indexer_score_math_util spawns them by id, so the ids must stay in lockstep.
-@pytest.mark.skipif(os.environ.get("CI") == "true", reason="perf test - run locally with tracy")
-@pytest.mark.parametrize("case_id, heads", [("glm5", 8), ("dsv32", 16)], ids=["glm5", "dsv32"])
-def test_indexer_score_sp7_perf_impl(device, case_id, heads):
-    """Inner test profiled by tracy: a few indexer_score_dsa ops at GLX sp_rank 7 (bf16 q, bfp8 k). No
-    accuracy check."""
+# perf run helpers at the deployed HiFi2 dtypes (bf16 q + bfp8 k). Each builds its inputs and dispatches the
+# op once, returning the output -- the same shape as the SDPA sprint's run_sdpa closure. test_indexer_score_
+# math_util profiles one call with the real-time device profiler (one dispatch -> one record). No accuracy
+# check -- these exist solely to be profiled.
+
+
+def run_indexer_sp7(device, heads):
+    """DSA at GLX sp_rank 7 (bf16 q, bfp8 k). Dispatches indexer_score_dsa once and returns the output."""
     q, k, w = make_inputs(heads, GLX_DIM, GLX_SQ, GLX_T)
     q_dev = to_device(q, device, dtype=ttnn.bfloat16)
     k_dev = to_device(k, device, dtype=ttnn.bfloat8_b)
     w_dev = to_device(w, device)
     cfg = glx_config(heads)
-    for _ in range(5):  # tracy logs each op's device duration; the outer test takes the min
-        ttnn.experimental.indexer_score_dsa(
-            q_dev, k_dev, w_dev, chunk_start_idx=SP7_CHUNK_START, program_config=cfg
-        ).deallocate()
-    ttnn.synchronize_device(device)
+    return ttnn.experimental.indexer_score_dsa(q_dev, k_dev, w_dev, chunk_start_idx=SP7_CHUNK_START, program_config=cfg)
 
 
 # Short-query-chunk perf: the SAME two deployments (GLM5, DSv32) on the SAME keys (T=56320), but resharded
@@ -873,25 +871,27 @@ def short_config(heads):
     return ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=256 if heads <= 32 else 128, head_group_size=0)
 
 
-@pytest.mark.skipif(os.environ.get("CI") == "true", reason="perf test - run locally with tracy")
-@pytest.mark.parametrize("case_id, heads", [("dsv32_tp1", 64), ("glm5_tp1", 32)], ids=["dsv32_tp1", "glm5_tp1"])
-def test_indexer_score_short_seq_perf_impl(device, case_id, heads):
-    """Inner test profiled by tracy: GLM5/DSv32 resharded TP=1/SP=32 -- a SHORT 160-query chunk (QC=1) that
-    under-fills the grid, so the block-split scheduler replicates each q-group across num_blocks=2 row-blocks
-    (110 cores). bf16 q + bfp8 k. No accuracy check."""
+def run_indexer_short(device, heads):
+    """GLM5/DSv32 resharded TP=1/SP=32 -- a SHORT 160-query chunk (QC=1) that under-fills the grid, so the
+    block-split scheduler replicates each q-group across num_blocks=2 row-blocks (110 cores). bf16 q + bfp8 k.
+    Dispatches indexer_score_dsa once and returns the output."""
     q, k, w = make_inputs(heads, GLX_DIM, SHORT_SQ, GLX_T)
     q_dev = to_device(q, device, dtype=ttnn.bfloat16)
     k_dev = to_device(k, device, dtype=ttnn.bfloat8_b)
     w_dev = to_device(w, device)
     cfg = short_config(heads)
-    for _ in range(5):  # tracy logs each op's device duration; the outer test takes the min
-        ttnn.experimental.indexer_score_dsa(
-            q_dev, k_dev, w_dev, chunk_start_idx=SHORT_CHUNK_START, program_config=cfg
-        ).deallocate()
-    ttnn.synchronize_device(device)
+    return ttnn.experimental.indexer_score_dsa(
+        q_dev, k_dev, w_dev, chunk_start_idx=SHORT_CHUNK_START, program_config=cfg
+    )
 
 
 INDEXER_PERF_MARGIN = 0.02  # symmetric +/- 2% band on the expected math util (catches regressions AND speedups)
+
+# indexer_score fills the full Blackhole 11x10 Tensix grid regardless of program config (QC=1 short chunks
+# get block-split across num_blocks=2 row-blocks to reach it). The real-time profiler record does not carry a
+# core count, so we hardcode the grid the way the SDPA sprint check hardcodes 11*10 -- this matches the CORE
+# COUNT (110) tracy reported for every one of these cases.
+INDEXER_PERF_CORES = 11 * 10
 
 
 # ---------------------------------------------------------------------------
@@ -1237,10 +1237,9 @@ def m3_valid_tiles():
     return sum(min(tt_tiles, chunk_t + s + 1) for s in range(sqt))
 
 
-@pytest.mark.skipif(os.environ.get("CI") == "true", reason="perf test - run locally with tracy")
-def test_indexer_score_msa_m3_perf_impl(device):
-    """Inner test profiled by tracy: a few indexer_score_msa ops for one SP=8 x TP=4 M3 device (1 group,
-    640 q, 55296 kv, raw dot, scale=1/sqrt(d), bf16 q + bfp8 k). No accuracy check."""
+def run_indexer_m3(device):
+    """One SP=8 x TP=4 M3 device (1 group, 640 q, 55296 kv, raw dot, scale=1/sqrt(d), bf16 q + bfp8 k).
+    Dispatches indexer_score_msa once and returns the output. No accuracy check."""
     q, k, _ = make_inputs(1, M3_DIM, M3_SQ, M3_T)
     q_dev = to_device(q, device, dtype=ttnn.bfloat16)
     k_dev = to_device(k, device, dtype=ttnn.bfloat8_b)
@@ -1248,49 +1247,45 @@ def test_indexer_score_msa_m3_perf_impl(device):
     # tensor, not the full ~70 MB score that made the unfused path memory-bound). QC=2 + grid-aligned q/K
     # multicast removes K-read redundancy; KC=32 (blocks_per_unit=8) is the largest pool unit that fits L1.
     cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=1024, head_group_size=0)
-    for _ in range(5):  # tracy logs each op's device duration; the outer test takes the min
-        ttnn.experimental.indexer_score_msa(
-            q_dev,
-            k_dev,
-            chunk_start_idx=M3_CHUNK_START,
-            scale=M3_DIM**-0.5,
-            num_groups=1,
-            block_size=128,
-            program_config=cfg,
-        ).deallocate()
-    ttnn.synchronize_device(device)
+    return ttnn.experimental.indexer_score_msa(
+        q_dev,
+        k_dev,
+        chunk_start_idx=M3_CHUNK_START,
+        scale=M3_DIM**-0.5,
+        num_groups=1,
+        block_size=128,
+        program_config=cfg,
+    )
 
 
 # ---------------------------------------------------------------------------
-# The math-utilization band checks (CI-gated by INDEXER_SCORE_PERF_CHECKS=1), all at the deployed HiFi2 dtypes
+# The math-utilization band checks (CI runs these on the IOMMU-enabled BH sku), all at the deployed HiFi2 dtypes
 # (bf16 q + bfp8 k): the deployed TP=4/SP=8 shapes GLM5, DSv32 and MiniMax-M3 at sp_rank 7, plus the resharded
-# TP=1/SP=32 grid-fill shapes glm5_tp1 and dsv32_tp1 (block-split, fullest causal). Each spawns its perf_impl
-# under tracy, reads the min DEVICE KERNEL DURATION, computes math_util = matmul FLOPs / (cores x device
-# cycles x matmul peak), and asserts it within +/- INDEXER_PERF_MARGIN of the value measured on a Blackhole
-# dev board. mm_flops is a thunk so the shape-derived FLOP count is evaluated at run time.
+# TP=1/SP=32 grid-fill shapes glm5_tp1 and dsv32_tp1 (block-split, fullest causal). Each profiles one dispatch
+# of its op with the real-time device profiler, reads the device kernel duration, computes
+# math_util = matmul FLOPs / (cores x device cycles x matmul peak), and asserts it within +/-
+# INDEXER_PERF_MARGIN of the value measured on a Blackhole dev board. mm_flops is a thunk so the shape-derived
+# FLOP count is evaluated at run time; run_fn takes the device, runs the op, and returns its output.
 # (M3 is a single index head, so its matmul is a small slice -- the block-pool dominates -- hence the much
 # lower expected util than the multi-head DSA cases.)
 # ---------------------------------------------------------------------------
 _MATH_UTIL_CASES = [
-    # (case_id, perf_impl_node_id, profiler_subdir, mm_flops_thunk, expected_util) -- HiFi2 (bf16 q, bfp8 k)
+    # (case_id, run_fn(device) -> op output, mm_flops_thunk, expected_util) -- HiFi2 (bf16 q, bfp8 k)
     (
         "glm5",
-        "test_indexer_score_sp7_perf_impl[glm5]",
-        "ttnn_indexer_score_sp7",
+        lambda device: run_indexer_sp7(device, 8),
         lambda: indexer_mm_flops(sp7_valid_tiles(), 8),
         70.1,
     ),
     (
         "dsv32",
-        "test_indexer_score_sp7_perf_impl[dsv32]",
-        "ttnn_indexer_score_sp7",
+        lambda device: run_indexer_sp7(device, 16),
         lambda: indexer_mm_flops(sp7_valid_tiles(), 16),
         76.1,
     ),
     (
         "minimax_m3",
-        "test_indexer_score_msa_m3_perf_impl",
-        "ttnn_indexer_score_msa_m3",
+        run_indexer_m3,
         lambda: m3_valid_tiles() * (32 * 32) * (2 * M3_DIM),
         43.55,
     ),
@@ -1301,52 +1296,41 @@ _MATH_UTIL_CASES = [
     # (shared KC=8, matmul-bound). dsv32_tp1 (64h) carries twice the heads.
     (
         "dsv32_tp1",
-        "test_indexer_score_short_seq_perf_impl[dsv32_tp1]",
-        "ttnn_indexer_score_short_seq",
+        lambda device: run_indexer_short(device, 64),
         lambda: indexer_mm_flops(short_valid_tiles(), 64),
         77.31,
     ),
     (
         "glm5_tp1",
-        "test_indexer_score_short_seq_perf_impl[glm5_tp1]",
-        "ttnn_indexer_score_short_seq",
+        lambda device: run_indexer_short(device, 32),
         lambda: indexer_mm_flops(short_valid_tiles(), 32),
         75.54,
     ),
 ]
 
 
-@pytest.mark.skipif(
-    os.environ.get("INDEXER_SCORE_PERF_CHECKS") != "1",
-    reason="Set INDEXER_SCORE_PERF_CHECKS=1 to run (CI: ops perf tests job)",
-)
 @pytest.mark.parametrize(
-    "case_id, perf_id, subdir, mm_flops_thunk, expected_util",
+    "case_id, run_fn, mm_flops_thunk, expected_util",
     _MATH_UTIL_CASES,
     ids=[c[0] for c in _MATH_UTIL_CASES],
 )
-def test_indexer_score_math_util(case_id, perf_id, subdir, mm_flops_thunk, expected_util):
-    """Per-deployment HiFi2 (bf16 q, bfp8 k) matmul math utilization via tracy, asserted within +/-
-    INDEXER_PERF_MARGIN: GLM5 / DSv32 / MiniMax-M3 at the deployed TP=4/SP=8, plus glm5_tp1 / dsv32_tp1 at the
-    resharded TP=1/SP=32 grid-fill shapes. Spawns the case's perf_impl under the profiler and compares the
-    achieved math_util to the expected value (measured on a BH dev board)."""
-    from tracy.process_model_log import run_device_profiler
-    from tests.nightly.sdpa_perf_utils import post_process_ops_log
-
-    command = "pytest tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py::" + perf_id
-    with mock.patch.dict(os.environ, {"CI": "false"}):
-        run_device_profiler(command, subdir, device_analysis_types=["device_kernel_duration"])
-    r = post_process_ops_log(
-        subdir,
-        float_columns=["CORE COUNT", "DEVICE KERNEL DURATION [ns]"],
-        columns=["ATTRIBUTES"],
-        sum_vals=False,
-        has_signposts=False,
-    )
-    assert len(r["DEVICE KERNEL DURATION [ns]"]) > 0, "profiler returned no indexer_score ops"
-
-    core_count = int(r["CORE COUNT"][0])
-    duration_ns = float(r["DEVICE KERNEL DURATION [ns]"].min())
+@skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
+@skip_with_watcher("Watcher perturbs kernel timing; perf checks are not meaningful with it enabled.")
+def test_indexer_score_math_util(device, case_id, run_fn, mm_flops_thunk, expected_util):
+    """Per-deployment HiFi2 (bf16 q, bfp8 k) matmul math utilization via real-time device program records,
+    asserted within +/- INDEXER_PERF_MARGIN: GLM5 / DSv32 / MiniMax-M3 at the deployed TP=4/SP=8, plus
+    glm5_tp1 / dsv32_tp1 at the resharded TP=1/SP=32 grid-fill shapes. Profiles one dispatch of the case's op
+    with the real-time device profiler and compares the achieved math_util to the expected value (measured on
+    a BH dev board). Pinned to the IOMMU-enabled BH sku (see ops_unit_tests.yaml) and excluded by name from the
+    broad non-IOMMU globs, so an inactive profiler here is a regression -> fail."""
+    if not ttnn.device.IsProgramRealtimeProfilerActive():
+        # This runs only on the IOMMU-pinned sku (the broad non-IOMMU globs exclude it by name), so an inactive
+        # profiler means it regressed on a sku that should have it -- fail (not skip), matching the sprint /
+        # ring-joint perf checks.
+        pytest.fail("Real-time profiler must be active for indexer_score perf checks (needs IOMMU)")
+    _, perf_record = profile_realtime_program(device, lambda: run_fn(device))
+    duration_ns = perf_record["duration_ns"]
+    core_count = INDEXER_PERF_CORES
     peak = _MM_FLOPS_PER_CYCLE_PER_CORE["HiFi2"]
     cycles = duration_ns * _BH_CLOCK_GHZ
     utilization = (mm_flops_thunk() / (core_count * cycles * peak)) * 100 if core_count > 0 else 0.0

--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa.py
@@ -233,6 +233,7 @@ _NV = {
     ],
     ids=["prod-dense", "prod-half", "prod-causal", "prod-sparse", "prod-mixed", "zone1tok", "lowcore"],
 )
+@pytest.mark.requires_host_iommu
 @skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
 @skip_with_watcher("Watcher perturbs kernel timing; perf checks are not meaningful with it enabled.")
 def test_sparse_sdpa_perf(device, S, T, TOPK, kc, nv, expected_ms):
@@ -241,7 +242,7 @@ def test_sparse_sdpa_perf(device, S, T, TOPK, kc, nv, expected_ms):
     q, kv, indices = make_inputs(H, S, T, TOPK, K_DIM, lambda s: nv_fn(s, T, TOPK))
 
     if not ttnn.device.IsProgramRealtimeProfilerActive():
-        # This runs only on the IOMMU-pinned sku (the broad non-IOMMU sdpa glob deselects it by name), so an
+        # This runs only on the IOMMU-pinned sku (the broad non-IOMMU sdpa glob excludes it by marker), so an
         # inactive profiler means it regressed on a sku that should have it -- fail (not skip), matching the
         # sprint / ring-joint perf checks.
         pytest.fail("Real-time profiler must be active for sparse_sdpa perf checks (needs IOMMU)")

--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa.py
@@ -10,9 +10,11 @@ tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa.py (shared helpers in spa
 
 import pytest
 import torch
+from loguru import logger
 
 import ttnn
-from models.common.utility_functions import run_for_blackhole
+from models.common.utility_functions import run_for_blackhole, skip_with_llk_assert, skip_with_watcher
+from tests.ttnn.profiling.realtime_profiler_utils import profile_realtime_program
 from tests.ttnn.unit_tests.operations.sdpa.sparse_sdpa_test_utils import (
     make_inputs,
     golden,
@@ -199,9 +201,14 @@ def test_sparse_sdpa_determinism(device, q_dtype, kv_dtype):
     assert mismatch == 0.0, "sparse_sdpa output is not deterministic across repeated runs"
 
 
-# ---- Perf-only (no golden; full-size golden gather is ~GBs). Profile with:
-#      python -m tracy -p -r -v -m pytest <thisfile>::test_sparse_sdpa_perf
-#      then read "DEVICE KERNEL DURATION [ns]" for SparseSDPAOperation. ----
+# ---- Perf check (no golden; full-size golden gather is ~GBs). Device timing via the real-time device program
+#      profiler: the op is profiled with profile_realtime_program and its device kernel duration is asserted
+#      within +/- SPARSE_PERF_MARGIN of the value measured on a Blackhole p150b. A symmetric band catches
+#      regressions AND unexpected speedups. Math utilization is not meaningful for this block-sparse op (the
+#      gather/DMA dominates), so we gate on wall-clock device duration. Needs no tracy build. ----
+# Observed run-to-run spread is <1%; 5% leaves headroom for board/thermal variance while catching a regression.
+SPARSE_PERF_MARGIN = 0.05
+
 # nv (valid keys/token) patterns. Chunk-skip benefit is sparsity-dependent, so sweep it.
 _NV = {
     "dense": lambda s, T, K: K,  # all TOPK valid (no skip) -> worst case, proves no regression
@@ -214,21 +221,44 @@ _NV = {
 
 @run_for_blackhole()
 @pytest.mark.parametrize(
-    "S,T,TOPK,kc,nv",
+    "S,T,TOPK,kc,nv,expected_ms",
     [
-        (640, 56320, 2048, 256, "dense"),  # production shape (Q[32,640,576], KV[56320,576], idx[640,2048])
-        (640, 56320, 2048, 256, "half"),
-        (640, 56320, 2048, 256, "causal"),
-        (640, 56320, 2048, 256, "sparse"),
-        (640, 56320, 2048, 256, "mixed"),
-        (110, 56320, 2048, 256, "dense"),  # 1 token/core, 8 chunks, real T -> representative DRAM locality
-        (8, 56320, 2048, 256, "dense"),  # 8 cores -> low DRAM contention; isolates BW headroom vs floor
+        (640, 56320, 2048, 256, "dense", 3.33),  # production shape (Q[32,640,576], KV[56320,576], idx[640,2048])
+        (640, 56320, 2048, 256, "half", 1.78),
+        (640, 56320, 2048, 256, "causal", 0.732),
+        (640, 56320, 2048, 256, "sparse", 0.576),
+        (640, 56320, 2048, 256, "mixed", 1.838),
+        (110, 56320, 2048, 256, "dense", 0.576),  # 1 token/core, 8 chunks, real T -> representative DRAM locality
+        (8, 56320, 2048, 256, "dense", 0.155),  # 8 cores -> low DRAM contention; isolates BW headroom vs floor
     ],
     ids=["prod-dense", "prod-half", "prod-causal", "prod-sparse", "prod-mixed", "zone1tok", "lowcore"],
 )
-def test_sparse_sdpa_perf(device, S, T, TOPK, kc, nv):
+@skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
+@skip_with_watcher("Watcher perturbs kernel timing; perf checks are not meaningful with it enabled.")
+def test_sparse_sdpa_perf(device, S, T, TOPK, kc, nv, expected_ms):
     H = 32
     nv_fn = _NV[nv]
     q, kv, indices = make_inputs(H, S, T, TOPK, K_DIM, lambda s: nv_fn(s, T, TOPK))
-    out, _ = run_op(q, kv, indices, device, kc, V_DIM)  # no golden; correctness covered by the PCC tests
+
+    if not ttnn.device.IsProgramRealtimeProfilerActive():
+        # This runs only on the IOMMU-pinned sku (the broad non-IOMMU sdpa glob deselects it by name), so an
+        # inactive profiler means it regressed on a sku that should have it -- fail (not skip), matching the
+        # sprint / ring-joint perf checks.
+        pytest.fail("Real-time profiler must be active for sparse_sdpa perf checks (needs IOMMU)")
+
+    # Profile the op with the real-time device profiler (one dispatch -> one device program record), same as
+    # the single-chip SDPA sprint perf check. No golden; correctness is covered by the PCC tests.
+    result, perf_record = profile_realtime_program(device, lambda: run_op(q, kv, indices, device, kc, V_DIM))
+    out, _ = result
+    duration_ms = perf_record["duration_ns"] / 1e6
+    lower = expected_ms * (1 - SPARSE_PERF_MARGIN)
+    upper = expected_ms * (1 + SPARSE_PERF_MARGIN)
+    logger.info(
+        f"sparse_sdpa perf S={S} T={T} TOPK={TOPK} kc={kc} nv={nv}: duration={duration_ms:.3f} ms "
+        f"(expected {expected_ms:.3f} ms, band [{lower:.3f}, {upper:.3f}])"
+    )
     assert tuple(out.shape) == (1, H, S, V_DIM)
+    assert lower <= duration_ms <= upper, (
+        f"sparse_sdpa {nv} device kernel duration {duration_ms:.3f} ms outside band [{lower:.3f}, {upper:.3f}] ms "
+        f"(expected {expected_ms:.3f} ms, margin +/- {SPARSE_PERF_MARGIN * 100:.0f}%)"
+    )

--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa_msa_perf.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa_msa_perf.py
@@ -1,46 +1,95 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Performance smoke for the production-scale sparse_sdpa_msa shapes.
+"""Performance check for the production-scale sparse_sdpa_msa shapes.
 
-Profile with:
-    python -m tracy -p -r -v -m pytest tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa_msa_perf.py
-then read "DEVICE KERNEL DURATION [ns]" for SparseSDPAMsaOperation.
+Device timing via the real-time device program profiler (no tracy build needed): the op is profiled with
+profile_realtime_program and its device kernel duration is asserted within +/- MSA_PERF_MARGIN of the
+value measured on a Blackhole dev board. A symmetric band catches regressions AND unexpected speedups
+(the latter often means work was silently skipped). Math utilization is not meaningful here (block-sparse
+DMA + block-pool dominate, not the matmul), so we gate on wall-clock device duration instead.
 
 Per-chip TP-shard shape: H=16, n_kv=1, S=640, T=56320 (nblk=440), topk=16, d=v_dim=128,
 block_size=128.
 Single-chip native GQA shape: H=64, n_kv=4, S=640, T=56320, topk=16, d=v_dim=128, block_size=128.
 """
 
-import os
-
 import pytest
+from loguru import logger
 
 import ttnn
 
-from models.common.utility_functions import run_for_blackhole
+from models.common.utility_functions import run_for_blackhole, skip_with_llk_assert, skip_with_watcher
+from tests.ttnn.profiling.realtime_profiler_utils import profile_realtime_program
 from tests.ttnn.unit_tests.operations.sdpa.sparse_sdpa_msa_test_utils import make_msa_inputs, run_op_msa_native
 
-pytestmark = [
-    pytest.mark.skipif(os.getenv("CI") == "true", reason="sparse_sdpa_msa perf smoke is skipped on CI for now"),
-    pytest.mark.use_module_device,
-]
+# CI runs these only on the IOMMU-enabled BH sku (see ops_unit_tests.yaml); the broad non-IOMMU sdpa glob
+# --ignores this whole file, and the perf helper fails (not skips) if the RT profiler is inactive, so an
+# IOMMU regression on the pinned sku reds rather than passing silently.
+pytestmark = pytest.mark.use_module_device
+
+# Symmetric +/- band on the expected device kernel duration (ms), measured on a Blackhole p150b. Observed
+# run-to-run spread is <1%; 5% leaves comfortable headroom for board/thermal variance while still catching a
+# real regression. Duration (unlike math util) is not normalized for clock/board, so keep some slack here.
+MSA_PERF_MARGIN = 0.05
+
+
+def _assert_msa_duration(device, run_fn, expected_ms, label):
+    """Profile one dispatch of the op with the real-time device profiler and assert its device kernel duration
+    is within +/- MSA_PERF_MARGIN of expected_ms. Returns the op output for the shape check."""
+    if not ttnn.device.IsProgramRealtimeProfilerActive():
+        # This runs only on the IOMMU-pinned sku (the broad non-IOMMU sdpa glob --ignores this file), so an
+        # inactive profiler means it regressed on a sku that should have it -- fail (not skip), matching the
+        # sprint / ring-joint perf checks.
+        pytest.fail("Real-time profiler must be active for sparse_sdpa_msa perf checks (needs IOMMU)")
+
+    out, perf_record = profile_realtime_program(device, run_fn)
+    duration_ms = perf_record["duration_ns"] / 1e6
+    lower = expected_ms * (1 - MSA_PERF_MARGIN)
+    upper = expected_ms * (1 + MSA_PERF_MARGIN)
+    logger.info(
+        f"sparse_sdpa_msa perf {label}: duration={duration_ms:.3f} ms "
+        f"(expected {expected_ms:.3f} ms, band [{lower:.3f}, {upper:.3f}])"
+    )
+    assert lower <= duration_ms <= upper, (
+        f"{label} device kernel duration {duration_ms:.3f} ms outside band [{lower:.3f}, {upper:.3f}] ms "
+        f"(expected {expected_ms:.3f} ms, margin +/- {MSA_PERF_MARGIN * 100:.0f}%)"
+    )
+    return out
 
 
 @run_for_blackhole()
-@pytest.mark.parametrize("kv_dtype", [ttnn.bfloat8_b, ttnn.bfloat16], ids=["bfp8", "bf16"])
-def test_msa_perf_prod(device, kv_dtype):
+@pytest.mark.parametrize(
+    "kv_dtype, expected_ms", [(ttnn.bfloat8_b, 0.774), (ttnn.bfloat16, 1.417)], ids=["bfp8", "bf16"]
+)
+@skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
+@skip_with_watcher("Watcher perturbs kernel timing; perf checks are not meaningful with it enabled.")
+def test_msa_perf_prod(device, kv_dtype, expected_ms):
     d, H, S, T, topk = 128, 16, 640, 56320, 16
     # Non-causal selection keeps topk=16 valid blocks for every query.
     q, k, v, indices = make_msa_inputs(H, 1, S, T, topk, d, causal=False, seed=7)
-    out = run_op_msa_native(q, k, v, indices, device, kv_dtype=kv_dtype)
+    out = _assert_msa_duration(
+        device,
+        lambda: run_op_msa_native(q, k, v, indices, device, kv_dtype=kv_dtype),
+        expected_ms,
+        f"prod H={H} n_kv=1 kv_dtype={kv_dtype}",
+    )
     assert tuple(out.shape) == (1, H, S, d)
 
 
 @run_for_blackhole()
-@pytest.mark.parametrize("kv_dtype", [ttnn.bfloat8_b, ttnn.bfloat16], ids=["bfp8", "bf16"])
-def test_msa_perf_prod_single_chip_gqa(device, kv_dtype):
+@pytest.mark.parametrize(
+    "kv_dtype, expected_ms", [(ttnn.bfloat8_b, 3.084), (ttnn.bfloat16, 5.601)], ids=["bfp8", "bf16"]
+)
+@skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
+@skip_with_watcher("Watcher perturbs kernel timing; perf checks are not meaningful with it enabled.")
+def test_msa_perf_prod_single_chip_gqa(device, kv_dtype, expected_ms):
     d, H, n_kv, S, T, topk = 128, 64, 4, 640, 56320, 16
     q, k, v, indices = make_msa_inputs(H, n_kv, S, T, topk, d, causal=False, seed=7)
-    out = run_op_msa_native(q, k, v, indices, device, kv_dtype=kv_dtype)
+    out = _assert_msa_duration(
+        device,
+        lambda: run_op_msa_native(q, k, v, indices, device, kv_dtype=kv_dtype),
+        expected_ms,
+        f"gqa H={H} n_kv={n_kv} kv_dtype={kv_dtype}",
+    )
     assert tuple(out.shape) == (1, H, S, d)

--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa_msa_perf.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa_msa_perf.py
@@ -23,10 +23,10 @@ from models.common.utility_functions import run_for_blackhole, skip_with_llk_ass
 from tests.ttnn.profiling.realtime_profiler_utils import profile_realtime_program
 from tests.ttnn.unit_tests.operations.sdpa.sparse_sdpa_msa_test_utils import make_msa_inputs, run_op_msa_native
 
-# CI runs these only on the IOMMU-enabled BH sku (see ops_unit_tests.yaml); the broad non-IOMMU sdpa glob
-# --ignores this whole file, and the perf helper fails (not skips) if the RT profiler is inactive, so an
-# IOMMU regression on the pinned sku reds rather than passing silently.
-pytestmark = pytest.mark.use_module_device
+# CI selects these by marker on the IOMMU-enabled BH sku (see ops_unit_tests.yaml); broad non-IOMMU jobs
+# exclude the marker, and the perf helper fails (not skips) if the RT profiler is inactive, so an IOMMU
+# regression on the pinned sku reds rather than passing silently.
+pytestmark = [pytest.mark.requires_host_iommu, pytest.mark.use_module_device]
 
 # Symmetric +/- band on the expected device kernel duration (ms), measured on a Blackhole p150b. Observed
 # run-to-run spread is <1%; 5% leaves comfortable headroom for board/thermal variance while still catching a
@@ -38,7 +38,7 @@ def _assert_msa_duration(device, run_fn, expected_ms, label):
     """Profile one dispatch of the op with the real-time device profiler and assert its device kernel duration
     is within +/- MSA_PERF_MARGIN of expected_ms. Returns the op output for the shape check."""
     if not ttnn.device.IsProgramRealtimeProfilerActive():
-        # This runs only on the IOMMU-pinned sku (the broad non-IOMMU sdpa glob --ignores this file), so an
+        # This runs only on the IOMMU-pinned sku (the broad non-IOMMU sdpa glob excludes it by marker), so an
         # inactive profiler means it regressed on a sku that should have it -- fail (not skip), matching the
         # sprint / ring-joint perf checks.
         pytest.fail("Real-time profiler must be active for sparse_sdpa_msa perf checks (needs IOMMU)")


### PR DESCRIPTION
Moves the `sparse_sdpa`, `sparse_sdpa_msa` and `indexer_score` perf checks off Tracy onto the realtime device program profiler (same pattern as ring-joint SDPA #48199) — no Tracy build required.

- `indexer_score` keeps its ±2% math-util band; `sparse_sdpa` / `sparse_sdpa_msa` gain a ±5% device-duration band.
- Adds a `requires_host_iommu` pytest marker. The existing 5-minute viommu job discovers marked tests under `experimental` and `sdpa`, while non-IOMMU jobs exclude the marker. Operation developers can add coverage without editing the infra-owned command; profiler checks still fail fast if the RT profiler is unexpectedly inactive.

## Validation (local, 8× BH p150b, IOMMU)
- `indexer_score`: 5/5 pass, math-util within <0.9% of the Tracy baseline
- `sparse_sdpa`: 7/7 pass · `sparse_sdpa_msa`: 4/4 pass — device durations within <0.7% of Tracy
- Marker routing: safe pytest collection selected exactly 17 IOMMU cases (1 H2D socket, 5 indexer, 7 sparse-SDPA, 4 sparse-SDPA-MSA)

## CI

**L2 nightly** — `sdpa` + `experimental` categories, Blackhole only — dispatched on `fb118183574`:

[![L2 nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/sdpa-indexer-rt-profiler-perf&event=workflow_dispatch)](https://github.com/tenstorrent/tt-metal/actions/runs/29867275855)

- Run: https://github.com/tenstorrent/tt-metal/actions/runs/29867275855
- Exercises the IOMMU-only checks (`sparse_sdpa`, `sparse_sdpa_msa`, `indexer_score` math-util) and confirms they stay off non-IOMMU runners. The marker-based routing keeps them in the existing viommu job without changing its 5-minute timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/sdpa-indexer-rt-profiler-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/sdpa-indexer-rt-profiler-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/sdpa-indexer-rt-profiler-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/sdpa-indexer-rt-profiler-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=skrstic/sdpa-indexer-rt-profiler-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:skrstic/sdpa-indexer-rt-profiler-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/sdpa-indexer-rt-profiler-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/sdpa-indexer-rt-profiler-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/sdpa-indexer-rt-profiler-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/sdpa-indexer-rt-profiler-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/sdpa-indexer-rt-profiler-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/sdpa-indexer-rt-profiler-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/sdpa-indexer-rt-profiler-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/sdpa-indexer-rt-profiler-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/sdpa-indexer-rt-profiler-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/sdpa-indexer-rt-profiler-perf)
## MiniMax M3 threshold calibration

The `minimax_m3` expected math-util threshold is recalibrated from 43.55% to 42.9% because this single-dispatch perf check is flaky at the low tail. Across 50 local runs, the rebased branch averaged 42.94% and the pre-rebase commit averaged 42.90%; both reproduced occasional samples around 42.60-42.66%. The shared +/-2% acceptance band remains unchanged.