### PR TITLE
Alexey zaytsev epam/fix hash collision 45821 w per token cast back device operation

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/per_token_cast_back_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/per_token_cast_back_device_operation.cpp
@@ -143,23 +143,6 @@ PerTokenCastBackDeviceOperation::tensor_return_value_t PerTokenCastBackDeviceOpe
     return create_device_tensor(compute_output_specs(attrs, tensor_args), tensor_args.input_e4m3.device());
 }
 
-ttsl::hash::hash_t PerTokenCastBackDeviceOperation::compute_program_hash(
-    const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
-    const auto tile_shape = tensor_args.input_e4m3.tensor_spec().tile().get_tile_shape();
-    const auto face_shape = tensor_args.input_e4m3.tensor_spec().tile().get_face_shape();
-    return tt::tt_metal::operation::hash_operation<PerTokenCastBackDeviceOperation>(
-        attrs,
-        tensor_args.input_e4m3.dtype(),
-        tensor_args.input_e4m3.memory_config(),
-        tensor_args.input_scale.memory_config(),
-        tensor_args.input_e4m3.logical_shape(),
-        tensor_args.input_scale.logical_shape(),
-        tile_shape[0],
-        tile_shape[1],
-        face_shape[0],
-        face_shape[1]);
-}
-
 }  // namespace ttnn::experimental::prim::per_token_cast_back
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/per_token_cast_back_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/per_token_cast_back_device_operation.hpp
@@ -24,7 +24,6 @@ struct PerTokenCastBackDeviceOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim::per_token_cast_back

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/per_token_cast_back_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/per_token_cast_back_device_operation_types.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <tuple>
+
 #include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::experimental::prim::per_token_cast_back {
@@ -11,6 +13,9 @@ namespace ttnn::experimental::prim::per_token_cast_back {
 struct PerTokenCastBackParams {
     tt::tt_metal::DataType output_dtype;
     tt::tt_metal::MemoryConfig output_memory_config;
+
+    static constexpr auto attribute_names = std::forward_as_tuple("output_dtype", "output_memory_config");
+    auto attribute_values() const { return std::forward_as_tuple(output_dtype, output_memory_config); }
 };
 
 struct PerTokenCastBackInputs {


### PR DESCRIPTION
### PR Category
hash calculation unification for operation PerTokenCastBackDeviceOperation

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for PerTokenCastBackDeviceOperation

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_PerTokenCastBackDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_PerTokenCastBackDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_PerTokenCastBackDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_PerTokenCastBackDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_PerTokenCastBackDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_PerTokenCastBackDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_PerTokenCastBackDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_PerTokenCastBackDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_PerTokenCastBackDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_PerTokenCastBackDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_PerTokenCastBackDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_PerTokenCastBackDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_PerTokenCastBackDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_PerTokenCastBackDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_PerTokenCastBackDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_PerTokenCastBackDeviceOperation)
