### PR TITLE
cleanup: Remove unused private header from sdpa.hpp

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.hpp
@@ -9,7 +9,6 @@
 #include "ttnn/operations/ccl/ccl_host_types.hpp"
 #include "ttnn/operations/ccl/ccl_common.hpp"
 #include "ttnn/types.hpp"
-#include "ttnn/operations/transformer/sdpa/device/exp_ring_joint_sdpa_device_operation.hpp"
 
 namespace ttnn::transformer {
 


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
This file was referencing a private header, which caused problems when I try to include this file from a third-party project. The include is also unnecessary.
