### PR TITLE
[Documentation] Add Tensor Prefetcher tech report

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ For information on initial model procedures, please see [Model Bring-Up and Test
 - [ViT Implementation in TT-NN on GS](./tech_reports/ViT-TTNN/vit.md)  (updated Sept 22nd, 2024)
 - [LLMs Bring up in TT-NN](./tech_reports/LLMs/llms.md)  (updated Oct 29th, 2024)
 - [CNN Bring up & Optimization in TT-NN](./tech_reports/CNNs/cnn_optimizations.md) (updated Jan 22nd, 2025)
+- [The Tensor Prefetcher on Blackhole](./tech_reports/TensorPrefetcher/TensorPrefetcher.md) (updated July 15th, 2026)
 
 ## Benchmarks
 

--- a/tech_reports/TensorPrefetcher/TensorPrefetcher.md
+++ b/tech_reports/TensorPrefetcher/TensorPrefetcher.md
@@ -1,0 +1,344 @@
+# The Tensor Prefetcher on Blackhole
+
+The Tensor prefetcher streams matmul weight tensors out of DRAM and pushes them, over the NoC, directly into a ring of worker cores running a `gather_in0` 1D multicast matmul. The matmul reads its weights (in1) from a Global Circular Buffer (GCB); the prefetcher aims to keep that GCB full so the matmul is not left waiting on a DRAM read. The sender kernel runs on the **programmable DRAM core (DRISC)** itself — on Blackhole, right next to the GDDR controller — so weights go DRAM → DRISC L1 → NoC → receiver, without staging through an intermediate worker core (the final NoC transfer is a route that may still cross several links).
+
+This report explains what the feature does, when it applies, and how to drive it from Python. It is the *usage* companion to the internal contract document `tt_metal/impl/buffers/prefetcher_matmul_design.md`, which pins down the byte-level handshake between the prefetcher and the matmul receiver.
+
+> **Status:** the Tensor prefetcher is an experimental API under active development (the `ttnn.experimental.*` surface below). This report was last validated against the tree at branch `jbauman/tensor-prefetcher-tech-report` (July 2026); signatures may shift as the feature stabilizes.
+
+## Contents
+
+1. [Overview](#1-overview)
+2. [When it applies](#2-when-it-applies)
+3. [The ring](#3-the-ring)
+4. [Weight layouts](#4-weight-layouts)
+5. [Basic usage](#5-basic-usage)
+6. [Sizing the GCB](#6-sizing-the-gcb)
+7. [Tracing](#7-tracing)
+8. [Lower-level control](#8-lower-level-control)
+9. [Pitfalls](#9-pitfalls)
+10. [References](#10-references)
+
+## 1. Overview
+
+Running the sender on the DRAM core puts it right beside the GDDR controller, which lets it push at high throughput on production shapes; its working L1 is small (~70 KB), which shapes how weights are staged. The path is Blackhole-only and requires programmable DRAM cores (§2).
+
+The Tensor prefetcher is a **Start / Queue / Stop** lifecycle rather than a single op:
+
+- `start_tensor_prefetcher` launches the DRISC sender kernels and a host worker thread, then returns. It is a long-running daemon; no prefetch work is scheduled yet. Only **one** prefetcher may be active per `MeshDevice` at a time.
+- Each request describes a list of weights to stream. The DRISC kernels DMA their share of each weight from GDDR and push it into the receiver-side GCB. The usual pattern queues each weight immediately before the matmul that consumes it. The prefetcher reads the weights from DRAM asynchronously (and again on every trace replay), so **every queued weight tensor and the GCB must stay alive until `stop_tensor_prefetcher` returns** — don't let them be deallocated while the prefetcher is running.
+- `stop_tensor_prefetcher` shuts the kernels and worker thread down. Call it before the device is torn down.
+
+GCB credits gate the producer/consumer pipeline, so the DRISC back-pressures when the ring is full and the matmul consumes pages as they arrive. The DRISC daemon lives outside any trace, but a request issued while a command queue is capturing is recorded into that trace and replayed on each run, alongside the matmul it precedes (§7).
+
+The figure below shows one workable layout on a Blackhole P150: ring size 64 (8 DRAM banks × 8 receivers per bank). You choose the receiver placement (§3), so treat the arrangement here as an example. Red tiles are the DRISC sender cores at the left/right DRAM columns; blue tiles are the activation-ring worker cores where the matmul runs. Pink links are weight pushes (DRISC → receiver, NoC0); green links are the activation ring (NoC1).
+
+<img src="media/tensor_prefetcher_ring64_chip.svg" style="width:900px;" alt="Blackhole P150 chip grid showing one example ring-64 layout: DRISC sender tiles on the left/right DRAM columns push weights over NoC0 (pink) to 64 activation-ring worker tiles connected in a ring over NoC1 (green)."/>
+
+*Figure 1: An example ring-64 layout. DRISC senders (red) push weights on NoC0 to the worker ring (blue), which circulates activations on NoC1.*
+
+## 2. When it applies
+
+The Tensor prefetcher runs only where programmable DRAM cores are available. `is_tensor_prefetcher_supported` reports this; `start_tensor_prefetcher` raises when it is `False`, so gate on the check:
+
+```python
+if not ttnn.experimental.is_tensor_prefetcher_supported(device):
+    pytest.skip("programmable DRAM cores unavailable")
+```
+
+It is `True` only on **Blackhole**, with firmware **≥ 19.12.0.0**, and **either no harvested DRAM channels or a single device**. A `models.common.utility_functions.run_for_blackhole` pytest marker handles the arch gate for tests.
+
+## 3. The ring
+
+A note on dimensions first, since the rest of the report leans on them. The matmul computes `out[M, N] = activation[M, K] @ weight[K, N]`. **K** is the contraction (input-feature) dimension — the width of the activation and the height of the weight, summed over during the multiply. **N** is the output-feature dimension — the weight's width and the output's width. **M** is the token/batch dimension, small in decode (often 32). The weight the prefetcher streams is the `K × N` matrix; the ring splits its **K** into blocks (one per ring step) and its **N** across receivers (each owns `N / ring_size` columns).
+
+Each weight is streamed across a fixed **ring** of receiver cores:
+
+```
+ring_size = num_dram_banks * receivers_per_bank
+```
+
+The ring size is the unit of everything: the K dimension is delivered as `ring_size` K-blocks, and the matmul does `wait_front(ring_size)` per layer. Each **DRAM bank** (identified by a `bank_id`) is a sender domain that feeds a disjoint set of **receiver worker cores**, described to the API as a `bank_to_receivers` list of `(bank_id, CoreRangeSet)` pairs.
+
+Take `num_dram_banks` from the device (`device.dram_grid_size().x`) rather than hardcoding 8 — some cards harvest a DRAM bank and have fewer. A P100, for example, reports 7 banks, not 8, and your ring geometry, weight sharding, and `bank_to_receivers` must all be built against that count. (Recall from §2 that a harvested DRAM channel is only supported on a single device, not across a mesh.)
+
+Ring position `r` determines what a receiver needs: it computes output N-columns `[r*per_core_N, (r+1)*per_core_N)`, so it must receive weight shard `r`. A core's ring position is set by the order it appears in the receiver `CoreRangeSet` — the ranges in the order you add them, row-major *within* each range — not by any fixed walk of the grid. So with one single-core range per position you assign ring positions explicitly, in any (even scattered) order; §5 shows exactly how that ordering reaches the matmul. Bank `b` must then own the ring positions the matmul expects, and the weight's shard placement must agree with that pairing (§4). Production uses a scattered receiver layout (see `models/tt_transformers/tt/prefetcher`); a plain row-major grid works for a smoke test:
+
+```python
+def bank_receivers_row_major(bank_idx, recv_per_bank, ring_cols, row_offset=0):
+    cores = []
+    for k in range(recv_per_bank):
+        ring_pos = bank_idx * recv_per_bank + k
+        col = ring_pos % ring_cols
+        row = ring_pos // ring_cols + row_offset
+        cores.append(ttnn.CoreRange(ttnn.CoreCoord(col, row), ttnn.CoreCoord(col, row)))
+    return ttnn.CoreRangeSet(cores)
+
+bank_to_receivers = [
+    (b, bank_receivers_row_major(b, recv_per_bank, ring_cols))
+    for b in range(num_dram_banks)
+]
+```
+
+A ring of 16 (8 banks × 2 receivers/bank) — the smallest production-shaped ring — might be laid out like this:
+
+<img src="media/tensor_prefetcher_ring16_chip.svg" style="width:750px;" alt="Blackhole chip grid showing one example ring-16 layout: 8 DRISC sender tiles each pushing weights over NoC0 to 2 of the 16 worker-ring tiles, which circulate activations over NoC1."/>
+
+*Figure 2: An example ring-16 layout (8 banks × 2 receivers).*
+
+### Receiver placement and NoC congestion
+
+The placement is entirely caller-controlled: you decide which worker cores form the receiver ring (by sharding the activation and output tensors on them) and how each DRAM bank pairs to its receivers (`bank_to_receivers`). The row-major grid above is the simplest choice and is fine to start with.
+
+Placement matters for bandwidth. The two traffic patterns run on separate NoCs — weight pushes (DRAM → receiver) on NoC0, the activation ring (receiver → receiver) on NoC1 — so they do not contend with each other; the goal is instead to avoid congestion within each NoC. The same receiver-core coordinates set the routes on both NoCs at once, so the placement is a single decision that has to keep both directions clean.
+
+You construct the receiver ring yourself, from the cores actually free on your device, and pair `bank_to_receivers` to it. Whatever placement you pick, keep these in mind:
+
+- **Ring order.** Receiver at ring position `r` must consume shard `r`, so lay the receivers out in ring order and pair `bank_to_receivers` to the weight's shard distribution (§4).
+- **Account for harvesting.** A column-harvested part changes the logical→physical core mapping, so the same logical placement lands on different physical cores — and therefore different NoC routes — than on an unharvested part. Factor the harvesting into an optimal placement.
+- **Both NoCs at once.** A placement that unclogs the NoC0 weight-push routes can crowd the NoC1 activation ring, or vice versa — the coordinates you choose fix both, so evaluate congestion on each NoC independently.
+
+`MeshDevice.get_optimal_dram_bank_to_logical_worker_assignment(noc, coord)` returns, for the device at mesh coordinate `coord`, a `Dict[int, CoreCoord]` mapping each DRAM bank id to a worker core. It is a useful *input* for placement — it reflects that device's harvesting and DRAM geometry, so you can read per-device bank→core relationships off it — but it is not a turnkey receiver assignment: it optimizes `noc_async_read`/`write` endpoints, whose rows differ from the DRISC NoC endpoints, so it does not directly optimize DRISC→receiver routes. (The one-argument `get_optimal_dram_bank_to_logical_worker_assignment(noc)` form is deprecated; it reports only the mesh's reference device and is wrong on a heterogeneously harvested mesh — pass the `coord` overload.)
+
+## 4. Weight layouts
+
+The prefetcher supports two DRAM weight layouts. The GCB factory detects which one a weight uses from its allocation and builds the matching plumbing; all weights sharing one GCB must use the same layout.
+
+**Receiver-contiguous** (`NdShardSpec`, `num_shards == ring_size`) is the recommended default. Each shard — full K, `N / ring_size` columns — is owned by exactly one receiver. Because receivers no longer share a bank's data, a bank with two or more receivers can be driven by two DRISC sender cores at once, roughly doubling per-bank bandwidth, and it is the layout that supports streaming delivery (§5). Combined, streaming receiver-contiguous weights give the best mix of throughput and flexibility, so use this layout by default. These recommendations (receiver-contiguous, dual senders, `CONTIGUOUS_1D` — §4) are measurement-backed on Blackhole production Llama shapes; measure your own shapes with `tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bench.py`.
+
+K must be tile-aligned *and* divisible by `ring_size`, and N must divide evenly into `ring_size` shard columns, so pad the host tensor before allocating: K up to a multiple of `ring_size * TILE_SIZE`, and require `N % ring_size == 0` (pad N similarly if it does not). The device weight is allocated from that padded host tensor.
+
+```python
+K_padded = round_up(K, ring_size * ttnn.TILE_SIZE)
+assert N % ring_size == 0, "N must divide evenly across ring_size receiver shards"
+
+# Pad the host weight to K_padded (zeros in the tail); the real rows occupy [:K].
+pt_weight = torch.zeros(1, 1, K_padded, N)
+pt_weight[:, :, :K, :] = pt_weight_unpadded            # (1, 1, K, N)
+
+dram_cores = ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (num_dram_banks - 1, 0))})
+nd_shard = ttnn.NdShardSpec(
+    ttnn.Shape([K_padded, N // ring_size]),
+    dram_cores,
+    ttnn.ShardOrientation.ROW_MAJOR,
+    ttnn.ShardDistributionStrategy.CONTIGUOUS_1D,    # preferred; see note below
+)
+weight_mem = ttnn.MemoryConfig(ttnn.BufferType.DRAM, nd_shard)
+tt_weight = ttnn.as_tensor(pt_weight, device=device, dtype=dtype,
+                           memory_config=weight_mem, layout=ttnn.TILE_LAYOUT)
+```
+
+The figure below shows a default dual-sender layout: each bank's receivers are divided ceil/floor across its two DRISC cores (`B<bank> S0`, `B<bank> S1`).
+
+<img src="media/tensor_prefetcher_dual_sender_chip.svg" style="width:750px;" alt="Chip grid showing a default dual-sender ring layout: each DRAM bank drives two DRISC sender tiles (labelled B# S0 and B# S1) that split the bank's receivers between them, roughly doubling per-bank push bandwidth."/>
+
+*Figure 3: One default dual-sender layout — each bank's two DRISC cores (B# S0 / B# S1) split that bank's receivers, roughly doubling per-bank bandwidth.*
+
+**Legacy K-row-major** (`WIDTH_SHARDED`) is the older alternative: one wide shard per bank, holding the full K dimension and `N / num_dram_banks` columns, K-row-major within the bank so a single read serves all of a bank's receivers. Always one sender per bank, and no streaming. Use it only for weights already allocated this way. It uses the same `K_padded` host tensor as above, and here N must divide evenly across the banks and per-bank across their receivers (`N % (num_dram_banks * recv_per_bank) == 0`).
+
+```python
+dram_cores = ttnn.CoreRangeSet({ttnn.CoreRange((0, 0), (num_dram_banks - 1, 0))})
+weight_mem = ttnn.MemoryConfig(
+    ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM,
+    ttnn.ShardSpec(dram_cores, [K_padded, N // num_dram_banks], ttnn.ShardOrientation.ROW_MAJOR),
+)
+```
+
+### The shard-placement / pairing contract
+
+The prefetcher delivers *shard s* to *ring position s*, which requires the weight's shard→bank placement and the GCB's `bank_to_receivers` pairing to agree. This pairing is a **caller-owned invariant: it is not cross-validated** — the GCB factory checks receiver counts and K/N geometry (§5), but not that your shard distribution matches your `bank_to_receivers` ordering. A mismatch is a common cause of wrong output or a hang and fails silently, so pair them deliberately:
+
+| Weight distribution | Pairing helper | Bank `b` feeds ring positions |
+|---|---|---|
+| `CONTIGUOUS_1D` (preferred) | `bank_receivers_contiguous` | `[b*R, b*R+1, …, b*R+R-1]` |
+| `ROUND_ROBIN_1D` | `bank_receivers_strided` | `[b, b+num_banks, b+2*num_banks, …]` |
+| Legacy `WIDTH_SHARDED` | `bank_receivers_row_major` | `[b*R, …, (b+1)*R-1]` |
+
+Under `CONTIGUOUS_1D`, shard `s` lands on bank `s // R`, so each bank feeds a contiguous ring arc; under `ROUND_ROBIN_1D`, shard `s` lands on bank `s % num_banks`, a strided set. `CONTIGUOUS_1D` is generally the more efficient of the two (a bank's pushes stay on a local ring segment rather than fanning across the whole ring), so prefer it. Either way, pairing with the matching helper makes shard index equal ring position, so the weight is stored in ring order with no host-side permutation. (`prefetcher_common.py` ships all three helpers.)
+
+## 5. Basic usage
+
+The common case — prefetch a weight and immediately run the matmul that consumes it — is a single call, `prefetch_and_linear`. It queues the prefetch and runs `ttnn.linear` against the same GCB and program config, deriving the prefetch parameters from the GCB so the two sides stay consistent. This example uses a receiver-contiguous weight (§4) with streaming enabled — the recommended combination.
+
+**Getting the ordered ring into the matmul.** The matmul runs on the receiver ring — the cores its activation and output tensors are sharded on (§3) — so no sub-device or stall group is needed; the DRAM senders live on a separate programmable core type off the worker grid. Ring *order* comes from the **activation (in0) tensor's shard-spec `CoreRangeSet`**, read in its stored range order, rather than from any program-config field: the `gather_in0` factory binds ring position `i` to the i-th core in that grid (which then consumes weight shard `i`). So you control the order, including scattered non-rectangular placements, through how you build that `CoreRangeSet`:
+
+```python
+# ring_cores: List[ttnn.CoreCoord] in ring-position order (index == ring position).
+# Build an ORDER-PRESERVING CoreRangeSet — one single-core range per position.
+# Do NOT pass a list of CoreCoords (that constructor merges/sorts and destroys the order).
+ring_crs = ttnn.CoreRangeSet([ttnn.CoreRange(c, c) for c in ring_cores])
+
+act_mem_config = ttnn.create_sharded_memory_config(
+    shape=(M, K_padded // ring_size),
+    core_grid=ring_crs,                 # <-- this ordering IS the ring order
+    strategy=ttnn.ShardStrategy.WIDTH,
+    orientation=ttnn.ShardOrientation.ROW_MAJOR,
+    use_height_and_width_as_shard_shape=True,
+)
+# Use the same ring_crs for the output sharded mem config.
+```
+
+Then the program config. `stream_in1=True` turns on streaming delivery, which lets the matmul consume weight blocks as they land (so the GCB can be shallow); `prefetch_and_linear` reads this flag to pick streaming vs batched automatically. Two fields are easy to misread: `in0_block_w` is a placeholder here — `gather_in0` overrides the effective in0 block width from the activation shard width, so its value is ignored — and `compute_with_storage_grid_size` is also ignored under `gather_in0` (the ring comes from the activation shard grid above; any grid whose product is `ring_size` is fine). Set `num_global_cb_receivers` to the per-bank receiver count: the legacy WIDTH_SHARDED path validates it exactly (a mismatch mis-sizes `in1_CB`), while the receiver-contiguous path derives its geometry from the GCB and does not check it.
+
+```python
+program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+    compute_with_storage_grid_size=(ring_cols, ring_rows),  # ignored for gather_in0
+    in0_block_w=1,                                     # placeholder; overridden from the in0 shard
+    out_subblock_h=1, out_subblock_w=out_subblock_w,   # out_subblock_w divides per_core_N, ≤ 8
+    per_core_M=M // ttnn.TILE_SIZE,
+    per_core_N=N // ring_size // ttnn.TILE_SIZE,        # == weight per-receiver N in tiles
+    fuse_batch=True, fused_activation=None,
+    mcast_in0=False, gather_in0=True,
+    num_global_cb_receivers=recv_per_bank,
+    stream_in1=True,                                    # streaming delivery (recv-contig only)
+    hop_cores=ttnn.CoreRangeSet([]),                    # only for relay hops
+)
+```
+
+Build the GCB with `create_global_circular_buffer_for_matmul_1d`. It validates the geometry — that the K dimension divides evenly into `ring_size` blocks, that per-receiver N matches `per_core_N`, and that `bank_to_receivers` has the right counts — then allocates the buffer at the `gcb_size` you pass (asserting only a min/max; see §6). It does **not** check that your shard distribution matches the `bank_to_receivers` ordering (§4) — that pairing is yours to get right:
+
+```python
+gcb = ttnn.experimental.create_global_circular_buffer_for_matmul_1d(
+    device, [program_config], [tt_weight], bank_to_receivers, gcb_size,
+)
+```
+
+Then start the prefetcher once, run the consuming matmuls through `prefetch_and_linear`, and stop when done. In real code, call `start_tensor_prefetcher` / `stop_tensor_prefetcher` directly (typically at model init / teardown), and keep the weights and GCB alive for the whole span between them:
+
+```python
+ttnn.experimental.start_tensor_prefetcher(device)
+try:
+    out = ttnn.experimental.tensor_prefetcher_matmul.prefetch_and_linear(
+        tt_act, tt_weight,
+        global_cb=gcb,
+        program_config=program_config,
+        memory_config=output_mem_config,    # extra kwargs forwarded to ttnn.linear
+        compute_kernel_config=compute_kernel_config,
+        dtype=ttnn.bfloat16,
+    )
+finally:
+    ttnn.experimental.stop_tensor_prefetcher(device)
+```
+
+`tt_act` and `output_mem_config` are width-sharded on the receiver ring (via `ring_crs` above), which is what places the matmul on those cores. `prefetch_and_linear` chooses batched vs streaming delivery from `program_config.stream_in1` automatically, so a single call covers both. (Tests can instead use the `tensor_prefetcher_session` context manager in `prefetcher_common.py`, which wraps start/stop and a device sync for setup/teardown convenience — it's a test helper, not the production pattern.)
+
+## 6. Sizing the GCB
+
+`gcb_size` is the per-receiver FIFO size in bytes. The per-receiver, per-block push page is
+
+```
+push_page = k_block_w_tiles * n_per_recv_tiles * tile_bytes
+```
+
+where for the receiver-contiguous layout `k_block_w_tiles = K_padded / ring_size / TILE` and `n_per_recv_tiles = N / ring_size / TILE` (`tile_bytes`: bf16 = 2048, bf8_b = 1088). A full ring is `ring_size` such pages — the entire per-receiver weight slab (`K × N/ring_size`). The floor depends on the delivery mode:
+
+- **Batched (non-streaming): the GCB must hold a full ring.** The matmul waits for a receiver's whole slab before it reads, so `gcb_size` must be at least the largest consuming matmul's per-receiver weight, `ring_size * push_page`. Size it below that and the matmul stalls waiting for pages the ring has no room to hold. When one GCB serves several weights, size to the largest.
+- **Streaming: a partial window is enough.** Because the matmul consumes blocks as they land, the GCB only needs to buffer a window of them (as few as two), so it can be far smaller than the full weight. This is streaming's main sizing advantage and why it pairs well with large weights.
+- **Pass a multiple of the page size — the remainder is discarded.** `create_global_circular_buffer_for_matmul_1d` allocates exactly `gcb_size` (asserting only the minimum above and a maximum cap); it does **not** round. The matmul then floors its effective in1 FIFO to a whole number of pages (`floor(gcb_size / push_page) * push_page`), so any bytes past the last whole page are wasted. Pass a multiple of the largest consuming matmul's `push_page`. Going beyond a full ring does not raise throughput — the DRISC stalls on `remote_cb_reserve_back` once the ring is full — and the size is capped against a remote-CB page-count limit regardless.
+- **Leave L1 headroom.** The GCB shares each receiver core's ~1.4 MB L1 with the matmul's in0/in1/out/interm CBs, so size it to fit alongside them (production benches reserve ~256 KB of headroom).
+
+## 7. Tracing
+
+The DRISC daemon is started once, outside the trace. Each `prefetch_and_linear` queues its weight right before its matmul. When a request targets a command queue that is mid trace-capture, the prefetcher records it into that trace instead of sending it immediately, and re-sends it on every `execute_trace`. So capture picks up the request together with its matmul, and `execute_trace` replays both, re-priming the ring each run. The same `prefetch_and_linear` call works inside and outside a trace — it uses the current command queue by default, which is the recording queue during capture.
+
+```python
+ttnn.experimental.start_tensor_prefetcher(device)
+
+# Compile once (fills the program cache) before capturing.
+prefetch_and_linear(...)
+ttnn.synchronize_device(device)
+
+trace = ttnn.begin_trace_capture(device, cq_id=0)
+out = prefetch_and_linear(...)               # queue request + matmul both captured
+ttnn.end_trace_capture(device, trace, cq_id=0)
+
+ttnn.execute_trace(device, trace, cq_id=0, blocking=True)   # replays both
+ttnn.release_trace(device, trace)
+ttnn.experimental.stop_tensor_prefetcher(device)
+```
+
+To capture more than one matmul per trace, issue several `prefetch_and_linear` calls between `begin`/`end`; each records its own queue request alongside its matmul. If you drive the request API directly (§8), pass the recording CQ as `cq_id` to `queue_tensor_prefetcher_request` so the request is captured rather than sent immediately.
+
+To guarantee freshly written weights have landed before the prefetcher reads them, call `wait_for_cq_on_tensor_prefetcher(device, cq_id)` on the host thread after the writes and before the dependent prefetch — every request queued after it waits for that CQ's prior work to complete on device.
+
+## 8. Lower-level control
+
+`prefetch_and_linear` covers the common case. When you need more control — replaying many distinct weights from one request, a custom delivery order, a raw GCB, or a subset of the mesh — drive the request API directly.
+
+### The request API
+
+```python
+ttnn.experimental.queue_tensor_prefetcher_request(
+    mesh_device,
+    tensors,               # List[(weight, block_count) | (weight, block_count, rotation)]
+    global_cb,
+    *,
+    device_subset=None,    # MeshCoordinateRangeSet; defaults to the full mesh
+    cq_id=None,
+)
+```
+
+`tensors` is the full, flattened list of weights, streamed in list order — distinct tensors for distinct layers, or a repeated tensor to replay it. Per-GCB ring state persists across requests, so successive queues resume where the last left off, and successive queues may target different GCBs. `block_count` is the number of K-blocks to split that tensor's K dimension into; for a `gather_in0` matmul it equals `ring_size`, and `tensor_prefetcher_block_count_for_matmul_1d(program_config, weight, gcb)` computes and validates it for a receiver-contiguous weight. The corresponding matmul is a normal `ttnn.linear(..., global_cb=gcb)` call.
+
+A manual queue + matmul, equivalent to one `prefetch_and_linear`:
+
+```python
+block_count = ttnn.experimental.tensor_prefetcher_block_count_for_matmul_1d(
+    program_config, tt_weight, gcb)          # recv-contig; legacy: block_count = ring_size
+
+ttnn.experimental.queue_tensor_prefetcher_request(
+    device, [(tt_weight, block_count)], global_cb=gcb)
+
+out = ttnn.linear(
+    tt_act, tt_weight, program_config=program_config, global_cb=gcb,
+    memory_config=output_mem_config, compute_kernel_config=compute_kernel_config,
+    dtype=ttnn.bfloat16,
+)
+```
+
+### Custom streaming rotation
+
+Streaming delivery is enabled with `program_config.stream_in1` and, through `prefetch_and_linear`, needs nothing more (§5) — it supplies the natural-order rotation automatically. Driving the request API directly exposes the underlying knob: the 3-tuple `(weight, block_count, rotation)` (receiver-contiguous layout only) delivers each receiver's K-blocks in a host-specified ring-rotated FIFO order instead of the whole slab at once, so a `stream_in1` matmul can consume blocks as they land and start before the tensor fully arrives (letting the GCB stay shallow). The 2-tuple form delivers batched (whole-slab) instead.
+
+`rotation` has length `ring_size`, is indexed by global ring position, and each entry is in `[0, block_count)`. At push step `p`, the receiver at global position `r` sources physical block `(rotation[r] + p) mod block_count`. `rotation[r] = r` reproduces the natural topology order (what `prefetch_and_linear` uses). The matmul must consume in the matching order; a mismatch delivers each receiver's blocks in the wrong order and silently produces incorrect results. For `CONTIGUOUS_1D` weights, slice the rotation by the contiguous global position (`bank*receivers_per_bank + slab`).
+
+### Raw GCB factory
+
+`ttnn.experimental.create_global_circular_buffer_for_tensor_prefetcher(mesh_device, bank_to_receivers, size, buffer_type=L1, support_multi_receiver_shards=True)` builds a DRAM-sender GCB without the matmul cross-checks — useful when there is no single program config to validate against (e.g. the validator smoke tests). `support_multi_receiver_shards` reads with an inverted sense: `True` forces a single sender per bank; `False` allows dual senders for a receiver-contiguous layout. `create_global_circular_buffer_for_matmul_1d` takes the same argument, defaulting to the detected layout when left unset.
+
+### Multiple GCBs and other knobs
+
+- **One prefetcher, many GCBs.** The receiver count is read per-GCB on every request, so a single prefetcher serves GCBs with different receiver counts. Successive queues may target different GCBs, each with its own persistent ring state; place them on disjoint receiver cores (e.g. via a `row_offset`).
+- **Page-size switching.** One GCB can serve tensors of different page sizes across requests; sender and receiver credit the skipped padding on resize. For batched delivery size it to `ring_size * max(page)` (a full ring of the largest); an all-streaming GCB only needs a partial window of the largest page (§6).
+- **`device_subset`.** Restrict a request to a `MeshCoordinateRangeSet`; it defaults to the full mesh.
+
+## 9. Pitfalls
+
+- **Skipping the support gate.** `start_tensor_prefetcher` raises on unsupported hardware — call `is_tensor_prefetcher_supported` first.
+- **`num_global_cb_receivers` ≠ receivers per bank (legacy path).** On the legacy WIDTH_SHARDED layout this mis-sizes `in1_CB`; the receiver-contiguous path ignores the field (§5).
+- **`bank_to_receivers` not matching the shard distribution.** Shard index ≠ ring position → wrong output or hang, silently (not cross-validated). Use the matching helper (§4).
+- **Weight K not divisible by `ring_size`.** The prefetcher over-reads and the matmul waits on pages that never come. `create_global_circular_buffer_for_matmul_1d` catches this.
+- **Mis-sizing the GCB.** Below a full ring, a batched (non-streaming) matmul stalls waiting for pages the ring can't hold; above a full ring gains no throughput and takes L1 the matmul CBs need. Size batched to exactly a full ring, streaming to a partial window (§6).
+- **Not stopping the prefetcher** before device teardown leaves the DRISC kernels running. Pair `start_tensor_prefetcher` with `stop_tensor_prefetcher` in a `try/finally` (in tests, the `tensor_prefetcher_session` helper does this for you).
+- **Freeing a weight or the GCB while the prefetcher runs.** The DRISC reads them asynchronously (and on every trace replay); keep every queued tensor and the GCB alive until `stop` returns (§1).
+- **Starting a second prefetcher on the same `MeshDevice`.** Only one may be active at a time — stop the first.
+- **Mixing layouts in one GCB.** `create_global_circular_buffer_for_matmul_1d` rejects it (all weights on a GCB must share one layout); the low-level runtime detects layout per tensor, so this guard is the matmul-aware factory's, not every raw GCB use's.
+- **A streaming rotation the matmul does not match** silently produces incorrect output (the blocks arrive in the wrong order).
+
+## 10. References
+
+Source:
+
+- Public ttnn API and cross-check documentation: [`ttnn/api/ttnn/global_circular_buffer.hpp`](../../ttnn/api/ttnn/global_circular_buffer.hpp).
+- Experimental `tt_metal` API: [`tt_metal/api/tt-metalium/experimental/global_circular_buffer.hpp`](../../tt_metal/api/tt-metalium/experimental/global_circular_buffer.hpp) and [`tt_metal/api/tt-metalium/experimental/tensor_prefetcher.hpp`](../../tt_metal/api/tt-metalium/experimental/tensor_prefetcher.hpp).
+- ttnn op + Python bindings: [`ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/`](../../ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/).
+- `prefetch_and_linear` helper: [`ttnn/ttnn/_experimental/tensor_prefetcher_matmul.py`](../../ttnn/ttnn/_experimental/tensor_prefetcher_matmul.py).
+- Manager + DRISC kernel: [`tt_metal/impl/buffers/tensor_prefetcher_manager.hpp`](../../tt_metal/impl/buffers/tensor_prefetcher_manager.hpp), [`.cpp`](../../tt_metal/impl/buffers/tensor_prefetcher_manager.cpp), [`tt_metal/impl/buffers/kernels/tensor_prefetcher.cpp`](../../tt_metal/impl/buffers/kernels/tensor_prefetcher.cpp).
+- Internal contract (matmul ↔ prefetcher): [`tt_metal/impl/buffers/prefetcher_matmul_design.md`](../../tt_metal/impl/buffers/prefetcher_matmul_design.md).
+
+Worked examples:
+
+- [`tests/ttnn/unit_tests/operations/prefetcher_common.py`](../../tests/ttnn/unit_tests/operations/prefetcher_common.py) — shared helpers (`bank_receivers_strided`, `bank_receivers_contiguous`, `make_recv_contig_weight`, `tensor_prefetcher_session`).
+- [`tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bench.py`](../../tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bench.py) — end-to-end matmul benchmarks (legacy, receiver-contiguous, dual-sender, streaming).
+- [`tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_validator.py`](../../tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_validator.py) — validator-receiver smoke tests (multi-GCB switching, mixed receiver counts, page-size switch).
+- [`tests/ttnn/unit_tests/base_functionality/test_dram_sender_global_cb_py.py`](../../tests/ttnn/unit_tests/base_functionality/test_dram_sender_global_cb_py.py) — minimal GCB creation.

--- a/tech_reports/TensorPrefetcher/media/tensor_prefetcher_dual_sender_chip.svg
+++ b/tech_reports/TensorPrefetcher/media/tensor_prefetcher_dual_sender_chip.svg
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-FileCopyrightText: &#x00A9; 2026 Tenstorrent USA, Inc. -->
+
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="1120" viewBox="0 0 1600 1120">
+  <defs>
+    <pattern id="chip-grid" width="80" height="70" patternUnits="userSpaceOnUse" patternTransform="translate(110 140)">
+      <rect x="6" y="6" width="68" height="58" rx="7" fill="#aeb4bc" stroke="#6f7782" stroke-width="1.5"/>
+    </pattern>
+    <marker id="arrow-green" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#12a150"/>
+    </marker>
+    <marker id="arrow-pink" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#ef4f9a"/>
+    </marker>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="2" stdDeviation="2" flood-color="#17202a" flood-opacity="0.25"/>
+    </filter>
+    <style>
+      .axis { font: 600 15px sans-serif; fill: #46505c; text-anchor: middle; }
+      .tile-label { font: 600 11px sans-serif; fill: #29323c; text-anchor: middle; dominant-baseline: middle; }
+      .ring-label { font: 700 12px sans-serif; fill: white; text-anchor: middle; dominant-baseline: middle; }
+      .sender-label { font: 700 10px sans-serif; fill: white; text-anchor: middle; dominant-baseline: middle; }
+      .weight-link { fill: none; stroke: #ef4f9a; stroke-width: 2.4; stroke-opacity: 0.38; stroke-linejoin: round; marker-mid: url(#arrow-pink); marker-end: url(#arrow-pink); }
+      .ring-link { fill: none; stroke: #12a150; stroke-width: 4.2; stroke-opacity: 0.95; stroke-linejoin: round; marker-mid: url(#arrow-green); marker-end: url(#arrow-green); }
+      .legend { font: 16px sans-serif; fill: #25303b; dominant-baseline: middle; }
+    </style>
+  </defs>
+
+  <rect width="1600" height="1120" fill="#f7f9fb"/>
+  <text x="800" y="50" text-anchor="middle" font-family="sans-serif" font-size="30" font-weight="700" fill="#17202a">
+    Blackhole Tensor Prefetcher - Dual-Sender NoC Routing
+  </text>
+  <text x="800" y="82" text-anchor="middle" font-family="sans-serif" font-size="16" fill="#52606d">
+    Weights: NoC0 X+ then Y+; activation ring: NoC1 Y- then X-; torus links wrap at chip edges
+  </text>
+
+  <!-- Coordinate axes. -->
+  <g aria-label="NoC0 coordinate axes">
+    <text x="790" y="111" text-anchor="middle" font-family="sans-serif" font-size="15" font-weight="700" fill="#46505c">NoC0 x</text>
+    <text x="55" y="560" transform="rotate(-90 55 560)" text-anchor="middle" font-family="sans-serif" font-size="15" font-weight="700" fill="#46505c">NoC0 y</text>
+    <g class="axis">
+      <text x="150" y="130">0</text><text x="230" y="130">1</text><text x="310" y="130">2</text>
+      <text x="390" y="130">3</text><text x="470" y="130">4</text><text x="550" y="130">5</text>
+      <text x="630" y="130">6</text><text x="710" y="130">7</text><text x="790" y="130">8</text>
+      <text x="870" y="130">9</text><text x="950" y="130">10</text><text x="1030" y="130">11</text>
+      <text x="1110" y="130">12</text><text x="1190" y="130">13</text><text x="1270" y="130">14</text>
+      <text x="1350" y="130">15</text><text x="1430" y="130">16</text>
+      <text x="90" y="180">0</text><text x="90" y="250">1</text><text x="90" y="320">2</text>
+      <text x="90" y="390">3</text><text x="90" y="460">4</text><text x="90" y="530">5</text>
+      <text x="90" y="600">6</text><text x="90" y="670">7</text><text x="90" y="740">8</text>
+      <text x="90" y="810">9</text><text x="90" y="880">10</text><text x="90" y="950">11</text>
+    </g>
+  </g>
+
+  <!-- Every coordinate in the 17-by-12 chip grid is occupied. Gray is the default for all unused resources. -->
+  <rect x="110" y="140" width="1360" height="840" fill="url(#chip-grid)"/>
+
+  <!-- Broad labels for unhighlighted resource regions. -->
+  <g class="tile-label" opacity="0.72">
+    <text x="790" y="175">ARC</text>
+    <text x="310" y="175">PCIe</text><text x="1030" y="175">PCIe</text>
+    <text x="790" y="245">RTR</text><text x="790" y="315">RTR</text><text x="790" y="385">RTR</text>
+    <text x="790" y="455">RTR</text><text x="790" y="525">RTR</text><text x="790" y="595">RTR</text>
+    <text x="790" y="665">RTR</text><text x="790" y="735">RTR</text><text x="790" y="805">RTR</text>
+    <text x="790" y="875">RTR</text><text x="790" y="945">RTR</text>
+    <text x="230" y="245">ETH</text><text x="310" y="245">ETH</text><text x="390" y="245">ETH</text>
+    <text x="470" y="245">ETH</text><text x="550" y="245">ETH</text><text x="630" y="245">ETH</text>
+    <text x="710" y="245">ETH</text><text x="950" y="245">ETH</text><text x="1030" y="245">ETH</text>
+    <text x="1110" y="245">ETH</text><text x="1190" y="245">ETH</text><text x="1270" y="245">ETH</text>
+    <text x="1350" y="245">ETH</text><text x="1430" y="245">ETH</text>
+    <text x="150" y="945">DRAM</text><text x="870" y="945">DRAM</text>
+    <text x="150" y="315">DRAM</text><text x="870" y="385">DRAM</text>
+    <text x="150" y="805">DRAM</text><text x="870" y="595">DRAM</text>
+  </g>
+
+  <!-- Activation-ring workers, physical NoC0 x={1..7,10}, y={2..5}. -->
+  <g fill="#2878d0" stroke="#0e4f98" stroke-width="2.5" filter="url(#shadow)" aria-label="Activation ring worker cores">
+    <rect x="196" y="286" width="68" height="58" rx="7"/><rect x="276" y="286" width="68" height="58" rx="7"/>
+    <rect x="356" y="286" width="68" height="58" rx="7"/><rect x="436" y="286" width="68" height="58" rx="7"/>
+    <rect x="516" y="286" width="68" height="58" rx="7"/><rect x="596" y="286" width="68" height="58" rx="7"/>
+    <rect x="676" y="286" width="68" height="58" rx="7"/><rect x="916" y="286" width="68" height="58" rx="7"/>
+    <rect x="196" y="356" width="68" height="58" rx="7"/><rect x="276" y="356" width="68" height="58" rx="7"/>
+    <rect x="356" y="356" width="68" height="58" rx="7"/><rect x="436" y="356" width="68" height="58" rx="7"/>
+    <rect x="516" y="356" width="68" height="58" rx="7"/><rect x="596" y="356" width="68" height="58" rx="7"/>
+    <rect x="676" y="356" width="68" height="58" rx="7"/><rect x="916" y="356" width="68" height="58" rx="7"/>
+    <rect x="196" y="426" width="68" height="58" rx="7"/><rect x="276" y="426" width="68" height="58" rx="7"/>
+    <rect x="356" y="426" width="68" height="58" rx="7"/><rect x="436" y="426" width="68" height="58" rx="7"/>
+    <rect x="516" y="426" width="68" height="58" rx="7"/><rect x="596" y="426" width="68" height="58" rx="7"/>
+    <rect x="676" y="426" width="68" height="58" rx="7"/><rect x="916" y="426" width="68" height="58" rx="7"/>
+    <rect x="196" y="496" width="68" height="58" rx="7"/><rect x="276" y="496" width="68" height="58" rx="7"/>
+    <rect x="356" y="496" width="68" height="58" rx="7"/><rect x="436" y="496" width="68" height="58" rx="7"/>
+    <rect x="516" y="496" width="68" height="58" rx="7"/><rect x="596" y="496" width="68" height="58" rx="7"/>
+    <rect x="676" y="496" width="68" height="58" rx="7"/><rect x="916" y="496" width="68" height="58" rx="7"/>
+  </g>
+
+  <!-- Dual DRISC senders: sender 0 is the free subchannel; sender 1 is the NOC1 endpoint, both using NOC0. -->
+  <g fill="#d9363e" stroke="#8d1720" stroke-width="2.5" filter="url(#shadow)" aria-label="Tensor Prefetcher DRAM sender cores">
+    <rect x="116" y="146" width="68" height="58" rx="7"/><rect x="116" y="216" width="68" height="58" rx="7"/>
+    <rect x="116" y="356" width="68" height="58" rx="7"/><rect x="116" y="846" width="68" height="58" rx="7"/>
+    <rect x="116" y="706" width="68" height="58" rx="7"/><rect x="116" y="426" width="68" height="58" rx="7"/>
+    <rect x="116" y="566" width="68" height="58" rx="7"/><rect x="116" y="636" width="68" height="58" rx="7"/>
+    <rect x="836" y="146" width="68" height="58" rx="7"/><rect x="836" y="216" width="68" height="58" rx="7"/>
+    <rect x="836" y="286" width="68" height="58" rx="7"/><rect x="836" y="846" width="68" height="58" rx="7"/>
+    <rect x="836" y="776" width="68" height="58" rx="7"/><rect x="836" y="426" width="68" height="58" rx="7"/>
+    <rect x="836" y="496" width="68" height="58" rx="7"/><rect x="836" y="636" width="68" height="58" rx="7"/>
+  </g>
+
+  <!-- Weight delivery uses NoC0 deterministic torus routing: X+ first, then Y+. -->
+  <g aria-label="Weight sending paths">
+    <path class="weight-link" d="M150,168 L224,168 L224,315"><title>B0 S0 to R0; lane offset for visibility; hardware route is NoC0 X+ then Y+</title></path>
+    <path class="weight-link" d="M150,173 L304,173 L304,315"><title>B0 S0 to R1; lane offset for visibility; hardware route is NoC0 X+ then Y+</title></path>
+    <path class="weight-link" d="M150,238 L384,238 L384,315"><title>B0 S1 to R2; lane offset for visibility; hardware route is NoC0 X+ then Y+</title></path>
+    <path class="weight-link" d="M150,243 L464,243 L464,315"><title>B0 S1 to R3; lane offset for visibility; hardware route is NoC0 X+ then Y+</title></path>
+    <path class="weight-link" d="M150,378 L544,378 L544,995 M544,135 L544,315"><title>B1 S0 to R4; lane offset for visibility; hardware route is NoC0 X+ then Y+</title></path>
+    <path class="weight-link" d="M150,383 L624,383 L624,995 M624,135 L624,315"><title>B1 S0 to R5; lane offset for visibility; hardware route is NoC0 X+ then Y+</title></path>
+    <path class="weight-link" d="M150,868 L704,868 L704,995 M704,135 L704,315"><title>B1 S1 to R6; lane offset for visibility; hardware route is NoC0 X+ then Y+</title></path>
+    <path class="weight-link" d="M150,873 L944,873 L944,995 M944,135 L944,315"><title>B1 S1 to R7; lane offset for visibility; hardware route is NoC0 X+ then Y+</title></path>
+    <path class="weight-link" d="M150,728 L228,728 L228,995 M228,135 L228,385"><title>B2 S0 to R8; lane offset for visibility; hardware route is NoC0 X+ then Y+</title></path>
+    <path class="weight-link" d="M150,733 L308,733 L308,995 M308,135 L308,385"><title>B2 S0 to R9; lane offset for visibility; hardware route is NoC0 X+ then Y+</title></path>
+    <path class="weight-link" d="M150,448 L388,448 L388,995 M388,135 L388,385"><title>B2 S1 to R10; lane offset for visibility; hardware route is NoC0 X+ then Y+</title></path>
+    <path class="weight-link" d="M150,453 L468,453 L468,995 M468,135 L468,385"><title>B2 S1 to R11; lane offset for visibility; hardware route is NoC0 X+ then Y+</title></path>
+    <path class="weight-link" d="M150,588 L548,588 L548,995 M548,135 L548,385"><title>B3 S0 to R12; lane offset for visibility; hardware route is NoC0 X+ then Y+</title></path>
+    <path class="weight-link" d="M150,593 L628,593 L628,995 M628,135 L628,385"><title>B3 S0 to R13; lane offset for visibility; hardware route is NoC0 X+ then Y+</title></path>
+    <path class="weight-link" d="M150,658 L708,658 L708,995 M708,135 L708,385"><title>B3 S1 to R14; lane offset for visibility; hardware route is NoC0 X+ then Y+</title></path>
+    <path class="weight-link" d="M150,663 L948,663 L948,995 M948,135 L948,385"><title>B3 S1 to R15; lane offset for visibility; hardware route is NoC0 X+ then Y+</title></path>
+    <path class="weight-link" d="M870,177 L1495,177 M105,177 L232,177 L232,455"><title>B4 S0 to R16; lane offset for visibility; hardware route is NoC0 X+ then Y+</title></path>
+    <path class="weight-link" d="M870,182 L1495,182 M105,182 L312,182 L312,455"><title>B4 S0 to R17; lane offset for visibility; hardware route is NoC0 X+ then Y+</title></path>
+    <path class="weight-link" d="M870,247 L1495,247 M105,247 L392,247 L392,455"><title>B4 S1 to R18; lane offset for visibility; hardware route is NoC0 X+ then Y+</title></path>
+    <path class="weight-link" d="M870,252 L1495,252 M105,252 L472,252 L472,455"><title>B4 S1 to R19; lane offset for visibility; hardware route is NoC0 X+ then Y+</title></path>
+    <path class="weight-link" d="M870,317 L1495,317 M105,317 L552,317 L552,455"><title>B5 S0 to R20; lane offset for visibility; hardware route is NoC0 X+ then Y+</title></path>
+    <path class="weight-link" d="M870,322 L1495,322 M105,322 L632,322 L632,455"><title>B5 S0 to R21; lane offset for visibility; hardware route is NoC0 X+ then Y+</title></path>
+    <path class="weight-link" d="M870,877 L1495,877 M105,877 L712,877 L712,995 M712,135 L712,455"><title>B5 S1 to R22; lane offset for visibility; hardware route is NoC0 X+ then Y+</title></path>
+    <path class="weight-link" d="M870,882 L952,882 L952,995 M952,135 L952,455"><title>B5 S1 to R23; lane offset for visibility; hardware route is NoC0 X+ then Y+</title></path>
+    <path class="weight-link" d="M870,807 L1495,807 M105,807 L236,807 L236,995 M236,135 L236,525"><title>B6 S0 to R24; lane offset for visibility; hardware route is NoC0 X+ then Y+</title></path>
+    <path class="weight-link" d="M870,812 L1495,812 M105,812 L316,812 L316,995 M316,135 L316,525"><title>B6 S0 to R25; lane offset for visibility; hardware route is NoC0 X+ then Y+</title></path>
+    <path class="weight-link" d="M870,457 L1495,457 M105,457 L396,457 L396,525"><title>B6 S1 to R26; lane offset for visibility; hardware route is NoC0 X+ then Y+</title></path>
+    <path class="weight-link" d="M870,462 L1495,462 M105,462 L476,462 L476,525"><title>B6 S1 to R27; lane offset for visibility; hardware route is NoC0 X+ then Y+</title></path>
+    <path class="weight-link" d="M870,527 L1495,527 M105,527 L556,527 L556,525"><title>B7 S0 to R28; lane offset for visibility; hardware route is NoC0 X+ then Y+</title></path>
+    <path class="weight-link" d="M870,532 L1495,532 M105,532 L636,532 L636,525"><title>B7 S0 to R29; lane offset for visibility; hardware route is NoC0 X+ then Y+</title></path>
+    <path class="weight-link" d="M870,667 L1495,667 M105,667 L716,667 L716,995 M716,135 L716,525"><title>B7 S1 to R30; lane offset for visibility; hardware route is NoC0 X+ then Y+</title></path>
+    <path class="weight-link" d="M870,672 L956,672 L956,995 M956,135 L956,525"><title>B7 S1 to R31; lane offset for visibility; hardware route is NoC0 X+ then Y+</title></path>
+  </g>
+
+  <!-- Activation gather ring uses dedicated NoC1: Y- first, then X-, with torus wrap. -->
+  <g aria-label="Activation ring path">
+    <polyline class="ring-link" points="950,300 710,300 630,300 550,300 470,300 390,300 310,300 230,300"/>
+    <polyline class="ring-link" points="950,370 710,370 630,370 550,370 470,370 390,370 310,370 230,370"/>
+    <polyline class="ring-link" points="950,440 710,440 630,440 550,440 470,440 390,440 310,440 230,440"/>
+    <polyline class="ring-link" points="950,510 710,510 630,510 550,510 470,510 390,510 310,510 230,510"/>
+    <path class="ring-link" d="M218,385 L218,300 L105,300 M1495,300 L950,300"><title>R8 to R7: visually offset NoC1 Y- then X- route with X wrap</title></path>
+    <path class="ring-link" d="M218,455 L218,370 L105,370 M1495,370 L950,370"><title>R16 to R15: visually offset NoC1 Y- then X- route with X wrap</title></path>
+    <path class="ring-link" d="M218,525 L218,440 L105,440 M1495,440 L950,440"><title>R24 to R23: visually offset NoC1 Y- then X- route with X wrap</title></path>
+    <path class="ring-link" d="M218,315 L218,135 M218,995 L218,510 L105,510 M1495,510 L950,510"><title>R0 to R31: visually offset NoC1 Y wrap followed by X wrap</title></path>
+  </g>
+
+  <!-- Labels are drawn last so paths do not obscure core identities. -->
+  <g class="ring-label" aria-label="Activation ring indices">
+    <text x="230" y="315">R0</text><text x="310" y="315">R1</text><text x="390" y="315">R2</text>
+    <text x="470" y="315">R3</text><text x="550" y="315">R4</text><text x="630" y="315">R5</text>
+    <text x="710" y="315">R6</text><text x="950" y="315">R7</text>
+    <text x="230" y="385">R8</text><text x="310" y="385">R9</text><text x="390" y="385">R10</text>
+    <text x="470" y="385">R11</text><text x="550" y="385">R12</text><text x="630" y="385">R13</text>
+    <text x="710" y="385">R14</text><text x="950" y="385">R15</text>
+    <text x="230" y="455">R16</text><text x="310" y="455">R17</text><text x="390" y="455">R18</text>
+    <text x="470" y="455">R19</text><text x="550" y="455">R20</text><text x="630" y="455">R21</text>
+    <text x="710" y="455">R22</text><text x="950" y="455">R23</text>
+    <text x="230" y="525">R24</text><text x="310" y="525">R25</text><text x="390" y="525">R26</text>
+    <text x="470" y="525">R27</text><text x="550" y="525">R28</text><text x="630" y="525">R29</text>
+    <text x="710" y="525">R30</text><text x="950" y="525">R31</text>
+  </g>
+  <g class="sender-label" aria-label="DRAM bank and sender indices">
+    <text x="150" y="175">B0 S0</text><text x="150" y="245">B0 S1</text>
+    <text x="150" y="385">B1 S0</text><text x="150" y="875">B1 S1</text>
+    <text x="150" y="735">B2 S0</text><text x="150" y="455">B2 S1</text>
+    <text x="150" y="595">B3 S0</text><text x="150" y="665">B3 S1</text>
+    <text x="870" y="175">B4 S0</text><text x="870" y="245">B4 S1</text>
+    <text x="870" y="315">B5 S0</text><text x="870" y="875">B5 S1</text>
+    <text x="870" y="805">B6 S0</text><text x="870" y="455">B6 S1</text>
+    <text x="870" y="525">B7 S0</text><text x="870" y="665">B7 S1</text>
+  </g>
+
+  <!-- Legend. -->
+  <g transform="translate(120,1025)">
+    <rect x="0" y="-22" width="1360" height="78" rx="12" fill="white" stroke="#d5dbe2"/>
+    <rect x="28" y="-4" width="34" height="28" rx="5" fill="#2878d0" stroke="#0e4f98" stroke-width="2"/>
+    <text class="legend" x="74" y="10">Activation-ring worker</text>
+    <rect x="300" y="-4" width="34" height="28" rx="5" fill="#d9363e" stroke="#8d1720" stroke-width="2"/>
+    <text class="legend" x="346" y="10">Tensor Prefetcher DRISC</text>
+    <rect x="600" y="-4" width="34" height="28" rx="5" fill="#aeb4bc" stroke="#6f7782"/>
+    <text class="legend" x="646" y="10">All other chip cores</text>
+    <line x1="810" y1="10" x2="850" y2="10" stroke="#12a150" stroke-width="5" marker-end="url(#arrow-green)"/>
+    <text class="legend" x="864" y="10">Activation: NoC1 Y- then X-</text>
+    <line x1="1095" y1="10" x2="1135" y2="10" stroke="#ef4f9a" stroke-width="4" marker-end="url(#arrow-pink)"/>
+    <text class="legend" x="1149" y="10">Weights: NoC0 X+ then Y+</text>
+    <text x="680" y="43" text-anchor="middle" font-family="sans-serif" font-size="13" fill="#66727f">
+      Ring R0-R31 and sender B0-B7/S0-S1 labels correspond to the current Llama-3.1-8B dual-sender configuration.
+    </text>
+  </g>
+</svg>

--- a/tech_reports/TensorPrefetcher/media/tensor_prefetcher_ring16_chip.svg
+++ b/tech_reports/TensorPrefetcher/media/tensor_prefetcher_ring16_chip.svg
@@ -1,0 +1,376 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-FileCopyrightText: &#x00A9; 2026 Tenstorrent USA, Inc. -->
+
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="1120" viewBox="0 0 1600 1120">
+  <defs>
+    <pattern id="chip-grid" width="80" height="70" patternUnits="userSpaceOnUse" patternTransform="translate(110 140)">
+      <rect x="6" y="6" width="68" height="58" rx="7" fill="#aeb4bc" stroke="#6f7782" stroke-width="1.5"/>
+    </pattern>
+    <marker id="arrow-green" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#12a150"/>
+    </marker>
+    <marker id="arrow-pink" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#ef4f9a"/>
+    </marker>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="2" stdDeviation="2" flood-color="#17202a" flood-opacity="0.25"/>
+    </filter>
+    <g id="worker-core"><rect x="-34" y="-29" width="68" height="58" rx="7" fill="#2878d0" stroke="#0e4f98" stroke-width="2.5"/></g>
+    <g id="sender-core"><rect x="-34" y="-29" width="68" height="58" rx="7" fill="#d9363e" stroke="#8d1720" stroke-width="2.5"/></g>
+    <style>
+      .axis { font: 600 15px sans-serif; fill: #46505c; text-anchor: middle; }
+      .tile-label { font: 600 11px sans-serif; fill: #29323c; text-anchor: middle; dominant-baseline: middle; }
+      .ring-label { font: 700 10px sans-serif; fill: white; text-anchor: middle; dominant-baseline: middle; }
+      .sender-label { font: 700 10px sans-serif; fill: white; text-anchor: middle; dominant-baseline: middle; }
+      .weight-link { fill: none; stroke: #ef4f9a; stroke-width: 2.2; stroke-opacity: 0.52; }
+      .ring-link { fill: none; stroke: #12a150; stroke-width: 3.2; stroke-opacity: 0.88; }
+      .legend { font: 16px sans-serif; fill: #25303b; dominant-baseline: middle; }
+    </style>
+  </defs>
+  <rect width="1600" height="1120" fill="#f7f9fb"/>
+  <text x="800" y="50" text-anchor="middle" font-family="sans-serif" font-size="30" font-weight="700" fill="#17202a">Tensor Prefetcher Ring 16</text>
+  <text x="800" y="82" text-anchor="middle" font-family="sans-serif" font-size="16" fill="#52606d">congestion_optimized_ring16; dual DRISC senders; shared links use offset visual lanes</text>
+  <g aria-label="NoC0 coordinate axes">
+    <text x="790" y="111" text-anchor="middle" font-family="sans-serif" font-size="15" font-weight="700" fill="#46505c">NoC0 x</text>
+    <text x="55" y="560" transform="rotate(-90 55 560)" text-anchor="middle" font-family="sans-serif" font-size="15" font-weight="700" fill="#46505c">NoC0 y</text>
+    <g class="axis"><text x="150" y="130">0</text><text x="230" y="130">1</text><text x="310" y="130">2</text><text x="390" y="130">3</text><text x="470" y="130">4</text><text x="550" y="130">5</text><text x="630" y="130">6</text><text x="710" y="130">7</text><text x="790" y="130">8</text><text x="870" y="130">9</text><text x="950" y="130">10</text><text x="1030" y="130">11</text><text x="1110" y="130">12</text><text x="1190" y="130">13</text><text x="1270" y="130">14</text><text x="1350" y="130">15</text><text x="1430" y="130">16</text><text x="90" y="180">0</text><text x="90" y="250">1</text><text x="90" y="320">2</text><text x="90" y="390">3</text><text x="90" y="460">4</text><text x="90" y="530">5</text><text x="90" y="600">6</text><text x="90" y="670">7</text><text x="90" y="740">8</text><text x="90" y="810">9</text><text x="90" y="880">10</text><text x="90" y="950">11</text></g>
+  </g>
+  <rect x="110" y="140" width="1360" height="840" fill="url(#chip-grid)"/>
+  <g class="tile-label" opacity="0.72"><text x="790" y="175">ARC</text><text x="310" y="175">PCIe</text><text x="1030" y="175">PCIe</text><text x="790" y="245">RTR</text><text x="790" y="315">RTR</text><text x="790" y="385">RTR</text><text x="790" y="455">RTR</text><text x="790" y="525">RTR</text><text x="790" y="595">RTR</text><text x="790" y="665">RTR</text><text x="790" y="735">RTR</text><text x="790" y="805">RTR</text><text x="790" y="875">RTR</text><text x="790" y="945">RTR</text><text x="230" y="245">ETH</text><text x="310" y="245">ETH</text><text x="390" y="245">ETH</text><text x="470" y="245">ETH</text><text x="550" y="245">ETH</text><text x="630" y="245">ETH</text><text x="710" y="245">ETH</text><text x="950" y="245">ETH</text><text x="1030" y="245">ETH</text><text x="1110" y="245">ETH</text><text x="1190" y="245">ETH</text><text x="1270" y="245">ETH</text><text x="1350" y="245">ETH</text><text x="1430" y="245">ETH</text><text x="150" y="945">DRAM</text><text x="870" y="945">DRAM</text><text x="150" y="315">DRAM</text><text x="870" y="385">DRAM</text><text x="150" y="805">DRAM</text><text x="870" y="595">DRAM</text></g>
+  <g filter="url(#shadow)" aria-label="Activation ring worker cores"><use href="#worker-core" transform="translate(310 315)"/><use href="#worker-core" transform="translate(390 315)"/><use href="#worker-core" transform="translate(230 385)"/><use href="#worker-core" transform="translate(470 385)"/><use href="#worker-core" transform="translate(230 455)"/><use href="#worker-core" transform="translate(310 455)"/><use href="#worker-core" transform="translate(230 595)"/><use href="#worker-core" transform="translate(550 595)"/><use href="#worker-core" transform="translate(1190 665)"/><use href="#worker-core" transform="translate(1270 665)"/><use href="#worker-core" transform="translate(390 735)"/><use href="#worker-core" transform="translate(1110 735)"/><use href="#worker-core" transform="translate(1110 805)"/><use href="#worker-core" transform="translate(1350 805)"/><use href="#worker-core" transform="translate(1030 875)"/><use href="#worker-core" transform="translate(1190 875)"/></g>
+  <g filter="url(#shadow)" aria-label="Tensor Prefetcher DRAM sender cores"><use href="#sender-core" transform="translate(150 175)"/><use href="#sender-core" transform="translate(150 245)"/><use href="#sender-core" transform="translate(150 385)"/><use href="#sender-core" transform="translate(150 875)"/><use href="#sender-core" transform="translate(150 735)"/><use href="#sender-core" transform="translate(150 455)"/><use href="#sender-core" transform="translate(150 595)"/><use href="#sender-core" transform="translate(150 665)"/><use href="#sender-core" transform="translate(870 175)"/><use href="#sender-core" transform="translate(870 245)"/><use href="#sender-core" transform="translate(870 315)"/><use href="#sender-core" transform="translate(870 875)"/><use href="#sender-core" transform="translate(870 805)"/><use href="#sender-core" transform="translate(870 455)"/><use href="#sender-core" transform="translate(870 525)"/><use href="#sender-core" transform="translate(870 665)"/></g>
+  <g aria-label="Exact offset NoC routes"><g aria-label="Bank 0 sender 0 to R0: NoC0 X+ then Y+"><title>Bank 0 sender 0 to R0: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="175.0" x2="230.0" y2="175.0"/>
+<line class="weight-link" x1="230.0" y1="175.0" x2="310.0" y2="175.0"/>
+<line class="weight-link" x1="311.4" y1="175.0" x2="311.4" y2="245.0"/>
+<line class="weight-link" x1="311.4" y1="245.0" x2="311.4" y2="315.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 0 sender 1 to R1: NoC0 X+ then Y+"><title>Bank 0 sender 1 to R1: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="245.0" x2="230.0" y2="245.0"/>
+<line class="weight-link" x1="230.0" y1="245.0" x2="310.0" y2="245.0"/>
+<line class="weight-link" x1="310.0" y1="245.0" x2="390.0" y2="245.0"/>
+<line class="weight-link" x1="390.0" y1="245.0" x2="390.0" y2="315.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 1 sender 0 to R2: NoC0 X+ then Y+"><title>Bank 1 sender 0 to R2: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="386.4" x2="230.0" y2="386.4" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 1 sender 1 to R3: NoC0 X+ then Y+"><title>Bank 1 sender 1 to R3: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="876.4" x2="230.0" y2="876.4"/>
+<line class="weight-link" x1="230.0" y1="876.4" x2="310.0" y2="876.4"/>
+<line class="weight-link" x1="310.0" y1="875.0" x2="390.0" y2="875.0"/>
+<line class="weight-link" x1="390.0" y1="875.0" x2="470.0" y2="875.0"/>
+<line class="weight-link" x1="470.0" y1="875.0" x2="470.0" y2="945.0"/>
+<line class="weight-link" x1="470.0" y1="945.0" x2="470.0" y2="995.0"/>
+<line class="weight-link" x1="470.0" y1="135.0" x2="470.0" y2="175.0"/>
+<line class="weight-link" x1="470.0" y1="175.0" x2="470.0" y2="245.0"/>
+<line class="weight-link" x1="470.0" y1="245.0" x2="470.0" y2="315.0"/>
+<line class="weight-link" x1="470.0" y1="315.0" x2="470.0" y2="385.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 2 sender 0 to R4: NoC0 X+ then Y+"><title>Bank 2 sender 0 to R4: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="735.0" x2="230.0" y2="735.0"/>
+<line class="weight-link" x1="230.0" y1="735.0" x2="230.0" y2="805.0"/>
+<line class="weight-link" x1="230.0" y1="805.0" x2="230.0" y2="875.0"/>
+<line class="weight-link" x1="230.0" y1="875.0" x2="230.0" y2="945.0"/>
+<line class="weight-link" x1="230.0" y1="945.0" x2="230.0" y2="995.0"/>
+<line class="weight-link" x1="230.0" y1="135.0" x2="230.0" y2="175.0"/>
+<line class="weight-link" x1="230.0" y1="175.0" x2="230.0" y2="245.0"/>
+<line class="weight-link" x1="230.0" y1="245.0" x2="230.0" y2="315.0"/>
+<line class="weight-link" x1="231.4" y1="315.0" x2="231.4" y2="385.0"/>
+<line class="weight-link" x1="231.4" y1="385.0" x2="231.4" y2="455.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 2 sender 1 to R5: NoC0 X+ then Y+"><title>Bank 2 sender 1 to R5: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="456.4" x2="230.0" y2="456.4"/>
+<line class="weight-link" x1="230.0" y1="456.4" x2="310.0" y2="456.4" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 3 sender 0 to R6: NoC0 X+ then Y+"><title>Bank 3 sender 0 to R6: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="595.0" x2="230.0" y2="595.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 3 sender 1 to R7: NoC0 X+ then Y+"><title>Bank 3 sender 1 to R7: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="666.4" x2="230.0" y2="666.4"/>
+<line class="weight-link" x1="230.0" y1="666.4" x2="310.0" y2="666.4"/>
+<line class="weight-link" x1="310.0" y1="666.4" x2="390.0" y2="666.4"/>
+<line class="weight-link" x1="390.0" y1="665.0" x2="470.0" y2="665.0"/>
+<line class="weight-link" x1="470.0" y1="665.0" x2="550.0" y2="665.0"/>
+<line class="weight-link" x1="550.0" y1="665.0" x2="550.0" y2="735.0"/>
+<line class="weight-link" x1="550.0" y1="735.0" x2="550.0" y2="805.0"/>
+<line class="weight-link" x1="550.0" y1="805.0" x2="550.0" y2="875.0"/>
+<line class="weight-link" x1="550.0" y1="875.0" x2="550.0" y2="945.0"/>
+<line class="weight-link" x1="550.0" y1="945.0" x2="550.0" y2="995.0"/>
+<line class="weight-link" x1="550.0" y1="135.0" x2="550.0" y2="175.0"/>
+<line class="weight-link" x1="550.0" y1="175.0" x2="550.0" y2="245.0"/>
+<line class="weight-link" x1="550.0" y1="245.0" x2="550.0" y2="315.0"/>
+<line class="weight-link" x1="550.0" y1="315.0" x2="550.0" y2="385.0"/>
+<line class="weight-link" x1="550.0" y1="385.0" x2="550.0" y2="455.0"/>
+<line class="weight-link" x1="550.0" y1="455.0" x2="550.0" y2="525.0"/>
+<line class="weight-link" x1="550.0" y1="525.0" x2="550.0" y2="595.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 4 sender 0 to R8: NoC0 X+ then Y+"><title>Bank 4 sender 0 to R8: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="175.0" x2="950.0" y2="175.0"/>
+<line class="weight-link" x1="950.0" y1="175.0" x2="1030.0" y2="175.0"/>
+<line class="weight-link" x1="1030.0" y1="175.0" x2="1110.0" y2="175.0"/>
+<line class="weight-link" x1="1110.0" y1="175.0" x2="1190.0" y2="175.0"/>
+<line class="weight-link" x1="1190.0" y1="175.0" x2="1190.0" y2="245.0"/>
+<line class="weight-link" x1="1190.0" y1="245.0" x2="1190.0" y2="315.0"/>
+<line class="weight-link" x1="1190.0" y1="315.0" x2="1190.0" y2="385.0"/>
+<line class="weight-link" x1="1190.0" y1="385.0" x2="1190.0" y2="455.0"/>
+<line class="weight-link" x1="1190.0" y1="455.0" x2="1190.0" y2="525.0"/>
+<line class="weight-link" x1="1190.0" y1="525.0" x2="1190.0" y2="595.0"/>
+<line class="weight-link" x1="1191.4" y1="595.0" x2="1191.4" y2="665.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 4 sender 1 to R9: NoC0 X+ then Y+"><title>Bank 4 sender 1 to R9: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="245.0" x2="950.0" y2="245.0"/>
+<line class="weight-link" x1="950.0" y1="245.0" x2="1030.0" y2="245.0"/>
+<line class="weight-link" x1="1030.0" y1="245.0" x2="1110.0" y2="245.0"/>
+<line class="weight-link" x1="1110.0" y1="245.0" x2="1190.0" y2="245.0"/>
+<line class="weight-link" x1="1190.0" y1="245.0" x2="1270.0" y2="245.0"/>
+<line class="weight-link" x1="1270.0" y1="245.0" x2="1270.0" y2="315.0"/>
+<line class="weight-link" x1="1270.0" y1="315.0" x2="1270.0" y2="385.0"/>
+<line class="weight-link" x1="1270.0" y1="385.0" x2="1270.0" y2="455.0"/>
+<line class="weight-link" x1="1270.0" y1="455.0" x2="1270.0" y2="525.0"/>
+<line class="weight-link" x1="1270.0" y1="525.0" x2="1270.0" y2="595.0"/>
+<line class="weight-link" x1="1270.0" y1="595.0" x2="1270.0" y2="665.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 5 sender 0 to R10: NoC0 X+ then Y+"><title>Bank 5 sender 0 to R10: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="316.4" x2="950.0" y2="316.4"/>
+<line class="weight-link" x1="950.0" y1="316.4" x2="1030.0" y2="316.4"/>
+<line class="weight-link" x1="1030.0" y1="316.4" x2="1110.0" y2="316.4"/>
+<line class="weight-link" x1="1110.0" y1="316.4" x2="1190.0" y2="316.4"/>
+<line class="weight-link" x1="1190.0" y1="316.4" x2="1270.0" y2="316.4"/>
+<line class="weight-link" x1="1270.0" y1="316.4" x2="1350.0" y2="316.4"/>
+<line class="weight-link" x1="1350.0" y1="316.4" x2="1430.0" y2="316.4"/>
+<line class="weight-link" x1="1430.0" y1="316.4" x2="1495.0" y2="316.4"/>
+<line class="weight-link" x1="105.0" y1="316.4" x2="150.0" y2="316.4"/>
+<line class="weight-link" x1="150.0" y1="316.4" x2="230.0" y2="316.4"/>
+<line class="weight-link" x1="230.0" y1="315.0" x2="310.0" y2="315.0"/>
+<line class="weight-link" x1="310.0" y1="316.4" x2="390.0" y2="316.4"/>
+<line class="weight-link" x1="390.0" y1="315.0" x2="390.0" y2="385.0"/>
+<line class="weight-link" x1="390.0" y1="385.0" x2="390.0" y2="455.0"/>
+<line class="weight-link" x1="390.0" y1="455.0" x2="390.0" y2="525.0"/>
+<line class="weight-link" x1="390.0" y1="525.0" x2="390.0" y2="595.0"/>
+<line class="weight-link" x1="390.0" y1="595.0" x2="390.0" y2="665.0"/>
+<line class="weight-link" x1="391.4" y1="665.0" x2="391.4" y2="735.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 5 sender 1 to R11: NoC0 X+ then Y+"><title>Bank 5 sender 1 to R11: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="875.0" x2="950.0" y2="875.0"/>
+<line class="weight-link" x1="950.0" y1="875.0" x2="1030.0" y2="875.0"/>
+<line class="weight-link" x1="1030.0" y1="876.4" x2="1110.0" y2="876.4"/>
+<line class="weight-link" x1="1110.0" y1="875.0" x2="1110.0" y2="945.0"/>
+<line class="weight-link" x1="1110.0" y1="945.0" x2="1110.0" y2="995.0"/>
+<line class="weight-link" x1="1110.0" y1="135.0" x2="1110.0" y2="175.0"/>
+<line class="weight-link" x1="1110.0" y1="175.0" x2="1110.0" y2="245.0"/>
+<line class="weight-link" x1="1110.0" y1="245.0" x2="1110.0" y2="315.0"/>
+<line class="weight-link" x1="1110.0" y1="315.0" x2="1110.0" y2="385.0"/>
+<line class="weight-link" x1="1110.0" y1="385.0" x2="1110.0" y2="455.0"/>
+<line class="weight-link" x1="1110.0" y1="455.0" x2="1110.0" y2="525.0"/>
+<line class="weight-link" x1="1110.0" y1="525.0" x2="1110.0" y2="595.0"/>
+<line class="weight-link" x1="1110.0" y1="595.0" x2="1110.0" y2="665.0"/>
+<line class="weight-link" x1="1110.0" y1="665.0" x2="1110.0" y2="735.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 6 sender 0 to R12: NoC0 X+ then Y+"><title>Bank 6 sender 0 to R12: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="806.4" x2="950.0" y2="806.4"/>
+<line class="weight-link" x1="950.0" y1="806.4" x2="1030.0" y2="806.4"/>
+<line class="weight-link" x1="1030.0" y1="805.0" x2="1110.0" y2="805.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 6 sender 1 to R13: NoC0 X+ then Y+"><title>Bank 6 sender 1 to R13: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="456.4" x2="950.0" y2="456.4"/>
+<line class="weight-link" x1="950.0" y1="456.4" x2="1030.0" y2="456.4"/>
+<line class="weight-link" x1="1030.0" y1="456.4" x2="1110.0" y2="456.4"/>
+<line class="weight-link" x1="1110.0" y1="456.4" x2="1190.0" y2="456.4"/>
+<line class="weight-link" x1="1190.0" y1="456.4" x2="1270.0" y2="456.4"/>
+<line class="weight-link" x1="1270.0" y1="456.4" x2="1350.0" y2="456.4"/>
+<line class="weight-link" x1="1350.0" y1="455.0" x2="1350.0" y2="525.0"/>
+<line class="weight-link" x1="1350.0" y1="525.0" x2="1350.0" y2="595.0"/>
+<line class="weight-link" x1="1350.0" y1="595.0" x2="1350.0" y2="665.0"/>
+<line class="weight-link" x1="1350.0" y1="665.0" x2="1350.0" y2="735.0"/>
+<line class="weight-link" x1="1350.0" y1="735.0" x2="1350.0" y2="805.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 7 sender 0 to R14: NoC0 X+ then Y+"><title>Bank 7 sender 0 to R14: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="525.0" x2="950.0" y2="525.0"/>
+<line class="weight-link" x1="950.0" y1="525.0" x2="1030.0" y2="525.0"/>
+<line class="weight-link" x1="1030.0" y1="525.0" x2="1030.0" y2="595.0"/>
+<line class="weight-link" x1="1030.0" y1="595.0" x2="1030.0" y2="665.0"/>
+<line class="weight-link" x1="1030.0" y1="665.0" x2="1030.0" y2="735.0"/>
+<line class="weight-link" x1="1030.0" y1="735.0" x2="1030.0" y2="805.0"/>
+<line class="weight-link" x1="1031.4" y1="805.0" x2="1031.4" y2="875.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 7 sender 1 to R15: NoC0 X+ then Y+"><title>Bank 7 sender 1 to R15: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="665.0" x2="950.0" y2="665.0"/>
+<line class="weight-link" x1="950.0" y1="665.0" x2="1030.0" y2="665.0"/>
+<line class="weight-link" x1="1030.0" y1="665.0" x2="1110.0" y2="665.0"/>
+<line class="weight-link" x1="1110.0" y1="665.0" x2="1190.0" y2="665.0"/>
+<line class="weight-link" x1="1190.0" y1="665.0" x2="1190.0" y2="735.0"/>
+<line class="weight-link" x1="1190.0" y1="735.0" x2="1190.0" y2="805.0"/>
+<line class="weight-link" x1="1190.0" y1="805.0" x2="1190.0" y2="875.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="R0 to R15: NoC1 Y- then X-"><title>R0 to R15: NoC1 Y- then X-</title>
+<line class="ring-link" x1="308.6" y1="315.0" x2="308.6" y2="245.0"/>
+<line class="ring-link" x1="308.6" y1="245.0" x2="308.6" y2="175.0"/>
+<line class="ring-link" x1="310.0" y1="175.0" x2="310.0" y2="135.0"/>
+<line class="ring-link" x1="310.0" y1="995.0" x2="310.0" y2="945.0"/>
+<line class="ring-link" x1="310.0" y1="945.0" x2="310.0" y2="875.0"/>
+<line class="ring-link" x1="310.0" y1="873.6" x2="230.0" y2="873.6"/>
+<line class="ring-link" x1="230.0" y1="873.6" x2="150.0" y2="873.6"/>
+<line class="ring-link" x1="150.0" y1="875.0" x2="105.0" y2="875.0"/>
+<line class="ring-link" x1="1495.0" y1="875.0" x2="1430.0" y2="875.0"/>
+<line class="ring-link" x1="1430.0" y1="875.0" x2="1350.0" y2="875.0"/>
+<line class="ring-link" x1="1350.0" y1="875.0" x2="1270.0" y2="875.0"/>
+<line class="ring-link" x1="1270.0" y1="875.0" x2="1190.0" y2="875.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R1 to R0: NoC1 Y- then X-"><title>R1 to R0: NoC1 Y- then X-</title>
+<line class="ring-link" x1="390.0" y1="313.6" x2="310.0" y2="313.6" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R2 to R1: NoC1 Y- then X-"><title>R2 to R1: NoC1 Y- then X-</title>
+<line class="ring-link" x1="228.6" y1="385.0" x2="228.6" y2="315.0"/>
+<line class="ring-link" x1="230.0" y1="313.6" x2="150.0" y2="313.6"/>
+<line class="ring-link" x1="150.0" y1="313.6" x2="105.0" y2="313.6"/>
+<line class="ring-link" x1="1495.0" y1="313.6" x2="1430.0" y2="313.6"/>
+<line class="ring-link" x1="1430.0" y1="313.6" x2="1350.0" y2="313.6"/>
+<line class="ring-link" x1="1350.0" y1="313.6" x2="1270.0" y2="313.6"/>
+<line class="ring-link" x1="1270.0" y1="313.6" x2="1190.0" y2="313.6"/>
+<line class="ring-link" x1="1190.0" y1="313.6" x2="1110.0" y2="313.6"/>
+<line class="ring-link" x1="1110.0" y1="313.6" x2="1030.0" y2="313.6"/>
+<line class="ring-link" x1="1030.0" y1="313.6" x2="950.0" y2="313.6"/>
+<line class="ring-link" x1="950.0" y1="313.6" x2="870.0" y2="313.6"/>
+<line class="ring-link" x1="870.0" y1="315.0" x2="790.0" y2="315.0"/>
+<line class="ring-link" x1="790.0" y1="315.0" x2="710.0" y2="315.0"/>
+<line class="ring-link" x1="710.0" y1="315.0" x2="630.0" y2="315.0"/>
+<line class="ring-link" x1="630.0" y1="315.0" x2="550.0" y2="315.0"/>
+<line class="ring-link" x1="550.0" y1="315.0" x2="470.0" y2="315.0"/>
+<line class="ring-link" x1="470.0" y1="315.0" x2="390.0" y2="315.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R3 to R2: NoC1 Y- then X-"><title>R3 to R2: NoC1 Y- then X-</title>
+<line class="ring-link" x1="470.0" y1="385.0" x2="390.0" y2="385.0"/>
+<line class="ring-link" x1="390.0" y1="385.0" x2="310.0" y2="385.0"/>
+<line class="ring-link" x1="310.0" y1="385.0" x2="230.0" y2="385.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R4 to R3: NoC1 Y- then X-"><title>R4 to R3: NoC1 Y- then X-</title>
+<line class="ring-link" x1="228.6" y1="455.0" x2="228.6" y2="385.0"/>
+<line class="ring-link" x1="230.0" y1="383.6" x2="150.0" y2="383.6"/>
+<line class="ring-link" x1="150.0" y1="385.0" x2="105.0" y2="385.0"/>
+<line class="ring-link" x1="1495.0" y1="385.0" x2="1430.0" y2="385.0"/>
+<line class="ring-link" x1="1430.0" y1="385.0" x2="1350.0" y2="385.0"/>
+<line class="ring-link" x1="1350.0" y1="385.0" x2="1270.0" y2="385.0"/>
+<line class="ring-link" x1="1270.0" y1="385.0" x2="1190.0" y2="385.0"/>
+<line class="ring-link" x1="1190.0" y1="385.0" x2="1110.0" y2="385.0"/>
+<line class="ring-link" x1="1110.0" y1="385.0" x2="1030.0" y2="385.0"/>
+<line class="ring-link" x1="1030.0" y1="385.0" x2="950.0" y2="385.0"/>
+<line class="ring-link" x1="950.0" y1="385.0" x2="870.0" y2="385.0"/>
+<line class="ring-link" x1="870.0" y1="385.0" x2="790.0" y2="385.0"/>
+<line class="ring-link" x1="790.0" y1="385.0" x2="710.0" y2="385.0"/>
+<line class="ring-link" x1="710.0" y1="385.0" x2="630.0" y2="385.0"/>
+<line class="ring-link" x1="630.0" y1="385.0" x2="550.0" y2="385.0"/>
+<line class="ring-link" x1="550.0" y1="385.0" x2="470.0" y2="385.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R5 to R4: NoC1 Y- then X-"><title>R5 to R4: NoC1 Y- then X-</title>
+<line class="ring-link" x1="310.0" y1="453.6" x2="230.0" y2="453.6" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R6 to R5: NoC1 Y- then X-"><title>R6 to R5: NoC1 Y- then X-</title>
+<line class="ring-link" x1="230.0" y1="595.0" x2="230.0" y2="525.0"/>
+<line class="ring-link" x1="230.0" y1="525.0" x2="230.0" y2="455.0"/>
+<line class="ring-link" x1="230.0" y1="453.6" x2="150.0" y2="453.6"/>
+<line class="ring-link" x1="150.0" y1="455.0" x2="105.0" y2="455.0"/>
+<line class="ring-link" x1="1495.0" y1="455.0" x2="1430.0" y2="455.0"/>
+<line class="ring-link" x1="1430.0" y1="455.0" x2="1350.0" y2="455.0"/>
+<line class="ring-link" x1="1350.0" y1="453.6" x2="1270.0" y2="453.6"/>
+<line class="ring-link" x1="1270.0" y1="453.6" x2="1190.0" y2="453.6"/>
+<line class="ring-link" x1="1190.0" y1="453.6" x2="1110.0" y2="453.6"/>
+<line class="ring-link" x1="1110.0" y1="453.6" x2="1030.0" y2="453.6"/>
+<line class="ring-link" x1="1030.0" y1="453.6" x2="950.0" y2="453.6"/>
+<line class="ring-link" x1="950.0" y1="453.6" x2="870.0" y2="453.6"/>
+<line class="ring-link" x1="870.0" y1="455.0" x2="790.0" y2="455.0"/>
+<line class="ring-link" x1="790.0" y1="455.0" x2="710.0" y2="455.0"/>
+<line class="ring-link" x1="710.0" y1="455.0" x2="630.0" y2="455.0"/>
+<line class="ring-link" x1="630.0" y1="455.0" x2="550.0" y2="455.0"/>
+<line class="ring-link" x1="550.0" y1="455.0" x2="470.0" y2="455.0"/>
+<line class="ring-link" x1="470.0" y1="455.0" x2="390.0" y2="455.0"/>
+<line class="ring-link" x1="390.0" y1="455.0" x2="310.0" y2="455.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R7 to R6: NoC1 Y- then X-"><title>R7 to R6: NoC1 Y- then X-</title>
+<line class="ring-link" x1="550.0" y1="595.0" x2="470.0" y2="595.0"/>
+<line class="ring-link" x1="470.0" y1="595.0" x2="390.0" y2="595.0"/>
+<line class="ring-link" x1="390.0" y1="595.0" x2="310.0" y2="595.0"/>
+<line class="ring-link" x1="310.0" y1="595.0" x2="230.0" y2="595.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R8 to R7: NoC1 Y- then X-"><title>R8 to R7: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1188.6" y1="665.0" x2="1188.6" y2="595.0"/>
+<line class="ring-link" x1="1190.0" y1="595.0" x2="1110.0" y2="595.0"/>
+<line class="ring-link" x1="1110.0" y1="595.0" x2="1030.0" y2="595.0"/>
+<line class="ring-link" x1="1030.0" y1="595.0" x2="950.0" y2="595.0"/>
+<line class="ring-link" x1="950.0" y1="595.0" x2="870.0" y2="595.0"/>
+<line class="ring-link" x1="870.0" y1="595.0" x2="790.0" y2="595.0"/>
+<line class="ring-link" x1="790.0" y1="595.0" x2="710.0" y2="595.0"/>
+<line class="ring-link" x1="710.0" y1="595.0" x2="630.0" y2="595.0"/>
+<line class="ring-link" x1="630.0" y1="595.0" x2="550.0" y2="595.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R9 to R8: NoC1 Y- then X-"><title>R9 to R8: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1270.0" y1="665.0" x2="1190.0" y2="665.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R10 to R9: NoC1 Y- then X-"><title>R10 to R9: NoC1 Y- then X-</title>
+<line class="ring-link" x1="388.6" y1="735.0" x2="388.6" y2="665.0"/>
+<line class="ring-link" x1="390.0" y1="663.6" x2="310.0" y2="663.6"/>
+<line class="ring-link" x1="310.0" y1="663.6" x2="230.0" y2="663.6"/>
+<line class="ring-link" x1="230.0" y1="663.6" x2="150.0" y2="663.6"/>
+<line class="ring-link" x1="150.0" y1="665.0" x2="105.0" y2="665.0"/>
+<line class="ring-link" x1="1495.0" y1="665.0" x2="1430.0" y2="665.0"/>
+<line class="ring-link" x1="1430.0" y1="665.0" x2="1350.0" y2="665.0"/>
+<line class="ring-link" x1="1350.0" y1="665.0" x2="1270.0" y2="665.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R11 to R10: NoC1 Y- then X-"><title>R11 to R10: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1110.0" y1="735.0" x2="1030.0" y2="735.0"/>
+<line class="ring-link" x1="1030.0" y1="735.0" x2="950.0" y2="735.0"/>
+<line class="ring-link" x1="950.0" y1="735.0" x2="870.0" y2="735.0"/>
+<line class="ring-link" x1="870.0" y1="735.0" x2="790.0" y2="735.0"/>
+<line class="ring-link" x1="790.0" y1="735.0" x2="710.0" y2="735.0"/>
+<line class="ring-link" x1="710.0" y1="735.0" x2="630.0" y2="735.0"/>
+<line class="ring-link" x1="630.0" y1="735.0" x2="550.0" y2="735.0"/>
+<line class="ring-link" x1="550.0" y1="735.0" x2="470.0" y2="735.0"/>
+<line class="ring-link" x1="470.0" y1="735.0" x2="390.0" y2="735.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R12 to R11: NoC1 Y- then X-"><title>R12 to R11: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1110.0" y1="805.0" x2="1110.0" y2="735.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R13 to R12: NoC1 Y- then X-"><title>R13 to R12: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1350.0" y1="805.0" x2="1270.0" y2="805.0"/>
+<line class="ring-link" x1="1270.0" y1="805.0" x2="1190.0" y2="805.0"/>
+<line class="ring-link" x1="1190.0" y1="805.0" x2="1110.0" y2="805.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R14 to R13: NoC1 Y- then X-"><title>R14 to R13: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1028.6" y1="875.0" x2="1028.6" y2="805.0"/>
+<line class="ring-link" x1="1030.0" y1="803.6" x2="950.0" y2="803.6"/>
+<line class="ring-link" x1="950.0" y1="803.6" x2="870.0" y2="803.6"/>
+<line class="ring-link" x1="870.0" y1="805.0" x2="790.0" y2="805.0"/>
+<line class="ring-link" x1="790.0" y1="805.0" x2="710.0" y2="805.0"/>
+<line class="ring-link" x1="710.0" y1="805.0" x2="630.0" y2="805.0"/>
+<line class="ring-link" x1="630.0" y1="805.0" x2="550.0" y2="805.0"/>
+<line class="ring-link" x1="550.0" y1="805.0" x2="470.0" y2="805.0"/>
+<line class="ring-link" x1="470.0" y1="805.0" x2="390.0" y2="805.0"/>
+<line class="ring-link" x1="390.0" y1="805.0" x2="310.0" y2="805.0"/>
+<line class="ring-link" x1="310.0" y1="805.0" x2="230.0" y2="805.0"/>
+<line class="ring-link" x1="230.0" y1="805.0" x2="150.0" y2="805.0"/>
+<line class="ring-link" x1="150.0" y1="805.0" x2="105.0" y2="805.0"/>
+<line class="ring-link" x1="1495.0" y1="805.0" x2="1430.0" y2="805.0"/>
+<line class="ring-link" x1="1430.0" y1="805.0" x2="1350.0" y2="805.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R15 to R14: NoC1 Y- then X-"><title>R15 to R14: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1190.0" y1="875.0" x2="1110.0" y2="875.0"/>
+<line class="ring-link" x1="1110.0" y1="873.6" x2="1030.0" y2="873.6" marker-end="url(#arrow-green)"/>
+</g></g>
+  <g aria-label="Activation ring indices"><text class="ring-label" x="310" y="315">R0</text><text class="ring-label" x="390" y="315">R1</text><text class="ring-label" x="230" y="385">R2</text><text class="ring-label" x="470" y="385">R3</text><text class="ring-label" x="230" y="455">R4</text><text class="ring-label" x="310" y="455">R5</text><text class="ring-label" x="230" y="595">R6</text><text class="ring-label" x="550" y="595">R7</text><text class="ring-label" x="1190" y="665">R8</text><text class="ring-label" x="1270" y="665">R9</text><text class="ring-label" x="390" y="735">R10</text><text class="ring-label" x="1110" y="735">R11</text><text class="ring-label" x="1110" y="805">R12</text><text class="ring-label" x="1350" y="805">R13</text><text class="ring-label" x="1030" y="875">R14</text><text class="ring-label" x="1190" y="875">R15</text></g>
+  <g aria-label="DRAM bank and sender indices"><text class="sender-label" x="150" y="175">B0 S0</text><text class="sender-label" x="150" y="245">B0 S1</text><text class="sender-label" x="150" y="385">B1 S0</text><text class="sender-label" x="150" y="875">B1 S1</text><text class="sender-label" x="150" y="735">B2 S0</text><text class="sender-label" x="150" y="455">B2 S1</text><text class="sender-label" x="150" y="595">B3 S0</text><text class="sender-label" x="150" y="665">B3 S1</text><text class="sender-label" x="870" y="175">B4 S0</text><text class="sender-label" x="870" y="245">B4 S1</text><text class="sender-label" x="870" y="315">B5 S0</text><text class="sender-label" x="870" y="875">B5 S1</text><text class="sender-label" x="870" y="805">B6 S0</text><text class="sender-label" x="870" y="455">B6 S1</text><text class="sender-label" x="870" y="525">B7 S0</text><text class="sender-label" x="870" y="665">B7 S1</text></g>
+  <g transform="translate(120,1025)">
+    <rect x="0" y="-22" width="1360" height="78" rx="12" fill="white" stroke="#d5dbe2"/>
+    <rect x="28" y="-4" width="34" height="28" rx="5" fill="#2878d0" stroke="#0e4f98" stroke-width="2"/>
+    <text class="legend" x="74" y="10">Activation-ring worker</text>
+    <rect x="300" y="-4" width="34" height="28" rx="5" fill="#d9363e" stroke="#8d1720" stroke-width="2"/>
+    <text class="legend" x="346" y="10">Tensor Prefetcher DRISC</text>
+    <rect x="600" y="-4" width="34" height="28" rx="5" fill="#aeb4bc" stroke="#6f7782"/>
+    <text class="legend" x="646" y="10">All other chip cores</text>
+    <line x1="810" y1="10" x2="850" y2="10" stroke="#12a150" stroke-width="5" marker-end="url(#arrow-green)"/>
+    <text class="legend" x="864" y="10">Activation: NoC1 Y- then X-</text>
+    <line x1="1095" y1="10" x2="1135" y2="10" stroke="#ef4f9a" stroke-width="4" marker-end="url(#arrow-pink)"/>
+    <text class="legend" x="1149" y="10">Weights: NoC0 X+ then Y+</text>
+    <text x="680" y="43" text-anchor="middle" font-family="sans-serif" font-size="13" fill="#66727f">Every coincident physical link is separated into parallel visual lanes; lane offsets are not hardware detours.</text>
+  </g>
+</svg>

--- a/tech_reports/TensorPrefetcher/media/tensor_prefetcher_ring64_chip.svg
+++ b/tech_reports/TensorPrefetcher/media/tensor_prefetcher_ring64_chip.svg
@@ -1,0 +1,1148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-FileCopyrightText: &#x00A9; 2026 Tenstorrent USA, Inc. -->
+
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="1120" viewBox="0 0 1600 1120">
+  <defs>
+    <pattern id="chip-grid" width="80" height="70" patternUnits="userSpaceOnUse" patternTransform="translate(110 140)">
+      <rect x="6" y="6" width="68" height="58" rx="7" fill="#aeb4bc" stroke="#6f7782" stroke-width="1.5"/>
+    </pattern>
+    <marker id="arrow-green" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#12a150"/>
+    </marker>
+    <marker id="arrow-pink" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#ef4f9a"/>
+    </marker>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="2" stdDeviation="2" flood-color="#17202a" flood-opacity="0.25"/>
+    </filter>
+    <g id="worker-core"><rect x="-34" y="-29" width="68" height="58" rx="7" fill="#2878d0" stroke="#0e4f98" stroke-width="2.5"/></g>
+    <g id="sender-core"><rect x="-34" y="-29" width="68" height="58" rx="7" fill="#d9363e" stroke="#8d1720" stroke-width="2.5"/></g>
+    <style>
+      .axis { font: 600 15px sans-serif; fill: #46505c; text-anchor: middle; }
+      .tile-label { font: 600 11px sans-serif; fill: #29323c; text-anchor: middle; dominant-baseline: middle; }
+      .ring-label { font: 700 10px sans-serif; fill: white; text-anchor: middle; dominant-baseline: middle; }
+      .sender-label { font: 700 10px sans-serif; fill: white; text-anchor: middle; dominant-baseline: middle; }
+      .weight-link { fill: none; stroke: #ef4f9a; stroke-width: 2.2; stroke-opacity: 0.52; }
+      .ring-link { fill: none; stroke: #12a150; stroke-width: 3.2; stroke-opacity: 0.88; }
+      .legend { font: 16px sans-serif; fill: #25303b; dominant-baseline: middle; }
+    </style>
+  </defs>
+  <rect width="1600" height="1120" fill="#f7f9fb"/>
+  <text x="800" y="50" text-anchor="middle" font-family="sans-serif" font-size="30" font-weight="700" fill="#17202a">Tensor Prefetcher Ring 64</text>
+  <text x="800" y="82" text-anchor="middle" font-family="sans-serif" font-size="16" fill="#52606d">spread_contiguous_ring64; dual DRISC senders; shared links use offset visual lanes</text>
+  <g aria-label="NoC0 coordinate axes">
+    <text x="790" y="111" text-anchor="middle" font-family="sans-serif" font-size="15" font-weight="700" fill="#46505c">NoC0 x</text>
+    <text x="55" y="560" transform="rotate(-90 55 560)" text-anchor="middle" font-family="sans-serif" font-size="15" font-weight="700" fill="#46505c">NoC0 y</text>
+    <g class="axis"><text x="150" y="130">0</text><text x="230" y="130">1</text><text x="310" y="130">2</text><text x="390" y="130">3</text><text x="470" y="130">4</text><text x="550" y="130">5</text><text x="630" y="130">6</text><text x="710" y="130">7</text><text x="790" y="130">8</text><text x="870" y="130">9</text><text x="950" y="130">10</text><text x="1030" y="130">11</text><text x="1110" y="130">12</text><text x="1190" y="130">13</text><text x="1270" y="130">14</text><text x="1350" y="130">15</text><text x="1430" y="130">16</text><text x="90" y="180">0</text><text x="90" y="250">1</text><text x="90" y="320">2</text><text x="90" y="390">3</text><text x="90" y="460">4</text><text x="90" y="530">5</text><text x="90" y="600">6</text><text x="90" y="670">7</text><text x="90" y="740">8</text><text x="90" y="810">9</text><text x="90" y="880">10</text><text x="90" y="950">11</text></g>
+  </g>
+  <rect x="110" y="140" width="1360" height="840" fill="url(#chip-grid)"/>
+  <g class="tile-label" opacity="0.72"><text x="790" y="175">ARC</text><text x="310" y="175">PCIe</text><text x="1030" y="175">PCIe</text><text x="790" y="245">RTR</text><text x="790" y="315">RTR</text><text x="790" y="385">RTR</text><text x="790" y="455">RTR</text><text x="790" y="525">RTR</text><text x="790" y="595">RTR</text><text x="790" y="665">RTR</text><text x="790" y="735">RTR</text><text x="790" y="805">RTR</text><text x="790" y="875">RTR</text><text x="790" y="945">RTR</text><text x="230" y="245">ETH</text><text x="310" y="245">ETH</text><text x="390" y="245">ETH</text><text x="470" y="245">ETH</text><text x="550" y="245">ETH</text><text x="630" y="245">ETH</text><text x="710" y="245">ETH</text><text x="950" y="245">ETH</text><text x="1030" y="245">ETH</text><text x="1110" y="245">ETH</text><text x="1190" y="245">ETH</text><text x="1270" y="245">ETH</text><text x="1350" y="245">ETH</text><text x="1430" y="245">ETH</text><text x="150" y="945">DRAM</text><text x="870" y="945">DRAM</text><text x="150" y="315">DRAM</text><text x="870" y="385">DRAM</text><text x="150" y="805">DRAM</text><text x="870" y="595">DRAM</text></g>
+  <g filter="url(#shadow)" aria-label="Activation ring worker cores"><use href="#worker-core" transform="translate(230 315)"/><use href="#worker-core" transform="translate(310 315)"/><use href="#worker-core" transform="translate(310 525)"/><use href="#worker-core" transform="translate(1110 315)"/><use href="#worker-core" transform="translate(390 315)"/><use href="#worker-core" transform="translate(470 455)"/><use href="#worker-core" transform="translate(470 315)"/><use href="#worker-core" transform="translate(1030 315)"/><use href="#worker-core" transform="translate(230 385)"/><use href="#worker-core" transform="translate(390 385)"/><use href="#worker-core" transform="translate(550 385)"/><use href="#worker-core" transform="translate(310 385)"/><use href="#worker-core" transform="translate(470 385)"/><use href="#worker-core" transform="translate(1030 385)"/><use href="#worker-core" transform="translate(310 875)"/><use href="#worker-core" transform="translate(390 945)"/><use href="#worker-core" transform="translate(230 455)"/><use href="#worker-core" transform="translate(230 735)"/><use href="#worker-core" transform="translate(310 735)"/><use href="#worker-core" transform="translate(310 455)"/><use href="#worker-core" transform="translate(390 455)"/><use href="#worker-core" transform="translate(390 525)"/><use href="#worker-core" transform="translate(550 455)"/><use href="#worker-core" transform="translate(230 525)"/><use href="#worker-core" transform="translate(230 595)"/><use href="#worker-core" transform="translate(310 595)"/><use href="#worker-core" transform="translate(310 665)"/><use href="#worker-core" transform="translate(390 595)"/><use href="#worker-core" transform="translate(550 595)"/><use href="#worker-core" transform="translate(630 595)"/><use href="#worker-core" transform="translate(230 665)"/><use href="#worker-core" transform="translate(390 665)"/><use href="#worker-core" transform="translate(1110 665)"/><use href="#worker-core" transform="translate(1110 385)"/><use href="#worker-core" transform="translate(1110 455)"/><use href="#worker-core" transform="translate(1190 665)"/><use href="#worker-core" transform="translate(1190 315)"/><use href="#worker-core" transform="translate(1190 385)"/><use href="#worker-core" transform="translate(1270 665)"/><use href="#worker-core" transform="translate(1350 665)"/><use href="#worker-core" transform="translate(1270 315)"/><use href="#worker-core" transform="translate(1350 315)"/><use href="#worker-core" transform="translate(390 735)"/><use href="#worker-core" transform="translate(470 735)"/><use href="#worker-core" transform="translate(1030 945)"/><use href="#worker-core" transform="translate(1110 945)"/><use href="#worker-core" transform="translate(1110 735)"/><use href="#worker-core" transform="translate(1190 735)"/><use href="#worker-core" transform="translate(230 805)"/><use href="#worker-core" transform="translate(1030 805)"/><use href="#worker-core" transform="translate(1110 805)"/><use href="#worker-core" transform="translate(1190 805)"/><use href="#worker-core" transform="translate(1270 805)"/><use href="#worker-core" transform="translate(1350 805)"/><use href="#worker-core" transform="translate(1030 455)"/><use href="#worker-core" transform="translate(1110 525)"/><use href="#worker-core" transform="translate(230 875)"/><use href="#worker-core" transform="translate(1030 875)"/><use href="#worker-core" transform="translate(1030 525)"/><use href="#worker-core" transform="translate(1030 595)"/><use href="#worker-core" transform="translate(1030 665)"/><use href="#worker-core" transform="translate(1030 735)"/><use href="#worker-core" transform="translate(1110 875)"/><use href="#worker-core" transform="translate(1190 875)"/></g>
+  <g filter="url(#shadow)" aria-label="Tensor Prefetcher DRAM sender cores"><use href="#sender-core" transform="translate(150 175)"/><use href="#sender-core" transform="translate(150 245)"/><use href="#sender-core" transform="translate(150 385)"/><use href="#sender-core" transform="translate(150 875)"/><use href="#sender-core" transform="translate(150 735)"/><use href="#sender-core" transform="translate(150 455)"/><use href="#sender-core" transform="translate(150 595)"/><use href="#sender-core" transform="translate(150 665)"/><use href="#sender-core" transform="translate(870 175)"/><use href="#sender-core" transform="translate(870 245)"/><use href="#sender-core" transform="translate(870 315)"/><use href="#sender-core" transform="translate(870 875)"/><use href="#sender-core" transform="translate(870 805)"/><use href="#sender-core" transform="translate(870 455)"/><use href="#sender-core" transform="translate(870 525)"/><use href="#sender-core" transform="translate(870 665)"/></g>
+  <g aria-label="Exact offset NoC routes"><g aria-label="Bank 0 sender 0 to R0: NoC0 X+ then Y+"><title>Bank 0 sender 0 to R0: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="170.8" x2="230.0" y2="170.8"/>
+<line class="weight-link" x1="231.4" y1="175.0" x2="231.4" y2="245.0"/>
+<line class="weight-link" x1="231.4" y1="245.0" x2="231.4" y2="315.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 0 sender 0 to R1: NoC0 X+ then Y+"><title>Bank 0 sender 0 to R1: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="173.6" x2="230.0" y2="173.6"/>
+<line class="weight-link" x1="230.0" y1="172.2" x2="310.0" y2="172.2"/>
+<line class="weight-link" x1="308.6" y1="175.0" x2="308.6" y2="245.0"/>
+<line class="weight-link" x1="308.6" y1="245.0" x2="308.6" y2="315.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 0 sender 0 to R2: NoC0 X+ then Y+"><title>Bank 0 sender 0 to R2: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="176.4" x2="230.0" y2="176.4"/>
+<line class="weight-link" x1="230.0" y1="175.0" x2="310.0" y2="175.0"/>
+<line class="weight-link" x1="311.4" y1="175.0" x2="311.4" y2="245.0"/>
+<line class="weight-link" x1="311.4" y1="245.0" x2="311.4" y2="315.0"/>
+<line class="weight-link" x1="311.4" y1="315.0" x2="311.4" y2="385.0"/>
+<line class="weight-link" x1="312.8" y1="385.0" x2="312.8" y2="455.0"/>
+<line class="weight-link" x1="312.8" y1="455.0" x2="312.8" y2="525.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 0 sender 0 to R3: NoC0 X+ then Y+"><title>Bank 0 sender 0 to R3: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="179.2" x2="230.0" y2="179.2"/>
+<line class="weight-link" x1="230.0" y1="177.8" x2="310.0" y2="177.8"/>
+<line class="weight-link" x1="310.0" y1="175.0" x2="390.0" y2="175.0"/>
+<line class="weight-link" x1="390.0" y1="175.0" x2="470.0" y2="175.0"/>
+<line class="weight-link" x1="470.0" y1="175.0" x2="550.0" y2="175.0"/>
+<line class="weight-link" x1="550.0" y1="175.0" x2="630.0" y2="175.0"/>
+<line class="weight-link" x1="630.0" y1="175.0" x2="710.0" y2="175.0"/>
+<line class="weight-link" x1="710.0" y1="175.0" x2="790.0" y2="175.0"/>
+<line class="weight-link" x1="790.0" y1="175.0" x2="870.0" y2="175.0"/>
+<line class="weight-link" x1="870.0" y1="169.4" x2="950.0" y2="169.4"/>
+<line class="weight-link" x1="950.0" y1="169.4" x2="1030.0" y2="169.4"/>
+<line class="weight-link" x1="1030.0" y1="169.4" x2="1110.0" y2="169.4"/>
+<line class="weight-link" x1="1108.6" y1="175.0" x2="1108.6" y2="245.0"/>
+<line class="weight-link" x1="1108.6" y1="245.0" x2="1108.6" y2="315.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 0 sender 1 to R4: NoC0 X+ then Y+"><title>Bank 0 sender 1 to R4: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="240.8" x2="230.0" y2="240.8"/>
+<line class="weight-link" x1="230.0" y1="240.8" x2="310.0" y2="240.8"/>
+<line class="weight-link" x1="310.0" y1="240.8" x2="390.0" y2="240.8"/>
+<line class="weight-link" x1="391.4" y1="245.0" x2="391.4" y2="315.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 0 sender 1 to R5: NoC0 X+ then Y+"><title>Bank 0 sender 1 to R5: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="243.6" x2="230.0" y2="243.6"/>
+<line class="weight-link" x1="230.0" y1="243.6" x2="310.0" y2="243.6"/>
+<line class="weight-link" x1="310.0" y1="243.6" x2="390.0" y2="243.6"/>
+<line class="weight-link" x1="390.0" y1="242.2" x2="470.0" y2="242.2"/>
+<line class="weight-link" x1="468.6" y1="245.0" x2="468.6" y2="315.0"/>
+<line class="weight-link" x1="468.6" y1="315.0" x2="468.6" y2="385.0"/>
+<line class="weight-link" x1="470.0" y1="385.0" x2="470.0" y2="455.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 0 sender 1 to R6: NoC0 X+ then Y+"><title>Bank 0 sender 1 to R6: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="246.4" x2="230.0" y2="246.4"/>
+<line class="weight-link" x1="230.0" y1="246.4" x2="310.0" y2="246.4"/>
+<line class="weight-link" x1="310.0" y1="246.4" x2="390.0" y2="246.4"/>
+<line class="weight-link" x1="390.0" y1="245.0" x2="470.0" y2="245.0"/>
+<line class="weight-link" x1="471.4" y1="245.0" x2="471.4" y2="315.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 0 sender 1 to R7: NoC0 X+ then Y+"><title>Bank 0 sender 1 to R7: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="249.2" x2="230.0" y2="249.2"/>
+<line class="weight-link" x1="230.0" y1="249.2" x2="310.0" y2="249.2"/>
+<line class="weight-link" x1="310.0" y1="249.2" x2="390.0" y2="249.2"/>
+<line class="weight-link" x1="390.0" y1="247.8" x2="470.0" y2="247.8"/>
+<line class="weight-link" x1="470.0" y1="245.0" x2="550.0" y2="245.0"/>
+<line class="weight-link" x1="550.0" y1="245.0" x2="630.0" y2="245.0"/>
+<line class="weight-link" x1="630.0" y1="245.0" x2="710.0" y2="245.0"/>
+<line class="weight-link" x1="710.0" y1="245.0" x2="790.0" y2="245.0"/>
+<line class="weight-link" x1="790.0" y1="245.0" x2="870.0" y2="245.0"/>
+<line class="weight-link" x1="870.0" y1="239.4" x2="950.0" y2="239.4"/>
+<line class="weight-link" x1="950.0" y1="239.4" x2="1030.0" y2="239.4"/>
+<line class="weight-link" x1="1031.4" y1="245.0" x2="1031.4" y2="315.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 1 sender 0 to R8: NoC0 X+ then Y+"><title>Bank 1 sender 0 to R8: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="383.6" x2="230.0" y2="383.6" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 1 sender 0 to R9: NoC0 X+ then Y+"><title>Bank 1 sender 0 to R9: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="386.4" x2="230.0" y2="386.4"/>
+<line class="weight-link" x1="230.0" y1="386.4" x2="310.0" y2="386.4"/>
+<line class="weight-link" x1="310.0" y1="386.4" x2="390.0" y2="386.4" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 1 sender 0 to R10: NoC0 X+ then Y+"><title>Bank 1 sender 0 to R10: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="389.2" x2="230.0" y2="389.2"/>
+<line class="weight-link" x1="230.0" y1="389.2" x2="310.0" y2="389.2"/>
+<line class="weight-link" x1="310.0" y1="389.2" x2="390.0" y2="389.2"/>
+<line class="weight-link" x1="390.0" y1="387.8" x2="470.0" y2="387.8"/>
+<line class="weight-link" x1="470.0" y1="387.8" x2="550.0" y2="387.8" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 1 sender 0 to R11: NoC0 X+ then Y+"><title>Bank 1 sender 0 to R11: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="392.0" x2="230.0" y2="392.0"/>
+<line class="weight-link" x1="230.0" y1="392.0" x2="310.0" y2="392.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 1 sender 1 to R12: NoC0 X+ then Y+"><title>Bank 1 sender 1 to R12: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="872.2" x2="230.0" y2="872.2"/>
+<line class="weight-link" x1="230.0" y1="872.2" x2="310.0" y2="872.2"/>
+<line class="weight-link" x1="310.0" y1="875.0" x2="390.0" y2="875.0"/>
+<line class="weight-link" x1="390.0" y1="875.0" x2="470.0" y2="875.0"/>
+<line class="weight-link" x1="471.4" y1="875.0" x2="471.4" y2="945.0"/>
+<line class="weight-link" x1="471.4" y1="945.0" x2="471.4" y2="995.0"/>
+<line class="weight-link" x1="471.4" y1="135.0" x2="471.4" y2="175.0"/>
+<line class="weight-link" x1="471.4" y1="175.0" x2="471.4" y2="245.0"/>
+<line class="weight-link" x1="474.2" y1="245.0" x2="474.2" y2="315.0"/>
+<line class="weight-link" x1="471.4" y1="315.0" x2="471.4" y2="385.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 1 sender 1 to R13: NoC0 X+ then Y+"><title>Bank 1 sender 1 to R13: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="875.0" x2="230.0" y2="875.0"/>
+<line class="weight-link" x1="230.0" y1="875.0" x2="310.0" y2="875.0"/>
+<line class="weight-link" x1="310.0" y1="877.8" x2="390.0" y2="877.8"/>
+<line class="weight-link" x1="390.0" y1="877.8" x2="470.0" y2="877.8"/>
+<line class="weight-link" x1="470.0" y1="876.4" x2="550.0" y2="876.4"/>
+<line class="weight-link" x1="550.0" y1="876.4" x2="630.0" y2="876.4"/>
+<line class="weight-link" x1="630.0" y1="876.4" x2="710.0" y2="876.4"/>
+<line class="weight-link" x1="710.0" y1="876.4" x2="790.0" y2="876.4"/>
+<line class="weight-link" x1="790.0" y1="876.4" x2="870.0" y2="876.4"/>
+<line class="weight-link" x1="870.0" y1="870.8" x2="950.0" y2="870.8"/>
+<line class="weight-link" x1="950.0" y1="870.8" x2="1030.0" y2="870.8"/>
+<line class="weight-link" x1="1032.8" y1="875.0" x2="1032.8" y2="945.0"/>
+<line class="weight-link" x1="1032.8" y1="945.0" x2="1032.8" y2="995.0"/>
+<line class="weight-link" x1="1032.8" y1="135.0" x2="1032.8" y2="175.0"/>
+<line class="weight-link" x1="1032.8" y1="175.0" x2="1032.8" y2="245.0"/>
+<line class="weight-link" x1="1034.2" y1="245.0" x2="1034.2" y2="315.0"/>
+<line class="weight-link" x1="1032.8" y1="315.0" x2="1032.8" y2="385.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 1 sender 1 to R14: NoC0 X+ then Y+"><title>Bank 1 sender 1 to R14: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="877.8" x2="230.0" y2="877.8"/>
+<line class="weight-link" x1="230.0" y1="877.8" x2="310.0" y2="877.8" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 1 sender 1 to R15: NoC0 X+ then Y+"><title>Bank 1 sender 1 to R15: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="880.6" x2="230.0" y2="880.6"/>
+<line class="weight-link" x1="230.0" y1="880.6" x2="310.0" y2="880.6"/>
+<line class="weight-link" x1="310.0" y1="880.6" x2="390.0" y2="880.6"/>
+<line class="weight-link" x1="392.8" y1="875.0" x2="392.8" y2="945.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 2 sender 0 to R16: NoC0 X+ then Y+"><title>Bank 2 sender 0 to R16: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="732.2" x2="230.0" y2="732.2"/>
+<line class="weight-link" x1="231.4" y1="735.0" x2="231.4" y2="805.0"/>
+<line class="weight-link" x1="230.0" y1="805.0" x2="230.0" y2="875.0"/>
+<line class="weight-link" x1="231.4" y1="875.0" x2="231.4" y2="945.0"/>
+<line class="weight-link" x1="232.8" y1="945.0" x2="232.8" y2="995.0"/>
+<line class="weight-link" x1="232.8" y1="135.0" x2="232.8" y2="175.0"/>
+<line class="weight-link" x1="234.2" y1="175.0" x2="234.2" y2="245.0"/>
+<line class="weight-link" x1="234.2" y1="245.0" x2="234.2" y2="315.0"/>
+<line class="weight-link" x1="232.8" y1="315.0" x2="232.8" y2="385.0"/>
+<line class="weight-link" x1="231.4" y1="385.0" x2="231.4" y2="455.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 2 sender 0 to R17: NoC0 X+ then Y+"><title>Bank 2 sender 0 to R17: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="735.0" x2="230.0" y2="735.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 2 sender 0 to R18: NoC0 X+ then Y+"><title>Bank 2 sender 0 to R18: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="737.8" x2="230.0" y2="737.8"/>
+<line class="weight-link" x1="230.0" y1="735.0" x2="310.0" y2="735.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 2 sender 0 to R19: NoC0 X+ then Y+"><title>Bank 2 sender 0 to R19: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="740.6" x2="230.0" y2="740.6"/>
+<line class="weight-link" x1="230.0" y1="737.8" x2="310.0" y2="737.8"/>
+<line class="weight-link" x1="312.8" y1="735.0" x2="312.8" y2="805.0"/>
+<line class="weight-link" x1="312.8" y1="805.0" x2="312.8" y2="875.0"/>
+<line class="weight-link" x1="311.4" y1="875.0" x2="311.4" y2="945.0"/>
+<line class="weight-link" x1="311.4" y1="945.0" x2="311.4" y2="995.0"/>
+<line class="weight-link" x1="311.4" y1="135.0" x2="311.4" y2="175.0"/>
+<line class="weight-link" x1="314.2" y1="175.0" x2="314.2" y2="245.0"/>
+<line class="weight-link" x1="314.2" y1="245.0" x2="314.2" y2="315.0"/>
+<line class="weight-link" x1="314.2" y1="315.0" x2="314.2" y2="385.0"/>
+<line class="weight-link" x1="315.6" y1="385.0" x2="315.6" y2="455.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 2 sender 1 to R20: NoC0 X+ then Y+"><title>Bank 2 sender 1 to R20: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="452.2" x2="230.0" y2="452.2"/>
+<line class="weight-link" x1="230.0" y1="452.2" x2="310.0" y2="452.2"/>
+<line class="weight-link" x1="310.0" y1="453.6" x2="390.0" y2="453.6" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 2 sender 1 to R21: NoC0 X+ then Y+"><title>Bank 2 sender 1 to R21: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="455.0" x2="230.0" y2="455.0"/>
+<line class="weight-link" x1="230.0" y1="455.0" x2="310.0" y2="455.0"/>
+<line class="weight-link" x1="310.0" y1="456.4" x2="390.0" y2="456.4"/>
+<line class="weight-link" x1="392.8" y1="455.0" x2="392.8" y2="525.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 2 sender 1 to R22: NoC0 X+ then Y+"><title>Bank 2 sender 1 to R22: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="457.8" x2="230.0" y2="457.8"/>
+<line class="weight-link" x1="230.0" y1="457.8" x2="310.0" y2="457.8"/>
+<line class="weight-link" x1="310.0" y1="459.2" x2="390.0" y2="459.2"/>
+<line class="weight-link" x1="390.0" y1="455.0" x2="470.0" y2="455.0"/>
+<line class="weight-link" x1="470.0" y1="455.0" x2="550.0" y2="455.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 2 sender 1 to R23: NoC0 X+ then Y+"><title>Bank 2 sender 1 to R23: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="460.6" x2="230.0" y2="460.6"/>
+<line class="weight-link" x1="232.8" y1="455.0" x2="232.8" y2="525.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 3 sender 0 to R24: NoC0 X+ then Y+"><title>Bank 3 sender 0 to R24: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="592.2" x2="230.0" y2="592.2" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 3 sender 0 to R25: NoC0 X+ then Y+"><title>Bank 3 sender 0 to R25: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="595.0" x2="230.0" y2="595.0"/>
+<line class="weight-link" x1="230.0" y1="593.6" x2="310.0" y2="593.6" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 3 sender 0 to R26: NoC0 X+ then Y+"><title>Bank 3 sender 0 to R26: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="597.8" x2="230.0" y2="597.8"/>
+<line class="weight-link" x1="230.0" y1="596.4" x2="310.0" y2="596.4"/>
+<line class="weight-link" x1="312.8" y1="595.0" x2="312.8" y2="665.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 3 sender 0 to R27: NoC0 X+ then Y+"><title>Bank 3 sender 0 to R27: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="600.6" x2="230.0" y2="600.6"/>
+<line class="weight-link" x1="230.0" y1="599.2" x2="310.0" y2="599.2"/>
+<line class="weight-link" x1="310.0" y1="595.0" x2="390.0" y2="595.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 3 sender 1 to R28: NoC0 X+ then Y+"><title>Bank 3 sender 1 to R28: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="662.2" x2="230.0" y2="662.2"/>
+<line class="weight-link" x1="230.0" y1="665.0" x2="310.0" y2="665.0"/>
+<line class="weight-link" x1="310.0" y1="666.4" x2="390.0" y2="666.4"/>
+<line class="weight-link" x1="390.0" y1="666.4" x2="470.0" y2="666.4"/>
+<line class="weight-link" x1="470.0" y1="666.4" x2="550.0" y2="666.4"/>
+<line class="weight-link" x1="551.4" y1="665.0" x2="551.4" y2="735.0"/>
+<line class="weight-link" x1="551.4" y1="735.0" x2="551.4" y2="805.0"/>
+<line class="weight-link" x1="551.4" y1="805.0" x2="551.4" y2="875.0"/>
+<line class="weight-link" x1="551.4" y1="875.0" x2="551.4" y2="945.0"/>
+<line class="weight-link" x1="551.4" y1="945.0" x2="551.4" y2="995.0"/>
+<line class="weight-link" x1="551.4" y1="135.0" x2="551.4" y2="175.0"/>
+<line class="weight-link" x1="551.4" y1="175.0" x2="551.4" y2="245.0"/>
+<line class="weight-link" x1="551.4" y1="245.0" x2="551.4" y2="315.0"/>
+<line class="weight-link" x1="551.4" y1="315.0" x2="551.4" y2="385.0"/>
+<line class="weight-link" x1="551.4" y1="385.0" x2="551.4" y2="455.0"/>
+<line class="weight-link" x1="550.0" y1="455.0" x2="550.0" y2="525.0"/>
+<line class="weight-link" x1="551.4" y1="525.0" x2="551.4" y2="595.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 3 sender 1 to R29: NoC0 X+ then Y+"><title>Bank 3 sender 1 to R29: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="665.0" x2="230.0" y2="665.0"/>
+<line class="weight-link" x1="230.0" y1="667.8" x2="310.0" y2="667.8"/>
+<line class="weight-link" x1="310.0" y1="669.2" x2="390.0" y2="669.2"/>
+<line class="weight-link" x1="390.0" y1="669.2" x2="470.0" y2="669.2"/>
+<line class="weight-link" x1="470.0" y1="669.2" x2="550.0" y2="669.2"/>
+<line class="weight-link" x1="550.0" y1="667.8" x2="630.0" y2="667.8"/>
+<line class="weight-link" x1="630.0" y1="665.0" x2="630.0" y2="735.0"/>
+<line class="weight-link" x1="630.0" y1="735.0" x2="630.0" y2="805.0"/>
+<line class="weight-link" x1="630.0" y1="805.0" x2="630.0" y2="875.0"/>
+<line class="weight-link" x1="630.0" y1="875.0" x2="630.0" y2="945.0"/>
+<line class="weight-link" x1="630.0" y1="945.0" x2="630.0" y2="995.0"/>
+<line class="weight-link" x1="630.0" y1="135.0" x2="630.0" y2="175.0"/>
+<line class="weight-link" x1="630.0" y1="175.0" x2="630.0" y2="245.0"/>
+<line class="weight-link" x1="630.0" y1="245.0" x2="630.0" y2="315.0"/>
+<line class="weight-link" x1="630.0" y1="315.0" x2="630.0" y2="385.0"/>
+<line class="weight-link" x1="630.0" y1="385.0" x2="630.0" y2="455.0"/>
+<line class="weight-link" x1="630.0" y1="455.0" x2="630.0" y2="525.0"/>
+<line class="weight-link" x1="630.0" y1="525.0" x2="630.0" y2="595.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 3 sender 1 to R30: NoC0 X+ then Y+"><title>Bank 3 sender 1 to R30: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="667.8" x2="230.0" y2="667.8" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 3 sender 1 to R31: NoC0 X+ then Y+"><title>Bank 3 sender 1 to R31: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="150.0" y1="670.6" x2="230.0" y2="670.6"/>
+<line class="weight-link" x1="230.0" y1="670.6" x2="310.0" y2="670.6"/>
+<line class="weight-link" x1="310.0" y1="672.0" x2="390.0" y2="672.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 4 sender 0 to R32: NoC0 X+ then Y+"><title>Bank 4 sender 0 to R32: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="172.2" x2="950.0" y2="172.2"/>
+<line class="weight-link" x1="950.0" y1="172.2" x2="1030.0" y2="172.2"/>
+<line class="weight-link" x1="1030.0" y1="172.2" x2="1110.0" y2="172.2"/>
+<line class="weight-link" x1="1111.4" y1="175.0" x2="1111.4" y2="245.0"/>
+<line class="weight-link" x1="1111.4" y1="245.0" x2="1111.4" y2="315.0"/>
+<line class="weight-link" x1="1108.6" y1="315.0" x2="1108.6" y2="385.0"/>
+<line class="weight-link" x1="1110.0" y1="385.0" x2="1110.0" y2="455.0"/>
+<line class="weight-link" x1="1110.0" y1="455.0" x2="1110.0" y2="525.0"/>
+<line class="weight-link" x1="1111.4" y1="525.0" x2="1111.4" y2="595.0"/>
+<line class="weight-link" x1="1111.4" y1="595.0" x2="1111.4" y2="665.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 4 sender 0 to R33: NoC0 X+ then Y+"><title>Bank 4 sender 0 to R33: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="175.0" x2="950.0" y2="175.0"/>
+<line class="weight-link" x1="950.0" y1="175.0" x2="1030.0" y2="175.0"/>
+<line class="weight-link" x1="1030.0" y1="175.0" x2="1110.0" y2="175.0"/>
+<line class="weight-link" x1="1114.2" y1="175.0" x2="1114.2" y2="245.0"/>
+<line class="weight-link" x1="1114.2" y1="245.0" x2="1114.2" y2="315.0"/>
+<line class="weight-link" x1="1111.4" y1="315.0" x2="1111.4" y2="385.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 4 sender 0 to R34: NoC0 X+ then Y+"><title>Bank 4 sender 0 to R34: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="177.8" x2="950.0" y2="177.8"/>
+<line class="weight-link" x1="950.0" y1="177.8" x2="1030.0" y2="177.8"/>
+<line class="weight-link" x1="1030.0" y1="177.8" x2="1110.0" y2="177.8"/>
+<line class="weight-link" x1="1117.0" y1="175.0" x2="1117.0" y2="245.0"/>
+<line class="weight-link" x1="1117.0" y1="245.0" x2="1117.0" y2="315.0"/>
+<line class="weight-link" x1="1114.2" y1="315.0" x2="1114.2" y2="385.0"/>
+<line class="weight-link" x1="1112.8" y1="385.0" x2="1112.8" y2="455.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 4 sender 0 to R35: NoC0 X+ then Y+"><title>Bank 4 sender 0 to R35: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="180.6" x2="950.0" y2="180.6"/>
+<line class="weight-link" x1="950.0" y1="180.6" x2="1030.0" y2="180.6"/>
+<line class="weight-link" x1="1030.0" y1="180.6" x2="1110.0" y2="180.6"/>
+<line class="weight-link" x1="1110.0" y1="175.0" x2="1190.0" y2="175.0"/>
+<line class="weight-link" x1="1190.0" y1="175.0" x2="1190.0" y2="245.0"/>
+<line class="weight-link" x1="1187.2" y1="245.0" x2="1187.2" y2="315.0"/>
+<line class="weight-link" x1="1188.6" y1="315.0" x2="1188.6" y2="385.0"/>
+<line class="weight-link" x1="1188.6" y1="385.0" x2="1188.6" y2="455.0"/>
+<line class="weight-link" x1="1190.0" y1="455.0" x2="1190.0" y2="525.0"/>
+<line class="weight-link" x1="1190.0" y1="525.0" x2="1190.0" y2="595.0"/>
+<line class="weight-link" x1="1190.0" y1="595.0" x2="1190.0" y2="665.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 4 sender 1 to R36: NoC0 X+ then Y+"><title>Bank 4 sender 1 to R36: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="242.2" x2="950.0" y2="242.2"/>
+<line class="weight-link" x1="950.0" y1="242.2" x2="1030.0" y2="242.2"/>
+<line class="weight-link" x1="1030.0" y1="240.8" x2="1110.0" y2="240.8"/>
+<line class="weight-link" x1="1110.0" y1="240.8" x2="1190.0" y2="240.8"/>
+<line class="weight-link" x1="1190.0" y1="245.0" x2="1190.0" y2="315.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 4 sender 1 to R37: NoC0 X+ then Y+"><title>Bank 4 sender 1 to R37: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="245.0" x2="950.0" y2="245.0"/>
+<line class="weight-link" x1="950.0" y1="245.0" x2="1030.0" y2="245.0"/>
+<line class="weight-link" x1="1030.0" y1="243.6" x2="1110.0" y2="243.6"/>
+<line class="weight-link" x1="1110.0" y1="243.6" x2="1190.0" y2="243.6"/>
+<line class="weight-link" x1="1192.8" y1="245.0" x2="1192.8" y2="315.0"/>
+<line class="weight-link" x1="1191.4" y1="315.0" x2="1191.4" y2="385.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 4 sender 1 to R38: NoC0 X+ then Y+"><title>Bank 4 sender 1 to R38: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="247.8" x2="950.0" y2="247.8"/>
+<line class="weight-link" x1="950.0" y1="247.8" x2="1030.0" y2="247.8"/>
+<line class="weight-link" x1="1030.0" y1="246.4" x2="1110.0" y2="246.4"/>
+<line class="weight-link" x1="1110.0" y1="246.4" x2="1190.0" y2="246.4"/>
+<line class="weight-link" x1="1190.0" y1="243.6" x2="1270.0" y2="243.6"/>
+<line class="weight-link" x1="1271.4" y1="245.0" x2="1271.4" y2="315.0"/>
+<line class="weight-link" x1="1270.0" y1="315.0" x2="1270.0" y2="385.0"/>
+<line class="weight-link" x1="1271.4" y1="385.0" x2="1271.4" y2="455.0"/>
+<line class="weight-link" x1="1270.0" y1="455.0" x2="1270.0" y2="525.0"/>
+<line class="weight-link" x1="1270.0" y1="525.0" x2="1270.0" y2="595.0"/>
+<line class="weight-link" x1="1270.0" y1="595.0" x2="1270.0" y2="665.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 4 sender 1 to R39: NoC0 X+ then Y+"><title>Bank 4 sender 1 to R39: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="250.6" x2="950.0" y2="250.6"/>
+<line class="weight-link" x1="950.0" y1="250.6" x2="1030.0" y2="250.6"/>
+<line class="weight-link" x1="1030.0" y1="249.2" x2="1110.0" y2="249.2"/>
+<line class="weight-link" x1="1110.0" y1="249.2" x2="1190.0" y2="249.2"/>
+<line class="weight-link" x1="1190.0" y1="246.4" x2="1270.0" y2="246.4"/>
+<line class="weight-link" x1="1270.0" y1="245.0" x2="1350.0" y2="245.0"/>
+<line class="weight-link" x1="1350.0" y1="245.0" x2="1350.0" y2="315.0"/>
+<line class="weight-link" x1="1350.0" y1="315.0" x2="1350.0" y2="385.0"/>
+<line class="weight-link" x1="1350.0" y1="385.0" x2="1350.0" y2="455.0"/>
+<line class="weight-link" x1="1348.6" y1="455.0" x2="1348.6" y2="525.0"/>
+<line class="weight-link" x1="1348.6" y1="525.0" x2="1348.6" y2="595.0"/>
+<line class="weight-link" x1="1348.6" y1="595.0" x2="1348.6" y2="665.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 5 sender 0 to R40: NoC0 X+ then Y+"><title>Bank 5 sender 0 to R40: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="312.2" x2="950.0" y2="312.2"/>
+<line class="weight-link" x1="950.0" y1="312.2" x2="1030.0" y2="312.2"/>
+<line class="weight-link" x1="1030.0" y1="312.2" x2="1110.0" y2="312.2"/>
+<line class="weight-link" x1="1110.0" y1="313.6" x2="1190.0" y2="313.6"/>
+<line class="weight-link" x1="1190.0" y1="313.6" x2="1270.0" y2="313.6" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 5 sender 0 to R41: NoC0 X+ then Y+"><title>Bank 5 sender 0 to R41: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="315.0" x2="950.0" y2="315.0"/>
+<line class="weight-link" x1="950.0" y1="315.0" x2="1030.0" y2="315.0"/>
+<line class="weight-link" x1="1030.0" y1="315.0" x2="1110.0" y2="315.0"/>
+<line class="weight-link" x1="1110.0" y1="316.4" x2="1190.0" y2="316.4"/>
+<line class="weight-link" x1="1190.0" y1="316.4" x2="1270.0" y2="316.4"/>
+<line class="weight-link" x1="1270.0" y1="316.4" x2="1350.0" y2="316.4" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 5 sender 0 to R42: NoC0 X+ then Y+"><title>Bank 5 sender 0 to R42: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="317.8" x2="950.0" y2="317.8"/>
+<line class="weight-link" x1="950.0" y1="317.8" x2="1030.0" y2="317.8"/>
+<line class="weight-link" x1="1030.0" y1="317.8" x2="1110.0" y2="317.8"/>
+<line class="weight-link" x1="1110.0" y1="319.2" x2="1190.0" y2="319.2"/>
+<line class="weight-link" x1="1190.0" y1="319.2" x2="1270.0" y2="319.2"/>
+<line class="weight-link" x1="1270.0" y1="319.2" x2="1350.0" y2="319.2"/>
+<line class="weight-link" x1="1350.0" y1="317.8" x2="1430.0" y2="317.8"/>
+<line class="weight-link" x1="1430.0" y1="317.8" x2="1495.0" y2="317.8"/>
+<line class="weight-link" x1="105.0" y1="317.8" x2="150.0" y2="317.8"/>
+<line class="weight-link" x1="150.0" y1="317.8" x2="230.0" y2="317.8"/>
+<line class="weight-link" x1="230.0" y1="317.8" x2="310.0" y2="317.8"/>
+<line class="weight-link" x1="310.0" y1="316.4" x2="390.0" y2="316.4"/>
+<line class="weight-link" x1="392.8" y1="315.0" x2="392.8" y2="385.0"/>
+<line class="weight-link" x1="392.8" y1="385.0" x2="392.8" y2="455.0"/>
+<line class="weight-link" x1="395.6" y1="455.0" x2="395.6" y2="525.0"/>
+<line class="weight-link" x1="392.8" y1="525.0" x2="392.8" y2="595.0"/>
+<line class="weight-link" x1="391.4" y1="595.0" x2="391.4" y2="665.0"/>
+<line class="weight-link" x1="392.8" y1="665.0" x2="392.8" y2="735.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 5 sender 0 to R43: NoC0 X+ then Y+"><title>Bank 5 sender 0 to R43: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="320.6" x2="950.0" y2="320.6"/>
+<line class="weight-link" x1="950.0" y1="320.6" x2="1030.0" y2="320.6"/>
+<line class="weight-link" x1="1030.0" y1="320.6" x2="1110.0" y2="320.6"/>
+<line class="weight-link" x1="1110.0" y1="322.0" x2="1190.0" y2="322.0"/>
+<line class="weight-link" x1="1190.0" y1="322.0" x2="1270.0" y2="322.0"/>
+<line class="weight-link" x1="1270.0" y1="322.0" x2="1350.0" y2="322.0"/>
+<line class="weight-link" x1="1350.0" y1="320.6" x2="1430.0" y2="320.6"/>
+<line class="weight-link" x1="1430.0" y1="320.6" x2="1495.0" y2="320.6"/>
+<line class="weight-link" x1="105.0" y1="320.6" x2="150.0" y2="320.6"/>
+<line class="weight-link" x1="150.0" y1="320.6" x2="230.0" y2="320.6"/>
+<line class="weight-link" x1="230.0" y1="320.6" x2="310.0" y2="320.6"/>
+<line class="weight-link" x1="310.0" y1="319.2" x2="390.0" y2="319.2"/>
+<line class="weight-link" x1="390.0" y1="316.4" x2="470.0" y2="316.4"/>
+<line class="weight-link" x1="474.2" y1="315.0" x2="474.2" y2="385.0"/>
+<line class="weight-link" x1="472.8" y1="385.0" x2="472.8" y2="455.0"/>
+<line class="weight-link" x1="471.4" y1="455.0" x2="471.4" y2="525.0"/>
+<line class="weight-link" x1="471.4" y1="525.0" x2="471.4" y2="595.0"/>
+<line class="weight-link" x1="471.4" y1="595.0" x2="471.4" y2="665.0"/>
+<line class="weight-link" x1="471.4" y1="665.0" x2="471.4" y2="735.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 5 sender 1 to R44: NoC0 X+ then Y+"><title>Bank 5 sender 1 to R44: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="873.6" x2="950.0" y2="873.6"/>
+<line class="weight-link" x1="950.0" y1="873.6" x2="1030.0" y2="873.6"/>
+<line class="weight-link" x1="1035.6" y1="875.0" x2="1035.6" y2="945.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 5 sender 1 to R45: NoC0 X+ then Y+"><title>Bank 5 sender 1 to R45: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="876.4" x2="950.0" y2="876.4"/>
+<line class="weight-link" x1="950.0" y1="876.4" x2="1030.0" y2="876.4"/>
+<line class="weight-link" x1="1030.0" y1="872.2" x2="1110.0" y2="872.2"/>
+<line class="weight-link" x1="1111.4" y1="875.0" x2="1111.4" y2="945.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 5 sender 1 to R46: NoC0 X+ then Y+"><title>Bank 5 sender 1 to R46: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="879.2" x2="950.0" y2="879.2"/>
+<line class="weight-link" x1="950.0" y1="879.2" x2="1030.0" y2="879.2"/>
+<line class="weight-link" x1="1030.0" y1="875.0" x2="1110.0" y2="875.0"/>
+<line class="weight-link" x1="1114.2" y1="875.0" x2="1114.2" y2="945.0"/>
+<line class="weight-link" x1="1114.2" y1="945.0" x2="1114.2" y2="995.0"/>
+<line class="weight-link" x1="1114.2" y1="135.0" x2="1114.2" y2="175.0"/>
+<line class="weight-link" x1="1119.8" y1="175.0" x2="1119.8" y2="245.0"/>
+<line class="weight-link" x1="1119.8" y1="245.0" x2="1119.8" y2="315.0"/>
+<line class="weight-link" x1="1117.0" y1="315.0" x2="1117.0" y2="385.0"/>
+<line class="weight-link" x1="1115.6" y1="385.0" x2="1115.6" y2="455.0"/>
+<line class="weight-link" x1="1112.8" y1="455.0" x2="1112.8" y2="525.0"/>
+<line class="weight-link" x1="1114.2" y1="525.0" x2="1114.2" y2="595.0"/>
+<line class="weight-link" x1="1114.2" y1="595.0" x2="1114.2" y2="665.0"/>
+<line class="weight-link" x1="1112.8" y1="665.0" x2="1112.8" y2="735.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 5 sender 1 to R47: NoC0 X+ then Y+"><title>Bank 5 sender 1 to R47: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="882.0" x2="950.0" y2="882.0"/>
+<line class="weight-link" x1="950.0" y1="882.0" x2="1030.0" y2="882.0"/>
+<line class="weight-link" x1="1030.0" y1="877.8" x2="1110.0" y2="877.8"/>
+<line class="weight-link" x1="1110.0" y1="876.4" x2="1190.0" y2="876.4"/>
+<line class="weight-link" x1="1191.4" y1="875.0" x2="1191.4" y2="945.0"/>
+<line class="weight-link" x1="1191.4" y1="945.0" x2="1191.4" y2="995.0"/>
+<line class="weight-link" x1="1191.4" y1="135.0" x2="1191.4" y2="175.0"/>
+<line class="weight-link" x1="1192.8" y1="175.0" x2="1192.8" y2="245.0"/>
+<line class="weight-link" x1="1195.6" y1="245.0" x2="1195.6" y2="315.0"/>
+<line class="weight-link" x1="1194.2" y1="315.0" x2="1194.2" y2="385.0"/>
+<line class="weight-link" x1="1191.4" y1="385.0" x2="1191.4" y2="455.0"/>
+<line class="weight-link" x1="1192.8" y1="455.0" x2="1192.8" y2="525.0"/>
+<line class="weight-link" x1="1192.8" y1="525.0" x2="1192.8" y2="595.0"/>
+<line class="weight-link" x1="1192.8" y1="595.0" x2="1192.8" y2="665.0"/>
+<line class="weight-link" x1="1190.0" y1="665.0" x2="1190.0" y2="735.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 6 sender 0 to R48: NoC0 X+ then Y+"><title>Bank 6 sender 0 to R48: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="803.6" x2="950.0" y2="803.6"/>
+<line class="weight-link" x1="950.0" y1="803.6" x2="1030.0" y2="803.6"/>
+<line class="weight-link" x1="1030.0" y1="803.6" x2="1110.0" y2="803.6"/>
+<line class="weight-link" x1="1110.0" y1="805.0" x2="1190.0" y2="805.0"/>
+<line class="weight-link" x1="1190.0" y1="806.4" x2="1270.0" y2="806.4"/>
+<line class="weight-link" x1="1270.0" y1="806.4" x2="1350.0" y2="806.4"/>
+<line class="weight-link" x1="1350.0" y1="806.4" x2="1430.0" y2="806.4"/>
+<line class="weight-link" x1="1430.0" y1="806.4" x2="1495.0" y2="806.4"/>
+<line class="weight-link" x1="105.0" y1="806.4" x2="150.0" y2="806.4"/>
+<line class="weight-link" x1="150.0" y1="806.4" x2="230.0" y2="806.4" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 6 sender 0 to R49: NoC0 X+ then Y+"><title>Bank 6 sender 0 to R49: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="806.4" x2="950.0" y2="806.4"/>
+<line class="weight-link" x1="950.0" y1="806.4" x2="1030.0" y2="806.4" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 6 sender 0 to R50: NoC0 X+ then Y+"><title>Bank 6 sender 0 to R50: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="809.2" x2="950.0" y2="809.2"/>
+<line class="weight-link" x1="950.0" y1="809.2" x2="1030.0" y2="809.2"/>
+<line class="weight-link" x1="1030.0" y1="806.4" x2="1110.0" y2="806.4" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 6 sender 0 to R51: NoC0 X+ then Y+"><title>Bank 6 sender 0 to R51: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="812.0" x2="950.0" y2="812.0"/>
+<line class="weight-link" x1="950.0" y1="812.0" x2="1030.0" y2="812.0"/>
+<line class="weight-link" x1="1030.0" y1="809.2" x2="1110.0" y2="809.2"/>
+<line class="weight-link" x1="1110.0" y1="807.8" x2="1190.0" y2="807.8" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 6 sender 1 to R52: NoC0 X+ then Y+"><title>Bank 6 sender 1 to R52: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="452.2" x2="950.0" y2="452.2"/>
+<line class="weight-link" x1="950.0" y1="452.2" x2="1030.0" y2="452.2"/>
+<line class="weight-link" x1="1030.0" y1="455.0" x2="1110.0" y2="455.0"/>
+<line class="weight-link" x1="1110.0" y1="456.4" x2="1190.0" y2="456.4"/>
+<line class="weight-link" x1="1190.0" y1="455.0" x2="1270.0" y2="455.0"/>
+<line class="weight-link" x1="1272.8" y1="455.0" x2="1272.8" y2="525.0"/>
+<line class="weight-link" x1="1272.8" y1="525.0" x2="1272.8" y2="595.0"/>
+<line class="weight-link" x1="1272.8" y1="595.0" x2="1272.8" y2="665.0"/>
+<line class="weight-link" x1="1271.4" y1="665.0" x2="1271.4" y2="735.0"/>
+<line class="weight-link" x1="1271.4" y1="735.0" x2="1271.4" y2="805.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 6 sender 1 to R53: NoC0 X+ then Y+"><title>Bank 6 sender 1 to R53: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="455.0" x2="950.0" y2="455.0"/>
+<line class="weight-link" x1="950.0" y1="455.0" x2="1030.0" y2="455.0"/>
+<line class="weight-link" x1="1030.0" y1="457.8" x2="1110.0" y2="457.8"/>
+<line class="weight-link" x1="1110.0" y1="459.2" x2="1190.0" y2="459.2"/>
+<line class="weight-link" x1="1190.0" y1="457.8" x2="1270.0" y2="457.8"/>
+<line class="weight-link" x1="1270.0" y1="456.4" x2="1350.0" y2="456.4"/>
+<line class="weight-link" x1="1351.4" y1="455.0" x2="1351.4" y2="525.0"/>
+<line class="weight-link" x1="1351.4" y1="525.0" x2="1351.4" y2="595.0"/>
+<line class="weight-link" x1="1351.4" y1="595.0" x2="1351.4" y2="665.0"/>
+<line class="weight-link" x1="1350.0" y1="665.0" x2="1350.0" y2="735.0"/>
+<line class="weight-link" x1="1350.0" y1="735.0" x2="1350.0" y2="805.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 6 sender 1 to R54: NoC0 X+ then Y+"><title>Bank 6 sender 1 to R54: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="457.8" x2="950.0" y2="457.8"/>
+<line class="weight-link" x1="950.0" y1="457.8" x2="1030.0" y2="457.8" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 6 sender 1 to R55: NoC0 X+ then Y+"><title>Bank 6 sender 1 to R55: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="460.6" x2="950.0" y2="460.6"/>
+<line class="weight-link" x1="950.0" y1="460.6" x2="1030.0" y2="460.6"/>
+<line class="weight-link" x1="1030.0" y1="460.6" x2="1110.0" y2="460.6"/>
+<line class="weight-link" x1="1115.6" y1="455.0" x2="1115.6" y2="525.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 7 sender 0 to R56: NoC0 X+ then Y+"><title>Bank 7 sender 0 to R56: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="522.2" x2="950.0" y2="522.2"/>
+<line class="weight-link" x1="950.0" y1="522.2" x2="1030.0" y2="522.2"/>
+<line class="weight-link" x1="1030.0" y1="526.4" x2="1110.0" y2="526.4"/>
+<line class="weight-link" x1="1110.0" y1="526.4" x2="1190.0" y2="526.4"/>
+<line class="weight-link" x1="1190.0" y1="526.4" x2="1270.0" y2="526.4"/>
+<line class="weight-link" x1="1270.0" y1="526.4" x2="1350.0" y2="526.4"/>
+<line class="weight-link" x1="1350.0" y1="526.4" x2="1430.0" y2="526.4"/>
+<line class="weight-link" x1="1430.0" y1="526.4" x2="1495.0" y2="526.4"/>
+<line class="weight-link" x1="105.0" y1="526.4" x2="150.0" y2="526.4"/>
+<line class="weight-link" x1="150.0" y1="526.4" x2="230.0" y2="526.4"/>
+<line class="weight-link" x1="234.2" y1="525.0" x2="234.2" y2="595.0"/>
+<line class="weight-link" x1="234.2" y1="595.0" x2="234.2" y2="665.0"/>
+<line class="weight-link" x1="232.8" y1="665.0" x2="232.8" y2="735.0"/>
+<line class="weight-link" x1="234.2" y1="735.0" x2="234.2" y2="805.0"/>
+<line class="weight-link" x1="232.8" y1="805.0" x2="232.8" y2="875.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 7 sender 0 to R57: NoC0 X+ then Y+"><title>Bank 7 sender 0 to R57: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="525.0" x2="950.0" y2="525.0"/>
+<line class="weight-link" x1="950.0" y1="525.0" x2="1030.0" y2="525.0"/>
+<line class="weight-link" x1="1030.0" y1="525.0" x2="1030.0" y2="595.0"/>
+<line class="weight-link" x1="1031.4" y1="595.0" x2="1031.4" y2="665.0"/>
+<line class="weight-link" x1="1030.0" y1="665.0" x2="1030.0" y2="735.0"/>
+<line class="weight-link" x1="1031.4" y1="735.0" x2="1031.4" y2="805.0"/>
+<line class="weight-link" x1="1032.8" y1="805.0" x2="1032.8" y2="875.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 7 sender 0 to R58: NoC0 X+ then Y+"><title>Bank 7 sender 0 to R58: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="527.8" x2="950.0" y2="527.8"/>
+<line class="weight-link" x1="950.0" y1="527.8" x2="1030.0" y2="527.8" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 7 sender 0 to R59: NoC0 X+ then Y+"><title>Bank 7 sender 0 to R59: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="530.6" x2="950.0" y2="530.6"/>
+<line class="weight-link" x1="950.0" y1="530.6" x2="1030.0" y2="530.6"/>
+<line class="weight-link" x1="1032.8" y1="525.0" x2="1032.8" y2="595.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 7 sender 1 to R60: NoC0 X+ then Y+"><title>Bank 7 sender 1 to R60: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="663.6" x2="950.0" y2="663.6"/>
+<line class="weight-link" x1="950.0" y1="663.6" x2="1030.0" y2="663.6" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 7 sender 1 to R61: NoC0 X+ then Y+"><title>Bank 7 sender 1 to R61: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="666.4" x2="950.0" y2="666.4"/>
+<line class="weight-link" x1="950.0" y1="666.4" x2="1030.0" y2="666.4"/>
+<line class="weight-link" x1="1032.8" y1="665.0" x2="1032.8" y2="735.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 7 sender 1 to R62: NoC0 X+ then Y+"><title>Bank 7 sender 1 to R62: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="669.2" x2="950.0" y2="669.2"/>
+<line class="weight-link" x1="950.0" y1="669.2" x2="1030.0" y2="669.2"/>
+<line class="weight-link" x1="1030.0" y1="666.4" x2="1110.0" y2="666.4"/>
+<line class="weight-link" x1="1115.6" y1="665.0" x2="1115.6" y2="735.0"/>
+<line class="weight-link" x1="1114.2" y1="735.0" x2="1114.2" y2="805.0"/>
+<line class="weight-link" x1="1114.2" y1="805.0" x2="1114.2" y2="875.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="Bank 7 sender 1 to R63: NoC0 X+ then Y+"><title>Bank 7 sender 1 to R63: NoC0 X+ then Y+</title>
+<line class="weight-link" x1="870.0" y1="672.0" x2="950.0" y2="672.0"/>
+<line class="weight-link" x1="950.0" y1="672.0" x2="1030.0" y2="672.0"/>
+<line class="weight-link" x1="1030.0" y1="669.2" x2="1110.0" y2="669.2"/>
+<line class="weight-link" x1="1110.0" y1="666.4" x2="1190.0" y2="666.4"/>
+<line class="weight-link" x1="1192.8" y1="665.0" x2="1192.8" y2="735.0"/>
+<line class="weight-link" x1="1191.4" y1="735.0" x2="1191.4" y2="805.0"/>
+<line class="weight-link" x1="1191.4" y1="805.0" x2="1191.4" y2="875.0" marker-end="url(#arrow-pink)"/>
+</g>
+<g aria-label="R0 to R63: NoC1 Y- then X-"><title>R0 to R63: NoC1 Y- then X-</title>
+<line class="ring-link" x1="225.8" y1="315.0" x2="225.8" y2="245.0"/>
+<line class="ring-link" x1="225.8" y1="245.0" x2="225.8" y2="175.0"/>
+<line class="ring-link" x1="227.2" y1="175.0" x2="227.2" y2="135.0"/>
+<line class="ring-link" x1="227.2" y1="995.0" x2="227.2" y2="945.0"/>
+<line class="ring-link" x1="228.6" y1="945.0" x2="228.6" y2="875.0"/>
+<line class="ring-link" x1="230.0" y1="869.4" x2="150.0" y2="869.4"/>
+<line class="ring-link" x1="150.0" y1="875.0" x2="105.0" y2="875.0"/>
+<line class="ring-link" x1="1495.0" y1="875.0" x2="1430.0" y2="875.0"/>
+<line class="ring-link" x1="1430.0" y1="875.0" x2="1350.0" y2="875.0"/>
+<line class="ring-link" x1="1350.0" y1="875.0" x2="1270.0" y2="875.0"/>
+<line class="ring-link" x1="1270.0" y1="875.0" x2="1190.0" y2="875.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R1 to R0: NoC1 Y- then X-"><title>R1 to R0: NoC1 Y- then X-</title>
+<line class="ring-link" x1="310.0" y1="309.4" x2="230.0" y2="309.4" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R2 to R1: NoC1 Y- then X-"><title>R2 to R1: NoC1 Y- then X-</title>
+<line class="ring-link" x1="307.2" y1="525.0" x2="307.2" y2="455.0"/>
+<line class="ring-link" x1="304.4" y1="455.0" x2="304.4" y2="385.0"/>
+<line class="ring-link" x1="305.8" y1="385.0" x2="305.8" y2="315.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R3 to R2: NoC1 Y- then X-"><title>R3 to R2: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1100.2" y1="315.0" x2="1100.2" y2="245.0"/>
+<line class="ring-link" x1="1100.2" y1="245.0" x2="1100.2" y2="175.0"/>
+<line class="ring-link" x1="1105.8" y1="175.0" x2="1105.8" y2="135.0"/>
+<line class="ring-link" x1="1105.8" y1="995.0" x2="1105.8" y2="945.0"/>
+<line class="ring-link" x1="1105.8" y1="945.0" x2="1105.8" y2="875.0"/>
+<line class="ring-link" x1="1105.8" y1="875.0" x2="1105.8" y2="805.0"/>
+<line class="ring-link" x1="1105.8" y1="805.0" x2="1105.8" y2="735.0"/>
+<line class="ring-link" x1="1104.4" y1="735.0" x2="1104.4" y2="665.0"/>
+<line class="ring-link" x1="1105.8" y1="665.0" x2="1105.8" y2="595.0"/>
+<line class="ring-link" x1="1105.8" y1="595.0" x2="1105.8" y2="525.0"/>
+<line class="ring-link" x1="1110.0" y1="523.6" x2="1030.0" y2="523.6"/>
+<line class="ring-link" x1="1030.0" y1="519.4" x2="950.0" y2="519.4"/>
+<line class="ring-link" x1="950.0" y1="519.4" x2="870.0" y2="519.4"/>
+<line class="ring-link" x1="870.0" y1="525.0" x2="790.0" y2="525.0"/>
+<line class="ring-link" x1="790.0" y1="525.0" x2="710.0" y2="525.0"/>
+<line class="ring-link" x1="710.0" y1="525.0" x2="630.0" y2="525.0"/>
+<line class="ring-link" x1="630.0" y1="525.0" x2="550.0" y2="525.0"/>
+<line class="ring-link" x1="550.0" y1="523.6" x2="470.0" y2="523.6"/>
+<line class="ring-link" x1="470.0" y1="523.6" x2="390.0" y2="523.6"/>
+<line class="ring-link" x1="390.0" y1="525.0" x2="310.0" y2="525.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R4 to R3: NoC1 Y- then X-"><title>R4 to R3: NoC1 Y- then X-</title>
+<line class="ring-link" x1="390.0" y1="310.8" x2="310.0" y2="310.8"/>
+<line class="ring-link" x1="310.0" y1="312.2" x2="230.0" y2="312.2"/>
+<line class="ring-link" x1="230.0" y1="309.4" x2="150.0" y2="309.4"/>
+<line class="ring-link" x1="150.0" y1="309.4" x2="105.0" y2="309.4"/>
+<line class="ring-link" x1="1495.0" y1="309.4" x2="1430.0" y2="309.4"/>
+<line class="ring-link" x1="1430.0" y1="309.4" x2="1350.0" y2="309.4"/>
+<line class="ring-link" x1="1350.0" y1="308.0" x2="1270.0" y2="308.0"/>
+<line class="ring-link" x1="1270.0" y1="308.0" x2="1190.0" y2="308.0"/>
+<line class="ring-link" x1="1190.0" y1="308.0" x2="1110.0" y2="308.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R5 to R4: NoC1 Y- then X-"><title>R5 to R4: NoC1 Y- then X-</title>
+<line class="ring-link" x1="467.2" y1="455.0" x2="467.2" y2="385.0"/>
+<line class="ring-link" x1="465.8" y1="385.0" x2="465.8" y2="315.0"/>
+<line class="ring-link" x1="470.0" y1="313.6" x2="390.0" y2="313.6" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R6 to R5: NoC1 Y- then X-"><title>R6 to R5: NoC1 Y- then X-</title>
+<line class="ring-link" x1="465.8" y1="315.0" x2="465.8" y2="245.0"/>
+<line class="ring-link" x1="468.6" y1="245.0" x2="468.6" y2="175.0"/>
+<line class="ring-link" x1="468.6" y1="175.0" x2="468.6" y2="135.0"/>
+<line class="ring-link" x1="468.6" y1="995.0" x2="468.6" y2="945.0"/>
+<line class="ring-link" x1="468.6" y1="945.0" x2="468.6" y2="875.0"/>
+<line class="ring-link" x1="470.0" y1="875.0" x2="470.0" y2="805.0"/>
+<line class="ring-link" x1="470.0" y1="805.0" x2="470.0" y2="735.0"/>
+<line class="ring-link" x1="468.6" y1="735.0" x2="468.6" y2="665.0"/>
+<line class="ring-link" x1="468.6" y1="665.0" x2="468.6" y2="595.0"/>
+<line class="ring-link" x1="468.6" y1="595.0" x2="468.6" y2="525.0"/>
+<line class="ring-link" x1="468.6" y1="525.0" x2="468.6" y2="455.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R7 to R6: NoC1 Y- then X-"><title>R7 to R6: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1030.0" y1="309.4" x2="950.0" y2="309.4"/>
+<line class="ring-link" x1="950.0" y1="309.4" x2="870.0" y2="309.4"/>
+<line class="ring-link" x1="870.0" y1="315.0" x2="790.0" y2="315.0"/>
+<line class="ring-link" x1="790.0" y1="315.0" x2="710.0" y2="315.0"/>
+<line class="ring-link" x1="710.0" y1="315.0" x2="630.0" y2="315.0"/>
+<line class="ring-link" x1="630.0" y1="315.0" x2="550.0" y2="315.0"/>
+<line class="ring-link" x1="550.0" y1="315.0" x2="470.0" y2="315.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R8 to R7: NoC1 Y- then X-"><title>R8 to R7: NoC1 Y- then X-</title>
+<line class="ring-link" x1="227.2" y1="385.0" x2="227.2" y2="315.0"/>
+<line class="ring-link" x1="230.0" y1="312.2" x2="150.0" y2="312.2"/>
+<line class="ring-link" x1="150.0" y1="312.2" x2="105.0" y2="312.2"/>
+<line class="ring-link" x1="1495.0" y1="312.2" x2="1430.0" y2="312.2"/>
+<line class="ring-link" x1="1430.0" y1="312.2" x2="1350.0" y2="312.2"/>
+<line class="ring-link" x1="1350.0" y1="310.8" x2="1270.0" y2="310.8"/>
+<line class="ring-link" x1="1270.0" y1="310.8" x2="1190.0" y2="310.8"/>
+<line class="ring-link" x1="1190.0" y1="310.8" x2="1110.0" y2="310.8"/>
+<line class="ring-link" x1="1110.0" y1="309.4" x2="1030.0" y2="309.4" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R9 to R8: NoC1 Y- then X-"><title>R9 to R8: NoC1 Y- then X-</title>
+<line class="ring-link" x1="390.0" y1="380.8" x2="310.0" y2="380.8"/>
+<line class="ring-link" x1="310.0" y1="378.0" x2="230.0" y2="378.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R10 to R9: NoC1 Y- then X-"><title>R10 to R9: NoC1 Y- then X-</title>
+<line class="ring-link" x1="550.0" y1="382.2" x2="470.0" y2="382.2"/>
+<line class="ring-link" x1="470.0" y1="382.2" x2="390.0" y2="382.2" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R11 to R10: NoC1 Y- then X-"><title>R11 to R10: NoC1 Y- then X-</title>
+<line class="ring-link" x1="310.0" y1="380.8" x2="230.0" y2="380.8"/>
+<line class="ring-link" x1="230.0" y1="378.0" x2="150.0" y2="378.0"/>
+<line class="ring-link" x1="150.0" y1="383.6" x2="105.0" y2="383.6"/>
+<line class="ring-link" x1="1495.0" y1="383.6" x2="1430.0" y2="383.6"/>
+<line class="ring-link" x1="1430.0" y1="383.6" x2="1350.0" y2="383.6"/>
+<line class="ring-link" x1="1350.0" y1="383.6" x2="1270.0" y2="383.6"/>
+<line class="ring-link" x1="1270.0" y1="382.2" x2="1190.0" y2="382.2"/>
+<line class="ring-link" x1="1190.0" y1="383.6" x2="1110.0" y2="383.6"/>
+<line class="ring-link" x1="1110.0" y1="383.6" x2="1030.0" y2="383.6"/>
+<line class="ring-link" x1="1030.0" y1="383.6" x2="950.0" y2="383.6"/>
+<line class="ring-link" x1="950.0" y1="383.6" x2="870.0" y2="383.6"/>
+<line class="ring-link" x1="870.0" y1="383.6" x2="790.0" y2="383.6"/>
+<line class="ring-link" x1="790.0" y1="383.6" x2="710.0" y2="383.6"/>
+<line class="ring-link" x1="710.0" y1="383.6" x2="630.0" y2="383.6"/>
+<line class="ring-link" x1="630.0" y1="383.6" x2="550.0" y2="383.6" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R12 to R11: NoC1 Y- then X-"><title>R12 to R11: NoC1 Y- then X-</title>
+<line class="ring-link" x1="470.0" y1="385.0" x2="390.0" y2="385.0"/>
+<line class="ring-link" x1="390.0" y1="383.6" x2="310.0" y2="383.6" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R13 to R12: NoC1 Y- then X-"><title>R13 to R12: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1030.0" y1="386.4" x2="950.0" y2="386.4"/>
+<line class="ring-link" x1="950.0" y1="386.4" x2="870.0" y2="386.4"/>
+<line class="ring-link" x1="870.0" y1="386.4" x2="790.0" y2="386.4"/>
+<line class="ring-link" x1="790.0" y1="386.4" x2="710.0" y2="386.4"/>
+<line class="ring-link" x1="710.0" y1="386.4" x2="630.0" y2="386.4"/>
+<line class="ring-link" x1="630.0" y1="386.4" x2="550.0" y2="386.4"/>
+<line class="ring-link" x1="550.0" y1="385.0" x2="470.0" y2="385.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R14 to R13: NoC1 Y- then X-"><title>R14 to R13: NoC1 Y- then X-</title>
+<line class="ring-link" x1="307.2" y1="875.0" x2="307.2" y2="805.0"/>
+<line class="ring-link" x1="307.2" y1="805.0" x2="307.2" y2="735.0"/>
+<line class="ring-link" x1="310.0" y1="735.0" x2="310.0" y2="665.0"/>
+<line class="ring-link" x1="307.2" y1="665.0" x2="307.2" y2="595.0"/>
+<line class="ring-link" x1="310.0" y1="595.0" x2="310.0" y2="525.0"/>
+<line class="ring-link" x1="310.0" y1="525.0" x2="310.0" y2="455.0"/>
+<line class="ring-link" x1="307.2" y1="455.0" x2="307.2" y2="385.0"/>
+<line class="ring-link" x1="310.0" y1="383.6" x2="230.0" y2="383.6"/>
+<line class="ring-link" x1="230.0" y1="380.8" x2="150.0" y2="380.8"/>
+<line class="ring-link" x1="150.0" y1="386.4" x2="105.0" y2="386.4"/>
+<line class="ring-link" x1="1495.0" y1="386.4" x2="1430.0" y2="386.4"/>
+<line class="ring-link" x1="1430.0" y1="386.4" x2="1350.0" y2="386.4"/>
+<line class="ring-link" x1="1350.0" y1="386.4" x2="1270.0" y2="386.4"/>
+<line class="ring-link" x1="1270.0" y1="385.0" x2="1190.0" y2="385.0"/>
+<line class="ring-link" x1="1190.0" y1="386.4" x2="1110.0" y2="386.4"/>
+<line class="ring-link" x1="1110.0" y1="386.4" x2="1030.0" y2="386.4" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R15 to R14: NoC1 Y- then X-"><title>R15 to R14: NoC1 Y- then X-</title>
+<line class="ring-link" x1="387.2" y1="945.0" x2="387.2" y2="875.0"/>
+<line class="ring-link" x1="390.0" y1="869.4" x2="310.0" y2="869.4" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R16 to R15: NoC1 Y- then X-"><title>R16 to R15: NoC1 Y- then X-</title>
+<line class="ring-link" x1="228.6" y1="455.0" x2="228.6" y2="385.0"/>
+<line class="ring-link" x1="230.0" y1="385.0" x2="230.0" y2="315.0"/>
+<line class="ring-link" x1="228.6" y1="315.0" x2="228.6" y2="245.0"/>
+<line class="ring-link" x1="228.6" y1="245.0" x2="228.6" y2="175.0"/>
+<line class="ring-link" x1="230.0" y1="175.0" x2="230.0" y2="135.0"/>
+<line class="ring-link" x1="230.0" y1="995.0" x2="230.0" y2="945.0"/>
+<line class="ring-link" x1="230.0" y1="945.0" x2="150.0" y2="945.0"/>
+<line class="ring-link" x1="150.0" y1="945.0" x2="105.0" y2="945.0"/>
+<line class="ring-link" x1="1495.0" y1="945.0" x2="1430.0" y2="945.0"/>
+<line class="ring-link" x1="1430.0" y1="945.0" x2="1350.0" y2="945.0"/>
+<line class="ring-link" x1="1350.0" y1="945.0" x2="1270.0" y2="945.0"/>
+<line class="ring-link" x1="1270.0" y1="945.0" x2="1190.0" y2="945.0"/>
+<line class="ring-link" x1="1190.0" y1="945.0" x2="1110.0" y2="945.0"/>
+<line class="ring-link" x1="1110.0" y1="943.6" x2="1030.0" y2="943.6"/>
+<line class="ring-link" x1="1030.0" y1="945.0" x2="950.0" y2="945.0"/>
+<line class="ring-link" x1="950.0" y1="945.0" x2="870.0" y2="945.0"/>
+<line class="ring-link" x1="870.0" y1="945.0" x2="790.0" y2="945.0"/>
+<line class="ring-link" x1="790.0" y1="945.0" x2="710.0" y2="945.0"/>
+<line class="ring-link" x1="710.0" y1="945.0" x2="630.0" y2="945.0"/>
+<line class="ring-link" x1="630.0" y1="945.0" x2="550.0" y2="945.0"/>
+<line class="ring-link" x1="550.0" y1="945.0" x2="470.0" y2="945.0"/>
+<line class="ring-link" x1="470.0" y1="945.0" x2="390.0" y2="945.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R17 to R16: NoC1 Y- then X-"><title>R17 to R16: NoC1 Y- then X-</title>
+<line class="ring-link" x1="227.2" y1="735.0" x2="227.2" y2="665.0"/>
+<line class="ring-link" x1="225.8" y1="665.0" x2="225.8" y2="595.0"/>
+<line class="ring-link" x1="225.8" y1="595.0" x2="225.8" y2="525.0"/>
+<line class="ring-link" x1="227.2" y1="525.0" x2="227.2" y2="455.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R18 to R17: NoC1 Y- then X-"><title>R18 to R17: NoC1 Y- then X-</title>
+<line class="ring-link" x1="310.0" y1="732.2" x2="230.0" y2="732.2" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R19 to R18: NoC1 Y- then X-"><title>R19 to R18: NoC1 Y- then X-</title>
+<line class="ring-link" x1="310.0" y1="455.0" x2="310.0" y2="385.0"/>
+<line class="ring-link" x1="308.6" y1="385.0" x2="308.6" y2="315.0"/>
+<line class="ring-link" x1="305.8" y1="315.0" x2="305.8" y2="245.0"/>
+<line class="ring-link" x1="305.8" y1="245.0" x2="305.8" y2="175.0"/>
+<line class="ring-link" x1="308.6" y1="175.0" x2="308.6" y2="135.0"/>
+<line class="ring-link" x1="308.6" y1="995.0" x2="308.6" y2="945.0"/>
+<line class="ring-link" x1="308.6" y1="945.0" x2="308.6" y2="875.0"/>
+<line class="ring-link" x1="310.0" y1="875.0" x2="310.0" y2="805.0"/>
+<line class="ring-link" x1="310.0" y1="805.0" x2="310.0" y2="735.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R20 to R19: NoC1 Y- then X-"><title>R20 to R19: NoC1 Y- then X-</title>
+<line class="ring-link" x1="390.0" y1="450.8" x2="310.0" y2="450.8" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R21 to R20: NoC1 Y- then X-"><title>R21 to R20: NoC1 Y- then X-</title>
+<line class="ring-link" x1="384.4" y1="525.0" x2="384.4" y2="455.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R22 to R21: NoC1 Y- then X-"><title>R22 to R21: NoC1 Y- then X-</title>
+<line class="ring-link" x1="548.6" y1="455.0" x2="548.6" y2="385.0"/>
+<line class="ring-link" x1="548.6" y1="385.0" x2="548.6" y2="315.0"/>
+<line class="ring-link" x1="548.6" y1="315.0" x2="548.6" y2="245.0"/>
+<line class="ring-link" x1="548.6" y1="245.0" x2="548.6" y2="175.0"/>
+<line class="ring-link" x1="548.6" y1="175.0" x2="548.6" y2="135.0"/>
+<line class="ring-link" x1="548.6" y1="995.0" x2="548.6" y2="945.0"/>
+<line class="ring-link" x1="548.6" y1="945.0" x2="548.6" y2="875.0"/>
+<line class="ring-link" x1="548.6" y1="875.0" x2="548.6" y2="805.0"/>
+<line class="ring-link" x1="548.6" y1="805.0" x2="548.6" y2="735.0"/>
+<line class="ring-link" x1="548.6" y1="735.0" x2="548.6" y2="665.0"/>
+<line class="ring-link" x1="550.0" y1="665.0" x2="550.0" y2="595.0"/>
+<line class="ring-link" x1="548.6" y1="595.0" x2="548.6" y2="525.0"/>
+<line class="ring-link" x1="550.0" y1="526.4" x2="470.0" y2="526.4"/>
+<line class="ring-link" x1="470.0" y1="526.4" x2="390.0" y2="526.4" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R23 to R22: NoC1 Y- then X-"><title>R23 to R22: NoC1 Y- then X-</title>
+<line class="ring-link" x1="230.0" y1="525.0" x2="230.0" y2="455.0"/>
+<line class="ring-link" x1="230.0" y1="449.4" x2="150.0" y2="449.4"/>
+<line class="ring-link" x1="150.0" y1="455.0" x2="105.0" y2="455.0"/>
+<line class="ring-link" x1="1495.0" y1="455.0" x2="1430.0" y2="455.0"/>
+<line class="ring-link" x1="1430.0" y1="455.0" x2="1350.0" y2="455.0"/>
+<line class="ring-link" x1="1350.0" y1="453.6" x2="1270.0" y2="453.6"/>
+<line class="ring-link" x1="1270.0" y1="452.2" x2="1190.0" y2="452.2"/>
+<line class="ring-link" x1="1190.0" y1="450.8" x2="1110.0" y2="450.8"/>
+<line class="ring-link" x1="1110.0" y1="449.4" x2="1030.0" y2="449.4"/>
+<line class="ring-link" x1="1030.0" y1="449.4" x2="950.0" y2="449.4"/>
+<line class="ring-link" x1="950.0" y1="449.4" x2="870.0" y2="449.4"/>
+<line class="ring-link" x1="870.0" y1="455.0" x2="790.0" y2="455.0"/>
+<line class="ring-link" x1="790.0" y1="455.0" x2="710.0" y2="455.0"/>
+<line class="ring-link" x1="710.0" y1="455.0" x2="630.0" y2="455.0"/>
+<line class="ring-link" x1="630.0" y1="455.0" x2="550.0" y2="455.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R24 to R23: NoC1 Y- then X-"><title>R24 to R23: NoC1 Y- then X-</title>
+<line class="ring-link" x1="228.6" y1="595.0" x2="228.6" y2="525.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R25 to R24: NoC1 Y- then X-"><title>R25 to R24: NoC1 Y- then X-</title>
+<line class="ring-link" x1="310.0" y1="590.8" x2="230.0" y2="590.8" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R26 to R25: NoC1 Y- then X-"><title>R26 to R25: NoC1 Y- then X-</title>
+<line class="ring-link" x1="310.0" y1="665.0" x2="310.0" y2="595.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R27 to R26: NoC1 Y- then X-"><title>R27 to R26: NoC1 Y- then X-</title>
+<line class="ring-link" x1="387.2" y1="595.0" x2="387.2" y2="525.0"/>
+<line class="ring-link" x1="387.2" y1="525.0" x2="387.2" y2="455.0"/>
+<line class="ring-link" x1="387.2" y1="455.0" x2="387.2" y2="385.0"/>
+<line class="ring-link" x1="387.2" y1="385.0" x2="387.2" y2="315.0"/>
+<line class="ring-link" x1="388.6" y1="315.0" x2="388.6" y2="245.0"/>
+<line class="ring-link" x1="390.0" y1="245.0" x2="390.0" y2="175.0"/>
+<line class="ring-link" x1="390.0" y1="175.0" x2="390.0" y2="135.0"/>
+<line class="ring-link" x1="390.0" y1="995.0" x2="390.0" y2="945.0"/>
+<line class="ring-link" x1="390.0" y1="945.0" x2="390.0" y2="875.0"/>
+<line class="ring-link" x1="390.0" y1="875.0" x2="390.0" y2="805.0"/>
+<line class="ring-link" x1="390.0" y1="805.0" x2="390.0" y2="735.0"/>
+<line class="ring-link" x1="387.2" y1="735.0" x2="387.2" y2="665.0"/>
+<line class="ring-link" x1="390.0" y1="658.0" x2="310.0" y2="658.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R28 to R27: NoC1 Y- then X-"><title>R28 to R27: NoC1 Y- then X-</title>
+<line class="ring-link" x1="550.0" y1="595.0" x2="470.0" y2="595.0"/>
+<line class="ring-link" x1="470.0" y1="595.0" x2="390.0" y2="595.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R29 to R28: NoC1 Y- then X-"><title>R29 to R28: NoC1 Y- then X-</title>
+<line class="ring-link" x1="630.0" y1="595.0" x2="550.0" y2="595.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R30 to R29: NoC1 Y- then X-"><title>R30 to R29: NoC1 Y- then X-</title>
+<line class="ring-link" x1="228.6" y1="665.0" x2="228.6" y2="595.0"/>
+<line class="ring-link" x1="230.0" y1="589.4" x2="150.0" y2="589.4"/>
+<line class="ring-link" x1="150.0" y1="595.0" x2="105.0" y2="595.0"/>
+<line class="ring-link" x1="1495.0" y1="595.0" x2="1430.0" y2="595.0"/>
+<line class="ring-link" x1="1430.0" y1="595.0" x2="1350.0" y2="595.0"/>
+<line class="ring-link" x1="1350.0" y1="595.0" x2="1270.0" y2="595.0"/>
+<line class="ring-link" x1="1270.0" y1="595.0" x2="1190.0" y2="595.0"/>
+<line class="ring-link" x1="1190.0" y1="595.0" x2="1110.0" y2="595.0"/>
+<line class="ring-link" x1="1110.0" y1="595.0" x2="1030.0" y2="595.0"/>
+<line class="ring-link" x1="1030.0" y1="595.0" x2="950.0" y2="595.0"/>
+<line class="ring-link" x1="950.0" y1="595.0" x2="870.0" y2="595.0"/>
+<line class="ring-link" x1="870.0" y1="595.0" x2="790.0" y2="595.0"/>
+<line class="ring-link" x1="790.0" y1="595.0" x2="710.0" y2="595.0"/>
+<line class="ring-link" x1="710.0" y1="595.0" x2="630.0" y2="595.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R31 to R30: NoC1 Y- then X-"><title>R31 to R30: NoC1 Y- then X-</title>
+<line class="ring-link" x1="390.0" y1="660.8" x2="310.0" y2="660.8"/>
+<line class="ring-link" x1="310.0" y1="659.4" x2="230.0" y2="659.4" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R32 to R31: NoC1 Y- then X-"><title>R32 to R31: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1110.0" y1="660.8" x2="1030.0" y2="660.8"/>
+<line class="ring-link" x1="1030.0" y1="658.0" x2="950.0" y2="658.0"/>
+<line class="ring-link" x1="950.0" y1="658.0" x2="870.0" y2="658.0"/>
+<line class="ring-link" x1="870.0" y1="663.6" x2="790.0" y2="663.6"/>
+<line class="ring-link" x1="790.0" y1="663.6" x2="710.0" y2="663.6"/>
+<line class="ring-link" x1="710.0" y1="663.6" x2="630.0" y2="663.6"/>
+<line class="ring-link" x1="630.0" y1="662.2" x2="550.0" y2="662.2"/>
+<line class="ring-link" x1="550.0" y1="660.8" x2="470.0" y2="660.8"/>
+<line class="ring-link" x1="470.0" y1="660.8" x2="390.0" y2="660.8" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R33 to R32: NoC1 Y- then X-"><title>R33 to R32: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1103.0" y1="385.0" x2="1103.0" y2="315.0"/>
+<line class="ring-link" x1="1103.0" y1="315.0" x2="1103.0" y2="245.0"/>
+<line class="ring-link" x1="1103.0" y1="245.0" x2="1103.0" y2="175.0"/>
+<line class="ring-link" x1="1108.6" y1="175.0" x2="1108.6" y2="135.0"/>
+<line class="ring-link" x1="1108.6" y1="995.0" x2="1108.6" y2="945.0"/>
+<line class="ring-link" x1="1108.6" y1="945.0" x2="1108.6" y2="875.0"/>
+<line class="ring-link" x1="1108.6" y1="875.0" x2="1108.6" y2="805.0"/>
+<line class="ring-link" x1="1108.6" y1="805.0" x2="1108.6" y2="735.0"/>
+<line class="ring-link" x1="1107.2" y1="735.0" x2="1107.2" y2="665.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R34 to R33: NoC1 Y- then X-"><title>R34 to R33: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1104.4" y1="455.0" x2="1104.4" y2="385.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R35 to R34: NoC1 Y- then X-"><title>R35 to R34: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1187.2" y1="665.0" x2="1187.2" y2="595.0"/>
+<line class="ring-link" x1="1187.2" y1="595.0" x2="1187.2" y2="525.0"/>
+<line class="ring-link" x1="1187.2" y1="525.0" x2="1187.2" y2="455.0"/>
+<line class="ring-link" x1="1190.0" y1="453.6" x2="1110.0" y2="453.6" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R36 to R35: NoC1 Y- then X-"><title>R36 to R35: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1184.4" y1="315.0" x2="1184.4" y2="245.0"/>
+<line class="ring-link" x1="1187.2" y1="245.0" x2="1187.2" y2="175.0"/>
+<line class="ring-link" x1="1188.6" y1="175.0" x2="1188.6" y2="135.0"/>
+<line class="ring-link" x1="1188.6" y1="995.0" x2="1188.6" y2="945.0"/>
+<line class="ring-link" x1="1188.6" y1="945.0" x2="1188.6" y2="875.0"/>
+<line class="ring-link" x1="1188.6" y1="875.0" x2="1188.6" y2="805.0"/>
+<line class="ring-link" x1="1188.6" y1="805.0" x2="1188.6" y2="735.0"/>
+<line class="ring-link" x1="1187.2" y1="735.0" x2="1187.2" y2="665.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R37 to R36: NoC1 Y- then X-"><title>R37 to R36: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1185.8" y1="385.0" x2="1185.8" y2="315.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R38 to R37: NoC1 Y- then X-"><title>R38 to R37: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1267.2" y1="665.0" x2="1267.2" y2="595.0"/>
+<line class="ring-link" x1="1267.2" y1="595.0" x2="1267.2" y2="525.0"/>
+<line class="ring-link" x1="1267.2" y1="525.0" x2="1267.2" y2="455.0"/>
+<line class="ring-link" x1="1268.6" y1="455.0" x2="1268.6" y2="385.0"/>
+<line class="ring-link" x1="1270.0" y1="387.8" x2="1190.0" y2="387.8" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R39 to R38: NoC1 Y- then X-"><title>R39 to R38: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1350.0" y1="665.0" x2="1270.0" y2="665.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R40 to R39: NoC1 Y- then X-"><title>R40 to R39: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1268.6" y1="315.0" x2="1268.6" y2="245.0"/>
+<line class="ring-link" x1="1270.0" y1="245.0" x2="1270.0" y2="175.0"/>
+<line class="ring-link" x1="1270.0" y1="175.0" x2="1270.0" y2="135.0"/>
+<line class="ring-link" x1="1270.0" y1="995.0" x2="1270.0" y2="945.0"/>
+<line class="ring-link" x1="1270.0" y1="945.0" x2="1270.0" y2="875.0"/>
+<line class="ring-link" x1="1270.0" y1="875.0" x2="1270.0" y2="805.0"/>
+<line class="ring-link" x1="1268.6" y1="805.0" x2="1268.6" y2="735.0"/>
+<line class="ring-link" x1="1268.6" y1="735.0" x2="1268.6" y2="665.0"/>
+<line class="ring-link" x1="1270.0" y1="665.0" x2="1190.0" y2="665.0"/>
+<line class="ring-link" x1="1190.0" y1="663.6" x2="1110.0" y2="663.6"/>
+<line class="ring-link" x1="1110.0" y1="663.6" x2="1030.0" y2="663.6"/>
+<line class="ring-link" x1="1030.0" y1="660.8" x2="950.0" y2="660.8"/>
+<line class="ring-link" x1="950.0" y1="660.8" x2="870.0" y2="660.8"/>
+<line class="ring-link" x1="870.0" y1="666.4" x2="790.0" y2="666.4"/>
+<line class="ring-link" x1="790.0" y1="666.4" x2="710.0" y2="666.4"/>
+<line class="ring-link" x1="710.0" y1="666.4" x2="630.0" y2="666.4"/>
+<line class="ring-link" x1="630.0" y1="665.0" x2="550.0" y2="665.0"/>
+<line class="ring-link" x1="550.0" y1="663.6" x2="470.0" y2="663.6"/>
+<line class="ring-link" x1="470.0" y1="663.6" x2="390.0" y2="663.6"/>
+<line class="ring-link" x1="390.0" y1="663.6" x2="310.0" y2="663.6"/>
+<line class="ring-link" x1="310.0" y1="662.2" x2="230.0" y2="662.2"/>
+<line class="ring-link" x1="230.0" y1="659.4" x2="150.0" y2="659.4"/>
+<line class="ring-link" x1="150.0" y1="665.0" x2="105.0" y2="665.0"/>
+<line class="ring-link" x1="1495.0" y1="665.0" x2="1430.0" y2="665.0"/>
+<line class="ring-link" x1="1430.0" y1="665.0" x2="1350.0" y2="665.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R41 to R40: NoC1 Y- then X-"><title>R41 to R40: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1350.0" y1="313.6" x2="1270.0" y2="313.6" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R42 to R41: NoC1 Y- then X-"><title>R42 to R41: NoC1 Y- then X-</title>
+<line class="ring-link" x1="390.0" y1="735.0" x2="390.0" y2="665.0"/>
+<line class="ring-link" x1="388.6" y1="665.0" x2="388.6" y2="595.0"/>
+<line class="ring-link" x1="390.0" y1="595.0" x2="390.0" y2="525.0"/>
+<line class="ring-link" x1="390.0" y1="525.0" x2="390.0" y2="455.0"/>
+<line class="ring-link" x1="390.0" y1="455.0" x2="390.0" y2="385.0"/>
+<line class="ring-link" x1="390.0" y1="385.0" x2="390.0" y2="315.0"/>
+<line class="ring-link" x1="390.0" y1="313.6" x2="310.0" y2="313.6"/>
+<line class="ring-link" x1="310.0" y1="315.0" x2="230.0" y2="315.0"/>
+<line class="ring-link" x1="230.0" y1="315.0" x2="150.0" y2="315.0"/>
+<line class="ring-link" x1="150.0" y1="315.0" x2="105.0" y2="315.0"/>
+<line class="ring-link" x1="1495.0" y1="315.0" x2="1430.0" y2="315.0"/>
+<line class="ring-link" x1="1430.0" y1="315.0" x2="1350.0" y2="315.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R43 to R42: NoC1 Y- then X-"><title>R43 to R42: NoC1 Y- then X-</title>
+<line class="ring-link" x1="470.0" y1="735.0" x2="390.0" y2="735.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R44 to R43: NoC1 Y- then X-"><title>R44 to R43: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1024.4" y1="945.0" x2="1024.4" y2="875.0"/>
+<line class="ring-link" x1="1027.2" y1="875.0" x2="1027.2" y2="805.0"/>
+<line class="ring-link" x1="1028.6" y1="805.0" x2="1028.6" y2="735.0"/>
+<line class="ring-link" x1="1030.0" y1="735.0" x2="950.0" y2="735.0"/>
+<line class="ring-link" x1="950.0" y1="735.0" x2="870.0" y2="735.0"/>
+<line class="ring-link" x1="870.0" y1="735.0" x2="790.0" y2="735.0"/>
+<line class="ring-link" x1="790.0" y1="735.0" x2="710.0" y2="735.0"/>
+<line class="ring-link" x1="710.0" y1="735.0" x2="630.0" y2="735.0"/>
+<line class="ring-link" x1="630.0" y1="735.0" x2="550.0" y2="735.0"/>
+<line class="ring-link" x1="550.0" y1="735.0" x2="470.0" y2="735.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R45 to R44: NoC1 Y- then X-"><title>R45 to R44: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1110.0" y1="946.4" x2="1030.0" y2="946.4" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R46 to R45: NoC1 Y- then X-"><title>R46 to R45: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1110.0" y1="735.0" x2="1110.0" y2="665.0"/>
+<line class="ring-link" x1="1108.6" y1="665.0" x2="1108.6" y2="595.0"/>
+<line class="ring-link" x1="1108.6" y1="595.0" x2="1108.6" y2="525.0"/>
+<line class="ring-link" x1="1104.4" y1="525.0" x2="1104.4" y2="455.0"/>
+<line class="ring-link" x1="1107.2" y1="455.0" x2="1107.2" y2="385.0"/>
+<line class="ring-link" x1="1105.8" y1="385.0" x2="1105.8" y2="315.0"/>
+<line class="ring-link" x1="1105.8" y1="315.0" x2="1105.8" y2="245.0"/>
+<line class="ring-link" x1="1105.8" y1="245.0" x2="1105.8" y2="175.0"/>
+<line class="ring-link" x1="1111.4" y1="175.0" x2="1111.4" y2="135.0"/>
+<line class="ring-link" x1="1111.4" y1="995.0" x2="1111.4" y2="945.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R47 to R46: NoC1 Y- then X-"><title>R47 to R46: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1190.0" y1="735.0" x2="1110.0" y2="735.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R48 to R47: NoC1 Y- then X-"><title>R48 to R47: NoC1 Y- then X-</title>
+<line class="ring-link" x1="225.8" y1="805.0" x2="225.8" y2="735.0"/>
+<line class="ring-link" x1="230.0" y1="729.4" x2="150.0" y2="729.4"/>
+<line class="ring-link" x1="150.0" y1="735.0" x2="105.0" y2="735.0"/>
+<line class="ring-link" x1="1495.0" y1="735.0" x2="1430.0" y2="735.0"/>
+<line class="ring-link" x1="1430.0" y1="735.0" x2="1350.0" y2="735.0"/>
+<line class="ring-link" x1="1350.0" y1="735.0" x2="1270.0" y2="735.0"/>
+<line class="ring-link" x1="1270.0" y1="735.0" x2="1190.0" y2="735.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R49 to R48: NoC1 Y- then X-"><title>R49 to R48: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1030.0" y1="798.0" x2="950.0" y2="798.0"/>
+<line class="ring-link" x1="950.0" y1="798.0" x2="870.0" y2="798.0"/>
+<line class="ring-link" x1="870.0" y1="803.6" x2="790.0" y2="803.6"/>
+<line class="ring-link" x1="790.0" y1="803.6" x2="710.0" y2="803.6"/>
+<line class="ring-link" x1="710.0" y1="803.6" x2="630.0" y2="803.6"/>
+<line class="ring-link" x1="630.0" y1="803.6" x2="550.0" y2="803.6"/>
+<line class="ring-link" x1="550.0" y1="803.6" x2="470.0" y2="803.6"/>
+<line class="ring-link" x1="470.0" y1="803.6" x2="390.0" y2="803.6"/>
+<line class="ring-link" x1="390.0" y1="803.6" x2="310.0" y2="803.6"/>
+<line class="ring-link" x1="310.0" y1="803.6" x2="230.0" y2="803.6" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R50 to R49: NoC1 Y- then X-"><title>R50 to R49: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1110.0" y1="800.8" x2="1030.0" y2="800.8" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R51 to R50: NoC1 Y- then X-"><title>R51 to R50: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1190.0" y1="802.2" x2="1110.0" y2="802.2" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R52 to R51: NoC1 Y- then X-"><title>R52 to R51: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1270.0" y1="803.6" x2="1190.0" y2="803.6" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R53 to R52: NoC1 Y- then X-"><title>R53 to R52: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1350.0" y1="803.6" x2="1270.0" y2="803.6" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R54 to R53: NoC1 Y- then X-"><title>R54 to R53: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1028.6" y1="455.0" x2="1028.6" y2="385.0"/>
+<line class="ring-link" x1="1027.2" y1="385.0" x2="1027.2" y2="315.0"/>
+<line class="ring-link" x1="1025.8" y1="315.0" x2="1025.8" y2="245.0"/>
+<line class="ring-link" x1="1027.2" y1="245.0" x2="1027.2" y2="175.0"/>
+<line class="ring-link" x1="1027.2" y1="175.0" x2="1027.2" y2="135.0"/>
+<line class="ring-link" x1="1027.2" y1="995.0" x2="1027.2" y2="945.0"/>
+<line class="ring-link" x1="1027.2" y1="945.0" x2="1027.2" y2="875.0"/>
+<line class="ring-link" x1="1030.0" y1="875.0" x2="1030.0" y2="805.0"/>
+<line class="ring-link" x1="1030.0" y1="800.8" x2="950.0" y2="800.8"/>
+<line class="ring-link" x1="950.0" y1="800.8" x2="870.0" y2="800.8"/>
+<line class="ring-link" x1="870.0" y1="806.4" x2="790.0" y2="806.4"/>
+<line class="ring-link" x1="790.0" y1="806.4" x2="710.0" y2="806.4"/>
+<line class="ring-link" x1="710.0" y1="806.4" x2="630.0" y2="806.4"/>
+<line class="ring-link" x1="630.0" y1="806.4" x2="550.0" y2="806.4"/>
+<line class="ring-link" x1="550.0" y1="806.4" x2="470.0" y2="806.4"/>
+<line class="ring-link" x1="470.0" y1="806.4" x2="390.0" y2="806.4"/>
+<line class="ring-link" x1="390.0" y1="806.4" x2="310.0" y2="806.4"/>
+<line class="ring-link" x1="310.0" y1="806.4" x2="230.0" y2="806.4"/>
+<line class="ring-link" x1="230.0" y1="803.6" x2="150.0" y2="803.6"/>
+<line class="ring-link" x1="150.0" y1="803.6" x2="105.0" y2="803.6"/>
+<line class="ring-link" x1="1495.0" y1="803.6" x2="1430.0" y2="803.6"/>
+<line class="ring-link" x1="1430.0" y1="803.6" x2="1350.0" y2="803.6" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R55 to R54: NoC1 Y- then X-"><title>R55 to R54: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1107.2" y1="525.0" x2="1107.2" y2="455.0"/>
+<line class="ring-link" x1="1110.0" y1="452.2" x2="1030.0" y2="452.2" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R56 to R55: NoC1 Y- then X-"><title>R56 to R55: NoC1 Y- then X-</title>
+<line class="ring-link" x1="227.2" y1="875.0" x2="227.2" y2="805.0"/>
+<line class="ring-link" x1="228.6" y1="805.0" x2="228.6" y2="735.0"/>
+<line class="ring-link" x1="230.0" y1="735.0" x2="230.0" y2="665.0"/>
+<line class="ring-link" x1="231.4" y1="665.0" x2="231.4" y2="595.0"/>
+<line class="ring-link" x1="231.4" y1="595.0" x2="231.4" y2="525.0"/>
+<line class="ring-link" x1="230.0" y1="523.6" x2="150.0" y2="523.6"/>
+<line class="ring-link" x1="150.0" y1="523.6" x2="105.0" y2="523.6"/>
+<line class="ring-link" x1="1495.0" y1="523.6" x2="1430.0" y2="523.6"/>
+<line class="ring-link" x1="1430.0" y1="523.6" x2="1350.0" y2="523.6"/>
+<line class="ring-link" x1="1350.0" y1="523.6" x2="1270.0" y2="523.6"/>
+<line class="ring-link" x1="1270.0" y1="523.6" x2="1190.0" y2="523.6"/>
+<line class="ring-link" x1="1190.0" y1="523.6" x2="1110.0" y2="523.6" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R57 to R56: NoC1 Y- then X-"><title>R57 to R56: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1030.0" y1="868.0" x2="950.0" y2="868.0"/>
+<line class="ring-link" x1="950.0" y1="868.0" x2="870.0" y2="868.0"/>
+<line class="ring-link" x1="870.0" y1="873.6" x2="790.0" y2="873.6"/>
+<line class="ring-link" x1="790.0" y1="873.6" x2="710.0" y2="873.6"/>
+<line class="ring-link" x1="710.0" y1="873.6" x2="630.0" y2="873.6"/>
+<line class="ring-link" x1="630.0" y1="873.6" x2="550.0" y2="873.6"/>
+<line class="ring-link" x1="550.0" y1="873.6" x2="470.0" y2="873.6"/>
+<line class="ring-link" x1="470.0" y1="872.2" x2="390.0" y2="872.2"/>
+<line class="ring-link" x1="390.0" y1="872.2" x2="310.0" y2="872.2"/>
+<line class="ring-link" x1="310.0" y1="869.4" x2="230.0" y2="869.4" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R58 to R57: NoC1 Y- then X-"><title>R58 to R57: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1030.0" y1="525.0" x2="1030.0" y2="455.0"/>
+<line class="ring-link" x1="1031.4" y1="455.0" x2="1031.4" y2="385.0"/>
+<line class="ring-link" x1="1030.0" y1="385.0" x2="1030.0" y2="315.0"/>
+<line class="ring-link" x1="1028.6" y1="315.0" x2="1028.6" y2="245.0"/>
+<line class="ring-link" x1="1030.0" y1="245.0" x2="1030.0" y2="175.0"/>
+<line class="ring-link" x1="1030.0" y1="175.0" x2="1030.0" y2="135.0"/>
+<line class="ring-link" x1="1030.0" y1="995.0" x2="1030.0" y2="945.0"/>
+<line class="ring-link" x1="1030.0" y1="945.0" x2="1030.0" y2="875.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R59 to R58: NoC1 Y- then X-"><title>R59 to R58: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1027.2" y1="595.0" x2="1027.2" y2="525.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R60 to R59: NoC1 Y- then X-"><title>R60 to R59: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1028.6" y1="665.0" x2="1028.6" y2="595.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R61 to R60: NoC1 Y- then X-"><title>R61 to R60: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1027.2" y1="735.0" x2="1027.2" y2="665.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R62 to R61: NoC1 Y- then X-"><title>R62 to R61: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1111.4" y1="875.0" x2="1111.4" y2="805.0"/>
+<line class="ring-link" x1="1111.4" y1="805.0" x2="1111.4" y2="735.0"/>
+<line class="ring-link" x1="1110.0" y1="735.0" x2="1030.0" y2="735.0" marker-end="url(#arrow-green)"/>
+</g>
+<g aria-label="R63 to R62: NoC1 Y- then X-"><title>R63 to R62: NoC1 Y- then X-</title>
+<line class="ring-link" x1="1190.0" y1="873.6" x2="1110.0" y2="873.6" marker-end="url(#arrow-green)"/>
+</g></g>
+  <g aria-label="Activation ring indices"><text class="ring-label" x="230" y="315">R0</text><text class="ring-label" x="310" y="315">R1</text><text class="ring-label" x="310" y="525">R2</text><text class="ring-label" x="1110" y="315">R3</text><text class="ring-label" x="390" y="315">R4</text><text class="ring-label" x="470" y="455">R5</text><text class="ring-label" x="470" y="315">R6</text><text class="ring-label" x="1030" y="315">R7</text><text class="ring-label" x="230" y="385">R8</text><text class="ring-label" x="390" y="385">R9</text><text class="ring-label" x="550" y="385">R10</text><text class="ring-label" x="310" y="385">R11</text><text class="ring-label" x="470" y="385">R12</text><text class="ring-label" x="1030" y="385">R13</text><text class="ring-label" x="310" y="875">R14</text><text class="ring-label" x="390" y="945">R15</text><text class="ring-label" x="230" y="455">R16</text><text class="ring-label" x="230" y="735">R17</text><text class="ring-label" x="310" y="735">R18</text><text class="ring-label" x="310" y="455">R19</text><text class="ring-label" x="390" y="455">R20</text><text class="ring-label" x="390" y="525">R21</text><text class="ring-label" x="550" y="455">R22</text><text class="ring-label" x="230" y="525">R23</text><text class="ring-label" x="230" y="595">R24</text><text class="ring-label" x="310" y="595">R25</text><text class="ring-label" x="310" y="665">R26</text><text class="ring-label" x="390" y="595">R27</text><text class="ring-label" x="550" y="595">R28</text><text class="ring-label" x="630" y="595">R29</text><text class="ring-label" x="230" y="665">R30</text><text class="ring-label" x="390" y="665">R31</text><text class="ring-label" x="1110" y="665">R32</text><text class="ring-label" x="1110" y="385">R33</text><text class="ring-label" x="1110" y="455">R34</text><text class="ring-label" x="1190" y="665">R35</text><text class="ring-label" x="1190" y="315">R36</text><text class="ring-label" x="1190" y="385">R37</text><text class="ring-label" x="1270" y="665">R38</text><text class="ring-label" x="1350" y="665">R39</text><text class="ring-label" x="1270" y="315">R40</text><text class="ring-label" x="1350" y="315">R41</text><text class="ring-label" x="390" y="735">R42</text><text class="ring-label" x="470" y="735">R43</text><text class="ring-label" x="1030" y="945">R44</text><text class="ring-label" x="1110" y="945">R45</text><text class="ring-label" x="1110" y="735">R46</text><text class="ring-label" x="1190" y="735">R47</text><text class="ring-label" x="230" y="805">R48</text><text class="ring-label" x="1030" y="805">R49</text><text class="ring-label" x="1110" y="805">R50</text><text class="ring-label" x="1190" y="805">R51</text><text class="ring-label" x="1270" y="805">R52</text><text class="ring-label" x="1350" y="805">R53</text><text class="ring-label" x="1030" y="455">R54</text><text class="ring-label" x="1110" y="525">R55</text><text class="ring-label" x="230" y="875">R56</text><text class="ring-label" x="1030" y="875">R57</text><text class="ring-label" x="1030" y="525">R58</text><text class="ring-label" x="1030" y="595">R59</text><text class="ring-label" x="1030" y="665">R60</text><text class="ring-label" x="1030" y="735">R61</text><text class="ring-label" x="1110" y="875">R62</text><text class="ring-label" x="1190" y="875">R63</text></g>
+  <g aria-label="DRAM bank and sender indices"><text class="sender-label" x="150" y="175">B0 S0</text><text class="sender-label" x="150" y="245">B0 S1</text><text class="sender-label" x="150" y="385">B1 S0</text><text class="sender-label" x="150" y="875">B1 S1</text><text class="sender-label" x="150" y="735">B2 S0</text><text class="sender-label" x="150" y="455">B2 S1</text><text class="sender-label" x="150" y="595">B3 S0</text><text class="sender-label" x="150" y="665">B3 S1</text><text class="sender-label" x="870" y="175">B4 S0</text><text class="sender-label" x="870" y="245">B4 S1</text><text class="sender-label" x="870" y="315">B5 S0</text><text class="sender-label" x="870" y="875">B5 S1</text><text class="sender-label" x="870" y="805">B6 S0</text><text class="sender-label" x="870" y="455">B6 S1</text><text class="sender-label" x="870" y="525">B7 S0</text><text class="sender-label" x="870" y="665">B7 S1</text></g>
+  <g transform="translate(120,1025)">
+    <rect x="0" y="-22" width="1360" height="78" rx="12" fill="white" stroke="#d5dbe2"/>
+    <rect x="28" y="-4" width="34" height="28" rx="5" fill="#2878d0" stroke="#0e4f98" stroke-width="2"/>
+    <text class="legend" x="74" y="10">Activation-ring worker</text>
+    <rect x="300" y="-4" width="34" height="28" rx="5" fill="#d9363e" stroke="#8d1720" stroke-width="2"/>
+    <text class="legend" x="346" y="10">Tensor Prefetcher DRISC</text>
+    <rect x="600" y="-4" width="34" height="28" rx="5" fill="#aeb4bc" stroke="#6f7782"/>
+    <text class="legend" x="646" y="10">All other chip cores</text>
+    <line x1="810" y1="10" x2="850" y2="10" stroke="#12a150" stroke-width="5" marker-end="url(#arrow-green)"/>
+    <text class="legend" x="864" y="10">Activation: NoC1 Y- then X-</text>
+    <line x1="1095" y1="10" x2="1135" y2="10" stroke="#ef4f9a" stroke-width="4" marker-end="url(#arrow-pink)"/>
+    <text class="legend" x="1149" y="10">Weights: NoC0 X+ then Y+</text>
+    <text x="680" y="43" text-anchor="middle" font-family="sans-serif" font-size="13" fill="#66727f">Every coincident physical link is separated into parallel visual lanes; lane offsets are not hardware detours.</text>
+  </g>
+</svg>


### PR DESCRIPTION
### PR Category
Documentation

### Summary
Adds a user-facing tech report for the DRAM-core (DRISC) **Tensor prefetcher** at `tech_reports/TensorPrefetcher/TensorPrefetcher.md`, and links it from the README under *TT-NN Tech Reports*. It is the usage companion to the existing internal contract doc `tt_metal/impl/buffers/prefetcher_matmul_design.md`.

Contents: overview and the Start/Queue/Stop lifecycle; the support gate; the ring; receiver placement and NoC congestion (incl. DRAM harvesting); weight layouts (receiver-contiguous + `CONTIGUOUS_1D` as the recommended default, legacy K-row-major as the alternative) and the shard/pairing contract; a basic-usage walkthrough built on `prefetch_and_linear` with streaming; GCB sizing (batched needs a full ring, streaming a partial window); tracing (requests are captured into the trace alongside their matmul); a lower-level-control section (the request API, custom streaming rotation, the raw `create_global_circular_buffer_for_tensor_prefetcher` factory, multi-GCB); and pitfalls. Includes whole-chip routing diagrams (ring16, ring64, dual-sender) as self-contained SVGs.

Docs-only — no functional change.

### Notes for reviewers
- Please sanity-check the technical claims against your mental model: receiver-contiguous + streaming as the recommended default; `CONTIGUOUS_1D` preferred over `ROUND_ROBIN_1D`; no sub-device needed; the batched GCB-size floor (≥ one full ring / largest per-receiver weight); and the placement guidance (NoC0 pushes vs NoC1 ring are independent but set by the same coordinates; harvesting shifts logical→physical mapping).
- The SVG figures are the pre-generated production layouts; the report deliberately omits the details of the optimized placement.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/tensor-prefetcher-tech-report)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/tensor-prefetcher-tech-report)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/tensor-prefetcher-tech-report)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/tensor-prefetcher-tech-report)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jbauman/tensor-prefetcher-tech-report)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jbauman/tensor-prefetcher-tech-report)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/tensor-prefetcher-tech-report)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/tensor-prefetcher-tech-report)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/tensor-prefetcher-tech-report)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/tensor-prefetcher-tech-report)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/tensor-prefetcher-tech-report)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/tensor-prefetcher-tech-report)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/tensor-prefetcher-tech-report)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/tensor-prefetcher-tech-report)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/tensor-prefetcher-tech-report)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/tensor-prefetcher-tech-report)