### PR TITLE
ci: provision Buildx driver before bake in build-docker-artifact.yaml, pin setup-buildx-action

### DIFF
--- a/.github/workflows/build-docker-artifact.yaml
+++ b/.github/workflows/build-docker-artifact.yaml
@@ -311,7 +311,7 @@ jobs:
           submodules: recursive
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -464,7 +464,7 @@ jobs:
           submodules: recursive
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/build-docker-artifact.yaml
+++ b/.github/workflows/build-docker-artifact.yaml
@@ -310,6 +310,9 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
           submodules: recursive
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -459,6 +462,9 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha }}
           submodules: recursive
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/build-evaluation-image.yaml
+++ b/.github/workflows/build-evaluation-image.yaml
@@ -202,7 +202,7 @@ jobs:
           nc -zv ${{ env.BUILDKIT_HOST }} ${{ env.BUILDKIT_PORT }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         if: ${{ inputs.buildkit }}
         with:
           driver: remote

--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -54,7 +54,7 @@ jobs:
           UBUNTU_VERSION="${PLATFORM#ubuntu-}"
           echo "version=$UBUNTU_VERSION" >> $GITHUB_OUTPUT
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Summary
- `build-docker-artifact.yaml` sets `BAKE_OUTPUT=type=image,push=true,compression=zstd,compression-level=22,force-compression=true,oci-mediatypes=true` and forwards it to `docker buildx bake` via `--set target.output=...`, but never provisions a Buildx builder itself — `manual-docker-bake`'s only setup step is `docker buildx use default || true`.
- On the plain `ubuntu-latest` GitHub-hosted runners this workflow uses, no `docker-container`/BuildKit-native builder named `default` exists, so `docker buildx use default` just falls back to the classic driver embedded in the local Docker Engine daemon. That driver's image exporter does not honor `compression=zstd` / `oci-mediatypes=true`, so bake silently falls back to a plain `docker push`: gzip compression, Docker Distribution Manifest v2 Schema 2 — regardless of `BAKE_OUTPUT`.
- Verified against a real published tag (`ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-amd64:806cbe97d55969c1c3f183e5235b3ece50a9e96d`): manifest mediaType is `application/vnd.docker.distribution.manifest.v2+json`, and every sampled layer blob (including the largest, ~968 MB) starts with gzip magic bytes `1f 8b`, not zstd.
- `publish-release-image.yaml` and `build-evaluation-image.yaml` both reuse this exact `BAKE_OUTPUT` string and both already run `docker/setup-buildx-action` before bake — `build-docker-artifact.yaml` was the one caller missing it.

Adds the same `Set up Docker Buildx` step to the `ubuntu` and `manylinux` jobs, right after checkout and before the GHCR login step, matching the existing pattern.

Also pins `docker/setup-buildx-action` to the v4.2.0 release commit (`bb05f3f5519dd87d3ba754cc423b652a5edd6d2c`), with an inline `# v4.2.0` comment, across all usages in the repo (`build-docker-artifact.yaml` ×2, `build-evaluation-image.yaml`, `publish-release-image.yaml`) — matching the SHA-pinning convention already used for other third-party actions (e.g. `actions/checkout@de0fac2... # v6.0.2`). `upstream-tests.yaml` only has a comment referencing this action (explicitly opting out due to docker/setup-buildx-action#57), no actual `uses:` line, so it's untouched.

## Test plan
- [ ] Re-run `build-docker-artifact.yaml` (or a workflow that calls it, e.g. `build-all-docker-images.yaml`) on a branch and confirm a newly pushed tag's manifest is `application/vnd.oci.image.manifest.v1+json` with `application/vnd.oci.image.layer.v1.tar+zstd` layers
- [ ] Spot-check a layer blob's magic bytes are `28 b5 2f fd` (zstd), not `1f 8b` (gzip)
- [ ] Confirm existing consumers (docker pull, containerd, any image-scanning tooling) can still pull/read the OCI-zstd image without issue
- [ ] Confirm `build-evaluation-image.yaml`'s remote-driver builder still connects fine with the pinned action version