### PR TITLE
[gpt_oss_d_p] GPT-OSS prefill: package scaffold + attention (GQA/sinks/sliding)

### DIFF
--- a/models/demos/gpt_oss_d_p/README.md
+++ b/models/demos/gpt_oss_d_p/README.md
@@ -1,5 +1,80 @@
+<!-- SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 # GPT-OSS-120B Prefill (`gpt_oss_d_p`)
 
-Placeholder for the GPT-OSS-120B prefill package. Implementation lands via the
-stacked PR chain (#50223 → #50265). This file exists so CODEOWNERS validation
-can pass ahead of the code landing; see `.github/CODEOWNERS`.
+Long-context **prefill** for GPT-OSS-120B on **4×8 Blackhole Galaxy** (TP=8, SP=4, EP=32),
+built "the MiniMax-M3 way": reuse the shared DeepSeek EP-MoE dispatch/combine substrate and the
+fused `unified_routed_expert_ffn` (SwiGLU-OAI + biases), a block-cyclic KV cache, and a runtime
+that plugs into the model-agnostic `models/demos/common/prefill` engine.
+
+> **"Chunked" is the target architecture, not yet the running behavior.** The KV cache and runtime
+> are chunk-oriented (block-cyclic, chunk-at-a-time), but the multi-chunk *cache-read* path (chunk
+> N attending chunks 0..N-1) lands at P6. P1 through P4 run **single-chunk / one-shot** prefill.
+
+## Roadmap
+
+Stacked PRs, bottom-up. **This PR is P1.**
+
+- [x] **P1 — package scaffold + attention** *(this PR)*: GQA, RoPE (YaRN), attention sinks, and
+      per-layer sliding/full alternation; single-Blackhole-card PCC vs a torch reference.
+- [ ] **P2 — KV cache + indexed RoPE**: chunked, block-cyclic, SP-sharded KV cache.
+- [ ] **P3 — MoE**: `TtGptOssMoE` over the DeepSeek EP submodules (SwiGLU-OAI + biases, no shared expert).
+- [ ] **P4 — model + runtime**: full model, chunked-prefill runtime, and the `common/prefill` adapter.
+- [ ] **P5 — galaxy bring-up**: TP=8 / SP=4 / EP=32 on the 4×8 Blackhole Galaxy (gated on galaxy access).
+- [ ] **P6 — ring SDPA**: the sinks + sliding + halo-CCL ring SDPA (Pavle Josipović's op), for scalable SP and multi-chunk long context.
+- [ ] **P7 — unification**: hoist the shared prefill scaffolding (attention output-proj/CCL tail, config, `utils/`) into `common/prefill`.
+
+## Correctness reference
+
+Bottom-up **PCC against a self-contained torch/HF reference** (HF `modeling_gpt_oss` conventions),
+plus CPU-generated golden KV caches for the full-model check. This package is a fresh build; the
+Wormhole/Galaxy `models/demos/gpt_oss` demo was a code-lineage source only and is **not** imported
+or used as a runtime or correctness oracle here.
+
+## What we reuse vs. write fresh
+
+**Reuse (import, don't reimplement)**, from `models/demos/deepseek_v3_d_p/tt/moe/`:
+`TtDispatchModule`, `TtCombineModule`, `TtReduceModule`, `TtMoERoutingSetup`, `TtRoutedExpert`
+(fused `unified_routed_expert_ffn`, `RoutedExpertActivation.SwiGluOai`), `init_helpers`
+(`ExpertMapping`, mesh mappers); the chunked-KV op
+(`ttnn.experimental.deepseek_prefill.update_padded_kv_cache`) and indexed RoPE
+(`rotary_embedding_indexed`); and `GptOss120BConfig`
+(`deepseek_v3_d_p/reference/gpt_oss_120b_config.py`), already the single source of truth for dims
+and already exercised at gpt-oss shapes by the DeepSeek MoE op tests.
+
+**Write fresh (gpt-oss-specific):**
+- `tt/attention/` — GQA, RoPE (YaRN), **attention sinks**, **sliding/full alternation**.
+- `tt/moe/` — thin `TtGptOssMoE` composing the DeepSeek EP submodules; SwiGLU-OAI **+ biases**, **no shared expert**.
+- `tt/router.py` — linear+bias, topk(4), softmax-over-4.
+- weight prep — MXFP4 to bf16 (host) to bfloat4_b (device); gate/up de-interleave; expert permutation.
+- `tt/tt_prefill_runtime.py` + `tt/runners/adapters/gpt_oss.py` — runtime + `common/prefill` adapter.
+
+## Attention (this PR): shapes & correctness notes
+
+Per chip, per layer, one prefill chunk (`S_loc = S/SP`):
+
+| tensor | shape | dtype | layout |
+|---|---|---|---|
+| Q | `[1, 8, S_loc, 64]` (8 of 64 Q-heads) | bf16 | TILE |
+| K | `[1, 1, S_loc, 64]` (1 of 8 KV-heads) | bf16 (cache bf8_b) | TILE |
+| V | `[1, 1, S_loc, 64]` | bf16 (cache bf8_b) | TILE |
+| sinks | `[8]` (per local Q-head), **pre-divided by `config.scaling`** | bf16 | — |
+| out | `[1, 8, S_loc, 64]` | bf16 | TILE |
+
+- GQA group = 8 Q-heads share the 1 local KV-head (no on-chip KV repeat).
+- Sinks are stored **pre-divided by `config.scaling`** (the `1/√head_dim` softmax scale, i.e. ×√64),
+  so the SDPA kernel's own `×scale` of the sink logit recovers the raw HF value (HF does not scale the sink).
+- Layers alternate `sliding_attention` (window 128) and `full_attention` off `hf_config.layer_types`.
+- **Bring-up (P1 through P4) uses AllGather + normal SDPA** (`ttnn.transformer.scaled_dot_product_attention`
+  with `is_causal`, `sliding_window_size`, `attention_sink`, all supported today). Correct, but it
+  replicates the full K/V per chip so it does not scale to 128k; the scalable ring SDPA swaps in at P6.
+
+## Testing
+
+Bottom-up PCC vs the HF reference (`modeling_gpt_oss.py`); thresholds per the design note. A single
+Blackhole card covers per-op and per-layer PCC (norm/rope ≥0.999, attn/router ≥0.99, expert bf4 ≥0.98).
+The full-model EP=32 and perf run happens on Galaxy **via CI** (workflow_dispatch), like the
+DeepSeek-prefill galaxy job.
+
+See the project plan: `GPT_OSS_PREFILL_PLAN.md`.

--- a/models/demos/gpt_oss_d_p/__init__.py
+++ b/models/demos/gpt_oss_d_p/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/models/demos/gpt_oss_d_p/tests/__init__.py
+++ b/models/demos/gpt_oss_d_p/tests/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/models/demos/gpt_oss_d_p/tests/unit/__init__.py
+++ b/models/demos/gpt_oss_d_p/tests/unit/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/models/demos/gpt_oss_d_p/tests/unit/test_attention_vs_ref.py
+++ b/models/demos/gpt_oss_d_p/tests/unit/test_attention_vs_ref.py
@@ -1,0 +1,260 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tier-1 PCC test for the GPT-OSS prefill GQA attention block vs a self-contained torch reference.
+
+Block: QKV proj (+bias) -> head split (GQA 64 Q / 8 KV) -> full RoPE (YaRN) -> causal SDPA with
+per-head attention sinks and optional sliding window -> o_proj (+bias). GPT-OSS-120B dims (from
+configs/gpt-oss-120b/config.json): hidden 2880, head_dim 64, rope_theta 150000, YaRN factor 32,
+orig_max_pos 4096, sliding_window 128, attention_bias true, no QK-norm.
+
+The reference and the TT module are driven by IDENTICAL random weights. The TT module is fed the
+Meta-RoPE-swizzled q/k projections via the production ``convert_hf_qkv_to_meta_format`` helper (and
+Meta-format cos/sin), so the TT swizzled-space path matches the HF-convention torch reference. RoPE
+cos/sin (with YaRN + mscale) are computed once and shared by both sides, so the test is
+self-consistent regardless of the exact YaRN constants. Single card (1x1 mesh, TP=1, SP=1).
+
+Run:
+    pytest models/demos/gpt_oss_d_p/tests/unit/test_attention_vs_ref.py
+(single Blackhole/Wormhole card; no HF checkpoint or network needed).
+"""
+
+import math
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import comp_pcc
+from models.demos.gpt_oss_d_p.tt.attention import Attention, AttentionConfig, ProgramConfig
+from models.demos.gpt_oss_d_p.tt.config import MeshConfig
+from models.tt_transformers.tt.common import get_rot_transformation_mat
+from models.tt_transformers.tt.load_checkpoints import convert_hf_qkv_to_meta_format
+
+# GPT-OSS-120B attention dims.
+HIDDEN = 2880
+NQ = 64
+NKV = 8
+HEAD_DIM = 64
+ROPE_THETA = 150000.0
+YARN_FACTOR = 32.0
+YARN_BETA_FAST = 32.0
+YARN_BETA_SLOW = 1.0
+YARN_ORIG_MAX_POS = 4096
+SLIDING_WINDOW = 128
+EPS = 1e-5
+
+
+# --------------------------------------------------------------------------------------
+# RoPE (YaRN) — matches transformers _compute_yarn_parameters. Shared by ref + TT so the
+# test is self-consistent (exact HF match is not required for a TT-vs-reference PCC).
+# --------------------------------------------------------------------------------------
+def _yarn_inv_freq(dim, base, factor, orig_max_pos, beta_fast, beta_slow):
+    def find_correction_dim(num_rotations):
+        return (dim * math.log(orig_max_pos / (num_rotations * 2 * math.pi))) / (2 * math.log(base))
+
+    low = math.floor(find_correction_dim(beta_fast))
+    high = math.ceil(find_correction_dim(beta_slow))
+    low = max(low, 0)
+    high = min(high, dim - 1)
+
+    pos_freqs = base ** (torch.arange(0, dim, 2).float() / dim)
+    inv_freq_extrapolation = 1.0 / pos_freqs
+    inv_freq_interpolation = 1.0 / (factor * pos_freqs)
+
+    # linear ramp over dim//2 frequency bands
+    lo, hi = low, high
+    if lo == hi:
+        hi += 0.001
+    ramp = (torch.arange(dim // 2).float() - lo) / (hi - lo)
+    ramp = ramp.clamp(0, 1)
+    inv_freq_extrapolation_factor = 1.0 - ramp
+
+    inv_freq = (
+        inv_freq_interpolation * (1.0 - inv_freq_extrapolation_factor)
+        + inv_freq_extrapolation * inv_freq_extrapolation_factor
+    )
+    attention_factor = 0.1 * math.log(factor) + 1.0
+    return inv_freq, attention_factor
+
+
+def _build_cos_sin(seq_len):
+    """Return (cos_hf, sin_hf) [S, head_dim] for the reference, and (cos_meta, sin_meta)
+    [1,1,S,head_dim] for the TT module. mscale (attention_factor) is folded into both."""
+    inv_freq, attn_factor = _yarn_inv_freq(
+        HEAD_DIM, ROPE_THETA, YARN_FACTOR, YARN_ORIG_MAX_POS, YARN_BETA_FAST, YARN_BETA_SLOW
+    )
+    pos = torch.arange(seq_len).float()
+    freqs = torch.outer(pos, inv_freq)  # [S, head_dim/2]
+    cos_half = torch.cos(freqs) * attn_factor  # [S, head_dim/2]
+    sin_half = torch.sin(freqs) * attn_factor
+
+    # HF convention: concat the halves -> rotate_half over the full head.
+    cos_hf = torch.cat([cos_half, cos_half], dim=-1)  # [S, head_dim]
+    sin_hf = torch.cat([sin_half, sin_half], dim=-1)
+
+    # Meta convention (ttnn rotary_embedding_llama + reverse_permute'd weights): interleave.
+    cos_meta = torch.stack([cos_half, cos_half], dim=-1).flatten(-2)[None, None]  # [1,1,S,head_dim]
+    sin_meta = torch.stack([sin_half, sin_half], dim=-1).flatten(-2)[None, None]
+    return (cos_hf, sin_hf), (cos_meta, sin_meta)
+
+
+def _rotate_half(x):
+    x1, x2 = x[..., : x.shape[-1] // 2], x[..., x.shape[-1] // 2 :]
+    return torch.cat([-x2, x1], dim=-1)
+
+
+def _rope_hf(t, cos, sin):
+    # cos/sin: [S, head_dim]; t: [B, H, S, head_dim]
+    return t * cos + _rotate_half(t) * sin
+
+
+# --------------------------------------------------------------------------------------
+# Torch reference: HF-convention GPT-OSS GQA attention with sinks + sliding window.
+# --------------------------------------------------------------------------------------
+def _torch_attention(x, w, cos_hf, sin_hf, sliding_window):
+    B, S, _ = x.shape
+    q = (x @ w["q"].t() + w["q_bias"]).view(B, S, NQ, HEAD_DIM).transpose(1, 2)  # [B, NQ, S, HD]
+    k = (x @ w["k"].t() + w["k_bias"]).view(B, S, NKV, HEAD_DIM).transpose(1, 2)
+    v = (x @ w["v"].t() + w["v_bias"]).view(B, S, NKV, HEAD_DIM).transpose(1, 2)
+
+    q = _rope_hf(q, cos_hf, sin_hf)
+    k = _rope_hf(k, cos_hf, sin_hf)
+
+    rep = NQ // NKV
+    k = k.repeat_interleave(rep, dim=1)  # [B, NQ, S, HD]
+    v = v.repeat_interleave(rep, dim=1)
+
+    scale = HEAD_DIM**-0.5
+    scores = (q @ k.transpose(-1, -2)) * scale  # [B, NQ, S, S]
+
+    # causal mask (+ sliding window: keys older than `sliding_window` are masked)
+    mask = torch.triu(torch.full((S, S), float("-inf")), diagonal=1)
+    if sliding_window is not None:
+        mask += torch.tril(torch.full((S, S), float("-inf")), diagonal=-sliding_window)
+    scores = scores + mask
+
+    # attention sinks: append a per-head learned logit as an extra softmax column, then drop it.
+    sinks = w["sinks"].view(1, NQ, 1, 1).expand(B, NQ, S, 1)  # [B, NQ, S, 1]
+    combined = torch.cat([scores, sinks], dim=-1)  # [B, NQ, S, S+1]
+    probs = torch.softmax(combined, dim=-1)[..., :S]  # drop the sink column
+
+    out = probs @ v  # [B, NQ, S, HD]
+    out = out.transpose(1, 2).reshape(B, S, NQ * HEAD_DIM)
+    return out @ w["o"].t() + w["o_bias"]
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
+@pytest.mark.parametrize(
+    "layer_idx, layer_types, is_sliding",
+    [
+        (0, ["sliding_attention", "full_attention"], True),  # sliding-window layer
+        (1, ["sliding_attention", "full_attention"], False),  # full-causal layer
+    ],
+    ids=["sliding_layer", "full_layer"],
+)
+@pytest.mark.parametrize("seq_len", [256], ids=["s256"])
+def test_attention_prefill_vs_ref(mesh_device, layer_idx, layer_types, is_sliding, seq_len, reset_seeds):
+    """GPT-OSS GQA prefill attention block vs a self-authored torch reference, random weights.
+
+    (1,1) = single card, TP=1 / SP=1 (no CCL). Both a sliding-window layer (layer_idx 0) and a
+    full-causal layer (layer_idx 1) are covered. PCC >= 0.99."""
+    torch.manual_seed(0)
+    x = torch.randn(1, seq_len, HIDDEN) * 0.1
+
+    # Random projection weights/biases (HF [out, in] layout) + per-head sinks.
+    w = {
+        "q": torch.randn(NQ * HEAD_DIM, HIDDEN) * 0.02,
+        "k": torch.randn(NKV * HEAD_DIM, HIDDEN) * 0.02,
+        "v": torch.randn(NKV * HEAD_DIM, HIDDEN) * 0.02,
+        "o": torch.randn(HIDDEN, NQ * HEAD_DIM) * 0.02,
+        "q_bias": torch.randn(NQ * HEAD_DIM) * 0.02,
+        "k_bias": torch.randn(NKV * HEAD_DIM) * 0.02,
+        "v_bias": torch.randn(NKV * HEAD_DIM) * 0.02,
+        "o_bias": torch.randn(HIDDEN) * 0.02,
+        "sinks": torch.randn(NQ) * 0.5,
+    }
+
+    (cos_hf, sin_hf), (cos_meta, sin_meta) = _build_cos_sin(seq_len)
+
+    ref_sliding = SLIDING_WINDOW if is_sliding else None
+    ref_out = _torch_attention(x.float(), w, cos_hf, sin_hf, ref_sliding)
+
+    # --- TT module from the SAME weights, Meta-RoPE-swizzled (q/k proj weight + bias) ---
+    hf_state = {
+        "q_proj.weight": w["q"],
+        "q_proj.bias": w["q_bias"],
+        "k_proj.weight": w["k"],
+        "k_proj.bias": w["k_bias"],
+        "v_proj.weight": w["v"],
+        "v_proj.bias": w["v_bias"],
+        "o_proj.weight": w["o"],
+        "o_proj.bias": w["o_bias"],
+        "sinks": w["sinks"],
+    }
+    state = convert_hf_qkv_to_meta_format(hf_state, HEAD_DIM)
+
+    mesh_config = MeshConfig(tuple(mesh_device.shape), tp=mesh_device.shape[1])
+
+    attn_config = AttentionConfig(
+        hidden_size=HIDDEN,
+        num_heads=NQ,
+        num_kv_heads=NKV,
+        head_dim=HEAD_DIM,
+        max_seq_len=max(seq_len, 128),
+        sliding_window=SLIDING_WINDOW,  # nulled by Attention for full-attention layers
+        rms_norm_eps=EPS,
+    )
+
+    # RoPE transformation matrix for the prefill rotary_embedding_llama op.
+    trans_mat = ttnn.from_torch(
+        get_rot_transformation_mat(),
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+    attn = Attention(
+        mesh_device=mesh_device,
+        config=attn_config,
+        state_dict=state,
+        ccl_manager=None,  # unused at TP=1 / SP=1
+        mesh_config=mesh_config,
+        program_config=ProgramConfig(),
+        layer_idx=layer_idx,
+        layer_types=layer_types,
+        transformation_mats={"prefill": trans_mat},
+        weight_dtype=ttnn.bfloat16,
+    )
+    assert attn.is_sliding == is_sliding
+    assert attn.config.sliding_window == (SLIDING_WINDOW if is_sliding else None)
+
+    def _to_tt_cos_sin(t):
+        return ttnn.from_torch(
+            t,
+            device=mesh_device,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=ttnn.bfloat16,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        )
+
+    rope_mats = [_to_tt_cos_sin(cos_meta), _to_tt_cos_sin(sin_meta)]
+
+    x_tt = ttnn.from_torch(
+        x.reshape(1, 1, seq_len, HIDDEN),
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+    tt_out = attn(x_tt, rope_mats=rope_mats, position_idx=None, kv_cache=None)
+    out = ttnn.to_torch(ttnn.get_device_tensors(tt_out)[0]).reshape(1, seq_len, HIDDEN)
+
+    passing, pcc = comp_pcc(ref_out, out, 0.99)
+    logger.info(f"gpt-oss attention prefill vs ref ({'sliding' if is_sliding else 'full'}): {pcc}")
+    assert passing, f"attention PCC fail ({'sliding' if is_sliding else 'full'}): {pcc}"

--- a/models/demos/gpt_oss_d_p/tt/__init__.py
+++ b/models/demos/gpt_oss_d_p/tt/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/models/demos/gpt_oss_d_p/tt/attention/__init__.py
+++ b/models/demos/gpt_oss_d_p/tt/attention/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/models/demos/gpt_oss_d_p/tt/attention/__init__.py
+++ b/models/demos/gpt_oss_d_p/tt/attention/__init__.py
@@ -1,3 +1,134 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
-#
 # SPDX-License-Identifier: Apache-2.0
+
+"""GPT-OSS prefill attention module."""
+
+import dataclasses
+
+import ttnn
+
+from models.demos.gpt_oss_d_p.tt.config import MeshConfig
+
+from .config import AttentionConfig, ProgramConfig
+from .prefill import attention_forward
+from .weights import AttentionWeights, load_attention_weights
+
+__all__ = ["Attention", "AttentionConfig", "ProgramConfig", "AttentionWeights"]
+
+
+class Attention:
+    """
+    GPT-OSS prefill attention layer.
+
+    Builds config + weights and dispatches the chunked-prefill forward. Selects sliding-window
+    vs full-causal masking per layer from ``hf_config.layer_types`` (or the caller-provided
+    ``layer_types``): "sliding_attention" keeps ``config.sliding_window`` (128 for gpt-oss),
+    "full_attention" nulls it. No decode path in this P1 bring-up module.
+    """
+
+    def __init__(
+        self,
+        mesh_device,
+        config: AttentionConfig,
+        state_dict,
+        ccl_manager,
+        mesh_config: MeshConfig,
+        program_config: ProgramConfig,
+        layer_idx,
+        layer_types=None,
+        transformation_mats=None,
+        weight_dtype=ttnn.bfloat8_b,
+        tensor_cache_path=None,
+    ):
+        """
+        Initialize attention layer.
+
+        Args:
+            mesh_device: TTNN mesh device
+            config: Attention configuration (``config.sliding_window`` holds the sliding window
+                *size*, e.g. 128; it is nulled here for full-attention layers)
+            state_dict: State dictionary containing weights
+            ccl_manager: Communication manager (unused when TP == 1 and SP == 1)
+            mesh_config: Mesh parallelization config
+            program_config: Model-specific program configurations
+            layer_idx: Layer index
+            layer_types: Optional per-layer type list (from hf_config.layer_types); entry
+                layer_idx selects sliding vs full. Falls back to even=sliding / odd=full when None.
+            transformation_mats: Optional {"prefill": tensor} RoPE transformation matrices
+            weight_dtype: Data type for weights (default: bfloat8_b)
+            tensor_cache_path: Optional path for weight caching
+        """
+        self.mesh_config = mesh_config
+        self.mesh_device = mesh_device
+        self.ccl_manager = ccl_manager
+        self.program_config = program_config
+        self.layer_idx = layer_idx
+        self.transformation_mats = transformation_mats
+
+        # Sliding vs full for this layer (gpt-oss alternates per hf_config.layer_types; even=sliding).
+        if layer_types is not None:
+            self.is_sliding = layer_types[layer_idx] == "sliding_attention"
+        else:
+            self.is_sliding = (layer_idx % 2) == 0
+        # Per-layer config copy so full layers get sliding_window=None — never mutate the caller's
+        # config, which may be shared across layers.
+        self.config = dataclasses.replace(config, sliding_window=config.sliding_window if self.is_sliding else None)
+
+        # Load weights
+        self.weights = load_attention_weights(
+            mesh_device=mesh_device,
+            config=config,
+            state_dict=state_dict,
+            mesh_config=mesh_config,
+            weight_dtype=weight_dtype,
+            tensor_cache_path=tensor_cache_path,
+        )
+
+        # Store references for convenience
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.num_heads
+        self.num_kv_heads = config.num_kv_heads
+        self.head_dim = config.head_dim
+        self.scaling = config.scaling
+
+    def __call__(
+        self,
+        hidden_states,
+        rope_mats,
+        position_idx=None,
+        kv_cache=None,
+        user_id=0,
+        batch_size=1,
+    ):
+        """
+        Prefill attention forward.
+
+        Args:
+            hidden_states: Input tensor [batch, seq_len, hidden_size]
+            rope_mats: Tuple/list of (cos, sin) matrices for RoPE (YaRN baked in)
+            position_idx: Position indices (unused in prefill)
+            kv_cache: Optional [k_cache, v_cache] pair; may be None
+            user_id: User/batch index; also the cache slot index (default: 0)
+            batch_size: number of users packed on the sequence dim
+
+        Returns:
+            Attention output [batch, seq_len, hidden_size]
+        """
+        transformation_mat = self.transformation_mats["prefill"] if self.transformation_mats else None
+
+        return attention_forward(
+            hidden_states=hidden_states,
+            rope_mats=rope_mats,
+            user_id=user_id,
+            weights=self.weights,
+            kv_cache=kv_cache,
+            config=self.config,
+            mesh_config=self.mesh_config,
+            mesh_device=self.mesh_device,
+            program_config=self.program_config,
+            transformation_mat=transformation_mat,
+            position_idx=position_idx,
+            ccl_manager=self.ccl_manager,
+            batch_size=batch_size,
+            layer_idx=self.layer_idx,
+        )

--- a/models/demos/gpt_oss_d_p/tt/attention/config.py
+++ b/models/demos/gpt_oss_d_p/tt/attention/config.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+GPT-OSS attention configuration (AttentionConfig + ProgramConfig split). Key points:
+
+- **GQA**: 64 Q-heads / 8 KV-heads, head_dim 64.
+- **Full rotary** (rotary_dim == head_dim), **YaRN** scaling — no partial rotary.
+- **Attention sinks**: a learned per-head logit folded into the softmax denominator
+  (held in AttentionWeights, pre-divided by ``config.scaling`` = the 1/sqrt(head_dim) scale; see weights.py).
+- **Sliding / full alternation**: ``sliding_window`` is set PER LAYER by the caller
+  from ``hf_config.layer_types`` (None => full-causal for that layer).
+- **No QK-norm**, **no MSA / sparse** path.
+- **QKV/O projections carry bias** (``attention_bias: true`` in the HF config).
+"""
+
+from dataclasses import dataclass
+
+import ttnn
+
+
+@dataclass
+class AttentionConfig:
+    """Core gpt-oss attention configuration."""
+
+    hidden_size: int  # 2880
+    num_heads: int  # 64 Q-heads
+    num_kv_heads: int  # 8 KV-heads (GQA group = num_heads // num_kv_heads = 8)
+    head_dim: int  # 64
+    max_seq_len: int
+
+    # Per-layer sliding window. Set by the caller from hf_config.layer_types:
+    #   "sliding_attention" -> sliding_window (128); "full_attention" -> None.
+    sliding_window: int | None = None
+    # Full rotary for gpt-oss (defaults to head_dim in __post_init__).
+    rotary_dim: int | None = None
+    rms_norm_eps: float = 1e-5
+    # softmax scale 1/sqrt(head_dim); computed if None. Sinks are stored pre-divided by this so the
+    # kernel's internal scaling reproduces HF (which doesn't scale the sink). See weights.py.
+    scaling: float | None = None
+
+    # P1 SP path: AllGather K/V + single-chip SDPA (sliding + sinks). Native ring SDPA swaps in at P6.
+    sequence_parallel: bool = False
+
+    def __post_init__(self):
+        if self.scaling is None:
+            self.scaling = self.head_dim**-0.5
+        if self.rotary_dim is None:
+            self.rotary_dim = self.head_dim
+
+    @property
+    def gqa_group_size(self) -> int:
+        return self.num_heads // self.num_kv_heads
+
+
+@dataclass
+class ProgramConfig:
+    """SDPA + projection program configs + Blackhole compute kernel config.
+    Models supply chunk sizes / core grids; boilerplate is here."""
+
+    # Prefill SDPA chunking (seq-len dependent).
+    prefill_q_chunk_size_small: int = 32
+    prefill_k_chunk_size_small: int = 32
+    prefill_q_chunk_size_large: int = 256
+    prefill_k_chunk_size_large: int = 256
+    prefill_threshold: int = 2048
+
+    # Compute config.
+    math_fidelity: str = "HiFi4"
+    math_approx_mode: bool = False
+    fp32_dest_acc_en: bool = False
+    packer_l1_acc: bool = False
+
+    def __post_init__(self):
+        if (
+            min(
+                self.prefill_q_chunk_size_small,
+                self.prefill_k_chunk_size_small,
+                self.prefill_q_chunk_size_large,
+                self.prefill_k_chunk_size_large,
+                self.prefill_threshold,
+            )
+            <= 0
+        ):
+            raise ValueError("SDPA chunk sizes and threshold must be positive")
+        valid_fidelities = ["LoFi", "HiFi2", "HiFi3", "HiFi4"]
+        if self.math_fidelity not in valid_fidelities:
+            raise ValueError(f"math_fidelity must be one of {valid_fidelities}, got {self.math_fidelity}")
+
+    def get_prefill_sdpa_config(self, mesh_device, seq_len: int) -> ttnn.SDPAProgramConfig:
+        if seq_len >= self.prefill_threshold:
+            q_chunk, k_chunk = self.prefill_q_chunk_size_large, self.prefill_k_chunk_size_large
+        else:
+            q_chunk, k_chunk = self.prefill_q_chunk_size_small, self.prefill_k_chunk_size_small
+        return ttnn.SDPAProgramConfig(
+            compute_with_storage_grid_size=ttnn.CoreCoord(8, 8),
+            exp_approx_mode=False,
+            q_chunk_size=q_chunk,
+            k_chunk_size=k_chunk,
+        )
+
+    def get_compute_kernel_config(self):
+        return ttnn.WormholeComputeKernelConfig(
+            math_fidelity=getattr(ttnn.MathFidelity, self.math_fidelity),
+            math_approx_mode=self.math_approx_mode,
+            fp32_dest_acc_en=self.fp32_dest_acc_en,
+            packer_l1_acc=self.packer_l1_acc,
+        )

--- a/models/demos/gpt_oss_d_p/tt/attention/operations.py
+++ b/models/demos/gpt_oss_d_p/tt/attention/operations.py
@@ -1,0 +1,249 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+GPT-OSS attention primitive ops: QKV/O projections carry bias, RoPE is FULL rotary
+(rotary_dim == head_dim, no partial-rotary slice/concat), and there is no QK-norm.
+"""
+
+import ttnn
+
+from .weights import AttentionWeights
+
+
+def apply_qkv_projection(hidden_states, weights: AttentionWeights):
+    """
+    Apply QKV projection and add the fused QKV bias.
+
+    Args:
+        hidden_states: Input tensor [batch, seq_len, hidden_size]
+        weights: Attention weights container
+
+    Returns:
+        Fused QKV tensor [batch, seq_len, total_qkv_dim]
+    """
+    xqkv_fused = ttnn.linear(hidden_states, weights.wqkv, bias=weights.wqkv_bias, dtype=ttnn.bfloat16)
+    return xqkv_fused
+
+
+def split_qkv_heads_prefill(xqkv_fused, num_heads: int, num_kv_heads: int):
+    """
+    Split fused QKV into separate head tensors for prefill mode (GQA: num_heads Q, num_kv_heads K/V).
+
+    Args:
+        xqkv_fused: Fused QKV tensor
+        num_heads: Number of (local) Q heads
+        num_kv_heads: Number of (local) K/V heads
+
+    Returns:
+        Tuple (Q, K, V) with shapes [1, num_heads, seq_len, head_dim] / [1, num_kv_heads, seq_len, head_dim]
+    """
+    return ttnn.experimental.nlp_create_qkv_heads(
+        xqkv_fused,
+        num_heads=num_heads,
+        num_kv_heads=num_kv_heads,
+        transpose_k_heads=False,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+
+def apply_rope(tensor, rope_mats, transformation_mat, is_decode_mode: bool = False):
+    """
+    Apply rotary position embedding (RoPE) — FULL rotary for gpt-oss (rotary_dim == head_dim, 64).
+
+    The YaRN scaling (rope_theta 150000, factor 32, orig_max_pos 4096) is baked into the cos/sin
+    matrices (``rope_mats``) at build time, so this op is a plain full rotation of the whole head.
+
+    Args:
+        tensor: Input tensor (Q or K), shape [1, n_heads, seq_len, head_dim]
+        rope_mats: Tuple/list of (cos, sin) matrices, last dim = head_dim
+        transformation_mat: Transformation matrix for the mode
+        is_decode_mode: Whether in decode mode (False for prefill)
+
+    Returns:
+        Tensor with RoPE applied
+    """
+    return ttnn.experimental.rotary_embedding_llama(
+        tensor, rope_mats[0], rope_mats[1], transformation_mat, is_decode_mode=is_decode_mode
+    )
+
+
+def concat_heads(tensor):
+    """
+    Concatenate attention heads back to the hidden dimension (prefill).
+
+    Args:
+        tensor: Attention output tensor with separate heads [1, n_heads, seq_len, head_dim]
+
+    Returns:
+        Tensor with concatenated heads [1, 1, seq_len, hidden_size]
+    """
+    return ttnn.experimental.nlp_concat_heads(tensor, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+
+def apply_output_projection(tensor, weights: AttentionWeights, activation_dtype):
+    """
+    Apply output projection and add the o_proj bias.
+
+    Args:
+        tensor: Attention output tensor [1, 1, seq_len, local_hidden]
+        weights: Attention weights container
+        activation_dtype: Target dtype for output
+
+    Returns:
+        Output tensor after projection (+ bias)
+    """
+    tensor = ttnn.typecast(tensor, ttnn.bfloat8_b)
+    out = ttnn.matmul(tensor, weights.o_proj, dtype=activation_dtype)
+    tensor.deallocate(True)
+    ttnn.add(out, weights.o_proj_bias, output_tensor=out)
+    return out
+
+
+# Per-M_tiles tuned config for the fused attention o_proj matmul + reduce-scatter.
+# Tuple layout: (grid_y, M_block, K_block, N_block, chunk_width, subblock_h, subblock_w, num_workers).
+_FUSED_MM_RS_CONFIGS = {
+    32: (4, 4, 4, 6, 2, 2, 2, 3),  # S=1024
+}
+
+
+def is_shape_fused_mm_rs_supported(tensor) -> bool:
+    # The async fused matmul+reduce_scatter (minimal_matmul_strided_reduce_scatter_async) RACES on
+    # Blackhole (semaphore/overlap sync bug) -> non-deterministic garbage. It is only validated on
+    # Wormhole, so gate the fused path off on Blackhole and fall back to the correct non-fused
+    # matmul+allreduce path there. Remove this gate once the fused-op sync is fixed for Blackhole.
+    if "blackhole" in ttnn.get_arch_name():
+        return False
+    m_tiles = (tensor.shape[-2] + 31) // 32
+    return m_tiles in _FUSED_MM_RS_CONFIGS
+
+
+def apply_output_projection_fused_rs(tensor, weights: AttentionWeights, mesh_config, ccl_manager):
+    """Attention output projection + TP reduce-scatter fused into one device op.
+
+    Replaces the sequential `apply_output_projection` + first half of `mesh_config.allreduce`
+    (the reduce-scatter). The trailing all-gather and padding-trim stay as separate ops in
+    `apply_allgather_and_slice`. Internally uses
+    `ttnn.experimental.minimal_matmul_strided_reduce_scatter_async` (Ring topology only).
+
+    Returns the reduce-scattered tensor [1, 1, S, padded_hidden_total / TP] in bf8_b.
+    Only valid for prefill (TP > 1).
+    """
+    TILE = 32
+    K = tensor.shape[-1]
+    N = weights.o_proj.shape[-1]
+    assert K % TILE == 0 and N % TILE == 0, f"K={K}, N={N} must be tile-aligned"
+
+    M_tiles = (tensor.shape[-2] + TILE - 1) // TILE
+    N_tiles = N // TILE
+
+    if M_tiles not in _FUSED_MM_RS_CONFIGS:
+        raise ValueError(
+            f"No tuned fused o_proj MM+RS config for M_tiles={M_tiles}; "
+            f"tuned shapes: {sorted(_FUSED_MM_RS_CONFIGS)}. "
+            f"Use apply_output_projection + apply_allreduce for untuned shapes."
+        )
+    grid_y, m_block, k_block, n_block, chunk_width, subblock_h, subblock_w, num_workers = _FUSED_MM_RS_CONFIGS[M_tiles]
+
+    mm_core_grid = ttnn.CoreCoord(8, grid_y)
+
+    tensor = ttnn.typecast(tensor, ttnn.bfloat8_b)
+
+    mm_config = ttnn.MinimalMatmulConfig(
+        M_block_size=m_block,
+        K_block_size=k_block,
+        N_block_size=n_block,
+        subblock_h=subblock_h,
+        subblock_w=subblock_w,
+        compute_with_storage_grid_size=mm_core_grid,
+    )
+
+    compute_config = ttnn.init_device_compute_kernel_config(
+        ccl_manager.mesh_device.arch(),
+        math_fidelity=ttnn.MathFidelity.LoFi,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+    )
+
+    mm_out, rs_out = ttnn.experimental.minimal_matmul_strided_reduce_scatter_async(
+        tensor,
+        weights.o_proj,
+        3,  # scatter on last (hidden) dim
+        ccl_manager.get_rs_ping_pong_semaphore(),
+        ttnn.CoreCoord(0, grid_y),  # RS cores start just below the MM rows
+        compute_kernel_config=compute_config,
+        num_links=ccl_manager.num_links,
+        memory_config_mm=ttnn.DRAM_MEMORY_CONFIG,
+        rs_output_mem_config=ttnn.DRAM_MEMORY_CONFIG,
+        topology=ccl_manager.topology,
+        cluster_axis=mesh_config.tp_axis,
+        bias=weights.o_proj_bias,
+        config=mm_config,
+        barrier_semaphore=ccl_manager.get_barrier_semaphore(),
+        chunk_width_in_mm_blocks=chunk_width,
+        num_workers_per_link=num_workers,
+    )
+
+    tensor.deallocate(True)
+    mm_out.deallocate(True)
+    return rs_out
+
+
+def apply_allgather_and_slice(rs_out, mesh_config, ccl_manager, hidden_size: int):
+    """Complete the attention-output chain after `apply_output_projection_fused_rs`.
+
+    Runs the all-gather (TP) on the scattered output, then drops the padding columns that
+    `weights.py` adds for tile alignment of the CCL ops.
+    """
+    gathered = mesh_config.allgather(rs_out, ccl_manager, axis=mesh_config.tp_axis)
+    rs_out.deallocate(True)
+
+    local_hidden = hidden_size // mesh_config.tp
+    padded_local_hidden = ((local_hidden + 31) // 32) * 32
+    if padded_local_hidden != local_hidden:
+        shape = gathered.shape
+        sliced = ttnn.slice(
+            gathered,
+            starts=[0, 0, 0, 0],
+            ends=[shape[0], shape[1], shape[2], hidden_size],
+            steps=[1, 1, 1, 1],
+        )
+        gathered.deallocate(True)
+        return sliced
+    return gathered
+
+
+def apply_allreduce(tensor, mesh_config, ccl_manager, hidden_size: int):
+    """
+    Apply tensor-parallel allreduce if needed (TP > 1), then strip the o_proj tile-alignment padding.
+
+    Args:
+        tensor: Input tensor
+        mesh_config: Mesh configuration
+        ccl_manager: Communication manager
+        hidden_size: Hidden size (for padding removal)
+
+    Returns:
+        Tensor after allreduce (if TP > 1) or the original tensor
+    """
+    if mesh_config.tp > 1:
+        tensor_allreduced = mesh_config.allreduce(tensor, ccl_manager, pad_size=0, axis=mesh_config.tp_axis)
+        # `mesh_config.allreduce` frees its input internally between reduce_scatter and all_gather;
+        # don't deallocate again here.
+        tensor = tensor_allreduced
+
+        # Remove padding added in weights.py for tile-aligned CCL operations (e.g. 360 -> 384).
+        local_hidden = hidden_size // mesh_config.tp
+        padded_local_hidden = ((local_hidden + 31) // 32) * 32
+        if padded_local_hidden != local_hidden:
+            shape = tensor.shape
+            tensor_sliced = ttnn.slice(
+                tensor,
+                starts=[0, 0, 0, 0],
+                ends=[shape[0], shape[1], shape[2], hidden_size],
+                steps=[1, 1, 1, 1],
+            )
+            tensor.deallocate(True)
+            tensor = tensor_sliced
+    return tensor

--- a/models/demos/gpt_oss_d_p/tt/attention/prefill.py
+++ b/models/demos/gpt_oss_d_p/tt/attention/prefill.py
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+GPT-OSS chunked-prefill attention forward: GQA with full rotary (YaRN baked into the cos/sin),
+attention sinks, and per-layer sliding-window vs full-causal masking. No MSA / sparse path, no
+partial rotary, no QK-norm.
+
+SP seam (P1): when the sequence is SP-sharded, AllGather K/V so each chip holds the full K/V, then
+run single-chip SDPA. The native ring SDPA (sinks+sliding+halo CCL) swaps in later — see the SP branch.
+"""
+
+import ttnn
+
+from .config import AttentionConfig, ProgramConfig
+from .operations import (
+    apply_allgather_and_slice,
+    apply_allreduce,
+    apply_output_projection,
+    apply_output_projection_fused_rs,
+    apply_qkv_projection,
+    apply_rope,
+    concat_heads,
+    is_shape_fused_mm_rs_supported,
+    split_qkv_heads_prefill,
+)
+from .weights import AttentionWeights
+
+
+def _run_sdpa(tt_q, tt_k, tt_v, weights, config, program_config, mesh_device, seq_len):
+    """Single-chip GQA SDPA with sliding-window + attention-sink (the P1 dense path)."""
+    return ttnn.transformer.scaled_dot_product_attention(
+        tt_q,
+        tt_k,
+        tt_v,
+        is_causal=True,
+        # Pass the configured scale explicitly so QK scaling and the sink pre-division (both use
+        # config.scaling) stay consistent for any config; it equals the kernel default (1/sqrt(head_dim)).
+        scale=config.scaling,
+        sliding_window_size=config.sliding_window,
+        attention_sink=weights.sinks,
+        program_config=program_config.get_prefill_sdpa_config(mesh_device, seq_len),
+        compute_kernel_config=program_config.get_compute_kernel_config(),
+    )
+
+
+def attention_forward(
+    hidden_states,
+    rope_mats,
+    weights: AttentionWeights,
+    kv_cache,
+    config: AttentionConfig,
+    mesh_config,
+    mesh_device,
+    program_config: ProgramConfig,
+    transformation_mat,
+    position_idx,
+    ccl_manager,
+    user_id=0,
+    batch_size=1,
+    layer_idx=0,
+):
+    """
+    Prefill forward pass — optimized for sequence processing (seq_len > 1).
+
+    Pipeline: QKV proj (+bias) -> head split (GQA) -> full RoPE on Q,K -> optional KV-cache write
+    -> SDPA (sliding_window + attention_sink) -> concat heads -> o_proj (+bias) -> TP allreduce.
+
+    Args:
+        hidden_states: Input tensor [batch, seq_len, hidden_size]
+        rope_mats: Tuple/list of (cos, sin) matrices for RoPE (YaRN baked in, full head_dim wide)
+        weights: Attention weights
+        kv_cache: Optional [k_cache, v_cache] pair; may be None (e.g. the unit test)
+        config: Attention configuration
+        mesh_config: Mesh parallelization config
+        mesh_device: TTNN mesh device
+        program_config: Model-specific program configs
+        transformation_mat: Transformation matrix for RoPE
+        position_idx: Position indices (unused in prefill)
+        ccl_manager: Communication manager (only used when TP > 1 or SP > 1)
+        user_id: cache slot index for the per-user cache write
+        batch_size: number of users packed on the sequence dim
+        layer_idx: this layer's index (informational)
+
+    Returns:
+        Attention output [batch, seq_len, hidden_size]
+    """
+    activation_dtype = ttnn.bfloat16
+    total_seq_len = hidden_states.shape[-2]
+    hidden_size = hidden_states.shape[-1]
+    seq_len = total_seq_len // batch_size  # Per-user sequence length
+    if seq_len > 32 * 1024:
+        activation_dtype = ttnn.bfloat8_b
+    else:
+        activation_dtype = ttnn.bfloat16
+
+    # Validate prefill mode
+    if seq_len <= 1:
+        raise ValueError(f"Prefill mode requires seq_len>1, got {seq_len}. Use decode mode for single tokens.")
+
+    # QKV projection (+ fused bias)
+    xqkv_fused = apply_qkv_projection(hidden_states, weights)
+    hidden_states.deallocate(True)  # Free input activations after projection
+
+    # Reshape for batch: [1, 1, B*S, QKV] -> [B, 1, S, QKV]
+    if batch_size > 1:
+        xqkv_fused = ttnn.reshape(xqkv_fused, [batch_size, 1, seq_len, -1])
+
+    # Split into Q, K, V heads (GQA: local Q / local KV heads per TP shard)
+    num_local_heads = mesh_config.shard_size(config.num_heads)
+    num_local_kv_heads = mesh_config.shard_size(config.num_kv_heads)
+
+    tt_q, tt_k, tt_v = split_qkv_heads_prefill(xqkv_fused, num_local_heads, num_local_kv_heads)
+    xqkv_fused.deallocate(True)
+
+    # Apply full RoPE on Q and K (use per-user seq_len positions when multi-user)
+    if batch_size > 1:
+        rope_mats_sliced = [rope_mats[0][:, :, :seq_len, :], rope_mats[1][:, :, :seq_len, :]]
+    else:
+        rope_mats_sliced = rope_mats
+    tt_q_orig = tt_q
+    tt_k_orig = tt_k
+    tt_q = apply_rope(tt_q, rope_mats_sliced, transformation_mat, is_decode_mode=False)
+    tt_k = apply_rope(tt_k, rope_mats_sliced, transformation_mat, is_decode_mode=False)
+    tt_q_orig.deallocate(True)
+    tt_k_orig.deallocate(True)
+
+    # Optional KV-cache write (non-paged). None in the unit test. Post-RoPE K + raw V.
+    # Write the cache in its own dtype (e.g. bf8_b) via a cast copy, but keep the bf16 tt_k/tt_v
+    # live for this chunk's SDPA below (casting them in place would run attention at cache precision).
+    if kv_cache is not None:
+        k_cache, v_cache = kv_cache
+        k_for_cache = ttnn.typecast(tt_k, k_cache.dtype)
+        v_for_cache = ttnn.typecast(tt_v, v_cache.dtype)
+        if batch_size > 1:
+            for b in range(batch_size):
+                k_b = ttnn.slice(
+                    k_for_cache, (b, 0, 0, 0), (b + 1, k_for_cache.shape[1], k_for_cache.shape[2], k_for_cache.shape[3])
+                )
+                v_b = ttnn.slice(
+                    v_for_cache, (b, 0, 0, 0), (b + 1, v_for_cache.shape[1], v_for_cache.shape[2], v_for_cache.shape[3])
+                )
+                ttnn.fill_cache(k_cache, k_b, batch_idx=user_id + b)
+                ttnn.fill_cache(v_cache, v_b, batch_idx=user_id + b)
+                k_b.deallocate(True)
+                v_b.deallocate(True)
+        else:
+            ttnn.fill_cache(k_cache, k_for_cache, batch_idx=user_id)
+            ttnn.fill_cache(v_cache, v_for_cache, batch_idx=user_id)
+        k_for_cache.deallocate(True)
+        v_for_cache.deallocate(True)
+
+    # --- Attention core ---
+    if config.sequence_parallel and mesh_config.sp > 1:
+        # PLACEHOLDER (SP>1): AllGather K/V to the full sequence, then single-chip SDPA. BROKEN as-is —
+        # Q stays the local SP shard while K spans the full seq, so is_causal SDPA has no per-rank
+        # position offset and the causal mask is wrong for rank>0. Not exercised by the single-chip PCC
+        # test; replaced by the native ring SDPA (sinks+sliding+halo CCL) at P6 — validate before SP>1 use.
+        tt_k_full = mesh_config.allgather(tt_k, ccl_manager, axis=mesh_config.sp_axis, dim=2)
+        tt_v_full = mesh_config.allgather(tt_v, ccl_manager, axis=mesh_config.sp_axis, dim=2)
+        tt_k.deallocate(True)
+        tt_v.deallocate(True)
+        tt_k, tt_v = tt_k_full, tt_v_full
+        tt_sdpa_out = _run_sdpa(tt_q, tt_k, tt_v, weights, config, program_config, mesh_device, seq_len)
+    else:
+        tt_sdpa_out = _run_sdpa(tt_q, tt_k, tt_v, weights, config, program_config, mesh_device, seq_len)
+
+    tt_q.deallocate(True)
+    tt_k.deallocate(True)
+    tt_v.deallocate(True)
+
+    # Concat heads back to (local) hidden dim
+    tt_sdpa_out_pre_concat = tt_sdpa_out
+    tt_sdpa_out = concat_heads(tt_sdpa_out)
+    tt_sdpa_out_pre_concat.deallocate(True)
+
+    # Flatten back for output projection: [B, 1, S, H] -> [1, 1, B*S, H]
+    if batch_size > 1:
+        tt_sdpa_out = ttnn.reshape(tt_sdpa_out, [1, 1, total_seq_len, -1])
+
+    # o_proj (+bias) + TP reduce. TP>1 on Ring (and a supported shape) uses fused matmul+reduce-scatter
+    # (then all-gather + slice off padding); else plain o_proj + all-reduce. Fused MM+RS is gated off
+    # on Blackhole (see is_shape_fused_mm_rs_supported).
+    use_fused_rs = (
+        mesh_config.tp > 1
+        and is_shape_fused_mm_rs_supported(tt_sdpa_out)
+        and ccl_manager.topology == ttnn.Topology.Ring
+    )
+    if use_fused_rs:
+        rs_out = apply_output_projection_fused_rs(tt_sdpa_out, weights, mesh_config, ccl_manager)
+        tt_sdpa_out.deallocate(True)
+        tt_out_result = apply_allgather_and_slice(rs_out, mesh_config, ccl_manager, hidden_size)
+    else:
+        tt_out = apply_output_projection(tt_sdpa_out, weights, activation_dtype)
+        tt_sdpa_out.deallocate(True)
+        tt_out_result = apply_allreduce(tt_out, mesh_config, ccl_manager, hidden_size)
+    return tt_out_result

--- a/models/demos/gpt_oss_d_p/tt/attention/weights.py
+++ b/models/demos/gpt_oss_d_p/tt/attention/weights.py
@@ -1,0 +1,209 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+GPT-OSS attention weight loading: fused TP-sharded QKV weight+bias, tile-aligned o_proj
+weight+bias, and the learned per-head attention sinks pre-divided by ``config.scaling``.
+No QK-norm and no MSA index branch, so only these tensors are stored.
+"""
+
+from dataclasses import dataclass
+
+import torch
+
+import ttnn
+from models.demos.gpt_oss_d_p.tt.config import MeshConfig
+from models.demos.gpt_oss_d_p.utils.general_utils import get_cache_file_name
+from models.demos.gpt_oss_d_p.utils.substate import substate
+
+from .config import AttentionConfig
+
+
+@dataclass(frozen=True)
+class AttentionWeights:
+    """Container for attention weight tensors - immutable after creation.
+
+    GPT-OSS carries q/k/v/o projection biases (``attention_bias: true``) and a learned per-Q-head
+    attention sink. ``sinks`` is stored PRE-DIVIDED by ``config.scaling`` (see the loader) so the
+    SDPA kernel's internal scaling of the sink logit reproduces HF.
+    """
+
+    wqkv: ttnn.Tensor
+    wqkv_bias: ttnn.Tensor
+    o_proj: ttnn.Tensor
+    o_proj_bias: ttnn.Tensor
+    sinks: ttnn.Tensor
+
+
+def load_attention_weights(
+    mesh_device,
+    config: AttentionConfig,
+    state_dict,
+    mesh_config: MeshConfig,
+    weight_dtype=ttnn.bfloat8_b,
+    bias_dtype=ttnn.bfloat16,
+    tensor_cache_path=None,
+) -> AttentionWeights:
+    """
+    Load and shard attention weights.
+
+    Args:
+        mesh_device: TTNN mesh device
+        config: Attention configuration
+        state_dict: State dictionary containing weights (q_proj/k_proj/v_proj/o_proj {weight,bias}
+            and the top-level ``sinks``). Empty dict -> cache-only load.
+        mesh_config: Mesh parallelization config
+        weight_dtype: Data type for weights (default: bfloat8_b)
+        bias_dtype: Data type for biases (default: bfloat16)
+        tensor_cache_path: Optional path for weight caching
+
+    Returns:
+        AttentionWeights container with all loaded weights
+    """
+
+    # o_proj padding (config/mesh-derived). local_hidden = hidden_size/TP may not be tile-aligned
+    # (2880/8 = 360), forcing CCL Untilize->Pad->Tilize; pad to a tile boundary to avoid it.
+    hidden_size = config.hidden_size
+    local_hidden = hidden_size // mesh_config.tp
+    padded_local_hidden = ((local_hidden + 31) // 32) * 32  # Round up to tile boundary
+    o_proj_pad_size = padded_local_hidden - local_hidden
+    o_proj_cache_suffix = f"_padded" if o_proj_pad_size > 0 and mesh_config.tp > 1 else ""
+
+    if state_dict:
+        # Extract projection weights from state dict
+        q_proj_weight = substate(state_dict, "q_proj")["weight"]  # [num_heads * head_dim, hidden_size]
+        k_proj_weight = substate(state_dict, "k_proj")["weight"]  # [num_kv_heads * head_dim, hidden_size]
+        v_proj_weight = substate(state_dict, "v_proj")["weight"]  # [num_kv_heads * head_dim, hidden_size]
+
+        o_proj = substate(state_dict, "o_proj")["weight"].transpose(-1, -2)
+        o_proj_bias = substate(state_dict, "o_proj")["bias"]
+
+        # Create fused QKV weight.
+        # Split Q, K, V across devices, then concatenate per device.
+        qkv_list = []
+        for i in range(mesh_config.tp):
+            # Chunk weights across tensor parallel dimension
+            wq_selected = torch.chunk(q_proj_weight, mesh_config.tp, dim=0)[i]
+            wk_selected = torch.chunk(k_proj_weight, mesh_config.tp, dim=0)[i]
+            wv_selected = torch.chunk(v_proj_weight, mesh_config.tp, dim=0)[i]
+
+            # Transpose for matmul: [hidden_size, local_dim]
+            wq = wq_selected.transpose(-2, -1)
+            wk = wk_selected.transpose(-2, -1)
+            wv = wv_selected.transpose(-2, -1)
+
+            # Concatenate Q, K, V: [hidden_size, local_q_dim + local_k_dim + local_v_dim]
+            qkv = torch.cat([wq, wk, wv], dim=-1)
+            qkv_list.append(qkv)
+
+        # Concatenate across devices: [1, 1, hidden_size, total_qkv_dim]
+        qkv_cat = torch.cat(qkv_list, dim=-1).unsqueeze(0).unsqueeze(0)
+
+        # Handle biases - create fused QKV bias (same per-device Q|K|V concat as the weights)
+        q_proj_bias = substate(state_dict, "q_proj")["bias"]
+        k_proj_bias = substate(state_dict, "k_proj")["bias"]
+        v_proj_bias = substate(state_dict, "v_proj")["bias"]
+
+        qkv_bias_list = []
+        for i in range(mesh_config.tp):
+            q_bias_selected = torch.chunk(q_proj_bias, mesh_config.tp, dim=0)[i]
+            k_bias_selected = torch.chunk(k_proj_bias, mesh_config.tp, dim=0)[i]
+            v_bias_selected = torch.chunk(v_proj_bias, mesh_config.tp, dim=0)[i]
+            qkv_bias = torch.cat([q_bias_selected, k_bias_selected, v_bias_selected], dim=-1)
+            qkv_bias_list.append(qkv_bias)
+
+        qkv_bias_cat = torch.cat(qkv_bias_list, dim=-1)  # [total_qkv_dim]
+
+        # Attention sinks. The SDPA kernel applies `scale` to the sink logit too, but HF does not
+        # scale sinks — so store sink/scale; the kernel's ×scale then recovers the raw HF value.
+        sinks = state_dict["sinks"].reshape(1, config.num_heads, 1, 1)
+        sinks_for_sdpa = sinks / config.scaling
+
+        # Pad o_proj output dimension for tile alignment in CCL operations.
+        if o_proj_pad_size > 0 and mesh_config.tp > 1:
+            # Pad the output dimension of o_proj weight: [input_dim, hidden_size] -> [input_dim, padded_hidden]
+            padded_hidden = padded_local_hidden * mesh_config.tp
+            o_proj = torch.nn.functional.pad(o_proj, (0, padded_hidden - hidden_size), "constant", value=0.0)
+            # Pad bias similarly
+            o_proj_bias = torch.nn.functional.pad(o_proj_bias, (0, padded_hidden - hidden_size), "constant", value=0.0)
+
+        if mesh_config.tp > 1:
+            # o_proj is row-parallel (K sharded across TP); replicate the bias to the first shard only
+            # so the post-allreduce sum adds the full bias exactly once.
+            o_proj_bias = torch.cat([o_proj_bias] + [torch.zeros_like(o_proj_bias)] * (mesh_config.tp - 1), dim=-1)
+
+    else:
+        # Cache-only loading (empty state_dict): pass None for every torch weight so ttnn.as_tensor
+        # loads each tilized tensor from disk.
+        qkv_cat = None
+        qkv_bias_cat = None
+        o_proj = None
+        o_proj_bias = None
+        sinks_for_sdpa = None
+
+    # Clean mesh mapping using MeshConfig
+    col_mesh_mapper = mesh_config.column_parallel(mesh_device)
+    row_mesh_mapper = mesh_config.row_parallel(mesh_device)
+
+    # Load QKV weight (column-parallel: heads sharded on the output/feature dim across TP)
+    wqkv = ttnn.as_tensor(
+        qkv_cat,
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=weight_dtype,
+        mesh_mapper=col_mesh_mapper,
+        cache_file_name=get_cache_file_name(tensor_cache_path, "wqkv"),
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    wqkv_bias = ttnn.as_tensor(
+        qkv_bias_cat,
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=bias_dtype,
+        mesh_mapper=col_mesh_mapper,
+        cache_file_name=get_cache_file_name(tensor_cache_path, "wqkv_bias"),
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    # o_proj is row-parallel (input/contraction dim sharded across TP)
+    o_proj_tt = ttnn.as_tensor(
+        o_proj,
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=weight_dtype,
+        mesh_mapper=row_mesh_mapper,
+        cache_file_name=get_cache_file_name(tensor_cache_path, f"o_proj{o_proj_cache_suffix}"),
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    o_proj_bias_tt = ttnn.as_tensor(
+        o_proj_bias,
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=bias_dtype,
+        mesh_mapper=col_mesh_mapper,
+        cache_file_name=get_cache_file_name(tensor_cache_path, f"o_proj_bias{o_proj_cache_suffix}"),
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    # Attention sinks: [1, num_heads, 1, 1], sharded head-wise across TP (dim -3) so each chip
+    # holds the sinks for exactly the Q-heads it computes. Pre-divided by config.scaling (see above).
+    sinks_tt = ttnn.as_tensor(
+        sinks_for_sdpa,
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=bias_dtype,
+        mesh_mapper=mesh_config.sequence_parallel(mesh_device),
+        # Cache key notes the pre-division by `config.scaling`.
+        cache_file_name=get_cache_file_name(tensor_cache_path, "sinks_div_scale"),
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    return AttentionWeights(
+        wqkv=wqkv,
+        wqkv_bias=wqkv_bias,
+        o_proj=o_proj_tt,
+        o_proj_bias=o_proj_bias_tt,
+        sinks=sinks_tt,
+    )

--- a/models/demos/gpt_oss_d_p/tt/config.py
+++ b/models/demos/gpt_oss_d_p/tt/config.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""MeshConfig — prefill mesh parallelization for GPT-OSS-120B.
+
+TP shards features on one axis (default cols); the other axis (rows) carries SP prefill (SP = #rows)
++ the EP MoE — both derived from mesh shape + tp_axis, so TP is the only knob. Target: 4x8 Blackhole
+Galaxy, TP=8 (64 Q / 8 KV heads across 8 cols), SP=4 (sequence across 4 rows)."""
+
+from loguru import logger
+
+import ttnn
+
+# The single configuration targeted on hardware (Blackhole Galaxy): (4,8), TP=8 -> SP=4, EP=32.
+_VALIDATED_MESH_SHAPE = (4, 8)
+_VALIDATED_TP = 8
+
+
+class MeshConfig:
+    """Prefill mesh parallelization. TP is the only knob; SP/EP follow from the mesh shape."""
+
+    def __init__(self, mesh_shape, tp, tp_axis: int = 1):
+        """
+        Args:
+            mesh_shape: (rows, cols) - any mesh size
+            tp: tensor-parallel size (shards features along tp_axis)
+            tp_axis: which mesh axis is TP (0=rows, 1=cols, default: 1). The other axis
+                carries sequence-parallel prefill (SP = size of that axis) and the EP MoE.
+        """
+        self.mesh_shape = tuple(mesh_shape)
+        self.tp = tp
+        self.tp_axis = tp_axis
+        self.ep_axis = 0 if tp_axis == 1 else 1
+        self.sp_axis = self.ep_axis
+        self.total_devices = self.mesh_shape[0] * self.mesh_shape[1]
+        self._validate()
+
+    def _validate(self):
+        tp_dim_size = self.mesh_shape[self.tp_axis]
+        # shard_mapper always shards a tensor across the ENTIRE tp_axis, so TP must span the whole
+        # axis. A smaller TP would build head/feature counts from `tp` while the mapper still splits
+        # across all `tp_dim_size` devices, giving inconsistent per-device shapes. Require equality
+        # until sub-axis (subgroup) mapping is implemented.
+        if self.tp != tp_dim_size:
+            raise ValueError(
+                f"TP({self.tp}) must equal mesh_{self.tp_axis}_size({tp_dim_size}); "
+                f"sub-axis TP is unsupported (shard_mapper shards the full axis)."
+            )
+        if (self.mesh_shape, self.tp) != (_VALIDATED_MESH_SHAPE, _VALIDATED_TP):
+            logger.warning(
+                f"MeshConfig(mesh_shape={self.mesh_shape}, tp={self.tp}) is untested; only "
+                f"mesh_shape={_VALIDATED_MESH_SHAPE}, tp={_VALIDATED_TP} (SP=4, EP=32) is the GPT-OSS target."
+            )
+
+    @property
+    def sp(self) -> int:
+        """Sequence-parallel degree (size of the non-TP axis)."""
+        return self.mesh_shape[self.sp_axis]
+
+    def shard_mapper(self, mesh_device, tensor_dim=None, mesh_dims=None):
+        """Unified 2D sharding - replaces all individual mappers"""
+        if mesh_dims is None:
+            # Default: shard along TP axis only
+            mesh_dims = (None, tensor_dim) if self.tp_axis == 1 else (tensor_dim, None)
+
+        return ttnn.ShardTensor2dMesh(mesh_device, mesh_device.shape, dims=mesh_dims)
+
+    # Clean semantic helpers (all use unified shard_mapper)
+    def column_parallel(self, mesh_device):
+        """Column-parallel weights (feature dimension sharding)"""
+        return self.shard_mapper(mesh_device, tensor_dim=-1)
+
+    def row_parallel(self, mesh_device):
+        """Row-parallel weights (sequence/batch dimension sharding)"""
+        return self.shard_mapper(mesh_device, tensor_dim=-2)
+
+    def sequence_parallel(self, mesh_device):
+        """Sequence sharding (for KV cache); also used to shard the per-head attention sinks."""
+        return self.shard_mapper(mesh_device, tensor_dim=-3)
+
+    def shard_size(self, total_size):
+        """Size per device for tensor parallel sharding"""
+        return total_size // self.tp
+
+    def allreduce(self, tensor, ccl_manager, memory_config=None, pad_size=None, axis=0):
+        """
+        General tensor parallel allreduce (reduce-scatter + all-gather)
+
+        Note: Caller should check if communication is needed before calling
+        """
+        memory_config = memory_config or ttnn.DRAM_MEMORY_CONFIG
+
+        # Optional performance padding (caller specifies, no magic numbers)
+        padded = False
+        if pad_size and tensor.shape[-2] >= 32:
+            tensor_padded = ttnn.pad(tensor, [(0, 0), (0, 0), (0, 0), (0, pad_size)], 0)
+            tensor.deallocate(True)
+            tensor = tensor_padded
+            padded = True
+
+        # Reduce-scatter along TP axis
+        scattered = ttnn.experimental.reduce_scatter_minimal_async(
+            tensor,
+            dim=3,
+            multi_device_global_semaphore=ccl_manager.get_rs_ping_pong_semaphore(),
+            num_links=ccl_manager.num_links,
+            memory_config=memory_config,
+            topology=ccl_manager.topology,
+            cluster_axis=axis,
+            barrier_semaphore=ccl_manager.get_barrier_semaphore(),
+        )
+        # Free the full-size input before the all-gather allocates its full-size output,
+        # to keep peak live DRAM bounded under long-context prefill. Callers must NOT use
+        # `tensor` after this returns (apply_allreduce assigns the return value).
+        tensor.deallocate(True)
+
+        # All-gather back
+        gathered = ttnn.experimental.all_gather_async(
+            scattered,
+            dim=3,
+            cluster_axis=axis,
+            mesh_device=ccl_manager.mesh_device,
+            topology=ccl_manager.topology,
+            multi_device_global_semaphore=ccl_manager.get_ag_ping_pong_semaphore(),
+            num_links=ccl_manager.num_links,
+            memory_config=memory_config,
+            barrier_semaphore=ccl_manager.get_barrier_semaphore(),
+        )
+        scattered.deallocate(True)
+
+        # Remove padding if applied
+        if padded:
+            gathered_sliced = gathered[:, :, :, :-pad_size]
+            gathered.deallocate(True)
+            gathered = gathered_sliced
+        return gathered
+
+    def allgather(self, tensor, ccl_manager, memory_config=None, axis=0, dim=3, linear=False):
+        """
+        All-gather operation for tensor parallel / sequence parallel communication
+
+        Note: Caller should check if communication is needed before calling
+        """
+        memory_config = memory_config or ttnn.DRAM_MEMORY_CONFIG
+
+        return ttnn.experimental.all_gather_async(
+            tensor,
+            dim=dim,
+            cluster_axis=axis,
+            mesh_device=ccl_manager.mesh_device,
+            topology=ttnn.Topology.Linear if linear else ccl_manager.topology,
+            multi_device_global_semaphore=ccl_manager.get_ag_ping_pong_semaphore(),
+            num_links=ccl_manager.num_links,
+            memory_config=memory_config,
+            barrier_semaphore=ccl_manager.get_barrier_semaphore(),
+        )
+
+    def __repr__(self):
+        return f"MeshConfig({self.mesh_shape}, tp={self.tp}, sp={self.sp}, tp_axis={self.tp_axis})"

--- a/models/demos/gpt_oss_d_p/utils/__init__.py
+++ b/models/demos/gpt_oss_d_p/utils/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0

--- a/models/demos/gpt_oss_d_p/utils/general_utils.py
+++ b/models/demos/gpt_oss_d_p/utils/general_utils.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+General utilities for GPT-OSS (d_p).
+"""
+
+from models.common.utility_functions import is_blackhole
+
+
+def get_cache_file_name(tensor_cache_path, name):
+    return f"{tensor_cache_path}/{name}" if tensor_cache_path else None
+
+
+def cache_file_exists(cache_file_name):
+    """True iff a tilized tensor cache file for `cache_file_name` exists on disk. ttnn appends a
+    `_dtype_<DT>_layout_<L>.tensorbin` suffix, so match by prefix. Used to decide whether to load an
+    OPTIONAL weight from cache when the source state_dict is absent (cache-only loading) — its
+    presence can't be known from an empty state_dict."""
+    if not cache_file_name:
+        return False
+    import glob
+
+    return bool(glob.glob(f"{cache_file_name}*.tensorbin"))
+
+
+def get_default_num_links(mesh_device):
+    """Default number of fabric links for CCL ops on the given mesh.
+
+    Blackhole exposes 2 fabric links per device; Wormhole exposes 4. Single-row meshes
+    (shape[0] == 1) only need 1 link regardless of arch.
+    """
+    if mesh_device.shape[0] == 1:
+        return 1
+    return 2 if is_blackhole() else 4

--- a/models/demos/gpt_oss_d_p/utils/substate.py
+++ b/models/demos/gpt_oss_d_p/utils/substate.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helpers to extract sub-dicts from nested state dicts (layer/weight loading)."""
+
+from __future__ import annotations
+
+import itertools
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import torch
+
+
+def substate(state: dict[str, torch.Tensor], key: str) -> dict[str, torch.Tensor]:
+    """
+    Extract a sub-dictionary from a state dict based on a key prefix.
+
+    Args:
+        state: The source state dictionary
+        key: The prefix key to filter by (e.g., "q_proj" to get all "q_proj.*" entries)
+
+    Returns:
+        A dictionary with the prefix removed from keys
+
+    Example:
+        >>> state = {"q_proj.weight": tensor1, "q_proj.bias": tensor2, "k_proj.weight": tensor3}
+        >>> substate(state, "q_proj")
+        {"weight": tensor1, "bias": tensor2}
+    """
+    prefix = f"{key}."
+    prefix_len = len(prefix)
+
+    return {k[prefix_len:]: v for k, v in state.items() if k.startswith(prefix)}
+
+
+def has_substate(state: dict[str, torch.Tensor], key: str) -> bool:
+    """
+    Check if a state dict contains any keys with the given prefix.
+
+    Args:
+        state: The state dictionary to check
+        key: The prefix to look for
+
+    Returns:
+        True if any key starts with "{key}.", False otherwise
+    """
+    prefix = f"{key}."
+
+    return any(k.startswith(prefix) for k in state)
+
+
+def indexed_substates(state: dict[str, torch.Tensor], key: str) -> list[dict[str, torch.Tensor]]:
+    """
+    Extract a list of indexed sub-states (e.g., "layer.0", "layer.1", ...).
+
+    Args:
+        state: The source state dictionary
+        key: The base prefix (e.g., "layer" to get "layer.0", "layer.1", etc.)
+
+    Returns:
+        A list of sub-state dictionaries, one for each indexed entry
+
+    Example:
+        >>> state = {"layer.0.weight": t1, "layer.0.bias": t2, "layer.1.weight": t3}
+        >>> indexed_substates(state, "layer")
+        [{"weight": t1, "bias": t2}, {"weight": t3}]
+    """
+    result = []
+    for i in itertools.count():
+        s = substate(state, f"{key}.{i}")
+        if not s:
+            return result
+        result.append(s)

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -603,6 +603,25 @@
   owner_id: U08TJ70UFRT # Harry Andrews
   team: models
 
+- name: GPT-OSS-120B (disaggregated prefill) unit tests
+  # Single-card PCC units for the gpt_oss_d_p prefill package (standalone: random weights +
+  # a self-contained torch reference, no HF_MODEL). Directory glob so the kv-cache / MoE tests
+  # auto-run as they land in the stacked PRs. Multi-device / EP=32 galaxy coverage is added
+  # separately (blackhole_e2e / galaxy job) once those tests exist.
+  cmd: |
+    pytest --timeout 600 models/demos/gpt_oss_d_p/tests/unit/
+  # Same model as the decode/tt-transformers "GPT-OSS 120B" entry above (prefill + decode + specdecode
+  # are one model); this is just the d_p prefill package's single-card slice. Not a separate model.
+  model: gpt-oss-120b
+  skus:
+    # Blackhole (single card; tests are pinned to a 1x1 mesh)
+    bh_p150:
+      # Suite runs in seconds; 5 min covers cold kernel compile. Keeps team/SKU under time_budget.
+      timeout: 5
+      tier: 2
+  owner_id: U08HM8SL5U4 # Maciek Dragula
+  team: models
+
 - name: Whisper unit tests
   cmd: |
     export TT_METAL_WATCHER=30


### PR DESCRIPTION
## Problem
GPT-OSS-120B needs a long-context **prefill** on Blackhole Galaxy (TP=8/SP=4/EP=32). The existing `models/demos/gpt_oss` is Wormhole/decode-first and isn't structured to reuse the DeepSeek/MiniMax-M3 prefill stack (EP-MoE dispatch/combine, chunked block-cyclic KV, the `common/prefill` engine).

## Context
First PR of a **stacked chain** that builds a fresh `gpt_oss_d_p` package "the MiniMax-M3 way." This PR is **package scaffold + attention only** — no MoE / KV cache / runtime yet.

Chain: **#50223 (this)** → #50228 (chunked KV+RoPE) → #50254 (MoE) → #50265 (model+runtime+adapter).

## Solution
| Piece | What |
|---|---|
| Package | new `gpt_oss_d_p/`, mirrors `minimax_m3/` layout |
| Attention | GQA (64 Q / 8 KV heads, `head_dim=64`) + full YaRN RoPE + per-Q-head attention sinks + per-layer sliding(128)/full alternation |
| Sinks | stored pre-divided by the softmax scale so the SDPA kernel's internal scaling reproduces HF |
| Multi-device | `MeshConfig`: TP shards KV-heads (1/col), SP shards the sequence. SP>1 uses a **correctness-first AllGather + single-chip SDPA stand-in** (efficient ring-SDPA swaps in later; the stand-in is documented as SP-placeholder and not yet SP-validated) |

## Tests
`tests/unit/test_attention_vs_ref.py` — GQA + sinks + sliding vs a torch reference on a single Blackhole card, both a sliding and a full layer, PCC ≥ 0.99. **2 passed.**

## Next (later PRs in the chain)
Chunked KV+RoPE (#50228) → MoE wrapper (#50254) → model/runtime/adapter (#50265). The AllGather SP stand-in is replaced by the native ring SDPA (sinks + sliding + halo CCL) for efficient sequence-parallel attention.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mdragula/gpt-oss-attention)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mdragula/gpt-oss-attention)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mdragula/gpt-oss-attention)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mdragula/gpt-oss-attention)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mdragula/gpt-oss-attention)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mdragula/gpt-oss-attention)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mdragula/gpt-oss-attention)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mdragula/gpt-oss-attention)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mdragula/gpt-oss-attention)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mdragula/gpt-oss-attention)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mdragula/gpt-oss-attention)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mdragula/gpt-oss-attention)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mdragula/gpt-oss-attention)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mdragula/gpt-oss-attention)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mdragula/gpt-oss-attention)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mdragula/gpt-oss-attention)
### CI Notes
The red **Sanity tests** badge above is from a test unrelated to this PR, which adds only a new model
package (`gpt_oss_d_p`) with no ttnn ops or kernels:

- **Sanity tests**: `test_dram_group_norm_vae_welford_reciprocal_performance`, an SDXL VAE group-norm
  performance test on Wormhole that trips its +/-1.5% perf-tolerance window (it measured *faster* than
  the baseline). Flaky on `main`, independent of this branch.

This PR's own coverage is green: the attention unit test passes via the scoped `all-model-tests` run
(`Model[gpt-oss-120b] SKUs[bh_p150]`); **PR Gate** and **Blackhole sanity** are green.
