### PR TITLE
[Performance] GDN prefill: native depthwise conv1d (replaces manual FIR)

### DIFF
--- a/models/demos/blackhole/qwen36/tests/test_factory.py
+++ b/models/demos/blackhole/qwen36/tests/test_factory.py
@@ -181,9 +181,12 @@ def parametrize_mesh_tp(max_tp=4):
     shape = _resolve_mesh_shape(max_tp)
 
     def decorator(fn):
-        fn = pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)(
-            fn
-        )
+        fn = pytest.mark.parametrize(
+            "device_params",
+            # l1_small_size required by ttnn.conv1d in the GDN prefill path
+            [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "l1_small_size": 24576}],
+            indirect=True,
+        )(fn)
         fn = pytest.mark.parametrize("mesh_device", [pytest.param(shape, id=f"{shape[0]}x{shape[1]}")], indirect=True)(
             fn
         )

--- a/models/demos/blackhole/qwen36/tests/test_factory.py
+++ b/models/demos/blackhole/qwen36/tests/test_factory.py
@@ -179,12 +179,14 @@ def parametrize_mesh_tp(max_tp=4):
     keys) are readable.
     """
     shape = _resolve_mesh_shape(max_tp)
+    # Local import to keep this test helper's module load light (see module docstring).
+    from models.demos.blackhole.qwen36.tt.model_config import GDN_CONV1D_L1_SMALL_SIZE
 
     def decorator(fn):
         fn = pytest.mark.parametrize(
             "device_params",
             # l1_small_size required by ttnn.conv1d in the GDN prefill path
-            [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "l1_small_size": 24576}],
+            [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "l1_small_size": GDN_CONV1D_L1_SMALL_SIZE}],
             indirect=True,
         )(fn)
         fn = pytest.mark.parametrize("mesh_device", [pytest.param(shape, id=f"{shape[0]}x{shape[1]}")], indirect=True)(

--- a/models/demos/blackhole/qwen36/tt/gdn/tp.py
+++ b/models/demos/blackhole/qwen36/tt/gdn/tp.py
@@ -110,6 +110,16 @@ def load_gdn_weights_tp(mesh, sd, args, cache_dir=None):
     # ---- conv taps (4), sharded per Q/K/V head grouping ----
     taps = tpc.prepare_conv_taps(conv1d_w, key_dim, nk, dk, nv, dv, args.gdn_conv_kernel_size, tp)
     tw["conv_taps"] = [tpc.shard_small(taps[j], mesh, c(f"tap{j}")) for j in range(args.gdn_conv_kernel_size)]
+    # Depthwise conv1d weight used in the prefill path
+    _kk = args.gdn_conv_kernel_size
+    tw["conv1d_w"] = ttnn.as_tensor(
+        torch.stack([t.float() for t in taps], dim=-1).reshape(-1, 1, _kk).to(torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        device=mesh,
+        mesh_mapper=ttnn.ShardTensorToMesh(mesh, dim=0),
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
     return tw
 
 
@@ -139,6 +149,10 @@ class TPGatedDeltaNet:
         # trace; pre-allocating here (outside any trace) makes the GDN prefill trace-safe. Mirrors
         # the single-device gdn/weights.py create_chunk_masks_seq usage.
         self.chunk_seq_masks = create_chunk_masks_seq(args.gdn_chunk_size, mesh)
+        # Depthwise conv1d for prefill
+        self._conv1d_w = tw.get("conv1d_w")
+        self._conv1d_w_dev = None
+        self._conv1d_ccfg = None
         self.conv_states = None
         self.rec_state = None
         # When True, decode/prefill update rec_state IN PLACE (ttnn.copy into the fixed
@@ -215,6 +229,71 @@ class TPGatedDeltaNet:
         ttnn.copy(zcc, self.conv_carry)
         ttnn.deallocate(zcc)
 
+    def _conv1d_prefill(self, qkv, conv_state, T):
+        """Depthwise conv1d + SiLU
+        Returns (conv [1,T,C] TILE
+        DRAM-interleaved, new_state [1,K-1,C] TILE for the cross-chunk carry).
+        """
+        K, C = self.K, self.qkv_dim_tp
+        DR = ttnn.DRAM_MEMORY_CONFIG
+        if conv_state is None:
+            pad = ttnn.zeros(
+                [1, K - 1, C], device=self.mesh, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, memory_config=DR
+            )
+            xp = ttnn.concat([pad, qkv], dim=1, memory_config=DR)
+            ttnn.deallocate(pad)
+        else:
+            xp = ttnn.concat([conv_state, qkv], dim=1, memory_config=DR)
+        Lp = (K - 1) + T
+        # new_state = last K-1 real conv inputs (TILE, for the carry buffer) — take before RM cast.
+        new_state = ttnn.to_layout(ttnn.slice(xp, (0, Lp - (K - 1), 0), (1, Lp, C)), ttnn.TILE_LAYOUT)
+        xp_rm = ttnn.to_layout(xp, ttnn.ROW_MAJOR_LAYOUT, memory_config=DR)
+        ttnn.deallocate(xp)
+        if self._conv1d_ccfg is None:
+            self._conv1d_ccfg = ttnn.init_device_compute_kernel_config(
+                self.mesh.arch(), math_fidelity=ttnn.MathFidelity.HiFi4, fp32_dest_acc_en=True
+            )
+        cfg = ttnn.Conv1dConfig(weights_dtype=ttnn.bfloat16, shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED)
+        w = self._conv1d_w_dev if self._conv1d_w_dev is not None else self._conv1d_w
+        try:
+            out, _, [w_dev, _] = ttnn.conv1d(
+                input_tensor=xp_rm,
+                weight_tensor=w,
+                in_channels=C,
+                out_channels=C,
+                device=self.mesh,
+                bias_tensor=None,
+                kernel_size=K,
+                stride=1,
+                padding=0,
+                batch_size=1,
+                input_length=Lp,
+                conv_config=cfg,
+                compute_config=self._conv1d_ccfg,
+                groups=C,
+                dtype=ttnn.bfloat16,
+                return_output_dim=True,
+                return_weights_and_bias=True,
+            )
+        except RuntimeError as e:
+            # The depthwise conv1d needs an L1_SMALL scratch region; if the device was opened
+            # without enough l1_small_size, ttnn TT_FATALs deep in the allocator with an opaque
+            # "bank size is 0 B" message. Surface the real cause + fix instead.
+            if "L1_SMALL" in str(e) or "bank size is 0" in str(e):
+                raise RuntimeError(
+                    "GDN prefill conv1d failed to allocate its L1_SMALL scratch buffer. The device "
+                    "must be opened with l1_small_size >= 24576 (the production demo/vLLM value). "
+                    "Set it in the device open, e.g. device_params={'l1_small_size': 24576} "
+                    "(see models/demos/blackhole/qwen36/demo/text_demo.py DEVICE_PARAMS). "
+                    f"Original error: {e}"
+                ) from e
+            raise
+        self._conv1d_w_dev = w_dev
+        ttnn.deallocate(xp_rm)
+        out = ttnn.to_memory_config(out, DR)  # sharded -> DRAM interleaved for the head-split
+        out = ttnn.reshape(out, (1, T, C))
+        return ttnn.silu(out, memory_config=DR), new_state
+
     def forward_prefill(self, x, chunk_size=128, valid_len=None, capture_state=False):
         """Causal chunk-prefill over a sequence (from scratch, zero init state).
 
