### PR TITLE
#45821: migrate LlamaReduceScatterCreateHeadsDeviceOperation to default program-cache hash

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/llama_reduce_scatter_create_heads_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/llama_reduce_scatter_create_heads_device_op.cpp
@@ -122,25 +122,6 @@ LlamaReduceScatterCreateHeadsDeviceOperation::create_output_tensors(
     return tensors;
 }
 
-tt::tt_metal::operation::Hash LlamaReduceScatterCreateHeadsDeviceOperation::compute_program_hash(
-    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
-    return tt::tt_metal::operation::hash_operation<LlamaReduceScatterCreateHeadsDeviceOperation>(
-        attributes.dim,
-        attributes.cluster_axis,
-        attributes.ring_devices,
-        attributes.num_links,
-        attributes.num_heads,
-        attributes.num_kv_heads,
-        attributes.head_dim,
-        attributes.slice_size,
-        attributes.topology,
-        attributes.use_noc1_only,
-        attributes.use_optimal_ccl_for_llama,
-        tensor_args.input_tensor.dtype(),
-        tensor_args.input_tensor.memory_config(),
-        tensor_args.input_tensor.device()->id());
-}
-
 }  // namespace ttnn::operations::experimental::ccl
 
 namespace ttnn::prim {
@@ -183,8 +164,7 @@ llama_reduce_scatter_create_heads(
         .use_noc1_only = use_noc1_only,
         .use_optimal_ccl_for_llama = use_optimal_ccl_for_llama,
     };
-    auto tensor_args = OperationType::tensor_args_t{
-        .input_tensor = input_tensor, .intermediate_packet_buffer = intermediate_packet_buffer};
+    auto tensor_args = OperationType::tensor_args_t{input_tensor, intermediate_packet_buffer};
 
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/llama_reduce_scatter_create_heads_device_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_create_heads/device/llama_reduce_scatter_create_heads_device_op.hpp
@@ -6,6 +6,7 @@
 
 #include <variant>
 #include <optional>
+#include <tuple>
 #include "ttnn/distributed/types.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/core.hpp"
@@ -34,10 +35,47 @@ struct LlamaReduceScatterCreateHeadsDeviceOperation {
         const std::optional<MemoryConfig> qkv_memory_config;
         bool use_noc1_only;
         bool use_optimal_ccl_for_llama;
+
+        static constexpr auto attribute_names = std::forward_as_tuple(
+            "dim",
+            "cluster_axis",
+            "ring_devices",
+            "num_links",
+            "num_heads",
+            "num_kv_heads",
+            "head_dim",
+            "slice_size",
+            "topology",
+            "use_noc1_only",
+            "use_optimal_ccl_for_llama");
+        auto attribute_values() const {
+            return std::make_tuple(
+                dim,
+                cluster_axis,
+                ring_devices,
+                num_links,
+                num_heads,
+                num_kv_heads,
+                head_dim,
+                slice_size,
+                topology,
+                use_noc1_only,
+                use_optimal_ccl_for_llama);
+        }
     };
     struct tensor_args_t {
-        const Tensor input_tensor;
-        Tensor intermediate_packet_buffer;
+        const Tensor& input_tensor;
+        Tensor& intermediate_packet_buffer;
+
+        tensor_args_t(const Tensor& input, Tensor& intermediate) :
+            input_tensor(input), intermediate_packet_buffer(intermediate) {}
+
+        static constexpr auto attribute_names =
+            std::forward_as_tuple("input_dtype", "input_memory_config", "input_device_id");
+        auto attribute_values() const {
+            return std::make_tuple(
+                input_tensor.dtype(), std::cref(input_tensor.memory_config()), input_tensor.device()->id());
+        }
     };
 
     using spec_return_value_t = std::vector<ttnn::TensorSpec>;
@@ -92,8 +130,6 @@ struct LlamaReduceScatterCreateHeadsDeviceOperation {
 
     // Create the output tensors based on the operation attributes and tensor args
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static tt::tt_metal::operation::Hash compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 }  // namespace ttnn::operations::experimental::ccl
 


### PR DESCRIPTION
### PR Category
hash calculation unification for operation LlamaReduceScatterCreateHeadsDeviceOperation

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for LlamaReduceScatterCreateHeadsDeviceOperation

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_LlamaReduceScatterCreateHeadsDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_LlamaReduceScatterCreateHeadsDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_LlamaReduceScatterCreateHeadsDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_LlamaReduceScatterCreateHeadsDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_LlamaReduceScatterCreateHeadsDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_LlamaReduceScatterCreateHeadsDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_LlamaReduceScatterCreateHeadsDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_LlamaReduceScatterCreateHeadsDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_LlamaReduceScatterCreateHeadsDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_LlamaReduceScatterCreateHeadsDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_LlamaReduceScatterCreateHeadsDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_LlamaReduceScatterCreateHeadsDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_LlamaReduceScatterCreateHeadsDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_LlamaReduceScatterCreateHeadsDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_LlamaReduceScatterCreateHeadsDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_LlamaReduceScatterCreateHeadsDeviceOperation)
