### PR TITLE
#45821: migrate BinaryNgDeviceOperation to default program-cache hash

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_program_cache.py
@@ -6,22 +6,23 @@
 Unit tests for binary_ng program cache behavior.
 
 Tests target potential caching issues.
-The binary_ng operation uses a single ProgramFactory with caching based on:
+The binary_ng operation uses a single ProgramFactory with the default
+reflection-based program-cache hash. The cache key is:
 
-to_hash(): binary_op_type, lhs/rhs/post_activations, memory_config, get_dtype(),
-           compute_kernel_config, sub_core_grids, subtile_broadcast_type,
-           is_sfpu, is_quant_op, is_where_op
+operation_attributes (via attribute_values()): binary_op_type,
+    lhs/rhs/post_activations, memory_config, output_dtype, compute_kernel_config,
+    sub_core_grids, subtile_broadcast_type, is_sfpu, is_quant_op, is_where_op,
+    input_layout_a/b, output_layout, equal_nan
 
-compute_program_hash(): attributes (via to_hash()), input tensor dtypes,
-                        input tensor memory_configs, shard_volumes
+tensor_args: the input/output Tensors are hashed in full via their TensorSpec,
+    so input dtype, memory_config AND logical_shape are part of the key.
 
-Fields correctly excluded from hash (handled by override_runtime_arguments):
-- logical_shape: not in compute_program_hash() by design - different logical
-  shapes share a cache entry and runtime arguments are updated accordingly
-- scalar.has_value(): not in to_hash(), but compute_program_hash branches
-  on input_tensor_b presence
-- input_dtype: not in to_hash(), but compute_program_hash includes input
-  tensor dtypes directly
+Fields excluded from the hash (re-applied by override_runtime_arguments on a
+cache hit):
+- buffer addresses: differently-allocated (incl. in-place, out=x) calls at the
+  same shape share one cache entry; addresses are re-applied at runtime
+- scalar value: not hashed; the scalar path vs tensor path differ because
+  tensor_args carries input_tensor_b only on the tensor path
 """
 
 import pytest
@@ -77,7 +78,7 @@ def run_scalar_ng_op(device, op, shape, scalar, dtype=ttnn.bfloat16, memory_conf
 
 
 # =============================================================================
-# Cache reuse tests (fields correctly excluded from hash)
+# Cache reuse tests (buffer addresses / scalar value excluded from hash)
 # =============================================================================
 
 
@@ -106,11 +107,9 @@ def test_ng_cache_reuse_same_config(device, isolate_program_cache):
 )
 def test_ng_inplace_cache_reuse_different_shapes(device, isolate_program_cache, shape_first, shape_second):
     """binary_ng re-applies all per-dispatch state on a cache hit via override_runtime_arguments
