### PR TITLE
#49987: Skip test for alignment mismatch in index_fill op 

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_index_fill.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_index_fill.py
@@ -248,6 +248,10 @@ def test_index_fill_block_sharded(device, shape, dim, num_indices, value):
 )
 def test_index_fill_cross_layout_to_col_sharded(device, shape, dim, num_indices, value, out_strategy):
     """INTERLEAVED/HEIGHT input with WIDTH/BLOCK output."""
+    if out_strategy == ttnn.ShardStrategy.BLOCK:
+        pytest.skip(
+            "HEIGHT->BLOCK alignment mismatch not yet fixed (see https://github.com/tenstorrent/tt-metal/issues/49987)"
+        )
     if out_strategy == ttnn.ShardStrategy.WIDTH:
         in_cfg = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
         out_cfg = ttnn.create_sharded_memory_config(


### PR DESCRIPTION
### Ticket
#49987 

### PR Category
Clean up

### Summary
Two nightly tests in test_index_fill_cross_layout_to_col_sharded are failing with a TT_FATAL alignment mismatch when ttnn.index_fill is called with a HEIGHT_SHARDED input tensor and a BLOCK_SHARDED output memory_config.

## Failing Tests

```
FAILED tests/ttnn/nightly/unit_tests/operations/data_movement/test_index_fill.py
    ::test_index_fill_cross_layout_to_col_sharded[height_to_block_dim1]
FAILED tests/ttnn/nightly/unit_tests/operations/data_movement/test_index_fill.py
    ::test_index_fill_cross_layout_to_col_sharded[height_to_block_dim3]
```

### What this PR does
The test_index_fill_cross_layout_to_col_sharded test will be skipped for the time being until a fix is introduced.


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abdulla/index_fill_test_skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abdulla/index_fill_test_skip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=abdulla/index_fill_test_skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:abdulla/index_fill_test_skip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=abdulla/index_fill_test_skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:abdulla/index_fill_test_skip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abdulla/index_fill_test_skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abdulla/index_fill_test_skip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=abdulla/index_fill_test_skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:abdulla/index_fill_test_skip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=abdulla/index_fill_test_skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:abdulla/index_fill_test_skip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=abdulla/index_fill_test_skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:abdulla/index_fill_test_skip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=abdulla/index_fill_test_skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:abdulla/index_fill_test_skip)