### PR TITLE
#45821: migrate CrossEntropyBackwardDeviceOperation (tt-train) to default program-cache hash

### DIFF
--- a/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/cross_entropy_bw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/cross_entropy_bw_device_operation.cpp
@@ -88,14 +88,6 @@ CrossEntropyBackwardDeviceOperation::tensor_return_value_t CrossEntropyBackwardD
     return output_tensor;
 }
 
-ttsl::hash::hash_t CrossEntropyBackwardDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    const auto& input_tensor = tensor_args.input;
-    const auto& input_logical_shape = input_tensor.logical_shape();
-    return tt::tt_metal::operation::hash_operation<CrossEntropyBackwardDeviceOperation>(
-        args, input_tensor.dtype(), input_logical_shape);
-}
-
 }  // namespace ttml::metal::ops::cross_entropy_bw::device
 
 namespace ttnn::prim {
@@ -109,11 +101,7 @@ ttml_cross_entropy_bw(
     using OperationType = ttml::metal::ops::cross_entropy_bw::device::CrossEntropyBackwardDeviceOperation;
 
     auto operation_attributes = OperationType::operation_attributes_t{.scaler = scaler};
-    auto tensor_args = OperationType::tensor_args_t{
-        .input = input_tensor,
-        .target = target_tensor,
-        .preallocated_output = preallocated_output,
-    };
+    auto tensor_args = OperationType::tensor_args_t{input_tensor, target_tensor, preallocated_output};
 
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/cross_entropy_bw_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/cross_entropy_bw_device_operation.hpp
@@ -25,8 +25,6 @@ struct CrossEntropyBackwardDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
-
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttml::metal::ops::cross_entropy_bw::device

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/cross_entropy_bw_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_bw/device/cross_entropy_bw_device_operation_types.hpp
@@ -4,12 +4,19 @@
 
 #pragma once
 
+#include <tuple>
+
 #include "metal/ttnn_all_includes.hpp"
 
 namespace ttml::metal::ops::cross_entropy_bw::device {
 
 struct CrossEntropyBackwardParams {
     const float scaler{1.0F};
+
+    static constexpr auto attribute_names = std::forward_as_tuple("scaler");
+    auto attribute_values() const {
+        return std::forward_as_tuple(scaler);
+    }
 };
 
 struct CrossEntropyBackwardInputs {
@@ -17,6 +24,18 @@ struct CrossEntropyBackwardInputs {
     const ttnn::Tensor& target;
 
     std::optional<ttnn::Tensor> preallocated_output;
+
+    CrossEntropyBackwardInputs(
+        const ttnn::Tensor& input,
+        const ttnn::Tensor& target,
+        std::optional<ttnn::Tensor> preallocated_output = std::nullopt) :
+        input(input), target(target), preallocated_output(std::move(preallocated_output)) {
+    }
+
+    static constexpr auto attribute_names = std::forward_as_tuple("input", "target");
+    auto attribute_values() const {
+        return std::forward_as_tuple(input, target);
+    }
 };
 
 using operation_attributes_t = CrossEntropyBackwardParams;


### PR DESCRIPTION
### PR Category
hash calculation unification for operation CrossEntropyBackwardDeviceOperation (tt-train)

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for CrossEntropyBackwardDeviceOperation (tt-train)

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_CrossEntropyBackwardDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_CrossEntropyBackwardDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_CrossEntropyBackwardDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_CrossEntropyBackwardDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_CrossEntropyBackwardDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_CrossEntropyBackwardDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_CrossEntropyBackwardDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_CrossEntropyBackwardDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_CrossEntropyBackwardDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_CrossEntropyBackwardDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_CrossEntropyBackwardDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_CrossEntropyBackwardDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_CrossEntropyBackwardDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_CrossEntropyBackwardDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_CrossEntropyBackwardDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_CrossEntropyBackwardDeviceOperation_tt-train)
