### PR TITLE
#45821: migrate Conv2dDeviceOperation (quasar) to default program-cache hash

### DIFF
--- a/models/demos/vision/classification/resnet50/quasar/tests/ops/test_conv2d.py
+++ b/models/demos/vision/classification/resnet50/quasar/tests/ops/test_conv2d.py
@@ -275,3 +275,89 @@ def test_quasar_conv2d(
         shard_layout=shard_layout,
         reshard_if_not_optimal=reshard_if_not_optimal,
     )
+
+
+def _launch_quasar_conv2d(device, *, full_inner_dim):
+    torch.manual_seed(0)
+    batch_size, in_channels, out_channels, input_height, input_width = 1, 256, 256, 14, 14
+    kernel_size, stride, padding = (3, 3), (1, 1), (1, 1)
+
+    torch_input_nhwc = torch.randn((batch_size, input_height, input_width, in_channels), dtype=torch.bfloat16)
+    torch_weight = torch.randn((out_channels, in_channels, *kernel_size), dtype=torch.bfloat16)
+    torch_bias = torch.randn((1, 1, 1, out_channels), dtype=torch.bfloat16)
+
+    tt_input = ttnn.from_torch(torch_input_nhwc, dtype=ttnn.bfloat16)
+    tt_weight = ttnn.from_torch(torch_weight, dtype=ttnn.bfloat16)
+    tt_bias = ttnn.from_torch(torch_bias, dtype=ttnn.bfloat16)
+
+    conv_config = ttnn.Conv2dConfig(
+        weights_dtype=ttnn.bfloat16,
+        shard_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+        reshard_if_not_optimal=True,
+        full_inner_dim=full_inner_dim,
+    )
+    compute_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.LoFi,
+        packer_l1_acc=True,
+    )
+
+    out, _, _ = ttnn.experimental.quasar.conv2d(
+        input_tensor=tt_input,
+        weight_tensor=tt_weight,
+        bias_tensor=tt_bias,
+        in_channels=in_channels,
+        out_channels=out_channels,
+        batch_size=batch_size,
+        input_height=input_height,
+        input_width=input_width,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        dilation=(1, 1),
+        groups=1,
+        device=device,
+        conv_config=conv_config,
+        compute_config=compute_config,
+        return_output_dim=True,
+        return_weights_and_bias=True,
+        dtype=ttnn.bfloat16,
+    )
+    ttnn.synchronize_device(device)
+    return out
+
+
+@pytest.mark.timeout(600)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+def test_quasar_conv2d_program_cache(mesh_device):
+    device = mesh_device
+    grid = device.compute_with_storage_grid_size()
+    max_cores = grid.x * grid.y
+    sticks = 14 * 14
+    if sticks / max_cores > 2048:
+        pytest.skip(
+            f"conv activation = {sticks} sticks over {max_cores} cores = {sticks // max_cores}/core; "
+            f"run on the full Quasar part."
+        )
+
+    device.enable_program_cache()
+    device.clear_program_cache()
+
+    before = device.num_program_cache_entries()
+    _launch_quasar_conv2d(device, full_inner_dim=False)
+    after_first = device.num_program_cache_entries()
+    assert (
+        after_first == before + 1
+    ), f"first launch should add exactly one program-cache entry, added {after_first - before}"
+
+    _launch_quasar_conv2d(device, full_inner_dim=False)
+    after_repeat = device.num_program_cache_entries()
+    assert (
+        after_repeat == after_first
+    ), f"identical relaunch should reuse the cached program, added {after_repeat - after_first}"
+
+    _launch_quasar_conv2d(device, full_inner_dim=True)
+    after_toggle = device.num_program_cache_entries()
+    assert (
+        after_toggle == after_repeat + 1
+    ), f"flipping full_inner_dim must produce a distinct cache entry, added {after_toggle - after_repeat}"

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp
@@ -6,6 +6,7 @@
 
 #include <optional>
 #include <string>
+#include <tuple>
 #include <utility>
 #include "ttnn/operations/sliding_window/sliding_window.hpp"
 #include "ttnn/tensor/tensor.hpp"