@@ -259,18 +338,23 @@ class TPGatedDeltaNet:
         # FIR causal conv1d + SiLU over the sequence. conv_state = the carried last K-1 conv
         # inputs of the previous chunk (left context); zero == None for a from-scratch pass.
         # valid_len makes new_state capture the last K-1 REAL tokens (not padding).
-        conv, conv_new_state = _causal_conv1d_fir(
-            qkv,
-            None,
-            None,
-            self.K,
-            self.mesh,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            conv_state=self.conv_carry if carry else None,
-            weight_taps=tw["conv_taps"],
-            bias_dev=None,
-            valid_len=valid_len,
-        )
+        if valid_len is None and self._conv1d_w is not None:
+            # On-core depthwise conv1d for the full-chunk path. The masked tail (valid_len set) +
+            # decode keep the manual FIR / decode helpers.
+            conv, conv_new_state = self._conv1d_prefill(qkv, self.conv_carry if carry else None, T)
+        else:
+            conv, conv_new_state = _causal_conv1d_fir(
+                qkv,
+                None,
+                None,
+                self.K,
+                self.mesh,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                conv_state=self.conv_carry if carry else None,
+                weight_taps=tw["conv_taps"],
+                bias_dev=None,
+                valid_len=valid_len,
+            )
         ttnn.deallocate(qkv)
 
         kd = self.key_dim_tp

