### PR TITLE
[Cleanup] Make RowMajorPageConfig custom tile a hard error

### DIFF
--- a/tests/tt_metal/tt_metal/api/tensor/test_vector_conversion.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_vector_conversion.cpp
@@ -222,22 +222,6 @@ TYPED_TEST(BorrowedStorageVectorConversionTest, Callbacks) {
     EXPECT_EQ(dtor_count, 1);
 }
 
-TYPED_TEST(BorrowedStorageVectorConversionTest, CustomTile) {
-    Shape shape{32, 32};
-    auto input = arange<TypeParam>(0, shape.volume(), 1);
-
-    auto tensor = HostTensor::from_borrowed_data(
-        std::span<TypeParam>(input),
-        shape,
-        MemoryPin(/*increment_ref_count=*/[]() {}, /*decrement_ref_count=*/[]() {}),
-        /*tile=*/Tile({16, 16}));
-
-    // Retain row major layout, but use custom tile.
-    // TODO: #18536 - this should be illegal.
-    EXPECT_EQ(tensor.tensor_spec().layout(), Layout::ROW_MAJOR);
-    EXPECT_EQ(tensor.tensor_spec().tile(), Tile({16, 16}));
-}
-
 class BlockFloatVectorConversionTest : public ::testing::TestWithParam<DataType> {};
 
 TEST_P(BlockFloatVectorConversionTest, InvalidLayout) {

--- a/tests/ttnn/unit_tests/gtests/tensor/test_unchecked_reinterpret_layout.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_unchecked_reinterpret_layout.cpp
@@ -56,21 +56,6 @@ TEST_F(UncheckedReinterpretLayoutDeviceTest, RowMajorToTilePreservesShapeAndDtyp
     EXPECT_EQ(tile_tensor.tensor_spec().tile(), rm_tensor.tensor_spec().tile());
 }
 
-TEST_F(UncheckedReinterpretLayoutDeviceTest, PreservesNonDefaultTile) {
-    MemoryConfig mem_cfg{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
-    Tile custom_tile({16, 32});
-    ttnn::Shape shape({1, 1, 16, 32});
-    TensorSpec spec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE, custom_tile), mem_cfg));
-
-    Tensor original = create_device_tensor(spec, device_);
-    ASSERT_EQ(original.tensor_spec().tile(), custom_tile);
-
-    Tensor reinterpreted = unchecked_reinterpret_layout(original, Layout::ROW_MAJOR);
-
-    EXPECT_EQ(reinterpreted.layout(), Layout::ROW_MAJOR);
-    EXPECT_EQ(reinterpreted.tensor_spec().tile(), custom_tile);
-}
-
 TEST_F(UncheckedReinterpretLayoutDeviceTest, AliasesTheSameDeviceAddress) {
     MemoryConfig mem_cfg{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     ttnn::Shape shape({1, 1, 32, 32});
@@ -133,22 +118,6 @@ TEST_F(UncheckedReinterpretLayoutHostTest, TileToRowMajorOnHost) {
     EXPECT_EQ(reinterpreted.logical_shape(), host_tensor.logical_shape());
     EXPECT_EQ(reinterpreted.dtype(), host_tensor.dtype());
     EXPECT_EQ(reinterpreted.tensor_spec().tile(), host_tensor.tensor_spec().tile());
-}
-
-TEST_F(UncheckedReinterpretLayoutHostTest, PreservesNonDefaultTileOnHost) {
-    Tile custom_tile({16, 32});
-    ttnn::Shape shape({1, 1, 16, 32});
-    TensorSpec spec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE, custom_tile), MemoryConfig{}));
-
-    auto num_elements = shape.volume();
-    std::vector<bfloat16> data(num_elements, bfloat16(1.0f));
-    Tensor host_tensor(HostBuffer(data), spec);
-    ASSERT_EQ(host_tensor.tensor_spec().tile(), custom_tile);
-
-    Tensor reinterpreted = unchecked_reinterpret_layout(host_tensor, Layout::ROW_MAJOR);
-
-    EXPECT_EQ(reinterpreted.layout(), Layout::ROW_MAJOR);
-    EXPECT_EQ(reinterpreted.tensor_spec().tile(), custom_tile);
 }
 
 TEST_F(UncheckedReinterpretLayoutHostTest, RowMajorToTileOnHost) {

--- a/tt_metal/impl/tensor/spec/layout/page_config.cpp
+++ b/tt_metal/impl/tensor/spec/layout/page_config.cpp
@@ -149,7 +149,7 @@ Alignment TilePageConfig::get_required_shard_shape_alignment() const {
 
 RowMajorPageConfig::RowMajorPageConfig(const Tile& tile) : tile_(tile) {
     TT_FATAL(
-        tile == Tile{}, "Configuring a ROW MAJOR page config with a tile configuration is not supported. See #18536");
+        tile == Tile{}, "Configuring a ROW MAJOR page config with a custom tile configuration is not supported.");
 }
 
 Alignment RowMajorPageConfig::create_default_alignment(DataType /*dtype*/, const MemoryConfig& memory_config) const {
@@ -217,7 +217,7 @@ size_t RowMajorPageConfig::get_page_size_bytes(const Shape2D& page_shape, DataTy
 const Tile& RowMajorPageConfig::get_tile() const {
     TT_FATAL(
         tile_ == Tile{},
-        "Attempting to extract tile information out of a ROW MAJOR layout is not supported. See #18536");
+        "Attempting to extract tile information out of a ROW MAJOR layout is not supported.");
     return tile_;
 }
 

--- a/tt_metal/impl/tensor/spec/layout/page_config.cpp
+++ b/tt_metal/impl/tensor/spec/layout/page_config.cpp
@@ -148,12 +148,8 @@ Alignment TilePageConfig::get_required_shard_shape_alignment() const {
 }
 
 RowMajorPageConfig::RowMajorPageConfig(const Tile& tile) : tile_(tile) {
-    if (tile != Tile{}) {
-        log_warning(
-            LogMetal,
-            "Configuring a ROW MAJOR page config with a tile configuration, this will be rejected in the future. See "
-            "#18536");
-    }
+    TT_FATAL(
+        tile == Tile{}, "Configuring a ROW MAJOR page config with a tile configuration is not supported. See #18536");
 }
 
 Alignment RowMajorPageConfig::create_default_alignment(DataType /*dtype*/, const MemoryConfig& memory_config) const {
@@ -219,13 +215,9 @@ size_t RowMajorPageConfig::get_page_size_bytes(const Shape2D& page_shape, DataTy
 }
 
 const Tile& RowMajorPageConfig::get_tile() const {
-    if (tile_ != Tile{}) {
-        log_warning(
-            LogMetal,
-            "Attempting to extract tile information out of a ROW MAJOR layout, this will be rejected in the future. "
-            "See "
-            "#18536.");
-    }
+    TT_FATAL(
+        tile_ == Tile{},
+        "Attempting to extract tile information out of a ROW MAJOR layout is not supported. See #18536");
     return tile_;
 }
 


### PR DESCRIPTION
### PR Category
Cleanup

### Summary

Row Major vs tilized layout are orthogonal kinds of tensor layouts. 

`RowMajorPageConfig` currently lets you construct a row major `Tensor` with a custom tile shape. This makes row major based construction APIs incredibly confusing as they all have an `optional<Tile>` argument, this also makes state management more complex.

In #47161 , a log warning message is injected to find out the use sites of RowMajorConfig with custom tile configuration. After wide greps throughout our nightly runs I have identified the only usage of this feature and fixed it in #49961 .

This PR converts the `log_warn` to a hard `TT_FATAL` error.

Relates to #18536.

### Notes for reviewers

The PR is made intentionally small (there's a lot of APIs that could be cleaned up) to allow easy revert. The goal is to deploy this PR and watch the nightly pipelines over the coming few days.


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/rowmajor-tile-fatal)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/rowmajor-tile-fatal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/rowmajor-tile-fatal)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/rowmajor-tile-fatal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=riverwu/rowmajor-tile-fatal)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:riverwu/rowmajor-tile-fatal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/rowmajor-tile-fatal)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/rowmajor-tile-fatal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/rowmajor-tile-fatal)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/rowmajor-tile-fatal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/rowmajor-tile-fatal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/rowmajor-tile-fatal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/rowmajor-tile-fatal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/rowmajor-tile-fatal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/rowmajor-tile-fatal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/rowmajor-tile-fatal)
