### PR TITLE
[ttnn] rotary_embedding: fix decode cos/sin freeze on program-cache hit

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding.py
@@ -374,7 +374,7 @@ def test_rotary_embedding_row_major(W, Z, Y, X, cache_size, device):
         (128, 64),
     ],
 )
-def test_rotary_embedding_rejects_cos_seq_smaller_than_input_seq(input_seq, head_dim, device):
+def test_rotary_embedding_rejects_cos_seq_smaller_than_input_seq(input_seq, head_dim, device, expect_error):
     torch.manual_seed(0)
     batch, n_heads = 1, 32
     x = torch.randn([batch, n_heads, input_seq, head_dim]).bfloat16().float()
@@ -385,13 +385,13 @@ def test_rotary_embedding_rejects_cos_seq_smaller_than_input_seq(input_seq, head
     cost = ttnn.Tensor(cos, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
     sint = ttnn.Tensor(sin, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
 
-    with pytest.raises(RuntimeError, match="Cosine cache must cover the input sequence length"):
+    with expect_error(RuntimeError, "Cosine cache must cover the input sequence length"):
         ttnn.experimental.rotary_embedding(xt, cost, sint)
 
 
 @pytest.mark.parametrize("token_idx", [0, 5, 31])
 @pytest.mark.parametrize("head_dim", [32, 64])
-def test_rotary_embedding_rejects_cos_seq_not_covering_token_index(token_idx, head_dim, device):
+def test_rotary_embedding_rejects_cos_seq_not_covering_token_index(token_idx, head_dim, device, expect_error):
     torch.manual_seed(0)
     batch, n_heads = 1, 32
     x = torch.randn([1, batch, n_heads, head_dim]).bfloat16().float()
@@ -405,5 +405,114 @@ def test_rotary_embedding_rejects_cos_seq_not_covering_token_index(token_idx, he
     if token_idx == 0:
         ttnn.experimental.rotary_embedding(xt, cost, sint, token_idx)
     else:
-        with pytest.raises(RuntimeError, match="Cosine cache must cover the token index"):
+        with expect_error(RuntimeError, "Cosine cache must cover the token index"):
             ttnn.experimental.rotary_embedding(xt, cost, sint, token_idx)
+
+
+def _run_rotary_decode_once(device, input_shape, cache_size, token_idx, in_sharded, out_sharded):
+    """Run one decode-mode rotary_embedding call and return whether the PCC check passed."""
+    W, Z, Y, X = input_shape
+    sin_cos_shape = [1, 1, cache_size, X]
+    x = torch.randn(input_shape).bfloat16().float()
+    cos_cached = torch.randn(sin_cos_shape).bfloat16().float()
+    sin_cached = torch.randn(sin_cos_shape).bfloat16().float()
+
+    out_mem_config = (
+        ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1)
+        if out_sharded
+        else ttnn.MemoryConfig()
+    )
+
+    xt = ttnn.Tensor(x, ttnn.bfloat16).to(ttnn.TILE_LAYOUT)
+
+    if in_sharded or out_sharded:
+        num_blocks = xt.volume() // xt.padded_shape[-1] // 32
+        compute_grid_size = device.compute_with_storage_grid_size()
+        num_cores = 1
+        for i in range(compute_grid_size.x * compute_grid_size.y, 0, -1):
+            if num_blocks % i == 0:
+                num_cores = i
+                break
+        if in_sharded:
+            Ht = divup(num_blocks, num_cores)
+            shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, True)
+            input_shard_spec = ttnn.ShardSpec(
+                shard_grid, [Ht * 32, xt.padded_shape[-1]], ttnn.ShardOrientation.ROW_MAJOR
+            )
+            input_mem_config = ttnn.MemoryConfig(
+                ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, input_shard_spec
+            )
+            xt = xt.to(device, input_mem_config)
+        else:
+            xt = xt.to(device)
+    else:
+        xt = xt.to(device)
+
+    cost = ttnn.Tensor(cos_cached, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+    sint = ttnn.Tensor(sin_cached, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+    xtt = ttnn.experimental.rotary_embedding(xt, cost, sint, token_idx, memory_config=out_mem_config)
+    if out_sharded:
+        xtt = ttnn.sharded_to_interleaved(xtt)
+
+    tt_got_back = xtt.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+    pt_out = apply_rotary_pos_emb(x, cos_cached, sin_cached, token_idx)
+    p, o = comp_pcc(pt_out, tt_got_back)
+    logger.info(f"token_idx={token_idx}: {o}")
+    return p
+
+
+# Regression: decode-mode rotary_embedding derives cos_sin_start_id / cos_sin_offset from token_idx
+# and bakes them into static reader/writer runtime args, but token_idx is (correctly) excluded from
+# the program-cache hash so successive decode positions cache-hit the SAME program.  Those offsets
+# must be re-applied on every hit via get_dynamic_runtime_args; without that, the cached program keeps
+# the first token's offsets and every later token reads the wrong cos/sin rows (silent PCC drop).
+#
+# The pre-existing test_rotary_embedding_decode parametrizes token_idx, so each position runs as a
+# separate invocation and never reuses the cached program -- it cannot catch this class of bug.  This
+# test drives multiple token positions THROUGH ONE cached program in a single test body, and also
+# asserts exactly one program-cache entry so a regression that re-keys on token_idx (rebuild-per-token
+# perf cliff) is caught too.
+#
+# X == 64 exercises the multi-tile path (Wt == 2); X == 32 the single-tile path (Wt == 1).  A sharded
+# case is included because the reader carries cos_sin_start_id at a different runtime-arg index than
+# the interleaved reader.
+@pytest.mark.parametrize(
+    "W, Z, Y, X",
+    [
+        [1, 1, 32, 64],
+        [1, 1, 32, 32],
+        [1, 8, 32, 64],
+    ],
+)
+@pytest.mark.parametrize("cache_size", [2048])
+@pytest.mark.parametrize(
+    "in_sharded, out_sharded",
+    [
+        (False, False),
+        (True, False),
+        (True, True),
+    ],
+)
+def test_rotary_embedding_decode_program_cache_reuse(W, Z, Y, X, cache_size, in_sharded, out_sharded, device):
+    torch.manual_seed(0)
+    input_shape = [W, Z, Y, X]
+
+    # Positions span multiple cos/sin tiles: cos_sin_offset = token_idx % 32 (varies within a tile),
+    # cos_sin_start_id = token_idx // 32 (changes at tile boundaries 32, 64, 128).  If the cached
+    # program froze the first token's offsets, positions after the first (esp. across tile boundaries)
+    # would fail the PCC check.
+    token_indices = [0, 1, 31, 32, 40, 63, 64, 128]
+
+    for token_idx in token_indices:
+        passed = _run_rotary_decode_once(device, input_shape, cache_size, token_idx, in_sharded, out_sharded)
+        assert passed, f"decode rotary_embedding wrong on cache-hit at token_idx={token_idx} (stale cos/sin offset)"
+
+    # All decode positions must share ONE rotary_embedding program (token_idx is not part of the
+    # cache key); more than that would mean token_idx leaked into the hash -> a rebuild-per-token perf
+    # regression.  The out-sharded path additionally runs sharded_to_interleaved (a second, shape-
+    # stable op), so it contributes exactly one extra entry.
+    expected_entries = 2 if out_sharded else 1
+    assert device.num_program_cache_entries() == expected_entries, (
+        f"expected {expected_entries} program-cache entry/entries, got {device.num_program_cache_entries()} "
+        f"(token_idx must not be hashed)"
+    )

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.cpp
@@ -145,8 +145,19 @@ Tensor RotaryEmbeddingDeviceOperation::create_output_tensors(
 
 ttsl::hash::hash_t RotaryEmbeddingDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    // Key token_idx.has_value() (it selects the program structure -- decode and prefill build different
+    // descriptors) but NOT its value, so successive decode positions reuse one program; the
+    // value-derived cos/sin offsets are re-applied per hit in override_runtime_arguments.
+    // compute_kernel_config must be keyed too: it drives the compute kernel's compile-time args, so
+    // without it two calls differing only in math_fidelity / fp32_dest_acc share a cached program.
     tt::tt_metal::operation::Hash hash = tt::tt_metal::operation::hash_operation<RotaryEmbeddingDeviceOperation>(
-        args.seq_len, args.output_mem_config, tensor_args.input, tensor_args.cos, tensor_args.sin);
+        args.seq_len,
+        args.token_idx.has_value(),
+        args.output_mem_config,
+        args.compute_kernel_config,
+        tensor_args.input,
+        tensor_args.cos,
+        tensor_args.sin);
     return hash;
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.hpp
@@ -30,9 +30,10 @@ struct RotaryEmbeddingDeviceOperation {
     // them into static reader/writer runtime args, while token_idx is deliberately excluded from
     // compute_program_hash so successive decode positions cache-hit the same program.  Those two
     // scalars must therefore be re-applied on every cache hit -- otherwise the cached program keeps
-    // the first token's offsets and every later token reads the wrong cos/sin rows.  Prefill mode
-    // (no token_idx) derives the offsets from hashed shapes, so this returns no dynamic args there.
-    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+    // the first token's offsets and every later token reads the wrong cos/sin rows.  override_runtime_arguments
+    // re-derives the descriptor and re-applies them (prefill derives offsets from hashed shapes -- a no-op there).
+    static void override_runtime_arguments(
+        tt::tt_metal::Program& program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& output,

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.hpp
@@ -7,6 +7,7 @@
 #include "ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation_types.hpp"
 #include "ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.hpp"
 #include "ttnn/types.hpp"
+#include <tt-metalium/experimental/program_descriptor_patching.hpp>
 
 namespace ttnn::experimental::prim {
 
@@ -24,6 +25,18 @@ struct RotaryEmbeddingDeviceOperation {
     static tensor_return_value_t create_output_tensors(const operation_attributes_t& args, const tensor_args_t&);
 
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+
+    // Decode mode (token_idx set) derives cos_sin_start_id / cos_sin_offset from token_idx and bakes
+    // them into static reader/writer runtime args, while token_idx is deliberately excluded from
+    // compute_program_hash so successive decode positions cache-hit the same program.  Those two
+    // scalars must therefore be re-applied on every cache hit -- otherwise the cached program keeps
+    // the first token's offsets and every later token reads the wrong cos/sin rows.  Prefill mode
+    // (no token_idx) derives the offsets from hashed shapes, so this returns no dynamic args there.
+    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& output,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.hpp
@@ -7,7 +7,6 @@
 #include "ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation_types.hpp"
 #include "ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.hpp"
 #include "ttnn/types.hpp"
-#include <tt-metalium/experimental/program_descriptor_patching.hpp>
 
 namespace ttnn::experimental::prim {
 
@@ -30,8 +29,9 @@ struct RotaryEmbeddingDeviceOperation {
     // them into static reader/writer runtime args, while token_idx is deliberately excluded from
     // compute_program_hash so successive decode positions cache-hit the same program.  Those two
     // scalars must therefore be re-applied on every cache hit -- otherwise the cached program keeps
-    // the first token's offsets and every later token reads the wrong cos/sin rows.  override_runtime_arguments
-    // re-derives the descriptor and re-applies them (prefill derives offsets from hashed shapes -- a no-op there).
+    // the first token's offsets and every later token reads the wrong cos/sin rows.  Declaring this
+    // hook also supersedes resolve_bindings, so it owns buffer-address re-application (runtime args and
+    // sharded CBs) too.  It patches those slots in place; it never rebuilds the descriptor.
     static void override_runtime_arguments(
         tt::tt_metal::Program& program,
         const operation_attributes_t& operation_attributes,

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.cpp
@@ -3,12 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.hpp"
+#include "ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.hpp"
 
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/experimental/program_descriptor_patching.hpp>
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 
 namespace ttnn::experimental::prim {
@@ -18,6 +20,68 @@ using namespace tt::constants;
 using namespace tt::tt_metal;
 
 namespace {
+
+// Work distribution shared between create_descriptor (cache miss) and get_dynamic_runtime_args
+// (cache hit).  Keeping this in one place guarantees the cache-hit path targets exactly the same
+// cores/kernel arg slots the miss path built, so the re-applied decode offsets can't drift from the
+// program layout.  `Wt` is the per-row tile count (1 on the single-tile path).
+struct RotaryWorkSplit {
+    bool row_major = true;
+    uint32_t num_cores = 0;
+    uint32_t num_cores_x = 0;
+    uint32_t num_cores_y = 0;
+    uint32_t num_rows_per_core_group_1 = 0;
+    uint32_t num_rows_per_core_group_2 = 0;
+    CoreRangeSet all_cores;
+    CoreRangeSet core_group_1;
+    CoreRangeSet core_group_2;
+    bool in_sharded = false;
+    bool out_sharded = false;
+    uint32_t num_input_tiles = 0;
+    uint32_t num_output_tiles = 0;
+};
+
+RotaryWorkSplit compute_rotary_work_split(const Tensor& input, const Tensor& output, uint32_t Wt) {
+    RotaryWorkSplit w;
+    w.in_sharded = input.shard_spec().has_value();
+    w.out_sharded = output.shard_spec().has_value();
+    std::optional<ShardSpec> shard_spec = w.in_sharded ? input.shard_spec() : output.shard_spec();
+
+    uint32_t num_rows = input.physical_volume() / input.padded_shape()[-1] / TILE_HEIGHT;
+
+    auto compute_with_storage_grid_size = input.device()->compute_with_storage_grid_size();
+    w.num_cores_x = compute_with_storage_grid_size.x;
+    w.num_cores_y = compute_with_storage_grid_size.y;
+
+    if (shard_spec.has_value()) {
+        w.row_major = shard_spec.value().orientation == ShardOrientation::ROW_MAJOR;
+        w.all_cores = shard_spec.value().grid;
+        w.num_cores = w.all_cores.num_cores();
+        w.core_group_1 = w.all_cores;
+        w.core_group_2 = CoreRangeSet();
+        w.num_rows_per_core_group_1 = shard_spec.value().shape[0] / TILE_HEIGHT;
+        w.num_rows_per_core_group_2 = 0;
+        w.num_input_tiles = w.in_sharded ? shard_spec.value().shape[0] * shard_spec.value().shape[1] / TILE_HW : 2 * Wt;
+        w.num_output_tiles =
+            w.out_sharded ? shard_spec.value().shape[0] * shard_spec.value().shape[1] / TILE_HW : 2 * Wt;
+        auto bbox = w.all_cores.bounding_box();
+        w.num_cores_x = bbox.end_coord.x + 1;
+        w.num_cores_y = bbox.end_coord.y + 1;
+    } else {
+        w.row_major = true;
+        std::tie(
+            w.num_cores,
+            w.all_cores,
+            w.core_group_1,
+            w.core_group_2,
+            w.num_rows_per_core_group_1,
+            w.num_rows_per_core_group_2) =
+            tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_rows, w.row_major);
+        w.num_input_tiles = 2 * Wt;
+        w.num_output_tiles = w.num_input_tiles;
+    }
+    return w;
+}
 
 // Single-tile (Wt == 1) path. The Wt >= 2 path implements HF rotate_half via
 // inter-tile half-swap + scalar negation, which collapses when Wt == 1 (half_Wt
@@ -53,7 +117,6 @@ ProgramDescriptor create_single_tile_descriptor(
     uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
 
     constexpr uint32_t Wt = 1;
-    uint32_t num_rows = input.physical_volume() / input.padded_shape()[-1] / TILE_HEIGHT;
     uint32_t Ht = input.padded_shape()[-2] / TILE_HEIGHT;
     uint32_t HtWt = Ht * Wt;
     uint32_t Wbytes = input.padded_shape()[-1] * sizeof(bfloat16);
@@ -63,41 +126,20 @@ ProgramDescriptor create_single_tile_descriptor(
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config);
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    uint32_t num_cores_x = compute_with_storage_grid_size.x;
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
-
-    bool row_major;
-    uint32_t num_cores, num_rows_per_core_group_1, num_rows_per_core_group_2;
-    CoreRangeSet all_cores, core_group_1, core_group_2;
-
-    bool in_sharded = input.shard_spec().has_value();
-    bool out_sharded = output.shard_spec().has_value();
-    std::optional<ShardSpec> shard_spec = in_sharded ? input.shard_spec() : output.shard_spec();
-
-    uint32_t num_input_tiles, num_output_tiles;
-
-    if (shard_spec.has_value()) {
-        row_major = shard_spec.value().orientation == ShardOrientation::ROW_MAJOR;
-        all_cores = shard_spec.value().grid;
-        num_cores = all_cores.num_cores();
-        core_group_1 = all_cores;
-        core_group_2 = CoreRangeSet();
-        num_rows_per_core_group_1 = shard_spec.value().shape[0] / TILE_HEIGHT;
-        num_rows_per_core_group_2 = 0;
-        num_input_tiles = in_sharded ? shard_spec.value().shape[0] * shard_spec.value().shape[1] / TILE_HW : 2 * Wt;
-        num_output_tiles = out_sharded ? shard_spec.value().shape[0] * shard_spec.value().shape[1] / TILE_HW : 2 * Wt;
-        auto bbox = all_cores.bounding_box();
-        num_cores_x = bbox.end_coord.x + 1;
-        num_cores_y = bbox.end_coord.y + 1;
-    } else {
-        row_major = true;
-        std::tie(
-            num_cores, all_cores, core_group_1, core_group_2, num_rows_per_core_group_1, num_rows_per_core_group_2) =
-            tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_rows, row_major);
-        num_input_tiles = 2 * Wt;
-        num_output_tiles = num_input_tiles;
-    }
+    auto work = compute_rotary_work_split(input, output, Wt);
+    bool row_major = work.row_major;
+    uint32_t num_cores = work.num_cores;
+    uint32_t num_cores_x = work.num_cores_x;
+    uint32_t num_cores_y = work.num_cores_y;
+    uint32_t num_rows_per_core_group_1 = work.num_rows_per_core_group_1;
+    uint32_t num_rows_per_core_group_2 = work.num_rows_per_core_group_2;
+    CoreRangeSet all_cores = work.all_cores;
+    CoreRangeSet core_group_1 = work.core_group_1;
+    CoreRangeSet core_group_2 = work.core_group_2;
+    bool in_sharded = work.in_sharded;
+    bool out_sharded = work.out_sharded;
+    uint32_t num_input_tiles = work.num_input_tiles;
+    uint32_t num_output_tiles = work.num_output_tiles;
 
     constexpr uint8_t input_cb_index = tt::CBIndex::c_0;
     desc.cbs.push_back(CBDescriptor{
@@ -458,7 +500,6 @@ ProgramDescriptor create_multi_tile_descriptor(
     tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
     uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
 
-    uint32_t num_rows = input.physical_volume() / input.padded_shape()[-1] / TILE_HEIGHT;
     uint32_t Ht = input.padded_shape()[-2] / TILE_HEIGHT;
     uint32_t Wt = input.padded_shape()[-1] / TILE_WIDTH;
     uint32_t half_Wt = Wt / 2;
@@ -470,42 +511,20 @@ ProgramDescriptor create_multi_tile_descriptor(
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config);
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    uint32_t num_cores_x = compute_with_storage_grid_size.x;
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
-
-    bool row_major;
-    uint32_t num_cores, num_rows_per_core_group_1, num_rows_per_core_group_2;
-
-    CoreRangeSet all_cores, core_group_1, core_group_2;
-
-    bool in_sharded = input.shard_spec().has_value();
-    bool out_sharded = output.shard_spec().has_value();
-    std::optional<ShardSpec> shard_spec = in_sharded ? input.shard_spec() : output.shard_spec();
-
-    uint32_t num_input_tiles, num_output_tiles;
-
-    if (shard_spec.has_value()) {
-        row_major = shard_spec.value().orientation == ShardOrientation::ROW_MAJOR;
-        all_cores = shard_spec.value().grid;
-        num_cores = all_cores.num_cores();
-        core_group_1 = all_cores;
-        core_group_2 = CoreRangeSet();
-        num_rows_per_core_group_1 = shard_spec.value().shape[0] / TILE_HEIGHT;
-        num_rows_per_core_group_2 = 0;
-        num_input_tiles = in_sharded ? shard_spec.value().shape[0] * shard_spec.value().shape[1] / TILE_HW : 2 * Wt;
-        num_output_tiles = out_sharded ? shard_spec.value().shape[0] * shard_spec.value().shape[1] / TILE_HW : 2 * Wt;
-        auto bbox = all_cores.bounding_box();
-        num_cores_x = bbox.end_coord.x + 1;
-        num_cores_y = bbox.end_coord.y + 1;
-    } else {
-        row_major = true;
-        std::tie(
-            num_cores, all_cores, core_group_1, core_group_2, num_rows_per_core_group_1, num_rows_per_core_group_2) =
-            tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_rows, row_major);
-        num_input_tiles = 2 * Wt;
-        num_output_tiles = num_input_tiles;
-    }
+    auto work = compute_rotary_work_split(input, output, Wt);
+    bool row_major = work.row_major;
+    uint32_t num_cores = work.num_cores;
+    uint32_t num_cores_x = work.num_cores_x;
+    uint32_t num_cores_y = work.num_cores_y;
+    uint32_t num_rows_per_core_group_1 = work.num_rows_per_core_group_1;
+    uint32_t num_rows_per_core_group_2 = work.num_rows_per_core_group_2;
+    CoreRangeSet all_cores = work.all_cores;
+    CoreRangeSet core_group_1 = work.core_group_1;
+    CoreRangeSet core_group_2 = work.core_group_2;
+    bool in_sharded = work.in_sharded;
+    bool out_sharded = work.out_sharded;
+    uint32_t num_input_tiles = work.num_input_tiles;
+    uint32_t num_output_tiles = work.num_output_tiles;
 
     constexpr uint8_t input_cb_index = tt::CBIndex::c_0;
     desc.cbs.push_back(CBDescriptor{
@@ -878,6 +897,51 @@ ProgramDescriptor RotaryEmbeddingProgramFactory::create_descriptor(
         return create_single_tile_descriptor(operation_attributes, tensor_args, tensor_return_value);
     }
     return create_multi_tile_descriptor(operation_attributes, tensor_args, tensor_return_value);
+}
+
+std::vector<tt::tt_metal::DynamicRuntimeArg> RotaryEmbeddingDeviceOperation::get_dynamic_runtime_args(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+    const auto& token_idx = operation_attributes.token_idx;
+    // Prefill mode (no token_idx) derives cos_sin_start_id from hashed shapes (num_tiles_written %
+    // HtWt), so the cached program's static args are already correct on a hit -- nothing to re-apply.
+    if (!token_idx.has_value()) {
+        return {};
+    }
+
+    const auto& input = tensor_args.input;
+    // Wt == 1 on the single-tile path (X == TILE_WIDTH); this expression yields 1 there too.
+    const uint32_t Wt = input.padded_shape()[-1] / TILE_WIDTH;
+    const uint32_t Wbytes = input.padded_shape()[-1] * sizeof(bfloat16);
+    // Identical arithmetic to create_*_descriptor's decode branch.
+    const uint32_t cos_sin_offset = token_idx.value() % TILE_HEIGHT * Wbytes;
+    const uint32_t cos_sin_start_id = token_idx.value() / TILE_HEIGHT * Wt;
+
+    // Reproduce the descriptor's work distribution so we target the exact same cores and, via
+    // grid_to_cores, the identical ordering used when the runtime args were built.
+    const auto work = compute_rotary_work_split(input, output, Wt);
+    const auto cores = grid_to_cores(work.num_cores, work.num_cores_x, work.num_cores_y, work.row_major);
+
+    // Kernel push order in create_descriptor: reader (0), writer (1), compute (2[, 3]).
+    constexpr uint32_t kReaderKernelIdx = 0;
+    constexpr uint32_t kWriterKernelIdx = 1;
+    // cos_sin_start_id is the last reader runtime arg; the interleaved reader prepends the src buffer
+    // (arg 0), shifting it to index 6, while the sharded reader omits src, leaving it at index 4.
+    const uint32_t reader_cos_sin_start_id_arg_idx = work.in_sharded ? 4 : 6;
+    // Writer runtime args: {dst, num_rows*Wt, num_tiles_written, cos_sin_offset, Wt, Wbytes}.
+    constexpr uint32_t kWriterCosSinOffsetArgIdx = 3;
+
+    // In decode mode both offsets are constant across cores (they depend only on token_idx), so every
+    // work core gets the same re-applied values.
+    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
+    dynamic_args.reserve(cores.size() * 2);
+    for (const auto& core : cores) {
+        dynamic_args.push_back({kReaderKernelIdx, core, reader_cos_sin_start_id_arg_idx, cos_sin_start_id});
+        dynamic_args.push_back({kWriterKernelIdx, core, kWriterCosSinOffsetArgIdx, cos_sin_offset});
+    }
+    return dynamic_args;
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.cpp
@@ -899,49 +899,16 @@ ProgramDescriptor RotaryEmbeddingProgramFactory::create_descriptor(
     return create_multi_tile_descriptor(operation_attributes, tensor_args, tensor_return_value);
 }
 
-std::vector<tt::tt_metal::DynamicRuntimeArg> RotaryEmbeddingDeviceOperation::get_dynamic_runtime_args(
+void RotaryEmbeddingDeviceOperation::override_runtime_arguments(
+    tt::tt_metal::Program& program,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    const auto& token_idx = operation_attributes.token_idx;
-    // Prefill mode (no token_idx) derives cos_sin_start_id from hashed shapes (num_tiles_written %
-    // HtWt), so the cached program's static args are already correct on a hit -- nothing to re-apply.
-    if (!token_idx.has_value()) {
-        return {};
-    }
-
-    const auto& input = tensor_args.input;
-    // Wt == 1 on the single-tile path (X == TILE_WIDTH); this expression yields 1 there too.
-    const uint32_t Wt = input.padded_shape()[-1] / TILE_WIDTH;
-    const uint32_t Wbytes = input.padded_shape()[-1] * sizeof(bfloat16);
-    // Identical arithmetic to create_*_descriptor's decode branch.
-    const uint32_t cos_sin_offset = token_idx.value() % TILE_HEIGHT * Wbytes;
-    const uint32_t cos_sin_start_id = token_idx.value() / TILE_HEIGHT * Wt;
-
-    // Reproduce the descriptor's work distribution so we target the exact same cores and, via
-    // grid_to_cores, the identical ordering used when the runtime args were built.
-    const auto work = compute_rotary_work_split(input, output, Wt);
-    const auto cores = grid_to_cores(work.num_cores, work.num_cores_x, work.num_cores_y, work.row_major);
-
-    // Kernel push order in create_descriptor: reader (0), writer (1), compute (2[, 3]).
-    constexpr uint32_t kReaderKernelIdx = 0;
-    constexpr uint32_t kWriterKernelIdx = 1;
-    // cos_sin_start_id is the last reader runtime arg; the interleaved reader prepends the src buffer
-    // (arg 0), shifting it to index 6, while the sharded reader omits src, leaving it at index 4.
-    const uint32_t reader_cos_sin_start_id_arg_idx = work.in_sharded ? 4 : 6;
-    // Writer runtime args: {dst, num_rows*Wt, num_tiles_written, cos_sin_offset, Wt, Wbytes}.
-    constexpr uint32_t kWriterCosSinOffsetArgIdx = 3;
-
-    // In decode mode both offsets are constant across cores (they depend only on token_idx), so every
-    // work core gets the same re-applied values.
-    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
-    dynamic_args.reserve(cores.size() * 2);
-    for (const auto& core : cores) {
-        dynamic_args.push_back({kReaderKernelIdx, core, reader_cos_sin_start_id_arg_idx, cos_sin_start_id});
-        dynamic_args.push_back({kWriterKernelIdx, core, kWriterCosSinOffsetArgIdx, cos_sin_offset});
-    }
-    return dynamic_args;
+    // Re-derive all per-dispatch state from the single source of truth (create_descriptor) for the
+    // current tensors and re-apply to the cached program -- no rebuild, still a cache hit.
+    auto desc = RotaryEmbeddingProgramFactory::create_descriptor(operation_attributes, tensor_args, output);
+    tt::tt_metal::apply_descriptor_runtime_args(program, desc);
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.cpp
@@ -9,8 +9,9 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/circular_buffer.hpp>
 #include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/experimental/program_descriptor_patching.hpp>
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 
 namespace ttnn::experimental::prim {
@@ -21,7 +22,7 @@ using namespace tt::tt_metal;
 
 namespace {
 
-// Work distribution shared between create_descriptor (cache miss) and get_dynamic_runtime_args
+// Work distribution shared between create_descriptor (cache miss) and override_runtime_arguments
 // (cache hit).  Keeping this in one place guarantees the cache-hit path targets exactly the same
 // cores/kernel arg slots the miss path built, so the re-applied decode offsets can't drift from the
 // program layout.  `Wt` is the per-row tile count (1 on the single-tile path).
@@ -905,10 +906,89 @@ void RotaryEmbeddingDeviceOperation::override_runtime_arguments(
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    // Re-derive all per-dispatch state from the single source of truth (create_descriptor) for the
-    // current tensors and re-apply to the cached program -- no rebuild, still a cache hit.
-    auto desc = RotaryEmbeddingProgramFactory::create_descriptor(operation_attributes, tensor_args, output);
-    tt::tt_metal::apply_descriptor_runtime_args(program, desc);
+    // Patch the cached program in place: only buffer addresses (never hashed) and the token_idx-derived
+    // decode scalars (deliberately hash-excluded) can change across a cache hit.  Everything else is a
+    // function of the shapes / memory configs / seq_len that compute_program_hash keys on, so it is
+    // identical by construction.  Rebuilding the descriptor here would pay the whole cache-miss host
+    // cost (work split, CoreRangeSet, arch queries, TensorAccessorArgs, per-core arg vectors) on every
+    // dispatch.
+    //
+    // Kernel push order in create_*_descriptor: reader(0), writer(1), compute g1(2)[, compute g2(3)].
+    // Compute kernels carry compile-time args only.
+    constexpr uint32_t kReaderKernelIdx = 0;
+    constexpr uint32_t kWriterKernelIdx = 1;
+    // Writer runtime args (both descriptor variants): {dst, num_rows*Wt, num_tiles_written,
+    // cos_sin_offset, Wt, Wbytes}.
+    constexpr uint32_t kWriterDstArgIdx = 0;
+    constexpr uint32_t kWriterCosSinOffsetArgIdx = 3;
+
+    const auto& input = tensor_args.input;
+    // Wt == 1 on the single-tile path (X == TILE_WIDTH); this expression yields 1 there too.  Both
+    // descriptor variants share the reader/writer runtime-arg layouts below.
+    const uint32_t Wt = input.padded_shape()[-1] / TILE_WIDTH;
+    const auto work = compute_rotary_work_split(input, output, Wt);
+    const auto cores = grid_to_cores(work.num_cores, work.num_cores_x, work.num_cores_y, work.row_major);
+
+    // Interleaved reader args: {src, cos, sin, num_rows, num_tiles_written, start_row_id,
+    // cos_sin_start_id}.  The sharded reader drops src -- it arrives on CB c_0 -- so every later index
+    // shifts down by one: {cos, sin, num_rows, start_row_id, cos_sin_start_id}.
+    auto* src_buffer = input.buffer();
+    auto* dst_buffer = output.buffer();
+    const auto src_addr = static_cast<uint32_t>(src_buffer->address());
+    const auto cos_addr = static_cast<uint32_t>(tensor_args.cos.buffer()->address());
+    const auto sin_addr = static_cast<uint32_t>(tensor_args.sin.buffer()->address());
+    const auto dst_addr = static_cast<uint32_t>(dst_buffer->address());
+    const uint32_t reader_cos_sin_start_id_arg_idx = work.in_sharded ? 4 : 6;
+
+    // Decode mode (token_idx set) derives cos_sin_start_id / cos_sin_offset from token_idx, which
+    // compute_program_hash deliberately excludes so successive decode positions cache-hit the same
+    // program.  Without re-applying them the cached program keeps the first token's offsets and every
+    // later token reads the wrong cos/sin rows.  Both are core-invariant.  Prefill instead derives
+    // cos_sin_start_id from the hashed work split (num_tiles_written % HtWt) and leaves cos_sin_offset
+    // at 0, so neither slot is touched there.
+    const auto& token_idx = operation_attributes.token_idx;
+    uint32_t cos_sin_offset = 0;
+    uint32_t cos_sin_start_id = 0;
+    if (token_idx.has_value()) {
+        const uint32_t Wbytes = input.padded_shape()[-1] * sizeof(bfloat16);
+        cos_sin_offset = token_idx.value() % TILE_HEIGHT * Wbytes;
+        cos_sin_start_id = token_idx.value() / TILE_HEIGHT * Wt;
+    }
+
+    for (const auto& core : cores) {
+        auto& reader_args = tt::tt_metal::GetRuntimeArgs(program, kReaderKernelIdx, core);
+        if (work.in_sharded) {
+            reader_args[0] = cos_addr;
+            reader_args[1] = sin_addr;
+        } else {
+            reader_args[0] = src_addr;
+            reader_args[1] = cos_addr;
+            reader_args[2] = sin_addr;
+        }
+        auto& writer_args = tt::tt_metal::GetRuntimeArgs(program, kWriterKernelIdx, core);
+        writer_args[kWriterDstArgIdx] = dst_addr;
+        if (token_idx.has_value()) {
+            reader_args[reader_cos_sin_start_id_arg_idx] = cos_sin_start_id;
+            writer_args[kWriterCosSinOffsetArgIdx] = cos_sin_offset;
+        }
+    }
+
+    // A sharded input/output carries its address on a globally-allocated CB (c_0 / c_16) instead of a
+    // runtime arg, so re-point those at the current buffers as well.  Matching by CBIndex rather than
+    // by position in desc.cbs keeps this correct for both descriptor variants, whose output CB sits at
+    // a different index.
+    if (work.in_sharded || work.out_sharded) {
+        for (const auto& cb : program.circular_buffers()) {
+            if (!cb->globally_allocated()) {
+                continue;
+            }
+            if (cb->buffer_indices().contains(static_cast<uint8_t>(tt::CBIndex::c_0))) {
+                tt::tt_metal::UpdateDynamicCircularBufferAddress(program, cb->id(), *src_buffer);
+            } else if (cb->buffer_indices().contains(static_cast<uint8_t>(tt::CBIndex::c_16))) {
+                tt::tt_metal::UpdateDynamicCircularBufferAddress(program, cb->id(), *dst_buffer);
+            }
+        }
+    }
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.hpp
@@ -11,10 +11,9 @@
 namespace ttnn::experimental::prim {
 
 struct RotaryEmbeddingProgramFactory {
-    // Contract (1): single ProgramDescriptor.  Sharded variants set CBDescriptor::buffer
-    // so the framework patches dynamic CB addresses on cache hit; per-core runtime args
-    // and CB total_sizes (which depend on input shape) are re-applied via
-    // apply_descriptor_runtime_args.
+    // Contract (1): single ProgramDescriptor.  Sharded variants set CBDescriptor::buffer.  Cache-hit
+    // re-application is owned by RotaryEmbeddingDeviceOperation::override_runtime_arguments, which
+    // patches the addresses and decode scalars in place -- this is a cache-miss-only path.
     static tt::tt_metal::ProgramDescriptor create_descriptor(
         const RotaryEmbeddingParams& operation_attributes,
         const RotaryEmbeddingInputs& tensor_args,


### PR DESCRIPTION
## Problem
In decode mode (`token_idx` set), the factory derives `cos_sin_start_id` / `cos_sin_offset` from `token_idx` and bakes them into **static** reader/writer runtime args, while `token_idx` is (correctly) excluded from `compute_program_hash` so successive decode positions cache-hit one program. Because the factory binds buffers via `emplace_runtime_args`, a cache hit takes the fast path (`apply_resolved_bindings` + `apply_dynamic_runtime_args`) and never re-runs `create_descriptor` — so those scalars stay frozen at token 0's values and every later decode position reads the **wrong cos/sin rows** (silent PCC drop). Migration regression.

## Fix
Add `get_dynamic_runtime_args` re-applying the two decode scalars on every hit (reader arg 6 interleaved / 4 sharded; writer arg 3), backed by a shared `compute_rotary_work_split` helper used by both `create_descriptor` variants **and** the hit path so the re-applied args can't drift from the built layout. Prefill (no `token_idx`) is unchanged — its offsets are shape-derived and already correct on a hit.

## Test
`test_rotary_embedding_decode_program_cache_reuse` drives 8 token positions through **one cached program** with distinct cos/sin (interleaved + sharded, single/multi-tile) and asserts a single program-cache entry. Negative control: reverting the fix makes token 1 fail at PCC -0.12 (the pre-existing parametrized decode test ran each position as a separate invocation and never reused the cache, so it could not catch this). 759 existing rotary tests pass.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/rotary-embedding-decode-freeze-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/rotary-embedding-decode-freeze-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/rotary-embedding-decode-freeze-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/rotary-embedding-decode-freeze-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/rotary-embedding-decode-freeze-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/rotary-embedding-decode-freeze-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/rotary-embedding-decode-freeze-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/rotary-embedding-decode-freeze-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/rotary-embedding-decode-freeze-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/rotary-embedding-decode-freeze-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/rotary-embedding-decode-freeze-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/rotary-embedding-decode-freeze-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/rotary-embedding-decode-freeze-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/rotary-embedding-decode-freeze-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/rotary-embedding-decode-freeze-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/rotary-embedding-decode-freeze-fix)