### PR TITLE
Alexey zaytsev epam/fix hash collision 45821 interleaved to sharded partial device operation

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.cpp
@@ -74,19 +74,6 @@ Tensor InterleavedToShardedPartialDeviceOperation::create_output_tensors(
     return create_device_tensor(output_spec, input_tensor.device());
 }
 
-ttsl::hash::hash_t InterleavedToShardedPartialDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const Tensor& input_tensor) {
-    return tt::tt_metal::operation::hash_operation<InterleavedToShardedPartialDeviceOperation>(
-        operation_attributes.grid_size,
-        operation_attributes.shard_spec,
-        operation_attributes.num_slices,
-        operation_attributes.slice_index,
-        operation_attributes.output_mem_config,
-        operation_attributes.output_dtype,
-        input_tensor.dtype(),
-        input_tensor.layout());
-}
-
 Tensor interleaved_to_sharded_partial(
     const Tensor& input_tensor,
     const CoreCoord& grid_size,

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.hpp
@@ -24,9 +24,6 @@ struct InterleavedToShardedPartialDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const Tensor& input_tensor);
-
-    static ttsl::hash::hash_t compute_program_hash(
-        const operation_attributes_t& operation_attributes, const Tensor& input_tensor);
 };
 
 Tensor interleaved_to_sharded_partial(

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op_types.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <utility>
+
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/types.hpp"
 #include <tt-metalium/core_coord.hpp>
@@ -17,6 +19,12 @@ struct InterleavedToShardedPartialParams {
     uint32_t slice_index{};
     tt::tt_metal::MemoryConfig output_mem_config;
     tt::tt_metal::DataType output_dtype{tt::tt_metal::DataType::INVALID};
+
+    static constexpr auto attribute_names = std::forward_as_tuple(
+        "grid_size", "shard_spec", "num_slices", "slice_index", "output_mem_config", "output_dtype");
+    auto attribute_values() const {
+        return std::forward_as_tuple(grid_size, shard_spec, num_slices, slice_index, output_mem_config, output_dtype);
+    }
 };
 
 }  // namespace ttnn::prim


### PR DESCRIPTION
### PR Category
hash calculation unification for operation InterleavedToShardedPartialDeviceOperation

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for InterleavedToShardedPartialDeviceOperation

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_InterleavedToShardedPartialDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_InterleavedToShardedPartialDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_InterleavedToShardedPartialDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_InterleavedToShardedPartialDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_InterleavedToShardedPartialDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_InterleavedToShardedPartialDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_InterleavedToShardedPartialDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_InterleavedToShardedPartialDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_InterleavedToShardedPartialDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_InterleavedToShardedPartialDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_InterleavedToShardedPartialDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_InterleavedToShardedPartialDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_InterleavedToShardedPartialDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_InterleavedToShardedPartialDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_InterleavedToShardedPartialDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_InterleavedToShardedPartialDeviceOperation)
