### PR TITLE
Runtime Test: add JIT-build compile-throughput CI microbenchmark

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -247,8 +247,8 @@ runtime:
     wh_galaxy: 15
     bh_galaxy: 15
   perf:
-    wh_n300_civ2: 55
-    bh_p150_perf: 40
+    wh_n300_civ2: 65
+    bh_p150_perf: 50
 
 triage:
   merge_gate:

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -247,6 +247,9 @@ runtime:
     wh_galaxy: 15
     bh_galaxy: 15
   perf:
+    # +10 min/SKU over the prior 55/40 to cover the new runtime_perf_jit_build job
+    # (JIT-build compile-throughput microbenchmark: 300 kernels x 3 reps, ~2-3 min
+    # measured, budgeted at 10 min in runtime_perf_tests.yaml).
     wh_n300_civ2: 65
     bh_p150_perf: 50
 

--- a/tests/pipeline_reorg/runtime_perf_tests.yaml
+++ b/tests/pipeline_reorg/runtime_perf_tests.yaml
@@ -1,6 +1,8 @@
-# This file defines the test matrix for the Runtime performance (dispatch) tests.
-# These are Google Benchmark-based microbenchmarks measuring dispatch latency and
-# buffer R/W bandwidth, with golden comparison for regression detection.
+# This file defines the test matrix for the Runtime performance tests.
+# These are host-side microbenchmarks (dispatch latency, buffer R/W bandwidth,
+# and JIT-build compile throughput), each with golden comparison for regression
+# detection. The dispatch/buffer benchmarks use Google Benchmark; the JIT-build
+# benchmark drives a gtest and gates via compile_stress_ci.py.
 #
 # Each entry represents a parallel job with the following keys:
 #   name: The display name for the job in GitHub Actions.
@@ -55,6 +57,25 @@
   skus:
     wh_n300_civ2:
       timeout: 25
+    bh_p150_perf:
+      timeout: 10
+  owner_id: U099A7FMKL2 # Manish Sudumbrekar
+  team: runtime
+
+# --- JIT Build (local host compile) Throughput Benchmark ---
+# Adapts DISABLED_TensixCompileStress into a runtime perf gate: real attached
+# device, no remote compile server, N cache-bypassing kernels compiled locally
+# per rep (kernels are compiled, not dispatched). The driver takes the fastest
+# rep and compares it against a per-arch golden (record mode until goldens are
+# armed). Auto-picks the golden from $ARCH_NAME.
+- name: runtime_perf_jit_build
+  cmd: |
+    mkdir -p generated/test_reports
+    ./tests/tt_metal/tt_metal/jit_build/compile_stress_ci.py \
+      --arch "$ARCH_NAME" --num-kernels 300 --repetitions 3
+  skus:
+    wh_n300_civ2:
+      timeout: 10
     bh_p150_perf:
       timeout: 10
   owner_id: U099A7FMKL2 # Manish Sudumbrekar

--- a/tests/tt_metal/tt_metal/jit_build/README_compile_stress_ci.md
+++ b/tests/tt_metal/tt_metal/jit_build/README_compile_stress_ci.md
@@ -75,7 +75,11 @@ Both goldens are **armed on `compile_ms_min`** (15% tolerance), set to the worst
 | SKU | golden `compile_ms_min` | fails above (~min × 1.15) |
 | --- | --- | --- |
 | `wh_n300_civ2` (wormhole_b0) | 50700 ms | ~58.3 s |
-| `bh_p150_perf` (blackhole)   | 19500 ms | ~22.4 s |
+| `bh_p150_perf` (blackhole)   | 44800 ms | ~51.5 s |
+
+> Blackhole compile is bimodal (~18–20 s with a warm host ccache vs ~43–45 s cold).
+> The golden is anchored to the worst **cold** min so it never false-fails on either
+> regime; a tighter gate needs the ccache bimodality removed (follow-up).
 
 `kernels_per_sec_max` stays `null` on both — the time gate is sufficient and
 throughput is just its inverse.

--- a/tests/tt_metal/tt_metal/jit_build/README_compile_stress_ci.md
+++ b/tests/tt_metal/tt_metal/jit_build/README_compile_stress_ci.md
@@ -75,7 +75,7 @@ Both goldens are **armed on `compile_ms_min`** (15% tolerance), set to the worst
 | SKU | golden `compile_ms_min` | fails above (~min × 1.15) |
 | --- | --- | --- |
 | `wh_n300_civ2` (wormhole_b0) | 50700 ms | ~58.3 s |
-| `bh_p150_perf` (blackhole)   | 44800 ms | ~51.5 s |
+| `bh_p150_perf` (blackhole)   | 19500 ms | ~22.4 s |
 
 `kernels_per_sec_max` stays `null` on both — the time gate is sufficient and
 throughput is just its inverse.

