### PR TITLE
[skip ci] CODEOWNERS: fix ds-prefill test ownership override

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -332,7 +332,6 @@ ttnn/cpp/ttnn/operations/experimental/cnn/ @tenstorrent/metalium-developers-conv
 ttnn/cpp/ttnn/operations/experimental/cnn/**/CMakeLists.txt @tenstorrent/metalium-developers-convolutions @esmalTT @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/ @tenstorrent/metalium-developers-ds-prefill @tenstorrent/codeowner-bypass
 ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/**/CMakeLists.txt @tenstorrent/metalium-developers-ds-prefill @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
-tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/ @tenstorrent/metalium-developers-ds-prefill @tenstorrent/codeowner-bypass
 ttnn/cpp/ttnn/operations/experimental/experimental_nanobind.cpp @mbezuljTT @ppetrovicTT @pavlepopovic @tenstorrent/metalium-developers-ops-leads @tenstorrent/codeowner-bypass
 ttnn/CMakeLists.txt @mbezuljTT @ppetrovicTT @pavlepopovic @tenstorrent/metalium-developers-ttnn-core @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 ttnn/sources.cmake @mbezuljTT @ppetrovicTT @pavlepopovic @tenstorrent/metalium-developers-ttnn-core @tenstorrent/codeowner-bypass
@@ -430,6 +429,7 @@ tests/ttnn/nightly/unit_tests/operations/reduction/ @tenstorrent/metalium-develo
 tests/ttnn/nightly/unit_tests/operations/transformers/ @tenstorrent/metallium-maintainers-llama-models @tenstorrent/codeowner-bypass
 tests/ttnn/unit_tests/operations/sdpa/ @tenstorrent/metalium-developers-sdpa @tenstorrent/codeowner-bypass
 tests/ttnn/nightly/unit_tests/operations/sdpa/ @tenstorrent/metalium-developers-sdpa @tenstorrent/codeowner-bypass
+tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/ @tenstorrent/metalium-developers-ds-prefill @tenstorrent/codeowner-bypass
 tests/ttnn/nightly/unit_tests/operations/experimental/test_topk_large_indices.py @tenstorrent/metalium-developers-sdpa @tenstorrent/codeowner-bypass
 tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py @tenstorrent/metalium-developers-sdpa @tenstorrent/codeowner-bypass
 tests/ttnn/nightly/unit_tests/operations/eltwise/ @tenstorrent/metalium-developers-eltwise @tenstorrent/codeowner-bypass


### PR DESCRIPTION
### PR Category
Infra / CODEOWNERS

### Summary
Fixes the code ownership of the deepseek_prefill nightly tests. Surfaced on #49811, where the prefill team was **not** requested as reviewer for changes under `tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/`.

### Root cause
`CODEOWNERS` is **last-match-wins**, not most-specific. The ds-prefill test rule was placed in the ops-source block (before the broad `tests/ttnn/` rule):

```
tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/ @tenstorrent/metalium-developers-ds-prefill ...
...
tests/ttnn/ @tenstorrent/metalium-developers-ttnn-core ...
```

Because `tests/ttnn/` appears later and also matches the deepseek_prefill test path, it overrode the ds-prefill rule and assigned those tests to ttnn-core.

### Fix
Move the rule into the tests block, after `tests/ttnn/` and alongside its siblings (sdpa/topk/indexer), so the prefill team correctly owns its tests. No owner set changed — only rule ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
