### PR TITLE
Fix Gemma-4-26B-A4B full-model PCC regression — revert #49715 (LLK fast reduce unpack)

### DIFF
--- a/tt_metal/tt-llk/tests/sources/reduce_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/reduce_perf.cpp
@@ -24,9 +24,7 @@ using namespace ckernel;
 
 static constexpr std::uint32_t MAX_TILES_DEST = is_fp32_dest_acc_en ? 4 : 8;
 
-static constexpr bool IS_REDUCE_ROW             = (REDUCE_DIM == ckernel::ReduceDim::REDUCE_ROW);
-static constexpr bool IS_FULL_TILE_REDUCE_ROW   = IS_REDUCE_ROW && (POOL_TYPE != ckernel::PoolType::MAX);
-static constexpr std::uint32_t DVALIDS_PER_TILE = IS_FULL_TILE_REDUCE_ROW ? 1 : TILE_NUM_FACES;
+static constexpr bool IS_REDUCE_ROW = (REDUCE_DIM == ckernel::ReduceDim::REDUCE_ROW);
 
 #ifdef LLK_TRISC_UNPACK
 
@@ -65,7 +63,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
-            _perf_unpack_loop_set_valid<true, true>(TILE_CNT * DVALIDS_PER_TILE);
+            _perf_unpack_loop_set_valid<true, true>(TILE_CNT * TILE_NUM_FACES);
             return;
         }
         else
@@ -117,7 +115,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            _perf_math_loop_clear_valid<true, true>(TILE_CNT * DVALIDS_PER_TILE);
+            _perf_math_loop_clear_valid<true, true>(TILE_CNT * TILE_NUM_FACES);
             return;
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_reduce.h
@@ -155,74 +155,51 @@ inline void reduce_configure_mop(const ckernel::TensorShape& tensor_shape)
 
     if constexpr (dim == ReduceDim::REDUCE_ROW && type != PoolType::MAX)
     {
-        if (tensor_shape.total_num_faces() == 4)
-        {
-            constexpr std::uint32_t replay_buf_len = 8;
-            constexpr std::uint32_t last_clr       = high_fidelity ? p_setrwc::CLR_NONE : p_setrwc::CLR_AB;
-            constexpr std::uint32_t inner_loops    = high_fidelity ? to_underlying(math_fidelity) : 1;
-            const std::uint32_t replay_start       = ckernel::math::replay_buf_offset;
+        // MVMUL multiplies the scaler column (SrcA) by each data face (SrcB), accumulating the
+        // reduced column directly in dest. The replay buffer records all column faces so a single
+        // replay covers one row of faces; the MOP outer loop repeats it for each row.
+        constexpr std::uint32_t fid_count  = (math_fidelity == MathFidelity::LoFi) ? 1 : to_underlying(math_fidelity);
+        const std::uint32_t replay_buf_len = tensor_shape.num_faces_c_dim * 2 * fid_count;
 
-            load_replay_buf(
-                replay_start,
-                replay_buf_len,
-                []
-                {
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0);
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
-                    TTI_MVMUL(last_clr, 0, ADDR_MOD_3, 0);
-                });
+        const std::uint32_t replay_start = ckernel::math::replay_buf_offset;
 
-            ckernel_template tmp(1, inner_loops, lltt::replay_insn(replay_start, replay_buf_len));
-            if constexpr (high_fidelity)
+        load_replay_buf(
+            replay_start,
+            replay_buf_len,
+            [&tensor_shape]
             {
-                tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_ABD_F));
-            }
-            tmp.program();
-        }
-        else
-        {
-            constexpr std::uint32_t fid_count  = (math_fidelity == MathFidelity::LoFi) ? 1 : to_underlying(math_fidelity);
-            const std::uint32_t replay_buf_len = tensor_shape.num_faces_c_dim * 2 * fid_count;
-            const std::uint32_t replay_start   = ckernel::math::replay_buf_offset;
-
-            load_replay_buf(
-                replay_start,
-                replay_buf_len,
-                [&tensor_shape]
+                for (std::uint32_t faces_remaining = tensor_shape.num_faces_c_dim; faces_remaining > 0; faces_remaining--)
                 {
-                    for (std::uint32_t faces_remaining = tensor_shape.num_faces_c_dim; faces_remaining > 0; faces_remaining--)
+                    // Top half of face (dst=0): run fidelity phases, last phase advances SrcB by 8 rows
+                    for (std::uint32_t p = 0; p < fid_count - 1; p++)
                     {
-                        for (std::uint32_t p = 0; p < fid_count - 1; p++)
-                        {
-                            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
-                        }
-                        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
-
-                        for (std::uint32_t p = 0; p < fid_count - 1; p++)
-                        {
-                            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 8);
-                        }
-                        if (faces_remaining == 1)
-                        {
-                            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_3, 8);
-                        }
-                        else
-                        {
-                            TTI_MVMUL(p_setrwc::CLR_AB, 0, ADDR_MOD_2, 8);
-                        }
+                        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
                     }
-                });
+                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
 
