### PR TITLE
[emule] NOC-aware multicast: undo the NOC1 coordinate swap in __emule_multicast_write

### DIFF
--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -327,7 +327,7 @@ extern "C" bool __emule_noc_addr_is_dram(uint64_t noc_addr) {
 // silicon clears the bit and the sender NIU drops the packet at itself ->
 // include_self=false. Sender coords come from the TLS that thread launch
 // wires up (my_x[0], my_y[0]).
-extern "C" void __emule_multicast_write(uint64_t mcast_addr, const uint8_t* src, uint32_t size, bool include_self) {
+extern "C" void __emule_multicast_write(uint64_t mcast_addr, const uint8_t* src, uint32_t size, bool include_self, uint8_t noc) {
     uint32_t x_end = (mcast_addr >> NOC_LOCAL_BITS) & NOC_NODE_MASK;
     uint32_t y_end = (mcast_addr >> (NOC_LOCAL_BITS + NOC_NODE_ID_BITS)) & NOC_NODE_MASK;
     uint32_t x_start = (mcast_addr >> (NOC_LOCAL_BITS + 2 * NOC_NODE_ID_BITS)) & NOC_NODE_MASK;
@@ -350,9 +350,37 @@ extern "C" void __emule_multicast_write(uint64_t mcast_addr, const uint8_t* src,
     uint32_t self_x = my_x[0];
     uint32_t self_y = my_y[0];
 
+    // NOC1 rectangles arrive with start<->end SWAPPED: silicon describes a NOC1
+    // multicast in NOC1's reflected coordinate frame (paired with the DYNAMIC_NOC_X/Y
+    // reflection). Emule models NOC coordinates as identity (DYNAMIC_NOC_X/Y is
+    // identity), so no reflection happens and the swap alone leaves the rectangle
+    // reversed. Undo it so the walk below runs on physical (NOC0-frame) coordinates
+    // for both NOCs. Without this, canonical NOC1 in0/in1-mcast ops (matmul/linear,
+    // multicore argmax) present start>end and the torus walk misreads it as a
+    // wraparound → receivers never see their semaphore → quiescent deadlock.
+    if (noc != 0) {
+        uint32_t t;
+        t = x_start; x_start = x_end; x_end = t;
+        t = y_start; y_start = y_end; y_end = t;
+    }
+
+    // Torus-wraparound walk on physical coords. Silicon's NOC treats the rectangle on
+    // a torus, so a rectangle whose cores straddle the worker-grid seam encodes
+    // start > end and wraps around the NOC node space rather than covering the min..max
+    // bounding box; SDPA S-block multicasts (NOC0) rely on this. Walk each axis
+    // start->end stepping +1 mod the node space; coords with no core in the map are
+    // skipped. For a non-wrapping rectangle (start <= end) this is identical to
+    // min..max — the post-un-swap NOC1 case (matmul/argmax in0-mcast).
+    auto axis_count = [](uint32_t s, uint32_t e) -> uint32_t {
+        return (e >= s ? (e - s) : ((NOC_NODE_MASK + 1 - s) + e)) + 1;
+    };
+    const uint32_t nx = axis_count(x_start, x_end);
+    const uint32_t ny = axis_count(y_start, y_end);
     uint32_t delivered = 0;
-    for (uint32_t x = std::min(x_start, x_end); x <= std::max(x_start, x_end); x++) {
-        for (uint32_t y = std::min(y_start, y_end); y <= std::max(y_start, y_end); y++) {
+    for (uint32_t ix = 0; ix < nx; ix++) {
+        const uint32_t x = (x_start + ix) & NOC_NODE_MASK;
+        for (uint32_t iy = 0; iy < ny; iy++) {
+            const uint32_t y = (y_start + iy) & NOC_NODE_MASK;
             if (!include_self && x == self_x && y == self_y) {
                 continue;
             }


### PR DESCRIPTION
## What

Makes the emulated-device multicast delivery (`__emule_multicast_write`) **NOC-aware**: it now takes the sender NOC and, for NOC1, undoes the `start↔end` coordinate swap before walking the rectangle as a torus.

## Why

`__emule_multicast_write` walked the multicast rectangle as an axis-wise **min…max bounding box**. That silently conflates the two coordinate conventions silicon uses:

- A **NOC1** multicast is described in NOC1's *reflected* coordinate frame, so the address builder emits the rectangle with `start↔end` swapped. emule models NOC coordinates as identity (no per-NOC reflection), so a NOC1 rectangle arrives reversed (`start>end`).
- A **NOC0** multicast whose cores straddle the worker-grid seam is a genuine **torus wraparound** (`start>end`), not a bounding box.

`min…max` collapsed both to the same box — accidentally fine for NOC1 (the reversal is harmless under min/max) but **wrong for a genuine NOC0 torus wrap**, which it over-covers.

## Change

Take the sender `noc`; for NOC1 undo the `start↔end` swap to recover physical coordinates, then walk the rectangle as a torus:

- A non-wrapping rectangle (`start ≤ end`) is **identical to the previous min…max** — so NOC1 in0/in1-mcast (matmul/linear, multicore argmax) is unchanged in effect.
- A genuine NOC0 wrap now delivers to exactly the wrapped cores instead of the over-covering bounding box.

The `noc` argument is supplied by the kernel-facing multicast shims. This is **emule-only** (the function is compiled under `TT_METAL_USE_EMULE`); it has **no effect on non-emule builds**, and there are no in-tree callers of the changed signature.

## Testing

Exercised through the tt-emule software emulator against the emule kernel shims (which forward the NOC): canonical multicore ops that route their in0/in1-mcast through this path — `matmul`/`linear` (`test_linear_fp32_acc`) and multicore `argmax` (`test_argmax … use_multicore=True`) — deliver correctly, and NOC0 torus-wrap SDPA multicasts deliver to exactly their target cores. No behavior change for the non-wrapping (bounding-box) case.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=xchin/emule-noc-aware-multicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:xchin/emule-noc-aware-multicast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=xchin/emule-noc-aware-multicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:xchin/emule-noc-aware-multicast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=xchin/emule-noc-aware-multicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:xchin/emule-noc-aware-multicast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=xchin/emule-noc-aware-multicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:xchin/emule-noc-aware-multicast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=xchin/emule-noc-aware-multicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:xchin/emule-noc-aware-multicast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=xchin/emule-noc-aware-multicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:xchin/emule-noc-aware-multicast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=xchin/emule-noc-aware-multicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:xchin/emule-noc-aware-multicast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=xchin/emule-noc-aware-multicast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:xchin/emule-noc-aware-multicast)