### PR TITLE
[scaleout][exabox] tag every recover.sh / run_validation.sh output line with [hostname][time]

### DIFF
--- a/tools/scaleout/exabox/mpi-docker
+++ b/tools/scaleout/exabox/mpi-docker
@@ -10,9 +10,8 @@ print_usage() {
     echo "  --mpi-interface <iface>   (Optional) Network interface to pin MPI to (default: ens5f0np0)"
     echo "                            Passed to --prtemca oob_tcp_if_include and --mca btl_tcp_if_include."
     echo "                            Interface names vary by site; override on non-Markham clusters."
-    echo "  --no-tag-host             (Optional) Disable per-rank [hostname] output tagging"
-    echo "                            (tagging is ON by default and replaces mpirun's [jobid,rank] tag;"
-    echo "                            --no-tag-host restores the plain --tag-output [jobid,rank] behavior)"
+    echo "  --tag-host                (Optional) Prefix each rank's output with [hostname]"
+    echo "                            instead of mpirun's [jobid,rank] --tag-output (off by default)"
     echo "  --print                   Print the command alongside execution"
     echo "  --print-only              Print the command without executing it"
     echo "  [global-mpi-args]     Global MPI arguments applied to all ranks"
@@ -51,8 +50,9 @@ default() {
     local print_flag=false
     local print_only=false
     # Host-tag each rank's output (replaces mpirun's [jobid,rank] --tag-output).
-    # On by default; disable with --no-tag-host.
-    local tag_host=true
+    # Off by default to preserve [jobid,rank] for callers that parse it; enable
+    # with --tag-host.
+    local tag_host=false
     # Interface names differ between sites; default works on Markham,
     # override elsewhere via --mpi-interface.
     local mpi_interface="ens5f0np0"
@@ -118,8 +118,8 @@ default() {
                 print_only=true
                 shift
                 ;;
-            --no-tag-host)
-                tag_host=false
+            --tag-host)
+                tag_host=true
                 shift
                 ;;
             *)

--- a/tools/scaleout/exabox/mpi-docker
+++ b/tools/scaleout/exabox/mpi-docker
@@ -118,10 +118,6 @@ default() {
                 print_only=true
                 shift
                 ;;
-            --tag-host)
-                tag_host=true
-                shift
-                ;;
             --no-tag-host)
                 tag_host=false
                 shift

