### PR TITLE
DeepSeek: Add mixed-format KV cache for sparse MLA

### DIFF
--- a/models/demos/common/prefill/adapter.py
+++ b/models/demos/common/prefill/adapter.py
@@ -69,6 +69,9 @@ class PrefillRunParams:
     weight_cache_path: Optional[Path]
     sp_axis: int = 0
     tp_axis: int = 1
+    # Explicit semantic cache format selected by model/module configuration. Scaled FP8 is a packed
+    # mixed-format row, so it must not be represented or inferred as a bare tensor dtype.
+    sparse_kv_cache_format: Optional[object] = None
 
     @property
     def sp_factor(self) -> int:
@@ -124,6 +127,19 @@ class PrefillModelAdapter(ABC):
     def load_hf_config(self) -> "PretrainedConfig":
         """Load (and normalize) the HF config from PREFILL_HF_MODEL (falling back
         to ``hf_model_default``). The runner sets ``max_seq_len`` on the result."""
+
+    @property
+    def default_sparse_kv_cache_format(self) -> Optional[object]:
+        """Semantic primary-cache format used when the runner builds ``PrefillRunParams``.
+
+        Models with a format choice override this property. Direct module users can instead put
+        an explicit format in ``PrefillRunParams.sparse_kv_cache_format``.
+        """
+        return None
+
+    def resolve_sparse_kv_cache_format(self, requested: Optional[object]) -> Optional[object]:
+        """Return an explicit request, otherwise this adapter's model default."""
+        return self.default_sparse_kv_cache_format if requested is None else requested
 
     @abstractmethod
     def weight_cache_path(self, mesh_shape: tuple) -> Optional[Path]:

--- a/models/demos/common/prefill/runners/prefill_producer.py
+++ b/models/demos/common/prefill/runners/prefill_producer.py
@@ -12,7 +12,7 @@ test suite as ProducerConfig data (see tests/test_producer_runner_e2e.py); this 
 
 After pushing, it drains the runner's per-layer LayerAcks and, if asked, reads the resulting KV cache
 back and PCC-checks it against the golden trace. The KV read (read_dram_umd over a bare UMD cluster)
-and the bfp8 decode are BOTH device-less on purpose: touching a real ttnn device here would take the
+and raw cache decode are BOTH device-less on purpose: touching a real ttnn device here would take the
 CHIP_IN_USE lock the runner already holds, and deadlock.
 
 `run_schedule()` takes injectable seams (push_fn / now_fn / sleep_fn / rng) so the scheduling logic
@@ -95,7 +95,7 @@ def _chunk_to_host_array(chunk_token_ids):
 
 
 # ---------------------------------------------------------------------------
-# Device-less helpers: read the KV table / device map, attach the LayerAck channel, decode bfp8.
+# Device-less helpers: read the KV table / device map, attach the LayerAck channel, decode cache data.
 # All device-less on purpose — none may touch a real ttnn device (that would take the CHIP_IN_USE
 # lock the runner holds and deadlock).
 # ---------------------------------------------------------------------------
@@ -226,34 +226,78 @@ def _decode_bf16_chunk(raw: bytes, head_dim: int) -> torch.Tensor:
     return torch.from_numpy(np.ascontiguousarray(decoded))
 
 
-def _decode_bf16_row_major_chunk(raw: bytes, head_dim: int) -> torch.Tensor:
-    """Decode a ``[32, head_dim]`` bf16 ROW_MAJOR chunk (raw device bytes) to float32, device-less. Unlike
-    ``_decode_bf16_chunk`` there is NO tile de-swizzle: a ROW_MAJOR cache stores 32 tokens x head_dim
-    contiguously, so element (token, dim) is a plain reshape (uint16 -> float32 via a 16-bit left shift,
-    exact). This is the layout the GLM sparse adapter allocates for the uncompressed KVPE cache."""
-    TILE = 32  # tokens per DRAM-bank chunk (NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK)
-    u16 = np.frombuffer(raw, dtype="<u2").reshape(TILE, head_dim)
-    f32 = (u16.astype(np.uint32) << 16).view(np.float32)
-    return torch.from_numpy(np.ascontiguousarray(f32))
+def _decode_row_major_chunk(raw: bytes, head_dim: int, dtype: torch.dtype) -> torch.Tensor:
+    """Decode 32 native row pages, dropping any physical row padding."""
+    element_size = torch.empty((), dtype=dtype).element_size()
+    if len(raw) % _KV_CHUNK_TOKENS != 0:
+        raise ValueError(f"row-major KV chunk has {len(raw)} bytes, not a multiple of {_KV_CHUNK_TOKENS} rows")
+    row_size_bytes = len(raw) // _KV_CHUNK_TOKENS
+    logical_row_size_bytes = head_dim * element_size
+    if row_size_bytes < logical_row_size_bytes:
+        raise ValueError(f"row-major KV row has {row_size_bytes} bytes, smaller than {head_dim} x {element_size} bytes")
+
+    rows = torch.frombuffer(bytearray(raw), dtype=torch.uint8).reshape(_KV_CHUNK_TOKENS, row_size_bytes)
+    logical = rows[:, :logical_row_size_bytes].contiguous()
+    return logical.view(dtype).reshape(_KV_CHUNK_TOKENS, head_dim).float()
 
 
-def _decoder_for_config(table, config_id: int, head_dim: int):
-    """Device-less chunk decoder for one config of the merged MLA table, inferred from its recorded
-    chunk_size_bytes so ONE reader serves GLM, DeepSeek and Kimi:
-      * bf8_b TILE     -> (head_dim / 32) tiles x 1088 B  (dense KVPE on DeepSeek/Kimi, and the index cache)
-      * bf16 ROW_MAJOR -> 32 tokens x head_dim x 2 B      (GLM's uncompressed KVPE)
-    NOTE: chunk_size_bytes alone can't tell bf16 ROW_MAJOR from bf16 TILE (same byte count); in the MLA
-    path the only bf16 cache is GLM's ROW_MAJOR KVPE, so a bf16-sized chunk here always means ROW_MAJOR."""
-    TILE = 32
-    chunk = table.config(config_id).chunk_size_bytes
-    if chunk == (head_dim // TILE) * 1088:
-        return _decode_bfp8_chunk
-    if chunk == TILE * head_dim * 2:
-        return _decode_bf16_row_major_chunk
-    raise ValueError(
-        f"config {config_id}: chunk_size_bytes={chunk} matches neither bf8 TILE "
-        f"({(head_dim // TILE) * 1088}) nor bf16 ROW_MAJOR ({TILE * head_dim * 2}) for head_dim={head_dim}"
+_KV_CHUNK_TOKENS = 32
+_BFP8_TILE_BYTES = 1088
+_SCALED_FP8_LATENT_DIM = 512
+_SCALED_FP8_SCALE_BLOCK = 128
+_SCALED_FP8_NUM_SCALES = _SCALED_FP8_LATENT_DIM // _SCALED_FP8_SCALE_BLOCK
+_SCALED_FP8_ROPE_DIM = 64
+_SCALED_FP8_SCALE_OFFSET = _SCALED_FP8_LATENT_DIM
+_SCALED_FP8_ROPE_OFFSET = _SCALED_FP8_SCALE_OFFSET + _SCALED_FP8_NUM_SCALES * 4
+_SCALED_FP8_ROW_BYTES = _SCALED_FP8_ROPE_OFFSET + _SCALED_FP8_ROPE_DIM * 2
+
+
+def _decode_scaled_fp8_kv_rows(rows: torch.Tensor, head_dim: int) -> torch.Tensor:
+    """Reconstruct ``[scaled latent | RoPE]`` from packed mixed-format row bytes."""
+    if head_dim != _SCALED_FP8_LATENT_DIM + _SCALED_FP8_ROPE_DIM:
+        raise ValueError(f"packed scaled-FP8 KV requires head_dim 576, got {head_dim}")
+
+    latent = rows[:, :_SCALED_FP8_SCALE_OFFSET].contiguous().view(torch.float8_e4m3fn).float()
+    scales = (
+        rows[:, _SCALED_FP8_SCALE_OFFSET:_SCALED_FP8_ROPE_OFFSET]
+        .contiguous()
+        .view(torch.float32)
+        .reshape(_KV_CHUNK_TOKENS, _SCALED_FP8_NUM_SCALES)
     )
+    rope = (
+        rows[:, _SCALED_FP8_ROPE_OFFSET:_SCALED_FP8_ROW_BYTES]
+        .contiguous()
+        .view(torch.bfloat16)
+        .reshape(_KV_CHUNK_TOKENS, _SCALED_FP8_ROPE_DIM)
+        .float()
+    )
+    latent = latent * scales.repeat_interleave(_SCALED_FP8_SCALE_BLOCK, dim=-1)
+    return torch.cat((latent, rope), dim=-1)
+
+
+def _decode_kv_chunk(raw: bytes, head_dim: int) -> torch.Tensor:
+    """Decode one raw 32-token MLA KV chunk by its table-reported physical byte size.
+
+    The deployed 576-wide formats have distinct physical row sizes: tiled bfp8_b, raw row-major
+    fp8_e4m3, packed scaled FP8, and row-major bfloat16. The packed format is reconstructed from its
+    512 E4M3 latent bytes, four FP32 scales, and 64 BF16 RoPE values. Row padding is discarded.
+    """
+    if head_dim % 32 == 0 and len(raw) == (head_dim // 32) * _BFP8_TILE_BYTES:
+        return _decode_bfp8_chunk(raw, head_dim)
+
+    if len(raw) % _KV_CHUNK_TOKENS != 0:
+        raise ValueError(f"unsupported KV chunk size {len(raw)} for head_dim {head_dim}")
+    row_size_bytes = len(raw) // _KV_CHUNK_TOKENS
+    rows = torch.frombuffer(bytearray(raw), dtype=torch.uint8).reshape(_KV_CHUNK_TOKENS, row_size_bytes)
+    if head_dim == 576 and _SCALED_FP8_ROW_BYTES <= row_size_bytes < 2 * head_dim:
+        return _decode_scaled_fp8_kv_rows(rows, head_dim)
+    fp8_fits = row_size_bytes >= head_dim
+    bf16_fits = row_size_bytes >= 2 * head_dim
+    if fp8_fits and not bf16_fits:
+        return _decode_row_major_chunk(raw, head_dim, torch.float8_e4m3fn)
+    if bf16_fits and row_size_bytes == 2 * head_dim:
+        return _decode_row_major_chunk(raw, head_dim, torch.bfloat16)
+    raise ValueError(f"ambiguous or unsupported row-major KV row size {row_size_bytes} bytes for head_dim {head_dim}")
 
 
 def _resolve_unique_id(fabric_node_ids, device_map: dict) -> int:
@@ -433,7 +477,7 @@ def run_schedule(cfg: ProducerConfig, *, push_fn, now_fn=time.perf_counter, slee
 
 
 # ---------------------------------------------------------------------------
-# Per-slot KV read-back + PCC (device-less: read_dram_umd over UMD + pure-numpy bfp8 decode)
+# Per-slot KV read-back + PCC (device-less: read_dram_umd over UMD + host cache decode)
 # ---------------------------------------------------------------------------
 
 
@@ -545,23 +589,15 @@ def _read_slot_kv_and_check_pcc_mla(table, device_map: dict, slot_id: int, real_
     tokens_per_block = NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
     read_len = ((real_len + tokens_per_block - 1) // tokens_per_block) * tokens_per_block  # round up to a block
 
-    # KVPE decoder generalized across models: bf8 TILE on DeepSeek/Kimi (dense), bf16 ROW_MAJOR on GLM
-    # (uncompressed). Picked from the config's recorded chunk size instead of hardcoding a dtype.
-    kvpe_decode = _decoder_for_config(table, 0, HEAD_DIM)
-    logger.info(
-        f"[producer] slot {slot_id} kvpe: decoder={kvpe_decode.__name__} "
-        f"chunk_size_bytes={table.config(0).chunk_size_bytes} HEAD_DIM={HEAD_DIM} NUM_LAYERS={NUM_LAYERS}"
-    )
-
     min_pcc = 1.0
     for layer in range(NUM_LAYERS):
-        # Read this layer's KV block by block over UMD, decode each chunk, concat to [real_len, HEAD_DIM].
+        # Read this layer's KV block by block over UMD, decode its physical cache format, and concat.
         decoded_rows = []
         for pos in range(0, read_len, tokens_per_block):
             loc = table.lookup(layer, pos, slot_id)
             unique_id = _resolve_unique_id(table.get_device_group(loc.device_group_index).fabric_node_ids, device_map)
             raw = ttnn.experimental.disaggregation.read_dram_umd(unique_id, loc.noc_addr, loc.size_bytes)
-            decoded_rows.append(kvpe_decode(raw, HEAD_DIM))
+            decoded_rows.append(_decode_kv_chunk(raw, HEAD_DIM))
         device_kv = torch.cat(decoded_rows, dim=0)[:real_len]  # natural order (table un-rotates block-cyclic)
 
         golden = _load_golden_kv_post(trace_dir, layer, real_len)

--- a/models/demos/common/prefill/runners/prefill_runner.py
+++ b/models/demos/common/prefill/runners/prefill_runner.py
@@ -716,6 +716,7 @@ def main() -> None:
         # this (single-rank inherits it); PREFILL_KV_ONLY_LAST_LAYER can force it off.
         kv_only_last_layer=is_last_rank and KV_ONLY_LAST_LAYER,
         weight_cache_path=ADAPTER.weight_cache_path(GLOBAL_MESH_SHAPE),
+        sparse_kv_cache_format=ADAPTER.default_sparse_kv_cache_format,
     )
 
     runtime = ADAPTER.build_runtime(mesh_device=mesh_device, hf_config=hf_config, params=params)

--- a/models/demos/common/prefill/tests/test_prefill_producer_kv_decode.py
+++ b/models/demos/common/prefill/tests/test_prefill_producer_kv_decode.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+from models.demos.common.prefill.runners.prefill_producer import _decode_kv_chunk
+
+
+@pytest.mark.parametrize("dtype", [torch.float8_e4m3fn, torch.bfloat16], ids=["fp8_e4m3", "bfloat16"])
+def test_decode_row_major_kv_chunk(dtype):
+    head_dim = 576
+    values = torch.linspace(-2, 2, 32 * head_dim, dtype=torch.float32).reshape(32, head_dim).to(dtype)
+    raw = values.view(torch.uint8).numpy().tobytes()
+
+    actual = _decode_kv_chunk(raw, head_dim)
+
+    assert torch.equal(actual, values.float())
+
+
+def test_decode_row_major_fp8_kv_chunk_with_page_padding():
+    head_dim = 33
+    row_size_bytes = 64
+    values = (
+        torch.arange(32 * head_dim, dtype=torch.float32).reshape(32, head_dim).remainder(31).to(torch.float8_e4m3fn)
+    )
+    padded = torch.full((32, row_size_bytes), 0xA5, dtype=torch.uint8)
+    padded[:, :head_dim] = values.view(torch.uint8)
+
+    actual = _decode_kv_chunk(padded.numpy().tobytes(), head_dim)
+
+    assert torch.equal(actual, values.float())
+
+
+def test_decode_packed_scaled_fp8_kv_chunk_with_page_padding():
+    latent = torch.arange(32 * 512, dtype=torch.float32).reshape(32, 512).remainder(31).sub(15).to(torch.float8_e4m3fn)
+    scales = torch.tensor([0.25, 0.5, 1.0, 2.0], dtype=torch.float32).repeat(32, 1)
+    rope = torch.arange(32 * 64, dtype=torch.float32).reshape(32, 64).to(torch.bfloat16)
+    rows = torch.full((32, 672), 0xA5, dtype=torch.uint8)
+    rows[:, :512] = latent.view(torch.uint8)
+    rows[:, 512:528] = scales.view(torch.uint8)
+    rows[:, 528:656] = rope.view(torch.uint8)
+
+    actual = _decode_kv_chunk(rows.numpy().tobytes(), head_dim=576)
+    expected = torch.cat((latent.float() * scales.repeat_interleave(128, dim=-1), rope.float()), dim=-1)
+
+    assert torch.equal(actual, expected)
+
+
+def test_decode_unknown_kv_chunk_rejected(expect_error):
+    with expect_error(ValueError, "unsupported"):
+        _decode_kv_chunk(bytes(17), head_dim=576)

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_mla_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_mla_cache.py
@@ -13,7 +13,7 @@ from models.common.utility_functions import profiler
 from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker, report_and_clear
-from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
+from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, init_mla_kv_cache
 from tests.ttnn.utils_for_testing import comp_pcc
 
 CACHE_DIR = Path("/tmp/DS_PREFILL_mla")
@@ -111,9 +111,9 @@ def test_mla_weights_cold_warm_cache(mesh_device, device_params, config_only):
     rope_tensors = rope_setup.get_rope_tensors(seq_len)
 
     # Initialize KVPE cache (required by MLA forward)
-    kvpe_cache_head_dim = config.qk_rope_head_dim + config.kv_lora_rank
-    tt_kvpe_cache = init_kvpe_cache(
-        kvpe_cache_head_dim=kvpe_cache_head_dim,
+    tt_kvpe_cache = init_mla_kv_cache(
+        cache_format=MlaKvCacheFormat.BFP8_TILE,
+        hf_config=config,
         mesh_device=mesh_device,
         seq_len=seq_len,
         mesh_shape=mesh_shape,

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_deepseek_prefill_update_padded_kv_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_deepseek_prefill_update_padded_kv_cache.py
@@ -11,13 +11,15 @@ around the boundary write at different offsets so new tokens overwrite the prior
 cache's trailing pad cells before spilling into the next slab.
 """
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 from loguru import logger
 
 import ttnn
 from models.common.utility_functions import is_blackhole
-from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
+from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, init_kvpe_cache, init_mla_kv_cache
 
 # MLA KVPE head dim (kv_lora_rank=512 + qk_rope_head_dim=64). The op is a pure page copy, so a
 # gathered cache slot must byte-match the input we sent (read back through the same dtype
@@ -57,6 +59,60 @@ def _make_input(torch_chunk, dtype, layout, mesh_device, mesh_mapper):
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
         mesh_mapper=mesh_mapper,
     )
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 1)], ids=["1x1"], indirect=True)
+@pytest.mark.timeout(0)
+def test_update_padded_kv_cache_scaled_fp8_packed_row(mesh_device):
+    """The update op preserves the complete 656-byte mixed-format row as one FP8-typed stream."""
+    if not is_blackhole():
+        pytest.skip("FP8_E4M3 is Blackhole-only")
+
+    head_dim = 656
+    num_users, num_layers = 1, 2
+    cache_tokens = 64
+    chunk_tokens = 32
+    sparse_cache = init_mla_kv_cache(
+        cache_format=MlaKvCacheFormat.SCALED_FP8,
+        hf_config=SimpleNamespace(kv_lora_rank=512, qk_rope_head_dim=64),
+        mesh_device=mesh_device,
+        seq_len=cache_tokens,
+        mesh_shape=list(mesh_device.shape),
+        sp_axis=0,
+        num_kvpe_cache_layers=num_layers,
+        num_users=num_users,
+    )
+    cache = sparse_cache.storage
+
+    torch.manual_seed(17)
+    source = torch.randn(1, 1, chunk_tokens, head_dim, dtype=torch.bfloat16)
+    tt_input = _make_input(
+        source,
+        ttnn.fp8_e4m3,
+        ttnn.ROW_MAJOR_LAYOUT,
+        mesh_device,
+        ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+    expected = ttnn.to_torch(tt_input, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0)).reshape(
+        chunk_tokens, head_dim
+    )
+
+    ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
+        cache,
+        tt_input,
+        slot_idx=0,
+        layer_idx=1,
+        num_layers=num_layers,
+        kv_actual_global=0,
+        cluster_axis=0,
+    )
+    result = ttnn.to_torch(cache, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0)).reshape(
+        num_users * num_layers, 1, cache_tokens, head_dim
+    )
+
+    assert torch.equal(result[1, 0, :chunk_tokens], expected)
+    assert torch.count_nonzero(result[0].float()) == 0
+    assert torch.count_nonzero(result[1, 0, chunk_tokens:].float()) == 0
 
 
 @pytest.mark.parametrize("mesh_device", [(1, 1)], ids=["1x1"], indirect=True)

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_fp8_kv_cache_gather.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_fp8_kv_cache_gather.py
@@ -1,0 +1,162 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused coverage for the FP8 sparse-MLA cache gather pipeline.
+
+The chunked path converts its ND-sharded persistent cache to interleaved DRAM, selects one slot, and
+all-gathers sequence rows over SP before sparse_sdpa. This test validates that exact dtype/layout and
+communication sequence independently of model weights.
+"""
+
+from dataclasses import replace
+
+import pytest
+import torch
+
+import ttnn
+from models.common.utility_functions import is_blackhole
+from models.demos.common.prefill.adapter import PrefillRunParams
+from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import glm_hf_config
+from models.demos.deepseek_v3_d_p.tt.runners.adapters.glm_5_1 import GLM51Adapter
+from models.demos.deepseek_v3_d_p.tt.runners.kv_chunk_table import (
+    _dram_chunk_size_bytes,
+    build_and_serialize_kv_chunk_table,
+)
+from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import PREFILL_CHUNK_OUTPUT_TOKENS, MlaKvCacheFormat
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+@pytest.mark.parametrize("mesh_device", [(2, 4)], ids=["2x4"], indirect=True)
+@pytest.mark.timeout(0)
+def test_fp8_row_major_kv_cache_all_gather(mesh_device, tmp_path):
+    if not is_blackhole():
+        pytest.skip("FP8_E4M3 is Blackhole-only")
+
+    sp_axis = 0
+    mesh_shape = tuple(mesh_device.shape)
+    seq_len = PREFILL_CHUNK_OUTPUT_TOKENS
+    config = glm_hf_config(max_seq=seq_len)
+    head_dim = config.kv_lora_rank + config.qk_rope_head_dim
+    params = PrefillRunParams(
+        mesh_shape=mesh_shape,
+        num_layers=1,
+        first_layer_idx=0,
+        is_first_rank=True,
+        is_last_rank=True,
+        max_seq_len=seq_len,
+        chunk_size=seq_len,
+        num_users=1,
+        capacity_factor=1,
+        num_links=1,
+        gate_mode_name="HOST_ALL",
+        kv_only_last_layer=False,
+        weight_cache_path=None,
+        sparse_kv_cache_format=MlaKvCacheFormat.SCALED_FP8,
+    )
+    adapter = GLM51Adapter()
+    assert adapter.default_sparse_kv_cache_format == MlaKvCacheFormat.SCALED_FP8
+    assert adapter.resolve_sparse_kv_cache_format(None) == MlaKvCacheFormat.SCALED_FP8
+    assert adapter.resolve_sparse_kv_cache_format(MlaKvCacheFormat.BF16_RM) == MlaKvCacheFormat.BF16_RM
+    caches = adapter.allocate_kv_cache(mesh_device=mesh_device, hf_config=config, params=params)
+    cache = caches.kvpe
+    index_cache = caches.index
+    assert index_cache is not None
+    assert cache.format == MlaKvCacheFormat.SCALED_FP8
+    assert cache.storage.dtype == ttnn.fp8_e4m3
+    assert cache.storage.layout == ttnn.ROW_MAJOR_LAYOUT
+    assert cache.storage.shape[-1] == 656
+    assert index_cache.dtype == ttnn.bfloat8_b
+    assert index_cache.layout == ttnn.TILE_LAYOUT
+    assert _dram_chunk_size_bytes(cache.storage) == 32 * cache.storage.buffer_aligned_page_size()
+
+    table_path = tmp_path / "scaled_fp8_kv_table.pb"
+    build_and_serialize_kv_chunk_table(
+        mesh_device=mesh_device,
+        kvpe_cache=cache,
+        index_kv_cache=index_cache,
+        seq_len=seq_len,
+        num_layers=1,
+        mesh_shape=mesh_shape,
+        sp_axis=sp_axis,
+        num_users=1,
+        chunk_size_global=PREFILL_CHUNK_OUTPUT_TOKENS,
+        path=str(table_path),
+    )
+    table = ttnn.experimental.disaggregation.import_from_protobuf_file(str(table_path))
+    assert table.num_configs() == 2  # packed KVPE, tiled index
+
+    bf16_params = replace(params, sparse_kv_cache_format=MlaKvCacheFormat.BF16_RM)
+    bf16_caches = adapter.allocate_kv_cache(mesh_device=mesh_device, hf_config=config, params=bf16_params)
+    bf16_cache = bf16_caches.kvpe
+    bf16_index_cache = bf16_caches.index
+    assert bf16_index_cache is not None
+    assert bf16_cache.format == MlaKvCacheFormat.BF16_RM
+    assert bf16_cache.storage.dtype == ttnn.bfloat16
+    assert cache.storage.buffer_aligned_page_size() < bf16_cache.storage.buffer_aligned_page_size()
+    ttnn.deallocate(bf16_cache.storage, force=True)
+    ttnn.deallocate(bf16_index_cache, force=True)
+
+    torch.manual_seed(0)
+    source = torch.randn(1, 1, seq_len, head_dim, dtype=torch.bfloat16)
+    source_bf16 = ttnn.from_torch(
+        source,
+        device=mesh_device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=(2, None)),
+    )
+    latent_bf16 = ttnn.slice(source_bf16, [0, 0, 0, 0], [1, 1, seq_len // 2, config.kv_lora_rank])
+    source_rope = ttnn.slice(
+        source_bf16,
+        [0, 0, 0, config.kv_lora_rank],
+        [1, 1, seq_len // 2, head_dim],
+    )
+    source_packed = cache.pack(latent_bf16, source_rope)
+    ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
+        cache.storage,
+        source_packed,
+        slot_idx=0,
+        layer_idx=0,
+        num_layers=1,
+        kv_actual_global=0,
+        cluster_axis=sp_axis,
+    )
+
+    # This is the exact prefix-gather preparation in ttMLA._gather_kvpe_prefix.
+    cache_interleaved = ttnn.to_memory_config(cache.storage, ttnn.DRAM_MEMORY_CONFIG)
+
+    compute_grid = mesh_device.compute_with_storage_grid_size()
+    cores = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid.x - 1, compute_grid.y - 1))}
+    )
+    gather_semaphores = [ttnn.create_global_semaphore(mesh_device, cores, 0) for _ in range(2)]
+    barrier_semaphore = ttnn.create_global_semaphore(mesh_device, cores, 0)
+    gathered = ttnn.experimental.all_gather_async(
+        cache_interleaved,
+        dim=2,
+        multi_device_global_semaphore=gather_semaphores,
+        barrier_semaphore=barrier_semaphore,
+        num_links=1,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        topology=ttnn.Topology.Linear,
+        cluster_axis=sp_axis,
+    )
+    ttnn.synchronize_device(mesh_device)
+
+    assert gathered.dtype == ttnn.fp8_e4m3
+    assert gathered.layout == ttnn.ROW_MAJOR_LAYOUT
+
+    # Every output device holds the full gathered sequence. Compose the replicated result as one tensor so
+    # FP8 host export remains supported, then compare raw mixed-format bytes.
+    composer = ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_shape)
+    expected = ttnn.to_torch(source_packed, mesh_composer=composer).contiguous().view(torch.uint8)[:, :1]
+    actual_all = ttnn.to_torch(gathered, mesh_composer=composer).contiguous().view(torch.uint8)
+    for sp_rank in range(mesh_shape[0]):
+        for tp_rank in range(mesh_shape[1]):
+            actual = actual_all[:, tp_rank : tp_rank + 1, sp_rank * seq_len : (sp_rank + 1) * seq_len]
+            assert torch.equal(actual, expected)

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
@@ -31,7 +31,7 @@ from models.demos.deepseek_v3_d_p.tt.mla.indexer import num_full_indexer_layers
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup, interleaved_to_halfsplit_perm
 from models.demos.deepseek_v3_d_p.tt.mla.utils import blockcyclic_positions, rotated_chip_positions
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config, get_max_payload_size
-from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
+from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, init_kvpe_cache, init_mla_kv_cache
 from models.demos.deepseek_v3_d_p.utils.test_utils import WH_WORKER_L1_SIZE
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
@@ -42,6 +42,12 @@ SPARSE_KVPE_PCC = 0.99
 # bf16 KVPE cache; 0.999 keeps ample bf8 headroom while still catching a real write regression.
 SPARSE_INDEX_PCC = 0.999
 SPARSE_VARIANTS = ["deepseek_v32", "glm_5_1", "glm_5_2"]
+
+
+def _collect_kvpe_cache(cache, mesh_device):
+    composer = ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape)
+    return cache.unpack_host(ttnn.to_torch(cache.storage, mesh_composer=composer))
+
 
 # ---------------------------------------------------------------------------
 # TEST MATRIX — single source of truth (see _sparse_cases for how it expands)
@@ -103,7 +109,28 @@ def _sparse_cases(seqs, anchor_only):
     return cases
 
 
-SPARSE_ACCURACY_CASES = _sparse_cases(SPARSE_SEQS_ACCURACY, anchor_only=False)
+def _sparse_accuracy_cases():
+    """BF16 covers both sparsity regimes; scaled FP8 covers only the real-pruning regime."""
+    cases = []
+    for case in _sparse_cases(SPARSE_SEQS_ACCURACY, anchor_only=False):
+        variant, mesh, seq_len = case.values
+        formats = [MlaKvCacheFormat.BF16_RM]
+        if seq_len == SPARSE_SEQS_ANCHOR[0]:
+            formats.append(MlaKvCacheFormat.SCALED_FP8)
+        for cache_format in formats:
+            cases.append(
+                pytest.param(
+                    variant,
+                    mesh,
+                    seq_len,
+                    cache_format,
+                    id=f"{case.id}-kv_{cache_format.value}",
+                )
+            )
+    return cases
+
+
+SPARSE_ACCURACY_CASES = _sparse_accuracy_cases()
 SPARSE_ANCHOR_CASES = _sparse_cases(SPARSE_SEQS_ANCHOR, anchor_only=True)
 
 # All three fabric transports, keyed by name. Fabric is NOT swept: correctness is ~invariant to the
@@ -199,7 +226,15 @@ def _collect_index_cache_natural(tt_index_kv_cache, mesh_device, config, chunk):
 
 
 def run_sparse_mla_accuracy_case(
-    variant, config, mesh_device, seq_len, topology, ds_layer=None, ds_checkpoint=None, ds_repo=None
+    variant,
+    config,
+    mesh_device,
+    seq_len,
+    topology,
+    cache_format,
+    ds_layer=None,
+    ds_checkpoint=None,
+    ds_repo=None,
 ):
     """Sparse-MLA accuracy: device output + KVPE cache vs MLACPU sparse reference."""
     # Validity (tp<=cap, seq/sp>=min tokens, off-box shapes) is enforced by _sparse_cases at
@@ -216,15 +251,14 @@ def run_sparse_mla_accuracy_case(
     mesh_shape = list(mesh_device.shape)
     sp_axis, tp_axis = 0, 1
     logger.debug(f"[{variant.name}] sparse MLA accuracy: initializing KVPE cache mesh_shape={mesh_shape}")
-    tt_kvpe_cache = init_kvpe_cache(
-        kvpe_cache_head_dim=config.kv_lora_rank + config.qk_rope_head_dim,
+    tt_kvpe_cache = init_mla_kv_cache(
+        cache_format=cache_format,
+        hf_config=config,
         mesh_device=mesh_device,
         seq_len=seq_len,
         mesh_shape=mesh_shape,
         sp_axis=sp_axis,
         num_kvpe_cache_layers=1,
-        dtype=ttnn.bfloat16,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
     )
 
     logger.info(f"[{variant.name}] sparse MLA accuracy: running TT inference")
@@ -262,10 +296,7 @@ def run_sparse_mla_accuracy_case(
     logger.info(f"[{variant.name}] Output PCC: {pcc_message}")
 
     logger.debug(f"[{variant.name}] sparse MLA accuracy: collecting KVPE cache")
-    tt_kvpe = ttnn.to_torch(
-        tt_kvpe_cache,
-        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape),
-    ).to(torch.bfloat16)[:1, :1]
+    tt_kvpe = _collect_kvpe_cache(tt_kvpe_cache, mesh_device)[:1, :1]
     kv = config.kv_lora_rank
     _, kv_pcc = assert_with_pcc(ref_kvpe[..., :kv], tt_kvpe[..., :kv], SPARSE_KVPE_PCC)
     _, pe_pcc = assert_with_pcc(ref_kvpe[..., kv:], tt_kvpe[..., kv:], SPARSE_KVPE_PCC)
@@ -293,15 +324,14 @@ def run_sparse_mla_determinism_case(
     for run_idx in range(n_runs):
         logger.info(f"[{variant.name}] sparse MLA determinism run {run_idx + 1}/{n_runs}: running TT inference")
         logger.debug(f"[{variant.name}] sparse MLA determinism run {run_idx + 1}: initializing KVPE cache")
-        tt_kvpe_cache = init_kvpe_cache(
-            kvpe_cache_head_dim=config.kv_lora_rank + config.qk_rope_head_dim,
+        tt_kvpe_cache = init_mla_kv_cache(
+            cache_format=MlaKvCacheFormat.BF16_RM,
+            hf_config=config,
             mesh_device=mesh_device,
             seq_len=seq_len,
             mesh_shape=mesh_shape,
             sp_axis=sp_axis,
             num_kvpe_cache_layers=1,
-            dtype=ttnn.bfloat16,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
         )
         tt_output, _, _, shard_dims = run_mla_inference(
             config=config,
@@ -335,18 +365,16 @@ def run_sparse_mla_determinism_case(
 
 
 def run_sparse_mla_chunked_case(
-    variant, config, mesh_device, seq_len, chunk, ds_layer, ds_checkpoint, ds_repo, ds_input
+    variant, config, mesh_device, seq_len, chunk, cache_format, ds_layer, ds_checkpoint, ds_repo, ds_input
 ):
     """Sparse chunked prefill: compare chunked ttMLA against MLACPU sparse chunked truth."""
     # Anchor mesh (TP>=2) and seq/SP validity are guaranteed by _sparse_cases (no runtime skips).
     #
-    # CACHE-QUANTIZATION NOTE: the CPU reference keeps KVPE in bf16 (SparseMLAReference defaults to
-    # simulate_fp8=False — see reference.cpu_deepseek_v32), matching the bf16 single-shot device
-    # cache. But the chunked DEVICE path reads the prefix back from the bf8 KVPE cache and upcasts it in
-    # _gather_kvpe_prefix, so this comparison crosses a bf8 cache round-trip the reference does not model.
-    # That quantization noise eats into the SPARSE_OUTPUT_PCC headroom here (vs single-shot). If chunked
-    # PCC ever drifts toward the threshold, add a simulate_fp8=True reference variant to separate expected
-    # cache-quantization noise from a true logic regression.
+    # CACHE-QUANTIZATION NOTE: the canonical CPU reference keeps KVPE in BF16. The BF16 device case
+    # therefore compares like-for-like, while the scaled-FP8 case intentionally measures the complete
+    # device quantize/store/gather/reconstruct path against BF16 truth. Any PCC delta between the two
+    # formats is expected quantization loss; the cache and final-output checks below keep it distinct from
+    # a cache-layout, block-cyclic-remap, or sparse-attention regression.
     seed = 42
     logger.info(
         f"[{variant.name}] sparse MLA chunked start: seq_len={seq_len} chunk={chunk} "
@@ -361,15 +389,14 @@ def run_sparse_mla_chunked_case(
     mesh_shape = list(mesh_device.shape)
     sp_axis, tp_axis = 0, 1
     logger.debug(f"[{variant.name}] sparse MLA chunked: initializing KVPE cache mesh_shape={mesh_shape}")
-    tt_kvpe_cache = init_kvpe_cache(
-        kvpe_cache_head_dim=config.kv_lora_rank + config.qk_rope_head_dim,
+    tt_kvpe_cache = init_mla_kv_cache(
+        cache_format=cache_format,
+        hf_config=config,
         mesh_device=mesh_device,
         seq_len=seq_len,
         mesh_shape=mesh_shape,
         sp_axis=sp_axis,
         num_kvpe_cache_layers=1,
-        dtype=ttnn.bfloat16,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
     )
 
     tt_index_kv_cache = _init_index_kv_cache(config, mesh_device, seq_len, mesh_shape, sp_axis)
@@ -384,6 +411,7 @@ def run_sparse_mla_chunked_case(
         tp_axis=tp_axis,
         is_chunked=True,
         layer_num=1,
+        sparse_kv_cache_format=cache_format,
     )
     rope = RotarySetup(config, mesh_device, sp_axis=sp_axis, is_balanced=False)
     rope_tensors = rope.get_rope_tensors_indexed(seq_len, chunk)
@@ -426,9 +454,7 @@ def run_sparse_mla_chunked_case(
 
     sp = mesh_device.shape[0]
     logger.debug(f"[{variant.name}] sparse MLA chunked: collecting KVPE cache")
-    cache_sr = ttnn.to_torch(
-        tt_kvpe_cache, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape)
-    ).to(torch.bfloat16)[:, :1]
+    cache_sr = _collect_kvpe_cache(tt_kvpe_cache, mesh_device)[:, :1]
     p = blockcyclic_positions(sp, chunk, cache_sr.shape[2])
     nat = torch.empty(cache_sr.shape[2], cache_sr.shape[-1], dtype=torch.bfloat16)
     nat[p] = cache_sr[0, 0]
@@ -444,6 +470,83 @@ def run_sparse_mla_chunked_case(
     logger.info(f"[{variant.name}] Chunked output PCC: {pcc_message}")
     ttnn.synchronize_device(mesh_device)
     logger.info(f"[{variant.name}] sparse MLA chunked complete")
+
+
+def run_sparse_mla_kv_only_case(variant, config, mesh_device, seq_len, chunk, ds_layer, ds_checkpoint, ds_repo):
+    """Last-layer chunked fast path must populate packed KVPE and tiled index caches without an output."""
+    seed = 42
+    weights, src_tag = build_weights(
+        variant, config, seed=seed, layer=ds_layer, checkpoint_path=ds_checkpoint, repo=ds_repo
+    )
+    config.max_seq_len = seq_len
+    mesh_shape = list(mesh_device.shape)
+    sp_axis, tp_axis = 0, 1
+    cache_format = MlaKvCacheFormat.SCALED_FP8
+    tt_kvpe_cache = init_mla_kv_cache(
+        cache_format=cache_format,
+        hf_config=config,
+        mesh_device=mesh_device,
+        seq_len=seq_len,
+        mesh_shape=mesh_shape,
+        sp_axis=sp_axis,
+        num_kvpe_cache_layers=1,
+    )
+    tt_index_kv_cache = _init_index_kv_cache(config, mesh_device, seq_len, mesh_shape, sp_axis)
+    mla_tt = ttMLA(
+        config,
+        weights,
+        mesh_device,
+        layer_idx=0,
+        seq_len=seq_len,
+        sp_axis=sp_axis,
+        tp_axis=tp_axis,
+        is_chunked=True,
+        layer_num=1,
+        sparse_kv_cache_format=cache_format,
+        kv_only=True,
+    )
+    rope_tensors = RotarySetup(config, mesh_device, sp_axis=sp_axis, is_balanced=False).get_rope_tensors_indexed(
+        seq_len, chunk
+    )
+    hidden = make_hidden(chunk, config.hidden_size, seed)
+    shard_dims = [None, None]
+    shard_dims[tp_axis], shard_dims[sp_axis] = -1, -2
+    tt_x = ttnn.from_torch(
+        hidden.unsqueeze(0),
+        device=mesh_device,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_shape), dims=shard_dims),
+    )
+
+    out = mla_tt.forward(
+        tt_x,
+        rope_tensors,
+        tt_kvpe_cache,
+        actual_start=0,
+        index_kv_cache=tt_index_kv_cache,
+    )
+    assert out is None
+
+    _, ref_kvpe, ref_index = run_cpu_reference(
+        config,
+        weights,
+        hidden,
+        chunk,
+        cpu_ref_cache_dir(variant),
+        cache_tag=f"{src_tag}_funcidx_kvonly",
+    )
+    cache_sr = _collect_kvpe_cache(tt_kvpe_cache, mesh_device)[:, :1]
+    positions = blockcyclic_positions(mesh_shape[sp_axis], chunk, cache_sr.shape[2])
+    cache_natural = torch.empty(cache_sr.shape[2], cache_sr.shape[-1], dtype=torch.bfloat16)
+    cache_natural[positions] = cache_sr[0, 0]
+    _, kv_msg = assert_with_pcc(ref_kvpe, cache_natural[:chunk].unsqueeze(0).unsqueeze(0), SPARSE_KVPE_PCC)
+
+    index_natural = _collect_index_cache_natural(tt_index_kv_cache, mesh_device, config, chunk)
+    _, index_msg = assert_with_pcc(ref_index[0, :chunk], index_natural[:chunk], SPARSE_INDEX_PCC)
+    logger.info(f"[{variant.name}] kv_only cache PCC: kvpe={kv_msg} index={index_msg}")
+    ttnn.synchronize_device(mesh_device)
 
 
 def run_sparse_mla_rotated_case(
@@ -503,15 +606,14 @@ def run_sparse_mla_rotated_case(
     rope_tensors = rope.get_rope_tensors_indexed(
         cache_seq_len_global=seq_len_cache, chunk_size_global=chunk_size_global
     )
-    tt_kvpe_cache = init_kvpe_cache(
-        kvpe_cache_head_dim=config.kv_lora_rank + config.qk_rope_head_dim,
+    tt_kvpe_cache = init_mla_kv_cache(
+        cache_format=MlaKvCacheFormat.BF16_RM,
+        hf_config=config,
         mesh_device=mesh_device,
         seq_len=seq_len_cache,
         mesh_shape=mesh_shape,
         sp_axis=sp_axis,
         num_kvpe_cache_layers=1,
-        dtype=ttnn.bfloat16,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
     )
     shard_dims = [None, None]
     shard_dims[tp_axis], shard_dims[sp_axis] = -1, -2
@@ -549,7 +651,8 @@ def run_sparse_mla_rotated_case(
     # compare per-iter region + full to the reference. If cache matches but output above diverged, the
     # bug is in SCORING (indexer top-k / sparse_sdpa), not the write.
     cache_sr = ttnn.to_torch(
-        tt_kvpe_cache, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape)
+        tt_kvpe_cache.storage,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape),
     ).to(torch.bfloat16)[:, :1]
     p = blockcyclic_positions(sp, chunk_size_global, cache_sr.shape[2])
     nat = torch.empty(cache_sr.shape[2], cache_sr.shape[-1], dtype=torch.bfloat16)
@@ -590,9 +693,13 @@ def test_sparse_mla_rotated(
     run_sparse_mla_rotated_case(variant, config_only, mesh_device, iters_isl, seq_len, ds_layer, ds_checkpoint, ds_repo)
 
 
-# One combined parametrization (variant, mesh_device, seq_len) instead of three independent axes: the
-# cases are generated by _sparse_cases for the current box, so the collected matrix IS the run matrix.
-@pytest.mark.parametrize("variant, mesh_device, seq_len", SPARSE_ACCURACY_CASES, indirect=["variant", "mesh_device"])
+# One combined parametrization instead of independent variant/mesh/sequence/format axes. BF16 retains
+# both sparsity regimes; scaled FP8 is restricted to the real-pruning sequence to avoid redundant CI work.
+@pytest.mark.parametrize(
+    "variant, mesh_device, seq_len, cache_format",
+    SPARSE_ACCURACY_CASES,
+    indirect=["variant", "mesh_device"],
+)
 @pytest.mark.parametrize("device_params", SPARSE_DEVICE_PARAMS, ids=SPARSE_DEVICE_IDS, indirect=True)
 @pytest.mark.skipif(not is_blackhole(), reason="DSA ops (indexer / sparse SDPA) are Blackhole-only")
 @pytest.mark.timeout(0)
@@ -600,6 +707,7 @@ def test_sparse_mla_accuracy(
     mesh_device,
     seq_len,
     device_params,
+    cache_format,
     variant,
     config_only,
     ds_layer,
@@ -615,7 +723,17 @@ def test_sparse_mla_accuracy(
 
     monkeypatch.setattr(ttnn.experimental, "indexer_score_dsa", check_indexer_q_format)
     topology = _topology_from_device_params(device_params)
-    run_sparse_mla_accuracy_case(variant, config_only, mesh_device, seq_len, topology, ds_layer, ds_checkpoint, ds_repo)
+    run_sparse_mla_accuracy_case(
+        variant,
+        config_only,
+        mesh_device,
+        seq_len,
+        topology,
+        cache_format,
+        ds_layer,
+        ds_checkpoint,
+        ds_repo,
+    )
 
 
 # GLM-5.2 indexer reuse: anchor cases for the reuse-capable variant only (others have no shared layers).
@@ -640,17 +758,14 @@ def test_sparse_mla_indexer_reuse(
     topology = _topology_from_device_params(device_params)
 
     def _kvpe():
-        # sparse_sdpa reads the KVPE cache natively and requires it uncompressed (bf16 ROW_MAJOR), not
-        # the bfloat8_b/TILE default — mla.py asserts this. Mirror the accuracy case's cache.
-        return init_kvpe_cache(
-            kvpe_cache_head_dim=config.kv_lora_rank + config.qk_rope_head_dim,
+        return init_mla_kv_cache(
+            cache_format=MlaKvCacheFormat.BF16_RM,
+            hf_config=config,
             mesh_device=mesh_device,
             seq_len=seq_len,
             mesh_shape=mesh_shape,
             sp_axis=sp_axis,
             num_kvpe_cache_layers=1,
-            dtype=ttnn.bfloat16,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
         )
 
     common = dict(
@@ -698,11 +813,40 @@ def test_sparse_mla_determinism(
 @pytest.mark.parametrize("variant, mesh_device, seq_len", SPARSE_ANCHOR_CASES, indirect=["variant", "mesh_device"])
 @pytest.mark.parametrize("device_params", SPARSE_DEVICE_PARAMS, ids=SPARSE_DEVICE_IDS, indirect=True)
 @pytest.mark.parametrize("chunk", [1024], ids=["c1k"])
+@pytest.mark.parametrize(
+    "cache_format",
+    [MlaKvCacheFormat.BF16_RM, MlaKvCacheFormat.SCALED_FP8],
+    ids=["kv_bf16", "kv_scaled_fp8"],
+)
 @pytest.mark.skipif(not is_blackhole(), reason="DSA ops (indexer / sparse SDPA) are Blackhole-only")
 @pytest.mark.timeout(0)
 def test_sparse_mla_chunked(
-    mesh_device, seq_len, chunk, device_params, variant, config_only, ds_layer, ds_checkpoint, ds_repo, ds_input
+    mesh_device,
+    seq_len,
+    chunk,
+    cache_format,
+    device_params,
+    variant,
+    config_only,
+    ds_layer,
+    ds_checkpoint,
+    ds_repo,
+    ds_input,
 ):
     run_sparse_mla_chunked_case(
-        variant, config_only, mesh_device, seq_len, chunk, ds_layer, ds_checkpoint, ds_repo, ds_input
+        variant, config_only, mesh_device, seq_len, chunk, cache_format, ds_layer, ds_checkpoint, ds_repo, ds_input
     )
+
+
+SPARSE_KV_ONLY_CASES = [c for c in SPARSE_ANCHOR_CASES if "glm_5_1" in c.id]
+
+
+@pytest.mark.parametrize("variant, mesh_device, seq_len", SPARSE_KV_ONLY_CASES, indirect=["variant", "mesh_device"])
+@pytest.mark.parametrize("device_params", SPARSE_DEVICE_PARAMS, ids=SPARSE_DEVICE_IDS, indirect=True)
+@pytest.mark.parametrize("chunk", [1024], ids=["c1k"])
+@pytest.mark.skipif(not is_blackhole(), reason="DSA ops (indexer / sparse SDPA) are Blackhole-only")
+@pytest.mark.timeout(0)
+def test_sparse_mla_kv_only(
+    mesh_device, seq_len, chunk, device_params, variant, config_only, ds_layer, ds_checkpoint, ds_repo
+):
+    run_sparse_mla_kv_only_case(variant, config_only, mesh_device, seq_len, chunk, ds_layer, ds_checkpoint, ds_repo)

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
@@ -79,12 +79,18 @@ attn_mode axis — a baseline to compare the sparse impl against:
   * sparse — v3.2 DSA: indexer builds top-k index keys, sparse_sdpa attends only the top-k=2048 keys.
   * dense  — v3.1 baseline: has_indexer=False -> NullIndexer + full-prefix ring MLA (ring_joint_sdpa
     over the whole prefix, no indexer/top-k). Needs no cache fill (ring reads the prefix by logical_n).
-  Each (variant, mode) writes its own profiler subdir ({variant}_{sparse,dense}_mla_perf) so the runs
-  never clobber and the CSVs stay directly comparable.
+  Each case writes its own profiler subdir, including the sparse KV format in the directory name, so
+  reports never clobber and the CSVs stay directly comparable.
 
-Run (Blackhole Galaxy/LoudBox/QuietBox) — all combos (2 variants × 3 scenarios × 2 modes), or narrow via -k:
+kv_cache_format axis — sparse mode runs both supported persistent-cache formats:
+  * kv_bf16 — row-major BF16 baseline (1152 logical bytes/token).
+  * kv_scaled_fp8 — packed [512 E4M3 + four FP32 scales + 64 BF16 RoPE] rows (656 bytes/token).
+  Dense mode retains its tiled bfloat8_b cache and therefore has no sparse-cache-format sweep.
+
+Run (Blackhole Galaxy/LoudBox/QuietBox) — all combos (2 variants × 3 scenarios × 3 cache/mode cases), or narrow via -k:
     pytest -m perf models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py::test_mla_chunked_perf -s
-    pytest -m perf ...::test_mla_chunked_perf -k "glm_5_1 and cold and sparse" -s
+    pytest -m perf ...::test_mla_chunked_perf -k "glm_5_1 and cold and sparse and kv_scaled_fp8" -s
+    pytest -m perf ...::test_mla_chunked_perf -k "warm and sparse and kv_bf16" -s
     pytest -m perf ...::test_mla_chunked_perf -k "deepseek_v32 and dense" -s
 
 Knobs (env): DS_PERF_CACHE (default 51200), DS_PERF_CHUNK (default 5120), DS_PERF_LONG_CACHE (default
@@ -124,7 +130,7 @@ from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_reference import m
 from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config, get_max_payload_size
-from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
+from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, init_kvpe_cache, init_mla_kv_cache
 from models.demos.deepseek_v3_d_p.utils.test_utils import WH_WORKER_L1_SIZE
 from tests.ttnn.profiling.realtime_profiler_utils import profile_realtime_program
 
@@ -137,7 +143,6 @@ LONG_CACHE_TOKENS = int(os.environ.get("DS_PERF_LONG_CACHE", 512000))
 # attn_mode axis: sparse (v3.2 DSA indexer + sparse_sdpa) vs dense (v3.1 full-prefix ring MLA — no
 # indexer, no top-k), a baseline to compare the sparse impl against. Each mode writes its own profiler
 # subdir + per-scenario CSVs so the two runs never clobber and stay directly comparable.
-ATTN_MODES = ("sparse", "dense")
 ATTN_MODE = os.environ.get("DS_PERF_ATTN_MODE", "sparse")  # module-level default (mesh-shape detection)
 # Model-variant axis: deepseek_v32 (128 q-heads / 64 index heads) vs glm_5_1 (64 / 32). BOTH run the
 # SAME TP=4 meshes — GLM's thin per-chip head shard (64/4=16 < 32) is handled by the head→sequence
@@ -166,14 +171,28 @@ RT_RECORD_TIMEOUT_S = float(os.environ.get("DS_PERF_RT_TIMEOUT", 30.0))
 RT_OPS_DUMP = os.environ.get("DS_PERF_RT_OPS_DUMP", "") not in ("", "0", "false")
 
 
-def _subdir(variant: str, mode: str) -> str:
-    """Per-(variant, mode) profiler subdir (per-scenario summary CSVs + run manifest). Keeps
-    deepseek_v32/glm_5_1 × sparse/dense runs from clobbering each other."""
-    return f"{variant}_{mode}_mla_perf"
+def _cache_format_id(cache_format: MlaKvCacheFormat) -> str:
+    return {
+        MlaKvCacheFormat.BF16_RM: "kv_bf16",
+        MlaKvCacheFormat.SCALED_FP8: "kv_scaled_fp8",
+    }[cache_format]
 
 
-def _csv_name(variant: str, mode: str) -> str:
-    return os.environ.get("DS_PERF_CSV" if mode == "sparse" else "DS_DENSE_PERF_CSV", f"{_subdir(variant, mode)}.csv")
+def _profile_case_id(mode: str, cache_format: MlaKvCacheFormat) -> str:
+    return f"{mode}-{_cache_format_id(cache_format)}" if mode == "sparse" else mode
+
+
+def _subdir(variant: str, mode: str, cache_format: MlaKvCacheFormat) -> str:
+    """Format-specific profiler directory; matched sparse BF16/FP8 reports must never clobber each other."""
+    profile_case = _profile_case_id(mode, cache_format).replace("-", "_")
+    return f"{variant}_{profile_case}_mla_perf"
+
+
+def _csv_name(variant: str, mode: str, cache_format: MlaKvCacheFormat) -> str:
+    return os.environ.get(
+        "DS_PERF_CSV" if mode == "sparse" else "DS_DENSE_PERF_CSV",
+        f"{_subdir(variant, mode, cache_format)}.csv",
+    )
 
 
 # Three profiling scenarios (the test sweeps all three):
@@ -217,9 +236,9 @@ def _output_dir(subdir: str) -> str:
     return d
 
 
-def _scenario_csv(out_dir, scenario: str, variant: str, mode: str) -> str:
-    """Per-(scenario, variant, mode) summary CSV path under the output dir."""
-    root, ext = os.path.splitext(_csv_name(variant, mode))
+def _scenario_csv(out_dir, scenario: str, variant: str, mode: str, cache_format: MlaKvCacheFormat) -> str:
+    """Per-scenario summary CSV path under its format-specific profiler directory."""
+    root, ext = os.path.splitext(_csv_name(variant, mode, cache_format))
     return os.path.join(out_dir, f"{root}_{scenario}{ext}")
 
 
@@ -270,7 +289,7 @@ def _git_head() -> dict:
         return {"commit": None, "branch": None}
 
 
-def _write_run_manifest(report_dir, *, variant, scenario, attn_mode, command, workload) -> None:
+def _write_run_manifest(report_dir, *, variant, scenario, attn_mode, cache_format, command, workload) -> None:
     """Drop a lean run_manifest_<scenario>.json into the output dir. Records ONLY what cannot be
     reconstructed from git (given the commit) or from the co-located ops CSV:
       * commit / branch — the code-state anchor (read subprocess-free from .git; no dirty flag — the
@@ -288,9 +307,10 @@ def _write_run_manifest(report_dir, *, variant, scenario, attn_mode, command, wo
             if os.path.exists(so)
             else None
         )
+        case_filter = _profile_case_id(attn_mode, cache_format)
         reproducer = (
             f"DS_PERF_CACHE={CACHE_TOKENS} DS_PERF_CHUNK={CHUNK_TOKENS} DS_PERF_LONG_CACHE={LONG_CACHE_TOKENS} "
-            f"{command} -k '{variant} and {scenario} and {attn_mode}'"
+            f"{command} -k '{variant} and {scenario} and {case_filter}'"
         )
         head = _git_head()
         manifest = {
@@ -299,6 +319,7 @@ def _write_run_manifest(report_dir, *, variant, scenario, attn_mode, command, wo
             "variant": variant,
             "scenario": scenario,
             "attn_mode": attn_mode,
+            "kv_cache_format": _cache_format_id(cache_format) if attn_mode == "sparse" else None,
             "commit": head["commit"],
             "branch": head["branch"],
             "device": {
@@ -567,6 +588,13 @@ def _by_op(frame: pd.DataFrame, dur_col: str) -> pd.DataFrame:
 # ============================================================================
 # The perf test — build the DSA ttMLA, profile the measured forward(s), report
 # ============================================================================
+PERF_CASES = [
+    pytest.param("sparse", MlaKvCacheFormat.BF16_RM, id="sparse-kv_bf16"),
+    pytest.param("sparse", MlaKvCacheFormat.SCALED_FP8, id="sparse-kv_scaled_fp8"),
+    pytest.param("dense", MlaKvCacheFormat.BF16_RM, id="dense"),
+]
+
+
 @pytest.mark.parametrize("mesh_device", [PERF_WORKLOAD.mesh_shape], ids=[PERF_WORKLOAD.id], indirect=True)
 @pytest.mark.parametrize(
     "device_params",
@@ -581,12 +609,12 @@ def _by_op(frame: pd.DataFrame, dur_col: str) -> pd.DataFrame:
     ids=["fabric2d"],
     indirect=True,
 )
-@pytest.mark.parametrize("attn_mode", list(ATTN_MODES), ids=list(ATTN_MODES))
+@pytest.mark.parametrize("attn_mode,kv_cache_format", PERF_CASES)
 @pytest.mark.parametrize("scenario", list(SCENARIOS), ids=list(SCENARIOS))
 @pytest.mark.parametrize("variant", list(VARIANTS), indirect=True, ids=list(VARIANTS))
 @pytest.mark.skipif(os.environ.get("CI") == "true", reason="Performance test — skip on CI")
 @pytest.mark.timeout(0)
-def test_mla_chunked_perf(mesh_device, variant, scenario, attn_mode, config_only):
+def test_mla_chunked_perf(mesh_device, variant, scenario, attn_mode, kv_cache_format, config_only):
     if PERF_SKIP_REASON:
         pytest.skip(PERF_SKIP_REASON)
 
@@ -602,7 +630,7 @@ def test_mla_chunked_perf(mesh_device, variant, scenario, attn_mode, config_only
     scenario_cfg = SCENARIOS[scenario]
     is_cold = scenario_cfg["loop"]
     has_indexer = attn_mode == "sparse"  # dense baseline drops the indexer -> full-prefix ring MLA
-    subdir = _subdir(variant.name, attn_mode)  # per-(variant, mode) dir: runs never clobber each other
+    subdir = _subdir(variant.name, attn_mode, kv_cache_format)
     sp_axis, tp_axis = 0, 1
     sp, tp = mesh_device.shape
     # cache scales per box (sp/GALAXY_SP) like the chunk, so every box profiles the Galaxy per-chip
@@ -620,8 +648,8 @@ def test_mla_chunked_perf(mesh_device, variant, scenario, attn_mode, config_only
         f"must be divisible by TP={tp}"
     )
 
-    # Every model dimension (heads, index_*, rope interleave) comes from the single-source reference
-    # config (config_only → reference/{deepseek_v3_2,glm_5_1}_config.py). Mirror the correctness tests:
+    # Every model dimension (heads, index_*, rope interleave) comes from the variant's single-source
+    # reference config via config_only. Mirror the correctness tests:
     # set only max_seq_len and let ttMLA read all dims from the config — no per-variant overrides here.
     config = copy.deepcopy(config_only)
     config.max_seq_len = total  # rope-table / buffer length (same hack as the correctness tests)
@@ -639,23 +667,32 @@ def test_mla_chunked_perf(mesh_device, variant, scenario, attn_mode, config_only
         is_chunked=True,
         layer_num=1,
         has_indexer=has_indexer,  # sparse: DSA indexer + sparse_sdpa; dense: NullIndexer + ring MLA
+        sparse_kv_cache_format=kv_cache_format if has_indexer else MlaKvCacheFormat.BF16_RM,
     )
 
     rope = RotarySetup(config, mesh_device, sp_axis=sp_axis, is_balanced=False).get_rope_tensors_indexed(total, chunk)
-    # KVPE cache format is mode-specific. sparse: sparse_sdpa reads it natively and requires an
-    # uncompressed bf16/fp8_e4m3 ROW_MAJOR cache (mla.py asserts) — NOT the init_kvpe_cache bfloat8_b/TILE
-    # default. dense: ring_joint_sdpa wants the default (bfloat8_b TILE) and derives its output dtype from
-    # the cache, so leave dense on the default.
-    kvpe_dtype_layout = dict(dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT) if has_indexer else {}
-    kvpe_cache = init_kvpe_cache(
-        kvpe_cache_head_dim=config.kv_lora_rank + config.qk_rope_head_dim,
-        mesh_device=mesh_device,
-        seq_len=total,
-        mesh_shape=list(mesh_device.shape),
-        sp_axis=sp_axis,
-        num_kvpe_cache_layers=1,
-        **kvpe_dtype_layout,
-    )
+    # Sparse mode profiles the selected cache format. Dense ring attention retains its tiled bfloat8_b
+    # cache because it has a different cache contract.
+    if has_indexer:
+        kvpe_cache = init_mla_kv_cache(
+            cache_format=kv_cache_format,
+            hf_config=config,
+            mesh_device=mesh_device,
+            seq_len=total,
+            mesh_shape=list(mesh_device.shape),
+            sp_axis=sp_axis,
+            num_kvpe_cache_layers=1,
+        )
+    else:
+        kvpe_cache = init_mla_kv_cache(
+            cache_format=MlaKvCacheFormat.BFP8_TILE,
+            hf_config=config,
+            mesh_device=mesh_device,
+            seq_len=total,
+            mesh_shape=list(mesh_device.shape),
+            sp_axis=sp_axis,
+            num_kvpe_cache_layers=1,
+        )
 
     # Block-cyclic indexer key cache (SPARSE only): allocated externally (same ownership as the KVPE cache)
     # and passed into forward. warm/long leave it (and the KVPE cache) at zero init — for a profiling proxy
@@ -695,7 +732,8 @@ def test_mla_chunked_perf(mesh_device, variant, scenario, attn_mode, config_only
     # sum correct (and replace the old signposted-region split).
     starts = list(range(0, cache + chunk, chunk)) if is_cold else [cache]
     logger.info(
-        f"profiling {workload.system_name} {attn_mode}/{scenario} proxy: {len(starts)} × {chunk}-token "
+        f"profiling {workload.system_name} {_profile_case_id(attn_mode, kv_cache_format)}/{scenario} proxy: "
+        f"{len(starts)} × {chunk}-token "
         f"chunk(s) filling to end_pos={total} on SP={sp}×TP={tp}; local chunk={chunk // sp}, "
         f"local MLA heads={config.num_attention_heads // tp}"
         + (f", local indexer heads={config.index_n_heads // tp}" if has_indexer else " (dense: no indexer)")
@@ -726,7 +764,8 @@ def test_mla_chunked_perf(mesh_device, variant, scenario, attn_mode, config_only
     span = f"full cold prefill 0→{cache}-tok cache" if is_cold else f"one chunk @ {cache}-tok cache"
     table = "\n".join(
         [
-            f"{variant.name} MLA chunked perf [{attn_mode}/{scenario}] — {workload.system_name} proxy "
+            f"{variant.name} MLA chunked perf [{_profile_case_id(attn_mode, kv_cache_format)}/{scenario}] — "
+            f"{workload.system_name} proxy "
             f"{workload.chunk_tokens}-tok chunk, {span}, SP={workload.sp}×TP={workload.tp}",
             f"Galaxy target: {CHUNK_TOKENS}-tok chunk @ {galaxy_cache}-tok cache, SP={GALAXY_SP}×TP={GALAXY_TP}; "
             f"local chunk={CHUNK_TOKENS // GALAXY_SP}, local MLA heads={workload.num_attention_heads // GALAXY_TP}",
@@ -743,7 +782,7 @@ def test_mla_chunked_perf(mesh_device, variant, scenario, attn_mode, config_only
     print("\n" + table)  # ensure full table reaches stdout even if logging is filtered
 
     out_dir = _output_dir(subdir)
-    csv_out = _contained(_scenario_csv(out_dir, scenario, variant.name, attn_mode))
+    csv_out = _contained(_scenario_csv(out_dir, scenario, variant.name, attn_mode, kv_cache_format))
     by_op.reset_index().to_csv(csv_out, index=False)
     logger.info(f"per-op CSV written to {os.path.abspath(csv_out)}")
 
@@ -758,7 +797,13 @@ def test_mla_chunked_perf(mesh_device, variant, scenario, attn_mode, config_only
         "pytest -m perf models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py::test_mla_chunked_perf -s"
     )
     _write_run_manifest(
-        out_dir, variant=variant.name, scenario=scenario, attn_mode=attn_mode, command=command, workload=workload
+        out_dir,
+        variant=variant.name,
+        scenario=scenario,
+        attn_mode=attn_mode,
+        cache_format=kv_cache_format,
+        command=command,
+        workload=workload,
     )
 
     # cold only: per-cache-fill-iteration breakdown. The aggregate above sums all chunks; this shows how
@@ -791,6 +836,6 @@ def test_mla_chunked_perf(mesh_device, variant, scenario, attn_mode, config_only
     )
     logger.info("\n" + iter_table)
     print("\n" + iter_table)
-    iter_csv = _scenario_csv(out_dir, f"{scenario}_by_iter", variant.name, attn_mode)
+    iter_csv = _scenario_csv(out_dir, f"{scenario}_by_iter", variant.name, attn_mode, kv_cache_format)
     by_iter_op.to_csv(iter_csv, index=False)
     logger.info(f"per-op×iteration CSV written to {os.path.abspath(iter_csv)}")

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_vs_trace.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_vs_trace.py
@@ -84,7 +84,7 @@ from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_mesh import (
 from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_plugin import is_marker_explicitly_selected
 from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup, interleaved_to_halfsplit_perm
-from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
+from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, init_kvpe_cache, init_mla_kv_cache
 from models.demos.deepseek_v3_d_p.utils.test_utils import WH_WORKER_L1_SIZE
 
 # Bespoke suite: validated against recorded vLLM trace bundles (indexer logits/topk, sparse output,
@@ -405,15 +405,14 @@ def _run_device_forward(model, config, layer, mesh_device):
     sp_axis, tp_axis = 0, 1
     # Sparse: uncompressed bf16/ROW_MAJOR KVPE cache + indexed rope + a caller-owned indexer key cache.
     # Single-shot is folded onto the block-cyclic path (one full-seq chunk at offset 0).
-    kvpe_cache = init_kvpe_cache(
-        kvpe_cache_head_dim=config.kv_lora_rank + config.qk_rope_head_dim,
+    kvpe_cache = init_mla_kv_cache(
+        cache_format=MlaKvCacheFormat.BF16_RM,
+        hf_config=config,
         mesh_device=mesh_device,
         seq_len=SEQ_LEN,
         mesh_shape=list(mesh_device.shape),
         sp_axis=sp_axis,
         num_kvpe_cache_layers=1,
-        dtype=ttnn.bfloat16,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
     )
     index_kv_cache = init_kvpe_cache(
         kvpe_cache_head_dim=config.index_head_dim,
@@ -447,7 +446,8 @@ def _run_device_forward(model, config, layer, mesh_device):
     ]  # [1, S, hidden]
     # KVPE: replicated across TP — concat TP replicas on the unused dim 1, keep first.
     kvpe_t = ttnn.to_torch(
-        kvpe_cache, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape)
+        kvpe_cache.storage,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape),
     ).to(torch.bfloat16)[
         0, 0, :SEQ_LEN
     ]  # [S, 576]

--- a/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
@@ -6,7 +6,6 @@ Test for instantiating both reference CPU and TT device MLA modules with the sam
 This test verifies that both modules can be created and weights are loaded correctly.
 """
 
-
 import pytest
 import torch
 from loguru import logger
@@ -23,9 +22,11 @@ from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import (
     BH_NUM_DRAM_BANKS,
     NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK,
     PREFILL_CHUNK_OUTPUT_TOKENS,
+    MlaKvCacheFormat,
     create_kv_chunk_address_table_ds,
     create_kv_chunk_address_table_kimi,
     init_kvpe_cache,
+    init_mla_kv_cache,
     populate_kv_chunk_address_table_kimi,
 )
 from tests.ttnn.utils_for_testing import assert_equal
@@ -514,15 +515,14 @@ def test_glm_kv_cache_table(
     rope_tensors = rope.get_rope_tensors_indexed(cache_seq_len_global=seq_len, chunk_size_global=chunk_size_global)
 
     # KVPE cache: uncompressed bf16 + ROW_MAJOR, the format sparse_sdpa reads natively (see MLA.forward).
-    tt_kvpe_cache = init_kvpe_cache(
-        kvpe_cache_head_dim=config.kv_lora_rank + config.qk_rope_head_dim,
+    tt_kvpe_cache = init_mla_kv_cache(
+        cache_format=MlaKvCacheFormat.BF16_RM,
+        hf_config=config,
         mesh_device=mesh_device,
         seq_len=seq_len,
         mesh_shape=mesh_shape,
         sp_axis=sp_axis,
         num_kvpe_cache_layers=1,
-        dtype=ttnn.bfloat16,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
     )
 
     # Indexer key cache: caller-owned (like the KVPE cache), NOT self-allocated by the indexer. Block-cyclic
@@ -645,7 +645,7 @@ def test_glm_kv_cache_table(
     # [1, 1, 32, kvpe_head_dim] bf16 = 32*kvpe_head_dim*2 bytes contiguous, decoded via tensor_from_bf16_bytes
     # (the RM/bf16 analogue of tensor_from_bfp8_bytes).
     tt_kvpe_cache_torch = ttnn.to_torch(
-        tt_kvpe_cache,
+        tt_kvpe_cache.storage,
         mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape),
     ).to(torch.bfloat16)[:1, :1, :, :]
 

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -38,7 +38,7 @@ from models.demos.deepseek_v3_d_p.utils.chunked_prefill_utils import (
     partition_iters,
     single_trace,
 )
-from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
+from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, init_kvpe_cache, init_mla_kv_cache
 from models.demos.deepseek_v3_d_p.utils.test_utils import WH_WORKER_L1_SIZE
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
@@ -92,6 +92,7 @@ def run_mla_inference(
         # goes through update_padded_kv_cache, which asserts cache_batch % layer_num == 0. Dense is
         # unaffected (its single-shot write uses fill_cache_for_user_, which ignores layer_num).
         layer_num=1,
+        sparse_kv_cache_format=tt_kvpe_cache.format,
     )
     rope_setup = RotarySetup(config, mesh_device, sp_axis=sp_axis, is_balanced=is_balanced)
     # Sparse (DSA) single-shot is folded onto the block-cyclic path (one full-seq chunk at offset 0):
@@ -242,9 +243,9 @@ def run_model(
     logger.info("=" * 80)
 
     # Initialize KVPE cache
-    kvpe_cache_head_dim = config.qk_rope_head_dim + config.kv_lora_rank  # 576
-    tt_kvpe_cache = init_kvpe_cache(
-        kvpe_cache_head_dim=kvpe_cache_head_dim,
+    tt_kvpe_cache = init_mla_kv_cache(
+        cache_format=MlaKvCacheFormat.BFP8_TILE,
+        hf_config=config,
         mesh_device=mesh_device,
         seq_len=seq_len,
         mesh_shape=mesh_shape,
@@ -337,7 +338,7 @@ def run_model(
         # Read back KVPE cache from device
         # Cache is replicated across TP, so concat TP replicas on dim 1 (unused) and discard extras
         tt_kvpe_cache_torch = ttnn.to_torch(
-            tt_kvpe_cache,
+            tt_kvpe_cache.storage,
             mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape),
         ).to(torch.bfloat16)
         tt_kvpe_cache_torch = tt_kvpe_cache_torch[:1, :1, :, :]
@@ -679,8 +680,9 @@ def _run_chunked_prefill(
     indexed_rope = rope_setup.get_rope_tensors_indexed(
         cache_seq_len_global=seq_len_cache, chunk_size_global=chunk_size_global
     )
-    tt_kvpe_cache = init_kvpe_cache(
-        kvpe_cache_head_dim=kvpe_dim,
+    tt_kvpe_cache = init_mla_kv_cache(
+        cache_format=MlaKvCacheFormat.BFP8_TILE,
+        hf_config=config,
         mesh_device=mesh_device,
         seq_len=seq_len_cache,
         mesh_shape=mesh_shape,
@@ -723,7 +725,7 @@ def _run_chunked_prefill(
             layout=ttnn.TILE_LAYOUT,
             mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=cache_shard_dims),
         )
-        ttnn.copy_host_to_device_tensor(cache_host_tt, tt_kvpe_cache)
+        ttnn.copy_host_to_device_tensor(cache_host_tt, tt_kvpe_cache.storage)
         ttnn.synchronize_device(mesh_device)
 
     mesh_device.enable_program_cache()
@@ -809,7 +811,7 @@ def _run_chunked_prefill(
     #      Meta-style) but re-interleaved for the GPU trace (HF half-split -> device Meta basis). ----
     if any(users[u]["kv_post"] is not None for u in range(num_users)):
         cache_sr = ttnn.to_torch(
-            tt_kvpe_cache,
+            tt_kvpe_cache.storage,
             mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape),
         ).to(torch.float32)[
             :, :1

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
@@ -43,7 +43,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_route
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_block import TtPrefillBlock
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker
-from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
+from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, init_kvpe_cache, init_mla_kv_cache
 from models.demos.deepseek_v3_d_p.utils.transformer_helpers import (
     ABC_1K_PATH,
     PROMPT_5K_PATH,
@@ -365,9 +365,9 @@ def run_model(
     rope_setup = RotarySetup(config, mesh_device, sp_axis=sp_axis, is_balanced=is_balanced)
     rope_tensors = rope_setup.get_rope_tensors(isl_total)
 
-    kvpe_cache_head_dim = config.qk_rope_head_dim + config.kv_lora_rank
-    tt_kvpe_cache = init_kvpe_cache(
-        kvpe_cache_head_dim=kvpe_cache_head_dim,
+    tt_kvpe_cache = init_mla_kv_cache(
+        cache_format=MlaKvCacheFormat.BFP8_TILE,
+        hf_config=config,
         mesh_device=mesh_device,
         seq_len=isl_total,
         mesh_shape=mesh_shape,
@@ -1050,15 +1050,14 @@ def test_glm_prefill_block(
         # num_layers=layer_num) gets a valid count, not the None default.
         layer_num=1,
     )
-    kvpe_cache = init_kvpe_cache(
-        kvpe_cache_head_dim=config.kv_lora_rank + config.qk_rope_head_dim,
+    kvpe_cache = init_mla_kv_cache(
+        cache_format=MlaKvCacheFormat.BF16_RM,
+        hf_config=config,
         mesh_device=mesh_device,
         seq_len=seq_len,
         mesh_shape=mesh_shape,
         sp_axis=sp_axis,
         num_kvpe_cache_layers=1,
-        dtype=ttnn.bfloat16,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
     )
     # Sparse (DSA) MLA single-shot is folded onto the block-cyclic path (one full-seq chunk at offset 0):
     # it uses the indexed rope tables and a caller-owned indexer key cache, exactly like the chunked path.

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block_chunked.py
@@ -41,7 +41,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_route
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_block import TtPrefillBlock
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker
-from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
+from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, init_kvpe_cache, init_mla_kv_cache
 from models.demos.deepseek_v3_d_p.utils.test_utils import (
     cache_half_pccs,
     gather_cache_tp0,
@@ -229,8 +229,9 @@ def run_chunked_block(
     rope_setup = RotarySetup(config, mesh_device, sp_axis=sp_axis, is_balanced=False)
     indexed_rope = rope_setup.get_rope_tensors_indexed(cache_seq_len_global=SEQ_CACHE, chunk_size_global=CHUNK)
 
-    tt_kvpe_cache = init_kvpe_cache(
-        kvpe_cache_head_dim=kvpe_dim,
+    tt_kvpe_cache = init_mla_kv_cache(
+        cache_format=MlaKvCacheFormat.BFP8_TILE,
+        hf_config=config,
         mesh_device=mesh_device,
         seq_len=SEQ_CACHE,
         mesh_shape=mesh_shape,
@@ -331,7 +332,7 @@ def run_chunked_block(
 
     # --- Independent sanity check: un-rotate the final device cache and compare to kv_post_transform. ---
     cache_sr = ttnn.to_torch(
-        tt_kvpe_cache,
+        tt_kvpe_cache.storage,
         mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape),
     ).to(torch.float32)[:, :1][
         0, 0
@@ -473,8 +474,9 @@ def run_chunked_block_multiuser(
     indexed_rope = rope_setup.get_rope_tensors_indexed(cache_seq_len_global=SEQ_CACHE, chunk_size_global=CHUNK)
 
     # num_users-slot cache (batch = num_users * 1 layer); only target_slot is written below.
-    tt_kvpe_cache = init_kvpe_cache(
-        kvpe_cache_head_dim=kvpe_dim,
+    tt_kvpe_cache = init_mla_kv_cache(
+        cache_format=MlaKvCacheFormat.BFP8_TILE,
+        hf_config=config,
         mesh_device=mesh_device,
         seq_len=SEQ_CACHE,
         mesh_shape=mesh_shape,
@@ -503,7 +505,7 @@ def run_chunked_block_multiuser(
     block.forward(
         tt_h,
         indexed_rope,
-        tt_kvpe_cache,
+        tt_kvpe_cache.storage,
         cache_layer_idx=0,
         actual_start=0,
         actual_end=CHUNK,
@@ -513,7 +515,7 @@ def run_chunked_block_multiuser(
 
     # Read all slots: gather SP (dim2) + TP (dim1), keep TP replica 0 -> [num_users, 1, SEQ_CACHE, kvpe].
     cache_all = ttnn.to_torch(
-        tt_kvpe_cache,
+        tt_kvpe_cache.storage,
         mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape),
     ).to(torch.float32)[:, :1]
     p = blockcyclic_positions(sp, CHUNK, SEQ_CACHE)
@@ -690,8 +692,9 @@ def run_chunked_block_padded(
 
     rope_setup = RotarySetup(config, mesh_device, sp_axis=sp_axis, is_balanced=False)
     indexed_rope = rope_setup.get_rope_tensors_indexed(cache_seq_len_global=seq_len_cache, chunk_size_global=CHUNK)
-    tt_kvpe_cache = init_kvpe_cache(
-        kvpe_cache_head_dim=kvpe_dim,
+    tt_kvpe_cache = init_mla_kv_cache(
+        cache_format=MlaKvCacheFormat.BFP8_TILE,
+        hf_config=config,
         mesh_device=mesh_device,
         seq_len=seq_len_cache,
         mesh_shape=mesh_shape,
@@ -798,7 +801,7 @@ def run_chunked_block_padded(
     # --- Final: gather the device KV cache, un-rotate, compare the contiguous [:total_real] valid
     #     region to the trace's kv_post_transform (this is the "5k gathered from 2 chunks" check). ---
     cache_sr = ttnn.to_torch(
-        tt_kvpe_cache,
+        tt_kvpe_cache.storage,
         mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape),
     ).to(torch.float32)[:, :1][
         0, 0

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block_loop.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block_loop.py
@@ -39,7 +39,7 @@ from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_block import TtPrefillBlock
-from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
+from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, init_mla_kv_cache
 from models.demos.deepseek_v3_d_p.utils.transformer_helpers import (
     PROMPT_1K_PATH,
     PROMPT_25K_PATH,
@@ -509,8 +509,6 @@ def test_prefill_block_loop(
     rope_setup = RotarySetup(config, mesh_device, sp_axis=sp_axis, is_balanced=True)
     rope_tensors = rope_setup.get_rope_tensors(isl_total)
     position_ids = torch.arange(isl_total, dtype=torch.long).unsqueeze(0)
-    kvpe_cache_head_dim = config.qk_rope_head_dim + config.kv_lora_rank
-
     # Shard initial input to device
     h_tt = ttnn.from_torch(
         h0.unsqueeze(0),  # [1, 1, 1024, 7168]
@@ -563,8 +561,9 @@ def test_prefill_block_loop(
 
     for iteration in range(1, num_iters + 1):
         # Fresh KV cache each iteration (prefill writes full seq range)
-        tt_kvpe_cache = init_kvpe_cache(
-            kvpe_cache_head_dim=kvpe_cache_head_dim,
+        tt_kvpe_cache = init_mla_kv_cache(
+            cache_format=MlaKvCacheFormat.BFP8_TILE,
+            hf_config=config,
             mesh_device=mesh_device,
             seq_len=isl_total,
             mesh_shape=mesh_shape,
@@ -592,7 +591,7 @@ def test_prefill_block_loop(
         if skip_reference:
             logger.info(f"  Iter {iteration:>3d}/{num_iters}  TT forward done (perf-only, no PCC)")
             h_tt = h_tt_next
-            ttnn.deallocate(tt_kvpe_cache)
+            ttnn.deallocate(tt_kvpe_cache.storage)
             continue
 
         # --- PCC ---
@@ -643,7 +642,7 @@ def test_prefill_block_loop(
         h_tt = h_tt_next
 
         # --- Cleanup KV cache ---
-        ttnn.deallocate(tt_kvpe_cache)
+        ttnn.deallocate(tt_kvpe_cache.storage)
 
     if skip_reference:
         logger.info("skip_reference=True: perf-only run complete (no PCC/plot/summary)")

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
@@ -45,7 +45,7 @@ from models.demos.deepseek_v3_d_p.tt.mla.utils import (
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_transformer import TtPrefillTransformer
-from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
+from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, init_kvpe_cache, init_mla_kv_cache
 from models.demos.deepseek_v3_d_p.utils.pcc_plot_utils import generate_pcc_plots, write_pcc_summary
 from models.demos.deepseek_v3_d_p.utils.test_utils import save_intermediate_output
 from models.demos.deepseek_v3_d_p.utils.transformer_helpers import (
@@ -441,21 +441,16 @@ def run_model(
     profiler.end("tt_transformer_creation")
 
     # --- Create external KVPE cache ---
-    kvpe_cache_head_dim = config.qk_rope_head_dim + config.kv_lora_rank
-    # Sparse MLA (DSA: v3.2 / GLM) reads the KVPE cache natively in sparse_sdpa and requires it
-    # uncompressed (bf16 ROW_MAJOR — mla.py asserts); dense MLA keeps the bfloat8_b/TILE cache.
     has_indexer = resolve_has_indexer(config)
-    kvpe_dtype = ttnn.bfloat16 if has_indexer else ttnn.bfloat8_b
-    kvpe_layout = ttnn.ROW_MAJOR_LAYOUT if has_indexer else ttnn.TILE_LAYOUT
-    tt_kvpe_cache = init_kvpe_cache(
-        kvpe_cache_head_dim=kvpe_cache_head_dim,
+    cache_format = MlaKvCacheFormat.BF16_RM if has_indexer else MlaKvCacheFormat.BFP8_TILE
+    tt_kvpe_cache = init_mla_kv_cache(
+        cache_format=cache_format,
+        hf_config=config,
         mesh_device=mesh_device,
         seq_len=isl_total,
         mesh_shape=mesh_shape,
         sp_axis=sp_axis,
         num_kvpe_cache_layers=num_layers,
-        dtype=kvpe_dtype,
-        layout=kvpe_layout,
     )
 
     # Sparse single-shot is folded onto the block-cyclic path, so (like chunked) it needs the caller-owned,
@@ -516,7 +511,7 @@ def run_model(
             torch.manual_seed(0)
             first_token_id, _, tt_intermediates = transformer(
                 tt_tokens,
-                tt_kvpe_cache,
+                tt_kvpe_cache.storage,
                 actual_isl=number_of_non_padded_tokens,
                 return_intermediates=True,
                 read_profiler=False,
@@ -676,7 +671,7 @@ def run_model(
         # Per-layer KVPE PCC comparison — read back from external cache
         if do_return_kv and ref_kvpe_list is not None:
             tt_kvpe_all = ttnn.to_torch(
-                tt_kvpe_cache,
+                tt_kvpe_cache.storage,
                 mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape),
             ).to(torch.bfloat16)
             # Shape: [num_layers, tp_factor, seq_total, head_dim] — take first TP replica

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -50,7 +50,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_route
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_block import get_block_timings, reset_block_timings
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_transformer import TtPrefillTransformer
-from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
+from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, init_kvpe_cache, init_mla_kv_cache
 from models.demos.deepseek_v3_d_p.utils.test_utils import (
     cache_half_pccs,
     gather_cache_tp0,
@@ -284,7 +284,7 @@ def _preload_kvpe_prefix_from_trace(
         layout=host_layout,
         mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=cache_shard_dims),
     )
-    ttnn.copy_host_to_device_tensor(cache_host_tt, tt_kvpe_cache)
+    ttnn.copy_host_to_device_tensor(cache_host_tt, tt_kvpe_cache.storage)
     ttnn.synchronize_device(mesh_device)
 
 
@@ -434,8 +434,9 @@ def run_chunked_transformer_padded(
     gc.collect()
     profiler.end("tt_transformer_creation")
 
-    tt_kvpe_cache = init_kvpe_cache(
-        kvpe_cache_head_dim=kvpe_dim,
+    tt_kvpe_cache = init_mla_kv_cache(
+        cache_format=MlaKvCacheFormat.BFP8_TILE,
+        hf_config=config,
         mesh_device=mesh_device,
         seq_len=seq_len_cache,
         mesh_shape=mesh_shape,
@@ -625,16 +626,16 @@ def run_chunked_transformer(
     # natively; mla.forward asserts) — NOT the init_kvpe_cache bfloat8_b/TILE default that dense
     # ring_mla wants. Match the cache format to the path.
     has_indexer = resolve_has_indexer(config)
-    kvpe_dtype_layout = dict(dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT) if has_indexer else {}
-    tt_kvpe_cache = init_kvpe_cache(
-        kvpe_cache_head_dim=kvpe_dim,
+    cache_format = MlaKvCacheFormat.BF16_RM if has_indexer else MlaKvCacheFormat.BFP8_TILE
+    tt_kvpe_cache = init_mla_kv_cache(
+        cache_format=cache_format,
+        hf_config=config,
         mesh_device=mesh_device,
         seq_len=SEQ_CACHE,
         mesh_shape=mesh_shape,
         sp_axis=sp_axis,
         num_kvpe_cache_layers=num_layers,
         num_users=1,
-        **kvpe_dtype_layout,
     )
 
     # Sparse (DSA) layers read a block-cyclic indexer key cache that is caller-owned and passed into
@@ -1269,8 +1270,9 @@ def run_chunked_transformer_no_pcc(
     # default that dense ring_mla wants. Match the cache format to the path (dense variants keep the
     # default). Same distinction as run_chunked_transformer.
     kvpe_dtype_layout = dict(dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT) if resolve_has_indexer(config) else {}
-    tt_kvpe_cache = init_kvpe_cache(
-        kvpe_cache_head_dim=kvpe_dim,
+    tt_kvpe_cache = init_mla_kv_cache(
+        cache_format=MlaKvCacheFormat.BFP8_TILE,
+        hf_config=config,
         mesh_device=mesh_device,
         seq_len=SEQ_CACHE_NOPCC,
         mesh_shape=mesh_shape,

--- a/models/demos/deepseek_v3_d_p/tests/test_sparse_kv_cache_contract.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_sparse_kv_cache_contract.py
@@ -1,0 +1,236 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import ttnn
+from models.demos.deepseek_v3_d_p.utils import kv_cache_utils
+from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import (
+    MlaKvCache,
+    MlaKvCacheFormat,
+    MlaKvCacheGeometry,
+    init_mla_kv_cache,
+    reconstruct_scaled_fp8_kv_cache,
+    unpack_scaled_fp8_kv_cache,
+)
+
+
+def _tensor(shape, dtype, layout=ttnn.ROW_MAJOR_LAYOUT):
+    return SimpleNamespace(shape=shape, dtype=dtype, layout=layout)
+
+
+PRODUCTION_GEOMETRY = MlaKvCacheGeometry(latent_dim=512, rope_dim=64)
+
+
+def test_mla_kv_cache_geometry_is_derived_from_config():
+    config = SimpleNamespace(kv_lora_rank=1024, qk_rope_head_dim=32)
+    geometry = MlaKvCacheGeometry.from_config(config)
+
+    assert geometry.logical_width == 1056
+    assert geometry.num_scales == 8
+    assert geometry.rope_offset_bytes == 1056
+    assert geometry.packed_row_bytes == 1120
+
+    storage = _tensor((1, 1, 32, geometry.packed_row_bytes), ttnn.fp8_e4m3)
+    cache = MlaKvCache(MlaKvCacheFormat.SCALED_FP8, storage=storage, geometry=geometry)
+    assert cache.geometry is geometry
+
+
+def test_scaled_mla_kv_cache_geometry_rejects_unaligned_rope_offset(expect_error):
+    geometry = MlaKvCacheGeometry(latent_dim=256, rope_dim=32)
+    storage = _tensor((1, 1, 32, geometry.packed_row_bytes), ttnn.fp8_e4m3)
+
+    with expect_error(ValueError, "16-byte aligned"):
+        MlaKvCache(MlaKvCacheFormat.SCALED_FP8, storage=storage, geometry=geometry)
+
+
+def test_mla_kv_cache_allocation_uses_config_geometry(monkeypatch):
+    config = SimpleNamespace(kv_lora_rank=1024, qk_rope_head_dim=32)
+
+    def allocate(*, kvpe_cache_head_dim, dtype, layout, **_):
+        return _tensor((1, 1, 32, kvpe_cache_head_dim), dtype, layout)
+
+    monkeypatch.setattr(kv_cache_utils, "init_kvpe_cache", allocate)
+    cache = init_mla_kv_cache(
+        cache_format=MlaKvCacheFormat.SCALED_FP8,
+        hf_config=config,
+        mesh_device=object(),
+        seq_len=32,
+        mesh_shape=[1, 1],
+        sp_axis=0,
+        num_kvpe_cache_layers=1,
+    )
+
+    assert cache.geometry == MlaKvCacheGeometry.from_config(config)
+    assert cache.storage.shape[-1] == 1120
+
+
+def test_synthetic_scaled_fp8_host_codec_uses_geometry_offsets():
+    geometry = MlaKvCacheGeometry(latent_dim=1024, rope_dim=32)
+    latent = torch.ones((1, geometry.latent_dim), dtype=torch.float8_e4m3fn)
+    scales = torch.arange(1, geometry.num_scales + 1, dtype=torch.float32).unsqueeze(0)
+    rope = torch.arange(geometry.rope_dim, dtype=torch.float32).to(torch.bfloat16).unsqueeze(0)
+    packed = torch.cat((latent.view(torch.uint8), scales.view(torch.uint8), rope.view(torch.uint8)), dim=-1).view(
+        torch.float8_e4m3fn
+    )
+
+    decoded = reconstruct_scaled_fp8_kv_cache(packed, geometry)
+    expected_latent = scales.repeat_interleave(geometry.SCALE_BLOCK_SIZE, dim=-1).to(torch.bfloat16)
+    torch.testing.assert_close(decoded, torch.cat((expected_latent, rope), dim=-1), rtol=0, atol=0)
+
+
+def test_mla_kv_cache_contract_covers_dense_and_sparse_physical_formats():
+    dense = MlaKvCache(
+        MlaKvCacheFormat.BFP8_TILE,
+        storage=_tensor((1, 1, 32, 576), ttnn.bfloat8_b, ttnn.TILE_LAYOUT),
+        geometry=PRODUCTION_GEOMETRY,
+    )
+    sparse = MlaKvCache(
+        MlaKvCacheFormat.BF16_RM,
+        storage=_tensor((1, 1, 32, 576), ttnn.bfloat16),
+        geometry=PRODUCTION_GEOMETRY,
+    )
+
+    assert dense.storage.layout == ttnn.TILE_LAYOUT
+    assert sparse.storage.layout == ttnn.ROW_MAJOR_LAYOUT
+
+
+def test_homogeneous_mla_kv_cache_does_not_require_scaled_geometry():
+    geometry = MlaKvCacheGeometry(latent_dim=96, rope_dim=32)
+    storage = _tensor((1, 1, 32, geometry.logical_width), ttnn.bfloat16)
+
+    cache = MlaKvCache(MlaKvCacheFormat.BF16_RM, storage=storage, geometry=geometry)
+
+    assert cache.storage is storage
+
+
+def test_bf16_sparse_kv_contract_retains_combined_cache():
+    kvpe = _tensor((78, 1, 1024, 576), ttnn.bfloat16)
+    cache = MlaKvCache(MlaKvCacheFormat.BF16_RM, storage=kvpe, geometry=PRODUCTION_GEOMETRY)
+
+    assert cache.storage is kvpe
+
+
+def test_mla_kv_cache_pack_rejects_inputs_that_disagree_with_config(expect_error):
+    storage = _tensor((1, 1, 32, PRODUCTION_GEOMETRY.logical_width), ttnn.bfloat16)
+    cache = MlaKvCache(MlaKvCacheFormat.BF16_RM, storage=storage, geometry=PRODUCTION_GEOMETRY)
+    latent = SimpleNamespace(shape=(1, 1, 32, 256))
+    rope = SimpleNamespace(shape=(1, 1, 32, 64))
+
+    with expect_error(ValueError, "latent width 512"):
+        cache.pack(latent, rope)
+
+
+def test_scaled_fp8_sparse_kv_contract_owns_one_mixed_format_cache():
+    packed = _tensor((78, 1, 1024, 656), ttnn.fp8_e4m3)
+    cache = MlaKvCache(MlaKvCacheFormat.SCALED_FP8, storage=packed, geometry=PRODUCTION_GEOMETRY)
+
+    assert cache.storage is packed
+    assert cache.geometry.packed_row_bytes == 656
+    assert cache.geometry.packed_row_bytes < 0.59 * cache.geometry.logical_width * 2
+
+
+def test_scaled_fp8_packed_host_codec_preserves_mixed_fields():
+    latent = torch.tensor([[0.5, -1.0, 2.0, -4.0]], dtype=torch.float8_e4m3fn).repeat(1, 128)
+    scales = torch.tensor([[0.25, 0.5, 1.0, 2.0]], dtype=torch.float32)
+    rope = torch.arange(64, dtype=torch.float32).to(torch.bfloat16).unsqueeze(0)
+    raw = torch.cat(
+        (latent.view(torch.uint8), scales.view(torch.uint8), rope.view(torch.uint8)),
+        dim=-1,
+    )
+    packed = raw.view(torch.float8_e4m3fn)
+
+    decoded_latent, decoded_scales, decoded_rope = unpack_scaled_fp8_kv_cache(packed, PRODUCTION_GEOMETRY)
+    torch.testing.assert_close(decoded_latent, latent.float(), rtol=0, atol=0)
+    torch.testing.assert_close(decoded_scales, scales, rtol=0, atol=0)
+    torch.testing.assert_close(decoded_rope, rope, rtol=0, atol=0)
+
+    expected_latent = latent.float() * scales.repeat_interleave(128, dim=-1)
+    expected = torch.cat((expected_latent.to(torch.bfloat16), rope), dim=-1)
+    torch.testing.assert_close(reconstruct_scaled_fp8_kv_cache(packed, PRODUCTION_GEOMETRY), expected, rtol=0, atol=0)
+
+
+def test_scaled_fp8_packing_preserves_logical_kvpe_debug_intermediate(monkeypatch):
+    latent = SimpleNamespace(shape=(1, 1, 32, PRODUCTION_GEOMETRY.latent_dim))
+    rope = SimpleNamespace(shape=(1, 1, 32, PRODUCTION_GEOMETRY.rope_dim))
+    latent_rm = object()
+    rope_rm = object()
+    latent_fp8 = object()
+    scales = object()
+    reconstructed_latent = object()
+    logical_kvpe = object()
+    packed = _tensor((1, 1, 32, PRODUCTION_GEOMETRY.packed_row_bytes), ttnn.fp8_e4m3)
+    deallocated = []
+
+    def to_layout(tensor, layout):
+        assert layout == ttnn.ROW_MAJOR_LAYOUT
+        return latent_rm if tensor is latent else rope_rm
+
+    def cast_to_fp8(tensor, *, round_scale_to_power_of_two):
+        assert tensor is latent_rm
+        assert round_scale_to_power_of_two
+        return latent_fp8, scales
+
+    def cast_back(fp8, fp8_scales, *, output_dtype):
+        assert (fp8, fp8_scales, output_dtype) == (latent_fp8, scales, ttnn.bfloat16)
+        return reconstructed_latent
+
+    def pack(fp8, fp8_scales, packed_rope):
+        assert (fp8, fp8_scales, packed_rope) == (latent_fp8, scales, rope_rm)
+        return packed
+
+    def concat(tensors, *, dim):
+        assert tensors == [reconstructed_latent, rope_rm]
+        assert dim == -1
+        return logical_kvpe
+
+    monkeypatch.setattr(ttnn, "to_layout", to_layout)
+    monkeypatch.setattr(ttnn, "deallocate", deallocated.append)
+    monkeypatch.setattr(ttnn, "clone", lambda tensor: ("clone", tensor))
+    monkeypatch.setattr(ttnn, "concat", concat)
+    monkeypatch.setattr(ttnn.experimental.deepseek_prefill, "per_token_cast_to_fp8", cast_to_fp8)
+    monkeypatch.setattr(ttnn.experimental.deepseek_prefill, "per_token_cast_back", cast_back)
+    monkeypatch.setattr(ttnn.experimental.deepseek_prefill, "pack_scaled_fp8_kv_cache", pack)
+
+    intermediates = {}
+    cache = MlaKvCache(MlaKvCacheFormat.SCALED_FP8, storage=packed, geometry=PRODUCTION_GEOMETRY)
+    encoded = cache.pack(latent, rope, intermediates=intermediates)
+
+    assert encoded is packed
+    assert intermediates["tt_kvpe"] is logical_kvpe
+    assert intermediates["tt_kvpe_latent"] == ("clone", latent_fp8)
+    assert intermediates["tt_kvpe_scales"] == ("clone", scales)
+    assert intermediates["tt_kvpe_rope"] == ("clone", rope_rm)
+    assert intermediates["tt_kvpe_packed"] == ("clone", packed)
+    assert reconstructed_latent in deallocated
+
+
+@pytest.mark.parametrize(
+    "packed,match",
+    [
+        (
+            _tensor((1, 1, 32, 656), ttnn.bfloat16),
+            "cache must use",
+        ),
+        (
+            _tensor((1, 1, 32, 512), ttnn.fp8_e4m3),
+            "cache width must be 656",
+        ),
+        (
+            _tensor((1, 1, 32, 656), ttnn.fp8_e4m3, ttnn.TILE_LAYOUT),
+            "ROW_MAJOR",
+        ),
+    ],
+)
+def test_scaled_fp8_sparse_kv_contract_rejects_invalid_packed_storage(packed, match, expect_error):
+    with expect_error(ValueError, match):
+        MlaKvCache(MlaKvCacheFormat.SCALED_FP8, storage=packed, geometry=PRODUCTION_GEOMETRY)
+
+
+def test_index_cache_contract_remains_tiled_bfloat8_b():
+    index_cache = _tensor((78, 1, 1024, 128), ttnn.bfloat8_b, ttnn.TILE_LAYOUT)
+    assert index_cache.dtype == ttnn.bfloat8_b
+    assert index_cache.layout == ttnn.TILE_LAYOUT

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -21,6 +21,7 @@ from models.demos.deepseek_v3_d_p.tt.mla.indexer import (
 )
 from models.demos.deepseek_v3_d_p.tt.mla.mla_config import MLA_MATMUL_CONFIG, MLA_SDPA_CONFIG
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import get_tt_ccl
+from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCache, MlaKvCacheFormat, MlaKvCacheGeometry
 
 
 class ttMLA:
@@ -263,6 +264,7 @@ class ttMLA:
         layer_num: int = 61,
         kv_only: bool = False,
         has_indexer: bool | None = None,
+        sparse_kv_cache_format: MlaKvCacheFormat = MlaKvCacheFormat.BF16_RM,
     ):
         # DSA indexer weights (v3.2 / GLM): extract NON-mutating, so the caller's state_dict survives
         # repeated construction / cache build+load (the old pop() emptied it on the first pass). Dense
@@ -279,6 +281,8 @@ class ttMLA:
         self.is_chunked = is_chunked
         self.slot_num = slot_num
         self.layer_num = layer_num
+        self.sparse_kv_cache_format = MlaKvCacheFormat(sparse_kv_cache_format or MlaKvCacheFormat.BF16_RM)
+        self.kv_cache_geometry = MlaKvCacheGeometry.from_config(config)
 
         # DSA indexer (v3.2 / GLM): resolve sparse mode EXPLICITLY — config DSA fields, then live host
         # weights, then a complete indexer cache — never from bool(idx_host), which silently went dense
@@ -459,9 +463,6 @@ class ttMLA:
             # device RoPE and the indexer_score per-device causal offset both index positions as
             # start_pos + sp_rank*S_local). The balanced chunk reorder breaks that, so guard it.
             assert not self.is_balanced, "DSA indexer requires is_balanced=False (natural-order SP sharding)"
-            # kv_only (last-layer KV-only fast path) skips Q/SDPA AND the indexer K-cache write, so a
-            # sparse decode would read an unpopulated indexer cache. Not implemented — fail at construction.
-            assert not self.kv_only, "DSA sparse path does not support kv_only (skips the indexer K-cache write)"
             if self._indexer_reuse:
                 self._indexer = ReuseIndexer()  # shared layer: reused indices injected at forward
             else:
@@ -507,10 +508,10 @@ class ttMLA:
             self._attention = self._dense_chunked_attn if self.is_chunked else self._dense_single_attn
 
     @staticmethod
-    def kv_cache_to_host(kvpe_cache: ttnn.Tensor, mesh_device: ttnn.MeshDevice, sp_axis: int = 0):
-        """Read KVPE cache from device to host tensor [1, 1, seq_total, kv_lora_rank + qk_rope_head_dim]."""
-        return ttnn.to_torch(
-            kvpe_cache,
+    def kv_cache_to_host(kvpe_cache: MlaKvCache, mesh_device: ttnn.MeshDevice, sp_axis: int = 0):
+        """Read and decode the logical KVPE cache in natural SP order."""
+        host = ttnn.to_torch(
+            kvpe_cache.storage,
             mesh_composer=ttnn.create_mesh_composer(
                 mesh_device,
                 config=ttnn.MeshComposerConfig(
@@ -521,7 +522,8 @@ class ttMLA:
                     ),
                 ),
             ),
-        ).to(torch.bfloat16)
+        )
+        return kvpe_cache.unpack_host(host)
 
     def get_weight_shapes(self) -> dict[str, tuple]:
         shapes = {
@@ -715,7 +717,7 @@ class ttMLA:
         *,
         tt_q: ttnn.Tensor,
         tt_kvpe: ttnn.Tensor,
-        kvpe_cache: ttnn.Tensor,
+        kvpe_cache: MlaKvCache,
         kv_actual_isl: int,
         cache_batch_idx: int,
         cache_layer_idx: int,
@@ -744,7 +746,7 @@ class ttMLA:
         # Write this chunk into the cache. update_padded_kv_cache derives each chip's local write
         # offset on-device from kv_actual_global (chunk-aligned kv_actual -> uniform per-chip write).
         ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
-            kvpe_cache,
+            kvpe_cache.storage,
             tt_kvpe,
             slot_idx=cache_user_id,
             layer_idx=cache_layer_idx,
@@ -758,7 +760,7 @@ class ttMLA:
         # user/layer's slot; kv_actual_isl drives the on-device rotation/causality offset.
         attn_out, _ = ttnn.transformer.ring_mla(
             tt_q,
-            kvpe_cache,
+            kvpe_cache.storage,
             persistent_output_buffer_kv=self._chunked_kv_buf,
             head_dim_v=self.kv_lora_rank,
             logical_n=kv_actual_isl + chunk_size_global,
@@ -894,15 +896,12 @@ class ttMLA:
         kv_actual_isl: Optional[int],
         seq_len_local: int,
         return_kv_intermediates: bool,
-        kvpe_cache: ttnn.Tensor,
-    ) -> tuple[ttnn.Tensor, ttnn.Tensor, dict | None]:
+        kvpe_cache: MlaKvCache,
+    ) -> tuple[ttnn.Tensor, Optional[ttnn.Tensor], dict | None]:
         """Shared KV stem.
 
-        Returns tt_kvpe: the kvpe converted to the persistent cache's dtype/layout via
-        _to_cache_format (bf8/TILE for dense, bf16 or fp8/ROW_MAJOR for sparse). This single tensor
-        is BOTH written to the cache and consumed as the attention K input — dense ring SDPA takes it
-        as-is, and sparse_sdpa reads the uncompressed sparse cache format natively, so no separate
-        full-precision copy is needed. Also returns tt_kv_nope (dense V projection) + intermediates.
+        Returns tt_kvpe in the persistent cache representation. The returned value is both written to the
+        cache and consumed by attention without a decode/re-encode round trip.
         """
         # NOTE: input is ideally L1 for chunked, but hidden states memory config is set outside the module
         tt_kv = ttnn.linear(
@@ -953,18 +952,12 @@ class ttMLA:
             kv_intermediates["tt_kv_nope"] = ttnn.clone(tt_kv_nope)
             kv_intermediates["tt_kv_rope"] = ttnn.clone(tt_kv_rope)
 
-        # TODO: concat rope and nope, workaround remove with ttnn.narrow or fusion
-        tt_kvpe_raw = ttnn.concat([tt_kv_nope, tt_kv_rope], dim=-1)
+        tt_kvpe = kvpe_cache.pack(tt_kv_nope, tt_kv_rope, intermediates=kv_intermediates)
         ttnn.deallocate(tt_kv_rope)
-        # Match the persistent cache format: bf8/TILE (dense) OR bf16 or fp8/ROW_MAJOR (sparse). For the
-        # uncompressed sparse cache this is a layout-only change (no dtype typecast), so sparse_sdpa reads
-        # it natively with no bf8->bf16 round-trip.
-        tt_kvpe = self._to_cache_format(tt_kvpe_raw, kvpe_cache)
-        ttnn.deallocate(tt_kvpe_raw)
-
-        if return_kv_intermediates:
-            # post-transform concat ([.., 576]) in the cache dtype -- what actually gets written.
-            kv_intermediates["tt_kvpe"] = ttnn.clone(tt_kvpe)
+        if self._has_indexer:
+            # Sparse attention reads latent V from the cache; only dense attention needs this standalone tensor.
+            ttnn.deallocate(tt_kv_nope)
+            tt_kv_nope = None
 
         return tt_kvpe, tt_kv_nope, kv_intermediates
 
@@ -976,30 +969,9 @@ class ttMLA:
             **self._get_mm_kwargs("wkv_b2", seq_len_local),
         )
 
-    def _to_cache_format(self, t: ttnn.Tensor, cache: ttnn.Tensor) -> ttnn.Tensor:
-        """Convert the freshly computed kvpe `t` (bf16, TILE) to the persistent cache's dtype+layout
-        for a write. The write ops require input dtype AND layout to match the cache:
-          - bf8/TILE cache (dense): typecast bf16->bfloat8_b, stays TILE.
-          - bf16 or fp8_e4m3 / ROW_MAJOR cache (sparse): retile TILE->ROW_MAJOR, and typecast only for
-            fp8 (bf16 needs none) — so sparse_sdpa reads the prefix natively, no bf8->bf16 round-trip.
-        LAYOUT is converted BEFORE dtype: fp8_e4m3 is ROW_MAJOR-only, so it must be produced by
-        typecasting an already-ROW_MAJOR tensor (never a TILE fp8 intermediate, which is unsupported) —
-        matching how init_kvpe_cache builds the fp8 cache. bf8 (block-float, TILE-only) is the reverse
-        case, but its layout already matches (both TILE) so the layout step is a no-op there.
-        Always returns a fresh tensor (clones if `t` already matches the cache format)."""
-        out = t
-        if out.layout != cache.layout:
-            out = ttnn.to_layout(out, cache.layout)
-        if out.dtype != cache.dtype:
-            relaid = ttnn.typecast(out, cache.dtype)
-            if out is not t:
-                ttnn.deallocate(out)
-            out = relaid
-        return ttnn.clone(t) if out is t else out
-
-    def _write_kvpe(self, kvpe_cache: ttnn.Tensor, tt_kvpe: ttnn.Tensor, cache_layer_idx: int) -> None:
+    def _write_kvpe(self, kvpe_cache: MlaKvCache, tt_kvpe: ttnn.Tensor, cache_layer_idx: int) -> None:
         """DENSE single-shot cache fill: write this layer's whole kvpe slot (bf8/TILE, already in the
-        cache's dtype/layout via _to_cache_format). Chunked modes (dense + sparse) and sparse single-shot
+        cache's dtype/layout via MlaKvCache.pack). Chunked modes (dense + sparse) and sparse single-shot
         write through update_padded_kv_cache instead; only dense single-shot still uses this TILE-only
         fill_cache_for_user_ primitive.
 
@@ -1009,7 +981,26 @@ class ttMLA:
         cluster_axis / block-cyclic / tile-aligned-kv_actual_global path is not yet validated. Confirm
         update_padded handles 1x1 (and sp=1), then switch _dense_single_attn onto it too (the sparse path
         already folded its single-shot onto the block-cyclic update_padded write)."""
-        ttnn.kv_cache.fill_cache_for_user_(kvpe_cache, tt_kvpe, cache_layer_idx)
+        ttnn.kv_cache.fill_cache_for_user_(kvpe_cache.storage, tt_kvpe, cache_layer_idx)
+
+    def _update_kv_cache(
+        self,
+        cache: MlaKvCache,
+        values: ttnn.Tensor,
+        *,
+        cache_user_id: int,
+        cache_layer_idx: int,
+        kv_actual_isl: int,
+    ) -> None:
+        ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
+            cache.storage,
+            values,
+            slot_idx=cache_user_id,
+            layer_idx=cache_layer_idx,
+            num_layers=self.layer_num,
+            kv_actual_global=kv_actual_isl,
+            cluster_axis=self.sp_axis,
+        )
 
     def _o_proj_epilogue(self, attn_out: ttnn.Tensor, seq_len_local: int) -> ttnn.Tensor:
         """Shared nlp_concat_heads -> o_proj -> TP reduce-scatter epilogue."""
@@ -1039,7 +1030,7 @@ class ttMLA:
         self,
         hidden_states: ttnn.Tensor,
         rope_tensors: dict,
-        kvpe_cache: ttnn.Tensor,
+        kvpe_cache: MlaKvCache,
         cache_layer_idx: int = 0,
         actual_start: Optional[int] = None,
         cache_user_id: int = 0,
@@ -1048,16 +1039,6 @@ class ttMLA:
         indexer_indices: Optional[ttnn.Tensor] = None,
         return_indexer_indices: bool = False,
     ) -> "ttnn.Tensor | tuple[ttnn.Tensor, Optional[dict]]":
-        if self.kv_only:
-            return self._forward_kv_only(
-                hidden_states,
-                rope_tensors,
-                kvpe_cache,
-                cache_layer_idx,
-                kv_actual_isl=actual_start,
-                cache_user_id=cache_user_id,
-            )
-
         # Chunked-prefill mode is fixed at construction: self.is_chunked drives buffer allocation in
         # __init__ and the rope variant, and forward honors that flag -- it does not infer the mode from
         # the arguments. actual_start is the chunk parameter, supplied iff chunked.
@@ -1065,10 +1046,22 @@ class ttMLA:
             f"actual_start ({'set' if actual_start is not None else 'None'}) does not match construction "
             f"(self.is_chunked={self.is_chunked}); pass actual_start iff built with is_chunked=True"
         )
+        if kvpe_cache.geometry != self.kv_cache_geometry:
+            raise ValueError(f"MLA configured for KV geometry {self.kv_cache_geometry}, got {kvpe_cache.geometry}")
+
+        if self.kv_only:
+            return self._forward_kv_only(
+                hidden_states,
+                rope_tensors,
+                kvpe_cache,
+                cache_layer_idx,
+                kv_actual_isl=actual_start or 0,
+                cache_user_id=cache_user_id,
+                index_kv_cache=index_kv_cache,
+            )
 
         seq_len_local = hidden_states.shape[2]
         kv_actual_isl = actual_start
-        is_chunked = self.is_chunked
 
         # Sparse always runs the block-cyclic path (indexed rope + kvpe cache read-back), which treats
         # single-shot as one full-seq chunk at offset 0. Coerce the None single-shot offset to 0 so the
@@ -1076,17 +1069,10 @@ class ttMLA:
         if self._has_indexer and kv_actual_isl is None:
             kv_actual_isl = 0
 
-        # Sparse attention (sparse_sdpa) reads the KVPE cache natively and only accepts bf16 / fp8_e4m3,
-        # ROW_MAJOR. Require the cache to already be in that op-wanted format so the whole path is a single
-        # kvpe tensor with NO compression round-trip (no bf8 typecast on write, no upcast on read-back).
         if self._has_indexer:
-            assert kvpe_cache.dtype in (ttnn.bfloat16, ttnn.fp8_e4m3), (
-                f"sparse MLA requires an uncompressed KVPE cache (bf16 or fp8_e4m3) that sparse_sdpa reads "
-                f"natively, got {kvpe_cache.dtype}"
-            )
             assert (
-                kvpe_cache.layout == ttnn.ROW_MAJOR_LAYOUT
-            ), f"sparse MLA requires a ROW_MAJOR KVPE cache, got {kvpe_cache.layout}"
+                kvpe_cache.format == self.sparse_kv_cache_format
+            ), f"MLA configured for {self.sparse_kv_cache_format}, got {kvpe_cache.format} cache"
 
         signpost(header="MLA_START")
 
@@ -1241,16 +1227,14 @@ class ttMLA:
         # gather ONLY that slot on device, then hand it to sparse_sdpa still block-cyclic — the op remaps
         # the natural top-k indices to physical pages in-kernel (block_cyclic_chunk_local = per-shard
         # chunk = seq_len_local), so no host reorder. Slicing the slot BEFORE the gather keeps the
-        # all-gather to a single [1,1,T,576] slot (gathering the whole B=num_users*num_layers cache OOMs
+        # all-gather to one physical-cache slot (gathering the whole B=num_users*num_layers cache OOMs
         # at 78 layers). The gathered kv is batch-1, so cache_batch_idx is unset (None) below.
-        ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
+        self._update_kv_cache(
             kvpe_cache,
             tt_kvpe,
-            slot_idx=cache_user_id,
-            layer_idx=cache_layer_idx,
-            num_layers=self.layer_num,
-            kv_actual_global=kv_actual_isl,
-            cluster_axis=self.sp_axis,
+            cache_user_id=cache_user_id,
+            cache_layer_idx=cache_layer_idx,
+            kv_actual_isl=kv_actual_isl,
         )
         # After the write above, KV is populated up to [0, kv_actual_isl + chunk_size_global); the gather
         # only needs that populated prefix (top-k indices never address the unwritten suffix).
@@ -1265,7 +1249,7 @@ class ttMLA:
         attn_out = self._sparse_mla(
             tt_q, kvpe_dev, indices, block_cyclic_chunk_local=seq_len_local, cache_batch_idx=None
         )
-        ttnn.deallocate(kvpe_dev)
+        ttnn.deallocate(kvpe_dev.storage)
         ttnn.deallocate(tt_q)
         return self._apply_wkv_b2(attn_out, seq_len_local)
 
@@ -1273,75 +1257,59 @@ class ttMLA:
         self,
         hidden_states: ttnn.Tensor,
         rope_tensors: dict,
-        kvpe_cache: ttnn.Tensor,
+        kvpe_cache: MlaKvCache,
         cache_layer_idx: int,
         kv_actual_isl: int,
         cache_user_id: int,
+        index_kv_cache: Optional[ttnn.Tensor],
     ) -> None:
-        """Last-layer fast path: fill the KV cache (which migration consumes), then stop. Skips
-        Q / SDPA / output projection entirely; the block also skips FFN/MoE/norm/LM head, so no
-        first-token output is produced.
+        """Last-layer fast path: fill the migratable KVPE cache, then stop before query/attention/output.
+
+        A sparse full-indexer layer also writes its index-key chunk to the caller-owned ``index_kv_cache``;
+        a shared/reuse-indexer layer deliberately skips that write because it owns no indexer state. The
+        enclosing block skips FFN/MoE/norm/LM head as well, so this path produces no first-token output.
         """
         signpost(header="MLA_START")
         seq_len_local = hidden_states.shape[2]
 
-        tt_kv = ttnn.linear(
+        # Sparse decode needs the index key cache for every full-indexer layer even though this fast path
+        # skips query construction and scoring. Shared-indexer layers reuse a prior layer's selection and
+        # intentionally own no indexer weights/cache write.
+        if self._has_indexer and not self._indexer_reuse:
+            assert index_kv_cache is not None, "sparse kv_only requires the caller-owned index key cache"
+            self._indexer.write_k(
+                hidden_states,
+                seq_len_local,
+                kv_actual_isl,
+                rope_tensors=rope_tensors,
+                cache_user_id=cache_user_id,
+                cache_layer_idx=cache_layer_idx,
+                index_kbuf=index_kv_cache,
+            )
+
+        # Reuse the regular KV stem so kv_only and full attention cannot drift in normalization,
+        # RoPE, quantization, or cache packing behavior.
+        tt_kvpe, tt_kv_nope, _ = self._kv_stem(
             hidden_states,
-            self.kv_a_proj_with_mqa_weight,
-            compute_kernel_config=self.default_compute_kernel_config,
-            **self._get_mm_kwargs("kv_a_proj_with_mqa", seq_len_local),
+            rope_tensors,
+            kv_actual_isl,
+            seq_len_local,
+            return_kv_intermediates=False,
+            kvpe_cache=kvpe_cache,
         )
-
-        if self.tp_factor > 1:
-            tt_kv = ttnn.experimental.all_gather_async(
-                tt_kv,
-                dim=1,
-                multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis=self.tp_axis),
-                barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.tp_axis),
-                num_links=self.ccl_num_links,
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                topology=self.tp_ccl_topology,
-                cluster_axis=self.tp_axis,
-            )
-            tt_kv = ttnn.experimental.fast_reduce_nc(
-                tt_kv, dims=[1], output=None, compute_kernel_config=self.hifi4_fp32_compute_kernel_config
-            )
-
-        # TODO: split rope and nope, workaround remove with ttnn.narrow or fusion
-        tt_kv_nope = ttnn.slice(tt_kv, [0, 0, 0, 0], [1, 1, seq_len_local, self.kv_lora_rank])
-        tt_kv_rope = ttnn.slice(
-            tt_kv, [0, 0, 0, self.kv_lora_rank], [1, 1, seq_len_local, self.kv_lora_rank + self.qk_rope_head_dim]
-        )
-        ttnn.deallocate(tt_kv)
-
-        tt_kv_nope = ttnn.rms_norm(
-            tt_kv_nope,
-            weight=self.kv_a_layernorm_weight,
-            epsilon=self.config.rms_norm_eps,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            compute_kernel_config=self.default_compute_kernel_config,
-        )
-
-        # Same rope as the full chunked path (indexed/padded when chunked, single-shot otherwise) so
-        # the KV written to the cache carries the correct per-chunk positional offset.
-        tt_kv_rope = self._apply_rope(tt_kv_rope, rope_tensors, kv_actual_isl)
-
-        # TODO: concat rope and nope, workaround remove with ttnn.narrow or fusion
-        tt_kvpe = ttnn.concat([tt_kv_nope, tt_kv_rope], dim=-1)
-        ttnn.deallocate(tt_kv_rope)
-        tt_kvpe = ttnn.typecast(tt_kvpe, dtype=ttnn.bfloat8_b)
+        if tt_kv_nope is not None:
+            ttnn.deallocate(tt_kv_nope)
 
         # Write the chunk via the SAME chunked path as _chunked_attn (not a single-shot fill):
         # update_padded_kv_cache writes at the per-chip offset derived from kv_actual_global.
-        ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
+        self._update_kv_cache(
             kvpe_cache,
             tt_kvpe,
-            slot_idx=cache_user_id,
-            layer_idx=cache_layer_idx,
-            num_layers=self.layer_num,
-            kv_actual_global=kv_actual_isl,
-            cluster_axis=self.sp_axis,
+            cache_user_id=cache_user_id,
+            cache_layer_idx=cache_layer_idx,
+            kv_actual_isl=kv_actual_isl,
         )
+        ttnn.deallocate(tt_kvpe)
 
         signpost(header="MLA_END")
         return None
@@ -1382,7 +1350,7 @@ class ttMLA:
     def _sparse_mla(
         self,
         q: ttnn.Tensor,
-        kvpe: ttnn.Tensor,
+        kvpe: MlaKvCache,
         indices: ttnn.Tensor,
         block_cyclic_chunk_local: Optional[int] = None,
         cache_batch_idx: Optional[int] = None,
@@ -1392,19 +1360,19 @@ class ttMLA:
         each chip runs the single-chip ``ttnn.transformer.sparse_sdpa`` over its own q shard, so q's
         distribution is preserved — q SP-sharded on seq (dim2), TP-sharded on heads (dim1), out the same.
 
-        q: [1, H/tp, S/sp, 576] absorbed (TILE bf16); kvpe: [1, 1, T, 576] full latent prefix, ROW_MAJOR
-        replicated (K = full 576, V = leading kv_lora_rank). indices: [1, 1, S_global, k] uint32 replicated,
-        re-sharded onto SP (dim2) to match q when sp > 1 (or already SP-sharded → pass through).
+        q is absorbed ``[1, H/tp, S/sp, geometry.logical_width]`` TILE bf16. ``kvpe`` carries one
+        replicated ROW_MAJOR physical cache row per token; its width depends on the explicit cache format.
+        Indices are ``[1, 1, S_global, k]`` uint32, re-sharded onto SP (dim2) to match q when needed.
 
         block_cyclic_chunk_local: when set, ``kvpe`` is the KVPE cache in its native BLOCK-CYCLIC SP layout
         (not natural order) and ``indices`` are natural positions; sparse_sdpa remaps each index to its
         physical page in-kernel (invP) over the SP mesh axis, so the host reorder is eliminated. It is the
         per-shard chunk length (chunk_size_global / sp). None → natural-order kvpe (single-shot path).
 
-        cache_batch_idx: when set, ``kvpe`` is the whole multi-user cache [B, 1, T, 576] (B =
+        cache_batch_idx: when set, ``kvpe`` is the whole multi-user physical cache [B, 1, T, row_width] (B =
         num_users*num_layers user-major slots) and this selects the slot to attend — the op offsets its
         gather page ids by cache_batch_idx * T in-kernel, so no host slot-slice. None → ``kvpe`` is a
-        single [1, 1, T, 576] slot (single-shot path)."""
+        single [1, 1, T, row_width] slot (single-shot path)."""
         assert self.sp_axis == 0 and self.tp_axis == 1, "sparse_mla assumes sp_axis=0 (outer), tp_axis=1"
         sp = self.sp_factor
         seq_len_local = q.shape[2]  # per-chip query rows == S / sp
@@ -1445,9 +1413,10 @@ class ttMLA:
         k_chunk = next((c for c in (128, 64, 32) if idx.shape[-1] % c == 0), 32)
         out = ttnn.transformer.sparse_sdpa(
             q_rm,
-            kvpe,
+            kvpe.storage,
             idx,
             v_dim=self.kv_lora_rank,
+            kv_format=kvpe.format.sparse_sdpa_format,
             scale=self.scale,
             k_chunk_size=k_chunk,
             block_cyclic_sp_axis=self.sp_axis if block_cyclic_chunk_local is not None else None,
@@ -1469,17 +1438,19 @@ class ttMLA:
             ttnn.deallocate(out_all_heads)
         return ret
 
-    def _gather_kvpe_prefix(self, kvpe_cache, cache_batch_idx, populated_global=None, chunk_local=None):
+    def _gather_kvpe_prefix(
+        self, kvpe_cache: MlaKvCache, cache_batch_idx, populated_global=None, chunk_local=None
+    ) -> MlaKvCache:
         """On-device read-back of the chunked KVPE prefix for sparse attention. The cache is
-        ND-sharded / block-cyclic across SP, in the op's format (bf16 or fp8_e4m3, ROW_MAJOR — the
-        sparse cache is uncompressed). sparse_sdpa consumes it replicated and remaps the
+        ND-sharded / block-cyclic across SP, in the op's format (BF16 or packed scaled FP8, ROW_MAJOR).
+        sparse_sdpa consumes it replicated and remaps the
         natural-position indices to physical block-cyclic pages in-kernel (invP), so the buffer is
         LEFT in block-cyclic order — no host reorder.
 
         SLOT SELECT BEFORE THE GATHER: the persistent cache's per-chip shape is [B, 1, seq_len_local,
-        576], B = num_users*num_layers (user-major slots), seq_len_local = seq_len_cache / sp. Slice the
+        row_width], B = num_users*num_layers (user-major slots), seq_len_local = seq_len_cache / sp. Slice the
         active (user, layer) slot out of dim 0 FIRST, then all-gather only that single slot over SP (→
-        [1, 1, seq_len_cache, 576]) — NOT the whole B-slot cache. At 78 layers the full-cache gather is
+        [1, 1, seq_len_cache, row_width]) — NOT the whole B-slot cache. At 78 layers the full-cache gather is
         ~5 GB (×2 in-flight → OOM against the near-full 78-layer weights); the single-slot gather is B×
         smaller. The gathered kv is then batch-1, so sparse_sdpa needs NO cache_batch_idx (the op
         requires B==1 when cache_batch_idx is unset). This mirrors the dense ring_mla single-slot gather
@@ -1499,28 +1470,29 @@ class ttMLA:
         Pipeline (all on device): ND→interleaved, slot + populated-width slice (no-op for a single-slot,
         full-width cache), SP all-gather (no-op at sp==1). The cache is already in the op format, so there
         is NO read-back dtype/layout conversion."""
-        cache_i = ttnn.to_memory_config(kvpe_cache, ttnn.DRAM_MEMORY_CONFIG)  # ND_SHARDED → INTERLEAVED
 
-        slot_lo = cache_batch_idx if cache_i.shape[0] > 1 else 0  # user-major slot select (single-slot → 0)
-        seq_hi = cache_i.shape[2]  # per-chip seq width to gather; default = full allocated cache
+        storage = ttnn.to_memory_config(kvpe_cache.storage, ttnn.DRAM_MEMORY_CONFIG)
+        slot_lo = cache_batch_idx if storage.shape[0] > 1 else 0
+        seq_hi = storage.shape[2]
         if populated_global is not None and chunk_local is not None:
-            # Round the populated depth UP to whole block-cyclic slabs (see docstring): a partial boundary
-            # slab is non-uniform across chips and fractional, so trim by slab count, not raw width.
             chunk_size_global = chunk_local * self.sp_factor
-            num_slabs = -(-populated_global // chunk_size_global)  # ceil-div
+            num_slabs = -(-populated_global // chunk_size_global)
             seq_hi = min(num_slabs * chunk_local, seq_hi)
 
-        # Slice iff the cache is multi-slot (must select this slot even when it's slot 0) and/or the
-        # populated-width trim applies. A single-slot cache (shape[0]==1) is already batch-1.
-        if cache_i.shape[0] > 1 or seq_hi != cache_i.shape[2]:  # slot and/or populated-width trim BEFORE the gather
-            sel = ttnn.slice(
-                cache_i,
+        if storage.shape[0] > 1 or seq_hi != storage.shape[2]:
+            selected = ttnn.slice(
+                storage,
                 [slot_lo, 0, 0, 0],
-                [slot_lo + 1, 1, seq_hi, cache_i.shape[3]],
+                [slot_lo + 1, 1, seq_hi, storage.shape[3]],
             )
-            ttnn.deallocate(cache_i)
-            cache_i = sel
-        full = self._all_gather(cache_i, dim=2, cluster_axis=self.sp_axis)  # → [1,1,seq_hi*sp,576] repl, block-cyclic
+            ttnn.deallocate(storage)
+            storage = selected
+        gathered = self._all_gather(storage, dim=2, cluster_axis=self.sp_axis)
         if self.sp_factor > 1:
-            ttnn.deallocate(cache_i)
-        return full
+            ttnn.deallocate(storage)
+
+        return MlaKvCache(
+            format=kvpe_cache.format,
+            storage=gathered,
+            geometry=kvpe_cache.geometry,
+        )

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/glm_5_1.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/glm_5_1.py
@@ -55,25 +55,24 @@ class GLM51Adapter(MLAPrefillAdapter):
         the same block-cyclic, user-major layout of ``num_users * num_layers`` slots, so the merged
         migration table can address them identically):
 
-          * index 0 — the MLA KVPE cache. sparse_sdpa reads it natively and requires it UNCOMPRESSED
-            (bf16 ROW_MAJOR), not the dense bf8/TILE cache the base MLA adapter allocates.
+          * index 0 — the MLA KVPE cache. sparse_sdpa reads either row-major fp8_e4m3 or bfloat16
+            natively. ``PrefillRunParams.sparse_kv_cache_format`` selects the format explicitly.
           * index 1 — the lightning-indexer's per-user block-cyclic KEY cache (bfp8 TILE,
             ``index_head_dim`` wide).
 
         The engine owns both, exactly like the dense KVPE cache."""
         import ttnn
-        from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
+        from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache, init_mla_kv_cache
 
-        kvpe_cache = init_kvpe_cache(
-            kvpe_cache_head_dim=hf_config.qk_rope_head_dim + hf_config.kv_lora_rank,
+        kvpe_cache = init_mla_kv_cache(
+            cache_format=self.resolve_sparse_kv_cache_format(params.sparse_kv_cache_format),
+            hf_config=hf_config,
             mesh_device=mesh_device,
             seq_len=params.max_seq_len,
             mesh_shape=list(params.mesh_shape),
             sp_axis=params.sp_axis,
             num_kvpe_cache_layers=params.num_layers,
             num_users=params.num_users,
-            dtype=ttnn.bfloat16,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
         )
         index_cache = init_kvpe_cache(
             kvpe_cache_head_dim=hf_config.index_head_dim,
@@ -84,8 +83,16 @@ class GLM51Adapter(MLAPrefillAdapter):
             num_kvpe_cache_layers=params.num_layers,
             num_users=params.num_users,
             dtype=ttnn.bfloat8_b,
+            layout=ttnn.TILE_LAYOUT,
         )
         return MlaKvCaches(kvpe=kvpe_cache, index=index_cache)
+
+    @property
+    def default_sparse_kv_cache_format(self):
+        """Use the model-native packed FP8 cache; callers can explicitly select BF16."""
+        from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat
+
+        return MlaKvCacheFormat.SCALED_FP8
 
     # --- test metadata (HF download coordinates + PCC thresholds + golden trace) ---
     hf_repo_id = "zai-org/GLM-5.1-FP8"

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/glm_5_2.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/glm_5_2.py
@@ -17,9 +17,7 @@ CONFIG-DRIVEN — ``glm_5_2_hf_config`` carries the ``indexer_types`` full/share
 indices — so no reuse-specific wiring lives in the adapter.
 
 Like GLM-5.1 (and Kimi) it has a single expert group with a device gate, so the MoE routing all-gather's
-semaphores go to L1_SMALL (needs the L1_SMALL carve-out at mesh-open). Run with
-``PREFILL_KV_ONLY_LAST_LAYER=0`` (the sparse path can't run a kv-only last layer); the glm52 manifest
-sets it.
+semaphores go to L1_SMALL (needs the L1_SMALL carve-out at mesh-open).
 """
 
 from __future__ import annotations
@@ -71,18 +69,21 @@ class GLM52Adapter(MLAPrefillAdapter):
         The engine owns both, exactly like the dense KVPE cache."""
         import ttnn
         from models.demos.deepseek_v3_d_p.tt.mla.indexer import num_full_indexer_layers
-        from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
+        from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import (
+            MlaKvCacheFormat,
+            init_kvpe_cache,
+            init_mla_kv_cache,
+        )
 
-        kvpe_cache = init_kvpe_cache(
-            kvpe_cache_head_dim=hf_config.qk_rope_head_dim + hf_config.kv_lora_rank,
+        kvpe_cache = init_mla_kv_cache(
+            cache_format=MlaKvCacheFormat.BF16_RM,
+            hf_config=hf_config,
             mesh_device=mesh_device,
             seq_len=params.max_seq_len,
             mesh_shape=list(params.mesh_shape),
             sp_axis=params.sp_axis,
             num_kvpe_cache_layers=params.num_layers,
             num_users=params.num_users,
-            dtype=ttnn.bfloat16,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
         )
         num_index_layers = num_full_indexer_layers(hf_config) or params.num_layers
         index_cache = init_kvpe_cache(

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/mla.py
@@ -140,6 +140,7 @@ class MLAPrefillAdapter(PrefillModelAdapter):
             is_last_rank=params.is_last_rank,
             kv_only_last_layer=params.kv_only_last_layer,
             routing_use_l1_small_for_semaphores=self.routing_use_l1_small_for_semaphores,
+            sparse_kv_cache_format=self.resolve_sparse_kv_cache_format(params.sparse_kv_cache_format),
         )
         return TtPrefillRuntime(
             mesh_device=mesh_device,

--- a/models/demos/deepseek_v3_d_p/tt/runners/kv_caches.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/kv_caches.py
@@ -2,18 +2,25 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import ttnn
 from models.demos.common.prefill.adapter import KvCaches
 
+if TYPE_CHECKING:
+    from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCache
+
 
 @dataclass
 class MlaKvCaches(KvCaches):
-    """Concrete KvCaches for the MLA/DSA prefill runner: the primary MLA KVPE cache (``kvpe``) and an
-    optional sparse-DSA indexer key cache (``index``, ``None`` for dense MLA). The adapters' allocate_kv_cache
-    builds it and TtPrefillRuntime consumes it via ``.kvpe`` / ``.index``."""
+    """DeepSeek-family prefill caches owned by the common prefill engine.
 
-    kvpe: ttnn.Tensor
+    ``kvpe`` is the primary MLA cache with explicit physical encoding. ``index`` is the optional DSA
+    indexer cache used by GLM variants.
+    """
+
+    kvpe: MlaKvCache
     index: Optional[ttnn.Tensor] = None

--- a/models/demos/deepseek_v3_d_p/tt/runners/kv_chunk_table.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/kv_chunk_table.py
@@ -29,17 +29,14 @@ from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import (
 # A KV chunk is one DRAM bank's worth of tokens (NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK=32) x head_dim.
 _TILE_DIM = 32  # bfp8 is tiled 32x32
 _BFP8_TILE_BYTES = 1088  # one 32x32 bfp8 tile: 1024 data + 64 exponent bytes
-_BF16_BYTES = 2
-
-# bfp8 [1, 1, 32, 576] KV chunk: 18 tiles * 1088 B = 19584 B.
-_CHUNK_SIZE_BYTES = 19584
 
 
 def _dram_chunk_size_bytes(cache) -> int:
     """Bytes of one 32-token DRAM-bank chunk ([.., 32, head_dim]) of `cache`, from its dtype:
       * bfp8_b  (block-float, TILE):  (head_dim / 32) tiles x 1088 B/tile (1024 data + 64 exponent).
-      * bfloat16 (ROW_MAJOR):         32 tokens x head_dim x 2 B, contiguous.
-    Derived from the tensor so each cache (dense bf8 KVPE, bf16 sparse KVPE, bf8 index) sizes itself."""
+      * bfloat16/fp8_e4m3 (ROW_MAJOR): 32 native row pages, including any DRAM page alignment.
+    Derived from the tensor so dense tiled-bfp8 KVPE, sparse BF16 or packed scaled-FP8 KVPE, and the
+    tiled-bfp8 index cache each size themselves from their physical representation."""
     head_dim = cache.shape[-1]
     if cache.dtype == ttnn.bfloat8_b:
         # bfp8 is tiled 32x32, so head_dim must be a whole number of tiles — otherwise integer division
@@ -47,12 +44,14 @@ def _dram_chunk_size_bytes(cache) -> int:
         if head_dim % _TILE_DIM != 0:
             raise ValueError(f"bfloat8_b KV cache head_dim {head_dim} must be a multiple of {_TILE_DIM} (tiled)")
         return (head_dim // _TILE_DIM) * _BFP8_TILE_BYTES
-    if cache.dtype == ttnn.bfloat16:
-        # The bf16 contiguous sizing below assumes a ROW_MAJOR cache (32 tokens x head_dim packed with no
-        # tile padding). A TILE-laid-out bf16 cache would need the tiled sizing instead, so reject it here.
+    if cache.dtype in (ttnn.bfloat16, ttnn.fp8_e4m3):
+        # Each token is one native row-major buffer page. Use its physical aligned size rather than
+        # head_dim * element_size: the migration worker copies raw DRAM bytes and must include padding.
         if cache.layout != ttnn.ROW_MAJOR_LAYOUT:
-            raise ValueError(f"bfloat16 KV cache must be ROW_MAJOR for contiguous chunk sizing, got {cache.layout}")
-        return NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK * head_dim * _BF16_BYTES
+            raise ValueError(
+                f"{cache.dtype} KV cache must be ROW_MAJOR for contiguous chunk sizing, got {cache.layout}"
+            )
+        return NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK * cache.buffer_aligned_page_size()
     raise ValueError(f"unsupported KV cache dtype for chunk sizing: {cache.dtype}")
 
 
@@ -98,11 +97,12 @@ def build_and_serialize_kv_chunk_table(
         f"A different period would mismap every position; re-introduce a parametrized builder if needed."
     )
 
-    if index_kv_cache is not None:
+    primary_cache = kvpe_cache.storage
+    all_caches = (primary_cache,) + ((index_kv_cache,) if index_kv_cache is not None else ())
+    if len(all_caches) > 1:
         return _build_and_serialize_merged_kv_chunk_table(
             mesh_device=mesh_device,
-            kvpe_cache=kvpe_cache,
-            index_kv_cache=index_kv_cache,
+            caches=all_caches,
             seq_len=seq_len,
             num_layers=num_layers,
             mesh_shape=mesh_shape,
@@ -118,7 +118,7 @@ def build_and_serialize_kv_chunk_table(
             mesh_shape=mesh_shape,
             seq_len=seq_len,
             sp_axis=sp_axis,
-            tt_kvpe_cache=kvpe_cache,
+            tt_kvpe_cache=primary_cache,
             chunk_size_bytes=chunk_size_bytes,
             num_users=num_users,
         )
@@ -129,13 +129,13 @@ def build_and_serialize_kv_chunk_table(
         max_seq_len=seq_len,
         num_users=num_users,
         chunk_n_tokens=NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK,
-        chunk_size_bytes=_CHUNK_SIZE_BYTES,
+        chunk_size_bytes=_dram_chunk_size_bytes(primary_cache),
         path=path,
     )
 
 
 def _build_and_serialize_merged_kv_chunk_table(
-    *, mesh_device, kvpe_cache, index_kv_cache, seq_len, num_layers, mesh_shape, sp_axis, num_users, path
+    *, mesh_device, caches, seq_len, num_layers, mesh_shape, sp_axis, num_users, path
 ) -> str:
     """Sparse (DSA) path: build ONE KvChunkAddressTable holding BOTH caches instead of two tables —
     config 0 = the KVPE cache, config 1 = the index-key cache. Each config carries its own
@@ -155,8 +155,8 @@ def _build_and_serialize_merged_kv_chunk_table(
         cfg.chunk_size_bytes = _dram_chunk_size_bytes(cache)
         return cfg
 
-    # config 0 = KVPE, config 1 = index (a list of configs -> config i is named "i").
-    caches = (kvpe_cache, index_kv_cache)
+    # BF16 and scaled FP8 both own one primary KVPE tensor; scaled FP8 stores its mixed fields in one
+    # packed row. The optional index cache is therefore always the next stable config.
     configs = [_table_config(c) for c in caches]
     table = disagg.KvChunkAddressTable(configs)
 

--- a/models/demos/deepseek_v3_d_p/tt/runners/prefill_kv_validation.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/prefill_kv_validation.py
@@ -199,13 +199,14 @@ def kv_cache_pcc_check(
     kv_lora = pipeline.hf_config.kv_lora_rank
     kvpe_dim = pipeline.hf_config.qk_rope_head_dim + kv_lora
 
-    # One gather: [num_users*num_layers, tp_replicas, seq_len_cache, kvpe] -> collapse TP via [:, :1].
-    cache_full = ttnn.to_torch(
-        kvpe_cache,
-        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape),
-    ).to(torch.float32)[
-        :, :1
-    ]  # [num_users*num_layers, 1, seq_len_cache, kvpe]
+    # Gather the persistent representation and reconstruct scaled FP8 only on the host. This keeps
+    # validation compatible with both cache formats without allocating a BF16 cache on device.
+    composer = ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape)
+
+    def _to_host(tensor):
+        return ttnn.to_torch(tensor, mesh_composer=composer)[:, :1]
+
+    cache_full = kvpe_cache.unpack_host(_to_host(kvpe_cache.storage)).to(torch.float32)
 
     p = blockcyclic_positions(sp, chunk_size, seq_len_cache)
     logger.info(f"[kv-pcc] device KV cache vs golden kv_post_transform (slot={slot_id}, per layer):")

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
@@ -18,6 +18,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.tt_moe import TtMoe
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
 from models.demos.deepseek_v3_d_p.tt.tt_distributed_rms_norm import TtDistributedRmsNorm
 from models.demos.deepseek_v3_d_p.tt.tt_ffn import TtFfn
+from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCache, MlaKvCacheFormat
 
 # Optional per-layer MLA-vs-FFN host timing (rough ratio only). Gated by TT_PREFILL_BLOCK_TIMING=1.
 # Host wall-clock with a device sync bracketing each region, so the syncs serialize the pipeline and
@@ -225,6 +226,7 @@ class TtPrefillBlock(LightweightModule):
         max_seq_len: Optional[int] = None,
         kv_only: bool = False,
         routing_use_l1_small_for_semaphores: bool = False,
+        sparse_kv_cache_format: MlaKvCacheFormat = MlaKvCacheFormat.BF16_RM,
     ):
         super().__init__()
         self.routing_use_l1_small_for_semaphores = routing_use_l1_small_for_semaphores
@@ -289,6 +291,7 @@ class TtPrefillBlock(LightweightModule):
             slot_num=slot_num,
             layer_num=layer_num,
             kv_only=kv_only,
+            sparse_kv_cache_format=sparse_kv_cache_format,
         )
 
         if kv_only:
@@ -425,7 +428,7 @@ class TtPrefillBlock(LightweightModule):
         self,
         x: ttnn.Tensor,
         rope_tensors: dict,
-        kvpe_cache: ttnn.Tensor,
+        kvpe_cache: MlaKvCache,
         cache_layer_idx: int = 0,
         return_kv_cache: bool = False,
         return_intermediates: bool = False,
@@ -511,9 +514,10 @@ class TtPrefillBlock(LightweightModule):
             # zero_padded_kv_cache is a DENSE (TILE) kvpe-cache op. A DSA-sparse model's kvpe cache is
             # bf16/fp8 ROW_MAJOR (sparse_sdpa reads it natively) and the op asserts TILE, so skip it for
             # sparse.
-            if kvpe_cache.layout == ttnn.TILE_LAYOUT:
+            cache_tensor = kvpe_cache.storage
+            if cache_tensor.layout == ttnn.TILE_LAYOUT:
                 ttnn.experimental.deepseek_prefill.zero_padded_kv_cache(
-                    kvpe_cache,
+                    cache_tensor,
                     cache_user_id,
                     cache_layer_idx,
                     self.mla.layer_num,

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
@@ -16,6 +16,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeM
 from models.demos.deepseek_v3_d_p.tt.runners.input_prep import prepare_prefill_input_tensor
 from models.demos.deepseek_v3_d_p.tt.runners.kv_caches import MlaKvCaches
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_transformer import TtPrefillTransformer
+from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat
 
 
 @dataclass
@@ -61,6 +62,7 @@ class TtPrefillRuntimeConfig:
     first_layer_idx: int = 0
     is_first_rank: bool = True
     is_last_rank: bool = True
+    sparse_kv_cache_format: MlaKvCacheFormat = MlaKvCacheFormat.BF16_RM
 
     @property
     def sp_factor(self) -> int:
@@ -162,6 +164,7 @@ class TtPrefillRuntime:
             first_layer_idx=self.config.first_layer_idx,
             is_first_rank=self.config.is_first_rank,
             is_last_rank=self.config.is_last_rank,
+            sparse_kv_cache_format=self.config.sparse_kv_cache_format,
         )
         self.model_built = True
 

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
@@ -30,6 +30,7 @@ from models.demos.deepseek_v3_d_p.tt.tt_lm_head import TtLMHead
 from models.demos.deepseek_v3_d_p.tt.tt_parallel_embedding import TtParallelEmbedding
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_block import TopologyArg, TtPrefillBlock
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker
+from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCache, MlaKvCacheFormat
 
 
 class TtPrefillTransformer(LightweightModule):
@@ -136,6 +137,7 @@ class TtPrefillTransformer(LightweightModule):
         first_layer_idx: int = 0,
         is_first_rank: bool = True,
         is_last_rank: bool = True,
+        sparse_kv_cache_format: MlaKvCacheFormat = MlaKvCacheFormat.BF16_RM,
     ):
         super().__init__()
         self.mesh_device = mesh_device
@@ -223,6 +225,7 @@ class TtPrefillTransformer(LightweightModule):
                 max_seq_len=max_seq_len,
                 kv_only=kv_only_last_layer and is_last,
                 routing_use_l1_small_for_semaphores=routing_use_l1_small_for_semaphores,
+                sparse_kv_cache_format=sparse_kv_cache_format,
             )
             self.layers.append(layer)
 
@@ -302,7 +305,7 @@ class TtPrefillTransformer(LightweightModule):
     def forward(
         self,
         token_ids: ttnn.Tensor,
-        kvpe_cache: ttnn.Tensor,
+        kvpe_cache: MlaKvCache,
         actual_isl: int,
         return_intermediates: bool = False,
         read_profiler: bool = False,

--- a/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
@@ -6,7 +6,10 @@ Utilities for KVPE cache initialization and management.
 """
 
 import socket
+from dataclasses import dataclass
+from enum import Enum
 
+import torch
 from loguru import logger
 
 import ttnn
@@ -19,6 +22,213 @@ NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK = 32
 # disaggregation address-table striding must both use the device's actual count to stay consistent.
 BH_NUM_DRAM_BANKS = 8
 PREFILL_CHUNK_OUTPUT_TOKENS = 5 * 1024
+
+
+class MlaKvCacheFormat(str, Enum):
+    """Physical encodings supported by the persistent MLA cache."""
+
+    BFP8_TILE = "bfp8_tile"
+    BF16_RM = "bf16_rm"
+    SCALED_FP8 = "scaled_fp8"
+
+    @property
+    def storage_dtype(self):
+        return {
+            MlaKvCacheFormat.BFP8_TILE: ttnn.bfloat8_b,
+            MlaKvCacheFormat.BF16_RM: ttnn.bfloat16,
+            MlaKvCacheFormat.SCALED_FP8: ttnn.fp8_e4m3,
+        }[self]
+
+    @property
+    def storage_layout(self):
+        return ttnn.TILE_LAYOUT if self == MlaKvCacheFormat.BFP8_TILE else ttnn.ROW_MAJOR_LAYOUT
+
+    def storage_width(self, geometry: "MlaKvCacheGeometry") -> int:
+        return geometry.packed_row_bytes if self == MlaKvCacheFormat.SCALED_FP8 else geometry.logical_width
+
+    @property
+    def sparse_sdpa_format(self):
+        try:
+            return {
+                MlaKvCacheFormat.BF16_RM: ttnn.transformer.SparseKVFormat.BF16,
+                MlaKvCacheFormat.SCALED_FP8: ttnn.transformer.SparseKVFormat.SCALED_FP8,
+            }[self]
+        except KeyError as error:
+            raise ValueError(f"{self} is not a sparse-SDPA cache format") from error
+
+
+@dataclass(frozen=True)
+class MlaKvCacheGeometry:
+    """Logical MLA dimensions and the packed scaled-FP8 row they imply."""
+
+    latent_dim: int
+    rope_dim: int
+
+    SCALE_BLOCK_SIZE = 128
+    SCALE_ELEMENT_BYTES = 4
+    ROPE_ELEMENT_BYTES = 2
+    PACKED_FIELD_ADDRESS_UNIT_BYTES = 16
+
+    @classmethod
+    def from_config(cls, config) -> "MlaKvCacheGeometry":
+        return cls(latent_dim=config.kv_lora_rank, rope_dim=config.qk_rope_head_dim)
+
+    def __post_init__(self) -> None:
+        if self.latent_dim <= 0 or self.rope_dim <= 0:
+            raise ValueError("MLA KV cache dimensions must be positive")
+
+    @property
+    def logical_width(self) -> int:
+        return self.latent_dim + self.rope_dim
+
+    @property
+    def num_scales(self) -> int:
+        block_size = self.SCALE_BLOCK_SIZE
+        if self.latent_dim % block_size != 0:
+            raise ValueError(f"scaled MLA KV latent dimension {self.latent_dim} must be a multiple of {block_size}")
+        return self.latent_dim // block_size
+
+    @property
+    def scale_bytes(self) -> int:
+        return self.num_scales * self.SCALE_ELEMENT_BYTES
+
+    @property
+    def rope_offset_bytes(self) -> int:
+        return self.latent_dim + self.scale_bytes
+
+    @property
+    def packed_row_bytes(self) -> int:
+        return self.rope_offset_bytes + self.rope_dim * self.ROPE_ELEMENT_BYTES
+
+    def validate_scaled(self) -> None:
+        if self.rope_offset_bytes % self.PACKED_FIELD_ADDRESS_UNIT_BYTES != 0:
+            raise ValueError(
+                f"scaled MLA KV RoPE offset {self.rope_offset_bytes} must be "
+                f"{self.PACKED_FIELD_ADDRESS_UNIT_BYTES}-byte aligned"
+            )
+
+
+@dataclass(frozen=True)
+class MlaKvCache:
+    """Persistent storage paired with the encoding of its physical rows.
+
+    Logical MLA values are ``[latent || RoPE]``. Homogeneous formats store that
+    row directly; scaled FP8 stores latent bytes, FP32 scales, and BF16 RoPE in
+    one mixed-format row. Physical operations use ``storage`` as a bare tensor.
+    """
+
+    format: MlaKvCacheFormat
+    storage: ttnn.Tensor
+    geometry: MlaKvCacheGeometry
+
+    def __post_init__(self) -> None:
+        if self.format == MlaKvCacheFormat.SCALED_FP8:
+            self.geometry.validate_scaled()
+        dtype = self.format.storage_dtype
+        layout = self.format.storage_layout
+        width = self.format.storage_width(self.geometry)
+        if self.storage.dtype != dtype:
+            raise ValueError(f"{self.format} cache must use {dtype}, got {self.storage.dtype}")
+        if self.storage.layout != layout:
+            raise ValueError(f"{self.format} cache must use {layout}, got {self.storage.layout}")
+        if self.storage.shape[-1] != width:
+            raise ValueError(f"{self.format} cache width must be {width}, got {self.storage.shape[-1]}")
+
+    def pack(
+        self,
+        latent: ttnn.Tensor,
+        rope: ttnn.Tensor,
+        *,
+        intermediates: dict[str, ttnn.Tensor] | None = None,
+    ) -> ttnn.Tensor:
+        """Encode logical values for a physical cache write without mutating storage."""
+        if latent.shape[-1] != self.geometry.latent_dim or rope.shape[-1] != self.geometry.rope_dim:
+            raise ValueError(
+                f"MLA KV inputs must be latent width {self.geometry.latent_dim} and RoPE width "
+                f"{self.geometry.rope_dim}, got {latent.shape[-1]} and {rope.shape[-1]}"
+            )
+        if self.format == MlaKvCacheFormat.SCALED_FP8:
+            return self._pack_scaled_fp8(latent, rope, intermediates=intermediates)
+        packed = ttnn.concat([latent, rope], dim=-1)
+        if packed.layout != self.storage.layout:
+            converted = ttnn.to_layout(packed, self.storage.layout)
+            ttnn.deallocate(packed)
+            packed = converted
+        if packed.dtype != self.storage.dtype:
+            converted = ttnn.typecast(packed, self.storage.dtype)
+            ttnn.deallocate(packed)
+            packed = converted
+        if intermediates is not None:
+            intermediates["tt_kvpe"] = ttnn.clone(packed)
+        return packed
+
+    def _pack_scaled_fp8(
+        self, latent: ttnn.Tensor, rope: ttnn.Tensor, *, intermediates: dict[str, ttnn.Tensor] | None
+    ) -> ttnn.Tensor:
+        latent_rm = ttnn.to_layout(latent, ttnn.ROW_MAJOR_LAYOUT)
+        latent_fp8, scales = ttnn.experimental.deepseek_prefill.per_token_cast_to_fp8(
+            latent_rm, round_scale_to_power_of_two=True
+        )
+        if latent_rm is not latent:
+            ttnn.deallocate(latent_rm)
+        rope_rm = ttnn.to_layout(rope, ttnn.ROW_MAJOR_LAYOUT)
+        packed = ttnn.experimental.deepseek_prefill.pack_scaled_fp8_kv_cache(latent_fp8, scales, rope_rm)
+        if intermediates is not None:
+            reconstructed = ttnn.experimental.deepseek_prefill.per_token_cast_back(
+                latent_fp8, scales, output_dtype=ttnn.bfloat16
+            )
+            intermediates["tt_kvpe"] = ttnn.concat([reconstructed, rope_rm], dim=-1)
+            ttnn.deallocate(reconstructed)
+            intermediates["tt_kvpe_latent"] = ttnn.clone(latent_fp8)
+            intermediates["tt_kvpe_scales"] = ttnn.clone(scales)
+            intermediates["tt_kvpe_rope"] = ttnn.clone(rope_rm)
+            intermediates["tt_kvpe_packed"] = ttnn.clone(packed)
+        ttnn.deallocate(latent_fp8)
+        ttnn.deallocate(scales)
+        if rope_rm is not rope:
+            ttnn.deallocate(rope_rm)
+        return packed
+
+    def unpack_host(self, physical: torch.Tensor) -> torch.Tensor:
+        """Decode host physical rows into logical BF16 [latent || RoPE] values."""
+        if self.format == MlaKvCacheFormat.SCALED_FP8:
+            return reconstruct_scaled_fp8_kv_cache(physical, self.geometry)
+        return physical.to(torch.bfloat16)
+
+
+def unpack_scaled_fp8_kv_cache(
+    packed: torch.Tensor, geometry: MlaKvCacheGeometry
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Decode a host copy of the packed sparse-MLA cache without interpreting its mixed fields as FP8.
+
+    ``ttnn.to_torch`` preserves the packed tensor's FP8 bytes. Re-viewing that storage as uint8 lets the
+    scale and RoPE fields be reconstructed using their native dtypes. Returns FP8 latent values widened
+    to float32, FP32 scales, and BF16 RoPE values.
+    """
+    geometry.validate_scaled()
+    if packed.shape[-1] != geometry.packed_row_bytes:
+        raise ValueError(f"packed sparse KV width must be {geometry.packed_row_bytes}, got {packed.shape[-1]}")
+
+    prefix = packed.shape[:-1]
+    raw = packed.contiguous().view(torch.uint8)
+    latent = (
+        raw[..., : geometry.latent_dim].contiguous().view(packed.dtype).reshape(*prefix, geometry.latent_dim).float()
+    )
+    scales = (
+        raw[..., geometry.latent_dim : geometry.rope_offset_bytes]
+        .contiguous()
+        .view(torch.float32)
+        .reshape(*prefix, geometry.num_scales)
+    )
+    rope = raw[..., geometry.rope_offset_bytes :].contiguous().view(torch.bfloat16).reshape(*prefix, geometry.rope_dim)
+    return latent, scales, rope
+
+
+def reconstruct_scaled_fp8_kv_cache(packed: torch.Tensor, geometry: MlaKvCacheGeometry) -> torch.Tensor:
+    """Reconstruct the logical BF16 ``[scaled latent || RoPE]`` cache from packed host bytes."""
+    latent, scales, rope = unpack_scaled_fp8_kv_cache(packed, geometry)
+    scaled = latent * scales.repeat_interleave(geometry.SCALE_BLOCK_SIZE, dim=-1)
+    return torch.cat((scaled.to(torch.bfloat16), rope), dim=-1)
 
 
 def get_num_dram_banks(mesh_device):
@@ -136,7 +346,7 @@ def create_kv_chunk_address_table_ds(
         logger.debug(
             f"Rank: {rank} Populating device_group_index: {group_idx} with positions: {device_position_indices_low_strip[row]} and {device_position_indices_high_strip[row]}"
         )
-        (current_position, max_position) = device_position_indices_low_strip[row]
+        current_position, max_position = device_position_indices_low_strip[row]
         for layer in range(num_layers):
             layer_current_position = current_position
             layer_max_position = max_position
@@ -162,7 +372,7 @@ def create_kv_chunk_address_table_ds(
                     assert (
                         layer_current_position == layer_max_position + 1
                     ), f"Missmatch in position calculation. Expected layer current_position to be {layer_max_position + 1}, but it is: {layer_current_position}."
-                    (layer_current_position, layer_max_position) = device_position_indices_high_strip[row]
+                    layer_current_position, layer_max_position = device_position_indices_high_strip[row]
 
     return lookup_table
 
@@ -359,22 +569,14 @@ def init_kvpe_cache(
     # num_users; a device kernel zeros it instead with no host transfer. Allocating
     # directly in the requested dtype/layout also sidesteps the mesh-mapper from_torch
     # path that forces TILE for fp8_e4m3 (so fp8 rides on ROW_MAJOR).
-    #
-    # fp8_e4m3 can't be DRAMZeroFill'd directly: its compute kernel needs fp32_dest_acc_en
-    # whenever an 8-bit-float CB is on-core (Blackhole TT_FATAL), so for fp8 we allocate +
-    # zero in bf16 and typecast on device (still no host transfer; typecast keeps the
-    # ROW_MAJOR layout and the ND shard spec).
-    is_fp8 = dtype == ttnn.fp8_e4m3
     tt_kvpe_cache = ttnn.allocate_tensor_on_device(
         ttnn.Shape([num_users * num_layers, 1, seq_len_local, kvpe_cache_head_dim]),
-        ttnn.bfloat16 if is_fp8 else dtype,
+        dtype,
         layout,
         mesh_device,
         kv_mem_config,
     )
     DRAMZeroFill.op(tt_kvpe_cache)
-    if is_fp8:
-        tt_kvpe_cache = ttnn.typecast(tt_kvpe_cache, ttnn.fp8_e4m3)
 
     # allocate_tensor_on_device assigns a default 2D fully-replicated topology, but the rest
     # of the model produces replicated tensors via ReplicateTensorToMesh, which is a 1D
@@ -391,7 +593,44 @@ def init_kvpe_cache(
     return tt_kvpe_cache
 
 
-def allocate_mla_kvpe_cache(*, mesh_device, hf_config, max_seq_len, mesh_shape, sp_axis, num_layers, num_users):
+def init_mla_kv_cache(
+    *,
+    cache_format: MlaKvCacheFormat,
+    hf_config,
+    mesh_device,
+    seq_len,
+    mesh_shape,
+    sp_axis,
+    num_kvpe_cache_layers,
+    num_users=1,
+) -> MlaKvCache:
+    """Allocate and zero a persistent MLA cache in the selected physical format.
+
+    Homogeneous formats store the config-derived logical row directly. Scaled FP8 owns one
+    ND-sharded mixed-format row per token. Physical DRAM usage is derived from the tensor's
+    aligned page size, not the logical row width.
+    """
+    cache_format = MlaKvCacheFormat(cache_format)
+    geometry = MlaKvCacheGeometry.from_config(hf_config)
+    if cache_format == MlaKvCacheFormat.SCALED_FP8:
+        geometry.validate_scaled()
+    storage = init_kvpe_cache(
+        kvpe_cache_head_dim=cache_format.storage_width(geometry),
+        dtype=cache_format.storage_dtype,
+        layout=cache_format.storage_layout,
+        mesh_device=mesh_device,
+        seq_len=seq_len,
+        mesh_shape=mesh_shape,
+        sp_axis=sp_axis,
+        num_kvpe_cache_layers=num_kvpe_cache_layers,
+        num_users=num_users,
+    )
+    return MlaKvCache(format=cache_format, storage=storage, geometry=geometry)
+
+
+def allocate_mla_kvpe_cache(
+    *, mesh_device, hf_config, max_seq_len, mesh_shape, sp_axis, num_layers, num_users
+) -> MlaKvCache:
     """Allocate the MLA KVPE cache for one runtime from the HF config.
 
     The MLA per-token cache row is ``qk_rope_head_dim + kv_lora_rank`` wide; ONE
@@ -399,12 +638,12 @@ def allocate_mla_kvpe_cache(*, mesh_device, hf_config, max_seq_len, mesh_shape, 
     ``max_seq_len`` each. Shared by ``TtPrefillRuntime`` (its default allocator)
     and the MLA model adapter, so the MLA KV layout has one definition.
     """
-    kvpe_head_dim = hf_config.qk_rope_head_dim + hf_config.kv_lora_rank
-    return init_kvpe_cache(
-        kvpe_cache_head_dim=kvpe_head_dim,
+    return init_mla_kv_cache(
+        cache_format=MlaKvCacheFormat.BFP8_TILE,
+        hf_config=hf_config,
         mesh_device=mesh_device,
         seq_len=max_seq_len,
-        mesh_shape=list(mesh_shape),
+        mesh_shape=mesh_shape,
         sp_axis=sp_axis,
         num_kvpe_cache_layers=num_layers,
         num_users=num_users,

--- a/tests/nightly/blackhole/sdpa/test_sparse_sdpa_multidevice.py
+++ b/tests/nightly/blackhole/sdpa/test_sparse_sdpa_multidevice.py
@@ -82,6 +82,7 @@ def test_sparse_sdpa_block_cyclic_sp_multi(mesh_device, nv_fn, nv_id):
         tt_kv,
         tt_idx,
         V_DIM,
+        kv_format=ttnn.transformer.SparseKVFormat.BF16,
         scale=K_DIM**-0.5,
         k_chunk_size=kc,
         block_cyclic_sp_axis=0,  # sp read from mesh axis 0

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -168,7 +168,7 @@
     exit $exit_code
   skus:
     bh_loudbox:
-      timeout: 120
+      timeout: 117
   owner_id: U08E1JCMAJF # Marko Bezulj
   team: models
 
@@ -199,6 +199,8 @@
   model-name: deepseek_prefill
   cmd: |
     exit_code=0
+    # Cheap host-side coverage for the mixed-format cache contract and producer decoding.
+    pytest models/demos/common/prefill/tests/test_prefill_producer_kv_decode.py models/demos/deepseek_v3_d_p/tests/test_sparse_kv_cache_contract.py -vvv --tb=short || exit_code=$?
     pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "(not test_ring_joint_mla or (4x2 and pcc_check and not fabric2d)) and (not test_rope_prefill or 4x2) and (not update_padded_kv_cache or 2x4) and (not rotary_embedding_indexed or 2x4) and (not zero_padded or linear-8 or 2x4) and not single-1 and (not test_prefill_dispatch or ((bf16_in and tile and bf16_out) or (fp8_scaled_in and row_major and fp8_out)))" -m "not extended_model" || exit_code=$?
     exit $exit_code
   skus:

--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa.py
@@ -219,6 +219,33 @@ _NV = {
 }
 
 
+def _run_sparse_sdpa_perf(device, H, S, T, TOPK, kc, nv, cache_format):
+    nv_fn = _NV[nv]
+    q, kv, indices = make_inputs(H, S, T, TOPK, K_DIM, lambda s: nv_fn(s, T, TOPK))
+    if cache_format == "bf16":
+        out, _ = run_op(q, kv, indices, device, kc, V_DIM)
+    else:
+        assert cache_format == "scaled_fp8"
+        tt_q = to_dev(q.to(torch.bfloat16), device, ttnn.bfloat16)
+        tt_latent_bf16 = to_dev(kv[..., :V_DIM].to(torch.bfloat16), device, ttnn.bfloat16)
+        tt_latent, tt_scales = ttnn.experimental.deepseek_prefill.per_token_cast_to_fp8(
+            tt_latent_bf16, round_scale_to_power_of_two=True
+        )
+        tt_rope = to_dev(kv[..., V_DIM:].to(torch.bfloat16), device, ttnn.bfloat16)
+        tt_packed = ttnn.experimental.deepseek_prefill.pack_scaled_fp8_kv_cache(tt_latent, tt_scales, tt_rope)
+        tt_indices = to_dev(indices.to(torch.int32), device, ttnn.uint32)
+        tt_out = ttnn.transformer.sparse_sdpa(
+            tt_q,
+            tt_packed,
+            tt_indices,
+            V_DIM,
+            scale=K_DIM**-0.5,
+            k_chunk_size=kc,
+        )
+        out = ttnn.to_torch(tt_out)
+    assert tuple(out.shape) == (1, H, S, V_DIM)
+
+
 @run_for_blackhole()
 @pytest.mark.parametrize(
     "S,T,TOPK,kc,nv,expected_ms",
@@ -263,3 +290,10 @@ def test_sparse_sdpa_perf(device, S, T, TOPK, kc, nv, expected_ms):
         f"sparse_sdpa {nv} device kernel duration {duration_ms:.3f} ms outside band [{lower:.3f}, {upper:.3f}] ms "
         f"(expected {expected_ms:.3f} ms, margin +/- {SPARSE_PERF_MARGIN * 100:.0f}%)"
     )
+
+
+@run_for_blackhole()
+@pytest.mark.parametrize("H", [32, 64], ids=["deepseek-h32", "glm-h64"])
+def test_sparse_sdpa_perf_scaled_fp8_production(device, H):
+    """Production DeepSeek and GLM geometries using the scaled mixed-format cache."""
+    _run_sparse_sdpa_perf(device, H, 640, 56320, 2048, 256, "dense", "scaled_fp8")

--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa.py
@@ -190,8 +190,15 @@ def test_sparse_sdpa_determinism(device, q_dtype, kv_dtype):
         return ttnn.to_layout(o, ttnn.TILE_LAYOUT)
 
     ref, marker = None, None
+    kv_format = (
+        ttnn.transformer.SparseKVFormat.BF16 if kv_dtype == ttnn.bfloat16 else ttnn.transformer.SparseKVFormat.FP8_E4M3
+    )
     for _ in range(iters):
-        cur = comparable(ttnn.transformer.sparse_sdpa(tt_q, tt_kv, tt_idx, V_DIM, scale=K_DIM**-0.5, k_chunk_size=kc))
+        cur = comparable(
+            ttnn.transformer.sparse_sdpa(
+                tt_q, tt_kv, tt_idx, V_DIM, kv_format=kv_format, scale=K_DIM**-0.5, k_chunk_size=kc
+            )
+        )
         if ref is None:
             ref = cur
         else:
@@ -239,6 +246,7 @@ def _run_sparse_sdpa_perf(device, H, S, T, TOPK, kc, nv, cache_format):
             tt_packed,
             tt_indices,
             V_DIM,
+            kv_format=ttnn.transformer.SparseKVFormat.SCALED_FP8,
             scale=K_DIM**-0.5,
             k_chunk_size=kc,
         )

--- a/tests/ttnn/unit_tests/operations/sdpa/sparse_sdpa_msa_test_utils.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/sparse_sdpa_msa_test_utils.py
@@ -188,6 +188,7 @@ def run_op_msa_composed(q, k, v, indices, device, *, k_chunk_size=128):
         dev(kv_packed.to(torch.bfloat16), ttnn.bfloat16),
         dev(exp.to(torch.int32), ttnn.uint32),
         v_dim,
+        kv_format=ttnn.transformer.SparseKVFormat.BF16,
         scale=scale,
         k_chunk_size=k_chunk_size,
     )

--- a/tests/ttnn/unit_tests/operations/sdpa/sparse_sdpa_test_utils.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/sparse_sdpa_test_utils.py
@@ -77,8 +77,18 @@ def run_op(
     tt_kv = to_dev(kv_host, device, kv_dtype)  # ttnn quantizes float -> fp8 when kv_dtype is fp8_e4m3
     tt_idx = to_dev(indices.to(torch.int32), device, ttnn.uint32)
     scale = q.shape[-1] ** -0.5  # 1/sqrt(k_dim), from the input width
+    kv_format = (
+        ttnn.transformer.SparseKVFormat.BF16 if kv_dtype == ttnn.bfloat16 else ttnn.transformer.SparseKVFormat.FP8_E4M3
+    )
     tt_out = ttnn.transformer.sparse_sdpa(
-        tt_q, tt_kv, tt_idx, v_dim, scale=scale, k_chunk_size=k_chunk_size, compute_kernel_config=compute_kernel_config
+        tt_q,
+        tt_kv,
+        tt_idx,
+        v_dim,
+        kv_format=kv_format,
+        scale=scale,
+        k_chunk_size=k_chunk_size,
+        compute_kernel_config=compute_kernel_config,
     )
     # Output dtype matches q. fp8 tensors can't be converted directly with to_torch, so typecast to bf16.
     if tt_out.dtype == ttnn.fp8_e4m3:

--- a/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa.py
@@ -24,11 +24,34 @@ from tests.ttnn.unit_tests.operations.sdpa.sparse_sdpa_test_utils import (
 
 K_DIM = 576  # head dim (q/kv width)
 V_DIM = 512  # V width / output width (op arg)
+SCALE_BLOCK_WIDTH = 128
 
 # Open the device ONCE per module (not per test) — all tests share one device config, so this avoids the
 # ~1.7s open/close on every test. The program cache persists across tests, which is fine: the recompile and
 # indexed tests clear_program_cache() at their start, and the hash keeps distinct configs separate.
 pytestmark = pytest.mark.use_module_device
+
+
+def make_scaled_kv_cache(device, batch, T, seed, round_scale):
+    """Build a packed cache and its reconstructed BF16 reference."""
+    gen = torch.Generator().manual_seed(seed)
+    latent = torch.randn(batch, 1, T, V_DIM, generator=gen, dtype=torch.float32)
+    block_scales = torch.logspace(-3, 0, steps=V_DIM // SCALE_BLOCK_WIDTH)
+    latent *= block_scales.repeat_interleave(SCALE_BLOCK_WIDTH)
+    rope = torch.randn(batch, 1, T, K_DIM - V_DIM, generator=gen, dtype=torch.float32).to(torch.bfloat16)
+
+    tt_latent = to_dev(latent.to(torch.bfloat16), device, ttnn.bfloat16)
+    tt_fp8, tt_scales = ttnn.experimental.deepseek_prefill.per_token_cast_to_fp8(
+        tt_latent, round_scale_to_power_of_two=round_scale
+    )
+    tt_packed = ttnn.experimental.deepseek_prefill.pack_scaled_fp8_kv_cache(
+        tt_fp8, tt_scales, to_dev(rope, device, ttnn.bfloat16)
+    )
+    tt_reconstructed = ttnn.experimental.deepseek_prefill.per_token_cast_back(
+        tt_fp8, tt_scales, output_dtype=ttnn.bfloat16
+    )
+    reconstructed = torch.cat([ttnn.to_torch(tt_reconstructed).float(), rope.float()], dim=-1)
+    return tt_packed, reconstructed
 
 
 # ---- op runs, output shape/layout correct ----
@@ -38,6 +61,113 @@ def test_sparse_sdpa_runs(device):
     q, kv, indices = make_inputs(H, S, T, TOPK, K_DIM, lambda s: TOPK)
     out, _ = run_op(q, kv, indices, device, kc, V_DIM)
     assert tuple(out.shape) == (1, H, S, V_DIM), f"got {tuple(out.shape)}"
+
+
+@run_for_blackhole()
+@pytest.mark.parametrize(
+    "S,T,TOPK,kc,all_valid,round_scale",
+    [
+        (32, 128, 64, 32, False, True),
+        (32, 128, 64, 64, False, True),
+        (32, 128, 64, 32, True, True),
+        (4, 512, 256, 256, True, True),
+        (4, 128, 64, 32, True, False),
+        (4, 256, 128, 128, False, False),
+    ],
+    ids=[
+        "multi_chunk",
+        "single_chunk",
+        "gather_ring_wrap",
+        "two_slab_pipeline_wrap",
+        "arbitrary_scale",
+        "scaled_e4m3_latent_bf16_rope",
+    ],
+)
+def test_sparse_sdpa_scaled_fp8_kv(device, S, T, TOPK, kc, all_valid, round_scale):
+    """Selected FP8 latent rows use per-token/block scales while RoPE remains BF16."""
+    H = 32
+    q, _, indices = make_inputs(
+        H, S, T, TOPK, K_DIM, (lambda s: TOPK) if all_valid else (lambda s: 1 + (s * 7) % TOPK), seed=41
+    )
+    tt_packed, reconstructed = make_scaled_kv_cache(device, 1, T, seed=42, round_scale=round_scale)
+    tt_q = to_dev(q.to(torch.bfloat16), device, ttnn.bfloat16)
+    tt_idx = to_dev(indices.to(torch.int32), device, ttnn.uint32)
+
+    block_cyclic_args = {"block_cyclic_sp_axis": 0, "block_cyclic_chunk_local": S} if kc == TOPK and TOPK == 64 else {}
+    tt_out = ttnn.transformer.sparse_sdpa(
+        tt_q,
+        tt_packed,
+        tt_idx,
+        V_DIM,
+        scale=K_DIM**-0.5,
+        k_chunk_size=kc,
+        **block_cyclic_args,
+    )
+
+    expected = golden(q, reconstructed, indices, K_DIM**-0.5, V_DIM)
+    score = pcc(ttnn.to_torch(tt_out), expected)
+    assert score >= 0.999, f"scaled FP8 sparse SDPA PCC {score:.5f}"
+
+
+@run_for_blackhole()
+def test_sparse_sdpa_bf16_multi_query_tile(device):
+    """Two query tiles must pack into distinct score rows when qsb is two."""
+    H, S, T, TOPK, kc = 64, 64, 128, 64, 32
+    q, kv, indices = make_inputs(H, S, T, TOPK, K_DIM, lambda s: TOPK, seed=60)
+    out, scale = run_op(q, kv, indices, device, k_chunk_size=kc, v_dim=V_DIM)
+    expected = golden(q, kv, indices, scale, V_DIM)
+    score = pcc(out, expected)
+    tile_scores = [pcc(out[:, start : start + 32], expected[:, start : start + 32]) for start in (0, 32)]
+    assert score >= 0.999, f"BF16 H=64 sparse SDPA PCC {score:.5f}; head-tile PCCs {tile_scores}"
+
+
+@run_for_blackhole()
+def test_sparse_sdpa_scaled_fp8_kv_multi_query_tile(device):
+    """GLM geometry: two 32-head query tiles share each gathered packed-KV chunk."""
+    H, S, T, TOPK, kc = 64, 64, 128, 64, 32
+    q, _, indices = make_inputs(H, S, T, TOPK, K_DIM, lambda s: TOPK, seed=61)
+    tt_packed, reconstructed = make_scaled_kv_cache(device, 1, T, seed=62, round_scale=True)
+    out = ttnn.transformer.sparse_sdpa(
+        to_dev(q.to(torch.bfloat16), device, ttnn.bfloat16),
+        tt_packed,
+        to_dev(indices.to(torch.int32), device, ttnn.uint32),
+        V_DIM,
+        scale=K_DIM**-0.5,
+        k_chunk_size=kc,
+    )
+
+    expected = golden(q, reconstructed, indices, K_DIM**-0.5, V_DIM)
+    actual = ttnn.to_torch(out)
+    score = pcc(actual, expected)
+    tile_scores = [pcc(actual[:, start : start + 32], expected[:, start : start + 32]) for start in (0, 32)]
+    assert score >= 0.999, f"scaled FP8 H=64 sparse SDPA PCC {score:.5f}; head-tile PCCs {tile_scores}"
+
+
+@run_for_blackhole()
+def test_sparse_sdpa_scaled_fp8_rejects_malformed_packed_width(device, expect_error):
+    H, S, T, TOPK = 32, 32, 128, 32
+    q, kv, indices = make_inputs(H, S, T, TOPK, K_DIM, lambda s: TOPK)
+    malformed = to_dev(torch.randn(1, 1, T, 600), device, ttnn.fp8_e4m3)
+    with expect_error(RuntimeError, "kv must be"):
+        ttnn.transformer.sparse_sdpa(
+            to_dev(q.to(torch.bfloat16), device, ttnn.bfloat16),
+            malformed,
+            to_dev(indices.to(torch.int32), device, ttnn.uint32),
+            V_DIM,
+        )
+
+
+@run_for_blackhole()
+def test_sparse_sdpa_rejects_v_dim_larger_than_k_dim(device, expect_error):
+    H, S, T, TOPK = 32, 32, 128, 32
+    q, kv, indices = make_inputs(H, S, T, TOPK, K_DIM, lambda s: TOPK)
+    with expect_error(RuntimeError, "v_dim must be in"):
+        ttnn.transformer.sparse_sdpa(
+            to_dev(q.to(torch.bfloat16), device, ttnn.bfloat16),
+            to_dev(kv.to(torch.bfloat16), device, ttnn.bfloat16),
+            to_dev(indices.to(torch.int32), device, ttnn.uint32),
+            K_DIM + 32,
+        )
 
 
 # ---- output dtype matches q (bf16 q -> bf16 out, fp8 q -> fp8 out) ----
@@ -210,11 +340,11 @@ def test_sparse_sdpa_indexed_kv_cache(device):
 
 
 # ---- indexed KV cache that is ND-sharded across DRAM banks (each batch slot is one shard). ----
-def _nd_sharded_dram_config(device, rows_per_shard):
+def _nd_sharded_dram_config(device, rows_per_shard, width=K_DIM):
     num_banks = device.dram_grid_size().x
     cores = [ttnn.CoreRange(ttnn.CoreCoord(b, 0), ttnn.CoreCoord(b, 0)) for b in range(num_banks)]
     spec = ttnn.NdShardSpec(
-        shard_shape=[1, 1, rows_per_shard, K_DIM],
+        shard_shape=[1, 1, rows_per_shard, width],
         grid=ttnn.CoreRangeSet(cores),
         orientation=ttnn.ShardOrientation.ROW_MAJOR,
         shard_distribution_strategy=ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
@@ -244,6 +374,32 @@ def test_sparse_sdpa_indexed_nd_sharded_kv(device):
         )
         p = pcc(ttnn.to_torch(tt_out), golden(q, kv_full[cb : cb + 1], indices, scale, V_DIM))
         assert p >= 0.99, f"PCC {p:.5f} (nd-sharded, cache_batch_idx={cb})"
+
+
+@run_for_blackhole()
+def test_sparse_sdpa_scaled_fp8_indexed_nd_sharded_kv(device):
+    """Production cache geometry: one packed ND-sharded cache and a dynamic user/layer slot."""
+    H, S, T, TOPK, kc, B = 32, 32, 128, 64, 32, 2
+    scale = K_DIM**-0.5
+    q, _, indices = make_inputs(H, S, T, TOPK, K_DIM, lambda s: TOPK, seed=51)
+    tt_packed, reconstructed = make_scaled_kv_cache(device, B, T, seed=52, round_scale=True)
+    tt_packed = ttnn.to_memory_config(tt_packed, _nd_sharded_dram_config(device, T, tt_packed.shape[-1]))
+    tt_q = to_dev(q.to(torch.bfloat16), device, ttnn.bfloat16)
+    tt_idx = to_dev(indices.to(torch.int32), device, ttnn.uint32)
+
+    for cache_batch_idx in range(B):
+        out = ttnn.transformer.sparse_sdpa(
+            tt_q,
+            tt_packed,
+            tt_idx,
+            V_DIM,
+            scale=scale,
+            k_chunk_size=kc,
+            cache_batch_idx=cache_batch_idx,
+        )
+        expected = golden(q, reconstructed[cache_batch_idx : cache_batch_idx + 1], indices, scale, V_DIM)
+        score = pcc(ttnn.to_torch(out), expected)
+        assert score >= 0.99, f"scaled ND-sharded PCC {score:.5f} (slot={cache_batch_idx})"
 
 
 # ---- A SHARDED kv's per-page bank mapping derives from its tensor shape (the accessor's shard strides), which

--- a/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa.py
@@ -25,11 +25,22 @@ from tests.ttnn.unit_tests.operations.sdpa.sparse_sdpa_test_utils import (
 K_DIM = 576  # head dim (q/kv width)
 V_DIM = 512  # V width / output width (op arg)
 SCALE_BLOCK_WIDTH = 128
+BF16_KV = ttnn.transformer.SparseKVFormat.BF16
+FP8_KV = ttnn.transformer.SparseKVFormat.FP8_E4M3
+SCALED_FP8_KV = ttnn.transformer.SparseKVFormat.SCALED_FP8
 
 # Open the device ONCE per module (not per test) — all tests share one device config, so this avoids the
 # ~1.7s open/close on every test. The program cache persists across tests, which is fine: the recompile and
 # indexed tests clear_program_cache() at their start, and the hash keeps distinct configs separate.
 pytestmark = pytest.mark.use_module_device
+
+
+def test_sparse_kv_format_api_is_explicit(expect_error):
+    assert ttnn.transformer.SparseKVFormat.BF16.name == "BF16"
+    assert ttnn.transformer.SparseKVFormat.FP8_E4M3.name == "FP8_E4M3"
+    assert ttnn.transformer.SparseKVFormat.SCALED_FP8.name == "SCALED_FP8"
+    with expect_error(TypeError, "kv_format"):
+        ttnn.transformer.sparse_sdpa(None, None, None, V_DIM)
 
 
 def make_scaled_kv_cache(device, batch, T, seed, round_scale):
@@ -99,6 +110,7 @@ def test_sparse_sdpa_scaled_fp8_kv(device, S, T, TOPK, kc, all_valid, round_scal
         tt_packed,
         tt_idx,
         V_DIM,
+        kv_format=SCALED_FP8_KV,
         scale=K_DIM**-0.5,
         k_chunk_size=kc,
         **block_cyclic_args,
@@ -132,6 +144,7 @@ def test_sparse_sdpa_scaled_fp8_kv_multi_query_tile(device):
         tt_packed,
         to_dev(indices.to(torch.int32), device, ttnn.uint32),
         V_DIM,
+        kv_format=SCALED_FP8_KV,
         scale=K_DIM**-0.5,
         k_chunk_size=kc,
     )
@@ -154,6 +167,28 @@ def test_sparse_sdpa_scaled_fp8_rejects_malformed_packed_width(device, expect_er
             malformed,
             to_dev(indices.to(torch.int32), device, ttnn.uint32),
             V_DIM,
+            kv_format=SCALED_FP8_KV,
+        )
+
+
+@run_for_blackhole()
+def test_sparse_sdpa_scaled_fp8_rejects_unaligned_rope_offset(device, expect_error):
+    """Scaled rows require the latent+scale prefix to be addressable in the kernel's 16-byte units."""
+    H, S, T, TOPK = 32, 32, 128, 32
+    k_dim, v_dim = 192, 128
+    scale_bytes = (v_dim // SCALE_BLOCK_WIDTH) * 4
+    packed_width = v_dim + scale_bytes + (k_dim - v_dim) * 2
+    q, _, indices = make_inputs(H, S, T, TOPK, k_dim, lambda s: TOPK)
+    packed = to_dev(torch.randn(1, 1, T, packed_width), device, ttnn.fp8_e4m3)
+
+    with expect_error(RuntimeError, "scale/RoPE boundary"):
+        ttnn.transformer.sparse_sdpa(
+            to_dev(q.to(torch.bfloat16), device, ttnn.bfloat16),
+            packed,
+            to_dev(indices.to(torch.int32), device, ttnn.uint32),
+            v_dim,
+            kv_format=SCALED_FP8_KV,
+            k_chunk_size=TOPK,
         )
 
 
@@ -167,6 +202,30 @@ def test_sparse_sdpa_rejects_v_dim_larger_than_k_dim(device, expect_error):
             to_dev(kv.to(torch.bfloat16), device, ttnn.bfloat16),
             to_dev(indices.to(torch.int32), device, ttnn.uint32),
             K_DIM + 32,
+            kv_format=BF16_KV,
+        )
+
+
+@run_for_blackhole()
+@pytest.mark.parametrize(
+    "kv_dtype,kv_format,message",
+    [
+        (ttnn.bfloat16, FP8_KV, "requires fp8_e4m3 storage"),
+        (ttnn.fp8_e4m3, BF16_KV, "requires bfloat16 storage"),
+    ],
+)
+def test_sparse_sdpa_rejects_kv_format_storage_mismatch(device, expect_error, kv_dtype, kv_format, message):
+    H, S, T, TOPK = 32, 32, 128, 32
+    q, kv, indices = make_inputs(H, S, T, TOPK, K_DIM, lambda s: TOPK)
+    kv_host = kv.to(torch.bfloat16) if kv_dtype == ttnn.bfloat16 else kv
+    with expect_error(RuntimeError, message):
+        ttnn.transformer.sparse_sdpa(
+            to_dev(q.to(torch.bfloat16), device, ttnn.bfloat16),
+            to_dev(kv_host, device, kv_dtype),
+            to_dev(indices.to(torch.int32), device, ttnn.uint32),
+            V_DIM,
+            kv_format=kv_format,
+            k_chunk_size=TOPK,
         )
 
 
@@ -180,7 +239,9 @@ def test_sparse_sdpa_output_dtype(device, q_dtype):
     tt_q = to_dev(q_host, device, q_dtype)
     tt_kv = to_dev(kv.to(torch.bfloat16), device, ttnn.bfloat16)
     tt_idx = to_dev(indices.to(torch.int32), device, ttnn.uint32)
-    out = ttnn.transformer.sparse_sdpa(tt_q, tt_kv, tt_idx, V_DIM, scale=K_DIM**-0.5, k_chunk_size=kc)
+    out = ttnn.transformer.sparse_sdpa(
+        tt_q, tt_kv, tt_idx, V_DIM, kv_format=BF16_KV, scale=K_DIM**-0.5, k_chunk_size=kc
+    )
     assert out.dtype == q_dtype, f"output dtype {out.dtype} != q dtype {q_dtype}"
 
 
@@ -245,7 +306,9 @@ def test_sparse_sdpa_oversized_persistent_kv(device):
             indices[0, 0, s, :] = torch.randperm(valid_len, generator=gen)[:TOPK]
         tt_q = to_dev(q.to(torch.bfloat16), device, ttnn.bfloat16)
         tt_idx = to_dev(indices.to(torch.int32), device, ttnn.uint32)
-        tt_out = ttnn.transformer.sparse_sdpa(tt_q, tt_kv, tt_idx, V_DIM, scale=scale, k_chunk_size=kc)
+        tt_out = ttnn.transformer.sparse_sdpa(
+            tt_q, tt_kv, tt_idx, V_DIM, kv_format=BF16_KV, scale=scale, k_chunk_size=kc
+        )
         p = pcc(ttnn.to_torch(tt_out), golden(q, kv, indices, scale, V_DIM))
         assert p >= 0.99, f"PCC {p:.5f} (valid_len={valid_len})"
     n = device.num_program_cache_entries()  # reusing the same oversized buffer must not realloc/recompile
@@ -276,6 +339,7 @@ def test_sparse_sdpa_block_cyclic_sp1_identity(device):
             to_dev(kv.to(torch.bfloat16), device, ttnn.bfloat16),  # sp=1 => block-cyclic order == natural
             to_dev(indices.to(torch.int32), device, ttnn.uint32),
             V_DIM,
+            kv_format=BF16_KV,
             scale=K_DIM**-0.5,
             k_chunk_size=kc,
             block_cyclic_sp_axis=0,
@@ -300,6 +364,7 @@ def test_sparse_sdpa_block_cyclic_chunk_local_rejected(device, expect_error):
             to_dev(kv_nat.to(torch.bfloat16), device, ttnn.bfloat16),
             to_dev(indices.to(torch.int32), device, ttnn.uint32),
             V_DIM,
+            kv_format=BF16_KV,
             scale=K_DIM**-0.5,
             k_chunk_size=kc,
             block_cyclic_sp_axis=0,
@@ -331,7 +396,7 @@ def test_sparse_sdpa_indexed_kv_cache(device):
     tt_idx = to_dev(indices.to(torch.int32), device, ttnn.uint32)
     for cb in range(B):
         tt_out = ttnn.transformer.sparse_sdpa(
-            tt_q, tt_kv, tt_idx, V_DIM, scale=scale, k_chunk_size=kc, cache_batch_idx=cb
+            tt_q, tt_kv, tt_idx, V_DIM, kv_format=BF16_KV, scale=scale, k_chunk_size=kc, cache_batch_idx=cb
         )
         p = pcc(ttnn.to_torch(tt_out), golden(q, kv_full[cb : cb + 1], indices, scale, V_DIM))  # golden uses slot cb
         assert p >= 0.99, f"PCC {p:.5f} (cache_batch_idx={cb})"
@@ -370,7 +435,7 @@ def test_sparse_sdpa_indexed_nd_sharded_kv(device):
     tt_idx = to_dev(indices.to(torch.int32), device, ttnn.uint32)
     for cb in range(B):
         tt_out = ttnn.transformer.sparse_sdpa(
-            tt_q, tt_kv, tt_idx, V_DIM, scale=scale, k_chunk_size=kc, cache_batch_idx=cb
+            tt_q, tt_kv, tt_idx, V_DIM, kv_format=BF16_KV, scale=scale, k_chunk_size=kc, cache_batch_idx=cb
         )
         p = pcc(ttnn.to_torch(tt_out), golden(q, kv_full[cb : cb + 1], indices, scale, V_DIM))
         assert p >= 0.99, f"PCC {p:.5f} (nd-sharded, cache_batch_idx={cb})"
@@ -393,6 +458,7 @@ def test_sparse_sdpa_scaled_fp8_indexed_nd_sharded_kv(device):
             tt_packed,
             tt_idx,
             V_DIM,
+            kv_format=SCALED_FP8_KV,
             scale=scale,
             k_chunk_size=kc,
             cache_batch_idx=cache_batch_idx,
@@ -424,7 +490,7 @@ def test_sparse_sdpa_nd_sharded_kv_len_change(device):
             memory_config=nd_cfg,
         )
         tt_idx = to_dev(indices.to(torch.int32), device, ttnn.uint32)
-        out = ttnn.transformer.sparse_sdpa(tt_q, tt_kv, tt_idx, V_DIM, scale=scale, k_chunk_size=kc)
+        out = ttnn.transformer.sparse_sdpa(tt_q, tt_kv, tt_idx, V_DIM, kv_format=BF16_KV, scale=scale, k_chunk_size=kc)
         p = pcc(ttnn.to_torch(out), golden(q, kv, indices, scale, V_DIM))
         assert p >= 0.99, f"PCC {p:.5f} (nd-sharded, T={T})"
     assert device.num_program_cache_entries() == 2, "sharded kv must recompile per shape (2 distinct T -> 2 entries)"
@@ -441,11 +507,13 @@ def test_sparse_sdpa_indexed_oob_rejected_on_hit(device, expect_error):
     tt_q = to_dev(q.to(torch.bfloat16), device, ttnn.bfloat16)
     tt_kv = to_dev(kv_full.to(torch.bfloat16), device, ttnn.bfloat16)
     tt_idx = to_dev(indices.to(torch.int32), device, ttnn.uint32)
-    ttnn.transformer.sparse_sdpa(tt_q, tt_kv, tt_idx, V_DIM, k_chunk_size=kc, cache_batch_idx=0)  # miss: builds
+    ttnn.transformer.sparse_sdpa(
+        tt_q, tt_kv, tt_idx, V_DIM, kv_format=BF16_KV, k_chunk_size=kc, cache_batch_idx=0
+    )  # miss: builds
     assert device.num_program_cache_entries() == 1
     # cache HIT, slot B is out of range [0,B) -> rejected by the hit validator
     with expect_error(RuntimeError, "cache_batch_idx"):
-        ttnn.transformer.sparse_sdpa(tt_q, tt_kv, tt_idx, V_DIM, k_chunk_size=kc, cache_batch_idx=B)
+        ttnn.transformer.sparse_sdpa(tt_q, tt_kv, tt_idx, V_DIM, kv_format=BF16_KV, k_chunk_size=kc, cache_batch_idx=B)
 
 
 # ---- q/indices layout/memory are NOT in the program hash, so an incompatible (e.g. TILE-layout) q with the
@@ -459,8 +527,10 @@ def test_sparse_sdpa_bad_layout_rejected_on_hit(device, expect_error):
     tt_q = to_dev(q.to(torch.bfloat16), device, ttnn.bfloat16)
     tt_kv = to_dev(kv.to(torch.bfloat16), device, ttnn.bfloat16)
     tt_idx = to_dev(indices.to(torch.int32), device, ttnn.uint32)
-    ttnn.transformer.sparse_sdpa(tt_q, tt_kv, tt_idx, V_DIM, k_chunk_size=kc)  # miss: builds the row-major program
+    ttnn.transformer.sparse_sdpa(
+        tt_q, tt_kv, tt_idx, V_DIM, kv_format=BF16_KV, k_chunk_size=kc
+    )  # miss: builds the row-major program
     assert device.num_program_cache_entries() == 1
     tt_q_tile = ttnn.to_layout(tt_q, ttnn.TILE_LAYOUT)  # same shape+dtype (same hash) but wrong layout -> HIT
     with expect_error(RuntimeError, "ROW_MAJOR"):
-        ttnn.transformer.sparse_sdpa(tt_q_tile, tt_kv, tt_idx, V_DIM, k_chunk_size=kc)
+        ttnn.transformer.sparse_sdpa(tt_q_tile, tt_kv, tt_idx, V_DIM, kv_format=BF16_KV, k_chunk_size=kc)

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sparse_sdpa_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sparse_sdpa_compute.cpp
@@ -15,6 +15,8 @@
 #include "api/compute/compute_kernel_api.h"
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/bcast.h"  // add_tiles_bcast_rows (mask add)
+#include "ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/sparse_sdpa_common.hpp"
+constexpr bool EXP_APPROX_MODE = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::MATH_APPROX_MODE) != 0;
 // compute_streaming.hpp needs declarations from compute_common.hpp (LightweightMaskContext, reduce helpers,
 // DEST_AUTO_LIMIT); include it first. Only compute_streaming primitives are used.
 #include "compute_common.hpp"
@@ -49,37 +51,82 @@ ALWI void swap_cb(CircularBuffer& a, CircularBuffer& b) {
     b = t;
 }
 
+// Tilize a 32-row field in a mixed-format packed slab without first copying it into a dense row-major CB.
+// `physical_ct_dim` programs the unpacker's row stride; `field_ct_dim` is the number of columns actually
+// emitted. The read-pointer offset is temporary and restored before the normal FIFO pop advances by 32
+// physical packed pages.
+template <
+    uint32_t input_cb,
+    uint32_t output_cb,
+    uint32_t physical_ct_dim,
+    uint32_t field_ct_dim,
+    uint32_t field_offset_16b,
+    bool manage_input_lifecycle = true>
+ALWI void tilize_packed_field() {
+    CircularBuffer in(input_cb), out(output_cb);
+    if constexpr (manage_input_lifecycle) {
+        in.wait_front(tt::constants::TILE_HEIGHT);
+    }
+    out.reserve_back(field_ct_dim);
+
+    reconfig_data_format_srca(input_cb);
+    pack_reconfig_data_format(output_cb);
+    tilize_init(input_cb, physical_ct_dim, output_cb);
+
+    uint32_t saved_rd_ptr = 0;
+    UNPACK({
+        auto& iface = get_local_cb_interface(input_cb);
+        saved_rd_ptr = iface.fifo_rd_ptr;
+        iface.fifo_rd_ptr = saved_rd_ptr + field_offset_16b;
+    });
+    tilize_block(input_cb, field_ct_dim, output_cb);
+    UNPACK(get_local_cb_interface(input_cb).fifo_rd_ptr = saved_rd_ptr;);
+
+    out.push_back(field_ct_dim);
+    if constexpr (manage_input_lifecycle) {
+        in.pop_front(tt::constants::TILE_HEIGHT);
+    }
+    tilize_uninit(input_cb, output_cb);
+}
+
 void kernel_main() {
-    constexpr uint32_t H = get_compile_time_arg_val(0);
-    constexpr uint32_t DHt = get_compile_time_arg_val(1);
-    constexpr uint32_t vDHt = get_compile_time_arg_val(2);
-    constexpr uint32_t Skt = get_compile_time_arg_val(3);
-    constexpr uint32_t scale_fp32 = get_compile_time_arg_val(4);
+    constexpr uint32_t H = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::H);
+    constexpr uint32_t DHt = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::DHT);
+    constexpr uint32_t vDHt = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::V_DHT);
+    constexpr uint32_t Skt = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::SKT);
+    constexpr uint32_t scale_fp32 = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::SCALE);
 
     // CB ids from the factory (the SparseCB enum is the single source); order matches the factory's compute
     // compile-arg block (5..24). They feed the templates + format helpers; the CB objects below wrap them.
-    constexpr uint32_t cb_q_rm = get_compile_time_arg_val(5);
-    constexpr uint32_t cb_q_in = get_compile_time_arg_val(6);
-    constexpr uint32_t cb_k_rm = get_compile_time_arg_val(7);
-    constexpr uint32_t cb_k_in = get_compile_time_arg_val(8);
-    constexpr uint32_t cb_neginf = get_compile_time_arg_val(9);
-    constexpr uint32_t cb_mask_part = get_compile_time_arg_val(10);
-    constexpr uint32_t cb_scale = get_compile_time_arg_val(11);
-    constexpr uint32_t cb_qk_im = get_compile_time_arg_val(12);
-    constexpr uint32_t cb_max_a = get_compile_time_arg_val(13);
-    constexpr uint32_t cb_max_b = get_compile_time_arg_val(14);
-    constexpr uint32_t cb_sum_a = get_compile_time_arg_val(15);
-    constexpr uint32_t cb_sum_b = get_compile_time_arg_val(16);
-    constexpr uint32_t cb_out_a = get_compile_time_arg_val(17);
-    constexpr uint32_t cb_out_b = get_compile_time_arg_val(18);
-    constexpr uint32_t cb_corr = get_compile_time_arg_val(19);
-    constexpr uint32_t cb_out_im = get_compile_time_arg_val(20);
-    constexpr uint32_t cb_out_rm = get_compile_time_arg_val(21);
-    constexpr uint32_t cb_ctrl = get_compile_time_arg_val(22);
-    constexpr uint32_t cb_col_identity = get_compile_time_arg_val(23);
-    constexpr uint32_t cb_recip_scratch = get_compile_time_arg_val(24);
+    constexpr uint32_t cb_q_rm = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::CB_Q_RM);
+    constexpr uint32_t cb_q_in = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::CB_Q_IN);
+    constexpr uint32_t cb_k_rm = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::CB_K_RM);
+    constexpr uint32_t cb_k_in = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::CB_K_IN);
+    constexpr uint32_t cb_neginf = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::CB_NEGINF);
+    constexpr uint32_t cb_mask_part = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::CB_MASK_PART);
+    constexpr uint32_t cb_scale = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::CB_SCALE);
+    constexpr uint32_t cb_qk_im = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::CB_QK_IM);
+    constexpr uint32_t cb_max_a = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::CB_MAX_A);
+    constexpr uint32_t cb_max_b = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::CB_MAX_B);
+    constexpr uint32_t cb_sum_a = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::CB_SUM_A);
+    constexpr uint32_t cb_sum_b = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::CB_SUM_B);
+    constexpr uint32_t cb_out_a = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::CB_OUT_A);
+    constexpr uint32_t cb_out_b = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::CB_OUT_B);
+    constexpr uint32_t cb_corr = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::CB_CORR);
+    constexpr uint32_t cb_out_im = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::CB_OUT_IM);
+    constexpr uint32_t cb_out_rm = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::CB_OUT_RM);
+    constexpr uint32_t cb_ctrl = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::CB_CTRL);
+    constexpr uint32_t cb_col_identity = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::CB_COL_IDENTITY);
+    constexpr uint32_t cb_recip_scratch = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::CB_RECIP_SCRATCH);
+    constexpr bool scaled_kv = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::SCALED_KV) != 0;
+    constexpr uint32_t cb_k_rope_rm = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::CB_K_ROPE_RM);
+    constexpr uint32_t cb_k_scale_bcast = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::CB_K_SCALE_BCAST);
+    constexpr uint32_t cb_k_latent_tile = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::CB_K_LATENT_TILE);
+    constexpr uint32_t cb_k_rope_tile = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::CB_K_ROPE_TILE);
 
-    constexpr uint32_t qsb = get_compile_time_arg_val(25);    // query tile-rows per DST group (<= dst_size)
+    constexpr uint32_t qsb =
+        get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::QUERY_SUBBLOCK);  // query tile-rows per DST group
+    constexpr uint32_t packed_row_bytes = get_compile_time_arg_val(sparse_sdpa::compute_ct_arg::PACKED_ROW_BYTES);
     constexpr uint32_t Sqt = H / tt::constants::TILE_HEIGHT;  // total query tile-rows (32 heads each)
     constexpr uint32_t q_groups = Sqt / qsb;                  // DST-bound work runs in this many query-row passes
     constexpr uint32_t KT_stride = Skt;                       // cb_qk_im physical row width
@@ -90,6 +137,8 @@ void kernel_main() {
     // CB wrappers for the fixed (non-ping-pong) buffers' lifecycle verbs.
     CircularBuffer q_in_cb(cb_q_in), k_in_cb(cb_k_in), qk_cb(cb_qk_im), scale_cb(cb_scale), ctrl_cb(cb_ctrl);
     CircularBuffer neginf_cb(cb_neginf), mask_part_cb(cb_mask_part), corr_cb(cb_corr);
+    CircularBuffer k_rm_cb(cb_k_rm), scale_bcast_cb(cb_k_scale_bcast);
+    CircularBuffer latent_tile_cb(cb_k_latent_tile), rope_tile_cb(cb_k_rope_tile);
 
     const uint32_t tok_count = get_arg_val<uint32_t>(1);
 
@@ -106,8 +155,10 @@ void kernel_main() {
         // num_valid_keys (last chunk's mask boundary). read_tile_value mailbox-distributes the UNPACK read so
         // all three threads see the same loop bound / mask branches.
         ctrl_cb.wait_front(1);
-        const uint32_t num_active_chunks = ckernel::read_tile_value(cb_ctrl, /*tile=*/0, /*element_offset=*/0);
-        const uint32_t num_valid_keys = ckernel::read_tile_value(cb_ctrl, /*tile=*/0, /*element_offset=*/1);
+        const uint32_t num_active_chunks = ckernel::read_tile_value(
+            cb_ctrl, /*tile=*/0, /*element_offset=*/sparse_sdpa::control_message::ACTIVE_CHUNKS);
+        const uint32_t num_valid_keys =
+            ckernel::read_tile_value(cb_ctrl, /*tile=*/0, /*element_offset=*/sparse_sdpa::control_message::VALID_KEYS);
         ctrl_cb.pop_front(1);
 
         // Flash running state, ping-pong. Reset every token; all buffers start empty.
@@ -116,11 +167,78 @@ void kernel_main() {
         CircularBuffer out_prev(cb_out_a), out_cur(cb_out_b);
 
         for (uint32_t chunk = 0; chunk < num_active_chunks; ++chunk) {
-            // tilize K rows -> [Skt, DHt] (waits on reader cb_k_rm -> absorbs the K-read stall)
-            compute_kernel_lib::tilize<DHt, cb_k_rm, cb_k_in>(
-                /*num_blocks=*/Skt, /*total_input_pages=*/Skt * tt::constants::TILE_HEIGHT);
-            // QK reads K (transposed -> srcA) and Q (srcB). Reconfigure both formats and the tiled descriptor
-            // geometry/strides; mm_no_mop_init_short only programs the matmul MOP.
+            if constexpr (scaled_kv) {
+                // Reconstruct only the scaled latent field into persistent BFP8 tiles. RoPE stays in its
+                // separate BF16 tiled buffer, avoiding both a full BF16 K and the RoPE copy into it.
+                constexpr uint32_t latent_DHt = vDHt;
+                constexpr uint32_t rope_DHt = DHt - vDHt;
+                constexpr uint32_t tiles_per_scale_block = sparse_sdpa::SCALE_BLOCK_WIDTH / tt::constants::TILE_WIDTH;
+                constexpr uint32_t scale_blocks = latent_DHt / tiles_per_scale_block;
+                constexpr uint32_t latent_physical_ct = packed_row_bytes / tt::constants::TILE_WIDTH;
+                constexpr uint32_t rope_physical_ct = packed_row_bytes / (tt::constants::TILE_WIDTH * sizeof(uint16_t));
+                constexpr uint32_t scale_bytes = scale_blocks * sizeof(float);
+                constexpr uint32_t unpack_address_unit_bytes = 16;
+                constexpr uint32_t rope_offset_16b =
+                    (vDHt * tt::constants::TILE_WIDTH + scale_bytes) / unpack_address_unit_bytes;
+
+                k_in_cb.reserve_back(Skt * vDHt);
+                for (uint32_t row_tile = 0; row_tile < Skt; ++row_tile) {
+                    k_rm_cb.wait_front(tt::constants::TILE_HEIGHT);
+                    {
+                        tilize_packed_field<
+                            cb_k_rm,
+                            cb_k_latent_tile,
+                            latent_physical_ct,
+                            latent_DHt,
+                            /*field_offset_16b=*/0,
+                            /*manage_input_lifecycle=*/false>();
+                    }
+
+                    {
+                        latent_tile_cb.wait_front(latent_DHt);
+                        scale_bcast_cb.wait_front(scale_blocks);
+                        reconfig_data_format(cb_k_latent_tile, cb_k_scale_bcast);
+                        pack_reconfig_data_format(cb_k_in);
+                        mul_bcast_cols_init_short(cb_k_latent_tile, cb_k_scale_bcast);
+                        for (uint32_t block = 0; block < scale_blocks; ++block) {
+                            for (uint32_t tile = 0; tile < tiles_per_scale_block; ++tile) {
+                                tile_regs_acquire();
+                                mul_tiles_bcast_cols(
+                                    cb_k_latent_tile, cb_k_scale_bcast, block * tiles_per_scale_block + tile, block, 0);
+                                tile_regs_commit();
+                                tile_regs_wait();
+                                pack_tile<true>(0, cb_k_in, row_tile * vDHt + block * tiles_per_scale_block + tile);
+                                tile_regs_release();
+                            }
+                        }
+                        latent_tile_cb.pop_front(latent_DHt);
+                        scale_bcast_cb.pop_front(scale_blocks);
+                    }
+
+                    {
+                        // cb_k_rope_rm is a format-only alias: synchronize its UNPACK pointer to the owning
+                        // packed FIFO for this slab. It never participates in wait/pop lifecycle accounting.
+                        UNPACK(get_local_cb_interface(cb_k_rope_rm).fifo_rd_ptr =
+                                   get_local_cb_interface(cb_k_rm).fifo_rd_ptr;);
+                        tilize_packed_field<
+                            cb_k_rope_rm,
+                            cb_k_rope_tile,
+                            rope_physical_ct,
+                            rope_DHt,
+                            rope_offset_16b,
+                            /*manage_input_lifecycle=*/false>();
+                    }
+                    k_rm_cb.pop_front(tt::constants::TILE_HEIGHT);
+                }
+                k_in_cb.push_back(Skt * vDHt);
+            } else {
+                // tilize K rows -> [Skt, DHt] (waits on reader cb_k_rm -> absorbs the K-read stall)
+                compute_kernel_lib::tilize<DHt, cb_k_rm, cb_k_in>(
+                    /*num_blocks=*/Skt, /*total_input_pages=*/Skt * tt::constants::TILE_HEIGHT);
+            }
+            // fp8 K tilize leaves srcA in fp8. QK reads K (transposed -> srcA) and Q (srcB), so restore
+            // srcA=cb_k_in (bfp8 for fp8 K), srcB=cb_q_in. Reconfigure the tiled descriptor geometry/strides;
+            // mm_no_mop_init_short only programs the matmul MOP.
             reconfig_data_format<SrcOrder::Regular, /*is_tile_dim_reconfig_en=*/true>(cb_k_in, cb_q_in);
             // K tilize also leaves the packer in cb_k_in's format+strides (bfp8 for fp8). Restore bf16 once per
             // chunk for the downstream packs (cb_qk_im/max/sum/out share its geometry); configure_pack_width in
@@ -136,7 +254,12 @@ void kernel_main() {
             qk_cb.reserve_back(Sqt * KT_stride);
             sum_cur.reserve_back(Sqt);
             out_cur.reserve_back(Sqt * vDHt);
-            k_in_cb.wait_front(Skt * DHt);  // shared by every query group (QK + PV)
+            if constexpr (scaled_kv) {
+                k_in_cb.wait_front(Skt * vDHt);
+                rope_tile_cb.wait_front(Skt * (DHt - vDHt));
+            } else {
+                k_in_cb.wait_front(Skt * DHt);  // shared by every query group (QK + PV)
+            }
             q_in_cb.wait_front(Sqt * DHt);
 
             // Boundary geometry (last chunk, same for every row): keys [valid_last, k_chunk) are sentinels ->
@@ -157,26 +280,70 @@ void kernel_main() {
 
                 // ===== Phase 1: Q@Kᵀ -> cb_qk_im band, mask, running row-max =====
                 {
-                    // scores[q,sk]=ΣQ·K. in1=K, transpose=true (within-tile transpose => Kᵀ), in1_stride=1.
-                    // ct/pack_width=1: the per-chunk tilize reprograms the packer addrmods/strides, which the
-                    // wider BH blocked pack can't tolerate (configure_pack_width can't restore them). matmul ct>1 is
-                    // fine.
-                    mm_no_mop_init_short(cb_q_in, cb_k_in, /*transpose=*/true, 1, qsb, DHt);
-                    configure_row_pack_width(cb_qk_im, 1);
-                    for (uint32_t kt = 0; kt < Skt; ++kt) {
-                        blocked_matmul_and_pack<true, /*in1_stride=*/1, /*out_num_cols=*/KT_stride>(
-                            cb_q_in,
-                            cb_k_in,
-                            cb_qk_im,
-                            /*in0_index_start=*/row_base * DHt,
-                            /*in1_index_start=*/kt * DHt,
-                            /*row_subblock_idx=*/qg,
-                            /*out_col_offset=*/kt,
-                            /*subblock_w=*/1,
-                            /*subblock_h=*/qsb,
-                            /*inner_dim=*/DHt,
-                            /*matmul_stride=*/DHt,
-                            /*skip_pack_configure=*/true);
+                    if constexpr (scaled_kv) {
+                        constexpr uint32_t rope_DHt = DHt - vDHt;
+                        // Both partial products read fields from the full-width Q matrix. The matmul stride must
+                        // therefore remain DHt even though their contraction widths are vDHt and rope_DHt.
+                        constexpr uint32_t q_row_stride = DHt;
+                        // Latent contribution from the scaled mixed-format cache.
+                        reconfig_data_format(cb_k_in, cb_q_in);
+                        mm_no_mop_init_short(cb_q_in, cb_k_in, /*transpose=*/true, 1, qsb, q_row_stride);
+                        configure_row_pack_width(cb_qk_im, 1);
+                        for (uint32_t kt = 0; kt < Skt; ++kt) {
+                            blocked_matmul_and_pack<true, /*in1_stride=*/1, /*out_num_cols=*/KT_stride>(
+                                cb_q_in,
+                                cb_k_in,
+                                cb_qk_im,
+                                /*in0_index_start=*/row_base * DHt,
+                                /*in1_index_start=*/kt * vDHt,
+                                /*row_subblock_idx=*/qg,
+                                /*out_col_offset=*/kt,
+                                /*subblock_w=*/1,
+                                /*subblock_h=*/qsb,
+                                /*inner_dim=*/vDHt,
+                                /*matmul_stride=*/q_row_stride,
+                                /*skip_pack_configure=*/true);
+                        }
+                        // Unscaled BF16 RoPE contribution, accumulated into the same held score tiles.
+                        reconfig_data_format(cb_k_rope_tile, cb_q_in);
+                        mm_no_mop_init_short(cb_q_in, cb_k_rope_tile, /*transpose=*/true, 1, qsb, q_row_stride);
+                        configure_row_pack_width(cb_qk_im, 1);
+                        pack_reconfig_l1_acc(1);
+                        for (uint32_t kt = 0; kt < Skt; ++kt) {
+                            blocked_matmul_and_pack<true, /*in1_stride=*/1, /*out_num_cols=*/KT_stride>(
+                                cb_q_in,
+                                cb_k_rope_tile,
+                                cb_qk_im,
+                                /*in0_index_start=*/row_base * DHt + vDHt,
+                                /*in1_index_start=*/kt * rope_DHt,
+                                /*row_subblock_idx=*/qg,
+                                /*out_col_offset=*/kt,
+                                /*subblock_w=*/1,
+                                /*subblock_h=*/qsb,
+                                /*inner_dim=*/rope_DHt,
+                                /*matmul_stride=*/q_row_stride,
+                                /*skip_pack_configure=*/true);
+                        }
+                        pack_reconfig_l1_acc(0);
+                    } else {
+                        // scores[q,sk]=ΣQ·K. in1=K, transpose=true (within-tile transpose => Kᵀ).
+                        mm_no_mop_init_short(cb_q_in, cb_k_in, /*transpose=*/true, 1, qsb, DHt);
+                        configure_row_pack_width(cb_qk_im, 1);
+                        for (uint32_t kt = 0; kt < Skt; ++kt) {
+                            blocked_matmul_and_pack<true, /*in1_stride=*/1, /*out_num_cols=*/KT_stride>(
+                                cb_q_in,
+                                cb_k_in,
+                                cb_qk_im,
+                                /*in0_index_start=*/row_base * DHt,
+                                /*in1_index_start=*/kt * DHt,
+                                /*row_subblock_idx=*/qg,
+                                /*out_col_offset=*/kt,
+                                /*subblock_w=*/1,
+                                /*subblock_h=*/qsb,
+                                /*inner_dim=*/DHt,
+                                /*matmul_stride=*/DHt,
+                                /*skip_pack_configure=*/true);
+                        }
                     }
                     // Publish the band to UNPACK while holding wr_ptr (for the in-place mask/sub_exp).
                     cb_push_back_hold_wr_ptr(cb_qk_im, qsb * KT_stride);
@@ -242,14 +409,13 @@ void kernel_main() {
                 // ===== Phase 2: probs@V -> out_cur band =====
                 {
                     qk_cb.wait_front((qg + 1) * qsb * KT_stride);
-                    // out[q,vd]=Σprobs·K, V = first vDHt feature cols (rope cols skipped). in1=K, transpose=false,
-                    // in1_stride=DHt. ct/pack_width=1 (same blocked-pack reason as QK). PV reads V into srcA and
+                    // out[q,vd]=Σprobs·K, V = the latent feature cols. PV reads V into srcA and
                     // probs (cb_qk_im) into srcB (operands swap); set srcA=cb_k_in, srcB=cb_qk_im.
                     reconfig_data_format(cb_k_in, cb_qk_im);
                     mm_no_mop_init_short(cb_qk_im, cb_k_in, /*transpose=*/false, 1, qsb, Skt);
                     configure_row_pack_width(out_cur.get_cb_id(), 1);
                     for (uint32_t vd = 0; vd < vDHt; ++vd) {
-                        blocked_matmul_and_pack<false, /*in1_stride=*/DHt, /*out_num_cols=*/vDHt>(
+                        blocked_matmul_and_pack<false, /*in1_stride=*/scaled_kv ? vDHt : DHt, /*out_num_cols=*/vDHt>(
                             cb_qk_im,
                             cb_k_in,
                             out_cur.get_cb_id(),
@@ -329,7 +495,12 @@ void kernel_main() {
 
             // Release the held cb_qk_im rows + this chunk's K (consumed by QK and PV).
             qk_cb.pop_front(Sqt * KT_stride);
-            k_in_cb.pop_front(Skt * DHt);
+            if constexpr (scaled_kv) {
+                k_in_cb.pop_front(Skt * vDHt);
+                rope_tile_cb.pop_front(Skt * (DHt - vDHt));
+            } else {
+                k_in_cb.pop_front(Skt * DHt);
+            }
 
             swap_cb(max_prev, max_cur);  // prev <-> cur for the next chunk
             swap_cb(sum_prev, sum_cur);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sparse_sdpa_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sparse_sdpa_compute.cpp
@@ -172,14 +172,23 @@ void kernel_main() {
                 // separate BF16 tiled buffer, avoiding both a full BF16 K and the RoPE copy into it.
                 constexpr uint32_t latent_DHt = vDHt;
                 constexpr uint32_t rope_DHt = DHt - vDHt;
+                constexpr uint32_t latent_width = latent_DHt * tt::constants::TILE_WIDTH;
+                static_assert(
+                    sparse_sdpa::SCALE_BLOCK_WIDTH % tt::constants::TILE_WIDTH == 0,
+                    "scaled KV scale blocks must span an exact number of tiles");
                 constexpr uint32_t tiles_per_scale_block = sparse_sdpa::SCALE_BLOCK_WIDTH / tt::constants::TILE_WIDTH;
-                constexpr uint32_t scale_blocks = latent_DHt / tiles_per_scale_block;
+                constexpr uint32_t scale_blocks = sparse_sdpa::scale_block_count(latent_width);
+                constexpr uint32_t scale_bytes = sparse_sdpa::scaled_kv_scale_bytes(latent_width);
+                static_assert(
+                    sparse_sdpa::scaled_kv_rope_offset_is_aligned(latent_width),
+                    "scaled KV scale/RoPE boundary must be addressable in 16-byte units");
+                static_assert(
+                    packed_row_bytes % (tt::constants::TILE_WIDTH * sizeof(uint16_t)) == 0,
+                    "scaled KV physical row stride must be an exact number of BF16 tile rows");
                 constexpr uint32_t latent_physical_ct = packed_row_bytes / tt::constants::TILE_WIDTH;
                 constexpr uint32_t rope_physical_ct = packed_row_bytes / (tt::constants::TILE_WIDTH * sizeof(uint16_t));
-                constexpr uint32_t scale_bytes = scale_blocks * sizeof(float);
-                constexpr uint32_t unpack_address_unit_bytes = 16;
                 constexpr uint32_t rope_offset_16b =
-                    (vDHt * tt::constants::TILE_WIDTH + scale_bytes) / unpack_address_unit_bytes;
+                    (latent_width + scale_bytes) / sparse_sdpa::PACKED_FIELD_ADDRESS_UNIT_BYTES;
 
                 k_in_cb.reserve_back(Skt * vDHt);
                 for (uint32_t row_tile = 0; row_tile < Skt; ++row_tile) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_gather.hpp
@@ -2,20 +2,63 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //
-// Shared helper for the dual-NoC K gather. The reader and writer each gather one half of every K chunk on
-// their own (factory-assigned) NoC into the same shared cb_k_rm L1; both halves use this trid ring. Include
-// after api/dataflow/dataflow_api.h and experimental_device_api.hpp (the reader/writer already do).
+// Shared helpers for the dual-NoC K gather. The reader and writer each gather one half of every K chunk on
+// their own (factory-assigned) NoC into the same shared cb_k_rm L1. Include after dataflow_api.h and
+// experimental_device_api.hpp (the reader/writer already do).
 #pragma once
 
 #include <stdint.h>
+#include <tt-metalium/constants.hpp>
+#include "ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/sparse_sdpa_common.hpp"
 
 #include "block_cyclic_remap.hpp"  // tt::block_cyclic::logical_to_physical_page (invP remap, rows)
 
 namespace sparse_sdpa {
 
-// Per-NoC trid-ring depth for each gather half (swept: 4 is the sweet spot — with the split halving each
-// NoC's load, a shallow ring beats both the plain burst and the old deep single-NoC ring).
+// Per-NoC trid-ring depths for each gather half. Raw tiled rows favor a shallow ring; packed scaled rows
+// benefit from more outstanding reads because each transfer is smaller and has reconstruction work to overlap.
 constexpr uint32_t K_TRID_RING = 4;
+constexpr uint32_t SCALED_K_TRID_RING = 8;
+
+// Offset, in tile elements, of column zero for a logical row in the four-face tile layout.
+FORCE_INLINE uint32_t tile_col0_offset(uint32_t row) {
+    const uint32_t face_row = row % tt::constants::FACE_HEIGHT;
+    const uint32_t face_row_group = row / tt::constants::FACE_HEIGHT;
+    constexpr uint32_t face_columns = tt::constants::TILE_WIDTH / tt::constants::FACE_WIDTH;
+    return face_row_group * face_columns * tt::constants::FACE_HW + face_row * tt::constants::FACE_WIDTH;
+}
+
+template <uint32_t ScaleBlocks>
+FORCE_INLINE void scatter_packed_scales(
+    uint32_t packed_l1,
+    uint32_t scale_tiles_l1,
+    uint32_t row_begin,
+    uint32_t row_end,
+    uint32_t packed_row_bytes,
+    uint32_t latent_row_bytes) {
+    volatile tt_l1_ptr uint32_t* packed = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(packed_l1);
+    volatile tt_l1_ptr uint32_t* scale_tiles = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(scale_tiles_l1);
+    const uint32_t packed_row_words = packed_row_bytes / sizeof(uint32_t);
+    const uint32_t latent_row_words = latent_row_bytes / sizeof(uint32_t);
+    for (uint32_t row = row_begin; row < row_end; ++row) {
+        const uint32_t tile_row_offset = tile_col0_offset(row);
+        volatile tt_l1_ptr uint32_t* row_scales = packed + row * packed_row_words + latent_row_words;
+        for (uint32_t block = 0; block < ScaleBlocks; ++block) {
+            scale_tiles[block * tt::constants::TILE_HW + tile_row_offset] = row_scales[block];
+        }
+    }
+}
+
+template <uint32_t ScaleBlocks>
+FORCE_INLINE void clear_scale_rows(uint32_t scale_tiles_l1, uint32_t row_begin, uint32_t row_end) {
+    volatile tt_l1_ptr uint32_t* scale_tiles = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(scale_tiles_l1);
+    for (uint32_t row = row_begin; row < row_end; ++row) {
+        const uint32_t tile_row_offset = tile_col0_offset(row);
+        for (uint32_t block = 0; block < ScaleBlocks; ++block) {
+            scale_tiles[block * tt::constants::TILE_HW + tile_row_offset] = 0;
+        }
+    }
+}
 
 template <
     bool BlockCyclic,
@@ -23,18 +66,20 @@ template <
     uint32_t Sp,
     uint32_t ShardStrideGap,
     uint32_t SlabStrideGap,
+    uint32_t RingDepth,
     typename Accessor>
 FORCE_INLINE void trid_ring_gather(
     Noc& noc,
     const Accessor& kv,
-    experimental::CB& k_cb,
+    uint32_t dst_l1,
     volatile tt_l1_ptr uint32_t* idx_ptr,
     uint32_t base,
     uint32_t lo,
     uint32_t hi,
     uint32_t k_row_bytes,
     uint32_t page_offset) {
-    constexpr uint32_t D = K_TRID_RING;
+    constexpr uint32_t D = RingDepth;
+    const UnicastEndpoint local_l1;
     const uint32_t cnt = hi - lo;
     for (uint32_t i = 0; i < cnt; ++i) {
         const uint32_t p = lo + i;
@@ -46,7 +91,7 @@ FORCE_INLINE void trid_ring_gather(
         const uint32_t page =
             tt::block_cyclic::logical_to_physical_page<BlockCyclic, ChunkLocal, Sp, ShardStrideGap, SlabStrideGap>(
                 idx_ptr[base + p]);
-        noc.async_read(kv, k_cb, k_row_bytes, {.page_id = page_offset + page}, {.offset_bytes = p * k_row_bytes});
+        noc.async_read(kv, local_l1, k_row_bytes, {.page_id = page_offset + page}, {.addr = dst_l1 + p * k_row_bytes});
     }
     const uint32_t to_drain = (cnt < D) ? cnt : D;
     for (uint32_t d = 0; d < to_drain; ++d) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_reader.cpp
@@ -21,34 +21,50 @@
 constexpr uint32_t sentinel = 0xFFFFFFFFu;
 constexpr uint16_t neg_inf_bf16 = 0xFF80u;
 
+FORCE_INLINE uint32_t valid_rows_in_slab(uint32_t valid, uint32_t row_base) {
+    if (valid <= row_base) {
+        return 0;
+    }
+    const uint32_t remaining = valid - row_base;
+    return remaining < tt::constants::TILE_HEIGHT ? remaining : tt::constants::TILE_HEIGHT;
+}
+
 void kernel_main() {
-    constexpr uint32_t H = get_compile_time_arg_val(0);
-    constexpr uint32_t S = get_compile_time_arg_val(1);
-    constexpr uint32_t topk = get_compile_time_arg_val(2);
-    constexpr uint32_t k_chunk = get_compile_time_arg_val(3);
-    constexpr uint32_t k_dim = get_compile_time_arg_val(4);  // q/kv head dim (from the tensor)
+    constexpr uint32_t H = get_compile_time_arg_val(sparse_sdpa::reader_ct_arg::H);
+    constexpr uint32_t S = get_compile_time_arg_val(sparse_sdpa::reader_ct_arg::S);
+    constexpr uint32_t topk = get_compile_time_arg_val(sparse_sdpa::reader_ct_arg::TOPK);
+    constexpr uint32_t k_chunk = get_compile_time_arg_val(sparse_sdpa::reader_ct_arg::K_CHUNK);
+    constexpr uint32_t k_dim =
+        get_compile_time_arg_val(sparse_sdpa::reader_ct_arg::K_DIM);  // q/kv head dim (from the tensor)
 
     // CB ids — passed by the factory (the SparseCB enum is the single source); order must match the
-    // factory's reader CB-arg block (compile args 5..9). cb_kreq/cb_kack come as defines (CB_KREQ/CB_KACK).
-    constexpr uint32_t cb_q_rm = get_compile_time_arg_val(5);
-    constexpr uint32_t cb_k_rm = get_compile_time_arg_val(6);
-    constexpr uint32_t cb_mask_part = get_compile_time_arg_val(7);
-    constexpr uint32_t cb_idx = get_compile_time_arg_val(8);
-    constexpr uint32_t cb_ctrl = get_compile_time_arg_val(9);
+    // factory's reader CB-arg block (compile args 5..9).
+    constexpr uint32_t cb_q_rm = get_compile_time_arg_val(sparse_sdpa::reader_ct_arg::CB_Q_RM);
+    constexpr uint32_t cb_k_rm = get_compile_time_arg_val(sparse_sdpa::reader_ct_arg::CB_K_RM);
+    constexpr uint32_t cb_mask_part = get_compile_time_arg_val(sparse_sdpa::reader_ct_arg::CB_MASK_PART);
+    constexpr uint32_t cb_idx = get_compile_time_arg_val(sparse_sdpa::reader_ct_arg::CB_IDX);
+    constexpr uint32_t cb_ctrl = get_compile_time_arg_val(sparse_sdpa::reader_ct_arg::CB_CTRL);
 
     // Element sizes (from the tensors' dtypes; passed after the CB ids so their indices stay fixed).
-    constexpr uint32_t q_elem_bytes = get_compile_time_arg_val(10);    // bf16
-    constexpr uint32_t kv_elem_bytes = get_compile_time_arg_val(11);   // bf16 or fp8_e4m3
-    constexpr uint32_t idx_elem_bytes = get_compile_time_arg_val(12);  // uint32
-    constexpr bool block_cyclic = get_compile_time_arg_val(13) != 0;
-    constexpr uint32_t bc_chunk_local = get_compile_time_arg_val(14);
-    constexpr uint32_t bc_sp = get_compile_time_arg_val(15);
-    constexpr uint32_t bc_shard_stride_gap = get_compile_time_arg_val(16);
-    constexpr uint32_t bc_slab_stride_gap = get_compile_time_arg_val(17);
+    constexpr uint32_t q_elem_bytes = get_compile_time_arg_val(sparse_sdpa::reader_ct_arg::Q_ELEM_BYTES);  // bf16
+    constexpr uint32_t kv_elem_bytes =
+        get_compile_time_arg_val(sparse_sdpa::reader_ct_arg::KV_ELEM_BYTES);  // bf16 or fp8_e4m3
+    constexpr uint32_t idx_elem_bytes = get_compile_time_arg_val(sparse_sdpa::reader_ct_arg::IDX_ELEM_BYTES);  // uint32
+    constexpr bool block_cyclic = get_compile_time_arg_val(sparse_sdpa::reader_ct_arg::BLOCK_CYCLIC) != 0;
+    constexpr uint32_t bc_chunk_local = get_compile_time_arg_val(sparse_sdpa::reader_ct_arg::BC_CHUNK_LOCAL);
+    constexpr uint32_t bc_sp = get_compile_time_arg_val(sparse_sdpa::reader_ct_arg::BC_SP);
+    constexpr uint32_t bc_shard_stride_gap = get_compile_time_arg_val(sparse_sdpa::reader_ct_arg::BC_SHARD_STRIDE_GAP);
+    constexpr uint32_t bc_slab_stride_gap = get_compile_time_arg_val(sparse_sdpa::reader_ct_arg::BC_SLAB_STRIDE_GAP);
+    constexpr bool scaled_kv = get_compile_time_arg_val(sparse_sdpa::reader_ct_arg::SCALED_KV) != 0;
+    constexpr uint32_t latent_width = get_compile_time_arg_val(sparse_sdpa::reader_ct_arg::LATENT_WIDTH);
+    constexpr uint32_t cb_k_scale_bcast = get_compile_time_arg_val(sparse_sdpa::reader_ct_arg::CB_K_SCALE_BCAST);
+    constexpr uint32_t packed_row_bytes = get_compile_time_arg_val(sparse_sdpa::reader_ct_arg::PACKED_ROW_BYTES);
+    constexpr uint32_t cb_kreq = get_compile_time_arg_val(sparse_sdpa::reader_ct_arg::CB_KREQ);
+    constexpr uint32_t cb_kack = get_compile_time_arg_val(sparse_sdpa::reader_ct_arg::CB_KACK);
 
     // kv carries a RUNTIME tensor shape (its T dim is common runtime args, not compile-time), so its accessor
     // spans both the compile-time AND common-runtime arg streams. Thread both offsets through all three.
-    constexpr auto q_args = TensorAccessorArgs<18, 0>();
+    constexpr auto q_args = TensorAccessorArgs<sparse_sdpa::reader_ct_arg::END, 0>();
     constexpr auto kv_args =
         TensorAccessorArgs<q_args.next_compile_time_args_offset(), q_args.next_common_runtime_args_offset()>();
     constexpr auto idx_args =
@@ -62,17 +78,19 @@ void kernel_main() {
     // Indexed KV cache: page offset (cache_batch_idx * T) selecting the cache's batch slot; 0 if not indexed.
     const uint32_t kv_batch_page_offset = get_arg_val<uint32_t>(5);
 
-    constexpr uint32_t q_row_bytes = k_dim * q_elem_bytes;     // Q row (bf16)
-    constexpr uint32_t k_row_bytes = k_dim * kv_elem_bytes;    // K row (native dtype: fp8 or bf16)
+    constexpr uint32_t q_row_bytes = k_dim * q_elem_bytes;   // Q row (bf16)
+    constexpr uint32_t k_row_bytes = k_dim * kv_elem_bytes;  // K row (native dtype: fp8 or bf16)
+    constexpr uint32_t latent_row_bytes = latent_width;
+    constexpr uint32_t scale_blocks = sparse_sdpa::scale_block_count(latent_width);
     constexpr uint32_t idx_row_bytes = topk * idx_elem_bytes;  // one index row
 
     Noc noc;
     experimental::CB q_cb(cb_q_rm), k_cb(cb_k_rm), mask_part_cb(cb_mask_part), idx_cb(cb_idx), ctrl_cb(cb_ctrl);
-    experimental::CB kreq_cb(CB_KREQ), kack_cb(CB_KACK);  // dual-NoC K-gather handoff to the writer
+    experimental::CB kreq_cb(cb_kreq), kack_cb(cb_kack);  // dual-NoC K-gather handoff to the writer
+    experimental::CB scale_bcast_cb(cb_k_scale_bcast);
     const auto q = TensorAccessor(q_args, q_addr);
     const auto kv = TensorAccessor(kv_args, kv_addr);
     const auto idx = TensorAccessor(idx_args, idx_addr);
-
     // Reader-internal scratch for one token's index row (reserved once, reused).
     idx_cb.reserve_back(1);
     const uint32_t idx_l1 = idx_cb.get_write_ptr();
@@ -112,8 +130,8 @@ void kernel_main() {
         ctrl_cb.reserve_back(1);
         {
             volatile tt_l1_ptr uint32_t* cp = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(ctrl_cb.get_write_ptr());
-            cp[0] = n_active;
-            cp[1] = nv;
+            cp[sparse_sdpa::control_message::ACTIVE_CHUNKS] = n_active;
+            cp[sparse_sdpa::control_message::VALID_KEYS] = nv;
         }
         ctrl_cb.push_back(1);
 
@@ -121,9 +139,65 @@ void kernel_main() {
             const uint32_t base = chunk * k_chunk;
             const uint32_t valid = (nv - base) < k_chunk ? (nv - base) : k_chunk;  // (0, k_chunk]
 
-            // K chunk rows -> cb_k_rm: read the `valid` real keys, zero-fill the sentinel suffix.
-            k_cb.reserve_back(k_chunk);
-            {
+            if constexpr (scaled_kv) {
+                // Stream one 32-row compressed slab at a time. cb_k_rm owns the double-buffered packed FIFO;
+                // cb_k_rope_rm is a format-only BF16 view whose read pointer is derived by compute.
+                constexpr uint32_t row_tiles = k_chunk / tt::constants::TILE_HEIGHT;
+                for (uint32_t row_tile = 0; row_tile < row_tiles; ++row_tile) {
+                    const uint32_t row_base = row_tile * tt::constants::TILE_HEIGHT;
+                    const uint32_t rows = valid_rows_in_slab(valid, row_base);
+                    const uint32_t split = rows / 2;
+
+                    k_cb.reserve_back(tt::constants::TILE_HEIGHT);
+                    scale_bcast_cb.reserve_back(scale_blocks);
+                    const uint32_t k_write_ptr = k_cb.get_write_ptr();
+                    const uint32_t scale_write_ptr = scale_bcast_cb.get_write_ptr();
+                    const uint32_t slab_base = base + row_base;
+                    const bool is_last_slab = (chunk == n_active - 1) && (row_tile == row_tiles - 1);
+
+                    kreq_cb.reserve_back(1);
+                    {
+                        volatile tt_l1_ptr uint32_t* request =
+                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(kreq_cb.get_write_ptr());
+                        request[sparse_sdpa::gather_request::BASE] = slab_base;
+                        request[sparse_sdpa::gather_request::SPLIT] = split;
+                        request[sparse_sdpa::gather_request::IS_LAST] = is_last_slab;
+                        request[sparse_sdpa::gather_request::DST_L1] = k_write_ptr;
+                        request[sparse_sdpa::gather_request::SCALE_DST_L1] = scale_write_ptr;
+                    }
+                    kreq_cb.push_back(1);
+
+                    sparse_sdpa::trid_ring_gather<
+                        block_cyclic,
+                        bc_chunk_local,
+                        bc_sp,
+                        bc_shard_stride_gap,
+                        bc_slab_stride_gap,
+                        sparse_sdpa::SCALED_K_TRID_RING>(
+                        noc, kv, k_write_ptr, idx_ptr, slab_base, split, rows, packed_row_bytes, kv_batch_page_offset);
+                    // Expand the scale rows from the reader's gathered half while the writer handles its
+                    // own half. The two RISCs write disjoint rows of the same FP32 broadcast tiles.
+                    sparse_sdpa::scatter_packed_scales<scale_blocks>(
+                        k_write_ptr, scale_write_ptr, split, rows, packed_row_bytes, latent_row_bytes);
+                    kack_cb.wait_front(1);
+                    kack_cb.pop_front(1);
+
+                    if (rows < tt::constants::TILE_HEIGHT) {
+                        noc.async_write_zeros(
+                            k_cb,
+                            (tt::constants::TILE_HEIGHT - rows) * packed_row_bytes,
+                            {.offset_bytes = rows * packed_row_bytes});
+                        noc.write_zeros_l1_barrier();
+                    }
+                    // Zero the scale rows for the padded suffix after both real-row halves have joined.
+                    sparse_sdpa::clear_scale_rows<scale_blocks>(scale_write_ptr, rows, tt::constants::TILE_HEIGHT);
+                    k_cb.push_back(tt::constants::TILE_HEIGHT);
+                    scale_bcast_cb.push_back(scale_blocks);
+                }
+            } else {
+                // K chunk rows -> cb_k_rm: read the `valid` real keys, zero-fill the sentinel suffix.
+                k_cb.reserve_back(k_chunk);
+                const uint32_t k_write_ptr = k_cb.get_write_ptr();
                 // Dual-NoC split gather: the K-row response data is the op's bottleneck (NoC-link bound, not
                 // DRAM-controller bound), so we spread it across BOTH NoCs. The reader (this NoC) gathers
                 // rows [half,valid); it hands the writer rows [0,half) via cb_kreq, and the writer gathers
@@ -132,17 +206,23 @@ void kernel_main() {
                 const uint32_t half = valid >> 1;
                 kreq_cb.reserve_back(1);
                 {
-                    volatile tt_l1_ptr uint32_t* rq =
+                    volatile tt_l1_ptr uint32_t* request =
                         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(kreq_cb.get_write_ptr());
-                    rq[0] = base;
-                    rq[1] = half;
-                    rq[2] = (chunk == n_active - 1);  // writer ends the token's gather phase on the last chunk
+                    request[sparse_sdpa::gather_request::BASE] = base;
+                    request[sparse_sdpa::gather_request::SPLIT] = half;
+                    request[sparse_sdpa::gather_request::IS_LAST] = chunk == n_active - 1;
+                    request[sparse_sdpa::gather_request::DST_L1] = k_write_ptr;
                 }
                 kreq_cb.push_back(1);
                 // Reader gathers its half [half, valid) on its NoC (depth-4 trid ring, shared helper).
-                sparse_sdpa::
-                    trid_ring_gather<block_cyclic, bc_chunk_local, bc_sp, bc_shard_stride_gap, bc_slab_stride_gap>(
-                        noc, kv, k_cb, idx_ptr, base, half, valid, k_row_bytes, kv_batch_page_offset);
+                sparse_sdpa::trid_ring_gather<
+                    block_cyclic,
+                    bc_chunk_local,
+                    bc_sp,
+                    bc_shard_stride_gap,
+                    bc_slab_stride_gap,
+                    sparse_sdpa::K_TRID_RING>(
+                    noc, kv, k_write_ptr, idx_ptr, base, half, valid, k_row_bytes, kv_batch_page_offset);
                 kack_cb.wait_front(1);  // writer's half landed in cb_k_rm L1
                 kack_cb.pop_front(1);
                 // Zero-fill the sentinel suffix: masked-key scores become a defined 0 (compute adds -inf).
@@ -150,8 +230,8 @@ void kernel_main() {
                     noc.async_write_zeros(k_cb, (k_chunk - valid) * k_row_bytes, {.offset_bytes = valid * k_row_bytes});
                     noc.write_zeros_l1_barrier();
                 }
+                k_cb.push_back(k_chunk);
             }
-            k_cb.push_back(k_chunk);
 
             // Boundary mask: only the LAST active chunk can have sentinels. Its key tile that straddles
             // `valid` (tile valid/32) needs cols >= valid%32 set to -inf; the tiles after it are fully

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_writer.cpp
@@ -20,22 +20,31 @@ constexpr uint32_t one_bf16_packed = 0x3F803F80u;  // bf16(1.0) double-packed; g
 constexpr uint16_t neg_inf_bf16 = 0xFF80u;
 
 void kernel_main() {
-    constexpr uint32_t H = get_compile_time_arg_val(0);
-    constexpr uint32_t S = get_compile_time_arg_val(1);
-    constexpr uint32_t vDHt = get_compile_time_arg_val(2);
+    constexpr uint32_t H = get_compile_time_arg_val(sparse_sdpa::writer_ct_arg::H);
+    constexpr uint32_t S = get_compile_time_arg_val(sparse_sdpa::writer_ct_arg::S);
+    constexpr uint32_t vDHt = get_compile_time_arg_val(sparse_sdpa::writer_ct_arg::V_DHT);
     // CB ids — passed by the factory (the SparseCB enum is the single source); order must match the
     // factory's writer CB-arg block (compile args 3..6).
-    constexpr uint32_t cb_out_rm = get_compile_time_arg_val(3);
-    constexpr uint32_t cb_scale = get_compile_time_arg_val(4);
-    constexpr uint32_t cb_col_identity = get_compile_time_arg_val(5);
-    constexpr uint32_t cb_neginf = get_compile_time_arg_val(6);
-    constexpr uint32_t out_elem_bytes = get_compile_time_arg_val(7);  // bf16 (from the output tensor's dtype)
-    constexpr bool block_cyclic = get_compile_time_arg_val(8) != 0;
-    constexpr uint32_t bc_chunk_local = get_compile_time_arg_val(9);
-    constexpr uint32_t bc_sp = get_compile_time_arg_val(10);
-    constexpr uint32_t bc_shard_stride_gap = get_compile_time_arg_val(11);
-    constexpr uint32_t bc_slab_stride_gap = get_compile_time_arg_val(12);
-    constexpr auto out_args = TensorAccessorArgs<13, 0>();
+    constexpr uint32_t cb_out_rm = get_compile_time_arg_val(sparse_sdpa::writer_ct_arg::CB_OUT_RM);
+    constexpr uint32_t cb_scale = get_compile_time_arg_val(sparse_sdpa::writer_ct_arg::CB_SCALE);
+    constexpr uint32_t cb_col_identity = get_compile_time_arg_val(sparse_sdpa::writer_ct_arg::CB_COL_IDENTITY);
+    constexpr uint32_t cb_neginf = get_compile_time_arg_val(sparse_sdpa::writer_ct_arg::CB_NEGINF);
+    constexpr uint32_t out_elem_bytes =
+        get_compile_time_arg_val(sparse_sdpa::writer_ct_arg::OUT_ELEM_BYTES);  // output tensor dtype
+    constexpr bool block_cyclic = get_compile_time_arg_val(sparse_sdpa::writer_ct_arg::BLOCK_CYCLIC) != 0;
+    constexpr uint32_t bc_chunk_local = get_compile_time_arg_val(sparse_sdpa::writer_ct_arg::BC_CHUNK_LOCAL);
+    constexpr uint32_t bc_sp = get_compile_time_arg_val(sparse_sdpa::writer_ct_arg::BC_SP);
+    constexpr uint32_t bc_shard_stride_gap = get_compile_time_arg_val(sparse_sdpa::writer_ct_arg::BC_SHARD_STRIDE_GAP);
+    constexpr uint32_t bc_slab_stride_gap = get_compile_time_arg_val(sparse_sdpa::writer_ct_arg::BC_SLAB_STRIDE_GAP);
+    constexpr bool scaled_kv = get_compile_time_arg_val(sparse_sdpa::writer_ct_arg::SCALED_KV) != 0;
+    constexpr uint32_t k_dim = get_compile_time_arg_val(sparse_sdpa::writer_ct_arg::K_DIM);
+    constexpr uint32_t kv_elem_bytes = get_compile_time_arg_val(sparse_sdpa::writer_ct_arg::KV_ELEM_BYTES);
+    constexpr uint32_t cb_k_rm = get_compile_time_arg_val(sparse_sdpa::writer_ct_arg::CB_K_RM);
+    constexpr uint32_t cb_idx = get_compile_time_arg_val(sparse_sdpa::writer_ct_arg::CB_IDX);
+    constexpr uint32_t cb_kreq = get_compile_time_arg_val(sparse_sdpa::writer_ct_arg::CB_KREQ);
+    constexpr uint32_t cb_kack = get_compile_time_arg_val(sparse_sdpa::writer_ct_arg::CB_KACK);
+    constexpr uint32_t packed_row_bytes = get_compile_time_arg_val(sparse_sdpa::writer_ct_arg::PACKED_ROW_BYTES);
+    constexpr auto out_args = TensorAccessorArgs<sparse_sdpa::writer_ct_arg::END, 0>();
     // kv carries a RUNTIME tensor shape (T dim in common runtime args), so its accessor spans both arg streams.
     constexpr auto kv_args =
         TensorAccessorArgs<out_args.next_compile_time_args_offset(), out_args.next_common_runtime_args_offset()>();
@@ -57,9 +66,11 @@ void kernel_main() {
     // (the reader owns the reserve/push; we fill rows [0,half) at the same write ptr). This spreads the
     // K response-data load over both NoC links. Indices live in the reader's shared cb_idx
     // scratch; the kv accessor + row size mirror the reader.
-    constexpr uint32_t k_row_bytes = K_DIM * KV_ELEM_BYTES;
+    constexpr uint32_t k_row_bytes = k_dim * kv_elem_bytes;
+    constexpr uint32_t latent_row_bytes = vDHt * tt::constants::TILE_WIDTH;
+    constexpr uint32_t scale_blocks = sparse_sdpa::scale_block_count(latent_row_bytes);
     const auto kv = TensorAccessor(kv_args, kv_addr);
-    experimental::CB k_cb(CB_K_RM), idx_cb(CB_IDX), kreq_cb(CB_KREQ), kack_cb(CB_KACK);
+    experimental::CB k_cb(cb_k_rm), idx_cb(cb_idx), kreq_cb(cb_kreq), kack_cb(cb_kack);
     volatile tt_l1_ptr uint32_t* idx_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(idx_cb.get_write_ptr());
 
     // --- persistent compute-input tiles (built once; the reader is busier with the K gather) ---
@@ -75,36 +86,61 @@ void kernel_main() {
     generate_bcast_col_scalar(CircularBuffer(cb_col_identity), one_bf16_packed);
 
     // All-(-inf) tile (row 0; compute bcast-adds it to fully-masked key tiles). Only row 0 matters for the
-    // row-broadcast add: cols 0-15 -> face0 row0 (offset c), cols 16-31 -> face1 row0 (offset 256+c).
+    // row-broadcast add: the left and right half-rows live in face 0 and face 1 respectively.
     {
         experimental::CB neginf_cb(cb_neginf);
         neginf_cb.reserve_back(1);
         volatile tt_l1_ptr uint16_t* p = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(neginf_cb.get_write_ptr());
-        for (uint32_t c = 0; c < 16; ++c) {
-            p[c] = neg_inf_bf16;        // face0 row 0 (cols 0-15)
-            p[256 + c] = neg_inf_bf16;  // face1 row 0 (cols 16-31)
+        for (uint32_t c = 0; c < tt::constants::FACE_WIDTH; ++c) {
+            p[c] = neg_inf_bf16;
+            p[tt::constants::FACE_HW + c] = neg_inf_bf16;
         }
         neginf_cb.push_back(1);
     }
 
     for (uint32_t tok = tok_start; tok < tok_start + tok_count; ++tok) {
-        // K-gather phase: process this token's active chunks (reader signals per chunk; is_last ends the
-        // token). Gather rows [0,half) on the writer's NoC into the reserved cb_k_rm L1, then ack.
+        // K-gather phase: process this token's active chunks (reader signals per chunk; is_last ends the token).
+        // Gather rows [0,split) on the writer's NoC into the reader-reserved destination, then ack.
         bool last = false;
         while (!last) {
             kreq_cb.wait_front(1);
-            uint32_t base, half;
+            uint32_t base, split, dst_l1, scale_dst_l1 = 0;
             {
-                volatile tt_l1_ptr uint32_t* rq =
+                volatile tt_l1_ptr uint32_t* request =
                     reinterpret_cast<volatile tt_l1_ptr uint32_t*>(kreq_cb.get_read_ptr());
-                base = rq[0];
-                half = rq[1];
-                last = rq[2] != 0;
+                base = request[sparse_sdpa::gather_request::BASE];
+                split = request[sparse_sdpa::gather_request::SPLIT];
+                if constexpr (scaled_kv) {
+                    last = request[sparse_sdpa::gather_request::IS_LAST] != 0;
+                    dst_l1 = request[sparse_sdpa::gather_request::DST_L1];
+                    scale_dst_l1 = request[sparse_sdpa::gather_request::SCALE_DST_L1];
+                } else {
+                    last = request[sparse_sdpa::gather_request::IS_LAST] != 0;
+                    dst_l1 = request[sparse_sdpa::gather_request::DST_L1];
+                }
             }
             kreq_cb.pop_front(1);
-            // Writer gathers its half [0, half) on its NoC (depth-4 trid ring, shared helper).
-            sparse_sdpa::trid_ring_gather<block_cyclic, bc_chunk_local, bc_sp, bc_shard_stride_gap, bc_slab_stride_gap>(
-                noc, kv, k_cb, idx_ptr, base, 0, half, k_row_bytes, kv_batch_page_offset);
+            if constexpr (scaled_kv) {
+                sparse_sdpa::trid_ring_gather<
+                    block_cyclic,
+                    bc_chunk_local,
+                    bc_sp,
+                    bc_shard_stride_gap,
+                    bc_slab_stride_gap,
+                    sparse_sdpa::SCALED_K_TRID_RING>(
+                    noc, kv, dst_l1, idx_ptr, base, 0, split, packed_row_bytes, kv_batch_page_offset);
+                sparse_sdpa::scatter_packed_scales<scale_blocks>(
+                    dst_l1, scale_dst_l1, 0, split, packed_row_bytes, latent_row_bytes);
+            } else {
+                sparse_sdpa::trid_ring_gather<
+                    block_cyclic,
+                    bc_chunk_local,
+                    bc_sp,
+                    bc_shard_stride_gap,
+                    bc_slab_stride_gap,
+                    sparse_sdpa::K_TRID_RING>(
+                    noc, kv, dst_l1, idx_ptr, base, 0, split, k_row_bytes, kv_batch_page_offset);
+            }
             kack_cb.reserve_back(1);
             kack_cb.push_back(1);
         }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_writer.cpp
@@ -39,7 +39,6 @@ void kernel_main() {
     constexpr bool scaled_kv = get_compile_time_arg_val(sparse_sdpa::writer_ct_arg::SCALED_KV) != 0;
     constexpr uint32_t k_dim = get_compile_time_arg_val(sparse_sdpa::writer_ct_arg::K_DIM);
     constexpr uint32_t kv_elem_bytes = get_compile_time_arg_val(sparse_sdpa::writer_ct_arg::KV_ELEM_BYTES);
-    constexpr uint32_t cb_k_rm = get_compile_time_arg_val(sparse_sdpa::writer_ct_arg::CB_K_RM);
     constexpr uint32_t cb_idx = get_compile_time_arg_val(sparse_sdpa::writer_ct_arg::CB_IDX);
     constexpr uint32_t cb_kreq = get_compile_time_arg_val(sparse_sdpa::writer_ct_arg::CB_KREQ);
     constexpr uint32_t cb_kack = get_compile_time_arg_val(sparse_sdpa::writer_ct_arg::CB_KACK);
@@ -70,7 +69,7 @@ void kernel_main() {
     constexpr uint32_t latent_row_bytes = vDHt * tt::constants::TILE_WIDTH;
     constexpr uint32_t scale_blocks = sparse_sdpa::scale_block_count(latent_row_bytes);
     const auto kv = TensorAccessor(kv_args, kv_addr);
-    experimental::CB k_cb(cb_k_rm), idx_cb(cb_idx), kreq_cb(cb_kreq), kack_cb(cb_kack);
+    experimental::CB idx_cb(cb_idx), kreq_cb(cb_kreq), kack_cb(cb_kack);
     volatile tt_l1_ptr uint32_t* idx_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(idx_cb.get_write_ptr());
 
     // --- persistent compute-input tiles (built once; the reader is busier with the K gather) ---
@@ -110,13 +109,10 @@ void kernel_main() {
                     reinterpret_cast<volatile tt_l1_ptr uint32_t*>(kreq_cb.get_read_ptr());
                 base = request[sparse_sdpa::gather_request::BASE];
                 split = request[sparse_sdpa::gather_request::SPLIT];
+                last = request[sparse_sdpa::gather_request::IS_LAST] != 0;
+                dst_l1 = request[sparse_sdpa::gather_request::DST_L1];
                 if constexpr (scaled_kv) {
-                    last = request[sparse_sdpa::gather_request::IS_LAST] != 0;
-                    dst_l1 = request[sparse_sdpa::gather_request::DST_L1];
                     scale_dst_l1 = request[sparse_sdpa::gather_request::SCALE_DST_L1];
-                } else {
-                    last = request[sparse_sdpa::gather_request::IS_LAST] != 0;
-                    dst_l1 = request[sparse_sdpa::gather_request::DST_L1];
                 }
             }
             kreq_cb.pop_front(1);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/sparse_sdpa_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/sparse_sdpa_common.hpp
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <stdint.h>
+
+// Host/device constants shared by the sparse-SDPA factory and JIT kernels. Keep this header free of host-only and
+// kernel-only dependencies so both compilation paths use the same protocol and packed-cache geometry.
+namespace sparse_sdpa {
+
+constexpr uint32_t SCALE_BLOCK_WIDTH = 128;
+constexpr uint32_t CB_PAGE_ALIGNMENT = 16;
+constexpr uint32_t CB_DOUBLE_BUFFER_DEPTH = 2;
+
+constexpr uint32_t align_cb_page(uint32_t bytes) {
+    return ((bytes + CB_PAGE_ALIGNMENT - 1) / CB_PAGE_ALIGNMENT) * CB_PAGE_ALIGNMENT;
+}
+
+constexpr uint32_t scale_block_count(uint32_t latent_width) { return latent_width / SCALE_BLOCK_WIDTH; }
+
+constexpr uint32_t packed_kv_width(uint32_t k_dim, uint32_t latent_width) {
+    return latent_width + scale_block_count(latent_width) * sizeof(float) + (k_dim - latent_width) * sizeof(uint16_t);
+}
+
+// Reader -> writer dual-NoC gather request. SCALE_DST_L1 is used only by the scaled-cache path.
+namespace gather_request {
+constexpr uint32_t BASE = 0;
+constexpr uint32_t SPLIT = 1;
+constexpr uint32_t IS_LAST = 2;
+constexpr uint32_t DST_L1 = 3;
+constexpr uint32_t SCALE_DST_L1 = 4;
+constexpr uint32_t WORD_COUNT = 5;
+constexpr uint32_t PAGE_BYTES = align_cb_page(WORD_COUNT * sizeof(uint32_t));
+}  // namespace gather_request
+
+// Reader -> compute token control message.
+namespace control_message {
+constexpr uint32_t ACTIVE_CHUNKS = 0;
+constexpr uint32_t VALID_KEYS = 1;
+constexpr uint32_t WORD_COUNT = 2;
+constexpr uint32_t PAGE_BYTES = align_cb_page(WORD_COUNT * sizeof(uint32_t));
+}  // namespace control_message
+
+constexpr uint32_t ACK_PAGE_BYTES = CB_PAGE_ALIGNMENT;
+
+// Compile-time argument positions. The factory checks the vector size against each END value before appending
+// TensorAccessorArgs, while the kernels use the same names to decode the stream.
+namespace reader_ct_arg {
+enum : uint32_t {
+    H = 0,
+    S,
+    TOPK,
+    K_CHUNK,
+    K_DIM,
+    CB_Q_RM,
+    CB_K_RM,
+    CB_MASK_PART,
+    CB_IDX,
+    CB_CTRL,
+    Q_ELEM_BYTES,
+    KV_ELEM_BYTES,
+    IDX_ELEM_BYTES,
+    BLOCK_CYCLIC,
+    BC_CHUNK_LOCAL,
+    BC_SP,
+    BC_SHARD_STRIDE_GAP,
+    BC_SLAB_STRIDE_GAP,
+    SCALED_KV,
+    LATENT_WIDTH,
+    CB_K_SCALE_BCAST,
+    PACKED_ROW_BYTES,
+    CB_KREQ,
+    CB_KACK,
+    END,
+};
+}  // namespace reader_ct_arg
+
+namespace writer_ct_arg {
+enum : uint32_t {
+    H = 0,
+    S,
+    V_DHT,
+    CB_OUT_RM,
+    CB_SCALE,
+    CB_COL_IDENTITY,
+    CB_NEGINF,
+    OUT_ELEM_BYTES,
+    BLOCK_CYCLIC,
+    BC_CHUNK_LOCAL,
+    BC_SP,
+    BC_SHARD_STRIDE_GAP,
+    BC_SLAB_STRIDE_GAP,
+    SCALED_KV,
+    K_DIM,
+    KV_ELEM_BYTES,
+    CB_K_RM,
+    CB_IDX,
+    CB_KREQ,
+    CB_KACK,
+    PACKED_ROW_BYTES,
+    END,
+};
+}  // namespace writer_ct_arg
+
+namespace compute_ct_arg {
+enum : uint32_t {
+    H = 0,
+    DHT,
+    V_DHT,
+    SKT,
+    SCALE,
+    CB_Q_RM,
+    CB_Q_IN,
+    CB_K_RM,
+    CB_K_IN,
+    CB_NEGINF,
+    CB_MASK_PART,
+    CB_SCALE,
+    CB_QK_IM,
+    CB_MAX_A,
+    CB_MAX_B,
+    CB_SUM_A,
+    CB_SUM_B,
+    CB_OUT_A,
+    CB_OUT_B,
+    CB_CORR,
+    CB_OUT_IM,
+    CB_OUT_RM,
+    CB_CTRL,
+    CB_COL_IDENTITY,
+    CB_RECIP_SCRATCH,
+    SCALED_KV,
+    CB_K_ROPE_RM,
+    CB_K_SCALE_BCAST,
+    CB_K_LATENT_TILE,
+    CB_K_ROPE_TILE,
+    MATH_APPROX_MODE,
+    QUERY_SUBBLOCK,
+    PACKED_ROW_BYTES,
+    END,
+};
+}  // namespace compute_ct_arg
+
+}  // namespace sparse_sdpa

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/sparse_sdpa_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/sparse_sdpa_common.hpp
@@ -11,6 +11,7 @@
 namespace sparse_sdpa {
 
 constexpr uint32_t SCALE_BLOCK_WIDTH = 128;
+constexpr uint32_t PACKED_FIELD_ADDRESS_UNIT_BYTES = 16;
 constexpr uint32_t CB_PAGE_ALIGNMENT = 16;
 constexpr uint32_t CB_DOUBLE_BUFFER_DEPTH = 2;
 
@@ -20,8 +21,16 @@ constexpr uint32_t align_cb_page(uint32_t bytes) {
 
 constexpr uint32_t scale_block_count(uint32_t latent_width) { return latent_width / SCALE_BLOCK_WIDTH; }
 
-constexpr uint32_t packed_kv_width(uint32_t k_dim, uint32_t latent_width) {
-    return latent_width + scale_block_count(latent_width) * sizeof(float) + (k_dim - latent_width) * sizeof(uint16_t);
+constexpr uint32_t scaled_kv_scale_bytes(uint32_t latent_width) {
+    return scale_block_count(latent_width) * sizeof(float);
+}
+
+constexpr bool scaled_kv_rope_offset_is_aligned(uint32_t latent_width) {
+    return (latent_width + scaled_kv_scale_bytes(latent_width)) % PACKED_FIELD_ADDRESS_UNIT_BYTES == 0;
+}
+
+constexpr uint32_t packed_kv_payload_bytes(uint32_t k_dim, uint32_t latent_width) {
+    return latent_width + scaled_kv_scale_bytes(latent_width) + (k_dim - latent_width) * sizeof(uint16_t);
 }
 
 // Reader -> writer dual-NoC gather request. SCALE_DST_L1 is used only by the scaled-cache path.
@@ -95,7 +104,6 @@ enum : uint32_t {
     SCALED_KV,
     K_DIM,
     KV_ELEM_BYTES,
-    CB_K_RM,
     CB_IDX,
     CB_KREQ,
     CB_KACK,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.hpp"
+#include "ttnn/operations/transformer/sdpa/device/kernels/sparse_sdpa_common.hpp"
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operation.hpp"
 #include "ttnn/device.hpp"
@@ -15,12 +16,11 @@ namespace ttnn::prim {
 namespace {
 // All input invariants the program hash does NOT key on, so they can vary while hitting the same cached
 // program and must be re-checked on EVERY dispatch (miss AND hit). The hash keys only on q/indices shape+dtype
-// and kv dtype+memory_config — NOT on tensor layout, padding, q/indices buffer type/sharding, the kv logical
-// shape (its T rides on the kv TensorAccessor's RuntimeTensorShape runtime metadata, not a kernel scalar),
-// cache_batch_idx (a dynamic runtime arg), or device
-// placement. The accessors assume ROW_MAJOR, unpadded, DRAM, interleaved q/indices, so a cache hit with a
-// tiled/padded/L1/sharded/off-device tensor would otherwise run on wrong assumptions. K_DIM comes from q,
-// whose shape IS hashed, so it is pinned. Shared by validate_on_program_cache_miss and _hit.
+// and kv dtype+memory_config — NOT on tensor layout, padding, q/indices buffer type/sharding, the logical shape
+// of a plain interleaved kv, cache_batch_idx (a dynamic runtime arg), or device placement. The accessors assume
+// ROW_MAJOR, unpadded, DRAM, interleaved q/indices, so a cache hit with a tiled/padded/L1/sharded/off-device tensor
+// would otherwise run on wrong assumptions. K_DIM comes from q, whose shape IS hashed, so it is pinned. Shared by
+// validate_on_program_cache_miss and _hit.
 void validate_non_hashed(const SparseSDPAParams& attrs, const SparseSDPAInputs& t) {
     const auto& q = t.q;
     const auto& kv = t.kv;
@@ -37,16 +37,20 @@ void validate_non_hashed(const SparseSDPAParams& attrs, const SparseSDPAInputs& 
     // kv: ROW_MAJOR and unpadded; may be interleaved OR ND-sharded DRAM (the accessor resolves the per-page
     // bank/shard either way — kv's DRAM/shard layout is pinned via the hashed kv.memory_config(), its
     // ROW_MAJOR layout and padding are not).
-    TT_FATAL(kv.layout() == Layout::ROW_MAJOR, "sparse_sdpa kv must be ROW_MAJOR");
-    TT_FATAL(kv.padded_shape() == kv.logical_shape(), "sparse_sdpa kv must not be padded");
+    TT_FATAL(kv.layout() == Layout::ROW_MAJOR, "sparse_sdpa KV cache must be ROW_MAJOR");
+    TT_FATAL(kv.padded_shape() == kv.logical_shape(), "sparse_sdpa KV cache must not be padded");
+    TT_FATAL(kv.memory_config().buffer_type() == BufferType::DRAM, "sparse_sdpa KV cache must be in DRAM");
     const uint32_t K_DIM = q.logical_shape()[3];
     const auto kvs = kv.logical_shape();
     // kv is [B,1,T,K_DIM]: B == 1 normally; when indexed (cache_batch_idx set) B is the cache's batch slots
     // and cache_batch_idx selects one. q is always batch-1, so the selected slot serves the whole query.
+    const uint32_t packed_kv_width = ::sparse_sdpa::packed_kv_width(K_DIM, attrs.v_dim);
+    const uint32_t expected_kv_width = t.has_scaled_kv() ? packed_kv_width : K_DIM;
     TT_FATAL(
-        kvs.rank() == 4 && kvs[1] == 1 && kvs[3] == K_DIM,
-        "kv must be [B,1,T,K_DIM] with K_DIM matching q ({})",
-        K_DIM);
+        kvs.rank() == 4 && kvs[1] == 1 && kvs[3] == expected_kv_width,
+        "kv must be [B,1,T,{}] (got {})",
+        expected_kv_width,
+        kvs);
     TT_FATAL(kvs[2] > 0, "kv T (cache length) must be > 0");
     const uint32_t B = kvs[0];
     if (attrs.cache_batch_idx.has_value()) {
@@ -79,12 +83,14 @@ void SparseSDPAOperation::validate_on_program_cache_miss(const SparseSDPAParams&
     const bool q_is_fp8 = (q.dtype() == DataType::FP8_E4M3);
     TT_FATAL(q.dtype() == DataType::BFLOAT16 || q_is_fp8, "q must be bf16 or fp8_e4m3");
     TT_FATAL(kv.dtype() == DataType::BFLOAT16 || kv_is_fp8, "kv must be bf16 or fp8_e4m3");
+    if (t.has_scaled_kv()) {
+        TT_FATAL(kv_is_fp8, "packed scaled KV must use fp8_e4m3 byte storage");
+        TT_FATAL(
+            attrs.v_dim % ::sparse_sdpa::SCALE_BLOCK_WIDTH == 0,
+            "scaled KV v_dim must be divisible by {}",
+            ::sparse_sdpa::SCALE_BLOCK_WIDTH);
+    }
     TT_FATAL(idx.dtype() == DataType::UINT32, "indices must be uint32");
-
-    // kv DRAM residency is keyed by the hash (kv.memory_config()), so it is checked on miss only. The
-    // remaining layout/memory/padding/device invariants (q/indices layout+memory+padding, kv layout+padding,
-    // same-device) are NOT hashed and are checked in validate_non_hashed (called below, run on miss AND hit).
-    TT_FATAL(kv.memory_config().buffer_type() == BufferType::DRAM, "sparse_sdpa kv must be in DRAM");
 
     const auto qs = q.logical_shape();
     const auto is = idx.logical_shape();
@@ -97,6 +103,19 @@ void SparseSDPAOperation::validate_on_program_cache_miss(const SparseSDPAParams&
     // scale with H — so a too-large H simply fails CB allocation at program creation rather than here.
     constexpr uint32_t tile_h = tt::constants::TILE_HEIGHT;
     TT_FATAL(H % tile_h == 0 && H >= tile_h, "sparse_sdpa: H must be a multiple of {} (got {})", tile_h, H);
+    // Validate v_dim before validate_non_hashed derives the packed mixed-format row width. In particular,
+    // reject v_dim > K_DIM before the unsigned RoPE-width subtraction.
+    TT_FATAL(attrs.v_dim > 0 && attrs.v_dim <= K_DIM, "v_dim must be in (0, K_DIM={}] (got {})", K_DIM, attrs.v_dim);
+    TT_FATAL(
+        attrs.v_dim % tt::constants::TILE_WIDTH == 0,
+        "v_dim must be a multiple of {} (got {})",
+        tt::constants::TILE_WIDTH,
+        attrs.v_dim);
+    TT_FATAL(
+        K_DIM % tt::constants::TILE_WIDTH == 0,
+        "K_DIM (q/kv last dim) must be a multiple of {} (got {})",
+        tt::constants::TILE_WIDTH,
+        K_DIM);
     // All non-hashed invariants (q/indices/kv layout+memory+padding, kv shape, cache_batch_idx, same-device).
     // kv may be oversized: a persistent max-size cache whose logical T far exceeds the keys any query attends
     // to. No valid-length bound is needed — reads are index-driven (indices < populated length, sentinels mark
@@ -123,19 +142,6 @@ void SparseSDPAOperation::validate_on_program_cache_miss(const SparseSDPAParams&
     const uint32_t TOPK = is[3];
     TT_FATAL(S > 0 && TOPK > 0, "S/TOPK must be > 0");
 
-    // V is the leading v_dim cols of the K_DIM-wide KV cache.
-    TT_FATAL(attrs.v_dim > 0 && attrs.v_dim <= K_DIM, "v_dim must be in (0, K_DIM={}] (got {})", K_DIM, attrs.v_dim);
-    TT_FATAL(
-        attrs.v_dim % tt::constants::TILE_WIDTH == 0,
-        "v_dim must be a multiple of {} (got {})",
-        tt::constants::TILE_WIDTH,
-        attrs.v_dim);
-    TT_FATAL(
-        K_DIM % tt::constants::TILE_WIDTH == 0,
-        "K_DIM (q/kv last dim) must be a multiple of {} (got {})",
-        tt::constants::TILE_WIDTH,
-        K_DIM);
-
     // k_chunk_size: multiple of the tile width (it tiles the key axis), divides TOPK
     constexpr uint32_t tile_w = tt::constants::TILE_WIDTH;
     TT_FATAL(
@@ -153,7 +159,12 @@ void SparseSDPAOperation::validate_on_program_cache_miss(const SparseSDPAParams&
     // matches q (compute_output_specs), so its row width uses q's element size.
     const uint32_t dram_align = tt::tt_metal::hal::get_dram_alignment();
     TT_FATAL((K_DIM * q.element_size()) % dram_align == 0, "Q row bytes must be {}B aligned", dram_align);
-    TT_FATAL((K_DIM * kv.element_size()) % dram_align == 0, "K row bytes must be {}B aligned", dram_align);
+    if (!t.has_scaled_kv()) {
+        TT_FATAL(
+            (kv.logical_shape()[3] * kv.element_size()) % dram_align == 0,
+            "K row bytes must be {}B aligned",
+            dram_align);
+    }
     TT_FATAL((TOPK * idx.element_size()) % dram_align == 0, "indices row bytes must be {}B aligned", dram_align);
     TT_FATAL((attrs.v_dim * q.element_size()) % dram_align == 0, "output row bytes must be {}B aligned", dram_align);
 
@@ -205,13 +216,14 @@ ttsl::hash::hash_t SparseSDPAOperation::compute_program_hash(const SparseSDPAPar
         t.q.logical_shape(),
         t.q.dtype(),
         t.kv.dtype(),
+        t.has_scaled_kv(),
         // kv.memory_config(): an ND-sharded kv produces different TensorAccessor compile-time args than an
         // interleaved one, so they must be distinct programs.
         t.kv.memory_config(),
         // kv.logical_shape() when sharded (see above) OR block-cyclic: the block-cyclic remap bakes its
         // T-dependent stride gap as a compile-time argument, so the cache length T must be in the hash (a
-        // different cache size is a distinct program). A plain interleaved kv keeps T out of the hash (sentinel
-        // shape) so changing T does not recompile.
+        // different cache size is a distinct program). A plain interleaved kv keeps T out of the hash by using
+        // a sentinel shape, so changing only T does not recompile.
         (t.kv.memory_config().is_sharded() || attrs.has_block_cyclic()) ? t.kv.logical_shape() : tt::tt_metal::Shape{},
         // Only whether kv is indexed (not which slot): cache_batch_idx's VALUE is a dynamic runtime arg
         // (see get_dynamic_runtime_args), so indexing into a different slot reuses the same program.
@@ -234,8 +246,7 @@ std::vector<tt::tt_metal::DynamicRuntimeArg> SparseSDPAOperation::get_dynamic_ru
     // interleaved kv), so the same program is reused across slots/T — create_descriptor bakes it at build time
     // and on a program-cache HIT it would be STALE, so re-apply it from the current slot/T every dispatch. The
     // Block-cyclic remap configuration is compile-time, so only indexed programs need dynamic patching.
-    const bool indexed = attrs.has_indexed_kv_cache();
-    if (!indexed) {
+    if (!attrs.has_indexed_kv_cache()) {
         return {};
     }
     const uint32_t T = t.kv.logical_shape()[2];

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.cpp
@@ -44,8 +44,8 @@ void validate_non_hashed(const SparseSDPAParams& attrs, const SparseSDPAInputs& 
     const auto kvs = kv.logical_shape();
     // kv is [B,1,T,K_DIM]: B == 1 normally; when indexed (cache_batch_idx set) B is the cache's batch slots
     // and cache_batch_idx selects one. q is always batch-1, so the selected slot serves the whole query.
-    const uint32_t packed_kv_width = ::sparse_sdpa::packed_kv_width(K_DIM, attrs.v_dim);
-    const uint32_t expected_kv_width = t.has_scaled_kv() ? packed_kv_width : K_DIM;
+    const uint32_t expected_kv_width =
+        attrs.has_scaled_kv() ? ::sparse_sdpa::packed_kv_payload_bytes(K_DIM, attrs.v_dim) : K_DIM;
     TT_FATAL(
         kvs.rank() == 4 && kvs[1] == 1 && kvs[3] == expected_kv_width,
         "kv must be [B,1,T,{}] (got {})",
@@ -83,12 +83,27 @@ void SparseSDPAOperation::validate_on_program_cache_miss(const SparseSDPAParams&
     const bool q_is_fp8 = (q.dtype() == DataType::FP8_E4M3);
     TT_FATAL(q.dtype() == DataType::BFLOAT16 || q_is_fp8, "q must be bf16 or fp8_e4m3");
     TT_FATAL(kv.dtype() == DataType::BFLOAT16 || kv_is_fp8, "kv must be bf16 or fp8_e4m3");
-    if (t.has_scaled_kv()) {
-        TT_FATAL(kv_is_fp8, "packed scaled KV must use fp8_e4m3 byte storage");
+    switch (attrs.kv_format) {
+        case transformer::SparseKVFormat::BF16:
+            TT_FATAL(kv.dtype() == DataType::BFLOAT16, "BF16 sparse KV format requires bfloat16 storage");
+            break;
+        case transformer::SparseKVFormat::FP8_E4M3:
+            TT_FATAL(kv_is_fp8, "FP8_E4M3 sparse KV format requires fp8_e4m3 storage");
+            break;
+        case transformer::SparseKVFormat::SCALED_FP8:
+            TT_FATAL(kv_is_fp8, "SCALED_FP8 sparse KV format requires fp8_e4m3 byte storage");
+            break;
+    }
+    if (attrs.has_scaled_kv()) {
         TT_FATAL(
             attrs.v_dim % ::sparse_sdpa::SCALE_BLOCK_WIDTH == 0,
             "scaled KV v_dim must be divisible by {}",
             ::sparse_sdpa::SCALE_BLOCK_WIDTH);
+        TT_FATAL(
+            ::sparse_sdpa::scaled_kv_rope_offset_is_aligned(attrs.v_dim),
+            "scaled KV scale/RoPE boundary must be {}-byte aligned (got v_dim={})",
+            ::sparse_sdpa::PACKED_FIELD_ADDRESS_UNIT_BYTES,
+            attrs.v_dim);
     }
     TT_FATAL(idx.dtype() == DataType::UINT32, "indices must be uint32");
 
@@ -159,7 +174,7 @@ void SparseSDPAOperation::validate_on_program_cache_miss(const SparseSDPAParams&
     // matches q (compute_output_specs), so its row width uses q's element size.
     const uint32_t dram_align = tt::tt_metal::hal::get_dram_alignment();
     TT_FATAL((K_DIM * q.element_size()) % dram_align == 0, "Q row bytes must be {}B aligned", dram_align);
-    if (!t.has_scaled_kv()) {
+    if (!attrs.has_scaled_kv()) {
         TT_FATAL(
             (kv.logical_shape()[3] * kv.element_size()) % dram_align == 0,
             "K row bytes must be {}B aligned",
@@ -197,8 +212,9 @@ SparseSDPAOperation::tensor_return_value_t SparseSDPAOperation::create_output_te
 }
 
 ttsl::hash::hash_t SparseSDPAOperation::compute_program_hash(const SparseSDPAParams& attrs, const SparseSDPAInputs& t) {
-    // dtypes + compute_kernel_config MUST be in the hash: q/kv may be bf16 or fp8_e4m3 (different CB
-    // formats, row byte widths, fp32-dest/unpack modes, and output dtype), and fp32_dest_acc_en changes
+    // kv_format + dtypes + compute_kernel_config MUST be in the hash: q/kv may be bf16 or fp8_e4m3 (different CB
+    // formats, row byte widths, fp32-dest/unpack modes, and output dtype), scaled FP8 changes row interpretation,
+    // and fp32_dest_acc_en changes
     // the program. Same-shape-different-dtype (or -config) calls otherwise alias to one program and the
     // second silently reuses the first's kernel (wrong results).
     //
@@ -211,12 +227,12 @@ ttsl::hash::hash_t SparseSDPAOperation::compute_program_hash(const SparseSDPAPar
     return tt::tt_metal::operation::hash_operation<SparseSDPAOperation>(
         std::bit_cast<uint32_t>(attrs.scale),
         attrs.v_dim,
+        attrs.kv_format,
         attrs.k_chunk_size,
         attrs.compute_kernel_config,
         t.q.logical_shape(),
         t.q.dtype(),
         t.kv.dtype(),
-        t.has_scaled_kv(),
         // kv.memory_config(): an ND-sharded kv produces different TensorAccessor compile-time args than an
         // interleaved one, so they must be distinct programs.
         t.kv.memory_config(),
@@ -282,6 +298,7 @@ Tensor sparse_sdpa(
     const Tensor& indices,
     float scale,
     uint32_t v_dim,
+    transformer::SparseKVFormat kv_format,
     uint32_t k_chunk_size,
     ttnn::DeviceComputeKernelConfig compute_kernel_config,
     std::optional<uint32_t> cache_batch_idx,
@@ -291,6 +308,7 @@ Tensor sparse_sdpa(
         OperationType::operation_attributes_t{
             .scale = scale,
             .v_dim = v_dim,
+            .kv_format = kv_format,
             .k_chunk_size = k_chunk_size,
             .compute_kernel_config = compute_kernel_config,
             .cache_batch_idx = cache_batch_idx,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.hpp
@@ -67,6 +67,7 @@ Tensor sparse_sdpa(
     const Tensor& indices,
     float scale,
     uint32_t v_dim,
+    transformer::SparseKVFormat kv_format,
     uint32_t k_chunk_size,
     ttnn::DeviceComputeKernelConfig compute_kernel_config,
     std::optional<uint32_t> cache_batch_idx = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation_types.hpp
@@ -31,6 +31,10 @@ struct SparseSDPAInputs {
     Tensor q;   // [1, H, S, K_DIM] bf16/fp8_e4m3 ROW_MAJOR  (K_DIM = head dim, e.g. 576)
     Tensor kv;  // [1, 1, T, K_DIM] bf16/fp8_e4m3 ROW_MAJOR  (or [B,1,T,K_DIM] when indexed; may be ND-sharded DRAM)
     Tensor indices;  // [1, 1, S, TOPK] uint32 ROW_MAJOR  (0xFFFFFFFF = masked)
+
+    bool has_scaled_kv() const {
+        return kv.dtype() == tt::tt_metal::DataType::FP8_E4M3 && kv.logical_shape()[-1] > q.logical_shape()[-1];
+    }
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation_types.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "ttnn/operations/transformer/sdpa/sparse_sdpa.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "block_cyclic_layout.hpp"  // ttnn::prim::BlockCyclicLayout (shared)
@@ -15,6 +16,7 @@ namespace ttnn::prim {
 struct SparseSDPAParams {
     float scale = 1.0f;  // compile-time (folded into the program hash)
     uint32_t v_dim;      // width of V (= leading v_dim cols of the K_DIM-wide KV cache); the output width
+    transformer::SparseKVFormat kv_format;
     uint32_t k_chunk_size = 128;
     DeviceComputeKernelConfig compute_kernel_config;
     // Indexed KV cache: when set, kv is a [B,1,T,K_DIM] shared cache and this selects the batch slot to
@@ -25,16 +27,13 @@ struct SparseSDPAParams {
     // The remap configuration is compile-time; T is part of the program hash for this path.
     std::optional<BlockCyclicLayout> block_cyclic = std::nullopt;
     bool has_block_cyclic() const { return block_cyclic.has_value(); }
+    bool has_scaled_kv() const { return kv_format == transformer::SparseKVFormat::SCALED_FP8; }
 };
 
 struct SparseSDPAInputs {
-    Tensor q;   // [1, H, S, K_DIM] bf16/fp8_e4m3 ROW_MAJOR  (K_DIM = head dim, e.g. 576)
-    Tensor kv;  // [1, 1, T, K_DIM] bf16/fp8_e4m3 ROW_MAJOR  (or [B,1,T,K_DIM] when indexed; may be ND-sharded DRAM)
+    Tensor q;        // [1, H, S, K_DIM] bf16/fp8_e4m3 ROW_MAJOR  (K_DIM = head dim, e.g. 576)
+    Tensor kv;       // Plain [B,1,T,K_DIM] or packed scaled-FP8 rows; format is explicit in SparseSDPAParams
     Tensor indices;  // [1, 1, S, TOPK] uint32 ROW_MAJOR  (0xFFFFFFFF = masked)
-
-    bool has_scaled_kv() const {
-        return kv.dtype() == tt::tt_metal::DataType::FP8_E4M3 && kv.logical_shape()[-1] > q.logical_shape()[-1];
-    }
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_program_factory.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.hpp"
+#include "ttnn/operations/transformer/sdpa/device/kernels/sparse_sdpa_common.hpp"
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_constants.h>  // NUM_CIRCULAR_BUFFERS
 #include <tt-metalium/constants.hpp>
@@ -11,7 +12,6 @@
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <array>
 #include <bit>
-#include <map>
 #include <string>
 
 namespace ttnn::prim {
@@ -22,7 +22,7 @@ enum SparseCB : uint32_t {
     cb_q_rm = 0,   // Q rows (row-major, reader -> compute tilize)
     cb_q_in,       // Q tiled [Sqt, DHt]
     cb_k_rm,       // K chunk rows (row-major)
-    cb_k_in,       // K tiled [Skt, DHt] (read directly by QK via within-tile transpose and by PV)
+    cb_k_in,       // K tiled [Skt,DHt], or scaled-cache latent [Skt,vDHt] in BFP8
     cb_neginf,     // all-(-inf) tile (writer-built once): bcast-added to fully-masked key tiles
     cb_mask_part,  // per-token partial-boundary mask tile (row 0: -inf for cols >= valid%32)
     cb_scale,      // reduce identity scaler (1 tile)
@@ -40,8 +40,12 @@ enum SparseCB : uint32_t {
     cb_ctrl,           // reader -> compute: [active chunk count (=ceil(valid_keys/k_chunk)), valid_keys] per token
     cb_col_identity,   // ones-in-col0 (writer-built): finalizes the partial row-sum via matmul_reduce
     cb_recip_scratch,  // 1-tile reciprocal scratch for normalize_row_streaming
-    cb_kreq,           // reader->writer K-gather handoff {base, half, is_last} (dual-NoC split)
+    cb_kreq,           // reader->writer K-gather handoff (dual-NoC split)
     cb_kack,           // writer->reader ack that its half of the chunk landed in cb_k_rm
+    cb_k_rope_rm,      // scaled FP8 only: format-only BF16 view of one packed row slab
+    cb_k_scale_bcast,  // scaled FP8 only: one FP32 per-row broadcast tile per scale block
+    cb_k_latent_tile,  // scaled FP8 only: one TILE_HEIGHT-row BFP8 latent slab
+    cb_k_rope_tile,    // scaled FP8 only: one K chunk's BF16 RoPE tiles
     cb_count
 };
 
@@ -63,24 +67,31 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
     const uint32_t scale_packed = std::bit_cast<uint32_t>(attrs.scale);
 
     // Element sizes come from the tensors (no hardcoded byte counts); passed to the kernels as compile args.
-    const uint32_t q_elem_bytes = t.q.element_size();          // bf16 -> 2
-    const uint32_t kv_elem_bytes = t.kv.element_size();        // bf16 -> 2, fp8_e4m3 -> 1
+    const uint32_t q_elem_bytes = t.q.element_size();
+    const bool scaled_kv = t.has_scaled_kv();
+    const uint32_t kv_elem_bytes = t.kv.element_size();
     const uint32_t idx_elem_bytes = t.indices.element_size();  // uint32 -> 4
-    const uint32_t out_elem_bytes = output.element_size();     // bf16 -> 2
-    const uint32_t q_row_bytes = k_dim * q_elem_bytes;         // 1152
-    const uint32_t k_row_bytes = k_dim * kv_elem_bytes;        // 1152 (bf16) or 576 (fp8)
+    const uint32_t out_elem_bytes = output.element_size();
+    const uint32_t q_row_bytes = k_dim * q_elem_bytes;
+    const uint32_t k_row_bytes = k_dim * kv_elem_bytes;
+    const uint32_t packed_page_bytes = scaled_kv ? t.kv.buffer()->aligned_page_size() : 0;
+    const uint32_t scale_blocks = ::sparse_sdpa::scale_block_count(v_dim);
     constexpr tt::DataFormat bf = tt::DataFormat::Float16_b;
+    constexpr tt::DataFormat fp32 = tt::DataFormat::Float32;
     constexpr uint32_t tile_bytes = tt::tile_size(bf);  // 2048
+    constexpr uint32_t fp32_tile_bytes = tt::tile_size(fp32);
     // cb_k_rm holds the row-major K in its native dtype (fp8 or bf16); compute tilizes it into cb_k_in.
     // For fp8 K, cb_k_in is bfp8_b (fp8->bfp8 is near-lossless): it halves cb_k_in's L1 footprint vs bf16
     // and both matmuls read it directly (the HW within-face transpose works on block-float). The compute
     // kernel restores the bf16 unpack srcA / pack formats after each per-chunk K tilize (see comments there).
-    const tt::DataFormat k_rm_df = tt::tt_metal::datatype_to_dataformat_converter(t.kv.dtype());
-    const bool kv_is_fp8 = (k_rm_df == tt::DataFormat::Fp8_e4m3);
+    const tt::DataFormat native_kv_df = tt::tt_metal::datatype_to_dataformat_converter(t.kv.dtype());
+    const bool kv_storage_is_fp8 = native_kv_df == tt::DataFormat::Fp8_e4m3;
+    const bool plain_kv_is_fp8 = !scaled_kv && kv_storage_is_fp8;
     // When K arrives as fp8, tilize it into bfp8_b cb_k_in (fp8->bfp8 is near-lossless, PCC 0.99998) to
     // halve cb_k_in's L1 footprint and cheapen both matmuls. bf16 K keeps bf16 cb_k_in (no precision loss).
-    const tt::DataFormat k_in_df = kv_is_fp8 ? tt::DataFormat::Bfp8_b : bf;
+    const tt::DataFormat k_in_df = (scaled_kv || plain_kv_is_fp8) ? tt::DataFormat::Bfp8_b : bf;
     const uint32_t k_in_tile_bytes = tt::tile_size(k_in_df);
+    const uint32_t k_in_width_tiles = scaled_kv ? vDHt : DHt;
     // Q is handled symmetrically: fp8 Q -> bfp8_b cb_q_in (halves cb_q_in L1, which scales with H), bf16
     // Q -> bf16 cb_q_in. Q is read row-major in its native dtype (cb_q_rm) and tilized into cb_q_in.
     const tt::DataFormat q_rm_df = tt::tt_metal::datatype_to_dataformat_converter(t.q.dtype());
@@ -100,39 +111,64 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
     const uint32_t base = S / num_cores;
     const uint32_t extra = S % num_cores;
 
-    // ---- CBs (fixed order = SparseCB enum) ----
-    const auto cb = [&](uint32_t page_size, uint32_t num_pages, tt::DataFormat df) {
-        const uint32_t idx = desc.cbs.size();
+    // ---- CBs (fixed ids = SparseCB enum; descriptor insertion order is irrelevant) ----
+    const auto cb = [&](uint32_t id, uint32_t page_size, uint32_t num_pages, tt::DataFormat df) {
         desc.cbs.push_back(tt::tt_metal::CBDescriptor{
             .total_size = page_size * num_pages,
             .core_ranges = core_grid,
             .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(idx), .data_format = df, .page_size = page_size}}},
+                .buffer_index = static_cast<uint8_t>(id), .data_format = df, .page_size = page_size}}},
         });
     };
-    cb(q_row_bytes, H, q_rm_df);              // cb_q_rm : H row-sticks (native Q dtype: fp8 or bf16)
-    cb(q_in_tile_bytes, Sqt * DHt, q_in_df);  // cb_q_in : [Sqt,DHt] (bfp8 when Q is fp8)
-    cb(k_row_bytes, k_chunk, k_rm_df);        // cb_k_rm : k_chunk row-sticks (native K dtype: fp8 or bf16)
-    cb(k_in_tile_bytes, Skt * DHt, k_in_df);  // cb_k_in : [Skt,DHt] (consumed by both QK and PV; no Kᵀ/V copies)
-    cb(tile_bytes, 1, bf);                    // cb_neginf : all-(-inf) tile (persistent)
-    cb(tile_bytes, 1, bf);                    // cb_mask_part : per-token partial-boundary mask tile
-    cb(tile_bytes, 1, bf);                    // cb_scale
-    cb(tile_bytes, Sqt * Skt, bf);            // cb_qk_im : [Sqt,Skt]
-    cb(tile_bytes, Sqt, bf);                  // cb_max_a
-    cb(tile_bytes, Sqt, bf);                  // cb_max_b
-    cb(tile_bytes, Sqt, bf);                  // cb_sum_a
-    cb(tile_bytes, Sqt, bf);                  // cb_sum_b
-    cb(tile_bytes, Sqt * vDHt, bf);           // cb_out_a : [Sqt,vDHt] (single-buffered for L1 acc)
-    cb(tile_bytes, Sqt * vDHt, bf);           // cb_out_b
-    cb(tile_bytes, Sqt, bf);                  // cb_corr : [Sqt,1]
-    cb(tile_bytes, Sqt * vDHt, bf);           // cb_out_im : [Sqt,vDHt] bf16 accumulator (pre-untilize, full precision)
-    cb(out_tile_bytes, Sqt * vDHt, out_df);   // cb_out_rm : untilized [H,V_DIM] in output dtype (fp8 or bf16)
-    cb(topk * idx_elem_bytes, 1, bf);         // cb_idx : one index row (uint32 bytes)
-    cb(16, 2, bf);                            // cb_ctrl : n_active per token (uint32; 16B aligned, double-buffered)
-    cb(tile_bytes, 1, bf);                    // cb_col_identity : ones-in-col0 (writer-built)
-    cb(tile_bytes, 1, bf);                    // cb_recip_scratch : 1-tile reciprocal scratch
-    cb(16, 2, bf);                            // cb_kreq : reader->writer K-gather handoff (dual-NoC split)
-    cb(16, 2, bf);                            // cb_kack : writer->reader gather ack
+    cb(cb_q_rm, q_row_bytes, H, q_rm_df);              // cb_q_rm : H row-sticks (native Q dtype: fp8 or bf16)
+    cb(cb_q_in, q_in_tile_bytes, Sqt * DHt, q_in_df);  // cb_q_in : [Sqt,DHt] (bfp8 when Q is fp8)
+    if (scaled_kv) {
+        // One double-buffered allocation with an owning FP8 FIFO and a format-only BF16 RoPE alias. Both use
+        // the physical packed-page stride. Only cb_k_rm advances FIFO state; compute derives the alias read
+        // pointer from the owner before reading RoPE. This lets the reader gather slab N+1 while compute
+        // reconstructs slab N without independent alias pointers drifting at the ring wrap.
+        desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+            .total_size = packed_page_bytes * tt::constants::TILE_HEIGHT * ::sparse_sdpa::CB_DOUBLE_BUFFER_DEPTH,
+            .core_ranges = core_grid,
+            .format_descriptors = {{
+                tt::tt_metal::CBFormatDescriptor{
+                    .buffer_index = static_cast<uint8_t>(cb_k_rm),
+                    .data_format = native_kv_df,
+                    .page_size = packed_page_bytes},
+                tt::tt_metal::CBFormatDescriptor{
+                    .buffer_index = static_cast<uint8_t>(cb_k_rope_rm),
+                    .data_format = bf,
+                    .page_size = packed_page_bytes},
+            }},
+        });
+    } else {
+        cb(cb_k_rm, k_row_bytes, k_chunk, native_kv_df);
+    }
+    cb(cb_k_in, k_in_tile_bytes, Skt * k_in_width_tiles, k_in_df);
+    cb(cb_neginf, tile_bytes, 1, bf);
+    cb(cb_mask_part, tile_bytes, 1, bf);
+    cb(cb_scale, tile_bytes, 1, bf);
+    cb(cb_qk_im, tile_bytes, Sqt * Skt, bf);
+    cb(cb_max_a, tile_bytes, Sqt, bf);
+    cb(cb_max_b, tile_bytes, Sqt, bf);
+    cb(cb_sum_a, tile_bytes, Sqt, bf);
+    cb(cb_sum_b, tile_bytes, Sqt, bf);
+    cb(cb_out_a, tile_bytes, Sqt * vDHt, bf);
+    cb(cb_out_b, tile_bytes, Sqt * vDHt, bf);
+    cb(cb_corr, tile_bytes, Sqt, bf);
+    cb(cb_out_im, tile_bytes, Sqt * vDHt, bf);
+    cb(cb_out_rm, out_tile_bytes, Sqt * vDHt, out_df);
+    cb(cb_idx, topk * idx_elem_bytes, 1, bf);
+    cb(cb_ctrl, ::sparse_sdpa::control_message::PAGE_BYTES, ::sparse_sdpa::CB_DOUBLE_BUFFER_DEPTH, bf);
+    cb(cb_col_identity, tile_bytes, 1, bf);
+    cb(cb_recip_scratch, tile_bytes, 1, bf);
+    cb(cb_kreq, ::sparse_sdpa::gather_request::PAGE_BYTES, ::sparse_sdpa::CB_DOUBLE_BUFFER_DEPTH, bf);
+    cb(cb_kack, ::sparse_sdpa::ACK_PAGE_BYTES, ::sparse_sdpa::CB_DOUBLE_BUFFER_DEPTH, bf);
+    if (scaled_kv) {
+        cb(cb_k_scale_bcast, fp32_tile_bytes, scale_blocks * ::sparse_sdpa::CB_DOUBLE_BUFFER_DEPTH, fp32);
+        cb(cb_k_latent_tile, k_in_tile_bytes, vDHt, tt::DataFormat::Bfp8_b);
+        cb(cb_k_rope_tile, tile_bytes, Skt * (DHt - vDHt), bf);
+    }
 
     // ---- compile-time args ----
     // CB ids are passed to each kernel as compile-time args (the SparseCB enum is the single source).
@@ -164,6 +200,12 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
         return args;
     }();
     reader_ct.insert(reader_ct.end(), block_cyclic_ct.begin(), block_cyclic_ct.end());
+    reader_ct.insert(
+        reader_ct.end(),
+        {static_cast<uint32_t>(scaled_kv), v_dim, cb_k_scale_bcast, packed_page_bytes, cb_kreq, cb_kack});
+    TT_FATAL(
+        reader_ct.size() == ::sparse_sdpa::reader_ct_arg::END,
+        "sparse_sdpa reader compile-time argument layout is out of sync");
     // kv (the K cache) uses a RUNTIME tensor shape: its T dimension (the cache length) is passed as common
     // runtime args, NOT compile-time args, so changing T reuses the same program (no recompile). q/indices
     // stay compile-time — their dims define the program. The accessor's runtime metadata is the same on
@@ -173,10 +215,15 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
     tt::tt_metal::TensorAccessorArgs(t.kv.buffer(), tensor_accessor::ArgConfig::RuntimeTensorShape)
         .append_to(reader_ct, reader_crt);
     tt::tt_metal::TensorAccessorArgs(t.indices.buffer()).append_to(reader_ct, reader_crt);
-
     // The writer is the lighter dataflow kernel, so it builds the three persistent compute-input tiles.
     std::vector<uint32_t> writer_ct = {H, S, vDHt, cb_out_rm, cb_scale, cb_col_identity, cb_neginf, out_elem_bytes};
     writer_ct.insert(writer_ct.end(), block_cyclic_ct.begin(), block_cyclic_ct.end());
+    writer_ct.insert(
+        writer_ct.end(),
+        {static_cast<uint32_t>(scaled_kv), k_dim, kv_elem_bytes, cb_k_rm, cb_idx, cb_kreq, cb_kack, packed_page_bytes});
+    TT_FATAL(
+        writer_ct.size() == ::sparse_sdpa::writer_ct_arg::END,
+        "sparse_sdpa writer compile-time argument layout is out of sync");
     std::vector<uint32_t> writer_crt;
     tt::tt_metal::TensorAccessorArgs(output.buffer()).append_to(writer_ct, writer_crt);
     tt::tt_metal::TensorAccessorArgs(t.kv.buffer(), tensor_accessor::ArgConfig::RuntimeTensorShape)
@@ -207,6 +254,9 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
                                         cb_ctrl,
                                         cb_col_identity,
                                         cb_recip_scratch};
+    compute_ct.insert(
+        compute_ct.end(),
+        {static_cast<uint32_t>(scaled_kv), cb_k_rope_rm, cb_k_scale_bcast, cb_k_latent_tile, cb_k_rope_tile});
 
     // ---- kernels ----
     const std::string kdir = "ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/";
@@ -217,11 +267,6 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
     reader_desc.compile_time_args = reader_ct;
     reader_desc.common_runtime_args = reader_crt;  // kv runtime tensor-shape metadata (same on every core)
     reader_desc.config = tt::tt_metal::ReaderConfigDescriptor{};
-    {
-        std::map<std::string, std::string> rdefs{
-            {"CB_KREQ", std::to_string(cb_kreq)}, {"CB_KACK", std::to_string(cb_kack)}};
-        reader_desc.defines = tt::tt_metal::KernelDescriptor::Defines(rdefs.begin(), rdefs.end());
-    }
 
     tt::tt_metal::KernelDescriptor writer_desc;
     writer_desc.kernel_source = kdir + "dataflow/sparse_sdpa_writer.cpp";
@@ -230,16 +275,6 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
     writer_desc.compile_time_args = writer_ct;
     writer_desc.common_runtime_args = writer_crt;  // kv runtime tensor-shape metadata (same on every core)
     writer_desc.config = tt::tt_metal::WriterConfigDescriptor{};
-    {  // writer gathers the other half of K on its NoC (see reader defines)
-        std::map<std::string, std::string> wdefs{
-            {"CB_KREQ", std::to_string(cb_kreq)},
-            {"CB_KACK", std::to_string(cb_kack)},
-            {"CB_K_RM", std::to_string(cb_k_rm)},
-            {"CB_IDX", std::to_string(cb_idx)},
-            {"K_DIM", std::to_string(k_dim)},
-            {"KV_ELEM_BYTES", std::to_string(kv_elem_bytes)}};
-        writer_desc.defines = tt::tt_metal::KernelDescriptor::Defines(wdefs.begin(), wdefs.end());
-    }
 
     // Order matches get_compute_kernel_config_args: (fidelity, approx_mode, fp32_dest_acc, packer_l1_acc,
     // dst_full_sync). packer_l1_acc has no ComputeConfigDescriptor field for this op (no L1 packer accum), so
@@ -260,7 +295,12 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
             break;
         }
     }
+    compute_ct.push_back(static_cast<uint32_t>(math_approx));
     compute_ct.push_back(qsb);
+    compute_ct.push_back(packed_page_bytes);
+    TT_FATAL(
+        compute_ct.size() == ::sparse_sdpa::compute_ct_arg::END,
+        "sparse_sdpa compute compile-time argument layout is out of sync");
 
     tt::tt_metal::KernelDescriptor compute_desc;
     compute_desc.kernel_source = kdir + "compute/sparse_sdpa_compute.cpp";
@@ -270,7 +310,7 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
     // fp8 inputs must unpack into a 32-bit dest (fp8 -> fp32 in DEST, then packed to bfp8 cb_*_in).
     std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
         NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
-    if (kv_is_fp8) {
+    if (kv_storage_is_fp8) {
         unpack_to_dest_mode[cb_k_rm] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
     }
     if (q_is_fp8) {
@@ -282,12 +322,6 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
         .dst_full_sync_en = dst_full_sync,
         .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
         .math_approx_mode = math_approx};
-    // EXP_APPROX_MODE selects the approximate exp LLK in the compute kernel.
-    std::map<std::string, std::string> cdefs{
-        {"EXP_APPROX_MODE", std::to_string(static_cast<int>(math_approx))},
-    };
-    compute_desc.defines = tt::tt_metal::KernelDescriptor::Defines(cdefs.begin(), cdefs.end());
-
     auto* q_buf = t.q.buffer();
     auto* kv_buf = t.kv.buffer();
     auto* idx_buf = t.indices.buffer();
@@ -305,8 +339,7 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
         // on a cache hit by get_dynamic_runtime_args (the slot changes per dispatch). If you reorder the args
         // before it, update those constants or the re-apply targets the wrong slot.
         reader_desc.emplace_runtime_args(core, {q_buf, kv_buf, idx_buf, tok_start, tok_count, kv_batch_page_offset});
-        writer_desc.emplace_runtime_args(
-            core, {out_buf, tok_start, tok_count, kv_buf, kv_batch_page_offset});  // kv_buf: writer K-half gather
+        writer_desc.emplace_runtime_args(core, {out_buf, tok_start, tok_count, kv_buf, kv_batch_page_offset});
         compute_desc.emplace_runtime_args(core, {tok_start, tok_count});
     }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_program_factory.cpp
@@ -68,7 +68,7 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
 
     // Element sizes come from the tensors (no hardcoded byte counts); passed to the kernels as compile args.
     const uint32_t q_elem_bytes = t.q.element_size();
-    const bool scaled_kv = t.has_scaled_kv();
+    const bool scaled_kv = attrs.has_scaled_kv();
     const uint32_t kv_elem_bytes = t.kv.element_size();
     const uint32_t idx_elem_bytes = t.indices.element_size();  // uint32 -> 4
     const uint32_t out_elem_bytes = output.element_size();
@@ -220,7 +220,7 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
     writer_ct.insert(writer_ct.end(), block_cyclic_ct.begin(), block_cyclic_ct.end());
     writer_ct.insert(
         writer_ct.end(),
-        {static_cast<uint32_t>(scaled_kv), k_dim, kv_elem_bytes, cb_k_rm, cb_idx, cb_kreq, cb_kack, packed_page_bytes});
+        {static_cast<uint32_t>(scaled_kv), k_dim, kv_elem_bytes, cb_idx, cb_kreq, cb_kack, packed_page_bytes});
     TT_FATAL(
         writer_ct.size() == ::sparse_sdpa::writer_ct_arg::END,
         "sparse_sdpa writer compile-time argument layout is out of sync");

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
@@ -340,8 +340,9 @@ void bind_sdpa(nb::module_& mod) {
 
         Args:
             q (ttnn.Tensor):       [1, H, S, K_DIM] bf16 or fp8_e4m3 (H a multiple of 32)
-            kv (ttnn.Tensor):      [1, 1, T, K_DIM] bf16 or fp8_e4m3 (fp8 halves the K-gather bytes; tilized to bfp8_b in-op).
-                                   When cache_batch_idx is set, [B, 1, T, K_DIM] and may be ND-sharded across DRAM banks.
+            kv (ttnn.Tensor):      [1, 1, T, K_DIM] bf16/raw fp8, or one packed scaled-FP8 row per token.
+                                   The packed DSA row is [512 FP8 | 4 FP32 scales | 64 BF16 RoPE] = 656 bytes.
+                                   When cache_batch_idx is set, B may exceed 1 and kv may be ND-sharded.
             indices (ttnn.Tensor): [1, 1, S, TOPK] uint32
             v_dim (int):           width of V (leading v_dim cols of the K_DIM-wide cache); the output width.
 
@@ -350,7 +351,8 @@ void bind_sdpa(nb::module_& mod) {
             k_chunk_size (int): defaults to 128 (must divide TOPK, multiple of 32).
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional).
             cache_batch_idx (int, optional): select the batch slot of a shared [B, 1, T, K_DIM] kv cache.
-                It is a dynamic runtime arg, so changing it (or T) does not recompile the kernels.
+                It is a dynamic runtime arg, so changing the slot does not recompile. Changing T also reuses the
+                program for a plain interleaved cache, but recompiles for sharded or block-cyclic caches.
             block_cyclic_sp_axis (int, optional): when set (with block_cyclic_chunk_local), `indices` are NATURAL
                 token positions and kv is stored block-cyclic across an SP-sharded cache; the kernel remaps each
                 index natural->physical page on the fly (no host reorder needed). This is the MESH axis the cache
@@ -359,7 +361,6 @@ void bind_sdpa(nb::module_& mod) {
             block_cyclic_chunk_local (int, optional): the per-shard chunk length (chunk_size_global / sp).
                 Required iff block_cyclic_sp_axis is set. Cross-checked against q's per-chip seq length: must be
                 q_isl or tp*q_isl (tp = mesh_size/sp) — the only two values it can legally take.
-
         Returns:
             ttnn.Tensor: [1, H, S, v_dim] ROW-MAJOR, DRAM interleaved; dtype matches q (bf16->bf16, fp8->fp8).
         )doc",

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
@@ -283,6 +283,11 @@ ttnn::Tensor chunked_scaled_dot_product_attention_wrapper(
 }  // namespace
 
 void bind_sdpa(nb::module_& mod) {
+    nb::enum_<ttnn::transformer::SparseKVFormat>(mod, "SparseKVFormat")
+        .value("BF16", ttnn::transformer::SparseKVFormat::BF16)
+        .value("FP8_E4M3", ttnn::transformer::SparseKVFormat::FP8_E4M3)
+        .value("SCALED_FP8", ttnn::transformer::SparseKVFormat::SCALED_FP8);
+
     const auto* const doc =
         R"doc(
         Causal scaled dot product attention. This API mimics the PyTorch API of the same name.
@@ -340,13 +345,15 @@ void bind_sdpa(nb::module_& mod) {
 
         Args:
             q (ttnn.Tensor):       [1, H, S, K_DIM] bf16 or fp8_e4m3 (H a multiple of 32)
-            kv (ttnn.Tensor):      [1, 1, T, K_DIM] bf16/raw fp8, or one packed scaled-FP8 row per token.
+            kv (ttnn.Tensor):      [1, 1, T, K_DIM] bf16/raw fp8, or one packed scaled-FP8 row per token;
+                                   interpretation is selected only by `kv_format`, never inferred from width.
                                    The packed DSA row is [512 FP8 | 4 FP32 scales | 64 BF16 RoPE] = 656 bytes.
                                    When cache_batch_idx is set, B may exceed 1 and kv may be ND-sharded.
             indices (ttnn.Tensor): [1, 1, S, TOPK] uint32
             v_dim (int):           width of V (leading v_dim cols of the K_DIM-wide cache); the output width.
 
         Keyword args:
+            kv_format (SparseKVFormat): explicit physical/logical format of `kv`.
             scale (float, optional): defaults to K_DIM**-0.5.
             k_chunk_size (int): defaults to 128 (must divide TOPK, multiple of 32).
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional).
@@ -370,6 +377,7 @@ void bind_sdpa(nb::module_& mod) {
         nb::arg("indices").noconvert(),
         nb::arg("v_dim"),
         nb::kw_only(),
+        nb::arg("kv_format"),
         nb::arg("scale") = nb::none(),
         nb::arg("k_chunk_size") = 128,
         nb::arg("compute_kernel_config") = nb::none(),

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa.cpp
@@ -15,6 +15,7 @@ ttnn::Tensor sparse_sdpa(
     const ttnn::Tensor& kv,
     const ttnn::Tensor& indices,
     uint32_t v_dim,
+    SparseKVFormat kv_format,
     std::optional<float> scale,
     uint32_t k_chunk_size,
     std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config,
@@ -65,7 +66,7 @@ ttnn::Tensor sparse_sdpa(
         /*default_l1_acc=*/false);
 
     return ttnn::prim::sparse_sdpa(
-        q, kv, indices, resolved_scale, v_dim, k_chunk_size, kernel_config, cache_batch_idx, block_cyclic);
+        q, kv, indices, resolved_scale, v_dim, kv_format, k_chunk_size, kernel_config, cache_batch_idx, block_cyclic);
 }
 
 }  // namespace ttnn::transformer

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa.hpp
@@ -37,6 +37,11 @@ namespace ttnn::transformer {
 //
 // Producer preconditions (NOT validated per-element): sentinels are a contiguous tail, every row has >= 1
 // valid key, and all non-sentinel indices are < T.
+//
+// Scaled FP8 cache: pass one byte-addressed fp8_e4m3 tensor with each token row packed as
+// [v_dim FP8 latent bytes | v_dim/128 FP32 scales | K_DIM-v_dim BF16 RoPE values]. For the DSA 512+64
+// geometry this is 656 logical bytes. Sparse gather writes each selected packed row once into a shared L1
+// allocation; compute reads aliased FP8-latent and BF16-RoPE views and applies the scales while tilizing.
 ttnn::Tensor sparse_sdpa(
     const ttnn::Tensor& q,
     const ttnn::Tensor& kv,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa.hpp
@@ -6,17 +6,26 @@
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include <cstdint>
 #include <optional>
 
 namespace ttnn::transformer {
+
+enum class SparseKVFormat : uint8_t {
+    BF16,
+    FP8_E4M3,
+    SCALED_FP8,
+};
 
 // Sparse MLA prefill (DeepSeek DSA), Blackhole single-chip.
 //   q       [1, H, S, K_DIM] bf16 or fp8_e4m3 ROW_MAJOR  (H = head count, any multiple of 32; K_DIM = head
 //                                                          dim, e.g. 576)
 //   kv      [1, 1, T, K_DIM] bf16 or fp8_e4m3 ROW_MAJOR  (K = full K_DIM, V = kv[..., :v_dim]; fp8 halves
-//                                                          the K-gather bytes, tilized in-op to bfp8_b)
+//                                                          the K-gather bytes, tilized in-op to bfp8_b), or a
+//           packed scaled-FP8 row described below
 //   indices [1, 1, S, TOPK] uint32 ROW_MAJOR (0xFFFFFFFF = masked; sentinels are a contiguous tail)
 //   v_dim   width of V (leading v_dim cols of the K_DIM-wide cache); the output width.
+//   kv_format explicitly identifies the KV representation and must agree with its dtype and logical width.
 // Returns out [1, H, S, v_dim] ROW_MAJOR; the output dtype MATCHES q (bf16 q -> bf16 out, fp8 q -> fp8 out).
 // (K_DIM is taken from q/kv; scale defaults to K_DIM**-0.5.)
 //
@@ -38,15 +47,16 @@ namespace ttnn::transformer {
 // Producer preconditions (NOT validated per-element): sentinels are a contiguous tail, every row has >= 1
 // valid key, and all non-sentinel indices are < T.
 //
-// Scaled FP8 cache: pass one byte-addressed fp8_e4m3 tensor with each token row packed as
-// [v_dim FP8 latent bytes | v_dim/128 FP32 scales | K_DIM-v_dim BF16 RoPE values]. For the DSA 512+64
-// geometry this is 656 logical bytes. Sparse gather writes each selected packed row once into a shared L1
-// allocation; compute reads aliased FP8-latent and BF16-RoPE views and applies the scales while tilizing.
+// Scaled FP8 cache: pass SparseKVFormat::SCALED_FP8 and one byte-addressed fp8_e4m3 tensor with each token row packed
+// as [v_dim FP8 latent bytes | v_dim/128 FP32 scales | K_DIM-v_dim BF16 RoPE values]. For the DSA 512+64 geometry this
+// is 656 logical bytes. Sparse gather writes each selected packed row once into a shared L1 allocation; compute reads
+// aliased FP8-latent and BF16-RoPE views and applies the scales while tilizing.
 ttnn::Tensor sparse_sdpa(
     const ttnn::Tensor& q,
     const ttnn::Tensor& kv,
     const ttnn::Tensor& indices,
     uint32_t v_dim,
+    SparseKVFormat kv_format,
     std::optional<float> scale = std::nullopt,
     uint32_t k_chunk_size = 128,
     std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -16,7 +16,6 @@ from loguru import logger
 
 import ttnn._ttnn
 
-
 Config = ttnn._ttnn.core.Config
 CONFIG = ttnn._ttnn.CONFIG
 CONFIG_PATH = None
@@ -560,7 +559,9 @@ experimental.disaggregation = disaggregation
 
 Conv1dConfig = ttnn._ttnn.operations.conv.Conv2dConfig
 
-from ttnn.operations.transformer import SDPAProgramConfig
+from ttnn.operations.transformer import SDPAProgramConfig, SparseKVFormat
+
+transformer.SparseKVFormat = SparseKVFormat
 
 IndexerScoreProgramConfig = ttnn._ttnn.operations.experimental.IndexerScoreProgramConfig
 

--- a/ttnn/ttnn/operations/transformer.py
+++ b/ttnn/ttnn/operations/transformer.py
@@ -7,6 +7,7 @@ from typing import Optional
 import ttnn
 
 SDPAProgramConfig = ttnn._ttnn.operations.transformer.SDPAProgramConfig
+SparseKVFormat = ttnn._ttnn.operations.transformer.SparseKVFormat
 
 
 def _golden_function(


### PR DESCRIPTION
## Summary

This PR adds a compact persistent KV-cache format for sparse MLA in DeepSeek V3.2 and GLM-5.1. Although an `fp8_e4m3` tensor provides byte-addressable storage, this is not a plain FP8 cache: every token row contains a 512-value E4M3 latent, four FP32 scales, and a 64-value BF16 RoPE segment. BF16 remains supported, while GLM-5.1 selects the packed format by default.

The implementation covers the complete cache lifetime: device-side quantization and packing, padded and block-cyclic cache updates, prefix all-gather, sparse-SDPA consumption, migration-table sizing, host reconstruction, and cache/output correctness coverage. Sparse SDPA also supports multi-row query sub-blocking for this format by retaining the full 576-element Q-row stride across the latent and RoPE partial products.

## Cache format

Each packed row represents the normal 576-element MLA KV state as:

| Region | Encoding | Shape per token | Bytes |
| --- | --- | ---: | ---: |
| Latent | E4M3 | 512 | 512 |
| Scales | FP32, one scale per 128 latent values | 4 | 16 |
| RoPE | BF16 | 64 | 128 |
| **Total** | Mixed-format row | | **656** |

The four latent scales are computed per token and rounded upward to powers of two. RoPE stays in BF16 rather than being quantized.

The packed tensor is explicitly wrapped in `SparseKVCache` so callers select the semantic format directly; consumers do not infer this mixed layout from the tensor dtype.

## Memory impact

The existing BF16 cache stores 576 BF16 values, or 1,152 logical bytes per token. The packed row uses 656 logical bytes, a **43.1% payload reduction**.

Blackhole DRAM pages are 64-byte aligned, so the physical comparison is:

| Format | Logical bytes/token | Physical bytes/token |
| --- | ---: | ---: |
| BF16 | 1,152 | 1,152 |
| Packed mixed format | 656 | 704 |

This reduces physical KV-cache allocation and migration traffic by **38.9%**, allowing approximately **1.64x more KV-cache capacity** for the same DRAM budget. Migration tables use the aligned page size rather than assuming the 656-byte logical width.

## Data path

MLA quantizes only the 512-wide latent, packs it with four FP32 scales and the 64-wide BF16 RoPE segment, and writes one persistent row-major tensor. Sparse SDPA gathers each selected packed row once, expands the four scales, reconstructs the latent contribution, and adds the unscaled BF16 RoPE contribution. There is no full-cache BF16 unpack or duplicate persistent cache.

## Performance impact

Matched warm measurements were taken on an 8-chip Blackhole LoudBox using SP=2 x TP=4 and FABRIC_2D. The proxy processes a 1,280-token chunk at a 12,800-token cache prefix; values below are device-collapsed critical-path kernel time.

| Variant | Metric | BF16 | Packed | Improvement |
| --- | --- | ---: | ---: | ---: |
| DeepSeek V3.2 | Sparse SDPA | 4.500 ms | 3.233 ms | **28.2% / 1.39x** |
| DeepSeek V3.2 | Full sparse MLA | 9.196 ms | 7.882 ms | **14.3% / 1.17x** |
| GLM-5.1 | Sparse SDPA | 1.314 ms | 1.107 ms | **15.7% / 1.19x** |
| GLM-5.1 | Full sparse MLA | 7.828 ms | 7.538 ms | **3.7% / 1.04x** |

GLM's smaller short-prefix gain is not a failure to scale with cache bytes. GLM has half as many MLA heads as DeepSeek, so its sparse-SDPA work is much shorter, while fixed per-step work and collectives remain substantial. In this LoudBox proxy, all-gather alone is about 2.9 ms and sparse SDPA is only 17% of the BF16 end-to-end step; reducing cache traffic therefore cannot move the full-step number much.

A direct GLM production-depth sparse-SDPA check at H=64, S=640, T=56,320, top-k=2,048, and k-chunk=256 measures **3.717 ms BF16 versus 2.757 ms packed: 25.8% faster, or 1.35x**. At that longer prefix, cache traffic dominates enough for the gain to approach the 1.64x physical-byte ratio. It does not reach that theoretical ceiling because scale expansion, the BF16 RoPE contribution, compute, and fixed kernel overhead remain unchanged.\n\nQuery sub-blocking is not the source of that speedup. On the same production GLM geometry and packed cache, a controlled comparison measured **2.749 ms with `qsb=2` versus 2.769 ms with forced `qsb=1`**, a 0.7% difference within the noise-level range. The `qsb=2` work fixes the second 32-head query row and keeps both query tile-rows in one pass; the material performance gain comes from reducing KV-cache traffic.

### Relevant workflows
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=pjosipovic/fp8-sparse-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml?query=branch:pjosipovic/fp8-sparse-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pjosipovic/fp8-sparse-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pjosipovic/fp8-sparse-kv-cache)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/fp8-sparse-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/fp8-sparse-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/fp8-sparse-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/fp8-sparse-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pjosipovic/fp8-sparse-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pjosipovic/fp8-sparse-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fp8-sparse-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fp8-sparse-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/fp8-sparse-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/fp8-sparse-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/fp8-sparse-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/fp8-sparse-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/fp8-sparse-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/fp8-sparse-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/fp8-sparse-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/fp8-sparse-kv-cache)