-            const std::uint32_t replay_op = lltt::replay_insn(replay_start, replay_buf_len);
-            ckernel_template tmp(tensor_shape.num_faces_r_dim, 1, replay_op);
-            tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_B));
-            tmp.program();
-        }
+                    // Bottom half of face (dst=8): run fidelity phases, last phase resets SrcB
+                    for (std::uint32_t p = 0; p < fid_count - 1; p++)
+                    {
+                        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 8);
+                    }
+                    if (faces_remaining == 1)
+                    {
+                        // Last face in row: reset SrcB, advance dest to next row
+                        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_3, 8);
+                    }
+                    else
+                    {
+                        // More faces remain: reset SrcB, clear sources for next face
+                        TTI_MVMUL(p_setrwc::CLR_AB, 0, ADDR_MOD_2, 8);
+                    }
+                }
+            });
+
+        const std::uint32_t replay_op = lltt::replay_insn(replay_start, replay_buf_len);
+        // Outer loop = num_faces_r_dim: replay the column face reduction for each row
+        ckernel_template tmp(tensor_shape.num_faces_r_dim, 1, replay_op);
+        tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_B));
+        tmp.program();
     }
     else if constexpr (high_fidelity)
     {
@@ -287,7 +264,7 @@ inline void _llk_math_reduce_(const std::uint32_t dst_index, const ckernel::Tens
         else
         {
             ckernel_template::run();
-            TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_ABD);
+            TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_BD);
         }
     }
     else if constexpr (dim == ReduceDim::REDUCE_COL)
@@ -370,75 +347,43 @@ inline void reduce_configure_addrmod(const ckernel::TensorShape& tensor_shape)
 
     if constexpr (dim == ReduceDim::REDUCE_ROW && type != PoolType::MAX)
     {
-        if (tensor_shape.total_num_faces() == 4)
+        if constexpr (high_fidelity)
         {
             addr_mod_t {
-                .srcb = {.incr = 8},
-                .dest = {.incr = 8},
+                .fidelity = {.incr = 1},
             }
                 .set(ADDR_MOD_0);
+        }
 
-            addr_mod_t {
-                .srcb = {.incr = 24},
-                .dest = {.incr = 24},
-            }
-                .set(ADDR_MOD_1);
+        addr_mod_t {
+            .srcb     = {.incr = 8},
+            .fidelity = {.clr = 1},
+        }
+            .set(ADDR_MOD_1);
 
-            addr_mod_t {
-                .srca = {.incr = 16},
-                .srcb = {.incr = 16, .cr = 1},
-                .dest = {.cr = 1},
-            }
-                .set(ADDR_MOD_2);
+        addr_mod_t {
+            .srcb     = {.cr = 1},
+            .fidelity = {.clr = 1},
+        }
+            .set(ADDR_MOD_2);
 
+        if (tensor_shape.num_faces_c_dim == 2)
+        {
             addr_mod_t {
-                .srca     = {.clr = 1, .cr = 1},
-                .srcb     = {.clr = 1, .cr = 1},
-                .dest     = {.clr = 1, .cr = 1},
-                .fidelity = {.incr = high_fidelity ? 1u : 0u},
+                .srcb     = {.cr = 1},
+                .dest     = {.incr = 32},
+                .fidelity = {.clr = 1},
             }
                 .set(ADDR_MOD_3);
         }
         else
         {
-            if constexpr (high_fidelity)
-            {
-                addr_mod_t {
-                    .fidelity = {.incr = 1},
-                }
-                    .set(ADDR_MOD_0);
-            }
-
-            addr_mod_t {
-                .srcb     = {.incr = 8},
-                .fidelity = {.clr = 1},
-            }
-                .set(ADDR_MOD_1);
-
             addr_mod_t {
                 .srcb     = {.cr = 1},
+                .dest     = {.incr = 16},
                 .fidelity = {.clr = 1},
             }
-                .set(ADDR_MOD_2);
-
-            if (tensor_shape.num_faces_c_dim == 2)
-            {
-                addr_mod_t {
-                    .srcb     = {.cr = 1},
-                    .dest     = {.incr = 32},
-                    .fidelity = {.clr = 1},
-                }
-                    .set(ADDR_MOD_3);
-            }
-            else
-            {
-                addr_mod_t {
-                    .srcb     = {.cr = 1},
-                    .dest     = {.incr = 16},
-                    .fidelity = {.clr = 1},
-                }
-                    .set(ADDR_MOD_3);
-            }
+                .set(ADDR_MOD_3);
         }
     }
     else

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_reduce.h
@@ -25,8 +25,6 @@ using namespace ckernel::unpacker;
 /**
  * @brief Configures the unpacker MOP for reduction operations. Handles both tiny tiles (face_r_dim < 16) and standard tiles.
  *
- * @note For full 4-face SUM/AVG REDUCE_ROW, a single UNPACR path unpacks all faces in a single instruction.
- *
  * @tparam pool_type: Type of pooling operation, values = <SUM/AVG/MAX>
  * @tparam reduce_dim: Dimension along which to reduce, values = <REDUCE_ROW/REDUCE_COL/REDUCE_SCALAR>
  * @param tensor_shape: Shape of the tensor, including face_r_dim and num_faces.
@@ -40,45 +38,55 @@ inline void _llk_unpack_AB_reduce_mop_config_(const ckernel::TensorShape &tensor
     // Validate tensor shape for tile-dependent operations
     LLK_VALIDATE_TENSOR_SHAPE_UNPACK("_llk_unpack_AB_reduce_mop_config_", tensor_shape);
 
-    constexpr bool is_max                  = pool_type == PoolType::MAX;
-    constexpr bool swap_operands           = (reduce_dim == ReduceDim::REDUCE_ROW) && !is_max;
-    constexpr bool is_scalar               = reduce_dim == ReduceDim::REDUCE_SCALAR;
-    constexpr std::uint32_t REPLAY_BUF_LEN = 2;
-    constexpr std::uint32_t clear_src      = swap_operands ? Srcs::SrcB : Srcs::SrcA;
+    // Data valid for clear instructions is set to 0 since the MATH kernel should not process this data.
+    // pool_type == PoolType::MAX sets the clear value to neginf if the pool-type is MAX and 0 if the pool-type is AVG/SUM
+    static constexpr std::uint32_t clear_pool_dep_srca =
+        TT_OP_UNPACR_NOP(Srcs::SrcA, 0, 0, 0 /* dvalid */, 0, 0 /* Stall_Clr_Cntrl */, 0, pool_type == PoolType::MAX /* 0 or neginf */, p_unpacr_nop::CLR_SRC);
+    static constexpr std::uint32_t clear_pool_dep_srcb =
+        TT_OP_UNPACR_NOP(Srcs::SrcB, 0, 0, 0 /* dvalid */, 0, 0 /* Stall_Clr_Cntrl */, 0, pool_type == PoolType::MAX /* 0 or neginf */, p_unpacr_nop::CLR_SRC);
+    static constexpr std::uint32_t clear_zero_srca =
+        TT_OP_UNPACR_NOP(Srcs::SrcA, 0, 0, 0 /* dvalid */, 0, 0 /* Stall_Clr_Cntrl */, 0, p_unpacr_nop::CLR_SRC_0, p_unpacr_nop::CLR_SRC);
 
