### PR TITLE
ci: remove bh_quietbox_2_iommu (merge back in to bh_quietbox_2)

### DIFF
--- a/.github/sku_config.yaml
+++ b/.github/sku_config.yaml
@@ -177,13 +177,6 @@ skus:
       - in-service
     weights-cache-mode: yyz4-mnt-models
 
-  bh_quietbox_2_iommu:
-    runs_on:
-      - BH-Quietbox-2-iommu
-      - pipeline-perf
-      - in-service
-    weights-cache-mode: yyz4-mnt-models
-
   bh_spsg:
     runs_on:
       - exabox-multihost-with-nfs

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -86,8 +86,7 @@ ttnn:
     wh_n300_civ2: 545
     bh_p100: 545
     bh_p150b_civ2: 545
-    bh_quietbox_2: 35
-    bh_quietbox_2_iommu: 30 # sdpa nightly (20) + ring sdpa PERF (10); both need IOMMU for the RT profiler (IOMMU-enabled QB2)
+    bh_quietbox_2: 65
     bh_p300: 15
     wh_llmbox: 25
     sim_wormhole_b0: 680

--- a/.github/workflows/blackhole-sanity-tests.yaml
+++ b/.github/workflows/blackhole-sanity-tests.yaml
@@ -222,7 +222,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/blackhole-multi-card-sanity-tests-impl.yaml
     with:
-      enabled-skus: "bh_quietbox_2,bh_p300,bh_quietbox_2_iommu"
+      enabled-skus: "bh_quietbox_2,bh_p300"
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -3941,7 +3941,7 @@ def test_ring_joint_attention_minimax3_gqa_chunked_reuse_kv_hang_regression():
     while logical_n grows. Before the idle-core cache-hit patch, an idle core kept a stale
     active_ring_iter_mask and skipped a ring iter the injector still multicast to, hanging forever.
 
-    Runs only on bh_quietbox_2_iommu (QuietBox 2, 4 chips, single ring sp_size=4). The hang needs an
+    Runs only on bh_quietbox_2 (QuietBox 2, 4 chips, single ring sp_size=4). The hang needs an
     idle core inside an active row-wide mcast row; on the fixed 10x10 grid that requires
     all_heads_num_q_chunks = NH*ceil(640/q_chunk) to not be a multiple of the row width. Production
     q=128 -> 80 = full rows (idle cores only in fully-idle rows, never hangs); q=320 -> 32 leaves a

--- a/tests/pipeline_reorg/blackhole_multi_card_sanity_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_multi_card_sanity_tests.yaml
@@ -48,26 +48,25 @@
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
 
-- name: sdpa nightly tests (QB2 IOMMU only)
+- name: sdpa nightly tests (QB2 only)
   cmd: pytest tests/nightly/blackhole/sdpa/ -svv
   skus:
-    bh_quietbox_2_iommu:
+    bh_quietbox_2:
       timeout: 20
   owner_id: U05ACKAJTHS # Naif Tarafdar
   team: ttnn
 
-- name: ring sdpa PERF tests (QB2 IOMMU only)
+- name: ring sdpa PERF tests (QB2 only)
   # These perf checks measure device kernel duration via the realtime device profiler. On Blackhole
   # the RT profiler's D2H socket uses 64-bit PCIe addressing, which requires host IOMMU (there is no
   # hugepage fallback) — see evaluate_realtime_profiler_eligibility in realtime_profiler_manager.cpp.
-  # Without IOMMU the profiler never activates and the tests fail the guard (issue #49665), so this
-  # job must run on the IOMMU-enabled runner, matching the sdpa nightly job above.
+  # Without IOMMU the profiler never activates and the tests fail the guard (issue #49665).
   cmd: |
     pytest tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py::test_ring_joint_attention_perf_check -svv
     pytest tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py::test_ring_mla_chunked_perf_check -svv
     pytest tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py::test_exp_ring_joint_attention_perf_check -svv
   skus:
-    bh_quietbox_2_iommu:
+    bh_quietbox_2:
       timeout: 10
   owner_id: U05ACKAJTHS # Naif Tarafdar
   team: ttnn


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Cleanup
https://tenstorrent.atlassian.net/browse/MINFRA-1071
Closes https://github.com/tenstorrent/tt-metal/issues/48271

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
IOMMU-specific QB2 runners were originally sectioned out as part of https://github.com/tenstorrent/tt-metal/pull/49157 due to instability
With KMD 2.10.0 the instability is fixed so now the entire QB2 pool is IOMMU enabled so we no longer need to have a separate sku/budget/jobs on iommu-only runners

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
Label will persist for a few days after merge to give devs a chance to rebase
BH sanity: https://github.com/tenstorrent/tt-metal/actions/runs/29512037099

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=williamly/remove-qb2-iommu-sku)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:williamly/remove-qb2-iommu-sku)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=williamly/remove-qb2-iommu-sku)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:williamly/remove-qb2-iommu-sku)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=williamly/remove-qb2-iommu-sku)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:williamly/remove-qb2-iommu-sku)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=williamly/remove-qb2-iommu-sku)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:williamly/remove-qb2-iommu-sku)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=williamly/remove-qb2-iommu-sku)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:williamly/remove-qb2-iommu-sku)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=williamly/remove-qb2-iommu-sku)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:williamly/remove-qb2-iommu-sku)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=williamly/remove-qb2-iommu-sku)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:williamly/remove-qb2-iommu-sku)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=williamly/remove-qb2-iommu-sku)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:williamly/remove-qb2-iommu-sku)