### PR TITLE
glm chunked prefill: e2e perf timing + padding-correct populated-KV gather

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -1567,8 +1567,8 @@ def test_ds_prefill_transformer_chunked_no_pcc(
 
 # GLM (glm_5_1 / glm_5_2) counterpart of the no-PCC perf sweep: same chunked driver, sparse (DSA) path.
 # Reports end-to-end prefill time — the per-iteration total ("iter {it} done ... in Xs") and the per-chunk
-# median/stddev table — for the two GLM variants at matched ISL (n_chunks x CHUNK) and num_layers. No PCC,
-# no golden-trace dependency (record-only). Uses the GLM fabric payload + on-device fp32 gate + L1_SMALL
+# median/stddev table — for the two GLM variants at matched ISL (n_chunks x CHUNK) and num_layers. No PCC;
+# the empty-cache case (preload0) needs no golden trace, preload_isl > 0 requires it. Uses the GLM fabric payload + on-device fp32 gate + L1_SMALL
 # routing semaphores, exactly like test_glm_prefill_transformer_chunked. glm_5_2 additionally exercises the
 # DSA cross-layer indexer reuse per chunk. Requires the GLM TTNN weight cache (set the variant's cache env).
 @pytest.mark.parametrize(
@@ -1584,6 +1584,7 @@ def test_ds_prefill_transformer_chunked_no_pcc(
 # up to that point. Pair with n_chunks=1 to sweep single-chunk ratio vs depth. 0 = start from empty cache.
 # Chunk-multiple KV depths to seed before measuring. Depths within the ~55k golden trace use real KV; the
 # rest (e.g. preload95k) fills random KV beyond the trace so larger ISLs than the trace can be measured.
+# Requires a golden trace when >0.
 @pytest.mark.parametrize(
     "preload_isl",
     [0, 5 * CHUNK, 10 * CHUNK, 19 * CHUNK],

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -1597,16 +1597,17 @@ def test_ds_prefill_transformer_chunked_no_pcc(
         pytest.param(
             (8, 4),
             {
-                # Ring fabric (FABRIC_1D_RING + Topology.Ring): the production transport for the GLM
-                # chunked-prefill perf measurement.
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+                # FABRIC_2D + Topology.Linear: the production transport for the GLM chunked-prefill
+                # perf measurement. RELAXED_INIT is required for FABRIC_2D bring-up on BH Galaxy.
+                "fabric_config": ttnn.FabricConfig.FABRIC_2D,
                 "fabric_router_config": create_fabric_router_config(max_payload_size=GLM51Config.FABRIC_PAYLOAD_SIZE),
+                "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
                 # Small L1_SMALL region for the MoE routing all-gather's global semaphores
                 # (use_l1_small_for_semaphores); see test_glm_prefill_transformer_chunked.
                 "l1_small_size": 512,
             },
             2,
-            ttnn.Topology.Ring,
+            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="mesh-8x4",
         ),

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -1021,10 +1021,9 @@ def run_chunked_transformer_no_pcc(
     attends to REAL prior KV — the MoE gate then sees realistic hidden states and routes representatively
     (a zero prefix would degrade routing). preload_isl>0 therefore requires a trace (set PREFILL_TRACE_DIR);
     KV depths beyond the trace length are filled with random KV (still non-degenerate for routing) so larger
-    ISLs than the trace can be exercised. NOTE: by default the KVPE gather is full-cache-width (SEQ_CACHE_NOPCC)
-    every chunk, so that fixed component does not grow with preload_isl. Set TT_MLA_GATHER_POPULATED_KV=1 to
-    trim the gather to the populated KV depth (preload_isl + measured chunks) instead, so the measured gather
-    cost tracks the real valid length (more realistic per-depth perf).
+    ISLs than the trace can be exercised. NOTE: the sparse KVPE gather trims to the populated KV depth
+    (preload_isl + measured chunks, rounded up to whole block-cyclic slabs), so the measured gather cost
+    tracks the real valid length and grows with preload_isl (realistic per-depth perf).
 
     Perf gate: when `baseline_chunk_times_s` is provided (a per-chunk list of baseline medians pulled
     from a known-good CI run), each chunk's measured median must stay within +/- `perf_margin` of its

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -40,10 +40,15 @@ from models.common.utility_functions import is_blackhole, profiler
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
-from models.demos.deepseek_v3_d_p.tt.mla.indexer import num_full_indexer_layers, resolve_has_indexer
-from models.demos.deepseek_v3_d_p.tt.mla.utils import blockcyclic_positions, rotated_chip_positions
+from models.demos.deepseek_v3_d_p.tt.mla.indexer import full_indexer_rank, num_full_indexer_layers, resolve_has_indexer
+from models.demos.deepseek_v3_d_p.tt.mla.utils import (
+    blockcyclic_cache_host,
+    blockcyclic_positions,
+    rotated_chip_positions,
+)
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
+from models.demos.deepseek_v3_d_p.tt.tt_prefill_block import get_block_timings, reset_block_timings
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_transformer import TtPrefillTransformer
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
 from tests.ttnn.utils_for_testing import comp_pcc
@@ -151,10 +156,13 @@ def _load_layer_rows(
     trace_dir: Path, layout: str, group: str, layer: int, key: str, start: int, end: int
 ) -> torch.Tensor:
     """Read trace tensor `key` rows [start:end] (float32) for `layer`, handling both layouts. `group`
-    is the logical bucket: "hidden_states" (decoder_io for Kimi) or "kv_cache"."""
+    is the logical bucket: "hidden_states" (decoder_io for Kimi), "kv_cache", or "dsa" (indexer-K, stored
+    as dsa/<key>/ where key == indexer_k_layer_<layer>, like decoder_io)."""
     if layout == _LAYOUT_CHUNKED_GROUP_A:
         if group == "hidden_states":
             tensor_dir = trace_dir / "decoder_io" / key
+        elif group == "dsa":
+            tensor_dir = trace_dir / "dsa" / key
         else:
             tensor_dir = trace_dir / "kv_cache" / f"layer_{layer}"
         return _read_sharded_rows(tensor_dir, key, start, end)
@@ -198,6 +206,118 @@ def _record_kv_cache_pcc(
         cache_min_pcc[i] = min(pcc_nope, pcc_pe)
         logger.info(f"  cache layer {i} PCC: nope={pcc_nope:.6f} pe(interleaved)={pcc_pe:.6f}")
     logger.info(f"KV cache min PCC across layers: {min(cache_min_pcc.values()):.6f}")
+
+
+def _preload_kvpe_prefix_from_trace(
+    tt_kvpe_cache,
+    trace_dir,
+    layout,
+    num_layers,
+    preload_isl,
+    trace_len,
+    sp,
+    seq_len_cache,
+    kvpe_dim,
+    kv_lora,
+    mesh_device,
+    sp_axis,
+    host_dtype,
+    host_layout,
+):
+    """Preload the first `preload_isl` tokens of each layer's prior KV into the block-cyclic device KVPE
+    cache, so a chunk measured at KV depth preload_isl attends to REAL prior KV (representative MoE routing)
+    instead of the zero-init prefix. Mirrors test_mla.py's chunked preload: per layer read the natural-order
+    prior KV from the trace's kv_post_transform, re-interleave the k_pe slice (the trace stores HF half-split;
+    the device cache is Meta interleaved), lay it out block-cyclic, and copy host->device.
+
+    Rows past `trace_len` (the trace only goes so deep) are filled with RANDOM KV so we can still exercise
+    KV depths beyond the trace — random keeps the MoE gate non-degenerate (unlike a zero prefix), which is
+    all this no-PCC timing run needs. The indexer key cache is preloaded separately from the golden
+    dsa/indexer_k trace (see _preload_indexer_k_prefix_from_trace)."""
+    real_len = min(preload_isl, trace_len)
+    rand_len = preload_isl - real_len
+    logger.info(
+        f"Preloading {preload_isl}-token KV prefix into {num_layers} layer slot(s) "
+        f"({real_len} real from trace {trace_dir}, {rand_len} random beyond the trace)"
+    )
+    # Build the replicated host cache in bf16 (the sparse KVPE cache dtype), not float32: at num_layers=78
+    # x SEQ_CACHE_NOPCC the float32 tensor would be ~19 GB. Per-layer transients (randn/blockcyclic) are
+    # freed each iteration, so the peak is this one bf16 tensor plus a single layer's working set.
+    cache_host = torch.zeros(num_layers, 1, seq_len_cache, kvpe_dim, dtype=torch.bfloat16)
+    d = kvpe_dim - kv_lora
+    gen = torch.Generator().manual_seed(1234)  # deterministic random tail
+    for i in range(num_layers):
+        kv_prior = torch.randn(preload_isl, kvpe_dim, generator=gen).to(torch.bfloat16)
+        if real_len > 0:
+            real = _load_layer_rows(trace_dir, layout, "kv_cache", i, f"kv_post_transform_layer_{i}", 0, real_len)
+            pe = real[:, kv_lora:]
+            real[:, kv_lora:] = torch.stack([pe[:, : d // 2], pe[:, d // 2 :]], dim=-1).reshape(pe.shape[0], d)
+            kv_prior[:real_len] = real.to(torch.bfloat16)
+        cache_host[i, 0] = blockcyclic_cache_host(kv_prior, sp, CHUNK, seq_len_cache, kvpe_dim)[0, 0]
+    cache_shard_dims = [None, None]
+    cache_shard_dims[sp_axis] = 2  # SP-shard the cache seq dim; TP-replicate (matches init_kvpe_cache)
+    cache_host_tt = ttnn.from_torch(
+        cache_host,
+        dtype=host_dtype,
+        layout=host_layout,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=cache_shard_dims),
+    )
+    ttnn.copy_host_to_device_tensor(cache_host_tt, tt_kvpe_cache)
+    ttnn.synchronize_device(mesh_device)
+
+
+def _preload_indexer_k_prefix_from_trace(
+    tt_index_kv_cache,
+    trace_dir,
+    layout,
+    config,
+    num_layers,
+    preload_isl,
+    trace_len,
+    sp,
+    seq_len_cache,
+    index_head_dim,
+    mesh_device,
+    sp_axis,
+):
+    """Preload the first `preload_isl` tokens of the DSA indexer key cache from the golden dsa/indexer_k
+    trace, so a measured chunk at KV depth preload_isl has a REAL indexer prefix (representative top-k
+    selection at depth) rather than a zero prior. Only "full" indexer layers own a cache slot / have a
+    golden (glm_5_1: all; glm_5_2: 0-2 + every 4th); layer i is written to its compacted slot
+    full_indexer_rank(config, i), and the cache is strided by num_full_indexer_layers. The golden
+    index_head_dim key is [rope | nope] already in the device's interleaved basis (GLM), so it is written
+    verbatim -- no re-interleave (unlike KVPE's k_pe half-split -> interleaved). Rows past the trace are
+    random (timing-representative). Mirrors _preload_kvpe_prefix_from_trace otherwise."""
+    full_layers = [i for i in range(num_layers) if (trace_dir / "dsa" / f"indexer_k_layer_{i}").exists()]
+    if not full_layers:
+        logger.info(f"no indexer_k golden in trace {trace_dir}; leaving the indexer prefix zero")
+        return
+    num_slots = num_full_indexer_layers(config) or num_layers
+    real_len = min(preload_isl, trace_len)
+    rand_len = preload_isl - real_len
+    logger.info(
+        f"Preloading {preload_isl}-token indexer-K prefix into {len(full_layers)} full-indexer slot(s) "
+        f"({real_len} real from trace, {rand_len} random beyond the trace)"
+    )
+    cache_host = torch.zeros(num_slots, 1, seq_len_cache, index_head_dim, dtype=torch.bfloat16)
+    gen = torch.Generator().manual_seed(2345)  # deterministic random tail (distinct from the KVPE seed)
+    for i in full_layers:
+        idx_prior = torch.randn(preload_isl, index_head_dim, generator=gen).to(torch.bfloat16)
+        if real_len > 0:
+            real = _load_layer_rows(trace_dir, layout, "dsa", i, f"indexer_k_layer_{i}", 0, real_len)
+            idx_prior[:real_len] = real.to(torch.bfloat16)
+        slot = full_indexer_rank(config, i)
+        cache_host[slot, 0] = blockcyclic_cache_host(idx_prior, sp, CHUNK, seq_len_cache, index_head_dim)[0, 0]
+    cache_shard_dims = [None, None]
+    cache_shard_dims[sp_axis] = 2  # SP-shard the cache seq dim; TP-replicate (matches init_kvpe_cache)
+    cache_host_tt = ttnn.from_torch(
+        cache_host,
+        dtype=ttnn.bfloat8_b,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=cache_shard_dims),
+    )
+    ttnn.copy_host_to_device_tensor(cache_host_tt, tt_index_kv_cache)
+    ttnn.synchronize_device(mesh_device)
 
 
 def run_chunked_transformer_padded(
@@ -885,12 +1005,26 @@ def run_chunked_transformer_no_pcc(
     routing_use_l1_small_for_semaphores=False,
     baseline_chunk_times_s=None,
     perf_margin=None,
+    preload_isl=0,
 ):
     """No-PCC perf/smoke variant of run_chunked_transformer: build the transformer ONCE, then drive the
     full n_chunks-chunk prefill `num_iters` times with return_intermediates=False (no per-layer host
     readback, no PCC). Tokens are the real (longbook) ids from the golden trace when present, else a
     deterministic in-vocab pattern, so this is trace-optional. The KV cache is reused across iterations
-    (each chunk overwrites the same [0, total_len) region in order).
+    (each chunk overwrites the same [preload_isl, preload_isl + measured_len) region in order).
+
+    `preload_isl` (must be a multiple of CHUNK): treat the cache as already holding this many prior KV
+    tokens, so the measured chunks run at absolute KV positions [preload_isl, preload_isl + n_chunks*CHUNK)
+    instead of starting at 0. This lets the MLA-vs-FFN ratio be measured at a target KV depth WITHOUT first
+    running chunked prefill up to that point. The prior [0, preload_isl) KVPE is preloaded from the golden
+    trace (kv_post_transform, block-cyclic; see _preload_kvpe_prefix_from_trace) so the measured chunk
+    attends to REAL prior KV — the MoE gate then sees realistic hidden states and routes representatively
+    (a zero prefix would degrade routing). preload_isl>0 therefore requires a trace (set PREFILL_TRACE_DIR);
+    KV depths beyond the trace length are filled with random KV (still non-degenerate for routing) so larger
+    ISLs than the trace can be exercised. NOTE: by default the KVPE gather is full-cache-width (SEQ_CACHE_NOPCC)
+    every chunk, so that fixed component does not grow with preload_isl. Set TT_MLA_GATHER_POPULATED_KV=1 to
+    trim the gather to the populated KV depth (preload_isl + measured chunks) instead, so the measured gather
+    cost tracks the real valid length (more realistic per-depth perf).
 
     Perf gate: when `baseline_chunk_times_s` is provided (a per-chunk list of baseline medians pulled
     from a known-good CI run), each chunk's measured median must stay within +/- `perf_margin` of its
@@ -978,15 +1112,20 @@ def run_chunked_transformer_no_pcc(
     assert (sp, tp) == (8, 4), f"this test targets mesh-8x4, got {mesh_shape}"
 
     chunk_local = CHUNK // sp  # 640
-    total_len = n_chunks * CHUNK
-    assert total_len <= SEQ_CACHE_NOPCC, f"{n_chunks} chunks ({total_len}) exceed cache {SEQ_CACHE_NOPCC}"
+    assert preload_isl % CHUNK == 0, f"preload_isl ({preload_isl}) must be a multiple of CHUNK ({CHUNK})"
+    measured_len = n_chunks * CHUNK  # tokens actually run this call
+    total_len = preload_isl + measured_len  # logical seq length: preloaded prefix + measured chunks
+    assert (
+        total_len <= SEQ_CACHE_NOPCC
+    ), f"preload_isl {preload_isl} + {n_chunks} chunks ({measured_len}) = {total_len} exceed cache {SEQ_CACHE_NOPCC}"
 
     kvpe_dim = config.qk_rope_head_dim + config.kv_lora_rank
     config.max_seq_len = SEQ_CACHE_NOPCC
 
     logger.info(
         f"chunked transformer (no-PCC): num_layers={num_layers} mesh={mesh_shape} n_chunks={n_chunks} "
-        f"total_len={total_len} cache={SEQ_CACHE_NOPCC} chunk={CHUNK} num_iters={num_iters}"
+        f"preload_isl={preload_isl} total_len={total_len} cache={SEQ_CACHE_NOPCC} chunk={CHUNK} "
+        f"num_iters={num_iters}"
     )
 
     iteration_chunk_times: list[list[float]] = []
@@ -1000,13 +1139,20 @@ def run_chunked_transformer_no_pcc(
         trace_dir = _resolve_trace_dir(variant)
     except FileNotFoundError:
         trace_dir = None
+    # preload_isl needs REAL prior KV (for representative MoE routing), which only the golden trace has.
+    # KV depths beyond the trace are filled with random KV in the preload (see helper), so a trace is
+    # required for preload_isl>0 but preload_isl may exceed the trace length.
+    if preload_isl > 0 and (trace_dir is None or not trace_dir.exists()):
+        pytest.skip(f"preload_isl={preload_isl} requires a golden trace; none found (set PREFILL_TRACE_DIR)")
+    trace_native_len = 0  # native token/KV length of the trace; 0 when no trace
     if trace_dir is not None and trace_dir.exists():
         trace_tokens = _load_metadata_token_ids(trace_dir, total_len)
+        trace_native_len = trace_tokens.numel()
         if trace_tokens.numel() < total_len:
             reps = (total_len + trace_tokens.numel() - 1) // trace_tokens.numel()
             trace_tokens = trace_tokens.repeat(reps)[:total_len]
         token_ids_full = trace_tokens % vocab_size
-        logger.info(f"no-PCC: loaded {token_ids_full.numel()} token ids from trace {trace_dir}")
+        logger.info(f"no-PCC: loaded {trace_native_len} token ids from trace {trace_dir}")
     else:
         token_ids_full = torch.arange(total_len, dtype=torch.int64) % vocab_size
         logger.info(f"no-PCC: trace not found ({trace_dir}); using synthetic token ids")
@@ -1047,6 +1193,11 @@ def run_chunked_transformer_no_pcc(
     gc.collect()
     profiler.end("tt_transformer_creation")
 
+    # Sparse (DSA: glm_5_1 / glm_5_2) requires an UNCOMPRESSED bf16/fp8_e4m3 ROW_MAJOR KVPE cache
+    # (sparse_sdpa reads it natively; mla.forward asserts) — NOT the init_kvpe_cache bfloat8_b/TILE
+    # default that dense ring_mla wants. Match the cache format to the path (dense variants keep the
+    # default). Same distinction as run_chunked_transformer.
+    kvpe_dtype_layout = dict(dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT) if resolve_has_indexer(config) else {}
     tt_kvpe_cache = init_kvpe_cache(
         kvpe_cache_head_dim=kvpe_dim,
         mesh_device=mesh_device,
@@ -1055,13 +1206,67 @@ def run_chunked_transformer_no_pcc(
         sp_axis=sp_axis,
         num_kvpe_cache_layers=num_layers,
         num_users=1,
+        **kvpe_dtype_layout,
     )
+
+    # Sparse (DSA) layers read a block-cyclic indexer key cache that is caller-owned and passed into
+    # forward, exactly like the KVPE cache. Strided by the compacted full-indexer count
+    # (num_full_indexer_layers, >1 for glm_5_2 cross-layer reuse; num_layers without an indexer_types map)
+    # so it matches the indexer's cache_batch stride. bf8 TILE. Dense variants get None.
+    tt_index_kv_cache = None
+    if resolve_has_indexer(config):
+        assert getattr(config, "index_head_dim", None) is not None, "sparse config must provide index_head_dim"
+        tt_index_kv_cache = init_kvpe_cache(
+            kvpe_cache_head_dim=config.index_head_dim,
+            mesh_device=mesh_device,
+            seq_len=SEQ_CACHE_NOPCC,
+            mesh_shape=mesh_shape,
+            sp_axis=sp_axis,
+            num_kvpe_cache_layers=num_full_indexer_layers(config) or num_layers,
+            num_users=1,
+            dtype=ttnn.bfloat8_b,
+        )
+
+    # preload_isl > 0: seed the prior [0, preload_isl) KVPE + indexer-K from the golden trace so the measured
+    # chunk attends to real KV (representative MoE routing) and the indexer scores a real prefix.
+    if preload_isl > 0:
+        _preload_kvpe_prefix_from_trace(
+            tt_kvpe_cache,
+            trace_dir,
+            variant.prefill_trace_layout,
+            num_layers,
+            preload_isl,
+            trace_native_len,
+            sp,
+            SEQ_CACHE_NOPCC,
+            kvpe_dim,
+            config.kv_lora_rank,
+            mesh_device,
+            sp_axis,
+            kvpe_dtype_layout.get("dtype", ttnn.bfloat8_b),
+            kvpe_dtype_layout.get("layout", ttnn.TILE_LAYOUT),
+        )
+        if tt_index_kv_cache is not None:
+            _preload_indexer_k_prefix_from_trace(
+                tt_index_kv_cache,
+                trace_dir,
+                variant.prefill_trace_layout,
+                config,
+                num_layers,
+                preload_isl,
+                trace_native_len,
+                sp,
+                SEQ_CACHE_NOPCC,
+                config.index_head_dim,
+                mesh_device,
+                sp_axis,
+            )
 
     # Precompute per-chunk SP-sharded token tiles once (reused across iterations). Chunk-aligned offsets
     # make the block-cyclic rotation degenerate to a plain per-chip reshape.
     chunk_tok_host = []
     for c in range(n_chunks):
-        kv_actual = c * CHUNK
+        kv_actual = preload_isl + c * CHUNK
         positions = rotated_chip_positions(kv_actual, sp, chunk_local)
         flat = torch.tensor([positions[ch][r] for ch in range(sp) for r in range(chunk_local)], dtype=torch.long)
         chunk_tok_host.append(token_ids_full[flat].reshape(sp, 1, chunk_local))
@@ -1083,14 +1288,16 @@ def run_chunked_transformer_no_pcc(
             layout=ttnn.ROW_MAJOR_LAYOUT,
             mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_shape), dims=(0, None)),
         )
+        # Warm at the measured region's first offset (preload_isl) so the JITted programs match exactly.
         transformer.forward(
             warm_tokens,
             tt_kvpe_cache,
             actual_isl=CHUNK,
-            actual_start=0,
-            actual_end=CHUNK,
+            actual_start=preload_isl,
+            actual_end=preload_isl + CHUNK,
             cache_user_id=0,
             return_intermediates=False,
+            index_kv_cache=tt_index_kv_cache,
         )
         ttnn.synchronize_device(mesh_device)
         ttnn.deallocate(warm_tokens)
@@ -1102,7 +1309,7 @@ def run_chunked_transformer_no_pcc(
         iter_start = time.time()
         chunk_times: list[float] = []
         for c in range(n_chunks):
-            kv_actual = c * CHUNK
+            kv_actual = preload_isl + c * CHUNK
             tt_tokens = ttnn.from_torch(
                 chunk_tok_host[c],
                 device=mesh_device,
@@ -1123,6 +1330,7 @@ def run_chunked_transformer_no_pcc(
                 actual_end=kv_actual + CHUNK,
                 cache_user_id=0,
                 return_intermediates=False,
+                index_kv_cache=tt_index_kv_cache,
             )
             ttnn.synchronize_device(mesh_device)
             ttnn.deallocate(tt_tokens)
@@ -1130,6 +1338,9 @@ def run_chunked_transformer_no_pcc(
         iter_total = time.time() - iter_start
         iteration_chunk_times.append(chunk_times)
         logger.info(f"iter {it} done ({n_chunks} chunks) in {iter_total:.3f} seconds")
+        # Drop iter 0's per-layer MLA/FFN samples (the compile iteration), same as the chunk-time table.
+        if it == 0:
+            reset_block_timings()
     profiler.end("tt_forward")
 
     profiler.end("total_test_time")
@@ -1139,6 +1350,71 @@ def run_chunked_transformer_no_pcc(
     perf_failures = print_duration_table(iteration_chunk_times)
     for key in profiler.times:
         logger.info(f"  {key}: {profiler.get(key) * 1000:.2f} ms")
+
+    # Rough per-layer MLA-vs-FFN split (TT_PREFILL_BLOCK_TIMING=1): host wall-clock, sync-bracketed, so
+    # absolutes inflate (syncs serialize) — read the RATIO and per-layer shape, not the totals. Mean +/- std
+    # over all recorded forward calls (iter 0 dropped above). Each layer sample = one chunk's block call.
+    timings = get_block_timings()
+    if timings:
+
+        def _mean_std_ms(samples):
+            mean_ms = statistics.mean(samples) * 1000.0 if samples else 0.0
+            std_ms = statistics.stdev(samples) * 1000.0 if len(samples) >= 2 else 0.0
+            return mean_ms, std_ms
+
+        headers = ["layer", "mla_mean_ms", "mla_std_ms", "moe_mean_ms", "moe_std_ms", "mla%", "moe%"]
+        rows = []
+        tot_mla = tot_moe = 0.0
+        for layer_idx in sorted(timings):
+            rec = timings[layer_idx]
+            mla_mean, mla_std = _mean_std_ms(rec["mla"])
+            moe_mean, moe_std = _mean_std_ms(rec["ffn"])
+            both = mla_mean + moe_mean
+            tot_mla += mla_mean
+            tot_moe += moe_mean
+            rows.append(
+                [
+                    f"{layer_idx}",
+                    f"{mla_mean:.2f}",
+                    f"{mla_std:.2f}",
+                    f"{moe_mean:.2f}",
+                    f"{moe_std:.2f}",
+                    f"{100.0 * mla_mean / both:.1f}" if both else "-",
+                    f"{100.0 * moe_mean / both:.1f}" if both else "-",
+                ]
+            )
+        tot_both = tot_mla + tot_moe
+        rows.append(
+            [
+                "ALL",
+                f"{tot_mla:.2f}",
+                "-",
+                f"{tot_moe:.2f}",
+                "-",
+                f"{100.0 * tot_mla / tot_both:.1f}" if tot_both else "-",
+                f"{100.0 * tot_moe / tot_both:.1f}" if tot_both else "-",
+            ]
+        )
+        widths = [max(len(h), *(len(r[i]) for r in rows)) for i, h in enumerate(headers)]
+        sep = "-+-".join("-" * w for w in widths)
+
+        def render(vals):
+            return " | ".join(v.rjust(widths[i]) for i, v in enumerate(vals))
+
+        n_samples = len(next(iter(timings.values()))["mla"])
+        logger.info(
+            f"per-layer MLA-vs-MoE mean +/- std host time over {n_samples} chunk-calls (sync-bracketed, iter 0 "
+            f"dropped; moe column is the FFN region -- MoE on MoE layers, dense FFN on the first_k_dense layers) "
+            f"-- ratio is the signal, absolutes are inflated by the syncs:"
+        )
+        logger.info("\n" + sep)
+        logger.info(render(headers))
+        logger.info(sep)
+        for r in rows[:-1]:
+            logger.info(render(r))
+        logger.info(sep)
+        logger.info(render(rows[-1]))
+        logger.info(sep)
 
     # Assert AFTER the table is logged so the full per-chunk breakdown is always visible on failure.
     assert not perf_failures, "chunk timing out of baseline tolerance:\n  " + "\n  ".join(perf_failures)
@@ -1155,6 +1431,16 @@ def run_chunked_transformer_no_pcc(
     "n_chunks",
     [1, 2, 5, 10, 11, 20],
     ids=["chunks1", "chunks2", "chunks5", "chunks10", "chunks_eleven", "chunks20"],
+)
+# preload_isl (multiple of CHUNK): pretend the cache already holds this many prior KV tokens so the
+# measured chunks run at KV depth [preload_isl, preload_isl + n_chunks*CHUNK) WITHOUT first running prefill
+# up to that point. Pair with n_chunks=1 to sweep the single-chunk MLA/MoE ratio vs depth. 0 = start from
+# empty cache. Depths within the golden trace use real KV; the rest fill random KV beyond the trace (still
+# non-degenerate for routing) so larger ISLs than the trace can be measured. Requires a golden trace when >0.
+@pytest.mark.parametrize(
+    "preload_isl",
+    [0, 5 * CHUNK, 10 * CHUNK, 19 * CHUNK],
+    ids=["preload0", "preload25k", "preload50k", "preload95k"],
 )
 @pytest.mark.parametrize("num_layers", [1, 10, 61], ids=["L1", "L10", "L61"])
 @pytest.mark.parametrize(
@@ -1191,10 +1477,16 @@ def test_kimi_prefill_transformer_chunked_no_pcc(
     num_links,
     topology,
     perf_margin,
+    preload_isl,
 ):
+    if preload_isl + n_chunks * CHUNK > SEQ_CACHE_NOPCC:
+        pytest.skip(f"preload_isl {preload_isl} + {n_chunks} chunks exceeds the {SEQ_CACHE_NOPCC}-token cache")
     # Gate against the CI baseline only for the exact config we have a recorded number for; every other
-    # combo in the sweep stays record-only (baseline None -> print_duration_table does not assert).
-    baseline_chunk_times_s = KIMI_NO_PCC_BASELINE_CHUNK_TIMES_S.get((num_layers, n_chunks, num_iters))
+    # combo in the sweep stays record-only (baseline None -> print_duration_table does not assert). The
+    # baseline is only meaningful at preload_isl=0 (the recorded runs started from an empty cache).
+    baseline_chunk_times_s = (
+        KIMI_NO_PCC_BASELINE_CHUNK_TIMES_S.get((num_layers, n_chunks, num_iters)) if preload_isl == 0 else None
+    )
     run_chunked_transformer_no_pcc(
         variant,
         config_only,
@@ -1209,6 +1501,7 @@ def test_kimi_prefill_transformer_chunked_no_pcc(
         routing_use_l1_small_for_semaphores=True,
         baseline_chunk_times_s=baseline_chunk_times_s,
         perf_margin=perf_margin,
+        preload_isl=preload_isl,
     )
 
 
@@ -1270,4 +1563,85 @@ def test_ds_prefill_transformer_chunked_no_pcc(
         topology,
         num_iters,
         routing_use_l1_small_for_semaphores=False,
+    )
+
+
+# GLM (glm_5_1 / glm_5_2) counterpart of the no-PCC perf sweep: same chunked driver, sparse (DSA) path.
+# Reports end-to-end prefill time — the per-iteration total ("iter {it} done ... in Xs") and the per-chunk
+# median/stddev table — for the two GLM variants at matched ISL (n_chunks x CHUNK) and num_layers. No PCC,
+# no golden-trace dependency (record-only). Uses the GLM fabric payload + on-device fp32 gate + L1_SMALL
+# routing semaphores, exactly like test_glm_prefill_transformer_chunked. glm_5_2 additionally exercises the
+# DSA cross-layer indexer reuse per chunk. Requires the GLM TTNN weight cache (set the variant's cache env).
+@pytest.mark.parametrize(
+    "num_iters", [1, 2, 10, 20, 25], ids=["iters1", "two_iters", "ten_iters", "iters20", "iters25"]
+)
+@pytest.mark.parametrize(
+    "n_chunks",
+    [1, 2, 5, 10, 11, 20],
+    ids=["chunks1", "chunks2", "chunks5", "chunks10", "chunks_eleven", "chunks20"],
+)
+# preload_isl (multiple of CHUNK): pretend the cache already holds this many prior KV tokens so the
+# measured chunks run at KV depth [preload_isl, preload_isl + n_chunks*CHUNK) WITHOUT first running prefill
+# up to that point. Pair with n_chunks=1 to sweep single-chunk ratio vs depth. 0 = start from empty cache.
+# Chunk-multiple KV depths to seed before measuring. Depths within the ~55k golden trace use real KV; the
+# rest (e.g. preload95k) fills random KV beyond the trace so larger ISLs than the trace can be measured.
+@pytest.mark.parametrize(
+    "preload_isl",
+    [0, 5 * CHUNK, 10 * CHUNK, 19 * CHUNK],
+    ids=["preload0", "preload25k", "preload50k", "preload95k"],
+)
+@pytest.mark.parametrize("num_layers", [1, 10, 78], ids=["L1", "L10", "L78"])
+@pytest.mark.parametrize(
+    "mesh_device, device_params, num_links, topology",
+    [
+        pytest.param(
+            (8, 4),
+            {
+                # Ring fabric (FABRIC_1D_RING + Topology.Ring): the production transport for the GLM
+                # chunked-prefill perf measurement.
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=GLM51Config.FABRIC_PAYLOAD_SIZE),
+                # Small L1_SMALL region for the MoE routing all-gather's global semaphores
+                # (use_l1_small_for_semaphores); see test_glm_prefill_transformer_chunked.
+                "l1_small_size": 512,
+            },
+            2,
+            ttnn.Topology.Ring,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
+            id="mesh-8x4",
+        ),
+    ],
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize("variant", ["glm_5_1", "glm_5_2"], indirect=True, ids=["glm51", "glm52"])
+@pytest.mark.skipif(not is_blackhole(), reason="GLM DSA ops (indexer / sparse SDPA) are Blackhole-only")
+@pytest.mark.timeout(0)
+def test_glm_prefill_transformer_chunked_no_pcc(
+    variant,
+    config_only,
+    mesh_device,
+    device_params,
+    weight_cache_path,
+    num_layers,
+    n_chunks,
+    num_iters,
+    num_links,
+    topology,
+    preload_isl,
+):
+    if preload_isl + n_chunks * CHUNK > SEQ_CACHE_NOPCC:
+        pytest.skip(f"preload_isl {preload_isl} + {n_chunks} chunks exceeds the {SEQ_CACHE_NOPCC}-token cache")
+    run_chunked_transformer_no_pcc(
+        variant,
+        config_only,
+        mesh_device,
+        weight_cache_path,
+        num_layers,
+        n_chunks,
+        GateComputeMode.DEVICE_FP32,
+        num_links,
+        topology,
+        num_iters,
+        routing_use_l1_small_for_semaphores=True,
+        preload_isl=preload_isl,
     )

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import math
-import os
 from pathlib import Path
 from typing import Optional
 
@@ -292,14 +291,6 @@ class ttMLA:
             weight_cache_path=self.weight_cache_path,
             cache_name_prefix=f"layer_{layer_idx}.mla",
         )
-
-        # Perf-measurement gate: when set, the sparse chunked KVPE gather (_gather_kvpe_prefix) trims
-        # the block-cyclic cache to only the POPULATED KV depth before the SP all-gather, instead of
-        # gathering the full allocated cache width every chunk. This makes the measured gather cost track
-        # the real valid length (realistic per-depth perf). Correctness-preserving (top-k indices never
-        # address the unwritten suffix) but assumes a chunk-aligned populated depth, so it stays OFF by
-        # default and the production path gathers full width unchanged.
-        self._gather_populated_kv = os.environ.get("TT_MLA_GATHER_POPULATED_KV", "0") == "1"
 
         # The RoPE op is fixed by the configured mode. It is bound AFTER self._has_indexer is resolved
         # (below), because sparse always runs the block-cyclic path (single-shot is one full-seq chunk at
@@ -1249,7 +1240,9 @@ class ttMLA:
         # After the write above, KV is populated up to [0, kv_actual_isl + chunk_size_global); the gather
         # only needs that populated prefix (top-k indices never address the unwritten suffix).
         populated_global = kv_actual_isl + seq_len_local * self.sp_factor
-        kvpe_dev = self._gather_kvpe_prefix(kvpe_cache, cache_batch_idx, populated_global=populated_global)
+        kvpe_dev = self._gather_kvpe_prefix(
+            kvpe_cache, cache_batch_idx, populated_global=populated_global, chunk_local=seq_len_local
+        )
         ttnn.deallocate(tt_kvpe)
 
         # Sparse attention runs over latent V; project to v_head_dim afterwards. The prefix is already
@@ -1459,7 +1452,7 @@ class ttMLA:
             ttnn.deallocate(out_all_heads)
         return ret
 
-    def _gather_kvpe_prefix(self, kvpe_cache, cache_batch_idx, populated_global=None):
+    def _gather_kvpe_prefix(self, kvpe_cache, cache_batch_idx, populated_global=None, chunk_local=None):
         """On-device read-back of the chunked KVPE prefix for sparse attention. The cache is
         ND-sharded / block-cyclic across SP, in the op's format (bf16 or fp8_e4m3, ROW_MAJOR — the
         sparse cache is uncompressed). sparse_sdpa consumes it replicated and remaps the
@@ -1475,15 +1468,16 @@ class ttMLA:
         requires B==1 when cache_batch_idx is unset). This mirrors the dense ring_mla single-slot gather
         (kv_cache_batch_idx → batch-1 scratch).
 
-        POPULATED-WIDTH TRIM (gated, ``populated_global``): by default the gather covers the full
-        allocated cache width every chunk, so that fixed cost does not track the real valid length. When
-        the ``TT_MLA_GATHER_POPULATED_KV`` gate is on and ``populated_global`` (the written KV depth after
-        this chunk) is given, trim the per-chip seq dim to only the populated slabs BEFORE the gather. The
-        per-chip cache is slab-major (slab s at local rows [s*chunk_local, (s+1)*chunk_local)), so the
-        first ``populated_global / sp`` local rows hold exactly the written slabs; the unwritten suffix is
-        never addressed (top-k indices stay < populated), so this is correctness-preserving. It shrinks
-        the SP all-gather (and the downstream sparse_sdpa buffer) to the real depth → realistic per-depth
-        perf. Requires a shard-aligned depth (asserted); OFF by default so production gathers full width.
+        POPULATED-WIDTH TRIM (``populated_global`` = written KV depth after this chunk, ``chunk_local`` =
+        per-chip slab width): trim the per-chip seq dim to only the populated SLABS BEFORE the gather
+        instead of gathering the full allocated cache width. The per-chip cache is slab-major (slab s at
+        local rows [s*chunk_local, (s+1)*chunk_local)) and ``populated_global`` can end mid-slab (padded /
+        rotated ``kv_actual_isl``). A partial boundary slab holds a NON-uniform valid-row count across
+        chips (low chips full, high chips none), and the block-cyclic index remap needs an integer slab
+        count -- so a uniform ``populated_global / sp`` width would drop valid rows on low chips AND slice
+        a fractional slab. Round the touched depth UP to a whole chunk: every valid slab is kept intact
+        and the pad tail is present but never addressed (top-k indices stay < valid). It shrinks the SP
+        all-gather (and the downstream sparse_sdpa buffer) to the populated slab count.
 
         Pipeline (all on device): ND→interleaved, slot + populated-width slice (no-op for a single-slot,
         full-width cache), SP all-gather (no-op at sp==1). The cache is already in the op format, so there
@@ -1492,12 +1486,12 @@ class ttMLA:
 
         slot_lo = cache_batch_idx if cache_i.shape[0] > 1 else 0  # user-major slot select (single-slot → 0)
         seq_hi = cache_i.shape[2]  # per-chip seq width to gather; default = full allocated cache
-        if self._gather_populated_kv and populated_global is not None:
-            assert populated_global % self.sp_factor == 0, (
-                f"populated_global ({populated_global}) must be divisible by sp ({self.sp_factor}) to trim "
-                f"the block-cyclic gather on a shard boundary"
-            )
-            seq_hi = min(populated_global // self.sp_factor, seq_hi)
+        if populated_global is not None and chunk_local is not None:
+            # Round the populated depth UP to whole block-cyclic slabs (see docstring): a partial boundary
+            # slab is non-uniform across chips and fractional, so trim by slab count, not raw width.
+            chunk_size_global = chunk_local * self.sp_factor
+            num_slabs = -(-populated_global // chunk_size_global)  # ceil-div
+            seq_hi = min(num_slabs * chunk_local, seq_hi)
 
         # Slice iff the cache is multi-slot (must select this slot even when it's slot 0) and/or the
         # populated-width trim applies. A single-slot cache (shape[0]==1) is already batch-1.

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import math
+import os
 from pathlib import Path
 from typing import Optional
 
@@ -291,6 +292,14 @@ class ttMLA:
             weight_cache_path=self.weight_cache_path,
             cache_name_prefix=f"layer_{layer_idx}.mla",
         )
+
+        # Perf-measurement gate: when set, the sparse chunked KVPE gather (_gather_kvpe_prefix) trims
+        # the block-cyclic cache to only the POPULATED KV depth before the SP all-gather, instead of
+        # gathering the full allocated cache width every chunk. This makes the measured gather cost track
+        # the real valid length (realistic per-depth perf). Correctness-preserving (top-k indices never
+        # address the unwritten suffix) but assumes a chunk-aligned populated depth, so it stays OFF by
+        # default and the production path gathers full width unchanged.
+        self._gather_populated_kv = os.environ.get("TT_MLA_GATHER_POPULATED_KV", "0") == "1"
 
         # The RoPE op is fixed by the configured mode. It is bound AFTER self._has_indexer is resolved
         # (below), because sparse always runs the block-cyclic path (single-shot is one full-seq chunk at
@@ -1237,7 +1246,10 @@ class ttMLA:
             kv_actual_global=kv_actual_isl,
             cluster_axis=self.sp_axis,
         )
-        kvpe_dev = self._gather_kvpe_prefix(kvpe_cache, cache_batch_idx)
+        # After the write above, KV is populated up to [0, kv_actual_isl + chunk_size_global); the gather
+        # only needs that populated prefix (top-k indices never address the unwritten suffix).
+        populated_global = kv_actual_isl + seq_len_local * self.sp_factor
+        kvpe_dev = self._gather_kvpe_prefix(kvpe_cache, cache_batch_idx, populated_global=populated_global)
         ttnn.deallocate(tt_kvpe)
 
         # Sparse attention runs over latent V; project to v_head_dim afterwards. The prefix is already
@@ -1447,37 +1459,57 @@ class ttMLA:
             ttnn.deallocate(out_all_heads)
         return ret
 
-    def _gather_kvpe_prefix(self, kvpe_cache, cache_batch_idx):
+    def _gather_kvpe_prefix(self, kvpe_cache, cache_batch_idx, populated_global=None):
         """On-device read-back of the chunked KVPE prefix for sparse attention. The cache is
         ND-sharded / block-cyclic across SP, in the op's format (bf16 or fp8_e4m3, ROW_MAJOR — the
         sparse cache is uncompressed). sparse_sdpa consumes it replicated and remaps the
         natural-position indices to physical block-cyclic pages in-kernel (invP), so the buffer is
         LEFT in block-cyclic order — no host reorder.
 
-        SLOT SELECT BEFORE THE GATHER: the persistent cache is [B, 1, seq_len_cache, 576], B =
-        num_users*num_layers (user-major slots). Slice the active (user, layer) slot out of dim 0 FIRST,
-        then all-gather only that single [1, 1, seq_len_cache, 576] slot over SP — NOT the whole B-slot
-        cache. At 78 layers the full-cache gather is ~5 GB (×2 in-flight → OOM against the near-full
-        78-layer weights); the single-slot gather is B× smaller. The gathered kv is then batch-1, so
-        sparse_sdpa needs NO cache_batch_idx (the op requires B==1 when cache_batch_idx is unset). This
-        mirrors the dense ring_mla single-slot gather (kv_cache_batch_idx → batch-1 scratch).
+        SLOT SELECT BEFORE THE GATHER: the persistent cache's per-chip shape is [B, 1, seq_len_local,
+        576], B = num_users*num_layers (user-major slots), seq_len_local = seq_len_cache / sp. Slice the
+        active (user, layer) slot out of dim 0 FIRST, then all-gather only that single slot over SP (→
+        [1, 1, seq_len_cache, 576]) — NOT the whole B-slot cache. At 78 layers the full-cache gather is
+        ~5 GB (×2 in-flight → OOM against the near-full 78-layer weights); the single-slot gather is B×
+        smaller. The gathered kv is then batch-1, so sparse_sdpa needs NO cache_batch_idx (the op
+        requires B==1 when cache_batch_idx is unset). This mirrors the dense ring_mla single-slot gather
+        (kv_cache_batch_idx → batch-1 scratch).
 
-        Pipeline (all on device): ND→interleaved, slot slice (no-op for a single-slot cache), SP
-        all-gather to full-T (no-op at sp==1). The cache is already in the op format, so there is NO
-        read-back dtype/layout conversion. The unwritten suffix is never addressed since indices stay
-        < populated."""
+        POPULATED-WIDTH TRIM (gated, ``populated_global``): by default the gather covers the full
+        allocated cache width every chunk, so that fixed cost does not track the real valid length. When
+        the ``TT_MLA_GATHER_POPULATED_KV`` gate is on and ``populated_global`` (the written KV depth after
+        this chunk) is given, trim the per-chip seq dim to only the populated slabs BEFORE the gather. The
+        per-chip cache is slab-major (slab s at local rows [s*chunk_local, (s+1)*chunk_local)), so the
+        first ``populated_global / sp`` local rows hold exactly the written slabs; the unwritten suffix is
+        never addressed (top-k indices stay < populated), so this is correctness-preserving. It shrinks
+        the SP all-gather (and the downstream sparse_sdpa buffer) to the real depth → realistic per-depth
+        perf. Requires a shard-aligned depth (asserted); OFF by default so production gathers full width.
+
+        Pipeline (all on device): ND→interleaved, slot + populated-width slice (no-op for a single-slot,
+        full-width cache), SP all-gather (no-op at sp==1). The cache is already in the op format, so there
+        is NO read-back dtype/layout conversion."""
         cache_i = ttnn.to_memory_config(kvpe_cache, ttnn.DRAM_MEMORY_CONFIG)  # ND_SHARDED → INTERLEAVED
-        if cache_i.shape[0] > 1:  # user-major slot select BEFORE the gather (single-slot cache → skip)
+
+        slot_lo = cache_batch_idx if cache_i.shape[0] > 1 else 0  # user-major slot select (single-slot → 0)
+        seq_hi = cache_i.shape[2]  # per-chip seq width to gather; default = full allocated cache
+        if self._gather_populated_kv and populated_global is not None:
+            assert populated_global % self.sp_factor == 0, (
+                f"populated_global ({populated_global}) must be divisible by sp ({self.sp_factor}) to trim "
+                f"the block-cyclic gather on a shard boundary"
+            )
+            seq_hi = min(populated_global // self.sp_factor, seq_hi)
+
+        # Slice iff the cache is multi-slot (must select this slot even when it's slot 0) and/or the
+        # populated-width trim applies. A single-slot cache (shape[0]==1) is already batch-1.
+        if cache_i.shape[0] > 1 or seq_hi != cache_i.shape[2]:  # slot and/or populated-width trim BEFORE the gather
             sel = ttnn.slice(
                 cache_i,
-                [cache_batch_idx, 0, 0, 0],
-                [cache_batch_idx + 1, 1, cache_i.shape[2], cache_i.shape[3]],
+                [slot_lo, 0, 0, 0],
+                [slot_lo + 1, 1, seq_hi, cache_i.shape[3]],
             )
             ttnn.deallocate(cache_i)
             cache_i = sel
-        full = self._all_gather(
-            cache_i, dim=2, cluster_axis=self.sp_axis
-        )  # → [1,1,seq_len_cache,576] repl, block-cyclic
+        full = self._all_gather(cache_i, dim=2, cluster_axis=self.sp_axis)  # → [1,1,seq_hi*sp,576] repl, block-cyclic
         if self.sp_factor > 1:
             ttnn.deallocate(cache_i)
         return full

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+import time
 from pathlib import Path
 from typing import Callable, Optional, Tuple, Union
 
@@ -16,6 +18,25 @@ from models.demos.deepseek_v3_d_p.tt.moe.tt_moe import TtMoe
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
 from models.demos.deepseek_v3_d_p.tt.tt_distributed_rms_norm import TtDistributedRmsNorm
 from models.demos.deepseek_v3_d_p.tt.tt_ffn import TtFfn
+
+# Optional per-layer MLA-vs-FFN host timing (rough ratio only). Gated by TT_PREFILL_BLOCK_TIMING=1.
+# Host wall-clock with a device sync bracketing each region, so the syncs serialize the pipeline and
+# ABSOLUTE times inflate vs an un-instrumented run — trust the MLA:FFN ratio and the per-layer shape,
+# NOT the totals. When off (default) there is no sync and no timing, so normal runs are unperturbed.
+# Keyed by global layer_idx -> {"mla": [seconds...], "ffn": [seconds...]} (one entry per forward call).
+_BLOCK_TIMING_ENABLED = os.environ.get("TT_PREFILL_BLOCK_TIMING", "0") == "1"
+_BLOCK_TIMINGS: dict[int, dict[str, list[float]]] = {}
+
+
+def reset_block_timings() -> None:
+    """Drop all recorded per-layer MLA/FFN samples (e.g. to exclude a warmup iteration)."""
+    _BLOCK_TIMINGS.clear()
+
+
+def get_block_timings() -> dict[int, dict[str, list[float]]]:
+    """Per-layer {"mla": [s...], "ffn": [s...]} host-timing samples recorded since the last reset."""
+    return _BLOCK_TIMINGS
+
 
 # Per-axis CCL topology. A scalar applies to both mesh axes; a 2-tuple (row = SP-axis-0,
 # col = TP-axis-1) configures each axis independently — e.g. (Ring, Linear) for
@@ -443,6 +464,14 @@ class TtPrefillBlock(LightweightModule):
             (output_tensor, kv_cache) where kv_cache is a host tensor or None, or
             (output_tensor, kv_intermediates_dict) when return_kv_intermediates=True.
         """
+        # Optional MLA-vs-FFN host timing (TT_PREFILL_BLOCK_TIMING=1). Bracket each region with a device
+        # sync so the wall-clock reflects device work; disabled by default (no sync, no perturbation).
+        # Skip kv_only layers (they run no FFN and return early below).
+        _timing = _BLOCK_TIMING_ENABLED and not self.kv_only
+        if _timing:
+            ttnn.synchronize_device(self.mesh_device)
+            _t_start = time.perf_counter()
+
         # --- Attention ---
         attn_norm_out = self.attn_norm(x)
         seq_len_local = attn_norm_out.shape[2]
@@ -503,6 +532,9 @@ class TtPrefillBlock(LightweightModule):
 
         x = ttnn.add(x, mla_out)
         ttnn.deallocate(mla_out)
+        if _timing:
+            ttnn.synchronize_device(self.mesh_device)
+            _t_mla = time.perf_counter()
         if return_kv_intermediates:
             # post-MLA residual (x + mla_out), TP-sharded on hidden.
             kv_intermediates["post_mla_residual"] = ttnn.clone(x)
@@ -526,6 +558,12 @@ class TtPrefillBlock(LightweightModule):
         ttnn.deallocate(ffn_norm_out)
         x = ttnn.add(x, ffn_out)
         ttnn.deallocate(ffn_out)
+        if _timing:
+            ttnn.synchronize_device(self.mesh_device)
+            _t_ffn = time.perf_counter()
+            rec = _BLOCK_TIMINGS.setdefault(self.mla.layer_idx, {"mla": [], "ffn": []})
+            rec["mla"].append(_t_mla - _t_start)  # attn_norm + MLA + residual
+            rec["ffn"].append(_t_ffn - _t_mla)  # ffn_norm + (MoE|dense FFN) + residual
 
         if return_kv_intermediates:
             if return_indexer_indices:

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -352,7 +352,7 @@
     export TT_KIMI_PREFILL_TTNN_CACHE=/mnt/models/Kimi-K2_6-Cache/Kimi-K2_6-Cache-prefill
     export PREFILL_TRACE_DIR=/mnt/models/kimi-prefill-cache/vllm-kimi-k26-codedebug-56320
     mpirun --pernode --tag-output bash -lc '
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py::test_kimi_prefill_transformer_chunked_no_pcc[blackhole-kimi-mesh-8x4-L61-chunks_eleven-ten_iters-margin5pct] -xvs
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py::test_kimi_prefill_transformer_chunked_no_pcc[blackhole-kimi-mesh-8x4-L61-preload0-chunks_eleven-ten_iters-margin5pct] -xvs
     '
   test_type: kimi_chunked
   test_group: module


### PR DESCRIPTION
Closes #50599. Perf-measurement instrumentation for GLM-5.1 / Kimi chunked prefill, plus improvements to the sparse chunked KVPE gather and a move of the GLM perf sweep to the production fabric.

### Instrumentation (gated OFF by default)

**1. Per-layer MLA-vs-FFN host timing** (`tt_prefill_block.py`) — gated by `TT_PREFILL_BLOCK_TIMING=1`.
Brackets the MLA region and the FFN region of each block with a device sync and records host wall-clock per global `layer_idx`. Exposes `reset_block_timings()` / `get_block_timings()`.
Caveat baked into the docstring: the syncs serialize the pipeline, so **absolute** times inflate vs an un-instrumented run — trust the MLA:FFN **ratio** and the per-layer shape, not the totals. When off (default) there is no sync and no timing, so normal runs are unperturbed.

**2. Test harness** (`test_prefill_transformer_chunked.py`).
KV preload to a target depth (GLM + Kimi `preload_isl` sweeps) to measure gather / MLA / MoE cost vs KV-ISL depth, plus MLA/MoE ratio reporting and the indexer-K prefix preload for the DSA path.

### Behavior changes (not gated)

**3. Populated-KV gather is now unconditional and padding-correct** (`mla.py` `_gather_kvpe_prefix`).
The sparse chunked KVPE gather now **always** trims the per-chip seq dim to the populated KV depth before the SP all-gather — the `TT_MLA_GATHER_POPULATED_KV` env gate is removed — so the gather cost (and the downstream `sparse_sdpa` buffer) tracks the real valid length instead of the full allocated cache width every chunk.
The trim rounds the populated depth **up to whole block-cyclic slabs** (`ceil` to `chunk_size_global`), not `populated_global // sp`: a padded / rotated mid-slab `kv_actual_isl` leaves a partial boundary slab whose valid-row count is **non-uniform across chips** and whose fractional width breaks the `sparse_sdpa` block-cyclic index remap. A uniform-width trim would both drop valid rows on low-index chips and pull in unwritten pad on high-index chips. Rounding up keeps every valid slab intact (the pad tail is present but never addressed — top-k indices stay `< valid`), so it is correctness-preserving for both chunk-aligned and padded depths. The old (insufficient) divisibility assert is dropped.

**4. GLM no-PCC perf sweep → FABRIC_2D** (`test_prefill_transformer_chunked.py`).
The GLM chunked-prefill perf sweep now runs on `FABRIC_2D` + `Topology.Linear` (with `RELAXED_INIT`) — the production transport — replacing `FABRIC_1D_RING` + `Topology.Ring`. The GLM PCC test is unchanged (`FABRIC_1D` + Linear).

**5. CI selector repin** (`tests/pipeline_reorg/blaze_models_prefill_tests.yaml`).
The kimi no-PCC selector is repinned to the `preload0` (no-preload) case: the new `preload_isl` parametrize inserts a `preloadN` token into every nodeid, so the previous fully-pinned selector would match nothing. `preload0` = empty cache, the same input CI ran before the param existed.

### Scope

`models/demos/deepseek_v3_d_p/` (3 files) + one CI selector. The default runtime path changes only in one place: the sparse chunked KVPE gather is now populated-width by default (item 3) — correctness-preserving, and a strict reduction in gathered width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/glm-chunked-e2e-timing)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/glm-chunked-e2e-timing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/glm-chunked-e2e-timing)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/glm-chunked-e2e-timing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ipotkonjak/glm-chunked-e2e-timing)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ipotkonjak/glm-chunked-e2e-timing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/glm-chunked-e2e-timing)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/glm-chunked-e2e-timing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/glm-chunked-e2e-timing)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/glm-chunked-e2e-timing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/glm-chunked-e2e-timing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/glm-chunked-e2e-timing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/glm-chunked-e2e-timing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/glm-chunked-e2e-timing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/glm-chunked-e2e-timing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/glm-chunked-e2e-timing)
