### PR TITLE
[Cleanup] Move tt_metal-only DRAM-sender GCB accessors out of the public API

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_dram_sender_global_cb.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_sender_global_cb.cpp
@@ -19,6 +19,7 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/global_circular_buffer.hpp>
 #include "impl/buffers/drisc_l1_arena.hpp"
+#include "impl/buffers/global_circular_buffer_dram_sender_internal.hpp"
 #include <tt-metalium/experimental/global_circular_buffer.hpp>
 
 #include "impl/kernels/kernel.hpp"  // DramConfig

--- a/tt_metal/api/tt-metalium/experimental/global_circular_buffer.hpp
+++ b/tt_metal/api/tt-metalium/experimental/global_circular_buffer.hpp
@@ -65,44 +65,14 @@ GlobalCircularBuffer CreateGlobalCircularBufferForTensorPrefetcher(
     BufferType buffer_type = BufferType::L1,
     bool support_multi_receiver_shards = false);
 
-// Read-only accessors for the DRAM-sender state inside a GlobalCircularBuffer. For
-// GCBs created via the worker-sender path these return SenderCoreType::Worker / 0 /
-// empty respectively.
+// Sender domain of a GlobalCircularBuffer. Returns SenderCoreType::Worker for GCBs created
+// via the worker-sender path, SenderCoreType::Dram for those from
+// CreateGlobalCircularBufferForTensorPrefetcher.
 SenderCoreType sender_core_type(const GlobalCircularBuffer& gcb);
 
-// DRISC unreserved-L1 base where the sender's per-receiver pages_sent/acked counters
-// live. Zero for worker-sender GCBs.
-DeviceAddr pages_sent_drisc_l1_base(const GlobalCircularBuffer& gcb);
-
-// Worker-L1 offset (inside the receiver's config buffer page) where the receiver's
-// local pages_sent counter lives. Zero for worker-sender GCBs.
-DeviceAddr pages_sent_worker_l1_base(const GlobalCircularBuffer& gcb);
-
-// DRISC L1 base of the per-GCB "sender state block" — the RemoteSenderCBInterface
-// bytes (including the fifo_wr_ptr that persists across requests), the sender config
-// block, and the receiver NOC XY table. Pre-written by the GCB constructor on every
-// (device, sender_core). The Tensor prefetcher kernel loads this block into its
-// static cb_interface slot on each request that targets this GCB, runs the chunk loop,
-// and writes fifo_wr_ptr back so the ring offset survives multi-GCB request switching.
-// Layout: tt_metal/impl/buffers/dram_sender_state_block.hpp. Zero for worker-sender GCBs.
-DeviceAddr sender_state_drisc_l1_base(const GlobalCircularBuffer& gcb);
-
-// Physical worker NOC XY for each sender's receivers. The DRISC kernel uses these as
-// runtime args. Empty for worker-sender GCBs.
-const std::vector<std::vector<CoreCoord>>& receiver_coords_per_sender(const GlobalCircularBuffer& gcb);
-
-// Per-sender bank-local slab indices: entry [s][r] is the bank-local slab index
-// (recv_index_base + r) that sender s's local receiver r reads, in
-// sender_receiver_core_mapping() order. This is the same "slab" the DRAM-sender kernel
-// addresses, and the single source of truth for the recv_index_base accounting (which the
-// GCB owns because it encodes the dual-sender-per-bank split contract).
-//
-// Order-agnostic on purpose: mapping a receiver's (bank, slab index) to a global position
-// depends on the tensor's shard distribution (ROUND_ROBIN_1D strided vs CONTIGUOUS_1D
-// contiguous), which a ring-matmul consumer treats as a "ring position". That is the
-// caller's concept, not the GCB's, so the streaming Tensor prefetcher reads the raw slab
-// indices here and permutes them itself. DRAM-sender GCBs only.
-std::vector<std::vector<uint32_t>> receiver_slab_indices(const GlobalCircularBuffer& gcb);
+// The impl-internal DRAM-sender L1-layout accessors (pages_sent / sender-state / receiver
+// coords / slab indices) are consumed only inside tt_metal/ and live in
+// tt_metal/impl/buffers/global_circular_buffer_dram_sender_internal.hpp.
 
 }  // namespace experimental
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -13,6 +13,7 @@
 #include <host_api.hpp>
 #include "impl/buffers/drisc_l1_arena.hpp"
 #include "impl/buffers/dram_sender_state_block.hpp"
+#include "impl/buffers/global_circular_buffer_dram_sender_internal.hpp"
 #include "impl/context/context_types.hpp"
 #include "distributed/mesh_device_impl.hpp"
 #include <tt-metalium/experimental/global_circular_buffer.hpp>

