### PR TITLE
Alexey zaytsev epam/fix hash collision 45821 reshape device operation

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_device_operation_types.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <tuple>
+
 #include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::prim {
@@ -12,10 +14,29 @@ struct ReshapeOnDeviceParams {
     tt::tt_metal::Shape logical_output_shape;
     tt::tt_metal::Shape padded_output_shape;
     tt::tt_metal::MemoryConfig output_mem_config;
+
+    static constexpr auto attribute_names =
+        std::forward_as_tuple("logical_output_shape", "padded_output_shape", "output_mem_config");
+    auto attribute_values() const {
+        return std::make_tuple(
+            std::cref(logical_output_shape), std::cref(padded_output_shape), std::cref(output_mem_config));
+    }
 };
 
 struct ReshapeOnDeviceInputs {
     tt::tt_metal::Tensor input_tensor;
+
+    ReshapeOnDeviceInputs() = default;
+    explicit ReshapeOnDeviceInputs(tt::tt_metal::Tensor tensor) : input_tensor(std::move(tensor)) {}
+
+    static constexpr auto attribute_names = std::forward_as_tuple("dtype", "memory_config", "layout", "padded_shape");
+    auto attribute_values() const {
+        return std::make_tuple(
+            input_tensor.dtype(),
+            std::cref(input_tensor.memory_config()),
+            input_tensor.layout(),
+            std::cref(input_tensor.padded_shape()));
+    }
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.cpp
@@ -81,22 +81,6 @@ ReshapeDeviceOperation::tensor_return_value_t ReshapeDeviceOperation::create_out
         compute_output_specs(operation_attributes, tensor_args), tensor_args.input_tensor.device());
 }
 
-ttsl::hash::hash_t ReshapeDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    const auto& input_tensor = tensor_args.input_tensor;
-    auto program_factory = select_program_factory(operation_attributes, tensor_args);
-
-    return operation::hash_operation<ReshapeDeviceOperation>(
-        operation_attributes.logical_output_shape,
-        operation_attributes.padded_output_shape,
-        operation_attributes.output_mem_config,
-        program_factory.index(),
-        input_tensor.dtype(),
-        input_tensor.memory_config(),
-        input_tensor.layout(),
-        input_tensor.padded_shape());
-}
-
 tt::tt_metal::Tensor reshape_on_device(
     const Tensor& input_tensor,
     const tt::tt_metal::Shape& logical_output_shape,

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.hpp
@@ -30,9 +30,6 @@ struct ReshapeDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
-
-    static ttsl::hash::hash_t compute_program_hash(
-        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 };
 
 tt::tt_metal::Tensor reshape_on_device(


### PR DESCRIPTION
### PR Category
hash calculation unification for operation ReshapeDeviceOperation

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for ReshapeDeviceOperation

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_ReshapeDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_ReshapeDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_ReshapeDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_ReshapeDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_ReshapeDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_ReshapeDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_ReshapeDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_ReshapeDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_ReshapeDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_ReshapeDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_ReshapeDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_ReshapeDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_ReshapeDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_ReshapeDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_ReshapeDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_ReshapeDeviceOperation)
