### PR TITLE
Alexey zaytsev epam/fix hash collision 45821 matmul reduce scatter async device operation

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_device_operation.cpp
@@ -79,42 +79,6 @@ MatmulReduceScatterAsyncDeviceOperation::create_output_tensors(
     return {.mm = matmul_output_tensor, .reduce_scatter = tensor_args.persistent_output};
 }
 
-ttsl::hash::hash_t MatmulReduceScatterAsyncDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    log_trace(tt::LogOp, "MatmulReduceScatterAsyncDeviceOperation::compute_program_hash is called");
-
-    const ttnn::Tensor& input_tensor = tensor_args.input;
-    const ttnn::Tensor& weight_tensor = tensor_args.weight;
-    const std::optional<ttnn::Tensor>& bias_tensor = tensor_args.bias;
-    const ttnn::Tensor& persistent_intermediate_tensor = tensor_args.persistent_intermediate;
-    const ttnn::Tensor& persistent_output_tensor = tensor_args.persistent_output;
-    return tt::tt_metal::operation::hash_operation<MatmulReduceScatterAsyncDeviceOperation>(
-        args.reduce_scatter_params.dim,
-        args.reduce_scatter_params.num_links,
-        args.reduce_scatter_params.ring_size,
-        args.reduce_scatter_params.output_mem_config,
-        args.reduce_scatter_params.optional_intermediate_mem_config,
-        args.reduce_scatter_params.topology,
-        args.reduce_scatter_params.sub_device_id.has_value(),
-        args.reduce_scatter_params.sub_device_id.has_value()
-            ? tensor_args.input.device()->worker_cores(
-                  tt::tt_metal::HalProgrammableCoreType::TENSIX, args.reduce_scatter_params.sub_device_id.value())
-            : CoreRangeSet(CoreRange({0, 0}, {0, 0})),
-        args.reduce_scatter_params.cluster_axis,
-        args.reduce_scatter_params.barrier_semaphore.has_value(),
-        args.reduce_scatter_params.using_persistent_buffers,
-        args.reduce_scatter_params.chunks_per_sync,
-        args.reduce_scatter_params.num_workers_per_link,
-        args.reduce_scatter_params.num_buffers_per_channel,
-        args.matmul_struct,
-        args.reduce_scatter_core_grid_offset,
-        input_tensor,
-        weight_tensor,
-        bias_tensor,
-        persistent_intermediate_tensor,
-        persistent_output_tensor);
-}
-
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_device_operation.hpp
@@ -39,7 +39,6 @@ struct MatmulReduceScatterAsyncDeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/matmul_reduce_scatter_async/device/matmul_reduce_scatter_async_device_operation_types.hpp
@@ -4,9 +4,11 @@
 
 #pragma once
 
+#include <tuple>
 #include <utility>
 #include <vector>
 
+#include <tt_stl/reflection.hpp>
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_op_device_operation_types.hpp"
 #include "ttnn/operations/matmul/device/matmul_device_operation_types.hpp"
@@ -33,9 +35,39 @@ struct MatmulReduceScatterAsyncParams {
         reduce_scatter_core_grid_offset(reduce_scatter_core_grid_offset),
         devices(std::move(devices)) {}
 
-    static constexpr auto attribute_names = std::forward_as_tuple("matmul_struct", "reduce_scatter_core_grid_offset");
+    static constexpr auto attribute_names = std::forward_as_tuple(
+        "dim",
+        "num_links",
+        "ring_size",
+        "output_mem_config",
+        "optional_intermediate_mem_config",
+        "topology",
+        "has_barrier_semaphore",
+        "using_persistent_buffers",
+        "sub_device_id",
+        "cluster_axis",
+        "chunks_per_sync",
+        "num_workers_per_link",
+        "num_buffers_per_channel",
+        "matmul_struct",
+        "reduce_scatter_core_grid_offset");
     auto attribute_values() const {
-        return std::forward_as_tuple(this->matmul_struct, this->reduce_scatter_core_grid_offset);
+        return std::make_tuple(
+            reduce_scatter_params.dim,
+            reduce_scatter_params.num_links,
+            reduce_scatter_params.ring_size,
+            std::cref(reduce_scatter_params.output_mem_config),
+            std::cref(reduce_scatter_params.optional_intermediate_mem_config),
+            reduce_scatter_params.topology,
+            reduce_scatter_params.barrier_semaphore.has_value(),
+            reduce_scatter_params.using_persistent_buffers,
+            reduce_scatter_params.sub_device_id,
+            std::cref(reduce_scatter_params.cluster_axis),
+            std::cref(reduce_scatter_params.chunks_per_sync),
+            std::cref(reduce_scatter_params.num_workers_per_link),
+            std::cref(reduce_scatter_params.num_buffers_per_channel),
+            std::cref(matmul_struct),
+            std::cref(reduce_scatter_core_grid_offset));
     }
 };
 


### PR DESCRIPTION
### PR Category
hash calculation unification for operation MatmulReduceScatterAsyncDeviceOperation

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for MatmulReduceScatterAsyncDeviceOperation

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_MatmulReduceScatterAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_MatmulReduceScatterAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_MatmulReduceScatterAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_MatmulReduceScatterAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_MatmulReduceScatterAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_MatmulReduceScatterAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_MatmulReduceScatterAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_MatmulReduceScatterAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_MatmulReduceScatterAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_MatmulReduceScatterAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_MatmulReduceScatterAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_MatmulReduceScatterAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_MatmulReduceScatterAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_MatmulReduceScatterAsyncDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_MatmulReduceScatterAsyncDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_MatmulReduceScatterAsyncDeviceOperation)
