### PR TITLE
#45821: migrate UpdatePaddedKvCacheDeviceOperation to default program-cache hash

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.cpp
@@ -155,31 +155,6 @@ UpdatePaddedKvCacheDeviceOperation::tensor_return_value_t UpdatePaddedKvCacheDev
     return tensor_args.cache;
 }
 
-ttsl::hash::hash_t UpdatePaddedKvCacheDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    // slot_idx and kv_actual_global are per-call scalars held in common runtime args and patched on
-    // cache hits, so they are intentionally NOT hashed and successive users/chunks reuse the cached
-    // program. layer_idx IS hashed: it takes only num_layers distinct values, so one program per layer
-    // is reused across users/chunks, and a hashed scalar stays correct on the fast cache-hit path.
-    // num_layers and cluster_axis stay IN: both are structural — they govern the cache slot
-    // linearization and which mesh dim is sp — not per-call data.
-    const auto& cache = tensor_args.cache;
-    const auto& input = tensor_args.input;
-    // Hash the full padded shapes, not just their volumes: the descriptor derives Wt, input_Ht,
-    // cache_HtWt/CHtWt and the work split from specific dimensions, so two differently-shaped
-    // tensors that happen to share a volume must NOT collide onto the same cached program.
-    return tt::tt_metal::operation::hash_operation<UpdatePaddedKvCacheDeviceOperation>(
-        args.layer_idx,
-        args.num_layers,
-        args.cluster_axis,
-        input.dtype(),
-        input.layout(),  // TILE vs ROW_MAJOR drives the page-unit math; must not collide
-        input.memory_config(),
-        input.padded_shape(),
-        cache.memory_config(),
-        cache.padded_shape());
-}
-
 tt::tt_metal::ProgramDescriptor UpdatePaddedKvCacheDeviceOperation::ProgramFactory::create_descriptor(
     const operation_attributes_t& args,
     const tensor_args_t& tensor_args,
@@ -377,6 +352,12 @@ ttnn::Tensor update_padded_kv_cache(
         .layer_idx = layer_idx,
         .num_layers = num_layers,
         .cluster_axis = cluster_axis,
+        .input_dtype = input.dtype(),
+        .input_layout = input.layout(),
+        .input_memory_config = input.memory_config(),
+        .input_padded_shape = input.padded_shape(),
+        .cache_memory_config = cache.memory_config(),
+        .cache_padded_shape = cache.padded_shape(),
     };
     auto tensor_args = OperationType::tensor_args_t{.cache = cache, .input = input};
     return ttnn::device_operation::launch<OperationType>(attrs, tensor_args);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.hpp
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 #include <optional>
+#include <tuple>
 #include <variant>
 
 #include <tt-metalium/program.hpp>
@@ -31,6 +32,35 @@ struct UpdatePaddedKvCacheDeviceOperation {
         uint32_t layer_idx;
         uint32_t num_layers;
         uint32_t cluster_axis;
+        DataType input_dtype;
+        Layout input_layout;
+        MemoryConfig input_memory_config;
+        Shape input_padded_shape;
+        MemoryConfig cache_memory_config;
+        Shape cache_padded_shape;
+
+        static constexpr auto attribute_names = std::forward_as_tuple(
+            "layer_idx",
+            "num_layers",
+            "cluster_axis",
+            "input_dtype",
+            "input_layout",
+            "input_memory_config",
+            "input_padded_shape",
+            "cache_memory_config",
+            "cache_padded_shape");
+        auto attribute_values() const {
+            return std::forward_as_tuple(
+                layer_idx,
+                num_layers,
+                cluster_axis,
+                input_dtype,
+                input_layout,
+                std::cref(input_memory_config),
+                input_padded_shape,
+                std::cref(cache_memory_config),
+                cache_padded_shape);
+        }
     };
 
     struct tensor_args_t {
@@ -85,7 +115,6 @@ struct UpdatePaddedKvCacheDeviceOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::update_padded_kv_cache


### PR DESCRIPTION
### PR Category
hash calculation unification for operation UpdatePaddedKvCacheDeviceOperation

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for UpdatePaddedKvCacheDeviceOperation

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_UpdatePaddedKvCacheDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_UpdatePaddedKvCacheDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_UpdatePaddedKvCacheDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_UpdatePaddedKvCacheDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_UpdatePaddedKvCacheDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_UpdatePaddedKvCacheDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_UpdatePaddedKvCacheDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_UpdatePaddedKvCacheDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_UpdatePaddedKvCacheDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_UpdatePaddedKvCacheDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_UpdatePaddedKvCacheDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_UpdatePaddedKvCacheDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_UpdatePaddedKvCacheDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_UpdatePaddedKvCacheDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_UpdatePaddedKvCacheDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_UpdatePaddedKvCacheDeviceOperation)
