### PR TITLE
ci: canonical, run-id-free artifact naming + embedded manifest for build-artifact.yaml

### DIFF
--- a/.github/actions/compute-artifact-key/action.yml
+++ b/.github/actions/compute-artifact-key/action.yml
@@ -33,6 +33,14 @@ inputs:
   toolchain:
     required: true
     description: "Raw toolchain path, e.g. cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake"
+  build-image:
+    required: true
+    description: >-
+      The exact resolved container image the build actually compiles inside
+      (e.g. ghcr.io/.../ci-build:<hash> or a caller-supplied override via
+      ci-build-docker-image). This is the compiler/runtime environment -- it
+      affects compiled output as much as toolchain/build-type do, so it's
+      part of the canonical key and manifest for every kind, not just build.
   tracy:
     required: true
   distributed:
@@ -102,6 +110,7 @@ runs:
         architecture=${{ inputs.architecture }}
         build-type=${{ inputs.build-type }}
         toolchain=${TOOLCHAIN_CLEANED}
+        build-image=${{ inputs.build-image }}
         tracy=${TRACY}
         distributed=${DISTRIBUTED}
         enable-lto=${ENABLE_LTO}
@@ -148,6 +157,7 @@ runs:
           "architecture": "${{ inputs.architecture }}",
           "build-type": "${{ inputs.build-type }}",
           "toolchain": "${TOOLCHAIN_CLEANED}",
+          "build-image": "${{ inputs.build-image }}",
           "tracy": ${TRACY},
           "distributed": ${DISTRIBUTED},
           "enable-lto": ${ENABLE_LTO},

--- a/.github/actions/compute-artifact-key/action.yml
+++ b/.github/actions/compute-artifact-key/action.yml
@@ -75,6 +75,24 @@ runs:
         SANITIZED_REF=$(echo "${{ inputs.ref }}" | sed 's/[\/:"<>|*?\r\n\\]/-/g')
         SHA12="${SANITIZED_REF:0:12}"
 
+        # Defensive boolean normalization: some of these inputs are only
+        # declared under this workflow's `workflow_call.inputs` and NOT under
+        # `workflow_dispatch.inputs` (e.g. skip-tt-train, build-ttnn-import-artifact).
+        # When triggered via workflow_dispatch, referencing such an input
+        # yields an EMPTY string, not its workflow_call default -- verified
+        # live (a workflow_dispatch smoke-test run produced a literal empty
+        # value here, breaking the JSON below). Coerce every boolean-ish
+        # field to a real "true"/"false" so the manifest is always valid
+        # JSON and the hash is stable regardless of which trigger fired.
+        norm_bool() { [ "$1" = "true" ] && echo "true" || echo "false"; }
+        TRACY=$(norm_bool "${{ inputs.tracy }}")
+        DISTRIBUTED=$(norm_bool "${{ inputs.distributed }}")
+        ENABLE_LTO=$(norm_bool "${{ inputs.enable-lto }}")
+        SKIP_TT_TRAIN=$(norm_bool "${{ inputs.skip-tt-train }}")
+        BUILD_UMD_TESTS=$(norm_bool "${{ inputs.build-umd-tests }}")
+        PROFILE=$(norm_bool "${{ inputs.profile }}")
+        BUILD_TTNN_IMPORT_ARTIFACT=$(norm_bool "${{ inputs.build-ttnn-import-artifact }}")
+
         # Canonical, order-independent parameter tuple. Every field that
         # affects compiled output must be listed here.
         CANONICAL=$(cat <<EOF
@@ -84,18 +102,18 @@ runs:
         architecture=${{ inputs.architecture }}
         build-type=${{ inputs.build-type }}
         toolchain=${TOOLCHAIN_CLEANED}
-        tracy=${{ inputs.tracy }}
-        distributed=${{ inputs.distributed }}
-        enable-lto=${{ inputs.enable-lto }}
-        skip-tt-train=${{ inputs.skip-tt-train }}
-        build-umd-tests=${{ inputs.build-umd-tests }}
-        profile=${{ inputs.profile }}
+        tracy=${TRACY}
+        distributed=${DISTRIBUTED}
+        enable-lto=${ENABLE_LTO}
+        skip-tt-train=${SKIP_TT_TRAIN}
+        build-umd-tests=${BUILD_UMD_TESTS}
+        profile=${PROFILE}
         EOF
         )
 
         if [ "${{ inputs.kind }}" = "ttnn-import" ]; then
           CANONICAL="${CANONICAL}
-        build-ttnn-import-artifact=${{ inputs.build-ttnn-import-artifact }}"
+        build-ttnn-import-artifact=${BUILD_TTNN_IMPORT_ARTIFACT}"
         fi
 
         CANONICAL_SORTED=$(echo "$CANONICAL" | sort)
@@ -106,7 +124,7 @@ runs:
             NAME="packages-${SHA12}-${CFGHASH}"
             ;;
           build)
-            TRACY_SUFFIX="${{ (inputs.tracy == 'true' && '_profiler') || '' }}"
+            TRACY_SUFFIX="$([ "$TRACY" = "true" ] && echo '_profiler' || echo '')"
             NAME="TTMetal_build_any${TRACY_SUFFIX}_${SHA12}_${CFGHASH}"
             ;;
           ttnn-import)
@@ -130,13 +148,13 @@ runs:
           "architecture": "${{ inputs.architecture }}",
           "build-type": "${{ inputs.build-type }}",
           "toolchain": "${TOOLCHAIN_CLEANED}",
-          "tracy": ${{ inputs.tracy }},
-          "distributed": ${{ inputs.distributed }},
-          "enable-lto": ${{ inputs.enable-lto }},
-          "skip-tt-train": ${{ inputs.skip-tt-train }},
-          "build-umd-tests": ${{ inputs.build-umd-tests }},
-          "profile": ${{ inputs.profile }},
-          "build-ttnn-import-artifact": ${{ inputs.build-ttnn-import-artifact || false }},
+          "tracy": ${TRACY},
+          "distributed": ${DISTRIBUTED},
+          "enable-lto": ${ENABLE_LTO},
+          "skip-tt-train": ${SKIP_TT_TRAIN},
+          "build-umd-tests": ${BUILD_UMD_TESTS},
+          "profile": ${PROFILE},
+          "build-ttnn-import-artifact": ${BUILD_TTNN_IMPORT_ARTIFACT},
           "cfg-hash": "${CFGHASH}"
         }
         JSON

--- a/.github/actions/compute-artifact-key/action.yml
+++ b/.github/actions/compute-artifact-key/action.yml
@@ -18,45 +18,63 @@ description: >-
 inputs:
   kind:
     required: true