--- a/models/demos/blackhole/qwen36/tt/gdn/tp.py
+++ b/models/demos/blackhole/qwen36/tt/gdn/tp.py
@@ -17,6 +17,7 @@ import torch
 
 import ttnn
 from models.demos.blackhole.qwen36.tt import tp_common as tpc
+from models.demos.blackhole.qwen36.tt.model_config import GDN_CONV1D_L1_SMALL_SIZE
 from models.experimental.gated_attention_gated_deltanet.tt.ttnn_delta_rule_ops import (
     recurrent_gated_delta_rule_decode_ttnn,
 )
@@ -253,7 +254,13 @@ class TPGatedDeltaNet:
             self._conv1d_ccfg = ttnn.init_device_compute_kernel_config(
                 self.mesh.arch(), math_fidelity=ttnn.MathFidelity.HiFi4, fp32_dest_acc_en=True
             )
-        cfg = ttnn.Conv1dConfig(weights_dtype=ttnn.bfloat16, shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED)
+        # SiLU fused into the conv epilogue — runs on the sharded output in-kernel, so it costs
+        # no extra dispatch or DRAM round-trip vs. a standalone ttnn.silu.
+        cfg = ttnn.Conv1dConfig(
+            weights_dtype=ttnn.bfloat16,
+            shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.SILU),
+        )
         w = self._conv1d_w_dev if self._conv1d_w_dev is not None else self._conv1d_w
         try:
             out, _, [w_dev, _] = ttnn.conv1d(
@@ -281,10 +288,10 @@ class TPGatedDeltaNet:
             # "bank size is 0 B" message. Surface the real cause + fix instead.
             if "L1_SMALL" in str(e) or "bank size is 0" in str(e):
                 raise RuntimeError(
-                    "GDN prefill conv1d failed to allocate its L1_SMALL scratch buffer. The device "
-                    "must be opened with l1_small_size >= 24576 (the production demo/vLLM value). "
-                    "Set it in the device open, e.g. device_params={'l1_small_size': 24576} "
-                    "(see models/demos/blackhole/qwen36/demo/text_demo.py DEVICE_PARAMS). "
+                    f"GDN prefill conv1d failed to allocate its L1_SMALL scratch buffer. The device "
+                    f"must be opened with l1_small_size >= {GDN_CONV1D_L1_SMALL_SIZE} (the production demo/vLLM "
+                    f"value). Set it in the device open, e.g. device_params={{'l1_small_size': {GDN_CONV1D_L1_SMALL_SIZE}}} "
+                    f"(see models/demos/blackhole/qwen36/demo/text_demo.py DEVICE_PARAMS). "
                     f"Original error: {e}"
                 ) from e
             raise
@@ -292,7 +299,7 @@ class TPGatedDeltaNet:
         ttnn.deallocate(xp_rm)
         out = ttnn.to_memory_config(out, DR)  # sharded -> DRAM interleaved for the head-split
         out = ttnn.reshape(out, (1, T, C))
-        return ttnn.silu(out, memory_config=DR), new_state
+        return out, new_state  # SiLU already applied in the conv epilogue (cfg.activation)
 
     def forward_prefill(self, x, chunk_size=128, valid_len=None, capture_state=False):
         """Causal chunk-prefill over a sequence (from scratch, zero init state).

--- a/models/demos/blackhole/qwen36/tt/gdn/tp.py
+++ b/models/demos/blackhole/qwen36/tt/gdn/tp.py
@@ -346,8 +346,8 @@ class TPGatedDeltaNet:
         # inputs of the previous chunk (left context); zero == None for a from-scratch pass.
         # valid_len makes new_state capture the last K-1 REAL tokens (not padding).
         if valid_len is None and self._conv1d_w is not None:
-            # On-core depthwise conv1d for the full-chunk path. The masked tail (valid_len set) +
-            # decode keep the manual FIR / decode helpers.
+            # Native depthwise conv1d for the full-chunk path.
+            # The masked tail and decode keep the manual FIR.
             conv, conv_new_state = self._conv1d_prefill(qkv, self.conv_carry if carry else None, T)
         else:
             conv, conv_new_state = _causal_conv1d_fir(

--- a/models/demos/blackhole/qwen36/tt/model_config.py
+++ b/models/demos/blackhole/qwen36/tt/model_config.py
@@ -26,6 +26,12 @@ from pathlib import Path
 
 from models.tt_transformers.tt.model_config import ModelArgs
 
+# l1_small_size (device-open scratch) the GDN prefill depthwise ttnn.conv1d requires. Empirically
+# established minimum; the production demo/vLLM open the device with this value. Single source of
+# truth for the runtime guard (gdn/tp.py) and the TP test decorator (tests/test_factory.py) so the
+# check, the tests, and device setup cannot drift apart.
+GDN_CONV1D_L1_SMALL_SIZE = 24576
+
 
 class Qwen36ModelArgs(ModelArgs):
     """Model configuration for Qwen3.5-9B on Blackhole P150."""

--- a/models/demos/blackhole/qwen36/tt/model_config.py
+++ b/models/demos/blackhole/qwen36/tt/model_config.py
@@ -26,10 +26,7 @@ from pathlib import Path
 
 from models.tt_transformers.tt.model_config import ModelArgs
 
-# l1_small_size (device-open scratch) the GDN prefill depthwise ttnn.conv1d requires. Empirically
-# established minimum; the production demo/vLLM open the device with this value. Single source of
-# truth for the runtime guard (gdn/tp.py) and the TP test decorator (tests/test_factory.py) so the
-# check, the tests, and device setup cannot drift apart.
+# l1_small_size the GDN prefill depthwise ttnn.conv1d requires.
 GDN_CONV1D_L1_SMALL_SIZE = 24576
 
 


### PR DESCRIPTION
### PR Category
Performance

### Summary

Contributes to https://github.com/tenstorrent/tt-metal/issues/42828

Replace the manual FIR causal-conv sequence on the Gated DeltaNet (GDN) `forward_prefill`
  full-chunk path with a single on-core **depthwise `ttnn.conv1d`** (K-tap MAC, `groups=C`,
  `HEIGHT_SHARDED`) + SiLU.

  1. **Native depthwise conv1d.** The full-chunk causal conv is now one on-core `ttnn.conv1d`
  instead of the K-tap manual FIR (~20 DRAM-round-tripping tilize / untilize / mul / mac / add
  ops). Left context comes from the existing conv-state concat; the last `K-1` inputs are sliced
  off (before the RM cast) for the cross-chunk carry.
  2. **Scoped to the full-chunk path.** The masked-tail path (`valid_len` set) and the decode path
  keep the manual FIR / decode helpers unchanged.

### Performance

  **End-to-end, `text_demo.py -k traced_8k` (8192-token prefill), p150b × 4 (TP)**
 | Metric | Baseline (`main`) | PR | Delta |
  |--------|------------------:|---:|------:|
  | TTFT (8192-token prefill) | 4.22 s | 4.01 s | **−0.21 s  (−5.0%)** |
  | Decode | 18.11 tok/s | 18.14 tok/s | ~0 (prefill-only change) |

  (Both configs stable across 2 runs: baseline 4.22 / 4.21 s, PR 4.01 / 4.01 s.)

  **GDN `forward_prefill` (one block, device-bound wall-clock, `GDN_PERF_SIM_TP=4` single card,
  min of 9 reps, T=4096 = 2 × 2048-token windows)**
 | Metric | Baseline (FIR) | PR (conv1d) | Delta |
  |--------|---------------:|------------:|------:|
  | forward_prefill (2 windows) | 84.6 ms | 74.0 ms | **−10.6 ms  (−12.5%)** |
  | per 2048-token window | 42.3 ms | 37.0 ms | −5.3 ms |

  The wall-clock delta captures both the kernel win and the ~15 fewer dispatched ops per window.

  **conv stage, isolated device-kernel time (Tracy, per-stage signposts)**
 | Stage | Baseline (FIR) | PR (conv1d) | Delta |
  |-------|---------------:|------------:|------:|
  | conv | 4.10 ms | 1.92 ms | **−2.18 ms  (−53%)** |

  The manual FIR's ~20 DRAM-round-tripping tilize / untilize / mul / add ops are replaced by one
  on-core depthwise conv1d + SiLU.

### Correctness

  `test_gdn_tp_prefill` (prefill-vs-decode self-consistency, p150b × 4, bar 0.95): **PCC 0.99205**
  (manual-FIR baseline 0.99213). conv1d is numerically equivalent to the FIR within bf16.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/gdn-conv1d)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/gdn-conv1d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/gdn-conv1d)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/gdn-conv1d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=iwrosz/gdn-conv1d)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:iwrosz/gdn-conv1d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/gdn-conv1d)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/gdn-conv1d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/gdn-conv1d)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/gdn-conv1d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/gdn-conv1d)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/gdn-conv1d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/gdn-conv1d)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/gdn-conv1d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/gdn-conv1d)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/gdn-conv1d)