### PR TITLE
Alexey zaytsev epam/fix hash collision 45821 inbound socket service sync operation

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/inbound_socket_service_sync/device/inbound_socket_service_sync_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/inbound_socket_service_sync/device/inbound_socket_service_sync_device_operation_types.hpp
@@ -32,12 +32,45 @@ struct InboundSocketServiceSyncParams {
     std::vector<uint32_t> consumed_addrs;  // L1 addr on each coord's service core
     std::vector<uint32_t> service_core_x;  // LOGICAL service-core x per coord
     std::vector<uint32_t> service_core_y;  // LOGICAL service-core y per coord
+
+    static constexpr auto attribute_names = std::forward_as_tuple(
+        "data_ready_sem_addr",
+        "page_size",
+        "num_pages",
+        "scratch_cb_index",
+        "metadata_size_bytes",
+        "metadata_l1_addr",
+        "worker_cores",
+        "mesh_num_cols",
+        "consumed_addrs",
+        "service_core_x",
+        "service_core_y");
+
+    auto attribute_values() const {
+        return std::forward_as_tuple(
+            data_ready_sem_addr,
+            page_size,
+            num_pages,
+            scratch_cb_index,
+            metadata_size_bytes,
+            metadata_l1_addr,
+            worker_cores,
+            mesh_num_cols,
+            consumed_addrs,
+            service_core_x,
+            service_core_y);
+    }
 };
 
 struct InboundSocketServiceSyncInputs {
     // The service's persistent backing tensor (read by the kernel). Supplies the
     // mesh device + per-shard spec; the output tensors mirror its spec.
     const Tensor& backing;
+
+    explicit InboundSocketServiceSyncInputs(const Tensor& backing_in) : backing(backing_in) {}
+
+    static constexpr auto attribute_names = std::forward_as_tuple("backing_dtype");
+    auto attribute_values() const { return std::forward_as_tuple(backing.dtype()); }
 };
 
 }  // namespace ttnn::experimental::prim


### PR DESCRIPTION
### PR Category
hash calculation unification for operation InboundSocketServiceSyncOperation

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for InboundSocketServiceSyncOperation

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_InboundSocketServiceSyncOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_InboundSocketServiceSyncOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_InboundSocketServiceSyncOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_InboundSocketServiceSyncOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_InboundSocketServiceSyncOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_InboundSocketServiceSyncOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_InboundSocketServiceSyncOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_InboundSocketServiceSyncOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_InboundSocketServiceSyncOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_InboundSocketServiceSyncOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_InboundSocketServiceSyncOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_InboundSocketServiceSyncOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_InboundSocketServiceSyncOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_InboundSocketServiceSyncOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_InboundSocketServiceSyncOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_InboundSocketServiceSyncOperation)
