### PR TITLE
Alexey zaytsev epam/fix hash collision 45821 mla q rope device operation tt train

### DIFF
--- a/tt-train/sources/ttml/metal/ops/mla_q_rope/device/mla_q_rope_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_q_rope/device/mla_q_rope_device_operation.cpp
@@ -124,12 +124,6 @@ MlaQRopeDeviceOperation::tensor_return_value_t MlaQRopeDeviceOperation::create_o
     return create_device_tensor(spec, tensor_args.q_in.device());
 }
 
-ttsl::hash::hash_t MlaQRopeDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    return tt::tt_metal::operation::hash_operation<MlaQRopeDeviceOperation>(
-        args, tensor_args.q_in.dtype(), tensor_args.q_in.logical_shape(), tensor_args.cos_cache.logical_shape());
-}
-
 MlaQRopeDeviceOperation::program_factory_t MlaQRopeDeviceOperation::select_program_factory(
     const operation_attributes_t&, const tensor_args_t&) {
     return MlaQRopeProgramFactory{};

--- a/tt-train/sources/ttml/metal/ops/mla_q_rope/device/mla_q_rope_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/mla_q_rope/device/mla_q_rope_device_operation.hpp
@@ -23,8 +23,6 @@ struct MlaQRopeDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
-
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
 };
 

--- a/tt-train/sources/ttml/metal/ops/mla_q_rope/device/mla_q_rope_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/mla_q_rope/device/mla_q_rope_device_operation_types.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdint>
+#include <tuple>
 
 #include "metal/ttnn_all_includes.hpp"
 
@@ -13,6 +14,11 @@ namespace ttml::metal::ops::mla_q_rope::device {
 struct MlaQRopeParams {
     uint32_t qk_nope_dim{};
     uint32_t qk_rope_dim{};
+
+    static constexpr auto attribute_names = std::forward_as_tuple("qk_nope_dim", "qk_rope_dim");
+    auto attribute_values() const {
+        return std::forward_as_tuple(qk_nope_dim, qk_rope_dim);
+    }
 };
 
 struct MlaQRopeInputs {
@@ -20,6 +26,19 @@ struct MlaQRopeInputs {
     const ttnn::Tensor& cos_cache;
     const ttnn::Tensor& sin_cache;
     const ttnn::Tensor& trans_mat;
+
+    static constexpr auto attribute_names = std::forward_as_tuple(
+        "q_in_dtype", "q_in_logical_shape", "cos_cache_logical_shape", "q_in", "cos_cache", "sin_cache", "trans_mat");
+    auto attribute_values() const {
+        return std::make_tuple(
+            q_in.dtype(),
+            std::cref(q_in.logical_shape()),
+            std::cref(cos_cache.logical_shape()),
+            std::cref(q_in),
+            std::cref(cos_cache),
+            std::cref(sin_cache),
+            std::cref(trans_mat));
+    }
 };
 
 using operation_attributes_t = MlaQRopeParams;


### PR DESCRIPTION
### PR Category
hash calculation unification for operation MlaQRopeDeviceOperation (tt-train)

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for MlaQRopeDeviceOperation (tt-train)

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_MlaQRopeDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_MlaQRopeDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_MlaQRopeDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_MlaQRopeDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_MlaQRopeDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_MlaQRopeDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_MlaQRopeDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_MlaQRopeDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_MlaQRopeDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_MlaQRopeDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_MlaQRopeDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_MlaQRopeDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_MlaQRopeDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_MlaQRopeDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_MlaQRopeDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_MlaQRopeDeviceOperation_tt-train)
