### PR TITLE
[LLK] Fix race condition on dest access register rmw

### DIFF
--- a/tt_metal/tt-llk/tests/helpers/include/dprint_tensix.h
+++ b/tt_metal/tt-llk/tests/helpers/include/dprint_tensix.h
@@ -5,7 +5,8 @@
 // Wrapper for Metal's dprint_tensix.h. We have our own dprint_tensix_dest_reg because the
 // original can't run in LLK infra. It relies on dbg_halt on BH, which is a choreography across
 // the TRISCs that would simply hang when run on Math, as we do here. We can't read DEST through
-// the debug bus; we read 0xFFBD8000 instead, which requires some hardware state programming.
+// the debug bus; we read RISCV_DEST_START_ADDR instead, which requires some hardware state
+// programming.
 //
 // The Wormhole path, and Blackhole fp32/int32, are shared.
 //
@@ -23,6 +24,9 @@
 
 #include "api/debug/dprint_tensix.h"
 #include "cfg_defines.h"
+#ifdef ARCH_BLACKHOLE
+#include "ckernel_dest.h"
+#endif
 
 inline void dprint_tensix_dest_reg(int tile_id = 0)
 {
@@ -48,17 +52,10 @@ inline void dprint_tensix_dest_reg(int tile_id = 0)
     DEVICE_PRINT("Tile ID = {}", tile_id);
 
 #ifdef ARCH_BLACKHOLE
-    // Program SEC1 once up front, then read every row from 0xFFBD8000.
-    // Element pointer type matches the format's element width.
-    // Informed by tt_llk_blackhole/common/inc/ckernel_debug.h:dbg_copy_dest_tile.
-    const uint32_t saved_dest_access = ckernel::cfg_read(RISC_DEST_ACCESS_CTRL_SEC1_fmt_ADDR32);
-    {
-        ckernel::set_dest_fmt<ckernel::MathThreadId>(ckernel::fmt_to_dest_type(data_format));
-        ckernel::set_dest_enable_swizzling<ckernel::MathThreadId>(true);
-        const bool is_signed = (data_format != DataFormat::UInt8) && (data_format != DataFormat::UInt16) && (data_format != DataFormat::UInt32);
-        ckernel::set_dest_int8_int16_signed<ckernel::MathThreadId>(is_signed);
-        ckernel::tensix_sync();
-    }
+    // Program Math's SEC1 for MMIO DEST reads. No restore: this register only
+    // affects the RISC MMIO window, and every MMIO consumer reprograms it.
+    ckernel::configure_dest_access<ckernel::MathThreadId>(data_format, /*enable_swizzle=*/true);
+    ckernel::tensix_sync();
 
     constexpr uint32_t ELT_PER_ROW = 16;
     const uint32_t tile_elt_base   = tile_id * NUM_ROWS_PER_TILE * ELT_PER_ROW;
@@ -79,7 +76,7 @@ inline void dprint_tensix_dest_reg(int tile_id = 0)
             case DataFormat::UInt16:
             {
                 uint32_t rd[8];
-                volatile uint16_t* addr = reinterpret_cast<volatile uint16_t*>(0xFFBD8000);
+                volatile uint16_t* addr = reinterpret_cast<volatile uint16_t*>(RISCV_DEST_START_ADDR);
                 for (int i = 0; i < 8; ++i)
                 {
                     const uint32_t lo = addr[row_elt_base + 2 * i];
@@ -93,7 +90,7 @@ inline void dprint_tensix_dest_reg(int tile_id = 0)
             case DataFormat::UInt8:
             {
                 uint32_t rd[4];
-                volatile uint8_t* addr = reinterpret_cast<volatile uint8_t*>(0xFFBD8000);
+                volatile uint8_t* addr = reinterpret_cast<volatile uint8_t*>(RISCV_DEST_START_ADDR);
                 for (int i = 0; i < 16; ++i)
                 {
                     reinterpret_cast<uint8_t*>(rd)[i] = addr[row_elt_base + i];
@@ -106,10 +103,6 @@ inline void dprint_tensix_dest_reg(int tile_id = 0)
                 break;
         }
     }
-
-    // Restore the caller's DEST access config.
-    ckernel::cfg_write(RISC_DEST_ACCESS_CTRL_SEC1_fmt_ADDR32, saved_dest_access);
-    ckernel::tensix_sync();
 #else
     // Wormhole (reuse Metal helpers)
     uint32_t row = tile_id * NUM_ROWS_PER_TILE;

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_debug.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_debug.h
@@ -195,11 +195,8 @@ inline void dbg_copy_dest_tile(
     constexpr std::uint32_t TILE_ELEMENTS = TILE_HEIGHT * TILE_WIDTH;
 
     const std::uint8_t dest_type = fmt_to_dest_type(fmt);
-    const bool is_signed = (fmt != DataFormat::UInt8) && (fmt != DataFormat::UInt16) && (fmt != DataFormat::UInt32);
 
-    set_dest_fmt<thread_id>(dest_type);
-    set_dest_enable_swizzling<thread_id>(enable_swizzle);
-    set_dest_int8_int16_signed<thread_id>(is_signed);
+    configure_dest_access<thread_id>(fmt, enable_swizzle);
     tensix_sync();
 
     const std::uint32_t offset = tile_id * TILE_ELEMENTS;

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_dest.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_dest.h
@@ -53,15 +53,15 @@ inline void set_dest_fmt(std::uint32_t fmt)
 
     if constexpr (thread_id == UnpackThreadId)
     {
-        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC0_fmt_RMW, fmt);
+        cfg_reg_rmw_tensix<RISC_DEST_ACCESS_CTRL_SEC0_fmt_RMW>(fmt);
     }
     else if constexpr (thread_id == MathThreadId)
     {
-        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC1_fmt_RMW, fmt);
+        cfg_reg_rmw_tensix<RISC_DEST_ACCESS_CTRL_SEC1_fmt_RMW>(fmt);
     }
     else if constexpr (thread_id == PackThreadId)
     {
-        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC2_fmt_RMW, fmt);
+        cfg_reg_rmw_tensix<RISC_DEST_ACCESS_CTRL_SEC2_fmt_RMW>(fmt);
     }
 }
 
