### PR TITLE
[Bug fix] Add missing tiny-tile TensorShapes to LLK coverage tables (#50196)

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -437,7 +437,7 @@ def test_matmul_reuse_config_sharded_tiny_tile(
             atol=0.04 * k,
             rtol=68.5 * k,
             frobenius_threshold=0.001 * k,
-            pcc_threshold=0.993,
+            pcc_threshold=0.9925,
             check_ulp=False,
         )
     elif in1_dtype == ttnn.bfloat8_b:

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -437,7 +437,7 @@ def test_matmul_reuse_config_sharded_tiny_tile(
             atol=0.04 * k,
             rtol=68.5 * k,
             frobenius_threshold=0.001 * k,
-            pcc_threshold=0.9925,
+            pcc_threshold=0.993,
             check_ulp=False,
         )
     elif in1_dtype == ttnn.bfloat8_b:

--- a/tt_metal/tt-llk/common/tensor_shape_coverage.h
+++ b/tt_metal/tt-llk/common/tensor_shape_coverage.h
@@ -37,6 +37,7 @@ constexpr TensorShape TENSOR_SHAPE_FR1_NF1x1  = {1, MAX_FACE_C_DIM, 1, 1};  ///<
 constexpr TensorShape TENSOR_SHAPE_FR1_NF1x2  = {1, MAX_FACE_C_DIM, 1, 2};  ///<  1x32
 constexpr TensorShape TENSOR_SHAPE_FR2_NF1x1  = {2, MAX_FACE_C_DIM, 1, 1};  ///<  2x16
 constexpr TensorShape TENSOR_SHAPE_FR2_NF1x2  = {2, MAX_FACE_C_DIM, 1, 2};  ///<  2x32
+constexpr TensorShape TENSOR_SHAPE_FR4_NF1x1  = {4, MAX_FACE_C_DIM, 1, 1};  ///<  4x16
 constexpr TensorShape TENSOR_SHAPE_FR4_NF1x2  = {4, MAX_FACE_C_DIM, 1, 2};  ///<  4x32
 constexpr TensorShape TENSOR_SHAPE_FR8_NF1x1  = {8, MAX_FACE_C_DIM, 1, 1};  ///<  8x16
 constexpr TensorShape TENSOR_SHAPE_FR8_NF1x2  = {8, MAX_FACE_C_DIM, 1, 2};  ///<  8x32

--- a/tt_metal/tt-llk/common/tensor_shape_coverage.h
+++ b/tt_metal/tt-llk/common/tensor_shape_coverage.h
@@ -35,6 +35,7 @@ namespace ckernel::coverage
 // entry only when a harvested shape needs a named constant.
 constexpr TensorShape TENSOR_SHAPE_FR1_NF1x1  = {1, MAX_FACE_C_DIM, 1, 1};  ///<  1x16
 constexpr TensorShape TENSOR_SHAPE_FR1_NF1x2  = {1, MAX_FACE_C_DIM, 1, 2};  ///<  1x32
+constexpr TensorShape TENSOR_SHAPE_FR2_NF1x1  = {2, MAX_FACE_C_DIM, 1, 1};  ///<  2x16
 constexpr TensorShape TENSOR_SHAPE_FR2_NF1x2  = {2, MAX_FACE_C_DIM, 1, 2};  ///<  2x32
 constexpr TensorShape TENSOR_SHAPE_FR4_NF1x2  = {4, MAX_FACE_C_DIM, 1, 2};  ///<  4x32
 constexpr TensorShape TENSOR_SHAPE_FR8_NF1x1  = {8, MAX_FACE_C_DIM, 1, 1};  ///<  8x16

--- a/tt_metal/tt-llk/common/tensor_shape_coverage_math.h
+++ b/tt_metal/tt-llk/common/tensor_shape_coverage_math.h
@@ -21,7 +21,8 @@ namespace ckernel::coverage
 inline bool is_math_tensor_shape_covered(const TensorShape& tensor_shape)
 {
     return tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR1_NF1x1) || tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR1_NF1x2) ||
-           tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR2_NF1x2) || tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR4_NF1x2) ||
+           tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR2_NF1x1) || tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR2_NF1x2) ||
+           tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR4_NF1x2) ||
            tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR8_NF1x2) || tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR16_NF1x1) ||
            tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR16_NF1x2) || tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR16_NF2x1) ||
            tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR16_NF2x2);

--- a/tt_metal/tt-llk/common/tensor_shape_coverage_math.h
+++ b/tt_metal/tt-llk/common/tensor_shape_coverage_math.h
@@ -22,7 +22,7 @@ inline bool is_math_tensor_shape_covered(const TensorShape& tensor_shape)
 {
     return tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR1_NF1x1) || tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR1_NF1x2) ||
            tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR2_NF1x1) || tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR2_NF1x2) ||
-           tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR4_NF1x2) ||
+           tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR4_NF1x1) || tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR4_NF1x2) ||
            tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR8_NF1x2) || tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR16_NF1x1) ||
            tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR16_NF1x2) || tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR16_NF2x1) ||
            tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR16_NF2x2);

--- a/tt_metal/tt-llk/common/tensor_shape_coverage_math.h
+++ b/tt_metal/tt-llk/common/tensor_shape_coverage_math.h
@@ -23,8 +23,8 @@ inline bool is_math_tensor_shape_covered(const TensorShape& tensor_shape)
     return tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR1_NF1x1) || tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR1_NF1x2) ||
            tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR2_NF1x1) || tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR2_NF1x2) ||
            tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR4_NF1x1) || tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR4_NF1x2) ||
