### PR TITLE
examples: add split_reader RISC-V issue scaling example

### DIFF
--- a/tests/ttnn/unit_tests/operations/examples/test_split_reader.py
+++ b/tests/ttnn/unit_tests/operations/examples/test_split_reader.py
@@ -1,0 +1,148 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Correctness and on-device performance tests for the split-reader example."""
+
+import os
+
+# The profiler must be enabled before the device fixture opens the device.
+os.environ.setdefault("TT_METAL_DEVICE_PROFILER", "1")
+os.environ.setdefault("TT_METAL_PROFILER_MID_RUN_DUMP", "1")
+os.environ.setdefault("TT_METAL_PROFILER_CPP_POST_PROCESS", "1")
+
+from loguru import logger
+import pytest
+import torch
+
+import ttnn
+from ttnn.operations.examples.split_reader import make_row_sharded_memory_config, row_gather_copy
+
+TILE = 32
+TILE_BYTES = TILE * TILE * 2
+NUM_CORES = int(os.environ.get("SR_CORES", "8"))
+TILES_PER_CORE = int(os.environ.get("SR_TILES_PER_CORE", "8"))
+BLOCK_TILES = int(os.environ.get("SR_BLOCK_TILES", "8"))
+TRANSACTION_BYTES = int(os.environ.get("SR_TRANSACTION_BYTES", "64"))
+PERF_TRANSACTION_BYTES = [
+    int(value) for value in os.environ.get("SR_TRANSACTION_BYTES_LIST", str(TRANSACTION_BYTES)).split(",")
+]
+N_WARMUP = 5
+N_PROFILE_ITERS = int(os.environ.get("SR_ITERS", "20"))
+_DURATION_KEYS = {
+    "device": "DEVICE KERNEL DURATION [ns]",
+    "brisc": "DEVICE BRISC KERNEL DURATION [ns]",
+    "ncrisc": "DEVICE NCRISC KERNEL DURATION [ns]",
+}
+
+
+def _make_input(device):
+    torch.manual_seed(0)
+    shape = (NUM_CORES * TILES_PER_CORE * TILE, TILE)
+    torch_input = torch.rand(shape, dtype=torch.float32)
+    memory_config = make_row_sharded_memory_config(shape, NUM_CORES)
+    tt_input = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=memory_config,
+    )
+    return torch_input, tt_input
+
+
+def _expected(torch_input):
+    return torch_input.to(torch.bfloat16).to(torch.float32)
+
+
+def _read_kernel_metrics(device):
+    ttnn.ReadDeviceProfiler(device)
+    per_chip = ttnn.get_latest_programs_perf_data()
+    totals = {name: 0.0 for name in _DURATION_KEYS}
+    found = {name: False for name in _DURATION_KEYS}
+    for programs in (per_chip or {}).values():
+        for program in programs:
+            results = getattr(program, "program_analyses_results", None) or {}
+            for name, profiler_key in _DURATION_KEYS.items():
+                entry = results.get(profiler_key)
+                if entry is not None:
+                    totals[name] += float(entry.duration)
+                    found[name] = True
+    return {name: totals[name] if found[name] else None for name in _DURATION_KEYS}
+
+
+def _measure_kernel_metrics(device, run_fn):
+    for _ in range(N_WARMUP):
+        run_fn()
+    ttnn.synchronize_device(device)
+    _read_kernel_metrics(device)
+    for _ in range(N_PROFILE_ITERS):
+        run_fn()
+    totals = _read_kernel_metrics(device)
+    return {name: value / N_PROFILE_ITERS if value is not None else None for name, value in totals.items()}
+
+
+@pytest.mark.parametrize("transaction_bytes", [32, 64, 256, 2048], ids=lambda value: f"tx{value}")
+@pytest.mark.parametrize("enabled", [False, True], ids=["off", "on"])
+def test_split_reader_correctness(device, enabled, transaction_bytes):
+    torch_input, tt_input = _make_input(device)
+    expected = _expected(torch_input)
+    tt_output = row_gather_copy(
+        tt_input,
+        split_reader=enabled,
+        num_cores=NUM_CORES,
+        block_tiles=BLOCK_TILES,
+        transaction_bytes=transaction_bytes,
+    )
+    assert tt_output.memory_config().buffer_type == ttnn.BufferType.DRAM
+    output = ttnn.to_torch(tt_output).to(torch.float32)
+
+    assert list(output.shape) == list(expected.shape)
+    assert torch.equal(expected, output)
+
+
+def test_split_reader_device_perf(device):
+    """Report RISC-V kernel lifetimes and end-to-end time; correctness is tested above."""
+    _, tt_input = _make_input(device)
+
+    results = {}
+    for transaction_bytes in PERF_TRANSACTION_BYTES:
+        metrics = {}
+        for enabled in (False, True):
+            run_fn = lambda value=enabled, tx=transaction_bytes: row_gather_copy(
+                tt_input,
+                split_reader=value,
+                num_cores=NUM_CORES,
+                block_tiles=BLOCK_TILES,
+                transaction_bytes=tx,
+            )
+            value = _measure_kernel_metrics(device, run_fn)
+            assert all(
+                metric is not None for metric in value.values()
+            ), "profiler produced incomplete data (is the build profiler-enabled?)"
+            metrics[enabled] = value
+        results[transaction_bytes] = metrics
+
+    num_blocks = NUM_CORES * TILES_PER_CORE // BLOCK_TILES
+    arch = os.environ.get("ARCH_NAME", "unknown")
+    lines = [
+        "",
+        "=== split_reader RISC-V issue scaling (row-sharded L1 gather -> DRAM copy) ===",
+        f"    cores={NUM_CORES}  tiles/source={TILES_PER_CORE}  block={BLOCK_TILES} tiles  "
+        f"blocks={num_blocks}  arch={arch}",
+        "    Per-RISC columns are kernel lifetimes, including NoC barriers and CB waits.",
+        f"    {'transaction':>12}  {'NoC reads':>9}  {'off NCRISC':>11}  {'on NCRISC':>10}  "
+        f"{'on BRISC':>9}  {'off device':>10}  {'on device':>9}  {'speedup':>8}",
+    ]
+    total_tiles = NUM_CORES * TILES_PER_CORE
+    for transaction_bytes, metrics in results.items():
+        reads_per_tile = TILE_BYTES // transaction_bytes
+        reads_per_launch = total_tiles * reads_per_tile
+        off = metrics[False]
+        on = metrics[True]
+        speedup = off["device"] / on["device"]
+        lines.append(
+            f"    {transaction_bytes:>9} B  {reads_per_launch:>9}  {off['ncrisc']:>11.1f}  "
+            f"{on['ncrisc']:>10.1f}  {on['brisc']:>9.1f}  {off['device']:>10.1f}  "
+            f"{on['device']:>9.1f}  {speedup:>7.2f}x"
+        )
+    logger.info("\n".join(lines))

--- a/ttnn/ttnn/operations/examples/master.md
+++ b/ttnn/ttnn/operations/examples/master.md
@@ -53,6 +53,20 @@ on this move faster than, writing it as 4 × 512 B faces — bigger coalesced tr
 achieved DRAM bandwidth. Reader on NoC0, writer on NoC1 to overlap.
 **Gist:** on a DRAM-bound move, move whole pages and batch barriers; don't scatter sub-tile faces.
 
+## ⭐⭐ T2 — [`split_reader`](split_reader/README.md)
+**Concept:** when a *single* data-movement RISC-V is the bottleneck — saturated **issuing** NoC read
+transactions — split those independent reads across both data-movement RISC-Vs (NCRISC + BRISC) so
+the issue work runs in parallel.
+**Situation:** you have measured that one reader RISC-V is issue-bound: it is on the critical path
+and its time goes to issuing NoC commands. The reads divide into independent ranges and the other
+data-movement RISC-V has spare capacity.
+**Does NOT solve:** this is *not* a general "make reads faster" trick — it does nothing unless a
+data-movement RISC-V is itself the bottleneck. First confirm you are RISC-V-issue-bound.
+**Gist:** split the disjoint reads across NCRISC and BRISC, preserving the second RISC-V's existing
+role. The example shrinks the NoC transaction size only to *create* that bottleneck and expose the
+effect (up to ~1.7×, Wormhole B0; see [`report.md`](split_reader/report.md)) — transaction size is
+the knob, not the point.
+
 ## ⭐⭐ T2 — [`matmul_output_subblock`](matmul_output_subblock/README.md)
 **Concept:** matmul output-subblock shape → SRC-register operand reuse (via the `matmul_block` helper).
 **Situation:** you wrote a tiled matmul that produces **one output tile per block-matmul** (a `1×1` subblock), so every output tile re-loads both its A and B operand into the SRC registers; you wonder whether a bigger output subblock is worth it.

--- a/ttnn/ttnn/operations/examples/split_reader/README.md
+++ b/ttnn/ttnn/operations/examples/split_reader/README.md
@@ -1,0 +1,100 @@
+# split_reader
+
+![One consumer core gathers an L1 tensor sharded across a source row and writes the identical tensor to DRAM.](split_reader.svg)
+
+**Trick:** when a *single* data-movement RISC-V is the bottleneck because it is saturated **issuing**
+NoC read transactions, split those independent reads between NCRISC and BRISC so the issue work runs
+in parallel. In this example the existing BRISC writer also reads half of each block before writing
+the unchanged tensor to DRAM.
+
+Consider this pattern once you have measured that one reader RISC-V is issue-bound — it is on the
+critical path and its time goes to issuing NoC commands — the reads partition without changing data
+dependencies or order, and the other data-movement RISC-V has spare capacity. It is *not* a general
+"make reads faster" trick: it does nothing unless a data-movement RISC-V is itself the bottleneck,
+so confirm you are RISC-V-issue-bound first. Small transactions, row-sharded L1 input, and the
+copy-only workload are just what make that bottleneck easy to create and isolate here.
+
+**Op:** `row_gather_copy(input, split_reader=False|True, num_cores=N, block_tiles=B,
+transaction_bytes=T)` — one consumer core gathers a tensor height-sharded across an L1 source row
+and copies it to DRAM with the same shape, values, and tile order.
+
+## Data path
+
+Sources are logical cores `(0,0)..(N-1,0)` and the only consumer is `(0,1)`. With the default
+`block_tiles=8`, every streaming block is handled as follows:
+
+```text
+row-sharded L1 block: [t0 t1 t2 t3 | t4 t5 t6 t7]
+
+split off:
+  NCRISC reads t0..t7 -> CB0/CB1
+  BRISC writes        -> DRAM [t0 t1 t2 t3 t4 t5 t6 t7]
+
+split on:
+  NCRISC reads t0..t3 -> CB0
+  BRISC  reads t4..t7 -> CB1
+  BRISC writes        -> DRAM [t0 t1 t2 t3 t4 t5 t6 t7]
+```
+
+The blocks only bound buffering and assign read work. They do not transform the output. There is
+no shuffle, interleave, accumulation, or Tensix compute kernel.
+
+## RISC-V bottleneck signal
+
+`transaction_bytes` is the knob this example uses to *manufacture* a RISC-V-issue bottleneck — it is
+not the point of the optimization. It controls how many NoC reads reconstruct each 2 KiB tile, and
+must be a multiple of 16 and divide 2,048. At the default 64 B, 8 source cores with 8 tiles each
+issue:
+
+```text
+64 gathered tiles * 32 transactions/tile = 2,048 NoC reads/launch
+```
+
+The transferred bytes never change. Smaller transactions increase the number of NoC commands that
+NCRISC must issue. The primary signal is therefore the NCRISC kernel lifetime: it grows as the read
+count grows even though the payload is fixed. Once that RISC-V becomes the bottleneck, split mode
+lets BRISC issue half of those reads concurrently. Larger transactions remove most of that RISC-V
+issue work, so the fixed writer and data-transfer work dominate and the split-reader gain shrinks.
+Both modes read the same tensor and perform the same original-order DRAM writes.
+
+## Measured result
+
+Wormhole B0, 8 source cores, 8 tiles/source, 8 tiles/block, 5 warmup + 20 timed launches per point:
+
+```text
+ transaction  NoC reads   off NCRISC   on NCRISC   on BRISC  off device  on device   speedup
+       32 B       4096     146303.2     74854.8    84739.8    147427.2    84767.1     1.74x
+       64 B       2048      82415.9     43319.5    50895.2     83488.8    50925.7     1.64x
+      128 B       1024      50434.9     29264.6    34809.9     51507.7    34837.6     1.48x
+      256 B        512      34802.6     21928.8    26396.8     35836.3    26434.4     1.36x
+      512 B        256      27276.9     18553.7    22523.0     28317.8    22563.5     1.26x
+     1024 B        128      24350.0     17314.9    21121.6     25385.4    21163.8     1.20x
+     2048 B         64      24051.2     17008.3    20740.8     25085.1    20787.0     1.21x
+```
+
+All times are ns/op. `off NCRISC` is the direct signal for the single-RISC read bottleneck: it
+rises from 24.1 us to 146.3 us as the read count for the same 128 KiB payload grows from 64 to 4,096.
+At 4,096 reads, split mode distributes that work across NCRISC and BRISC and reduces device time
+from 147.4 us to 84.8 us. Per-RISC profiler values are kernel lifetimes, so they include NoC
+barriers and CB waits rather than representing instruction-level utilization.
+
+See [`report.md`](report.md) for the measurement stamp.
+
+## Run it
+
+```bash
+python -m ttnn.operations.examples.split_reader \
+  --cores 8 --tiles-per-core 8 --block-tiles 8 \
+  --transaction-bytes 32 64 128 256 512 1024 2048 --iters 20
+```
+
+Pass one transaction size for a single comparison or several for a sweep. `--block-tiles` must be
+even, at least four, and divide the total gathered tile count.
+
+```bash
+scripts/run_safe_pytest.sh --run-all \
+  tests/ttnn/unit_tests/operations/examples/test_split_reader.py::test_split_reader_correctness
+
+scripts/run_safe_pytest.sh --run-all \
+  tests/ttnn/unit_tests/operations/examples/test_split_reader.py::test_split_reader_device_perf
+```

--- a/ttnn/ttnn/operations/examples/split_reader/__init__.py
+++ b/ttnn/ttnn/operations/examples/split_reader/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from .split_reader import make_row_sharded_memory_config, row_gather_copy, SPLIT_READER_MODES
+
+__all__ = ["make_row_sharded_memory_config", "row_gather_copy", "SPLIT_READER_MODES"]

--- a/ttnn/ttnn/operations/examples/split_reader/__main__.py
+++ b/ttnn/ttnn/operations/examples/split_reader/__main__.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CLI for the split-reader off/on device-performance comparison."""
+
+import argparse
+import os
+import subprocess
+import sys
+
+_TEST = "tests/ttnn/unit_tests/operations/examples/test_split_reader.py::test_split_reader_device_perf"
+
+
+def main():
+    parser = argparse.ArgumentParser(prog="python -m ttnn.operations.examples.split_reader")
+    parser.add_argument("--cores", type=int, default=8, help="source shards in the top row (default: 8)")
+    parser.add_argument(
+        "--tiles-per-core", type=int, default=8, help="L1 source tiles owned by each worker (default: 8)"
+    )
+    parser.add_argument(
+        "--block-tiles", type=int, default=8, help="input tiles assigned per streaming block (default: 8)"
+    )
+    parser.add_argument(
+        "--transaction-bytes",
+        type=int,
+        nargs="+",
+        default=[64],
+        help="one or more NoC read sizes to compare (default: 64)",
+    )
+    parser.add_argument("--iters", type=int, default=20, help="profiled launches per variant (default: 20)")
+    args = parser.parse_args()
+
+    env = dict(
+        os.environ,
+        SR_CORES=str(args.cores),
+        SR_TILES_PER_CORE=str(args.tiles_per_core),
+        SR_BLOCK_TILES=str(args.block_tiles),
+        SR_TRANSACTION_BYTES_LIST=",".join(str(value) for value in args.transaction_bytes),
+        SR_ITERS=str(args.iters),
+    )
+    cmd = ["scripts/run_safe_pytest.sh", "--run-all", _TEST]
+    print(
+        f"[split_reader] cores={args.cores} tiles_per_core={args.tiles_per_core} block_tiles={args.block_tiles} "
+        f"transaction_bytes={args.transaction_bytes} iters={args.iters}"
+    )
+    print(f"[split_reader] {' '.join(cmd)}")
+    return subprocess.call(cmd, env=env)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ttnn/ttnn/operations/examples/split_reader/kernels/gather_reader.cpp
+++ b/ttnn/ttnn/operations/examples/split_reader/kernels/gather_reader.cpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// One or both halves of every block in a streaming row gather-copy.
+//
+// A tile is reconstructed with a configurable number of NoC reads. The payload
+// is always 2 KiB, but smaller transactions create the data-movement RISC-V
+// issue bottleneck that split readers address.
+
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    constexpr uint32_t cb_gather_0 = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_gather_1 = get_compile_time_arg_val(1);
+    constexpr uint32_t tiles_per_source = get_compile_time_arg_val(2);
+    constexpr uint32_t tile_bytes = get_compile_time_arg_val(3);
+    constexpr uint32_t transaction_bytes = get_compile_time_arg_val(4);
+    constexpr uint32_t num_cores = get_compile_time_arg_val(5);
+    constexpr uint32_t block_tiles = get_compile_time_arg_val(6);
+    constexpr uint32_t num_blocks = get_compile_time_arg_val(7);
+    constexpr uint32_t half_begin = get_compile_time_arg_val(8);
+    constexpr uint32_t num_halves = get_compile_time_arg_val(9);
+    constexpr uint32_t half_block_tiles = block_tiles / 2;
+    constexpr uint32_t transactions_per_tile = tile_bytes / transaction_bytes;
+
+    const uint32_t source_l1_base = get_arg_val<uint32_t>(0);
+    const tt_l1_ptr uint32_t* noc_x = reinterpret_cast<const tt_l1_ptr uint32_t*>(get_arg_addr(1));
+    const tt_l1_ptr uint32_t* noc_y = reinterpret_cast<const tt_l1_ptr uint32_t*>(get_arg_addr(1 + num_cores));
+
+    for (uint32_t block = 0; block < num_blocks; ++block) {
+        for (uint32_t half = half_begin; half < half_begin + num_halves; ++half) {
+            const uint32_t cb_gather = half == 0 ? cb_gather_0 : cb_gather_1;
+            const uint32_t half_start = block * block_tiles + half * half_block_tiles;
+
+            for (uint32_t i = 0; i < half_block_tiles; ++i) {
+                const uint32_t global_tile = half_start + i;
+                const uint32_t source = global_tile / tiles_per_source;
+                const uint32_t source_tile = global_tile % tiles_per_source;
+
+                cb_reserve_back(cb_gather, 1);
+                const uint32_t dst = get_write_ptr(cb_gather);
+                const uint32_t src = source_l1_base + source_tile * tile_bytes;
+
+                for (uint32_t transaction = 0; transaction < transactions_per_tile; ++transaction) {
+                    const uint32_t offset = transaction * transaction_bytes;
+                    noc_async_read(
+                        get_noc_addr(noc_x[source], noc_y[source], src + offset), dst + offset, transaction_bytes);
+                }
+                noc_async_read_barrier();
+                cb_push_back(cb_gather, 1);
+            }
+        }
+    }
+}

