### PR TITLE
[Deepseek Prefill][Performance] Combine noc congestion fix

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -20,6 +20,7 @@
 #include <tt-metalium/workload_descriptor.hpp>
 #include <ttnn/global_semaphore.hpp>
 #include "ttnn/operations/ccl/common/host/moe_utils.hpp"
+#include "ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/relay_config.hpp"
 
 namespace ttnn::operations::experimental::deepseek_prefill::combine {
 
@@ -240,6 +241,7 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
     std::vector<std::vector<CoreCoord>> sender_untilizer_groups(num_cores);
     std::vector<CoreCoord> all_untilizer_cores;
     std::vector<uint32_t> untilizer_sender_map;
+    std::vector<CoreCoord> relay_cores;  // USE_RELAY: one relay ("R") core per sender battery, left of the sender
 
     // Both TILE_LAYOUT and ROW_MAJOR route dispatched_buffer through the untilizer pipeline, so
     // both use the same layout: divide the line into per-sender groups with the sender at the
@@ -298,6 +300,74 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
         num_cores);
     uint32_t untilizer_cores_per_sender = num_untilizer_cores / num_cores;
     uint32_t senders_with_extra_untilizer = num_untilizer_cores % num_cores;
+
+#if USE_RELAY
+    // ===================== USE_RELAY — explicit relay-battery placement =====================
+    // Discard the default line split above and rebuild placement explicitly so each battery reads
+    // R-S-U-U-U-U, with a dedicated relay core prepended to the LEFT of the sender. Coordinates below
+    // are PHYSICAL NOC0 (== virtual for unharvested BH tensix); we invert virtual_core_from_logical_core
+    // to recover the logical worker cores the rest of the factory addresses. Both batteries sit on the
+    // bottom tensix rows (physical y=10, y=11), farthest from the eth cores:
+    //   y=10: R@x1, S@x2, U@x3, U@x4, U@x5, U@x6
+    //   y=11: R@x2, S@x7, U@x10, U@x11, U@x12, U@x13
+    TT_FATAL(num_cores == 2, "USE_RELAY currently supports exactly 2 senders (num_links>=2); got {}", num_cores);
+    {
+        // physical NOC0 (x,y) -> logical worker CoreCoord, by inverting the logical->virtual map.
+        std::map<std::pair<uint32_t, uint32_t>, CoreCoord> phys_to_logical;
+        auto cg = mesh_device->compute_with_storage_grid_size();
+        for (uint32_t ly = 0; ly < cg.y; ly++) {
+            for (uint32_t lx = 0; lx < cg.x; lx++) {
+                CoreCoord lc(lx, ly);
+                auto v = mesh_device->virtual_core_from_logical_core(lc, tt::CoreType::WORKER);
+                phys_to_logical[{(uint32_t)v.x, (uint32_t)v.y}] = lc;
+            }
+        }
+        auto phys_to_logical_core = [&](uint32_t px, uint32_t py) -> CoreCoord {
+            auto it = phys_to_logical.find({px, py});
+            TT_FATAL(
+                it != phys_to_logical.end(),
+                "USE_RELAY: requested physical worker core ({}, {}) is not a tensix worker on this device",
+                px,
+                py);
+            return it->second;
+        };
+
+        struct RelayBattery {
+            uint32_t phys_y;
+            uint32_t relay_x;
+            uint32_t sender_x;
+            std::array<uint32_t, 4> untilizer_x;
+        };
+        const std::array<RelayBattery, 2> relay_batteries = {{
+            {/*phys_y=*/10, /*relay_x=*/1, /*sender_x=*/2, {{3, 4, 5, 6}}},
+            {/*phys_y=*/11, /*relay_x=*/2, /*sender_x=*/7, {{10, 11, 12, 13}}},
+        }};
+
+        // Clear the default split's assignments and rebuild from the explicit table.
+        sender_cores.clear();
+        for (auto& g : sender_untilizer_groups) {
+            g.clear();
+        }
+        all_untilizer_cores.clear();
+        untilizer_sender_map.clear();
+        relay_cores.clear();
+
+        for (uint32_t s = 0; s < num_cores; s++) {
+            const auto& b = relay_batteries[s];
+            relay_cores.push_back(phys_to_logical_core(b.relay_x, b.phys_y));
+            sender_cores.push_back(phys_to_logical_core(b.sender_x, b.phys_y));
+            for (uint32_t u = 0; u < b.untilizer_x.size(); u++) {
+                CoreCoord uc = phys_to_logical_core(b.untilizer_x[u], b.phys_y);
+                sender_untilizer_groups[s].push_back(uc);
+                all_untilizer_cores.push_back(uc);
+                untilizer_sender_map.push_back(s);
+            }
+        }
+        num_untilizer_cores = static_cast<uint32_t>(all_untilizer_cores.size());
+        untilizer_cores_per_sender = num_untilizer_cores / num_cores;
+        senders_with_extra_untilizer = num_untilizer_cores % num_cores;
+    }
+#endif
 
     // Build sender_core_grid from selected sender cores
     std::set<CoreRange> sender_ranges_set;