-    const bool full_tile          = swap_operands && (tensor_shape.total_num_faces() == 4);
-    const bool is_tiny            = tensor_shape.face_r_dim < FACE_R_DIM;
-    const std::uint32_t innerloop = full_tile ? 1 : tensor_shape.total_num_faces();
-    const std::uint32_t clear_val = is_max ? p_unpacr_nop::CLR_SRC_NEGINF : p_unpacr_nop::CLR_SRC_0;
+    constexpr std::uint32_t REPLAY_BUF_LEN = 2;
 
     load_replay_buf(
         0,
         REPLAY_BUF_LEN,
-        [full_tile]
+        []
         {
-            if (full_tile)
-            {
-                TTI_UNPACR(Srcs::SrcA, 0, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-                TTI_UNPACR(Srcs::SrcB, 0, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-            }
-            else
-            {
-                TTI_UNPACR(Srcs::SrcA, 0b01, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-                TTI_UNPACR(Srcs::SrcB, 0b01, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-            }
+            // Configure unpacker instruction for Src{A,B}. These instructions always increment L1 by 1 face.
+            TTI_UNPACR(Srcs::SrcA, 0b01, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1); // Unpack SrcA
+            TTI_UNPACR(Srcs::SrcB, 0b01, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1); // Unpack SrcB
         });
 
-    const std::uint32_t replay = lltt::replay_insn(0, REPLAY_BUF_LEN);
+    // MOP constants
+    constexpr std::uint32_t outerloop = 1;
+    const std::uint32_t innerloop     = tensor_shape.total_num_faces();
 
-    if (is_tiny || is_scalar)
+    constexpr bool swap_operands = (reduce_dim == ReduceDim::REDUCE_ROW) && (pool_type != PoolType::MAX);
+
+    // Padding should only be done when using tiny tiles otherwise the entire face overwrites the data read in Math
+    if (tensor_shape.face_r_dim < FACE_R_DIM) // Using tiny faces
     {
-        ckernel_template tmp(1, innerloop, TT_OP_UNPACR_NOP(clear_src, 0, 0, 0, 0, 0, 0, clear_val, p_unpacr_nop::CLR_SRC), replay);
+        // Swapped REDUCE_ROW: data is in SrcB, pad SrcB; otherwise data is in SrcA, pad SrcA
+        static constexpr std::uint32_t clear_pool_dep = swap_operands ? clear_pool_dep_srcb : clear_pool_dep_srca;
+        ckernel_template tmp(outerloop, innerloop, clear_pool_dep, lltt::replay_insn(0, REPLAY_BUF_LEN));
         tmp.program();
     }
-    else
+    else // Using standard faces (face_r_dim = FACE_R_DIM)
     {
-        ckernel_template tmp(1, innerloop, replay);
-        tmp.program();
+        if constexpr (reduce_dim == ReduceDim::REDUCE_SCALAR)
+        {
+            // For scalar reduction, clear SrcA to zero before unpacking. SrcA is clobbered in Math kernel.
+            ckernel_template tmp(outerloop, innerloop, clear_zero_srca, lltt::replay_insn(0, REPLAY_BUF_LEN));
+            tmp.program();
+        }
+        else
+        {
+            // For row/column reduction, no clearing needed
+            ckernel_template tmp(outerloop, innerloop, lltt::replay_insn(0, REPLAY_BUF_LEN));
+            tmp.program();
+        }
     }
 }
 
@@ -108,24 +116,16 @@ inline void _llk_unpack_AB_reduce_init_(const ckernel::TensorShape &tensor_shape
     // Validate tensor shape for tile-dependent operations
     LLK_VALIDATE_TENSOR_SHAPE_UNPACK("_llk_unpack_AB_reduce_init_", tensor_shape);
 
-    constexpr bool is_max        = pool_type == PoolType::MAX;
-    constexpr bool swap_operands = (reduce_dim == ReduceDim::REDUCE_ROW) && !is_max;
-
+    // SUM/AVG REDUCE_ROW swaps operands (scaler→SrcA, data→SrcB), no transpose needed.
+    // MAX REDUCE_ROW keeps original layout (data→SrcA transposed, scaler→SrcB) — GMPOOL only reads SrcA.
+    constexpr bool swap_operands = (reduce_dim == ReduceDim::REDUCE_ROW) && (pool_type != PoolType::MAX);
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>((reduce_dim == ReduceDim::REDUCE_ROW));
 
-    const bool full_tile = swap_operands && (tensor_shape.total_num_faces() == 4);
+    config_unpacker_x_end<p_setadc::UNP_A>(tensor_shape.face_r_dim);
 
-    if (full_tile)
-    {
-        const std::uint32_t x_end = tensor_shape.total_num_faces() * FACE_R_DIM * FACE_C_DIM - 1;
-        TT_SETADCXX(p_setadc::UNP_A, x_end, 0x0);
-        TT_SETADCXX(p_setadc::UNP_B, x_end, 0x0);
-    }
-    else
-    {
-        config_unpacker_x_end<p_setadc::UNP_A>(tensor_shape.face_r_dim);
-        config_unpacker_x_end<p_setadc::UNP_B>(swap_operands ? tensor_shape.face_r_dim : 1);
-    }
+    // UNP_B reads data faces (face_r_dim rows) in swapped mode, or a single
+    // scaler row in the non-swapped (MAX / COL / SCALAR) mode.
+    config_unpacker_x_end<p_setadc::UNP_B>(swap_operands ? tensor_shape.face_r_dim : 1);
 
     // Configure unpack MOP
     _llk_unpack_AB_reduce_mop_config_<pool_type, reduce_dim>(tensor_shape);
@@ -163,14 +163,17 @@ inline void _llk_unpack_AB_reduce_(const std::uint32_t address_a, const std::uin
     // Wait for free context
     wait_for_next_context(2);
 
-    constexpr bool is_max        = pool_type == PoolType::MAX;
-    constexpr bool swap_operands = (reduce_dim == ReduceDim::REDUCE_ROW) && !is_max;
-
-    // SUM/AVG REDUCE_ROW swaps operands (scaler→SrcA, data→SrcB), no transpose needed.
-    // MAX REDUCE_ROW keeps original layout (data→SrcA transposed, scaler→SrcB) — GMPOOL only reads SrcA.
-    const std::uint32_t addr_unp_a = swap_operands ? address_b : address_a;
-    const std::uint32_t addr_unp_b = swap_operands ? address_a : address_b;
-    _llk_unpack_configure_addresses_(addr_unp_a, addr_unp_b, cfg);
+    // SUM/AVG REDUCE_ROW: swap operands so scaler→SrcA, data→SrcB
+    // MAX REDUCE_ROW: keep original order (data→SrcA, scaler→SrcB)
+    constexpr bool swap_operands = (reduce_dim == ReduceDim::REDUCE_ROW) && (pool_type != PoolType::MAX);
+    if constexpr (swap_operands)
+    {
+        _llk_unpack_configure_addresses_(address_b, address_a, cfg);
+    }
+    else
+    {
+        _llk_unpack_configure_addresses_(address_a, address_b, cfg);
+    }
 
     // Trisc::SEMPOST for context acquire
     semaphore_post(semaphore::UNPACK_SYNC);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
@@ -156,64 +156,38 @@ inline void reduce_configure_mop(const ckernel::TensorShape& tensor_shape)
 
     if constexpr (dim == ReduceDim::REDUCE_ROW && type != PoolType::MAX)
     {
-        if (tensor_shape.total_num_faces() == 4)
+        constexpr std::uint32_t fid_count  = (math_fidelity == MathFidelity::LoFi) ? 1 : to_underlying(math_fidelity);
+        const std::uint32_t replay_buf_len = tensor_shape.num_faces_c_dim * 2 * fid_count;
+
+        const std::uint32_t replay_start = ckernel::math::replay_buf_offset;
+
+        lltt::record<lltt::NoExec>(replay_start, replay_buf_len);
+        for (std::uint32_t faces_remaining = tensor_shape.num_faces_c_dim; faces_remaining > 0; faces_remaining--)
         {
-            constexpr std::uint32_t replay_buf_len = 8;
-            constexpr std::uint32_t last_clr       = high_fidelity ? p_setrwc::CLR_NONE : p_setrwc::CLR_AB;
-            constexpr std::uint32_t inner_loops    = high_fidelity ? to_underlying(math_fidelity) : 1;
-            const std::uint32_t replay_start       = ckernel::math::replay_buf_offset;
-
-            lltt::record(replay_start, replay_buf_len);
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_2, 0);
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
-            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
-            TTI_MVMUL(last_clr, 0, ADDR_MOD_3, 0);
-
-            ckernel_template tmp(1, inner_loops, lltt::replay_insn(replay_start, replay_buf_len));
-            if constexpr (high_fidelity)
+            for (std::uint32_t p = 0; p < fid_count - 1; p++)
             {
-                tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_ABD_F));
+                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
             }
-            tmp.program();
-        }
-        else
-        {
-            constexpr std::uint32_t fid_count  = (math_fidelity == MathFidelity::LoFi) ? 1 : to_underlying(math_fidelity);
-            const std::uint32_t replay_buf_len = tensor_shape.num_faces_c_dim * 2 * fid_count;
-            const std::uint32_t replay_start   = ckernel::math::replay_buf_offset;
+            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
 
-            lltt::record<lltt::NoExec>(replay_start, replay_buf_len);
-            for (std::uint32_t faces_remaining = tensor_shape.num_faces_c_dim; faces_remaining > 0; faces_remaining--)
+            for (std::uint32_t p = 0; p < fid_count - 1; p++)
             {
-                for (std::uint32_t p = 0; p < fid_count - 1; p++)
-                {
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0);
-                }
-                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
-
-                for (std::uint32_t p = 0; p < fid_count - 1; p++)
-                {
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 8);
-                }
-                if (faces_remaining == 1)
-                {
-                    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_3, 8);
-                }
-                else
-                {
-                    TTI_MVMUL(p_setrwc::CLR_AB, 0, ADDR_MOD_2, 8);
-                }
+                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 8);
             }
