### PR TITLE
[cmake] Scope descriptor-patching parity-check definition to the ttnn target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,14 +259,14 @@ endif()
 # Descriptor cache-hit fast-path parity check: on every fast-path hit, rebuild the descriptor and
 # assert the patched runtime args + CB addresses match a full rebuild. A debug/CI regression net for
 # incomplete in-place re-application (SDXL silu / MorehAdamW). OFF by default (per-hit rebuild cost).
+# The check is compiled only in ttnn (mesh_device_operation_adapter.hpp), so the
+# TT_DESCRIPTOR_PATCHING_PARITY_CHECK definition is scoped to the ttnn target in ttnn/CMakeLists.txt
+# rather than applied globally.
 option(
     ENABLE_DESCRIPTOR_PATCHING_PARITY_CHECK
     "Assert descriptor cache-hit fast-path parity against a full rebuild (debug/CI)."
     OFF
 )
-if(ENABLE_DESCRIPTOR_PATCHING_PARITY_CHECK)
-    add_compile_definitions(TT_DESCRIPTOR_PATCHING_PARITY_CHECK)
-endif()
 
 add_library(metal_common_pch STATIC)
 add_library(TT::CommonPCH ALIAS metal_common_pch)

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -96,6 +96,14 @@ add_library(TTNN::Core ALIAS ttnn_core)
 TT_ENABLE_UNITY_BUILD(ttnn_core)
 
 target_compile_definitions(ttnn_core PUBLIC "$<$<CXX_COMPILER_ID:GNU>:DISABLE_NAMESPACE_STATIC_ASSERT>")
+
+# Descriptor cache-hit fast-path parity check (opt-in via -DENABLE_DESCRIPTOR_PATCHING_PARITY_CHECK).
+# The #ifdef lives in ttnn/api/ttnn/mesh_device_operation_adapter.hpp, so scope the definition to the
+# ttnn target (PUBLIC so header consumers see it consistently) instead of defining it globally.
+if(ENABLE_DESCRIPTOR_PATCHING_PARITY_CHECK)
+    target_compile_definitions(ttnn_core PUBLIC TT_DESCRIPTOR_PATCHING_PARITY_CHECK)
+endif()
+
 tt_reuse_precompile_headers(ttnn_core TTNN::PCHFull)
 
 set(TENSOR_FLATBUFFER_SCHEMAS


### PR DESCRIPTION
## Follow-up to #49828 (addresses @blozano-tt review)

#49828 added `ENABLE_DESCRIPTOR_PATCHING_PARITY_CHECK` but applied its `TT_DESCRIPTOR_PATCHING_PARITY_CHECK` definition **globally** via `add_compile_definitions`. The `#ifdef` only lives in ttnn (`ttnn/api/ttnn/mesh_device_operation_adapter.hpp`); the `tt_metal` reference is a doc comment, not a guard. So the definition should be scoped to the ttnn target.

## Change
- Root `CMakeLists.txt`: keep the `option()` (grouped with the other project options), drop the global `add_compile_definitions`.
- `ttnn/CMakeLists.txt`: add `target_compile_definitions(ttnn_core PUBLIC TT_DESCRIPTOR_PATCHING_PARITY_CHECK)` gated on the option (PUBLIC so header consumers see it consistently), mirroring the existing `ttnn_core` definition.

## Verified
`cmake -DENABLE_DESCRIPTOR_PATCHING_PARITY_CHECK=ON` configures clean; in `compile_commands.json` the macro lands on **1117 ttnn TUs and 0 tt_metal TUs** (was global before). Compile-neutral vs. #49828 — the same `#ifdef` code sees the same macro, just scoped.

## Note
Stacked on #49828 (the option only exists there, not on main yet). **Base will be retargeted to `main` once #49828 merges.`

_(Separately, per @afuller-TT: no CI job currently builds with this ON — wiring a gated parity-check CI job is a larger follow-up, not included here.)_

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/parity-check-target-scope)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/parity-check-target-scope)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/parity-check-target-scope)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/parity-check-target-scope)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/parity-check-target-scope)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/parity-check-target-scope)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/parity-check-target-scope)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/parity-check-target-scope)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/parity-check-target-scope)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/parity-check-target-scope)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/parity-check-target-scope)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/parity-check-target-scope)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/parity-check-target-scope)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/parity-check-target-scope)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/parity-check-target-scope)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/parity-check-target-scope)