@@ -216,6 +217,47 @@ struct Conv2dParams {
     bool config_tensors_in_dram = false;
     uint32_t pre_op_l1_allocation_size_bytes = 0;
     std::optional<bool> force_split_reader;
+
+    static constexpr auto attribute_names = std::forward_as_tuple(
+        "sliding_window_config",
+        "output_channels",
+        "groups",
+        "untilize_out",
+        "has_bias",
+        "activation",
+        "parallelization_config",
+        "block_config",
+        "memory_config",
+        "dtype",
+        "input_tensor_shape",
+        "compute_kernel_config",
+        "enable_act_double_buffer",
+        "enable_weights_double_buffer",
+        "full_inner_dim",
+        "enable_activation_reuse",
+        "config_tensors_in_dram",
+        "force_split_reader");
+    auto attribute_values() const {
+        return std::make_tuple(
+            std::cref(this->sliding_window_config),
+            this->output_channels,
+            this->groups,
+            this->untilize_out,
+            this->has_bias,
+            std::cref(this->activation),
+            std::cref(this->parallelization_config),
+            std::cref(this->block_config),
+            std::cref(this->memory_config),
+            this->dtype,
+            std::cref(this->input_tensor_shape),
+            std::cref(this->compute_kernel_config),
+            this->enable_act_double_buffer,
+            this->enable_weights_double_buffer,
+            this->full_inner_dim,
+            this->enable_activation_reuse,
+            this->config_tensors_in_dram,
+            std::cref(this->force_split_reader));
+    }
 };
 
 struct Conv2dHashableParams {

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_device_operation.cpp
@@ -142,30 +142,6 @@ void Conv2dDeviceOperation::validate_on_program_cache_miss(
     }
 }
 
-ttsl::hash::hash_t Conv2dDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    hashable_operation_attributes_t hashable_args = {
-        .sliding_window_config = args.sliding_window_config,
-        .output_channels = args.output_channels,
-        .groups = args.groups,
-        .untilize_out = args.untilize_out,
-        .has_bias = args.has_bias,
-        .activation = args.activation,
-        .parallelization_config = args.parallelization_config,
-        .block_config = args.block_config,
-        .memory_config = args.memory_config,
-        .dtype = args.dtype,
-        .input_tensor_shape = args.input_tensor_shape,
-        .compute_kernel_config = args.compute_kernel_config,
-        .enable_act_double_buffer = args.enable_act_double_buffer,
-        .enable_weights_double_buffer = args.enable_weights_double_buffer,
-        .enable_activation_reuse = args.enable_activation_reuse,
-        .config_tensors_in_dram = args.config_tensors_in_dram,
-        .force_split_reader = args.force_split_reader,
-    };
-    return ttsl::hash::hash_objects_with_default_seed(hashable_args, tensor_args);
-}
-
 tt::tt_metal::operation::OpPerformanceModelGeneral<Tensor> Conv2dDeviceOperation::create_op_performance_model(
     const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensor) {
     const auto& input_tensor_a_shape = args.input_tensor_shape;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_device_operation.hpp
@@ -28,7 +28,6 @@ namespace sliding_window = ttnn::operations::sliding_window;
 
 struct Conv2dDeviceOperation {
     using operation_attributes_t = Conv2dParams;
-    using hashable_operation_attributes_t = Conv2dHashableParams;
     using tensor_args_t = Conv2dInputs;
     using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
@@ -41,8 +40,6 @@ struct Conv2dDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& args, const tensor_args_t& tensor_args);
     static void validate_on_program_cache_miss(const operation_attributes_t& args, const tensor_args_t& tensor_args);
-    static ttsl::hash::hash_t compute_program_hash(
-        const operation_attributes_t& args, const tensor_args_t& tensor_args);
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensor);
 };


### PR DESCRIPTION
### PR Category
hash calculation unification for operation Conv2dDeviceOperation (quasar)

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for Conv2dDeviceOperation (quasar)

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_Conv2dDeviceOperation_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_Conv2dDeviceOperation_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_Conv2dDeviceOperation_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_Conv2dDeviceOperation_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_Conv2dDeviceOperation_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_Conv2dDeviceOperation_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_Conv2dDeviceOperation_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_Conv2dDeviceOperation_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_Conv2dDeviceOperation_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_Conv2dDeviceOperation_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_Conv2dDeviceOperation_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_Conv2dDeviceOperation_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_Conv2dDeviceOperation_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_Conv2dDeviceOperation_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_Conv2dDeviceOperation_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_Conv2dDeviceOperation_quasar)
