### PR TITLE
[feature] Add to_tensor_spec to HostTensor facility

### DIFF
--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -96,6 +96,7 @@ set(UNIT_TESTS_API_TENSOR_SOURCES
     tensor/test_host_tensor_to_layout.cpp
     tensor/test_host_tensor_to_dtype.cpp
     tensor/test_host_tensor_spec_preservation.cpp
+    tensor/test_host_tensor_to_tensor_spec.cpp
     tensor/test_mesh_tensor.cpp
     tensor/test_tensor_types.cpp
     tensor/test_tensor_layout.cpp

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_tensor_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_tensor_spec.cpp
@@ -4,12 +4,14 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
-#include <cmath>
 #include <cstdint>
 #include <limits>
+#include <utility>
 #include <vector>
 
 #include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/bfloat4.hpp>
+#include <tt-metalium/bfloat8.hpp>
 #include <tt-metalium/experimental/tensor/host_tensor.hpp>
 #include <tt-metalium/experimental/tensor/tensor_apis.hpp>
 #include <tt-metalium/experimental/tensor/spec/tensor_spec.hpp>
@@ -24,7 +26,9 @@
 
 namespace tt::tt_metal {
 namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
 
+// Deterministic ramp for test data
 template <typename T>
 std::vector<T> make_ramp(size_t count) {
     std::vector<T> data(count);
@@ -34,9 +38,73 @@ std::vector<T> make_ramp(size_t count) {
     return data;
 }
 
+std::vector<float> make_bfp_data(const Shape& shape, const Tile& tile) {
+    // Boundary-sensitive to faces: cycles face indices and steps magnitudes for BFP checks.
+    const size_t count = shape.volume();
+    const size_t face_width = tile.get_face_shape()[1];
+    std::vector<float> data(count);
+    size_t i = 0;
+    for (size_t face_row = 0; i < count; ++face_row) {
+        for (size_t face_index = 0; face_index < face_width && i < count; ++face_index) {
+            data[i++] = static_cast<float>(face_index) + static_cast<float>(face_row) * 0.5f;
+        }
+    }
+    return data;
+}
+
+using PackedBfp = std::vector<uint32_t>;
+using UnpackedBfp = std::vector<float>;
+
+// BFP -> float golden: packed bytes plus their reference unpack (not the pre-quant floats).
+std::pair<PackedBfp, UnpackedBfp> generate_bfp8_dataset(const Shape& shape, const Tile& tile) {
+    const auto src = make_bfp_data(shape, tile);
+    auto packed = pack_as_bfp8_tiles(ttsl::make_const_span(src), /*row_major_input=*/true, /*is_exp_a=*/false, tile);
+    auto unpacked = unpack_bfp8_tiles_into_float_vec(packed, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
+    return {std::move(packed), std::move(unpacked)};
+}
+
+std::pair<PackedBfp, UnpackedBfp> generate_bfp4_dataset(const Shape& shape, const Tile& tile) {
+    const auto src = make_bfp_data(shape, tile);
+    auto packed = pack_as_bfp4_tiles(ttsl::make_const_span(src), /*row_major_input=*/true, /*is_exp_a=*/false, tile);
+    auto unpacked = unpack_bfp4_tiles_into_float_vec(packed, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
+    return {std::move(packed), std::move(unpacked)};
+}
+
+// Float(TILE) -> BFP golden: tile-layout floats plus their reference pack.
+std::pair<UnpackedBfp, PackedBfp> generate_float_to_bfp8_dataset(const Shape& shape, const Tile& tile) {
+    auto floats = make_bfp_data(shape, tile);
+    auto packed =
+        pack_as_bfp8_tiles(ttsl::make_const_span(floats), /*row_major_input=*/false, /*is_exp_a=*/false, tile);
+    return {std::move(floats), std::move(packed)};
+}
+
+std::pair<UnpackedBfp, PackedBfp> generate_float_to_bfp4_dataset(const Shape& shape, const Tile& tile) {
+    auto floats = make_bfp_data(shape, tile);
+    auto packed =
+        pack_as_bfp4_tiles(ttsl::make_const_span(floats), /*row_major_input=*/false, /*is_exp_a=*/false, tile);
+    return {std::move(floats), std::move(packed)};
+}
+
+template <typename T>
+HostTensor make_host_tensor(std::vector<T> data, const TensorSpec& spec) {
+    auto dist_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 1));
+    dist_buffer.emplace_shard(
+        distributed::MeshCoordinate(0, 0), [data = std::move(data)]() mutable { return HostBuffer(std::move(data)); });
+    return HostTensor::from_buffer(std::move(dist_buffer), spec, TensorTopology{});
+}
+
 bool exact_spec_match(const TensorSpec& a, const TensorSpec& b) {
     return a == b && experimental::per_core_allocation::is_per_core_allocation(a.memory_config()) ==
                          experimental::per_core_allocation::is_per_core_allocation(b.memory_config());
+}
+
+void expect_packed_sizes(const HostTensor& tensor) {
+    const size_t expected = tensor.tensor_spec().compute_packed_buffer_size_bytes();
+    for (const auto& coord : tensor.buffer().shard_coords()) {
+        auto shard = tensor.buffer().get_shard(coord);
+        ASSERT_TRUE(shard.has_value());
+        EXPECT_EQ(shard->view_bytes().size(), expected);
+    }
 }
 
 TensorSpec make_rm_spec(const Shape& shape, DataType dtype, const MemoryConfig& memory_config = MemoryConfig{}) {
@@ -47,24 +115,39 @@ TensorSpec make_tile_spec(
     const Shape& shape,
     DataType dtype,
     const Tile& tile = Tile({32, 32}),
-    const MemoryConfig& memory_config = MemoryConfig{}) {
-    return TensorSpec(shape, TensorLayout(dtype, PageConfig(Layout::TILE, tile), memory_config));
+    const MemoryConfig& memory_config = MemoryConfig{},
+    const Alignment& alignment = {}) {
+    return TensorSpec(shape, TensorLayout(dtype, PageConfig(Layout::TILE, tile), memory_config, alignment));
 }
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+
+using ::testing::Eq;
+using ::testing::Pointwise;
 
 TEST(HostTensorToTensorSpec, EarlyOutExactSpecMatch) {
     const Shape shape{32, 32};
-    auto data = make_ramp<float>(shape.volume());
-    auto spec = make_tile_spec(shape, DataType::FLOAT32);
-    auto source = HostTensor::from_vector(data, spec);
+    auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto alignment = Alignment({32, 32});
+    auto tile = Tile({16, 16});
+    auto spec =
+        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto source = HostTensor::from_vector<float>(data, spec);
 
     auto result = to_tensor_spec<float>(source, spec);
-    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), spec));
-    EXPECT_EQ(result.to_vector<float>(), data);
+
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), spec));
+    EXPECT_EQ(result.dtype(), DataType::FLOAT32);
+    EXPECT_EQ(result.layout(), Layout::TILE);
+    EXPECT_EQ(result.tensor_spec().tile(), tile);
+    EXPECT_THAT(result.to_vector<float>(), Pointwise(Eq(), data));
+    CMAKE_UNIQUE_NAMESPACE::expect_packed_sizes(result);
 }
 
 TEST(HostTensorToTensorSpec, PerCoreOnlyMismatchFullRewrite) {
     const Shape shape{20, 20};
-    auto data = make_ramp<float>(shape.volume());
+    auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
 
     auto memory_config = MemoryConfig{
         TensorMemoryLayout::HEIGHT_SHARDED,
@@ -73,7 +156,7 @@ TEST(HostTensorToTensorSpec, PerCoreOnlyMismatchFullRewrite) {
 
     auto src_spec = TensorSpec(
         shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, Alignment({32, 32})));
-    auto source = HostTensor::from_vector(data, src_spec, /*pad_value=*/99.f);
+    auto source = HostTensor::from_vector<float>(data, src_spec, /*pad_value=*/99.f);
     EXPECT_FALSE(experimental::per_core_allocation::is_per_core_allocation(source.tensor_spec().memory_config()));
 
     auto dest_memory = memory_config;
@@ -83,53 +166,63 @@ TEST(HostTensorToTensorSpec, PerCoreOnlyMismatchFullRewrite) {
 
     // Spec equality ignores per_core, but exact-spec predicate must not early-out.
     EXPECT_TRUE(source.tensor_spec() == dest_spec);
-    EXPECT_FALSE(exact_spec_match(source.tensor_spec(), dest_spec));
+    EXPECT_FALSE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(source.tensor_spec(), dest_spec));
 
     auto result = to_tensor_spec<float>(source, dest_spec, /*pad_value=*/77.f);
-    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), dest_spec));
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), dest_spec));
     EXPECT_TRUE(experimental::per_core_allocation::is_per_core_allocation(result.tensor_spec().memory_config()));
-    EXPECT_EQ(result.to_vector<float>(), data);
+    EXPECT_THAT(result.to_vector<float>(), Pointwise(Eq(), data));
+    CMAKE_UNIQUE_NAMESPACE::expect_packed_sizes(result);
 
     auto result_physical = host_buffer::get_as<float>(result);
-    // RM layout, shape 20x20, physical 32x32.
-    // Index (31, 31) is 31 * 32 + 31.
+    // RM layout, shape 20x20, physical 32x32. Index (31, 31) is 31 * 32 + 31.
     EXPECT_EQ(result_physical[31 * 32 + 31], 77.f);
 }
 
 TEST(HostTensorToTensorSpec, LogicalRoundTripRmTileRm) {
     const Shape shape{20, 20};
-    auto data = make_ramp<float>(shape.volume());
-    auto rm_spec = make_rm_spec(shape, DataType::FLOAT32);
-    auto tile_spec = make_tile_spec(shape, DataType::FLOAT32, Tile({16, 16}));
+    auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto tile = Tile({16, 16});
+    auto rm_spec = CMAKE_UNIQUE_NAMESPACE::make_rm_spec(shape, DataType::FLOAT32, memory_config);
+    auto tile_spec = CMAKE_UNIQUE_NAMESPACE::make_tile_spec(shape, DataType::FLOAT32, tile, memory_config);
 
-    auto source = HostTensor::from_vector(data, rm_spec);
+    auto source = HostTensor::from_vector<float>(data, rm_spec);
     auto tiled = to_tensor_spec<float>(source, tile_spec, /*pad_value=*/0.f);
-    EXPECT_TRUE(exact_spec_match(tiled.tensor_spec(), tile_spec));
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(tiled.tensor_spec(), tile_spec));
+    EXPECT_EQ(tiled.layout(), Layout::TILE);
+    EXPECT_EQ(tiled.tensor_spec().tile(), tile);
+    CMAKE_UNIQUE_NAMESPACE::expect_packed_sizes(tiled);
 
     auto back = to_tensor_spec<float>(tiled, rm_spec);
