### PR TITLE
[Cleanup] Remove tile config from row-major tensors in deepseek_v3_b1 tests

### DIFF
--- a/models/demos/deepseek_v3_b1/micro_ops/tilize_8x32/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/tilize_8x32/op.py
@@ -87,12 +87,16 @@ def tilize_8x32_kernel(input_tensor, output_tensor):
     in_cb = 0
     out_cb = 16  # Output operands start at 16
 
+    # tile
+    input_tile = ttnn.Tile((8, 32))
+
     # ========================================================================
     # Circular Buffer Descriptors
     # ========================================================================
 
-    # CB 0: Input (sharded tensor, row-major format)
+    # CB 0: Input (sharded tensor, row-major format).
     input_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(in_cb, input_tensor)
+    input_cb_descriptor.format_descriptors[in_cb].tile = ttnn.TileDescriptor(input_tile)
 
     # CB 16: Output (sharded tensor, tiled format)
     output_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(out_cb, output_tensor)

--- a/models/demos/deepseek_v3_b1/micro_ops/tilize_8x32/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/tilize_8x32/op.py
@@ -94,7 +94,7 @@ def tilize_8x32_kernel(input_tensor, output_tensor):
     # Circular Buffer Descriptors
     # ========================================================================
 
-    # CB 0: Input (sharded tensor, row-major format).
+    # CB 0: Input (sharded tensor, row-major format)
     input_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(in_cb, input_tensor)
     input_cb_descriptor.format_descriptors[in_cb].tile = ttnn.TileDescriptor(input_tile)
 

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_sdpa_tail.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_sdpa_tail.py
@@ -141,7 +141,7 @@ def test_sdpa_tail(device, width, block_size, num_blocks, dense, final_reduction
         layout=ttnn.TILE_LAYOUT if not untilize_out else ttnn.ROW_MAJOR_LAYOUT,
         device=device,
         memory_config=l_mem_config,
-        tile=tile,
+        tile=None if untilize_out else tile,
     )
     torch_ms_out = torch.zeros(ms_shape, dtype=torch.bfloat16)
     ttnn_ms_out = ttnn.from_torch(

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_tilize_8x32.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_tilize_8x32.py
@@ -50,10 +50,6 @@ def test_tilize_8x32(device, N):
     )
     input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, input_shard_spec)
 
-    # Input tile: 8x32 - represents the logical tile size
-    # The data is in row-major format before tilizing
-    input_tile = ttnn.Tile((8, 32))
-
     # Create input tensor - use ROW_MAJOR_LAYOUT since tilize_block expects row-major input
     # The tilize_block kernel will convert from row-major to tiled format
     ttnn_input = ttnn.from_torch(
@@ -62,7 +58,6 @@ def test_tilize_8x32(device, N):
         layout=ttnn.ROW_MAJOR_LAYOUT,
         device=device,
         memory_config=input_mem_config,
-        tile=input_tile,
     )
 
     logger.info(f"Created input tensor with shard shape {input_shard_shape}")


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
The `deepseek_v3_b1` `tilize_8x32` and `sdpa_tail` unit tests construct ROW_MAJOR tensors while passing a `tile=`, which trips the deprecation warning *"Configuring a ROW MAJOR page config with a tile configuration, this will be rejected in the future"* (Relates to #18536). ROW_MAJOR and tile are orthogonal layouts, so the tile doesn't belong on the tensor.

This PR stops passing the tile to those ROW_MAJOR tensors. For `tilize_8x32`, the tile is genuinely needed by the kernel, so it's relocated onto the input CB format descriptor (`format_descriptors[...].tile`) instead of the tensor — where the tilize kernel actually consumes it.

### Notes for reviewers
- `test_tilize_8x32.py` / `test_sdpa_tail.py`: purely drop the `tile=` on the ROW_MAJOR path (sdpa keeps it for the tiled `untilize_out=False` case).
- `micro_ops/tilize_8x32/op.py`: the 8x32 tile moves onto the input CB descriptor.

### Verificaiton:
Attempt: [here](https://github.com/tenstorrent/tt-metal/actions/runs/29459095720#step:6:17271)
The test passes, while the log "Attempting to extract tile information out of a ROW MAJOR layout..." is no longer omitted.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/fix-tile-plubming-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/fix-tile-plubming-models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/fix-tile-plubming-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/fix-tile-plubming-models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=riverwu/fix-tile-plubming-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:riverwu/fix-tile-plubming-models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/fix-tile-plubming-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/fix-tile-plubming-models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/fix-tile-plubming-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/fix-tile-plubming-models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/fix-tile-plubming-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/fix-tile-plubming-models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/fix-tile-plubming-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/fix-tile-plubming-models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/fix-tile-plubming-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/fix-tile-plubming-models)