### PR TITLE
[codegen-port] repeat_interleave: generated DeviceOperation + ProgramFactory

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/data_movement/CMakeLists.txt
@@ -36,6 +36,7 @@ file(
     permute/device/kernels/*.cpp
     reshape_on_device/device/kernels/*.cpp
     repeat/device/kernels/*.cpp
+    repeat_interleave/codegen/kernels/*
     roll/device/kernels/*.cpp
     reshape_view/device/device/*.cpp
     scatter/device/kernels/*.hpp

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels/reader_repeat_interleave_lastdim_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels/reader_repeat_interleave_lastdim_rm.cpp
@@ -1,0 +1,88 @@
+// Reader for repeat_interleave on the LAST (within-stick, W) dim, RM interleaved.
+//
+// torch.repeat_interleave(x, R, dim=-1): each element along W is replicated R
+// times consecutively (AABB), so out[j] = in[j / R] within every stick. Output
+// sticks are 1:1 with input sticks (only W grows: W_out = W_in * R), so the page
+// map is the identity (src_page == out_page); all the work is the intra-stick
+// element expansion.
+//
+// Single-CB, no scratch: read the input stick into the TAIL of the (larger)
+// output CB slot, then expand front-to-back IN PLACE. This never clobbers an
+// unread source element -- for element i the write region ends at (i+1)*R and
+// the source of any later element j>i sits at W_in*(R-1)+j >= (i+1)*R, with
+// equality only at the last element (already read before it is overwritten).
+//
+// Block-float (bf8_b/bf4_b) is gated out by the Python builder: per-element copy
+// would split the shared-exponent tile header (silent-wrong).
+//
+// CT: stick_out_bytes, stick_in_bytes, W_in, REPEATS, ELEM_SIZE,
+//     TensorAccessorArgs(in_t), cb_id, BATCH
+// RT: src_addr, num_out_pages, out_start_page   (src_page == out_page)
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t num_out_pages = get_arg_val<uint32_t>(1);
+    uint32_t out_start_page = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t stick_out = get_compile_time_arg_val(0);
+    constexpr uint32_t stick_in = get_compile_time_arg_val(1);
+    constexpr uint32_t W_in = get_compile_time_arg_val(2);
+    constexpr uint32_t REPEATS = get_compile_time_arg_val(3);
+    constexpr uint32_t ELEM_SIZE = get_compile_time_arg_val(4);
+    constexpr auto src_args = TensorAccessorArgs<5>();
+    constexpr uint32_t cb_id = get_compile_time_arg_val(src_args.next_compile_time_args_offset());
+    constexpr uint32_t BATCH = get_compile_time_arg_val(src_args.next_compile_time_args_offset() + 1);
+
+    const auto s = TensorAccessor(src_args, src_addr);
+
+    constexpr uint32_t src_off = stick_out - stick_in;  // tail offset (bytes)
+
+    uint32_t page = out_start_page;
+    uint32_t pages_left = num_out_pages;
+
+    while (pages_left > 0) {
+        uint32_t batch = (pages_left < BATCH) ? pages_left : BATCH;
+        cb_reserve_back(cb_id, batch);
+        uint32_t l1 = get_write_ptr(cb_id);
+
+        // Read all sticks in the batch into the tail of their slots first.
+        uint32_t rd = l1;
+        for (uint32_t t = 0; t < batch; t++) {
+            noc_async_read(s.get_noc_addr(page + t), rd + src_off, stick_in);
+            rd += stick_out;
+        }
+        noc_async_read_barrier();
+
+        // Expand each stick front-to-back, in place.
+        uint32_t slot = l1;
+        for (uint32_t t = 0; t < batch; t++) {
+            if constexpr (ELEM_SIZE == 2) {
+                volatile tt_l1_ptr uint16_t* b = (volatile tt_l1_ptr uint16_t*)slot;
+                constexpr uint32_t in0 = src_off / 2;  // input elem 0 index
+                uint32_t o = 0;
+                for (uint32_t i = 0; i < W_in; i++) {
+                    uint16_t v = b[in0 + i];
+                    for (uint32_t r = 0; r < REPEATS; r++) {
+                        b[o++] = v;
+                    }
+                }
+            } else {  // ELEM_SIZE == 4
+                volatile tt_l1_ptr uint32_t* b = (volatile tt_l1_ptr uint32_t*)slot;
+                constexpr uint32_t in0 = src_off / 4;
+                uint32_t o = 0;
+                for (uint32_t i = 0; i < W_in; i++) {
+                    uint32_t v = b[in0 + i];
+                    for (uint32_t r = 0; r < REPEATS; r++) {
+                        b[o++] = v;
+                    }
+                }
+            }
+            slot += stick_out;
+        }
+
+        cb_push_back(cb_id, batch);
+        page += batch;
+        pages_left -= batch;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels/reader_repeat_interleave_lastdim_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels/reader_repeat_interleave_lastdim_rm.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // Reader for repeat_interleave on the LAST (within-stick, W) dim, RM interleaved.
 //
 // torch.repeat_interleave(x, R, dim=-1): each element along W is replicated R

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels/reader_repeat_interleave_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels/reader_repeat_interleave_rm.cpp
@@ -1,0 +1,69 @@
+// Reader for repeat_interleave on RM interleaved tensors.
+//
+// Same RM stick addressing as ops/repeat (now common/templates/reader_repeat_higherdim_rm.cpp), but the
+// within-block source page uses the per-element (AABB) interleave formula
+// instead of the modular (ABAB) repeat formula:
+//
+//   SRC_LOWER = REP_DIM_PAGES * LOWER_PAGES
+//   DST_LOWER = NUM_REPEATS * SRC_LOWER
+//   block     = out_page / DST_LOWER          (everything above rep_dim)
+//   within    = out_page % DST_LOWER
+//   lo        = within % LOWER_PAGES           (offset below rep_dim)
+//   out_rep   = within / LOWER_PAGES           (replicated rep_dim index)
+//   in_rep    = out_rep / NUM_REPEATS          (AABB collapse, per-element)
+//   src       = block*SRC_LOWER + in_rep*LOWER_PAGES + lo
+//
+// This is valid only when the interleaved dim is a whole-stick (outer or H)
+// dim — i.e. NOT the last (W, within-stick) dim. The Python builder gates the
+// last-dim case as an invalid-skip.
+//
+// CT args: stick_size, aligned_page_size, TensorAccessorArgs(in_t),
+//          cb_id, NUM_REPEATS, LOWER_PAGES, REP_DIM_PAGES, BATCH
+// RT args: src_addr, num_out_pages, out_start_page
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t num_out_pages = get_arg_val<uint32_t>(1);
+    uint32_t out_start_page = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t stick_size = get_compile_time_arg_val(0);
+    constexpr uint32_t aligned_page_size = get_compile_time_arg_val(1);
+    constexpr auto src_args = TensorAccessorArgs<2>();
+    constexpr uint32_t cb_id = get_compile_time_arg_val(src_args.next_compile_time_args_offset());
+    constexpr uint32_t NUM_REPEATS = get_compile_time_arg_val(src_args.next_compile_time_args_offset() + 1);
+    constexpr uint32_t LOWER_PAGES = get_compile_time_arg_val(src_args.next_compile_time_args_offset() + 2);
+    constexpr uint32_t REP_DIM_PAGES = get_compile_time_arg_val(src_args.next_compile_time_args_offset() + 3);
+    constexpr uint32_t BATCH = get_compile_time_arg_val(src_args.next_compile_time_args_offset() + 4);
+
+    const auto s = TensorAccessor(src_args, src_addr);
+
+    constexpr uint32_t SRC_LOWER = REP_DIM_PAGES * LOWER_PAGES;
+    constexpr uint32_t DST_LOWER = NUM_REPEATS * SRC_LOWER;
+
+    uint32_t out_page = out_start_page;
+    uint32_t pages_left = num_out_pages;
+
+    while (pages_left > 0) {
+        uint32_t batch = (pages_left < BATCH) ? pages_left : BATCH;
+        cb_reserve_back(cb_id, batch);
+        uint32_t l1_addr = get_write_ptr(cb_id);
+
+        for (uint32_t t = 0; t < batch; t++) {
+            uint32_t block = out_page / DST_LOWER;
+            uint32_t within = out_page % DST_LOWER;
+            uint32_t lo = within % LOWER_PAGES;
+            uint32_t out_rep = within / LOWER_PAGES;
+            uint32_t in_rep = out_rep / NUM_REPEATS;
+            uint32_t src_page = block * SRC_LOWER + in_rep * LOWER_PAGES + lo;
+
+            uint64_t noc_addr = s.get_noc_addr(src_page);
+            noc_async_read(noc_addr, l1_addr, stick_size);
+            l1_addr += stick_size;
+            out_page++;
+        }
+        noc_async_read_barrier();
+        cb_push_back(cb_id, batch);
+        pages_left -= batch;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels/reader_repeat_interleave_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels/reader_repeat_interleave_rm.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // Reader for repeat_interleave on RM interleaved tensors.
 //
 // Same RM stick addressing as ops/repeat (now common/templates/reader_repeat_higherdim_rm.cpp), but the

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels/reader_tile_interleaved_unified.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels/reader_tile_interleaved_unified.cpp
@@ -1,0 +1,263 @@
+// Unified batched tile reader for interleaved tensors.
+//
+// One transport loop, pluggable address sequencer selected by "seq_id".
+// The sequencer maps output_page -> source_page. All sequencer logic
+// lives in sequencers.h as FORCE_INLINE functions.
+//
+// CT args:
+//   Named:      seq_id, cb_id, batch
+//   Positional: TensorAccessorArgs (starts at index 0)
+//
+// RT args (flat uint32_t array, read as struct via get_arg_addr):
+//   [0] src_addr    — source buffer address
+//   [1] num_pages   — pages this core reads
+//   [2] start_id    — starting page ID (meaning varies by sequencer)
+//   [3..] sequencer-specific params (see SeqArgs structs in sequencers.h)
+#include "api/dataflow/dataflow_api.h"
+#include "sequencers.h"
+
+// ── RT arg structs ──────────────────────────────────────────────────
+// Laid out to match the Python builder's RT arg packing exactly.
+// All structs share a common 3-field header.
+
+struct ArgsBase {
+    uint32_t src_addr;
+    uint32_t num_pages;
+    uint32_t start_id;
+};
+
+struct ArgsRepeat : ArgsBase {
+    uint32_t num_repeats;
+    uint32_t lower_pages;
+    uint32_t rep_dim_pages;
+};
+
+struct ArgsSlice : ArgsBase {
+    uint32_t num_dims;
+    // followed by: num_unpadded[D], num_padded[D], id_per_dim[D]
+    // (variable length — access via pointer arithmetic from &num_dims + 1)
+};
+
+struct ArgsPermute : ArgsBase {
+    uint32_t num_dims;
+    // followed by: src_strides[D], out_shape[D], inv_perm[D], id_per_dim[D]
+};
+
+struct ArgsTransposeWh : ArgsBase {
+    uint32_t start_ht;
+    uint32_t start_wt;
+    uint32_t Ht;
+    uint32_t Wt;
+    uint32_t HtWt;
+};
+
+struct ArgsPad : ArgsBase {
+    uint32_t start_wt;
+    uint32_t start_ht;
+    uint32_t start_c;
+    uint32_t start_n;
+    uint32_t Wt_in;
+    uint32_t Ht_in;
+    uint32_t C_in;
+    uint32_t N_in;
+    uint32_t Wt_out;
+    uint32_t Ht_out;
+    uint32_t C_out;
+    uint32_t N_out;
+    uint32_t tile_bytes;
+    uint32_t packed_pad_val;
+    uint32_t cb_pad;
+    uint32_t front_wt;  // tile-aligned leading pad, W (tiles)
+    uint32_t front_ht;  // tile-aligned leading pad, H (tiles)
+    uint32_t front_c;   // leading pad, C
+    uint32_t front_n;   // leading pad, N
+};
+
+struct ArgsConcat : ArgsBase {
+    uint32_t src_addr_1;
+    uint32_t start_tensor;
+    uint32_t start_tensor_id;
+    uint32_t page_id_0;
+    uint32_t page_id_1;
+    uint32_t ppb_0;
+    uint32_t ppb_1;
+};
+
+// ── Transport loop (written ONCE) ───────────────────────────────────
+// For simple sequencers (identity, repeat, slice, permute, transpose_wh):
+//   each page = noc_async_read_tile(next_page, accessor, l1)
+// PAD and CONCAT have different loop bodies (conditional reads / 2 accessors).
+
+template <typename Accessor, typename State, typename NextFn>
+FORCE_INLINE void read_pages(
+    uint32_t cb_id,
+    uint32_t BATCH,
+    uint32_t page_size,
+    const Accessor& accessor,
+    uint32_t num_pages,
+    State& state,
+    NextFn next_fn) {
+    uint32_t pages_left = num_pages;
+    while (pages_left > 0) {
+        uint32_t batch = (pages_left < BATCH) ? pages_left : BATCH;
+        cb_reserve_back(cb_id, batch);
+        uint32_t l1_addr = get_write_ptr(cb_id);
+        for (uint32_t t = 0; t < batch; t++) {
+            noc_async_read_tile(next_fn(state), accessor, l1_addr);
+            l1_addr += page_size;
+        }
+        noc_async_read_barrier();
+        cb_push_back(cb_id, batch);
+        pages_left -= batch;
+    }
+}
+
+// ── Main ────────────────────────────────────────────────────────────
+
+void kernel_main() {
+    // Named CT args
+    constexpr uint32_t SEQ_ID = get_named_compile_time_arg_val("seq_id");
+    constexpr uint32_t cb_id = get_named_compile_time_arg_val("cb_id");
+    constexpr uint32_t BATCH = get_named_compile_time_arg_val("batch");
+
+    // Positional CT args: TensorAccessorArgs only (index 0)
+    constexpr auto src_args = TensorAccessorArgs<0>();
+
+    // RT args base (common header)
+    const auto* base = reinterpret_cast<const ArgsBase*>(get_arg_addr(0));
+    const uint32_t page_size = get_tile_size(cb_id);
+    const auto s = TensorAccessor(src_args, base->src_addr, page_size);
+
+    // ── IDENTITY ────────────────────────────────────────────────────
+    if constexpr (SEQ_ID == SEQ_IDENTITY) {
+        auto st = seq_identity_init(base->start_id);
+        read_pages(cb_id, BATCH, page_size, s, base->num_pages, st, seq_identity_next);
+    }
+
+    // ── REPEAT ──────────────────────────────────────────────────────
+    else if constexpr (SEQ_ID == SEQ_REPEAT) {
+        const auto* a = reinterpret_cast<const ArgsRepeat*>(get_arg_addr(0));
+        auto st = seq_repeat_init(a->start_id, a->num_repeats, a->lower_pages, a->rep_dim_pages);
+        read_pages(cb_id, BATCH, page_size, s, a->num_pages, st, seq_repeat_next);
+    }
+
+    // ── REPEAT_INTERLEAVE (per-element AABB replication) ─────────────
+    // Reuses ArgsRepeat — only the addressing function differs.
+    else if constexpr (SEQ_ID == SEQ_REPEAT_INTERLEAVE) {
+        const auto* a = reinterpret_cast<const ArgsRepeat*>(get_arg_addr(0));
+        auto st = seq_repeat_interleave_init(a->start_id, a->num_repeats, a->lower_pages, a->rep_dim_pages);
+        read_pages(cb_id, BATCH, page_size, s, a->num_pages, st, seq_repeat_interleave_next);
+    }
+
+    // ── SLICE ───────────────────────────────────────────────────────
+    else if constexpr (SEQ_ID == SEQ_SLICE) {
+        const auto* a = reinterpret_cast<const ArgsSlice*>(get_arg_addr(0));
+        const uint32_t nd = a->num_dims;
+        // Variable-length arrays follow num_dims in RT arg memory
+        tt_l1_ptr uint32_t* num_unpadded = (tt_l1_ptr uint32_t*)(&a->num_dims + 1);
+        tt_l1_ptr uint32_t* num_padded = num_unpadded + nd;
+        tt_l1_ptr uint32_t* id_per_dim = num_padded + nd;
+
+        auto st = seq_slice_init(a->start_id, nd, num_unpadded, num_padded, id_per_dim);
+        read_pages(cb_id, BATCH, page_size, s, a->num_pages, st, seq_slice_next);
+    }
+
+    // ── PERMUTE ─────────────────────────────────────────────────────
+    else if constexpr (SEQ_ID == SEQ_PERMUTE) {
+        const auto* a = reinterpret_cast<const ArgsPermute*>(get_arg_addr(0));
+        // src_strides[D], out_shape[D], inv_perm[D], id_per_dim[D] follow num_dims
+        // seq_permute_init reads them from RT arg indices starting at &num_dims + 1
+        uint32_t rt_data_start = 4;  // index of first element after ArgsPermute header
+        auto st = seq_permute_init(a->num_dims, rt_data_start);
+        read_pages(cb_id, BATCH, page_size, s, a->num_pages, st, seq_permute_next);
+    }
+
+    // ── TRANSPOSE_WH ────────────────────────────────────────────────
+    else if constexpr (SEQ_ID == SEQ_TRANSPOSE_WH) {
+        const auto* a = reinterpret_cast<const ArgsTransposeWh*>(get_arg_addr(0));
+        auto st = seq_transpose_wh_init(a->start_id, a->start_ht, a->start_wt, a->Ht, a->Wt, a->HtWt);
+        read_pages(cb_id, BATCH, page_size, s, a->num_pages, st, seq_transpose_wh_next);
+    }
+
+    // ── PAD (conditional source / fill) ─────────────────────────────
+    // Different loop body: branches on is_data per page.
+    else if constexpr (SEQ_ID == SEQ_PAD) {
+        const auto* a = reinterpret_cast<const ArgsPad*>(get_arg_addr(0));
+
+        // Fill pad tile in scratch CB
+        {
+            volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(a->cb_pad));
+            for (uint32_t i = 0; i < a->tile_bytes / 4 + 1; ++i) {
+                ptr[i] = a->packed_pad_val;
+            }
+        }
+        uint64_t pad_noc_addr = get_noc_addr(get_read_ptr(a->cb_pad));
+
+        auto st = seq_pad_init(
+            a->start_id,
+            a->start_wt,
+            a->start_ht,
+            a->start_c,
+            a->start_n,
+            a->Wt_in,
+            a->Ht_in,
+            a->C_in,
+            a->N_in,
+            a->Wt_out,
+            a->Ht_out,
+            a->C_out,
+            a->N_out,
+            a->front_wt,
+            a->front_ht,
+            a->front_c,
+            a->front_n);
+
+        uint32_t pages_left = a->num_pages;
+        while (pages_left > 0) {
+            uint32_t batch = (pages_left < BATCH) ? pages_left : BATCH;
+            cb_reserve_back(cb_id, batch);
+            uint32_t l1_addr = get_write_ptr(cb_id);
+            for (uint32_t t = 0; t < batch; t++) {
+                uint32_t src_page = seq_pad_next(st);
+                if (st.is_data) {
+                    noc_async_read_tile(src_page, s, l1_addr);
+                } else {
+                    noc_async_read(pad_noc_addr, l1_addr, a->tile_bytes);
+                }
+                l1_addr += a->tile_bytes;
+            }
+            noc_async_read_barrier();
+            cb_push_back(cb_id, batch);
+            pages_left -= batch;
+        }
+    }
+
+    // ── CONCAT (2-tensor interleave) ────────────────────────────────
+    // Different loop body: two TensorAccessors.
+    else if constexpr (SEQ_ID == SEQ_CONCAT) {
+        const auto* a = reinterpret_cast<const ArgsConcat*>(get_arg_addr(0));
+        const auto s1 = TensorAccessor(src_args, a->src_addr_1, page_size);
+
+        auto st = seq_concat_init(a->start_tensor, a->start_tensor_id, a->page_id_0, a->page_id_1, a->ppb_0, a->ppb_1);
+
+        uint32_t pages_left = a->num_pages;
+        while (pages_left > 0) {
+            uint32_t batch = (pages_left < BATCH) ? pages_left : BATCH;
+            cb_reserve_back(cb_id, batch);
+            uint32_t l1_addr = get_write_ptr(cb_id);
+            for (uint32_t t = 0; t < batch; t++) {
+                uint32_t read_tensor = st.curr_tensor;
+                uint32_t src_page = seq_concat_next(st);
+                if (read_tensor == 0) {
+                    noc_async_read_tile(src_page, s, l1_addr);
+                } else {
+                    noc_async_read_tile(src_page, s1, l1_addr);
+                }
+                l1_addr += page_size;
+            }
+            noc_async_read_barrier();
+            cb_push_back(cb_id, batch);
+            pages_left -= batch;
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels/reader_tile_interleaved_unified.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels/reader_tile_interleaved_unified.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // Unified batched tile reader for interleaved tensors.
 //
 // One transport loop, pluggable address sequencer selected by "seq_id".

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels/sequencers.h
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels/sequencers.h
@@ -1,0 +1,476 @@
+// Unified address sequencers for data movement ops.
+//
+// Each sequencer maps output_page -> source_page. The transport loop
+// (reader_tile_interleaved_unified.cpp) calls sequencer_next<SEQ_ID>()
+// per page. All functions are FORCE_INLINE — the compiler eliminates
+// dead code via if constexpr on SEQ_ID. Zero overhead vs hand-written.
+//
+// Sequencer IDs (passed as CT arg SEQ_ID):
+//   0 = IDENTITY   : src = sequential page (copy, no remapping)
+//   1 = REPEAT     : modular block arithmetic for higher-dim repeat
+//   2 = SLICE      : N-dim skip with padding offsets
+//   3 = PERMUTE    : inverse permutation with strides
+//   4 = TRANSPOSE_WH: stride-permuted tile index (W↔H swap)
+//   5 = PAD        : conditional in-bounds/fill
+//   6 = CONCAT     : multi-tensor page interleave (2 tensors)
+//   7 = HC         : height-channel transpose stick mapper
+//   8 = CN         : channel-batch transpose page mapper
+//   9 = REPEAT_INTERLEAVE : per-element (AABB) replication for repeat_interleave
+#pragma once
+
+#include "api/dataflow/dataflow_api.h"
+
+// --- Sequencer ID constants (match CT arg SEQ_ID) ---
+constexpr uint32_t SEQ_IDENTITY = 0;
+constexpr uint32_t SEQ_REPEAT = 1;
+constexpr uint32_t SEQ_SLICE = 2;
+constexpr uint32_t SEQ_PERMUTE = 3;
+constexpr uint32_t SEQ_TRANSPOSE_WH = 4;
+constexpr uint32_t SEQ_PAD = 5;
+constexpr uint32_t SEQ_CONCAT = 6;
+constexpr uint32_t SEQ_HC = 7;
+constexpr uint32_t SEQ_CN = 8;
+constexpr uint32_t SEQ_REPEAT_INTERLEAVE = 9;
+
+// Max supported dimensions for N-dim sequencers (slice, permute)
+constexpr uint32_t SEQ_MAX_DIMS = 8;
+
+// =====================================================================
+// Sequencer state structs
+// =====================================================================
+
+struct SeqIdentityState {
+    uint32_t page_id;
+};
+
+struct SeqRepeatState {
+    uint32_t out_page;
+    uint32_t src_lower;  // REP_DIM_PAGES * LOWER_PAGES
+    uint32_t dst_lower;  // NUM_REPEATS * src_lower
+};
+
+struct SeqRepeatInterleaveState {
+    uint32_t out_page;
+    uint32_t src_lower;    // REP_DIM_PAGES * LOWER_PAGES
+    uint32_t dst_lower;    // NUM_REPEATS * src_lower
+    uint32_t num_repeats;  // per-element replication factor
+    uint32_t lower_pages;  // pages below the repeat dim
+};
+
+struct SeqSliceState {
+    uint32_t src_tile_id;
+    uint32_t num_dims;
+    // These point into RT arg memory (L1) — no copy needed
+    tt_l1_ptr uint32_t* num_unpadded;
+    tt_l1_ptr uint32_t* num_padded;
+    tt_l1_ptr uint32_t* id_per_dim;
+};
+
+struct SeqPermuteState {
+    uint32_t num_dims;
+    uint32_t src_strides[SEQ_MAX_DIMS];
+    uint32_t out_shape[SEQ_MAX_DIMS];
+    uint32_t inv_perm[SEQ_MAX_DIMS];
+    uint32_t id_per_dim[SEQ_MAX_DIMS];
+};
+
+struct SeqTransposeWhState {
+    uint32_t i_tile;
+    uint32_t ht;
+    uint32_t wt;
+    uint32_t Ht;
+    uint32_t Wt;
+    uint32_t HtWt;
+};
+
+struct SeqPadState {
+    uint32_t src_tile;
+    uint32_t curr_wt;
+    uint32_t curr_ht;
+    uint32_t curr_c;
+    uint32_t curr_n;
+    uint32_t Wt_in;
+    uint32_t Ht_in;
+    uint32_t C_in;
+    uint32_t N_in;
+    uint32_t Wt_out;
+    uint32_t Ht_out;
+    uint32_t C_out;
+    uint32_t N_out;
+    uint32_t front_wt;  // tile-aligned leading pad, W (tiles)
+    uint32_t front_ht;  // tile-aligned leading pad, H (tiles)
+    uint32_t front_c;   // leading pad, C
+    uint32_t front_n;   // leading pad, N
+    bool is_data;       // set by next(), read by transport loop
+};
+
+struct SeqConcatState {
+    uint32_t curr_tensor;
+    uint32_t curr_tensor_id;
+    uint32_t page_id_0;
+    uint32_t page_id_1;
+    uint32_t ppb_0;  // pages per block, tensor 0
+    uint32_t ppb_1;  // pages per block, tensor 1
+};
+
+// =====================================================================
+// IDENTITY sequencer
+// =====================================================================
+
+inline __attribute__((always_inline)) SeqIdentityState seq_identity_init(uint32_t start_id) { return {start_id}; }
+
+inline __attribute__((always_inline)) uint32_t seq_identity_next(SeqIdentityState& st) { return st.page_id++; }
+
+// =====================================================================
+// REPEAT sequencer
+// =====================================================================
+
+inline __attribute__((always_inline)) SeqRepeatState
+seq_repeat_init(uint32_t out_start_page, uint32_t num_repeats, uint32_t lower_pages, uint32_t rep_dim_pages) {
+    uint32_t src_lower = rep_dim_pages * lower_pages;
+    uint32_t dst_lower = num_repeats * src_lower;
+    return {out_start_page, src_lower, dst_lower};
+}
+
+inline __attribute__((always_inline)) uint32_t seq_repeat_next(SeqRepeatState& st) {
+    uint32_t block = st.out_page / st.dst_lower;
+    uint32_t within = st.out_page % st.dst_lower;
+    uint32_t lower_in_rep = within % st.src_lower;
+    uint32_t src_page = block * st.src_lower + lower_in_rep;
+    st.out_page++;
+    return src_page;
+}
+
+// =====================================================================
+// REPEAT_INTERLEAVE sequencer (per-element / AABB replication)
+//
+// Same modular-block family as REPEAT, but the within-block offset uses
+// integer division by num_repeats instead of modulo by src_lower:
+//   src_lower = rep_dim_pages * lower_pages
+//   dst_lower = num_repeats * src_lower
+//   block     = out_page / dst_lower            (everything above rep_dim)
+//   within    = out_page % dst_lower
+//   lo        = within % lower_pages            (offset below rep_dim)
+//   out_rep   = within / lower_pages            (replicated rep_dim index)
+//   in_rep    = out_rep / num_repeats           (AABB collapse, per-element)
+//   src = block*src_lower + in_rep*lower_pages + lo
+//
+// When lower_pages == 1 this reduces to the documented short form
+//   src = block*src_lower + (within / num_repeats)
+// repeat (ABAB) instead uses within % src_lower, replicating whole blocks.
+// =====================================================================
+
+inline __attribute__((always_inline)) SeqRepeatInterleaveState seq_repeat_interleave_init(
+    uint32_t out_start_page, uint32_t num_repeats, uint32_t lower_pages, uint32_t rep_dim_pages) {
+    uint32_t src_lower = rep_dim_pages * lower_pages;
+    uint32_t dst_lower = num_repeats * src_lower;
+    return {out_start_page, src_lower, dst_lower, num_repeats, lower_pages};
+}
+
+inline __attribute__((always_inline)) uint32_t seq_repeat_interleave_next(SeqRepeatInterleaveState& st) {
+    uint32_t block = st.out_page / st.dst_lower;
+    uint32_t within = st.out_page % st.dst_lower;
+    uint32_t lo = within % st.lower_pages;
+    uint32_t out_rep = within / st.lower_pages;
+    uint32_t in_rep = out_rep / st.num_repeats;
+    uint32_t src_page = block * st.src_lower + in_rep * st.lower_pages + lo;
+    st.out_page++;
+    return src_page;
+}
+
+// =====================================================================
+// SLICE sequencer (N-dimensional skip)
+// =====================================================================
+
+inline __attribute__((always_inline)) SeqSliceState seq_slice_init(
+    uint32_t start_id,
+    uint32_t num_dims,
+    tt_l1_ptr uint32_t* num_unpadded,
+    tt_l1_ptr uint32_t* num_padded,
+    tt_l1_ptr uint32_t* id_per_dim) {
+    return {start_id, num_dims, num_unpadded, num_padded, id_per_dim};
+}
+
+inline __attribute__((always_inline)) uint32_t seq_slice_next(SeqSliceState& st) {
+    uint32_t result = st.src_tile_id;
+    st.src_tile_id++;
+    for (uint32_t j = 0; j < st.num_dims; ++j) {
+        st.id_per_dim[j]++;
+        if (st.id_per_dim[j] == st.num_unpadded[j]) {
+            st.id_per_dim[j] = 0;
+            st.src_tile_id += st.num_padded[j];
+        } else {
+            break;
+        }
+    }
+    return result;
+}
+
+// =====================================================================
+// PERMUTE sequencer (inverse permutation with strides)
+// =====================================================================
+
+inline __attribute__((always_inline)) SeqPermuteState seq_permute_init(
+    uint32_t num_dims,
+    uint32_t rt_start_idx  // RT arg index where src_strides[D] begins
+) {
+    SeqPermuteState st;
+    st.num_dims = num_dims;
+    uint32_t idx = rt_start_idx;
+    for (uint32_t d = 0; d < num_dims; d++) {
+        st.src_strides[d] = get_arg_val<uint32_t>(idx++);
+    }
+    for (uint32_t d = 0; d < num_dims; d++) {
+        st.out_shape[d] = get_arg_val<uint32_t>(idx++);
+    }
+    for (uint32_t d = 0; d < num_dims; d++) {
+        st.inv_perm[d] = get_arg_val<uint32_t>(idx++);
+    }
+    for (uint32_t d = 0; d < num_dims; d++) {
+        st.id_per_dim[d] = get_arg_val<uint32_t>(idx++);
+    }
+    return st;
+}
+
+inline __attribute__((always_inline)) uint32_t seq_permute_next(SeqPermuteState& st) {
+    // Compute source tile via inverse permutation
+    uint32_t src_tile_id = 0;
+    for (uint32_t d = 0; d < st.num_dims; d++) {
+        src_tile_id += st.id_per_dim[st.inv_perm[d]] * st.src_strides[d];
+    }
+    // Advance N-dim output position (innermost last)
+    for (uint32_t d = st.num_dims; d > 0; d--) {
+        st.id_per_dim[d - 1]++;
+        if (st.id_per_dim[d - 1] < st.out_shape[d - 1]) {
+            break;
+        }
+        st.id_per_dim[d - 1] = 0;
+    }
+    return src_tile_id;
+}
+
+// =====================================================================
+// TRANSPOSE_WH sequencer (W↔H tile swap via stride arithmetic)
+// =====================================================================
+
+inline __attribute__((always_inline)) SeqTransposeWhState seq_transpose_wh_init(
+    uint32_t start_id, uint32_t start_ht, uint32_t start_wt, uint32_t Ht, uint32_t Wt, uint32_t HtWt) {
+    return {start_id, start_ht, start_wt, Ht, Wt, HtWt};
+}
+
+inline __attribute__((always_inline)) uint32_t seq_transpose_wh_next(SeqTransposeWhState& st) {
+    uint32_t result = st.i_tile;
+    st.i_tile += st.Wt;
+    st.ht++;
+    if (st.ht == st.Ht) {
+        st.ht = 0;
+        st.i_tile++;
+        st.wt++;
+        if (st.wt == st.Wt) {
+            st.wt = 0;
+            st.i_tile -= st.Wt;
+        } else {
+            st.i_tile -= st.HtWt;
+        }
+    }
+    return result;
+}
+
+// =====================================================================
+// PAD sequencer (conditional in-bounds vs fill tile)
+//
+// After calling seq_pad_next(), check st.is_data:
+//   true  -> returned page is a valid source tile ID, use noc_async_read_tile
+//   false -> tile is padding, use noc_async_read from pad_noc_addr
+// =====================================================================
+
+inline __attribute__((always_inline)) SeqPadState seq_pad_init(
+    uint32_t start_src_tile,
+    uint32_t start_wt,
+    uint32_t start_ht,
+    uint32_t start_c,
+    uint32_t start_n,
+    uint32_t Wt_in,
+    uint32_t Ht_in,
+    uint32_t C_in,
+    uint32_t N_in,
+    uint32_t Wt_out,
+    uint32_t Ht_out,
+    uint32_t C_out,
+    uint32_t N_out,
+    uint32_t front_wt,
+    uint32_t front_ht,
+    uint32_t front_c,
+    uint32_t front_n) {
+    return {
+        start_src_tile,
+        start_wt,
+        start_ht,
+        start_c,
+        start_n,
+        Wt_in,
+        Ht_in,
+        C_in,
+        N_in,
+        Wt_out,
+        Ht_out,
+        C_out,
+        N_out,
+        front_wt,
+        front_ht,
+        front_c,
+        front_n,
+        false};
+}
+
+inline __attribute__((always_inline)) uint32_t seq_pad_next(SeqPadState& st) {
+    // Data occupies [front, front + in) in each dim; everything else is pad.
+    // Back-only padding is the front_* == 0 special case.
+    st.is_data = (st.curr_wt >= st.front_wt) && (st.curr_wt < st.front_wt + st.Wt_in) && (st.curr_ht >= st.front_ht) &&
+                 (st.curr_ht < st.front_ht + st.Ht_in) && (st.curr_c >= st.front_c) &&
+                 (st.curr_c < st.front_c + st.C_in) && (st.curr_n >= st.front_n) && (st.curr_n < st.front_n + st.N_in);
+
+    uint32_t result = st.src_tile;
+    if (st.is_data) {
+        st.src_tile++;
+    }
+
+    // Advance output tile coordinates: wt (innermost), ht, c, n
+    st.curr_wt++;
+    if (st.curr_wt == st.Wt_out) {
+        st.curr_wt = 0;
+        st.curr_ht++;
+        if (st.curr_ht == st.Ht_out) {
+            st.curr_ht = 0;
+            st.curr_c++;
+            if (st.curr_c == st.C_out) {
+                st.curr_c = 0;
+                st.curr_n++;
+            }
+        }
+    }
+    return result;
+}
+
+// =====================================================================
+// CONCAT sequencer (2-tensor page interleave)
+//
+// After calling seq_concat_next(), check st.curr_tensor to know
+// which TensorAccessor to use for the NOC read.
+// The returned value is the page_id within that tensor.
+// =====================================================================
+
+inline __attribute__((always_inline)) SeqConcatState seq_concat_init(
+    uint32_t start_tensor,
+    uint32_t start_tensor_id,
+    uint32_t page_id_0,
+    uint32_t page_id_1,
+    uint32_t ppb_0,
+    uint32_t ppb_1) {
+    return {start_tensor, start_tensor_id, page_id_0, page_id_1, ppb_0, ppb_1};
+}
+
+inline __attribute__((always_inline)) uint32_t seq_concat_next(SeqConcatState& st) {
+    uint32_t result;
+    uint32_t read_tensor = st.curr_tensor;  // save for caller
+
+    if (st.curr_tensor == 0) {
+        result = st.page_id_0++;
+    } else {
+        result = st.page_id_1++;
+    }
+
+    // Advance block tracking
+    st.curr_tensor_id++;
+    if (st.curr_tensor == 0 && st.curr_tensor_id == st.ppb_0) {
+        st.curr_tensor_id = 0;
+        st.curr_tensor = 1;
+    } else if (st.curr_tensor == 1 && st.curr_tensor_id == st.ppb_1) {
+        st.curr_tensor_id = 0;
+        st.curr_tensor = 0;
+    }
+
+    return result;
+}
+
+// =====================================================================
+// HC sequencer (height-channel transpose: iterate C fast, then H, then N)
+//
+// Input layout [N,C,H,W], output [N,H,C,W]. Sticks are W-element rows.
+// Reader iterates in output order: for each output stick at (n,h,c),
+// reads from input stick at (n,c,h) = i_stick.
+// i_stick advances by H per C step (jumping between channels).
+// =====================================================================
+
+struct SeqHcState {
+    uint32_t i_stick;
+    uint32_t curr_c;
+    uint32_t curr_h;
+    uint32_t curr_n;
+    uint32_t C;
+    uint32_t H;
+    uint32_t CH;
+};
+
+inline __attribute__((always_inline)) SeqHcState
+seq_hc_init(uint32_t start_id, uint32_t curr_c, uint32_t curr_h, uint32_t curr_n, uint32_t C, uint32_t H) {
+    return {start_id, curr_c, curr_h, curr_n, C, H, C * H};
+}
+
+inline __attribute__((always_inline)) uint32_t seq_hc_next(SeqHcState& st) {
+    uint32_t result = st.i_stick;
+    st.curr_c++;
+    st.i_stick += st.H;
+    if (st.curr_c == st.C) {
+        st.curr_h++;
+        st.curr_c = 0;
+        if (st.curr_h == st.H) {
+            st.curr_n++;
+            st.curr_h = 0;
+            st.i_stick = st.i_stick - st.H + 1;
+        } else {
+            st.i_stick = st.i_stick - st.CH + 1;
+        }
+    }
+    return result;
+}
+
+// =====================================================================
+// CN sequencer (channel-batch transpose: iterate N fast, then C)
+//
+// Input layout [N,C,HtWt], output [C,N,HtWt]. Pages are tiles or sticks.
+// Reader iterates in output order: for each (c,n,hw), reads from (n,c,hw).
+// page_idx advances by 1 within an HtWt block, then jumps by batch_step
+// to next N, wraps by channel_step at N boundary.
+// =====================================================================
+
+struct SeqCnState {
+    uint32_t page_idx;
+    uint32_t hw;
+    uint32_t n;
+    uint32_t N;
+    uint32_t HtWt;
+    uint32_t batch_step;    // C*HtWt - HtWt
+    uint32_t channel_step;  // N*C*HtWt - HtWt
+};
+
+inline __attribute__((always_inline)) SeqCnState seq_cn_init(
+    uint32_t start_id, uint32_t hw, uint32_t n, uint32_t N, uint32_t HtWt, uint32_t batch_step, uint32_t channel_step) {
+    return {start_id, hw, n, N, HtWt, batch_step, channel_step};
+}
+
+inline __attribute__((always_inline)) uint32_t seq_cn_next(SeqCnState& st) {
+    uint32_t result = st.page_idx;
+    st.page_idx++;
+    st.hw++;
+    if (st.hw == st.HtWt) {
+        st.hw = 0;
+        st.n++;
+        st.page_idx += st.batch_step;
+        if (st.n == st.N) {
+            st.n = 0;
+            st.page_idx -= st.channel_step;
+        }
+    }
+    return result;
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels/sequencers.h
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels/sequencers.h
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // Unified address sequencers for data movement ops.
 //
 // Each sequencer maps output_page -> source_page. The transport loop

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels/writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels/writer_interleaved.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // Sequential page writer for interleaved tensors (TILE and RM).
 // Supports optional batching via BATCH compile-time arg.
 // When BATCH > 1: pipelined — overlaps NOC DMA of batch N with compute

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels/writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels/writer_interleaved.cpp
@@ -1,0 +1,76 @@
+// Sequential page writer for interleaved tensors (TILE and RM).
+// Supports optional batching via BATCH compile-time arg.
+// When BATCH > 1: pipelined — overlaps NOC DMA of batch N with compute
+// delivering batch N+1. Requires cb_out depth >= 2 * BATCH.
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    uint32_t num_tiles = get_arg_val<uint32_t>(1);
+    uint32_t start_id = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t cb_out = get_compile_time_arg_val(0);
+    constexpr uint32_t page_size = get_compile_time_arg_val(1);
+    constexpr auto dst_args = TensorAccessorArgs<2>();
+    constexpr uint32_t BATCH = get_compile_time_arg_val(dst_args.next_compile_time_args_offset());
+
+    const auto d = TensorAccessor(dst_args, dst_addr, page_size);
+
+    // CB pages are laid out in L1 on a 16B-aligned stride. When page_size is not
+    // a multiple of 16 (RM sub-stick slice: 10B/4B/254B sticks) the batched path
+    // must step the L1 read pointer by the aligned stride while still writing the
+    // compact page_size bytes to the DRAM page. Aligned callers (TILE 2048B,
+    // aligned RM) are unaffected: l1_page_stride == page_size.
+    constexpr uint32_t l1_page_stride = (page_size + 15u) & ~15u;
+
+    uint32_t tile_id = start_id;
+
+    if constexpr (BATCH > 1) {
+        // Pipelined batched writer: overlap NOC DMA of batch N with compute
+        // delivering batch N+1. While we wait for the new batch to arrive
+        // (cb_wait_front), the NOC finishes reading the previous batch from L1,
+        // so the subsequent flush is nearly free.
+        uint32_t tiles_left = num_tiles;
+
+        // Prime the pipeline: issue first batch without prior flush
+        uint32_t batch = (tiles_left < BATCH) ? tiles_left : BATCH;
+        cb_wait_front(cb_out, batch);
+        uint32_t l1_addr = get_read_ptr(cb_out);
+        for (uint32_t t = 0; t < batch; t++) {
+            noc_async_write_page(tile_id++, d, l1_addr);
+            l1_addr += l1_page_stride;
+        }
+        tiles_left -= batch;
+        uint32_t prev_batch = batch;
+
+        // Steady state: wait for old + new tiles, then flush/pop old, issue new.
+        // We must wait for prev_batch + batch because prev_batch tiles haven't
+        // been popped yet and are still counted as "available" by cb_wait_front.
+        while (tiles_left > 0) {
+            batch = (tiles_left < BATCH) ? tiles_left : BATCH;
+            cb_wait_front(cb_out, prev_batch + batch);  // wait for NEW batch to arrive
+            noc_async_writes_flushed();                 // flush prev (NOC drained during wait)
+            cb_pop_front(cb_out, prev_batch);           // reclaim prev batch space
+
+            l1_addr = get_read_ptr(cb_out);
+            for (uint32_t t = 0; t < batch; t++) {
+                noc_async_write_page(tile_id++, d, l1_addr);
+                l1_addr += l1_page_stride;
+            }
+            tiles_left -= batch;
+            prev_batch = batch;
+        }
+
+        // Drain final batch
+        noc_async_writes_flushed();
+        cb_pop_front(cb_out, prev_batch);
+    } else {
+        for (uint32_t i = 0; i < num_tiles; i++) {
+            cb_wait_front(cb_out, 1);
+            noc_async_write_page(tile_id++, d, get_read_ptr(cb_out));
+            noc_async_writes_flushed();
+            cb_pop_front(cb_out, 1);
+        }
+    }
+    noc_async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels/writer_repeat_interleave_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels/writer_repeat_interleave_rm.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // Sequential stick writer for RM interleaved tensors with repeat.
 // Uses get_noc_addr for aligned page addressing, writes stick_size bytes.
 //

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels/writer_repeat_interleave_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels/writer_repeat_interleave_rm.cpp
@@ -1,0 +1,65 @@
+// Sequential stick writer for RM interleaved tensors with repeat.
+// Uses get_noc_addr for aligned page addressing, writes stick_size bytes.
+//
+// CT args: cb_out, stick_size, aligned_page_size, TensorAccessorArgs(out_t), BATCH
+// RT args: dst_addr, num_pages, start_id
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    uint32_t num_pages = get_arg_val<uint32_t>(1);
+    uint32_t start_id = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t cb_out = get_compile_time_arg_val(0);
+    constexpr uint32_t stick_size = get_compile_time_arg_val(1);
+    constexpr uint32_t aligned_page_size = get_compile_time_arg_val(2);
+    constexpr auto dst_args = TensorAccessorArgs<3>();
+    constexpr uint32_t BATCH = get_compile_time_arg_val(dst_args.next_compile_time_args_offset());
+
+    const auto d = TensorAccessor(dst_args, dst_addr);
+
+    uint32_t page_id = start_id;
+
+    if constexpr (BATCH > 1) {
+        uint32_t pages_left = num_pages;
+
+        // Prime the pipeline
+        uint32_t batch = (pages_left < BATCH) ? pages_left : BATCH;
+        cb_wait_front(cb_out, batch);
+        uint32_t l1_addr = get_read_ptr(cb_out);
+        for (uint32_t t = 0; t < batch; t++) {
+            noc_async_write_page(page_id++, d, l1_addr, stick_size);
+            l1_addr += stick_size;
+        }
+        pages_left -= batch;
+        uint32_t prev_batch = batch;
+
+        // Steady state
+        while (pages_left > 0) {
+            batch = (pages_left < BATCH) ? pages_left : BATCH;
+            cb_wait_front(cb_out, prev_batch + batch);
+            noc_async_writes_flushed();
+            cb_pop_front(cb_out, prev_batch);
+
+            l1_addr = get_read_ptr(cb_out);
+            for (uint32_t t = 0; t < batch; t++) {
+                noc_async_write_page(page_id++, d, l1_addr, stick_size);
+                l1_addr += stick_size;
+            }
+            pages_left -= batch;
+            prev_batch = batch;
+        }
+
+        // Drain
+        noc_async_writes_flushed();
+        cb_pop_front(cb_out, prev_batch);
+    } else {
+        for (uint32_t i = 0; i < num_pages; i++) {
+            cb_wait_front(cb_out, 1);
+            noc_async_write_page(page_id++, d, get_read_ptr(cb_out), stick_size);
+            noc_async_writes_flushed();
+            cb_pop_front(cb_out, 1);
+        }
+    }
+    noc_async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_device_operation.cpp
@@ -5,6 +5,7 @@
 #include "ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_device_operation.hpp"
 
 #include "ttnn/device_operation.hpp"
+#include "ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_supported.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
 
 namespace ttnn::prim {
@@ -16,12 +17,23 @@ RepeatInterleaveCodegenDeviceOperation::select_program_factory(
 }
 
 void RepeatInterleaveCodegenDeviceOperation::validate_on_program_cache_miss(
-    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& tensor_args) {
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     const Tensor& input_tensor = tensor_args.input;
     TT_FATAL(
         input_tensor.storage_type() == tt::tt_metal::StorageType::DEVICE,
         "Operands to repeat_interleave need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands need to be allocated in buffers on device!");
+
+    // rep_dim is stored 4D-padded (left-pad by 4 - ndim); recover the original, tensor-relative dim
+    // to check against the same normalized-attribute predicate the host free function gates on.
+    const uint32_t ndim = input_tensor.logical_shape().rank();
+    const uint32_t original_dim = operation_attributes.rep_dim - (4 - ndim);
+    TT_FATAL(
+        ttnn::operations::data_movement::repeat_interleave::supported_by_codegen(
+            input_tensor, operation_attributes.num_repeats, static_cast<int32_t>(original_dim)),
+        "repeat_interleave: unsupported by codegen for the given input/attrs (rep_dim={}, num_repeats={})",
+        operation_attributes.rep_dim,
+        operation_attributes.num_repeats);
 }
 
 RepeatInterleaveCodegenDeviceOperation::spec_return_value_t
@@ -29,7 +41,9 @@ RepeatInterleaveCodegenDeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
     auto output_shape = input_tensor.logical_shape();
-    output_shape[operation_attributes.rep_dim] *= operation_attributes.num_repeats;
+    const uint32_t ndim = output_shape.rank();
+    const uint32_t original_dim = operation_attributes.rep_dim - (4 - ndim);
+    output_shape[original_dim] *= operation_attributes.num_repeats;
     return TensorSpec(
         output_shape,
         tt::tt_metal::TensorLayout(

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_device_operation.cpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_device_operation.hpp"
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/tensor/tensor_ops.hpp"
+
+namespace ttnn::prim {
+
+RepeatInterleaveCodegenDeviceOperation::program_factory_t
+RepeatInterleaveCodegenDeviceOperation::select_program_factory(
+    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& /*tensor_args*/) {
+    return RepeatInterleaveCodegenProgramFactory{};
+}
+
+void RepeatInterleaveCodegenDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& tensor_args) {
+    const Tensor& input_tensor = tensor_args.input;
+    TT_FATAL(
+        input_tensor.storage_type() == tt::tt_metal::StorageType::DEVICE,
+        "Operands to repeat_interleave need to be on device!");
+    TT_FATAL(input_tensor.buffer() != nullptr, "Operands need to be allocated in buffers on device!");
+}
+
+RepeatInterleaveCodegenDeviceOperation::spec_return_value_t
+RepeatInterleaveCodegenDeviceOperation::compute_output_specs(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.input;
+    auto output_shape = input_tensor.logical_shape();
+    output_shape[operation_attributes.rep_dim] *= operation_attributes.num_repeats;
+    return TensorSpec(
+        output_shape,
+        tt::tt_metal::TensorLayout(
+            input_tensor.dtype(),
+            tt::tt_metal::PageConfig(input_tensor.layout()),
+            operation_attributes.output_mem_config));
+}
+
+RepeatInterleaveCodegenDeviceOperation::tensor_return_value_t
+RepeatInterleaveCodegenDeviceOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
+}
+
+RepeatInterleaveCodegenDeviceOperation::tensor_return_value_t repeat_interleave_codegen(
+    const Tensor& input, const RepeatInterleaveCodegenParams& params) {
+    using OperationType = RepeatInterleaveCodegenDeviceOperation;
+    return ttnn::device_operation::launch<OperationType>(params, OperationType::tensor_args_t{.input = input});
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_device_operation.hpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/operation.hpp"
+#include "ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_device_operation_types.hpp"
+#include "ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_program_factory.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::prim {
+
+struct RepeatInterleaveCodegenDeviceOperation {
+    using operation_attributes_t = RepeatInterleaveCodegenParams;
+    using tensor_args_t = RepeatInterleaveCodegenInputs;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
+    using program_factory_t = RepeatInterleaveCodegenProgramFactory;
+
+    static program_factory_t select_program_factory(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static void validate_on_program_cache_miss(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static spec_return_value_t compute_output_specs(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+
+    static tensor_return_value_t create_output_tensors(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+};
+
+RepeatInterleaveCodegenDeviceOperation::tensor_return_value_t repeat_interleave_codegen(
+    const Tensor& input, const RepeatInterleaveCodegenParams& params);
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_device_operation.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <variant>
+
 #include "ttnn/operation.hpp"
 #include "ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_device_operation_types.hpp"
 #include "ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_program_factory.hpp"
@@ -16,7 +18,9 @@ struct RepeatInterleaveCodegenDeviceOperation {
     using tensor_args_t = RepeatInterleaveCodegenInputs;
     using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
-    using program_factory_t = RepeatInterleaveCodegenProgramFactory;
+    // DeviceOperationConcept's AllFactoriesValid requires program_factory_t to be a std::variant, even
+    // with a single alternative (see ttnn/operation_concepts.hpp).
+    using program_factory_t = std::variant<RepeatInterleaveCodegenProgramFactory>;
 
     static program_factory_t select_program_factory(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_device_operation_types.hpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::prim {
+
+struct RepeatInterleaveCodegenParams {
+    uint32_t rep_dim{};
+    uint32_t num_repeats{};
+    uint32_t lower_pages{};
+    uint32_t rep_dim_pages{};
+    uint32_t total_out_pages{};
+    uint32_t stick_size{};
+    uint32_t stick_size_out{};
+    tt::tt_metal::MemoryConfig output_mem_config;
+};
+
+struct RepeatInterleaveCodegenInputs {
+    Tensor input;
+};
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_program_factory.cpp
@@ -4,13 +4,240 @@
 
 #include "ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_program_factory.hpp"
 
+#include <variant>
+#include <vector>
+
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/tt_align.hpp>
+#include <tt-metalium/work_split.hpp>
+
+#include "ttnn/tensor/tensor.hpp"
+
 namespace ttnn::prim {
 
+using namespace tt::tt_metal;
+
+namespace {
+
+// Matches READ_BATCH / WRITE_BATCH / _CB_DEPTH in ops/repeat_interleave/spec.py and
+// ops/repeat/spec.py (shared TILE builder).
+constexpr uint32_t kReadBatch = 4;
+constexpr uint32_t kWriteBatch = 4;
+constexpr uint32_t kCbDepth = 8;              // max(2 * max(READ_BATCH, WRITE_BATCH), 8)
+constexpr uint32_t kSeqRepeatInterleave = 9;  // sequencers.h SEQ_REPEAT_INTERLEAVE
+constexpr const char* kKernelDir = "ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels";
+
+std::string kernel_path(const char* name) { return std::string(kKernelDir) + "/" + name; }
+
+// Result of the standard split_work_to_cores() 2-group work split.
+struct CoreSplit {
+    uint32_t num_cores;
+    CoreRangeSet all_cores;
+    CoreRangeSet core_group_1;
+    CoreRangeSet core_group_2;
+    uint32_t units_per_core_group_1;
+    uint32_t units_per_core_group_2;
+};
+
+CoreSplit split_work(IDevice* device, uint32_t total_work) {
+    const CoreCoord grid = device->compute_with_storage_grid_size();
+    auto [num_cores, all_cores, cg1, cg2, upc1, upc2] = split_work_to_cores(grid, total_work);
+    return CoreSplit{num_cores, all_cores, cg1, cg2, upc1, upc2};
+}
+
+// Per-core RT emission shared by all three kernel variants: reader RT is always
+// [src_addr, n, start] plus an (optionally empty) fixed tail; writer RT is always
+// [dst_addr, n, start] (matches assemble_rm_positional / build_repeat_tile's
+// rt_closure — only the TILE path has a non-empty reader tail).
+void emit_per_core_rt(
+    const CoreSplit& split,
+    KernelDescriptor& reader_desc,
+    KernelDescriptor& writer_desc,
+    Buffer* src_buffer,
+    Buffer* dst_buffer,
+    const std::vector<uint32_t>& reader_tail = {}) {
+    const auto cores = corerange_to_cores(split.all_cores, split.num_cores);
+    const uint32_t g1_num_cores = split.core_group_1.num_cores();
+    uint32_t start = 0;
+    for (uint32_t i = 0; i < cores.size(); i++) {
+        const uint32_t n = (i < g1_num_cores) ? split.units_per_core_group_1 : split.units_per_core_group_2;
+        std::vector<std::variant<uint32_t, Buffer*>> reader_args{src_buffer, n, start};
+        for (uint32_t v : reader_tail) {
+            reader_args.emplace_back(v);
+        }
+        reader_desc.emplace_runtime_args(cores[i], reader_args);
+        writer_desc.emplace_runtime_args(cores[i], std::vector<std::variant<uint32_t, Buffer*>>{dst_buffer, n, start});
+        start += n;
+    }
+}
+
+}  // namespace
+
+// Transliterated from ops/repeat_interleave/spec.py (build_repeat_tile via ops/repeat/spec.py
+// for the TILE path, build_repeat_interleave_rm_factory / build_repeat_interleave_lastdim_rm for
+// ROW_MAJOR). Layout selects TILE vs ROW_MAJOR; within ROW_MAJOR, operation_attributes.rep_dim == 3
+// (the 4D-padded last-dim marker set by the host free function) selects the lastdim kernel,
+// otherwise the higher-dim (whole-stick) kernel.
 tt::tt_metal::ProgramDescriptor RepeatInterleaveCodegenProgramFactory::create_descriptor(
-    const RepeatInterleaveCodegenParams& /*operation_attributes*/,
-    const RepeatInterleaveCodegenInputs& /*tensor_args*/,
-    Tensor& /*tensor_return_value*/) {
-    return tt::tt_metal::ProgramDescriptor{};
+    const RepeatInterleaveCodegenParams& operation_attributes,
+    const RepeatInterleaveCodegenInputs& tensor_args,
+    Tensor& tensor_return_value) {
+    const Tensor& input = tensor_args.input;
+    Tensor& output = tensor_return_value;
+    IDevice* device = input.device();
+    Buffer* src_buffer = input.buffer();
+    Buffer* dst_buffer = output.buffer();
+    TT_FATAL(dst_buffer != nullptr, "repeat_interleave: output buffer should be allocated on device!");
+
+    ProgramDescriptor desc;
+
+    if (input.layout() == Layout::TILE) {
+        const tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input.dtype());
+        const uint32_t raw_tile_size = tt::tile_size(cb_data_format);
+        const uint32_t aligned_tile_size = tt::align(raw_tile_size, tt::tt_metal::hal::get_dram_alignment());
+
+        const CoreSplit split = split_work(device, operation_attributes.total_out_pages);
+
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = kCbDepth * aligned_tile_size,
+            .core_ranges = split.all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = 0,
+                .data_format = cb_data_format,
+                .page_size = aligned_tile_size,
+            }}},
+        });
+
+        std::vector<uint32_t> reader_ct;
+        TensorAccessorArgs(*src_buffer).append_to(reader_ct);
+
+        KernelDescriptor reader_desc;
+        reader_desc.kernel_source = kernel_path("reader_tile_interleaved_unified.cpp");
+        reader_desc.core_ranges = split.all_cores;
+        reader_desc.compile_time_args = std::move(reader_ct);
+        reader_desc.named_compile_time_args = {{"seq_id", kSeqRepeatInterleave}, {"cb_id", 0}, {"batch", kReadBatch}};
+        reader_desc.config = ReaderConfigDescriptor{};
+
+        std::vector<uint32_t> writer_ct = {0, aligned_tile_size};
+        TensorAccessorArgs(*dst_buffer).append_to(writer_ct);
+        writer_ct.push_back(kWriteBatch);
+
+        KernelDescriptor writer_desc;
+        writer_desc.kernel_source = kernel_path("writer_interleaved.cpp");
+        writer_desc.core_ranges = split.all_cores;
+        writer_desc.compile_time_args = std::move(writer_ct);
+        writer_desc.config = WriterConfigDescriptor{};
+
+        emit_per_core_rt(
+            split,
+            reader_desc,
+            writer_desc,
+            src_buffer,
+            dst_buffer,
+            {operation_attributes.num_repeats, operation_attributes.lower_pages, operation_attributes.rep_dim_pages});
+
+        desc.kernels.push_back(std::move(reader_desc));
+        desc.kernels.push_back(std::move(writer_desc));
+        return desc;
+    }
+
+    // ROW_MAJOR. rep_dim == 3 marks the (4D-padded) last dim -> within-stick (W) path.
+    if (operation_attributes.rep_dim == 3) {
+        const uint32_t stick_in = operation_attributes.stick_size;
+        const uint32_t stick_out = operation_attributes.stick_size_out;
+        const uint32_t elem_size = input.element_size();
+        const uint32_t w_in = stick_in / elem_size;
+        const uint32_t out_align = dst_buffer->alignment();
+        const uint32_t aligned_out = tt::align(stick_out, out_align);
+
+        const CoreSplit split = split_work(device, operation_attributes.total_out_pages);
+
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = kCbDepth * stick_out,
+            .core_ranges = split.all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = 0,
+                .data_format = datatype_to_dataformat_converter(input.dtype()),
+                .page_size = stick_out,
+            }}},
+        });
+
+        std::vector<uint32_t> reader_ct = {stick_out, stick_in, w_in, operation_attributes.num_repeats, elem_size};
+        TensorAccessorArgs(*src_buffer).append_to(reader_ct);
+        reader_ct.push_back(0);  // cb_id
+        reader_ct.push_back(kReadBatch);
+
+        KernelDescriptor reader_desc;
+        reader_desc.kernel_source = kernel_path("reader_repeat_interleave_lastdim_rm.cpp");
+        reader_desc.core_ranges = split.all_cores;
+        reader_desc.compile_time_args = std::move(reader_ct);
+        reader_desc.config = ReaderConfigDescriptor{};
+
+        std::vector<uint32_t> writer_ct = {0, stick_out, aligned_out};
+        TensorAccessorArgs(*dst_buffer).append_to(writer_ct);
+        writer_ct.push_back(kWriteBatch);
+
+        KernelDescriptor writer_desc;
+        writer_desc.kernel_source = kernel_path("writer_repeat_interleave_rm.cpp");
+        writer_desc.core_ranges = split.all_cores;
+        writer_desc.compile_time_args = std::move(writer_ct);
+        writer_desc.config = WriterConfigDescriptor{};
+
+        emit_per_core_rt(split, reader_desc, writer_desc, src_buffer, dst_buffer);
+
+        desc.kernels.push_back(std::move(reader_desc));
+        desc.kernels.push_back(std::move(writer_desc));
+        return desc;
+    }
+
+    // ROW_MAJOR higher-dim (whole-stick, outer/H) path.
+    const uint32_t stick_size = operation_attributes.stick_size;
+    const uint32_t aligned_page_size = tt::align(stick_size, src_buffer->alignment());
+
+    const CoreSplit split = split_work(device, operation_attributes.total_out_pages);
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = kCbDepth * stick_size,
+        .core_ranges = split.all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = 0,
+            .data_format = datatype_to_dataformat_converter(input.dtype()),
+            .page_size = stick_size,
+        }}},
+    });
+
+    std::vector<uint32_t> reader_ct = {stick_size, aligned_page_size};
+    TensorAccessorArgs(*src_buffer).append_to(reader_ct);
+    reader_ct.push_back(0);  // cb_id
+    reader_ct.push_back(operation_attributes.num_repeats);
+    reader_ct.push_back(operation_attributes.lower_pages);
+    reader_ct.push_back(operation_attributes.rep_dim_pages);
+    reader_ct.push_back(kReadBatch);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = kernel_path("reader_repeat_interleave_rm.cpp");
+    reader_desc.core_ranges = split.all_cores;
+    reader_desc.compile_time_args = std::move(reader_ct);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    std::vector<uint32_t> writer_ct = {0, stick_size, aligned_page_size};
+    TensorAccessorArgs(*dst_buffer).append_to(writer_ct);
+    writer_ct.push_back(kWriteBatch);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = kernel_path("writer_repeat_interleave_rm.cpp");
+    writer_desc.core_ranges = split.all_cores;
+    writer_desc.compile_time_args = std::move(writer_ct);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    emit_per_core_rt(split, reader_desc, writer_desc, src_buffer, dst_buffer);
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    return desc;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_program_factory.cpp
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_program_factory.hpp"
+
+namespace ttnn::prim {
+
+tt::tt_metal::ProgramDescriptor RepeatInterleaveCodegenProgramFactory::create_descriptor(
+    const RepeatInterleaveCodegenParams& /*operation_attributes*/,
+    const RepeatInterleaveCodegenInputs& /*tensor_args*/,
+    Tensor& /*tensor_return_value*/) {
+    return tt::tt_metal::ProgramDescriptor{};
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_program_factory.hpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/program_descriptors.hpp>
+
+#include "ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_device_operation_types.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::prim {
+
+struct RepeatInterleaveCodegenProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const RepeatInterleaveCodegenParams& operation_attributes,
+        const RepeatInterleaveCodegenInputs& tensor_args,
+        Tensor& tensor_return_value);
+};
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_supported.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_supported.cpp
@@ -82,13 +82,8 @@ bool supported_by_codegen(const Tensor& input_tensor, uint32_t repeats, int32_t 
     return false;
 }
 