-    EXPECT_TRUE(exact_spec_match(back.tensor_spec(), rm_spec));
-    EXPECT_EQ(back.to_vector<float>(), data);
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(back.tensor_spec(), rm_spec));
+    EXPECT_EQ(back.layout(), Layout::ROW_MAJOR);
+    EXPECT_THAT(back.to_vector<float>(), Pointwise(Eq(), data));
+    CMAKE_UNIQUE_NAMESPACE::expect_packed_sizes(back);
 }
 
 TEST(HostTensorToTensorSpec, RmToTileAndTileToRm) {
     const Shape shape{32, 32};
-    auto data = make_ramp<uint16_t>(shape.volume());
-    auto rm_spec = make_rm_spec(shape, DataType::UINT16);
-    auto tile_spec = make_tile_spec(shape, DataType::UINT16);
+    auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<uint16_t>(shape.volume());
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto rm_spec = CMAKE_UNIQUE_NAMESPACE::make_rm_spec(shape, DataType::UINT16, memory_config);
+    auto tile_spec = CMAKE_UNIQUE_NAMESPACE::make_tile_spec(shape, DataType::UINT16, Tile({32, 32}), memory_config);
 
-    auto source = HostTensor::from_vector(data, rm_spec);
+    auto source = HostTensor::from_vector<uint16_t>(data, rm_spec);
     auto tiled = to_tensor_spec<uint16_t>(source, tile_spec);
-    EXPECT_TRUE(exact_spec_match(tiled.tensor_spec(), tile_spec));
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(tiled.tensor_spec(), tile_spec));
     EXPECT_EQ(tiled.layout(), Layout::TILE);
+    EXPECT_EQ(tiled.dtype(), DataType::UINT16);
+    CMAKE_UNIQUE_NAMESPACE::expect_packed_sizes(tiled);
 
     auto back = to_tensor_spec<uint16_t>(tiled, rm_spec);
-    EXPECT_TRUE(exact_spec_match(back.tensor_spec(), rm_spec));
-    EXPECT_EQ(back.to_vector<uint16_t>(), data);
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(back.tensor_spec(), rm_spec));
+    EXPECT_THAT(back.to_vector<uint16_t>(), Pointwise(Eq(), data));
 }
 
 TEST(HostTensorToTensorSpec, CustomTileAndAlignment) {
     const Shape shape{32, 32};
-    auto data = make_ramp<float>(shape.volume());
+    auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
     auto tile = Tile({16, 16});
     auto alignment = Alignment({16, 16});
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
@@ -138,23 +231,38 @@ TEST(HostTensorToTensorSpec, CustomTileAndAlignment) {
     auto dest_spec =
         TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
 
-    auto source = HostTensor::from_vector(data, src_spec);
+    auto source = HostTensor::from_vector<float>(data, src_spec);
     auto result = to_tensor_spec<float>(source, dest_spec);
-    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), dest_spec));
+
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), dest_spec));
+    EXPECT_EQ(result.dtype(), DataType::FLOAT32);
+    EXPECT_EQ(result.layout(), Layout::TILE);
     EXPECT_EQ(result.tensor_spec().tile(), tile);
     EXPECT_EQ(result.tensor_spec().tensor_layout().get_alignment(), dest_spec.tensor_layout().get_alignment());
-    EXPECT_EQ(result.to_vector<float>(), data);
+    EXPECT_THAT(result.to_vector<float>(), Pointwise(Eq(), data));
+    CMAKE_UNIQUE_NAMESPACE::expect_packed_sizes(result);
 }
 
-TEST(HostTensorToTensorSpec, CrossDtypeFloat32ToBfloat16) {
+TEST(HostTensorToTensorSpec, Float32ToBfloat16PreservesMetadata) {
     const Shape shape{32, 32};
-    auto data = make_ramp<float>(shape.volume());
-    auto src_spec = make_tile_spec(shape, DataType::FLOAT32);
-    auto dest_spec = make_tile_spec(shape, DataType::BFLOAT16);
+    auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto alignment = Alignment({32, 32});
+    auto tile = Tile({16, 16});
 
-    auto source = HostTensor::from_vector(data, src_spec);
+    auto src_spec =
+        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto dest_spec =
+        TensorSpec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto source = HostTensor::from_vector<float>(data, src_spec);
+
     auto result = to_tensor_spec<float>(source, dest_spec);
-    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), dest_spec));
+
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), dest_spec));
+    EXPECT_EQ(result.dtype(), DataType::BFLOAT16);
+    EXPECT_EQ(result.layout(), Layout::TILE);
+    EXPECT_EQ(result.tensor_spec().tile(), tile);
+    CMAKE_UNIQUE_NAMESPACE::expect_packed_sizes(result);
 
     auto result_data = result.to_vector<bfloat16>();
     ASSERT_EQ(result_data.size(), data.size());
@@ -163,237 +271,189 @@ TEST(HostTensorToTensorSpec, CrossDtypeFloat32ToBfloat16) {
     }
 }
 
+TEST(HostTensorToTensorSpec, Float32ToBfloat16RowMajorShardedValueCheck) {
+    const Shape shape{32, 64};
+    auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
+    auto memory_config = MemoryConfig{
+        TensorMemoryLayout::HEIGHT_SHARDED,
+        BufferType::L1,
+        ShardSpec{CoreRangeSet({CoreRange({0, 0}, {0, 1})}), {16, 64}, ShardOrientation::ROW_MAJOR}};
+    experimental::per_core_allocation::set_per_core_allocation(memory_config, true);
+
+    auto src_spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
+    auto dest_spec = TensorSpec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config));
+    auto source = HostTensor::from_vector<float>(data, src_spec);
+
+    auto result = to_tensor_spec<float>(source, dest_spec);
+
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), dest_spec));
+    EXPECT_EQ(result.dtype(), DataType::BFLOAT16);
+    EXPECT_EQ(result.layout(), Layout::ROW_MAJOR);
+    EXPECT_TRUE(experimental::per_core_allocation::is_per_core_allocation(result.tensor_spec().memory_config()));
+    CMAKE_UNIQUE_NAMESPACE::expect_packed_sizes(result);
+
+    auto result_data = result.to_vector<bfloat16>();
+    ASSERT_EQ(result_data.size(), data.size());
+    for (size_t i = 0; i < data.size(); ++i) {
+        EXPECT_EQ(static_cast<float>(result_data[i]), static_cast<float>(bfloat16(data[i])));
+    }
+}
+
+TEST(HostTensorToTensorSpec, Float32TileToBfp8ValueCheck) {
+    const Shape shape{32, 32};
+    const auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    const auto alignment = Alignment({32, 32});
+    const auto tile = Tile({16, 16});
+    const auto& [floats, packed_golden] = CMAKE_UNIQUE_NAMESPACE::generate_float_to_bfp8_dataset(shape, tile);
+
+    auto src_spec =
+        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto dest_spec =
+        TensorSpec(shape, TensorLayout(DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(floats, src_spec);
+
+    auto result = to_tensor_spec<float>(source, dest_spec, /*pad_value=*/0.f);
+
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), dest_spec));
+    EXPECT_EQ(result.dtype(), DataType::BFLOAT8_B);
+    EXPECT_EQ(result.layout(), Layout::TILE);
+    EXPECT_EQ(result.tensor_spec().tile(), tile);
+    EXPECT_THAT(host_buffer::get_as<uint32_t>(result), Pointwise(Eq(), packed_golden));
+    CMAKE_UNIQUE_NAMESPACE::expect_packed_sizes(result);
+}
+
+TEST(HostTensorToTensorSpec, Float32TileToBfp4ValueCheck) {
+    const Shape shape{32, 32};
+    const auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    const auto alignment = Alignment({32, 32});
+    const auto tile = Tile({16, 16});
+    const auto& [floats, packed_golden] = CMAKE_UNIQUE_NAMESPACE::generate_float_to_bfp4_dataset(shape, tile);
+
+    auto src_spec =
+        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto dest_spec =
+        TensorSpec(shape, TensorLayout(DataType::BFLOAT4_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(floats, src_spec);
+
+    auto result = to_tensor_spec<float>(source, dest_spec, /*pad_value=*/0.f);
+
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), dest_spec));
+    EXPECT_EQ(result.dtype(), DataType::BFLOAT4_B);
+    EXPECT_EQ(result.layout(), Layout::TILE);
+    EXPECT_EQ(result.tensor_spec().tile(), tile);
+    EXPECT_THAT(host_buffer::get_as<uint32_t>(result), Pointwise(Eq(), packed_golden));
+    CMAKE_UNIQUE_NAMESPACE::expect_packed_sizes(result);
+}
+
+TEST(HostTensorToTensorSpec, Bfp8TileToFloat32RowMajorValueCheck) {
+    const Shape shape{32, 32};
+    const auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    const auto alignment = Alignment({32, 32});
+    const auto tile = Tile({16, 16});
+    const auto& [packed, unpacked_golden] = CMAKE_UNIQUE_NAMESPACE::generate_bfp8_dataset(shape, tile);
+
+    auto src_spec =
+        TensorSpec(shape, TensorLayout(DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto dest_spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
+    auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(packed, src_spec);
+
+    auto result = to_tensor_spec<float>(source, dest_spec);
+
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), dest_spec));
+    EXPECT_EQ(result.dtype(), DataType::FLOAT32);
+    EXPECT_EQ(result.layout(), Layout::ROW_MAJOR);
+    CMAKE_UNIQUE_NAMESPACE::expect_packed_sizes(result);
+
+    // unpacked_golden is tile-major; convert to RM logical for comparison.
+    auto rm_golden =
+        tensor_impl::to_row_major_layout(src_spec.physical_shape(), tile, ttsl::make_const_span(unpacked_golden));
+    EXPECT_THAT(result.to_vector<float>(), Pointwise(Eq(), rm_golden));
+}
+
+TEST(HostTensorToTensorSpec, Bfp4TileToFloat32RowMajorValueCheck) {
+    const Shape shape{32, 32};
+    const auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    const auto alignment = Alignment({32, 32});
+    const auto tile = Tile({16, 16});
+    const auto& [packed, unpacked_golden] = CMAKE_UNIQUE_NAMESPACE::generate_bfp4_dataset(shape, tile);
+
+    auto src_spec =
+        TensorSpec(shape, TensorLayout(DataType::BFLOAT4_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto dest_spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
+    auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(packed, src_spec);
+
+    auto result = to_tensor_spec<float>(source, dest_spec);
+
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), dest_spec));
+    EXPECT_EQ(result.dtype(), DataType::FLOAT32);
+    EXPECT_EQ(result.layout(), Layout::ROW_MAJOR);
+    CMAKE_UNIQUE_NAMESPACE::expect_packed_sizes(result);
+
+    auto rm_golden =
+        tensor_impl::to_row_major_layout(src_spec.physical_shape(), tile, ttsl::make_const_span(unpacked_golden));
+    EXPECT_THAT(result.to_vector<float>(), Pointwise(Eq(), rm_golden));
+}
+
+TEST(HostTensorToTensorSpec, RowMajorToBfp8ChangesLayoutAndPreservesTile) {
+    const Shape shape{32, 32};
+    auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto alignment = Alignment({32, 32});
+    auto tile = Tile({16, 16});
+
+    auto src_spec =
+        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
+    auto dest_spec =
+        TensorSpec(shape, TensorLayout(DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto source = HostTensor::from_vector<float>(data, src_spec);
+
+    auto result = to_tensor_spec<float>(source, dest_spec, /*pad_value=*/0.f);
+
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), dest_spec));
+    EXPECT_EQ(result.layout(), Layout::TILE);
+    EXPECT_EQ(result.dtype(), DataType::BFLOAT8_B);
+    EXPECT_EQ(result.tensor_spec().tile(), tile);
+    CMAKE_UNIQUE_NAMESPACE::expect_packed_sizes(result);
+
+    auto result_packed_data = host_buffer::get_as<uint32_t>(result);
+    auto unpacked_data =
+        unpack_bfp8_tiles_into_float_vec(result_packed_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
+    auto rm_data =
+        tensor_impl::to_row_major_layout(dest_spec.physical_shape(), tile, ttsl::make_const_span(unpacked_data));
+
+    ASSERT_EQ(rm_data.size(), data.size());
+    for (size_t i = 0; i < data.size(); ++i) {
+        EXPECT_NEAR(rm_data[i], data[i], 1.0f);
+    }
+}
+
+TEST(HostTensorToTensorSpec, BfpStagingRequiresFloatPad) {
+    const Shape shape{32, 32};
+    auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
+    auto src_spec = CMAKE_UNIQUE_NAMESPACE::make_tile_spec(shape, DataType::FLOAT32, Tile({16, 16}));
+    auto dest_spec = CMAKE_UNIQUE_NAMESPACE::make_tile_spec(shape, DataType::BFLOAT8_B, Tile({16, 16}));
+
+    auto source = HostTensor::from_vector<float>(data, src_spec);
+    EXPECT_ANY_THROW(to_tensor_spec<bfloat16>(source, dest_spec, bfloat16(0.f)));
+    EXPECT_NO_THROW(to_tensor_spec<float>(source, dest_spec, 0.f));
+}
+
 TEST(HostTensorToTensorSpec, Fp8SrcOrDestFatal) {
     const Shape shape{16, 16};
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     auto fp8_spec = TensorSpec(shape, TensorLayout(DataType::FP8_E4M3, PageConfig(Layout::ROW_MAJOR), memory_config));
-    auto f32_spec = make_rm_spec(shape, DataType::FLOAT32);
+    auto f32_spec = CMAKE_UNIQUE_NAMESPACE::make_rm_spec(shape, DataType::FLOAT32, memory_config);
 
-    auto f32_data = make_ramp<float>(shape.volume());
-    auto f32_tensor = HostTensor::from_vector(f32_data, f32_spec);
+    auto f32_data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
+    auto f32_tensor = HostTensor::from_vector<float>(f32_data, f32_spec);
     EXPECT_ANY_THROW(to_tensor_spec<float>(f32_tensor, fp8_spec));
 
     std::vector<float8_e4m3> fp8_data(shape.volume());
     for (size_t i = 0; i < fp8_data.size(); ++i) {
         fp8_data[i] = float8_e4m3(static_cast<float>(i % 16));
     }
-    auto dist_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 1));
-    dist_buffer.emplace_shard(
-        distributed::MeshCoordinate(0, 0), [&]() { return HostBuffer(std::vector<float8_e4m3>(fp8_data)); });
-    auto fp8_tensor = HostTensor::from_buffer(std::move(dist_buffer), fp8_spec, TensorTopology{});
+    auto fp8_tensor = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(std::move(fp8_data), fp8_spec);
     EXPECT_ANY_THROW(to_tensor_spec<float>(fp8_tensor, f32_spec));