-    description: "Artifact kind: packages | build | ttnn-import"
+    description: "Artifact kind: packages | build | ttnn-import | wheel"
   ref:
     required: true
     description: "Resolved git ref/SHA the build was performed at (i.e. inputs.ref || github.sha), NOT a workflow run ID"
-  distro:
-    required: true
-  version:
-    required: true
-  architecture:
-    required: true
   build-type:
     required: true
-  toolchain:
-    required: true
-    description: "Raw toolchain path, e.g. cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake"
   build-image:
     required: true
     description: >-
       The exact resolved container image the build actually compiles inside
       (e.g. ghcr.io/.../ci-build:<hash> or a caller-supplied override via
-      ci-build-docker-image). This is the compiler/runtime environment -- it
-      affects compiled output as much as toolchain/build-type do, so it's
-      part of the canonical key and manifest for every kind, not just build.
+      ci-build-docker-image, or the manylinux image for kind=wheel). This is
+      the compiler/runtime environment -- it affects compiled output as much
+      as toolchain/build-type do, so it's part of the canonical key and
+      manifest for every kind.
   tracy:
-    required: true
-  distributed:
     required: true
   enable-lto:
     required: true
+  # packages/build/ttnn-import only -- wheels.yaml's cibuildwheel-based build
+  # has no distro/toolchain/distributed/skip-tt-train/build-umd-tests/profile
+  # concept at all, so these are optional and simply omitted from the
+  # canonical tuple and manifest for kind=wheel.
+  distro:
+    required: false
+    default: ""
+  version:
+    required: false
+    default: ""
+  architecture:
+    required: false
+    default: ""
+  toolchain:
+    required: false
+    default: ""
+    description: "Raw toolchain path, e.g. cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake"
+  distributed:
+    required: false
+    default: "false"
   skip-tt-train:
-    required: true
+    required: false
+    default: "false"
   build-umd-tests:
-    required: true
+    required: false
+    default: "false"
   profile:
-    required: true
+    required: false
+    default: "false"
   build-ttnn-import-artifact:
     required: false
     default: "false"
     description: "Only relevant for kind=ttnn-import; included in that kind's canonical key"
+  # wheel only
+  python-version:
+    required: false
+    default: ""
+    description: "Only relevant for kind=wheel; e.g. 3.10, 3.12"
 
 outputs:
   name:
@@ -79,9 +97,9 @@ runs:
       run: |
         set -eu
 
-        TOOLCHAIN_CLEANED=$(echo "${{ inputs.toolchain }}" | sed -E 's/^cmake\///; s/-toolchain\.cmake$//')
         SANITIZED_REF=$(echo "${{ inputs.ref }}" | sed 's/[\/:"<>|*?\r\n\\]/-/g')
         SHA12="${SANITIZED_REF:0:12}"
+        KIND="${{ inputs.kind }}"
 
         # Defensive boolean normalization: some of these inputs are only
         # declared under this workflow's `workflow_call.inputs` and NOT under
@@ -94,8 +112,57 @@ runs:
         # JSON and the hash is stable regardless of which trigger fired.
         norm_bool() { [ "$1" = "true" ] && echo "true" || echo "false"; }
         TRACY=$(norm_bool "${{ inputs.tracy }}")
-        DISTRIBUTED=$(norm_bool "${{ inputs.distributed }}")
         ENABLE_LTO=$(norm_bool "${{ inputs.enable-lto }}")
+
+        if [ "$KIND" = "wheel" ]; then
+          # wheels.yaml (cibuildwheel-based) has no distro/toolchain/distributed/
+          # skip-tt-train/build-umd-tests/profile concept -- only the fields
+          # that actually affect its compiled output go in the tuple/manifest.
+          PYVER_NODOT=$(echo "${{ inputs.python-version }}" | tr -d '.')
+
+          CANONICAL=$(cat <<EOF
+        ref=${SANITIZED_REF}
+        build-type=${{ inputs.build-type }}
+        build-image=${{ inputs.build-image }}
+        tracy=${TRACY}
+        enable-lto=${ENABLE_LTO}
+        python-version=${{ inputs.python-version }}
+        EOF
+          )
+          CANONICAL_SORTED=$(echo "$CANONICAL" | sort)
+          CFGHASH=$(printf '%s' "$CANONICAL_SORTED" | sha256sum | cut -c1-10)
+
+          # "ttnn-dist" prefix preserved: download-artifacts-from-run/action.yml
+          # and tests/scripts/download_artifacts.sh both grep for "ttnn-dist|ttnn".
+          NAME="ttnn-dist-cp${PYVER_NODOT}-${SHA12}-${CFGHASH}"
+
+          MANIFEST=$(cat <<JSON
+        {
+          "schema-version": 1,
+          "kind": "wheel",
+          "ref": "${SANITIZED_REF}",
+          "build-type": "${{ inputs.build-type }}",
+          "build-image": "${{ inputs.build-image }}",
+          "tracy": ${TRACY},
+          "enable-lto": ${ENABLE_LTO},
+          "python-version": "${{ inputs.python-version }}",
+          "cfg-hash": "${CFGHASH}"
+        }
+        JSON
+          )
+
+          echo "name=$NAME" >> "$GITHUB_OUTPUT"
+          {
+            echo "manifest-json<<ARTIFACT_KEY_MANIFEST_EOF"
+            echo "$MANIFEST"
+            echo "ARTIFACT_KEY_MANIFEST_EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "Computed artifact key: $NAME"
+          exit 0
+        fi
+
+        TOOLCHAIN_CLEANED=$(echo "${{ inputs.toolchain }}" | sed -E 's/^cmake\///; s/-toolchain\.cmake$//')
+        DISTRIBUTED=$(norm_bool "${{ inputs.distributed }}")
         SKIP_TT_TRAIN=$(norm_bool "${{ inputs.skip-tt-train }}")
         BUILD_UMD_TESTS=$(norm_bool "${{ inputs.build-umd-tests }}")
         PROFILE=$(norm_bool "${{ inputs.profile }}")
@@ -120,7 +187,7 @@ runs:
         EOF
         )
 
-        if [ "${{ inputs.kind }}" = "ttnn-import" ]; then
+        if [ "$KIND" = "ttnn-import" ]; then
           CANONICAL="${CANONICAL}
         build-ttnn-import-artifact=${BUILD_TTNN_IMPORT_ARTIFACT}"
         fi
@@ -128,7 +195,7 @@ runs:
         CANONICAL_SORTED=$(echo "$CANONICAL" | sort)
         CFGHASH=$(printf '%s' "$CANONICAL_SORTED" | sha256sum | cut -c1-10)
 
