### PR TITLE
Alexey zaytsev epam/fix hash collision 45821 w SGDDeviceOperation tt-train

### DIFF
--- a/tt-train/sources/ttml/metal/optimizers/sgd/device/sgd_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/optimizers/sgd/device/sgd_device_operation.cpp
@@ -83,18 +83,6 @@ SGDDeviceOperation::tensor_return_value_t SGDDeviceOperation::create_output_tens
     return tensor_args.param;
 }
 
-ttsl::hash::hash_t SGDDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    const auto& param_tensor = tensor_args.param;
-    const auto& param_logical_shape = param_tensor.logical_shape();
-    auto nesterov = args.nesterov;
-    auto momentum_initialized = tensor_args.momentum_buffer.has_value();
-    auto hash = tt::tt_metal::operation::hash_operation<SGDDeviceOperation>(
-        nesterov, momentum_initialized, param_tensor.dtype(), param_logical_shape);
-
-    return hash;
-}
-
 }  // namespace ttml::metal::optimizers::sgd::device
 
 namespace ttnn::prim {

--- a/tt-train/sources/ttml/metal/optimizers/sgd/device/sgd_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/optimizers/sgd/device/sgd_device_operation.hpp
@@ -25,8 +25,6 @@ struct SGDDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
-
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttml::metal::optimizers::sgd::device

--- a/tt-train/sources/ttml/metal/optimizers/sgd/device/sgd_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/optimizers/sgd/device/sgd_device_operation_types.hpp
@@ -6,6 +6,7 @@
 
 #include <optional>
 #include <ttnn/tensor/tensor.hpp>
+#include <tuple>
 
 #include "metal/ttnn_all_includes.hpp"
 
@@ -17,12 +18,29 @@ struct operation_attributes_t {
     float dampening{0.0F};
     float weight_decay{0.0F};
     bool nesterov{false};
+
+    static constexpr auto attribute_names = std::forward_as_tuple("nesterov");
+    auto attribute_values() const {
+        return std::forward_as_tuple(nesterov);
+    }
 };
 
 struct tensor_args_t {
     const ttnn::Tensor& param;
     const ttnn::Tensor& grad;
     std::optional<ttnn::Tensor> momentum_buffer = std::nullopt;
+
+    static constexpr auto attribute_names = std::forward_as_tuple(
+        "momentum_initialized", "param_dtype", "param_logical_shape", "param", "grad", "momentum_buffer");
+    auto attribute_values() const {
+        return std::make_tuple(
+            momentum_buffer.has_value(),
+            param.dtype(),
+            std::cref(param.logical_shape()),
+            std::cref(param),
+            std::cref(grad),
+            momentum_buffer);
+    }
 };
 
 using tensor_return_value_t = ttnn::Tensor;


### PR DESCRIPTION
### PR Category
hash calculation unification for operation SGDDeviceOperation (tt-train)

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for SGDDeviceOperation (tt-train)

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SGDDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SGDDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SGDDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SGDDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SGDDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SGDDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SGDDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SGDDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SGDDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SGDDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SGDDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SGDDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SGDDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SGDDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SGDDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SGDDeviceOperation_tt-train)
