### PR TITLE
indexer_score: consolidate seq-shard axes into a single seq_shard_axes arg

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -570,7 +570,7 @@ class TtIndexer:
         # (block-cyclic-correct, cluster_axis=sp_axis), so every row already carries its true position; now
         # split those rows over TP so each chip scores only S/(sp·tp) of them — indexer_score + topk shrink
         # ~TP×. RoPE is per-row so the split is safe (no 2-D rope op needed). The score is told the TP axis via
-        # seq_subshard_axis below, so its EXACT block-cyclic geometry adds each device's tp_rank*Sq' sub-offset
+        # seq_shard_axes below, so its EXACT block-cyclic geometry adds each device's tp_rank*Sq' sub-offset
         # (rotation-safe). topk runs on the sub-rows; indices are all-gathered back over TP to the [1,1,S/sp,k]
         # contract so mla.py / sparse_sdpa are unchanged (both DeepSeek and GLM ride this one path).
         tpsp = self.tp_factor > 1
@@ -616,11 +616,10 @@ class TtIndexer:
             weights,
             chunk_start_idx=start_pos,
             program_config=cfg,
-            cluster_axis=self.sp_axis,
-            # TP×SP: name the TP axis the query was sub-sharded over so the score adds each device's
-            # tp_rank*Sq' block-cyclic sub-offset — rotation-EXACT (vs the flat cluster_axis=None path,
-            # which is linear-approximate under a mid-slab start). None when the query stays SP-only.
-            seq_subshard_axis=self.tp_axis if tpsp else None,
+            # Seq shard axes, outermost (SP ring) first. TP×SP adds the TP axis so the score adds each
+            # device's tp_rank*Sq' block-cyclic sub-offset — rotation-EXACT (vs the flat [] path, which is
+            # linear-approximate under a mid-slab start). SP-only ([sp]) when the query stays SP-sharded.
+            seq_shard_axes=[self.sp_axis, self.tp_axis] if tpsp else [self.sp_axis],
             cache_batch_idx=None,  # k_full is already sliced to this slot (batch-1) → no in-kernel select
             block_cyclic_sp_axis=self.sp_axis,
             block_cyclic_chunk_local=seq_len,  # cache slab == chunk_size_global / sp (== Sq'·tp when TP-split)

--- a/models/demos/minimax_m3/tests/unit/test_indexer_score_msa_accuracy.py
+++ b/models/demos/minimax_m3/tests/unit/test_indexer_score_msa_accuracy.py
@@ -139,7 +139,7 @@ def test_indexer_score_msa_accuracy(mesh_device, device_params, Sq, T, reset_see
         scale=scale,
         block_size=BLOCK,
         program_config=ttnn.IndexerScoreProgramConfig(q_chunk_size=Q_CHUNK, k_chunk_size=K_CHUNK, head_group_size=0),
-        cluster_axis=None,
+        seq_shard_axes=[],
     )
     dev = ttnn.to_torch(ttnn.get_device_tensors(bs)[0]).float()[0]  # [G, Sq, nblk]
     assert dev.shape == ref.shape, f"shape {tuple(dev.shape)} != {tuple(ref.shape)}"

--- a/models/demos/minimax_m3/tests/unit/test_msa_sp_sharded_vs_ref.py
+++ b/models/demos/minimax_m3/tests/unit/test_msa_sp_sharded_vs_ref.py
@@ -87,7 +87,7 @@ def test_msa_sp_sharded(mesh_device, device_params, chunk_local, reset_seeds):
         scale=scale,
         block_size=BLOCK,
         program_config=ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=1024, head_group_size=0),
-        cluster_axis=sp_axis,
+        seq_shard_axes=[sp_axis],
     )
     bs_dev = ttnn.get_device_tensors(block_scores)
     # Per SP row r, the LAST local query (row 639) is at global r*640+639. Its causal frontier = the count

--- a/models/demos/minimax_m3/tt/attention/msa.py
+++ b/models/demos/minimax_m3/tt/attention/msa.py
@@ -129,7 +129,7 @@ def msa_indexer_sparse(
         num_groups=num_groups,
         block_size=block_size,
         program_config=ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=1024, head_group_size=0),
-        cluster_axis=cluster_axis,
+        seq_shard_axes=[cluster_axis] if cluster_axis is not None else [],
     )
 
     # Top-k block ids (uint32 row-major) — the block selection that encodes causality. The op already

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
@@ -1128,7 +1128,7 @@ def test_indexer_score_qb_sp2_tp2(mesh_device, case_id, heads):
         q_dev,
         k_dev,
         w_dev,
-        cluster_axis=QB2_SP_AXIS,
+        seq_shard_axes=[QB2_SP_AXIS],
         program_config=glx_config(heads // QB2_TP),  # per-device head count
     )
     # Concat SP shards along seq (dim 2) and the TP head-partials along the size-1 head dim (dim 1), then
