### PR TITLE
ci: extend GPT-OSS low-latency benchmark timeout

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -217,7 +217,7 @@ jobs:
               "name": "[WH-GLX] GPT-OSS-120B (low-latency)",
               "model": "openai/gpt-oss-120b",
               "server-timeout": 35,
-              "benchmark-timeout": 15,
+              "benchmark-timeout": 30,
               "runner-label": "topology-6u",
               "arch": "arch-wormhole_b0",
               "mesh-device": "(4, 8)",


### PR DESCRIPTION
Bumps the `benchmark-timeout` for the `[WH-GLX] GPT-OSS-120B (low-latency)` job in `vllm-nightly-tests-impl.yaml` from 15 to 30 minutes, so the benchmark has enough headroom to complete.

Failing CI before: https://github.com/tenstorrent/tt-metal/actions/runs/28557518844/job/84669453490#step:15:152
Passing CI after: https://github.com/tenstorrent/tt-metal/actions/runs/29578767049

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=viktorpus/extend-gpt-oss-benchmark-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:viktorpus/extend-gpt-oss-benchmark-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=viktorpus/extend-gpt-oss-benchmark-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:viktorpus/extend-gpt-oss-benchmark-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=viktorpus/extend-gpt-oss-benchmark-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:viktorpus/extend-gpt-oss-benchmark-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=viktorpus/extend-gpt-oss-benchmark-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:viktorpus/extend-gpt-oss-benchmark-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=viktorpus/extend-gpt-oss-benchmark-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:viktorpus/extend-gpt-oss-benchmark-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=viktorpus/extend-gpt-oss-benchmark-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:viktorpus/extend-gpt-oss-benchmark-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=viktorpus/extend-gpt-oss-benchmark-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:viktorpus/extend-gpt-oss-benchmark-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=viktorpus/extend-gpt-oss-benchmark-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:viktorpus/extend-gpt-oss-benchmark-timeout)