### PR TITLE
#45821: migrate SelectTargetLogitDeviceOperation (tt-train) to default program-cache hash

### DIFF
--- a/tt-train/sources/ttml/metal/ops/select_target_logit/device/select_target_logit_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/select_target_logit/device/select_target_logit_device_operation.cpp
@@ -106,14 +106,6 @@ SelectTargetLogitDeviceOperation::tensor_return_value_t SelectTargetLogitDeviceO
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.logit.device());
 }
 
-ttsl::hash::hash_t SelectTargetLogitDeviceOperation::compute_program_hash(
-    const operation_attributes_t& /*args*/, const tensor_args_t& tensor_args) {
-    // first_v / local_V / cluster_axis only affect runtime args (they're patched by
-    // override_runtime_arguments per coord); they don't change the compiled kernel binary.
-    return tt::tt_metal::operation::hash_operation<SelectTargetLogitDeviceOperation>(
-        tensor_args.logit.dtype(), tensor_args.logit.logical_shape());
-}
-
 }  // namespace ttml::metal::ops::select_target_logit::device
 
 namespace ttnn::prim {

--- a/tt-train/sources/ttml/metal/ops/select_target_logit/device/select_target_logit_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/select_target_logit/device/select_target_logit_device_operation.hpp
@@ -25,8 +25,6 @@ struct SelectTargetLogitDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
-
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttml::metal::ops::select_target_logit::device

--- a/tt-train/sources/ttml/metal/ops/select_target_logit/device/select_target_logit_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/select_target_logit/device/select_target_logit_device_operation_types.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <optional>
+#include <tuple>
 
 #include "metal/ttnn_all_includes.hpp"
 
@@ -22,6 +23,11 @@ struct SelectTargetLogitParams {
     uint32_t first_v{0U};
     uint32_t local_V{0U};
     std::optional<uint32_t> cluster_axis{};
+
+    static constexpr auto attribute_names = std::forward_as_tuple();
+    auto attribute_values() const {
+        return std::forward_as_tuple();
+    }
 };
 
 struct SelectTargetLogitInputs {
@@ -29,6 +35,11 @@ struct SelectTargetLogitInputs {
     const ttnn::Tensor& target;  // [N, S]              ROW_MAJOR UINT32  (global indices)
 
     std::optional<ttnn::Tensor> preallocated_output;
+
+    static constexpr auto attribute_names = std::forward_as_tuple("logit_dtype", "logit_logical_shape");
+    auto attribute_values() const {
+        return std::make_tuple(logit.dtype(), std::cref(logit.logical_shape()));
+    }
 };
 
 using operation_attributes_t = SelectTargetLogitParams;


### PR DESCRIPTION
### PR Category
hash calculation unification for operation SelectTargetLogitDeviceOperation (tt-train)

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for SelectTargetLogitDeviceOperation (tt-train)

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SelectTargetLogitDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SelectTargetLogitDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SelectTargetLogitDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SelectTargetLogitDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SelectTargetLogitDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SelectTargetLogitDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SelectTargetLogitDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SelectTargetLogitDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SelectTargetLogitDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SelectTargetLogitDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SelectTargetLogitDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SelectTargetLogitDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SelectTargetLogitDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SelectTargetLogitDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SelectTargetLogitDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SelectTargetLogitDeviceOperation_tt-train)