@@ -470,6 +540,51 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
             }}},
         });
     }
+
+#if USE_RELAY
+    // Relay cores: dedicated single-writer-kernel cores = the combine FABRIC ENDPOINT. Build the core
+    // grid + L1 buffers here; the writer kernel is created later (after writer_defines) and its fabric
+    // connection + RT args are appended in the RT-arg section.
+    CoreRangeSet relay_core_grid;
+    tt::tt_metal::KernelHandle relay_writer_kernel_id = 0;
+    {
+        std::set<CoreRange> relay_ranges_set;
+        for (const auto& rc : relay_cores) {
+            relay_ranges_set.insert(CoreRange(rc));
+        }
+        relay_core_grid = CoreRangeSet(relay_ranges_set);
+        TT_FATAL(relay_cores.size() == num_cores, "Expected {} relay cores, got {}", num_cores, relay_cores.size());
+
+        // c_24: relay receive ring. RELAY_SLOTS slots, each = route_info (l1_alignment) + one aligned
+        // output page (token), mirroring the sender's c_3 layout.
+        uint32_t relay_slot_size = l1_alignment + detail::get_aligned_page_size(output_tensor);
+        desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+            .total_size = RELAY_SLOTS * relay_slot_size,
+            .core_ranges = relay_core_grid,
+            .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_24),
+                .data_format = tt::DataFormat::UInt8,
+                .page_size = relay_slot_size,
+            }}},
+        });
+
+        // c_5: packet-header CB on the relay (2 headers: unicast + handshake), mirroring the sender's c_5.
+        // The relay owns the fabric endpoint now, so it owns the header pool.
+        if (num_links > 0) {
+            constexpr uint32_t num_relay_packet_headers = 2;
+            auto packet_header_size_bytes = tt::tt_fabric::get_tt_fabric_packet_header_size_bytes();
+            desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+                .total_size = num_relay_packet_headers * packet_header_size_bytes,
+                .core_ranges = relay_core_grid,
+                .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+                    .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_5),
+                    .data_format = tt::DataFormat::UInt8,
+                    .page_size = packet_header_size_bytes,
+                }}},
+            });
+        }
+    }
+#endif
 
     // Iterate over every coordinate in the mesh (full coord range derived from the
     // mesh shape) — replaces the legacy `tensor_coords` parameter, which the new
@@ -687,6 +802,26 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
             }
         }
     }
+
+#if USE_RELAY
+    // sender->relay flow-control semaphores (1:1 sender:relay), scoped to each {sender, relay} pair so
+    // the id is valid on both cores:
+    //   relay_data_ready (lives on relay, init 0): sender ++ after writing a token slot; relay waits
+    //                     on a monotonic `consumed` counter.
+    //   relay_credits    (lives on sender, init RELAY_SLOTS): relay ++ when it frees a slot; sender keeps
+    //                     a local credit counter and sucks this sem when it runs out.
+    //   relay_buf_addr   (lives on sender, init 0): relay publishes get_write_ptr(c_24) here so the sender
+    //                     learns where to NOC-write tokens; the sender spins until it is non-zero.
+    std::vector<uint32_t> relay_data_ready_sem_ids(num_cores);
+    std::vector<uint32_t> relay_credits_sem_ids(num_cores);
+    std::vector<uint32_t> relay_buf_addr_sem_ids(num_cores);
+    for (uint32_t s = 0; s < num_cores; s++) {
+        CoreRangeSet pair_grid(std::set<CoreRange>{CoreRange(sender_cores[s]), CoreRange(relay_cores[s])});
+        relay_data_ready_sem_ids[s] = add_sema(pair_grid, 0);
+        relay_credits_sem_ids[s] = add_sema(pair_grid, RELAY_SLOTS);
+        relay_buf_addr_sem_ids[s] = add_sema(pair_grid, 0);
+    }
+#endif
 
     // Largest divisor of (hidden_size / 32) that is <= 8.  Reader_untilize pushes tiles into
     // cb_dispatched_buffer (c_0) in chunks of this size, and the untilize compute kernel consumes
@@ -1012,6 +1147,47 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
     tt::tt_metal::KernelHandle writer_kernel_id = static_cast<tt::tt_metal::KernelHandle>(desc.kernels.size());
     desc.kernels.push_back(std::move(writer_kd));
 
