### PR TITLE
[skip ci]  fix per-job owner_id on single_card_ttnn_models_frequent_tests.yaml

### DIFF
--- a/tests/pipeline_reorg/single_card_ttnn_models_frequent_tests.yaml
+++ b/tests/pipeline_reorg/single_card_ttnn_models_frequent_tests.yaml
@@ -42,7 +42,7 @@
       timeout: 30
     wh_n300:
       timeout: 30
-  owner_id: U03PUAKE719 # TODO: verify owner. CODEOWNERS: @tenstorrent/metalium-developers-convolutions (team, no individual)
+  owner_id: U085GDCAZTN # Pavle Josipovic (top contributor; CODEOWNERS team @tenstorrent/metalium-developers-convolutions)
   team: models
 - name: openpdn_mnist nightly
   cmd: $PYTEST_CMD tests/nightly/single_card/openpdn_mnist
@@ -52,7 +52,7 @@
       timeout: 30
     wh_n300:
       timeout: 30
-  owner_id: U03PUAKE719 # TODO: verify owner. CODEOWNERS: @tenstorrent/cse-developer-ttnn (team, no individual)
+  owner_id: U088413NP0Q # Ashai Reddy Ginuga (CODEOWNERS team @tenstorrent/cse-developer-ttnn)
   team: models
 - name: vit nightly
   cmd: |

--- a/tests/pipeline_reorg/single_card_ttnn_models_frequent_tests.yaml
+++ b/tests/pipeline_reorg/single_card_ttnn_models_frequent_tests.yaml
@@ -261,7 +261,7 @@
       timeout: 30
     wh_n300_civ2:
       timeout: 30
-  owner_id: U03PUAKE719 # Miguel Tairum (@mtairum)
+  owner_id: U088413NP0Q # Ashai Reddy Ginuga
   team: models
 
 # Blackhole frequent model tests

--- a/tests/pipeline_reorg/single_card_ttnn_models_frequent_tests.yaml
+++ b/tests/pipeline_reorg/single_card_ttnn_models_frequent_tests.yaml
@@ -22,7 +22,7 @@
       timeout: 30
     wh_n300:
       timeout: 30
-  owner_id: U03PUAKE719 # TODO: verify owner. CODEOWNERS: @gtobarTT (no known Slack ID)
+  owner_id: U082LLYBLSW # Gabriel Tobar (CODEOWNERS @gtobarTT)
   team: models
 - name: common_models nightly
   cmd: $PYTEST_CMD tests/nightly/single_card/common_models
@@ -32,7 +32,7 @@
       timeout: 30
     wh_n300:
       timeout: 30
-  owner_id: U03PUAKE719 # TODO: verify owner. No CODEOWNERS model dir (falls to /models/ catch-all)
+  owner_id: U03PUAKE719 # Miguel Tairum (@mtairum)
   team: models
 - name: resnet50 nightly
   cmd: $PYTEST_CMD tests/nightly/single_card/resnet50
@@ -156,7 +156,7 @@
       timeout: 30
     wh_n300:
       timeout: 30
-  owner_id: U03PUAKE719 # TODO: verify owner. CODEOWNERS: @ssinghalTT (no known Slack ID)
+  owner_id: U087HGJ455E # (CODEOWNERS @ssinghalTT)
   team: models
 - name: efficientdetd0 nightly
   cmd: $PYTEST_CMD tests/nightly/single_card/efficientdetd0
@@ -176,7 +176,7 @@
       timeout: 30
     wh_n300:
       timeout: 30
-  owner_id: U03PUAKE719 # TODO: verify owner. CODEOWNERS: @ssinghalTT (no known Slack ID)
+  owner_id: U087HGJ455E # (CODEOWNERS @ssinghalTT)
   team: models
 - name: ssd512 nightly
   cmd: $PYTEST_CMD tests/nightly/single_card/ssd512
@@ -196,7 +196,7 @@
       timeout: 30
     wh_n300:
       timeout: 30
-  owner_id: U03PUAKE719 # TODO: verify owner. CODEOWNERS first: @tvardhineniTT (no known Slack ID); 2nd @dvartaniansTT = U056BK5U81E
+  owner_id: U0978501V8B # (CODEOWNERS @tvardhineniTT)
   team: models
 - name: retinanet nightly
   cmd: $PYTEST_CMD tests/nightly/single_card/retinanet
@@ -261,7 +261,7 @@
       timeout: 30
     wh_n300_civ2:
       timeout: 30
