### PR TITLE
[gpt_oss_d_p] GPT-OSS prefill: chunked KV cache + indexed RoPE

### DIFF
--- a/models/demos/gpt_oss_d_p/tests/unit/test_indexed_rope_vs_ref.py
+++ b/models/demos/gpt_oss_d_p/tests/unit/test_indexed_rope_vs_ref.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+GPT-OSS indexed-RoPE device test. Validates that gpt_oss_d_p's ``build_indexed_rope`` (whole-cache,
+block-cyclic, SP-sharded YaRN cos/sin, truncate=False) + the indexed ``apply_rope`` path apply the
+SAME rotation at a nonzero tile-aligned offset as the plain non-indexed op (``rotary_embedding_llama``,
+which test_attention_vs_ref validates against the HF reference at offset 0) does at the corresponding
+absolute positions.
+
+The raw ``rotary_embedding_indexed`` op is exercised thoroughly in
+``deepseek_v3_d_p/tests/op_unit_tests/test_deepseek_prefill_rotary_embedding_indexed.py``; this test
+covers the gpt-oss-specific glue (YaRN table build + block-cyclic assembly + the offset dispatch)
+that the attention reference test (offset 0, non-indexed) does not.
+"""
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import comp_pcc
+from models.demos.gpt_oss_d_p.tt.attention.operations import apply_rope
+from models.demos.gpt_oss_d_p.tt.rope import build_indexed_rope, build_transformation_mat, build_yarn_cos_sin
+
+HEAD_DIM = 64
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
+@pytest.mark.parametrize("n_heads", [8], ids=["h8"])
+@pytest.mark.parametrize("chunk, offset", [(128, 128)], ids=["c128-off128"])
+def test_indexed_rope_matches_nonindexed_at_offset(mesh_device, n_heads, chunk, offset, reset_seeds):
+    """Indexed RoPE at ``kv_actual_global=offset`` == non-indexed RoPE with cos/sin sliced to
+    ``[offset, offset+chunk)``. Single card (sp=1): block-cyclic degenerates to identity, so this
+    isolates the YaRN-table + indexed-offset-dispatch correctness (block-cyclic layout is covered
+    separately by the pure-torch inverse test)."""
+    rows, cols = tuple(mesh_device.shape)
+    sp_axis, tp_axis = 0, 1
+    sp = rows
+    assert offset % (ttnn.TILE_SIZE * sp) == 0 and chunk % (ttnn.TILE_SIZE * sp) == 0
+    max_seq_len = offset + chunk  # cache big enough to hold the prefix + this chunk
+
+    torch.manual_seed(0)
+    q = torch.randn(1, n_heads, chunk, HEAD_DIM)  # this chunk's Q (tokens at global [offset, offset+chunk))
+
+    xform = build_transformation_mat(mesh_device)
+
+    q_dims = [None, None]
+    q_dims[sp_axis] = 2  # seq on SP rows
+    q_dims[tp_axis] = 1  # heads on TP cols
+
+    def to_dev(t, shard_seq):
+        dims = [None, None]
+        if shard_seq:
+            dims[sp_axis] = 2
+        mapper = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=(rows, cols), dims=tuple(dims))
+        return ttnn.from_torch(
+            t,
+            device=mesh_device,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=mapper,
+        )
+
+    def q_to_dev():
+        return ttnn.from_torch(
+            q,
+            device=mesh_device,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=(rows, cols), dims=tuple(q_dims)),
+        )
+
+    # --- indexed path: whole-cache block-cyclic cos/sin + rotary_embedding_indexed at the offset ---
+    idx_cos_sin = build_indexed_rope(
+        mesh_device, head_dim=HEAD_DIM, max_seq_len=max_seq_len, chunk_size=chunk, sp_axis=sp_axis
+    )
+    out_idx = apply_rope(q_to_dev(), idx_cos_sin, xform, kv_actual_global=offset, cluster_axis=sp_axis)
+    idx_host = ttnn.to_torch(ttnn.get_device_tensors(out_idx)[0]).float()[:, :n_heads]
+
+    # --- non-indexed reference: same YaRN cos/sin, sliced to [offset, offset+chunk) ---
+    cos, sin = build_yarn_cos_sin(max_seq_len, HEAD_DIM)  # [1, 1, max_seq_len, head_dim]
+    cos_sl = to_dev(cos[:, :, offset : offset + chunk, :], shard_seq=True)
+    sin_sl = to_dev(sin[:, :, offset : offset + chunk, :], shard_seq=True)
+    out_ref = apply_rope(q_to_dev(), [cos_sl, sin_sl], xform)  # kv_actual_global=None -> non-indexed
+    ref_host = ttnn.to_torch(ttnn.get_device_tensors(out_ref)[0]).float()[:, :n_heads]
+
+    ok, pcc = comp_pcc(ref_host, idx_host, 0.99)
+    logger.info(f"indexed vs non-indexed RoPE @ offset={offset}: pcc={pcc}")
+    assert ok, f"indexed RoPE at offset {offset} disagrees with the non-indexed reference: {pcc}"

--- a/models/demos/gpt_oss_d_p/tests/unit/test_kv_cache_vs_ref.py
+++ b/models/demos/gpt_oss_d_p/tests/unit/test_kv_cache_vs_ref.py
@@ -141,3 +141,69 @@ def test_blockcyclic_reorder_positions_inverse():
     recovered[p] = reordered
     assert torch.equal(recovered, nat), "block-cyclic scatter/gather did not round-trip to natural order"
     logger.info(f"block-cyclic reorder/positions inverse OK (sp={sp}, seq_len={seq_len})")
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
+@pytest.mark.parametrize("chunk, n_chunks", [(128, 3)], ids=["c128x3"])
+def test_kv_cache_multichunk_write_vs_ref(mesh_device, chunk, n_chunks, reset_seeds):
+    """Write N tile-aligned chunks at increasing ``kv_actual`` offsets (0, chunk, 2*chunk, ...) into a
+    multi-chunk cache and verify every position reads back in natural order.
+
+    Exercises ``update_padded_kv_cache``'s nonzero-``kv_actual`` chunk placement — the round-trip test
+    above only writes ``kv_actual=0`` (one chunk == whole cache), so this is the only coverage of the
+    chunk-offset write."""
+    rows, cols = tuple(mesh_device.shape)
+    sp, tp = rows, cols
+    sp_axis, tp_axis = 0, 1
+    nkv = tp
+    assert chunk % (32 * sp) == 0, f"chunk {chunk} must be a multiple of 32*sp ({32 * sp})"
+    max_seq_len = chunk * n_chunks
+
+    torch.manual_seed(0)
+    sent_k = torch.randn(nkv, max_seq_len, HEAD_DIM)  # natural-order K/V over the whole cache
+    sent_v = torch.randn(nkv, max_seq_len, HEAD_DIM)
+
+    kv_cache = allocate_kv_cache(
+        mesh_device, num_layers=1, max_seq_len=max_seq_len, sp_axis=sp_axis, num_users=1, head_dim=HEAD_DIM
+    )
+
+    in_dims = [None, None]
+    in_dims[sp_axis] = 2
+    in_dims[tp_axis] = 1
+
+    def to_chunk(nat):  # [nkv, chunk, HD] -> device [1, nkv, chunk, HD], SP+TP sharded
+        return ttnn.from_torch(
+            nat.reshape(1, nkv, chunk, HEAD_DIM),
+            device=mesh_device,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=(rows, cols), dims=in_dims),
+        )
+
+    for i in range(n_chunks):
+        lo = i * chunk  # kv_actual for this chunk: 0, chunk, 2*chunk (all tile-aligned)
+        tt_k = to_chunk(sent_k[:, lo : lo + chunk])
+        tt_v = to_chunk(sent_v[:, lo : lo + chunk])
+        write_kv_chunk(kv_cache, tt_k, tt_v, slot_idx=0, layer_idx=0, kv_actual=lo, sp_axis=sp_axis)
+        tt_k.deallocate(True)
+        tt_v.deallocate(True)
+    ttnn.synchronize_device(mesh_device)
+
+    # Read back the whole cache and invert the block-cyclic layout (per-chunk-global key = chunk).
+    p = blockcyclic_positions(sp, chunk, max_seq_len)
+
+    def gather(cache_tensor, col):
+        dts = ttnn.get_device_tensors(cache_tensor)
+        dev = torch.cat([ttnn.to_torch(dts[r * cols + col])[0, 0].float() for r in range(rows)], dim=0)
+        nat = torch.empty_like(dev)
+        nat[p] = dev
+        return nat[:max_seq_len]
+
+    host_k = torch.stack([gather(kv_cache.k, c) for c in range(nkv)], dim=0)
+    host_v = torch.stack([gather(kv_cache.v, c) for c in range(nkv)], dim=0)
+    ok_k, pcc_k = comp_pcc(sent_k, host_k, 0.99)
+    ok_v, pcc_v = comp_pcc(sent_v, host_v, 0.99)
+    logger.info(f"multi-chunk write ({n_chunks} x {chunk} tokens): K pcc={pcc_k} V pcc={pcc_v}")
+    assert ok_k, f"K multi-chunk mismatch: {pcc_k}"
+    assert ok_v, f"V multi-chunk mismatch: {pcc_v}"

--- a/models/demos/gpt_oss_d_p/tests/unit/test_kv_cache_vs_ref.py
+++ b/models/demos/gpt_oss_d_p/tests/unit/test_kv_cache_vs_ref.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+GPT-OSS GQA chunked-KV cache write + read-back PCC vs torch golden (round-trip + slot/layout).
+
+Allocates a small ``GptOssKVCache`` (a couple of users x layers), writes random natural-order K/V
+into each (user, layer) slot via the M3-style ``write_kv_chunk`` wrapper (which drives DeepSeek's
+``update_padded_kv_cache``), reads the caches back, inverts the block-cyclic SP layout to natural
+token order, and PCC-checks each slot against the torch tensor that was written.
+
+This validates: the two persistent DRAM NdShard caches, the user-major slot packing
+(slot = user_id * num_layers + layer_idx), the head-sharded (1 KV head / TP col) + SP-sharded
+sequence layout, and the bf8 round-trip. Threshold PCC >= 0.99.
+
+Single card (1x1 mesh): sp=1, tp=1 -> 1 KV head/chip, block-cyclic == identity (kv_actual=0, cache
+sized to the chunk), so readback is in natural order. The same code also exercises SP block-cyclic +
+TP head-sharding on a multi-row/col mesh (sp=rows, tp=cols, NKV=cols), if the parent runs it there.
+
+Run:
+    pytest models/demos/gpt_oss_d_p/tests/unit/test_kv_cache_vs_ref.py
+"""
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import comp_pcc
+from models.demos.deepseek_v3_d_p.tt.mla.utils import block_cyclic_reorder, blockcyclic_positions
+from models.demos.gpt_oss_d_p.tt.attention import allocate_kv_cache, write_kv_chunk
+
+HEAD_DIM = 64
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
+@pytest.mark.parametrize("num_users, num_layers", [(2, 2)], ids=["u2xl2"])
+@pytest.mark.parametrize("seq_len", [128], ids=["s128"])
+def test_kv_cache_write_read_vs_ref(mesh_device, num_users, num_layers, seq_len, reset_seeds):
+    """Write GQA K/V into each (user, layer) slot, read back, PCC vs natural-order torch."""
+    rows, cols = tuple(mesh_device.shape)
+    sp, tp = rows, cols
+    sp_axis, tp_axis = 0, 1  # matches gpt_oss_d_p MeshConfig (tp_axis=1 -> sp_axis=0)
+    nkv = tp  # 1 KV head per TP col (the cache's per-chip head slot is 1)
+
+    # Single chunk sized to the whole cache => block-cyclic layout is the identity (kv_actual=0).
+    assert seq_len % (32 * sp) == 0, f"seq_len {seq_len} must be a multiple of 32*sp ({32 * sp})"
+    max_seq_len = seq_len
+
+    torch.manual_seed(0)
+    # Natural-order per-(user, layer) K/V, one head per TP col: [num_users, num_layers, nkv, seq, HEAD_DIM].
+    sent_k = torch.randn(num_users, num_layers, nkv, seq_len, HEAD_DIM)
+    sent_v = torch.randn(num_users, num_layers, nkv, seq_len, HEAD_DIM)
+
+    kv_cache = allocate_kv_cache(
+        mesh_device,
+        num_layers=num_layers,
+        max_seq_len=max_seq_len,
+        sp_axis=sp_axis,
+        num_users=num_users,
+        head_dim=HEAD_DIM,
+    )
+
+    # Chunk input sharding: sequence on SP rows (dim 2), heads on TP cols (dim 1).
+    in_dims = [None, None]
+    in_dims[sp_axis] = 2
+    in_dims[tp_axis] = 1
+
+    def to_chunk(nat):  # nat: [nkv, seq, HEAD_DIM] -> device [1, nkv, seq, HEAD_DIM], SP+TP sharded
+        chunk = nat.reshape(1, nkv, seq_len, HEAD_DIM)
+        return ttnn.from_torch(
+            chunk,
+            device=mesh_device,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=(rows, cols), dims=in_dims),
+        )
+
+    for u in range(num_users):
+        for l in range(num_layers):
+            tt_k = to_chunk(sent_k[u, l])
+            tt_v = to_chunk(sent_v[u, l])
+            write_kv_chunk(kv_cache, tt_k, tt_v, slot_idx=u, layer_idx=l, kv_actual=0, sp_axis=sp_axis)
+            tt_k.deallocate(True)
+            tt_v.deallocate(True)
+    ttnn.synchronize_device(mesh_device)
+
+    # Read back: per chip the cache is [num_users*num_layers, 1, seq_local, HEAD_DIM]; KV head c on col
+    # c, seq (block-cyclic) split across SP rows. Concat rows -> invert block-cyclic -> natural order.
+    p = blockcyclic_positions(sp, seq_len, max_seq_len)  # global pos held by each block-cyclic shard row
+
+    def gather(cache_tensor, slot, col):
+        dts = ttnn.get_device_tensors(cache_tensor)
+        dev = torch.cat([ttnn.to_torch(dts[r * cols + col])[slot, 0].float() for r in range(rows)], dim=0)
+        nat = torch.empty_like(dev)
+        nat[p] = dev
+        return nat[:seq_len]  # [seq, HEAD_DIM]
+
+    for u in range(num_users):
+        for l in range(num_layers):
+            slot = u * num_layers + l
+            host_k = torch.stack([gather(kv_cache.k, slot, c) for c in range(nkv)], dim=0)  # [nkv, seq, HD]
+            host_v = torch.stack([gather(kv_cache.v, slot, c) for c in range(nkv)], dim=0)
+            ok_k, pcc_k = comp_pcc(sent_k[u, l], host_k, 0.99)
+            ok_v, pcc_v = comp_pcc(sent_v[u, l], host_v, 0.99)
+            logger.info(f"(user={u}, layer={l}) slot={slot}: K pcc={pcc_k} V pcc={pcc_v}")
+            assert ok_k, f"K cache mismatch (user={u}, layer={l}): {pcc_k}"
+            assert ok_v, f"V cache mismatch (user={u}, layer={l}): {pcc_v}"
+
+    logger.info(f"GQA chunked-KV cache round-trip ({num_users} users x {num_layers} layers): all slots PCC>=0.99")
+
+
+def test_blockcyclic_reorder_positions_inverse():
+    """Pure-torch (no device): ``block_cyclic_reorder`` (natural -> block-cyclic scatter) and
+    ``blockcyclic_positions`` (block-cyclic row -> global natural position) are exact inverses for sp>1.
+
+    The (1,1) device test above degenerates block-cyclic to the identity (sp=1), so this is the ONLY
+    coverage of the actual layout math that the SP-sharded cache write/read relies on. Runs anywhere
+    (CI single card included) since it never touches a device."""
+    sp = 4
+    chunk_local = ttnn.TILE_SIZE  # 32 — tile-aligned per-chip block
+    chunk_size_global = chunk_local * sp  # 128
+    seq_len = 3 * chunk_size_global  # 384 (a few global chunks, so the reorder is non-trivial)
+    dim = 8
+
+    # Row i carries value i, so each permuted row reveals which natural position it holds.
+    nat = torch.arange(seq_len).reshape(seq_len, 1).repeat(1, dim)
+    reordered = block_cyclic_reorder(nat, chunk_local, sp, seq_dim=0)
+    p = blockcyclic_positions(sp, chunk_size_global, seq_len)  # p[r] = natural pos held by block-cyclic row r
+
+    # p is a genuine permutation of [0, seq_len) and NON-identity (else sp>1 isn't actually exercised).
+    assert torch.equal(torch.sort(p).values, torch.arange(seq_len)), "blockcyclic_positions is not a permutation"
+    assert not torch.equal(p, torch.arange(seq_len)), "expected a non-identity block-cyclic reorder for sp>1"
+
+    # Core invariant: block-cyclic row r holds natural position p[r]  =>  reordered[r] == nat[p[r]] == p[r].
+    assert torch.equal(reordered[:, 0], p), "block_cyclic_reorder and blockcyclic_positions disagree"
+
+    # Full un-scatter (as the device test does: nat[p] = dev) recovers natural order.
+    recovered = torch.empty_like(nat)
+    recovered[p] = reordered
+    assert torch.equal(recovered, nat), "block-cyclic scatter/gather did not round-trip to natural order"
+    logger.info(f"block-cyclic reorder/positions inverse OK (sp={sp}, seq_len={seq_len})")