--- a/ttnn/ttnn/operations/examples/split_reader/kernels/gather_writer.cpp
+++ b/ttnn/ttnn/operations/examples/split_reader/kernels/gather_writer.cpp
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// BRISC / NoC1 writes the gathered tiles to DRAM in their original order. In
+// split-reader mode it also gathers the second half of each block from the
+// row-sharded L1 input. There is no transform or Tensix compute stage.
+
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    constexpr uint32_t cb_gather_0 = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_gather_1 = get_compile_time_arg_val(1);
+    constexpr uint32_t tiles_per_source = get_compile_time_arg_val(2);
+    constexpr uint32_t tile_bytes = get_compile_time_arg_val(3);
+    constexpr uint32_t transaction_bytes = get_compile_time_arg_val(4);
+    constexpr uint32_t num_cores = get_compile_time_arg_val(5);
+    constexpr uint32_t block_tiles = get_compile_time_arg_val(6);
+    constexpr uint32_t num_blocks = get_compile_time_arg_val(7);
+    constexpr bool split_reader = get_compile_time_arg_val(8) != 0;
+    constexpr auto out_args = TensorAccessorArgs<9>();
+    constexpr uint32_t half_block_tiles = block_tiles / 2;
+    constexpr uint32_t transactions_per_tile = tile_bytes / transaction_bytes;
+
+    const uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    const uint32_t source_l1_base = get_arg_val<uint32_t>(1);
+    const tt_l1_ptr uint32_t* noc_x = reinterpret_cast<const tt_l1_ptr uint32_t*>(get_arg_addr(2));
+    const tt_l1_ptr uint32_t* noc_y = reinterpret_cast<const tt_l1_ptr uint32_t*>(get_arg_addr(2 + num_cores));
+
+    const auto out_acc = TensorAccessor(out_args, dst_addr, tile_bytes);
+
+    for (uint32_t block = 0; block < num_blocks; ++block) {
+        if constexpr (split_reader) {
+            const uint32_t half_start = block * block_tiles + half_block_tiles;
+            for (uint32_t i = 0; i < half_block_tiles; ++i) {
+                const uint32_t global_tile = half_start + i;
+                const uint32_t source = global_tile / tiles_per_source;
+                const uint32_t source_tile = global_tile % tiles_per_source;
+
+                cb_reserve_back(cb_gather_1, 1);
+                const uint32_t l1_write_addr = get_write_ptr(cb_gather_1);
+                const uint32_t src = source_l1_base + source_tile * tile_bytes;
+                for (uint32_t transaction = 0; transaction < transactions_per_tile; ++transaction) {
+                    const uint32_t offset = transaction * transaction_bytes;
+                    noc_async_read(
+                        get_noc_addr(noc_x[source], noc_y[source], src + offset),
+                        l1_write_addr + offset,
+                        transaction_bytes);
+                }
+                noc_async_read_barrier();
+                cb_push_back(cb_gather_1, 1);
+            }
+        }
+
+        cb_wait_front(cb_gather_0, half_block_tiles);
+        cb_wait_front(cb_gather_1, half_block_tiles);
+        const uint32_t first_half_l1 = get_read_ptr(cb_gather_0);
+        const uint32_t second_half_l1 = get_read_ptr(cb_gather_1);
+        const uint32_t output_block_start = block * block_tiles;
+        for (uint32_t i = 0; i < half_block_tiles; ++i) {
+            noc_async_write(first_half_l1 + i * tile_bytes, out_acc.get_noc_addr(output_block_start + i), tile_bytes);
+            noc_async_write(
+                second_half_l1 + i * tile_bytes,
+                out_acc.get_noc_addr(output_block_start + half_block_tiles + i),
+                tile_bytes);
+        }
+        noc_async_writes_flushed();
+        cb_pop_front(cb_gather_0, half_block_tiles);
+        cb_pop_front(cb_gather_1, half_block_tiles);
+    }
+    noc_async_write_barrier();
+}

