### PR TITLE
Fix data race in multicast inbound_kernel: block until L1 tile lands before cb_push_back

### DIFF
--- a/tt_metal/programming_examples/contributed/multicast/kernels/dataflow/inbound_kernel.cpp
+++ b/tt_metal/programming_examples/contributed/multicast/kernels/dataflow/inbound_kernel.cpp
@@ -4,19 +4,33 @@
 
 #include "api/debug/dprint.h"  // required in all kernels using DPRINT
 #include "api/dataflow/dataflow_api.h"
+#include "ckernel.h"  // ckernel::load_blocking
 
 // Helper function to copy a tile from one CB to another CB (eg. input CB to output CB) via L1.
+//
+// The copy is *blocking*: it does not return until the tile has been committed to L1. This is
+// required because the caller follows this with cb_push_back(), which writes a credit to a STREAM
+// register in a different memory region. Per MemoryOrdering.md, a store then a store to a *different*
+// region has no processing-order guarantee, so that credit could become visible to the consuming
+// RISC before these L1 tile stores land — letting it NoC-read stale L1.
+//
+// To close that window we ckernel::load_blocking() the LAST written word: every store above targets
+// one L1 region, and same-region stores are "processed in order", so once the last word's store is
+// processed all earlier ones already are. load_blocking issues a same-address load and stalls the
+// pipeline (dependent instruction + memory clobber) until the read-response arrives — so cb_push_back
+// cannot emit its credit store until the whole tile is committed to L1.
 inline void copy_tile_between_cb(uint32_t src_addr, uint32_t dst_addr, uint32_t bytes) {
     volatile tt_l1_ptr uint32_t* src = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(src_addr);
     volatile tt_l1_ptr uint32_t* dst = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dst_addr);
