### PR TITLE
fix(mla): guard dense k_chunk=640 against DeepSeek-V3.1 L1 OOM

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -423,6 +423,11 @@ class ttMLA:
             weight_cache_path=self.weight_cache_path,
             cache_name_prefix=f"layer_{layer_idx}.mla",
         )
+        # DSA *family* (config carries the indexer fields), independent of whether the indexer is
+        # active this layer. V3.1's dense config lacks them; V3.2's config has them even when a
+        # benchmark forces the attention dense (has_indexer=False). Dense-path tuning gates that must
+        # tell V3.1 from a dense-run V3.2 key on this, not _has_indexer (see _get_sdpa_program_config).
+        self._is_dsa_family = TtIndexer.matches_config(config)
         # GLM-5.2 indexer reuse: a "shared" layer is sparse but owns no indexer weights — it reuses the
         # most recent "full" layer's top-k indices, injected at forward, and binds a weight-less
         # ReuseIndexer (never computes). Absent indexer_types (v3.1 / v3.2 / GLM-5.1) every layer is
@@ -625,6 +630,17 @@ class ttMLA:
         # Like the matmul configs, an SDPA config may be head-count specific (the chunked 640 entry
         # was tuned for Kimi's 64 heads). Fall back to defaults when it doesn't match this model.
         if cfg is not None and cfg.get("num_heads") not in (None, self.num_heads):
+            cfg = None
+        # The 640 tiling's shape is head-agnostic, but its dense-path L1 footprint (full-context K over
+        # every head) only fits large head counts for the DSA family. This config is consumed ONLY on
+        # the dense path (ring_mla / ring_joint SDPA); sparse V3.2/GLM go through sparse_sdpa and never
+        # reach here. The dense consumers are pure-dense V3.1 (128 heads) and Kimi (64), plus a
+        # dense-run V3.2 benchmark (128 heads, DSA family). V3.1 and V3.2 are dimensionally identical,
+        # so num_heads can't separate them — key on the DSA family. Above dense_head_cap_non_dsa,
+        # non-DSA models (V3.1) OOM L1 at k=640, so fall back to the k=32 default; DSA-family V3.2 is
+        # exempt (validated dense) and Kimi stays under the cap.
+        cap = cfg.get("dense_head_cap_non_dsa") if cfg is not None else None
+        if cap is not None and self.num_heads > cap and not self._is_dsa_family:
             cfg = None
         # The 640 chunk tiling drives ring joint attention and is only valid in chunked mode.
         if cfg is not None and cfg.get("chunked_only") and not self.is_chunked:

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla_config.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla_config.py
@@ -365,6 +365,7 @@ MLA_SDPA_CONFIG = {
         "q_chunk_size": 32,
         "k_chunk_size": 640,
         "num_heads": None,
+        "dense_head_cap_non_dsa": 64,
         "chunked_only": True,
     },
 }


### PR DESCRIPTION
### Problem

PR #49729 made the dense `640`-seq SDPA entry head-agnostic (`num_heads: 64 → None`) to speed up dense chunked-prefill at DeepSeek's 128 heads. That entry is consumed **only on the dense path** (`ring_mla` / `ring_joint_scaled_dot_product_attention`); sparse V3.2/GLM go through `sparse_sdpa` and never reach it.

In production the only 128-head dense consumer is **DeepSeek-V3.1**, which now picks `k_chunk=640` (full-context K over 128 heads) and **OOMs L1**. Kimi (64 heads) already matched at 64; the dsv32 speedup the PR reports is a dense-*proxy* benchmark (V3.2 dims run dense), not the production sparse path.

### Why not just re-gate on `num_heads`

V3.1 and V3.2 are dimensionally identical (128 heads, `q_lora_rank=1536`, same head dims), so `num_heads`/`q_lora_rank` can't separate them. The distinguishing signal is the **DSA config family**: V3.2's config carries the indexer fields (`index_topk`/`index_n_heads`/`index_head_dim`), V3.1's does not — and that holds even when a benchmark runs V3.2 with the attention forced dense (`has_indexer=False`).

### Change

- `mla.py`: add `self._is_dsa_family = TtIndexer.matches_config(config)` — the config-field family, independent of whether the indexer is *active* this layer (`_has_indexer`).
- `mla.py` `_get_sdpa_program_config`: above the cap, skip the tuned config for non-DSA models.
- `mla_config.py`: add `"dense_head_cap_non_dsa": 64` to the `640` SDPA entry.

Net effect on the dense consumers of this config:

| model | heads | DSA family | k_chunk |
|-------|-------|-----------|---------|
| DeepSeek-V3.1 | 128 | no | **32 (fallback — OOM fixed)** |
| DeepSeek-V3.2 (dense-run) | 128 | yes | 640 (kept) |
| Kimi | 64 | no | 640 (kept, under cap) |
| GLM-5.1 | 64 | yes | 640 (kept; sparse in prod → uses `sparse_sdpa`) |

The matmul `640` configs were untouched by #49729 (still gated `num_heads: 64`), so V3.1's matmuls already fall back correctly — only the SDPA entry was the regression.

### Validation

Discriminator verified against the real config builders (`DeepSeekV3Config`, `deepseek_v32_hf_config`, `glm_hf_config`): V3.1 → not DSA-family → 640 skipped; V3.2 → DSA-family → 640 kept; GLM → kept. Device validation (V3.1 chunked prefill) needs a Galaxy; not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/guard-v31-dense-kchunk-oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/guard-v31-dense-kchunk-oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/guard-v31-dense-kchunk-oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/guard-v31-dense-kchunk-oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ipotkonjak/guard-v31-dense-kchunk-oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ipotkonjak/guard-v31-dense-kchunk-oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/guard-v31-dense-kchunk-oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/guard-v31-dense-kchunk-oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/guard-v31-dense-kchunk-oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/guard-v31-dense-kchunk-oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/guard-v31-dense-kchunk-oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/guard-v31-dense-kchunk-oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/guard-v31-dense-kchunk-oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/guard-v31-dense-kchunk-oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/guard-v31-dense-kchunk-oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/guard-v31-dense-kchunk-oom)