### PR TITLE
[Cleanup] Add APIs that allow mutating DFB rd/wr pointers on 1xx 

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -38,7 +38,6 @@ using test_helpers::BindTensorParameterToKernel;
 using test_helpers::MakeMinimalDFB;
 using test_helpers::MakeMinimalGen1ComputeKernel;
 using test_helpers::MakeMinimalGen1DMKernel;
-using test_helpers::MakeMinimalReaderDMKernel;
 using test_helpers::MakeMinimalWorkUnit;
 using test_helpers::MakeShardedTensorParameter;
 
@@ -329,63 +328,36 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopback) {
 // The named-args helpers reach a compute kernel via a completely different
 // include chain than a DM kernel.
 //
-// Pipeline:
-//   Compute kernel (TRISC) — produces out_dfb. Reads named RTAs/CRTAs/CTAs +
-//       RTA/CRTA varargs; writes the XOR sum of all of them into the first
-//       uint32_t of every entry, zeros the rest.
-//   DM Consumer (NCRISC) — out_dfb → DRAM output. Positional varargs only.
+// Pipeline (compute-only; no DFB / DM consumer):
+//   Compute kernel (TRISC) — reads named RTAs/CRTAs/CTAs + RTA/CRTA varargs; PACK writes the
+//       XOR sum into L1 at the allocator base address on the compute core. Host reads that
+//       word via ReadFromDeviceL1 after LaunchProgram.
 //
-// The kernel does NOT use the unpack/math/pack tile pipeline — just raw L1 writes
-// from PACK after reserve_back. This is a plumbing test only; didn't want to
-// tangle with type conversions....
-//
-// Verification: the host arranges every named arg + every vararg so their XOR
-// equals a known target. Output DRAM should contain {target, 0, 0, …} per
-// entry, exactly. A wrong offset on any accessor → wrong sum → test fails on
-// the byte-for-byte compare.
+// Verification: the host arranges every named arg + every vararg so their XOR equals a known
+// target. A wrong offset on any accessor → wrong sum → test fails.
 
 TEST_F(ProgramSpecHWTest, NamedArgsLoopbackCompute) {
     auto mesh_device = devices_.at(0);
     IDevice* device = mesh_device->get_devices()[0];
 
-    constexpr uint32_t entry_size = 1024;
-    constexpr uint32_t num_entries_in_dfb = 4;
-    constexpr uint32_t num_transfers = 8;
-    constexpr uint32_t total_bytes = entry_size * num_transfers;
+    constexpr uint32_t entry_size = 1024;  // CTA value folded into the XOR (not a DFB size)
+    constexpr uint32_t num_tiles = 8;      // CRTA value folded into the XOR
+    const uint32_t report_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1);
 
     const NodeCoord node{0, 0};
-
-    InterleavedBufferConfig dram_config{
-        .device = device, .size = total_bytes, .page_size = total_bytes, .buffer_type = BufferType::DRAM};
-    auto output_buffer = CreateBuffer(dram_config);
 
     ProgramSpec spec;
     spec.name = "named_args_loopback_compute";
 
-    // Compute kernel: produces out_dfb. The kernel under test — exercises every
-    // named-arg accessor (RTA / CRTA / two CTAs) plus RTA + CRTA varargs.
     auto compute = MakeMinimalGen1ComputeKernel("compute");
     compute.source = "tests/tt_metal/tt_metal/test_kernels/compute/named_args_loopback_compute.cpp";
-    compute.runtime_arg_schema.runtime_arg_names = {"input_offset"};
+    compute.runtime_arg_schema.runtime_arg_names = {"input_offset", "report_addr"};
     compute.runtime_arg_schema.common_runtime_arg_names = {"num_tiles"};
     compute.advanced_options = KernelAdvancedOptions{.num_runtime_varargs = 2, .num_common_runtime_varargs = 1};
     compute.compile_time_args = {{"magic", 0xCAFE0001u}, {"entry_size", entry_size}};
 
-    // Consumer: NCRISC reads out_dfb → DRAM. Reuses dfb_accessor_loopback_consumer.cpp
-    // verbatim (positional varargs only).
-    auto consumer = MakeMinimalReaderDMKernel("consumer");
-    consumer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_consumer.cpp";
-    consumer.advanced_options.num_runtime_varargs = 3;
-
-    auto out_dfb = MakeMinimalDFB("out_dfb", entry_size, num_entries_in_dfb);
-    out_dfb.data_format_metadata = tt::DataFormat::Float16_b;
-
-    compute.dfb_bindings.push_back(ProducerOf(DFBSpecName{"out_dfb"}, "out_dfb"));
-    consumer.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"out_dfb"}, "a_dfb_named_bob"));
-
-    spec.kernels = {compute, consumer};
-    spec.dataflow_buffers = {out_dfb};
-    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", node, {"compute", "consumer"})};
+    spec.kernels = {compute};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", node, {"compute"})};
 
     Program program = MakeProgramFromSpec(*mesh_device, spec);
 
@@ -399,43 +371,31 @@ TEST_F(ProgramSpecHWTest, NamedArgsLoopbackCompute) {
     constexpr uint32_t kVararg0 = 0xAAAA1111u;
     constexpr uint32_t kVararg1 = 0xBBBB2222u;
     constexpr uint32_t kCommonVararg0 =
-        kTargetXorSum ^ kMagic ^ entry_size ^ num_transfers ^ kInputOffset ^ kVararg0 ^ kVararg1;
+        kTargetXorSum ^ kMagic ^ entry_size ^ num_tiles ^ kInputOffset ^ kVararg0 ^ kVararg1;
 
     ProgramRunArgs params;
-    params.kernel_run_args = {
-        ProgramRunArgs::KernelRunArgs{
-            .kernel = KernelSpecName{"compute"},
-            .runtime_arg_values = MakeRuntimeArgsForSingleNode(node, {{"input_offset", kInputOffset}}),
-            .common_runtime_arg_values = {{"num_tiles", num_transfers}},
-            .advanced_options =
-                AdvancedKernelRunArgs{
-                    .runtime_varargs = {{node, {kVararg0, kVararg1}}},
-                    .common_runtime_varargs = {kCommonVararg0},
-                },
-        },
-        ProgramRunArgs::KernelRunArgs{
-            .kernel = KernelSpecName{"consumer"},
-            .advanced_options =
-                AdvancedKernelRunArgs{
-                    .runtime_varargs = {{node, {output_buffer->address(), 0u, num_transfers}}},
-                },
-        },
-    };
+    params.kernel_run_args = {ProgramRunArgs::KernelRunArgs{
+        .kernel = KernelSpecName{"compute"},
+        .runtime_arg_values =
+            MakeRuntimeArgsForSingleNode(node, {{"input_offset", kInputOffset}, {"report_addr", report_addr}}),
+        .common_runtime_arg_values = {{"num_tiles", num_tiles}},
+        .advanced_options =
+            AdvancedKernelRunArgs{
+                .runtime_varargs = {{node, {kVararg0, kVararg1}}},
+                .common_runtime_varargs = {kCommonVararg0},
+            },
+    }};
     SetProgramRunArgs(program, params);
+
+    std::vector<uint32_t> zero_report(1, 0u);
+    detail::WriteToDeviceL1(device, node, report_addr, zero_report);
 
     detail::LaunchProgram(device, program);
 
-    std::vector<uint32_t> output_data;
-    detail::ReadFromBuffer(output_buffer, output_data);
-
-    constexpr uint32_t words_per_entry = entry_size / sizeof(uint32_t);
-    std::vector<uint32_t> expected(total_bytes / sizeof(uint32_t), 0u);
-    for (uint32_t e = 0; e < num_transfers; ++e) {
-        expected[e * words_per_entry] = kTargetXorSum;
-    }
-
-    ASSERT_EQ(output_data.size(), expected.size());
-    EXPECT_EQ(output_data, expected);
+    std::vector<uint32_t> reported;
+    detail::ReadFromDeviceL1(device, node, report_addr, sizeof(uint32_t), reported);
+    ASSERT_EQ(reported.size(), 1u);
+    EXPECT_EQ(reported[0], kTargetXorSum);
 }
 
 // ============================================================================
@@ -532,91 +492,60 @@ TEST_F(ProgramSpecHWTest, TtKernelNamedArgsLoopback) {
 // The TT_KERNEL counterpart to NamedArgsLoopbackCompute, and the test that proves the generated
 // kernel_main() shim is emitted on the COMPUTE (TRISC) compile path — the gap fixed by routing
 // both genfiles paths through the shared shim helper. The compute kernel is authored in TT_KERNEL
-// form (magic/entry_size as template CTAs; input_offset (RTA) and num_tiles (CRTA) as function
-// params); the DM consumer reuses the existing positional-vararg DFB consumer verbatim.
+// form (magic/entry_size as template CTAs; input_offset + report_addr (RTAs) and num_tiles (CRTA)
+// as function params). No DFB — PACK writes the XOR into L1 at the allocator base address on the
+// compute core (same ReadFromDeviceL1 idiom as NamedArgsLoopbackCompute).
 //
-// Verification: the kernel writes magic ^ entry_size ^ input_offset ^ num_tiles into word 0 of
-// every entry; the host solves input_offset so the XOR equals a known target. A wrong binding on
-// the compute path → wrong sum → wrong DRAM word → test fails.
+// Verification: the host solves input_offset so magic ^ entry_size ^ input_offset ^ num_tiles
+// equals a known target. A wrong binding on the compute path → wrong sum → test fails.
 
 TEST_F(ProgramSpecHWTest, TtKernelNamedArgsLoopbackCompute) {
     auto mesh_device = devices_.at(0);
     IDevice* device = mesh_device->get_devices()[0];
 
-    constexpr uint32_t entry_size = 1024;
-    constexpr uint32_t num_entries_in_dfb = 4;
-    constexpr uint32_t num_transfers = 8;
-    constexpr uint32_t total_bytes = entry_size * num_transfers;
+    constexpr uint32_t entry_size = 1024;  // CTA value folded into the XOR (not a DFB size)
+    constexpr uint32_t num_tiles = 8;      // CRTA value folded into the XOR
+    const uint32_t report_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1);
 
     const NodeCoord node{0, 0};
-
-    InterleavedBufferConfig dram_config{
-        .device = device, .size = total_bytes, .page_size = total_bytes, .buffer_type = BufferType::DRAM};
-    auto output_buffer = CreateBuffer(dram_config);
 
     ProgramSpec spec;
     spec.name = "tt_kernel_named_args_loopback_compute";
 
-    // Compute kernel authored in TT_KERNEL form. magic/entry_size are template params (CTAs);
-    // input_offset (RTA) and num_tiles (CRTA) are function params. No varargs.
     auto compute = MakeMinimalGen1ComputeKernel("compute");
     compute.source = "tests/tt_metal/tt_metal/test_kernels/compute/tt_kernel_named_args_compute.cpp";
-    compute.runtime_arg_schema.runtime_arg_names = {"input_offset"};
+    compute.runtime_arg_schema.runtime_arg_names = {"input_offset", "report_addr"};
     compute.runtime_arg_schema.common_runtime_arg_names = {"num_tiles"};
     compute.compile_time_args = {{"magic", 0xCAFE0001u}, {"entry_size", entry_size}};
 
-    // Consumer: NCRISC reads out_dfb → DRAM. Reuses the existing positional-vararg consumer.
-    auto consumer = MakeMinimalReaderDMKernel("consumer");
-    consumer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_consumer.cpp";
-    consumer.advanced_options.num_runtime_varargs = 3;
-
-    auto out_dfb = MakeMinimalDFB("out_dfb", entry_size, num_entries_in_dfb);
-    out_dfb.data_format_metadata = tt::DataFormat::Float16_b;
-
-    compute.dfb_bindings.push_back(ProducerOf(DFBSpecName{"out_dfb"}, "out_dfb"));
-    consumer.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"out_dfb"}, "a_dfb_named_bob"));
-
-    spec.kernels = {compute, consumer};
-    spec.dataflow_buffers = {out_dfb};
-    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", node, {"compute", "consumer"})};
+    spec.kernels = {compute};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", node, {"compute"})};
 
     Program program = MakeProgramFromSpec(*mesh_device, spec);
 
     // sum = magic ^ entry_size ^ input_offset ^ num_tiles. Solve input_offset for a known target.
     constexpr uint32_t kTargetXorSum = 0xDEADBEEFu;
     constexpr uint32_t kMagic = 0xCAFE0001u;
-    constexpr uint32_t kInputOffset = kTargetXorSum ^ kMagic ^ entry_size ^ num_transfers;
+    constexpr uint32_t kInputOffset = kTargetXorSum ^ kMagic ^ entry_size ^ num_tiles;
 
     ProgramRunArgs params;
-    params.kernel_run_args = {
-        ProgramRunArgs::KernelRunArgs{
-            .kernel = KernelSpecName{"compute"},
-            .runtime_arg_values = MakeRuntimeArgsForSingleNode(node, {{"input_offset", kInputOffset}}),
-            .common_runtime_arg_values = {{"num_tiles", num_transfers}},
-        },
-        ProgramRunArgs::KernelRunArgs{
-            .kernel = KernelSpecName{"consumer"},
-            .advanced_options =
-                AdvancedKernelRunArgs{
-                    .runtime_varargs = {{node, {output_buffer->address(), 0u, num_transfers}}},
-                },
-        },
-    };
+    params.kernel_run_args = {ProgramRunArgs::KernelRunArgs{
+        .kernel = KernelSpecName{"compute"},
+        .runtime_arg_values =
+            MakeRuntimeArgsForSingleNode(node, {{"input_offset", kInputOffset}, {"report_addr", report_addr}}),
+        .common_runtime_arg_values = {{"num_tiles", num_tiles}},
+    }};
     SetProgramRunArgs(program, params);
+
+    std::vector<uint32_t> zero_report(1, 0u);
+    detail::WriteToDeviceL1(device, node, report_addr, zero_report);
 
     detail::LaunchProgram(device, program);
 
-    std::vector<uint32_t> output_data;
-    detail::ReadFromBuffer(output_buffer, output_data);
-
-    constexpr uint32_t words_per_entry = entry_size / sizeof(uint32_t);
-    std::vector<uint32_t> expected(total_bytes / sizeof(uint32_t), 0u);
-    for (uint32_t e = 0; e < num_transfers; ++e) {
-        expected[e * words_per_entry] = kTargetXorSum;
-    }
-
-    ASSERT_EQ(output_data.size(), expected.size());
-    EXPECT_EQ(output_data, expected);
+    std::vector<uint32_t> reported;
+    detail::ReadFromDeviceL1(device, node, report_addr, sizeof(uint32_t), reported);
+    ASSERT_EQ(reported.size(), 1u);
+    EXPECT_EQ(reported[0], kTargetXorSum);
 }
 
 // ============================================================================
