### PR TITLE
#50137: add channel parameter to pad_and_fold_conv_filters_for_unity_stride

### DIFF
--- a/models/common/utility_functions.py
+++ b/models/common/utility_functions.py
@@ -1117,6 +1117,7 @@ def ttl_complex_2_torch_complex(tt_tensor):
 def pad_and_fold_conv_filters_for_unity_stride(filter_pyt_nchw_tensor, stride_h, stride_w, align_c=4):
     assert stride_h == stride_w
     assert filter_pyt_nchw_tensor.shape[2] == filter_pyt_nchw_tensor.shape[3]
+    assert isinstance(align_c, int) and align_c > 0
     # Fold activation for unity stride
     # Pad channel size to align_c. This keeps L1 read addresses aligned; extra channels become
     # zero-valued weights that contribute nothing to the convolution. align_c=4 is the WH/BH default

--- a/models/common/utility_functions.py
+++ b/models/common/utility_functions.py
@@ -1114,12 +1114,16 @@ def ttl_complex_2_torch_complex(tt_tensor):
     return result
 
 
-def pad_and_fold_conv_filters_for_unity_stride(filter_pyt_nchw_tensor, stride_h, stride_w):
+def pad_and_fold_conv_filters_for_unity_stride(filter_pyt_nchw_tensor, stride_h, stride_w, align_c=4):
     assert stride_h == stride_w
     assert filter_pyt_nchw_tensor.shape[2] == filter_pyt_nchw_tensor.shape[3]
     # Fold activation for unity stride
-    # Pad channel size to 4. This is to make sure L1 read addresses are 16 bit aligned
-    C = _nearest_y(filter_pyt_nchw_tensor.shape[1], 4)
+    # Pad channel size to align_c. This keeps L1 read addresses aligned; the extra channels become zero
+    # weight channels that contribute nothing to the conv. align_c=4 is the WH/BH default (16B alignment
+    # for bf16 gives C multiple of 4 with a tiled conv reader); Quasar's row-major fold needs align_c=8
+    # (bf16 row-major shard width must be a multiple of 8), so the first conv folds to groups*8 input
+    # channels and consumes the direct fold's aligned output with no per-group padding strip.
+    C = _nearest_y(filter_pyt_nchw_tensor.shape[1], align_c)
     # Pad filter to nearest stride
     Padded_filter_height = _nearest_y(filter_pyt_nchw_tensor.shape[2], stride_h)
     Padded_filter_width = _nearest_y(filter_pyt_nchw_tensor.shape[3], stride_w)

--- a/models/common/utility_functions.py
+++ b/models/common/utility_functions.py
@@ -1118,11 +1118,11 @@ def pad_and_fold_conv_filters_for_unity_stride(filter_pyt_nchw_tensor, stride_h,
     assert stride_h == stride_w
     assert filter_pyt_nchw_tensor.shape[2] == filter_pyt_nchw_tensor.shape[3]
     # Fold activation for unity stride
-    # Pad channel size to align_c. This keeps L1 read addresses aligned; the extra channels become zero
-    # weight channels that contribute nothing to the conv. align_c=4 is the WH/BH default (16B alignment
-    # for bf16 gives C multiple of 4 with a tiled conv reader); Quasar's row-major fold needs align_c=8
-    # (bf16 row-major shard width must be a multiple of 8), so the first conv folds to groups*8 input
-    # channels and consumes the direct fold's aligned output with no per-group padding strip.
+    # Pad channel size to align_c. This keeps L1 read addresses aligned; extra channels become
+    # zero-valued weights that contribute nothing to the convolution. align_c=4 is the WH/BH default
+    # (16B alignment for bf16 gives C a multiple of 4 with a tiled conv reader). Quasar's row-major
+    # fold needs align_c=8 (bf16 row-major shard width must be a multiple of 8) so the first conv
+    # folds to groups*8 input channels and consumes the aligned output without per-group padding strip.
     C = _nearest_y(filter_pyt_nchw_tensor.shape[1], align_c)
     # Pad filter to nearest stride
     Padded_filter_height = _nearest_y(filter_pyt_nchw_tensor.shape[2], stride_h)


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Feature

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #50137 

Quasar has different alignment requirements form WH/BH. Add extra parameter to allow those to be handled in conv.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-50137_conv_c)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-50137_conv_c)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-50137_conv_c)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-50137_conv_c)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=bbradel-50137_conv_c)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:bbradel-50137_conv_c)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-50137_conv_c)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-50137_conv_c)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-50137_conv_c)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-50137_conv_c)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-50137_conv_c)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-50137_conv_c)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-50137_conv_c)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-50137_conv_c)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-50137_conv_c)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-50137_conv_c)