--- a/models/demos/gpt_oss_d_p/tt/attention/__init__.py
+++ b/models/demos/gpt_oss_d_p/tt/attention/__init__.py
@@ -10,10 +10,19 @@ import ttnn
 from models.demos.gpt_oss_d_p.tt.config import MeshConfig
 
 from .config import AttentionConfig, ProgramConfig
+from .kv_cache import GptOssKVCache, allocate_kv_cache, write_kv_chunk
 from .prefill import attention_forward
 from .weights import AttentionWeights, load_attention_weights
 
-__all__ = ["Attention", "AttentionConfig", "ProgramConfig", "AttentionWeights"]
+__all__ = [
+    "Attention",
+    "AttentionConfig",
+    "ProgramConfig",
+    "AttentionWeights",
+    "GptOssKVCache",
+    "allocate_kv_cache",
+    "write_kv_chunk",
+]
 
 
 class Attention:
@@ -99,17 +108,22 @@ class Attention:
         kv_cache=None,
         user_id=0,
         batch_size=1,
+        cached_len=0,
+        indexed_rope=False,
     ):
         """
         Prefill attention forward.
 
         Args:
             hidden_states: Input tensor [batch, seq_len, hidden_size]
-            rope_mats: Tuple/list of (cos, sin) matrices for RoPE (YaRN baked in)
+            rope_mats: Tuple/list of (cos, sin) matrices for RoPE (YaRN baked in). Whole-cache
+                block-cyclic SP cos/sin when ``indexed_rope`` is set (see tt/rope.build_indexed_rope).
             position_idx: Position indices (unused in prefill)
-            kv_cache: Optional [k_cache, v_cache] pair; may be None
+            kv_cache: Optional GptOssKVCache (packed K/V); may be None
             user_id: User/batch index; also the cache slot index (default: 0)
             batch_size: number of users packed on the sequence dim
+            cached_len: valid prefix already in the cache before this chunk (>0 -> cache-read path)
+            indexed_rope: use the on-device indexed RoPE (whole-cache block-cyclic SP cos/sin)
 
         Returns:
             Attention output [batch, seq_len, hidden_size]
@@ -131,4 +145,6 @@ class Attention:
             ccl_manager=self.ccl_manager,
             batch_size=batch_size,
             layer_idx=self.layer_idx,
+            cached_len=cached_len,
+            indexed_rope=indexed_rope,
         )

--- a/models/demos/gpt_oss_d_p/tt/attention/kv_cache.py
+++ b/models/demos/gpt_oss_d_p/tt/attention/kv_cache.py
@@ -140,6 +140,14 @@ def write_kv_chunk(kv_cache: GptOssKVCache, tt_k, tt_v, *, slot_idx, layer_idx, 
     cols, sequence SP-sharded on the ``sp_axis`` rows) — exactly the per-chip cache layout, so they write
     in place. ``kv_actual`` is the cumulative valid prefix before this chunk (0 for the first/only chunk).
     """
