### PR TITLE
Migrate Conv2d to the default program-cache hash

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation.cpp
@@ -142,30 +142,6 @@ void Conv2dDeviceOperation::validate_on_program_cache_miss(
     }
 }
 
-ttsl::hash::hash_t Conv2dDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    hashable_operation_attributes_t hashable_args = {
-        .sliding_window_config = args.sliding_window_config,
-        .output_channels = args.output_channels,
-        .groups = args.groups,
-        .untilize_out = args.untilize_out,
-        .has_bias = args.has_bias,
-        .activation = args.activation,
-        .parallelization_config = args.parallelization_config,
-        .block_config = args.block_config,
-        .memory_config = args.memory_config,
-        .dtype = args.dtype,
-        .input_tensor_shape = args.input_tensor_shape,
-        .compute_kernel_config = args.compute_kernel_config,
-        .enable_act_double_buffer = args.enable_act_double_buffer,
-        .enable_weights_double_buffer = args.enable_weights_double_buffer,
-        .enable_activation_reuse = args.enable_activation_reuse,
-        .config_tensors_in_dram = args.config_tensors_in_dram,
-        .force_split_reader = args.force_split_reader,
-    };
-    return ttsl::hash::hash_objects_with_default_seed(hashable_args, tensor_args);
-}
-
 tt::tt_metal::operation::OpPerformanceModelGeneral<Tensor> Conv2dDeviceOperation::create_op_performance_model(
     const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensor) {
     const auto& input_tensor_a_shape = args.input_tensor_shape;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation.hpp
@@ -28,7 +28,6 @@ namespace sliding_window = ttnn::operations::sliding_window;
 
 struct Conv2dDeviceOperation {
     using operation_attributes_t = Conv2dParams;
-    using hashable_operation_attributes_t = Conv2dHashableParams;
     using tensor_args_t = Conv2dInputs;
     using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
@@ -41,8 +40,6 @@ struct Conv2dDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& args, const tensor_args_t& tensor_args);
     static void validate_on_program_cache_miss(const operation_attributes_t& args, const tensor_args_t& tensor_args);
-    static ttsl::hash::hash_t compute_program_hash(
-        const operation_attributes_t& args, const tensor_args_t& tensor_args);
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensor);
 };

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp
@@ -232,6 +232,7 @@ struct Conv2dParams {
         "compute_kernel_config",
         "enable_act_double_buffer",
         "enable_weights_double_buffer",
+        "full_inner_dim",
         "enable_activation_reuse",
         "config_tensors_in_dram",
         "force_split_reader");
@@ -251,6 +252,7 @@ struct Conv2dParams {
             std::cref(this->compute_kernel_config),
             std::cref(this->enable_act_double_buffer),
             std::cref(this->enable_weights_double_buffer),
+            std::cref(this->full_inner_dim),
             std::cref(this->enable_activation_reuse),
             std::cref(this->config_tensors_in_dram),
             std::cref(this->force_split_reader));

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp
@@ -216,6 +216,45 @@ struct Conv2dParams {
     bool config_tensors_in_dram = false;
     uint32_t pre_op_l1_allocation_size_bytes = 0;
     std::optional<bool> force_split_reader;
+
+    static constexpr auto attribute_names = std::make_tuple(
+        "sliding_window_config",
+        "output_channels",
+        "groups",
+        "untilize_out",
+        "has_bias",
+        "activation",
+        "parallelization_config",
+        "block_config",
+        "memory_config",
+        "dtype",
+        "input_tensor_shape",
+        "compute_kernel_config",
+        "enable_act_double_buffer",
+        "enable_weights_double_buffer",
+        "enable_activation_reuse",
+        "config_tensors_in_dram",
+        "force_split_reader");
+    auto attribute_values() const {
+        return std::make_tuple(
+            std::cref(this->sliding_window_config),
+            std::cref(this->output_channels),
+            std::cref(this->groups),
+            std::cref(this->untilize_out),
+            std::cref(this->has_bias),
+            std::cref(this->activation),
+            std::cref(this->parallelization_config),
+            std::cref(this->block_config),
+            std::cref(this->memory_config),
+            std::cref(this->dtype),
+            std::cref(this->input_tensor_shape),
+            std::cref(this->compute_kernel_config),
+            std::cref(this->enable_act_double_buffer),
+            std::cref(this->enable_weights_double_buffer),
+            std::cref(this->enable_activation_reuse),
+            std::cref(this->config_tensors_in_dram),
+            std::cref(this->force_split_reader));
+    }
 };
 
 struct Conv2dHashableParams {


### PR DESCRIPTION
### PR Category
hash calculation unification for operation Conv2dDeviceOperation

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for Conv2dDeviceOperation

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_Conv2dDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_Conv2dDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_Conv2dDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_Conv2dDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_Conv2dDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_Conv2dDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_Conv2dDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_Conv2dDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_Conv2dDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_Conv2dDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_Conv2dDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_Conv2dDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_Conv2dDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_Conv2dDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_Conv2dDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_Conv2dDeviceOperation)
