### PR TITLE
[gpt_oss_d_p] GPT-OSS prefill: MoE wrapper (router + fused experts, SwiGLU-OAI)

### DIFF
--- a/models/demos/gpt_oss_d_p/README.md
+++ b/models/demos/gpt_oss_d_p/README.md
@@ -14,12 +14,12 @@ that plugs into the model-agnostic `models/demos/common/prefill` engine.
 
 ## Roadmap
 
-Stacked PRs, bottom-up. **This PR is P1.**
+Stacked PRs, bottom-up. **This PR is P3.**
 
-- [x] **P1 — package scaffold + attention** *(this PR)*: GQA, RoPE (YaRN), attention sinks, and
+- [x] **P1 — package scaffold + attention** (merged): GQA, RoPE (YaRN), attention sinks, and
       per-layer sliding/full alternation; single-Blackhole-card PCC vs a torch reference.
-- [ ] **P2 — KV cache + indexed RoPE**: chunked, block-cyclic, SP-sharded KV cache.
-- [ ] **P3 — MoE**: `TtGptOssMoE` over the DeepSeek EP submodules (SwiGLU-OAI + biases, no shared expert).
+- [x] **P2 — KV cache + indexed RoPE** (merged): chunked, block-cyclic, SP-sharded KV cache.
+- [ ] **P3 — MoE** *(this PR)*: `TtGptOssMoE` over the DeepSeek EP submodules (SwiGLU-OAI + biases, no shared expert).
 - [ ] **P4 — model + runtime**: full model, chunked-prefill runtime, and the `common/prefill` adapter.
 - [ ] **P5 — galaxy bring-up**: TP=8 / SP=4 / EP=32 on the 4×8 Blackhole Galaxy (gated on galaxy access).
 - [ ] **P6 — ring SDPA**: the sinks + sliding + halo-CCL ring SDPA (Pavle Josipović's op), for scalable SP and multi-chunk long context.

--- a/models/demos/gpt_oss_d_p/tests/unit/test_moe_vs_ref.py
+++ b/models/demos/gpt_oss_d_p/tests/unit/test_moe_vs_ref.py
@@ -1,0 +1,427 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+PCC tests for the GPT-OSS prefill MoE wrapper.
+
+Three tests, two of which run on a single card:
+
+  1. test_router_vs_ref  (single card, no fabric)
+       TtGptOssRouter vs a torch reference: linear(+bias) -> topk(4, sorted) -> softmax over the 4
+       selected logits. Indices must match exactly; weights PCC >= 0.99. Fully validates the router.
+
+  2. test_routed_expert_ffn_vs_ref  (single card, mesh=1, all experts local, fabric DISABLED)
+       Mirrors deepseek_v3_d_p/tests/op_unit_tests/test_ttnn_routed_expert.py's `single-1` param, but
+       with GPT-OSS dims (emb 2880 / hidden 2880), a reduced expert count (E=8, topk=4), the
+       SwiGluOai activation, and a BIAS-FREE SwiGLU-OAI torch reference (biases land with #49619).
+       PCC >= 0.97. Validates the fused routed-expert kernel wiring.
+
+  3. test_gpt_oss_moe_vs_ref  (GALAXY ONLY — gated behind requires_mesh_topology((4,8)))
+       Full TtGptOssMoE end-to-end (router -> dispatch -> routed_expert -> combine -> reduce) at
+       EP=32. Needs multi-device + fabric, so it is AUTO-SKIPPED on a single card and only runs on a
+       (4,8) Blackhole galaxy.
+
+Run (single card, both card-safe tests):
+    pytest models/demos/gpt_oss_d_p/tests/unit/test_moe_vs_ref.py -k "router or routed_expert_ffn"
+Galaxy (all three):
+    pytest models/demos/gpt_oss_d_p/tests/unit/test_moe_vs_ref.py
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import comp_pcc
+from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
+    ExpertMapping,
+    compute_constants,
+    extract_mesh_config,
+    get_ep_mesh_composer,
+    get_ep_mesh_mapper,
+    get_gate_outputs,
+    initialize_test_inputs,
+)
+from models.demos.deepseek_v3_d_p.tt.moe.tt_routed_expert import TtRoutedExpert
+from models.demos.gpt_oss_d_p.tt.moe.router import TtGptOssRouter
+
+# GPT-OSS-120B MoE dims (configs/gpt-oss-120b/config.json / GptOss120BConfig).
+HIDDEN = 2880
+INTER = 2880
+NUM_EXPERTS = 128
+TOPK = 4
+ALPHA = 1.702  # swigluoai alpha
+LIMIT = 7.0  # swigluoai clamp limit
+
+
+# =====================================================================================
+# 1. Router PCC (single card)
+# =====================================================================================
+@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
+@pytest.mark.parametrize("num_tokens", [64], ids=["t64"])
+def test_router_vs_ref(mesh_device, num_tokens, reset_seeds):
+    """TtGptOssRouter vs torch: linear(+bias) -> topk(4) -> softmax over the 4 selected."""
+    torch.manual_seed(0)
+
+    weight = torch.randn(NUM_EXPERTS, HIDDEN) * 0.05  # HF gate Linear weight [E, H]
+    bias = torch.randn(NUM_EXPERTS) * 0.1  # [E]
+    x = torch.randn(num_tokens, HIDDEN)
+
+    # --- torch reference ---
+    logits = x @ weight.t() + bias  # [T, E]
+    ref_weights, ref_indices = torch.topk(logits, TOPK, dim=-1, sorted=True)  # [T, k]
+    ref_weights = torch.softmax(ref_weights, dim=-1)
+
+    # --- TT router ---
+    hf_config = SimpleNamespace(num_experts_per_tok=TOPK, num_local_experts=NUM_EXPERTS, hidden_size=HIDDEN)
+    router = TtGptOssRouter(mesh_device, hf_config, {"weight": weight, "bias": bias})
+
+    x_tt = ttnn.from_torch(
+        x,
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+    idx_tt, wts_tt = router(x_tt)
+    ttnn.synchronize_device(mesh_device)
+
+    idx = ttnn.to_torch(ttnn.get_device_tensors(idx_tt)[0]).reshape(-1, TOPK)[:num_tokens].to(torch.int64)
+    wts = ttnn.to_torch(ttnn.get_device_tensors(wts_tt)[0]).reshape(-1, TOPK)[:num_tokens].float()
+
+    # bf16 matmul rounding can flip experts at the top-4/top-5 boundary vs the fp32 reference —
+    # inherent to bf16 top-k, not a router defect. So rather than demand an exact index match,
+    # verify every mismatch is a genuine near-tie: the reference's 4th- and 5th-largest logits
+    # are within a bf16-scale tolerance. Order within the top-4 is irrelevant (softmax is over
+    # the selected set), so compare unordered sets.
+    top5 = torch.topk(logits, TOPK + 1, dim=-1).values  # [T, k+1], descending
+    boundary_gap = top5[:, TOPK - 1] - top5[:, TOPK]  # (4th - 5th) logit gap, >= 0
+    tol = 0.02 * top5[:, 0].abs().clamp(min=1.0)  # ~bf16 relative scale, per token
+    ref_sets = [set(r.tolist()) for r in ref_indices]
+    dev_sets = [set(r.tolist()) for r in idx]
+    set_match = sum(a == b for a, b in zip(ref_sets, dev_sets)) / num_tokens
+    logger.info(f"router top-4 set-match fraction: {set_match:.4f}")
+    for i in range(num_tokens):
+        if ref_sets[i] != dev_sets[i]:
+            assert boundary_gap[i] <= tol[i], (
+                f"token {i}: top-4 differs from reference but 4th/5th logits are not a near-tie "
+                f"(gap={boundary_gap[i]:.4f} > tol={tol[i]:.4f}) — router logic error, not a bf16 flip"
+            )
+
+    # Softmax-over-top-4 math: compare on tokens whose selection matched the reference (weights
+    # are only element-wise comparable there; flipped tokens picked a different near-tied set).
+    matched = [i for i in range(num_tokens) if ref_sets[i] == dev_sets[i]]
+    assert len(matched) >= num_tokens * 0.5, f"too few matched tokens to validate weights ({len(matched)})"
+    passing, pcc = comp_pcc(ref_weights[matched], wts[matched], 0.99)
+    logger.info(f"router weights pcc (matched tokens): {pcc}")
+    assert passing, f"router expert-weights PCC fail: {pcc}"
+
+
+# =====================================================================================
+# SwiGLU-OAI bias-free torch expert (matches ttnn.RoutedExpertActivation.SwiGluOai without bias)
+# =====================================================================================
+def _swiglu_oai_ffn(x, w):
+    """Bias-free clamped swigluoai FFN. w: HF (out, in) tensors gate_proj/up_proj/down_proj."""
+    g = (x @ w["gate_proj"].t()).clamp(max=LIMIT)
+    u = (x @ w["up_proj"].t()).clamp(min=-LIMIT, max=LIMIT)
+    return ((u + 1.0) * (g * torch.sigmoid(ALPHA * g))) @ w["down_proj"].t()
+
+
+@torch.no_grad()
+def _run_torch_routed_experts(
+    dispatched_buffer, weights_list, experts_per_chip, num_dispatch_groups, dispatch_group_size, expert_token_counts
+):
+    """Torch SwiGLU-OAI routed experts over the dispatch-shaped buffer. Mirrors the offset walk in
+    deepseek's test_ttnn_routed_expert.run_torch_routed_experts (TILE-aligned per-expert regions)."""
+    out = torch.zeros_like(dispatched_buffer)
+    for dg in range(num_dispatch_groups):
+        for ds in range(dispatch_group_size):
+            off = 0
+            for local_expert in range(experts_per_chip):
+                ge = ExpertMapping.get_global_expert_idx(
+                    group=dg,
+                    chip=ds,
+                    local_expert=local_expert,
+                    experts_per_chip=experts_per_chip,
+                    dispatch_group_size=dispatch_group_size,
+                    num_dispatch_groups=num_dispatch_groups,
+                    is_col_major=True,
+                )
+                count = expert_token_counts[dg, 0, ge].item()
+                if count > 0:
+                    xin = dispatched_buffer[dg, ds, off : off + count, :].float()
+                    out[dg, ds, off : off + count, :] = _swiglu_oai_ffn(xin, weights_list[ge])
+                off += (count + ttnn.TILE_SIZE - 1) // ttnn.TILE_SIZE * ttnn.TILE_SIZE
+    return out
+
+
+# =====================================================================================
+# 2. Routed-expert FFN plumbing PCC, BIAS-FREE (single card, mesh=1)
+# =====================================================================================
+@pytest.mark.parametrize(
+    "mesh_device, device_params",
+    [pytest.param(1, {"fabric_config": ttnn.FabricConfig.DISABLED}, id="single-1")],
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize(
+    "seq_len_per_chip, emb_dim, hidden_dim, num_routed_experts, num_experts_per_tok, capacity_factor",
+    [(256, HIDDEN, INTER, 8, TOPK, 8)],
+    ids=["gptoss-e8"],
+)
+def test_routed_expert_ffn_vs_ref(
+    mesh_device,
+    device_params,
+    seq_len_per_chip,
+    emb_dim,
+    hidden_dim,
+    num_routed_experts,
+    num_experts_per_tok,
+    capacity_factor,
+    reset_seeds,
+):
+    """TtRoutedExpert (SwiGluOai, bias-free) vs a bias-free SwiGLU-OAI torch reference. All experts
+    local on a single device (mesh=1). Validates the fused routed-expert kernel wiring at GPT-OSS
+    dims; the biased version lands with #49619."""
+    torch.manual_seed(42)
+    num_devices = mesh_device.get_num_devices()
+    mc = extract_mesh_config(mesh_device)
+    dispatch_group_size = mc.dispatch_group_size
+    num_dispatch_groups = mc.num_dispatch_groups
+
+    experts_per_chip, metadata_len, max_buf, max_tok = compute_constants(
+        seq_len_per_chip, num_routed_experts, num_experts_per_tok, num_devices, dispatch_group_size, capacity_factor
+    )
+    total_experts = num_devices * experts_per_chip
+
+    # Routing indices -> per-expert token counts + TILE-aligned region offsets.
+    expert_dispatch_table = ExpertMapping.create_dispatch_table(
+        num_routed_experts=num_routed_experts,
+        dispatch_group_size=dispatch_group_size,
+        num_dispatch_groups=num_dispatch_groups,
+    )
+    _, _, routing_indices = initialize_test_inputs(
+        dispatch_group_size=dispatch_group_size,
+        seq_len_per_chip=seq_len_per_chip,
+        emb_dim=emb_dim,
+        num_routed_experts=num_routed_experts,
+        num_experts_per_tok=num_experts_per_tok,
+        max_dispatched_tokens_per_expert=max_tok,
+        num_dispatch_groups=num_dispatch_groups,
+        skip_x_initialization=True,
+    )
+    _, expert_token_counts_torch, expert_region_offsets_torch, _ = get_gate_outputs(
+        routing_indices,
+        dispatch_group_size,
+        num_routed_experts,
+        experts_per_chip,
+        seq_len_per_chip,
+        num_experts_per_tok,
+        expert_dispatch_table=expert_dispatch_table,
+    )
+
+    per_device_shape = (max_buf, emb_dim)
+
+    # Random dispatch buffer + per-expert weights (HF (out, in), global order 0..E-1).
+    dispatched_buffer_torch = torch.randn(num_dispatch_groups, dispatch_group_size, max_buf, emb_dim)
+    weights_list = [
+        {
+            "gate_proj": torch.randn(hidden_dim, emb_dim) * 0.02,
+            "up_proj": torch.randn(hidden_dim, emb_dim) * 0.02,
+            "down_proj": torch.randn(emb_dim, hidden_dim) * 0.02,
+        }
+        for _ in range(total_experts)
+    ]
+
+    torch_outputs = _run_torch_routed_experts(
+        dispatched_buffer_torch,
+        weights_list,
+        experts_per_chip,
+        num_dispatch_groups,
+        dispatch_group_size,
+        expert_token_counts_torch,
+    )
+
+    dispatched_buffer_tt = ttnn.from_torch(
+        dispatched_buffer_torch,
+        mesh_mapper=get_ep_mesh_mapper(mesh_device),
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        dtype=ttnn.bfloat8_b,
+    )
+    dispatched_buffer_tt = ttnn.reshape(dispatched_buffer_tt, per_device_shape)
+
+    global_expert_idx_torch = ExpertMapping.create_global_expert_idx_table(
+        experts_per_chip=experts_per_chip,
+        dispatch_group_size=dispatch_group_size,
+        num_dispatch_groups=num_dispatch_groups,
+    )
+    global_expert_idx_tt = ttnn.from_torch(
+        global_expert_idx_torch,
+        mesh_mapper=get_ep_mesh_mapper(mesh_device),
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=mesh_device,
+        dtype=ttnn.uint32,
+    )
+    global_expert_idx_tt = ttnn.squeeze(ttnn.squeeze(global_expert_idx_tt, 0), 0)
+
+    # BIAS-FREE TtRoutedExpert (no bias kwarg — the current kernel is bias-free; #49619).
+    tt_routed_expert = TtRoutedExpert(
+        mesh_device=mesh_device,
+        experts_per_chip=experts_per_chip,
+        global_expert_idx_table=global_expert_idx_tt,
+        emb_dim=emb_dim,
+        hidden_dim=hidden_dim,
+        max_tokens=max_tok,
+        torch_weights=weights_list,
+        activations_dtype=ttnn.bfloat8_b,
+        weights_dtype=ttnn.bfloat4_b,
+        activation=ttnn.RoutedExpertActivation.SwiGluOai,
+    )
+
+    expert_token_counts_tt = TtRoutedExpert.shard_expert_token_counts(mesh_device, expert_token_counts_torch)
+    expert_region_offsets_tt = TtRoutedExpert.shard_expert_token_counts(mesh_device, expert_region_offsets_torch)
+
+    ttnn_outputs = tt_routed_expert(dispatched_buffer_tt, expert_token_counts_tt, expert_region_offsets_tt)
+    ttnn.synchronize_device(mesh_device)
+
+    ttnn_outputs_expanded = ttnn.unsqueeze(ttnn.unsqueeze(ttnn_outputs, dim=0), dim=0)
+    ttnn_outputs_torch = ttnn.to_torch(ttnn_outputs_expanded, mesh_composer=get_ep_mesh_composer(mesh_device))
+
+    pcc_values = []
+    for dg in range(num_dispatch_groups):
+        for ds in range(dispatch_group_size):
+            off = 0
+            for local_expert in range(experts_per_chip):
+                ge = ExpertMapping.get_global_expert_idx(
+                    group=dg,
+                    chip=ds,
+                    local_expert=local_expert,
+                    experts_per_chip=experts_per_chip,
+                    dispatch_group_size=dispatch_group_size,
+                    num_dispatch_groups=num_dispatch_groups,
+                    is_col_major=True,
+                )
+                count = expert_token_counts_torch[dg, 0, ge].item()
+                if count > 0:
+                    t = torch_outputs[dg, ds, off : off + count]
+                    n = ttnn_outputs_torch[dg, ds, off : off + count]
+                    _, pcc = comp_pcc(t, n)
+                    pcc_values.append(pcc)
+                    assert not torch.isnan(n).any(), f"NaN in expert {ge}"
+                    assert not torch.isinf(n).any(), f"Inf in expert {ge}"
+                off += (count + ttnn.TILE_SIZE - 1) // ttnn.TILE_SIZE * ttnn.TILE_SIZE
+
+    min_pcc = min(pcc_values)
+    logger.info(f"routed-expert FFN min PCC: {min_pcc:.6f} across {len(pcc_values)} experts")
+    assert min_pcc >= 0.97, f"routed-expert FFN PCC {min_pcc:.6f} below 0.97"
+
+
+# =====================================================================================
+# 3. Full TtGptOssMoE end-to-end (GALAXY ONLY — auto-skipped on a single card)
+# =====================================================================================
+@pytest.mark.requires_mesh_topology(mesh_shape=(4, 8), topology="mesh-4x8")
+@pytest.mark.parametrize(
+    "mesh_device, device_params",
+    [pytest.param((4, 8), {"fabric_config": ttnn.FabricConfig.FABRIC_1D}, id="galaxy-4x8")],
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize("seq_len", [128], ids=["s128"])
+def test_gpt_oss_moe_vs_ref(mesh_device, device_params, seq_len, reset_seeds):
+    """Full GPT-OSS MoE MLP (router + 128-expert EP routed experts) on (4,8) EP=32 vs a per-row torch
+    reference. NEEDS a Blackhole galaxy — auto-skipped on a single card by requires_mesh_topology.
+
+    NOTE: BIAS-FREE on this branch (#49619 not merged), so the torch reference below is also
+    bias-free. Once #49619 lands, add the gate/up/down biases to both the reference FFN and the MLP
+    (set use_expert_bias=True).
+
+    DEPENDENCY: the MLP's TP all-gather needs a CCL manager (``.num_links``, ping-pong/barrier
+    semaphores — the object MeshConfig.allgather consumes). gpt_oss_d_p does NOT yet ship one
+    (attention runs at TP=1 with ccl_manager=None), so this test skips until that manager lands.
+    This is the ONLY remaining wiring gap for the full EP MoE; router + routed-expert plumbing are
+    already validated by the two single-card tests above."""
+    from models.demos.gpt_oss_d_p.tt.config import MeshConfig
+    from models.demos.gpt_oss_d_p.tt.mlp import MLP
+    from models.demos.gpt_oss_d_p.utils.general_utils import get_default_num_links
+
+    try:
+        from models.demos.gpt_oss_d_p.tt.ccl import CCLManager  # not yet implemented in this package
+    except ImportError:
+        pytest.skip("gpt_oss_d_p CCL manager not yet implemented; full EP MoE test is blocked on it.")
+
+    rows, cols = mesh_device.shape
+    assert (rows, cols) == (4, 8), "this test targets the (4,8) galaxy layout (EP=32)"
+    torch.manual_seed(0)
+
+    E, H, I = NUM_EXPERTS, HIDDEN, INTER
+    router_w = torch.randn(E, H) * 0.05
+    router_b = torch.randn(E) * 0.1
+    experts = [
+        {
+            "gate_proj": torch.randn(I, H) * 0.02,
+            "up_proj": torch.randn(I, H) * 0.02,
+            "down_proj": torch.randn(H, I) * 0.02,
+        }
+        for _ in range(E)
+    ]
+
+    def _ref_moe(x):  # x: [S, H]
+        logits = x @ router_w.t() + router_b
+        wts, idx = torch.topk(logits, TOPK, dim=-1, sorted=True)
+        wts = torch.softmax(wts, dim=-1)
+        out = torch.zeros_like(x)
+        for t in range(x.shape[0]):
+            for j in range(TOPK):
+                out[t] += wts[t, j] * _swiglu_oai_ffn(x[t : t + 1], experts[idx[t, j].item()]).squeeze(0)
+        return out
+
+    x = torch.randn(rows, seq_len, H, dtype=torch.bfloat16)
+    ref = [_ref_moe(x[r].float()) for r in range(rows)]
+
+    # Build the HF GptOssMLP state dict: router.{weight,bias} + interleaved experts.* .
+    gate_up = torch.zeros(E, H, 2 * I)
+    gate_up[..., ::2] = torch.stack([w["gate_proj"].t() for w in experts])  # (in=H, out=I)
+    gate_up[..., 1::2] = torch.stack([w["up_proj"].t() for w in experts])
+    gate_up_bias = torch.zeros(E, 2 * I)  # bias-free ref -> zeros
+    state = {
+        "router.weight": router_w,
+        "router.bias": router_b,
+        "experts.gate_up_proj": gate_up,
+        "experts.gate_up_proj_bias": gate_up_bias,
+        "experts.down_proj": torch.stack([w["down_proj"].t() for w in experts]),  # (in=I, out=H)
+        "experts.down_proj_bias": torch.zeros(E, H),
+    }
+
+    hf_config = SimpleNamespace(num_experts_per_tok=TOPK, num_local_experts=E, hidden_size=H, intermediate_size=I)
+    mesh_config = MeshConfig((rows, cols), tp=cols)
+    ccl = CCLManager(mesh_device, num_links=get_default_num_links(mesh_device), topology=ttnn.Topology.Linear)
+    mlp = MLP(
+        mesh_device=mesh_device,
+        hf_config=hf_config,
+        state_dict=state,
+        ccl_manager=ccl,
+        mesh_config=mesh_config,
+        expert_weight_dtype=ttnn.bfloat8_b,
+        use_ep_moe=True,
+        ep_seq_len_per_chip=seq_len,
+    )
+
+    tt_x = ttnn.from_torch(
+        x.reshape(rows, 1, seq_len, H),
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(0, None), mesh_shape=mesh_device.shape),
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        dtype=ttnn.bfloat16,
+    )
+    out = mlp(tt_x)
+    ttnn.synchronize_device(mesh_device)
+
+    dts = ttnn.get_device_tensors(out)
+    for r in range(rows):
+        row = ttnn.to_torch(dts[r * cols]).float().reshape(-1, H)[:seq_len]
+        passing, pcc = comp_pcc(ref[r], row, 0.90)
+        logger.info(f"prompt{r}: pcc={pcc}")
+        assert passing, f"prompt {r} GPT-OSS MoE PCC fail: {pcc}"

--- a/models/demos/gpt_oss_d_p/tests/unit/test_moe_vs_ref.py
+++ b/models/demos/gpt_oss_d_p/tests/unit/test_moe_vs_ref.py
@@ -123,6 +123,54 @@ def test_router_vs_ref(mesh_device, num_tokens, reset_seeds):
 
 
 # =====================================================================================
+# 1b. Expert weight/bias preparation (pure torch, no device)
+# =====================================================================================
+def test_prepare_routed_expert_weights_deinterleave():
+    """Pure-torch: prepare_routed_expert_weights de-interleaves gate(even)/up(odd) columns, splits the
+    matching biases the same way, transposes every projection to HF (out,in), and emits the #49619
+    bias keys (gate/up/down_proj_bias). Guards the host-side layout math that the galaxy MoE test and
+    the biased FFN test both depend on but neither exercises through prepare()."""
+    from models.demos.gpt_oss_d_p.tt.moe.weights import prepare_routed_expert_weights
+
+    torch.manual_seed(0)
+    E, H, I = 3, 4, 5
+    gate = torch.randn(E, H, I)  # (in=H, out=I)
+    up = torch.randn(E, H, I)
+    gate_up = torch.zeros(E, H, 2 * I)
+    gate_up[..., ::2] = gate  # even columns -> gate
+    gate_up[..., 1::2] = up  # odd columns -> up
+    gate_b = torch.randn(E, I)
+    up_b = torch.randn(E, I)
+    gate_up_b = torch.zeros(E, 2 * I)
+    gate_up_b[..., ::2] = gate_b
+    gate_up_b[..., 1::2] = up_b
+    down = torch.randn(E, I, H)  # (in=I, out=H)
+    down_b = torch.randn(E, H)
+
+    w, b = prepare_routed_expert_weights(
+        {
+            "gate_up_proj": gate_up,
+            "gate_up_proj_bias": gate_up_b,
+            "down_proj": down,
+            "down_proj_bias": down_b,
+        },
+        E,
+        H,
+        I,
+    )
+    assert len(w) == E and len(b) == E
+    for e in range(E):
+        # weights transposed to HF (out, in)
+        assert torch.equal(w[e]["gate_proj"], gate[e].t()), f"gate mismatch expert {e}"
+        assert torch.equal(w[e]["up_proj"], up[e].t()), f"up mismatch expert {e}"
+        assert torch.equal(w[e]["down_proj"], down[e].t()), f"down mismatch expert {e}"
+        # biases split + #49619 key names, kept 1D (not transposed)
+        assert torch.equal(b[e]["gate_proj_bias"], gate_b[e]), f"gate_bias mismatch expert {e}"
+        assert torch.equal(b[e]["up_proj_bias"], up_b[e]), f"up_bias mismatch expert {e}"
+        assert torch.equal(b[e]["down_proj_bias"], down_b[e]), f"down_bias mismatch expert {e}"
+
+
+# =====================================================================================
 # SwiGLU-OAI bias-free torch expert (matches ttnn.RoutedExpertActivation.SwiGluOai without bias)
 # =====================================================================================
 def _swiglu_oai_ffn(x, w, b=None):
@@ -373,23 +421,24 @@ def test_gpt_oss_moe_vs_ref(mesh_device, device_params, seq_len, reset_seeds):
     """Full GPT-OSS MoE MLP (router + 128-expert EP routed experts) on (4,8) EP=32 vs a per-row torch
     reference. NEEDS a Blackhole galaxy — auto-skipped on a single card by requires_mesh_topology.
 
-    NOTE: BIAS-FREE on this branch (#49619 not merged), so the torch reference below is also
-    bias-free. Once #49619 lands, add the gate/up/down biases to both the reference FFN and the MLP
-    (set use_expert_bias=True).
+    NOTE: this end-to-end check uses ZERO expert biases (bias-free reference) — it validates the
+    router -> dispatch -> combine -> reduce plumbing at EP=32, not the bias path. #49619 (expert bias)
+    is merged and the biased fused FFN is covered single-card by test_routed_expert_ffn_vs_ref[biased];
+    a non-zero-bias galaxy variant is future work.
 
     DEPENDENCY: the MLP's TP all-gather needs a CCL manager (``.num_links``, ping-pong/barrier
-    semaphores — the object MeshConfig.allgather consumes). gpt_oss_d_p does NOT yet ship one
-    (attention runs at TP=1 with ccl_manager=None), so this test skips until that manager lands.
-    This is the ONLY remaining wiring gap for the full EP MoE; router + routed-expert plumbing are
-    already validated by the two single-card tests above."""
+    semaphores — the object MeshConfig.allgather consumes). CCLManager ships in the runtime PR
+    (tt/ccl.py, one PR up the stack); on this (MoE) branch the import fails, so this galaxy test
+    skips here and runs once the runtime PR lands. Router + routed-expert plumbing are already
+    validated by the single-card tests above."""
     from models.demos.gpt_oss_d_p.tt.config import MeshConfig
     from models.demos.gpt_oss_d_p.tt.mlp import MLP
     from models.demos.gpt_oss_d_p.utils.general_utils import get_default_num_links
 
     try:
-        from models.demos.gpt_oss_d_p.tt.ccl import CCLManager  # not yet implemented in this package
+        from models.demos.gpt_oss_d_p.tt.ccl import CCLManager  # ships in the runtime PR (one PR up the stack)
     except ImportError:
-        pytest.skip("gpt_oss_d_p CCL manager not yet implemented; full EP MoE test is blocked on it.")
+        pytest.skip("gpt_oss_d_p CCLManager ships in the runtime PR; full EP MoE test runs once it lands.")
 
     rows, cols = mesh_device.shape
     assert (rows, cols) == (4, 8), "this test targets the (4,8) galaxy layout (EP=32)"

--- a/models/demos/gpt_oss_d_p/tests/unit/test_moe_vs_ref.py
+++ b/models/demos/gpt_oss_d_p/tests/unit/test_moe_vs_ref.py
@@ -12,9 +12,10 @@ Three tests, two of which run on a single card:
 
   2. test_routed_expert_ffn_vs_ref  (single card, mesh=1, all experts local, fabric DISABLED)
        Mirrors deepseek_v3_d_p/tests/op_unit_tests/test_ttnn_routed_expert.py's `single-1` param, but
-       with GPT-OSS dims (emb 2880 / hidden 2880), a reduced expert count (E=8, topk=4), the
-       SwiGluOai activation, and a BIAS-FREE SwiGLU-OAI torch reference (biases land with #49619).
-       PCC >= 0.97. Validates the fused routed-expert kernel wiring.
+       with GPT-OSS dims (emb 2880 / hidden 2880), a reduced expert count (E=8, topk=4) and the
+       SwiGluOai activation. Parametrized over `biasfree` and `biased` (per-expert gate/up/down
+       biases, #49619 — the deployment default): the `biased` case exercises the exact path the model
+       runs. PCC >= 0.97. Validates the fused routed-expert kernel wiring.
 
   3. test_gpt_oss_moe_vs_ref  (GALAXY ONLY — gated behind requires_mesh_topology((4,8)))
        Full TtGptOssMoE end-to-end (router -> dispatch -> routed_expert -> combine -> reduce) at
@@ -124,19 +125,36 @@ def test_router_vs_ref(mesh_device, num_tokens, reset_seeds):
 # =====================================================================================
 # SwiGLU-OAI bias-free torch expert (matches ttnn.RoutedExpertActivation.SwiGluOai without bias)
 # =====================================================================================
-def _swiglu_oai_ffn(x, w):
-    """Bias-free clamped swigluoai FFN. w: HF (out, in) tensors gate_proj/up_proj/down_proj."""
-    g = (x @ w["gate_proj"].t()).clamp(max=LIMIT)
-    u = (x @ w["up_proj"].t()).clamp(min=-LIMIT, max=LIMIT)
-    return ((u + 1.0) * (g * torch.sigmoid(ALPHA * g))) @ w["down_proj"].t()
+def _swiglu_oai_ffn(x, w, b=None):
+    """Clamped swigluoai FFN. w: HF (out, in) tensors gate_proj/up_proj/down_proj. b (optional):
+    per-expert gate_proj_bias/up_proj_bias/down_proj_bias (1D), applied the way the fused kernel does
+    (#49619): gate/up bias BEFORE the clamp, down bias AFTER the down matmul."""
+    gp = x @ w["gate_proj"].t()
+    up = x @ w["up_proj"].t()
+    if b is not None:
+        gp = gp + b["gate_proj_bias"]
+        up = up + b["up_proj_bias"]
+    g = gp.clamp(max=LIMIT)
+    u = up.clamp(min=-LIMIT, max=LIMIT)
+    out = ((u + 1.0) * (g * torch.sigmoid(ALPHA * g))) @ w["down_proj"].t()
+    if b is not None:
+        out = out + b["down_proj_bias"]
+    return out
 
 
 @torch.no_grad()
 def _run_torch_routed_experts(
-    dispatched_buffer, weights_list, experts_per_chip, num_dispatch_groups, dispatch_group_size, expert_token_counts
+    dispatched_buffer,
+    weights_list,
+    experts_per_chip,
+    num_dispatch_groups,
+    dispatch_group_size,
+    expert_token_counts,
+    biases_list=None,
 ):
     """Torch SwiGLU-OAI routed experts over the dispatch-shaped buffer. Mirrors the offset walk in
-    deepseek's test_ttnn_routed_expert.run_torch_routed_experts (TILE-aligned per-expert regions)."""
+    deepseek's test_ttnn_routed_expert.run_torch_routed_experts (TILE-aligned per-expert regions).
+    biases_list (optional): per-expert bias dicts in the same global order as weights_list."""
     out = torch.zeros_like(dispatched_buffer)
     for dg in range(num_dispatch_groups):
         for ds in range(dispatch_group_size):
@@ -154,13 +172,14 @@ def _run_torch_routed_experts(
                 count = expert_token_counts[dg, 0, ge].item()
                 if count > 0:
                     xin = dispatched_buffer[dg, ds, off : off + count, :].float()
-                    out[dg, ds, off : off + count, :] = _swiglu_oai_ffn(xin, weights_list[ge])
+                    b = biases_list[ge] if biases_list is not None else None
+                    out[dg, ds, off : off + count, :] = _swiglu_oai_ffn(xin, weights_list[ge], b)
                 off += (count + ttnn.TILE_SIZE - 1) // ttnn.TILE_SIZE * ttnn.TILE_SIZE
     return out
 
 
 # =====================================================================================
-# 2. Routed-expert FFN plumbing PCC, BIAS-FREE (single card, mesh=1)
+# 2. Routed-expert FFN plumbing PCC (single card, mesh=1) — bias-free AND biased
 # =====================================================================================
 @pytest.mark.parametrize(
     "mesh_device, device_params",
@@ -172,6 +191,7 @@ def _run_torch_routed_experts(
     [(256, HIDDEN, INTER, 8, TOPK, 8)],
     ids=["gptoss-e8"],
 )
+@pytest.mark.parametrize("use_bias", [False, True], ids=["biasfree", "biased"])
 def test_routed_expert_ffn_vs_ref(
     mesh_device,
     device_params,
@@ -181,11 +201,13 @@ def test_routed_expert_ffn_vs_ref(
     num_routed_experts,
     num_experts_per_tok,
     capacity_factor,
+    use_bias,
     reset_seeds,
 ):
-    """TtRoutedExpert (SwiGluOai, bias-free) vs a bias-free SwiGLU-OAI torch reference. All experts
+    """TtRoutedExpert (SwiGluOai) vs a SwiGLU-OAI torch reference, both bias-free (``biasfree``) and
+    with per-expert gate/up/down biases (``biased``, #49619 — the deployment default). All experts
     local on a single device (mesh=1). Validates the fused routed-expert kernel wiring at GPT-OSS
-    dims; the biased version lands with #49619."""
+    dims, including the bias path the model actually runs."""
     torch.manual_seed(42)
     num_devices = mesh_device.get_num_devices()
     mc = extract_mesh_config(mesh_device)
@@ -235,6 +257,20 @@ def test_routed_expert_ffn_vs_ref(
         }
         for _ in range(total_experts)
     ]
+    # Per-expert gate/up/down biases (deployment default, #49619). Kept at the same 0.02 scale as the
+    # weights so the biased path exercises real (non-trivial) bias contributions.
+    biases_list = (
+        [
+            {
+                "gate_proj_bias": torch.randn(hidden_dim) * 0.02,
+                "up_proj_bias": torch.randn(hidden_dim) * 0.02,
+                "down_proj_bias": torch.randn(emb_dim) * 0.02,
+            }
+            for _ in range(total_experts)
+        ]
+        if use_bias
+        else None
+    )
 
     torch_outputs = _run_torch_routed_experts(
         dispatched_buffer_torch,
@@ -243,6 +279,7 @@ def test_routed_expert_ffn_vs_ref(
         num_dispatch_groups,
         dispatch_group_size,
         expert_token_counts_torch,
+        biases_list=biases_list,
     )
 
     dispatched_buffer_tt = ttnn.from_torch(
@@ -268,7 +305,8 @@ def test_routed_expert_ffn_vs_ref(
     )
     global_expert_idx_tt = ttnn.squeeze(ttnn.squeeze(global_expert_idx_tt, 0), 0)
 
-    # BIAS-FREE TtRoutedExpert (no bias kwarg — the current kernel is bias-free; #49619).
+    # TtRoutedExpert (SwiGluOai). torch_biases=None -> bias-free path; a per-expert bias list -> the
+    # biased fused path (#49619, the deployment default).
     tt_routed_expert = TtRoutedExpert(
         mesh_device=mesh_device,
         experts_per_chip=experts_per_chip,
@@ -277,6 +315,7 @@ def test_routed_expert_ffn_vs_ref(
         hidden_dim=hidden_dim,
         max_tokens=max_tok,
         torch_weights=weights_list,
+        torch_biases=biases_list,
         activations_dtype=ttnn.bfloat8_b,
         weights_dtype=ttnn.bfloat4_b,
         activation=ttnn.RoutedExpertActivation.SwiGluOai,

--- a/models/demos/gpt_oss_d_p/tt/mlp.py
+++ b/models/demos/gpt_oss_d_p/tt/mlp.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+GPT-OSS MoE MLP for prefill: top-k router + expert-parallel routed experts.
+
+Thin wrapper around ``TtGptOssRouter`` + ``TtGptOssMoE``. Unlike MiniMax-M3 there is NO shared
+expert and NO dense-layer branch — every GPT-OSS layer is a MoE layer. Expert-parallel only (the
+deployment path): the routed experts run across the mesh (DeepSeek EP dispatch/combine reused
+verbatim + the fused clamped-swigluoai kernel). Needs multi-device + fabric.
+
+State-dict split (HF GptOssMLP): ``router.{weight,bias}`` and ``experts.{gate_up_proj,
+gate_up_proj_bias, down_proj, down_proj_bias}``.
+"""
+
+from pathlib import Path
+
+import ttnn
+from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import compute_constants, extract_mesh_config
+from models.demos.gpt_oss_d_p.tt.moe.router import TtGptOssRouter
+from models.demos.gpt_oss_d_p.tt.moe.tt_gpt_oss_moe import TtGptOssMoE
+from models.demos.gpt_oss_d_p.tt.moe.weights import prepare_routed_expert_weights
+from models.demos.gpt_oss_d_p.utils.general_utils import get_cache_file_name
+from models.demos.gpt_oss_d_p.utils.substate import substate
+
+
+def _ep_cache_dir(tensor_cache_path):
+    """Create (if needed) and return the EP routed-expert weight-cache subdir, or None."""
+    if not tensor_cache_path:
+        return None
+    d = Path(str(tensor_cache_path)) / "experts_ep"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+class MLP:
+    """Router + expert-parallel routed experts (EP MoE). No shared expert, no dense branch."""
+
+    def __init__(
+        self,
+        mesh_device,
+        hf_config,
+        state_dict,
+        ccl_manager,
+        tensor_cache_path=None,
+        mesh_config=None,
+        expert_weight_dtype=ttnn.bfloat4_b,
+        expert_activation_dtype=ttnn.bfloat8_b,
+        use_ep_moe=True,
+        ep_seq_len_per_chip=1024,
+        layer_idx: int = 0,
+    ):
+        self.mesh_device = mesh_device
+        self.mesh_config = mesh_config
+        self.ccl = ccl_manager
+
+        # Split state dict: HF GptOssMLP has `router.{weight,bias}` + `experts.*`.
+        router_state_dict = substate(state_dict, "router")
+        experts_state_dict = substate(state_dict, "experts")
+
+        self.router = TtGptOssRouter(
+            mesh_device,
+            hf_config,
+            router_state_dict,
+            tensor_cache_path=get_cache_file_name(tensor_cache_path, "router"),
+        )
+
+        # GPT-OSS MoE is expert-parallel only (matches deepseek_v3_d_p / minimax_m3 prefill).
+        self.use_ep_moe = use_ep_moe and mesh_device.get_num_devices() > 1
+        if not self.use_ep_moe:
+            raise NotImplementedError("GPT-OSS MoE is expert-parallel only (use_ep_moe=True + multi-device).")
+
+        E = hf_config.num_local_experts
+        H = hf_config.hidden_size
+        I = hf_config.intermediate_size
+
+        mc = extract_mesh_config(mesh_device)
+        dgs, ndg = mc.dispatch_group_size, mc.num_dispatch_groups
+        experts_per_chip, metadata_len, max_buf, max_tok = compute_constants(
+            ep_seq_len_per_chip, E, hf_config.num_experts_per_tok, mesh_device.get_num_devices(), dgs, 2
+        )
+
+        # De-interleave gate_up_proj, transpose to HF (out,in), global expert order 0..E-1.
+        # Biases are kept SEPARATE (not attached to the weight dicts) — the current kernel is
+        # bias-free (#49619). None in cache-only mode -> TtRoutedExpert loads tilized weights from cache.
+        cache_only = not state_dict
+        if cache_only:
+            routed_w, routed_b = None, None
+        else:
+            routed_w, routed_b = prepare_routed_expert_weights(experts_state_dict, E, H, I)
+
+        self.experts = TtGptOssMoE(
+            mesh_device=mesh_device,
+            dispatch_group_size=dgs,
+            num_dispatch_groups=ndg,
+            experts_per_chip=experts_per_chip,
+            num_routed_experts=E,
+            num_experts_per_tok=hf_config.num_experts_per_tok,
+            metadata_len=metadata_len,
+            max_dispatched_tokens_per_expert=max_tok,
+            max_dispatch_buffer_token_size=max_buf,
+            seq_len_per_chip=ep_seq_len_per_chip,
+            emb_dim=H,
+            hidden_dim=I,
+            routed_expert_weights=routed_w,
+            routed_expert_biases=routed_b,  # threaded for #49619; NOT passed to TtRoutedExpert yet
+            num_links=ccl_manager.num_links,
+            routed_expert_activations_dtype=expert_activation_dtype,
+            routed_expert_weights_dtype=expert_weight_dtype,
+            weight_cache_path=_ep_cache_dir(tensor_cache_path),
+            layer_idx=layer_idx,
+            use_expert_bias=False,  # TODO(#49619): flip to True once the biased kernel lands
+        )
+        self.ep_num_links = ccl_manager.num_links
+
+    def __call__(self, hidden_states):
+        """Forward (prefill): top-k route, then expert-parallel routed experts.
+
+        hidden_states: per-device [1,1,S,H] (full emb, replicated across TP cols; seq shards on rows).
+        Returns [1,1,S,H] (all-gathered back to full emb to match the layer residual).
+        """
+        Hfull = hidden_states.shape[-1]
+        idx, wts = self.router(hidden_states)  # per-row top-k on [1,1,S,H] -> [tokens, k]
+        x3d = ttnn.squeeze(hidden_states, dim=0)  # [1,1,S,H] -> [1,S,H] per device
+        out = self.experts(x3d, topk_indices=idx, topk_weights=wts)  # -> [1,S,H/tp] reduce-scattered
+        out = ttnn.unsqueeze(out, dim=0)  # -> [1,1,S,H/tp]
+        if self.mesh_device.shape[1] > 1 and out.shape[-1] < Hfull:
+            # TP all-gather (reduce-scattered emb -> full emb). Prefer the managed all_gather (the
+            # path DeepSeek/M3 use) over raw ttnn.all_gather to avoid stale-tile garbage.
+            if self.mesh_config is not None and self.ccl is not None:
+                out = self.mesh_config.allgather(out, self.ccl, axis=1, dim=3)
+            else:
+                out = ttnn.all_gather(
+                    out, dim=-1, cluster_axis=1, num_links=self.ep_num_links, topology=ttnn.Topology.Linear
+                )
+        return out

--- a/models/demos/gpt_oss_d_p/tt/mlp.py
+++ b/models/demos/gpt_oss_d_p/tt/mlp.py
@@ -103,13 +103,13 @@ class MLP:
             emb_dim=H,
             hidden_dim=I,
             routed_expert_weights=routed_w,
-            routed_expert_biases=routed_b,  # threaded for #49619; NOT passed to TtRoutedExpert yet
+            routed_expert_biases=routed_b,  # #49619 merged: now passed to TtRoutedExpert
             num_links=ccl_manager.num_links,
             routed_expert_activations_dtype=expert_activation_dtype,
             routed_expert_weights_dtype=expert_weight_dtype,
             weight_cache_path=_ep_cache_dir(tensor_cache_path),
             layer_idx=layer_idx,
-            use_expert_bias=False,  # TODO(#49619): flip to True once the biased kernel lands
+            use_expert_bias=True,  # #49619 merged: biased unified_routed_expert_moe kernel is live
         )
         self.ep_num_links = ccl_manager.num_links
 

--- a/models/demos/gpt_oss_d_p/tt/mlp.py
+++ b/models/demos/gpt_oss_d_p/tt/mlp.py
@@ -15,6 +15,8 @@ gate_up_proj_bias, down_proj, down_proj_bias}``.
 
 from pathlib import Path
 
+import torch
+
 import ttnn
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import compute_constants, extract_mesh_config
 from models.demos.gpt_oss_d_p.tt.moe.router import TtGptOssRouter
@@ -80,15 +82,30 @@ class MLP:
             ep_seq_len_per_chip, E, hf_config.num_experts_per_tok, mesh_device.get_num_devices(), dgs, 2
         )
 