+    # One user per call: update_padded_kv_cache writes a single (slot_idx, layer_idx) and ignores the
+    # leading/batch dim, so a batched (batch>1) tt_k/tt_v would silently write only slot_idx and drop the
+    # rest. Require batch==1 and fail loud; batched multi-user prefill must loop this per user (slot_idx+b)
+    # at the call site. The scatter-to-slots write lands with the runtime multi-user path (P4).
+    assert tt_k.shape[0] == 1 and tt_v.shape[0] == 1, (
+        f"write_kv_chunk writes one user per call, but got leading (batch) dim "
+        f"k={tt_k.shape[0]}, v={tt_v.shape[0]}; loop over users (slot_idx + b) at the call site"
+    )
     # Fail loud on a bad slot/layer (would otherwise be a silent OOB write into another user's slot) and
     # on a misaligned chunk offset (the block-cyclic per-device write assumes a tile-aligned boundary).
     assert 0 <= slot_idx < kv_cache.num_users, f"slot_idx {slot_idx} out of range [0, {kv_cache.num_users})"

--- a/models/demos/gpt_oss_d_p/tt/attention/kv_cache.py
+++ b/models/demos/gpt_oss_d_p/tt/attention/kv_cache.py
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+GPT-OSS chunked-prefill KV cache. Mirrors ``minimax_m3/tt/attention/kv_cache.py`` but for GQA
+(not MLA): the cache holds head-sharded K and V (no MLA latent, no MSA ``index_k``).
+
+Layout is otherwise identical to M3 / DeepSeek: two persistent device caches, each per-chip shape
+``[num_users*num_layers, 1, seq_local, head_dim]`` (the DeepSeek chunked-KV NdShard DRAM layout),
+written by ``ttnn.experimental.deepseek_prefill.update_padded_kv_cache(slot_idx, layer_idx, ...)``.
+Under TP=cols each chip holds exactly ONE KV head (8 KV heads sharded on the 8 TP cols at write
+time); the sequence is SP-sharded block-cyclic on the ``sp`` rows.
+
+The batch dim is user-major: ``slot = user_id * num_layers + layer_idx`` so each user's layers stay
+contiguous, matching ``update_padded_kv_cache``'s ``slot_idx`` / ``layer_idx`` indexing.
+"""
+
+from dataclasses import dataclass
+
+import torch
+
+import ttnn
+from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK, get_num_dram_banks
+
+
+@dataclass
+class GptOssKVCache:
+    """Externally-owned, user-major packed prefill KV caches for the SP chunked-KV path.
+
+    Two persistent device caches, each per-chip shape ``[num_users*num_layers, 1, seq_local, head_dim]``:
+
+      * ``k``, ``v`` — GQA K/V. Under TP=cols each chip holds 1 KV head (heads sharded on the TP cols
+        at write time); the sequence is SP-sharded block-cyclic on the ``sp`` rows.
+
+    Unlike M3 there is NO ``index_k`` (gpt-oss has no sparse lightning indexer).
+    """
+
+    k: ttnn.Tensor
+    v: ttnn.Tensor
+    num_users: int
+    num_layers: int
+    max_seq_len: int
+    sp: int
+
+
+def allocate_kv_cache(
+    mesh_device,
+    *,
+    num_layers,
+    max_seq_len,
+    sp_axis=0,
+    num_users=1,
+    head_dim=64,
+    cache_dtype=ttnn.bfloat8_b,
+) -> GptOssKVCache:
+    """Allocate the two external prefill KV caches (K, V). See :class:`GptOssKVCache`.
+
+    Deliberately NOT ``init_kvpe_cache`` (that is MLA-specific and allocates a single latent cache):
+    this owns the GQA K/V pair and the user-major packing. It reuses the same DRAM NdShard spec (same
+    bank grid + 32-token contiguous shard) so ``update_padded_kv_cache`` can write into these tensors
+    unchanged.
+
+    Args:
+        num_layers: layers per user (full model = 36). All layers allocate K/V slots.
+        max_seq_len: per-user cache capacity in tokens, a multiple of ``TILE_SIZE * sp`` so ``seq_local =
+            max_seq_len // sp`` is tile-aligned (matches build_indexed_rope + the 32-token DRAM shard).
+        sp_axis: mesh axis the sequence is sharded over (rows).
+        num_users: independent user slots sharing the cache (1 for bring-up).
+        head_dim: per-head width (64 for gpt-oss).
+        cache_dtype: on-device cache dtype (bf8 matches the DeepSeek substrate + the device golden check).
+    """
+    sp = mesh_device.shape[sp_axis]
+    # seq_local must be tile-aligned: the cache is TILE_LAYOUT and the DRAM NdShard is 32-token; also
+    # matches build_indexed_rope's chunk_size % (TILE_SIZE*sp) constraint so cache + rope layouts agree.
+    assert (
+        max_seq_len % (ttnn.TILE_SIZE * sp) == 0
+    ), f"max_seq_len ({max_seq_len}) must be a multiple of TILE_SIZE*sp ({ttnn.TILE_SIZE * sp}); seq_local must be tile-aligned"
+    seq_local = max_seq_len // sp
+
+    core_ranges = [
+        ttnn.CoreRange(ttnn.CoreCoord(bank_id, 0), ttnn.CoreCoord(bank_id, 0))
+        for bank_id in range(get_num_dram_banks(mesh_device))
+    ]
+    nd_shard_spec = ttnn.NdShardSpec(
+        shard_shape=[1, 1, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK, head_dim],
+        grid=ttnn.CoreRangeSet(core_ranges),
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        shard_distribution_strategy=ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
+    )
+    mem_config = ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM, nd_shard_spec=nd_shard_spec)
+
+    def _alloc(dtype=cache_dtype):
+        # Per-chip cache is one head ([.., 1, ..]); WHICH head a chip holds is decided at write time by
+        # how the input chunk is mesh-mapped, not here. Allocated zeroed + ReplicateTensorToMesh: every
+        # chip gets the same empty buffer; content diverges on the first update_padded_kv_cache write.
+        return ttnn.from_torch(
+            torch.zeros(num_users * num_layers, 1, seq_local, head_dim),
+            dtype=dtype,
+            device=mesh_device,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=mem_config,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        )
+
+    return GptOssKVCache(
+        k=_alloc(),
+        v=_alloc(),
+        num_users=num_users,
+        num_layers=num_layers,
+        max_seq_len=max_seq_len,
+        sp=sp,
+    )
+
+
+def _write_one(cache, tensor, *, slot_idx, layer_idx, num_layers, kv_actual, sp_axis):
+    """Write one SP-sharded chunk tensor into a packed cache via update_padded_kv_cache.
+
+    The op requires TILE layout and input.dtype == cache.dtype, so cast a copy to the cache's dtype when
+    needed (the original stays live for the attention op that follows). At ``kv_actual % 32 == 0`` chunk
+    boundaries the per-device write offset is contiguous (block-cyclic degenerates to a reshape).
+    """
+    src = tensor if tensor.dtype == cache.dtype else ttnn.typecast(tensor, cache.dtype)
+    ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
+        cache,
+        src,
+        slot_idx=slot_idx,
+        layer_idx=layer_idx,
+        num_layers=num_layers,
+        kv_actual_global=kv_actual,
+        cluster_axis=sp_axis,
+    )
+    if src is not tensor:
+        src.deallocate(True)
+
+
+def write_kv_chunk(kv_cache: GptOssKVCache, tt_k, tt_v, *, slot_idx, layer_idx, kv_actual, sp_axis):
+    """Write this chunk's post-RoPE K and raw V into the packed cache (every layer).
+
+    tt_k / tt_v are the per-device SP shards [1, n_kv_local, s_local, head_dim] (heads TP-sharded on the
+    cols, sequence SP-sharded on the ``sp_axis`` rows) — exactly the per-chip cache layout, so they write
+    in place. ``kv_actual`` is the cumulative valid prefix before this chunk (0 for the first/only chunk).
+    """
+    # Fail loud on a bad slot/layer (would otherwise be a silent OOB write into another user's slot) and
+    # on a misaligned chunk offset (the block-cyclic per-device write assumes a tile-aligned boundary).
+    assert 0 <= slot_idx < kv_cache.num_users, f"slot_idx {slot_idx} out of range [0, {kv_cache.num_users})"
+    assert 0 <= layer_idx < kv_cache.num_layers, f"layer_idx {layer_idx} out of range [0, {kv_cache.num_layers})"
+    assert (
+        kv_actual % ttnn.TILE_SIZE == 0
+    ), f"kv_actual ({kv_actual}) must be tile-aligned (multiple of {ttnn.TILE_SIZE})"
+    _write_one(
+        kv_cache.k,
+        tt_k,
+        slot_idx=slot_idx,
+        layer_idx=layer_idx,
+        num_layers=kv_cache.num_layers,
+        kv_actual=kv_actual,
+        sp_axis=sp_axis,
+    )
+    _write_one(
+        kv_cache.v,
+        tt_v,
+        slot_idx=slot_idx,
+        layer_idx=layer_idx,
+        num_layers=kv_cache.num_layers,
+        kv_actual=kv_actual,
+        sp_axis=sp_axis,
+    )

--- a/models/demos/gpt_oss_d_p/tt/attention/operations.py
+++ b/models/demos/gpt_oss_d_p/tt/attention/operations.py
@@ -47,22 +47,43 @@ def split_qkv_heads_prefill(xqkv_fused, num_heads: int, num_kv_heads: int):
     )
 
 
-def apply_rope(tensor, rope_mats, transformation_mat, is_decode_mode: bool = False):
+def apply_rope(
+    tensor, rope_mats, transformation_mat, is_decode_mode: bool = False, kv_actual_global=None, cluster_axis=None
+):
     """
     Apply rotary position embedding (RoPE) — FULL rotary for gpt-oss (rotary_dim == head_dim, 64).
 
     The YaRN scaling (rope_theta 150000, factor 32, orig_max_pos 4096) is baked into the cos/sin
     matrices (``rope_mats``) at build time, so this op is a plain full rotation of the whole head.
 
