### PR TITLE
Alexey zaytsev epam/fix hash collision 45821 unary device operation

### DIFF
--- a/tests/tt_eager/ops/test_eltwise_unary_op.cpp
+++ b/tests/tt_eager/ops/test_eltwise_unary_op.cpp
@@ -9,6 +9,7 @@
 #include <numbers>
 
 #include <tt_stl/assert.hpp>
+#include <tt_stl/reflection.hpp>
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/device.hpp>
@@ -142,13 +143,29 @@ void test_operation_infrastructure() {
         .worker_grid = worker_grid,
         .sub_core_grids = std::nullopt,
     };
-    Op::tensor_args_t tensor_args{.input = input_tensor, .output_tensor = std::nullopt};
-    auto program_hash = Op::compute_program_hash(op_args, tensor_args);
-    auto program_hash_repeat = Op::compute_program_hash(op_args, tensor_args);
-    TT_FATAL(program_hash != 0, "compute_program_hash returned 0 — likely a bug");
+    Op::tensor_args_t tensor_args(input_tensor, std::nullopt);
+    op_args.input_dtype = input_tensor.dtype();
+    op_args.input_layout = input_tensor.layout();
+    op_args.input_memory_config = input_tensor.memory_config();
+    if (input_tensor.layout() == Layout::ROW_MAJOR) {
+        op_args.row_major_padded_shape = input_tensor.padded_shape();
+    }
+    const auto output_spec = Op::compute_output_specs(op_args, tensor_args);
+    if (const auto shard_specs = ttnn::operations::unary::get_shard_specs(input_tensor.tensor_spec(), output_spec)) {
+        const auto tile_hw = input_tensor.tensor_spec().tile().get_tile_hw();
+        if (input_tensor.is_sharded()) {
+            op_args.src_shard_vol = shard_specs->input_shard_spec.numel() / tile_hw;
+        }
+        const auto out_tile_hw = output_spec.tile().get_tile_hw();
+        op_args.dst_shard_vol = shard_specs->output_shard_spec.numel() / out_tile_hw;
+    }
+    auto program_hash = ttsl::hash::hash_objects_with_default_seed(ttsl::hash::type_hash<Op>, op_args, tensor_args);
+    auto program_hash_repeat =
+        ttsl::hash::hash_objects_with_default_seed(ttsl::hash::type_hash<Op>, op_args, tensor_args);
+    TT_FATAL(program_hash != 0, "default program hash returned 0 — likely a bug");
     TT_FATAL(
         program_hash == program_hash_repeat,
-        "UnaryDeviceOperation::compute_program_hash must be deterministic ({} vs {})",
+        "UnaryDeviceOperation default program hash must be deterministic ({} vs {})",
         program_hash,
         program_hash_repeat);
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
@@ -5,25 +5,12 @@
 #include "unary_device_operation.hpp"
 #include "ttnn/operations/eltwise/unary/common/unary_utils.hpp"
 #include "ttnn/device_operation.hpp"
-#include "ttnn/operation.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
 
 using namespace tt::tt_metal;
 
 namespace ttnn::operations::unary {
-
-ttsl::hash::hash_t UnaryDeviceOperation::operation_attributes_t::to_hash() const {
-    return ttsl::hash::hash_objects_with_default_seed(
-        op_chain,
-        output_dtype,
-        memory_config,
-        fp32_dest_acc_en,
-        preserve_fp32_precision,
-        bfp8_pack_precise,
-        sub_core_grids,
-        worker_grid);
-}
 
 void UnaryDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
@@ -143,48 +130,6 @@ Tensor UnaryDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input.device());
 }
 
