### PR TITLE
[LLK][WH,BH] Move reduce_block_max Zero_Flag src set to the math init

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_reduce_custom_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_reduce_custom_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "llk_math_common_api.h"
 #include "experimental/llk_math_reduce_custom.h"
 
@@ -26,12 +27,12 @@
  * Use the standard llk_math_reduce_init<PoolType::MAX, ReduceDim::REDUCE_ROW>() with multiple
  * llk_math_reduce() calls in a loop for general-purpose block reduction.
  */
-template <uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
+template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
 inline void llk_math_reduce_block_max_row_init() {
     _llk_math_reduce_block_max_row_init_<block_ct_dim, is_fp32_dest_acc_en>();
 }
 
-template <uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
+template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
 inline void llk_math_reduce_block_max_row_mop_config() {
     _llk_math_reduce_block_max_row_mop_config_<block_ct_dim, is_fp32_dest_acc_en>();
 }
@@ -51,8 +52,8 @@ inline void llk_math_reduce_block_max_row_mop_config() {
  * Use the standard llk_math_reduce<PoolType::MAX, ReduceDim::REDUCE_ROW>() in a loop
  * for general-purpose block reduction across multiple tiles.
  */
-template <uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
-inline void llk_math_reduce_block_max_row(const uint dst_index) {
+template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
+inline void llk_math_reduce_block_max_row(const std::uint32_t dst_index) {
     LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
 
     _llk_math_reduce_block_max_row_<block_ct_dim, is_fp32_dest_acc_en>(dst_index);
@@ -66,10 +67,12 @@ inline void llk_math_reduce_block_max_row(const uint dst_index) {
  * the native llk_math_reduce_block_max_row_init LLK. This function is highly specialized
  * for a certain use case and the LLK team does not guarantee any degree of generality.
  */
-inline void llk_math_reduce_block_max_row_reinit_minimal() { reduce_max_row_configure_addrmod_reinit_minimal(); }
+template <bool is_fp32_dest_acc_en = false>
+inline void llk_math_reduce_block_max_row_reinit_minimal() {
+    _llk_math_reduce_block_max_row_reinit_minimal_<is_fp32_dest_acc_en>();
+}
 
-template <uint32_t block_ct_dim>
+template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
 inline void llk_math_reduce_block_max_row_reinit_with_mop() {
-    reduce_max_row_configure_addrmod();
-    _llk_math_reduce_block_max_row_mop_reprogram_only_<block_ct_dim>();
+    _llk_math_reduce_block_max_row_reinit_with_mop_<block_ct_dim, is_fp32_dest_acc_en>();
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_reduce_custom_runtime_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_reduce_custom_runtime_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "llk_math_common_api.h"
 #include "experimental/llk_math_reduce_custom.h"
 #include "experimental/llk_math_reduce_runtime_custom.h"
@@ -28,12 +29,12 @@
  * llk_math_reduce() calls in a loop for general-purpose block reduction.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void llk_math_reduce_block_max_row_init_runtime(uint32_t block_ct_dim) {
+inline void llk_math_reduce_block_max_row_init_runtime(std::uint32_t block_ct_dim) {
     _llk_math_reduce_block_max_row_init_runtime_<is_fp32_dest_acc_en>(block_ct_dim);
 }
 
 template <bool is_fp32_dest_acc_en = false>
-inline void llk_math_reduce_block_max_row_mop_config_runtime(uint32_t block_ct_dim) {
+inline void llk_math_reduce_block_max_row_mop_config_runtime(std::uint32_t block_ct_dim) {
     _llk_math_reduce_block_max_row_mop_config_runtime_<is_fp32_dest_acc_en>(block_ct_dim);
 }
 
@@ -53,7 +54,7 @@ inline void llk_math_reduce_block_max_row_mop_config_runtime(uint32_t block_ct_d
  * for general-purpose block reduction across multiple tiles.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void llk_math_reduce_block_max_row_runtime(const uint dst_index) {
+inline void llk_math_reduce_block_max_row_runtime(const std::uint32_t dst_index) {
     LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
 
     _llk_math_reduce_block_max_row_runtime_<is_fp32_dest_acc_en>(dst_index);
@@ -77,7 +78,7 @@ inline void llk_math_reduce_block_max_row_reinit_runtime() { _llk_math_reduce_bl
  * after a matmul operation in an SDPA inner loop.
  */
 template <bool is_fp32_dest_acc_en = false>
-inline void llk_math_reduce_block_max_row_reinit_short_runtime(uint32_t block_ct_dim) {
+inline void llk_math_reduce_block_max_row_reinit_short_runtime(std::uint32_t block_ct_dim) {
     _llk_math_reduce_block_max_row_reinit_short_runtime_<is_fp32_dest_acc_en>(block_ct_dim);
 }
 
@@ -85,6 +86,7 @@ inline void llk_math_reduce_block_max_row_reinit_short_runtime(uint32_t block_ct
  * Minimal reinitialization for block-based reduce_max_row operation.
  * Only reconfigures ADDR_MOD_1, ADDR_MOD_2, and ADDR_MOD_6 (preserves ADDR_MOD_3).
  */
+template <bool is_fp32_dest_acc_en = false>
 inline void llk_math_reduce_block_max_row_reinit_minimal_runtime() {
-    _llk_math_reduce_block_max_row_reinit_minimal_runtime_();
+    _llk_math_reduce_block_max_row_reinit_minimal_runtime_<is_fp32_dest_acc_en>();
 }

--- a/tt_metal/hw/inc/api/compute/reduce_custom.h
+++ b/tt_metal/hw/inc/api/compute/reduce_custom.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include "api/compute/common.h"
 #ifdef TRISC_MATH
 #include "llk_math_reduce_api.h"
@@ -56,8 +57,8 @@ namespace ckernel {
  * | Function   | ocb                       | The identifier of the output circular buffer (CB)                                       | uint32_t  | 0 to 31                                        | True     |
  */
 // clang-format on
-template <uint32_t block_ct_dim, bool respect_trigger = false>
-ALWI void reduce_block_max_row_init(uint32_t ocb) {
+template <std::uint32_t block_ct_dim, bool respect_trigger = false>
+ALWI void reduce_block_max_row_init(std::uint32_t ocb) {
     UNPACK((llk_unpack_AB_reduce_block_max_row_init<block_ct_dim, DST_ACCUM_MODE, respect_trigger>()));
     MATH((llk_math_reduce_block_max_row_init<block_ct_dim, DST_ACCUM_MODE>()));
     PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_ROW, PackMode::Default>(ocb)));
@@ -101,8 +102,9 @@ ALWI void reduce_block_max_row_init(uint32_t ocb) {
  * | Function   | idst                      | The index of the tile in DST REG for the result                                         | uint32_t  | Must be less than the acquired size of DST REG | True     |
  */
 // clang-format on
-template <uint32_t block_ct_dim, bool respect_trigger = false>
-ALWI void reduce_block_max_row(uint32_t icb, uint32_t icb_scaler, uint32_t row_start_index, uint32_t idst) {
+template <std::uint32_t block_ct_dim, bool respect_trigger = false>
+ALWI void reduce_block_max_row(
+    std::uint32_t icb, std::uint32_t icb_scaler, std::uint32_t row_start_index, std::uint32_t idst) {
     UNPACK((llk_unpack_AB_reduce_block_max_row<block_ct_dim, respect_trigger>(icb, icb_scaler, row_start_index)));
     MATH((llk_math_reduce_block_max_row<block_ct_dim, DST_ACCUM_MODE>(idst)));
 }
@@ -130,10 +132,10 @@ ALWI void reduce_block_max_row(uint32_t icb, uint32_t icb_scaler, uint32_t row_s
  * | Function   | ocb                       | The identifier of the output circular buffer (CB)                                       | uint32_t  | 0 to 31                                        | True     |
  */
 // clang-format on
-template <uint32_t block_ct_dim, bool respect_trigger = false>
-ALWI void reduce_block_max_row_reinit_short(uint32_t ocb) {
+template <std::uint32_t block_ct_dim, bool respect_trigger = false>
+ALWI void reduce_block_max_row_reinit_short(std::uint32_t ocb) {
     UNPACK((llk_unpack_AB_reduce_block_max_row_init<block_ct_dim, DST_ACCUM_MODE, respect_trigger>()));
-    MATH((llk_math_reduce_block_max_row_reinit_with_mop<block_ct_dim>()));
+    MATH((llk_math_reduce_block_max_row_reinit_with_mop<block_ct_dim, DST_ACCUM_MODE>()));
     PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_ROW, PackMode::Default>(ocb)));
 }
 #endif
@@ -143,10 +145,10 @@ ALWI void reduce_block_max_row_reinit_short(uint32_t ocb) {
  * Minimal reinit: only ADDR_MOD_1 + ADDR_MOD_2 + ADDR_MOD_6. Requires copy_tile_custom
  * (which uses ADDR_MOD_4) so ADDR_MOD_3 is preserved from the previous reduce.
  */
-template <uint32_t block_ct_dim, bool respect_trigger = false>
-ALWI void reduce_block_max_row_reinit_minimal(uint32_t ocb) {
+template <std::uint32_t block_ct_dim, bool respect_trigger = false>
+ALWI void reduce_block_max_row_reinit_minimal(std::uint32_t ocb) {
     UNPACK((llk_unpack_AB_reduce_block_max_row_init<block_ct_dim, DST_ACCUM_MODE, respect_trigger>()));
-    MATH((llk_math_reduce_block_max_row_reinit_minimal()));
+    MATH((llk_math_reduce_block_max_row_reinit_minimal<DST_ACCUM_MODE>()));
     PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_ROW, PackMode::Default>(ocb)));
 }
 
@@ -156,9 +158,9 @@ ALWI void reduce_block_max_row_reinit_minimal(uint32_t ocb) {
  * from the previous reduce.
  */
 ALWI void reduce_block_max_row_reinit_minimal_runtime(
-    uint32_t ocb, uint32_t block_ct_dim, bool respect_trigger = false) {
+    std::uint32_t ocb, std::uint32_t block_ct_dim, bool respect_trigger = false) {
     UNPACK((llk_unpack_AB_reduce_block_max_row_init_runtime<DST_ACCUM_MODE>(block_ct_dim, respect_trigger)));
-    MATH((llk_math_reduce_block_max_row_reinit_minimal_runtime()));
+    MATH((llk_math_reduce_block_max_row_reinit_minimal_runtime<DST_ACCUM_MODE>()));
     PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_ROW, PackMode::Default>(ocb)));
 }
 
@@ -166,7 +168,8 @@ ALWI void reduce_block_max_row_reinit_minimal_runtime(
  * Short reinit (runtime variant): Reprograms reduce MOP and restores addrmods.
  * Used when reduce follows custom SDPA sub path with runtime block_ct_dim.
  */
-ALWI void reduce_block_max_row_reinit_short_runtime(uint32_t ocb, uint32_t block_ct_dim, bool respect_trigger = false) {
+ALWI void reduce_block_max_row_reinit_short_runtime(
+    std::uint32_t ocb, std::uint32_t block_ct_dim, bool respect_trigger = false) {
     UNPACK((llk_unpack_AB_reduce_block_max_row_init_runtime<DST_ACCUM_MODE>(block_ct_dim, respect_trigger)));
     MATH((llk_math_reduce_block_max_row_reinit_short_runtime<DST_ACCUM_MODE>(block_ct_dim)));
     PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_ROW, PackMode::Default>(ocb)));
@@ -206,7 +209,7 @@ ALWI void reduce_block_max_row_reinit_short_runtime(uint32_t ocb, uint32_t block
  */
 // clang-format on
 template <bool respect_trigger = false>
-ALWI void reduce_block_max_row_uninit(uint32_t icb) {
+ALWI void reduce_block_max_row_uninit(std::uint32_t icb) {
 #ifdef ARCH_BLACKHOLE
     MATH((llk_math_reduce_uninit()));
 #else
@@ -220,17 +223,18 @@ ALWI void reduce_block_max_row_uninit(uint32_t icb) {
 }
 
 // Runtime variants - block_ct_dim and respect_trigger are runtime parameters.
-ALWI void reduce_block_max_row_init_runtime(uint32_t ocb, uint32_t block_ct_dim, bool respect_trigger = false) {
+ALWI void reduce_block_max_row_init_runtime(
+    std::uint32_t ocb, std::uint32_t block_ct_dim, bool respect_trigger = false) {
     UNPACK((llk_unpack_AB_reduce_block_max_row_init_runtime<DST_ACCUM_MODE>(block_ct_dim, respect_trigger)));
     MATH((llk_math_reduce_block_max_row_init_runtime<DST_ACCUM_MODE>(block_ct_dim)));
     PACK((llk_pack_reduce_mask_config<ReduceDim::REDUCE_ROW, PackMode::Default>(ocb)));
 }
 
 ALWI void reduce_block_max_row_runtime(
-    uint32_t icb,
-    uint32_t icb_scaler,
-    uint32_t row_start_index,
-    uint32_t idst,
+    std::uint32_t icb,
+    std::uint32_t icb_scaler,
+    std::uint32_t row_start_index,
+    std::uint32_t idst,
     bool respect_trigger = false,
     bool overlap_first_half = false) {
     UNPACK((llk_unpack_AB_reduce_block_max_row_runtime(
@@ -239,7 +243,7 @@ ALWI void reduce_block_max_row_runtime(
 }
 
 ALWI void reduce_block_max_row_uninit_runtime(
-    uint32_t icb, bool respect_trigger = false, bool overlap_first_half = false) {
+    std::uint32_t icb, bool respect_trigger = false, bool overlap_first_half = false) {
 #ifdef ARCH_BLACKHOLE
     MATH((llk_math_reduce_uninit()));
 #else

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_reduce_custom.h
@@ -253,6 +253,7 @@ inline void _llk_math_reduce_block_max_row_init_()
     {
         // Disable the ALU src zero-flag (denormal flush) so the fp32 hi16/lo16 MOVB2D packing works.
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+        math::_invalidate_src_zero_flag_state_();
     }
     reduce_max_row_configure_addrmod();
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_reduce_custom.h
@@ -201,6 +201,37 @@ inline void _llk_math_reduce_block_max_row_mop_reprogram_only_()
 }
 
 /**
+ * Minimal reinit for block-based reduce_max_row (addrmods only), re-establishing the fp32 ALU src
+ * zero-flag baseline on the math thread. See _llk_math_reduce_block_max_row_init_ for the full init.
+ */
+template <bool is_fp32_dest_acc_en = false>
+inline void _llk_math_reduce_block_max_row_reinit_minimal_()
+{
+    if constexpr (is_fp32_dest_acc_en)
+    {
+        // Disable the ALU src zero-flag (denormal flush) so the fp32 hi16/lo16 MOVB2D packing works.
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+    }
+    reduce_max_row_configure_addrmod_reinit_minimal();
+}
+
+/**
+ * Reinit for block-based reduce_max_row that also reprograms the reduce MOP, re-establishing the
+ * fp32 ALU src zero-flag baseline on the math thread. See _llk_math_reduce_block_max_row_init_.
+ */
+template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
+inline void _llk_math_reduce_block_max_row_reinit_with_mop_()
+{
+    if constexpr (is_fp32_dest_acc_en)
+    {
+        // Disable the ALU src zero-flag (denormal flush) so the fp32 hi16/lo16 MOVB2D packing works.
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+    }
+    reduce_max_row_configure_addrmod();
+    _llk_math_reduce_block_max_row_mop_reprogram_only_<block_ct_dim>();
+}
+
+/**
  * Initializes block-based reduce_max_row operation for processing multiple tiles.
  *
  * This function works with the following assumptions:
@@ -218,6 +249,11 @@ inline void _llk_math_reduce_block_max_row_mop_reprogram_only_()
 template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
 inline void _llk_math_reduce_block_max_row_init_()
 {
+    if constexpr (is_fp32_dest_acc_en)
+    {
+        // Disable the ALU src zero-flag (denormal flush) so the fp32 hi16/lo16 MOVB2D packing works.
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+    }
     reduce_max_row_configure_addrmod();
 
     TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_reduce_runtime_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_reduce_runtime_custom.h
@@ -247,6 +247,7 @@ inline void _llk_math_reduce_block_max_row_init_runtime_(std::uint32_t block_ct_
     {
         // Disable the ALU src zero-flag (denormal flush) so the fp32 hi16/lo16 MOVB2D packing works.
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+        math::_invalidate_src_zero_flag_state_();
     }
     reduce_max_row_configure_addrmod_runtime();
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_reduce_runtime_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_reduce_runtime_custom.h
@@ -243,6 +243,11 @@ inline void _llk_math_reduce_block_max_row_mop_reprogram_only_runtime_(std::uint
 template <bool is_fp32_dest_acc_en = false>
 inline void _llk_math_reduce_block_max_row_init_runtime_(std::uint32_t block_ct_dim)
 {
+    if constexpr (is_fp32_dest_acc_en)
+    {
+        // Disable the ALU src zero-flag (denormal flush) so the fp32 hi16/lo16 MOVB2D packing works.
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+    }
     reduce_max_row_configure_addrmod_runtime();
 
     TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
@@ -321,6 +326,11 @@ inline void _llk_math_reduce_block_max_row_reinit_runtime_()
 template <bool is_fp32_dest_acc_en = false>
 inline void _llk_math_reduce_block_max_row_reinit_short_runtime_(std::uint32_t block_ct_dim)
 {
+    if constexpr (is_fp32_dest_acc_en)
+    {
+        // Disable the ALU src zero-flag (denormal flush) so the fp32 hi16/lo16 MOVB2D packing works.
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+    }
     reduce_max_row_configure_addrmod();
     TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
     math::reset_counters(p_setrwc::SET_ABD_F);
@@ -332,8 +342,14 @@ inline void _llk_math_reduce_block_max_row_reinit_short_runtime_(std::uint32_t b
  * Only reconfigures ADDR_MOD_1, ADDR_MOD_2, and ADDR_MOD_6 (preserves ADDR_MOD_3).
  * Used when only specific addrmods were clobbered by previous operations.
  */
+template <bool is_fp32_dest_acc_en = false>
 inline void _llk_math_reduce_block_max_row_reinit_minimal_runtime_()
 {
+    if constexpr (is_fp32_dest_acc_en)
+    {
+        // Disable the ALU src zero-flag (denormal flush) so the fp32 hi16/lo16 MOVB2D packing works.
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+    }
     reduce_max_row_configure_addrmod_reinit_minimal_runtime();
     TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
     math::reset_counters(p_setrwc::SET_ABD_F);

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom.h
@@ -64,11 +64,6 @@ inline void _llk_unpack_AB_reduce_block_max_row_mop_config_()
 template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, bool respect_trigger = false>
 inline void _llk_unpack_AB_reduce_block_max_row_init_()
 {
-    if constexpr (is_fp32_dest_acc_en)
-    {
-        // Set necessary config regs for MOVB2D hi16/lo16 to work
-        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
-    }
     // REDUCE_ROW requires transpose itself; additionally, within_face_16x16_transpose flag could require transpose;
     // if we have the flag set with REDUCE_ROW, we don't need to do anything
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(1);

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
@@ -61,11 +61,6 @@ inline void _llk_unpack_AB_reduce_block_max_row_mop_config_runtime_(std::uint32_
 template <bool is_fp32_dest_acc_en = false>
 inline void _llk_unpack_AB_reduce_block_max_row_init_runtime_(std::uint32_t block_ct_dim, bool respect_trigger = false)
 {
-    if constexpr (is_fp32_dest_acc_en)
-    {
-        // Set necessary config regs for MOVB2D hi16/lo16 to work
-        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
-    }
     // REDUCE_ROW requires transpose itself; additionally, within_face_16x16_transpose flag could require transpose;
     // if we have the flag set with REDUCE_ROW, we don't need to do anything
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(1);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_reduce_custom.h
@@ -165,6 +165,11 @@ inline void _llk_math_reduce_block_max_row_mop_config_()
 template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
 inline void _llk_math_reduce_block_max_row_init_()
 {
+    if constexpr (is_fp32_dest_acc_en)
+    {
+        // Disable the ALU src zero-flag (denormal flush) so the fp32 hi16/lo16 MOVB2D packing works.
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+    }
     reduce_max_row_configure_addrmod();
 
     TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_reduce_custom.h
@@ -169,6 +169,7 @@ inline void _llk_math_reduce_block_max_row_init_()
     {
         // Disable the ALU src zero-flag (denormal flush) so the fp32 hi16/lo16 MOVB2D packing works.
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+        math::_invalidate_src_zero_flag_state_();
     }
     reduce_max_row_configure_addrmod();
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_reduce_runtime_custom.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_reduce_runtime_custom.h
@@ -152,6 +152,11 @@ inline void _llk_math_reduce_block_max_row_mop_reprogram_only_runtime_(std::uint
 template <bool is_fp32_dest_acc_en = false>
 inline void _llk_math_reduce_block_max_row_init_runtime_(std::uint32_t block_ct_dim)
 {
+    if constexpr (is_fp32_dest_acc_en)
+    {
+        // Disable the ALU src zero-flag (denormal flush) so the fp32 hi16/lo16 MOVB2D packing works.
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+    }
     reduce_max_row_configure_addrmod_reinit_runtime();
 
     TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_reduce_runtime_custom.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_reduce_runtime_custom.h
@@ -156,6 +156,7 @@ inline void _llk_math_reduce_block_max_row_init_runtime_(std::uint32_t block_ct_
     {
         // Disable the ALU src zero-flag (denormal flush) so the fp32 hi16/lo16 MOVB2D packing works.
         cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+        math::_invalidate_src_zero_flag_state_();
     }
     reduce_max_row_configure_addrmod_reinit_runtime();
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_reduce_custom.h
@@ -64,11 +64,6 @@ inline void _llk_unpack_AB_reduce_block_max_row_mop_config_()
 template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false, bool respect_trigger = false>
 inline void _llk_unpack_AB_reduce_block_max_row_init_()
 {
-    if constexpr (is_fp32_dest_acc_en)
-    {
-        // Set necessary config regs for MOVB2D hi16/lo16 to work
-        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
-    }
     // REDUCE_ROW requires transpose itself; additionally, within_face_16x16_transpose flag could require transpose;
     // if we have the flag set with REDUCE_ROW, we don't need to do anything
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(1);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_AB_reduce_custom_runtime.h
@@ -61,11 +61,6 @@ inline void _llk_unpack_AB_reduce_block_max_row_mop_config_runtime_(std::uint32_
 template <bool is_fp32_dest_acc_en = false>
 inline void _llk_unpack_AB_reduce_block_max_row_init_runtime_(std::uint32_t block_ct_dim, bool respect_trigger = false)
 {
-    if constexpr (is_fp32_dest_acc_en)
-    {
-        // Set necessary config regs for MOVB2D hi16/lo16 to work
-        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
-    }
     // REDUCE_ROW requires transpose itself; additionally, within_face_16x16_transpose flag could require transpose;
     // if we have the flag set with REDUCE_ROW, we don't need to do anything
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(1);


### PR DESCRIPTION
## What

In the experimental block-reduce-max-row LLK, the unpacker init (`_llk_unpack_AB_reduce_block_max_row_init_` and its `_runtime_` variant) set `ALU_ACC_CTRL_Zero_Flag_disabled_src = 1` on the fp32 path. This moves that set onto the math thread — the flag's sole consumer — on both Wormhole B0 and Blackhole.

- Remove it from the unpacker init (`_init_` / `_init_runtime_`), WH + BH.
- Add it to the sibling math init (`_llk_math_reduce_block_max_row_init_` / `_runtime_`), WH + BH — both already carry `is_fp32_dest_acc_en`.
- Add it to the **Blackhole reinit paths** that reuse the unpacker init, threading `is_fp32_dest_acc_en` through parent → api → lib: `reinit_with_mop`, `reinit_minimal`, `reinit_minimal_runtime` (`reinit_short_runtime` already carried it). Two new dedicated lib functions (`_llk_math_reduce_block_max_row_reinit_minimal_` / `_reinit_with_mop_`) keep the shared addrmod/mop helpers (and their test-only caller) untouched. The reinit paths are `ARCH_BLACKHOLE`-only.

## Why

`ALU_ACC_CTRL_Zero_Flag_disabled_src` is a **Matrix-Unit (FPU) denormal-flush control** (`FlushDenormals = !flag`). Its only consumer in this op is the math thread's **MOVB2D** in the fp32 hi16/lo16 packing path — the unpacker never reads it. Setting it from the unpacker was a cross-thread write; moving it onto the math thread puts the flag entirely on its consumer. The math init siblings already had `is_fp32_dest_acc_en`, so no new argument was needed there; the reinit paths get it threaded through.

## Behavior

No functional change. The flag is established at the same logical point (block-op init/reinit, before the first execute) — just from the math thread instead of cross-thread from the unpacker:

- **GMPOOL** (the MOP column-reduce) does **not** read the flag (confirmed against the ISA functional models), so removing the unpacker's pre-set doesn't affect it.
- **MOVB2D** (the only consumer) is additionally set/cleared inside the math execute.
- No unpack/math **uninit** ever cleared this bit — it is set at init/reinit and cleared per-tile by the math execute — so there is no uninit-side counterpart.

## Verification

- **WH silicon:** `test_fused.py -k reduce_block_max` (`fpu_reduce_block_max` + `_runtime`, `dest_acc: true`/Float32 — exercises the new fp32 branch in math init + init_runtime and the modified unpack init) — 2 passed, **PCC 1.000000**.
- **BH compile:** `reduce_block_max` clean (parse-checks the new reinit lib functions; non-reinit paths intact).
- The reinit paths' end-to-end compile test (`sdpa_inner_loop_step`) is blocked by a **pre-existing, unrelated** sfpi toolchain error (identical failure on clean `main`); no error references the reduce/reinit/Zero_Flag code. The added `cfg_reg_rmw_tensix<...Zero_Flag...>(1)` is byte-identical to the statement already compiling in the math execute of the same files.
- Consumption confirmed against the ISA functional models (`MOVB2D`: `FlushDenormals = !ALU_ACC_CTRL_Zero_Flag_disabled_src`; `GMPOOL`: no reference to the flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/llk-move-reduce-zero-flag-to-math-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/llk-move-reduce-zero-flag-to-math-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/llk-move-reduce-zero-flag-to-math-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/llk-move-reduce-zero-flag-to-math-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/llk-move-reduce-zero-flag-to-math-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/llk-move-reduce-zero-flag-to-math-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/llk-move-reduce-zero-flag-to-math-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/llk-move-reduce-zero-flag-to-math-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/llk-move-reduce-zero-flag-to-math-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/llk-move-reduce-zero-flag-to-math-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/llk-move-reduce-zero-flag-to-math-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/llk-move-reduce-zero-flag-to-math-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/llk-move-reduce-zero-flag-to-math-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/llk-move-reduce-zero-flag-to-math-init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/llk-move-reduce-zero-flag-to-math-init)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/llk-move-reduce-zero-flag-to-math-init)