### PR TITLE
Alexey zaytsev epam/fix hash collision 45821 w RollDeviceOperation

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_device_operation.cpp
@@ -41,12 +41,6 @@ void RollDeviceOperation::validate_on_program_cache_hit(
     validate_roll(operation_attributes, tensor_args);
 }
 
-ttsl::hash::hash_t RollDeviceOperation::compute_program_hash(
-    const operation_attributes_t& attrs, const tensor_args_t& args) {
-    return tt::tt_metal::operation::hash_operation<RollDeviceOperation>(
-        attrs.shift, attrs.dim, args.input.memory_config(), args.input.dtype(), args.input.layout());
-}
-
 RollDeviceOperation::spec_return_value_t RollDeviceOperation::compute_output_specs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     const auto& input = tensor_args.input;
@@ -75,7 +69,7 @@ RollDeviceOperation::tensor_return_value_t roll_sharded(
     using OperationType = RollDeviceOperation;
     return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{.shift = shift, .dim = dim, .output_mem_config = output_mem_config},
-        OperationType::tensor_args_t{.input = input});
+        OperationType::tensor_args_t{input});
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_device_operation.hpp
@@ -25,8 +25,6 @@ struct RollDeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
 
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
-
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/roll/device/roll_device_operation_types.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <tuple>
+
 #include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::prim {
@@ -14,10 +16,20 @@ struct RollParams {
     uint32_t shift{};  // normalized to [0, dim_size)
     int32_t dim{};     // absolute (non-negative) dim index
     tt::tt_metal::MemoryConfig output_mem_config;
+
+    static constexpr auto attribute_names = std::forward_as_tuple("shift", "dim");
+    auto attribute_values() const { return std::make_tuple(shift, dim); }
 };
 
 struct RollInputs {
     Tensor input;
+
+    RollInputs(const Tensor& input_tensor) : input(input_tensor) {}
+
+    static constexpr auto attribute_names = std::forward_as_tuple("memory_config", "dtype", "layout");
+    auto attribute_values() const {
+        return std::make_tuple(std::cref(input.memory_config()), input.dtype(), input.layout());
+    }
 };
 
 }  // namespace ttnn::prim


### PR DESCRIPTION
### PR Category
hash calculation unification for operation RollDeviceOperation

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for RollDeviceOperation

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_RollDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_RollDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_RollDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_RollDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_RollDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_RollDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_RollDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_RollDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_RollDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_RollDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_RollDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_RollDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_RollDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_RollDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_RollDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_RollDeviceOperation)
