### PR TITLE
#45821: migrate AdamWDeviceOperation (tt-train) to default program-cache hash

### DIFF
--- a/tt-train/sources/ttml/metal/optimizers/adamw/device/adamw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/optimizers/adamw/device/adamw_device_operation.cpp
@@ -99,19 +99,6 @@ AdamWDeviceOperation::tensor_return_value_t AdamWDeviceOperation::create_output_
     return tensor_args.param;
 }
 
-ttsl::hash::hash_t AdamWDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    const auto& param_tensor = tensor_args.param;
-    const auto& param_logical_shape = param_tensor.logical_shape();
-    auto amsgrad = args.amsgrad;
-    auto stochastic_rounding = args.stochastic_rounding;
-    auto max_exp_avg_sq_initialized = tensor_args.max_exp_avg_sq.has_value();
-    auto hash = tt::tt_metal::operation::hash_operation<AdamWDeviceOperation>(
-        amsgrad, stochastic_rounding, max_exp_avg_sq_initialized, param_tensor.dtype(), param_logical_shape);
-
-    return hash;
-}
-
 }  // namespace ttml::metal::optimizers::adamw::device
 
 namespace ttnn::prim {

--- a/tt-train/sources/ttml/metal/optimizers/adamw/device/adamw_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/optimizers/adamw/device/adamw_device_operation.hpp
@@ -25,8 +25,6 @@ struct AdamWDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
-
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttml::metal::optimizers::adamw::device

--- a/tt-train/sources/ttml/metal/optimizers/adamw/device/adamw_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/optimizers/adamw/device/adamw_device_operation_types.hpp
@@ -6,6 +6,7 @@
 
 #include <optional>
 #include <ttnn/tensor/tensor.hpp>
+#include <tuple>
 
 #include "metal/common/const_utils.hpp"
 
@@ -21,6 +22,11 @@ struct operation_attributes_t {
     float weight_decay{};
     bool amsgrad{false};
     StochasticRounding stochastic_rounding{StochasticRounding::Disabled};
+
+    static constexpr auto attribute_names = std::forward_as_tuple("amsgrad", "stochastic_rounding");
+    auto attribute_values() const {
+        return std::forward_as_tuple(amsgrad, stochastic_rounding);
+    }
 };
 
 struct tensor_args_t {
@@ -30,6 +36,27 @@ struct tensor_args_t {
     const ttnn::Tensor& exp_avg;
     const ttnn::Tensor& exp_avg_sq;
     std::optional<ttnn::Tensor> max_exp_avg_sq = std::nullopt;
+
+    static constexpr auto attribute_names = std::forward_as_tuple(
+        "max_exp_avg_sq_initialized",
+        "param_dtype",
+        "param_logical_shape",
+        "param",
+        "grad",
+        "exp_avg",
+        "exp_avg_sq",
+        "max_exp_avg_sq");
+    auto attribute_values() const {
+        return std::make_tuple(
+            max_exp_avg_sq.has_value(),
+            param.dtype(),
+            std::cref(param.logical_shape()),
+            std::cref(param),
+            std::cref(grad),
+            std::cref(exp_avg),
+            std::cref(exp_avg_sq),
+            max_exp_avg_sq);
+    }
 };
 
 using tensor_return_value_t = ttnn::Tensor;


### PR DESCRIPTION
### PR Category
hash calculation unification for operation AdamWDeviceOperation (tt-train)

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for AdamWDeviceOperation (tt-train)

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_AdamWDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_AdamWDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_AdamWDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_AdamWDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_AdamWDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_AdamWDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_AdamWDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_AdamWDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_AdamWDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_AdamWDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_AdamWDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_AdamWDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_AdamWDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_AdamWDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_AdamWDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_AdamWDeviceOperation_tt-train)