@@ -72,32 +72,32 @@ inline void set_dest_fmt(DataFormat fmt)
 }
 
 template <ThreadId thread_id>
-constexpr void set_dest_unsigned_int_rmw(const int val)
+inline void set_dest_unsigned_int_rmw(const int val)
 {
     static_assert(IS_TRISC_THREAD<thread_id>, "Thread must be UnpackThreadId or MathThreadId or PackThreadId");
 
     if constexpr (thread_id == UnpackThreadId)
     {
-        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC0_unsigned_int_RMW, val);
+        cfg_reg_rmw_tensix<RISC_DEST_ACCESS_CTRL_SEC0_unsigned_int_RMW>(val);
     }
     else if constexpr (thread_id == MathThreadId)
     {
-        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC1_unsigned_int_RMW, val);
+        cfg_reg_rmw_tensix<RISC_DEST_ACCESS_CTRL_SEC1_unsigned_int_RMW>(val);
     }
     else if constexpr (thread_id == PackThreadId)
     {
-        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC2_unsigned_int_RMW, val);
+        cfg_reg_rmw_tensix<RISC_DEST_ACCESS_CTRL_SEC2_unsigned_int_RMW>(val);
     }
 }
 
 template <ThreadId thread_id>
-inline void set_dest_int8_int16_signed(bool const is_signed)
+inline void set_dest_int8_int16_signed(const bool is_signed)
 {
     set_dest_unsigned_int_rmw<thread_id>(is_signed ? 0 : 1);
 }
 
 template <ThreadId thread_id>
-constexpr void set_dest_no_swizzle_rmw(const int val)
+inline void set_dest_no_swizzle_rmw(const int val)
 {
     static_assert(IS_TRISC_THREAD<thread_id>, "Thread must be UnpackThreadId or MathThreadId or PackThreadId");
 
@@ -107,22 +107,36 @@ constexpr void set_dest_no_swizzle_rmw(const int val)
     // debugging
     if constexpr (thread_id == UnpackThreadId)
     {
-        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC0_no_swizzle_RMW, val);
+        cfg_reg_rmw_tensix<RISC_DEST_ACCESS_CTRL_SEC0_no_swizzle_RMW>(val);
     }
     else if constexpr (thread_id == MathThreadId)
     {
-        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC1_no_swizzle_RMW, val);
+        cfg_reg_rmw_tensix<RISC_DEST_ACCESS_CTRL_SEC1_no_swizzle_RMW>(val);
     }
     else if constexpr (thread_id == PackThreadId)
     {
-        cfg_rmw(RISC_DEST_ACCESS_CTRL_SEC2_no_swizzle_RMW, val);
+        cfg_reg_rmw_tensix<RISC_DEST_ACCESS_CTRL_SEC2_no_swizzle_RMW>(val);
     }
 }
 
 template <ThreadId thread_id>
-inline void set_dest_enable_swizzling(bool const enable)
+inline void set_dest_enable_swizzling(const bool enable)
 {
     set_dest_no_swizzle_rmw<thread_id>(enable ? 0 : 1);
+}
+
+inline bool dest_fmt_is_signed(DataFormat fmt)
+{
+    return fmt != DataFormat::UInt8 && fmt != DataFormat::UInt16 && fmt != DataFormat::UInt32;
+}
+
+// Program this thread's RISC_DEST_ACCESS_CTRL section for MMIO DEST access.
+template <ThreadId thread_id>
+inline void configure_dest_access(DataFormat fmt, bool enable_swizzle = true)
+{
+    set_dest_fmt<thread_id>(fmt);
+    set_dest_enable_swizzling<thread_id>(enable_swizzle);
+    set_dest_int8_int16_signed<thread_id>(dest_fmt_is_signed(fmt));
 }
 
 } // namespace ckernel


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Closes https://github.com/tenstorrent/tt-llk/issues/1671

### Notes for reviewers
Note: This change also refactors dprint_tensix.h to use the header, I also removed the restoring of the register, as it seemed unnecessary. That register should be reconfigured on every dest access.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=halgh/bh-dest-access-ctrl-rmw-race-1671)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:halgh/bh-dest-access-ctrl-rmw-race-1671)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=halgh/bh-dest-access-ctrl-rmw-race-1671)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:halgh/bh-dest-access-ctrl-rmw-race-1671)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=halgh/bh-dest-access-ctrl-rmw-race-1671)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:halgh/bh-dest-access-ctrl-rmw-race-1671)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=halgh/bh-dest-access-ctrl-rmw-race-1671)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:halgh/bh-dest-access-ctrl-rmw-race-1671)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=halgh/bh-dest-access-ctrl-rmw-race-1671)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:halgh/bh-dest-access-ctrl-rmw-race-1671)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=halgh/bh-dest-access-ctrl-rmw-race-1671)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:halgh/bh-dest-access-ctrl-rmw-race-1671)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=halgh/bh-dest-access-ctrl-rmw-race-1671)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:halgh/bh-dest-access-ctrl-rmw-race-1671)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=halgh/bh-dest-access-ctrl-rmw-race-1671)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:halgh/bh-dest-access-ctrl-rmw-race-1671)