-    (#48928). An in-place add (output_tensor aliases input) with different logical shapes shares one
-    cache entry (volume is excluded from the hash), so the second call is a cache HIT that reuses the
-    first program WITHOUT rebuild. binary_ng's override_runtime_arguments must re-derive every per-core
-    arg for the current shape or the reused program corrupts the result. Regression guard for the
-    in-place cache-hit path (the SDXL silu / moreh class of bug)."""
+    (#48928). With the default reflection hash, logical_shape is part of the key, so two different
+    shapes MISS and get distinct cache entries. This guards in-place correctness (output_tensor
+    aliases input) across the rebuild for both shapes (the SDXL silu / moreh class of bug)."""
 
     def inplace_add(shape, seed):
         torch.manual_seed(seed)
@@ -121,23 +120,23 @@ def test_ng_inplace_cache_reuse_different_shapes(device, isolate_program_cache, 
         with device.cache_entries_counter.measure():
             tt_c = ttnn.add(tt_a, tt_b, output_tensor=tt_a)  # in-place
         # Prove the op is ACTUALLY in-place: if a future change ignored output_tensor or allocated a
-        # fresh output, PCC + single-cache-entry would still pass while no longer testing the alias.
+        # fresh output, PCC would still pass while no longer testing the alias.
         assert tt_c.buffer_address() == tt_a.buffer_address()
         return a + b, ttnn.to_torch(tt_c)
 
     ref1, out1 = inplace_add(shape_first, 0)
     assert_with_pcc(ref1, out1, 0.999)
 
-    ref2, out2 = inplace_add(shape_second, 1)  # cache HIT on the differently-shaped program
+    ref2, out2 = inplace_add(shape_second, 1)  # different shape -> distinct cache entry (miss)
     assert_with_pcc(ref2, out2, 0.999)
 
-    assert device.cache_entries_counter.total == 1  # proves it was a hit, not a rebuild masking the bug
+    assert device.cache_entries_counter.total == 2  # different logical shapes -> distinct entries
 
 
 def test_ng_inplace_cache_hit_sharded_readdresses(device, isolate_program_cache):
     """binary_ng in-place add on SHARDED tensors — the sharding mode SDXL exercised (silu) — driven
-    through binary_ng's override_runtime_arguments cache-hit path. Repeated at the SAME shard config
-    (sharded binary_ng keys shard_volume into the hash, so a different shape would MISS, not hit) but
+    through binary_ng's override_runtime_arguments cache-hit path. Repeated at the SAME shape/shard
+    config (logical_shape is part of the hash, so a different shape would MISS, not hit) but
     with freshly-allocated operands kept alive, so each cache HIT sees a DIFFERENT buffer address.
     binary_ng's tensor-backed CB / rt-arg addresses must be re-applied on the hit (no rebuild) or the
     result is stale."""
@@ -169,7 +168,7 @@ def test_ng_inplace_cache_hit_sharded_readdresses(device, isolate_program_cache)
 def test_ng_cache_mixed_inplace_outofplace_interleaved(device, isolate_program_cache, first_inplace):
     """REGRESSION (aliased address re-derivation): one cached INTERLEAVED program reused across a MIX of
     in-place (output_tensor aliases an input) and out-of-place calls sharing a single cache entry
-    (logical shape is excluded from the hash). The legacy resolve_bindings maps an aliased buffer to its
+    (same shape across all calls; only buffer addresses differ). The legacy resolve_bindings maps an aliased buffer to its
     FIRST occurrence, so a program built under one aliasing pattern and reused under another would patch
     the writer's output address from the wrong tensor slot. binary_ng's override_runtime_arguments
     re-derives every rt-arg address for the actual current tensors, so it MUST survive both orders —
@@ -232,7 +231,7 @@ def test_ng_cache_mixed_inplace_outofplace_sharded(device, isolate_program_cache
     for i, inplace in enumerate([first_inplace, not first_inplace, first_inplace, not first_inplace]):
         ref, out = do(i, inplace)
         assert_with_pcc(ref, out, 0.999)
-    # Same shard config across all calls (sharded binary_ng keys shard_volume) → one shared cache entry.
+    # Same shape/shard config across all calls → one shared cache entry.
     assert device.cache_entries_counter.total == 1
 
 
@@ -270,7 +269,7 @@ def test_ng_cache_miss_different_op_types(device, isolate_program_cache):
 
 def test_ng_cache_miss_different_input_dtypes(device, isolate_program_cache):
     """Different input dtypes -> different cache entries.
-    Differentiated via input tensor dtype in compute_program_hash()."""
+    Differentiated via the input tensors' TensorSpec (dtype) in tensor_args."""
     shape = [1, 1, 32, 64]
 
     torch_ref1, tt_out1 = run_binary_ng_op(device, ttnn.add, shape, shape, dtype=ttnn.bfloat16)
@@ -301,7 +300,7 @@ def test_ng_cache_miss_different_memory_configs(device, isolate_program_cache):
 
 def test_ng_cache_miss_different_subtile_broadcast(device, isolate_program_cache):
     """Different subtile broadcast types -> different cache entries.
-    subtile_broadcast_type is in to_hash() and depends on last-2-dim shapes."""
+    subtile_broadcast_type is in the hash (operation_attributes) and depends on last-2-dim shapes."""
     # NONE: equal shapes
     torch_ref1, tt_out1 = run_binary_ng_op(device, ttnn.add, [1, 1, 32, 64], [1, 1, 32, 64], dtype=ttnn.float32)
     assert_with_pcc(torch_ref1, tt_out1, 0.9999)
@@ -344,9 +343,8 @@ def test_ng_cache_miss_different_output_dtypes(device, isolate_program_cache):
 
 def test_ng_scalar_vs_tensor_cache_differentiation(device, isolate_program_cache):
     """Scalar op vs tensor op -> different cache entries.
-    scalar.has_value() is not in to_hash(), but compute_program_hash()
-    naturally differentiates because the scalar path excludes tensor_b
-    from hash arguments while the tensor path includes it."""
+    The scalar value is not hashed, but tensor_args naturally differentiates:
+    the scalar path carries no input_tensor_b while the tensor path does."""
     shape = [1, 1, 32, 64]
 
     # Scalar path
@@ -362,7 +360,7 @@ def test_ng_scalar_vs_tensor_cache_differentiation(device, isolate_program_cache
 
 def test_ng_cache_miss_different_sub_core_grids(device, isolate_program_cache):
     """Different sub_core_grids -> different cache entries.
-    sub_core_grids is in to_hash() and directly determines worker_grid."""
+    sub_core_grids is in the hash (operation_attributes) and directly determines worker_grid."""
     shape = [1, 1, 32, 64]
 
     torch_a1 = torch.rand(shape, dtype=torch.float32)
@@ -392,8 +390,8 @@ def test_ng_cache_miss_different_sub_core_grids(device, isolate_program_cache):
 
 def test_ng_different_input_dtypes_same_output_dtype(device, isolate_program_cache):
     """Different input dtypes with same output dtype -> different cache entries.
-    input_dtype is not in to_hash(), but compute_program_hash() includes
-    input tensor dtypes directly, which compensates."""
+    The input dtype is not in operation_attributes, but tensor_args hashes each
+    input's TensorSpec (dtype), which differentiates them."""
     shape = [1, 1, 32, 64]
 
     # bfloat16 input -> float32 output
@@ -422,31 +420,30 @@ def test_ng_different_input_dtypes_same_output_dtype(device, isolate_program_cac
 
 
 # =============================================================================
-# Cache reuse tests: logical_shape correctly excluded from hash
+# Cache miss tests: logical_shape included in the hash
 #
-# Different logical shapes share a cache entry by design. Hashing logical
-# shapes would be overkill since override_runtime_arguments handles shape
-# differences at runtime.
+# With the default reflection hash, tensor_args (and thus each Tensor's
+# TensorSpec.logical_shape) is part of the key, so different logical shapes get
+# distinct cache entries. override_runtime_arguments still re-applies per-core
+# args and buffer addresses on same-shape cache hits.
 # =============================================================================
 
 
-def test_ng_cache_reuse_different_logical_shapes(device, isolate_program_cache):
-    """Different logical shapes share 1 cache entry, different outputs (by design).
-    logical_shape is correctly excluded from compute_program_hash();
-    override_runtime_arguments handles shape differences at runtime."""
+def test_ng_cache_miss_different_logical_shapes(device, isolate_program_cache):
+    """Different logical shapes -> distinct cache entries, different outputs.
+    logical_shape is part of the default reflection hash (via TensorSpec)."""
     torch_ref1, tt_out1 = run_binary_ng_op(device, ttnn.add, [1, 1, 32, 32], [1, 1, 32, 32], dtype=ttnn.float32)
     assert_with_pcc(torch_ref1, tt_out1, 0.9999)
 
     torch_ref2, tt_out2 = run_binary_ng_op(device, ttnn.add, [1, 1, 64, 64], [1, 1, 64, 64], dtype=ttnn.float32)
     assert_with_pcc(torch_ref2, tt_out2, 0.9999)
 
-    assert device.cache_entries_counter.total == 1
+    assert device.cache_entries_counter.total == 2
     assert tt_out1.shape != tt_out2.shape
 
 
-def test_ng_cache_reuse_different_logical_shapes_correctness(device, isolate_program_cache):
-    """Correctness across multiple logical shapes sharing a single cache entry.
-    override_runtime_arguments correctly updates runtime args for each shape."""
+def test_ng_cache_different_logical_shapes_correctness(device, isolate_program_cache):
+    """Correctness across multiple logical shapes, each with its own cache entry."""
     for shape_dim in [32, 64, 128]:
         shape = [1, 1, shape_dim, shape_dim]
         torch_a = torch.rand(shape, dtype=torch.float32)
@@ -461,7 +458,7 @@ def test_ng_cache_reuse_different_logical_shapes_correctness(device, isolate_pro
             tt_out = ttnn.add(tt_a, tt_b)
         assert_with_pcc(torch_ref, ttnn.to_torch(tt_out), 0.9999)
 
-    assert device.cache_entries_counter.total == 1
+    assert device.cache_entries_counter.total == 3
 
 
 # =============================================================================

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -225,30 +225,6 @@ SubtileBroadcastType get_subtile_broadcast_type(uint32_t a_h, uint32_t a_w, uint
     TT_THROW("Invalid subtile broadcast type");
 }
 
-ttsl::hash::hash_t BinaryNgDeviceOperation::operation_attributes_t::to_hash() const {
-    // TODO: a more generalized way to skip the hashing of an EltwiseUnaryWithParam?
-    auto base_hash = ttsl::hash::hash_objects_with_default_seed(
-        binary_op_type,
-        lhs_activations,
-        rhs_activations,
-        (is_where_op || is_quant_op) ? ttsl::SmallVector<unary::EltwiseUnaryWithParam>{} : post_activations,
-        memory_config,
-        get_dtype(),
-        compute_kernel_config,
-        sub_core_grids,
-        subtile_broadcast_type,
-        is_sfpu,
-        is_quant_op,
-        is_where_op,
-        input_layout_a,
-        input_layout_b,
-        output_layout);
-    if (binary_op_type == BinaryOpType::ISCLOSE) {
-        base_hash = ttsl::hash::hash_objects(base_hash, equal_nan);
-    }
-    return base_hash;
-}
-
 DataType BinaryNgDeviceOperation::operation_attributes_t::get_dtype() const {
     return this->dtype.value_or(this->input_dtype);
 }
@@ -510,32 +486,6 @@ BinaryNgDeviceOperation::tensor_return_value_t BinaryNgDeviceOperation::create_o
 
     return create_device_tensor(
         compute_output_specs(operation_attributes, tensor_args), tensor_args.input_tensor_a.device());
-}
-
-ttsl::hash::hash_t BinaryNgDeviceOperation::compute_program_hash(
-    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
-    const auto& input_tensor_a = tensor_args.input_tensor_a;
-    const auto& input_tensor_b = tensor_args.input_tensor_b;
-
-    TT_FATAL(is_device_tensor(input_tensor_a), "Unexpected Tensor type {}", input_tensor_a.storage_type());
-
-    if (input_tensor_b.has_value()) {
-        TT_FATAL(is_device_tensor(*input_tensor_b), "Unexpected Tensor type {}", input_tensor_b->storage_type());
-
-        const auto shard_volumes = get_shard_volumes(
-            input_tensor_a.tensor_spec(), input_tensor_b->tensor_spec(), compute_output_specs(attributes, tensor_args));
-
-        return operation::hash_operation<BinaryNgDeviceOperation>(
-            attributes,
-            input_tensor_a.dtype(),
-            input_tensor_a.memory_config(),
-            input_tensor_b->dtype(),
-            input_tensor_b->memory_config(),
-            shard_volumes);
-    }
-
-    return operation::hash_operation<BinaryNgDeviceOperation>(
-        attributes, input_tensor_a.dtype(), input_tensor_a.memory_config());
 }
 
 bool BinaryNgDeviceOperation::skip_launch(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <tuple>
+
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/operations/eltwise/binary_ng/types.hpp"
@@ -56,7 +58,43 @@ struct BinaryNgDeviceOperation {
         Layout input_layout_b = Layout::TILE;
         Layout output_layout = Layout::TILE;
 
-        ttsl::hash::hash_t to_hash() const;
+        static constexpr auto attribute_names = std::forward_as_tuple(
+            "binary_op_type",
+            "lhs_activations",
+            "rhs_activations",
+            "post_activations",
+            "memory_config",
+            "output_dtype",
+            "compute_kernel_config",
+            "sub_core_grids",
+            "subtile_broadcast_type",
+            "is_sfpu",
+            "is_quant_op",
+            "is_where_op",
+            "input_layout_a",
+            "input_layout_b",
+            "output_layout",
+            "equal_nan");
+        auto attribute_values() const {
+            return std::make_tuple(
+                binary_op_type,
+                lhs_activations,
+                rhs_activations,
+                (is_where_op || is_quant_op) ? ttsl::SmallVector<unary::EltwiseUnaryWithParam>{} : post_activations,
+                memory_config,
+                get_dtype(),
+                compute_kernel_config,
+                sub_core_grids,
+                subtile_broadcast_type,
+                is_sfpu,
+                is_quant_op,
+                is_where_op,
+                input_layout_a,
+                input_layout_b,
+                output_layout,
+                equal_nan);
+        }
+
         DataType get_dtype() const;
     };
 
@@ -78,14 +116,13 @@ struct BinaryNgDeviceOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static bool skip_launch(const operation_attributes_t&, const tensor_args_t&, const tensor_return_value_t&);
 
     // Re-apply ALL per-dispatch state to the cached program on every program-cache hit — the
-    // descriptor-era analog of the legacy override_runtime_arguments().  compute_program_hash
-    // EXCLUDES the tensor volume, so one cached program is reused across differently-shaped and
-    // differently-allocated (incl. in-place, out=x) calls; this re-derives every per-core runtime
-    // arg AND every tensor-backed circular-buffer base address for the CURRENT tensors, via the same
+    // descriptor-era analog of the legacy override_runtime_arguments().  The program hash EXCLUDES
+    // buffer addresses, so one cached program is reused across differently-allocated (incl. in-place,
+    // out=x) calls; this re-derives every per-core runtime arg AND every tensor-backed
+    // circular-buffer base address for the CURRENT tensors, via the same
     // shared builder create_descriptor() uses.  Correct by construction — no address inference, so
     // in-place / mixed-aliasing / matmul(X,X)-style cases can't be mis-patched.  An op that defines
     // this MUST NOT also define get_dynamic_runtime_args (the adapter static_asserts it); override

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -401,16 +401,15 @@ struct BinaryNgPerCoreArgs {
 // SINGLE SOURCE OF TRUTH for binary_ng per-core runtime args.  Run by BOTH create_descriptor()
 // (cache miss) and BinaryNgDeviceOperation::override_runtime_arguments() (cache hit).
 //
-// binary_ng's compute_program_hash intentionally EXCLUDES the tensor volume, so one cached program
-// is shared across differently-shaped calls.  On a cache hit the descriptor is NOT rebuilt, so every
-// shape/work-split-dependent per-core arg (c_start_id, per-core tile counts, strides, D/N/C/Ht/Wt,
-// compute_tiles, freq/counter, packed scalar, ...) would otherwise stay frozen at the first-miss
-// shape and corrupt results.  override_runtime_arguments() re-runs THIS builder for the current
-// tensors and re-applies each arg every dispatch.  Because the work-core set itself changes with
-// volume (a core can flip between work and noop across hits), the builder emits args for ALL
-// num_cores_total cores -- noop cores get zero-filled lists sized to match the work-core layout -- and
-// override_runtime_arguments re-applies every slot (buffer slots via their current address), so nothing
-// is left frozen regardless of how the partition shifts.
+// binary_ng's program hash EXCLUDES buffer addresses, so one cached program is shared across
+// differently-allocated (incl. in-place, out=x) calls.  On a cache hit the descriptor is NOT rebuilt,
+// so every per-core arg that carries a tensor address -- and every shape/work-split-dependent arg
+// (c_start_id, per-core tile counts, strides, D/N/C/Ht/Wt, compute_tiles, freq/counter, packed scalar,
+// ...) -- would otherwise stay frozen at the first miss and corrupt results.  override_runtime_arguments()
+// re-runs THIS builder for the current tensors and re-applies each arg every dispatch.  The builder
+// emits args for ALL num_cores_total cores -- noop cores get zero-filled lists sized to match the
+// work-core layout -- and override_runtime_arguments re-applies every slot (buffer slots via their
+// current address), so nothing is left frozen.
 BinaryNgPerCoreArgs build_per_core_runtime_args(
     const BinaryNgDeviceOperation::operation_attributes_t& operation_attributes,
     const Tensor& a,
@@ -605,8 +604,8 @@ BinaryNgPerCoreArgs build_per_core_runtime_args(
             c_num_tiles_core = num_tiles_per_core_group_2;
         } else {
             // Noop core: zero-filled runtime args, sized to match the active kernel variant so unused
-            // cores neither inflate the per-kernel max runtime-arg allocation nor change slot count when a
-            // core flips between noop and work across differently-shaped cache hits.
+            // cores neither inflate the per-kernel max runtime-arg allocation nor change the slot count
+            // the reader/writer/compute kernels expect.
             const size_t reader_len = row_major_inputs ? 26 : 21;
             const size_t writer_len = row_major_inputs ? 14 : (b.has_value() ? 11 : 12);
             const size_t compute_len = (op_type == BinaryOpType::ISCLOSE) ? 5 : 4;
@@ -1355,9 +1354,9 @@ void BinaryNgDeviceOperation::override_runtime_arguments(
     tensor_return_value_t& c,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
     // Re-apply ALL per-dispatch state to the cached program on a program-cache hit (the descriptor-era
-    // override_runtime_arguments()).  compute_program_hash EXCLUDES the tensor volume, so one cached
-    // program is reused across differently-shaped and differently-allocated (incl. in-place, out=x)
-    // calls; every shape-/work-split-dependent per-core arg AND every tensor-backed CB base address
+    // override_runtime_arguments()).  The program hash EXCLUDES buffer addresses, so one cached
+    // program is reused across differently-allocated (incl. in-place, out=x) calls; every
+    // tensor-backed CB base address AND every shape-/work-split-dependent per-core arg
     // would otherwise stay frozen at the first miss.  We re-derive them for the CURRENT tensors from
     // the SAME shared builder create_descriptor() uses, so the two stay byte-identical by construction.
     //
@@ -1365,10 +1364,9 @@ void BinaryNgDeviceOperation::override_runtime_arguments(
     // from Buffer* identity, so an in-place alias (input_a == output) or a mixed in-place/out-of-place
     // reuse of one cache entry writes each slot from the tensor it actually belongs to.
     //
-    // Kernel push order in create_descriptor(): reader(0), writer(1), compute(2).  The work-core
-    // partition shifts with the volume (a core can flip between work and noop), so the builder emits
+    // Kernel push order in create_descriptor(): reader(0), writer(1), compute(2).  The builder emits
     // args for ALL cores; we re-apply every one, buffer-address slots included (via the current Buffer
-    // address), so a core promoted to a work core on this hit is never left with a stale base address.
+    // address), so no core is ever left with a stale base address.
     const auto& a = tensor_args.input_tensor_a;
     const auto& b = tensor_args.input_tensor_b;
 


### PR DESCRIPTION
### PR Category
hash calculation unification for operation BinaryNgDeviceOperation

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for BinaryNgDeviceOperation

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_BinaryNgDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_BinaryNgDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_BinaryNgDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_BinaryNgDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_BinaryNgDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_BinaryNgDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_BinaryNgDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_BinaryNgDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_BinaryNgDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_BinaryNgDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_BinaryNgDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_BinaryNgDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_BinaryNgDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_BinaryNgDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_BinaryNgDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_BinaryNgDeviceOperation)