-  owner_id: U03PUAKE719 # TODO: verify owner. No CODEOWNERS model dir (falls to /models/ catch-all)
+  owner_id: U03PUAKE719 # Miguel Tairum (@mtairum)
   team: models
 
 # Blackhole frequent model tests

--- a/tests/pipeline_reorg/single_card_ttnn_models_frequent_tests.yaml
+++ b/tests/pipeline_reorg/single_card_ttnn_models_frequent_tests.yaml
@@ -32,7 +32,7 @@
       timeout: 30
     wh_n300:
       timeout: 30
-  owner_id: U03PUAKE719 # Miguel Tairum (@mtairum)
+  owner_id: U087S3K319A # Austin Ho (CODEOWNERS @tt-aho, models/demos/metal_BERT_large_11)
   team: models
 - name: resnet50 nightly
   cmd: $PYTEST_CMD tests/nightly/single_card/resnet50

--- a/tests/pipeline_reorg/single_card_ttnn_models_frequent_tests.yaml
+++ b/tests/pipeline_reorg/single_card_ttnn_models_frequent_tests.yaml
@@ -22,7 +22,7 @@
       timeout: 30
     wh_n300:
       timeout: 30
-  owner_id: U03PUAKE719 # Miguel Tairum Cruz
+  owner_id: U03PUAKE719 # TODO: verify owner. CODEOWNERS: @gtobarTT (no known Slack ID)
   team: models
 - name: common_models nightly
   cmd: $PYTEST_CMD tests/nightly/single_card/common_models
@@ -32,7 +32,7 @@
       timeout: 30
     wh_n300:
       timeout: 30
-  owner_id: U03PUAKE719
+  owner_id: U03PUAKE719 # TODO: verify owner. No CODEOWNERS model dir (falls to /models/ catch-all)
   team: models
 - name: resnet50 nightly
   cmd: $PYTEST_CMD tests/nightly/single_card/resnet50
@@ -42,7 +42,7 @@
       timeout: 30
     wh_n300:
       timeout: 30
-  owner_id: U03PUAKE719
+  owner_id: U03PUAKE719 # TODO: verify owner. CODEOWNERS: @tenstorrent/metalium-developers-convolutions (team, no individual)
   team: models
 - name: openpdn_mnist nightly
   cmd: $PYTEST_CMD tests/nightly/single_card/openpdn_mnist
@@ -52,7 +52,7 @@
       timeout: 30
     wh_n300:
       timeout: 30
-  owner_id: U03PUAKE719
+  owner_id: U03PUAKE719 # TODO: verify owner. CODEOWNERS: @tenstorrent/cse-developer-ttnn (team, no individual)
   team: models
 - name: vit nightly
   cmd: |
@@ -64,7 +64,7 @@
       timeout: 30
     wh_n300:
       timeout: 30
-  owner_id: U03PUAKE719
+  owner_id: U088413NP0Q # Ashai Reddy Ginuga (CODEOWNERS @arginugaTT)
   team: models
 - name: sentence_bert nightly
   cmd: $PYTEST_CMD tests/nightly/single_card/sentence_bert
@@ -74,7 +74,7 @@
       timeout: 30
     wh_n300:
       timeout: 30
-  owner_id: U03PUAKE719
+  owner_id: U088413NP0Q # Ashai Reddy Ginuga (CODEOWNERS @arginugaTT)
   team: models
 - name: swin_s nightly
   cmd: $PYTEST_CMD tests/nightly/single_card/swin_s
@@ -84,7 +84,7 @@
       timeout: 30
     wh_n300:
       timeout: 30
-  owner_id: U03PUAKE719
+  owner_id: U088413NP0Q # Ashai Reddy Ginuga (CODEOWNERS @arginugaTT)
   team: models
 - name: swin_v2 nightly
   cmd: $PYTEST_CMD tests/nightly/single_card/swin_v2
@@ -94,7 +94,7 @@
       timeout: 30
     wh_n300:
       timeout: 30
-  owner_id: U03PUAKE719
+  owner_id: U088413NP0Q # Ashai Reddy Ginuga (CODEOWNERS @arginugaTT)
   team: models
 - name: mobilenetv2 nightly
   cmd: $PYTEST_CMD tests/nightly/single_card/mobilenetv2
@@ -104,7 +104,7 @@
       timeout: 30
     wh_n300:
       timeout: 30