-        case "${{ inputs.kind }}" in
+        case "$KIND" in
           packages)
             NAME="packages-${SHA12}-${CFGHASH}"
             ;;
@@ -140,7 +207,7 @@ runs:
             NAME="ttnn-import-${{ inputs.build-type }}-${SHA12}-${CFGHASH}"
             ;;
           *)
-            echo "::error::compute-artifact-key: unknown kind '${{ inputs.kind }}'"
+            echo "::error::compute-artifact-key: unknown kind '$KIND'"
             exit 1
             ;;
         esac

--- a/.github/actions/compute-artifact-key/action.yml
+++ b/.github/actions/compute-artifact-key/action.yml
@@ -1,0 +1,151 @@
+name: "Compute Artifact Key"
+description: >-
+  Computes a canonical, content-addressable name and a build-manifest.json for
+  a build-artifact.yaml output, given every build parameter that affects
+  compiled output. This is the single source of truth for artifact naming:
+  it is used at upload time (build-artifact.yaml) and will be used again at
+  reuse-lookup time (a follow-up PR) so the two computations can never drift
+  apart.
+
+  The legacy substring markers that existing consumers grep for are
+  preserved by construction: the `packages-` prefix (download-artifacts-from-run),
+  the `TTMetal_build_any` prefix and `_profiler_` substring when tracy is
+  enabled (download-artifacts-from-run and tests/scripts/download_artifacts.sh).
+  The trailing workflow run ID that made every prior name unique-per-run
+  (and therefore never reusable, even for byte-identical rebuilds) is
+  dropped and replaced with a short hash of every build-affecting parameter.
+
+inputs:
+  kind:
+    required: true
+    description: "Artifact kind: packages | build | ttnn-import"
+  ref:
+    required: true
+    description: "Resolved git ref/SHA the build was performed at (i.e. inputs.ref || github.sha), NOT a workflow run ID"
+  distro:
+    required: true
+  version:
+    required: true
+  architecture:
+    required: true
+  build-type:
+    required: true
+  toolchain:
+    required: true
+    description: "Raw toolchain path, e.g. cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake"
+  tracy:
+    required: true
+  distributed:
+    required: true
+  enable-lto:
+    required: true
+  skip-tt-train:
+    required: true
+  build-umd-tests:
+    required: true
+  profile:
+    required: true
+  build-ttnn-import-artifact:
+    required: false
+    default: "false"
+    description: "Only relevant for kind=ttnn-import; included in that kind's canonical key"
+
+outputs:
+  name:
+    description: "Canonical artifact name for this kind"
+    value: ${{ steps.compute.outputs.name }}
+  manifest-json:
+    description: >-
+      JSON manifest of every literal parameter value plus the computed
+      cfg-hash. Write this into the artifact alongside its payload; a reuse
+      consumer must validate it field-by-field before trusting a name-based
+      match -- the name/hash is a lookup optimization, this manifest is the
+      actual correctness guarantee.
+    value: ${{ steps.compute.outputs.manifest-json }}
+
+runs:
+  using: composite
+  steps:
+    - id: compute
+      shell: bash
+      run: |
+        set -eu
+
+        TOOLCHAIN_CLEANED=$(echo "${{ inputs.toolchain }}" | sed -E 's/^cmake\///; s/-toolchain\.cmake$//')
+        SANITIZED_REF=$(echo "${{ inputs.ref }}" | sed 's/[\/:"<>|*?\r\n\\]/-/g')
+        SHA12="${SANITIZED_REF:0:12}"
+
+        # Canonical, order-independent parameter tuple. Every field that
+        # affects compiled output must be listed here.
+        CANONICAL=$(cat <<EOF
+        ref=${SANITIZED_REF}
+        distro=${{ inputs.distro }}
+        version=${{ inputs.version }}
+        architecture=${{ inputs.architecture }}
+        build-type=${{ inputs.build-type }}
+        toolchain=${TOOLCHAIN_CLEANED}
+        tracy=${{ inputs.tracy }}
+        distributed=${{ inputs.distributed }}
+        enable-lto=${{ inputs.enable-lto }}
+        skip-tt-train=${{ inputs.skip-tt-train }}
+        build-umd-tests=${{ inputs.build-umd-tests }}
+        profile=${{ inputs.profile }}
+        EOF
+        )
+
+        if [ "${{ inputs.kind }}" = "ttnn-import" ]; then
+          CANONICAL="${CANONICAL}
+        build-ttnn-import-artifact=${{ inputs.build-ttnn-import-artifact }}"
+        fi
+
+        CANONICAL_SORTED=$(echo "$CANONICAL" | sort)
+        CFGHASH=$(printf '%s' "$CANONICAL_SORTED" | sha256sum | cut -c1-10)
+
+        case "${{ inputs.kind }}" in
+          packages)
+            NAME="packages-${SHA12}-${CFGHASH}"
+            ;;
+          build)
+            TRACY_SUFFIX="${{ (inputs.tracy == 'true' && '_profiler') || '' }}"
+            NAME="TTMetal_build_any${TRACY_SUFFIX}_${SHA12}_${CFGHASH}"
+            ;;
+          ttnn-import)
+            NAME="ttnn-import-${{ inputs.build-type }}-${SHA12}-${CFGHASH}"
+            ;;
+          *)
+            echo "::error::compute-artifact-key: unknown kind '${{ inputs.kind }}'"
+            exit 1
+            ;;
+        esac
+
+        echo "name=$NAME" >> "$GITHUB_OUTPUT"
+
+        MANIFEST=$(cat <<JSON
+        {
+          "schema-version": 1,
+          "kind": "${{ inputs.kind }}",
+          "ref": "${SANITIZED_REF}",
+          "distro": "${{ inputs.distro }}",
+          "version": "${{ inputs.version }}",
+          "architecture": "${{ inputs.architecture }}",
+          "build-type": "${{ inputs.build-type }}",
+          "toolchain": "${TOOLCHAIN_CLEANED}",
+          "tracy": ${{ inputs.tracy }},
+          "distributed": ${{ inputs.distributed }},
+          "enable-lto": ${{ inputs.enable-lto }},
+          "skip-tt-train": ${{ inputs.skip-tt-train }},
+          "build-umd-tests": ${{ inputs.build-umd-tests }},
+          "profile": ${{ inputs.profile }},
+          "build-ttnn-import-artifact": ${{ inputs.build-ttnn-import-artifact || false }},
+          "cfg-hash": "${CFGHASH}"
+        }
+        JSON
+        )
+
+        {
+          echo "manifest-json<<ARTIFACT_KEY_MANIFEST_EOF"
+          echo "$MANIFEST"
+          echo "ARTIFACT_KEY_MANIFEST_EOF"
+        } >> "$GITHUB_OUTPUT"
+
+        echo "Computed artifact key: $NAME"

