### PR TITLE
[tt-triage] Replace mdashes with regular dashes

### DIFF
--- a/tools/triage/check_broken_components.py
+++ b/tools/triage/check_broken_components.py
@@ -111,7 +111,7 @@ def verify_halted_cores(run_checks: RunChecks) -> None:
         risc_debug = location.noc_block.get_risc_debug(risc_name)
         if not risc_debug.is_halted():
             log_warning_risc(
-                risc_name, location, "Was halted by triage but is no longer halted — core was broken during triage."
+                risc_name, location, "Was halted by triage but is no longer halted - core was broken during triage."
             )
             session.add_broken_core(location, risc_name)
         return None

--- a/tools/triage/device_info.py
+++ b/tools/triage/device_info.py
@@ -12,7 +12,7 @@ Description:
     postcode state. One row per device.
 
     Groups multiple chips that share a physical sub-unit through the `Tray/Board`
-    column — UBB tray (1..4) on Wormhole/Blackhole Galaxy boards, board id on
+    column - UBB tray (1..4) on Wormhole/Blackhole Galaxy boards, board id on
     N300/P300, and board id on single-chip boards. Sort by that column to
     recover the "chips per tray/board" view.
 

--- a/tools/triage/dispatcher_data.py
+++ b/tools/triage/dispatcher_data.py
@@ -85,7 +85,7 @@ class DispatcherCoreData:
     # Whether kernel_config.enables turned this specific risc on. False => idle by design (no kernel
     # launched on it). None => unknown (read failed / corrupt), so callers must not hide the core.
     risc_enabled_by_kernel: bool | None = None
-    # Hint surfaced when find_kernel fails — explains the most likely cause (program cache off,
+    # Hint surfaced when find_kernel fails - explains the most likely cause (program cache off,
     # or workload destroyed despite cache being on) so callers can append it to "PC not in range" style errors.
     kernel_lookup_warning: str | None = None
 
@@ -282,7 +282,7 @@ class DispatcherData:
                 f"Enable program cache to see the callstack."
             )
         return (
-            "No host-side live program owns the kernel on this device —"
+            "No host-side live program owns the kernel on this device -"
             " the program should remain alive on host while its kernel is running."
         )
 

--- a/tools/triage/dump_op_mesh.py
+++ b/tools/triage/dump_op_mesh.py
@@ -21,10 +21,10 @@ Description:
     that has no live ops shows `(idle)`; a device on this host that this
     process never opened shows `(unused)`; cross-host chips show `(remote)`.
 
-    A leading `[!] ` on an op line marks that op as a *straggler* — its
+    A leading `[!] ` on an op line marks that op as a *straggler* - its
     `host_assigned_id` is strictly less than the highest live id in the
     mesh (the leading edge of dispatch). In a hang, the leading-edge chips
-    are themselves stuck — they're waiting on the stragglers to finish —
+    are themselves stuck - they're waiting on the stragglers to finish -
     so stragglers are the root cause and get the marker; leading-edge ops
     stay clean. On a multi-op chip, only the lagging op line is flagged;
     the leading-edge op on the same chip is unmarked. In a healthy mesh
@@ -86,7 +86,7 @@ def _leading_edge_op_id(aggregations: dict[int, RunningOperationAggregation]) ->
 
 
 def _ubb_prefix(cd, chip_id: int) -> str:
-    # `get_tray_id` returns None for non-UBB boards by contract — use that as the predicate.
+    # `get_tray_id` returns None for non-UBB boards by contract - use that as the predicate.
     tray = cd.get_tray_id(chip_id)
     if tray is None:
         return ""

--- a/tools/triage/dump_running_operations.py
+++ b/tools/triage/dump_running_operations.py
@@ -22,8 +22,8 @@ Description:
           - Devices / Cores: enumerated lists (may be truncated with "..." for readability)
 
     Companion scripts:
-      - `dump_op_window` — context table of ops with id near the currently-running set.
-      - `dump_op_mesh` — 2D mesh-grid view of running ops, sourced from Inspector's system mesh.
+      - `dump_op_window` - context table of ops with id near the currently-running set.
+      - `dump_op_mesh` - 2D mesh-grid view of running ops, sourced from Inspector's system mesh.
       All share the same aggregation via `operation_provider` (use `--include-done`
       on the triage CLI to surface DONE cores in every consumer).
 

--- a/tools/triage/helpers/parse_debug_bus_json.py
+++ b/tools/triage/helpers/parse_debug_bus_json.py
@@ -241,7 +241,7 @@ def main() -> None:
                 if not selected_groups:
                     continue
                 printed_any = True
-                INFO(f"\n[{device_key}] {block_type} — {loc_key}")
+                INFO(f"\n[{device_key}] {block_type} - {loc_key}")
                 WARN(f"Failed RISCs: {loc_data['failed_riscs']}")
                 _print_groups_for_location(selected_groups, debug_bus, groups_data)
 

--- a/tools/triage/inspector_data.py
+++ b/tools/triage/inspector_data.py
@@ -214,7 +214,7 @@ def run(args, context) -> InspectorData:
     except:
         raise InspectorException(
             f"Inspector unavailable (no live RPC at {rpc_host}:{rpc_port}, no serialized logs at {log_directory}). "
-            "This usually means no Metal workload is currently running — there's nothing to triage.\n"
+            "This usually means no Metal workload is currently running - there's nothing to triage.\n"
             "  If you're debugging a live hang, keep the process alive while running triage in another terminal.\n"
             "  If you're analyzing a past run, point --inspector-log-path at the saved logs."
         )

