### PR TITLE
[Bug fix] Quickfix remove problematic warning message from telemetry

### DIFF
--- a/tt_metal/impl/dispatch/dispatch_telemetry.cpp
+++ b/tt_metal/impl/dispatch/dispatch_telemetry.cpp
@@ -40,11 +40,9 @@ std::optional<SMCRuntimeTelemetryBuffer> discover_smc_dispatch_telemetry_control
         // "unavailable" rather than propagate, otherwise it would break device init/close on devices that
         // don't back a firmware info provider.
         firmware_info_provider = tt_device.get_firmware_info_provider();
-    } catch (const std::exception& e) {
+    } catch (...) {
         log_warning(
-            tt::LogMetal,
-            "Dispatch telemetry SMC buffer unavailable (no firmware info provider, e.g. simulator): {}",
-            e.what());
+            tt::LogMetal, "Dispatch telemetry SMC buffer unavailable (no firmware info provider, e.g. simulator)");
     }
     if (firmware_info_provider == nullptr) {
         return std::nullopt;


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Remove problematic warning message that prints a traceback on telemetry incompatible platforms

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=anashTT/runtime-telemetry-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:anashTT/runtime-telemetry-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=anashTT/runtime-telemetry-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:anashTT/runtime-telemetry-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=anashTT/runtime-telemetry-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:anashTT/runtime-telemetry-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=anashTT/runtime-telemetry-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:anashTT/runtime-telemetry-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=anashTT/runtime-telemetry-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:anashTT/runtime-telemetry-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=anashTT/runtime-telemetry-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:anashTT/runtime-telemetry-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=anashTT/runtime-telemetry-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:anashTT/runtime-telemetry-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=anashTT/runtime-telemetry-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:anashTT/runtime-telemetry-fixes)