### PR TITLE
feat(docs): OpenSearch docs search indexing

### DIFF
--- a/.github/workflows/docs-latest-public.yaml
+++ b/.github/workflows/docs-latest-public.yaml
@@ -181,26 +181,11 @@ jobs:
             -f message="Update versions.json after ${DEPLOYED_VERSION} deploy" \
             -f content="$(echo "$payload" | base64 -w0)" \
             -f branch=gh-pages "${extra_args[@]}"
-      - name: Check OpenSearch ingest key
-        # Gate the indexer without exposing the write credential to the whole job.
-        # Only this trusted shell step and the indexer step below read the secret;
-        # the third-party deploy/artifact actions in this job never see it.
-        id: search-key
-        if: ${{ steps.deployment.outcome == 'success' }}
-        env:
-          DOCS_SEARCH_INGEST_API_KEY: ${{ secrets.DOCS_SEARCH_INGEST_API_KEY_DOCS_TENSTORRENT }}
-        run: |
-          if [ -n "${DOCS_SEARCH_INGEST_API_KEY}" ]; then
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::Skipping OpenSearch indexing because DOCS_SEARCH_INGEST_API_KEY_DOCS_TENSTORRENT is not set."
-          fi
       - name: Index docs into OpenSearch
         # The indexer reads the built HTML from the artifact downloaded above.
         # Non-critical post-deploy enhancement: a transient ingest failure must
         # not mark an otherwise-successful docs deploy as failed.
-        if: ${{ steps.deployment.outcome == 'success' && steps.search-key.outputs.enabled == 'true' }}
+        if: ${{ steps.deployment.outcome == 'success' }}
         continue-on-error: true
         env:
           # Scoped to this step only (not job-level) so the OpenSearch write
@@ -212,7 +197,12 @@ jobs:
           DOCS_INDEX_VERSION: ${{ inputs.version }}
           DOCS_OUTPUT_DIR: gh_pages/${{ inputs.version }}
           DOC_SITE_BASE_URL: https://docs.tenstorrent.com/tt-metal/${{ inputs.version }}
-        run: python3 scripts/index_remote_search.py
+        run: |
+          if [ -z "${DOCS_SEARCH_INGEST_API_KEY}" ]; then
+            echo "::warning::Skipping OpenSearch indexing because DOCS_SEARCH_INGEST_API_KEY_DOCS_TENSTORRENT is not set."
+            exit 0
+          fi
+          python3 scripts/index_remote_search.py
       - name: Check the docs deployment is up
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |

--- a/.github/workflows/docs-latest-public.yaml
+++ b/.github/workflows/docs-latest-public.yaml
@@ -110,10 +110,6 @@ jobs:
       # ok because each post-commit pipeline definitely takes more than 30 min
       group: "pages-${{ github.ref }}"
       cancel-in-progress: false # WARNING: This will only queue a single job; all else will still be cancelled!
-    env:
-      # Expose as a job-level env so it can be read in step-level if: conditions.
-      # (The secrets context is not available in step if: expressions.)
-      DOCS_SEARCH_INGEST_API_KEY: ${{ secrets.DOCS_SEARCH_INGEST_API_KEY_DOCS_TENSTORRENT }}
     defaults:
       run:
         shell: bash
@@ -185,14 +181,31 @@ jobs:
             -f message="Update versions.json after ${DEPLOYED_VERSION} deploy" \
             -f content="$(echo "$payload" | base64 -w0)" \
             -f branch=gh-pages "${extra_args[@]}"
