### PR TITLE
[skip ci] ci(sweeps): native category/owner tagging + budget-aware batching in compute_sweep_matrix

### DIFF
--- a/tests/sweep_framework/framework/compute_sweep_matrix.py
+++ b/tests/sweep_framework/framework/compute_sweep_matrix.py
@@ -38,10 +38,14 @@ from matrix_runner_config import (
     SCHEDULE_TYPES,
     SUPPORTED_VECTOR_GROUPING_MODES,
     SWEEP_TYPES,
+    get_category_metadata_for_module,
+    get_category_time_budget,
     get_lead_models_test_group_name_for_hardware_group,
     get_mesh_test_group_map,
+    get_module_runtime_estimate,
     get_runner_config,
     get_test_group_name_for_hardware_group,
+    resolve_batch_category_metadata,
 )
 
 DEFAULT_PRETTY_MATRIX_PATH = "tests/sweep_framework/framework/sweep_matrix.json"
@@ -99,6 +103,10 @@ def _build_entries(runner_config, batches, batch_display_prefix, suite_name):
     entries = []
     for batch in batches:
         base_display = f"{batch_display_prefix}:{batch}" if batch_display_prefix else batch
+        # Tag each job with its functional category + owner so CI failures are
+        # attributable. Single-category batches get their real owner; mixed
+        # batches fall back to the default sweep owner.
+        category_meta = resolve_batch_category_metadata(batch, strip_grouping_suffix)
         entries.append(
             {
                 **runner_config,
@@ -106,9 +114,35 @@ def _build_entries(runner_config, batches, batch_display_prefix, suite_name):
                 "batch_display": base_display,
                 "suite_name": suite_name,
                 "mesh_dims": "",
+                **category_meta,
             }
         )
     return entries
+
+
+def _budget_pack(modules, budget_seconds):
+    """Pack modules into comma-joined batches whose estimated runtime stays under
+    ``budget_seconds``.
+
+    Greedy first-fit over the module order: a module is added to the current
+    batch unless doing so would exceed the budget, in which case a new batch is
+    started. A single module always gets at least its own batch even if its own
+    estimate already exceeds the budget.
+    """
+    batches = []
+    current = []
+    current_cost = 0.0
+    for module in modules:
+        cost = get_module_runtime_estimate(module)
+        if current and current_cost + cost > budget_seconds:
+            batches.append(",".join(current))
+            current = []
+            current_cost = 0.0
+        current.append(module)
+        current_cost += cost
+    if current:
+        batches.append(",".join(current))
+    return batches
 
 
 def _load_generation_manifest(vectors_path):
