### PR TITLE
#45821: migrate FrobeniusNormalizeDeviceOperation (tt-train) to default program-cache hash

### DIFF
--- a/tt-train/sources/ttml/metal/ops/frobenius_normalize/device/frobenius_normalize_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/frobenius_normalize/device/frobenius_normalize_device_operation.cpp
@@ -73,13 +73,6 @@ FrobeniusNormalizeTensorReturn FrobeniusNormalizeDeviceOperation::create_output_
     return {create_device_tensor(output_specs[0], tensor_args.input.device())};
 }
 
-ttsl::hash::hash_t FrobeniusNormalizeDeviceOperation::compute_program_hash(
-    const FrobeniusNormalizeAttributes& args, const FrobeniusNormalizeTensorArgs& tensor_args) {
-    const auto& input_tensor = tensor_args.input;
-    return tt::tt_metal::operation::hash_operation<FrobeniusNormalizeDeviceOperation>(
-        input_tensor.dtype(), input_tensor.logical_shape());
-}
-
 }  // namespace ttml::metal::ops::frobenius_normalize::device
 
 namespace ttnn::prim {

--- a/tt-train/sources/ttml/metal/ops/frobenius_normalize/device/frobenius_normalize_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/frobenius_normalize/device/frobenius_normalize_device_operation.hpp
@@ -28,9 +28,6 @@ struct FrobeniusNormalizeDeviceOperation {
 
     static FrobeniusNormalizeTensorReturn create_output_tensors(
         const FrobeniusNormalizeAttributes& operation_attributes, const FrobeniusNormalizeTensorArgs&);
-
-    static ttsl::hash::hash_t compute_program_hash(
-        const FrobeniusNormalizeAttributes&, const FrobeniusNormalizeTensorArgs&);
 };
 
 }  // namespace ttml::metal::ops::frobenius_normalize::device

--- a/tt-train/sources/ttml/metal/ops/frobenius_normalize/device/frobenius_normalize_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/frobenius_normalize/device/frobenius_normalize_device_operation_types.hpp
@@ -4,17 +4,29 @@
 
 #pragma once
 
+#include <tuple>
+
 #include "metal/ttnn_all_includes.hpp"
 
 namespace ttml::metal::ops::frobenius_normalize::device {
 
 struct FrobeniusNormalizeAttributes {
     float epsilon{1e-7F};
+
+    static constexpr auto attribute_names = std::forward_as_tuple();
+    auto attribute_values() const {
+        return std::forward_as_tuple();
+    }
 };
 
 struct FrobeniusNormalizeTensorArgs {
     const ttnn::Tensor& input;
     std::optional<ttnn::Tensor> preallocated_output;
+
+    static constexpr auto attribute_names = std::forward_as_tuple("input_dtype", "input_logical_shape");
+    auto attribute_values() const {
+        return std::make_tuple(input.dtype(), std::cref(input.logical_shape()));
+    }
 };
 
 using FrobeniusNormalizeTensorReturn = std::vector<ttnn::Tensor>;


### PR DESCRIPTION
### PR Category
hash calculation unification for operation FrobeniusNormalizeDeviceOperation (tt-train)

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for FrobeniusNormalizeDeviceOperation (tt-train)

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_FrobeniusNormalizeDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_FrobeniusNormalizeDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_FrobeniusNormalizeDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_FrobeniusNormalizeDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_FrobeniusNormalizeDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_FrobeniusNormalizeDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_FrobeniusNormalizeDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_FrobeniusNormalizeDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_FrobeniusNormalizeDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_FrobeniusNormalizeDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_FrobeniusNormalizeDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_FrobeniusNormalizeDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_FrobeniusNormalizeDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_FrobeniusNormalizeDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_FrobeniusNormalizeDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_FrobeniusNormalizeDeviceOperation_tt-train)
