### PR TITLE
[Bug fix] Use mock env in MetalEnv fork-safety tests to fix CHIP_IN_USE PCIe lock deadlock

### DIFF
--- a/tt_metal/impl/context/metal_env.cpp
+++ b/tt_metal/impl/context/metal_env.cpp
@@ -94,6 +94,10 @@ MetalEnvImpl::~MetalEnvImpl() {
         std::lock_guard<std::mutex> lock(s_registry_mutex_);
         s_registry_.erase(this);
     }
+    // NOTE: the env-owned context (see ensure_context_registered) is intentionally torn down earlier, in
+    // MetalEnv::~MetalEnv(), before the MetalEnv::impl_ unique_ptr is reset. MetalContext::teardown()
+    // routes get_cluster()/rtoptions() back through *env_ (the outer MetalEnv), whose impl_ is already
+    // nullptr by the time ~MetalEnvImpl runs, so destroying it here would dereference that null impl_.
     check_use_count_zero();
     teardown_fabric_objects();
     cluster_.reset();
@@ -376,6 +380,20 @@ bool MetalEnvImpl::consume_force_reinit() {
 
 // ─── Control plane ────────────────────────────────────────────────────────────
 
+int MetalEnvImpl::ensure_context_registered(MetalEnv& env) {
+    if (!registered_context_id_.has_value()) {
+        registered_context_id_ = MetalContext::create_instance(env).get();
+    }
+    return *registered_context_id_;
+}
+
+void MetalEnvImpl::teardown_registered_context() {
+    if (registered_context_id_.has_value()) {
+        MetalContext::destroy_instance(/*check_device_count=*/false, ContextId{*registered_context_id_});
+        registered_context_id_.reset();
+    }
+}
+
 tt::tt_fabric::ControlPlane& MetalEnvImpl::get_control_plane() {
     std::lock_guard<std::mutex> lock(control_plane_mutex_);
     if (!control_plane_) {
@@ -591,7 +609,13 @@ void MetalEnvImpl::teardown_fabric_objects() {
 
 MetalEnv::MetalEnv(MetalEnvDescriptor descriptor) : impl_(std::make_unique<MetalEnvImpl>(std::move(descriptor))) {}
 
-MetalEnv::~MetalEnv() { this->impl_.reset(); }
+MetalEnv::~MetalEnv() {
+    // Destroy the env-owned MetalContext (if any) while impl_ is still valid: MetalContext::teardown()
+    // reaches back through *env_ -> MetalEnv::impl_, which unique_ptr::reset() nulls before running
+    // ~MetalEnvImpl. See ensure_context_registered / teardown_registered_context.
+    impl_->teardown_registered_context();
+    this->impl_.reset();
+}
 
 const MetalEnvDescriptor& MetalEnv::get_descriptor() const { return impl_->get_descriptor(); }
 
@@ -614,8 +638,14 @@ float MetalEnv::get_eps() const { return impl_->get_hal().get_eps(); }
 float MetalEnv::get_nan() const { return impl_->get_hal().get_nan(); }
 float MetalEnv::get_inf() const { return impl_->get_hal().get_inf(); }
 
-tt::tt_fabric::ControlPlane& MetalEnv::get_control_plane() { return impl_->get_control_plane(); }
-distributed::SystemMesh& MetalEnv::get_system_mesh() { return impl_->get_system_mesh(); }
+tt::tt_fabric::ControlPlane& MetalEnv::get_control_plane() {
+    impl_->ensure_context_registered(*this);
+    return impl_->get_control_plane();
+}
+distributed::SystemMesh& MetalEnv::get_system_mesh() {
+    impl_->ensure_context_registered(*this);
+    return impl_->get_system_mesh();
+}
 std::shared_ptr<distributed::MeshDevice> MetalEnv::create_mesh_device(
     const distributed::MeshDeviceConfig& config,
     size_t l1_small_size,
@@ -626,7 +656,12 @@ std::shared_ptr<distributed::MeshDevice> MetalEnv::create_mesh_device(
     size_t worker_l1_size) {
     // Associate a context ID for the mesh device's dependencies to easily access the MetalContext::instance(contextId)
     // TODO: Remove this and directly pass in the MetalEnv reference
-    ContextId context_id = MetalContext::create_instance(*this);
+    // If the control plane / system mesh was already accessed, the env owns a registered context; reuse it
+    // (its lifetime is tied to the env). Otherwise create one here and let the mesh device tear it down on
+    // close, preserving the legacy create_mesh_device-only behavior.
+    const bool env_owns_context = impl_->has_registered_context();
+    ContextId context_id =
+        env_owns_context ? ContextId{impl_->ensure_context_registered(*this)} : MetalContext::create_instance(*this);
     auto mesh_device = distributed::MeshDeviceImpl::create(
         context_id,
         config,
@@ -636,7 +671,9 @@ std::shared_ptr<distributed::MeshDevice> MetalEnv::create_mesh_device(
         dispatch_core_config,
         l1_bank_remap,
         worker_l1_size);
-    mesh_device->impl().set_destroy_metal_context_instance_on_close(true);
+    if (!env_owns_context) {
+        mesh_device->impl().set_destroy_metal_context_instance_on_close(true);
+    }
     return mesh_device;
 }
 
@@ -648,7 +685,9 @@ std::shared_ptr<distributed::MeshDevice> MetalEnv::create_unit_mesh_device(
     const DispatchCoreConfig& dispatch_core_config,
     ttsl::Span<const std::uint32_t> l1_bank_remap,
     size_t worker_l1_size) {
-    ContextId context_id = MetalContext::create_instance(*this);
+    const bool env_owns_context = impl_->has_registered_context();
+    ContextId context_id =
+        env_owns_context ? ContextId{impl_->ensure_context_registered(*this)} : MetalContext::create_instance(*this);
     auto mesh_device = distributed::MeshDeviceImpl::create_unit_mesh(
         context_id,
         device_id,
@@ -658,7 +697,9 @@ std::shared_ptr<distributed::MeshDevice> MetalEnv::create_unit_mesh_device(
         dispatch_core_config,
         l1_bank_remap,
         worker_l1_size);
-    mesh_device->impl().set_destroy_metal_context_instance_on_close(true);
+    if (!env_owns_context) {
+        mesh_device->impl().set_destroy_metal_context_instance_on_close(true);
+    }
     return mesh_device;
 }
 
@@ -670,7 +711,9 @@ std::map<int, std::shared_ptr<distributed::MeshDevice>> MetalEnv::create_unit_me
     const DispatchCoreConfig& dispatch_core_config,
     ttsl::Span<const std::uint32_t> l1_bank_remap,
     size_t worker_l1_size) {
-    ContextId context_id = MetalContext::create_instance(*this);
+    const bool env_owns_context = impl_->has_registered_context();
+    ContextId context_id =
+        env_owns_context ? ContextId{impl_->ensure_context_registered(*this)} : MetalContext::create_instance(*this);
     auto result = distributed::MeshDeviceImpl::create_unit_meshes(
         context_id,
         device_ids,
@@ -680,7 +723,7 @@ std::map<int, std::shared_ptr<distributed::MeshDevice>> MetalEnv::create_unit_me
         dispatch_core_config,
         l1_bank_remap,
         worker_l1_size);
-    if (!result.empty()) {
+    if (!env_owns_context && !result.empty()) {
         const auto& parent = result.begin()->second->get_parent_mesh();
         if (parent) {
             parent->impl().set_destroy_metal_context_instance_on_close(true);

--- a/tt_metal/impl/context/metal_env_impl.hpp
+++ b/tt_metal/impl/context/metal_env_impl.hpp
@@ -90,6 +90,22 @@ public:
     // Teardown fabric-layer objects (control plane, system mesh, distributed context).
     void teardown_fabric_objects();
 
+    // Register this env as a MetalContext (silicon: default slot; mock: non-default slot) so that legacy
+    // fabric code reached during control-plane / system-mesh / mesh-device construction (which still calls
+    // the bare MetalContext::instance()) resolves to this env instead of implicitly creating a default
+    // silicon context that opens a second real PCIe device and self-deadlocks on its CHIP_IN_USE lock
+    // (GitHub #50041, #50043). Idempotent; returns the env-owned context id (created on first call). The
+    // context lifetime is tied to the env (uplift of mesh-device-level cleanup, GitHub #21500).
+    int ensure_context_registered(MetalEnv& env);
+
+    // True once ensure_context_registered has created the env-owned context.
+    bool has_registered_context() const { return registered_context_id_.has_value(); }
+
+    // Destroy the env-owned context created by ensure_context_registered, if any. Must be called from
+    // MetalEnv::~MetalEnv() while MetalEnv::impl_ is still valid (MetalContext::teardown() reaches back
+    // through *env_ -> impl_), not from ~MetalEnvImpl where impl_ has already been nulled by reset().
+    void teardown_registered_context();
+
     // Returns true if set_fabric_config changed state requiring a reinit.
     bool consume_force_reinit();
 
@@ -105,6 +121,11 @@ private:
     std::unique_ptr<Hal> hal_;
 
     std::atomic<int> use_count_{0};
+
+    // MetalContext id registered lazily for this env (see ensure_context_registered). Stored as a raw int
+    // to avoid pulling metal_context.hpp into this header; wrapped back into a ContextId at the
+    // metal_context.cpp boundary. Torn down by teardown_registered_context() from MetalEnv::~MetalEnv().
+    std::optional<int> registered_context_id_ = std::nullopt;
 
     // --- Fabric config state ---
     tt_fabric::FabricConfig fabric_config_ = tt_fabric::FabricConfig::DISABLED;


### PR DESCRIPTION
Fixes #50041 and #50043

## Summary

Fixes a 12-minute CI timeout in the `(Runtime) Unit Tests` → `runtime_core` job where `MetalContextTest.CreateSiliconInstance` hangs on the UMD `CHIP_IN_USE_*_PCIe` robust mutex (`Waiting for lock 'CHIP_IN_USE_0_PCIe'...`, same PID/TID → self-deadlock).

**Root cause.** A standalone `MetalEnv` (mock or silicon) reaches the bare `MetalContext::instance()` during control-plane / system-mesh / mesh-device construction *without* a registered context. With no context present, `instance()` falls back to `create_default_instance_implicit_locked()`, which implicitly spins up a **default silicon context**, opens a **second** device, and self-deadlocks on the `CHIP_IN_USE` robust mutex (`PTHREAD_PROCESS_SHARED` + `PTHREAD_MUTEX_ROBUST`, in `/dev/shm`) already held by the first cluster. The recent UMD bump (#49643) made that lock blocking, turning a latent double-open into a hard hang.

This is the **same class of bug** already fixed once for `HelloWorld` in #45386 (bare `instance()` in `PinnedMemoryCache::release_for_device()` during teardown). It regressed via a **different** bare-`instance()` call site — this time on the *construction* side, in fabric discovery reached from `get_system_mesh()`. `MetalContextTest.CreateSiliconInstance` is actually the *victim*: an earlier silicon test leaks the lock, and it is the next test to try opening the device. A test-only or single-call-site fix would just move the hang to the next `instance()` caller (confirmed — guarding one discovery call site simply relocated the deadlock).

**Fix.** `MetalEnv` now lazily registers itself as its own `MetalContext` before any fabric code runs, so *every* bare `MetalContext::instance()` caller — the #45386 teardown site, the current discovery site, and any future one — resolves to this env instead of spawning a rogue silicon cluster. This uses the `instance()` fallback intentionally built in #38445 to bridge legacy singleton callers to the `MetalEnv` design.

- `get_control_plane()` / `get_system_mesh()` register the env's context before constructing.
- `create_mesh_device()` (and unit-mesh variants) reuse the env-owned context when it exists; otherwise they keep the legacy `create_instance` + destroy-on-close path, so `create_mesh_device`-only callers are unchanged.
- Context lifetime is tied to the env (uplift of the mesh-device-level cleanup, #21500) and torn down in `~MetalEnv` **before** `impl_.reset()` — required because `MetalContext::teardown()` reaches back through `env_ -> MetalEnv::impl_`, which `unique_ptr::reset()` nulls before running `~MetalEnvImpl` (destroying it there segfaults).

Product-code fix only. Preserves #45386 (`release_for_device` untouched; the context now lives even longer, so its "release before destroy" invariant still holds) and #46133 (its `MetalEnvMockCCL` tests stay green). No prior PRs are reverted. The earlier mock-fork-safety test change is reverted (ineffective; wrong root cause).

## Changes

- `tt_metal/impl/context/metal_env.cpp`, `tt_metal/impl/context/metal_env_impl.hpp`:
  - Add `ensure_context_registered()` — lazily registers this env as its `MetalContext` (silicon: default slot; mock: non-default slot); idempotent.
  - `get_control_plane()` / `get_system_mesh()` call it before constructing the fabric objects.
  - `create_mesh_device` / `create_unit_mesh_device` / `create_unit_meshes` reuse the env-owned context when present, else keep the legacy create-instance + destroy-on-close path.
  - Tear the context down via `teardown_registered_context()` from `~MetalEnv()`, while `impl_` is still valid.

## Test plan

- [x] Full `unit_tests_context` with the exact `runtime_core` filter (`--gtest_filter='-MetalContextIntegrationTest.Legacy'`) on a Blackhole p150: **42 passed, 1 skipped** (`ForkWithDisjointDevices`, needs ≥2 MMIO devices), ~28s — no `CHIP_IN_USE` hang, no segfault (previously a 12-min timeout).
- [x] `MetalContextTest.CreateSiliconInstance` passes instead of hanging 12 min.
- [x] `MetalContextIntegrationTest.HelloWorld`, `HelloWorldQueryThenCreate`, and `Coexisting*` pass.
- [x] `MetalEnv.*` (incl. the original **physical** `ForkSafety*`) and `MetalEnvMockCCL.*` suites pass.
- [x] Re-verified after rebasing onto latest `main` (47 commits newer).

Relates to #21500, #38445, #45386, #46133, #49643.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-metalenv-fork-safety-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:msudumbrekar/fix-metalenv-fork-safety-deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-metalenv-fork-safety-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:msudumbrekar/fix-metalenv-fork-safety-deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-metalenv-fork-safety-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:msudumbrekar/fix-metalenv-fork-safety-deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=msudumbrekar/fix-metalenv-fork-safety-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:msudumbrekar/fix-metalenv-fork-safety-deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=msudumbrekar/fix-metalenv-fork-safety-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:msudumbrekar/fix-metalenv-fork-safety-deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=msudumbrekar/fix-metalenv-fork-safety-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:msudumbrekar/fix-metalenv-fork-safety-deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=msudumbrekar/fix-metalenv-fork-safety-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:msudumbrekar/fix-metalenv-fork-safety-deadlock)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=msudumbrekar/fix-metalenv-fork-safety-deadlock)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:msudumbrekar/fix-metalenv-fork-safety-deadlock)