@@ -842,11 +771,11 @@ TEST_F(ProgramSpecHWTest, TensorAccessorBindingLoopback) {
 //   3. The binding's base-address CRTA is broadcast to the compute kernel and resolves to the local
 //      L1 shard address — verified by comparing the reported address to the bound tensor's address.
 //
-// Pipeline (compute-only producer, no DM producer needed):
+// Pipeline (compute-only; no DFB / DM consumer):
 //   Compute kernel (TRISC) — constructs LocalTensorAccessor (token ctor) and a second via the legacy
-//       base-address ctor, deposits {base_address, get_unsafe_ptr, &operator[], legacy-ctor base} into
-//       each out_dfb entry (raw L1 writes from PACK); all four should equal the bound tensor's address.
-//   DM consumer (NCRISC)   — out_dfb → DRAM output.
+//       base-address ctor; PACK writes {base_address, get_unsafe_ptr, &operator[], legacy-ctor base}
+//       into a host-known L1 report buffer (named RTA). All four should equal the bound tensor's
+//       address. Host reads the report via ReadFromDeviceL1 after LaunchProgram.
 //
 // The tensor is a single-shard L1 tensor on core (0,0) (the compute kernel's core), so its shard base
 // address equals MeshTensor::address(). No dereference of the shard occurs (address-of only), so the
@@ -856,16 +785,10 @@ TEST_F(ProgramSpecHWTest, LocalTensorAccessorBindingCompileComputeKernel) {
     auto mesh_device = devices_.at(0);
     IDevice* device = mesh_device->get_devices()[0];
 
-    constexpr uint32_t entry_size = 1024;
-    constexpr uint32_t num_entries_in_dfb = 4;
-    constexpr uint32_t num_tiles = 2;  // entries the compute kernel pushes
-    constexpr uint32_t total_bytes = entry_size * num_tiles;
+    constexpr uint32_t kReportAddr = 100 * 1024;  // host-known fixed L1 addr (same idiom as ScratchpadWriteReadback)
+    constexpr uint32_t kNumReportWords = 4;
 
     const NodeCoord node{0, 0};
-
-    InterleavedBufferConfig dram_config{
-        .device = device, .size = total_bytes, .page_size = total_bytes, .buffer_type = BufferType::DRAM};
-    auto output_buffer = CreateBuffer(dram_config);
 
     // Single-shard L1 tensor on core (0,0): one 32x32 BFLOAT16 tile.
     auto tensor_param = MakeShardedTensorParameter("local_t", Shape{32, 32}, {32, 32}, /*num_cores=*/1);
@@ -874,61 +797,41 @@ TEST_F(ProgramSpecHWTest, LocalTensorAccessorBindingCompileComputeKernel) {
     ProgramSpec spec;
     spec.name = "local_tensor_accessor_compute";
 
-    // Compute kernel (the kernel under test) — binds the tensor, produces into out_dfb.
     auto compute = MakeMinimalGen1ComputeKernel("compute");
     compute.source = "tests/tt_metal/tt_metal/test_kernels/compute/local_tensor_accessor_compute.cpp";
-    compute.compile_time_args = {{"entry_size", entry_size}, {"num_tiles", num_tiles}};
+    compute.runtime_arg_schema.runtime_arg_names = {"report_addr"};
     BindTensorParameterToKernel(compute, "local_t", "local_t");
 
-    // Consumer (NCRISC): drains out_dfb → DRAM. Reuses dfb_accessor_loopback_consumer.cpp verbatim.
-    auto consumer = MakeMinimalReaderDMKernel("consumer");
-    consumer.source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_consumer.cpp";
-    consumer.advanced_options.num_runtime_varargs = 3;
-
-    auto out_dfb = MakeMinimalDFB("out_dfb", entry_size, num_entries_in_dfb);
-    out_dfb.data_format_metadata = tt::DataFormat::Float16_b;
-
-    compute.dfb_bindings.push_back(ProducerOf(DFBSpecName{"out_dfb"}, "out_dfb"));
-    consumer.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"out_dfb"}, "a_dfb_named_bob"));
-
-    spec.kernels = {compute, consumer};
-    spec.dataflow_buffers = {out_dfb};
+    spec.kernels = {compute};
     spec.tensor_parameters = {tensor_param};
-    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", node, {"compute", "consumer"})};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", node, {"compute"})};
 
     Program program = MakeProgramFromSpec(*mesh_device, spec);
 
     ProgramRunArgs params;
-    params.kernel_run_args = {
-        ProgramRunArgs::KernelRunArgs{.kernel = KernelSpecName{"compute"}},
-        ProgramRunArgs::KernelRunArgs{
-            .kernel = KernelSpecName{"consumer"},
-            .advanced_options =
-                AdvancedKernelRunArgs{
-                    .runtime_varargs = {{node, {output_buffer->address(), 0u, num_tiles}}},
-                },
-        },
-    };
+    params.kernel_run_args = {ProgramRunArgs::KernelRunArgs{
+        .kernel = KernelSpecName{"compute"},
+        .runtime_arg_values = MakeRuntimeArgsForSingleNode(node, {{"report_addr", kReportAddr}}),
+    }};
     params.tensor_args = {
         {TensorParamName{"local_t"}, TensorArgument{local_tensor}},
     };
     SetProgramRunArgs(program, params);
 
+    std::vector<uint32_t> zero_report(kNumReportWords, 0u);
+    detail::WriteToDeviceL1(device, node, kReportAddr, zero_report);
+
     detail::LaunchProgram(device, program);
 
-    std::vector<uint32_t> output_data;
-    detail::ReadFromBuffer(output_buffer, output_data);
+    std::vector<uint32_t> reported;
+    detail::ReadFromDeviceL1(device, node, kReportAddr, kNumReportWords * sizeof(uint32_t), reported);
+    ASSERT_EQ(reported.size(), kNumReportWords);
 
     const uint32_t expected_address = static_cast<uint32_t>(local_tensor.address());
-    constexpr uint32_t words_per_entry = entry_size / sizeof(uint32_t);
-    ASSERT_EQ(output_data.size(), total_bytes / sizeof(uint32_t));
-    for (uint32_t e = 0; e < num_tiles; ++e) {
-        const uint32_t* entry = output_data.data() + e * words_per_entry;
-        EXPECT_EQ(entry[0], expected_address) << "entry " << e << ": get_bank_base_address mismatch";
-        EXPECT_EQ(entry[1], expected_address) << "entry " << e << ": get_unsafe_ptr mismatch";
-        EXPECT_EQ(entry[2], expected_address) << "entry " << e << ": &operator[] mismatch";
-        EXPECT_EQ(entry[3], expected_address) << "entry " << e << ": legacy base-address ctor mismatch";
-    }
+    EXPECT_EQ(reported[0], expected_address) << "get_bank_base_address mismatch";
+    EXPECT_EQ(reported[1], expected_address) << "get_unsafe_ptr mismatch";
+    EXPECT_EQ(reported[2], expected_address) << "&operator[] mismatch";
+    EXPECT_EQ(reported[3], expected_address) << "legacy base-address ctor mismatch";
 }
 
 // ============================================================================
