### PR TITLE
#45821: migrate SparseSDPAOperation to default program-cache hash

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.cpp
@@ -8,7 +8,6 @@
 #include "ttnn/device.hpp"
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/hal.hpp>
-#include <bit>
 
 namespace ttnn::prim {
 
@@ -185,46 +184,6 @@ SparseSDPAOperation::tensor_return_value_t SparseSDPAOperation::create_output_te
     return create_device_tensor(compute_output_specs(attrs, t), t.q.device());
 }
 
-ttsl::hash::hash_t SparseSDPAOperation::compute_program_hash(const SparseSDPAParams& attrs, const SparseSDPAInputs& t) {
-    // dtypes + compute_kernel_config MUST be in the hash: q/kv may be bf16 or fp8_e4m3 (different CB
-    // formats, row byte widths, fp32-dest/unpack modes, and output dtype), and fp32_dest_acc_en changes
-    // the program. Same-shape-different-dtype (or -config) calls otherwise alias to one program and the
-    // second silently reuses the first's kernel (wrong results).
-    //
-    // kv's shape is hashed ONLY when kv is sharded. For an INTERLEAVED kv the per-page address is
-    // shape-independent (just page_id, page_size, num_banks), so T rides on the accessor's common runtime
-    // args and may change without recompiling. For a SHARDED kv the per-page bank mapping derives from the
-    // tensor shape (the shard-grid strides), which is baked into the accessor at create time and is NOT
-    // re-emitted on a cache-hit fast path — so a sharded kv MUST recompile when its shape changes, else a hit
-    // would reuse stale strides and read the wrong banks. (K_DIM is pinned via q's hashed shape regardless.)
-    return tt::tt_metal::operation::hash_operation<SparseSDPAOperation>(
-        std::bit_cast<uint32_t>(attrs.scale),
-        attrs.v_dim,
-        attrs.k_chunk_size,
-        attrs.compute_kernel_config,
-        t.q.logical_shape(),
-        t.q.dtype(),
-        t.kv.dtype(),
-        // kv.memory_config(): an ND-sharded kv produces different TensorAccessor compile-time args than an
-        // interleaved one, so they must be distinct programs.
-        t.kv.memory_config(),
-        // kv.logical_shape() when sharded (see above) OR block-cyclic: the block-cyclic remap bakes its
-        // T-dependent stride gap as a compile-time argument, so the cache length T must be in the hash (a
-        // different cache size is a distinct program). A plain interleaved kv keeps T out of the hash (sentinel
-        // shape) so changing T does not recompile.
-        (t.kv.memory_config().is_sharded() || attrs.has_block_cyclic()) ? t.kv.logical_shape() : tt::tt_metal::Shape{},
-        // Only whether kv is indexed (not which slot): cache_batch_idx's VALUE is a dynamic runtime arg
-        // (see get_dynamic_runtime_args), so indexing into a different slot reuses the same program.
-        attrs.has_indexed_kv_cache(),
-        // Block-cyclic remap configuration is compile-time; distinct sp/chunk_local/cache-size values produce
-        // distinct programs (T is hashed above). No runtime remap arg.
-        attrs.has_block_cyclic(),
-        attrs.block_cyclic.has_value() ? attrs.block_cyclic->sp : 0u,
-        attrs.block_cyclic.has_value() ? attrs.block_cyclic->chunk_local : 0u,
-        t.indices.logical_shape(),
-        t.indices.dtype());
-}
-
 std::vector<tt::tt_metal::DynamicRuntimeArg> SparseSDPAOperation::get_dynamic_runtime_args(
     const SparseSDPAParams& attrs,
     const SparseSDPAInputs& t,
@@ -278,18 +237,8 @@ Tensor sparse_sdpa(
     using OperationType = ttnn::prim::SparseSDPAOperation;
     return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
-            .scale = scale,
-            .v_dim = v_dim,
-            .k_chunk_size = k_chunk_size,
-            .compute_kernel_config = compute_kernel_config,
-            .cache_batch_idx = cache_batch_idx,
-            .block_cyclic = block_cyclic,
-        },
-        OperationType::tensor_args_t{
-            .q = q,
-            .kv = kv,
-            .indices = indices,
-        });
+            scale, v_dim, k_chunk_size, compute_kernel_config, cache_batch_idx, block_cyclic},
+        OperationType::tensor_args_t{q, kv, indices, block_cyclic.has_value()});
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.hpp
@@ -49,7 +49,6 @@ struct SparseSDPAOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 
     // cache_batch_idx is excluded from the program hash, so it must be re-applied to the cached program on
     // every dispatch (the non-Buffer analog of buffer-address patching). Returns the per-core gather page

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation_types.hpp
@@ -7,7 +7,9 @@
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "block_cyclic_layout.hpp"  // ttnn::prim::BlockCyclicLayout (shared)
+#include <bit>
 #include <optional>