-        # De-interleave gate_up_proj, transpose to HF (out,in), global expert order 0..E-1.
-        # Biases are kept SEPARATE (not attached to the weight dicts) and passed through to
-        # TtRoutedExpert (#49619 merged). None in cache-only mode -> TtRoutedExpert loads tilized
-        # weights from cache.
+        # De-interleave gate_up_proj, transpose to HF (out,in), global expert order 0..E-1. Biases
+        # are kept SEPARATE (not attached to the weight dicts) and passed to TtRoutedExpert (#49619).
+        # TtRoutedExpert persists the tilized WEIGHTS to the TTNN cache but NOT the biases, so a
+        # cache-only build (empty state_dict) has no in-band bias source. Persist them to a small
+        # sidecar on the real-weights build and reload it here; without it a cache-only build would
+        # silently run bias-free and regress accuracy, so fail loud if the sidecar is missing.
         cache_only = not state_dict
+        ep_dir = _ep_cache_dir(tensor_cache_path)
+        bias_sidecar = (ep_dir / "routed_expert_biases.pt") if ep_dir is not None else None
         if cache_only:
-            routed_w, routed_b = None, None
+            routed_w = None
+            if bias_sidecar is not None and bias_sidecar.exists():
+                routed_b = torch.load(bias_sidecar, weights_only=False)  # our own file (list[dict] of biases)
+            else:
+                raise RuntimeError(
+                    "cache-only MLP build (empty state_dict) has no expert-bias source: the TTNN weight "
+                    "cache does not persist biases and no sidecar was found"
+                    + (f" at {bias_sidecar}" if bias_sidecar is not None else " (no tensor_cache_path set)")
+                    + ". Build once with a real state_dict to populate it."
+                )
         else:
             routed_w, routed_b = prepare_routed_expert_weights(experts_state_dict, E, H, I)
