### PR TITLE
[skip ci] [Qwen3-32B Galaxy] Disable force-argmax sampling on Wormhole

### DIFF
--- a/models/demos/llama3_70b_galaxy/tt/qwen_model_config.py
+++ b/models/demos/llama3_70b_galaxy/tt/qwen_model_config.py
@@ -324,8 +324,10 @@ class TtQwenModelArgs(TtModelArgs):
         # On Blackhole the full non-greedy ttnn.sampling pipeline (distributed top-k +
         # scatter_add bincounts) is not supported, so route greedy sampling through the
         # simple all-gather + ttnn.argmax path. Topology follows the 2D-torus fabric (Ring).
+        # On Wormhole the full ttnn.sampling pipeline is supported and greedy sampling goes
+        # through it (with correct sub_core_grids), so force-argmax must stay disabled there.
         self.model_config["SAMPLING_AG_CONFIG"] = {
-            "allow_force_argmax": True,
+            "allow_force_argmax": self.is_blackhole,
             "num_links": self.model_config["GALAXY_NUM_LINKS"],
             "chunks_per_sync": 10,
             "topology": ttnn.Topology.Ring,


### PR DESCRIPTION
PR #49457 set SAMPLING_AG_CONFIG['allow_force_argmax']=True unconditionally for Qwen3-32B galaxy. That flag is only needed on Blackhole, where the full non-greedy ttnn.sampling pipeline (distributed top-k + scatter_add bincounts) is unsupported. On Wormhole it forced greedy sampling through the shared force-argmax fast-path, which the Galaxy TT_CCL does not fully support, causing runtime failures during on-device greedy sampling.

Gate the flag to Blackhole (allow_force_argmax=self.is_blackhole) so Wormhole uses the full ttnn.sampling pipeline (with correct sub_core_grids) as it did before #49457.


### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mgiermakowski/WH-qwen-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mgiermakowski/WH-qwen-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mgiermakowski/WH-qwen-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mgiermakowski/WH-qwen-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mgiermakowski/WH-qwen-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mgiermakowski/WH-qwen-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mgiermakowski/WH-qwen-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mgiermakowski/WH-qwen-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mgiermakowski/WH-qwen-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mgiermakowski/WH-qwen-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mgiermakowski/WH-qwen-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mgiermakowski/WH-qwen-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mgiermakowski/WH-qwen-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mgiermakowski/WH-qwen-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mgiermakowski/WH-qwen-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mgiermakowski/WH-qwen-fix)