### PR TITLE
#45821: migrate DitFusedDistributedRmsnormDeviceOperation to default program-cache hash

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_rmsnorm/device/dit_fused_distributed_rmsnorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_rmsnorm/device/dit_fused_distributed_rmsnorm_device_operation.cpp
@@ -334,28 +334,6 @@ DitFusedDistributedRmsnormDeviceOperation::create_output_tensors(
     return tensors;
 }
 
-ttsl::hash::hash_t DitFusedDistributedRmsnormDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    log_trace(tt::LogOp, "DitFusedDistributedRmsnormDeviceOperation::compute_program_hash");
-    auto* mesh_device = tensor_args.input.device();
-    auto sd_id = args.sub_device_id.value_or(mesh_device->get_sub_device_ids().at(0));
-    auto subdevice_core_range_set = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sd_id);
-    return tt::tt_metal::operation::hash_operation<DitFusedDistributedRmsnormDeviceOperation>(
-        args.epsilon,
-        args.num_heads_per_device,
-        args.per_head_norm,
-        args.dtype,
-        args.output_mem_config,
-        args.cluster_axis,
-        args.num_links,
-        args.ring_size,
-        args.topology,
-        args.compute_kernel_config,
-        static_cast<uint8_t>(args.norm_type),
-        subdevice_core_range_set,
-        tensor_args);
-}
-
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_rmsnorm/device/dit_fused_distributed_rmsnorm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_rmsnorm/device/dit_fused_distributed_rmsnorm_device_operation.hpp
@@ -32,8 +32,6 @@ struct DitFusedDistributedRmsnormDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_rmsnorm/device/dit_fused_distributed_rmsnorm_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/dit_fused_distributed_rmsnorm/device/dit_fused_distributed_rmsnorm_device_operation_types.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <optional>
+#include <tuple>
 
 #include <tt-metalium/core_coord.hpp>
 #include <tt_stl/reflection.hpp>
@@ -79,21 +80,33 @@ struct DitFusedDistributedRmsnormParams {
         sub_device_id(sub_device_id),
         compute_kernel_config(compute_kernel_config) {}
 
-    auto attributes() const {
-        using ttsl::reflection::Attribute;
-        std::vector<std::tuple<std::string, Attribute>> attrs;
-        attrs.emplace_back("epsilon", epsilon);
-        attrs.emplace_back("num_heads_per_device", num_heads_per_device);
-        attrs.emplace_back("per_head_norm", per_head_norm);
-        attrs.emplace_back("norm_type", static_cast<uint8_t>(norm_type));
-        attrs.emplace_back("dtype", dtype);
-        attrs.emplace_back("output_mem_config", output_mem_config);
-        attrs.emplace_back("cluster_axis", cluster_axis);
-        attrs.emplace_back("num_links", num_links);
-        attrs.emplace_back("ring_size", ring_size);
-        attrs.emplace_back("topology", topology);
-        attrs.emplace_back("compute_kernel_config", compute_kernel_config);
-        return attrs;
+    static constexpr auto attribute_names = std::forward_as_tuple(
+        "epsilon",
+        "num_heads_per_device",
+        "per_head_norm",
+        "dtype",
+        "output_mem_config",
+        "cluster_axis",
+        "num_links",
+        "ring_size",
+        "topology",
+        "compute_kernel_config",
+        "norm_type",
+        "sub_device_id");
+    auto attribute_values() const {
+        return std::make_tuple(
+            epsilon,
+            num_heads_per_device,
+            per_head_norm,
+            dtype,
+            output_mem_config,
+            cluster_axis,
+            num_links,
+            ring_size,
+            topology,
+            compute_kernel_config,
+            static_cast<uint8_t>(norm_type),
+            sub_device_id);
     }
 };
 


### PR DESCRIPTION
### PR Category
hash calculation unification for operation DitFusedDistributedRmsnormDeviceOperation

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for DitFusedDistributedRmsnormDeviceOperation

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_DitFusedDistributedRmsnormDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_DitFusedDistributedRmsnormDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_DitFusedDistributedRmsnormDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_DitFusedDistributedRmsnormDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_DitFusedDistributedRmsnormDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_DitFusedDistributedRmsnormDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_DitFusedDistributedRmsnormDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_DitFusedDistributedRmsnormDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_DitFusedDistributedRmsnormDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_DitFusedDistributedRmsnormDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_DitFusedDistributedRmsnormDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_DitFusedDistributedRmsnormDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_DitFusedDistributedRmsnormDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_DitFusedDistributedRmsnormDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_DitFusedDistributedRmsnormDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_DitFusedDistributedRmsnormDeviceOperation)
