### PR TITLE
test(deepseek_v3_d_p): fix stale GLM52Adapter import in conftest

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/conftest.py
+++ b/models/demos/deepseek_v3_d_p/tests/conftest.py
@@ -36,7 +36,7 @@ DSV3 = get_adapter("deepseek_v3_d_p")
 # glm_5_2 is a TEST-ONLY variant here: its adapter is intentionally kept out of the shared common
 # ADAPTER_PATHS (prefill serving is not wired), so register it locally for the `variant` fixture
 # without modifying the common prefill registry.
-from models.demos.deepseek_v3_d_p.tt.runners.adapters.sparse_mla import GLM52Adapter
+from models.demos.deepseek_v3_d_p.tt.runners.adapters.glm_5_2 import GLM52Adapter
 
 TEST_VARIANTS["glm_5_2"] = GLM52Adapter()
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config, get_max_payload_size


### PR DESCRIPTION
## Problem

Collecting **any** `models/demos/deepseek_v3_d_p` test currently fails on `main`:

```
ImportError: cannot import name 'GLM52Adapter' from
'models.demos.deepseek_v3_d_p.tt.runners.adapters.sparse_mla'
```

## Root cause

Two PRs landed with a semantic conflict git didn't flag:

- **#49315** (GLM-5.2 cross-layer indexer reuse) added a test-conftest import
  `from ...adapters.sparse_mla import GLM52Adapter` — valid at the time, when
  the adapter still lived in `sparse_mla.py`.
- **#49730** (GLM-5.2 in prefill runner) moved `GLM52Adapter` into the new
  `adapters/glm_5_2.py`, updated `adapters/__init__.py` and the registry, and
  "dropped the old test-only `GLM52Adapter` stub from `sparse_mla.py`" — but did
  not update the conftest import #49315 had added.

Result: `sparse_mla.py` no longer defines `GLM52Adapter`, so the conftest import
raises at collection time.

## Fix

Point the conftest import at `adapters/glm_5_2.py`, matching
`adapters/__init__.py`. One line.

Verified this is the **only** stale reference: `adapters/__init__.py` and
`common/prefill/adapter.py` import only symbols that still exist in
`sparse_mla.py` (`DeepSeekV32Adapter`, `SparseMLAPrefillAdapter`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/fix-glm52adapter-conftest-import)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/fix-glm52adapter-conftest-import)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/fix-glm52adapter-conftest-import)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/fix-glm52adapter-conftest-import)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ipotkonjak/fix-glm52adapter-conftest-import)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ipotkonjak/fix-glm52adapter-conftest-import)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/fix-glm52adapter-conftest-import)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/fix-glm52adapter-conftest-import)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/fix-glm52adapter-conftest-import)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/fix-glm52adapter-conftest-import)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/fix-glm52adapter-conftest-import)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/fix-glm52adapter-conftest-import)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/fix-glm52adapter-conftest-import)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/fix-glm52adapter-conftest-import)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/fix-glm52adapter-conftest-import)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/fix-glm52adapter-conftest-import)