### PR TITLE
Alexey zaytsev epam/fix hash collision 45821 recv async h2d device operation

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async_h2d/device/recv_async_h2d_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async_h2d/device/recv_async_h2d_op_device_operation.cpp
@@ -55,18 +55,6 @@ RecvAsyncH2DDeviceOperation::tensor_return_value_t RecvAsyncH2DDeviceOperation::
     return {tensor_args};
 }
 
-ttsl::hash::hash_t RecvAsyncH2DDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    log_trace(tt::LogOp, "RecvAsyncH2DDeviceOperation::compute_program_hash is called");
-    const ttnn::Tensor& output_tensor = tensor_args;
-    // Hash on the stable, structural properties of the H2D socket exposed via attributes()
-    // along with the output tensor.
-    return tt::tt_metal::operation::hash_operation<RecvAsyncH2DDeviceOperation>(
-        args.h2d_socket->get_config_buffer_address(),
-        static_cast<uint8_t>(args.h2d_socket->get_h2d_mode()),
-        output_tensor);
-}
-
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async_h2d/device/recv_async_h2d_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async_h2d/device/recv_async_h2d_op_device_operation.hpp
@@ -21,8 +21,6 @@ struct RecvAsyncH2DDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async_h2d/device/recv_async_h2d_op_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/recv_async_h2d/device/recv_async_h2d_op_device_operation_types.hpp
@@ -22,6 +22,13 @@ struct RecvAsyncH2DParams {
 
     explicit RecvAsyncH2DParams(const tt::tt_metal::distributed::H2DSocket& h2d_socket) : h2d_socket(&h2d_socket) {}
 
+    static constexpr auto attribute_names = std::forward_as_tuple("h2d_config_buffer_address", "h2d_mode");
+    auto attribute_values() const {
+        TT_FATAL(h2d_socket != nullptr, "recv_async_h2d: H2DSocket pointer is null");
+        return std::forward_as_tuple(
+            h2d_socket->get_config_buffer_address(), static_cast<uint8_t>(h2d_socket->get_h2d_mode()));
+    }
+
     // Reflection: surface a small set of stable, hashable properties of the H2D socket.
     // These uniquely identify the socket from a program-cache perspective: same device,
     // same config buffer address and same mode produces the same program.


### PR DESCRIPTION
### PR Category
hash calculation unification for operation RecvAsyncH2DDeviceOperation

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for RecvAsyncH2DDeviceOperation

### Notes for reviewers
NA

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_RecvAsyncH2DDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_RecvAsyncH2DDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_RecvAsyncH2DDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_RecvAsyncH2DDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_RecvAsyncH2DDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_RecvAsyncH2DDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_RecvAsyncH2DDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_RecvAsyncH2DDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_RecvAsyncH2DDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_RecvAsyncH2DDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_RecvAsyncH2DDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_RecvAsyncH2DDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_RecvAsyncH2DDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_RecvAsyncH2DDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_RecvAsyncH2DDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_RecvAsyncH2DDeviceOperation)