-
-            const std::uint32_t replay_op = lltt::replay_insn(replay_start, replay_buf_len);
-            ckernel_template tmp(tensor_shape.num_faces_r_dim, 1, replay_op);
-            tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_B));
-            tmp.program();
+            if (faces_remaining == 1)
+            {
+                TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_3, 8);
+            }
+            else
+            {
+                TTI_MVMUL(p_setrwc::CLR_AB, 0, ADDR_MOD_2, 8);
+            }
         }
+
+        const std::uint32_t replay_op = lltt::replay_insn(replay_start, replay_buf_len);
+        ckernel_template tmp(tensor_shape.num_faces_r_dim, 1, replay_op);
+        tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, p_setrwc::SET_B));
+        tmp.program();
     }
     else if constexpr (high_fidelity)
     {
@@ -278,7 +252,7 @@ inline void _llk_math_reduce_(const std::uint32_t dst_index, const ckernel::Tens
         else
         {
             ckernel_template::run();
-            TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_ABD);
+            TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_BD);
         }
     }
     else if constexpr (dim == ReduceDim::REDUCE_COL)
@@ -361,75 +335,43 @@ inline void reduce_configure_addrmod(const ckernel::TensorShape& tensor_shape)
 
     if constexpr (dim == ReduceDim::REDUCE_ROW && type != PoolType::MAX)
     {
-        if (tensor_shape.total_num_faces() == 4)
+        if constexpr (high_fidelity)
         {
             addr_mod_t {
-                .srcb = {.incr = 8},
-                .dest = {.incr = 8},
+                .fidelity = {.incr = 1},
             }
                 .set(ADDR_MOD_0);
+        }
 
-            addr_mod_t {
-                .srcb = {.incr = 24},
-                .dest = {.incr = 24},
-            }
-                .set(ADDR_MOD_1);
+        addr_mod_t {
+            .srcb     = {.incr = 8},
+            .fidelity = {.clr = 1},
+        }
+            .set(ADDR_MOD_1);
 
-            addr_mod_t {
-                .srca = {.incr = 16},
-                .srcb = {.incr = 16, .cr = 1},
-                .dest = {.cr = 1},
-            }
-                .set(ADDR_MOD_2);
+        addr_mod_t {
+            .srcb     = {.cr = 1},
+            .fidelity = {.clr = 1},
+        }
+            .set(ADDR_MOD_2);
 
+        if (tensor_shape.num_faces_c_dim == 2)
+        {
             addr_mod_t {
-                .srca     = {.clr = 1, .cr = 1},
-                .srcb     = {.clr = 1, .cr = 1},
-                .dest     = {.clr = 1, .cr = 1},
-                .fidelity = {.incr = high_fidelity ? 1u : 0u},
+                .srcb     = {.cr = 1},
+                .dest     = {.incr = 32},
+                .fidelity = {.clr = 1},
             }
                 .set(ADDR_MOD_3);
         }
         else
         {
-            if constexpr (high_fidelity)
-            {
-                addr_mod_t {
-                    .fidelity = {.incr = 1},
-                }
-                    .set(ADDR_MOD_0);
-            }
-
-            addr_mod_t {
-                .srcb     = {.incr = 8},
-                .fidelity = {.clr = 1},
-            }
-                .set(ADDR_MOD_1);
-
             addr_mod_t {
                 .srcb     = {.cr = 1},
+                .dest     = {.incr = 16},
                 .fidelity = {.clr = 1},
             }
-                .set(ADDR_MOD_2);
-
-            if (tensor_shape.num_faces_c_dim == 2)
-            {
-                addr_mod_t {
-                    .srcb     = {.cr = 1},
-                    .dest     = {.incr = 32},
-                    .fidelity = {.clr = 1},
-                }
-                    .set(ADDR_MOD_3);
-            }
-            else
-            {
-                addr_mod_t {
-                    .srcb     = {.cr = 1},
-                    .dest     = {.incr = 16},
-                    .fidelity = {.clr = 1},
-                }
-                    .set(ADDR_MOD_3);
-            }
+                .set(ADDR_MOD_3);
         }
     }
     else

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB_reduce.h
@@ -33,8 +33,6 @@ using namespace ckernel::unpacker;
 /**
  * @brief Configures the unpacker MOP for reduction operations. Handles both tiny tiles (face_r_dim < 16) and standard tiles.
  *
- * @note For full 4-face SUM/AVG REDUCE_ROW, a single UNPACR path unpacks all faces in a single instruction.
- *
  * @tparam pool_type: Type of pooling operation, values = <SUM/AVG/MAX>
  * @tparam reduce_dim: Dimension along which to reduce, values = <REDUCE_ROW/REDUCE_COL/REDUCE_SCALAR>
  * @param tensor_shape: Shape of the tensor, including face_r_dim and num_faces.
@@ -48,40 +46,56 @@ inline void _llk_unpack_AB_reduce_mop_config_(const ckernel::TensorShape &tensor
     // Validate tensor shape for tile-dependent operations
     LLK_VALIDATE_TENSOR_SHAPE_UNPACK("_llk_unpack_AB_reduce_mop_config_", tensor_shape);
 
-    constexpr bool is_max                  = pool_type == PoolType::MAX;
-    constexpr bool swap_operands           = (reduce_dim == ReduceDim::REDUCE_ROW) && !is_max;
-    constexpr bool is_scalar               = reduce_dim == ReduceDim::REDUCE_SCALAR;
+    // Data valid for clear instructions is set to 0 since the MATH kernel should not process this data.
+    // pool_type == PoolType::MAX sets the clear value to neginf if the pool-type is MAX and 0 if the pool-type is AVG/SUM
+    static constexpr std::uint32_t clear_pool_dep_srca =
+        TT_OP_UNPACR_NOP(p_unpacr_nop::UNP0, (pool_type == PoolType::MAX) ? p_unpacr_nop::UNP_NEGINFSRC : p_unpacr_nop::UNP_ZEROSRC);
+    static constexpr std::uint32_t clear_pool_dep_srcb =
+        TT_OP_UNPACR_NOP(p_unpacr_nop::UNP1, (pool_type == PoolType::MAX) ? p_unpacr_nop::UNP_NEGINFSRC : p_unpacr_nop::UNP_ZEROSRC);
+    static constexpr std::uint32_t clear_zero_srca = TT_OP_UNPACR_NOP(p_unpacr_nop::UNP0, p_unpacr_nop::UNP_ZEROSRC);
+
     constexpr std::uint32_t REPLAY_BUF_LEN = 2;
-    constexpr std::uint32_t clear_src      = swap_operands ? p_unpacr_nop::UNP1 : p_unpacr_nop::UNP0;
 
-    const bool full_tile          = swap_operands && (tensor_shape.total_num_faces() == 4);
-    const bool is_tiny            = tensor_shape.face_r_dim < FACE_R_DIM;
-    const std::uint32_t innerloop = full_tile ? 1 : tensor_shape.total_num_faces();
-    const std::uint32_t clear_val = is_max ? p_unpacr_nop::UNP_NEGINFSRC : p_unpacr_nop::UNP_ZEROSRC;
-
+    // Configure unpacker instruction for Src{A,B}. These instructions always increment L1 by 1 face.
     lltt::record<lltt::NoExec>(0, REPLAY_BUF_LEN);
-    if (full_tile)
-    {
-        TTI_UNPACR(Srcs::SrcA, 0, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-        TTI_UNPACR(Srcs::SrcB, 0, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-    }
-    else
-    {
-        TTI_UNPACR(Srcs::SrcA, 0b01, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-        TTI_UNPACR(Srcs::SrcB, 0b01, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-    }
+    TTI_UNPACR(Srcs::SrcA, 0b01, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1); // Unpack SrcA
+    TTI_UNPACR(Srcs::SrcB, 0b01, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1); // Unpack SrcB
 
-    const std::uint32_t replay = lltt::replay_insn(0, REPLAY_BUF_LEN);
+    // MOP constants
+    constexpr std::uint32_t outerloop = 1;
+    const std::uint32_t innerloop     = tensor_shape.total_num_faces();
 
-    if (is_tiny || is_scalar)
+    constexpr bool swap_operands = (reduce_dim == ReduceDim::REDUCE_ROW) && (pool_type != PoolType::MAX);
+
+    // Padding should only be done when using tiny tiles otherwise the entire face overwrites the data read in Math
+    if (tensor_shape.face_r_dim < FACE_R_DIM) // Using tiny faces
     {
-        ckernel_template tmp(1, innerloop, TT_OP_UNPACR_NOP(clear_src, clear_val), replay);
-        tmp.program();
+        // Swapped REDUCE_ROW: data is in SrcB, pad SrcB; otherwise data is in SrcA, pad SrcA
+        if constexpr (swap_operands)
+        {
+            ckernel_template tmp(outerloop, innerloop, clear_pool_dep_srcb, lltt::replay_insn(0, REPLAY_BUF_LEN));
+            tmp.program();
+        }
+        else
+        {
+            ckernel_template tmp(outerloop, innerloop, clear_pool_dep_srca, lltt::replay_insn(0, REPLAY_BUF_LEN));
+            tmp.program();
+        }
     }
-    else
+    else // Using standard faces (face_r_dim = FACE_R_DIM)
     {
-        ckernel_template tmp(1, innerloop, replay);
-        tmp.program();
+        if constexpr (reduce_dim == ReduceDim::REDUCE_SCALAR)
+        {
+            // For scalar reduction, clear SrcA to zero before unpacking. SrcA is clobbered in Math kernel.
+            ckernel_template tmp(outerloop, innerloop, clear_zero_srca, lltt::replay_insn(0, REPLAY_BUF_LEN));
+            tmp.program();
+        }
+        else
+        {
+            // For row/column reduction, no clearing needed
+            ckernel_template tmp(outerloop, innerloop, lltt::replay_insn(0, REPLAY_BUF_LEN));
+            tmp.program();
+        }
     }
 }
 
@@ -111,23 +125,22 @@ inline void _llk_unpack_AB_reduce_init_(const ckernel::TensorShape &tensor_shape
     // Validate tensor shape for tile-dependent operations
     LLK_VALIDATE_TENSOR_SHAPE_UNPACK("_llk_unpack_AB_reduce_init_", tensor_shape);
 
-    constexpr bool is_max        = pool_type == PoolType::MAX;
-    constexpr bool swap_operands = (reduce_dim == ReduceDim::REDUCE_ROW) && !is_max;
-
+    // SUM/AVG REDUCE_ROW swaps operands (scaler→SrcA, data→SrcB), no transpose needed.
+    // MAX REDUCE_ROW keeps original layout (data→SrcA transposed, scaler→SrcB) — GMPOOL only reads SrcA.
+    constexpr bool swap_operands = (reduce_dim == ReduceDim::REDUCE_ROW) && (pool_type != PoolType::MAX);
     cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>((reduce_dim == ReduceDim::REDUCE_ROW));
 
-    const bool full_tile = swap_operands && (tensor_shape.total_num_faces() == 4);
+    config_unpacker_x_end<p_setadc::UNP_A>(tensor_shape.face_r_dim);
 
-    if (full_tile)
+    // UNP_B reads data faces (face_r_dim rows) in swapped mode, or a single
+    // scaler row in the non-swapped (MAX / COL / SCALAR) mode.
+    if constexpr (swap_operands)
     {
-        const std::uint32_t x_end = tensor_shape.total_num_faces() * FACE_R_DIM * FACE_C_DIM - 1;
-        TT_SETADCXX(p_setadc::UNP_A, x_end, 0x0);
-        TT_SETADCXX(p_setadc::UNP_B, x_end, 0x0);
+        config_unpacker_x_end<p_setadc::UNP_B>(tensor_shape.face_r_dim);
     }
     else
     {
-        config_unpacker_x_end<p_setadc::UNP_A>(tensor_shape.face_r_dim);
-        config_unpacker_x_end<p_setadc::UNP_B>(swap_operands ? tensor_shape.face_r_dim : 1);
+        config_unpacker_x_end<p_setadc::UNP_B>(1);
     }
 
     // Configure unpack MOP
@@ -166,14 +179,17 @@ inline void _llk_unpack_AB_reduce_(const std::uint32_t address_a, const std::uin
     // Wait for free context
     wait_for_next_context(2);
 
-    constexpr bool is_max        = pool_type == PoolType::MAX;
-    constexpr bool swap_operands = (reduce_dim == ReduceDim::REDUCE_ROW) && !is_max;
-
-    // SUM/AVG REDUCE_ROW swaps operands (scaler→SrcA, data→SrcB), no transpose needed.
-    // MAX REDUCE_ROW keeps original layout (data→SrcA transposed, scaler→SrcB) — GMPOOL only reads SrcA.
-    const std::uint32_t addr_unp_a = swap_operands ? address_b : address_a;
-    const std::uint32_t addr_unp_b = swap_operands ? address_a : address_b;
-    _llk_unpack_configure_addresses_(addr_unp_a, addr_unp_b, cfg);
+    // SUM/AVG REDUCE_ROW: swap operands so scaler→SrcA, data→SrcB
+    // MAX REDUCE_ROW: keep original order (data→SrcA, scaler→SrcB)
+    constexpr bool swap_operands = (reduce_dim == ReduceDim::REDUCE_ROW) && (pool_type != PoolType::MAX);
+    if constexpr (swap_operands)
+    {
+        _llk_unpack_configure_addresses_(address_b, address_a, cfg);
+    }
+    else
+    {
+        _llk_unpack_configure_addresses_(address_a, address_b, cfg);
+    }
 
     // Trisc::SEMPOST for context acquire
     semaphore_post(semaphore::UNPACK_SYNC);


### PR DESCRIPTION
## Bad commit

🔴 **#49715 — "[LLK] fast reduce unpack for 32x32 tiles"** (`fe7519882b53d7d42342f71da42e9850a1c6e2e4`, @markoradosavljevic, 2026-07-15)

Identified via CI bisect on the (Tier 2) Models E2E scheduled pipeline (window `52c1d0e554..5f990184fc`): p35 GOOD (PCC 0.9383 @ `ed4331a`) → p36 BAD (PCC 0.7696 @ `fe75198`); #49715 is the lone commit between them.

## Regression

**Gemma-4-26B-A4B** `[wh_llmbox_perf]` `test_full_model`: full-model PCC dropped from a bit-stable **0.9383** (7 consecutive scheduled runs) to **0.7696** (threshold 0.8), first failing 2026-07-16. Prefill/decode sub-checks (0.99) still pass → break is in the full-model logits path.

## Cause

#49715's 4-face `REDUCE_ROW` SUM/AVG fast path never seeds the SrcB CR-base to row 16, so its `cr` reload re-reads faces F0/F2 and the right-column faces F1/F3 are never reduced. Full root-cause analysis + a failed surgical-fix attempt: **#50224**.

## This PR

Clean **revert of #49715** — restores the correct general reduce path (known-good bit-stable 0.9383). No LLK signature changes → metal callers unaffected. The perf optimization should be re-landed with corrected fast-path microcode (**#50224**, owner @handrewsTT / @markoradosavljevic).

**CI validation:** run [29582263968](https://github.com/tenstorrent/tt-metal/actions/runs/29582263968) → full-model PCC back to **0.9383** ✅

Closes #50255
Root cause / proper fast-path fix tracked in #50224