+            if bias_sidecar is not None:
+                torch.save(routed_b, bias_sidecar)
 
         self.experts = TtGptOssMoE(
             mesh_device=mesh_device,
@@ -108,7 +125,7 @@ class MLP:
             num_links=ccl_manager.num_links,
             routed_expert_activations_dtype=expert_activation_dtype,
             routed_expert_weights_dtype=expert_weight_dtype,
-            weight_cache_path=_ep_cache_dir(tensor_cache_path),
+            weight_cache_path=ep_dir,
             layer_idx=layer_idx,
             use_expert_bias=True,  # #49619 merged: biased unified_routed_expert_moe kernel is live
         )

--- a/models/demos/gpt_oss_d_p/tt/mlp.py
+++ b/models/demos/gpt_oss_d_p/tt/mlp.py
@@ -81,8 +81,9 @@ class MLP:
         )
 
         # De-interleave gate_up_proj, transpose to HF (out,in), global expert order 0..E-1.
-        # Biases are kept SEPARATE (not attached to the weight dicts) — the current kernel is
-        # bias-free (#49619). None in cache-only mode -> TtRoutedExpert loads tilized weights from cache.
+        # Biases are kept SEPARATE (not attached to the weight dicts) and passed through to
+        # TtRoutedExpert (#49619 merged). None in cache-only mode -> TtRoutedExpert loads tilized
+        # weights from cache.
         cache_only = not state_dict
         if cache_only:
             routed_w, routed_b = None, None

