### PR TITLE
#45821: migrate MLAQKVAssembleBwDeviceOperation (tt-train) to default program-cache hash

### DIFF
--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation.cpp
@@ -153,16 +153,6 @@ MLAQKVAssembleBwDeviceOperation::tensor_return_value_t MLAQKVAssembleBwDeviceOpe
         create_device_tensor(specs[2], device)};
 }
 
-ttsl::hash::hash_t MLAQKVAssembleBwDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    return tt::tt_metal::operation::hash_operation<MLAQKVAssembleBwDeviceOperation>(
-        args,
-        tensor_args.dQ.dtype(),
-        tensor_args.dQ.logical_shape(),
-        tensor_args.dK.logical_shape(),
-        tensor_args.dV.logical_shape());
-}
-
 MLAQKVAssembleBwDeviceOperation::program_factory_t MLAQKVAssembleBwDeviceOperation::select_program_factory(
     const operation_attributes_t& /*args*/, const tensor_args_t& /*tensor_args*/) {
     return MLAQKVAssembleBwProgramFactory{};

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation.hpp
@@ -23,8 +23,6 @@ struct MLAQKVAssembleBwDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
-
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
 };
 

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation_types.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdint>
+#include <tuple>
 
 #include "metal/ttnn_all_includes.hpp"
 
@@ -15,12 +16,24 @@ struct MLAQKVAssembleBwParams {
     uint32_t qk_nope_dim{};
     uint32_t qk_rope_dim{};
     uint32_t v_dim{};
+
+    static constexpr auto attribute_names = std::forward_as_tuple("n_heads", "qk_nope_dim", "qk_rope_dim", "v_dim");
+    auto attribute_values() const {
+        return std::forward_as_tuple(n_heads, qk_nope_dim, qk_rope_dim, v_dim);
+    }
 };
 
 struct MLAQKVAssembleBwInputs {
     const ttnn::Tensor& dQ;
     const ttnn::Tensor& dK;
     const ttnn::Tensor& dV;
+
+    static constexpr auto attribute_names =
+        std::forward_as_tuple("dQ_dtype", "dQ_logical_shape", "dK_logical_shape", "dV_logical_shape");
+    auto attribute_values() const {
+        return std::make_tuple(
+            dQ.dtype(), std::cref(dQ.logical_shape()), std::cref(dK.logical_shape()), std::cref(dV.logical_shape()));
+    }
 };
 
 using operation_attributes_t = MLAQKVAssembleBwParams;


### PR DESCRIPTION
### PR Category
hash calculation unification for operation MLAQKVAssembleBwDeviceOperation (tt-train)

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for MLAQKVAssembleBwDeviceOperation (tt-train)

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_MLAQKVAssembleBwDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_MLAQKVAssembleBwDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_MLAQKVAssembleBwDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_MLAQKVAssembleBwDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_MLAQKVAssembleBwDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_MLAQKVAssembleBwDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_MLAQKVAssembleBwDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_MLAQKVAssembleBwDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_MLAQKVAssembleBwDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_MLAQKVAssembleBwDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_MLAQKVAssembleBwDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_MLAQKVAssembleBwDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_MLAQKVAssembleBwDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_MLAQKVAssembleBwDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_MLAQKVAssembleBwDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_MLAQKVAssembleBwDeviceOperation_tt-train)
