### PR TITLE
Alexey zaytsev epam/fix hash collision 45821 w SliceDeviceOperation

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
@@ -295,60 +295,6 @@ SliceDeviceOperation::program_factory_t SliceDeviceOperation::select_program_fac
     return SliceTileProgramFactory{};
 }
 
-ttsl::hash::hash_t SliceDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    // Default hash has weak distribution for small-integer shape sequences (boost::hash_combine
-    // style), causing false cache hits when shapes differ but collide. Mix in full input/output
-    // specs and slice params so any two invocations with different core-grid sizes get distinct
-    // keys. Same pattern as concat fix in PR #45144 (issue #47602).
-    auto factory = select_program_factory(operation_attributes, tensor_args);
-    auto hash = tt::tt_metal::operation::hash_operation<SliceDeviceOperation>(
-        operation_attributes.slice_start,
-        operation_attributes.slice_end,
-        operation_attributes.step,
-        operation_attributes.use_tensor_args,
-        operation_attributes.slice_dim,
-        operation_attributes.num_devices,
-        operation_attributes.output_mem_config,
-        operation_attributes.sub_core_grids,
-        factory.index(),
-        tensor_args.start_tensor.has_value());
-
-    const auto& input = tensor_args.input;
-    hash = ttsl::hash::hash_objects(
-        hash,
-        input.logical_shape().rank(),
-        input.logical_shape(),
-        input.padded_shape(),
-        input.layout(),
-        input.dtype(),
-        input.memory_config());
-
-    if (tensor_args.start_tensor.has_value()) {
-        const auto& st = tensor_args.start_tensor.value();
-        hash = ttsl::hash::hash_objects(
-            hash,
-            st.logical_shape().rank(),
-            st.logical_shape(),
-            st.padded_shape(),
-            st.layout(),
-            st.dtype(),
-            st.memory_config());
-    }
-
-    const auto output_spec = compute_output_specs(operation_attributes, tensor_args);
-    hash = ttsl::hash::hash_objects(
-        hash,
-        output_spec.logical_shape().rank(),
-        output_spec.logical_shape(),
-        output_spec.padded_shape(),
-        output_spec.layout(),
-        output_spec.data_type(),
-        output_spec.memory_config());
-
-    return hash;
-}
-
 tt::tt_metal::operation::OpPerformanceModelGeneral<SliceDeviceOperation::tensor_return_value_t>
 SliceDeviceOperation::create_op_performance_model(
     const operation_attributes_t& /*args*/, const tensor_args_t& tensor_args, const Tensor& output) {

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.hpp
@@ -50,8 +50,6 @@ struct SliceDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
-
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t&, const tensor_args_t&, const Tensor&);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation_types.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <optional>
+#include <tuple>
 
 #include "ttnn/tensor/tensor.hpp"
 
@@ -19,6 +20,27 @@ struct SliceParams {
     std::optional<uint32_t> slice_dim = std::nullopt;
     std::optional<uint32_t> num_devices = std::nullopt;
     std::optional<CoreRangeSet> sub_core_grids = std::nullopt;
+
+    static constexpr auto attribute_names = std::forward_as_tuple(
+        "slice_start",
+        "slice_end",
+        "step",
+        "use_tensor_args",
+        "slice_dim",
+        "num_devices",
+        "output_mem_config",
+        "sub_core_grids");
+    auto attribute_values() const {
+        return std::make_tuple(
+            std::cref(slice_start),
+            std::cref(slice_end),
+            std::cref(step),
+            use_tensor_args,
+            slice_dim,
+            num_devices,
+            std::cref(output_mem_config),
+            std::cref(sub_core_grids));
+    }
 };
 
 struct SliceInputs {


### PR DESCRIPTION
### PR Category
hash calculation unification for operation SliceDeviceOperation

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for SliceDeviceOperation

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SliceDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SliceDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SliceDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SliceDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SliceDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SliceDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SliceDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SliceDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SliceDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SliceDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SliceDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SliceDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SliceDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SliceDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SliceDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SliceDeviceOperation)
