### PR TITLE
#50157: static cast size_t to uint32_t in hetergeneous_data_structs.hpp

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp
@@ -188,7 +188,16 @@ inline size_t flattened_index (const ttnn::ccl::Shape4D<uint32_t>& shape, const 
         size_t new_y = index / tensor_slice_shape.x;
         size_t new_x = index - (new_y * tensor_slice_shape.x);
 
-        curr_page_idx = flattened_index(tensor_shape, tensor_slice_shape + Shape4D<uint32_t>{new_x, new_y, new_z, new_w});
+        // Explicit narrowing casts: new_* are size_t here (unlike the uint32_t twin in
+        // advance_worker_global_page below) but are page coords bounded by the uint32_t slice-shape
+        // dims, so they fit. Required for -Werror=narrowing under stricter kernel build.
+        curr_page_idx = flattened_index(
+            tensor_shape,
+            tensor_slice_shape + Shape4D<uint32_t>{
+                                     static_cast<uint32_t>(new_x),
+                                     static_cast<uint32_t>(new_y),
+                                     static_cast<uint32_t>(new_z),
+                                     static_cast<uint32_t>(new_w)});
     }
 
     return end_of_worker_slice_row;


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #50157 
Quasar kernel generation has stricter compile time checks. Need to explicitly cast size_t to uint32_t. The values will always fit.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-50157_ccl_cast)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-50157_ccl_cast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-50157_ccl_cast)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-50157_ccl_cast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=bbradel-50157_ccl_cast)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:bbradel-50157_ccl_cast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-50157_ccl_cast)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-50157_ccl_cast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-50157_ccl_cast)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-50157_ccl_cast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-50157_ccl_cast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-50157_ccl_cast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-50157_ccl_cast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-50157_ccl_cast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-50157_ccl_cast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-50157_ccl_cast)