--- a/.github/actions/compute-artifact-key/action.yml
+++ b/.github/actions/compute-artifact-key/action.yml
@@ -94,12 +94,42 @@ runs:
   steps:
     - id: compute
       shell: bash
+      env:
+        # Hardening: every caller-supplied value is passed through env vars
+        # and read back as quoted "$VAR" shell expansions below, never spliced
+        # into the script body via textual ${{ }} substitution. This action is
+        # the shared source of truth slated for reuse-lookup consumption in a
+        # follow-up PR, so its own input handling must not assume today's
+        # callers (all repo-controlled literals/matrix values/github.sha) are
+        # the only ones it will ever see.
+        INPUT_KIND: ${{ inputs.kind }}
+        INPUT_REF: ${{ inputs.ref }}
+        INPUT_BUILD_TYPE: ${{ inputs.build-type }}
+        INPUT_BUILD_IMAGE: ${{ inputs.build-image }}
+        INPUT_TRACY: ${{ inputs.tracy }}
+        INPUT_ENABLE_LTO: ${{ inputs.enable-lto }}
+        INPUT_DISTRO: ${{ inputs.distro }}
+        INPUT_VERSION: ${{ inputs.version }}
+        INPUT_ARCHITECTURE: ${{ inputs.architecture }}
+        INPUT_TOOLCHAIN: ${{ inputs.toolchain }}
+        INPUT_DISTRIBUTED: ${{ inputs.distributed }}
+        INPUT_SKIP_TT_TRAIN: ${{ inputs.skip-tt-train }}
+        INPUT_BUILD_UMD_TESTS: ${{ inputs.build-umd-tests }}
+        INPUT_PROFILE: ${{ inputs.profile }}
+        INPUT_BUILD_TTNN_IMPORT_ARTIFACT: ${{ inputs.build-ttnn-import-artifact }}
+        INPUT_PYTHON_VERSION: ${{ inputs.python-version }}
       run: |
         set -eu
 
-        SANITIZED_REF=$(echo "${{ inputs.ref }}" | sed 's/[\/:"<>|*?\r\n\\]/-/g')
+        SANITIZED_REF=$(echo "$INPUT_REF" | sed 's/[\/:"<>|*?\r\n\\]/-/g')
         SHA12="${SANITIZED_REF:0:12}"
-        KIND="${{ inputs.kind }}"
+        KIND="$INPUT_KIND"
+
+        # Random per-run delimiter: guards against a build-affecting input
+        # value that happens to contain the literal delimiter line, which
+        # could otherwise terminate the GITHUB_OUTPUT heredoc early and let
+        # forged key=value pairs after it be parsed as extra step outputs.
+        OUTPUT_DELIM="ARTIFACT_KEY_MANIFEST_EOF_${RANDOM}${RANDOM}_$$"
 
         # Defensive boolean normalization: some of these inputs are only
         # declared under this workflow's `workflow_call.inputs` and NOT under
@@ -111,22 +141,22 @@ runs:
         # field to a real "true"/"false" so the manifest is always valid
         # JSON and the hash is stable regardless of which trigger fired.
         norm_bool() { [ "$1" = "true" ] && echo "true" || echo "false"; }
-        TRACY=$(norm_bool "${{ inputs.tracy }}")
-        ENABLE_LTO=$(norm_bool "${{ inputs.enable-lto }}")
+        TRACY=$(norm_bool "$INPUT_TRACY")
+        ENABLE_LTO=$(norm_bool "$INPUT_ENABLE_LTO")
 
         if [ "$KIND" = "wheel" ]; then
           # wheels.yaml (cibuildwheel-based) has no distro/toolchain/distributed/
           # skip-tt-train/build-umd-tests/profile concept -- only the fields
           # that actually affect its compiled output go in the tuple/manifest.
-          PYVER_NODOT=$(echo "${{ inputs.python-version }}" | tr -d '.')
+          PYVER_NODOT=$(echo "$INPUT_PYTHON_VERSION" | tr -d '.')
 
           CANONICAL=$(cat <<EOF
         ref=${SANITIZED_REF}
-        build-type=${{ inputs.build-type }}
-        build-image=${{ inputs.build-image }}
+        build-type=${INPUT_BUILD_TYPE}
+        build-image=${INPUT_BUILD_IMAGE}
         tracy=${TRACY}
         enable-lto=${ENABLE_LTO}
-        python-version=${{ inputs.python-version }}
+        python-version=${INPUT_PYTHON_VERSION}
         EOF
           )
           CANONICAL_SORTED=$(echo "$CANONICAL" | sort)
@@ -141,11 +171,11 @@ runs:
           "schema-version": 1,
           "kind": "wheel",
           "ref": "${SANITIZED_REF}",
-          "build-type": "${{ inputs.build-type }}",
-          "build-image": "${{ inputs.build-image }}",
+          "build-type": "${INPUT_BUILD_TYPE}",
+          "build-image": "${INPUT_BUILD_IMAGE}",
           "tracy": ${TRACY},
           "enable-lto": ${ENABLE_LTO},
-          "python-version": "${{ inputs.python-version }}",
+          "python-version": "${INPUT_PYTHON_VERSION}",
           "cfg-hash": "${CFGHASH}"
         }
         JSON
@@ -153,31 +183,31 @@ runs:
 
           echo "name=$NAME" >> "$GITHUB_OUTPUT"
           {
-            echo "manifest-json<<ARTIFACT_KEY_MANIFEST_EOF"
+            echo "manifest-json<<${OUTPUT_DELIM}"
             echo "$MANIFEST"
-            echo "ARTIFACT_KEY_MANIFEST_EOF"
+            echo "${OUTPUT_DELIM}"
           } >> "$GITHUB_OUTPUT"
           echo "Computed artifact key: $NAME"
           exit 0
         fi
 
