### PR TITLE
#45821: migrate Matmul_RS to default program-cache hash

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.cpp
@@ -83,20 +83,6 @@ Matmul_RS::tensor_return_value_t Matmul_RS::create_output_tensors(
     return {matmul_output_tensor, rs_output_tensor};
 }
 
-ttsl::hash::hash_t Matmul_RS::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    return tt::tt_metal::operation::hash_operation<Matmul_RS>(
-        operation_attributes.rs_op.dim,
-        operation_attributes.rs_op.cluster_axis,
-        operation_attributes.rs_op.ring_devices,
-        operation_attributes.rs_op.num_links,
-        operation_attributes.rs_op.topology,
-        operation_attributes.rs_op.use_noc1_only,
-        tensor_args.rs.input_tensor.dtype(),
-        tensor_args.rs.input_tensor.memory_config(),
-        tensor_args.rs.input_tensor.device()->id());
-}
-
 }  // namespace ttnn::operations::experimental::ccl
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter_matmul/device/rs_matmul_op.hpp
@@ -16,6 +16,7 @@
 #include "ttnn/operation.hpp"
 
 #include <optional>
+#include <tuple>
 #include <vector>
 #include <algorithm>
 
@@ -45,6 +46,18 @@ struct Matmul_RS {
         LlamaReduceScatterDeviceOperation::operation_attributes_t rs_op;
         ttnn::prim::MatmulDeviceOperation::operation_attributes_t matmul;
         using matmul_device_t = ttnn::prim::MatmulDeviceOperation;
+
+        static constexpr auto attribute_names =
+            std::forward_as_tuple("dim", "cluster_axis", "ring_devices", "num_links", "topology", "use_noc1_only");
+        auto attribute_values() const {
+            return std::make_tuple(
+                rs_op.dim,
+                rs_op.cluster_axis,
+                rs_op.ring_devices,
+                rs_op.num_links,
+                rs_op.topology,
+                rs_op.use_noc1_only);
+        }
     };
     struct Matmul_RS_PF {
         // Shared variables are the variables that are shared between the create and override_runtime_arguments methods
@@ -77,7 +90,6 @@ struct Matmul_RS {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::operations::experimental::ccl


### PR DESCRIPTION
### PR Category
hash calculation unification for operation Matmul_RS

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for Matmul_RS

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_Matmul_RS)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_Matmul_RS)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_Matmul_RS)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_Matmul_RS)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_Matmul_RS)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_Matmul_RS)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_Matmul_RS)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_Matmul_RS)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_Matmul_RS)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_Matmul_RS)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_Matmul_RS)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_Matmul_RS)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_Matmul_RS)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_Matmul_RS)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_Matmul_RS)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_Matmul_RS)