-}
-
-TEST(HostTensorToTensorSpec, MultiShardTopologyPreservation) {
-    const Shape shape{32, 64};
-    const size_t volume = shape.volume();
-
-    auto memory_config = MemoryConfig{
-        TensorMemoryLayout::HEIGHT_SHARDED,
-        BufferType::L1,
-        ShardSpec{CoreRangeSet({CoreRange({0, 0}, {0, 1})}), {16, 64}, ShardOrientation::ROW_MAJOR}};
-    auto tile = Tile({16, 16});
-    auto alignment = Alignment({32, 64});
-
-    auto src_spec =
-        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
-    auto dest_spec =
-        TensorSpec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE, tile), memory_config, alignment));
-
-    auto topology = TensorTopology::create_fully_replicated_tensor_topology(distributed::MeshShape(1, 2));
-    auto distributed_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 2));
-
-    auto data_0 = make_ramp<float>(volume);
-    auto data_1 = make_ramp<float>(volume);
-    for (auto& v : data_1) {
-        v += 10.0f;
-    }
-
-    // Encode each shard into the TILE FLOAT32 physical layout expected by from_buffer.
-    auto encoded_0 = tensor_impl::encode_tensor_data(ttsl::make_const_span(data_0), src_spec, 0.f);
-    auto encoded_1 = tensor_impl::encode_tensor_data(ttsl::make_const_span(data_1), src_spec, 0.f);
-    distributed_buffer.emplace_shard(
-        distributed::MeshCoordinate(0, 0), [&]() { return HostBuffer(std::vector<float>(encoded_0)); });
-    distributed_buffer.emplace_shard(
-        distributed::MeshCoordinate(0, 1), [&]() { return HostBuffer(std::vector<float>(encoded_1)); });
-
-    auto source = HostTensor::from_buffer(std::move(distributed_buffer), src_spec, topology);
-    auto result = to_tensor_spec<float>(source, dest_spec);
-
-    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), dest_spec));
-    EXPECT_EQ(result.tensor_topology(), topology);
-
-    const size_t expected_shard_size = dest_spec.compute_packed_buffer_size_bytes();
-    auto coords = result.buffer().shard_coords();
-    EXPECT_EQ(coords.size(), 2);
-    EXPECT_TRUE(coords.contains(distributed::MeshCoordinate(0, 0)));
-    EXPECT_TRUE(coords.contains(distributed::MeshCoordinate(0, 1)));
-
-    for (const auto& coord : coords) {
-        auto shard = result.buffer().get_shard(coord);
-        ASSERT_TRUE(shard.has_value());
-        EXPECT_EQ(shard->view_bytes().size(), expected_shard_size);
-
-        auto logical = tensor_impl::decode_tensor_data(shard->view_as<const bfloat16>(), dest_spec);
-        const auto& expected_data = (coord == distributed::MeshCoordinate(0, 0)) ? data_0 : data_1;
-        ASSERT_EQ(logical.size(), expected_data.size());
-        for (size_t i = 0; i < logical.size(); ++i) {
-            EXPECT_EQ(static_cast<float>(logical[i]), static_cast<float>(bfloat16(expected_data[i])));
-        }
-    }
-}
-
-TEST(HostTensorToTensorSpec, ShapeMismatchFatal) {
-    auto src = HostTensor::from_vector(make_ramp<float>(32 * 32), make_rm_spec(Shape{32, 32}, DataType::FLOAT32));
-    auto dest = make_rm_spec(Shape{16, 16}, DataType::FLOAT32);
-    EXPECT_ANY_THROW(to_tensor_spec<float>(src, dest));
-}
-
-TEST(HostTensorToTensorSpec, TypedPadUint8AndWrongTFatal) {
-    const Shape shape{20, 20};
-    auto data = make_ramp<uint8_t>(shape.volume());
-    auto src_spec = make_rm_spec(shape, DataType::UINT8);
-    auto dest_spec = make_tile_spec(shape, DataType::UINT8, Tile({16, 16}));
-
-    auto source = HostTensor::from_vector(data, src_spec);
-    auto result = to_tensor_spec<uint8_t>(source, dest_spec, /*pad_value=*/uint8_t{7});
-    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), dest_spec));
-    EXPECT_EQ(result.to_vector<uint8_t>(), data);
-
-    // Wrong T vs working encode dtype (source UINT8).
-    EXPECT_ANY_THROW(to_tensor_spec<float>(source, dest_spec, 0.f));
-}
-
-TEST(HostTensorToTensorSpec, BfpStagingRequiresFloatPad) {
-    const Shape shape{32, 32};
-    auto data = make_ramp<float>(shape.volume());
-    auto src_spec = make_tile_spec(shape, DataType::FLOAT32, Tile({16, 16}));
-    auto dest_spec = make_tile_spec(shape, DataType::BFLOAT8_B, Tile({16, 16}));
-
-    auto source = HostTensor::from_vector(data, src_spec);
-    EXPECT_ANY_THROW(to_tensor_spec<bfloat16>(source, dest_spec, bfloat16(0.f)));
-    EXPECT_NO_THROW(to_tensor_spec<float>(source, dest_spec, 0.f));
-}
-
-TEST(HostTensorToTensorSpec, BfpDestinationStaging) {
-    const Shape shape{20, 20};
-    auto data = make_ramp<float>(shape.volume());
-    auto tile = Tile({16, 16});
-    auto src_spec = make_rm_spec(shape, DataType::FLOAT32);
-    auto dest_spec = make_tile_spec(shape, DataType::BFLOAT8_B, tile);
-
-    auto source = HostTensor::from_vector(data, src_spec);
-    auto result = to_tensor_spec<float>(source, dest_spec, /*pad_value=*/0.f);
-    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), dest_spec));
-    EXPECT_EQ(result.layout(), Layout::TILE);
-    EXPECT_EQ(result.dtype(), DataType::BFLOAT8_B);
-
-    // Round-trip logical values through FLOAT32 (BFP quantization tolerant).
-    auto as_float = to_dtype(result, DataType::FLOAT32);
-    auto logical = as_float.to_vector<float>();
-    ASSERT_EQ(logical.size(), data.size());
-    for (size_t i = 0; i < data.size(); ++i) {
-        EXPECT_NEAR(logical[i], data[i], 1.0f);
-    }
-}
-
-TEST(HostTensorToTensorSpec, BfpSourceStaging) {
-    const Shape shape{32, 32};
-    auto data = make_ramp<float>(shape.volume());
-    auto tile = Tile({16, 16});
-    auto bfp_spec = make_tile_spec(shape, DataType::BFLOAT8_B, tile);
-    auto dest_spec = make_rm_spec(shape, DataType::FLOAT32);
-
-    auto source = HostTensor::from_vector(data, bfp_spec);
-    auto result = to_tensor_spec<float>(source, dest_spec);
-    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), dest_spec));
-
-    auto logical = result.to_vector<float>();
-    ASSERT_EQ(logical.size(), data.size());
-    for (size_t i = 0; i < data.size(); ++i) {
-        EXPECT_NEAR(logical[i], data[i], 1.0f);
-    }
-}
-
-TEST(HostTensorToTensorSpec, FloatPadToIntegralDestRejectsNanInfOor) {
-    const Shape shape{20, 20};
-    auto data = make_ramp<float>(shape.volume());
-    auto src_spec = make_rm_spec(shape, DataType::FLOAT32);
-    auto dest_spec = make_tile_spec(shape, DataType::UINT8, Tile({16, 16}));
-    auto source = HostTensor::from_vector(data, src_spec);
-
-    EXPECT_ANY_THROW(to_tensor_spec<float>(source, dest_spec, std::numeric_limits<float>::quiet_NaN()));
-    EXPECT_ANY_THROW(to_tensor_spec<float>(source, dest_spec, std::numeric_limits<float>::infinity()));
-    EXPECT_ANY_THROW(to_tensor_spec<float>(source, dest_spec, -1.f));
-    EXPECT_ANY_THROW(to_tensor_spec<float>(source, dest_spec, 256.f));
-
-    auto ok = to_tensor_spec<float>(source, dest_spec, 7.f);
-    EXPECT_TRUE(exact_spec_match(ok.tensor_spec(), dest_spec));
-    auto logical = ok.to_vector<uint8_t>();
-    ASSERT_EQ(logical.size(), data.size());
-    for (size_t i = 0; i < data.size(); ++i) {
-        EXPECT_EQ(logical[i], static_cast<uint8_t>(data[i]));
-    }
-
-    // Verify physical padding
-    auto physical = host_buffer::get_as<uint8_t>(ok);
-    // Physical shape is 32x32.
-    // Index (31, 31) in tile layout is at the end.
-    // The padding should be filled with 7.
-    EXPECT_EQ(physical.back(), 7);
-}
-
-TEST(HostTensorToTensorSpec, EqualPaddedDifferentPackingRoundTrip) {
-    // Same logical shape and equal physical 2D size, but different packing (padded RM vs TILE).
-    const Shape shape{20, 20};
-    auto data = make_ramp<float>(shape.volume());
-    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
-    auto rm_spec = TensorSpec(
-        shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, Alignment({16, 16})));
-    auto tile_spec =
-        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, Tile({16, 16})), memory_config));
-
-    EXPECT_EQ(rm_spec.physical_shape(), tile_spec.physical_shape());
-    EXPECT_NE(rm_spec.page_config(), tile_spec.page_config());
-    EXPECT_TRUE(rm_spec.logical_2d_shape() != rm_spec.physical_shape());
-    EXPECT_TRUE(tile_spec.logical_2d_shape() != tile_spec.physical_shape());
-
-    auto source = HostTensor::from_vector(data, rm_spec, /*pad_value=*/3.f);
-    auto tiled = to_tensor_spec<float>(source, tile_spec, /*pad_value=*/5.f);
-    EXPECT_TRUE(exact_spec_match(tiled.tensor_spec(), tile_spec));
-    EXPECT_EQ(tiled.to_vector<float>(), data);
-
-    // Check physical pad of tiled
-    auto tiled_physical = host_buffer::get_as<float>(tiled);
-    EXPECT_EQ(tiled_physical.back(), 5.f);
-
-    auto back = to_tensor_spec<float>(tiled, rm_spec, /*pad_value=*/9.f);
-    EXPECT_TRUE(exact_spec_match(back.tensor_spec(), rm_spec));
-    EXPECT_EQ(back.to_vector<float>(), data);
-
-    // Check physical pad of back
-    auto back_physical = host_buffer::get_as<float>(back);
-    // RM layout, shape 20x20, physical 32x32.
-    // Index (31, 31) is 31 * 32 + 31.
-    EXPECT_EQ(back_physical[31 * 32 + 31], 9.f);
-}
-
-TEST(HostTensorToTensorSpec, Rank0Unsupported) {
-    // Rank-0 shape: empty dimensions vector.
-    Shape rank0_shape(ttsl::SmallVector<uint32_t>{});
-    EXPECT_EQ(rank0_shape.rank(), 0);
-
-    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
-    auto spec = TensorSpec(rank0_shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
-
-    auto dist_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 1));
-    dist_buffer.emplace_shard(distributed::MeshCoordinate(0, 0), [&]() { return HostBuffer(std::vector<float>{}); });
-    auto tensor = HostTensor::from_buffer(std::move(dist_buffer), spec, TensorTopology{});
-
-    // Dest with different packing metadata forces a rewrite attempt (not early-out).
-    auto dest = TensorSpec(
-        rank0_shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, Tile({32, 32})), memory_config));
-    EXPECT_ANY_THROW(to_tensor_spec<float>(tensor, dest));
 }
 
 TEST(HostTensorToTensorSpec, ExactMatchFp8Fatal) {
@@ -405,60 +465,188 @@ TEST(HostTensorToTensorSpec, ExactMatchFp8Fatal) {
     for (size_t i = 0; i < fp8_data.size(); ++i) {
         fp8_data[i] = float8_e4m3(static_cast<float>(i % 16));
     }
-    auto dist_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 1));
-    dist_buffer.emplace_shard(
-        distributed::MeshCoordinate(0, 0), [&]() { return HostBuffer(std::vector<float8_e4m3>(fp8_data)); });
-    auto fp8_tensor = HostTensor::from_buffer(std::move(dist_buffer), fp8_spec, TensorTopology{});
+    auto fp8_tensor = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(std::move(fp8_data), fp8_spec);
 
