### PR TITLE
#45821: migrate CrossEntropyForwardDeviceOperation (tt-train) to default program-cache hash

### DIFF
--- a/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/cross_entropy_fw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/cross_entropy_fw_device_operation.cpp
@@ -88,16 +88,6 @@ CrossEntropyForwardDeviceOperation::tensor_return_value_t CrossEntropyForwardDev
     return output_tensor;
 }
 
-ttsl::hash::hash_t CrossEntropyForwardDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    const auto& input_tensor = tensor_args.input;
-    const auto& input_logical_shape = input_tensor.logical_shape();
-    auto hash = tt::tt_metal::operation::hash_operation<CrossEntropyForwardDeviceOperation>(
-        args, input_tensor.dtype(), input_logical_shape);
-
-    return hash;
-}
-
 }  // namespace ttml::metal::ops::cross_entropy_fw::device
 
 namespace ttnn::prim {
@@ -110,11 +100,7 @@ ttml_cross_entropy_fw(
     using OperationType = ttml::metal::ops::cross_entropy_fw::device::CrossEntropyForwardDeviceOperation;
 
     auto operation_attributes = OperationType::operation_attributes_t{};
-    auto tensor_args = OperationType::tensor_args_t{
-        .input = input_tensor,
-        .target = target_tensor,
-        .preallocated_output = preallocated_output,
-    };
+    auto tensor_args = OperationType::tensor_args_t{input_tensor, target_tensor, preallocated_output};
 
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/cross_entropy_fw_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/cross_entropy_fw_device_operation.hpp
@@ -25,8 +25,6 @@ struct CrossEntropyForwardDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
-
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttml::metal::ops::cross_entropy_fw::device

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/cross_entropy_fw_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/cross_entropy_fw_device_operation_types.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <tuple>
+
 #include "metal/ttnn_all_includes.hpp"
 
 namespace ttml::metal::ops::cross_entropy_fw::device {
@@ -15,6 +17,18 @@ struct CrossEntropyForwardInputs {
     const ttnn::Tensor& target;
 
     std::optional<ttnn::Tensor> preallocated_output;
+
+    CrossEntropyForwardInputs(
+        const ttnn::Tensor& input,
+        const ttnn::Tensor& target,
+        std::optional<ttnn::Tensor> preallocated_output = std::nullopt) :
+        input(input), target(target), preallocated_output(std::move(preallocated_output)) {
+    }
+
+    static constexpr auto attribute_names = std::forward_as_tuple("input", "target");
+    auto attribute_values() const {
+        return std::forward_as_tuple(input, target);
+    }
 };
 
 using operation_attributes_t = CrossEntropyForwardParams;

--- a/tt-train/tests/ops/cross_entropy_fw_op_test.cpp
+++ b/tt-train/tests/ops/cross_entropy_fw_op_test.cpp
@@ -179,6 +179,48 @@ TEST_F(CrossEntropyForwardTest, CrossEntropyForward_Large_Forward) {
     EXPECT_TRUE(xt::allclose(result_xtensor, expected_result, 3e-2F, 1e-2F));
 }
 
+TEST_F(CrossEntropyForwardTest, CrossEntropyForward_ProgramCache_MissAndHit) {
+    using namespace ttml;
+
+    auto* device = &autograd::ctx().get_device();
+    device->enable_program_cache();
+
+    auto run_and_check = [&](uint32_t N, uint32_t H, uint32_t W, uint32_t seed) {
+        xt::xarray<float> input_tensor =
+            ttml::test_utils::make_uniform_xarray<float>(std::array<std::size_t, 4>{N, 1U, H, W}, -10.0F, 10.0F, seed);
+        xt::xarray<uint32_t> target_tensor =
+            ttml::test_utils::make_uniform_xarray<uint32_t>(std::array<std::size_t, 2>{N, H}, 0U, W - 1U, seed + 1U);
+
+        auto input = core::from_xtensor(input_tensor, device);
+        auto target =
+            core::from_xtensor<uint32_t, ttnn::DataType::UINT32>(target_tensor, device, ttnn::Layout::ROW_MAJOR);
+
+        auto result = ttml::metal::cross_entropy_fw(input, target);
+
+        auto expected_result = calculate_cross_entropy_loss(input_tensor, target_tensor);
+        auto result_xtensor = core::to_xtensor(result);
+        EXPECT_TRUE(xt::allclose(result_xtensor, expected_result, 3e-2F, 1e-2F));
+    };
+
+    // Two distinct inner dimensions (W) generate different compile-time args, so each must compile a fresh
+    // program (cache miss) rather than reuse the other's cached program.
+    const auto entries_start = device->num_program_cache_entries();
+    run_and_check(/*N=*/2U, /*H=*/32U, /*W=*/64U, /*seed=*/101U);
+    const auto entries_after_first = device->num_program_cache_entries();
+    EXPECT_GT(entries_after_first, entries_start) << "first shape did not populate the program cache";
+
+    run_and_check(/*N=*/2U, /*H=*/32U, /*W=*/128U, /*seed=*/103U);
+    const auto entries_after_second = device->num_program_cache_entries();
+    EXPECT_GT(entries_after_second, entries_after_first)
+        << "a distinct input shape reused the first shape's cached program (incomplete program-cache key)";
+
+    // Re-running the first shape must reuse its cached program (cache hit), leaving the entry count unchanged.
+    run_and_check(/*N=*/2U, /*H=*/32U, /*W=*/64U, /*seed=*/101U);
+    const auto entries_after_repeat = device->num_program_cache_entries();
+    EXPECT_EQ(entries_after_repeat, entries_after_second)
+        << "re-running the first shape compiled a new program instead of hitting the cache";
+}
+
 TEST_F(CrossEntropyForwardTest, NIGHTLY_CrossEntropyForward_Huge_Forward) {
     using namespace ttml;
 


### PR DESCRIPTION
### PR Category
hash calculation unification for operation CrossEntropyForwardDeviceOperation (tt-train)

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for CrossEntropyForwardDeviceOperation (tt-train)

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_CrossEntropyForwardDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_CrossEntropyForwardDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_CrossEntropyForwardDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_CrossEntropyForwardDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_CrossEntropyForwardDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_CrossEntropyForwardDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_CrossEntropyForwardDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_CrossEntropyForwardDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_CrossEntropyForwardDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_CrossEntropyForwardDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_CrossEntropyForwardDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_CrossEntropyForwardDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_CrossEntropyForwardDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_CrossEntropyForwardDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_CrossEntropyForwardDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_CrossEntropyForwardDeviceOperation_tt-train)
