### PR TITLE
#45821: migrate DramPrefetcherValidatorDeviceOperation to default program-cache hash

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_validator.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_validator.cpp
@@ -5,7 +5,6 @@
 #include "dram_prefetcher_validator.hpp"
 
 #include <tt_stl/assert.hpp>
-#include <tt_stl/reflection.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_distribution_spec.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
@@ -52,24 +51,6 @@ DramPrefetcherValidatorDeviceOperation::compute_output_specs(const operation_att
 DramPrefetcherValidatorDeviceOperation::tensor_return_value_t
 DramPrefetcherValidatorDeviceOperation::create_output_tensors(const operation_attributes_t&, const tensor_args_t&) {
     return std::vector<ttnn::Tensor>{};
-}
-
-ttsl::hash::hash_t DramPrefetcherValidatorDeviceOperation::compute_program_hash(
-    const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
-    // GlobalCircularBuffer / Tensor aren't reflection-hashable here; pick the bits that
-    // determine Program shape: scalar attrs, GCB identity, the source tensor's DRAM
-    // address (compile-time arg via TensorAccessorArgs), and its dataformat.
-    const auto* tensor_buffer = tensor_args.source_tensor.buffer();
-    const tt::DataFormat dataformat = tt::tt_metal::datatype_to_dataformat_converter(tensor_args.source_tensor.dtype());
-    return ttsl::hash::hash_objects_with_default_seed(
-        ttsl::hash::type_hash<DramPrefetcherValidatorDeviceOperation>,
-        attrs.num_layers,
-        attrs.print_stride,
-        attrs.streaming,
-        attrs.rotation,
-        static_cast<uint64_t>(attrs.global_cb->config_address()),
-        static_cast<uint64_t>(tensor_buffer != nullptr ? tensor_buffer->address() : 0),
-        static_cast<uint32_t>(dataformat));
 }
 
 ttnn::device_operation::CachedProgram<DramPrefetcherValidatorDeviceOperation::ProgramFactory::shared_variables_t>
@@ -271,7 +252,7 @@ void test_dram_prefetcher_validator(
         .streaming = streaming,
         .rotation = rotation,
     };
-    OperationType::tensor_args_t tensor_args{.source_tensor = source_tensor};
+    OperationType::tensor_args_t tensor_args{source_tensor};
     ttnn::device_operation::launch<OperationType>(attrs, tensor_args);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_validator.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_validator.hpp
@@ -9,11 +9,13 @@
 #include <variant>
 #include <vector>
 
+#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/global_circular_buffer.hpp>
 #include <tt-metalium/mesh_device.hpp>
 
 #include "ttnn/device_operation.hpp"
 #include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/types.hpp"
 #include "ttnn/types.hpp"
 
 namespace ttnn::operations::experimental::test {
@@ -37,10 +39,34 @@ struct DramPrefetcherValidatorDeviceOperation {
         // queued to the prefetcher). Empty == identity (lead_block = ring_pos), the natural
         // topology order. Non-empty exercises a host-chosen lead block per receiver.
         std::vector<uint32_t> rotation = {};
+
+        static constexpr auto attribute_names =
+            std::forward_as_tuple("num_layers", "print_stride", "streaming", "rotation", "global_cb_config_address");
+        auto attribute_values() const {
+            return std::make_tuple(
+                num_layers,
+                print_stride,
+                streaming,
+                rotation,
+                global_cb.has_value() ? static_cast<uint64_t>(global_cb->config_address()) : uint64_t{0});
+        }
     };
 
     struct tensor_args_t {
         const ttnn::Tensor& source_tensor;
+
+        explicit tensor_args_t(const ttnn::Tensor& source_tensor) : source_tensor(source_tensor) {}
+
+        static constexpr auto attribute_names =
+            std::forward_as_tuple("source_tensor_buffer_address", "source_tensor_dataformat", "source_tensor");
+        auto attribute_values() const {
+            const auto* tensor_buffer = source_tensor.buffer();
+            const tt::DataFormat dataformat = tt::tt_metal::datatype_to_dataformat_converter(source_tensor.dtype());
+            return std::make_tuple(
+                static_cast<uint64_t>(tensor_buffer != nullptr ? tensor_buffer->address() : 0),
+                static_cast<uint32_t>(dataformat),
+                std::cref(source_tensor));
+        }
     };
 
     // Side-effect op (no output tensors).
@@ -70,7 +96,6 @@ struct DramPrefetcherValidatorDeviceOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 // Public free function (kept for the nanobind binding `ttnn.experimental.test_dram_prefetcher_validator`).


### PR DESCRIPTION
### PR Category
hash calculation unification for operation DramPrefetcherValidatorDeviceOperation

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for DramPrefetcherValidatorDeviceOperation

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_DramPrefetcherValidatorDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_DramPrefetcherValidatorDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_DramPrefetcherValidatorDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_DramPrefetcherValidatorDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_DramPrefetcherValidatorDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_DramPrefetcherValidatorDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_DramPrefetcherValidatorDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_DramPrefetcherValidatorDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_DramPrefetcherValidatorDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_DramPrefetcherValidatorDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_DramPrefetcherValidatorDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_DramPrefetcherValidatorDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_DramPrefetcherValidatorDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_DramPrefetcherValidatorDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_DramPrefetcherValidatorDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_DramPrefetcherValidatorDeviceOperation)
