### PR TITLE
test(sparse_mla): size standalone GLM-5.2 index cache to num_full_indexer_layers

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
@@ -27,6 +27,7 @@ from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_reference import (
 )
 from models.demos.deepseek_v3_d_p.tests.test_mla import run_mla_inference
 from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
+from models.demos.deepseek_v3_d_p.tt.mla.indexer import num_full_indexer_layers
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup, interleaved_to_halfsplit_perm
 from models.demos.deepseek_v3_d_p.tt.mla.utils import blockcyclic_positions, rotated_chip_positions
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config, get_max_payload_size
@@ -153,14 +154,20 @@ def _topology_from_device_params(device_params):
 
 def _init_index_kv_cache(config, mesh_device, seq_len, mesh_shape, sp_axis, slot_num=1):
     """Block-cyclic indexer key cache, allocated OUTSIDE ttMLA (mirrors tt_kvpe_cache) and passed into
-    ttMLA.forward(index_kv_cache=...) every call. BF8 (matches BF16 top-k within bf16 noise, half the memory)."""
+    ttMLA.forward(index_kv_cache=...) every call. BF8 (matches BF16 top-k within bf16 noise, half the memory).
+
+    Layer-slot count mirrors the serving adapter (glm_5_2.py allocate_kv_cache): the indexer strides the
+    folded user-major cache by num_full_indexer_layers (only ``full`` layers own an index slot), so the
+    cache must carry that many layer slots for update_padded_kv_cache's cache_batch % num_layers check to
+    hold. Falls back to 1 when the config has no ``indexer_types`` (deepseek_v32 / glm_5_1: every layer full,
+    single-layer standalone MLA -> stride 1)."""
     return init_kvpe_cache(
         kvpe_cache_head_dim=getattr(config, "index_head_dim", 128),
         mesh_device=mesh_device,
         seq_len=seq_len,
         mesh_shape=mesh_shape,
         sp_axis=sp_axis,
-        num_kvpe_cache_layers=1,
+        num_kvpe_cache_layers=num_full_indexer_layers(config) or 1,
         num_users=slot_num,
         dtype=ttnn.bfloat8_b,
     )


### PR DESCRIPTION
## Problem

The GLM-5.2 sparse-MLA standalone tests fatal on `main`:

```
RuntimeError: TT_FATAL ... update_padded_kv_cache_device_operation.cpp:125:
cache_shape[0] % args.num_layers == 0
```

e.g. `test_sparse_mla_rotated[blackhole-maxedge-fabric2d-glm_5_2-8x4-seq5120]`,
and `test_sparse_mla_chunked[...glm_5_2...]`.

## Root cause

The GLM-5.2 cross-layer indexer-reuse feature (#49315) allocates the folded
user-major index KEY cache with **only** `num_full_indexer_layers` slots (shared
layers reuse a prior full layer's top-k and own no slot), so `TtIndexer` strides
the cache by `num_full` and `update_padded_kv_cache` asserts
`cache_shape[0] % num_layers == 0`.

The **serving adapter** sizes the cache correctly
(`adapters/glm_5_2.py::allocate_kv_cache` → `num_full_indexer_layers(hf_config) or
num_layers`), but the **test helper** `_init_index_kv_cache` hardcoded
`num_kvpe_cache_layers=1`. For GLM-5.2 (`num_full > 1`) the cache batch dim (1) is
not divisible by the stride, so the write fatals before any comparison.

Only GLM-5.2 is affected — `deepseek_v32` / `glm_5_1` have no `indexer_types`, so
`num_full_indexer_layers` is `None` and every layer is full.

## Fix

Size the standalone index cache the same way the serving adapter does:
`num_full_indexer_layers(config) or 1`. The single tested layer writes/reads its
compacted-rank slot (rank 0 → slot 0); numerics are unchanged, and non-GLM-5.2
configs fall back to 1 (no behavior change).

Test-only; no runtime/model code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/fix-glm52-index-cache-layers)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/fix-glm52-index-cache-layers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/fix-glm52-index-cache-layers)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/fix-glm52-index-cache-layers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ipotkonjak/fix-glm52-index-cache-layers)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ipotkonjak/fix-glm52-index-cache-layers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/fix-glm52-index-cache-layers)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/fix-glm52-index-cache-layers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/fix-glm52-index-cache-layers)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/fix-glm52-index-cache-layers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/fix-glm52-index-cache-layers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/fix-glm52-index-cache-layers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/fix-glm52-index-cache-layers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/fix-glm52-index-cache-layers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/fix-glm52-index-cache-layers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/fix-glm52-index-cache-layers)