### PR TITLE
[LLK][BH] Remove dead unpacker writes of INT8 / SrcB word-1 config bits

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cunpack_common.h
@@ -196,13 +196,6 @@ inline void wait_for_idle()
     }
 }
 
-inline void enable_int8_fpu_math()
-{
-    alu_config_u alu_payload                     = {.val = 0};
-    alu_payload.f.ALU_ACC_CTRL_INT8_math_enabled = 1;
-    cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_ADDR32, 0, ALU_ACC_CTRL_INT8_math_enabled_MASK>(alu_payload.val);
-}
-
 /**
  * \brief Returns true if unpacker I/O uses 32-bit formats (Int32 or Float32).
  *

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_common.h
@@ -279,14 +279,6 @@ inline void _llk_unpack_reconfig_data_format_srcb_impl_(
 }
 
 /**
- * @brief Enable Int8 math on the FPU.
- */
-inline void _llk_enable_int8_fpu_math_()
-{
-    enable_int8_fpu_math();
-}
-
-/**
  * @brief Mark SrcA and SrcB as data-valid without unpacking real data.
  *
  * Issues zero-source UNPACR NOPs that set the data-valid flag on both source registers, e.g. to

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_reduce.h
@@ -66,7 +66,6 @@ inline void _llk_unpack_reduce_init_(
     const std::uint32_t unpB_src_format, const std::uint32_t unpB_dst_format, const std::uint32_t within_face_16x16_transpose = 0)
 {
     // Configure SrcB format registers
-    cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG1_SrcB_RMW>(unpB_dst_format);
     cfg_reg_rmw_tensix<THCON_SEC1_REG0_TileDescriptor_ADDR32, 0, 0xf>(unpB_src_format);
 
     // Set FP8 E4M3 mode for SrcB; selects the e4m3 (vs e5m2) exponent layout and clears any stale 4b-exp setting.


### PR DESCRIPTION
## What

Blackhole counterpart of #49637 (Wormhole B0). Issue: https://github.com/tenstorrent/tt-llk/issues/1667

These registers are not consumed by Unpacker and the code is dead too, using this could only lead to races.

On Blackhole, remove three pieces of **dead unpacker code** that write two shared `ALU_FORMAT_SPEC` (word 1) config fields:

1. `enable_int8_fpu_math` (`cunpack_common.h`) — the only unpacker writer of `ALU_ACC_CTRL_INT8_math_enabled` (bit 31).
2. `_llk_enable_int8_fpu_math_` (`llk_unpack_common.h`) — its sole caller.
3. The `ALU_FORMAT_SPEC_REG1_SrcB` write (bits 21-24) in `_llk_unpack_reduce_init_` (`llk_unpack_reduce.h`).

## Why

The same cross-thread word-1 config-sharing audit that motivated the WH change (tt-llk #1249 context) applies identically on Blackhole — these unpacker-side writers are **unreachable dead code**:

- `_llk_enable_int8_fpu_math_` / `enable_int8_fpu_math` have **zero callers** anywhere in the repo. `INT8_math_enabled` is written only by the MATH thread in the live paths (`llk_math_common.h`).
- The single-operand reduce path (`llk_unpack_reduce_init` / `_llk_unpack_reduce_init_`) is **orphaned** on BH — the live reduce (`tt_metal/hw/inc/api/compute/reduce.h`) uses `_llk_unpack_AB_reduce_`. The SrcB ALU format is programmed by the MATH thread.

Removing them eliminates the latent unpack↔math cross-thread sharing of these word-1 fields.

## Scope / safety

- **Blackhole only.** Wormhole was handled in #49637.
- The unpacker's own THCON SrcB format regs (tile descriptor / FP8 E4M3 mode / out-data-format) in `_llk_unpack_reduce_init_` are **kept** — only the ALU word-1 write is removed.
- Verified: no remaining references to the removed symbols; `ALU_ACC_CTRL_INT8_math_enabled` mask/bitfield still used by the MATH writer and `alu_config_u`.
- Pure dead-code deletion (16 lines, no callers) — no behavioral change on any live path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/llk-bh-drop-dead-unpacker-int8-srcb-writes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/llk-bh-drop-dead-unpacker-int8-srcb-writes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/llk-bh-drop-dead-unpacker-int8-srcb-writes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/llk-bh-drop-dead-unpacker-int8-srcb-writes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/llk-bh-drop-dead-unpacker-int8-srcb-writes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/llk-bh-drop-dead-unpacker-int8-srcb-writes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/llk-bh-drop-dead-unpacker-int8-srcb-writes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/llk-bh-drop-dead-unpacker-int8-srcb-writes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/llk-bh-drop-dead-unpacker-int8-srcb-writes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/llk-bh-drop-dead-unpacker-int8-srcb-writes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/llk-bh-drop-dead-unpacker-int8-srcb-writes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/llk-bh-drop-dead-unpacker-int8-srcb-writes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/llk-bh-drop-dead-unpacker-int8-srcb-writes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/llk-bh-drop-dead-unpacker-int8-srcb-writes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/llk-bh-drop-dead-unpacker-int8-srcb-writes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/llk-bh-drop-dead-unpacker-int8-srcb-writes)