### PR TITLE
#45821: migrate ZeroPaddedKvCacheDeviceOperation to default program-cache hash

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/zero_padded_kv_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/zero_padded_kv_cache_device_operation.cpp
@@ -154,23 +154,6 @@ ZeroPaddedKvCacheDeviceOperation::tensor_return_value_t ZeroPaddedKvCacheDeviceO
     return tensor_args.cache;  // in-place
 }
 
-ttsl::hash::hash_t ZeroPaddedKvCacheDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    // slot_idx and valid_global are per-call scalars (patched, NOT hashed). layer_idx, num_layers,
-    // cluster_axis, chunk_size_global and pad_align are structural (hashed). Hash the full cache shape.
-    const auto& cache = tensor_args.cache;
-    return tt::tt_metal::operation::hash_operation<ZeroPaddedKvCacheDeviceOperation>(
-        args.layer_idx,
-        args.num_layers,
-        args.cluster_axis,
-        args.chunk_size_global,
-        args.pad_align,
-        cache.dtype(),
-        cache.layout(),
-        cache.memory_config(),
-        cache.padded_shape());
-}
-
 tt::tt_metal::ProgramDescriptor ZeroPaddedKvCacheDeviceOperation::ProgramFactory::create_descriptor(
     const operation_attributes_t& args,
     const tensor_args_t& tensor_args,
@@ -346,6 +329,10 @@ ttnn::Tensor zero_padded_kv_cache(
         .layer_idx = layer_idx,
         .num_layers = num_layers,
         .cluster_axis = cluster_axis,
+        .cache_dtype = cache.dtype(),
+        .cache_layout = cache.layout(),
+        .cache_memory_config = cache.memory_config(),
+        .cache_padded_shape = cache.padded_shape(),
     };
     auto tensor_args = OperationType::tensor_args_t{.cache = cache};
     return ttnn::device_operation::launch<OperationType>(attrs, tensor_args);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/zero_padded_kv_cache_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/zero_padded_kv_cache/device/zero_padded_kv_cache_device_operation.hpp
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 #include <optional>
+#include <tuple>
 #include <variant>
 
 #include <tt-metalium/program.hpp>
@@ -37,6 +38,33 @@ struct ZeroPaddedKvCacheDeviceOperation {
         uint32_t layer_idx;          // hashed (structural)
         uint32_t num_layers;         // hashed (structural)
         uint32_t cluster_axis;       // hashed (structural): which mesh dim is sequence-parallel
+        DataType cache_dtype;
+        Layout cache_layout;
+        MemoryConfig cache_memory_config;
+        Shape cache_padded_shape;
+
+        static constexpr auto attribute_names = std::forward_as_tuple(
+            "layer_idx",
+            "num_layers",
+            "cluster_axis",
+            "chunk_size_global",
+            "pad_align",
+            "cache_dtype",
+            "cache_layout",
+            "cache_memory_config",
+            "cache_padded_shape");
+        auto attribute_values() const {
+            return std::forward_as_tuple(
+                layer_idx,
+                num_layers,
+                cluster_axis,
+                chunk_size_global,
+                pad_align,
+                cache_dtype,
+                cache_layout,
+                std::cref(cache_memory_config),
+                cache_padded_shape);
+        }
     };
 
     struct tensor_args_t {
@@ -92,7 +120,6 @@ struct ZeroPaddedKvCacheDeviceOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::zero_padded_kv_cache


### PR DESCRIPTION
### PR Category
hash calculation unification for operation ZeroPaddedKvCacheDeviceOperation

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for ZeroPaddedKvCacheDeviceOperation

### Notes for reviewers
NA
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_ZeroPaddedKvCacheDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_ZeroPaddedKvCacheDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_ZeroPaddedKvCacheDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_ZeroPaddedKvCacheDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_ZeroPaddedKvCacheDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_ZeroPaddedKvCacheDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_ZeroPaddedKvCacheDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_ZeroPaddedKvCacheDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_ZeroPaddedKvCacheDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_ZeroPaddedKvCacheDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_ZeroPaddedKvCacheDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_ZeroPaddedKvCacheDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_ZeroPaddedKvCacheDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_ZeroPaddedKvCacheDeviceOperation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_w_ZeroPaddedKvCacheDeviceOperation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_w_ZeroPaddedKvCacheDeviceOperation)
