### PR TITLE
#45821: migrate SparseSDPAMsaOperation to default program-cache hash

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.cpp
@@ -9,7 +9,6 @@
 #include "ttnn/operations/ccl/ccl_common.hpp"
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/hal.hpp>
-#include <bit>
 
 namespace ttnn::prim {
 
@@ -197,34 +196,6 @@ SparseSDPAMsaOperation::spec_return_value_t SparseSDPAMsaOperation::compute_outp
 SparseSDPAMsaOperation::tensor_return_value_t SparseSDPAMsaOperation::create_output_tensors(
     const SparseSDPAMsaParams& attrs, const SparseSDPAMsaInputs& t) {
     return create_device_tensor(compute_output_specs(attrs, t), t.q.device());
-}
-
-ttsl::hash::hash_t SparseSDPAMsaOperation::compute_program_hash(
-    const SparseSDPAMsaParams& attrs, const SparseSDPAMsaInputs& t) {
-    // Hash compile-time choices. Interleaved K/V T and cache_batch_idx are patched at dispatch.
-    // Sharded K/V shapes stay hashed because accessor strides depend on them. The block-cyclic path also
-    // hashes T: the shard stride gap (= (T/sp - chunk_local)/block_size, in blocks) is baked as a compile-time
-    // argument, so a different cache size must be a distinct program.
-    return tt::tt_metal::operation::hash_operation<SparseSDPAMsaOperation>(
-        std::bit_cast<uint32_t>(attrs.scale),
-        attrs.block_size,
-        attrs.compute_kernel_config,
-        t.q.logical_shape(),
-        t.q.dtype(),
-        t.k.dtype(),
-        t.k.memory_config(),
-        (t.k.memory_config().is_sharded() || attrs.has_block_cyclic()) ? t.k.logical_shape() : tt::tt_metal::Shape{},
-        t.v.dtype(),
-        t.v.memory_config(),
-        (t.v.memory_config().is_sharded() || attrs.has_block_cyclic()) ? t.v.logical_shape() : tt::tt_metal::Shape{},
-        t.v.logical_shape()[3],
-        attrs.has_indexed_kv_cache(),
-        attrs.causal_enabled(),
-        attrs.has_block_cyclic(),
-        attrs.block_cyclic.has_value() ? attrs.block_cyclic->sp : 0u,
-        attrs.block_cyclic.has_value() ? attrs.block_cyclic->chunk_local : 0u,
-        t.indices.logical_shape(),
-        t.indices.dtype());
 }
 
 uint32_t SparseSDPAMsaOperation::compute_chunk_start_local(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.hpp
@@ -62,7 +62,6 @@ struct SparseSDPAMsaOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 
     // Per-device causal start: chunk_start_idx + rank*S along cluster_axis (rank from the coordinate; 0 on a
     // single device or when non-causal). Shared by create_descriptor (miss-bake) and get_dynamic_runtime_args

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation_types.hpp
@@ -7,7 +7,9 @@
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "block_cyclic_layout.hpp"  // ttnn::prim::BlockCyclicLayout (shared)
+#include <bit>
 #include <optional>
+#include <tuple>
 
 namespace ttnn::prim {
 
@@ -27,9 +29,34 @@ struct SparseSDPAMsaParams {
     std::optional<uint32_t> chunk_start_idx = std::nullopt;
     // SP mesh axis used to derive the per-device chunk_start (chunk_start_idx + rank*S); host-side only.
     std::optional<uint32_t> cluster_axis = std::nullopt;
+
     bool has_indexed_kv_cache() const { return cache_batch_idx.has_value(); }
     bool causal_enabled() const { return chunk_start_idx.has_value(); }
     bool has_block_cyclic() const { return block_cyclic.has_value(); }
+
+    // Mirrors the removed compute_program_hash: cache_batch_idx / chunk_start_idx / cluster_axis values are
+    // runtime-patched or host-only (excluded), so only their derived booleans are hashed. block_cyclic shapes
+    // the gather kernels (invP remap), so its presence and sp/chunk_local are hashed.
+    static constexpr auto attribute_names = std::forward_as_tuple(
+        "scale_bits",
+        "block_size",
+        "compute_kernel_config",
+        "has_indexed_kv_cache",
+        "causal_enabled",
+        "has_block_cyclic",
+        "block_cyclic_sp",
+        "block_cyclic_chunk_local");
+    auto attribute_values() const {
+        return std::make_tuple(
+            std::bit_cast<uint32_t>(scale),
+            block_size,
+            std::cref(compute_kernel_config),
+            has_indexed_kv_cache(),
+            causal_enabled(),
+            has_block_cyclic(),
+            block_cyclic.has_value() ? block_cyclic->sp : 0u,
+            block_cyclic.has_value() ? block_cyclic->chunk_local : 0u);
+    }
 };
 
 struct SparseSDPAMsaInputs {
@@ -37,6 +64,37 @@ struct SparseSDPAMsaInputs {
     Tensor k;        // [B,n_kv,T,d] TILE bf16|bfp8_b
     Tensor v;        // [B,n_kv,T,v_dim] TILE bf16|bfp8_b
     Tensor indices;  // [1,n_kv,S,TOPK] uint32 block ids; 0xFFFFFFFF is the sentinel
+
+    // K/V logical shapes are hashed unconditionally: under a block-cyclic cache the shard stride gap is baked
+    // into the gather kernels as a compile-time argument derived from T, so a different cache size must be a
+    // distinct program even for an interleaved cache. (Params can't observe block_cyclic from here, so we hash
+    // K/V T always — stricter than the old interleaved-only sentinel, but never a wrong cache hit.)
+    static constexpr auto attribute_names = std::forward_as_tuple(
+        "q_logical_shape",
+        "q_dtype",
+        "k_dtype",
+        "k_memory_config",
+        "k_logical_shape",
+        "v_dtype",
+        "v_memory_config",
+        "v_logical_shape",
+        "v_dim",
+        "indices_logical_shape",
+        "indices_dtype");
+    auto attribute_values() const {
+        return std::make_tuple(
+            q.logical_shape(),
+            q.dtype(),
+            k.dtype(),
+            std::cref(k.memory_config()),
+            k.logical_shape(),
+            v.dtype(),
+            std::cref(v.memory_config()),
+            v.logical_shape(),
+            v.logical_shape()[3],
+            indices.logical_shape(),
+            indices.dtype());
+    }
 };
 
 }  // namespace ttnn::prim


### PR DESCRIPTION
### PR Category
hash calculation unification for operation SparseSDPAMsaOperation

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for SparseSDPAMsaOperation

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SparseSDPAMsaOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SparseSDPAMsaOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SparseSDPAMsaOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SparseSDPAMsaOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SparseSDPAMsaOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SparseSDPAMsaOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SparseSDPAMsaOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SparseSDPAMsaOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SparseSDPAMsaOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SparseSDPAMsaOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SparseSDPAMsaOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SparseSDPAMsaOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SparseSDPAMsaOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SparseSDPAMsaOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SparseSDPAMsaOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SparseSDPAMsaOperation)