+#include <tuple>
 
 namespace ttnn::prim {
 
@@ -25,12 +27,74 @@ struct SparseSDPAParams {
     // The remap configuration is compile-time; T is part of the program hash for this path.
     std::optional<BlockCyclicLayout> block_cyclic = std::nullopt;
     bool has_block_cyclic() const { return block_cyclic.has_value(); }
+
+    SparseSDPAParams(
+        float scale,
+        uint32_t v_dim,
+        uint32_t k_chunk_size,
+        DeviceComputeKernelConfig compute_kernel_config,
+        std::optional<uint32_t> cache_batch_idx = std::nullopt,
+        std::optional<BlockCyclicLayout> block_cyclic = std::nullopt) :
+        scale(scale),
+        v_dim(v_dim),
+        k_chunk_size(k_chunk_size),
+        compute_kernel_config(compute_kernel_config),
+        cache_batch_idx(cache_batch_idx),
+        block_cyclic(block_cyclic) {}
+
+    static constexpr auto attribute_names = std::forward_as_tuple(
+        "scale_bits",
+        "v_dim",
+        "k_chunk_size",
+        "compute_kernel_config",
+        "has_indexed_kv_cache",
+        "has_block_cyclic",
+        "block_cyclic_sp",
+        "block_cyclic_chunk_local");
+    auto attribute_values() const {
+        return std::make_tuple(
+            std::bit_cast<uint32_t>(scale),
+            v_dim,
+            k_chunk_size,
+            std::cref(compute_kernel_config),
+            has_indexed_kv_cache(),
+            has_block_cyclic(),
+            block_cyclic.has_value() ? block_cyclic->sp : 0u,
+            block_cyclic.has_value() ? block_cyclic->chunk_local : 0u);
+    }
 };
 
 struct SparseSDPAInputs {
     Tensor q;   // [1, H, S, K_DIM] bf16/fp8_e4m3 ROW_MAJOR  (K_DIM = head dim, e.g. 576)
     Tensor kv;  // [1, 1, T, K_DIM] bf16/fp8_e4m3 ROW_MAJOR  (or [B,1,T,K_DIM] when indexed; may be ND-sharded DRAM)
     Tensor indices;  // [1, 1, S, TOPK] uint32 ROW_MAJOR  (0xFFFFFFFF = masked)
+    // Mirrors attrs.has_block_cyclic() for the kv shape hash sentinel (set at launch).
+    bool block_cyclic_for_hash = false;
+
+    SparseSDPAInputs(Tensor q_in, Tensor kv_in, Tensor indices_in, bool block_cyclic_for_hash_in = false) :
+        q(std::move(q_in)),
+        kv(std::move(kv_in)),
+        indices(std::move(indices_in)),
+        block_cyclic_for_hash(block_cyclic_for_hash_in) {}
+
+    static constexpr auto attribute_names = std::forward_as_tuple(
+        "q_logical_shape",
+        "q_dtype",
+        "kv_dtype",
+        "kv_memory_config",
+        "kv_logical_shape_if_sharded_or_block_cyclic",
+        "indices_logical_shape",
+        "indices_dtype");
+    auto attribute_values() const {
+        return std::make_tuple(
+            q.logical_shape(),
+            q.dtype(),
+            kv.dtype(),
+            std::cref(kv.memory_config()),
+            (kv.memory_config().is_sharded() || block_cyclic_for_hash) ? kv.logical_shape() : tt::tt_metal::Shape{},
+            indices.logical_shape(),
+            indices.dtype());
+    }
 };
 
 }  // namespace ttnn::prim


### PR DESCRIPTION
### PR Category
hash calculation unification for operation SparseSDPAOperation

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for SparseSDPAOperation

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SparseSDPAOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SparseSDPAOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SparseSDPAOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SparseSDPAOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SparseSDPAOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SparseSDPAOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SparseSDPAOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SparseSDPAOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SparseSDPAOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SparseSDPAOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SparseSDPAOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SparseSDPAOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SparseSDPAOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SparseSDPAOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SparseSDPAOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SparseSDPAOperation)