-           tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR8_NF1x2) || tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR16_NF1x1) ||
-           tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR16_NF1x2) || tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR16_NF2x1) ||
+           tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR8_NF1x1) || tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR8_NF1x2) ||
+           tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR16_NF1x1) || tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR16_NF1x2) ||
            tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR16_NF2x2);
 }
 

--- a/tt_metal/tt-llk/common/tensor_shape_coverage_math.h
+++ b/tt_metal/tt-llk/common/tensor_shape_coverage_math.h
@@ -25,7 +25,7 @@ inline bool is_math_tensor_shape_covered(const TensorShape& tensor_shape)
            tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR4_NF1x1) || tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR4_NF1x2) ||
            tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR8_NF1x1) || tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR8_NF1x2) ||
            tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR16_NF1x1) || tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR16_NF1x2) ||
-           tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR16_NF2x2);
+           tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR16_NF2x1) || tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR16_NF2x2);
 }
 
 } // namespace ckernel::coverage

--- a/tt_metal/tt-llk/common/tensor_shape_coverage_unpack.h
+++ b/tt_metal/tt-llk/common/tensor_shape_coverage_unpack.h
@@ -22,7 +22,7 @@ inline bool is_unpack_tensor_shape_covered(const TensorShape& tensor_shape)
 {
     return tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR1_NF1x1) || tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR1_NF1x2) ||
            tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR2_NF1x1) || tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR2_NF1x2) ||
-           tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR4_NF1x2) ||
+           tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR4_NF1x1) || tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR4_NF1x2) ||
            tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR8_NF1x1) || tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR8_NF1x2) ||
            tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR16_NF1x1) || tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR16_NF1x2) ||
            tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR16_NF2x1) || tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR16_NF2x2);

--- a/tt_metal/tt-llk/common/tensor_shape_coverage_unpack.h
+++ b/tt_metal/tt-llk/common/tensor_shape_coverage_unpack.h
@@ -21,7 +21,8 @@ namespace ckernel::coverage
 inline bool is_unpack_tensor_shape_covered(const TensorShape& tensor_shape)
 {
     return tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR1_NF1x1) || tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR1_NF1x2) ||
-           tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR2_NF1x2) || tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR4_NF1x2) ||
+           tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR2_NF1x1) || tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR2_NF1x2) ||
+           tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR4_NF1x2) ||
            tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR8_NF1x1) || tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR8_NF1x2) ||
            tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR16_NF1x1) || tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR16_NF1x2) ||
            tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR16_NF2x1) || tensor_shape_eq(tensor_shape, TENSOR_SHAPE_FR16_NF2x2);

--- a/tt_metal/tt-llk/tests/python_tests/helpers/tensor_shape_coverage_parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/tensor_shape_coverage_parser.py
@@ -70,6 +70,7 @@ SHAPE_NAMES = {
     (1, 1, 2): "TENSOR_SHAPE_FR1_NF1x2",
     (2, 1, 1): "TENSOR_SHAPE_FR2_NF1x1",
     (2, 1, 2): "TENSOR_SHAPE_FR2_NF1x2",
+    (4, 1, 1): "TENSOR_SHAPE_FR4_NF1x1",
     (4, 1, 2): "TENSOR_SHAPE_FR4_NF1x2",
     (8, 1, 1): "TENSOR_SHAPE_FR8_NF1x1",
     (8, 1, 2): "TENSOR_SHAPE_FR8_NF1x2",

--- a/tt_metal/tt-llk/tests/python_tests/helpers/tensor_shape_coverage_parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/tensor_shape_coverage_parser.py
@@ -68,6 +68,7 @@ PREDICATE_BODY_RE = re.compile(
 SHAPE_NAMES = {
     (1, 1, 1): "TENSOR_SHAPE_FR1_NF1x1",
     (1, 1, 2): "TENSOR_SHAPE_FR1_NF1x2",
+    (2, 1, 1): "TENSOR_SHAPE_FR2_NF1x1",
     (2, 1, 2): "TENSOR_SHAPE_FR2_NF1x2",
     (4, 1, 2): "TENSOR_SHAPE_FR4_NF1x2",
     (8, 1, 1): "TENSOR_SHAPE_FR8_NF1x1",


### PR DESCRIPTION
### Summary
Closes #50195, #50196, #50197, and #50198.
Closes #50718, #50719, #50720, and #50721.
Closes #50761, #50762, #50763, and #50765.

Adds missing narrow tiny-tile `TensorShape` entries to LLK coverage tables so matmul kernels with `TT_METAL_LLK_ASSERTS=1` no longer hang on uncovered shapes:

| Shape | Unpack | Math | Trigger |
|-------|--------|------|---------|
| `TENSOR_SHAPE_FR2_NF1x1` (2×16) | ✓ | ✓ | `test_optional_output_argument_with_tiny_tiles[tile_h=2]` |
| `TENSOR_SHAPE_FR4_NF1x1` (4×16) | ✓ | ✓ | `test_optional_output_argument_with_tiny_tiles[tile_h=4]` |
| `TENSOR_SHAPE_FR8_NF1x1` (8×16) | (already present) | ✓ | `test_matmul_2d_tiny_tile` fused bias (`has_bias=True`, `tile_h=8`) |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=gchoudhary/50196-tensor-shape-fr2-nf1x1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:gchoudhary/50196-tensor-shape-fr2-nf1x1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=gchoudhary/50196-tensor-shape-fr2-nf1x1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:gchoudhary/50196-tensor-shape-fr2-nf1x1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=gchoudhary/50196-tensor-shape-fr2-nf1x1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:gchoudhary/50196-tensor-shape-fr2-nf1x1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gchoudhary/50196-tensor-shape-fr2-nf1x1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gchoudhary/50196-tensor-shape-fr2-nf1x1)