### PR TITLE
Organize merge gate by team

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -49,7 +49,7 @@ Scripts that collect CI/CD metrics and benchmark data for upload to the analytic
 | Script | Description |
 |--------|-------------|
 | `utils/find-changed-files.sh` | Detects which files changed between `origin/main` and `HEAD`, then sets boolean flags for affected areas (CMake, tt-metalium, ttnn, models, docs, LLK, etc.). Used to conditionally gate CI jobs. |
-| `utils/prepare_test_matrix.py` | Builds a filtered GitHub Actions test matrix from a YAML test definition file and a list of enabled SKUs. Outputs JSON. Usage: `prepare_test_matrix.py <tests_yaml> <enabled_skus> <sku_config_yaml>` |
+| `utils/prepare_test_matrix.py` | Builds a filtered GitHub Actions test matrix from a YAML test definition file and enabled SKUs. Expands each `(test, sku)` into a matrix row with `runs_on` from `.github/sku_config.yaml`. Supports `ALL_SKUS_IN_TESTS`, optional `--sku-allowlist` change gating, and `--event merge_group` prio routing via `merge_queue_sku`. See [Prepare test matrix](#prepare-test-matrix) below. |
 | `utils/count_pytests.py` | Counts total pytest cases in a directory, including `@pytest.mark.parametrize` expansions, by parsing Python ASTs. |
 | `utils/verify_time_budget.py` | Validates that the sum of test timeouts per (team, SKU) pair stays within the time budget defined in the budget YAML. Optionally enforces `--max-per-test-timeout` (minutes) against each individual SKU timeout. |
 | `utils/validate_perf_targets.py` | Validates model performance benchmark results against targets defined in `models/model_targets.yaml`. Exits non-zero if any metric regresses beyond tolerance. |
@@ -60,3 +60,37 @@ Scripts that collect CI/CD metrics and benchmark data for upload to the analytic
 | `utils/generate_tray_mapping.py` | Generates tray-to-PCIe device mapping and TP2 (Tensor Parallel 2) Ethernet-connected device pairs for Galaxy/UBB multi-chip systems. |
 | `utils/multi-user-create-files.py` | Generates `docker-compose.yml` and related files for multi-user container setups on Galaxy/UBB systems, assigning Tenstorrent devices to containers. |
 | `utils/multi-user-configure-container.sh` | Entrypoint script for multi-user containers — installs Python dev requirements, installs ttnn wheel, and sleeps to keep the container alive. |
+
+### Prepare test matrix
+
+Gate pipelines (merge-gate / PR-gate) treat test-list SKU keys as **logical** coverage. Concrete merge-queue prio runners are resolved at matrix build time—not listed as twin keys in `tests/pipeline_reorg/*gate*` YAMLs.
+
+```text
+prepare_test_matrix.py <tests_yaml> <enabled_skus> <sku_config_yaml>
+    [--event EVENT] [--sku-allowlist LIST]
+```
+
+| Input | Behavior |
+|-------|----------|
+| `enabled_skus` | Comma-separated SKUs, or `ALL_SKUS_IN_TESTS` to take every key under any test's `skus:` map. |
+| `--event` | When `merge_group`, rewrite each logical SKU that defines `merge_queue_sku` in `.github/sku_config.yaml` to that concrete prio SKU (sets `logical_sku` on the row). Other events leave the logical key unchanged. |
+| `--sku-allowlist` | Omit for no extra filter. Empty string → skip all (`matrix=[]`, exit 0). Otherwise CSV of logical SKUs intersected with coverage (used for LLK change gating). |
+
+Gate workflows typically pass `enabled-skus: ALL_SKUS_IN_TESTS` so the test list owns device coverage. LLK jobs also pass `sku-allowlist` (`*` in the workflow means “omit flag / no filter”; empty skips; else CSV)—see `llk-unit-tests-impl.yaml` / `llk-smoke-impl.yaml`.
+
+Do not list `*_prio` SKUs in gate test YAMLs; those entries live only under the merge-queue section of `sku_config.yaml` and are selected via `merge_queue_sku`.
+
+Examples:
+
+```bash
+# All SKUs in the list, rewrite to prio runners in the merge queue
+python3 .github/scripts/utils/prepare_test_matrix.py \
+  tests/pipeline_reorg/runtime_validation_merge_gate_tests.yaml \
+  ALL_SKUS_IN_TESTS .github/sku_config.yaml --event merge_group
+
+# LLK wormhole-only change gating
+python3 .github/scripts/utils/prepare_test_matrix.py \
+  tests/pipeline_reorg/llk_merge_gate_tests.yaml \
+  ALL_SKUS_IN_TESTS .github/sku_config.yaml \
+  --event pull_request --sku-allowlist wh_n150_civ2
+```

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -51,7 +51,7 @@ Scripts that collect CI/CD metrics and benchmark data for upload to the analytic
 | `utils/find-changed-files.sh` | Detects which files changed between `origin/main` and `HEAD`, then sets boolean flags for affected areas (CMake, tt-metalium, ttnn, models, docs, LLK, etc.). Used to conditionally gate CI jobs. |
 | `utils/prepare_test_matrix.py` | Builds a filtered GitHub Actions test matrix from a YAML test definition file and a list of enabled SKUs. Outputs JSON. Usage: `prepare_test_matrix.py <tests_yaml> <enabled_skus> <sku_config_yaml>` |
 | `utils/count_pytests.py` | Counts total pytest cases in a directory, including `@pytest.mark.parametrize` expansions, by parsing Python ASTs. |
-| `utils/verify_time_budget.py` | Validates that the sum of test timeouts per (team, SKU) pair stays within the time budget defined in the budget YAML. |
+| `utils/verify_time_budget.py` | Validates that the sum of test timeouts per (team, SKU) pair stays within the time budget defined in the budget YAML. Optionally enforces `--max-per-test-timeout` (minutes) against each individual SKU timeout. |
 | `utils/validate_perf_targets.py` | Validates model performance benchmark results against targets defined in `models/model_targets.yaml`. Exits non-zero if any metric regresses beyond tolerance. |
 | `utils/validate_golden_csv_columns.sh` | Validates that golden bandwidth CSV files in the perf microbenchmark directory have the expected column headers. |
 | `utils/hang_report.py` | Generates a JUnit XML test report for a hung test (dispatch timeout). Ensures the hung test appears in CI artifacts even if the process is killed before pytest finalizes. Supports a two-phase flow: initial report, then update with triage summary. |

--- a/.github/scripts/utils/find-changed-files.sh
+++ b/.github/scripts/utils/find-changed-files.sh
@@ -97,7 +97,7 @@ while IFS= read -r FILE; do
         # LLK engine submodule's pytest suite. Must come before the generic
         # tests/tt_metal/**/*.{h,hpp,c,cpp,py} catch-all so the narrower flag is set; we
         # also raise the broader TTMETALIUM_TESTS_CHANGED here so existing test gates
-        # (e.g. metalium-smoke-tests) keep firing for these changes.
+        # (e.g. runtime-smoke-tests) keep firing for these changes.
         tests/tt_metal/tt_metal/llk/**)
             LLK_UNIT_TESTS_CHANGED=true
             TTMETALIUM_TESTS_CHANGED=true

--- a/.github/scripts/utils/prepare_test_matrix.py
+++ b/.github/scripts/utils/prepare_test_matrix.py
@@ -18,7 +18,8 @@ Usage:
         [--event EVENT] [--sku-allowlist LIST]
 
 enabled_skus is a comma-separated list, or the literal ALL_SKUS_IN_TESTS to enable every SKU
-key that appears under any test entry's skus mapping in the tests YAML.
+key that appears under any test entry's skus mapping in the tests YAML. An empty / placeholder
+tests YAML resolves ALL_SKUS_IN_TESTS to an empty matrix (matrix=[], exit 0) rather than failing.
 
 --event: when set to merge_group, logical SKUs with merge_queue_sku in sku_config are
 rewritten to that concrete prio SKU before runs_on lookup.
@@ -178,6 +179,11 @@ def load_tests(tests_yaml_path):
     with open(tests_yaml_path, "r") as f:
         tests = yaml.safe_load(f)
 
+    # An empty or comment-only YAML parses to None; treat it as a placeholder
+    # (no tests) rather than a malformed file.
+    if tests is None:
+        return []
+
     if not isinstance(tests, list):
         print(f"::error::Test matrix file must contain a list of tests: {tests_yaml_path}")
         sys.exit(1)
@@ -238,14 +244,10 @@ def build_test_matrix(tests, enabled_skus, sku_config, event=None):
 
         for logical_sku in matching_skus:
             sku_test_config = test_skus[logical_sku]
+            # logical_sku is guaranteed to be in sku_config (enabled_skus is validated
+            # above); resolve_sku_for_event returns either logical_sku or an alias it
+            # has already validated (else it exits), so concrete_sku is always valid.
             concrete_sku = resolve_sku_for_event(logical_sku, sku_config, event)
-
-            if concrete_sku not in sku_config:
-                print(
-                    f"::warning::SKU '{concrete_sku}' (from '{logical_sku}') for test "
-                    f"'{test_name}' not found in SKU config, skipping"
-                )
-                continue
 
             # Start from test copy so all keys (model, arch, etc.) are preserved
             entry = test.copy()
@@ -325,8 +327,11 @@ def main(argv=None):
         enabled_skus = collect_skus_from_tests(tests)
         print(f"Resolved {ALL_SKUS_IN_TESTS} to: {enabled_skus}")
         if not enabled_skus:
-            print("::error::No SKU keys found under skus in the tests YAML.")
-            sys.exit(1)
+            # Empty / placeholder test list (e.g. a team's not-yet-populated gate
+            # yaml). Emit an empty matrix and skip rather than failing the job.
+            print("No SKU keys found under skus in the tests YAML; skipping all tests (matrix=[]).")
+            write_matrix_output([])
+            return 0
     else:
         enabled_skus = parse_enabled_skus(args.enabled_skus)
         print(f"Parsed enabled SKUs: {enabled_skus}")

--- a/.github/scripts/utils/prepare_test_matrix.py
+++ b/.github/scripts/utils/prepare_test_matrix.py
@@ -5,17 +5,26 @@ Build a filtered test matrix based on enabled SKUs.
 This script:
 1. Loads test definitions from a YAML file
 2. Filters tests based on enabled SKUs (comma-separated string)
-3. Adds runs_on labels from the SKU configuration
-4. Annotates each entry with weights-cache-mode from sku_config.yaml
+3. Optionally intersects with --sku-allowlist (change gating)
+4. Optionally rewrites SKUs to merge_queue_sku when --event is merge_group
+5. Adds runs_on labels from the SKU configuration
+6. Annotates each entry with weights-cache-mode from sku_config.yaml
    (used by the Blackhole demo pipeline so the per-job container volume mount can
    pick the right cache source)
-5. Outputs the filtered matrix as JSON
+7. Outputs the filtered matrix as JSON
 
 Usage:
     python prepare_test_matrix.py <tests_yaml_path> <enabled_skus> <sku_config_yaml_path>
+        [--event EVENT] [--sku-allowlist LIST]
 
 enabled_skus is a comma-separated list, or the literal ALL_SKUS_IN_TESTS to enable every SKU
 key that appears under any test entry's skus mapping in the tests YAML.
+
+--event: when set to merge_group, logical SKUs with merge_queue_sku in sku_config are
+rewritten to that concrete prio SKU before runs_on lookup.
+
+--sku-allowlist: omit for no extra filter; empty string skips all tests (matrix=[]
+exit 0); otherwise comma-separated logical SKUs intersected with coverage.
 
 `weights-cache-mode` is an optional per-SKU field in sku_config.yaml; when present,
 it is copied into each output matrix entry.
@@ -23,15 +32,18 @@ it is copied into each output matrix entry.
 Examples:
     python prepare_test_matrix.py tests/pipeline_reorg/galaxy_e2e_tests.yaml "wh_galaxy,bh_galaxy" .github/sku_config.yaml
     python prepare_test_matrix.py tests/pipeline_reorg/galaxy_demo_tests.yaml ALL_SKUS_IN_TESTS .github/sku_config.yaml
-    python prepare_test_matrix.py tests/pipeline_reorg/blackhole_demo_tests.yaml ALL_SKUS_IN_TESTS .github/sku_config.yaml
+    python prepare_test_matrix.py tests/pipeline_reorg/blackhole_demo_tests.yaml ALL_SKUS_IN_TESTS .github/sku_config.yaml --event merge_group
 """
 
-import yaml
+import argparse
 import json
-import sys
 import os
+import sys
+
+import yaml
 
 ALL_SKUS_IN_TESTS = "ALL_SKUS_IN_TESTS"
+MERGE_GROUP_EVENT = "merge_group"
 
 
 def collect_skus_from_tests(tests):
@@ -60,6 +72,52 @@ def parse_enabled_skus(enabled_skus_str):
     # Split by comma, strip whitespace, filter out empty strings
     skus = [sku.strip() for sku in enabled_skus_str.split(",") if sku.strip()]
     return skus
+
+
+def apply_sku_allowlist(enabled_skus, sku_allowlist):
+    """
+    Intersect coverage SKUs with an optional allowlist.
+
+    Args:
+        enabled_skus: Coverage SKU list (logical names from tests / enabled_skus)
+        sku_allowlist: None = no filter; "" or whitespace = skip all; else CSV
+
+    Returns:
+        Filtered SKU list (possibly empty)
+    """
+    if sku_allowlist is None:
+        return enabled_skus
+
+    allow = parse_enabled_skus(sku_allowlist)
+    if not allow:
+        print("SKU allowlist is empty; skipping all tests (matrix=[]).")
+        return []
+
+    filtered = [s for s in enabled_skus if s in allow]
+    print(f"SKU allowlist {allow} → {filtered}")
+    return filtered
+
+
+def resolve_sku_for_event(sku_name, sku_config, event):
+    """
+    Map a logical SKU to its concrete runner SKU for the given event.
+
+    On merge_group, if sku_config[sku].merge_queue_sku is set, return that prio SKU.
+    """
+    if event != MERGE_GROUP_EVENT:
+        return sku_name
+
+    entry = sku_config.get(sku_name) or {}
+    alias = entry.get("merge_queue_sku")
+    if not alias:
+        return sku_name
+
+    if alias not in sku_config:
+        print(f"::error::SKU '{sku_name}' has merge_queue_sku '{alias}' " f"which is not defined in SKU configuration.")
+        sys.exit(1)
+
+    print(f"Event '{event}': rewriting SKU '{sku_name}' → '{alias}'")
+    return alias
 
 
 def load_sku_config(sku_config_path):
@@ -127,7 +185,7 @@ def load_tests(tests_yaml_path):
     return tests
 
 
-def build_test_matrix(tests, enabled_skus, sku_config):
+def build_test_matrix(tests, enabled_skus, sku_config, event=None):
     """
     Filter tests based on enabled SKUs and expand multi-SKU entries into flat matrix entries.
 
@@ -136,10 +194,15 @@ def build_test_matrix(tests, enabled_skus, sku_config):
     timeout and runs_on labels. If the SKU entry in sku_config carries a weights-cache-mode
     field, it is copied into the output entry.
 
+    When event is merge_group, logical SKUs are rewritten via merge_queue_sku before
+    runs_on lookup. Timeout and other per-SKU fields still come from the logical key
+    in the tests YAML.
+
     Args:
         tests: List of test dictionaries (with 'skus' dict)
-        enabled_skus: List of enabled SKU strings
+        enabled_skus: List of enabled logical SKU strings
         sku_config: Dictionary mapping SKU names to their configuration
+        event: Optional GitHub event name (e.g. merge_group)
 
     Returns:
         Filtered list of flat test dictionaries. Each entry has all keys from the
@@ -150,7 +213,7 @@ def build_test_matrix(tests, enabled_skus, sku_config):
         print("::error::No SKUs enabled. At least one SKU must be specified.")
         sys.exit(1)
 
-    # Validate that all enabled SKUs exist in config
+    # Validate that all enabled (logical) SKUs exist in config
     for sku in enabled_skus:
         if sku not in sku_config:
             print(f"::error::SKU '{sku}' not found in SKU configuration. Available SKUs: {list(sku_config.keys())}")
@@ -167,31 +230,37 @@ def build_test_matrix(tests, enabled_skus, sku_config):
             print(f"::warning::Test '{test_name}' has no valid 'skus' mapping, skipping")
             continue
 
-        # Determine which of this test's SKUs are enabled
+        # Determine which of this test's SKUs are enabled (logical names)
         matching_skus = [s for s in test_skus if s in enabled_skus]
 
         # Always append SKU to name for clarity in CI
         append_sku_to_name = True
 
-        for sku_name in matching_skus:
-            sku_test_config = test_skus[sku_name]
+        for logical_sku in matching_skus:
+            sku_test_config = test_skus[logical_sku]
+            concrete_sku = resolve_sku_for_event(logical_sku, sku_config, event)
 
-            if sku_name not in sku_config:
-                print(f"::warning::SKU '{sku_name}' for test '{test_name}' not found in SKU config, skipping")
+            if concrete_sku not in sku_config:
+                print(
+                    f"::warning::SKU '{concrete_sku}' (from '{logical_sku}') for test "
+                    f"'{test_name}' not found in SKU config, skipping"
+                )
                 continue
 
             # Start from test copy so all keys (model, arch, etc.) are preserved
             entry = test.copy()
             entry.pop("skus", None)
-            entry["sku"] = sku_name
+            entry["sku"] = concrete_sku
+            if concrete_sku != logical_sku:
+                entry["logical_sku"] = logical_sku
             entry["timeout"] = sku_test_config.get("timeout", 0)
-            entry["runs_on"] = sku_config[sku_name].get("runs_on", [])
+            entry["runs_on"] = sku_config[concrete_sku].get("runs_on", [])
             if append_sku_to_name:
-                entry["name"] = f"{test_name} [{sku_name}]"
+                entry["name"] = f"{test_name} [{concrete_sku}]"
             for key, value in sku_test_config.items():
                 if key != "timeout" and value is not None:
                     entry[key] = value
-            sku_entry = sku_config[sku_name]
+            sku_entry = sku_config[concrete_sku]
             if "weights-cache-mode" in sku_entry:
                 entry["weights-cache-mode"] = sku_entry["weights-cache-mode"]
             substitute_cmd_placeholders(entry)
@@ -204,55 +273,74 @@ def build_test_matrix(tests, enabled_skus, sku_config):
     return filtered_tests
 
 
-def main():
-    if len(sys.argv) != 4:
-        print("Usage: python prepare_test_matrix.py <tests_yaml_path> <enabled_skus> <sku_config_yaml_path>")
-        print("  enabled_skus: comma-separated list, or ALL_SKUS_IN_TESTS")
-        print(
-            'Example: python prepare_test_matrix.py tests/pipeline_reorg/galaxy_e2e_tests.yaml "wh_galaxy,bh_galaxy" .github/sku_config.yaml'
-        )
-        sys.exit(1)
-
-    tests_yaml_path = sys.argv[1]
-    enabled_skus_str = sys.argv[2]
-    sku_config_path = sys.argv[3]
-
-    print(f"Loading tests from: {tests_yaml_path}")
-    print(f"Loading SKU config from: {sku_config_path}")
-    print(f"Enabled SKUs: '{enabled_skus_str}'")
-
-    sku_config = load_sku_config(sku_config_path)
-    tests = load_tests(tests_yaml_path)
-
-    if enabled_skus_str.strip().upper() == ALL_SKUS_IN_TESTS:
-        enabled_skus = collect_skus_from_tests(tests)
-        print(f"Resolved {ALL_SKUS_IN_TESTS} to: {enabled_skus}")
-        if not enabled_skus:
-            print("::error::No SKU keys found under skus in the tests YAML.")
-            sys.exit(1)
-    else:
-        enabled_skus = parse_enabled_skus(enabled_skus_str)
-        print(f"Parsed enabled SKUs: {enabled_skus}")
-
-    filtered_matrix = build_test_matrix(tests, enabled_skus, sku_config)
-
-    # Output as JSON
+def write_matrix_output(filtered_matrix):
+    """Print and optionally write matrix to GITHUB_OUTPUT."""
     print(f"\nFiltered test matrix ({len(filtered_matrix)} tests):")
     json_output_pretty = json.dumps(filtered_matrix, indent=2)
     print(json_output_pretty)
 
-    # Output for GitHub Actions (using multiline output format)
-    # This writes to GITHUB_OUTPUT file for job outputs
-    # Use compact JSON for GITHUB_OUTPUT to match other workflows
     json_output_compact = json.dumps(filtered_matrix)
     github_output = os.environ.get("GITHUB_OUTPUT")
     if github_output:
         with open(github_output, "a") as f:
             f.write(f"matrix<<EOF\n{json_output_compact}\nEOF\n")
     else:
-        # Fallback: output to stdout (for testing)
         print(f"\nmatrix={json_output_compact}")
 
 
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Build a filtered test matrix based on enabled SKUs.",
+    )
+    parser.add_argument("tests_yaml_path", help="Path to pipeline_reorg tests yaml")
+    parser.add_argument(
+        "enabled_skus",
+        help="Comma-separated SKUs, or ALL_SKUS_IN_TESTS",
+    )
+    parser.add_argument("sku_config_yaml_path", help="Path to sku_config.yaml")
+    parser.add_argument(
+        "--event",
+        default=os.environ.get("MATRIX_EVENT_NAME") or None,
+        help="GitHub event name; merge_group triggers merge_queue_sku rewrite",
+    )
+    parser.add_argument(
+        "--sku-allowlist",
+        default=None,
+        help="Omit for no filter; empty string skips all; else CSV of logical SKUs",
+    )
+    args = parser.parse_args(argv)
+
+    print(f"Loading tests from: {args.tests_yaml_path}")
+    print(f"Loading SKU config from: {args.sku_config_yaml_path}")
+    print(f"Enabled SKUs: '{args.enabled_skus}'")
+    if args.event:
+        print(f"Event: '{args.event}'")
+    if args.sku_allowlist is not None:
+        print(f"SKU allowlist: '{args.sku_allowlist}'")
+
+    sku_config = load_sku_config(args.sku_config_yaml_path)
+    tests = load_tests(args.tests_yaml_path)
+
+    if args.enabled_skus.strip().upper() == ALL_SKUS_IN_TESTS:
+        enabled_skus = collect_skus_from_tests(tests)
+        print(f"Resolved {ALL_SKUS_IN_TESTS} to: {enabled_skus}")
+        if not enabled_skus:
+            print("::error::No SKU keys found under skus in the tests YAML.")
+            sys.exit(1)
+    else:
+        enabled_skus = parse_enabled_skus(args.enabled_skus)
+        print(f"Parsed enabled SKUs: {enabled_skus}")
+
+    enabled_skus = apply_sku_allowlist(enabled_skus, args.sku_allowlist)
+    if not enabled_skus:
+        # Empty after allowlist (including explicit empty allowlist) → skip, do not fail.
+        write_matrix_output([])
+        return 0
+
+    filtered_matrix = build_test_matrix(tests, enabled_skus, sku_config, event=args.event)
+    write_matrix_output(filtered_matrix)
+    return 0
+
+
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/.github/scripts/utils/test_prepare_test_matrix.py
+++ b/.github/scripts/utils/test_prepare_test_matrix.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import textwrap
@@ -15,6 +16,7 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[3]
 SCRIPT = Path(__file__).resolve().parent / "prepare_test_matrix.py"
 SKU_CONFIG = REPO_ROOT / ".github" / "sku_config.yaml"
+PIPELINE = REPO_ROOT / "tests" / "pipeline_reorg"
 
 
 @pytest.fixture
@@ -41,7 +43,12 @@ def tests_yaml(tmp_path: Path) -> Path:
     return path
 
 
-def run_matrix(tests_yaml: Path, enabled: str, *extra: str) -> list:
+def run_matrix(
+    tests_yaml: Path,
+    enabled: str,
+    *extra: str,
+    env: dict | None = None,
+) -> list:
     cmd = [
         sys.executable,
         str(SCRIPT),
@@ -50,13 +57,22 @@ def run_matrix(tests_yaml: Path, enabled: str, *extra: str) -> list:
         str(SKU_CONFIG),
         *extra,
     ]
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    run_env = os.environ.copy()
+    run_env.pop("GITHUB_OUTPUT", None)
+    if env:
+        run_env.update(env)
+    else:
+        run_env.pop("MATRIX_EVENT_NAME", None)
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False, env=run_env)
     assert result.returncode == 0, result.stdout + result.stderr
-    # Last line with matrix= for local runs
     for line in reversed(result.stdout.splitlines()):
         if line.startswith("matrix="):
             return json.loads(line[len("matrix=") :])
     raise AssertionError(f"No matrix= in output:\n{result.stdout}")
+
+
+def concrete_skus(matrix: list) -> set[str]:
+    return {e["sku"] for e in matrix}
 
 
 def test_default_no_event_keeps_logical_skus(tests_yaml: Path):
@@ -94,8 +110,26 @@ def test_pull_request_does_not_rewrite(tests_yaml: Path):
     ]
 
 
+@pytest.mark.parametrize("event", ["push", "workflow_dispatch", "schedule"])
+def test_non_merge_group_events_do_not_rewrite(tests_yaml: Path, event: str):
+    matrix = run_matrix(tests_yaml, "ALL_SKUS_IN_TESTS", "--event", event)
+    assert "bh_p150b_civ2_viommu_prio" not in concrete_skus(matrix)
+    assert "bh_p150b_civ2_viommu" in concrete_skus(matrix)
+
+
 def test_empty_allowlist_skips_all(tests_yaml: Path):
     matrix = run_matrix(tests_yaml, "ALL_SKUS_IN_TESTS", "--sku-allowlist", "")
+    assert matrix == []
+
+
+def test_whitespace_allowlist_skips_all(tests_yaml: Path):
+    matrix = run_matrix(tests_yaml, "ALL_SKUS_IN_TESTS", "--sku-allowlist", "  ,  ")
+    assert matrix == []
+
+
+def test_allowlist_star_is_not_all_at_script_level(tests_yaml: Path):
+    """Workflows treat '*' as omit-flag; the script itself has no '*' sentinel."""
+    matrix = run_matrix(tests_yaml, "ALL_SKUS_IN_TESTS", "--sku-allowlist", "*")
     assert matrix == []
 
 
@@ -108,6 +142,16 @@ def test_allowlist_intersects(tests_yaml: Path):
     )
     assert len(matrix) == 1
     assert matrix[0]["sku"] == "wh_n150_civ2"
+
+
+def test_allowlist_unknown_sku_yields_empty(tests_yaml: Path):
+    matrix = run_matrix(
+        tests_yaml,
+        "ALL_SKUS_IN_TESTS",
+        "--sku-allowlist",
+        "does_not_exist",
+    )
+    assert matrix == []
 
 
 def test_allowlist_then_merge_group_route(tests_yaml: Path):
@@ -124,6 +168,162 @@ def test_allowlist_then_merge_group_route(tests_yaml: Path):
     assert matrix[0]["logical_sku"] == "bh_p150b_civ2_viommu"
 
 
+def test_rewrite_preserves_logical_timeout_and_names_concrete_sku(tmp_path: Path):
+    path = tmp_path / "tests.yaml"
+    path.write_text(
+        textwrap.dedent(
+            """\
+            - name: timeout check
+              cmd: echo ok
+              skus:
+                bh_p150b_civ2_viommu:
+                  timeout: 11
+              team: triage
+            """
+        )
+    )
+    matrix = run_matrix(path, "ALL_SKUS_IN_TESTS", "--event", "merge_group")
+    assert len(matrix) == 1
+    assert matrix[0]["timeout"] == 11
+    assert matrix[0]["sku"] == "bh_p150b_civ2_viommu_prio"
+    assert matrix[0]["name"] == "timeout check [bh_p150b_civ2_viommu_prio]"
+
+
+def test_cpu_medium_routes_on_merge_group(tmp_path: Path):
+    path = tmp_path / "tests.yaml"
+    path.write_text(
+        textwrap.dedent(
+            """\
+            - name: fabric cpu
+              cmd: echo ok
+              skus:
+                cpu_medium:
+                  timeout: 10
+              team: scaleout
+            """
+        )
+    )
+    matrix = run_matrix(path, "ALL_SKUS_IN_TESTS", "--event", "merge_group")
+    assert matrix[0]["sku"] == "cpu_medium_prio"
+    assert matrix[0]["logical_sku"] == "cpu_medium"
+    assert matrix[0]["runs_on"] == ["tt-ubuntu-2204-medium-prio-stable"]
+
+
+def test_matrix_event_name_env_triggers_rewrite(tests_yaml: Path):
+    matrix = run_matrix(
+        tests_yaml,
+        "ALL_SKUS_IN_TESTS",
+        env={"MATRIX_EVENT_NAME": "merge_group"},
+    )
+    assert "bh_p150b_civ2_viommu_prio" in concrete_skus(matrix)
+
+
+def test_explicit_event_overrides_env(tests_yaml: Path):
+    matrix = run_matrix(
+        tests_yaml,
+        "ALL_SKUS_IN_TESTS",
+        "--event",
+        "pull_request",
+        env={"MATRIX_EVENT_NAME": "merge_group"},
+    )
+    assert "bh_p150b_civ2_viommu_prio" not in concrete_skus(matrix)
+
+
+def test_backcompat_no_flags_with_dual_sku_list(tmp_path: Path):
+    """Non-migrated lists that still list prio twins keep expanding both without --event."""
+    path = tmp_path / "legacy.yaml"
+    path.write_text(
+        textwrap.dedent(
+            """\
+            - name: legacy
+              cmd: echo ok
+              skus:
+                bh_p150b_civ2_viommu:
+                  timeout: 10
+                bh_p150b_civ2_viommu_prio:
+                  timeout: 10
+              team: runtime
+            """
+        )
+    )
+    matrix = run_matrix(path, "ALL_SKUS_IN_TESTS")
+    assert concrete_skus(matrix) == {"bh_p150b_civ2_viommu", "bh_p150b_civ2_viommu_prio"}
+    assert len(matrix) == 2
+
+
+def test_dual_sku_list_plus_merge_group_duplicates_prio(tmp_path: Path):
+    """Calling --event merge_group while YAML still has prio twins duplicates prio rows."""
+    path = tmp_path / "legacy.yaml"
+    path.write_text(
+        textwrap.dedent(
+            """\
+            - name: legacy
+              cmd: echo ok
+              skus:
+                bh_p150b_civ2_viommu:
+                  timeout: 10
+                bh_p150b_civ2_viommu_prio:
+                  timeout: 10
+              team: runtime
+            """
+        )
+    )
+    matrix = run_matrix(path, "ALL_SKUS_IN_TESTS", "--event", "merge_group")
+    assert [e["sku"] for e in matrix] == [
+        "bh_p150b_civ2_viommu_prio",
+        "bh_p150b_civ2_viommu_prio",
+    ]
+
+
+def test_backcompat_explicit_csv_enabled_skus_filters(tests_yaml: Path):
+    matrix = run_matrix(tests_yaml, "wh_n150_civ2,bh_p150b_civ2_viommu")
+    assert concrete_skus(matrix) == {"wh_n150_civ2", "bh_p150b_civ2_viommu"}
+
+
+def test_broken_merge_queue_alias_fails(tmp_path: Path):
+    tests = tmp_path / "tests.yaml"
+    tests.write_text(
+        textwrap.dedent(
+            """\
+            - name: bad alias
+              cmd: echo ok
+              skus:
+                wh_n150_civ2:
+                  timeout: 5
+              team: runtime
+            """
+        )
+    )
+    broken_cfg = tmp_path / "sku_config.yaml"
+    broken_cfg.write_text(
+        textwrap.dedent(
+            """\
+            skus:
+              wh_n150_civ2:
+                runs_on: [runner-a]
+                merge_queue_sku: missing_prio
+            """
+        )
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            str(tests),
+            "ALL_SKUS_IN_TESTS",
+            str(broken_cfg),
+            "--event",
+            "merge_group",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={k: v for k, v in os.environ.items() if k not in ("GITHUB_OUTPUT", "MATRIX_EVENT_NAME")},
+    )
+    assert result.returncode != 0
+    assert "missing_prio" in result.stdout + result.stderr
+
+
 def test_sku_config_aliases_point_at_grouped_prio_skus():
     with open(SKU_CONFIG) as f:
         cfg = yaml.safe_load(f)["skus"]
@@ -137,3 +337,128 @@ def test_sku_config_aliases_point_at_grouped_prio_skus():
         alias = cfg[logical]["merge_queue_sku"]
         assert alias in cfg
         assert "runs_on" in cfg[alias]
+
+
+# ---------------------------------------------------------------------------
+# Integration: real gate test lists (expected post-migration behavior)
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_smoke_merge_gate_push_includes_n150():
+    """Functional change: merge-gate smoke now runs wh_n150_civ2 (was filtered out)."""
+    matrix = run_matrix(
+        PIPELINE / "runtime_validation_merge_gate_tests.yaml",
+        "ALL_SKUS_IN_TESTS",
+        "--event",
+        "push",
+    )
+    assert concrete_skus(matrix) == {
+        "wh_n150_civ2",
+        "wh_n300_civ2",
+        "wh_llmbox_civ2_viommu",
+        "bh_p150b_civ2_viommu",
+    }
+
+
+def test_runtime_smoke_merge_gate_routes_prio_on_merge_group():
+    matrix = run_matrix(
+        PIPELINE / "runtime_validation_merge_gate_tests.yaml",
+        "ALL_SKUS_IN_TESTS",
+        "--event",
+        "merge_group",
+    )
+    assert concrete_skus(matrix) == {
+        "wh_n150_civ2",
+        "wh_n300_civ2",
+        "wh_llmbox_civ2_prio",
+        "bh_p150b_civ2_viommu_prio",
+    }
+
+
+def test_runtime_basic_merge_gate_matches_prior_coverage():
+    push = run_matrix(
+        PIPELINE / "runtime_validation_basic_tests.yaml",
+        "ALL_SKUS_IN_TESTS",
+        "--event",
+        "push",
+    )
+    mq = run_matrix(
+        PIPELINE / "runtime_validation_basic_tests.yaml",
+        "ALL_SKUS_IN_TESTS",
+        "--event",
+        "merge_group",
+    )
+    assert concrete_skus(push) == {"wh_n150_civ2", "bh_p150b_civ2_viommu"}
+    assert concrete_skus(mq) == {"wh_n150_civ2", "bh_p150b_civ2_viommu_prio"}
+
+
+def test_llk_merge_gate_allowlist_wh_only():
+    matrix = run_matrix(
+        PIPELINE / "llk_merge_gate_tests.yaml",
+        "ALL_SKUS_IN_TESTS",
+        "--event",
+        "push",
+        "--sku-allowlist",
+        "wh_n150_civ2",
+    )
+    assert concrete_skus(matrix) == {"wh_n150_civ2"}
+    assert len(matrix) == 5  # 4 FD shards + 1 SD
+
+
+def test_llk_merge_gate_allowlist_bh_routes_prio():
+    matrix = run_matrix(
+        PIPELINE / "llk_merge_gate_tests.yaml",
+        "ALL_SKUS_IN_TESTS",
+        "--event",
+        "merge_group",
+        "--sku-allowlist",
+        "bh_p150b_civ2_viommu",
+    )
+    assert concrete_skus(matrix) == {"bh_p150b_civ2_viommu_prio"}
+    assert len(matrix) == 3  # 2 FD shards + 1 SD
+    assert all(e["logical_sku"] == "bh_p150b_civ2_viommu" for e in matrix)
+
+
+def test_llk_pr_gate_uses_viommu_not_bh_p150b_civ2():
+    """Functional change: PR LLK BH moved from bh_p150b_civ2 to bh_p150b_civ2_viommu."""
+    pr = run_matrix(
+        PIPELINE / "llk_pr_gate_tests.yaml",
+        "ALL_SKUS_IN_TESTS",
+        "--event",
+        "pull_request",
+    )
+    mq = run_matrix(
+        PIPELINE / "llk_pr_gate_tests.yaml",
+        "ALL_SKUS_IN_TESTS",
+        "--event",
+        "merge_group",
+    )
+    assert concrete_skus(pr) == {"wh_n150_civ2", "bh_p150b_civ2_viommu"}
+    assert "bh_p150b_civ2" not in concrete_skus(pr)
+    assert concrete_skus(mq) == {"wh_n150_civ2", "bh_p150b_civ2_viommu_prio"}
+
+
+def test_gate_yamls_have_no_prio_twin_keys():
+    gate_globs = [
+        "*merge_gate*.yaml",
+        "*pr_gate*.yaml",
+        "*validation_basic*.yaml",
+        "runtime_examples_pr_gate_tests.yaml",
+        "ttnn_examples_pr_gate_tests.yaml",
+        "triage_merge_gate_tests.yaml",
+        "train_merge_gate_tests.yaml",
+        "fabric_merge_gate_tests.yaml",
+        "fabric_cpu_only_smoke_merge_gate_tests.yaml",
+    ]
+    leftovers = []
+    for pattern in gate_globs:
+        for path in PIPELINE.glob(pattern):
+            text = path.read_text()
+            # Ignore commented examples mentioning prio.
+            for i, line in enumerate(text.splitlines(), 1):
+                stripped = line.lstrip()
+                if stripped.startswith("#"):
+                    continue
+                if "_prio" in line:
+                    leftovers.append(f"{path.name}:{i}:{line.strip()}")
+    assert leftovers == []

--- a/.github/scripts/utils/test_prepare_test_matrix.py
+++ b/.github/scripts/utils/test_prepare_test_matrix.py
@@ -289,6 +289,33 @@ def test_backcompat_explicit_csv_enabled_skus_filters(tests_yaml: Path):
     assert concrete_skus(matrix) == {"wh_n150_civ2", "bh_p150b_civ2_viommu"}
 
 
+def test_all_skus_on_empty_list_yaml_yields_empty_matrix(tmp_path: Path):
+    """Placeholder gate list ('[]') + ALL_SKUS_IN_TESTS skips, does not fail."""
+    path = tmp_path / "empty.yaml"
+    path.write_text("[]\n")
+    matrix = run_matrix(path, "ALL_SKUS_IN_TESTS", "--event", "merge_group")
+    assert matrix == []
+
+
+def test_all_skus_on_comment_only_yaml_yields_empty_matrix(tmp_path: Path):
+    """Commented-out entries (yaml parses to None) also skip rather than fail."""
+    path = tmp_path / "comments.yaml"
+    path.write_text("# just a header\n# - name: not yet\n")
+    matrix = run_matrix(path, "ALL_SKUS_IN_TESTS")
+    assert matrix == []
+
+
+def test_models_merge_gate_placeholder_skips(tmp_path: Path):
+    """The real (currently empty) models gate list must not fail on merge_group."""
+    matrix = run_matrix(
+        PIPELINE / "models_merge_gate_tests.yaml",
+        "ALL_SKUS_IN_TESTS",
+        "--event",
+        "merge_group",
+    )
+    assert matrix == []
+
+
 def test_broken_merge_queue_alias_fails(tmp_path: Path):
     tests = tmp_path / "tests.yaml"
     tests.write_text(

--- a/.github/scripts/utils/test_prepare_test_matrix.py
+++ b/.github/scripts/utils/test_prepare_test_matrix.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Tests for prepare_test_matrix event routing and sku allowlist."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = Path(__file__).resolve().parent / "prepare_test_matrix.py"
+SKU_CONFIG = REPO_ROOT / ".github" / "sku_config.yaml"
+
+
+@pytest.fixture
+def tests_yaml(tmp_path: Path) -> Path:
+    """Logical-only smoke-like fixture (no prio twin keys)."""
+    path = tmp_path / "tests.yaml"
+    path.write_text(
+        textwrap.dedent(
+            """\
+            - name: sample test
+              cmd: echo ok
+              skus:
+                wh_n150_civ2:
+                  timeout: 15
+                bh_p150b_civ2_viommu:
+                  timeout: 15
+                wh_llmbox_civ2_viommu:
+                  timeout: 15
+              team: runtime
+              owner_id: U000
+            """
+        )
+    )
+    return path
+
+
+def run_matrix(tests_yaml: Path, enabled: str, *extra: str) -> list:
+    cmd = [
+        sys.executable,
+        str(SCRIPT),
+        str(tests_yaml),
+        enabled,
+        str(SKU_CONFIG),
+        *extra,
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    assert result.returncode == 0, result.stdout + result.stderr
+    # Last line with matrix= for local runs
+    for line in reversed(result.stdout.splitlines()):
+        if line.startswith("matrix="):
+            return json.loads(line[len("matrix=") :])
+    raise AssertionError(f"No matrix= in output:\n{result.stdout}")
+
+
+def test_default_no_event_keeps_logical_skus(tests_yaml: Path):
+    matrix = run_matrix(tests_yaml, "ALL_SKUS_IN_TESTS")
+    skus = sorted(e["sku"] for e in matrix)
+    assert skus == [
+        "bh_p150b_civ2_viommu",
+        "wh_llmbox_civ2_viommu",
+        "wh_n150_civ2",
+    ]
+    assert all("logical_sku" not in e for e in matrix)
+
+
+def test_merge_group_rewrites_aliased_skus(tests_yaml: Path):
+    matrix = run_matrix(tests_yaml, "ALL_SKUS_IN_TESTS", "--event", "merge_group")
+    by_logical = {e.get("logical_sku", e["sku"]): e for e in matrix}
+
+    assert by_logical["wh_n150_civ2"]["sku"] == "wh_n150_civ2"
+    assert "logical_sku" not in by_logical["wh_n150_civ2"]
+
+    assert by_logical["bh_p150b_civ2_viommu"]["sku"] == "bh_p150b_civ2_viommu_prio"
+    assert by_logical["bh_p150b_civ2_viommu"]["runs_on"] == ["tt-ubuntu-2204-P150b-viommu-prio-stable"]
+
+    assert by_logical["wh_llmbox_civ2_viommu"]["sku"] == "wh_llmbox_civ2_prio"
+    assert by_logical["wh_llmbox_civ2_viommu"]["runs_on"] == ["tt-ubuntu-2204-N300-llmbox-viommu-prio-stable"]
+
+
+def test_pull_request_does_not_rewrite(tests_yaml: Path):
+    matrix = run_matrix(tests_yaml, "ALL_SKUS_IN_TESTS", "--event", "pull_request")
+    skus = sorted(e["sku"] for e in matrix)
+    assert skus == [
+        "bh_p150b_civ2_viommu",
+        "wh_llmbox_civ2_viommu",
+        "wh_n150_civ2",
+    ]
+
+
+def test_empty_allowlist_skips_all(tests_yaml: Path):
+    matrix = run_matrix(tests_yaml, "ALL_SKUS_IN_TESTS", "--sku-allowlist", "")
+    assert matrix == []
+
+
+def test_allowlist_intersects(tests_yaml: Path):
+    matrix = run_matrix(
+        tests_yaml,
+        "ALL_SKUS_IN_TESTS",
+        "--sku-allowlist",
+        "wh_n150_civ2",
+    )
+    assert len(matrix) == 1
+    assert matrix[0]["sku"] == "wh_n150_civ2"
+
+
+def test_allowlist_then_merge_group_route(tests_yaml: Path):
+    matrix = run_matrix(
+        tests_yaml,
+        "ALL_SKUS_IN_TESTS",
+        "--sku-allowlist",
+        "bh_p150b_civ2_viommu",
+        "--event",
+        "merge_group",
+    )
+    assert len(matrix) == 1
+    assert matrix[0]["sku"] == "bh_p150b_civ2_viommu_prio"
+    assert matrix[0]["logical_sku"] == "bh_p150b_civ2_viommu"
+
+
+def test_sku_config_aliases_point_at_grouped_prio_skus():
+    with open(SKU_CONFIG) as f:
+        cfg = yaml.safe_load(f)["skus"]
+
+    assert cfg["bh_p150b_civ2_viommu"]["merge_queue_sku"] == "bh_p150b_civ2_viommu_prio"
+    assert cfg["wh_llmbox_civ2_viommu"]["merge_queue_sku"] == "wh_llmbox_civ2_prio"
+    assert cfg["cpu_medium"]["merge_queue_sku"] == "cpu_medium_prio"
+
+    # Many-to-one is allowed; prio targets must exist as concrete entries
+    for logical in ("bh_p150b_civ2_viommu", "wh_llmbox_civ2_viommu", "cpu_medium"):
+        alias = cfg[logical]["merge_queue_sku"]
+        assert alias in cfg
+        assert "runs_on" in cfg[alias]

--- a/.github/scripts/utils/test_prepare_test_matrix.py
+++ b/.github/scripts/utils/test_prepare_test_matrix.py
@@ -353,8 +353,8 @@ def test_sku_config_aliases_point_at_grouped_prio_skus():
 # ---------------------------------------------------------------------------
 
 
-def test_runtime_smoke_merge_gate_push_includes_n150():
-    """Functional change: merge-gate smoke now runs wh_n150_civ2 (was filtered out)."""
+def test_runtime_smoke_merge_gate_excludes_n150():
+    """Merge-gate smoke keeps prior coverage (no wh_n150_civ2); PR-gate list owns n150."""
     matrix = run_matrix(
         PIPELINE / "runtime_validation_merge_gate_tests.yaml",
         "ALL_SKUS_IN_TESTS",
@@ -362,11 +362,11 @@ def test_runtime_smoke_merge_gate_push_includes_n150():
         "push",
     )
     assert concrete_skus(matrix) == {
-        "wh_n150_civ2",
         "wh_n300_civ2",
         "wh_llmbox_civ2_viommu",
         "bh_p150b_civ2_viommu",
     }
+    assert "wh_n150_civ2" not in concrete_skus(matrix)
 
 
 def test_runtime_smoke_merge_gate_routes_prio_on_merge_group():
@@ -377,7 +377,6 @@ def test_runtime_smoke_merge_gate_routes_prio_on_merge_group():
         "merge_group",
     )
     assert concrete_skus(matrix) == {
-        "wh_n150_civ2",
         "wh_n300_civ2",
         "wh_llmbox_civ2_prio",
         "bh_p150b_civ2_viommu_prio",

--- a/.github/scripts/utils/test_prepare_test_matrix.py
+++ b/.github/scripts/utils/test_prepare_test_matrix.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 import textwrap
@@ -230,7 +231,11 @@ def test_explicit_event_overrides_env(tests_yaml: Path):
 
 
 def test_backcompat_no_flags_with_dual_sku_list(tmp_path: Path):
-    """Non-migrated lists that still list prio twins keep expanding both without --event."""
+    """Synthetic: listing prio twins still expands both if someone misconfigures a YAML.
+
+    Production pipeline_reorg lists must not contain *_prio keys (see
+    test_pipeline_reorg_yamls_have_no_prio_sku_keys).
+    """
     path = tmp_path / "legacy.yaml"
     path.write_text(
         textwrap.dedent(
@@ -252,7 +257,11 @@ def test_backcompat_no_flags_with_dual_sku_list(tmp_path: Path):
 
 
 def test_dual_sku_list_plus_merge_group_duplicates_prio(tmp_path: Path):
-    """Calling --event merge_group while YAML still has prio twins duplicates prio rows."""
+    """Hazard if a test list still has prio twins AND --event merge_group is set.
+
+    Gate/non-gate pipeline_reorg YAMLs must not list *_prio; this guards the script
+    contract so a regression is obvious.
+    """
     path = tmp_path / "legacy.yaml"
     path.write_text(
         textwrap.dedent(
@@ -438,27 +447,15 @@ def test_llk_pr_gate_uses_viommu_not_bh_p150b_civ2():
     assert concrete_skus(mq) == {"wh_n150_civ2", "bh_p150b_civ2_viommu_prio"}
 
 
-def test_gate_yamls_have_no_prio_twin_keys():
-    gate_globs = [
-        "*merge_gate*.yaml",
-        "*pr_gate*.yaml",
-        "*validation_basic*.yaml",
-        "runtime_examples_pr_gate_tests.yaml",
-        "ttnn_examples_pr_gate_tests.yaml",
-        "triage_merge_gate_tests.yaml",
-        "train_merge_gate_tests.yaml",
-        "fabric_merge_gate_tests.yaml",
-        "fabric_cpu_only_smoke_merge_gate_tests.yaml",
-    ]
+def test_pipeline_reorg_yamls_have_no_prio_sku_keys():
+    """Prio SKUs belong only in sku_config (merge_queue_sku targets), never in test lists."""
     leftovers = []
-    for pattern in gate_globs:
-        for path in PIPELINE.glob(pattern):
-            text = path.read_text()
-            # Ignore commented examples mentioning prio.
-            for i, line in enumerate(text.splitlines(), 1):
-                stripped = line.lstrip()
-                if stripped.startswith("#"):
-                    continue
-                if "_prio" in line:
-                    leftovers.append(f"{path.name}:{i}:{line.strip()}")
+    sku_prio = re.compile(r"^(\s*)([A-Za-z0-9_]*_prio)\s*:")
+    for path in sorted(PIPELINE.rglob("*.yaml")):
+        for i, line in enumerate(path.read_text().splitlines(), 1):
+            if line.lstrip().startswith("#"):
+                continue
+            m = sku_prio.match(line)
+            if m:
+                leftovers.append(f"{path.name}:{i}:{m.group(2)}")
     assert leftovers == []

--- a/.github/scripts/utils/verify_time_budget.py
+++ b/.github/scripts/utils/verify_time_budget.py
@@ -1,10 +1,10 @@
+import argparse
 import yaml
 import sys
-import os
 from collections import defaultdict
 
 
-def verify_timeouts(tests_file, time_budget_file, workflow_name, tier=None):
+def verify_timeouts(tests_file, time_budget_file, workflow_name, tier=None, max_per_test_timeout=None):
     """
     Verifies that the SUM of all test timeouts for each (Team, SKU) pair in tests_file
     is within the total time budget defined in time_budget_file for the given workflow.
@@ -13,6 +13,10 @@ def verify_timeouts(tests_file, time_budget_file, workflow_name, tier=None):
     the budget is looked up under the per-tier key "<workflow_name>_tier<tier>" (e.g.
     "unit_tier1"). When `tier` is None the behaviour is unchanged: every SKU entry is
     summed and the budget is looked up under the plain "<workflow_name>" key.
+
+    When `max_per_test_timeout` is provided, every individual SKU timeout in the tests
+    file must be <= that limit (minutes). Used by smoke/basic to enforce a per-entry
+    ceiling for a given pipeline (e.g. merge_gate).
     """
     budget_workflow = workflow_name if tier is None else f"{workflow_name}_tier{tier}"
 
@@ -22,10 +26,13 @@ def verify_timeouts(tests_file, time_budget_file, workflow_name, tier=None):
 
     print(f"Loading tests from: {tests_file}")
     with open(tests_file, "r") as f:
-        tests = yaml.safe_load(f)
+        tests = yaml.safe_load(f) or []
 
     if tier is not None:
         print(f"Filtering tests to tier '{tier}'; budgets looked up under workflow key '{budget_workflow}'.")
+
+    if max_per_test_timeout is not None:
+        print(f"Enforcing max per-test timeout of {max_per_test_timeout} min " f"for pipeline '{workflow_name}'.")
 
     errors_found = False
 
@@ -72,13 +79,21 @@ def verify_timeouts(tests_file, time_budget_file, workflow_name, tier=None):
 
             test_timeout = sku_config["timeout"]
 
+            if max_per_test_timeout is not None and float(test_timeout) > float(max_per_test_timeout):
+                print(
+                    f"  [ERROR] Per-test timeout FAILED! Test '{test_name}', SKU '{sku_name}' "
+                    f"has timeout {test_timeout} min, which exceeds the max per-test timeout of "
+                    f"{max_per_test_timeout} min for pipeline '{workflow_name}'."
+                )
+                errors_found = True
+
             # Use a tuple (team, sku) as the key for summation
             budget_key = (test_team, sku_name)
             budget_totals[budget_key] += test_timeout
             print(f"  Test '{test_name}' (Team: {test_team}, SKU: {sku_name}) adds {test_timeout} min.")
 
     if errors_found:
-        print(f"\nMissing keys in {tests_file}. Please fix the entries above.")
+        print(f"\nValidation errors in {tests_file}. Please fix the entries above.")
         sys.exit(1)
 
     # --- Part 2: Verify Total Time Budget for each (Team, SKU) pair ---
@@ -119,15 +134,25 @@ def verify_timeouts(tests_file, time_budget_file, workflow_name, tier=None):
 
 
 if __name__ == "__main__":
-    if len(sys.argv) not in (4, 5):
-        print(
-            "Usage: python verify_time_budget.py <path_to_tests.yaml> <path_to_time_budget.yaml> "
-            "<workflow_name> [<tier>]"
-        )
-        sys.exit(1)
+    parser = argparse.ArgumentParser(
+        description="Verify test yaml timeouts against team time budgets (and optional per-test ceiling)."
+    )
+    parser.add_argument("tests_file", help="Path to pipeline_reorg tests yaml")
+    parser.add_argument("time_budget_file", help="Path to time_budget.yaml")
+    parser.add_argument("workflow_name", help="Budget workflow key (e.g. merge_gate, pr_gate, unit)")
+    parser.add_argument(
+        "tier",
+        nargs="?",
+        default=None,
+        help="Optional tier; budgets looked up under <workflow_name>_tier<tier>",
+    )
+    parser.add_argument(
+        "--max-per-test-timeout",
+        type=float,
+        default=None,
+        help="Optional max allowed timeout (minutes) for any individual test SKU entry",
+    )
+    args = parser.parse_args()
 
-    # Optional tier arg: when given (and non-empty) budgets are checked per tier
-    # under the "<workflow_name>_tier<tier>" key.
-    tier_arg = sys.argv[4].strip() if len(sys.argv) == 5 and sys.argv[4].strip() else None
-
-    verify_timeouts(sys.argv[1], sys.argv[2], sys.argv[3], tier_arg)
+    tier_arg = args.tier.strip() if args.tier and args.tier.strip() else None
+    verify_timeouts(args.tests_file, args.time_budget_file, args.workflow_name, tier_arg, args.max_per_test_timeout)

--- a/.github/sku_config.yaml
+++ b/.github/sku_config.yaml
@@ -3,6 +3,9 @@
 
 # Each SKU entry contains:
 #   runs_on: Array of GitHub Actions runner labels that tests for this SKU.
+#   merge_queue_sku: (Optional) Concrete prio SKU to use when github.event_name is
+#     merge_group. Logical test-list SKUs should set this instead of listing prio
+#     SKUs in YAML. Multiple logical SKUs may share the same merge_queue_sku.
 #   allocation: (Optional) Configuration for TTOP allocation
 #     type: "Count" or "MGD"
 #     count: Number of nodes (for Count type)
@@ -92,10 +95,7 @@ skus:
   wh_llmbox_civ2_viommu:
     runs_on:
       - tt-ubuntu-2204-N300-llmbox-viommu-stable
-
-  wh_llmbox_civ2_prio:
-    runs_on:
-      - tt-ubuntu-2204-N300-llmbox-viommu-prio-stable
+    merge_queue_sku: wh_llmbox_civ2_prio
 
   bh_p100_perf:
     runs_on:
@@ -110,10 +110,7 @@ skus:
   bh_p150b_civ2_viommu:
     runs_on:
       - tt-ubuntu-2204-P150b-viommu-stable
-
-  bh_p150b_civ2_viommu_prio:
-    runs_on:
-      - tt-ubuntu-2204-P150b-viommu-prio-stable
+    merge_queue_sku: bh_p150b_civ2_viommu_prio
 
   bh_p150b_civ2:
     runs_on:
@@ -230,6 +227,21 @@ skus:
   cpu_medium:
     runs_on:
       - tt-ubuntu-2204-medium-stable
+    merge_queue_sku: cpu_medium_prio
+
+  # ---------------------------------------------------------------------------
+  # Merge-queue prio SKUs (merge_group events only).
+  # Referenced from logical SKUs via merge_queue_sku; do not list these in test
+  # YAML skus maps. Multiple logical SKUs may share the same merge_queue_sku.
+  # ---------------------------------------------------------------------------
+  wh_llmbox_civ2_prio:
+    runs_on:
+      - tt-ubuntu-2204-N300-llmbox-viommu-prio-stable
+
+  bh_p150b_civ2_viommu_prio:
+    runs_on:
+      - tt-ubuntu-2204-P150b-viommu-prio-stable
+
   cpu_medium_prio:
     runs_on:
       - tt-ubuntu-2204-medium-prio-stable

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -254,8 +254,7 @@ triage:
 llk:
   pr_gate:
     wh_n150_civ2: 40
-    bh_p150b_civ2: 40
-    bh_p150b_civ2_viommu_prio: 40
+    bh_p150b_civ2_viommu: 40
   unit:
     wh_n150_civ2: 40
     wh_n300_civ2: 40
@@ -273,7 +272,6 @@ llk:
     wh_n150_civ2: 300
     bh_p150b_civ2: 160
     bh_p150b_civ2_viommu: 70
-    bh_p150b_civ2_viommu_prio: 70
 
 models:
   merge_gate:

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -77,9 +77,7 @@ ttnn:
     wh_n150_civ2: 45
     wh_n300_civ2: 55
     wh_llmbox_civ2_viommu: 15
-    wh_llmbox_civ2_prio: 15
     bh_p150b_civ2_viommu: 45
-    bh_p150b_civ2_viommu_prio: 45
     sim_wormhole_b0: 40
     sim_blackhole: 40
   sanity:
@@ -216,9 +214,7 @@ runtime:
     wh_n150_civ2: 45
     wh_n300_civ2: 15
     wh_llmbox_civ2_viommu: 15
-    wh_llmbox_civ2_prio: 15
     bh_p150b_civ2_viommu: 45
-    bh_p150b_civ2_viommu_prio: 45
   sanity:
     wh_n150_civ2: 13
     bh_p150b_civ2: 13

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -248,7 +248,6 @@ triage:
     bh_p150b_civ2_viommu: 11
   unit:
     wh_n150_civ2: 16
-    bh_p150b_civ2_viommu_prio: 16
     bh_p150b_civ2_viommu: 16
 
 llk:
@@ -260,7 +259,6 @@ llk:
     wh_n300_civ2: 40
     bh_p150: 40
     bh_p150b_civ2_viommu: 110
-    bh_p150b_civ2_viommu_prio: 70
     bh_p100: 40
   e2e:
     wh_n150_civ2: 1800

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -268,7 +268,6 @@ llk:
     bh_p150b_civ2: 1200
   merge_gate:
     wh_n150_civ2: 300
-    bh_p150b_civ2: 160
     bh_p150b_civ2_viommu: 70
 
 models:

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -176,7 +176,6 @@ shield:
 scaleout:
   merge_gate:
     cpu_medium: 10
-    cpu_medium_prio: 10
     wh_n300_civ2: 10
   unit:
     cpu_medium: 235 # fabric CPU-only shards: unit/sp4-glx/subtorus/pod-revAB/pod-revC ×15 + bh-slices ×25 + pod-llama ×55 + bh-subtorus-sc20 ×40 + bh-blitz-decode ×30 + bh-ring-stress ×10
@@ -246,7 +245,6 @@ runtime:
 triage:
   merge_gate:
     wh_n150_civ2: 11
-    bh_p150b_civ2_viommu_prio: 11
     bh_p150b_civ2_viommu: 11
   unit:
     wh_n150_civ2: 16

--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -16,7 +16,11 @@ on:
       per-test-timeout:
         required: false
         type: string
-        default: "10"
+        default: ""
+        description: >-
+          Max allowed timeout (minutes) for any individual test SKU entry in the
+          tests yaml. Verified during load-test-matrix via verify_time_budget.py.
+          Empty skips the per-test ceiling check.
       product:
         required: true
         type: string # tt-metalium or tt-nn
@@ -52,11 +56,16 @@ jobs:
 
       - name: Verify test timeouts against budget
         run: |
-          set -e
+          set -euo pipefail
+          extra=()
+          if [ -n "${{ inputs.per-test-timeout }}" ]; then
+            extra+=(--max-per-test-timeout "${{ inputs.per-test-timeout }}")
+          fi
           python3 .github/scripts/utils/verify_time_budget.py \
             "${{ env.TESTS_YAML_PATH }}" \
             ./.github/time_budget.yaml \
-            "${{ inputs.test-category }}"
+            "${{ inputs.test-category }}" \
+            "${extra[@]}"
 
       - name: Build test matrix based on enabled SKUs
         id: build-matrix
@@ -154,8 +163,3 @@ jobs:
         with:
           path: /work/test-reports/
           prefix: "test_reports_"
-
-      - name: Check for slow tests
-        uses: tenstorrent/tt-metal/.github/actions/detect-slow-tests@main
-        with:
-          threshold: ${{ inputs.per-test-timeout }}

--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -73,7 +73,8 @@ jobs:
           python3 .github/scripts/utils/prepare_test_matrix.py \
             "${{ env.TESTS_YAML_PATH }}" \
             "${{ inputs.enabled-skus }}" \
-            ./.github/sku_config.yaml
+            ./.github/sku_config.yaml \
+            --event "${{ github.event_name }}"
 
   basic:
     needs: load-test-matrix

--- a/.github/workflows/fabric-build-and-unit-tests.yaml
+++ b/.github/workflows/fabric-build-and-unit-tests.yaml
@@ -36,6 +36,14 @@ on:
         required: false
         type: boolean
         default: false
+      per-test-timeout:
+        required: false
+        type: string
+        default: ""
+        description: >-
+          Max allowed timeout (minutes) for any individual test SKU entry in the
+          tests yaml. Verified during load-test-matrix via verify_time_budget.py.
+          Empty skips the per-test ceiling check.
 
 jobs:
   load-test-matrix:
@@ -59,11 +67,16 @@ jobs:
 
       - name: Verify test timeouts against budget
         run: |
-          set -e
+          set -euo pipefail
+          extra=()
+          if [ -n "${{ inputs.per-test-timeout }}" ]; then
+            extra+=(--max-per-test-timeout "${{ inputs.per-test-timeout }}")
+          fi
           python3 .github/scripts/utils/verify_time_budget.py \
             ${{ env.TESTS_YAML_PATH }} \
             ./.github/time_budget.yaml \
-            "${{ inputs.test-category }}"
+            "${{ inputs.test-category }}" \
+            "${extra[@]}"
 
       - name: Build test matrix based on enabled SKUs
         id: build-matrix

--- a/.github/workflows/fabric-build-and-unit-tests.yaml
+++ b/.github/workflows/fabric-build-and-unit-tests.yaml
@@ -84,7 +84,8 @@ jobs:
           python3 .github/scripts/utils/prepare_test_matrix.py \
             ${{ env.TESTS_YAML_PATH }} \
             "${{ inputs.enabled-skus }}" \
-            ./.github/sku_config.yaml
+            ./.github/sku_config.yaml \
+            --event "${{ github.event_name }}"
 
   fabric-tests:
     needs: load-test-matrix

--- a/.github/workflows/fabric-cpu-only-tests-impl.yaml
+++ b/.github/workflows/fabric-cpu-only-tests-impl.yaml
@@ -56,9 +56,8 @@ jobs:
         run: pip3 install PyYAML
       - name: Verify test timeouts against budget
         run: |
-          set -e
-          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
           set -euo pipefail
+          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
           extra=()
           if [ -n "${{ inputs.per-test-timeout }}" ]; then
             extra+=(--max-per-test-timeout "${{ inputs.per-test-timeout }}")

--- a/.github/workflows/fabric-cpu-only-tests-impl.yaml
+++ b/.github/workflows/fabric-cpu-only-tests-impl.yaml
@@ -74,7 +74,8 @@ jobs:
           python3 .github/scripts/utils/prepare_test_matrix.py \
             ${{ env.TESTS_YAML_PATH }} \
             "${{ inputs.runs-on-sku }}" \
-            ./.github/sku_config.yaml
+            ./.github/sku_config.yaml \
+            --event "${{ github.event_name }}"
 
   fabric-cpu-unit-tests:
     needs: load-test-matrix

--- a/.github/workflows/fabric-cpu-only-tests-impl.yaml
+++ b/.github/workflows/fabric-cpu-only-tests-impl.yaml
@@ -27,6 +27,14 @@ on:
       wheel-artifact-name:
         required: true
         type: string
+      per-test-timeout:
+        required: false
+        type: string
+        default: ""
+        description: >-
+          Max allowed timeout (minutes) for any individual test SKU entry in the
+          tests yaml. Verified during load-test-matrix via verify_time_budget.py.
+          Empty skips the per-test ceiling check.
 
 jobs:
   load-test-matrix:
@@ -50,10 +58,16 @@ jobs:
         run: |
           set -e
           echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
+          set -euo pipefail
+          extra=()
+          if [ -n "${{ inputs.per-test-timeout }}" ]; then
+            extra+=(--max-per-test-timeout "${{ inputs.per-test-timeout }}")
+          fi
           python3 .github/scripts/utils/verify_time_budget.py \
             ${{ env.TESTS_YAML_PATH }} \
             ./.github/time_budget.yaml \
-            "${{ inputs.test-category }}"
+            "${{ inputs.test-category }}" \
+            "${extra[@]}"
       - name: Build unified test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/llk-smoke-impl.yaml
+++ b/.github/workflows/llk-smoke-impl.yaml
@@ -24,6 +24,14 @@ on:
           Max allowed timeout (minutes) for any individual test SKU entry in the
           tests yaml. Verified during load-test-matrix via verify_time_budget.py.
           Empty skips the per-test ceiling check.
+      sku-allowlist:
+        required: false
+        type: string
+        default: "*"
+        description: >-
+          Optional logical SKU allowlist (comma-separated) for change gating.
+          Default "*" means no extra filter. Empty string skips all tests.
+          Any other value is forwarded as --sku-allowlist.
 
 permissions:
   checks: write
@@ -65,10 +73,19 @@ jobs:
       - name: Build test matrix
         id: build-matrix
         run: |
+          set -euo pipefail
+          allowlist_args=()
+          allowlist='${{ inputs.sku-allowlist }}'
+          # "*" (default) = omit flag (no filter). Empty = skip all. Else CSV.
+          if [ "$allowlist" != '*' ]; then
+            allowlist_args+=(--sku-allowlist "$allowlist")
+          fi
           python3 .github/scripts/utils/prepare_test_matrix.py \
             ${{ env.TESTS_YAML_PATH }} \
             "${{ inputs.enabled-skus }}" \
-            ./.github/sku_config.yaml
+            ./.github/sku_config.yaml \
+            --event "${{ github.event_name }}" \
+            "${allowlist_args[@]}"
 
   llk-smoke-exec:
     needs: load-test-matrix

--- a/.github/workflows/llk-smoke-impl.yaml
+++ b/.github/workflows/llk-smoke-impl.yaml
@@ -16,6 +16,14 @@ on:
         required: false
         type: string
         default: "not perf and not nightly and not quasar"
+      per-test-timeout:
+        required: false
+        type: string
+        default: ""
+        description: >-
+          Max allowed timeout (minutes) for any individual test SKU entry in the
+          tests yaml. Verified during load-test-matrix via verify_time_budget.py.
+          Empty skips the per-test ceiling check.
 
 permissions:
   checks: write
@@ -44,11 +52,16 @@ jobs:
         run: pip3 install PyYAML
       - name: Verify test timeouts against budget
         run: |
-          set -e
+          set -euo pipefail
+          extra=()
+          if [ -n "${{ inputs.per-test-timeout }}" ]; then
+            extra+=(--max-per-test-timeout "${{ inputs.per-test-timeout }}")
+          fi
           python3 .github/scripts/utils/verify_time_budget.py \
             ${{ env.TESTS_YAML_PATH }} \
             ./.github/time_budget.yaml \
-            pr_gate
+            pr_gate \
+            "${extra[@]}"
       - name: Build test matrix
         id: build-matrix
         run: |

--- a/.github/workflows/llk-unit-tests-impl.yaml
+++ b/.github/workflows/llk-unit-tests-impl.yaml
@@ -23,6 +23,14 @@ on:
         type: boolean
         default: true
         description: "Enable LLK asserts"
+      per-test-timeout:
+        required: false
+        type: string
+        default: ""
+        description: >-
+          Max allowed timeout (minutes) for any individual test SKU entry in the
+          tests yaml. Verified during load-test-matrix via verify_time_budget.py.
+          Empty skips the per-test ceiling check.
 
 jobs:
   load-test-matrix:
@@ -46,10 +54,16 @@ jobs:
         run: |
           set -e
           echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
+          set -euo pipefail
+          extra=()
+          if [ -n "${{ inputs.per-test-timeout }}" ]; then
+            extra+=(--max-per-test-timeout "${{ inputs.per-test-timeout }}")
+          fi
           python3 .github/scripts/utils/verify_time_budget.py \
             ${{ env.TESTS_YAML_PATH }} \
             ./.github/time_budget.yaml \
-            "${{ inputs.test-category }}"
+            "${{ inputs.test-category }}" \
+            "${extra[@]}"
       - name: Build unified test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/llk-unit-tests-impl.yaml
+++ b/.github/workflows/llk-unit-tests-impl.yaml
@@ -60,9 +60,8 @@ jobs:
         run: pip3 install PyYAML
       - name: Verify test timeouts against budget
         run: |
-          set -e
-          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
           set -euo pipefail
+          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
           extra=()
           if [ -n "${{ inputs.per-test-timeout }}" ]; then
             extra+=(--max-per-test-timeout "${{ inputs.per-test-timeout }}")

--- a/.github/workflows/llk-unit-tests-impl.yaml
+++ b/.github/workflows/llk-unit-tests-impl.yaml
@@ -31,6 +31,14 @@ on:
           Max allowed timeout (minutes) for any individual test SKU entry in the
           tests yaml. Verified during load-test-matrix via verify_time_budget.py.
           Empty skips the per-test ceiling check.
+      sku-allowlist:
+        required: false
+        type: string
+        default: "*"
+        description: >-
+          Optional logical SKU allowlist (comma-separated) for change gating.
+          Default "*" means no extra filter. Empty string skips all tests.
+          Any other value is forwarded as --sku-allowlist.
 
 jobs:
   load-test-matrix:
@@ -67,10 +75,19 @@ jobs:
       - name: Build unified test matrix based on enabled SKUs
         id: build-matrix
         run: |
+          set -euo pipefail
+          allowlist_args=()
+          allowlist='${{ inputs.sku-allowlist }}'
+          # "*" (default) = omit flag (no filter). Empty = skip all. Else CSV.
+          if [ "$allowlist" != '*' ]; then
+            allowlist_args+=(--sku-allowlist "$allowlist")
+          fi
           python3 .github/scripts/utils/prepare_test_matrix.py \
             ${{ env.TESTS_YAML_PATH }} \
             "${{ inputs.enabled-skus }}" \
-            ./.github/sku_config.yaml
+            ./.github/sku_config.yaml \
+            --event "${{ github.event_name }}" \
+            "${allowlist_args[@]}"
 
   llk-unit-tests:
     needs: load-test-matrix

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -450,8 +450,9 @@ jobs:
   # ===========================================================================
 
   # Merge-gate LLK gtest matrix (tests/pipeline_reorg/llk_merge_gate_tests.yaml).
-  # SKU coverage is narrowed below based on find-changes outputs. L2 nightly uses
-  # tests/pipeline_reorg/llk_unit_tests.yaml.
+  # SKU coverage is narrowed via sku-allowlist from find-changes. L2 nightly uses
+  # tests/pipeline_reorg/llk_unit_tests.yaml. merge_group prio routing is via
+  # prepare_test_matrix --event + sku_config merge_queue_sku.
   llk-unit-tests:
     needs: [build, resolve-docker-pull-refs, find-changes]
     if: ${{
@@ -472,10 +473,9 @@ jobs:
       docker-image: ${{ needs.resolve-docker-pull-refs.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
       per-test-timeout: 15
-      # Prio runner pool is reserved for merge-queue traffic; any other trigger
-      # (pull_request, push, etc.) routes blackhole jobs to the non-prio viommu
-      # variant so PR runs don't starve the merge-group queue.
-      enabled-skus: ${{
+      enabled-skus: ALL_SKUS_IN_TESTS
+      # "*" = no allowlist filter; empty = skip all; else CSV of logical SKUs.
+      sku-allowlist: ${{
           (github.ref_name == 'main'
            || needs.find-changes.outputs.llk-common-changed == 'true'
            || needs.find-changes.outputs.llk-sfpi-changed == 'true'
@@ -483,9 +483,9 @@ jobs:
            || needs.find-changes.outputs.llk-ci-changed == 'true'
            || (needs.find-changes.outputs.llk-wormhole-changed == 'true'
                && needs.find-changes.outputs.llk-blackhole-changed == 'true'))
-          && (github.event_name == 'merge_group' && 'wh_n150_civ2,bh_p150b_civ2_viommu_prio' || 'wh_n150_civ2,bh_p150b_civ2_viommu')
+          && '*'
           || (needs.find-changes.outputs.llk-wormhole-changed == 'true' && 'wh_n150_civ2')
-          || (needs.find-changes.outputs.llk-blackhole-changed == 'true' && (github.event_name == 'merge_group' && 'bh_p150b_civ2_viommu_prio' || 'bh_p150b_civ2_viommu'))
+          || (needs.find-changes.outputs.llk-blackhole-changed == 'true' && 'bh_p150b_civ2_viommu')
           || '' }}
 
   # ===========================================================================

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -299,7 +299,7 @@ jobs:
       docker-image: ${{ needs.resolve-docker-pull-refs.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
-      enabled-skus: ${{ github.event_name == 'merge_group' && 'wh_n150_civ2,bh_p150b_civ2_viommu_prio' || 'wh_n150_civ2,bh_p150b_civ2_viommu' }}
+      enabled-skus: ALL_SKUS_IN_TESTS
       per-test-timeout: 15
 
   # ===========================================================================
@@ -373,7 +373,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/models-smoke-tests-impl.yaml
     with:
-      enabled-skus: wh_galaxy_merge_gate
+      enabled-skus: ALL_SKUS_IN_TESTS
       docker-image: ${{ needs.resolve-docker-pull-refs.outputs.dev-docker-image }}
       harbor-prefix: ${{ needs.check-harbor.outputs.harbor-prefix }}
       build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
@@ -398,7 +398,7 @@ jobs:
     uses: ./.github/workflows/tt-train-tests.yaml
     with:
       test-category: merge_gate
-      enabled-skus: "wh_n150_civ2"
+      enabled-skus: ALL_SKUS_IN_TESTS
       docker-image: ${{ needs.build.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
       per-test-timeout: 15
@@ -438,7 +438,7 @@ jobs:
     with:
       tests-yaml-path: ./tests/pipeline_reorg/fabric_cpu_only_smoke_merge_gate_tests.yaml
       test-category: smoke
-      runs-on-sku: ${{ github.event_name == 'merge_group' && 'cpu_medium_prio' || 'cpu_medium' }}
+      runs-on-sku: cpu_medium
       docker-image: ${{ needs.resolve-docker-pull-refs.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -53,6 +53,10 @@ permissions:
   packages: write
 
 jobs:
+  # ===========================================================================
+  # Infrastructure (shared builds / images / change detection)
+  # ===========================================================================
+
   static-checks:
     # Workaround for https://github.com/orgs/community/discussions/46757?sort=old#discussioncomment-4909336
     # We must have this workflow trigger on PRs in order to allow us to require them in the merge queue.
@@ -82,7 +86,6 @@ jobs:
     uses: ./.github/workflows/check-harbor.yaml
     with:
       runs-on: ${{ github.event_name == 'merge_group' && 'tt-ubuntu-light-prio' || 'tt-ubuntu-light' }}
-
 
   find-changes:
     if: github.event.action != 'destroyed' && github.event_name != 'pull_request'
@@ -171,68 +174,6 @@ jobs:
       runs-on: ${{ github.event_name == 'merge_group' && 'tt-ubuntu-2204-large-prio-stable' || 'tt-ubuntu-2204-large-stable' }}
       fetch-depth: 1
 
-  build-sweeps:
-    if: ${{ github.ref_name == 'main' ||
-            needs.find-changes.outputs.cmake-changed == 'true' ||
-            needs.find-changes.outputs.any-code-changed == 'true'
-        }}
-    needs: [find-changes, docker-images, check-harbor]
-    uses: ./.github/workflows/build-wrapper.yaml
-    permissions:
-      contents: read
-      packages: write
-    secrets: inherit
-    with:
-      harbor-prefix: ${{ needs.check-harbor.outputs.harbor-prefix }}
-      ubuntu-2204-ci-build-tag: ${{ needs.docker-images.outputs.ubuntu-2204-ci-build-tag }}
-      ubuntu-2204-dev-tag: ${{ needs.docker-images.outputs.ubuntu-2204-dev-tag }}
-      ubuntu-2204-manylinux-tag: ${{ needs.docker-images.outputs.manylinux-tag }}
-      ubuntu-2404-ci-build-tag: ${{ needs.docker-images.outputs.ubuntu-2404-ci-build-tag }}
-      ubuntu-2404-dev-tag: ${{ needs.docker-images.outputs.ubuntu-2404-dev-tag }}
-      ubuntu-2404-manylinux-tag: ${{ needs.docker-images.outputs.manylinux-tag }}
-      runs-on: ${{ github.event_name == 'merge_group' && 'tt-ubuntu-2204-medium-prio-stable' || 'tt-ubuntu-2204-medium-stable' }}
-      fetch-depth: 1
-
-  resolve-docker-pull-refs-tsan:
-    needs: [check-harbor, build-tsan]
-    uses: ./.github/workflows/resolve-docker-pull-refs.yaml
-    with:
-      harbor-prefix: ${{ needs.check-harbor.outputs.harbor-prefix }}
-      dev-docker-image: ${{ needs.build-tsan.outputs.dev-docker-image }}
-
-  metalium-smoke-tests:
-    needs: [find-changes, resolve-docker-pull-refs-tsan, build-tsan, check-harbor]
-    if: ${{ github.ref_name == 'main' ||
-            needs.find-changes.outputs.cmake-changed == 'true' ||
-            needs.find-changes.outputs.tt-metalium-changed == 'true' ||
-            needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
-        }}
-    uses: ./.github/workflows/smoke.yaml
-    with:
-      docker-image: ${{ needs.resolve-docker-pull-refs-tsan.outputs.dev-docker-image }}
-      package-artifact-name: ${{ needs.build-tsan.outputs.packages-artifact-name }}
-      enabled-skus: ${{ github.event_name == 'merge_group' && 'wh_n300_civ2,wh_llmbox_civ2_prio,bh_p150b_civ2_viommu_prio' || 'wh_n300_civ2,wh_llmbox_civ2_viommu,bh_p150b_civ2_viommu' }}
-      per-test-timeout: 11 # TSan can be slow; relax the timeout somewhat
-      product: tt-metalium
-      enable-kernel-ccache: true
-
-  ttnn-smoke-tests:
-    needs: [find-changes, resolve-docker-pull-refs-tsan, build-tsan, check-harbor]
-    if: ${{ github.ref_name == 'main' ||
-            needs.find-changes.outputs.cmake-changed == 'true' ||
-            needs.find-changes.outputs.tt-metalium-changed == 'true' ||
-            needs.find-changes.outputs.tt-nn-changed == 'true' ||
-            needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
-        }}
-    uses: ./.github/workflows/smoke.yaml
-    with:
-      docker-image: ${{ needs.resolve-docker-pull-refs-tsan.outputs.dev-docker-image }}
-      package-artifact-name: ${{ needs.build-tsan.outputs.packages-artifact-name }}
-      enabled-skus: ${{ github.event_name == 'merge_group' && 'wh_n300_civ2,wh_llmbox_civ2_prio,bh_p150b_civ2_viommu_prio' || 'wh_n300_civ2,wh_llmbox_civ2_viommu,bh_p150b_civ2_viommu' }}
-      per-test-timeout: 11 # TSan can be slow; relax the timeout somewhat
-      product: tt-nn
-      enable-kernel-ccache: true
-
   build-asan:
     if: ${{ github.ref_name == 'main' ||
             needs.find-changes.outputs.cmake-changed == 'true' ||
@@ -261,6 +202,44 @@ jobs:
       runs-on: ${{ github.event_name == 'merge_group' && 'tt-ubuntu-2204-large-prio-stable' || 'tt-ubuntu-2204-large-stable' }}
       fetch-depth: 1
 
+  build-sweeps:
+    if: ${{ github.ref_name == 'main' ||
+            needs.find-changes.outputs.cmake-changed == 'true' ||
+            needs.find-changes.outputs.any-code-changed == 'true'
+        }}
+    needs: [find-changes, docker-images, check-harbor]
+    uses: ./.github/workflows/build-wrapper.yaml
+    permissions:
+      contents: read
+      packages: write
+    secrets: inherit
+    with:
+      harbor-prefix: ${{ needs.check-harbor.outputs.harbor-prefix }}
+      ubuntu-2204-ci-build-tag: ${{ needs.docker-images.outputs.ubuntu-2204-ci-build-tag }}
+      ubuntu-2204-dev-tag: ${{ needs.docker-images.outputs.ubuntu-2204-dev-tag }}
+      ubuntu-2204-manylinux-tag: ${{ needs.docker-images.outputs.manylinux-tag }}
+      ubuntu-2404-ci-build-tag: ${{ needs.docker-images.outputs.ubuntu-2404-ci-build-tag }}
+      ubuntu-2404-dev-tag: ${{ needs.docker-images.outputs.ubuntu-2404-dev-tag }}
+      ubuntu-2404-manylinux-tag: ${{ needs.docker-images.outputs.manylinux-tag }}
+      runs-on: ${{ github.event_name == 'merge_group' && 'tt-ubuntu-2204-medium-prio-stable' || 'tt-ubuntu-2204-medium-stable' }}
+      fetch-depth: 1
+
+  resolve-docker-pull-refs:
+    needs: [check-harbor, build]
+    uses: ./.github/workflows/resolve-docker-pull-refs.yaml
+    with:
+      harbor-prefix: ${{ needs.check-harbor.outputs.harbor-prefix }}
+      dev-docker-image: ${{ needs.build.outputs.dev-docker-image }}
+      basic-dev-docker-image: ${{ needs.build.outputs.basic-dev-docker-image }}
+      ci-test-docker-image: ${{ needs.build.outputs.ci-test-docker-image }}
+
+  resolve-docker-pull-refs-tsan:
+    needs: [check-harbor, build-tsan]
+    uses: ./.github/workflows/resolve-docker-pull-refs.yaml
+    with:
+      harbor-prefix: ${{ needs.check-harbor.outputs.harbor-prefix }}
+      dev-docker-image: ${{ needs.build-tsan.outputs.dev-docker-image }}
+
   resolve-docker-pull-refs-asan:
     needs: [check-harbor, build-asan]
     uses: ./.github/workflows/resolve-docker-pull-refs.yaml
@@ -268,7 +247,29 @@ jobs:
       harbor-prefix: ${{ needs.check-harbor.outputs.harbor-prefix }}
       dev-docker-image: ${{ needs.build-asan.outputs.dev-docker-image }}
 
-  metalium-basic-tests:
+  # ===========================================================================
+  # Team: runtime
+  # test list: runtime_validation_merge_gate_tests.yaml,
+  #            runtime_validation_basic_tests.yaml
+  # ===========================================================================
+
+  runtime-smoke-tests:
+    needs: [find-changes, resolve-docker-pull-refs-tsan, build-tsan, check-harbor]
+    if: ${{ github.ref_name == 'main' ||
+            needs.find-changes.outputs.cmake-changed == 'true' ||
+            needs.find-changes.outputs.tt-metalium-changed == 'true' ||
+            needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
+        }}
+    uses: ./.github/workflows/smoke.yaml
+    with:
+      docker-image: ${{ needs.resolve-docker-pull-refs-tsan.outputs.dev-docker-image }}
+      package-artifact-name: ${{ needs.build-tsan.outputs.packages-artifact-name }}
+      enabled-skus: ${{ github.event_name == 'merge_group' && 'wh_n300_civ2,wh_llmbox_civ2_prio,bh_p150b_civ2_viommu_prio' || 'wh_n300_civ2,wh_llmbox_civ2_viommu,bh_p150b_civ2_viommu' }}
+      per-test-timeout: 11 # TSan can be slow; relax the timeout somewhat
+      product: tt-metalium
+      enable-kernel-ccache: true
+
+  runtime-basic-tests:
     if: ${{
         github.ref_name == 'main' ||
         needs.find-changes.outputs.cmake-changed == 'true' ||
@@ -283,6 +284,47 @@ jobs:
       enabled-skus: ${{ github.event_name == 'merge_group' && 'wh_n150_civ2,bh_p150b_civ2_viommu_prio' || 'wh_n150_civ2,bh_p150b_civ2_viommu' }}
       per-test-timeout: 11
       product: tt-metalium
+
+  # ===========================================================================
+  # Team: triage
+  # test list: triage_merge_gate_tests.yaml
+  # (kept next to runtime in case the teams are combined later)
+  # ===========================================================================
+
+  triage-tests:
+    needs: [build, resolve-docker-pull-refs, find-changes, check-harbor]
+    secrets: inherit
+    uses: ./.github/workflows/triage-tests-impl.yaml
+    with:
+      test-category: merge_gate
+      docker-image: ${{ needs.resolve-docker-pull-refs.outputs.dev-docker-image }}
+      wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
+      build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
+      enabled-skus: ${{ github.event_name == 'merge_group' && 'wh_n150_civ2,bh_p150b_civ2_viommu_prio' || 'wh_n150_civ2,bh_p150b_civ2_viommu' }}
+
+  # ===========================================================================
+  # Team: ttnn
+  # test list: ttnn_validation_merge_gate_tests.yaml,
+  #            ttnn_validation_basic_tests.yaml,
+  #            ttnn_merge_gate_tests.yaml
+  # ===========================================================================
+
+  ttnn-smoke-tests:
+    needs: [find-changes, resolve-docker-pull-refs-tsan, build-tsan, check-harbor]
+    if: ${{ github.ref_name == 'main' ||
+            needs.find-changes.outputs.cmake-changed == 'true' ||
+            needs.find-changes.outputs.tt-metalium-changed == 'true' ||
+            needs.find-changes.outputs.tt-nn-changed == 'true' ||
+            needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
+        }}
+    uses: ./.github/workflows/smoke.yaml
+    with:
+      docker-image: ${{ needs.resolve-docker-pull-refs-tsan.outputs.dev-docker-image }}
+      package-artifact-name: ${{ needs.build-tsan.outputs.packages-artifact-name }}
+      enabled-skus: ${{ github.event_name == 'merge_group' && 'wh_n300_civ2,wh_llmbox_civ2_prio,bh_p150b_civ2_viommu_prio' || 'wh_n300_civ2,wh_llmbox_civ2_viommu,bh_p150b_civ2_viommu' }}
+      per-test-timeout: 11 # TSan can be slow; relax the timeout somewhat
+      product: tt-nn
+      enable-kernel-ccache: true
 
   ttnn-basic-tests:
     needs: [build-asan, resolve-docker-pull-refs-asan, find-changes, check-harbor]
@@ -300,15 +342,6 @@ jobs:
       per-test-timeout: 11
       product: tt-nn
 
-  resolve-docker-pull-refs:
-    needs: [check-harbor, build]
-    uses: ./.github/workflows/resolve-docker-pull-refs.yaml
-    with:
-      harbor-prefix: ${{ needs.check-harbor.outputs.harbor-prefix }}
-      dev-docker-image: ${{ needs.build.outputs.dev-docker-image }}
-      basic-dev-docker-image: ${{ needs.build.outputs.basic-dev-docker-image }}
-      ci-test-docker-image: ${{ needs.build.outputs.ci-test-docker-image }}
-
   ttnn-merge-gate-tests:
     needs: [build, find-changes]
     if: ${{ github.ref_name == 'main' ||
@@ -322,6 +355,11 @@ jobs:
     with:
       docker-image: ${{ needs.build.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
+
+  # ===========================================================================
+  # Team: models
+  # test list: models_merge_gate_tests.yaml (currently empty)
+  # ===========================================================================
 
   models-smoke-tests:
     needs: [build, resolve-docker-pull-refs, find-changes, check-harbor]
@@ -340,7 +378,12 @@ jobs:
       build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
 
-  tt-train-smoke-tests:
+  # ===========================================================================
+  # Team: train
+  # test list: train_merge_gate_tests.yaml
+  # ===========================================================================
+
+  train-smoke-tests:
     needs: [build, find-changes]
     if: ${{ github.event_name == 'workflow_dispatch' ||
             github.ref_name == 'main' ||
@@ -357,7 +400,13 @@ jobs:
       docker-image: ${{ needs.build.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
 
-  fabric-unit-tests:
+  # ===========================================================================
+  # Team: scaleout (fabric)
+  # test list: fabric_merge_gate_tests.yaml,
+  #            fabric_cpu_only_smoke_merge_gate_tests.yaml
+  # ===========================================================================
+
+  scaleout-unit-tests:
     needs: [build, resolve-docker-pull-refs, find-changes, check-harbor]
     if: ${{ github.ref_name == 'main' ||
             needs.find-changes.outputs.cmake-changed == 'true' ||
@@ -376,8 +425,8 @@ jobs:
   # Fabric CPU-only tests removed from merge gate — https://github.com/tenstorrent/tt-metal/pull/47987
   # Scaffolding kept for a future smoke subset (fabric_cpu_only_smoke_merge_gate_tests.yaml).
   # When re-enabling: uncomment tests in that yaml, replace `if: false` with a real trigger,
-  # and add fabric-cpu-only-unit-tests back to workflow-status needs + optional-jobs below.
-  fabric-cpu-only-unit-tests:
+  # and add scaleout-cpu-only-unit-tests back to workflow-status needs + optional-jobs below.
+  scaleout-cpu-only-unit-tests:
     needs: [build, resolve-docker-pull-refs, find-changes, check-harbor]
     if: false
     secrets: inherit
@@ -390,16 +439,10 @@ jobs:
       build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
 
-  triage-tests:
-    needs: [build, resolve-docker-pull-refs, find-changes, check-harbor]
-    secrets: inherit
-    uses: ./.github/workflows/triage-tests-impl.yaml
-    with:
-      test-category: merge_gate
-      docker-image: ${{ needs.resolve-docker-pull-refs.outputs.dev-docker-image }}
-      wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
-      build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
-      enabled-skus: ${{ github.event_name == 'merge_group' && 'wh_n150_civ2,bh_p150b_civ2_viommu_prio' || 'wh_n150_civ2,bh_p150b_civ2_viommu' }}
+  # ===========================================================================
+  # Team: llk
+  # test list: llk_merge_gate_tests.yaml
+  # ===========================================================================
 
   # Merge-gate LLK gtest matrix (tests/pipeline_reorg/llk_merge_gate_tests.yaml).
   # SKU coverage is narrowed below based on find-changes outputs. L2 nightly uses
@@ -439,6 +482,20 @@ jobs:
           || (needs.find-changes.outputs.llk-blackhole-changed == 'true' && (github.event_name == 'merge_group' && 'bh_p150b_civ2_viommu_prio' || 'bh_p150b_civ2_viommu'))
           || '' }}
 
+  # ===========================================================================
+  # Team: shield
+  # No merge-gate jobs yet.
+  # ===========================================================================
+
+  # ===========================================================================
+  # Team: blaze
+  # No merge-gate jobs yet.
+  # ===========================================================================
+
+  # ===========================================================================
+  # Status
+  # ===========================================================================
+
   # GitHub has so many design limitations it's not even funny.
   # This job is purely so we can capture the essence of the workflow as a whole in our status checks.
   workflow-status:
@@ -452,14 +509,14 @@ jobs:
         contains(join(needs.*.result, ','), 'success') ||
         contains(join(needs.*.result, ','), 'failure')
       }}
-    needs: [static-checks, docker-images, find-changes, build, build-tsan, build-sweeps, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests, ttnn-merge-gate-tests, models-smoke-tests, tt-train-smoke-tests, triage-tests, fabric-unit-tests, llk-unit-tests]
+    needs: [static-checks, docker-images, find-changes, build, build-tsan, build-sweeps, runtime-smoke-tests, runtime-basic-tests, triage-tests, ttnn-smoke-tests, ttnn-basic-tests, ttnn-merge-gate-tests, models-smoke-tests, train-smoke-tests, scaleout-unit-tests, llk-unit-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Check if all jobs passed
         uses: tenstorrent/tt-metal/.github/actions/workflow-status@main
         with:
           required-jobs: "static-checks, find-changes"
-          optional-jobs: "build, build-tsan, build-sweeps, metalium-smoke-tests, ttnn-smoke-tests, ttnn-basic-tests, metalium-basic-tests, ttnn-merge-gate-tests, models-smoke-tests, tt-train-smoke-tests, triage-tests, fabric-unit-tests, llk-unit-tests"
+          optional-jobs: "build, build-tsan, build-sweeps, runtime-smoke-tests, runtime-basic-tests, triage-tests, ttnn-smoke-tests, ttnn-basic-tests, ttnn-merge-gate-tests, models-smoke-tests, train-smoke-tests, scaleout-unit-tests, llk-unit-tests"
         env:
           NEEDS_CONTEXT: "${{ toJSON(needs) }}"
       - if: (failure() && contains(join(needs.*.result, ','), 'failure') && github.event_name == 'merge_group')

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -300,6 +300,7 @@ jobs:
       wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
       enabled-skus: ${{ github.event_name == 'merge_group' && 'wh_n150_civ2,bh_p150b_civ2_viommu_prio' || 'wh_n150_civ2,bh_p150b_civ2_viommu' }}
+      per-test-timeout: 15
 
   # ===========================================================================
   # Team: ttnn
@@ -354,6 +355,7 @@ jobs:
     with:
       docker-image: ${{ needs.build.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
+      per-test-timeout: 15
 
   # ===========================================================================
   # Team: models
@@ -376,6 +378,7 @@ jobs:
       harbor-prefix: ${{ needs.check-harbor.outputs.harbor-prefix }}
       build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
+      per-test-timeout: 15
 
   # ===========================================================================
   # Team: train
@@ -398,6 +401,7 @@ jobs:
       enabled-skus: "wh_n150_civ2"
       docker-image: ${{ needs.build.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
+      per-test-timeout: 15
 
   # ===========================================================================
   # Team: scaleout (fabric)
@@ -420,6 +424,7 @@ jobs:
       docker-image: ${{ needs.resolve-docker-pull-refs.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
+      per-test-timeout: 15
 
   # Fabric CPU-only tests removed from merge gate — https://github.com/tenstorrent/tt-metal/pull/47987
   # Scaffolding kept for a future smoke subset (fabric_cpu_only_smoke_merge_gate_tests.yaml).
@@ -437,6 +442,7 @@ jobs:
       docker-image: ${{ needs.resolve-docker-pull-refs.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
+      per-test-timeout: 15
 
   # ===========================================================================
   # Team: llk
@@ -465,6 +471,7 @@ jobs:
       test-category: merge_gate
       docker-image: ${{ needs.resolve-docker-pull-refs.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
+      per-test-timeout: 15
       # Prio runner pool is reserved for merge-queue traffic; any other trigger
       # (pull_request, push, etc.) routes blackhole jobs to the non-prio viommu
       # variant so PR runs don't starve the merge-group queue.

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -265,7 +265,7 @@ jobs:
       docker-image: ${{ needs.resolve-docker-pull-refs-tsan.outputs.dev-docker-image }}
       package-artifact-name: ${{ needs.build-tsan.outputs.packages-artifact-name }}
       enabled-skus: ${{ github.event_name == 'merge_group' && 'wh_n300_civ2,wh_llmbox_civ2_prio,bh_p150b_civ2_viommu_prio' || 'wh_n300_civ2,wh_llmbox_civ2_viommu,bh_p150b_civ2_viommu' }}
-      per-test-timeout: 11 # TSan can be slow; relax the timeout somewhat
+      per-test-timeout: 15 # max minutes for any SKU timeout in the smoke tests yaml
       product: tt-metalium
       enable-kernel-ccache: true
 
@@ -282,13 +282,12 @@ jobs:
       docker-image: ${{ needs.resolve-docker-pull-refs-asan.outputs.dev-docker-image }}
       package-artifact-name: ${{ needs.build-asan.outputs.packages-artifact-name }}
       enabled-skus: ${{ github.event_name == 'merge_group' && 'wh_n150_civ2,bh_p150b_civ2_viommu_prio' || 'wh_n150_civ2,bh_p150b_civ2_viommu' }}
-      per-test-timeout: 11
+      per-test-timeout: 15 # max minutes for any SKU timeout in the basic tests yaml
       product: tt-metalium
 
   # ===========================================================================
   # Team: triage
   # test list: triage_merge_gate_tests.yaml
-  # (kept next to runtime in case the teams are combined later)
   # ===========================================================================
 
   triage-tests:
@@ -322,7 +321,7 @@ jobs:
       docker-image: ${{ needs.resolve-docker-pull-refs-tsan.outputs.dev-docker-image }}
       package-artifact-name: ${{ needs.build-tsan.outputs.packages-artifact-name }}
       enabled-skus: ${{ github.event_name == 'merge_group' && 'wh_n300_civ2,wh_llmbox_civ2_prio,bh_p150b_civ2_viommu_prio' || 'wh_n300_civ2,wh_llmbox_civ2_viommu,bh_p150b_civ2_viommu' }}
-      per-test-timeout: 11 # TSan can be slow; relax the timeout somewhat
+      per-test-timeout: 15 # max minutes for any SKU timeout in the smoke tests yaml
       product: tt-nn
       enable-kernel-ccache: true
 
@@ -339,7 +338,7 @@ jobs:
       docker-image: ${{ needs.resolve-docker-pull-refs-asan.outputs.dev-docker-image }}
       package-artifact-name: ${{ needs.build-asan.outputs.packages-artifact-name }}
       enabled-skus: ${{ github.event_name == 'merge_group' && 'wh_n150_civ2,bh_p150b_civ2_viommu_prio' || 'wh_n150_civ2,bh_p150b_civ2_viommu' }}
-      per-test-timeout: 11
+      per-test-timeout: 15 # max minutes for any SKU timeout in the basic tests yaml
       product: tt-nn
 
   ttnn-merge-gate-tests:

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -264,7 +264,7 @@ jobs:
     with:
       docker-image: ${{ needs.resolve-docker-pull-refs-tsan.outputs.dev-docker-image }}
       package-artifact-name: ${{ needs.build-tsan.outputs.packages-artifact-name }}
-      enabled-skus: ${{ github.event_name == 'merge_group' && 'wh_n300_civ2,wh_llmbox_civ2_prio,bh_p150b_civ2_viommu_prio' || 'wh_n300_civ2,wh_llmbox_civ2_viommu,bh_p150b_civ2_viommu' }}
+      enabled-skus: ALL_SKUS_IN_TESTS
       per-test-timeout: 15 # max minutes for any SKU timeout in the smoke tests yaml
       product: tt-metalium
       enable-kernel-ccache: true
@@ -281,7 +281,7 @@ jobs:
     with:
       docker-image: ${{ needs.resolve-docker-pull-refs-asan.outputs.dev-docker-image }}
       package-artifact-name: ${{ needs.build-asan.outputs.packages-artifact-name }}
-      enabled-skus: ${{ github.event_name == 'merge_group' && 'wh_n150_civ2,bh_p150b_civ2_viommu_prio' || 'wh_n150_civ2,bh_p150b_civ2_viommu' }}
+      enabled-skus: ALL_SKUS_IN_TESTS
       per-test-timeout: 15 # max minutes for any SKU timeout in the basic tests yaml
       product: tt-metalium
 
@@ -321,7 +321,7 @@ jobs:
     with:
       docker-image: ${{ needs.resolve-docker-pull-refs-tsan.outputs.dev-docker-image }}
       package-artifact-name: ${{ needs.build-tsan.outputs.packages-artifact-name }}
-      enabled-skus: ${{ github.event_name == 'merge_group' && 'wh_n300_civ2,wh_llmbox_civ2_prio,bh_p150b_civ2_viommu_prio' || 'wh_n300_civ2,wh_llmbox_civ2_viommu,bh_p150b_civ2_viommu' }}
+      enabled-skus: ALL_SKUS_IN_TESTS
       per-test-timeout: 15 # max minutes for any SKU timeout in the smoke tests yaml
       product: tt-nn
       enable-kernel-ccache: true
@@ -338,7 +338,7 @@ jobs:
     with:
       docker-image: ${{ needs.resolve-docker-pull-refs-asan.outputs.dev-docker-image }}
       package-artifact-name: ${{ needs.build-asan.outputs.packages-artifact-name }}
-      enabled-skus: ${{ github.event_name == 'merge_group' && 'wh_n150_civ2,bh_p150b_civ2_viommu_prio' || 'wh_n150_civ2,bh_p150b_civ2_viommu' }}
+      enabled-skus: ALL_SKUS_IN_TESTS
       per-test-timeout: 15 # max minutes for any SKU timeout in the basic tests yaml
       product: tt-nn
 

--- a/.github/workflows/models-smoke-tests-impl.yaml
+++ b/.github/workflows/models-smoke-tests-impl.yaml
@@ -25,6 +25,14 @@ on:
         type: boolean
         default: true
         description: "Set to false to allow write access to MLPerf mount"
+      per-test-timeout:
+        required: false
+        type: string
+        default: ""
+        description: >-
+          Max allowed timeout (minutes) for any individual test SKU entry in the
+          tests yaml. Verified during load-test-matrix via verify_time_budget.py.
+          Empty skips the per-test ceiling check.
 
 jobs:
   load-test-matrix:
@@ -48,11 +56,16 @@ jobs:
 
       - name: Verify test timeouts against budget
         run: |
-          set -e
+          set -euo pipefail
+          extra=()
+          if [ -n "${{ inputs.per-test-timeout }}" ]; then
+            extra+=(--max-per-test-timeout "${{ inputs.per-test-timeout }}")
+          fi
           python3 .github/scripts/utils/verify_time_budget.py \
             "${{ env.TESTS_YAML_PATH }}" \
             ./.github/time_budget.yaml \
-            merge_gate
+            merge_gate \
+            "${extra[@]}"
 
       - name: Build test matrix based on enabled SKUs
         id: build-matrix

--- a/.github/workflows/models-smoke-tests-impl.yaml
+++ b/.github/workflows/models-smoke-tests-impl.yaml
@@ -90,7 +90,8 @@ jobs:
           python3 .github/scripts/utils/prepare_test_matrix.py \
             "${{ env.TESTS_YAML_PATH }}" \
             "${{ inputs.enabled-skus }}" \
-            ./.github/sku_config.yaml
+            ./.github/sku_config.yaml \
+            --event "${{ github.event_name }}"
 
   models-smoke-tests:
     needs: load-test-matrix

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -197,6 +197,7 @@ jobs:
       package-artifact-name: ${{ needs.asan-build.outputs.packages-artifact-name }}
       product: tt-metalium
       test-category: pr_gate
+      per-test-timeout: 15 # max minutes for any SKU timeout in the smoke tests yaml
       upload-coverage: false
       enable-kernel-ccache: true
   ttnn-smoke-tests:
@@ -215,6 +216,7 @@ jobs:
       package-artifact-name: ${{ needs.asan-build.outputs.packages-artifact-name }}
       product: tt-nn
       test-category: pr_gate
+      per-test-timeout: 15 # max minutes for any SKU timeout in the smoke tests yaml
       upload-coverage: false
       enable-kernel-ccache: true
 

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -182,7 +182,7 @@ jobs:
       - id: find-changes
         uses: ./.github/actions/find-changed-files
 
-  metalium-smoke-tests:
+  runtime-smoke-tests:
     needs: [asan-build, find-changed-files]
     if: ${{
       github.ref_name == 'main' ||
@@ -232,7 +232,7 @@ jobs:
       wheel-artifact-name: ${{ needs.asan-build.outputs.wheel-artifact-name }}
       build-type: 'ASan'
 
-  metalium-examples:
+  runtime-examples:
     needs: [ asan-build, find-changed-files ]
     if: ${{
         github.ref_name == 'main' ||
@@ -461,9 +461,9 @@ jobs:
       }}
     needs:
       - asan-build
-      - metalium-smoke-tests
+      - runtime-smoke-tests
       - ttnn-smoke-tests
-      - metalium-examples
+      - runtime-examples
       - ttnn-examples
       - code-analysis
       - model-charts-sync
@@ -482,7 +482,7 @@ jobs:
           required-jobs: ""
           optional-jobs: >-
             asan-build, code-analysis,
-            metalium-smoke-tests, ttnn-smoke-tests, metalium-examples, ttnn-examples,
+            runtime-smoke-tests, ttnn-smoke-tests, runtime-examples, ttnn-examples,
             model-charts-sync, build-docs,
             llk-smoke-tests, llk-build-quasar
         env:

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -248,6 +248,7 @@ jobs:
       product: tt-metalium
       build-type: 'ASan'
       enable-kernel-ccache: true
+      per-test-timeout: 15
     secrets: inherit
 
   ttnn-examples:
@@ -265,6 +266,7 @@ jobs:
       product: tt-nn
       build-type: 'ASan'
       enable-kernel-ccache: true
+      per-test-timeout: 15
     secrets: inherit
 
   # A quick check that parses the models charts in README.md and models/README.md
@@ -409,6 +411,7 @@ jobs:
     secrets: inherit
     with:
       docker-image: ${{ needs.resolve-docker-pull-refs.outputs.llk-ci-docker-image }}
+      per-test-timeout: 15
       # Priority runners only accept merge-queue traffic. Regular PRs and
       # other triggers must continue using the original non-priority runner.
       enabled-skus: ${{

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -393,7 +393,8 @@ jobs:
       - uses: tenstorrent/tt-github-actions/.github/actions/copilot-pr-labeler@629b4727fa0dff3d43895601dd538e303880ecbc # main (tt-github-actions#144)
 
   # PR-gate LLK python_tests matrix (tests/pipeline_reorg/llk_pr_gate_tests.yaml).
-  # SKU coverage is narrowed below based on find-changed-files outputs.
+  # SKU coverage is narrowed via sku-allowlist from find-changed-files.
+  # merge_group prio routing is via prepare_test_matrix --event + sku_config.
   llk-smoke-tests:
     needs: [resolve-docker-pull-refs, build-docker-images, find-changed-files]
     if: ${{
@@ -412,9 +413,9 @@ jobs:
     with:
       docker-image: ${{ needs.resolve-docker-pull-refs.outputs.llk-ci-docker-image }}
       per-test-timeout: 15
-      # Priority runners only accept merge-queue traffic. Regular PRs and
-      # other triggers must continue using the original non-priority runner.
-      enabled-skus: ${{
+      enabled-skus: ALL_SKUS_IN_TESTS
+      # "*" = no allowlist filter; empty = skip all; else CSV of logical SKUs.
+      sku-allowlist: ${{
           (github.ref_name == 'main'
            || needs.find-changed-files.outputs.llk-common-changed == 'true'
            || needs.find-changed-files.outputs.llk-sfpi-changed == 'true'
@@ -422,9 +423,9 @@ jobs:
            || needs.find-changed-files.outputs.llk-ci-changed == 'true'
            || (needs.find-changed-files.outputs.llk-wormhole-changed == 'true'
                && needs.find-changed-files.outputs.llk-blackhole-changed == 'true'))
-          && (github.event_name == 'merge_group' && 'wh_n150_civ2,bh_p150b_civ2_viommu_prio' || 'wh_n150_civ2,bh_p150b_civ2')
+          && '*'
           || (needs.find-changed-files.outputs.llk-wormhole-changed == 'true' && 'wh_n150_civ2')
-          || (needs.find-changed-files.outputs.llk-blackhole-changed == 'true' && (github.event_name == 'merge_group' && 'bh_p150b_civ2_viommu_prio' || 'bh_p150b_civ2'))
+          || (needs.find-changed-files.outputs.llk-blackhole-changed == 'true' && 'bh_p150b_civ2_viommu')
           || '' }}
       pytest-markers: "not perf and not nightly and not quasar and not accuracy"
 

--- a/.github/workflows/sdk-examples.yaml
+++ b/.github/workflows/sdk-examples.yaml
@@ -75,7 +75,8 @@ jobs:
           python3 .github/scripts/utils/prepare_test_matrix.py \
             "${{ env.TESTS_YAML_PATH }}" \
             "${{ inputs.enabled-skus }}" \
-            ./.github/sku_config.yaml
+            ./.github/sku_config.yaml \
+            --event "${{ github.event_name }}"
 
   sdk-examples:
     needs: load-test-matrix

--- a/.github/workflows/sdk-examples.yaml
+++ b/.github/workflows/sdk-examples.yaml
@@ -26,6 +26,14 @@ on:
         description: 'Enable kernel ccache for JIT compilation at runtime'
         default: false
         type: boolean
+      per-test-timeout:
+        required: false
+        type: string
+        default: ""
+        description: >-
+          Max allowed timeout (minutes) for any individual test SKU entry in the
+          tests yaml. Verified during load-test-matrix via verify_time_budget.py.
+          Empty skips the per-test ceiling check.
 
 jobs:
   load-test-matrix:
@@ -50,11 +58,16 @@ jobs:
 
       - name: Verify test timeouts against budget
         run: |
-          set -e
+          set -euo pipefail
+          extra=()
+          if [ -n "${{ inputs.per-test-timeout }}" ]; then
+            extra+=(--max-per-test-timeout "${{ inputs.per-test-timeout }}")
+          fi
           python3 .github/scripts/utils/verify_time_budget.py \
             "${{ env.TESTS_YAML_PATH }}" \
             ./.github/time_budget.yaml \
-            pr_gate
+            pr_gate \
+            "${extra[@]}"
 
       - name: Build test matrix based on enabled SKUs
         id: build-matrix

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -93,7 +93,8 @@ jobs:
           python3 .github/scripts/utils/prepare_test_matrix.py \
             "${{ env.TESTS_YAML_PATH }}" \
             "${{ inputs.enabled-skus }}" \
-            ./.github/sku_config.yaml
+            ./.github/sku_config.yaml \
+            --event "${{ github.event_name }}"
 
   smoke:
     needs: load-test-matrix

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -21,7 +21,11 @@ on:
       per-test-timeout:
         required: false
         type: string
-        default: "4.0" # TODO: Drop back to 3.5 when https://github.com/tenstorrent/github-ci-infra/issues/876 is resolved.
+        default: ""
+        description: >-
+          Max allowed timeout (minutes) for any individual test SKU entry in the
+          tests yaml. Verified during load-test-matrix via verify_time_budget.py.
+          Empty skips the per-test ceiling check.
       product:
         required: true
         type: string # tt-metalium or tt-nn
@@ -72,11 +76,16 @@ jobs:
 
       - name: Verify test timeouts against budget
         run: |
-          set -e
+          set -euo pipefail
+          extra=()
+          if [ -n "${{ inputs.per-test-timeout }}" ]; then
+            extra+=(--max-per-test-timeout "${{ inputs.per-test-timeout }}")
+          fi
           python3 .github/scripts/utils/verify_time_budget.py \
             "${{ env.TESTS_YAML_PATH }}" \
             ./.github/time_budget.yaml \
-            "${{ inputs.test-category }}"
+            "${{ inputs.test-category }}" \
+            "${extra[@]}"
 
       - name: Build test matrix based on enabled SKUs
         id: build-matrix
@@ -331,8 +340,3 @@ jobs:
             "$GITHUB_WORKSPACE/.github/scripts/ccache_log_filter.sh" /tmp/ccache.log >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
           fi
-
-      - name: Check for slow tests
-        uses: tenstorrent/tt-metal/.github/actions/detect-slow-tests@main
-        with:
-          threshold: ${{ inputs.per-test-timeout }}

--- a/.github/workflows/triage-tests-impl.yaml
+++ b/.github/workflows/triage-tests-impl.yaml
@@ -61,9 +61,8 @@ jobs:
         run: pip3 install PyYAML
       - name: Verify test timeouts against budget
         run: |
-          set -e
-          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
           set -euo pipefail
+          echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
           extra=()
           if [ -n "${{ inputs.per-test-timeout }}" ]; then
             extra+=(--max-per-test-timeout "${{ inputs.per-test-timeout }}")

--- a/.github/workflows/triage-tests-impl.yaml
+++ b/.github/workflows/triage-tests-impl.yaml
@@ -79,7 +79,8 @@ jobs:
           python3 .github/scripts/utils/prepare_test_matrix.py \
             ${{ env.TESTS_YAML_PATH }} \
             "${{ inputs.enabled-skus }}" \
-            ./.github/sku_config.yaml
+            ./.github/sku_config.yaml \
+            --event "${{ github.event_name }}"
 
   triage-tests:
     needs: load-test-matrix

--- a/.github/workflows/triage-tests-impl.yaml
+++ b/.github/workflows/triage-tests-impl.yaml
@@ -32,6 +32,14 @@ on:
         description: "Enable LLK asserts"
         default: false
         type: boolean
+      per-test-timeout:
+        required: false
+        type: string
+        default: ""
+        description: >-
+          Max allowed timeout (minutes) for any individual test SKU entry in the
+          tests yaml. Verified during load-test-matrix via verify_time_budget.py.
+          Empty skips the per-test ceiling check.
 
 jobs:
   load-test-matrix:
@@ -55,10 +63,16 @@ jobs:
         run: |
           set -e
           echo "Verifying that timeouts defined in tests.yaml are within the allowed limits..."
+          set -euo pipefail
+          extra=()
+          if [ -n "${{ inputs.per-test-timeout }}" ]; then
+            extra+=(--max-per-test-timeout "${{ inputs.per-test-timeout }}")
+          fi
           python3 .github/scripts/utils/verify_time_budget.py \
             ${{ env.TESTS_YAML_PATH }} \
             ./.github/time_budget.yaml \
-            "${{ inputs.test-category }}"
+            "${{ inputs.test-category }}" \
+            "${extra[@]}"
       - name: Build unified test matrix based on enabled SKUs
         id: prepare
         run: |

--- a/.github/workflows/tt-train-tests.yaml
+++ b/.github/workflows/tt-train-tests.yaml
@@ -105,7 +105,8 @@ jobs:
           python3 .github/scripts/utils/prepare_test_matrix.py \
             ${{ env.TESTS_YAML_PATH }} \
             "${{ inputs.enabled-skus }}" \
-            ./.github/sku_config.yaml
+            ./.github/sku_config.yaml \
+            --event "${{ github.event_name }}"
 
       - name: Filter matrix by subcategories
         if: ${{ inputs.subcategories != '' }}

--- a/.github/workflows/tt-train-tests.yaml
+++ b/.github/workflows/tt-train-tests.yaml
@@ -55,6 +55,14 @@ on:
         type: string
         default: ''
         description: "Comma-separated category filter. Keep only entries whose `category` field appears in this list."
+      per-test-timeout:
+        required: false
+        type: string
+        default: ""
+        description: >-
+          Max allowed timeout (minutes) for any individual test SKU entry in the
+          tests yaml. Verified during load-test-matrix via verify_time_budget.py.
+          Empty skips the per-test ceiling check.
 
 jobs:
   load-test-matrix:
@@ -80,11 +88,16 @@ jobs:
       - name: Verify test timeouts against budget
         if: ${{ inputs.timeout-minutes-override == 0 }}
         run: |
-          set -e
+          set -euo pipefail
+          extra=()
+          if [ -n "${{ inputs.per-test-timeout }}" ]; then
+            extra+=(--max-per-test-timeout "${{ inputs.per-test-timeout }}")
+          fi
           python3 .github/scripts/utils/verify_time_budget.py \
             ${{ env.TESTS_YAML_PATH }} \
             ./.github/time_budget.yaml \
-            "${{ inputs.test-category }}"
+            "${{ inputs.test-category }}" \
+            "${extra[@]}"
 
       - name: Build test matrix based on enabled SKUs
         id: build-matrix

--- a/.github/workflows/ttnn-smoke-tests-impl.yaml
+++ b/.github/workflows/ttnn-smoke-tests-impl.yaml
@@ -97,7 +97,8 @@ jobs:
           python3 .github/scripts/utils/prepare_test_matrix.py \
             ${{ env.TESTS_YAML_PATH }} \
             "ALL_SKUS_IN_TESTS" \
-            ./.github/sku_config.yaml
+            ./.github/sku_config.yaml \
+            --event "${{ github.event_name }}"
 
       - name: Detect sim SKUs in matrix
         id: detect-sim

--- a/.github/workflows/ttnn-smoke-tests-impl.yaml
+++ b/.github/workflows/ttnn-smoke-tests-impl.yaml
@@ -42,6 +42,14 @@ on:
         type: boolean
         default: false
         description: "When true, collect LLVM profraw data and upload per-job profdata artifact for coverage aggregation."
+      per-test-timeout:
+        required: false
+        type: string
+        default: ""
+        description: >-
+          Max allowed timeout (minutes) for any individual test SKU entry in the
+          tests yaml. Verified during load-test-matrix via verify_time_budget.py.
+          Empty skips the per-test ceiling check.
 
 jobs:
   load-test-matrix:
@@ -72,11 +80,16 @@ jobs:
       - name: Verify test timeouts against budget
         if: ${{ inputs.timeout-minutes-override == 0 }}
         run: |
-          set -e
+          set -euo pipefail
+          extra=()
+          if [ -n "${{ inputs.per-test-timeout }}" ]; then
+            extra+=(--max-per-test-timeout "${{ inputs.per-test-timeout }}")
+          fi
           python3 .github/scripts/utils/verify_time_budget.py \
             ${{ env.TESTS_YAML_PATH }} \
             ./.github/time_budget.yaml \
-            "merge_gate"
+            "merge_gate" \
+            "${extra[@]}"
 
       - name: Build test matrix based on enabled SKUs
         id: build-matrix

--- a/tests/pipeline_reorg/fabric_cpu_only_smoke_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/fabric_cpu_only_smoke_merge_gate_tests.yaml
@@ -6,6 +6,7 @@
 #
 # Empty until merge gate re-enables fabric CPU tests (see #47987). Uncomment the example
 # below before removing `if: false` on the merge-gate job.
+# Logical SKUs only; merge_group prio routing is via sku_config merge_queue_sku.
 
 []
 
@@ -14,8 +15,6 @@
 #   cmd: ./tests/scripts/multihost/run_fabric_cpu_only_unit_tests.sh --group unit
 #   skus:
 #     cpu_medium:
-#       timeout: 10
-#     cpu_medium_prio:
 #       timeout: 10
 #   team: scaleout
 #   arch: wormhole_b0

--- a/tests/pipeline_reorg/fabric_cpu_only_smoke_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/fabric_cpu_only_smoke_merge_gate_tests.yaml
@@ -9,8 +9,8 @@
 
 []
 
-# - id: fabric-cpu-unit-smoke
-#   name: fabric cpu unit tests (unit)
+# - id: scaleout-cpu-unit-smoke
+#   name: scaleout cpu unit tests (unit)
 #   cmd: ./tests/scripts/multihost/run_fabric_cpu_only_unit_tests.sh --group unit
 #   skus:
 #     cpu_medium:

--- a/tests/pipeline_reorg/fabric_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/fabric_merge_gate_tests.yaml
@@ -2,6 +2,7 @@
 #
 # Each entry: name, cmd, skus: { <sku>: { timeout: N } }, team, arch, owner_id.
 # For max allowed timeout refer to .github/time_budget.yaml (scaleout -> merge_gate).
+# Logical SKUs only; merge_group prio routing is via sku_config merge_queue_sku.
 
 - name: scaleout unit tests
   cmd: ./tests/scripts/run_cpp_fabric_tests.sh

--- a/tests/pipeline_reorg/fabric_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/fabric_merge_gate_tests.yaml
@@ -3,7 +3,7 @@
 # Each entry: name, cmd, skus: { <sku>: { timeout: N } }, team, arch, owner_id.
 # For max allowed timeout refer to .github/time_budget.yaml (scaleout -> merge_gate).
 
-- name: fabric unit tests
+- name: scaleout unit tests
   cmd: ./tests/scripts/run_cpp_fabric_tests.sh
   skus:
     wh_n300_civ2:

--- a/tests/pipeline_reorg/llk_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/llk_merge_gate_tests.yaml
@@ -2,6 +2,7 @@
 #
 # Each entry: name, cmd, skus, team, arch, dispatch_mode; optional gtest sharding.
 # For sd entries the impl prepends TT_METAL_SLOW_DISPATCH_MODE=1 at invocation time.
+# Logical SKUs only; merge_group prio routing is via sku_config merge_queue_sku.
 
 # --- FD shards (full LLK gtest suite) ---
 - name: LLK FD wormhole
@@ -53,8 +54,6 @@
   skus:
     bh_p150b_civ2_viommu:
       timeout: 15
-    bh_p150b_civ2_viommu_prio:
-      timeout: 15
   team: llk
   arch: blackhole
   dispatch_mode: fd
@@ -65,8 +64,6 @@
   cmd: ./build/test/tt_metal/unit_tests_llk --gtest_filter='-LLKBlackholeSingleCardFixture.*:*MulReduceScalarTest*'
   skus:
     bh_p150b_civ2_viommu:
-      timeout: 15
-    bh_p150b_civ2_viommu_prio:
       timeout: 15
   team: llk
   arch: blackhole
@@ -88,8 +85,6 @@
   cmd: ./build/test/tt_metal/unit_tests_llk --gtest_filter='LLKMeshDeviceFixtureSlowDispatchOnly.*:LLKBlackholeSingleCardFixture.*:*MulReduceScalarTest*:LLKQuasarMeshDeviceSingleCardFixture.*:QuasarMeshDeviceSingleCardFixture.*-LLKBlackholeSingleCardFixture.TensixComputeUnpackTilizeFp8e4m3:LLKBlackholeSingleCardFixture.TensixComputePackUntilizeFp8e4m3:LLKBlackholeSingleCardFixture.TensixFp8e4m3ToFp8e4m3'
   skus:
     bh_p150b_civ2_viommu:
-      timeout: 15
-    bh_p150b_civ2_viommu_prio:
       timeout: 15
   team: llk
   arch: blackhole

--- a/tests/pipeline_reorg/llk_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/llk_merge_gate_tests.yaml
@@ -8,7 +8,7 @@
   cmd: ./build/test/tt_metal/unit_tests_llk --gtest_filter='*'
   skus:
     wh_n150_civ2:
-      timeout: 25
+      timeout: 15
   team: llk
   arch: wormhole_b0
   dispatch_mode: fd
@@ -19,7 +19,7 @@
   cmd: ./build/test/tt_metal/unit_tests_llk --gtest_filter='*'
   skus:
     wh_n150_civ2:
-      timeout: 25
+      timeout: 15
   team: llk
   arch: wormhole_b0
   dispatch_mode: fd
@@ -30,7 +30,7 @@
   cmd: ./build/test/tt_metal/unit_tests_llk --gtest_filter='*'
   skus:
     wh_n150_civ2:
-      timeout: 25
+      timeout: 15
   team: llk
   arch: wormhole_b0
   dispatch_mode: fd
@@ -41,7 +41,7 @@
   cmd: ./build/test/tt_metal/unit_tests_llk --gtest_filter='*'
   skus:
     wh_n150_civ2:
-      timeout: 25
+      timeout: 15
   team: llk
   arch: wormhole_b0
   dispatch_mode: fd
@@ -79,7 +79,7 @@
   cmd: ./build/test/tt_metal/unit_tests_llk --gtest_filter='LLKMeshDeviceFixtureSlowDispatchOnly.*:LLKQuasarMeshDeviceSingleCardFixture.*:QuasarMeshDeviceSingleCardFixture.*'
   skus:
     wh_n150_civ2:
-      timeout: 40
+      timeout: 15
   team: llk
   arch: wormhole_b0
   dispatch_mode: sd
@@ -88,9 +88,9 @@
   cmd: ./build/test/tt_metal/unit_tests_llk --gtest_filter='LLKMeshDeviceFixtureSlowDispatchOnly.*:LLKBlackholeSingleCardFixture.*:*MulReduceScalarTest*:LLKQuasarMeshDeviceSingleCardFixture.*:QuasarMeshDeviceSingleCardFixture.*-LLKBlackholeSingleCardFixture.TensixComputeUnpackTilizeFp8e4m3:LLKBlackholeSingleCardFixture.TensixComputePackUntilizeFp8e4m3:LLKBlackholeSingleCardFixture.TensixFp8e4m3ToFp8e4m3'
   skus:
     bh_p150b_civ2_viommu:
-      timeout: 40
+      timeout: 15
     bh_p150b_civ2_viommu_prio:
-      timeout: 40
+      timeout: 15
   team: llk
   arch: blackhole
   dispatch_mode: sd

--- a/tests/pipeline_reorg/llk_pr_gate_tests.yaml
+++ b/tests/pipeline_reorg/llk_pr_gate_tests.yaml
@@ -3,6 +3,9 @@
 # Merge-gate gtest coverage lives in llk_merge_gate_tests.yaml.
 # PYTEST_MARKERS is set by llk-smoke-impl.yaml / workflow_call inputs.
 # For max allowed timeout refer to .github/time_budget.yaml (llk -> pr_gate).
+# Logical SKUs only; merge_group prio routing is via sku_config merge_queue_sku.
+# Blackhole uses bh_p150b_civ2_viommu (same logical SKU as merge-gate); previously
+# non-prio PR runs used bh_p150b_civ2.
 
 - name: llk_smoke_wormhole
   team: llk
@@ -30,8 +33,6 @@
       --timeout=60 \
       --junitxml=pytest-report-blackhole.xml .
   skus:
-    bh_p150b_civ2:
-      timeout: 15
-    bh_p150b_civ2_viommu_prio:
+    bh_p150b_civ2_viommu:
       timeout: 15
   owner_id: U07J3K6KS1K # LLK team

--- a/tests/pipeline_reorg/llk_pr_gate_tests.yaml
+++ b/tests/pipeline_reorg/llk_pr_gate_tests.yaml
@@ -16,7 +16,7 @@
       --junitxml=pytest-report-wormhole.xml .
   skus:
     wh_n150_civ2:
-      timeout: 40
+      timeout: 15
   owner_id: U07J3K6KS1K # LLK team
 
 - name: llk_smoke_blackhole
@@ -31,7 +31,7 @@
       --junitxml=pytest-report-blackhole.xml .
   skus:
     bh_p150b_civ2:
-      timeout: 40
+      timeout: 15
     bh_p150b_civ2_viommu_prio:
-      timeout: 40
+      timeout: 15
   owner_id: U07J3K6KS1K # LLK team

--- a/tests/pipeline_reorg/models_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/models_merge_gate_tests.yaml
@@ -2,6 +2,7 @@
 #
 # Each entry: name, cmd, skus: { <sku>: { timeout: N } }, team, owner_id, model (optional).
 # For max allowed timeout refer to .github/time_budget.yaml (models -> merge_gate).
+# Logical SKUs only; merge_group prio routing is via sku_config merge_queue_sku.
 #
 # Intended first entry:
 # - name: GPT-OSS 120B e2e tests

--- a/tests/pipeline_reorg/runtime_examples_pr_gate_tests.yaml
+++ b/tests/pipeline_reorg/runtime_examples_pr_gate_tests.yaml
@@ -3,7 +3,7 @@
 # Each entry: name, cmd, skus: { <sku>: { timeout: N } }, team, owner_id.
 # For max allowed timeout refer to .github/time_budget.yaml (runtime -> pr_gate).
 
-- name: metalium sdk examples
+- name: runtime sdk examples
   cmd: ./tests/scripts/run_sdk_examples.sh
   skus:
     wh_n150_civ2:

--- a/tests/pipeline_reorg/runtime_examples_pr_gate_tests.yaml
+++ b/tests/pipeline_reorg/runtime_examples_pr_gate_tests.yaml
@@ -2,6 +2,7 @@
 #
 # Each entry: name, cmd, skus: { <sku>: { timeout: N } }, team, owner_id.
 # For max allowed timeout refer to .github/time_budget.yaml (runtime -> pr_gate).
+# Logical SKUs only; merge_group prio routing is via sku_config merge_queue_sku.
 
 - name: runtime sdk examples
   cmd: ./tests/scripts/run_sdk_examples.sh

--- a/tests/pipeline_reorg/runtime_validation_basic_tests.yaml
+++ b/tests/pipeline_reorg/runtime_validation_basic_tests.yaml
@@ -3,7 +3,7 @@
 # Each entry: name, cmd, skus: { <sku>: { timeout: N } }, team, owner_id.
 # For max allowed timeout refer to .github/time_budget.yaml (runtime -> merge_gate; budget is shared with validation merge gate).
 
-- name: metalium validation basic
+- name: runtime validation basic
   cmd: /usr/bin/tt-metalium-validation-basic
   skus:
     wh_n150_civ2:

--- a/tests/pipeline_reorg/runtime_validation_basic_tests.yaml
+++ b/tests/pipeline_reorg/runtime_validation_basic_tests.yaml
@@ -2,6 +2,7 @@
 #
 # Each entry: name, cmd, skus: { <sku>: { timeout: N } }, team, owner_id.
 # For max allowed timeout refer to .github/time_budget.yaml (runtime -> merge_gate; budget is shared with validation merge gate).
+# Logical SKUs only; merge_group prio routing is via sku_config merge_queue_sku.
 
 - name: runtime validation basic
   cmd: /usr/bin/tt-metalium-validation-basic
@@ -9,8 +10,6 @@
     wh_n150_civ2:
       timeout: 15
     bh_p150b_civ2_viommu:
-      timeout: 15
-    bh_p150b_civ2_viommu_prio:
       timeout: 15
   team: runtime
   owner_id: U099A7FMKL2 # Manish Sudumbrekar

--- a/tests/pipeline_reorg/runtime_validation_basic_tests.yaml
+++ b/tests/pipeline_reorg/runtime_validation_basic_tests.yaml
@@ -7,10 +7,10 @@
   cmd: /usr/bin/tt-metalium-validation-basic
   skus:
     wh_n150_civ2:
-      timeout: 30
+      timeout: 15
     bh_p150b_civ2_viommu:
-      timeout: 30
+      timeout: 15
     bh_p150b_civ2_viommu_prio:
-      timeout: 30
+      timeout: 15
   team: runtime
   owner_id: U099A7FMKL2 # Manish Sudumbrekar

--- a/tests/pipeline_reorg/runtime_validation_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/runtime_validation_merge_gate_tests.yaml
@@ -3,6 +3,7 @@
 # Each entry: name, cmd, skus: { <sku>: { timeout: N } }, team, owner_id.
 # For max allowed timeout refer to .github/time_budget.yaml (runtime -> merge_gate).
 # PR gate matrix lives in runtime_validation_pr_gate_tests.yaml (runtime -> pr_gate).
+# Logical SKUs only; merge_group prio routing is via sku_config merge_queue_sku.
 
 - name: runtime validation smoke
   cmd: /usr/bin/tt-metalium-validation-smoke
@@ -13,11 +14,7 @@
       timeout: 15
     wh_llmbox_civ2_viommu:
       timeout: 15
-    wh_llmbox_civ2_prio:
-      timeout: 15
     bh_p150b_civ2_viommu:
-      timeout: 15
-    bh_p150b_civ2_viommu_prio:
       timeout: 15
   team: runtime
   owner_id: U099A7FMKL2 # Manish Sudumbrekar

--- a/tests/pipeline_reorg/runtime_validation_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/runtime_validation_merge_gate_tests.yaml
@@ -4,7 +4,7 @@
 # For max allowed timeout refer to .github/time_budget.yaml (runtime -> merge_gate).
 # PR gate matrix lives in runtime_validation_pr_gate_tests.yaml (runtime -> pr_gate).
 
-- name: metalium validation smoke
+- name: runtime validation smoke
   cmd: /usr/bin/tt-metalium-validation-smoke
   skus:
     wh_n150_civ2:

--- a/tests/pipeline_reorg/runtime_validation_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/runtime_validation_merge_gate_tests.yaml
@@ -4,12 +4,11 @@
 # For max allowed timeout refer to .github/time_budget.yaml (runtime -> merge_gate).
 # PR gate matrix lives in runtime_validation_pr_gate_tests.yaml (runtime -> pr_gate).
 # Logical SKUs only; merge_group prio routing is via sku_config merge_queue_sku.
+# Note: wh_n150_civ2 is intentionally omitted here (PR-gate smoke covers n150).
 
 - name: runtime validation smoke
   cmd: /usr/bin/tt-metalium-validation-smoke
   skus:
-    wh_n150_civ2:
-      timeout: 15
     wh_n300_civ2:
       timeout: 15
     wh_llmbox_civ2_viommu:

--- a/tests/pipeline_reorg/runtime_validation_pr_gate_tests.yaml
+++ b/tests/pipeline_reorg/runtime_validation_pr_gate_tests.yaml
@@ -3,7 +3,7 @@
 # Each entry: name, cmd, skus: { <sku>: { timeout: N } }, team, owner_id.
 # For max allowed timeout refer to .github/time_budget.yaml (runtime -> pr_gate).
 
-- name: metalium validation smoke
+- name: runtime validation smoke
   cmd: /usr/bin/tt-metalium-validation-smoke
   skus:
     wh_n150_civ2:

--- a/tests/pipeline_reorg/train_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/train_merge_gate_tests.yaml
@@ -18,6 +18,6 @@
     build/tt-train/tests/ttml_tests --gtest_output=xml:generated/test_reports/ctest_report.xml --gtest_filter="-*NIGHTLY*"
   skus:
     wh_n150_civ2:
-      timeout: 20
+      timeout: 15
   owner_id: U07K00A281X # Kevin Wu
   team: train

--- a/tests/pipeline_reorg/train_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/train_merge_gate_tests.yaml
@@ -10,6 +10,7 @@
 #   team: The team that owns the test.
 #
 # For max allowed timeout refer to .github/time_budget.yaml.
+# Logical SKUs only; merge_group prio routing is via sku_config merge_queue_sku.
 
 # Non-nightly smoke tests
 - name: tt-train cpp smoke tests

--- a/tests/pipeline_reorg/triage_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/triage_merge_gate_tests.yaml
@@ -2,13 +2,12 @@
 #
 # Each entry: name, cmd, skus, team, owner_id.
 # For max allowed timeout refer to .github/time_budget.yaml (triage -> merge_gate).
+# Logical SKUs only; merge_group prio routing is via sku_config merge_queue_sku.
 
 - name: triage
   cmd: pytest -v -s ./tools/tests/triage/ --ignore=./tools/tests/triage/test_hang_report.py
   skus:
     wh_n150_civ2:
-      timeout: 11
-    bh_p150b_civ2_viommu_prio:
       timeout: 11
     bh_p150b_civ2_viommu:
       timeout: 11

--- a/tests/pipeline_reorg/triage_tests.yaml
+++ b/tests/pipeline_reorg/triage_tests.yaml
@@ -5,13 +5,12 @@
 #
 # Each entry: name, cmd, skus, team, owner_id.
 # For max allowed timeout refer to .github/time_budget.yaml
+# Logical SKUs only; do not list merge-queue *_prio SKUs here.
 
 - name: triage_hang_report
   cmd: pytest -v -s ./tools/tests/triage/test_hang_report.py
   skus:
     wh_n150_civ2:
-      timeout: 5
-    bh_p150b_civ2_viommu_prio:
       timeout: 5
     bh_p150b_civ2_viommu:
       timeout: 5

--- a/tests/pipeline_reorg/ttnn_examples_pr_gate_tests.yaml
+++ b/tests/pipeline_reorg/ttnn_examples_pr_gate_tests.yaml
@@ -2,6 +2,7 @@
 #
 # Each entry: name, cmd, skus: { <sku>: { timeout: N } }, team, owner_id.
 # For max allowed timeout refer to .github/time_budget.yaml (ttnn -> pr_gate).
+# Logical SKUs only; merge_group prio routing is via sku_config merge_queue_sku.
 
 - name: ttnn sdk examples
   cmd: ./tests/scripts/run_sdk_examples.sh

--- a/tests/pipeline_reorg/ttnn_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/ttnn_merge_gate_tests.yaml
@@ -10,10 +10,10 @@
   cmd: "./tests/scripts/run_ttnn_examples.sh"
   skus:
     wh_n300_civ2:
-      timeout: 40
+      timeout: 15
     sim_wormhole_b0:
-      timeout: 40
+      timeout: 15
     sim_blackhole:
-      timeout: 40
+      timeout: 15
   team: ttnn
   owner_id: U076Z1JJUQZ # Artem Yerofieiev

--- a/tests/pipeline_reorg/ttnn_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/ttnn_merge_gate_tests.yaml
@@ -5,6 +5,7 @@
 # sim_wormhole_b0 / sim_blackhole SKUs run the same cmd under the ttsim simulator
 # on ubuntu-latest; ttnn-smoke-tests-impl.yaml invokes setup-ttsim for these.
 # See .github/actions/setup-ttsim/action.yml.
+# Logical SKUs only; merge_group prio routing is via sku_config merge_queue_sku.
 
 - name: "ttnn example tests"
   cmd: "./tests/scripts/run_ttnn_examples.sh"

--- a/tests/pipeline_reorg/ttnn_validation_basic_tests.yaml
+++ b/tests/pipeline_reorg/ttnn_validation_basic_tests.yaml
@@ -2,6 +2,7 @@
 #
 # Each entry: name, cmd, skus: { <sku>: { timeout: N } }, team, owner_id.
 # For max allowed timeout refer to .github/time_budget.yaml (ttnn -> merge_gate; budget is shared with validation merge gate).
+# Logical SKUs only; merge_group prio routing is via sku_config merge_queue_sku.
 
 - name: ttnn validation basic
   cmd: /usr/bin/tt-nn-validation-basic
@@ -9,8 +10,6 @@
     wh_n150_civ2:
       timeout: 15
     bh_p150b_civ2_viommu:
-      timeout: 15
-    bh_p150b_civ2_viommu_prio:
       timeout: 15
   team: ttnn
   owner_id: U076Z1JJUQZ # Artem Yerofieiev

--- a/tests/pipeline_reorg/ttnn_validation_basic_tests.yaml
+++ b/tests/pipeline_reorg/ttnn_validation_basic_tests.yaml
@@ -7,10 +7,10 @@
   cmd: /usr/bin/tt-nn-validation-basic
   skus:
     wh_n150_civ2:
-      timeout: 30
+      timeout: 15
     bh_p150b_civ2_viommu:
-      timeout: 30
+      timeout: 15
     bh_p150b_civ2_viommu_prio:
-      timeout: 30
+      timeout: 15
   team: ttnn
   owner_id: U076Z1JJUQZ # Artem Yerofieiev

--- a/tests/pipeline_reorg/ttnn_validation_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/ttnn_validation_merge_gate_tests.yaml
@@ -3,6 +3,7 @@
 # Each entry: name, cmd, skus: { <sku>: { timeout: N } }, team, owner_id.
 # For max allowed timeout refer to .github/time_budget.yaml (ttnn -> merge_gate).
 # PR gate matrix lives in ttnn_validation_pr_gate_tests.yaml (ttnn -> pr_gate).
+# Logical SKUs only; merge_group prio routing is via sku_config merge_queue_sku.
 
 - name: ttnn validation smoke
   cmd: /usr/bin/tt-nn-validation-smoke
@@ -13,11 +14,7 @@
       timeout: 15
     wh_llmbox_civ2_viommu:
       timeout: 15
-    wh_llmbox_civ2_prio:
-      timeout: 15
     bh_p150b_civ2_viommu:
-      timeout: 15
-    bh_p150b_civ2_viommu_prio:
       timeout: 15
   team: ttnn
   owner_id: U076Z1JJUQZ # Artem Yerofieiev

--- a/tests/pipeline_reorg/ttnn_validation_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/ttnn_validation_merge_gate_tests.yaml
@@ -4,12 +4,11 @@
 # For max allowed timeout refer to .github/time_budget.yaml (ttnn -> merge_gate).
 # PR gate matrix lives in ttnn_validation_pr_gate_tests.yaml (ttnn -> pr_gate).
 # Logical SKUs only; merge_group prio routing is via sku_config merge_queue_sku.
+# Note: wh_n150_civ2 is intentionally omitted here (PR-gate smoke covers n150).
 
 - name: ttnn validation smoke
   cmd: /usr/bin/tt-nn-validation-smoke
   skus:
-    wh_n150_civ2:
-      timeout: 15
     wh_n300_civ2:
       timeout: 15
     wh_llmbox_civ2_viommu:

--- a/tt_metal/tt-llk/common/llk_assert.h
+++ b/tt_metal/tt-llk/common/llk_assert.h
@@ -1,4 +1,3 @@
-// Force gates to run
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/tt_metal/tt-llk/common/llk_assert.h
+++ b/tt_metal/tt-llk/common/llk_assert.h
@@ -1,3 +1,4 @@
+// Force gates to run
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
### PR Category
Infra cleanup

### Summary
Reorganize merge/PR gate CI around team ownership, and move merge-queue prio routing + LLK change gating into prepare_test_matrix / sku_config so test lists own logical SKUs only.

**Functional changes**

- Dropped the advisory (non-failing) detect-slow-tests per-gtest second-threshold from smoke.yaml/basic.yaml; added a hard 15-minute cap on each SKU's declared timeout:, enforced at load-matrix time.
- LLK change gating: enabled-skus: ALL_SKUS_IN_TESTS + sku-allowlist (* = all, CSV = subset, "" = skip / matrix=[]) replaces large event+arch ternaries. The LLK tests and test triggers still maintain previous behaviour.
- PR-gate LLK blackhole uses bh_p150b_civ2_viommu instead of bh_p150b_civ2 (merge_queue still routes to prio via alias).

**Non-behavioral changes**

- Merge-gate YAML regrouped under team comment headers; empty shield/blaze stubs.
- Test display name: fields renamed to team prefixes (binaries/cmds unchanged).
- Drop *_prio twin keys from gate (and unit triage hang-report) test lists; budgets trimmed to logical SKUs only 
- Add a test script for `prepare_test_matrix.py`

### Notes for reviewers
Routing model: logical SKUs in tests/pipeline_reorg/*gate* → merge_queue_sku in sku_config.yaml when --event merge_group. Do not list *_prio in test YAMLs.
Gates: smoke/basic/triage/train/models/fabric/LLK use ALL_SKUS_IN_TESTS; LLK uses sku-allowlist (* / CSV / "") for change gating. Impls pass --event "${{ github.event_name }}" (PR gate in merge queue gets prio too).
Backcompat: omitting --event / --sku-allowlist keeps old matrix behavior for non-migrated callers.

- [x] Merge gate on non merge group: https://github.com/tenstorrent/tt-metal/actions/runs/29473395458
- [x] PR gate on non merge group: https://github.com/tenstorrent/tt-metal/actions/runs/29473377234

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=roseli/cleanup-merge-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:roseli/cleanup-merge-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=roseli/cleanup-merge-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:roseli/cleanup-merge-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=roseli/cleanup-merge-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:roseli/cleanup-merge-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=roseli/cleanup-merge-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:roseli/cleanup-merge-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=roseli/cleanup-merge-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:roseli/cleanup-merge-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=roseli/cleanup-merge-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:roseli/cleanup-merge-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=roseli/cleanup-merge-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:roseli/cleanup-merge-gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=roseli/cleanup-merge-gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:roseli/cleanup-merge-gate)