-// Perf-demoted ledger: empty. The one point flagged by phase 7 ([1, 4, 64, 64] | dim=1 |
-// repeats=4 | int32 | row_major -- generic/ported=0.901408, native/ported=3.576852) was NOT
-// demoted: reroutes were exhausted, and the regression against generic (~10%) was accepted
-// because codegen still beats native by ~3.6x on this point. `auto` therefore keeps routing it to
-// codegen, same as forced implementation="codegen"/"validate". Still emitted (always returning
-// false) so the `auto` branch's `supported_by_codegen(attrs) && !is_demoted(attrs)` wiring holds
-// even with an empty ledger.
+// Perf-demoted ledger: empty. Still emitted (always returning false) so the `auto` branch's
+// `supported_by_codegen(attrs) && !is_demoted(attrs)` wiring holds even with an empty ledger.
 bool is_demoted(const Tensor& /*input_tensor*/, uint32_t /*repeats*/, int32_t /*dim*/) { return false; }
 
 }  // namespace ttnn::operations::data_movement::repeat_interleave

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_supported.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_supported.cpp
@@ -16,8 +16,59 @@ ImplementationSelector parse_implementation(std::string_view implementation) {
     return ImplementationSelector::kAuto;
 }
 
-bool supported_by_codegen(const Tensor& /*input_tensor*/, uint32_t /*repeats*/, int32_t /*dim*/) { return false; }
+// Transcribed from common/sweeps/codegen_repeat_interleave.py's invalidate_vector, which is the
+// ledger's source of truth for this op (codegen_repeat_interleave.py has no upstream_sweep_module).
+// `dim` is the raw (possibly negative) user-facing axis, normalized here exactly like the sweep's
+// `nd = dim if dim >= 0 else dim + ndim`.
+//
+// NOTE: invalidate_vector rejects ROW_MAJOR nd == ndim - 1 (the within-stick/W dim), but that gate
+// is stale: RepeatInterleaveCodegen (ops/repeat_interleave/repeat_interleave.py) actually implements
+// this case via build_repeat_interleave_lastdim_rm. Transcribed verbatim anyway, per the manifest's
+// explicit scope: out classification for that case and the instruction that supported_by_codegen()
+// must agree with the manifest's cases.
+bool supported_by_codegen(const Tensor& input_tensor, uint32_t repeats, int32_t dim) {
+    const auto logical_shape = input_tensor.logical_shape();
+    const int32_t ndim = static_cast<int32_t>(logical_shape.rank());
+    if (ndim < 2) {
+        return false;
+    }
+    if (repeats < 1) {
+        return false;
+    }
+    // Not covered by invalidate_vector (the sweep carries no memory_config axis) but required by
+    // the manifest's hand-authored sharded-input case: the port has no S2I unshard step, so a
+    // sharded input can never reach the codegen path.
+    if (input_tensor.is_sharded()) {
+        return false;
+    }
 
+    const int32_t nd = dim >= 0 ? dim : dim + ndim;
+    if (nd < 0 || nd >= ndim) {
+        return false;
+    }
+
+    const tt::tt_metal::Layout layout = input_tensor.layout();
+    if (layout == tt::tt_metal::Layout::TILE) {
+        // Sub-tile (last two) dims: no tile-granular sequencer exists.
+        return nd < ndim - 2;
+    }
+
+    if (layout == tt::tt_metal::Layout::ROW_MAJOR) {
+        if (input_tensor.dtype() == tt::tt_metal::DataType::BFLOAT8_B) {
+            return false;
+        }
+        if (logical_shape[-1] < 2) {
+            return false;
+        }
+        return nd != ndim - 1;
+    }
+
+    return false;
+}
+
+// No perf-demoted cases have been identified for repeat_interleave yet. Still emitted (per the
+// porting guide) so the auto branch's `supported_by_codegen(attrs) && !is_demoted(attrs)` wiring is
+// identical regardless of whether anything is demoted.
 bool is_demoted(const Tensor& /*input_tensor*/, uint32_t /*repeats*/, int32_t /*dim*/) { return false; }
 
 }  // namespace ttnn::operations::data_movement::repeat_interleave

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_supported.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_supported.cpp
@@ -82,27 +82,13 @@ bool supported_by_codegen(const Tensor& input_tensor, uint32_t repeats, int32_t 
     return false;
 }
 