--- a/tools/scaleout/exabox/mpi-docker
+++ b/tools/scaleout/exabox/mpi-docker
@@ -250,12 +250,12 @@ default() {
     local base_mpirun_args="$output_tag_arg --prtemca oob_tcp_if_include $mpi_interface --mca plm_ssh_args \"-o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR\" --mca btl_tcp_if_include $mpi_interface"
 
     # Per-rank self-tagger: runs in the remote shell (outside the container), pipes the
-    # container's merged stdout/stderr, and stamps each line with the real host + time.
-    # Lines that already begin with their own "YYYY-MM-DD HH:MM:SS" timestamp only get
-    # [hostname] prepended so the time is not duplicated. No single quotes (would clash
-    # with the bash -c '...' wrapper); $(hostname)/$l are kept literal here and resolved
-    # on the rank at run time. pipefail preserves the container's exit code through the pipe.
-    local host_tag_pipe='while IFS= read -r l; do case $l in [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]\ [0-9][0-9]:[0-9][0-9]:[0-9][0-9]*) printf "[%s] %s\n" "$(hostname)" "$l";; *) printf "[%s][%(%H:%M:%S)T] %s\n" "$(hostname)" -1 "$l";; esac; done'
+    # container's merged stdout/stderr, and stamps each line with a bare [real-host]
+    # prefix. The caller's tag_stream adds the time and avoids duplicating any timestamp
+    # the line already carries. No single quotes (would clash with the bash -c '...'
+    # wrapper); $(hostname)/$l are kept literal here and resolved on the rank at run
+    # time. pipefail preserves the container's exit code through the pipe.
+    local host_tag_pipe='while IFS= read -r l; do printf "[%s] %s\n" "$(hostname)" "$l"; done'
 
     # Add global MPI args to base
     if [[ ${#global_mpi_args[@]} -gt 0 ]]; then

--- a/tools/scaleout/exabox/mpi-docker
+++ b/tools/scaleout/exabox/mpi-docker
@@ -10,7 +10,7 @@ print_usage() {
     echo "  --mpi-interface <iface>   (Optional) Network interface to pin MPI to (default: ens5f0np0)"
     echo "                            Passed to --prtemca oob_tcp_if_include and --mca btl_tcp_if_include."
     echo "                            Interface names vary by site; override on non-Markham clusters."
-    echo "  --no-tag-host             (Optional) Disable per-rank [hostname][time] output tagging"
+    echo "  --no-tag-host             (Optional) Disable per-rank [hostname] output tagging"
     echo "                            (tagging is ON by default and replaces mpirun's [jobid,rank] tag;"
     echo "                            --no-tag-host restores the plain --tag-output [jobid,rank] behavior)"
     echo "  --print                   Print the command alongside execution"
@@ -50,11 +50,8 @@ default() {
     local extra_volumes=""
     local print_flag=false
     local print_only=false
-    # Prefix every output line of each rank with [hostname][time], where hostname is
-    # resolved on the rank's own host (the prefixer runs in the remote shell that
-    # launches `docker run`, outside the container, so it reports the real host
-    # regardless of container hostname). Replaces mpirun's opaque [jobid,rank]
-    # --tag-output tag. On by default; disable with --no-tag-host.
+    # Host-tag each rank's output (replaces mpirun's [jobid,rank] --tag-output).
+    # On by default; disable with --no-tag-host.
     local tag_host=true
     # Interface names differ between sites; default works on Markham,
     # override elsewhere via --mpi-interface.
@@ -240,21 +237,17 @@ default() {
         exit 1
     fi
 
-    # Build the command for each rank group. With --tag-host we do our own per-line
-    # [hostname][time] tagging on each rank, so mpirun's [jobid,rank] --tag-output is
-    # dropped to avoid a redundant/confusing double tag.
+    # With --tag-host we host-tag each rank ourselves, so drop mpirun's [jobid,rank]
+    # --tag-output to avoid a double tag.
     local output_tag_arg="--tag-output"
     if [[ "$tag_host" == true ]]; then
         output_tag_arg=""
     fi
     local base_mpirun_args="$output_tag_arg --prtemca oob_tcp_if_include $mpi_interface --mca plm_ssh_args \"-o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR\" --mca btl_tcp_if_include $mpi_interface"
 
-    # Per-rank self-tagger: runs in the remote shell (outside the container), pipes the
-    # container's merged stdout/stderr, and stamps each line with a bare [real-host]
-    # prefix. The caller's tag_stream adds the time and avoids duplicating any timestamp
-    # the line already carries. No single quotes (would clash with the bash -c '...'
-    # wrapper); $(hostname)/$l are kept literal here and resolved on the rank at run
-    # time. pipefail preserves the container's exit code through the pipe.
+    # Bare [real-host] tag applied in the remote shell (outside the container), so it
+    # reports the true host regardless of container hostname. No single quotes (would
+    # clash with the bash -c '...' wrapper); $(hostname)/$l resolve on the rank.
     local host_tag_pipe='while IFS= read -r l; do printf "[%s] %s\n" "$(hostname)" "$l"; done'
 
     # Add global MPI args to base

--- a/tools/scaleout/exabox/mpi-docker
+++ b/tools/scaleout/exabox/mpi-docker
@@ -10,6 +10,9 @@ print_usage() {
     echo "  --mpi-interface <iface>   (Optional) Network interface to pin MPI to (default: ens5f0np0)"
     echo "                            Passed to --prtemca oob_tcp_if_include and --mca btl_tcp_if_include."
     echo "                            Interface names vary by site; override on non-Markham clusters."
+    echo "  --no-tag-host             (Optional) Disable per-rank [hostname][time] output tagging"
+    echo "                            (tagging is ON by default and replaces mpirun's [jobid,rank] tag;"
+    echo "                            --no-tag-host restores the plain --tag-output [jobid,rank] behavior)"
     echo "  --print                   Print the command alongside execution"
     echo "  --print-only              Print the command without executing it"
     echo "  [global-mpi-args]     Global MPI arguments applied to all ranks"
@@ -47,6 +50,12 @@ default() {
     local extra_volumes=""
     local print_flag=false
     local print_only=false
+    # Prefix every output line of each rank with [hostname][time], where hostname is
+    # resolved on the rank's own host (the prefixer runs in the remote shell that
+    # launches `docker run`, outside the container, so it reports the real host
+    # regardless of container hostname). Replaces mpirun's opaque [jobid,rank]
+    # --tag-output tag. On by default; disable with --no-tag-host.
+    local tag_host=true
     # Interface names differ between sites; default works on Markham,
     # override elsewhere via --mpi-interface.
     local mpi_interface="ens5f0np0"
@@ -110,6 +119,14 @@ default() {
                 ;;
             --print-only)
                 print_only=true
+                shift
+                ;;
+            --tag-host)
+                tag_host=true
+                shift
+                ;;
+            --no-tag-host)
+                tag_host=false
                 shift
                 ;;
             *)
@@ -223,8 +240,21 @@ default() {
         exit 1
     fi
 
-    # Build the command for each rank group
-    local base_mpirun_args="--tag-output --prtemca oob_tcp_if_include $mpi_interface --mca plm_ssh_args \"-o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR\" --mca btl_tcp_if_include $mpi_interface"
+    # Build the command for each rank group. With --tag-host we do our own per-line
+    # [hostname][time] tagging on each rank, so mpirun's [jobid,rank] --tag-output is
+    # dropped to avoid a redundant/confusing double tag.
+    local output_tag_arg="--tag-output"
+    if [[ "$tag_host" == true ]]; then
+        output_tag_arg=""
+    fi
+    local base_mpirun_args="$output_tag_arg --prtemca oob_tcp_if_include $mpi_interface --mca plm_ssh_args \"-o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR\" --mca btl_tcp_if_include $mpi_interface"
+
+    # Per-rank self-tagger: runs in the remote shell (outside the container), pipes the
+    # container's merged stdout/stderr, and stamps each line with the real host + time.
+    # No single quotes (would clash with the bash -c '...' wrapper); $(hostname)/$l are
+    # kept literal here and resolved on the rank at run time. pipefail preserves the
+    # container's exit code through the pipe.
+    local host_tag_pipe='while IFS= read -r l; do printf "[%s][%(%H:%M:%S)T] %s\n" "$(hostname)" -1 "$l"; done'
 
     # Add global MPI args to base
     if [[ ${#global_mpi_args[@]} -gt 0 ]]; then
@@ -281,7 +311,11 @@ default() {
         local docker_cmd="docker run \$(env | grep -E \"^(OMPI_|PMIX_)\" | cut -f1 -d= | awk \"{print \\\"-e \\\" \\\$1}\" | tr \"\n\" \" \") $docker_env_flags --rm --net=host --privileged -v /tmp:/tmp -v /dev/hugepages-1G:/dev/hugepages-1G -v \$HOME:\$HOME --user \$(id -u):\$(id -g) -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro$extra_volumes $entrypoint_opt $image $executable"
 
         # Single segment without per-rank args
-        mpirun_segments+=("bash -c '$docker_cmd'")
+        if [[ "$tag_host" == true ]]; then
+            mpirun_segments+=("bash -c 'set -o pipefail; $docker_cmd 2>&1 | $host_tag_pipe'")
+        else
+            mpirun_segments+=("bash -c '$docker_cmd'")
+        fi
     else
         # Multi-executable mode with per-rank specifications
         for group in "${rank_groups[@]}"; do
@@ -354,7 +388,11 @@ default() {
             local docker_cmd="docker run \$(env | grep -E \"^(OMPI_|PMIX_)\" | cut -f1 -d= | awk \"{print \\\"-e \\\" \\\$1}\" | tr \"\n\" \" \") $docker_env_flags --rm --net=host --privileged -v /tmp:/tmp -v /dev/hugepages-1G:/dev/hugepages-1G -v \$HOME:\$HOME --user \$(id -u):\$(id -g) -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro$extra_volumes $entrypoint_opt $image $executable"
 
             # Combine this group's MPI args with docker command
-            mpirun_segments+=("${mpi_args[*]} bash -c '$docker_cmd'")
+            if [[ "$tag_host" == true ]]; then
+                mpirun_segments+=("${mpi_args[*]} bash -c 'set -o pipefail; $docker_cmd 2>&1 | $host_tag_pipe'")
+            else
+                mpirun_segments+=("${mpi_args[*]} bash -c '$docker_cmd'")
+            fi
         done
     fi
 

--- a/tools/scaleout/exabox/mpi-docker
+++ b/tools/scaleout/exabox/mpi-docker
@@ -251,10 +251,11 @@ default() {
 
     # Per-rank self-tagger: runs in the remote shell (outside the container), pipes the
     # container's merged stdout/stderr, and stamps each line with the real host + time.
-    # No single quotes (would clash with the bash -c '...' wrapper); $(hostname)/$l are
-    # kept literal here and resolved on the rank at run time. pipefail preserves the
-    # container's exit code through the pipe.
-    local host_tag_pipe='while IFS= read -r l; do printf "[%s][%(%H:%M:%S)T] %s\n" "$(hostname)" -1 "$l"; done'
+    # Lines that already begin with their own "YYYY-MM-DD HH:MM:SS" timestamp only get
+    # [hostname] prepended so the time is not duplicated. No single quotes (would clash
+    # with the bash -c '...' wrapper); $(hostname)/$l are kept literal here and resolved
+    # on the rank at run time. pipefail preserves the container's exit code through the pipe.
+    local host_tag_pipe='while IFS= read -r l; do case $l in [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]\ [0-9][0-9]:[0-9][0-9]:[0-9][0-9]*) printf "[%s] %s\n" "$(hostname)" "$l";; *) printf "[%s][%(%H:%M:%S)T] %s\n" "$(hostname)" -1 "$l";; esac; done'
 
     # Add global MPI args to base
     if [[ ${#global_mpi_args[@]} -gt 0 ]]; then

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -7,6 +7,22 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/utils/mpi_if_selection.sh"
 source "$SCRIPT_DIR/utils/host_utils.sh"
 
+# Prefix every output line with [hostname][time] using the orchestrator host.
+# Lines that already carry a [host][time] tag (e.g. the per-rank tt-smi reset
+# lines, which are tagged with their own remote hostname) are passed through
+# unchanged so they keep their real source attribution and are not double-tagged.
+tag_stream() {
+    local line
+    local tagged_re='^\[[^]]*\]\[[0-9][0-9]:[0-9][0-9]:[0-9][0-9]\]'
+    while IFS= read -r line; do
+        if [[ "$line" =~ $tagged_re ]]; then
+            printf '%s\n' "$line"
+        else
+            printf '[%s][%(%H:%M:%S)T] %s\n' "${HOSTNAME:-$(hostname)}" -1 "$line"
+        fi
+    done
+}
+
 # Function to display help
 show_help() {
     cat << EOF
@@ -311,8 +327,9 @@ mkdir -p "$OUTPUT_DIR"
 OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
 LOG_FILE="$OUTPUT_DIR/recover_$(date +%Y%m%d_%H%M%S).log"
 
-# Redirect all output: terminal sees colors, log file gets ANSI/CR stripped
-exec > >(tee >(sed 's/\x1b\[[0-9;]*[mJKHABCDfsuGMF]//g; s/\r//g' > "$LOG_FILE")) 2>&1
+# Redirect all output: every line is tagged with [hostname][time] (already-tagged
+# reset lines pass through untouched), terminal sees colors, log file gets ANSI/CR stripped
+exec > >(tag_stream | tee >(sed 's/\x1b\[[0-9;]*[mJKHABCDfsuGMF]//g; s/\r//g' > "$LOG_FILE")) 2>&1
 echo "Logging to: $LOG_FILE"
 
 # --check: dry run to verify MPI can reach all hosts, then exit

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -460,6 +460,8 @@ if [[ "$SKIP_VALIDATION" == false ]]; then
 
     run_cluster_validation() {
         if [[ -n "$DOCKER_IMAGE" ]]; then
+            # mpi-docker tags each rank's output with [hostname][time] at the source
+            # by default (real host, replacing mpirun's [jobid,rank] tag).
             ./tools/scaleout/exabox/mpi-docker --image "$DOCKER_IMAGE" \
                 --empty-entrypoint \
                 --mpi-interface "$MPI_IF" \
@@ -469,12 +471,15 @@ if [[ "$SKIP_VALIDATION" == false ]]; then
                 ./build/tools/scaleout/run_cluster_validation \
                 "${VALIDATION_ARGS[@]}"
         else
+            # Self-tag each rank's output with its own [hostname][time] at the source
+            # (mpirun merges all ranks into one stream at the launcher, so tagging must
+            # happen on the rank). pipefail keeps run_cluster_validation's real exit code.
+            local _bin_cmd
+            _bin_cmd=$(printf '%q ' ./build/tools/scaleout/run_cluster_validation "${VALIDATION_ARGS[@]}")
             mpirun --host "$HOSTS" \
                 --mca btl_tcp_if_include "$MPI_IF" \
                 "${MPI_EXTRA_ARGS[@]}" \
-                --tag-output \
-                ./build/tools/scaleout/run_cluster_validation \
-                "${VALIDATION_ARGS[@]}"
+                bash -c "set -o pipefail; $_bin_cmd 2>&1 | while IFS= read -r l; do printf '[%s][%(%H:%M:%S)T] %s\n' \"\$(hostname)\" -1 \"\$l\"; done"
         fi
     }
 

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -7,22 +7,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/utils/mpi_if_selection.sh"
 source "$SCRIPT_DIR/utils/host_utils.sh"
 
-# Single place that prefixes each output line with a [hostname] tag, plus a
-# [HH:MM:SS] time only when the line does not already carry its own
-# "YYYY-MM-DD HH:MM:SS" timestamp (Metal/UMD/tt-smi logs), so the time is never
-# printed twice on one line. Ranks prepend a bare "[host] " tag at the source
-# (mpirun merges all ranks into one stream, so only the rank knows its own
-# hostname); this function keeps that host, decides the time, and also tags the
-# orchestrator's own local lines. The leading-timestamp check tolerates leading
-# ANSI colour codes (tt-smi runs under a pty and colourises its output). Lines
-# already fully tagged as "[host][time] " (e.g. from an earlier pass through this
-# function) are emitted unchanged so nothing is double-tagged.
+# Tag each line with [hostname], adding [HH:MM:SS] only when the line has no
+# timestamp of its own so tool logs aren't stamped twice. Ranks prepend a bare
+# "[host] " prefix at the source; this keeps that host, adds the time, and passes
+# already fully-tagged lines through unchanged (idempotent under a second pass).
 tag_stream() {
     local line host rest
     local esc=$'\x1b'
-    local done_re='^\[[^][]*\]\[[0-9][0-9]:[0-9][0-9]:[0-9][0-9]\] '
-    local rank_re='^\[([^][]*)\] (.*)$'
-    local ts_re="^(${esc}\[[0-9;]*[a-zA-Z])*[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}"
+    local done_re='^\[[^][]*\]\[[0-9][0-9]:[0-9][0-9]:[0-9][0-9]\] '   # already [host][time]
+    local rank_re='^\[([^][]*)\] (.*)$'                                # rank's bare [host] prefix
+    local ts_re="^(${esc}\[[0-9;]*[a-zA-Z])*[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}"  # leading timestamp, ANSI-tolerant
     local self="${HOSTNAME:-$(hostname)}"
     while IFS= read -r line; do
         if [[ "$line" =~ $done_re ]]; then
@@ -348,8 +342,7 @@ mkdir -p "$OUTPUT_DIR"
 OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
 LOG_FILE="$OUTPUT_DIR/recover_$(date +%Y%m%d_%H%M%S).log"
 
-# Redirect all output: every line is tagged with [hostname][time] (already-tagged
-# reset lines pass through untouched), terminal sees colors, log file gets ANSI/CR stripped
+# Tag all output; terminal keeps colors, log file gets ANSI/CR stripped.
 exec > >(tag_stream | tee >(sed 's/\x1b\[[0-9;]*[mJKHABCDfsuGMF]//g; s/\r//g' > "$LOG_FILE")) 2>&1
 echo "Logging to: $LOG_FILE"
 
@@ -428,8 +421,8 @@ echo ""
 # Note: tt-smi -glx_reset is deprecated as of tt-smi 3.1.1; use tt-smi -r if available
 if [[ "$SKIP_RESET" == false ]]; then
     echo "Running tt-smi -glx_reset..."
-    # Host-tag every reset line for attribution. tt-smi writes key progress to the tty (not stdout) so
-    # run under `script`; the tr/sed/awk pipeline collapses its animated \r/spinner output, keeps colors.
+    # tt-smi writes progress to the tty (not stdout), so run under `script`; the
+    # tr/sed/awk pipeline collapses its animated \r/spinner output and keeps colors.
     read -r -d '' RESET_CMD <<'RESET_CMD' || true
 set -o pipefail
 h=$(hostname)
@@ -481,8 +474,7 @@ if [[ "$SKIP_VALIDATION" == false ]]; then
 
     run_cluster_validation() {
         if [[ -n "$DOCKER_IMAGE" ]]; then
-            # mpi-docker tags each rank's output with [hostname][time] at the source
-            # by default (real host, replacing mpirun's [jobid,rank] tag).
+            # mpi-docker host-tags each rank at the source by default.
             ./tools/scaleout/exabox/mpi-docker --image "$DOCKER_IMAGE" \
                 --empty-entrypoint \
                 --mpi-interface "$MPI_IF" \
@@ -492,10 +484,8 @@ if [[ "$SKIP_VALIDATION" == false ]]; then
                 ./build/tools/scaleout/run_cluster_validation \
                 "${VALIDATION_ARGS[@]}"
         else
-            # Self-tag each rank's output with a bare [hostname] at the source (mpirun
-            # merges all ranks into one stream at the launcher, so only the rank knows
-            # its own hostname). tag_stream adds the time and avoids duplicating any
-            # timestamp the line already carries. pipefail keeps the real exit code.
+            # Bare [host] tag on the rank (only the rank knows its hostname); tag_stream
+            # adds the time. pipefail keeps run_cluster_validation's real exit code.
             local _bin_cmd
             _bin_cmd=$(printf '%q ' ./build/tools/scaleout/run_cluster_validation "${VALIDATION_ARGS[@]}")
             mpirun --host "$HOSTS" \

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -474,9 +474,10 @@ if [[ "$SKIP_VALIDATION" == false ]]; then
 
     run_cluster_validation() {
         if [[ -n "$DOCKER_IMAGE" ]]; then
-            # mpi-docker host-tags each rank at the source by default.
+            # --tag-host makes mpi-docker prefix each rank with [hostname]; tag_stream adds the time.
             ./tools/scaleout/exabox/mpi-docker --image "$DOCKER_IMAGE" \
                 --empty-entrypoint \
+                --tag-host \
                 --mpi-interface "$MPI_IF" \
                 --volume /data/scaleout_configs \
                 "${MPI_EXTRA_ARGS[@]}" \

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -8,15 +8,21 @@ source "$SCRIPT_DIR/utils/mpi_if_selection.sh"
 source "$SCRIPT_DIR/utils/host_utils.sh"
 
 # Prefix every output line with [hostname][time] using the orchestrator host.
-# Lines that already carry a [host][time] tag (e.g. the per-rank tt-smi reset
-# lines, which are tagged with their own remote hostname) are passed through
-# unchanged so they keep their real source attribution and are not double-tagged.
+# Two kinds of lines are emitted with a reduced tag to avoid duplicating a time:
+#   - lines that already carry a [host][time] tag (e.g. the per-rank tt-smi reset
+#     lines, tagged with their own remote hostname) pass through unchanged; and
+#   - lines that already begin with their own "YYYY-MM-DD HH:MM:SS" timestamp
+#     (e.g. Metal/UMD logs) only get [hostname] prepended, so the time is not
+#     printed twice on the same line.
 tag_stream() {
     local line
     local tagged_re='^\[[^]]*\]\[[0-9][0-9]:[0-9][0-9]:[0-9][0-9]\]'
+    local ts_re='^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}'
     while IFS= read -r line; do
         if [[ "$line" =~ $tagged_re ]]; then
             printf '%s\n' "$line"
+        elif [[ "$line" =~ $ts_re ]]; then
+            printf '[%s] %s\n' "${HOSTNAME:-$(hostname)}" "$line"
         else
             printf '[%s][%(%H:%M:%S)T] %s\n' "${HOSTNAME:-$(hostname)}" -1 "$line"
         fi
@@ -424,7 +430,12 @@ script -qefc "tt-smi -glx_reset" /dev/null |
     }
     END { if (seen) print buf }' |
     while IFS= read -r line; do
-        printf '[%s][%(%H:%M:%S)T] %s\n' "$h" -1 "$line"
+        case $line in
+            [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]\ [0-9][0-9]:[0-9][0-9]:[0-9][0-9]*)
+                printf '[%s] %s\n' "$h" "$line" ;;
+            *)
+                printf '[%s][%(%H:%M:%S)T] %s\n' "$h" -1 "$line" ;;
+        esac
     done
 ec=${PIPESTATUS[0]}
 if [[ $ec -eq 0 ]]; then
@@ -473,13 +484,15 @@ if [[ "$SKIP_VALIDATION" == false ]]; then
         else
             # Self-tag each rank's output with its own [hostname][time] at the source
             # (mpirun merges all ranks into one stream at the launcher, so tagging must
-            # happen on the rank). pipefail keeps run_cluster_validation's real exit code.
+            # happen on the rank). Lines that already begin with their own timestamp
+            # only get [hostname] prepended so the time is not duplicated. pipefail
+            # keeps run_cluster_validation's real exit code.
             local _bin_cmd
             _bin_cmd=$(printf '%q ' ./build/tools/scaleout/run_cluster_validation "${VALIDATION_ARGS[@]}")
             mpirun --host "$HOSTS" \
                 --mca btl_tcp_if_include "$MPI_IF" \
                 "${MPI_EXTRA_ARGS[@]}" \
-                bash -c "set -o pipefail; $_bin_cmd 2>&1 | while IFS= read -r l; do printf '[%s][%(%H:%M:%S)T] %s\n' \"\$(hostname)\" -1 \"\$l\"; done"
+                bash -c "set -o pipefail; h=\$(hostname); $_bin_cmd 2>&1 | while IFS= read -r l; do case \$l in [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]\ [0-9][0-9]:[0-9][0-9]:[0-9][0-9]*) printf '[%s] %s\n' \"\$h\" \"\$l\";; *) printf '[%s][%(%H:%M:%S)T] %s\n' \"\$h\" -1 \"\$l\";; esac; done"
         fi
     }
 

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -7,24 +7,39 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/utils/mpi_if_selection.sh"
 source "$SCRIPT_DIR/utils/host_utils.sh"
 
-# Prefix every output line with [hostname][time] using the orchestrator host.
-# Two kinds of lines are emitted with a reduced tag to avoid duplicating a time:
-#   - lines that already carry a [host][time] tag (e.g. the per-rank tt-smi reset
-#     lines, tagged with their own remote hostname) pass through unchanged; and
-#   - lines that already begin with their own "YYYY-MM-DD HH:MM:SS" timestamp
-#     (e.g. Metal/UMD logs) only get [hostname] prepended, so the time is not
-#     printed twice on the same line.
+# Single place that prefixes each output line with a [hostname] tag, plus a
+# [HH:MM:SS] time only when the line does not already carry its own
+# "YYYY-MM-DD HH:MM:SS" timestamp (Metal/UMD/tt-smi logs), so the time is never
+# printed twice on one line. Ranks prepend a bare "[host] " tag at the source
+# (mpirun merges all ranks into one stream, so only the rank knows its own
+# hostname); this function keeps that host, decides the time, and also tags the
+# orchestrator's own local lines. The leading-timestamp check tolerates leading
+# ANSI colour codes (tt-smi runs under a pty and colourises its output). Lines
+# already fully tagged as "[host][time] " (e.g. from an earlier pass through this
+# function) are emitted unchanged so nothing is double-tagged.
 tag_stream() {
-    local line
-    local tagged_re='^\[[^]]*\]\[[0-9][0-9]:[0-9][0-9]:[0-9][0-9]\]'
-    local ts_re='^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}'
+    local line host rest
+    local esc=$'\x1b'
+    local done_re='^\[[^][]*\]\[[0-9][0-9]:[0-9][0-9]:[0-9][0-9]\] '
+    local rank_re='^\[([^][]*)\] (.*)$'
+    local ts_re="^(${esc}\[[0-9;]*[a-zA-Z])*[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}"
+    local self="${HOSTNAME:-$(hostname)}"
     while IFS= read -r line; do
-        if [[ "$line" =~ $tagged_re ]]; then
+        if [[ "$line" =~ $done_re ]]; then
             printf '%s\n' "$line"
-        elif [[ "$line" =~ $ts_re ]]; then
-            printf '[%s] %s\n' "${HOSTNAME:-$(hostname)}" "$line"
+            continue
+        fi
+        if [[ "$line" =~ $rank_re ]]; then
+            host="${BASH_REMATCH[1]}"
+            rest="${BASH_REMATCH[2]}"
         else
-            printf '[%s][%(%H:%M:%S)T] %s\n' "${HOSTNAME:-$(hostname)}" -1 "$line"
+            host="$self"
+            rest="$line"
+        fi
+        if [[ "$rest" =~ $ts_re ]]; then
+            printf '[%s] %s\n' "$host" "$rest"
+        else
+            printf '[%s][%(%H:%M:%S)T] %s\n' "$host" -1 "$rest"
         fi
     done
 }
@@ -430,18 +445,13 @@ script -qefc "tt-smi -glx_reset" /dev/null |
     }
     END { if (seen) print buf }' |
     while IFS= read -r line; do
-        case $line in
-            [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]\ [0-9][0-9]:[0-9][0-9]:[0-9][0-9]*)
-                printf '[%s] %s\n' "$h" "$line" ;;
-            *)
-                printf '[%s][%(%H:%M:%S)T] %s\n' "$h" -1 "$line" ;;
-        esac
+        printf '[%s] %s\n' "$h" "$line"
     done
 ec=${PIPESTATUS[0]}
 if [[ $ec -eq 0 ]]; then
-    printf '[%s][%(%H:%M:%S)T] Reset completed successfully\n' "$h" -1
+    printf '[%s] Reset completed successfully\n' "$h"
 else
-    printf '[%s][%(%H:%M:%S)T] Reset failed | Exit code: %s\n' "$h" -1 "$ec"
+    printf '[%s] Reset failed | Exit code: %s\n' "$h" "$ec"
 fi
 RESET_CMD
     mpirun --host "$HOSTS" \
@@ -482,17 +492,16 @@ if [[ "$SKIP_VALIDATION" == false ]]; then
                 ./build/tools/scaleout/run_cluster_validation \
                 "${VALIDATION_ARGS[@]}"
         else
-            # Self-tag each rank's output with its own [hostname][time] at the source
-            # (mpirun merges all ranks into one stream at the launcher, so tagging must
-            # happen on the rank). Lines that already begin with their own timestamp
-            # only get [hostname] prepended so the time is not duplicated. pipefail
-            # keeps run_cluster_validation's real exit code.
+            # Self-tag each rank's output with a bare [hostname] at the source (mpirun
+            # merges all ranks into one stream at the launcher, so only the rank knows
+            # its own hostname). tag_stream adds the time and avoids duplicating any
+            # timestamp the line already carries. pipefail keeps the real exit code.
             local _bin_cmd
             _bin_cmd=$(printf '%q ' ./build/tools/scaleout/run_cluster_validation "${VALIDATION_ARGS[@]}")
             mpirun --host "$HOSTS" \
                 --mca btl_tcp_if_include "$MPI_IF" \
                 "${MPI_EXTRA_ARGS[@]}" \
-                bash -c "set -o pipefail; h=\$(hostname); $_bin_cmd 2>&1 | while IFS= read -r l; do case \$l in [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]\ [0-9][0-9]:[0-9][0-9]:[0-9][0-9]*) printf '[%s] %s\n' \"\$h\" \"\$l\";; *) printf '[%s][%(%H:%M:%S)T] %s\n' \"\$h\" -1 \"\$l\";; esac; done"
+                bash -c "set -o pipefail; h=\$(hostname); $_bin_cmd 2>&1 | while IFS= read -r l; do printf '[%s] %s\n' \"\$h\" \"\$l\"; done"
         fi
     }
 

--- a/tools/scaleout/exabox/run_validation.sh
+++ b/tools/scaleout/exabox/run_validation.sh
@@ -6,15 +6,21 @@ source "$SCRIPT_DIR/utils/mpi_if_selection.sh"
 source "$SCRIPT_DIR/utils/host_utils.sh"
 
 # Prefix every output line with [hostname][time] using the orchestrator host.
-# Lines that already carry a [host][time] tag (e.g. the per-rank tt-smi reset
-# lines, which are tagged with their own remote hostname) are passed through
-# unchanged so they keep their real source attribution and are not double-tagged.
+# Two kinds of lines are emitted with a reduced tag to avoid duplicating a time:
+#   - lines that already carry a [host][time] tag (e.g. the per-rank tt-smi reset
+#     lines, tagged with their own remote hostname) pass through unchanged; and
+#   - lines that already begin with their own "YYYY-MM-DD HH:MM:SS" timestamp
+#     (e.g. Metal/UMD logs) only get [hostname] prepended, so the time is not
+#     printed twice on the same line.
 tag_stream() {
     local line
     local tagged_re='^\[[^]]*\]\[[0-9][0-9]:[0-9][0-9]:[0-9][0-9]\]'
+    local ts_re='^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}'
     while IFS= read -r line; do
         if [[ "$line" =~ $tagged_re ]]; then
             printf '%s\n' "$line"
+        elif [[ "$line" =~ $ts_re ]]; then
+            printf '[%s] %s\n' "${HOSTNAME:-$(hostname)}" "$line"
         else
             printf '[%s][%(%H:%M:%S)T] %s\n' "${HOSTNAME:-$(hostname)}" -1 "$line"
         fi
@@ -264,7 +270,9 @@ run_cluster_validation() {
     if [[ $DOCKER_IMAGE == "none" ]]; then
         # Self-tag each rank's output with its own [hostname][time] at the source
         # (mpirun merges all ranks into one stream at the launcher, so tagging must
-        # happen on the rank). pipefail keeps run_cluster_validation's real exit code.
+        # happen on the rank). Lines that already begin with their own timestamp
+        # only get [hostname] prepended so the time is not duplicated. pipefail
+        # keeps run_cluster_validation's real exit code.
         local bin_cmd
         bin_cmd=$(printf '%q ' ./build/tools/scaleout/run_cluster_validation \
             "${descriptor_args[@]}" \
@@ -275,7 +283,7 @@ run_cluster_validation() {
         mpirun --host "$HOSTS" \
             --mca btl_tcp_if_include "$MPI_IF" \
             "${MPI_EXTRA_ARGS[@]}" \
-            bash -c "set -o pipefail; $bin_cmd 2>&1 | while IFS= read -r l; do printf '[%s][%(%H:%M:%S)T] %s\n' \"\$(hostname)\" -1 \"\$l\"; done"
+            bash -c "set -o pipefail; h=\$(hostname); $bin_cmd 2>&1 | while IFS= read -r l; do case \$l in [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]\ [0-9][0-9]:[0-9][0-9]:[0-9][0-9]*) printf '[%s] %s\n' \"\$h\" \"\$l\";; *) printf '[%s][%(%H:%M:%S)T] %s\n' \"\$h\" -1 \"\$l\";; esac; done"
     else
         # mpi-docker tags each rank's output with [hostname][time] at the source
         # by default (real host, replacing mpirun's [jobid,rank] tag).
@@ -320,7 +328,12 @@ script -qefc "tt-smi -glx_reset" /dev/null |
     }
     END { if (seen) print buf }' |
     while IFS= read -r line; do
-        printf '[%s][%(%H:%M:%S)T] %s\n' "$h" -1 "$line"
+        case $line in
+            [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]\ [0-9][0-9]:[0-9][0-9]:[0-9][0-9]*)
+                printf '[%s] %s\n' "$h" "$line" ;;
+            *)
+                printf '[%s][%(%H:%M:%S)T] %s\n' "$h" -1 "$line" ;;
+        esac
     done >&2
 ec=${PIPESTATUS[0]}
 echo "RESET_RESULT|$h|$ec"

--- a/tools/scaleout/exabox/run_validation.sh
+++ b/tools/scaleout/exabox/run_validation.sh
@@ -5,24 +5,39 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/utils/mpi_if_selection.sh"
 source "$SCRIPT_DIR/utils/host_utils.sh"
 
-# Prefix every output line with [hostname][time] using the orchestrator host.
-# Two kinds of lines are emitted with a reduced tag to avoid duplicating a time:
-#   - lines that already carry a [host][time] tag (e.g. the per-rank tt-smi reset
-#     lines, tagged with their own remote hostname) pass through unchanged; and
-#   - lines that already begin with their own "YYYY-MM-DD HH:MM:SS" timestamp
-#     (e.g. Metal/UMD logs) only get [hostname] prepended, so the time is not
-#     printed twice on the same line.
+# Single place that prefixes each output line with a [hostname] tag, plus a
+# [HH:MM:SS] time only when the line does not already carry its own
+# "YYYY-MM-DD HH:MM:SS" timestamp (Metal/UMD/tt-smi logs), so the time is never
+# printed twice on one line. Ranks prepend a bare "[host] " tag at the source
+# (mpirun merges all ranks into one stream, so only the rank knows its own
+# hostname); this function keeps that host, decides the time, and also tags the
+# orchestrator's own local lines. The leading-timestamp check tolerates leading
+# ANSI colour codes (tt-smi runs under a pty and colourises its output). Lines
+# already fully tagged as "[host][time] " (e.g. from an earlier pass through this
+# function) are emitted unchanged so nothing is double-tagged.
 tag_stream() {
-    local line
-    local tagged_re='^\[[^]]*\]\[[0-9][0-9]:[0-9][0-9]:[0-9][0-9]\]'
-    local ts_re='^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}'
+    local line host rest
+    local esc=$'\x1b'
+    local done_re='^\[[^][]*\]\[[0-9][0-9]:[0-9][0-9]:[0-9][0-9]\] '
+    local rank_re='^\[([^][]*)\] (.*)$'
+    local ts_re="^(${esc}\[[0-9;]*[a-zA-Z])*[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}"
+    local self="${HOSTNAME:-$(hostname)}"
     while IFS= read -r line; do
-        if [[ "$line" =~ $tagged_re ]]; then
+        if [[ "$line" =~ $done_re ]]; then
             printf '%s\n' "$line"
-        elif [[ "$line" =~ $ts_re ]]; then
-            printf '[%s] %s\n' "${HOSTNAME:-$(hostname)}" "$line"
+            continue
+        fi
+        if [[ "$line" =~ $rank_re ]]; then
+            host="${BASH_REMATCH[1]}"
+            rest="${BASH_REMATCH[2]}"
         else
-            printf '[%s][%(%H:%M:%S)T] %s\n' "${HOSTNAME:-$(hostname)}" -1 "$line"
+            host="$self"
+            rest="$line"
+        fi
+        if [[ "$rest" =~ $ts_re ]]; then
+            printf '[%s] %s\n' "$host" "$rest"
+        else
+            printf '[%s][%(%H:%M:%S)T] %s\n' "$host" -1 "$rest"
         fi
     done
 }
@@ -268,11 +283,10 @@ run_cluster_validation() {
     done
 
     if [[ $DOCKER_IMAGE == "none" ]]; then
-        # Self-tag each rank's output with its own [hostname][time] at the source
-        # (mpirun merges all ranks into one stream at the launcher, so tagging must
-        # happen on the rank). Lines that already begin with their own timestamp
-        # only get [hostname] prepended so the time is not duplicated. pipefail
-        # keeps run_cluster_validation's real exit code.
+        # Self-tag each rank's output with a bare [hostname] at the source (mpirun
+        # merges all ranks into one stream at the launcher, so only the rank knows
+        # its own hostname). tag_stream adds the time and avoids duplicating any
+        # timestamp the line already carries. pipefail keeps the real exit code.
         local bin_cmd
         bin_cmd=$(printf '%q ' ./build/tools/scaleout/run_cluster_validation \
             "${descriptor_args[@]}" \
@@ -283,7 +297,7 @@ run_cluster_validation() {
         mpirun --host "$HOSTS" \
             --mca btl_tcp_if_include "$MPI_IF" \
             "${MPI_EXTRA_ARGS[@]}" \
-            bash -c "set -o pipefail; h=\$(hostname); $bin_cmd 2>&1 | while IFS= read -r l; do case \$l in [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]\ [0-9][0-9]:[0-9][0-9]:[0-9][0-9]*) printf '[%s] %s\n' \"\$h\" \"\$l\";; *) printf '[%s][%(%H:%M:%S)T] %s\n' \"\$h\" -1 \"\$l\";; esac; done"
+            bash -c "set -o pipefail; h=\$(hostname); $bin_cmd 2>&1 | while IFS= read -r l; do printf '[%s] %s\n' \"\$h\" \"\$l\"; done"
     else
         # mpi-docker tags each rank's output with [hostname][time] at the source
         # by default (real host, replacing mpirun's [jobid,rank] tag).
@@ -328,12 +342,7 @@ script -qefc "tt-smi -glx_reset" /dev/null |
     }
     END { if (seen) print buf }' |
     while IFS= read -r line; do
-        case $line in
-            [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]\ [0-9][0-9]:[0-9][0-9]:[0-9][0-9]*)
-                printf '[%s] %s\n' "$h" "$line" ;;
-            *)
-                printf '[%s][%(%H:%M:%S)T] %s\n' "$h" -1 "$line" ;;
-        esac
+        printf '[%s] %s\n' "$h" "$line"
     done >&2
 ec=${PIPESTATUS[0]}
 echo "RESET_RESULT|$h|$ec"

--- a/tools/scaleout/exabox/run_validation.sh
+++ b/tools/scaleout/exabox/run_validation.sh
@@ -262,17 +262,23 @@ run_cluster_validation() {
     done
 
     if [[ $DOCKER_IMAGE == "none" ]]; then
-        mpirun --host "$HOSTS" \
-            --mca btl_tcp_if_include "$MPI_IF" \
-            "${MPI_EXTRA_ARGS[@]}" \
-            --tag-output \
-            ./build/tools/scaleout/run_cluster_validation \
+        # Self-tag each rank's output with its own [hostname][time] at the source
+        # (mpirun merges all ranks into one stream at the launcher, so tagging must
+        # happen on the rank). pipefail keeps run_cluster_validation's real exit code.
+        local bin_cmd
+        bin_cmd=$(printf '%q ' ./build/tools/scaleout/run_cluster_validation \
             "${descriptor_args[@]}" \
             "${VALIDATION_EXTRA_ARGS[@]}" \
             --send-traffic \
             --num-iterations 10 \
-            --output-path "$validation_output_path"
+            --output-path "$validation_output_path")
+        mpirun --host "$HOSTS" \
+            --mca btl_tcp_if_include "$MPI_IF" \
+            "${MPI_EXTRA_ARGS[@]}" \
+            bash -c "set -o pipefail; $bin_cmd 2>&1 | while IFS= read -r l; do printf '[%s][%(%H:%M:%S)T] %s\n' \"\$(hostname)\" -1 \"\$l\"; done"
     else
+        # mpi-docker tags each rank's output with [hostname][time] at the source
+        # by default (real host, replacing mpirun's [jobid,rank] tag).
         ./tools/scaleout/exabox/mpi-docker --image "$DOCKER_IMAGE" \
             --empty-entrypoint \
             --mpi-interface "$MPI_IF" \

--- a/tools/scaleout/exabox/run_validation.sh
+++ b/tools/scaleout/exabox/run_validation.sh
@@ -5,22 +5,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/utils/mpi_if_selection.sh"
 source "$SCRIPT_DIR/utils/host_utils.sh"
 
-# Single place that prefixes each output line with a [hostname] tag, plus a
-# [HH:MM:SS] time only when the line does not already carry its own
-# "YYYY-MM-DD HH:MM:SS" timestamp (Metal/UMD/tt-smi logs), so the time is never
-# printed twice on one line. Ranks prepend a bare "[host] " tag at the source
-# (mpirun merges all ranks into one stream, so only the rank knows its own
-# hostname); this function keeps that host, decides the time, and also tags the
-# orchestrator's own local lines. The leading-timestamp check tolerates leading
-# ANSI colour codes (tt-smi runs under a pty and colourises its output). Lines
-# already fully tagged as "[host][time] " (e.g. from an earlier pass through this
-# function) are emitted unchanged so nothing is double-tagged.
+# Tag each line with [hostname], adding [HH:MM:SS] only when the line has no
+# timestamp of its own so tool logs aren't stamped twice. Ranks prepend a bare
+# "[host] " prefix at the source; this keeps that host, adds the time, and passes
+# already fully-tagged lines through unchanged (idempotent under a second pass).
 tag_stream() {
     local line host rest
     local esc=$'\x1b'
-    local done_re='^\[[^][]*\]\[[0-9][0-9]:[0-9][0-9]:[0-9][0-9]\] '
-    local rank_re='^\[([^][]*)\] (.*)$'
-    local ts_re="^(${esc}\[[0-9;]*[a-zA-Z])*[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}"
+    local done_re='^\[[^][]*\]\[[0-9][0-9]:[0-9][0-9]:[0-9][0-9]\] '   # already [host][time]
+    local rank_re='^\[([^][]*)\] (.*)$'                                # rank's bare [host] prefix
+    local ts_re="^(${esc}\[[0-9;]*[a-zA-Z])*[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}"  # leading timestamp, ANSI-tolerant
     local self="${HOSTNAME:-$(hostname)}"
     while IFS= read -r line; do
         if [[ "$line" =~ $done_re ]]; then
@@ -283,10 +277,8 @@ run_cluster_validation() {
     done
 
     if [[ $DOCKER_IMAGE == "none" ]]; then
-        # Self-tag each rank's output with a bare [hostname] at the source (mpirun
-        # merges all ranks into one stream at the launcher, so only the rank knows
-        # its own hostname). tag_stream adds the time and avoids duplicating any
-        # timestamp the line already carries. pipefail keeps the real exit code.
+        # Bare [host] tag on the rank (only the rank knows its hostname); tag_stream
+        # adds the time. pipefail keeps run_cluster_validation's real exit code.
         local bin_cmd
         bin_cmd=$(printf '%q ' ./build/tools/scaleout/run_cluster_validation \
             "${descriptor_args[@]}" \
@@ -299,8 +291,7 @@ run_cluster_validation() {
             "${MPI_EXTRA_ARGS[@]}" \
             bash -c "set -o pipefail; h=\$(hostname); $bin_cmd 2>&1 | while IFS= read -r l; do printf '[%s] %s\n' \"\$h\" \"\$l\"; done"
     else
-        # mpi-docker tags each rank's output with [hostname][time] at the source
-        # by default (real host, replacing mpirun's [jobid,rank] tag).
+        # mpi-docker host-tags each rank at the source by default.
         ./tools/scaleout/exabox/mpi-docker --image "$DOCKER_IMAGE" \
             --empty-entrypoint \
             --mpi-interface "$MPI_IF" \
@@ -323,10 +314,10 @@ run_board_reset() {
     local output_file="$2"
     local msg_prefix="$3"
 
-    # Each rank host-tags the reset log and streams it to stderr (shown live + tee'd), then prints one
-    # "RESET_RESULT|<host>|<exit_code>" line to stdout for the retry logic below. tt-smi writes key
-    # progress to the tty (not stdout) so it runs under `script`; the tr/sed/awk pipeline collapses its
-    # animated \r/spinner output and keeps colors (pipefail+`script -e` give the real exit code).
+    # Each rank streams its host-tagged reset log to stderr and prints one
+    # "RESET_RESULT|<host>|<exit_code>" line to stdout for the retry logic below.
+    # tt-smi writes progress to the tty, so run under `script`; the tr/sed/awk
+    # pipeline collapses its animated \r/spinner output and keeps colors.
     read -r -d '' RESET_CMD <<'RESET_CMD' || true
 set -o pipefail
 h=$(hostname)
@@ -383,10 +374,8 @@ RESET_CMD
 }
 
 
-# Tag every line of this script's output with [hostname][time]. Per-rank reset
-# lines already carry their own remote tag and pass through untouched. The
-# per-iteration tee blocks below re-run tag_stream so their log files are tagged
-# too; those lines arrive here already-tagged and are left as-is.
+# Route all output through tag_stream. The per-iteration tee blocks below also
+# pipe through tag_stream; those lines arrive here already tagged and pass through.
 exec > >(tag_stream) 2>&1
 
 echo "Using hosts: $HOSTS"

--- a/tools/scaleout/exabox/run_validation.sh
+++ b/tools/scaleout/exabox/run_validation.sh
@@ -291,9 +291,10 @@ run_cluster_validation() {
             "${MPI_EXTRA_ARGS[@]}" \
             bash -c "set -o pipefail; h=\$(hostname); $bin_cmd 2>&1 | while IFS= read -r l; do printf '[%s] %s\n' \"\$h\" \"\$l\"; done"
     else
-        # mpi-docker host-tags each rank at the source by default.
+        # --tag-host makes mpi-docker prefix each rank with [hostname]; tag_stream adds the time.
         ./tools/scaleout/exabox/mpi-docker --image "$DOCKER_IMAGE" \
             --empty-entrypoint \
+            --tag-host \
             --mpi-interface "$MPI_IF" \
             "${volume_args[@]}" \
             "${MPI_EXTRA_ARGS[@]}" \

--- a/tools/scaleout/exabox/run_validation.sh
+++ b/tools/scaleout/exabox/run_validation.sh
@@ -5,6 +5,22 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/utils/mpi_if_selection.sh"
 source "$SCRIPT_DIR/utils/host_utils.sh"
 
+# Prefix every output line with [hostname][time] using the orchestrator host.
+# Lines that already carry a [host][time] tag (e.g. the per-rank tt-smi reset
+# lines, which are tagged with their own remote hostname) are passed through
+# unchanged so they keep their real source attribution and are not double-tagged.
+tag_stream() {
+    local line
+    local tagged_re='^\[[^]]*\]\[[0-9][0-9]:[0-9][0-9]:[0-9][0-9]\]'
+    while IFS= read -r line; do
+        if [[ "$line" =~ $tagged_re ]]; then
+            printf '%s\n' "$line"
+        else
+            printf '[%s][%(%H:%M:%S)T] %s\n' "${HOSTNAME:-$(hostname)}" -1 "$line"
+        fi
+    done
+}
+
 # Function to display help
 show_help() {
     cat << EOF
@@ -339,6 +355,12 @@ RESET_CMD
 }
 
 
+# Tag every line of this script's output with [hostname][time]. Per-rank reset
+# lines already carry their own remote tag and pass through untouched. The
+# per-iteration tee blocks below re-run tag_stream so their log files are tagged
+# too; those lines arrive here already-tagged and are left as-is.
+exec > >(tag_stream) 2>&1
+
 echo "Using hosts: $HOSTS"
 echo "Using docker image: $DOCKER_IMAGE"
 if [[ -n "$FACTORY_DESCRIPTOR_PATH" ]]; then
@@ -420,7 +442,7 @@ for ((i=1; i<=ITERATIONS; i++)); do
 
         echo "Iteration $i completed at $(date)"
         echo "=========================================="
-    } 2>&1 | tee "$LOG_FILE"
+    } 2>&1 | tag_stream | tee "$LOG_FILE"
 
     echo "Iteration $i logged to $LOG_FILE"
     echo ""


### PR DESCRIPTION
When `mpirun` fans work across hosts it merges every rank's stdout into one stream, so you can't tell which host produced which line. This adds per-line `[hostname]` tagging (replacing mpirun's opaque `[jobid,rank]`) plus a timestamp to `recover.sh`, `run_validation.sh`, and `mpi-docker`.

- Each rank prepends a bare `[host]` prefix at the source (only the rank know its own hostname); `mpi-docker` does this outside the container so it reports the real host, not the container.
- A single `tag_stream` on the orchestrator adds `[HH:MM:SS]`, but only when the line doesn't already carry its own `YYYY-MM-DD HH:MM:SS` timestamp (Metal/UMD/tt-smi logs), so the time is never printed twice. Detection is ANSI-tolerant since tt-smi runs under a pty and colorizes output.
- Already-tagged lines pass through unchanged, so it's idempotent under `run_validation`'s double pass.

Output of recover.sh run: https://gist.github.com/jpanasiukTT/e18f93b457a7df6546701fab3633e1c1


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jpanasiuk/tag_logs_exabox_scripts)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/tag_logs_exabox_scripts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jpanasiuk/tag_logs_exabox_scripts)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jpanasiuk/tag_logs_exabox_scripts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jpanasiuk/tag_logs_exabox_scripts)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jpanasiuk/tag_logs_exabox_scripts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/tag_logs_exabox_scripts)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/tag_logs_exabox_scripts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jpanasiuk/tag_logs_exabox_scripts)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jpanasiuk/tag_logs_exabox_scripts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jpanasiuk/tag_logs_exabox_scripts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/tag_logs_exabox_scripts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jpanasiuk/tag_logs_exabox_scripts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/tag_logs_exabox_scripts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jpanasiuk/tag_logs_exabox_scripts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/tag_logs_exabox_scripts)