### PR TITLE
emule fiber: rename read_latency primitive to defer_to_quiescence

### DIFF
--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -261,7 +261,7 @@ extern "C" void __emule_fiber_park_locked(const void* key) {
 }
 extern "C" void __emule_fiber_wake(const void* key) { efib::FiberScheduler::instance().wake(key); }
 extern "C" void __emule_fiber_yield(void) { efib::FiberScheduler::instance().yield(); }
-extern "C" void __emule_fiber_read_latency(void) { efib::FiberScheduler::instance().latency_park(); }
+extern "C" void __emule_fiber_defer_to_quiescence(void) { efib::FiberScheduler::instance().quiescence_park(); }
 extern "C" void __emule_fiber_note_publish(unsigned pages) {
     efib::FiberScheduler::instance().note_publish(pages);
 }

--- a/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
+++ b/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
@@ -36,7 +36,7 @@ namespace tt::tt_metal::emule_fiber {
 
 namespace {
 
-enum class FiberState : uint8_t { Ready, Running, Parked, LatencyParked, Done };
+enum class FiberState : uint8_t { Ready, Running, Parked, QuiescenceDeferred, Done };
 
 struct Fiber {
     ucontext_t ctx{};
@@ -85,8 +85,9 @@ struct FiberSchedulerImpl {
     std::vector<std::deque<Fiber*>> ready_;            // per-worker ready queues (fibers are
                                                        // pinned: ready_[w] holds only home==w)
     std::unordered_map<const void*, Fiber*> parked_;   // key -> intrusive list head
-    std::vector<Fiber*> latency_parked_;               // fibers modeling NOC read latency:
-                                                       // released only at quiescence (below)
+    std::vector<Fiber*> quiescence_deferred_;          // fibers deferred to quiescence: re-queued
+                                                       // at lowest priority, released only once the
+                                                       // scheduler reaches quiescence (below)
     std::vector<std::unique_ptr<Fiber>> all_;          // ownership of every spawned fiber
 
     unsigned K_ = 1;           // persistent pool size (read once at pool creation)
@@ -194,16 +195,18 @@ void FiberSchedulerImpl::inner_loop(unsigned w) {
             // at W>1 (a worker counts itself idle before re-observing a just-enqueued
             // fiber). See tt-emule docs/fiber-engine.md.
             if (idle_ == W_ && running_ == 0 && !any_ready()) {
-                // Read-latency model: a latency-parked fiber is an in-flight read. At
-                // quiescence the read "completes" — release them all (lowest priority),
-                // reproducing the silicon ordering some kernels lean on.
+                // Quiescence-defer release: a deferred fiber was re-queued at lowest
+                // priority to run only once every other runnable fiber has. We are at
+                // that quiescence point now — release them all back to ready. Clients
+                // use this to reproduce a silicon ordering (e.g. argmax's first read
+                // barrier, or a two-producer cb_wait_front letting its co-producer run).
                 // See tt-emule docs/fiber-engine.md.
-                if (!latency_parked_.empty()) {
-                    for (Fiber* f : latency_parked_) {
+                if (!quiescence_deferred_.empty()) {
+                    for (Fiber* f : quiescence_deferred_) {
                         f->state = FiberState::Ready;
                         ready_[f->home].push_back(f);
                     }
-                    latency_parked_.clear();
+                    quiescence_deferred_.clear();
                     cv_.notify_all();
                     --idle_;
                     continue;
@@ -266,17 +269,19 @@ void FiberScheduler::park_locked(const void* key) {
     swapcontext(&f->ctx, &t_sched);          // -> worker loop (mu_ held); resumes mu_-UNLOCKED
 }
 
-void FiberScheduler::latency_park() {
-    // Model NOC read latency: defer the current fiber as lowest-priority "in-flight" work,
-    // released only at quiescence (see worker_loop). No key, no predicate; takes mu_ itself
-    // and hands it to the worker loop across the switch (mirrors park_locked).
+void FiberScheduler::quiescence_park() {
+    // Defer the current fiber to scheduler quiescence: re-queue it at lowest priority,
+    // released only once every other runnable fiber has run (see worker_loop). No key, no
+    // predicate; takes mu_ itself and hands it to the worker loop across the switch (mirrors
+    // park_locked). Clients use it to reproduce a silicon ordering (argmax's first read
+    // barrier; a two-producer cb_wait_front letting its co-producer run).
     Fiber* f = t_current;
     if (!f) {
-        return;  // read barriers only run inside a fiber; insurance against a host-side call
+        return;  // only meaningful inside a fiber; insurance against a host-side call
     }
     p_->mu_.lock();
-    f->state = FiberState::LatencyParked;
-    p_->latency_parked_.push_back(f);
+    f->state = FiberState::QuiescenceDeferred;
+    p_->quiescence_deferred_.push_back(f);
     swapcontext(&f->ctx, &t_sched);          // -> worker loop (mu_ held); resumes mu_-UNLOCKED
 }
 
@@ -381,8 +386,8 @@ std::string FiberSchedulerImpl::dump_parked() {
             os << " waiting on " << (name ? name : "sync object") << " (key " << key << ")\n";
         }
     }
-    if (!latency_parked_.empty()) {
-        os << "  " << latency_parked_.size() << " fiber(s) in read-latency flight\n";
+    if (!quiescence_deferred_.empty()) {
+        os << "  " << quiescence_deferred_.size() << " fiber(s) deferred to quiescence\n";
     }
     return os.str();
 }
@@ -454,7 +459,7 @@ void FiberScheduler::run_until_idle() {
         p_->deadlock_ = false;
         p_->abort_flag_ = false;
         p_->first_eptr_ = nullptr;
-        p_->latency_parked_.clear();
+        p_->quiescence_deferred_.clear();
         p_->progress_.store(0);
         p_->resumptions_.store(0);
         // Activate W = min(K, fiber count) workers; pin each fiber round-robin across [0,W).
@@ -506,7 +511,7 @@ void FiberScheduler::run_until_idle() {
         }
         p_->ready_.clear();
         p_->parked_.clear();
-        p_->latency_parked_.clear();
+        p_->quiescence_deferred_.clear();
         p_->all_.clear();   // frees Fiber stacks via ~Fiber
     }
 

--- a/tt_metal/impl/emulation/emule_fiber_scheduler.hpp
+++ b/tt_metal/impl/emulation/emule_fiber_scheduler.hpp
@@ -50,7 +50,7 @@ public:
     void lock();
     void unlock();
     void park_locked(const void* key);  // pre: lock held; post: lock released
-    void latency_park();                 // model NOC read latency; released at quiescence
+    void quiescence_park();              // defer to quiescence: re-queue lowest-priority, released at quiescence
     void wake(const void* key);
     void yield();
     void note_publish(unsigned pages);


### PR DESCRIPTION
## What

Pure rename of the tt-emule software-emulator fiber-scheduler "defer to quiescence"
primitive, so it is no longer named after its first client (NOC read-latency modeling).
All under `tt_metal/impl/emulation/` (the emule mock runner); **no behavior change** and
**no effect on non-emule builds**.

- extern-C bridge `__emule_fiber_read_latency` → `__emule_fiber_defer_to_quiescence`
- `FiberScheduler::latency_park()` → `quiescence_park()`
- `FiberState::LatencyParked` → `QuiescenceDeferred`
- member `latency_parked_` → `quiescence_deferred_`
- diagnostic dump "N fiber(s) in read-latency flight" → "N fiber(s) deferred to quiescence"

## Why

The mechanism re-queues a fiber at lowest priority and releases it only once the scheduler
reaches quiescence. It was named entirely after its first client (argmax's first-read-barrier
ordering). A second, unrelated client — a two-producer `cb_wait_front` that lets a cross-RISC
co-producer run (tt-emule-blaze#43/#48) — makes the `read_latency` spelling a non-sequitur at
that call site. The read-latency naming now lives only on the argmax client wrapper
(`__emule_model_first_read_latency`), which genuinely models read latency and calls the renamed
primitive underneath.

## Context

Companion to tt-emule-blaze#47 / tt-emule-blaze#75. Cherry-picked onto the emule metal fast-lane
branch `emule-blaze-metal-fork`, which `tt-emule-blaze/tt-metal-pin.txt` tracks.

Release-at-quiescence logic is byte-identical; the extern-C symbol and all internal names are
renamed symmetrically (no old names remain).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sgholami/emule-fiber-defer-to-quiescence)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sgholami/emule-fiber-defer-to-quiescence)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sgholami/emule-fiber-defer-to-quiescence)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sgholami/emule-fiber-defer-to-quiescence)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=sgholami/emule-fiber-defer-to-quiescence)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:sgholami/emule-fiber-defer-to-quiescence)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sgholami/emule-fiber-defer-to-quiescence)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sgholami/emule-fiber-defer-to-quiescence)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sgholami/emule-fiber-defer-to-quiescence)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sgholami/emule-fiber-defer-to-quiescence)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sgholami/emule-fiber-defer-to-quiescence)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sgholami/emule-fiber-defer-to-quiescence)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sgholami/emule-fiber-defer-to-quiescence)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sgholami/emule-fiber-defer-to-quiescence)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sgholami/emule-fiber-defer-to-quiescence)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sgholami/emule-fiber-defer-to-quiescence)