### PR TITLE
#45821: migrate GatedDeltaAttnSeqDeviceOperation to default program-cache hash

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/gated_delta_attn/device/gated_delta_attn_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/gated_delta_attn/device/gated_delta_attn_device_operation.cpp
@@ -101,30 +101,6 @@ GatedDeltaAttnSeqDeviceOperation::tensor_return_value_t GatedDeltaAttnSeqDeviceO
     };
 }
 
-ttsl::hash::hash_t GatedDeltaAttnSeqDeviceOperation::compute_program_hash(
-    const operation_attributes_t& attrs, const tensor_args_t& in) {
-    return operation::hash_operation<GatedDeltaAttnSeqDeviceOperation>(
-        attrs.num_heads,
-        attrs.num_chunks,
-        attrs.chunk_size,
-        attrs.key_dim,
-        attrs.val_dim,
-        attrs.output_mem_config,
-        attrs.compute_kernel_config,
-        in.L_unit,
-        in.v_beta_sc,
-        in.k_bd_sc,
-        in.intra_attn,
-        in.q_decay,
-        in.k_decay_t,
-        in.dl_exp,
-        // L_inv and initial_state bake TensorAccessorArgs into the reader, so they must be hashed:
-        // otherwise a cache hit can reuse a reader compiled for a different L_inv layout or for absent
-        // initial_state. Hashing the optional also distinguishes state present vs. absent.
-        in.L_inv,
-        in.initial_state);
-}
-
 std::vector<Tensor> gated_delta_attn_seq(
     const Tensor& L_unit,
     const Tensor& v_beta_sc,

--- a/ttnn/cpp/ttnn/operations/transformer/gated_delta_attn/device/gated_delta_attn_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/gated_delta_attn/device/gated_delta_attn_device_operation.hpp
@@ -29,8 +29,6 @@ struct GatedDeltaAttnSeqDeviceOperation {
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 // Low-level dispatch function (used by public API).


### PR DESCRIPTION
### PR Category
hash calculation unification for operation GatedDeltaAttnSeqDeviceOperation

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for GatedDeltaAttnSeqDeviceOperation

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_GatedDeltaAttnSeqDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_GatedDeltaAttnSeqDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_GatedDeltaAttnSeqDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_GatedDeltaAttnSeqDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_GatedDeltaAttnSeqDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_GatedDeltaAttnSeqDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_GatedDeltaAttnSeqDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_GatedDeltaAttnSeqDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_GatedDeltaAttnSeqDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_GatedDeltaAttnSeqDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_GatedDeltaAttnSeqDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_GatedDeltaAttnSeqDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_GatedDeltaAttnSeqDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_GatedDeltaAttnSeqDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_GatedDeltaAttnSeqDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_GatedDeltaAttnSeqDeviceOperation)