+    Two inner ops:
+      * default (``kv_actual_global`` is None): ``rotary_embedding_llama`` with a per-chunk cos/sin
+        already sliced to this chunk's positions (the non-cache / single-shot prefill path).
+      * indexed (``kv_actual_global`` set): ``rotary_embedding_indexed`` — ``rope_mats`` carry the
+        WHOLE-cache, block-cyclic-reordered, SP-sharded cos/sin (built once by tt/rope.py), and the op
+        derives this chunk's per-chip start row on-device from ``kv_actual_global`` + the device's
+        ``cluster_axis`` coordinate (same block-cyclic math as the KV-cache writer). No host reshard.
+
     Args:
         tensor: Input tensor (Q or K), shape [1, n_heads, seq_len, head_dim]
         rope_mats: Tuple/list of (cos, sin) matrices, last dim = head_dim
         transformation_mat: Transformation matrix for the mode
         is_decode_mode: Whether in decode mode (False for prefill)
+        kv_actual_global: prior valid global KV length (tile-aligned). Set -> indexed on-device RoPE.
+        cluster_axis: SP mesh axis the whole-cache cos/sin are sharded along (required when indexed).
 
     Returns:
         Tensor with RoPE applied
     """
+    if kv_actual_global is not None:
+        return ttnn.experimental.deepseek_prefill.rotary_embedding_indexed(
+            tensor,
+            rope_mats[0],
+            rope_mats[1],
+            transformation_mat,
+            kv_actual_global=kv_actual_global,
+            cluster_axis=cluster_axis,
+        )
     return ttnn.experimental.rotary_embedding_llama(
         tensor, rope_mats[0], rope_mats[1], transformation_mat, is_decode_mode=is_decode_mode
     )

--- a/models/demos/gpt_oss_d_p/tt/attention/prefill.py
+++ b/models/demos/gpt_oss_d_p/tt/attention/prefill.py
@@ -6,13 +6,16 @@ GPT-OSS chunked-prefill attention forward: GQA with full rotary (YaRN baked into
 attention sinks, and per-layer sliding-window vs full-causal masking. No MSA / sparse path, no
 partial rotary, no QK-norm.
 
-SP seam (P1): when the sequence is SP-sharded, AllGather K/V so each chip holds the full K/V, then
-run single-chip SDPA. The native ring SDPA (sinks+sliding+halo CCL) swaps in later — see the SP branch.
+Sequence-parallel seam (P1 bring-up): when the sequence is sharded across the SP axis, we
+AllGather K/V so every chip holds the full K/V and then run a normal single-chip SDPA. The
+native ring SDPA (sinks + sliding + halo CCL, Pavle's op) is swapped in behind this seam later.
+See the ``config.sequence_parallel`` branch below.
 """
 
 import ttnn
 
 from .config import AttentionConfig, ProgramConfig