--- a/models/demos/gpt_oss_d_p/tt/moe/__init__.py
+++ b/models/demos/gpt_oss_d_p/tt/moe/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/models/demos/gpt_oss_d_p/tt/moe/router.py
+++ b/models/demos/gpt_oss_d_p/tt/moe/router.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+GPT-OSS MoE router (top-k gate) for prefill.
+
+Ported from ``models/demos/gpt_oss/tt/topk.py::TopKRouter`` — the PLAIN, model-agnostic
+routing path only. GPT-OSS routing differs from DeepSeek/MiniMax (which score ALL experts
+with sigmoid + an ``e_score_correction_bias`` and then top-k). GPT-OSS instead:
+
+    logits = hidden @ router.weight.T + router.bias      # Linear (+bias) over all experts
+    weights, indices = topk(logits, k=num_experts_per_tok, sorted=True)   # top-k FIRST
+    weights = softmax(weights, dim=-1)                   # softmax over the k SELECTED logits
+
+so the router cannot reuse DeepSeek's ``TtMoEGatePrefill``. We return the SPARSE ``[tokens, k]``
+output (``use_throughput_experts=True`` in the reference) that the EP dispatch/combine machinery
+consumes — NOT the decode-only fused ``topk_router_gpt`` kernel, and NOT the dense scatter path.
+
+Reference: models/demos/gpt_oss/tt/topk.py (TopKRouter.__call__ plain path + topk_router).
+"""
+
+import ttnn
+from models.demos.gpt_oss_d_p.utils.general_utils import get_cache_file_name
+
+
+def route_tokens_to_experts(router_logits, experts_per_token, softmax_compute_config):
+    """Apply GPT-OSS routing to gate logits ``[tokens, num_experts]``.
+
+    top-k FIRST (sorted), then softmax over the k selected logits (dim=-1). Returns the sparse
+    ``(expert_indices [tokens, k], expert_weights [tokens, k])`` pair. ``expert_indices`` is
+    converted to uint16 / ROW_MAJOR — the layout ``TtMoERoutingSetup`` requires for its
+    height-sharded ``ttnn_top_k_experts_indices`` input (see tt_moe_routing_setup.py).
+    """
+    if router_logits.dtype != ttnn.bfloat16:
+        router_logits = ttnn.typecast(router_logits, dtype=ttnn.bfloat16)
+
+    # top-k over experts (last dim). ttnn.topk returns (values, indices), values sorted desc.
+    expert_weights, expert_indices = ttnn.topk(router_logits, k=experts_per_token, dim=-1, sorted=True)
+
+    # Softmax over the k selected logits. dim=1 == last dim of the [tokens, k] tensor (matches the
+    # gpt_oss reference, which also softmaxes the SELECTED logits, not the full expert axis).
+    expert_weights = ttnn.softmax(
+        expert_weights, dim=1, numeric_stable=True, compute_kernel_config=softmax_compute_config
+    )
+
+    # routing_setup wants uint16, ROW_MAJOR, height-sharded [tokens, k] indices.
+    expert_indices = ttnn.to_layout(expert_indices, ttnn.ROW_MAJOR_LAYOUT)
+    if expert_indices.dtype != ttnn.uint16:
+        expert_indices = ttnn.typecast(expert_indices, ttnn.uint16)
+
+    return expert_indices, expert_weights
+
+
+class TtGptOssRouter:
+    """GPT-OSS top-k router: Linear(+bias) -> top-k(sorted) -> softmax over the k selected."""
+
+    def __init__(self, mesh_device, hf_config, state_dict, tensor_cache_path=None):
+        self.top_k = hf_config.num_experts_per_tok
+        self.num_experts = hf_config.num_local_experts
+        self.hidden_dim = hf_config.hidden_size
+        self.tensor_cache_path = tensor_cache_path
+
+        # HF gate Linear: weight [num_experts, hidden] -> [hidden, num_experts]; bias [num_experts].
+        torch_weight = state_dict["weight"].transpose(0, 1) if state_dict else None
+        torch_bias = state_dict["bias"].unsqueeze(0) if state_dict else None
+        self.weight = ttnn.as_tensor(
+            torch_weight,
+            device=mesh_device,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=ttnn.bfloat16,
+            cache_file_name=get_cache_file_name(tensor_cache_path, "weight"),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        self.bias = ttnn.as_tensor(
+            torch_bias,
+            device=mesh_device,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=ttnn.bfloat16,
+            cache_file_name=get_cache_file_name(tensor_cache_path, "bias"),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+        # Keep compute_config=None for the linear (quality-safe default, per gpt_oss).
+        self.compute_config = None
+        self.softmax_compute_config = ttnn.init_device_compute_kernel_config(
+            mesh_device.arch(),
+            math_fidelity=ttnn.MathFidelity.HiFi3,
+            math_approx_mode=False,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=False,
+        )
+
+    def __call__(self, hidden_states):
+        """Route ``hidden_states`` -> ``(expert_indices [tokens, k], expert_weights [tokens, k])``.
+
+        ``hidden_states`` may be any shape whose trailing dim is ``hidden_dim`` (e.g. [1, 1, S, H]);
+        it is flattened to ``[tokens, hidden_dim]`` first. Token count is derived from the tensor
+        volume (shape[0] after reshape is tile-padded in TILE_LAYOUT)."""
+        actual_tokens = hidden_states.volume() // self.hidden_dim
+        hidden_states = ttnn.reshape(hidden_states, (-1, self.hidden_dim))
+
+        # L1 for small (decode) token counts, DRAM for large (prefill) sequences.
+        is_decode = actual_tokens <= 128
+        mem_config = ttnn.L1_MEMORY_CONFIG if is_decode else ttnn.DRAM_MEMORY_CONFIG
+        router_logits = ttnn.linear(
+            hidden_states,
+            self.weight,
+            bias=self.bias,
+            memory_config=mem_config,
+            compute_kernel_config=self.compute_config,
+        )
+
+        expert_indices, expert_weights = route_tokens_to_experts(router_logits, self.top_k, self.softmax_compute_config)
+        ttnn.deallocate(router_logits)
+        return expert_indices, expert_weights

--- a/models/demos/gpt_oss_d_p/tt/moe/tt_gpt_oss_moe.py
+++ b/models/demos/gpt_oss_d_p/tt/moe/tt_gpt_oss_moe.py
@@ -74,12 +74,8 @@ class TtGptOssMoE(LightweightModule):
         # the hookup is a one-line change once #49619 lands; do NOT enable use_expert_bias until then.
         self.routed_expert_biases = routed_expert_biases
         self.use_expert_bias = use_expert_bias
-        if use_expert_bias:
-            raise NotImplementedError(
-                "use_expert_bias=True requires #49619 (bias in unified_routed_expert_moe), which is "
-                "NOT merged on this branch. Leave use_expert_bias=False until it lands; see the "
-                "TODO(#49619) at the TtRoutedExpert construction below."
-            )
+        # #49619 (bias in unified_routed_expert_moe / TtRoutedExpert) is now MERGED, so
+        # use_expert_bias=True is supported: biases are passed to TtRoutedExpert below.
 
         expert_dispatch_table = ExpertMapping.create_dispatch_table(
             num_routed_experts, dispatch_group_size, num_dispatch_groups
@@ -137,13 +133,11 @@ class TtGptOssMoE(LightweightModule):
 
         # Routed expert: the fused unified_routed_expert_moe kernel with the clamped swigluoai
         # activation (RoutedExpertActivation.SwiGluOai bakes GPT-OSS's alpha=1.702 / limit=7.0).
-        #
-        # TODO(#49619): once expert bias lands in unified_routed_expert_moe, pass the prepared
-        # per-expert biases to TtRoutedExpert here, e.g. add:
-        #     torch_biases=self.routed_expert_biases,   # [{gate_bias, up_bias, down_bias}, ...]
-        # (guarded by self.use_expert_bias). The exact kwarg name follows #49619's TtRoutedExpert
-        # signature. DO NOT pass any bias kwarg on this branch — TtRoutedExpert.__init__ does not
-        # accept one and the current kernel is bias-free (verified 2026-07-17).
+        # #49619 (merged) added expert-bias support to TtRoutedExpert (torch_biases kwarg; the kernel
+        # adds gate/up bias before the clamp and down bias after the down matmul, SwiGluOai only).
+        # Passing the biases is required for correctness — without them the MoE output is
+        # systematically off every layer and the error accumulates through the residual (V PCC
+        # collapses with depth). Gated by use_expert_bias so the bias-free path stays available.
         self.routed_expert = TtRoutedExpert(
             mesh_device=mesh_device,
             experts_per_chip=experts_per_chip,
@@ -152,6 +146,7 @@ class TtGptOssMoE(LightweightModule):
             hidden_dim=hidden_dim,
             max_tokens=max_dispatched_tokens_per_expert,
             torch_weights=routed_expert_weights,
+            torch_biases=self.routed_expert_biases if self.use_expert_bias else None,
             activations_dtype=routed_expert_activations_dtype,
             weights_dtype=routed_expert_weights_dtype,
             weight_cache_path=weight_cache_path,

--- a/models/demos/gpt_oss_d_p/tt/moe/tt_gpt_oss_moe.py
+++ b/models/demos/gpt_oss_d_p/tt/moe/tt_gpt_oss_moe.py
@@ -1,0 +1,228 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+TtGptOssMoE — GPT-OSS prefill expert-parallel routed-expert MoE block.
+
+Mirrors ``models/demos/minimax_m3/tt/moe/tt_minimax_moe.py`` almost line-for-line, composing the
+(generic, already-validated) DeepSeek EP sub-modules:
+
+    routing_setup -> all_gather(x) -> dispatch -> routed_expert -> combine -> reduce
+
+GPT-OSS-specific differences vs the MiniMax-M3 template:
+  - NO internal gate. GPT-OSS routing (top-k FIRST, then softmax over the k selected logits, with a
+    Linear bias) is different math from DeepSeek/MiniMax and lives in ``TtGptOssRouter``. This module
+    REQUIRES external ``topk_indices`` / ``topk_weights`` in ``forward`` (no TtMoEGatePrefill).
+  - NO shared expert (GPT-OSS has none; the M3 shared-expert wiring is dropped).
+  - Expert FFNs carry gate/up/down biases. The current ``unified_routed_expert_moe`` kernel on this
+    branch does NOT accept bias args (#49619), so this module runs the routed experts BIAS-FREE.
+    Biases are threaded as far as ``__init__`` behind ``use_expert_bias`` and a ``# TODO(#49619)``
+    where they would be passed to ``TtRoutedExpert`` — see below.
+
+Keeps M3's ``combine(init_zeros=True)`` (safe for skewed routing) and
+``activation=ttnn.RoutedExpertActivation.SwiGluOai`` (bakes GPT-OSS's alpha=1.702 / limit=7.0).
+
+Reference: models/demos/minimax_m3/tt/moe/tt_minimax_moe.py (TtMiniMaxMoE.__init__/forward).
+"""
+
+import ttnn
+from models.common.lightweightmodule import LightweightModule
+from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import ExpertMapping, get_ep_mesh_mapper
+from models.demos.deepseek_v3_d_p.tt.moe.tt_combine import TtCombineModule
+from models.demos.deepseek_v3_d_p.tt.moe.tt_dispatch import TtDispatchModule
+from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_routing_setup import TtMoERoutingSetup
+from models.demos.deepseek_v3_d_p.tt.moe.tt_reduce import TtReduceModule
+from models.demos.deepseek_v3_d_p.tt.moe.tt_routed_expert import TtRoutedExpert
+
+
+class TtGptOssMoE(LightweightModule):
+    def __init__(
+        self,
+        mesh_device,
+        dispatch_group_size: int,
+        num_dispatch_groups: int,
+        experts_per_chip: int,
+        num_routed_experts: int,
+        num_experts_per_tok: int,
+        metadata_len: int,
+        max_dispatched_tokens_per_expert: int,
+        max_dispatch_buffer_token_size: int,
+        seq_len_per_chip: int,
+        emb_dim: int,
+        hidden_dim: int,
+        routed_expert_weights: list,  # per-expert {gate_proj, up_proj, down_proj}, global id order 0..E-1
+        routed_expert_biases: list = None,  # per-expert {gate_bias, up_bias, down_bias}, same order (#49619)
+        num_links: int = 2,
+        topology=ttnn.Topology.Linear,
+        routed_expert_activations_dtype=ttnn.bfloat8_b,
+        routed_expert_weights_dtype=ttnn.bfloat4_b,
+        weight_cache_path=None,
+        layer_idx: int = 0,
+        use_expert_bias: bool = False,
+    ):
+        super().__init__()
+        self.mesh_device = mesh_device
+        self.num_routed_experts = num_routed_experts
+        self.num_experts_per_tok = num_experts_per_tok
+        self.seq_len_per_chip = seq_len_per_chip
+        self.experts_per_chip = experts_per_chip
+        self.emb_dim = emb_dim
+
+        # ---- Expert bias (#49619) -----------------------------------------------------------------
+        # The current unified_routed_expert_moe kernel on this branch is BIAS-FREE — passing a
+        # bias/torch_biases kwarg to TtRoutedExpert WILL CRASH. We keep the prepared biases here so
+        # the hookup is a one-line change once #49619 lands; do NOT enable use_expert_bias until then.
+        self.routed_expert_biases = routed_expert_biases
+        self.use_expert_bias = use_expert_bias
+        if use_expert_bias:
+            raise NotImplementedError(
+                "use_expert_bias=True requires #49619 (bias in unified_routed_expert_moe), which is "
+                "NOT merged on this branch. Leave use_expert_bias=False until it lands; see the "
+                "TODO(#49619) at the TtRoutedExpert construction below."
+            )
+
+        expert_dispatch_table = ExpertMapping.create_dispatch_table(
+            num_routed_experts, dispatch_group_size, num_dispatch_groups
+        )
+
+        # NOTE: no internal gate (TtMoEGatePrefill) — GPT-OSS routing lives in TtGptOssRouter and is
+        # passed into forward() as external topk_indices / topk_weights.
+        self.routing_setup = TtMoERoutingSetup(
+            mesh_device, expert_dispatch_table, num_links=num_links, experts_per_chip=experts_per_chip
+        )
+        self.tt_expert_dispatch_table = TtDispatchModule.shard_expert_dispatch_table(
+            mesh_device, expert_dispatch_table, dispatch_axis=0
+        )
+        self.dispatch_module = TtDispatchModule(
+            mesh_device=mesh_device,
+            dispatch_group_size=dispatch_group_size,
+            experts_per_chip=experts_per_chip,
+            num_routed_experts=num_routed_experts,
+            num_experts_per_tok=num_experts_per_tok,
+            metadata_len=metadata_len,
+            max_dispatch_buffer_token_size=max_dispatch_buffer_token_size,
+            seq_len_per_chip=seq_len_per_chip,
+            emb_dim=emb_dim,
+            cluster_axis=0,
+            num_links=num_links,
+            topology=topology,
+            subdevice_id=None,
+        )
+        self.combine_module = TtCombineModule(
+            mesh_device=mesh_device,
+            dispatch_group_size=dispatch_group_size,
+            num_dispatch_groups=num_dispatch_groups,
+            experts_per_chip=experts_per_chip,
+            num_experts_per_tok=num_experts_per_tok,
+            seq_len_per_chip=seq_len_per_chip,
+            cluster_axis=0,
+            num_links=num_links,
+            topology=topology,
+            # init_zeros=True (M3 override): skewed routing leaves many empty combine slots; with
+            # init_zeros=False those keep stale DRAM -> garbage weighted-sum -> nan. Zero-init them.
+            init_zeros=True,
+        )
+        global_expert_idx_tt = ttnn.from_torch(
+            ExpertMapping.create_global_expert_idx_table(
+                experts_per_chip=experts_per_chip,
+                dispatch_group_size=dispatch_group_size,
+                num_dispatch_groups=num_dispatch_groups,
+            ),
+            mesh_mapper=get_ep_mesh_mapper(mesh_device),
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=mesh_device,
+            dtype=ttnn.uint32,
+        )
+        global_expert_idx_tt = ttnn.squeeze(ttnn.squeeze(global_expert_idx_tt, 0), 0)
+
+        # Routed expert: the fused unified_routed_expert_moe kernel with the clamped swigluoai
+        # activation (RoutedExpertActivation.SwiGluOai bakes GPT-OSS's alpha=1.702 / limit=7.0).
+        #
+        # TODO(#49619): once expert bias lands in unified_routed_expert_moe, pass the prepared
+        # per-expert biases to TtRoutedExpert here, e.g. add:
+        #     torch_biases=self.routed_expert_biases,   # [{gate_bias, up_bias, down_bias}, ...]
+        # (guarded by self.use_expert_bias). The exact kwarg name follows #49619's TtRoutedExpert
+        # signature. DO NOT pass any bias kwarg on this branch — TtRoutedExpert.__init__ does not
+        # accept one and the current kernel is bias-free (verified 2026-07-17).
+        self.routed_expert = TtRoutedExpert(
+            mesh_device=mesh_device,
+            experts_per_chip=experts_per_chip,
+            global_expert_idx_table=global_expert_idx_tt,
+            emb_dim=emb_dim,
+            hidden_dim=hidden_dim,
+            max_tokens=max_dispatched_tokens_per_expert,
+            torch_weights=routed_expert_weights,
+            activations_dtype=routed_expert_activations_dtype,
+            weights_dtype=routed_expert_weights_dtype,
+            weight_cache_path=weight_cache_path,
+            cache_name_prefix=f"layer_{layer_idx}.routed_expert",
+            activation=ttnn.RoutedExpertActivation.SwiGluOai,
+        )
+        self.reduce_module = TtReduceModule(
+            mesh_device=mesh_device,
+            topk_dim=3,
+            cluster_axis=1,
+            num_links=num_links,
+            topology=topology,
+        )
+
+    def forward(self, x, topk_indices, topk_weights):
+        """Routed (expert-parallel) MoE output.
+
+        x: (dispatch_group_size, seq_len_per_chip, emb_dim) — emb may be TP-sharded (then it is
+           all-gathered to full) or already full (replicated, e.g. from the decoder layer), in which
+           case the gather is skipped.
+        topk_indices / topk_weights: REQUIRED external routing [tokens, k] from TtGptOssRouter
+           (indices uint16/ROW_MAJOR, weights bf16). Unlike M3 there is no internal gate fallback.
+        """
+        assert topk_indices is not None and topk_weights is not None, (
+            "TtGptOssMoE requires external topk_indices/topk_weights (from TtGptOssRouter); " "it has no internal gate."
+        )
+        indices, scores = topk_indices, topk_weights
+
+        tt_expert_offsets, tt_expert_token_counts, tt_expert_region_offsets, _ = self.routing_setup(
+            ttnn_top_k_experts_indices=indices,
+            num_routed_experts=self.num_routed_experts,
+            seq_len_per_chip=self.seq_len_per_chip,
+            num_experts_per_tok=self.num_experts_per_tok,
+        )
+        indices = ttnn.to_layout(indices, ttnn.ROW_MAJOR_LAYOUT)
+        scores = ttnn.to_layout(scores, ttnn.ROW_MAJOR_LAYOUT)
+        b, s = x.shape[0], x.shape[1]
+        scores = ttnn.reshape(scores, (b, s, scores.shape[-1]))
+        indices = ttnn.reshape(indices, (b, s, indices.shape[-1]))
+
+        # Dispatch needs full emb per chip. All-gather across TP only if emb is sharded; if the input
+        # is already full emb (replicated, e.g. from the decoder layer), skip.
+        if self.mesh_device.shape[1] > 1 and x.shape[-1] < self.emb_dim:
+            x = ttnn.all_gather(
+                x, dim=-1, cluster_axis=1, num_links=self.reduce_module.num_links, topology=ttnn.Topology.Linear
+            )
+
+        # Dispatch -> per-expert buffers (NO shared expert)
+        dispatched_buffer, metadata = self.dispatch_module(
+            x, scores, indices, tt_expert_offsets, self.tt_expert_dispatch_table
+        )
+        ttnn.deallocate(x)
+        scores = ttnn.to_memory_config(scores, ttnn.DRAM_MEMORY_CONFIG)
+        indices = ttnn.to_memory_config(indices, ttnn.DRAM_MEMORY_CONFIG)
+
+        dispatched_buffer_tiled = ttnn.to_layout(
+            ttnn.squeeze(ttnn.squeeze(dispatched_buffer, dim=0), dim=0),
+            ttnn.TILE_LAYOUT,
+            dtype=self.routed_expert.activations_dtype,
+        )
+        ttnn.deallocate(dispatched_buffer)
+
+        expert_outputs = self.routed_expert(dispatched_buffer_tiled, tt_expert_token_counts, tt_expert_region_offsets)
+        expert_outputs = ttnn.unsqueeze(ttnn.unsqueeze(expert_outputs, dim=0), dim=0)
+
+        combined_output = self.combine_module(
+            expert_outputs, metadata, tt_expert_token_counts, tt_expert_region_offsets
+        )
+        # Fused weighted-sum over topk + reduce-scatter across TP
+        routed_output = self.reduce_module(
+            combined_output, weights=scores, indices=indices, expert_dispatch_table=self.tt_expert_dispatch_table
+        )
+        routed_output = ttnn.squeeze(routed_output, dim=0)
+        return routed_output