@@ -353,18 +387,36 @@ def compute_model_traced_matrix(modules, batch_size, suite_name, grouping_mode=N
 
 
 def compute_standard_matrix(modules, batch_size, suite_name):
-    """Compute matrix for nightly/comprehensive runs."""
+    """Compute matrix for nightly/comprehensive runs.
+
+    Regular (non-CCL) modules are grouped by functional category first, so each
+    matrix entry carries a single category/owner and CI failures are
+    attributable to the owning team. Within a category, modules are batched by
+    time budget when the category declares one (``CATEGORY_TIME_BUDGET_SECONDS``)
+    and by fixed ``batch_size`` otherwise. CCL modules keep their dedicated N300
+    lane.
+    """
     base_modules = sorted(set(strip_grouping_suffix(m) for m in modules))
     ccl_modules = [m for m in base_modules if m.startswith("ccl.")]
     regular_modules = [m for m in base_modules if not m.startswith("ccl.")]
 
-    # Keep CCL modules off the default runner path; they get their own N300 lane below.
-    regular_batches = chunk_modules(regular_modules, batch_size)
-    ccl_batches = chunk_modules(ccl_modules, batch_size)
+    # Group regular modules by category so batches never straddle owners.
+    modules_by_category = defaultdict(list)
+    for module in regular_modules:
+        modules_by_category[get_category_metadata_for_module(module)["category"]].append(module)
 
     n150_config = _get_runner("wormhole-n150-sweeps")
-    include_entries = _build_entries(n150_config, regular_batches, "", suite_name)
+    regular_batches = []
+    include_entries = []
+    for category in sorted(modules_by_category):
+        cat_modules = modules_by_category[category]
+        budget = get_category_time_budget(category)
+        cat_batches = _budget_pack(cat_modules, budget) if budget else chunk_modules(cat_modules, batch_size)
+        regular_batches.extend(cat_batches)
+        include_entries.extend(_build_entries(n150_config, cat_batches, "", suite_name))
 
+    # Keep CCL modules off the default runner path; they get their own N300 lane.
+    ccl_batches = chunk_modules(ccl_modules, batch_size)
     if ccl_batches:
         ccl_config = _get_runner("n300-llmbox-ccl")
         include_entries.extend(_build_entries(ccl_config, ccl_batches, "ccl", "generality_suite_fabric_1d"))

--- a/tests/sweep_framework/framework/compute_sweep_matrix_README.md
+++ b/tests/sweep_framework/framework/compute_sweep_matrix_README.md
@@ -90,6 +90,28 @@ export SWEEP_NAME="ALL SWEEPS (Nightly)"
 python3 tests/sweep_framework/framework/compute_sweep_matrix.py | python3 -m json.tool
 ```
 
+## Module ownership, categories, and time budgets
+
+Every matrix entry is tagged with a functional **category**, an **owner** (Slack
+member id), and a **team** so a failing sweep job is attributable to the team
+that owns it (consumed by `ttnn-sweeps-slack-notify.yaml`). This policy lives in
+`matrix_runner_config.py` and is produced natively by the matrix builder — there
+is no separate static category list to keep in sync.
+
+- **Category** is the leading segment of the module stem, i.e. the top-level
+  directory under `tests/sweep_framework/sweeps/` (`eltwise.unary.relu` →
+  `eltwise`). Ownership is `SWEEP_CATEGORY_OWNERS`; unlisted categories fall back
+  to `DEFAULT_CATEGORY_METADATA`.
+- **Attributable jobs**: `compute_standard_matrix` groups regular modules by
+  category *before* batching, so a single job never straddles two owners. Mixed
+  batches (possible on the mesh/hardware-routed lead-models / model-traced paths)
+  fall back to the default owner.
+- **Time budgets** (opt-in): set `CATEGORY_TIME_BUDGET_SECONDS[<category>]` and
+  that category is packed into batches whose estimated runtime stays under the
+  budget (`_budget_pack`), instead of a fixed module count. Per-module estimates
+  come from `MODULE_RUNTIME_ESTIMATES` (seed from CI history), defaulting to
+  `DEFAULT_MODULE_RUNTIME_SECONDS`. Categories with no budget are unchanged.
+
 ## Related Files
 
 - `.github/workflows/ttnn-run-sweeps.yaml` — workflow that calls this script

--- a/tests/sweep_framework/framework/matrix_runner_config.py
+++ b/tests/sweep_framework/framework/matrix_runner_config.py
@@ -286,9 +286,107 @@ LOCAL_HARDWARE_MESH_CAPABILITY_RULES = (
 )
 
 
+# ── Sweep module ownership: category, owner, and time budget ─────────────────
+# The routing maps above answer "which physical runner lane runs this vector
+# file?". This block answers a different, op-level question that CI failure
+# triage needs: "which functional category does a sweep module belong to, who
+# owns it, and how long should one CI job for that category run?"
+#
+# Keyed by the leading segment of the sweep module stem — the top-level directory
+# under tests/sweep_framework/sweeps/ (e.g. "eltwise.unary.relu" -> "eltwise").
+# A module whose category is not listed falls back to DEFAULT_CATEGORY_METADATA.
+#
+# ``owner_id`` is a Slack member id consumed by ttnn-sweeps-slack-notify.yaml to
+# ping the owning team on failure. Until per-category owners are assigned they
+# inherit the sweep-suite default owner; fill in real owners incrementally.
+
+DEFAULT_SWEEP_OWNER_ID = "U08T3JQEB36"  # stevendae (current ttnn_sweep_tests.yaml owner)
+DEFAULT_SWEEP_TEAM = "ttnn"
+
+DEFAULT_CATEGORY_METADATA = {
+    "category": "sweep",
+    "owner_id": DEFAULT_SWEEP_OWNER_ID,
+    "team": DEFAULT_SWEEP_TEAM,
+}
+
+# category (sweeps/ top-level dir) -> {owner_id, team}.
+SWEEP_CATEGORY_OWNERS = {
+    "ccl": {"owner_id": DEFAULT_SWEEP_OWNER_ID, "team": DEFAULT_SWEEP_TEAM},
+    "composite": {"owner_id": DEFAULT_SWEEP_OWNER_ID, "team": DEFAULT_SWEEP_TEAM},
+    "conv2d": {"owner_id": DEFAULT_SWEEP_OWNER_ID, "team": DEFAULT_SWEEP_TEAM},
+    "conv_transpose2d": {"owner_id": DEFAULT_SWEEP_OWNER_ID, "team": DEFAULT_SWEEP_TEAM},
+    "creation": {"owner_id": DEFAULT_SWEEP_OWNER_ID, "team": DEFAULT_SWEEP_TEAM},
+    "data_movement": {"owner_id": DEFAULT_SWEEP_OWNER_ID, "team": DEFAULT_SWEEP_TEAM},
+    "eltwise": {"owner_id": DEFAULT_SWEEP_OWNER_ID, "team": DEFAULT_SWEEP_TEAM},
+    "embedding": {"owner_id": DEFAULT_SWEEP_OWNER_ID, "team": DEFAULT_SWEEP_TEAM},
+    "embedding_bw": {"owner_id": DEFAULT_SWEEP_OWNER_ID, "team": DEFAULT_SWEEP_TEAM},
+    "fused": {"owner_id": DEFAULT_SWEEP_OWNER_ID, "team": DEFAULT_SWEEP_TEAM},
+    "losses": {"owner_id": DEFAULT_SWEEP_OWNER_ID, "team": DEFAULT_SWEEP_TEAM},
+    "matmul": {"owner_id": DEFAULT_SWEEP_OWNER_ID, "team": DEFAULT_SWEEP_TEAM},
+    "model_traced": {"owner_id": DEFAULT_SWEEP_OWNER_ID, "team": DEFAULT_SWEEP_TEAM},
+    "normalization": {"owner_id": DEFAULT_SWEEP_OWNER_ID, "team": DEFAULT_SWEEP_TEAM},
+    "pool2d": {"owner_id": DEFAULT_SWEEP_OWNER_ID, "team": DEFAULT_SWEEP_TEAM},
+    "reduction": {"owner_id": DEFAULT_SWEEP_OWNER_ID, "team": DEFAULT_SWEEP_TEAM},
+    "transformer": {"owner_id": DEFAULT_SWEEP_OWNER_ID, "team": DEFAULT_SWEEP_TEAM},
+}
+
+# Per-category CI job wall-clock budget (seconds). When a category sets a budget,
+# compute_sweep_matrix packs its modules into batches whose *estimated* runtime
+# stays under this ceiling instead of using a fixed module count. Categories with
+# no entry keep the caller's fixed ``batch_size`` behavior (no behavior change).
+CATEGORY_TIME_BUDGET_SECONDS = {}
+
+# Per-module runtime estimate (seconds) used by budget packing. Seed from CI
+# history as data becomes available; unlisted modules use the nominal default.
+DEFAULT_MODULE_RUNTIME_SECONDS = 300
+MODULE_RUNTIME_ESTIMATES = {}
+
+
 # ── Routing helpers ───────────────────────────────────────────────────────────
 # Resolve ``test_group_name`` / runner payloads for ``compute_*_matrix`` and
 # ``main`` output splitting.
+
+
+def get_category_for_module(module_stem):
+    """Return the functional category (sweeps/ top-level dir) for a module stem."""
+    return module_stem.split(".", 1)[0] if module_stem else ""
+
+
+def get_category_metadata_for_module(module_stem):
+    """Resolve a module stem to ``{category, owner_id, team}``."""
+    category = get_category_for_module(module_stem)
+    owner = SWEEP_CATEGORY_OWNERS.get(category)
+    if owner is None:
+        return dict(DEFAULT_CATEGORY_METADATA)
+    return {"category": category, "owner_id": owner["owner_id"], "team": owner["team"]}
+
+
+def resolve_batch_category_metadata(batch_selector, strip_fn):
+    """Resolve ``{category, owner_id, team}`` for a comma-joined batch of stems.
+
+    Returns the shared metadata when every module in the batch maps to the same
+    category; otherwise falls back to ``DEFAULT_CATEGORY_METADATA`` (a mixed
+    batch has no single owner). ``strip_fn`` removes any grouping suffix so the
+    stem matches the category map — kept as a parameter so this module stays free
+    of the ``constants.py`` filename-parsing dependency.
+    """
+    modules = [m for m in batch_selector.split(",") if m]
+    if not modules:
+        return dict(DEFAULT_CATEGORY_METADATA)
+    categories = {get_category_for_module(strip_fn(m)) for m in modules}
+    if len(categories) == 1:
+        return get_category_metadata_for_module(strip_fn(modules[0]))
+    return dict(DEFAULT_CATEGORY_METADATA)
+
+
+def get_module_runtime_estimate(module_stem):
+    """Return the runtime estimate (seconds) used for budget packing."""
+    return MODULE_RUNTIME_ESTIMATES.get(module_stem, DEFAULT_MODULE_RUNTIME_SECONDS)
+
+
+def get_category_time_budget(category):
+    """Return the per-job wall-clock budget (seconds) for a category, or ``None``."""
+    return CATEGORY_TIME_BUDGET_SECONDS.get(category)
 
 
 def get_runner_config(test_group_name):


### PR DESCRIPTION
## What

Make `compute_sweep_matrix.py` produce **budget-aware, owner-tagged category groups natively**, instead of the static-YAML + inject-script approach attempted in #49169.

Every sweep matrix entry now carries three new fields — `category`, `owner_id` (Slack member id), `team` — so a failing sweep job is attributable to the owning team (ready for `ttnn-sweeps-slack-notify.yaml` to consume). Categories can also opt into **time-budget batching** instead of a fixed module count.

## Why this shape (vs #49169)

#49169 added a *parallel* static category system (per-category `ttnn_sweep_*_tests.yaml` + `inject_module_selectors.py` + a workflow rewrite) alongside the existing dynamic generator. Its review bugs — empty `ENABLED_SKUS`, unguarded `matrix.category`, the `contains(",\($c)")` prefix false-match — all lived at the *seam* between the two systems. The generator already groups dynamically; this PR moves category/owner/budget into it so there is a single source of truth and no seam.

## Changes

- **`matrix_runner_config.py`** — new config block: `SWEEP_CATEGORY_OWNERS` (category → owner/team, keyed by the `sweeps/` top-level dir), `DEFAULT_CATEGORY_METADATA`, opt-in `CATEGORY_TIME_BUDGET_SECONDS`, `MODULE_RUNTIME_ESTIMATES` (+ `DEFAULT_MODULE_RUNTIME_SECONDS`). Helpers: `get_category_for_module`, `get_category_metadata_for_module`, `resolve_batch_category_metadata`, `get_module_runtime_estimate`, `get_category_time_budget`.
- **`compute_sweep_matrix.py`** — `_build_entries` tags every entry with resolved category metadata (single-category batch → real owner; mixed batch → default). New `_budget_pack` greedy first-fit batcher. `compute_standard_matrix` now groups regular modules **by category before batching** so a job never straddles two owners, and batches by time budget when the category declares one (else unchanged fixed `batch_size`).
- **`compute_sweep_matrix_README.md`** — documents the ownership/category/budget model.

## Non-breaking

New matrix keys are additive — the workflow ignores unknown include keys, so nothing downstream changes until it opts in. With no `CATEGORY_TIME_BUDGET_SECONDS` entries, batching is byte-identical to today except regular batches are now grouped per category (attributable) rather than mixed.

## Follow-ups (draft)

- Per-category owners currently inherit the default sweep owner (`stevendae`) — fill in real owners incrementally.
- Time budgets + per-module estimates are scaffolded but empty; seed `MODULE_RUNTIME_ESTIMATES` from CI history to enable budget packing.
- Category-first batching is applied to the standard (nightly/comprehensive) path; the mesh/hardware-routed lead-models & model-traced paths are tag-only for now (mixed batches → default owner).

Draft for direction review — not for merge.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=brain/sweep-matrix-category-ownership)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:brain/sweep-matrix-category-ownership)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=brain/sweep-matrix-category-ownership)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:brain/sweep-matrix-category-ownership)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=brain/sweep-matrix-category-ownership)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:brain/sweep-matrix-category-ownership)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=brain/sweep-matrix-category-ownership)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:brain/sweep-matrix-category-ownership)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=brain/sweep-matrix-category-ownership)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:brain/sweep-matrix-category-ownership)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=brain/sweep-matrix-category-ownership)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:brain/sweep-matrix-category-ownership)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=brain/sweep-matrix-category-ownership)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:brain/sweep-matrix-category-ownership)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=brain/sweep-matrix-category-ownership)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:brain/sweep-matrix-category-ownership)