### PR TITLE
#45821: migrate SwigluElemwiseBwDeviceOperation (tt-train) to default program-cache hash

### DIFF
--- a/tt-train/sources/ttml/metal/ops/swiglu_elemwise_bw/device/swiglu_elemwise_bw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_elemwise_bw/device/swiglu_elemwise_bw_device_operation.cpp
@@ -122,30 +122,6 @@ tensor_return_value_t SwigluElemwiseBwDeviceOperation::create_output_tensors(
     };
 }
 
-ttsl::hash::hash_t SwigluElemwiseBwDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    const auto& dL_dlinear1_memcfg = tensor_args.preallocated_dL_dlinear1.has_value()
-                                         ? tensor_args.preallocated_dL_dlinear1->memory_config()
-                                         : tensor_args.linear1.memory_config();
-    const auto& dL_dgate_memcfg = tensor_args.preallocated_dL_dgate.has_value()
-                                      ? tensor_args.preallocated_dL_dgate->memory_config()
-                                      : tensor_args.linear1.memory_config();
-
-    return tt::tt_metal::operation::hash_operation<SwigluElemwiseBwDeviceOperation>(
-        args,
-        tensor_args.linear1.dtype(),
-        tensor_args.linear1.logical_shape(),
-        tensor_args.linear1.padded_shape(),
-        tensor_args.gate.dtype(),
-        tensor_args.gate.logical_shape(),
-        tensor_args.gate.padded_shape(),
-        tensor_args.dL_dprod.dtype(),
-        tensor_args.dL_dprod.logical_shape(),
-        tensor_args.dL_dprod.padded_shape(),
-        dL_dlinear1_memcfg,
-        dL_dgate_memcfg);
-}
-
 }  // namespace ttml::metal::ops::swiglu_elemwise_bw::device
 
 namespace ttnn::prim {

--- a/tt-train/sources/ttml/metal/ops/swiglu_elemwise_bw/device/swiglu_elemwise_bw_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_elemwise_bw/device/swiglu_elemwise_bw_device_operation.hpp
@@ -23,8 +23,6 @@ struct SwigluElemwiseBwDeviceOperation {
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttml::metal::ops::swiglu_elemwise_bw::device

--- a/tt-train/sources/ttml/metal/ops/swiglu_elemwise_bw/device/swiglu_elemwise_bw_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/ops/swiglu_elemwise_bw/device/swiglu_elemwise_bw_device_operation_types.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <tuple>
+
 #include "metal/ttnn_all_includes.hpp"
 
 namespace ttml::metal::ops::swiglu_elemwise_bw::device {
@@ -16,6 +18,47 @@ struct SwigluElemwiseBwInputs {
     ttnn::Tensor dL_dprod;
     std::optional<ttnn::Tensor> preallocated_dL_dlinear1 = std::nullopt;
     std::optional<ttnn::Tensor> preallocated_dL_dgate = std::nullopt;
+
+    static constexpr auto attribute_names = std::forward_as_tuple(
+        "linear1_dtype",
+        "linear1_logical_shape",
+        "linear1_padded_shape",
+        "gate_dtype",
+        "gate_logical_shape",
+        "gate_padded_shape",
+        "dL_dprod_dtype",
+        "dL_dprod_logical_shape",
+        "dL_dprod_padded_shape",
+        "dL_dlinear1_memcfg",
+        "dL_dgate_memcfg",
+        "linear1",
+        "gate",
+        "dL_dprod",
+        "preallocated_dL_dlinear1",
+        "preallocated_dL_dgate");
+    auto attribute_values() const {
+        const auto& dL_dlinear1_memcfg =
+            preallocated_dL_dlinear1.has_value() ? preallocated_dL_dlinear1->memory_config() : linear1.memory_config();
+        const auto& dL_dgate_memcfg =
+            preallocated_dL_dgate.has_value() ? preallocated_dL_dgate->memory_config() : linear1.memory_config();
+        return std::make_tuple(
+            linear1.dtype(),
+            std::cref(linear1.logical_shape()),
+            std::cref(linear1.padded_shape()),
+            gate.dtype(),
+            std::cref(gate.logical_shape()),
+            std::cref(gate.padded_shape()),
+            dL_dprod.dtype(),
+            std::cref(dL_dprod.logical_shape()),
+            std::cref(dL_dprod.padded_shape()),
+            dL_dlinear1_memcfg,
+            dL_dgate_memcfg,
+            std::cref(linear1),
+            std::cref(gate),
+            std::cref(dL_dprod),
+            preallocated_dL_dlinear1,
+            preallocated_dL_dgate);
+    }
 };
 
 struct SwigluElemwiseBwResult {


### PR DESCRIPTION
### PR Category
hash calculation unification for operation SwigluElemwiseBwDeviceOperation (tt-train)

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for SwigluElemwiseBwDeviceOperation (tt-train)

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SwigluElemwiseBwDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SwigluElemwiseBwDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SwigluElemwiseBwDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SwigluElemwiseBwDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SwigluElemwiseBwDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SwigluElemwiseBwDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SwigluElemwiseBwDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SwigluElemwiseBwDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SwigluElemwiseBwDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SwigluElemwiseBwDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SwigluElemwiseBwDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SwigluElemwiseBwDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SwigluElemwiseBwDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SwigluElemwiseBwDeviceOperation_tt-train)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_SwigluElemwiseBwDeviceOperation_tt-train)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_SwigluElemwiseBwDeviceOperation_tt-train)
