### PR TITLE
Unify program-cache hashing for Quasar BinaryNgDeviceOperation

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.cpp
@@ -227,30 +227,6 @@ SubtileBroadcastType get_subtile_broadcast_type(uint32_t a_h, uint32_t a_w, uint
     TT_THROW("Invalid subtile broadcast type");
 }
 
-ttsl::hash::hash_t BinaryNgDeviceOperation::operation_attributes_t::to_hash() const {
-    // TODO: a more generalized way to skip the hashing of an EltwiseUnaryWithParam?
-    auto base_hash = ttsl::hash::hash_objects_with_default_seed(
-        binary_op_type,
-        lhs_activations,
-        rhs_activations,
-        (is_where_op || is_quant_op) ? ttsl::SmallVector<unary::EltwiseUnaryWithParam>{} : post_activations,
-        memory_config,
-        get_dtype(),
-        compute_kernel_config,
-        sub_core_grids,
-        subtile_broadcast_type,
-        is_sfpu,
-        is_quant_op,
-        is_where_op,
-        input_layout_a,
-        input_layout_b,
-        output_layout);
-    if (binary_op_type == BinaryOpType::ISCLOSE) {
-        base_hash = ttsl::hash::hash_objects(base_hash, equal_nan);
-    }
-    return base_hash;
-}
-
 DataType BinaryNgDeviceOperation::operation_attributes_t::get_dtype() const {
     return this->dtype.value_or(this->input_dtype);
 }
@@ -481,66 +457,6 @@ BinaryNgDeviceOperation::tensor_return_value_t BinaryNgDeviceOperation::create_o
 
     return create_device_tensor(
         compute_output_specs(operation_attributes, tensor_args), tensor_args.input_tensor_a.device());
-}
-
-ttsl::hash::hash_t BinaryNgDeviceOperation::compute_program_hash(
-    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
-    const auto& input_tensor_a = tensor_args.input_tensor_a;
-    const auto& input_tensor_b = tensor_args.input_tensor_b;
-
-    TT_FATAL(is_device_tensor(input_tensor_a), "Unexpected Tensor type {}", input_tensor_a.storage_type());
-
-    // The Metal 2.0 factory bakes each operand's full TensorSpec into the ProgramSpec's
-    // TensorParameters, and ValidateTensorArgs enforces exact spec equality on every cache hit — so a
-    // cached program is reusable only for an identical (a, b, output) spec triple. The metal_v2 branch
-    // therefore folds the full specs. (Folding only the output volume collides for differently-shaped
-    // ops that share a volume — e.g. outer-broadcast operands — reusing a program whose baked spec no
-    // longer matches.) The descriptor path keeps the default shape-excluding hash (its program is
-    // shape-agnostic via runtime args).
-    const bool metal_v2 = select_program_factory(attributes, tensor_args).index() != 0;
-
-    if (input_tensor_b.has_value()) {
-        TT_FATAL(is_device_tensor(*input_tensor_b), "Unexpected Tensor type {}", input_tensor_b->storage_type());
-
-        const auto output_spec = compute_output_specs(attributes, tensor_args);
-
-        if (metal_v2) {
-            return operation::hash_operation<BinaryNgDeviceOperation>(
-                attributes, input_tensor_a.tensor_spec(), input_tensor_b->tensor_spec(), output_spec);
-        }
-
-        // Descriptor (ProgramFactory) path. Its program is nominally shape-agnostic via runtime args, but
-        // it bakes shape-dependent uint32 scalars (per-core tile counts, start ids, D/N/C/Ht/Wt dims,
-        // row-width strides — see the reader/writer arg builders in binary_ng_program_factory.cpp) into
-        // those args, and now declares the output as a BufferBinding, so a cross-shape cache hit would
-        // re-use frozen scalars against a differently-shaped tensor (wrong tile range / OOB). Key on
-        // dtype/memory_config plus the per-operand shard volumes AND the full padded shapes of every
-        // present operand + output, so both differently-sharded and differently-shaped ops get distinct
-        // cache entries (over-keying is safe; under-keying is the bug). shard_volumes is computed only on
-        // this branch — the metal_v2 branch folds full specs instead.
-        const auto shard_volumes =
-            get_shard_volumes(input_tensor_a.tensor_spec(), input_tensor_b->tensor_spec(), output_spec);
-        return operation::hash_operation<BinaryNgDeviceOperation>(
-            attributes,
-            input_tensor_a.dtype(),
-            input_tensor_a.memory_config(),
-            input_tensor_b->dtype(),
-            input_tensor_b->memory_config(),
-            shard_volumes,
-            input_tensor_a.padded_shape(),
-            input_tensor_b->padded_shape(),
-            output_spec.padded_shape());
-    }
-
-    // Descriptor path, single operand (scalar RHS). Same reasoning as the has-b descriptor branch above:
-    // the baked reader/writer scalars derive from the a/output padded shapes, so hash them.
-    const auto output_spec = compute_output_specs(attributes, tensor_args);
-    return operation::hash_operation<BinaryNgDeviceOperation>(
-        attributes,
-        input_tensor_a.dtype(),
-        input_tensor_a.memory_config(),
-        input_tensor_a.padded_shape(),
-        output_spec.padded_shape());
 }
 
 bool BinaryNgDeviceOperation::skip_launch(

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.hpp
@@ -72,9 +72,12 @@ struct BinaryNgDeviceOperation {
             "input_layout_a",
             "input_layout_b",
             "output_layout",
-            "equal_nan");
+            "equal_nan",
+            "scalar",
+            "rtol",
+            "atol");
         auto attribute_values() const {
-            return std::forward_as_tuple(
+            return std::make_tuple(
                 binary_op_type,
                 lhs_activations,
                 rhs_activations,
@@ -90,7 +93,10 @@ struct BinaryNgDeviceOperation {
                 input_layout_a,
                 input_layout_b,
                 output_layout,
-                equal_nan);
+                equal_nan,
+                scalar,
+                rtol,
+                atol);
         }
         DataType get_dtype() const;
     };

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.hpp
@@ -10,6 +10,7 @@
 #include "ttnn/operations/experimental/quasar/binary_ng/types.hpp"
 #include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
 #include <tt-metalium/sub_device_types.hpp>