-        TOOLCHAIN_CLEANED=$(echo "${{ inputs.toolchain }}" | sed -E 's/^cmake\///; s/-toolchain\.cmake$//')
-        DISTRIBUTED=$(norm_bool "${{ inputs.distributed }}")
-        SKIP_TT_TRAIN=$(norm_bool "${{ inputs.skip-tt-train }}")
-        BUILD_UMD_TESTS=$(norm_bool "${{ inputs.build-umd-tests }}")
-        PROFILE=$(norm_bool "${{ inputs.profile }}")
-        BUILD_TTNN_IMPORT_ARTIFACT=$(norm_bool "${{ inputs.build-ttnn-import-artifact }}")
+        TOOLCHAIN_CLEANED=$(echo "$INPUT_TOOLCHAIN" | sed -E 's/^cmake\///; s/-toolchain\.cmake$//')
+        DISTRIBUTED=$(norm_bool "$INPUT_DISTRIBUTED")
+        SKIP_TT_TRAIN=$(norm_bool "$INPUT_SKIP_TT_TRAIN")
+        BUILD_UMD_TESTS=$(norm_bool "$INPUT_BUILD_UMD_TESTS")
+        PROFILE=$(norm_bool "$INPUT_PROFILE")
+        BUILD_TTNN_IMPORT_ARTIFACT=$(norm_bool "$INPUT_BUILD_TTNN_IMPORT_ARTIFACT")
 
         # Canonical, order-independent parameter tuple. Every field that
         # affects compiled output must be listed here.
         CANONICAL=$(cat <<EOF
         ref=${SANITIZED_REF}
-        distro=${{ inputs.distro }}
-        version=${{ inputs.version }}
-        architecture=${{ inputs.architecture }}
-        build-type=${{ inputs.build-type }}
+        distro=${INPUT_DISTRO}
+        version=${INPUT_VERSION}
+        architecture=${INPUT_ARCHITECTURE}
+        build-type=${INPUT_BUILD_TYPE}
         toolchain=${TOOLCHAIN_CLEANED}
-        build-image=${{ inputs.build-image }}
+        build-image=${INPUT_BUILD_IMAGE}
         tracy=${TRACY}
         distributed=${DISTRIBUTED}
         enable-lto=${ENABLE_LTO}
@@ -204,7 +234,7 @@ runs:
             NAME="TTMetal_build_any${TRACY_SUFFIX}_${SHA12}_${CFGHASH}"
             ;;
           ttnn-import)
-            NAME="ttnn-import-${{ inputs.build-type }}-${SHA12}-${CFGHASH}"
+            NAME="ttnn-import-${INPUT_BUILD_TYPE}-${SHA12}-${CFGHASH}"
             ;;
           *)
             echo "::error::compute-artifact-key: unknown kind '$KIND'"
