### PR TITLE
[ttnn] interleaved_to_sharded_partial: stop over-keying on slice_index

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
@@ -415,6 +415,65 @@ def test_sharded_partial_op(
     assert passing
 
 
+# Regression: interleaved_to_sharded_partial excludes slice_index from the program-cache hash (it only
+# feeds the runtime read-offset starting_idx_h) and re-applies it on every cache hit via
+# get_dynamic_runtime_args. Two things this guards:
+#   (1) correctness on cache hit -- reading slice N must return slice N's data, not slice 0's (frozen
+#       starting_idx_h). NOTE: this uses DISTINCT per-slice data; the pre-existing test_sharded_partial_op
+#       uses torch.ones, which cannot detect a slice mixup.
+#   (2) perf -- all slices of one partial-slicing loop share a single cached program, so the op must
+#       contribute exactly ONE program-cache entry (a slice_index re-keying regression would make N).
+@pytest.mark.parametrize("H, num_cores, num_slices", [[64, 64, 2], [256, 64, 4]])
+def test_interleaved_to_sharded_partial_program_cache_reuse(device, H, num_cores, num_slices, function_level_defaults):
+    compute_grid_size = device.compute_with_storage_grid_size()
+    if num_cores > (compute_grid_size.x * compute_grid_size.y):
+        pytest.skip(f"Need {num_cores} cores to run this test but core grid is {compute_grid_size}")
+    grid_size = (8, 8)
+    W = 64
+    in0_shape = [1, 1, H, W]
+    new_height = H // num_slices
+
+    interleaved_mem_config = ttnn.MemoryConfig(
+        memory_layout=ttnn.TensorMemoryLayout.INTERLEAVED,
+        buffer_type=ttnn.BufferType.L1,
+    )
+
+    # Distinct data per row so that reading the wrong slice is observable (all-ones would hide it).
+    torch.manual_seed(0)
+    in0 = torch.randn(in0_shape).bfloat16().float()
+    in0_t = torch2tt_tensor(in0, device, tt_memory_config=interleaved_mem_config, tt_dtype=ttnn.bfloat16)
+
+    height_shard_spec = [new_height, W]
+
+    entries_before = device.num_program_cache_entries()
+    slice_tensors = []
+    for slice_index in range(num_slices):
+        slice_tensors.append(
+            ttnn.interleaved_to_sharded_partial(
+                in0_t,
+                grid_size,
+                height_shard_spec,
+                num_slices,
+                slice_index,
+                ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+                ttnn.ShardOrientation.ROW_MAJOR,
+            )
+        )
+
+    # Every slice reused one program; slice_index is not part of the key.
+    assert device.num_program_cache_entries() - entries_before == 1, (
+        f"interleaved_to_sharded_partial should build ONE program for all {num_slices} slices, "
+        f"built {device.num_program_cache_entries() - entries_before} (slice_index must not be hashed)"
+    )
+
+    # Correctness on the cache-hit path: slice N must hold input rows [N*new_height:(N+1)*new_height].
+    for slice_index, slice_t in enumerate(slice_tensors):
+        got = tt2torch_tensor(slice_t)
+        expected = in0[:, :, slice_index * new_height : (slice_index + 1) * new_height, :]
+        passing, output = comp_pcc(expected, got)
+        assert passing, f"slice {slice_index} returned wrong data on cache hit (stale starting_idx_h): {output}"
+
+
 @pytest.mark.parametrize("H, W, num_cores, num_slices", [[32 * 32, 16 * 32, 64, 2], [2816, 16 * 32, 64, 11]])
 @pytest.mark.parametrize(
     "activations_dtype",

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.cpp
@@ -76,11 +76,15 @@ Tensor InterleavedToShardedPartialDeviceOperation::create_output_tensors(
 
 ttsl::hash::hash_t InterleavedToShardedPartialDeviceOperation::compute_program_hash(
     const operation_attributes_t& operation_attributes, const Tensor& input_tensor) {
+    // slice_index is deliberately excluded from the key: it only feeds the runtime read-offset
+    // starting_idx_h (same program structure for every slice of a given num_slices), and it is
+    // re-applied on every cache hit via get_dynamic_runtime_args. Keying on it would rebuild the
+    // program for each slice of a partial-slicing loop. num_slices -- which drives the work split --
+    // stays keyed.
     return tt::tt_metal::operation::hash_operation<InterleavedToShardedPartialDeviceOperation>(
         operation_attributes.grid_size,
         operation_attributes.shard_spec,
         operation_attributes.num_slices,
-        operation_attributes.slice_index,
         operation_attributes.output_mem_config,
         operation_attributes.output_dtype,
         input_tensor.dtype(),

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.hpp
@@ -7,6 +7,7 @@
 #include "interleaved_to_sharded_partial_op_types.hpp"
 #include "interleaved_to_sharded_partial_program_factory.hpp"
 #include "ttnn/types.hpp"
+#include <tt-metalium/experimental/program_descriptor_patching.hpp>
 
 namespace ttnn::prim {
 
@@ -27,6 +28,15 @@ struct InterleavedToShardedPartialDeviceOperation {
 
     static ttsl::hash::hash_t compute_program_hash(
         const operation_attributes_t& operation_attributes, const Tensor& input_tensor);
+
+    // slice_index feeds only the runtime read-offset starting_idx_h and is excluded from the program
+    // hash, so it must be re-applied on every cache hit (the reader/writer args baked at build time
+    // otherwise stay frozen at the first slice, reading the wrong slice of the input).
+    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+        const operation_attributes_t& operation_attributes,
+        const Tensor& input_tensor,
+        tensor_return_value_t& output,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 
 Tensor interleaved_to_sharded_partial(

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.hpp
@@ -30,9 +30,11 @@ struct InterleavedToShardedPartialDeviceOperation {
         const operation_attributes_t& operation_attributes, const Tensor& input_tensor);
 
     // slice_index feeds only the runtime read-offset starting_idx_h and is excluded from the program
-    // hash, so it must be re-applied on every cache hit (the reader/writer args baked at build time
-    // otherwise stay frozen at the first slice, reading the wrong slice of the input).
-    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+    // hash, so cache hits for a different slice must re-derive the per-dispatch args (otherwise the
+    // reader/writer args baked at first miss stay frozen at the first slice). Re-run create_descriptor
+    // (single source of truth) and re-apply its per-core args + tensor-backed CB addresses.
+    static void override_runtime_arguments(
+        tt::tt_metal::Program& program,
         const operation_attributes_t& operation_attributes,
         const Tensor& input_tensor,
         tensor_return_value_t& output,

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_program_factory.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "interleaved_to_sharded_partial_program_factory.hpp"
+#include "interleaved_to_sharded_partial_op.hpp"
 
 #include <cmath>
 
@@ -428,6 +429,41 @@ ProgramDescriptor InterleavedToShardedPartialProgramFactory::create_descriptor(
     }
 
     return desc;
+}
+
+std::vector<tt::tt_metal::DynamicRuntimeArg> InterleavedToShardedPartialDeviceOperation::get_dynamic_runtime_args(
+    const operation_attributes_t& operation_attributes,
+    const Tensor& input_tensor,
+    tensor_return_value_t& output,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+    // Only TILE layout is supported (validated in validate_on_program_cache_miss). starting_idx_h is
+    // the sole slice_index-dependent value; it is uniform across cores and baked into reader arg 7
+    // (always) and writer arg 7 (only when the output is in DRAM -- the sharded-output writer carries
+    // no start id). Re-apply it here so a cache hit for a different slice reads the right input slice.
+    const uint32_t starting_idx_h = operations::data_movement::detail::calculate_starting_idx_h(
+        input_tensor, operation_attributes.num_slices, operation_attributes.slice_index);
+
+    const auto& shard_spec = operation_attributes.shard_spec;
+    const bool rm_orientation = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
+    const auto cores = corerange_to_cores(shard_spec.grid, std::nullopt, rm_orientation);
+    const bool dst_is_dram = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;
+
+    // Kernel push order in create_descriptor: reader (0), writer (1)[, compute (2)].
+    constexpr uint32_t kReaderKernelIdx = 0;
+    constexpr uint32_t kWriterKernelIdx = 1;
+    // Reader RT args: {src, shard_h, shard_w, padded_offset, num_units_offset, units_per_shard,
+    //   curr_idx_h+curr_idx_w, starting_idx_h}; DRAM writer RT args mirror it with starting_idx_h at 7.
+    constexpr uint32_t kStartingIdxHArgIdx = 7;
+
+    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
+    dynamic_args.reserve(cores.size() * (dst_is_dram ? 2 : 1));
+    for (const auto& core : cores) {
+        dynamic_args.push_back({kReaderKernelIdx, core, kStartingIdxHArgIdx, starting_idx_h});
+        if (dst_is_dram) {
+            dynamic_args.push_back({kWriterKernelIdx, core, kStartingIdxHArgIdx, starting_idx_h});
+        }
+    }
+    return dynamic_args;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_program_factory.cpp
@@ -431,39 +431,18 @@ ProgramDescriptor InterleavedToShardedPartialProgramFactory::create_descriptor(
     return desc;
 }
 
-std::vector<tt::tt_metal::DynamicRuntimeArg> InterleavedToShardedPartialDeviceOperation::get_dynamic_runtime_args(
+void InterleavedToShardedPartialDeviceOperation::override_runtime_arguments(
+    tt::tt_metal::Program& program,
     const operation_attributes_t& operation_attributes,
     const Tensor& input_tensor,
     tensor_return_value_t& output,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    // Only TILE layout is supported (validated in validate_on_program_cache_miss). starting_idx_h is
-    // the sole slice_index-dependent value; it is uniform across cores and baked into reader arg 7
-    // (always) and writer arg 7 (only when the output is in DRAM -- the sharded-output writer carries
-    // no start id). Re-apply it here so a cache hit for a different slice reads the right input slice.
-    const uint32_t starting_idx_h = operations::data_movement::detail::calculate_starting_idx_h(
-        input_tensor, operation_attributes.num_slices, operation_attributes.slice_index);
-
-    const auto& shard_spec = operation_attributes.shard_spec;
-    const bool rm_orientation = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
-    const auto cores = corerange_to_cores(shard_spec.grid, std::nullopt, rm_orientation);
-    const bool dst_is_dram = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM;
-
-    // Kernel push order in create_descriptor: reader (0), writer (1)[, compute (2)].
-    constexpr uint32_t kReaderKernelIdx = 0;
-    constexpr uint32_t kWriterKernelIdx = 1;
-    // Reader RT args: {src, shard_h, shard_w, padded_offset, num_units_offset, units_per_shard,
-    //   curr_idx_h+curr_idx_w, starting_idx_h}; DRAM writer RT args mirror it with starting_idx_h at 7.
-    constexpr uint32_t kStartingIdxHArgIdx = 7;
-
-    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
-    dynamic_args.reserve(cores.size() * (dst_is_dram ? 2 : 1));
-    for (const auto& core : cores) {
-        dynamic_args.push_back({kReaderKernelIdx, core, kStartingIdxHArgIdx, starting_idx_h});
-        if (dst_is_dram) {
-            dynamic_args.push_back({kWriterKernelIdx, core, kStartingIdxHArgIdx, starting_idx_h});
-        }
-    }
-    return dynamic_args;
+    // Cache-hit fast path: re-derive the full descriptor (the single source of truth) and re-apply its
+    // per-core reader/writer args + tensor-backed CB addresses to the cached program. This re-covers the
+    // slice_index-dependent starting_idx_h (reader arg 7, and DRAM writer arg 7) AND all buffer addresses
+    // for the current tensors, correct by construction. Replaces get_dynamic_runtime_args.
+    auto desc = InterleavedToShardedPartialProgramFactory::create_descriptor(operation_attributes, input_tensor, output);
+    tt::tt_metal::apply_descriptor_runtime_args(program, desc);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_program_factory.cpp
@@ -437,12 +437,54 @@ void InterleavedToShardedPartialDeviceOperation::override_runtime_arguments(
     const Tensor& input_tensor,
     tensor_return_value_t& output,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    // Cache-hit fast path: re-derive the full descriptor (the single source of truth) and re-apply its
-    // per-core reader/writer args + tensor-backed CB addresses to the cached program. This re-covers the
-    // slice_index-dependent starting_idx_h (reader arg 7, and DRAM writer arg 7) AND all buffer addresses
-    // for the current tensors, correct by construction. Replaces get_dynamic_runtime_args.
-    auto desc = InterleavedToShardedPartialProgramFactory::create_descriptor(operation_attributes, input_tensor, output);
-    tt::tt_metal::apply_descriptor_runtime_args(program, desc);
+    // Cache-hit fast path. Only TILE layout is supported (validate_on_program_cache_miss); the static
+    // work-split (shard extents, curr_idx, num_units) is pinned by the hashed shape/shard-spec. The only
+    // per-dispatch values are the source/output buffer addresses and the slice_index-dependent
+    // starting_idx_h. Patch just those slots in place instead of rebuilding the whole descriptor (O(1)
+    // per core rather than O(num_cores) descriptor work). Replaces get_dynamic_runtime_args.
+    const uint32_t starting_idx_h = operations::data_movement::detail::calculate_starting_idx_h(
+        input_tensor, operation_attributes.num_slices, operation_attributes.slice_index);
+    const uint32_t src_addr = input_tensor.buffer()->address();
+    auto* dst_buffer = output.buffer();
+    const bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
+
+    const auto& shard_spec = operation_attributes.shard_spec;
+    const bool rm_orientation = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
+    const auto cores = corerange_to_cores(shard_spec.grid, std::nullopt, rm_orientation);
+
+    // Kernel push order in create_descriptor: reader (0), writer (1)[, compute (2)].
+    // Reader TILE RT args: {src, shard_h, shard_w, padded_offset, num_units_offset, units_per_shard,
+    //   curr_idx_h+curr_idx_w, starting_idx_h}; the DRAM-output writer mirrors src->dst at 0 and
+    //   starting_idx_h at 7. The sharded-output writer carries neither (address rides on the output CB).
+    constexpr uint32_t kReaderKernelIdx = 0;
+    constexpr uint32_t kWriterKernelIdx = 1;
+    constexpr uint32_t kBufferAddrArgIdx = 0;
+    constexpr uint32_t kStartingIdxHArgIdx = 7;
+    for (const auto& core : cores) {
+        auto& reader_rt = tt::tt_metal::GetRuntimeArgs(program, kReaderKernelIdx, core);
+        reader_rt[kBufferAddrArgIdx] = src_addr;
+        reader_rt[kStartingIdxHArgIdx] = starting_idx_h;
+        if (dst_is_dram) {
+            auto& writer_rt = tt::tt_metal::GetRuntimeArgs(program, kWriterKernelIdx, core);
+            writer_rt[kBufferAddrArgIdx] = dst_buffer->address();
+            writer_rt[kStartingIdxHArgIdx] = starting_idx_h;
+        }
+    }
+
+    // Sharded (non-DRAM) output binds its buffer to the output CB rather than a writer RT arg, so refresh
+    // that CB's base address in place. create_descriptor pushes the (unbound) input CB first only when
+    // converting data formats; mirror that ordering positionally -- apply_descriptor_runtime_args maps
+    // desc.cbs[i] to program CB i and updates only the entries that carry a buffer.
+    if (!dst_is_dram) {
+        const bool convert_df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype()) !=
+                                tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+        ProgramDescriptor cb_addr_only;
+        if (convert_df) {
+            cb_addr_only.cbs.emplace_back();  // input CB placeholder (unbound; address unchanged)
+        }
+        cb_addr_only.cbs.push_back(CBDescriptor{.buffer = dst_buffer});
+        tt::tt_metal::apply_descriptor_runtime_args(program, cb_addr_only);
+    }
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_program_factory.cpp
@@ -483,7 +483,7 @@ void InterleavedToShardedPartialDeviceOperation::override_runtime_arguments(
             cb_addr_only.cbs.emplace_back();  // input CB placeholder (unbound; address unchanged)
         }
         cb_addr_only.cbs.push_back(CBDescriptor{.buffer = dst_buffer});
-        tt::tt_metal::apply_descriptor_runtime_args(program, cb_addr_only);
+        tt::tt_metal::apply_descriptor_runtime_args(program, cb_addr_only);  // override-rebuild-ok: cb-addr-only
     }
 }
 


### PR DESCRIPTION
## Problem
`compute_program_hash` folded `slice_index` into the program-cache key, but `slice_index` only feeds the runtime read-offset `starting_idx_h` — the program structure (work split, CBs, kernels) is identical for every slice of a given `num_slices`, and the output shape is fixed. A `for slice_index in range(num_slices)` loop therefore built and cached a **separate program per slice** instead of reusing one.

## Fix
Exclude `slice_index` from the hash (`num_slices`, which drives the work split, stays keyed) and add `get_dynamic_runtime_args` to re-apply `starting_idx_h` on every cache hit (reader arg 7 on all cores; writer arg 7 when the output is in DRAM). The op only supports TILE layout, so `starting_idx_h` is the sole `slice_index`-dependent value — de-keying is collision-safe, not just a perf win.

## Test
`test_interleaved_to_sharded_partial_program_cache_reuse` drives all slices through one cached program with **distinct per-slice data** (the pre-existing `test_sharded_partial_op` uses `torch.ones`, which cannot detect a slice mixup), asserts a single program-cache entry, and checks each slice's contents. Negative control: without the fix, the op builds `num_slices` cache entries. 34 existing partial-slice tests pass.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/i2s-partial-sliceidx-overkeying-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/i2s-partial-sliceidx-overkeying-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/i2s-partial-sliceidx-overkeying-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/i2s-partial-sliceidx-overkeying-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/i2s-partial-sliceidx-overkeying-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/i2s-partial-sliceidx-overkeying-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/i2s-partial-sliceidx-overkeying-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/i2s-partial-sliceidx-overkeying-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/i2s-partial-sliceidx-overkeying-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/i2s-partial-sliceidx-overkeying-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/i2s-partial-sliceidx-overkeying-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/i2s-partial-sliceidx-overkeying-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/i2s-partial-sliceidx-overkeying-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/i2s-partial-sliceidx-overkeying-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/i2s-partial-sliceidx-overkeying-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/i2s-partial-sliceidx-overkeying-fix)