### PR TITLE
[Performance] fused create-heads op for GDN prefill use

### DIFF
--- a/models/demos/blackhole/qwen36/tt/gdn/tp.py
+++ b/models/demos/blackhole/qwen36/tt/gdn/tp.py
@@ -21,6 +21,7 @@ from models.experimental.gated_attention_gated_deltanet.tt.ttnn_delta_rule_ops i
     recurrent_gated_delta_rule_decode_ttnn,
 )
 from models.experimental.gated_attention_gated_deltanet.tt.ttnn_delta_rule_seq import (
+    _create_heads,
     chunk_gated_delta_rule_seq_adapter,
     create_chunk_masks_seq,
 )
@@ -275,14 +276,23 @@ class TPGatedDeltaNet:
 
         kd = self.key_dim_tp
         rf = Nv // Nk
-        # Head-split in ROW_MAJOR, so that the reshapes are free
-        conv = ttnn.to_layout(conv, ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-        q = ttnn.reshape(ttnn.slice(conv, (0, 0, 0), (1, T, kd)), (1, T, Nk, Dk))
-        k = ttnn.reshape(ttnn.slice(conv, (0, 0, kd), (1, T, 2 * kd)), (1, T, Nk, Dk))
-        v = ttnn.reshape(ttnn.slice(conv, (0, 0, 2 * kd), (1, T, self.qkv_dim_tp)), (1, T, Nv, Dv))
-        ttnn.deallocate(conv)
-        q = ttnn.repeat_interleave(q, rf, dim=2)
-        k = ttnn.repeat_interleave(k, rf, dim=2)
+        # create_gdn_heads (default on): hand the fused TILE conv to nlp_create_qkv_heads_gdn inside
+        # the adapter, folding the host-side head-split (RM cast + slices + reshapes) AND the
+        # adapter's token->head permute into one address-arithmetic op. conv is TILE here (pre-RM).
+        # QWEN_GDN_CREATE_HEADS=0 restores the legacy host-side head-split below. Bit-identical.
+        if _create_heads():
+            q = k = v = None
+            fused_qkv, fused_hc = conv, (Nk, Nk, Nv, Dk)
+        else:
+            fused_qkv = fused_hc = None
+            # Head-split in ROW_MAJOR, so that the reshapes are free
+            conv = ttnn.to_layout(conv, ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+            q = ttnn.reshape(ttnn.slice(conv, (0, 0, 0), (1, T, kd)), (1, T, Nk, Dk))
+            k = ttnn.reshape(ttnn.slice(conv, (0, 0, kd), (1, T, 2 * kd)), (1, T, Nk, Dk))
+            v = ttnn.reshape(ttnn.slice(conv, (0, 0, 2 * kd), (1, T, self.qkv_dim_tp)), (1, T, Nv, Dv))
+            ttnn.deallocate(conv)
+            q = ttnn.repeat_interleave(q, rf, dim=2)
+            k = ttnn.repeat_interleave(k, rf, dim=2)
 
         beta = ttnn.reshape(ttnn.sigmoid(b), (1, T, Nv))
         ttnn.deallocate(b)
@@ -301,6 +311,8 @@ class TPGatedDeltaNet:
             device=self.mesh,
             cached_masks=self.chunk_seq_masks,
             valid_len=valid_len,
+            fused_qkv=fused_qkv,
+            fused_hc=fused_hc,
         )
         B, D = 1, self.qkv_dim_tp
         # ---- Carry recurrent + conv state for the NEXT chunk (chunk-outer prefill). ----

--- a/models/experimental/gated_attention_gated_deltanet/tt/ttnn_delta_rule_seq.py
+++ b/models/experimental/gated_attention_gated_deltanet/tt/ttnn_delta_rule_seq.py
@@ -52,33 +52,55 @@ _TILE = 32
 _DRAM = ttnn.DRAM_MEMORY_CONFIG
 
 
+def _create_heads():
+    """Default-ON switch for the fused ``nlp_create_qkv_heads_gdn`` op: one kernel reads the fused
+    token-major conv output and emits head-major q/k/v, replacing the caller's host-side conv
+    head-split AND this adapter's ``_to_bhtd`` token->head permute with page-id address arithmetic.
+    Bit-identical (pure tile relocation). Set ``QWEN_GDN_CREATE_HEADS=0`` to fall back to the legacy
+    head-split + ``_to_bhtd`` permute path."""
+    return _os.environ.get("QWEN_GDN_CREATE_HEADS", "1") != "0"
+
+
 def chunk_gated_delta_rule_seq_adapter(
-    q,  # [B, T, H, K]
-    k,  # [B, T, H, K]
-    v,  # [B, T, H, V]
-    beta,  # [B, T, H]
-    g,  # [B, T, H]
+    q=None,  # [B, T, H, K]  (None when fused_qkv is given)
+    k=None,  # [B, T, H, K]
+    v=None,  # [B, T, H, V]
+    beta=None,  # [B, T, H]
+    g=None,  # [B, T, H]
     chunk_size=128,
     scale=None,
     initial_state=None,  # [B, H, K, V] (any dtype) or None
     device=None,
     cached_masks=None,
     valid_len=None,
+    fused_qkv=None,  # [B, T, (Nq+Nk+Nv)*D] token-major conv output; when set, one
+    fused_hc=None,  # (num_q, num_k, num_v, head_dim) — nlp_create_qkv_heads_gdn does the head-split
 ):
     """Drop-in replacement for chunk_gated_delta_rule_ttnn that runs the C++
     chunk-parallel `gated_delta_attn_seq` kernel.
 
-    Same interface ([B,T,H,*] inputs, returns (o [B,T,H,V], new_state [B,H,K,V])).
-    Internally L2-norms q/k (matching the bf16 chunk path), converts to the seq
-    kernel's [BH,T,*] float32 layout, runs the kernel, and converts the output
-    and final state back. final_state is returned as bfloat16 to match the
-    decode recurrent_state dtype.
+    Inputs are [B,T,H,*] (q/k/v/beta/g), or — when ``fused_qkv``/``fused_hc`` are given — the fused
+    token-major conv output plus its (num_q, num_k, num_v, head_dim); in that mode the head-split +
+    token->head permute are done by the ``nlp_create_qkv_heads_gdn`` op instead of the ``_to_bhtd``
+    permute (bit-identical). Returns (o [B,T,H,V], new_state [B,H,K,V]). Internally L2-norms q/k
+    (matching the bf16 chunk path), converts to the seq kernel's [BH,T,*] float32 layout, runs the
+    kernel, and converts the output and final state back. final_state is returned as bfloat16 to
+    match the decode recurrent_state dtype.
     """
-    B = q.shape[0]
-    T = q.shape[1]
-    H = q.shape[2]
-    K = q.shape[3]
-    V = v.shape[3]
+    _use_fork = fused_qkv is not None
+    if _use_fork:
+        _nq, _nk, _nv, _dh = fused_hc
+        B = fused_qkv.shape[0]
+        T = fused_qkv.shape[1]
+        H = _nv  # value-head count (beta/g/v/output/state all use this)
+        K = _dh
+        V = _dh
+    else:
+        B = q.shape[0]
+        T = q.shape[1]
+        H = q.shape[2]
+        K = q.shape[3]
+        V = v.shape[3]
     BH = B * H
 
     def _tilize_f32(t):
@@ -99,9 +121,28 @@ def chunk_gated_delta_rule_seq_adapter(
         t = ttnn.reshape(t, [BH, T])
         return _tilize_f32(t)
 
-    q_bh = _to_bhtd(q, K)
-    k_bh = _to_bhtd(k, K)
-    v_bh = _to_bhtd(v, V)
+    if _use_fork:
+        # One fused op: token-major conv [B,T,(Nq+Nk+Nv)*D] -> head-major q/k/v, folding the
+        # host-side head-split + the _to_bhtd token->head permute into address arithmetic. The op
+        # emits q/k at Nk heads; block-repeat them to Nv (the GQA expand, unchanged from the legacy
+        # path) so all three enter the kernel at Nv. Reshape [B,Hh,T,D] -> [B*Hh,T,D] is free; the
+        # fp32 tilize matches _to_bhtd's output.
+        fused4 = ttnn.reshape(fused_qkv, [B, 1, T, (_nq + _nk + _nv) * _dh], memory_config=_DRAM)
+        q_h, k_h, v_h = ttnn.experimental.nlp_create_qkv_heads_gdn(
+            fused4, num_q_heads=_nq, num_k_heads=_nk, num_v_heads=_nv
+        )
+        ttnn.deallocate(fused_qkv)
+        rf = _nv // _nk
+        if rf > 1:
+            q_h = ttnn.repeat_interleave(q_h, rf, dim=1)  # [B,Nk,T,D] -> [B,Nv,T,D]
+            k_h = ttnn.repeat_interleave(k_h, rf, dim=1)
+        q_bh = _tilize_f32(ttnn.reshape(q_h, [BH, T, _dh]))
+        k_bh = _tilize_f32(ttnn.reshape(k_h, [BH, T, _dh]))
+        v_bh = _tilize_f32(ttnn.reshape(v_h, [BH, T, _dh]))
+    else:
+        q_bh = _to_bhtd(q, K)
+        k_bh = _to_bhtd(k, K)
+        v_bh = _to_bhtd(v, V)
 
     q_bh = l2_norm_ttnn(q_bh, dim=-1)
     k_bh = l2_norm_ttnn(k_bh, dim=-1)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_gdn.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_gdn.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit test for the GDN create-heads op `ttnn.experimental.nlp_create_qkv_heads_gdn`.
+
+The op is a pure address-arithmetic scatter (fused token-major [B,1,S,(Nq+Nk+Nv)*D] ->
+head-major Q/K/V [B,H,S,D], no compute), so its output must be BIT-IDENTICAL to a torch
+slice+reshape+permute reference. This is also the primary gate for the batched-barrier
+reader/writer change: batching the NoC transfers only relocates barriers, so `max_abs_diff`
+must stay exactly 0.
+
+The B>1 shapes exercise the writer's per-block batch-rollover bookkeeping.
+"""
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import comp_pcc
+
+
+def _reference(A, nq, nk, nv, d):
+    """[B, 1, S, (nq+nk+nv)*d] -> head-major q/k/v, each [B, H, S, d]."""
+    B, _, S, _ = A.shape
+    q, k, v = torch.split(A, [nq * d, nk * d, nv * d], dim=-1)
+
+    def to_heads(t, h):
+        return t.reshape(B, S, h, d).permute(0, 2, 1, 3).contiguous()
+
+    return to_heads(q, nq), to_heads(k, nk), to_heads(v, nv)
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize(
+    "batch, seq_len, nq, nk, nv, head_dim",
+    [
+        (1, 128, 4, 4, 12, 128),  # GDN Qwen3.6-27B SIM_TP=4 shape (a few seq tile-rows)
+        (1, 2048, 4, 4, 12, 128),  # GDN full prefill window
+        (2, 256, 4, 4, 12, 128),  # B>1 -> exercises the writer batch-rollover
+        (1, 64, 2, 2, 3, 64),  # smaller / odd head counts + head_dim
+    ],
+)
+def test_nlp_create_qkv_heads_gdn(batch, seq_len, nq, nk, nv, head_dim, dtype, device):
+    torch.manual_seed(1234)
+    width = (nq + nk + nv) * head_dim
+    A = torch.randn(batch, 1, seq_len, width)
+    if dtype == ttnn.bfloat16:
+        # Snap to the bf16 grid so the reference and the (bf16-tile-moving) op agree exactly.
+        A = A.to(torch.bfloat16).to(torch.float32)
+
+    in0 = ttnn.from_torch(A, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    q, k, v = ttnn.experimental.nlp_create_qkv_heads_gdn(in0, num_q_heads=nq, num_k_heads=nk, num_v_heads=nv)
+
+    assert list(q.padded_shape) == [batch, nq, seq_len, head_dim]
+    assert list(k.padded_shape) == [batch, nk, seq_len, head_dim]
+    assert list(v.padded_shape) == [batch, nv, seq_len, head_dim]
+
+    ref_q, ref_k, ref_v = _reference(A, nq, nk, nv, head_dim)
+    for name, got_t, ref in [("Q", q, ref_q), ("K", k, ref_k), ("V", v, ref_v)]:
+        got = ttnn.to_torch(got_t).to(torch.float32)
+        max_abs = (got - ref).abs().max().item()
+        passing, pcc = comp_pcc(ref, got, 1.0)
+        logger.info(f"{name}: max_abs_diff={max_abs} pcc={pcc}")
+        # Pure relocation of tiles -> must be exact, not just high-PCC.
+        assert max_abs == 0.0, f"{name} not bit-identical (max_abs_diff={max_abs})"
+        assert passing, f"{name} PCC {pcc} below 1.0"

--- a/ttnn/cpp/ttnn/operations/experimental/experimental_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/experimental_nanobind.cpp
@@ -26,6 +26,7 @@
 #include "ttnn/operations/experimental/transformer/nlp_concat_heads_decode/nlp_concat_heads_decode_nanobind.hpp"
 #include "ttnn/operations/experimental/transformer/nlp_concat_heads_boltz/nlp_concat_heads_boltz_nanobind.hpp"
 #include "ttnn/operations/experimental/transformer/nlp_create_qkv_heads/nlp_create_qkv_heads_nanobind.hpp"
+#include "ttnn/operations/experimental/transformer/nlp_create_qkv_heads_gdn/nlp_create_qkv_heads_gdn_nanobind.hpp"
 #include "ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/nlp_create_qkv_heads_decode_nanobind.hpp"
 #include "ttnn/operations/experimental/transformer/nlp_create_qkv_heads_falcon7b/nlp_create_qkv_heads_falcon7b_nanobind.hpp"
 #include "ttnn/operations/experimental/transformer/nlp_create_qkv_heads_vit/nlp_create_qkv_heads_vit_nanobind.hpp"
@@ -102,6 +103,7 @@ void py_module(nb::module_& mod) {
     transformer::detail::bind_concatenate_heads(mod);
     transformer::detail::bind_split_qkv(mod);
     transformer::detail::bind_nlp_create_qkv_heads(mod);
+    transformer::detail::bind_nlp_create_qkv_heads_gdn(mod);
     transformer::detail::bind_create_qkv_heads_from_separate_tensors(mod);
     nlp_concat_heads_decode::detail::bind_nlp_concat_heads_decode(mod);
     nlp_concat_heads::detail::bind_nlp_concat_heads(mod);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_gdn/device/kernels/dataflow/reader_nlp_create_qkv_heads_gdn.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_gdn/device/kernels/dataflow/reader_nlp_create_qkv_heads_gdn.cpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// GDN create-heads reader: reads the fused token-major input one seq-tile-row ("block") at a time.
+// Per block the fused width is a contiguous run of q_num_tiles (Q) + k_num_tiles (K) + v_num_tiles
+// (V) tiles; the Q|K|V column split is implicit in read order. The whole block's qkv_tiles are read
+// into cb1 behind a SINGLE async_read_barrier so the NoC pipelines them (vs one barrier per tile).
+// The writer pops them in the same q→k→v order and scatters them head-major. No transpose.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    Noc noc;
+
+    // RUNTIME ARGS
+    uint32_t in0_tensor_addr = get_arg_val<uint32_t>(0);
+    uint32_t num_blocks = get_arg_val<uint32_t>(1);
+    uint32_t in0_tensor_tile_id = get_arg_val<uint32_t>(2);
+
+    // COMPILE TIME ARGS
+    constexpr uint32_t q_num_tiles = get_compile_time_arg_val(0);
+    constexpr uint32_t k_num_tiles = get_compile_time_arg_val(1);
+    constexpr uint32_t v_num_tiles = get_compile_time_arg_val(2);
+    constexpr auto in0_args = TensorAccessorArgs<3>();
+
+    constexpr uint32_t cb_id = 1;
+    constexpr uint32_t qkv_tiles = q_num_tiles + k_num_tiles + v_num_tiles;
+
+    const auto s0 = TensorAccessor(in0_args, in0_tensor_addr);
+    CircularBuffer cb(cb_id);
+    const uint32_t tile_bytes = get_tile_size(cb_id);
+
+    for (uint32_t block = 0; block < num_blocks; block++) {
+        // Reserve the whole block (Q run, then K run, then V run — contiguous in the fused input).
+        // The CB is sized to an integer multiple of qkv_tiles (see the program factory), so the
+        // reserved region never wraps the ring and the qkv_tiles tiles are contiguous in L1.
+        cb.reserve_back(qkv_tiles);
+        uint32_t l1_write_addr = cb.get_write_ptr();
+        for (uint32_t i = 0; i < qkv_tiles; i++) {
+            noc.async_read(
+                s0,
+                CoreLocalMem<uint32_t>(l1_write_addr + i * tile_bytes),
+                tile_bytes,
+                {.page_id = in0_tensor_tile_id},
+                {});
+            in0_tensor_tile_id++;
+        }
+        noc.async_read_barrier();  // one barrier for the whole block: the reads pipeline on the NoC
+        cb.push_back(qkv_tiles);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_gdn/device/kernels/dataflow/writer_nlp_create_qkv_heads_gdn.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_gdn/device/kernels/dataflow/writer_nlp_create_qkv_heads_gdn.cpp
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// GDN create-heads writer: consumes one seq-tile-row ("block") of cb1 tiles in q→k→v order and
+// scatters them head-major into Q [B, q_out_c, S, head_dim], K [B, k_out_c, S, head_dim],
+// V [B, v_out_c, S, head_dim]. Each head is a contiguous HtWt block in its output tensor (per-head
+// stride out_HtWt); within a head the out_w_tiles (head_dim) tiles are contiguous. No transpose.
+// Q/K/V share out_h_tiles/out_w_tiles (shared head_dim); only the head COUNT differs. The whole
+// block's qkv_tiles scattered writes are issued behind a SINGLE async_write_barrier so the NoC
+// pipelines them (vs one barrier per tile); the CB handshake (wait_front/pop_front) is per block.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    Noc noc;
+
+    // RUNTIME ARGS
+    uint32_t q_tensor_addr = get_arg_val<uint32_t>(0);
+    uint32_t k_tensor_addr = get_arg_val<uint32_t>(1);
+    uint32_t v_tensor_addr = get_arg_val<uint32_t>(2);
+    uint32_t num_blocks = get_arg_val<uint32_t>(3);
+    uint32_t out_h_dim = get_arg_val<uint32_t>(4);
+    uint32_t q_out_tensor_tile_id = get_arg_val<uint32_t>(5);
+    uint32_t k_out_tensor_tile_id = get_arg_val<uint32_t>(6);
+    uint32_t v_out_tensor_tile_id = get_arg_val<uint32_t>(7);
+
+    // COMPILE TIME ARGS
+    constexpr uint32_t out_h_tiles = get_compile_time_arg_val(0);
+    constexpr uint32_t out_w_tiles = get_compile_time_arg_val(1);
+    constexpr uint32_t out_HtWt = get_compile_time_arg_val(2);
+    constexpr uint32_t q_out_c = get_compile_time_arg_val(3);
+    constexpr uint32_t k_out_c = get_compile_time_arg_val(4);
+    constexpr uint32_t v_out_c = get_compile_time_arg_val(5);
+    constexpr auto q_args = TensorAccessorArgs<6>();
+    constexpr auto k_args = TensorAccessorArgs<q_args.next_compile_time_args_offset()>();
+    constexpr auto v_args = TensorAccessorArgs<k_args.next_compile_time_args_offset()>();
+
+    constexpr uint32_t cb_id = 1;
+    constexpr uint32_t qkv_tiles = (q_out_c + k_out_c + v_out_c) * out_w_tiles;
+
+    const auto sq = TensorAccessor(q_args, q_tensor_addr);
+    const auto sk = TensorAccessor(k_args, k_tensor_addr);
+    const auto sv = TensorAccessor(v_args, v_tensor_addr);
+
+    CircularBuffer cb(cb_id);
+    const uint32_t tile_bytes = get_tile_size(cb_id);
+
+    // Scatter one output tensor's heads for this block: `heads` heads, each an HtWt block, base
+    // page-id `out_tile_id`, per-head stride out_HtWt, per-w-tile stride 1. Reads each tile from
+    // `read_base + idx * tile_bytes` (idx runs across the whole block's q→k→v tiles, matching the
+    // reader's read order) and issues the async_write WITHOUT its own barrier/pop — the caller
+    // barriers + pops the whole block once. Returns the last current tile-id (for batch rollover).
+    auto scatter =
+        [&](const auto& s, uint32_t heads, uint32_t out_tile_id, uint32_t read_base, uint32_t& idx) -> uint32_t {
+        uint32_t along_c = out_tile_id;
+        uint32_t cur = out_tile_id;
+        for (uint32_t c_dim = 0; c_dim < heads; c_dim++) {
+            cur = along_c;
+            for (uint32_t w_dim = 0; w_dim < out_w_tiles; w_dim++) {
+                noc.async_write(
+                    CoreLocalMem<uint32_t>(read_base + idx * tile_bytes), s, tile_bytes, {}, {.page_id = cur});
+                idx++;
+                cur++;
+            }
+            along_c += out_HtWt;
+        }
+        return cur;
+    };
+
+    for (uint32_t block = 0; block < num_blocks; block++) {
+        // Consume the whole block at once. The CB is sized to a multiple of qkv_tiles (program
+        // factory), so the qkv_tiles tiles are contiguous in L1 from read_base; idx threads the
+        // q→k→v read order the reader produced.
+        cb.wait_front(qkv_tiles);
+        uint32_t read_base = cb.get_read_ptr();
+        uint32_t idx = 0;
+        uint32_t q_cur = scatter(sq, q_out_c, q_out_tensor_tile_id, read_base, idx);
+        uint32_t k_cur = scatter(sk, k_out_c, k_out_tensor_tile_id, read_base, idx);
+        uint32_t v_cur = scatter(sv, v_out_c, v_out_tensor_tile_id, read_base, idx);
+        noc.async_write_barrier();  // one barrier for the whole block: the writes pipeline on the NoC
+        cb.pop_front(qkv_tiles);
+
+        // Advance to the next seq tile-row, or roll over to the next batch after one full CHtWt.
+        out_h_dim++;
+        if (out_h_dim < out_h_tiles) {
+            q_out_tensor_tile_id += out_w_tiles;
+            k_out_tensor_tile_id += out_w_tiles;
+            v_out_tensor_tile_id += out_w_tiles;
+        } else {
+            q_out_tensor_tile_id = q_cur;
+            k_out_tensor_tile_id = k_cur;
+            v_out_tensor_tile_id = v_cur;
+            out_h_dim = 0;
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_gdn/device/nlp_create_qkv_heads_gdn_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_gdn/device/nlp_create_qkv_heads_gdn_device_operation.cpp
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "nlp_create_qkv_heads_gdn_device_operation.hpp"
+#include "ttnn/tensor/tensor_ops.hpp"
+
+#include <tt-metalium/work_split.hpp>
+#include "ttnn/device_operation.hpp"
+
+namespace ttnn::operations::experimental::transformer {
+
+void NlpCreateHeadsGdnDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    using namespace tt::constants;
+    const auto& input_tensor = tensor_args.input_tensor;
+    const auto input_shape = input_tensor.padded_shape();
+
+    TT_FATAL(
+        input_tensor.storage_type() == StorageType::DEVICE,
+        "Operands to TM need to be on device! {}",
+        input_tensor.storage_type());
+    TT_FATAL(input_tensor.buffer() != nullptr, "Operands to TM need to be allocated in buffers on device!");
+    TT_FATAL(
+        input_tensor.dtype() == tt::tt_metal::DataType::FLOAT32 ||
+            input_tensor.dtype() == tt::tt_metal::DataType::BFLOAT16 ||
+            input_tensor.dtype() == tt::tt_metal::DataType::BFLOAT8_B,
+        "Unsupported data format");
+    TT_FATAL(
+        input_tensor.layout() == Layout::TILE, "Input tensor layout must be TILE but got {}", input_tensor.layout());
+    TT_FATAL(!input_tensor.is_sharded(), "GDN create-heads supports only interleaved input");
+    TT_FATAL(
+        operation_attributes.output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED,
+        "Output memory config layout must be INTERLEAVED but got {}",
+        operation_attributes.output_mem_config.memory_layout());
+
+    TT_FATAL(input_shape[1] == 1, "Unsupported input shape[1] {} is not equal to 1", input_shape[1]);
+    TT_FATAL(input_shape[2] % TILE_HEIGHT == 0, "Unsupported input height {} is not tile aligned", input_shape[2]);
+    TT_FATAL(
+        operation_attributes.head_dim % TILE_WIDTH == 0,
+        "head_dim {} must be tile aligned",
+        operation_attributes.head_dim);
+    const uint32_t expected_w =
+        (operation_attributes.num_q_heads + operation_attributes.num_k_heads + operation_attributes.num_v_heads) *
+        operation_attributes.head_dim;
+    TT_FATAL(
+        input_shape[3] == expected_w, "Fused width {} must equal (Nq+Nk+Nv)*head_dim = {}", input_shape[3], expected_w);
+}
+
+void NlpCreateHeadsGdnDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& /*tensor_args*/) {}
+
+NlpCreateHeadsGdnDeviceOperation::spec_return_value_t NlpCreateHeadsGdnDeviceOperation::compute_output_specs(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    using namespace tt::constants;
+    if (tensor_args.optional_output_tensors.size() == 3) {
+        const auto& output_tensors = tensor_args.optional_output_tensors;
+        return {
+            output_tensors.at(0)->tensor_spec(),
+            output_tensors.at(1)->tensor_spec(),
+            output_tensors.at(2)->tensor_spec()};
+    }
+
+    const auto& input_tensor = tensor_args.input_tensor;
+    const auto input_shape = input_tensor.logical_shape();
+    const auto sequence_length = input_shape[2];
+    const auto head_dim = operation_attributes.head_dim;
+
+    const Shape q_output_shape({input_shape[0], operation_attributes.num_q_heads, sequence_length, head_dim});
+    const Shape k_output_shape({input_shape[0], operation_attributes.num_k_heads, sequence_length, head_dim});
+    const Shape v_output_shape({input_shape[0], operation_attributes.num_v_heads, sequence_length, head_dim});
+
+    auto make_spec = [&](const Shape& shape) {
+        return TensorSpec(
+            shape,
+            tt::tt_metal::TensorLayout(
+                input_tensor.dtype(), tt::tt_metal::PageConfig(Layout::TILE), operation_attributes.output_mem_config));
+    };
+    return {make_spec(q_output_shape), make_spec(k_output_shape), make_spec(v_output_shape)};
+}
+
+NlpCreateHeadsGdnDeviceOperation::tensor_return_value_t NlpCreateHeadsGdnDeviceOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.input_tensor;
+    if (tensor_args.optional_output_tensors.size() == 3) {
+        const auto& output_tensors = tensor_args.optional_output_tensors;
+        return {output_tensors.at(0).value(), output_tensors.at(1).value(), output_tensors.at(2).value()};
+    }
+    auto output_specs = compute_output_specs(operation_attributes, tensor_args);
+    return {
+        create_device_tensor(std::get<0>(output_specs), input_tensor.device()),
+        create_device_tensor(std::get<1>(output_specs), input_tensor.device()),
+        create_device_tensor(std::get<2>(output_specs), input_tensor.device()),
+    };
+}
+
+NlpCreateHeadsGdnDeviceOperation::program_factory_t NlpCreateHeadsGdnDeviceOperation::select_program_factory(
+    const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& /*tensor_args*/) {
+    return Interleaved{};
+}
+
+}  // namespace ttnn::operations::experimental::transformer
+
+namespace ttnn::prim {
+
+std::tuple<Tensor, Tensor, Tensor> nlp_create_qkv_heads_gdn(
+    const Tensor& input_tensor,
+    uint32_t num_q_heads,
+    uint32_t num_k_heads,
+    uint32_t num_v_heads,
+    uint32_t head_dim,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<std::vector<std::optional<Tensor>>>& optional_output_tensors) {
+    using OperationType = ttnn::operations::experimental::transformer::NlpCreateHeadsGdnDeviceOperation;
+
+    auto operation_attributes = OperationType::operation_attributes_t{
+        .num_q_heads = num_q_heads,
+        .num_k_heads = num_k_heads,
+        .num_v_heads = num_v_heads,
+        .head_dim = head_dim,
+        .output_mem_config = memory_config.value_or(input_tensor.memory_config())};
+    auto tensor_args = OperationType::tensor_args_t{
+        .input_tensor = input_tensor,
+        .optional_output_tensors = optional_output_tensors.value_or(std::vector<std::optional<Tensor>>{})};
+
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_gdn/device/nlp_create_qkv_heads_gdn_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_gdn/device/nlp_create_qkv_heads_gdn_device_operation.hpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+#include <variant>
+
+#include "ttnn/operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/types.hpp"
+
+#include <tt-metalium/program_descriptors.hpp>
+
+// GDN fork of nlp_create_qkv_heads: splits a fused token-major [B, 1, S, (Nq+Nk+Nv)*head_dim]
+// input into head-major Q [B, Nq, S, head_dim], K [B, Nk, S, head_dim], V [B, Nv, S, head_dim].
+// Unlike the base op, Q/K/V may each have an INDEPENDENT head count (GDN uses Nq==Nk!=Nv), the K
+// head-transpose is dropped (always false), and only the INTERLEAVED path is supported. head_dim
+// is shared across Q/K/V (caller must guarantee Dk==Dv).
+
+namespace ttnn::operations::experimental::transformer {
+
+struct NlpCreateHeadsGdnDeviceOperation {
+    struct operation_attributes_t {
+        uint32_t num_q_heads;
+        uint32_t num_k_heads;
+        uint32_t num_v_heads;
+        uint32_t head_dim;
+        MemoryConfig output_mem_config;
+    };
+
+    struct tensor_args_t {
+        const Tensor& input_tensor;
+        std::vector<std::optional<Tensor>> optional_output_tensors;
+    };
+
+    using spec_return_value_t = std::tuple<ttnn::TensorSpec, ttnn::TensorSpec, ttnn::TensorSpec>;
+    using tensor_return_value_t = std::tuple<Tensor, Tensor, Tensor>;
+
+    struct Interleaved {
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value);
+    };
+
+    using program_factory_t = std::variant<Interleaved>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+};
+
+}  // namespace ttnn::operations::experimental::transformer
+
+namespace ttnn::prim {
+std::tuple<Tensor, Tensor, Tensor> nlp_create_qkv_heads_gdn(
+    const Tensor& input_tensor,
+    uint32_t num_q_heads,
+    uint32_t num_k_heads,
+    uint32_t num_v_heads,
+    uint32_t head_dim,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<std::vector<std::optional<Tensor>>>& optional_output_tensors);
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_gdn/device/nlp_create_qkv_heads_gdn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_gdn/device/nlp_create_qkv_heads_gdn_program_factory.cpp
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+#include "nlp_create_qkv_heads_gdn_device_operation.hpp"
+
+namespace ttnn::operations::experimental::transformer {
+
+using namespace tt::constants;
+using namespace tt;
+using namespace tt::tt_metal;
+
+ProgramDescriptor NlpCreateHeadsGdnDeviceOperation::Interleaved::create_descriptor(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    const Tensor& input_tensor = tensor_args.input_tensor;
+    const uint32_t num_q_heads = operation_attributes.num_q_heads;
+    const uint32_t num_k_heads = operation_attributes.num_k_heads;
+    const uint32_t num_v_heads = operation_attributes.num_v_heads;
+    const uint32_t head_dim = operation_attributes.head_dim;
+    auto& output = tensor_return_value;
+    CoreCoord compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
+
+    const auto& input_shape = input_tensor.padded_shape();
+    tt::DataFormat cb_data_format = tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+    uint32_t single_tile_size = tt::tile_size(cb_data_format);
+    tt_metal::Buffer* in0_buffer = input_tensor.buffer();
+    TT_ASSERT(in0_buffer->size() % single_tile_size == 0);
+
+    // TM params. Output h/w dims (S tiles, head_dim tiles) are identical for Q/K/V (shared head_dim),
+    // so the per-head block HtWt is shared; only the head COUNT (and thus the batch stride) differs.
+    uint32_t in0_w_tiles = input_shape[3] / TILE_WIDTH;
+    uint32_t out_h_tiles = input_shape[2] / TILE_HEIGHT;
+    uint32_t out_w_tiles = head_dim / TILE_WIDTH;  // tiles along head_dim
+    uint32_t out_HtWt = out_h_tiles * out_w_tiles;
+    uint32_t q_out_CHtWt = num_q_heads * out_HtWt;
+    uint32_t k_out_CHtWt = num_k_heads * out_HtWt;
+    uint32_t v_out_CHtWt = num_v_heads * out_HtWt;
+    uint32_t q_num_tiles = num_q_heads * out_w_tiles;
+    uint32_t k_num_tiles = num_k_heads * out_w_tiles;
+    uint32_t v_num_tiles = num_v_heads * out_w_tiles;
+
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    // Block = one seq tile-row (TILE_HEIGHT tokens) = in0_w_tiles fused-width tiles.
+    uint32_t num_blocks = input_shape[0] * input_shape[1] * input_shape[2] / TILE_HEIGHT;
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_blocks_per_core_group_1, num_blocks_per_core_group_2] =
+        tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_blocks);
+
+    tt_metal::Tensor& q = std::get<0>(output);
+    tt_metal::Tensor& k = std::get<1>(output);
+    tt_metal::Tensor& v = std::get<2>(output);
+    tt_metal::Buffer* q_buffer = q.buffer();
+    tt_metal::Buffer* k_buffer = k.buffer();
+    tt_metal::Buffer* v_buffer = v.buffer();
+    TT_ASSERT(q_buffer != nullptr && k_buffer != nullptr && v_buffer != nullptr, "Output buffers must be allocated!");
+
+    ProgramDescriptor desc;
+
+    std::vector<uint32_t> reader_compile_time_args = {
+        (std::uint32_t)q_num_tiles,
+        (std::uint32_t)k_num_tiles,
+        (std::uint32_t)v_num_tiles,
+    };
+    tt::tt_metal::TensorAccessorArgs(in0_buffer).append_to(reader_compile_time_args);
+
+    std::vector<uint32_t> writer_compile_time_args = {
+        (std::uint32_t)out_h_tiles,
+        (std::uint32_t)out_w_tiles,
+        (std::uint32_t)out_HtWt,
+        (std::uint32_t)num_q_heads,
+        (std::uint32_t)num_k_heads,
+        (std::uint32_t)num_v_heads,
+    };
+    tt::tt_metal::TensorAccessorArgs(q_buffer).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(k_buffer).append_to(writer_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(v_buffer).append_to(writer_compile_time_args);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_gdn/device/kernels/dataflow/"
+        "reader_nlp_create_qkv_heads_gdn.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_gdn/device/kernels/dataflow/"
+        "writer_nlp_create_qkv_heads_gdn.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    // Single circular buffer (cb1) — Q, K, V all flow through it in read order (no transpose).
+    // Sized to hold a whole block (qkv_tiles = in0_w_tiles) double-buffered: the reader fills the
+    // block behind one barrier and the writer drains it behind one barrier, so the two kernels
+    // pipeline one block apart. The total MUST stay an integer multiple of the block size so each
+    // reserve_back(qkv_tiles)/wait_front(qkv_tiles) region is contiguous in L1 (no ring wrap
+    // mid-block) — the ×2 factor keeps that invariant.
+    uint32_t cb_index = 1;
+    constexpr uint32_t kBufferFactor = 2;                 // double-buffer the block for reader/writer overlap
+    uint32_t cb_num_tiles = kBufferFactor * in0_w_tiles;  // in0_w_tiles == qkv_tiles (per block)
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = cb_num_tiles * single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(cb_index),
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+    });
+
+    for (uint32_t i = 0, num_blocks_written = 0; i < num_cores; i++) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        uint32_t num_blocks_per_core = 0;
+        if (core_group_1.contains(core)) {
+            num_blocks_per_core = num_blocks_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_blocks_per_core = num_blocks_per_core_group_2;
+        } else {
+            TT_ASSERT(false, "Core not in specified core ranges");
+        }
+
+        uint32_t out_h_dim = num_blocks_written % out_h_tiles;
+        uint32_t q_out_tensor_tile_id = (num_blocks_written / out_h_tiles * q_out_CHtWt) + (out_h_dim * out_w_tiles);
+        uint32_t k_out_tensor_tile_id = (num_blocks_written / out_h_tiles * k_out_CHtWt) + (out_h_dim * out_w_tiles);
+        uint32_t v_out_tensor_tile_id = (num_blocks_written / out_h_tiles * v_out_CHtWt) + (out_h_dim * out_w_tiles);
+
+        KernelDescriptor::RTArgList reader_rt;
+        reader_rt.reserve(3);
+        reader_rt.push_back(in0_buffer);
+        reader_rt.push_back(num_blocks_per_core);
+        reader_rt.push_back(num_blocks_written * in0_w_tiles);
+        reader_desc.emplace_runtime_args(core, reader_rt);
+
+        writer_desc.emplace_runtime_args(
+            core,
+            {
+                q_buffer,
+                k_buffer,
+                v_buffer,
+                num_blocks_per_core,
+                out_h_dim,
+                q_out_tensor_tile_id,
+                k_out_tensor_tile_id,
+                v_out_tensor_tile_id,
+            });
+
+        num_blocks_written += num_blocks_per_core;
+    }
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::operations::experimental::transformer

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_gdn/nlp_create_qkv_heads_gdn.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_gdn/nlp_create_qkv_heads_gdn.cpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "nlp_create_qkv_heads_gdn.hpp"
+
+namespace ttnn::experimental {
+
+std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> nlp_create_qkv_heads_gdn(
+    const Tensor& input_tensor,
+    const uint32_t num_q_heads,
+    const uint32_t num_k_heads,
+    const uint32_t num_v_heads,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<std::vector<std::optional<Tensor>>>& optional_output_tensors) {
+    const uint32_t total_heads = num_q_heads + num_k_heads + num_v_heads;
+    TT_FATAL(
+        input_tensor.padded_shape()[3] % total_heads == 0,
+        "Fused width {} must be divisible by (Nq+Nk+Nv) = {}",
+        input_tensor.padded_shape()[3],
+        total_heads);
+    const uint32_t head_dim = input_tensor.padded_shape()[3] / total_heads;
+
+    return ttnn::prim::nlp_create_qkv_heads_gdn(
+        input_tensor, num_q_heads, num_k_heads, num_v_heads, head_dim, memory_config, optional_output_tensors);
+}
+
+}  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_gdn/nlp_create_qkv_heads_gdn.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_gdn/nlp_create_qkv_heads_gdn.hpp
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "device/nlp_create_qkv_heads_gdn_device_operation.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::experimental {
+
+// GDN fork of nlp_create_qkv_heads. Splits a fused token-major [B, 1, S, (Nq+Nk+Nv)*head_dim]
+// input into head-major Q [B, Nq, S, head_dim], K [B, Nk, S, head_dim], V [B, Nv, S, head_dim].
+// Q/K/V may each have an independent head count (GDN: Nq==Nk!=Nv); head_dim is shared and inferred.
+std::tuple<Tensor, Tensor, Tensor> nlp_create_qkv_heads_gdn(
+    const Tensor& input_tensor,
+    uint32_t num_q_heads,
+    uint32_t num_k_heads,
+    uint32_t num_v_heads,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<std::vector<std::optional<Tensor>>>& optional_output_tensors = std::nullopt);
+
+}  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_gdn/nlp_create_qkv_heads_gdn_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_gdn/nlp_create_qkv_heads_gdn_nanobind.cpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "nlp_create_qkv_heads_gdn_nanobind.hpp"
+
+#include <optional>
+#include <vector>
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/tuple.h>
+#include <nanobind/stl/vector.h>
+
+#include "ttnn-nanobind/bind_function.hpp"
+#include "ttnn/operations/experimental/transformer/nlp_create_qkv_heads_gdn/nlp_create_qkv_heads_gdn.hpp"
+
+namespace ttnn::operations::experimental::transformer::detail {
+
+void bind_nlp_create_qkv_heads_gdn(nb::module_& mod) {
+    ttnn::bind_function<"nlp_create_qkv_heads_gdn", "ttnn.experimental.">(
+        mod,
+        R"doc(
+            GDN fork of nlp_create_qkv_heads. Shuffles a fused token-major
+            [B, 1, S, (num_q_heads + num_k_heads + num_v_heads) * head_dim] input into head-major
+            Q [B, num_q_heads, S, head_dim], K [B, num_k_heads, S, head_dim], V [B, num_v_heads, S, head_dim].
+            Q/K/V may each have an independent head count (GDN uses num_q==num_k!=num_v); head_dim is
+            shared across Q/K/V and inferred from the fused width. Interleaved TILE in/out, no K-transpose.
+        )doc",
+        &ttnn::experimental::nlp_create_qkv_heads_gdn,
+        nb::arg("input").noconvert(),
+        nb::kw_only(),
+        nb::arg("num_q_heads").noconvert(),
+        nb::arg("num_k_heads").noconvert(),
+        nb::arg("num_v_heads").noconvert(),
+        nb::arg("memory_config").noconvert() = nb::none(),
+        nb::arg("output_tensors").noconvert() = nb::none());
+}
+
+}  // namespace ttnn::operations::experimental::transformer::detail

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_gdn/nlp_create_qkv_heads_gdn_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_gdn/nlp_create_qkv_heads_gdn_nanobind.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-nanobind/nanobind_fwd.hpp"
+
+namespace ttnn::operations::experimental::transformer::detail {
+
+namespace nb = nanobind;
+void bind_nlp_create_qkv_heads_gdn(nb::module_& mod);
+}  // namespace ttnn::operations::experimental::transformer::detail

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/sources.cmake
@@ -27,6 +27,9 @@ set(TTNN_OP_EXPERIMENTAL_TRANSFORMER_SRCS
     nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.cpp
     nlp_create_qkv_heads/device/nlp_create_qkv_heads_program_factory.cpp
     nlp_create_qkv_heads/nlp_create_qkv_heads.cpp
+    nlp_create_qkv_heads_gdn/device/nlp_create_qkv_heads_gdn_device_operation.cpp
+    nlp_create_qkv_heads_gdn/device/nlp_create_qkv_heads_gdn_program_factory.cpp
+    nlp_create_qkv_heads_gdn/nlp_create_qkv_heads_gdn.cpp
     nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_device_operation.cpp
     nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_interleaved_program_factory.cpp
     nlp_create_qkv_heads_decode/device/nlp_create_qkv_heads_decode_sharded_program_factory.cpp
@@ -89,6 +92,8 @@ set(TTNN_OP_EXPERIMENTAL_TRANSFORMER_API_HEADERS
     nlp_concat_heads/nlp_concat_heads.hpp
     nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.hpp
     nlp_create_qkv_heads/nlp_create_qkv_heads.hpp
+    nlp_create_qkv_heads_gdn/device/nlp_create_qkv_heads_gdn_device_operation.hpp
+    nlp_create_qkv_heads_gdn/nlp_create_qkv_heads_gdn.hpp
     nlp_kv_cache_load_slice/nlp_kv_cache_load_slice.hpp
     rotary_embedding_llama/rotary_embedding_llama.hpp
 )
@@ -107,6 +112,7 @@ set(TTNN_OP_EXPERIMENTAL_TRANSFORMER_NANOBIND_SRCS
     nlp_concat_heads_decode/nlp_concat_heads_decode_nanobind.cpp
     nlp_concat_heads_boltz/nlp_concat_heads_boltz_nanobind.cpp
     nlp_create_qkv_heads/nlp_create_qkv_heads_nanobind.cpp
+    nlp_create_qkv_heads_gdn/nlp_create_qkv_heads_gdn_nanobind.cpp
     nlp_create_qkv_heads_decode/nlp_create_qkv_heads_decode_nanobind.cpp
     nlp_create_qkv_heads_falcon7b/nlp_create_qkv_heads_falcon7b_nanobind.cpp
     nlp_create_qkv_heads_segformer/nlp_create_qkv_heads_segformer_nanobind.cpp


### PR DESCRIPTION
### PR Category
Performance

### Summary

Contributes to https://github.com/tenstorrent/tt-metal/issues/42828

Adds a new experimental op `ttnn.experimental.nlp_create_qkv_heads_gdn` and uses it in the Qwen3.6-27B TP Gated-DeltaNet `forward_prefill` to fold the token to head layout change into a single dataflow op.

1. New op (fork of `nlp_create_qkv_heads`). Reads a fused token-major `[B, 1, S, (Nq+Nk+Nv)·D]` and emits head-major `Q [B, Nq, S, D]`, `K [B, Nk, S, D]`, `V [B, Nv, S, D]`.

2. Use in prefill. The fused TILE conv output is handed to the op inside `chunk_gated_delta_rule_seq_adapter`, replacing the host-side head-split (`ROW_MAJOR` cast + 3 slices + reshapes) **and** the adapter's 3× `_to_bhtd` token→head permute. GQA expand (`Nk→Nv`) and the fp32 tilize are unchanged. Gated by `QWEN_GDN_CREATE_HEADS` (default **on**; `=0` restores the legacy head-split, kept verbatim).

### Performance

**GDN `forward_prefill` (one block, isolated device-kernel time via Tracy, single card, T=4096 = 2 × 2048-token windows, Blackhole p100a).

| Stage | Baseline (legacy) | PR (create-heads) | Delta |
|-------|------------------:|------------------:|------:|
| conv (head-split folded away) | 1.635 ms | 1.214 ms | **−0.421 ms** |
| core.prep (token→head permute + L2-norm) | 1.504 ms | 1.101 ms | **−0.403 ms** |
| **Total (GDN block)** | **16.813 ms** | **15.957 ms** | **−0.856 ms (−5.1%)** |

### Notes for reviewers
