### PR TITLE
[tt-triage] Allow simple table borders

### DIFF
--- a/tools/triage/serializers.py
+++ b/tools/triage/serializers.py
@@ -217,7 +217,7 @@ class RichSerializer(OutputSerializer):
             utils.INFO(f"  {result}")
             return
 
-        table = Table()
+        table = Table(box=_table_box())
         for col in table_data.columns:
             table.add_column(col, justify="left")
         for row in table_data.rows:
@@ -226,6 +226,13 @@ class RichSerializer(OutputSerializer):
 
     def close(self) -> None:
         self._sink.close()
+
+
+def _table_box():
+    # Uses simple chars for tables (| - +) instead of multi-byte chars that are Rich's default.
+    from rich import box
+
+    return box.ASCII if os.environ.get("TT_TRIAGE_SIMPLE_TABLE") == "1" else box.HEAVY_HEAD
 
 
 def _one_line(s: str) -> str:

--- a/tools/tt-run-triage.py
+++ b/tools/tt-run-triage.py
@@ -250,7 +250,8 @@ def _run_multi_rank(passthrough: list[str], tt_run_args: list[str]) -> int:
 
     interactive = sys.stdout.isatty()
     cols = shutil.get_terminal_size().columns if interactive else 10000
-    env = {**os.environ, "COLUMNS": str(cols), "TT_TRIAGE_COLOR": "1" if interactive else "0"}
+    # ASCII table borders: multi-byte box-drawing chars corrupt mpirun's line buffer in multi-rank runs.
+    env = {**os.environ, "COLUMNS": str(cols), "TT_TRIAGE_COLOR": "1" if interactive else "0", "TT_TRIAGE_SIMPLE_TABLE": "1"}
 
     # Buffer the stderr/stdout lines and flush after progress stops so they don't fight the Live display.
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1, env=env)

--- a/tools/tt-run-triage.py
+++ b/tools/tt-run-triage.py
@@ -251,7 +251,12 @@ def _run_multi_rank(passthrough: list[str], tt_run_args: list[str]) -> int:
     interactive = sys.stdout.isatty()
     cols = shutil.get_terminal_size().columns if interactive else 10000
     # ASCII table borders: multi-byte box-drawing chars corrupt mpirun's line buffer in multi-rank runs.
-    env = {**os.environ, "COLUMNS": str(cols), "TT_TRIAGE_COLOR": "1" if interactive else "0", "TT_TRIAGE_SIMPLE_TABLE": "1"}
+    env = {
+        **os.environ,
+        "COLUMNS": str(cols),
+        "TT_TRIAGE_COLOR": "1" if interactive else "0",
+        "TT_TRIAGE_SIMPLE_TABLE": "1",
+    }
 
     # Buffer the stderr/stdout lines and flush after progress stops so they don't fight the Live display.
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1, env=env)


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Rich's default tables use multi-byte characters which can cause catastrophic problems in `tt-run-triage.py`. `mpirun` buffers at 2KB which can split the multi-byte char and crash the triage run due to decoding issue. 

If a user is interested in viewing tables for `tt-run-triage.py`, the only way is to use simple chars.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=onenezic/triage-simple-table)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:onenezic/triage-simple-table)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=onenezic/triage-simple-table)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:onenezic/triage-simple-table)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=onenezic/triage-simple-table)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:onenezic/triage-simple-table)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=onenezic/triage-simple-table)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:onenezic/triage-simple-table)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=onenezic/triage-simple-table)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:onenezic/triage-simple-table)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=onenezic/triage-simple-table)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:onenezic/triage-simple-table)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=onenezic/triage-simple-table)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:onenezic/triage-simple-table)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=onenezic/triage-simple-table)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:onenezic/triage-simple-table)