### PR TITLE
Alexey zaytsev epam/fix hash collision 45821 w send async d2h device operation

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async_d2h/device/send_async_d2h_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async_d2h/device/send_async_d2h_op_device_operation.cpp
@@ -53,14 +53,6 @@ SendAsyncD2HDeviceOperation::tensor_return_value_t SendAsyncD2HDeviceOperation::
     return {};
 }
 
-ttsl::hash::hash_t SendAsyncD2HDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    log_trace(tt::LogOp, "SendAsyncD2HDeviceOperation::compute_program_hash is called");
-    const ttnn::Tensor& input_tensor = tensor_args;
-    return tt::tt_metal::operation::hash_operation<SendAsyncD2HDeviceOperation>(
-        args.d2h_socket->get_config_buffer_address(), input_tensor);
-}
-
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async_d2h/device/send_async_d2h_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async_d2h/device/send_async_d2h_op_device_operation.hpp
@@ -21,8 +21,6 @@ struct SendAsyncD2HDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async_d2h/device/send_async_d2h_op_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/send_recv_async/send_async_d2h/device/send_async_d2h_op_device_operation_types.hpp
@@ -22,6 +22,12 @@ struct SendAsyncD2HParams {
 
     explicit SendAsyncD2HParams(const tt::tt_metal::distributed::D2HSocket& d2h_socket) : d2h_socket(&d2h_socket) {}
 
+    static constexpr auto attribute_names = std::forward_as_tuple("d2h_config_buffer_address");
+    auto attribute_values() const {
+        TT_FATAL(d2h_socket != nullptr, "send_async_d2h: D2HSocket pointer is null");
+        return std::forward_as_tuple(d2h_socket->get_config_buffer_address());
+    }
+
     // Reflection: surface a small set of stable, hashable properties of the D2H socket.
     // These uniquely identify the socket from a program-cache perspective: same device
     // and same config buffer address produces the same program.


### PR DESCRIPTION
### PR Category
hash calculation unification for operation SendAsyncD2HDeviceOperation

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for SendAsyncD2HDeviceOperation

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SendAsyncD2HDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SendAsyncD2HDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SendAsyncD2HDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SendAsyncD2HDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SendAsyncD2HDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SendAsyncD2HDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SendAsyncD2HDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SendAsyncD2HDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SendAsyncD2HDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SendAsyncD2HDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SendAsyncD2HDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SendAsyncD2HDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SendAsyncD2HDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SendAsyncD2HDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SendAsyncD2HDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SendAsyncD2HDeviceOperation)
