### PR TITLE
Fix repeat op reporting an over-provisioned output tensor grid

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_repeat.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_repeat.py
@@ -1019,15 +1019,53 @@ def test_repeat_composite_edge_cases(shape, repeat_shape, in_mc_fn, out_mc_fn, p
     )
 
 
-def test_repeat_block_sharded_derived_grid_is_minimal(device):
-    """Regression: when repeat synthesizes a block-sharded output grid (output memory config with no
-    explicit shard spec -- the TT-Forge compiler's op-constraints query path), it must report the minimal grid
-    its shards occupy, not the full device grid. tt-metal would otherwise trim the grid to the used
-    cores at allocation, leaving the reported layout inconsistent with the physical buffer potentially causing bad PCC.
+def test_repeat_block_sharded_explicit_over_provisioned_grid_errors(device, expect_error):
+    """A falsely-reported (over-provisioned) explicit block-sharded output grid must be a catchable
+    error, not a silent trim that leaves the reported grid inconsistent with the physical buffer.
 
-    Input 1x1x1x128 in a 1x4 block-sharded grid; the 1x1x8x128 result (= 32x128 padded = 1 tile tall
-    x 4 tiles wide = 4 shards) must be reported on 4 cores, not the full device grid.
+    1x1x8x128 = 32x128 padded = 1 tile tall x 4 tiles wide = 4 shards, so an explicit 8x8 (64-core)
+    grid is over-provisioned and must be rejected rather than silently trimmed to 4 cores.
     """
+    torch.manual_seed(0)
+    x = torch.rand((1, 1, 1, 128), dtype=torch.bfloat16)
+
+    input_mem_config = _explicit_block_shard_config(device, grid_y=1, grid_x=4, sh=32, sw=32)
+    over_provisioned_output = _explicit_block_shard_config(device, grid_y=8, grid_x=8, sh=32, sw=32)
+
+    ttnn_in = ttnn.from_torch(
+        x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=input_mem_config
+    )
+    with expect_error(RuntimeError, "larger than the"):
+        ttnn.repeat(ttnn_in, [1, 1, 8, 1], memory_config=over_provisioned_output)
+
+
+@pytest.mark.parametrize(
+    "num_repeats, expected_grid_rows, expected_grid_cols",
+    [
+        (8, 1, 4),  # out 1x1x8x128 (the Falcon shape) = 1 tile tall x 4 wide -> 1 row x 4 cols (4 cores)
+        (64, 2, 4),  # out 1x1x64x128  = 2 tiles tall x 4 wide -> 2 rows x 4 cols (8 cores)
+        (128, 4, 4),  # out 1x1x128x128 = 4 tiles tall x 4 wide -> 4 rows x 4 cols (16 cores)
+        (256, 8, 4),  # out 1x1x256x128 = 8 tiles tall x 4 wide -> 8 rows x 4 cols (32 cores)
+    ],
+)
+def test_repeat_block_sharded_derived_grid_scales_with_shape(
+    device, num_repeats, expected_grid_rows, expected_grid_cols
+):
+    """Regression (TT-Forge Falcon3 repeat->bad PCC): when repeat synthesizes a block-sharded
+    output grid (output memory config with no explicit shard spec -- the compiler's op-constraints
+    query path), it must report the minimal grid its shards occupy and scale that grid with the
+    output, not pin it to the full device grid. tt-metal would otherwise trim the grid to the used
+    cores at allocation, leaving the reported layout inconsistent with the physical buffer.
+
+    repeat [1,1,N,1] on [1,1,1,128] -> [1,1,N,128] = ceil(N/32) tiles tall x 4 tiles wide, so the
+    derived grid is ceil(N/32) rows x 4 cols (1x4 at N=8, 2x4 at N=64, 4x4 at N=128, 8x4 at N=256).
+    """
+    compute_grid = device.compute_with_storage_grid_size()
+    if expected_grid_rows > compute_grid.y or expected_grid_cols > compute_grid.x:
+        pytest.skip(
+            f"device grid ({compute_grid.y}x{compute_grid.x}) too small for {expected_grid_rows}x{expected_grid_cols}"
+        )
+
     torch.manual_seed(0)
     x = torch.rand((1, 1, 1, 128), dtype=torch.bfloat16)
 
@@ -1038,13 +1076,16 @@ def test_repeat_block_sharded_derived_grid_is_minimal(device):
     ttnn_in = ttnn.from_torch(
         x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=input_mem_config
     )
-    result = ttnn.repeat(ttnn_in, [1, 1, 8, 1], memory_config=derived_block_output)
+    result = ttnn.repeat(ttnn_in, [1, 1, num_repeats, 1], memory_config=derived_block_output)
 
     shard_spec = result.memory_config().shard_spec
     assert shard_spec is not None, "expected a sharded output"
-    # 4 shards (1x4 tiles) must occupy 4 cores; the bug synthesised the full device grid instead.
-    assert shard_spec.num_cores() == 4, f"grid not minimal: {shard_spec.num_cores()} cores ({shard_spec.grid})"
-
-    ref = x.repeat(1, 1, 8, 1)
-    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
-    assert_with_pcc(ref.float(), got.float(), 0.9999)
+    grid = shard_spec.grid.bounding_box().grid_size()  # CoreCoord: x = columns, y = rows
+    assert (grid.y, grid.x) == (expected_grid_rows, expected_grid_cols), (
+        f"expected {expected_grid_rows}x{expected_grid_cols} (rows x cols) grid, "
+        f"got {grid.y}x{grid.x} ({shard_spec.grid})"
+    )
+    # No PCC check here: eager consumers read the live (trimmed) buffer, so data is correct with or
+    # without this fix -- PCC would not discriminate. The reported grid above is the regression. The
+    # corruption this fix prevents only surfaces in the compiled program (reader args baked from the
+    # advertised grid); data correctness of repeat itself is covered by the run_repeat_test cases.

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_repeat.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_repeat.py
@@ -1019,24 +1019,30 @@ def test_repeat_composite_edge_cases(shape, repeat_shape, in_mc_fn, out_mc_fn, p
     )
 
 
-def test_repeat_block_sharded_explicit_over_provisioned_grid_errors(device, expect_error):
-    """A falsely-reported (over-provisioned) explicit block-sharded output grid must be a catchable
-    error, not a silent trim that leaves the reported grid inconsistent with the physical buffer.
-
-    1x1x8x128 = 32x128 padded = 1 tile tall x 4 tiles wide = 4 shards, so an explicit 8x8 (64-core)
-    grid is over-provisioned and must be rejected rather than silently trimmed to 4 cores.
+@pytest.mark.parametrize(
+    "over_provisioned_output_fn",
+    [
+        # For the 1x1x8x128 result (32x128 padded): BLOCK needs 1x4=4 shards, HEIGHT needs 1, WIDTH needs 4.
+        pytest.param(lambda d: _explicit_block_shard_config(d, grid_y=8, grid_x=8, sh=32, sw=32), id="block_8x8"),
+        pytest.param(lambda d: _explicit_height_shard_config(d, 8, 32, 128), id="height_8core"),
+        pytest.param(lambda d: _explicit_width_shard_config(d, 8, 32, 32), id="width_8core"),
+    ],
+)
+def test_repeat_sharded_explicit_over_provisioned_grid_errors(device, expect_error, over_provisioned_output_fn):
+    """A falsely-reported (over-provisioned) explicit sharded output grid must be a catchable error,
+    not a silent trim that leaves the reported grid inconsistent with the physical buffer -- for any
+    sharded layout (BLOCK/HEIGHT/WIDTH). Each config below asks for more cores than the output's
+    shard count and must be rejected.
     """
     torch.manual_seed(0)
     x = torch.rand((1, 1, 1, 128), dtype=torch.bfloat16)
 
     input_mem_config = _explicit_block_shard_config(device, grid_y=1, grid_x=4, sh=32, sw=32)
-    over_provisioned_output = _explicit_block_shard_config(device, grid_y=8, grid_x=8, sh=32, sw=32)
-
     ttnn_in = ttnn.from_torch(
         x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=input_mem_config
     )
     with expect_error(RuntimeError, "larger than the"):
-        ttnn.repeat(ttnn_in, [1, 1, 8, 1], memory_config=over_provisioned_output)
+        ttnn.repeat(ttnn_in, [1, 1, 8, 1], memory_config=over_provisioned_output_fn(device))
 
 
 @pytest.mark.parametrize(
@@ -1089,3 +1095,46 @@ def test_repeat_block_sharded_derived_grid_scales_with_shape(
     # without this fix -- PCC would not discriminate. The reported grid above is the regression. The
     # corruption this fix prevents only surfaces in the compiled program (reader args baked from the
     # advertised grid); data correctness of repeat itself is covered by the run_repeat_test cases.
+
+
+@pytest.mark.parametrize(
+    "memory_layout, num_repeats, expected_num_cores",
+    [
+        # HEIGHT: full-width shard, ceil(N/32) shards along height.
+        (ttnn.TensorMemoryLayout.HEIGHT_SHARDED, 8, 1),
+        (ttnn.TensorMemoryLayout.HEIGHT_SHARDED, 64, 2),
+        (ttnn.TensorMemoryLayout.HEIGHT_SHARDED, 128, 4),
+        (ttnn.TensorMemoryLayout.HEIGHT_SHARDED, 256, 8),
+        # WIDTH: 128 wide = 128/32 = 4 shards, independent of the repeat count.
+        (ttnn.TensorMemoryLayout.WIDTH_SHARDED, 8, 4),
+        (ttnn.TensorMemoryLayout.WIDTH_SHARDED, 256, 4),
+    ],
+)
+def test_repeat_1d_sharded_derived_grid_is_minimal(device, memory_layout, num_repeats, expected_num_cores):
+    """Height/width-sharded sibling of test_repeat_block_sharded_derived_grid_scales_with_shape: a
+    derived (no explicit shard spec) 1D-sharded output must report exactly the cores its shards
+    occupy, not the full compute grid (which would be silently trimmed at allocation). repeat
+    [1,1,N,1] on [1,1,1,128] -> [1,1,N,128]; HEIGHT uses ceil(N/32) cores (full-width shard), WIDTH
+    uses 128/32 = 4 cores regardless of N. (num_cores, not grid dims, is the meaningful 1D metric.)
+    """
+    compute_grid = device.compute_with_storage_grid_size()
+    if expected_num_cores > compute_grid.x * compute_grid.y:
+        pytest.skip(f"device has {compute_grid.x * compute_grid.y} cores, need {expected_num_cores}")
+
+    torch.manual_seed(0)
+    x = torch.rand((1, 1, 1, 128), dtype=torch.bfloat16)
+
+    input_mem_config = _explicit_block_shard_config(device, grid_y=1, grid_x=4, sh=32, sw=32)
+    # No explicit output shard spec -> repeat derives the grid via generate_repeat_shard_spec.
+    derived_output = _sharded_no_spec(memory_layout)(device)
+
+    ttnn_in = ttnn.from_torch(
+        x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=input_mem_config
+    )
+    result = ttnn.repeat(ttnn_in, [1, 1, num_repeats, 1], memory_config=derived_output)
+
+    shard_spec = result.memory_config().shard_spec
+    assert shard_spec is not None, "expected a sharded output"
+    assert (
+        shard_spec.num_cores() == expected_num_cores
+    ), f"expected {expected_num_cores} cores, got {shard_spec.num_cores()} ({shard_spec.grid})"

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_repeat.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_repeat.py
@@ -1019,38 +1019,31 @@ def test_repeat_composite_edge_cases(shape, repeat_shape, in_mc_fn, out_mc_fn, p
     )
 
 
-def test_repeat_block_sharded_output_grid_is_trimmed(device):
-    """Regression: repeat must report the honest, trimmed block-sharded output grid rather than an
-    over-provisioned device grid whose metadata mismatches the physical buffer.
+def test_repeat_block_sharded_derived_grid_is_minimal(device):
+    """Regression: when repeat synthesizes a block-sharded output grid (output memory config with no
+    explicit shard spec -- the TT-Forge compiler's op-constraints query path), it must report the minimal grid
+    its shards occupy, not the full device grid. tt-metal would otherwise trim the grid to the used
+    cores at allocation, leaving the reported layout inconsistent with the physical buffer potentially causing bad PCC.
 
-    This is the Falcon3 repeat->SDPA PCC bug: a compiler emitted an 8x8 (64-core) block-sharded
-    output for a tensor that only fills 1x4 tiles. tt-metal would silently trim the buffer to the 4
-    real cores while the tensor's shard_spec still advertised 64 cores, so the op-constraints query
-    (and downstream consumers) saw a grid that didn't match the physical layout. The repeat op must
-    return the trimmed grid so the reported layout is consistent with what is actually allocated.
-
-    Input 1x1x1x128 in a 1x4 block-sharded grid; requesting an 8x8 block-sharded output for the
-    1x1x8x128 result (= 32x128 padded = 1 tile tall x 4 tiles wide = 4 shards) must trim to 4 cores.
+    Input 1x1x1x128 in a 1x4 block-sharded grid; the 1x1x8x128 result (= 32x128 padded = 1 tile tall
+    x 4 tiles wide = 4 shards) must be reported on 4 cores, not the full device grid.
     """
-    compute_grid = device.compute_with_storage_grid_size()
-    if compute_grid.x < 8 or compute_grid.y < 8:
-        pytest.skip("requires at least an 8x8 compute grid")
-
     torch.manual_seed(0)
     x = torch.rand((1, 1, 1, 128), dtype=torch.bfloat16)
 
     input_mem_config = _explicit_block_shard_config(device, grid_y=1, grid_x=4, sh=32, sw=32)
-    over_provisioned_output = _explicit_block_shard_config(device, grid_y=8, grid_x=8, sh=32, sw=32)
+    # No explicit output shard spec -> repeat derives the grid via generate_repeat_shard_spec.
+    derived_block_output = _sharded_no_spec(ttnn.TensorMemoryLayout.BLOCK_SHARDED)(device)
 
     ttnn_in = ttnn.from_torch(
         x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=input_mem_config
     )
-    result = ttnn.repeat(ttnn_in, [1, 1, 8, 1], memory_config=over_provisioned_output)
+    result = ttnn.repeat(ttnn_in, [1, 1, 8, 1], memory_config=derived_block_output)
 
     shard_spec = result.memory_config().shard_spec
     assert shard_spec is not None, "expected a sharded output"
-    # 4 shards (1x4 tiles) must occupy 4 cores, not the requested 64 -- the pre-fix bug reported 64.
-    assert shard_spec.num_cores() == 4, f"grid not trimmed: {shard_spec.num_cores()} cores ({shard_spec.grid})"
+    # 4 shards (1x4 tiles) must occupy 4 cores; the bug synthesised the full device grid instead.
+    assert shard_spec.num_cores() == 4, f"grid not minimal: {shard_spec.num_cores()} cores ({shard_spec.grid})"
 
     ref = x.repeat(1, 1, 8, 1)
     got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_repeat.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_repeat.py
@@ -1017,3 +1017,41 @@ def test_repeat_composite_edge_cases(shape, repeat_shape, in_mc_fn, out_mc_fn, p
         input_mem_config=in_mc_fn(device),
         output_mem_config=out_mc_fn(device),
     )
+
+
+def test_repeat_block_sharded_output_grid_is_trimmed(device):
+    """Regression: repeat must report the honest, trimmed block-sharded output grid rather than an
+    over-provisioned device grid whose metadata mismatches the physical buffer.
+
+    This is the Falcon3 repeat->SDPA PCC bug: a compiler emitted an 8x8 (64-core) block-sharded
+    output for a tensor that only fills 1x4 tiles. tt-metal would silently trim the buffer to the 4
+    real cores while the tensor's shard_spec still advertised 64 cores, so the op-constraints query
+    (and downstream consumers) saw a grid that didn't match the physical layout. The repeat op must
+    return the trimmed grid so the reported layout is consistent with what is actually allocated.
+
+    Input 1x1x1x128 in a 1x4 block-sharded grid; requesting an 8x8 block-sharded output for the
+    1x1x8x128 result (= 32x128 padded = 1 tile tall x 4 tiles wide = 4 shards) must trim to 4 cores.
+    """
+    compute_grid = device.compute_with_storage_grid_size()
+    if compute_grid.x < 8 or compute_grid.y < 8:
+        pytest.skip("requires at least an 8x8 compute grid")
+
+    torch.manual_seed(0)
+    x = torch.rand((1, 1, 1, 128), dtype=torch.bfloat16)
+
+    input_mem_config = _explicit_block_shard_config(device, grid_y=1, grid_x=4, sh=32, sw=32)
+    over_provisioned_output = _explicit_block_shard_config(device, grid_y=8, grid_x=8, sh=32, sw=32)
+
+    ttnn_in = ttnn.from_torch(
+        x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=input_mem_config
+    )
+    result = ttnn.repeat(ttnn_in, [1, 1, 8, 1], memory_config=over_provisioned_output)
+
+    shard_spec = result.memory_config().shard_spec
+    assert shard_spec is not None, "expected a sharded output"
+    # 4 shards (1x4 tiles) must occupy 4 cores, not the requested 64 -- the pre-fix bug reported 64.
+    assert shard_spec.num_cores() == 4, f"grid not trimmed: {shard_spec.num_cores()} cores ({shard_spec.grid})"
+
+    ref = x.repeat(1, 1, 8, 1)
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    assert_with_pcc(ref.float(), got.float(), 0.9999)

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.cpp
@@ -82,13 +82,13 @@ RepeatDeviceOperation::spec_return_value_t RepeatDeviceOperation::compute_output
             if (derived.has_value()) {
                 mem_config = MemoryConfig(mem_config.memory_layout(), mem_config.buffer_type(), derived);
             }
-        } else if (mem_config.memory_layout() == tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED) {
-            // Reject an explicitly-requested block-sharded grid larger than the shards the output
-            // occupies (would be silently trimmed -> reported grid inconsistent with the buffer).
+        } else {
+            // Reject an explicitly-requested sharded grid larger than the shards the output occupies
+            // (would be silently trimmed -> reported grid inconsistent with the buffer).
             const tt::tt_metal::TensorLayout probe_layout(
                 input_tensor_a.dtype(), tt::tt_metal::PageConfig(input_tensor_a.layout()), mem_config);
             const auto physical_shape = probe_layout.compute_physical_shape(output_shape);
-            operations::data_movement::repeat::validate_block_shard_grid_not_over_provisioned(
+            operations::data_movement::repeat::validate_shard_grid_not_over_provisioned(
                 mem_config,
                 static_cast<uint32_t>(physical_shape.height()),
                 static_cast<uint32_t>(physical_shape.width()));

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.cpp
@@ -84,21 +84,6 @@ RepeatDeviceOperation::spec_return_value_t RepeatDeviceOperation::compute_output
             }
         }
     }
-
-    // Report the honest block-sharded grid: trim an over-provisioned grid (whether provided by the
-    // caller or synthesised above) down to the sub-grid its shards actually occupy. Otherwise
-    // tt-metal trims the grid silently at allocation, so the layout surfaced through the
-    // op-constraints query and created at runtime would not match the physical buffer -- which hides
-    // the real grid from the compiler and corrupts consumers that trust the reported grid.
-    if (mem_config.is_sharded() && mem_config.memory_layout() == tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED &&
-        mem_config.shard_spec().has_value()) {
-        const tt::tt_metal::TensorLayout probe_layout(
-            input_tensor_a.dtype(), tt::tt_metal::PageConfig(input_tensor_a.layout()), mem_config);
-        const auto physical_shape = probe_layout.compute_physical_shape(output_shape);
-        mem_config = operations::data_movement::repeat::trim_block_shard_grid(
-            mem_config, static_cast<uint32_t>(physical_shape.height()), static_cast<uint32_t>(physical_shape.width()));
-    }
-
     return TensorSpec(
         output_shape,
         tt::tt_metal::TensorLayout(

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.cpp
@@ -82,6 +82,16 @@ RepeatDeviceOperation::spec_return_value_t RepeatDeviceOperation::compute_output
             if (derived.has_value()) {
                 mem_config = MemoryConfig(mem_config.memory_layout(), mem_config.buffer_type(), derived);
             }
+        } else if (mem_config.memory_layout() == tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED) {
+            // Reject an explicitly-requested block-sharded grid larger than the shards the output
+            // occupies (would be silently trimmed -> reported grid inconsistent with the buffer).
+            const tt::tt_metal::TensorLayout probe_layout(
+                input_tensor_a.dtype(), tt::tt_metal::PageConfig(input_tensor_a.layout()), mem_config);
+            const auto physical_shape = probe_layout.compute_physical_shape(output_shape);
+            operations::data_movement::repeat::validate_block_shard_grid_not_over_provisioned(
+                mem_config,
+                static_cast<uint32_t>(physical_shape.height()),
+                static_cast<uint32_t>(physical_shape.width()));
         }
     }
     return TensorSpec(

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_device_operation.cpp
@@ -84,6 +84,21 @@ RepeatDeviceOperation::spec_return_value_t RepeatDeviceOperation::compute_output
             }
         }
     }
+
+    // Report the honest block-sharded grid: trim an over-provisioned grid (whether provided by the
+    // caller or synthesised above) down to the sub-grid its shards actually occupy. Otherwise
+    // tt-metal trims the grid silently at allocation, so the layout surfaced through the
+    // op-constraints query and created at runtime would not match the physical buffer -- which hides
+    // the real grid from the compiler and corrupts consumers that trust the reported grid.
+    if (mem_config.is_sharded() && mem_config.memory_layout() == tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED &&
+        mem_config.shard_spec().has_value()) {
+        const tt::tt_metal::TensorLayout probe_layout(
+            input_tensor_a.dtype(), tt::tt_metal::PageConfig(input_tensor_a.layout()), mem_config);
+        const auto physical_shape = probe_layout.compute_physical_shape(output_shape);
+        mem_config = operations::data_movement::repeat::trim_block_shard_grid(
+            mem_config, static_cast<uint32_t>(physical_shape.height()), static_cast<uint32_t>(physical_shape.width()));
+    }
+
     return TensorSpec(
         output_shape,
         tt::tt_metal::TensorLayout(

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_utils.cpp
@@ -271,4 +271,34 @@ std::optional<ShardSpec> generate_repeat_shard_spec(
     return ShardSpec(shard_grid, shard_shape, orientation);
 }
 
+void validate_block_shard_grid_not_over_provisioned(
+    const MemoryConfig& mem_config, uint32_t physical_height, uint32_t physical_width) {
+    if (mem_config.memory_layout() != TensorMemoryLayout::BLOCK_SHARDED || !mem_config.shard_spec().has_value()) {
+        return;
+    }
+    const auto& shard_spec = *mem_config.shard_spec();
+    if (shard_spec.grid.ranges().size() != 1 || shard_spec.shape[0] == 0 || shard_spec.shape[1] == 0) {
+        return;
+    }
+    const uint32_t num_shards_along_height = tt::div_up(physical_height, shard_spec.shape[0]);
+    const uint32_t num_shards_along_width = tt::div_up(physical_width, shard_spec.shape[1]);
+    // Row-major maps width-shards to grid columns (x) and height-shards to rows (y); column-major swaps.
+    const bool row_major = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
+    const uint32_t needed_x = row_major ? num_shards_along_width : num_shards_along_height;
+    const uint32_t needed_y = row_major ? num_shards_along_height : num_shards_along_width;
+    const auto grid = shard_spec.grid.bounding_box().grid_size();
+    TT_FATAL(
+        grid.x <= needed_x && grid.y <= needed_y,
+        "ttnn.repeat: requested block-sharded output grid {}x{} (rows x columns) is larger than the {}x{} "
+        "shards the {}x{} output occupies; the extra cores would be silently trimmed at allocation, leaving "
+        "the reported grid inconsistent with the physical buffer. Request a grid matching the shard count, "
+        "or omit the output shard_spec to have it derived.",
+        grid.y,
+        grid.x,
+        needed_y,
+        needed_x,
+        physical_height,
+        physical_width);
+}
+
 }  // namespace ttnn::operations::data_movement::repeat

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_utils.cpp
@@ -248,51 +248,27 @@ std::optional<ShardSpec> generate_repeat_shard_spec(
     } else if (input_tensor.shard_spec().has_value()) {
         orientation = input_tensor.shard_spec()->orientation;
     }
-    return ShardSpec(all_cores, shard_shape, orientation);
-}
 
-MemoryConfig trim_block_shard_grid(const MemoryConfig& mem_config, uint32_t physical_height, uint32_t physical_width) {
-    if (mem_config.memory_layout() != TensorMemoryLayout::BLOCK_SHARDED || !mem_config.shard_spec().has_value()) {
-        return mem_config;
+    // For BLOCK sharding, place the shards on exactly the sub-grid they occupy instead of the whole
+    // compute grid. Reporting the full grid would leave the tensor's shard_spec inconsistent with its
+    // physical buffer (tt-metal trims the grid to the used cores at allocation), which hides the real
+    // layout from the op-constraints query and can corrupt consumers that trust the reported grid.
+    CoreRangeSet shard_grid = all_cores;
+    if (memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
+        const uint32_t num_shards_along_height =
+            static_cast<uint32_t>(tt::div_up(tensor_height, static_cast<uint64_t>(shard_shape[0])));
+        const uint32_t num_shards_along_width =
+            static_cast<uint32_t>(tt::div_up(tensor_width, static_cast<uint64_t>(shard_shape[1])));
+        // Row-major maps width-shards to grid columns (x) and height-shards to rows (y); column-major swaps.
+        const bool row_major = orientation == ShardOrientation::ROW_MAJOR;
+        const uint32_t grid_x = row_major ? num_shards_along_width : num_shards_along_height;
+        const uint32_t grid_y = row_major ? num_shards_along_height : num_shards_along_width;
+        if (grid_x == 0 || grid_y == 0 || grid_x > compute_grid_size.x || grid_y > compute_grid_size.y) {
+            return std::nullopt;
+        }
+        shard_grid = CoreRangeSet(CoreRange({0, 0}, {grid_x - 1, grid_y - 1}));
     }
-    const auto& shard_spec = *mem_config.shard_spec();
-    // Only a single full rectangular grid has a well-defined bounding box to trim.
-    if (shard_spec.grid.ranges().size() != 1) {
-        return mem_config;
-    }
-    const uint32_t shard_height = shard_spec.shape[0];
-    const uint32_t shard_width = shard_spec.shape[1];
-    if (shard_height == 0 || shard_width == 0) {
-        return mem_config;
-    }
-    const uint32_t num_shards_along_height = tt::div_up(physical_height, shard_height);
-    const uint32_t num_shards_along_width = tt::div_up(physical_width, shard_width);
-    // Row-major maps width-shards to grid columns (x) and height-shards to rows (y); column-major swaps.
-    const bool row_major = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
-    const uint32_t needed_x = row_major ? num_shards_along_width : num_shards_along_height;
-    const uint32_t needed_y = row_major ? num_shards_along_height : num_shards_along_width;
-    if (needed_x == 0 || needed_y == 0) {
-        return mem_config;
-    }
-    const auto bounding_box = shard_spec.grid.bounding_box();
-    const auto grid_size = bounding_box.grid_size();
-    // Only shrink: a grid smaller than the shard count is a separate error handled by TensorSpec.
-    if (needed_x >= grid_size.x && needed_y >= grid_size.y) {
-        return mem_config;
-    }
-    const auto start = bounding_box.start_coord;
-    CoreRangeSet trimmed_grid(CoreRange(start, CoreCoord{start.x + needed_x - 1, start.y + needed_y - 1}));
-    log_debug(
-        tt::LogOp,
-        "Repeat: trimmed over-provisioned block-sharded grid {}x{} -> {}x{} to match shard layout",
-        grid_size.y,
-        grid_size.x,
-        needed_y,
-        needed_x);
-    return MemoryConfig(
-        mem_config.memory_layout(),
-        mem_config.buffer_type(),
-        ShardSpec(trimmed_grid, shard_spec.shape, shard_spec.orientation));
+    return ShardSpec(shard_grid, shard_shape, orientation);
 }
 
 }  // namespace ttnn::operations::data_movement::repeat

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_utils.cpp
@@ -6,6 +6,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/work_split.hpp>
 
 namespace ttnn::operations::data_movement::repeat {
 
@@ -249,10 +250,10 @@ std::optional<ShardSpec> generate_repeat_shard_spec(
         orientation = input_tensor.shard_spec()->orientation;
     }
 
-    // For BLOCK sharding, place the shards on exactly the sub-grid they occupy instead of the whole
-    // compute grid. Reporting the full grid would leave the tensor's shard_spec inconsistent with its
-    // physical buffer (tt-metal trims the grid to the used cores at allocation), which hides the real
-    // layout from the op-constraints query and can corrupt consumers that trust the reported grid.
+    // Place the shards on exactly the sub-grid they occupy instead of the whole compute grid.
+    // Reporting the full grid would leave the tensor's shard_spec inconsistent with its physical
+    // buffer (tt-metal trims the grid to the used cores at allocation), which hides the real layout
+    // from the op-constraints query and can corrupt consumers that trust the reported grid.
     CoreRangeSet shard_grid = all_cores;
     if (memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
         const uint32_t num_shards_along_height =
@@ -267,38 +268,75 @@ std::optional<ShardSpec> generate_repeat_shard_spec(
             return std::nullopt;
         }
         shard_grid = CoreRangeSet(CoreRange({0, 0}, {grid_x - 1, grid_y - 1}));
+    } else {
+        // HEIGHT/WIDTH are 1D: use exactly num_shards cores (matching the buffer's 1D trim order), so
+        // num_cores == num_shards and the buffer performs no trimming. num_cores_to_corerangeset may
+        // return an up-to-3-range set, which HEIGHT/WIDTH validation allows (unlike block).
+        const uint32_t num_shards = static_cast<uint32_t>(
+            memory_layout == TensorMemoryLayout::HEIGHT_SHARDED
+                ? tt::div_up(tensor_height, static_cast<uint64_t>(shard_shape[0]))
+                : tt::div_up(tensor_width, static_cast<uint64_t>(shard_shape[1])));
+        if (num_shards == 0 || num_shards > num_cores) {
+            return std::nullopt;
+        }
+        shard_grid =
+            num_cores_to_corerangeset(num_shards, compute_grid_size, orientation == ShardOrientation::ROW_MAJOR);
     }
     return ShardSpec(shard_grid, shard_shape, orientation);
 }
 
-void validate_block_shard_grid_not_over_provisioned(
+void validate_shard_grid_not_over_provisioned(
     const MemoryConfig& mem_config, uint32_t physical_height, uint32_t physical_width) {
-    if (mem_config.memory_layout() != TensorMemoryLayout::BLOCK_SHARDED || !mem_config.shard_spec().has_value()) {
+    if (!mem_config.is_sharded() || !mem_config.shard_spec().has_value()) {
         return;
     }
     const auto& shard_spec = *mem_config.shard_spec();
-    if (shard_spec.grid.ranges().size() != 1 || shard_spec.shape[0] == 0 || shard_spec.shape[1] == 0) {
+    if (shard_spec.shape[0] == 0 || shard_spec.shape[1] == 0) {
         return;
     }
-    const uint32_t num_shards_along_height = tt::div_up(physical_height, shard_spec.shape[0]);
-    const uint32_t num_shards_along_width = tt::div_up(physical_width, shard_spec.shape[1]);
-    // Row-major maps width-shards to grid columns (x) and height-shards to rows (y); column-major swaps.
-    const bool row_major = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
-    const uint32_t needed_x = row_major ? num_shards_along_width : num_shards_along_height;
-    const uint32_t needed_y = row_major ? num_shards_along_height : num_shards_along_width;
-    const auto grid = shard_spec.grid.bounding_box().grid_size();
-    TT_FATAL(
-        grid.x <= needed_x && grid.y <= needed_y,
-        "ttnn.repeat: requested block-sharded output grid {}x{} (rows x columns) is larger than the {}x{} "
-        "shards the {}x{} output occupies; the extra cores would be silently trimmed at allocation, leaving "
-        "the reported grid inconsistent with the physical buffer. Request a grid matching the shard count, "
-        "or omit the output shard_spec to have it derived.",
-        grid.y,
-        grid.x,
-        needed_y,
-        needed_x,
-        physical_height,
-        physical_width);
+    const auto memory_layout = mem_config.memory_layout();
+    if (memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
+        if (shard_spec.grid.ranges().size() != 1) {
+            return;  // non-rectangular grid: no well-defined bounding box to compare
+        }
+        const uint32_t num_shards_along_height = tt::div_up(physical_height, shard_spec.shape[0]);
+        const uint32_t num_shards_along_width = tt::div_up(physical_width, shard_spec.shape[1]);
+        // Row-major maps width-shards to grid columns (x) and height-shards to rows (y); column-major swaps.
+        const bool row_major = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
+        const uint32_t needed_x = row_major ? num_shards_along_width : num_shards_along_height;
+        const uint32_t needed_y = row_major ? num_shards_along_height : num_shards_along_width;
+        const auto grid = shard_spec.grid.bounding_box().grid_size();
+        TT_FATAL(
+            grid.x <= needed_x && grid.y <= needed_y,
+            "ttnn.repeat: requested block-sharded output grid {}x{} (rows x columns) is larger than the {}x{} "
+            "shards the {}x{} output occupies; the extra cores would be silently trimmed at allocation, leaving "
+            "the reported grid inconsistent with the physical buffer. Request a grid matching the shard count, "
+            "or omit the output shard_spec to have it derived.",
+            grid.y,
+            grid.x,
+            needed_y,
+            needed_x,
+            physical_height,
+            physical_width);
+    } else if (
+        memory_layout == TensorMemoryLayout::HEIGHT_SHARDED || memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
+        // HEIGHT/WIDTH are 1D: the used cores are min(num_cores, num_shards); a grid with more cores than
+        // shards is silently trimmed, so the reported grid diverges from the physical buffer.
+        const bool is_height = memory_layout == TensorMemoryLayout::HEIGHT_SHARDED;
+        const uint32_t num_shards = is_height ? tt::div_up(physical_height, shard_spec.shape[0])
+                                              : tt::div_up(physical_width, shard_spec.shape[1]);
+        TT_FATAL(
+            shard_spec.num_cores() <= num_shards,
+            "ttnn.repeat: requested {}-sharded output grid has {} cores, larger than the {} shards the {}x{} output "
+            "occupies; the extra cores would be silently trimmed at allocation, leaving the reported grid "
+            "inconsistent with the physical buffer. Request a grid matching the shard count, or omit the output "
+            "shard_spec to have it derived.",
+            is_height ? "height" : "width",
+            shard_spec.num_cores(),
+            num_shards,
+            physical_height,
+            physical_width);
+    }
 }
 
 }  // namespace ttnn::operations::data_movement::repeat

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_utils.cpp
@@ -251,4 +251,48 @@ std::optional<ShardSpec> generate_repeat_shard_spec(
     return ShardSpec(all_cores, shard_shape, orientation);
 }
 
+MemoryConfig trim_block_shard_grid(const MemoryConfig& mem_config, uint32_t physical_height, uint32_t physical_width) {
+    if (mem_config.memory_layout() != TensorMemoryLayout::BLOCK_SHARDED || !mem_config.shard_spec().has_value()) {
+        return mem_config;
+    }
+    const auto& shard_spec = *mem_config.shard_spec();
+    // Only a single full rectangular grid has a well-defined bounding box to trim.
+    if (shard_spec.grid.ranges().size() != 1) {
+        return mem_config;
+    }
+    const uint32_t shard_height = shard_spec.shape[0];
+    const uint32_t shard_width = shard_spec.shape[1];
+    if (shard_height == 0 || shard_width == 0) {
+        return mem_config;
+    }
+    const uint32_t num_shards_along_height = tt::div_up(physical_height, shard_height);
+    const uint32_t num_shards_along_width = tt::div_up(physical_width, shard_width);
+    // Row-major maps width-shards to grid columns (x) and height-shards to rows (y); column-major swaps.
+    const bool row_major = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
+    const uint32_t needed_x = row_major ? num_shards_along_width : num_shards_along_height;
+    const uint32_t needed_y = row_major ? num_shards_along_height : num_shards_along_width;
+    if (needed_x == 0 || needed_y == 0) {
+        return mem_config;
+    }
+    const auto bounding_box = shard_spec.grid.bounding_box();
+    const auto grid_size = bounding_box.grid_size();
+    // Only shrink: a grid smaller than the shard count is a separate error handled by TensorSpec.
+    if (needed_x >= grid_size.x && needed_y >= grid_size.y) {
+        return mem_config;
+    }
+    const auto start = bounding_box.start_coord;
+    CoreRangeSet trimmed_grid(CoreRange(start, CoreCoord{start.x + needed_x - 1, start.y + needed_y - 1}));
+    log_debug(
+        tt::LogOp,
+        "Repeat: trimmed over-provisioned block-sharded grid {}x{} -> {}x{} to match shard layout",
+        grid_size.y,
+        grid_size.x,
+        needed_y,
+        needed_x);
+    return MemoryConfig(
+        mem_config.memory_layout(),
+        mem_config.buffer_type(),
+        ShardSpec(trimmed_grid, shard_spec.shape, shard_spec.orientation));
+}
+
 }  // namespace ttnn::operations::data_movement::repeat

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_utils.hpp
@@ -40,13 +40,13 @@ std::optional<tt::tt_metal::ShardSpec> generate_repeat_shard_spec(
     tt::tt_metal::TensorMemoryLayout memory_layout,
     std::optional<tt::tt_metal::ShardOrientation> orientation_hint = std::nullopt);
 
-// TT_FATAL if a BLOCK_SHARDED output config requests a grid larger than the shards the given physical
-// (padded) output extents occupy. tt-metal would silently trim such a grid to the used cores at
-// allocation, leaving the reported grid inconsistent with the physical buffer -- a falsely reported
-// grid that corrupts consumers (and the op-constraints query) that trust it. No-op for non-block
-// layouts, a missing/non-rectangular shard spec, or a grid that matches (or is smaller than) the
-// shard count.
-void validate_block_shard_grid_not_over_provisioned(
+// TT_FATAL if a sharded output config (BLOCK, HEIGHT, or WIDTH) requests a grid larger than the shards
+// the given physical (padded) output extents occupy. tt-metal would silently trim such a grid to the
+// used cores at allocation, leaving the reported grid inconsistent with the physical buffer -- a
+// falsely reported grid that corrupts consumers (and the op-constraints query) that trust it. No-op
+// for interleaved/unsharded, a missing shard spec, a non-rectangular block grid, or a grid that
+// matches (or is smaller than) the shard count.
+void validate_shard_grid_not_over_provisioned(
     const tt::tt_metal::MemoryConfig& mem_config, uint32_t physical_height, uint32_t physical_width);
 
 }  // namespace ttnn::operations::data_movement::repeat

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_utils.hpp
@@ -40,13 +40,4 @@ std::optional<tt::tt_metal::ShardSpec> generate_repeat_shard_spec(
     tt::tt_metal::TensorMemoryLayout memory_layout,
     std::optional<tt::tt_metal::ShardOrientation> orientation_hint = std::nullopt);
 
-// Trim an over-provisioned BLOCK_SHARDED grid down to the sub-grid its shards actually occupy for
-// the given physical (padded) output extents. tt-metal otherwise trims the grid silently at
-// allocation, so the layout reported by the op-constraints query (and created at runtime) would not
-// match the physical buffer -- hiding the real grid from the compiler and corrupting consumers that
-// trust the reported grid. No-op for non-block layouts, a non-rectangular grid, or a grid that
-// already matches (or is smaller than) the shard count.
-tt::tt_metal::MemoryConfig trim_block_shard_grid(
-    const tt::tt_metal::MemoryConfig& mem_config, uint32_t physical_height, uint32_t physical_width);
-
 }  // namespace ttnn::operations::data_movement::repeat

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_utils.hpp
@@ -40,4 +40,13 @@ std::optional<tt::tt_metal::ShardSpec> generate_repeat_shard_spec(
     tt::tt_metal::TensorMemoryLayout memory_layout,
     std::optional<tt::tt_metal::ShardOrientation> orientation_hint = std::nullopt);
 
+// TT_FATAL if a BLOCK_SHARDED output config requests a grid larger than the shards the given physical
+// (padded) output extents occupy. tt-metal would silently trim such a grid to the used cores at
+// allocation, leaving the reported grid inconsistent with the physical buffer -- a falsely reported
+// grid that corrupts consumers (and the op-constraints query) that trust it. No-op for non-block
+// layouts, a missing/non-rectangular shard spec, or a grid that matches (or is smaller than) the
+// shard count.
+void validate_block_shard_grid_not_over_provisioned(
+    const tt::tt_metal::MemoryConfig& mem_config, uint32_t physical_height, uint32_t physical_width);
+
 }  // namespace ttnn::operations::data_movement::repeat

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/repeat_utils.hpp
@@ -40,4 +40,13 @@ std::optional<tt::tt_metal::ShardSpec> generate_repeat_shard_spec(
     tt::tt_metal::TensorMemoryLayout memory_layout,
     std::optional<tt::tt_metal::ShardOrientation> orientation_hint = std::nullopt);
 
+// Trim an over-provisioned BLOCK_SHARDED grid down to the sub-grid its shards actually occupy for
+// the given physical (padded) output extents. tt-metal otherwise trims the grid silently at
+// allocation, so the layout reported by the op-constraints query (and created at runtime) would not
+// match the physical buffer -- hiding the real grid from the compiler and corrupting consumers that
+// trust the reported grid. No-op for non-block layouts, a non-rectangular grid, or a grid that
+// already matches (or is smaller than) the shard count.
+tt::tt_metal::MemoryConfig trim_block_shard_grid(
+    const tt::tt_metal::MemoryConfig& mem_config, uint32_t physical_height, uint32_t physical_width);
+
 }  // namespace ttnn::operations::data_movement::repeat

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.cpp
@@ -283,20 +283,6 @@ ttnn::Tensor repeat(
                 return working_tensor;  // No valid spec; keep interleaved.
             }
         }
-        // Trim an over-provisioned block-sharded output grid to the sub-grid its shards occupy, so
-        // the created tensor's layout matches its physical buffer (and the op-constraints query
-        // reports the honest grid) instead of tt-metal trimming it silently at allocation.
-        if (final_mc.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
-            const auto& padded = working_tensor.padded_shape();
-            const int32_t rank = static_cast<int32_t>(padded.rank());
-            uint32_t physical_width = rank > 0 ? padded[-1] : 1;
-            uint32_t physical_height = 1;
-            for (int32_t i = 0; i + 1 < rank; ++i) {
-                physical_height *= padded[i];
-            }
-            final_mc =
-                operations::data_movement::repeat::trim_block_shard_grid(final_mc, physical_height, physical_width);
-        }
         working_tensor = ttnn::interleaved_to_sharded(working_tensor, final_mc, std::nullopt);
     }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.cpp
@@ -283,6 +283,20 @@ ttnn::Tensor repeat(
                 return working_tensor;  // No valid spec; keep interleaved.
             }
         }
+        // Reject an over-provisioned explicit block-sharded output grid before resharding into it
+        // (see validate_block_shard_grid_not_over_provisioned). physical extents from the repeated
+        // tensor's tile-padded shape.
+        {
+            const auto& padded = working_tensor.padded_shape();
+            const int32_t rank = static_cast<int32_t>(padded.rank());
+            uint64_t physical_height = 1;
+            for (int32_t i = 0; i + 1 < rank; ++i) {
+                physical_height *= static_cast<uint64_t>(padded[i]);
+            }
+            const uint64_t physical_width = rank > 0 ? static_cast<uint64_t>(padded[-1]) : 1;
+            operations::data_movement::repeat::validate_block_shard_grid_not_over_provisioned(
+                final_mc, static_cast<uint32_t>(physical_height), static_cast<uint32_t>(physical_width));
+        }
         working_tensor = ttnn::interleaved_to_sharded(working_tensor, final_mc, std::nullopt);
     }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.cpp
@@ -283,8 +283,8 @@ ttnn::Tensor repeat(
                 return working_tensor;  // No valid spec; keep interleaved.
             }
         }
-        // Reject an over-provisioned explicit block-sharded output grid before resharding into it
-        // (see validate_block_shard_grid_not_over_provisioned). physical extents from the repeated
+        // Reject an over-provisioned explicit sharded output grid before resharding into it
+        // (see validate_shard_grid_not_over_provisioned). physical extents from the repeated
         // tensor's tile-padded shape.
         {
             const auto& padded = working_tensor.padded_shape();
@@ -294,7 +294,7 @@ ttnn::Tensor repeat(
                 physical_height *= static_cast<uint64_t>(padded[i]);
             }
             const uint64_t physical_width = rank > 0 ? static_cast<uint64_t>(padded[-1]) : 1;
-            operations::data_movement::repeat::validate_block_shard_grid_not_over_provisioned(
+            operations::data_movement::repeat::validate_shard_grid_not_over_provisioned(
                 final_mc, static_cast<uint32_t>(physical_height), static_cast<uint32_t>(physical_width));
         }
         working_tensor = ttnn::interleaved_to_sharded(working_tensor, final_mc, std::nullopt);

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/repeat.cpp
@@ -283,6 +283,20 @@ ttnn::Tensor repeat(
                 return working_tensor;  // No valid spec; keep interleaved.
             }
         }
+        // Trim an over-provisioned block-sharded output grid to the sub-grid its shards occupy, so
+        // the created tensor's layout matches its physical buffer (and the op-constraints query
+        // reports the honest grid) instead of tt-metal trimming it silently at allocation.
+        if (final_mc.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
+            const auto& padded = working_tensor.padded_shape();
+            const int32_t rank = static_cast<int32_t>(padded.rank());
+            uint32_t physical_width = rank > 0 ? padded[-1] : 1;
+            uint32_t physical_height = 1;
+            for (int32_t i = 0; i + 1 < rank; ++i) {
+                physical_height *= padded[i];
+            }
+            final_mc =
+                operations::data_movement::repeat::trim_block_shard_grid(final_mc, physical_height, physical_width);
+        }
         working_tensor = ttnn::interleaved_to_sharded(working_tensor, final_mc, std::nullopt);
     }
 


### PR DESCRIPTION
### Problem
Manifested as https://github.com/tenstorrent/tt-xla/issues/5605

`ttnn.repeat` could report a block-sharded output tensor on the **full device grid** (e.g. `8×8` = 64 cores) when the data only fills a few tiles (e.g. `1×4` = 4 shards). tt-metal then silently trims the buffer to the 4 used cores at allocation, so the tensor's `shard_spec` advertises 64 cores while the physical buffer only ever writes 4. The compiler's op-constraints query sees the inflated grid and emits it, and any downstream consumer that trusts the reported grid ends up reading cores this tensor never wrote — surfaced as a PCC failure in Falcon3-1B (`repeat → SDPA` path) and other models.

### Why it only failed on the *second* run (the confusing part)
The failure is an **order-dependent stale-L1 read**, which is why it looked non-deterministic:

- A consumer reading per the advertised 64-core grid touches the 60 cores that were never allocated/written for this tensor. Their L1 contents are undefined.
- **PCC check run on its own (or first):** those cores hold fresh/zeroed L1, so the out-of-region read is benign → PCC passes.
- **Perf-benchmark run first:** its outputs are correct (it reads clean L1, and perf doesn't PCC-check), but it leaves activations scattered across L1 — including those 60 cores.
- **PCC check run *after* perf:** the over-read now picks up the perf run's leftovers → corrupted input → bad PCC.

So the perf run *poisons* the extra cores and the PCC run *consumes* the poison — the first run of the pair seeds the L1 the second run reads. Classic uninitialized-memory signature, invisible in a clean single run.

> Note: this only bites the **compiled** program. Eager `ttnn` ops recompute their read from the live (already-trimmed) buffer distribution, so they touch only the 4 real cores and are unaffected — verified by staging poison at the phantom cores' exact address and observing zero leakage. The over-read comes from the reader runtime args baked at compile time from the inflated grid, which is why this surfaced in the compiled model but not in eager unit tests.

### Root cause
When the output memory config has no explicit shard spec (the compiler's query path), `generate_repeat_shard_spec` synthesized the output grid over `all_cores` (the whole compute grid) instead of the sub-grid the shards actually occupy — for BLOCK, HEIGHT, and WIDTH sharding alike.

### Fix
Two parts, both scoped to `ttnn.repeat` and covering all three sharded layouts:
1. **Derive an honest grid** — `generate_repeat_shard_spec` now sizes the derived grid to exactly the shards the output occupies, instead of `all_cores`: BLOCK → `num_shards_h × num_shards_w` cores (orientation-aware); HEIGHT/WIDTH → `num_shards` cores via `num_cores_to_corerangeset` (mirroring the existing `upsample` autoshard). The reported grid matches the physical buffer, so the op-constraints query returns the honest layout (covers both the native and composite paths — both go through `generate`).
2. **Reject a false explicit grid** — if a caller passes an *explicit* sharded output grid (BLOCK, HEIGHT, or WIDTH) larger than the shards the output occupies, `repeat` now raises a catchable `TT_FATAL` instead of letting it be silently trimmed. At the op-constraints query this makes the over-provisioned candidate infeasible (the compiler picks a matching grid); at runtime it's a loud error rather than silent bad PCC.

**Why both files change (native vs composite path):** `ttnn.repeat` has two implementations. On the **native** path (sharded input + fast-path predicate accepts) it repeats directly on the sharded L1 buffer and writes the sharded output itself — grid handled in `compute_output_specs`. On the **composite** path (fallback) it strips to interleaved, repeats, then reshards into the requested layout via `interleaved_to_sharded` — grid handled in `repeat.cpp` just before that reshard. The Falcon case (input `1×4` → output `8×8`, grids differ → predicate rejects) takes the **composite** path, so both fixes are applied in both spots.

### Open question for reviewers — is this the right layer for tt-metal?
Part 1 (deriving a minimal grid) is low-risk. **Part 2 (the `TT_FATAL`) is the debatable one, because it makes `repeat` stricter than tt-metal's general policy — flagging it explicitly:**

- tt-metal otherwise **supports** over-provisioned sharded grids: `TensorSpec` (`get_shape_fits_shard_grid_error`) only rejects grids that are *too small*, and `buffer_distribution_spec` silently **trims** a too-large grid to the used cores. `LegacyToNdShardingTests` explicitly assert an over-provisioned block grid is valid and preserved.
- So this PR rejects, in `repeat`, a shape of config the rest of the stack accepts. And the "reported grid ≠ physical grid" mismatch is **not repeat-specific**: the same `generate_*_shard_spec` → `ShardSpec(all_cores, …)` pattern this PR fixes is copy-pasted across ~6 op families — **transpose** (and its dependents **slice**/**permute**), **binary_ng**, **ternary**, **unary**, and **indexed_fill** — each reporting the full compute grid regardless of shard count (`indexed_fill` even comments on the mismatch but still reports `all_cores`). The divergence is *created centrally*: `buffer_distribution_spec` silently trims any over-sized grid at allocation (`trimmed_core_grid` / `num_cores_with_data`), so reported vs physical split there for all of them. (I confirmed the shared code pattern by reading; I only empirically reproduced the resulting corruption for `repeat`.)
- Candidate layers: **(a) compiler** — don't emit over-provisioned grids (the root cause; tt-metal already handles the *data* correctly); **(b) platform-wide** — fix it once in the shared derivation (size the grid to the shard count) or reconcile at the central trim, covering all ~6 ops instead of patching each; **(c) this PR** — fix `repeat` fully (all three of its sharded layouts) as a targeted fail-fast; the other ~5 op families keep the pattern.

Question for a maintainer: is the repeat-scoped `TT_FATAL` acceptable as a fail-fast, or should over-provisioned grids be addressed compiler-side / platform-wide instead? (Part 1 stands on its own either way.)

**Scope check (verified):** this PR is repeat-only — it does not touch `tensor_spec.cpp`, so all 17 `LegacyToNdSharding` tests stay green with it applied. Only a *central* `TensorSpec`-level reject (option **b**) breaks them (7 of the 17, the block over-provisioned params). That's the concrete cost of the platform-wide path.

### Tests
Nightly `test_universal_input_tm_repeat.py`, covering all three sharded layouts:
- `test_repeat_block_sharded_derived_grid_scales_with_shape` — derived BLOCK grid scales to the shards (`1×4/2×4/4×4/8×4` for `repeat=8/64/128/256`), not the full device grid.
- `test_repeat_1d_sharded_derived_grid_is_minimal` — derived HEIGHT/WIDTH grid uses exactly the shard count (HEIGHT `1/2/4/8`, WIDTH `4`), not the full grid.
- `test_repeat_sharded_explicit_over_provisioned_grid_errors` — an explicit over-provisioned grid raises the `TT_FATAL`, parametrized over BLOCK/HEIGHT/WIDTH.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bmalesevic/fix-repeat-op-output-sharding)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bmalesevic/fix-repeat-op-output-sharding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bmalesevic/fix-repeat-op-output-sharding)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bmalesevic/fix-repeat-op-output-sharding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=bmalesevic/fix-repeat-op-output-sharding)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:bmalesevic/fix-repeat-op-output-sharding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bmalesevic/fix-repeat-op-output-sharding)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bmalesevic/fix-repeat-op-output-sharding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bmalesevic/fix-repeat-op-output-sharding)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bmalesevic/fix-repeat-op-output-sharding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bmalesevic/fix-repeat-op-output-sharding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bmalesevic/fix-repeat-op-output-sharding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bmalesevic/fix-repeat-op-output-sharding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bmalesevic/fix-repeat-op-output-sharding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bmalesevic/fix-repeat-op-output-sharding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bmalesevic/fix-repeat-op-output-sharding)
