### PR TITLE
[Feature] Widen RT-profiler runtime ID to 32 bits end-to-end

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_sanity.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_realtime_profiler_sanity.cpp
@@ -120,6 +120,7 @@ void enqueue_sanity_program(
 
 TEST(RealtimeProfilerSanity, FiveProgramsBackToBack) {
     constexpr int kDeviceId = 0;
+    const std::set<uint32_t> expected_runtime_ids = {1, 2, 3, 0x12345678u, 0x12345679u};
 
     auto mesh_device = distributed::MeshDevice::create_unit_mesh(
         kDeviceId,
@@ -150,10 +151,8 @@ TEST(RealtimeProfilerSanity, FiveProgramsBackToBack) {
 
     CoreCoord compute_grid = mesh_device->compute_with_storage_grid_size();
     CoreRange all_cores(CoreCoord{0, 0}, CoreCoord{compute_grid.x - 1, compute_grid.y - 1});
-    for (uint32_t i = 0; i < kNumPrograms; ++i) {
-        // Runtime IDs start at 1 so every program emits a record (runtime_id == 0
-        // is reserved for infrastructure traffic and filtered host-side).
-        enqueue_sanity_program(mesh_device, /*runtime_id=*/i + 1, all_cores);
+    for (uint32_t runtime_id : expected_runtime_ids) {
+        enqueue_sanity_program(mesh_device, runtime_id, all_cores);
     }
 
     mesh_device->quiesce_devices();
@@ -165,8 +164,9 @@ TEST(RealtimeProfilerSanity, FiveProgramsBackToBack) {
 
     UnregisterProgramRealtimeProfilerCallback(handle);
 
-    ASSERT_GE(records.size(), kNumPrograms)
-        << "Expected at least " << kNumPrograms << " RT profiler records (one per program), got " << records.size();
+    ASSERT_GE(records.size(), expected_runtime_ids.size())
+        << "Expected at least " << expected_runtime_ids.size() << " RT profiler records (one per program), got "
+        << records.size();
     EXPECT_EQ(dropped, 0u);
 
     for (const auto& rec : records) {
@@ -189,7 +189,7 @@ TEST(RealtimeProfilerSanity, FiveProgramsBackToBack) {
     // source.
     std::set<uint32_t> programs_with_correct_sources;
     for (const auto& rec : records) {
-        if (rec.runtime_id < 1 || rec.runtime_id > kNumPrograms) {
+        if (!expected_runtime_ids.contains(rec.runtime_id)) {
             continue;
         }
         ASSERT_FALSE(rec.kernel_sources.empty())
@@ -203,7 +203,7 @@ TEST(RealtimeProfilerSanity, FiveProgramsBackToBack) {
         }
         programs_with_correct_sources.insert(rec.runtime_id);
     }
-    EXPECT_EQ(programs_with_correct_sources.size(), kNumPrograms)
+    EXPECT_EQ(programs_with_correct_sources, expected_runtime_ids)
         << "Not every program's source was correctly correlated by runtime ID";
 }
 

--- a/tt_metal/api/tt-metalium/experimental/realtime_profiler.hpp
+++ b/tt_metal/api/tt-metalium/experimental/realtime_profiler.hpp
@@ -12,8 +12,7 @@
 namespace tt::tt_metal::experimental {
 
 struct ProgramRealtimeRecord {
-    uint32_t runtime_id;                               // Runtime ID. Currently truncated to 16 bits;
-                                                       // widening tracked in #46103.
+    uint32_t runtime_id;                               // Program runtime ID
     uint32_t chip_id;                                  // Device chip ID
     uint64_t start_timestamp;                          // Device start timestamp (raw ticks)
     uint64_t end_timestamp;                            // Device end timestamp (raw ticks)

--- a/tt_metal/distributed/realtime_profiler_manager.cpp
+++ b/tt_metal/distributed/realtime_profiler_manager.cpp
@@ -342,18 +342,21 @@ void RealtimeProfilerManager::publish_pages(
     const uint32_t chip_id = dev_state.chip_id;
     const double sync_frequency = dev_state.sync_frequency;
     const DataCollector* const data_collector = data_collector_;
-    for (uint32_t page = 0; page < num_pages; ++page) {
-        const uint32_t* rp = page_buf + page * kPageWords;
-        if (!is_record(rp)) {
-            continue;
+    {
+        TTZoneScopedDN(RT_PROFILER, "BuildRecords");
+        for (uint32_t page = 0; page < num_pages; ++page) {
+            const uint32_t* rp = page_buf + page * kPageWords;
+            if (!is_record(rp)) {
+                continue;
+            }
+            records.emplace_back(
+                rp[2],
+                chip_id,
+                (static_cast<uint64_t>(rp[0]) << 32) | rp[1],
+                (static_cast<uint64_t>(rp[4]) << 32) | rp[5],
+                sync_frequency,
+                data_collector->GetKernelSourcesForRuntimeId(rp[2]));
         }
-        records.emplace_back(
-            rp[2],
-            chip_id,
-            (static_cast<uint64_t>(rp[0]) << 32) | rp[1],
-            (static_cast<uint64_t>(rp[4]) << 32) | rp[5],
-            sync_frequency,
-            data_collector->GetKernelSourcesForRuntimeId(static_cast<uint16_t>(rp[2])));
     }
     if (records.empty()) {
         return;

--- a/tt_metal/hw/inc/hostdev/realtime_profiler_msgs.h
+++ b/tt_metal/hw/inc/hostdev/realtime_profiler_msgs.h
@@ -22,7 +22,7 @@ enum RealtimeProfilerState : uint32_t {
 struct realtime_profiler_timestamp_t {
     uint32_t time_hi;
     uint32_t time_lo;
-    uint32_t id;
+    uint32_t runtime_id;
     uint32_t header;
 };
 
@@ -37,7 +37,7 @@ struct realtime_profiler_msg_t {
     struct realtime_profiler_timestamp_t kernel_end_b;
     volatile uint32_t sync_request;
     volatile uint32_t sync_host_timestamp;
-    volatile uint32_t program_id_fifo[32];
-    volatile uint32_t program_id_fifo_start;
-    volatile uint32_t program_id_fifo_end;
+    volatile uint32_t runtime_id_fifo[32];
+    volatile uint32_t runtime_id_fifo_start;
+    volatile uint32_t runtime_id_fifo_end;
 };

--- a/tt_metal/impl/dispatch/data_collection.cpp
+++ b/tt_metal/impl/dispatch/data_collection.cpp
@@ -66,7 +66,7 @@ void RecordProgramMetadata(ProgramImpl& program) {
     tt::tt_metal::MetalContext::instance().data_collector()->RecordProgramMetadata(program);
 }
 
-std::span<const std::string_view> GetKernelSourcesForRuntimeId(uint16_t runtime_id) {
+std::span<const std::string_view> GetKernelSourcesForRuntimeId(uint32_t runtime_id) {
     return tt::tt_metal::MetalContext::instance().data_collector()->GetKernelSourcesForRuntimeId(runtime_id);
 }
 

--- a/tt_metal/impl/dispatch/data_collection.hpp
+++ b/tt_metal/impl/dispatch/data_collection.hpp
@@ -81,7 +81,7 @@ std::optional<ProgramSubDeviceInfo> GetProgramSubDevice(tt::ChipId device_id, ui
 
 // Look up kernel source paths by runtime_id; empty span if the runtime_id is unknown.
 // The returned span is valid until MetalContext teardown or reinitialization.
-std::span<const std::string_view> GetKernelSourcesForRuntimeId(uint16_t runtime_id);
+std::span<const std::string_view> GetKernelSourcesForRuntimeId(uint32_t runtime_id);
 
 // Register a callback to be invoked when real-time profiler data arrives.
 // Multiple callbacks can be registered; each callback is called from its own thread.

--- a/tt_metal/impl/dispatch/data_collector.cpp
+++ b/tt_metal/impl/dispatch/data_collector.cpp
@@ -132,8 +132,7 @@ void DataCollector::RecordKernelGroup(
 void DataCollector::RecordProgramRun(uint64_t program_id) { program_id_to_call_count[program_id]++; }
 
 void DataCollector::RecordProgramMetadata(ProgramImpl& program) {
-    // The real-time profiler currently narrows the runtime ID to 16 bits, so we do the same here.
-    uint16_t runtime_id = static_cast<uint16_t>(program.get_runtime_id());
+    uint32_t runtime_id = static_cast<uint32_t>(program.get_runtime_id());
     uint64_t program_id = program.get_id();
     std::lock_guard<std::mutex> lock(kernel_source_mutex_);
     auto [it, inserted] = program_id_to_kernel_sources_.try_emplace(program_id);
@@ -149,7 +148,17 @@ void DataCollector::RecordProgramMetadata(ProgramImpl& program) {
             }
         }
     }
-    runtime_id_to_kernel_sources_[runtime_id].store(&it->second, std::memory_order_release);
+
+    const uint32_t page_index = runtime_id >> kRuntimeIdPageBits;
+    const uint32_t slot_index = runtime_id & kRuntimeIdPageMask;
+    KernelSourcesPage* page = kernel_sources_page_directory_[page_index].load(std::memory_order_relaxed);
+    if (page == nullptr) {
+        auto new_page = std::make_unique<KernelSourcesPage>();
+        page = new_page.get();
+        kernel_sources_pages_.push_back(std::move(new_page));
+        kernel_sources_page_directory_[page_index].store(page, std::memory_order_release);
+    }
+    (*page)[slot_index].store(&it->second, std::memory_order_release);
 }
 
 void DataCollector::RecordProgramSubDevice(

--- a/tt_metal/impl/dispatch/data_collector.cpp
+++ b/tt_metal/impl/dispatch/data_collector.cpp
@@ -133,8 +133,7 @@ void DataCollector::RecordKernelGroup(
 void DataCollector::RecordProgramRun(uint64_t program_id) { program_id_to_call_count[program_id]++; }
 
 void DataCollector::RecordProgramMetadata(ProgramImpl& program) {
-    // The real-time profiler currently narrows the runtime ID to 16 bits, so we do the same here.
-    uint16_t runtime_id = static_cast<uint16_t>(program.get_runtime_id());
+    uint32_t runtime_id = static_cast<uint32_t>(program.get_runtime_id());
     uint64_t program_id = program.get_id();
     std::lock_guard<std::mutex> lock(kernel_source_mutex_);
     auto [it, inserted] = program_id_to_kernel_sources_.try_emplace(program_id);
@@ -150,7 +149,17 @@ void DataCollector::RecordProgramMetadata(ProgramImpl& program) {
             }
         }
     }
-    runtime_id_to_kernel_sources_[runtime_id].store(&it->second, std::memory_order_release);
+
+    const uint32_t page_index = runtime_id >> kRuntimeIdPageBits;
+    const uint32_t slot_index = runtime_id & kRuntimeIdPageMask;
+    KernelSourcesPage* page = kernel_sources_page_directory_[page_index].load(std::memory_order_relaxed);
+    if (page == nullptr) {
+        auto new_page = std::make_unique<KernelSourcesPage>();
+        page = new_page.get();
+        kernel_sources_pages_.push_back(std::move(new_page));
+        kernel_sources_page_directory_[page_index].store(page, std::memory_order_release);
+    }
+    (*page)[slot_index].store(&it->second, std::memory_order_release);
 }
 
 void DataCollector::RecordProgramSubDevice(

--- a/tt_metal/impl/dispatch/data_collector.hpp
+++ b/tt_metal/impl/dispatch/data_collector.hpp
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <cstdint>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <span>
 #include <string>
@@ -65,8 +66,14 @@ public:
     std::optional<tt::ProgramSubDeviceInfo> GetProgramSubDevice(tt::ChipId device_id, uint64_t runtime_id) const;
     // Look up kernel source paths by runtime_id; empty span if the runtime_id is unknown.
     // The returned span is valid until MetalContext teardown or reinitialization.
-    std::span<const std::string_view> GetKernelSourcesForRuntimeId(uint16_t runtime_id) const noexcept {
-        const auto* sources = runtime_id_to_kernel_sources_[runtime_id].load(std::memory_order_acquire);
+    std::span<const std::string_view> GetKernelSourcesForRuntimeId(uint32_t runtime_id) const noexcept {
+        const uint32_t page_index = runtime_id >> kRuntimeIdPageBits;
+        const uint32_t slot_index = runtime_id & kRuntimeIdPageMask;
+        const KernelSourcesPage* page = kernel_sources_page_directory_[page_index].load(std::memory_order_acquire);
+        if (page == nullptr) {
+            return {};
+        }
+        const auto* sources = (*page)[slot_index].load(std::memory_order_acquire);
         return sources != nullptr ? std::span<const std::string_view>(*sources) : std::span<const std::string_view>{};
     }
     // Register a callback to be invoked when real-time profiler data arrives.
@@ -88,7 +95,11 @@ public:
     void DumpData();
 
 private:
-    static constexpr size_t kRuntimeIdSlots = 1u << 16;
+    static constexpr uint32_t kRuntimeIdPageBits = 13;
+    static constexpr size_t kRuntimeIdsPerPage = size_t{1} << kRuntimeIdPageBits;
+    static constexpr size_t kRuntimeIdPageCount = size_t{1} << (32 - kRuntimeIdPageBits);
+    static constexpr uint32_t kRuntimeIdPageMask = static_cast<uint32_t>(kRuntimeIdsPerPage - 1);
+    using KernelSourcesPage = std::array<std::atomic<const std::vector<std::string_view>*>, kRuntimeIdsPerPage>;
 
     struct RealtimeCallbackRegistration {
         tt::ProgramRealtimeProfilerCallbackHandle handle;
@@ -106,12 +117,11 @@ private:
     std::map<uint64_t, std::vector<DispatchData>> program_id_to_dispatch_data;
     std::map<uint64_t, std::map<HalProgrammableCoreType, std::vector<KernelGroupData>>> program_id_to_kernel_groups;
     std::map<uint64_t, int> program_id_to_call_count;
-    // Kernel source bookkeeping for the real-time profiler. Guarded because the dispatch thread writes and
-    // the real-time profiler receiver thread reads.
     mutable std::mutex kernel_source_mutex_;
     std::unordered_set<std::string> unique_kernel_sources_;
     std::unordered_map<uint64_t, std::vector<std::string_view>> program_id_to_kernel_sources_;
-    std::array<std::atomic<const std::vector<std::string_view>*>, kRuntimeIdSlots> runtime_id_to_kernel_sources_{};
+    std::array<std::atomic<KernelSourcesPage*>, kRuntimeIdPageCount> kernel_sources_page_directory_{};
+    std::vector<std::unique_ptr<KernelSourcesPage>> kernel_sources_pages_;
     std::map<std::pair<tt::ChipId, uint64_t>, tt::ProgramSubDeviceInfo> runtime_id_to_sub_device;
     mutable std::mutex runtime_id_to_sub_device_mutex_;
     mutable std::mutex program_realtime_profiler_callbacks_mutex_;

--- a/tt_metal/impl/dispatch/data_collector.hpp
+++ b/tt_metal/impl/dispatch/data_collector.hpp
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <cstdint>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <span>
 #include <string>
@@ -67,8 +68,14 @@ public:
     std::optional<tt::ProgramSubDeviceInfo> GetProgramSubDevice(tt::ChipId device_id, uint64_t runtime_id) const;
     // Look up kernel source paths by runtime_id; empty span if the runtime_id is unknown.
     // The returned span is valid until MetalContext teardown or reinitialization.
-    std::span<const std::string_view> GetKernelSourcesForRuntimeId(uint16_t runtime_id) const noexcept {
-        const auto* sources = runtime_id_to_kernel_sources_[runtime_id].load(std::memory_order_acquire);
+    std::span<const std::string_view> GetKernelSourcesForRuntimeId(uint32_t runtime_id) const noexcept {
+        const uint32_t page_index = runtime_id >> kRuntimeIdPageBits;
+        const uint32_t slot_index = runtime_id & kRuntimeIdPageMask;
+        const KernelSourcesPage* page = kernel_sources_page_directory_[page_index].load(std::memory_order_acquire);
+        if (page == nullptr) {
+            return {};
+        }
+        const auto* sources = (*page)[slot_index].load(std::memory_order_acquire);
         return sources != nullptr ? std::span<const std::string_view>(*sources) : std::span<const std::string_view>{};
     }
     // Register a callback to be invoked when real-time profiler data arrives.
@@ -90,7 +97,11 @@ public:
     void DumpData();
 
 private:
-    static constexpr size_t kRuntimeIdSlots = 1u << 16;
+    static constexpr uint32_t kRuntimeIdPageBits = 13;
+    static constexpr size_t kRuntimeIdsPerPage = size_t{1} << kRuntimeIdPageBits;
+    static constexpr size_t kRuntimeIdPageCount = size_t{1} << (32 - kRuntimeIdPageBits);
+    static constexpr uint32_t kRuntimeIdPageMask = static_cast<uint32_t>(kRuntimeIdsPerPage - 1);
+    using KernelSourcesPage = std::array<std::atomic<const std::vector<std::string_view>*>, kRuntimeIdsPerPage>;
 
     struct RealtimeCallbackRegistration {
         tt::ProgramRealtimeProfilerCallbackHandle handle;
@@ -110,12 +121,11 @@ private:
     std::map<uint64_t, std::vector<DispatchData>> program_id_to_dispatch_data;
     std::map<uint64_t, std::map<HalProgrammableCoreType, std::vector<KernelGroupData>>> program_id_to_kernel_groups;
     std::map<uint64_t, int> program_id_to_call_count;
-    // Kernel source bookkeeping for the real-time profiler. Guarded because the dispatch thread writes and
-    // the real-time profiler receiver thread reads.
     mutable std::mutex kernel_source_mutex_;
     std::unordered_set<std::string> unique_kernel_sources_;
     std::unordered_map<uint64_t, std::vector<std::string_view>> program_id_to_kernel_sources_;
-    std::array<std::atomic<const std::vector<std::string_view>*>, kRuntimeIdSlots> runtime_id_to_kernel_sources_{};
+    std::array<std::atomic<KernelSourcesPage*>, kRuntimeIdPageCount> kernel_sources_page_directory_{};
+    std::vector<std::unique_ptr<KernelSourcesPage>> kernel_sources_pages_;
     std::map<std::pair<tt::ChipId, uint64_t>, tt::ProgramSubDeviceInfo> runtime_id_to_sub_device;
     mutable std::mutex runtime_id_to_sub_device_mutex_;
     mutable std::mutex program_realtime_profiler_callbacks_mutex_;

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
@@ -45,13 +45,13 @@ using namespace tt::tt_metal;
 namespace {
 
 // Zeros selected realtime_profiler_msg_t fields on dispatch_s L1 (REALTIME_PROFILER_MSG carve); order matches
-// former cq_dispatch_subordinate kernel_main init (signalling fields before FIFO, then timestamp .id words).
+// former cq_dispatch_subordinate kernel_main init (signalling fields before FIFO, then timestamp runtime IDs).
 void zero_dispatch_s_realtime_profiler_msg_fields(
     IDevice* device, const CoreCoord& logical_core, tt::CoreType core_type, const Hal& hal, uint32_t msg_base_l1_addr) {
     const auto& factory = hal.get_realtime_profiler_msgs_factory(HalProgrammableCoreType::TENSIX);
     // WriteToDeviceL1(..., vector<uint32_t>&) requires a mutable vector (non-const ref overload).
     std::vector<uint32_t> zero_word = {0u};
-    const uint32_t ts_id_byte_off = offsetof(realtime_profiler_timestamp_t, id);
+    const uint32_t runtime_id_byte_offset = offsetof(realtime_profiler_timestamp_t, runtime_id);
 
     auto write_u32 = [&](uint32_t addr) {
         tt::tt_metal::detail::WriteToDeviceL1(device, logical_core, addr, zero_word, core_type);
@@ -69,10 +69,10 @@ void zero_dispatch_s_realtime_profiler_msg_fields(
                    realtime_profiler_msgs::realtime_profiler_msg_t::Field::realtime_profiler_state));
     write_u32(
         base + factory.offset_of<realtime_profiler_msgs::realtime_profiler_msg_t>(
-                   realtime_profiler_msgs::realtime_profiler_msg_t::Field::program_id_fifo_start));
+                   realtime_profiler_msgs::realtime_profiler_msg_t::Field::runtime_id_fifo_start));
     write_u32(
         base + factory.offset_of<realtime_profiler_msgs::realtime_profiler_msg_t>(
-                   realtime_profiler_msgs::realtime_profiler_msg_t::Field::program_id_fifo_end));
+                   realtime_profiler_msgs::realtime_profiler_msg_t::Field::runtime_id_fifo_end));
 
     const uint32_t ksa = factory.offset_of<realtime_profiler_msgs::realtime_profiler_msg_t>(
         realtime_profiler_msgs::realtime_profiler_msg_t::Field::kernel_start_a);
@@ -82,10 +82,10 @@ void zero_dispatch_s_realtime_profiler_msg_fields(
         realtime_profiler_msgs::realtime_profiler_msg_t::Field::kernel_start_b);
     const uint32_t keb = factory.offset_of<realtime_profiler_msgs::realtime_profiler_msg_t>(
         realtime_profiler_msgs::realtime_profiler_msg_t::Field::kernel_end_b);
-    write_u32(base + ksa + ts_id_byte_off);
-    write_u32(base + kea + ts_id_byte_off);
-    write_u32(base + ksb + ts_id_byte_off);
-    write_u32(base + keb + ts_id_byte_off);
+    write_u32(base + ksa + runtime_id_byte_offset);
+    write_u32(base + kea + runtime_id_byte_offset);
+    write_u32(base + ksb + runtime_id_byte_offset);
+    write_u32(base + keb + runtime_id_byte_offset);
 }
 
 }  // namespace

--- a/tt_metal/impl/dispatch/kernels/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_commands.hpp
@@ -384,7 +384,7 @@ constexpr uint32_t CQ_DISPATCH_MAX_WRITE_OFFSETS = 4;
 
 struct CQDispatchSetWriteOffsetCmd {
     uint8_t offset_count;  // Number of uint32_t offsets this command sets. Offsets are stored after the CQDispatchCmd.
-    uint16_t program_host_id;  // Program Host ID for upcoming commands. Used for profiling.
+    uint32_t host_runtime_id;  // Host runtime ID for upcoming commands. Used for profiling.
 } __attribute__((packed));
 
 struct CQDispatchSetUnicastOnlyCoresCmd {

--- a/tt_metal/impl/dispatch/kernels/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_commands.hpp
@@ -384,6 +384,7 @@ constexpr uint32_t CQ_DISPATCH_MAX_WRITE_OFFSETS = 4;
 
 struct CQDispatchSetWriteOffsetCmd {
     uint8_t offset_count;  // Number of uint32_t offsets this command sets. Offsets are stored after the CQDispatchCmd.
+    uint16_t pad1;
     uint32_t host_runtime_id;  // Host runtime ID for upcoming commands. Used for profiling.
 } __attribute__((packed));
 
@@ -435,7 +436,7 @@ struct CQDispatchSetSubDeviceWorkerCountsCmd {
     uint32_t num_sub_devices;
 } __attribute__((packed));
 
-struct CQDispatchCmd {
+struct alignas(4) CQDispatchCmd {
     CQDispatchBaseCmd base;
 
     union {

--- a/tt_metal/impl/dispatch/kernels/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_commands.hpp
@@ -384,6 +384,7 @@ constexpr uint32_t CQ_DISPATCH_MAX_WRITE_OFFSETS = 4;
 
 struct CQDispatchSetWriteOffsetCmd {
     uint8_t offset_count;  // Number of uint32_t offsets this command sets. Offsets are stored after the CQDispatchCmd.
+    uint16_t pad1;
     uint32_t host_runtime_id;  // Host runtime ID for upcoming commands. Used for profiling.
 } __attribute__((packed));
 

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -169,7 +169,7 @@ constexpr uint32_t dispatch_cb_pages_per_block = dispatch_cb_pages / dispatch_cb
 // CommandQueueDeviceAddrType::REALTIME_PROFILER_MSG. Address is supplied by host through
 // the REALTIME_PROFILER_MSG_ADDR compile-time define; the same value is wired into the
 // co-located cq_dispatch_subordinate kernel and the reserved RT-profiler tensix core, so
-// all three view the same physical L1. The embedded program_id_fifo is the BRISC
+// all three view the same physical L1. The embedded runtime_id_fifo is the BRISC
 // (producer) / dispatch_s NCRISC (consumer) handoff.
 volatile tt_l1_ptr realtime_profiler_msg_t* rt_profiler_msg =
     reinterpret_cast<volatile tt_l1_ptr realtime_profiler_msg_t*>(REALTIME_PROFILER_MSG_ADDR);
@@ -1361,16 +1361,16 @@ re_run_command:
         case CQ_DISPATCH_CMD_SET_WRITE_OFFSET: {
             // DPRINT("write offset: {} {} {} host id {}\n", cmd->set_write_offset.offset0,
             // cmd->set_write_offset.offset1,
-            //              cmd->set_write_offset.offset2, cmd->set_write_offset.program_host_id);
-            DeviceTimestampedData("runtime_host_id_dispatch", cmd->set_write_offset.program_host_id);
+            //              cmd->set_write_offset.offset2, cmd->set_write_offset.host_runtime_id);
+            DeviceTimestampedData("runtime_host_id_dispatch", cmd->set_write_offset.host_runtime_id);
             if constexpr (telemetry_enabled) {
                 reinterpret_cast<volatile tt_l1_ptr tt::tt_metal::dispatch_telemetry_types::DispatchCoreTelemetry*>(
                     dispatch_telemetry_base)
                     ->program_count = ++program_counter;
             }
             if (rt_profiler_msg->realtime_profiler_core_noc_xy != 0 &&
-                cmd->set_write_offset.program_host_id != REALTIME_PROFILER_UNPROFILED_PROGRAM_HOST_ID) {
-                while (!program_id_fifo_append(rt_profiler_msg, cmd->set_write_offset.program_host_id)) {
+                cmd->set_write_offset.host_runtime_id != REALTIME_PROFILER_UNPROFILED_RUNTIME_ID) {
+                while (!runtime_id_fifo_append(rt_profiler_msg, cmd->set_write_offset.host_runtime_id)) {
                     invalidate_l1_cache();
                 }
             }

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -1368,10 +1368,12 @@ re_run_command:
                     dispatch_telemetry_base)
                     ->program_count = ++program_counter;
             }
-            if (rt_profiler_msg->realtime_profiler_core_noc_xy != 0 &&
-                cmd->set_write_offset.host_runtime_id != REALTIME_PROFILER_UNPROFILED_RUNTIME_ID) {
-                while (!runtime_id_fifo_append(rt_profiler_msg, cmd->set_write_offset.host_runtime_id)) {
-                    invalidate_l1_cache();
+            if (rt_profiler_msg->realtime_profiler_core_noc_xy != 0) {
+                const uint32_t host_runtime_id = cmd->set_write_offset.host_runtime_id;
+                if (host_runtime_id != REALTIME_PROFILER_UNPROFILED_RUNTIME_ID) {
+                    while (!runtime_id_fifo_append(rt_profiler_msg, host_runtime_id)) {
+                        invalidate_l1_cache();
+                    }
                 }
             }
             uint32_t offset_count = cmd->set_write_offset.offset_count;

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -1429,10 +1429,12 @@ re_run_command:
                     dispatch_telemetry_base)
                     ->program_count = ++program_counter;
             }
-            if (rt_profiler_msg->realtime_profiler_core_noc_xy != 0 &&
-                cmd->set_write_offset.host_runtime_id != REALTIME_PROFILER_UNPROFILED_RUNTIME_ID) {
-                while (!runtime_id_fifo_append(rt_profiler_msg, cmd->set_write_offset.host_runtime_id)) {
-                    invalidate_l1_cache();
+            if (rt_profiler_msg->realtime_profiler_core_noc_xy != 0) {
+                const uint32_t host_runtime_id = cmd->set_write_offset.host_runtime_id;
+                if (host_runtime_id != REALTIME_PROFILER_UNPROFILED_RUNTIME_ID) {
+                    while (!runtime_id_fifo_append(rt_profiler_msg, host_runtime_id)) {
+                        invalidate_l1_cache();
+                    }
                 }
             }
             uint32_t offset_count = cmd->set_write_offset.offset_count;

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -169,7 +169,7 @@ constexpr uint32_t dispatch_cb_pages_per_block = dispatch_cb_pages / dispatch_cb
 // CommandQueueDeviceAddrType::REALTIME_PROFILER_MSG. Address is supplied by host through
 // the REALTIME_PROFILER_MSG_ADDR compile-time define; the same value is wired into the
 // co-located cq_dispatch_subordinate kernel and the reserved RT-profiler tensix core, so
-// all three view the same physical L1. The embedded program_id_fifo is the BRISC
+// all three view the same physical L1. The embedded runtime_id_fifo is the BRISC
 // (producer) / dispatch_s NCRISC (consumer) handoff.
 volatile tt_l1_ptr realtime_profiler_msg_t* rt_profiler_msg =
     reinterpret_cast<volatile tt_l1_ptr realtime_profiler_msg_t*>(REALTIME_PROFILER_MSG_ADDR);
@@ -1422,16 +1422,16 @@ re_run_command:
         case CQ_DISPATCH_CMD_SET_WRITE_OFFSET: {
             // DPRINT("write offset: {} {} {} host id {}\n", cmd->set_write_offset.offset0,
             // cmd->set_write_offset.offset1,
-            //              cmd->set_write_offset.offset2, cmd->set_write_offset.program_host_id);
-            DeviceTimestampedData("runtime_host_id_dispatch", cmd->set_write_offset.program_host_id);
+            //              cmd->set_write_offset.offset2, cmd->set_write_offset.host_runtime_id);
+            DeviceTimestampedData("runtime_host_id_dispatch", cmd->set_write_offset.host_runtime_id);
             if constexpr (telemetry_enabled) {
                 reinterpret_cast<volatile tt_l1_ptr tt::tt_metal::dispatch_telemetry_types::DispatchCoreTelemetry*>(
                     dispatch_telemetry_base)
                     ->program_count = ++program_counter;
             }
             if (rt_profiler_msg->realtime_profiler_core_noc_xy != 0 &&
-                cmd->set_write_offset.program_host_id != REALTIME_PROFILER_UNPROFILED_PROGRAM_HOST_ID) {
-                while (!program_id_fifo_append(rt_profiler_msg, cmd->set_write_offset.program_host_id)) {
+                cmd->set_write_offset.host_runtime_id != REALTIME_PROFILER_UNPROFILED_RUNTIME_ID) {
+                while (!runtime_id_fifo_append(rt_profiler_msg, cmd->set_write_offset.host_runtime_id)) {
                     invalidate_l1_cache();
                 }
             }

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
@@ -143,7 +143,7 @@ constexpr uintptr_t cb_end = cb_base + cb_size;
 // Dispatch-core-local L1 region assigned by DispatchMemMap via
 // CommandQueueDeviceAddrType::REALTIME_PROFILER_MSG. Address comes from host through the
 // REALTIME_PROFILER_MSG_ADDR compile-time define. See cq_dispatch.cpp for the full mailbox
-// description; this kernel is the consumer side of the embedded program_id_fifo.
+// description; this kernel is the consumer side of the embedded runtime_id_fifo.
 volatile tt_l1_ptr realtime_profiler_msg_t* rt_profiler_msg =
     reinterpret_cast<volatile tt_l1_ptr realtime_profiler_msg_t*>(REALTIME_PROFILER_MSG_ADDR);
 
@@ -608,10 +608,10 @@ void kernel_main() {
     while (!done) {
         DeviceZoneScopedN("CQ-DISPATCH-SUBORDINATE");
         rt_profiler_enabled = (rt_profiler_msg->realtime_profiler_core_noc_xy != 0);
-        uint32_t popped_pid = 0;
+        uint32_t runtime_id = 0;
         if (rt_profiler_enabled) {
             record_realtime_timestamp(rt_profiler_msg, true);
-            popped_pid = pop_program_id(rt_profiler_msg);
+            runtime_id = pop_runtime_id(rt_profiler_msg);
         }
 #if DEVICE_PRINT_DISPATCH_ENABLED
         device_print_dispatcher.execute();
@@ -623,9 +623,8 @@ void kernel_main() {
         if (rt_profiler_enabled) {
             const bool is_profiled_cmd = cmd->base.cmd_id == CQ_DISPATCH_CMD_SEND_GO_SIGNAL ||
                                          cmd->base.cmd_id == CQ_DISPATCH_CMD_RT_PROFILER_FLUSH;
-            write_buffer_id(
-                rt_profiler_msg,
-                is_profiled_cmd ? popped_pid : static_cast<uint32_t>(REALTIME_PROFILER_UNPROFILED_PROGRAM_HOST_ID));
+            write_buffer_runtime_id(
+                rt_profiler_msg, is_profiled_cmd ? runtime_id : REALTIME_PROFILER_UNPROFILED_RUNTIME_ID);
         }
         switch (cmd->base.cmd_id) {
             case CQ_DISPATCH_CMD_SEND_GO_SIGNAL:

--- a/tt_metal/impl/dispatch/kernels/cq_realtime_profiler.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_realtime_profiler.cpp
@@ -53,8 +53,8 @@ __attribute__((noinline)) void realtime_profiler_read_and_enqueue(bool buffer_a)
     noc_async_read(dispatch_noc_addr, slot_addr, realtime_profiler_timestamp_size);
     noc_async_read_barrier();
 
-    const uint32_t id = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(slot_addr)[2];
-    if (id != REALTIME_PROFILER_UNPROFILED_PROGRAM_HOST_ID) {
+    const uint32_t runtime_id = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(slot_addr)[2];
+    if (runtime_id != REALTIME_PROFILER_UNPROFILED_RUNTIME_ID) {
         ring_buffer->write_index++;
     }
 }

--- a/tt_metal/impl/dispatch/kernels/realtime_profiler.hpp
+++ b/tt_metal/impl/dispatch/kernels/realtime_profiler.hpp
@@ -16,48 +16,48 @@ constexpr uint32_t WALL_CLOCK_HIGH_INDEX = 2;
 // Sync marker ID - used to identify sync packets in real-time profiler stream
 constexpr uint32_t REALTIME_PROFILER_SYNC_MARKER_ID = 0xFFFFFFFF;
 
-// CQDispatchSetWriteOffsetCmd::program_host_id and RT timestamp correlation: this value means the
+// CQDispatchSetWriteOffsetCmd::host_runtime_id and RT timestamp correlation: this value means the
 // dispatch event is not tied to a profiled program (raw streams, preamble defaults). dispatch_d
-// must not push it into the program-id FIFO; dispatch_s passes it to write_buffer_id for non-GO
+// must not push it into the runtime-ID FIFO; dispatch_s passes it to write_buffer_runtime_id for non-GO
 // commands so the host can filter those records out.
-constexpr uint16_t REALTIME_PROFILER_UNPROFILED_PROGRAM_HOST_ID = 0;
+constexpr uint32_t REALTIME_PROFILER_UNPROFILED_RUNTIME_ID = 0;
 
-// Program ID FIFO size
-constexpr uint32_t PROGRAM_ID_FIFO_SIZE = 32;
+// Runtime ID FIFO size
+constexpr uint32_t RUNTIME_ID_FIFO_SIZE = 32;
 
 #ifndef ARCH_QUASAR
-// Append a program ID to the circular buffer embedded in realtime_profiler_msg_t.
+// Append a runtime ID to the circular buffer embedded in realtime_profiler_msg_t.
 // Returns true if successful, false if the buffer is full.
 // The control block (including this FIFO) lives in dispatch-core-local L1, assigned by
 // CommandQueueDeviceAddrType::REALTIME_PROFILER_MSG.
 FORCE_INLINE
-bool program_id_fifo_append(volatile tt_l1_ptr realtime_profiler_msg_t* msg, uint32_t program_id) {
-    uint32_t end = msg->program_id_fifo_end;
-    uint32_t next_end = (end + 1) % PROGRAM_ID_FIFO_SIZE;
+bool runtime_id_fifo_append(volatile tt_l1_ptr realtime_profiler_msg_t* msg, uint32_t runtime_id) {
+    uint32_t end = msg->runtime_id_fifo_end;
+    uint32_t next_end = (end + 1) % RUNTIME_ID_FIFO_SIZE;
 
     // Check if buffer is full (next write position equals read position)
-    if (next_end == msg->program_id_fifo_start) {
+    if (next_end == msg->runtime_id_fifo_start) {
         return false;
     }
 
-    msg->program_id_fifo[end] = program_id;
-    msg->program_id_fifo_end = next_end;
+    msg->runtime_id_fifo[end] = runtime_id;
+    msg->runtime_id_fifo_end = next_end;
     return true;
 }
 
-// Pop a program ID from the circular buffer embedded in realtime_profiler_msg_t.
-// Returns true if successful (and stores the value in *program_id), false if the buffer is empty.
+// Pop a runtime ID from the circular buffer embedded in realtime_profiler_msg_t.
+// Returns true if successful (and stores the value in *runtime_id), false if the buffer is empty.
 FORCE_INLINE
-bool program_id_fifo_pop(volatile tt_l1_ptr realtime_profiler_msg_t* msg, uint32_t* program_id) {
-    uint32_t start = msg->program_id_fifo_start;
+bool runtime_id_fifo_pop(volatile tt_l1_ptr realtime_profiler_msg_t* msg, uint32_t* runtime_id) {
+    uint32_t start = msg->runtime_id_fifo_start;
 
     // Check if buffer is empty (read position equals write position)
-    if (start == msg->program_id_fifo_end) {
+    if (start == msg->runtime_id_fifo_end) {
         return false;
     }
 
-    *program_id = msg->program_id_fifo[start];
-    msg->program_id_fifo_start = (start + 1) % PROGRAM_ID_FIFO_SIZE;
+    *runtime_id = msg->runtime_id_fifo[start];
+    msg->runtime_id_fifo_start = (start + 1) % RUNTIME_ID_FIFO_SIZE;
     return true;
 }
 
@@ -89,46 +89,46 @@ void record_realtime_timestamp(volatile tt_l1_ptr realtime_profiler_msg_t* msg, 
     ts->time_hi = time_hi;
 }
 
-// Pop a program ID from the FIFO without writing it to the buffer.
+// Pop a runtime ID from the FIFO without writing it to the buffer.
 // Returns the popped ID, or 0 if the FIFO was empty.
 // Call this early to maintain timing (FIFO pop involves L1 reads/writes),
-// then call write_buffer_id() later once the command type is known.
+// then call write_buffer_runtime_id() later once the command type is known.
 FORCE_INLINE
-uint32_t pop_program_id(volatile tt_l1_ptr realtime_profiler_msg_t* msg) {
-    uint32_t id = 0;
-    program_id_fifo_pop(msg, &id);
-    return id;
+uint32_t pop_runtime_id(volatile tt_l1_ptr realtime_profiler_msg_t* msg) {
+    uint32_t runtime_id = 0;
+    runtime_id_fifo_pop(msg, &runtime_id);
+    return runtime_id;
 }
 
-// Write a program ID to both start and end timestamps of the current write buffer.
-// For GO_SIGNAL commands: pass the ID from pop_program_id().
-// For non-GO commands: pass REALTIME_PROFILER_UNPROFILED_PROGRAM_HOST_ID so the host filters them out.
+// Write a runtime ID to both start and end timestamps of the current write buffer.
+// For GO_SIGNAL commands: pass the ID from pop_runtime_id().
+// For non-GO commands: pass REALTIME_PROFILER_UNPROFILED_RUNTIME_ID so the host filters them out.
 FORCE_INLINE
-void write_buffer_id(volatile tt_l1_ptr realtime_profiler_msg_t* msg, uint32_t id) {
+void write_buffer_runtime_id(volatile tt_l1_ptr realtime_profiler_msg_t* msg, uint32_t runtime_id) {
     RealtimeProfilerState state = static_cast<RealtimeProfilerState>(msg->realtime_profiler_state);
     bool use_buffer_a = (state == REALTIME_PROFILER_STATE_PUSH_B);
 
     if (use_buffer_a) {
-        msg->kernel_start_a.id = id;
-        msg->kernel_end_a.id = id;
+        msg->kernel_start_a.runtime_id = runtime_id;
+        msg->kernel_end_a.runtime_id = runtime_id;
     } else {
-        msg->kernel_start_b.id = id;
-        msg->kernel_end_b.id = id;
+        msg->kernel_start_b.runtime_id = runtime_id;
+        msg->kernel_end_b.runtime_id = runtime_id;
     }
 }
 #else
 FORCE_INLINE
-bool program_id_fifo_append(volatile tt_l1_ptr realtime_profiler_msg_t*, uint32_t) { return false; }
+bool runtime_id_fifo_append(volatile tt_l1_ptr realtime_profiler_msg_t*, uint32_t) { return false; }
 
 FORCE_INLINE
-bool program_id_fifo_pop(volatile tt_l1_ptr realtime_profiler_msg_t*, uint32_t*) { return false; }
+bool runtime_id_fifo_pop(volatile tt_l1_ptr realtime_profiler_msg_t*, uint32_t*) { return false; }
 
 FORCE_INLINE
 void record_realtime_timestamp(volatile tt_l1_ptr realtime_profiler_msg_t*, bool) {}
 
 FORCE_INLINE
-uint32_t pop_program_id(volatile tt_l1_ptr realtime_profiler_msg_t*) { return 0; }
+uint32_t pop_runtime_id(volatile tt_l1_ptr realtime_profiler_msg_t*) { return 0; }
 
 FORCE_INLINE
-void write_buffer_id(volatile tt_l1_ptr realtime_profiler_msg_t*, uint32_t) {}
+void write_buffer_runtime_id(volatile tt_l1_ptr realtime_profiler_msg_t*, uint32_t) {}
 #endif

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -2478,8 +2478,8 @@ void update_program_dispatch_commands(
     static constexpr uint32_t tensix_l1_write_offset_offset = write_offsets_offset + sizeof(uint32_t);
     static constexpr uint32_t tensix_l1_binary_write_offset_offset = write_offsets_offset + (sizeof(uint32_t) * 2);
     static constexpr uint32_t eth_l1_write_offset_offset = write_offsets_offset + (sizeof(uint32_t) * 3);
-    static constexpr uint32_t program_host_id_offset =
-        (sizeof(CQPrefetchCmd) + offsetof(CQDispatchCmd, set_write_offset.program_host_id));
+    static constexpr uint32_t host_runtime_id_offset =
+        (sizeof(CQPrefetchCmd) + offsetof(CQDispatchCmd, set_write_offset.host_runtime_id));
     // Update Stall Command Sequence
     if (program_binary_status != ProgramBinaryStatus::Committed) {
         // Program binary is in flight. Issue a Prefetch Stall
@@ -2515,13 +2515,12 @@ void update_program_dispatch_commands(
         tensix_l1_binary_write_offset_offset,
         &dispatch_md.kernel_config_addrs[hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX)],
         sizeof(uint32_t));
-    // May truncate to fit the space.
     static_assert(
-        std::is_same_v<uint16_t, decltype(std::declval<CQDispatchCmd>().set_write_offset.program_host_id)>,
-        "program_host_id type should be uint16_t");
-    uint16_t runtime_id = static_cast<uint16_t>(program.get_runtime_id());
+        std::is_same_v<uint32_t, decltype(std::declval<CQDispatchCmd>().set_write_offset.host_runtime_id)>,
+        "host_runtime_id type should be uint32_t");
+    uint32_t runtime_id = static_cast<uint32_t>(program.get_runtime_id());
     cached_program_command_sequence.preamble_command_sequence.update_cmd_sequence(
-        program_host_id_offset, &runtime_id, sizeof(runtime_id));
+        host_runtime_id_offset, &runtime_id, sizeof(runtime_id));
 
     RecordProgramMetadata(program);
 
@@ -2692,8 +2691,8 @@ void update_traced_program_dispatch_commands(
     static constexpr uint32_t tensix_l1_write_offset_offset = write_offsets_offset + sizeof(uint32_t);
     static constexpr uint32_t tensix_l1_binary_write_offset_offset = write_offsets_offset + (sizeof(uint32_t) * 2);
     static constexpr uint32_t eth_l1_write_offset_offset = write_offsets_offset + (sizeof(uint32_t) * 3);
-    static constexpr uint32_t program_host_id_offset =
-        (sizeof(CQPrefetchCmd) + offsetof(CQDispatchCmd, set_write_offset.program_host_id));
+    static constexpr uint32_t host_runtime_id_offset =
+        (sizeof(CQPrefetchCmd) + offsetof(CQDispatchCmd, set_write_offset.host_runtime_id));
     // Update Stall Command Sequence
     if (program_binary_status != ProgramBinaryStatus::Committed) {
         // Program binary is in flight. Issue a Prefetch Stall
@@ -2729,13 +2728,12 @@ void update_traced_program_dispatch_commands(
         dispatch_md.binary_kernel_config_addrs[tensix_index].addr - program_config.kernel_text_offset;
     cached_program_command_sequence.preamble_command_sequence.update_cmd_sequence(
         tensix_l1_binary_write_offset_offset, &binary_write_offset, sizeof(uint32_t));
-    // May truncate to fit the space.
     static_assert(
-        std::is_same_v<uint16_t, decltype(std::declval<CQDispatchCmd>().set_write_offset.program_host_id)>,
-        "program_host_id type should be uint16_t");
-    uint16_t runtime_id = trace_node.program_runtime_id;
+        std::is_same_v<uint32_t, decltype(std::declval<CQDispatchCmd>().set_write_offset.host_runtime_id)>,
+        "host_runtime_id type should be uint32_t");
+    uint32_t runtime_id = trace_node.program_runtime_id;
     cached_program_command_sequence.preamble_command_sequence.update_cmd_sequence(
-        program_host_id_offset, &runtime_id, sizeof(runtime_id));
+        host_runtime_id_offset, &runtime_id, sizeof(runtime_id));
     if (hal.get_programmable_core_type_count() >= 2) {
         cached_program_command_sequence.preamble_command_sequence.update_cmd_sequence(
             eth_l1_write_offset_offset,

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -2487,8 +2487,8 @@ void update_program_dispatch_commands(
     static constexpr uint32_t tensix_l1_write_offset_offset = write_offsets_offset + sizeof(uint32_t);
     static constexpr uint32_t tensix_l1_binary_write_offset_offset = write_offsets_offset + (sizeof(uint32_t) * 2);
     static constexpr uint32_t eth_l1_write_offset_offset = write_offsets_offset + (sizeof(uint32_t) * 3);
-    static constexpr uint32_t program_host_id_offset =
-        (sizeof(CQPrefetchCmd) + offsetof(CQDispatchCmd, set_write_offset.program_host_id));
+    static constexpr uint32_t host_runtime_id_offset =
+        (sizeof(CQPrefetchCmd) + offsetof(CQDispatchCmd, set_write_offset.host_runtime_id));
     // Update Stall Command Sequence
     if (program_binary_status != ProgramBinaryStatus::Committed) {
         // Program binary is in flight. Issue a Prefetch Stall
@@ -2524,13 +2524,12 @@ void update_program_dispatch_commands(
         tensix_l1_binary_write_offset_offset,
         &dispatch_md.kernel_config_addrs[hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX)],
         sizeof(uint32_t));
-    // May truncate to fit the space.
     static_assert(
-        std::is_same_v<uint16_t, decltype(std::declval<CQDispatchCmd>().set_write_offset.program_host_id)>,
-        "program_host_id type should be uint16_t");
-    uint16_t runtime_id = static_cast<uint16_t>(program.get_runtime_id());
+        std::is_same_v<uint32_t, decltype(std::declval<CQDispatchCmd>().set_write_offset.host_runtime_id)>,
+        "host_runtime_id type should be uint32_t");
+    uint32_t runtime_id = static_cast<uint32_t>(program.get_runtime_id());
     cached_program_command_sequence.preamble_command_sequence.update_cmd_sequence(
-        program_host_id_offset, &runtime_id, sizeof(runtime_id));
+        host_runtime_id_offset, &runtime_id, sizeof(runtime_id));
 
     RecordProgramMetadata(program);
 
@@ -2701,8 +2700,8 @@ void update_traced_program_dispatch_commands(
     static constexpr uint32_t tensix_l1_write_offset_offset = write_offsets_offset + sizeof(uint32_t);
     static constexpr uint32_t tensix_l1_binary_write_offset_offset = write_offsets_offset + (sizeof(uint32_t) * 2);
     static constexpr uint32_t eth_l1_write_offset_offset = write_offsets_offset + (sizeof(uint32_t) * 3);
-    static constexpr uint32_t program_host_id_offset =
-        (sizeof(CQPrefetchCmd) + offsetof(CQDispatchCmd, set_write_offset.program_host_id));
+    static constexpr uint32_t host_runtime_id_offset =
+        (sizeof(CQPrefetchCmd) + offsetof(CQDispatchCmd, set_write_offset.host_runtime_id));
     // Update Stall Command Sequence
     if (program_binary_status != ProgramBinaryStatus::Committed) {
         // Program binary is in flight. Issue a Prefetch Stall
@@ -2738,13 +2737,12 @@ void update_traced_program_dispatch_commands(
         dispatch_md.binary_kernel_config_addrs[tensix_index].addr - program_config.kernel_text_offset;
     cached_program_command_sequence.preamble_command_sequence.update_cmd_sequence(
         tensix_l1_binary_write_offset_offset, &binary_write_offset, sizeof(uint32_t));
-    // May truncate to fit the space.
     static_assert(
-        std::is_same_v<uint16_t, decltype(std::declval<CQDispatchCmd>().set_write_offset.program_host_id)>,
-        "program_host_id type should be uint16_t");
-    uint16_t runtime_id = trace_node.program_runtime_id;
+        std::is_same_v<uint32_t, decltype(std::declval<CQDispatchCmd>().set_write_offset.host_runtime_id)>,
+        "host_runtime_id type should be uint32_t");
+    uint32_t runtime_id = trace_node.program_runtime_id;
     cached_program_command_sequence.preamble_command_sequence.update_cmd_sequence(
-        program_host_id_offset, &runtime_id, sizeof(runtime_id));
+        host_runtime_id_offset, &runtime_id, sizeof(runtime_id));
     if (hal.get_programmable_core_type_count() >= 2) {
         cached_program_command_sequence.preamble_command_sequence.update_cmd_sequence(
             eth_l1_write_offset_offset,


### PR DESCRIPTION
### PR Category
Feature

### Summary
Widens the runtime ID transmitted by the real-time profiler from 16 to 32 bits. This completes the RT-profiler portion of #46103.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=yusuf/32b-runtime-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:yusuf/32b-runtime-id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=yusuf/32b-runtime-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:yusuf/32b-runtime-id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=yusuf/32b-runtime-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:yusuf/32b-runtime-id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=yusuf/32b-runtime-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:yusuf/32b-runtime-id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=yusuf/32b-runtime-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:yusuf/32b-runtime-id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=yusuf/32b-runtime-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:yusuf/32b-runtime-id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=yusuf/32b-runtime-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:yusuf/32b-runtime-id)