### PR TITLE
[LLK] Zero Flags 'HAL' attempt

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_defs.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel_defs.h
@@ -15,33 +15,6 @@
 namespace ckernel
 {
 
-/**
- * @brief Whether the Src zero-substitution flag (ALU_ACC_CTRL_Zero_Flag_disabled_src) must be
- *        disabled (written 1) for the given SrcA/SrcB destination formats.
- *
- * While the flag is clear (its reset state), MOVA2D / MOVB2D flush any SrcA/SrcB datum whose low
- * 8 bits are zero to 0 (FlushDenormals; see MOVA2D.md `if (FlushDenormals && !(SrcAVal & 0xff))`).
- * For the floating-point Src layout the low 8 bits are the exponent, and a zero exponent denotes a
- * subnormal, which the HW does not support and therefore rounds to zero.
- *
- * UInt16 is the HW "Integer 16" format and the only 16-bit integer unpacker destination format. It
- * shares the Src bit layout, so its low byte is the integer's low magnitude bits, NOT an exponent.
- * A legitimate value such as 256 (0x0100) has a zero low byte and would be silently flushed to 0,
- * destroying the high magnitude bits. Disabling the flag suppresses the flush so 16-bit integer
- * data survives the move into Dst.
- *
- * @param srca_dst_format Destination data format of SrcA.
- * @param srcb_dst_format Destination data format of SrcB.
- * @return true when either operand is UInt16, in which case the flag must be disabled.
- *
- * @note ISA (paths are in the tt-isa-documentation repo): Blackhole/TensixTile/TensixCoprocessor/MOVA2D.md (FlushDenormals branch) and
- *       SrcASrcB.md (the "Integer 16" note).
- */
-inline bool requires_disabled_src_zero_flag(const std::uint32_t srca_dst_format, const std::uint32_t srcb_dst_format)
-{
-    return (srca_dst_format == static_cast<std::uint32_t>(DataFormat::UInt16)) || (srcb_dst_format == static_cast<std::uint32_t>(DataFormat::UInt16));
-}
-
 enum Srcs
 {
     SrcA = 0,

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cmath_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/cmath_common.h
@@ -43,71 +43,139 @@ constexpr std::uint32_t replay_buf_offset = 16; // split replay buffer usage bet
 //                    bf16 -0.0 and 16-bit-integer datums.
 //   MOV_OPS        : flag = 1. Selected by transpose_dest 32b hi16-lo16 MOV sequences.
 //
-// Each configurator early-returns when already in its state (DEFAULT additionally re-applies when
-// the cached operand formats changed), so steady-state ops pay no extra cfg writes.
-// See ckernel::requires_disabled_src_zero_flag for the UInt16 rationale.
-// (Blackhole reduce's enforce_fp32 path uses ALU_ACC_CTRL_Fp32_enabled for the same MOVD2B/B2D
-// workaround - Issue tt-llk#449 - so it does not interact with this flag.)
+// CFG write is only issued when necessary, so the user doesn't pay for CFG writes unless necessary.
 // ---------------------------------------------------------------------------------------------
-enum class SrcZeroFlagState : std::uint8_t
+class ZeroFlags
 {
-    UNCONFIGURED   = 0,
-    DEFAULT        = 1,
-    UNARY_PRESERVE = 2,
-    MOV_OPS        = 3,
+public:
+    enum class State : bool
+    {
+        Enable  = true,
+        Disable = false,
+    };
+
+private:
+    enum class TrackerState : std::uint8_t
+    {
+        UNCONFIGURED   = 0,
+        DEFAULT        = 1,
+        UNARY_PRESERVE = 2,
+        MOV_OPS        = 3,
+    };
+
+    static inline TrackerState tracker_state = TrackerState::UNCONFIGURED;
+    static inline std::uint32_t fpu_format  = 0xff;
+    static inline std::uint32_t sfpu_format  = 0xff;
+
+    static inline void zero_flags_toggle(const State state)
+    {
+        TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
+
+        // Disabling subnormal flush is done by disabling Zero Flags, which will force ZeroFlag == 0 for each datum, leading to the raw value being used.
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(state == State::Disable ? 1 : 0);
+    }
+
+public:
+    /**
+     * @brief Whether the zero flags (ALU_ACC_CTRL_Zero_Flag_disabled_src) must be
+     *        disabled (State::Disable, written 1) for the given SrcA/SrcB destination formats.
+     *
+     * While the flag is clear (its reset state), MOVA2D / MOVB2D flush any SrcA/SrcB datum whose low
+     * 8 bits are zero to 0 (FlushDenormals; see MOVA2D.md `if (FlushDenormals && !(SrcAVal & 0xff))`).
+     * For the floating-point Src layout the low 8 bits are the exponent, and a zero exponent denotes a
+     * subnormal, which the HW does not support and therefore rounds to zero.
+     *
+     * UInt16 is the HW "Integer 16" format and the only 16-bit integer unpacker destination format. It
+     * shares the Src bit layout, so its low byte is the integer's low magnitude bits, NOT an exponent.
+     * A legitimate value such as 256 (0x0100) has a zero low byte and would be silently flushed to 0,
+     * destroying the high magnitude bits. Disabling the flag suppresses the flush so 16-bit integer
+     * data survives the move into Dst.
+     *
+     * @param fpu_format format used by the FPU
+     * @param sfpu_format format used by the SFPU
+     * @return State::Disable when either operand is UInt16 (flag must be disabled), else State::Enable.
+     *
+     * @note ISA (paths are in the tt-isa-documentation repo): Blackhole/TensixTile/TensixCoprocessor/MOVA2D.md (FlushDenormals branch) and
+     *       SrcASrcB.md (the "Integer 16" note).
+     */
+    static constexpr State compute_reconfig(const std::uint32_t fpu_format, const std::uint32_t sfpu_format)
+    {
+        const bool requires_disable =
+            (fpu_format == static_cast<std::uint32_t>(DataFormat::UInt16)) || (sfpu_format == static_cast<std::uint32_t>(DataFormat::UInt16));
+        return requires_disable ? State::Disable : State::Enable;
+    }
+
+    /**
+     * @brief DEFAULT state: the flag follows the operand formats. Re-applies when the state or cached formats change.
+     *
+     * @param fpu_format_next format used by the FPU
+     * @param sfpu_format_next format used by the SFPU
+     */
+    static void execute_reconfig(const std::uint32_t fpu_format_next, const std::uint32_t sfpu_format_next)
+    {
+        const bool formats_match = (fpu_format == fpu_format_next) && (sfpu_format == sfpu_format_next);
+        if (tracker_state != TrackerState::DEFAULT || !formats_match)
+        {
+            tracker_state = TrackerState::DEFAULT;
+            fpu_format   = fpu_format_next;
+            sfpu_format   = sfpu_format_next;
+            zero_flags_toggle(compute_reconfig(fpu_format, sfpu_format));
+        }
+    }
+
+    /** @brief Cached FPU destination format, so a single-operand reconfig can reuse the other operand. */
+    static std::uint32_t get_fpu_format()
+    {
+        return fpu_format;
+    }
+
+    /** @brief Cached SFPU destination format, so a single-operand reconfig can reuse the other operand. */
+    static std::uint32_t get_sfpu_format()
+    {
+        return sfpu_format;
+    }
+
+    /**
+     * @brief Setup zero flags for UNARY / SFPU / DATACOPY ops.
+     *
+     * Used for preservation of -0.0 and INT16/UINT16 (redundant).
+     */
+    static void execute_reconfig_unary_preserve()
+    {
+        if (tracker_state != TrackerState::UNARY_PRESERVE)
+        {
+            tracker_state = TrackerState::UNARY_PRESERVE;
+            zero_flags_toggle(State::Disable);
+        }
+    }
+
+    /**
+     * @brief Setup zero flags for MOV operations.
+     *
+     * Used for 32bit TRANSPOSE_DEST to ensure HI16/LO16 MOV operations don't accidentally flush raw bits to zero.
+     */
+    static void execute_reconfig_mov_ops()
+    {
+        if (tracker_state != TrackerState::MOV_OPS)
+        {
+            tracker_state = TrackerState::MOV_OPS;
+            zero_flags_toggle(State::Disable);
+        }
+    }
+
+    /**
+     * @brief Invalidates the tracked state leading to forced reconfiguration on next execute_reconfig_**
+     *
+     * @note This is useful after Zero Flags is altered outside of this wrapper, bypassing the tracker
+     */
+    static void invalidate_tracker()
+    {
+        tracker_state = TrackerState::UNCONFIGURED;
+    }
 };
 
-static SrcZeroFlagState src_zero_flag_state = SrcZeroFlagState::UNCONFIGURED;
-static std::uint32_t src_zero_flag_srca_fmt = 0xff;
-static std::uint32_t src_zero_flag_srcb_fmt = 0xff;
 
-inline void _configure_src_zero_flag_(const bool disable)
-{
-    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
-    cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(disable ? 1 : 0);
-}
 
-// DEFAULT: the flag follows the operand formats. Re-applies when the state or cached formats change.
-inline void _configure_default_zero_flag_state_(const std::uint32_t srca_dst_format, const std::uint32_t srcb_dst_format)
-{
-    if (src_zero_flag_state == SrcZeroFlagState::DEFAULT && src_zero_flag_srca_fmt == srca_dst_format && src_zero_flag_srcb_fmt == srcb_dst_format)
-    {
-        return;
-    }
-    src_zero_flag_srca_fmt = srca_dst_format;
-    src_zero_flag_srcb_fmt = srcb_dst_format;
-    src_zero_flag_state    = SrcZeroFlagState::DEFAULT;
-    _configure_src_zero_flag_(requires_disabled_src_zero_flag(srca_dst_format, srcb_dst_format));
-}
-
-// UNARY_PRESERVE: unary / SFPU / datacopy ops keep the flag disabled (preserve -0.0 and 16b ints).
-inline void _configure_unary_preserve_zero_flag_state_()
-{
-    if (src_zero_flag_state == SrcZeroFlagState::UNARY_PRESERVE)
-    {
-        return;
-    }
-    src_zero_flag_state = SrcZeroFlagState::UNARY_PRESERVE;
-    _configure_src_zero_flag_(true);
-}
-
-// MOV_OPS: transpose_dest 32b hi16-lo16 MOV sequences keep the flag disabled.
-inline void _configure_mov_ops_zero_flag_state_()
-{
-    if (src_zero_flag_state == SrcZeroFlagState::MOV_OPS)
-    {
-        return;
-    }
-    src_zero_flag_state = SrcZeroFlagState::MOV_OPS;
-    _configure_src_zero_flag_(true);
-}
-
-// Invalidate the tracked state after a code path that writes the flag directly (bypassing the
-// tracker), so the next configurator re-applies regardless of the skip-if-set fast path.
-inline void _invalidate_src_zero_flag_state_()
-{
-    src_zero_flag_state = SrcZeroFlagState::UNCONFIGURED;
-}
 
 inline void reset_counters(const std::uint32_t setrwc)
 {

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_common.h
@@ -58,7 +58,7 @@ inline void _llk_math_hw_configure_(const std::uint32_t srca_data_format, const 
     cfg_reg_rmw_tensix<ALU_ACC_CTRL_SFPU_Fp32_enabled_RMW>(is_fp32_dest_acc_en);
 
     // Establish the operand-driven baseline for the Src zero-substitution flag.
-    _configure_default_zero_flag_state_(srca_data_format, srcb_data_format);
+    ZeroFlags::execute_reconfig(srca_data_format, srcb_data_format);
 }
 
 /**
@@ -177,7 +177,7 @@ inline void _llk_math_reconfig_data_format_srca_(const std::uint32_t srca_data_f
     }
 
     // Re-establish the operand-driven baseline (clears stale op-state) for the new SrcA format.
-    _configure_default_zero_flag_state_(srca_data_format, src_zero_flag_srcb_fmt);
+    ZeroFlags::execute_reconfig(srca_data_format, ZeroFlags::get_sfpu_format());
 }
 
 /**
@@ -207,7 +207,7 @@ inline void _llk_math_reconfig_data_format_srcb_(const std::uint32_t srcb_data_f
     }
 
     // Re-establish the operand-driven baseline (clears stale op-state) for the new SrcB format.
-    _configure_default_zero_flag_state_(src_zero_flag_srca_fmt, srcb_data_format);
+    ZeroFlags::execute_reconfig(ZeroFlags::get_fpu_format(), srcb_data_format);
 }
 
 /**
@@ -239,7 +239,7 @@ inline void _llk_math_reconfig_data_format_(const std::uint32_t srca_data_format
     }
 
     // Re-establish the operand-driven baseline (clears stale op-state) for the new formats.
-    _configure_default_zero_flag_state_(srca_data_format, srcb_data_format);
+    ZeroFlags::execute_reconfig(srca_data_format, srcb_data_format);
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -88,8 +88,7 @@ inline void _llk_math_eltwise_unary_datacopy_(
             TTI_SETC16(DISABLE_IMPLIED_SRCA_FMT_Base_ADDR32, 1);
             cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_RMW>(to_underlying(DataFormat::Float32));
 
-            // Disable zero flag to prevent mantissa flushing when exponent bits are 0.
-            cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+            math::ZeroFlags::execute_reconfig_unary_preserve();
         }
 
         if constexpr (src_b_bcast_type == BroadcastType::ROW)
@@ -266,10 +265,6 @@ inline void _llk_math_eltwise_unary_datacopy_(
         if constexpr (src_b_bcast_type != BroadcastType::NONE)
         {
             TTI_SETC16(DISABLE_IMPLIED_SRCA_FMT_Base_ADDR32, 0);
-
-            // The 32b path manipulated the flag directly above (tt-llk#449 Fp32_enabled dance); invalidate the
-            // tracked state so the next op re-applies the Src zero-substitution flag.
-            math::_invalidate_src_zero_flag_state_();
         }
     }
     else
@@ -284,7 +279,7 @@ inline void _llk_math_eltwise_unary_datacopy_(
             if (dst_format == to_underlying(DataFormat::UInt16))
             {
                 TTI_SETC16(DISABLE_IMPLIED_SRCA_FMT_Base_ADDR32, 1);
-                cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+                math::ZeroFlags::execute_reconfig_unary_preserve();
                 cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_RMW>(to_underlying(DataFormat::Tf32));
             }
         }
@@ -315,7 +310,6 @@ inline void _llk_math_eltwise_unary_datacopy_(
             if (dst_format == to_underlying(DataFormat::UInt16))
             {
                 TTI_SETC16(DISABLE_IMPLIED_SRCA_FMT_Base_ADDR32, 0);
-                math::_invalidate_src_zero_flag_state_();
             }
         }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_reduce.h
@@ -40,7 +40,7 @@ inline void reduce_row_perform_transpose()
     // A datum whose low byte is zero (e.g. bf16 0x4400 = 768.0) would be flushed to 0 mid-reduction,
     // corrupting the sum. Disable the flag (via the math state tracker) around the transpose+add, then
     // return it to the operand driven baseline. WH does the same in its fp32 transpose.
-    math::_configure_mov_ops_zero_flag_state_();
+    math::ZeroFlags::execute_reconfig_mov_ops();
 
     if constexpr (is_int_fpu_en)
     {
@@ -72,7 +72,7 @@ inline void reduce_row_perform_transpose()
     TTI_ELWADD(0, 0, p_elwise::SRCB_NO_BCAST, ADDR_MOD_1, 0);
 
     // Restore the operand-driven baseline for the currently configured formats.
-    math::_configure_default_zero_flag_state_(math::src_zero_flag_srca_fmt, math::src_zero_flag_srcb_fmt);
+    math::ZeroFlags::execute_reconfig(math::ZeroFlags::get_fpu_format(), math::ZeroFlags::get_sfpu_format());
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_transpose_dest.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_transpose_dest.h
@@ -43,7 +43,7 @@ inline void transpose_dest_32b()
     // The 32b hi16/lo16 MOV sequence must not flush datums with a zero low byte; own the Src
     // zero-substitution flag via the math state tracker. Asserted here (execute) so it survives any
     // llk_math_hw_configure that ran after the init; skip-if-set keeps it cheap.
-    math::_configure_mov_ops_zero_flag_state_();
+    math::ZeroFlags::execute_reconfig_mov_ops();
 
     // Transpose all the low 16 bit elements of all faces and put them in SrcA.
     // Eventually Dest=0, SrcA=0.

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel_defs.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel_defs.h
@@ -15,33 +15,6 @@
 namespace ckernel
 {
 
-/**
- * @brief Whether the Src zero-substitution flag (ALU_ACC_CTRL_Zero_Flag_disabled_src) must be
- *        disabled (written 1) for the given SrcA/SrcB destination formats.
- *
- * While the flag is clear (its reset state), MOVA2D / MOVB2D flush any SrcA/SrcB datum whose low
- * 8 bits are zero to 0 (FlushDenormals; see MOVA2D.md `if (FlushDenormals && !(SrcAVal & 0xff))`).
- * For the floating-point Src layout the low 8 bits are the exponent, and a zero exponent denotes a
- * subnormal, which the HW does not support and therefore rounds to zero.
- *
- * UInt16 is the HW "Integer 16" format and the only 16-bit integer unpacker destination format. It
- * shares the Src bit layout, so its low byte is the integer's low magnitude bits, NOT an exponent.
- * A legitimate value such as 256 (0x0100) has a zero low byte and would be silently flushed to 0,
- * destroying the high magnitude bits. Disabling the flag suppresses the flush so 16-bit integer
- * data survives the move into Dst.
- *
- * @param srca_dst_format Destination data format of SrcA.
- * @param srcb_dst_format Destination data format of SrcB.
- * @return true when either operand is UInt16, in which case the flag must be disabled.
- *
- * @note ISA (paths are in the tt-isa-documentation repo): WormholeB0/TensixTile/TensixCoprocessor/MOVA2D.md (FlushDenormals branch) and
- *       SrcASrcB.md (the "Integer 16" note).
- */
-inline bool requires_disabled_src_zero_flag(const std::uint32_t srca_dst_format, const std::uint32_t srcb_dst_format)
-{
-    return (srca_dst_format == static_cast<std::uint32_t>(DataFormat::UInt16)) || (srcb_dst_format == static_cast<std::uint32_t>(DataFormat::UInt16));
-}
-
 enum Srcs
 {
     SrcA = 0,

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cmath_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cmath_common.h
@@ -44,69 +44,136 @@ constexpr std::uint32_t replay_buf_offset = 16; // split replay buffer usage bet
 //                    bf16 -0.0 and 16-bit-integer datums.
 //   MOV_OPS        : flag = 1. Selected by transpose_dest / 32b hi16-lo16 MOV sequences.
 //
-// Each configurator early-returns when already in its state (DEFAULT additionally re-applies when
-// the cached operand formats changed), so steady-state ops pay no extra cfg writes.
-// See ckernel::requires_disabled_src_zero_flag for the UInt16 rationale.
+// CFG write is only issued when necessary, so the user doesn't pay for CFG writes unless necessary.
 // ---------------------------------------------------------------------------------------------
-enum class SrcZeroFlagState : std::uint8_t
+class ZeroFlags
 {
-    UNCONFIGURED   = 0,
-    DEFAULT        = 1,
-    UNARY_PRESERVE = 2,
-    MOV_OPS        = 3,
+public:
+    enum class State : bool
+    {
+        Enable  = true,
+        Disable = false,
+    };
+
+private:
+    enum class TrackerState : std::uint8_t
+    {
+        UNCONFIGURED   = 0,
+        DEFAULT        = 1,
+        UNARY_PRESERVE = 2,
+        MOV_OPS        = 3,
+    };
+
+    static inline TrackerState tracker_state = TrackerState::UNCONFIGURED;
+    static inline std::uint32_t fpu_format  = 0xff;
+    static inline std::uint32_t sfpu_format  = 0xff;
+
+    static inline void zero_flags_toggle(const State state)
+    {
+        TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
+
+        // Disabling subnormal flush is done by disabling Zero Flags, which will force ZeroFlag == 0 for each datum, leading to the raw value being used.
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(state == State::Disable ? 1 : 0);
+    }
+
+public:
+    /**
+     * @brief Whether the zero flags (ALU_ACC_CTRL_Zero_Flag_disabled_src) must be
+     *        disabled (State::Disable, written 1) for the given SrcA/SrcB destination formats.
+     *
+     * While the flag is clear (its reset state), MOVA2D / MOVB2D flush any SrcA/SrcB datum whose low
+     * 8 bits are zero to 0 (FlushDenormals; see MOVA2D.md `if (FlushDenormals && !(SrcAVal & 0xff))`).
+     * For the floating-point Src layout the low 8 bits are the exponent, and a zero exponent denotes a
+     * subnormal, which the HW does not support and therefore rounds to zero.
+     *
+     * UInt16 is the HW "Integer 16" format and the only 16-bit integer unpacker destination format. It
+     * shares the Src bit layout, so its low byte is the integer's low magnitude bits, NOT an exponent.
+     * A legitimate value such as 256 (0x0100) has a zero low byte and would be silently flushed to 0,
+     * destroying the high magnitude bits. Disabling the flag suppresses the flush so 16-bit integer
+     * data survives the move into Dst.
+     *
+     * @param fpu_format format used by the FPU
+     * @param sfpu_format format used by the SFPU
+     * @return State::Disable when either operand is UInt16 (flag must be disabled), else State::Enable.
+     *
+     * @note ISA (paths are in the tt-isa-documentation repo): WormholeB0/TensixTile/TensixCoprocessor/MOVA2D.md (FlushDenormals branch) and
+     *       SrcASrcB.md (the "Integer 16" note).
+     */
+    static constexpr State compute_reconfig(const std::uint32_t fpu_format, const std::uint32_t sfpu_format)
+    {
+        const bool requires_disable =
+            (fpu_format == static_cast<std::uint32_t>(DataFormat::UInt16)) || (sfpu_format == static_cast<std::uint32_t>(DataFormat::UInt16));
+        return requires_disable ? State::Disable : State::Enable;
+    }
+
+    /**
+     * @brief DEFAULT state: the flag follows the operand formats. Re-applies when the state or cached formats change.
+     *
+     * @param fpu_format_next format used by the FPU
+     * @param sfpu_format_next format used by the SFPU
+     */
+    static void execute_reconfig(const std::uint32_t fpu_format_next, const std::uint32_t sfpu_format_next)
+    {
+        const bool formats_match = (fpu_format == fpu_format_next) && (sfpu_format == sfpu_format_next);
+        if (tracker_state != TrackerState::DEFAULT || !formats_match)
+        {
+            tracker_state = TrackerState::DEFAULT;
+            fpu_format   = fpu_format_next;
+            sfpu_format   = sfpu_format_next;
+            zero_flags_toggle(compute_reconfig(fpu_format, sfpu_format));
+        }
+    }
+
+    /** @brief Cached FPU destination format, so a single-operand reconfig can reuse the other operand. */
+    static std::uint32_t get_fpu_format()
+    {
+        return fpu_format;
+    }
+
+    /** @brief Cached SFPU destination format, so a single-operand reconfig can reuse the other operand. */
+    static std::uint32_t get_sfpu_format()
+    {
+        return sfpu_format;
+    }
+
+    /**
+     * @brief Setup zero flags for UNARY / SFPU / DATACOPY ops.
+     *
+     * Used for preservation of -0.0 and INT16/UINT16 (redundant).
+     */
+    static void execute_reconfig_unary_preserve()
+    {
+        if (tracker_state != TrackerState::UNARY_PRESERVE)
+        {
+            tracker_state = TrackerState::UNARY_PRESERVE;
+            zero_flags_toggle(State::Disable);
+        }
+    }
+
+    /**
+     * @brief Setup zero flags for MOV operations.
+     *
+     * Used for 32bit TRANSPOSE_DEST to ensure HI16/LO16 MOV operations don't accidentally flush raw bits to zero.
+     */
+    static void execute_reconfig_mov_ops()
+    {
+        if (tracker_state != TrackerState::MOV_OPS)
+        {
+            tracker_state = TrackerState::MOV_OPS;
+            zero_flags_toggle(State::Disable);
+        }
+    }
+
+    /**
+     * @brief Invalidates the tracked state leading to forced reconfiguration on next execute_reconfig_**
+     *
+     * @note This is useful after Zero Flags is altered outside of this wrapper, bypassing the tracker
+     */
+    static void invalidate_tracker()
+    {
+        tracker_state = TrackerState::UNCONFIGURED;
+    }
 };
-
-static SrcZeroFlagState src_zero_flag_state = SrcZeroFlagState::UNCONFIGURED;
-static std::uint32_t src_zero_flag_srca_fmt = 0xff;
-static std::uint32_t src_zero_flag_srcb_fmt = 0xff;
-
-inline void _configure_src_zero_flag_(const bool disable)
-{
-    TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
-    cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(disable ? 1 : 0);
-}
-
-// DEFAULT: the flag follows the operand formats. Re-applies when the state or cached formats change.
-inline void _configure_default_zero_flag_state_(const std::uint32_t srca_dst_format, const std::uint32_t srcb_dst_format)
-{
-    if (src_zero_flag_state == SrcZeroFlagState::DEFAULT && src_zero_flag_srca_fmt == srca_dst_format && src_zero_flag_srcb_fmt == srcb_dst_format)
-    {
-        return;
-    }
-    src_zero_flag_srca_fmt = srca_dst_format;
-    src_zero_flag_srcb_fmt = srcb_dst_format;
-    src_zero_flag_state    = SrcZeroFlagState::DEFAULT;
-    _configure_src_zero_flag_(requires_disabled_src_zero_flag(srca_dst_format, srcb_dst_format));
-}
-
-// UNARY_PRESERVE: unary / SFPU / datacopy ops keep the flag disabled (preserve -0.0 and 16b ints).
-inline void _configure_unary_preserve_zero_flag_state_()
-{
-    if (src_zero_flag_state == SrcZeroFlagState::UNARY_PRESERVE)
-    {
-        return;
-    }
-    src_zero_flag_state = SrcZeroFlagState::UNARY_PRESERVE;
-    _configure_src_zero_flag_(true);
-}
-
-// MOV_OPS: transpose_dest / 32b hi16-lo16 MOV sequences keep the flag disabled.
-inline void _configure_mov_ops_zero_flag_state_()
-{
-    if (src_zero_flag_state == SrcZeroFlagState::MOV_OPS)
-    {
-        return;
-    }
-    src_zero_flag_state = SrcZeroFlagState::MOV_OPS;
-    _configure_src_zero_flag_(true);
-}
-
-// Invalidate the tracked state after code path that writes the flag directly (bypassing the
-// tracker), so the next configurator re-applies regardless of the skip-if-set fast path.
-inline void _invalidate_src_zero_flag_state_()
-{
-    src_zero_flag_state = SrcZeroFlagState::UNCONFIGURED;
-}
 
 inline void reset_counters(const std::uint32_t setrwc)
 {

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_common.h
@@ -55,7 +55,7 @@ inline void _llk_math_hw_configure_(const std::uint32_t srca_data_format, const 
     cfg_reg_rmw_tensix<ALU_ACC_CTRL_SFPU_Fp32_enabled_RMW>(is_fp32_dest_acc_en);
 
     // Establish the operand-driven baseline for the Src zero-substitution flag.
-    _configure_default_zero_flag_state_(srca_data_format, srcb_data_format);
+    ZeroFlags::execute_reconfig(srca_data_format, srcb_data_format);
 }
 
 /**
@@ -153,7 +153,7 @@ inline void _llk_math_reconfig_data_format_srca_(const std::uint32_t srca_data_f
     }
 
     // Re-establish the operand-driven baseline (clears stale op-state) for the new SrcA format.
-    _configure_default_zero_flag_state_(srca_data_format, src_zero_flag_srcb_fmt);
+    ZeroFlags::execute_reconfig(srca_data_format, ZeroFlags::get_sfpu_format());
 }
 
 /**
@@ -187,7 +187,7 @@ inline void _llk_math_reconfig_data_format_srcb_(const std::uint32_t srcb_data_f
     }
 
     // Re-establish the operand-driven baseline (clears stale op-state) for the new SrcB format.
-    _configure_default_zero_flag_state_(src_zero_flag_srca_fmt, srcb_data_format);
+    ZeroFlags::execute_reconfig(ZeroFlags::get_fpu_format(), srcb_data_format);
 }
 
 /**
@@ -225,7 +225,7 @@ inline void _llk_math_reconfig_data_format_(const std::uint32_t srca_data_format
     }
 
     // Re-establish the operand-driven baseline (clears stale op-state) for the new formats.
-    _configure_default_zero_flag_state_(srca_data_format, srcb_data_format);
+    ZeroFlags::execute_reconfig(srca_data_format, srcb_data_format);
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -63,9 +63,9 @@ inline void _llk_math_eltwise_unary_datacopy_(const std::uint32_t dst_index, con
         // Switch from the default SrcA format bank to the override bank so manual SrcA_val writes control MOVB2D behavior.
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_override_RMW>(1);
 
-        // The 32b hi16/lo16 MOVB2D below must not flush datums with a zero low byte; own the Src
-        // zero-substitution flag via the math state tracker.
-        math::_configure_mov_ops_zero_flag_state_();
+        // The 32b hi16/lo16 MOVB2D below must not flush datums with a zero low byte; disable the Src
+        // zero-substitution flag (via the tracker) so its recorded state stays consistent with HW.
+        math::ZeroFlags::execute_reconfig_unary_preserve();
 
         if constexpr (src_b_bcast_type == BroadcastType::ROW)
         {
@@ -190,12 +190,8 @@ inline void _llk_math_eltwise_unary_datacopy_(const std::uint32_t dst_index, con
             TTI_CLEARDVALID(0b10, 0);
         }
         cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_override_RMW>(0);
-
-        // This 32b hi16/lo16 MOV sequence drove the Src zero-substitution flag (and the SrcA format
-        // override bank) directly for the duration of the block; invalidate the tracked state so the
-        // next configurator re-applies the flag from a known baseline instead of taking its
-        // skip-if-set fast path (matches the Blackhole path).
-        math::_invalidate_src_zero_flag_state_();
+        // The block manipulated only the SrcA format override bank directly; the Src zero-substitution flag
+        // was set via the tracker above, so its recorded UNARY_PRESERVE state is still accurate.
     }
     else
     {
@@ -209,7 +205,9 @@ inline void _llk_math_eltwise_unary_datacopy_(const std::uint32_t dst_index, con
             if (dst_format == to_underlying(DataFormat::UInt16))
             {
                 cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_override_RMW>(1);
-                cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+                // Disable the Src zero-substitution flag (via the tracker) so UInt16 datums whose low byte is 0
+                // are not flushed. Owning it through the tracker keeps its recorded state consistent with HW.
+                math::ZeroFlags::execute_reconfig_unary_preserve();
                 cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_val_RMW>(to_underlying(DataFormat::Tf32));
             }
         }
@@ -236,16 +234,12 @@ inline void _llk_math_eltwise_unary_datacopy_(const std::uint32_t dst_index, con
 
         if constexpr (is_fp32_dest_acc_en && src_b_bcast_type != BroadcastType::NONE)
         {
-            // Undo format switching option: clear the override and zero-flag-disable bits set above so the
-            // implied SrcA format and default zero-flag behavior are restored (matches the Blackhole path).
+            // Undo format switching option: clear the SrcA override so the implied SrcA format is restored.
+            // The Src zero-substitution flag was set via the tracker above (UNARY_PRESERVE); leave it for the
+            // next reconfig to re-apply, matching the Blackhole path.
             if (dst_format == to_underlying(DataFormat::UInt16))
             {
                 cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_override_RMW>(0);
-                cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(0);
-                // The Zero_Flag_disabled_src bit was set/cleared above via raw RMW, bypassing the math
-                // state tracker; invalidate the tracked state so the next configurator re-applies the flag
-                // instead of taking its skip-if-set fast path (matches the Blackhole path).
-                math::_invalidate_src_zero_flag_state_();
             }
         }
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
@@ -41,7 +41,7 @@ inline void reduce_row_perform_transpose()
     // A datum whose low byte is zero (e.g. bf16 0x4400 = 768.0) would be flushed to 0 mid-reduction,
     // corrupting the sum. Disable the flag (via the math state tracker) around the transpose+add, then
     // return it to the operand driven baseline.
-    math::_configure_mov_ops_zero_flag_state_();
+    math::ZeroFlags::execute_reconfig_mov_ops();
 
     if constexpr (is_int_fpu_en)
     {
@@ -73,7 +73,7 @@ inline void reduce_row_perform_transpose()
     TTI_ELWADD(0, 0, p_elwise::SRCB_NO_BCAST, ADDR_MOD_1, 0);
 
     // Restore the operand-driven baseline for the currently configured formats.
-    math::_configure_default_zero_flag_state_(src_zero_flag_srca_fmt, src_zero_flag_srcb_fmt);
+    math::ZeroFlags::execute_reconfig(math::ZeroFlags::get_fpu_format(), math::ZeroFlags::get_sfpu_format());
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_transpose_dest.h
@@ -48,7 +48,7 @@ inline void transpose_dest_32b()
     // The 32b hi16/lo16 MOV sequence must not flush datums with a zero low byte; own the Src
     // zero-substitution flag via the math state tracker. Asserted here (execute) so it survives any
     // llk_math_hw_configure that ran after the init; skip-if-set keeps it cheap.
-    math::_configure_mov_ops_zero_flag_state_();
+    math::ZeroFlags::execute_reconfig_mov_ops();
 
     // Transpose all the low 16 bit elements of all faces and put them in SrcA.
     // Eventually Dest=0, SrcA=0.


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Feature

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Attempt to centralize Zero Flags management

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sstanisic/flush-wrapper)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sstanisic/flush-wrapper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sstanisic/flush-wrapper)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sstanisic/flush-wrapper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=sstanisic/flush-wrapper)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:sstanisic/flush-wrapper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sstanisic/flush-wrapper)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sstanisic/flush-wrapper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sstanisic/flush-wrapper)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sstanisic/flush-wrapper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sstanisic/flush-wrapper)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sstanisic/flush-wrapper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sstanisic/flush-wrapper)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sstanisic/flush-wrapper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sstanisic/flush-wrapper)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sstanisic/flush-wrapper)