-  owner_id: U03PUAKE719
+  owner_id: U056BK5U81E # Dalar Vartanians (CODEOWNERS @dvartaniansTT)
   team: models
 - name: mobilenetv3 nightly
   cmd: $PYTEST_CMD tests/nightly/single_card/mobilenetv3
@@ -114,7 +114,7 @@
       timeout: 30
     wh_n300:
       timeout: 30
-  owner_id: U03PUAKE719
+  owner_id: U056BK5U81E # Dalar Vartanians (CODEOWNERS @dvartaniansTT)
   team: models
 - name: segformer nightly
   cmd: |
@@ -126,7 +126,7 @@
       timeout: 30
     wh_n300:
       timeout: 30
-  owner_id: U03PUAKE719
+  owner_id: U088413NP0Q # Ashai Reddy Ginuga (CODEOWNERS @arginugaTT)
   team: models
 - name: vgg_unet nightly
   cmd: $PYTEST_CMD tests/nightly/single_card/vgg_unet
@@ -136,7 +136,7 @@
       timeout: 30
     wh_n300:
       timeout: 30
-  owner_id: U03PUAKE719
+  owner_id: U056BK5U81E # Dalar Vartanians (CODEOWNERS @dvartaniansTT)
   team: models
 - name: vanilla_unet nightly
   cmd: $PYTEST_CMD tests/nightly/single_card/vanilla_unet
@@ -146,7 +146,7 @@
       timeout: 30
     wh_n300:
       timeout: 30
-  owner_id: U03PUAKE719
+  owner_id: U056BK5U81E # Dalar Vartanians (CODEOWNERS @dvartaniansTT)
   team: models
 - name: efficientnetb0 nightly
   cmd: $PYTEST_CMD tests/nightly/single_card/efficientnetb0
@@ -156,7 +156,7 @@
       timeout: 30
     wh_n300:
       timeout: 30
-  owner_id: U03PUAKE719
+  owner_id: U03PUAKE719 # TODO: verify owner. CODEOWNERS: @ssinghalTT (no known Slack ID)
   team: models
 - name: efficientdetd0 nightly
   cmd: $PYTEST_CMD tests/nightly/single_card/efficientdetd0
@@ -166,7 +166,7 @@
       timeout: 30
     wh_n300:
       timeout: 30
-  owner_id: U03PUAKE719
+  owner_id: U056BK5U81E # Dalar Vartanians (CODEOWNERS @dvartaniansTT)
   team: models
 - name: vovnet nightly
   cmd: $PYTEST_CMD tests/nightly/single_card/vovnet
@@ -176,7 +176,7 @@
       timeout: 30
     wh_n300:
       timeout: 30
-  owner_id: U03PUAKE719
+  owner_id: U03PUAKE719 # TODO: verify owner. CODEOWNERS: @ssinghalTT (no known Slack ID)
   team: models
 - name: ssd512 nightly
   cmd: $PYTEST_CMD tests/nightly/single_card/ssd512
@@ -186,7 +186,7 @@
       timeout: 30
     wh_n300:
       timeout: 30
-  owner_id: U03PUAKE719
+  owner_id: U056BK5U81E # Dalar Vartanians (CODEOWNERS @dvartaniansTT)
   team: models
 - name: yunet nightly
   cmd: $PYTEST_CMD tests/nightly/single_card/yunet
@@ -196,7 +196,7 @@
       timeout: 30
     wh_n300:
       timeout: 30
-  owner_id: U03PUAKE719
+  owner_id: U03PUAKE719 # TODO: verify owner. CODEOWNERS first: @tvardhineniTT (no known Slack ID); 2nd @dvartaniansTT = U056BK5U81E
   team: models
 - name: retinanet nightly
   cmd: $PYTEST_CMD tests/nightly/single_card/retinanet
@@ -206,7 +206,7 @@
       timeout: 30
     wh_n300:
       timeout: 30
-  owner_id: U03PUAKE719
+  owner_id: U056BK5U81E # Dalar Vartanians (CODEOWNERS @dvartaniansTT)
   team: models
 - name: ufld_v2 nightly
   cmd: $PYTEST_CMD tests/nightly/single_card/ufld_v2
@@ -216,7 +216,7 @@
       timeout: 30
     wh_n300:
       timeout: 30
-  owner_id: U03PUAKE719
+  owner_id: U056BK5U81E # Dalar Vartanians (CODEOWNERS @dvartaniansTT)
   team: models
 
 # Wormhole models with extended timeouts / special commands