+#if USE_RELAY
+    // Relay writer kernel = the fabric endpoint (opens eth connections, runs the init/exit handshake,
+    // drains its c_24 ring, sends tokens to fabric). Single kernel on its core -> free to use NOC_0. Gets
+    // the same fabric defines as writer_combine (DEST_CHIP_ID / DEST_MESH_ID / DIRECTIONS / AXIS). num_chips
+    // mirrors writer_combine's compile arg 13 (== dispatch_group_size).
+    {
+        std::vector<uint32_t> relay_compile_time_args = {
+            detail::get_num_pages(output_tensor),          // 0:  output_pages
+            detail::get_aligned_page_size(output_tensor),  // 1:  aligned_output_page_size
+            (uint32_t)fabric_max_packet_size,              // 2:  fabric_max_packet_size
+            l1_alignment,                                  // 3:  l1_alignment
+            static_cast<uint32_t>(num_links),              // 4:  num_links
+            static_cast<uint32_t>(topology),               // 5:  topology
+            mesh_rows,                                     // 6:  mesh_rows
+            mesh_cols,                                     // 7:  mesh_cols
+            linearized_mesh_coord,                         // 8:  linearized_mesh_coord
+            src_chip_id,                                   // 9:  src_chip_id
+            src_mesh_id,                                   // 10: src_mesh_id
+            operation_attributes.dispatch_group_size,      // 11: num_chips (== writer_combine arg 13)
+            static_cast<uint32_t>(tt::CBIndex::c_5),       // 12: cb_packet_header_id
+            static_cast<uint32_t>(tt::CBIndex::c_24),      // 13: cb_relay_buf
+        };
+        tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(relay_compile_time_args);  // 14+
+
+        tt::tt_metal::KernelDescriptor relay_writer_kd;
+        relay_writer_kd.kernel_source =
+            "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/"
+            "writer_relay.cpp";
+        relay_writer_kd.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+        relay_writer_kd.core_ranges = relay_core_grid;
+        relay_writer_kd.compile_time_args = std::move(relay_compile_time_args);
+        relay_writer_kd.defines = {writer_defines.begin(), writer_defines.end()};
+        relay_writer_kd.config = tt::tt_metal::DataMovementConfigDescriptor{
+            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt::tt_metal::NOC::NOC_0,
+        };
+        relay_writer_kernel_id = static_cast<tt::tt_metal::KernelHandle>(desc.kernels.size());
+        desc.kernels.push_back(std::move(relay_writer_kd));
+    }
+#endif
+
     // Compute kernel on untilizer cores that untilizes dispatched_buffer data (TILE_LAYOUT only).
     // Compile-time args are shared across all untilizer cores; per-sender values (core_id,
     // num_untilizer_cores, expert range) are passed via SetRuntimeArgs below.  Initialized to 0
@@ -1231,7 +1407,25 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
             writer_runtime_args_raw.push_back(noc_y);
         }
 
