### PR TITLE
[Bug fix] Route LLK smoke tests to event-appropriate runners

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -256,6 +256,7 @@ triage:
 llk:
   pr_gate:
     wh_n150_civ2: 40
+    bh_p150b_civ2: 40
     bh_p150b_civ2_viommu_prio: 40
   unit:
     wh_n150_civ2: 40

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -407,6 +407,8 @@ jobs:
     secrets: inherit
     with:
       docker-image: ${{ needs.resolve-docker-pull-refs.outputs.llk-ci-docker-image }}
+      # Priority runners only accept merge-queue traffic. Regular PRs and
+      # other triggers must continue using the original non-priority runner.
       enabled-skus: ${{
           (github.ref_name == 'main'
            || needs.find-changed-files.outputs.llk-common-changed == 'true'
@@ -415,9 +417,9 @@ jobs:
            || needs.find-changed-files.outputs.llk-ci-changed == 'true'
            || (needs.find-changed-files.outputs.llk-wormhole-changed == 'true'
                && needs.find-changed-files.outputs.llk-blackhole-changed == 'true'))
-          && 'wh_n150_civ2,bh_p150b_civ2_viommu_prio'
+          && (github.event_name == 'merge_group' && 'wh_n150_civ2,bh_p150b_civ2_viommu_prio' || 'wh_n150_civ2,bh_p150b_civ2')
           || (needs.find-changed-files.outputs.llk-wormhole-changed == 'true' && 'wh_n150_civ2')
-          || (needs.find-changed-files.outputs.llk-blackhole-changed == 'true' && 'bh_p150b_civ2_viommu_prio')
+          || (needs.find-changed-files.outputs.llk-blackhole-changed == 'true' && (github.event_name == 'merge_group' && 'bh_p150b_civ2_viommu_prio' || 'bh_p150b_civ2'))
           || '' }}
       pytest-markers: "not perf and not nightly and not quasar and not accuracy"
 

--- a/tests/pipeline_reorg/llk_pr_gate_tests.yaml
+++ b/tests/pipeline_reorg/llk_pr_gate_tests.yaml
@@ -30,6 +30,8 @@
       --timeout=60 \
       --junitxml=pytest-report-blackhole.xml .
   skus:
+    bh_p150b_civ2:
+      timeout: 40
     bh_p150b_civ2_viommu_prio:
       timeout: 40
   owner_id: U07J3K6KS1K # LLK team


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

PR #49908 routed LLK Blackhole smoke tests to a priority runner that only accepts `merge_group` events, causing ordinary `pull_request` runs to fail during runner setup.

This change selects the runner based on the event type:
- Regular PR, push, and manual runs use `bh_p150b_civ2`.
- Merge-queue runs use `bh_p150b_civ2_viommu_prio`.

Both SKUs are registered in the LLK PR-gate test matrix and time budget.

Fixes #49934

### Notes for reviewers

Please focus on the event-aware expressions for both full LLK coverage and Blackhole-only changes. The Wormhole selection is unchanged.

Validated both Blackhole SKU matrices with `prepare_test_matrix.py`, verified the PR-gate budgets with `verify_time_budget.py`, and ran `git diff --check`.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/fix_pr_gate_runner_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/fix_pr_gate_runner_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/fix_pr_gate_runner_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/fix_pr_gate_runner_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ndivnic/fix_pr_gate_runner_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ndivnic/fix_pr_gate_runner_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/fix_pr_gate_runner_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/fix_pr_gate_runner_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/fix_pr_gate_runner_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/fix_pr_gate_runner_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/fix_pr_gate_runner_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/fix_pr_gate_runner_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/fix_pr_gate_runner_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/fix_pr_gate_runner_issue)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/fix_pr_gate_runner_issue)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/fix_pr_gate_runner_issue)