@@ -1136,6 +1039,7 @@ TEST_F(ProgramSpecHWTest, CrtaAllFourSectionsSetAndPartialUpdate) {
     auto producer = MakeMinimalGen1DMKernel("producer", DataMovementProcessor::RISCV_0);
     producer.source = KernelSpec::SourceCode{R"(
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "experimental/kernel_args.h"
 void kernel_main() {
     const uint32_t named0 = get_arg(args::named0);
@@ -1165,15 +1069,19 @@ void kernel_main() {
     auto consumer = MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
     consumer.source = KernelSpec::SourceCode{R"(
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/dataflow/noc.h"
 #include "experimental/kernel_args.h"
 void kernel_main() {
     auto dst_addr = get_arg(args::dst_addr);
     auto bank_id = get_arg(args::bank_id);
+    Noc noc;
+    AllocatorBank<AllocatorBankType::DRAM> dram_dst;
     DataflowBuffer buf(dfb::stage);
     buf.wait_front(1);
-    uint64_t dst_noc_addr = get_noc_addr_from_bank_id<true>(bank_id, dst_addr);
-    noc_async_write(buf.get_read_ptr(), dst_noc_addr, buf.get_entry_size());
-    noc_async_write_barrier();
+    noc.async_write(buf, dram_dst, buf.get_entry_size(), {}, {.bank_id = bank_id, .addr = dst_addr});
+    noc.async_write_barrier();
     buf.pop_front(1);
 }
 )"};
@@ -1329,6 +1237,7 @@ TEST_F(ProgramSpecHWTest, ScratchpadBaseReDeliveredAfterDfbResize) {
     auto producer = MakeMinimalGen1DMKernel("producer", DataMovementProcessor::RISCV_0);
     producer.source = KernelSpec::SourceCode{R"(
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "experimental/kernel_args.h"
 void kernel_main() {
     Scratchpad<uint32_t> pad(scratch::pad);
@@ -1350,15 +1259,19 @@ void kernel_main() {
     auto consumer = MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
     consumer.source = KernelSpec::SourceCode{R"(
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/dataflow/noc.h"
 #include "experimental/kernel_args.h"
 void kernel_main() {
     auto dst_addr = get_arg(args::dst_addr);
     auto bank_id = get_arg(args::bank_id);
+    Noc noc;
+    AllocatorBank<AllocatorBankType::DRAM> dram_dst;
     DataflowBuffer buf(dfb::stage);
     buf.wait_front(1);
-    uint64_t dst_noc_addr = get_noc_addr_from_bank_id<true>(bank_id, dst_addr);
-    noc_async_write(buf.get_read_ptr(), dst_noc_addr, buf.get_entry_size());
-    noc_async_write_barrier();
+    noc.async_write(buf, dram_dst, buf.get_entry_size(), {}, {.bank_id = bank_id, .addr = dst_addr});
+    noc.async_write_barrier();
     buf.pop_front(1);
 }
 )"};

--- a/tests/tt_metal/tt_metal/test_kernels/compute/local_tensor_accessor_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/local_tensor_accessor_compute.cpp
@@ -11,8 +11,8 @@
 //
 // The accessor is constructed on all three TRISC threads (UNPACK/MATH/PACK) — the strongest compile
 // proof — and its full surface (get_bank_base_address / local_mem / operator[]) is exercised so every
-// method is instantiated. The PACK thread deposits the reported values into each output DFB entry; a
-// DM consumer carries them to DRAM for host verification.
+// method is instantiated. The PACK thread deposits the reported values into a host-known L1 report
+// buffer (named RTA); the host reads that L1 after launch.
 //
 // The host checks that the reported base address equals the bound tensor's address — proving the
 // binding token reached the compute kernel and resolved to the correct local L1 shard address. The
@@ -22,14 +22,11 @@
 #include <cstdint>
 
 #include "api/compute/common.h"
-#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/local_tensor_accessor.h"
 #include "experimental/kernel_args.h"
 
 void kernel_main() {
-    // CTAs — compile-time constants.
-    constexpr uint32_t entry_size = get_arg(args::entry_size);
-    constexpr uint32_t num_tiles = get_arg(args::num_tiles);
+    const uint32_t report_addr = get_arg(args::report_addr);
 
     // Construct on every TRISC thread (the binding's base-address CRTA is broadcast to all three).
     LocalTensorAccessor<uint32_t> acc(tensor::local_t);
@@ -46,27 +43,12 @@ void kernel_main() {
     LocalTensorAccessor<uint32_t> acc_legacy(base_address);
     const uint32_t legacy_base = acc_legacy.get_bank_base_address();
 
-    DataflowBuffer dfb_out(dfb::out_dfb);
-
-    for (uint32_t t = 0; t < num_tiles; ++t) {
-        dfb_out.reserve_back(1);  // implementation gates this to PACK only
-
-        // PACK is the only TRISC that populates the L1 slot. On tt-1xx TRISCs, fifo_wr_ptr is a
-        // 16-byte unit address; shift left 4 to get a byte address (mirrors named_args_loopback_compute).
+    // Single writer so UNPACK/MATH/PACK do not race the report slot.
 #ifdef TRISC_PACK
-        {
-            volatile tt_l1_ptr uint32_t* out_ptr = (volatile tt_l1_ptr uint32_t*)(dfb_out.get_write_ptr() << 4);
-            out_ptr[0] = base_address;
-            out_ptr[1] = via_unsafe_ptr;
-            out_ptr[2] = via_subscript;
-            out_ptr[3] = legacy_base;
-            const uint32_t words = entry_size / sizeof(uint32_t);
-            for (uint32_t w = 4; w < words; ++w) {
-                out_ptr[w] = 0;
-            }
-        }
+    volatile tt_l1_ptr uint32_t* out_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(report_addr);
+    out_ptr[0] = base_address;
+    out_ptr[1] = via_unsafe_ptr;
+    out_ptr[2] = via_subscript;
+    out_ptr[3] = legacy_base;
 #endif
-
-        dfb_out.push_back(1);  // implementation gates this to PACK only
-    }
 }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/named_args_loopback_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/named_args_loopback_compute.cpp
@@ -3,16 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Test kernel: Metal 2.0 named-args producer (compute side).
-// Acts as the producer of an output DFB: every entry it pushes contains the
-// XOR sum of every named arg + vararg the kernel was given, deposited into the
-// first uint32_t of the entry's L1 slot. A DM consumer carries those entries
-// to a DRAM buffer the host can verify byte-for-byte.
-//
-// Companion test on the COMPUTE compile path (TRISC_UNPACK / TRISC_MATH /
-// TRISC_PACK) for the existing dataflow named_args_loopback pair, which only
-// covers the BRISC/NCRISC compile path. The named-args surface reaches a
-// compute kernel via a different include chain (compute_kernel_api.h →
-// api/compute/common.h) than DM (api/dataflow/dataflow_api.h), and
+// Companion test on the COMPUTE compile path (TRISC_UNPACK / TRISC_MATH / TRISC_PACK) for the
+// existing dataflow named_args_loopback pair, which only covers the BRISC/NCRISC compile path.
+// The named-args surface reaches a compute kernel via a different include chain
+// (compute_kernel_api.h → api/compute/common.h) than DM (api/dataflow/dataflow_api.h), and
 // experimental/kernel_args.h must work in both contexts.
 //
 // Exercises the Metal 2.0 kernel-args feature surface:
@@ -20,58 +14,32 @@
 //   args::entry_size   — named CTA (compile-time)
 //   args::num_tiles    — named CRTA (broadcast at runtime)
 //   args::input_offset — named RTA (per-node at runtime)
+//   args::report_addr  — named RTA; host-allocated L1 word for the XOR result
 //   get_vararg(0..1)   — two RTA varargs
 //   get_common_vararg(0) — one CRTA vararg
 //
-// Verification: the host arranges all six values so their XOR equals a known
-// target. The output DRAM should contain that target in word 0 of every
-// entry, with the rest zeroed. A wrong offset on any accessor → wrong sum →
-// wrong word in DRAM output → test fails. (No tile compute pipeline is
-// involved — the kernel writes raw bytes to the output DFB's L1 slot, which
-// avoids Float16_b lossy conversion and inter-TRISC sync issues that aren't
-// what this test is trying to cover.)
+// Verification: the host arranges all six values so their XOR equals a known target. PACK writes
+// that XOR into report_addr; the host reads that L1 word after LaunchProgram. A wrong offset on any
+// accessor → wrong sum → test fails.
 
 #include <cstdint>
 
 #include "api/compute/common.h"
-#include "api/dataflow/dataflow_buffer.h"
 #include "experimental/kernel_args.h"
 
 void kernel_main() {
-    // CTAs — compile-time constants, so the constexpr form is legal here.
     constexpr uint32_t magic = get_arg(args::magic);
     constexpr uint32_t entry_size = get_arg(args::entry_size);
 
-    // CRTA (broadcast at runtime)
     const uint32_t num_tiles = get_arg(args::num_tiles);
-
-    // RTA (per-node at runtime)
     const uint32_t input_offset = get_arg(args::input_offset);
+    const uint32_t report_addr = get_arg(args::report_addr);
 
-    // XOR every named arg + every vararg — exercises all six accessor paths.
     const uint32_t vararg_xor =
         magic ^ entry_size ^ num_tiles ^ input_offset ^ get_vararg(0) ^ get_vararg(1) ^ get_common_vararg(0);
 
-    DataflowBuffer dfb_out(dfb::out_dfb);
-
-    for (uint32_t t = 0; t < num_tiles; ++t) {
-        dfb_out.reserve_back(1);  // implementation gates this to PACK only
-
-        // PACK is the only TRISC that needs to populate the L1 slot — the
-        // others reach reserve_back / push_back as no-ops via the impl gates.
-        // On tt-1xx TRISCs, fifo_wr_ptr is stored as a 16-byte unit address;
-        // shift left 4 to get a byte address for L1 access.
 #ifdef TRISC_PACK
-        {
-            volatile tt_l1_ptr uint32_t* out_ptr = (volatile tt_l1_ptr uint32_t*)(dfb_out.get_write_ptr() << 4);
-            out_ptr[0] = vararg_xor;
-            const uint32_t words = entry_size / sizeof(uint32_t);
-            for (uint32_t w = 1; w < words; ++w) {
-                out_ptr[w] = 0;
-            }
-        }
+    volatile tt_l1_ptr uint32_t* out_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(report_addr);
+    out_ptr[0] = vararg_xor;
 #endif
-
-        dfb_out.push_back(1);  // implementation gates this to PACK only
-    }
 }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/tt_kernel_named_args_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/tt_kernel_named_args_compute.cpp
@@ -15,46 +15,29 @@
 //   magic        — CTA (template parameter, compile-time)
 //   entry_size   — CTA (template parameter, compile-time)
 //   input_offset — RTA (function parameter, per-node)
+//   report_addr  — RTA; host-allocated L1 word for the XOR result
 //   num_tiles    — CRTA (function parameter, broadcast)
 //
-// Verification: writes magic ^ entry_size ^ input_offset ^ num_tiles into the first uint32_t of
-// every out_dfb entry (rest zeroed). The host arranges the values so that XOR equals a known
-// target; a wrong arg binding → wrong sum → wrong DRAM word → test fails. (No tile pipeline —
-// raw L1 writes from PACK, same as the named_args_loopback_compute baseline.)
+// Verification: PACK writes magic ^ entry_size ^ input_offset ^ num_tiles into report_addr. The
+// host arranges the values so that XOR equals a known target; a wrong arg binding → wrong sum →
+// test fails.
 
 #include <cstdint>
 
 #include "api/compute/common.h"
-#include "api/dataflow/dataflow_buffer.h"
-#include "experimental/kernel_args.h"  // provides TT_KERNEL, get_arg, the args:: / dfb:: accessors
+#include "experimental/kernel_args.h"  // provides TT_KERNEL, get_arg, the args:: accessors
 
 template <uint32_t magic, uint32_t entry_size>  // CTAs (compile-time)
 TT_KERNEL void loopback_compute(
     uint32_t input_offset,  // RTA (per-node)
+    uint32_t report_addr,   // RTA (host L1 report word)
     uint32_t num_tiles) {   // CRTA (broadcast)
     const uint32_t sum = magic ^ entry_size ^ input_offset ^ num_tiles;
 
-    DataflowBuffer dfb_out(dfb::out_dfb);
-
-    for (uint32_t t = 0; t < num_tiles; ++t) {
-        dfb_out.reserve_back(1);  // implementation gates this to PACK only
-
-        // PACK is the only TRISC that needs to populate the L1 slot — the others reach
-        // reserve_back / push_back as no-ops via the impl gates. On tt-1xx TRISCs, fifo_wr_ptr is
-        // stored as a 16-byte unit address; shift left 4 to get a byte address for L1 access.
 #ifdef TRISC_PACK
-        {
-            volatile tt_l1_ptr uint32_t* out_ptr = (volatile tt_l1_ptr uint32_t*)(dfb_out.get_write_ptr() << 4);
-            out_ptr[0] = sum;
-            const uint32_t words = entry_size / sizeof(uint32_t);
-            for (uint32_t w = 1; w < words; ++w) {
-                out_ptr[w] = 0;
-            }
-        }
+    volatile tt_l1_ptr uint32_t* out_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(report_addr);
+    out_ptr[0] = sum;
 #endif
-
-        dfb_out.push_back(1);  // implementation gates this to PACK only
-    }
 }
 
 // No kernel_main() here — genfiles generates it from this signature (the compute path now wires

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_consumer.cpp
@@ -12,21 +12,24 @@
 //   arg 2: number of entries to transfer
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/dataflow/noc.h"
 
 void kernel_main() {
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
     uint32_t bank_id = get_arg_val<uint32_t>(1);
     uint32_t num_entries = get_arg_val<uint32_t>(2);
 
-    // Construct the DataflowBuffer using the named accessor from kernel_bindings_generated.h
+    Noc noc;
+    AllocatorBank<AllocatorBankType::DRAM> dram_dst;
     DataflowBuffer buf(dfb::a_dfb_named_bob);
     uint32_t entry_size = buf.get_entry_size();
 
     for (uint32_t i = 0; i < num_entries; i++) {
         buf.wait_front(1);
-        uint64_t dst_noc_addr = get_noc_addr_from_bank_id<true>(bank_id, dst_addr);
-        noc_async_write(buf.get_read_ptr(), dst_noc_addr, entry_size);
-        noc_async_write_barrier();
+        noc.async_write(buf, dram_dst, entry_size, {}, {.bank_id = bank_id, .addr = dst_addr});
+        noc.async_write_barrier();
         buf.pop_front(1);
         dst_addr += entry_size;
     }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_accessor_loopback_producer.cpp
@@ -12,21 +12,24 @@
 //   arg 2: number of entries to transfer
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/dataflow/noc.h"
 
 void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);
     uint32_t bank_id = get_arg_val<uint32_t>(1);
     uint32_t num_entries = get_arg_val<uint32_t>(2);
 
-    // Construct the DataflowBuffer using the named accessor from kernel_bindings_generated.h
+    Noc noc;
+    AllocatorBank<AllocatorBankType::DRAM> dram_src;
     DataflowBuffer buf(dfb::my_local_dfb_name);
     uint32_t entry_size = buf.get_entry_size();
 
     for (uint32_t i = 0; i < num_entries; i++) {
         buf.reserve_back(1);
-        uint64_t src_noc_addr = get_noc_addr_from_bank_id<true>(bank_id, src_addr);
-        noc_async_read(src_noc_addr, buf.get_write_ptr(), entry_size);
-        noc_async_read_barrier();
+        noc.async_read(dram_src, buf, entry_size, {.bank_id = bank_id, .addr = src_addr}, {});
+        noc.async_read_barrier();
         buf.push_back(1);
         src_addr += entry_size;
     }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/named_args_loopback_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/named_args_loopback_consumer.cpp
@@ -17,6 +17,9 @@
 // See the producer source for the XOR-cancellation verification trick.
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/dataflow/noc.h"
 #include "experimental/kernel_args.h"
 
 void kernel_main() {
@@ -31,6 +34,8 @@ void kernel_main() {
     // entry survives round-trip. A wrong offset in either kernel breaks the cancellation.
     const uint32_t vararg_xor = get_vararg(0) ^ get_vararg(1) ^ get_common_vararg(0);
 
+    Noc noc;
+    AllocatorBank<AllocatorBankType::DRAM> dram_dst;
     DataflowBuffer buf(dfb::loopback_dfb);
 
     for (uint32_t i = 0; i < num_entries; i++) {
@@ -38,9 +43,8 @@ void kernel_main() {
         // Unfold the producer's XOR by applying our (equal) sum to the same word.
         volatile tt_l1_ptr uint32_t* dfb_read_ptr = (volatile tt_l1_ptr uint32_t*)buf.get_read_ptr();
         dfb_read_ptr[0] ^= vararg_xor;
-        uint64_t dst_noc_addr = get_noc_addr_from_bank_id<true>(bank_id, dst_addr);
-        noc_async_write(buf.get_read_ptr(), dst_noc_addr, entry_size);
-        noc_async_write_barrier();
+        noc.async_write(buf, dram_dst, entry_size, {}, {.bank_id = bank_id, .addr = dst_addr});
+        noc.async_write_barrier();
         buf.pop_front(1);
         dst_addr += entry_size;
     }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/named_args_loopback_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/named_args_loopback_producer.cpp
@@ -21,6 +21,9 @@
 // return the wrong word, flip bits in the sum, scramble the first word, and fail the test.
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/dataflow/noc.h"
 #include "experimental/kernel_args.h"
 
 void kernel_main() {
@@ -39,13 +42,14 @@ void kernel_main() {
     // word of each DFB entry will end up corrupted in the DRAM output buffer.
     const uint32_t vararg_xor = get_vararg(0) ^ get_vararg(1) ^ get_vararg(2) ^ get_common_vararg(0);
 
+    Noc noc;
+    AllocatorBank<AllocatorBankType::DRAM> dram_src;
     DataflowBuffer buf(dfb::loopback_dfb);
 
     for (uint32_t i = 0; i < num_entries; i++) {
         buf.reserve_back(1);
-        uint64_t src_noc_addr = get_noc_addr_from_bank_id<true>(bank_id, src_addr);
-        noc_async_read(src_noc_addr, buf.get_write_ptr(), entry_size);
-        noc_async_read_barrier();
+        noc.async_read(dram_src, buf, entry_size, {.bank_id = bank_id, .addr = src_addr}, {});
+        noc.async_read_barrier();
         // Fold vararg sum into the first word of this entry — the consumer will XOR
         // its own sum into the same word on read.
         volatile tt_l1_ptr uint32_t* dfb_write_ptr = (volatile tt_l1_ptr uint32_t*)buf.get_write_ptr();

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_8bank_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_8bank_2_0.cpp
@@ -19,9 +19,7 @@ void generate_bcast_scaler() {
     u.u = scaler;
     constexpr uint32_t onetile = 1;
     dfb1.reserve_back(onetile);
-    // On Quasar, dfb.get_write_ptr() returns a cacheable-alias L1 address; the noncacheable
-    // alias is reached by adding MEMORY_PORT_NONCACHEABLE_MEM_PORT_MEM_BASE_ADDR. On Gen1 the
-    // returned pointer is already usable; the macro doesn't exist there.
+    // Local L1 fill of the reserved entry (data peek — not a NOC transfer endpoint).
 #ifdef ARCH_QUASAR
     auto ptr = reinterpret_cast<uint16_t*>(dfb1.get_write_ptr() + MEMORY_PORT_NONCACHEABLE_MEM_PORT_MEM_BASE_ADDR);
 #else
@@ -68,17 +66,9 @@ void kernel_main() {
     for (uint32_t i = 0; i < num_tiles; i += blk) {
         uint32_t rem = blk;
         dfb0.reserve_back(rem);
-#ifdef ARCH_QUASAR
-        uint32_t l1_write_addr = dfb0.get_write_ptr() + MEMORY_PORT_NONCACHEABLE_MEM_PORT_MEM_BASE_ADDR;
-#else
-        uint32_t l1_write_addr = dfb0.get_write_ptr();
-#endif
 
         for (uint32_t r = 0; r < rem; r++) {
-            uint64_t src_noc_addr =
-                src_a.get_noc_addr(i + r + tile_offset);  // not contiguous for sequential r, can be banked
-            auto addr = l1_write_addr + (r * tile_bytes);
-            noc_async_read(src_noc_addr, addr, tile_bytes);
+            noc.async_read(src_a, dfb0, tile_bytes, {.page_id = i + r + tile_offset}, {.offset_bytes = r * tile_bytes});
         }
         noc.async_read_barrier();
         dfb0.push_back(rem);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/tensor_accessor_loopback_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/tensor_accessor_loopback_consumer.cpp
@@ -11,19 +11,22 @@
 //   arg 0: number of pages to transfer
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/dataflow/noc.h"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
     uint32_t num_pages = get_arg_val<uint32_t>(0);
 
+    Noc noc;
     TensorAccessor accessor(tensor::output_tensor);
     DataflowBuffer buf(dfb::input_dfb);
     uint32_t entry_size = buf.get_entry_size();
 
     for (uint32_t page_id = 0; page_id < num_pages; page_id++) {
         buf.wait_front(1);
-        uint64_t dst_noc_addr = accessor.get_noc_addr(page_id);
-        noc_async_write(buf.get_read_ptr(), dst_noc_addr, entry_size);
-        noc_async_write_barrier();
+        noc.async_write(buf, accessor, entry_size, {}, {.page_id = page_id});
+        noc.async_write_barrier();
         buf.pop_front(1);
     }
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/tensor_accessor_loopback_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/tensor_accessor_loopback_producer.cpp
@@ -12,19 +12,22 @@
 //   arg 0: number of pages to transfer
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/dataflow/noc.h"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
     uint32_t num_pages = get_arg_val<uint32_t>(0);
 
+    Noc noc;
     TensorAccessor accessor(tensor::input_tensor);
     DataflowBuffer buf(dfb::input_dfb);
     uint32_t entry_size = buf.get_entry_size();
 
     for (uint32_t page_id = 0; page_id < num_pages; page_id++) {
         buf.reserve_back(1);
-        uint64_t src_noc_addr = accessor.get_noc_addr(page_id);
-        noc_async_read(src_noc_addr, buf.get_write_ptr(), entry_size);
-        noc_async_read_barrier();
+        noc.async_read(accessor, buf, entry_size, {.page_id = page_id}, {});
+        noc.async_read_barrier();
         buf.push_back(1);
     }
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/tt_kernel_named_args_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/tt_kernel_named_args_consumer.cpp
@@ -16,19 +16,23 @@
 // Paired with tt_kernel_named_args_producer.cpp; the host verifies input == output.
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/dataflow/noc.h"
 #include "experimental/kernel_args.h"  // provides TT_KERNEL, get_arg, the args:: / dfb:: accessors
 
 template <uint32_t bank_id, uint32_t entry_size>  // CTAs (compile-time)
 TT_KERNEL void loopback_consumer(
     uint32_t dst_addr,       // RTA (per-node)
     uint32_t num_entries) {  // CRTA (broadcast)
+    Noc noc;
+    AllocatorBank<AllocatorBankType::DRAM> dram_dst;
     DataflowBuffer buf(dfb::loopback_dfb);
 
     for (uint32_t i = 0; i < num_entries; i++) {
         buf.wait_front(1);
-        uint64_t dst_noc_addr = get_noc_addr_from_bank_id<true>(bank_id, dst_addr);
-        noc_async_write(buf.get_read_ptr(), dst_noc_addr, entry_size);
-        noc_async_write_barrier();
+        noc.async_write(buf, dram_dst, entry_size, {}, {.bank_id = bank_id, .addr = dst_addr});
+        noc.async_write_barrier();
         buf.pop_front(1);
         dst_addr += entry_size;  // by-value function param; mutating the local copy is fine
     }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/tt_kernel_named_args_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/tt_kernel_named_args_producer.cpp
@@ -20,19 +20,23 @@
 // address, size, bank, or count) corrupts the round-trip and fails the test.
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/dataflow/noc.h"
 #include "experimental/kernel_args.h"  // provides TT_KERNEL, get_arg, the args:: / dfb:: accessors
 
 template <uint32_t bank_id, uint32_t entry_size>  // CTAs (compile-time)
 TT_KERNEL void loopback_producer(
     uint32_t src_addr,       // RTA (per-node)
     uint32_t num_entries) {  // CRTA (broadcast)
+    Noc noc;
+    AllocatorBank<AllocatorBankType::DRAM> dram_src;
     DataflowBuffer buf(dfb::loopback_dfb);
 
     for (uint32_t i = 0; i < num_entries; i++) {
         buf.reserve_back(1);
-        uint64_t src_noc_addr = get_noc_addr_from_bank_id<true>(bank_id, src_addr);
-        noc_async_read(src_noc_addr, buf.get_write_ptr(), entry_size);
-        noc_async_read_barrier();
+        noc.async_read(dram_src, buf, entry_size, {.bank_id = bank_id, .addr = src_addr}, {});
+        noc.async_read_barrier();
         buf.push_back(1);
         src_addr += entry_size;  // by-value function param; mutating the local copy is fine
     }

--- a/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
@@ -289,8 +289,17 @@ public:
     void write_barrier(const Noc &noc) const { write_barrier_impl(noc); }
 #endif
 
+    // Peek current FIFO cursors (byte address / arch units). Use for local entry data access —
+    // prefer with scoped_lock when poking L1. Prefer noc.h for Class 1 transfers (pass the DFB).
     uint32_t get_write_ptr() const { return get_write_ptr_impl(); }
-    uint32_t get_read_ptr()  const { return get_read_ptr_impl(); }
+    uint32_t get_read_ptr() const { return get_read_ptr_impl(); }
+
+#ifndef ARCH_QUASAR
+    // WH/BH only — mutate FIFO cursor state (rewind / jump / hold-wr style surgery).
+    // Not for peeks: use get_*_ptr. Not declared on Quasar (redesign Classes 2–5).
+    void evil_set_write_ptr(uint32_t addr);
+    void evil_set_read_ptr(uint32_t addr);
+#endif
 
     [[nodiscard]] auto scoped_lock() {
         // TODO: Register with the debugger to track the lock
@@ -314,7 +323,7 @@ private:
     void handle_final_credits(uint16_t transactions_issued, uint8_t txn_id_index);
 
 #ifndef COMPILE_FOR_TRISC
-    friend class Noc;  // grants Noc::async_read/write access to prepare_*/commit_* implicit-sync helpers
+    friend class Noc;  // grants Noc::async_read/write access to prepare_*/commit_*
 
     uint32_t prepare_implicit_read();
     void commit_implicit_read();

--- a/tt_metal/hw/inc/internal/tt-1xx/dataflow_buffer.inl
+++ b/tt_metal/hw/inc/internal/tt-1xx/dataflow_buffer.inl
@@ -124,6 +124,22 @@ inline uint32_t DataflowBuffer::get_read_ptr_impl() const {
 #endif
 }
 
+inline void DataflowBuffer::evil_set_write_ptr(uint32_t addr) {
+#if DFB_IS_COMPUTE_MATH
+    (void)addr;
+#else
+    local_dfb_interface_.fifo_wr_ptr = addr;
+#endif
+}
+
+inline void DataflowBuffer::evil_set_read_ptr(uint32_t addr) {
+#if DFB_IS_COMPUTE_MATH
+    (void)addr;
+#else
+    local_dfb_interface_.fifo_rd_ptr = addr;
+#endif
+}
+
 #ifdef COMPILE_FOR_TRISC
 
 inline uint32_t DataflowBuffer::get_tile_address(uint32_t tile_index) {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_rm_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_rm_no_bcast.cpp
@@ -8,8 +8,6 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
-#include "api/core_local_mem.h"
-
 void kernel_main() {
     uint32_t index = 0;
     const uint32_t dst_addr = get_arg_val<uint32_t>(index++);
@@ -79,16 +77,14 @@ void kernel_main() {
 
                             dfb_out.wait_front(1);
 
-                            uint32_t l1_read_addr = dfb_out.get_read_ptr();
                             for (uint32_t row = 0; row < limit; ++row) {
                                 const uint32_t row_abs_idx = row_block_base_row + row;
                                 noc.async_write(
-                                    CoreLocalMem<uint32_t>(l1_read_addr),
+                                    dfb_out,
                                     dst,
                                     current_write_len,
-                                    {},
+                                    {.offset_bytes = row * current_chunk_bytes},
                                     {.page_id = row_abs_idx, .offset_bytes = current_chunk_offset});
-                                l1_read_addr += current_chunk_bytes;
                             }
 
                             noc.async_write_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_col_bcast.cpp
@@ -187,31 +187,27 @@ void kernel_main() {
                                 FILL_TILE_WITH_FIRST_COLUMN_RM(row_l1_addr, current_chunk_elements);
                             }
 
-                            uint32_t curr_l1_b = l1_write_addr_src_b;
                             for (uint32_t k = 0; k < limit; ++k) {
                                 const uint32_t row_idx_b = row_block_b + k * s_h_b;
                                 noc.async_read(
                                     src_b,
-                                    CoreLocalMem<uint32_t>(curr_l1_b),
+                                    cb_src_b,
                                     current_read_len_b,
                                     {.page_id = row_idx_b, .offset_bytes = current_chunk_offset},
-                                    {});
-                                curr_l1_b += current_chunk_bytes;
+                                    {.offset_bytes = k * current_chunk_bytes});
                             }
                             noc.async_read_barrier();
 #else
                             const uint32_t current_read_len_a = align(current_chunk_bytes, alignment_a);
 
-                            uint32_t curr_l1_a = l1_write_addr_src;
                             for (uint32_t k = 0; k < limit; ++k) {
                                 const uint32_t row_idx_a = row_block_a + k * s_h_a;
                                 noc.async_read(
                                     src,
-                                    CoreLocalMem<uint32_t>(curr_l1_a),
+                                    cb_src,
                                     current_read_len_a,
                                     {.page_id = row_idx_a, .offset_bytes = current_chunk_offset},
-                                    {});
-                                curr_l1_a += current_chunk_bytes;
+                                    {.offset_bytes = k * current_chunk_bytes});
                             }
                             noc.async_read_barrier();
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_no_bcast.cpp
@@ -9,8 +9,6 @@
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
-#include "api/core_local_mem.h"
-
 void kernel_main() {
     uint32_t index = 0;
     const uint32_t src_addr = get_arg_val<uint32_t>(index++);
@@ -130,34 +128,27 @@ void kernel_main() {
                             const uint32_t current_read_len_b = align(current_chunk_bytes, alignment_b);
 
                             cb_src.reserve_back(1);
-                            const uint32_t l1_write_addr_src = cb_src.get_write_ptr();
-
                             cb_src_b.reserve_back(1);
-                            const uint32_t l1_write_addr_src_b = cb_src_b.get_write_ptr();
 
-                            uint32_t curr_l1_a = l1_write_addr_src;
                             for (uint32_t k = 0; k < limit; ++k) {
                                 const uint32_t row_idx_a = row_block_a + k * s_h_a;
                                 noc.async_read(
                                     src,
-                                    CoreLocalMem<uint32_t>(curr_l1_a),
+                                    cb_src,
                                     current_read_len_a,
                                     {.page_id = row_idx_a, .offset_bytes = current_chunk_offset},
-                                    {});
-                                curr_l1_a += current_chunk_bytes;
+                                    {.offset_bytes = k * current_chunk_bytes});
                             }
                             noc.async_read_barrier();
 
-                            uint32_t curr_l1_b = l1_write_addr_src_b;
                             for (uint32_t k = 0; k < limit; ++k) {
                                 const uint32_t row_idx_b = row_block_b + k * s_h_b;
                                 noc.async_read(
                                     src_b,
-                                    CoreLocalMem<uint32_t>(curr_l1_b),
+                                    cb_src_b,
                                     current_read_len_b,
                                     {.page_id = row_idx_b, .offset_bytes = current_chunk_offset},
-                                    {});
-                                curr_l1_b += current_chunk_bytes;
+                                    {.offset_bytes = k * current_chunk_bytes});
                             }
                             noc.async_read_barrier();
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_bcast.cpp
@@ -145,40 +145,36 @@ void kernel_main() {
 #if SRC_BCAST
                             noc.async_read(
                                 src,
-                                CoreLocalMem<uint32_t>(l1_write_addr_src),
+                                cb_src,
                                 current_read_len_a,
                                 {.page_id = row_block_a, .offset_bytes = current_chunk_offset},
                                 {});
 
-                            uint32_t curr_l1_b = l1_write_addr_src_b;
                             for (uint32_t k = 0; k < limit; ++k) {
                                 const uint32_t row_idx_b = row_block_b + k * s_h_b;
                                 noc.async_read(
                                     src_b,
-                                    CoreLocalMem<uint32_t>(curr_l1_b),
+                                    cb_src_b,
                                     current_read_len_b,
                                     {.page_id = row_idx_b, .offset_bytes = current_chunk_offset},
-                                    {});
-                                curr_l1_b += current_chunk_bytes;
+                                    {.offset_bytes = k * current_chunk_bytes});
                             }
                             noc.async_read_barrier();
                             FILL_TILE_WITH_FIRST_ROW_RM(l1_write_addr_src, current_chunk_elements, limit);
 #else
-                            uint32_t curr_l1_a = l1_write_addr_src;
                             for (uint32_t k = 0; k < limit; ++k) {
                                 const uint32_t row_idx_a = row_block_a + k * s_h_a;
                                 noc.async_read(
                                     src,
-                                    CoreLocalMem<uint32_t>(curr_l1_a),
+                                    cb_src,
                                     current_read_len_a,
                                     {.page_id = row_idx_a, .offset_bytes = current_chunk_offset},
-                                    {});
-                                curr_l1_a += current_chunk_bytes;
+                                    {.offset_bytes = k * current_chunk_bytes});
                             }
 
                             noc.async_read(
                                 src_b,
-                                CoreLocalMem<uint32_t>(l1_write_addr_src_b),
+                                cb_src_b,
                                 current_read_len_b,
                                 {.page_id = row_block_b, .offset_bytes = current_chunk_offset},
                                 {});

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_col_mixed_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_col_mixed_bcast.cpp
@@ -189,7 +189,7 @@ void kernel_main() {
 
                             noc.async_read(
                                 src_b,
-                                CoreLocalMem<uint32_t>(l1_write_addr_src_b),
+                                cb_src_b,
                                 current_read_len_b,
                                 {.page_id = row_block_b, .offset_bytes = current_chunk_offset},
                                 {});
@@ -220,7 +220,7 @@ void kernel_main() {
 
                             noc.async_read(
                                 src,
-                                CoreLocalMem<uint32_t>(l1_write_addr_src),
+                                cb_src,
                                 current_read_len_a,
                                 {.page_id = row_block_a, .offset_bytes = current_chunk_offset},
                                 {});

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_bcast.cpp
@@ -181,32 +181,28 @@ void kernel_main() {
                             copy_one_element<element_size>(l1_write_addr_src, scratch_l1_addr);
                             FILL_TILE_WITH_FIRST_COLUMN_RM(l1_write_addr_src, current_chunk_elements);
 
-                            uint32_t curr_l1_b = l1_write_addr_src_b;
                             for (uint32_t k = 0; k < limit; ++k) {
                                 const uint32_t row_idx_b = row_block_b + k * s_h_b;
                                 noc.async_read(
                                     src_b,
-                                    CoreLocalMem<uint32_t>(curr_l1_b),
+                                    cb_src_b,
                                     current_read_len_b,
                                     {.page_id = row_idx_b, .offset_bytes = current_chunk_offset},
-                                    {});
-                                curr_l1_b += current_chunk_bytes;
+                                    {.offset_bytes = k * current_chunk_bytes});
                             }
                             noc.async_read_barrier();
 
                             FILL_TILE_WITH_FIRST_ROW_RM(l1_write_addr_src, current_chunk_elements, limit);
 #else
                             const uint32_t current_read_len_a = align(current_chunk_bytes, alignment_a);
-                            uint32_t curr_l1_a = l1_write_addr_src;
                             for (uint32_t k = 0; k < limit; ++k) {
                                 const uint32_t row_idx_a = row_block_a + k * s_h_a;
                                 noc.async_read(
                                     src,
-                                    CoreLocalMem<uint32_t>(curr_l1_a),
+                                    cb_src,
                                     current_read_len_a,
                                     {.page_id = row_idx_a, .offset_bytes = current_chunk_offset},
-                                    {});
-                                curr_l1_a += current_chunk_bytes;
+                                    {.offset_bytes = k * current_chunk_bytes});
                             }
                             noc.async_read_barrier();
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_op.cpp
@@ -9,7 +9,6 @@
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
-#include "api/core_local_mem.h"
 #include "ttnn/operations/experimental/quasar/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
 void kernel_main() {
@@ -121,18 +120,15 @@ void kernel_main() {
                             const uint32_t current_read_len = align(current_chunk_bytes, alignment_a);
 
                             cb_src.reserve_back(1);
-                            const uint32_t l1_write_addr_src = cb_src.get_write_ptr();
 
-                            uint32_t curr_l1_a = l1_write_addr_src;
                             for (uint32_t k = 0; k < limit; ++k) {
                                 const uint32_t row_idx_a = row_block_a + k * s_h_a;
                                 noc.async_read(
                                     src,
-                                    CoreLocalMem<uint32_t>(curr_l1_a),
+                                    cb_src,
                                     current_read_len,
                                     {.page_id = row_idx_a, .offset_bytes = current_chunk_offset},
-                                    {});
-                                curr_l1_a += current_chunk_bytes;
+                                    {.offset_bytes = k * current_chunk_bytes});
                             }
                             noc.async_read_barrier();
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/writer_interleaved_rm_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_ng/dataflow/writer_interleaved_rm_no_bcast.cpp
@@ -9,8 +9,6 @@
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
-#include "api/core_local_mem.h"
-
 void kernel_main() {
     uint32_t index = 0;
     const uint32_t dst_addr = get_arg_val<uint32_t>(index++);
@@ -80,16 +78,14 @@ void kernel_main() {
 
                             cb_out.wait_front(1);
 
-                            uint32_t l1_read_addr = cb_out.get_read_ptr();
                             for (uint32_t row = 0; row < limit; ++row) {
                                 const uint32_t row_abs_idx = row_block_base_row + row;
                                 noc.async_write(
-                                    CoreLocalMem<uint32_t>(l1_read_addr),
+                                    cb_out,
                                     dst,
                                     current_write_len,
-                                    {},
+                                    {.offset_bytes = row * current_chunk_bytes},
                                     {.page_id = row_abs_idx, .offset_bytes = current_chunk_offset});
-                                l1_read_addr += current_chunk_bytes;
                             }
 
                             noc.async_write_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_bmm_tilize_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_bmm_tilize_metal2.cpp
@@ -52,9 +52,11 @@ struct QsrDfbRingPos {
     uint8_t tc_idx;
 };
 using PartialsRingPos = QsrDfbRingPos;
-#define QSR_SNAPSHOT_WR(pos, cb)                                   \
+// Quasar has no evil_set_*; snapshot/restore the DFB ring via get_local_dfb_interface.
+// Macros take a DataflowBuffer so call sites match the WH/BH evil_* path.
+#define QSR_SNAPSHOT_WR(pos, dfb)                                  \
     do {                                                           \
-        LocalDFBInterface& _qd = get_local_dfb_interface(cb);      \
+        LocalDFBInterface& _qd = get_local_dfb_interface((dfb).get_id()); \
         for (uint8_t _qi = 0; _qi < _qd.num_tcs_to_rr; ++_qi) {    \
             (pos).entry_idx[_qi] = _qd.tc_slots[_qi].wr_entry_idx; \
             (pos).offset[_qi] = _qd.tc_slots[_qi].wr_offset;       \
@@ -62,9 +64,9 @@ using PartialsRingPos = QsrDfbRingPos;
         (pos).entry_ptr = _qd.wr_entry_ptr;                        \
         (pos).tc_idx = _qd.tc_idx;                                 \
     } while (0)
-#define QSR_RESTORE_WR(pos, cb)                                    \
+#define QSR_RESTORE_WR(pos, dfb)                                   \
     do {                                                           \
-        LocalDFBInterface& _qd = get_local_dfb_interface(cb);      \
+        LocalDFBInterface& _qd = get_local_dfb_interface((dfb).get_id()); \
         for (uint8_t _qi = 0; _qi < _qd.num_tcs_to_rr; ++_qi) {    \
             _qd.tc_slots[_qi].wr_entry_idx = (pos).entry_idx[_qi]; \
             _qd.tc_slots[_qi].wr_offset = (pos).offset[_qi];       \
@@ -72,42 +74,43 @@ using PartialsRingPos = QsrDfbRingPos;
         _qd.wr_entry_ptr = (pos).entry_ptr;                        \
         _qd.tc_idx = (pos).tc_idx;                                 \
     } while (0)
-#define QSR_SNAPSHOT_RD(pos, cb)                                   \
+#define QSR_SNAPSHOT_RD(pos, dfb)                                  \
     do {                                                           \
-        LocalDFBInterface& _qd = get_local_dfb_interface(cb);      \
+        LocalDFBInterface& _qd = get_local_dfb_interface((dfb).get_id()); \
         for (uint8_t _qi = 0; _qi < _qd.num_tcs_to_rr; ++_qi) {    \
             (pos).entry_idx[_qi] = _qd.tc_slots[_qi].rd_entry_idx; \
             (pos).offset[_qi] = _qd.tc_slots[_qi].rd_offset;       \
         }                                                          \
         (pos).tc_idx = _qd.tc_idx;                                 \
     } while (0)
-#define QSR_RESTORE_RD(pos, cb)                                    \
+#define QSR_RESTORE_RD(pos, dfb)                                   \
     do {                                                           \
-        LocalDFBInterface& _qd = get_local_dfb_interface(cb);      \
+        LocalDFBInterface& _qd = get_local_dfb_interface((dfb).get_id()); \
         for (uint8_t _qi = 0; _qi < _qd.num_tcs_to_rr; ++_qi) {    \
             _qd.tc_slots[_qi].rd_entry_idx = (pos).entry_idx[_qi]; \
             _qd.tc_slots[_qi].rd_offset = (pos).offset[_qi];       \
         }                                                          \
         _qd.tc_idx = (pos).tc_idx;                                 \
     } while (0)
-#define SAVE_PARTIALS_WR(var, cb) \
-    PartialsRingPos var;          \
-    QSR_SNAPSHOT_WR(var, cb)
-#define SAVE_PARTIALS_RD(var, cb) \
-    PartialsRingPos var;          \
-    QSR_SNAPSHOT_RD(var, cb)
-#define RESAVE_PARTIALS_WR(var, cb) QSR_SNAPSHOT_WR(var, cb)
-#define RESAVE_PARTIALS_RD(var, cb) QSR_SNAPSHOT_RD(var, cb)
-#define RESTORE_PARTIALS_WR(var, cb) QSR_RESTORE_WR(var, cb)
-#define RESTORE_PARTIALS_RD(var, cb) QSR_RESTORE_RD(var, cb)
+#define SAVE_PARTIALS_WR(var, dfb) \
+    PartialsRingPos var;           \
+    QSR_SNAPSHOT_WR(var, dfb)
+#define SAVE_PARTIALS_RD(var, dfb) \
+    PartialsRingPos var;           \
+    QSR_SNAPSHOT_RD(var, dfb)
+#define RESAVE_PARTIALS_WR(var, dfb) QSR_SNAPSHOT_WR(var, dfb)
+#define RESAVE_PARTIALS_RD(var, dfb) QSR_SNAPSHOT_RD(var, dfb)
+#define RESTORE_PARTIALS_WR(var, dfb) QSR_RESTORE_WR(var, dfb)
+#define RESTORE_PARTIALS_RD(var, dfb) QSR_RESTORE_RD(var, dfb)
 #else
+// WH/BH: rewind via DataflowBuffer get_*/evil_set_* (do not poke local_cb_interface directly).
 using PartialsRingPos = uint32_t;
-#define SAVE_PARTIALS_WR(var, cb) uint32_t var = get_local_cb_interface(cb).fifo_wr_ptr
-#define SAVE_PARTIALS_RD(var, cb) uint32_t var = get_local_cb_interface(cb).fifo_rd_ptr
-#define RESAVE_PARTIALS_WR(var, cb) var = get_local_cb_interface(cb).fifo_wr_ptr
-#define RESAVE_PARTIALS_RD(var, cb) var = get_local_cb_interface(cb).fifo_rd_ptr
-#define RESTORE_PARTIALS_WR(var, cb) get_local_cb_interface(cb).fifo_wr_ptr = var
-#define RESTORE_PARTIALS_RD(var, cb) get_local_cb_interface(cb).fifo_rd_ptr = var
+#define SAVE_PARTIALS_WR(var, dfb) uint32_t var = (dfb).get_write_ptr()
+#define SAVE_PARTIALS_RD(var, dfb) uint32_t var = (dfb).get_read_ptr()
+#define RESAVE_PARTIALS_WR(var, dfb) var = (dfb).get_write_ptr()
+#define RESAVE_PARTIALS_RD(var, dfb) var = (dfb).get_read_ptr()
+#define RESTORE_PARTIALS_WR(var, dfb) (dfb).evil_set_write_ptr(var)
+#define RESTORE_PARTIALS_RD(var, dfb) (dfb).evil_set_read_ptr(var)
 #endif
 
 #ifdef SPLIT_READER
@@ -150,7 +153,7 @@ void tilize_in(
 }  // tilize_in()
 
 template <uint32_t in_cb_id, uint32_t in_block_w, uint32_t out_cb_id>
-inline void tilize_single_block(DataflowBuffer in_cb) {
+inline void tilize_single_block(DataflowBuffer& in_cb) {
     in_cb.wait_front(in_block_w);
 #ifndef ARCH_QUASAR  // Quasar has no fast tilize; these helpers are only reached on the split_reader/
                      // activation_reuse path, which the resnet conv factories force OFF. Guard the
@@ -160,18 +163,19 @@ inline void tilize_single_block(DataflowBuffer in_cb) {
     in_cb.pop_front(in_block_w);
 }
 
-template <uint32_t in_cb_id, uint32_t window_reuse_offset>
-inline uint32_t update_in_cb(uint32_t in_cb_addr) {
+template <uint32_t window_reuse_offset>
+inline uint32_t update_in_cb(DataflowBuffer& in_cb, uint32_t in_cb_addr) {
 #ifndef ARCH_QUASAR  // activation_reuse/split_reader path is off for resnet; dead on Quasar (no cb_interface)
-    UNPACK((get_local_cb_interface(in_cb_id).fifo_rd_ptr = in_cb_addr));
+    UNPACK((in_cb.evil_set_read_ptr(in_cb_addr)));
 #endif
     return in_cb_addr + window_reuse_offset;
 }
 
 template <uint32_t in_cb_id, uint32_t in_block_w, uint32_t out_cb_id, uint32_t tilized_cb_row_offset>
-inline void tilize_single_block_with_out_cb_update(DataflowBuffer in_cb, uint32_t& out_cb_addr) {
+inline void tilize_single_block_with_out_cb_update(
+    DataflowBuffer& in_cb, DataflowBuffer& out_cb, uint32_t& out_cb_addr) {
 #ifndef ARCH_QUASAR  // activation_reuse/split_reader path is off for resnet; dead on Quasar (no cb_interface)
-    PACK((get_local_cb_interface(out_cb_id).fifo_wr_ptr = out_cb_addr));
+    PACK((out_cb.evil_set_write_ptr(out_cb_addr)));
 #endif
     PACK((out_cb_addr += tilized_cb_row_offset));
     tilize_single_block<in_cb_id, in_block_w, out_cb_id>(in_cb);
@@ -190,9 +194,9 @@ template <
     uint32_t tilized_cb_second_reader_offset,
     uint32_t image_width_in_tiles>
 inline void tilize_in_reuse_split_reader(
-    DataflowBuffer in1_cb,
-    DataflowBuffer in2_cb,
-    DataflowBuffer out_cb,
+    DataflowBuffer& in1_cb,
+    DataflowBuffer& in2_cb,
+    DataflowBuffer& out_cb,
     uint32_t act_cb_start_address,
     uint32_t act_cb_second_reader_start_address) {
     out_cb.reserve_back(out_cb_tiles);
@@ -205,7 +209,7 @@ inline void tilize_in_reuse_split_reader(
 
     uint32_t out_cb_addr, out_cb_addr_second_reader, out_cb_addr_init = 0;
 #ifndef ARCH_QUASAR  // activation_reuse/split_reader path is off for resnet; dead on Quasar (no cb_interface)
-    PACK((out_cb_addr_init = get_local_cb_interface(out_cb_id).fifo_wr_ptr));
+    PACK((out_cb_addr_init = out_cb.get_write_ptr()));
 #endif
     PACK((out_cb_addr = out_cb_addr_init));
     PACK((out_cb_addr_second_reader = out_cb_addr_init + tilized_cb_second_reader_offset));
@@ -218,40 +222,40 @@ inline void tilize_in_reuse_split_reader(
     constexpr uint32_t max_leftover = leftover_in1 > leftover_in2 ? leftover_in1 : leftover_in2;
 
     for (uint32_t image_row = 0; image_row < min_num_image_rows; ++image_row) {
-        in1_cb_addr = update_in_cb<in1_cb_id, window_reuse_offset>(in1_cb_addr);
-        in2_cb_addr = update_in_cb<in2_cb_id, window_reuse_offset>(in2_cb_addr);
+        in1_cb_addr = update_in_cb<window_reuse_offset>(in1_cb, in1_cb_addr);
+        in2_cb_addr = update_in_cb<window_reuse_offset>(in2_cb, in2_cb_addr);
         for (uint32_t image_col = 0; image_col < image_width_in_tiles; ++image_col) {
             tilize_single_block_with_out_cb_update<in1_cb_id, in_block_w, out_cb_id, tilized_cb_row_offset>(
-                in1_cb, out_cb_addr);
+                in1_cb, out_cb, out_cb_addr);
             tilize_single_block_with_out_cb_update<in2_cb_id, in_block_w, out_cb_id, tilized_cb_row_offset>(
-                in2_cb, out_cb_addr_second_reader);
+                in2_cb, out_cb, out_cb_addr_second_reader);
         }
     }
 
-    in1_cb_addr = update_in_cb<in1_cb_id, window_reuse_offset>(in1_cb_addr);
-    in2_cb_addr = update_in_cb<in2_cb_id, window_reuse_offset>(in2_cb_addr);
+    in1_cb_addr = update_in_cb<window_reuse_offset>(in1_cb, in1_cb_addr);
+    in2_cb_addr = update_in_cb<window_reuse_offset>(in2_cb, in2_cb_addr);
     for (uint32_t image_col = 0; image_col < max_leftover; ++image_col) {
         if (image_col < leftover_in1) {
             tilize_single_block_with_out_cb_update<in1_cb_id, in_block_w, out_cb_id, tilized_cb_row_offset>(
-                in1_cb, out_cb_addr);
+                in1_cb, out_cb, out_cb_addr);
 
             if (image_col == image_width_in_tiles - 1) {
-                in1_cb_addr = update_in_cb<in1_cb_id, window_reuse_offset>(in1_cb_addr);
+                in1_cb_addr = update_in_cb<window_reuse_offset>(in1_cb, in1_cb_addr);
             }
         }
 
         if (image_col < leftover_in2) {
             tilize_single_block_with_out_cb_update<in2_cb_id, in_block_w, out_cb_id, tilized_cb_row_offset>(
-                in2_cb, out_cb_addr_second_reader);
+                in2_cb, out_cb, out_cb_addr_second_reader);
 
             if (image_col == image_width_in_tiles - 1) {
-                in2_cb_addr = update_in_cb<in2_cb_id, window_reuse_offset>(in2_cb_addr);
+                in2_cb_addr = update_in_cb<window_reuse_offset>(in2_cb, in2_cb_addr);
             }
         }
     }
 
 #ifndef ARCH_QUASAR  // activation_reuse/split_reader path is off for resnet; dead on Quasar (no cb_interface)
-    PACK((get_local_cb_interface(out_cb_id).fifo_wr_ptr = out_cb_addr_init));
+    PACK((out_cb.evil_set_write_ptr(out_cb_addr_init)));
 #endif
     out_cb.push_back(out_cb_tiles);
 #ifndef ARCH_QUASAR  // Quasar has no fast tilize (split_reader/activation_reuse path, off for resnet)
@@ -261,8 +265,8 @@ inline void tilize_in_reuse_split_reader(
 
 template <uint32_t out_subblock_w, uint32_t out_block_w>
 inline void reblock_and_untilize(
-    DataflowBuffer interm_cb,
-    DataflowBuffer out_cb,
+    DataflowBuffer& interm_cb,
+    DataflowBuffer& out_cb,
     uint32_t num_out_subblocks_in_col,
     uint32_t out_subblock_num_tiles,
     uint32_t out_subblock_h) {
@@ -370,31 +374,6 @@ void kernel_main() {
         (split_reader && !split_reader_cb_shared) ? reader_num_h_subblocks / 2 : 0;
     constexpr uint32_t in0_num_subblocks_read = reader_num_h_subblocks - in0_num_subblocks_read_last;
 
-    [[maybe_unused]] const uint32_t out_cb_tiles =
-        activation_reuse ? in0_block_w * (in0_num_subblocks_read + in0_num_subblocks_read_last) : 0;
-    // activation_reuse base addresses (used only on the split_reader activation_reuse path, off for
-    // resnet). Quasar has no cb_interface; the path is dead here, so source them as 0.
-#ifdef ARCH_QUASAR
-    [[maybe_unused]] uint32_t act_cb_start_address = 0;
-    [[maybe_unused]] const uint32_t tilized_cb_start_address = 0;
-#ifdef SPLIT_READER
-    [[maybe_unused]] const uint32_t act_cb_second_reader_start_address = 0;
-#endif
-#else
-    [[maybe_unused]] uint32_t act_cb_start_address =
-        activation_reuse ? get_local_cb_interface(in0_cb_id).fifo_rd_ptr : 0;
-    [[maybe_unused]] const uint32_t tilized_cb_start_address =
-        activation_reuse ? get_local_cb_interface(tilized_in0_cb_id).fifo_wr_ptr : 0;
-#ifdef SPLIT_READER
-    [[maybe_unused]] const uint32_t act_cb_second_reader_start_address =
-        activation_reuse ? get_local_cb_interface(in0_cb_second_reader_id).fifo_rd_ptr : 0;
-#endif
-#endif
-
-#ifdef CHECK_SKIP_COMPUTE
-    bool skip_compute = (bool)get_arg(args::skip_compute);
-#endif
-
     DataflowBuffer cb_in0(in0_cb_id);
 #ifdef SPLIT_READER
     DataflowBuffer cb_in0_second_reader(in0_cb_second_reader_id);
@@ -410,13 +389,37 @@ void kernel_main() {
 #endif
     DataflowBuffer cb_untilize_mode_out(untilize_mode_out_cb_id);
 
+    [[maybe_unused]] const uint32_t out_cb_tiles =
+        activation_reuse ? in0_block_w * (in0_num_subblocks_read + in0_num_subblocks_read_last) : 0;
+    // activation_reuse base addresses (used only on the split_reader activation_reuse path, off for
+    // resnet). Quasar has no evil_set_*; the path is dead here, so source them as 0.
+#ifdef ARCH_QUASAR
+    [[maybe_unused]] uint32_t act_cb_start_address = 0;
+    [[maybe_unused]] const uint32_t tilized_cb_start_address = 0;
+#ifdef SPLIT_READER
+    [[maybe_unused]] const uint32_t act_cb_second_reader_start_address = 0;
+#endif
+#else
+    [[maybe_unused]] uint32_t act_cb_start_address = activation_reuse ? cb_in0.get_read_ptr() : 0;
+    [[maybe_unused]] const uint32_t tilized_cb_start_address =
+        activation_reuse ? cb_tilized_in0.get_write_ptr() : 0;
+#ifdef SPLIT_READER
+    [[maybe_unused]] const uint32_t act_cb_second_reader_start_address =
+        activation_reuse ? cb_in0_second_reader.get_read_ptr() : 0;
+#endif
+#endif
+
+#ifdef CHECK_SKIP_COMPUTE
+    bool skip_compute = (bool)get_arg(args::skip_compute);
+#endif
+
     compute_kernel_hw_startup<SrcOrder::Reverse>(mm_in0_cb_id, in1_cb_id, out_cb_id);
     matmul_block_init(mm_in0_cb_id, in1_cb_id, false, out_subblock_w, out_subblock_h, in0_block_w);
 #ifdef SFPU_OP_INIT_ACTIVATION
     SFPU_OP_INIT_ACTIVATION
 #endif
-    UNPACK(SAVE_PARTIALS_RD(partials_cb_read_ptr, matmul_partials_cb);)
-    PACK(SAVE_PARTIALS_WR(partials_cb_write_ptr, matmul_partials_cb);)
+    UNPACK(SAVE_PARTIALS_RD(partials_cb_read_ptr, cb_matmul_partials);)
+    PACK(SAVE_PARTIALS_WR(partials_cb_write_ptr, cb_matmul_partials);)
     for (uint32_t in1_block_w_i = 0; in1_block_w_i < in1_num_blocks_w; ++in1_block_w_i) {
         for (uint32_t in0_block_h_i = 0; in0_block_h_i < in0_num_blocks_h; ++in0_block_h_i) {
             bool enable_reload = false;
@@ -425,8 +428,8 @@ void kernel_main() {
                 PACK((llk_pack_relu_config(ReluConfig::none())));
             }
             if constexpr (partials_cb_uses_output) {
-                UNPACK(RESAVE_PARTIALS_RD(partials_cb_read_ptr, matmul_partials_cb);)
-                PACK(RESAVE_PARTIALS_WR(partials_cb_write_ptr, matmul_partials_cb);)
+                UNPACK(RESAVE_PARTIALS_RD(partials_cb_read_ptr, cb_matmul_partials);)
+                PACK(RESAVE_PARTIALS_WR(partials_cb_write_ptr, cb_matmul_partials);)
             }
             uint32_t curr_matmul_out_cb = matmul_partials_cb;
             for (uint32_t in0_block_w_i = 0; in0_block_w_i < in0_num_blocks_w; ++in0_block_w_i) {
@@ -481,8 +484,8 @@ void kernel_main() {
                             tilize_in<in0_block_w, in0_cb_second_reader_id, tilized_in0_cb_id, false, true>(
                                 in0_num_subblocks_read_last);
                         } else {
-#ifndef ARCH_QUASAR  // activation_reuse path is off for resnet; dead on Quasar (no cb_interface)
-                            PACK((get_local_cb_interface(tilized_in0_cb_id).fifo_wr_ptr = tilized_cb_start_address));
+#ifndef ARCH_QUASAR  // activation_reuse path is off for resnet; dead on Quasar (no evil_set_*)
+                            PACK((cb_tilized_in0.evil_set_write_ptr(tilized_cb_start_address)));
 #endif
                             tilize_in_reuse_split_reader<
                                 in0_cb_id,
@@ -618,8 +621,8 @@ void kernel_main() {
                 }
                 if (curr_matmul_out_cb == matmul_partials_cb) {
                     if constexpr (!partials_cb_uses_output) {
-                        UNPACK(RESTORE_PARTIALS_RD(partials_cb_read_ptr, matmul_partials_cb);)
-                        PACK(RESTORE_PARTIALS_WR(partials_cb_write_ptr, matmul_partials_cb);)
+                        UNPACK(RESTORE_PARTIALS_RD(partials_cb_read_ptr, cb_matmul_partials);)
+                        PACK(RESTORE_PARTIALS_WR(partials_cb_write_ptr, cb_matmul_partials);)
                     }
                 }
                 if constexpr (packer_l1_acc) {
@@ -628,8 +631,8 @@ void kernel_main() {
                             cb_matmul_partials.wait_front(out_block_num_tiles);
                             cb_matmul_partials.pop_front(out_block_num_tiles);
                             if constexpr (spill) {
-                                UNPACK(RESTORE_PARTIALS_RD(partials_cb_read_ptr, matmul_partials_cb));
-                                PACK(RESTORE_PARTIALS_WR(partials_cb_write_ptr, matmul_partials_cb));
+                                UNPACK(RESTORE_PARTIALS_RD(partials_cb_read_ptr, cb_matmul_partials));
+                                PACK(RESTORE_PARTIALS_WR(partials_cb_write_ptr, cb_matmul_partials));
                             }
                         }
                         enable_reload = false;
@@ -638,8 +641,8 @@ void kernel_main() {
                             cb_matmul_partials.wait_front(out_block_num_tiles);
                             cb_matmul_partials.pop_front(out_block_num_tiles);
                             if constexpr (spill) {
-                                UNPACK(RESTORE_PARTIALS_RD(partials_cb_read_ptr, matmul_partials_cb));
-                                PACK(RESTORE_PARTIALS_WR(partials_cb_write_ptr, matmul_partials_cb));
+                                UNPACK(RESTORE_PARTIALS_RD(partials_cb_read_ptr, cb_matmul_partials));
+                                PACK(RESTORE_PARTIALS_WR(partials_cb_write_ptr, cb_matmul_partials));
                             }
                         }
                         if (in0_block_w_i == in0_num_blocks_w - 2) {
@@ -652,15 +655,15 @@ void kernel_main() {
 
                         if constexpr (fuse_bias) {
                             if (!last_inner_dim_block) {
-                                UNPACK(RESTORE_PARTIALS_RD(partials_cb_read_ptr, matmul_partials_cb));
-                                PACK(RESTORE_PARTIALS_WR(partials_cb_write_ptr, matmul_partials_cb));
+                                UNPACK(RESTORE_PARTIALS_RD(partials_cb_read_ptr, cb_matmul_partials));
+                                PACK(RESTORE_PARTIALS_WR(partials_cb_write_ptr, cb_matmul_partials));
                             }
                         } else {
                             if (!last_inner_dim_block) {
-                                UNPACK(RESTORE_PARTIALS_RD(partials_cb_read_ptr, matmul_partials_cb));
+                                UNPACK(RESTORE_PARTIALS_RD(partials_cb_read_ptr, cb_matmul_partials));
                             }
                             if (in0_block_w_i < in0_num_blocks_w - 2) {
-                                PACK(RESTORE_PARTIALS_WR(partials_cb_write_ptr, matmul_partials_cb));
+                                PACK(RESTORE_PARTIALS_WR(partials_cb_write_ptr, cb_matmul_partials));
                             }
                         }
                     }
@@ -670,7 +673,7 @@ void kernel_main() {
                 cb_in1.pop_front(in1_block_num_tiles);
             }  // for in0_num_blocks_w
             if constexpr (matmul_partials_cb == mm_out_cb_id && partials_cb_uses_output) {
-                UNPACK(RESTORE_PARTIALS_RD(partials_cb_read_ptr, matmul_partials_cb));
+                UNPACK(RESTORE_PARTIALS_RD(partials_cb_read_ptr, cb_matmul_partials));
             }
 #ifdef CHECK_SKIP_COMPUTE
             if (skip_compute) {
@@ -725,8 +728,8 @@ void kernel_main() {
                     }  // for in1_num_subblocks
                 }  // in0_num_subblocks
                 if constexpr (untilize_out) {
-                    UNPACK(RESTORE_PARTIALS_RD(partials_cb_read_ptr, matmul_partials_cb));
-                    PACK(RESTORE_PARTIALS_WR(partials_cb_write_ptr, matmul_partials_cb));
+                    UNPACK(RESTORE_PARTIALS_RD(partials_cb_read_ptr, cb_matmul_partials));
+                    PACK(RESTORE_PARTIALS_WR(partials_cb_write_ptr, cb_matmul_partials));
                 }
             }
 #endif  // FUSE_BIAS

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_reader_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_reader_common.hpp
@@ -88,7 +88,7 @@ FORCE_INLINE void pass_to_the_next_image_width(
     pixel_row++;
     cb_act.reserve_back(act_cb_tiles);
     l1_write_addr_act = cb_start_addr + pixel_row * window_reuse_offset;
-    get_local_cb_interface(cb_id_act).fifo_wr_ptr = l1_write_addr_act;
+    cb_act.evil_set_write_ptr(l1_write_addr_act);
 
     if (new_batch_image_rows_to_fill > 0) {
         new_batch_image_rows_to_fill--;
@@ -105,7 +105,7 @@ template <uint32_t cb_id_act, uint32_t act_cb_w_tiles, uint32_t image_width_tile
 FORCE_INLINE void push_remaining_tiles(Cb cb_act, uint32_t remaining_tiles_to_push, uint32_t cb_start_addr) {
     constexpr uint32_t tiles_to_push = image_width_tiles * act_cb_w_tiles;
     for (uint32_t i = 0; i < remaining_tiles_to_push; i += image_width_tiles) {
-        get_local_cb_interface(cb_id_act).fifo_wr_ptr = cb_start_addr;
+        cb_act.evil_set_write_ptr(cb_start_addr);
         cb_act.push_back(tiles_to_push);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2_metal2.cpp
@@ -111,7 +111,7 @@ void kernel_main() {
     for (uint32_t bh = 0; bh < act_num_blocks_h; bh++) {
         if constexpr (activation_reuse_enabled) {
             l1_write_addr_act = cb_start_addr;
-            get_local_cb_interface(cb_id_act).fifo_wr_ptr = l1_write_addr_act;
+            cb_act.evil_set_write_ptr(l1_write_addr_act);
         }
         uint32_t reader_offset = act_l1_read_addr;
         for (uint32_t outer = 0; outer < window_outer; outer++) {

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks_metal2.cpp
@@ -132,7 +132,7 @@ void kernel_main() {
         if constexpr (split_reader_enabled) {
             if constexpr (activation_reuse_enabled) {
                 l1_write_addr_act = cb_start_addr;
-                get_local_cb_interface(dfb::act_second_reader).fifo_wr_ptr = l1_write_addr_act;
+                cb_act_second_obj.evil_set_write_ptr(l1_write_addr_act);
             }
             reader_offset = act_l1_read_addr;
         }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks_metal2.cpp
@@ -175,7 +175,7 @@ void kernel_main() {
         if constexpr (split_reader_enabled) {
             if constexpr (activation_reuse_enabled) {
                 l1_write_addr_act = cb_start_addr;
-                get_local_cb_interface(dfb::act_second_reader).fifo_wr_ptr = l1_write_addr_act;
+                cb_act_second_obj.evil_set_write_ptr(l1_write_addr_act);
             }
             reader_offset = act_l1_read_addr;
         }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/kernels/dataflow/move_stick_layout_interleaved_with_overlap.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/kernels/dataflow/move_stick_layout_interleaved_with_overlap.cpp
@@ -7,7 +7,6 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/noc_semaphore.h"
-#include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 #include "experimental/kernel_args.h"
 
@@ -50,12 +49,14 @@ void kernel_main() {
 
     // read a ublock of tiles from src to CB
     cb.reserve_back(num_pages);
-    uint32_t l1_write_addr = cb.get_write_ptr();
     for (uint32_t i = start_id; i < start_id + num_pages; ++i) {
-        CoreLocalMem<uint32_t> dst(l1_write_addr);
-        noc.async_read(src_addrgen, dst, page_size, {.page_id = i, .offset_bytes = 0}, {.offset_bytes = 0});
+        noc.async_read(
+            src_addrgen,
+            cb,
+            page_size,
+            {.page_id = i, .offset_bytes = 0},
+            {.offset_bytes = (i - start_id) * aligned_page_size});
         noc.async_read_barrier();
-        l1_write_addr += aligned_page_size;
     }
 
     if (is_controller) {

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/kernels/dataflow/move_stick_layout_interleaved_with_overlap_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/device/kernels/dataflow/move_stick_layout_interleaved_with_overlap_writer.cpp
@@ -15,7 +15,6 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
-#include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 #include "experimental/kernel_args.h"
 
@@ -34,12 +33,14 @@ void kernel_main() {
     // Drain the staged pages (CB -> dst). wait_front unblocks only after the reader's
     // post-handshake push_back, i.e. after all cores have finished reading src.
     cb.wait_front(num_pages);
-    uint32_t l1_read_addr = cb.get_read_ptr();
     for (uint32_t i = start_id; i < start_id + num_pages; ++i) {
-        CoreLocalMem<uint32_t> src(l1_read_addr);
-        noc.async_write(src, dst_addrgen, page_size, {.offset_bytes = 0}, {.page_id = i, .offset_bytes = 0});
+        noc.async_write(
+            cb,
+            dst_addrgen,
+            page_size,
+            {.offset_bytes = (i - start_id) * aligned_page_size},
+            {.page_id = i, .offset_bytes = 0});
         noc.async_write_barrier();
-        l1_read_addr += aligned_page_size;
     }
     cb.pop_front(num_pages);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/kernels/dataflow/reader_unary_stick_layout_split_rows_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/kernels/dataflow/reader_unary_stick_layout_split_rows_multicore.cpp
@@ -7,7 +7,6 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
-#include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 #include "experimental/kernel_args.h"
 
@@ -34,17 +33,17 @@ void kernel_main() {
 
     auto read_tiles = [&](const uint32_t& num_tiles, uint32_t page_id) {
         cb_in0.reserve_back(num_tiles);
-        uint32_t l1_write_addr = cb_in0.get_write_ptr();
+        uint32_t dst_offset = 0;
         for (uint32_t k = 0; k < tile_height; k++) {
             // Need an inner loop for pages within row. Only relevant for ND-sharded case on multicore
             // (otherwise this loop only has 1 iteration).
             for (uint32_t l = 0; l < num_pages_in_row; l++) {
                 uint32_t width_size =
                     (l == num_pages_in_row - 1) ? size_of_valid_data_in_last_page_in_row : block_width_size;
-                CoreLocalMem<uint32_t> dst(l1_write_addr);
-                noc.async_read(s, dst, width_size, {.page_id = page_id, .offset_bytes = 0}, {.offset_bytes = 0});
+                noc.async_read(
+                    s, cb_in0, width_size, {.page_id = page_id, .offset_bytes = 0}, {.offset_bytes = dst_offset});
                 page_id++;
-                l1_write_addr += width_size;
+                dst_offset += width_size;
             }
         }
         noc.async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/kernels/dataflow/reader_unary_stick_layout_split_rows_singlecore.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/kernels/dataflow/reader_unary_stick_layout_split_rows_singlecore.cpp
@@ -6,7 +6,6 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
-#include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 #include "experimental/kernel_args.h"
 
@@ -30,12 +29,13 @@ void kernel_main() {
 
     auto read_tiles = [&](const uint32_t& num_tiles, const uint32_t& width_size) {
         cb_in0.reserve_back(num_tiles);
-        uint32_t l1_write_addr = cb_in0.get_write_ptr();
         for (uint32_t k = 0; k < tile_height; k++) {
-            CoreLocalMem<uint32_t> dst(l1_write_addr);
             noc.async_read(
-                s, dst, width_size, {.page_id = stick_ids[k], .offset_bytes = stick_offset}, {.offset_bytes = 0});
-            l1_write_addr += width_size;
+                s,
+                cb_in0,
+                width_size,
+                {.page_id = stick_ids[k], .offset_bytes = stick_offset},
+                {.offset_bytes = k * width_size});
         }
         stick_offset += width_size;
         noc.async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/device/kernels/dataflow/reader_unary_pad_dims_split_rows.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/device/kernels/dataflow/reader_unary_pad_dims_split_rows.cpp
@@ -6,7 +6,6 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
-#include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 #include "experimental/kernel_args.h"
 
@@ -65,9 +64,12 @@ void kernel_main() {
         uint32_t l1_write_addr = cb_in0.get_write_ptr();
         uint32_t curr_stick_id = base_stick_id;
         for (uint32_t k = 0; k < num_rows; k++) {
-            CoreLocalMem<uint32_t> dst_mem(l1_write_addr);
             noc.async_read(
-                s, dst_mem, block_size, {.page_id = curr_stick_id + k, .offset_bytes = offset}, {.offset_bytes = 0});
+                s,
+                cb_in0,
+                block_size,
+                {.page_id = curr_stick_id + k, .offset_bytes = offset},
+                {.offset_bytes = k * block_row_size});
 
             if (block_row_size > block_size) {
                 volatile tt_l1_ptr std::uint32_t* dst = (volatile tt_l1_ptr uint32_t*)(l1_write_addr + block_size);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/device/kernels/dataflow/reader_unary_pad_dims_split_rows_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/device/kernels/dataflow/reader_unary_pad_dims_split_rows_multicore.cpp
@@ -7,7 +7,6 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
-#include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 #include "experimental/kernel_args.h"
 
@@ -99,28 +98,29 @@ void kernel_main() {
 
         cb_in0.reserve_back(num_tiles_per_row * has_rows);
         uint32_t l1_write_addr = cb_in0.get_write_ptr();
+        uint32_t dst_offset = 0;
         for (uint32_t k = 0; k < num_rows; k++) {
             uint32_t start_of_row_l1_write_addr = l1_write_addr;
             for (uint32_t i = 0; i < num_pages_in_row - 1; i++) {
-                CoreLocalMem<uint32_t> dst(l1_write_addr);
                 noc.async_read(
                     s,
-                    dst,
+                    cb_in0,
                     page_size,
                     {.page_id = base_page_id + k * num_pages_in_row + i, .offset_bytes = 0},
-                    {.offset_bytes = 0});
+                    {.offset_bytes = dst_offset});
+                dst_offset += page_size;
                 l1_write_addr += page_size;
             }
             // Process the last page in a row separately, as it may have padding at the end
-            CoreLocalMem<uint32_t> dst(l1_write_addr);
             noc.async_read(
                 s,
-                dst,
+                cb_in0,
                 size_of_valid_data_in_last_page_in_row,
                 {.page_id = base_page_id + k * num_pages_in_row + num_pages_in_row - 1, .offset_bytes = 0},
-                {.offset_bytes = 0});
+                {.offset_bytes = dst_offset});
             uint32_t size_of_padding_columns = padded_X_size - unpadded_X_size;
             fill_with_val<elem_size>(start_of_row_l1_write_addr + unpadded_X_size, size_of_padding_columns, pad_value);
+            dst_offset += size_of_valid_data_in_last_page_in_row + size_of_padding_columns;
             l1_write_addr += size_of_valid_data_in_last_page_in_row + size_of_padding_columns;
         }
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/writer_unary_transpose_wh_sharded_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/kernels/dataflow/writer_unary_transpose_wh_sharded_rm.cpp
@@ -14,7 +14,6 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/dataflow/endpoints.h"
-#include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 #include "api/tensor/tensor_accessor.h"
 #include "experimental/kernel_args.h"
@@ -52,19 +51,16 @@ void kernel_main() {
         for (uint32_t n = 0; n < num_hw_blocks_per_core; n++) {
             for (uint32_t w = 0; w < Wt; ++w) {
                 cb_src.wait_front(Ht);
-                uint32_t l1_read_addr = cb_src.get_read_ptr();
                 uint32_t W_curr = w == Wt - 1 ? W_per_tile_last : W_per_tile;
                 for (uint32_t w_datum = 0; w_datum < W_curr; ++w_datum) {
-                    CoreLocalMem<uint32_t> src(l1_read_addr);
                     noc.async_write_with_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
-                        src,
+                        cb_src,
                         UnicastEndpoint{},
                         stick_size_bytes,
-                        {.offset_bytes = 0},
+                        {.offset_bytes = w_datum * l1_read_offset_bytes},
                         {.noc_x = (uint32_t)my_x[noc.get_noc_id()],
                          .noc_y = (uint32_t)my_y[noc.get_noc_id()],
                          .addr = dst_addr});
-                    l1_read_addr += l1_read_offset_bytes;
                     dst_addr += stick_size_bytes;
                 }
                 noc.async_writes_flushed();

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/typecast/device/kernels/dataflow/reader_typecast_rm_chunked.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/typecast/device/kernels/dataflow/reader_typecast_rm_chunked.cpp
@@ -8,7 +8,6 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/dataflow_buffer.h"
-#include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -36,15 +35,9 @@ void kernel_main() {
         // Process all full chunks for this row
         for (uint32_t chunk_idx = 0; chunk_idx < full_chunks_per_row; ++chunk_idx) {
             cb_in.reserve_back(onepage);
-            const uint32_t l1_write_addr = cb_in.get_write_ptr();
 
             const uint32_t byte_offset = chunk_idx * full_chunk_size_bytes;
-            noc.async_read(
-                s,
-                CoreLocalMem<uint32_t>(l1_write_addr),
-                full_chunk_size_bytes,
-                {.page_id = row_id, .offset_bytes = byte_offset},
-                {});
+            noc.async_read(s, cb_in, full_chunk_size_bytes, {.page_id = row_id, .offset_bytes = byte_offset}, {});
 
             noc.async_read_barrier();
             cb_in.push_back(onepage);
@@ -53,15 +46,9 @@ void kernel_main() {
         // Process partial chunk if it exists
         if constexpr (partial_chunks_per_row > 0) {
             cb_in.reserve_back(onepage);
-            const uint32_t l1_write_addr = cb_in.get_write_ptr();
 
             const uint32_t byte_offset = full_chunks_per_row * full_chunk_size_bytes;
-            noc.async_read(
-                s,
-                CoreLocalMem<uint32_t>(l1_write_addr),
-                partial_chunk_size_bytes,
-                {.page_id = row_id, .offset_bytes = byte_offset},
-                {});
+            noc.async_read(s, cb_in, partial_chunk_size_bytes, {.page_id = row_id, .offset_bytes = byte_offset}, {});
 
             noc.async_read_barrier();
             cb_in.push_back(onepage);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/typecast/device/kernels/dataflow/writer_typecast_rm_chunked.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/typecast/device/kernels/dataflow/writer_typecast_rm_chunked.cpp
@@ -8,7 +8,6 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/dataflow_buffer.h"
-#include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -36,15 +35,9 @@ void kernel_main() {
         // Process all full chunks for this row
         for (uint32_t chunk_idx = 0; chunk_idx < full_chunks_per_row; ++chunk_idx) {
             cb_out.wait_front(onepage);
-            const uint32_t l1_read_addr = cb_out.get_read_ptr();
 
             const uint32_t byte_offset = chunk_idx * full_chunk_size_bytes;
-            noc.async_write(
-                CoreLocalMem<uint32_t>(l1_read_addr),
-                s,
-                full_chunk_size_bytes,
-                {},
-                {.page_id = row_id, .offset_bytes = byte_offset});
+            noc.async_write(cb_out, s, full_chunk_size_bytes, {}, {.page_id = row_id, .offset_bytes = byte_offset});
 
             noc.async_writes_flushed();
             cb_out.pop_front(onepage);
@@ -53,15 +46,9 @@ void kernel_main() {
         // Process partial chunk if it exists
         if constexpr (partial_chunks_per_row > 0) {
             cb_out.wait_front(onepage);
-            const uint32_t l1_read_addr = cb_out.get_read_ptr();
 
             const uint32_t byte_offset = full_chunks_per_row * full_chunk_size_bytes;
-            noc.async_write(
-                CoreLocalMem<uint32_t>(l1_read_addr),
-                s,
-                partial_chunk_size_bytes,
-                {},
-                {.page_id = row_id, .offset_bytes = byte_offset});
+            noc.async_write(cb_out, s, partial_chunk_size_bytes, {}, {.page_id = row_id, .offset_bytes = byte_offset});
 
             noc.async_writes_flushed();
             cb_out.pop_front(onepage);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/kernels/dataflow/writer_unary_stick_layout_split_rows_interleaved_parallel_columns.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/kernels/dataflow/writer_unary_stick_layout_split_rows_interleaved_parallel_columns.cpp
@@ -7,7 +7,6 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/dataflow_buffer.h"
-#include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 
 void kernel_main() {
@@ -34,16 +33,13 @@ void kernel_main() {
 
     auto write_tiles = [&](const uint32_t& num_tiles, const uint32_t& width_size) {
         cb_out.wait_front(num_tiles);
-        uint32_t l1_read_addr = cb_out.get_read_ptr();
         for (uint32_t k = 0; k < tile_height; k++) {
-            CoreLocalMem<uint32_t> src(l1_read_addr);
             noc.async_write(
-                src,
+                cb_out,
                 s,
                 width_size,
-                {.offset_bytes = 0},
+                {.offset_bytes = k * width_size},
                 {.page_id = row_stick_ids[k], .offset_bytes = curr_stick_offset});
-            l1_read_addr += width_size;
         }
         noc.async_write_barrier();
         cb_out.pop_front(num_tiles);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/kernels/dataflow/writer_unary_stick_layout_split_rows_interleaved_parallel_columns_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/kernels/dataflow/writer_unary_stick_layout_split_rows_interleaved_parallel_columns_metal2.cpp
@@ -12,7 +12,6 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
-#include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 #include "experimental/kernel_args.h"
 
@@ -37,16 +36,13 @@ void kernel_main() {
 
     auto write_tiles = [&](const uint32_t& num_tiles, const uint32_t& width_size) {
         cb_out.wait_front(num_tiles);
-        uint32_t l1_read_addr = cb_out.get_read_ptr();
         for (uint32_t k = 0; k < tile_height; k++) {
-            CoreLocalMem<uint32_t> src(l1_read_addr);
             noc.async_write(
-                src,
+                cb_out,
                 s,
                 width_size,
-                {.offset_bytes = 0},
+                {.offset_bytes = k * width_size},
                 {.page_id = row_stick_ids[k], .offset_bytes = curr_stick_offset});
-            l1_read_addr += width_size;
         }
         noc.async_write_barrier();
         cb_out.pop_front(num_tiles);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/kernels/dataflow/writer_unary_stick_layout_split_rows_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/kernels/dataflow/writer_unary_stick_layout_split_rows_multi_core.cpp
@@ -7,7 +7,6 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/dataflow_buffer.h"
-#include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 #include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
 
@@ -38,12 +37,9 @@ void kernel_main() {
     auto write_tiles_in_current_block = [&](uint32_t block_height_index) {
         cb_out.wait_front(num_tiles_per_input_block);
 
-        // Base address of the row of elements we are going to be writing.
-        uint32_t base_l1_read_addr = cb_out.get_read_ptr();
-
         // Process each row of elements in the input block
         for (uint32_t j = 0; j < tile_height; ++j) {
-            uint32_t current_l1_read_addr = base_l1_read_addr + j * num_cols_per_input_block * output_element_size;
+            const uint32_t row_src_offset = j * num_cols_per_input_block * output_element_size;
 
             // Output page_id that we are going to be writing to
             uint32_t num_rows_already_processed = block_height_index * tile_height + j;
@@ -59,22 +55,22 @@ void kernel_main() {
 
             // Iterate through all columns in the input block that this core is processing
             uint32_t num_input_cols_processed = 0;
+            uint32_t col_src_offset = 0;
             while (num_input_cols_processed < num_unpadded_cols_per_input_block) {
                 uint32_t num_cols_to_write = std::min(
                     num_unpadded_cols_per_input_block - num_input_cols_processed,
                     num_cols_remaining_in_current_output_block);
                 uint32_t num_bytes_to_write = num_cols_to_write * output_element_size;
 
-                CoreLocalMem<uint32_t> src(current_l1_read_addr);
                 noc.async_write(
-                    src,
+                    cb_out,
                     s,
                     num_bytes_to_write,
-                    {.offset_bytes = 0},
+                    {.offset_bytes = row_src_offset + col_src_offset},
                     {.page_id = output_page_id, .offset_bytes = output_offset_within_page_in_bytes});
 
                 num_input_cols_processed += num_cols_to_write;
-                current_l1_read_addr += num_bytes_to_write;
+                col_src_offset += num_bytes_to_write;
                 output_page_id++;
                 num_cols_remaining_in_current_output_block = num_cols_per_output_block;
                 output_offset_within_page_in_bytes = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/kernels/dataflow/writer_unary_stick_layout_split_rows_multi_core_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/kernels/dataflow/writer_unary_stick_layout_split_rows_multi_core_metal2.cpp
@@ -12,7 +12,6 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
-#include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 #include "api/tensor/tensor_accessor.h"
 #include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
@@ -43,12 +42,9 @@ void kernel_main() {
     auto write_tiles_in_current_block = [&](uint32_t block_height_index) {
         cb_out.wait_front(num_tiles_per_input_block);
 
-        // Base address of the row of elements we are going to be writing.
-        uint32_t base_l1_read_addr = cb_out.get_read_ptr();
-
         // Process each row of elements in the input block
         for (uint32_t j = 0; j < tile_height; ++j) {
-            uint32_t current_l1_read_addr = base_l1_read_addr + j * num_cols_per_input_block * output_element_size;
+            const uint32_t row_src_offset = j * num_cols_per_input_block * output_element_size;
 
             // Output page_id that we are going to be writing to
             uint32_t num_rows_already_processed = block_height_index * tile_height + j;
@@ -64,22 +60,22 @@ void kernel_main() {
 
             // Iterate through all columns in the input block that this core is processing
             uint32_t num_input_cols_processed = 0;
+            uint32_t col_src_offset = 0;
             while (num_input_cols_processed < num_unpadded_cols_per_input_block) {
                 uint32_t num_cols_to_write = std::min(
                     num_unpadded_cols_per_input_block - num_input_cols_processed,
                     num_cols_remaining_in_current_output_block);
                 uint32_t num_bytes_to_write = num_cols_to_write * output_element_size;
 
-                CoreLocalMem<uint32_t> src(current_l1_read_addr);
                 noc.async_write(
-                    src,
+                    cb_out,
                     s,
                     num_bytes_to_write,
-                    {.offset_bytes = 0},
+                    {.offset_bytes = row_src_offset + col_src_offset},
                     {.page_id = output_page_id, .offset_bytes = output_offset_within_page_in_bytes});
 
                 num_input_cols_processed += num_cols_to_write;
-                current_l1_read_addr += num_bytes_to_write;
+                col_src_offset += num_bytes_to_write;
                 output_page_id++;
                 num_cols_remaining_in_current_output_block = num_cols_per_output_block;
                 output_offset_within_page_in_bytes = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/kernels/dataflow/writer_unary_stick_layout_split_rows_multi_core_nd_shard.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/kernels/dataflow/writer_unary_stick_layout_split_rows_multi_core_nd_shard.cpp
@@ -8,7 +8,6 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/dataflow_buffer.h"
-#include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 #include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
 
@@ -48,10 +47,8 @@ void kernel_main() {
                                             uint32_t num_rows_to_write) {
         cb_out.wait_front(num_tiles_per_input_block);
 
-        uint32_t base_l1_read_addr = cb_out.get_read_ptr();
-
         for (uint32_t j = 0; j < num_rows_to_write; ++j) {
-            uint32_t current_l1_read_addr = base_l1_read_addr + j * num_cols_per_input_block * output_element_size;
+            const uint32_t row_src_offset = j * num_cols_per_input_block * output_element_size;
 
             uint32_t num_rows_already_processed = block_height_index * tile_height + j;
             uint32_t num_pages_already_processed_in_previous_rows =
@@ -65,22 +62,22 @@ void kernel_main() {
                 num_cols_already_processed_in_first_output_block * output_element_size;
 
             uint32_t num_input_cols_processed = 0;
+            uint32_t col_src_offset = 0;
             while (num_input_cols_processed < num_unpadded_cols_per_input_block) {
                 uint32_t num_cols_to_write = std::min(
                     num_unpadded_cols_per_input_block - num_input_cols_processed,
                     num_cols_remaining_in_current_output_block);
                 uint32_t num_bytes_to_write = num_cols_to_write * output_element_size;
 
-                CoreLocalMem<uint32_t> src(current_l1_read_addr);
                 noc.async_write(
-                    src,
+                    cb_out,
                     accessor_dst,
                     num_bytes_to_write,
-                    {.offset_bytes = 0},
+                    {.offset_bytes = row_src_offset + col_src_offset},
                     {.page_id = output_page_id, .offset_bytes = output_offset_within_page_in_bytes});
 
                 num_input_cols_processed += num_cols_to_write;
-                current_l1_read_addr += num_bytes_to_write;
+                col_src_offset += num_bytes_to_write;
                 output_page_id++;
                 num_cols_remaining_in_current_output_block = num_cols_per_output_block;
                 output_offset_within_page_in_bytes = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/kernels/dataflow/writer_unary_stick_layout_split_rows_multi_core_nd_shard_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/kernels/dataflow/writer_unary_stick_layout_split_rows_multi_core_nd_shard_metal2.cpp
@@ -14,7 +14,6 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
-#include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 #include "api/tensor/tensor_accessor.h"
 #include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
@@ -49,10 +48,8 @@ void kernel_main() {
                                             uint32_t num_rows_to_write) {
         cb_out.wait_front(num_tiles_per_input_block);
 
-        uint32_t base_l1_read_addr = cb_out.get_read_ptr();
-
         for (uint32_t j = 0; j < num_rows_to_write; ++j) {
-            uint32_t current_l1_read_addr = base_l1_read_addr + j * num_cols_per_input_block * output_element_size;
+            const uint32_t row_src_offset = j * num_cols_per_input_block * output_element_size;
 
             uint32_t num_rows_already_processed = block_height_index * tile_height + j;
             uint32_t num_pages_already_processed_in_previous_rows =
@@ -66,22 +63,22 @@ void kernel_main() {
                 num_cols_already_processed_in_first_output_block * output_element_size;
 
             uint32_t num_input_cols_processed = 0;
+            uint32_t col_src_offset = 0;
             while (num_input_cols_processed < num_unpadded_cols_per_input_block) {
                 uint32_t num_cols_to_write = std::min(
                     num_unpadded_cols_per_input_block - num_input_cols_processed,
                     num_cols_remaining_in_current_output_block);
                 uint32_t num_bytes_to_write = num_cols_to_write * output_element_size;
 
-                CoreLocalMem<uint32_t> src(current_l1_read_addr);
                 noc.async_write(
-                    src,
+                    cb_out,
                     accessor_dst,
                     num_bytes_to_write,
-                    {.offset_bytes = 0},
+                    {.offset_bytes = row_src_offset + col_src_offset},
                     {.page_id = output_page_id, .offset_bytes = output_offset_within_page_in_bytes});
 
                 num_input_cols_processed += num_cols_to_write;
-                current_l1_read_addr += num_bytes_to_write;
+                col_src_offset += num_bytes_to_write;
                 output_page_id++;
                 num_cols_remaining_in_current_output_block = num_cols_per_output_block;
                 output_offset_within_page_in_bytes = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/kernels/dataflow/writer_unary_stick_layout_split_rows_single_core.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/kernels/dataflow/writer_unary_stick_layout_split_rows_single_core.cpp
@@ -6,7 +6,6 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
-#include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 #include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
 #include "experimental/kernel_args.h"
@@ -31,16 +30,13 @@ void kernel_main() {
     auto write_tiles_in_current_block = [&]() {
         cb_out.wait_front(num_tiles_per_output_block);
 
-        uint32_t l1_read_addr = cb_out.get_read_ptr();
         for (uint32_t l = 0; l < tile_height; ++l) {
-            CoreLocalMem<uint32_t> src(l1_read_addr);
             noc.async_write(
-                src,
+                cb_out,
                 s,
                 output_single_block_width_size,
-                {.offset_bytes = 0},
+                {.offset_bytes = l * output_single_block_width_size},
                 {.page_id = row_stick_ids[l], .offset_bytes = stick_offset});
-            l1_read_addr += output_single_block_width_size;
         }
         stick_offset += output_single_block_width_size;
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_interleaved_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_interleaved_blocks.cpp
@@ -6,7 +6,6 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
-#include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 #include "api/tensor/tensor_accessor.h"
 #include "experimental/kernel_args.h"
@@ -28,19 +27,16 @@ inline void write_tiles_in_block(
     for (uint32_t tile_row_id = 0; tile_row_id < block_height_ntiles; tile_row_id++) {
         // We reserve back an entire row of tiles in a block and issue a bunch of reads
         cb_out0.wait_front(block_width_ntiles);
-        uint32_t l1_read_addr = cb_out0.get_read_ptr();
         for (uint32_t j = 0; j < TILE_HEIGHT; j++) {
             if (block_row_id >= num_rows_unpadded) {
                 break;
             }
-            CoreLocalMem<uint32_t> src(l1_read_addr);
             noc.async_write(
-                src,
+                cb_out0,
                 s,
                 block_row_size_unpadded,
-                {.offset_bytes = 0},
+                {.offset_bytes = j * block_row_size},
                 {.page_id = block_row_id, .offset_bytes = block_row_offset});
-            l1_read_addr += block_row_size;
             block_row_id++;
         }  // for tile_nrows
         noc.async_write_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_split_rows_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_split_rows_multicore.cpp
@@ -7,7 +7,6 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
-#include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 #include "experimental/kernel_args.h"
 
@@ -41,14 +40,15 @@ void kernel_main() {
         bool has_rows = (num_rows + padding_rows) > 0;
 
         cb_out0.wait_front(num_tiles_per_row * has_rows);
-        uint32_t l1_read_addr = cb_out0.get_read_ptr();
         for (uint32_t k = 0; k < num_rows; k++) {
-            CoreLocalMem<uint32_t> src(l1_read_addr);
             noc.async_write(
-                src, s, unpadded_X_size, {.offset_bytes = 0}, {.page_id = base_stick_id + k, .offset_bytes = 0});
+                cb_out0,
+                s,
+                unpadded_X_size,
+                {.offset_bytes = k * padded_X_size},
+                {.page_id = base_stick_id + k, .offset_bytes = 0});
 
             noc.async_write_barrier();
-            l1_read_addr += padded_X_size;
         }
         cb_out0.pop_front(num_tiles_per_row * has_rows);
     };

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_split_rows_multicore_nd_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_split_rows_multicore_nd_sharded.cpp
@@ -7,7 +7,6 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
-#include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 #include "api/tensor/tensor_accessor.h"
 #include "experimental/kernel_args.h"
@@ -49,10 +48,8 @@ void kernel_main() {
                                             uint32_t num_rows_to_write) {
         cb_out.wait_front(num_tiles_per_input_block);
 
-        uint32_t base_l1_read_addr = cb_out.get_read_ptr();
-
         for (uint32_t j = 0; j < num_rows_to_write; ++j) {
-            uint32_t current_l1_read_addr = base_l1_read_addr + j * num_cols_per_input_block * output_element_size;
+            const uint32_t row_src_offset = j * num_cols_per_input_block * output_element_size;
 
             uint32_t num_rows_already_processed = start_row + j;
             uint32_t num_pages_already_processed_in_previous_rows =
@@ -66,22 +63,22 @@ void kernel_main() {
                 num_cols_already_processed_in_first_output_block * output_element_size;
 
             uint32_t num_input_cols_processed = 0;
+            uint32_t col_src_offset = 0;
             while (num_input_cols_processed < num_unpadded_cols_per_input_block) {
                 uint32_t num_cols_to_write = std::min(
                     num_unpadded_cols_per_input_block - num_input_cols_processed,
                     num_cols_remaining_in_current_output_block);
                 uint32_t num_bytes_to_write = num_cols_to_write * output_element_size;
 
-                CoreLocalMem<uint32_t> src(current_l1_read_addr);
                 noc.async_write(
-                    src,
+                    cb_out,
                     accessor_dst,
                     num_bytes_to_write,
-                    {.offset_bytes = 0},
+                    {.offset_bytes = row_src_offset + col_src_offset},
                     {.page_id = output_page_id, .offset_bytes = output_offset_within_page_in_bytes});
 
                 num_input_cols_processed += num_cols_to_write;
-                current_l1_read_addr += num_bytes_to_write;
+                col_src_offset += num_bytes_to_write;
                 output_page_id++;
                 num_cols_remaining_in_current_output_block = num_cols_per_output_block;
                 output_offset_within_page_in_bytes = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_wh_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_wh_multicore.cpp
@@ -7,7 +7,6 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
-#include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 #include "api/tensor/tensor_accessor.h"
 #include "experimental/kernel_args.h"
@@ -31,14 +30,9 @@ void kernel_main() {
         bool has_rows = (num_rows) > 0;
 
         cb_out0.wait_front(single_block_size * has_rows);
-        // Read from the front of the waited entries. The legacy kernel used get_write_ptr() here,
-        // which only coincides with the front when the CB is sized EXACTLY to one block (full ->
-        // write ptr wraps to read ptr). The Metal 2.0 port shares one DFB sized to the max region
-        // block count across sub-regions, so smaller regions never fill it; get_read_ptr() is the
-        // size-independent address of the block's data.
-        uint32_t l1_read_addr = cb_out0.get_read_ptr();
 
-        for (uint32_t k = start_row_id; k < start_row_id + num_rows; k++) {
+        for (uint32_t row = 0; row < num_rows; ++row) {
+            const uint32_t k = start_row_id + row;
             uint32_t total_size = start_column_id + width_size;
             uint32_t write_size = width_size;
 
@@ -47,13 +41,14 @@ void kernel_main() {
                 write_size -= padded_size;
             }
 
-            CoreLocalMem<uint32_t> src(l1_read_addr);
             noc.async_write(
-                src, s, write_size, {.offset_bytes = 0}, {.page_id = size_2d + k, .offset_bytes = start_column_id});
+                cb_out0,
+                s,
+                write_size,
+                {.offset_bytes = row * width_size},
+                {.page_id = size_2d + k, .offset_bytes = start_column_id});
 
             noc.async_write_barrier();
-
-            l1_read_addr += width_size;
         }
 
         cb_out0.pop_front(single_block_size * has_rows);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/kernels/dataflow/writer_unary_unpad_dims_split_rows.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/kernels/dataflow/writer_unary_unpad_dims_split_rows.cpp
@@ -6,7 +6,6 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
-#include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 #include "experimental/kernel_args.h"
 
@@ -52,14 +51,15 @@ void kernel_main() {
 
     auto write_block = [&](uint32_t base_stick_id, uint32_t num_rows, uint32_t offset, uint32_t block_size) {
         cb_out0.wait_front(num_tiles_block_c);
-        uint32_t l1_read_addr = cb_out0.get_read_ptr();
         uint32_t curr_stick_id = base_stick_id;
         for (uint32_t k = 0; k < num_rows; k++) {
-            CoreLocalMem<uint32_t> src(l1_read_addr);
             noc.async_write(
-                src, s, block_size, {.offset_bytes = 0}, {.page_id = curr_stick_id, .offset_bytes = offset});
+                cb_out0,
+                s,
+                block_size,
+                {.offset_bytes = k * block_row_size},
+                {.page_id = curr_stick_id, .offset_bytes = offset});
 
-            l1_read_addr += block_row_size;
             curr_stick_id++;
 
             // Block write


### PR DESCRIPTION
### Summary
Many CB use cases fall outside the standard handshake path of reserve / push / wait / pop by manipulating rd/wr ptrs to jump/rewind/save and restore. This is done by accessing the `get_local_cb_interface(...).fifo_*_ptr =` 

For the WH/BH AI driven port we want to eliminate accesses to `get_local_cb_interface` without changing the kernel semantics. `evil_set_read/write_ptr` APIs are added only for WH/BH to enable this. These are not available on Quasar as the port to Quasar requires redesign of kernels to use Scratchpad/LocalTensorAccessor/Alternative legal DFB semantics. 

`get_read/write_ptr` APIs are not considered evil because observing the ptrs to do local entry access can be safe guarded with the use of scoped lock.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abhullar/evil-dfb)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/evil-dfb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=abhullar/evil-dfb)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:abhullar/evil-dfb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=abhullar/evil-dfb)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:abhullar/evil-dfb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abhullar/evil-dfb)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abhullar/evil-dfb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=abhullar/evil-dfb)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:abhullar/evil-dfb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=abhullar/evil-dfb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:abhullar/evil-dfb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=abhullar/evil-dfb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:abhullar/evil-dfb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=abhullar/evil-dfb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:abhullar/evil-dfb)