+#include <tuple>
 #include <tt-metalium/program_descriptors.hpp>
 namespace ttnn::operations::experimental::quasar::binary_ng {
 
@@ -55,7 +56,42 @@ struct BinaryNgDeviceOperation {
         Layout input_layout_b = Layout::TILE;
         Layout output_layout = Layout::TILE;
 
-        ttsl::hash::hash_t to_hash() const;
+        static constexpr auto attribute_names = std::forward_as_tuple(
+            "binary_op_type",
+            "lhs_activations",
+            "rhs_activations",
+            "post_activations",
+            "memory_config",
+            "dtype",
+            "compute_kernel_config",
+            "sub_core_grids",
+            "subtile_broadcast_type",
+            "is_sfpu",
+            "is_quant_op",
+            "is_where_op",
+            "input_layout_a",
+            "input_layout_b",
+            "output_layout",
+            "equal_nan");
+        auto attribute_values() const {
+            return std::forward_as_tuple(
+                binary_op_type,
+                lhs_activations,
+                rhs_activations,
+                (is_where_op || is_quant_op) ? ttsl::SmallVector<unary::EltwiseUnaryWithParam>{} : post_activations,
+                memory_config,
+                get_dtype(),
+                compute_kernel_config,
+                sub_core_grids,
+                subtile_broadcast_type,
+                is_sfpu,
+                is_quant_op,
+                is_where_op,
+                input_layout_a,
+                input_layout_b,
+                output_layout,
+                equal_nan);
+        }
         DataType get_dtype() const;
     };
 
@@ -92,15 +128,13 @@ struct BinaryNgDeviceOperation {
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
 
     // True iff (attributes, tensor_args) match the Metal 2.0 factory's supported slice. Shared by
-    // select_program_factory and compute_program_hash (to fold the shape into the hash for matching
-    // ops only).
+    // select_program_factory.
     static bool matches_metal_v2_slice(const operation_attributes_t&, const tensor_args_t&);
 
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static bool skip_launch(const operation_attributes_t&, const tensor_args_t&, const tensor_return_value_t&);
 };
 


### PR DESCRIPTION
### PR Category
hash calculation unification for operation BinaryNgDeviceOperation (quasar)

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for BinaryNgDeviceOperation (quasar)

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_BinaryNgDeviceOperation_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_BinaryNgDeviceOperation_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_BinaryNgDeviceOperation_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_BinaryNgDeviceOperation_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_BinaryNgDeviceOperation_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_BinaryNgDeviceOperation_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_BinaryNgDeviceOperation_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_BinaryNgDeviceOperation_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_BinaryNgDeviceOperation_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_BinaryNgDeviceOperation_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_BinaryNgDeviceOperation_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_BinaryNgDeviceOperation_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_BinaryNgDeviceOperation_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_BinaryNgDeviceOperation_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_BinaryNgDeviceOperation_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_BinaryNgDeviceOperation_quasar)
