### PR TITLE
Alexey zaytsev epam/fix hash collision 45821 w generic op device operation

### DIFF
--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.cpp
@@ -108,16 +108,6 @@ ttsl::hash::hash_t compute_program_descriptor_hash(const tt::tt_metal::ProgramDe
     return hash;
 }
 
-ttsl::hash::hash_t GenericOpDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& /*tensor_args*/) {
-    size_t hash = 0;
-    for (const auto& [mesh_coord_range, program_descriptor] : operation_attributes.mesh_programs) {
-        ttsl::hash::hash_combine(hash, mesh_coord_range);
-        ttsl::hash::hash_combine(hash, compute_program_descriptor_hash(program_descriptor));
-    }
-    return hash;
-}
-
 }  // namespace ttnn::operations::generic
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.hpp
@@ -5,10 +5,6 @@
 #pragma once
 
 #include <variant>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/experimental/mesh_program_descriptor.hpp>
-#include <tt_stl/reflection.hpp>  // ttsl::hash::hash_t
-
 #include "ttnn/tensor/tensor.hpp"
 #include "generic_op_program_factory.hpp"
 #include "generic_op_device_operation_types.hpp"
@@ -28,10 +24,6 @@ struct GenericOpDeviceOperation {
     static void validate_inputs(const operation_attributes_t& attributes, const tensor_args_t& tensor_args);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
-
-    // Note: will either compute a program hash, or simply return user provided custom program hash
-    static ttsl::hash::hash_t compute_program_hash(
-        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 };  // struct GenericOpDeviceOperation
 
 }  // namespace ttnn::operations::generic

--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation_types.hpp
@@ -6,10 +6,36 @@
 
 #include "ttnn/tensor/tensor.hpp"
 #include <tt-metalium/experimental/mesh_program_descriptor.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt_stl/reflection.hpp>
+
+#include <vector>
 
 namespace ttnn::operations::generic {
 
-using operation_attributes_t = tt::tt_metal::experimental::MeshProgramDescriptor;
+ttsl::hash::hash_t compute_program_descriptor_hash(const tt::tt_metal::ProgramDescriptor& program_descriptor);
+
+struct operation_attributes_t : tt::tt_metal::experimental::MeshProgramDescriptor {
+    operation_attributes_t() = default;
+    operation_attributes_t(const tt::tt_metal::experimental::MeshProgramDescriptor& mesh_program_descriptor) :
+        tt::tt_metal::experimental::MeshProgramDescriptor(mesh_program_descriptor) {}
+    operation_attributes_t(tt::tt_metal::experimental::MeshProgramDescriptor&& mesh_program_descriptor) :
+        tt::tt_metal::experimental::MeshProgramDescriptor(std::move(mesh_program_descriptor)) {}
+
+    static constexpr auto attribute_names = std::forward_as_tuple("mesh_coord_ranges", "program_descriptor_hashes");
+    auto attribute_values() const {
+        std::vector<tt::tt_metal::distributed::MeshCoordinateRange> mesh_coord_ranges;
+        std::vector<ttsl::hash::hash_t> program_descriptor_hashes;
+        mesh_coord_ranges.reserve(mesh_programs.size());
+        program_descriptor_hashes.reserve(mesh_programs.size());
+        for (const auto& [mesh_coord_range, program_descriptor] : mesh_programs) {
+            mesh_coord_ranges.push_back(mesh_coord_range);
+            program_descriptor_hashes.push_back(compute_program_descriptor_hash(program_descriptor));
+        }
+        return std::make_tuple(std::move(mesh_coord_ranges), std::move(program_descriptor_hashes));
+    }
+};
+
 using tensor_return_value_t = Tensor;
 using spec_return_value_t = TensorSpec;
 

--- a/ttnn/cpp/ttnn/operations/generic/generic_op.cpp
+++ b/ttnn/cpp/ttnn/operations/generic/generic_op.cpp
@@ -4,13 +4,15 @@
 
 #include "generic_op.hpp"
 #include "device/generic_op_device_operation.hpp"
+#include "device/generic_op_device_operation_types.hpp"
 
 namespace ttnn {
 
 Tensor generic_op(
     const std::vector<Tensor>& io_tensors,
     const tt::tt_metal::experimental::MeshProgramDescriptor& mesh_program_descriptor) {
-    return ttnn::prim::generic_op(io_tensors, mesh_program_descriptor);
+    return ttnn::prim::generic_op(
+        io_tensors, ttnn::operations::generic::operation_attributes_t{mesh_program_descriptor});
 }
 
 Tensor generic_op(const std::vector<Tensor>& io_tensors, const tt::tt_metal::ProgramDescriptor& program_descriptor) {

--- a/ttnn/cpp/ttnn/operations/generic/generic_op_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/generic/generic_op_nanobind.cpp
@@ -11,14 +11,12 @@
 #include <nanobind/stl/vector.h>
 
 #include "generic_op.hpp"
+#include "device/generic_op_device_operation_types.hpp"
 #include "ttnn-nanobind/bind_function.hpp"
 #include <tt-metalium/program_descriptors.hpp>
 #include <tt_stl/reflection.hpp>
 
 namespace ttnn::operations::generic {
-
-// Defined in generic_op_device_operation.cpp
-ttsl::hash::hash_t compute_program_descriptor_hash(const tt::tt_metal::ProgramDescriptor& program_descriptor);
 
 void bind_generic_operation(nb::module_& mod) {
     std::string doc =


### PR DESCRIPTION
### PR Category
hash calculation unification for operation GenericOpDeviceOperation

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for GenericOpDeviceOperation

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_GenericOpDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_GenericOpDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_GenericOpDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_GenericOpDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_GenericOpDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_GenericOpDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_GenericOpDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_GenericOpDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_GenericOpDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_GenericOpDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_GenericOpDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_GenericOpDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_GenericOpDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_GenericOpDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_GenericOpDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_GenericOpDeviceOperation)