--- a/models/demos/gpt_oss_d_p/tt/moe/tt_gpt_oss_moe.py
+++ b/models/demos/gpt_oss_d_p/tt/moe/tt_gpt_oss_moe.py
@@ -51,7 +51,7 @@ class TtGptOssMoE(LightweightModule):
         emb_dim: int,
         hidden_dim: int,
         routed_expert_weights: list,  # per-expert {gate_proj, up_proj, down_proj}, global id order 0..E-1
-        routed_expert_biases: list = None,  # per-expert {gate_bias, up_bias, down_bias}, same order (#49619)
+        routed_expert_biases: list = None,  # per-expert {gate_proj_bias, up_proj_bias, down_proj_bias} (#49619)
         num_links: int = 2,
         topology=ttnn.Topology.Linear,
         routed_expert_activations_dtype=ttnn.bfloat8_b,
@@ -177,7 +177,6 @@ class TtGptOssMoE(LightweightModule):
         tt_expert_offsets, tt_expert_token_counts, tt_expert_region_offsets, _ = self.routing_setup(
             ttnn_top_k_experts_indices=indices,
             num_routed_experts=self.num_routed_experts,
-            seq_len_per_chip=self.seq_len_per_chip,
             num_experts_per_tok=self.num_experts_per_tok,
         )
         indices = ttnn.to_layout(indices, ttnn.ROW_MAJOR_LAYOUT)