--- a/ttnn/ttnn/operations/examples/split_reader/report.md
+++ b/ttnn/ttnn/operations/examples/split_reader/report.md
@@ -1,0 +1,64 @@
+# split_reader — measured report
+
+| stamp | value |
+|---|---|
+| box | `bgd-lab-08-special-astancov-for-reservation-44672` |
+| arch | Wormhole B0 (8×8 compute grid) |
+| base commit | `89089ffd11e` |
+| date | 2026-07-16 |
+| metrics | `DEVICE KERNEL DURATION`, `DEVICE NCRISC KERNEL DURATION`, and `DEVICE BRISC KERNEL DURATION` in ns, read in-process with `ttnn.ReadDeviceProfiler` + `ttnn.get_latest_programs_perf_data` |
+| method | 5 warmup + 20 timed launches per variant and transaction size, flush-bracketed, on-device duration averaged; all points in one device session |
+
+> Numbers are illustrative of the effect, not a CI bound. Re-run the CLI on the target architecture
+> and workload. Add results from another architecture as a new block rather than replacing this one.
+
+## Config A — 8 source cores, 8 tiles/source, 8 tiles/block, transaction-size sweep
+
+The input is height-sharded in L1 across logical source row `(0,0)..(7,0)`. Consumer `(0,1)`
+gathers all 64 tiles and BRISC copies them to DRAM in their original order. Split-off puts all
+reads on NCRISC. Split-on gives the first four tiles of every block to NCRISC and the second four
+to BRISC. Blocks affect only read scheduling and bounded buffering; the DRAM tensor equals the
+input exactly and no compute kernel runs.
+
+Depending on transaction size, the consumer issues 64–4,096 reads to transfer the same 128 KiB
+from row L1 into its two gather CBs, then writes the same 128 KiB to DRAM in both modes.
+
+```text
+ transaction  NoC reads   off NCRISC   on NCRISC   on BRISC  off device  on device   speedup
+       32 B       4096     146303.2     74854.8    84739.8    147427.2    84767.1     1.74x
+       64 B       2048      82415.9     43319.5    50895.2     83488.8    50925.7     1.64x
+      128 B       1024      50434.9     29264.6    34809.9     51507.7    34837.6     1.48x
+      256 B        512      34802.6     21928.8    26396.8     35836.3    26434.4     1.36x
+      512 B        256      27276.9     18553.7    22523.0     28317.8    22563.5     1.26x
+     1024 B        128      24350.0     17314.9    21121.6     25385.4    21163.8     1.20x
+     2048 B         64      24051.2     17008.3    20740.8     25085.1    20787.0     1.21x
+```
+
+All duration columns are ns/op. The per-RISC columns are profiler kernel lifetimes and include NoC
+barriers and CB waits; they are not instruction-level utilization counters. `on BRISC` also
+includes the unchanged DRAM writer work.
+
+## Findings
+
+- With split off, NCRISC time rises from **24.1 us** at 64 reads to **146.3 us** at 4,096 reads.
+  This is the main signal: more commands add RISC-V issue work while transferred bytes stay fixed.
+- At 4,096 reads the single NCRISC is the device bottleneck. Split mode moves half of the read
+  workload to BRISC: NCRISC finishes in **74.9 us**, BRISC in **84.7 us**, and device time improves
+  from **147.4 us** to **84.8 us** (**1.74×**).
+- The gain falls to about **1.20×** at 1–2 KiB transactions, where RISC-V issue overhead is no
+  longer the dominant fraction of runtime.
+- Both modes pass exact equality against the bf16 input tensor.
+- Source placement, consumer placement, CB capacity, input reads, DRAM writes, and output order
+  are identical between modes; only the RISC-V assignment of second-half reads changes.
+- BRISC always writes the output. Split-on additionally uses it to gather half of each block while
+  NCRISC gathers the other half.
+
+## Reproduce
+
+```bash
+python -m ttnn.operations.examples.split_reader \
+  --cores 8 --tiles-per-core 8 --block-tiles 8 \
+  --transaction-bytes 32 64 128 256 512 1024 2048 --iters 20
+```
+
+Performance remains reported evidence, not a test assertion.

