### PR TITLE
[Bug Fix] Fix Host tensor operations dropping attribtues

### DIFF
--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -110,6 +110,7 @@ set(UNIT_TESTS_API_TENSOR_SOURCES
     tensor/test_host_tensor.cpp
     tensor/test_host_tensor_to_layout.cpp
     tensor/test_host_tensor_to_dtype.cpp
+    tensor/test_host_tensor_spec_preservation.cpp
     tensor/test_mesh_tensor.cpp
     tensor/test_tensor_types.cpp
     tensor/test_tensor_layout.cpp

--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -109,6 +109,7 @@ set(UNIT_TESTS_API_TENSOR_SOURCES
     tensor/test_tensor_sharding.cpp
     tensor/test_host_tensor.cpp
     tensor/test_host_tensor_to_layout.cpp
+    tensor/test_host_tensor_to_dtype.cpp
     tensor/test_mesh_tensor.cpp
     tensor/test_tensor_types.cpp
     tensor/test_tensor_layout.cpp

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_spec_preservation.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_spec_preservation.cpp
@@ -1,0 +1,256 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include <tt-metalium/experimental/tensor/host_tensor.hpp>
+#include <tt-metalium/experimental/tensor/tensor_apis.hpp>
+#include <tt-metalium/experimental/tensor/spec/tensor_spec.hpp>
+#include <tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp>
+#include <tt-metalium/experimental/tensor/spec/layout/page_config.hpp>
+#include <tt-metalium/experimental/per_core_allocation/buffer.hpp>
+#include <tt-metalium/host_buffer.hpp>
+#include <tt-metalium/shape.hpp>
+#include <tt-metalium/tile.hpp>
+
+namespace tt::tt_metal {
+namespace {
+
+template <typename T>
+std::vector<T> make_ramp(size_t count) {
+    std::vector<T> data(count);
+    for (size_t i = 0; i < count; ++i) {
+        data[i] = static_cast<T>(static_cast<float>(i % 251));
+    }
+    return data;
+}
+
+bool exact_spec_match(const TensorSpec& a, const TensorSpec& b) {
+    return a == b && experimental::per_core_allocation::is_per_core_allocation(a.memory_config()) ==
+                         experimental::per_core_allocation::is_per_core_allocation(b.memory_config());
+}
+
+void expect_packed_sizes(const HostTensor& tensor) {
+    const size_t expected = tensor.tensor_spec().compute_packed_buffer_size_bytes();
+    for (const auto& coord : tensor.buffer().shard_coords()) {
+        auto shard = tensor.buffer().get_shard(coord);
+        ASSERT_TRUE(shard.has_value());
+        EXPECT_EQ(shard->view_bytes().size(), expected);
+    }
+}
+
+TEST(HostTensorSpecPreservation, ToLayoutInterleavedRmTileRoundTrip) {
+    const Shape shape{32, 32};
+    auto data = make_ramp<float>(shape.volume());
+    // Interleaved cannot set per_core (requires sharded); exact_spec_match still checks the flag.
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    // Alignment coherent with TILE after initialize_alignment (multiples of tile H/W).
+    auto alignment = Alignment({32, 32});
+    auto tile = Tile({16, 16});
+
+    auto tile_source_spec =
+        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto tile_source = HostTensor::from_vector<float>(data, tile_source_spec);
+
+    auto rm = to_layout(tile_source, Layout::ROW_MAJOR);
+    auto expected_rm_spec =
+        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
+    EXPECT_TRUE(exact_spec_match(rm.tensor_spec(), expected_rm_spec));
+    EXPECT_EQ(rm.memory_config().buffer_type(), BufferType::DRAM);
+    EXPECT_EQ(rm.tensor_topology(), tile_source.tensor_topology());
+    expect_packed_sizes(rm);
+
+    // RM PageConfig does not carry a non-default tile; restore TILE with explicit tile.
+    auto tiled_back = to_tile_layout(rm, tile);
+    auto expected_tile_spec =
+        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    EXPECT_TRUE(exact_spec_match(tiled_back.tensor_spec(), expected_tile_spec));
+    EXPECT_EQ(tiled_back.memory_config().buffer_type(), BufferType::DRAM);
+    EXPECT_EQ(tiled_back.tensor_topology(), tile_source.tensor_topology());
+    expect_packed_sizes(tiled_back);
+
+    auto round_trip = tiled_back.to_vector<float>();
+    ASSERT_EQ(round_trip.size(), data.size());
+    for (size_t i = 0; i < data.size(); ++i) {
+        EXPECT_EQ(round_trip[i], data[i]);
+    }
+}
+
+TEST(HostTensorSpecPreservation, ToLayoutShardedPreservesShardSpecAndPackedSizes) {
+    const Shape shape{32, 64};
+    auto memory_config = MemoryConfig{
+        TensorMemoryLayout::HEIGHT_SHARDED,
+        BufferType::L1,
+        ShardSpec{CoreRangeSet({CoreRange({0, 0}, {0, 1})}), {16, 64}, ShardOrientation::ROW_MAJOR}};
+    experimental::per_core_allocation::set_per_core_allocation(memory_config, true);
+    auto alignment = Alignment({32, 64});
+    auto tile = Tile({16, 16});
+
+    auto source_spec =
+        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+
+    auto topology = TensorTopology::create_fully_replicated_tensor_topology(distributed::MeshShape(1, 2));
+    auto distributed_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 2));
+    auto data_0 = make_ramp<float>(shape.volume());
+    auto data_1 = make_ramp<float>(shape.volume());
+    for (auto& v : data_1) {
+        v += 10.0f;
+    }
+    distributed_buffer.emplace_shard(
+        distributed::MeshCoordinate(0, 0), [&]() { return HostBuffer(std::vector<float>(data_0)); });
+    distributed_buffer.emplace_shard(
+        distributed::MeshCoordinate(0, 1), [&]() { return HostBuffer(std::vector<float>(data_1)); });
+    auto source = HostTensor::from_buffer(std::move(distributed_buffer), source_spec, topology);
+
+    auto result = to_layout(source, Layout::ROW_MAJOR);
+
+    auto expected_spec =
+        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
+    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), expected_spec));
+    EXPECT_TRUE(result.memory_config().shard_spec().has_value());
+    EXPECT_EQ(result.memory_config().shard_spec(), memory_config.shard_spec());
+    EXPECT_TRUE(experimental::per_core_allocation::is_per_core_allocation(result.memory_config()));
+    EXPECT_EQ(result.tensor_topology(), topology);
+    expect_packed_sizes(result);
+
+    auto coords = result.buffer().shard_coords();
+    EXPECT_EQ(coords.size(), 2);
+    EXPECT_TRUE(coords.contains(distributed::MeshCoordinate(0, 0)));
+    EXPECT_TRUE(coords.contains(distributed::MeshCoordinate(0, 1)));
+}
+
+TEST(HostTensorSpecPreservation, ToLayoutPhysicalMismatchThrows) {
+    const Shape shape{32, 24};
+    auto data = make_ramp<float>(shape.volume());
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    // Width alignment is not a multiple of tile width 16 → TILE initialize_alignment rounds up.
+    auto alignment = Alignment({32, 24});
+    auto tile = Tile({16, 16});
+
+    auto source_spec = TensorSpec(
+        shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR, tile), memory_config, alignment));
+    auto source = HostTensor::from_vector<float>(data, source_spec);
+
+    EXPECT_ANY_THROW(std::ignore = to_tile_layout(source, tile));
+}
+
+TEST(HostTensorSpecPreservation, ToTileLayoutTileMismatchThrows) {
+    const Shape shape{32, 32};
+    auto data = make_ramp<float>(shape.volume());
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto source_spec =
+        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, Tile({32, 32})), memory_config));
+    auto source = HostTensor::from_vector<float>(data, source_spec);
+
+    EXPECT_ANY_THROW(std::ignore = to_tile_layout(source, Tile({16, 16})));
+}
+
+TEST(HostTensorSpecPreservation, ToTileLayoutBfpTileMismatchThrows) {
+    const Shape shape{32, 32};
+    auto data = make_ramp<float>(shape.volume());
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto source_spec =
+        TensorSpec(shape, TensorLayout(DataType::BFLOAT8_B, PageConfig(Layout::TILE, Tile({32, 32})), memory_config));
+    auto source = HostTensor::from_vector<float>(data, source_spec);
+
+    EXPECT_ANY_THROW(std::ignore = to_tile_layout(source, Tile({16, 16})));
+}
+
+TEST(HostTensorSpecPreservation, PadUnpadInterleavedPreservesMemoryAndGeometry) {
+    const Shape logical{2, 3};
+    auto data = make_ramp<float>(logical.volume());
+    // pad/unpad reject sharded hosts, so per_core cannot be set true here; exact_spec_match still covers the flag.
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto source_spec =
+        TensorSpec(logical, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
+    auto source = HostTensor::from_vector<float>(data, source_spec);
+
+    const Shape padded{4, 6};
+    auto padded_tensor = pad(source, padded, Shape{0, 0}, 0.0f);
+
+    auto expected_pad_spec = TensorSpec(
+        logical,
+        TensorLayout::fromPaddedShape(
+            DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, logical, padded));
+    EXPECT_TRUE(exact_spec_match(padded_tensor.tensor_spec(), expected_pad_spec));
+    EXPECT_EQ(padded_tensor.memory_config().buffer_type(), BufferType::DRAM);
+    EXPECT_EQ(padded_tensor.padded_shape(), padded);
+    EXPECT_EQ(padded_tensor.logical_shape(), logical);
+    expect_packed_sizes(padded_tensor);
+
+    auto unpadded = unpad(padded_tensor, Shape{0, 0}, Shape{2, 3});
+    auto expected_unpad_spec = TensorSpec(
+        logical,
+        TensorLayout::fromPaddedShape(
+            DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, logical, logical));
+    EXPECT_TRUE(exact_spec_match(unpadded.tensor_spec(), expected_unpad_spec));
+    EXPECT_EQ(unpadded.memory_config().buffer_type(), BufferType::DRAM);
+    EXPECT_EQ(unpadded.logical_shape(), logical);
+    EXPECT_EQ(unpadded.padded_shape(), logical);
+    expect_packed_sizes(unpadded);
+
+    auto values = unpadded.to_vector<float>();
+    ASSERT_EQ(values.size(), data.size());
+    for (size_t i = 0; i < data.size(); ++i) {
+        EXPECT_EQ(values[i], data[i]);
+    }
+}
+
+TEST(HostTensorSpecPreservation, PadShardedLegacyThrows) {
+    const Shape shape{32, 32};
+    auto data = make_ramp<float>(shape.volume());
+    auto memory_config = MemoryConfig{
+        TensorMemoryLayout::HEIGHT_SHARDED,
+        BufferType::L1,
+        ShardSpec{CoreRangeSet({CoreRange({0, 0}, {0, 0})}), {32, 32}, ShardOrientation::ROW_MAJOR}};
+    auto source_spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
+    auto source = HostTensor::from_vector<float>(data, source_spec);
+
+    EXPECT_ANY_THROW(std::ignore = pad(source, Shape{64, 32}, Shape{0, 0}, 0.0f));
+}
+
+TEST(HostTensorSpecPreservation, UnpadShardedLegacyThrows) {
+    const Shape shape{32, 32};
+    auto data = make_ramp<float>(shape.volume());
+    auto memory_config = MemoryConfig{
+        TensorMemoryLayout::HEIGHT_SHARDED,
+        BufferType::L1,
+        ShardSpec{CoreRangeSet({CoreRange({0, 0}, {0, 0})}), {32, 32}, ShardOrientation::ROW_MAJOR}};
+    auto source_spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
+    auto source = HostTensor::from_vector<float>(data, source_spec);
+
+    EXPECT_ANY_THROW(std::ignore = unpad(source, Shape{0, 0}, Shape{16, 32}));
+}
+
+TEST(HostTensorSpecPreservation, PadShardedConvertibleNdThrows) {
+    const Shape shape{32, 32};
+    auto data = make_ramp<float>(shape.volume());
+    // Convertible ND: 2D height-sharded via NdShardSpec (auto-fills legacy shard_spec).
+    NdShardSpec nd_shard_spec{Shape{32, 32}, CoreRangeSet({CoreRange({0, 0}, {0, 0})}), ShardOrientation::ROW_MAJOR};
+    MemoryConfig memory_config{BufferType::L1, nd_shard_spec};
+    auto source_spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
+    ASSERT_TRUE(source_spec.memory_config().is_sharded());
+    ASSERT_TRUE(source_spec.memory_config().shard_spec().has_value());
+    auto source = HostTensor::from_vector<float>(data, source_spec);
+
+    EXPECT_ANY_THROW(std::ignore = pad(source, Shape{64, 32}, Shape{0, 0}, 0.0f));
+}
+
+TEST(HostTensorSpecPreservation, UnpadShardedConvertibleNdThrows) {
+    const Shape shape{32, 32};
+    auto data = make_ramp<float>(shape.volume());
+    NdShardSpec nd_shard_spec{Shape{32, 32}, CoreRangeSet({CoreRange({0, 0}, {0, 0})}), ShardOrientation::ROW_MAJOR};
+    MemoryConfig memory_config{BufferType::L1, nd_shard_spec};
+    auto source_spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
+    auto source = HostTensor::from_vector<float>(data, source_spec);
+
+    EXPECT_ANY_THROW(std::ignore = unpad(source, Shape{0, 0}, Shape{16, 32}));
+}
+
+}  // namespace
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_spec_preservation.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_spec_preservation.cpp
@@ -20,6 +20,7 @@
 
 namespace tt::tt_metal {
 namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
 
 template <typename T>
 std::vector<T> make_ramp(size_t count) {
@@ -44,9 +45,11 @@ void expect_packed_sizes(const HostTensor& tensor) {
     }
 }
 
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+
 TEST(HostTensorSpecPreservation, ToLayoutInterleavedRmTileRoundTrip) {
     const Shape shape{32, 32};
-    auto data = make_ramp<float>(shape.volume());
+    auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
     // Interleaved cannot set per_core (requires sharded); exact_spec_match still checks the flag.
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     // Alignment coherent with TILE after initialize_alignment (multiples of tile H/W).
@@ -60,19 +63,19 @@ TEST(HostTensorSpecPreservation, ToLayoutInterleavedRmTileRoundTrip) {
     auto rm = to_layout(tile_source, Layout::ROW_MAJOR);
     auto expected_rm_spec =
         TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
-    EXPECT_TRUE(exact_spec_match(rm.tensor_spec(), expected_rm_spec));
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(rm.tensor_spec(), expected_rm_spec));
     EXPECT_EQ(rm.memory_config().buffer_type(), BufferType::DRAM);
     EXPECT_EQ(rm.tensor_topology(), tile_source.tensor_topology());
-    expect_packed_sizes(rm);
+    CMAKE_UNIQUE_NAMESPACE::expect_packed_sizes(rm);
 
     // RM PageConfig does not carry a non-default tile; restore TILE with explicit tile.
     auto tiled_back = to_tile_layout(rm, tile);
     auto expected_tile_spec =
         TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
-    EXPECT_TRUE(exact_spec_match(tiled_back.tensor_spec(), expected_tile_spec));
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(tiled_back.tensor_spec(), expected_tile_spec));
     EXPECT_EQ(tiled_back.memory_config().buffer_type(), BufferType::DRAM);
     EXPECT_EQ(tiled_back.tensor_topology(), tile_source.tensor_topology());
-    expect_packed_sizes(tiled_back);
+    CMAKE_UNIQUE_NAMESPACE::expect_packed_sizes(tiled_back);
 
     auto round_trip = tiled_back.to_vector<float>();
     ASSERT_EQ(round_trip.size(), data.size());
@@ -96,8 +99,8 @@ TEST(HostTensorSpecPreservation, ToLayoutShardedPreservesShardSpecAndPackedSizes
 
     auto topology = TensorTopology::create_fully_replicated_tensor_topology(distributed::MeshShape(1, 2));
     auto distributed_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 2));
