### PR TITLE
Alexey zaytsev epam/fix hash collision 45821 k split gram matmul device operation tt train

### DIFF
--- a/tt-train/sources/ttml/metal/ops/k_split_gram_matmul/device/k_split_gram_matmul_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/k_split_gram_matmul/device/k_split_gram_matmul_device_operation.cpp
@@ -82,10 +82,4 @@ KSplitGramMatmulDeviceOperation::tensor_return_value_t KSplitGramMatmulDeviceOpe
         compute_output_specs(operation_attributes, tensor_args), tensor_args.input_tensor.device());
 }
 
-ttsl::hash::hash_t KSplitGramMatmulDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    return tt::tt_metal::operation::hash_operation<KSplitGramMatmulDeviceOperation>(
-        operation_attributes.output_mode, operation_attributes.math_fidelity, tensor_args.input_tensor.logical_shape());
-}
-
 }  // namespace ttml::metal::ops::k_split_gram_matmul::device

--- a/tt-train/sources/ttml/metal/ops/k_split_gram_matmul/device/k_split_gram_matmul_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/k_split_gram_matmul/device/k_split_gram_matmul_device_operation.hpp
@@ -22,7 +22,6 @@ struct KSplitGramMatmulDeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t &, const tensor_args_t &);
     static spec_return_value_t compute_output_specs(const operation_attributes_t &, const tensor_args_t &);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t &, const tensor_args_t &);
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t &, const tensor_args_t &);
 };
 
 }  // namespace ttml::metal::ops::k_split_gram_matmul::device

--- a/tt-train/sources/ttml/metal/ops/k_split_gram_matmul/device/k_split_gram_matmul_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/k_split_gram_matmul/device/k_split_gram_matmul_device_operation_types.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <ttnn/tensor/tensor.hpp>
+#include <tuple>
 
 #include "metal/common/const_utils.hpp"
 
@@ -13,11 +14,21 @@ namespace ttml::metal::ops::k_split_gram_matmul::device {
 struct KSplitGramMatmulParams {
     ttml::metal::OutputMode output_mode = ttml::metal::OutputMode::UpperTriangle;
     tt::tt_metal::MathFidelity math_fidelity = tt::tt_metal::MathFidelity::HiFi4;
+
+    static constexpr auto attribute_names = std::forward_as_tuple("output_mode", "math_fidelity");
+    auto attribute_values() const {
+        return std::forward_as_tuple(this->output_mode, this->math_fidelity);
+    }
 };
 
 struct KSplitGramMatmulInputs {
     ttnn::Tensor input_tensor;
     std::optional<ttnn::Tensor> preallocated_output = std::nullopt;
+
+    static constexpr auto attribute_names = std::forward_as_tuple("input_logical_shape");
+    auto attribute_values() const {
+        return std::forward_as_tuple(this->input_tensor.logical_shape());
+    }
 };
 
 using operation_attributes_t = KSplitGramMatmulParams;


### PR DESCRIPTION
### PR Category
hash calculation unification for operation KSplitGramMatmulDeviceOperation (tt-train)

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for KSplitGramMatmulDeviceOperation (tt-train)

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_KSplitGramMatmulDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_KSplitGramMatmulDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_KSplitGramMatmulDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_KSplitGramMatmulDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_KSplitGramMatmulDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_KSplitGramMatmulDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_KSplitGramMatmulDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_KSplitGramMatmulDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_KSplitGramMatmulDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_KSplitGramMatmulDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_KSplitGramMatmulDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_KSplitGramMatmulDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_KSplitGramMatmulDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_KSplitGramMatmulDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_KSplitGramMatmulDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_KSplitGramMatmulDeviceOperation_tt-train)