--- a/models/demos/gpt_oss_d_p/tt/moe/tt_gpt_oss_moe.py
+++ b/models/demos/gpt_oss_d_p/tt/moe/tt_gpt_oss_moe.py
@@ -14,10 +14,10 @@ GPT-OSS-specific differences vs the MiniMax-M3 template:
     Linear bias) is different math from DeepSeek/MiniMax and lives in ``TtGptOssRouter``. This module
     REQUIRES external ``topk_indices`` / ``topk_weights`` in ``forward`` (no TtMoEGatePrefill).
   - NO shared expert (GPT-OSS has none; the M3 shared-expert wiring is dropped).
-  - Expert FFNs carry gate/up/down biases. The current ``unified_routed_expert_moe`` kernel on this
-    branch does NOT accept bias args (#49619), so this module runs the routed experts BIAS-FREE.
-    Biases are threaded as far as ``__init__`` behind ``use_expert_bias`` and a ``# TODO(#49619)``
-    where they would be passed to ``TtRoutedExpert`` — see below.
+  - Expert FFNs carry gate/up/down biases. #49619 (bias in unified_routed_expert_moe /
+    TtRoutedExpert) is MERGED, so this module passes the biases through to TtRoutedExpert behind
+    ``use_expert_bias`` (the kernel adds gate/up bias before the clamp and down bias after the down
+    matmul, SwiGluOai only). ``use_expert_bias=False`` keeps the bias-free path.
 
 Keeps M3's ``combine(init_zeros=True)`` (safe for skewed routing) and
 ``activation=ttnn.RoutedExpertActivation.SwiGluOai`` (bakes GPT-OSS's alpha=1.702 / limit=7.0).
@@ -68,14 +68,13 @@ class TtGptOssMoE(LightweightModule):
         self.experts_per_chip = experts_per_chip
         self.emb_dim = emb_dim
 
-        # ---- Expert bias (#49619) -----------------------------------------------------------------
-        # The current unified_routed_expert_moe kernel on this branch is BIAS-FREE — passing a
-        # bias/torch_biases kwarg to TtRoutedExpert WILL CRASH. We keep the prepared biases here so
-        # the hookup is a one-line change once #49619 lands; do NOT enable use_expert_bias until then.
+        # ---- Expert bias (#49619, MERGED) ---------------------------------------------------------
+        # unified_routed_expert_moe / TtRoutedExpert now accept per-expert gate/up/down biases, so
+        # use_expert_bias=True is supported: the prepared biases are passed to TtRoutedExpert below
+        # (gate/up bias before the clamp, down bias after the down matmul; SwiGluOai only). Set
+        # use_expert_bias=False to fall back to the bias-free path.
         self.routed_expert_biases = routed_expert_biases
         self.use_expert_bias = use_expert_bias
-        # #49619 (bias in unified_routed_expert_moe / TtRoutedExpert) is now MERGED, so
-        # use_expert_bias=True is supported: biases are passed to TtRoutedExpert below.
 
         expert_dispatch_table = ExpertMapping.create_dispatch_table(
             num_routed_experts, dispatch_group_size, num_dispatch_groups

--- a/models/demos/gpt_oss_d_p/tt/moe/weights.py
+++ b/models/demos/gpt_oss_d_p/tt/moe/weights.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+GPT-OSS routed-expert weight preparation for the EP MoE (TtGptOssMoE / TtRoutedExpert).
+
+HF GPT-OSS packs each expert's gate and up projections into a single interleaved tensor
+``experts.gate_up_proj`` of shape ``[E, hidden, 2*inter]`` (gate = even columns, up = odd
+columns), with a matching interleaved ``experts.gate_up_proj_bias`` of shape ``[E, 2*inter]``.
+The down projection lives in ``experts.down_proj`` ``[E, inter, hidden]`` with bias
+``experts.down_proj_bias`` ``[E, hidden]``.
+
+This module:
+  * de-interleaves ``gate_up_proj[..., ::2]`` -> gate, ``[..., 1::2]`` -> up (and the matching
+    bias split from ``gate_up_proj_bias``),
+  * transposes every projection to HuggingFace ``(out_features, in_features)`` per expert — the
+    layout ``TtRoutedExpert`` expects (it transposes back to ``(in, out)`` internally for the
+    matmul). De-interleaved gate/up are ``(hidden=in, inter=out)`` and ``down`` is
+    ``(inter=in, hidden=out)``, so all three are transposed,
+  * emits the per-expert ``routed_expert_weights`` list in GLOBAL expert-id order 0..E-1
+    (``TtRoutedExpert`` / ``ExpertMapping.gather_weights_for_mesh_distribution`` performs the mesh
+    gather itself — no explicit permutation here).
+
+Biases are emitted into a SEPARATE structure (``routed_expert_biases``) and are NOT attached to
+the weight dicts: the current ``unified_routed_expert_moe`` kernel on this branch does NOT accept
+bias args (see #49619). The biased hookup is stubbed in ``TtGptOssMoE``.
+
+Target dtypes (applied downstream by TtRoutedExpert, not here): weights bfloat4_b, activations
+bfloat8_b. This module returns plain torch tensors.
+"""
+
+
+def prepare_routed_expert_weights(state_dict, num_experts, hidden_size, intermediate_size):
+    """Build the per-expert routed-expert weights + biases from an ``experts.*`` sub state dict.
+
+    Args:
+        state_dict: experts sub-dict with keys ``gate_up_proj`` ``[E, hidden, 2*inter]``,
+            ``gate_up_proj_bias`` ``[E, 2*inter]``, ``down_proj`` ``[E, inter, hidden]``,
+            ``down_proj_bias`` ``[E, hidden]``.
+        num_experts: number of routed experts E (global).
+        hidden_size: model embedding dim (hidden).
+        intermediate_size: MoE FFN hidden dim (inter).
+
+    Returns:
+        (routed_expert_weights, routed_expert_biases):
+          * routed_expert_weights: list[dict] len E, global order 0..E-1, keys
+            ``gate_proj``/``up_proj``/``down_proj`` in HF ``(out, in)`` layout.
+          * routed_expert_biases: list[dict] len E, global order 0..E-1, keys
+            ``gate_bias``/``up_bias``/``down_bias`` (1D). SEPARATE from the weights (#49619).
+    """
+    gate_up_proj = state_dict["gate_up_proj"]  # [E, hidden, 2*inter]
+    gate_up_proj_bias = state_dict["gate_up_proj_bias"]  # [E, 2*inter]
+    down_proj = state_dict["down_proj"]  # [E, inter, hidden]
+    down_proj_bias = state_dict["down_proj_bias"]  # [E, hidden]
+
+    # De-interleave: gate = even columns, up = odd columns.
+    gate = gate_up_proj[..., ::2].reshape(num_experts, hidden_size, intermediate_size)  # (in=hidden, out=inter)
+    up = gate_up_proj[..., 1::2].reshape(num_experts, hidden_size, intermediate_size)  # (in=hidden, out=inter)
+    gate_bias = gate_up_proj_bias[..., ::2].reshape(num_experts, intermediate_size)  # [E, inter]
+    up_bias = gate_up_proj_bias[..., 1::2].reshape(num_experts, intermediate_size)  # [E, inter]
+    down = down_proj.reshape(num_experts, intermediate_size, hidden_size)  # (in=inter, out=hidden)
+    down_bias = down_proj_bias.reshape(num_experts, hidden_size)  # [E, hidden]
+
+    routed_expert_weights = []
+    routed_expert_biases = []
+    for e in range(num_experts):
+        # Transpose to HF (out, in): gate/up -> (inter, hidden); down -> (hidden, inter).
+        routed_expert_weights.append(
+            {
+                "gate_proj": gate[e].transpose(0, 1).contiguous(),
+                "up_proj": up[e].transpose(0, 1).contiguous(),
+                "down_proj": down[e].transpose(0, 1).contiguous(),
+            }
+        )
+        routed_expert_biases.append(
+            {
+                "gate_bias": gate_bias[e].contiguous(),
+                "up_bias": up_bias[e].contiguous(),
+                "down_bias": down_bias[e].contiguous(),
+            }
+        )
+
+    return routed_expert_weights, routed_expert_biases

--- a/models/demos/gpt_oss_d_p/tt/moe/weights.py
+++ b/models/demos/gpt_oss_d_p/tt/moe/weights.py
@@ -74,9 +74,10 @@ def prepare_routed_expert_weights(state_dict, num_experts, hidden_size, intermed
         )
         routed_expert_biases.append(
             {
-                "gate_bias": gate_bias[e].contiguous(),
-                "up_bias": up_bias[e].contiguous(),
-                "down_bias": down_bias[e].contiguous(),
+                # keys match TtRoutedExpert._convert_expert_biases (gate/up/down_proj_bias)
+                "gate_proj_bias": gate_bias[e].contiguous(),
+                "up_proj_bias": up_bias[e].contiguous(),
+                "down_proj_bias": down_bias[e].contiguous(),
             }
         )
 

--- a/models/demos/gpt_oss_d_p/tt/moe/weights.py
+++ b/models/demos/gpt_oss_d_p/tt/moe/weights.py
@@ -47,7 +47,7 @@ def prepare_routed_expert_weights(state_dict, num_experts, hidden_size, intermed
           * routed_expert_weights: list[dict] len E, global order 0..E-1, keys
             ``gate_proj``/``up_proj``/``down_proj`` in HF ``(out, in)`` layout.
           * routed_expert_biases: list[dict] len E, global order 0..E-1, keys
-            ``gate_bias``/``up_bias``/``down_bias`` (1D). SEPARATE from the weights (#49619).
+            ``gate_proj_bias``/``up_proj_bias``/``down_proj_bias`` (1D). SEPARATE from the weights (#49619).
     """
     gate_up_proj = state_dict["gate_up_proj"]  # [E, hidden, 2*inter]
     gate_up_proj_bias = state_dict["gate_up_proj_bias"]  # [E, 2*inter]

--- a/models/demos/gpt_oss_d_p/tt/moe/weights.py
+++ b/models/demos/gpt_oss_d_p/tt/moe/weights.py
@@ -22,8 +22,9 @@ This module:
     gather itself — no explicit permutation here).
 
 Biases are emitted into a SEPARATE structure (``routed_expert_biases``) and are NOT attached to
-the weight dicts: the current ``unified_routed_expert_moe`` kernel on this branch does NOT accept
-bias args (see #49619). The biased hookup is stubbed in ``TtGptOssMoE``.
+the weight dicts. ``TtGptOssMoE`` passes them through to ``TtRoutedExpert`` (#49619, merged: the
+``unified_routed_expert_moe`` kernel adds gate/up bias before the clamp and down bias after the
+down matmul, SwiGluOai only).
 
 Target dtypes (applied downstream by TtRoutedExpert, not here): weights bfloat4_b, activations
 bfloat8_b. This module returns plain torch tensors.


### PR DESCRIPTION
> **P3 of the GPT-OSS prefill stack.** #50223 (attention) + #50228 (KV cache) are merged, so this now stacks directly on `main`; the diff is the MoE delta only.

## What
The **MoE wrapper** — a thin `TtGptOssMoE` composing the DeepSeek EP substrate, plus a gpt-oss-specific router. Mirrors `minimax_m3`'s `TtMiniMaxMoE`. Every gpt-oss layer is MoE (no shared expert, no dense branch).

## This PR
- **`tt/moe/router.py`** — `TtGptOssRouter`, ported from `gpt_oss/tt/topk.py`: `linear(+bias) → topk(4) → softmax over the 4 selected`. gpt-oss selects top-4 *then* softmaxes (DeepSeek's gate scores all experts first), so routing is external — not DeepSeek's `TtMoEGatePrefill`.
- **`tt/moe/tt_gpt_oss_moe.py`** — `TtGptOssMoE`, mirrors `TtMiniMaxMoE` **minus the internal gate and the shared expert**; reuses `deepseek_v3_d_p.tt.moe.*` dispatch/combine/reduce/routing_setup + `TtRoutedExpert` (`activation=SwiGluOai`, `combine init_zeros=True`) verbatim.
- **`tt/moe/weights.py`** — expert weight prep: de-interleave `gate_up_proj[...,::2]`/`[...,1::2]` (+ matching bias split), transpose to HF `(out,in)`, global expert-id order.
- **`tt/mlp.py`** — thin router + MoE wrapper (all-MoE, no shared expert, no dense branch).

## Expert bias (#49619, merged)
gpt-oss experts carry gate/up/down **biases**. #49619 added bias support to `TtRoutedExpert` / the fused `unified_routed_expert_moe` kernel (gate/up bias before the clamp, down bias after the down matmul; SwiGluOai only), and it is **merged**. This PR runs **biased** (`use_expert_bias=True`): `weights.py` preps the per-expert biases and `TtGptOssMoE` passes them straight through to `TtRoutedExpert`. `use_expert_bias=False` keeps the bias-free path available.

## Tests (`tests/unit/test_moe_vs_ref.py`)
- **`test_router_vs_ref`** (single card): topk indices vs ref — mismatches proven to be genuine bf16 top-4/5 near-ties; softmax weights PCC **0.9955**.
- **`test_routed_expert_ffn_vs_ref`** (single card) — parametrized **`[biasfree, biased]`**: SwiGLU-OAI expert FFN vs a torch reference, both bias-free and with per-expert gate/up/down biases (the deployment default). min PCC **0.9833** (both variants). The `biased` case exercises the exact path the model runs.
- **`test_gpt_oss_moe_vs_ref`** (galaxy-gated): full router→dispatch→combine→reduce at EP=32 — auto-skips on a single card.

## Follow-ups
- Add the full-MoE + per-layer golden-KV validation on a 4×8 Blackhole galaxy (P5).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mdragula/gpt-oss-moe)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mdragula/gpt-oss-moe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mdragula/gpt-oss-moe)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mdragula/gpt-oss-moe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mdragula/gpt-oss-moe)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mdragula/gpt-oss-moe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mdragula/gpt-oss-moe)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mdragula/gpt-oss-moe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mdragula/gpt-oss-moe)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mdragula/gpt-oss-moe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mdragula/gpt-oss-moe)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mdragula/gpt-oss-moe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mdragula/gpt-oss-moe)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mdragula/gpt-oss-moe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mdragula/gpt-oss-moe)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mdragula/gpt-oss-moe)