-    auto data_0 = make_ramp<float>(shape.volume());
-    auto data_1 = make_ramp<float>(shape.volume());
+    auto data_0 = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
+    auto data_1 = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
     for (auto& v : data_1) {
         v += 10.0f;
     }
@@ -111,12 +114,12 @@ TEST(HostTensorSpecPreservation, ToLayoutShardedPreservesShardSpecAndPackedSizes
 
     auto expected_spec =
         TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
-    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), expected_spec));
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
     EXPECT_TRUE(result.memory_config().shard_spec().has_value());
     EXPECT_EQ(result.memory_config().shard_spec(), memory_config.shard_spec());
     EXPECT_TRUE(experimental::per_core_allocation::is_per_core_allocation(result.memory_config()));
     EXPECT_EQ(result.tensor_topology(), topology);
-    expect_packed_sizes(result);
+    CMAKE_UNIQUE_NAMESPACE::expect_packed_sizes(result);
 
     auto coords = result.buffer().shard_coords();
     EXPECT_EQ(coords.size(), 2);
@@ -126,7 +129,7 @@ TEST(HostTensorSpecPreservation, ToLayoutShardedPreservesShardSpecAndPackedSizes
 
 TEST(HostTensorSpecPreservation, ToLayoutPhysicalMismatchThrows) {
     const Shape shape{32, 24};
-    auto data = make_ramp<float>(shape.volume());
+    auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     // Width alignment is not a multiple of tile width 16 → TILE initialize_alignment rounds up.
     auto alignment = Alignment({32, 24});
@@ -141,7 +144,7 @@ TEST(HostTensorSpecPreservation, ToLayoutPhysicalMismatchThrows) {
 
 TEST(HostTensorSpecPreservation, ToTileLayoutTileMismatchThrows) {
     const Shape shape{32, 32};
-    auto data = make_ramp<float>(shape.volume());
+    auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     auto source_spec =
         TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, Tile({32, 32})), memory_config));
@@ -152,7 +155,7 @@ TEST(HostTensorSpecPreservation, ToTileLayoutTileMismatchThrows) {
 
 TEST(HostTensorSpecPreservation, ToTileLayoutBfpTileMismatchThrows) {
     const Shape shape{32, 32};
-    auto data = make_ramp<float>(shape.volume());
+    auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     auto source_spec =
         TensorSpec(shape, TensorLayout(DataType::BFLOAT8_B, PageConfig(Layout::TILE, Tile({32, 32})), memory_config));
@@ -163,7 +166,7 @@ TEST(HostTensorSpecPreservation, ToTileLayoutBfpTileMismatchThrows) {
 
 TEST(HostTensorSpecPreservation, PadUnpadInterleavedPreservesMemoryAndGeometry) {
     const Shape logical{2, 3};
-    auto data = make_ramp<float>(logical.volume());
+    auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(logical.volume());
     // pad/unpad reject sharded hosts, so per_core cannot be set true here; exact_spec_match still covers the flag.
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     auto source_spec =
@@ -177,22 +180,22 @@ TEST(HostTensorSpecPreservation, PadUnpadInterleavedPreservesMemoryAndGeometry) 
         logical,
         TensorLayout::fromPaddedShape(
             DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, logical, padded));
-    EXPECT_TRUE(exact_spec_match(padded_tensor.tensor_spec(), expected_pad_spec));
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(padded_tensor.tensor_spec(), expected_pad_spec));
     EXPECT_EQ(padded_tensor.memory_config().buffer_type(), BufferType::DRAM);
     EXPECT_EQ(padded_tensor.padded_shape(), padded);
     EXPECT_EQ(padded_tensor.logical_shape(), logical);
-    expect_packed_sizes(padded_tensor);
+    CMAKE_UNIQUE_NAMESPACE::expect_packed_sizes(padded_tensor);
 
     auto unpadded = unpad(padded_tensor, Shape{0, 0}, Shape{2, 3});
     auto expected_unpad_spec = TensorSpec(
         logical,
         TensorLayout::fromPaddedShape(
             DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, logical, logical));
-    EXPECT_TRUE(exact_spec_match(unpadded.tensor_spec(), expected_unpad_spec));
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(unpadded.tensor_spec(), expected_unpad_spec));
     EXPECT_EQ(unpadded.memory_config().buffer_type(), BufferType::DRAM);
     EXPECT_EQ(unpadded.logical_shape(), logical);
     EXPECT_EQ(unpadded.padded_shape(), logical);
-    expect_packed_sizes(unpadded);
+    CMAKE_UNIQUE_NAMESPACE::expect_packed_sizes(unpadded);
 
     auto values = unpadded.to_vector<float>();
     ASSERT_EQ(values.size(), data.size());
@@ -203,7 +206,7 @@ TEST(HostTensorSpecPreservation, PadUnpadInterleavedPreservesMemoryAndGeometry) 
 
 TEST(HostTensorSpecPreservation, PadShardedLegacyThrows) {
     const Shape shape{32, 32};
-    auto data = make_ramp<float>(shape.volume());
+    auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
     auto memory_config = MemoryConfig{
         TensorMemoryLayout::HEIGHT_SHARDED,
         BufferType::L1,
@@ -216,7 +219,7 @@ TEST(HostTensorSpecPreservation, PadShardedLegacyThrows) {
 
 TEST(HostTensorSpecPreservation, UnpadShardedLegacyThrows) {
     const Shape shape{32, 32};
-    auto data = make_ramp<float>(shape.volume());
+    auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
     auto memory_config = MemoryConfig{
         TensorMemoryLayout::HEIGHT_SHARDED,
         BufferType::L1,
@@ -229,7 +232,7 @@ TEST(HostTensorSpecPreservation, UnpadShardedLegacyThrows) {
 
 TEST(HostTensorSpecPreservation, PadShardedConvertibleNdThrows) {
     const Shape shape{32, 32};
-    auto data = make_ramp<float>(shape.volume());
+    auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
     // Convertible ND: 2D height-sharded via NdShardSpec (auto-fills legacy shard_spec).
     NdShardSpec nd_shard_spec{Shape{32, 32}, CoreRangeSet({CoreRange({0, 0}, {0, 0})}), ShardOrientation::ROW_MAJOR};
     MemoryConfig memory_config{BufferType::L1, nd_shard_spec};
@@ -243,7 +246,7 @@ TEST(HostTensorSpecPreservation, PadShardedConvertibleNdThrows) {
 
 TEST(HostTensorSpecPreservation, UnpadShardedConvertibleNdThrows) {
     const Shape shape{32, 32};
-    auto data = make_ramp<float>(shape.volume());
+    auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
     NdShardSpec nd_shard_spec{Shape{32, 32}, CoreRangeSet({CoreRange({0, 0}, {0, 0})}), ShardOrientation::ROW_MAJOR};
     MemoryConfig memory_config{BufferType::L1, nd_shard_spec};
     auto source_spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_dtype.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_dtype.cpp
@@ -25,6 +25,7 @@
 
 namespace tt::tt_metal {
 namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
 
 
 // Deterministic ramp for test data
@@ -42,9 +43,11 @@ bool exact_spec_match(const TensorSpec& a, const TensorSpec& b) {
                          experimental::per_core_allocation::is_per_core_allocation(b.memory_config());
 }
 
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+
 TEST(HostTensorToDtype, NonBfpPreservesMetadata) {
     const Shape shape{32, 32};
-    auto data = make_ramp<float>(shape.volume());
+    auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     auto alignment = tt::tt_metal::Alignment({32, 32});
     auto tile = Tile({16, 16});
@@ -58,7 +61,7 @@ TEST(HostTensorToDtype, NonBfpPreservesMetadata) {
     auto expected_spec =
         TensorSpec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE, tile), memory_config, alignment));
 
-    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), expected_spec));
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
     EXPECT_EQ(result.dtype(), DataType::BFLOAT16);
     EXPECT_EQ(result.layout(), Layout::TILE);
     EXPECT_EQ(result.tensor_spec().tile(), tile);
@@ -66,7 +69,7 @@ TEST(HostTensorToDtype, NonBfpPreservesMetadata) {
 
 TEST(HostTensorToDtype, RowMajorToBfpChangesLayoutToTileAndPreservesTile) {
     const Shape shape{32, 32};
-    auto data = make_ramp<float>(shape.volume());
+    auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     auto alignment = tt::tt_metal::Alignment({32, 32});
     auto tile = Tile({16, 16});
@@ -81,7 +84,7 @@ TEST(HostTensorToDtype, RowMajorToBfpChangesLayoutToTileAndPreservesTile) {
     auto expected_spec =
         TensorSpec(shape, TensorLayout(DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
 
-    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), expected_spec));
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
     EXPECT_EQ(result.layout(), Layout::TILE);
     EXPECT_EQ(result.tensor_spec().tile(), tile);
 
@@ -131,7 +134,7 @@ TEST(HostTensorToDtype, TileBfp8ToFloat32ValueCheck) {
     auto expected_spec =
         TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
 
-    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), expected_spec));
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
     EXPECT_EQ(result.dtype(), DataType::FLOAT32);
     EXPECT_EQ(result.layout(), Layout::TILE);
     EXPECT_EQ(result.tensor_spec().tile(), tile);
@@ -176,7 +179,7 @@ TEST(HostTensorToDtype, Float32ToTileBfp8ValueCheck) {
     auto expected_spec =
         TensorSpec(shape, TensorLayout(DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
 
-    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), expected_spec));
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
     EXPECT_EQ(result.dtype(), DataType::BFLOAT8_B);
     EXPECT_EQ(result.layout(), Layout::TILE);
     EXPECT_EQ(result.tensor_spec().tile(), tile);
@@ -216,7 +219,7 @@ TEST(HostTensorToDtype, TileBfp4ToFloat32ValueCheck) {
     auto expected_spec =
         TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
 
-    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), expected_spec));
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
     EXPECT_EQ(result.dtype(), DataType::FLOAT32);
     EXPECT_EQ(result.layout(), Layout::TILE);
     EXPECT_EQ(result.tensor_spec().tile(), tile);
@@ -260,7 +263,7 @@ TEST(HostTensorToDtype, Float32ToTileBfp4ValueCheck) {
     auto expected_spec =
         TensorSpec(shape, TensorLayout(DataType::BFLOAT4_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
 
-    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), expected_spec));
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
     EXPECT_EQ(result.dtype(), DataType::BFLOAT4_B);
     EXPECT_EQ(result.layout(), Layout::TILE);
     EXPECT_EQ(result.tensor_spec().tile(), tile);
@@ -274,7 +277,7 @@ TEST(HostTensorToDtype, Float32ToTileBfp4ValueCheck) {
 
 TEST(HostTensorToDtype, Float32ToBfloat16RowMajorValueCheck) {
     const Shape shape{32, 64};
-    auto data = make_ramp<float>(shape.volume());
+    auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
     auto memory_config = MemoryConfig{
         TensorMemoryLayout::HEIGHT_SHARDED,
         BufferType::L1,
@@ -288,7 +291,7 @@ TEST(HostTensorToDtype, Float32ToBfloat16RowMajorValueCheck) {
 
     auto expected_spec =
         TensorSpec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config));
-    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), expected_spec));
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
     EXPECT_EQ(result.dtype(), DataType::BFLOAT16);
     EXPECT_EQ(result.layout(), Layout::ROW_MAJOR);
 
@@ -301,7 +304,7 @@ TEST(HostTensorToDtype, Float32ToBfloat16RowMajorValueCheck) {
 
 TEST(HostTensorToDtype, Bfloat16ToFloat32RowMajorValueCheck) {
     const Shape shape{32, 64};
-    auto data = make_ramp<bfloat16>(shape.volume());
+    auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<bfloat16>(shape.volume());
     auto memory_config = MemoryConfig{
         TensorMemoryLayout::HEIGHT_SHARDED,
         BufferType::L1,
@@ -316,7 +319,7 @@ TEST(HostTensorToDtype, Bfloat16ToFloat32RowMajorValueCheck) {
 
     auto expected_spec =
         TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
-    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), expected_spec));
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
     EXPECT_EQ(result.dtype(), DataType::FLOAT32);
     EXPECT_EQ(result.layout(), Layout::ROW_MAJOR);
 
@@ -329,7 +332,7 @@ TEST(HostTensorToDtype, Bfloat16ToFloat32RowMajorValueCheck) {
 
 TEST(HostTensorToDtype, PerCoreAllocationPreserved) {
     const Shape shape{32, 64};
-    auto data = make_ramp<float>(shape.volume());
+    auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
 
     // Sharded MemoryConfig
     auto memory_config = MemoryConfig{
@@ -350,7 +353,7 @@ TEST(HostTensorToDtype, PerCoreAllocationPreserved) {
     auto expected_spec =
         TensorSpec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE, tile), memory_config, alignment));
 
-    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), expected_spec));
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
     EXPECT_TRUE(experimental::per_core_allocation::is_per_core_allocation(result.tensor_spec().memory_config()));
 }
 
@@ -360,7 +363,7 @@ TEST(HostTensorToDtype, OversizedBufferToDtype) {
     auto spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
 
     // Create an oversized buffer
-    auto oversized_data = make_ramp<float>(shape.volume() + 100);
+    auto oversized_data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume() + 100);
 
     // Create tensor from buffer (from_buffer accepts oversized buffers if they are large enough)
     auto dist_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 1));
@@ -430,8 +433,8 @@ TEST(HostTensorToDtype, MultiShardTopologyPreservation) {
 
     auto distributed_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 2));
 
