### PR TITLE
[LLK][WH,BH] Move ALU_FORMAT_SPEC override zero-init to the consuming threads

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cpack_common.h
@@ -610,6 +610,14 @@ inline void configure_pack(
 
     cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG2_Dstacc_RMW>(is_fp8_e4m3 ? to_underlying(DataFormat::Float16) : pack_output_src_format);
 
+    // Establish the no-override baseline for the Dstacc ALU format-select fields (ADDR32=0), consumed
+    // by the packer: clear Dstacc_val/override so the base REG2_Dstacc format programmed above is
+    // used. The SrcA/SrcB override fields in the same word are owned by the math thread
+    // (_llk_math_hw_configure_); the two writers touch disjoint bits and rely on per-byte RMWCIB
+    // atomicity, so this write does not depend on the surrounding REG_RMW mutex for cross-thread safety.
+    constexpr std::uint32_t dstacc_fmt_override_mask = ALU_FORMAT_SPEC_REG_Dstacc_val_MASK | ALU_FORMAT_SPEC_REG_Dstacc_override_MASK;
+    cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_Dstacc_val_ADDR32, 0, dstacc_fmt_override_mask>(0);
+
     // Config RELU
     relu_config_u hw_relu_config;
     hw_relu_config.r.STACC_RELU_ApplyRelu     = relu_config & 0xffff;

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cunpack_common.h
@@ -824,11 +824,6 @@ inline void configure_unpack_AB(
 
     // Math ALU_FORMAT_REG
     t6_mutex_acquire(mutex::REG_RMW);
-    std::uint32_t alu_src_format = (0x0 << ALU_FORMAT_SPEC_REG_SrcA_val_SHAMT);
-
-    constexpr std::uint32_t mask0 = (1 << (ALU_FORMAT_SPEC_REG_Dstacc_override_SHAMT + 1)) - 1;
-    cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_val_ADDR32, ALU_FORMAT_SPEC_REG_SrcA_val_SHAMT, mask0>(alu_src_format);
-
     alu_config_u alu_payload = {.val = 0};
 
     constexpr std::uint32_t alu_format_mask = ALU_FORMAT_SPEC_REG0_SrcAUnsigned_MASK | ALU_FORMAT_SPEC_REG0_SrcBUnsigned_MASK;

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
@@ -57,6 +57,16 @@ inline void _llk_math_hw_configure_(const std::uint32_t srca_data_format, const 
     cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(is_fp32_dest_acc_en);
     cfg_reg_rmw_tensix<ALU_ACC_CTRL_SFPU_Fp32_enabled_RMW>(is_fp32_dest_acc_en);
 
+    // Establish the no-override baseline for the SrcA/SrcB ALU format-select fields (ADDR32=0),
+    // consumed by the FPU (SrcA) and SFPU (SrcB) on this thread: clear SrcA_val/override and
+    // SrcB_val/override so the base (or Blackhole per-bank implied) SrcA/SrcB formats are used. The
+    // Dstacc override fields in the same word are owned by the pack thread (configure_pack); the two
+    // writers touch disjoint bits and rely on per-byte RMWCIB atomicity, so no cross-thread mutex is
+    // needed.
+    constexpr std::uint32_t src_fmt_override_mask =
+        ALU_FORMAT_SPEC_REG_SrcA_val_MASK | ALU_FORMAT_SPEC_REG_SrcA_override_MASK | ALU_FORMAT_SPEC_REG_SrcB_val_MASK | ALU_FORMAT_SPEC_REG_SrcB_override_MASK;
+    cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_val_ADDR32, 0, src_fmt_override_mask>(0);
+
     // Establish the operand-driven baseline for the Src zero-substitution flag.
     _configure_default_zero_flag_state_(srca_data_format, srcb_data_format);
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cpack_common.h
@@ -376,10 +376,8 @@ inline void cache_exponential_section_sizes_in_gprs(const std::uint32_t num_face
 
     if constexpr (!reconfiguring)
     {
-        regfile[p_gpr_pack::EXP2_SEC_SIZE_BFP8] = bfp_exp_section_size(2 /* index */, bfp8_row_bytes, num_faces)
-                                                  << THCON_SEC0_REG8_Exp_section_size_SHAMT;
-        regfile[p_gpr_pack::EXP3_SEC_SIZE_BFP8] = bfp_exp_section_size(3 /* index */, bfp8_row_bytes, num_faces)
-                                                  << THCON_SEC0_REG8_Exp_section_size_SHAMT;
+        regfile[p_gpr_pack::EXP2_SEC_SIZE_BFP8] = bfp_exp_section_size(2 /* index */, bfp8_row_bytes, num_faces) << THCON_SEC0_REG8_Exp_section_size_SHAMT;
+        regfile[p_gpr_pack::EXP3_SEC_SIZE_BFP8] = bfp_exp_section_size(3 /* index */, bfp8_row_bytes, num_faces) << THCON_SEC0_REG8_Exp_section_size_SHAMT;
     }
 
     regfile[p_gpr_pack::EXP1_SEC_SIZE_BFP4] = bfp_exp_section_size(1 /* index */, bfp4_row_bytes, num_faces) << THCON_SEC0_REG8_Exp_section_size_SHAMT;
@@ -780,6 +778,14 @@ inline void configure_pack(
     const std::uint32_t alu_dst_format = pack_src_format;
 
     cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG2_Dstacc_RMW>(alu_dst_format);
+
+    // Establish the no-override baseline for the Dstacc ALU format-select fields (ADDR32=0), consumed
+    // by the packer: clear Dstacc_val/override so the base REG2_Dstacc format programmed above is
+    // used. The SrcA/SrcB override fields in the same word are owned by the math thread
+    // (_llk_math_hw_configure_); the two writers touch disjoint bits and rely on per-byte RMWCIB
+    // atomicity, so this write does not depend on the surrounding REG_RMW mutex for cross-thread safety.
+    constexpr std::uint32_t dstacc_fmt_override_mask = ALU_FORMAT_SPEC_REG_Dstacc_val_MASK | ALU_FORMAT_SPEC_REG_Dstacc_override_MASK;
+    cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_Dstacc_val_ADDR32, 0, dstacc_fmt_override_mask>(0);
 
     // Config RELU
     relu_config_u hw_relu_config;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cunpack_common.h
@@ -814,11 +814,6 @@ inline void configure_unpack_AB(
 
     // Math ALU_FORMAT_REG
     t6_mutex_acquire(mutex::REG_RMW);
-    std::uint32_t alu_src_format = (0x0 << ALU_FORMAT_SPEC_REG_SrcA_val_SHAMT);
-
-    constexpr std::uint32_t mask0 = (1 << (ALU_FORMAT_SPEC_REG_Dstacc_override_SHAMT + 1)) - 1;
-    cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_val_ADDR32, ALU_FORMAT_SPEC_REG_SrcA_val_SHAMT, mask0>(alu_src_format);
-
     alu_config_u alu_payload = {.val = 0};
 
     constexpr std::uint32_t alu_format_mask = ALU_FORMAT_SPEC_REG0_SrcAUnsigned_MASK | ALU_FORMAT_SPEC_REG0_SrcBUnsigned_MASK;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
@@ -46,10 +46,19 @@ inline void _llk_math_hw_configure_(const std::uint32_t srca_data_format, const 
 
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
     std::uint32_t int8_math_enabled = is_int8_or_int32_format(srca_data_format) || is_int8_or_int32_format(srcb_data_format);
-    std::uint32_t config_data = (srca_data_format << ALU_FORMAT_SPEC_REG0_SrcA_SHAMT) | (srcb_data_format << ALU_FORMAT_SPEC_REG1_SrcB_SHAMT) |
+    std::uint32_t config_data       = (srca_data_format << ALU_FORMAT_SPEC_REG0_SrcA_SHAMT) | (srcb_data_format << ALU_FORMAT_SPEC_REG1_SrcB_SHAMT) |
                                 (int8_math_enabled << ALU_ACC_CTRL_INT8_math_enabled_SHAMT);
     constexpr std::uint32_t config_mask = ALU_FORMAT_SPEC_REG0_SrcA_MASK | ALU_FORMAT_SPEC_REG1_SrcB_MASK | ALU_ACC_CTRL_INT8_math_enabled_MASK;
     cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_ADDR32, 0, config_mask>(config_data);
+
+    // Establish the no-override baseline for the SrcA/SrcB ALU format-select fields (ADDR32=0),
+    // consumed by the FPU (SrcA) and SFPU (SrcB) on this thread: clear SrcA_val/override and
+    // SrcB_val/override so the base REG0_SrcA/REG1_SrcB formats programmed above are used. The Dstacc
+    // override fields in the same word are owned by the pack thread (configure_pack); the two writers
+    // touch disjoint bits and rely on per-byte RMWCIB atomicity, so no cross-thread mutex is needed.
+    constexpr std::uint32_t src_fmt_override_mask =
+        ALU_FORMAT_SPEC_REG_SrcA_val_MASK | ALU_FORMAT_SPEC_REG_SrcA_override_MASK | ALU_FORMAT_SPEC_REG_SrcB_val_MASK | ALU_FORMAT_SPEC_REG_SrcB_override_MASK;
+    cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_val_ADDR32, 0, src_fmt_override_mask>(0);
 
     cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(is_fp32_dest_acc_en);
     cfg_reg_rmw_tensix<ALU_ACC_CTRL_SFPU_Fp32_enabled_RMW>(is_fp32_dest_acc_en);
@@ -144,8 +153,8 @@ inline void _llk_math_reconfig_data_format_srca_(const std::uint32_t srca_data_f
             is_fp32_dest_acc_en || !is_int8_or_int32_format(srca_data_format),
             "Reconfiguring math to/from Int8/UInt8/Int32 formats requires FP32 Dest mode enabled");
         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
-        std::uint32_t int8_math_enabled     = is_int8_or_int32_format(srca_data_format);
-        std::uint32_t config_data = (srca_data_format << ALU_FORMAT_SPEC_REG0_SrcA_SHAMT) | (int8_math_enabled << ALU_ACC_CTRL_INT8_math_enabled_SHAMT);
+        std::uint32_t int8_math_enabled = is_int8_or_int32_format(srca_data_format);
+        std::uint32_t config_data       = (srca_data_format << ALU_FORMAT_SPEC_REG0_SrcA_SHAMT) | (int8_math_enabled << ALU_ACC_CTRL_INT8_math_enabled_SHAMT);
         constexpr std::uint32_t config_mask = ALU_FORMAT_SPEC_REG0_SrcA_MASK | ALU_ACC_CTRL_INT8_math_enabled_MASK;
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_ADDR32, 0, config_mask>(config_data);
     }
@@ -181,8 +190,8 @@ inline void _llk_math_reconfig_data_format_srcb_(const std::uint32_t srcb_data_f
             is_fp32_dest_acc_en || !is_int8_or_int32_format(srcb_data_format),
             "Reconfiguring math to/from Int8/UInt8/Int32 formats requires FP32 Dest mode enabled");
         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
-        std::uint32_t int8_math_enabled     = is_int8_or_int32_format(srcb_data_format);
-        std::uint32_t config_data = (srcb_data_format << ALU_FORMAT_SPEC_REG1_SrcB_SHAMT) | (int8_math_enabled << ALU_ACC_CTRL_INT8_math_enabled_SHAMT);
+        std::uint32_t int8_math_enabled = is_int8_or_int32_format(srcb_data_format);
+        std::uint32_t config_data       = (srcb_data_format << ALU_FORMAT_SPEC_REG1_SrcB_SHAMT) | (int8_math_enabled << ALU_ACC_CTRL_INT8_math_enabled_SHAMT);
         constexpr std::uint32_t config_mask = ALU_FORMAT_SPEC_REG1_SrcB_MASK | ALU_ACC_CTRL_INT8_math_enabled_MASK;
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG1_SrcB_ADDR32, 0, config_mask>(config_data);
     }
@@ -220,7 +229,7 @@ inline void _llk_math_reconfig_data_format_(const std::uint32_t srca_data_format
             "Reconfiguring math to/from Int8/UInt8/Int32 formats requires FP32 Dest mode enabled");
         TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
         std::uint32_t int8_math_enabled = is_int8_or_int32_format(srca_data_format) || is_int8_or_int32_format(srcb_data_format);
-        std::uint32_t config_data = (srca_data_format << ALU_FORMAT_SPEC_REG0_SrcA_SHAMT) | (srcb_data_format << ALU_FORMAT_SPEC_REG1_SrcB_SHAMT) |
+        std::uint32_t config_data       = (srca_data_format << ALU_FORMAT_SPEC_REG0_SrcA_SHAMT) | (srcb_data_format << ALU_FORMAT_SPEC_REG1_SrcB_SHAMT) |
                                     (int8_math_enabled << ALU_ACC_CTRL_INT8_math_enabled_SHAMT);
         constexpr std::uint32_t config_mask = ALU_FORMAT_SPEC_REG0_SrcA_MASK | ALU_FORMAT_SPEC_REG1_SrcB_MASK | ALU_ACC_CTRL_INT8_math_enabled_MASK;
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_ADDR32, 0, config_mask>(config_data);


### PR DESCRIPTION
## What

Issue: https://github.com/tenstorrent/tt-llk/issues/1669

The unpacker's `configure_unpack_AB` zero-initialized **all** of the `ALU_FORMAT_SPEC_REG` val/override fields (CFG `ADDR32=0`, bits 0–14) in one RMW — even though the unpacker consumes **none** of them. This moves each field's no-override baseline into the thread that actually consumes it, on both Wormhole B0 and Blackhole:

| Field (ADDR32=0) | Bits | Consumer | New owner |
|---|---|---|---|
| `SrcA_val`/`SrcA_override` | 0–4 | FPU | `_llk_math_hw_configure_` |
| `SrcB_val`/`SrcB_override` | 5–9 | SFPU (SFPLOAD/SFPSTORE) | `_llk_math_hw_configure_` |
| `Dstacc_val`/`Dstacc_override` | 10–14 | packer | `configure_pack` |

MATH clears bits 0–9 (`mask 0x03FF`); PACK clears bits 10–14 (`mask 0x7C00`). The two masks partition the old clear exactly (`0x03FF | 0x7C00 = 0x7FFF`, intersection 0).

## Why

Each override field is consumed by exactly one thread, so its no-override baseline belongs to that thread — established in program order before that thread's first consuming op, instead of via a cross-thread write from the unpacker that only worked because the value is always 0 (nothing guaranteed the unpack write happened-before a math/pack read). Consumption is confirmed against the ISA functional models (DeepWiki / tt-isa-documentation): `SrcAFmt = SrcA_override ? SrcA_val : REG0_SrcA` (FPU), `SrcBFmt` likewise (SFPU load/store), packer `IntermediateFormat = Dstacc_override ? Dstacc_val : REG2_Dstacc`.

## Safety

- **Ordering:** the MATH clear sits inside the existing `STALLWAIT(STALL_CFG, MATH | WAIT_SFPU)` drain (covers both FPU and SFPU); the PACK clear sits immediately after the existing `REG2_Dstacc` write and inherits its exact stall regime.
- **Shared word:** byte 1 of `ADDR32=0` is now written by both MATH (bits 8–9) and PACK (bits 10–14), but with **disjoint** bit masks via `cfg_reg_rmw_tensix` (per-byte-atomic `RMWCIB`), so **no cross-thread mutex is required**. There is no full-word writer of this word. MATH owns byte 0 exclusively (runtime SrcA overrides in datacopy/transpose/reduce touch byte 0 only, never colliding with PACK's byte-1 Dstacc).
- **No functional change:** these override fields are cold-reset 0 and have no nonzero writer, so every consumer still takes the base-register (`override=0`) path.
- **Scope:** Wormhole B0 + Blackhole only. Quasar already programs this word on the math thread (auto-TTSync) and is untouched.

## Verification

- **WH silicon:** `test_eltwise_binary` (Float16_b) and `test_reduce` (Float32) pass; a broader run had 177 reduce variants pass on silicon with **0 correctness failures** and no hangs.
- **BH compile:** clean across all variants (`test_eltwise_binary` 4364, `test_reduce` 3528).
- **Race audit:** adversarial `cfg-word-overlap` / `reconfig-stall` / `mmio-race` verification — all refutation attempts failed; no race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/llk-alu-format-override-init-owner-threads)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/llk-alu-format-override-init-owner-threads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/llk-alu-format-override-init-owner-threads)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/llk-alu-format-override-init-owner-threads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/llk-alu-format-override-init-owner-threads)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/llk-alu-format-override-init-owner-threads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/llk-alu-format-override-init-owner-threads)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/llk-alu-format-override-init-owner-threads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/llk-alu-format-override-init-owner-threads)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/llk-alu-format-override-init-owner-threads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/llk-alu-format-override-init-owner-threads)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/llk-alu-format-override-init-owner-threads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/llk-alu-format-override-init-owner-threads)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/llk-alu-format-override-init-owner-threads)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/llk-alu-format-override-init-owner-threads)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/llk-alu-format-override-init-owner-threads)