-    for (uint32_t i = 0; i < bytes / sizeof(uint32_t); i++) {
+    const uint32_t num_words = bytes / sizeof(uint32_t);
+    for (uint32_t i = 0; i < num_words; i++) {
         dst[i] = src[i];
     }
+    (void)ckernel::load_blocking(&dst[num_words - 1]);
 }
 
 // Ensure this is set: export TT_METAL_DPRINT_CORES='(0,0)-(3,0)'
 void kernel_main() {
-
     ////////// RUNTIME ARGS & VARS //////////
     uint32_t start_x = get_arg_val<uint32_t>(0);
     uint32_t start_y = get_arg_val<uint32_t>(1);
@@ -24,7 +38,7 @@ void kernel_main() {
     uint32_t receiver_addr = get_semaphore(get_arg_val<uint32_t>(3));
 
     ////////// BUFFER SETUP //////////
-    constexpr uint32_t cb_id_in0 = tt::CB::c_in0; // index=0
+    constexpr uint32_t cb_id_in0 = tt::CB::c_in0;    // index=0
     constexpr uint32_t cb_id_out0 = tt::CB::c_out0;  // index=16
     uint32_t ublock_size_bytes = get_tile_size(cb_id_in0);
     uint32_t l1_addr_in = get_write_ptr(cb_id_in0);
@@ -46,7 +60,8 @@ void kernel_main() {
     // At this stage, the receiver cores should have now received the tile.
 
     ////////// PRINT TILE (8-ELEMENT-STRIDED TILE SLICE) //////////
-    SliceRange sr = SliceRange{.h0 = static_cast<uint8_t>(0), .h1 = static_cast<uint8_t>(32), .hs = 8, .w0 = 0, .w1 = 32, .ws = 8};
+    SliceRange sr =
+        SliceRange{.h0 = static_cast<uint8_t>(0), .h1 = static_cast<uint8_t>(32), .hs = 8, .w0 = 0, .w1 = 32, .ws = 8};
     DPRINT("Tile slice:\n{}\n", TileSlice(cb_id_in0, 0, sr, TSLICE_INPUT_CB, TSLICE_WR_PTR, true, false));
 
     ////////// PRINT TILE (FULL TILE) //////////

--- a/tt_metal/programming_examples/contributed/multicast/kernels/dataflow/inbound_kernel.cpp
+++ b/tt_metal/programming_examples/contributed/multicast/kernels/dataflow/inbound_kernel.cpp
@@ -6,19 +6,11 @@
 #include "api/dataflow/dataflow_api.h"
 #include "ckernel.h"  // ckernel::load_blocking
 
-// Helper function to copy a tile from one CB to another CB (eg. input CB to output CB) via L1.
-//
-// The copy is *blocking*: it does not return until the tile has been committed to L1. This is
-// required because the caller follows this with cb_push_back(), which writes a credit to a STREAM
-// register in a different memory region. Per MemoryOrdering.md, a store then a store to a *different*
-// region has no processing-order guarantee, so that credit could become visible to the consuming
-// RISC before these L1 tile stores land — letting it NoC-read stale L1.
-//
-// To close that window we ckernel::load_blocking() the LAST written word: every store above targets
-// one L1 region, and same-region stores are "processed in order", so once the last word's store is
-// processed all earlier ones already are. load_blocking issues a same-address load and stalls the
-// pipeline (dependent instruction + memory clobber) until the read-response arrives — so cb_push_back
-// cannot emit its credit store until the whole tile is committed to L1.
+// Copy a tile from one CB to another via L1, blocking until the tile has landed in L1.
+// The caller's cb_push_back() writes a credit to a STREAM register (a different memory region, so no
+// store-ordering guarantee vs these L1 stores); without the drain the consumer could see that credit
+// and NoC-read stale L1. load_blocking on the last written word stalls until it lands, and since
+// same-region stores are processed in order, draining the last drains all.
 inline void copy_tile_between_cb(uint32_t src_addr, uint32_t dst_addr, uint32_t bytes) {
     volatile tt_l1_ptr uint32_t* src = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(src_addr);
     volatile tt_l1_ptr uint32_t* dst = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dst_addr);


### PR DESCRIPTION
### Problem
The multicast programming example's inbound kernel (BRISC) fills `cb_out0` with a plain RISC store loop (`copy_tile_between_cb`, ~512 `sw` stores to L1), then calls `cb_push_back(cb_id_out0, 1)`, which increments a credit in a **STREAM register** — a different memory region from L1. The outbound kernel (NCRISC) then `cb_wait_front(cb_out0)`s and NoC-reads that L1 buffer.

Per the WormholeB0 BabyRISCV memory model (`WormholeB0/TensixTile/BabyRISCV/MemoryOrdering.md`), a store then a store **to a different region** has no processing-order guarantee: the credit store can be processed before the tile stores land, letting the consumer NoC-read stale/garbage L1.

### Fix
Make the copy blocking. After the store loop, issue a blocking load (`lw` + a dependent `and` that consumes the result) of the **last** written word before `cb_push_back`:

- Same-region L1 stores are *"processed in order"*, so the last word's store completing implies all earlier ones have.
- The dependent consume stalls the pipeline until the load's read-response arrives ("Enforcing stronger ordering" in `MemoryOrdering.md`), so `cb_push_back` cannot emit its credit until the whole tile is committed to L1.

The blocking-load mechanism and the "load only the last word" optimization are both grounded in `MemoryOrdering.md` (quoted in the code comments).

> Note: this finding was audited on Wormhole B0 (#50154); the baby-RISCV store / NoC memory-ordering it relies on holds identically on Blackhole, where the verification below was run.

## Verification (Blackhole p150b)
- Ran the `multicast` example end-to-end (kernel JIT-compiled fresh): all 3 receiver tiles match the golden tile (`[PASS] All 3 receiver tiles match the golden tile`), exit 0.

Closes #50182. Sub-issue of #50154 (finding #1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/fix-multicast-inbound-cb-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/fix-multicast-inbound-cb-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/fix-multicast-inbound-cb-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/fix-multicast-inbound-cb-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/fix-multicast-inbound-cb-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/fix-multicast-inbound-cb-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/fix-multicast-inbound-cb-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/fix-multicast-inbound-cb-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/fix-multicast-inbound-cb-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/fix-multicast-inbound-cb-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/fix-multicast-inbound-cb-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/fix-multicast-inbound-cb-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/fix-multicast-inbound-cb-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/fix-multicast-inbound-cb-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/fix-multicast-inbound-cb-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/fix-multicast-inbound-cb-race)