-// Perf-demoted ledger (seeded by phase 7's device qualification, extended by the demote-escape
-// rebuild): generic beat the port on device for this exact point, and reroutes were exhausted, so
-// `auto` must fall back to native. `validate` and forced implementation="codegen" never consult
-// this -- the case is still correct, just not worth the codegen path under auto.
-bool is_demoted(const Tensor& input_tensor, uint32_t repeats, int32_t dim) {
-    const auto logical_shape = input_tensor.logical_shape();
-    if (logical_shape.rank() != 4) {
-        return false;
-    }
-    const int32_t ndim = static_cast<int32_t>(logical_shape.rank());
-    const int32_t nd = dim >= 0 ? dim : dim + ndim;
-
-    // [1, 4, 64, 64] | dim=1 | repeats=4 | int32 | row_major
-    // (generic/ported=0.903418, native/ported=3.659768, wall=2.942047)
-    if (logical_shape[0] == 1 && logical_shape[1] == 4 && logical_shape[2] == 64 && logical_shape[3] == 64 && nd == 1 &&
-        repeats == 4 && input_tensor.dtype() == tt::tt_metal::DataType::INT32 &&
-        input_tensor.layout() == tt::tt_metal::Layout::ROW_MAJOR) {
-        return true;
-    }
-
-    return false;
-}
+// Perf-demoted ledger: empty. The one point flagged by phase 7 ([1, 4, 64, 64] | dim=1 |
+// repeats=4 | int32 | row_major -- generic/ported=0.901408, native/ported=3.576852) was NOT
+// demoted: reroutes were exhausted, and the regression against generic (~10%) was accepted
+// because codegen still beats native by ~3.6x on this point. `auto` therefore keeps routing it to
+// codegen, same as forced implementation="codegen"/"validate". Still emitted (always returning
+// false) so the `auto` branch's `supported_by_codegen(attrs) && !is_demoted(attrs)` wiring holds
+// even with an empty ledger.
+bool is_demoted(const Tensor& /*input_tensor*/, uint32_t /*repeats*/, int32_t /*dim*/) { return false; }
 
 }  // namespace ttnn::operations::data_movement::repeat_interleave

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_supported.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_supported.cpp
@@ -82,9 +82,27 @@ bool supported_by_codegen(const Tensor& input_tensor, uint32_t repeats, int32_t 
     return false;
 }
 
