### PR TITLE
Reshape always copy by default (no zero-copy view)

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_reshape.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_reshape.py
@@ -934,3 +934,23 @@ def test_reshape_rm_interleaved_wide_multi_page(device, input_shape, output_shap
     )
     y = ttnn.reshape(x, output_shape)
     assert_equal(t.reshape(*output_shape), ttnn.to_torch(y))
+
+    
+def test_reshape_no_aliasing(device):
+    """Reshape must return a tensor with independent device memory.
+    Deallocating the original must not invalidate the reshaped tensor."""
+    torch_a = torch.randn(1, 2, dtype=torch.bfloat16)
+    a = ttnn.from_torch(torch_a, device=device, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    b = ttnn.reshape(a, (1, 1, 1, 1, 1, 2))
+    assert b.is_allocated()
+
+    ttnn.deallocate(a, force=True)
+    assert not a.is_allocated(), "Original tensor should be deallocated"
+
+    assert b.is_allocated(), "Reshaped tensor must survive original's deallocation"
+    c = ttnn.to_layout(b, ttnn.TILE_LAYOUT)
+    assert c.is_allocated()
+
+    result = ttnn.to_torch(b)
+    assert torch.equal(torch_a.reshape(1, 1, 1, 1, 1, 2), result)

--- a/tests/ttnn/unit_tests/base_functionality/test_reshape.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_reshape.py
@@ -935,22 +935,51 @@ def test_reshape_rm_interleaved_wide_multi_page(device, input_shape, output_shap
     y = ttnn.reshape(x, output_shape)
     assert_equal(t.reshape(*output_shape), ttnn.to_torch(y))
 
-    
-def test_reshape_no_aliasing(device):
+
+@pytest.mark.parametrize(
+    "input_shape, output_shape, layout",
+    [
+        ((1, 2), (1, 1, 1, 1, 1, 2), ttnn.ROW_MAJOR_LAYOUT),
+        ((1, 32, 64), (1, 1, 32, 64), ttnn.TILE_LAYOUT),
+    ],
+)
+def test_reshape_no_aliasing(device, input_shape, output_shape, layout):
     """Reshape must return a tensor with independent device memory.
     Deallocating the original must not invalidate the reshaped tensor."""
-    torch_a = torch.randn(1, 2, dtype=torch.bfloat16)
-    a = ttnn.from_torch(torch_a, device=device, layout=ttnn.ROW_MAJOR_LAYOUT)
+    torch_a = torch.randn(input_shape, dtype=torch.bfloat16)
+    a = ttnn.from_torch(torch_a, device=device, layout=layout)
 
-    b = ttnn.reshape(a, (1, 1, 1, 1, 1, 2))
+    b = ttnn.reshape(a, output_shape)
     assert b.is_allocated()
 
     ttnn.deallocate(a, force=True)
     assert not a.is_allocated(), "Original tensor should be deallocated"
 
     assert b.is_allocated(), "Reshaped tensor must survive original's deallocation"
-    c = ttnn.to_layout(b, ttnn.TILE_LAYOUT)
-    assert c.is_allocated()
 
     result = ttnn.to_torch(b)
-    assert torch.equal(torch_a.reshape(1, 1, 1, 1, 1, 2), result)
+    assert torch.equal(torch_a.reshape(output_shape), result)
+
+
+@pytest.mark.parametrize(
+    "input_shape, layout",
+    [
+        ((2, 4), ttnn.ROW_MAJOR_LAYOUT),
+        ((1, 32, 64), ttnn.TILE_LAYOUT),
+    ],
+)
+def test_reshape_no_aliasing_same_shape(device, input_shape, layout):
+    """Same-shape reshape must also return independent storage (#40547).
+    The early no-op path used to return the input tensor itself."""
+    torch_a = torch.randn(input_shape, dtype=torch.bfloat16)
+    a = ttnn.from_torch(torch_a, device=device, layout=layout)
+
+    b = ttnn.reshape(a, a.shape)
+    assert b.is_allocated()
+
+    ttnn.deallocate(a, force=True)
+    assert not a.is_allocated(), "Original tensor should be deallocated"
+    assert b.is_allocated(), "Same-shape reshape must survive original's deallocation"
+
+    result = ttnn.to_torch(b)
+    assert torch.equal(torch_a, result)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
@@ -583,10 +583,10 @@ def test_sort_rank5_all_dims(shape, dim, descending, device):
 
     The composite layer permutes the sort dim to the last position, squeezes
     leading dims into 4D, runs the kernel, then restores the original rank
-    and order.  The rank-restoration reshape targets the *transposed* shape,
-    keeping the last dim unchanged, so it routes through ttnn::reshape's
-    `this_is_view` fast path (metadata-only `view`).  This avoids the device
-    reshape kernel entirely — important because that kernel rejects UINT16.
+    and order.  The rank-restoration step targets the *transposed* shape,
+    keeping the last dim unchanged, and calls `ttnn::experimental::view`
+    directly (metadata-only view).  This avoids the device reshape kernel
+    entirely — important because that kernel rejects UINT16.
     """
     torch.manual_seed(0)
 

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -578,7 +578,21 @@ ttnn::Tensor ttnn::reshape(
         operations::data_movement::shape_corrector(tensor, logical_input_shape, padded_input_shape);
     // First Case, No reshape Required
     if (tensor.logical_shape() == logical_shape && tensor.padded_shape() == padded_shape) {
-        return tensor;
+        // Host: returning the same tensor is fine (no device-dealloc hazard).
+        if (!is_device_tensor(tensor)) {
+            return tensor;
+        }
+        // TODO(#40547): CloneOperation does not support ND_SHARDED yet; return
+        // the original tensor (zero-copy) until clone gains ND-shard awareness.
+        // Gate on the *input* layout so an interleaved→ND request falls through
+        // instead of silently returning the input.
+        if (tensor.memory_config().memory_layout() == TensorMemoryLayout::ND_SHARDED) {
+            return tensor;
+        }
+        // Device (#40547): do not clone unconditionally here — CloneOperation
+        // rejects mixed/differing sharded configs. Fall through so the
+        // memory_config_clone_compatible check below can clone when safe, or
+        // route incompatible memory_config conversions to device reshape.
     }
     PadValue default_pad_value;
     if (tensor.dtype() == DataType::BFLOAT8_B or tensor.dtype() == DataType::BFLOAT4_B or
@@ -632,6 +646,10 @@ ttnn::Tensor ttnn::reshape(
         if (!mem_config.is_sharded()) {
             return true;
         }
+        // TODO(#40547): CloneOperation does not support ND_SHARDED yet.
+        if (mem_config.memory_layout() == TensorMemoryLayout::ND_SHARDED) {
+            return false;
+        }
         // Clone requires identical shard specs when both ends are sharded.
         const auto& out_spec = mem_config.shard_spec();
         const auto& in_spec = input_mem_config.shard_spec();
@@ -651,8 +669,8 @@ ttnn::Tensor ttnn::reshape(
              padded_shape[-1] % tile.get_width() == 0 and tensor.padded_shape()[-1] == padded_shape[-1]);
 
         if (tile_tensor_view_reshape_possible) {
-            // This case has been allowed in the past though it means introducing padding values to the data
-            return ttnn::experimental::view(tensor, logical_shape, padded_shape);
+            auto cloned = ttnn::clone(tensor, std::nullopt, tensor.memory_config(), std::nullopt);
+            return ttnn::experimental::view(cloned, logical_shape, padded_shape);
         }
         // This is a completely incorrect test but it is due to issue 15558
         TT_FATAL(false, "Attempting to reshape between two shapes with different volumes");

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -15,6 +15,7 @@
 
 #include "ttnn/operations/copy/typecast/typecast.hpp"
 #include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/data_movement/clone/clone.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/operations/data_movement/fill_pad/fill_pad.hpp"
 #include "ttnn/operations/data_movement/reshape_on_device/reshape.hpp"
@@ -610,17 +611,37 @@ ttnn::Tensor ttnn::reshape(
         return ttnn::experimental::view(tensor, logical_shape, padded_shape);
     }
 
-    bool this_is_view =
+    // Issue #40547: reshape must never return an aliased (zero-copy view) tensor.
+    // When the physical layout is compatible (same last dim, etc.) we still need
+    // to copy the data so the result has independent device memory. Clone first,
+    // then adjust shape metadata via PerformView.
+    // Clone cannot convert between sharded layouts / shard specs — those cases
+    // fall through to the device reshape path (which already copies).
+    // Use ttnn.experimental.view explicitly when zero-copy aliasing is intended.
+    bool shape_is_view_compatible =
         (tensor_shape_last_dim == shape_last_dim) && (mem_config.is_sharded() == tensor.memory_config().is_sharded()) &&
         (mem_config.is_l1() == tensor.memory_config().is_l1()) &&
-        ((tensor.layout() == ttnn::ROW_MAJOR_LAYOUT) ||              // Its row major
-         (tensor_shape_second_last_dim == shape_second_last_dim) ||  // Second last dimension is the same
-         (shape_second_last_dim % tile_second_dim == 0 &&
-          tensor_shape_second_last_dim % tile_first_dim == 0));  // There is no padding on the second last dimension
+        ((tensor.layout() == ttnn::ROW_MAJOR_LAYOUT) || (tensor_shape_second_last_dim == shape_second_last_dim) ||
+         (shape_second_last_dim % tile_second_dim == 0 && tensor_shape_second_last_dim % tile_first_dim == 0));
 
-    if (this_is_view) {
+    const auto& input_mem_config = tensor.memory_config();
+    const bool memory_config_clone_compatible = [&]() {
+        if (mem_config.memory_layout() != input_mem_config.memory_layout()) {
+            return false;
+        }
+        if (!mem_config.is_sharded()) {
+            return true;
+        }
+        // Clone requires identical shard specs when both ends are sharded.
+        const auto& out_spec = mem_config.shard_spec();
+        const auto& in_spec = input_mem_config.shard_spec();
+        return out_spec.has_value() && in_spec.has_value() && out_spec.value() == in_spec.value();
+    }();
+
+    if (shape_is_view_compatible && memory_config_clone_compatible) {
+        auto cloned = ttnn::clone(tensor, std::nullopt, mem_config, std::nullopt);
         return operations::data_movement::PerformView(
-            tensor, logical_shape, padded_shape, tile_first_dim, tile_second_dim);
+            cloned, logical_shape, padded_shape, tile_first_dim, tile_second_dim);
     }
     if (logical_shape.volume() != tensor.logical_volume()) {
         // This is completely incorrect but it is due to issue 15137 or issue 15558

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape_nanobind.cpp
@@ -34,10 +34,12 @@ ttnn::Tensor reshape_shape_vector_wrapper(
 
 void bind_reshape_view_operation(nb::module_& mod) {
     const auto* doc = R"doc(
-            Reshape always copies data and returns a tensor with independent device memory.
-            The result never aliases (shares memory with) the input tensor, so it is always
-            safe to deallocate the input after reshaping. Use ``ttnn.experimental.view`` when
-            zero-copy aliasing is explicitly desired.
+            On device tensors, reshape returns independent storage (not a zero-copy alias
+            of the input).  It is therefore safe to deallocate the input after reshaping.
+            Exception: ND_SHARDED device tensors currently retain zero-copy behavior
+            because CloneOperation does not yet support ND shard specs (tracked as TODO #40547).
+            Host tensors and zero-volume tensors may still be returned without a copy.
+            Use ``ttnn.experimental.view`` when zero-copy aliasing is explicitly desired.
 
             Args:
                 * input_tensor: Input Tensor.

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape_nanobind.cpp
@@ -34,9 +34,10 @@ ttnn::Tensor reshape_shape_vector_wrapper(
 
 void bind_reshape_view_operation(nb::module_& mod) {
     const auto* doc = R"doc(
-            Note: for a 0 cost view, the following conditions must be met:
-                * the last dimension must not change
-                * In Tiled the second last two dimensions must not change OR there is no padding on the second last dimension
+            Reshape always copies data and returns a tensor with independent device memory.
+            The result never aliases (shares memory with) the input tensor, so it is always
+            safe to deallocate the input after reshaping. Use ``ttnn.experimental.view`` when
+            zero-copy aliasing is explicitly desired.
 
             Args:
                 * input_tensor: Input Tensor.

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/sort.cpp
@@ -13,6 +13,7 @@
 #include "ttnn/operations/data_movement/slice/slice.hpp"
 #include "ttnn/tensor/shape/shape.hpp"
 #include "ttnn/operations/data_movement/transpose/transpose.hpp"
+#include "ttnn/operations/experimental/reshape/view.hpp"
 
 #include <numeric>
 
@@ -59,7 +60,20 @@ Tensor pre_sort_transform_tensor(
     }
 
     const Tensor transposed_tensor = reduction_common::perform_transpose(input_tensor, is_dim_last_idx, dim, -1);
-    const Tensor transformed_tensor = reduction_common::transform_to_4d_tensor(transposed_tensor, is_rank_le_4d);
+    // Use view (zero-copy) for rank ≤ 4 unsqueeze instead of ttnn::reshape,
+    // which now clones and would pollute the program cache.
+    const Tensor transformed_tensor = [&]() -> Tensor {
+        if (is_rank_le_4d) {
+            if (transposed_tensor.logical_shape().rank() == 4) {
+                return transposed_tensor;
+            }
+            return ttnn::experimental::view(
+                transposed_tensor,
+                transposed_tensor.logical_shape().to_rank(4),
+                transposed_tensor.padded_shape().to_rank(4));
+        }
+        return reduction_common::transform_to_4d_tensor(transposed_tensor, is_rank_le_4d);
+    }();
 
     Tensor padded_tensor = transformed_tensor;
     const bool is_row_major = (transformed_tensor.layout() == Layout::ROW_MAJOR);
@@ -159,14 +173,21 @@ std::vector<Tensor> post_sort_transform_tensor(
         }
     }
 
-    // Reshape back to original rank if needed
+    // Reshape back to original rank if needed.
+    // All rank-restoration paths are pure metadata changes (last dim unchanged).
+    // Use ttnn::experimental::view (zero-copy) to avoid the clone cost that
+    // ttnn::reshape now incurs, and to keep the program cache entry count at 1.
     if (orig_rank < 4 && orig_rank > 1) {
-        result[0] = ttnn::squeeze_from_4D(result[0], orig_rank);
-        result[1] = ttnn::squeeze_from_4D(result[1], orig_rank);
+        auto squeezed_shape_0 = result[0].logical_shape().to_rank(orig_rank);
+        auto squeezed_pshape_0 = result[0].padded_shape().to_rank(orig_rank);
+        result[0] = ttnn::experimental::view(result[0], squeezed_shape_0, squeezed_pshape_0);
+        auto squeezed_shape_1 = result[1].logical_shape().to_rank(orig_rank);
+        auto squeezed_pshape_1 = result[1].padded_shape().to_rank(orig_rank);
+        result[1] = ttnn::experimental::view(result[1], squeezed_shape_1, squeezed_pshape_1);
     } else if (orig_rank == 1) {
         const ttsl::SmallVector<uint32_t> result_shape(input_shape.cbegin(), input_shape.cend());
-        result[0] = ttnn::reshape(result[0], ttnn::Shape{result_shape});
-        result[1] = ttnn::reshape(result[1], ttnn::Shape{result_shape});
+        result[0] = ttnn::experimental::view(result[0], ttnn::Shape{result_shape});
+        result[1] = ttnn::experimental::view(result[1], ttnn::Shape{result_shape});
     } else if (orig_rank > 4) {
         // The 4D `result` tensor came from squeeze_from_ND_to_4D applied to the
         // *transposed* high-rank tensor (the sort dim was moved to the last
@@ -174,18 +195,17 @@ std::vector<Tensor> post_sort_transform_tensor(
         // back to the transposed N-D shape — NOT the original — so that the
         // subsequent `transpose` swaps it back to the user's layout.
         //
-        // Targeting the transposed shape keeps the last dim unchanged, which
-        // triggers ttnn::reshape's `this_is_view` fast path (pure metadata via
-        // ttnn::experimental::view) and entirely bypasses the device reshape
-        // kernel.  This is essential for UINT16 indices, which the device
-        // reshape kernel rejects, and avoids the cost of a dtype round-trip.
+        // Targeting the transposed shape keeps the last dim unchanged, so this
+        // is a pure metadata change.  Use ttnn::experimental::view (zero-copy)
+        // to bypass the device reshape kernel — essential for UINT16 indices,
+        // which the device reshape kernel rejects.
         ttsl::SmallVector<uint32_t> reshape_target(input_shape.cbegin(), input_shape.cend());
         if (!is_dim_last_idx) {
             const int normalized = dim < 0 ? orig_rank + dim : dim;
             std::swap(reshape_target[normalized], reshape_target[orig_rank - 1]);
         }
-        result[0] = ttnn::reshape(result[0], ttnn::Shape{reshape_target});
-        result[1] = ttnn::reshape(result[1], ttnn::Shape{reshape_target});
+        result[0] = ttnn::experimental::view(result[0], ttnn::Shape{reshape_target});
+        result[1] = ttnn::experimental::view(result[1], ttnn::Shape{reshape_target});
     }
 
     // Transpose back to original dimension order if needed

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/reshape.cpp
@@ -15,6 +15,7 @@
 
 #include "ttnn/operations/copy/typecast/typecast.hpp"
 #include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/data_movement/clone/clone.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/operations/data_movement/fill_pad/fill_pad.hpp"
 #include "ttnn/operations/data_movement/reshape_on_device/reshape.hpp"
@@ -622,16 +623,31 @@ ttnn::Tensor ttnn::operations::experimental::quasar::reshape(
         return ttnn::experimental::view(tensor, logical_shape, padded_shape);
     }
 
-    bool this_is_view =
+    // Clone first to get independent storage, then adjust shape metadata.
+    // Clone cannot convert between sharded layouts / shard specs — fall through
+    // to the device reshape path in that case (it already copies).
+    bool shape_is_view_compatible =
         (tensor_shape_last_dim == shape_last_dim) && (mem_config.is_sharded() == tensor.memory_config().is_sharded()) &&
         (mem_config.is_l1() == tensor.memory_config().is_l1()) &&
-        ((tensor.layout() == ttnn::ROW_MAJOR_LAYOUT) ||              // Its row major
-         (tensor_shape_second_last_dim == shape_second_last_dim) ||  // Second last dimension is the same
-         (shape_second_last_dim % tile_second_dim == 0 &&
-          tensor_shape_second_last_dim % tile_first_dim == 0));  // There is no padding on the second last dimension
+        ((tensor.layout() == ttnn::ROW_MAJOR_LAYOUT) || (tensor_shape_second_last_dim == shape_second_last_dim) ||
+         (shape_second_last_dim % tile_second_dim == 0 && tensor_shape_second_last_dim % tile_first_dim == 0));
 
-    if (this_is_view) {
-        return PerformView(tensor, logical_shape, padded_shape, tile_first_dim, tile_second_dim);
+    const auto& input_mem_config = tensor.memory_config();
+    const bool memory_config_clone_compatible = [&]() {
+        if (mem_config.memory_layout() != input_mem_config.memory_layout()) {
+            return false;
+        }
+        if (!mem_config.is_sharded()) {
+            return true;
+        }
+        const auto& out_spec = mem_config.shard_spec();
+        const auto& in_spec = input_mem_config.shard_spec();
+        return out_spec.has_value() && in_spec.has_value() && out_spec.value() == in_spec.value();
+    }();
+
+    if (shape_is_view_compatible && memory_config_clone_compatible) {
+        auto cloned = ttnn::clone(tensor, std::nullopt, mem_config, std::nullopt);
+        return PerformView(cloned, logical_shape, padded_shape, tile_first_dim, tile_second_dim);
     }
     if (logical_shape.volume() != tensor.logical_volume()) {
         // This is completely incorrect but it is due to issue 15137 or issue 15558

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/reshape.cpp
@@ -590,7 +590,21 @@ ttnn::Tensor ttnn::operations::experimental::quasar::reshape(
     const auto [logical_shape, padded_shape] = shape_corrector(tensor, logical_input_shape, padded_input_shape);
     // First Case, No reshape Required
     if (tensor.logical_shape() == logical_shape && tensor.padded_shape() == padded_shape) {
-        return tensor;
+        // Host: returning the same tensor is fine (no device-dealloc hazard).
+        if (!is_device_tensor(tensor)) {
+            return tensor;
+        }
+        // TODO(#40547): CloneOperation does not support ND_SHARDED yet; return
+        // the original tensor (zero-copy) until clone gains ND-shard awareness.
+        // Gate on the *input* layout so an interleaved→ND request falls through
+        // instead of silently returning the input.
+        if (tensor.memory_config().memory_layout() == TensorMemoryLayout::ND_SHARDED) {
+            return tensor;
+        }
+        // Device (#40547): do not clone unconditionally here — CloneOperation
+        // rejects mixed/differing sharded configs. Fall through so the
+        // memory_config_clone_compatible check below can clone when safe, or
+        // route incompatible memory_config conversions to device reshape.
     }
     PadValue default_pad_value;
     if (tensor.dtype() == DataType::BFLOAT8_B or tensor.dtype() == DataType::BFLOAT16 or
@@ -640,6 +654,11 @@ ttnn::Tensor ttnn::operations::experimental::quasar::reshape(
         if (!mem_config.is_sharded()) {
             return true;
         }
+        // TODO(#40547): CloneOperation does not support ND_SHARDED yet.
+        if (mem_config.memory_layout() == TensorMemoryLayout::ND_SHARDED) {
+            return false;
+        }
+        // Clone requires identical shard specs when both ends are sharded.
         const auto& out_spec = mem_config.shard_spec();
         const auto& in_spec = input_mem_config.shard_spec();
         return out_spec.has_value() && in_spec.has_value() && out_spec.value() == in_spec.value();
@@ -657,8 +676,8 @@ ttnn::Tensor ttnn::operations::experimental::quasar::reshape(
              padded_shape[-1] % tile.get_width() == 0 and tensor.padded_shape()[-1] == padded_shape[-1]);
 
         if (tile_tensor_view_reshape_possible) {
-            // This case has been allowed in the past though it means introducing padding values to the data
-            return ttnn::experimental::view(tensor, logical_shape, padded_shape);
+            auto cloned = ttnn::clone(tensor, std::nullopt, tensor.memory_config(), std::nullopt);
+            return ttnn::experimental::view(cloned, logical_shape, padded_shape);
         }
         // This is a completely incorrect test but it is due to issue 15558
         TT_FATAL(false, "Attempting to reshape between two shapes with different volumes");


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-metal/issues/40547

### Summary
`ttnn.reshape` previously returned a zero-copy view (aliased memory) when the physical layout was compatible (same last dim, matching sharding/L1, etc.). That made it unsafe to deallocate the input after reshape — the reshaped tensor could be invalidated.

This PR makes reshape always copy by default (on device tensors):
- When the shape is view-compatible, clone the tensor first, then apply shape metadata via `PerformView`.
- Same-shape reshape (previously a no-op returning the input) also clones on device, so force-deallocating the input cannot invalidate the result.
- Callers that intentionally want zero-copy aliasing must use `ttnn.experimental.view`.

Also updates:
- Python docstring / nanobind docs to match the new contract
- Quasar reshape path with the same clone-then-view behavior
- `ttnn.sort` pre- and post-processing to call `ttnn::experimental::view` explicitly (it relied on reshape's old view fast path; needed for UINT16 indices that the device reshape kernel rejects, and to avoid clone cost / program-cache pollution on rank ≤ 4 unsqueeze)
- New unit tests `test_reshape_no_aliasing` and `test_reshape_no_aliasing_same_shape` that deallocate the input and check the reshaped tensor still works

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/reshape_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/reshape_copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/reshape_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/reshape_copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=virdhatchani/reshape_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:virdhatchani/reshape_copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/reshape_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/reshape_copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/reshape_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/reshape_copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/reshape_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/reshape_copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/reshape_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/reshape_copy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/reshape_copy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/reshape_copy)