### PR TITLE
#45821: migrate RingSDPAFwDeviceOperation (tt-train) to default program-cache hash

### DIFF
--- a/tt-train/sources/ttml/metal/ops/ring_sdpa_fw/device/ring_sdpa_fw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/ring_sdpa_fw/device/ring_sdpa_fw_device_operation.cpp
@@ -63,20 +63,6 @@ RingSDPAFwDeviceOperation::tensor_return_value_t RingSDPAFwDeviceOperation::crea
     return {output, intermediates};
 }
 
-ttsl::hash::hash_t RingSDPAFwDeviceOperation::compute_program_hash(
-    const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
-    // Hash based on operation configuration - buffer addresses are updated via override_runtime_arguments
-    return ttsl::hash::hash_objects(
-        attrs.ring_size,
-        attrs.ring_axis,
-        attrs.step,
-        attrs.mask_type,
-        static_cast<int>(attrs.ring_direction),
-        tensor_args.query.logical_shape(),
-        tensor_args.query.dtype(),
-        tensor_args.key.logical_shape());
-}
-
 }  // namespace ttml::metal::ops::ring_sdpa_fw
 
 namespace ttnn::prim {

--- a/tt-train/sources/ttml/metal/ops/ring_sdpa_fw/device/ring_sdpa_fw_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/ring_sdpa_fw/device/ring_sdpa_fw_device_operation.hpp
@@ -23,9 +23,6 @@ struct RingSDPAFwDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
-
-    static ttsl::hash::hash_t compute_program_hash(
-        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 };
 
 }  // namespace ttml::metal::ops::ring_sdpa_fw

--- a/tt-train/sources/ttml/metal/ops/ring_sdpa_fw/device/ring_sdpa_fw_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/ring_sdpa_fw/device/ring_sdpa_fw_device_operation_types.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <tuple>
+
 #include "metal/common/const_utils.hpp"
 #include "metal/ttnn_all_includes.hpp"
 #include "ttnn/device_operation.hpp"
@@ -22,6 +24,12 @@ struct RingSDPAFwParams {
     ttml::metal::AttentionMaskType mask_type = ttml::metal::AttentionMaskType::None;
     RingDirection ring_direction =
         ttnn_fixed::distributed::RingShiftDirection::Backward;  // Direction K/V is shifting in the ring
+
+    static constexpr auto attribute_names =
+        std::forward_as_tuple("ring_size", "ring_axis", "step", "mask_type", "ring_direction");
+    auto attribute_values() const {
+        return std::forward_as_tuple(ring_size, ring_axis, step, mask_type, ring_direction);
+    }
 };
 
 struct RingSDPAFwInputs {
@@ -30,6 +38,12 @@ struct RingSDPAFwInputs {
     ttnn::Tensor value;
     std::optional<ttnn::Tensor> preallocated_output;         // Preallocated output buffer
     std::optional<ttnn::Tensor> preallocated_intermediates;  // Preallocated intermediates buffer
+
+    static constexpr auto attribute_names =
+        std::forward_as_tuple("query_logical_shape", "query_dtype", "key_logical_shape");
+    auto attribute_values() const {
+        return std::make_tuple(std::cref(query.logical_shape()), query.dtype(), std::cref(key.logical_shape()));
+    }
 };
 
 using operation_attributes_t = RingSDPAFwParams;


### PR DESCRIPTION
### PR Category
hash calculation unification for operation RingSDPAFwDeviceOperation (tt-train)

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for RingSDPAFwDeviceOperation (tt-train)

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_RingSDPAFwDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_RingSDPAFwDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_RingSDPAFwDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_RingSDPAFwDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_RingSDPAFwDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_RingSDPAFwDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_RingSDPAFwDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_RingSDPAFwDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_RingSDPAFwDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_RingSDPAFwDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_RingSDPAFwDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_RingSDPAFwDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_RingSDPAFwDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_RingSDPAFwDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_RingSDPAFwDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_RingSDPAFwDeviceOperation_tt-train)
