### PR TITLE
[Cleanup] Consolidate and rename the DRAM-sender GCB / tensor-prefetcher API

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_dram_sender_global_cb.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_sender_global_cb.cpp
@@ -71,7 +71,7 @@ TEST_F(DramSenderGCBFixture, SmokeOneSenderFourReceivers) {
 
     // Size: per-receiver fifo. Use 1KB.
     constexpr uint32_t kGcbSize = 1024;
-    auto gcb = experimental::CreateGlobalCircularBufferWithDramSenders(
+    auto gcb = experimental::CreateGlobalCircularBufferForTensorPrefetcher(
         *mesh_device_, bank_to_receivers, kGcbSize, BufferType::L1);
     // Use the sender coord the factory resolved; recomputing via pick_unused_dram_logical_core
     // would couple this test to the picker's current strategy.
@@ -215,7 +215,7 @@ TEST_F(DramSenderGCBFixture, SmokeTwoProgramsAsyncSlowDispatch) {
     const uint32_t bank_id = 0;
     CoreRangeSet receiver_cores(CoreRange({0, 0}, {kNumReceivers - 1, 0}));
     std::vector<std::pair<uint32_t, CoreRangeSet>> bank_to_receivers = {{bank_id, receiver_cores}};
-    auto gcb = experimental::CreateGlobalCircularBufferWithDramSenders(
+    auto gcb = experimental::CreateGlobalCircularBufferForTensorPrefetcher(
         *mesh_device_, bank_to_receivers, kGcbSize, BufferType::L1);
     const CoreCoord sender_logical = gcb.sender_receiver_core_mapping().at(0).first;
 
@@ -343,9 +343,9 @@ TEST_F(DramSenderGCBFixture, MultiGcbDisjointPagesSent) {
     // GCB A: receiver at worker (0, 0). GCB B: receiver at worker (1, 0). Same bank.
     CoreRangeSet recv_a(CoreRange({0, 0}, {0, 0}));
     CoreRangeSet recv_b(CoreRange({1, 0}, {1, 0}));
-    auto gcb_a = experimental::CreateGlobalCircularBufferWithDramSenders(
+    auto gcb_a = experimental::CreateGlobalCircularBufferForTensorPrefetcher(
         *mesh_device_, {{bank_id, recv_a}}, kGcbSize, BufferType::L1);
-    auto gcb_b = experimental::CreateGlobalCircularBufferWithDramSenders(
+    auto gcb_b = experimental::CreateGlobalCircularBufferForTensorPrefetcher(
         *mesh_device_, {{bank_id, recv_b}}, kGcbSize, BufferType::L1);
 
     const DeviceAddr pa = experimental::pages_sent_drisc_l1_base(gcb_a);
@@ -498,7 +498,7 @@ TEST_F(DramSenderGCBFixture, RejectsDuplicateSender) {
     CoreRangeSet recv0(CoreRange({0, 0}, {0, 0}));
     CoreRangeSet recv1(CoreRange({1, 0}, {1, 0}));
     std::vector<std::pair<uint32_t, CoreRangeSet>> bank_to_receivers = {{0, recv0}, {0, recv1}};
-    EXPECT_ANY_THROW(experimental::CreateGlobalCircularBufferWithDramSenders(
+    EXPECT_ANY_THROW(experimental::CreateGlobalCircularBufferForTensorPrefetcher(
         *mesh_device_, bank_to_receivers, 1024, BufferType::L1));
 }
 

--- a/tests/tt_metal/tt_metal/api/test_dram_sender_global_cb.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_sender_global_cb.cpp
@@ -72,7 +72,7 @@ TEST_F(DramSenderGCBFixture, SmokeOneSenderFourReceivers) {
     // Size: per-receiver fifo. Use 1KB.
     constexpr uint32_t kGcbSize = 1024;
     auto gcb = experimental::CreateGlobalCircularBufferForTensorPrefetcher(
-        *mesh_device_, bank_to_receivers, kGcbSize, BufferType::L1);
+        *mesh_device_, bank_to_receivers, kGcbSize, BufferType::L1, /*support_multi_receiver_shards=*/true);
     // Use the sender coord the factory resolved; recomputing via pick_unused_dram_logical_core
     // would couple this test to the picker's current strategy.
     const CoreCoord sender_logical = gcb.sender_receiver_core_mapping().at(0).first;
@@ -216,7 +216,7 @@ TEST_F(DramSenderGCBFixture, SmokeTwoProgramsAsyncSlowDispatch) {
     CoreRangeSet receiver_cores(CoreRange({0, 0}, {kNumReceivers - 1, 0}));
     std::vector<std::pair<uint32_t, CoreRangeSet>> bank_to_receivers = {{bank_id, receiver_cores}};
     auto gcb = experimental::CreateGlobalCircularBufferForTensorPrefetcher(
-        *mesh_device_, bank_to_receivers, kGcbSize, BufferType::L1);
+        *mesh_device_, bank_to_receivers, kGcbSize, BufferType::L1, /*support_multi_receiver_shards=*/true);
     const CoreCoord sender_logical = gcb.sender_receiver_core_mapping().at(0).first;
 
     const auto& hal = MetalContext::instance().hal();
@@ -344,9 +344,9 @@ TEST_F(DramSenderGCBFixture, MultiGcbDisjointPagesSent) {
     CoreRangeSet recv_a(CoreRange({0, 0}, {0, 0}));
     CoreRangeSet recv_b(CoreRange({1, 0}, {1, 0}));
     auto gcb_a = experimental::CreateGlobalCircularBufferForTensorPrefetcher(
-        *mesh_device_, {{bank_id, recv_a}}, kGcbSize, BufferType::L1);
+        *mesh_device_, {{bank_id, recv_a}}, kGcbSize, BufferType::L1, /*support_multi_receiver_shards=*/true);
     auto gcb_b = experimental::CreateGlobalCircularBufferForTensorPrefetcher(
-        *mesh_device_, {{bank_id, recv_b}}, kGcbSize, BufferType::L1);
+        *mesh_device_, {{bank_id, recv_b}}, kGcbSize, BufferType::L1, /*support_multi_receiver_shards=*/true);
 
     const DeviceAddr pa = experimental::pages_sent_drisc_l1_base(gcb_a);
     const DeviceAddr pb = experimental::pages_sent_drisc_l1_base(gcb_b);
@@ -499,7 +499,7 @@ TEST_F(DramSenderGCBFixture, RejectsDuplicateSender) {
     CoreRangeSet recv1(CoreRange({1, 0}, {1, 0}));
     std::vector<std::pair<uint32_t, CoreRangeSet>> bank_to_receivers = {{0, recv0}, {0, recv1}};
     EXPECT_ANY_THROW(experimental::CreateGlobalCircularBufferForTensorPrefetcher(
-        *mesh_device_, bank_to_receivers, 1024, BufferType::L1));
+        *mesh_device_, bank_to_receivers, 1024, BufferType::L1, /*support_multi_receiver_shards=*/true));
 }
 
 }  // namespace tt::tt_metal

--- a/tests/ttnn/unit_tests/base_functionality/test_dram_sender_global_cb_py.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_dram_sender_global_cb_py.py
@@ -26,7 +26,7 @@ def _single_recv(x: int, y: int) -> ttnn.CoreRangeSet:
 
 def test_create_dram_sender_global_circular_buffer_single_bank(device):
     bank_to_receivers = [(0, _single_recv(0, 0))]
-    gcb = ttnn.experimental.create_global_circular_buffer_with_dram_senders(device, bank_to_receivers, 1024)
+    gcb = ttnn.experimental.create_global_circular_buffer_for_tensor_prefetcher(device, bank_to_receivers, 1024)
     assert gcb.size() == 1024
     assert gcb.sender_cores().num_cores() == 1
     assert gcb.receiver_cores().num_cores() == 1
@@ -35,7 +35,7 @@ def test_create_dram_sender_global_circular_buffer_single_bank(device):
 def test_create_dram_sender_global_circular_buffer_multi_bank_disjoint(device):
     # Each bank gets a disjoint single-core receiver set.
     bank_to_receivers = [(b, _single_recv(b, 0)) for b in range(4)]
-    gcb = ttnn.experimental.create_global_circular_buffer_with_dram_senders(device, bank_to_receivers, 2048)
+    gcb = ttnn.experimental.create_global_circular_buffer_for_tensor_prefetcher(device, bank_to_receivers, 2048)
     assert gcb.size() == 2048
     assert gcb.sender_cores().num_cores() == 4
     assert gcb.receiver_cores().num_cores() == 4

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bench.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bench.py
@@ -509,9 +509,9 @@ def test_bench_dram_core_repeats_recv_contig(device, op_name, shape, distributio
         ring positions [b, b+num_banks, b+2*num_banks, ...]. Under BDS round-robin,
         bank b's slab s == shard (b + s*num_banks), so this delivers shard r to ring
         position r (PCC-verified below).
-      - GCB built via create_global_circular_buffer_for_tensor_prefetcher (the _for_matmul_1d
-        wrapper asserts a K-row-major single-wide-shard-per-bank layout, which recv-contig
-        is not; the underlying GCB object is identical).
+      - GCB built via create_global_circular_buffer_for_matmul_1d, which auto-detects the
+        weight's DRAM layout (here receiver-contiguous NdShardSpec) and sizes/builds the GCB
+        accordingly.
     """
     _apply_shape(shape)
 

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bench.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bench.py
@@ -628,7 +628,7 @@ def test_bench_dram_core_repeats_recv_contig(device, op_name, shape, distributio
     # Centralized recv-contig GCB builder: validates the (program_config, weight, bank_to_receivers)
     # triple (num_shards == ring_size, K % ring_size == 0, per_core_N == per-receiver N) and sizes/builds
     # the GCB in one place.
-    gcb = ttnn.experimental.create_global_circular_buffer_for_matmul_1d_recv_contig(
+    gcb = ttnn.experimental.create_global_circular_buffer_for_matmul_1d(
         device,
         [cc_program_config],
         [tt_weight],

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bench.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bench.py
@@ -509,7 +509,7 @@ def test_bench_dram_core_repeats_recv_contig(device, op_name, shape, distributio
         ring positions [b, b+num_banks, b+2*num_banks, ...]. Under BDS round-robin,
         bank b's slab s == shard (b + s*num_banks), so this delivers shard r to ring
         position r (PCC-verified below).
-      - GCB built via create_global_circular_buffer_with_dram_senders (the _for_matmul_1d
+      - GCB built via create_global_circular_buffer_for_tensor_prefetcher (the _for_matmul_1d
         wrapper asserts a K-row-major single-wide-shard-per-bank layout, which recv-contig
         is not; the underlying GCB object is identical).
     """

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bench.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bench.py
@@ -634,7 +634,7 @@ def test_bench_dram_core_repeats_recv_contig(device, op_name, shape, distributio
         [tt_weight],
         bank_to_receivers,
         gcb_size,
-        dual_senders_per_bank=dual_senders,
+        support_multi_receiver_shards=not dual_senders,
     )
     output_mem_config = ttnn.create_sharded_memory_config(
         shape=(_M, _N // ring_size),

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bw_bench.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bw_bench.py
@@ -335,7 +335,7 @@ def test_bw_tensor_prefetcher_recv_contig(device, op_name, shape):
     gcb_size = _gcb_size_bytes(page_size, pages_per_layer)
     dual_senders = os.environ.get("BENCH_DUAL_SENDERS", "0") == "1"
     gcb = ttnn.experimental.create_global_circular_buffer_with_dram_senders(
-        device, bank_to_receivers, gcb_size, dual_senders_per_bank=dual_senders
+        device, bank_to_receivers, gcb_size, support_multi_receiver_shards=not dual_senders
     )
 
     ttnn.experimental.start_tensor_prefetcher(device)
@@ -421,7 +421,7 @@ def test_bw_tensor_prefetcher_streaming(device, op_name, shape):
     gcb_size = window_blocks * page_size
     dual_senders = os.environ.get("BENCH_DUAL_SENDERS", "0") == "1"
     gcb = ttnn.experimental.create_global_circular_buffer_with_dram_senders(
-        device, bank_to_receivers, gcb_size, dual_senders_per_bank=dual_senders
+        device, bank_to_receivers, gcb_size, support_multi_receiver_shards=not dual_senders
     )
 
     logger.info(

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bw_bench.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bw_bench.py
@@ -243,7 +243,7 @@ def test_bw_tensor_prefetcher(device, op_name, shape):
         for b in range(num_dram_banks)
     ]
     gcb_size = _gcb_size_bytes(page_size, pages_per_layer)
-    gcb = ttnn.experimental.create_global_circular_buffer_with_dram_senders(device, bank_to_receivers, gcb_size)
+    gcb = ttnn.experimental.create_global_circular_buffer_for_tensor_prefetcher(device, bank_to_receivers, gcb_size)
 
     ttnn.experimental.start_tensor_prefetcher(device)
     ttnn.experimental.queue_tensor_prefetcher_request(
@@ -334,7 +334,7 @@ def test_bw_tensor_prefetcher_recv_contig(device, op_name, shape):
     ]
     gcb_size = _gcb_size_bytes(page_size, pages_per_layer)
     dual_senders = os.environ.get("BENCH_DUAL_SENDERS", "0") == "1"
-    gcb = ttnn.experimental.create_global_circular_buffer_with_dram_senders(
+    gcb = ttnn.experimental.create_global_circular_buffer_for_tensor_prefetcher(
         device, bank_to_receivers, gcb_size, support_multi_receiver_shards=not dual_senders
     )
 
@@ -420,7 +420,7 @@ def test_bw_tensor_prefetcher_streaming(device, op_name, shape):
     window_blocks = min(window_blocks, pages_per_layer)
     gcb_size = window_blocks * page_size
     dual_senders = os.environ.get("BENCH_DUAL_SENDERS", "0") == "1"
-    gcb = ttnn.experimental.create_global_circular_buffer_with_dram_senders(
+    gcb = ttnn.experimental.create_global_circular_buffer_for_tensor_prefetcher(
         device, bank_to_receivers, gcb_size, support_multi_receiver_shards=not dual_senders
     )
 

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_tensor_large.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_tensor_large.py
@@ -280,7 +280,7 @@ def test_tensor_prefetcher_BH_param(
 # create_global_circular_buffer_for_matmul_1d factory
 # ---------------------------------------------------------------------------
 # Drive the same shape as the qkv_small case (K=256, N=8*32, bf16) but build the GCB
-# via the matmul-aware factory instead of calling create_global_circular_buffer_with_dram_senders
+# via the matmul-aware factory instead of calling create_global_circular_buffer_for_tensor_prefetcher
 # directly. End-to-end PCC check confirms the factory's bank-to-receivers mapping +
 # size validation match what the matmul + prefetcher expect.
 @pytest.mark.parametrize(
@@ -549,7 +549,7 @@ def test_tensor_prefetcher_multi_tensor(device, num_tensors, num_layers):
         (b, _bank_receivers_row_major(b, _MT_NUM_RECV_PER_BANK, ring_cols=num_dram_banks))
         for b in range(num_dram_banks)
     ]
-    gcb = ttnn.experimental.create_global_circular_buffer_with_dram_senders(device, bank_to_receivers, gcb_size)
+    gcb = ttnn.experimental.create_global_circular_buffer_for_tensor_prefetcher(device, bank_to_receivers, gcb_size)
 
     # Per receiver per (layer, tensor): ring_size pushes.
     num_iters_total = num_layers * num_tensors * ring_size
@@ -615,7 +615,7 @@ def test_tensor_prefetcher_recv_contig_smoke(device, num_tensors, num_layers):
         (b, _bank_receivers_strided(b, num_recv_per_bank, num_dram_banks, ring_cols=num_dram_banks))
         for b in range(num_dram_banks)
     ]
-    gcb = ttnn.experimental.create_global_circular_buffer_with_dram_senders(device, bank_to_receivers, gcb_size)
+    gcb = ttnn.experimental.create_global_circular_buffer_for_tensor_prefetcher(device, bank_to_receivers, gcb_size)
 
     num_iters_total = num_layers * num_tensors * ring_size
 
@@ -910,7 +910,7 @@ def test_tensor_prefetcher_streaming_matmul(
     # The recv-contig matmul factory validates the (program_config, weight, bank_to_receivers) triple
     # and, because program_config.stream_in1 is set, relaxes its size floor from a full layer down to a
     # double-buffer window -- so the shallow streaming GCB is accepted here instead of only via the raw
-    # create_global_circular_buffer_with_dram_senders path.
+    # create_global_circular_buffer_for_tensor_prefetcher path.
     gcb = ttnn.experimental.create_global_circular_buffer_for_matmul_1d_recv_contig(
         device, [program_config], [tt_weight], bank_to_receivers=bank_to_receivers, size=gcb_size
     )

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_tensor_large.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_tensor_large.py
@@ -911,7 +911,7 @@ def test_tensor_prefetcher_streaming_matmul(
     # and, because program_config.stream_in1 is set, relaxes its size floor from a full layer down to a
     # double-buffer window -- so the shallow streaming GCB is accepted here instead of only via the raw
     # create_global_circular_buffer_for_tensor_prefetcher path.
-    gcb = ttnn.experimental.create_global_circular_buffer_for_matmul_1d_recv_contig(
+    gcb = ttnn.experimental.create_global_circular_buffer_for_matmul_1d(
         device, [program_config], [tt_weight], bank_to_receivers=bank_to_receivers, size=gcb_size
     )
 

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_validator.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_validator.py
@@ -118,7 +118,7 @@ def _setup_weight_and_gcb_dram_sender(device, K, N, dtype, recv_per_bank, num_la
     ]
     gcb_size = _GCB_DEPTH_PAGES * push_page_size
     gcb = ttnn.experimental.create_global_circular_buffer_with_dram_senders(
-        device, bank_to_receivers, gcb_size, dual_senders_per_bank=dual_senders
+        device, bank_to_receivers, gcb_size, support_multi_receiver_shards=not dual_senders
     )
 
     num_iters_total = num_layers * ring_size
@@ -387,7 +387,7 @@ def _setup_weight_and_gcb_recv_contig(
         ]
     gcb_size = _GCB_DEPTH_PAGES * push_page_size
     gcb = ttnn.experimental.create_global_circular_buffer_with_dram_senders(
-        device, bank_to_receivers, gcb_size, dual_senders_per_bank=dual_senders
+        device, bank_to_receivers, gcb_size, support_multi_receiver_shards=not dual_senders
     )
     num_iters_total = num_layers * ring_size
     return tt_weight, gcb, num_iters_total, push_page_size, ring_size
@@ -438,7 +438,7 @@ def test_validator_dram_sender_recv_contig(device, K, N, dtype, recv_per_bank, n
 
 @pytest.mark.parametrize("K,N,dtype,num_layers", [(448, 1792, ttnn.bfloat16, 2)])
 def test_validator_dram_sender_dual_single_receiver_bank(device, K, N, dtype, num_layers):
-    """dual_senders_per_bank=True with a single receiver per bank (recv_per_bank=1).
+    """support_multi_receiver_shards=False (dual senders) with a single receiver per bank (recv_per_bank=1).
 
     A single receiver cannot split across two senders, so every bank falls back to its
     primary sender and the mapping is identical to a single-sender GCB — previously this

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_validator.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_validator.py
@@ -117,7 +117,7 @@ def _setup_weight_and_gcb_dram_sender(device, K, N, dtype, recv_per_bank, num_la
         for b in range(num_dram_banks)
     ]
     gcb_size = _GCB_DEPTH_PAGES * push_page_size
-    gcb = ttnn.experimental.create_global_circular_buffer_with_dram_senders(
+    gcb = ttnn.experimental.create_global_circular_buffer_for_tensor_prefetcher(
         device, bank_to_receivers, gcb_size, support_multi_receiver_shards=not dual_senders
     )
 
@@ -386,7 +386,7 @@ def _setup_weight_and_gcb_recv_contig(
             for b in range(num_dram_banks)
         ]
     gcb_size = _GCB_DEPTH_PAGES * push_page_size
-    gcb = ttnn.experimental.create_global_circular_buffer_with_dram_senders(
+    gcb = ttnn.experimental.create_global_circular_buffer_for_tensor_prefetcher(
         device, bank_to_receivers, gcb_size, support_multi_receiver_shards=not dual_senders
     )
     num_iters_total = num_layers * ring_size
@@ -550,7 +550,7 @@ def test_validator_dram_sender_recv_contig_page_size_switch(device):
     assert (ring_size * page_a) % page_b != 0
 
     gcb_size = ring_size * max(page_a, page_b)
-    gcb = ttnn.experimental.create_global_circular_buffer_with_dram_senders(device, bank_to_receivers, gcb_size)
+    gcb = ttnn.experimental.create_global_circular_buffer_for_tensor_prefetcher(device, bank_to_receivers, gcb_size)
 
     with tensor_prefetcher_session(device):
         ttnn.experimental.queue_tensor_prefetcher_request(device, [(weight_a, ring_size)], global_cb=gcb)

--- a/tt_metal/api/tt-metalium/experimental/global_circular_buffer.hpp
+++ b/tt_metal/api/tt-metalium/experimental/global_circular_buffer.hpp
@@ -42,23 +42,28 @@ enum class SenderCoreType : uint8_t {
 // sets across senders must be disjoint and must not collide with the resolved DRAM-sender
 // physical NOC coords.
 //
-// When `dual_senders_per_bank` is true, each bank with two or more receivers is driven by
-// two DRISC sender cores (the free subchannel plus the bank's NOC1-endpoint subchannel, both
-// on NOC0); the bank's receivers are split ceil/floor across them. This is only valid for the
-// receiver-contiguous DRAM layout. A single-receiver bank cannot split one receiver across two
-// senders, so it falls back to a single sender (the free subchannel) with its secondary core
-// left parked — single- and dual-sender banks may coexist in one dual-mode GCB. The Tensor
-// prefetcher always provisions both cores and routes PREFETCH requests only to this GCB's
-// mapped sender subset.
+// `support_multi_receiver_shards` (the default) declares that a bank's shard may be consumed by
+// more than one receiver — the legacy interleaved DRAM layout, where a single read pulls data for
+// every receiver on the bank. Because the receivers share that data, the bank must be driven by a
+// single sender core (the free non-endpoint subchannel on NOC0).
+//
+// Set it to false to promise the opposite: each receiver owns a disjoint, contiguous shard (the
+// receiver-contiguous layout). With no shared data between receivers, a bank holding two or more
+// receivers can then be driven by two DRISC sender cores (the free subchannel plus the bank's
+// NOC1-endpoint subchannel, both on NOC0), splitting the bank's receivers ceil/floor across them
+// to roughly double per-bank bandwidth. A single-receiver bank cannot split one receiver across
+// two senders, so it falls back to a single sender with its secondary core left parked —
+// single- and dual-sender banks may therefore coexist in one GCB. The Tensor prefetcher always
+// provisions both cores and routes PREFETCH requests only to this GCB's mapped sender subset.
 //
 // MeshDevice-only: the arena that backs this GCB's pages_sent allocation lives on
 // MeshDeviceImpl, so a bare IDevice cannot construct one.
-GlobalCircularBuffer CreateGlobalCircularBufferWithDramSenders(
+GlobalCircularBuffer CreateGlobalCircularBufferForTensorPrefetcher(
     distributed::MeshDevice& mesh_device,
     const std::vector<std::pair<uint32_t, CoreRangeSet>>& bank_to_receivers,
     uint32_t size,
     BufferType buffer_type = BufferType::L1,
-    bool dual_senders_per_bank = false);
+    bool support_multi_receiver_shards = true);
 
 // Read-only accessors for the DRAM-sender state inside a GlobalCircularBuffer. For
 // GCBs created via the worker-sender path these return SenderCoreType::Worker / 0 /

--- a/tt_metal/api/tt-metalium/experimental/global_circular_buffer.hpp
+++ b/tt_metal/api/tt-metalium/experimental/global_circular_buffer.hpp
@@ -42,12 +42,12 @@ enum class SenderCoreType : uint8_t {
 // sets across senders must be disjoint and must not collide with the resolved DRAM-sender
 // physical NOC coords.
 //
-// `support_multi_receiver_shards` (the default) declares that a bank's shard may be consumed by
+// `support_multi_receiver_shards=true` declares that a bank's shard may be consumed by
 // more than one receiver — the legacy interleaved DRAM layout, where a single read pulls data for
 // every receiver on the bank. Because the receivers share that data, the bank must be driven by a
 // single sender core (the free non-endpoint subchannel on NOC0).
 //
-// Set it to false to promise the opposite: each receiver owns a disjoint, contiguous shard (the
+// The default, false, promises the opposite: each receiver owns a disjoint, contiguous shard (the
 // receiver-contiguous layout). With no shared data between receivers, a bank holding two or more
 // receivers can then be driven by two DRISC sender cores (the free subchannel plus the bank's
 // NOC1-endpoint subchannel, both on NOC0), splitting the bank's receivers ceil/floor across them
@@ -63,7 +63,7 @@ GlobalCircularBuffer CreateGlobalCircularBufferForTensorPrefetcher(
     const std::vector<std::pair<uint32_t, CoreRangeSet>>& bank_to_receivers,
     uint32_t size,
     BufferType buffer_type = BufferType::L1,
-    bool support_multi_receiver_shards = true);
+    bool support_multi_receiver_shards = false);
 
 // Read-only accessors for the DRAM-sender state inside a GlobalCircularBuffer. For
 // GCBs created via the worker-sender path these return SenderCoreType::Worker / 0 /

--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -562,13 +562,16 @@ std::vector<std::pair<CoreCoord, CoreRangeSet>> build_dram_sender_mapping(
 
 }  // namespace
 
-GlobalCircularBuffer CreateGlobalCircularBufferWithDramSenders(
+GlobalCircularBuffer CreateGlobalCircularBufferForTensorPrefetcher(
     distributed::MeshDevice& mesh_device,
     const std::vector<std::pair<uint32_t, CoreRangeSet>>& bank_to_receivers,
     uint32_t size,
     BufferType buffer_type,
-    bool dual_senders_per_bank) {
-    auto mapping = build_dram_sender_mapping(&mesh_device, bank_to_receivers, dual_senders_per_bank);
+    bool support_multi_receiver_shards) {
+    // Multi-receiver shards (legacy interleaved layout) force one sender per bank; the
+    // receiver-contiguous layout that disallows them is what lets a bank use two senders.
+    auto mapping = build_dram_sender_mapping(
+        &mesh_device, bank_to_receivers, /*dual_senders_per_bank=*/!support_multi_receiver_shards);
     return global_circular_buffer_dram_sender::GlobalCircularBufferDramSenderInternals::make_dram_sender(
         &mesh_device, mapping, size, buffer_type);
 }

--- a/ttnn/api/ttnn/global_circular_buffer.hpp
+++ b/ttnn/api/ttnn/global_circular_buffer.hpp
@@ -34,7 +34,7 @@ GlobalCircularBuffer create_global_circular_buffer_with_dram_senders(
     const std::vector<std::pair<uint32_t, CoreRangeSet>>& bank_to_receivers,
     uint32_t size,
     BufferType buffer_type = BufferType::L1,
-    bool dual_senders_per_bank = false);
+    bool support_multi_receiver_shards = true);
 
 // Build a DRAM-sender GCB shaped to feed one or more 1D ring matmuls (gather_in0=true)
 // from the given weight tensors. The caller supplies `bank_to_receivers` (the same layout
@@ -100,7 +100,8 @@ uint32_t tensor_prefetcher_block_count_for_matmul_1d(
 //   * `size` minimum is ring_size * largest per-receiver page (= (K_tiles/ring_size) * per_core_N * tile);
 //   * receivers need NOT be uniform per bank and the bank->ring mapping is the strided round-robin one,
 //     so no per-bank-count / contiguous-ring assertions (the matmul op asserts the strided walk);
-//   * `dual_senders_per_bank` may split each bank's receivers across two DRISC sender cores
+//   * clearing `support_multi_receiver_shards` (i.e. promising each receiver owns a disjoint
+//     contiguous shard) lets each bank split its receivers across two DRISC sender cores
 //     (a single-receiver bank falls back to one sender, so mixed single/dual banks are allowed).
 //     The Tensor prefetcher always provisions both cores and targets the subset mapped by this GCB.
 //
@@ -114,6 +115,6 @@ GlobalCircularBuffer create_global_circular_buffer_for_matmul_1d_recv_contig(
     const std::vector<std::pair<uint32_t, CoreRangeSet>>& bank_to_receivers,
     uint32_t size,
     BufferType buffer_type = BufferType::L1,
-    bool dual_senders_per_bank = false);
+    bool support_multi_receiver_shards = true);
 
 }  // namespace ttnn::global_circular_buffer

--- a/ttnn/api/ttnn/global_circular_buffer.hpp
+++ b/ttnn/api/ttnn/global_circular_buffer.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <tt-metalium/global_circular_buffer.hpp>
 #include "ttnn/operations/matmul/device/config/matmul_program_config_types.hpp"
 #include "ttnn/tensor/tensor.hpp"
@@ -66,9 +67,15 @@ GlobalCircularBuffer create_global_circular_buffer_for_tensor_prefetcher(
 // remote-CB page-count limit; larger-than-one-layer buffering does not raise throughput (the DRISC
 // stalls on remote_cb_reserve_back).
 //
-// `support_multi_receiver_shards` (receiver-contiguous only): leave true (default) for one sender
-// per bank; set false to fan a bank's receivers across two DRISC senders for higher bandwidth. It is
-// an error to pass false with a legacy weight (that layout is inherently single-sender).
+// `support_multi_receiver_shards` is an optional override for the per-bank sender count; leave it
+// unset (nullopt) in production — the sender count is derived from the detected layout:
+//   * legacy K-row-major -> single sender per bank (the only option);
+//   * receiver-contiguous -> DUAL senders per bank (the higher-bandwidth default; single-receiver
+//     banks fall back to one sender automatically).
+// An explicit value overrides that default, mainly for tests/benchmarks: true forces single sender,
+// false forces dual senders. Recall the sense — true = a bank's shard may feed multiple receivers
+// (single sender); false = each receiver owns its own shard (dual senders). Forcing false (dual) on
+// a legacy weight is an error (that layout is inherently single-sender per bank).
 GlobalCircularBuffer create_global_circular_buffer_for_matmul_1d(
     MeshDevice* mesh_device,
     const std::vector<ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>& program_configs,
@@ -76,7 +83,7 @@ GlobalCircularBuffer create_global_circular_buffer_for_matmul_1d(
     const std::vector<std::pair<uint32_t, CoreRangeSet>>& bank_to_receivers,
     uint32_t size,
     BufferType buffer_type = BufferType::L1,
-    bool support_multi_receiver_shards = true);
+    std::optional<bool> support_multi_receiver_shards = std::nullopt);
 
 // Compute the validated `block_count` to pair with `weight` in a TensorPrefetcherInput when feeding a
 // gather_in0 1D matmul (`program_config`) from a *receiver-contiguous* DRAM weight via `gcb`. This is the

--- a/ttnn/api/ttnn/global_circular_buffer.hpp
+++ b/ttnn/api/ttnn/global_circular_buffer.hpp
@@ -29,7 +29,7 @@ GlobalCircularBuffer create_global_circular_buffer(
 // DRAM-sender variant: senders are programmable DRAM cores identified by DRAM bank id.
 // The returned GlobalCircularBuffer is the same type as the worker variant; the sender
 // domain is queryable via tt::tt_metal::experimental::sender_core_type(gcb).
-GlobalCircularBuffer create_global_circular_buffer_with_dram_senders(
+GlobalCircularBuffer create_global_circular_buffer_for_tensor_prefetcher(
     MeshDevice* mesh_device,
     const std::vector<std::pair<uint32_t, CoreRangeSet>>& bank_to_receivers,
     uint32_t size,
@@ -38,7 +38,7 @@ GlobalCircularBuffer create_global_circular_buffer_with_dram_senders(
 
 // Build a DRAM-sender GCB shaped to feed one or more 1D ring matmuls (gather_in0=true)
 // from the given weight tensors. The caller supplies `bank_to_receivers` (the same layout
-// the low-level `create_global_circular_buffer_with_dram_senders` takes), and the factory
+// the low-level `create_global_circular_buffer_for_tensor_prefetcher` takes), and the factory
 // validates it is compatible with the matmul program configs and weight shapes.
 //
 // One (program_config, weight) pair per matmul. Each pair is validated independently:

--- a/ttnn/api/ttnn/global_circular_buffer.hpp
+++ b/ttnn/api/ttnn/global_circular_buffer.hpp
@@ -36,42 +36,47 @@ GlobalCircularBuffer create_global_circular_buffer_for_tensor_prefetcher(
     BufferType buffer_type = BufferType::L1,
     bool support_multi_receiver_shards = true);
 
-// Build a DRAM-sender GCB shaped to feed one or more 1D ring matmuls (gather_in0=true)
-// from the given weight tensors. The caller supplies `bank_to_receivers` (the same layout
-// the low-level `create_global_circular_buffer_for_tensor_prefetcher` takes), and the factory
-// validates it is compatible with the matmul program configs and weight shapes.
+// Build a DRAM-sender GCB shaped to feed one or more 1D ring matmuls (gather_in0=true) from the
+// given weight tensors. The caller supplies `bank_to_receivers` (the same layout the low-level
+// `create_global_circular_buffer_for_tensor_prefetcher` takes); this factory validates it against
+// the matmul program configs and weight shapes and sizes the GCB accordingly.
 //
-// One (program_config, weight) pair per matmul. Each pair is validated independently:
-//   * weight K is tile-aligned AND divisible by ring_size (so activation K_per_shard is
-//     integer-tile, the silent-hang case where matmul pads K beyond what the prefetcher
-//     pushes),
-//   * weight N shards evenly across senders (num_senders = bank_to_receivers.size()) and
-//     per-bank N splits evenly across receivers,
-//   * matmul's per_core_N matches the weight per-receiver N.
-// All configs must agree on compute_with_storage_grid_size and num_global_cb_receivers
-// (the GCB has one receiver rectangle shared across all consumer matmuls).
+// The DRAM layout is detected from the weight allocation, NOT chosen by the caller — the tensor's
+// layout determines what the prefetcher does (mirrors tt_metal detect_layout_mode). All weights
+// sharing one GCB must use the same layout:
+//   * Legacy K-row-major (WIDTH_SHARDED): one shard per bank, K-row-major within the bank, so one
+//     read serves all of a bank's receivers. Always single-sender per bank. Validated: weight K
+//     tile-aligned AND divisible by ring_size (the silent-hang case where the matmul pads K beyond
+//     what the prefetcher pushes); weight N shards evenly across senders and per-bank N splits
+//     evenly across receivers; matmul per_core_N == weight per-receiver N. `bank_to_receivers`
+//     shape is checked: num_senders * num_global_cb_receivers == ring_size, every bank owns exactly
+//     num_global_cb_receivers cores. `size` floor is one full layer (ring_size * largest in1 block).
+//   * Receiver-contiguous (NdShardSpec): num_shards == ring_size, each shard (full K, N/ring_size)
+//     owned by one receiver. Validated: num_shards == ring_size, weight K-tiles divisible by
+//     ring_size, per_core_N == per-receiver N. Receivers need NOT be uniform per bank (strided
+//     round-robin). `size` floor is ring_size * largest per-receiver page, relaxed to a
+//     double-buffer window when every config is stream_in1. This layout also permits dual senders
+//     per bank via `support_multi_receiver_shards=false` (see below).
 //
-// `bank_to_receivers` shape is checked: num_senders * num_global_cb_receivers must equal
-// ring_size, and every bank must own exactly num_global_cb_receivers cores. The factory
-// does NOT check that the receivers row-major-walk into the same order as the matmul's
-// activation grid — the matmul op asserts that at construction time.
+// All configs must agree on compute_with_storage_grid_size (and, for legacy, num_global_cb_receivers)
+// — the GCB has one receiver rectangle shared across all consumer matmuls. The factory does NOT
+// check that receivers row-major-walk into the matmul's activation-grid order (the matmul op asserts
+// that at construction time), nor L1 capacity — callers must size the GCB to fit alongside the
+// matmul's in0/in1/out/interm CBs on the receiver cores. `size` is capped against a conservative
+// remote-CB page-count limit; larger-than-one-layer buffering does not raise throughput (the DRISC
+// stalls on remote_cb_reserve_back).
 //
-// `size` is the GCB size in bytes. Picking it:
-//   * Minimum = num_blocks * largest_in1_block_size (one full layer's pages). The matmul
-//     does wait_front(num_blocks) per layer, so anything smaller deadlocks.
-//   * Larger values let the DRISC prefetcher run further ahead. Past one full layer worth
-//     more buffering does not increase throughput — the DRISC stalls on
-//     remote_cb_reserve_back.
-//   * The factory only caps `size` against a conservative remote-CB page-count limit; it
-//     does NOT check L1 capacity. Callers must size the GCB to fit alongside the matmul's
-//     in0/in1/out/interm CBs on the receiver cores.
+// `support_multi_receiver_shards` (receiver-contiguous only): leave true (default) for one sender
+// per bank; set false to fan a bank's receivers across two DRISC senders for higher bandwidth. It is
+// an error to pass false with a legacy weight (that layout is inherently single-sender).
 GlobalCircularBuffer create_global_circular_buffer_for_matmul_1d(
     MeshDevice* mesh_device,
     const std::vector<ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>& program_configs,
     const std::vector<tt::tt_metal::Tensor>& weights,
     const std::vector<std::pair<uint32_t, CoreRangeSet>>& bank_to_receivers,
     uint32_t size,
-    BufferType buffer_type = BufferType::L1);
+    BufferType buffer_type = BufferType::L1,
+    bool support_multi_receiver_shards = true);
 
 // Compute the validated `block_count` to pair with `weight` in a TensorPrefetcherInput when feeding a
 // gather_in0 1D matmul (`program_config`) from a *receiver-contiguous* DRAM weight via `gcb`. This is the
@@ -91,30 +96,5 @@ uint32_t tensor_prefetcher_block_count_for_matmul_1d(
     const ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig& program_config,
     const tt::tt_metal::Tensor& weight,
     const GlobalCircularBuffer& gcb);
-
-// Receiver-contiguous counterpart of create_global_circular_buffer_for_matmul_1d: build a DRAM-sender
-// GCB sized to feed one or more gather_in0 1D ring matmuls from *receiver-contiguous* (NdShardSpec) DRAM
-// weights, and validate the (program_config, weight, bank_to_receivers) triple in one place.
-//
-// Differences from the K-row-major builder, all inherent to the recv-contig layout:
-//   * `size` minimum is ring_size * largest per-receiver page (= (K_tiles/ring_size) * per_core_N * tile);
-//   * receivers need NOT be uniform per bank and the bank->ring mapping is the strided round-robin one,
-//     so no per-bank-count / contiguous-ring assertions (the matmul op asserts the strided walk);
-//   * clearing `support_multi_receiver_shards` (i.e. promising each receiver owns a disjoint
-//     contiguous shard) lets each bank split its receivers across two DRISC sender cores
-//     (a single-receiver bank falls back to one sender, so mixed single/dual banks are allowed).
-//     The Tensor prefetcher always provisions both cores and targets the subset mapped by this GCB.
-//
-// Per (config, weight) it runs the same recv-contig cross-checks as
-// tensor_prefetcher_block_count_for_matmul_1d (num_shards == ring_size, weight K-tiles divisible by
-// ring_size, per_core_N == per-receiver N). Throws (TT_FATAL) on any mismatch.
-GlobalCircularBuffer create_global_circular_buffer_for_matmul_1d_recv_contig(
-    MeshDevice* mesh_device,
-    const std::vector<ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>& program_configs,
-    const std::vector<tt::tt_metal::Tensor>& weights,
-    const std::vector<std::pair<uint32_t, CoreRangeSet>>& bank_to_receivers,
-    uint32_t size,
-    BufferType buffer_type = BufferType::L1,
-    bool support_multi_receiver_shards = true);
 
 }  // namespace ttnn::global_circular_buffer

--- a/ttnn/core/global_circular_buffer.cpp
+++ b/ttnn/core/global_circular_buffer.cpp
@@ -464,7 +464,7 @@ GlobalCircularBuffer create_global_circular_buffer_for_matmul_1d(
     const std::vector<std::pair<uint32_t, CoreRangeSet>>& bank_to_receivers,
     uint32_t size,
     BufferType buffer_type,
-    bool support_multi_receiver_shards) {
+    std::optional<bool> support_multi_receiver_shards) {
     TT_FATAL(!program_configs.empty(), "Must provide at least one program config");
     TT_FATAL(
         program_configs.size() == weights.size(),
@@ -485,14 +485,20 @@ GlobalCircularBuffer create_global_circular_buffer_for_matmul_1d(
     }
 
     if (recv_contig) {
+        // Dual senders are the production default for receiver-contiguous weights (highest per-bank
+        // bandwidth); single-receiver banks fall back to one sender automatically. An explicit value
+        // overrides (e.g. a benchmark forcing single-sender for an A/B comparison). Recall the flag's
+        // sense: false => dual senders, true => single sender.
+        const bool single_sender = support_multi_receiver_shards.value_or(false);
         return build_matmul_1d_gcb_recv_contig(
-            mesh_device, program_configs, weights, bank_to_receivers, size, buffer_type, support_multi_receiver_shards);
+            mesh_device, program_configs, weights, bank_to_receivers, size, buffer_type, single_sender);
     }
 
     // Legacy K-row-major is single-sender per bank by construction (a bank's shard feeds all its
-    // receivers), so it cannot honor a dual-sender request.
+    // receivers), so it cannot honor a dual-sender request. The layout-derived default is single; an
+    // explicit request for dual (support_multi_receiver_shards=false) is an error here.
     TT_FATAL(
-        support_multi_receiver_shards,
+        support_multi_receiver_shards.value_or(true),
         "support_multi_receiver_shards=false (dual senders) requires a receiver-contiguous (NdShardSpec) weight; the "
         "supplied weight is legacy K-row-major (WIDTH_SHARDED), which is always single-sender per bank");
     return build_matmul_1d_gcb_krow_major(mesh_device, program_configs, weights, bank_to_receivers, size, buffer_type);

--- a/ttnn/core/global_circular_buffer.cpp
+++ b/ttnn/core/global_circular_buffer.cpp
@@ -254,7 +254,7 @@ static GlobalCircularBuffer build_matmul_1d_gcb_krow_major(
         kMaxCbPagesBytes);
 
     return tt::tt_metal::experimental::CreateGlobalCircularBufferForTensorPrefetcher(
-        *mesh_device, bank_to_receivers, size, buffer_type);
+        *mesh_device, bank_to_receivers, size, buffer_type, /*support_multi_receiver_shards=*/true);
 }
 
 namespace {

--- a/ttnn/core/global_circular_buffer.cpp
+++ b/ttnn/core/global_circular_buffer.cpp
@@ -35,7 +35,7 @@ GlobalCircularBuffer create_global_circular_buffer(
         device, sender_receiver_core_mapping, size, buffer_type);
 }
 
-GlobalCircularBuffer create_global_circular_buffer_with_dram_senders(
+GlobalCircularBuffer create_global_circular_buffer_for_tensor_prefetcher(
     MeshDevice* mesh_device,
     const std::vector<std::pair<uint32_t, CoreRangeSet>>& bank_to_receivers,
     uint32_t size,

--- a/ttnn/core/global_circular_buffer.cpp
+++ b/ttnn/core/global_circular_buffer.cpp
@@ -40,9 +40,9 @@ GlobalCircularBuffer create_global_circular_buffer_with_dram_senders(
     const std::vector<std::pair<uint32_t, CoreRangeSet>>& bank_to_receivers,
     uint32_t size,
     BufferType buffer_type,
-    bool dual_senders_per_bank) {
-    return tt::tt_metal::experimental::CreateGlobalCircularBufferWithDramSenders(
-        *mesh_device, bank_to_receivers, size, buffer_type, dual_senders_per_bank);
+    bool support_multi_receiver_shards) {
+    return tt::tt_metal::experimental::CreateGlobalCircularBufferForTensorPrefetcher(
+        *mesh_device, bank_to_receivers, size, buffer_type, support_multi_receiver_shards);
 }
 
 GlobalCircularBuffer create_global_circular_buffer_for_matmul_1d(
@@ -255,7 +255,7 @@ GlobalCircularBuffer create_global_circular_buffer_for_matmul_1d(
         size,
         kMaxCbPagesBytes);
 
-    return tt::tt_metal::experimental::CreateGlobalCircularBufferWithDramSenders(
+    return tt::tt_metal::experimental::CreateGlobalCircularBufferForTensorPrefetcher(
         *mesh_device, bank_to_receivers, size, buffer_type);
 }
 
@@ -360,7 +360,7 @@ GlobalCircularBuffer create_global_circular_buffer_for_matmul_1d_recv_contig(
     const std::vector<std::pair<uint32_t, CoreRangeSet>>& bank_to_receivers,
     uint32_t size,
     BufferType buffer_type,
-    bool dual_senders_per_bank) {
+    bool support_multi_receiver_shards) {
     TT_FATAL(!program_configs.empty(), "Must provide at least one program config");
     TT_FATAL(
         program_configs.size() == weights.size(),
@@ -441,8 +441,8 @@ GlobalCircularBuffer create_global_circular_buffer_for_matmul_1d_recv_contig(
         size,
         kMaxCbPagesBytes);
 
-    return tt::tt_metal::experimental::CreateGlobalCircularBufferWithDramSenders(
-        *mesh_device, bank_to_receivers, size, buffer_type, dual_senders_per_bank);
+    return tt::tt_metal::experimental::CreateGlobalCircularBufferForTensorPrefetcher(
+        *mesh_device, bank_to_receivers, size, buffer_type, support_multi_receiver_shards);
 }
 
 }  // namespace ttnn::global_circular_buffer

--- a/ttnn/core/global_circular_buffer.cpp
+++ b/ttnn/core/global_circular_buffer.cpp
@@ -45,19 +45,17 @@ GlobalCircularBuffer create_global_circular_buffer_for_tensor_prefetcher(
         *mesh_device, bank_to_receivers, size, buffer_type, support_multi_receiver_shards);
 }
 
-GlobalCircularBuffer create_global_circular_buffer_for_matmul_1d(
+// Builds the GCB for a legacy K-row-major (WIDTH_SHARDED) weight: one shard per DRAM bank, the
+// bank's shard interleaving all its receivers (one read serves every receiver on the bank). Always
+// single-sender per bank. Extracted from the former public create_global_circular_buffer_for_matmul_1d;
+// the public entry point now detects the layout and dispatches here or to build_matmul_1d_gcb_recv_contig.
+static GlobalCircularBuffer build_matmul_1d_gcb_krow_major(
     MeshDevice* mesh_device,
     const std::vector<ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>& program_configs,
     const std::vector<tt::tt_metal::Tensor>& weights,
     const std::vector<std::pair<uint32_t, CoreRangeSet>>& bank_to_receivers,
     uint32_t size,
     BufferType buffer_type) {
-    TT_FATAL(!program_configs.empty(), "Must provide at least one program config");
-    TT_FATAL(
-        program_configs.size() == weights.size(),
-        "Expected one weight tensor per program config; got {} configs and {} weights",
-        program_configs.size(),
-        weights.size());
     TT_FATAL(size > 0, "size must be > 0");
     TT_FATAL(!bank_to_receivers.empty(), "bank_to_receivers must be non-empty");
 
@@ -261,6 +259,23 @@ GlobalCircularBuffer create_global_circular_buffer_for_matmul_1d(
 
 namespace {
 
+// Classify a prefetcher weight's DRAM layout. This mirrors tt_metal's detect_layout_mode
+// (impl/buffers/tensor_prefetcher_manager.cpp) and MUST stay in sync with it: the runtime
+// prefetcher routes on that function, so if this factory classifies a weight differently the
+// validation here and the kernel's actual consumption disagree (wrong output / silent hang).
+//
+// Key on how the weight was ALLOCATED, not on shard count. Some legacy WIDTH_SHARDED buffers also
+// expose an NdShardSpec-like descriptor via BDS, so the explicit legacy shard spec must win; and a
+// shard-count test is ambiguous when total_receivers == num_banks (num_shards == num_banks in both
+// layouts). num_shards == ring_size for recv-contig is enforced separately by the validator.
+bool is_receiver_contiguous_weight(const tt::tt_metal::Tensor& weight) {
+    TT_FATAL(weight.buffer() != nullptr && weight.buffer()->is_dram(), "prefetcher weight must live in DRAM");
+    if (weight.buffer()->has_shard_spec()) {
+        return false;  // legacy K-row-major (WIDTH_SHARDED)
+    }
+    return weight.nd_shard_spec().has_value();
+}
+
 // Shared receiver-contiguous weight ↔ matmul cross-checks, parameterized on ring_size so both the
 // block_count helper (ring_size from the GCB) and the GCB factory (ring_size from bank_to_receivers /
 // the program-config grid) can call it. See the header docs on the two public functions for the
@@ -353,7 +368,10 @@ uint32_t tensor_prefetcher_block_count_for_matmul_1d(
     return ring_size;
 }
 
-GlobalCircularBuffer create_global_circular_buffer_for_matmul_1d_recv_contig(
+// Builds the GCB for a receiver-contiguous (NdShardSpec) weight: num_shards == ring_size, each shard
+// (full K, N/ring_size) owned by exactly one receiver. Supports dual senders per bank. Extracted from
+// the former public create_global_circular_buffer_for_matmul_1d_recv_contig.
+static GlobalCircularBuffer build_matmul_1d_gcb_recv_contig(
     MeshDevice* mesh_device,
     const std::vector<ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>& program_configs,
     const std::vector<tt::tt_metal::Tensor>& weights,
@@ -361,12 +379,6 @@ GlobalCircularBuffer create_global_circular_buffer_for_matmul_1d_recv_contig(
     uint32_t size,
     BufferType buffer_type,
     bool support_multi_receiver_shards) {
-    TT_FATAL(!program_configs.empty(), "Must provide at least one program config");
-    TT_FATAL(
-        program_configs.size() == weights.size(),
-        "Expected one weight tensor per program config; got {} configs and {} weights",
-        program_configs.size(),
-        weights.size());
     TT_FATAL(size > 0, "size must be > 0");
     TT_FATAL(!bank_to_receivers.empty(), "bank_to_receivers must be non-empty");
 
@@ -443,6 +455,47 @@ GlobalCircularBuffer create_global_circular_buffer_for_matmul_1d_recv_contig(
 
     return tt::tt_metal::experimental::CreateGlobalCircularBufferForTensorPrefetcher(
         *mesh_device, bank_to_receivers, size, buffer_type, support_multi_receiver_shards);
+}
+
+GlobalCircularBuffer create_global_circular_buffer_for_matmul_1d(
+    MeshDevice* mesh_device,
+    const std::vector<ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>& program_configs,
+    const std::vector<tt::tt_metal::Tensor>& weights,
+    const std::vector<std::pair<uint32_t, CoreRangeSet>>& bank_to_receivers,
+    uint32_t size,
+    BufferType buffer_type,
+    bool support_multi_receiver_shards) {
+    TT_FATAL(!program_configs.empty(), "Must provide at least one program config");
+    TT_FATAL(
+        program_configs.size() == weights.size(),
+        "Expected one weight tensor per program config; got {} configs and {} weights",
+        program_configs.size(),
+        weights.size());
+
+    // All weights share one GCB receiver rectangle, so they must all use the same DRAM layout.
+    // Detect from the weight allocation (not the caller) so callers don't have to know which builder
+    // to pick — the tensor's layout determines what the prefetcher does.
+    const bool recv_contig = is_receiver_contiguous_weight(weights.front());
+    for (size_t i = 1; i < weights.size(); ++i) {
+        TT_FATAL(
+            is_receiver_contiguous_weight(weights[i]) == recv_contig,
+            "weights[{}] has a different DRAM layout than weights[0]; all weights sharing one GCB must be either "
+            "all receiver-contiguous (NdShardSpec) or all legacy K-row-major (WIDTH_SHARDED)",
+            i);
+    }
+
+    if (recv_contig) {
+        return build_matmul_1d_gcb_recv_contig(
+            mesh_device, program_configs, weights, bank_to_receivers, size, buffer_type, support_multi_receiver_shards);
+    }
+
+    // Legacy K-row-major is single-sender per bank by construction (a bank's shard feeds all its
+    // receivers), so it cannot honor a dual-sender request.
+    TT_FATAL(
+        support_multi_receiver_shards,
+        "support_multi_receiver_shards=false (dual senders) requires a receiver-contiguous (NdShardSpec) weight; the "
+        "supplied weight is legacy K-row-major (WIDTH_SHARDED), which is always single-sender per bank");
+    return build_matmul_1d_gcb_krow_major(mesh_device, program_configs, weights, bank_to_receivers, size, buffer_type);
 }
 
 }  // namespace ttnn::global_circular_buffer

--- a/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher_nanobind.cpp
@@ -185,10 +185,13 @@ void bind_tensor_prefetcher(nb::module_& mod) {
                 bank_to_receivers: List of (bank_id, receivers) pairs.
                 size: GCB size in bytes.
                 buffer_type: Buffer type (L1 or L1_SMALL).
-                support_multi_receiver_shards: If True (default), a bank's shard may feed multiple
-                    receivers (single sender per bank). Set False on a receiver-contiguous weight to
-                    fan a bank's receivers across two DRISC senders for higher bandwidth. Error if
-                    False with a legacy weight (that layout is always single-sender).
+                support_multi_receiver_shards: Optional per-bank sender-count override; leave None
+                    (default) in production. When None the sender count follows the detected layout:
+                    legacy WIDTH_SHARDED -> single sender per bank; receiver-contiguous -> dual
+                    senders per bank (higher bandwidth; single-receiver banks fall back to one).
+                    Pass an explicit value to override, mainly for tests/benchmarks: True forces
+                    single sender, False forces dual senders. Forcing False (dual) on a legacy
+                    weight raises (that layout is always single-sender).
         )doc",
         &ttnn::global_circular_buffer::create_global_circular_buffer_for_matmul_1d,
         nb::keep_alive<0, 1>(),
@@ -198,7 +201,7 @@ void bind_tensor_prefetcher(nb::module_& mod) {
         nb::arg("bank_to_receivers"),
         nb::arg("size"),
         nb::arg("buffer_type") = tt::tt_metal::BufferType::L1,
-        nb::arg("support_multi_receiver_shards") = true);
+        nb::arg("support_multi_receiver_shards") = std::nullopt);
 
     ttnn::bind_function<"tensor_prefetcher_block_count_for_matmul_1d", "ttnn.experimental.">(
         mod,

--- a/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher_nanobind.cpp
@@ -82,7 +82,7 @@ void bind_tensor_prefetcher(nb::module_& mod) {
                     = r reproduces the natural topology order; the matmul must consume in the
                     matching order, else it deadlocks.
                 global_cb (GlobalCircularBuffer): a DRAM-sender GCB (created via
-                    ttnn.experimental.create_global_circular_buffer_with_dram_senders).
+                    ttnn.experimental.create_global_circular_buffer_for_tensor_prefetcher).
                 device_subset (Optional[MeshCoordinateRangeSet]): subset of the mesh that
                     processes this request. Defaults to the full mesh.
                 cq_id (Optional[int]): command queue that may be recording a trace. When that
@@ -142,7 +142,7 @@ void bind_tensor_prefetcher(nb::module_& mod) {
 
     // DRAM-sender GCB factories. MeshDevice-only (the per-mesh DRISC L1 arena lives on
     // MeshDeviceImpl) and only ever paired with the Tensor prefetcher above.
-    ttnn::bind_function<"create_global_circular_buffer_with_dram_senders", "ttnn.experimental.">(
+    ttnn::bind_function<"create_global_circular_buffer_for_tensor_prefetcher", "ttnn.experimental.">(
         mod,
         R"doc(
             Create a GlobalCircularBuffer where senders are programmable DRAM cores (Blackhole DRISCs).
@@ -160,7 +160,7 @@ void bind_tensor_prefetcher(nb::module_& mod) {
                     (receiver-contiguous layout); a bank with two or more receivers may then split
                     them across two DRISC sender cores for higher bandwidth.
         )doc",
-        &ttnn::global_circular_buffer::create_global_circular_buffer_with_dram_senders,
+        &ttnn::global_circular_buffer::create_global_circular_buffer_for_tensor_prefetcher,
         nb::keep_alive<0, 1>(),
         nb::arg("mesh_device"),
         nb::arg("bank_to_receivers"),

--- a/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher_nanobind.cpp
@@ -154,9 +154,11 @@ void bind_tensor_prefetcher(nb::module_& mod) {
                 bank_to_receivers: List of (bank_id, receivers) pairs.
                 size: Per-receiver fifo size in bytes.
                 buffer_type: Buffer type (L1 or L1_SMALL).
-                dual_senders_per_bank: If True, split each bank's receivers across two DRISC
-                    sender cores (receiver-contiguous layout only). Otherwise, the GCB targets
-                    only the primary sender and the second provisioned prefetcher sender remains idle.
+                support_multi_receiver_shards: If True (default), a bank's shard may feed multiple
+                    receivers (legacy interleaved layout), which requires a single sender per bank.
+                    Set False to promise each receiver owns a disjoint contiguous shard
+                    (receiver-contiguous layout); a bank with two or more receivers may then split
+                    them across two DRISC sender cores for higher bandwidth.
         )doc",
         &ttnn::global_circular_buffer::create_global_circular_buffer_with_dram_senders,
         nb::keep_alive<0, 1>(),
@@ -164,7 +166,7 @@ void bind_tensor_prefetcher(nb::module_& mod) {
         nb::arg("bank_to_receivers"),
         nb::arg("size"),
         nb::arg("buffer_type") = tt::tt_metal::BufferType::L1,
-        nb::arg("dual_senders_per_bank") = false);
+        nb::arg("support_multi_receiver_shards") = true);
 
     ttnn::bind_function<"create_global_circular_buffer_for_matmul_1d", "ttnn.experimental.">(
         mod,
@@ -228,8 +230,10 @@ void bind_tensor_prefetcher(nb::module_& mod) {
                 bank_to_receivers: List of (bank_id, receivers) pairs (strided round-robin placement).
                 size: GCB size in bytes (>= ring_size * largest per-receiver page).
                 buffer_type: Buffer type (L1 or L1_SMALL).
-                dual_senders_per_bank: If True, split each bank's receivers across two DRISC sender cores
-                    instead of targeting only the primary sender.
+                support_multi_receiver_shards: If True (default), a bank's shard may feed multiple
+                    receivers (single sender per bank). Set False to promise each receiver owns a
+                    disjoint contiguous shard, letting a bank split its receivers across two DRISC
+                    sender cores for higher bandwidth.
         )doc",
         &ttnn::global_circular_buffer::create_global_circular_buffer_for_matmul_1d_recv_contig,
         nb::keep_alive<0, 1>(),
@@ -239,7 +243,7 @@ void bind_tensor_prefetcher(nb::module_& mod) {
         nb::arg("bank_to_receivers"),
         nb::arg("size"),
         nb::arg("buffer_type") = tt::tt_metal::BufferType::L1,
-        nb::arg("dual_senders_per_bank") = false);
+        nb::arg("support_multi_receiver_shards") = true);
 }
 
 }  // namespace ttnn::operations::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher_nanobind.cpp
@@ -172,16 +172,23 @@ void bind_tensor_prefetcher(nb::module_& mod) {
         mod,
         R"doc(
             Build a DRAM-sender GlobalCircularBuffer sized to feed one or more 1D ring matmuls
-            (gather_in0=true) with their weight tensors. See impl notes in
-            tt_metal/impl/buffers/global_circular_buffer.cpp.
+            (gather_in0=true) with their weight tensors. The weight's DRAM layout is auto-detected
+            (legacy WIDTH_SHARDED K-row-major vs receiver-contiguous NdShardSpec) and validated/sized
+            accordingly, so callers do not choose a layout-specific factory. See notes in
+            ttnn/api/ttnn/global_circular_buffer.hpp.
 
             Args:
                 mesh_device: The mesh device.
                 program_configs: List of 1D mcast matmul program configs (each gather_in0=True).
-                weights: List of DRAM-sharded in1 tensors, one per program_config.
+                weights: List of DRAM in1 tensors, one per program_config. All must share the same
+                    DRAM layout (all legacy WIDTH_SHARDED, or all receiver-contiguous NdShardSpec).
                 bank_to_receivers: List of (bank_id, receivers) pairs.
                 size: GCB size in bytes.
                 buffer_type: Buffer type (L1 or L1_SMALL).
+                support_multi_receiver_shards: If True (default), a bank's shard may feed multiple
+                    receivers (single sender per bank). Set False on a receiver-contiguous weight to
+                    fan a bank's receivers across two DRISC senders for higher bandwidth. Error if
+                    False with a legacy weight (that layout is always single-sender).
         )doc",
         &ttnn::global_circular_buffer::create_global_circular_buffer_for_matmul_1d,
         nb::keep_alive<0, 1>(),
@@ -190,7 +197,8 @@ void bind_tensor_prefetcher(nb::module_& mod) {
         nb::arg("weights"),
         nb::arg("bank_to_receivers"),
         nb::arg("size"),
-        nb::arg("buffer_type") = tt::tt_metal::BufferType::L1);
+        nb::arg("buffer_type") = tt::tt_metal::BufferType::L1,
+        nb::arg("support_multi_receiver_shards") = true);
 
     ttnn::bind_function<"tensor_prefetcher_block_count_for_matmul_1d", "ttnn.experimental.">(
         mod,
@@ -214,36 +222,6 @@ void bind_tensor_prefetcher(nb::module_& mod) {
         nb::arg("program_config"),
         nb::arg("weight"),
         nb::arg("global_cb"));
-
-    ttnn::bind_function<"create_global_circular_buffer_for_matmul_1d_recv_contig", "ttnn.experimental.">(
-        mod,
-        R"doc(
-            Receiver-contiguous counterpart of create_global_circular_buffer_for_matmul_1d: build a
-            DRAM-sender GlobalCircularBuffer sized to feed one or more gather_in0 1D ring matmuls from
-            NdShardSpec (receiver-contiguous) DRAM weights, validating the (program_config, weight,
-            bank_to_receivers) triple in one place. See impl notes in ttnn/core/global_circular_buffer.cpp.
-
-            Args:
-                mesh_device: The mesh device.
-                program_configs: List of 1D mcast matmul program configs (each gather_in0=True).
-                weights: List of NdShardSpec DRAM in1 tensors, one per program_config.
-                bank_to_receivers: List of (bank_id, receivers) pairs (strided round-robin placement).
-                size: GCB size in bytes (>= ring_size * largest per-receiver page).
-                buffer_type: Buffer type (L1 or L1_SMALL).
-                support_multi_receiver_shards: If True (default), a bank's shard may feed multiple
-                    receivers (single sender per bank). Set False to promise each receiver owns a
-                    disjoint contiguous shard, letting a bank split its receivers across two DRISC
-                    sender cores for higher bandwidth.
-        )doc",
-        &ttnn::global_circular_buffer::create_global_circular_buffer_for_matmul_1d_recv_contig,
-        nb::keep_alive<0, 1>(),
-        nb::arg("mesh_device"),
-        nb::arg("program_configs"),
-        nb::arg("weights"),
-        nb::arg("bank_to_receivers"),
-        nb::arg("size"),
-        nb::arg("buffer_type") = tt::tt_metal::BufferType::L1,
-        nb::arg("support_multi_receiver_shards") = true);
 }
 
 }  // namespace ttnn::operations::experimental


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Cleanups to the DRAM-sender GlobalCircularBuffer / tensor-prefetcher API: rename to state intent, consolidate the two matmul factories behind layout auto-detection, and make dual-sender the production default for receiver-contiguous weights. The renames are behavior-preserving; the last change intentionally flips the default sender count for recv-contig weights that don't pass an explicit flag (single → dual).

Part of #46373 (*Finalize Tensor prefetcher API*) — advances that work but does not close the issue.

**1. Rename to state intent, not mechanism** (commits 1–2):
- `CreateGlobalCircularBufferWithDramSenders` → `CreateGlobalCircularBufferForTensorPrefetcher` (C++ metal + ttnn wrapper + `ttnn.experimental.create_global_circular_buffer_with_dram_senders` → `..._for_tensor_prefetcher`). The tensor prefetcher (`tt_metal/api/tt-metalium/experimental/tensor_prefetcher.hpp`) is the sole consumer and a same-namespace peer, so the factory joins the `*TensorPrefetcher*` family.
- Argument `bool dual_senders_per_bank = false` → `bool support_multi_receiver_shards = true` (inverted sense). `dual_senders_per_bank` baked in "exactly two," only today's Blackhole point. The new flag names the layout capability the GCB retains and reads coherently both ways: `true` = a bank's shard may feed multiple receivers (legacy interleaved) → one sender/bank; `false` = each receiver owns a disjoint contiguous shard (receiver-contiguous) → a bank may fan its receivers across multiple DRISC senders. Default value flips, behavior unchanged (single sender). Inversion is localized to the one boundary call; the private `build_dram_sender_mapping` keeps its mechanism-level param.

**2. Merge the recv-contig factory into `for_matmul_1d`** (commit 3):
- `create_global_circular_buffer_for_matmul_1d_recv_contig` is **removed**; its logic folds into `create_global_circular_buffer_for_matmul_1d`, which now auto-detects the weight's DRAM layout and dispatches:
  - legacy WIDTH_SHARDED (`buffer()->has_shard_spec()`) → K-row-major builder
  - NdShardSpec → receiver-contiguous builder
- Detection mirrors `tt_metal detect_layout_mode` — keyed on **allocation type, not shard count** (unambiguous when `total_receivers == num_banks`) — and must stay in sync with it, since the runtime prefetcher routes on the same discriminator. A local `is_receiver_contiguous_weight` helper carries a prominent cross-reference comment.
- All weights sharing one GCB must use the same layout (enforced). Callers no longer pick a layout-specific factory — the tensor determines what the prefetcher does. The two test call sites migrate to the unified factory.

**3. Dual senders become the production default for recv-contig** (commit 4):
- `support_multi_receiver_shards` on `for_matmul_1d` becomes `std::optional<bool>` (default `nullopt`). Unset ⇒ the per-bank sender count follows the detected layout: legacy → single sender (only option); receiver-contiguous → **dual senders** (highest per-bank bandwidth; single-receiver banks fall back to one automatically). An explicit value overrides — mainly tests/benches: `true` forces single, `false` forces dual; forcing dual on a legacy weight still `TT_FATAL`s.
- This makes dual-sender the default wherever the layout allows, per the always-dual direction, rather than an opt-in. **Behavior change:** a recv-contig caller that omits the flag now gets dual senders (previously single). Callers passing an explicit bool are unaffected.

### Notes for reviewers
- **Layout-detection sync** is the load-bearing correctness point: `is_receiver_contiguous_weight` (ttnn/core/global_circular_buffer.cpp) must classify identically to `detect_layout_mode` (tt_metal/impl/buffers/tensor_prefetcher_manager.cpp), else the factory's validation and the kernel's consumption disagree. Both key on **allocation type, not shard count** — because `num_shards == num_banks` (one receiver per bank) is identical for both layouts and can't discriminate them. Within that, `has_shard_spec()` is checked *first* and wins the tie: a legacy WIDTH_SHARDED tensor can carry both a legacy shard spec and an NdShardSpec-like BDS, so testing `nd_shard_spec()` first would misclassify legacy as recv-contig; an NdShardSpec-only buffer reports `has_shard_spec() == false`. (At one receiver per bank the two layouts are also the same physical GCB, so the count tie is benign in any case.)
- Sense-flip invariant: `dual_senders_per_bank == !support_multi_receiver_shards`, applied consistently; C++ tests never passed the flag, the Python benches invert at the ttnn boundary (`support_multi_receiver_shards=not dual_senders`, keeping their own knob).
- Dual-default blast radius: the streaming validator test (`test_prefetcher_BH_tensor_large.py`) omits the flag, so it now exercises the **dual-sender** recv-contig path by default (previously single). The benches pass an explicit value, so they're unaffected. These weren't run here (see below), so the dual path under that test's `stream_in1` shape is unverified on-device.
- Build verification: `ttnncpp` (the `_ttnncpp.so` nanobind module) rebuilt cleanly; the merged C++ symbol carries the trailing `std::optional<bool>`, and the removed `_recv_contig` Python name is absent from the `.so`. Full test-executable linking and the Python tests were **not** run (local disk-quota limit unrelated to this change).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/rename-tensor-prefetcher-gcb-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/rename-tensor-prefetcher-gcb-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/rename-tensor-prefetcher-gcb-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/rename-tensor-prefetcher-gcb-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jbauman/rename-tensor-prefetcher-gcb-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jbauman/rename-tensor-prefetcher-gcb-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/rename-tensor-prefetcher-gcb-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/rename-tensor-prefetcher-gcb-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/rename-tensor-prefetcher-gcb-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/rename-tensor-prefetcher-gcb-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/rename-tensor-prefetcher-gcb-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/rename-tensor-prefetcher-gcb-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/rename-tensor-prefetcher-gcb-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/rename-tensor-prefetcher-gcb-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/rename-tensor-prefetcher-gcb-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/rename-tensor-prefetcher-gcb-api)
