### PR TITLE
#45821: migrate SiLUBackwardDeviceOperation (tt-train) to default program-cache hash

### DIFF
--- a/tt-train/sources/ttml/metal/ops/silu_bw/device/silu_bw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/silu_bw/device/silu_bw_device_operation.cpp
@@ -84,16 +84,6 @@ tensor_return_value_t SiLUBackwardDeviceOperation::create_output_tensors(
     }
 }
 
-ttsl::hash::hash_t SiLUBackwardDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    const auto& input_tensor = tensor_args.input;
-    const auto& input_logical_shape = input_tensor.logical_shape();
-    tt::tt_metal::operation::Hash hash = tt::tt_metal::operation::hash_operation<SiLUBackwardDeviceOperation>(
-        args, input_tensor.dtype(), input_logical_shape);
-
-    return hash;
-}
-
 }  // namespace ttml::metal::ops::silu_bw::device
 
 namespace ttnn::prim {

--- a/tt-train/sources/ttml/metal/ops/silu_bw/device/silu_bw_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/silu_bw/device/silu_bw_device_operation.hpp
@@ -24,8 +24,6 @@ struct SiLUBackwardDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttml::metal::ops::silu_bw::device

--- a/tt-train/sources/ttml/metal/ops/silu_bw/device/silu_bw_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/silu_bw/device/silu_bw_device_operation_types.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <tuple>
+
 #include "metal/ttnn_all_includes.hpp"
 
 namespace ttml::metal::ops::silu_bw::device {
@@ -16,6 +18,11 @@ struct SiLUBackwardInputs {
     ttnn::Tensor input;
     ttnn::Tensor dL_dout;
     std::optional<ttnn::Tensor> preallocated_da = std::nullopt;
+
+    static constexpr auto attribute_names = std::forward_as_tuple("input_dtype", "input_logical_shape");
+    auto attribute_values() const {
+        return std::make_tuple(input.dtype(), std::cref(input.logical_shape()));
+    }
 };
 
 using operation_attributes_t = SiLUBackwardParams;


### PR DESCRIPTION
### PR Category
hash calculation unification for operation SiLUBackwardDeviceOperation (tt-train)

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for SiLUBackwardDeviceOperation (tt-train)

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SiLUBackwardDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SiLUBackwardDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SiLUBackwardDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SiLUBackwardDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SiLUBackwardDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SiLUBackwardDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SiLUBackwardDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SiLUBackwardDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SiLUBackwardDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SiLUBackwardDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SiLUBackwardDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SiLUBackwardDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SiLUBackwardDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SiLUBackwardDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SiLUBackwardDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SiLUBackwardDeviceOperation_tt-train)
