### PR TITLE
Alexey zaytsev epam/fix hash collision 45821 outbound socket service sync operation

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/outbound_socket_service_sync/device/outbound_socket_service_sync_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/outbound_socket_service_sync/device/outbound_socket_service_sync_device_operation.cpp
@@ -75,25 +75,6 @@ OutboundSocketServiceSyncOperation::tensor_return_value_t OutboundSocketServiceS
     return tensor_args.backing;
 }
 
-ttsl::hash::hash_t OutboundSocketServiceSyncOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    // Stable across calls for a given (service, config): the changing input address is
-    // a BufferBinding (patched on cache hit), NOT part of the hash.
-    return operation::hash_operation<OutboundSocketServiceSyncOperation>(
-        args.page_size,
-        args.num_pages,
-        args.scratch_cb_index,
-        args.metadata_size_bytes,
-        args.metadata_only,
-        args.worker_cores,
-        args.mesh_num_cols,
-        args.data_ready_addrs,
-        args.service_core_x,
-        args.service_core_y,
-        args.metadata_addrs,
-        tensor_args.input.dtype());
-}
-
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/outbound_socket_service_sync/device/outbound_socket_service_sync_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/outbound_socket_service_sync/device/outbound_socket_service_sync_device_operation.hpp
@@ -30,9 +30,6 @@ struct OutboundSocketServiceSyncOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    // Keys the program on (service identity + config), NOT on the per-call input
-    // buffer address (that is a BufferBinding, patched on cache hits).
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/outbound_socket_service_sync/device/outbound_socket_service_sync_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/outbound_socket_service_sync/device/outbound_socket_service_sync_device_operation_types.hpp
@@ -32,6 +32,34 @@ struct OutboundSocketServiceSyncParams {
     std::vector<uint32_t> service_core_x;    // LOGICAL service-core x per coord
     std::vector<uint32_t> service_core_y;    // LOGICAL service-core y per coord
     std::vector<uint32_t> metadata_addrs;    // per-coord service-core metadata L1 (metadata mode)
+
+    static constexpr auto attribute_names = std::forward_as_tuple(
+        "page_size",
+        "num_pages",
+        "scratch_cb_index",
+        "metadata_size_bytes",
+        "metadata_only",
+        "worker_cores",
+        "mesh_num_cols",
+        "data_ready_addrs",
+        "service_core_x",
+        "service_core_y",
+        "metadata_addrs");
+
+    auto attribute_values() const {
+        return std::forward_as_tuple(
+            page_size,
+            num_pages,
+            scratch_cb_index,
+            metadata_size_bytes,
+            metadata_only,
+            worker_cores,
+            mesh_num_cols,
+            data_ready_addrs,
+            service_core_x,
+            service_core_y,
+            metadata_addrs);
+    }
 };
 
 struct OutboundSocketServiceSyncInputs {
@@ -44,6 +72,13 @@ struct OutboundSocketServiceSyncInputs {
     Tensor input;
     Tensor backing;
     std::optional<Tensor> metadata;
+
+    OutboundSocketServiceSyncInputs(
+        const Tensor& input_in, const Tensor& backing_in, const std::optional<Tensor>& metadata_in) :
+        input(input_in), backing(backing_in), metadata(metadata_in) {}
+
+    static constexpr auto attribute_names = std::forward_as_tuple("input_dtype");
+    auto attribute_values() const { return std::forward_as_tuple(input.dtype()); }
 };
 
 }  // namespace ttnn::experimental::prim


### PR DESCRIPTION
### PR Category
hash calculation unification for operation OutboundSocketServiceSyncOperation

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for OutboundSocketServiceSyncOperation

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_OutboundSocketServiceSyncOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_OutboundSocketServiceSyncOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_OutboundSocketServiceSyncOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_OutboundSocketServiceSyncOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_OutboundSocketServiceSyncOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_OutboundSocketServiceSyncOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_OutboundSocketServiceSyncOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_OutboundSocketServiceSyncOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_OutboundSocketServiceSyncOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_OutboundSocketServiceSyncOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_OutboundSocketServiceSyncOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_OutboundSocketServiceSyncOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_OutboundSocketServiceSyncOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_OutboundSocketServiceSyncOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_OutboundSocketServiceSyncOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_OutboundSocketServiceSyncOperation)