+      - name: Check OpenSearch ingest key
+        # Gate the indexer without exposing the write credential to the whole job.
+        # Only this trusted shell step and the indexer step below read the secret;
+        # the third-party deploy/artifact actions in this job never see it.
+        id: search-key
+        if: ${{ steps.deployment.outcome == 'success' }}
+        env:
+          DOCS_SEARCH_INGEST_API_KEY: ${{ secrets.DOCS_SEARCH_INGEST_API_KEY_DOCS_TENSTORRENT }}
+        run: |
+          if [ -n "${DOCS_SEARCH_INGEST_API_KEY}" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Skipping OpenSearch indexing because DOCS_SEARCH_INGEST_API_KEY_DOCS_TENSTORRENT is not set."
+          fi
       - name: Index docs into OpenSearch
-        # Runs only on successful deployments when the ingest key is available.
-        # The indexer reads docs/html files from the artifact downloaded above.
+        # The indexer reads the built HTML from the artifact downloaded above.
         # Non-critical post-deploy enhancement: a transient ingest failure must
         # not mark an otherwise-successful docs deploy as failed.
-        if: ${{ steps.deployment.outcome == 'success' && env.DOCS_SEARCH_INGEST_API_KEY != '' }}
+        if: ${{ steps.deployment.outcome == 'success' && steps.search-key.outputs.enabled == 'true' }}
         continue-on-error: true
         env:
+          # Scoped to this step only (not job-level) so the OpenSearch write
+          # credential is never exposed to the other actions in this job.
+          DOCS_SEARCH_INGEST_API_KEY: ${{ secrets.DOCS_SEARCH_INGEST_API_KEY_DOCS_TENSTORRENT }}
           SEARCH_API_BASE: https://csl860x2oj.execute-api.us-east-2.amazonaws.com/prod
           DOC_CATALOG_SOURCE_ID: docs-tenstorrent
           DOCS_ID_NAMESPACE: tt-metal

--- a/.github/workflows/docs-latest-public.yaml
+++ b/.github/workflows/docs-latest-public.yaml
@@ -110,6 +110,10 @@ jobs:
       # ok because each post-commit pipeline definitely takes more than 30 min
       group: "pages-${{ github.ref }}"
       cancel-in-progress: false # WARNING: This will only queue a single job; all else will still be cancelled!
+    env:
+      # Expose as a job-level env so it can be read in step-level if: conditions.
+      # (The secrets context is not available in step if: expressions.)
+      DOCS_SEARCH_INGEST_API_KEY: ${{ secrets.DOCS_SEARCH_INGEST_API_KEY_DOCS_TENSTORRENT }}
     defaults:
       run:
         shell: bash
@@ -181,6 +185,21 @@ jobs:
             -f message="Update versions.json after ${DEPLOYED_VERSION} deploy" \
             -f content="$(echo "$payload" | base64 -w0)" \
             -f branch=gh-pages "${extra_args[@]}"
+      - name: Index docs into OpenSearch
+        # Runs only on successful deployments when the ingest key is available.
+        # The indexer reads docs/html files from the artifact downloaded above.
+        # Non-critical post-deploy enhancement: a transient ingest failure must
+        # not mark an otherwise-successful docs deploy as failed.
+        if: ${{ steps.deployment.outcome == 'success' && env.DOCS_SEARCH_INGEST_API_KEY != '' }}
+        continue-on-error: true
+        env:
+          SEARCH_API_BASE: https://csl860x2oj.execute-api.us-east-2.amazonaws.com/prod
+          DOC_CATALOG_SOURCE_ID: docs-tenstorrent
+          DOCS_ID_NAMESPACE: tt-metal
+          DOCS_INDEX_VERSION: ${{ inputs.version }}
+          DOCS_OUTPUT_DIR: gh_pages/${{ inputs.version }}
+          DOC_SITE_BASE_URL: https://docs.tenstorrent.com/tt-metal/${{ inputs.version }}
+        run: python3 scripts/index_remote_search.py
       - name: Check the docs deployment is up
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |

--- a/scripts/index_remote_search.py
+++ b/scripts/index_remote_search.py
@@ -45,6 +45,49 @@ def _extract_title(content: str, fallback: str) -> str:
     return _strip_html_to_text(match.group(1)) or fallback
 
 
+def _extract_article_body(content: str) -> str:
+    """Return just the main article region of a Sphinx/RTD page.
+
+    The RTD theme wraps the real page content in an element carrying
+    ``itemprop="articleBody"``; everything else (sidebar, version selector,
+    top/side navigation, footer) is boilerplate chrome that repeats on every
+    page. Indexing the whole document would put that chrome into every body and
+    make unrelated pages match on navigation terms, distorting relevance.
+
+    Falls back to the full document when no article-body marker is present
+    (e.g. custom landing pages), so nothing is silently dropped.
+    """
+    start_match = re.search(
+        r"<(\w+)\b[^>]*\bitemprop\s*=\s*[\"']articleBody[\"'][^>]*>",
+        content,
+        flags=re.IGNORECASE,
+    )
+    if not start_match:
+        return content
+
+    tag = start_match.group(1)
+    open_re = re.compile(r"<" + re.escape(tag) + r"\b", re.IGNORECASE)
+    close_re = re.compile(r"</" + re.escape(tag) + r"\s*>", re.IGNORECASE)
+
+    # Walk forward from the opening tag, tracking nesting of the same tag, to
+    # find the matching close (handles nested <section>/<div> etc.).
+    depth = 1
+    pos = start_match.end()
+    while depth > 0:
+        next_close = close_re.search(content, pos)
+        if not next_close:
+            # Unbalanced markup: take everything after the opening tag.
+            return content[start_match.end() :]
+        next_open = open_re.search(content, pos)
+        if next_open and next_open.start() < next_close.start():
+            depth += 1
+            pos = next_open.end()
+        else:
+            depth -= 1
+            pos = next_close.end()
+    return content[start_match.end() : next_close.start()]
+
+
 def _iter_html_files(output_root: Path) -> Iterable[Path]:
     for path in output_root.rglob("*.html"):
         rel = path.relative_to(output_root).as_posix()
@@ -69,7 +112,8 @@ def _build_documents(
         rel = html_file.relative_to(output_root).as_posix()
         raw = html_file.read_text(encoding="utf-8", errors="ignore")
         title = _extract_title(raw, rel)
-        body = _strip_html_to_text(raw)
+        # Index only the article body, not the surrounding navigation chrome.
+        body = _strip_html_to_text(_extract_article_body(raw))
         doc_id = f"{catalog}:{id_namespace}:{version}:{rel}"
         url = f"{site_base_url}/{rel}"
         docs.append({"id": doc_id, "title": title, "body": body, "url": url})

--- a/scripts/index_remote_search.py
+++ b/scripts/index_remote_search.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Crawl the built docs in output/ and push them to the OpenSearch-backed
+docs search service so the in-page search modal has something to query.
+
+Configured entirely through environment variables (see main()); intended to run
+as a step in the Pages deploy workflow after `python build_docs.py`."""
+
+from __future__ import annotations
+
+import html
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Iterable
+
+# Keep batches small: the indexer Lambda fans each batch out to an OpenSearch
+# _bulk call, and API Gateway caps the request at ~29s. 200 docs in one POST
+# times out (HTTP 504) on the larger catalogs; 50 stays comfortably under it.
+MAX_BATCH_SIZE = 50
+TIMEOUT_SECONDS = 30
+
+
+def _strip_html_to_text(content: str) -> str:
+    # Remove script/style blocks first so they do not pollute search text.
+    content = re.sub(r"<script\b[^>]*>.*?</script>", " ", content, flags=re.IGNORECASE | re.DOTALL)
+    content = re.sub(r"<style\b[^>]*>.*?</style>", " ", content, flags=re.IGNORECASE | re.DOTALL)
+    # Strip tags.
+    content = re.sub(r"<[^>]+>", " ", content)
+    # Decode entities and normalize whitespace.
+    content = html.unescape(content)
+    content = re.sub(r"\s+", " ", content).strip()
+    return content
+
+
+def _extract_title(content: str, fallback: str) -> str:
+    match = re.search(r"<title[^>]*>(.*?)</title>", content, flags=re.IGNORECASE | re.DOTALL)
+    if not match:
+        return fallback
+    return _strip_html_to_text(match.group(1)) or fallback
+
+
+def _iter_html_files(output_root: Path) -> Iterable[Path]:
+    for path in output_root.rglob("*.html"):
+        rel = path.relative_to(output_root).as_posix()
+        if rel.startswith("_static/") or rel.startswith("_sources/"):
+            continue
+        if "/_static/" in rel or "/_sources/" in rel:
+            continue
+        # Skip Sphinx's own search/genindex shell pages — they carry no content.
+        name = path.name
+        if name in {"search.html", "genindex.html"}:
+            continue
+        yield path
+
+
+def _build_documents(
+    output_root: Path, site_base_url: str, catalog: str, version: str, id_namespace: str
+) -> list[dict]:
+    site_base_url = site_base_url.rstrip("/")
+    docs: list[dict] = []
+
+    for html_file in _iter_html_files(output_root):
+        rel = html_file.relative_to(output_root).as_posix()
+        raw = html_file.read_text(encoding="utf-8", errors="ignore")
+        title = _extract_title(raw, rel)
+        body = _strip_html_to_text(raw)
+        doc_id = f"{catalog}:{id_namespace}:{version}:{rel}"
+        url = f"{site_base_url}/{rel}"
+        docs.append({"id": doc_id, "title": title, "body": body, "url": url})
+
+    return docs
+
+
+def _chunks(items: list[dict], size: int) -> Iterable[list[dict]]:
+    for i in range(0, len(items), size):
+        yield items[i : i + size]
+
+
+def _post_json(url: str, payload: dict, api_key: str) -> tuple[int, str]:
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url=url,
+        method="POST",
+        data=data,
+        headers={
+            "Content-Type": "application/json",
+            "x-api-key": api_key,
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=TIMEOUT_SECONDS) as response:
+            return response.getcode(), response.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as err:
+        return err.code, err.read().decode("utf-8", errors="replace")
+
+
+def main() -> int:
+    api_base = os.environ.get("SEARCH_API_BASE", "").rstrip("/")
+    source_id = os.environ.get("DOC_CATALOG_SOURCE_ID", "").strip()
+    api_key = os.environ.get("DOCS_SEARCH_INGEST_API_KEY", "").strip()
+    output_dir = os.environ.get("DOCS_OUTPUT_DIR", "output").strip()
+    site_base = os.environ.get("DOC_SITE_BASE_URL", "").rstrip("/")
+    version = os.environ.get("DOCS_INDEX_VERSION", "latest").strip()
+    id_namespace = os.environ.get("DOCS_ID_NAMESPACE", "tenstorrent").strip()
+
+    if not api_base:
+        print("Missing SEARCH_API_BASE", file=sys.stderr)
+        return 2
+    if not source_id:
+        print("Missing DOC_CATALOG_SOURCE_ID", file=sys.stderr)
+        return 2
+    if not api_key:
+        print("Missing DOCS_SEARCH_INGEST_API_KEY", file=sys.stderr)
+        return 2
+    if not site_base:
+        print("Missing DOC_SITE_BASE_URL", file=sys.stderr)
+        return 2
+    if not id_namespace:
+        print("Missing DOCS_ID_NAMESPACE", file=sys.stderr)
+        return 2
+
+    output_root = Path(output_dir)
+    if not output_root.exists():
+        print(f"Output directory not found: {output_root}", file=sys.stderr)
+        return 2
+
+    docs = _build_documents(output_root, site_base, source_id, version, id_namespace)
+    if not docs:
+        print("No HTML docs found to index.", file=sys.stderr)
+        return 1
+
+    endpoint = f"{api_base}/v1/index/{source_id}"
+    print(f"Indexing {len(docs)} documents to {endpoint}")
+
+    indexed = 0
+    for batch in _chunks(docs, MAX_BATCH_SIZE):
+        payload = {"version": version, "documents": batch}
+        status, body = _post_json(endpoint, payload, api_key)
+        if status < 200 or status >= 300:
+            print(f"Indexing failed: HTTP {status}", file=sys.stderr)
+            print(body, file=sys.stderr)
+            if status == 403:
+                print(
+                    (
+                        "Hint: DOCS_SEARCH_INGEST_API_KEY must be the API key VALUE, "
+                        "not the API key ID (for example, not '427rdpxpb6')."
+                    ),
+                    file=sys.stderr,
+                )
+            return 1
+        indexed += len(batch)
+        print(f"Indexed {indexed}/{len(docs)}")
+
+    print("Indexing complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Part 1 of 4 — the docs-frontend migration (previously #49333), split into small, independently-reviewable PRs.

## What this PR does
Adds **OpenSearch-backed full-text search indexing** for the published docs, so the in-page search box on docs.tenstorrent.com/tt-metal can return results. It is a post-deploy step: after the docs are built and pushed to GitHub Pages, the built HTML is crawled, reduced to plain text, and pushed to the docs search ingest API.

Two files:
- **`scripts/index_remote_search.py`** — a dependency-free (stdlib-only) crawler. For each built `*.html` page it extracts the title, reduces the article body to text, and POSTs the documents to the ingest API in batches. Everything is configured through environment variables; it validates required config and exits non-zero with a clear message if anything is missing.
- **`.github/workflows/docs-latest-public.yaml`** — a new **Index docs into OpenSearch** step in the existing docs deploy job.

## Why it's built this way
- **Runs only after a successful Pages deploy**, and is marked `continue-on-error` — indexing is a non-critical enhancement, so a transient ingest hiccup (timeout / 5xx) must never turn an otherwise-successful docs deploy red on `main`/release tags.
- **Secret is scoped to the indexer, not the job.** The OpenSearch write credential (`DOCS_SEARCH_INGEST_API_KEY_DOCS_TENSTORRENT`) is read only by a small trusted gate step and by the indexer step's own `env:` — never at job scope — so the third-party Pages-deploy and artifact actions in the same job can't read it. A preceding `Check OpenSearch ingest key` step sets a boolean output that gates (and warns/ skips) when the secret is absent.
- **Indexes only the article body.** The RTD theme wraps real content in `itemprop="articleBody"`; the crawler extracts just that region (falling back to the whole page when absent) so the shared sidebar / version-selector / nav / footer text isn't indexed into every page and doesn't distort search relevance.
- **Batched** to stay under the API Gateway request timeout on larger catalogs.

## Blast radius / safety
Self-contained: one new script + one additive, secret-gated, non-fatal CI step. With the secret absent the step is skipped and nothing changes. Independent of the other three split PRs.

_Updated per Copilot review: job→step secret scoping, and article-body-only extraction._

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=docs/opensearch-indexing)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:docs/opensearch-indexing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=docs/opensearch-indexing)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:docs/opensearch-indexing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=docs/opensearch-indexing)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:docs/opensearch-indexing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=docs/opensearch-indexing)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:docs/opensearch-indexing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=docs/opensearch-indexing)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:docs/opensearch-indexing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=docs/opensearch-indexing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:docs/opensearch-indexing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=docs/opensearch-indexing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:docs/opensearch-indexing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=docs/opensearch-indexing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:docs/opensearch-indexing)