### PR TITLE
Alexey zaytsev epam/fix hash collision 45821 per token cast to fp8 device operation

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/device/per_token_cast_to_fp8_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/device/per_token_cast_to_fp8_device_operation.cpp
@@ -148,22 +148,6 @@ PerTokenCastToFp8DeviceOperation::tensor_return_value_t PerTokenCastToFp8DeviceO
     return {create_device_tensor(output_e4m3_spec, device), create_device_tensor(scale_spec, device)};
 }
 
-ttsl::hash::hash_t PerTokenCastToFp8DeviceOperation::compute_program_hash(
-    const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
-    const auto& input = tensor_args.input_tensor;
-    const auto tile_shape = input.tensor_spec().tile().get_tile_shape();
-    const auto face_shape = input.tensor_spec().tile().get_face_shape();
-    return tt::tt_metal::operation::hash_operation<PerTokenCastToFp8DeviceOperation>(
-        attrs,
-        input.dtype(),
-        input.memory_config(),
-        input.logical_shape(),
-        tile_shape[0],
-        tile_shape[1],
-        face_shape[0],
-        face_shape[1]);
-}
-
 }  // namespace ttnn::experimental::prim::per_token_cast_to_fp8
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/device/per_token_cast_to_fp8_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/device/per_token_cast_to_fp8_device_operation.hpp
@@ -25,7 +25,6 @@ struct PerTokenCastToFp8DeviceOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim::per_token_cast_to_fp8

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/device/per_token_cast_to_fp8_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/device/per_token_cast_to_fp8_device_operation_types.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <tuple>
+
 #include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::experimental::prim::per_token_cast_to_fp8 {
@@ -11,6 +13,10 @@ namespace ttnn::experimental::prim::per_token_cast_to_fp8 {
 struct PerTokenCastToFp8Params {
     tt::tt_metal::MemoryConfig output_memory_config;
     bool round_scale_to_power_of_two;
+
+    static constexpr auto attribute_names =
+        std::forward_as_tuple("output_memory_config", "round_scale_to_power_of_two");
+    auto attribute_values() const { return std::forward_as_tuple(output_memory_config, round_scale_to_power_of_two); }
 };
 
 struct PerTokenCastToFp8Inputs {


### PR DESCRIPTION
### PR Category
hash calculation unification for operation PerTokenCastToFp8DeviceOperation

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for PerTokenCastToFp8DeviceOperation

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_PerTokenCastToFp8DeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_PerTokenCastToFp8DeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_PerTokenCastToFp8DeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_PerTokenCastToFp8DeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_PerTokenCastToFp8DeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_PerTokenCastToFp8DeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_PerTokenCastToFp8DeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_PerTokenCastToFp8DeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_PerTokenCastToFp8DeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_PerTokenCastToFp8DeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_PerTokenCastToFp8DeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_PerTokenCastToFp8DeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_PerTokenCastToFp8DeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_PerTokenCastToFp8DeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_PerTokenCastToFp8DeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_PerTokenCastToFp8DeviceOperation)