+from .kv_cache import GptOssKVCache, write_kv_chunk
 from .operations import (
     apply_allgather_and_slice,
     apply_allreduce,
@@ -59,6 +62,8 @@ def attention_forward(
     user_id=0,
     batch_size=1,
     layer_idx=0,
+    cached_len=0,
+    indexed_rope=False,
 ):
     """
     Prefill forward pass — optimized for sequence processing (seq_len > 1).
@@ -68,9 +73,11 @@ def attention_forward(
 
     Args:
         hidden_states: Input tensor [batch, seq_len, hidden_size]
-        rope_mats: Tuple/list of (cos, sin) matrices for RoPE (YaRN baked in, full head_dim wide)
+        rope_mats: Tuple/list of (cos, sin) matrices for RoPE (YaRN baked in, full head_dim wide).
+            When ``indexed_rope`` is set these are the WHOLE-cache block-cyclic SP-sharded cos/sin
+            built once by tt/rope.build_indexed_rope (not per-chunk).
         weights: Attention weights
-        kv_cache: Optional [k_cache, v_cache] pair; may be None (e.g. the unit test)
+        kv_cache: Optional GptOssKVCache (packed K/V); may be None (e.g. the unit test)
         config: Attention configuration
         mesh_config: Mesh parallelization config
         mesh_device: TTNN mesh device
@@ -80,7 +87,11 @@ def attention_forward(
         ccl_manager: Communication manager (only used when TP > 1 or SP > 1)
         user_id: cache slot index for the per-user cache write
         batch_size: number of users packed on the sequence dim
-        layer_idx: this layer's index (informational)
+        layer_idx: this layer's index, for the per-layer cache write
+        cached_len: valid prefix length already in the cache BEFORE this chunk (0 = first/only chunk).
+            >0 selects the cache-read attention path (current chunk attends the accumulated prefix).
+        indexed_rope: use the on-device indexed RoPE (rope_mats are the whole-cache block-cyclic SP
+            cos/sin; the op derives this chunk's rows from cached_len + the SP mesh coord).
 
     Returns:
         Attention output [batch, seq_len, hidden_size]
@@ -113,55 +124,101 @@ def attention_forward(
     tt_q, tt_k, tt_v = split_qkv_heads_prefill(xqkv_fused, num_local_heads, num_local_kv_heads)
     xqkv_fused.deallocate(True)
 
-    # Apply full RoPE on Q and K (use per-user seq_len positions when multi-user)
-    if batch_size > 1:
+    # Apply full RoPE on Q and K.
+    # indexed_rope: rope_mats are the WHOLE-cache block-cyclic SP-sharded cos/sin (built once); the
+    # indexed op derives this chunk's per-chip start from kv_actual_global=cached_len + the device's
+    # SP mesh coord on-device (no per-chunk host reshard). The per-user seq_len slice only applies to
+    # the non-indexed multi-user path (indexed rope carries the whole cache, never sliced here).
+    rope_kv_actual = cached_len if indexed_rope else None
+    rope_cluster_axis = mesh_config.sp_axis if indexed_rope else None
+    if batch_size > 1 and not indexed_rope:
         rope_mats_sliced = [rope_mats[0][:, :, :seq_len, :], rope_mats[1][:, :, :seq_len, :]]
     else:
         rope_mats_sliced = rope_mats
     tt_q_orig = tt_q
     tt_k_orig = tt_k
-    tt_q = apply_rope(tt_q, rope_mats_sliced, transformation_mat, is_decode_mode=False)
-    tt_k = apply_rope(tt_k, rope_mats_sliced, transformation_mat, is_decode_mode=False)
+    tt_q = apply_rope(
+        tt_q,
+        rope_mats_sliced,
+        transformation_mat,
+        is_decode_mode=False,
+        kv_actual_global=rope_kv_actual,
+        cluster_axis=rope_cluster_axis,
+    )
+    tt_k = apply_rope(
+        tt_k,
+        rope_mats_sliced,
+        transformation_mat,
+        is_decode_mode=False,
+        kv_actual_global=rope_kv_actual,
+        cluster_axis=rope_cluster_axis,
+    )
     tt_q_orig.deallocate(True)
     tt_k_orig.deallocate(True)
 
-    # Optional KV-cache write (non-paged). None in the unit test. Post-RoPE K + raw V.
-    # Write the cache in its own dtype (e.g. bf8_b) via a cast copy, but keep the bf16 tt_k/tt_v
-    # live for this chunk's SDPA below (casting them in place would run attention at cache precision).
+    # Per-layer KV cache write: post-RoPE K + raw V into the packed SP cache at this chunk's offset
+    # (cached_len). Single write point for all chunks; the cache-read path below then reads the
+    # accumulated prefix. None in the unit test. tt_k / tt_v stay live (bf16) for the SDPA that follows;
+    # write_kv_chunk casts its own copy to the cache dtype.
     if kv_cache is not None:
-        k_cache, v_cache = kv_cache
-        k_for_cache = ttnn.typecast(tt_k, k_cache.dtype)
-        v_for_cache = ttnn.typecast(tt_v, v_cache.dtype)
-        if batch_size > 1:
-            for b in range(batch_size):
-                k_b = ttnn.slice(
-                    k_for_cache, (b, 0, 0, 0), (b + 1, k_for_cache.shape[1], k_for_cache.shape[2], k_for_cache.shape[3])
-                )
-                v_b = ttnn.slice(
-                    v_for_cache, (b, 0, 0, 0), (b + 1, v_for_cache.shape[1], v_for_cache.shape[2], v_for_cache.shape[3])
-                )
-                ttnn.fill_cache(k_cache, k_b, batch_idx=user_id + b)
-                ttnn.fill_cache(v_cache, v_b, batch_idx=user_id + b)
-                k_b.deallocate(True)
-                v_b.deallocate(True)
-        else:
-            ttnn.fill_cache(k_cache, k_for_cache, batch_idx=user_id)
-            ttnn.fill_cache(v_cache, v_for_cache, batch_idx=user_id)
-        k_for_cache.deallocate(True)
-        v_for_cache.deallocate(True)
+        assert isinstance(kv_cache, GptOssKVCache), "kv_cache must be a GptOssKVCache"
+        write_kv_chunk(
+            kv_cache,
+            tt_k,
+            tt_v,
+            slot_idx=user_id,
+            layer_idx=layer_idx,
+            kv_actual=cached_len,
+            sp_axis=mesh_config.sp_axis,
+        )
 
     # --- Attention core ---
+    # Clean sequence_parallel seam. sp==1 => single-chip SDPA (exact). sp>1 => P1 bring-up path:
+    # AllGather K/V across the SP axis so each chip holds the full K/V, then single-chip SDPA.
+    # cached_len > 0 selects the cache-read path (current chunk attends the accumulated prefix).
     if config.sequence_parallel and mesh_config.sp > 1:
-        # PLACEHOLDER (SP>1): AllGather K/V to the full sequence, then single-chip SDPA. BROKEN as-is —
-        # Q stays the local SP shard while K spans the full seq, so is_causal SDPA has no per-rank
-        # position offset and the causal mask is wrong for rank>0. Not exercised by the single-chip PCC
-        # test; replaced by the native ring SDPA (sinks+sliding+halo CCL) at P6 — validate before SP>1 use.
+        if cached_len > 0:
+            # TODO(P6): SP cache-read needs the native ring SDPA over the block-cyclic packed cache
+            # (mirror M3's dense_sp_attention / ring_joint, which gpt_oss_d_p has not yet ported).
+            # The current AllGather + single-chip SDPA seam cannot read the SP-sharded accumulated
+            # prefix with correct per-rank causality. Raise until the ring op lands.
+            raise NotImplementedError(
+                "SP (sp>1) chunked cache-read is not implemented yet; needs the ring-joint dense SDPA "
+                "over the block-cyclic packed cache (see M3 dense_sp_attention). Only the one-shot paths "
+                "(cached_len==0, single-chip and the SP gather-Q stand-in) run today; all chunked "
+                "cache-read (cached_len>0) raises (single-chip cache-read also raises, see below)."
+            )
+        # TODO(P6): replace this AllGather + single-chip SDPA with the native ring SDPA
+        # (sinks + sliding + halo CCL, Pavle's op). That op keeps Q/K/V SP-sharded and streams
+        # the K/V halo across the ring instead of materializing the full K/V on every chip.
+        #
+        # KNOWN LIMITATION of this bring-up stub: after the AllGather, K/V span the full sequence
+        # but Q is still the local SP shard. A plain is_causal SDPA assumes Q and K start at the
+        # same global position, which is only true for the first SP rank. Correct per-rank causal
+        # masking needs a position offset (cached_len + rank * seq_local) that the current
+        # ttnn.transformer.scaled_dot_product_attention prefill entrypoint does not expose. This
+        # branch is therefore a placeholder for the multi-chip wiring and is NOT exercised by the
+        # single-chip PCC test; it must be validated (or replaced by the ring op) before SP>1 use.
         tt_k_full = mesh_config.allgather(tt_k, ccl_manager, axis=mesh_config.sp_axis, dim=2)
         tt_v_full = mesh_config.allgather(tt_v, ccl_manager, axis=mesh_config.sp_axis, dim=2)
         tt_k.deallocate(True)
         tt_v.deallocate(True)
         tt_k, tt_v = tt_k_full, tt_v_full
         tt_sdpa_out = _run_sdpa(tt_q, tt_k, tt_v, weights, config, program_config, mesh_device, seq_len)
+    elif cached_len > 0:
+        # Chunked cache-read (current chunk attends the accumulated prefix) is not implemented yet.
+        # The KV-cache STORAGE + write is done and validated (test_kv_cache_vs_ref); reading it back
+        # for attention needs a chunk-position-aware SDPA, because Q is the current chunk at global
+        # offset cached_len while K/V span [0, cached_len+seq_len) — plain is_causal SDPA (which assumes
+        # Q row 0 aligns with K row 0) is off by cached_len and silently wrong. The correct paths are
+        # the paged chunked_scaled_dot_product_attention (needs a paged KV cache + page table) or the
+        # ring-joint dense SDPA over the block-cyclic cache (M3 dense_sp_attention). Wired when the
+        # runtime drives multi-chunk prefill. Fail loud rather than return wrong output.
+        raise NotImplementedError(
+            "gpt_oss_d_p: chunked cache-read attention (cached_len>0) is not implemented yet — needs a "
+            "chunk-position-aware SDPA (paged chunked SDPA or ring-joint over the block-cyclic cache). "
+            "KV-cache storage/write is supported and validated; first-chunk (cached_len==0) works."
+        )
     else:
         tt_sdpa_out = _run_sdpa(tt_q, tt_k, tt_v, weights, config, program_config, mesh_device, seq_len)
 
@@ -178,9 +235,11 @@ def attention_forward(
     if batch_size > 1:
         tt_sdpa_out = ttnn.reshape(tt_sdpa_out, [1, 1, total_seq_len, -1])
 
-    # o_proj (+bias) + TP reduce. TP>1 on Ring (and a supported shape) uses fused matmul+reduce-scatter
-    # (then all-gather + slice off padding); else plain o_proj + all-reduce. Fused MM+RS is gated off
-    # on Blackhole (see is_shape_fused_mm_rs_supported).
+    # Output projection (+bias) + tensor-parallel allreduce.
+    # When TP > 1 (and supported), use the fused matmul + reduce-scatter op; the trailing
+    # all-gather + padding slice stay separate. The fused MM+RS op only supports Ring topology and
+    # is gated off on Blackhole (see is_shape_fused_mm_rs_supported), so fall back to plain
+    # o_proj + all-reduce otherwise.
     use_fused_rs = (
         mesh_config.tp > 1
         and is_shape_fused_mm_rs_supported(tt_sdpa_out)

--- a/models/demos/gpt_oss_d_p/tt/rope.py
+++ b/models/demos/gpt_oss_d_p/tt/rope.py
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+GPT-OSS indexed RoPE setup for chunked prefill.
+
+Builds the whole-cache, block-cyclic, SP-sharded cos/sin ONCE (reused for every chunk), mirroring
+``minimax_m3/tt/tt_prefill_runtime._build_indexed_rope`` and DeepSeek's
+``RotarySetup.get_rope_tensors_indexed``. ``ttnn.experimental.deepseek_prefill.rotary_embedding_indexed``
+then derives each chunk's per-chip start row on-device from a single ``kv_actual_global`` runtime arg
+(the same block-cyclic ``update_idxt`` math the KV-cache writer uses), so no per-chunk host reshard.
+
+gpt-oss RoPE is FULL rotary (rotary_dim == head_dim == 64) with YaRN scaling (rope_theta 150000,
+factor 32, original_max_position 4096). The cos/sin are built in the Meta interleaved convention
+(``[c0, c0, c1, c1, ...]``) with the YaRN mscale/attention_factor folded in — exactly the convention
+``rotary_embedding_indexed`` + ``get_rot_transformation_mat`` expect (see the DeepSeek indexed-rope
+op test), and matching ``convert_hf_qkv_to_meta_format``-swizzled q/k projections.
+"""
+
+import math
+
+import torch
+
+import ttnn
+from models.demos.deepseek_v3_d_p.tt.mla.utils import block_cyclic_reorder
+from models.tt_transformers.tt.common import get_rot_transformation_mat
+
+# GPT-OSS-120B YaRN defaults (configs/gpt-oss-120b/config.json).
+DEFAULT_ROPE_THETA = 150000.0
+DEFAULT_YARN_FACTOR = 32.0
+DEFAULT_YARN_ORIG_MAX_POS = 4096
+DEFAULT_YARN_BETA_FAST = 32.0
+DEFAULT_YARN_BETA_SLOW = 1.0
+
+
+def yarn_inv_freq(
+    head_dim,
+    base=DEFAULT_ROPE_THETA,
+    factor=DEFAULT_YARN_FACTOR,
+    orig_max_pos=DEFAULT_YARN_ORIG_MAX_POS,
+    beta_fast=DEFAULT_YARN_BETA_FAST,
+    beta_slow=DEFAULT_YARN_BETA_SLOW,
+):
+    """YaRN inverse frequencies + attention_factor (mscale). Matches transformers
+    ``_compute_yarn_parameters`` (see gpt_oss_d_p/tests/unit/test_attention_vs_ref.py)."""
+
+    def find_correction_dim(num_rotations):
+        return (head_dim * math.log(orig_max_pos / (num_rotations * 2 * math.pi))) / (2 * math.log(base))
+
+    low = max(math.floor(find_correction_dim(beta_fast)), 0)
+    high = min(math.ceil(find_correction_dim(beta_slow)), head_dim - 1)
+
+    pos_freqs = base ** (torch.arange(0, head_dim, 2).float() / head_dim)
+    inv_freq_extrapolation = 1.0 / pos_freqs
+    inv_freq_interpolation = 1.0 / (factor * pos_freqs)
+
+    if low == high:
+        high += 0.001
+    ramp = ((torch.arange(head_dim // 2).float() - low) / (high - low)).clamp(0, 1)
+    inv_freq_extrapolation_factor = 1.0 - ramp
+
+    inv_freq = (
+        inv_freq_interpolation * (1.0 - inv_freq_extrapolation_factor)
+        + inv_freq_extrapolation * inv_freq_extrapolation_factor
+    )
+    attention_factor = 0.1 * math.log(factor) + 1.0
+    return inv_freq, attention_factor
+
+
+def build_yarn_cos_sin(
+    seq_len,
+    head_dim,
+    *,
+    rope_theta=DEFAULT_ROPE_THETA,
+    yarn_factor=DEFAULT_YARN_FACTOR,
+    yarn_orig_max_pos=DEFAULT_YARN_ORIG_MAX_POS,
+    yarn_beta_fast=DEFAULT_YARN_BETA_FAST,
+    yarn_beta_slow=DEFAULT_YARN_BETA_SLOW,
+):
+    """Meta interleaved cos/sin ``[1, 1, seq_len, head_dim]`` with YaRN mscale folded in.
+
+    Meta convention (matches ttnn.rotary_embedding_llama / rotary_embedding_indexed +
+    reverse_permute'd weights): ``[c0, c0, c1, c1, ...]`` (interleave the per-freq value, not the
+    concat-halves HF convention).
+    """
+    inv_freq, attn_factor = yarn_inv_freq(
+        head_dim, rope_theta, yarn_factor, yarn_orig_max_pos, yarn_beta_fast, yarn_beta_slow
+    )
+    pos = torch.arange(seq_len).float()
+    freqs = torch.outer(pos, inv_freq)  # [seq_len, head_dim/2]
+    cos_half = torch.cos(freqs) * attn_factor
+    sin_half = torch.sin(freqs) * attn_factor
+    cos_meta = torch.stack([cos_half, cos_half], dim=-1).flatten(-2)[None, None]  # [1,1,seq_len,head_dim]
+    sin_meta = torch.stack([sin_half, sin_half], dim=-1).flatten(-2)[None, None]
+    return cos_meta, sin_meta
+
+
+def build_transformation_mat(mesh_device, dtype=ttnn.bfloat16):
+    """Replicated RoPE transformation matrix for rotary_embedding_llama / rotary_embedding_indexed."""
+    return ttnn.from_torch(
+        get_rot_transformation_mat(),
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=dtype,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+
+def build_indexed_rope(
+    mesh_device,
+    *,
+    head_dim,
+    max_seq_len,
+    chunk_size,
+    sp_axis=0,
+    rope_theta=DEFAULT_ROPE_THETA,
+    yarn_factor=DEFAULT_YARN_FACTOR,
+    yarn_orig_max_pos=DEFAULT_YARN_ORIG_MAX_POS,
+    yarn_beta_fast=DEFAULT_YARN_BETA_FAST,
+    yarn_beta_slow=DEFAULT_YARN_BETA_SLOW,
+    dtype=ttnn.bfloat16,
+):
+    """Build the whole-cache, block-cyclic, SP-sharded cos/sin for the INDEXED on-device RoPE, ONCE.
+
+    The cos/sin cover EVERY cache position (up to ``max_seq_len``), block-cyclic-reordered keyed by the
+    per-chip chunk (``chunk_size // sp``) then SP-sharded on ``sp_axis``, so device ``c``'s contiguous
+    shard holds — in local-cache-row order — the rope for every global position it will carry.
+    ``rotary_embedding_indexed`` then picks this chunk's rows on-device from ``kv_actual_global``.
+
+    Constraints (mirroring the block-cyclic / cache layout, see RotarySetup.get_rope_tensors_indexed):
+      * ``chunk_size % (TILE_SIZE * sp) == 0``
+      * ``max_seq_len % chunk_size == 0``
+
+    Returns ``[cos_tt, sin_tt]`` (persistent — reused across all chunks; do NOT deallocate per chunk).
+    Use with :func:`build_transformation_mat` and ``apply_rope(..., kv_actual_global=cached_len,
+    cluster_axis=sp_axis)``.
+    """
+    sp = mesh_device.shape[sp_axis]
+    assert (
+        chunk_size % (ttnn.TILE_SIZE * sp) == 0
+    ), f"chunk_size ({chunk_size}) must be a multiple of TILE_SIZE * sp ({ttnn.TILE_SIZE * sp})"
+    assert max_seq_len % chunk_size == 0, f"max_seq_len ({max_seq_len}) must be a multiple of chunk_size ({chunk_size})"
+    chunk_local = chunk_size // sp
+
+    cos, sin = build_yarn_cos_sin(
+        max_seq_len,
+        head_dim,
+        rope_theta=rope_theta,
+        yarn_factor=yarn_factor,
+        yarn_orig_max_pos=yarn_orig_max_pos,
+        yarn_beta_fast=yarn_beta_fast,
+        yarn_beta_slow=yarn_beta_slow,
+    )
+    cos = block_cyclic_reorder(cos, chunk_local, sp, seq_dim=2)
+    sin = block_cyclic_reorder(sin, chunk_local, sp, seq_dim=2)
+
+    shard_dims = [None, None]
+    shard_dims[sp_axis] = 2  # SP-shard the seq dim; replicate across TP
+    mapper = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=tuple(shard_dims))
+
+    def _to_dev(t):
+        return ttnn.from_torch(
+            t,
+            device=mesh_device,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=dtype,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=mapper,
+        )
+
+    return [_to_dev(cos), _to_dev(sin)]

--- a/models/demos/gpt_oss_d_p/tt/rope.py
+++ b/models/demos/gpt_oss_d_p/tt/rope.py
@@ -47,8 +47,13 @@ def yarn_inv_freq(
     def find_correction_dim(num_rotations):
         return (head_dim * math.log(orig_max_pos / (num_rotations * 2 * math.pi))) / (2 * math.log(base))
 
-    low = max(math.floor(find_correction_dim(beta_fast)), 0)
-    high = min(math.ceil(find_correction_dim(beta_slow)), head_dim - 1)
+    # gpt-oss sets rope_scaling.truncate=False, so HF keeps the correction dims as FLOATS (no
+    # floor/ceil). Truncating shifts the interpolation<->extrapolation ramp and injects a per-freq
+    # inv_freq error that grows linearly with position: invisible at short seq (~0.02 rad by pos 100,
+    # so the unit test passes) but ~1.1 rad phase drift by pos 5000 -> long-context K PCC collapse
+    # (layer-0 K fell to ~0.69 at the tail). Match HF exactly: no floor/ceil (verified inv_freq to 1e-7).
+    low = max(find_correction_dim(beta_fast), 0.0)
+    high = min(find_correction_dim(beta_slow), head_dim - 1)
 
     pos_freqs = base ** (torch.arange(0, head_dim, 2).float() / head_dim)
     inv_freq_extrapolation = 1.0 / pos_freqs


### PR DESCRIPTION
> **P2 of the GPT-OSS prefill stack.** #50223 (attention) is merged, so this now stacks directly on `main`; the diff is the KV-cache delta only.

## What
The **chunked, block-cyclic, SP-sharded KV cache + indexed RoPE** (M3-style), wired into the attention block.

## This PR
- **`tt/attention/kv_cache.py`** — `GptOssKVCache` (head-sharded GQA K/V, so no MLA latent and no `index_k`) + `allocate_kv_cache` (persistent DRAM NdShard, per-chip `[num_users*num_layers, 1, seq_local, head_dim]`, same DRAM-bank spec as DeepSeek so `update_padded_kv_cache` writes in place) + `write_kv_chunk`. Inputs are validated (slot/layer bounds, `max_seq_len` and `kv_actual` tile-alignment) so a bad caller fails loud, not with a silent OOB or mis-sharded write.
- **`tt/rope.py`** — whole-cache block-cyclic SP-sharded **YaRN** cos/sin built once (indexed RoPE via `rotary_embedding_indexed`); `apply_rope` extended with the indexed path.
- **`tt/attention/prefill.py`** — KV write wired in (replaces the `fill_cache` stub); first-chunk (one-shot) attention path.
- **Chunked cache-read** (`cached_len>0`) **raises `NotImplementedError`** — fail-loud in **both** the single-chip and SP branches (plain `is_causal` is off by `cached_len`; needs a chunk-position-aware SDPA: paged chunked SDPA, or ring-joint over the block-cyclic cache). Deferred to when the runtime drives multi-chunk prefill (P6); not shipped silently-wrong.

## Tests
- `test_kv_cache_write_read_vs_ref` — single-card KV **write/read-back round-trip** PCC (2 users × 2 layers), threshold **≥ 0.99** (the ~1% headroom is the bf8 cache round-trip). Validates slot packing, head/seq layout, bf8 storage.
- `test_blockcyclic_reorder_positions_inverse` — **pure-torch** (no device) check that the block-cyclic scatter (`block_cyclic_reorder`) and its inverse position map (`blockcyclic_positions`) round-trip at **sp=4**. Covers the layout math that the single-card round-trip degenerates to the identity, so a regression is caught in CI, not only on galaxy.
- P1 attention tests still pass.

## Follow-ups
- Chunked cache-read attention (paged or ring-joint) — needed for multi-chunk prefill (P6).
- On-device SP block-cyclic (sp>1) still runs only on a multi-chip mesh; the pure-torch test above covers the layout math in the meantime.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mdragula/gpt-oss-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mdragula/gpt-oss-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mdragula/gpt-oss-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mdragula/gpt-oss-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mdragula/gpt-oss-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mdragula/gpt-oss-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mdragula/gpt-oss-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mdragula/gpt-oss-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mdragula/gpt-oss-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mdragula/gpt-oss-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mdragula/gpt-oss-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mdragula/gpt-oss-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mdragula/gpt-oss-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mdragula/gpt-oss-kv-cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mdragula/gpt-oss-kv-cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mdragula/gpt-oss-kv-cache)