### PR TITLE
sdpa: Fix share_cache=True returning batch size 1

### DIFF
--- a/tests/ttnn/unit_tests/operations/sdpa/sdpa_test_utils.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/sdpa_test_utils.py
@@ -359,6 +359,7 @@ def run_test_sdpa_decode_single_iter(
     override_q_chunk_size=None,
     override_k_chunk_size=None,
     sliding_window_size=None,
+    share_cache=False,
 ):
     compute_grid_size = device.compute_with_storage_grid_size()
     if sub_core_grids is None:
@@ -404,8 +405,9 @@ def run_test_sdpa_decode_single_iter(
 
     height_sharded_memcfg = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
 
-    K = fa_rand(b, nkv, s, d)
-    V = fa_rand(b, nkv, s, d)
+    kv_batch = 1 if share_cache else b
+    K = fa_rand(kv_batch, nkv, s, d)
+    V = fa_rand(kv_batch, nkv, s, d)
 
     tt_K = ttnn.as_tensor(K, device=device, dtype=dtype, layout=ttnn.TILE_LAYOUT, memory_config=dram_memcfg)
     tt_V = ttnn.as_tensor(V, device=device, dtype=dtype, layout=ttnn.TILE_LAYOUT, memory_config=dram_memcfg)
@@ -475,6 +477,7 @@ def run_test_sdpa_decode_single_iter(
                     program_config=program_config,
                     compute_kernel_config=compute_kernel_config,
                     memory_config=height_sharded_memcfg if sharded_out else dram_memcfg,
+                    share_cache=share_cache,
                 )
         else:
             with device.cache_entries_counter.measure():
@@ -488,6 +491,7 @@ def run_test_sdpa_decode_single_iter(
                     program_config=program_config,
                     compute_kernel_config=compute_kernel_config,
                     memory_config=height_sharded_memcfg if sharded_out else dram_memcfg,
+                    share_cache=share_cache,
                 )
     else:
         tt_mask = ttnn.as_tensor(
@@ -508,6 +512,7 @@ def run_test_sdpa_decode_single_iter(
                 program_config=program_config,
                 compute_kernel_config=compute_kernel_config,
                 memory_config=height_sharded_memcfg if sharded_out else dram_memcfg,
+                share_cache=share_cache,
             )
 
     tt_back_shape = list(tt_back.shape)
@@ -515,16 +520,25 @@ def run_test_sdpa_decode_single_iter(
         f"SDPA decode output logical head dim should be {nh} (unpadded), got {tt_back_shape[2]}. "
         f"SDPA decode should preserve the logical head dimension regardless of tensor layout."
     )
+    assert tt_back_shape[1] == b, (
+        f"SDPA decode output batch dim should be {b} (Q's batch), got {tt_back_shape[1]}. "
+    )
 
     tt_back = ttnn.to_torch(tt_back)
     tt_back = tt_back[:, :, :nh, :]
 
     Q_slice = Q[:, :, :nh, :].permute(1, 2, 0, 3)  # b, nh, 1, d
-    K_slice = K[:, :, :padded_layer_len, :]  # b, nkv, S, d
+    K_slice = K[:, :, :padded_layer_len, :]  # kv_batch, nkv, S, d
+    V_slice = V[:, :, :padded_layer_len, :]  # kv_batch, nkv, S, d
+
+    if share_cache:
+        # K/V were generated with batch=1; broadcast to Q's batch size for the reference
+        K_slice = K_slice.expand(b, -1, -1, -1)
+        V_slice = V_slice.expand(b, -1, -1, -1)
+
     K_slice = torch.cat(
         [K_slice[:, i : i + 1, :, :].repeat(1, nh // nkv, 1, 1) for i in range(nkv)], dim=1
     )  # b, nh, S, d
-    V_slice = V[:, :, :padded_layer_len, :]  # b, nkv, S, d
     V_slice = torch.cat(
         [V_slice[:, i : i + 1, :, :].repeat(1, nh // nkv, 1, 1) for i in range(nkv)], dim=1
     )  # b, nh, S, d

--- a/tests/ttnn/unit_tests/operations/sdpa/test_sdpa_decode.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_sdpa_decode.py
@@ -437,3 +437,43 @@ def test_sdpa_decode_broadcast_mask_batch(device, b, nh, nkv, s, d, dtype, grid_
         grid_size=grid_size,
         mask_dtype=mask_dtype,
     )
+
+
+@pytest.mark.parametrize(
+    "dtype, q_dtype",
+    [
+        [ttnn.bfloat8_b, ttnn.bfloat16],
+    ],
+    ids=["kv_bfp8_q_bf16"],
+)
+@pytest.mark.parametrize(
+    "b, nh, nkv, s, d, grid_size",
+    [
+        [4, 8, 1, 2048, 128, (8, 4)],
+    ],
+    ids=["share_cache_b4"],
+)
+@pytest.mark.timeout(120)
+def test_sdpa_decode_share_cache(device, b, nh, nkv, s, d, dtype, grid_size, q_dtype):
+    """Test share_cache=True: K/V have batch=1 while Q has batch>1.
+
+    Validates that the output batch dimension is taken from Q (b), not from
+    K (which would be 1).  Regression test for compute_output_specs incorrectly
+    using K's batch dimension instead of Q's when share_cache=True.
+    """
+    run_test_sdpa_decode_single_iter(
+        device,
+        b,
+        nh,
+        nkv,
+        s,
+        d,
+        dtype,
+        grid_size,
+        q_dtype,
+        cur_pos_tensor=False,
+        sharded_in=False,
+        sharded_out=False,
+        causal=False,
+        share_cache=True,
+    )

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_device_operation.cpp
@@ -464,7 +464,7 @@ TensorSpec SdpaDecodeDeviceOperation::compute_output_specs(
             B = page_table.padded_shape()[0];
         }
     } else {
-        B = tensor_args.k.padded_shape()[0];
+        B = tensor_args.q.padded_shape()[1];
     }
     bool q_locally_available = false;
     uint32_t num_q_heads = q_shape_unpadded[2];


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
sdpa `share_cache=True` should allow a single unified kv cache to be used for decoding multiple tokens, however, the old code only returned tensor with B=1, even if the Q batch is > 1. It seems like elsewhere in the code this is implemented correctly, and it's only the output tensor shape that's set incorrectly.

Additionally, I added code to `run_test_sdpa_decode_single_iter` to test `share_cache=True` and a test case for it.

### Notes for reviewers
I didn't add any custom mask generating code that better approximates the behavior of multiple different token streams sharing the same cache tensors, instead just relying on the default random non-causal attn mask generation behavior.