### PR TITLE
Alexey zaytsev epam/fix hash collision 45821 w SoftmaxDeviceOperation tt-train

### DIFF
--- a/tt-train/sources/ttml/metal/ops/softmax/device/softmax_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/softmax/device/softmax_device_operation.cpp
@@ -99,14 +99,6 @@ SoftmaxDeviceOperation::tensor_return_value_t SoftmaxDeviceOperation::create_out
     return output_tensor;
 }
 
-ttsl::hash::hash_t SoftmaxDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    const auto& input_tensor = tensor_args.input;
-    const auto& input_logical_shape = input_tensor.logical_shape();
-    return tt::tt_metal::operation::hash_operation<SoftmaxDeviceOperation>(
-        args, input_tensor.dtype(), input_logical_shape);
-}
-
 }  // namespace ttml::metal::ops::softmax::device
 
 namespace ttnn::prim {

--- a/tt-train/sources/ttml/metal/ops/softmax/device/softmax_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/softmax/device/softmax_device_operation.hpp
@@ -25,8 +25,6 @@ struct SoftmaxDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
-
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttml::metal::ops::softmax::device

--- a/tt-train/sources/ttml/metal/ops/softmax/device/softmax_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/softmax/device/softmax_device_operation_types.hpp
@@ -4,18 +4,30 @@
 
 #pragma once
 
+#include <tuple>
+
 #include "metal/ttnn_all_includes.hpp"
 
 namespace ttml::metal::ops::softmax::device {
 
 struct SoftmaxParams {
     const int32_t dim{3U};  // Use last dimension by default
+
+    static constexpr auto attribute_names = std::forward_as_tuple("dim");
+    auto attribute_values() const {
+        return std::forward_as_tuple(dim);
+    }
 };
 
 struct SoftmaxInputs {
     const ttnn::Tensor& input;
 
     std::optional<ttnn::Tensor> preallocated_output;
+
+    static constexpr auto attribute_names = std::forward_as_tuple("input_dtype", "input_logical_shape");
+    auto attribute_values() const {
+        return std::make_tuple(input.dtype(), std::cref(input.logical_shape()));
+    }
 };
 
 using operation_attributes_t = SoftmaxParams;


### PR DESCRIPTION
### PR Category
hash calculation unification for operation SoftmaxDeviceOperation (tt-train)

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for SoftmaxDeviceOperation (tt-train)

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SoftmaxDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SoftmaxDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SoftmaxDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SoftmaxDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SoftmaxDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SoftmaxDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SoftmaxDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SoftmaxDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SoftmaxDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SoftmaxDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SoftmaxDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SoftmaxDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SoftmaxDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SoftmaxDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SoftmaxDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SoftmaxDeviceOperation_tt-train)
