### PR TITLE
 [Bug fix] Fix NoC wedge in watcher sanitize tests under SD mode

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -238,6 +238,11 @@ void RunTestOnCore(
         }
         // (gen1 path: no CTA bindings needed; the kernel runs on exactly one DM processor.)
 
+        // Under SD the kernel signals completion via RUN_MSG_DONE, not the FD notify path (which wedges the NOC).
+        if (fixture->IsSlowDispatch()) {
+            defines["WATCHER_KERNEL_SLOW_DISPATCH"] = "1";
+        }
+
         // Select the DM config variant matching the current architecture (Gen2 on Quasar, Gen1 otherwise).
         auto gen1_processor =
             use_ncrisc ? tt::tt_metal::DataMovementProcessor::RISCV_1 : tt::tt_metal::DataMovementProcessor::RISCV_0;

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord_2_0.cpp
@@ -77,8 +77,9 @@ void kernel_main() {
     // Dispatcher Kernel is able to finish.
     // Device::close() requires fast-dispatch kernels to finish.
     volatile tt_l1_ptr go_msg_t* go_message_in = GET_MAILBOX_ADDRESS_DEV(go_messages[0]);
-#if defined(COMPILE_FOR_DM)
-    // SD signaling: Quasar DM requires RUN_MSG_DONE. TODO: remove once FD is enabled on Quasar.
+    // SD enabled on all archs: notify completion via RUN_MSG_DONE to mailbox. FD notify path
+    // posts to a dispatcher absent under SD and wedges the NOC.
+#if defined(WATCHER_KERNEL_SLOW_DISPATCH)
     go_message_in->signal = RUN_MSG_DONE;
 #else
     uint64_t dispatch_addr = calculate_dispatch_addr(go_message_in);


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes https://github.com/tenstorrent/tt-metal/issues/50046

https://github.com/tenstorrent/tt-metal/pull/49622 enabled watcher NoC sanitize tests on TENSIX/ACTIVE_ETH under slow dispatch on all archs (previously was FD only, SD was Quasar/idle-eth only). Under SD the sanitize kernel still signaled completion via the FD `notify_dispatch_core_done` path, which posts to a dispatcher that doesn't exist under SD - perturbing overlay/NoC state and permanently wedging the device. Regressed by https://github.com/tenstorrent/tt-metal/pull/49622.

Fix: select the completion signal by dispatch mode, not arch - `RUN_MSG_DONE` write to mailbox under SD, `notify_dispatch_core_done` under FD - via a new `WATCHER_KERNEL_SLOW_DISPATCH` compile define set from `fixture->IsSlowDispatch()`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

Runtime unit tests: https://github.com/tenstorrent/tt-metal/actions/runs/29546258407

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadkarni/fix_sanitize_sd)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadkarni/fix_sanitize_sd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=snadkarni/fix_sanitize_sd)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:snadkarni/fix_sanitize_sd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=snadkarni/fix_sanitize_sd)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:snadkarni/fix_sanitize_sd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/fix_sanitize_sd)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/fix_sanitize_sd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=snadkarni/fix_sanitize_sd)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:snadkarni/fix_sanitize_sd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/fix_sanitize_sd)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/fix_sanitize_sd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/fix_sanitize_sd)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/fix_sanitize_sd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/fix_sanitize_sd)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/fix_sanitize_sd)