--- a/tt_metal/impl/buffers/global_circular_buffer_dram_sender_internal.hpp
+++ b/tt_metal/impl/buffers/global_circular_buffer_dram_sender_internal.hpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Impl-internal DRAM-sender accessors for GlobalCircularBuffer. These read back the L1 layout
+// that the DRAM-sender GCB constructor stamps out; they are consumed only inside tt_metal/ (the
+// Tensor prefetcher manager and the DRAM-sender GCB tests), so they live here rather than on the
+// public experimental surface in tt-metalium/experimental/global_circular_buffer.hpp. The public
+// header keeps only what ttnn consumes: SenderCoreType, sender_core_type(), and
+// CreateGlobalCircularBufferForTensorPrefetcher().
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/global_circular_buffer.hpp>
+
+namespace tt::tt_metal::experimental {
+
+// DRISC unreserved-L1 base where the sender's per-receiver pages_sent/acked counters
+// live. Zero for worker-sender GCBs.
+DeviceAddr pages_sent_drisc_l1_base(const GlobalCircularBuffer& gcb);
+
+// Worker-L1 offset (inside the receiver's config buffer page) where the receiver's
+// local pages_sent counter lives. Zero for worker-sender GCBs.
+DeviceAddr pages_sent_worker_l1_base(const GlobalCircularBuffer& gcb);
+
+// DRISC L1 base of the per-GCB "sender state block" — the RemoteSenderCBInterface
+// bytes (including the fifo_wr_ptr that persists across requests), the sender config
+// block, and the receiver NOC XY table. Pre-written by the GCB constructor on every
+// (device, sender_core). The Tensor prefetcher kernel loads this block into its
+// static cb_interface slot on each request that targets this GCB, runs the chunk loop,
+// and writes fifo_wr_ptr back so the ring offset survives multi-GCB request switching.
+// Layout: tt_metal/impl/buffers/dram_sender_state_block.hpp. Zero for worker-sender GCBs.
+DeviceAddr sender_state_drisc_l1_base(const GlobalCircularBuffer& gcb);
+
+// Physical worker NOC XY for each sender's receivers. The DRISC kernel uses these as
+// runtime args. Empty for worker-sender GCBs.
+const std::vector<std::vector<CoreCoord>>& receiver_coords_per_sender(const GlobalCircularBuffer& gcb);
+
+// Per-sender bank-local slab indices: entry [s][r] is the bank-local slab index
+// (recv_index_base + r) that sender s's local receiver r reads, in
+// sender_receiver_core_mapping() order. This is the same "slab" the DRAM-sender kernel
+// addresses, and the single source of truth for the recv_index_base accounting (which the
+// GCB owns because it encodes the dual-sender-per-bank split contract).
+//
+// Order-agnostic on purpose: mapping a receiver's (bank, slab index) to a global position
+// depends on the tensor's shard distribution (ROUND_ROBIN_1D strided vs CONTIGUOUS_1D
+// contiguous), which a ring-matmul consumer treats as a "ring position". That is the
+// caller's concept, not the GCB's, so the streaming Tensor prefetcher reads the raw slab
+// indices here and permutes them itself. DRAM-sender GCBs only.
+std::vector<std::vector<uint32_t>> receiver_slab_indices(const GlobalCircularBuffer& gcb);
+
+}  // namespace tt::tt_metal::experimental

--- a/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
@@ -7,6 +7,7 @@
 #include "distributed/mesh_device_impl.hpp"
 #include "distributed/mesh_command_queue_base.hpp"
 #include "impl/buffers/drisc_l1_arena.hpp"
+#include "impl/buffers/global_circular_buffer_dram_sender_internal.hpp"
 #include "impl/buffers/h2d_socket_internal.hpp"
 
 #include <algorithm>


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

The experimental DRAM-sender `GlobalCircularBuffer` header
(`tt-metalium/experimental/global_circular_buffer.hpp`) exposed five DRISC/worker
L1-layout accessors that no consumer outside `tt_metal/` actually uses:

- `pages_sent_drisc_l1_base`
- `pages_sent_worker_l1_base`
- `sender_state_drisc_l1_base`
- `receiver_coords_per_sender`
- `receiver_slab_indices`

Their only callers are the Tensor prefetcher manager (`impl/buffers/tensor_prefetcher_manager.cpp`)
and the DRAM-sender GCB unit tests. Nothing in `ttnn/` or `models/` references them, so they
don't need to sit on the public API surface.

This moves their declarations into a new impl-internal header,
`impl/buffers/global_circular_buffer_dram_sender_internal.hpp`, and includes it from the three
`tt_metal/` translation units that use them. The free-function definitions in
`global_circular_buffer.cpp` are unchanged.

The public experimental surface now keeps only what `ttnn` consumes:
`SenderCoreType`, `sender_core_type()`, and `CreateGlobalCircularBufferForTensorPrefetcher()`.

No functional change.

### Notes for reviewers

- `tests/tt_metal/tt_metal/api/test_dram_sender_global_cb.cpp` already reaches into
  `impl/buffers/` (it includes `drisc_l1_arena.hpp`), so pulling in the new internal header
  follows the existing pattern for these tt_metal tests.
- Builds clean (`cmake --build build`, all targets including `ttnn`).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/gcb-internalize-dram-sender-accessors)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/gcb-internalize-dram-sender-accessors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/gcb-internalize-dram-sender-accessors)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/gcb-internalize-dram-sender-accessors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jbauman/gcb-internalize-dram-sender-accessors)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jbauman/gcb-internalize-dram-sender-accessors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/gcb-internalize-dram-sender-accessors)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/gcb-internalize-dram-sender-accessors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/gcb-internalize-dram-sender-accessors)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/gcb-internalize-dram-sender-accessors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/gcb-internalize-dram-sender-accessors)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/gcb-internalize-dram-sender-accessors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/gcb-internalize-dram-sender-accessors)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/gcb-internalize-dram-sender-accessors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/gcb-internalize-dram-sender-accessors)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/gcb-internalize-dram-sender-accessors)