### PR TITLE
[Bug fix] Make golden FTZ threshold format-specific

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -77,9 +77,8 @@ _FTZ_THRESHOLD = {
 def _apply_ftz(result: torch.Tensor, data_format: DataFormat) -> torch.Tensor:
     """Flush subnormal-magnitude values in *result* to zero, matching hardware FTZ.
 
-    The flush boundary is the format's smallest normal value; anything below it
-    is a subnormal the hardware flushes. Integer formats have no subnormals, so
-    they are returned unchanged.
+    The threshold is format-specific (see _FTZ_THRESHOLD above). Integer formats
+    have no subnormals, so they are returned unchanged.
     """
     if data_format.is_integer():
         return result

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -63,13 +63,14 @@ MAX_TILES_32_BIT_DEST = 4
 golden_registry = {}
 
 
-# Hardware flushes subnormals to zero (FTZ): values below a format's smallest
-# normal get snapped to 0. Plain float formats use their smallest-normal, listed
-# below. Other formats (BFP/MX) use 1e-37.
+# Flush-to-zero (FTZ): values below a threshold get snapped to 0, matching what
+# the hardware keeps as nonzero. bf16/fp32 flush subnormals, so they flush below
+# their smallest normal; fp16 keeps subnormals, so it flushes below its smallest
+# subnormal (i.e. effectively nothing). Other formats (BFP/MX) use 1e-37.
 _FTZ_THRESHOLD = {
     DataFormat.Float32: float(torch.finfo(torch.float32).tiny),  # 2^-126 ~ 1.18e-38
     DataFormat.Float16_b: float(torch.finfo(torch.bfloat16).tiny),  # 2^-126 ~ 1.18e-38
-    DataFormat.Float16: float(torch.finfo(torch.float16).tiny),  # 2^-14 ~ 6.10e-5
+    DataFormat.Float16: 2.0**-24,  # smallest fp16 subnormal ~ 5.96e-8
 }
 
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -63,27 +63,29 @@ MAX_TILES_32_BIT_DEST = 4
 golden_registry = {}
 
 
-# Hardware always flushes subnormals to zero (FTZ).  Centralised here so that
-# every golden's __call__ funnels through the same pass — covers BFP/MX paths
-# (where near-zero values arise from BFP scale arithmetic with very small
-# shared exponents) and plain FP paths (where it's the only FTZ).
-#
-# The smallest meaningful BFP value has shared_exp=2, giving ~2.35e-38, so a
-# threshold of 1e-37 is just above the largest value the hardware flushes.
-_FTZ_THRESHOLD = 1e-37
+# Hardware flushes subnormals to zero (FTZ): values below a format's smallest
+# normal get snapped to 0. Plain float formats use their smallest-normal, listed
+# below. Other formats (BFP/MX) use 1e-37.
+_FTZ_THRESHOLD = {
+    DataFormat.Float32: float(torch.finfo(torch.float32).tiny),  # 2^-126 ~ 1.18e-38
+    DataFormat.Float16_b: float(torch.finfo(torch.bfloat16).tiny),  # 2^-126 ~ 1.18e-38
+    DataFormat.Float16: float(torch.finfo(torch.float16).tiny),  # 2^-14 ~ 6.10e-5
+}
 
 
 def _apply_ftz(result: torch.Tensor, data_format: DataFormat) -> torch.Tensor:
-    """Flush sub-FTZ values in *result* to zero, matching hardware FTZ.
+    """Flush subnormal-magnitude values in *result* to zero, matching hardware FTZ.
 
-    No-op for integer formats — they have no subnormals and the float32
-    round-trip would silently lose precision for large values.
+    The flush boundary is the format's smallest normal value; anything below it
+    is a subnormal the hardware flushes. Integer formats have no subnormals, so
+    they are returned unchanged.
     """
     if data_format.is_integer():
         return result
+    threshold = _FTZ_THRESHOLD.get(data_format, 1e-37)
     result_f32 = result.float()
     return torch.where(
-        result_f32.abs() < _FTZ_THRESHOLD,
+        result_f32.abs() < threshold,
         torch.zeros_like(result_f32),
         result_f32,
     ).to(result.dtype)


### PR DESCRIPTION
### Summary
The golden generator's flush-to-zero (FTZ) pass used a single `1e-37` threshold
for every float format. For plain float formats that value is far above their
real subnormal boundary (bf16/fp32 smallest-normal is `~1.18e-38`), so the
golden was flushing perfectly valid *normal* values to `0`.

This produced errors near zero: for example, `exp` over `x ∈ [-87, -85]`
had the golden report `0` while the hardware correctly returned small denormals,
which then showed up as huge ULP errors in the accuracy metrics tests.

Now `_apply_ftz` uses a per-format threshold: each plain float format
(Float32 / Float16_b / Float16) flushes at its own smallest-normal
(`torch.finfo(...).tiny`). BFP/MX formats have no single such boundary, so they
fall back to the existing `1e-37`.

### Notes for reviewers
- BFP/MX behavior is unchanged (they hit the `1e-37` fallback), so no BFP/matmul
  goldens should move.
- Plain FP goldens now keep normal values down to their true subnormal boundary,
  matching hardware FTZ. No kernel/hardware change.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jmacanovic/format-aware-ftz)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jmacanovic/format-aware-ftz)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jmacanovic/format-aware-ftz)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jmacanovic/format-aware-ftz)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jmacanovic/format-aware-ftz)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jmacanovic/format-aware-ftz)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jmacanovic/format-aware-ftz)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jmacanovic/format-aware-ftz)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jmacanovic/format-aware-ftz)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jmacanovic/format-aware-ftz)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jmacanovic/format-aware-ftz)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jmacanovic/format-aware-ftz)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jmacanovic/format-aware-ftz)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jmacanovic/format-aware-ftz)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jmacanovic/format-aware-ftz)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jmacanovic/format-aware-ftz)