### PR TITLE
[Cleanup] Provide proper plumbing for custom tile format in ttnn

### DIFF
--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_spec_preservation.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_spec_preservation.cpp
@@ -60,7 +60,7 @@ TEST(HostTensorSpecPreservation, ToLayoutInterleavedRmTileRoundTrip) {
         TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto tile_source = HostTensor::from_vector<float>(data, tile_source_spec);
 
-    auto rm = to_layout(tile_source, Layout::ROW_MAJOR);
+    auto rm = to_row_major_layout(tile_source);
     auto expected_rm_spec =
         TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(rm.tensor_spec(), expected_rm_spec));
@@ -110,7 +110,7 @@ TEST(HostTensorSpecPreservation, ToLayoutShardedPreservesShardSpecAndPackedSizes
         distributed::MeshCoordinate(0, 1), [&]() { return HostBuffer(std::vector<float>(data_1)); });
     auto source = HostTensor::from_buffer(std::move(distributed_buffer), source_spec, topology);
 
-    auto result = to_layout(source, Layout::ROW_MAJOR);
+    auto result = to_row_major_layout(source);
 
     auto expected_spec =
         TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_layout.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_layout.cpp
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Tests for the host-only layout conversion tt::tt_metal::to_layout(const HostTensor&, Layout).
+// Tests for the host-only layout conversion helpers in tt::tt_metal.
 //
 // Group 1 (no sharding): a matrix of {conversion direction} x {dtype}. For each cell, to_layout's
 // output is compared against an INDEPENDENTLY constructed reference tensor built directly in the
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <sstream>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -108,7 +109,7 @@ TEST_P(HostTensorToLayoutMatrix, MatchesFreshConstruction) {
         const auto data = make_ramp<T>(shape.volume());
 
         const auto source = HostTensor::from_vector<T>(data, make_spec(shape, dtype, src));
-        const auto result = to_layout(source, tgt);
+        const auto result = (tgt == Layout::TILE) ? to_tile_layout(source, Tile{}) : to_row_major_layout(source);
         const auto expected = HostTensor::from_vector<T>(data, make_spec(shape, dtype, tgt));
 
         EXPECT_EQ(result.layout(), tgt);
@@ -238,7 +239,7 @@ TEST(HostTensorToLayout, Bfloat8BToRowMajorDoesNotThrow) {
     const auto data = make_ramp<float>(shape.volume());
     const auto source = HostTensor::from_vector<float>(data, make_spec(shape, DataType::BFLOAT8_B, Layout::TILE));
 
-    EXPECT_NO_THROW(std::ignore = to_layout(source, Layout::ROW_MAJOR));
+    EXPECT_NO_THROW(std::ignore = to_row_major_layout(source));
 }
 
 TEST(HostTensorToLayout, Bfloat4BToRowMajorDoesNotThrow) {
@@ -246,7 +247,7 @@ TEST(HostTensorToLayout, Bfloat4BToRowMajorDoesNotThrow) {
     const auto data = make_ramp<float>(shape.volume());
     const auto source = HostTensor::from_vector<float>(data, make_spec(shape, DataType::BFLOAT4_B, Layout::TILE));
 
-    EXPECT_NO_THROW(std::ignore = to_layout(source, Layout::ROW_MAJOR));
+    EXPECT_NO_THROW(std::ignore = to_row_major_layout(source));
 }
 
 // G3: dtypes that cannot be converted to TILE. FP8_E4M3 is constrained to ROW_MAJOR, so tilizing it
@@ -256,8 +257,78 @@ TEST(HostTensorToLayout, Fp8E4m3CannotConvertToTile) {
     const auto data = make_ramp<float>(shape.volume());
     const auto source = HostTensor::from_vector<float>(data, make_spec(shape, DataType::FP8_E4M3, Layout::ROW_MAJOR));
 
-    EXPECT_ANY_THROW(std::ignore = to_layout(source, Layout::TILE));
+    EXPECT_ANY_THROW(std::ignore = to_tile_layout(source, Tile{}));
 }
+
+// ----------------------------------------------------------------------------------------------------
+// Round-trip RM <-> TILE. With padding: logical H/W are not tile-aligned, so padded_shape is larger.
+// ----------------------------------------------------------------------------------------------------
+
+using RoundTripTileParam = std::array<uint32_t, 2>;
+
+std::string round_trip_tile_param_name(const ::testing::TestParamInfo<RoundTripTileParam>& info) {
+    return "Tile" + std::to_string(info.param[0]) + "x" + std::to_string(info.param[1]);
+}
+
+// Default 32x32 plus two custom tiles (see TILE_FACE_HW_CHOICES in tile.cpp).
+const auto k_round_trip_tiles =
+    ::testing::Values(RoundTripTileParam{32, 32}, RoundTripTileParam{16, 32}, RoundTripTileParam{16, 16});
+
+class HostTensorLayoutRoundTripNoPadding : public ::testing::TestWithParam<RoundTripTileParam> {};
+
+TEST_P(HostTensorLayoutRoundTripNoPadding, PreservesData) {
+    const Tile tile{GetParam()};
+    // Tile-aligned logical shape: padded_shape == logical_shape in both layouts.
+    const Shape shape{2 * tile.get_height(), 2 * tile.get_width()};
+    const auto data = make_ramp<float>(shape.volume());
+
+    const auto source = HostTensor::from_vector<float>(data, make_spec(shape, DataType::FLOAT32, Layout::ROW_MAJOR));
+    const auto tiled = to_tile_layout(source, tile);
+    const auto round_tripped = to_row_major_layout(tiled);
+    const auto expected = HostTensor::from_vector<float>(data, make_spec(shape, DataType::FLOAT32, Layout::ROW_MAJOR));
+
+    EXPECT_EQ(tiled.layout(), Layout::TILE);
+    EXPECT_EQ(tiled.tensor_spec().tile(), tile);
+    EXPECT_EQ(tiled.logical_shape(), shape);
+    EXPECT_EQ(tiled.padded_shape(), shape);
+    EXPECT_EQ(round_tripped.layout(), Layout::ROW_MAJOR);
+    EXPECT_EQ(round_tripped.logical_shape(), shape);
+    EXPECT_EQ(round_tripped.padded_shape(), shape);
+    expect_equal_shard_data(round_tripped, expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    HostTensorToLayout, HostTensorLayoutRoundTripNoPadding, k_round_trip_tiles, round_trip_tile_param_name);
+
+class HostTensorLayoutRoundTripWithPadding : public ::testing::TestWithParam<RoundTripTileParam> {};
+
+TEST_P(HostTensorLayoutRoundTripWithPadding, PreservesData) {
+    const Tile tile{GetParam()};
+    // Not tile-aligned: PageConfig(TILE, tile) infers padded_shape > logical_shape. Round-trip
+    // TILE -> RM -> TILE; compare logical data only (pad bytes are not part of the contract).
+    const Shape logical_shape{tile.get_height() - 2, tile.get_width() + 2};
+    const Shape padded_shape{tile.get_height(), 2 * tile.get_width()};
+    const auto data = make_ramp<float>(logical_shape.volume());
+
+    const auto source = HostTensor::from_vector<float>(data, make_tile_spec(logical_shape, DataType::FLOAT32, tile));
+    const auto row_major = to_row_major_layout(source);
+    const auto round_tripped = to_tile_layout(row_major, tile);
+
+    EXPECT_EQ(source.padded_shape(), padded_shape);
+    EXPECT_EQ(row_major.layout(), Layout::ROW_MAJOR);
+    EXPECT_EQ(row_major.logical_shape(), logical_shape);
+    EXPECT_EQ(row_major.padded_shape(), padded_shape);
+    EXPECT_EQ(round_tripped.layout(), Layout::TILE);
+    EXPECT_EQ(round_tripped.tensor_spec().tile(), tile);
+    EXPECT_EQ(round_tripped.logical_shape(), logical_shape);
+    EXPECT_EQ(round_tripped.padded_shape(), padded_shape);
+    EXPECT_EQ(source.to_vector<float>(), data);
+    EXPECT_EQ(row_major.to_vector<float>(), data);
+    EXPECT_EQ(round_tripped.to_vector<float>(), data);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    HostTensorToLayout, HostTensorLayoutRoundTripWithPadding, k_round_trip_tiles, round_trip_tile_param_name);
 
 }  // namespace
 }  // namespace tt::tt_metal

--- a/tests/ttnn/unit_tests/base_functionality/test_to_layout.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_to_layout.py
@@ -1001,6 +1001,86 @@ def test_to_layout_pad_value_default_is_zero(device, shape):
     assert torch.equal(output_default, torch_output_tensor)
 
 
+@pytest.mark.parametrize("tile_shape", [(16, 32), (32, 16), (16, 16)])
+def test_to_layout_custom_tile_host_roundtrip(tile_shape):
+    torch.manual_seed(0)
+    torch_input_tensor = torch.rand((30, 50), dtype=torch.bfloat16)
+    tile = ttnn.Tile(tile_shape)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16)
+    tiled = ttnn.to_layout(input_tensor, ttnn.TILE_LAYOUT, tile=tile)
+
+    assert tiled.layout == ttnn.TILE_LAYOUT
+    assert tiled.tile == tile
+    assert list(tiled.padded_shape)[-2:] == [
+        ((torch_input_tensor.shape[-2] + tile_shape[0] - 1) // tile_shape[0]) * tile_shape[0],
+        ((torch_input_tensor.shape[-1] + tile_shape[1] - 1) // tile_shape[1]) * tile_shape[1],
+    ]
+
+    round_tripped = ttnn.to_layout(tiled, ttnn.ROW_MAJOR_LAYOUT)
+    assert round_tripped.layout == ttnn.ROW_MAJOR_LAYOUT
+    assert_equal(torch_input_tensor, ttnn.to_torch(round_tripped))
+
+
+@pytest.mark.parametrize("tile_shape", [(16, 32), (8, 32), (4, 32), (2, 32)])
+def test_to_layout_custom_tile_on_device_supported(device, tile_shape):
+    """Device to_layout(tile=...) succeeds for #50129-supported tiny tiles (width == 32)."""
+    torch.manual_seed(0)
+    torch_input = torch.rand((32, 64), dtype=torch.bfloat16)
+    tile = ttnn.Tile(list(tile_shape))
+    input_tensor = ttnn.from_torch(
+        torch_input,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        device=device,
+    )
+    tiled = ttnn.to_layout(input_tensor, ttnn.TILE_LAYOUT, tile=tile)
+    assert tiled.layout == ttnn.TILE_LAYOUT
+    assert tiled.tile == tile
+    assert_equal(torch_input, ttnn.to_torch(tiled))
+
+
+@pytest.mark.parametrize("tile_shape", [(32, 16), (16, 16)])
+def test_to_layout_rejects_unsupported_tile_width_on_device(device, expect_error, tile_shape):
+    """tilize requires tile width 32; non-32 widths are rejected on device."""
+    input_tensor = ttnn.from_torch(
+        torch.rand((32, 32), dtype=torch.bfloat16),
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        device=device,
+    )
+    with expect_error(RuntimeError, "tile width"):
+        ttnn.to_layout(input_tensor, ttnn.TILE_LAYOUT, tile=ttnn.Tile(list(tile_shape)))
+
+
+def test_to_layout_rejects_custom_tile_via_padding_path(device, expect_error):
+    """Unaligned shapes go through tilize_with_val_padding, which still rejects custom tiles (#50508)."""
+    input_tensor = ttnn.from_torch(
+        torch.rand((30, 50), dtype=torch.bfloat16),
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        device=device,
+    )
+    with expect_error(RuntimeError, "Custom tile is not supported"):
+        ttnn.to_layout(input_tensor, ttnn.TILE_LAYOUT, tile=ttnn.Tile((16, 32)))
+
+
+def test_to_layout_rejects_tile_kwarg_for_row_major(expect_error):
+    input_tensor = ttnn.from_torch(torch.rand((32, 32), dtype=torch.bfloat16), layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    # Passing tile information to a row major transformation
+    with expect_error(RuntimeError, "tile argument is only supported"):
+        ttnn.to_layout(input_tensor, ttnn.ROW_MAJOR_LAYOUT, tile=ttnn.Tile((16, 16)))
+
+
+def test_to_layout_rejects_transpose_only_tile_mismatch(expect_error):
+    input_tensor = ttnn.from_torch(torch.rand((32, 32), dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT)
+
+    # Same geometry with different tile metadata (transpose) is not a supported retilize.
+    with expect_error(RuntimeError, "cannot convert to tile"):
+        ttnn.to_layout(input_tensor, ttnn.TILE_LAYOUT, tile=ttnn.Tile((32, 32), transpose_tile=True))
+
+
 # ---------------------------------------------------------------------------
 # to_layout on ND-sharded tensors
 #

--- a/tests/ttnn/unit_tests/base_functionality/test_to_layout.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_to_layout.py
@@ -1073,14 +1073,6 @@ def test_to_layout_rejects_tile_kwarg_for_row_major(expect_error):
         ttnn.to_layout(input_tensor, ttnn.ROW_MAJOR_LAYOUT, tile=ttnn.Tile((16, 16)))
 
 
-def test_to_layout_rejects_transpose_only_tile_mismatch(expect_error):
-    input_tensor = ttnn.from_torch(torch.rand((32, 32), dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT)
-
-    # Same geometry with different tile metadata (transpose) is not a supported retilize.
-    with expect_error(RuntimeError, "cannot convert to tile"):
-        ttnn.to_layout(input_tensor, ttnn.TILE_LAYOUT, tile=ttnn.Tile((32, 32), transpose_tile=True))
-
-
 # ---------------------------------------------------------------------------
 # to_layout on ND-sharded tensors
 #

--- a/tests/ttnn/unit_tests/operations/data_movement/test_tilize_with_val_padding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_tilize_with_val_padding.py
@@ -699,3 +699,14 @@ def test_tilize_with_val_padding_tilize_after_avg_pool2d_sum(device, hw, kernel,
     result_flat = y_torch_after_tile.reshape(-1)[: ref_flat.numel()]
 
     assert_with_pcc(ref_flat, result_flat, pcc=0.999)
+
+
+@pytest.mark.parametrize("tile_shape", [(16, 32), (32, 16), (16, 16)])
+def test_tilize_with_val_padding_rejects_custom_tile(device, expect_error, tile_shape):
+    tt_input = ttnn.from_torch(
+        torch.rand((32, 32), dtype=torch.bfloat16),
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+    )
+    with expect_error(RuntimeError, "Custom tile is not supported"):
+        ttnn.tilize_with_val_padding(tt_input, [64, 64], 0.0, tile=ttnn.Tile(tile_shape))

--- a/tests/ttnn/unit_tests/operations/data_movement/test_tilize_with_zero_padding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_tilize_with_zero_padding.py
@@ -42,3 +42,14 @@ def test_tilize_with_zero_padding_test(input_shapes, tilize_with_zero_padding_ar
 
     torch_golden = tilize_with_zero_padding(torch_input)
     assert_equal(torch_golden, torch_output)
+
+
+@pytest.mark.parametrize("tile_shape", [(16, 32), (32, 16), (16, 16)])
+def test_tilize_with_zero_padding_rejects_custom_tile(device, expect_error, tile_shape):
+    tt_input = ttnn.from_torch(
+        torch.rand((32, 32), dtype=torch.bfloat16),
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+    )
+    with expect_error(RuntimeError, "Custom tile is not supported"):
+        ttnn.tilize_with_zero_padding(tt_input, tile=ttnn.Tile(tile_shape))

--- a/tt_metal/api/tt-metalium/experimental/tensor/tensor_apis.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/tensor_apis.hpp
@@ -122,7 +122,6 @@ std::vector<distributed::MeshCoordinate> enqueue_write_tensor(
 //                                  .to_layout()
 // ======================================================================================
 
-HostTensor to_layout(const HostTensor& tensor, Layout target_layout);
 HostTensor to_tile_layout(const HostTensor& tensor, const Tile& tile);
 HostTensor to_row_major_layout(const HostTensor& tensor);
 

--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -608,6 +608,11 @@ HostTensor to_row_major_layout_impl(const HostTensor& tensor) {
 template <typename T>
 HostTensor to_tile_layout_impl(const HostTensor& tensor, Tile tile) {
     if (tensor.layout() == Layout::TILE) {
+        TT_FATAL(
+            tensor.tensor_spec().tile() == tile,
+            "Cannot reinterpret TILE tensor with tile {} as requested tile {}",
+            tensor.tensor_spec().tile(),
+            tile);
         return tensor;
     }
 
@@ -689,14 +694,6 @@ HostTensor to_tile_layout(const HostTensor& tensor, const Tile& tile) {
             return CMAKE_UNIQUE_NAMESPACE::to_tile_layout_impl<T>(tensor, tile);
         }
     });
-}
-
-HostTensor to_layout(const HostTensor& tensor, Layout target_layout) {
-    switch (target_layout) {
-        case Layout::ROW_MAJOR: return to_row_major_layout(tensor);
-        case Layout::TILE: return to_tile_layout(tensor, tensor.tensor_spec().tile());
-        default: TT_THROW("Target layout {} is not supported", target_layout);
-    }
 }
 
 // ======================================================================================

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -150,7 +150,8 @@ public:
         ttsl::optional_reference<const tt::tt_metal::MemoryConfig> mem_config = std::nullopt,
         std::optional<tt::tt_metal::QueueId> cq_id = std::nullopt) const;
 
-    [[nodiscard]] Tensor to_layout(tt::tt_metal::Layout target_layout) const;
+    [[nodiscard]] Tensor to_layout(
+        tt::tt_metal::Layout target_layout, std::optional<tt::tt_metal::Tile> tile = std::nullopt) const;
 
     [[nodiscard]] Tensor pad(
         const tt::tt_metal::Shape& output_padded_shape,

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -151,7 +151,8 @@ public:
         std::optional<tt::tt_metal::QueueId> cq_id = std::nullopt) const;
 
     [[nodiscard]] Tensor to_layout(
-        tt::tt_metal::Layout target_layout, std::optional<tt::tt_metal::Tile> tile = std::nullopt) const;
+        tt::tt_metal::Layout target_layout,
+        ttsl::optional_reference<const tt::tt_metal::Tile> tile = std::nullopt) const;
 
     [[nodiscard]] Tensor pad(
         const tt::tt_metal::Shape& output_padded_shape,

--- a/ttnn/api/ttnn/tensor/tensor_ops.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_ops.hpp
@@ -7,6 +7,7 @@
 
 #include "ttnn/common/queue_id.hpp"
 #include "ttnn/tensor/layout/layout.hpp"
+#include <tt-metalium/tile.hpp>
 #include <tt_stl/optional_reference.hpp>
 #include <ttnn/distributed/tensor_topology.hpp>
 #include "ttnn/tensor/tensor_spec.hpp"
@@ -95,7 +96,8 @@ ttnn::Tensor to_device(
     ttsl::optional_reference<const MemoryConfig> mem_config = std::nullopt,
     std::optional<QueueId> cq_id = std::nullopt);
 
-ttnn::Tensor to_layout(const ttnn::Tensor& input_tensor, Layout target_layout);
+ttnn::Tensor to_layout(
+    const ttnn::Tensor& input_tensor, Layout target_layout, std::optional<Tile> tile = std::nullopt);
 
 ttnn::Tensor view(const ttnn::Tensor& input_tensor, const Shape& new_shape);
 ttnn::Tensor view(const ttnn::Tensor& input_tensor, const Shape& new_logical_shape, const Shape& new_padded_shape);

--- a/ttnn/api/ttnn/tensor/tensor_ops.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_ops.hpp
@@ -97,7 +97,7 @@ ttnn::Tensor to_device(
     std::optional<QueueId> cq_id = std::nullopt);
 
 ttnn::Tensor to_layout(
-    const ttnn::Tensor& input_tensor, Layout target_layout, std::optional<Tile> tile = std::nullopt);
+    const ttnn::Tensor& input_tensor, Layout target_layout, ttsl::optional_reference<const Tile> tile = std::nullopt);
 
 ttnn::Tensor view(const ttnn::Tensor& input_tensor, const Shape& new_shape);
 ttnn::Tensor view(const ttnn::Tensor& input_tensor, const Shape& new_logical_shape, const Shape& new_padded_shape);

--- a/ttnn/core/tensor/py_to_tt_tensor.cpp
+++ b/ttnn/core/tensor/py_to_tt_tensor.cpp
@@ -74,9 +74,7 @@ bool can_construct_on_device(
                !preserve_nan_values;
 
     if (optional_tile.has_value()) {
-        // on-device tiling operation expects tiles to be divisible by 32x32.
-        res &= ((optional_tile->get_width() % tt::constants::TILE_WIDTH) == 0) &&
-               ((optional_tile->get_height() % tt::constants::TILE_HEIGHT) == 0);
+        res &= (*optional_tile == Tile{});
     }
 
     return res;
@@ -448,8 +446,8 @@ Tensor convert_python_tensor_to_tt_tensor(
 
     auto set_layout = [&](Layout target) {
         if (output.layout() != target) {
-            output =
-                ttnn::to_layout(output, target, std::nullopt, memory_config, std::nullopt, pad_value.value_or(0.0f));
+            output = ttnn::to_layout(
+                output, target, std::nullopt, memory_config, std::nullopt, pad_value.value_or(0.0f), optional_tile);
         }
     };
 

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -338,7 +338,7 @@ Tensor Tensor::extract_shard(const CoreCoord& core) const {
 
 Tensor Tensor::extract_shard(const uint32_t& core_id) const { return tensor_impl::extract_shard(*this, core_id); }
 
-Tensor Tensor::to_layout(Layout target_layout, std::optional<Tile> tile) const {
+Tensor Tensor::to_layout(Layout target_layout, ttsl::optional_reference<const Tile> tile) const {
     return tt::tt_metal::to_layout(*this, target_layout, tile);
 }
 

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -338,7 +338,9 @@ Tensor Tensor::extract_shard(const CoreCoord& core) const {
 
 Tensor Tensor::extract_shard(const uint32_t& core_id) const { return tensor_impl::extract_shard(*this, core_id); }
 
-Tensor Tensor::to_layout(Layout target_layout) const { return tt::tt_metal::to_layout(*this, target_layout); }
+Tensor Tensor::to_layout(Layout target_layout, std::optional<Tile> tile) const {
+    return tt::tt_metal::to_layout(*this, target_layout, tile);
+}
 
 std::string Tensor::write_to_string() const { return tensor_impl::to_string(*this); }
 

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -142,10 +142,19 @@ Tensor to_device(
     return device_tensor;
 }
 
-Tensor to_layout(const Tensor& input_tensor, Layout target_layout) {
-    GraphTracker::instance().track_function_start("Tensor::to_layout", input_tensor, target_layout);
+Tensor to_layout(const Tensor& input_tensor, Layout target_layout, std::optional<Tile> tile) {
+    GraphTracker::instance().track_function_start("Tensor::to_layout", input_tensor, target_layout, tile);
     TT_FATAL(is_cpu_tensor(input_tensor), "Tensor must be on host for to_layout conversion");
-    HostTensor host_output = ::tt::tt_metal::to_layout(input_tensor.host_tensor(), target_layout);
+    TT_FATAL(
+        target_layout != Layout::ROW_MAJOR || !tile.has_value(),
+        "Tensor::to_layout: tile argument is only supported when converting to TILE layout");
+    HostTensor host_output = [&] {
+        switch (target_layout) {
+            case Layout::ROW_MAJOR: return ::tt::tt_metal::to_row_major_layout(input_tensor.host_tensor());
+            case Layout::TILE: return ::tt::tt_metal::to_tile_layout(input_tensor.host_tensor(), tile.value_or(Tile{}));
+            default: TT_THROW("Target layout {} is not supported", target_layout);
+        }
+    }();
     Tensor output = Tensor(std::move(host_output));
     output = ttnn::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -142,7 +142,7 @@ Tensor to_device(
     return device_tensor;
 }
 
-Tensor to_layout(const Tensor& input_tensor, Layout target_layout, std::optional<Tile> tile) {
+Tensor to_layout(const Tensor& input_tensor, Layout target_layout, ttsl::optional_reference<const Tile> tile) {
     GraphTracker::instance().track_function_start("Tensor::to_layout", input_tensor, target_layout, tile);
     TT_FATAL(is_cpu_tensor(input_tensor), "Tensor must be on host for to_layout conversion");
     TT_FATAL(
@@ -151,7 +151,8 @@ Tensor to_layout(const Tensor& input_tensor, Layout target_layout, std::optional
     HostTensor host_output = [&] {
         switch (target_layout) {
             case Layout::ROW_MAJOR: return ::tt::tt_metal::to_row_major_layout(input_tensor.host_tensor());
-            case Layout::TILE: return ::tt::tt_metal::to_tile_layout(input_tensor.host_tensor(), tile.value_or(Tile{}));
+            case Layout::TILE:
+                return ::tt::tt_metal::to_tile_layout(input_tensor.host_tensor(), tile.has_value() ? *tile : Tile{});
             default: TT_THROW("Target layout {} is not supported", target_layout);
         }
     }();

--- a/ttnn/cpp/ttnn-nanobind/operations/core.cpp
+++ b/ttnn/cpp/ttnn-nanobind/operations/core.cpp
@@ -429,9 +429,9 @@ void py_module(nb::module_& mod) {
         Organizes the `ttnn.Tensor` tensor into either `ttnn.ROW_MAJOR_LAYOUT` or `ttnn.TILE_LAYOUT`.
 
         When requesting `ttnn.ROW_MAJOR_LAYOUT`, the tensor will be returned unpadded in the last two dimensions.
-        When requesting `ttnn.TILE_LAYOUT`, the tensor will be automatically padded where the width and height
-        become multiples of 32. In the case where the layout is the same, the operation simply pads or unpads
-        the last two dimensions depending on the requested layout.
+        When requesting `ttnn.TILE_LAYOUT`, the tensor will be padded to the requested tile shape. In the case where
+        the layout is the same, the operation simply pads or unpads the last two dimensions depending on the requested
+        layout.
 
         Args:
             tensor (ttnn.Tensor): the input tensor to be organized.
@@ -440,6 +440,8 @@ void py_module(nb::module_& mod) {
             memory_config (ttnn.MemoryConfig, optional): the optional output memory configuration.
             sub_core_grids (ttnn.CoreRangeSet, optional): the optional sub core grids. Defaults to `None`.
             pad_value (float, optional): the optional pad value. Defaults to `0.0f`.
+            tile (ttnn.Tile, optional): explicit tile metadata for TILE conversions, including
+                non-32x32 tiles. Defaults to `None`.
 
         Returns:
             ttnn.Tensor: the tensor with the requested layout.
@@ -450,7 +452,9 @@ void py_module(nb::module_& mod) {
         nb::arg("dtype") = nb::none(),
         nb::arg("memory_config") = nb::none(),
         nb::arg("sub_core_grids") = nb::none(),
-        nb::arg("pad_value") = 0.0f);
+        nb::arg("pad_value") = 0.0f,
+        nb::kw_only(),
+        nb::arg("tile") = nb::none());
 
     mod.def(
         "num_cores_to_corerangeset",

--- a/ttnn/cpp/ttnn-nanobind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/pytensor.cpp
@@ -907,6 +907,10 @@ void pytensor_module(nb::module_& mod) {
             .. code-block:: python
 
                 tt_tensor = tt_tensor.to(ttnn.Layout.TILE)
+
+            Note:
+                This method always uses the default tile. Use ``ttnn.to_layout(tensor, layout, tile=...)``
+                when you need a custom tile.
         )doc")
         .def(
             "pad",

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -23,7 +23,9 @@ namespace ttnn::operations::core::CMAKE_UNIQUE_NAMESPACE {
 namespace {
 
 void validate_tile_semantics(
-    const ttnn::Tensor& tensor, ttnn::Layout layout, const std::optional<tt::tt_metal::Tile>& requested_tile) {
+    const ttnn::Tensor& tensor,
+    ttnn::Layout layout,
+    ttsl::optional_reference<const tt::tt_metal::Tile> requested_tile) {
     if (layout == Layout::ROW_MAJOR) {
         TT_FATAL(
             !requested_tile.has_value(),
@@ -128,12 +130,12 @@ Tensor to_tile_layout_impl(
     const std::optional<ttnn::MemoryConfig>& memory_config,
     const std::optional<CoreRangeSet>& sub_core_grids,
     const float pad_value,
-    const std::optional<tt::tt_metal::Tile>& tile) {
+    ttsl::optional_reference<const tt::tt_metal::Tile> tile) {
     auto tensor = tensor_arg;
     const auto& output_shape = tensor_arg.logical_shape();
     auto output_memory_config =
         memory_config.value_or(ttnn::get_memory_config(tensor).value_or(ttnn::DRAM_MEMORY_CONFIG));
-    const auto target_tile = tile.value_or(tt::tt_metal::Tile{});
+    const auto target_tile = tile.has_value() ? *tile : tt::tt_metal::Tile{};
 
     // Padded shape only (dtype-independent). Use TensorLayout, not a TensorSpec: TensorSpec rejects
     // FP8_E4M3 + TILE (fp8 is ROW_MAJOR-only) though fp8 is a valid tilize input; the real output dtype
@@ -264,7 +266,7 @@ Tensor to_layout_impl(
     const std::optional<ttnn::MemoryConfig>& memory_config,
     const std::optional<CoreRangeSet>& sub_core_grids,
     const float pad_value,
-    const std::optional<tt::tt_metal::Tile>& tile) {
+    ttsl::optional_reference<const tt::tt_metal::Tile> tile) {
     validate_tile_semantics(tensor_arg, layout, tile);
 
     const bool needs_retile = layout == ttnn::TILE_LAYOUT && tile.has_value() &&
@@ -309,7 +311,7 @@ Tensor to_layout(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<CoreRangeSet>& sub_core_grids,
     const float pad_value,
-    const std::optional<tt::tt_metal::Tile>& tile) {
+    ttsl::optional_reference<const tt::tt_metal::Tile> tile) {
     return operations::core::CMAKE_UNIQUE_NAMESPACE::to_layout_impl(
         tensor_arg, layout, dtype, memory_config, sub_core_grids, pad_value, tile);
 }

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -24,6 +24,17 @@
 namespace ttnn::operations::core::CMAKE_UNIQUE_NAMESPACE {
 namespace {
 
+tt::tt_metal::Tile resolve_effective_tile(
+    const ttnn::Tensor& tensor,
+    ttnn::Layout layout,
+    ttsl::optional_reference<const tt::tt_metal::Tile> requested_tile) {
+    TT_FATAL(layout == Layout::TILE, "Effective tile is only defined for TILE conversions");
+    if (tensor.layout() == Layout::TILE) {
+        return requested_tile.has_value() ? *requested_tile : tensor.tensor_spec().tile();
+    }
+    return requested_tile.has_value() ? *requested_tile : tt::tt_metal::Tile{};
+}
+
 void validate_tile_semantics(
     const ttnn::Tensor& tensor,
     ttnn::Layout layout,
@@ -51,9 +62,13 @@ void validate_tile_semantics(
     }
 }
 
-bool requires_padding_change_to_tile(const ttnn::Tensor& tensor, const tt::tt_metal::Tile& target_tile) {
+bool requires_padding_change(const ttnn::Tensor& tensor, ttnn::Layout layout, const tt::tt_metal::Tile& target_tile) {
+    if (layout == Layout::ROW_MAJOR) {
+        // There shouldn't be extra paddings for Row Major layout
+        return tensor.logical_shape() != tensor.padded_shape();
+    }
     // It's okay for conversion to tile layout to preserve arbitrary padding as long as it satisfies the alignment
-    tt::tt_metal::PageConfig page_config(Layout::TILE, target_tile);
+    tt::tt_metal::PageConfig page_config = tt::tt_metal::PageConfig(layout, target_tile);
 
     // Padded shape only (dtype-independent). Use TensorLayout, not a TensorSpec: TensorSpec rejects
     // FP8_E4M3 + TILE (fp8 is ROW_MAJOR-only) though fp8 is a valid tilize input.
@@ -74,193 +89,6 @@ constexpr std::string_view kRowMajorDtypeErrorMessage =
     "dtype cannot be different from tensor dtype when converting to ROW_MAJOR_LAYOUT on device "
     "(allowed exception: BFLOAT8_B -> BFLOAT16, which untilize handles natively)!";
 
-Tensor to_row_major_layout_impl(
-    const ttnn::Tensor& tensor_arg,
-    const std::optional<ttnn::DataType>& dtype,
-    const std::optional<ttnn::MemoryConfig>& memory_config,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
-    auto tensor = tensor_arg;
-
-    if (ttnn::is_device_tensor(tensor_arg)) {
-        constexpr bool use_multicore_untilize = true;
-        TT_FATAL(is_allowed_row_major_dtype(tensor_arg.dtype(), dtype), "{}", kRowMajorDtypeErrorMessage);
-
-        auto output_memory_config =
-            memory_config.value_or(ttnn::get_memory_config(tensor).value_or(ttnn::DRAM_MEMORY_CONFIG));
-
-        // No extra paddings
-        if (tensor.logical_shape() == tensor.padded_shape()) {
-            return ttnn::untilize(tensor, output_memory_config, use_multicore_untilize, sub_core_grids);
-        }
-
-        // Handle device tensor with padding
-        if (tensor.is_sharded()) {
-            output_memory_config =
-                memory_config.value_or(ttnn::get_memory_config(tensor).value_or(ttnn::DRAM_MEMORY_CONFIG));
-        }
-        Shape output_tensor_end(ttsl::SmallVector<uint32_t>(tensor.logical_shape().rank(), 0));
-        int logical_rank = tensor.logical_shape().rank();
-        for (int index = -1; index >= -logical_rank; --index) {
-            output_tensor_end[index] = tensor.logical_shape()[index] - 1;
-        }
-        return ttnn::untilize_with_unpadding(
-            tensor, output_tensor_end, output_memory_config, use_multicore_untilize, sub_core_grids);
-    }
-
-    // Handle to_row_major layout on host
-    TT_ASSERT(!dtype.has_value(), "dtype cannot be specified when converting layout on host!");
-
-    // No extra paddings
-    if (tensor.logical_shape() == tensor.padded_shape()) {
-        return tensor.to_layout(Layout::ROW_MAJOR);
-    }
-
-    tensor = tensor.to_layout(Layout::ROW_MAJOR);
-    tensor = tensor.unpad_from_tile(tensor.logical_shape());
-    return ttnn::reshape(
-        tensor,
-        tensor.logical_shape(),
-        std::nullopt, /*Memory Config*/
-        std::nullopt, /*Pad Value*/
-        TileReshapeMapMode::CACHE,
-        sub_core_grids);
-}
-
-Tensor to_tile_layout_impl(
-    const ttnn::Tensor& tensor_arg,
-    const std::optional<ttnn::DataType>& dtype,
-    const std::optional<ttnn::MemoryConfig>& memory_config,
-    const std::optional<CoreRangeSet>& sub_core_grids,
-    const float pad_value,
-    ttsl::optional_reference<const tt::tt_metal::Tile> tile) {
-    auto tensor = tensor_arg;
-    const auto& output_shape = tensor_arg.logical_shape();
-    auto output_memory_config =
-        memory_config.value_or(ttnn::get_memory_config(tensor).value_or(ttnn::DRAM_MEMORY_CONFIG));
-    const auto target_tile = tile.has_value() ? *tile : tt::tt_metal::Tile{};
-
-    // Padded shape only (dtype-independent). Use TensorLayout, not a TensorSpec: TensorSpec rejects
-    // FP8_E4M3 + TILE (fp8 is ROW_MAJOR-only) though fp8 is a valid tilize input; the real output dtype
-    // flows through `dtype` into tilize()/untilize() below.
-    const auto padded_output_shape =
-        tt::tt_metal::TensorLayout(
-            tensor_arg.dtype(), tt::tt_metal::PageConfig(Layout::TILE, target_tile), output_memory_config)
-            .compute_padded_shape(tensor_arg.logical_shape());
-    const auto original_rank = tensor_arg.logical_shape().rank();
-    const auto& original_shape = tensor_arg.logical_shape();
-
-    if (tensor.padded_shape().size() < 2) {
-        TT_FATAL(
-            !tensor.is_sharded(),
-            "ttnn::to_layout: Cannot convert a sharded device tensor with rank {} to TILE_LAYOUT. "
-            "Tilize requires shard dimensions divisible by tile size, but rank promotion to 2D "
-            "produces a shard height of 1. Move to interleaved first, then tilize.",
-            tensor.padded_shape().size());
-        const bool is_scalar = tensor.padded_shape().size() == 0;
-        ttsl::SmallVector<uint32_t> new_padded_shape =
-            is_scalar ? ttsl::SmallVector<uint32_t>{1, 1} : ttsl::SmallVector<uint32_t>{1, tensor.padded_shape()[-1]};
-        tensor = ttnn::experimental::view(tensor, tensor.logical_shape(), Shape(new_padded_shape));
-    }
-
-    if (ttnn::is_device_tensor(tensor_arg)) {
-        constexpr bool use_multicore_tilize = true;
-
-        if (not requires_padding_change_to_tile(tensor, target_tile)) {
-            if (tensor.is_sharded()) {
-                uint32_t tile_height = target_tile.get_height();
-                uint32_t tile_width = target_tile.get_width();
-                const auto mem_config = get_memory_config(tensor).value();
-                uint32_t shard_h, shard_w;
-                if (mem_config.shard_spec().has_value()) {
-                    shard_h = mem_config.shard_spec().value().shape[0];
-                    shard_w = mem_config.shard_spec().value().shape[1];
-                } else {
-                    const auto& nd_spec = mem_config.nd_shard_spec().value();
-                    shard_h = nd_spec.shard_shape[-2];
-                    shard_w = nd_spec.shard_shape[-1];
-                }
-                if (shard_h % tile_height != 0 or shard_w % tile_width != 0) {
-                    TT_THROW(
-                        "ttnn::to_layout: Sharded tensor must have shard shape that is a multiple of "
-                        "TILE_SIZE!");
-                }
-            }
-            return ttnn::tilize(
-                tensor,
-                output_memory_config,
-                dtype,
-                use_multicore_tilize,
-                false /* low perf mode */,
-                target_tile,
-                sub_core_grids);
-        }
-
-        if (tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
-            // ttnn::tilize_with_val_padding doesn't support height sharded tensors
-            // workaround by applying padding and then tilizing
-            ttsl::SmallVector<std::array<uint32_t, 2>> padding = {
-                {0, 0},
-                {0, 0},
-                {0, padded_output_shape[2] - output_shape[2]},
-                {0, padded_output_shape[3] - output_shape[3]}};
-            TT_FATAL(!sub_core_grids.has_value(), "Pad OP does not currently support sub core grid");
-            tensor = ttnn::pad(tensor, padding, pad_value, true, std::nullopt);
-            return ttnn::tilize(
-                tensor, output_memory_config, dtype, use_multicore_tilize, false, target_tile, std::nullopt);
-        }
-
-        PadValue pad_value_variant;
-        if (tensor.dtype() == ttnn::DataType::BFLOAT16 or tensor.dtype() == ttnn::DataType::FLOAT32) {
-            pad_value_variant = pad_value;
-        } else if (tensor.dtype() == ttnn::DataType::INT32) {
-            TT_FATAL(
-                pad_value >= static_cast<float>(std::numeric_limits<int32_t>::min()) &&
-                    pad_value < static_cast<float>(std::numeric_limits<int32_t>::max()),
-                "Pad value must be in the range of INT32 type");
-            // static_cast safely truncates the float into a signed integer,
-            // while std::bit_cast reinterprets those exact bits as unsigned to cleanly handle negative
-            // wrap-arounds.
-            pad_value_variant = std::bit_cast<uint32_t>(static_cast<int32_t>(pad_value));
-        } else {
-            TT_FATAL(
-                pad_value >= 0.0f && pad_value < static_cast<float>(std::numeric_limits<uint32_t>::max()),
-                "Pad value must be in the range of UINT32 type");
-            pad_value_variant = (uint32_t)pad_value;
-        }
-        tensor = ttnn::tilize_with_val_padding(
-            tensor,
-            Shape(padded_output_shape),
-            pad_value_variant,
-            output_memory_config,
-            dtype,
-            use_multicore_tilize,
-            sub_core_grids,
-            target_tile);
-
-        if (original_rank < 2) {
-            return ttnn::reshape(
-                tensor,
-                original_shape,
-                std::nullopt /*Memory Config*/,
-                std::nullopt /*pad value*/,
-                TileReshapeMapMode::CACHE,
-                sub_core_grids);
-        }
-        return tensor;
-    }
-
-    TT_ASSERT(!dtype.has_value(), "dtype cannot be specified when converting layout on host!");
-
-    if (!requires_padding_change_to_tile(tensor, target_tile)) {
-        return tensor.to_layout(Layout::TILE, target_tile);
-    }
-
-    ttsl::SmallVector<uint32_t> padded_input_start(padded_output_shape.rank(), 0);
-    tensor = tensor.pad(ttnn::Shape(padded_output_shape), ttnn::Shape(std::move(padded_input_start)), pad_value);
-    tensor = tensor.to_layout(Layout::TILE, target_tile);
-    return ttnn::experimental::view(tensor, output_shape, padded_output_shape);
-}
-
 Tensor to_layout_impl(
     const ttnn::Tensor& tensor_arg,
     const ttnn::Layout layout,
@@ -272,8 +100,8 @@ Tensor to_layout_impl(
     validate_tile_semantics(tensor_arg, layout, tile);
 
     const bool needs_retile = layout == ttnn::TILE_LAYOUT && tile.has_value() &&
-                               tensor_arg.layout() == ttnn::TILE_LAYOUT &&
-                               tensor_arg.tensor_spec().tile() != tile.value();
+                              tensor_arg.layout() == ttnn::TILE_LAYOUT &&
+                              tensor_arg.tensor_spec().tile() != tile.value();
     if (tensor_arg.layout() == layout && !needs_retile) {
         if (dtype.has_value() and dtype.value() != tensor_arg.dtype()) {
             log_warning(
@@ -292,14 +120,187 @@ Tensor to_layout_impl(
         return tensor_arg;
     }
 
-    switch (layout) {
-        case ttnn::ROW_MAJOR_LAYOUT: return to_row_major_layout_impl(tensor_arg, dtype, memory_config, sub_core_grids);
-        case ttnn::TILE_LAYOUT:
-            return to_tile_layout_impl(tensor_arg, dtype, memory_config, sub_core_grids, pad_value, tile);
-        default: TT_THROW("ttnn::to_layout: Unsupported layout conversion from {} to {}!", tensor_arg.layout(), layout);
-    }
-}
+    const std::set<ttnn::Layout> supported_layouts = {
+        ttnn::ROW_MAJOR_LAYOUT,
+        ttnn::TILE_LAYOUT,
+    };
 
+    if (!supported_layouts.contains(layout)) {
+        TT_THROW("ttnn::to_layout: Unsupported layout conversion from {} to {}!", tensor_arg.layout(), layout);
+    }
+
+    auto tensor = tensor_arg;
+    auto output_shape = tensor_arg.logical_shape();
+    auto output_memory_config =
+        memory_config.value_or(ttnn::get_memory_config(tensor).value_or(ttnn::DRAM_MEMORY_CONFIG));
+
+    const auto effective_tile =
+        layout == Layout::TILE ? resolve_effective_tile(tensor_arg, layout, tile) : tt::tt_metal::Tile{};
+    tt::tt_metal::PageConfig page_config = tt::tt_metal::PageConfig(Layout::TILE, effective_tile);
+    // Padded shape only (dtype-independent). Use TensorLayout, not a TensorSpec: TensorSpec rejects
+    // FP8_E4M3 + TILE (fp8 is ROW_MAJOR-only) though fp8 is a valid tilize input; the real output dtype
+    // flows through `dtype` into tilize()/untilize() below.
+    auto padded_output_shape = tt::tt_metal::TensorLayout(tensor_arg.dtype(), page_config, output_memory_config)
+                                   .compute_padded_shape(tensor_arg.logical_shape());
+    auto original_rank = tensor_arg.logical_shape().rank();
+    const auto& original_shape = tensor_arg.logical_shape();
+
+    if (layout == ttnn::TILE_LAYOUT) {
+        if (tensor.padded_shape().size() < 2) {
+            TT_FATAL(
+                !tensor.is_sharded(),
+                "ttnn::to_layout: Cannot convert a sharded device tensor with rank {} to TILE_LAYOUT. "
+                "Tilize requires shard dimensions divisible by tile size, but rank promotion to 2D "
+                "produces a shard height of 1. Move to interleaved first, then tilize.",
+                tensor.padded_shape().size());
+            const bool is_scalar = tensor.padded_shape().size() == 0;
+            ttsl::SmallVector<uint32_t> new_padded_shape =
+                is_scalar ? ttsl::SmallVector<uint32_t>{1, 1}
+                          : ttsl::SmallVector<uint32_t>{1, tensor.padded_shape()[-1]};
+            tensor = ttnn::experimental::view(tensor, tensor.logical_shape(), Shape(new_padded_shape));
+        }
+    }
+
+    if (ttnn::is_device_tensor(tensor_arg)) {
+        bool use_multicore_untilize = true;
+        bool use_multicore_tilize = true;
+        const bool converting_to_row_major = layout == ttnn::ROW_MAJOR_LAYOUT;
+        const bool converting_to_tile = layout == ttnn::TILE_LAYOUT;
+
+        if (converting_to_row_major) {
+            TT_FATAL(is_allowed_row_major_dtype(tensor_arg.dtype(), dtype), "{}", kRowMajorDtypeErrorMessage);
+        }
+
+        if (not requires_padding_change(tensor, layout, effective_tile)) {
+            if (converting_to_row_major) {
+                return ttnn::untilize(tensor, output_memory_config, use_multicore_untilize, sub_core_grids);
+            }
+            if (converting_to_tile) {
+                if (tensor.is_sharded()) {
+                    uint32_t tile_height = effective_tile.get_height();
+                    uint32_t tile_width = effective_tile.get_width();
+                    const auto mem_config = get_memory_config(tensor).value();
+                    uint32_t shard_h, shard_w;
+                    if (mem_config.shard_spec().has_value()) {
+                        shard_h = mem_config.shard_spec().value().shape[0];
+                        shard_w = mem_config.shard_spec().value().shape[1];
+                    } else {
+                        const auto& nd_spec = mem_config.nd_shard_spec().value();
+                        shard_h = nd_spec.shard_shape[-2];
+                        shard_w = nd_spec.shard_shape[-1];
+                    }
+                    if (shard_h % tile_height != 0 or shard_w % tile_width != 0) {
+                        TT_THROW(
+                            "ttnn::to_layout: Sharded tensor must have shard shape that is a multiple of "
+                            "TILE_SIZE!");
+                    }
+                }
+                return ttnn::tilize(
+                    tensor,
+                    output_memory_config,
+                    dtype,
+                    use_multicore_tilize,
+                    false /* low perf mode */,
+                    effective_tile,
+                    sub_core_grids);
+            }
+            throw std::runtime_error("ttnn::to_layout: Unsupported layout!");
+        }
+        if (converting_to_row_major) {
+            if (tensor.is_sharded()) {
+                output_memory_config =
+                    memory_config.value_or(ttnn::get_memory_config(tensor).value_or(ttnn::DRAM_MEMORY_CONFIG));
+            }
+            Shape output_tensor_end(ttsl::SmallVector<uint32_t>(tensor.logical_shape().rank(), 0));
+            int logical_rank = tensor.logical_shape().rank();
+            for (int index = -1; index >= -logical_rank; --index) {
+                output_tensor_end[index] = tensor.logical_shape()[index] - 1;
+            }
+            return ttnn::untilize_with_unpadding(
+                tensor, output_tensor_end, output_memory_config, use_multicore_untilize, sub_core_grids);
+        }
+        if (converting_to_tile) {
+            if (tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
+                // ttnn::tilize_with_val_padding doesn't support height sharded tensors
+                // workaround by applying padding and then tilizing
+                ttsl::SmallVector<std::array<uint32_t, 2>> padding = {
+                    {0, 0},
+                    {0, 0},
+                    {0, padded_output_shape[2] - output_shape[2]},
+                    {0, padded_output_shape[3] - output_shape[3]}};
+                TT_FATAL(!sub_core_grids.has_value(), "Pad OP does not currently support sub core grid");
+                tensor = ttnn::pad(tensor, padding, pad_value, true, std::nullopt);
+                return ttnn::tilize(
+                    tensor, output_memory_config, dtype, use_multicore_tilize, false, effective_tile, std::nullopt);
+            } else {
+                PadValue pad_value_variant;
+                if (tensor.dtype() == ttnn::DataType::BFLOAT16 or tensor.dtype() == ttnn::DataType::FLOAT32) {
+                    pad_value_variant = pad_value;
+                } else if (tensor.dtype() == ttnn::DataType::INT32) {
+                    TT_FATAL(
+                        pad_value >= static_cast<float>(std::numeric_limits<int32_t>::min()) &&
+                            pad_value < static_cast<float>(std::numeric_limits<int32_t>::max()),
+                        "Pad value must be in the range of INT32 type");
+                    // static_cast safely truncates the float into a signed integer,
+                    // while std::bit_cast reinterprets those exact bits as unsigned to cleanly handle negative
+                    // wrap-arounds.
+                    pad_value_variant = std::bit_cast<uint32_t>(static_cast<int32_t>(pad_value));
+                } else {
+                    TT_FATAL(
+                        pad_value >= 0.0f && pad_value < static_cast<float>(std::numeric_limits<uint32_t>::max()),
+                        "Pad value must be in the range of UINT32 type");
+                    pad_value_variant = (uint32_t)pad_value;
+                }
+                tensor = ttnn::tilize_with_val_padding(
+                    tensor,
+                    Shape(padded_output_shape),
+                    pad_value_variant,
+                    output_memory_config,
+                    dtype,
+                    use_multicore_tilize,
+                    sub_core_grids,
+                    effective_tile);
+            }
+            if (original_rank < 2) {
+                return ttnn::reshape(
+                    tensor,
+                    original_shape,
+                    std::nullopt /*Memory Config*/,
+                    std::nullopt /*pad value*/,
+                    TileReshapeMapMode::CACHE,
+                    sub_core_grids);
+            }
+            return tensor;
+        }
+        TT_THROW("ttnn::to_layout: Unsupported output layout: {}!", layout);
+    }
+    TT_ASSERT(!dtype.has_value(), "dtype cannot be specified when converting layout on host!");
+    if (!requires_padding_change(tensor, layout, effective_tile)) {
+        return tensor.to_layout(
+            layout, layout == ttnn::TILE_LAYOUT ? std::make_optional(effective_tile) : std::nullopt);
+    }
+    if (layout == ttnn::ROW_MAJOR_LAYOUT) {
+        tensor = tensor.to_layout(layout);
+        tensor = tensor.unpad_from_tile(tensor.logical_shape());
+        return ttnn::reshape(
+            tensor,
+            ttnn::Shape{output_shape},
+            std::nullopt, /*Memory Config*/
+            std::nullopt, /*Pad Value*/
+            TileReshapeMapMode::CACHE,
+            sub_core_grids);
+    }
+    if (layout == ttnn::TILE_LAYOUT) {
+        ttsl::SmallVector<uint32_t> padded_input_start;
+        for (int index = 0; index < padded_output_shape.rank(); ++index) {
+            padded_input_start.push_back(0);
+        }
+        tensor = tensor.pad(ttnn::Shape(padded_output_shape), ttnn::Shape(std::move(padded_input_start)), pad_value);
+        tensor = tensor.to_layout(layout, effective_tile);
+        return ttnn::experimental::view(tensor, output_shape, padded_output_shape);
+    }
+    TT_THROW("ttnn::to_layout: Unsupported output layout: {}!", layout);
+}
 }  // namespace
 
 }  // namespace ttnn::operations::core::CMAKE_UNIQUE_NAMESPACE

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -8,6 +8,8 @@
 #include <limits>
 #include <string_view>
 
+#include <tt_stl/reflection.hpp>
+
 #include "ttnn/distributed/types.hpp"
 #include "ttnn/operations/data_movement/pad/pad.hpp"
 #include "ttnn/operations/data_movement/tilize/tilize.hpp"

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -22,19 +22,37 @@
 namespace ttnn::operations::core::CMAKE_UNIQUE_NAMESPACE {
 namespace {
 
-bool requires_padding_change(const ttnn::Tensor& tensor, ttnn::Layout layout) {
+void validate_tile_semantics(
+    const ttnn::Tensor& tensor, ttnn::Layout layout, const std::optional<tt::tt_metal::Tile>& requested_tile) {
     if (layout == Layout::ROW_MAJOR) {
-        // There shouldn't be extra paddings for Row Major layout
-        return tensor.logical_shape() != tensor.padded_shape();
-    }
-    // It's okay for conversion to tile layout to preserve arbitrary padding as long as it satisfies the alignment
-    tt::tt_metal::PageConfig page_config = tt::tt_metal::PageConfig(layout);
-    if (tensor.layout() == Layout::TILE) {
-        page_config = tt::tt_metal::PageConfig(layout, tensor.tensor_spec().tile());
+        TT_FATAL(
+            !requested_tile.has_value(),
+            "ttnn::to_layout: tile argument is only supported when converting to TILE_LAYOUT");
+        return;
     }
 
-    // Padded shape only (dtype-independent). Use TensorLayout, not a tt::tt_metal::TensorSpec: tt::tt_metal::TensorSpec
-    // rejects FP8_E4M3 + TILE (fp8 is ROW_MAJOR-only) though fp8 is a valid tilize input.
+    // Retile (#50129) can change tile height/width. Metadata-only differences (e.g. transpose_tile)
+    // with the same geometry are not a supported retilize conversion.
+    if (layout == Layout::TILE && tensor.layout() == Layout::TILE && requested_tile.has_value()) {
+        const auto& current = tensor.tensor_spec().tile();
+        const auto& requested = requested_tile.value();
+        if (current != requested && current.get_width() == requested.get_width() &&
+            current.get_height() == requested.get_height()) {
+            TT_FATAL(
+                false,
+                "ttnn::to_layout: TILE tensor already uses tile {}, cannot convert to tile {} without retilize",
+                current,
+                requested);
+        }
+    }
+}
+
+bool requires_padding_change_to_tile(const ttnn::Tensor& tensor, const tt::tt_metal::Tile& target_tile) {
+    // It's okay for conversion to tile layout to preserve arbitrary padding as long as it satisfies the alignment
+    tt::tt_metal::PageConfig page_config(Layout::TILE, target_tile);
+
+    // Padded shape only (dtype-independent). Use TensorLayout, not a TensorSpec: TensorSpec rejects
+    // FP8_E4M3 + TILE (fp8 is ROW_MAJOR-only) though fp8 is a valid tilize input.
     const auto padded_shape = tt::tt_metal::TensorLayout(tensor.dtype(), page_config, tensor.memory_config())
                                   .compute_padded_shape(tensor.padded_shape());
     return tensor.padded_shape() != padded_shape;
@@ -52,14 +70,207 @@ constexpr std::string_view kRowMajorDtypeErrorMessage =
     "dtype cannot be different from tensor dtype when converting to ROW_MAJOR_LAYOUT on device "
     "(allowed exception: BFLOAT8_B -> BFLOAT16, which untilize handles natively)!";
 
+Tensor to_row_major_layout_impl(
+    const ttnn::Tensor& tensor_arg,
+    const std::optional<ttnn::DataType>& dtype,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
+    auto tensor = tensor_arg;
+
+    if (ttnn::is_device_tensor(tensor_arg)) {
+        constexpr bool use_multicore_untilize = true;
+        TT_FATAL(is_allowed_row_major_dtype(tensor_arg.dtype(), dtype), "{}", kRowMajorDtypeErrorMessage);
+
+        auto output_memory_config =
+            memory_config.value_or(ttnn::get_memory_config(tensor).value_or(ttnn::DRAM_MEMORY_CONFIG));
+
+        // No extra paddings
+        if (tensor.logical_shape() == tensor.padded_shape()) {
+            return ttnn::untilize(tensor, output_memory_config, use_multicore_untilize, sub_core_grids);
+        }
+
+        // Handle device tensor with padding
+        if (tensor.is_sharded()) {
+            output_memory_config =
+                memory_config.value_or(ttnn::get_memory_config(tensor).value_or(ttnn::DRAM_MEMORY_CONFIG));
+        }
+        Shape output_tensor_end(ttsl::SmallVector<uint32_t>(tensor.logical_shape().rank(), 0));
+        int logical_rank = tensor.logical_shape().rank();
+        for (int index = -1; index >= -logical_rank; --index) {
+            output_tensor_end[index] = tensor.logical_shape()[index] - 1;
+        }
+        return ttnn::untilize_with_unpadding(
+            tensor, output_tensor_end, output_memory_config, use_multicore_untilize, sub_core_grids);
+    }
+
+    // Handle to_row_major layout on host
+    TT_ASSERT(!dtype.has_value(), "dtype cannot be specified when converting layout on host!");
+
+    // No extra paddings
+    if (tensor.logical_shape() == tensor.padded_shape()) {
+        return tensor.to_layout(Layout::ROW_MAJOR);
+    }
+
+    tensor = tensor.to_layout(Layout::ROW_MAJOR);
+    tensor = tensor.unpad_from_tile(tensor.logical_shape());
+    return ttnn::reshape(
+        tensor,
+        tensor.logical_shape(),
+        std::nullopt, /*Memory Config*/
+        std::nullopt, /*Pad Value*/
+        TileReshapeMapMode::CACHE,
+        sub_core_grids);
+}
+
+Tensor to_tile_layout_impl(
+    const ttnn::Tensor& tensor_arg,
+    const std::optional<ttnn::DataType>& dtype,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const float pad_value,
+    const std::optional<tt::tt_metal::Tile>& tile) {
+    auto tensor = tensor_arg;
+    const auto& output_shape = tensor_arg.logical_shape();
+    auto output_memory_config =
+        memory_config.value_or(ttnn::get_memory_config(tensor).value_or(ttnn::DRAM_MEMORY_CONFIG));
+    const auto target_tile = tile.value_or(tt::tt_metal::Tile{});
+
+    // Padded shape only (dtype-independent). Use TensorLayout, not a TensorSpec: TensorSpec rejects
+    // FP8_E4M3 + TILE (fp8 is ROW_MAJOR-only) though fp8 is a valid tilize input; the real output dtype
+    // flows through `dtype` into tilize()/untilize() below.
+    const auto padded_output_shape =
+        tt::tt_metal::TensorLayout(
+            tensor_arg.dtype(), tt::tt_metal::PageConfig(Layout::TILE, target_tile), output_memory_config)
+            .compute_padded_shape(tensor_arg.logical_shape());
+    const auto original_rank = tensor_arg.logical_shape().rank();
+    const auto& original_shape = tensor_arg.logical_shape();
+
+    if (tensor.padded_shape().size() < 2) {
+        TT_FATAL(
+            !tensor.is_sharded(),
+            "ttnn::to_layout: Cannot convert a sharded device tensor with rank {} to TILE_LAYOUT. "
+            "Tilize requires shard dimensions divisible by tile size, but rank promotion to 2D "
+            "produces a shard height of 1. Move to interleaved first, then tilize.",
+            tensor.padded_shape().size());
+        const bool is_scalar = tensor.padded_shape().size() == 0;
+        ttsl::SmallVector<uint32_t> new_padded_shape =
+            is_scalar ? ttsl::SmallVector<uint32_t>{1, 1} : ttsl::SmallVector<uint32_t>{1, tensor.padded_shape()[-1]};
+        tensor = ttnn::experimental::view(tensor, tensor.logical_shape(), Shape(new_padded_shape));
+    }
+
+    if (ttnn::is_device_tensor(tensor_arg)) {
+        constexpr bool use_multicore_tilize = true;
+
+        if (not requires_padding_change_to_tile(tensor, target_tile)) {
+            if (tensor.is_sharded()) {
+                uint32_t tile_height = target_tile.get_height();
+                uint32_t tile_width = target_tile.get_width();
+                const auto mem_config = get_memory_config(tensor).value();
+                uint32_t shard_h, shard_w;
+                if (mem_config.shard_spec().has_value()) {
+                    shard_h = mem_config.shard_spec().value().shape[0];
+                    shard_w = mem_config.shard_spec().value().shape[1];
+                } else {
+                    const auto& nd_spec = mem_config.nd_shard_spec().value();
+                    shard_h = nd_spec.shard_shape[-2];
+                    shard_w = nd_spec.shard_shape[-1];
+                }
+                if (shard_h % tile_height != 0 or shard_w % tile_width != 0) {
+                    TT_THROW(
+                        "ttnn::to_layout: Sharded tensor must have shard shape that is a multiple of "
+                        "TILE_SIZE!");
+                }
+            }
+            return ttnn::tilize(
+                tensor,
+                output_memory_config,
+                dtype,
+                use_multicore_tilize,
+                false /* low perf mode */,
+                target_tile,
+                sub_core_grids);
+        }
+
+        if (tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
+            // ttnn::tilize_with_val_padding doesn't support height sharded tensors
+            // workaround by applying padding and then tilizing
+            ttsl::SmallVector<std::array<uint32_t, 2>> padding = {
+                {0, 0},
+                {0, 0},
+                {0, padded_output_shape[2] - output_shape[2]},
+                {0, padded_output_shape[3] - output_shape[3]}};
+            TT_FATAL(!sub_core_grids.has_value(), "Pad OP does not currently support sub core grid");
+            tensor = ttnn::pad(tensor, padding, pad_value, true, std::nullopt);
+            return ttnn::tilize(
+                tensor, output_memory_config, dtype, use_multicore_tilize, false, target_tile, std::nullopt);
+        }
+
+        PadValue pad_value_variant;
+        if (tensor.dtype() == ttnn::DataType::BFLOAT16 or tensor.dtype() == ttnn::DataType::FLOAT32) {
+            pad_value_variant = pad_value;
+        } else if (tensor.dtype() == ttnn::DataType::INT32) {
+            TT_FATAL(
+                pad_value >= static_cast<float>(std::numeric_limits<int32_t>::min()) &&
+                    pad_value < static_cast<float>(std::numeric_limits<int32_t>::max()),
+                "Pad value must be in the range of INT32 type");
+            // static_cast safely truncates the float into a signed integer,
+            // while std::bit_cast reinterprets those exact bits as unsigned to cleanly handle negative
+            // wrap-arounds.
+            pad_value_variant = std::bit_cast<uint32_t>(static_cast<int32_t>(pad_value));
+        } else {
+            TT_FATAL(
+                pad_value >= 0.0f && pad_value < static_cast<float>(std::numeric_limits<uint32_t>::max()),
+                "Pad value must be in the range of UINT32 type");
+            pad_value_variant = (uint32_t)pad_value;
+        }
+        tensor = ttnn::tilize_with_val_padding(
+            tensor,
+            Shape(padded_output_shape),
+            pad_value_variant,
+            output_memory_config,
+            dtype,
+            use_multicore_tilize,
+            sub_core_grids,
+            target_tile);
+
+        if (original_rank < 2) {
+            return ttnn::reshape(
+                tensor,
+                original_shape,
+                std::nullopt /*Memory Config*/,
+                std::nullopt /*pad value*/,
+                TileReshapeMapMode::CACHE,
+                sub_core_grids);
+        }
+        return tensor;
+    }
+
+    TT_ASSERT(!dtype.has_value(), "dtype cannot be specified when converting layout on host!");
+
+    if (!requires_padding_change_to_tile(tensor, target_tile)) {
+        return tensor.to_layout(Layout::TILE, target_tile);
+    }
+
+    ttsl::SmallVector<uint32_t> padded_input_start(padded_output_shape.rank(), 0);
+    tensor = tensor.pad(ttnn::Shape(padded_output_shape), ttnn::Shape(std::move(padded_input_start)), pad_value);
+    tensor = tensor.to_layout(Layout::TILE, target_tile);
+    return ttnn::experimental::view(tensor, output_shape, padded_output_shape);
+}
+
 Tensor to_layout_impl(
     const ttnn::Tensor& tensor_arg,
     const ttnn::Layout layout,
     const std::optional<ttnn::DataType>& dtype,
     const std::optional<ttnn::MemoryConfig>& memory_config,
     const std::optional<CoreRangeSet>& sub_core_grids,
-    const float pad_value) {
-    if (tensor_arg.layout() == layout) {
+    const float pad_value,
+    const std::optional<tt::tt_metal::Tile>& tile) {
+    validate_tile_semantics(tensor_arg, layout, tile);
+
+    const bool needs_retile = layout == ttnn::TILE_LAYOUT && tile.has_value() &&
+                               tensor_arg.layout() == ttnn::TILE_LAYOUT &&
+                               tensor_arg.tensor_spec().tile() != tile.value();
+    if (tensor_arg.layout() == layout && !needs_retile) {
         if (dtype.has_value() and dtype.value() != tensor_arg.dtype()) {
             log_warning(
                 tt::LogOp,
@@ -77,186 +288,14 @@ Tensor to_layout_impl(
         return tensor_arg;
     }
 
-    const std::set<ttnn::Layout> supported_layouts = {
-        ttnn::ROW_MAJOR_LAYOUT,
-        ttnn::TILE_LAYOUT,
-    };
-
-    if (!supported_layouts.contains(layout)) {
-        TT_THROW("ttnn::to_layout: Unsupported layout conversion from {} to {}!", tensor_arg.layout(), layout);
+    switch (layout) {
+        case ttnn::ROW_MAJOR_LAYOUT: return to_row_major_layout_impl(tensor_arg, dtype, memory_config, sub_core_grids);
+        case ttnn::TILE_LAYOUT:
+            return to_tile_layout_impl(tensor_arg, dtype, memory_config, sub_core_grids, pad_value, tile);
+        default: TT_THROW("ttnn::to_layout: Unsupported layout conversion from {} to {}!", tensor_arg.layout(), layout);
     }
-
-    auto tensor = tensor_arg;
-    auto output_shape = tensor_arg.logical_shape();
-    auto output_memory_config =
-        memory_config.value_or(ttnn::get_memory_config(tensor).value_or(ttnn::DRAM_MEMORY_CONFIG));
-
-    tt::tt_metal::PageConfig page_config = tt::tt_metal::PageConfig(Layout::TILE);
-    if (tensor_arg.layout() == Layout::TILE) {
-        page_config = tt::tt_metal::PageConfig(Layout::TILE, tensor_arg.tensor_spec().tile());
-    }
-    // Padded shape only (dtype-independent). Use TensorLayout, not a tt::tt_metal::TensorSpec: tt::tt_metal::TensorSpec
-    // rejects FP8_E4M3 + TILE (fp8 is ROW_MAJOR-only) though fp8 is a valid tilize input; the real output dtype flows
-    // through `dtype` into tilize()/untilize() below.
-    auto padded_output_shape = tt::tt_metal::TensorLayout(tensor_arg.dtype(), page_config, output_memory_config)
-                                   .compute_padded_shape(tensor_arg.logical_shape());
-    auto original_rank = tensor_arg.logical_shape().rank();
-    const auto& original_shape = tensor_arg.logical_shape();
-
-    if (layout == ttnn::TILE_LAYOUT) {
-        if (tensor.padded_shape().size() < 2) {
-            TT_FATAL(
-                !tensor.is_sharded(),
-                "ttnn::to_layout: Cannot convert a sharded device tensor with rank {} to TILE_LAYOUT. "
-                "Tilize requires shard dimensions divisible by tile size, but rank promotion to 2D "
-                "produces a shard height of 1. Move to interleaved first, then tilize.",
-                tensor.padded_shape().size());
-            const bool is_scalar = tensor.padded_shape().size() == 0;
-            ttsl::SmallVector<uint32_t> new_padded_shape =
-                is_scalar ? ttsl::SmallVector<uint32_t>{1, 1}
-                          : ttsl::SmallVector<uint32_t>{1, tensor.padded_shape()[-1]};
-            tensor = ttnn::experimental::view(tensor, tensor.logical_shape(), Shape(new_padded_shape));
-        }
-    }
-
-    if (ttnn::is_device_tensor(tensor_arg)) {
-        bool use_multicore_untilize = true;
-        bool use_multicore_tilize = true;
-
-        if (not requires_padding_change(tensor, layout)) {
-            if (layout == ttnn::ROW_MAJOR_LAYOUT) {
-                TT_FATAL(is_allowed_row_major_dtype(tensor_arg.dtype(), dtype), "{}", kRowMajorDtypeErrorMessage);
-                return ttnn::untilize(tensor, output_memory_config, use_multicore_untilize, sub_core_grids);
-            }
-            tt::tt_metal::Tile tensor_tile = tt::tt_metal::Tile();
-            if (layout == ttnn::TILE_LAYOUT) {
-                if (tensor.is_sharded()) {
-                    if (tensor.layout() == ttnn::TILE_LAYOUT) {
-                        tensor_tile = tensor.tensor_spec().tile();
-                    }
-                    uint32_t tile_height = tensor_tile.get_height();
-                    uint32_t tile_width = tensor_tile.get_width();
-                    const auto mem_config = get_memory_config(tensor).value();
-                    uint32_t shard_h, shard_w;
-                    if (mem_config.shard_spec().has_value()) {
-                        shard_h = mem_config.shard_spec().value().shape[0];
-                        shard_w = mem_config.shard_spec().value().shape[1];
-                    } else {
-                        const auto& nd_spec = mem_config.nd_shard_spec().value();
-                        shard_h = nd_spec.shard_shape[-2];
-                        shard_w = nd_spec.shard_shape[-1];
-                    }
-                    if (shard_h % tile_height != 0 or shard_w % tile_width != 0) {
-                        TT_THROW(
-                            "ttnn::to_layout: Sharded tensor must have shard shape that is a multiple of "
-                            "TILE_SIZE!");
-                    }
-                }
-                return ttnn::tilize(
-                    tensor,
-                    output_memory_config,
-                    dtype,
-                    use_multicore_tilize,
-                    false /* low perf mode */,
-                    tensor_tile,
-                    sub_core_grids);
-            }
-            throw std::runtime_error("ttnn::to_layout: Unsupported layout!");
-        }
-        if (layout == ttnn::ROW_MAJOR_LAYOUT) {
-            TT_FATAL(is_allowed_row_major_dtype(tensor_arg.dtype(), dtype), "{}", kRowMajorDtypeErrorMessage);
-
-            if (tensor.is_sharded()) {
-                output_memory_config =
-                    memory_config.value_or(ttnn::get_memory_config(tensor).value_or(ttnn::DRAM_MEMORY_CONFIG));
-            }
-            Shape output_tensor_end(ttsl::SmallVector<uint32_t>(tensor.logical_shape().rank(), 0));
-            int logical_rank = tensor.logical_shape().rank();
-            for (int index = -1; index >= -logical_rank; --index) {
-                output_tensor_end[index] = tensor.logical_shape()[index] - 1;
-            }
-            return ttnn::untilize_with_unpadding(
-                tensor, output_tensor_end, output_memory_config, use_multicore_untilize, sub_core_grids);
-        }
-        if (layout == ttnn::TILE_LAYOUT) {
-            if (tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
-                // ttnn::tilize_with_val_padding doesn't support height sharded tensors
-                // workaround by applying padding and then tilizing
-                ttsl::SmallVector<std::array<uint32_t, 2>> padding = {
-                    {0, 0},
-                    {0, 0},
-                    {0, padded_output_shape[2] - output_shape[2]},
-                    {0, padded_output_shape[3] - output_shape[3]}};
-                TT_FATAL(!sub_core_grids.has_value(), "Pad OP does not currently support sub core grid");
-                tensor = ttnn::pad(tensor, padding, pad_value, true, std::nullopt);
-                return ttnn::tilize(tensor, output_memory_config, dtype, use_multicore_tilize);
-            } else {
-                PadValue pad_value_variant;
-                if (tensor.dtype() == ttnn::DataType::BFLOAT16 or tensor.dtype() == ttnn::DataType::FLOAT32) {
-                    pad_value_variant = pad_value;
-                } else if (tensor.dtype() == ttnn::DataType::INT32) {
-                    TT_FATAL(
-                        pad_value >= static_cast<float>(std::numeric_limits<int32_t>::min()) &&
-                            pad_value < static_cast<float>(std::numeric_limits<int32_t>::max()),
-                        "Pad value must be in the range of INT32 type");
-                    // static_cast safely truncates the float into a signed integer,
-                    // while std::bit_cast reinterprets those exact bits as unsigned to cleanly handle negative
-                    // wrap-arounds.
-                    pad_value_variant = std::bit_cast<uint32_t>(static_cast<int32_t>(pad_value));
-                } else {
-                    TT_FATAL(
-                        pad_value >= 0.0f && pad_value < static_cast<float>(std::numeric_limits<uint32_t>::max()),
-                        "Pad value must be in the range of UINT32 type");
-                    pad_value_variant = (uint32_t)pad_value;
-                }
-                tensor = ttnn::tilize_with_val_padding(
-                    tensor,
-                    Shape(padded_output_shape),
-                    pad_value_variant,
-                    output_memory_config,
-                    dtype,
-                    use_multicore_tilize,
-                    sub_core_grids);
-            }
-            if (original_rank < 2) {
-                return ttnn::reshape(
-                    tensor,
-                    original_shape,
-                    std::nullopt /*Memory Config*/,
-                    std::nullopt /*pad value*/,
-                    TileReshapeMapMode::CACHE,
-                    sub_core_grids);
-            }
-            return tensor;
-        }
-        TT_THROW("ttnn::to_layout: Unsupported output layout: {}!", layout);
-    }
-    TT_ASSERT(!dtype.has_value(), "dtype cannot be specified when converting layout on host!");
-    if (!requires_padding_change(tensor, layout)) {
-        return tensor.to_layout(layout);
-    }
-    if (layout == ttnn::ROW_MAJOR_LAYOUT) {
-        tensor = tensor.to_layout(layout);
-        tensor = tensor.unpad_from_tile(tensor.logical_shape());
-        return ttnn::reshape(
-            tensor,
-            ttnn::Shape{output_shape},
-            std::nullopt, /*Memory Config*/
-            std::nullopt, /*Pad Value*/
-            TileReshapeMapMode::CACHE,
-            sub_core_grids);
-    }
-    if (layout == ttnn::TILE_LAYOUT) {
-        ttsl::SmallVector<uint32_t> padded_input_start;
-        for (int index = 0; index < padded_output_shape.rank(); ++index) {
-            padded_input_start.push_back(0);
-        }
-        tensor = tensor.pad(ttnn::Shape(padded_output_shape), ttnn::Shape(std::move(padded_input_start)), pad_value);
-        tensor = tensor.to_layout(layout);
-        return ttnn::experimental::view(tensor, output_shape, padded_output_shape);
-    }
-    TT_THROW("ttnn::to_layout: Unsupported output layout: {}!", layout);
 }
+
 }  // namespace
 
 }  // namespace ttnn::operations::core::CMAKE_UNIQUE_NAMESPACE
@@ -269,9 +308,10 @@ Tensor to_layout(
     const std::optional<DataType>& dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<CoreRangeSet>& sub_core_grids,
-    const float pad_value) {
+    const float pad_value,
+    const std::optional<tt::tt_metal::Tile>& tile) {
     return operations::core::CMAKE_UNIQUE_NAMESPACE::to_layout_impl(
-        tensor_arg, layout, dtype, memory_config, sub_core_grids, pad_value);
+        tensor_arg, layout, dtype, memory_config, sub_core_grids, pad_value, tile);
 }
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.hpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.hpp
@@ -23,6 +23,7 @@ Tensor to_layout(
     const std::optional<DataType>& dtype = std::nullopt,
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
-    float pad_value = 0.0f);
+    float pad_value = 0.0f,
+    const std::optional<tt::tt_metal::Tile>& tile = std::nullopt);
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.hpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.hpp
@@ -7,6 +7,7 @@
 #include <functional>
 #include <optional>
 
+#include <tt_stl/optional_reference.hpp>
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/host_buffer/functions.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
@@ -24,6 +25,6 @@ Tensor to_layout(
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
     float pad_value = 0.0f,
-    const std::optional<tt::tt_metal::Tile>& tile = std::nullopt);
+    ttsl::optional_reference<const tt::tt_metal::Tile> tile = std::nullopt);
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
@@ -125,14 +125,14 @@ void TilizeWithValPaddingDeviceOperation::validate_on_program_cache_miss(
         }
     }
 
-    uint32_t num_rows = operation_attributes.output_padded_shape[-1];
-    uint32_t inner_dim = operation_attributes.output_padded_shape[-2];
+    const uint32_t height = operation_attributes.output_padded_shape[-2];
+    const uint32_t width = operation_attributes.output_padded_shape[-1];
     TT_FATAL(
-        inner_dim % TILE_WIDTH == 0 && num_rows % TILE_HEIGHT == 0,
+        height % TILE_HEIGHT == 0 && width % TILE_WIDTH == 0,
         "To be tilizable output tensor shape {} must be divisible by tile size ({}, {})",
         operation_attributes.output_padded_shape,
-        TILE_WIDTH,
-        TILE_HEIGHT);
+        TILE_HEIGHT,
+        TILE_WIDTH);
 
     const uint32_t alignment_requirement = hal::get_l1_alignment();
     if (input_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED ||

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.cpp
@@ -70,7 +70,7 @@ ttnn::Tensor tilize_with_val_padding(
     std::optional<DataType> output_dtype,
     bool use_multicore,
     const std::optional<CoreRangeSet>& sub_core_grids,
-    tt::tt_metal::Tile tile) {
+    const tt::tt_metal::Tile& tile) {
     if (input_tensor.layout() == Layout::TILE) {
         TT_FATAL(
             input_tensor.tensor_spec().tile() == tile,
@@ -142,7 +142,7 @@ ttnn::Tensor tilize_with_val_padding(
     std::optional<DataType> output_dtype,
     bool use_multicore,
     const std::optional<CoreRangeSet>& sub_core_grids,
-    tt::tt_metal::Tile tile) {
+    const tt::tt_metal::Tile& tile) {
     TT_FATAL(
         tile == tt::tt_metal::Tile{},
         "Custom tile is not supported for tilize_with_val_padding (See: #50508). Please transfer the tensor to host "
@@ -178,7 +178,7 @@ ttnn::Tensor tilize_with_zero_padding(
     std::optional<DataType> output_dtype,
     bool use_multicore,
     const std::optional<CoreRangeSet>& sub_core_grids,
-    tt::tt_metal::Tile tile) {
+    const tt::tt_metal::Tile& tile) {
     using namespace tt::constants;
     if (input_tensor.layout() == Layout::TILE) {
         TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.cpp
@@ -69,10 +69,28 @@ ttnn::Tensor tilize_with_val_padding(
     const std::optional<MemoryConfig>& memory_config,
     std::optional<DataType> output_dtype,
     bool use_multicore,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    tt::tt_metal::Tile tile) {
     if (input_tensor.layout() == Layout::TILE) {
+        TT_FATAL(
+            input_tensor.tensor_spec().tile() == tile,
+            "ttnn::tilize_with_val_padding: TILE tensor already uses tile {}, cannot reinterpret as {}",
+            input_tensor.tensor_spec().tile(),
+            tile);
+        TT_FATAL(
+            !memory_config.has_value() || memory_config.value() == input_tensor.memory_config(),
+            "ttnn::tilize_with_val_padding: cannot silently drop requested memory_config on already-TILE input");
+        TT_FATAL(
+            !output_dtype.has_value() || output_dtype.value() == input_tensor.dtype(),
+            "ttnn::tilize_with_val_padding: cannot silently drop requested dtype on already-TILE input");
         return input_tensor;
     }
+
+    TT_FATAL(
+        tile == tt::tt_metal::Tile{},
+        "Custom tile is not supported for tilize_with_val_padding (See: #50508). Please transfer the tensor to host "
+        "and "
+        "use `tt::tt_metal::to_tile_layout(HostTensor, Tile)` instead.");
 
     // Handle empty tensors - no tiling needed for tensors with no data
     if (input_tensor.physical_volume() == 0) {
@@ -81,7 +99,7 @@ ttnn::Tensor tilize_with_val_padding(
             output_padded_shape,
             TensorLayout(
                 output_dtype.value_or(input_tensor.dtype()),
-                PageConfig(Layout::TILE),
+                PageConfig(Layout::TILE, tile),
                 memory_config.value_or(input_tensor.memory_config())));
         return create_device_tensor(spec, input_tensor.device());
     }
@@ -92,8 +110,8 @@ ttnn::Tensor tilize_with_val_padding(
         output_dtype.has_value() ? tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(output_dtype.value()))
                                  : input_single_tile_size;
 
-    uint32_t num_tiles_per_row = output_padded_shape[-1] / tt::constants::TILE_WIDTH;
-    uint32_t num_tiles_per_col = output_padded_shape[-2] / tt::constants::TILE_HEIGHT;
+    uint32_t num_tiles_per_row = output_padded_shape[-1] / tile.get_width();
+    uint32_t num_tiles_per_col = output_padded_shape[-2] / tile.get_height();
 
     bool enough_space_width = operations::data_movement::is_enough_space(
         input_tensor, input_single_tile_size, output_single_tile_size, num_tiles_per_col);
@@ -123,7 +141,14 @@ ttnn::Tensor tilize_with_val_padding(
     const std::optional<MemoryConfig>& memory_config,
     std::optional<DataType> output_dtype,
     bool use_multicore,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    tt::tt_metal::Tile tile) {
+    TT_FATAL(
+        tile == tt::tt_metal::Tile{},
+        "Custom tile is not supported for tilize_with_val_padding (See: #50508). Please transfer the tensor to host "
+        "and "
+        "use `tt::tt_metal::to_tile_layout(HostTensor, Tile)` instead.");
+
     // Handle empty tensors - no tiling needed for tensors with no data
     if (input_tensor.physical_volume() == 0) {
         // Create output tensor with same properties
@@ -131,7 +156,7 @@ ttnn::Tensor tilize_with_val_padding(
             ttnn::Shape{output_padded_shape},
             TensorLayout(
                 output_dtype.value_or(input_tensor.dtype()),
-                PageConfig(Layout::TILE),
+                PageConfig(Layout::TILE, tile),
                 memory_config.value_or(input_tensor.memory_config())));
         return create_device_tensor(spec, input_tensor.device());
     }
@@ -143,7 +168,8 @@ ttnn::Tensor tilize_with_val_padding(
         memory_config,
         output_dtype,
         use_multicore,
-        sub_core_grids);
+        sub_core_grids,
+        tile);
 }
 
 ttnn::Tensor tilize_with_zero_padding(
@@ -151,17 +177,34 @@ ttnn::Tensor tilize_with_zero_padding(
     const std::optional<MemoryConfig>& memory_config,
     std::optional<DataType> output_dtype,
     bool use_multicore,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    tt::tt_metal::Tile tile) {
     using namespace tt::constants;
+    if (input_tensor.layout() == Layout::TILE) {
+        TT_FATAL(
+            input_tensor.tensor_spec().tile() == tile,
+            "ttnn::tilize_with_zero_padding: TILE tensor already uses tile {}, cannot reinterpret as {}",
+            input_tensor.tensor_spec().tile(),
+            tile);
+        TT_FATAL(
+            !memory_config.has_value() || memory_config.value() == input_tensor.memory_config(),
+            "ttnn::tilize_with_zero_padding: cannot silently drop requested memory_config on already-TILE input");
+        TT_FATAL(
+            !output_dtype.has_value() || output_dtype.value() == input_tensor.dtype(),
+            "ttnn::tilize_with_zero_padding: cannot silently drop requested dtype on already-TILE input");
+        return input_tensor;
+    }
+
+    TT_FATAL(
+        tile == tt::tt_metal::Tile{},
+        "Custom tile is not supported for tilize_with_zero_padding (See: #50508). Please transfer the tensor to host "
+        "and "
+        "use `tt::tt_metal::to_tile_layout(HostTensor, Tile)` instead.");
+
     auto padded_shape = input_tensor.padded_shape();
 
-    tt::tt_metal::Tile tile =
-        (input_tensor.layout() == Layout::TILE) ? input_tensor.tensor_spec().tile() : tt::tt_metal::Tile();
-    uint32_t input_tile_width = tile.get_width();
-    uint32_t input_tile_height = tile.get_height();
-
-    padded_shape[-2] = tt::round_up(padded_shape[-2], input_tile_height);
-    padded_shape[-1] = tt::round_up(padded_shape[-1], input_tile_width);
+    padded_shape[-2] = tt::round_up(padded_shape[-2], tile.get_height());
+    padded_shape[-1] = tt::round_up(padded_shape[-1], tile.get_width());
 
     // Handle empty tensors - no tiling needed for tensors with no data
     if (input_tensor.physical_volume() == 0) {
@@ -170,7 +213,7 @@ ttnn::Tensor tilize_with_zero_padding(
             padded_shape,
             TensorLayout(
                 output_dtype.value_or(input_tensor.dtype()),
-                PageConfig(Layout::TILE),
+                PageConfig(Layout::TILE, tile),
                 memory_config.value_or(input_tensor.memory_config())));
         return create_device_tensor(spec, input_tensor.device());
     }
@@ -182,7 +225,7 @@ ttnn::Tensor tilize_with_zero_padding(
         pad_value = (uint32_t)0;
     }
     return tilize_with_val_padding(
-        input_tensor, padded_shape, pad_value, memory_config, output_dtype, use_multicore, sub_core_grids);
+        input_tensor, padded_shape, pad_value, memory_config, output_dtype, use_multicore, sub_core_grids, tile);
 }
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.cpp
@@ -4,6 +4,8 @@
 
 #include "tilize_with_val_padding.hpp"
 
+#include <tt_stl/reflection.hpp>
+
 #include "device/tilize_with_val_padding_device_operation.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/operations/data_movement/reshape_view/reshape.hpp"

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.hpp
@@ -17,7 +17,7 @@ ttnn::Tensor tilize_with_val_padding(
     std::optional<DataType> output_dtype = std::nullopt,
     bool use_multicore = true,
     const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
-    tt::tt_metal::Tile tile = {});
+    const tt::tt_metal::Tile& tile = {});
 
 ttnn::Tensor tilize_with_val_padding(
     const ttnn::Tensor& input_tensor,
@@ -27,7 +27,7 @@ ttnn::Tensor tilize_with_val_padding(
     std::optional<DataType> output_dtype = std::nullopt,
     bool use_multicore = true,
     const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
-    tt::tt_metal::Tile tile = {});
+    const tt::tt_metal::Tile& tile = {});
 
 ttnn::Tensor tilize_with_zero_padding(
     const ttnn::Tensor& input_tensor,
@@ -35,6 +35,6 @@ ttnn::Tensor tilize_with_zero_padding(
     std::optional<DataType> output_dtype = std::nullopt,
     bool use_multicore = true,
     const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
-    tt::tt_metal::Tile tile = {});
+    const tt::tt_metal::Tile& tile = {});
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.hpp
@@ -16,7 +16,8 @@ ttnn::Tensor tilize_with_val_padding(
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     std::optional<DataType> output_dtype = std::nullopt,
     bool use_multicore = true,
-    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    tt::tt_metal::Tile tile = {});
 
 ttnn::Tensor tilize_with_val_padding(
     const ttnn::Tensor& input_tensor,
@@ -25,13 +26,15 @@ ttnn::Tensor tilize_with_val_padding(
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     std::optional<DataType> output_dtype = std::nullopt,
     bool use_multicore = true,
-    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    tt::tt_metal::Tile tile = {});
 
 ttnn::Tensor tilize_with_zero_padding(
     const ttnn::Tensor& input_tensor,
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     std::optional<DataType> output_dtype = std::nullopt,
     bool use_multicore = true,
-    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    tt::tt_metal::Tile tile = {});
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding_nanobind.cpp
@@ -36,6 +36,7 @@ void bind_tilize_with_val_padding(nb::module_& mod) {
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
                 dtype (data type, optional): Data type of the output tensor. Defaults to `None`.
                 use_multicore (bool, optional): Whether to use multicore. Defaults to `True`.
+                tile (tt.tt_metal.Tile, optional): Geometry of the tile to be tilized to. Defaults to the default tile.
 
             Returns:
                 ttnn.Tensor: the output tensor.
@@ -52,7 +53,8 @@ void bind_tilize_with_val_padding(nb::module_& mod) {
             const std::optional<MemoryConfig>&,
             std::optional<DataType>,
             bool,
-            const std::optional<CoreRangeSet>&>(&ttnn::tilize_with_val_padding),
+            const std::optional<CoreRangeSet>&,
+            tt::tt_metal::Tile>(&ttnn::tilize_with_val_padding),
         nb::arg("input_tensor"),
         nb::arg("output_tensor_shape"),
         nb::arg("pad_value"),
@@ -60,7 +62,8 @@ void bind_tilize_with_val_padding(nb::module_& mod) {
         nb::arg("memory_config") = nb::none(),
         nb::arg("dtype") = nb::none(),
         nb::arg("use_multicore") = true,
-        nb::arg("sub_core_grids") = nb::none());
+        nb::arg("sub_core_grids") = nb::none(),
+        nb::arg("tile") = tt::tt_metal::Tile{});
 }
 
 void bind_tilize_with_zero_padding(nb::module_& mod) {
@@ -79,6 +82,7 @@ void bind_tilize_with_zero_padding(nb::module_& mod) {
                 * :attr:`memory_config`: Memory Config of the output tensor.
                 * :attr:`dtype`: Data type of the output tensor.
                 * :attr:`use_multicore`: Whether to use multicore.
+                * :attr:`tile`: Geometry of the tile to be tilized to. Defaults to the default tile.
         )doc";
 
     ttnn::bind_function<"tilize_with_zero_padding">(
@@ -90,7 +94,8 @@ void bind_tilize_with_zero_padding(nb::module_& mod) {
         nb::arg("memory_config") = nb::none(),
         nb::arg("output_dtype") = nb::none(),
         nb::arg("use_multicore") = true,
-        nb::arg("sub_core_grids") = nb::none());
+        nb::arg("sub_core_grids") = nb::none(),
+        nb::arg("tile") = tt::tt_metal::Tile{});
 }
 
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding_nanobind.cpp
@@ -54,7 +54,7 @@ void bind_tilize_with_val_padding(nb::module_& mod) {
             std::optional<DataType>,
             bool,
             const std::optional<CoreRangeSet>&,
-            tt::tt_metal::Tile>(&ttnn::tilize_with_val_padding),
+            const tt::tt_metal::Tile&>(&ttnn::tilize_with_val_padding),
         nb::arg("input_tensor"),
         nb::arg("output_tensor_shape"),
         nb::arg("pad_value"),

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/tilize.cpp
@@ -51,7 +51,7 @@ ttnn::Tensor tilize(
     std::optional<DataType> output_dtype,
     bool use_multicore,
     bool use_low_perf,
-    tt::tt_metal::Tile tile,
+    const tt::tt_metal::Tile& tile,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     TT_FATAL(
         tile == tt::tt_metal::Tile{},

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/tilize.cpp
@@ -7,7 +7,6 @@
 #include "device/tilize_device_operation.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/operations/experimental/quasar/reshape_view/reshape.hpp"
-#include "ttnn/operations/experimental/quasar/to_memory_config/to_memory_config_op.hpp"  // wide-sharded OOM reroute (#45331)
 
 using namespace tt::tt_metal;
 
@@ -52,15 +51,21 @@ ttnn::Tensor tilize(
     std::optional<DataType> output_dtype,
     bool use_multicore,
     bool use_low_perf,
+    tt::tt_metal::Tile tile,
     const std::optional<CoreRangeSet>& sub_core_grids) {
+    TT_FATAL(
+        tile == tt::tt_metal::Tile{},
+        "Custom tile is not supported for tilize (See: #50508). Please transfer the tensor to host and use "
+        "`tt::tt_metal::to_tile_layout(HostTensor, Tile)` instead.");
+
     tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
     uint32_t output_single_tile_size =
         output_dtype.has_value() ? tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(output_dtype.value()))
                                  : input_single_tile_size;
 
-    uint32_t input_tile_width = input_tensor.tensor_spec().tile().get_width();
-    uint32_t input_tile_height = input_tensor.tensor_spec().tile().get_height();
+    uint32_t input_tile_width = tile.get_width();
+    uint32_t input_tile_height = tile.get_height();
 
     uint32_t num_tiles_per_row = input_tensor.padded_shape()[-1] / input_tile_width;
     uint32_t num_tiles_per_col = input_tensor.padded_shape()[-1] / input_tile_height;
@@ -71,24 +76,6 @@ ttnn::Tensor tilize(
         input_tensor, input_single_tile_size, output_single_tile_size, num_tiles_per_row);
 
     auto base_tilize = [=](const ttnn::Tensor& input_tensor) {
-        // Port of tt-metal 1e95aec97d5 (#45331): ttnn::prim::qsr::tilize routes wide width-sharded input
-        // to the default tilize factory, whose CBs are sized to a full tile-row (ntiles_per_block) and
-        // exceed L1. Reroute via interleaved DRAM so the prim selects the block factory (CBs bounded by
-        // max_l1 / (in_tile + out_tile)). Uses the quasar to_memory_config (same namespace).
-        if (input_tensor.memory_config().is_sharded() && !enough_space_height) {
-            const auto target_memory_config = memory_config.value_or(input_tensor.memory_config());
-            auto interleaved_input = to_memory_config(input_tensor, ttnn::DRAM_MEMORY_CONFIG);
-            auto interleaved_tile = ttnn::prim::qsr::tilize(
-                interleaved_input,
-                ttnn::DRAM_MEMORY_CONFIG,
-                output_dtype,
-                use_multicore,
-                enough_space_width,
-                /*enough_space_height=*/false,
-                use_low_perf,
-                sub_core_grids);
-            return to_memory_config(interleaved_tile, target_memory_config);
-        }
         return ttnn::prim::qsr::tilize(
             input_tensor,
             memory_config,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/tilize.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/tilize.hpp
@@ -14,7 +14,7 @@ ttnn::Tensor tilize(
     std::optional<DataType> output_dtype = std::nullopt,
     bool use_multicore = true,
     bool use_low_perf = false,
-    tt::tt_metal::Tile tile = {},
+    const tt::tt_metal::Tile& tile = {},
     const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 
 }  // namespace ttnn::operations::experimental::quasar

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/tilize.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/tilize.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 #include "ttnn/types.hpp"
+#include <tt-metalium/tile.hpp>
 
 namespace ttnn::operations::experimental::quasar {
 
@@ -13,6 +14,7 @@ ttnn::Tensor tilize(
     std::optional<DataType> output_dtype = std::nullopt,
     bool use_multicore = true,
     bool use_low_perf = false,
+    tt::tt_metal::Tile tile = {},
     const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 
 }  // namespace ttnn::operations::experimental::quasar

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/tilize_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/tilize_nanobind.cpp
@@ -31,6 +31,7 @@ void bind_tilize(nb::module_& mod) {
             use_multicore (bool, optional): Whether to use multicore. Defaults to `True`.
             use_low_perf (bool, optional): Use a low performance version that uses less memory. USE ONLY IF ABSOLUTELY NEEDED IN MODELS. Defaults to `False`.
             sub_core_grids (CoreRangeSet, optional): Used to restrict tilize to a set of cores, Defaults to using the entire device
+            tile (tt.tt_metal.Tile, optional): Geometry of the tile to be tilized to. Defaults to the default tile.
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -46,6 +47,7 @@ void bind_tilize(nb::module_& mod) {
         nb::arg("dtype") = nb::none(),
         nb::arg("use_multicore") = true,
         nb::arg("use_low_perf") = false,
+        nb::arg("tile") = tt::tt_metal::Tile{},
         nb::arg("sub_core_grids") = nb::none());
 }
 }  // namespace ttnn::operations::experimental::quasar::detail

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
@@ -131,14 +131,14 @@ void TilizeWithValPaddingDeviceOperation::validate_on_program_cache_miss(
         }
     }
 
-    uint32_t num_rows = operation_attributes.output_padded_shape[-1];
-    uint32_t inner_dim = operation_attributes.output_padded_shape[-2];
+    const uint32_t height = operation_attributes.output_padded_shape[-2];
+    const uint32_t width = operation_attributes.output_padded_shape[-1];
     TT_FATAL(
-        inner_dim % TILE_WIDTH == 0 && num_rows % TILE_HEIGHT == 0,
+        height % TILE_HEIGHT == 0 && width % TILE_WIDTH == 0,
         "To be tilizable output tensor shape {} must be divisible by tile size ({}, {})",
         operation_attributes.output_padded_shape,
-        TILE_WIDTH,
-        TILE_HEIGHT);
+        TILE_HEIGHT,
+        TILE_WIDTH);
 
     const uint32_t alignment_requirement = hal::get_l1_alignment();
     if (input_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED ||

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/tilize_with_val_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/tilize_with_val_padding.cpp
@@ -76,7 +76,7 @@ ttnn::Tensor tilize_with_val_padding(
     std::optional<DataType> output_dtype,
     bool use_multicore,
     const std::optional<CoreRangeSet>& sub_core_grids,
-    tt::tt_metal::Tile tile) {
+    const tt::tt_metal::Tile& tile) {
     if (input_tensor.layout() == Layout::TILE) {
         TT_FATAL(
             input_tensor.tensor_spec().tile() == tile,
@@ -151,7 +151,7 @@ ttnn::Tensor tilize_with_val_padding(
     std::optional<DataType> output_dtype,
     bool use_multicore,
     const std::optional<CoreRangeSet>& sub_core_grids,
-    tt::tt_metal::Tile tile) {
+    const tt::tt_metal::Tile& tile) {
     TT_FATAL(
         tile == tt::tt_metal::Tile{},
         "Custom tile is not supported for tilize_with_val_padding (See: #50508). Please transfer the tensor to host "
@@ -187,7 +187,7 @@ ttnn::Tensor tilize_with_zero_padding(
     std::optional<DataType> output_dtype,
     bool use_multicore,
     const std::optional<CoreRangeSet>& sub_core_grids,
-    tt::tt_metal::Tile tile) {
+    const tt::tt_metal::Tile& tile) {
     using namespace tt::constants;
     if (input_tensor.layout() == Layout::TILE) {
         TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/tilize_with_val_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/tilize_with_val_padding.cpp
@@ -4,6 +4,8 @@
 
 #include "tilize_with_val_padding.hpp"
 
+#include <tt_stl/reflection.hpp>
+
 #include "device/tilize_with_val_padding_device_operation.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/operations/experimental/quasar/reshape_view/reshape.hpp"

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/tilize_with_val_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/tilize_with_val_padding.cpp
@@ -75,10 +75,31 @@ ttnn::Tensor tilize_with_val_padding(
     const std::optional<MemoryConfig>& memory_config,
     std::optional<DataType> output_dtype,
     bool use_multicore,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    tt::tt_metal::Tile tile) {
     if (input_tensor.layout() == Layout::TILE) {
+        TT_FATAL(
+            input_tensor.tensor_spec().tile() == tile,
+            "ttnn::experimental::quasar::tilize_with_val_padding: TILE tensor already uses tile {}, cannot "
+            "reinterpret as {}",
+            input_tensor.tensor_spec().tile(),
+            tile);
+        TT_FATAL(
+            !memory_config.has_value() || memory_config.value() == input_tensor.memory_config(),
+            "ttnn::experimental::quasar::tilize_with_val_padding: cannot silently drop requested memory_config on "
+            "already-TILE input");
+        TT_FATAL(
+            !output_dtype.has_value() || output_dtype.value() == input_tensor.dtype(),
+            "ttnn::experimental::quasar::tilize_with_val_padding: cannot silently drop requested dtype on "
+            "already-TILE input");
         return input_tensor;
     }
+
+    TT_FATAL(
+        tile == tt::tt_metal::Tile{},
+        "Custom tile is not supported for tilize_with_val_padding (See: #50508). Please transfer the tensor to host "
+        "and "
+        "use `tt::tt_metal::to_tile_layout(HostTensor, Tile)` instead.");
 
     // Handle empty tensors - no tiling needed for tensors with no data
     if (input_tensor.physical_volume() == 0) {
@@ -87,7 +108,7 @@ ttnn::Tensor tilize_with_val_padding(
             output_padded_shape,
             TensorLayout(
                 output_dtype.value_or(input_tensor.dtype()),
-                PageConfig(Layout::TILE),
+                PageConfig(Layout::TILE, tile),
                 memory_config.value_or(input_tensor.memory_config())));
         return create_device_tensor(spec, input_tensor.device());
     }
@@ -98,8 +119,8 @@ ttnn::Tensor tilize_with_val_padding(
         output_dtype.has_value() ? tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(output_dtype.value()))
                                  : input_single_tile_size;
 
-    uint32_t num_tiles_per_row = output_padded_shape[-1] / tt::constants::TILE_WIDTH;
-    uint32_t num_tiles_per_col = output_padded_shape[-2] / tt::constants::TILE_HEIGHT;
+    uint32_t num_tiles_per_row = output_padded_shape[-1] / tile.get_width();
+    uint32_t num_tiles_per_col = output_padded_shape[-2] / tile.get_height();
 
     bool enough_space_width = operations::data_movement::is_enough_space(
         input_tensor, input_single_tile_size, output_single_tile_size, num_tiles_per_col);
@@ -129,7 +150,14 @@ ttnn::Tensor tilize_with_val_padding(
     const std::optional<MemoryConfig>& memory_config,
     std::optional<DataType> output_dtype,
     bool use_multicore,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    tt::tt_metal::Tile tile) {
+    TT_FATAL(
+        tile == tt::tt_metal::Tile{},
+        "Custom tile is not supported for tilize_with_val_padding (See: #50508). Please transfer the tensor to host "
+        "and "
+        "use `tt::tt_metal::to_tile_layout(HostTensor, Tile)` instead.");
+
     // Handle empty tensors - no tiling needed for tensors with no data
     if (input_tensor.physical_volume() == 0) {
         // Create output tensor with same properties
@@ -137,7 +165,7 @@ ttnn::Tensor tilize_with_val_padding(
             ttnn::Shape{output_padded_shape},
             TensorLayout(
                 output_dtype.value_or(input_tensor.dtype()),
-                PageConfig(Layout::TILE),
+                PageConfig(Layout::TILE, tile),
                 memory_config.value_or(input_tensor.memory_config())));
         return create_device_tensor(spec, input_tensor.device());
     }
@@ -149,7 +177,8 @@ ttnn::Tensor tilize_with_val_padding(
         memory_config,
         output_dtype,
         use_multicore,
-        sub_core_grids);
+        sub_core_grids,
+        tile);
 }
 
 ttnn::Tensor tilize_with_zero_padding(
@@ -157,17 +186,37 @@ ttnn::Tensor tilize_with_zero_padding(
     const std::optional<MemoryConfig>& memory_config,
     std::optional<DataType> output_dtype,
     bool use_multicore,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    tt::tt_metal::Tile tile) {
     using namespace tt::constants;
+    if (input_tensor.layout() == Layout::TILE) {
+        TT_FATAL(
+            input_tensor.tensor_spec().tile() == tile,
+            "ttnn::experimental::quasar::tilize_with_zero_padding: TILE tensor already uses tile {}, cannot "
+            "reinterpret as {}",
+            input_tensor.tensor_spec().tile(),
+            tile);
+        TT_FATAL(
+            !memory_config.has_value() || memory_config.value() == input_tensor.memory_config(),
+            "ttnn::experimental::quasar::tilize_with_zero_padding: cannot silently drop requested memory_config on "
+            "already-TILE input");
+        TT_FATAL(
+            !output_dtype.has_value() || output_dtype.value() == input_tensor.dtype(),
+            "ttnn::experimental::quasar::tilize_with_zero_padding: cannot silently drop requested dtype on "
+            "already-TILE input");
+        return input_tensor;
+    }
+
+    TT_FATAL(
+        tile == tt::tt_metal::Tile{},
+        "Custom tile is not supported for tilize_with_zero_padding (See: #50508). Please transfer the tensor to host "
+        "and "
+        "use `tt::tt_metal::to_tile_layout(HostTensor, Tile)` instead.");
+
     auto padded_shape = input_tensor.padded_shape();
 
-    tt::tt_metal::Tile tile =
-        (input_tensor.layout() == Layout::TILE) ? input_tensor.tensor_spec().tile() : tt::tt_metal::Tile();
-    uint32_t input_tile_width = tile.get_width();
-    uint32_t input_tile_height = tile.get_height();
-
-    padded_shape[-2] = tt::round_up(padded_shape[-2], input_tile_height);
-    padded_shape[-1] = tt::round_up(padded_shape[-1], input_tile_width);
+    padded_shape[-2] = tt::round_up(padded_shape[-2], tile.get_height());
+    padded_shape[-1] = tt::round_up(padded_shape[-1], tile.get_width());
 
     // Handle empty tensors - no tiling needed for tensors with no data
     if (input_tensor.physical_volume() == 0) {
@@ -176,7 +225,7 @@ ttnn::Tensor tilize_with_zero_padding(
             padded_shape,
             TensorLayout(
                 output_dtype.value_or(input_tensor.dtype()),
-                PageConfig(Layout::TILE),
+                PageConfig(Layout::TILE, tile),
                 memory_config.value_or(input_tensor.memory_config())));
         return create_device_tensor(spec, input_tensor.device());
     }
@@ -188,7 +237,7 @@ ttnn::Tensor tilize_with_zero_padding(
         pad_value = (uint32_t)0;
     }
     return tilize_with_val_padding(
-        input_tensor, padded_shape, pad_value, memory_config, output_dtype, use_multicore, sub_core_grids);
+        input_tensor, padded_shape, pad_value, memory_config, output_dtype, use_multicore, sub_core_grids, tile);
 }
 
 }  // namespace ttnn::operations::experimental::quasar

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/tilize_with_val_padding.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/tilize_with_val_padding.hpp
@@ -17,7 +17,7 @@ ttnn::Tensor tilize_with_val_padding(
     std::optional<DataType> output_dtype = std::nullopt,
     bool use_multicore = true,
     const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
-    tt::tt_metal::Tile tile = {});
+    const tt::tt_metal::Tile& tile = {});
 
 ttnn::Tensor tilize_with_val_padding(
     const ttnn::Tensor& input_tensor,
@@ -27,7 +27,7 @@ ttnn::Tensor tilize_with_val_padding(
     std::optional<DataType> output_dtype = std::nullopt,
     bool use_multicore = true,
     const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
-    tt::tt_metal::Tile tile = {});
+    const tt::tt_metal::Tile& tile = {});
 
 ttnn::Tensor tilize_with_zero_padding(
     const ttnn::Tensor& input_tensor,
@@ -35,6 +35,6 @@ ttnn::Tensor tilize_with_zero_padding(
     std::optional<DataType> output_dtype = std::nullopt,
     bool use_multicore = true,
     const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
-    tt::tt_metal::Tile tile = {});
+    const tt::tt_metal::Tile& tile = {});
 
 }  // namespace ttnn::operations::experimental::quasar

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/tilize_with_val_padding.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/tilize_with_val_padding.hpp
@@ -16,7 +16,8 @@ ttnn::Tensor tilize_with_val_padding(
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     std::optional<DataType> output_dtype = std::nullopt,
     bool use_multicore = true,
-    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    tt::tt_metal::Tile tile = {});
 
 ttnn::Tensor tilize_with_val_padding(
     const ttnn::Tensor& input_tensor,
@@ -25,13 +26,15 @@ ttnn::Tensor tilize_with_val_padding(
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     std::optional<DataType> output_dtype = std::nullopt,
     bool use_multicore = true,
-    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    tt::tt_metal::Tile tile = {});
 
 ttnn::Tensor tilize_with_zero_padding(
     const ttnn::Tensor& input_tensor,
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     std::optional<DataType> output_dtype = std::nullopt,
     bool use_multicore = true,
-    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
+    tt::tt_metal::Tile tile = {});
 
 }  // namespace ttnn::operations::experimental::quasar

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/tilize_with_val_padding_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/tilize_with_val_padding_nanobind.cpp
@@ -36,6 +36,7 @@ void bind_tilize_with_val_padding(nb::module_& mod) {
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
                 dtype (data type, optional): Data type of the output tensor. Defaults to `None`.
                 use_multicore (bool, optional): Whether to use multicore. Defaults to `True`.
+                tile (tt.tt_metal.Tile, optional): Geometry of the tile to be tilized to. Defaults to the default tile.
 
             Returns:
                 ttnn.Tensor: the output tensor.
@@ -52,7 +53,8 @@ void bind_tilize_with_val_padding(nb::module_& mod) {
             const std::optional<MemoryConfig>&,
             std::optional<DataType>,
             bool,
-            const std::optional<CoreRangeSet>&>(&ttnn::operations::experimental::quasar::tilize_with_val_padding),
+            const std::optional<CoreRangeSet>&,
+            tt::tt_metal::Tile>(&ttnn::operations::experimental::quasar::tilize_with_val_padding),
         nb::arg("input_tensor"),
         nb::arg("output_tensor_shape"),
         nb::arg("pad_value"),
@@ -60,7 +62,8 @@ void bind_tilize_with_val_padding(nb::module_& mod) {
         nb::arg("memory_config") = nb::none(),
         nb::arg("dtype") = nb::none(),
         nb::arg("use_multicore") = true,
-        nb::arg("sub_core_grids") = nb::none());
+        nb::arg("sub_core_grids") = nb::none(),
+        nb::arg("tile") = tt::tt_metal::Tile{});
 }
 
 void bind_tilize_with_zero_padding(nb::module_& mod) {
@@ -79,6 +82,7 @@ void bind_tilize_with_zero_padding(nb::module_& mod) {
                 * :attr:`memory_config`: Memory Config of the output tensor.
                 * :attr:`dtype`: Data type of the output tensor.
                 * :attr:`use_multicore`: Whether to use multicore.
+                * :attr:`tile`: Geometry of the tile to be tilized to. Defaults to the default tile.
         )doc";
 
     ttnn::bind_function<"tilize_with_zero_padding", "ttnn.experimental.quasar.">(
@@ -90,7 +94,8 @@ void bind_tilize_with_zero_padding(nb::module_& mod) {
         nb::arg("memory_config") = nb::none(),
         nb::arg("output_dtype") = nb::none(),
         nb::arg("use_multicore") = true,
-        nb::arg("sub_core_grids") = nb::none());
+        nb::arg("sub_core_grids") = nb::none(),
+        nb::arg("tile") = tt::tt_metal::Tile{});
 }
 
 }  // namespace ttnn::operations::experimental::quasar::detail

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/tilize_with_val_padding_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/tilize_with_val_padding_nanobind.cpp
@@ -54,7 +54,7 @@ void bind_tilize_with_val_padding(nb::module_& mod) {
             std::optional<DataType>,
             bool,
             const std::optional<CoreRangeSet>&,
-            tt::tt_metal::Tile>(&ttnn::operations::experimental::quasar::tilize_with_val_padding),
+            const tt::tt_metal::Tile&>(&ttnn::operations::experimental::quasar::tilize_with_val_padding),
         nb::arg("input_tensor"),
         nb::arg("output_tensor_shape"),
         nb::arg("pad_value"),

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/to_layout/to_layout_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/to_layout/to_layout_nanobind.cpp
@@ -20,9 +20,9 @@ void bind_to_layout(nb::module_& mod) {
         Organizes the `ttnn.Tensor` tensor into either `ttnn.ROW_MAJOR_LAYOUT` or `ttnn.TILE_LAYOUT`.
 
         When requesting `ttnn.ROW_MAJOR_LAYOUT`, the tensor will be returned unpadded in the last two dimensions.
-        When requesting `ttnn.TILE_LAYOUT`, the tensor will be automatically padded where the width and height
-        become multiples of 32. In the case where the layout is the same, the operation simply pads or unpads
-        the last two dimensions depending on the requested layout.
+        When requesting `ttnn.TILE_LAYOUT`, the tensor will be padded to the requested tile shape. In the case where
+        the layout is the same, the operation simply pads or unpads the last two dimensions depending on the requested
+        layout.
 
         Args:
             tensor (ttnn.Tensor): the input tensor to be organized.
@@ -31,6 +31,8 @@ void bind_to_layout(nb::module_& mod) {
             memory_config (ttnn.MemoryConfig, optional): the optional output memory configuration.
             sub_core_grids (ttnn.CoreRangeSet, optional): the optional sub core grids. Defaults to `None`.
             pad_value (float, optional): the optional pad value. Defaults to `0.0f`.
+            tile (ttnn.Tile, optional): explicit tile metadata for TILE conversions, including
+                non-32x32 tiles. Defaults to `None`.
 
         Returns:
             ttnn.Tensor: the tensor with the requested layout.
@@ -45,7 +47,9 @@ void bind_to_layout(nb::module_& mod) {
         nb::arg("dtype") = nb::none(),
         nb::arg("memory_config") = nb::none(),
         nb::arg("sub_core_grids") = nb::none(),
-        nb::arg("pad_value") = 0.0f);
+        nb::arg("pad_value") = 0.0f,
+        nb::kw_only(),
+        nb::arg("tile") = nb::none());
 }
 
 }  // namespace ttnn::operations::experimental::quasar::detail

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/to_layout/to_layout_op.cpp
@@ -24,6 +24,17 @@
 namespace ttnn::operations::experimental::quasar::CMAKE_UNIQUE_NAMESPACE {
 namespace {
 
+tt::tt_metal::Tile resolve_effective_tile(
+    const ttnn::Tensor& tensor,
+    ttnn::Layout layout,
+    ttsl::optional_reference<const tt::tt_metal::Tile> requested_tile) {
+    TT_FATAL(layout == Layout::TILE, "Effective tile is only defined for TILE conversions");
+    if (tensor.layout() == Layout::TILE) {
+        return requested_tile.has_value() ? *requested_tile : tensor.tensor_spec().tile();
+    }
+    return requested_tile.has_value() ? *requested_tile : tt::tt_metal::Tile{};
+}
+
 void validate_tile_semantics(
     const ttnn::Tensor& tensor,
     ttnn::Layout layout,
@@ -44,16 +55,21 @@ void validate_tile_semantics(
             current.get_height() == requested.get_height()) {
             TT_FATAL(
                 false,
-                "ttnn::experimental::quasar::to_layout: TILE tensor already uses tile {}, cannot convert to tile {} without retilize",
+                "ttnn::experimental::quasar::to_layout: TILE tensor already uses tile {}, cannot convert to tile {} "
+                "without retilize",
                 current,
                 requested);
         }
     }
 }
 
-bool requires_padding_change_to_tile(const ttnn::Tensor& tensor, const tt::tt_metal::Tile& target_tile) {
+bool requires_padding_change(const ttnn::Tensor& tensor, ttnn::Layout layout, const tt::tt_metal::Tile& target_tile) {
+    if (layout == Layout::ROW_MAJOR) {
+        // There shouldn't be extra paddings for Row Major layout
+        return tensor.logical_shape() != tensor.padded_shape();
+    }
     // It's okay for conversion to tile layout to preserve arbitrary padding as long as it satisfies the alignment
-    tt::tt_metal::PageConfig page_config(Layout::TILE, target_tile);
+    tt::tt_metal::PageConfig page_config = tt::tt_metal::PageConfig(layout, target_tile);
 
     // Padded shape only (dtype-independent). Use TensorLayout, not a TensorSpec: TensorSpec rejects
     // FP8_E4M3 + TILE (fp8 is ROW_MAJOR-only) though fp8 is a valid tilize input.
@@ -74,194 +90,6 @@ constexpr std::string_view kRowMajorDtypeErrorMessage =
     "dtype cannot be different from tensor dtype when converting to ROW_MAJOR_LAYOUT on device "
     "(allowed exception: BFLOAT8_B -> BFLOAT16, which untilize handles natively)!";
 
-Tensor to_row_major_layout_impl(
-    const ttnn::Tensor& tensor_arg,
-    const std::optional<ttnn::DataType>& dtype,
-    const std::optional<ttnn::MemoryConfig>& memory_config,
-    const std::optional<CoreRangeSet>& sub_core_grids) {
-    auto tensor = tensor_arg;
-
-    if (ttnn::is_device_tensor(tensor_arg)) {
-        constexpr bool use_multicore_untilize = true;
-        TT_FATAL(is_allowed_row_major_dtype(tensor_arg.dtype(), dtype), "{}", kRowMajorDtypeErrorMessage);
-
-        auto output_memory_config =
-            memory_config.value_or(ttnn::get_memory_config(tensor).value_or(ttnn::DRAM_MEMORY_CONFIG));
-
-        // No extra paddings
-        if (tensor.logical_shape() == tensor.padded_shape()) {
-            return ttnn::operations::experimental::quasar::untilize(
-                tensor, output_memory_config, use_multicore_untilize, sub_core_grids);
-        }
-
-        // Handle device tensor with padding
-        if (tensor.is_sharded()) {
-            output_memory_config =
-                memory_config.value_or(ttnn::get_memory_config(tensor).value_or(ttnn::DRAM_MEMORY_CONFIG));
-        }
-        Shape output_tensor_end(ttsl::SmallVector<uint32_t>(tensor.logical_shape().rank(), 0));
-        int logical_rank = tensor.logical_shape().rank();
-        for (int index = -1; index >= -logical_rank; --index) {
-            output_tensor_end[index] = tensor.logical_shape()[index] - 1;
-        }
-        return ttnn::operations::experimental::quasar::untilize_with_unpadding(
-            tensor, output_tensor_end, output_memory_config, use_multicore_untilize, sub_core_grids);
-    }
-
-    // Handle to_row_major layout on host
-    TT_ASSERT(!dtype.has_value(), "dtype cannot be specified when converting layout on host!");
-
-    // No extra paddings
-    if (tensor.logical_shape() == tensor.padded_shape()) {
-        return tensor.to_layout(Layout::ROW_MAJOR);
-    }
-
-    tensor = tensor.to_layout(Layout::ROW_MAJOR);
-    tensor = tensor.unpad_from_tile(tensor.logical_shape());
-    return ttnn::operations::experimental::quasar::reshape(
-        tensor,
-        tensor.logical_shape(),
-        std::nullopt, /*Memory Config*/
-        std::nullopt, /*Pad Value*/
-        TileReshapeMapMode::CACHE,
-        sub_core_grids);
-}
-
-Tensor to_tile_layout_impl(
-    const ttnn::Tensor& tensor_arg,
-    const std::optional<ttnn::DataType>& dtype,
-    const std::optional<ttnn::MemoryConfig>& memory_config,
-    const std::optional<CoreRangeSet>& sub_core_grids,
-    const float pad_value,
-    ttsl::optional_reference<const tt::tt_metal::Tile> tile) {
-    auto tensor = tensor_arg;
-    const auto& output_shape = tensor_arg.logical_shape();
-    auto output_memory_config =
-        memory_config.value_or(ttnn::get_memory_config(tensor).value_or(ttnn::DRAM_MEMORY_CONFIG));
-    const auto target_tile = tile.has_value() ? *tile : tt::tt_metal::Tile{};
-
-    // Padded shape only (dtype-independent). Use TensorLayout, not a TensorSpec: TensorSpec rejects
-    // FP8_E4M3 + TILE (fp8 is ROW_MAJOR-only) though fp8 is a valid tilize input; the real output dtype
-    // flows through `dtype` into tilize()/untilize() below.
-    const auto padded_output_shape =
-        tt::tt_metal::TensorLayout(
-            tensor_arg.dtype(), tt::tt_metal::PageConfig(Layout::TILE, target_tile), output_memory_config)
-            .compute_padded_shape(tensor_arg.logical_shape());
-    const auto original_rank = tensor_arg.logical_shape().rank();
-    const auto& original_shape = tensor_arg.logical_shape();
-
-    if (tensor.padded_shape().size() < 2) {
-        TT_FATAL(
-            !tensor.is_sharded(),
-            "ttnn::to_layout: Cannot convert a sharded device tensor with rank {} to TILE_LAYOUT. "
-            "Tilize requires shard dimensions divisible by tile size, but rank promotion to 2D "
-            "produces a shard height of 1. Move to interleaved first, then tilize.",
-            tensor.padded_shape().size());
-        const bool is_scalar = tensor.padded_shape().size() == 0;
-        ttsl::SmallVector<uint32_t> new_padded_shape =
-            is_scalar ? ttsl::SmallVector<uint32_t>{1, 1} : ttsl::SmallVector<uint32_t>{1, tensor.padded_shape()[-1]};
-        tensor = ttnn::experimental::view(tensor, tensor.logical_shape(), Shape(new_padded_shape));
-    }
-
-    if (ttnn::is_device_tensor(tensor_arg)) {
-        constexpr bool use_multicore_tilize = true;
-
-        if (not requires_padding_change_to_tile(tensor, target_tile)) {
-            if (tensor.is_sharded()) {
-                uint32_t tile_height = target_tile.get_height();
-                uint32_t tile_width = target_tile.get_width();
-                const auto mem_config = get_memory_config(tensor).value();
-                uint32_t shard_h, shard_w;
-                if (mem_config.shard_spec().has_value()) {
-                    shard_h = mem_config.shard_spec().value().shape[0];
-                    shard_w = mem_config.shard_spec().value().shape[1];
-                } else {
-                    const auto& nd_spec = mem_config.nd_shard_spec().value();
-                    shard_h = nd_spec.shard_shape[-2];
-                    shard_w = nd_spec.shard_shape[-1];
-                }
-                if (shard_h % tile_height != 0 or shard_w % tile_width != 0) {
-                    TT_THROW(
-                        "ttnn::to_layout: Sharded tensor must have shard shape that is a multiple of "
-                        "TILE_SIZE!");
-                }
-            }
-            return ttnn::operations::experimental::quasar::tilize(
-                tensor,
-                output_memory_config,
-                dtype,
-                use_multicore_tilize,
-                false /* low perf mode */,
-                target_tile,
-                sub_core_grids);
-        }
-
-        if (tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
-            // ttnn::tilize_with_val_padding doesn't support height sharded tensors
-            // workaround by applying padding and then tilizing
-            ttsl::SmallVector<std::array<uint32_t, 2>> padding = {
-                {0, 0},
-                {0, 0},
-                {0, padded_output_shape[2] - output_shape[2]},
-                {0, padded_output_shape[3] - output_shape[3]}};
-            TT_FATAL(!sub_core_grids.has_value(), "Pad OP does not currently support sub core grid");
-            tensor = ttnn::operations::experimental::quasar::pad(tensor, padding, pad_value, true, std::nullopt);
-            return ttnn::operations::experimental::quasar::tilize(
-                tensor, output_memory_config, dtype, use_multicore_tilize, false, target_tile, std::nullopt);
-        }
-
-        PadValue pad_value_variant;
-        if (tensor.dtype() == ttnn::DataType::BFLOAT16 or tensor.dtype() == ttnn::DataType::FLOAT32) {
-            pad_value_variant = pad_value;
-        } else if (tensor.dtype() == ttnn::DataType::INT32) {
-            TT_FATAL(
-                pad_value >= static_cast<float>(std::numeric_limits<int32_t>::min()) &&
-                    pad_value < static_cast<float>(std::numeric_limits<int32_t>::max()),
-                "Pad value must be in the range of INT32 type");
-            // static_cast safely truncates the float into a signed integer,
-            // while std::bit_cast reinterprets those exact bits as unsigned to cleanly handle negative
-            // wrap-arounds.
-            pad_value_variant = std::bit_cast<uint32_t>(static_cast<int32_t>(pad_value));
-        } else {
-            TT_FATAL(
-                pad_value >= 0.0f && pad_value < static_cast<float>(std::numeric_limits<uint32_t>::max()),
-                "Pad value must be in the range of UINT32 type");
-            pad_value_variant = (uint32_t)pad_value;
-        }
-        tensor = ttnn::operations::experimental::quasar::tilize_with_val_padding(
-            tensor,
-            Shape(padded_output_shape),
-            pad_value_variant,
-            output_memory_config,
-            dtype,
-            use_multicore_tilize,
-            sub_core_grids,
-            target_tile);
-
-        if (original_rank < 2) {
-            return ttnn::operations::experimental::quasar::reshape(
-                tensor,
-                original_shape,
-                std::nullopt /*Memory Config*/,
-                std::nullopt /*pad value*/,
-                TileReshapeMapMode::CACHE,
-                sub_core_grids);
-        }
-        return tensor;
-    }
-
-    TT_ASSERT(!dtype.has_value(), "dtype cannot be specified when converting layout on host!");
-
-    if (!requires_padding_change_to_tile(tensor, target_tile)) {
-        return tensor.to_layout(Layout::TILE, target_tile);
-    }
-
-    ttsl::SmallVector<uint32_t> padded_input_start(padded_output_shape.rank(), 0);
-    tensor = tensor.pad(ttnn::Shape(padded_output_shape), ttnn::Shape(std::move(padded_input_start)), pad_value);
-    tensor = tensor.to_layout(Layout::TILE, target_tile);
-    return ttnn::experimental::view(tensor, output_shape, padded_output_shape);
-}
-
 Tensor to_layout_impl(
     const ttnn::Tensor& tensor_arg,
     const ttnn::Layout layout,
@@ -273,8 +101,8 @@ Tensor to_layout_impl(
     validate_tile_semantics(tensor_arg, layout, tile);
 
     const bool needs_retile = layout == ttnn::TILE_LAYOUT && tile.has_value() &&
-                               tensor_arg.layout() == ttnn::TILE_LAYOUT &&
-                               tensor_arg.tensor_spec().tile() != tile.value();
+                              tensor_arg.layout() == ttnn::TILE_LAYOUT &&
+                              tensor_arg.tensor_spec().tile() != tile.value();
     if (tensor_arg.layout() == layout && !needs_retile) {
         if (dtype.has_value() and dtype.value() != tensor_arg.dtype()) {
             log_warning(
@@ -293,14 +121,188 @@ Tensor to_layout_impl(
         return tensor_arg;
     }
 
-    switch (layout) {
-        case ttnn::ROW_MAJOR_LAYOUT: return to_row_major_layout_impl(tensor_arg, dtype, memory_config, sub_core_grids);
-        case ttnn::TILE_LAYOUT:
-            return to_tile_layout_impl(tensor_arg, dtype, memory_config, sub_core_grids, pad_value, tile);
-        default: TT_THROW("ttnn::to_layout: Unsupported layout conversion from {} to {}!", tensor_arg.layout(), layout);
-    }
-}
+    const std::set<ttnn::Layout> supported_layouts = {
+        ttnn::ROW_MAJOR_LAYOUT,
+        ttnn::TILE_LAYOUT,
+    };
 
+    if (!supported_layouts.contains(layout)) {
+        TT_THROW("ttnn::to_layout: Unsupported layout conversion from {} to {}!", tensor_arg.layout(), layout);
+    }
+
+    auto tensor = tensor_arg;
+    auto output_shape = tensor_arg.logical_shape();
+    auto output_memory_config =
+        memory_config.value_or(ttnn::get_memory_config(tensor).value_or(ttnn::DRAM_MEMORY_CONFIG));
+
+    const auto effective_tile =
+        layout == Layout::TILE ? resolve_effective_tile(tensor_arg, layout, tile) : tt::tt_metal::Tile{};
+    tt::tt_metal::PageConfig page_config = tt::tt_metal::PageConfig(Layout::TILE, effective_tile);
+    // Padded shape only (dtype-independent). Use TensorLayout, not a TensorSpec: TensorSpec rejects
+    // FP8_E4M3 + TILE (fp8 is ROW_MAJOR-only) though fp8 is a valid tilize input; the real output dtype
+    // flows through `dtype` into tilize()/untilize() below.
+    auto padded_output_shape = tt::tt_metal::TensorLayout(tensor_arg.dtype(), page_config, output_memory_config)
+                                   .compute_padded_shape(tensor_arg.logical_shape());
+    auto original_rank = tensor_arg.logical_shape().rank();
+    const auto& original_shape = tensor_arg.logical_shape();
+
+    if (layout == ttnn::TILE_LAYOUT) {
+        if (tensor.padded_shape().size() < 2) {
+            TT_FATAL(
+                !tensor.is_sharded(),
+                "ttnn::to_layout: Cannot convert a sharded device tensor with rank {} to TILE_LAYOUT. "
+                "Tilize requires shard dimensions divisible by tile size, but rank promotion to 2D "
+                "produces a shard height of 1. Move to interleaved first, then tilize.",
+                tensor.padded_shape().size());
+            const bool is_scalar = tensor.padded_shape().size() == 0;
+            ttsl::SmallVector<uint32_t> new_padded_shape =
+                is_scalar ? ttsl::SmallVector<uint32_t>{1, 1}
+                          : ttsl::SmallVector<uint32_t>{1, tensor.padded_shape()[-1]};
+            tensor = ttnn::experimental::view(tensor, tensor.logical_shape(), Shape(new_padded_shape));
+        }
+    }
+
+    if (ttnn::is_device_tensor(tensor_arg)) {
+        bool use_multicore_untilize = true;
+        bool use_multicore_tilize = true;
+        const bool converting_to_row_major = layout == ttnn::ROW_MAJOR_LAYOUT;
+        const bool converting_to_tile = layout == ttnn::TILE_LAYOUT;
+
+        if (converting_to_row_major) {
+            TT_FATAL(is_allowed_row_major_dtype(tensor_arg.dtype(), dtype), "{}", kRowMajorDtypeErrorMessage);
+        }
+
+        if (not requires_padding_change(tensor, layout, effective_tile)) {
+            if (converting_to_row_major) {
+                return ttnn::operations::experimental::quasar::untilize(
+                    tensor, output_memory_config, use_multicore_untilize, sub_core_grids);
+            }
+            if (converting_to_tile) {
+                if (tensor.is_sharded()) {
+                    uint32_t tile_height = effective_tile.get_height();
+                    uint32_t tile_width = effective_tile.get_width();
+                    const auto mem_config = get_memory_config(tensor).value();
+                    uint32_t shard_h, shard_w;
+                    if (mem_config.shard_spec().has_value()) {
+                        shard_h = mem_config.shard_spec().value().shape[0];
+                        shard_w = mem_config.shard_spec().value().shape[1];
+                    } else {
+                        const auto& nd_spec = mem_config.nd_shard_spec().value();
+                        shard_h = nd_spec.shard_shape[-2];
+                        shard_w = nd_spec.shard_shape[-1];
+                    }
+                    if (shard_h % tile_height != 0 or shard_w % tile_width != 0) {
+                        TT_THROW(
+                            "ttnn::to_layout: Sharded tensor must have shard shape that is a multiple of "
+                            "TILE_SIZE!");
+                    }
+                }
+                return ttnn::operations::experimental::quasar::tilize(
+                    tensor,
+                    output_memory_config,
+                    dtype,
+                    use_multicore_tilize,
+                    false /* low perf mode */,
+                    effective_tile,
+                    sub_core_grids);
+            }
+            throw std::runtime_error("ttnn::to_layout: Unsupported layout!");
+        }
+        if (converting_to_row_major) {
+            if (tensor.is_sharded()) {
+                output_memory_config =
+                    memory_config.value_or(ttnn::get_memory_config(tensor).value_or(ttnn::DRAM_MEMORY_CONFIG));
+            }
+            Shape output_tensor_end(ttsl::SmallVector<uint32_t>(tensor.logical_shape().rank(), 0));
+            int logical_rank = tensor.logical_shape().rank();
+            for (int index = -1; index >= -logical_rank; --index) {
+                output_tensor_end[index] = tensor.logical_shape()[index] - 1;
+            }
+            return ttnn::operations::experimental::quasar::untilize_with_unpadding(
+                tensor, output_tensor_end, output_memory_config, use_multicore_untilize, sub_core_grids);
+        }
+        if (converting_to_tile) {
+            if (tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
+                // ttnn::tilize_with_val_padding doesn't support height sharded tensors
+                // workaround by applying padding and then tilizing
+                ttsl::SmallVector<std::array<uint32_t, 2>> padding = {
+                    {0, 0},
+                    {0, 0},
+                    {0, padded_output_shape[2] - output_shape[2]},
+                    {0, padded_output_shape[3] - output_shape[3]}};
+                TT_FATAL(!sub_core_grids.has_value(), "Pad OP does not currently support sub core grid");
+                tensor = ttnn::operations::experimental::quasar::pad(tensor, padding, pad_value, true, std::nullopt);
+                return ttnn::operations::experimental::quasar::tilize(
+                    tensor, output_memory_config, dtype, use_multicore_tilize, false, effective_tile, std::nullopt);
+            } else {
+                PadValue pad_value_variant;
+                if (tensor.dtype() == ttnn::DataType::BFLOAT16 or tensor.dtype() == ttnn::DataType::FLOAT32) {
+                    pad_value_variant = pad_value;
+                } else if (tensor.dtype() == ttnn::DataType::INT32) {
+                    TT_FATAL(
+                        pad_value >= static_cast<float>(std::numeric_limits<int32_t>::min()) &&
+                            pad_value < static_cast<float>(std::numeric_limits<int32_t>::max()),
+                        "Pad value must be in the range of INT32 type");
+                    // static_cast safely truncates the float into a signed integer,
+                    // while std::bit_cast reinterprets those exact bits as unsigned to cleanly handle negative
+                    // wrap-arounds.
+                    pad_value_variant = std::bit_cast<uint32_t>(static_cast<int32_t>(pad_value));
+                } else {
+                    TT_FATAL(
+                        pad_value >= 0.0f && pad_value < static_cast<float>(std::numeric_limits<uint32_t>::max()),
+                        "Pad value must be in the range of UINT32 type");
+                    pad_value_variant = (uint32_t)pad_value;
+                }
+                tensor = ttnn::operations::experimental::quasar::tilize_with_val_padding(
+                    tensor,
+                    Shape(padded_output_shape),
+                    pad_value_variant,
+                    output_memory_config,
+                    dtype,
+                    use_multicore_tilize,
+                    sub_core_grids,
+                    effective_tile);
+            }
+            if (original_rank < 2) {
+                return ttnn::operations::experimental::quasar::reshape(
+                    tensor,
+                    original_shape,
+                    std::nullopt /*Memory Config*/,
+                    std::nullopt /*pad value*/,
+                    TileReshapeMapMode::CACHE,
+                    sub_core_grids);
+            }
+            return tensor;
+        }
+        TT_THROW("ttnn::to_layout: Unsupported output layout: {}!", layout);
+    }
+    TT_ASSERT(!dtype.has_value(), "dtype cannot be specified when converting layout on host!");
+    if (!requires_padding_change(tensor, layout, effective_tile)) {
+        return tensor.to_layout(
+            layout, layout == ttnn::TILE_LAYOUT ? std::make_optional(effective_tile) : std::nullopt);
+    }
+    if (layout == ttnn::ROW_MAJOR_LAYOUT) {
+        tensor = tensor.to_layout(layout);
+        tensor = tensor.unpad_from_tile(tensor.logical_shape());
+        return ttnn::operations::experimental::quasar::reshape(
+            tensor,
+            ttnn::Shape{output_shape},
+            std::nullopt, /*Memory Config*/
+            std::nullopt, /*Pad Value*/
+            TileReshapeMapMode::CACHE,
+            sub_core_grids);
+    }
+    if (layout == ttnn::TILE_LAYOUT) {
+        ttsl::SmallVector<uint32_t> padded_input_start;
+        for (int index = 0; index < padded_output_shape.rank(); ++index) {
+            padded_input_start.push_back(0);
+        }
+        tensor = tensor.pad(ttnn::Shape(padded_output_shape), ttnn::Shape(std::move(padded_input_start)), pad_value);
+        tensor = tensor.to_layout(layout, effective_tile);
+        return ttnn::experimental::view(tensor, output_shape, padded_output_shape);
+    }
+    TT_THROW("ttnn::to_layout: Unsupported output layout: {}!", layout);
+}
 }  // namespace
 
 }  // namespace ttnn::operations::experimental::quasar::CMAKE_UNIQUE_NAMESPACE

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/to_layout/to_layout_op.cpp
@@ -22,19 +22,37 @@
 namespace ttnn::operations::experimental::quasar::CMAKE_UNIQUE_NAMESPACE {
 namespace {
 
-bool requires_padding_change(const ttnn::Tensor& tensor, ttnn::Layout layout) {
+void validate_tile_semantics(
+    const ttnn::Tensor& tensor, ttnn::Layout layout, const std::optional<tt::tt_metal::Tile>& requested_tile) {
     if (layout == Layout::ROW_MAJOR) {
-        // There shouldn't be extra paddings for Row Major layout
-        return tensor.logical_shape() != tensor.padded_shape();
-    }
-    // It's okay for conversion to tile layout to preserve arbitrary padding as long as it satisfies the alignment
-    tt::tt_metal::PageConfig page_config = tt::tt_metal::PageConfig(layout);
-    if (tensor.layout() == Layout::TILE) {
-        page_config = tt::tt_metal::PageConfig(layout, tensor.tensor_spec().tile());
+        TT_FATAL(
+            !requested_tile.has_value(),
+            "ttnn::experimental::quasar::to_layout: tile argument is only supported when converting to TILE_LAYOUT");
+        return;
     }
 
-    // Padded shape only (dtype-independent). Use TensorLayout, not a tt::tt_metal::TensorSpec: tt::tt_metal::TensorSpec
-    // rejects FP8_E4M3 + TILE (fp8 is ROW_MAJOR-only) though fp8 is a valid tilize input.
+    // Retile (#50129) can change tile height/width. Metadata-only differences (e.g. transpose_tile)
+    // with the same geometry are not a supported retilize conversion.
+    if (layout == Layout::TILE && tensor.layout() == Layout::TILE && requested_tile.has_value()) {
+        const auto& current = tensor.tensor_spec().tile();
+        const auto& requested = requested_tile.value();
+        if (current != requested && current.get_width() == requested.get_width() &&
+            current.get_height() == requested.get_height()) {
+            TT_FATAL(
+                false,
+                "ttnn::experimental::quasar::to_layout: TILE tensor already uses tile {}, cannot convert to tile {} without retilize",
+                current,
+                requested);
+        }
+    }
+}
+
+bool requires_padding_change_to_tile(const ttnn::Tensor& tensor, const tt::tt_metal::Tile& target_tile) {
+    // It's okay for conversion to tile layout to preserve arbitrary padding as long as it satisfies the alignment
+    tt::tt_metal::PageConfig page_config(Layout::TILE, target_tile);
+
+    // Padded shape only (dtype-independent). Use TensorLayout, not a TensorSpec: TensorSpec rejects
+    // FP8_E4M3 + TILE (fp8 is ROW_MAJOR-only) though fp8 is a valid tilize input.
     const auto padded_shape = tt::tt_metal::TensorLayout(tensor.dtype(), page_config, tensor.memory_config())
                                   .compute_padded_shape(tensor.padded_shape());
     return tensor.padded_shape() != padded_shape;
@@ -52,14 +70,208 @@ constexpr std::string_view kRowMajorDtypeErrorMessage =
     "dtype cannot be different from tensor dtype when converting to ROW_MAJOR_LAYOUT on device "
     "(allowed exception: BFLOAT8_B -> BFLOAT16, which untilize handles natively)!";
 
+Tensor to_row_major_layout_impl(
+    const ttnn::Tensor& tensor_arg,
+    const std::optional<ttnn::DataType>& dtype,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
+    auto tensor = tensor_arg;
+
+    if (ttnn::is_device_tensor(tensor_arg)) {
+        constexpr bool use_multicore_untilize = true;
+        TT_FATAL(is_allowed_row_major_dtype(tensor_arg.dtype(), dtype), "{}", kRowMajorDtypeErrorMessage);
+
+        auto output_memory_config =
+            memory_config.value_or(ttnn::get_memory_config(tensor).value_or(ttnn::DRAM_MEMORY_CONFIG));
+
+        // No extra paddings
+        if (tensor.logical_shape() == tensor.padded_shape()) {
+            return ttnn::operations::experimental::quasar::untilize(
+                tensor, output_memory_config, use_multicore_untilize, sub_core_grids);
+        }
+
+        // Handle device tensor with padding
+        if (tensor.is_sharded()) {
+            output_memory_config =
+                memory_config.value_or(ttnn::get_memory_config(tensor).value_or(ttnn::DRAM_MEMORY_CONFIG));
+        }
+        Shape output_tensor_end(ttsl::SmallVector<uint32_t>(tensor.logical_shape().rank(), 0));
+        int logical_rank = tensor.logical_shape().rank();
+        for (int index = -1; index >= -logical_rank; --index) {
+            output_tensor_end[index] = tensor.logical_shape()[index] - 1;
+        }
+        return ttnn::operations::experimental::quasar::untilize_with_unpadding(
+            tensor, output_tensor_end, output_memory_config, use_multicore_untilize, sub_core_grids);
+    }
+
+    // Handle to_row_major layout on host
+    TT_ASSERT(!dtype.has_value(), "dtype cannot be specified when converting layout on host!");
+
+    // No extra paddings
+    if (tensor.logical_shape() == tensor.padded_shape()) {
+        return tensor.to_layout(Layout::ROW_MAJOR);
+    }
+
+    tensor = tensor.to_layout(Layout::ROW_MAJOR);
+    tensor = tensor.unpad_from_tile(tensor.logical_shape());
+    return ttnn::operations::experimental::quasar::reshape(
+        tensor,
+        tensor.logical_shape(),
+        std::nullopt, /*Memory Config*/
+        std::nullopt, /*Pad Value*/
+        TileReshapeMapMode::CACHE,
+        sub_core_grids);
+}
+
+Tensor to_tile_layout_impl(
+    const ttnn::Tensor& tensor_arg,
+    const std::optional<ttnn::DataType>& dtype,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const float pad_value,
+    const std::optional<tt::tt_metal::Tile>& tile) {
+    auto tensor = tensor_arg;
+    const auto& output_shape = tensor_arg.logical_shape();
+    auto output_memory_config =
+        memory_config.value_or(ttnn::get_memory_config(tensor).value_or(ttnn::DRAM_MEMORY_CONFIG));
+    const auto target_tile = tile.value_or(tt::tt_metal::Tile{});
+
+    // Padded shape only (dtype-independent). Use TensorLayout, not a TensorSpec: TensorSpec rejects
+    // FP8_E4M3 + TILE (fp8 is ROW_MAJOR-only) though fp8 is a valid tilize input; the real output dtype
+    // flows through `dtype` into tilize()/untilize() below.
+    const auto padded_output_shape =
+        tt::tt_metal::TensorLayout(
+            tensor_arg.dtype(), tt::tt_metal::PageConfig(Layout::TILE, target_tile), output_memory_config)
+            .compute_padded_shape(tensor_arg.logical_shape());
+    const auto original_rank = tensor_arg.logical_shape().rank();
+    const auto& original_shape = tensor_arg.logical_shape();
+
+    if (tensor.padded_shape().size() < 2) {
+        TT_FATAL(
+            !tensor.is_sharded(),
+            "ttnn::to_layout: Cannot convert a sharded device tensor with rank {} to TILE_LAYOUT. "
+            "Tilize requires shard dimensions divisible by tile size, but rank promotion to 2D "
+            "produces a shard height of 1. Move to interleaved first, then tilize.",
+            tensor.padded_shape().size());
+        const bool is_scalar = tensor.padded_shape().size() == 0;
+        ttsl::SmallVector<uint32_t> new_padded_shape =
+            is_scalar ? ttsl::SmallVector<uint32_t>{1, 1} : ttsl::SmallVector<uint32_t>{1, tensor.padded_shape()[-1]};
+        tensor = ttnn::experimental::view(tensor, tensor.logical_shape(), Shape(new_padded_shape));
+    }
+
+    if (ttnn::is_device_tensor(tensor_arg)) {
+        constexpr bool use_multicore_tilize = true;
+
+        if (not requires_padding_change_to_tile(tensor, target_tile)) {
+            if (tensor.is_sharded()) {
+                uint32_t tile_height = target_tile.get_height();
+                uint32_t tile_width = target_tile.get_width();
+                const auto mem_config = get_memory_config(tensor).value();
+                uint32_t shard_h, shard_w;
+                if (mem_config.shard_spec().has_value()) {
+                    shard_h = mem_config.shard_spec().value().shape[0];
+                    shard_w = mem_config.shard_spec().value().shape[1];
+                } else {
+                    const auto& nd_spec = mem_config.nd_shard_spec().value();
+                    shard_h = nd_spec.shard_shape[-2];
+                    shard_w = nd_spec.shard_shape[-1];
+                }
+                if (shard_h % tile_height != 0 or shard_w % tile_width != 0) {
+                    TT_THROW(
+                        "ttnn::to_layout: Sharded tensor must have shard shape that is a multiple of "
+                        "TILE_SIZE!");
+                }
+            }
+            return ttnn::operations::experimental::quasar::tilize(
+                tensor,
+                output_memory_config,
+                dtype,
+                use_multicore_tilize,
+                false /* low perf mode */,
+                target_tile,
+                sub_core_grids);
+        }
+
+        if (tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
+            // ttnn::tilize_with_val_padding doesn't support height sharded tensors
+            // workaround by applying padding and then tilizing
+            ttsl::SmallVector<std::array<uint32_t, 2>> padding = {
+                {0, 0},
+                {0, 0},
+                {0, padded_output_shape[2] - output_shape[2]},
+                {0, padded_output_shape[3] - output_shape[3]}};
+            TT_FATAL(!sub_core_grids.has_value(), "Pad OP does not currently support sub core grid");
+            tensor = ttnn::operations::experimental::quasar::pad(tensor, padding, pad_value, true, std::nullopt);
+            return ttnn::operations::experimental::quasar::tilize(
+                tensor, output_memory_config, dtype, use_multicore_tilize, false, target_tile, std::nullopt);
+        }
+
+        PadValue pad_value_variant;
+        if (tensor.dtype() == ttnn::DataType::BFLOAT16 or tensor.dtype() == ttnn::DataType::FLOAT32) {
+            pad_value_variant = pad_value;
+        } else if (tensor.dtype() == ttnn::DataType::INT32) {
+            TT_FATAL(
+                pad_value >= static_cast<float>(std::numeric_limits<int32_t>::min()) &&
+                    pad_value < static_cast<float>(std::numeric_limits<int32_t>::max()),
+                "Pad value must be in the range of INT32 type");
+            // static_cast safely truncates the float into a signed integer,
+            // while std::bit_cast reinterprets those exact bits as unsigned to cleanly handle negative
+            // wrap-arounds.
+            pad_value_variant = std::bit_cast<uint32_t>(static_cast<int32_t>(pad_value));
+        } else {
+            TT_FATAL(
+                pad_value >= 0.0f && pad_value < static_cast<float>(std::numeric_limits<uint32_t>::max()),
+                "Pad value must be in the range of UINT32 type");
+            pad_value_variant = (uint32_t)pad_value;
+        }
+        tensor = ttnn::operations::experimental::quasar::tilize_with_val_padding(
+            tensor,
+            Shape(padded_output_shape),
+            pad_value_variant,
+            output_memory_config,
+            dtype,
+            use_multicore_tilize,
+            sub_core_grids,
+            target_tile);
+
+        if (original_rank < 2) {
+            return ttnn::operations::experimental::quasar::reshape(
+                tensor,
+                original_shape,
+                std::nullopt /*Memory Config*/,
+                std::nullopt /*pad value*/,
+                TileReshapeMapMode::CACHE,
+                sub_core_grids);
+        }
+        return tensor;
+    }
+
+    TT_ASSERT(!dtype.has_value(), "dtype cannot be specified when converting layout on host!");
+
+    if (!requires_padding_change_to_tile(tensor, target_tile)) {
+        return tensor.to_layout(Layout::TILE, target_tile);
+    }
+
+    ttsl::SmallVector<uint32_t> padded_input_start(padded_output_shape.rank(), 0);
+    tensor = tensor.pad(ttnn::Shape(padded_output_shape), ttnn::Shape(std::move(padded_input_start)), pad_value);
+    tensor = tensor.to_layout(Layout::TILE, target_tile);
+    return ttnn::experimental::view(tensor, output_shape, padded_output_shape);
+}
+
 Tensor to_layout_impl(
     const ttnn::Tensor& tensor_arg,
     const ttnn::Layout layout,
     const std::optional<ttnn::DataType>& dtype,
     const std::optional<ttnn::MemoryConfig>& memory_config,
     const std::optional<CoreRangeSet>& sub_core_grids,
-    const float pad_value) {
-    if (tensor_arg.layout() == layout) {
+    const float pad_value,
+    const std::optional<tt::tt_metal::Tile>& tile) {
+    validate_tile_semantics(tensor_arg, layout, tile);
+
+    const bool needs_retile = layout == ttnn::TILE_LAYOUT && tile.has_value() &&
+                               tensor_arg.layout() == ttnn::TILE_LAYOUT &&
+                               tensor_arg.tensor_spec().tile() != tile.value();
+    if (tensor_arg.layout() == layout && !needs_retile) {
         if (dtype.has_value() and dtype.value() != tensor_arg.dtype()) {
             log_warning(
                 tt::LogOp,
@@ -77,187 +289,14 @@ Tensor to_layout_impl(
         return tensor_arg;
     }
 
-    const std::set<ttnn::Layout> supported_layouts = {
-        ttnn::ROW_MAJOR_LAYOUT,
-        ttnn::TILE_LAYOUT,
-    };
-
-    if (!supported_layouts.contains(layout)) {
-        TT_THROW("ttnn::to_layout: Unsupported layout conversion from {} to {}!", tensor_arg.layout(), layout);
+    switch (layout) {
+        case ttnn::ROW_MAJOR_LAYOUT: return to_row_major_layout_impl(tensor_arg, dtype, memory_config, sub_core_grids);
+        case ttnn::TILE_LAYOUT:
+            return to_tile_layout_impl(tensor_arg, dtype, memory_config, sub_core_grids, pad_value, tile);
+        default: TT_THROW("ttnn::to_layout: Unsupported layout conversion from {} to {}!", tensor_arg.layout(), layout);
     }
-
-    auto tensor = tensor_arg;
-    auto output_shape = tensor_arg.logical_shape();
-    auto output_memory_config =
-        memory_config.value_or(ttnn::get_memory_config(tensor).value_or(ttnn::DRAM_MEMORY_CONFIG));
-
-    tt::tt_metal::PageConfig page_config = tt::tt_metal::PageConfig(Layout::TILE);
-    if (tensor_arg.layout() == Layout::TILE) {
-        page_config = tt::tt_metal::PageConfig(Layout::TILE, tensor_arg.tensor_spec().tile());
-    }
-    // Padded shape only (dtype-independent). Use TensorLayout, not a tt::tt_metal::TensorSpec: tt::tt_metal::TensorSpec
-    // rejects FP8_E4M3 + TILE (fp8 is ROW_MAJOR-only) though fp8 is a valid tilize input; the real output dtype flows
-    // through `dtype` into tilize()/untilize() below.
-    auto padded_output_shape = tt::tt_metal::TensorLayout(tensor_arg.dtype(), page_config, output_memory_config)
-                                   .compute_padded_shape(tensor_arg.logical_shape());
-    auto original_rank = tensor_arg.logical_shape().rank();
-    const auto& original_shape = tensor_arg.logical_shape();
-
-    if (layout == ttnn::TILE_LAYOUT) {
-        if (tensor.padded_shape().size() < 2) {
-            TT_FATAL(
-                !tensor.is_sharded(),
-                "ttnn::to_layout: Cannot convert a sharded device tensor with rank {} to TILE_LAYOUT. "
-                "Tilize requires shard dimensions divisible by tile size, but rank promotion to 2D "
-                "produces a shard height of 1. Move to interleaved first, then tilize.",
-                tensor.padded_shape().size());
-            const bool is_scalar = tensor.padded_shape().size() == 0;
-            ttsl::SmallVector<uint32_t> new_padded_shape =
-                is_scalar ? ttsl::SmallVector<uint32_t>{1, 1}
-                          : ttsl::SmallVector<uint32_t>{1, tensor.padded_shape()[-1]};
-            tensor = ttnn::experimental::view(tensor, tensor.logical_shape(), Shape(new_padded_shape));
-        }
-    }
-
-    if (ttnn::is_device_tensor(tensor_arg)) {
-        bool use_multicore_untilize = true;
-        bool use_multicore_tilize = true;
-
-        if (not requires_padding_change(tensor, layout)) {
-            if (layout == ttnn::ROW_MAJOR_LAYOUT) {
-                TT_FATAL(is_allowed_row_major_dtype(tensor_arg.dtype(), dtype), "{}", kRowMajorDtypeErrorMessage);
-                return ttnn::operations::experimental::quasar::untilize(
-                    tensor, output_memory_config, use_multicore_untilize, sub_core_grids);
-            }
-            if (layout == ttnn::TILE_LAYOUT) {
-                if (tensor.is_sharded()) {
-                    tt::tt_metal::Tile tensor_tile = tt::tt_metal::Tile();
-                    if (tensor.layout() == ttnn::TILE_LAYOUT) {
-                        tensor_tile = tensor.tensor_spec().tile();
-                    }
-                    uint32_t tile_height = tensor_tile.get_height();
-                    uint32_t tile_width = tensor_tile.get_width();
-                    const auto mem_config = get_memory_config(tensor).value();
-                    uint32_t shard_h, shard_w;
-                    if (mem_config.shard_spec().has_value()) {
-                        shard_h = mem_config.shard_spec().value().shape[0];
-                        shard_w = mem_config.shard_spec().value().shape[1];
-                    } else {
-                        const auto& nd_spec = mem_config.nd_shard_spec().value();
-                        shard_h = nd_spec.shard_shape[-2];
-                        shard_w = nd_spec.shard_shape[-1];
-                    }
-                    if (shard_h % tile_height != 0 or shard_w % tile_width != 0) {
-                        TT_THROW(
-                            "ttnn::to_layout: Sharded tensor must have shard shape that is a multiple of "
-                            "TILE_SIZE!");
-                    }
-                }
-                return ttnn::operations::experimental::quasar::tilize(
-                    tensor,
-                    output_memory_config,
-                    dtype,
-                    use_multicore_tilize,
-                    false /* low perf mode */,
-                    sub_core_grids);
-            }
-            throw std::runtime_error("ttnn::to_layout: Unsupported layout!");
-        }
-        if (layout == ttnn::ROW_MAJOR_LAYOUT) {
-            TT_FATAL(is_allowed_row_major_dtype(tensor_arg.dtype(), dtype), "{}", kRowMajorDtypeErrorMessage);
-
-            if (tensor.is_sharded()) {
-                output_memory_config =
-                    memory_config.value_or(ttnn::get_memory_config(tensor).value_or(ttnn::DRAM_MEMORY_CONFIG));
-            }
-            Shape output_tensor_end(ttsl::SmallVector<uint32_t>(tensor.logical_shape().rank(), 0));
-            int logical_rank = tensor.logical_shape().rank();
-            for (int index = -1; index >= -logical_rank; --index) {
-                output_tensor_end[index] = tensor.logical_shape()[index] - 1;
-            }
-            return ttnn::operations::experimental::quasar::untilize_with_unpadding(
-                tensor, output_tensor_end, output_memory_config, use_multicore_untilize, sub_core_grids);
-        }
-        if (layout == ttnn::TILE_LAYOUT) {
-            if (tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
-                // ttnn::tilize_with_val_padding doesn't support height sharded tensors
-                // workaround by applying padding and then tilizing
-                ttsl::SmallVector<std::array<uint32_t, 2>> padding = {
-                    {0, 0},
-                    {0, 0},
-                    {0, padded_output_shape[2] - output_shape[2]},
-                    {0, padded_output_shape[3] - output_shape[3]}};
-                TT_FATAL(!sub_core_grids.has_value(), "Pad OP does not currently support sub core grid");
-                tensor = ttnn::operations::experimental::quasar::pad(tensor, padding, pad_value, true, std::nullopt);
-                return ttnn::operations::experimental::quasar::tilize(
-                    tensor, output_memory_config, dtype, use_multicore_tilize);
-            } else {
-                PadValue pad_value_variant;
-                if (tensor.dtype() == ttnn::DataType::BFLOAT16 or tensor.dtype() == ttnn::DataType::FLOAT32) {
-                    pad_value_variant = pad_value;
-                } else if (tensor.dtype() == ttnn::DataType::INT32) {
-                    TT_FATAL(
-                        pad_value >= static_cast<float>(std::numeric_limits<int32_t>::min()) &&
-                            pad_value < static_cast<float>(std::numeric_limits<int32_t>::max()),
-                        "Pad value must be in the range of INT32 type");
-                    // static_cast safely truncates the float into a signed integer,
-                    // while std::bit_cast reinterprets those exact bits as unsigned to cleanly handle negative
-                    // wrap-arounds.
-                    pad_value_variant = std::bit_cast<uint32_t>(static_cast<int32_t>(pad_value));
-                } else {
-                    TT_FATAL(
-                        pad_value >= 0.0f && pad_value < static_cast<float>(std::numeric_limits<uint32_t>::max()),
-                        "Pad value must be in the range of UINT32 type");
-                    pad_value_variant = (uint32_t)pad_value;
-                }
-                tensor = ttnn::operations::experimental::quasar::tilize_with_val_padding(
-                    tensor,
-                    Shape(padded_output_shape),
-                    pad_value_variant,
-                    output_memory_config,
-                    dtype,
-                    use_multicore_tilize,
-                    sub_core_grids);
-            }
-            if (original_rank < 2) {
-                return ttnn::operations::experimental::quasar::reshape(
-                    tensor,
-                    original_shape,
-                    std::nullopt /*Memory Config*/,
-                    std::nullopt /*pad value*/,
-                    TileReshapeMapMode::CACHE,
-                    sub_core_grids);
-            }
-            return tensor;
-        }
-        TT_THROW("ttnn::to_layout: Unsupported output layout: {}!", layout);
-    }
-    TT_ASSERT(!dtype.has_value(), "dtype cannot be specified when converting layout on host!");
-    if (!requires_padding_change(tensor, layout)) {
-        return tensor.to_layout(layout);
-    }
-    if (layout == ttnn::ROW_MAJOR_LAYOUT) {
-        tensor = tensor.to_layout(layout);
-        tensor = tensor.unpad_from_tile(tensor.logical_shape());
-        return ttnn::operations::experimental::quasar::reshape(
-            tensor,
-            ttnn::Shape{output_shape},
-            std::nullopt, /*Memory Config*/
-            std::nullopt, /*Pad Value*/
-            TileReshapeMapMode::CACHE,
-            sub_core_grids);
-    }
-    if (layout == ttnn::TILE_LAYOUT) {
-        ttsl::SmallVector<uint32_t> padded_input_start;
-        for (int index = 0; index < padded_output_shape.rank(); ++index) {
-            padded_input_start.push_back(0);
-        }
-        tensor = tensor.pad(ttnn::Shape(padded_output_shape), ttnn::Shape(std::move(padded_input_start)), pad_value);
-        tensor = tensor.to_layout(layout);
-        return ttnn::experimental::view(tensor, output_shape, padded_output_shape);
-    }
-    TT_THROW("ttnn::to_layout: Unsupported output layout: {}!", layout);
 }
+
 }  // namespace
 
 }  // namespace ttnn::operations::experimental::quasar::CMAKE_UNIQUE_NAMESPACE
@@ -270,8 +309,10 @@ Tensor to_layout(
     const std::optional<DataType>& dtype,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<CoreRangeSet>& sub_core_grids,
-    const float pad_value) {
-    return CMAKE_UNIQUE_NAMESPACE::to_layout_impl(tensor_arg, layout, dtype, memory_config, sub_core_grids, pad_value);
+    const float pad_value,
+    const std::optional<tt::tt_metal::Tile>& tile) {
+    return CMAKE_UNIQUE_NAMESPACE::to_layout_impl(
+        tensor_arg, layout, dtype, memory_config, sub_core_grids, pad_value, tile);
 }
 
 }  // namespace ttnn::operations::experimental::quasar

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/to_layout/to_layout_op.cpp
@@ -8,6 +8,8 @@
 #include <limits>
 #include <string_view>
 
+#include <tt_stl/reflection.hpp>
+
 #include "ttnn/distributed/types.hpp"
 #include "ttnn/operations/experimental/quasar/pad/pad.hpp"
 #include "ttnn/operations/experimental/quasar/tilize/tilize.hpp"

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/to_layout/to_layout_op.cpp
@@ -23,7 +23,9 @@ namespace ttnn::operations::experimental::quasar::CMAKE_UNIQUE_NAMESPACE {
 namespace {
 
 void validate_tile_semantics(
-    const ttnn::Tensor& tensor, ttnn::Layout layout, const std::optional<tt::tt_metal::Tile>& requested_tile) {
+    const ttnn::Tensor& tensor,
+    ttnn::Layout layout,
+    ttsl::optional_reference<const tt::tt_metal::Tile> requested_tile) {
     if (layout == Layout::ROW_MAJOR) {
         TT_FATAL(
             !requested_tile.has_value(),
@@ -129,12 +131,12 @@ Tensor to_tile_layout_impl(
     const std::optional<ttnn::MemoryConfig>& memory_config,
     const std::optional<CoreRangeSet>& sub_core_grids,
     const float pad_value,
-    const std::optional<tt::tt_metal::Tile>& tile) {
+    ttsl::optional_reference<const tt::tt_metal::Tile> tile) {
     auto tensor = tensor_arg;
     const auto& output_shape = tensor_arg.logical_shape();
     auto output_memory_config =
         memory_config.value_or(ttnn::get_memory_config(tensor).value_or(ttnn::DRAM_MEMORY_CONFIG));
-    const auto target_tile = tile.value_or(tt::tt_metal::Tile{});
+    const auto target_tile = tile.has_value() ? *tile : tt::tt_metal::Tile{};
 
     // Padded shape only (dtype-independent). Use TensorLayout, not a TensorSpec: TensorSpec rejects
     // FP8_E4M3 + TILE (fp8 is ROW_MAJOR-only) though fp8 is a valid tilize input; the real output dtype
@@ -265,7 +267,7 @@ Tensor to_layout_impl(
     const std::optional<ttnn::MemoryConfig>& memory_config,
     const std::optional<CoreRangeSet>& sub_core_grids,
     const float pad_value,
-    const std::optional<tt::tt_metal::Tile>& tile) {
+    ttsl::optional_reference<const tt::tt_metal::Tile> tile) {
     validate_tile_semantics(tensor_arg, layout, tile);
 
     const bool needs_retile = layout == ttnn::TILE_LAYOUT && tile.has_value() &&
@@ -310,7 +312,7 @@ Tensor to_layout(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<CoreRangeSet>& sub_core_grids,
     const float pad_value,
-    const std::optional<tt::tt_metal::Tile>& tile) {
+    ttsl::optional_reference<const tt::tt_metal::Tile> tile) {
     return CMAKE_UNIQUE_NAMESPACE::to_layout_impl(
         tensor_arg, layout, dtype, memory_config, sub_core_grids, pad_value, tile);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/to_layout/to_layout_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/to_layout/to_layout_op.hpp
@@ -23,6 +23,7 @@ Tensor to_layout(
     const std::optional<DataType>& dtype = std::nullopt,
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
-    float pad_value = 0.0f);
+    float pad_value = 0.0f,
+    const std::optional<tt::tt_metal::Tile>& tile = std::nullopt);
 
 }  // namespace ttnn::operations::experimental::quasar

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/to_layout/to_layout_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/to_layout/to_layout_op.hpp
@@ -7,6 +7,7 @@
 #include <functional>
 #include <optional>
 
+#include <tt_stl/optional_reference.hpp>
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/host_buffer/functions.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
@@ -24,6 +25,6 @@ Tensor to_layout(
     const std::optional<MemoryConfig>& memory_config = std::nullopt,
     const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
     float pad_value = 0.0f,
-    const std::optional<tt::tt_metal::Tile>& tile = std::nullopt);
+    ttsl::optional_reference<const tt::tt_metal::Tile> tile = std::nullopt);
 
 }  // namespace ttnn::operations::experimental::quasar


### PR DESCRIPTION
### PR Category
Cleanup

### Summary

Part of #18536.

Custom tile geometry is currently plumbed through ttnn in a janky way: to tilize a tensor into a custom tile you have to stamp that tile onto the tensor at creation, so that `tilize`/`to_layout` can implicitly read it back off the tensor spec later. This makes custom-tile info a "would be" property of a tensor rather than an input to the tilization operation that actually uses it.

This PR flips that: the tile becomes an explicit optional argument to `to_layout`, `tilize`, and `tilize_with_val_padding`, passed at the point of conversion instead of at creation. When omitted, everything falls back to the default tile, so existing call sites are unaffected.

### Notes for reviewers

- Note that there's an assumption in this stream of changes that the tile metadata in row major tensor is always the default tile, this is enforced by #50166.
- Device `tilize(tile=...)` support for tiny tiles (width 32, heights `{32,16,8,4,2}`) landed in #50129; this PR adopts that API (`tile` before `sub_core_grids`) and wires `to_layout(tile=...)` through it, including retile when geometry differs.
- Custom tile on `tilize_with_val_padding` / `tilize_with_zero_padding` (and Quasar `tilize`) is still explicitly rejected until device support exists. 

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/ttnn-tile-plumbing)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/ttnn-tile-plumbing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/ttnn-tile-plumbing)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/ttnn-tile-plumbing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=riverwu/ttnn-tile-plumbing)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:riverwu/ttnn-tile-plumbing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/ttnn-tile-plumbing)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/ttnn-tile-plumbing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/ttnn-tile-plumbing)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/ttnn-tile-plumbing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/ttnn-tile-plumbing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/ttnn-tile-plumbing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/ttnn-tile-plumbing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/ttnn-tile-plumbing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/ttnn-tile-plumbing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/ttnn-tile-plumbing)