-ttsl::hash::hash_t UnaryDeviceOperation::compute_program_hash(
-    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
-    const auto& input_tensor = tensor_args.input;
-    TT_FATAL(
-        tt::tt_metal::is_device_tensor(input_tensor), "Unary: Unexpected tensor type {}", input_tensor.storage_type());
-
-    const auto output_spec = compute_output_specs(attributes, tensor_args);
-    const auto shard_specs = get_shard_specs(input_tensor.tensor_spec(), output_spec);
-    std::optional<uint32_t> src_shard_vol = std::nullopt;
-    std::optional<uint32_t> dst_shard_vol = std::nullopt;
-    if (shard_specs.has_value()) {
-        const auto tile_hw = input_tensor.tensor_spec().tile().get_tile_hw();
-        if (input_tensor.is_sharded()) {
-            src_shard_vol = shard_specs->input_shard_spec.numel() / tile_hw;
-        }
-        const auto out_tile_hw = output_spec.tile().get_tile_hw();
-        dst_shard_vol = shard_specs->output_shard_spec.numel() / out_tile_hw;
-    }
-
-    // TODO: For ROW_MAJOR, page size depends on width. Hashing padded_shape ensures
-    // different widths get separate cache entries. Consider hashing only the last
-    // dimension to allow cache reuse when only height differs
-    if (input_tensor.layout() == Layout::ROW_MAJOR) {
-        return operation::hash_operation<UnaryDeviceOperation>(
-            attributes,
-            input_tensor.dtype(),
-            input_tensor.layout(),
-            input_tensor.memory_config(),
-            input_tensor.padded_shape(),
-            src_shard_vol,
-            dst_shard_vol);
-    }
-
-    return operation::hash_operation<UnaryDeviceOperation>(
-        attributes,
-        input_tensor.dtype(),
-        input_tensor.layout(),
-        input_tensor.memory_config(),
-        src_shard_vol,
-        dst_shard_vol);
-}
-
 bool UnaryDeviceOperation::skip_launch(
     const operation_attributes_t& /*attributes*/,
     const tensor_args_t& /*tensor_args*/,
@@ -229,7 +174,22 @@ Tensor unary(
         .sub_core_grids = sub_core_grids,
     };
 
-    auto tensor_args = OperationType::tensor_args_t{.input = input, .output_tensor = optional_output_tensor};
+    auto tensor_args = OperationType::tensor_args_t(input, optional_output_tensor);
+    operation_attributes.input_dtype = input.dtype();
+    operation_attributes.input_layout = input.layout();
+    operation_attributes.input_memory_config = input.memory_config();
+    if (input.layout() == Layout::ROW_MAJOR) {
+        operation_attributes.row_major_padded_shape = input.padded_shape();
+    }
+    const auto output_spec = OperationType::compute_output_specs(operation_attributes, tensor_args);
+    if (const auto shard_specs = ttnn::operations::unary::get_shard_specs(input.tensor_spec(), output_spec)) {
+        const auto tile_hw = input.tensor_spec().tile().get_tile_hw();
+        if (input.is_sharded()) {
+            operation_attributes.src_shard_vol = shard_specs->input_shard_spec.numel() / tile_hw;
+        }
+        const auto out_tile_hw = output_spec.tile().get_tile_hw();
+        operation_attributes.dst_shard_vol = shard_specs->output_shard_spec.numel() / out_tile_hw;
+    }
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.hpp
@@ -4,7 +4,9 @@
 
 #pragma once
 
+#include <cstdint>
 #include <optional>
+#include <tuple>
 #include <vector>
 
 #include <tt-metalium/core_coord.hpp>
@@ -31,13 +33,56 @@ struct UnaryDeviceOperation {
         bool bfp8_pack_precise = false;
         const CoreRangeSet worker_grid;
         std::optional<CoreRangeSet> sub_core_grids;
+        DataType input_dtype = DataType::INVALID;
+        Layout input_layout = Layout::TILE;
+        MemoryConfig input_memory_config;
+        std::optional<Shape> row_major_padded_shape = std::nullopt;
+        std::optional<std::uint32_t> src_shard_vol = std::nullopt;
+        std::optional<std::uint32_t> dst_shard_vol = std::nullopt;
 
-        ttsl::hash::hash_t to_hash() const;
+        static constexpr auto attribute_names = std::forward_as_tuple(
+            "op_chain",
+            "output_dtype",
+            "memory_config",
+            "fp32_dest_acc_en",
+            "preserve_fp32_precision",
+            "bfp8_pack_precise",
+            "sub_core_grids",
+            "worker_grid",
+            "input_dtype",
+            "input_layout",
+            "input_memory_config",
+            "row_major_padded_shape",
+            "src_shard_vol",
+            "dst_shard_vol");
+        auto attribute_values() const {
+            return std::make_tuple(
+                op_chain,
+                output_dtype,
+                memory_config,
+                fp32_dest_acc_en,
+                preserve_fp32_precision,
+                bfp8_pack_precise,
+                sub_core_grids,
+                worker_grid,
+                input_dtype,
+                input_layout,
+                input_memory_config,
+                input_layout == Layout::ROW_MAJOR ? row_major_padded_shape : std::optional<Shape>{},
+                src_shard_vol,
+                dst_shard_vol);
+        }
     };
 
     struct tensor_args_t {
         const Tensor& input;
         std::optional<Tensor> output_tensor;
+
+        tensor_args_t(const Tensor& input_in, std::optional<Tensor> output_tensor_in) :
+            input(input_in), output_tensor(std::move(output_tensor_in)) {}
+
+        static constexpr auto attribute_names = std::forward_as_tuple();
+        auto attribute_values() const { return std::make_tuple(); }
     };
 
     struct ProgramFactory {
@@ -52,7 +97,6 @@ struct UnaryDeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static bool skip_launch(const operation_attributes_t&, const tensor_args_t&, const tensor_return_value_t&);
 
     // Cache-hit re-apply of all per-dispatch state (per-core args + tensor-backed CB/buffer addresses),


### PR DESCRIPTION
### PR Category
hash calculation unification for operation UnaryDeviceOperation

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for UnaryDeviceOperation

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_UnaryDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_UnaryDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_UnaryDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_UnaryDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_UnaryDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_UnaryDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_UnaryDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_UnaryDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_UnaryDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_UnaryDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_UnaryDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_UnaryDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_UnaryDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_UnaryDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_UnaryDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_UnaryDeviceOperation)