--- a/ttnn/ttnn/operations/examples/split_reader/split_reader.py
+++ b/ttnn/ttnn/operations/examples/split_reader/split_reader.py
@@ -1,0 +1,250 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dual-RISC-V split-reader example for a small-transaction row gather-copy.
+
+Each core in the top row owns a height-sharded L1 slice. One consumer core below
+the row streams the tiles in their original order, deliberately reconstructing
+each 2 KiB tile with a configurable number of NoC reads. Its BRISC writes the
+same tensor to DRAM, so the operation stays entirely on that core's
+data-movement processors.
+
+``split_reader=False`` puts every read transaction on the normal reader
+(RISCV_1, NoC0), while BRISC writes the gathered tiles to DRAM. With
+``split_reader=True``, BRISC still writes the results but also gathers the
+second half of every block on NoC1. The input, block boundaries, DRAM writes,
+and output are otherwise identical.
+"""
+
+from pathlib import Path
+
+import ttnn
+
+KERNEL_DIR = Path(__file__).parent / "kernels"
+
+TILE = 32
+TILE_BYTES = TILE * TILE * 2
+DEFAULT_TRANSACTION_BYTES = TILE * 2  # 64 B: 32 independently issued transactions per tile
+
+CB_GATHER_0 = 0
+CB_GATHER_1 = 1
+
+SPLIT_READER_MODES = (False, True)
+
+
+def _row_cores(num_cores):
+    return ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_cores - 1, 0))])
+
+
+def _single_core(x, y):
+    core = ttnn.CoreCoord(x, y)
+    return ttnn.CoreRangeSet([ttnn.CoreRange(core, core)])
+
+
+def make_row_sharded_memory_config(shape, num_cores):
+    """Height-shard ``shape`` over logical cores ``(0,0)..(N-1,0)`` in L1."""
+    h, w = list(shape)
+    if h % num_cores:
+        raise ValueError(f"split_reader example: height {h} must divide evenly over {num_cores} cores")
+    return ttnn.create_sharded_memory_config(
+        [h // num_cores, w],
+        core_grid=_row_cores(num_cores),
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+
+def _validate(input_tensor, num_cores, block_tiles, transaction_bytes):
+    shape = list(input_tensor.shape)
+    if len(shape) != 2:
+        raise ValueError(f"split_reader example: rank must be 2, got {len(shape)}")
+    if input_tensor.layout != ttnn.TILE_LAYOUT:
+        raise ValueError("split_reader example: input must be TILE_LAYOUT")
+    if input_tensor.dtype != ttnn.bfloat16:
+        raise ValueError("split_reader example: input must be bfloat16")
+    if num_cores < 2:
+        raise ValueError(f"split_reader example: num_cores must be >= 2, got {num_cores}")
+    if block_tiles < 4 or block_tiles % 2:
+        raise ValueError(f"split_reader example: block_tiles must be even and >= 4, got {block_tiles}")
+    if transaction_bytes < 16 or transaction_bytes > TILE_BYTES or transaction_bytes % 16:
+        raise ValueError(
+            f"split_reader example: transaction_bytes must be a multiple of 16 in [16, {TILE_BYTES}], "
+            f"got {transaction_bytes}"
+        )
+    if TILE_BYTES % transaction_bytes:
+        raise ValueError(
+            f"split_reader example: transaction_bytes={transaction_bytes} must divide tile size {TILE_BYTES}"
+        )
+
+    grid = input_tensor.device().compute_with_storage_grid_size()
+    if num_cores > grid.x:
+        raise ValueError(
+            f"split_reader example: num_cores={num_cores} does not fit in the {grid.x}-core-wide worker row"
+        )
+    if grid.y < 2:
+        raise ValueError("split_reader example: a consumer core below the source row is required")
+
+    h, w = shape
+    if w != TILE or h % (num_cores * TILE):
+        raise ValueError(
+            "split_reader example: expected shape [num_cores * tiles_per_core * 32, 32], "
+            f"got {shape} for num_cores={num_cores}"
+        )
+    total_tiles = h // TILE
+    if total_tiles % block_tiles:
+        raise ValueError(f"split_reader example: total tiles {total_tiles} must divide into block_tiles={block_tiles}")
+    if total_tiles // block_tiles < 2:
+        raise ValueError("split_reader example: the input must contain at least two streaming blocks")
+
+    memory_config = input_tensor.memory_config()
+    expected_grid = _row_cores(num_cores)
+    if not memory_config.is_sharded() or memory_config.memory_layout != ttnn.TensorMemoryLayout.HEIGHT_SHARDED:
+        raise ValueError("split_reader example: input must be height-sharded in L1")
+    if memory_config.buffer_type != ttnn.BufferType.L1:
+        raise ValueError("split_reader example: input shards must be in L1")
+    if memory_config.shard_spec.grid != expected_grid:
+        raise ValueError("split_reader example: input shard grid must be the top source row (0,0)..(N-1,0)")
+    expected_shard_shape = [h // num_cores, w]
+    if list(memory_config.shard_spec.shape) != expected_shard_shape:
+        raise ValueError(
+            f"split_reader example: expected per-core shard shape {expected_shard_shape}, "
+            f"got {list(memory_config.shard_spec.shape)}"
+        )
+
+
+def _create_program_descriptor(input_tensor, output_tensor, *, split_reader, num_cores, block_tiles, transaction_bytes):
+    device = input_tensor.device()
+    consumer_core = _single_core(0, 1)
+    tiles_per_source = list(input_tensor.shape)[0] // (num_cores * TILE)
+    total_tiles = num_cores * tiles_per_source
+    num_blocks = total_tiles // block_tiles
+    half_block_tiles = block_tiles // 2
+
+    # Two blocks deep permits reader/writer overlap. Both modes use the same
+    # CBs: the baseline's one reader fills both, while split mode assigns one CB
+    # (one half of every block) to each data-movement RISC-V.
+    gather_cbs = [
+        ttnn.CBDescriptor(
+            total_size=2 * half_block_tiles * TILE_BYTES,
+            core_ranges=consumer_core,
+            format_descriptors=[
+                ttnn.CBFormatDescriptor(buffer_index=cb_id, data_format=ttnn.bfloat16, page_size=TILE_BYTES)
+            ],
+        )
+        for cb_id in (CB_GATHER_0, CB_GATHER_1)
+    ]
+    # Tensor shards have one common L1 base address. Readers receive the virtual
+    # NoC coordinates for each logical source core and select the remote shard by
+    # coordinate, exactly as sharded transpose/all-gather kernels do.
+    physical_cores = [device.worker_core_from_logical_core(ttnn.CoreCoord(x, 0)) for x in range(num_cores)]
+    noc_x = [core.x for core in physical_cores]
+    noc_y = [core.y for core in physical_cores]
+
+    def make_reader(num_halves):
+        compile_args = [
+            CB_GATHER_0,
+            CB_GATHER_1,
+            tiles_per_source,
+            TILE_BYTES,
+            transaction_bytes,
+            num_cores,
+            block_tiles,
+            num_blocks,
+            0,
+            num_halves,
+        ]
+        runtime_args = ttnn.RuntimeArgs()
+        runtime_args[0][1] = [input_tensor.buffer_address(), *noc_x, *noc_y]
+        return ttnn.KernelDescriptor(
+            kernel_source=str(KERNEL_DIR / "gather_reader.cpp"),
+            core_ranges=consumer_core,
+            compile_time_args=compile_args,
+            runtime_args=runtime_args,
+            config=ttnn.ReaderConfigDescriptor(),
+        )
+
+    reader_kernel = make_reader(1 if split_reader else 2)
+
+    writer_compile_args = [
+        CB_GATHER_0,
+        CB_GATHER_1,
+        tiles_per_source,
+        TILE_BYTES,
+        transaction_bytes,
+        num_cores,
+        block_tiles,
+        num_blocks,
+        int(split_reader),
+    ]
+    writer_compile_args.extend(ttnn.TensorAccessorArgs(output_tensor).get_compile_time_args())
+    writer_runtime_args = ttnn.RuntimeArgs()
+    writer_runtime_args[0][1] = [
+        output_tensor.buffer_address(),
+        input_tensor.buffer_address(),
+        *noc_x,
+        *noc_y,
+    ]
+    writer_kernel = ttnn.KernelDescriptor(
+        kernel_source=str(KERNEL_DIR / "gather_writer.cpp"),
+        core_ranges=consumer_core,
+        compile_time_args=writer_compile_args,
+        runtime_args=writer_runtime_args,
+        config=ttnn.WriterConfigDescriptor(),
+    )
+
+    return ttnn.ProgramDescriptor(
+        kernels=[reader_kernel, writer_kernel],
+        semaphores=[],
+        cbs=gather_cbs,
+    )
+
+
+def row_gather_copy(
+    input_tensor: ttnn.Tensor,
+    *,
+    split_reader: bool = True,
+    num_cores: int = 8,
+    block_tiles: int = 8,
+    transaction_bytes: int = DEFAULT_TRANSACTION_BYTES,
+):
+    """Gather top-row L1 shards into an identical DRAM tensor.
+
+    One consumer core receives the row's sequence and preserves its tile order.
+    Split mode additionally gives BRISC the second-half reads in every streaming
+    block; the DRAM writes are identical in both modes and no Tensix compute
+    kernel is used.
+
+    Args:
+        split_reader: False has NCRISC fill both block halves while BRISC only
+            writes output. True has NCRISC fill the first half and BRISC gather
+            the second half before writing that block to DRAM.
+        num_cores: Number of source shards in the top logical row.
+        block_tiles: Even number of input tiles consumed per streaming iteration;
+            must be at least four and divide the total gathered tile count.
+        transaction_bytes: Bytes issued by each NoC read. Must be a multiple of
+            16 and divide a 2 KiB tile. Smaller values issue more transactions.
+    """
+    if split_reader not in SPLIT_READER_MODES:
+        raise ValueError(f"split_reader example: split_reader must be bool, got {split_reader!r}")
+    _validate(input_tensor, num_cores, block_tiles, transaction_bytes)
+
+    device = input_tensor.device()
+    total_tiles = list(input_tensor.shape)[0] // TILE
+    output_shape = [total_tiles * TILE, TILE]
+    output_tensor = ttnn.allocate_tensor_on_device(
+        ttnn.Shape(output_shape),
+        ttnn.bfloat16,
+        ttnn.TILE_LAYOUT,
+        device,
+        ttnn.DRAM_MEMORY_CONFIG,
+    )
+    descriptor = _create_program_descriptor(
+        input_tensor,
+        output_tensor,
+        split_reader=split_reader,
+        num_cores=num_cores,
+        block_tiles=block_tiles,
+        transaction_bytes=transaction_bytes,
+    )
+    return ttnn.generic_op([input_tensor, output_tensor], descriptor)

--- a/ttnn/ttnn/operations/examples/split_reader/split_reader.svg
+++ b/ttnn/ttnn/operations/examples/split_reader/split_reader.svg
@@ -1,0 +1,73 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="410" viewBox="0 0 960 410" role="img" aria-labelledby="title desc">
+  <title id="title">Split-reader gather-copy</title>
+  <desc id="desc">One consumer core gathers a tensor from row-sharded L1. Its NCRISC reads the first half of each block, its BRISC reads the second half, and BRISC writes the original tensor to DRAM.</desc>
+  <defs>
+    <marker id="arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" fill="#475569"/>
+    </marker>
+    <style>
+      .title { font: 700 18px sans-serif; fill: #0f172a; }
+      .label { font: 600 13px sans-serif; fill: #0f172a; }
+      .small { font: 12px sans-serif; fill: #334155; }
+      .tiny { font: 11px sans-serif; fill: #475569; }
+      .box { stroke-width: 1.5; rx: 8; }
+      .arrow { stroke: #475569; stroke-width: 1.8; fill: none; marker-end: url(#arrow); }
+    </style>
+  </defs>
+
+  <rect width="960" height="410" rx="12" fill="#f8fafc" stroke="#cbd5e1"/>
+  <text x="480" y="28" text-anchor="middle" class="title">One consumer core gathers row-sharded L1 to DRAM</text>
+
+  <text x="34" y="60" class="label">Row L1 shards</text>
+  <g fill="#e2e8f0" stroke="#94a3b8" class="box">
+    <rect x="150" y="42" width="72" height="34"/><rect x="230" y="42" width="72" height="34"/>
+    <rect x="310" y="42" width="72" height="34"/><rect x="390" y="42" width="72" height="34"/>
+    <rect x="470" y="42" width="72" height="34"/><rect x="550" y="42" width="72" height="34"/>
+    <rect x="630" y="42" width="72" height="34"/><rect x="710" y="42" width="72" height="34"/>
+  </g>
+  <g text-anchor="middle" class="small">
+    <text x="186" y="64">core 0</text><text x="266" y="64">core 1</text>
+    <text x="346" y="64">core 2</text><text x="426" y="64">core 3</text>
+    <text x="506" y="64">core 4</text><text x="586" y="64">core 5</text>
+    <text x="666" y="64">core 6</text><text x="746" y="64">core 7</text>
+  </g>
+  <text x="806" y="63" class="tiny">one consumer gathers all</text>
+
+  <path d="M470 78 V104" class="arrow"/>
+  <text x="34" y="126" class="label">Input block</text>
+  <rect x="150" y="104" width="316" height="42" rx="7" fill="#dbeafe" stroke="#3b82f6" stroke-width="1.5"/>
+  <rect x="466" y="104" width="316" height="42" rx="7" fill="#ffedd5" stroke="#f97316" stroke-width="1.5"/>
+  <text x="308" y="130" text-anchor="middle" class="label">first half: t0  t1  t2  t3</text>
+  <text x="624" y="130" text-anchor="middle" class="label">second half: t4  t5  t6  t7</text>
+
+  <path d="M308 148 V177" class="arrow"/>
+  <path d="M624 148 V177" class="arrow"/>
+  <rect x="198" y="178" width="220" height="50" class="box" fill="#bfdbfe" stroke="#2563eb"/>
+  <rect x="514" y="178" width="220" height="50" class="box" fill="#fed7aa" stroke="#ea580c"/>
+  <text x="308" y="199" text-anchor="middle" class="label">NCRISC / NoC0</text>
+  <text x="308" y="216" text-anchor="middle" class="small">2 KiB / transaction_bytes reads</text>
+  <text x="624" y="199" text-anchor="middle" class="label">BRISC / NoC1</text>
+  <text x="624" y="216" text-anchor="middle" class="small">second-half reads + writer</text>
+
+  <path d="M308 228 V252" class="arrow"/>
+  <path d="M624 228 V252" class="arrow"/>
+  <rect x="238" y="253" width="140" height="40" class="box" fill="#dbeafe" stroke="#2563eb"/>
+  <rect x="554" y="253" width="140" height="40" class="box" fill="#ffedd5" stroke="#ea580c"/>
+  <text x="308" y="278" text-anchor="middle" class="label">CB0: t0..t3</text>
+  <text x="624" y="278" text-anchor="middle" class="label">CB1: t4..t7</text>
+
+  <path d="M308 293 L410 316" class="arrow"/>
+  <path d="M624 293 L522 316" class="arrow"/>
+  <rect x="410" y="298" width="252" height="58" class="box" fill="#fef3c7" stroke="#d97706"/>
+  <text x="536" y="320" text-anchor="middle" class="label">BRISC DRAM writer</text>
+  <text x="536" y="338" text-anchor="middle" class="small">preserve order: t0, t1, t2, t3, t4, t5, t6, t7</text>
+
+  <path d="M662 327 H812" class="arrow"/>
+  <rect x="812" y="298" width="126" height="58" class="box" fill="#ede9fe" stroke="#7c3aed"/>
+  <text x="875" y="321" text-anchor="middle" class="label">DRAM output</text>
+  <text x="875" y="339" text-anchor="middle" class="tiny">all 8 tiles</text>
+
+  <rect x="24" y="366" width="912" height="1" fill="#cbd5e1"/>
+  <text x="480" y="384" text-anchor="middle" class="small">Small transactions -> many RISC-V-issued NoC reads -> NCRISC bottleneck.</text>
+  <text x="480" y="401" text-anchor="middle" class="small">Split ON shares those reads with BRISC; Split OFF makes NCRISC fill both CBs.</text>
+</svg>


### PR DESCRIPTION
# [Performance] Add runnable split-reader RISC-V scaling example

### PR Category

Performance

### Summary

Adds a self-contained TTNN performance example demonstrating the split-reader pattern: partitioning independent input reads across NCRISC and BRISC so both data-movement RISC-Vs and NoCs can make progress concurrently.

The example implements:

```python
row_gather_copy(
    input,
    split_reader=False | True,
    num_cores=N,
    block_tiles=B,
    transaction_bytes=T,
)
```

A consumer core gathers a height-sharded L1 tensor from a source row and writes an identical tensor to DRAM. There is no data transformation or Tensix compute—the two modes differ only in which RISC-V issues the reads:

- Split off: NCRISC reads both halves of each block; BRISC writes the result.
- Split on: NCRISC reads the first half while BRISC reads the second half, then BRISC writes the result.

The general use case is a core whose input-read path is on the critical path, where the reads can be partitioned safely and the second data-movement RISC-V has enough capacity alongside its existing responsibilities. The small-transaction gather-copy used here is a controlled workload for exposing that tradeoff, not a requirement of the optimization.

### Changes

- Adds the `ttnn.operations.examples.split_reader` example operation.
- Adds paired NCRISC and BRISC data-movement kernels.
- Uses two double-buffered circular buffers to preserve block ordering while the readers operate concurrently.
- Adds a configurable NoC transaction size so command-issue work can be varied while holding transferred bytes constant.
- Adds a CLI for split-off/on performance sweeps.
- Adds exact-output correctness and per-RISC device-performance tests.
- Adds a diagram, measured report, and entry in the performance-example catalog.

### Performance

Measured on Wormhole B0 with 8 source cores, 8 tiles per source, 8 tiles per block, 5 warmups, and 20 timed launches:

| Transaction | NoC reads | Split off | Split on | Speedup |
|---:|---:|---:|---:|---:|
| 32 B | 4,096 | 147.4 µs | 84.8 µs | 1.74× |
| 64 B | 2,048 | 83.5 µs | 50.9 µs | 1.64× |
| 128 B | 1,024 | 51.5 µs | 34.8 µs | 1.48× |
| 256 B | 512 | 35.8 µs | 26.4 µs | 1.36× |
| 512 B | 256 | 28.3 µs | 22.6 µs | 1.26× |
| 1,024 B | 128 | 25.4 µs | 21.2 µs | 1.20× |
| 2,048 B | 64 | 25.1 µs | 20.8 µs | 1.21× |

With payload and transaction count fixed, varying the source distribution from `2 × 32` to `8 × 8` tiles produced essentially the same 1.64–1.65× speedup. Block granularity had a larger effect: 4-tile blocks achieved 1.54×, while 16–32-tile blocks achieved 1.72–1.75× because they incurred less synchronization overhead.

The reported numbers are illustrative rather than CI bounds. Split-reader remains workload-dependent: BRISC's existing work, synchronization, and shared NoC or memory bottlenecks can reduce or eliminate the benefit.

### Tests

```bash
scripts/run_safe_pytest.sh --run-all \
  tests/ttnn/unit_tests/operations/examples/test_split_reader.py::test_split_reader_correctness

scripts/run_safe_pytest.sh --run-all \
  tests/ttnn/unit_tests/operations/examples/test_split_reader.py::test_split_reader_device_perf
```

- Correctness: 8/8 split-off/on and transaction-size cases passed with exact equality.
- Device performance test passed.
- Additional core-distribution and block-size configurations passed.

### Notes for reviewers

This PR adds an isolated example and does not change an existing production operation or public TTNN API.

The main review points are:

- Work partitioning and preservation of tile order between the two readers.
- Circular-buffer sizing and synchronization between the readers and BRISC writer.
- Interpretation of per-RISC profiler values: they are kernel lifetimes including NoC barriers and CB waits, not instruction-utilization counters.
- The distinction between the general split-reader applicability criteria and the specific small-transaction workload used to demonstrate them.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=astancov/llk_helper_library_split_reader_example)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:astancov/llk_helper_library_split_reader_example)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=astancov/llk_helper_library_split_reader_example)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:astancov/llk_helper_library_split_reader_example)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=astancov/llk_helper_library_split_reader_example)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:astancov/llk_helper_library_split_reader_example)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=astancov/llk_helper_library_split_reader_example)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:astancov/llk_helper_library_split_reader_example)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=astancov/llk_helper_library_split_reader_example)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:astancov/llk_helper_library_split_reader_example)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=astancov/llk_helper_library_split_reader_example)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:astancov/llk_helper_library_split_reader_example)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=astancov/llk_helper_library_split_reader_example)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:astancov/llk_helper_library_split_reader_example)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=astancov/llk_helper_library_split_reader_example)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:astancov/llk_helper_library_split_reader_example)