### PR TITLE
#45821: migrate AllToAllAsyncDeviceOperation to default program-cache hash

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_async_device_operation.cpp
@@ -173,25 +173,6 @@ AllToAllAsyncDeviceOperation::tensor_return_value_t AllToAllAsyncDeviceOperation
     return tensor_args.persistent_output_buffer;
 }
 
-ttsl::hash::hash_t AllToAllAsyncDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    log_trace(tt::LogOp, "AllToAllAsyncDeviceOperation::compute_program_hash is called");
-
-    auto subdevice_id = operation_attributes.sub_device_id;
-    auto* mesh_device = tensor_args.input_tensor.device();
-    auto sd_id = subdevice_id.value_or(mesh_device->get_sub_device_ids().at(0));
-    auto subdevice_core_range_set = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sd_id);
-    return tt::tt_metal::operation::hash_operation<AllToAllAsyncDeviceOperation>(
-        operation_attributes.in_dim,
-        operation_attributes.out_dim,
-        operation_attributes.num_links,
-        operation_attributes.ring_size,
-        operation_attributes.output_mem_config,
-        operation_attributes.topology,
-        subdevice_core_range_set,
-        tensor_args);
-}
-
 Tensor all_to_all_async(
     const ttnn::Tensor& input_tensor,
     ttnn::Tensor& persistent_intermediate_buffer,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_async_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_async_device_operation.hpp
@@ -29,7 +29,6 @@ struct AllToAllAsyncDeviceOperation {
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 Tensor all_to_all_async(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async/device/all_to_all_async_device_operation_types.hpp
@@ -10,6 +10,7 @@
 #include "ttnn/global_semaphore.hpp"
 #include <tt-metalium/sub_device.hpp>
 #include <optional>
+#include <tuple>
 
 namespace ttnn::experimental::prim {
 
@@ -55,6 +56,12 @@ struct AllToAllAsyncParams {
             attrs.emplace_back("sub_device_id", sub_device_id.value());
         }
         return attrs;
+    }
+
+    static constexpr auto attribute_names = std::forward_as_tuple(
+        "in_dim", "out_dim", "num_links", "ring_size", "output_mem_config", "topology", "sub_device_id");
+    auto attribute_values() const {
+        return std::make_tuple(in_dim, out_dim, num_links, ring_size, output_mem_config, topology, sub_device_id);
     }
 };
 


### PR DESCRIPTION
### PR Category
hash calculation unification for operation AllToAllAsyncDeviceOperation

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for AllToAllAsyncDeviceOperation

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_AllToAllAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_AllToAllAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_AllToAllAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_AllToAllAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_AllToAllAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_AllToAllAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_AllToAllAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_AllToAllAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_AllToAllAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_AllToAllAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_AllToAllAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_AllToAllAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_AllToAllAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_AllToAllAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_AllToAllAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_AllToAllAsyncDeviceOperation)
