### PR TITLE
[Test Only] Sparse MLA perf harness: Tracy → realtime profiler

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
@@ -31,10 +31,11 @@ datamover off); the test gates on ``ttnn.device.IsProgramRealtimeProfilerActive(
 Tracy subprocess, signposts, and ops-CSV re-parse — the same swap PR #49840 made for the sparse-MLA
 CCL benchmarks (LoudBox: ~11× faster wall-clock). Two semantic notes versus the Tracy harness:
 
-  * Reporting unit is the device **program** (one ``runtime_id`` per op dispatch), NOT Tracy's
-    ``OP CODE``. A record carries only kernel-source paths, so the ``OP CODE`` column here holds a
-    best-effort label derived from the kernel path (``.../operations/<name>/...``); it groups by op
-    kind but is kernel-derived, not Tracy's op code.
+  * Reporting unit is the device **program** (one ``runtime_id`` per op dispatch). A record carries only
+    kernel-source paths, so the ``OP CODE`` column is mapped from those paths to a tracy-style op code
+    (``_op_code``: a priority table over the operations dir, verified against the tracy op-code
+    counts/durations). One program = one op code, matching Tracy's op names — not per-instance identical
+    to a tracy op struct, but the same code space the report/graph pipeline consumes.
   * Multi-chip collapse takes the **max** ``duration_ns`` across chips for every program (the slowest
     chip gates that program's critical path). Tracy used max for compute and avg for collectives, so
     collective-heavy numbers can differ a few percent (see PR #49840 deltas). Both express the same
@@ -100,6 +101,7 @@ context (no manual rope bump).
 """
 
 import copy
+import csv
 import datetime
 import json
 import os
@@ -155,6 +157,11 @@ PERF_FABRIC = ttnn.FabricConfig.FABRIC_2D
 # default covers a many-program forward across up to 32 chips; each forward is profiled as its own
 # (volume-bounded) region so this is a safety ceiling, not the expected wait.
 RT_RECORD_TIMEOUT_S = float(os.environ.get("DS_PERF_RT_TIMEOUT", 30.0))
+
+# When set, also write an execution-ordered per-call CSV (the RT analog of tracy's ops_perf_results):
+# one device-collapsed row per program per forward, ordered by start tick — the input a per-call graph
+# attribution (parse_percall) needs. Off by default (the summary CSVs are the normal output).
+RT_OPS_DUMP = os.environ.get("DS_PERF_RT_OPS_DUMP", "") not in ("", "0", "false")
 
 
 def _subdir(variant: str, mode: str) -> str:
@@ -421,11 +428,90 @@ def _op_label(kernel_sources) -> str:
     return "+".join(sorted(basenames)) if basenames else "unknown"
 
 
+# kernel-path substring -> tracy-style OP CODE, in PRIORITY order (first match wins). Ordering resolves
+# programs whose kernel set spans dirs: the op-defining kernel must precede its helpers/epilogue —
+# untilize_with_unpadding before untilize, tilize_with_val_padding before tilize, typecast before copy,
+# the indexer rope (rotary_embedding_indexed) before its shared llama rope kernel, and every real op
+# before the trailing eltwise/unary epilogue. Codes chosen to match the tracy device-op names so the
+# existing per-call graph attribution (parse_percall + its alias sets) consumes this dump unchanged.
+# Verified against the tracy op-code counts/durations for deepseek_v32 warm/sparse.
+_OP_CODE_RULES = (
+    # ring_mla (dense) fuses a ring all-gather with the joint-SDPA compute; its compute kernel lives under
+    # transformer/sdpa/ (ring_joint_sdpa.cpp), so it must be matched BEFORE the generic sparse-SDPA rule.
+    ("/ring_joint_sdpa", "RingJointSDPA"),
+    ("/ring_attention_all_gather", "RingJointSDPA"),
+    ("/transformer/sdpa/", "SDPA"),
+    ("/indexer_score/", "IndexerScore"),
+    ("/topk_large_indices/", "TopkLargeIndices"),
+    ("/ccl/all_gather_async/", "AllGatherAsync"),
+    ("/ccl/reduce_scatter_minimal_async/", "ReduceScatterMinimalAsync"),
+    ("/ccl/broadcast/", "AllBroadcast"),
+    ("/nlp_create_qkv_heads", "NlpCreateHeads"),
+    ("/nlp_concat_heads", "NlpConcatHeads"),
+    ("/rotary_embedding_indexed/", "RotaryEmbeddingIndexed"),
+    ("/rotary_embedding_llama/", "RotaryEmbeddingLlama"),
+    ("/update_padded_kv_cache/", "UpdateCache"),
+    ("/fast_reduce_nc/", "FastReduceNC"),
+    ("/matmul/", "Matmul"),
+    ("/layernorm/", "LayerNorm"),
+    ("/untilize_with_unpadding/", "UntilizeWithUnpadding"),
+    ("/tilize_with_val_padding/", "TilizeWithValPadding"),
+    ("/untilize/", "Untilize"),
+    ("/tilize/", "Tilize"),
+    ("/concat/", "Concat"),
+    ("/permute/", "Permute"),
+    ("/slice/", "Slice"),
+    ("/fill_pad/", "FillPad"),
+    ("/typecast/", "Typecast"),
+    ("/copy/", "Copy"),
+    ("/binary", "BinaryNg"),
+    ("/unary", "UnaryEltwise"),
+)
+
+
+def _op_code(kernel_sources) -> str:
+    """Translate a program's kernel-source paths to a tracy-style OP CODE (one program = one op), so the
+    per-call dump — and the summary table — carry op identity the tracy graph pipeline already understands.
+    Priority match over _OP_CODE_RULES (op-defining kernel wins over helpers/epilogue); falls back to the
+    coarse operations-dir label for any op not in the table."""
+    paths = "\n".join(src.replace("\\", "/") for src in kernel_sources)
+    for needle, code in _OP_CODE_RULES:
+        if needle in paths:
+            return code
+    return _op_label(kernel_sources)
+
+
+def _write_ops_dump(out_dir: str, name_root: str, forwards: list) -> str:
+    """Execution-ordered per-call CSV — the RT analog of tracy's ops_perf_results. One device-collapsed
+    row per program (duration = max across chips) per forward, in program order (the per_program dict is
+    keyed by first arrival, which equals device execution order — see _profile_forward). Also carries the
+    raw kernel_sources so the op-code translation can be authored/verified from real data."""
+    path = os.path.join(out_dir, f"{name_root}_ops.csv")
+    with open(path, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["forward", "seq", "runtime_id", "OP CODE", "DEVICE KERNEL DURATION [ns]", "kernel_sources"])
+        for forward_index, per_program in enumerate(forwards):
+            for seq, (runtime_id, info) in enumerate(per_program.items()):
+                w.writerow(
+                    [
+                        forward_index,
+                        seq,
+                        runtime_id,
+                        _op_code(info["kernel_sources"]),
+                        f"{info['duration_ns']:.3f}",
+                        "|".join(info["kernel_sources"]),
+                    ]
+                )
+    return path
+
+
 def _profile_forward(mesh_device, run_fn) -> dict:
     """Profile one region and collapse the device dimension: return {runtime_id -> {"duration_ns",
     "kernel_sources"}} where duration_ns is the MAX across chips for that program (slowest chip = that
     program's critical path). Mirrors PR #49840's _profile_programs. runtime_id 0 is the profiler's
-    sentinel and is skipped."""
+    sentinel and is skipped. The dict preserves first-arrival order, which equals device execution
+    (dispatch) order — the profiler delivers records in program order; verified equal to the device
+    start-tick order across every case/forward — so callers get the ops in program order for free."""
     _, records = profile_realtime_program(
         mesh_device, run_fn, collect_all=True, record_timeout_seconds=RT_RECORD_TIMEOUT_S
     )
@@ -436,8 +522,10 @@ def _profile_forward(mesh_device, run_fn) -> dict:
             continue
         duration_ns = float(record["duration_ns"])
         current = per_program.get(runtime_id)
-        if current is None or duration_ns > current["duration_ns"]:
+        if current is None:
             per_program[runtime_id] = {"duration_ns": duration_ns, "kernel_sources": record["kernel_sources"]}
+        else:
+            current["duration_ns"] = max(current["duration_ns"], duration_ns)
     assert per_program, "real-time profiler returned no valid program records for the measured forward"
     return per_program
 
@@ -445,7 +533,7 @@ def _profile_forward(mesh_device, run_fn) -> dict:
 def _programs_to_frame(per_program: dict, dur_col: str) -> pd.DataFrame:
     """One row per device program: (OP CODE label, critical-path duration)."""
     return pd.DataFrame(
-        [{"OP CODE": _op_label(info["kernel_sources"]), dur_col: info["duration_ns"]} for info in per_program.values()]
+        [{"OP CODE": _op_code(info["kernel_sources"]), dur_col: info["duration_ns"]} for info in per_program.values()]
     )
 
 
@@ -628,7 +716,7 @@ def test_mla_chunked_perf(mesh_device, variant, scenario, attn_mode, config_only
             f"critical-path device-kernel time over the {'prefill' if is_cold else 'chunk'} "
             f"(realtime profiler; per-program max across chips): "
             f"{total_ns/1e6:.3f} ms across {int(by_op['count'].sum())} device programs",
-            "(OP CODE = kernel-derived op label; see module docstring)",
+            "(OP CODE = tracy-style op code mapped from kernel sources; see module docstring)",
             header,
             "-" * len(header),
             *rows,
@@ -641,6 +729,10 @@ def test_mla_chunked_perf(mesh_device, variant, scenario, attn_mode, config_only
     csv_out = _scenario_csv(out_dir, scenario, variant.name, attn_mode)
     by_op.reset_index().to_csv(csv_out, index=False)
     logger.info(f"per-op CSV written to {os.path.abspath(csv_out)}")
+
+    if RT_OPS_DUMP:
+        ops_csv = _write_ops_dump(out_dir, os.path.splitext(os.path.basename(csv_out))[0], forwards)
+        logger.info(f"per-call ops dump written to {os.path.abspath(ops_csv)}")
 
     # Provenance: drop run_manifest_<scenario>.json next to the summary CSV so every dump self-documents
     # the commit, command, and device/mesh/fabric that produced it (config and per-op measurements are

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
@@ -42,9 +42,11 @@ CCL benchmarks (LoudBox: ~11× faster wall-clock). Two semantic notes versus the
     per-step critical-path quantity.
 
 Each measured ``forward()`` is profiled as its own region (register callback → run one forward →
-drain), because a cached op re-dispatched across the cold loop reuses its ``runtime_id`` — so
-per-forward regions are what make the cold per-iteration sum correct (and replace the old MLA_START
-signpost split). The run total is the sum of per-forward criticals.
+drain). ``runtime_id`` is a globally monotonic per-execution id (assigned per enqueue, cache hit or
+miss — ttnn ``device_operation.hpp``), so every op execution — including the same op across cold
+iterations — gets a distinct id; the max-collapse only merges the per-chip records of one execution.
+Per-forward regions are what attribute ops to each cold iteration (the per-iteration breakdown) and
+replace the old MLA_START signpost split. The run total is the sum of per-forward criticals.
 
 Single test (was a two-test tracy driver+impl split):
   * test_mla_chunked_perf — parametrized over [deepseek_v32, glm_5_1] × [warm, cold, long] ×
@@ -574,13 +576,15 @@ def _by_op(frame: pd.DataFrame, dur_col: str) -> pd.DataFrame:
 def test_mla_chunked_perf(mesh_device, variant, scenario, attn_mode, config_only):
     if PERF_SKIP_REASON:
         pytest.skip(PERF_SKIP_REASON)
-    _require_rt_profiler()
 
     # Workload is variant-specific (head counts differ); the mesh/SP is shared. Resolve per parametrized
     # variant so labels + head counts match the variant under test (module-level VARIANT may differ).
     workload, skip_reason = _detect_perf_workload(variant.name)
     if skip_reason:
         pytest.skip(skip_reason)
+    # Assert profiler activation only after skip checks pass: an unsupported system should skip with the
+    # informative reason above, not hard-fail here.
+    _require_rt_profiler()
 
     scenario_cfg = SCENARIOS[scenario]
     is_cold = scenario_cfg["loop"]

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Tracy perf harness for the DeepSeek V3.2 / GLM-5.1 MLA (DSA) chunked-prefill layer.
+Realtime-profiler perf harness for the DeepSeek V3.2 / GLM-5.1 MLA (DSA) chunked-prefill layer.
 
 Production scenario (defaults): process one **5k-token chunk** with **50k tokens already cached**,
 on the Galaxy **SP=8 × TP=4** mesh.
@@ -21,33 +21,51 @@ replicated full-depth (= the box-local cache), so on smaller boxes it holds a pr
 prefix than Galaxy — only Galaxy exercises the true 50k (or 0.5M) indexer/top-k depth; smaller boxes
 under-represent any op that scales with the replicated key-cache length.
 No reference values: this just runs the real device forward and reports per-op device-kernel time.
-Multi-chip rows are device-collapsed (compute=max, collectives=avg across chips) via merge_device_rows
-so the reported time is per-step critical path, not the ~8× over-count of summing parallel device rows.
 
-Three scenarios (DS_PERF_SCENARIO; the driver sweeps all three):
+Profiler — realtime (lightweight), in-process (replaces Tracy)
+--------------------------------------------------------------
+Timing comes from the in-process realtime device profiler
+(``tests/ttnn/profiling/realtime_profiler_utils.profile_realtime_program``), not Tracy. It is
+auto-enabled by device open on eligible hardware (real Blackhole, WORKER dispatch, fabric-tensix
+datamover off); the test gates on ``ttnn.device.IsProgramRealtimeProfilerActive()``. This removes the
+Tracy subprocess, signposts, and ops-CSV re-parse — the same swap PR #49840 made for the sparse-MLA
+CCL benchmarks (LoudBox: ~11× faster wall-clock). Two semantic notes versus the Tracy harness:
+
+  * Reporting unit is the device **program** (one ``runtime_id`` per op dispatch), NOT Tracy's
+    ``OP CODE``. A record carries only kernel-source paths, so the ``OP CODE`` column here holds a
+    best-effort label derived from the kernel path (``.../operations/<name>/...``); it groups by op
+    kind but is kernel-derived, not Tracy's op code.
+  * Multi-chip collapse takes the **max** ``duration_ns`` across chips for every program (the slowest
+    chip gates that program's critical path). Tracy used max for compute and avg for collectives, so
+    collective-heavy numbers can differ a few percent (see PR #49840 deltas). Both express the same
+    per-step critical-path quantity.
+
+Each measured ``forward()`` is profiled as its own region (register callback → run one forward →
+drain), because a cached op re-dispatched across the cold loop reuses its ``runtime_id`` — so
+per-forward regions are what make the cold per-iteration sum correct (and replace the old MLA_START
+signpost split). The run total is the sum of per-forward criticals.
+
+Single test (was a two-test tracy driver+impl split):
+  * test_mla_chunked_perf — parametrized over [deepseek_v32, glm_5_1] × [warm, cold, long] ×
+    [sparse, dense]. Builds the DSA ttMLA (variant from the ``variant`` fixture) and, per scenario,
+    measures one forward over the (zero-init) block-cyclic caches (warm/long) or a chunk loop that
+    fills them (cold), profiling each forward under the realtime profiler. Prints a per-op table and
+    writes a per-(scenario, variant, mode) CSV under generated/profiler/<variant>_<mode>_mla_perf/.
+
+Three scenarios (the test sweeps all three):
   * warm — production step: one `chunk`-token forward at start=cache over a `cache`-length prefix. Both
     block-cyclic caches (indexer index_kv_cache + KVPE) are left at init — no warm-up forwards; for a perf
     proxy only op shapes/timing matter, and those are set by the full `total` prefix width the gather+score
     span, not the cache contents. Measures a single steady-state chunk.
   * cold — full cold prefill: forward chunks start=0,chunk,…,cache with real forwards that grow both
-    caches (both by per-chunk block-cyclic slab writes). The signposted region spans ALL chunks = the
+    caches (both by per-chunk block-cyclic slab writes). The measured region spans ALL chunks = the
     total cold-start prefill cost; the final chunk (start=cache) is exactly the `warm` step. Besides the
     aggregate per-op table, cold also emits a per-cache-fill-iteration breakdown (…_cold_by_iter.csv:
     iteration, cache_depth_tokens, total_ns, op_count) showing how the per-chunk critical path grows as
-    the cache fills — recovered by splitting the ops log on each forward's MLA_START marker.
+    the cache fills — recovered by profiling each forward as its own region.
   * long — like `warm` but with a 0.5M-token Galaxy cache (512000 = 100 chunks), to profile a single
     chunk over a long prefix. Like the others the cache scales by SP/8, so per-chip depth stays
     Galaxy-equal on every box (LoudBox=128k, QuietBox=64k box-local cache).
-
-Two-test pattern (mirrors tests/nightly/blackhole/sdpa):
-  * test_mla_chunked_perf_impl  — the work to profile. Builds the DSA ttMLA (variant from DS_PERF_VARIANT)
-    and, per DS_PERF_SCENARIO, either measures one forward over the (zero-init) block-cyclic caches
-    (warm/long) or forwards a chunk loop that fills them (cold), wrapping the measured forward(s) in
-    signpost("start"/"stop"). Run under tracy.
-  * test_mla_chunked_perf       — the driver, parametrized over [deepseek_v32, glm_5_1] × [warm, cold,
-    long] × [sparse, dense]. Spawns the impl under tracy via run_device_profiler (passing DS_PERF_VARIANT
-    + DS_PERF_SCENARIO + DS_PERF_ATTN_MODE), reads the device ops log for the signposted region, prints a
-    per-op table, and writes a per-(scenario, variant, mode) CSV under the per-(variant, mode) profiler dir.
 
 variant axis — deepseek_v32 (128 q-heads / 64 index heads) vs glm_5_1 (64 / 32). Both run the SAME TP=4
   meshes: GLM's thin per-chip head shard (64/4=16 < 32) is handled by the head→sequence reshard in
@@ -66,13 +84,13 @@ Run (Blackhole Galaxy/LoudBox/QuietBox) — all combos (2 variants × 3 scenario
     pytest -m perf ...::test_mla_chunked_perf -k "glm_5_1 and cold and sparse" -s
     pytest -m perf ...::test_mla_chunked_perf -k "deepseek_v32 and dense" -s
 
-Knobs (env): DS_PERF_VARIANT (deepseek_v32|glm_5_1, default deepseek_v32 for a standalone impl run),
-DS_PERF_SCENARIO (warm|cold|long, default warm for a standalone impl run), DS_PERF_ATTN_MODE
-(sparse|dense, default sparse), DS_PERF_CACHE (default 51200), DS_PERF_CHUNK (default 5120),
-DS_PERF_LONG_CACHE (default 512000), DS_PERF_CSV (summary filename, per-scenario suffix appended; written
-under the tracy profiler dir generated/profiler/{variant}_{mode}_mla_perf/). DS_PERF_CHUNK is the
-Galaxy-global target chunk; smaller boxes scale BOTH the measured chunk and the cache by SP/8; cache must
-stay a whole chunk multiple.
+Knobs (env): DS_PERF_CACHE (default 51200), DS_PERF_CHUNK (default 5120), DS_PERF_LONG_CACHE (default
+512000), DS_PERF_CSV / DS_DENSE_PERF_CSV (summary filename, per-scenario suffix appended; written under
+generated/profiler/{variant}_{mode}_mla_perf/), DS_PERF_RT_TIMEOUT (realtime-profiler record drain
+ceiling in seconds, default 30). DS_PERF_CHUNK is the Galaxy-global target chunk; smaller boxes scale
+BOTH the measured chunk and the cache by SP/8; cache must stay a whole chunk multiple. DS_PERF_VARIANT /
+DS_PERF_SCENARIO / DS_PERF_ATTN_MODE remain as the module-level defaults used for mesh-shape detection,
+but the test itself sweeps the full matrix via parametrization.
 
 NOTE: warm/long leave both block-cyclic caches at zero init rather than warming with real chunks — only
 op shapes/timing matter here, not values, and those come from the full `total` prefix width (allocation),
@@ -86,7 +104,6 @@ import datetime
 import json
 import os
 from dataclasses import dataclass
-from unittest import mock
 
 import pandas as pd
 import pytest
@@ -105,6 +122,7 @@ from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config, get_max_payload_size
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
 from models.demos.deepseek_v3_d_p.utils.test_utils import WH_WORKER_L1_SIZE
+from tests.ttnn.profiling.realtime_profiler_utils import profile_realtime_program
 
 CACHE_TOKENS = int(os.environ.get("DS_PERF_CACHE", 51200))  # 50 * 1024 already cached
 CHUNK_TOKENS = int(os.environ.get("DS_PERF_CHUNK", 5120))  # 5 * 1024 processed this step
@@ -113,28 +131,34 @@ CHUNK_TOKENS = int(os.environ.get("DS_PERF_CHUNK", 5120))  # 5 * 1024 processed 
 # DS_PERF_LONG_CACHE (must stay a chunk multiple), e.g. 522240 (=102 chunks ≈ 512*1024).
 LONG_CACHE_TOKENS = int(os.environ.get("DS_PERF_LONG_CACHE", 512000))
 # attn_mode axis: sparse (v3.2 DSA indexer + sparse_sdpa) vs dense (v3.1 full-prefix ring MLA — no
-# indexer, no top-k), a baseline to compare the sparse impl against. Each mode writes its own tracy
-# profiler subdir + per-scenario CSVs so the two runs never clobber and stay directly comparable.
+# indexer, no top-k), a baseline to compare the sparse impl against. Each mode writes its own profiler
+# subdir + per-scenario CSVs so the two runs never clobber and stay directly comparable.
 ATTN_MODES = ("sparse", "dense")
-ATTN_MODE = os.environ.get("DS_PERF_ATTN_MODE", "sparse")  # the impl selects its mode from this
+ATTN_MODE = os.environ.get("DS_PERF_ATTN_MODE", "sparse")  # module-level default (mesh-shape detection)
 # Model-variant axis: deepseek_v32 (128 q-heads / 64 index heads) vs glm_5_1 (64 / 32). BOTH run the
 # SAME TP=4 meshes — GLM's thin per-chip head shard (64/4=16 < 32) is handled by the head→sequence
 # reshard in ttMLA._sparse_mla (#48727) plus the head-replicated seq-sharded indexer, so no TP cap
 # applies. Every model dimension comes from the single-source reference config
-# (reference/{deepseek_v3_2,glm_5_1}_config.py), never hardcoded here. The impl selects its variant
-# from DS_PERF_VARIANT (the driver sweeps both).
+# (reference/{deepseek_v3_2,glm_5_1}_config.py), never hardcoded here.
 VARIANTS = ("deepseek_v32", "glm_5_1")
 VARIANT = os.environ.get("DS_PERF_VARIANT", "deepseek_v32")
 _CONFIG_BUILDERS = {"deepseek_v32": deepseek_v32_hf_config, "glm_5_1": glm_hf_config}
 
-# Fabric transport being profiled — single source for BOTH the impl's device_params and the run manifest,
-# so the recorded provenance can never drift from what actually ran (FABRIC_2D is the production transport;
-# FABRIC_1D exhibited the multi-hop line-broadcast hang).
+# Fabric transport being profiled — single source for BOTH the device_params and the run manifest, so the
+# recorded provenance can never drift from what actually ran (FABRIC_2D is the production transport;
+# FABRIC_1D exhibited the multi-hop line-broadcast hang). FABRIC_2D + fabric_router_config leaves the
+# fabric-tensix datamover off, so the realtime profiler stays eligible (see PR #49840 CCL benchmarks).
 PERF_FABRIC = ttnn.FabricConfig.FABRIC_2D
+
+# Realtime-profiler record drain ceiling. The receiver thread delivers records asynchronously; the
+# wrapper stops once no new record has landed for its settle window, bounded by this ceiling. A generous
+# default covers a many-program forward across up to 32 chips; each forward is profiled as its own
+# (volume-bounded) region so this is a safety ceiling, not the expected wait.
+RT_RECORD_TIMEOUT_S = float(os.environ.get("DS_PERF_RT_TIMEOUT", 30.0))
 
 
 def _subdir(variant: str, mode: str) -> str:
-    """Per-(variant, mode) tracy profiler subdir (raw device reports + per-scenario summary CSVs). Keeps
+    """Per-(variant, mode) profiler subdir (per-scenario summary CSVs + run manifest). Keeps
     deepseek_v32/glm_5_1 × sparse/dense runs from clobbering each other."""
     return f"{variant}_{mode}_mla_perf"
 
@@ -143,11 +167,11 @@ def _csv_name(variant: str, mode: str) -> str:
     return os.environ.get("DS_PERF_CSV" if mode == "sparse" else "DS_DENSE_PERF_CSV", f"{_subdir(variant, mode)}.csv")
 
 
-# Three profiling scenarios (select the impl's via DS_PERF_SCENARIO; the driver sweeps all three):
+# Three profiling scenarios (the test sweeps all three):
 #   warm  — the production step: one chunk over a pre-filled `cache` (indexer K-cache populated
 #           directly, no warm-up forwards). Measures a single steady-state chunk.
 #   cold  — full cold prefill: iteratively forward chunks start=0,chunk,…,cache (real forwards that
-#           grow the caches). The signposted region spans ALL chunks = total cold-start prefill cost;
+#           grow the caches). The measured region spans ALL chunks = total cold-start prefill cost;
 #           the final chunk (start=cache) is exactly the `warm` case.
 #   long  — like `warm` but with a 0.5M-token cache, to profile a single chunk over a long prefix.
 SCENARIOS = {
@@ -158,13 +182,23 @@ SCENARIOS = {
 SCENARIO = os.environ.get("DS_PERF_SCENARIO", "warm")
 
 
+_REPO_DIR = os.path.dirname(os.path.abspath(__file__))
+# Repo root is five levels up (sparse_mla → tests → deepseek_v3_d_p → demos → models → <root>).
+_REPO_ROOT = os.path.normpath(os.path.join(_REPO_DIR, *([os.pardir] * 5)))
+
+
+def _output_dir(subdir: str) -> str:
+    """Per-(variant, mode) output dir for summary CSVs + run manifest. Replaces Tracy's
+    PROFILER_ARTIFACTS_DIR now that profiling is in-process (no tracy report tree)."""
+    d = os.path.join(_REPO_ROOT, "generated", "profiler", subdir)
+    os.makedirs(d, exist_ok=True)
+    return d
+
+
 def _scenario_csv(out_dir, scenario: str, variant: str, mode: str) -> str:
-    """Per-(scenario, variant, mode) summary CSV path under the tracy profiler dir (next to the raw reports)."""
+    """Per-(scenario, variant, mode) summary CSV path under the output dir."""
     root, ext = os.path.splitext(_csv_name(variant, mode))
     return os.path.join(out_dir, f"{root}_{scenario}{ext}")
-
-
-_REPO_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 def _git_head() -> dict:
@@ -215,7 +249,7 @@ def _git_head() -> dict:
 
 
 def _write_run_manifest(report_dir, *, variant, scenario, attn_mode, command, workload) -> None:
-    """Drop a lean run_manifest.json into the tracy ``reports/<ts>/`` dir. Records ONLY what cannot be
+    """Drop a lean run_manifest_<scenario>.json into the output dir. Records ONLY what cannot be
     reconstructed from git (given the commit) or from the co-located ops CSV:
       * commit / branch — the code-state anchor (read subprocess-free from .git; no dirty flag — the
         workflow commits before profiling);
@@ -224,22 +258,22 @@ def _write_run_manifest(report_dir, *, variant, scenario, attn_mode, command, wo
       * command — a copy-paste reproducer (env-prefixed).
     Deliberately omitted because they are recoverable: commit subject/time & the full model config (from
     ``git show <commit>`` + reference/{variant}_config.py), the workload sizes (derived from config + mesh
-    + scenario), and per-op measurements (the ops_perf_results CSV sitting in this same dir). Never raises."""
+    + scenario), and per-op measurements (the summary CSV sitting in this same dir). Never raises."""
     try:
-        so = os.path.normpath(os.path.join(_REPO_DIR, *([os.pardir] * 5), "ttnn", "ttnn", "_ttnn.so"))
+        so = os.path.join(_REPO_ROOT, "ttnn", "ttnn", "_ttnn.so")
         so_mtime = (
             datetime.datetime.fromtimestamp(os.path.getmtime(so), datetime.timezone.utc).isoformat()
             if os.path.exists(so)
             else None
         )
         reproducer = (
-            f"DS_PERF_VARIANT={variant} DS_PERF_SCENARIO={scenario} DS_PERF_ATTN_MODE={attn_mode} "
             f"DS_PERF_CACHE={CACHE_TOKENS} DS_PERF_CHUNK={CHUNK_TOKENS} DS_PERF_LONG_CACHE={LONG_CACHE_TOKENS} "
-            f"{command}"
+            f"{command} -k '{variant} and {scenario} and {attn_mode}'"
         )
         head = _git_head()
         manifest = {
-            "schema_version": 2,
+            "schema_version": 3,
+            "profiler": "realtime",
             "variant": variant,
             "scenario": scenario,
             "attn_mode": attn_mode,
@@ -255,7 +289,7 @@ def _write_run_manifest(report_dir, *, variant, scenario, attn_mode, command, wo
             "build": {"so_mtime": so_mtime},
             "command": reproducer,
         }
-        path = os.path.join(report_dir, "run_manifest.json")
+        path = os.path.join(report_dir, f"run_manifest_{scenario}.json")
         with open(path, "w") as f:
             json.dump(manifest, f, indent=2)
         logger.info(f"run manifest written to {path}")
@@ -356,7 +390,79 @@ def _require_perf(request):
 
 
 # ============================================================================
-# Inner: the work to profile (run under tracy by the driver below)
+# Realtime-profiler helpers (mirror PR #49840 CCL harness + SDPA nightly suite)
+# ============================================================================
+def _require_rt_profiler() -> None:
+    """The realtime profiler is auto-enabled on eligible hardware; a False here means the current
+    dispatch/fabric config disabled it (see realtime_profiler_manager eligibility) — fail loudly rather
+    than silently mis-measure with an empty record set."""
+    if not ttnn.device.IsProgramRealtimeProfilerActive():
+        pytest.fail("Real-time profiler must be active for sparse MLA perf checks (eligible Blackhole HW required)")
+
+
+def _op_label(kernel_sources) -> str:
+    """Best-effort human label for a device program from its kernel-source paths. RT records carry no
+    Tracy OP CODE, so derive the op kind from the ttnn operations path (``.../operations/<name>/...``,
+    unwrapping an ``experimental`` prefix); fall back to the kernel basenames. Programs of the same op
+    kind share kernels, so this groups like the old per-OP-CODE table — kernel-derived, not exact."""
+    names = set()
+    for src in kernel_sources:
+        parts = src.replace("\\", "/").split("/")
+        if "operations" in parts:
+            i = parts.index("operations") + 1
+            if i < len(parts):
+                name = parts[i]
+                if name == "experimental" and i + 1 < len(parts):
+                    name = parts[i + 1]
+                names.add(name)
+    if names:
+        return "+".join(sorted(names))
+    basenames = {os.path.splitext(os.path.basename(s))[0] for s in kernel_sources}
+    return "+".join(sorted(basenames)) if basenames else "unknown"
+
+
+def _profile_forward(mesh_device, run_fn) -> dict:
+    """Profile one region and collapse the device dimension: return {runtime_id -> {"duration_ns",
+    "kernel_sources"}} where duration_ns is the MAX across chips for that program (slowest chip = that
+    program's critical path). Mirrors PR #49840's _profile_programs. runtime_id 0 is the profiler's
+    sentinel and is skipped."""
+    _, records = profile_realtime_program(
+        mesh_device, run_fn, collect_all=True, record_timeout_seconds=RT_RECORD_TIMEOUT_S
+    )
+    per_program: dict = {}
+    for record in records:
+        runtime_id = record["runtime_id"]
+        if not runtime_id:
+            continue
+        duration_ns = float(record["duration_ns"])
+        current = per_program.get(runtime_id)
+        if current is None or duration_ns > current["duration_ns"]:
+            per_program[runtime_id] = {"duration_ns": duration_ns, "kernel_sources": record["kernel_sources"]}
+    assert per_program, "real-time profiler returned no valid program records for the measured forward"
+    return per_program
+
+
+def _programs_to_frame(per_program: dict, dur_col: str) -> pd.DataFrame:
+    """One row per device program: (OP CODE label, critical-path duration)."""
+    return pd.DataFrame(
+        [{"OP CODE": _op_label(info["kernel_sources"]), dur_col: info["duration_ns"]} for info in per_program.values()]
+    )
+
+
+def _by_op(frame: pd.DataFrame, dur_col: str) -> pd.DataFrame:
+    """Aggregate per-op-label: count, total_ns, avg_ns, pct — sorted by total desc (old table shape)."""
+    total_ns = frame[dur_col].sum()
+    by_op = (
+        frame.groupby("OP CODE")[dur_col]
+        .agg(count="count", total_ns="sum", avg_ns="mean")
+        .sort_values("total_ns", ascending=False)
+    )
+    by_op["pct"] = 100.0 * by_op["total_ns"] / total_ns
+    return by_op
+
+
+# ============================================================================
+# The perf test — build the DSA ttMLA, profile the measured forward(s), report
 # ============================================================================
 @pytest.mark.parametrize("mesh_device", [PERF_WORKLOAD.mesh_shape], ids=[PERF_WORKLOAD.id], indirect=True)
 @pytest.mark.parametrize(
@@ -372,25 +478,34 @@ def _require_perf(request):
     ids=["fabric2d"],
     indirect=True,
 )
-@pytest.mark.parametrize("variant", [VARIANT], indirect=True, ids=[VARIANT])
+@pytest.mark.parametrize("attn_mode", list(ATTN_MODES), ids=list(ATTN_MODES))
+@pytest.mark.parametrize("scenario", list(SCENARIOS), ids=list(SCENARIOS))
+@pytest.mark.parametrize("variant", list(VARIANTS), indirect=True, ids=list(VARIANTS))
 @pytest.mark.skipif(os.environ.get("CI") == "true", reason="Performance test — skip on CI")
 @pytest.mark.timeout(0)
-def test_mla_chunked_perf_impl(mesh_device, device_params, variant, config_only):
-    from tracy import signpost
-
+def test_mla_chunked_perf(mesh_device, variant, scenario, attn_mode, config_only):
     if PERF_SKIP_REASON:
         pytest.skip(PERF_SKIP_REASON)
+    _require_rt_profiler()
 
-    scenario = SCENARIOS[SCENARIO]
-    is_cold = scenario["loop"]
-    has_indexer = ATTN_MODE == "sparse"  # dense baseline drops the indexer -> full-prefix ring MLA
+    # Workload is variant-specific (head counts differ); the mesh/SP is shared. Resolve per parametrized
+    # variant so labels + head counts match the variant under test (module-level VARIANT may differ).
+    workload, skip_reason = _detect_perf_workload(variant.name)
+    if skip_reason:
+        pytest.skip(skip_reason)
+
+    scenario_cfg = SCENARIOS[scenario]
+    is_cold = scenario_cfg["loop"]
+    has_indexer = attn_mode == "sparse"  # dense baseline drops the indexer -> full-prefix ring MLA
+    subdir = _subdir(variant.name, attn_mode)  # per-(variant, mode) dir: runs never clobber each other
     sp_axis, tp_axis = 0, 1
     sp, tp = mesh_device.shape
     # cache scales per box (sp/GALAXY_SP) like the chunk, so every box profiles the Galaxy per-chip
     # workload: constant chunks-to-fill and Galaxy-equal per-chip depth (see _local_cache_tokens).
-    cache, chunk = _local_cache_tokens(scenario["cache"], sp), PERF_WORKLOAD.chunk_tokens
+    galaxy_cache = scenario_cfg["cache"]
+    cache, chunk = _local_cache_tokens(galaxy_cache, sp), workload.chunk_tokens
     total = cache + chunk
-    assert (sp, tp) == PERF_WORKLOAD.mesh_shape, f"expected mesh {PERF_WORKLOAD.mesh_shape}, got {(sp, tp)}"
+    assert (sp, tp) == workload.mesh_shape, f"expected mesh {workload.mesh_shape}, got {(sp, tp)}"
     # cache must be a whole number of chunks: the cold loop steps by `chunk`, and the indexed rope
     # table (get_rope_tensors_indexed) requires total = cache + chunk to be a multiple of chunk.
     assert cache % chunk == 0, f"cache {cache} must be a whole number of {chunk}-token chunks"
@@ -469,91 +584,33 @@ def test_mla_chunked_perf_impl(mesh_device, device_params, variant, config_only)
         mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims),
     )
 
-    # cold: forward every chunk start=0,chunk,…,cache (the last, start=cache, is the warm step) and
-    # signpost the WHOLE loop = total cold-start prefill cost. warm/long: one forward at start=cache.
+    # cold: forward every chunk start=0,chunk,…,cache (the last, start=cache, is the warm step). warm/long:
+    # one forward at start=cache. Each forward is profiled as its OWN realtime-profiler region: a cached op
+    # reuses its runtime_id across forwards, so per-forward regions are what make the cold per-iteration
+    # sum correct (and replace the old signposted-region split).
     starts = list(range(0, cache + chunk, chunk)) if is_cold else [cache]
     logger.info(
-        f"profiling {PERF_WORKLOAD.system_name} {ATTN_MODE}/{SCENARIO} proxy: {len(starts)} × {chunk}-token "
+        f"profiling {workload.system_name} {attn_mode}/{scenario} proxy: {len(starts)} × {chunk}-token "
         f"chunk(s) filling to end_pos={total} on SP={sp}×TP={tp}; local chunk={chunk // sp}, "
         f"local MLA heads={config.num_attention_heads // tp}"
         + (f", local indexer heads={config.index_n_heads // tp}" if has_indexer else " (dense: no indexer)")
     )
-    signpost("start")
-    for start in starts:
+
+    def _one_forward(start):
         out = mla.forward(tt_x, rope, kvpe_cache, actual_start=start, index_kv_cache=index_kv_cache)
         ttnn.deallocate(out)
-    ttnn.synchronize_device(mesh_device)
-    signpost("stop")
 
+    forwards = []  # one {runtime_id -> {...}} per measured forward (device-collapsed to critical path)
+    for start in starts:
+        ttnn.synchronize_device(mesh_device)  # drain prior programs so only this forward contributes records
+        forwards.append(_profile_forward(mesh_device, lambda start=start: _one_forward(start)))
 
-# ============================================================================
-# Outer: drive the impl under tracy, post-process, print + write CSV
-# ============================================================================
-@pytest.mark.parametrize("attn_mode", list(ATTN_MODES), ids=list(ATTN_MODES))
-@pytest.mark.parametrize("scenario", list(SCENARIOS), ids=list(SCENARIOS))
-@pytest.mark.parametrize("variant", list(VARIANTS), ids=list(VARIANTS))
-@pytest.mark.skipif(os.environ.get("CI") == "true", reason="perf test — run locally with tracy")
-@pytest.mark.timeout(0)
-def test_mla_chunked_perf(variant, scenario, attn_mode):
-    from tracy.common import PROFILER_ARTIFACTS_DIR
-    from tracy.process_model_log import run_device_profiler
+    dur_col = "DEVICE KERNEL DURATION [ns]"  # kept for downstream compatibility (holds RT critical-path ns)
+    frame = pd.concat([_programs_to_frame(pp, dur_col) for pp in forwards], ignore_index=True)
+    assert len(frame), "no device programs in the measured region — was the impl skipped (wrong device count)?"
 
-    # Workload is variant-specific (head counts differ); the mesh/SP is shared, but resolve per variant
-    # so labels + head counts are correct for the variant being driven (the parent's module-level VARIANT
-    # may differ from this parametrized variant).
-    workload, skip_reason = _detect_perf_workload(variant)
-    if skip_reason:
-        pytest.skip(skip_reason)
-
-    subdir = _subdir(variant, attn_mode)  # per-(variant, mode) dir: runs never clobber each other
-
-    # merge_device_rows: the deepseek_v3_d_p / tt_transformers convention for collapsing the device
-    # dimension of a multi-chip Tracy ops log (see models/demos/deepseek_v3_d_p/utils/perf_utils.py).
-    from models.tt_transformers.tests.test_utils import merge_device_rows
-    from tests.nightly.sdpa_perf_utils import post_process_ops_log
-
-    galaxy_cache = SCENARIOS[scenario]["cache"]
-    cache = _local_cache_tokens(galaxy_cache, workload.sp)  # box-scaled (matches the impl)
-    is_cold = SCENARIOS[scenario]["loop"]
-
-    # The impl is skipif(CI=="true"); CI=false in the subprocess lets it run there (mirrors the
-    # tests/nightly/blackhole/sdpa perf pattern). DS_PERF_SCENARIO selects which scenario the impl runs.
-    # The driver itself opens no device, so when the gate is run by node-id only the tracy subprocess
-    # opens the board — no parent CHIP_IN_USE lock contention.
-    command = (
-        "pytest -m perf models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py"
-        "::test_mla_chunked_perf_impl"
-    )
-    # run_device_profiler defaults op_support_count to ~1333 ops/device — the tracy device-profiler
-    # ring buffer silently drops ops beyond it. cold forwards ~11 chunks (~800 ops); raise the cap so a
-    # future op-count bump can't silently truncate the log (which would corrupt the per-op totals).
-    with mock.patch.dict(
-        os.environ,
-        {"CI": "false", "DS_PERF_SCENARIO": scenario, "DS_PERF_ATTN_MODE": attn_mode, "DS_PERF_VARIANT": variant},
-    ):
-        run_device_profiler(command, subdir, device_analysis_types=["device_kernel_duration"], op_support_count=5000)
-
-    dur_col = "DEVICE KERNEL DURATION [ns]"
-    # Rows between signpost("start") and signpost("stop") = the measured chunk's device ops, with ONE
-    # ROW PER (op call × mesh chip). On the selected SP×TP mesh every op runs across chips in parallel,
-    # so the raw rows must NOT be summed — that over-counts wall-clock by ~num_devices. Collapse
-    # the device dimension to one row per logical op call with the standard merge_device_rows rule:
-    #   * compute ops -> MAX duration across chips (the slowest chip gates the step = critical path)
-    #   * collectives -> AVG duration across chips (all chips run the same collective together)
-    # region = the sliced signpost("start")..signpost("stop") window, still holding the per-forward
-    # MLA_START/MLA_END signpost rows (used below to split cold into per-iteration segments).
-    region = post_process_ops_log(subdir, has_signposts=True)
-    region[dur_col] = pd.to_numeric(region[dur_col], errors="coerce")
-    df = merge_device_rows(region)  # aggregate; filters to tt_dnn_device rows internally
-    assert len(df), "no device ops in the signposted region — was the impl skipped (wrong device count)?"
-
-    total_ns = df[dur_col].sum()
-    by_op = (
-        df.groupby("OP CODE")[dur_col]
-        .agg(count="count", total_ns="sum", avg_ns="mean")
-        .sort_values("total_ns", ascending=False)
-    )
-    by_op["pct"] = 100.0 * by_op["total_ns"] / total_ns
+    total_ns = frame[dur_col].sum()
+    by_op = _by_op(frame, dur_col)
 
     # Manual formatting (pandas to_string can truncate long tables) — print every op.
     header = f"{'OP CODE':<44}{'count':>7}{'total_ms':>12}{'avg_us':>12}{'pct':>8}"
@@ -564,13 +621,14 @@ def test_mla_chunked_perf(variant, scenario, attn_mode):
     span = f"full cold prefill 0→{cache}-tok cache" if is_cold else f"one chunk @ {cache}-tok cache"
     table = "\n".join(
         [
-            f"{variant} MLA chunked perf [{attn_mode}/{scenario}] — {workload.system_name} proxy "
+            f"{variant.name} MLA chunked perf [{attn_mode}/{scenario}] — {workload.system_name} proxy "
             f"{workload.chunk_tokens}-tok chunk, {span}, SP={workload.sp}×TP={workload.tp}",
             f"Galaxy target: {CHUNK_TOKENS}-tok chunk @ {galaxy_cache}-tok cache, SP={GALAXY_SP}×TP={GALAXY_TP}; "
             f"local chunk={CHUNK_TOKENS // GALAXY_SP}, local MLA heads={workload.num_attention_heads // GALAXY_TP}",
             f"critical-path device-kernel time over the {'prefill' if is_cold else 'chunk'} "
-            f"(device-collapsed: compute=max, collectives=avg across chips): "
-            f"{total_ns/1e6:.3f} ms across {int(by_op['count'].sum())} op calls",
+            f"(realtime profiler; per-program max across chips): "
+            f"{total_ns/1e6:.3f} ms across {int(by_op['count'].sum())} device programs",
+            "(OP CODE = kernel-derived op label; see module docstring)",
             header,
             "-" * len(header),
             *rows,
@@ -579,72 +637,51 @@ def test_mla_chunked_perf(variant, scenario, attn_mode):
     logger.info("\n" + table)
     print("\n" + table)  # ensure full table reaches stdout even if logging is filtered
 
-    csv_out = _scenario_csv(PROFILER_ARTIFACTS_DIR / subdir, scenario, variant, attn_mode)
+    out_dir = _output_dir(subdir)
+    csv_out = _scenario_csv(out_dir, scenario, variant.name, attn_mode)
     by_op.reset_index().to_csv(csv_out, index=False)
     logger.info(f"per-op CSV written to {os.path.abspath(csv_out)}")
 
-    # Provenance: drop run_manifest.json next to the raw report so every dump self-documents the commit,
-    # command, and device/mesh/fabric that produced it (config and per-op measurements are deliberately
-    # omitted — recoverable from git + reference config + the co-located ops CSV). The reports/<ts>/ dir
-    # is never clobbered, so this survives across subsequent runs (unlike the summary CSV).
-    try:
-        from tracy.process_model_log import get_latest_ops_log_filename
+    # Provenance: drop run_manifest_<scenario>.json next to the summary CSV so every dump self-documents
+    # the commit, command, and device/mesh/fabric that produced it (config and per-op measurements are
+    # deliberately omitted — recoverable from git + reference config + the co-located ops CSV).
+    command = (
+        "pytest -m perf models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py::test_mla_chunked_perf -s"
+    )
+    _write_run_manifest(
+        out_dir, variant=variant.name, scenario=scenario, attn_mode=attn_mode, command=command, workload=workload
+    )
 
-        report_dir = os.path.dirname(get_latest_ops_log_filename(subdir))
-        _write_run_manifest(
-            report_dir,
-            variant=variant,
-            scenario=scenario,
-            attn_mode=attn_mode,
-            command=command,
-            workload=workload,
-        )
-    except Exception as e:  # noqa: BLE001 — provenance must never break the run
-        logger.warning(f"run manifest: could not resolve report dir ({e}); skipping")
+    # cold only: per-cache-fill-iteration breakdown. The aggregate above sums all chunks; this shows how
+    # the per-chunk critical path grows as the cache fills (the point of the cold scenario). Each forward
+    # was profiled as its own region, so iteration i is simply forwards[i] — no signpost splitting.
+    if not is_cold:
+        return
+    per_op_rows, totals = [], []
+    for i, per_program in enumerate(forwards):
+        seg = _programs_to_frame(per_program, dur_col)
+        tot = seg[dur_col].sum()
+        g = _by_op(seg, dur_col).reset_index()
+        g.insert(0, "cache_depth_tokens", i * chunk)  # tokens already cached when this chunk ran
+        g.insert(0, "iteration", i)
+        per_op_rows.append(g)
+        totals.append((i, i * chunk, tot, len(g)))
+    by_iter_op = pd.concat(per_op_rows, ignore_index=True)
 
-    # cold only: per-cache-fill-iteration breakdown. The aggregate above sums all chunks; this shows
-    # how the per-chunk critical path grows as the cache fills (the point of the cold scenario). Each
-    # forward emits its own MLA_START marker, so split the region on those and device-collapse each
-    # segment independently (merge_device_rows drops the interleaved signpost rows internally).
-    if is_cold:
-        ri = region.reset_index(drop=True)
-        starts = list(ri.index[ri["OP CODE"] == "MLA_START"])
-        bounds = starts + [len(ri)]
-        chunk = workload.chunk_tokens
-        # Per-op × per-iteration: the SAME per-op table as the aggregate above (OP CODE, count,
-        # total_ns, avg_ns, pct — sorted desc), but computed for each iteration's segment and tagged
-        # with iteration + cache_depth_tokens, so each op's time can be tracked as the cache fills.
-        per_op_rows, totals = [], []
-        for i in range(len(starts)):
-            seg = merge_device_rows(ri.iloc[bounds[i] + 1 : bounds[i + 1]])
-            tot = seg[dur_col].sum()
-            g = (
-                seg.groupby("OP CODE")[dur_col]
-                .agg(count="count", total_ns="sum", avg_ns="mean")
-                .sort_values("total_ns", ascending=False)
-            )
-            g["pct"] = 100.0 * g["total_ns"] / tot
-            g = g.reset_index()
-            g.insert(0, "cache_depth_tokens", i * chunk)  # tokens already cached when this chunk ran
-            g.insert(0, "iteration", i)
-            per_op_rows.append(g)
-            totals.append((i, i * chunk, tot, len(g)))
-        by_iter_op = pd.concat(per_op_rows, ignore_index=True)
-
-        # stdout: compact per-iteration totals (the full per-op×iteration detail goes to the CSV — too
-        # many rows to print). pivot the CSV to a per-op-by-iteration matrix for charting an op's growth.
-        iter_header = f"{'iter':>4}{'cache_depth':>12}{'total_ms':>12}{'ops':>6}"
-        iter_table = "\n".join(
-            [
-                f"cold per-iteration critical path [{variant}/{workload.system_name}] "
-                f"(device-collapsed; last iter == the `warm` step):",
-                iter_header,
-                "-" * len(iter_header),
-                *(f"{i:>4}{d:>12}{t/1e6:>12.3f}{n:>6}" for i, d, t, n in totals),
-            ]
-        )
-        logger.info("\n" + iter_table)
-        print("\n" + iter_table)
-        iter_csv = _scenario_csv(PROFILER_ARTIFACTS_DIR / subdir, f"{scenario}_by_iter", variant, attn_mode)
-        by_iter_op.to_csv(iter_csv, index=False)
-        logger.info(f"per-op×iteration CSV written to {os.path.abspath(iter_csv)}")
+    # stdout: compact per-iteration totals (the full per-op×iteration detail goes to the CSV — too many
+    # rows to print). The CSV pivots to a per-op-by-iteration matrix for charting an op's growth.
+    iter_header = f"{'iter':>4}{'cache_depth':>12}{'total_ms':>12}{'ops':>6}"
+    iter_table = "\n".join(
+        [
+            f"cold per-iteration critical path [{variant.name}/{workload.system_name}] "
+            f"(realtime profiler; last iter == the `warm` step):",
+            iter_header,
+            "-" * len(iter_header),
+            *(f"{i:>4}{d:>12}{t/1e6:>12.3f}{n:>6}" for i, d, t, n in totals),
+        ]
+    )
+    logger.info("\n" + iter_table)
+    print("\n" + iter_table)
+    iter_csv = _scenario_csv(out_dir, f"{scenario}_by_iter", variant.name, attn_mode)
+    by_iter_op.to_csv(iter_csv, index=False)
+    logger.info(f"per-op×iteration CSV written to {os.path.abspath(iter_csv)}")

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
@@ -194,12 +194,25 @@ SCENARIO = os.environ.get("DS_PERF_SCENARIO", "warm")
 _REPO_DIR = os.path.dirname(os.path.abspath(__file__))
 # Repo root is five levels up (sparse_mla → tests → deepseek_v3_d_p → demos → models → <root>).
 _REPO_ROOT = os.path.normpath(os.path.join(_REPO_DIR, *([os.pardir] * 5)))
+_PROFILER_ROOT = os.path.join(_REPO_ROOT, "generated", "profiler")
+
+
+def _contained(path: str) -> str:
+    """Resolve `path` and require it to stay under generated/profiler/. Guards the one real traversal
+    vector — a DS_PERF_CSV / DS_DENSE_PERF_CSV env override with `../` in it (see _csv_name) — from
+    escaping the output tree. commonpath, not startswith: startswith would accept a sibling like
+    `<root>-evil`."""
+    resolved = os.path.abspath(path)
+    root = os.path.abspath(_PROFILER_ROOT)
+    if os.path.commonpath([resolved, root]) != root:
+        raise ValueError(f"refusing path outside {root}: {path!r}")
+    return resolved
 
 
 def _output_dir(subdir: str) -> str:
     """Per-(variant, mode) output dir for summary CSVs + run manifest. Replaces Tracy's
     PROFILER_ARTIFACTS_DIR now that profiling is in-process (no tracy report tree)."""
-    d = os.path.join(_REPO_ROOT, "generated", "profiler", subdir)
+    d = _contained(os.path.join(_PROFILER_ROOT, subdir))
     os.makedirs(d, exist_ok=True)
     return d
 
@@ -298,7 +311,7 @@ def _write_run_manifest(report_dir, *, variant, scenario, attn_mode, command, wo
             "build": {"so_mtime": so_mtime},
             "command": reproducer,
         }
-        path = os.path.join(report_dir, f"run_manifest_{scenario}.json")
+        path = _contained(os.path.join(report_dir, f"run_manifest_{scenario}.json"))
         with open(path, "w") as f:
             json.dump(manifest, f, indent=2)
         logger.info(f"run manifest written to {path}")
@@ -488,7 +501,7 @@ def _write_ops_dump(out_dir: str, name_root: str, forwards: list) -> str:
     row per program (duration = max across chips) per forward, in program order (the per_program dict is
     keyed by first arrival, which equals device execution order — see _profile_forward). Also carries the
     raw kernel_sources so the op-code translation can be authored/verified from real data."""
-    path = os.path.join(out_dir, f"{name_root}_ops.csv")
+    path = _contained(os.path.join(out_dir, f"{name_root}_ops.csv"))
     with open(path, "w", newline="") as f:
         w = csv.writer(f)
         w.writerow(["forward", "seq", "runtime_id", "OP CODE", "DEVICE KERNEL DURATION [ns]", "kernel_sources"])
@@ -730,7 +743,7 @@ def test_mla_chunked_perf(mesh_device, variant, scenario, attn_mode, config_only
     print("\n" + table)  # ensure full table reaches stdout even if logging is filtered
 
     out_dir = _output_dir(subdir)
-    csv_out = _scenario_csv(out_dir, scenario, variant.name, attn_mode)
+    csv_out = _contained(_scenario_csv(out_dir, scenario, variant.name, attn_mode))
     by_op.reset_index().to_csv(csv_out, index=False)
     logger.info(f"per-op CSV written to {os.path.abspath(csv_out)}")
 


### PR DESCRIPTION
Test Only

### Summary

Refactor the sparse-MLA chunked-prefill perf harness
(`models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py`) to
replace the Tracy device profiler with the in-process **realtime profiler**
(`profile_realtime_program`), mirroring the approach in #49840 (sparse-MLA CCL
benchmarks) and the SDPA nightly suite. The realtime profiler is auto-enabled on
eligible Blackhole hardware, so this drops the Tracy subprocess, signposts, the
`run_device_profiler` re-entry, and the ops-CSV re-parse — collapsing the
two-test driver+impl split into a single in-process test.

Each measured `forward()` is profiled as its own RT region and device-collapsed
by max duration across chips per `runtime_id` (slowest chip = that program's
critical path); the run total is the sum. Per-forward regions are required
because a cached op reuses its `runtime_id` across the cold loop, so they also
yield the cold per-iteration breakdown directly (no signpost split).

To keep the downstream report/graph pipeline working, a `DS_PERF_RT_OPS_DUMP`
mode emits an execution-ordered, op-coded per-call CSV (the RT analog of Tracy's
`ops_perf_results`), and a `_op_code` mapping translates each program's
kernel-source paths to tracy-style op codes (verified against the tracy op-code
counts/durations). The summary table uses the same mapping, restoring
tracy-matching op names.

### Validation

LoudBox (8 Blackhole p150b, SP=2×TP=4), rebased on `origin/main` so the
`indexer.py` caller and build agree. All 12 cases
(`[deepseek_v32, glm_5_1] × [warm, cold, long] × [sparse, dense]`) pass, sparse
**and** dense.

**Dev-loop: Tracy vs realtime profiler** (per-case pytest `call` time, warm JIT
cache; Tracy = full `run_device_profiler` subprocess + device-profiler dump +
CSV parse, RT = in-process profiled forward(s)):

| Case (variant · scenario · mode) | Tracy (s) | RT (s) | Speedup |
|---|--:|--:|--:|
| deepseek_v32 · cold · sparse | 140.7 | 6.2 | 22.5× |
| deepseek_v32 · warm · sparse | 95.7 | 5.5 | 17.5× |
| glm_5_1 · cold · sparse | 85.7 | 6.3 | 13.5× |
| glm_5_1 · warm · sparse | 60.6 | 4.7 | 13.0× |
| deepseek_v32 · cold · dense | 49.7 | 6.0 | 8.2× |
| deepseek_v32 · warm · dense | 38.5 | 4.8 | 8.0× |
| glm_5_1 · warm · dense | 33.6 | 4.2 | 8.0× |
| glm_5_1 · cold · dense | 46.5 | 5.9 | 7.8× |
| deepseek_v32 · long · sparse | 45.9 | 6.2 | 7.4× |
| deepseek_v32 · long · dense | 37.4 | 6.3 | 5.9× |
| glm_5_1 · long · sparse | 38.6 | 7.7 | 5.0× |
| glm_5_1 · long · dense | 33.6 | 7.1 | 4.7× |
| **TOTAL (sum of per-case call)** | **706.5** | **71.1** | **≈9.9×** |

Full RT suite wall-clock: **97s** for all 12 vs Tracy's ~12 min.

Two documented fidelity notes: the reporting unit is the device program (records
carry no Tracy op code — mapped from kernel sources via `_op_code`), and
collectives are collapsed by max rather than Tracy's avg (a few percent on
collective-heavy flows, per #49840).

_Test-only change; these perf tests are not run in CI (skipped on `CI=true`,
run locally on Blackhole hardware)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mvasilijevic/sparse-mla-rt-profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mvasilijevic/sparse-mla-rt-profiler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mvasilijevic/sparse-mla-rt-profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mvasilijevic/sparse-mla-rt-profiler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mvasilijevic/sparse-mla-rt-profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mvasilijevic/sparse-mla-rt-profiler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mvasilijevic/sparse-mla-rt-profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mvasilijevic/sparse-mla-rt-profiler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mvasilijevic/sparse-mla-rt-profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mvasilijevic/sparse-mla-rt-profiler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mvasilijevic/sparse-mla-rt-profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mvasilijevic/sparse-mla-rt-profiler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mvasilijevic/sparse-mla-rt-profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mvasilijevic/sparse-mla-rt-profiler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mvasilijevic/sparse-mla-rt-profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mvasilijevic/sparse-mla-rt-profiler)