-        if (num_links > 0) {
+#if USE_RELAY
+        // sender->relay pipe args (owning relay NOC coords + the 3 flow-control sem ids), appended right
+        // after the barrier NOC coords; the sender reads them in its USE_RELAY producer block. No
+        // fabric-connection args follow (the sender is not the fabric endpoint), so these are the last of
+        // the sender's RT args.
+        {
+            auto relay_v = mesh_device->virtual_core_from_logical_core(relay_cores[core_idx], tt::CoreType::WORKER);
+            writer_runtime_args_raw.push_back((uint32_t)relay_v.x);
+            writer_runtime_args_raw.push_back((uint32_t)relay_v.y);
+            writer_runtime_args_raw.push_back(relay_data_ready_sem_ids[core_idx]);
+            writer_runtime_args_raw.push_back(relay_credits_sem_ids[core_idx]);
+            writer_runtime_args_raw.push_back(relay_buf_addr_sem_ids[core_idx]);
+        }
+#endif
+
+        // USE_RELAY: the relay is the fabric endpoint, so the sender opens no fabric connection and gets
+        // no fabric-connection RT args (writer_combine returns before it would read them). The relay's
+        // connection is appended in the relay RT-arg loop below.
+        if (num_links > 0 && !USE_RELAY) {
             // Combine-axis neighbors (each a distinct fabric direction) as fabric nodes.
             std::vector<tt::tt_fabric::FabricNodeId> dst_nodes;
             for (const auto& neighbor_coordinate : neighbors) {
@@ -1293,6 +1487,54 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
         desc.kernels[reader_kernel_ids[core_idx]].emplace_runtime_args(sender_core, reader_runtime_args);
         core_idx++;
     }
+
+#if USE_RELAY
+    // Relay RT args = the fabric endpoint's args. Order the relay kernel reads:
+    //   output_addr, init_sem_addr, exit_sem_addr, sender pipe args (sender NOC x/y + 3 sem ids), then the
+    //   fabric-connection args (FABRIC_1D per-target unicast). output_addr is promoted to a Buffer* below
+    //   for the cache-hit fast path.
+    TT_FATAL(!is_2d_fabric, "USE_RELAY relay endpoint is FABRIC_1D only.");
+    for (uint32_t s = 0; s < num_cores; s++) {
+        const CoreCoord& relay_core = relay_cores[s];
+        std::vector<uint32_t> relay_rt_raw = {
+            output_tensor.buffer()->address(),   // 0: output_addr (promoted to Buffer* below)
+            (uint32_t)init_semaphore.address(),  // 1: init_semaphore_address
+            (uint32_t)exit_semaphore.address(),  // 2: exit_semaphore_address
+        };
+        // 3..7: sender->relay pipe args (owning sender NOC coords + the 3 flow-control sem ids). Read by
+        // the relay BEFORE open_direction_connections, so they must precede the fabric-connection args.
+        auto sender_v = mesh_device->virtual_core_from_logical_core(sender_cores[s], tt::CoreType::WORKER);
+        relay_rt_raw.push_back((uint32_t)sender_v.x);
+        relay_rt_raw.push_back((uint32_t)sender_v.y);
+        relay_rt_raw.push_back(relay_data_ready_sem_ids[s]);
+        relay_rt_raw.push_back(relay_credits_sem_ids[s]);
+        relay_rt_raw.push_back(relay_buf_addr_sem_ids[s]);
+
+        if (num_links > 0) {
+            std::vector<tt::tt_fabric::FabricNodeId> dst_nodes;
+            for (const auto& neighbor_coordinate : neighbors) {
+                if (neighbor_coordinate[0] == mesh_coordinate[0] && neighbor_coordinate[1] == mesh_coordinate[1]) {
+                    continue;
+                }
+                dst_nodes.push_back(mesh_device->get_fabric_node_id(neighbor_coordinate));
+            }
+            const uint32_t core_link = s % num_links;
+            for (const auto& dst_node : dst_nodes) {
+                tt::tt_fabric::append_fabric_connection_rt_args<tt::tt_metal::ProgramDescriptor>(
+                    src_fabric_node_id, dst_node, core_link, desc, relay_core, relay_rt_raw);
+            }
+        }
+
+        // Promote: output_addr slot -> Buffer*, everything else stays uint32.
+        tt::tt_metal::KernelDescriptor::RTArgList relay_rt_args;
+        relay_rt_args.reserve(relay_rt_raw.size());
+        relay_rt_args.push_back(output_tensor.buffer());
+        for (size_t i = 1; i < relay_rt_raw.size(); ++i) {
+            relay_rt_args.push_back(relay_rt_raw[i]);
+        }
+        desc.kernels[relay_writer_kernel_id].emplace_runtime_args(relay_core, relay_rt_args);
+    }
+#endif
 
     // Set runtime args for untilizer cores (both layouts — reader_untilize kernel).
     // Layout: counter_ready_sem, dispatched_buffer_addr, expert_start, expert_end,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/relay_config.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/relay_config.hpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// ============================================================================
+// USE_RELAY — dedicated relay ("R") tensix core per sender battery
+// ============================================================================
+//
+// A core that runs both DM0 and DM1 kernels must use opposite NOCs for them, so the combine sender
+// (which runs reader_combine + writer_combine) cannot issue its eth write on NOC_0 while reader_combine
+// also uses that core. Splitting the untilizer->sender->eth chain into untilizer->sender->relay->eth
+// moves the fabric send onto a dedicated single-kernel core (the relay), which is then free to use NOC_0
+// for the eth write, without perturbing the sender/untilizer NOC assignments.
+//
+// With USE_RELAY:
+//   - each sender battery gets a relay core prepended (row layout R-S-U-U-U-U), placed at explicit
+//     physical rows (see combine_program_factory);
+//   - writer_combine (the sender) stops opening a fabric connection; it forwards each token (route_info +
+//     payload) into the relay's c_24 receive ring over NOC, credit-flow-controlled;
+//   - writer_relay (the relay) is the fabric endpoint: it opens the eth connections, runs the cross-chip
+//     init/exit handshake, drains its c_24 ring, and forwards each token to fabric on NOC_0.
+//
+// Constraints of the current implementation: FABRIC_1D only and exactly 2 senders (num_links >= 2). The
+// factory TT_FATALs otherwise. Set to 0 to restore the byte-for-byte original sender->eth path.
+// HOST-FACTORY toggle -> needs a libttnn rebuild.
+#define USE_RELAY 1
+
+// Slot count of the relay's c_24 L1 receive ring. Each slot holds one token = routing metadata
+// (l1_alignment bytes) + one aligned output page (~14 KB), mirroring the sender's c_3 layout. The sender
+// writes slots round-robin and the relay drains them in order; RELAY_SLOTS is the max number of tokens
+// the sender may run ahead of the relay (credit-flow-controlled).
+#define RELAY_SLOTS 64

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_combine.cpp
@@ -13,6 +13,7 @@
 #include "tt_metal/fabric/hw/inc/packet_header_pool.h"
 #include "ttnn/operations/ccl/common/kernels/moe_utils.hpp"
 #include "ttnn/operations/ccl/kernel_common/worker_routing_utils.hpp"
+#include "ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/relay_config.hpp"
 
 // FABRIC_2D vs 1D dispatch is handled portably via ccl_routing_utils::fabric_set_line_unicast_route
 // (templated on packet-header type). Under 1D the helper consumes route_info.distance_in_hops,
@@ -153,6 +154,97 @@ void kernel_main() {
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(output_init_complete_semaphore_address);
     noc_semaphore_wait(output_init_complete_sem_ptr, 1);
     noc_semaphore_set(output_init_complete_sem_ptr, 0);
+#endif
+
+#if USE_RELAY
+    {
+        // USE_RELAY: the sender is NOT the fabric endpoint (the relay is). It forwards each token
+        // (route_info + payload) from its cb_route_info (c_3) into the relay's c_24 receive ring over NOC,
+        // credit-flow-controlled; the relay reads them and sends to fabric. No fabric connection / handshake
+        // here (the relay owns it). Terminates by forwarding the ROUTE_INFO_SENTINEL slot so the relay's
+        // consumer stops. (INIT_ZEROS + USE_RELAY is unsupported: the reader-barrier signal below is skipped
+        // by this early return; the test path uses init_zeros=false.)
+        //
+        // Pipe RT args, appended by the factory right after the per-core barrier NOC coords:
+        uint32_t relay_noc_x = get_arg_val<uint32_t>(rt_args_idx++);
+        uint32_t relay_noc_y = get_arg_val<uint32_t>(rt_args_idx++);
+        uint32_t relay_data_ready_sem_id = get_arg_val<uint32_t>(rt_args_idx++);
+        uint32_t relay_credits_sem_id = get_arg_val<uint32_t>(rt_args_idx++);
+        uint32_t relay_buf_addr_sem_id = get_arg_val<uint32_t>(rt_args_idx++);
+
+        // Discover the relay's c_24 base (published by the relay into relay_buf_addr after its init handshake).
+        volatile tt_l1_ptr uint32_t* relay_buf_addr_ptr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(relay_buf_addr_sem_id));
+        do {
+            invalidate_l1_cache();
+        } while (*relay_buf_addr_ptr == 0);
+        const uint32_t relay_c24_base = *relay_buf_addr_ptr;
+
+        // Credit-based flow control: local counter, refilled by sucking the credits sem the relay
+        // increments as it frees slots.
+        const uint32_t relay_slot_size = l1_alignment + aligned_output_page_size;
+        const uint64_t relay_data_ready_noc_addr =
+            get_noc_addr(relay_noc_x, relay_noc_y, get_semaphore(relay_data_ready_sem_id));
+        const uint32_t relay_credits_l1 = get_semaphore(relay_credits_sem_id);
+        volatile tt_l1_ptr uint32_t* relay_credits_ptr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(relay_credits_l1);
+        const uint64_t self_relay_credits_noc_addr = get_noc_addr(my_x[noc_index], my_y[noc_index], relay_credits_l1);
+        uint32_t local_credits = RELAY_SLOTS;
+        uint32_t w = 0;
+
+        // Forward one slot_size L1 region ([route_info | payload]) from `src_l1` into the relay's next c_24
+        // slot, credit-flow-controlled, then signal data_ready. The relay READS this slot (route_info in the
+        // first bytes AND the payload) as soon as it sees data_ready, so the whole slot must have LANDED in
+        // the relay's L1 before the inc: noc_async_write_barrier() waits for the write to be acked (landed),
+        // unlike noc_async_writes_flushed() which only waits for it to be sent. (Matches the untilizer->
+        // sender handoff, which barriers before its own data_ready inc.)
+        auto forward_slot = [&](uint32_t src_l1) {
+            if (local_credits == 0) {
+                while (true) {
+                    invalidate_l1_cache();
+                    if (*relay_credits_ptr > 0) {
+                        break;
+                    }
+                }
+                uint32_t n = *relay_credits_ptr;
+                noc_semaphore_inc(self_relay_credits_noc_addr, (uint32_t)(-(int32_t)n));
+                noc_async_atomic_barrier();
+                local_credits += n;
+            }
+            const uint32_t relay_slot_l1 = relay_c24_base + w * relay_slot_size;
+            const uint64_t relay_slot_noc = get_noc_addr(relay_noc_x, relay_noc_y, relay_slot_l1);
+            noc_async_write(src_l1, relay_slot_noc, relay_slot_size);
+            noc_async_write_barrier();  // wait for the slot to LAND at the relay (not just be sent)
+            noc_semaphore_inc<true>(relay_data_ready_noc_addr, 1);
+            local_credits--;
+            w = (w + 1 == RELAY_SLOTS) ? 0u : w + 1u;
+        };
+
+        // Drain c_3 (filled by reader_combine with route_info + payload, ROUTE_INFO_SENTINEL-terminated),
+        // forwarding each token's whole slot to the relay.
+        while (true) {
+            cb_wait_front(cb_route_info_id, 1);
+            const uint32_t cb_base = get_read_ptr(cb_route_info_id);
+            volatile tt_l1_ptr uint32_t* route_info = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_base);
+            if (route_info[0] == ROUTE_INFO_SENTINEL) {
+                cb_pop_front(cb_route_info_id, 1);
+                break;
+            }
+            forward_slot(cb_base);
+            cb_pop_front(cb_route_info_id, 1);
+        }
+
+        // Forward a sentinel slot so the relay's consumer terminates. Reuse the (now free) c_3 write slot
+        // as scratch: reader_combine has finished (pushed its sentinel, which we consumed) so it won't
+        // touch c_3 again.
+        const uint32_t stage_base = get_write_ptr(cb_route_info_id);
+        volatile tt_l1_ptr uint32_t* stage_route_info = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(stage_base);
+        stage_route_info[0] = ROUTE_INFO_SENTINEL;
+        forward_slot(stage_base);
+
+        // The relay owns the exit handshake + teardown; the sender is done once all tokens are queued.
+        return;
+    }
 #endif
 
 #ifdef DEST_CHIP_ID

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_relay.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_relay.cpp
@@ -133,6 +133,7 @@ void kernel_main() {
             get_noc_addr(sender_noc_x, sender_noc_y, get_semaphore(relay_credits_sem_id));
 
         uint32_t consumed = 0;
+        DeviceZoneScopedN("combine-ethernet-flow");
         while (true) {
             // Wait until slot `consumed` is filled: the producer monotonically ++ data_ready per token.
             while (true) {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_relay.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_relay.cpp
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+#include "api/debug/assert.h"
+#include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
+#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
+#include "tt_metal/fabric/hw/inc/edm_fabric/routing_plane_connection_manager.hpp"
+#include "tt_metal/fabric/hw/inc/linear/api.h"
+#include "tt_metal/fabric/hw/inc/packet_header_pool.h"
+#include "ttnn/operations/ccl/common/kernels/moe_utils.hpp"
+#include "ttnn/operations/ccl/kernel_common/worker_routing_utils.hpp"
+#include "ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/relay_config.hpp"
+
+// ============================================================================
+// writer_relay — relay ("R") core writer kernel = the combine FABRIC ENDPOINT.
+// ============================================================================
+//
+// The relay is the ONLY kernel on its core, so it uses NOC_0 for everything (the preferred
+// write-to-eth NOC), while the sender/untilizer NOC assignments are unchanged from the base op. It:
+//   1. opens the eth (EDM) fabric connections,
+//   2. runs the cross-chip init/exit semaphore handshake,
+//   3. drains tokens (route_info + payload) from its c_24 receive ring — fed by the owning sender over
+//      the sender->relay NOC pipe, credit-flow-controlled — and forwards each to fabric,
+//   4. tears the connections down.
+// writer_combine (the sender) opens no connection and sends nothing over eth (see its USE_RELAY block).
+//
+// FABRIC_1D only (1D init/exit handshake + line-unicast route info).
+#ifdef FABRIC_2D
+#error "writer_relay is FABRIC_1D only."
+#endif
+#ifndef DEST_CHIP_ID
+#error "writer_relay requires a multi-chip build (DEST_CHIP_ID)."
+#endif
+
+// Matches writer_combine / reader_combine: a slot whose route_info[0] == this marks end-of-stream.
+constexpr uint32_t ROUTE_INFO_SENTINEL = 0xFFFFFFFF;
+
+void kernel_main() {
+    using namespace ttnn::operations::ccl::common;
+
+    // ===== Compile-time args =====
+    [[maybe_unused]] constexpr uint32_t output_pages = get_compile_time_arg_val(0);  // page idx comes from slot
+    constexpr uint32_t aligned_output_page_size = get_compile_time_arg_val(1);
+    constexpr uint32_t fabric_max_packet_size = get_compile_time_arg_val(2);
+    constexpr uint32_t l1_alignment = get_compile_time_arg_val(3);
+    [[maybe_unused]] constexpr uint32_t num_links = get_compile_time_arg_val(4);
+    [[maybe_unused]] constexpr tt::tt_fabric::Topology topology = (tt::tt_fabric::Topology)get_compile_time_arg_val(5);
+    constexpr uint32_t mesh_rows = get_compile_time_arg_val(6);
+    constexpr uint32_t mesh_cols = get_compile_time_arg_val(7);
+    constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(8);
+    constexpr uint32_t src_chip_id = get_compile_time_arg_val(9);
+    [[maybe_unused]] constexpr uint32_t src_mesh_id = get_compile_time_arg_val(10);
+    constexpr uint32_t num_chips = get_compile_time_arg_val(11);
+    constexpr uint32_t cb_packet_header_id = get_compile_time_arg_val(12);
+    constexpr uint32_t cb_relay_buf = get_compile_time_arg_val(13);
+    constexpr auto output_args = TensorAccessorArgs<14>();
+
+#ifdef AXIS
+    constexpr ReplicateGroup axis = ReplicateGroup(AXIS);
+    constexpr uint32_t combine_devices = axis == ReplicateGroup::COLS ? mesh_rows : mesh_cols;
+#else
+    constexpr ReplicateGroup axis = ReplicateGroup::NONE;
+    constexpr uint32_t combine_devices = num_chips;
+#endif
+    constexpr uint32_t total_mesh_devices = mesh_rows * mesh_cols;
+    constexpr uint8_t dest_chip_ids[total_mesh_devices] = DEST_CHIP_ID;
+    constexpr uint8_t dest_mesh_ids[total_mesh_devices] = DEST_MESH_ID;
+    constexpr std::array<bool, 4> directions = DIRECTIONS;
+
+    // ===== Runtime args =====
+    size_t rt_args_idx = 0;
+    uint32_t output_addr = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t init_semaphore_address = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t exit_semaphore_address = get_arg_val<uint32_t>(rt_args_idx++);
+    // sender->relay pipe args (owning sender NOC coords + 3 flow-control sem ids). Read BEFORE the
+    // fabric-connection args (which follow), matching the factory append order.
+    const uint32_t sender_noc_x = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t sender_noc_y = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t relay_data_ready_sem_id = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t relay_credits_sem_id = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t relay_buf_addr_sem_id = get_arg_val<uint32_t>(rt_args_idx++);
+    // fabric-connection args are appended after this by append_fabric_connection_rt_args (read below).
+
+    // ===== Fabric connections (FABRIC_1D array + per-target unicast handshake) =====
+    uint32_t packet_header_buffer_address = get_read_ptr(cb_packet_header_id);
+    auto* unicast_packet_header = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_address);
+    std::array<tt::tt_fabric::WorkerToFabricEdmSender, 4> fabric_connections;
+    open_direction_connections_async(directions, fabric_connections, rt_args_idx);
+    auto* sem_packet_header =
+        reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_address + sizeof(PACKET_HEADER_TYPE));
+    open_direction_connections_barrier(directions, fabric_connections);
+
+    // ===== Init semaphore exchange =====
+    const uint64_t init_noc_semaphore_addr = get_noc_addr(init_semaphore_address);
+    send_init_semaphore_to_configured_targets<
+        linearized_mesh_coord,
+        topology,
+        src_chip_id,
+        mesh_rows,
+        mesh_cols,
+        axis,
+        total_mesh_devices>(
+        fabric_connections, sem_packet_header, dest_chip_ids, dest_mesh_ids, init_noc_semaphore_addr);
+    volatile tt_l1_ptr uint32_t* init_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(init_semaphore_address);
+    noc_semaphore_wait(init_sem_ptr, combine_devices - 1);
+    noc_semaphore_set(init_sem_ptr, 0);
+
+    // Publish our c_24 base to the owning sender (into its relay_buf_addr sem L1) so it knows where to
+    // NOC-write tokens. Done AFTER the init handshake; the sender spins on this until non-zero.
+    const uint32_t relay_buf_base = get_write_ptr(cb_relay_buf);
+    noc_inline_dw_write<InlineWriteDst::L1>(
+        get_noc_addr(sender_noc_x, sender_noc_y, get_semaphore(relay_buf_addr_sem_id)), relay_buf_base);
+    noc_async_writes_flushed();
+
+    const auto output_addr_gen = TensorAccessor(output_args, output_addr);
+
+    // ===== CB consumer: read sender-produced tokens from c_24 and forward to fabric =====
+    // The sender (writer_combine) produces route_info + payload into our c_24 ring and terminates the
+    // stream with a ROUTE_INFO_SENTINEL slot. For each real slot we read its route_info (route dir,
+    // distance, page idx), fabric-send its payload, then return the slot's credit so the sender can
+    // refill it; a sentinel breaks the loop. The send is blocking (fabric_send_noc_unicast +
+    // noc_async_writes_flushed), so the slot's payload read has completed before we return the credit —
+    // the sender cannot overwrite the slot until it sees that credit, so there is no torn read.
+    {
+        const uint32_t relay_slot_size = l1_alignment + aligned_output_page_size;
+        const uint32_t relay_buf_base_c = get_write_ptr(cb_relay_buf);
+        volatile tt_l1_ptr uint32_t* data_ready_ptr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(relay_data_ready_sem_id));
+        const uint64_t sender_credits_noc_addr =
+            get_noc_addr(sender_noc_x, sender_noc_y, get_semaphore(relay_credits_sem_id));
+
+        uint32_t consumed = 0;
+        while (true) {
+            // Wait until slot `consumed` is filled: the producer monotonically ++ data_ready per token.
+            while (true) {
+                invalidate_l1_cache();
+                if (*data_ready_ptr > consumed) {
+                    break;
+                }
+            }
+            const uint32_t r = consumed % RELAY_SLOTS;
+            const uint32_t slot_base = relay_buf_base_c + r * relay_slot_size;
+            volatile tt_l1_ptr uint32_t* ri = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(slot_base);
+            const uint32_t route = ri[0];
+
+            if (route == ROUTE_INFO_SENTINEL) {
+                // Sender signalled end-of-stream. Free the sentinel slot and stop.
+                noc_semaphore_inc<true>(sender_credits_noc_addr, 1);
+                consumed++;
+                break;
+            }
+
+            const uint32_t distance = ri[1];
+            const uint32_t output_page_idx = ri[2];
+            const uint32_t payload_addr = slot_base + l1_alignment;
+
+            ccl_routing_utils::line_unicast_route_info_t pkt_route_info{};
+            pkt_route_info.distance_in_hops = static_cast<uint16_t>(distance);
+            auto& payload_sender = fabric_connections[route];
+
+            ccl_routing_utils::fabric_set_line_unicast_route(
+                pkt_hdr_for_route_helper(unicast_packet_header), pkt_route_info);
+            fabric_send_noc_unicast<fabric_max_packet_size>(
+                output_addr_gen,
+                payload_sender,
+                unicast_packet_header,
+                payload_addr,
+                output_page_idx,
+                (int)aligned_output_page_size,
+                l1_alignment);
+            noc_async_writes_flushed();  // payload has departed L1 -> slot's read done, safe to free
+
+            // Return the slot's credit so the sender can refill it.
+            noc_semaphore_inc<true>(sender_credits_noc_addr, 1);
+            consumed++;
+        }
+    }
+
+    // Drain pending local NOC writes before the exit handshake / connection teardown.
+    noc_async_write_barrier();
+
+    // ===== Exit semaphore exchange (flush=true so peers can't see the inc before our data lands) =====
+    {
+        const uint64_t exit_noc_semaphore_addr = get_noc_addr(exit_semaphore_address);
+        send_init_semaphore_to_configured_targets<
+            linearized_mesh_coord,
+            topology,
+            src_chip_id,
+            mesh_rows,
+            mesh_cols,
+            axis,
+            total_mesh_devices>(
+            fabric_connections,
+            sem_packet_header,
+            dest_chip_ids,
+            dest_mesh_ids,
+            exit_noc_semaphore_addr,
+            /*flush=*/true);
+        volatile tt_l1_ptr uint32_t* exit_sem_ptr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(exit_semaphore_address);
+        noc_semaphore_wait(exit_sem_ptr, combine_devices - 1);
+        noc_semaphore_set(exit_sem_ptr, 0);
+    }
+
+    noc_async_full_barrier();
+    close_direction_connections(directions, fabric_connections);
+}


### PR DESCRIPTION
### PR Category
Performance

### Summary
Two sender tensix cores are writing over NoC_1 to the 4 ETH cores. ETH cores are also forming 2 ring-type communication channels (1 per fabric plane) to forward packages which are just transiting through the chip. This overlaps up to 6 writes over same NoC row (the one where ETH cores are). The fix puts each sender battery on its own row, and adds new tensix core which switches NoC over which it writes to ETH cores, so that there are at most 2 congesting data transfers over any NoC line. For BH_GLX this makes fabric the bottleneck.

Further improvements are possible with round-robin of destinations during send, so that load on fabric links is balanced and they are equally loaded all the time, but that is out of scope of this PR.

### Notes for reviewers
Ideally call out all the tests that should be conducted. So far, a sanity check on BH-LB-ring8-200GbE of test_ttnn_combine was conducted in tracy wrapper to verify that main data send loop on every device is shorter than in main.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dlukic/combine-noc-congestion-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dlukic/combine-noc-congestion-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dlukic/combine-noc-congestion-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dlukic/combine-noc-congestion-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dlukic/combine-noc-congestion-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dlukic/combine-noc-congestion-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dlukic/combine-noc-congestion-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dlukic/combine-noc-congestion-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dlukic/combine-noc-congestion-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dlukic/combine-noc-congestion-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dlukic/combine-noc-congestion-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dlukic/combine-noc-congestion-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dlukic/combine-noc-congestion-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dlukic/combine-noc-congestion-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dlukic/combine-noc-congestion-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dlukic/combine-noc-congestion-fix)