### PR TITLE
Alexey zaytsev epam/fix hash collision 45821 sdpa decode device operation

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
@@ -13,8 +13,6 @@
 #include "ttnn/operation.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 
-#include <tt_stl/reflection.hpp>
-
 using namespace tt::tt_metal;
 
 namespace ttnn::prim {
@@ -559,6 +557,11 @@ Tensor sdpa_decode(
         .page_table_tensor = page_table_tensor,
         .attn_mask = attn_mask,
         .attention_sink = attention_sink,
+        .q_padded_shape = input_tensor_q.padded_shape(),
+        .k_padded_shape = input_tensor_k.padded_shape(),
+        .v_padded_shape = input_tensor_v.has_value() ? std::optional{input_tensor_v->padded_shape()} : std::nullopt,
+        .cur_pos_tensor_logical_shape =
+            cur_pos_tensor.has_value() ? std::optional{cur_pos_tensor->logical_shape()} : std::nullopt,
     };
 
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation_types.hpp
@@ -4,7 +4,9 @@
 
 #pragma once
 
+#include <cstdint>
 #include <optional>
+#include <tuple>
 #include <vector>
 
 #include "ttnn/tensor/tensor.hpp"
@@ -40,6 +42,45 @@ struct SdpaDecodeParams {
     // the effective block_size and ≥ sliding_window_size when both are set. Paged-mode
     // only (validated in validate_on_program_cache_miss).
     std::optional<uint32_t> cache_position_modulo = std::nullopt;
+
+    uint8_t share_cache_hash_tag() const {
+        return share_cache.has_value() ? (share_cache.value() ? uint8_t{2} : uint8_t{1}) : uint8_t{0};
+    }
+
+    static constexpr auto attribute_names = std::forward_as_tuple(
+        "scale",
+        "output_mem_config",
+        "program_config",
+        "compute_kernel_config",
+        "k_chunk_size",
+        "paged_attention",
+        "is_causal",
+        "share_cache_hash_tag",
+        "cur_pos",
+        "use_mla",
+        "head_dim_v",
+        "sliding_window_size",
+        "block_size_override",
+        "num_kv_heads_override",
+        "cache_position_modulo");
+    auto attribute_values() const {
+        return std::make_tuple(
+            std::cref(scale),
+            std::cref(output_mem_config),
+            std::cref(program_config),
+            std::cref(compute_kernel_config),
+            k_chunk_size,
+            paged_attention,
+            is_causal,
+            share_cache_hash_tag(),
+            std::cref(cur_pos),
+            std::cref(use_mla),
+            std::cref(head_dim_v),
+            std::cref(sliding_window_size),
+            std::cref(block_size_override),
+            std::cref(num_kv_heads_override),
+            std::cref(cache_position_modulo));
+    }
 };
 
 struct SdpaDecodeInputs {
@@ -55,6 +96,11 @@ struct SdpaDecodeInputs {
     std::optional<Tensor> page_table_tensor;
     std::optional<Tensor> attn_mask;
     std::optional<Tensor> attention_sink;
+
+    tt::tt_metal::Shape q_padded_shape;
+    tt::tt_metal::Shape k_padded_shape;
+    std::optional<tt::tt_metal::Shape> v_padded_shape;
+    std::optional<tt::tt_metal::Shape> cur_pos_tensor_logical_shape;
 };
 
 }  // namespace ttnn::prim


### PR DESCRIPTION
### PR Category
hash calculation unification for operation SdpaDecodeDeviceOperation

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for SdpaDecodeDeviceOperation

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SdpaDecodeDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SdpaDecodeDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SdpaDecodeDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SdpaDecodeDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SdpaDecodeDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SdpaDecodeDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SdpaDecodeDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SdpaDecodeDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SdpaDecodeDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SdpaDecodeDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SdpaDecodeDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SdpaDecodeDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SdpaDecodeDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SdpaDecodeDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SdpaDecodeDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SdpaDecodeDeviceOperation)