@@ -1200,7 +1200,7 @@ def test_indexer_score_qb_msa_sp2_tp2(mesh_device):
     out = ttnn.experimental.indexer_score_msa(
         q_dev,
         k_dev,
-        cluster_axis=QB2_SP_AXIS,
+        seq_shard_axes=[QB2_SP_AXIS],
         scale=M3_QB_SCALE,
         num_groups=1,
         program_config=glx_config(M3_QB_HEADS // QB2_TP),  # per-device head count
@@ -1900,7 +1900,7 @@ def test_indexer_score_qb_block_cyclic(mesh_device, case_id, heads):
         q_dev,
         k_dev,
         w_dev,
-        cluster_axis=0,  # SP axis (same axis the cache was striped over)
+        seq_shard_axes=[0],  # SP axis (same axis the cache was striped over)
         block_cyclic_sp_axis=0,
         block_cyclic_chunk_local=QB_SQ,
         program_config=glx_config(heads),
@@ -1910,9 +1910,9 @@ def test_indexer_score_qb_block_cyclic(mesh_device, case_id, heads):
     assert_indexer_match(out_t, ref, QB_CHUNK, QB_T, check_neg=True)
 
 
-# ---- Q sequence sharded across BOTH mesh axes via cluster_axis=None (block_cyclic_chunk_local == tp*q_isl) ----
+# ---- Q sequence sharded across BOTH mesh axes via seq_shard_axes=[] (block_cyclic_chunk_local == tp*q_isl) ----
 # On a 2x2 mesh with K block-cyclic over ONE axis (sp=2, tp=2), Q's sequence is split across all 4 devices.
-# cluster_axis=None ranks device (a,b) by its row-major position in the device list (a*B+b), so the flat
+# seq_shard_axes=[] ranks device (a,b) by its row-major position in the device list (a*B+b), so the flat
 # linearization IS a row-major nested 2D seq shard: device r's q-row 0 sits at base + r*Sq. For a slab-aligned
 # base every device stays inside its slab (no straddle), so the flat shard + block-cyclic remap reassembles to
 # a plain contiguous natural-order scoring of the whole chunk. A NAMED cluster_axis is rejected (its rank would
@@ -1920,10 +1920,10 @@ def test_indexer_score_qb_block_cyclic(mesh_device, case_id, heads):
 @pytest.mark.parametrize("mesh_device", [(2, 2)], ids=["2x2"], indirect=True)
 @pytest.mark.parametrize("case_id, heads", QB_CASES, ids=QB_IDS)
 def test_indexer_score_qb_both_axes_seq(mesh_device, case_id, heads, expect_error):
-    """Q seq sharded across both axes (all 4 devices) with cluster_axis=None: chunk_local == tp*q_isl (tp=2),
-    which the guard allows only for cluster_axis=None. K block-cyclic over sp=2, aligned base -> no straddle,
-    so the reassembled score equals the contiguous natural-order reference. Also asserts a NAMED cluster_axis
-    (which would mis-rank) is still rejected."""
+    """Q seq sharded across both axes (all 4 devices) with seq_shard_axes=[]: chunk_local == tp*q_isl (tp=2),
+    which the guard allows only for seq_shard_axes=[] (flat). K block-cyclic over sp=2, aligned base -> no
+    straddle, so the reassembled score equals the contiguous natural-order reference. Also asserts a lone SP
+    axis (seq_shard_axes=[sp], which would mis-rank) is still rejected."""
     sp, chunk_global, t = 2, 256, 512  # cl=128, Sq per device = 256/4 = 64 (2 tiles); 2 chunks -> >1 slab/shard
     q_g, k_nat, w_g = _global_inputs(heads, chunk_global, t, seed=42)
     k_bc = _to_slab(k_nat, sp, chunk_global)
@@ -1933,16 +1933,16 @@ def test_indexer_score_qb_both_axes_seq(mesh_device, case_id, heads, expect_erro
     k_dev = _to_mesh(mesh_device, k_bc, ttnn.bfloat8_b, ttnn.ReplicateTensorToMesh(mesh_device))
     kw = dict(block_cyclic_sp_axis=0, block_cyclic_chunk_local=chunk_global // sp, program_config=glx_config(heads))
 
-    # cluster_axis=None -> Q linearized row-major over all 4 devices (both axes). chunk_start OMITTED ->
+    # seq_shard_axes=[] -> Q linearized row-major over all 4 devices (both axes). chunk_start OMITTED ->
     # base = T - global_chunk = 256 (slab-aligned). Reassembled == contiguous natural scoring at base.
-    out = ttnn.experimental.indexer_score_dsa(q_dev, k_dev, w_dev, cluster_axis=None, **kw)
+    out = ttnn.experimental.indexer_score_dsa(q_dev, k_dev, w_dev, seq_shard_axes=[], **kw)
     out_t = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=2))
     ref = indexer_score_dsa_ref(q_g, k_nat, w_g, t - chunk_global)
     assert_indexer_match(out_t, ref, chunk_global, t, check_neg=True)
 
-    # A NAMED cluster_axis with tp*q_isl is rejected (rank would miss the second axis's seq offset).
-    with expect_error(RuntimeError, "NAMED cluster_axis"):
-        ttnn.experimental.indexer_score_dsa(q_dev, k_dev, w_dev, cluster_axis=0, **kw)
+    # A lone SP axis with tp*q_isl is rejected (rank would miss the second axis's seq offset).
+    with expect_error(RuntimeError, "needs the TP axis"):
+        ttnn.experimental.indexer_score_dsa(q_dev, k_dev, w_dev, seq_shard_axes=[0], **kw)
 
 
 @pytest.mark.parametrize("mesh_device", [(1, 4)], ids=["sp1xtp4"], indirect=True)
@@ -1964,8 +1964,7 @@ def test_indexer_score_sp1_tp4_seq_subshard(mesh_device):
         k_dev,
         w_dev,
         chunk_start_idx=chunk_start,
-        cluster_axis=0,
-        seq_subshard_axis=1,
+        seq_shard_axes=[0, 1],
         block_cyclic_sp_axis=0,
         block_cyclic_chunk_local=chunk,
         program_config=ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=64, head_group_size=0),
@@ -1978,8 +1977,7 @@ def test_indexer_score_sp1_tp4_seq_subshard(mesh_device):
         q_dev,
         k_dev,
         w_dev,
-        cluster_axis=0,
-        seq_subshard_axis=1,
+        seq_shard_axes=[0, 1],
         block_cyclic_sp_axis=0,
         block_cyclic_chunk_local=chunk,
         program_config=ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=64, head_group_size=0),
@@ -2010,8 +2008,7 @@ def test_indexer_score_sp1_tp4_rejects_undersized_causal_window(mesh_device, exp
             k_dev,
             w_dev,
             chunk_start_idx=chunk_start,
-            cluster_axis=0,
-            seq_subshard_axis=1,
+            seq_shard_axes=[0, 1],
             block_cyclic_sp_axis=0,
             block_cyclic_chunk_local=chunk,
             program_config=ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=64, head_group_size=0),
@@ -2037,8 +2034,7 @@ def test_indexer_score_sp2_tp2_seq_subshard_rotated(mesh_device):
         k_dev,
         w_dev,
         chunk_start_idx=chunk_start,
-        cluster_axis=0,
-        seq_subshard_axis=1,
+        seq_shard_axes=[0, 1],
         block_cyclic_sp_axis=0,
         block_cyclic_chunk_local=chunk // sp,
         program_config=ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=64, head_group_size=0),
@@ -2162,7 +2158,7 @@ def test_indexer_score_qb_straddle(mesh_device, case_id, heads):
             k_dev,
             w_dev,
             chunk_start_idx=chunk_start,
-            cluster_axis=0,
+            seq_shard_axes=[0],
             block_cyclic_sp_axis=0,
             block_cyclic_chunk_local=ST_CHUNK // sp,
             program_config=cfg,