--- a/tools/triage/operation_provider.py
+++ b/tools/triage/operation_provider.py
@@ -14,7 +14,7 @@ Options:
 Description:
     Data provider for the running-ops view chain. Builds two things:
 
-      1. An `OperationRuntimeMap` — Inspector runtime_id → OperationInfo
+      1. An `OperationRuntimeMap` - Inspector runtime_id → OperationInfo
          (name, parameters, trace_id). The mailbox holds the raw runtime_id
          for both fast and slow dispatch (see tt_metal/impl/program/dispatch.cpp
          and tt_metal/impl/host_api/tt_metal.cpp).
@@ -61,7 +61,7 @@ script_config = ScriptConfig(
 )
 
 
-# Core filtering — matches the historical block list from dump_running_operations.
+# Core filtering - matches the historical block list from dump_running_operations.
 BLOCK_TYPES_TO_CHECK = ["tensix", "idle_eth", "active_eth", "dram"]
 
 # Matches the sentinel in rpc.capnp (kNoTraceId). Capnp has no null for primitives.

--- a/tools/triage/run_checks.py
+++ b/tools/triage/run_checks.py
@@ -135,13 +135,13 @@ def get_devices(
         metal_device_ids = list(inspector_data.getDevicesInUse().metalDeviceIds)
 
         if len(metal_device_ids) == 0:
-            # Live "in use" list is empty — most often because firmware init failed and
+            # Live "in use" list is empty - most often because firmware init failed and
             # devices were torn down. Fall back to the SystemMesh's configured local set.
             system_mesh = inspector_data.getSystemMesh().systemMesh
             metal_device_ids = [m.localChipId for m in system_mesh.mappedDevices if m.isLocal]
             if len(metal_device_ids) > 0:
                 utils.WARN(
-                    f"  No devices in use found in inspector data — firmware init likely failed. "
+                    f"  No devices in use found in inspector data - firmware init likely failed. "
                     f"Falling back to the {len(metal_device_ids)} device(s) configured in the System Mesh."
                 )
             else:
@@ -233,7 +233,7 @@ def get_block_locations(
         for block_type in BLOCK_TYPES:
             block_locations[device][block_type] = _exalens_block_locations(device, block_type)
 
-    # Keep only the requested locations. Only logical coordinates are accepted — physical (noc0)
+    # Keep only the requested locations. Only logical coordinates are accepted - physical (noc0)
     # layout shifts with harvesting, so a logical string maps to the same core on every device.
     if locations:
         for loc in locations:

--- a/tools/triage/serializers.py
+++ b/tools/triage/serializers.py
@@ -34,7 +34,7 @@ def extract_table_data(result: Any, verbose_level: int = 0) -> TableData | None:
     Convert a dataclass or list-of-dataclasses to a `TableData`.
 
     Returns `None` for results that aren't a dataclass or non-empty list of
-    dataclasses — those are emitted as plain strings by serializers.
+    dataclasses - those are emitted as plain strings by serializers.
     """
     if not (
         is_dataclass(result)
@@ -129,7 +129,7 @@ class Sink(ABC):
 
 class ConsoleSink(Sink):
     """`Sink` backed by a Rich console. Supports plain lines and Rich
-    renderables (tables, panels) — the latter is needed by `RichSerializer`."""
+    renderables (tables, panels) - the latter is needed by `RichSerializer`."""
 
     def __init__(self, console: Any):
         self._console = console
@@ -237,7 +237,7 @@ def _strip_rich_markup(s: str) -> str:
 
     Some script messages contain bracketed text that looks like markup but
     isn't (e.g. `[!] core`, `[0x...]`, coordinate strings like `[1-1 (0,0)]`).
-    Rich raises `MarkupError` on those — fall back to the original string in
+    Rich raises `MarkupError` on those - fall back to the original string in
     that case so we never crash on otherwise valid triage output.
     """
     from rich.errors import MarkupError

--- a/tools/triage/triage.py
+++ b/tools/triage/triage.py
@@ -983,7 +983,7 @@ def main():
             for script in script_queue:
                 progress.update(scripts_task, description=f"Running {script.name}")
                 if not all(not dep.failed for dep in script.depends):
-                    # Silently mark as skipped — the original root-cause failure already
+                    # Silently mark as skipped - the original root-cause failure already
                     # printed its own message; cascading "Cannot run due to failed dependencies"
                     # lines for every downstream script are noise.
                     script.failed = True

--- a/tools/triage/tt-triage.md
+++ b/tools/triage/tt-triage.md
@@ -34,7 +34,7 @@ If a check is critical (such as a missing ELF file), the script should raise a `
 
 ### Data visualization
 
-`tt-triage` will try to visualize data returned by scripts, so it is important to describe the data accordingly. For example, see `dump_callstacks` — `tt-triage` would generate a table with all callstacks.
+`tt-triage` will try to visualize data returned by scripts, so it is important to describe the data accordingly. For example, see `dump_callstacks` - `tt-triage` would generate a table with all callstacks.
 
 #### dump_callstacks output modes
 


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Cleanup

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Mdashes are multichar that can meddle with mpirun's piping buffer of 2kb, if the buffer's end happens to split the mdash multichar, next one will not be able to be decoded so mpirun will crash.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=onenezic/triage-health)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:onenezic/triage-health)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=onenezic/triage-health)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:onenezic/triage-health)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=onenezic/triage-health)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:onenezic/triage-health)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=onenezic/triage-health)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:onenezic/triage-health)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=onenezic/triage-health)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:onenezic/triage-health)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=onenezic/triage-health)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:onenezic/triage-health)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=onenezic/triage-health)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:onenezic/triage-health)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=onenezic/triage-health)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:onenezic/triage-health)