### PR TITLE
[BugFix] Fix reduce to root reader local

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/root_receive_reader_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/root_receive_reader_kernel.cpp
@@ -282,7 +282,7 @@ void kernel_main() {
     noc_semaphore_set(local_semaphore_ptr, 0);
     tt::tt_fabric::fabric_client_disconnect(*mux_connection_handle2);
 
-    if (is_termination_master) {
+    if (is_termination_master2) {
         auto* termination_sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_address2);
         noc_semaphore_wait(termination_sync_ptr, num_mux_clients - 1);
         tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x2, fabric_mux_y2, fabric_mux_termination_signal_address);

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/root_receive_reader_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/root_receive_reader_kernel.cpp
@@ -193,6 +193,8 @@ void kernel_main() {
 
     uint64_t packet_noc_addr = get_noc_addr(core_noc_x, core_noc_y, intermediate_base_addr);
     noc_async_read(packet_noc_addr, packet_l1_addr, new_packet_size_bytes);
+    // Wait for the packet to arrive before the tt_memmove copies consume packet_l1_addr.
+    noc_async_read_barrier();
 
     // moving l tensor
     tt_memmove<true, false, false, 0>(noc, dest_page_base_addr, packet_l1_addr, packet_size_bytes);
@@ -215,8 +217,6 @@ void kernel_main() {
     cb_push_back(receiver_cb_id_m, 1);
 
     cb_push_back(packet_cb_id, 1);
-
-    noc_async_read_barrier();
 
     // now the similar behaviour when device 2 is sending data to device 1
     // will be waiting on another semaphore, and fabric is for the other 2 muxes
@@ -260,7 +260,7 @@ void kernel_main() {
     mux_connection_handle2 = &mux_connection2;
 
     tt::tt_fabric::wait_for_fabric_endpoint_ready(
-        fabric_mux_x2, fabric_mux_y2, fabric_mux_status_address, local_fabric_mux_status_address);
+        fabric_mux_x2, fabric_mux_y2, fabric_mux_status_address, local_fabric_mux_status_address2);
     tt::tt_fabric::fabric_client_connect(*mux_connection_handle2);
 
     cb_reserve_back(packet_header_cb_id, 1);
@@ -302,6 +302,8 @@ void kernel_main() {
     dest_page_base_addr = get_write_ptr(receiver_cb_id_l);
     packet_noc_addr = get_noc_addr(core_noc_x, core_noc_y, intermediate_base_addr);
     noc_async_read(packet_noc_addr, packet_l1_addr, new_packet_size_bytes);
+    // Wait for the packet to arrive before the tt_memmove copies consume packet_l1_addr.
+    noc_async_read_barrier();
 
     tt_memmove<true, false, false, 0>(noc, dest_page_base_addr, packet_l1_addr, packet_size_bytes);
     cb_push_back(receiver_cb_id_l, input_num_tiles);
@@ -321,6 +323,4 @@ void kernel_main() {
     cb_push_back(receiver_cb_id_s, 1);
     cb_push_back(receiver_cb_id_m, 1);
     cb_push_back(packet_cb_id, 1);
-
-    noc_async_read_barrier();
 }


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary

1. Stale-packet read race. Each phase reads an incoming packet into L1
  with an async read, then immediately copies it out with tt_memmove. The
  barrier that waits for the packet to actually arrive was placed at the
  end of the block — after the copies had already run. So the copies could
  read a not-yet-arrived (partial/stale) packet and publish garbage L/S/M
  data to the compute buffers. Fix: move the barrier to right after the
  packet read, before the copies.
  2. Wrong local status semaphore for the 2nd connection. When
  establishing the second fabric connection, the "wait until the mux is
  ready" call polled the first connection's local status semaphore instead
  of the second's. Since that semaphore had already been used, the second
  connection could read stale state and mishandle its handshake. Fix: use
  the second connection's own status semaphore.

  3. Second mux torn down by the wrong worker. Each connection has a
  designated "termination master" that shuts its mux down. The second
  connection's teardown mistakenly checked the first connection's master
  flag (the correct second flag was read but never used). Because the host
  assigns the two connections different master cores, the wrong worker
  ran the second mux's shutdown while the real master didn't — hanging or
  prematurely terminating the second connection. Fix: check the second
  connection's own termination-master flag.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
