### PR TITLE
#45821: migrate DramPrefetcherConsumerDeviceOperation to default program-cache hash

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_consumer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_consumer.cpp
@@ -5,7 +5,6 @@
 #include "dram_prefetcher_consumer.hpp"
 
 #include <tt_stl/assert.hpp>
-#include <tt_stl/reflection.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/distributed.hpp>
@@ -41,17 +40,6 @@ DramPrefetcherConsumerDeviceOperation::spec_return_value_t DramPrefetcherConsume
 DramPrefetcherConsumerDeviceOperation::tensor_return_value_t
 DramPrefetcherConsumerDeviceOperation::create_output_tensors(const operation_attributes_t&, const tensor_args_t&) {
     return std::vector<ttnn::Tensor>{};
-}
-
-ttsl::hash::hash_t DramPrefetcherConsumerDeviceOperation::compute_program_hash(
-    const operation_attributes_t& attrs, const tensor_args_t& /*tensor_args*/) {
-    // GlobalCircularBuffer isn't reflection-hashable; hash its identity via config_address
-    // (unique per GCB instance on this device) along with the other attrs.
-    return ttsl::hash::hash_objects_with_default_seed(
-        ttsl::hash::type_hash<DramPrefetcherConsumerDeviceOperation>,
-        attrs.num_iters,
-        attrs.page_size_bytes,
-        static_cast<uint64_t>(attrs.global_cb->config_address()));
 }
 
 ttnn::device_operation::CachedProgram<DramPrefetcherConsumerDeviceOperation::ProgramFactory::shared_variables_t>

--- a/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_consumer.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_consumer.hpp
@@ -28,6 +28,15 @@ struct DramPrefetcherConsumerDeviceOperation {
         // constructible attribute struct, and GlobalCircularBuffer has no default ctor.
         std::optional<tt::tt_metal::experimental::GlobalCircularBuffer> global_cb;
         ttnn::MeshDevice* mesh_device;
+
+        static constexpr auto attribute_names =
+            std::forward_as_tuple("num_iters", "page_size_bytes", "global_cb_config_address");
+        auto attribute_values() const {
+            return std::make_tuple(
+                num_iters,
+                page_size_bytes,
+                global_cb.has_value() ? static_cast<uint64_t>(global_cb->config_address()) : uint64_t{0});
+        }
     };
 
     struct tensor_args_t {};
@@ -59,7 +68,6 @@ struct DramPrefetcherConsumerDeviceOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 // Public free function (kept for the nanobind binding `ttnn.experimental.test_dram_prefetcher_consumer`).


### PR DESCRIPTION
### PR Category
hash calculation unification for operation DramPrefetcherConsumerDeviceOperation

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for DramPrefetcherConsumerDeviceOperation

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_DramPrefetcherConsumerDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_DramPrefetcherConsumerDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_DramPrefetcherConsumerDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_DramPrefetcherConsumerDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_DramPrefetcherConsumerDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_DramPrefetcherConsumerDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_DramPrefetcherConsumerDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_DramPrefetcherConsumerDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_DramPrefetcherConsumerDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_DramPrefetcherConsumerDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_DramPrefetcherConsumerDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_DramPrefetcherConsumerDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_DramPrefetcherConsumerDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_DramPrefetcherConsumerDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_DramPrefetcherConsumerDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_DramPrefetcherConsumerDeviceOperation)
