### PR TITLE
Add Flux2 img2img

### DIFF
--- a/models/tt_dit/blocks/vae.py
+++ b/models/tt_dit/blocks/vae.py
@@ -277,6 +277,7 @@ class VaeConv2d(Module):
         out_channels: int,
         *,
         kernel_size: int,
+        stride: int = 1,
         padding: int = 0,
         tensor_parallel: bool = True,
         ctx: VaeContext,
@@ -304,6 +305,9 @@ class VaeConv2d(Module):
         self._use_conv3d = ctx.use_conv3d and no_tp
 
         if self._use_conv3d:
+            if stride != 1:
+                msg = "conv3d path does not support stride != 1"
+                raise ValueError(msg)
             self.inner = _VaeConv2dConv3d(
                 in_channels,
                 out_channels,
@@ -317,6 +321,7 @@ class VaeConv2d(Module):
                 in_channels,
                 out_channels,
                 kernel_size=kernel_size,
+                stride=stride,
                 padding=actual_padding,
                 mesh_device=ctx.device,
                 in_mesh_axis=ctx.tp_axis if tensor_parallel and not out_is_greater else None,
@@ -659,6 +664,65 @@ class VaeUpBlock(Module):
 
         if self.upsampler is not None:
             x = self.upsampler.forward(x)
+
+        return x
+
+
+class VaeDownsample(Module):
+    # Mirrors diffusers Downsample2D(use_conv=True, padding=0): asymmetric bottom/right pad of 1
+    # (F.pad(0,1,0,1)) followed by a 3x3 stride-2 conv. Under H/W spatial sharding the stride-2
+    # conv would need a strided halo exchange, so we all-gather to full spatial, run the conv
+    # replicated across the spatial axes (channel TP is preserved), then repartition. Only one
+    # gather per downsample (3 total in the encoder) — a deliberate correctness-over-comms tradeoff.
+    def __init__(self, *, channels: int, ctx: VaeContext) -> None:
+        super().__init__()
+        conv_ctx = replace(ctx, h_factor=1, w_factor=1, h_mesh_axis=None, w_mesh_axis=None)
+        self.conv = VaeConv2d(channels, channels, kernel_size=3, stride=2, padding=0, ctx=conv_ctx)
+        self._ctx = ctx
+
+    def forward(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        x = _all_gather_hw(self._ctx, x)  # → [N, H, W, C] full spatial, TILE_LAYOUT
+        x = ttnn.to_layout(x, ttnn.ROW_MAJOR_LAYOUT)
+        # pad right (W) and bottom (H) by 1 to match diffusers' F.pad(0, 1, 0, 1)
+        x = ttnn.pad(x, [(0, 0), (0, 1), (0, 1), (0, 0)], value=0.0)
+        x = self.conv.forward(x)
+        return _partition_hw(self._ctx, x)
+
+
+class VaeDownBlock(Module):
+    def __init__(
+        self,
+        *,
+        in_channels: int,
+        out_channels: int,
+        num_layers: int,
+        downsample: bool,
+        norm: VaeNormDesc,
+        ctx: VaeContext,
+    ) -> None:
+        super().__init__()
+
+        self.resnets = ModuleList(
+            VaeResnetBlock(
+                in_channels=in_channels if i == 0 else out_channels,
+                out_channels=out_channels,
+                norm=norm,
+                ctx=ctx,
+            )
+            for i in range(num_layers)
+        )
+
+        self.downsampler = VaeDownsample(channels=out_channels, ctx=ctx) if downsample else None
+
+    def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
+        rename_substate(state, "downsamplers.0", "downsampler")
+
+    def forward(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        for block in self.resnets:
+            x = block.forward(x)
+
+        if self.downsampler is not None:
+            x = self.downsampler.forward(x)
 
         return x
 

--- a/models/tt_dit/models/vae/vae_flux2.py
+++ b/models/tt_dit/models/vae/vae_flux2.py
@@ -9,7 +9,16 @@ from typing import TYPE_CHECKING
 
 import ttnn
 
-from ...blocks.vae import VaeContext, VaeConv2d, VaeMidBlock, VaeNormDescGroup, VaeUpBlock, _all_gather_hw, _norm
+from ...blocks.vae import (
+    VaeContext,
+    VaeConv2d,
+    VaeDownBlock,
+    VaeMidBlock,
+    VaeNormDescGroup,
+    VaeUpBlock,
+    _all_gather_hw,
+    _norm,
+)
 from ...layers.linear import Linear
 from ...layers.module import Module, ModuleList, Parameter
 from ...parallel.config import Flux2VaeParallelConfig
@@ -156,3 +165,161 @@ class Flux2VaeDecoder(Module):
 
         z = self.conv_out.forward(z)
         return _all_gather_hw(self._ctx, z)
+
+
+# https://github.com/black-forest-labs/flux2/blob/6bb103559da75b67d75bf77cebba0027ba412ebc/src/flux2/autoencoder.py#L188
+class Flux2VaeEncoder(Module):
+    """TT implementation of the FLUX.2 VAE encoder (diffusers `AutoencoderKLFlux2.encode`).
+
+    Mirrors the diffusers `Encoder`: conv_in -> 4x DownEncoderBlock2D -> mid block (2 resnets +
+    1 attention) -> GroupNorm -> SiLU -> conv_out (double_z, 2*z channels) -> quant_conv, then
+    `.mode()` (first z channels). `patchify` performs the diffusers space-to-depth patchify and
+    the pipeline's forward batch-norm normalization on device.
+    """
+
+    _PATCH_SIZE = 2
+
+    def __init__(
+        self,
+        *,
+        in_channels: int = 3,
+        block_out_channels: Sequence[int] = (128, 256, 512, 512),
+        layers_per_block: int = 2,
+        z_channels: int = 32,
+        parallel_config: Flux2VaeParallelConfig,
+        device: ttnn.MeshDevice,
+        ccl_manager: CCLManager | None,
+        use_conv3d: bool = False,
+    ) -> None:
+        super().__init__()
+
+        ctx = VaeContext(
+            tp_axis=parallel_config.tp_parallel.mesh_axis if parallel_config.tp_parallel is not None else None,
+            device=device,
+            ccl_manager=ccl_manager,
+            h_mesh_axis=parallel_config.h_parallel.mesh_axis if parallel_config.h_parallel is not None else None,
+            h_factor=parallel_config.h_parallel.factor if parallel_config.h_parallel is not None else 1,
+            w_mesh_axis=parallel_config.w_parallel.mesh_axis if parallel_config.w_parallel is not None else None,
+            w_factor=parallel_config.w_parallel.factor if parallel_config.w_parallel is not None else 1,
+            use_conv3d=use_conv3d,
+        )
+
+        if ctx.tp_axis is not None and ctx.ccl_manager is None:
+            msg = "ccl_manager must be provided if tensor parallelism is used"
+            raise ValueError(msg)
+
+        block_out_channels = list(block_out_channels)
+        eps = 1e-6
+        self._z_channels = z_channels
+
+        self.conv_in = VaeConv2d(in_channels, block_out_channels[0], kernel_size=3, padding=1, ctx=ctx)
+
+        down_blocks = []
+        output_channel = block_out_channels[0]
+        for i, channel in enumerate(block_out_channels):
+            input_channel = output_channel
+            output_channel = channel
+            is_final_block = i == len(block_out_channels) - 1
+            down_blocks.append(
+                VaeDownBlock(
+                    in_channels=input_channel,
+                    out_channels=output_channel,
+                    num_layers=layers_per_block,
+                    downsample=not is_final_block,
+                    norm=VaeNormDescGroup(num_groups=32, eps=eps),
+                    ctx=ctx,
+                )
+            )
+        self.down_blocks = ModuleList(down_blocks)
+
+        self.mid_block = VaeMidBlock(
+            num_channels=block_out_channels[-1],
+            norm=VaeNormDescGroup(num_groups=32, eps=eps),
+            ctx=ctx,
+        )
+
+        self.conv_norm_out = _norm(
+            VaeNormDescGroup(num_groups=32, eps=eps), num_channels=block_out_channels[-1], ctx=ctx
+        )
+        # double_z: the encoder emits 2*z_channels (mean|logvar); tensor_parallel disabled so the
+        # channel dim stays replicated for the per-position quant_conv and the .mode() slice.
+        self.conv_out = VaeConv2d(
+            block_out_channels[-1], 2 * z_channels, kernel_size=3, padding=1, tensor_parallel=False, ctx=ctx
+        )
+        self.quant_conv = Linear(2 * z_channels, 2 * z_channels, mesh_device=ctx.device)
+
+        bn_size = self._PATCH_SIZE**2 * z_channels
+        self.bn_running_mean = Parameter(total_shape=[bn_size], device=ctx.device)
+        self.bn_running_var = Parameter(total_shape=[bn_size], device=ctx.device)
+        self.bn_eps = 1e-4
+
+        self._ctx = ctx
+
+    def _prepare_torch_state(self, state: dict[str, torch.Tensor]) -> None:
+        # keep only encoder + quant_conv + batch-norm state
+        pop_substate(state, "decoder")
+        pop_substate(state, "post_quant_conv")
+
+        if "quant_conv.weight" in state:
+            state["quant_conv.weight"] = state["quant_conv.weight"].squeeze(2, 3)
+
+        if "bn.running_mean" in state:
+            state["bn_running_mean"] = state.pop("bn.running_mean")
+        if "bn.running_var" in state:
+            state["bn_running_var"] = state.pop("bn.running_var")
+        state.pop("bn.num_batches_tracked", None)
+
+        rename_substate(state, "encoder", "")
+
+    @traced_function(device=lambda self: self._ctx.device, clone_prep_inputs=False)
+    def forward(self, x: ttnn.Tensor, /) -> ttnn.Tensor:
+        # x arrives as [N, H, W, C] (NHWC), H-sharded when SP is active or replicated otherwise.
+        x = self.conv_in.forward(x)
+
+        for block in self.down_blocks:
+            x = block.forward(x)
+
+        x = self.mid_block.forward(x)
+
+        x = self.conv_norm_out.forward(x)
+        x = ttnn.silu(x, output_tensor=x)
+
+        # conv_out is tensor_parallel=False → gather channels so it sees the full feature dim.
+        if self._ctx.ccl_manager is not None and self._ctx.tp_axis is not None:
+            x = self._ctx.ccl_manager.all_gather(x, dim=-1, mesh_axis=self._ctx.tp_axis, use_hyperparams=True)
+
+        x = self.conv_out.forward(x)
+        return self.quant_conv.forward(x)
+
+    @traced_function(device=lambda self: self._ctx.device, clone_prep_inputs=False)
+    def encode_and_patchify(self, x: ttnn.Tensor, /, *, height: int, width: int) -> ttnn.Tensor:
+        """Forward + patchify in one traced region (the img2img hot path)."""
+        return self.patchify(self.forward(x), height=height, width=width)
+
+    def patchify(self, enc: ttnn.Tensor, *, height: int, width: int) -> ttnn.Tensor:
+        """Take `.mode()`, space-to-depth patchify (p=2) and forward batch-norm normalize.
+
+        `enc`: [N, H, W, 2*z] encoder output (H is the full encoder-output height, i.e. the input
+        image height // vae_scale_factor). Returns [N, H/p, W/p, p*p*z] normalized latents H-sharded
+        to match the input's spatial sharding.
+        """
+        p = self._PATCH_SIZE
+        h_factor = self._ctx.h_factor
+        assert height % (p * h_factor) == 0, f"height {height} must be divisible by patch {p} * h_factor {h_factor}"
+        assert width % (p * self._ctx.w_factor) == 0, f"width {width} must be divisible by patch {p}"
+        height_local = height // h_factor
+
+        # .mode(): DiagonalGaussianDistribution splits channels into (mean, logvar); take the mean.
+        z = enc[..., : self._z_channels]
+
+        # N, H, W, C -> N, H/p, W/p, C*p*p with torch channel order (C, p_h, p_w) to match
+        # diffusers Flux2Pipeline._patchify_latents.
+        z = ttnn.to_layout(z, ttnn.ROW_MAJOR_LAYOUT)
+        z = z.reshape([z.shape[0], height_local // p, p, width // p, p, self._z_channels])
+        z = ttnn.permute(z, [0, 1, 3, 5, 2, 4])
+        z = z.reshape([z.shape[0], height_local // p, width // p, self._z_channels * p * p])
+        z = ttnn.to_layout(z, ttnn.TILE_LAYOUT)
+
+        # forward batch-norm normalize: (z - mean) / sqrt(var + eps)
+        inv_std = ttnn.rsqrt(self.bn_running_var.data + self.bn_eps)
+        return (z - self.bn_running_mean.data) * inv_std

--- a/models/tt_dit/pipelines/flux2/pipeline_flux2.py
+++ b/models/tt_dit/pipelines/flux2/pipeline_flux2.py
@@ -35,6 +35,11 @@ if TYPE_CHECKING:
 
     from PIL import Image
 
+# Defaults aligned with diffusers FluxImg2ImgPipeline for image-to-image generation.
+DEFAULT_NUM_INFERENCE_STEPS = 28
+DEFAULT_IMG2IMG_STRENGTH = 0.6
+DEFAULT_GUIDANCE_SCALE = 4.0
+
 
 class Flux2TransformerState:
     def __init__(self) -> None:
@@ -70,6 +75,7 @@ class Flux2Pipeline:
         trace_warmup: bool = False,
         vae_use_conv3d: bool = False,
         shard_prompt: bool = False,
+        warmup_image: Image.Image | None = None,
     ) -> None:
         self._mesh_device = mesh_device
         self._parallel_config = parallel_config
@@ -223,20 +229,25 @@ class Flux2Pipeline:
             prompt_rope_sin.unsqueeze(0).unsqueeze(0), False, mesh_axes=prompt_rope_mesh_axes, device=self._mesh_device
         )
 
-        self.warmup(warmup_info="e2e warmup")  # E2E warmup. Preallocate buffers
+        # Warm up with a condition image when the pipeline will be used for img2img, so the
+        # persistent StateTensor buffers (latents, spatial rope) get preallocated at the combined
+        # noise+image sequence length. Otherwise the text2img e2e warmup sizes them for noise-only
+        # latents and the first img2img (traced) call fails the copy-into-existing-buffer.
+        self.warmup(warmup_info="e2e warmup", image=warmup_image)  # E2E warmup. Preallocate buffers
         if trace_warmup:  # warmup for trace capture
-            self.warmup(traced=True, warmup_info="trace warmup")  # warmup for trace capture
+            self.warmup(traced=True, warmup_info="trace warmup", image=warmup_image)  # warmup for trace capture
             self.warmup(
-                traced=True, warmup_info="steady state trace warmup for VAE"
+                traced=True, warmup_info="steady state trace warmup for VAE", image=warmup_image
             )  # TODO: INVESTIGATE. For some reason, the VAE time still incures some overhead without this extra trace
 
-    def warmup(self, traced: bool = False, warmup_info="warmup") -> None:
+    def warmup(self, traced: bool = False, warmup_info="warmup", image: Image.Image | None = None) -> None:
         logger.info(f"Warming up pipeline___ {warmup_info}...")
         self.__call__(
             prompts=["warmup"],
             num_inference_steps=2,
             seed=0,
             traced=traced,
+            image=image,
         )
 
     def _prepare_transformer(self) -> None:
@@ -298,6 +309,7 @@ class Flux2Pipeline:
         checkpoint_name: str = "black-forest-labs/FLUX.2-dev",
         vae_use_conv3d: bool = False,
         shard_prompt: bool = False,
+        warmup_image: Image.Image | None = None,
     ) -> Flux2Pipeline:
         dit_parallel_config = DiTGParallelConfigNoCFG(
             tensor_parallel=ParallelFactor(factor=int(mesh_device.shape[tp_axis]), mesh_axis=tp_axis),
@@ -325,16 +337,18 @@ class Flux2Pipeline:
             trace_warmup=trace_warmup,
             vae_use_conv3d=vae_use_conv3d,
             shard_prompt=shard_prompt,
+            warmup_image=warmup_image,
         )
 
     def __call__(
         self,
         *,
         num_images_per_prompt: int = 1,
-        guidance_scale: float = 4.0,
+        guidance_scale: float = DEFAULT_GUIDANCE_SCALE,
         prompts: Sequence[str],
-        num_inference_steps: int,
+        num_inference_steps: int = DEFAULT_NUM_INFERENCE_STEPS,
         image: Image.Image | None = None,
+        strength: float = DEFAULT_IMG2IMG_STRENGTH,
         prompt_upsample_temperature: float | None = None,  # prompt upsampling is currently very slow
         seed: int | None = None,
         traced: bool = False,
@@ -347,6 +361,11 @@ class Flux2Pipeline:
 
         assert num_images_per_prompt == 1, "generating multiple images is not supported"
         assert prompt_count == 1, "generating multiple images is not supported"
+
+        if image is not None:
+            if strength < 0 or strength > 1:
+                msg = f"The value of strength should be in [0.0, 1.0] but is {strength}"
+                raise ValueError(msg)
 
         latents_height = self._height // self._vae_scale_factor
         latents_width = self._width // self._vae_scale_factor
@@ -400,6 +419,20 @@ class Flux2Pipeline:
             step_count=num_inference_steps,
             spatial_sequence_length=noise_sequence_length,
         )
+        if image is not None:
+            timesteps, sigmas, num_inference_steps = _truncate_timesteps_for_strength(
+                self._scheduler,
+                timesteps=timesteps,
+                sigmas=sigmas,
+                num_inference_steps=num_inference_steps,
+                strength=strength,
+            )
+            if num_inference_steps < 1:
+                msg = (
+                    f"After adjusting num_inference_steps by strength={strength}, the number of pipeline steps is "
+                    f"{num_inference_steps}, which is < 1 and not appropriate for this pipeline."
+                )
+                raise ValueError(msg)
 
         guidance = torch.full([transformer_batch_size], fill_value=guidance_scale)
 
@@ -652,6 +685,26 @@ class Flux2Pipeline:
 
         latents = latents.reshape([batch_size, height // p, p, width // p, p, channels])
         return latents.permute(0, 1, 3, 5, 2, 4).flatten(3, 5).flatten(1, 2)
+
+
+def _truncate_timesteps_for_strength(
+    scheduler: FlowMatchEulerDiscreteScheduler,
+    *,
+    timesteps: torch.Tensor,
+    sigmas: torch.Tensor,
+    num_inference_steps: int,
+    strength: float,
+) -> tuple[torch.Tensor, torch.Tensor, int]:
+    # Copied from diffusers.pipelines.stable_diffusion_3.pipeline_stable_diffusion_3_img2img.StableDiffusion3Img2ImgPipeline.get_timesteps
+    init_timestep = min(num_inference_steps * strength, num_inference_steps)
+    t_start = int(max(num_inference_steps - init_timestep, 0))
+    order = scheduler.order
+    timesteps = timesteps[t_start * order :]
+    sigmas = sigmas[t_start * order : t_start * order + len(timesteps) + 1]
+    if hasattr(scheduler, "set_begin_index"):
+        scheduler.set_begin_index(t_start * order)
+
+    return timesteps, sigmas, num_inference_steps - t_start
 
 
 def _schedule(

--- a/models/tt_dit/pipelines/flux2/pipeline_flux2.py
+++ b/models/tt_dit/pipelines/flux2/pipeline_flux2.py
@@ -12,8 +12,8 @@ import diffusers
 import numpy as np
 import torch
 import tqdm
-from diffusers.image_processor import VaeImageProcessor
 from diffusers.models.autoencoders.autoencoder_kl_flux2 import AutoencoderKLFlux2
+from diffusers.pipelines.flux2.image_processor import Flux2ImageProcessor
 from diffusers.schedulers import FlowMatchEulerDiscreteScheduler
 from loguru import logger
 from PIL import Image
@@ -141,7 +141,7 @@ class Flux2Pipeline:
 
         self._pos_embed = self._torch_transformer.pos_embed
 
-        self._image_processor = VaeImageProcessor()
+        self._image_processor = Flux2ImageProcessor(vae_scale_factor=self._vae_scale_factor * self._patch_size)
 
         logger.info("creating TT-NN text encoder...")
         self._encoder_ccl_manager = CCLManager(self._mesh_device, num_links=num_links, topology=topology)
@@ -307,6 +307,7 @@ class Flux2Pipeline:
         guidance_scale: float = 4.0,
         prompts: Sequence[str],
         num_inference_steps: int,
+        image: Image.Image | None = None,
         prompt_upsample_temperature: float | None = None,  # prompt upsampling is currently very slow
         seed: int | None = None,
         traced: bool = False,
@@ -323,7 +324,7 @@ class Flux2Pipeline:
         latents_height = self._height // self._vae_scale_factor
         latents_width = self._width // self._vae_scale_factor
         transformer_batch_size = prompt_count * num_images_per_prompt
-        spatial_sequence_length = (latents_height // self._patch_size) * (latents_width // self._patch_size)
+        noise_sequence_length = (latents_height // self._patch_size) * (latents_width // self._patch_size)
 
         logger.info("encoding prompts...")
 
@@ -334,6 +335,7 @@ class Flux2Pipeline:
                     prompts,
                     max_length=224,  # TODO: this should be higher
                     temperature=prompt_upsample_temperature,
+                    images=[image] if image is not None else None,
                     traced=traced,
                 )
 
@@ -345,11 +347,30 @@ class Flux2Pipeline:
             )
             _, prompt_sequence_length, _ = prompt_embeds.shape
 
+        image_latents_torch: torch.Tensor | None = None
+        image_latents_for_rope: list[torch.Tensor] | None = None
+        if image is not None:
+            logger.info("encoding condition image...")
+            condition_image = self._preprocess_condition_image(image)
+            patchified = self._encode_vae_image(condition_image)
+            image_latents_torch = _pack_latents(patchified).repeat(transformer_batch_size, 1, 1)
+            image_latents_for_rope = [patchified[0]]
+
+        spatial_sequence_length = noise_sequence_length
+        if image_latents_torch is not None:
+            spatial_sequence_length += image_latents_torch.shape[1]
+            self._update_spatial_rope(
+                noise_height=latents_height // self._patch_size,
+                noise_width=latents_width // self._patch_size,
+                image_latents=image_latents_for_rope or [],
+                traced=traced,
+            )
+
         logger.info("preparing timesteps...")
         timesteps, sigmas = _schedule(
             self._scheduler,
             step_count=num_inference_steps,
-            spatial_sequence_length=spatial_sequence_length,
+            spatial_sequence_length=noise_sequence_length,
         )
 
         guidance = torch.full([transformer_batch_size], fill_value=guidance_scale)
@@ -362,13 +383,18 @@ class Flux2Pipeline:
         shape = [transformer_batch_size, self._num_channels_latents, latents_height, latents_width]
         latents = self._patchify(torch.randn(shape).permute(0, 2, 3, 1))
 
+        is_img2img = image_latents_torch is not None
+        latents_to_upload = torch.cat([latents, image_latents_torch], dim=1) if is_img2img else latents
+
         # Shard the prompt sequence across SP (like spatial) when enabled, so per-block matmuls
         # run on 1/sp of the prompt tokens; attention gathers prompt q/k/v for the joint SDPA.
         prompt_embeds_mesh_axes = [None, sp_axis, None] if self._shard_prompt else None
         self.ts._tt_prompt_embeds.update(
             prompt_embeds, traced, mesh_axes=prompt_embeds_mesh_axes, device=self._mesh_device
         )
-        self.ts._tt_latents_step.update(latents, traced, mesh_axes=[None, sp_axis, None], device=self._mesh_device)
+        self.ts._tt_latents_step.update(
+            latents_to_upload, traced, mesh_axes=[None, sp_axis, None], device=self._mesh_device
+        )
         self.ts._tt_guidance.update(guidance.unsqueeze(1), traced, device=self._mesh_device)
 
         logger.info("denoising...")
@@ -401,6 +427,7 @@ class Flux2Pipeline:
                         sigma_difference=self.ts.tt_sigma_difference,
                         spatial_rope=(self.ts.tt_spatial_rope_cos, self.ts.tt_spatial_rope_sin),
                         prompt_rope=(self.ts.tt_prompt_rope_cos, self.ts.tt_prompt_rope_sin),
+                        noise_sequence_length=noise_sequence_length,
                         spatial_sequence_length=spatial_sequence_length,
                         prompt_sequence_length=prompt_sequence_length,
                         traced=traced,
@@ -411,6 +438,15 @@ class Flux2Pipeline:
         with pcv:
             self._prepare_vae()
 
+            tt_latents = self.ts.tt_latents_step
+            if is_img2img:
+                tt_latents = _extract_noise_latents_from_combined(
+                    self._ccl_manager,
+                    self._parallel_config,
+                    tt_latents,
+                    noise_sequence_length=noise_sequence_length,
+                )
+
             # Latents arrive SP-sharded on dim=1 (patchified token dim). Redistribute to
             # whatever spatial sharding the VAE conv pyramid expects before unpatchifying.
             #
@@ -418,10 +454,10 @@ class Flux2Pipeline:
             # W (spatial dim=2): can only be applied after unpatchify since H/W are interleaved
             #   in patchified tokens; mesh_partition is applied right after the reshape below.
             if self._vae_parallel.h_parallel is not None and self._vae_parallel.h_parallel.mesh_axis == sp_axis:
-                tt_latents = self.ts.tt_latents_step
+                pass
             else:
                 tt_latents = self._ccl_manager.all_gather(
-                    self.ts.tt_latents_step,
+                    tt_latents,
                     dim=1,
                     mesh_axis=sp_axis,
                     use_hyperparams=True,
@@ -471,9 +507,12 @@ class Flux2Pipeline:
         sigma_difference: ttnn.Tensor,
         spatial_rope: tuple[ttnn.Tensor, ttnn.Tensor],
         prompt_rope: tuple[ttnn.Tensor, ttnn.Tensor],
+        noise_sequence_length: int,
         spatial_sequence_length: int,
         prompt_sequence_length: int,
     ) -> None:
+        is_img2img = spatial_sequence_length > noise_sequence_length
+
         noise_pred = self.transformer.forward(
             spatial=spatial,
             prompt=prompt,
@@ -485,8 +524,74 @@ class Flux2Pipeline:
             prompt_sequence_length=prompt_sequence_length,
         )
 
+        if is_img2img:
+            _apply_img2img_scheduler_step(
+                self._ccl_manager,
+                self._parallel_config,
+                spatial=spatial,
+                noise_pred=noise_pred,
+                noise_sequence_length=noise_sequence_length,
+                sigma_difference=sigma_difference,
+            )
+            return
+
         ttnn.multiply_(noise_pred, sigma_difference)
         ttnn.add_(spatial, noise_pred)
+
+    def _preprocess_condition_image(self, image: Image.Image) -> torch.Tensor:
+        self._image_processor.check_image_input(image)
+
+        image_width, image_height = image.size
+        if image_width * image_height > 1024 * 1024:
+            image = self._image_processor._resize_to_target_area(image, 1024 * 1024)
+            image_width, image_height = image.size
+
+        multiple_of = self._vae_scale_factor * self._patch_size
+        image_width = (image_width // multiple_of) * multiple_of
+        image_height = (image_height // multiple_of) * multiple_of
+        return self._image_processor.preprocess(image, height=image_height, width=image_width, resize_mode="crop")
+
+    def _encode_vae_image(self, image: torch.Tensor) -> torch.Tensor:
+        with torch.no_grad():
+            encoded = self._torch_vae.encode(image).latent_dist.mode()
+
+        encoded = _patchify_latents(encoded)
+        mean = self._torch_vae.bn.running_mean.view(1, -1, 1, 1).to(device=encoded.device, dtype=encoded.dtype)
+        std = torch.sqrt(self._torch_vae.bn.running_var.view(1, -1, 1, 1) + self._torch_vae.config.batch_norm_eps).to(
+            device=encoded.device, dtype=encoded.dtype
+        )
+        return (encoded - mean) / std
+
+    def _update_spatial_rope(
+        self,
+        *,
+        noise_height: int,
+        noise_width: int,
+        image_latents: list[torch.Tensor],
+        traced: bool,
+    ) -> None:
+        sp_axis = self._parallel_config.sequence_parallel.mesh_axis
+
+        noise_ids = _prepare_ids(height=noise_height, width=noise_width, text_sequence_length=1)
+        if image_latents:
+            image_ids = _prepare_image_ids(image_latents).squeeze(0)
+            spatial_ids = torch.cat([noise_ids, image_ids], dim=0)
+        else:
+            spatial_ids = noise_ids
+
+        spatial_rope_cos, spatial_rope_sin = self._pos_embed.forward(spatial_ids)
+        self.ts._tt_spatial_rope_cos.update(
+            spatial_rope_cos.unsqueeze(0).unsqueeze(0),
+            traced,
+            mesh_axes=[None, None, sp_axis, None],
+            device=self._mesh_device,
+        )
+        self.ts._tt_spatial_rope_sin.update(
+            spatial_rope_sin.unsqueeze(0).unsqueeze(0),
+            traced,
+            mesh_axes=[None, None, sp_axis, None],
+            device=self._mesh_device,
+        )
 
     def _patchify(self, latents: torch.Tensor) -> torch.Tensor:
         # N, H, W, C -> N, (H / P) * (W / P), C * P * P
@@ -547,3 +652,93 @@ def _prepare_ids(*, height: int = 1, width: int = 1, text_sequence_length: int =
     s = torch.arange(text_sequence_length)
 
     return torch.cartesian_prod(t, h, w, s)
+
+
+def _patchify_latents(latents: torch.Tensor) -> torch.Tensor:
+    batch_size, num_channels_latents, height, width = latents.shape
+    latents = latents.view(batch_size, num_channels_latents, height // 2, 2, width // 2, 2)
+    latents = latents.permute(0, 1, 3, 5, 2, 4)
+    return latents.reshape(batch_size, num_channels_latents * 4, height // 2, width // 2)
+
+
+def _pack_latents(latents: torch.Tensor) -> torch.Tensor:
+    batch_size, num_channels, height, width = latents.shape
+    return latents.reshape(batch_size, num_channels, height * width).permute(0, 2, 1)
+
+
+def _extract_noise_latents_from_combined(
+    ccl_manager: CCLManager,
+    parallel_config: DiTGParallelConfigNoCFG,
+    combined: ttnn.Tensor,
+    *,
+    noise_sequence_length: int,
+) -> ttnn.Tensor:
+    sp_axis = parallel_config.sequence_parallel.mesh_axis
+    full_combined = ccl_manager.all_gather(combined, dim=1, mesh_axis=sp_axis, use_hyperparams=True)
+    noise_latents = ttnn.slice(
+        full_combined,
+        [0, 0, 0],
+        [full_combined.shape[0], noise_sequence_length, full_combined.shape[2]],
+    )
+    return ttnn.mesh_partition(
+        noise_latents,
+        dim=1,
+        cluster_axis=sp_axis,
+        memory_config=noise_latents.memory_config(),
+    )
+
+
+def _apply_img2img_scheduler_step(
+    ccl_manager: CCLManager,
+    parallel_config: DiTGParallelConfigNoCFG,
+    *,
+    spatial: ttnn.Tensor,
+    noise_pred: ttnn.Tensor,
+    noise_sequence_length: int,
+    sigma_difference: ttnn.Tensor,
+) -> None:
+    sp_axis = parallel_config.sequence_parallel.mesh_axis
+
+    full_pred = ccl_manager.all_gather(noise_pred, dim=1, mesh_axis=sp_axis, use_hyperparams=True)
+    noise_pred_only = ttnn.slice(
+        full_pred,
+        [0, 0, 0],
+        [full_pred.shape[0], noise_sequence_length, full_pred.shape[2]],
+    )
+    ttnn.multiply_(noise_pred_only, sigma_difference)
+
+    full_spatial = ccl_manager.all_gather(spatial, dim=1, mesh_axis=sp_axis, use_hyperparams=True)
+    noise_spatial = ttnn.slice(
+        full_spatial,
+        [0, 0, 0],
+        [full_spatial.shape[0], noise_sequence_length, full_spatial.shape[2]],
+    )
+    image_spatial = ttnn.slice(
+        full_spatial,
+        [0, noise_sequence_length, 0],
+        [full_spatial.shape[0], full_spatial.shape[1], full_spatial.shape[2]],
+    )
+    updated_noise = ttnn.add(noise_spatial, noise_pred_only)
+    full_spatial = ttnn.concat([updated_noise, image_spatial], dim=1)
+
+    updated_combined = ttnn.mesh_partition(
+        full_spatial,
+        dim=1,
+        cluster_axis=sp_axis,
+        memory_config=full_spatial.memory_config(),
+    )
+    ttnn.copy(updated_combined, spatial)
+
+
+def _prepare_image_ids(image_latents: list[torch.Tensor], *, scale: int = 10) -> torch.Tensor:
+    t_coords = [scale + scale * t for t in torch.arange(0, len(image_latents))]
+    t_coords = [t.view(-1) for t in t_coords]
+
+    image_latent_ids = []
+    for latent, t in zip(image_latents, t_coords):
+        latent = latent.squeeze(0)
+        _, height, width = latent.shape
+        x_ids = torch.cartesian_prod(t, torch.arange(height), torch.arange(width), torch.arange(1))
+        image_latent_ids.append(x_ids)
+
+    return torch.cat(image_latent_ids, dim=0).unsqueeze(0)

--- a/models/tt_dit/pipelines/flux2/pipeline_flux2.py
+++ b/models/tt_dit/pipelines/flux2/pipeline_flux2.py
@@ -21,10 +21,10 @@ from PIL import Image
 import ttnn
 
 from ...models.transformers.transformer_flux2 import Flux2Transformer
-from ...models.vae.vae_flux2 import Flux2VaeDecoder
+from ...models.vae.vae_flux2 import Flux2VaeDecoder, Flux2VaeEncoder
 from ...parallel.config import DiTGParallelConfigNoCFG, EncoderParallelConfig, Flux2VaeParallelConfig, ParallelFactor
 from ...parallel.manager import CCLManager
-from ...utils import cache
+from ...utils import cache, tensor
 from ...utils.padding import PaddingConfig
 from ...utils.tensor import fast_device_to_host, float_to_uint8
 from ...utils.tracing import StateTensor, traced_function
@@ -166,10 +166,25 @@ class Flux2Pipeline:
             use_conv3d=self._vae_use_conv3d,
         )
 
+        logger.info("creating TT-NN VAE encoder...")
+        self._vae_encoder = Flux2VaeEncoder(
+            in_channels=3,
+            block_out_channels=[128, 256, 512, 512],
+            layers_per_block=2,
+            z_channels=32,
+            device=self._mesh_device,
+            parallel_config=self._vae_parallel,
+            ccl_manager=self._vae_ccl_manager,
+            use_conv3d=self._vae_use_conv3d,
+        )
+
         if self.dynamic_load:
-            self.transformer.register_coresident_exclusions(self._prompt_encoder._encoder, self._vae_decoder)
+            self.transformer.register_coresident_exclusions(
+                self._prompt_encoder._encoder, self._vae_decoder, self._vae_encoder
+            )
             self._prompt_encoder._encoder.register_coresident_exclusions(self.transformer)
             self._vae_decoder.register_coresident_exclusions(self.transformer)
+            self._vae_encoder.register_coresident_exclusions(self.transformer)
 
         # Load in reverse order of use so the first-used model (encoder) stays loaded before __call__.
         self._prepare_vae()
@@ -246,6 +261,18 @@ class Flux2Pipeline:
             get_torch_state_dict=self._torch_vae.state_dict,
             model_name=os.path.basename(self.checkpoint_name),
             subfolder="vae",
+            parallel_config=self._vae_parallel,
+            mesh_shape=tuple(self._mesh_device.shape),
+        )
+        ttnn.synchronize_device(self._mesh_device)
+
+    def _prepare_vae_encoder(self) -> None:
+        # distinct subfolder from the decoder so the two VAE halves don't collide in the weight cache
+        cache.load_model(
+            tt_model=self._vae_encoder,
+            get_torch_state_dict=self._torch_vae.state_dict,
+            model_name=os.path.basename(self.checkpoint_name),
+            subfolder="vae_encoder",
             parallel_config=self._vae_parallel,
             mesh_shape=tuple(self._mesh_device.shape),
         )
@@ -351,8 +378,9 @@ class Flux2Pipeline:
         image_latents_for_rope: list[torch.Tensor] | None = None
         if image is not None:
             logger.info("encoding condition image...")
-            condition_image = self._preprocess_condition_image(image)
-            patchified = self._encode_vae_image(condition_image)
+            with profiler("vae_encode", profiler_iteration) if profiler else nullcontext():
+                condition_image = self._preprocess_condition_image(image)
+                patchified = self._encode_vae_image(condition_image, traced=traced)
             image_latents_torch = _pack_latents(patchified).repeat(transformer_batch_size, 1, 1)
             image_latents_for_rope = [patchified[0]]
 
@@ -551,16 +579,36 @@ class Flux2Pipeline:
         image_height = (image_height // multiple_of) * multiple_of
         return self._image_processor.preprocess(image, height=image_height, width=image_width, resize_mode="crop")
 
-    def _encode_vae_image(self, image: torch.Tensor) -> torch.Tensor:
-        with torch.no_grad():
-            encoded = self._torch_vae.encode(image).latent_dist.mode()
+    def _encode_vae_image(self, image: torch.Tensor, *, traced: bool = False) -> torch.Tensor:
+        # Runs the VAE encoder, .mode(), space-to-depth patchify and batch-norm normalize entirely
+        # on device. Returns the normalized patchified latent as host [B, C*p^2, H/16, W/16]
+        # (channel-first), matching the previous torch fallback's contract so the packing/rope/cat
+        # logic in __call__ is unchanged.
+        self._prepare_vae_encoder()
 
-        encoded = _patchify_latents(encoded)
-        mean = self._torch_vae.bn.running_mean.view(1, -1, 1, 1).to(device=encoded.device, dtype=encoded.dtype)
-        std = torch.sqrt(self._torch_vae.bn.running_var.view(1, -1, 1, 1) + self._torch_vae.config.batch_norm_eps).to(
-            device=encoded.device, dtype=encoded.dtype
+        _, _, img_height, img_width = image.shape
+        h_axis = self._vae_parallel.h_parallel.mesh_axis if self._vae_parallel.h_parallel is not None else None
+        mesh_axes = [None, h_axis, None, None] if h_axis is not None else None
+
+        image_nhwc = image.permute(0, 2, 3, 1).contiguous().to(torch.bfloat16)
+        tt_image = tensor.from_torch(
+            image_nhwc,
+            device=self._mesh_device,
+            layout=ttnn.TILE_LAYOUT,
+            mesh_axes=mesh_axes,
         )
-        return (encoded - mean) / std
+
+        enc_height = img_height // self._vae_scale_factor
+        enc_width = img_width // self._vae_scale_factor
+        patchified = self._vae_encoder.encode_and_patchify(tt_image, height=enc_height, width=enc_width, traced=traced)
+
+        patchified_host = tensor.to_torch(
+            patchified,
+            mesh_axes=mesh_axes,
+            composer_device=self._mesh_device,
+        )
+        # [B, H/16, W/16, C*p^2] -> [B, C*p^2, H/16, W/16]
+        return patchified_host.permute(0, 3, 1, 2).contiguous().to(torch.float32)
 
     def _update_spatial_rope(
         self,

--- a/models/tt_dit/pipelines/flux2/prompt_encoder.py
+++ b/models/tt_dit/pipelines/flux2/prompt_encoder.py
@@ -17,12 +17,13 @@ from ...encoders.mistral3.model_mistral3 import Mistral3Encoder
 from ...encoders.transformer import RopeConfig
 from ...layers.module import Module
 from ...utils import cache, tensor
-from .system_messages import SYSTEM_MESSAGE, SYSTEM_MESSAGE_UPSAMPLING_T2I
+from .system_messages import SYSTEM_MESSAGE, SYSTEM_MESSAGE_UPSAMPLING_I2I, SYSTEM_MESSAGE_UPSAMPLING_T2I
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from typing import Any
 
+    from PIL import Image
     from transformers import PreTrainedTokenizerBase
 
     from ...parallel.config import EncoderParallelConfig
@@ -42,6 +43,7 @@ class PromptEncoder:
         self._device = device
         self._ccl_manager = ccl_manager
         self._parallel_config = parallel_config
+        self._checkpoint_name = checkpoint_name
 
         self._tokenizer = transformers.LlamaTokenizerFast.from_pretrained(checkpoint_name, subfolder="tokenizer")
         assert isinstance(self._tokenizer, transformers.LlamaTokenizerFast)
@@ -49,8 +51,6 @@ class PromptEncoder:
         if use_torch_encoder:
             self._encoder = _load_torch_encoder(checkpoint_name)
             return
-
-        self._checkpoint_name = checkpoint_name
 
         self._encoder = Mistral3Encoder(
             vocab_size=131072,
@@ -106,8 +106,26 @@ class PromptEncoder:
         )
 
     def upsample(
-        self, prompts: Sequence[str], *, max_length: int, temperature: float, traced: bool = False
+        self,
+        prompts: Sequence[str],
+        *,
+        max_length: int,
+        temperature: float,
+        images: Sequence[Image.Image | None] | None = None,
+        traced: bool = False,
     ) -> list[str]:
+        if images is not None and any(img is not None for img in images):
+            return _upsample_prompts_i2i(
+                prompts,
+                images=images,
+                max_length=max_length,
+                temperature=temperature,
+                checkpoint_name=self._checkpoint_name,
+                tokenizer=self._tokenizer,
+                encoder=self._encoder,
+                device=self._device,
+            )
+
         return _upsample_prompts(
             prompts,
             max_length=max_length,
@@ -253,14 +271,97 @@ def _upsample_prompts(
     return tokenizer.batch_decode(generated_tokens, skip_special_tokens=True, clean_up_tokenization_spaces=True)
 
 
-def _format_input(prompts: Sequence[str], *, system_message: str) -> list[list[dict[str, Any]]]:
-    return [
-        [
-            {
-                "role": "system",
-                "content": [{"type": "text", "text": system_message}],
-            },
-            {"role": "user", "content": [{"type": "text", "text": prompt}]},
+def _upsample_prompts_i2i(
+    prompts: Sequence[str],
+    *,
+    images: Sequence[Image.Image | None],
+    encoder: Module | torch.nn.Module,
+    tokenizer: PreTrainedTokenizerBase,
+    max_length: int,
+    temperature: float,
+    checkpoint_name: str | None,
+    device: ttnn.MeshDevice | None,
+) -> list[str]:
+    if isinstance(encoder, Module):
+        torch_encoder = _load_torch_encoder(checkpoint_name)
+    else:
+        torch_encoder = encoder
+
+    torch_processor = transformers.AutoProcessor.from_pretrained(checkpoint_name, subfolder="tokenizer")
+
+    conversation = _format_input(
+        prompts,
+        system_message=SYSTEM_MESSAGE_UPSAMPLING_I2I,
+        images=list(images),
+    )
+
+    # Image-conditioned upsampling needs PixtralProcessor tokenization (see Flux2Pipeline.upsample_prompt).
+    tokenizer_out = torch_processor.apply_chat_template(
+        conversation,
+        add_generation_prompt=True,
+        tokenize=True,
+        return_dict=True,
+        return_tensors="pt",
+        padding="max_length",
+        truncation=True,
+        max_length=2048,
+    )
+
+    input_ids = tokenizer_out["input_ids"].to(torch_encoder.device)
+    attention_mask = tokenizer_out["attention_mask"].to(torch_encoder.device)
+    model_inputs: dict[str, Any] = {"input_ids": input_ids, "attention_mask": attention_mask}
+    for key in ("pixel_values", "image_sizes"):
+        if key in tokenizer_out:
+            value = tokenizer_out[key].to(torch_encoder.device)
+            if key == "pixel_values":
+                value = value.to(torch_encoder.dtype)
+            model_inputs[key] = value
+
+    with torch.no_grad():
+        output_tokens = torch_encoder.generate(
+            **model_inputs,
+            max_new_tokens=512,
+            do_sample=True,
+            temperature=temperature,
+            use_cache=True,
+        )
+
+    input_length = input_ids.shape[1]
+    generated_tokens = output_tokens[:, input_length:]
+    return torch_processor.tokenizer.batch_decode(
+        generated_tokens, skip_special_tokens=True, clean_up_tokenization_spaces=True
+    )
+
+
+def _format_input(
+    prompts: Sequence[str],
+    *,
+    system_message: str,
+    images: Sequence[Image.Image | None] | None = None,
+) -> list[list[dict[str, Any]]]:
+    cleaned = [prompt.replace("[IMG]", "") for prompt in prompts]
+
+    if images is None:
+        return [
+            [
+                {"role": "system", "content": [{"type": "text", "text": system_message}]},
+                {"role": "user", "content": [{"type": "text", "text": prompt}]},
+            ]
+            for prompt in cleaned
         ]
-        for prompt in prompts
-    ]
+
+    if len(images) != len(cleaned):
+        msg = f"Number of images ({len(images)}) must match number of prompts ({len(cleaned)})"
+        raise ValueError(msg)
+
+    messages: list[list[dict[str, Any]]] = []
+    for prompt, image in zip(cleaned, images):
+        conversation: list[dict[str, Any]] = [
+            {"role": "system", "content": [{"type": "text", "text": system_message}]},
+        ]
+        if image is not None:
+            conversation.append({"role": "user", "content": [{"type": "image", "image": image}]})
+        conversation.append({"role": "user", "content": [{"type": "text", "text": prompt}]})
+        messages.append(conversation)
+
+    return messages

--- a/models/tt_dit/tests/models/flux2/conftest.py
+++ b/models/tt_dit/tests/models/flux2/conftest.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+def _default_tt_dit_cache_dir(*, is_ci_env: bool) -> str:
+    if is_ci_env:
+        return "/tmp/TT_DIT_CACHE"
+    user = os.environ.get("USER", "unknown")
+    return f"/proj_sw/user_dev/{user}/tt_dit_cache"
+
+
+@pytest.fixture
+def tt_dit_cache_dir(monkeypatch: pytest.MonkeyPatch, is_ci_env: bool) -> None:
+    if os.getenv("TT_DIT_CACHE_DIR") is None:
+        monkeypatch.setenv("TT_DIT_CACHE_DIR", _default_tt_dit_cache_dir(is_ci_env=is_ci_env))

--- a/models/tt_dit/tests/models/flux2/run_img2img_tests.sh
+++ b/models/tt_dit/tests/models/flux2/run_img2img_tests.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Run Flux2 img2img tests with a persistent TT-Metal DiT weight cache.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../../.." && pwd)"
+
+export TT_DIT_CACHE_DIR="/proj_sw/user_dev/${USER}/tt_dit_cache"
+
+cd "${REPO_ROOT}"
+# shellcheck source=/dev/null
+source python_env/bin/activate
+
+STAGE="${1:-all}"
+
+run_cpu() {
+    pytest models/tt_dit/tests/models/flux2/test_transformer_flux2.py::test_img2img_latent_helpers \
+        models/tt_dit/tests/models/flux2/test_vae_flux2.py::test_vae_encode_img2img \
+        models/tt_dit/tests/models/flux2/test_prompt_encoder.py::test_format_input_i2i \
+        models/tt_dit/tests/models/flux2/test_img2img_flux2.py::test_img2img_spatial_rope_ids \
+        models/tt_dit/tests/models/flux2/test_img2img_flux2.py::test_img2img_euler_step_matches_torch -v
+}
+
+run_combine() {
+    pytest models/tt_dit/tests/models/flux2/test_img2img_flux2.py::test_combine_img2img_spatial_input \
+        models/tt_dit/tests/models/flux2/test_img2img_flux2.py::test_extract_noise_latents_from_combined -v
+}
+
+run_transformer() {
+    pytest models/tt_dit/tests/models/flux2/test_transformer_flux2.py::test_transformer_img2img \
+        models/tt_dit/tests/models/flux2/test_img2img_flux2.py::test_transformer_img2img_separate_latents -v
+}
+
+run_prompt_encoder() {
+    pytest models/tt_dit/tests/models/flux2/test_prompt_encoder.py::test_upsample_i2i -v
+}
+
+run_pipeline() {
+    pytest models/tt_dit/tests/models/flux2/test_pipeline_flux2.py::test_pipeline_img2img -v
+}
+
+echo "Using TT_DIT_CACHE_DIR=${TT_DIT_CACHE_DIR}"
+
+case "${STAGE}" in
+    cpu) run_cpu ;;
+    transformer) run_transformer ;;
+    prompt_encoder) run_prompt_encoder ;;
+    pipeline) run_pipeline ;;
+    device)
+        run_combine
+        run_transformer
+        run_prompt_encoder
+        run_pipeline
+        ;;
+    all)
+        run_cpu
+        run_combine
+        run_transformer
+        run_prompt_encoder
+        run_pipeline
+        ;;
+    *)
+        echo "Usage: $0 [cpu|combine|transformer|prompt_encoder|pipeline|device|all]" >&2
+        exit 1
+        ;;
+esac

--- a/models/tt_dit/tests/models/flux2/test_img2img_flux2.py
+++ b/models/tt_dit/tests/models/flux2/test_img2img_flux2.py
@@ -1,0 +1,310 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""PCC tests for Flux2 image-to-image pipeline components."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+
+from ....parallel.config import DiTGParallelConfigNoCFG, ParallelFactor
+from ....parallel.manager import CCLManager
+from ....pipelines.flux2.pipeline_flux2 import _extract_noise_latents_from_combined
+from ....utils import tensor
+from ....utils.check import assert_quality
+from .test_pipeline_flux2 import line_params_flux2
+
+
+@pytest.mark.parametrize(
+    "mesh_device, sp_axis, tp_axis, num_links, device_params",
+    [
+        [(4, 8), 0, 1, 4, line_params_flux2],
+        [(1, 8), 0, 1, 1, line_params_flux2],
+    ],
+    ids=["wh_4x8", "wh_1x8"],
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize(
+    ("noise_seq_len", "image_seq_len", "channels"),
+    [
+        (4096, 4096, 128),
+        (1024, 256, 128),
+    ],
+    ids=["symmetric_1024", "asymmetric_512_256"],
+)
+def test_combine_img2img_spatial_input(
+    mesh_device: ttnn.MeshDevice,
+    sp_axis: int,
+    tp_axis: int,
+    num_links: int,
+    noise_seq_len: int,
+    image_seq_len: int,
+    channels: int,
+) -> None:
+    """PCC: torch.cat([noise, image]) then SP shard matches global [noise | image] layout."""
+    batch_size = 1
+
+    torch.manual_seed(0)
+    noise = torch.randn(batch_size, noise_seq_len, channels)
+    image = torch.randn(batch_size, image_seq_len, channels)
+    ref_combined = torch.cat([noise, image], dim=1)
+    ref_combined_torch = tensor.to_torch(
+        tensor.from_torch(ref_combined, device=mesh_device, mesh_axes=[None, sp_axis, None]),
+        mesh_axes=[None, sp_axis, None],
+    )
+    ttnn.synchronize_device(mesh_device)
+
+    assert_quality(ref_combined, ref_combined_torch, pcc=0.99999, relative_rmse=0.003)
+
+
+@pytest.mark.parametrize(
+    "mesh_device, sp_axis, tp_axis, num_links, device_params",
+    [
+        [(4, 8), 0, 1, 4, line_params_flux2],
+        [(1, 8), 0, 1, 1, line_params_flux2],
+    ],
+    ids=["wh_4x8", "wh_1x8"],
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize(
+    ("noise_seq_len", "image_seq_len", "channels"),
+    [
+        (4096, 4096, 128),
+        (1024, 256, 128),
+    ],
+    ids=["symmetric_1024", "asymmetric_512_256"],
+)
+def test_extract_noise_latents_from_combined(
+    mesh_device: ttnn.MeshDevice,
+    sp_axis: int,
+    tp_axis: int,
+    num_links: int,
+    noise_seq_len: int,
+    image_seq_len: int,
+    channels: int,
+) -> None:
+    """PCC: noise-prefix extraction from combined [noise | image] tensor matches diffusers slice."""
+    sp_factor = tuple(mesh_device.shape)[sp_axis]
+    tp_factor = tuple(mesh_device.shape)[tp_axis]
+    batch_size = 1
+    total_seq_len = noise_seq_len + image_seq_len
+
+    torch.manual_seed(1)
+    ref_pred = torch.randn(batch_size, total_seq_len, channels)
+    ref_noise_pred = ref_pred[:, :noise_seq_len]
+
+    ccl_manager = CCLManager(mesh_device, topology=ttnn.Topology.Linear, num_links=num_links)
+    parallel_config = DiTGParallelConfigNoCFG(
+        tensor_parallel=ParallelFactor(factor=tp_factor, mesh_axis=tp_axis),
+        sequence_parallel=ParallelFactor(factor=sp_factor, mesh_axis=sp_axis),
+    )
+
+    tt_pred = tensor.from_torch(ref_pred, device=mesh_device, mesh_axes=[None, sp_axis, None])
+    tt_noise_pred = _extract_noise_latents_from_combined(
+        ccl_manager,
+        parallel_config,
+        tt_pred,
+        noise_sequence_length=noise_seq_len,
+    )
+    ttnn.synchronize_device(mesh_device)
+
+    tt_noise_pred_torch = tensor.to_torch(tt_noise_pred, mesh_axes=[None, sp_axis, None])
+    assert_quality(ref_noise_pred, tt_noise_pred_torch, pcc=0.99999, relative_rmse=0.003)
+
+
+def test_img2img_spatial_rope_ids(tt_dit_cache_dir) -> None:
+    """PCC: combined noise + image position IDs match diffusers Flux2Pipeline."""
+    from diffusers.pipelines.flux2.pipeline_flux2 import Flux2Pipeline
+
+    from ....pipelines.flux2.pipeline_flux2 import _prepare_ids, _prepare_image_ids
+
+    torch.manual_seed(0)
+    noise_h, noise_w = 64, 64
+    cond_latent = torch.randn(1, 128, 32, 32)
+
+    noise_ids = Flux2Pipeline._prepare_latent_ids(torch.randn(1, 128, noise_h, noise_w))[0]
+    ours_noise_ids = _prepare_ids(height=noise_h, width=noise_w, text_sequence_length=1)
+    assert torch.equal(noise_ids, ours_noise_ids)
+
+    ref_image_ids = Flux2Pipeline._prepare_image_ids([cond_latent[0]]).squeeze(0)
+    ours_image_ids = _prepare_image_ids([cond_latent[0]]).squeeze(0)
+    assert torch.equal(ref_image_ids, ours_image_ids)
+
+    ref_combined = torch.cat([noise_ids, ref_image_ids], dim=0)
+    ours_combined = torch.cat([ours_noise_ids, ours_image_ids], dim=0)
+    assert torch.equal(ref_combined, ours_combined)
+
+
+def test_img2img_euler_step_matches_torch(tt_dit_cache_dir) -> None:
+    """PCC: manual flow-match Euler update on noise latents matches torch reference."""
+    torch.manual_seed(2)
+    batch_size = 1
+    noise_seq_len = 256
+    channels = 128
+
+    spatial = torch.randn(batch_size, noise_seq_len, channels)
+    noise_pred = torch.randn(batch_size, noise_seq_len, channels)
+    sigma_difference = -0.05
+
+    ref_spatial = spatial + noise_pred * sigma_difference
+
+    spatial_out = spatial.clone()
+    spatial_out.add_(noise_pred, alpha=sigma_difference)
+
+    assert torch.allclose(ref_spatial, spatial_out)
+    assert_quality(ref_spatial, spatial_out, pcc=0.99999, relative_rmse=0.001)
+
+
+@pytest.mark.parametrize(
+    "mesh_device, sp_axis, tp_axis, topology, num_links, device_params",
+    [
+        [(4, 8), 0, 1, ttnn.Topology.Linear, 4, line_params_flux2],
+    ],
+    ids=["wh_4x8"],
+    indirect=["mesh_device", "device_params"],
+)
+def test_transformer_img2img_separate_latents(
+    tt_dit_cache_dir,
+    mesh_device: ttnn.MeshDevice,
+    sp_axis: int,
+    tp_axis: int,
+    topology: ttnn.Topology,
+    num_links: int,
+    model_location_generator,
+) -> None:
+    """PCC: transformer img2img via separate noise/image tensors (production path)."""
+    import diffusers
+
+    from ....models.transformers.transformer_flux2 import Flux2Transformer
+    from ....pipelines.flux2.pipeline_flux2 import _prepare_image_ids
+    from ....utils import cache
+    from ....utils.padding import PaddingConfig
+    from .test_transformer_flux2 import _prepare_ids
+
+    sp_factor = tuple(mesh_device.shape)[sp_axis]
+    tp_factor = tuple(mesh_device.shape)[tp_axis]
+    batch_size = 1
+    height = 1024
+    width = 1024
+    cond_height = 512
+    cond_width = 512
+    prompt_seq_len = 512
+
+    skip_layers = 7
+    skip_single_layers = 47
+
+    model_name = model_location_generator("black-forest-labs/FLUX.2-dev", model_subdir="transformer")
+    torch_model = diffusers.Flux2Transformer2DModel.from_pretrained(model_name, subfolder="transformer")
+    assert isinstance(torch_model, diffusers.Flux2Transformer2DModel)
+    torch_model.eval()
+
+    del torch_model.transformer_blocks[len(torch_model.transformer_blocks) - skip_layers :]
+    del torch_model.single_transformer_blocks[len(torch_model.single_transformer_blocks) - skip_single_layers :]
+
+    head_dim = torch_model.config.attention_head_dim
+    num_heads = torch_model.config.num_attention_heads
+    in_channels = torch_model.in_channels
+    joint_attention_dim = torch_model.config.joint_attention_dim
+
+    ccl_manager = CCLManager(mesh_device=mesh_device, num_links=num_links, topology=topology)
+    parallel_config = DiTGParallelConfigNoCFG(
+        tensor_parallel=ParallelFactor(factor=tp_factor, mesh_axis=tp_axis),
+        sequence_parallel=ParallelFactor(factor=sp_factor, mesh_axis=sp_axis),
+    )
+    padding_config = (
+        PaddingConfig.from_tensor_parallel_factor(num_heads, head_dim, tp_factor)
+        if num_heads % tp_factor != 0
+        else None
+    )
+
+    tt_model = Flux2Transformer(
+        in_channels=in_channels,
+        num_layers=torch_model.config.num_layers - skip_layers,
+        num_single_layers=torch_model.config.num_single_layers - skip_single_layers,
+        attention_head_dim=head_dim,
+        num_attention_heads=num_heads,
+        joint_attention_dim=joint_attention_dim,
+        out_channels=torch_model.out_channels,
+        device=mesh_device,
+        ccl_manager=ccl_manager,
+        parallel_config=parallel_config,
+        padding_config=padding_config,
+    )
+    cache.load_model(
+        tt_model,
+        get_torch_state_dict=torch_model.state_dict,
+        model_name="FLUX.2-dev",
+        subfolder="transformer",
+        parallel_config=parallel_config,
+        mesh_shape=tuple(mesh_device.shape),
+    )
+
+    noise_seq_len = height * width // 16**2
+    cond_seq_len = cond_height * cond_width // 16**2
+    total_seq_len = noise_seq_len + cond_seq_len
+
+    torch.manual_seed(0)
+    noise_latents = torch.randn([batch_size, noise_seq_len, in_channels])
+    cond_latents = torch.randn([batch_size, cond_seq_len, in_channels])
+    concat_latents = torch.cat([noise_latents, cond_latents], dim=1)
+
+    prompt = torch.randn([batch_size, prompt_seq_len, joint_attention_dim])
+    timestep = torch.full([batch_size], fill_value=500)
+    guidance = torch.full([batch_size], fill_value=3)
+
+    text_ids = _prepare_ids(text_sequence_length=prompt_seq_len)
+    noise_ids = _prepare_ids(height=height // 16, width=width // 16, text_sequence_length=1)
+    cond_patchified = torch.randn(1, in_channels, cond_height // 16, cond_width // 16)
+    cond_ids = _prepare_image_ids([cond_patchified[0]]).squeeze(0)
+    combined_ids = torch.cat([noise_ids, cond_ids], dim=0)
+
+    prompt_rope_cos, prompt_rope_sin = torch_model.pos_embed.forward(text_ids)
+    spatial_rope_cos, spatial_rope_sin = torch_model.pos_embed.forward(combined_ids)
+
+    ref_concat = torch.cat([noise_latents, cond_latents], dim=1)
+    tt_concat = tensor.from_torch(ref_concat, device=mesh_device, mesh_axes=[None, sp_axis, None])
+    tt_prompt = tensor.from_torch(prompt, device=mesh_device)
+    tt_timestep = tensor.from_torch(timestep.unsqueeze(-1), dtype=ttnn.float32, device=mesh_device)
+    tt_guidance = tensor.from_torch(guidance.unsqueeze(-1), device=mesh_device)
+    tt_spatial_rope_cos = tensor.from_torch(
+        spatial_rope_cos.unsqueeze(0).unsqueeze(0), device=mesh_device, mesh_axes=[None, None, sp_axis, None]
+    )
+    tt_spatial_rope_sin = tensor.from_torch(
+        spatial_rope_sin.unsqueeze(0).unsqueeze(0), device=mesh_device, mesh_axes=[None, None, sp_axis, None]
+    )
+    tt_prompt_rope_cos = tensor.from_torch(prompt_rope_cos.unsqueeze(0).unsqueeze(0), device=mesh_device)
+    tt_prompt_rope_sin = tensor.from_torch(prompt_rope_sin.unsqueeze(0).unsqueeze(0), device=mesh_device)
+
+    logger.info("running Torch model (img2img concat)...")
+    with torch.no_grad():
+        torch_output_full = torch_model.forward(
+            hidden_states=concat_latents,
+            encoder_hidden_states=prompt,
+            timestep=timestep / 1000,
+            guidance=guidance,
+            img_ids=combined_ids,
+            txt_ids=text_ids,
+        ).sample
+    torch_output = torch_output_full[:, :noise_seq_len]
+
+    logger.info("running TT model (img2img separate latents + combine)...")
+    tt_output_full = tt_model.forward(
+        spatial=tt_concat,
+        prompt=tt_prompt,
+        timestep=tt_timestep,
+        guidance=tt_guidance,
+        spatial_rope=(tt_spatial_rope_cos, tt_spatial_rope_sin),
+        prompt_rope=(tt_prompt_rope_cos, tt_prompt_rope_sin),
+        spatial_sequence_length=total_seq_len,
+        prompt_sequence_length=prompt_seq_len,
+    )
+    tt_output_sliced = _extract_noise_latents_from_combined(
+        ccl_manager, parallel_config, tt_output_full, noise_sequence_length=noise_seq_len
+    )
+    tt_output_torch = tensor.to_torch(tt_output_sliced, mesh_axes=[None, sp_axis, None])
+    assert_quality(torch_output, tt_output_torch, pcc=0.996, relative_rmse=0.09)

--- a/models/tt_dit/tests/models/flux2/test_performance_flux2.py
+++ b/models/tt_dit/tests/models/flux2/test_performance_flux2.py
@@ -257,13 +257,14 @@ def test_flux2_performance(
 @pytest.mark.parametrize(
     "mesh_device, sp_axis, tp_axis, encoder_tp_axis, vae_tp_axis, topology, num_links, is_fsdp, dynamic_load, device_params",
     [
-        [(4, 8), 0, 1, 1, 1, ttnn.Topology.Linear, 4, False, False, line_params_flux2],
+        [(4, 8), 0, 1, 1, 1, ttnn.Topology.Linear, 4, True, False, line_params_flux2],
     ],
     ids=[
         "wh_glx_linear",
     ],
     indirect=["mesh_device", "device_params"],
 )
+@pytest.mark.timeout(1800)  # full e2e img2img perf run (encoder load + trace warmups + 3x50-step runs)
 def test_flux2_img2img_performance(
     *,
     mesh_device: ttnn.MeshDevice,
@@ -297,6 +298,13 @@ def test_flux2_img2img_performance(
         f"mesh={tuple(mesh_device.shape)}, sp={sp_factor}, tp={tp_factor}, topology={topology}"
     )
 
+    # Deterministic condition image for the img2img reference path. Built before the pipeline so it
+    # can be passed as warmup_image, ensuring the traced latents/rope buffers are sized for the
+    # combined noise+image sequence (the timed traced runs reuse those buffers).
+    torch.manual_seed(42)
+    cond_array = (torch.rand(cond_height, cond_width, 3) * 255).to(torch.uint8).numpy()
+    condition_image = Image.fromarray(cond_array, mode="RGB")
+
     pipeline = Flux2Pipeline.create_pipeline(
         mesh_device=mesh_device,
         checkpoint_name=model_location_generator("black-forest-labs/FLUX.2-dev"),
@@ -314,12 +322,8 @@ def test_flux2_img2img_performance(
         is_fsdp=is_fsdp,
         trace_warmup=True,
         shard_prompt=True,
+        warmup_image=condition_image,
     )
-
-    # Deterministic condition image for the img2img reference path.
-    torch.manual_seed(42)
-    cond_array = (torch.rand(cond_height, cond_width, 3) * 255).to(torch.uint8).numpy()
-    condition_image = Image.fromarray(cond_array, mode="RGB")
 
     logger.info(f"Running {NUM_PERF_RUNS} timed img2img iterations...")
 

--- a/models/tt_dit/tests/models/flux2/test_performance_flux2.py
+++ b/models/tt_dit/tests/models/flux2/test_performance_flux2.py
@@ -8,6 +8,7 @@ import statistics
 import pytest
 import torch
 from loguru import logger
+from PIL import Image
 
 import ttnn
 from models.common.utility_functions import is_blackhole
@@ -233,3 +234,210 @@ def test_flux2_performance(
         )
 
     logger.info("Performance test completed successfully!")
+
+
+@pytest.mark.parametrize(
+    "width, height",
+    [
+        (1024, 1024),
+    ],
+    ids=[
+        "1024x1024",
+    ],
+)
+@pytest.mark.parametrize(
+    "cond_width, cond_height",
+    [
+        (512, 512),
+    ],
+    ids=[
+        "cond512x512",
+    ],
+)
+@pytest.mark.parametrize(
+    "mesh_device, sp_axis, tp_axis, encoder_tp_axis, vae_tp_axis, topology, num_links, is_fsdp, dynamic_load, device_params",
+    [
+        [(4, 8), 0, 1, 1, 1, ttnn.Topology.Linear, 4, False, False, line_params_flux2],
+    ],
+    ids=[
+        "wh_glx_linear",
+    ],
+    indirect=["mesh_device", "device_params"],
+)
+def test_flux2_img2img_performance(
+    *,
+    mesh_device: ttnn.MeshDevice,
+    sp_axis: int,
+    tp_axis: int,
+    encoder_tp_axis: int,
+    vae_tp_axis: int,
+    topology: ttnn.Topology,
+    num_links: int,
+    is_fsdp: bool,
+    dynamic_load: bool,
+    width: int,
+    height: int,
+    cond_width: int,
+    cond_height: int,
+    model_location_generator,
+    is_ci_env: bool,
+) -> None:
+    """Image-to-image performance test for the Flux2 pipeline on a 4x8 Wormhole galaxy.
+
+    Reports the on-device VAE-encode duration (the img2img input path added by this work) alongside
+    the full image-to-image pipeline breakdown (prompt encode, denoising, VAE decode, total).
+    """
+    benchmark_profiler = BenchmarkProfiler()
+
+    sp_factor = tuple(mesh_device.shape)[sp_axis]
+    tp_factor = tuple(mesh_device.shape)[tp_axis]
+
+    logger.info(
+        f"img2img config: {width}x{height} (cond {cond_width}x{cond_height}), "
+        f"mesh={tuple(mesh_device.shape)}, sp={sp_factor}, tp={tp_factor}, topology={topology}"
+    )
+
+    pipeline = Flux2Pipeline.create_pipeline(
+        mesh_device=mesh_device,
+        checkpoint_name=model_location_generator("black-forest-labs/FLUX.2-dev"),
+        sp_axis=sp_axis,
+        tp_axis=tp_axis,
+        encoder_tp_axis=encoder_tp_axis,
+        vae_tp_axis=vae_tp_axis,
+        vae_h_axis=1 - vae_tp_axis,
+        vae_w_axis=None,
+        num_links=num_links,
+        topology=topology,
+        width=width,
+        height=height,
+        dynamic_load=dynamic_load,
+        is_fsdp=is_fsdp,
+        trace_warmup=True,
+        shard_prompt=True,
+    )
+
+    # Deterministic condition image for the img2img reference path.
+    torch.manual_seed(42)
+    cond_array = (torch.rand(cond_height, cond_width, 3) * 255).to(torch.uint8).numpy()
+    condition_image = Image.fromarray(cond_array, mode="RGB")
+
+    logger.info(f"Running {NUM_PERF_RUNS} timed img2img iterations...")
+
+    for i in range(NUM_PERF_RUNS):
+        logger.info(f"img2img performance run {i + 1}/{NUM_PERF_RUNS}...")
+
+        ttnn.synchronize_device(mesh_device)
+        ttnn.distributed_context_barrier()
+
+        with benchmark_profiler("run", iteration=i):
+            with torch.no_grad():
+                images = pipeline(
+                    prompts=["A photo of a cat sitting on a windowsill at sunset"],
+                    image=condition_image,
+                    num_inference_steps=NUM_INFERENCE_STEPS,
+                    seed=42,
+                    traced=True,
+                    profiler=benchmark_profiler,
+                    profiler_iteration=i,
+                )
+                ttnn.synchronize_device(mesh_device)
+
+        logger.info(f"  Run {i + 1} completed in {benchmark_profiler.get_duration('run', i):.2f}s")
+
+    def _durations(step_name: str) -> list[float]:
+        out = []
+        for i in range(NUM_PERF_RUNS):
+            if benchmark_profiler.contains_step(step_name, i):
+                out.append(benchmark_profiler.get_duration(step_name, i))
+        return out
+
+    encoder_times = _durations("encoder")
+    vae_encode_times = _durations("vae_encode")
+    denoising_times = _durations("denoising")
+    vae_times = _durations("vae")
+    total_times = _durations("run")
+
+    if not is_ci_env:
+        rank = int(ttnn.distributed_context_get_rank())
+        if rank == 0:
+            mesh_tag = "x".join(str(s) for s in mesh_device.shape)
+            output_path = f"flux2_img2img_{mesh_tag}_{width}x{height}.png"
+            images[0].save(output_path)
+            logger.info(f"Image saved as {output_path}")
+
+    print("\n" + "=" * 80)
+    print("FLUX2 IMAGE-TO-IMAGE PERFORMANCE RESULTS")
+    print("=" * 80)
+    print(f"Image Size: {width}x{height} | Condition Image: {cond_width}x{cond_height}")
+    print(f"Inference Steps: {NUM_INFERENCE_STEPS}")
+    print(f"Performance Runs: {NUM_PERF_RUNS}")
+    print(f"DiT Configuration: sp={sp_factor}, tp={tp_factor}")
+    print(f"Mesh Shape: {tuple(mesh_device.shape)}")
+    print(f"Topology: {topology}")
+    print("-" * 80)
+
+    def print_stats(name, times):
+        if not times:
+            print(f"{name:28} | No data available")
+            return
+        mean_time = statistics.mean(times)
+        std_time = statistics.stdev(times) if len(times) > 1 else 0
+        print(
+            f"{name:28} | Mean: {mean_time:8.4f}s | Std: {std_time:8.4f}s | "
+            f"Min: {min(times):8.4f}s | Max: {max(times):8.4f}s"
+        )
+
+    print_stats("Prompt encoding", encoder_times)
+    print_stats("VAE encode (img2img)", vae_encode_times)
+    print_stats("Denoising (total)", denoising_times)
+    print_stats("VAE decoding", vae_times)
+    print_stats("Total img2img pipeline", total_times)
+    print("-" * 80)
+
+    if total_times:
+        avg_total = statistics.mean(total_times)
+        print(f"Overall throughput: {1 / avg_total:.4f} images/second")
+        print("\nTime breakdown:")
+        if vae_encode_times:
+            print(f"  VAE encode (img2img): {statistics.mean(vae_encode_times) / avg_total * 100:5.1f}%")
+        if encoder_times:
+            print(f"  Prompt encoding:      {statistics.mean(encoder_times) / avg_total * 100:5.1f}%")
+        if denoising_times:
+            print(f"  Denoising:            {statistics.mean(denoising_times) / avg_total * 100:5.1f}%")
+        if vae_times:
+            print(f"  VAE decoding:         {statistics.mean(vae_times) / avg_total * 100:5.1f}%")
+    print("=" * 80)
+
+    if is_ci_env:
+        benchmark_data = BenchmarkData()
+        for i in range(NUM_PERF_RUNS):
+            for step_name in ["encoder", "vae_encode", "denoising", "vae", "run"]:
+                if benchmark_profiler.contains_step(step_name, i):
+                    benchmark_data.add_measurement(
+                        profiler=benchmark_profiler,
+                        iteration=i,
+                        step_name=step_name,
+                        name=step_name,
+                        value=benchmark_profiler.get_duration(step_name, i),
+                        target=benchmark_profiler.get_duration(step_name, i),
+                    )
+        benchmark_data.save_partial_run_json(
+            benchmark_profiler,
+            run_type="BH_GLX" if is_blackhole() else "WH_GLX",
+            ml_model_name=os.path.basename(pipeline.checkpoint_name),
+            batch_size=1,
+            config_params={
+                "width": width,
+                "height": height,
+                "cond_width": cond_width,
+                "cond_height": cond_height,
+                "num_steps": NUM_INFERENCE_STEPS,
+                "num_perf_runs": NUM_PERF_RUNS,
+                "sp_factor": sp_factor,
+                "tp_factor": tp_factor,
+                "topology": str(topology),
+                "mode": "img2img",
+            },
+        )
+
+    logger.info("img2img performance test completed successfully!")

--- a/models/tt_dit/tests/models/flux2/test_pipeline_flux2.py
+++ b/models/tt_dit/tests/models/flux2/test_pipeline_flux2.py
@@ -7,6 +7,7 @@ import os
 
 import pytest
 from loguru import logger
+from PIL import Image
 
 import ttnn
 from models.common.utility_functions import is_blackhole
@@ -19,6 +20,24 @@ line_params_flux2 = {**line_params, "l1_small_size": 65536}
 ring_params_flux2 = {**ring_params, "l1_small_size": 65536}
 ring_params_8k_flux2 = {**ring_params_8k, "l1_small_size": 65536}
 line_params_8k_flux2 = {**line_params_8k, "l1_small_size": 65536}
+
+
+def _load_init_image(*, width: int, height: int, mesh_device: ttnn.MeshDevice) -> Image.Image:
+    """Load a real reference image for img2img (Flux2 conditions on encoded reference latents)."""
+    arch = "bh" if is_blackhole() else "wh"
+    mesh_tag = "x".join(str(s) for s in mesh_device.shape)
+    ref_path = f"flux2_{arch}_{width}_{height}_{mesh_tag}_0.png"
+    if os.path.isfile(ref_path):
+        logger.info(f"Using reference image: {ref_path}")
+        return Image.open(ref_path).convert("RGB")
+
+    logger.warning(f"Reference image not found at {ref_path}; using synthetic gradient")
+    gradient = Image.new("RGB", (width, height))
+    pixels = gradient.load()
+    for y in range(height):
+        for x in range(width):
+            pixels[x, y] = (x * 255 // width, y * 255 // height, 128)
+    return gradient
 
 
 @pytest.mark.parametrize(
@@ -124,3 +143,70 @@ def test_pipeline(
             if prompt[0] == "q":
                 break
             run(prompt=prompt, number=i, seed=i)
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [line_params_flux2],
+    indirect=True,
+)
+@pytest.mark.parametrize(("width", "height", "num_inference_steps"), [(1024, 1024, 12)])
+@pytest.mark.parametrize(
+    "mesh_device, sp_axis, tp_axis, encoder_tp_axis, vae_tp_axis, topology, num_links, is_fsdp, dynamic_load",
+    [
+        [(4, 8), 0, 1, 1, 1, ttnn.Topology.Linear, 4, True, False],
+    ],
+    ids=["wh_4x8"],
+    indirect=["mesh_device"],
+)
+def test_pipeline_img2img(
+    tt_dit_cache_dir,
+    *,
+    mesh_device: ttnn.MeshDevice,
+    width: int,
+    height: int,
+    num_inference_steps: int,
+    sp_axis: int,
+    tp_axis: int,
+    encoder_tp_axis: int,
+    vae_tp_axis: int,
+    topology: ttnn.Topology,
+    num_links: int,
+    is_fsdp: bool,
+    dynamic_load: bool,
+    model_location_generator,
+) -> None:
+    pipeline = Flux2Pipeline.create_pipeline(
+        mesh_device=mesh_device,
+        checkpoint_name=model_location_generator("black-forest-labs/FLUX.2-dev"),
+        sp_axis=sp_axis,
+        tp_axis=tp_axis,
+        encoder_tp_axis=encoder_tp_axis,
+        vae_tp_axis=vae_tp_axis,
+        vae_h_axis=1 - vae_tp_axis,
+        vae_w_axis=None,
+        num_links=num_links,
+        topology=topology,
+        width=width,
+        height=height,
+        is_fsdp=is_fsdp,
+        dynamic_load=dynamic_load,
+        trace_warmup=False,
+    )
+
+    init_image = _load_init_image(width=width, height=height, mesh_device=mesh_device)
+    prompt = "winter night"
+
+    images = pipeline(
+        prompts=[prompt],
+        image=init_image,
+        num_inference_steps=num_inference_steps,
+        seed=0,
+        traced=False,
+    )
+
+    arch = "bh" if is_blackhole() else "wh"
+    mesh_tag = "x".join(str(s) for s in mesh_device.shape)
+    output_filename = f"flux2_{arch}_{width}_{height}_{mesh_tag}_img2img_0.png"
+    images[0].save(output_filename)
+    logger.info(f"Image saved as {output_filename}")

--- a/models/tt_dit/tests/models/flux2/test_pipeline_flux2.py
+++ b/models/tt_dit/tests/models/flux2/test_pipeline_flux2.py
@@ -11,6 +11,7 @@ from PIL import Image
 
 import ttnn
 from models.common.utility_functions import is_blackhole
+from models.perf.benchmarking_utils import BenchmarkProfiler
 
 from ....pipelines.flux2.pipeline_flux2 import Flux2Pipeline
 from ....utils.test import line_params, line_params_8k, ring_params, ring_params_8k
@@ -197,13 +198,38 @@ def test_pipeline_img2img(
     init_image = _load_init_image(width=width, height=height, mesh_device=mesh_device)
     prompt = "winter night"
 
-    images = pipeline(
-        prompts=[prompt],
-        image=init_image,
-        num_inference_steps=num_inference_steps,
-        seed=0,
-        traced=False,
-    )
+    benchmark_profiler = BenchmarkProfiler()
+    ttnn.synchronize_device(mesh_device)
+    with benchmark_profiler("run", iteration=0):
+        images = pipeline(
+            prompts=[prompt],
+            image=init_image,
+            num_inference_steps=num_inference_steps,
+            seed=0,
+            traced=False,
+            profiler=benchmark_profiler,
+            profiler_iteration=0,
+        )
+        ttnn.synchronize_device(mesh_device)
+
+    def _dur(step: str) -> float:
+        try:
+            return benchmark_profiler.get_duration(step, 0)
+        except Exception:
+            return float("nan")
+
+    total = _dur("run")
+    print("\n" + "=" * 72)
+    print(f"FLUX2 IMG2IMG PERF (4x8 WH galaxy, {width}x{height}, {num_inference_steps} steps)")
+    print("-" * 72)
+    print(f"  {'prompt+encoder':24} | {_dur('encoder') * 1e3:10.3f} ms")
+    print(f"  {'VAE image encode':24} | {_dur('vae_encode') * 1e3:10.3f} ms")
+    print(f"  {'denoising (total)':24} | {_dur('denoising') * 1e3:10.3f} ms")
+    print(f"  {'VAE decode':24} | {_dur('vae') * 1e3:10.3f} ms")
+    print("-" * 72)
+    print(f"  {'total image-to-image':24} | {total * 1e3:10.3f} ms")
+    print("=" * 72)
+    logger.info(f"img2img total: {total:.3f}s (vae_encode {_dur('vae_encode'):.3f}s)")
 
     arch = "bh" if is_blackhole() else "wh"
     mesh_tag = "x".join(str(s) for s in mesh_device.shape)

--- a/models/tt_dit/tests/models/flux2/test_prompt_encoder.py
+++ b/models/tt_dit/tests/models/flux2/test_prompt_encoder.py
@@ -10,7 +10,8 @@ import ttnn
 
 from ....parallel.config import EncoderParallelConfig, ParallelFactor
 from ....parallel.manager import CCLManager
-from ....pipelines.flux2.prompt_encoder import PromptEncoder
+from ....pipelines.flux2.prompt_encoder import PromptEncoder, _format_input
+from ....pipelines.flux2.system_messages import SYSTEM_MESSAGE_UPSAMPLING_I2I
 from ....utils.check import assert_quality
 
 
@@ -95,3 +96,69 @@ def test_upsample(mesh_device: ttnn.MeshDevice) -> None:
     logger.info("running TT model...")
     tt_output = tt_encoder.upsample(prompts, max_length=224, temperature=temperature)
     print(tt_output)
+
+
+def test_format_input_i2i(tt_dit_cache_dir) -> None:
+    from diffusers.pipelines.flux2.pipeline_flux2 import format_input as diffusers_format_input
+    from PIL import Image
+
+    prompts = ["Make the sky purple at sunset"]
+    image = Image.new("RGB", (64, 64), color=(1, 2, 3))
+
+    ref = diffusers_format_input(prompts, system_message=SYSTEM_MESSAGE_UPSAMPLING_I2I, images=[[image]])
+    ours = _format_input(prompts, system_message=SYSTEM_MESSAGE_UPSAMPLING_I2I, images=[image])
+
+    assert len(ref) == len(ours) == 1
+    assert len(ref[0]) == len(ours[0])
+    for ref_msg, our_msg in zip(ref[0], ours[0], strict=True):
+        assert ref_msg["role"] == our_msg["role"]
+        ref_types = [part["type"] for part in ref_msg["content"]]
+        our_types = [part["type"] for part in our_msg["content"]]
+        assert ref_types == our_types
+        for ref_part, our_part in zip(ref_msg["content"], our_msg["content"], strict=True):
+            if ref_part["type"] == "text":
+                assert ref_part["text"] == our_part["text"]
+
+
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        pytest.param((4, 8), id="4x8"),
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+def test_upsample_i2i(tt_dit_cache_dir, mesh_device: ttnn.MeshDevice) -> None:
+    from PIL import Image
+
+    tp_axis = 1
+    checkpoint_name = "black-forest-labs/FLUX.2-dev"
+    prompts = ["Make the sky purple at sunset"]
+    temperature = 0.15
+    image = Image.new("RGB", (256, 256), color=(10, 20, 30))
+
+    ccl_manager = CCLManager(mesh_device, topology=ttnn.Topology.Linear)
+    parallel_config = EncoderParallelConfig(
+        tensor_parallel=ParallelFactor(factor=mesh_device.shape[tp_axis], mesh_axis=tp_axis),
+    )
+
+    tt_encoder = PromptEncoder(
+        checkpoint_name=checkpoint_name,
+        use_torch_encoder=False,
+        device=mesh_device,
+        parallel_config=parallel_config,
+        ccl_manager=ccl_manager,
+    )
+    tt_encoder.load_weights()
+
+    logger.info("running TT model (img2img upsample)...")
+    tt_output = tt_encoder.upsample(
+        prompts,
+        max_length=224,
+        temperature=temperature,
+        images=[image],
+    )
+
+    assert len(tt_output) == 1
+    assert isinstance(tt_output[0], str)
+    assert len(tt_output[0]) > 0

--- a/models/tt_dit/tests/models/flux2/test_transformer_flux2.py
+++ b/models/tt_dit/tests/models/flux2/test_transformer_flux2.py
@@ -245,6 +245,177 @@ def test_transformer(
     assert_quality(torch_output, tt_output_torch, pcc=0.996, relative_rmse=0.09)
 
 
+def test_img2img_latent_helpers(tt_dit_cache_dir) -> None:
+    from diffusers.pipelines.flux2.pipeline_flux2 import Flux2Pipeline
+
+    from ....pipelines.flux2.pipeline_flux2 import _pack_latents, _patchify_latents, _prepare_ids, _prepare_image_ids
+
+    torch.manual_seed(0)
+    latents = torch.randn(2, 32, 128, 128)
+
+    ref_patchified = Flux2Pipeline._patchify_latents(latents)
+    ours_patchified = _patchify_latents(latents)
+    assert torch.equal(ref_patchified, ours_patchified)
+
+    ref_packed = Flux2Pipeline._pack_latents(ref_patchified)
+    ours_packed = _pack_latents(ours_patchified)
+    assert torch.equal(ref_packed, ours_packed)
+
+    ref_image_ids = Flux2Pipeline._prepare_image_ids([ref_patchified[0]])
+    ours_image_ids = _prepare_image_ids([ref_patchified[0]])
+    assert torch.equal(ref_image_ids, ours_image_ids)
+
+    ref_latent_ids = Flux2Pipeline._prepare_latent_ids(ref_patchified)[0]
+    noise_ids = _prepare_ids(height=ref_patchified.shape[2], width=ref_patchified.shape[3], text_sequence_length=1)
+    assert torch.equal(ref_latent_ids, noise_ids)
+
+
+@pytest.mark.parametrize(
+    "mesh_device, sp_axis, tp_axis, topology, num_links, device_params",
+    [
+        [(4, 8), 0, 1, ttnn.Topology.Linear, 2, line_params_flux2_transformer],
+    ],
+    ids=["wh_4x8_linear"],
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize(
+    ("batch_size", "height", "width", "cond_height", "cond_width", "prompt_seq_len"),
+    [
+        (1, 1024, 1024, 512, 512, 512),
+    ],
+)
+def test_transformer_img2img(
+    tt_dit_cache_dir,
+    mesh_device: ttnn.MeshDevice,
+    sp_axis: int,
+    tp_axis: int,
+    topology: ttnn.Topology,
+    num_links: int,
+    batch_size: int,
+    height: int,
+    width: int,
+    cond_height: int,
+    cond_width: int,
+    prompt_seq_len: int,
+    model_location_generator: ModelLocationGenerator,
+) -> None:
+    """PCC: transformer forward with concatenated noise + reference image latents (img2img)."""
+    sp_factor = tuple(mesh_device.shape)[sp_axis]
+    tp_factor = tuple(mesh_device.shape)[tp_axis]
+
+    skip_layers = 7
+    skip_single_layers = 47
+
+    model_name = model_location_generator("black-forest-labs/FLUX.2-dev", model_subdir="transformer")
+    torch_model = diffusers.Flux2Transformer2DModel.from_pretrained(model_name, subfolder="transformer")
+    assert isinstance(torch_model, diffusers.Flux2Transformer2DModel)
+    torch_model.eval()
+
+    del torch_model.transformer_blocks[len(torch_model.transformer_blocks) - skip_layers :]
+    del torch_model.single_transformer_blocks[len(torch_model.single_transformer_blocks) - skip_single_layers :]
+
+    head_dim = torch_model.config.attention_head_dim
+    num_heads = torch_model.config.num_attention_heads
+    in_channels = torch_model.in_channels
+    joint_attention_dim = torch_model.config.joint_attention_dim
+
+    ccl_manager = CCLManager(mesh_device=mesh_device, num_links=num_links, topology=topology)
+    parallel_config = DiTGParallelConfigNoCFG(
+        tensor_parallel=ParallelFactor(factor=tp_factor, mesh_axis=tp_axis),
+        sequence_parallel=ParallelFactor(factor=sp_factor, mesh_axis=sp_axis),
+    )
+    padding_config = (
+        PaddingConfig.from_tensor_parallel_factor(num_heads, head_dim, tp_factor)
+        if num_heads % tp_factor != 0
+        else None
+    )
+
+    tt_model = Flux2Transformer(
+        in_channels=in_channels,
+        num_layers=torch_model.config.num_layers - skip_layers,
+        num_single_layers=torch_model.config.num_single_layers - skip_single_layers,
+        attention_head_dim=head_dim,
+        num_attention_heads=num_heads,
+        joint_attention_dim=joint_attention_dim,
+        out_channels=torch_model.out_channels,
+        device=mesh_device,
+        ccl_manager=ccl_manager,
+        parallel_config=parallel_config,
+        padding_config=padding_config,
+    )
+    cache.load_model(
+        tt_model,
+        get_torch_state_dict=torch_model.state_dict,
+        model_name="FLUX.2-dev",
+        subfolder="transformer",
+        parallel_config=parallel_config,
+        mesh_shape=tuple(mesh_device.shape),
+    )
+
+    from ....pipelines.flux2.pipeline_flux2 import _prepare_image_ids
+
+    noise_seq_len = height * width // 16**2
+    cond_seq_len = cond_height * cond_width // 16**2
+    total_seq_len = noise_seq_len + cond_seq_len
+
+    torch.manual_seed(0)
+    noise_latents = torch.randn([batch_size, noise_seq_len, in_channels])
+    cond_latents = torch.randn([batch_size, cond_seq_len, in_channels])
+    concat_latents = torch.cat([noise_latents, cond_latents], dim=1)
+
+    prompt = torch.randn([batch_size, prompt_seq_len, joint_attention_dim])
+    timestep = torch.full([batch_size], fill_value=500)
+    guidance = torch.full([batch_size], fill_value=3)
+
+    text_ids = _prepare_ids(text_sequence_length=prompt_seq_len)
+    noise_ids = _prepare_ids(height=height // 16, width=width // 16, text_sequence_length=1)
+    cond_patchified = torch.randn(1, in_channels, cond_height // 16, cond_width // 16)
+    cond_ids = _prepare_image_ids([cond_patchified[0]]).squeeze(0)
+    combined_ids = torch.cat([noise_ids, cond_ids], dim=0)
+
+    prompt_rope_cos, prompt_rope_sin = torch_model.pos_embed.forward(text_ids)
+    spatial_rope_cos, spatial_rope_sin = torch_model.pos_embed.forward(combined_ids)
+
+    tt_concat = tensor.from_torch(concat_latents, device=mesh_device, mesh_axes=[None, sp_axis, None])
+    tt_prompt = tensor.from_torch(prompt, device=mesh_device)
+    tt_timestep = tensor.from_torch(timestep.unsqueeze(-1), dtype=ttnn.float32, device=mesh_device)
+    tt_guidance = tensor.from_torch(guidance.unsqueeze(-1), device=mesh_device)
+    tt_spatial_rope_cos = tensor.from_torch(
+        spatial_rope_cos.unsqueeze(0).unsqueeze(0), device=mesh_device, mesh_axes=[None, None, sp_axis, None]
+    )
+    tt_spatial_rope_sin = tensor.from_torch(
+        spatial_rope_sin.unsqueeze(0).unsqueeze(0), device=mesh_device, mesh_axes=[None, None, sp_axis, None]
+    )
+    tt_prompt_rope_cos = tensor.from_torch(prompt_rope_cos.unsqueeze(0).unsqueeze(0), device=mesh_device)
+    tt_prompt_rope_sin = tensor.from_torch(prompt_rope_sin.unsqueeze(0).unsqueeze(0), device=mesh_device)
+
+    logger.info("running Torch model (img2img concat)...")
+    with torch.no_grad():
+        torch_output_full = torch_model.forward(
+            hidden_states=concat_latents,
+            encoder_hidden_states=prompt,
+            timestep=timestep / 1000,
+            guidance=guidance,
+            img_ids=combined_ids,
+            txt_ids=text_ids,
+        ).sample
+    torch_output = torch_output_full[:, :noise_seq_len]
+
+    logger.info("running TT model (img2img concat)...")
+    tt_output_full = tt_model.forward(
+        spatial=tt_concat,
+        prompt=tt_prompt,
+        timestep=tt_timestep,
+        guidance=tt_guidance,
+        spatial_rope=(tt_spatial_rope_cos, tt_spatial_rope_sin),
+        prompt_rope=(tt_prompt_rope_cos, tt_prompt_rope_sin),
+        spatial_sequence_length=total_seq_len,
+        prompt_sequence_length=prompt_seq_len,
+    )
+    tt_output_torch = tensor.to_torch(tt_output_full, mesh_axes=[None, sp_axis, None])[:, :noise_seq_len]
+    assert_quality(torch_output, tt_output_torch, pcc=0.996, relative_rmse=0.09)
+
+
 @pytest.mark.parametrize(
     "mesh_device, sp_axis, tp_axis, topology, num_links, fsdp, device_params",
     [

--- a/models/tt_dit/tests/models/flux2/test_vae_flux2.py
+++ b/models/tt_dit/tests/models/flux2/test_vae_flux2.py
@@ -9,7 +9,7 @@ import torch
 
 import ttnn
 
-from ....models.vae.vae_flux2_opt import Flux2VaeDecoder
+from ....models.vae.vae_flux2 import Flux2VaeDecoder
 from ....parallel.config import Flux2VaeParallelConfig
 from ....parallel.manager import CCLManager
 from ....utils import tensor
@@ -163,3 +163,38 @@ def test_vae_flux2_decoder(
 
     tt_out_torch = tensor.to_torch(tt_out).permute(0, 3, 1, 2)  # [B, 3, H, W]
     assert_quality(torch_output, tt_out_torch, pcc=0.9978, relative_rmse=0.034)
+
+
+def test_vae_encode_img2img(tt_dit_cache_dir) -> None:
+    """PCC: img2img VAE encode + patchify + pack helpers match diffusers Flux2Pipeline."""
+    from diffusers.models.autoencoders.autoencoder_kl_flux2 import AutoencoderKLFlux2
+    from diffusers.pipelines.flux2.image_processor import Flux2ImageProcessor
+    from diffusers.pipelines.flux2.pipeline_flux2 import Flux2Pipeline
+    from PIL import Image
+
+    from ....pipelines.flux2.pipeline_flux2 import _pack_latents, _patchify_latents
+
+    vae = AutoencoderKLFlux2.from_pretrained("black-forest-labs/FLUX.2-dev", subfolder="vae")
+    assert isinstance(vae, AutoencoderKLFlux2)
+    vae.eval()
+
+    image_processor = Flux2ImageProcessor(vae_scale_factor=16)
+    image = Image.new("RGB", (512, 512), color=(32, 64, 128))
+    preprocessed = image_processor.preprocess(image, height=512, width=512, resize_mode="crop")
+
+    with torch.no_grad():
+        encoded = vae.encode(preprocessed).latent_dist.mode()
+
+    ref_patchified = Flux2Pipeline._patchify_latents(encoded)
+    ours_patchified = _patchify_latents(encoded)
+    assert torch.equal(ref_patchified, ours_patchified)
+
+    mean = vae.bn.running_mean.view(1, -1, 1, 1).to(ref_patchified.dtype)
+    std = torch.sqrt(vae.bn.running_var.view(1, -1, 1, 1) + vae.config.batch_norm_eps).to(ref_patchified.dtype)
+    ref_normalized = (ref_patchified - mean) / std
+    ours_normalized = (ours_patchified - mean) / std
+    assert torch.equal(ref_normalized, ours_normalized)
+
+    ref_packed = Flux2Pipeline._pack_latents(ref_normalized)
+    ours_packed = _pack_latents(ours_normalized)
+    assert torch.equal(ref_packed, ours_packed)

--- a/models/tt_dit/tests/models/flux2/test_vae_flux2.py
+++ b/models/tt_dit/tests/models/flux2/test_vae_flux2.py
@@ -3,19 +3,34 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+import statistics
+import time
+
 import diffusers.models.autoencoders.autoencoder_kl_flux2 as reference
 import pytest
 import torch
+from loguru import logger
 
 import ttnn
 
-from ....models.vae.vae_flux2 import Flux2VaeDecoder
+from ....models.vae.vae_flux2 import Flux2VaeDecoder, Flux2VaeEncoder
 from ....parallel.config import Flux2VaeParallelConfig
 from ....parallel.manager import CCLManager
 from ....utils import tensor
 from ....utils.check import assert_quality
 
 _LAYERS_PER_BLOCK = 1  # pruned from pretrained (2) to keep host run fast
+
+# Encoder perf: one compile warmup + a few timed end-to-end runs (no trace capture).
+_PERF_WARMUP_RUNS = 1
+_PERF_NUM_RUNS = 3
+
+
+def _encoder_parallel_axes(mesh_device: ttnn.MeshDevice) -> tuple[int, int]:
+    """Match pipeline / perf tests: TP on the size-8 axis, H-shard on the size-4 axis."""
+    if mesh_device.shape[1] >= mesh_device.shape[0]:
+        return 1, 0
+    return 0, 1
 
 
 def _load_pruned_torch_model() -> reference.AutoencoderKLFlux2:
@@ -31,6 +46,38 @@ def _load_pruned_torch_model() -> reference.AutoencoderKLFlux2:
     for up_block in model.decoder.up_blocks:
         up_block.resnets = torch.nn.ModuleList(list(up_block.resnets)[:keep])
     return model
+
+
+def _load_pruned_torch_encoder_model() -> reference.AutoencoderKLFlux2:
+    """Load the pretrained VAE and truncate each encoder down_block to _LAYERS_PER_BLOCK resnets.
+
+    The mid_block is left intact (num_layers=1) to match TT's VaeMidBlock default.
+    """
+    model = reference.AutoencoderKLFlux2.from_pretrained("black-forest-labs/FLUX.2-dev", subfolder="vae")
+    assert isinstance(model, reference.AutoencoderKLFlux2)
+    model.eval()
+    for down_block in model.encoder.down_blocks:
+        down_block.resnets = torch.nn.ModuleList(list(down_block.resnets)[:_LAYERS_PER_BLOCK])
+    return model
+
+
+def _torch_encode_reference(torch_model: reference.AutoencoderKLFlux2, image: torch.Tensor) -> torch.Tensor:
+    """Run the torch encoder + .mode() + space-to-depth patchify + batch-norm normalize.
+
+    image: [B, 3, H, W]. Returns [B, C*p^2, H/16, W/16] channel-first, matching the TT encoder's
+    patchify output permuted to NCHW.
+    """
+    from ....pipelines.flux2.pipeline_flux2 import _patchify_latents
+
+    with torch.no_grad():
+        encoded = torch_model.encode(image).latent_dist.mode()  # [B, C, H/8, W/8]
+
+    encoded = _patchify_latents(encoded)  # [B, C*p^2, H/16, W/16]
+    mean = torch_model.bn.running_mean.view(1, -1, 1, 1).to(dtype=encoded.dtype)
+    std = torch.sqrt(torch_model.bn.running_var.view(1, -1, 1, 1) + torch_model.config.batch_norm_eps).to(
+        dtype=encoded.dtype
+    )
+    return (encoded - mean) / std
 
 
 def _torch_decode_reference(torch_model: reference.AutoencoderKLFlux2, inp: torch.Tensor) -> torch.Tensor:
@@ -163,6 +210,304 @@ def test_vae_flux2_decoder(
 
     tt_out_torch = tensor.to_torch(tt_out).permute(0, 3, 1, 2)  # [B, 3, H, W]
     assert_quality(torch_output, tt_out_torch, pcc=0.9978, relative_rmse=0.034)
+
+
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        pytest.param((1, 1), id="1x1"),
+        pytest.param((1, 8), id="1x8"),
+        pytest.param((4, 8), id="4x8"),
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "l1_small_size": 65536}],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    ("batch_size", "height", "width"),
+    [(1, 512, 512)],
+    ids=["512"],
+)
+def test_vae_flux2_encoder(
+    *,
+    mesh_device: ttnn.Device,
+    batch_size: int,
+    height: int,
+    width: int,
+) -> None:
+    torch.manual_seed(0)
+
+    tp_axis, h_axis = _encoder_parallel_axes(mesh_device)
+    w_axis = None
+
+    torch_model = _load_pruned_torch_encoder_model()
+
+    ccl_manager = CCLManager(mesh_device, topology=ttnn.Topology.Linear)
+    vae_parallel_config = Flux2VaeParallelConfig.from_axes(mesh_device, tp_axis=tp_axis, h_axis=h_axis, w_axis=w_axis)
+
+    z_channels = torch_model.config.latent_channels
+    vae_scale_factor = 8
+
+    tt_model = Flux2VaeEncoder(
+        in_channels=torch_model.config.in_channels,
+        block_out_channels=list(torch_model.config.block_out_channels),
+        layers_per_block=_LAYERS_PER_BLOCK,
+        z_channels=z_channels,
+        device=mesh_device,
+        parallel_config=vae_parallel_config,
+        ccl_manager=ccl_manager,
+        use_conv3d=False,
+    )
+    tt_model.load_torch_state_dict(torch_model.state_dict())
+
+    image = torch.randn(batch_size, torch_model.config.in_channels, height, width)
+
+    torch_output = _torch_encode_reference(torch_model, image)  # [B, C*p^2, H/16, W/16]
+
+    h_mesh_axis = vae_parallel_config.h_parallel.mesh_axis if vae_parallel_config.h_parallel is not None else None
+    mesh_axes = [None, h_mesh_axis, None, None] if h_mesh_axis is not None else None
+
+    tt_image = tensor.from_torch(
+        image.permute(0, 2, 3, 1).contiguous().to(torch.bfloat16),
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_axes=mesh_axes,
+    )
+
+    patchified = tt_model.encode_and_patchify(
+        tt_image, height=height // vae_scale_factor, width=width // vae_scale_factor
+    )
+    ttnn.synchronize_device(mesh_device)
+
+    tt_out_torch = tensor.to_torch(patchified, mesh_axes=mesh_axes, composer_device=mesh_device).permute(0, 3, 1, 2)
+    assert_quality(torch_output, tt_out_torch, pcc=0.99, relative_rmse=0.06)
+
+
+def _gather_nhwc_to_nchw(
+    t: ttnn.Tensor,
+    *,
+    mesh_device: ttnn.Device,
+    h_mesh_axis: int | None,
+    tp_mesh_axis: int | None,
+    channel_sharded: bool,
+) -> torch.Tensor:
+    """Gather a (possibly H-sharded and/or channel-TP-sharded) NHWC device tensor to host NCHW."""
+    mesh_axes = [
+        None,
+        h_mesh_axis,
+        None,
+        tp_mesh_axis if channel_sharded else None,
+    ]
+    if all(a is None for a in mesh_axes):
+        mesh_axes = None
+    th = tensor.to_torch(t, mesh_axes=mesh_axes, composer_device=mesh_device)
+    return th.permute(0, 3, 1, 2)
+
+
+@pytest.mark.parametrize(
+    "mesh_device",
+    [pytest.param((1, 1), id="1x1")],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "l1_small_size": 65536}],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    ("batch_size", "height", "width"),
+    [(1, 512, 512)],
+    ids=["512"],
+)
+def test_vae_flux2_encoder_components(
+    *,
+    mesh_device: ttnn.Device,
+    batch_size: int,
+    height: int,
+    width: int,
+) -> None:
+    """Per-component PCC test: run the TT encoder stage-by-stage (feeding each stage's output
+    into the next, exactly as forward does) and assert PCC >= 0.99 at every component boundary
+    against the torch reference activations.
+    """
+    torch.manual_seed(0)
+
+    tp_axis, h_axis = _encoder_parallel_axes(mesh_device)
+    w_axis = None
+
+    torch_model = _load_pruned_torch_encoder_model()
+
+    ccl_manager = CCLManager(mesh_device, topology=ttnn.Topology.Linear)
+    vae_parallel_config = Flux2VaeParallelConfig.from_axes(mesh_device, tp_axis=tp_axis, h_axis=h_axis, w_axis=w_axis)
+
+    z_channels = torch_model.config.latent_channels
+    vae_scale_factor = 8
+
+    tt_model = Flux2VaeEncoder(
+        in_channels=torch_model.config.in_channels,
+        block_out_channels=list(torch_model.config.block_out_channels),
+        layers_per_block=_LAYERS_PER_BLOCK,
+        z_channels=z_channels,
+        device=mesh_device,
+        parallel_config=vae_parallel_config,
+        ccl_manager=ccl_manager,
+        use_conv3d=False,
+    )
+    tt_model.load_torch_state_dict(torch_model.state_dict())
+
+    image = torch.randn(batch_size, torch_model.config.in_channels, height, width)
+
+    # --- torch reference activations, stage by stage ---
+    enc = torch_model.encoder
+    torch_stages: dict[str, torch.Tensor] = {}
+    with torch.no_grad():
+        h = enc.conv_in(image)
+        torch_stages["conv_in"] = h
+        for i, down_block in enumerate(enc.down_blocks):
+            h = down_block(h)
+            torch_stages[f"down_block{i}"] = h
+        h = enc.mid_block(h)
+        torch_stages["mid_block"] = h
+        h = enc.conv_norm_out(h)
+        h = enc.conv_act(h)
+        torch_stages["norm_silu"] = h
+        h = enc.conv_out(h)
+        torch_stages["conv_out"] = h
+        q = torch_model.quant_conv(h)
+        torch_stages["quant_conv"] = q
+
+    torch_stages["patchify"] = _torch_encode_reference(torch_model, image)
+
+    # --- TT activations, stage by stage (chained, mirroring forward) ---
+    ctx = tt_model._ctx
+    tp_mesh_axis = ctx.tp_axis
+    h_mesh_axis = ctx.h_mesh_axis
+    tp_size = mesh_device.shape[tp_mesh_axis] if tp_mesh_axis is not None else 1
+
+    up_mesh_axes = [None, h_mesh_axis, None, None] if h_mesh_axis is not None else None
+    tt_image = tensor.from_torch(
+        image.permute(0, 2, 3, 1).contiguous().to(torch.bfloat16),
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_axes=up_mesh_axes,
+    )
+
+    def check(name: str, tt_tensor: ttnn.Tensor, *, channel_sharded: bool, pcc: float = 0.99) -> None:
+        tt_nchw = _gather_nhwc_to_nchw(
+            tt_tensor,
+            mesh_device=mesh_device,
+            h_mesh_axis=h_mesh_axis,
+            tp_mesh_axis=tp_mesh_axis,
+            channel_sharded=channel_sharded,
+        )
+        assert_quality(torch_stages[name], tt_nchw, pcc=pcc)
+
+    x = tt_model.conv_in.forward(tt_image)
+    check("conv_in", x, channel_sharded=True)
+
+    for i, down_block in enumerate(tt_model.down_blocks):
+        x = down_block.forward(x)
+        check(f"down_block{i}", x, channel_sharded=True)
+
+    x = tt_model.mid_block.forward(x)
+    check("mid_block", x, channel_sharded=True)
+
+    x = tt_model.conv_norm_out.forward(x)
+    x = ttnn.silu(x)
+    check("norm_silu", x, channel_sharded=True)
+
+    if ctx.ccl_manager is not None and tp_mesh_axis is not None and tp_size > 1:
+        x = ctx.ccl_manager.all_gather(x, dim=-1, mesh_axis=tp_mesh_axis, use_hyperparams=True)
+    x = tt_model.conv_out.forward(x)
+    check("conv_out", x, channel_sharded=False)
+
+    x = tt_model.quant_conv.forward(x)
+    check("quant_conv", x, channel_sharded=False)
+
+    patchified = tt_model.patchify(x, height=height // vae_scale_factor, width=width // vae_scale_factor)
+    ttnn.synchronize_device(mesh_device)
+    check("patchify", patchified, channel_sharded=False)
+
+
+@pytest.mark.parametrize(
+    "mesh_device",
+    [pytest.param((4, 8), id="4x8")],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "l1_small_size": 65536}],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    ("batch_size", "height", "width"),
+    [(1, 512, 512)],
+    ids=["512"],
+)
+def test_vae_flux2_encoder_perf_4x8(
+    *,
+    mesh_device: ttnn.Device,
+    batch_size: int,
+    height: int,
+    width: int,
+) -> None:
+    """Encoder perf on 4x8: timed ``encode_and_patchify`` only (no per-stage or trace capture)."""
+    torch.manual_seed(0)
+
+    tp_axis, h_axis = _encoder_parallel_axes(mesh_device)
+
+    torch_model = _load_pruned_torch_encoder_model()
+    ccl_manager = CCLManager(mesh_device, topology=ttnn.Topology.Linear)
+    vae_parallel_config = Flux2VaeParallelConfig.from_axes(mesh_device, tp_axis=tp_axis, h_axis=h_axis, w_axis=None)
+
+    tt_model = Flux2VaeEncoder(
+        in_channels=torch_model.config.in_channels,
+        block_out_channels=list(torch_model.config.block_out_channels),
+        layers_per_block=_LAYERS_PER_BLOCK,
+        z_channels=torch_model.config.latent_channels,
+        device=mesh_device,
+        parallel_config=vae_parallel_config,
+        ccl_manager=ccl_manager,
+        use_conv3d=False,
+    )
+    tt_model.load_torch_state_dict(torch_model.state_dict())
+
+    image = torch.randn(batch_size, torch_model.config.in_channels, height, width)
+    enc_height = height // 8
+    enc_width = width // 8
+
+    h_mesh_axis = vae_parallel_config.h_parallel.mesh_axis if vae_parallel_config.h_parallel is not None else None
+    up_mesh_axes = [None, h_mesh_axis, None, None] if h_mesh_axis is not None else None
+
+    tt_image = tensor.from_torch(
+        image.permute(0, 2, 3, 1).contiguous().to(torch.bfloat16),
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_axes=up_mesh_axes,
+    )
+
+    for _ in range(_PERF_WARMUP_RUNS):
+        tt_model.encode_and_patchify(tt_image, height=enc_height, width=enc_width)
+    ttnn.synchronize_device(mesh_device)
+
+    samples: list[float] = []
+    for _ in range(_PERF_NUM_RUNS):
+        t0 = time.perf_counter()
+        tt_model.encode_and_patchify(tt_image, height=enc_height, width=enc_width)
+        ttnn.synchronize_device(mesh_device)
+        samples.append(time.perf_counter() - t0)
+
+    mean_s = statistics.mean(samples)
+    logger.info("=" * 72)
+    logger.info(f"Flux2 VAE encoder perf (4x8 WH galaxy, {height}x{width})")
+    logger.info("-" * 72)
+    logger.info(f"  {'encode_and_patchify':28} | {mean_s * 1e3:9.3f} ms  (mean of {_PERF_NUM_RUNS} runs)")
+    logger.info(f"  {'min':28} | {min(samples) * 1e3:9.3f} ms")
+    logger.info(f"  {'max':28} | {max(samples) * 1e3:9.3f} ms")
+    logger.info("=" * 72)
 
 
 def test_vae_encode_img2img(tt_dit_cache_dir) -> None:

--- a/models/tt_dit/utils/cache.py
+++ b/models/tt_dit/utils/cache.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple
 
@@ -12,7 +13,7 @@ from loguru import logger
 
 import ttnn
 
-from ..layers.module import Module
+from ..layers.module import LoadingError, Module
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -38,6 +39,17 @@ def config_id(parallel_config):
 
 def cache_dir_is_set() -> bool:
     return _cache_root() is not None
+
+
+def _remove_cache_dir(cache_dir: Path) -> None:
+    if not cache_dir.is_dir():
+        return
+    if ttnn.using_distributed_env():
+        if int(ttnn.distributed_context_get_rank()) == 0:
+            shutil.rmtree(cache_dir)
+        ttnn.distributed_context_barrier()
+    else:
+        shutil.rmtree(cache_dir)
 
 
 def load_model(
@@ -102,14 +114,24 @@ def load_model(
 
     if Path(cache_dir).is_dir():
         logger.info(f"loading cache at '{cache_dir}'.")
-        tt_model.load(cache_dir)
-        ttnn.distributed_context_barrier()
-        return
+        try:
+            tt_model.load(cache_dir)
+            ttnn.distributed_context_barrier()
+            return
+        except LoadingError as err:
+            if get_torch_state_dict is None:
+                raise
+            logger.warning(
+                f"Failed to load cache at '{cache_dir}' ({err}). "
+                "Reloading from PyTorch state dict and rewriting cache."
+            )
+            tt_model.deallocate_weights()
 
     if get_torch_state_dict is None:
         raise MissingCacheError(cache_dir)
 
-    logger.info("Cache does not exist. Loading PyTorch state dict.")
+    if not Path(cache_dir).is_dir():
+        logger.info("Cache does not exist. Loading PyTorch state dict.")
     tt_model.load_torch_state_dict(get_torch_state_dict())
 
     # If distributed, ensure that all processes have completed the check whether cache_dir exists,
@@ -117,6 +139,7 @@ def load_model(
     ttnn.distributed_context_barrier()
 
     if create_cache:
+        _remove_cache_dir(cache_dir)
         logger.info(f"Writing cache to '{cache_dir}'.")
         tt_model.save(cache_dir)
 


### PR DESCRIPTION
## What

Adds image-to-image to TT Flux2

### Highlights
- **On-device VAE encode for img2img.** The condition image is encoded, `.mode()`'d, space to depth patchified and batch norm normalized entirely on the mesh via `Flux2VaeEncoder.encode_and_patchify` (`pipeline_flux2.py::_encode_vae_image`). Host <-> device traffic is limited to the image upload and the patchified latent download, the resulting latents are packed and concatenated with the noise latents for denoising
- Adds `strength` (and diffusers-aligned defaults for `num_inference_steps`, `guidance_scale`) and truncates the timestep/sigma schedule by strength, matching the diffusers Flux2 img2img
- `create_pipeline`/`warmup` now accept a `warmup_image` so the persistent `StateTensor` buffers (latents, spatial rope) are preallocated at the combined noise+image sequence length. Without this the text2img warmup sized the buffers for noise only latents and the first traced img2img call failed a copy into existing buffer with a shape mismatch

### Test Results

  Full e2e breakdown (1024×1024, cond 512×512, 50 steps, full pretrained model):
  - on-device VAE encode (img2img): 139.1 ms
  - prompt encode: 177.1 ms
  - denoising: 17.895 s (~95%)
  - VAE decode: 607.6 ms

## Base
`friedrich/flux2` (the shared Flux2 feature branch these commits build on)

### CI Status
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=drohani/flux2_img2img)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:drohani/flux2_img2img)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=drohani/flux2_img2img)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:drohani/flux2_img2img)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=drohani/flux2_img2img)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:drohani/flux2_img2img)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=drohani/flux2_img2img)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:drohani/flux2_img2img)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=drohani/flux2_img2img)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:drohani/flux2_img2img)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=drohani/flux2_img2img)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:drohani/flux2_img2img)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=drohani/flux2_img2img)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:drohani/flux2_img2img)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=drohani/flux2_img2img)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:drohani/flux2_img2img)