### PR TITLE
ds_prefill(read_profiler) - plumb TT_PREFILL_READ_PROFILER into chunked prefill tests

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -26,6 +26,7 @@ import gc
 import json
 import os
 import statistics
+import sys
 import time
 from pathlib import Path
 
@@ -53,6 +54,22 @@ SEQ_CACHE = 55 * 1024  # 56320 KV cache length (1 user)
 # Larger KV cache for the no-PCC perf sweep only (up to 100k ISL = 20 chunks). Kept separate from
 # SEQ_CACHE so the PCC tests and the _PADDED_FULL_55K split (which assert against 55*1024) are untouched.
 SEQ_CACHE_NOPCC = 100 * 1024  # 102400 KV cache length (1 user)
+
+# Read the TTNN device profiler after each layer to avoid profiler-buffer overflows during long
+# runs. Off by default (normal runs are unaffected); enable with TT_PREFILL_READ_PROFILER=1. Plumbed
+# into every transformer.forward() in this file.
+READ_PROFILER = os.environ.get("TT_PREFILL_READ_PROFILER", "0") == "1"
+
+# Override logger level (only when reading the profiler)
+if READ_PROFILER:
+    logger.configure(
+        handlers=[
+            {
+                "sink": sys.stderr,
+                "level": "INFO",
+            }
+        ]
+    )
 
 
 def _resolve_trace_dir(variant) -> Path:
@@ -338,6 +355,7 @@ def run_chunked_transformer_padded(
             actual_end=valid_end,
             cache_user_id=0,
             return_intermediates=True,
+            read_profiler=READ_PROFILER,
         )
         ttnn.synchronize_device(mesh_device)
 
@@ -546,6 +564,7 @@ def run_chunked_transformer(
             cache_user_id=0,
             return_intermediates=True,
             index_kv_cache=tt_index_kv_cache,
+            read_profiler=READ_PROFILER,
         )
         ttnn.synchronize_device(mesh_device)
 
@@ -1087,6 +1106,7 @@ def run_chunked_transformer_no_pcc(
             actual_end=CHUNK,
             cache_user_id=0,
             return_intermediates=False,
+            read_profiler=READ_PROFILER,
         )
         ttnn.synchronize_device(mesh_device)
         ttnn.deallocate(warm_tokens)
@@ -1119,6 +1139,7 @@ def run_chunked_transformer_no_pcc(
                 actual_end=kv_actual + CHUNK,
                 cache_user_id=0,
                 return_intermediates=False,
+                read_profiler=READ_PROFILER,
             )
             ttnn.synchronize_device(mesh_device)
             ttnn.deallocate(tt_tokens)
@@ -1217,7 +1238,7 @@ def test_kimi_prefill_transformer_chunked_no_pcc(
 @pytest.mark.parametrize(
     "n_chunks",
     [1, 2, 5, 10, 11, 20],
-    ids=["chunks1", "chunks2", "chunks5", "chunks10", "chunks_eleven", "chunks20"],
+    ids=["chunks1", "chunks2", "chunks5", "chunks_ten", "chunks_eleven", "chunks20"],
 )
 @pytest.mark.parametrize("num_layers", [1, 10, 61], ids=["L1", "L10", "L61"])
 @pytest.mark.parametrize(

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
@@ -409,6 +409,7 @@ class TtPrefillTransformer(LightweightModule):
                 ttnn.synchronize_device(self.mesh_device)
                 intermediates[f"layer_{i}"] = self._to_host(h)
             if read_profiler:
+                logger.warning(f"Reading TTNN profiler after layer {i} to avoid buffer overflow")
                 ttnn.ReadDeviceProfiler(self.mesh_device)
         # GLM-5.2 reuse: free the last full layer's held top-k indices after the final layer.
         if reuse and indexer_indices is not None:


### PR DESCRIPTION
## Summary
- Add a `READ_PROFILER` env-var gate (`TT_PREFILL_READ_PROFILER=1`) to the chunked prefill tests and pass `read_profiler` through every `transformer.forward()` call so the TTNN device profiler is drained per-layer, avoiding profiler-buffer overflows on long runs. Off by default — normal runs are unaffected.
- Raise the loguru handler level to INFO when profiler reading is enabled.
- Log a warning in `TtPrefillTransformer` when the profiler is read after each layer.
- Fix a duplicate parametrize id: `chunks10` -> `chunks_ten`.

## Test plan
- CI workflows not triggered for this PR (per request).

### DeepSeek Prefill CI
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=ds_prefill_read_profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:ds_prefill_read_profiler) Galaxy
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=ds_prefill_read_profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:ds_prefill_read_profiler) T3K
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=ds_prefill_read_profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:ds_prefill_read_profiler) Single Card
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=ds_prefill_read_profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:ds_prefill_read_profiler) Blackhole

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ds_prefill_read_profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ds_prefill_read_profiler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ds_prefill_read_profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ds_prefill_read_profiler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ds_prefill_read_profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ds_prefill_read_profiler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ds_prefill_read_profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ds_prefill_read_profiler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ds_prefill_read_profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ds_prefill_read_profiler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ds_prefill_read_profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ds_prefill_read_profiler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ds_prefill_read_profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ds_prefill_read_profiler)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ds_prefill_read_profiler)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ds_prefill_read_profiler)