-    // Exact match FP8 should still fatal
+    // Exact match FP8 should still fatal.
     EXPECT_ANY_THROW(to_tensor_spec<float>(fp8_tensor, fp8_spec));
+}
+
+TEST(HostTensorToTensorSpec, ShapeMismatchFatal) {
+    auto src = HostTensor::from_vector<float>(
+        CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(32 * 32),
+        CMAKE_UNIQUE_NAMESPACE::make_rm_spec(Shape{32, 32}, DataType::FLOAT32));
+    auto dest = CMAKE_UNIQUE_NAMESPACE::make_rm_spec(Shape{16, 16}, DataType::FLOAT32);
+    EXPECT_ANY_THROW(to_tensor_spec<float>(src, dest));
+}
+
+TEST(HostTensorToTensorSpec, TypedPadUint8AndWrongTFatal) {
+    const Shape shape{20, 20};
+    auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<uint8_t>(shape.volume());
+    auto src_spec = CMAKE_UNIQUE_NAMESPACE::make_rm_spec(shape, DataType::UINT8);
+    auto dest_spec = CMAKE_UNIQUE_NAMESPACE::make_tile_spec(shape, DataType::UINT8, Tile({16, 16}));
+
+    auto source = HostTensor::from_vector<uint8_t>(data, src_spec);
+    auto result = to_tensor_spec<uint8_t>(source, dest_spec, /*pad_value=*/uint8_t{7});
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), dest_spec));
+    EXPECT_THAT(result.to_vector<uint8_t>(), Pointwise(Eq(), data));
+    EXPECT_EQ(host_buffer::get_as<uint8_t>(result).back(), 7);
+
+    // Wrong T vs working encode dtype (source UINT8).
+    EXPECT_ANY_THROW(to_tensor_spec<float>(source, dest_spec, 0.f));
+}
+
+TEST(HostTensorToTensorSpec, FloatPadToIntegralDestRejectsNanInfOor) {
+    const Shape shape{20, 20};
+    auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
+    auto src_spec = CMAKE_UNIQUE_NAMESPACE::make_rm_spec(shape, DataType::FLOAT32);
+    auto dest_spec = CMAKE_UNIQUE_NAMESPACE::make_tile_spec(shape, DataType::UINT8, Tile({16, 16}));
+    auto source = HostTensor::from_vector<float>(data, src_spec);
+
+    EXPECT_ANY_THROW(to_tensor_spec<float>(source, dest_spec, std::numeric_limits<float>::quiet_NaN()));
+    EXPECT_ANY_THROW(to_tensor_spec<float>(source, dest_spec, std::numeric_limits<float>::infinity()));
+    EXPECT_ANY_THROW(to_tensor_spec<float>(source, dest_spec, -1.f));
+    EXPECT_ANY_THROW(to_tensor_spec<float>(source, dest_spec, 256.f));
+
+    auto ok = to_tensor_spec<float>(source, dest_spec, 7.f);
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(ok.tensor_spec(), dest_spec));
+    EXPECT_EQ(ok.dtype(), DataType::UINT8);
+    EXPECT_EQ(ok.layout(), Layout::TILE);
+    CMAKE_UNIQUE_NAMESPACE::expect_packed_sizes(ok);
+
+    auto logical = ok.to_vector<uint8_t>();
+    ASSERT_EQ(logical.size(), data.size());
+    for (size_t i = 0; i < data.size(); ++i) {
+        EXPECT_EQ(logical[i], static_cast<uint8_t>(data[i]));
+    }
+
+    // Physical shape is 32x32 TILE; trailing pad element should be 7.
+    EXPECT_EQ(host_buffer::get_as<uint8_t>(ok).back(), 7);
+}
+
+TEST(HostTensorToTensorSpec, EqualPaddedDifferentPackingRoundTrip) {
+    // Same logical shape and equal physical 2D size, but different packing (padded RM vs TILE).
+    const Shape shape{20, 20};
+    auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto rm_spec = TensorSpec(
+        shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, Alignment({16, 16})));
+    auto tile_spec =
+        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, Tile({16, 16})), memory_config));
+
+    EXPECT_EQ(rm_spec.physical_shape(), tile_spec.physical_shape());
+    EXPECT_NE(rm_spec.page_config(), tile_spec.page_config());
+    EXPECT_TRUE(rm_spec.logical_2d_shape() != rm_spec.physical_shape());
+    EXPECT_TRUE(tile_spec.logical_2d_shape() != tile_spec.physical_shape());
+
+    auto source = HostTensor::from_vector<float>(data, rm_spec, /*pad_value=*/3.f);
+    auto tiled = to_tensor_spec<float>(source, tile_spec, /*pad_value=*/5.f);
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(tiled.tensor_spec(), tile_spec));
+    EXPECT_THAT(tiled.to_vector<float>(), Pointwise(Eq(), data));
+    EXPECT_EQ(host_buffer::get_as<float>(tiled).back(), 5.f);
+    CMAKE_UNIQUE_NAMESPACE::expect_packed_sizes(tiled);
+
+    auto back = to_tensor_spec<float>(tiled, rm_spec, /*pad_value=*/9.f);
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(back.tensor_spec(), rm_spec));
+    EXPECT_THAT(back.to_vector<float>(), Pointwise(Eq(), data));
+    // RM layout, shape 20x20, physical 32x32. Index (31, 31) is 31 * 32 + 31.
+    EXPECT_EQ(host_buffer::get_as<float>(back)[31 * 32 + 31], 9.f);
+    CMAKE_UNIQUE_NAMESPACE::expect_packed_sizes(back);
+}
+
+TEST(HostTensorToTensorSpec, TypedIntegralPadBoundaries) {
+    const Shape shape{20, 20};
+    auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<uint32_t>(shape.volume());
+    auto src_spec = CMAKE_UNIQUE_NAMESPACE::make_rm_spec(shape, DataType::UINT32);
+    auto dest_spec = CMAKE_UNIQUE_NAMESPACE::make_tile_spec(shape, DataType::UINT32, Tile({16, 16}));
+    auto source = HostTensor::from_vector<uint32_t>(data, src_spec);
+
+    auto min_pad = std::numeric_limits<uint32_t>::lowest();
+    auto result_min = to_tensor_spec<uint32_t>(source, dest_spec, min_pad);
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result_min.tensor_spec(), dest_spec));
+    EXPECT_EQ(host_buffer::get_as<uint32_t>(result_min).back(), min_pad);
+    EXPECT_THAT(result_min.to_vector<uint32_t>(), Pointwise(Eq(), data));
+
+    auto max_pad = std::numeric_limits<uint32_t>::max();
+    auto result_max = to_tensor_spec<uint32_t>(source, dest_spec, max_pad);
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result_max.tensor_spec(), dest_spec));
+    EXPECT_EQ(host_buffer::get_as<uint32_t>(result_max).back(), max_pad);
+    EXPECT_THAT(result_max.to_vector<uint32_t>(), Pointwise(Eq(), data));
+}
+
+TEST(HostTensorToTensorSpec, Rank0Unsupported) {
+    Shape rank0_shape(ttsl::SmallVector<uint32_t>{});
+    EXPECT_EQ(rank0_shape.rank(), 0);
+
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto spec = TensorSpec(rank0_shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
+    auto tensor = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(std::vector<float>{}, spec);
+
+    // Dest with different packing metadata forces a rewrite attempt (not early-out).
+    auto dest = TensorSpec(
+        rank0_shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, Tile({32, 32})), memory_config));
+    EXPECT_ANY_THROW(to_tensor_spec<float>(tensor, dest));
 }
 
 TEST(HostTensorToTensorSpec, ExactMatchRank0Fatal) {
     Shape rank0_shape(ttsl::SmallVector<uint32_t>{});
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     auto spec = TensorSpec(rank0_shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
+    auto tensor = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(std::vector<float>{}, spec);
 
-    auto dist_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 1));
-    dist_buffer.emplace_shard(distributed::MeshCoordinate(0, 0), [&]() { return HostBuffer(std::vector<float>{}); });
-    auto tensor = HostTensor::from_buffer(std::move(dist_buffer), spec, TensorTopology{});
-
-    // Exact match rank-0 should still fatal
+    // Exact match rank-0 should still fatal.
     EXPECT_ANY_THROW(to_tensor_spec<float>(tensor, spec));
 }
 
 TEST(HostTensorToTensorSpec, ExactMatchBfpWrongTFatal) {
     const Shape shape{32, 32};
-    auto data = make_ramp<float>(shape.volume());
-    auto spec = make_tile_spec(shape, DataType::BFLOAT8_B, Tile({16, 16}));
+    auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
+    auto spec = CMAKE_UNIQUE_NAMESPACE::make_tile_spec(shape, DataType::BFLOAT8_B, Tile({16, 16}));
+    auto source = HostTensor::from_vector<float>(data, spec);
 
-    auto source = HostTensor::from_vector(data, spec);
-
-    // Exact match but wrong T (not float) should still fatal
+    // Exact match but wrong T (not float) should still fatal.
     EXPECT_ANY_THROW(to_tensor_spec<bfloat16>(source, spec, bfloat16(0.f)));
 }
 
