### PR TITLE
Alexey zaytsev epam/fix hash collision 45821 w indexer score device operation

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
@@ -186,36 +186,6 @@ IndexerScoreDeviceOperation::program_factory_t IndexerScoreDeviceOperation::sele
     return program::IndexerScoreProgramFactory{};
 }
 
-ttsl::hash::hash_t IndexerScoreDeviceOperation::compute_program_hash(
-    const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
-    // Hash what shapes the binary, NOT the runtime values: chunk_start_idx is EXCLUDED, cache_batch_idx /
-    // kv_len contribute only has_value() (so distinct slot / kv_len / chunk_start reuse one program).
-    // The seq-shard axes ARE hashed (they shape the causal geometry); tensor_args cover dtype + shape.
-    // apply_relu / num_groups / block_size pick the compile-time kernel path, so they MUST be hashed (else
-    // DSA vs MSA, or pooled vs unpooled, would collide). Hash via the SP/TP accessors so the key is identical
-    // to the pre-consolidation (cluster_axis, seq_subshard_axis) form.
-    return tt::tt_metal::operation::hash_operation<IndexerScoreDeviceOperation>(
-        attrs.apply_relu,
-        attrs.num_groups,
-        attrs.block_size,
-        attrs.synthesize_gate,  // gate read from DRAM vs filled in-kernel -> different reader binary
-        attrs.gate_scale,       // the in-kernel fill value; distinct scales get distinct programs
-        attrs.program_config,
-        attrs.compute_kernel_config,
-        attrs.sp_axis().has_value(),
-        attrs.sp_axis().value_or(0u),
-        attrs.tp_axis().has_value(),
-        attrs.tp_axis().value_or(0u),
-        attrs.has_indexed_kv_cache(),
-        attrs.has_runtime_kv_len(),
-        // The block-cyclic layout bakes invP divisors into the reader as compile-time arguments, so sp/chunk_local
-        // must be hashed (a contiguous vs block-cyclic read, or a different layout shape, is a different binary).
-        attrs.has_block_cyclic(),
-        attrs.block_cyclic.has_value() ? attrs.block_cyclic->sp : 0u,
-        attrs.block_cyclic.has_value() ? attrs.block_cyclic->chunk_local : 0u,
-        tensor_args);
-}
-
 void IndexerScoreDeviceOperation::validate_on_program_cache_hit(
     const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
     // chunk_start, cache slot, kv_len are hash-excluded runtime values -> re-checked on hits.

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
@@ -25,10 +25,6 @@ struct IndexerScoreDeviceOperation {
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
 
-    // Custom hash: runtime values (cache_batch_idx / kv_len / chunk_start_idx) are excluded so they reuse
-    // one program; the seq_shard_axes (SP/TP) ARE hashed.
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
-
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     // Re-checks the runtime values that can change on a hit (slot < B, kv_len bounds, chunk_start window).
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <optional>
+#include <tuple>
 #include <vector>
 
 #include "ttnn/tensor/tensor.hpp"
@@ -85,6 +86,43 @@ struct operation_attributes_t {
     // (which is also what sp == 1 resolves to, since that is the identity permutation).
     std::optional<BlockCyclicLayout> block_cyclic{std::nullopt};
     bool has_block_cyclic() const { return block_cyclic.has_value(); }
+
+    static constexpr auto attribute_names = std::forward_as_tuple(
+        "apply_relu",
+        "num_groups",
+        "block_size",
+        "synthesize_gate",
+        "gate_scale",
+        "program_config",
+        "compute_kernel_config",
+        "sp_axis_present",
+        "sp_axis",
+        "tp_axis_present",
+        "tp_axis",
+        "has_indexed_kv_cache",
+        "has_runtime_kv_len",
+        "has_block_cyclic",
+        "block_cyclic_sp",
+        "block_cyclic_chunk_local");
+    auto attribute_values() const {
+        return std::make_tuple(
+            apply_relu,
+            num_groups,
+            block_size,
+            synthesize_gate,
+            gate_scale,
+            std::cref(program_config),
+            std::cref(compute_kernel_config),
+            sp_axis().has_value(),
+            sp_axis().value_or(0u),
+            tp_axis().has_value(),
+            tp_axis().value_or(0u),
+            has_indexed_kv_cache(),
+            has_runtime_kv_len(),
+            has_block_cyclic(),
+            block_cyclic.has_value() ? block_cyclic->sp : 0u,
+            block_cyclic.has_value() ? block_cyclic->chunk_local : 0u);
+    }
 };
 
 struct tensor_args_t {


### PR DESCRIPTION
### PR Category
hash calculation unification for operation IndexerScoreDeviceOperation

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for IndexerScoreDeviceOperation

### Notes for reviewers
NA

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_IndexerScoreDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_IndexerScoreDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_IndexerScoreDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_IndexerScoreDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_IndexerScoreDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_IndexerScoreDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_IndexerScoreDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_IndexerScoreDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_IndexerScoreDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_IndexerScoreDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_IndexerScoreDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_IndexerScoreDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_IndexerScoreDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_IndexerScoreDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_IndexerScoreDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_IndexerScoreDeviceOperation)