-// No perf-demoted cases have been identified for repeat_interleave yet. Still emitted (per the
-// porting guide) so the auto branch's `supported_by_codegen(attrs) && !is_demoted(attrs)` wiring is
-// identical regardless of whether anything is demoted.
-bool is_demoted(const Tensor& /*input_tensor*/, uint32_t /*repeats*/, int32_t /*dim*/) { return false; }
+// Perf-demoted ledger (seeded by phase 7's device qualification, extended by the demote-escape
+// rebuild): generic beat the port on device for this exact point, and reroutes were exhausted, so
+// `auto` must fall back to native. `validate` and forced implementation="codegen" never consult
+// this -- the case is still correct, just not worth the codegen path under auto.
+bool is_demoted(const Tensor& input_tensor, uint32_t repeats, int32_t dim) {
+    const auto logical_shape = input_tensor.logical_shape();
+    if (logical_shape.rank() != 4) {
+        return false;
+    }
+    const int32_t ndim = static_cast<int32_t>(logical_shape.rank());
+    const int32_t nd = dim >= 0 ? dim : dim + ndim;
+
+    // [1, 4, 64, 64] | dim=1 | repeats=4 | int32 | row_major
+    // (generic/ported=0.903418, native/ported=3.659768, wall=2.942047)
+    if (logical_shape[0] == 1 && logical_shape[1] == 4 && logical_shape[2] == 64 && logical_shape[3] == 64 && nd == 1 &&
+        repeats == 4 && input_tensor.dtype() == tt::tt_metal::DataType::INT32 &&
+        input_tensor.layout() == tt::tt_metal::Layout::ROW_MAJOR) {
+        return true;
+    }
+
+    return false;
+}
 
 }  // namespace ttnn::operations::data_movement::repeat_interleave

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_supported.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_supported.cpp
@@ -4,6 +4,8 @@
 
 #include "ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_supported.hpp"
 