-TEST(HostTensorToTensorSpec, TypedIntegralPadBoundaries) {
-    const Shape shape{20, 20};
-    auto data = make_ramp<uint32_t>(shape.volume());
-    auto src_spec = make_rm_spec(shape, DataType::UINT32);
-    auto dest_spec = make_tile_spec(shape, DataType::UINT32, Tile({16, 16}));
+TEST(HostTensorToTensorSpec, OversizedBufferThrows) {
+    const Shape shape{32, 32};
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto src_spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
+    auto dest_spec =
+        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, Tile({16, 16})), memory_config));
 
-    auto source = HostTensor::from_vector(data, src_spec);
+    auto oversized_data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume() + 100);
+    auto host_tensor = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(std::move(oversized_data), src_spec);
 
-    // Min boundary
-    auto min_pad = std::numeric_limits<uint32_t>::lowest();
-    auto result_min = to_tensor_spec<uint32_t>(source, dest_spec, min_pad);
-    EXPECT_TRUE(exact_spec_match(result_min.tensor_spec(), dest_spec));
-    auto physical_min = host_buffer::get_as<uint32_t>(result_min);
-    EXPECT_EQ(physical_min.back(), min_pad);
+    // decode_tensor_data asserts physical size matches the spec.
+    EXPECT_ANY_THROW(to_tensor_spec<float>(host_tensor, dest_spec));
+}
 
