### PR TITLE
Alexey zaytsev epam/fix hash collision 45821 w RMSNormForwardDeviceOperation tt-train

### DIFF
--- a/tt-train/sources/ttml/metal/ops/rmsnorm_fw/device/rmsnorm_fw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_fw/device/rmsnorm_fw_device_operation.cpp
@@ -114,16 +114,6 @@ tensor_return_value_t RMSNormForwardDeviceOperation::create_output_tensors(
     return output_tensors;
 }
 
-ttsl::hash::hash_t RMSNormForwardDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    const auto& input_tensor = tensor_args.input;
-    const auto& input_logical_shape = input_tensor.logical_shape();
-    tt::tt_metal::operation::Hash hash = tt::tt_metal::operation::hash_operation<RMSNormForwardDeviceOperation>(
-        args, input_tensor.dtype(), input_logical_shape);
-
-    return hash;
-}
-
 }  // namespace ttml::metal::ops::rmsnorm_fw::device
 
 namespace ttnn::prim {

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_fw/device/rmsnorm_fw_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_fw/device/rmsnorm_fw_device_operation.hpp
@@ -25,8 +25,6 @@ struct RMSNormForwardDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
-
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttml::metal::ops::rmsnorm_fw::device

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_fw/device/rmsnorm_fw_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_fw/device/rmsnorm_fw_device_operation_types.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <tuple>
+
 #include "metal/ttnn_all_includes.hpp"
 
 namespace ttml::metal::ops::rmsnorm_fw::device {
@@ -11,6 +13,11 @@ namespace ttml::metal::ops::rmsnorm_fw::device {
 struct RMSNormForwardParams {
     bool return_intermediates{false};
     float epsilon{1e-6F};
+
+    static constexpr auto attribute_names = std::forward_as_tuple("return_intermediates", "epsilon");
+    auto attribute_values() const {
+        return std::forward_as_tuple(return_intermediates, epsilon);
+    }
 };
 
 struct RMSNormForwardInputs {
@@ -19,6 +26,11 @@ struct RMSNormForwardInputs {
 
     std::optional<ttnn::Tensor> preallocated_rms;
     std::optional<ttnn::Tensor> preallocated_output;
+
+    static constexpr auto attribute_names = std::forward_as_tuple("input_dtype", "input_logical_shape", "input");
+    auto attribute_values() const {
+        return std::make_tuple(input.dtype(), std::cref(input.logical_shape()), std::cref(input));
+    }
 };
 
 using operation_attributes_t = RMSNormForwardParams;


### PR DESCRIPTION
### PR Category
hash calculation unification for operation RMSNormForwardDeviceOperation (tt-train)

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for RMSNormForwardDeviceOperation (tt-train)

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_RMSNormForwardDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_RMSNormForwardDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_RMSNormForwardDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_RMSNormForwardDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_RMSNormForwardDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_RMSNormForwardDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_RMSNormForwardDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_RMSNormForwardDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_RMSNormForwardDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_RMSNormForwardDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_RMSNormForwardDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_RMSNormForwardDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_RMSNormForwardDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_RMSNormForwardDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_RMSNormForwardDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_RMSNormForwardDeviceOperation_tt-train)