+#include <tt-metalium/hal.hpp>
+
 namespace ttnn::operations::data_movement::repeat_interleave {
 
 ImplementationSelector parse_implementation(std::string_view implementation) {
@@ -60,7 +62,21 @@ bool supported_by_codegen(const Tensor& input_tensor, uint32_t repeats, int32_t 
         if (logical_shape[-1] < 2) {
             return false;
         }
-        return nd != ndim - 1;
+        if (nd == ndim - 1) {
+            return false;
+        }
+        // RM higher-dim (whole-stick) path only: RepeatInterleaveCodegen.repeat_interleave
+        // (ops/repeat_interleave/repeat_interleave.py) gates unaligned stick widths here -- the
+        // batched stick transport packs CB pages at raw stick width, and a stick size that isn't a
+        // multiple of the buffer's page alignment silently overlaps successive output pages
+        // (torch-golden caught this with BF16 W=133). Not reachable via invalidate_vector (the
+        // sweep has no alignment-aware gate), so transcribed directly from the op guard.
+        const uint32_t elem_size = input_tensor.element_size();
+        const uint32_t stick_bytes = logical_shape[-1] * elem_size;
+        const uint32_t alignment = input_tensor.memory_config().buffer_type() == tt::tt_metal::BufferType::L1
+                                       ? tt::tt_metal::hal::get_l1_alignment()
+                                       : tt::tt_metal::hal::get_dram_alignment();
+        return stick_bytes % alignment == 0;
     }
 
     return false;

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_supported.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_supported.cpp
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_supported.hpp"
+
+namespace ttnn::operations::data_movement::repeat_interleave {
+
+ImplementationSelector parse_implementation(std::string_view implementation) {
+    if (implementation == "native") {
+        return ImplementationSelector::kNative;
+    }
+    if (implementation == "codegen") {
+        return ImplementationSelector::kCodegen;
+    }
+    return ImplementationSelector::kAuto;
+}
+
+bool supported_by_codegen(const Tensor& /*input_tensor*/, uint32_t /*repeats*/, int32_t /*dim*/) { return false; }
+
+bool is_demoted(const Tensor& /*input_tensor*/, uint32_t /*repeats*/, int32_t /*dim*/) { return false; }
+
+}  // namespace ttnn::operations::data_movement::repeat_interleave

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_supported.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_supported.hpp
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <string_view>
+
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::operations::data_movement::repeat_interleave {
+
+enum class ImplementationSelector { kAuto, kNative, kCodegen };
+
+ImplementationSelector parse_implementation(std::string_view implementation);
+
+// Correctness gate: true only for shapes/layouts/dtypes the codegen kernels actually cover.
+bool supported_by_codegen(const Tensor& input_tensor, uint32_t repeats, int32_t dim);
+
+// Perf gate (auto routing only): true when codegen is supported but known slower than native.
+bool is_demoted(const Tensor& input_tensor, uint32_t repeats, int32_t dim);
+
+}  // namespace ttnn::operations::data_movement::repeat_interleave

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/repeat_interleave.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/repeat_interleave.cpp
@@ -4,8 +4,12 @@
 
 #include "repeat_interleave.hpp"
 
+#include <array>
+
 #include "ttnn/operations/data_movement/concat/concat.hpp"
 #include "ttnn/operations/data_movement/reshape_on_device/reshape.hpp"
+#include "ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_device_operation.hpp"
+#include "ttnn/operations/data_movement/repeat_interleave/codegen/repeat_interleave_codegen_supported.hpp"
 #include "ttnn/operations/data_movement/unsqueeze/unsqueeze.hpp"
 #include "ttnn/operations/data_movement/transpose/transpose.hpp"
 #include "ttnn/operations/copy/typecast/typecast.hpp"
@@ -13,8 +17,15 @@
 
 namespace ttnn {
 
+namespace {
+
+using ttnn::operations::data_movement::repeat_interleave::ImplementationSelector;
+using ttnn::operations::data_movement::repeat_interleave::is_demoted;
+using ttnn::operations::data_movement::repeat_interleave::parse_implementation;
+using ttnn::operations::data_movement::repeat_interleave::supported_by_codegen;
+
 // repeat interleave supports repeats as 1 to inf, dim between 0 to 2
-ttnn::Tensor repeat_interleave(
+ttnn::Tensor repeat_interleave_native(
     const ttnn::Tensor& input_a, uint32_t repeat, int32_t dim, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> combined_tensors;
     combined_tensors.reserve(repeat);
@@ -27,7 +38,9 @@ ttnn::Tensor repeat_interleave(
     uint32_t normalized_dim = input_a_shape.get_normalized_index(dim);
     if (normalized_dim == input_rank - 1) {
         auto transposed_input = ttnn::transpose(input_a, -1, -2, mem_config);
-        auto repeated_input = ttnn::repeat_interleave(transposed_input, repeat, -2, mem_config);
+        // Recurse into the native implementation directly (not the public dispatcher) so the
+        // "native" selector stays unconditionally native, never escalating to auto/codegen.
+        auto repeated_input = repeat_interleave_native(transposed_input, repeat, -2, mem_config);
         return ttnn::transpose(repeated_input, -1, -2, mem_config);
     }
 
@@ -66,6 +79,106 @@ ttnn::Tensor repeat_interleave(
     auto reshaped_tensor = ttnn::reshape(concatenated_tensor, ttnn::Shape(final_shape));
     auto original_layout = ttnn::to_layout(reshaped_tensor, input_a.layout());
     return typecast ? ttnn::typecast(original_layout, input_a.dtype(), mem_config) : original_layout;
+}
+
+// Host-side transliteration of the page-map math in ops/repeat_interleave/spec.py (and, for the
+// TILE path, ops/repeat/spec.py's shared build_repeat_tile) that populates
+// RepeatInterleaveCodegenParams. `normalized_dim` is already 0..ndim-1 (non-negative).
+ttnn::prim::RepeatInterleaveCodegenParams build_codegen_params(
+    const Tensor& input_tensor, uint32_t repeats, uint32_t normalized_dim, const MemoryConfig& mem_config) {
+    const auto logical_shape = input_tensor.logical_shape();
+    const uint32_t ndim = logical_shape.rank();
+    const uint32_t pad = 4 - ndim;
+
+    std::array<uint32_t, 4> shape4 = {1, 1, 1, 1};
+    for (uint32_t i = 0; i < ndim; i++) {
+        shape4[pad + i] = logical_shape[i];
+    }
+    const uint32_t rep_dim_4d = normalized_dim + pad;
+
+    ttnn::prim::RepeatInterleaveCodegenParams params{};
+    params.num_repeats = repeats;
+    params.output_mem_config = mem_config;
+
+    const bool row_major = input_tensor.layout() == Layout::ROW_MAJOR;
+    const uint32_t elem_size = input_tensor.element_size();
+
+    if (row_major && normalized_dim == ndim - 1) {
+        // RM last-dim (within-stick W) path: rep_dim == 3 is the marker the program factory and
+        // validate use to select this branch (the 4D-padded last dim is always index 3).
+        const uint32_t w_in = shape4[3];
+        params.rep_dim = 3;
+        params.stick_size = w_in * elem_size;
+        params.stick_size_out = w_in * repeats * elem_size;
+        params.total_out_pages = shape4[0] * shape4[1] * shape4[2];
+        return params;
+    }
+
+    std::array<uint32_t, 4> dim_pages = {1, 1, 1, 1};
+    if (row_major) {
+        // RM higher-dim (whole-stick, outer/H) path: pages are sticks.
+        dim_pages = {shape4[0], shape4[1], shape4[2], 1};
+        params.stick_size = shape4[3] * elem_size;
+    } else {
+        // TILE path: pages are tiles (ops/repeat/spec.py's _page_map).
+        constexpr uint32_t kTileH = 32;
+        constexpr uint32_t kTileW = 32;
+        const uint32_t ht = (shape4[2] + kTileH - 1) / kTileH;
+        const uint32_t wt = (shape4[3] + kTileW - 1) / kTileW;
+        dim_pages = {shape4[0], shape4[1], ht, wt};
+    }
+
+    uint32_t lower_pages = 1;
+    for (uint32_t d = rep_dim_4d + 1; d < 4; d++) {
+        lower_pages *= dim_pages[d];
+    }
+    uint32_t total_pages = 1;
+    for (uint32_t d = 0; d < 4; d++) {
+        total_pages *= dim_pages[d];
+    }
+
+    params.rep_dim = rep_dim_4d;
+    params.lower_pages = lower_pages;
+    params.rep_dim_pages = dim_pages[rep_dim_4d];
+    params.total_out_pages = total_pages * repeats;
+    return params;
+}
+
+}  // namespace
+
+ttnn::Tensor repeat_interleave(
+    const ttnn::Tensor& input_a,
+    uint32_t repeats,
+    int32_t dim,
+    const std::optional<MemoryConfig>& output_mem_config,
+    const std::string& implementation) {
+    const MemoryConfig mem_config = output_mem_config.value_or(input_a.memory_config());
+    const ImplementationSelector sel = parse_implementation(implementation);
+
+    if (sel == ImplementationSelector::kNative) {
+        return repeat_interleave_native(input_a, repeats, dim, output_mem_config);
+    }
+
+    const uint32_t normalized_dim = input_a.logical_shape().get_normalized_index(dim);
+
+    if (sel == ImplementationSelector::kCodegen) {
+        TT_FATAL(
+            supported_by_codegen(input_a, repeats, static_cast<int32_t>(normalized_dim)),
+            "ttnn.repeat_interleave: implementation=\"codegen\" is not supported for this input (dim={}, "
+            "repeats={})",
+            dim,
+            repeats);
+        const auto params = build_codegen_params(input_a, repeats, normalized_dim, mem_config);
+        return ttnn::prim::repeat_interleave_codegen(input_a, params);
+    }
+
+    // Auto: codegen iff supported and not perf-demoted; else native.
+    if (supported_by_codegen(input_a, repeats, static_cast<int32_t>(normalized_dim)) &&
+        !is_demoted(input_a, repeats, static_cast<int32_t>(normalized_dim))) {
+        const auto params = build_codegen_params(input_a, repeats, normalized_dim, mem_config);
+        return ttnn::prim::repeat_interleave_codegen(input_a, params);
+    }
+    return repeat_interleave_native(input_a, repeats, dim, output_mem_config);
 }
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/repeat_interleave.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/repeat_interleave.hpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <string>
+
 #include "ttnn/types.hpp"
 
 namespace ttnn {
@@ -11,10 +13,14 @@ namespace ttnn {
 // #   - Shape([2[32], 2[32]]) -> repeats = 2, dim = 0
 // #   - Shape([2[32], 2[32]]) -> repeats = Tensor[1,2], dim = 1
 
+// `implementation` selects "auto" (default; codegen when supported and not perf-demoted, else
+// native), "native" (always the composite host implementation below), or "codegen" (always
+// prim::repeat_interleave_codegen; TT_FATALs if the input is not codegen-supported).
 ttnn::Tensor repeat_interleave(
     const ttnn::Tensor& input_a,
     uint32_t repeats,
     int32_t dim,
-    const std::optional<MemoryConfig>& output_mem_config = std::nullopt);
+    const std::optional<MemoryConfig>& output_mem_config = std::nullopt,
+    const std::string& implementation = "auto");
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/repeat_interleave_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/repeat_interleave_nanobind.cpp
@@ -5,9 +5,11 @@
 #include "repeat_interleave_nanobind.hpp"
 
 #include <optional>
+#include <string>
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/optional.h>
+#include <nanobind/stl/string.h>
 
 #include "ttnn-nanobind/bind_function.hpp"
 
@@ -26,6 +28,7 @@ void bind_repeat_interleave(nb::module_& mod) {
 
         Keyword args:
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
+            implementation (str, optional): "auto" (default), "native", or "codegen".
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -39,7 +42,8 @@ void bind_repeat_interleave(nb::module_& mod) {
         nb::arg("repeats"),
         nb::arg("dim"),
         nb::kw_only(),
-        nb::arg("memory_config") = nb::none());
+        nb::arg("memory_config") = nb::none(),
+        nb::arg("implementation") = "auto");
 }
 
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/data_movement/sources.cmake
@@ -77,6 +77,9 @@ set(TTNN_OP_DATA_MOVEMENT_SRCS
     repeat/device/repeat_utils.cpp
     repeat/repeat.cpp
     repeat_interleave/repeat_interleave.cpp
+    repeat_interleave/codegen/repeat_interleave_codegen_device_operation.cpp
+    repeat_interleave/codegen/repeat_interleave_codegen_program_factory.cpp
+    repeat_interleave/codegen/repeat_interleave_codegen_supported.cpp
     reshape_on_device/device/reshape_op.cpp
     reshape_on_device/device/reshape_tile_program_factory.cpp
     reshape_on_device/device/reshape_rm_program_factory.cpp


### PR DESCRIPTION
## Ported: `repeat_interleave`

Automated port of `repeat_interleave` from tt-dm-codegen into a registered `ttnn.DeviceOperation` + `ProgramFactory` that reuses the generated kernels. Opened as a **draft** by the agentic port pipeline. Confirmed on `blackhole` only — a single-arch port. Cross-arch confirmation and the full CI sweep run via ordinary tt-metal CI.

### Performance
(ratios are worst-case / min across configs)
| arch | verdict | configs | wall | device vs native | device vs generic_op | bw util % |
|---|---|---:|---:|---:|---:|---:|
| blackhole | win | 72 | 1.616 | 1.118 | 0.908 | 1.381 |

#### Top device wins
| arch | layout | shape | kwargs | native device µs | ported device µs | device/native | device/generic_op |
|---|---|---|---|---:|---:|---:|---:|
| blackhole | tile | `[4, 2, 32, 32]` | `dim=0&repeats=2` | 10.296 | 1.214 | 8.481 | 1.018 |
| blackhole | tile | `[2, 1, 32, 32]` | `dim=0&repeats=2` | 8.350 | 0.986 | 8.469 | 0.998 |
| blackhole | tile | `[4, 2, 32, 32]` | `dim=0&repeats=2` | 10.155 | 1.211 | 8.386 | 1.012 |
| blackhole | tile | `[2, 1, 32, 32]` | `dim=0&repeats=2` | 8.201 | 0.982 | 8.351 | 1.004 |
| blackhole | tile | `[1, 1, 32, 32]` | `dim=0&repeats=2` | 7.851 | 0.953 | 8.238 | 0.998 |
| blackhole | tile | `[1, 1, 32, 32]` | `dim=1&repeats=2` | 7.800 | 0.951 | 8.202 | 0.999 |

#### Why it is faster
Native repeat_interleave is a multi-kernel host composite (typecast round-trip to bfloat16, layout conversion, unsqueeze, a batched 32-way concat tree, reshape, and a typecast back) while the codegen path is a single reader/writer kernel pair doing a direct stick- or tile-page copy in the tensor's native dtype.
- repeat_interleave.cpp's repeat_interleave_native forces a bfloat16 typecast + RM layout conversion for any non-bf16 dtype, then builds the repeated result via unsqueeze + concat in batches of 32 tensors (each concat a separate device op with its own intermediate DRAM allocation) before reshaping and typecasting back to the original dtype/layout.
- The generated program factory (repeat_interleave_codegen_program_factory.cpp) issues exactly one reader kernel and one writer kernel that read source pages/sticks via the SEQ_REPEAT_INTERLEAVE address sequencer (or the RM stick readers) and write them out directly in the input dtype, with no intermediate tensors, no typecast, and no concat tree.

### Routing
| route | count | why |
|---|---:|---|
| codegen | 72 | supported and performance-qualified |
| native (correctness fallback) | 24 | 18× sub-tile (last two) dims deferred for TILE path<br>3× within-stick (last W) dim deferred for RM path<br>2× unaligned ROW_MAJOR stick (32B) deferred for RM path<br>1× unaligned ROW_MAJOR stick (16B) deferred for RM path |

### Coverage ledger (final status)
| status | count |
|---|---|
| implemented_passing | 72 |
| proven_infeasible | 0 |
| routing (out-of-scope) | 24 |

Branch: `port/repeat_interleave-repeat_interleave-blackhole-20260715T120329Z` @ `624f67cb3`
Codegen source: `94c963d0b`

<!-- codegen-port-results:v1
{
  "arch": "blackhole",
  "measurements": {
    "correctness": {
      "failing": 0,
      "implemented_passing": 72,
      "not_started": 0,
      "proven_infeasible": 0,
      "routing": 24
    },
    "perf": {
      "blackhole": {
        "bw_util_pct": 1.3812949640287768,
        "device_vs_generic_op": 0.907829839704069,
        "device_vs_native": 1.1180555555555556,
        "top_wins": [
          {
            "case_id": "[4, 2, 32, 32]|dim=0&repeats=2|int32|tile",
            "device_vs_generic_op": 1.0181219110378912,
            "device_vs_native": 8.481054365733113,
            "native_ns": 10296.0,
            "ported_ns": 1214.0,
            "wall_ratio": 4.015410191273162
          },
          {
            "case_id": "[2, 1, 32, 32]|dim=0&repeats=2|int32|tile",
            "device_vs_generic_op": 0.9979716024340771,
            "device_vs_native": 8.468559837728195,
            "native_ns": 8350.0,
            "ported_ns": 986.0,
            "wall_ratio": 3.97850790513834
          },
          {
            "case_id": "[4, 2, 32, 32]|dim=0&repeats=2|float32|tile",
            "device_vs_generic_op": 1.0115606936416186,
            "device_vs_native": 8.38563170933113,
            "native_ns": 10155.0,
            "ported_ns": 1211.0,
            "wall_ratio": 4.027728900702582
          },
          {
            "case_id": "[2, 1, 32, 32]|dim=0&repeats=2|float32|tile",
            "device_vs_generic_op": 1.0040733197556009,
            "device_vs_native": 8.35132382892057,
            "native_ns": 8201.0,
            "ported_ns": 982.0,
            "wall_ratio": 3.9258501011520432
          },
          {
            "case_id": "[1, 1, 32, 32]|dim=0&repeats=2|int32|tile",
            "device_vs_generic_op": 0.9979013641133263,
            "device_vs_native": 8.238195173137461,
            "native_ns": 7851.0,
            "ported_ns": 953.0,
            "wall_ratio": 3.630664288619794
          },
          {
            "case_id": "[1, 1, 32, 32]|dim=1&repeats=2|int32|tile",
            "device_vs_generic_op": 0.9989484752891693,
            "device_vs_native": 8.201892744479496,
            "native_ns": 7800.0,
            "ported_ns": 951.0,
            "wall_ratio": 3.762968237260851
          }
        ],
        "wall_ratio": 1.6159048602722779
      }
    }
  },
  "op": "repeat_interleave",
  "pins": {
    "codegen_commit": "94c963d0b07f1f20070ae68614eb28b8ad803f7e",
    "ttmetal_branch": "port/repeat_interleave-repeat_interleave-blackhole-20260715T120329Z",
    "ttmetal_commit": "624f67cb3af487be9e526a20f6c19151a61e081d"
  }
}
-->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=port/repeat_interleave-repeat_interleave-blackhole-20260715T120329Z)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:port/repeat_interleave-repeat_interleave-blackhole-20260715T120329Z)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=port/repeat_interleave-repeat_interleave-blackhole-20260715T120329Z)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:port/repeat_interleave-repeat_interleave-blackhole-20260715T120329Z)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=port/repeat_interleave-repeat_interleave-blackhole-20260715T120329Z)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:port/repeat_interleave-repeat_interleave-blackhole-20260715T120329Z)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=port/repeat_interleave-repeat_interleave-blackhole-20260715T120329Z)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:port/repeat_interleave-repeat_interleave-blackhole-20260715T120329Z)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=port/repeat_interleave-repeat_interleave-blackhole-20260715T120329Z)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:port/repeat_interleave-repeat_interleave-blackhole-20260715T120329Z)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=port/repeat_interleave-repeat_interleave-blackhole-20260715T120329Z)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:port/repeat_interleave-repeat_interleave-blackhole-20260715T120329Z)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=port/repeat_interleave-repeat_interleave-blackhole-20260715T120329Z)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:port/repeat_interleave-repeat_interleave-blackhole-20260715T120329Z)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=port/repeat_interleave-repeat_interleave-blackhole-20260715T120329Z)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:port/repeat_interleave-repeat_interleave-blackhole-20260715T120329Z)