### PR TITLE
Alexey zaytsev epam/fix hash collision 45821 fusion dispatch op device operation

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/fusion/device/fusion_dispatch_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/fusion/device/fusion_dispatch_op_device_operation.cpp
@@ -5,13 +5,6 @@
 #include "ttnn/device_operation.hpp"
 #include "fusion_dispatch_op_device_operation.hpp"
 
-#include <tt_stl/reflection.hpp>
-
-// Reuse the hash function from generic_op
-namespace ttnn::operations::generic {
-ttsl::hash::hash_t compute_program_descriptor_hash(const tt::tt_metal::ProgramDescriptor& program_descriptor);
-}
-
 namespace ttnn::operations::experimental::fusion {
 
 using namespace tt::tt_metal;
@@ -30,18 +23,6 @@ fusion_dispatch_spec_return_value_t FusionDispatchOpDeviceOperation::compute_out
 fusion_dispatch_tensor_return_value_t FusionDispatchOpDeviceOperation::create_output_tensors(
     const operation_attributes_t&, const tensor_args_t& tensor_args) {
     return tensor_args.output_tensor;
-}
-
-ttsl::hash::hash_t FusionDispatchOpDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t&) {
-    // Must differ from GenericOpDeviceOperation::compute_program_hash — same descriptor would
-    // otherwise hit the wrong cached_mesh_workload_t layout (segfault in override).
-    size_t hash = ttsl::hash::type_hash<FusionDispatchOpDeviceOperation>;
-    for (const auto& [mesh_coord_range, program_descriptor] : operation_attributes.mesh_programs) {
-        ttsl::hash::hash_combine(hash, mesh_coord_range);
-        ttsl::hash::hash_combine(hash, ttnn::operations::generic::compute_program_descriptor_hash(program_descriptor));
-    }
-    return hash;
 }
 
 ProgramDescriptor FusionDispatchOpDeviceOperation::create_descriptor(

--- a/ttnn/cpp/ttnn/operations/experimental/fusion/device/fusion_dispatch_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/fusion/device/fusion_dispatch_op_device_operation.hpp
@@ -23,7 +23,6 @@ struct FusionDispatchOpDeviceOperation {
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 
     // The operation_attributes_t holds a MeshPrograms vector of
     // (MeshCoordinateRange, ProgramDescriptor) pairs.  In practice Python emits a

--- a/ttnn/cpp/ttnn/operations/experimental/fusion/device/fusion_dispatch_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/fusion/device/fusion_dispatch_op_types.hpp
@@ -7,10 +7,40 @@
 #include "ttnn/tensor/tensor.hpp"
 #include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/experimental/mesh_program_descriptor.hpp>
+#include <tt_stl/reflection.hpp>
+
+#include <vector>
+
+namespace ttnn::operations::generic {
+ttsl::hash::hash_t compute_program_descriptor_hash(const tt::tt_metal::ProgramDescriptor& program_descriptor);
+}
 
 namespace ttnn::operations::experimental::fusion {
 
-using fusion_dispatch_operation_attributes_t = tt::tt_metal::experimental::MeshProgramDescriptor;
+struct fusion_dispatch_operation_attributes_t : tt::tt_metal::experimental::MeshProgramDescriptor {
+    fusion_dispatch_operation_attributes_t() = default;
+    fusion_dispatch_operation_attributes_t(
+        const tt::tt_metal::experimental::MeshProgramDescriptor& mesh_program_descriptor) :
+        tt::tt_metal::experimental::MeshProgramDescriptor(mesh_program_descriptor) {}
+    fusion_dispatch_operation_attributes_t(
+        tt::tt_metal::experimental::MeshProgramDescriptor&& mesh_program_descriptor) :
+        tt::tt_metal::experimental::MeshProgramDescriptor(std::move(mesh_program_descriptor)) {}
+
+    static constexpr auto attribute_names = std::forward_as_tuple("mesh_coord_ranges", "program_descriptor_hashes");
+    auto attribute_values() const {
+        std::vector<tt::tt_metal::distributed::MeshCoordinateRange> mesh_coord_ranges;
+        std::vector<ttsl::hash::hash_t> program_descriptor_hashes;
+        mesh_coord_ranges.reserve(mesh_programs.size());
+        program_descriptor_hashes.reserve(mesh_programs.size());
+        for (const auto& [mesh_coord_range, program_descriptor] : mesh_programs) {
+            mesh_coord_ranges.push_back(mesh_coord_range);
+            program_descriptor_hashes.push_back(
+                ttnn::operations::generic::compute_program_descriptor_hash(program_descriptor));
+        }
+        return std::make_tuple(std::move(mesh_coord_ranges), std::move(program_descriptor_hashes));
+    }
+};
+
 using fusion_dispatch_tensor_return_value_t = Tensor;
 using fusion_dispatch_spec_return_value_t = TensorSpec;
 

--- a/ttnn/cpp/ttnn/operations/experimental/fusion/fusion_dispatch_op_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/fusion/fusion_dispatch_op_nanobind.cpp
@@ -37,7 +37,8 @@ void fusion_dispatch_op_with_address_refresh(
     auto& desc_copy = mesh_program_descriptor.mesh_programs.back().second;
     patch_stale_descriptor(desc_copy, io_tensors, address_slots);
 
-    (void)ttnn::prim::fusion_dispatch_op(io_tensors, mesh_program_descriptor);
+    (void)ttnn::prim::fusion_dispatch_op(
+        io_tensors, fusion_dispatch_operation_attributes_t{std::move(mesh_program_descriptor)});
 }
 
 void dispatch_patched(
@@ -61,7 +62,8 @@ void dispatch_patched(
     auto& desc_copy = mesh_program_descriptor.mesh_programs.back().second;
     patch_stale_descriptor(desc_copy, io_tensors, address_slots);
 
-    (void)ttnn::prim::fusion_dispatch_op(io_tensors, mesh_program_descriptor);
+    (void)ttnn::prim::fusion_dispatch_op(
+        io_tensors, fusion_dispatch_operation_attributes_t{std::move(mesh_program_descriptor)});
 }
 
 std::vector<Tensor> allocate_outputs(
@@ -144,7 +146,7 @@ public:
             patch_semaphore_addresses(desc, address_slots_.sem_rt_arg_slots, sem_addresses);
         }
         patch_stale_descriptor(desc, io_tensors, address_slots_);
-        (void)ttnn::prim::fusion_dispatch_op(io_tensors, mesh_desc_);
+        (void)ttnn::prim::fusion_dispatch_op(io_tensors, fusion_dispatch_operation_attributes_t{mesh_desc_});
 
         if (!result_reorder_.empty()) {
             std::vector<Tensor> reordered;


### PR DESCRIPTION
### PR Category
hash calculation unification for operation FusionDispatchOpDeviceOperation

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for FusionDispatchOpDeviceOperation

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_FusionDispatchOpDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_FusionDispatchOpDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_FusionDispatchOpDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_FusionDispatchOpDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_FusionDispatchOpDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_FusionDispatchOpDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_FusionDispatchOpDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_FusionDispatchOpDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_FusionDispatchOpDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_FusionDispatchOpDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_FusionDispatchOpDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_FusionDispatchOpDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_FusionDispatchOpDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_FusionDispatchOpDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_FusionDispatchOpDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_FusionDispatchOpDeviceOperation)
