### PR TITLE
Fix cross-route data race in all_to_all_combine completion credit (Ring)

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_program_factory.cpp
@@ -158,7 +158,9 @@ tt::tt_metal::ProgramDescriptor build_combine_program_descriptor(
     });
 
     // client interface
-    constexpr auto num_headers = 2;  // data unicast headers and atomic inc "multicast" headers
+    // [0] = data unicast header; [1]/[2] = completion atomic-inc bidirectional multicast headers
+    // (positive/negative ring directions); [1] is reused earlier for the init-semaphore send.
+    constexpr auto num_headers = 3;
     constexpr auto client_interface_cb_id = tt::CBIndex::c_4;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_headers * CLIENT_INTERFACE_SIZE,

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/all_to_all_combine_program_factory.cpp
@@ -158,8 +158,7 @@ tt::tt_metal::ProgramDescriptor build_combine_program_descriptor(
     });
 
     // client interface
-    // [0] = data unicast header; [1]/[2] = completion atomic-inc bidirectional multicast headers
-    // (positive/negative ring directions); [1] is reused earlier for the init-semaphore send.
+    // [0] data unicast; [1]/[2] bidirectional completion atomic-inc (pos/neg arcs); [1] reused for init send.
     constexpr auto num_headers = 3;
     constexpr auto client_interface_cb_id = tt::CBIndex::c_4;
     desc.cbs.push_back(CBDescriptor{

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/kernels/dataflow/writer_all_to_all_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/kernels/dataflow/writer_all_to_all_combine.cpp
@@ -41,6 +41,70 @@ inline uint32_t get_output_page_idx(const uint32_t t, const uint32_t k) {
     return k * TokensPerDevice + t_idx;
 }
 
+// Signal combine completion to the other devices in the replicate group.
+//
+// Templated (not inlined into kernel_main) so the `if constexpr` below genuinely discards the
+// unused branch: fabric_multicast_bidirectional_atomic_inc_1d static_asserts a 1D topology, so it
+// must not be instantiated for a 2D (Mesh/Torus) build — which only holds inside a template.
+//
+// 1D fix (matches selective_reduce_combine / all_to_all_dispatch_metadata): send the completion
+// credit as a bidirectional ring/line multicast so it egresses on BOTH arcs and therefore follows
+// this device's payloads on whichever arc they took (same-connection, in-order) — it can no longer
+// overtake a payload on the opposite arc. Previously the credit re-derived its route via the
+// stateful get_route(), which for the antipodal "tie" destination could pick the opposite arc from
+// the payload and be observed before the data landed. DoubleAntipodalAtomicInc=true increments the
+// antipodal device from both directions, so on a Ring every device receives exactly
+// replicate_group_devices credits (see the wait in kernel_main); Linear does no antipodal doubling.
+//
+// 2D path is unchanged: the credit routes via the deterministic hop router (not get_route), so a
+// per-device unicast credit cannot mis-route relative to the payload.
+template <
+    uint32_t LinearizedMeshCoord,
+    tt::tt_fabric::Topology Topology,
+    uint32_t MeshRows,
+    uint32_t MeshCols,
+    ReplicateGroup ReplicateAxis,
+    uint32_t SrcChipId,
+    uint32_t DeviceBeginIdx,
+    uint32_t DeviceEndIdx,
+    uint32_t DeviceStride,
+    typename SenderType>
+inline void send_completion_credits(
+    std::array<SenderType, 4>& fabric_connections,
+    volatile PACKET_HEADER_TYPE* packet_header_pos,
+    volatile PACKET_HEADER_TYPE* packet_header_neg,
+    uint64_t global_noc_semaphore_addr,
+    const uint8_t* dest_chip_ids,
+    const uint8_t* dest_mesh_ids) {
+    if constexpr (is_1d_topology<Topology>() && ReplicateAxis != ReplicateGroup::NONE) {
+        fabric_multicast_bidirectional_atomic_inc_1d<
+            LinearizedMeshCoord,
+            Topology,
+            MeshRows,
+            MeshCols,
+            ReplicateAxis,
+            /*DoubleAntipodalAtomicInc=*/(Topology == tt::tt_fabric::Topology::Ring)>(
+            fabric_connections, packet_header_pos, packet_header_neg, global_noc_semaphore_addr);
+        noc_async_atomic_barrier();
+    } else {
+        for (uint32_t device_idx = DeviceBeginIdx; device_idx < DeviceEndIdx; device_idx += DeviceStride) {
+            if (device_idx == LinearizedMeshCoord) {
+                noc_semaphore_inc(global_noc_semaphore_addr, 1);
+                noc_async_atomic_barrier();
+            } else if (is_configured_target<LinearizedMeshCoord, MeshRows, MeshCols, ReplicateAxis>(device_idx)) {
+                fabric_send_chip_unicast_noc_unicast_semaphore_only<SrcChipId, MeshRows, MeshCols>(
+                    fabric_connections,
+                    packet_header_pos,
+                    dest_chip_ids[device_idx],
+                    dest_mesh_ids[device_idx],
+                    global_noc_semaphore_addr,
+                    1,
+                    true);
+            }
+        }
+    }
+}
+
 }  // namespace detail
 
 void kernel_main() {
@@ -109,8 +173,8 @@ void kernel_main() {
 
     const auto output_addrgen = TensorAccessor(output_args, output_base_addr);
 
-    volatile PACKET_HEADER_TYPE * packet_headers[2];
-    for(uint8_t i =0;i<2;++i){
+    volatile PACKET_HEADER_TYPE* packet_headers[3];
+    for (uint8_t i = 0; i < 3; ++i) {
         cb_reserve_back(packet_header_cb_id,1);
         const uint32_t packet_header_addr = get_read_ptr(packet_header_cb_id);
         packet_headers[i] = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_addr);
@@ -213,38 +277,32 @@ void kernel_main() {
         noc_async_write_barrier();
     }
     const uint64_t global_noc_semaphore_addr = get_noc_addr(global_semaphore_addr);
-    // "multicast" semaphore increment to let other devices know we are done
-    for (uint32_t device_idx = device_begin_idx; device_idx < device_end_idx; device_idx += device_stride) {
-        const auto & dest_chip_id = dest_chip_ids[device_idx];
-
-        if (device_idx == linearized_mesh_coord) {
-            noc_semaphore_inc(global_noc_semaphore_addr, 1);
-            noc_async_atomic_barrier();
-        } else if (is_configured_target<linearized_mesh_coord, mesh_rows, mesh_cols, replicate_axis>(device_idx)) {
-            if constexpr (is_1d_topology<topology>()) {
-                fabric_send_chip_unicast_noc_unicast_semaphore_only_1d<
-                    linearized_mesh_coord,
-                    topology,
-                    mesh_rows,
-                    mesh_cols>(fabric_connections, packet_headers[1], device_idx, global_noc_semaphore_addr, 1, true);
-            } else {
-                const auto& dest_mesh_id = dest_mesh_ids[device_idx];
-                const auto& dest_chip_id = dest_chip_ids[device_idx];
-                fabric_send_chip_unicast_noc_unicast_semaphore_only<src_chip_id, mesh_rows, mesh_cols>(
-                    fabric_connections,
-                    packet_headers[1],
-                    dest_chip_id,
-                    dest_mesh_id,
-                    global_noc_semaphore_addr,
-                    1,
-                    true);
-            }
-        }
-    }
+    // Signal completion to the other devices in the replicate group (see send_completion_credits).
+    detail::send_completion_credits<
+        linearized_mesh_coord,
+        topology,
+        mesh_rows,
+        mesh_cols,
+        replicate_axis,
+        src_chip_id,
+        device_begin_idx,
+        device_end_idx,
+        device_stride>(
+        fabric_connections,
+        packet_headers[1],
+        packet_headers[2],
+        global_noc_semaphore_addr,
+        dest_chip_ids,
+        dest_mesh_ids);
 
     close_direction_connections(directions, fabric_connections);
 
     auto semaphore_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(global_semaphore_addr);
-    noc_semaphore_wait(semaphore_ptr, replicate_group_devices);
+    // Ring (bidirectional, DoubleAntipodal): each device receives replicate_group_devices credits.
+    // Linear (bidirectional): replicate_group_devices - 1 (no antipodal doubling).
+    // 2D unicast path: local self-inc (1) + (replicate_group_devices - 1) remotes = replicate_group_devices.
+    constexpr uint32_t expected_credits =
+        (topology == tt::tt_fabric::Topology::Linear) ? (replicate_group_devices - 1) : replicate_group_devices;
+    noc_semaphore_wait(semaphore_ptr, expected_credits);
     noc_semaphore_set(semaphore_ptr, 0);
 }

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/kernels/dataflow/writer_all_to_all_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/kernels/dataflow/writer_all_to_all_combine.cpp
@@ -41,23 +41,14 @@ inline uint32_t get_output_page_idx(const uint32_t t, const uint32_t k) {
     return k * TokensPerDevice + t_idx;
 }
 
-// Signal combine completion to the other devices in the replicate group.
-//
-// Templated (not inlined into kernel_main) so the `if constexpr` below genuinely discards the
-// unused branch: fabric_multicast_bidirectional_atomic_inc_1d static_asserts a 1D topology, so it
-// must not be instantiated for a 2D (Mesh/Torus) build — which only holds inside a template.
-//
-// 1D fix (matches selective_reduce_combine / all_to_all_dispatch_metadata): send the completion
-// credit as a bidirectional ring/line multicast so it egresses on BOTH arcs and therefore follows
-// this device's payloads on whichever arc they took (same-connection, in-order) — it can no longer
-// overtake a payload on the opposite arc. Previously the credit re-derived its route via the
-// stateful get_route(), which for the antipodal "tie" destination could pick the opposite arc from
-// the payload and be observed before the data landed. DoubleAntipodalAtomicInc=true increments the
-// antipodal device from both directions, so on a Ring every device receives exactly
-// replicate_group_devices credits (see the wait in kernel_main); Linear does no antipodal doubling.
-//
-// 2D path is unchanged: the credit routes via the deterministic hop router (not get_route), so a
-// per-device unicast credit cannot mis-route relative to the payload.
+// Signal combine completion to the replicate group.
+// Templated so the `if constexpr` genuinely discards the unused branch
+// (fabric_multicast_bidirectional_atomic_inc_1d static_asserts a 1D topology).
+// 1D: send the credit as a bidirectional ring/line multicast so it follows the payload on
+// whichever arc it took and cannot overtake it on the opposite arc. On a Ring the antipodal
+// device is incremented from both directions (DoubleAntipodalAtomicInc), so every device
+// receives replicate_group_devices credits; Linear does no antipodal doubling.
+// 2D: credit routes via the deterministic hop router, so a unicast credit cannot mis-route.
 template <
     uint32_t LinearizedMeshCoord,
     tt::tt_fabric::Topology Topology,
@@ -173,13 +164,9 @@ void kernel_main() {
 
     const auto output_addrgen = TensorAccessor(output_args, output_base_addr);
 
-    // packet_header_cb holds 3 distinct pages. The bidirectional completion send below uses
-    // packet_headers[1] and packet_headers[2] as two SEPARATE arc headers (positive/negative), filled and
-    // sent back-to-back with a non-blocking (non-source-draining) fabric send, so they must be distinct L1
-    // buffers or the negative-arc fill clobbers the still-in-flight positive-arc header. get_read_ptr stays
-    // pinned here (cb_push_back only advances the write ptr and nothing pops this scratch CB), so take the
-    // base once and offset each header by sizeof(PACKET_HEADER_TYPE), mirroring writer_all_to_all_dispatch.
-    // (issue #50154 finding #10)
+    // 3 distinct header buffers: the bidirectional completion send fills packet_headers[1] and [2]
+    // back-to-back with non-draining fabric sends, so they must not alias. get_read_ptr stays pinned
+    // (nothing pops this scratch CB), so take the base once and offset each by sizeof(PACKET_HEADER_TYPE).
     volatile PACKET_HEADER_TYPE* packet_headers[3];
     cb_reserve_back(packet_header_cb_id, 3);
     const uint32_t packet_header_base = get_read_ptr(packet_header_cb_id);
@@ -208,8 +195,7 @@ void kernel_main() {
 
     for (uint32_t t = token_start_idx; t < token_end_idx; ++t) {
         cb_wait_front(metadata_cb_id, 1);
-        // Consumer role: read the front page via get_read_ptr, not get_write_ptr (which only coincides while
-        // metadata_cb depth==1). Drops the hidden depth==1 dependence. (issue #50154 finding #11)
+        // Consumer: read the front page via get_read_ptr (get_write_ptr only coincides while depth==1).
         const uint32_t metadata_l1_addr = get_read_ptr(metadata_cb_id);
         auto metadata_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(metadata_l1_addr);
 
@@ -308,9 +294,8 @@ void kernel_main() {
     close_direction_connections(directions, fabric_connections);
 
     auto semaphore_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(global_semaphore_addr);
-    // Ring (bidirectional, DoubleAntipodal): each device receives replicate_group_devices credits.
-    // Linear (bidirectional): replicate_group_devices - 1 (no antipodal doubling).
-    // 2D unicast path: local self-inc (1) + (replicate_group_devices - 1) remotes = replicate_group_devices.
+    // Credits expected: Ring = replicate_group_devices (antipodal doubled); Linear = replicate_group_devices - 1;
+    // 2D unicast = 1 self-inc + (replicate_group_devices - 1) remotes = replicate_group_devices.
     constexpr uint32_t expected_credits =
         (topology == tt::tt_fabric::Topology::Linear) ? (replicate_group_devices - 1) : replicate_group_devices;
     noc_semaphore_wait(semaphore_ptr, expected_credits);

--- a/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/kernels/dataflow/writer_all_to_all_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_to_all_combine/device/kernels/dataflow/writer_all_to_all_combine.cpp
@@ -173,13 +173,21 @@ void kernel_main() {
 
     const auto output_addrgen = TensorAccessor(output_args, output_base_addr);
 
+    // packet_header_cb holds 3 distinct pages. The bidirectional completion send below uses
+    // packet_headers[1] and packet_headers[2] as two SEPARATE arc headers (positive/negative), filled and
+    // sent back-to-back with a non-blocking (non-source-draining) fabric send, so they must be distinct L1
+    // buffers or the negative-arc fill clobbers the still-in-flight positive-arc header. get_read_ptr stays
+    // pinned here (cb_push_back only advances the write ptr and nothing pops this scratch CB), so take the
+    // base once and offset each header by sizeof(PACKET_HEADER_TYPE), mirroring writer_all_to_all_dispatch.
+    // (issue #50154 finding #10)
     volatile PACKET_HEADER_TYPE* packet_headers[3];
+    cb_reserve_back(packet_header_cb_id, 3);
+    const uint32_t packet_header_base = get_read_ptr(packet_header_cb_id);
     for (uint8_t i = 0; i < 3; ++i) {
-        cb_reserve_back(packet_header_cb_id,1);
-        const uint32_t packet_header_addr = get_read_ptr(packet_header_cb_id);
-        packet_headers[i] = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_addr);
-        cb_push_back(packet_header_cb_id,1);
+        packet_headers[i] =
+            reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_base + i * sizeof(PACKET_HEADER_TYPE));
     }
+    cb_push_back(packet_header_cb_id, 3);
     const uint64_t init_noc_semaphore_addr = get_noc_addr(init_semaphore_addr);
 
     open_direction_connections_barrier(directions, fabric_connections);
@@ -192,7 +200,7 @@ void kernel_main() {
         replicate_axis,
         num_devices>(fabric_connections, packet_headers[1], dest_chip_ids, dest_mesh_ids, init_noc_semaphore_addr);
 
-    cb_wait_front(local_experts_cb_id,1);
+    cb_wait_front(local_experts_cb_id, 1);
     auto local_experts_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(get_read_ptr(local_experts_cb_id));
     bool needs_barrier = false;
     noc_semaphore_wait((uint32_t*)init_semaphore_addr, replicate_group_devices - 1);
@@ -200,15 +208,17 @@ void kernel_main() {
 
     for (uint32_t t = token_start_idx; t < token_end_idx; ++t) {
         cb_wait_front(metadata_cb_id, 1);
-        const uint32_t metadata_l1_addr = get_write_ptr(metadata_cb_id);
+        // Consumer role: read the front page via get_read_ptr, not get_write_ptr (which only coincides while
+        // metadata_cb depth==1). Drops the hidden depth==1 dependence. (issue #50154 finding #11)
+        const uint32_t metadata_l1_addr = get_read_ptr(metadata_cb_id);
         auto metadata_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(metadata_l1_addr);
 
         for (uint32_t e = 0; e < num_local_experts; ++e) {
-            const auto & expert_idx = local_experts_ptr[e];
+            const auto& expert_idx = local_experts_ptr[e];
             const auto [found, k] = find_if<uint16_t, selected_experts_k, true>(metadata_ptr, expert_idx);
 
             if (found) {
-                cb_wait_front(data_cb_id,1);
+                cb_wait_front(data_cb_id, 1);
                 const uint32_t src_data_l1_ptr = get_read_ptr(data_cb_id);
 
                 // figure out output page index, noc address.
@@ -225,7 +235,7 @@ void kernel_main() {
                 const auto& dest_chip_id = dest_chip_ids[dest_device_idx];
 
                 if (dest_device_idx == linearized_mesh_coord) {
-                    noc_async_write(src_data_l1_ptr,output_noc_addr,data_size_bytes);
+                    noc_async_write(src_data_l1_ptr, output_noc_addr, data_size_bytes);
                     needs_barrier = true;
                     noc_async_writes_flushed();
                 } else {
@@ -262,7 +272,7 @@ void kernel_main() {
                             alignment);
                     }
                 }
-                cb_pop_front(data_cb_id,1);
+                cb_pop_front(data_cb_id, 1);
 
                 if constexpr (locally_reduced) {
                     break;


### PR DESCRIPTION
### Problem

Addresses **#33875** (author-filed: "Low probability race in a2a dispatch and combine when using Ring topology") for the **combine** op. Also closes the tracker sub-issue #50272 (race-audit #50154, finding 2).

On a **Ring** topology, payloads to a destination can alternate fabric arcs — the antipodal "tie" destination (equal East/West hop counts) toggles `polar_state` inside the stateful `get_route()`. The completion semaphore `atomic_inc`, however, **re-derived its route via the same stateful `get_route()`** and could egress on the **opposite arc** from the payloads. Payload (multi-flit) and credit (header-only) then travel **different EDMs/VCs**, where there is no cross-arc ordering, so the credit could satisfy the receiver's `noc_semaphore_wait` **before the output page landed** → the receiver reads a **stale/partial page** (silent, intermittent MoE-combine corruption). This is exactly what #33875 describes: *"we send a semaphore increment along only one direction … we should send a final semaphore increment the other direction too."*

`all_to_all_combine` was the **last op still using the vulnerable per-device unicast credit** — `all_to_all_dispatch_metadata` and `selective_reduce_combine` already send their completion credit as a bidirectional ring multicast, and `all_to_all_dispatch` fuses the credit into each payload packet.

### Fix

Send the completion credit as a **bidirectional ring/line multicast** (`fabric_multicast_bidirectional_atomic_inc_1d` with `DoubleAntipodalAtomicInc` on Ring), so the credit egresses on **both** arcs and follows this device's payloads on whichever arc they took (same-connection, in-order delivery). This mirrors the already-shipped fix in `selective_reduce_combine` / `all_to_all_dispatch_metadata`. Payloads keep alternating arcs (no bandwidth change).

- Move the completion send into a templated `detail::send_completion_credits<…>` so the `if constexpr` genuinely discards the 1D-only bidirectional helper for **2D (Mesh/Torus)** builds — `kernel_main` is not a template, so an inline `if constexpr` there would still instantiate the helper's `static_assert(Topology == Ring || Linear)` and break the 2D build.
- Completion wait becomes `replicate_group_devices` (Ring) / `replicate_group_devices - 1` (Linear), matching the double-antipodal count (each device receives exactly that many credits; I verified the per-receiver sum for even and odd rings). The 2D unicast path is unchanged (self-inc + `rgd-1` remotes = `rgd`).
- Add a third packet header (positive/negative multicast) — factory `num_headers` 2 → 3.

### Counting sanity (single-link)

Ring, `DoubleAntipodalAtomicInc=true`: each sender's pos+neg ranges sum to `dispatch_devices`, covering every other device once and its antipodal twice. A receiver R is the antipodal of exactly one sender → receives `2 + (rgd-2) = rgd` credits total → matches the wait. No self-inc.

### ⚠️ Testing / caveats

> **Not validated on hardware** — this kernel is JIT-compiled on-device and cannot be built in my environment. Needs **hardware CI** (t3000 / TG `fabric_1d_ring` combine tests) and **owner review**.
>
> - **Multi-link (`num_links > 1`)**: combine runs the writer on `num_cores = min(num_links, …)` cores with no single "sync core", so every writer core sends the completion. Each receiver would then get `num_cores × rgd` credits while waiting `rgd`. **This over-count is pre-existing** (the original per-device unicast loop had the same shape) and is **not changed by this PR** — flagging it for the owner as a separate concern.
> - **NONE axis**: guarded by `if constexpr` (and `axis` is a hard `TT_FATAL` requirement today), so the 1D-only helper is never instantiated for it.

cc @sjameelTT (author of #33875 and the 1D fabric path).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/fix-a2a-combine-cross-route-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/fix-a2a-combine-cross-route-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/fix-a2a-combine-cross-route-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/fix-a2a-combine-cross-route-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/fix-a2a-combine-cross-route-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/fix-a2a-combine-cross-route-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/fix-a2a-combine-cross-route-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/fix-a2a-combine-cross-route-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/fix-a2a-combine-cross-route-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/fix-a2a-combine-cross-route-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/fix-a2a-combine-cross-route-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/fix-a2a-combine-cross-route-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/fix-a2a-combine-cross-route-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/fix-a2a-combine-cross-route-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/fix-a2a-combine-cross-route-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/fix-a2a-combine-cross-route-race)
### Also folds in #50154 findings #10 & #11 (same writer)
This PR's bidirectional completion send requires `packet_headers[1]`/`[2]` to be distinct buffers, but the header setup aliased all three (`get_read_ptr` with no `cb_pop_front`). Fixed by offsetting each header by `sizeof(PACKET_HEADER_TYPE)` (finding #10, #50377). Also switched the `metadata_cb` consumer from `get_write_ptr` to `get_read_ptr` (finding #11, #50378). Verified on a 4-chip Blackhole box (`test_all_to_all_combine_bh.py`, fabric_1d_ring, num_devices=4).

Fixes #50377. Fixes #50378.