### PR TITLE
#45821: migrate MoeUngroupDeviceOperation (tt-train) to default program-cache hash

### DIFF
--- a/tt-train/sources/ttml/metal/ops/moe_ungroup/device/moe_ungroup_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/moe_ungroup/device/moe_ungroup_device_operation.cpp
@@ -100,12 +100,6 @@ tensor_return_value_t MoeUngroupDeviceOperation::create_output_tensors(
     return create_device_tensor(spec, device);
 }
 
-ttsl::hash::hash_t MoeUngroupDeviceOperation::compute_program_hash(
-    const operation_attributes_t& attrs, const tensor_args_t& args) {
-    return tt::tt_metal::operation::hash_operation<MoeUngroupDeviceOperation>(
-        attrs, args.expert_out.dtype(), args.expert_out.logical_shape());
-}
-
 }  // namespace ttml::metal::ops::moe_ungroup::device
 
 namespace ttnn::prim {

--- a/tt-train/sources/ttml/metal/ops/moe_ungroup/device/moe_ungroup_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/moe_ungroup/device/moe_ungroup_device_operation.hpp
@@ -24,8 +24,6 @@ struct MoeUngroupDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttml::metal::ops::moe_ungroup::device

--- a/tt-train/sources/ttml/metal/ops/moe_ungroup/device/moe_ungroup_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/moe_ungroup/device/moe_ungroup_device_operation_types.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdint>
+#include <tuple>
 
 #include "metal/ttnn_all_includes.hpp"
 
@@ -17,6 +18,11 @@ struct MoeUngroupAttributes {
     uint32_t s{};
     uint32_t h{};
     uint32_t t_cap{};
+
+    static constexpr auto attribute_names = std::forward_as_tuple("e_local", "d", "b", "s", "h", "t_cap");
+    auto attribute_values() const {
+        return std::forward_as_tuple(e_local, d, b, s, h, t_cap);
+    }
 };
 
 struct MoeUngroupTensorArgs {
@@ -24,6 +30,11 @@ struct MoeUngroupTensorArgs {
     ttnn::Tensor plan;            // [1, 1, 1, T_cap]     ROW_MAJOR uint32
     ttnn::Tensor offsets;         // [1, 1, 1, E_local+1] ROW_MAJOR uint32
     ttnn::Tensor grouped_scores;  // [1, 1, 1, T_cap]     ROW_MAJOR bf16
+
+    static constexpr auto attribute_names = std::forward_as_tuple("expert_out_dtype", "expert_out_logical_shape");
+    auto attribute_values() const {
+        return std::make_tuple(expert_out.dtype(), std::cref(expert_out.logical_shape()));
+    }
 };
 
 using MoeUngroupSpecReturn = ttnn::TensorSpec;


### PR DESCRIPTION
### PR Category
hash calculation unification for operation MoeUngroupDeviceOperation (tt-train)

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for MoeUngroupDeviceOperation (tt-train)

### Notes for reviewers
NA

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_MoeUngroupDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_MoeUngroupDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_MoeUngroupDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_MoeUngroupDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_MoeUngroupDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_MoeUngroupDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_MoeUngroupDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_MoeUngroupDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_MoeUngroupDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_MoeUngroupDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_MoeUngroupDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_MoeUngroupDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_MoeUngroupDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_MoeUngroupDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_MoeUngroupDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_MoeUngroupDeviceOperation_tt-train)