-    // Max boundary
-    auto max_pad = std::numeric_limits<uint32_t>::max();
-    auto result_max = to_tensor_spec<uint32_t>(source, dest_spec, max_pad);
-    EXPECT_TRUE(exact_spec_match(result_max.tensor_spec(), dest_spec));
-    auto physical_max = host_buffer::get_as<uint32_t>(result_max);
-    EXPECT_EQ(physical_max.back(), max_pad);
+TEST(HostTensorToTensorSpec, UndersizedBfpBufferThrows) {
+    const Shape shape{32, 32};
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto tile = Tile({16, 16});
+    auto src_spec = TensorSpec(shape, TensorLayout(DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config));
+    auto dest_spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
+
+    auto undersized_data = std::vector<uint32_t>(10, 0);
+    auto host_tensor = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(std::move(undersized_data), src_spec);
+
+    // Staging to_dtype asserts packed input size before unpack.
+    EXPECT_ANY_THROW(to_tensor_spec<float>(host_tensor, dest_spec));
+}
+
+TEST(HostTensorToTensorSpec, MalformedBfpBufferThrows) {
+    const Shape shape{32, 32};
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto tile = Tile({16, 16});
+    auto src_spec = TensorSpec(shape, TensorLayout(DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config));
+    auto dest_spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
+
+    size_t expected_size_bytes = src_spec.compute_packed_buffer_size_bytes();
+    auto malformed_data = std::vector<uint32_t>((expected_size_bytes / sizeof(uint32_t)) - 1, 0);
+    auto host_tensor = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(std::move(malformed_data), src_spec);
+
+    EXPECT_ANY_THROW(to_tensor_spec<float>(host_tensor, dest_spec));
 }
 
 }  // namespace

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_tensor_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_tensor_spec.cpp
@@ -1,0 +1,465 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/experimental/tensor/host_tensor.hpp>
+#include <tt-metalium/experimental/tensor/tensor_apis.hpp>
+#include <tt-metalium/experimental/tensor/spec/tensor_spec.hpp>
+#include <tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp>
+#include <tt-metalium/experimental/tensor/spec/layout/page_config.hpp>
+#include <tt-metalium/experimental/tensor/impl/tensor_impl.hpp>
+#include <tt-metalium/experimental/per_core_allocation/buffer.hpp>
+#include <tt-metalium/float8.hpp>
+#include <tt-metalium/host_buffer.hpp>
+#include <tt-metalium/shape.hpp>
+#include <tt-metalium/tile.hpp>
+
+namespace tt::tt_metal {
+namespace {
+
+template <typename T>
+std::vector<T> make_ramp(size_t count) {
+    std::vector<T> data(count);
+    for (size_t i = 0; i < count; ++i) {
+        data[i] = static_cast<T>(static_cast<float>(i % 251));
+    }
+    return data;
+}
+
+bool exact_spec_match(const TensorSpec& a, const TensorSpec& b) {
+    return a == b && experimental::per_core_allocation::is_per_core_allocation(a.memory_config()) ==
+                         experimental::per_core_allocation::is_per_core_allocation(b.memory_config());
+}
+
+TensorSpec make_rm_spec(const Shape& shape, DataType dtype, const MemoryConfig& memory_config = MemoryConfig{}) {
+    return TensorSpec(shape, TensorLayout(dtype, PageConfig(Layout::ROW_MAJOR), memory_config));
+}
+
+TensorSpec make_tile_spec(
+    const Shape& shape,
+    DataType dtype,
+    const Tile& tile = Tile({32, 32}),
+    const MemoryConfig& memory_config = MemoryConfig{}) {
+    return TensorSpec(shape, TensorLayout(dtype, PageConfig(Layout::TILE, tile), memory_config));
+}
+
+TEST(HostTensorToTensorSpec, EarlyOutExactSpecMatch) {
+    const Shape shape{32, 32};
+    auto data = make_ramp<float>(shape.volume());
+    auto spec = make_tile_spec(shape, DataType::FLOAT32);
+    auto source = HostTensor::from_vector(data, spec);
+
+    auto result = to_tensor_spec<float>(source, spec);
+    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), spec));
+    EXPECT_EQ(result.to_vector<float>(), data);
+}
+
+TEST(HostTensorToTensorSpec, PerCoreOnlyMismatchFullRewrite) {
+    const Shape shape{20, 20};
+    auto data = make_ramp<float>(shape.volume());
+
+    auto memory_config = MemoryConfig{
+        TensorMemoryLayout::HEIGHT_SHARDED,
+        BufferType::L1,
+        ShardSpec{CoreRangeSet({CoreRange({0, 0}, {0, 0})}), {32, 32}, ShardOrientation::ROW_MAJOR}};
+
+    auto src_spec = TensorSpec(
+        shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, Alignment({32, 32})));
+    auto source = HostTensor::from_vector(data, src_spec, /*pad_value=*/99.f);
+    EXPECT_FALSE(experimental::per_core_allocation::is_per_core_allocation(source.tensor_spec().memory_config()));
+
+    auto dest_memory = memory_config;
+    experimental::per_core_allocation::set_per_core_allocation(dest_memory, true);
+    auto dest_spec = TensorSpec(
+        shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), dest_memory, Alignment({32, 32})));
+
+    // Spec equality ignores per_core, but exact-spec predicate must not early-out.
+    EXPECT_TRUE(source.tensor_spec() == dest_spec);
+    EXPECT_FALSE(exact_spec_match(source.tensor_spec(), dest_spec));
+
+    auto result = to_tensor_spec<float>(source, dest_spec, /*pad_value=*/77.f);
+    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), dest_spec));
+    EXPECT_TRUE(experimental::per_core_allocation::is_per_core_allocation(result.tensor_spec().memory_config()));
+    EXPECT_EQ(result.to_vector<float>(), data);
+
+    auto result_physical = host_buffer::get_as<float>(result);
+    // RM layout, shape 20x20, physical 32x32.
+    // Index (31, 31) is 31 * 32 + 31.
+    EXPECT_EQ(result_physical[31 * 32 + 31], 77.f);
+}
+
+TEST(HostTensorToTensorSpec, LogicalRoundTripRmTileRm) {
+    const Shape shape{20, 20};
+    auto data = make_ramp<float>(shape.volume());
+    auto rm_spec = make_rm_spec(shape, DataType::FLOAT32);
+    auto tile_spec = make_tile_spec(shape, DataType::FLOAT32, Tile({16, 16}));
+
+    auto source = HostTensor::from_vector(data, rm_spec);
+    auto tiled = to_tensor_spec<float>(source, tile_spec, /*pad_value=*/0.f);
+    EXPECT_TRUE(exact_spec_match(tiled.tensor_spec(), tile_spec));
+
+    auto back = to_tensor_spec<float>(tiled, rm_spec);
+    EXPECT_TRUE(exact_spec_match(back.tensor_spec(), rm_spec));
+    EXPECT_EQ(back.to_vector<float>(), data);
+}
+
+TEST(HostTensorToTensorSpec, RmToTileAndTileToRm) {
+    const Shape shape{32, 32};
+    auto data = make_ramp<uint16_t>(shape.volume());
+    auto rm_spec = make_rm_spec(shape, DataType::UINT16);
+    auto tile_spec = make_tile_spec(shape, DataType::UINT16);
+
+    auto source = HostTensor::from_vector(data, rm_spec);
+    auto tiled = to_tensor_spec<uint16_t>(source, tile_spec);
+    EXPECT_TRUE(exact_spec_match(tiled.tensor_spec(), tile_spec));
+    EXPECT_EQ(tiled.layout(), Layout::TILE);
+
+    auto back = to_tensor_spec<uint16_t>(tiled, rm_spec);
+    EXPECT_TRUE(exact_spec_match(back.tensor_spec(), rm_spec));
+    EXPECT_EQ(back.to_vector<uint16_t>(), data);
+}
+
+TEST(HostTensorToTensorSpec, CustomTileAndAlignment) {
+    const Shape shape{32, 32};
+    auto data = make_ramp<float>(shape.volume());
+    auto tile = Tile({16, 16});
+    auto alignment = Alignment({16, 16});
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+
+    auto src_spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
+    auto dest_spec =
+        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+
+    auto source = HostTensor::from_vector(data, src_spec);
+    auto result = to_tensor_spec<float>(source, dest_spec);
+    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), dest_spec));
+    EXPECT_EQ(result.tensor_spec().tile(), tile);
+    EXPECT_EQ(result.tensor_spec().tensor_layout().get_alignment(), dest_spec.tensor_layout().get_alignment());
+    EXPECT_EQ(result.to_vector<float>(), data);
+}
+
+TEST(HostTensorToTensorSpec, CrossDtypeFloat32ToBfloat16) {
+    const Shape shape{32, 32};
+    auto data = make_ramp<float>(shape.volume());
+    auto src_spec = make_tile_spec(shape, DataType::FLOAT32);
+    auto dest_spec = make_tile_spec(shape, DataType::BFLOAT16);
+
+    auto source = HostTensor::from_vector(data, src_spec);
+    auto result = to_tensor_spec<float>(source, dest_spec);
+    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), dest_spec));
+
+    auto result_data = result.to_vector<bfloat16>();
+    ASSERT_EQ(result_data.size(), data.size());
+    for (size_t i = 0; i < data.size(); ++i) {
+        EXPECT_EQ(static_cast<float>(result_data[i]), static_cast<float>(bfloat16(data[i])));
+    }
+}
+
+TEST(HostTensorToTensorSpec, Fp8SrcOrDestFatal) {
+    const Shape shape{16, 16};
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto fp8_spec = TensorSpec(shape, TensorLayout(DataType::FP8_E4M3, PageConfig(Layout::ROW_MAJOR), memory_config));
+    auto f32_spec = make_rm_spec(shape, DataType::FLOAT32);
+
+    auto f32_data = make_ramp<float>(shape.volume());
+    auto f32_tensor = HostTensor::from_vector(f32_data, f32_spec);
+    EXPECT_ANY_THROW(to_tensor_spec<float>(f32_tensor, fp8_spec));
+
+    std::vector<float8_e4m3> fp8_data(shape.volume());
+    for (size_t i = 0; i < fp8_data.size(); ++i) {
+        fp8_data[i] = float8_e4m3(static_cast<float>(i % 16));
+    }
+    auto dist_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 1));
+    dist_buffer.emplace_shard(
+        distributed::MeshCoordinate(0, 0), [&]() { return HostBuffer(std::vector<float8_e4m3>(fp8_data)); });
+    auto fp8_tensor = HostTensor::from_buffer(std::move(dist_buffer), fp8_spec, TensorTopology{});
+    EXPECT_ANY_THROW(to_tensor_spec<float>(fp8_tensor, f32_spec));
+}
+
+TEST(HostTensorToTensorSpec, MultiShardTopologyPreservation) {
+    const Shape shape{32, 64};
+    const size_t volume = shape.volume();
+
+    auto memory_config = MemoryConfig{
+        TensorMemoryLayout::HEIGHT_SHARDED,
+        BufferType::L1,
+        ShardSpec{CoreRangeSet({CoreRange({0, 0}, {0, 1})}), {16, 64}, ShardOrientation::ROW_MAJOR}};
+    auto tile = Tile({16, 16});
+    auto alignment = Alignment({32, 64});
+
+    auto src_spec =
+        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto dest_spec =
+        TensorSpec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE, tile), memory_config, alignment));
+
+    auto topology = TensorTopology::create_fully_replicated_tensor_topology(distributed::MeshShape(1, 2));
+    auto distributed_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 2));
+
+    auto data_0 = make_ramp<float>(volume);
+    auto data_1 = make_ramp<float>(volume);
+    for (auto& v : data_1) {
+        v += 10.0f;
+    }
+
+    // Encode each shard into the TILE FLOAT32 physical layout expected by from_buffer.
+    auto encoded_0 = tensor_impl::encode_tensor_data(ttsl::make_const_span(data_0), src_spec, 0.f);
+    auto encoded_1 = tensor_impl::encode_tensor_data(ttsl::make_const_span(data_1), src_spec, 0.f);
+    distributed_buffer.emplace_shard(
+        distributed::MeshCoordinate(0, 0), [&]() { return HostBuffer(std::vector<float>(encoded_0)); });
+    distributed_buffer.emplace_shard(
+        distributed::MeshCoordinate(0, 1), [&]() { return HostBuffer(std::vector<float>(encoded_1)); });
+
+    auto source = HostTensor::from_buffer(std::move(distributed_buffer), src_spec, topology);
+    auto result = to_tensor_spec<float>(source, dest_spec);
+
+    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), dest_spec));
+    EXPECT_EQ(result.tensor_topology(), topology);
+
+    const size_t expected_shard_size = dest_spec.compute_packed_buffer_size_bytes();
+    auto coords = result.buffer().shard_coords();
+    EXPECT_EQ(coords.size(), 2);
+    EXPECT_TRUE(coords.contains(distributed::MeshCoordinate(0, 0)));
+    EXPECT_TRUE(coords.contains(distributed::MeshCoordinate(0, 1)));
+
+    for (const auto& coord : coords) {
+        auto shard = result.buffer().get_shard(coord);
+        ASSERT_TRUE(shard.has_value());
+        EXPECT_EQ(shard->view_bytes().size(), expected_shard_size);
+
+        auto logical = tensor_impl::decode_tensor_data(shard->view_as<const bfloat16>(), dest_spec);
+        const auto& expected_data = (coord == distributed::MeshCoordinate(0, 0)) ? data_0 : data_1;
+        ASSERT_EQ(logical.size(), expected_data.size());
+        for (size_t i = 0; i < logical.size(); ++i) {
+            EXPECT_EQ(static_cast<float>(logical[i]), static_cast<float>(bfloat16(expected_data[i])));
+        }
+    }
+}
+
+TEST(HostTensorToTensorSpec, ShapeMismatchFatal) {
+    auto src = HostTensor::from_vector(make_ramp<float>(32 * 32), make_rm_spec(Shape{32, 32}, DataType::FLOAT32));
+    auto dest = make_rm_spec(Shape{16, 16}, DataType::FLOAT32);
+    EXPECT_ANY_THROW(to_tensor_spec<float>(src, dest));
+}
+
+TEST(HostTensorToTensorSpec, TypedPadUint8AndWrongTFatal) {
+    const Shape shape{20, 20};
+    auto data = make_ramp<uint8_t>(shape.volume());
+    auto src_spec = make_rm_spec(shape, DataType::UINT8);
+    auto dest_spec = make_tile_spec(shape, DataType::UINT8, Tile({16, 16}));
+
+    auto source = HostTensor::from_vector(data, src_spec);
+    auto result = to_tensor_spec<uint8_t>(source, dest_spec, /*pad_value=*/uint8_t{7});
+    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), dest_spec));
+    EXPECT_EQ(result.to_vector<uint8_t>(), data);
+
+    // Wrong T vs working encode dtype (source UINT8).
+    EXPECT_ANY_THROW(to_tensor_spec<float>(source, dest_spec, 0.f));
+}
+
+TEST(HostTensorToTensorSpec, BfpStagingRequiresFloatPad) {
+    const Shape shape{32, 32};
+    auto data = make_ramp<float>(shape.volume());
+    auto src_spec = make_tile_spec(shape, DataType::FLOAT32, Tile({16, 16}));
+    auto dest_spec = make_tile_spec(shape, DataType::BFLOAT8_B, Tile({16, 16}));
+
+    auto source = HostTensor::from_vector(data, src_spec);
+    EXPECT_ANY_THROW(to_tensor_spec<bfloat16>(source, dest_spec, bfloat16(0.f)));
+    EXPECT_NO_THROW(to_tensor_spec<float>(source, dest_spec, 0.f));
+}
+
+TEST(HostTensorToTensorSpec, BfpDestinationStaging) {
+    const Shape shape{20, 20};
+    auto data = make_ramp<float>(shape.volume());
+    auto tile = Tile({16, 16});
+    auto src_spec = make_rm_spec(shape, DataType::FLOAT32);
+    auto dest_spec = make_tile_spec(shape, DataType::BFLOAT8_B, tile);
+
+    auto source = HostTensor::from_vector(data, src_spec);
+    auto result = to_tensor_spec<float>(source, dest_spec, /*pad_value=*/0.f);
+    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), dest_spec));
+    EXPECT_EQ(result.layout(), Layout::TILE);
+    EXPECT_EQ(result.dtype(), DataType::BFLOAT8_B);
+
+    // Round-trip logical values through FLOAT32 (BFP quantization tolerant).
+    auto as_float = to_dtype(result, DataType::FLOAT32);
+    auto logical = as_float.to_vector<float>();
+    ASSERT_EQ(logical.size(), data.size());
+    for (size_t i = 0; i < data.size(); ++i) {
+        EXPECT_NEAR(logical[i], data[i], 1.0f);
+    }
+}
+
+TEST(HostTensorToTensorSpec, BfpSourceStaging) {
+    const Shape shape{32, 32};
+    auto data = make_ramp<float>(shape.volume());
+    auto tile = Tile({16, 16});
+    auto bfp_spec = make_tile_spec(shape, DataType::BFLOAT8_B, tile);
+    auto dest_spec = make_rm_spec(shape, DataType::FLOAT32);
+
+    auto source = HostTensor::from_vector(data, bfp_spec);
+    auto result = to_tensor_spec<float>(source, dest_spec);
+    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), dest_spec));
+
+    auto logical = result.to_vector<float>();
+    ASSERT_EQ(logical.size(), data.size());
+    for (size_t i = 0; i < data.size(); ++i) {
+        EXPECT_NEAR(logical[i], data[i], 1.0f);
+    }
+}
+
+TEST(HostTensorToTensorSpec, FloatPadToIntegralDestRejectsNanInfOor) {
+    const Shape shape{20, 20};
+    auto data = make_ramp<float>(shape.volume());
+    auto src_spec = make_rm_spec(shape, DataType::FLOAT32);
+    auto dest_spec = make_tile_spec(shape, DataType::UINT8, Tile({16, 16}));
+    auto source = HostTensor::from_vector(data, src_spec);
+
+    EXPECT_ANY_THROW(to_tensor_spec<float>(source, dest_spec, std::numeric_limits<float>::quiet_NaN()));
+    EXPECT_ANY_THROW(to_tensor_spec<float>(source, dest_spec, std::numeric_limits<float>::infinity()));
+    EXPECT_ANY_THROW(to_tensor_spec<float>(source, dest_spec, -1.f));
+    EXPECT_ANY_THROW(to_tensor_spec<float>(source, dest_spec, 256.f));
+
+    auto ok = to_tensor_spec<float>(source, dest_spec, 7.f);
+    EXPECT_TRUE(exact_spec_match(ok.tensor_spec(), dest_spec));
+    auto logical = ok.to_vector<uint8_t>();
+    ASSERT_EQ(logical.size(), data.size());
+    for (size_t i = 0; i < data.size(); ++i) {
+        EXPECT_EQ(logical[i], static_cast<uint8_t>(data[i]));
+    }
+
+    // Verify physical padding
+    auto physical = host_buffer::get_as<uint8_t>(ok);
+    // Physical shape is 32x32.
+    // Index (31, 31) in tile layout is at the end.
+    // The padding should be filled with 7.
+    EXPECT_EQ(physical.back(), 7);
+}
+
+TEST(HostTensorToTensorSpec, EqualPaddedDifferentPackingRoundTrip) {
+    // Same logical shape and equal physical 2D size, but different packing (padded RM vs TILE).
+    const Shape shape{20, 20};
+    auto data = make_ramp<float>(shape.volume());
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto rm_spec = TensorSpec(
+        shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, Alignment({16, 16})));
+    auto tile_spec =
+        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, Tile({16, 16})), memory_config));
+
+    EXPECT_EQ(rm_spec.physical_shape(), tile_spec.physical_shape());
+    EXPECT_NE(rm_spec.page_config(), tile_spec.page_config());
+    EXPECT_TRUE(rm_spec.logical_2d_shape() != rm_spec.physical_shape());
+    EXPECT_TRUE(tile_spec.logical_2d_shape() != tile_spec.physical_shape());
+
+    auto source = HostTensor::from_vector(data, rm_spec, /*pad_value=*/3.f);
+    auto tiled = to_tensor_spec<float>(source, tile_spec, /*pad_value=*/5.f);
+    EXPECT_TRUE(exact_spec_match(tiled.tensor_spec(), tile_spec));
+    EXPECT_EQ(tiled.to_vector<float>(), data);
+
+    // Check physical pad of tiled
+    auto tiled_physical = host_buffer::get_as<float>(tiled);
+    EXPECT_EQ(tiled_physical.back(), 5.f);
+
+    auto back = to_tensor_spec<float>(tiled, rm_spec, /*pad_value=*/9.f);
+    EXPECT_TRUE(exact_spec_match(back.tensor_spec(), rm_spec));
+    EXPECT_EQ(back.to_vector<float>(), data);
+
+    // Check physical pad of back
+    auto back_physical = host_buffer::get_as<float>(back);
+    // RM layout, shape 20x20, physical 32x32.
+    // Index (31, 31) is 31 * 32 + 31.
+    EXPECT_EQ(back_physical[31 * 32 + 31], 9.f);
+}
+
+TEST(HostTensorToTensorSpec, Rank0Unsupported) {
+    // Rank-0 shape: empty dimensions vector.
+    Shape rank0_shape(ttsl::SmallVector<uint32_t>{});
+    EXPECT_EQ(rank0_shape.rank(), 0);
+
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto spec = TensorSpec(rank0_shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
+
+    auto dist_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 1));
+    dist_buffer.emplace_shard(distributed::MeshCoordinate(0, 0), [&]() { return HostBuffer(std::vector<float>{}); });
+    auto tensor = HostTensor::from_buffer(std::move(dist_buffer), spec, TensorTopology{});
+
+    // Dest with different packing metadata forces a rewrite attempt (not early-out).
+    auto dest = TensorSpec(
+        rank0_shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, Tile({32, 32})), memory_config));
+    EXPECT_ANY_THROW(to_tensor_spec<float>(tensor, dest));
+}
+
+TEST(HostTensorToTensorSpec, ExactMatchFp8Fatal) {
+    const Shape shape{16, 16};
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto fp8_spec = TensorSpec(shape, TensorLayout(DataType::FP8_E4M3, PageConfig(Layout::ROW_MAJOR), memory_config));
+
+    std::vector<float8_e4m3> fp8_data(shape.volume());
+    for (size_t i = 0; i < fp8_data.size(); ++i) {
+        fp8_data[i] = float8_e4m3(static_cast<float>(i % 16));
+    }
+    auto dist_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 1));
+    dist_buffer.emplace_shard(
+        distributed::MeshCoordinate(0, 0), [&]() { return HostBuffer(std::vector<float8_e4m3>(fp8_data)); });
+    auto fp8_tensor = HostTensor::from_buffer(std::move(dist_buffer), fp8_spec, TensorTopology{});
+
+    // Exact match FP8 should still fatal
+    EXPECT_ANY_THROW(to_tensor_spec<float>(fp8_tensor, fp8_spec));
+}
+
+TEST(HostTensorToTensorSpec, ExactMatchRank0Fatal) {
+    Shape rank0_shape(ttsl::SmallVector<uint32_t>{});
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto spec = TensorSpec(rank0_shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
+
+    auto dist_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 1));
+    dist_buffer.emplace_shard(distributed::MeshCoordinate(0, 0), [&]() { return HostBuffer(std::vector<float>{}); });
+    auto tensor = HostTensor::from_buffer(std::move(dist_buffer), spec, TensorTopology{});
+
+    // Exact match rank-0 should still fatal
+    EXPECT_ANY_THROW(to_tensor_spec<float>(tensor, spec));
+}
+
+TEST(HostTensorToTensorSpec, ExactMatchBfpWrongTFatal) {
+    const Shape shape{32, 32};
+    auto data = make_ramp<float>(shape.volume());
+    auto spec = make_tile_spec(shape, DataType::BFLOAT8_B, Tile({16, 16}));
+
+    auto source = HostTensor::from_vector(data, spec);
+
+    // Exact match but wrong T (not float) should still fatal
+    EXPECT_ANY_THROW(to_tensor_spec<bfloat16>(source, spec, bfloat16(0.f)));
+}
+
+TEST(HostTensorToTensorSpec, TypedIntegralPadBoundaries) {
+    const Shape shape{20, 20};
+    auto data = make_ramp<uint32_t>(shape.volume());
+    auto src_spec = make_rm_spec(shape, DataType::UINT32);
+    auto dest_spec = make_tile_spec(shape, DataType::UINT32, Tile({16, 16}));
+
+    auto source = HostTensor::from_vector(data, src_spec);
+
+    // Min boundary
+    auto min_pad = std::numeric_limits<uint32_t>::lowest();
+    auto result_min = to_tensor_spec<uint32_t>(source, dest_spec, min_pad);
+    EXPECT_TRUE(exact_spec_match(result_min.tensor_spec(), dest_spec));
+    auto physical_min = host_buffer::get_as<uint32_t>(result_min);
+    EXPECT_EQ(physical_min.back(), min_pad);
+
+    // Max boundary
+    auto max_pad = std::numeric_limits<uint32_t>::max();
+    auto result_max = to_tensor_spec<uint32_t>(source, dest_spec, max_pad);
+    EXPECT_TRUE(exact_spec_match(result_max.tensor_spec(), dest_spec));
+    auto physical_max = host_buffer::get_as<uint32_t>(result_max);
+    EXPECT_EQ(physical_max.back(), max_pad);
+}
+
+}  // namespace
+}  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/experimental/tensor/tensor_apis.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/tensor_apis.hpp
@@ -145,6 +145,14 @@ HostTensor unpad_from_tile(const HostTensor& input_tensor, const Shape& output_t
 
 HostTensor to_dtype(const HostTensor& input_tensor, DataType dtype);
 
+// Same convention as HostTensor::from_vector: no default T; pad_value defaults to 0.
+// T is the logical encode / pad element type.
+// Unlike from_vector (T deduced from the buffer), callers must supply T explicitly
+// (to_tensor_spec<float>(t, spec)) or pass a typed pad_value for deduction.
+// Explicit instantiations: float, bfloat16, int32_t, uint32_t, uint16_t, uint8_t (same as from_vector).
+template <typename T>
+HostTensor to_tensor_spec(const HostTensor& tensor, const TensorSpec& dest_spec, T pad_value = 0);
+
 // ======================================================================================
 //                                  Utility functions
 // ======================================================================================

--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -3,16 +3,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <algorithm>
+#include <cmath>
 #include <cstring>
 #include <functional>
+#include <limits>
 #include <string_view>
+#include <type_traits>
 #include <unordered_set>
 
 #include "host_tensor_impl.hpp"
 #include "mesh_tensor_impl.hpp"
 
+#include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/experimental/tensor/tensor_apis.hpp>
 #include <tt-metalium/experimental/tensor/impl/tensor_impl.hpp>
+#include <tt-metalium/experimental/tensor/tensor_types.hpp>
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/math.hpp>
@@ -22,6 +27,7 @@
 #include <tt_stl/concepts.hpp>
 #include <tt_stl/reflection.hpp>
 #include <tt_stl/small_vector.hpp>
+#include <tt_stl/span.hpp>
 
 namespace tt::tt_metal {
 
@@ -1397,6 +1403,157 @@ HostTensor to_dtype(const HostTensor& input_tensor, DataType dtype) {
 
     return HostTensor::from_buffer(std::move(result_buffer), output_spec, input_tensor.tensor_topology());
 }
+
+// ======================================================================================
+//                                  .to_tensor_spec()
+// ======================================================================================
+
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+
+bool exact_spec_match(const TensorSpec& a, const TensorSpec& b) {
+    return a == b && experimental::per_core_allocation::is_per_core_allocation(a.memory_config()) ==
+                         experimental::per_core_allocation::is_per_core_allocation(b.memory_config());
+}
+
+bool is_bfp_dtype(DataType dtype) { return dtype == DataType::BFLOAT8_B || dtype == DataType::BFLOAT4_B; }
+
+bool is_integral_dtype(DataType dtype) {
+    return dtype == DataType::UINT8 || dtype == DataType::UINT16 || dtype == DataType::UINT32 ||
+           dtype == DataType::INT32;
+}
+
+template <typename DestInt, typename PadT>
+void validate_float_pad_against_integral(PadT pad_value) {
+    const double pad_as_double = static_cast<double>(static_cast<float>(pad_value));
+    TT_FATAL(
+        std::isfinite(pad_as_double),
+        "to_tensor_spec: floating pad_value must be finite when destination dtype is integral (got {})",
+        pad_as_double);
+    const double lo = static_cast<double>(std::numeric_limits<DestInt>::lowest());
+    const double hi = static_cast<double>(std::numeric_limits<DestInt>::max());
+    TT_FATAL(
+        pad_as_double >= lo && pad_as_double <= hi,
+        "to_tensor_spec: floating pad_value {} is out of range for integral destination [{}, {}]",
+        pad_as_double,
+        lo,
+        hi);
+}
+
+template <typename PadT>
+void validate_pad_for_integral_dest(PadT pad_value, DataType dest_dtype) {
+    if constexpr (!(std::is_same_v<PadT, float> || std::is_same_v<PadT, bfloat16>)) {
+        return;
+    }
+    switch (dest_dtype) {
+        case DataType::UINT8: validate_float_pad_against_integral<uint8_t>(pad_value); break;
+        case DataType::UINT16: validate_float_pad_against_integral<uint16_t>(pad_value); break;
+        case DataType::UINT32: validate_float_pad_against_integral<uint32_t>(pad_value); break;
+        case DataType::INT32: validate_float_pad_against_integral<int32_t>(pad_value); break;
+        default: break;
+    }
+}
+
+void assert_packed_shard_sizes(const DistributedHostBuffer& buffer, const TensorSpec& spec) {
+    const size_t expected_shard_size = spec.compute_packed_buffer_size_bytes();
+    for (const auto& coord : buffer.shard_coords()) {
+        auto shard = buffer.get_shard(coord);
+        if (shard) {
+            TT_FATAL(
+                shard->view_bytes().size() == expected_shard_size,
+                "to_tensor_spec shard size mismatch: actual {} != expected {}",
+                shard->view_bytes().size(),
+                expected_shard_size);
+        }
+    }
+}
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
+
+template <typename T>
+HostTensor to_tensor_spec(const HostTensor& tensor, const TensorSpec& dest_spec, T pad_value) {
+    TT_FATAL(
+        tensor.logical_shape().rank() > 0,
+        "to_tensor_spec: rank-0 tensors are unsupported (got rank {})",
+        tensor.logical_shape().rank());
+    TT_FATAL(
+        tensor.logical_shape() == dest_spec.logical_shape(),
+        "to_tensor_spec: logical shapes must match (src {}, dest {})",
+        tensor.logical_shape(),
+        dest_spec.logical_shape());
+    TT_FATAL(
+        tensor.dtype() != DataType::FP8_E4M3 && dest_spec.data_type() != DataType::FP8_E4M3,
+        "to_tensor_spec: FP8_E4M3 source/destination is unsupported in v1");
+
+    const bool bfp_src = CMAKE_UNIQUE_NAMESPACE::is_bfp_dtype(tensor.dtype());
+    const bool bfp_dst = CMAKE_UNIQUE_NAMESPACE::is_bfp_dtype(dest_spec.data_type());
+    const DataType working_encode_dtype = (bfp_src || bfp_dst) ? DataType::FLOAT32 : tensor.dtype();
+    const auto pad_dtype = convert_to_data_type<T>();
+    TT_FATAL(
+        pad_dtype == working_encode_dtype,
+        "to_tensor_spec: pad/encode type {} must match working encode dtype {} "
+        "(BFP paths require float; otherwise T must match the post-decode source dtype)",
+        pad_dtype,
+        working_encode_dtype);
+
+    if (CMAKE_UNIQUE_NAMESPACE::exact_spec_match(tensor.tensor_spec(), dest_spec)) {
+        return tensor;
+    }
+
+    HostTensor source_for_decode = tensor;
+    if (working_encode_dtype == DataType::FLOAT32 && tensor.dtype() != DataType::FLOAT32) {
+        // Mandatory BFP staging (and BFP-dest float pivot): convert to FLOAT32 before decode.
+        source_for_decode = to_dtype(tensor, DataType::FLOAT32);
+    }
+
+    const TensorSpec& decode_spec = source_for_decode.tensor_spec();
+    const TensorSpec working_spec(
+        dest_spec.logical_shape(),
+        TensorLayout(
+            working_encode_dtype,
+            dest_spec.page_config(),
+            dest_spec.memory_config(),
+            dest_spec.tensor_layout().get_alignment()));
+
+    // If floating pad will land in padded regions that a later integral to_dtype casts, reject bad pads first.
+    if (CMAKE_UNIQUE_NAMESPACE::is_integral_dtype(dest_spec.data_type()) &&
+        working_spec.logical_2d_shape() != working_spec.physical_shape()) {
+        CMAKE_UNIQUE_NAMESPACE::validate_pad_for_integral_dest(pad_value, dest_spec.data_type());
+    }
+
+    auto transformed_buffer = source_for_decode.buffer().transform(
+        [&](const HostBuffer& buffer) {
+            auto physical = buffer.view_as<const T>();
+            auto logical = tensor_impl::decode_tensor_data(physical, decode_spec);
+            auto encoded = tensor_impl::encode_tensor_data(ttsl::make_const_span(logical), working_spec, pad_value);
+            return HostBuffer(std::move(encoded));
+        },
+        DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
+
+    CMAKE_UNIQUE_NAMESPACE::assert_packed_shard_sizes(transformed_buffer, working_spec);
+
+    HostTensor result = HostTensor::from_buffer(std::move(transformed_buffer), working_spec, tensor.tensor_topology());
+
+    if (result.dtype() != dest_spec.data_type()) {
+        result = to_dtype(result, dest_spec.data_type());
+    }
+
+    TT_FATAL(
+        CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), dest_spec),
+        "to_tensor_spec: result does not satisfy exact-spec predicate against dest_spec");
+    CMAKE_UNIQUE_NAMESPACE::assert_packed_shard_sizes(result.buffer(), dest_spec);
+    TT_FATAL(result.tensor_topology() == tensor.tensor_topology(), "to_tensor_spec: topology must be preserved");
+
+    return result;
+}
+
+template HostTensor to_tensor_spec<float>(const HostTensor&, const TensorSpec&, float);
+template HostTensor to_tensor_spec<bfloat16>(const HostTensor&, const TensorSpec&, bfloat16);
+template HostTensor to_tensor_spec<int32_t>(const HostTensor&, const TensorSpec&, int32_t);
+template HostTensor to_tensor_spec<uint32_t>(const HostTensor&, const TensorSpec&, uint32_t);
+template HostTensor to_tensor_spec<uint16_t>(const HostTensor&, const TensorSpec&, uint16_t);
+template HostTensor to_tensor_spec<uint8_t>(const HostTensor&, const TensorSpec&, uint8_t);
 
 // ======================================================================================
 //                                  Utility functions


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Feature

### Summary
There is currently no host-side API to rewrite a `HostTensor` to a new `TensorSpec`, so sharding / packing metadata on host tensors cannot be updated on host side post construction. 

This adds `to_tensor_spec<T>`, and reuses the exiting infrastructure when possible (`to_dtype`, `to_row_major/tile_layout`).

### Notes for reviewers
- **Tests:** `test_host_tensor_to_tensor_spec.cpp` (sharding / exact-spec / BFP staging / pad oracles); `test_host_tensor_to_dtype.cpp` and ExactSpec updates in `test_vector_conversion.cpp` cover the enabling fixes.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/host-side-to-tensor-spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/host-side-to-tensor-spec)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/host-side-to-tensor-spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/host-side-to-tensor-spec)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=riverwu/host-side-to-tensor-spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:riverwu/host-side-to-tensor-spec)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/host-side-to-tensor-spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/host-side-to-tensor-spec)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/host-side-to-tensor-spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/host-side-to-tensor-spec)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/host-side-to-tensor-spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/host-side-to-tensor-spec)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/host-side-to-tensor-spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/host-side-to-tensor-spec)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/host-side-to-tensor-spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/host-side-to-tensor-spec)