### PR TITLE
ci: migrate sparse/DSA MLA + GLM prefill block tests to fabric2d

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -290,7 +290,7 @@ models:
     wh_llmbox: 198
     bh_p150b_civ2: 8
     bh_p300: 20
-    bh_loudbox: 190
+    bh_loudbox: 193
     bh_quietbox_2: 80
     bh_spsg: 20 # single galaxy MLA chunked prefill
   # Per-tier e2e budgets, consumed by the tiered model pipelines;

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
@@ -879,13 +879,15 @@ def _glm_pretrained_weights(config, model_dir, layer_idx, is_moe):
         pytest.param(
             (8, 4),
             {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_config": ttnn.FabricConfig.FABRIC_2D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=GLM51Config.FABRIC_PAYLOAD_SIZE),
+                "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
                 "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE,
             },
             2,
             ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
+            id="fabric2d-mesh-8x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -179,21 +179,18 @@
     exit_code=0
     export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528
     export DEEPSEEK_V32_MLA_REF_CACHE=/tmp/deepseek_v32_mla_ref_cache GLM51_MLA_REF_CACHE=/tmp/glm_5_1_mla_ref_cache
-    # `line` is the verified-portable fabric on the LoudBox (ring/fabric2d fail to train on a partial-Galaxy
-    # box). The suite auto-pins one fabric (priority default fabric2d), so DS_SPARSE_FABRIC=line forces the
-    # collected fabric id back to `line` — which the -k filter below then selects.
-    export DS_SPARSE_FABRIC=line
+    export DS_SPARSE_FABRIC=fabric2d
     # Sparse MLA (V3.2 + GLM-5.1) vs MLACPU. Random weights + on-the-fly CPU truth -> no staged weights.
     # GLM-5.1 reshards heads->sequence in _sparse_mla so it now runs at tp=4; 2x4 is its coverage (accuracy
     # + the determinism/chunked anchor cases, which pin to the highest-TP mesh). DeepSeek-V3.2 covers the
     # asymmetric 2x4 mesh (its 8x4 coverage is on Galaxy). The sparse suite carries no tier markers, so
     # there is no -m gate.
-    pytest models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py -k "glm_5_1 and 2x4 and line" -vvv --tb=short || exit_code=$?
-    pytest models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py -k "deepseek_v32 and 2x4 and line" -vvv --tb=short || exit_code=$?
+    pytest models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py -k "glm_5_1 and 2x4 and fabric2d" -vvv --tb=short || exit_code=$?
+    pytest models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py -k "deepseek_v32 and 2x4 and fabric2d" -vvv --tb=short || exit_code=$?
     exit $exit_code
   skus:
     bh_loudbox:
-      timeout: 7
+      timeout: 10
   owner_id: U07N3CUUN05  # Iva Potkonjak
   team: models
 

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -157,10 +157,10 @@
   cmd: |
     export DEEPSEEK_V3_HF_MODEL=/mnt/models/deepseek-ai/DeepSeek-R1-0528
     export DEEPSEEK_V32_MLA_REF_CACHE=/tmp/deepseek_v32_mla_ref_cache
-    export DS_SPARSE_FABRIC=line
+    export DS_SPARSE_FABRIC=fabric2d
 
     mpirun --pernode --tag-output bash -lc '
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py -k "deepseek_v32 and 8x4 and line" -vvv --tb=short
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py -k "deepseek_v32 and 8x4 and fabric2d" -vvv --tb=short
     '
 
   test_type: dsa_mla
@@ -176,12 +176,12 @@
   cmd: |
     export MESH_DEVICE=TG
     export GLM51_MLA_REF_CACHE=/mnt/models/deepseek-prefill-cache/glm_5_1_mla_ref_cache
-    export DS_SPARSE_FABRIC=line
+    export DS_SPARSE_FABRIC=fabric2d
     # GLM-5.1 sparse MLA (indexer + sparse SDPA) vs the MLACPU reference, plus the GLM-5.2 indexer-reuse
     # equivalence case (inject a prior-layer top-k == recompute). Random weights + on-the-fly CPU truth
     # -> no staged weights. Reuse shares the warm sparse-MLA JIT for this job (same op graph; glm_5_2 == glm_5_1 dims).
     mpirun --pernode --tag-output bash -lc '
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py -k "(glm_5_1 and 8x4 and line) or indexer_reuse" -vvv --tb=short
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py -k "(glm_5_1 and 8x4 and fabric2d) or indexer_reuse" -vvv --tb=short
     '
   test_type: dsa_mla_glm
   test_group: module
@@ -211,17 +211,16 @@
 - name: "Blaze - GLM-5.1 Prefill Block"
   cmd: |
     export MESH_DEVICE=TG
-    export DS_SPARSE_FABRIC=line
     export GLM51_HF_MODEL=/mnt/models/deepseek-prefill-cache/GLM-5.1-FP8/
     export TT_GLM51_PREFILL_TTNN_CACHE=/mnt/models/deepseek-prefill-cache/GLM-5.1-Cache/CI
     export PREFILL_TRACE_DIR=/mnt/models/deepseek-prefill-cache/golden/structured_traces/glm_51_code_debug_55k_vllm
     export GLM51_MLA_REF_CACHE=/mnt/models/deepseek-prefill-cache/glm_5_1_mla_ref_cache
     # Fused GLM-5.1 decoder block (sparse-SDPA MLA + norm/residual + dense/MoE FFN, layers 0 and 3) vs the
-    # composed CPU reference. Real weights via the prebuilt ttnn cache when present (random fallback
-    # otherwise; never rebuilds). -k glm51 so the shared glm_5_2 parametrization is not run here: its MoE
-    # block is skipped under the degenerate gate, and GLM-5.2 is covered by the DSA-MLA and MoE jobs.
+    # composed CPU reference on the fabric2d transport. Real weights via the prebuilt ttnn cache when present
+    # (random fallback otherwise; never rebuilds). -k glm51 so the shared glm_5_2 parametrization is not run
+    # here: its MoE block is skipped under the degenerate gate, and GLM-5.2 is covered by the DSA-MLA/MoE jobs.
     mpirun --pernode --tag-output bash -lc '
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_glm_prefill_block -k "seq5120 and mesh-8x4 and glm51" -vvv --tb=short --timeout=300
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_glm_prefill_block -k "seq5120 and fabric2d-mesh-8x4 and glm51" -vvv --tb=short --timeout=300
     '
   test_type: glm_prefill_block
   test_group: module

--- a/tests/pipeline_reorg/demo_sp_release_tests.yaml
+++ b/tests/pipeline_reorg/demo_sp_release_tests.yaml
@@ -78,9 +78,9 @@
 - name: "(bh loudbox) GLM-5.1 Prefill modules"
   cmd: |
     # GLM-5.1 counterparts to the Kimi lines above. GLM's MLA is DSA/sparse (no absorbed-MLA analog), so
-    # it's its own stage. sparse MLA: `line` fabric (ring/fabric2d don't train on a partial-Galaxy box) +
-    # its own MLA ref cache; no EXPECT_NUM_TESTS since _sparse_cases emits a box-dependent seq count.
-    DS_SPARSE_FABRIC=line GLM51_MLA_REF_CACHE=/tmp/glm_5_1_mla_ref_cache pytest models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py -k "glm_5_1 and 2x4 and line" -vvv --tb=short
+    # it's its own stage with its own MLA ref cache; no EXPECT_NUM_TESTS since _sparse_cases emits a
+    # box-dependent seq count.
+    DS_SPARSE_FABRIC=fabric2d GLM51_MLA_REF_CACHE=/tmp/glm_5_1_mla_ref_cache pytest models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py -k "glm_5_1 and 2x4 and fabric2d" -vvv --tb=short
     EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_ds_moe -k "linear-8 and pcc-device-glm-256 and not pad50" -vvv --tb=short --timeout=1800
   model: deepseek_prefill
   skus:


### PR DESCRIPTION
### What & why

The sparse/DSA MLA suite (`test_sparse_mla.py`) and the GLM-5.1 fused prefill block (`test_glm_prefill_block`) were exercised in CI **only on the `line` (FABRIC_1D) transport**, even though fabric2d is the production transport the model ships on. This migrates them to fabric2d so the sparse path (indexer + `sparse_sdpa`) is actually validated on the fabric it runs on in production.

### Changes

**Sparse-MLA suite** — the suite pins one fabric via `DS_SPARSE_FABRIC` (default priority is already fabric2d); every CI job overrode it to `line`. Moved all four invocations to `fabric2d` (env + `-k` selector):
- `blaze_models_prefill_tests.yaml` — DSA MLA (V3.2), 8x4 Galaxy
- `blaze_models_prefill_tests.yaml` — DSA MLA (GLM-5.1 + GLM-5.2 indexer reuse), 8x4 Galaxy
- `blackhole_e2e_tests.yaml` — `bh-lb-deepseek-dsa`, 2x4 LoudBox
- `demo_sp_release_tests.yaml` — GLM-5.1 modules, 2x4 LoudBox

**GLM prefill block** — `test_glm_prefill_block` had a single FABRIC_1D 8x4 param; migrated it to FABRIC_2D (`fabric2d-mesh-8x4`), mirroring the sibling `test_ds_prefill_block` fabric2d entry (`RELAXED_INIT` + router config), keeping the sparse-path `worker_l1_size`. Updated the Blaze selector to the new id and dropped the dead `DS_SPARSE_FABRIC=line` from that job (it was a no-op — only `test_sparse_mla.py` reads that var).

Dropped the stale "ring/fabric2d fail to train on a partial-Galaxy box" comments: the dense-MLA and prefill-block jobs on those same LoudBox runners already run fabric2d, so fabric init is not box-limited.

### Notes for reviewers

- `DS_SPARSE_FABRIC` is read **only** by `test_sparse_mla.py`, so these edits are well-scoped to the sparse path.
- The GLM prefill **transformer** is not scheduled in CI, so there's nothing to migrate there.
- Draft: pending a green run on the target boxes to confirm the sparse rotated case + block PCC hold on fabric2d (the `line` runs were the ones hanging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/sparse-mla-fabric2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/sparse-mla-fabric2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/sparse-mla-fabric2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/sparse-mla-fabric2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ipotkonjak/sparse-mla-fabric2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ipotkonjak/sparse-mla-fabric2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/sparse-mla-fabric2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/sparse-mla-fabric2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/sparse-mla-fabric2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/sparse-mla-fabric2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/sparse-mla-fabric2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/sparse-mla-fabric2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/sparse-mla-fabric2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/sparse-mla-fabric2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/sparse-mla-fabric2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/sparse-mla-fabric2d)