--- a/tests/tt_metal/tt_metal/jit_build/README_compile_stress_ci.md
+++ b/tests/tt_metal/tt_metal/jit_build/README_compile_stress_ci.md
@@ -1,0 +1,82 @@
+<!-- SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# JIT-build compile-throughput CI benchmark
+
+Part of [#46305](https://github.com/tenstorrent/tt-metal/issues/46305) (extend the
+runtime microbenchmark suite) — this covers the **"jit building"** item, alongside
+the op-to-op latency benchmark ([#49771](https://github.com/tenstorrent/tt-metal/pull/49771)).
+
+## What it measures
+
+Host-side **local JIT compile throughput**: how fast metal compiles kernels on the
+host (fork the RISC-V toolchain, produce ELFs). Kernels are compiled, **not**
+dispatched — the device is only used for build config (arch/grid).
+
+It adapts the existing `DISABLED_TensixCompileStress` gtest in
+[`test_compile_stress.cpp`](./test_compile_stress.cpp), which creates N compute
+kernels with unique `{id, seed}` compile-time args so each one **bypasses the JIT
+cache**, spreads them across grid-sized programs, and compiles all programs in
+parallel, reporting `total_elapsed_ms`.
+
+The gated metric is **`compile_ms_min`** (wall-clock to cold-compile N kernels;
+lower is better). `kernels_per_sec_max` is recorded alongside it.
+
+> **Real device, not mock.** The test's original mock path (`TT_METAL_COMPILE_STRESS_MOCK=1`,
+> the default) is for device-less compile hosts / the remote-server harness; on a
+> device-equipped host its real→mock transition throws because
+> `MeshDispatchFixture::SetUpTestSuite` already opened the device. The runtime-perf
+> SKUs have hardware, so the driver sets `TT_METAL_COMPILE_STRESS_MOCK=0` to compile
+> against the real attached device. Compilation is host-side either way.
+>
+> This is the **local** compile path (`TT_METAL_JIT_SERVER_ENABLE=0`). The remote
+> compile-server stress mode (`run_compile_stress_harness.py`, multi-client against
+> `TT_METAL_JIT_SERVER_ENDPOINTS`) is a separate, non-gated use-case and is not run
+> by CI here.
+
+## How CI runs it
+
+`compile_stress_ci.py` is the driver + regression gate, wired into the
+**(Runtime) Performance Tests** pipeline as `runtime_perf_jit_build`
+(`tests/pipeline_reorg/runtime_perf_tests.yaml`), on `wh_n300_civ2` and
+`bh_p150_perf`. CI config: `--num-kernels 300 --repetitions 3` (≈2–4 min/SKU;
+throughput is CPU-bound at roughly a few hundred kernels/min).
+
+For each of `--repetitions` runs it launches the gtest in a fresh process with:
+
+- a unique per-rep seed (`BASE_SEED + rep`) → every rep is a genuine **cold** compile,
+- an isolated `TT_METAL_CACHE` dir → no disk-cache carryover between reps,
+- a fresh process → fresh in-memory `JitBuildCache`,
+- `TT_METAL_JIT_SERVER_ENABLE=0` → local compile path only,
+- `TT_METAL_COMPILE_STRESS_MOCK=0` → real attached device, arch pinned to `$ARCH_NAME`.
+
+It then takes the **fastest** rep (min wall-clock rejects upward CPU-contention
+noise on shared runners) and compares it to a per-arch golden.
+
+Run it locally against a build:
+
+```bash
+./tests/tt_metal/tt_metal/jit_build/compile_stress_ci.py \
+    --arch blackhole --num-kernels 300 --repetitions 3
+```
+
+## Goldens and record mode
+
+- [`compile_stress_golden.json`](./compile_stress_golden.json) — Wormhole (`wh_n300_civ2`)
+- [`compile_stress_blackhole_golden.json`](./compile_stress_blackhole_golden.json) — Blackhole (`bh_p150_perf`)
+
+A golden metric set to `null` stays in **record mode**: the value is printed but the
+job is **not** gated on it. A non-null metric is **gated** — the job fails if the
+measured value regresses beyond `tolerance_pct` (default 15%).
+
+Both goldens currently ship in record mode so this can land before CI-SKU numbers
+exist (same rollout as op-to-op).
+
+### Arming the gate (follow-up)
+
+1. Let `runtime_perf_jit_build` run on CI for a few cycles.
+2. Read `compile_ms  min` off the passing runs for each SKU.
+3. Set `metrics.compile_ms_min` in the matching golden to that value (a stable
+   median across runs). Leave `kernels_per_sec_max` `null` unless you also want to
+   gate throughput.
+4. Adjust `tolerance_pct` if 15% is too tight/loose for observed CI variance.

--- a/tests/tt_metal/tt_metal/jit_build/README_compile_stress_ci.md
+++ b/tests/tt_metal/tt_metal/jit_build/README_compile_stress_ci.md
@@ -60,7 +60,7 @@ Run it locally against a build:
     --arch blackhole --num-kernels 300 --repetitions 3
 ```
 
-## Goldens and record mode
+## Goldens and gating
 
 - [`compile_stress_golden.json`](./compile_stress_golden.json) — Wormhole (`wh_n300_civ2`)
 - [`compile_stress_blackhole_golden.json`](./compile_stress_blackhole_golden.json) — Blackhole (`bh_p150_perf`)
@@ -69,14 +69,20 @@ A golden metric set to `null` stays in **record mode**: the value is printed but
 job is **not** gated on it. A non-null metric is **gated** — the job fails if the
 measured value regresses beyond `tolerance_pct` (default 15%).
 
-Both goldens currently ship in record mode so this can land before CI-SKU numbers
-exist (same rollout as op-to-op).
+Both goldens are **armed on `compile_ms_min`** (15% tolerance), set to the worst
+`compile_ms min` observed across two CI runs per SKU:
 
-### Arming the gate (follow-up)
+| SKU | golden `compile_ms_min` | fails above (~min × 1.15) |
+| --- | --- | --- |
+| `wh_n300_civ2` (wormhole_b0) | 50700 ms | ~58.3 s |
+| `bh_p150_perf` (blackhole)   | 44800 ms | ~51.5 s |
 
-1. Let `runtime_perf_jit_build` run on CI for a few cycles.
-2. Read `compile_ms  min` off the passing runs for each SKU.
-3. Set `metrics.compile_ms_min` in the matching golden to that value (a stable
-   median across runs). Leave `kernels_per_sec_max` `null` unless you also want to
-   gate throughput.
-4. Adjust `tolerance_pct` if 15% is too tight/loose for observed CI variance.
+`kernels_per_sec_max` stays `null` on both — the time gate is sufficient and
+throughput is just its inverse.
+
+### Re-tuning the gate
+
+1. Read `compile_ms  min` off the passing CI runs for the SKU.
+2. Update `metrics.compile_ms_min` in the matching golden (use the worst stable
+   min so normal variance doesn't flake the gate).
+3. Adjust `tolerance_pct` if 15% is too tight/loose for observed CI variance.

--- a/tests/tt_metal/tt_metal/jit_build/compile_stress_blackhole_golden.json
+++ b/tests/tt_metal/tt_metal/jit_build/compile_stress_blackhole_golden.json
@@ -2,9 +2,9 @@
   "arch": "blackhole",
   "num_kernels": 300,
   "tolerance_pct": 15.0,
-  "comment": "Local JIT-build throughput golden for the (Runtime) Performance Tests pipeline (SKU bh_p150_perf). RECORD MODE: metrics are null so the job prints but does not gate. Arm compile_ms_min from CI-run medians in a follow-up once numbers are stable. See README_compile_stress_ci.md.",
+  "comment": "Local JIT-build throughput golden for the (Runtime) Performance Tests pipeline (SKU bh_p150_perf). GATED on compile_ms_min: armed to the worst min observed across two CI runs (44730/42881 ms) with the 15% tolerance, so the job fails only if a run's min exceeds ~51.5s. kernels_per_sec_max stays null (time gate is sufficient; throughput is its inverse). See README_compile_stress_ci.md.",
   "metrics": {
-    "compile_ms_min": null,
+    "compile_ms_min": 44800,
     "kernels_per_sec_max": null
   }
 }

--- a/tests/tt_metal/tt_metal/jit_build/compile_stress_blackhole_golden.json
+++ b/tests/tt_metal/tt_metal/jit_build/compile_stress_blackhole_golden.json
@@ -2,9 +2,9 @@
   "arch": "blackhole",
   "num_kernels": 300,
   "tolerance_pct": 15.0,
-  "comment": "Local JIT-build throughput golden for the (Runtime) Performance Tests pipeline (SKU bh_p150_perf). GATED on compile_ms_min: armed to the worst min observed across two CI runs (44730/42881 ms) with the 15% tolerance, so the job fails only if a run's min exceeds ~51.5s. kernels_per_sec_max stays null (time gate is sufficient; throughput is its inverse). See README_compile_stress_ci.md.",
+  "comment": "Local JIT-build throughput golden for the (Runtime) Performance Tests pipeline (SKU bh_p150_perf). GATED on compile_ms_min: armed to the worst min observed across two CI runs in the current regime (18378/19292 ms) with the 15% tolerance, so the job fails only if a run's min exceeds ~22.4s. (Re-armed down from 44800 after a BH-specific ~2.4x compile speedup landed.) kernels_per_sec_max stays null (time gate is sufficient; throughput is its inverse). See README_compile_stress_ci.md.",
   "metrics": {
-    "compile_ms_min": 44800,
+    "compile_ms_min": 19500,
     "kernels_per_sec_max": null
   }
 }

--- a/tests/tt_metal/tt_metal/jit_build/compile_stress_blackhole_golden.json
+++ b/tests/tt_metal/tt_metal/jit_build/compile_stress_blackhole_golden.json
@@ -2,9 +2,9 @@
   "arch": "blackhole",
   "num_kernels": 300,
   "tolerance_pct": 15.0,
-  "comment": "Local JIT-build throughput golden for the (Runtime) Performance Tests pipeline (SKU bh_p150_perf). GATED on compile_ms_min: armed to the worst min observed across two CI runs in the current regime (18378/19292 ms) with the 15% tolerance, so the job fails only if a run's min exceeds ~22.4s. (Re-armed down from 44800 after a BH-specific ~2.4x compile speedup landed.) kernels_per_sec_max stays null (time gate is sufficient; throughput is its inverse). See README_compile_stress_ci.md.",
+  "comment": "Local JIT-build throughput golden for the (Runtime) Performance Tests pipeline (SKU bh_p150_perf). GATED on compile_ms_min: BH compile is bimodal - ~18-20s with a warm host ccache vs ~43-45s on a cold cache (the honest cold-compile cost). Armed to the worst cold min observed (44730 ms) + 15% tolerance so the job fails only above ~51.5s and never false-fails on either regime. A tighter gate needs the bimodality removed (force cold ccache) as a follow-up. kernels_per_sec_max stays null (time gate is sufficient). See README_compile_stress_ci.md.",
   "metrics": {
-    "compile_ms_min": 19500,
+    "compile_ms_min": 44800,
     "kernels_per_sec_max": null
   }
 }

--- a/tests/tt_metal/tt_metal/jit_build/compile_stress_blackhole_golden.json
+++ b/tests/tt_metal/tt_metal/jit_build/compile_stress_blackhole_golden.json
@@ -1,0 +1,10 @@
+{
+  "arch": "blackhole",
+  "num_kernels": 300,
+  "tolerance_pct": 15.0,
+  "comment": "Local JIT-build throughput golden for the (Runtime) Performance Tests pipeline (SKU bh_p150_perf). RECORD MODE: metrics are null so the job prints but does not gate. Arm compile_ms_min from CI-run medians in a follow-up once numbers are stable. See README_compile_stress_ci.md.",
+  "metrics": {
+    "compile_ms_min": null,
+    "kernels_per_sec_max": null
+  }
+}

--- a/tests/tt_metal/tt_metal/jit_build/compile_stress_ci.py
+++ b/tests/tt_metal/tt_metal/jit_build/compile_stress_ci.py
@@ -27,6 +27,12 @@ The fastest repetition is then compared against a per-arch golden:
 Exit code is non-zero on a gated regression, a missing/failed repetition, or a
 malformed golden.
 
+Security note: the gtest binary, golden files, and all per-run scratch paths are
+hardcoded, script-relative constants or live under a process-created temp dir -
+never derived from command-line input - so no external value ever reaches the
+subprocess executable or a filesystem ``open()``. The only string argument,
+``--arch``, is validated against a safelist and merely selects among constants.
+
 Example (matches the runtime-perf pipeline invocation):
   ./tests/tt_metal/tt_metal/jit_build/compile_stress_ci.py \
       --arch "$ARCH_NAME" --num-kernels 1000 --repetitions 5
@@ -62,16 +68,20 @@ BASE_SEED = 0x5EED
 
 SCRIPT_DIR = Path(__file__).parent.resolve()
 
-DEFAULT_GOLDEN_BY_ARCH = {
+# Hardcoded, script-relative constants - never derived from command-line input -
+# so no external value reaches the subprocess executable or a file open().
+TEST_BINARY = Path("build/test/tt_metal/unit_tests_jit_build")
+GOLDEN_BY_ARCH = {
     "wormhole_b0": SCRIPT_DIR / "compile_stress_golden.json",
     "blackhole": SCRIPT_DIR / "compile_stress_blackhole_golden.json",
 }
 
-# Safelist of architectures this benchmark accepts. --arch flows into the child
-# env, so validate it against known values rather than passing it through raw.
-KNOWN_ARCHES = ("wormhole_b0", "blackhole", "quasar")
+# Safelist of architectures. --arch is the one remaining string arg; it only
+# selects among the constants above and flows into the child env, never into a
+# path open() or the command executable.
+KNOWN_ARCHES = tuple(GOLDEN_BY_ARCH)
 
-# gtest arguments are fixed literals; only the (validated) binary path is dynamic.
+# gtest arguments are fixed literals; the binary is the hardcoded constant above.
 GTEST_ARGS = (
     "--gtest_also_run_disabled_tests",
     "--gtest_filter=*TensixCompileStress*",
@@ -82,8 +92,8 @@ GTEST_ARGS = (
 def _safe_child(base: Path, *parts: str) -> Path:
     """Join ``parts`` onto ``base`` and confirm the result stays within ``base``.
 
-    Guards against path traversal: every file this script reads/writes lives under
-    the run's work dir, so a resolved child that escapes ``base`` is rejected.
+    Defense-in-depth: ``base`` is always a process-created temp dir and ``parts``
+    are literals/ints, but we still reject any resolved child that escapes it.
     """
     base = base.resolve()
     child = base.joinpath(*parts).resolve()
@@ -109,15 +119,9 @@ class RepResult:
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument(
-        "--test-binary",
-        type=Path,
-        default=Path("./build/test/tt_metal/unit_tests_jit_build"),
-        help="Path to the compiled unit_tests_jit_build gtest binary.",
-    )
-    p.add_argument(
         "--arch",
         default=os.environ.get("ARCH_NAME", "wormhole_b0"),
-        help="Mock architecture to compile for (default: $ARCH_NAME or wormhole_b0).",
+        help="Architecture to compile for; must be one of the safelist (default: $ARCH_NAME or wormhole_b0).",
     )
     p.add_argument(
         "--num-kernels",
@@ -131,47 +135,25 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=5,
         help="Number of cold-compile repetitions; the fastest one is gated.",
     )
-    p.add_argument(
-        "--golden",
-        type=Path,
-        default=None,
-        help="Golden JSON. Defaults to the per-arch golden next to this script.",
-    )
-    p.add_argument(
-        "--output-dir",
-        type=Path,
-        default=None,
-        help="Directory for per-rep result JSON, logs, and isolated caches (default: a temp dir).",
-    )
-    p.add_argument(
-        "--keep-output",
-        action="store_true",
-        help="Do not delete a temp --output-dir on exit (for debugging).",
-    )
     return p.parse_args(argv)
 
 
-def resolve_golden(args: argparse.Namespace) -> Path:
-    # Default goldens are a hardcoded safelist next to this script. An explicit
-    # --golden override is resolved and must be an existing regular file, so only
-    # a validated path is ever opened.
-    if args.golden is not None:
-        golden = args.golden.resolve()
-    else:
-        golden = DEFAULT_GOLDEN_BY_ARCH.get(args.arch)
-        if golden is None:
-            raise SystemExit(
-                f"No default golden for arch {args.arch!r}; pass --golden explicitly. "
-                f"Known arches: {sorted(DEFAULT_GOLDEN_BY_ARCH)}"
-            )
-        golden = golden.resolve()
-    if not golden.is_file():
-        raise SystemExit(f"[jit-build-perf] golden not found: {golden}")
-    return golden
+def resolve_golden(arch: str) -> Path:
+    # arch is safelist-validated in main(). Select the golden by matching it
+    # against the known keys and returning the *constant* dict value, so the path
+    # that gets opened is a literal - never a subscript of external input.
+    for known_arch, golden in GOLDEN_BY_ARCH.items():
+        if arch == known_arch:
+            golden = golden.resolve()
+            if not golden.is_file():
+                raise SystemExit(f"[jit-build-perf] golden not found: {golden}")
+            return golden
+    raise SystemExit(f"No golden for arch {arch!r}; known arches: {sorted(GOLDEN_BY_ARCH)}")
 
 
 def run_repetition(test_binary: Path, args: argparse.Namespace, work_dir: Path, rep: int) -> RepResult:
-    # All per-rep paths are confined to work_dir (rep index is an int, not input).
+    # work_dir is a process-created temp dir and every child path is built from
+    # literals + the int rep index, so nothing external reaches these opens.
     rep_dir = _safe_child(work_dir, f"rep_{rep:02d}")
     cache_dir = _safe_child(rep_dir, "cache")
     cache_dir.mkdir(parents=True, exist_ok=True)
@@ -198,9 +180,8 @@ def run_repetition(test_binary: Path, args: argparse.Namespace, work_dir: Path, 
         }
     )
 
-    # test_binary is pre-validated in main() (resolved absolute path to an existing
-    # regular file); the remaining argv entries are fixed literals and shell=False,
-    # so no untrusted string reaches a shell.
+    # The executable is the hardcoded TEST_BINARY constant and every other argv
+    # entry is a fixed literal (shell=False), so no external string is executed.
     cmd = [str(test_binary), *GTEST_ARGS]
     print(f"[jit-build-perf] rep {rep}: seed={seed} num_kernels={args.num_kernels} arch={args.arch}")
     with open(stdout_log, "w") as log:
@@ -249,8 +230,8 @@ def gate(reps: list[RepResult], golden_path: Path, args: argparse.Namespace) -> 
     print(f"kernels/sec (best):{kernels_per_sec_max:.1f}")
     print()
 
-    if not golden_path.exists():
-        raise SystemExit(f"[jit-build-perf] golden not found: {golden_path}")
+    # golden_path is the constant returned by resolve_golden() (already validated
+    # to exist), so this open() never touches external input.
     with open(golden_path) as f:
         golden = json.load(f)
 
@@ -304,27 +285,23 @@ def main(argv: list[str] | None = None) -> int:
     if args.num_kernels < 1:
         raise SystemExit("--num-kernels must be >= 1")
 
-    # Resolve and validate the executable up front so the only dynamic argv entry
-    # passed to subprocess is a known, existing regular file.
-    test_binary = args.test_binary.resolve()
+    # TEST_BINARY is a hardcoded constant; resolve it and confirm the build
+    # produced it before we try to execute anything.
+    test_binary = TEST_BINARY.resolve()
     if not test_binary.is_file():
-        raise SystemExit(f"--test-binary is not an existing file: {test_binary}")
+        raise SystemExit(f"gtest binary not found (build it first): {test_binary}")
 
-    golden_path = resolve_golden(args)
+    golden_path = resolve_golden(args.arch)
 
-    if args.output_dir is not None:
-        work_dir = args.output_dir.resolve()
-        work_dir.mkdir(parents=True, exist_ok=True)
-        cleanup = False
-    else:
-        work_dir = Path(tempfile.mkdtemp(prefix="jit_build_perf_")).resolve()
-        cleanup = not args.keep_output
+    # All scratch lives under a process-created temp dir (untainted) and is
+    # removed on exit; there is no user-controlled output location.
+    work_dir = Path(tempfile.mkdtemp(prefix="jit_build_perf_")).resolve()
 
     try:
         reps = [run_repetition(test_binary, args, work_dir, rep) for rep in range(args.repetitions)]
         return gate(reps, golden_path, args)
     finally:
-        if cleanup and work_dir.exists():
+        if work_dir.exists():
             shutil.rmtree(work_dir, ignore_errors=True)
 
 

--- a/tests/tt_metal/tt_metal/jit_build/compile_stress_ci.py
+++ b/tests/tt_metal/tt_metal/jit_build/compile_stress_ci.py
@@ -35,7 +35,7 @@ subprocess executable or a filesystem ``open()``. The only string argument,
 
 Example (matches the runtime-perf pipeline invocation):
   ./tests/tt_metal/tt_metal/jit_build/compile_stress_ci.py \
-      --arch "$ARCH_NAME" --num-kernels 1000 --repetitions 5
+      --arch "$ARCH_NAME" --num-kernels 300 --repetitions 3
 """
 
 from __future__ import annotations
@@ -67,10 +67,14 @@ SIM_FORCING_ENV_VARS = (
 BASE_SEED = 0x5EED
 
 SCRIPT_DIR = Path(__file__).parent.resolve()
+# tests/tt_metal/tt_metal/jit_build/ -> repo root is four levels up.
+REPO_ROOT = SCRIPT_DIR.parents[3]
 
 # Hardcoded, script-relative constants - never derived from command-line input -
-# so no external value reaches the subprocess executable or a file open().
-TEST_BINARY = Path("build/test/tt_metal/unit_tests_jit_build")
+# so no external value reaches the subprocess executable or a file open(). The
+# binary is anchored to REPO_ROOT (not the caller's CWD) and the gtest runs with
+# cwd=REPO_ROOT so its repo-relative kernel paths resolve regardless of caller.
+TEST_BINARY = REPO_ROOT / "build/test/tt_metal/unit_tests_jit_build"
 GOLDEN_BY_ARCH = {
     "wormhole_b0": SCRIPT_DIR / "compile_stress_golden.json",
     "blackhole": SCRIPT_DIR / "compile_stress_blackhole_golden.json",
@@ -126,8 +130,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p.add_argument(
         "--num-kernels",
         type=int,
-        default=1000,
-        help="Kernels compiled per repetition (TT_METAL_COMPILE_STRESS_NUM_KERNELS).",
+        default=300,
+        help="Kernels compiled per repetition (TT_METAL_COMPILE_STRESS_NUM_KERNELS). "
+        "Must match the golden's num_kernels (the shipped goldens use 300).",
     )
     p.add_argument(
         "--repetitions",
@@ -185,7 +190,9 @@ def run_repetition(test_binary: Path, args: argparse.Namespace, work_dir: Path, 
     cmd = [str(test_binary), *GTEST_ARGS]
     print(f"[jit-build-perf] rep {rep}: seed={seed} num_kernels={args.num_kernels} arch={args.arch}")
     with open(stdout_log, "w") as log:
-        rc = subprocess.run(cmd, env=env, stdout=log, stderr=subprocess.STDOUT, shell=False).returncode
+        rc = subprocess.run(
+            cmd, env=env, cwd=str(REPO_ROOT), stdout=log, stderr=subprocess.STDOUT, shell=False
+        ).returncode
     if rc != 0:
         raise SystemExit(f"[jit-build-perf] rep {rep} failed (exit {rc}). See {stdout_log}.")
     if not result_file.exists():
@@ -235,6 +242,17 @@ def gate(reps: list[RepResult], golden_path: Path, args: argparse.Namespace) -> 
     with open(golden_path) as f:
         golden = json.load(f)
 
+    # The golden encodes the benchmark identity it was calibrated for. Refuse to
+    # gate a run whose arch/workload differs, else we'd compare non-equivalent
+    # configurations (e.g. a 1000-kernel run against the 300-kernel baseline).
+    if golden.get("arch") != args.arch:
+        raise SystemExit(f"[jit-build-perf] golden arch {golden.get('arch')!r} does not match --arch {args.arch!r}")
+    if golden.get("num_kernels") != args.num_kernels:
+        raise SystemExit(
+            f"[jit-build-perf] golden num_kernels {golden.get('num_kernels')!r} "
+            f"does not match --num-kernels {args.num_kernels}"
+        )
+
     tolerance_pct = float(golden.get("tolerance_pct", 15.0))
     metrics = golden.get("metrics", {})
 
@@ -248,11 +266,18 @@ def gate(reps: list[RepResult], golden_path: Path, args: argparse.Namespace) -> 
 
     exit_code = 0
     for name, meas in measured.items():
-        golden_val = metrics.get(name, None)
+        # Every measured metric must be represented in the golden. A missing key
+        # is a malformed golden (not the same as an explicit record-mode null),
+        # and only a finite positive number is a valid armed baseline.
+        if name not in metrics:
+            raise SystemExit(f"[jit-build-perf] golden is missing metric {name!r}")
+        golden_val = metrics[name]
         if golden_val is None:
             print(f"[record] {name}: measured {meas:.3f} (golden null -> not gated)")
             continue
         golden_val = float(golden_val)
+        if not 0.0 < golden_val < float("inf"):
+            raise SystemExit(f"[jit-build-perf] invalid golden value for {name!r}: {golden_val!r}")
         if lower_is_better[name]:
             diff_pct = (meas / golden_val - 1.0) * 100.0 if golden_val > 0 else 0.0
             regressed = diff_pct > tolerance_pct
@@ -293,16 +318,22 @@ def main(argv: list[str] | None = None) -> int:
 
     golden_path = resolve_golden(args.arch)
 
-    # All scratch lives under a process-created temp dir (untainted) and is
-    # removed on exit; there is no user-controlled output location.
+    # All scratch lives under a process-created temp dir (untainted) and there is
+    # no user-controlled output location. We only delete it on a clean run; on any
+    # failure the per-rep stdout.log / result.json are retained for debugging.
     work_dir = Path(tempfile.mkdtemp(prefix="jit_build_perf_")).resolve()
 
+    completed = False
     try:
         reps = [run_repetition(test_binary, args, work_dir, rep) for rep in range(args.repetitions)]
-        return gate(reps, golden_path, args)
+        result = gate(reps, golden_path, args)
+        completed = True
+        return result
     finally:
-        if work_dir.exists():
+        if completed:
             shutil.rmtree(work_dir, ignore_errors=True)
+        else:
+            print(f"[jit-build-perf] retained failure diagnostics at {work_dir}")
 
 
 if __name__ == "__main__":

--- a/tests/tt_metal/tt_metal/jit_build/compile_stress_ci.py
+++ b/tests/tt_metal/tt_metal/jit_build/compile_stress_ci.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""CI driver + regression gate for the local JIT-build throughput microbenchmark.
+
+Drives DISABLED_TensixCompileStress (tests/tt_metal/tt_metal/jit_build/
+test_compile_stress.cpp) as a *local* host-compile benchmark against the real
+attached device (TT_METAL_COMPILE_STRESS_MOCK=0), with no remote JIT compile
+server, a fixed kernel count, and per-repetition unique {id, seed} tuples + an
+isolated JIT cache so every repetition is a genuine cold compile of N kernels.
+The device is only used for build config (arch/grid); kernels are compiled, not
+dispatched, so device open/close stays outside the timed compile section.
+
+Each repetition runs the gtest in its own process (fresh in-memory JitBuildCache)
+and emits a result JSON via TT_METAL_COMPILE_STRESS_OUTPUT. We take the *fastest*
+repetition (min wall-clock -> max throughput); a flake almost never makes the
+compiler faster, so the min rejects upward CPU-contention noise on shared runners.
+
+The fastest repetition is then compared against a per-arch golden:
+  * A ``null`` golden metric stays in RECORD MODE - the measured value is printed
+    but the job is not gated on it (lets this land before CI-SKU numbers exist).
+  * A non-null golden metric is GATED: the job fails if the measured compile time
+    regresses beyond ``tolerance_pct`` (i.e. gets slower).
+
+Exit code is non-zero on a gated regression, a missing/failed repetition, or a
+malformed golden.
+
+Example (matches the runtime-perf pipeline invocation):
+  ./tests/tt_metal/tt_metal/jit_build/compile_stress_ci.py \
+      --arch "$ARCH_NAME" --num-kernels 1000 --repetitions 5
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+# We benchmark the real attached device (TT_METAL_COMPILE_STRESS_MOCK=0): the
+# runtime-perf SKUs have hardware, and the test's mock real->mock transition
+# throws once MeshDispatchFixture::SetUpTestSuite has opened the device. Strip
+# simulator/emulator overrides so we measure the plain local-compile path.
+SIM_FORCING_ENV_VARS = (
+    "TT_METAL_SIMULATOR",
+    "TT_METAL_EMULE_MODE",
+    "TT_METAL_MOCK_CLUSTER_DESC_PATH",
+)
+
+# Fixed base seed so the compiled kernel set is reproducible across runs. Each
+# repetition uses BASE_SEED + rep so its {id, seed} tuples are unique (cache
+# miss) yet deterministic for a given repetition index.
+BASE_SEED = 0x5EED
+
+SCRIPT_DIR = Path(__file__).parent.resolve()
+
+DEFAULT_GOLDEN_BY_ARCH = {
+    "wormhole_b0": SCRIPT_DIR / "compile_stress_golden.json",
+    "blackhole": SCRIPT_DIR / "compile_stress_blackhole_golden.json",
+}
+
+
+@dataclass
+class RepResult:
+    rep: int
+    seed: int
+    num_kernels: int
+    num_programs: int
+    total_elapsed_ms: float
+    target_device_type: str
+
+    @property
+    def kernels_per_sec(self) -> float:
+        return (self.num_kernels * 1000.0) / self.total_elapsed_ms if self.total_elapsed_ms > 0 else 0.0
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument(
+        "--test-binary",
+        type=Path,
+        default=Path("./build/test/tt_metal/unit_tests_jit_build"),
+        help="Path to the compiled unit_tests_jit_build gtest binary.",
+    )
+    p.add_argument(
+        "--arch",
+        default=os.environ.get("ARCH_NAME", "wormhole_b0"),
+        help="Mock architecture to compile for (default: $ARCH_NAME or wormhole_b0).",
+    )
+    p.add_argument(
+        "--num-kernels",
+        type=int,
+        default=1000,
+        help="Kernels compiled per repetition (TT_METAL_COMPILE_STRESS_NUM_KERNELS).",
+    )
+    p.add_argument(
+        "--repetitions",
+        type=int,
+        default=5,
+        help="Number of cold-compile repetitions; the fastest one is gated.",
+    )
+    p.add_argument(
+        "--golden",
+        type=Path,
+        default=None,
+        help="Golden JSON. Defaults to the per-arch golden next to this script.",
+    )
+    p.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Directory for per-rep result JSON, logs, and isolated caches (default: a temp dir).",
+    )
+    p.add_argument(
+        "--keep-output",
+        action="store_true",
+        help="Do not delete a temp --output-dir on exit (for debugging).",
+    )
+    return p.parse_args(argv)
+
+
+def resolve_golden(args: argparse.Namespace) -> Path:
+    if args.golden is not None:
+        return args.golden
+    golden = DEFAULT_GOLDEN_BY_ARCH.get(args.arch)
+    if golden is None:
+        raise SystemExit(
+            f"No default golden for arch {args.arch!r}; pass --golden explicitly. "
+            f"Known arches: {sorted(DEFAULT_GOLDEN_BY_ARCH)}"
+        )
+    return golden
+
+
+def run_repetition(args: argparse.Namespace, work_dir: Path, rep: int) -> RepResult:
+    rep_dir = work_dir / f"rep_{rep:02d}"
+    cache_dir = rep_dir / "cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    result_file = rep_dir / "result.json"
+    stdout_log = rep_dir / "stdout.log"
+    seed = BASE_SEED + rep
+
+    env = dict(os.environ)
+    for var in SIM_FORCING_ENV_VARS:
+        env.pop(var, None)
+    # Force the local compile path: never route to a remote JIT compile server.
+    env.pop("TT_METAL_JIT_SERVER_ENDPOINTS", None)
+    env["TT_METAL_JIT_SERVER_ENABLE"] = "0"
+    env.update(
+        {
+            "TT_METAL_COMPILE_STRESS_MOCK": "0",
+            "TT_METAL_CACHE": str(cache_dir),
+            "TT_METAL_COMPILE_STRESS_NUM_KERNELS": str(args.num_kernels),
+            "TT_METAL_COMPILE_STRESS_ARCH": args.arch,
+            "TT_METAL_COMPILE_STRESS_CLIENT_ID": str(rep),
+            "TT_METAL_COMPILE_STRESS_SEED": str(seed),
+            "TT_METAL_COMPILE_STRESS_SHARED_FRACTION": "0.000000",
+            "TT_METAL_COMPILE_STRESS_OUTPUT": str(result_file),
+        }
+    )
+
+    cmd = [
+        str(args.test_binary),
+        "--gtest_also_run_disabled_tests",
+        "--gtest_filter=*TensixCompileStress*",
+        "--gtest_color=no",
+    ]
+    print(f"[jit-build-perf] rep {rep}: seed={seed} num_kernels={args.num_kernels} arch={args.arch}")
+    with open(stdout_log, "w") as log:
+        rc = subprocess.run(cmd, env=env, stdout=log, stderr=subprocess.STDOUT).returncode
+    if rc != 0:
+        raise SystemExit(f"[jit-build-perf] rep {rep} failed (exit {rc}). See {stdout_log}.")
+    if not result_file.exists():
+        raise SystemExit(f"[jit-build-perf] rep {rep} produced no JSON at {result_file}. See {stdout_log}.")
+
+    with open(result_file) as f:
+        data = json.load(f)
+    result = RepResult(
+        rep=rep,
+        seed=seed,
+        num_kernels=int(data["num_kernels"]),
+        num_programs=int(data["num_programs"]),
+        total_elapsed_ms=float(data["total_elapsed_ms"]),
+        target_device_type=str(data["target_device_type"]),
+    )
+    print(
+        f"[jit-build-perf] rep {rep}: {result.total_elapsed_ms:.1f} ms "
+        f"({result.kernels_per_sec:.1f} kernels/sec, {result.num_programs} programs, "
+        f"target={result.target_device_type})"
+    )
+    return result
+
+
+def gate(reps: list[RepResult], golden_path: Path, args: argparse.Namespace) -> int:
+    best = min(reps, key=lambda r: r.total_elapsed_ms)
+    elapsed = [r.total_elapsed_ms for r in reps]
+    compile_ms_min = best.total_elapsed_ms
+    kernels_per_sec_max = best.kernels_per_sec
+
+    print()
+    print("=" * 72)
+    print("JIT-build local compile throughput")
+    print("=" * 72)
+    print(f"arch:              {args.arch}")
+    print(f"target device:     {best.target_device_type}")
+    print(f"num_kernels:       {best.num_kernels}")
+    print(f"num_programs:      {best.num_programs}")
+    print(f"repetitions:       {len(reps)}")
+    print(
+        f"compile_ms  min:   {compile_ms_min:.1f}   median: {statistics.median(elapsed):.1f}   max: {max(elapsed):.1f}"
+    )
+    print(f"kernels/sec (best):{kernels_per_sec_max:.1f}")
+    print()
+
+    if not golden_path.exists():
+        raise SystemExit(f"[jit-build-perf] golden not found: {golden_path}")
+    with open(golden_path) as f:
+        golden = json.load(f)
+
+    tolerance_pct = float(golden.get("tolerance_pct", 15.0))
+    metrics = golden.get("metrics", {})
+
+    measured = {
+        "compile_ms_min": compile_ms_min,
+        "kernels_per_sec_max": kernels_per_sec_max,
+    }
+    # For each metric, "worse" is defined by direction: lower-is-better for a
+    # time, higher-is-better for a throughput.
+    lower_is_better = {"compile_ms_min": True, "kernels_per_sec_max": False}
+
+    exit_code = 0
+    for name, meas in measured.items():
+        golden_val = metrics.get(name, None)
+        if golden_val is None:
+            print(f"[record] {name}: measured {meas:.3f} (golden null -> not gated)")
+            continue
+        golden_val = float(golden_val)
+        if lower_is_better[name]:
+            diff_pct = (meas / golden_val - 1.0) * 100.0 if golden_val > 0 else 0.0
+            regressed = diff_pct > tolerance_pct
+        else:
+            diff_pct = (1.0 - meas / golden_val) * 100.0 if golden_val > 0 else 0.0
+            regressed = diff_pct > tolerance_pct
+        verdict = "FAIL" if regressed else "ok"
+        print(
+            f"[gated]  {name}: measured {meas:.3f} vs golden {golden_val:.3f} "
+            f"({diff_pct:+.2f}% worse, tol {tolerance_pct:.1f}%) -> {verdict}"
+        )
+        if regressed:
+            exit_code = 1
+
+    print()
+    if exit_code == 0:
+        print("[jit-build-perf] PASS")
+    else:
+        print("[jit-build-perf] FAIL: compile throughput regressed beyond tolerance")
+    return exit_code
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if not args.test_binary.exists():
+        raise SystemExit(f"--test-binary not found: {args.test_binary}")
+    if args.repetitions < 1:
+        raise SystemExit("--repetitions must be >= 1")
+    if args.num_kernels < 1:
+        raise SystemExit("--num-kernels must be >= 1")
+
+    golden_path = resolve_golden(args)
+
+    if args.output_dir is not None:
+        work_dir = args.output_dir
+        work_dir.mkdir(parents=True, exist_ok=True)
+        cleanup = False
+    else:
+        work_dir = Path(tempfile.mkdtemp(prefix="jit_build_perf_"))
+        cleanup = not args.keep_output
+
+    try:
+        reps = [run_repetition(args, work_dir, rep) for rep in range(args.repetitions)]
+        return gate(reps, golden_path, args)
+    finally:
+        if cleanup and work_dir.exists():
+            shutil.rmtree(work_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tt_metal/tt_metal/jit_build/compile_stress_ci.py
+++ b/tests/tt_metal/tt_metal/jit_build/compile_stress_ci.py
@@ -67,6 +67,30 @@ DEFAULT_GOLDEN_BY_ARCH = {
     "blackhole": SCRIPT_DIR / "compile_stress_blackhole_golden.json",
 }
 
+# Safelist of architectures this benchmark accepts. --arch flows into the child
+# env, so validate it against known values rather than passing it through raw.
+KNOWN_ARCHES = ("wormhole_b0", "blackhole", "quasar")
+
+# gtest arguments are fixed literals; only the (validated) binary path is dynamic.
+GTEST_ARGS = (
+    "--gtest_also_run_disabled_tests",
+    "--gtest_filter=*TensixCompileStress*",
+    "--gtest_color=no",
+)
+
+
+def _safe_child(base: Path, *parts: str) -> Path:
+    """Join ``parts`` onto ``base`` and confirm the result stays within ``base``.
+
+    Guards against path traversal: every file this script reads/writes lives under
+    the run's work dir, so a resolved child that escapes ``base`` is rejected.
+    """
+    base = base.resolve()
+    child = base.joinpath(*parts).resolve()
+    if child != base and not child.is_relative_to(base):
+        raise SystemExit(f"[jit-build-perf] refusing to use path outside {base}: {child}")
+    return child
+
 
 @dataclass
 class RepResult:
@@ -128,23 +152,31 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def resolve_golden(args: argparse.Namespace) -> Path:
+    # Default goldens are a hardcoded safelist next to this script. An explicit
+    # --golden override is resolved and must be an existing regular file, so only
+    # a validated path is ever opened.
     if args.golden is not None:
-        return args.golden
-    golden = DEFAULT_GOLDEN_BY_ARCH.get(args.arch)
-    if golden is None:
-        raise SystemExit(
-            f"No default golden for arch {args.arch!r}; pass --golden explicitly. "
-            f"Known arches: {sorted(DEFAULT_GOLDEN_BY_ARCH)}"
-        )
+        golden = args.golden.resolve()
+    else:
+        golden = DEFAULT_GOLDEN_BY_ARCH.get(args.arch)
+        if golden is None:
+            raise SystemExit(
+                f"No default golden for arch {args.arch!r}; pass --golden explicitly. "
+                f"Known arches: {sorted(DEFAULT_GOLDEN_BY_ARCH)}"
+            )
+        golden = golden.resolve()
+    if not golden.is_file():
+        raise SystemExit(f"[jit-build-perf] golden not found: {golden}")
     return golden
 
 
-def run_repetition(args: argparse.Namespace, work_dir: Path, rep: int) -> RepResult:
-    rep_dir = work_dir / f"rep_{rep:02d}"
-    cache_dir = rep_dir / "cache"
+def run_repetition(test_binary: Path, args: argparse.Namespace, work_dir: Path, rep: int) -> RepResult:
+    # All per-rep paths are confined to work_dir (rep index is an int, not input).
+    rep_dir = _safe_child(work_dir, f"rep_{rep:02d}")
+    cache_dir = _safe_child(rep_dir, "cache")
     cache_dir.mkdir(parents=True, exist_ok=True)
-    result_file = rep_dir / "result.json"
-    stdout_log = rep_dir / "stdout.log"
+    result_file = _safe_child(rep_dir, "result.json")
+    stdout_log = _safe_child(rep_dir, "stdout.log")
     seed = BASE_SEED + rep
 
     env = dict(os.environ)
@@ -166,15 +198,13 @@ def run_repetition(args: argparse.Namespace, work_dir: Path, rep: int) -> RepRes
         }
     )
 
-    cmd = [
-        str(args.test_binary),
-        "--gtest_also_run_disabled_tests",
-        "--gtest_filter=*TensixCompileStress*",
-        "--gtest_color=no",
-    ]
+    # test_binary is pre-validated in main() (resolved absolute path to an existing
+    # regular file); the remaining argv entries are fixed literals and shell=False,
+    # so no untrusted string reaches a shell.
+    cmd = [str(test_binary), *GTEST_ARGS]
     print(f"[jit-build-perf] rep {rep}: seed={seed} num_kernels={args.num_kernels} arch={args.arch}")
     with open(stdout_log, "w") as log:
-        rc = subprocess.run(cmd, env=env, stdout=log, stderr=subprocess.STDOUT).returncode
+        rc = subprocess.run(cmd, env=env, stdout=log, stderr=subprocess.STDOUT, shell=False).returncode
     if rc != 0:
         raise SystemExit(f"[jit-build-perf] rep {rep} failed (exit {rc}). See {stdout_log}.")
     if not result_file.exists():
@@ -267,25 +297,31 @@ def gate(reps: list[RepResult], golden_path: Path, args: argparse.Namespace) -> 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
 
-    if not args.test_binary.exists():
-        raise SystemExit(f"--test-binary not found: {args.test_binary}")
+    if args.arch not in KNOWN_ARCHES:
+        raise SystemExit(f"--arch {args.arch!r} not in safelist {KNOWN_ARCHES}")
     if args.repetitions < 1:
         raise SystemExit("--repetitions must be >= 1")
     if args.num_kernels < 1:
         raise SystemExit("--num-kernels must be >= 1")
 
+    # Resolve and validate the executable up front so the only dynamic argv entry
+    # passed to subprocess is a known, existing regular file.
+    test_binary = args.test_binary.resolve()
+    if not test_binary.is_file():
+        raise SystemExit(f"--test-binary is not an existing file: {test_binary}")
+
     golden_path = resolve_golden(args)
 
     if args.output_dir is not None:
-        work_dir = args.output_dir
+        work_dir = args.output_dir.resolve()
         work_dir.mkdir(parents=True, exist_ok=True)
         cleanup = False
     else:
-        work_dir = Path(tempfile.mkdtemp(prefix="jit_build_perf_"))
+        work_dir = Path(tempfile.mkdtemp(prefix="jit_build_perf_")).resolve()
         cleanup = not args.keep_output
 
     try:
-        reps = [run_repetition(args, work_dir, rep) for rep in range(args.repetitions)]
+        reps = [run_repetition(test_binary, args, work_dir, rep) for rep in range(args.repetitions)]
         return gate(reps, golden_path, args)
     finally:
         if cleanup and work_dir.exists():

--- a/tests/tt_metal/tt_metal/jit_build/compile_stress_ci.py
+++ b/tests/tt_metal/tt_metal/jit_build/compile_stress_ci.py
@@ -172,6 +172,12 @@ def run_repetition(test_binary: Path, args: argparse.Namespace, work_dir: Path, 
     # Force the local compile path: never route to a remote JIT compile server.
     env.pop("TT_METAL_JIT_SERVER_ENDPOINTS", None)
     env["TT_METAL_JIT_SERVER_ENABLE"] = "0"
+    # Force a true cold host compile: disable the opt-in kernel ccache so a warm
+    # ccache (esp. the shared Redis backend some CI jobs enable) can't turn the
+    # identical, deterministic kernel set into a ~2.4x-faster cache-hit run. This
+    # removes the warm/cold bimodality so the measurement is reproducible.
+    env.pop("TT_METAL_CCACHE_KERNEL_SUPPORT", None)
+    env["CCACHE_DISABLE"] = "1"
     env.update(
         {
             "TT_METAL_COMPILE_STRESS_MOCK": "0",

--- a/tests/tt_metal/tt_metal/jit_build/compile_stress_golden.json
+++ b/tests/tt_metal/tt_metal/jit_build/compile_stress_golden.json
@@ -1,0 +1,10 @@
+{
+  "arch": "wormhole_b0",
+  "num_kernels": 300,
+  "tolerance_pct": 15.0,
+  "comment": "Local JIT-build throughput golden for the (Runtime) Performance Tests pipeline (SKU wh_n300_civ2). RECORD MODE: metrics are null so the job prints but does not gate. Arm compile_ms_min from CI-run medians in a follow-up once numbers are stable. See README_compile_stress_ci.md.",
+  "metrics": {
+    "compile_ms_min": null,
+    "kernels_per_sec_max": null
+  }
+}

--- a/tests/tt_metal/tt_metal/jit_build/compile_stress_golden.json
+++ b/tests/tt_metal/tt_metal/jit_build/compile_stress_golden.json
@@ -2,9 +2,9 @@
   "arch": "wormhole_b0",
   "num_kernels": 300,
   "tolerance_pct": 15.0,
-  "comment": "Local JIT-build throughput golden for the (Runtime) Performance Tests pipeline (SKU wh_n300_civ2). RECORD MODE: metrics are null so the job prints but does not gate. Arm compile_ms_min from CI-run medians in a follow-up once numbers are stable. See README_compile_stress_ci.md.",
+  "comment": "Local JIT-build throughput golden for the (Runtime) Performance Tests pipeline (SKU wh_n300_civ2). GATED on compile_ms_min: armed to the worst min observed across two CI runs (48809/50677 ms) with the 15% tolerance, so the job fails only if a run's min exceeds ~58.3s. kernels_per_sec_max stays null (time gate is sufficient; throughput is its inverse). See README_compile_stress_ci.md.",
   "metrics": {
-    "compile_ms_min": null,
+    "compile_ms_min": 50700,
     "kernels_per_sec_max": null
   }
 }

--- a/tests/tt_metal/tt_metal/jit_build/test_compile_stress.cpp
+++ b/tests/tt_metal/tt_metal/jit_build/test_compile_stress.cpp
@@ -93,7 +93,12 @@ tt::ARCH get_mock_arch_from_env() {
 // remote-server harness. Set to 0 to compile against the real attached device
 // (CI runtime-perf runs on device SKUs, where mock's real->mock transition would
 // throw because MeshDispatchFixture::SetUpTestSuite already opened the device).
-bool use_mock_mode() { return tt::parse_env<std::uint32_t>("TT_METAL_COMPILE_STRESS_MOCK", 1) != 0; }
+bool use_mock_mode() {
+    // Parse the env var once; the value is fixed for the process lifetime and is
+    // queried from SetUp/TearDown/the test body.
+    static const bool mock = tt::parse_env<std::uint32_t>("TT_METAL_COMPILE_STRESS_MOCK", 1) != 0;
+    return mock;
+}
 
 constexpr std::string_view target_device_type_to_string(tt::TargetDevice t) noexcept {
     const std::string_view name = enchantum::to_string(t);

--- a/tests/tt_metal/tt_metal/jit_build/test_compile_stress.cpp
+++ b/tests/tt_metal/tt_metal/jit_build/test_compile_stress.cpp
@@ -213,14 +213,26 @@ protected:
 
 TEST_F(CompileStressFixture, DISABLED_TensixCompileStress) {
     const auto target = MetalContext::instance().get_cluster().get_target_device_type();
+
+    IDevice* dev = devices_[0]->get_devices()[0];
+
     if (use_mock_mode()) {
         TT_FATAL(
             target == tt::TargetDevice::Mock,
             "CompileStressFixture expects mock device; got target_type={}.",
             target_device_type_to_string(target));
+    } else {
+        // Real mode compiles for the attached device (TT_METAL_COMPILE_STRESS_ARCH
+        // does not steer CompileProgram), so a runner/arch mismatch would gate
+        // e.g. Wormhole kernels against the Blackhole golden. Fail fast instead.
+        const tt::ARCH expected_arch = get_mock_arch_from_env();
+        const tt::ARCH actual_arch = dev->arch();
+        TT_FATAL(
+            actual_arch == expected_arch,
+            "CompileStressFixture requested arch '{}' but the attached device is '{}'.",
+            tt::get_string_lowercase(expected_arch),
+            tt::get_string_lowercase(actual_arch));
     }
-
-    IDevice* dev = devices_[0]->get_devices()[0];
 
     const uint32_t target_num_kernels = tt::parse_env<std::uint32_t>("TT_METAL_COMPILE_STRESS_NUM_KERNELS", 1000);
     const uint32_t client_id = tt::parse_env<std::uint32_t>("TT_METAL_COMPILE_STRESS_CLIENT_ID", 0);

--- a/tests/tt_metal/tt_metal/jit_build/test_compile_stress.cpp
+++ b/tests/tt_metal/tt_metal/jit_build/test_compile_stress.cpp
@@ -89,6 +89,12 @@ tt::ARCH get_mock_arch_from_env() {
     return arch;
 }
 
+// Default (1): mock device, for device-less compile hosts / the multi-client
+// remote-server harness. Set to 0 to compile against the real attached device
+// (CI runtime-perf runs on device SKUs, where mock's real->mock transition would
+// throw because MeshDispatchFixture::SetUpTestSuite already opened the device).
+bool use_mock_mode() { return tt::parse_env<std::uint32_t>("TT_METAL_COMPILE_STRESS_MOCK", 1) != 0; }
+
 constexpr std::string_view target_device_type_to_string(tt::TargetDevice t) noexcept {
     const std::string_view name = enchantum::to_string(t);
     return name.empty() ? std::string_view{"Unknown"} : name;
@@ -191,22 +197,28 @@ void write_result_json(const std::string& path, const StressResult& r) {
 class CompileStressFixture : public MeshDispatchFixture {
 protected:
     void SetUp() override {
-        experimental::configure_mock_mode(
-            get_mock_arch_from_env(), tt::parse_env<std::uint32_t>("TT_METAL_COMPILE_STRESS_NUM_CHIPS", 1));
+        if (use_mock_mode()) {
+            experimental::configure_mock_mode(
+                get_mock_arch_from_env(), tt::parse_env<std::uint32_t>("TT_METAL_COMPILE_STRESS_NUM_CHIPS", 1));
+        }
         MeshDispatchFixture::SetUp();
     }
     void TearDown() override {
         MeshDispatchFixture::TearDown();
-        experimental::disable_mock_mode();
+        if (use_mock_mode()) {
+            experimental::disable_mock_mode();
+        }
     }
 };
 
 TEST_F(CompileStressFixture, DISABLED_TensixCompileStress) {
     const auto target = MetalContext::instance().get_cluster().get_target_device_type();
-    TT_FATAL(
-        target == tt::TargetDevice::Mock,
-        "CompileStressFixture expects mock device; got target_type={}.",
-        target_device_type_to_string(target));
+    if (use_mock_mode()) {
+        TT_FATAL(
+            target == tt::TargetDevice::Mock,
+            "CompileStressFixture expects mock device; got target_type={}.",
+            target_device_type_to_string(target));
+    }
 
     IDevice* dev = devices_[0]->get_devices()[0];
 


### PR DESCRIPTION
Part of #46305 (extend runtime performance test CI coverage) - adds the "jit build" microbenchmark alongside op-to-op latency (#49771).

Adapts DISABLED_TensixCompileStress into a runtime perf gate that measures local host JIT compile throughput: N cache-bypassing kernels compiled (not dispatched) against the real attached device, with no remote compile server.

- compile_stress_ci.py: driver + regression gate. Runs K reps, each a fresh process with a unique seed + isolated TT_METAL_CACHE so every rep is a genuine cold compile; gates the fastest rep (min rejects upward host-CPU noise) against a per-arch golden. Record mode (null golden) prints but does not gate, so this lands before CI-SKU numbers exist.
- test_compile_stress.cpp: add TT_METAL_COMPILE_STRESS_MOCK env (default 1, unchanged for the device-less harness); =0 compiles against the real device. Needed because on device SKUs MeshDispatchFixture::SetUpTestSuite opens the device before the fixture's mock transition, which then throws.
- Wire runtime_perf_jit_build (N=300, 3 reps) into runtime_perf_tests.yaml on wh_n300_civ2 + bh_p150_perf; bump runtime/perf time_budget accordingly.
- Add per-arch record-mode goldens and README (metric + arming procedure).

Verified end-to-end on Blackhole locally (N=300, 3 reps): 37.50/37.76/37.78s (<1% spread); job wall ~2.2 min, well under the 10-min budget.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=msudumbrekar/jit-build-perf-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:msudumbrekar/jit-build-perf-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=msudumbrekar/jit-build-perf-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:msudumbrekar/jit-build-perf-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=msudumbrekar/jit-build-perf-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:msudumbrekar/jit-build-perf-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=msudumbrekar/jit-build-perf-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:msudumbrekar/jit-build-perf-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=msudumbrekar/jit-build-perf-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:msudumbrekar/jit-build-perf-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=msudumbrekar/jit-build-perf-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:msudumbrekar/jit-build-perf-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=msudumbrekar/jit-build-perf-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:msudumbrekar/jit-build-perf-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=msudumbrekar/jit-build-perf-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:msudumbrekar/jit-build-perf-ci)