### PR TITLE
[Feature] DCAMP-1042 - Create a minimal Docker image for the cabling generator

### DIFF
--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -54,6 +54,7 @@ env:
   BLACKHOLE_P300_IMAGE_NAME: ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-p300
   BLACKHOLE_QB_GE_IMAGE_NAME: ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-qb-ge
   BLACKHOLE_GLX_IMAGE_NAME: ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-glx
+  CABLING_GENERATOR_IMAGE_NAME: ghcr.io/tenstorrent/tt-metal/scaleout-cabling-generator
 
 jobs:
   check-harbor:
@@ -255,6 +256,56 @@ jobs:
           context: ${{ github.workspace }}
           build-args: |
             TECHDEBT_INSTALL_TTT_REQS=${{ matrix.image-config.techdebt-install-ttt-reqs && 'true' || 'false' }}
+          outputs: |
+            type=registry,push=true,compression=zstd,compression-level=3,force-compression=true,oci-mediatypes=true
+  build-cabling-generator-image:
+    needs:
+      - build-artifact
+      - get-image-tags
+    permissions:
+      packages: write
+      contents: read
+    runs-on: tt-ubuntu-2204-large-stable
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        timeout-minutes: 20
+      - name: Download artifacts from metal
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      - name: Extract build artifact
+        run: |
+          mkdir -p _tt-metal
+          tar --zstd -xf ttm_any.tar.zst -C _tt-metal/
+          ls -hal _tt-metal/build/tools/scaleout/run_cabling_generator
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Compute tags
+        id: tags
+        run: |
+          suffix="${{ needs.get-image-tags.outputs.image-tag-suffix }}"
+          TAGS="${{ env.CABLING_GENERATOR_IMAGE_NAME }}:${suffix}"
+          # Move :latest only on main (scheduled runs on main and dispatches from main).
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            TAGS="${TAGS}"$'\n'"${{ env.CABLING_GENERATOR_IMAGE_NAME }}:latest"
+          fi
+          {
+            echo "tags<<EOF"
+            echo "$TAGS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          file: dockerfile/scaleout_cabling_generator/Dockerfile
+          platforms: linux/amd64
+          pull: true
+          tags: ${{ steps.tags.outputs.tags }}
+          context: ${{ github.workspace }}
           outputs: |
             type=registry,push=true,compression=zstd,compression-level=3,force-compression=true,oci-mediatypes=true
   test-wh-6u-image:

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -284,13 +284,15 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Compute tags
+      - name: Compute tags and Ubuntu version
         id: tags
         run: |
           suffix="${{ needs.get-image-tags.outputs.image-tag-suffix }}"
           TAGS="${{ env.CABLING_GENERATOR_IMAGE_NAME }}:${suffix}"
-          # Move :latest only on main (scheduled runs on main and dispatches from main).
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          # Move :latest on main, or when explicitly requested for a non-main dispatch.
+          # Mirrors the push-latest job's update-latest-via-branch gating so this image
+          # doesn't go stale relative to the upstream test images.
+          if [ "${{ github.ref }}" = "refs/heads/main" ] || [ "${{ inputs.update-latest-via-branch }}" = "true" ]; then
             TAGS="${TAGS}"$'\n'"${{ env.CABLING_GENERATOR_IMAGE_NAME }}:latest"
           fi
           {
@@ -298,6 +300,10 @@ jobs:
             echo "$TAGS"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
+          # Runtime base must match the version the binary was built against so glibc
+          # is compatible. "Ubuntu 22.04" -> "22.04", "Ubuntu 24.04" -> "24.04".
+          platform="${{ inputs.platform || 'Ubuntu 22.04' }}"
+          echo "ubuntu-version=${platform#Ubuntu }" >> "$GITHUB_OUTPUT"
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -306,6 +312,8 @@ jobs:
           pull: true
           tags: ${{ steps.tags.outputs.tags }}
           context: ${{ github.workspace }}
+          build-args: |
+            UBUNTU_VERSION=${{ steps.tags.outputs.ubuntu-version }}
           outputs: |
             type=registry,push=true,compression=zstd,compression-level=3,force-compression=true,oci-mediatypes=true
   test-wh-6u-image:

--- a/dockerfile/scaleout_cabling_generator/Dockerfile
+++ b/dockerfile/scaleout_cabling_generator/Dockerfile
@@ -53,6 +53,12 @@ ENV LD_LIBRARY_PATH=/opt/tt-metal/build/lib
 # the layout above must be preserved.
 COPY tools/scaleout/cabling_generator/merge_cluster_configs.py ./tools/scaleout/cabling_generator/merge_cluster_configs.py
 
+# run_cabling_generator writes transient output to <repo>/out/scaleout, relative to
+# its working directory (/opt/tt-metal). Pre-create it world-writable so the tool
+# works when the container is run with an arbitrary --user (e.g. the host uid/gid)
+# without needing a `--tmpfs /opt/tt-metal/out` mount at runtime.
+RUN mkdir -p /opt/tt-metal/out/scaleout && chmod -R 777 /opt/tt-metal/out
+
 # Fail the build early if any required shared library is unresolved or the binary
 # cannot start.
 RUN ldd ./build/tools/scaleout/run_cabling_generator | tee /tmp/ldd.txt \

--- a/dockerfile/scaleout_cabling_generator/Dockerfile
+++ b/dockerfile/scaleout_cabling_generator/Dockerfile
@@ -14,7 +14,11 @@
 #   - tools/      : the tt-metal source checkout (for the Python driver script)
 # This mirrors how dockerfile/upstream_test_images/Dockerfile.template consumes _tt-metal/build.
 
-FROM mirror.gcr.io/ubuntu:22.04
+# Must match the Ubuntu version the binary was built against (build-artifact platform),
+# otherwise the binary can require a newer glibc than the runtime base provides. The
+# workflow passes this as a build-arg derived from its `platform` input.
+ARG UBUNTU_VERSION=22.04
+FROM mirror.gcr.io/ubuntu:${UBUNTU_VERSION}
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/dockerfile/scaleout_cabling_generator/Dockerfile
+++ b/dockerfile/scaleout_cabling_generator/Dockerfile
@@ -1,0 +1,64 @@
+# Minimal image containing ONLY the scaleout "merge cluster configs" tool.
+#
+# It ships three things:
+#   - tools/scaleout/cabling_generator/merge_cluster_configs.py  (pure-Python driver)
+#   - build/tools/scaleout/run_cabling_generator                 (compiled binary it invokes)
+#   - the two tt-metal shared libraries that binary needs        (libtt_stl, libtt-umd)
+#
+# It intentionally does NOT contain ttnn, the Python venv, or the rest of the
+# tt-metal build tree, so it is dramatically smaller than the upstream-tests image.
+#
+# The build context is expected to contain:
+#   - _tt-metal/  : the EXTRACTED tt-metal build artifact (ttm_any.tar.zst), providing
+#                   _tt-metal/build/tools/scaleout/run_cabling_generator and _tt-metal/build/lib/*
+#   - tools/      : the tt-metal source checkout (for the Python driver script)
+# This mirrors how dockerfile/upstream_test_images/Dockerfile.template consumes _tt-metal/build.
+
+FROM mirror.gcr.io/ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+LABEL org.opencontainers.image.source="https://github.com/tenstorrent/tt-metal"
+LABEL org.opencontainers.image.description="Scaleout cabling generator (merge cluster configs) tool"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+# Runtime shared libraries required by run_cabling_generator (as reported by ldd).
+# libhwloc/libnsl/libtirpc/libatomic/libgssapi are pulled in transitively by
+# libtt-umd and are not present in the base ubuntu image. python3 runs the driver.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 \
+        libhwloc15 \
+        libnsl2 \
+        libtirpc3 \
+        libatomic1 \
+        libgssapi-krb5-2 \
+        zlib1g \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV TT_METAL_HOME=/opt/tt-metal
+WORKDIR /opt/tt-metal
+
+# Compiled binary + only the tt-metal shared libraries it links against.
+COPY _tt-metal/build/tools/scaleout/run_cabling_generator ./build/tools/scaleout/run_cabling_generator
+COPY _tt-metal/build/lib/libtt_stl.so* ./build/lib/
+COPY _tt-metal/build/lib/libtt-umd.so* ./build/lib/
+
+# run_cabling_generator records a build-tree DT_RUNPATH. DT_RUNPATH has lower
+# precedence than LD_LIBRARY_PATH, so pointing the loader at the libs we shipped
+# in build/lib is enough to resolve them without patching the binary.
+ENV LD_LIBRARY_PATH=/opt/tt-metal/build/lib
+
+# Pure-Python driver. It resolves the repo root three directories up from its own
+# location and looks for the binary under <root>/build/tools/scaleout, which is why
+# the layout above must be preserved.
+COPY tools/scaleout/cabling_generator/merge_cluster_configs.py ./tools/scaleout/cabling_generator/merge_cluster_configs.py
+
+# Fail the build early if any required shared library is unresolved or the binary
+# cannot start.
+RUN ldd ./build/tools/scaleout/run_cabling_generator | tee /tmp/ldd.txt \
+    && ! grep -q "not found" /tmp/ldd.txt \
+    && ./build/tools/scaleout/run_cabling_generator --help >/dev/null \
+    && rm -f /tmp/ldd.txt
+
+ENTRYPOINT ["python3", "/opt/tt-metal/tools/scaleout/cabling_generator/merge_cluster_configs.py"]
+CMD ["--help"]


### PR DESCRIPTION
### Ticket

[DCAMP-1042]()

### Summary

Currently, the runner in the tt-cluster-config repository needed to be changed due to memory restrictions on GitHub runners (the tt-metal-upstream-tests image was too big). The new runner is a CIv2 machine, which blocks the connection to the cosign registry. To overcome this issue, it was decided that we'll create a small Docker image containing only the necessary cabling generator files and switch back to the GitHub runner.

### Notes for reviewers

This PR introduces this Docker image, adds it to upstream-tests build workflow.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mgajewskiTT/DCAMP-1042-create-and-incorporate-minimal-docker-image-with-cabling-generator)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mgajewskiTT/DCAMP-1042-create-and-incorporate-minimal-docker-image-with-cabling-generator)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mgajewskiTT/DCAMP-1042-create-and-incorporate-minimal-docker-image-with-cabling-generator)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mgajewskiTT/DCAMP-1042-create-and-incorporate-minimal-docker-image-with-cabling-generator)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mgajewskiTT/DCAMP-1042-create-and-incorporate-minimal-docker-image-with-cabling-generator)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mgajewskiTT/DCAMP-1042-create-and-incorporate-minimal-docker-image-with-cabling-generator)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mgajewskiTT/DCAMP-1042-create-and-incorporate-minimal-docker-image-with-cabling-generator)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mgajewskiTT/DCAMP-1042-create-and-incorporate-minimal-docker-image-with-cabling-generator)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mgajewskiTT/DCAMP-1042-create-and-incorporate-minimal-docker-image-with-cabling-generator)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mgajewskiTT/DCAMP-1042-create-and-incorporate-minimal-docker-image-with-cabling-generator)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mgajewskiTT/DCAMP-1042-create-and-incorporate-minimal-docker-image-with-cabling-generator)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mgajewskiTT/DCAMP-1042-create-and-incorporate-minimal-docker-image-with-cabling-generator)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mgajewskiTT/DCAMP-1042-create-and-incorporate-minimal-docker-image-with-cabling-generator)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mgajewskiTT/DCAMP-1042-create-and-incorporate-minimal-docker-image-with-cabling-generator)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mgajewskiTT/DCAMP-1042-create-and-incorporate-minimal-docker-image-with-cabling-generator)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mgajewskiTT/DCAMP-1042-create-and-incorporate-minimal-docker-image-with-cabling-generator)