### PR TITLE
Fix OOB L1 write in distributed layernorm 2D pre-all-gather merge CB (c_15)

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_rmsnorm_allgather.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_distributed_rmsnorm_allgather.py
@@ -112,6 +112,9 @@ def _run_distributed_rmsnorm_single_device(
         # LLaMA 70B Galaxy decode shape: hidden=8192, cluster_axis=1 with 4 devices.
         # The 2D-grid path activates when shape[-2] == 128.
         (128, 8192, 4),
+        # Regression: cores_y > tiles_per_core_y (Wt=32 -> cores_y=8, tiles_per_core_y=4) exercises
+        # the c_15 merge-gather CB OOB; fails unless c_15 is sized by cores_y.
+        (128, 4096, 4),
     ],
 )
 @pytest.mark.parametrize("use_2d_core_grid", [False, True])

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/layernorm_pre_all_gather_program_factory.cpp
@@ -542,9 +542,15 @@ tt::tt_metal::ProgramDescriptor LayerNormPreAllGather2DProgramFactory::create_de
             .data_format = cb_data_format,
             .page_size = single_tile_size}}}});
 
-    // c_intermed1 (CB 15)
+    // c_intermed1 (CB 15) — cross-core merge buffer (cb_x2_merge) for the 2D core grid.
+    // Each of the cores_y worker rows writes one partial-stat tile into this buffer on the merge
+    // core, and the merge core's compute wait_front/add_tiles/pop_front over cores_y tiles. Size it
+    // by the gather count (cores_y), NOT the per-core width (tiles_per_core_y): when
+    // cores_y > tiles_per_core_y (i.e. cores_y^2 > Wt, e.g. grid.y=8 with Wt=32 -> cores_y=8,
+    // tiles_per_core_y=4) the old sizing was too small and workers with y >= tiles_per_core_y wrote
+    // past the allocation, corrupting adjacent L1 (with a matching over-read on the compute side).
     program_descriptor.cbs.push_back(CBDescriptor{
-        .total_size = tiles_per_core_y * single_tile_size,
+        .total_size = cores_y * single_tile_size,
         .core_ranges = all_cores,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_15),


### PR DESCRIPTION
### Problem

Closes #50287 (sub-issue of the race-audit tracker #50154, finding 5).

In the distributed-layernorm **2D-core-grid** pre-all-gather path, worker cores gather one partial `x²` statistic tile from each of the `cores_y` rows into the merge buffer **`c_15` (`cb_x2_merge`)** on the merge core, and the merge core's compute reduces over `cores_y` tiles (`wait_front`/`add_tiles`/`pop_front` over `num_cores_to_wait == cores_y`). But the CB is allocated by the per-core **width** `tiles_per_core_y = Wt / cores_y`, not the **gather count** `cores_y`:

```cpp
.total_size = tiles_per_core_y * single_tile_size,   // c_15
```

Whenever `cores_y > tiles_per_core_y` (i.e. `cores_y² > Wt`) the gather writes past the allocation → **out-of-bounds L1 write** on the merge core (corrupts adjacent L1) with a matching over-read on the compute side → wrong normalization output. On a full WH B0 grid (`grid.y=8`) with `Wt=32` (`hidden_per_dev=1024`): `cores_y=8`, `tiles_per_core_y=4` → worker rows `y ≥ 4` write out of bounds. The 2D path is selected by `use_2d_core_grid=True` with no `TT_FATAL` guarding it, and the only in-tree 2D test sits exactly on `tiles_per_core_y == cores_y == 8`, masking it.

This is orthogonal to NoC ordering — the worker already does non-posted `async_write` + `async_write_barrier` before `reducer_sem.up`; a barriered write to an out-of-range address still lands out of range.

### Fix

Size `c_15` by the gather count:

```cpp
.total_size = cores_y * single_tile_size,
```

`cores_y` is the exact number of tiles gathered and consumed, so this is correct for every shape (it also shrinks the buffer when `cores_y < tiles_per_core_y`). Host-side one-line change; **no kernel change needed**.

### Scope / relationship to other issues

- **Not** a duplicate of #48393 / #48188 / #48586. The nearest, **#48586 (#2)**, is the *same op family* (`layernorm_distributed` pre-all-gather) but a **different defect** — a two-stage-reduce CB credit-count deficit/hang in the **sharded `reader_mcast`** path (`c_13`), not this 2D-core-grid merge buffer (`c_15`).
- The **welford** pre-all-gather factory does not share this bug (online `welford_spill_tiles` algorithm, no `c_15` merge CB).

### Testing

> ⚠️ **Not validated on hardware** — this op is JIT-compiled on-device and can't be built in my environment. Needs a targeted 2D-grid case where `cores_y > tiles_per_core_y` (e.g. `grid.y=8`, `Wt=32`), which no in-tree test currently exercises — the existing 2D test lands on `tiles_per_core_y == cores_y`, so it passes both before and after. Requires CI + owner review.

Introduced by @sraizada-tt (2D core-grid path); recent refactors by Diego Gomez (ProgramDescriptor migration) and Vasisht Suresh (welford migration) — review ping welcome.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/fix-layernorm-distributed-2d-merge-cb-oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/fix-layernorm-distributed-2d-merge-cb-oob)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/fix-layernorm-distributed-2d-merge-cb-oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/fix-layernorm-distributed-2d-merge-cb-oob)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/fix-layernorm-distributed-2d-merge-cb-oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/fix-layernorm-distributed-2d-merge-cb-oob)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/fix-layernorm-distributed-2d-merge-cb-oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/fix-layernorm-distributed-2d-merge-cb-oob)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/fix-layernorm-distributed-2d-merge-cb-oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/fix-layernorm-distributed-2d-merge-cb-oob)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/fix-layernorm-distributed-2d-merge-cb-oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/fix-layernorm-distributed-2d-merge-cb-oob)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/fix-layernorm-distributed-2d-merge-cb-oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/fix-layernorm-distributed-2d-merge-cb-oob)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/fix-layernorm-distributed-2d-merge-cb-oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/fix-layernorm-distributed-2d-merge-cb-oob)