### PR TITLE
[Bug fix] sparse MLA: gather DSA indexer top-k indices in TILE layout (fix TP-fabric hang)

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -709,9 +709,21 @@ class TtIndexer:
         # [1,1,S/sp,k] contract so sparse_sdpa/mla.py are unchanged. (Redundant TP-round-trip for GLM's
         # head→seq reshard, which re-splits it; correct regardless. tp=1: no-op.)
         if tpsp:
-            idx_local = idx  # the TP-sharded top-k; all_gather allocates the regathered [1,1,S/sp,k] replacement
-            idx = self._tp_all_gather(idx, dim=2)
+            # Regather the TP-seq-sharded top-k indices back to [1,1,S/sp,k]. topk_large_indices emits
+            # ROW_MAJOR uint32, and an all-gather on a ROW_MAJOR tensor is routed by use_composite_all_gather
+            # to composite_all_gather -> all_broadcast, whose multicast over a partial cluster-axis line of a
+            # 2D (SP×TP) mesh DEADLOCKS the fabric (erisc routers stall in run_receiver_channel_step; device
+            # unrecoverable, system_memory_manager.cpp TIMEOUT). Gather in TILE layout so it takes the NATIVE
+            # minimal all-gather instead — the tile-aligned gather dim keeps it off the composite path, and
+            # the native path handles this TP cluster-axis correctly (as _tp_rs_ag does, and as the canonical
+            # top-k-index gather in tt_sampling.py does). Round-trip RM->TILE->gather->RM.
+            idx_local = idx
+            idx_tiled = ttnn.to_layout(idx, ttnn.TILE_LAYOUT)
+            idx_gathered = self._tp_all_gather(idx_tiled, dim=2)  # native all-gather over TP; [1,1,S/sp,k] TILE
+            idx = ttnn.to_layout(idx_gathered, ttnn.ROW_MAJOR_LAYOUT)
             ttnn.deallocate(idx_local)
+            ttnn.deallocate(idx_tiled)
+            ttnn.deallocate(idx_gathered)
         return idx
 
 


### PR DESCRIPTION
[![Blackhole e2e](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=mvasilijevic/fix-sparse-mla-indexer-hang)](https://github.com/tenstorrent/tt-metal/actions/runs/29547180259)

## Problem

`test_sparse_mla_rotated` (deepseek_v32, glm_5_1, `2x4-seq5120`) hangs on Blackhole E2E MLA CI:
`system_memory_manager.cpp:765 TIMEOUT: device timeout ... unrecoverable`.

## Root cause

The TP×SP indexer query-split (#49496) regathers the top-k indices over the TP axis:

- `topk_large_indices` emits **ROW_MAJOR uint32**.
- `use_composite_all_gather` routes **any** row-major tensor to `composite_all_gather` → **`all_broadcast`** (multi-hop line broadcast) + `concat`, instead of the native all-gather.
- Under a **1D fabric**, that broadcast over a **partial cluster-axis of the 2D (SP×TP) mesh** deadlocks — erisc routers stall in `run_receiver_channel_step` (`--dev` watcher). Hangs on the aligned iter-0 chunk too, so it's the CCL, not the block-cyclic geometry.

The native all-gather handles this TP axis fine on every fabric (`_tp_rs_ag` bf16-TILE; `tt_sampling.py` gathers uint32 top-k indices in TILE). Only ROW_MAJOR hits the broken `all_broadcast` path — which has no uint32 / partial-2D-cluster-axis test coverage (tests use `1×N` bf16 only).

## Fabric cross-check — 1D-only (measured)

| Fabric | RM regather |
|---|---|
| `FABRIC_1D` (line, **CI**) | **HANG** |
| `FABRIC_1D_RING` (ring) | **HANG** |
| `FABRIC_2D` (fabric2d) | **PASS** (PCC 0.9938) |

Control (line + same toggle) hangs → the fabric2d PASS is real. 1D-vs-2D routing difference is inferred from code; the fabric-dependence is measured.

## Fix

Gather the indices in **TILE layout** (`RM → TILE → all_gather → RM`) → native path. Indexer-only (~14 lines); **keeps the TP×SP feature enabled**.

## Verification (LoudBox 2x4)

- **Correctness** (`line`, matching CI): deepseek_v32 **PASS** (PCC 0.9926), glm_5_1 **PASS** (PCC 0.9938); both reproduced HANG on line+ring before.
- **Perf** (glm warm sparse, `FABRIC_2D` — only fabric where RM also runs): **7.899 → 7.936 ms** critical path (**+0.5%, within noise**). Swaps 1 `all_broadcast`+`concat` for 1 native `all_gather`+`tilize`+`untilize`. Regather is fixed-size → <0.05% on cold/long; on 1D the RM path hangs, so the fix is the only working option.

## Follow-up (not here)

`all_broadcast` deadlocks on a partial 2D-mesh cluster-axis under a 1D fabric and lacks uint32 / partial-axis coverage — a real CCL bug to fix + cover upstream. This PR routes around it via the native path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
