### PR TITLE
 [Cleanup] Relax Quasar NoC transfer alignment

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -122,6 +122,12 @@ void RunTestOnCore(
     if (multi_dm_race && !is_quasar) {
         GTEST_SKIP() << "Multi-DM race test only runs on Quasar";
     }
+    // The Quasar NOC shifts the data so transfers don't need to be aligned; a misaligned transfer is
+    // legal there and there is nothing to flag. These tests stay valid on WH/BH where alignment is
+    // enforced.
+    if ((feature == SanitizeNOCAlignmentL1Write || feature == SanitizeNOCAlignmentL1Read) && is_quasar) {
+        GTEST_SKIP() << "Quasar NOC has no L1 alignment restriction; misaligned transfers are legal";
+    }
     // Both exercise Quasar's uncached L1 alias, which only exists on Quasar DM cores.
     if ((feature == SanitizeNOCMailboxWriteUncachedAlias || feature == SanitizeL1OverflowStraddle) &&
         (!is_quasar || is_eth_core)) {
@@ -323,8 +329,8 @@ void RunTestOnCore(
             output_buf_noc_xy.y = 18;
             break;
         case SanitizeNOCAlignmentL1Write:
-            output_buffer_addr++;  // This is illegal because reading DRAM->L1 needs DRAM alignment
-                                   // requirements (32 byte aligned).
+            output_buffer_addr++;  // Misaligned L1 write: on WH/BH the NoC requires
+                                   // NOC_L1_WRITE_ALIGNMENT_BYTES alignment.
             buffer_size--;
             break;
         case SanitizeNOCAlignmentL1Read:

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -846,6 +846,23 @@ TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeNOCAlignmentL1ReadNCrisc) {
         this->devices_[0]);
 }
 
+// Quasar relaxes NoC transfer alignment to 1B (misaligned transfers are legal, so the watcher can't
+// flag them) while allocation alignment stays at the physical floor. Guards against regressing either.
+TEST_F(MeshWatcherFixture, TensixTestWatcherQuasarAlignmentContract) {
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    if (hal.get_arch() != tt::ARCH::QUASAR) {
+        GTEST_SKIP() << "Relaxed NoC alignment is Quasar-only";
+    }
+    // NoC transfer alignment relaxed to 1B.
+    EXPECT_EQ(hal.get_read_alignment(HalMemType::L1), 1u);
+    EXPECT_EQ(hal.get_write_alignment(HalMemType::L1), 1u);
+    EXPECT_EQ(hal.get_read_alignment(HalMemType::DRAM), 1u);
+    EXPECT_EQ(hal.get_write_alignment(HalMemType::DRAM), 1u);
+    // Allocation alignment stays at the physical floor.
+    EXPECT_EQ(hal.get_alignment(HalMemType::L1), 16u);
+    EXPECT_EQ(hal.get_alignment(HalMemType::DRAM), 64u);
+}
+
 TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeNOCZeroL1Write) {
     this->RunTestOnDevice(
         [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc/noc_parameters.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc/noc_parameters.h
@@ -471,28 +471,26 @@
 //   3. Change this macro to identity: #define NOC_LOCAL_ADDR(addr) (addr)
 #define NOC_LOCAL_ADDR(addr) NOC_LOCAL_ADDR_OFFSET(addr)
 
-// TODO review these alignment restrictions
-// Alignment restrictions
-#define NOC_L1_READ_ALIGNMENT_BYTES 16
-#define NOC_L1_WRITE_ALIGNMENT_BYTES 16
+// NOC transfer alignment. The Quasar NOC shifts the data to make it so things don't need to be
+// aligned, hence no L1/DRAM restriction. Kept DECOUPLED from L1_ALIGNMENT/DRAM_ALIGNMENT below: the
+// NOC's relaxed alignment does not apply to other L1 consumers (e.g. the unpacker), which still
+// need the physical L1 width.
+#define NOC_L1_READ_ALIGNMENT_BYTES 1
+#define NOC_L1_WRITE_ALIGNMENT_BYTES 1
 #define NOC_PCIE_READ_ALIGNMENT_BYTES 64
 #define NOC_PCIE_WRITE_ALIGNMENT_BYTES 16
-#define NOC_DRAM_READ_ALIGNMENT_BYTES 64
-#define NOC_DRAM_WRITE_ALIGNMENT_BYTES 16
+#define NOC_DRAM_READ_ALIGNMENT_BYTES 1
+#define NOC_DRAM_WRITE_ALIGNMENT_BYTES 1
 // TODO(quasar): For Quasar, do a per-register lookup - 4 or 8 depending on target reg.
 #define NOC_REG_ALIGNMENT_BYTES 4
 
-#define L1_ALIGNMENT                                                                              \
-    (static_cast<uint32_t>(                                                                       \
-        NOC_L1_READ_ALIGNMENT_BYTES >= NOC_L1_WRITE_ALIGNMENT_BYTES ? NOC_L1_READ_ALIGNMENT_BYTES \
-                                                                    : NOC_L1_WRITE_ALIGNMENT_BYTES))
+// Allocation / layout alignment. Pinned to the physical floor (L1 = 16B, GDDR = 64B), NOT derived
+// from the NOC values above
+#define L1_ALIGNMENT (static_cast<uint32_t>(16))
 #define PCIE_ALIGNMENT                                                                                  \
     (static_cast<uint32_t>(                                                                             \
         NOC_PCIE_READ_ALIGNMENT_BYTES >= NOC_PCIE_WRITE_ALIGNMENT_BYTES ? NOC_PCIE_READ_ALIGNMENT_BYTES \
                                                                         : NOC_PCIE_WRITE_ALIGNMENT_BYTES))
-#define DRAM_ALIGNMENT                                                                                  \
-    (static_cast<uint32_t>(                                                                             \
-        NOC_DRAM_READ_ALIGNMENT_BYTES >= NOC_DRAM_WRITE_ALIGNMENT_BYTES ? NOC_DRAM_READ_ALIGNMENT_BYTES \
-                                                                        : NOC_DRAM_WRITE_ALIGNMENT_BYTES))
+#define DRAM_ALIGNMENT (static_cast<uint32_t>(64))
 
 #endif


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Related to https://github.com/tenstorrent/tt-metal/issues/43927. The Quasar NoC shifts data internally, so transfers don't require L1/DRAM alignment. This relaxes NoC L1/DRAM READ/WRITE alignment bytes to 1 and stops the watcher/sanitizer from flagging misaligned Quasar transfers as errors.

PR decouples transfer alignment from allocation alignment: `L1_ALIGNMENT` (16) and `DRAM_ALIGNMENT` (64) are now pinned to the physical memory floor instead of being derived from the NoC macros. Non-NoC L1 consumers (e.g. the unpacker) might still need the still get the physical width.

### Notes for reviewers
- `noc_parameters.h` - confirm the alignment decoupling is correct: allocation alignment (`L1_ALIGNMENT/DRAM_ALIGNMENT`) must stay at the physical floor (16/64) even though NOC transfer alignment drops to 1. HAL populates these into separate arrays for each arch.
- Out of scope (follow-up): ttnn welford groupnorm kernels reuse `NOC_L1_READ_ALIGNMENT_BYTES` as a 16-byte packing constant. Need to source the physical L1 width instead as an arch-specific compile-time arg from the host before groupnorm runs on Quasar. Tracking issue: https://github.com/tenstorrent/tt-metal/issues/49951

### CI Status
Runtime unit tests: https://github.com/tenstorrent/tt-metal/actions/runs/29457019713

_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadkarni/qsr_noc_relax_alignments)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadkarni/qsr_noc_relax_alignments)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=snadkarni/qsr_noc_relax_alignments)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:snadkarni/qsr_noc_relax_alignments)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=snadkarni/qsr_noc_relax_alignments)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:snadkarni/qsr_noc_relax_alignments)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/qsr_noc_relax_alignments)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/qsr_noc_relax_alignments)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=snadkarni/qsr_noc_relax_alignments)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:snadkarni/qsr_noc_relax_alignments)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/qsr_noc_relax_alignments)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/qsr_noc_relax_alignments)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/qsr_noc_relax_alignments)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/qsr_noc_relax_alignments)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/qsr_noc_relax_alignments)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/qsr_noc_relax_alignments)