@@ -236,7 +236,7 @@
       timeout: 120
     wh_n300:
       timeout: 120
-  owner_id: U03PUAKE719
+  owner_id: U08E1JCMAJF # Marko Bezulj (CODEOWNERS @mbezuljTT)
   team: models
 - name: stable_diffusion nightly
   cmd: |
@@ -249,7 +249,7 @@
       timeout: 45
     wh_n300:
       timeout: 45
-  owner_id: U03PUAKE719
+  owner_id: U06ECNVR0EN # Evan Smal (CODEOWNERS @esmalTT)
   team: models
 
 # CIv2 wormhole tests
@@ -261,7 +261,7 @@
       timeout: 30
     wh_n300_civ2:
       timeout: 30
-  owner_id: U03PUAKE719
+  owner_id: U03PUAKE719 # TODO: verify owner. No CODEOWNERS model dir (falls to /models/ catch-all)
   team: models
 
 # Blackhole frequent model tests
@@ -278,5 +278,5 @@
   skus:
     bh_p150b_civ2:
       timeout: 120
-  owner_id: U03PUAKE719
+  owner_id: U08E1JCMAJF # Marko Bezulj (CODEOWNERS @mbezuljTT)
   team: models


### PR DESCRIPTION
## What

Follow-up to #49743. The new single-card frequent model tests matrix (`tests/pipeline_reorg/single_card_ttnn_models_frequent_tests.yaml`) had **every** job assigned the same placeholder `owner_id: U03PUAKE719` (Miguel Tairum), so all failure notifications would route to one person regardless of the model.

This PR maps each job to its model source directory in `.github/CODEOWNERS` and sets `owner_id` to the **first individual code owner**, resolving the Slack ID from the owner_ids already used in sibling pipeline yamls.

## Changed (16 jobs)

| Owner | Slack ID | Jobs |
|-------|----------|------|
| Ashai Reddy Ginuga (`@arginugaTT`) | `U088413NP0Q` | vit, sentence_bert, swin_s, swin_v2, segformer |
| Dalar Vartanians (`@dvartaniansTT`) | `U056BK5U81E` | mobilenetv2, mobilenetv3, vgg_unet, vanilla_unet, efficientdetd0, ssd512, retinanet, ufld_v2 |
| Marko Bezulj (`@mbezuljTT`) | `U08E1JCMAJF` | stable_diffusion_xl_base (WH + BH) |
| Evan Smal (`@esmalTT`) | `U06ECNVR0EN` | stable_diffusion |

## Left as placeholder — needs manual review (8 jobs)

Kept `owner_id: U03PUAKE719` with an inline `# TODO` because CODEOWNERS doesn't give a mappable individual:

- **`bge_m3`** — CODEOWNERS `@gtobarTT` (no known Slack ID)
- **`efficientnetb0`**, **`vovnet`** — CODEOWNERS `@ssinghalTT` (no known Slack ID)
- **`yunet`** — first owner `@tvardhineniTT` (no known Slack ID); 2nd is `@dvartaniansTT` = `U056BK5U81E` if we prefer that
- **`resnet50`** — only `@tenstorrent/metalium-developers-convolutions` (team, no individual)
- **`openpdn_mnist`** — only `@tenstorrent/cse-developer-ttnn` (team, no individual)
- **`common_models`**, **`vadv2`** — no dedicated CODEOWNERS model dir (falls to `/models/` catch-all)

## Notes

- `owner_id` is a **Slack** ID; CODEOWNERS uses **GitHub** handles. Slack IDs were bridged from existing `owner_id` entries in the other `tests/pipeline_reorg/*.yaml` files.
- There is no CODEOWNERS rule for the `tests/nightly/single_card/` test paths themselves, so ownership was resolved via each model's `models/...` source dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/fix-frequent-tests-owners)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/fix-frequent-tests-owners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/fix-frequent-tests-owners)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/fix-frequent-tests-owners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mtairum/fix-frequent-tests-owners)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mtairum/fix-frequent-tests-owners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/fix-frequent-tests-owners)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/fix-frequent-tests-owners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/fix-frequent-tests-owners)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/fix-frequent-tests-owners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/fix-frequent-tests-owners)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/fix-frequent-tests-owners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/fix-frequent-tests-owners)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/fix-frequent-tests-owners)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/fix-frequent-tests-owners)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/fix-frequent-tests-owners)