### PR TITLE
GDN decode: fuse exp into the decay multiply

### DIFF
--- a/models/demos/blackhole/qwen36/tests/test_gdn_tp.py
+++ b/models/demos/blackhole/qwen36/tests/test_gdn_tp.py
@@ -19,6 +19,7 @@ Run:
 """
 import os
 
+import pytest
 import torch
 import torch.nn.functional as F
 from loguru import logger
@@ -38,6 +39,9 @@ from models.demos.blackhole.qwen36.tests.test_factory import (
 )
 from models.demos.blackhole.qwen36.tt.gdn.tp import TPGatedDeltaNet, load_gdn_weights_tp
 from models.demos.blackhole.qwen36.tt.model_config import Qwen36ModelArgs
+from models.experimental.gated_attention_gated_deltanet.tt.ttnn_delta_rule_ops import (
+    recurrent_gated_delta_rule_decode_ttnn,
+)
 
 
 @torch.no_grad()
@@ -108,6 +112,77 @@ def test_gdn_tp(mesh_device, B, reset_seeds, ensure_gc, request):
     out2_t = ttnn.to_torch(out2, mesh_composer=tp_composer(mesh_device))
     assert not torch.isnan(out2_t).any() and out2_t.abs().max() > 0
     logger.info("PASSED: GDN TP decode (pos0 PCC + pos1 shape/NaN)")
+
+
+@torch.no_grad()
+@parametrize_mesh_tp()
+@pytest.mark.parametrize("high_precision", [pytest.param(True, id="fp32"), pytest.param(False, id="bf16")])
+def test_gdn_tp_decode_recurrence_state(mesh_device, high_precision, reset_seeds, ensure_gc, request):
+    """Multi-step T=1 decode: output AND recurrent state vs a torch reference each step.
+
+    ``test_gdn_tp`` validates pos0 only, where the recurrent state is zero and the
+    state-decay multiply (h * exp(g), fused as an EXP pre-activation on the multiply)
+    is invisible. This test drives ``recurrent_gated_delta_rule_decode_ttnn`` — the
+    exact T=1 function ``forward_decode`` dispatches to — for several steps from a
+    NONZERO initial state, checking both the step output and the carried state, so a
+    broken decay (or an ignored fused activation) collapses the PCC immediately.
+    fp32 mirrors the TP default (``high_precision=True``); bf16 covers the
+    ``QWEN35_GDN_DECODE_BF16=1`` fallback.
+    """
+    B, H, K, V = 2, 8, 128, 128
+    steps = 4
+    # One threshold per node via pcc_thresholds.json; fp32/bf16 defaults differ (bf16
+    # accumulates state quantization error over the 4 steps).
+    thr = get_pcc_threshold(request, default=0.9999 if high_precision else 0.99)
+
+    # Pre-quantize inputs to bf16 so device and reference consume identical values —
+    # the remaining error is device math, not input rounding.
+    def _bf16(t):
+        return t.to(torch.bfloat16).float()
+
+    q = _bf16(torch.randn(steps, B, H, K))
+    k = _bf16(torch.randn(steps, B, H, K))
+    v = _bf16(torch.randn(steps, B, H, V))
+    beta = _bf16(torch.sigmoid(torch.randn(steps, B, H)))
+    g = _bf16(-F.softplus(torch.randn(steps, B, H)))  # log-decay <= 0, exp(g) in (0,1]
+    h0 = _bf16(torch.randn(B, H, K, V))  # nonzero: decay must actually act on it
+
+    state_dtype = ttnn.float32 if high_precision else ttnn.bfloat16
+    h_tt = replicate_to_device(mesh_device, h0, dtype=state_dtype)
+    h_ref = h0.clone()
+
+    def _first_shard(t):
+        return ttnn.to_torch(ttnn.get_device_tensors(t)[0]).float()
+
+    for s in range(steps):
+        o_tt, h_tt = recurrent_gated_delta_rule_decode_ttnn(
+            replicate_to_device(mesh_device, q[s].reshape(B, 1, H, K)),
+            replicate_to_device(mesh_device, k[s].reshape(B, 1, H, K)),
+            replicate_to_device(mesh_device, v[s].reshape(B, 1, H, V)),
+            replicate_to_device(mesh_device, beta[s].reshape(B, 1, H)),
+            replicate_to_device(mesh_device, g[s].reshape(B, 1, H)),
+            initial_state=h_tt,
+            device=mesh_device,
+            high_precision=high_precision,
+        )
+
+        # ---- torch reference: mirrors the ttnn function step-for-step ----
+        qh = F.normalize(q[s], dim=-1) * (K**-0.5)  # [B,H,K]
+        kh = F.normalize(k[s], dim=-1)
+        h_ref = h_ref * torch.exp(g[s])[..., None, None]  # decay BEFORE read
+        v_read = kh.unsqueeze(-2) @ h_ref  # [B,H,1,V]
+        delta = v[s].unsqueeze(-2) - v_read
+        h_ref = h_ref + beta[s][..., None, None] * (kh.unsqueeze(-1) @ delta)
+        o_ref = (qh.unsqueeze(-2) @ h_ref).reshape(B, H, V)
+
+        o_t = _first_shard(o_tt).reshape(B, H, V)
+        pcc_o = compute_pcc(o_ref, o_t)
+        pcc_h = compute_pcc(h_ref, _first_shard(h_tt))
+        logger.info(f"step {s}: out PCC={pcc_o:.6f} state PCC={pcc_h:.6f}")
+        assert pcc_o >= thr, f"step {s} output PCC {pcc_o:.6f} < {thr}"
+        assert pcc_h >= thr, f"step {s} state PCC {pcc_h:.6f} < {thr}"
+
+    logger.info(f"PASSED: GDN TP decode recurrence ({steps} steps, {'fp32' if high_precision else 'bf16'})")
 
 
 @torch.no_grad()

--- a/models/experimental/gated_attention_gated_deltanet/tt/ttnn_delta_rule_ops.py
+++ b/models/experimental/gated_attention_gated_deltanet/tt/ttnn_delta_rule_ops.py
@@ -540,9 +540,7 @@ def recurrent_gated_delta_rule_decode_ttnn(
     beta_t = ttnn.reshape(beta, [B, H], memory_config=ttnn.L1_MEMORY_CONFIG)
     g_t = ttnn.reshape(g, [B, H], memory_config=ttnn.L1_MEMORY_CONFIG)
 
-    # Compute decay
-    decay_t = ttnn.exp(g_t, memory_config=ttnn.L1_MEMORY_CONFIG)
-
+    # Decay is exp(g); fused into the decay multiply below (no standalone ttnn.exp).
     # Ensure state is ready
     h = initial_state
     if h is None:
@@ -575,8 +573,10 @@ def recurrent_gated_delta_rule_decode_ttnn(
     # Canonical gated-delta-rule order: DECAY the state BEFORE reading from it. The FLA
     # reference and the chunked prefill path both decay-then-read; reading the un-decayed
     # state makes the delta correction (v - k·h) use the wrong state.
-    decay_bhkv = ttnn.reshape(decay_t, [B, H, 1, 1], memory_config=ttnn.L1_MEMORY_CONFIG)
-    h = ttnn.multiply(h, decay_bhkv)
+    # decay = exp(g), fused as a pre-activation on the multiply's second operand — one fewer op
+    # than a standalone ttnn.exp + multiply.
+    g_bhkv = ttnn.reshape(g_t, [B, H, 1, 1], memory_config=ttnn.L1_MEMORY_CONFIG)
+    h = ttnn.multiply(h, g_bhkv, input_tensor_b_activations=[ttnn.UnaryOpType.EXP])
 
     # Read from the DECAYED state: v_read = k @ h  (k_row already [B,H,1,K] TILE_LAYOUT)
     v_read = ttnn.matmul(
@@ -587,8 +587,10 @@ def recurrent_gated_delta_rule_decode_ttnn(
     # Delta and state update — write the outer product WITHOUT re-decaying (h already decayed).
     delta = ttnn.subtract(v_t, v_read, memory_config=None)
     k_t = ttnn.reshape(k_row, [B, H, K], memory_config=None)
+    # decay_t is unused downstream (apply_decay=False -> h already decayed above); pass g_bhkv to
+    # satisfy the signature without recomputing a decay tensor.
     h = fused_decay_and_write_ttnn(
-        h=h, k_t=k_t, delta=delta, decay_t=decay_t, beta_t=beta_t, device=device, apply_decay=False
+        h=h, k_t=k_t, delta=delta, decay_t=g_bhkv, beta_t=beta_t, device=device, apply_decay=False
     )
 
     # Query state: o = q @ h  (q_row already [B,H,1,K] TILE_LAYOUT)

--- a/models/experimental/gated_attention_gated_deltanet/tt/ttnn_delta_rule_ops.py
+++ b/models/experimental/gated_attention_gated_deltanet/tt/ttnn_delta_rule_ops.py
@@ -421,9 +421,7 @@ def recurrent_gated_delta_rule_decode_ttnn(
     beta_t = ttnn.reshape(beta, [B, H], memory_config=ttnn.L1_MEMORY_CONFIG)
     g_t = ttnn.reshape(g, [B, H], memory_config=ttnn.L1_MEMORY_CONFIG)
 
-    # Compute decay
-    decay_t = ttnn.exp(g_t, memory_config=ttnn.L1_MEMORY_CONFIG)
-
+    # Decay is exp(g); fused into the decay multiply below (no standalone ttnn.exp).
     # Ensure state is ready
     h = initial_state
     if h is None:
@@ -451,9 +449,11 @@ def recurrent_gated_delta_rule_decode_ttnn(
             pass
 
     # Decay before read; keep recurrence step L1-resident.
+    # decay = exp(g), fused as a pre-activation on the multiply's second operand — one fewer op
+    # than a standalone ttnn.exp + multiply.
     _L1 = ttnn.L1_MEMORY_CONFIG
-    decay_bhkv = ttnn.reshape(decay_t, [B, H, 1, 1], memory_config=_L1)
-    h = ttnn.multiply(h, decay_bhkv, memory_config=_L1)
+    g_bhkv = ttnn.reshape(g_t, [B, H, 1, 1], memory_config=_L1)
+    h = ttnn.multiply(h, g_bhkv, input_tensor_b_activations=[ttnn.UnaryOpType.EXP], memory_config=_L1)
 
     # v_read = k @ h (decayed state)
     v_read = ttnn.matmul(
@@ -464,8 +464,10 @@ def recurrent_gated_delta_rule_decode_ttnn(
     # Delta + state write (no re-decay).
     delta = ttnn.subtract(v_t, v_read, memory_config=_L1)
     k_t = ttnn.reshape(k_row, [B, H, K], memory_config=_L1)
+    # decay_t is unused downstream (apply_decay=False -> h already decayed above); pass g_bhkv to
+    # satisfy the signature without recomputing a decay tensor.
     h = fused_decay_and_write_ttnn(
-        h=h, k_t=k_t, delta=delta, decay_t=decay_t, beta_t=beta_t, device=device, apply_decay=False
+        h=h, k_t=k_t, delta=delta, decay_t=g_bhkv, beta_t=beta_t, device=device, apply_decay=False
     )
 
     # o = q @ h


### PR DESCRIPTION
## What

Fuses the state-decay `exp` into the decay multiply on the shared **GDN decode** path (`ttnn_delta_rule_ops.py::recurrent_gated_delta_rule_decode_ttnn`). Affects only the recurrent (`T=1`) decode; prefill/chunk paths are untouched. Because the change is inside the shared op, all decode call sites benefit automatically: single-device `gated_deltanet_forward_ttnn`, its inplace wrapper, and the TP path (`qwen36/tt/gdn/tp.py`, the 27B / 4×p150 path).

## Optimization

**Fuse `exp` into the decay multiply.** The canonical decay-before-read step computes `h = h * exp(g)`. Instead of a standalone `ttnn.exp(g)` followed by a `ttnn.multiply`, apply `exp` as a pre-activation on the multiply's second operand:

```python
h = ttnn.multiply(h, g_bhkv, input_tensor_b_activations=[ttnn.UnaryOpType.EXP])
```

One fewer op per decode step, same math. Applied unconditionally (no flag).

## Correctness

Same `exp`→multiply, fused into one op. A/B (opts vs base, 8 decode steps, TP path): out PCC 0.99998, rec_state PCC 0.99999 — fp op-order only.

## Performance

Measured on a Blackhole p100a (SIM_TP=4, traced decode replay — the deployment-relevant device-bound metric):

| batch | baseline | +fused-exp | Δ |
|------:|---------:|-----------:|---:|
| 1  | 364.8 µs/step | 359.8 µs/step | **−1.4%** |
| 32 | 1164.1 µs/step | 1160.0 µs/step | −0.4% |

Small but consistent

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/gdn-decode-opts-from-qwen35)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/gdn-decode-opts-from-qwen35)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/gdn-decode-opts-from-qwen35)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/gdn-decode-opts-from-qwen35)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=iwrosz/gdn-decode-opts-from-qwen35)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:iwrosz/gdn-decode-opts-from-qwen35)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/gdn-decode-opts-from-qwen35)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/gdn-decode-opts-from-qwen35)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/gdn-decode-opts-from-qwen35)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/gdn-decode-opts-from-qwen35)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/gdn-decode-opts-from-qwen35)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/gdn-decode-opts-from-qwen35)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/gdn-decode-opts-from-qwen35)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/gdn-decode-opts-from-qwen35)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/gdn-decode-opts-from-qwen35)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/gdn-decode-opts-from-qwen35)