@@ -217,14 +247,14 @@ runs:
         MANIFEST=$(cat <<JSON
         {
           "schema-version": 1,
-          "kind": "${{ inputs.kind }}",
+          "kind": "${INPUT_KIND}",
           "ref": "${SANITIZED_REF}",
-          "distro": "${{ inputs.distro }}",
-          "version": "${{ inputs.version }}",
-          "architecture": "${{ inputs.architecture }}",
-          "build-type": "${{ inputs.build-type }}",
+          "distro": "${INPUT_DISTRO}",
+          "version": "${INPUT_VERSION}",
+          "architecture": "${INPUT_ARCHITECTURE}",
+          "build-type": "${INPUT_BUILD_TYPE}",
           "toolchain": "${TOOLCHAIN_CLEANED}",
-          "build-image": "${{ inputs.build-image }}",
+          "build-image": "${INPUT_BUILD_IMAGE}",
           "tracy": ${TRACY},
           "distributed": ${DISTRIBUTED},
           "enable-lto": ${ENABLE_LTO},
@@ -238,9 +268,9 @@ runs:
         )
 
         {
-          echo "manifest-json<<ARTIFACT_KEY_MANIFEST_EOF"
+          echo "manifest-json<<${OUTPUT_DELIM}"
           echo "$MANIFEST"
-          echo "ARTIFACT_KEY_MANIFEST_EOF"
+          echo "${OUTPUT_DELIM}"
         } >> "$GITHUB_OUTPUT"
 
         echo "Computed artifact key: $NAME"

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -413,7 +413,7 @@ jobs:
     environment: ${{ github.ref == 'refs/heads/main' && 'mainline' || '' }}
     outputs:
       packages-artifact-name: ${{ steps.set-artifact-name.outputs.name }}
-      build_artifact_name: ${{ steps.set_build_artifact_name.outputs.build_artifact_name }}
+      build_artifact_name: ${{ steps.set_build_artifact_name.outputs.name }}
       ttnn_import_artifact_id: ${{ steps.upload_ttnn_import.outputs.artifact-id }}
     env:
       # Platform values from parse-platform job (handles both workflow_dispatch and workflow_call)
@@ -464,6 +464,16 @@ jobs:
         working-directory: /work # https://github.com/actions/runner/issues/878
 
     steps:
+      - name: ⬇️ Checkout actions
+        # Sparse-checkout just .github/actions so local composite actions (like
+        # compute-artifact-key below) resolve before the full checkout later in
+        # this job. Mirrors the same pattern used in parse-platform/download-artifacts.
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        timeout-minutes: 20
+        with:
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: true
+
       - name: Configure S3 ccache storage
         # Failing internal jobs draws attention immediately so we can fix them and make them fast.
         # Forks will never have secrets; don't fail the job for them, they'll just run slower
@@ -522,33 +532,21 @@ jobs:
 
       - name: Set artifact name
         id: set-artifact-name
-        run: |
-          TOOLCHAIN_CLEANED=$(echo "${{ env.TOOLCHAIN }}" | sed -E 's/^cmake\///; s/-toolchain\.cmake$//')
-          # Use full sanitized ref/SHA and workflow run ID to ensure uniqueness
-          # Sanitize ref/SHA by replacing invalid characters with hyphens
-          RAW_REF="${{ inputs.ref || github.sha }}"
-          SANITIZED_REF=$(echo "$RAW_REF" | sed 's/[\/:"<>|*?\r\n\\]/-/g')
-          TRACY_SUFFIX="${{ (inputs.tracy && '-profiler') || '' }}"
-          DIST_SUFFIX="${{ (inputs.distributed == false && '-no-distributed') || '' }}"
-          DISTRO="${{ env.DISTRO }}"
-          VERSION="${{ env.VERSION }}"
-          ARCH="${{ inputs.architecture }}"
-          BUILD_TYPE="${{ inputs.build-type }}"
-          RUN_ID="${{ github.run_id }}"
-          ARTIFACT_PARTS=(
-            "packages"
-            "${DISTRO}"
-            "${VERSION}"
-            "${ARCH}"
-            "${BUILD_TYPE}"
-            "${TOOLCHAIN_CLEANED}${TRACY_SUFFIX}${DIST_SUFFIX}"
-            "${SANITIZED_REF}"
-            "${RUN_ID}"
-          )
-          ARTIFACT_NAME=$(IFS='-'; echo "${ARTIFACT_PARTS[*]}")
-
-          echo "name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
-          echo "ARTIFACT_NAME=$ARTIFACT_NAME" >> "$GITHUB_ENV"
+        uses: ./.github/actions/compute-artifact-key
+        with:
+          kind: packages
+          ref: ${{ inputs.ref || github.sha }}
+          distro: ${{ env.DISTRO }}
+          version: ${{ env.VERSION }}
+          architecture: ${{ inputs.architecture }}
+          build-type: ${{ inputs.build-type }}
+          toolchain: ${{ env.TOOLCHAIN }}
+          tracy: ${{ inputs.tracy }}
+          distributed: ${{ inputs.distributed }}
+          enable-lto: ${{ inputs.enable-lto }}
+          skip-tt-train: ${{ inputs.skip-tt-train }}
+          build-umd-tests: ${{ inputs.build-umd-tests }}
+          profile: ${{ inputs.profile }}
 
       - name: ⬇️ Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -706,15 +704,23 @@ jobs:
             echo '```' >> $GITHUB_STEP_SUMMARY
           fi
 
+      - name: Write packages manifest
+        if: ${{ inputs.publish-package }}
+        run: |
+          cat > /work/build/build-manifest.json <<'MANIFEST_EOF'
+          ${{ steps.set-artifact-name.outputs.manifest-json }}
+          MANIFEST_EOF
+
       - name: ☁️ Upload packages
         if: ${{ inputs.publish-package }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         timeout-minutes: 10
         with:
-          name: ${{ env.ARTIFACT_NAME }}
+          name: ${{ steps.set-artifact-name.outputs.name }}
           path: |
             /work/build/*.deb
             /work/build/*.ddeb
+            /work/build/build-manifest.json
           compression-level: 0
           if-no-files-found: error
 
@@ -729,13 +735,40 @@ jobs:
           cp -a /work/runtime /work/ttnn-import/runtime
           echo "Lean ttnn-import tree size:"; du -sh /work/ttnn-import /work/ttnn-import/build/lib
 
+      - name: Set ttnn-import artifact name
+        id: set-ttnn-import-artifact-name
+        if: ${{ inputs.build-ttnn-import-artifact }}
+        uses: ./.github/actions/compute-artifact-key
+        with:
+          kind: ttnn-import
+          ref: ${{ inputs.ref || github.sha }}
+          distro: ${{ env.DISTRO }}
+          version: ${{ env.VERSION }}
+          architecture: ${{ inputs.architecture }}
+          build-type: ${{ inputs.build-type }}
+          toolchain: ${{ env.TOOLCHAIN }}
+          tracy: ${{ inputs.tracy }}
+          distributed: ${{ inputs.distributed }}
+          enable-lto: ${{ inputs.enable-lto }}
+          skip-tt-train: ${{ inputs.skip-tt-train }}
+          build-umd-tests: ${{ inputs.build-umd-tests }}
+          profile: ${{ inputs.profile }}
+          build-ttnn-import-artifact: ${{ inputs.build-ttnn-import-artifact }}
+
+      - name: Write ttnn-import manifest
+        if: ${{ inputs.build-ttnn-import-artifact }}
+        run: |
+          cat > /work/ttnn-import/build-manifest.json <<'MANIFEST_EOF'
+          ${{ steps.set-ttnn-import-artifact-name.outputs.manifest-json }}
+          MANIFEST_EOF
+
       - name: ☁️ Upload ttnn-import artifact
         id: upload_ttnn_import
         if: ${{ inputs.build-ttnn-import-artifact }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         timeout-minutes: 10
         with:
-          name: ttnn-import-${{ inputs.build-type }}
+          name: ${{ steps.set-ttnn-import-artifact-name.outputs.name }}
           path: /work/ttnn-import
           compression-level: 1
           if-no-files-found: error
@@ -755,37 +788,38 @@ jobs:
 
       - name: Set build artifact name
         id: set_build_artifact_name
+        uses: ./.github/actions/compute-artifact-key
+        with:
+          kind: build
+          ref: ${{ inputs.ref || github.sha }}
+          distro: ${{ env.DISTRO }}
+          version: ${{ env.VERSION }}
+          architecture: ${{ inputs.architecture }}
+          build-type: ${{ inputs.build-type || 'Release' }}
+          toolchain: ${{ env.TOOLCHAIN }}
+          tracy: ${{ inputs.tracy }}
+          distributed: ${{ inputs.distributed }}
+          enable-lto: ${{ inputs.enable-lto }}
+          skip-tt-train: ${{ inputs.skip-tt-train }}
+          build-umd-tests: ${{ inputs.build-umd-tests }}
+          profile: ${{ inputs.profile }}
+
+      - name: Write build manifest
+        if: ${{ inputs.publish-artifact }}
         run: |
-          TOOLCHAIN_CLEANED=$(echo "${{ env.TOOLCHAIN }}" | sed -E 's/^cmake\///; s/-toolchain\.cmake$//')
-          # Use full sanitized ref/SHA and workflow run ID to ensure uniqueness
-          # Sanitize ref/SHA by replacing invalid characters with hyphens
-          RAW_REF="${{ inputs.ref || github.sha }}"
-          SANITIZED_REF=$(echo "$RAW_REF" | sed 's/[\/:"<>|*?\r\n\\]/-/g')
-          TRACY_SUFFIX="${{ (inputs.tracy && '_profiler') || '' }}"
-          DIST_SUFFIX="${{ (inputs.distributed == false && '_no_distributed') || '' }}"
-          BUILD_TYPE="${{ inputs.build-type || 'Release' }}"
-          VERSION="${{ env.VERSION }}"
-          ARCH="${{ inputs.architecture }}"
-          RUN_ID="${{ github.run_id }}"
-          BUILD_ARTIFACT_PARTS=(
-            "TTMetal_build_any"
-            "${VERSION}"
-            "${ARCH}"
-            "${TOOLCHAIN_CLEANED}${TRACY_SUFFIX}${DIST_SUFFIX}_${BUILD_TYPE}"
-            "${SANITIZED_REF}"
-            "${RUN_ID}"
-          )
-          BUILD_ARTIFACT_NAME=$(IFS='_'; echo "${BUILD_ARTIFACT_PARTS[*]}")
-          echo "build_artifact_name=$BUILD_ARTIFACT_NAME" >> "$GITHUB_ENV"
-          echo "build_artifact_name=$BUILD_ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
+          cat > /work/ttm_any.manifest.json <<'MANIFEST_EOF'
+          ${{ steps.set_build_artifact_name.outputs.manifest-json }}
+          MANIFEST_EOF
 
       - name: ☁️ Upload tarball
         if: ${{ inputs.publish-artifact }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         timeout-minutes: 10
         with:
-          name: ${{ env.build_artifact_name }}
-          path: /work/ttm_any.tar.zst
+          name: ${{ steps.set_build_artifact_name.outputs.name }}
+          path: |
+            /work/ttm_any.tar.zst
+            /work/ttm_any.manifest.json
           if-no-files-found: error
           compression-level: 0
 

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -420,6 +420,21 @@ jobs:
       DISTRO: ${{ needs.parse-platform.outputs.distro }}
       VERSION: ${{ needs.parse-platform.outputs.version }}
       TOOLCHAIN: ${{ inputs.toolchain || needs.parse-platform.outputs.toolchain }}
+      # The exact image the container below actually compiles inside. It's the compiler/
+      # runtime environment -- affects compiled output just as much as toolchain/build-type
+      # do -- so it belongs in the canonical key and manifest too (see compute-artifact-key
+      # calls below). NOTE: this expression is intentionally IDENTICAL to container.image
+      # below, duplicated rather than factored into one place, because the `env` context is
+      # documented as available in `jobs.<job_id>.container` but is not actually honored
+      # there in practice (github/docs#25520) -- referencing env.BUILD_IMAGE from
+      # container.image fails workflow validation. Keep both expressions in sync by hand.
+      BUILD_IMAGE: >-
+        ${{
+          (inputs.ci-build-docker-image != '' &&
+            format('{0}{1}', inputs.harbor-prefix, inputs.ci-build-docker-image)) ||
+          format('{0}{1}', inputs.harbor-prefix,
+            needs.build-docker-image.outputs.ci-build-tag || 'docker-image-unresolved!')
+        }}
       CCACHE_S3_BUCKET: ccache
       CCACHE_S3_PREFIX: tt-metal
       CCACHE_S3_READONLY: "false"
@@ -541,6 +556,7 @@ jobs:
           architecture: ${{ inputs.architecture }}
           build-type: ${{ inputs.build-type }}
           toolchain: ${{ env.TOOLCHAIN }}
+          build-image: ${{ env.BUILD_IMAGE }}
           tracy: ${{ inputs.tracy }}
           distributed: ${{ inputs.distributed }}
           enable-lto: ${{ inputs.enable-lto }}
@@ -747,6 +763,7 @@ jobs:
           architecture: ${{ inputs.architecture }}
           build-type: ${{ inputs.build-type }}
           toolchain: ${{ env.TOOLCHAIN }}
+          build-image: ${{ env.BUILD_IMAGE }}
           tracy: ${{ inputs.tracy }}
           distributed: ${{ inputs.distributed }}
           enable-lto: ${{ inputs.enable-lto }}
@@ -797,6 +814,7 @@ jobs:
           architecture: ${{ inputs.architecture }}
           build-type: ${{ inputs.build-type || 'Release' }}
           toolchain: ${{ env.TOOLCHAIN }}
+          build-image: ${{ env.BUILD_IMAGE }}
           tracy: ${{ inputs.tracy }}
           distributed: ${{ inputs.distributed }}
           enable-lto: ${{ inputs.enable-lto }}

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -807,7 +807,7 @@ jobs:
       - name: Write build manifest
         if: ${{ inputs.publish-artifact }}
         run: |
-          cat > /work/ttm_any.manifest.json <<'MANIFEST_EOF'
+          cat > /work/build-manifest.json <<'MANIFEST_EOF'
           ${{ steps.set_build_artifact_name.outputs.manifest-json }}
           MANIFEST_EOF
 
@@ -819,7 +819,7 @@ jobs:
           name: ${{ steps.set_build_artifact_name.outputs.name }}
           path: |
             /work/ttm_any.tar.zst
-            /work/ttm_any.manifest.json
+            /work/build-manifest.json
           if-no-files-found: error
           compression-level: 0
 

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     environment: ${{ github.ref == 'refs/heads/main' && 'mainline' || '' }}
     outputs:
-      artifact_name: ${{ steps.set_artifact_name.outputs.artifact_name }}
+      artifact_name: ${{ steps.set_artifact_name.outputs.name }}
     env:
       # S3 ccache config — lift to repo vars/secrets when ready
       CCACHE_S3_BUCKET: ccache
@@ -212,20 +212,26 @@ jobs:
 
       - name: Set wheel artifact name
         id: set_artifact_name
+        uses: ./.github/actions/compute-artifact-key
+        with:
+          kind: wheel
+          ref: ${{ inputs.ref || github.sha }}
+          build-type: ${{ inputs.build-type }}
+          build-image: ${{ inputs.docker-image }}
+          tracy: ${{ inputs.tracy }}
+          enable-lto: ${{ inputs.enable-lto }}
+          python-version: ${{ inputs.python-version }}
+
+      - name: Write wheel manifest
         run: |
-          # Use full sanitized ref/SHA and workflow run ID to ensure uniqueness across parallel builds
-          # Sanitize ref/SHA by replacing invalid characters with hyphens
-          RAW_REF="${{ inputs.ref || github.sha }}"
-          SANITIZED_REF=$(echo "$RAW_REF" | sed 's/[\/:"<>|*?\r\n\\]/-/g')
-          TRACY_SUFFIX="${{ (inputs.tracy && '-profiler') || '' }}"
-          ARTIFACT_NAME="ttnn-dist-cp${{ steps.format_python_version.outputs.python_version_nodot }}-${{ inputs.build-type }}${TRACY_SUFFIX}-${SANITIZED_REF}-${{ github.run_id }}"
-          echo "artifact_name=${ARTIFACT_NAME}" >> $GITHUB_OUTPUT
-          echo "artifact_name=${ARTIFACT_NAME}" >> "$GITHUB_ENV"
+          cat > wheelhouse/build-manifest.json <<'MANIFEST_EOF'
+          ${{ steps.set_artifact_name.outputs.manifest-json }}
+          MANIFEST_EOF
 
       - name: ☁️ Upload wheel
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         timeout-minutes: 10
         with:
-          name: ${{ steps.set_artifact_name.outputs.artifact_name }}
+          name: ${{ steps.set_artifact_name.outputs.name }}
           path: wheelhouse
           if-no-files-found: error


### PR DESCRIPTION
## PR1 of 3 — artifact reuse redesign for `build-artifact.yaml`

Context: `use-artifacts-from-run` requires the caller to already know a specific prior run ID, and the matching logic in `download-artifacts-from-run` only validates the `tracy` flag via a substring grep — every other build parameter (toolchain, LTO, distro/version, arch, build-type, distributed, skip-tt-train, build-umd-tests, profile) is ignored. Full design writeup (mechanism verified live against this repo's Artifacts API) available on request.

This is PR1 of an incremental sequence: **canonical naming + embedded manifest, no behavior change.** No `enable-artifact-reuse` gate yet — that's PR3, after the lookup action (PR2) lands separately for isolated review.

### What changed

- New composite action `.github/actions/compute-artifact-key`, used by **all four** artifact kinds this workflow family produces — `build-artifact.yaml`'s packages/tarball/ttnn-import outputs, and `wheels.yaml`'s wheel output (wheel was originally flagged as an out-of-scope follow-up but turned out to have the identical gaps, so it's in scope now):
  - a canonical **name** — `github.run_id` is dropped (that's why two byte-identical builds never produced the same name before) and replaced with a short hash of the full parameter tuple, keyed off the resolved git ref instead of the run.
  - a **`build-manifest.json`** with every literal parameter value + the computed hash, written into every uploaded artifact. Not consumed by anything yet — it's the mechanism a future reuse-lookup step (PR2/PR3) will validate field-by-field before trusting a name/hash match. The name is a lookup optimization; the manifest is the actual correctness guarantee against a collision or naming bug.
  - the **resolved build container image** (the exact docker image the build compiles inside — `ci-build-docker-image` for build-artifact.yaml, the manylinux image for wheels.yaml) is part of the canonical key + manifest for every kind. It affects compiled output as much as toolchain/build-type does, so it's captured from day one rather than deferred.
- `build-artifact.yaml`'s three naming steps and `wheels.yaml`'s one now call this shared action instead of duplicating naming logic inline.

### Real bugs found via live CI testing, not just review

- **Boolean-input bug:** `skip-tt-train`/`build-ttnn-import-artifact` are declared only under this workflow's `workflow_call` inputs, not `workflow_dispatch` — so on a dispatch-triggered run they resolve to an empty string, which was embedded as a bare unquoted JSON literal, producing invalid `build-manifest.json`. Caught by an actual `workflow_dispatch` smoke-test run (not by inspection), fixed with a `norm_bool()` coercion applied to every boolean-ish field.
- **Manifest filename inconsistency:** the tarball wrote `ttm_any.manifest.json` while packages/ttnn-import used the documented `build-manifest.json`. Caught by Copilot review, confirmed against the actual code, fixed.

### Independent adversarial security review

Ran the finished implementation through a 3-reviewer (security / correctness / acceptance) adversarial debate-consensus process — each reviewer blind to the others' votes.

- **Round 0:** security objected — every caller-supplied string input in `compute-artifact-key` was spliced directly into its bash script via textual `${{ }}` substitution, including inside unquoted heredocs. Not fork-exploitable by any real caller today (every input traces back to repo-controlled literals, matrix values, or `github.sha`), but flagged because this action is explicitly the shared source of truth slated for expansion in PR2/PR3 — an unhardened injection surface now is a latent risk for whatever calls it next. Correctness and acceptance both approved.
- **Fix:** every `${{ inputs.* }}` reference used inside the script now flows through a step-level `env:` mapping, read back as a quoted `"$VAR"` shell variable instead of textual substitution. The `GITHUB_OUTPUT` heredoc delimiter is now randomized per-invocation (closes a related, lower-likelihood delimiter-spoofing finding).
- **Verification:** an adversarial local test injecting a `$(touch /tmp/PWNED)`/backtick payload into an input value confirms it's now inert literal data — no command executes, the manifest correctly records the literal text. Re-verified against a live CI run.
- **Round 1:** all three reviewers re-voted against the new diff (not just trusting the "fixed" claim) — unanimous approval.

### Backward compatibility (verified, not assumed)

The only places that structurally parse today's artifact names are `.github/actions/download-artifacts-from-run/action.yml` and `tests/scripts/download_artifacts.sh`. Both are checked against the literal new names:
- `packages-` prefix (packages) — preserved
- `TTMetal_build_any` prefix + `_profiler_` substring when tracy is enabled (tarball) — preserved, verified for both tracy=true and tracy=false
- `ttnn-dist`/`ttnn` substring (wheel) — preserved

`ttnn-import` is consumed purely by artifact **id** in every caller found (`pr-gate.yaml`, `docs-latest-public.yaml`) — never by name — so it gained real disambiguation (previously just `ttnn-import-${build-type}`, zero collision protection).

Every other current consumer of the job-level outputs (~125 references across the repo) treats the name as an opaque string; verified zero dangling references to the internal step-output keys this PR renamed.

### Verified against real CI, not just locally

All four kinds — packages, tarball, ttnn-import, wheel — were actually built via live GitHub Actions runs (both direct-GHCR and Harbor-pull-through-prefix docker paths), downloaded, and their `build-manifest.json` inspected directly for valid JSON and correct field values, across 8+ separate workflow runs spanning every commit in this PR.

### Not in this PR (explicit follow-ups for PR2/PR3)

- The actual reuse-lookup composite action (queries the Artifacts API by name, downloads, validates the manifest) — PR2.
- The `enable-artifact-reuse` boolean gate wired into `build-artifact.yaml`, plus the `actions: read` permission it needs — PR3.
- The legacy `download-artifacts-from-run` / `use-artifacts-from-run` manual reuse path doesn't preserve `build-manifest.json` when downloading from a prior run (it has zero callers today, so this is dormant, not live). Fix alongside whichever PR first makes the manifest load-bearing.
- `ref` isn't resolved to an immutable commit SHA before hashing — harmless today since every real caller passes `github.sha` or an explicit SHA per the input's own "Commit SHA" documentation, but the eventual reuse-lookup should resolve-then-hash defensively rather than trust a caller-supplied ref string.
- The manifest JSON is still built via string interpolation rather than a proper serializer (`jq -n --arg`) — fail-safe today since the only free-form field (`ref`) is already sanitized against JSON-breaking characters, but worth doing properly whenever PR2 touches this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci/build-artifact-canonical-key-manifest)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci/build-artifact-canonical-key-manifest)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci/build-artifact-canonical-key-manifest)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci/build-artifact-canonical-key-manifest)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ci/build-artifact-canonical-key-manifest)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ci/build-artifact-canonical-key-manifest)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci/build-artifact-canonical-key-manifest)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci/build-artifact-canonical-key-manifest)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci/build-artifact-canonical-key-manifest)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci/build-artifact-canonical-key-manifest)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci/build-artifact-canonical-key-manifest)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci/build-artifact-canonical-key-manifest)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci/build-artifact-canonical-key-manifest)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci/build-artifact-canonical-key-manifest)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci/build-artifact-canonical-key-manifest)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci/build-artifact-canonical-key-manifest)