-    auto data_0 = make_ramp<float>(volume);
-    auto data_1 = make_ramp<float>(volume);
+    auto data_0 = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(volume);
+    auto data_1 = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(volume);
     // Make data distinct
     for (auto& v : data_1) {
         v += 10.0f;
@@ -449,7 +452,7 @@ TEST(HostTensorToDtype, MultiShardTopologyPreservation) {
     auto expected_spec =
         TensorSpec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE, tile), memory_config, alignment));
 
-    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), expected_spec));
+    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
     EXPECT_EQ(result.tensor_topology(), topology);
 
     const size_t expected_shard_size = expected_spec.compute_packed_buffer_size_bytes();
@@ -477,7 +480,7 @@ TEST(HostTensorToDtype, MultiShardTopologyPreservation) {
 
 TEST(HostTensorToDtype, RowMajorToBfpPhysicalMismatchThrows) {
     const Shape shape{32, 24};
-    auto data = make_ramp<float>(shape.volume());
+    auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     // Alignment that is NOT a multiple of 16 (tile size)
     auto alignment = tt::tt_metal::Alignment({32, 24});

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_dtype.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_dtype.cpp
@@ -7,8 +7,6 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
-#include <string>
-#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -27,7 +25,6 @@ namespace tt::tt_metal {
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
 
-
 // Deterministic ramp for test data
 template <typename T>
 std::vector<T> make_ramp(size_t count) {
@@ -38,12 +35,70 @@ std::vector<T> make_ramp(size_t count) {
     return data;
 }
 
+std::vector<float> make_bfp_data(const Shape& shape, const Tile& tile) {
+    // Boundary-sensitive to faces: cycles face indices and steps magnitudes for BFP checks.
+    const size_t count = shape.volume();
+    const size_t face_width = tile.get_face_shape()[1];
+    std::vector<float> data(count);
+    size_t i = 0;
+    for (size_t face_row = 0; i < count; ++face_row) {
+        for (size_t face_index = 0; face_index < face_width && i < count; ++face_index) {
+            data[i++] = static_cast<float>(face_index) + static_cast<float>(face_row) * 0.5f;
+        }
+    }
+    return data;
+}
+
+using PackedBfp = std::vector<uint32_t>;
+using UnpackedBfp = std::vector<float>;
+
+// BFP -> float golden: packed bytes plus their reference unpack (not the pre-quant floats).
+std::pair<PackedBfp, UnpackedBfp> generate_bfp8_dataset(const Shape& shape, const Tile& tile) {
+    const auto src = make_bfp_data(shape, tile);
+    auto packed = pack_as_bfp8_tiles(ttsl::make_const_span(src), /*row_major_input=*/true, /*is_exp_a=*/false, tile);
+    auto unpacked = unpack_bfp8_tiles_into_float_vec(packed, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
+    return {std::move(packed), std::move(unpacked)};
+}
+
+std::pair<PackedBfp, UnpackedBfp> generate_bfp4_dataset(const Shape& shape, const Tile& tile) {
+    const auto src = make_bfp_data(shape, tile);
+    auto packed = pack_as_bfp4_tiles(ttsl::make_const_span(src), /*row_major_input=*/true, /*is_exp_a=*/false, tile);
+    auto unpacked = unpack_bfp4_tiles_into_float_vec(packed, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
+    return {std::move(packed), std::move(unpacked)};
+}
+
+// Float(TILE) -> BFP golden: tile-layout floats plus their reference pack.
+std::pair<UnpackedBfp, PackedBfp> generate_float_to_bfp8_dataset(const Shape& shape, const Tile& tile) {
+    auto floats = make_bfp_data(shape, tile);
+    auto packed =
+        pack_as_bfp8_tiles(ttsl::make_const_span(floats), /*row_major_input=*/false, /*is_exp_a=*/false, tile);
+    return {std::move(floats), std::move(packed)};
+}
+
+std::pair<UnpackedBfp, PackedBfp> generate_float_to_bfp4_dataset(const Shape& shape, const Tile& tile) {
+    auto floats = make_bfp_data(shape, tile);
+    auto packed =
+        pack_as_bfp4_tiles(ttsl::make_const_span(floats), /*row_major_input=*/false, /*is_exp_a=*/false, tile);
+    return {std::move(floats), std::move(packed)};
+}
+
+template <typename T>
+HostTensor make_host_tensor(std::vector<T> data, const TensorSpec& spec) {
+    auto dist_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 1));
+    dist_buffer.emplace_shard(
+        distributed::MeshCoordinate(0, 0), [data = std::move(data)]() mutable { return HostBuffer(std::move(data)); });
+    return HostTensor::from_buffer(std::move(dist_buffer), spec, TensorTopology{});
+}
+
 bool exact_spec_match(const TensorSpec& a, const TensorSpec& b) {
     return a == b && experimental::per_core_allocation::is_per_core_allocation(a.memory_config()) ==
                          experimental::per_core_allocation::is_per_core_allocation(b.memory_config());
 }
 
 }  // namespace CMAKE_UNIQUE_NAMESPACE
+
+using ::testing::Eq;
+using ::testing::Pointwise;
 
 TEST(HostTensorToDtype, NonBfpPreservesMetadata) {
     const Shape shape{32, 32};
@@ -104,175 +159,94 @@ TEST(HostTensorToDtype, RowMajorToBfpChangesLayoutToTileAndPreservesTile) {
 
 TEST(HostTensorToDtype, TileBfp8ToFloat32ValueCheck) {
     const Shape shape{32, 32};
-    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
-    auto alignment = tt::tt_metal::Alignment({32, 32});
-    auto tile = Tile(
-        {16,
-         16});  // Custom tile size could be used here if supported, but let's stick to 16x16 or 32x32. Let's use 16x16.
-
-    // Create boundary-sensitive float data
-    std::vector<float> float_data(shape.volume());
-    for (size_t i = 0; i < float_data.size(); ++i) {
-        // Values that test quantization and faces
-        float_data[i] = static_cast<float>(i % 16) + (i / 16) * 0.5f;
-    }
-
-    // Independently pack to BFP8
-    auto packed_bfp8_data =
-        pack_as_bfp8_tiles(ttsl::make_const_span(float_data), /*row_major_input=*/true, /*is_exp_a=*/false, tile);
+    const auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    const auto alignment = Alignment({32, 32});
+    const auto tile = Tile({16, 16});
+    const auto& [packed, unpacked_golden] = CMAKE_UNIQUE_NAMESPACE::generate_bfp8_dataset(shape, tile);
 
     auto source_spec =
         TensorSpec(shape, TensorLayout(DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
-
-    auto dist_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 1));
-    dist_buffer.emplace_shard(
-        distributed::MeshCoordinate(0, 0), [&]() { return HostBuffer(std::vector<uint32_t>(packed_bfp8_data)); });
-    auto source = HostTensor::from_buffer(std::move(dist_buffer), source_spec, TensorTopology{});
+    auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(packed, source_spec);
 
     auto result = to_dtype(source, DataType::FLOAT32);
 
     auto expected_spec =
         TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
-
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
     EXPECT_EQ(result.dtype(), DataType::FLOAT32);
     EXPECT_EQ(result.layout(), Layout::TILE);
     EXPECT_EQ(result.tensor_spec().tile(), tile);
 
-    // Independently unpack golden
-    auto expected_unpacked_data =
-        unpack_bfp8_tiles_into_float_vec(packed_bfp8_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
-
-    auto result_data = host_buffer::get_as<float>(result);
-    EXPECT_EQ(result_data.size(), expected_unpacked_data.size());
-    for (size_t i = 0; i < expected_unpacked_data.size(); ++i) {
-        EXPECT_EQ(result_data[i], expected_unpacked_data[i]);
-    }
+    EXPECT_THAT(host_buffer::get_as<float>(result), Pointwise(Eq(), unpacked_golden));
 }
 
 TEST(HostTensorToDtype, Float32ToTileBfp8ValueCheck) {
     const Shape shape{32, 32};
-    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
-    auto alignment = tt::tt_metal::Alignment({32, 32});
-    auto tile = Tile({16, 16});
-
-    // Create boundary-sensitive float data in TILE layout
-    std::vector<float> float_data(shape.volume());
-    for (size_t i = 0; i < float_data.size(); ++i) {
-        float_data[i] = static_cast<float>(i % 16) + (i / 16) * 0.5f;
-    }
-
-    // Independently pack to BFP8 golden
-    auto expected_packed_data =
-        pack_as_bfp8_tiles(ttsl::make_const_span(float_data), /*row_major_input=*/false, /*is_exp_a=*/false, tile);
+    const auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    const auto alignment = Alignment({32, 32});
+    const auto tile = Tile({16, 16});
+    const auto& [floats, packed_golden] = CMAKE_UNIQUE_NAMESPACE::generate_float_to_bfp8_dataset(shape, tile);
 
     auto source_spec =
         TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
-
-    auto dist_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 1));
-    dist_buffer.emplace_shard(
-        distributed::MeshCoordinate(0, 0), [&]() { return HostBuffer(std::vector<float>(float_data)); });
-    auto source = HostTensor::from_buffer(std::move(dist_buffer), source_spec, TensorTopology{});
+    auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(floats, source_spec);
 
     auto result = to_dtype(source, DataType::BFLOAT8_B);
 
     auto expected_spec =
         TensorSpec(shape, TensorLayout(DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
-
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
     EXPECT_EQ(result.dtype(), DataType::BFLOAT8_B);
     EXPECT_EQ(result.layout(), Layout::TILE);
     EXPECT_EQ(result.tensor_spec().tile(), tile);
 
-    auto result_data = host_buffer::get_as<uint32_t>(result);
-    EXPECT_EQ(result_data.size(), expected_packed_data.size());
-    for (size_t i = 0; i < expected_packed_data.size(); ++i) {
-        EXPECT_EQ(result_data[i], expected_packed_data[i]);
-    }
+    EXPECT_THAT(host_buffer::get_as<uint32_t>(result), Pointwise(Eq(), packed_golden));
 }
 
 TEST(HostTensorToDtype, TileBfp4ToFloat32ValueCheck) {
     const Shape shape{32, 32};
-    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
-    auto alignment = tt::tt_metal::Alignment({32, 32});
-    auto tile = Tile({16, 16});
-
-    std::vector<float> float_data(shape.volume());
-    for (size_t i = 0; i < float_data.size(); ++i) {
-        float_data[i] = static_cast<float>(i % 16) + (i / 16) * 0.5f;
-    }
-
-    // Independently pack to BFP4
-    auto packed_bfp4_data =
-        pack_as_bfp4_tiles(ttsl::make_const_span(float_data), /*row_major_input=*/true, /*is_exp_a=*/false, tile);
+    const auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    const auto alignment = Alignment({32, 32});
+    const auto tile = Tile({16, 16});
+    const auto& [packed, unpacked_golden] = CMAKE_UNIQUE_NAMESPACE::generate_bfp4_dataset(shape, tile);
 
     auto source_spec =
         TensorSpec(shape, TensorLayout(DataType::BFLOAT4_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
-
-    auto dist_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 1));
-    dist_buffer.emplace_shard(
-        distributed::MeshCoordinate(0, 0), [&]() { return HostBuffer(std::vector<uint32_t>(packed_bfp4_data)); });
-    auto source = HostTensor::from_buffer(std::move(dist_buffer), source_spec, TensorTopology{});
+    auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(packed, source_spec);
 
     auto result = to_dtype(source, DataType::FLOAT32);
 
     auto expected_spec =
         TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
-
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
     EXPECT_EQ(result.dtype(), DataType::FLOAT32);
     EXPECT_EQ(result.layout(), Layout::TILE);
     EXPECT_EQ(result.tensor_spec().tile(), tile);
 
-    // Independently unpack golden
-    auto expected_unpacked_data =
-        unpack_bfp4_tiles_into_float_vec(packed_bfp4_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
-
-    auto result_data = host_buffer::get_as<float>(result);
-    EXPECT_EQ(result_data.size(), expected_unpacked_data.size());
-    for (size_t i = 0; i < expected_unpacked_data.size(); ++i) {
-        EXPECT_EQ(result_data[i], expected_unpacked_data[i]);
-    }
+    EXPECT_THAT(host_buffer::get_as<float>(result), Pointwise(Eq(), unpacked_golden));
 }
 
 TEST(HostTensorToDtype, Float32ToTileBfp4ValueCheck) {
     const Shape shape{32, 32};
-    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
-    auto alignment = tt::tt_metal::Alignment({32, 32});
-    auto tile = Tile({16, 16});
-
-    std::vector<float> float_data(shape.volume());
-    for (size_t i = 0; i < float_data.size(); ++i) {
-        float_data[i] = static_cast<float>(i % 16) + (i / 16) * 0.5f;
-    }
-
-    // Independently pack to BFP4 golden
-    auto expected_packed_data =
-        pack_as_bfp4_tiles(ttsl::make_const_span(float_data), /*row_major_input=*/false, /*is_exp_a=*/false, tile);
+    const auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    const auto alignment = Alignment({32, 32});
+    const auto tile = Tile({16, 16});
+    const auto& [floats, packed_golden] = CMAKE_UNIQUE_NAMESPACE::generate_float_to_bfp4_dataset(shape, tile);
 
     auto source_spec =
         TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
-
-    auto dist_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 1));
-    dist_buffer.emplace_shard(
-        distributed::MeshCoordinate(0, 0), [&]() { return HostBuffer(std::vector<float>(float_data)); });
-    auto source = HostTensor::from_buffer(std::move(dist_buffer), source_spec, TensorTopology{});
+    auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(floats, source_spec);
 
     auto result = to_dtype(source, DataType::BFLOAT4_B);
 
     auto expected_spec =
         TensorSpec(shape, TensorLayout(DataType::BFLOAT4_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
-
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
     EXPECT_EQ(result.dtype(), DataType::BFLOAT4_B);
     EXPECT_EQ(result.layout(), Layout::TILE);
     EXPECT_EQ(result.tensor_spec().tile(), tile);
 
-    auto result_data = host_buffer::get_as<uint32_t>(result);
-    EXPECT_EQ(result_data.size(), expected_packed_data.size());
-    for (size_t i = 0; i < expected_packed_data.size(); ++i) {
-        EXPECT_EQ(result_data[i], expected_packed_data[i]);
-    }
+    EXPECT_THAT(host_buffer::get_as<uint32_t>(result), Pointwise(Eq(), packed_golden));
 }
 
 TEST(HostTensorToDtype, Float32ToBfloat16RowMajorValueCheck) {
@@ -413,71 +387,6 @@ TEST(HostTensorToDtype, MalformedBfpBufferToDtypeThrows) {
 
     EXPECT_ANY_THROW(to_dtype(host_tensor, DataType::FLOAT32));
 }
-TEST(HostTensorToDtype, MultiShardTopologyPreservation) {
-    const Shape shape{32, 64};
-    const size_t volume = shape.volume();
-
-    // Create sharded MemoryConfig
-    auto memory_config = MemoryConfig{
-        TensorMemoryLayout::HEIGHT_SHARDED,
-        BufferType::L1,
-        ShardSpec{CoreRangeSet({CoreRange({0, 0}, {0, 1})}), {16, 64}, ShardOrientation::ROW_MAJOR}};
-
-    auto alignment = tt::tt_metal::Alignment({32, 64});
-    auto tile = Tile({16, 16});
-    auto source_spec =
-        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
-
-    // Create fully populated multi-shard host tensor on 1x2 mesh
-    auto topology = TensorTopology::create_fully_replicated_tensor_topology(distributed::MeshShape(1, 2));
-
-    auto distributed_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 2));
-
-    auto data_0 = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(volume);
-    auto data_1 = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(volume);
-    // Make data distinct
-    for (auto& v : data_1) {
-        v += 10.0f;
-    }
-
-    distributed_buffer.emplace_shard(
-        distributed::MeshCoordinate(0, 0), [&]() { return HostBuffer(std::vector<float>(data_0)); });
-    distributed_buffer.emplace_shard(
-        distributed::MeshCoordinate(0, 1), [&]() { return HostBuffer(std::vector<float>(data_1)); });
-
-    auto source = HostTensor::from_buffer(std::move(distributed_buffer), source_spec, topology);
-
-    auto result = to_dtype(source, DataType::BFLOAT16);
-
-    auto expected_spec =
-        TensorSpec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE, tile), memory_config, alignment));
-
-    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
-    EXPECT_EQ(result.tensor_topology(), topology);
-
-    const size_t expected_shard_size = expected_spec.compute_packed_buffer_size_bytes();
-
-    // Check coordinate set
-    auto coords = result.buffer().shard_coords();
-    EXPECT_EQ(coords.size(), 2);
-    EXPECT_TRUE(coords.contains(distributed::MeshCoordinate(0, 0)));
-    EXPECT_TRUE(coords.contains(distributed::MeshCoordinate(0, 1)));
-
-    for (const auto& coord : coords) {
-        auto shard = result.buffer().get_shard(coord);
-        ASSERT_TRUE(shard.has_value());
-        EXPECT_EQ(shard->view_bytes().size(), expected_shard_size);
-
-        auto result_data = shard->view_as<bfloat16>();
-        EXPECT_EQ(result_data.size(), volume);
-
-        const auto& expected_data = (coord == distributed::MeshCoordinate(0, 0)) ? data_0 : data_1;
-        for (size_t i = 0; i < volume; ++i) {
-            EXPECT_EQ(static_cast<float>(result_data[i]), static_cast<float>(bfloat16(expected_data[i])));
-        }
-    }
-}
-
 TEST(HostTensorToDtype, RowMajorToBfpPhysicalMismatchThrows) {
     const Shape shape{32, 24};
     auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_dtype.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_dtype.cpp
@@ -1,0 +1,497 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include <tt-metalium/experimental/tensor/host_tensor.hpp>
+#include <tt-metalium/experimental/tensor/tensor_apis.hpp>
+#include <tt-metalium/experimental/tensor/spec/tensor_spec.hpp>
+#include <tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp>
+#include <tt-metalium/experimental/tensor/spec/layout/page_config.hpp>
+#include <tt-metalium/experimental/tensor/impl/tensor_impl.hpp>
+#include <tt-metalium/experimental/per_core_allocation/buffer.hpp>
+#include <tt-metalium/host_buffer.hpp>
+#include <tt-metalium/shape.hpp>
+#include <tt-metalium/tile.hpp>
+
+namespace tt::tt_metal {
+namespace {
+
+using ::testing::Eq;
+
+// Deterministic ramp for test data
+template <typename T>
+std::vector<T> make_ramp(size_t count) {
+    std::vector<T> data(count);
+    for (size_t i = 0; i < count; ++i) {
+        data[i] = static_cast<T>(static_cast<float>(i % 251));
+    }
+    return data;
+}
+
+bool exact_spec_match(const TensorSpec& a, const TensorSpec& b) {
+    return a == b && experimental::per_core_allocation::is_per_core_allocation(a.memory_config()) ==
+                         experimental::per_core_allocation::is_per_core_allocation(b.memory_config());
+}
+
+TEST(HostTensorToDtype, NonBfpPreservesMetadata) {
+    const Shape shape{32, 32};
+    auto data = make_ramp<float>(shape.volume());
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto alignment = tt::tt_metal::Alignment({32, 32});
+    auto tile = Tile({16, 16});
+
+    auto source_spec =
+        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto source = HostTensor::from_vector<float>(data, source_spec);
+
+    auto result = to_dtype(source, DataType::BFLOAT16);
+
+    auto expected_spec =
+        TensorSpec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE, tile), memory_config, alignment));
+
+    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), expected_spec));
+    EXPECT_EQ(result.dtype(), DataType::BFLOAT16);
+    EXPECT_EQ(result.layout(), Layout::TILE);
+    EXPECT_EQ(result.tensor_spec().tile(), tile);
+}
+
+TEST(HostTensorToDtype, RowMajorToBfpChangesLayoutToTileAndPreservesTile) {
+    const Shape shape{32, 32};
+    auto data = make_ramp<float>(shape.volume());
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto alignment = tt::tt_metal::Alignment({32, 32});
+    auto tile = Tile({16, 16});
+
+    // Create a ROW_MAJOR tensor, but specify a tile in the page config (embedded tile)
+    auto source_spec = TensorSpec(
+        shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR, tile), memory_config, alignment));
+    auto source = HostTensor::from_vector<float>(data, source_spec);
+
+    auto result = to_dtype(source, DataType::BFLOAT8_B);
+
+    auto expected_spec =
+        TensorSpec(shape, TensorLayout(DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
+
+    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), expected_spec));
+    EXPECT_EQ(result.layout(), Layout::TILE);
+    EXPECT_EQ(result.tensor_spec().tile(), tile);
+
+    // Value check on the aligned supported path
+    // We can unpack the BFP8_B data to float and check if it matches the original data
+    auto result_packed_data = host_buffer::get_as<uint32_t>(result);
+    auto unpacked_data =
+        unpack_bfp8_tiles_into_float_vec(result_packed_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
+    auto rm_data =
+        tensor_impl::to_row_major_layout(expected_spec.physical_shape(), tile, ttsl::make_const_span(unpacked_data));
+
+    EXPECT_EQ(rm_data.size(), data.size());
+    for (size_t i = 0; i < data.size(); ++i) {
+        EXPECT_NEAR(rm_data[i], data[i], 1.0f);
+    }
+}
+
+TEST(HostTensorToDtype, TileBfp8ToFloat32ValueCheck) {
+    const Shape shape{32, 32};
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto alignment = tt::tt_metal::Alignment({32, 32});
+    auto tile = Tile(
+        {16,
+         16});  // Custom tile size could be used here if supported, but let's stick to 16x16 or 32x32. Let's use 16x16.
+
+    // Create boundary-sensitive float data
+    std::vector<float> float_data(shape.volume());
+    for (size_t i = 0; i < float_data.size(); ++i) {
+        // Values that test quantization and faces
+        float_data[i] = static_cast<float>(i % 16) + (i / 16) * 0.5f;
+    }
+
+    // Independently pack to BFP8
+    auto packed_bfp8_data =
+        pack_as_bfp8_tiles(ttsl::make_const_span(float_data), /*row_major_input=*/true, /*is_exp_a=*/false, tile);
+
+    auto source_spec =
+        TensorSpec(shape, TensorLayout(DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
+
+    auto dist_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 1));
+    dist_buffer.emplace_shard(
+        distributed::MeshCoordinate(0, 0), [&]() { return HostBuffer(std::vector<uint32_t>(packed_bfp8_data)); });
+    auto source = HostTensor::from_buffer(std::move(dist_buffer), source_spec, TensorTopology{});
+
+    auto result = to_dtype(source, DataType::FLOAT32);
+
+    auto expected_spec =
+        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+
+    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), expected_spec));
+    EXPECT_EQ(result.dtype(), DataType::FLOAT32);
+    EXPECT_EQ(result.layout(), Layout::TILE);
+    EXPECT_EQ(result.tensor_spec().tile(), tile);
+
+    // Independently unpack golden
+    auto expected_unpacked_data =
+        unpack_bfp8_tiles_into_float_vec(packed_bfp8_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
+
+    auto result_data = host_buffer::get_as<float>(result);
+    EXPECT_EQ(result_data.size(), expected_unpacked_data.size());
+    for (size_t i = 0; i < expected_unpacked_data.size(); ++i) {
+        EXPECT_EQ(result_data[i], expected_unpacked_data[i]);
+    }
+}
+
+TEST(HostTensorToDtype, Float32ToTileBfp8ValueCheck) {
+    const Shape shape{32, 32};
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto alignment = tt::tt_metal::Alignment({32, 32});
+    auto tile = Tile({16, 16});
+
+    // Create boundary-sensitive float data in TILE layout
+    std::vector<float> float_data(shape.volume());
+    for (size_t i = 0; i < float_data.size(); ++i) {
+        float_data[i] = static_cast<float>(i % 16) + (i / 16) * 0.5f;
+    }
+
+    // Independently pack to BFP8 golden
+    auto expected_packed_data =
+        pack_as_bfp8_tiles(ttsl::make_const_span(float_data), /*row_major_input=*/false, /*is_exp_a=*/false, tile);
+
+    auto source_spec =
+        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+
+    auto dist_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 1));
+    dist_buffer.emplace_shard(
+        distributed::MeshCoordinate(0, 0), [&]() { return HostBuffer(std::vector<float>(float_data)); });
+    auto source = HostTensor::from_buffer(std::move(dist_buffer), source_spec, TensorTopology{});
+
+    auto result = to_dtype(source, DataType::BFLOAT8_B);
+
+    auto expected_spec =
+        TensorSpec(shape, TensorLayout(DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
+
+    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), expected_spec));
+    EXPECT_EQ(result.dtype(), DataType::BFLOAT8_B);
+    EXPECT_EQ(result.layout(), Layout::TILE);
+    EXPECT_EQ(result.tensor_spec().tile(), tile);
+
+    auto result_data = host_buffer::get_as<uint32_t>(result);
+    EXPECT_EQ(result_data.size(), expected_packed_data.size());
+    for (size_t i = 0; i < expected_packed_data.size(); ++i) {
+        EXPECT_EQ(result_data[i], expected_packed_data[i]);
+    }
+}
+
+TEST(HostTensorToDtype, TileBfp4ToFloat32ValueCheck) {
+    const Shape shape{32, 32};
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto alignment = tt::tt_metal::Alignment({32, 32});
+    auto tile = Tile({16, 16});
+
+    std::vector<float> float_data(shape.volume());
+    for (size_t i = 0; i < float_data.size(); ++i) {
+        float_data[i] = static_cast<float>(i % 16) + (i / 16) * 0.5f;
+    }
+
+    // Independently pack to BFP4
+    auto packed_bfp4_data =
+        pack_as_bfp4_tiles(ttsl::make_const_span(float_data), /*row_major_input=*/true, /*is_exp_a=*/false, tile);
+
+    auto source_spec =
+        TensorSpec(shape, TensorLayout(DataType::BFLOAT4_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
+
+    auto dist_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 1));
+    dist_buffer.emplace_shard(
+        distributed::MeshCoordinate(0, 0), [&]() { return HostBuffer(std::vector<uint32_t>(packed_bfp4_data)); });
+    auto source = HostTensor::from_buffer(std::move(dist_buffer), source_spec, TensorTopology{});
+
+    auto result = to_dtype(source, DataType::FLOAT32);
+
+    auto expected_spec =
+        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+
+    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), expected_spec));
+    EXPECT_EQ(result.dtype(), DataType::FLOAT32);
+    EXPECT_EQ(result.layout(), Layout::TILE);
+    EXPECT_EQ(result.tensor_spec().tile(), tile);
+
+    // Independently unpack golden
+    auto expected_unpacked_data =
+        unpack_bfp4_tiles_into_float_vec(packed_bfp4_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
+
+    auto result_data = host_buffer::get_as<float>(result);
+    EXPECT_EQ(result_data.size(), expected_unpacked_data.size());
+    for (size_t i = 0; i < expected_unpacked_data.size(); ++i) {
+        EXPECT_EQ(result_data[i], expected_unpacked_data[i]);
+    }
+}
+
+TEST(HostTensorToDtype, Float32ToTileBfp4ValueCheck) {
+    const Shape shape{32, 32};
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto alignment = tt::tt_metal::Alignment({32, 32});
+    auto tile = Tile({16, 16});
+
+    std::vector<float> float_data(shape.volume());
+    for (size_t i = 0; i < float_data.size(); ++i) {
+        float_data[i] = static_cast<float>(i % 16) + (i / 16) * 0.5f;
+    }
+
+    // Independently pack to BFP4 golden
+    auto expected_packed_data =
+        pack_as_bfp4_tiles(ttsl::make_const_span(float_data), /*row_major_input=*/false, /*is_exp_a=*/false, tile);
+
+    auto source_spec =
+        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+
+    auto dist_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 1));
+    dist_buffer.emplace_shard(
+        distributed::MeshCoordinate(0, 0), [&]() { return HostBuffer(std::vector<float>(float_data)); });
+    auto source = HostTensor::from_buffer(std::move(dist_buffer), source_spec, TensorTopology{});
+
+    auto result = to_dtype(source, DataType::BFLOAT4_B);
+
+    auto expected_spec =
+        TensorSpec(shape, TensorLayout(DataType::BFLOAT4_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
+
+    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), expected_spec));
+    EXPECT_EQ(result.dtype(), DataType::BFLOAT4_B);
+    EXPECT_EQ(result.layout(), Layout::TILE);
+    EXPECT_EQ(result.tensor_spec().tile(), tile);
+
+    auto result_data = host_buffer::get_as<uint32_t>(result);
+    EXPECT_EQ(result_data.size(), expected_packed_data.size());
+    for (size_t i = 0; i < expected_packed_data.size(); ++i) {
+        EXPECT_EQ(result_data[i], expected_packed_data[i]);
+    }
+}
+
+TEST(HostTensorToDtype, Float32ToBfloat16RowMajorValueCheck) {
+    const Shape shape{32, 64};
+    auto data = make_ramp<float>(shape.volume());
+    auto memory_config = MemoryConfig{
+        TensorMemoryLayout::HEIGHT_SHARDED,
+        BufferType::L1,
+        ShardSpec{CoreRangeSet({CoreRange({0, 0}, {0, 1})}), {16, 64}, ShardOrientation::ROW_MAJOR}};
+    experimental::per_core_allocation::set_per_core_allocation(memory_config, true);
+
+    auto source_spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
+    auto source = HostTensor::from_vector<float>(data, source_spec);
+
+    auto result = to_dtype(source, DataType::BFLOAT16);
+
+    auto expected_spec =
+        TensorSpec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config));
+    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), expected_spec));
+    EXPECT_EQ(result.dtype(), DataType::BFLOAT16);
+    EXPECT_EQ(result.layout(), Layout::ROW_MAJOR);
+
+    auto result_data = result.to_vector<bfloat16>();
+    EXPECT_EQ(result_data.size(), data.size());
+    for (size_t i = 0; i < data.size(); ++i) {
+        EXPECT_EQ(static_cast<float>(result_data[i]), static_cast<float>(bfloat16(data[i])));
+    }
+}
+
+TEST(HostTensorToDtype, Bfloat16ToFloat32RowMajorValueCheck) {
+    const Shape shape{32, 64};
+    auto data = make_ramp<bfloat16>(shape.volume());
+    auto memory_config = MemoryConfig{
+        TensorMemoryLayout::HEIGHT_SHARDED,
+        BufferType::L1,
+        ShardSpec{CoreRangeSet({CoreRange({0, 0}, {0, 1})}), {16, 64}, ShardOrientation::ROW_MAJOR}};
+    experimental::per_core_allocation::set_per_core_allocation(memory_config, true);
+
+    auto source_spec =
+        TensorSpec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config));
+    auto source = HostTensor::from_vector<bfloat16>(data, source_spec);
+
+    auto result = to_dtype(source, DataType::FLOAT32);
+
+    auto expected_spec =
+        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
+    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), expected_spec));
+    EXPECT_EQ(result.dtype(), DataType::FLOAT32);
+    EXPECT_EQ(result.layout(), Layout::ROW_MAJOR);
+
+    auto result_data = result.to_vector<float>();
+    EXPECT_EQ(result_data.size(), data.size());
+    for (size_t i = 0; i < data.size(); ++i) {
+        EXPECT_EQ(result_data[i], static_cast<float>(data[i]));
+    }
+}
+
+TEST(HostTensorToDtype, PerCoreAllocationPreserved) {
+    const Shape shape{32, 64};
+    auto data = make_ramp<float>(shape.volume());
+
+    // Sharded MemoryConfig
+    auto memory_config = MemoryConfig{
+        TensorMemoryLayout::HEIGHT_SHARDED,
+        BufferType::L1,
+        ShardSpec{CoreRangeSet({CoreRange({0, 0}, {0, 0})}), {32, 64}, ShardOrientation::ROW_MAJOR}};
+    experimental::per_core_allocation::set_per_core_allocation(memory_config, true);
+
+    auto alignment = tt::tt_metal::Alignment({32, 64});
+    auto tile = Tile({32, 32});
+
+    auto source_spec =
+        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto source = HostTensor::from_vector<float>(data, source_spec);
+
+    auto result = to_dtype(source, DataType::BFLOAT16);
+
+    auto expected_spec =
+        TensorSpec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE, tile), memory_config, alignment));
+
+    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), expected_spec));
+    EXPECT_TRUE(experimental::per_core_allocation::is_per_core_allocation(result.tensor_spec().memory_config()));
+}
+
+TEST(HostTensorToDtype, OversizedBufferToDtype) {
+    Shape shape{32, 32};
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
+
+    // Create an oversized buffer
+    auto oversized_data = make_ramp<float>(shape.volume() + 100);
+
+    // Create tensor from buffer (from_buffer accepts oversized buffers if they are large enough)
+    auto dist_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 1));
+    dist_buffer.emplace_shard(
+        distributed::MeshCoordinate(0, 0), [&]() { return HostBuffer(std::vector<float>(oversized_data)); });
+    auto host_tensor = HostTensor::from_buffer(std::move(dist_buffer), spec, TensorTopology{});
+
+    // Currently to_dtype asserts on exact packed size, so it will fail if it's oversized.
+    EXPECT_ANY_THROW(to_dtype(host_tensor, DataType::BFLOAT16));
+}
+
+TEST(HostTensorToDtype, UndersizedBufferToDtypeThrows) {
+    Shape shape{32, 32};
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    // Use BFLOAT8_B so we test the pre-unpack size check
+    auto spec =
+        TensorSpec(shape, TensorLayout(DataType::BFLOAT8_B, PageConfig(Layout::TILE, Tile({16, 16})), memory_config));
+
+    // Create an undersized buffer
+    auto undersized_data = std::vector<uint32_t>(10, 0);  // Much smaller than required
+
+    auto dist_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 1));
+    dist_buffer.emplace_shard(
+        distributed::MeshCoordinate(0, 0), [&]() { return HostBuffer(std::vector<uint32_t>(undersized_data)); });
+
+    // from_buffer doesn't check size, so this succeeds
+    auto host_tensor = HostTensor::from_buffer(std::move(dist_buffer), spec, TensorTopology{});
+
+    EXPECT_ANY_THROW(to_dtype(host_tensor, DataType::FLOAT32));
+}
+
+TEST(HostTensorToDtype, MalformedBfpBufferToDtypeThrows) {
+    Shape shape{32, 32};
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto spec =
+        TensorSpec(shape, TensorLayout(DataType::BFLOAT8_B, PageConfig(Layout::TILE, Tile({16, 16})), memory_config));
+
+    // Create a buffer that is slightly off in size (e.g. missing one word)
+    size_t expected_size_bytes = spec.compute_packed_buffer_size_bytes();
+    auto malformed_data = std::vector<uint32_t>((expected_size_bytes / sizeof(uint32_t)) - 1, 0);
+
+    auto dist_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 1));
+    dist_buffer.emplace_shard(
+        distributed::MeshCoordinate(0, 0), [&]() { return HostBuffer(std::vector<uint32_t>(malformed_data)); });
+
+    auto host_tensor = HostTensor::from_buffer(std::move(dist_buffer), spec, TensorTopology{});
+
+    EXPECT_ANY_THROW(to_dtype(host_tensor, DataType::FLOAT32));
+}
+TEST(HostTensorToDtype, MultiShardTopologyPreservation) {
+    const Shape shape{32, 64};
+    const size_t volume = shape.volume();
+
+    // Create sharded MemoryConfig
+    auto memory_config = MemoryConfig{
+        TensorMemoryLayout::HEIGHT_SHARDED,
+        BufferType::L1,
+        ShardSpec{CoreRangeSet({CoreRange({0, 0}, {0, 1})}), {16, 64}, ShardOrientation::ROW_MAJOR}};
+
+    auto alignment = tt::tt_metal::Alignment({32, 64});
+    auto tile = Tile({16, 16});
+    auto source_spec =
+        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+
+    // Create fully populated multi-shard host tensor on 1x2 mesh
+    auto topology = TensorTopology::create_fully_replicated_tensor_topology(distributed::MeshShape(1, 2));
+
+    auto distributed_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 2));
+
+    auto data_0 = make_ramp<float>(volume);
+    auto data_1 = make_ramp<float>(volume);
+    // Make data distinct
+    for (auto& v : data_1) {
+        v += 10.0f;
+    }
+
+    distributed_buffer.emplace_shard(
+        distributed::MeshCoordinate(0, 0), [&]() { return HostBuffer(std::vector<float>(data_0)); });
+    distributed_buffer.emplace_shard(
+        distributed::MeshCoordinate(0, 1), [&]() { return HostBuffer(std::vector<float>(data_1)); });
+
+    auto source = HostTensor::from_buffer(std::move(distributed_buffer), source_spec, topology);
+
+    auto result = to_dtype(source, DataType::BFLOAT16);
+
+    auto expected_spec =
+        TensorSpec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE, tile), memory_config, alignment));
+
+    EXPECT_TRUE(exact_spec_match(result.tensor_spec(), expected_spec));
+    EXPECT_EQ(result.tensor_topology(), topology);
+
+    const size_t expected_shard_size = expected_spec.compute_packed_buffer_size_bytes();
+
+    // Check coordinate set
+    auto coords = result.buffer().shard_coords();
+    EXPECT_EQ(coords.size(), 2);
+    EXPECT_TRUE(coords.contains(distributed::MeshCoordinate(0, 0)));
+    EXPECT_TRUE(coords.contains(distributed::MeshCoordinate(0, 1)));
+
+    for (const auto& coord : coords) {
+        auto shard = result.buffer().get_shard(coord);
+        ASSERT_TRUE(shard.has_value());
+        EXPECT_EQ(shard->view_bytes().size(), expected_shard_size);
+
+        auto result_data = shard->view_as<bfloat16>();
+        EXPECT_EQ(result_data.size(), volume);
+
+        const auto& expected_data = (coord == distributed::MeshCoordinate(0, 0)) ? data_0 : data_1;
+        for (size_t i = 0; i < volume; ++i) {
+            EXPECT_EQ(static_cast<float>(result_data[i]), static_cast<float>(bfloat16(expected_data[i])));
+        }
+    }
+}
+
+TEST(HostTensorToDtype, RowMajorToBfpPhysicalMismatchThrows) {
+    const Shape shape{32, 24};
+    auto data = make_ramp<float>(shape.volume());
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    // Alignment that is NOT a multiple of 16 (tile size)
+    auto alignment = tt::tt_metal::Alignment({32, 24});
+    auto tile = Tile({16, 16});
+
+    auto source_spec = TensorSpec(
+        shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR, tile), memory_config, alignment));
+    auto source = HostTensor::from_vector<float>(data, source_spec);
+
+    // This should throw because BFLOAT8_B forces TILE layout, which forces alignment to be multiple of 16
+    // So output physical shape width will be 32 instead of 24
+    EXPECT_ANY_THROW(to_dtype(source, DataType::BFLOAT8_B));
+}
+
+}  // namespace
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_dtype.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_dtype.cpp
@@ -26,7 +26,6 @@
 namespace tt::tt_metal {
 namespace {
 
-using ::testing::Eq;
 
 // Deterministic ramp for test data
 template <typename T>

--- a/tests/tt_metal/tt_metal/api/tensor/test_vector_conversion.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_vector_conversion.cpp
@@ -309,6 +309,80 @@ TEST_F(DeviceVectorConversionTest, RoundtripWithMemoryConfig) {
     EXPECT_THAT(readback.to_vector<float>(), Pointwise(Eq(), input));
 }
 
+bool exact_spec_match(const TensorSpec& a, const TensorSpec& b) {
+    return a == b && experimental::per_core_allocation::is_per_core_allocation(a.memory_config()) ==
+                         experimental::per_core_allocation::is_per_core_allocation(b.memory_config());
+}
+
+TEST(VectorConversionTest, ExactSpecPredicateCustomAlignment) {
+    Shape shape{32, 32};
+    auto input = arange<float>(0, shape.volume(), 1);
+
+    auto alignment = tt::tt_metal::Alignment({64, 64});
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto spec =
+        TensorSpec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
+
+    auto host_tensor = HostTensor::from_vector(input, spec);
+
+    // Exact spec match!
+    EXPECT_TRUE(exact_spec_match(host_tensor.tensor_spec(), spec));
+}
+
+TEST(VectorConversionTest, ExactSpecPredicateCustomAlignmentRvalueVector) {
+    Shape shape{64, 64};  // Matches alignment so logical_matches_physical is true
+    auto input = arange<float>(0, shape.volume(), 1);
+
+    auto alignment = tt::tt_metal::Alignment({64, 64});
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto spec =
+        TensorSpec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
+
+    auto host_tensor = HostTensor::from_vector(std::move(input), spec);
+
+    EXPECT_TRUE(exact_spec_match(host_tensor.tensor_spec(), spec));
+}
+
+TEST(VectorConversionTest, ExactSpecPredicateCustomAlignmentFromSpan) {
+    Shape shape{32, 32};
+    auto input = arange<float>(0, shape.volume(), 1);
+
+    auto alignment = tt::tt_metal::Alignment({64, 64});
+    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
+    auto spec =
+        TensorSpec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
+
+    auto host_tensor = HostTensor::from_span<float>(std::span<float>(input), spec);
+
+    EXPECT_TRUE(exact_spec_match(host_tensor.tensor_spec(), spec));
+}
+
+TEST(VectorConversionTest, ExactSpecShardedPackedSizes) {
+    Shape shape{64, 64};
+    auto input = arange<float>(0, shape.volume(), 1);
+
+    auto memory_config = MemoryConfig{
+        TensorMemoryLayout::HEIGHT_SHARDED,
+        BufferType::L1,
+        ShardSpec{CoreRangeSet({CoreRange({0, 0}, {0, 1})}), {32, 64}, ShardOrientation::ROW_MAJOR}};
+    experimental::per_core_allocation::set_per_core_allocation(memory_config, true);
+    auto alignment = tt::tt_metal::Alignment({64, 64});
+    auto spec =
+        TensorSpec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
+
+    auto host_tensor = HostTensor::from_vector(input, spec);
+
+    EXPECT_TRUE(exact_spec_match(host_tensor.tensor_spec(), spec));
+
+    // Check packed size
+    const size_t expected_shard_size = spec.compute_packed_buffer_size_bytes();
+    for (const auto& coord : host_tensor.buffer().shard_coords()) {
+        auto shard = host_tensor.buffer().get_shard(coord);
+        ASSERT_TRUE(shard.has_value());
+        EXPECT_EQ(shard->view_bytes().size(), expected_shard_size);
+    }
+}
+
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/tensor/host_tensor_factory.cpp
+++ b/tt_metal/impl/tensor/host_tensor_factory.cpp
@@ -28,8 +28,9 @@ namespace CMAKE_UNIQUE_NAMESPACE {
 template <typename T>
 HostTensor from_span_impl(std::span<const T> buffer, const TensorSpec& spec, T pad_value) {
     auto buffer_dtype = convert_to_data_type<T>();
-    auto buffer_spec =
-        TensorSpec(spec.logical_shape(), TensorLayout(buffer_dtype, spec.page_config(), spec.memory_config()));
+    auto buffer_spec = TensorSpec(
+        spec.logical_shape(),
+        TensorLayout(buffer_dtype, spec.page_config(), spec.memory_config(), spec.tensor_layout().get_alignment()));
 
     size_t volume = spec.logical_shape().volume();
 
@@ -91,8 +92,9 @@ HostTensor HostTensor::from_vector(std::vector<T>&& buffer, const TensorSpec& sp
     }
 
     auto buffer_dtype = convert_to_data_type<T>();
-    auto buffer_spec =
-        TensorSpec(spec.logical_shape(), TensorLayout(buffer_dtype, spec.page_config(), spec.memory_config()));
+    auto buffer_spec = TensorSpec(
+        spec.logical_shape(),
+        TensorLayout(buffer_dtype, spec.page_config(), spec.memory_config(), spec.tensor_layout().get_alignment()));
 
     auto host_buffer =
         logical_matches_physical(buffer_spec)

--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -1123,21 +1123,23 @@ struct bfloat8_tag {};
 
 // Preprocess the storage to unpack the bfloat8/4 tiles into float32.
 tt::tt_metal::DistributedHostBuffer preprocess_buffers(
-    const tt::tt_metal::DistributedHostBuffer& input_storage, const DataType input_dtype) {
+    const tt::tt_metal::DistributedHostBuffer& input_storage,
+    const DataType input_dtype,
+    const tt::tt_metal::Tile& tile) {
     constexpr bool row_major_output = false;
     constexpr bool is_exp_a = false;
 
     if (input_dtype == DataType::BFLOAT8_B) {
         return input_storage.transform([&](const tt::tt_metal::HostBuffer& buffer) {
             ttsl::Span<const uint32_t> uint32_data = buffer.view_as<const uint32_t>();
-            auto float_unpacked_data = unpack_bfp8_tiles_into_float_vec(uint32_data, row_major_output, is_exp_a);
+            auto float_unpacked_data = unpack_bfp8_tiles_into_float_vec(uint32_data, row_major_output, is_exp_a, tile);
             return tt::tt_metal::HostBuffer(std::move(float_unpacked_data));
         });
     }
     if (input_dtype == DataType::BFLOAT4_B) {
         return input_storage.transform([&](const tt::tt_metal::HostBuffer& buffer) {
             ttsl::Span<const uint32_t> uint32_data = buffer.view_as<const uint32_t>();
-            auto float_unpacked_data = unpack_bfp4_tiles_into_float_vec(uint32_data, row_major_output, is_exp_a);
+            auto float_unpacked_data = unpack_bfp4_tiles_into_float_vec(uint32_data, row_major_output, is_exp_a, tile);
             return tt::tt_metal::HostBuffer(std::move(float_unpacked_data));
         });
     }
@@ -1146,7 +1148,9 @@ tt::tt_metal::DistributedHostBuffer preprocess_buffers(
 
 template <typename SrcType, typename DstType>
 tt::tt_metal::DistributedHostBuffer transform_buffers(
-    const tt::tt_metal::TensorSpec& input_tensor_spec, const tt::tt_metal::DistributedHostBuffer& input_buffer) {
+    const tt::tt_metal::TensorSpec& input_tensor_spec,
+    const tt::tt_metal::TensorSpec& output_spec,
+    const tt::tt_metal::DistributedHostBuffer& input_buffer) {
     if constexpr (std::is_same_v<SrcType, DstType>) {
         return input_buffer;
     } else if constexpr (std::is_same_v<SrcType, float8_e4m3> || std::is_same_v<DstType, float8_e4m3>) {
@@ -1175,8 +1179,8 @@ tt::tt_metal::DistributedHostBuffer transform_buffers(
             ttsl::Span<const SrcType> data = buffer.view_as<const SrcType>();
             std::vector<SrcType> tilized_data;  // empty if `data` is already in tile layout.
             if (input_tensor_spec.layout() == Layout::ROW_MAJOR) {
-                tilized_data = tensor_impl::to_tile_major_layout(
-                    input_tensor_spec.physical_shape(), input_tensor_spec.tile(), data);
+                tilized_data =
+                    tensor_impl::to_tile_major_layout(output_spec.physical_shape(), output_spec.tile(), data);
                 data = ttsl::make_const_span(tilized_data);
             }
 
@@ -1184,9 +1188,9 @@ tt::tt_metal::DistributedHostBuffer transform_buffers(
                 constexpr bool row_major_input = false;
                 constexpr bool is_exp_a = false;
                 if constexpr (std::is_same_v<DstType, bfloat8_tag>) {
-                    return pack_as_bfp8_tiles(data, row_major_input, is_exp_a, input_tensor_spec.tile());
+                    return pack_as_bfp8_tiles(data, row_major_input, is_exp_a, output_spec.tile());
                 } else if constexpr (std::is_same_v<DstType, bfloat4_tag>) {
-                    return pack_as_bfp4_tiles(data, row_major_input, is_exp_a, input_tensor_spec.tile());
+                    return pack_as_bfp4_tiles(data, row_major_input, is_exp_a, output_spec.tile());
                 } else {
                     static_assert(ttsl::concepts::always_false_v<DstType>, "Unsupported data type");
                 }
@@ -1218,12 +1222,46 @@ HostTensor to_dtype(const HostTensor& input_tensor, DataType dtype) {
         return input_tensor;
     }
 
-    auto input_buffer = CMAKE_UNIQUE_NAMESPACE::preprocess_buffers(input_tensor.buffer(), src_type);
+    const size_t expected_input_shard_size = input_tensor.tensor_spec().compute_packed_buffer_size_bytes();
+    for (const auto& coord : input_tensor.buffer().shard_coords()) {
+        auto shard = input_tensor.buffer().get_shard(coord);
+        if (shard) {
+            TT_FATAL(
+                shard->view_bytes().size() == expected_input_shard_size,
+                "to_dtype input shard size mismatch before conversion: actual {} != expected {}",
+                shard->view_bytes().size(),
+                expected_input_shard_size);
+        }
+    }
 
-    auto output_storage = [src_type, dst_type = dtype, &input_tensor, &input_buffer]() {
+    auto input_buffer =
+        CMAKE_UNIQUE_NAMESPACE::preprocess_buffers(input_tensor.buffer(), src_type, input_tensor.tensor_spec().tile());
+
+    const auto layout =
+        (dtype == DataType::BFLOAT4_B || dtype == DataType::BFLOAT8_B) ? Layout::TILE : input_tensor.layout();
+
+    tt::tt_metal::PageConfig page_config(layout, input_tensor.tensor_spec().tile());
+
+    auto output_spec = TensorSpec(
+        input_tensor.logical_shape(),
+        tt::tt_metal::TensorLayout(
+            dtype,
+            page_config,
+            input_tensor.tensor_spec().memory_config(),
+            input_tensor.tensor_spec().tensor_layout().get_alignment()));
+
+    TT_FATAL(
+        input_tensor.tensor_spec().physical_shape() == output_spec.physical_shape(),
+        "to_dtype: Converting layout to {} implicitly changed physical shape from {} to {} due to alignment "
+        "constraints. This is currently unsupported. Please pad the tensor explicitly before conversion.",
+        layout,
+        input_tensor.tensor_spec().physical_shape(),
+        output_spec.physical_shape());
+
+    auto output_storage = [src_type, dst_type = dtype, &input_tensor, &input_buffer, &output_spec]() {
         auto with_src_and_dst = [&]<typename SrcType, typename DstType>() {
             return CMAKE_UNIQUE_NAMESPACE::transform_buffers<SrcType, DstType>(
-                input_tensor.tensor_spec(), input_buffer);
+                input_tensor.tensor_spec(), output_spec, input_buffer);
         };
 
         auto with_src = [dst_type, &with_src_and_dst]<typename SrcType>() {
@@ -1259,24 +1297,20 @@ HostTensor to_dtype(const HostTensor& input_tensor, DataType dtype) {
         TT_THROW("Unreachable");
     }();
 
-    const auto layout =
-        (dtype == DataType::BFLOAT4_B || dtype == DataType::BFLOAT8_B) ? Layout::TILE : input_tensor.layout();
-
-    tt::tt_metal::PageConfig page_config(layout);
-    if (input_tensor.layout() == Layout::TILE) {
-        page_config = tt::tt_metal::PageConfig(layout, input_tensor.tensor_spec().tile());
+    auto result_buffer = std::move(output_storage);
+    const size_t expected_shard_size = output_spec.compute_packed_buffer_size_bytes();
+    for (const auto& coord : result_buffer.shard_coords()) {
+        auto shard = result_buffer.get_shard(coord);
+        if (shard) {
+            TT_FATAL(
+                shard->view_bytes().size() == expected_shard_size,
+                "to_dtype shard size mismatch after conversion: actual {} != expected {}",
+                shard->view_bytes().size(),
+                expected_shard_size);
+        }
     }
 
-    auto output_spec = TensorSpec(
-        input_tensor.logical_shape(),
-        tt::tt_metal::TensorLayout::fromPaddedShape(
-            dtype,
-            page_config,
-            input_tensor.tensor_spec().memory_config(),
-            input_tensor.logical_shape(),
-            input_tensor.padded_shape()));
-
-    return HostTensor::from_buffer(std::move(output_storage), output_spec, input_tensor.tensor_topology());
+    return HostTensor::from_buffer(std::move(result_buffer), output_spec, input_tensor.tensor_topology());
 }
 
 // ======================================================================================

--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -20,6 +20,7 @@
 #include "tt_metal/distributed/pinned_memory_cache.hpp"
 #include "tt_metal/distributed/mesh_device_view_impl.hpp"
 #include <tt_stl/concepts.hpp>
+#include <tt_stl/reflection.hpp>
 #include <tt_stl/small_vector.hpp>
 
 namespace tt::tt_metal {

--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cstring>
 #include <functional>
+#include <string_view>
 #include <unordered_set>
 
 #include "host_tensor_impl.hpp"
@@ -546,6 +547,22 @@ std::vector<distributed::MeshCoordinate> enqueue_write_tensor(
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
 
+void assert_host_shards_match_packed_size(
+    const DistributedHostBuffer& buffer, const TensorSpec& spec, std::string_view op_name) {
+    const size_t expected_shard_size = spec.compute_packed_buffer_size_bytes();
+    for (const auto& coord : buffer.shard_coords()) {
+        auto shard = buffer.get_shard(coord);
+        if (shard) {
+            TT_FATAL(
+                shard->view_bytes().size() == expected_shard_size,
+                "{} shard size mismatch after conversion: actual {} != expected {}",
+                op_name,
+                shard->view_bytes().size(),
+                expected_shard_size);
+        }
+    }
+}
+
 template <typename T>
 HostTensor to_row_major_layout_impl(const HostTensor& tensor) {
     if (tensor.layout() == Layout::ROW_MAJOR) {
@@ -553,15 +570,23 @@ HostTensor to_row_major_layout_impl(const HostTensor& tensor) {
     }
 
     TT_FATAL(tensor.layout() == Layout::TILE, "Converting from {} to Row Major is unsupported.", tensor.layout());
-    // Construct the new tensor spec first to verify that this is a supported Tensor configuration
-    TensorSpec new_tensor_spec(
+
+    // Do not pass a non-default tile into ROW_MAJOR PageConfig (deprecation #18536).
+    auto output_spec = TensorSpec(
         tensor.logical_shape(),
-        TensorLayout::fromPaddedShape(
+        TensorLayout(
             tensor.dtype(),
             PageConfig(Layout::ROW_MAJOR),
-            MemoryConfig{},
-            tensor.logical_shape(),
-            tensor.padded_shape()));
+            tensor.memory_config(),
+            tensor.tensor_spec().tensor_layout().get_alignment()));
+
+    TT_FATAL(
+        output_spec.physical_shape() == tensor.tensor_spec().physical_shape(),
+        "to_layout: Converting layout to {} implicitly changed physical shape from {} to {} due to alignment "
+        "constraints. This is currently unsupported. Please pad the tensor explicitly before conversion.",
+        Layout::ROW_MAJOR,
+        tensor.tensor_spec().physical_shape(),
+        output_spec.physical_shape());
 
     auto tile = tensor.tensor_spec().tile();
     auto physical_shape = tensor.tensor_spec().physical_shape();
@@ -574,7 +599,9 @@ HostTensor to_row_major_layout_impl(const HostTensor& tensor) {
         },
         DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
 
-    return HostTensor::from_buffer(std::move(transformed_buffer), new_tensor_spec, tensor.tensor_topology());
+    assert_host_shards_match_packed_size(transformed_buffer, output_spec, "to_row_major_layout");
+
+    return HostTensor::from_buffer(std::move(transformed_buffer), output_spec, tensor.tensor_topology());
 }
 
 template <typename T>
@@ -589,15 +616,21 @@ HostTensor to_tile_layout_impl(const HostTensor& tensor, Tile tile) {
     } else {
         TT_FATAL(tensor.layout() == Layout::ROW_MAJOR, "Converting from {} to Tile is unsupported.", tensor.layout());
 
-        // Construct the new tensor spec first to verify that this is a supported Tensor configuration
-        TensorSpec new_tensor_spec(
+        auto output_spec = TensorSpec(
             tensor.logical_shape(),
-            TensorLayout::fromPaddedShape(
+            TensorLayout(
                 tensor.dtype(),
                 PageConfig(Layout::TILE, tile),
-                MemoryConfig{},
-                tensor.logical_shape(),
-                tensor.padded_shape()));
+                tensor.memory_config(),
+                tensor.tensor_spec().tensor_layout().get_alignment()));
+
+        TT_FATAL(
+            output_spec.physical_shape() == tensor.tensor_spec().physical_shape(),
+            "to_layout: Converting layout to {} implicitly changed physical shape from {} to {} due to alignment "
+            "constraints. This is currently unsupported. Please pad the tensor explicitly before conversion.",
+            Layout::TILE,
+            tensor.tensor_spec().physical_shape(),
+            output_spec.physical_shape());
 
         auto physical_shape = tensor.tensor_spec().physical_shape();
 
@@ -609,7 +642,9 @@ HostTensor to_tile_layout_impl(const HostTensor& tensor, Tile tile) {
             },
             DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
 
-        return HostTensor::from_buffer(std::move(transformed_buffer), new_tensor_spec, tensor.tensor_topology());
+        assert_host_shards_match_packed_size(transformed_buffer, output_spec, "to_tile_layout");
+
+        return HostTensor::from_buffer(std::move(transformed_buffer), output_spec, tensor.tensor_topology());
     }
 }
 
@@ -637,6 +672,14 @@ HostTensor to_row_major_layout(const HostTensor& tensor) {
 }
 
 HostTensor to_tile_layout(const HostTensor& tensor, const Tile& tile) {
+    // Reject mismatched retile before dtype dispatch so BFP cannot silently identity-return.
+    if (tensor.layout() == Layout::TILE) {
+        TT_FATAL(
+            tile == tensor.tensor_spec().tile(),
+            "to_tile_layout: requested tile {} does not match input tile {}. Retile is not supported.",
+            tile,
+            tensor.tensor_spec().tile());
+    }
     return tensor_impl::dispatch(tensor.dtype(), [&]<typename T>() {
         if constexpr (std::is_same_v<T, tensor_impl::bfloat4_b> || std::is_same_v<T, tensor_impl::bfloat8_b>) {
             // Block-float formats are natively TILE — no conversion needed.
@@ -920,17 +963,28 @@ HostTensor pad_impl(
         tile = tensor.tensor_spec().tile();
     }
 
-    return HostTensor::from_buffer(
-        std::move(transformed_buffer),
-        TensorSpec(
+    auto output_spec = TensorSpec(
+        tensor.logical_shape(),
+        TensorLayout::fromPaddedShape(
+            tensor.dtype(),
+            PageConfig(tensor.layout(), tile),
+            tensor.memory_config(),
             tensor.logical_shape(),
-            TensorLayout::fromPaddedShape(
-                tensor.dtype(),
-                PageConfig(tensor.layout(), tile),
-                MemoryConfig{},
-                tensor.logical_shape(),
-                output_padded_shape)),
-        tensor.tensor_topology());
+            output_padded_shape));
+
+    const size_t expected_shard_size = output_spec.compute_packed_buffer_size_bytes();
+    for (const auto& coord : transformed_buffer.shard_coords()) {
+        auto shard = transformed_buffer.get_shard(coord);
+        if (shard) {
+            TT_FATAL(
+                shard->view_bytes().size() == expected_shard_size,
+                "pad shard size mismatch after conversion: actual {} != expected {}",
+                shard->view_bytes().size(),
+                expected_shard_size);
+        }
+    }
+
+    return HostTensor::from_buffer(std::move(transformed_buffer), output_spec, tensor.tensor_topology());
 }
 
 template <>
@@ -1006,15 +1060,35 @@ HostTensor unpad_impl(
     auto transformed_buffer = tensor.buffer().transform(
         [&](const HostBuffer& buffer) { return HostBuffer(unpad(buffer)); },
         DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
-    return HostTensor::from_buffer(
-        std::move(transformed_buffer),
-        TensorSpec(
-            tt::tt_metal::Shape(output_shape),
-            tt::tt_metal::TensorLayout(
-                tensor.dtype(),
-                tt::tt_metal::PageConfig(tensor.layout(), tensor.tensor_spec().tile()),
-                tt::tt_metal::MemoryConfig{})),
-        tensor.tensor_topology());
+
+    // Exact authorship: padded == logical == cropped buffer. Do not re-apply source alignment.
+    const auto output_tensor_shape = tt::tt_metal::Shape(output_shape);
+    auto tile = tt::tt_metal::Tile();
+    if (tensor.layout() == Layout::TILE) {
+        tile = tensor.tensor_spec().tile();
+    }
+    auto output_spec = TensorSpec(
+        output_tensor_shape,
+        TensorLayout::fromPaddedShape(
+            tensor.dtype(),
+            PageConfig(tensor.layout(), tile),
+            tensor.memory_config(),
+            output_tensor_shape,
+            output_tensor_shape));
+
+    const size_t expected_shard_size = output_spec.compute_packed_buffer_size_bytes();
+    for (const auto& coord : transformed_buffer.shard_coords()) {
+        auto shard = transformed_buffer.get_shard(coord);
+        if (shard) {
+            TT_FATAL(
+                shard->view_bytes().size() == expected_shard_size,
+                "unpad shard size mismatch after conversion: actual {} != expected {}",
+                shard->view_bytes().size(),
+                expected_shard_size);
+        }
+    }
+
+    return HostTensor::from_buffer(std::move(transformed_buffer), output_spec, tensor.tensor_topology());
 }
 
 template <>
@@ -1048,6 +1122,11 @@ HostTensor pad(
     const tt::tt_metal::Shape& input_tensor_start,
     float pad_value) {
     TT_FATAL(tensor.layout() == Layout::ROW_MAJOR, "Tensor layout must be ROW_MAJOR for padding");
+    TT_FATAL(
+        !tensor.memory_config().is_sharded(),
+        "pad: sharded host tensors are not supported (legacy and ND). "
+        "legacyShapeToAlignment short-circuits on shard_spec and ignores output_padded_shape for convertible ND; "
+        "rederiving shard geometry under pad is out of scope.");
     return tensor_impl::dispatch(tensor.dtype(), [&]<typename T>() {
         return CMAKE_UNIQUE_NAMESPACE::pad_impl<T>(tensor, output_padded_shape, input_tensor_start, pad_value);
     });
@@ -1084,6 +1163,11 @@ HostTensor unpad(
     const tt::tt_metal::Shape& output_tensor_start,
     const tt::tt_metal::Shape& output_tensor_end) {
     TT_FATAL(tensor.layout() == Layout::ROW_MAJOR, "Tensor layout must be ROW_MAJOR for unpadding");
+    TT_FATAL(
+        !tensor.memory_config().is_sharded(),
+        "unpad: sharded host tensors are not supported (legacy and ND). "
+        "legacyShapeToAlignment short-circuits on shard_spec and ignores cropped geometry for convertible ND; "
+        "rederiving shard geometry under unpad is out of scope.");
     return tensor_impl::dispatch(tensor.dtype(), [&]<typename T>() {
         return CMAKE_UNIQUE_NAMESPACE::unpad_impl<T>(tensor, output_tensor_start, output_tensor_end);
     });


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Bug Fix

### Summary

Runtime Tensor has a set of host side creation factory (`from_vector`/ `from_span`), as well as a set of host sdie operations (`to_dtype`, `to_layout`, `pad`, `unpad`). The usage expectation is the operation performs transformation while maintaining the original TensorSpec. However host side ops almost always drop sharding/ alignment information upon transformation.

This PR ensures proper propagation of TensroSpec in these host side ops.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/host-to-dtype-packing-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/host-to-dtype-packing-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/host-to-dtype-packing-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/host-to-dtype-packing-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=riverwu/host-to-dtype-packing-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:riverwu/host-to-dtype-packing-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/host-to-dtype-packing-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/host-to-dtype-packing-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/host-to-dtype-packing-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/host-to-dtype-packing-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/host-to-dtype-packing-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/host-to-dtype-packing-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/host-to-dtype-packing-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/host-to-dtype-packing-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/host-to-dtype-packing-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/host-to-dtype-packing-fix)