### PR TITLE
fix: add missing MlaKvCaches module (deepseek_v3_d_p prefill runner)

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/runners/kv_caches.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/kv_caches.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass
+from typing import Optional
+
+import ttnn
+from models.demos.common.prefill.adapter import KvCaches
+
+
+@dataclass
+class MlaKvCaches(KvCaches):
+    """Concrete KvCaches for the MLA/DSA prefill runner: the primary MLA KVPE cache (``kvpe``) and an
+    optional sparse-DSA indexer key cache (``index``, ``None`` for dense MLA). The adapters' allocate_kv_cache
+    builds it and TtPrefillRuntime consumes it via ``.kvpe`` / ``.index``."""
+
+    kvpe: ttnn.Tensor
+    index: Optional[ttnn.Tensor] = None


### PR DESCRIPTION
### What & why

PR #49618 (`31011763fcb`, merged 2026-07-17 12:19 UTC) switched the deepseek_v3_d_p prefill adapters + runtime to `from models.demos.deepseek_v3_d_p.tt.runners.kv_caches import MlaKvCaches`, but **never committed `kv_caches.py`**. `class MlaKvCaches` exists in no ref, so importing any of those adapters raises `ModuleNotFoundError`.

`tests/conftest.py` imports every adapter at collection time, so this breaks collection of **all deepseek_v3_d_p prefill tests** on `main` (e.g. `test_prefill_transformer_chunked`, `test_prefill_block`).

### Fix

Add the missing `runners/kv_caches.py` defining `MlaKvCaches` — reconstructed from its only call sites:
- `adapters/{mla,glm_5_1,glm_5_2}.py::allocate_kv_cache` build it as `MlaKvCaches(kvpe=..., index=...)` (dense MLA passes only `kvpe`).
- `TtPrefillRuntime` reads `.kvpe` / `.index`.

A `KvCaches` subclass (the abstract base has no abstract methods) holding the MLA KVPE cache plus an optional DSA indexer key cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/fix-mla-kv-caches-module)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/fix-mla-kv-caches-module)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/fix-mla-kv-caches-module)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/fix-mla-kv-caches-module)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ipotkonjak/fix-mla-kv-caches-module)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ipotkonjak/fix-mla-kv-caches-module)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/fix-mla-kv-caches-module)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/fix-mla-kv-caches-module)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/fix-mla-kv-caches-module)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/fix-mla-kv-caches-module)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/fix-mla-kv-caches-module)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/fix-mla-kv-caches-module)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/fix-mla-kv-caches-module)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/fix-mla-kv-caches-module)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/fix-mla-kv-caches-module)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/fix-mla-kv-caches-module)