### PR TITLE
Alexey zaytsev epam/fix hash collision 45821 w all gather matmul async device operation

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_device_operation.cpp
@@ -113,32 +113,6 @@ AllGatherMatmulAsyncDeviceOperation::tensor_return_value_t AllGatherMatmulAsyncD
     return {all_gather_output_tensor, matmul_output_tensor};
 }
 
-ttsl::hash::hash_t AllGatherMatmulAsyncDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    log_trace(tt::LogOp, "AllGatherMatmulAsyncDeviceOperation::compute_program_hash is called");
-
-    auto subdevice_id = operation_attributes.all_gather_async_attributes.sub_device_id;
-    auto* mesh_device = tensor_args.input_tensor.device();
-    auto sd_id = subdevice_id.value_or(mesh_device->get_sub_device_ids().at(0));
-    auto subdevice_core_range_set = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sd_id);
-    return tt::tt_metal::operation::hash_operation<AllGatherMatmulAsyncDeviceOperation>(
-        operation_attributes.all_gather_async_attributes.dim,
-        operation_attributes.all_gather_async_attributes.num_links,
-        operation_attributes.all_gather_async_attributes.ring_size,
-        operation_attributes.all_gather_async_attributes.output_mem_config,
-        operation_attributes.all_gather_async_attributes.topology,
-        operation_attributes.all_gather_async_attributes.cluster_axis,
-        operation_attributes.all_gather_async_attributes.barrier_semaphore.has_value(),
-        operation_attributes.all_gather_async_attributes.using_persistent_buffers,
-        operation_attributes.all_gather_async_attributes.chunks_per_sync,
-        operation_attributes.all_gather_async_attributes.num_workers_per_link,
-        operation_attributes.all_gather_async_attributes.num_buffers_per_channel,
-        operation_attributes.matmul,
-        operation_attributes.all_gather_core_grid_offset,
-        subdevice_core_range_set,
-        tensor_args);
-}
-
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_device_operation.hpp
@@ -28,8 +28,6 @@ struct AllGatherMatmulAsyncDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
-
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_device_operation_types.hpp
@@ -29,8 +29,38 @@ struct AllGatherMatmulAsyncParams {
     /* Fusion params */
     CoreCoord all_gather_core_grid_offset;
 
-    static constexpr auto attribute_names = std::forward_as_tuple("matmul_struct", "all_gather_core_grid_offset");
-    auto attribute_values() const { return std::forward_as_tuple(this->matmul, this->all_gather_core_grid_offset); }
+    static constexpr auto attribute_names = std::forward_as_tuple(
+        "dim",
+        "num_links",
+        "ring_size",
+        "output_mem_config",
+        "topology",
+        "cluster_axis",
+        "barrier_semaphore_present",
+        "using_persistent_buffers",
+        "chunks_per_sync",
+        "num_workers_per_link",
+        "num_buffers_per_channel",
+        "sub_device_id",
+        "matmul",
+        "all_gather_core_grid_offset");
+    auto attribute_values() const {
+        return std::make_tuple(
+            all_gather_async_attributes.dim,
+            all_gather_async_attributes.num_links,
+            all_gather_async_attributes.ring_size,
+            std::cref(all_gather_async_attributes.output_mem_config),
+            all_gather_async_attributes.topology,
+            std::cref(all_gather_async_attributes.cluster_axis),
+            all_gather_async_attributes.barrier_semaphore.has_value(),
+            all_gather_async_attributes.using_persistent_buffers,
+            std::cref(all_gather_async_attributes.chunks_per_sync),
+            std::cref(all_gather_async_attributes.num_workers_per_link),
+            std::cref(all_gather_async_attributes.num_buffers_per_channel),
+            all_gather_async_attributes.sub_device_id,
+            std::cref(matmul),
+            std::cref(all_gather_core_grid_offset));
+    }
 };
 
 struct AllGatherMatmulAsyncInputs {


### PR DESCRIPTION
### PR Category
hash calculation unification for operation AllGatherMatmulAsyncDeviceOperation

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for AllGatherMatmulAsyncDeviceOperation

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_AllGatherMatmulAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_AllGatherMatmulAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_AllGatherMatmulAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_AllGatherMatmulAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_AllGatherMatmulAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_AllGatherMatmulAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_AllGatherMatmulAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_AllGatherMatmulAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_AllGatherMatmulAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_AllGatherMatmulAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_AllGatherMatmulAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_AllGatherMatmulAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_AllGatherMatmulAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_AllGatherMatmulAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_AllGatherMatmulAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_AllGatherMatmulAsyncDeviceOperation)
