### PR TITLE
test(routed_expert): scale expert count by actual mesh size

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ttnn_routed_expert.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ttnn_routed_expert.py
@@ -102,6 +102,11 @@ def run_torch_routed_experts(
     return expert_outputs
 
 
+# Device count of a full Galaxy. Model configs express NUM_ROUTED_EXPERTS for this topology, so it
+# is the denominator used to scale a model's expert count down to whatever mesh a test runs on.
+GALAXY_DEVICE_COUNT = 32
+
+
 ROUTED_EXPERT_MESH_PARAMS = [
     pytest.param(
         1,
@@ -537,7 +542,10 @@ def _xfail_known_routed_expert_failures(request):
 
 def routed_expert_shape_params():
     """Build the per-model shape parametrization. Non-baseline models carry the extended_model
-    marker on their params so they stay gated exactly as the separate tests were."""
+    marker on their params so they stay gated exactly as the separate tests were.
+
+    NUM_ROUTED_EXPERTS is the model's full-Galaxy expert count; it is scaled down to the
+    per-mesh expert count inside the test body once the actual mesh size is known."""
     params = []
     for name, config, extended in ROUTED_EXPERT_MODELS:
         marks = (pytest.mark.extended_model,) if extended else ()
@@ -546,7 +554,7 @@ def routed_expert_shape_params():
                 640,
                 config.EMB_SIZE,
                 config.MOE_INTERMEDIATE_SIZE,
-                config.NUM_ROUTED_EXPERTS // 4,
+                config.NUM_ROUTED_EXPERTS,
                 2,
                 3,
                 False,
@@ -558,7 +566,7 @@ def routed_expert_shape_params():
 
 
 @pytest.mark.parametrize(
-    "seq_len_per_chip, emb_dim, hidden_dim, num_routed_experts, num_experts_per_tok, dispatch_buffer_capacity_factor, run_pcc_check",
+    "seq_len_per_chip, emb_dim, hidden_dim, total_expert_count, num_experts_per_tok, dispatch_buffer_capacity_factor, run_pcc_check",
     routed_expert_shape_params(),
 )
 @pytest.mark.parametrize(
@@ -571,12 +579,16 @@ def test_ttnn_routed_expert_models(
     seq_len_per_chip,
     emb_dim,
     hidden_dim,
-    num_routed_experts,
+    total_expert_count,
     num_experts_per_tok,
     dispatch_buffer_capacity_factor,
     run_pcc_check,
     use_predictable_data,
 ):
+    # total_expert_count is the model's full-Galaxy (GALAXY_DEVICE_COUNT devices) expert count.
+    # Scale it down to the number of experts hosted by the mesh we're actually running on.
+    # To keep real per-chip workload.
+    num_routed_experts = total_expert_count // GALAXY_DEVICE_COUNT * mesh_device.get_num_devices()
     run_routed_expert(
         mesh_device,
         device_params,


### PR DESCRIPTION
## Problem

`routed_expert_shape_params()` in `test_ttnn_routed_expert.py` hardcoded `config.NUM_ROUTED_EXPERTS // 4` for the per-model routed-expert test. The `// 4` assumed a 4-device mesh, but the test fans out over several mesh layouts (`single-1`, `linear-4`, `linear-8`, `mesh-4x2`, `mesh-2x4`). On any non-4-device layout this produced the wrong per-chip expert count.

## Change

- Pass the model's full-Galaxy `NUM_ROUTED_EXPERTS` through as a new `total_expert_count` parameter (renamed from `num_routed_experts`).
- Scale it to the actual mesh **inside the test body**, where `mesh_device` exists:
  ```python
  num_routed_experts = total_expert_count // GALAXY_DEVICE_COUNT * mesh_device.get_num_devices()
  ```
- Added a module-level `GALAXY_DEVICE_COUNT = 32` constant.
- `mesh_device.get_num_devices()` (per-mesh count) is used rather than `ttnn.get_num_devices()` (cluster-wide) so submeshes scale correctly.

The shared `run_routed_expert` and the model-independent `test_ttnn_routed_expert` (fixed `num_routed_experts=64`) are untouched — no double-scaling.

## Testing

`pytest ... -k test_ttnn_routed_expert_models` on Blackhole (single-1 mesh): **14 passed, 56 skipped** (4-/8-device layouts skipped for lack of devices). Runtime dropped from ~17m to ~2m because single-device now simulates the real per-chip load (`NUM // 32`) instead of the inflated `NUM // 4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mbezulj/routed-expert-scale-mesh-devices)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mbezulj/routed-expert-scale-mesh-devices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mbezulj/routed-expert-scale-mesh-devices)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mbezulj/routed-expert-scale-mesh-devices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mbezulj/routed-expert-scale-mesh-devices)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mbezulj/routed-expert-scale-mesh-devices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mbezulj/routed-expert-scale-mesh-devices)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mbezulj/routed-expert-scale-mesh-devices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mbezulj/routed-expert-scale-mesh-devices)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mbezulj/routed-expert-scale-mesh-devices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mbezulj/routed-expert-scale-mesh-devices)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mbezulj/routed-expert-scale-mesh-devices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mbezulj/routed-expert-scale-mesh-devices)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mbezulj/routed-expert-scale-mesh-devices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mbezulj/routed-expert-scale-mesh-devices)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mbezulj/routed-expert-scale-mesh-devices)

### DeepSeek Prefill CI
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=mbezulj/routed-expert-scale-mesh-devices)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:mbezulj/routed-expert-scale-mesh-devices) T3K
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=mbezulj/routed-expert-scale-mesh-devices)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:mbezulj/routed-expert-scale-mesh-devices) Blackhole
