### PR TITLE
[tt-train] Fix MFU calculation

### DIFF
--- a/tt-train/sources/ttml/ttml/models/deepseek/flops.py
+++ b/tt-train/sources/ttml/ttml/models/deepseek/flops.py
@@ -67,15 +67,12 @@ def calculate_flops_per_token(config, seq_len: int) -> int:
     gate_params = d * config.n_routed_experts
     moe_active_per_layer = moe_active + gate_params
 
-    # ── Embedding + Head ──
+    # ── Output head ──
     padded_vocab = ((config.vocab_size + 31) // 32) * 32
-    embed_params = padded_vocab * d
     head_params = d * padded_vocab
 
     # ── Total active parameters per token ──
-    active_params = (
-        embed_params + head_params + n_layers * mla_params + n_dense * dense_mlp_params + n_moe * moe_active_per_layer
-    )
+    active_params = head_params + n_layers * mla_params + n_dense * dense_mlp_params + n_moe * moe_active_per_layer
 
     # ── Attention QK^T and attn@V FLOPs (scale with seq_len) ──
     # Q@K^T: [S, qk_head] @ [qk_head, S] per head per layer

--- a/tt-train/sources/ttml/ttml/models/llama/flops.py
+++ b/tt-train/sources/ttml/ttml/models/llama/flops.py
@@ -29,9 +29,7 @@ def calculate_flops_per_token(config, seq_len: int) -> int:
     # Get the actual vocab size from the model config
     vocab_size = config.vocab_size
 
-    # Parameter calculation using actual Llama architecture
-    # Embedding: vocab_size * hidden_size
-    embed_params = vocab_size * config.hidden_size
+    # Parameter calculation using actual Llama architecture.
 
     # Get intermediate size using the same logic as LlamaMLP
     intermediate_size = getattr(config, "intermediate_size", None)
@@ -74,16 +72,14 @@ def calculate_flops_per_token(config, seq_len: int) -> int:
     params_per_layer = attention_params + mlp_params
     transformer_params = config.num_hidden_layers * params_per_layer
 
-    # Output head (if not weight-tied)
+    # Output projection (LM head).
     head_params = vocab_size * config.hidden_size
-    if hasattr(config, "weight_tying") and config.weight_tying.name == "Enabled":
-        head_params = 0
 
     # Final layer norm (RMSNorm - no bias)
     final_norm_params = config.hidden_size
 
     # Total parameters
-    N = embed_params + transformer_params + head_params + final_norm_params
+    N = transformer_params + head_params + final_norm_params
 
     # Standard LLM FLOPs formula
     L = config.num_hidden_layers

--- a/tt-train/sources/ttml/ttml/models/nanogpt/flops.py
+++ b/tt-train/sources/ttml/ttml/models/nanogpt/flops.py
@@ -33,12 +33,6 @@ def calculate_flops_per_token(config, seq_len: int) -> int:
     E = config.n_embd
     vocab_size = config.vocab_size
 
-    embed_params = vocab_size * E
-
-    pos_embed_params = 0
-    if hasattr(config, "positional_embedding_type") and config.positional_embedding_type == "trainable":
-        pos_embed_params = config.block_size * E
-
     # Per-layer parameter count (from actual layer constructors):
     # Attention weights: qkv_linear(E, 3E) + out_linear(E, E) = 4E²
     # Attention biases (always on): 3E + E = 4E
@@ -52,14 +46,14 @@ def calculate_flops_per_token(config, seq_len: int) -> int:
 
     transformer_params = config.n_layer * params_per_layer
 
+    # Output projection (LM head).
     head_params = vocab_size * E
-    if hasattr(config, "weight_tying") and config.weight_tying.name == "Enabled":
-        head_params = 0
 
     # Final LayerNorm: gamma always, beta only if config.bias
     final_norm_params = E * (2 if config.bias else 1)
 
-    N = embed_params + pos_embed_params + transformer_params + head_params + final_norm_params
+    # Total parameters
+    N = transformer_params + head_params + final_norm_params
 
     L = config.n_layer
     H = config.n_head

--- a/tt-train/sources/ttml/ttml/models/qwen3/flops.py
+++ b/tt-train/sources/ttml/ttml/models/qwen3/flops.py
@@ -33,9 +33,6 @@ def calculate_flops_per_token(config, seq_len: int) -> int:
     q_out = config.num_attention_heads * head_dim
     kv_out = config.num_key_value_heads * head_dim
 
-    # Embedding: vocab_size * hidden_size
-    embed_params = vocab_size * config.hidden_size
-
     # Attention per layer:
     #   q_proj:  hidden_size x q_out
     #   k_proj:  hidden_size x kv_out
@@ -72,15 +69,14 @@ def calculate_flops_per_token(config, seq_len: int) -> int:
     params_per_layer = attention_params + mlp_params
     transformer_params = config.num_hidden_layers * params_per_layer
 
-    # Output head (if not weight-tied)
+    # Output projection (LM head).
     head_params = vocab_size * config.hidden_size
-    if hasattr(config, "weight_tying") and config.weight_tying.name == "Enabled":
-        head_params = 0
 
     # Final layer norm (RMSNorm)
     final_norm_params = config.hidden_size
 
-    N = embed_params + transformer_params + head_params + final_norm_params
+    # Total parameters
+    N = transformer_params + head_params + final_norm_params
 
     L = config.num_hidden_layers
     H = config.num_attention_heads


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Fixed MFU calculation. With untied embedding weights, MFU calculation was counting input embedding as a matmul, doing floating point operations, same way lm head is counted, instead of a look up.

With this fix, the input embedding doesn't contribute flops/token, lowering calculated MFU.

This affects MFU calculation across all 4 ttml models (nanoGPT, Llama, Qwen, Deepseek) with embedding weight tying disabled (most configs).

This results in around 5-6% lower MFU, depending on the model size relative to the embedding size.

For training_shakespeare_tinyllama.yaml on a p150.
```
MFU: 35% -> 33.2%
```

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=imichalak/fix-mfu-calculation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:imichalak/fix-mfu-calculation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=imichalak/fix-mfu-calculation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:imichalak/fix-mfu-calculation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=imichalak/fix-mfu-calculation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:imichalak/fix-mfu-calculation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=imichalak/fix-mfu-calculation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:imichalak/fix-mfu-calculation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=imichalak/fix-mfu-calculation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:imichalak/fix-mfu-calculation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=imichalak/fix-mfu-calculation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:imichalak/fix-mfu-calculation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=imichalak/fix-mfu-calculation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:imichalak/fix-mfu-calculation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=imichalak/fix-mfu-calculation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:imichalak/fix-mfu-calculation)