@@ -2199,7 +2195,7 @@ def test_indexer_score_qb_msa_block_cyclic(mesh_device):
     out = ttnn.experimental.indexer_score_msa(
         q_dev,
         k_dev,
-        cluster_axis=0,
+        seq_shard_axes=[0],
         scale=M3_QB_SCALE,
         num_groups=1,
         block_cyclic_sp_axis=0,
@@ -2232,7 +2228,7 @@ def test_indexer_score_qb_msa_block_cyclic_straddle(mesh_device):
         q_dev,
         k_dev,
         chunk_start_idx=ST_CS,  # explicit, mid-slab -> offset 64 -> straddle
-        cluster_axis=0,
+        seq_shard_axes=[0],
         scale=M3_QB_SCALE,
         num_groups=1,
         block_size=bs,

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
@@ -7,6 +7,8 @@
 #include <algorithm>
 #include <cmath>
 #include <tuple>
+#include <utility>
+#include <vector>
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/hal.hpp>
@@ -18,14 +20,14 @@
 namespace ttnn::operations::experimental::indexer_score {
 
 namespace {
-// Largest linearized index of q's devices along cluster_axis (0 on a single device). Single source for the
-// worst-case window check (max_chunk_start) and the host-side chunk_start deduction, so a future change to
-// the coord/linearization semantics can't desync the deduced base from the validated window.
-uint32_t max_linearized_rank(const Tensor& q, std::optional<uint32_t> cluster_axis) {
+// Largest linearized index of q's devices along the given mesh axis (0 on a single device). Single source
+// for the worst-case window check (max_chunk_start) and the host-side chunk_start deduction, so a future
+// change to the coord/linearization semantics can't desync the deduced base from the validated window.
+uint32_t max_linearized_rank(const Tensor& q, std::optional<uint32_t> axis) {
     uint32_t max_rank = 0;
     if (q.device_storage().get_coords().size() > 1) {
         for (const auto& coord : q.device_storage().get_coords()) {
-            max_rank = std::max(max_rank, ttnn::ccl::get_linearized_index_from_physical_coord(q, coord, cluster_axis));
+            max_rank = std::max(max_rank, ttnn::ccl::get_linearized_index_from_physical_coord(q, coord, axis));
         }
     }
     return max_rank;
@@ -43,8 +45,8 @@ uint32_t max_chunk_start(const operation_attributes_t& attrs, const Tensor& q, u
     if (attrs.block_cyclic.has_value()) {
         return attrs.chunk_start_idx + attrs.block_cyclic->sp * attrs.block_cyclic->chunk_local - Sq;
     }
-    const uint32_t tp_rank = attrs.seq_subshard_axis.has_value() ? max_linearized_rank(q, attrs.seq_subshard_axis) : 0u;
-    return attrs.chunk_start_idx + (max_linearized_rank(q, attrs.cluster_axis) + tp_rank) * Sq;
+    const uint32_t tp_rank = attrs.tp_axis().has_value() ? max_linearized_rank(q, attrs.tp_axis()) : 0u;
+    return attrs.chunk_start_idx + (max_linearized_rank(q, attrs.sp_axis()) + tp_rank) * Sq;
 }
 
 // Miss-only checks: hash-pinned (placement, non-indexed k batch shape) so they can't differ on a hit. The
@@ -188,8 +190,10 @@ ttsl::hash::hash_t IndexerScoreDeviceOperation::compute_program_hash(
     const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
     // Hash what shapes the binary, NOT the runtime values: chunk_start_idx is EXCLUDED, cache_batch_idx /
     // kv_len contribute only has_value() (so distinct slot / kv_len / chunk_start reuse one program).
-    // cluster_axis IS hashed; tensor_args cover dtype + shape. apply_relu / num_groups / block_size pick the
-    // compile-time kernel path, so they MUST be hashed (else DSA vs MSA, or pooled vs unpooled, would collide).
+    // The seq-shard axes ARE hashed (they shape the causal geometry); tensor_args cover dtype + shape.
+    // apply_relu / num_groups / block_size pick the compile-time kernel path, so they MUST be hashed (else
+    // DSA vs MSA, or pooled vs unpooled, would collide). Hash via the SP/TP accessors so the key is identical
+    // to the pre-consolidation (cluster_axis, seq_subshard_axis) form.
     return tt::tt_metal::operation::hash_operation<IndexerScoreDeviceOperation>(
         attrs.apply_relu,
         attrs.num_groups,
@@ -198,10 +202,10 @@ ttsl::hash::hash_t IndexerScoreDeviceOperation::compute_program_hash(
         attrs.gate_scale,       // the in-kernel fill value; distinct scales get distinct programs
         attrs.program_config,
         attrs.compute_kernel_config,
-        attrs.cluster_axis.has_value(),
-        attrs.cluster_axis.value_or(0u),
-        attrs.seq_subshard_axis.has_value(),
-        attrs.seq_subshard_axis.value_or(0u),
+        attrs.sp_axis().has_value(),
+        attrs.sp_axis().value_or(0u),
+        attrs.tp_axis().has_value(),
+        attrs.tp_axis().value_or(0u),
         attrs.has_indexed_kv_cache(),
         attrs.has_runtime_kv_len(),
         // The block-cyclic layout bakes invP divisors into the reader as compile-time arguments, so sp/chunk_local
@@ -455,14 +459,12 @@ IndexerScoreDeviceOperation::invoke(
     const DeviceComputeKernelConfig& compute_kernel_config,
     std::optional<uint32_t> cache_batch_idx,
     std::optional<uint32_t> kv_len,
-    std::optional<uint32_t> cluster_axis,
-    std::optional<uint32_t> seq_subshard_axis,
+    std::vector<uint32_t> seq_shard_axes,
     std::optional<BlockCyclicLayout> block_cyclic) {
     return {
         operation_attributes_t{
             .chunk_start_idx = chunk_start_idx,
-            .cluster_axis = cluster_axis,
-            .seq_subshard_axis = seq_subshard_axis,
+            .seq_shard_axes = std::move(seq_shard_axes),
             .apply_relu = apply_relu,
             .num_groups = num_groups,
             .block_size = block_size,
@@ -482,6 +484,24 @@ namespace ttnn::experimental {
 
 namespace {
 
+// seq_shard_axes names the mesh axes the query seq is sharded over, outermost (SP ring) -> innermost (TP
+// sub-shard). Decompose to the (SP, TP) roles the validation + causal geometry use: {} -> (none, none) =
+// linear device order; {sp} -> (sp, none); {sp, tp} -> (sp, tp). allow_subshard is false for MSA (no TP
+// sub-shard -> at most one axis).
+std::pair<std::optional<uint32_t>, std::optional<uint32_t>> split_seq_shard_axes(
+    const std::vector<uint32_t>& axes, bool allow_subshard) {
+    const uint32_t max_axes = allow_subshard ? 2u : 1u;
+    TT_FATAL(
+        axes.size() <= max_axes,
+        "indexer_score: seq_shard_axes takes at most {} axis/axes [SP{}], got {}",
+        max_axes,
+        allow_subshard ? ", TP" : "",
+        axes.size());
+    return {
+        axes.empty() ? std::nullopt : std::optional<uint32_t>(axes[0]),
+        axes.size() >= 2 ? std::optional<uint32_t>(axes[1]) : std::nullopt};
+}
+
 // Shared launch path for both frontends: resolve the compute-kernel config from the matmul-input dtypes,
 // then pack and launch the one device op. The flavour knobs are decided by the caller below.
 ttnn::Tensor launch_indexer_score(
@@ -498,10 +518,12 @@ ttnn::Tensor launch_indexer_score(
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
     std::optional<uint32_t> cache_batch_idx,
     std::optional<uint32_t> kv_len,
-    std::optional<uint32_t> cluster_axis,
-    std::optional<uint32_t> seq_subshard_axis,
+    std::vector<uint32_t> seq_shard_axes,
+    bool allow_subshard,
     std::optional<uint32_t> block_cyclic_sp_axis,
     std::optional<uint32_t> block_cyclic_chunk_local) {
+    // Decompose the seq-shard axes into the SP/TP roles the validation + causal geometry below reason about.
+    const auto [cluster_axis, seq_subshard_axis] = split_seq_shard_axes(seq_shard_axes, allow_subshard);
     using OperationType = ttnn::operations::experimental::indexer_score::IndexerScoreDeviceOperation;
     using ttnn::operations::experimental::indexer_score::BlockCyclicLayout;
 
@@ -518,10 +540,11 @@ ttnn::Tensor launch_indexer_score(
         "(got sp_axis={}, chunk_local={})",
         block_cyclic_sp_axis.has_value(),
         block_cyclic_chunk_local.has_value());
-    // seq_subshard_axis (2D TP sub-shard) only means anything with a block-cyclic layout; reject a stray one.
+    // seq_shard_axes[1] (2D TP sub-shard) only means anything with a block-cyclic layout; reject a stray one.
     TT_FATAL(
         !seq_subshard_axis.has_value() || block_cyclic_sp_axis.has_value(),
-        "indexer_score: seq_subshard_axis requires a block-cyclic layout (block_cyclic_sp_axis/chunk_local)");
+        "indexer_score: seq_shard_axes[1] (TP sub-shard) requires a block-cyclic layout "
+        "(block_cyclic_sp_axis/chunk_local)");
     std::optional<BlockCyclicLayout> block_cyclic = std::nullopt;
     if (block_cyclic_sp_axis.has_value()) {
         const auto mesh_shape = q.device()->get_view().shape();
@@ -545,29 +568,31 @@ ttnn::Tensor launch_indexer_score(
             Sq * tp);
         // Seq sharded across BOTH axes (chunk_local == tp*q_isl, tp > 1) needs the second axis's seq offset.
         // Two ways to supply it:
-        //   (a) cluster_axis=None -> the flat row-major device rank (a*B+b) folds BOTH axes in, so the LINEAR
+        //   (a) seq_shard_axes=[] -> the flat row-major device rank (a*B+b) folds BOTH axes in, so the LINEAR
         //       chunk_start is each device's position -- but that linear form is only exact for a slab-aligned
         //       (boundary_chip == 0) start; mid-slab (rotated) starts drift (see device_causal_geometry).
-        //   (b) a NAMED cluster_axis (SP) PLUS seq_subshard_axis (the TP axis) -> the EXACT block-cyclic
-        //       geometry (mirroring rotated_chip_positions) adds the tp_rank*Sq sub-offset. Rotation-exact.
-        // A named cluster_axis WITHOUT seq_subshard_axis would miss the TP offset entirely -- reject that.
+        //   (b) seq_shard_axes=[SP, TP] -> the EXACT block-cyclic geometry (mirroring rotated_chip_positions)
+        //       adds the tp_rank*Sq sub-offset. Rotation-exact.
+        // A lone SP axis (seq_shard_axes=[SP]) would miss the TP offset entirely -- reject that.
         const bool both_axes = (chunk_local == Sq * tp && tp > 1);
         TT_FATAL(
             !(both_axes && cluster_axis.has_value() && !seq_subshard_axis.has_value()),
-            "indexer_score: block_cyclic_chunk_local == tp*q_isl (tp={} > 1) with a NAMED cluster_axis needs "
-            "seq_subshard_axis (the TP axis) so the second axis's seq offset is applied; or use cluster_axis=None.",
+            "indexer_score: block_cyclic_chunk_local == tp*q_isl (tp={} > 1) with seq_shard_axes=[SP] needs the "
+            "TP axis too (seq_shard_axes=[SP, TP]) so the second axis's seq offset is applied; or pass "
+            "seq_shard_axes=[] (flat linearization).",
             tp);
         if (seq_subshard_axis.has_value()) {
             TT_FATAL(
                 cluster_axis.has_value() && both_axes,
-                "indexer_score: seq_subshard_axis needs a named cluster_axis (SP) and a 2D seq shard "
-                "(block_cyclic_chunk_local == tp*q_isl); got has_cluster_axis={}, chunk_local={}, Sq*tp={}",
+                "indexer_score: seq_shard_axes TP axis needs the SP axis present (seq_shard_axes=[SP, TP]) and a "
+                "2D seq shard (block_cyclic_chunk_local == tp*q_isl); got has_sp_axis={}, chunk_local={}, Sq*tp={}",
                 cluster_axis.has_value(),
                 chunk_local,
                 Sq * tp);
             TT_FATAL(
                 *seq_subshard_axis < mesh_shape.dims() && *seq_subshard_axis != *cluster_axis,
-                "indexer_score: seq_subshard_axis ({}) must be an in-range mesh axis distinct from cluster_axis ({})",
+                "indexer_score: seq_shard_axes TP axis ({}) must be an in-range mesh axis distinct from the SP "
+                "axis ({})",
                 *seq_subshard_axis,
                 *cluster_axis);
         }
@@ -640,8 +665,7 @@ ttnn::Tensor launch_indexer_score(
         resolved,
         cache_batch_idx,
         kv_len,
-        cluster_axis,
-        seq_subshard_axis,
+        std::move(seq_shard_axes),
         block_cyclic);
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
@@ -657,8 +681,7 @@ ttnn::Tensor indexer_score_dsa(
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
     std::optional<uint32_t> cache_batch_idx,
     std::optional<uint32_t> kv_len,
-    std::optional<uint32_t> cluster_axis,
-    std::optional<uint32_t> seq_subshard_axis,
+    const std::optional<std::vector<uint32_t>>& seq_shard_axes,
     std::optional<uint32_t> block_cyclic_sp_axis,
     std::optional<uint32_t> block_cyclic_chunk_local) {
     // DSA/GLM: relu, learned per-head gates, one head-summed plane, no pooling. Reads its real weights tensor.
@@ -676,8 +699,8 @@ ttnn::Tensor indexer_score_dsa(
         compute_kernel_config,
         cache_batch_idx,
         kv_len,
-        cluster_axis,
-        seq_subshard_axis,
+        seq_shard_axes.value_or(std::vector<uint32_t>{}),
+        /*allow_subshard=*/true,
         block_cyclic_sp_axis,
         block_cyclic_chunk_local);
 }
@@ -693,7 +716,7 @@ ttnn::Tensor indexer_score_msa(
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
     std::optional<uint32_t> cache_batch_idx,
     std::optional<uint32_t> kv_len,
-    std::optional<uint32_t> cluster_axis,
+    const std::optional<std::vector<uint32_t>>& seq_shard_axes,
     std::optional<uint32_t> block_cyclic_sp_axis,
     std::optional<uint32_t> block_cyclic_chunk_local) {
     // M3 has no learned gates, only a 1/sqrt(d) scale. Rather than materialize a constant [B,Hi,Sq,1] gate
@@ -717,8 +740,8 @@ ttnn::Tensor indexer_score_msa(
         compute_kernel_config,
         cache_batch_idx,
         kv_len,
-        cluster_axis,
-        /*seq_subshard_axis=*/std::nullopt,
+        seq_shard_axes.value_or(std::vector<uint32_t>{}),
+        /*allow_subshard=*/false,  // MSA has no TP sub-shard
         block_cyclic_sp_axis,
         block_cyclic_chunk_local);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
@@ -7,6 +7,7 @@
 #include <optional>
 #include <tuple>
 #include <variant>
+#include <vector>
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operation.hpp"
@@ -25,7 +26,7 @@ struct IndexerScoreDeviceOperation {
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
 
     // Custom hash: runtime values (cache_batch_idx / kv_len / chunk_start_idx) are excluded so they reuse
-    // one program; cluster_axis IS hashed.
+    // one program; the seq_shard_axes (SP/TP) ARE hashed.
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
@@ -53,8 +54,7 @@ struct IndexerScoreDeviceOperation {
         const DeviceComputeKernelConfig& compute_kernel_config,
         std::optional<uint32_t> cache_batch_idx,
         std::optional<uint32_t> kv_len,
-        std::optional<uint32_t> cluster_axis,
-        std::optional<uint32_t> seq_subshard_axis,
+        std::vector<uint32_t> seq_shard_axes,
         std::optional<BlockCyclicLayout> block_cyclic);
 };
 
@@ -72,10 +72,14 @@ namespace ttnn::experimental {
 // (block_cyclic_sp_axis) and passes the per-shard chunk length (block_cyclic_chunk_local); `sp` is DERIVED
 // from the mesh shape on that axis, so a caller cannot pass an sp that disagrees with the device.
 // block_cyclic_chunk_local must be q_isl (seq sharded only on the SP axis) or tp*q_isl (tp = mesh/sp). Both
-// set together, or neither = contiguous K (no remap); sp==1 is the identity. Seq sharded across BOTH axes
-// (chunk_local == tp*q_isl, tp>1) is allowed ONLY with cluster_axis=None (flat row-major linearization over
-// all devices == a row-major nested 2D seq shard); with a NAMED cluster_axis it is rejected (chunk_start
-// would miss the second axis's seq offset).
+// set together, or neither = contiguous K (no remap); sp==1 is the identity.
+//
+// SEQ SHARD AXES: seq_shard_axes names the mesh axes the query seq is sharded over, outermost (SP ring)
+// first: [] = linear device order, [sp] = 1D SP ring, [sp, tp] = 2D SP + TP sub-shard. Seq sharded across
+// BOTH axes (chunk_local == tp*q_isl, tp>1) has two forms: seq_shard_axes=[] (flat row-major linearization
+// over all devices, exact only for a slab-aligned start), or [sp, tp] (the EXACT block-cyclic geometry that
+// adds the TP sub-offset; rotation-safe). A lone SP axis ([sp]) with tp*q_isl is rejected (would miss the
+// second axis's seq offset). The two axis roles map internally to (cluster_axis, seq_subshard_axis).
 
 // DeepSeek-V3.2 DSA / GLM-5 (ttnn.experimental.indexer_score_dsa):
 //   score[b, 0, s, t] = sum_h relu(q[b,h,s,:] . k[b,t,:]) * weights[b,h,s]
@@ -91,8 +95,7 @@ ttnn::Tensor indexer_score_dsa(
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
     std::optional<uint32_t> cache_batch_idx = std::nullopt,
     std::optional<uint32_t> kv_len = std::nullopt,
-    std::optional<uint32_t> cluster_axis = std::nullopt,
-    std::optional<uint32_t> seq_subshard_axis = std::nullopt,
+    const std::optional<std::vector<uint32_t>>& seq_shard_axes = std::nullopt,
     std::optional<uint32_t> block_cyclic_sp_axis = std::nullopt,
     std::optional<uint32_t> block_cyclic_chunk_local = std::nullopt);
 
@@ -102,8 +105,9 @@ ttnn::Tensor indexer_score_dsa(
 // tensor). q [B,Hi,Sq,D], k [B,1,T,D] -> score [B,num_groups,Sq,T_out].
 // num_groups: G output planes (no cross-group sum); G==1 = TP=4 group-aligned (Hi=1/device), G>1 needs all
 //   heads resident + k_chunk>=64. block_size: 0 = full [B,G,Sq,T]; >0 = block-max-pool -> [B,G,Sq,T/bs].
-// chunk_start_idx / cluster_axis / cache_batch_idx / kv_len: same semantics as indexer_score_dsa (the last
-// two are runtime, hash-excluded pass-throughs -- no recompile when the slot or valid length changes).
+// chunk_start_idx / seq_shard_axes / cache_batch_idx / kv_len: same semantics as indexer_score_dsa (the last
+// two are runtime, hash-excluded pass-throughs -- no recompile when the slot or valid length changes). MSA
+// has no TP sub-shard, so seq_shard_axes takes at most one axis ([sp]).
 // num_groups is required (no default): per-GQA-group selection is MSA's purpose, so the caller must state
 // the group count explicitly. It is placed before the defaulted optionals so the signature stays well-formed.
 ttnn::Tensor indexer_score_msa(
@@ -117,7 +121,7 @@ ttnn::Tensor indexer_score_msa(
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
     std::optional<uint32_t> cache_batch_idx = std::nullopt,
     std::optional<uint32_t> kv_len = std::nullopt,
-    std::optional<uint32_t> cluster_axis = std::nullopt,
+    const std::optional<std::vector<uint32_t>>& seq_shard_axes = std::nullopt,
     std::optional<uint32_t> block_cyclic_sp_axis = std::nullopt,
     std::optional<uint32_t> block_cyclic_chunk_local = std::nullopt);
 

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <optional>
+#include <vector>
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
@@ -35,13 +36,19 @@ using ttnn::prim::BlockCyclicLayout;
 struct operation_attributes_t {
     // Absolute chunk_start of rank 0. Rank r uses chunk_start_idx + r*Sq; the per-device value is derived
     // host-side and passed to compute as a RUNTIME arg (hash-excluded), so distinct values reuse one program.
-    uint32_t chunk_start_idx{0};             // elements, tile-aligned
-    std::optional<uint32_t> cluster_axis{};  // mesh axis that is the SP ring; unset = linear device order
-    // Second mesh axis (TP) that the query sequence is ALSO block-cyclically sub-sharded over, on top of the
-    // SP block-cyclic layout. When set (alongside a named cluster_axis + block_cyclic), each device owns a
-    // Sq-row sub-range [tp_rank*Sq, (tp_rank+1)*Sq) of its SP chip's chunk_local-wide slab; the causal geometry
-    // adds that TP sub-offset to the exact block-cyclic position. unset = query sharded on the SP axis only.
-    std::optional<uint32_t> seq_subshard_axis{};
+    uint32_t chunk_start_idx{0};  // elements, tile-aligned
+    // Mesh axes the query sequence is sharded over, outermost (SP ring) first: {} = linear device order,
+    // {sp} = 1D SP ring, {sp, tp} = 2D SP ring + TP sub-shard. The SP axis sets each device's causal offset;
+    // the optional TP axis (only alongside an SP axis + block_cyclic) adds a Sq-row sub-offset so each device
+    // owns [tp_rank*Sq, (tp_rank+1)*Sq) of its SP chip's chunk_local slab. Read via sp_axis()/tp_axis().
+    // Hashed via those accessors (it shapes the causal geometry, so distinct shardings get distinct programs).
+    std::vector<uint32_t> seq_shard_axes{};
+    std::optional<uint32_t> sp_axis() const {
+        return seq_shard_axes.empty() ? std::nullopt : std::optional<uint32_t>(seq_shard_axes.front());
+    }
+    std::optional<uint32_t> tp_axis() const {
+        return seq_shard_axes.size() >= 2 ? std::optional<uint32_t>(seq_shard_axes[1]) : std::nullopt;
+    }
     // ReLU on each per-head q.kT before the gate-mul. true = DSA/GLM (relu(q.k)*w); false = raw dot (M3 MSA).
     // Compile-time, so the true path is byte-identical to before.
     bool apply_relu{true};

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
@@ -60,7 +60,7 @@ constexpr uint32_t writer_straddle_jump_tiles = 1 + 9;
 //       (chunk_global - chunk_local) tiles at q-row (chunk_local - offset).
 // The linear form only misses (a) when boundary_chip != 0 -- exactly the mid-slab, non-chip-0-start case
 // (e.g. the multi-turn rotated prefill). Chunk-aligned (offset == 0, boundary_chip == 0) reduces to linear.
-// No block_cyclic -> plain linear. The both-axes case (cluster_axis unset, block_cyclic_chunk_local == tp*Sq)
+// No block_cyclic -> plain linear. The both-axes case (seq_shard_axes=[], block_cyclic_chunk_local == tp*Sq)
 // keeps the prior linear+straddle form. Shared by create_at (device_index from the coordinate) and override
 // (stored device_index).
 struct DeviceCausalGeometry {
@@ -83,10 +83,10 @@ inline DeviceCausalGeometry device_causal_geometry(
     const uint32_t chunk_local = args.block_cyclic->chunk_local;  // cache per-shard slab width (elements)
     const uint32_t chunk_global = sp * chunk_local;
 
-    if (args.cluster_axis.has_value()) {
+    if (args.sp_axis().has_value()) {
         TT_FATAL(
             device_index < sp,
-            "indexer_score: device_index {} out of range for block-cyclic sp={} (check cluster_axis vs "
+            "indexer_score: device_index {} out of range for block-cyclic sp={} (check seq_shard_axes[0] vs "
             "block_cyclic_sp_axis)",
             device_index,
             sp);
@@ -112,7 +112,7 @@ inline DeviceCausalGeometry device_causal_geometry(
         return {logical_start / TW, straddle_q_tile, straddle_jump_tiles};
     }
 
-    // Both-axes (cluster_axis unset): prior linear + within-block straddle geometry.
+    // Both-axes (seq_shard_axes=[], SP axis unset): prior linear + within-block straddle geometry.
     const uint32_t chunk_start = args.chunk_start_idx + device_index * Sq;
     const uint32_t offset = chunk_start % chunk_local;
     uint32_t straddle_q_tile = 0, straddle_jump_tiles = 0;
@@ -129,7 +129,7 @@ inline uint32_t device_index_for(
     if (q.device_storage().get_coords().size() <= 1) {
         return 0;
     }
-    return ttnn::ccl::get_linearized_index_from_physical_coord(q, coord, args.cluster_axis);
+    return ttnn::ccl::get_linearized_index_from_physical_coord(q, coord, args.sp_axis());
 }
 
 // Patch one runtime-arg slot on a program-cache hit, asserting the slot exists.
@@ -175,13 +175,12 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create_
     const uint32_t T = k.logical_shape()[2];
 
     // This device's SP-ring index and chunk_start (tiles), from the coordinate. chunk_t is a compute RUNTIME
-    // arg, so the binary is identical across coords and steps. tp_index = its rank along seq_subshard_axis
-    // (the 2D SP×TP query sub-shard); 0 when not sub-sharded or single-device.
+    // arg, so the binary is identical across coords and steps. tp_index = its rank along the TP axis
+    // (seq_shard_axes[1], the 2D SP×TP query sub-shard); 0 when not sub-sharded or single-device.
     const uint32_t device_index = device_index_for(args, coord, q);
-    const uint32_t tp_index =
-        (args.seq_subshard_axis.has_value() && q.device_storage().get_coords().size() > 1)
-            ? ttnn::ccl::get_linearized_index_from_physical_coord(q, coord, args.seq_subshard_axis)
-            : 0u;
+    const uint32_t tp_index = (args.tp_axis().has_value() && q.device_storage().get_coords().size() > 1)
+                                  ? ttnn::ccl::get_linearized_index_from_physical_coord(q, coord, args.tp_axis())
+                                  : 0u;
     const auto geom = device_causal_geometry(args, device_index, tp_index, Sq);
     const uint32_t chunk_t = geom.chunk_start_tiles;
 

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.hpp
@@ -20,8 +20,8 @@ struct IndexerScoreSharedVariables {
     // This device's linearized SP-ring index (from its mesh coordinate); chunk_start = base + idx*stride.
     // Stored so override_runtime_arguments can recompute chunk_start for new base/stride on a cache hit.
     uint32_t device_index = 0;
-    // This device's TP-rank along seq_subshard_axis (0 when not 2D-sub-sharded); the 2D block-cyclic geometry
-    // adds tp_index*Sq to the slab position. Stored for the same override recompute.
+    // This device's TP-rank along the TP axis (seq_shard_axes[1]; 0 when not 2D-sub-sharded); the 2D block-cyclic
+    // geometry adds tp_index*Sq to the slab position. Stored for the same override recompute.
     uint32_t tp_index = 0;
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
@@ -4,6 +4,8 @@
 
 #include "indexer_score_nanobind.hpp"
 
+#include <nanobind/stl/vector.h>
+
 #include "ttnn-nanobind/bind_function.hpp"
 #include "indexer_score.hpp"
 
@@ -38,10 +40,10 @@ void bind_indexer_score(nb::module_& mod) {
             weights: [B, Hi, Sq, 1] bf16 tiled learned per-head gates (scale
                 pre-folded)
             chunk_start_idx: absolute global position of rank 0's query row 0
-                (rank 0 = lowest cluster_axis coord; causality: key t visible to
-                query s iff t <= chunk_start + s). OMIT on a mesh -> deduced as
-                T - sp_ring*Sq (sp_ring = mesh extent along cluster_axis, whole
-                mesh if unset). Single device: set to history + rank*Sq per rank.
+                (rank 0 = lowest seq_shard_axes[0] (SP) coord; causality: key t
+                visible to query s iff t <= chunk_start + s). OMIT on a mesh ->
+                deduced as T - sp_ring*Sq (sp_ring = mesh extent along the SP axis,
+                whole mesh if unset). Single device: set to history + rank*Sq per rank.
             program_config: work-unit knobs (q_chunk_size, k_chunk_size,
                 head_group_size; elements, tile-aligned). Defaults always fit
                 L1; raise head_group_size (0 = all resident) for performance.
@@ -58,18 +60,18 @@ void bind_indexer_score(nb::module_& mod) {
                 chunk_start_idx + Sq <= kv_len. Re-applied each dispatch, so a
                 serving loop growing kv_len (<= T) reuses one program -- no
                 recompile. Only output columns [0, kv_len) are written.
-            cluster_axis: mesh axis that is the SP ring. On a mesh, device r uses
-                chunk_start = chunk_start_idx + r*Sq, where r is its linearized
-                index along this axis (Sq = q seq len). None = linear device order
-                (1 on a single device, so chunk_start_idx is used as-is).
-            seq_subshard_axis: optional int, the SECOND mesh axis (TP) the query seq is
-                block-cyclically sub-sharded over, on top of the SP block-cyclic layout.
-                Set it alongside a named cluster_axis + block_cyclic when the query rows
-                are further split across TP (block_cyclic_chunk_local == tp*q_isl): the
-                exact geometry adds tp_rank*Sq to each device's block-cyclic position, so
-                the causal mask stays correct under rotated (mid-slab) starts — unlike the
-                cluster_axis=None flat path, which is linear-approximate there. Requires a
-                block-cyclic layout and an axis distinct from cluster_axis.
+            seq_shard_axes: the mesh axes the query seq is sharded over, outermost
+                (SP ring) first: [] = linear device order (single device / whole-mesh
+                ring, chunk_start_idx used as-is), [sp] = 1D SP ring, [sp, tp] = 2D SP
+                ring + TP sub-shard. The SP axis (seq_shard_axes[0]) sets each device's
+                causal offset: device r along it uses chunk_start = chunk_start_idx +
+                r*Sq (Sq = q seq len). The optional TP axis (seq_shard_axes[1]) is the
+                SECOND axis the query seq is block-cyclically sub-sharded over; set it
+                (with a block-cyclic layout, when block_cyclic_chunk_local == tp*q_isl)
+                so the exact geometry adds tp_rank*Sq to each device's block-cyclic
+                position, keeping the causal mask correct under rotated (mid-slab) starts
+                — unlike the flat [] path, which is linear-approximate there. The TP axis
+                must be in range and distinct from the SP axis.
             block_cyclic_sp_axis: optional int. The MESH AXIS the K cache was striped
                 over (chunked prefill + SP all-gather leaves [B,1,T,D] k in per-SP-shard
                 slab / block-cyclic physical order). ``sp`` is DERIVED from the mesh
@@ -82,11 +84,10 @@ void bind_indexer_score(nb::module_& mod) {
                 The per-shard chunk length (chunk_size_global / sp). Cross-checked
                 against q: must equal q_isl (Sq, seq sharded only on the SP axis) or
                 tp*q_isl (tp = mesh_size/sp). The tp*q_isl case with tp>1 (seq sharded
-                across BOTH axes) has two forms: with cluster_axis=None it uses flat
-                row-major linearization over all devices (linear-approximate under a
-                mid-slab start); with a named cluster_axis it must also pass
-                seq_subshard_axis naming the TP axis, which gives the rotation-exact 2D
-                geometry (see seq_subshard_axis above).
+                across BOTH axes) has two forms: seq_shard_axes=[] uses flat row-major
+                linearization over all devices (linear-approximate under a mid-slab
+                start); seq_shard_axes=[sp, tp] names both axes, giving the rotation-exact
+                2D geometry (see seq_shard_axes above).
 
         Returns: score [B, 1, Sq, T] bf16 row-major; future/pad columns -inf.
         )doc",
@@ -100,8 +101,7 @@ void bind_indexer_score(nb::module_& mod) {
         nb::arg("compute_kernel_config") = std::nullopt,
         nb::arg("cache_batch_idx") = std::nullopt,
         nb::arg("kv_len") = std::nullopt,
-        nb::arg("cluster_axis") = std::nullopt,
-        nb::arg("seq_subshard_axis") = std::nullopt,
+        nb::arg("seq_shard_axes") = std::nullopt,
         nb::arg("block_cyclic_sp_axis") = std::nullopt,
         nb::arg("block_cyclic_chunk_local") = std::nullopt);
 
@@ -154,9 +154,9 @@ void bind_indexer_score(nb::module_& mod) {
                 blocks are written). Re-applied each dispatch (a serving loop
                 growing kv_len reuses one program). Only columns/blocks within
                 the valid prefix are written.
-            cluster_axis: mesh axis that is the SP ring. On a mesh, device r uses
-                chunk_start = chunk_start_idx + r*Sq, where r is its linearized
-                index along this axis. None = linear device order.
+            seq_shard_axes: the mesh axes the query seq is sharded over. MSA has no
+                TP sub-shard, so at most one axis: [] = linear device order, [sp] = SP
+                ring (device r along it uses chunk_start = chunk_start_idx + r*Sq).
             block_cyclic_sp_axis / block_cyclic_chunk_local: same semantics as
                 indexer_score_dsa. block_cyclic_sp_axis = the MESH AXIS the K cache
                 was striped over (sp derived from the mesh shape on that axis) and
@@ -180,7 +180,7 @@ void bind_indexer_score(nb::module_& mod) {
         nb::arg("compute_kernel_config") = std::nullopt,
         nb::arg("cache_batch_idx") = std::nullopt,
         nb::arg("kv_len") = std::nullopt,
-        nb::arg("cluster_axis") = std::nullopt,
+        nb::arg("seq_shard_axes") = std::nullopt,
         nb::arg("block_cyclic_sp_axis") = std::nullopt,
         nb::arg("block_cyclic_chunk_local") = std::nullopt);
 }


### PR DESCRIPTION
Follow-up to #49496 (review comment from @ipotkonjak-tt): fold the indexer_score op's two scalar sequence-shard axis args — `cluster_axis` (SP ring) and `seq_subshard_axis` (TP sub-shard) — into a single ordered list `seq_shard_axes`.

## API

Outermost (SP ring) axis first:

| `seq_shard_axes` | meaning |
|---|---|
| `None` / `[]` (or omitted) | linear device order (single device / whole-mesh ring) |
| `[sp]` | 1D SP ring |
| `[sp, tp]` | 2D SP ring + TP sub-shard |

`block_cyclic_sp_axis` / `block_cyclic_chunk_local` stay separate — they name the **K-cache stripe** layout, a distinct concern, and the part that mirrors `ttnn.transformer.sparse_sdpa` (which has neither `cluster_axis` nor `seq_subshard_axis`). Applies to both `indexer_score_dsa` and `indexer_score_msa` (MSA takes at most `[sp]`).

## Why a list

The two axes weren't independent: `seq_subshard_axis` was only ever valid alongside a named `cluster_axis` + block-cyclic 2D shard, and had to differ from it. A variable-length list makes "the query seq is sharded over these axes, in order" one concept and makes the illegal "TP without SP" state unrepresentable.

## Implementation notes

- Public arg is `std::optional<std::vector<uint32_t>>` so Python `None` is accepted (`None` == `[]` == omitted).
- Consistent through the whole stack: `operation_attributes_t` stores the vector with named `sp_axis()` / `tp_axis()` accessors used by the causal geometry, program factory, and hashing. **Hashing reads through those accessors, so the program-cache key is byte-identical to the pre-consolidation form** — no recompile-behavior change.
- User-facing `TT_FATAL` messages reworded to `seq_shard_axes` terms.

## Test plan

Pure API refactor — compiled behavior unchanged (program-cache key byte-identical). Mapped CI is long / Galaxy-gated, so validated locally on a LoudBox (8× Blackhole, `scripts/run_safe_pytest.sh`) at head `29e74cd`:

| Test | Covers | Result |
|---|---|---|
| `test_indexer_score.py` | op (DSA+MSA), all `seq_shard_axes` geometry (`[]`/`[sp]`/`[sp,tp]`/rotated/rejects) | 142 passed, 5 skipped (perf) |
| `test_indexer_score_msa_accuracy.py` | `indexer_score_msa` accuracy | 3 passed (PCC 0.9996) |
| `test_msa_prefill_vs_ref.py` | MSA prefill chain | 1 passed |
| 8×1 `seq_shard_axes=[sp]` repro | migrated MSA caller + `msa_indexer_sparse` e2e | PASS (causal frontier exact) |

Re-validated locally after rebasing onto `main` (`822f15b`): `test_indexer_score.py` 142 passed / 5 skipped, `test_indexer_score_msa_accuracy.py` 3 passed (PCC 0.999582), `test_msa_prefill_vs_ref.py` 1 passed (PCC 0.9999). The committed `test_msa_sp_sharded_vs_ref.py` is Galaxy-only (needs a (8,4) mesh) so it stays a local 8×1 manual repro.

### CI — selected & triggered for this change

Smallest pipeline flavors covering the changed DSA indexer path (`indexer_score` op + DeepSeek `indexer.py` → `indexer_score_dsa`), dispatched on this branch.

[![Blaze Models Prefill tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=mvasilijevic/indexer_api&event=workflow_dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml?query=branch%3Amvasilijevic%2Findexer_api)
[![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=mvasilijevic/indexer_api&event=workflow_dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch%3Amvasilijevic%2Findexer_api)

**Run analysis** (`f4c2dab`): the DSA path this PR changes passed on hardware — `bh_lb_DeepSeek_DSA` ✅ and blaze `DSA MLA (V3.2)` ✅. Failures are unrelated: blaze GLM = 16-min **timeout** (finished sub-cases passed; same content green on LoudBox); blackhole `PREFILL`/`OP_TESTS`/`PERF` = **pre-existing MoE** failures, outside this diff.

| Pill | Test target | Covers |
|---|---|---|
| blaze · `dsa_mla` | `sparse_mla/test_sparse_mla.py -k "deepseek_v32 and 8x4 and line"` | DeepSeek-V3.2 sparse (DSA) MLA — `indexer_score_dsa` |
| blaze · `dsa_mla_glm` | `sparse_mla/test_sparse_mla.py -k "(glm_5_1 and 8x4 and line) or indexer_reuse"` | GLM-5.1 DSA + GLM-5.2 indexer-reuse equivalence |
| blackhole-e2e · LoudBox | `bh-lb-deepseek-dsa` (+ prefill / MLA / op-tests / perf) | V3.2 + GLM-5.1 DSA on LoudBox (8× Blackhole) — the local-validation SKU |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mvasilijevic/indexer_api)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mvasilijevic/indexer_api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mvasilijevic/indexer_api)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mvasilijevic/indexer_api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mvasilijevic/indexer_api)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mvasilijevic/indexer_api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mvasilijevic/indexer_api)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mvasilijevic/indexer_api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mvasilijevic/indexer_api)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mvasilijevic/indexer_api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mvasilijevic/indexer_api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mvasilijevic/indexer_api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mvasilijevic/indexer_api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mvasilijevic/indexer_api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mvasilijevic/indexer_api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mvasilijevic/indexer_api)


