### PR TITLE
[Bug Fix] Fix iDMA tests hang

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/kernels/idma_1d_strided_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/kernels/idma_1d_strided_example.cpp
@@ -18,7 +18,7 @@
 //   4. Wait for IDMA ack
 
 #include "api/dataflow/dataflow_api.h"
-#include "api/debug/dprint.h"
+#include "api/debug/device_print.h"
 #include "experimental/kernel_args.h"
 #include "internal/tt-2xx/quasar/overlay/addrgen_api.hpp"
 #include "internal/tt-2xx/quasar/overlay/cmdbuff_api.hpp"
@@ -61,7 +61,9 @@ void kernel_main() {
     }
 
     /* wait on IDMA to finish */
-    while (!idma_acked_cmdbuf_0());
+    while (!idma_acked_cmdbuf_0()) {
+    }
 
-    DPRINT << "IDMA 1D strided done: " << DEC() << num_elements << " elements, src_stride=" << src_stride << ENDL();
+    // DPRINT << "IDMA 1D strided done: " << DEC() << num_elements << " elements, src_stride=" << src_stride << ENDL();
+    DEVICE_PRINT("IDMA 1D strided done: {} elements, src_stride = {}", num_elements, src_stride);
 }

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/kernels/idma_1d_strided_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/kernels/idma_1d_strided_example.cpp
@@ -64,6 +64,5 @@ void kernel_main() {
     while (!idma_acked_cmdbuf_0()) {
     }
 
-    // DPRINT << "IDMA 1D strided done: " << DEC() << num_elements << " elements, src_stride=" << src_stride << ENDL();
-    DEVICE_PRINT("IDMA 1D strided done: {} elements, src_stride = {}", num_elements, src_stride);
+    DEVICE_PRINT("IDMA 1D strided done: {} elements, src_stride: {} \n", num_elements, src_stride);
 }

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/kernels/idma_basic_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/kernels/idma_basic_example.cpp
@@ -44,5 +44,5 @@ void kernel_main() {
     while (!idma_acked_cmdbuf_0()) {
     }
 
-    DEVICE_PRINT("IDMA 1D strided done: {} elements, total_bytes: {} \n", num_elements, total_bytes);
+    DEVICE_PRINT("IDMA basic done: {} elements, total_bytes: {}\n", num_elements, total_bytes);
 }

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/kernels/idma_basic_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/kernels/idma_basic_example.cpp
@@ -28,28 +28,21 @@ void kernel_main() {
     constexpr uint32_t dst_addr = get_arg(args::dst_addr);
 
     reset_cmdbuf_0();
-    DEVICE_PRINT("HERE \n");
 
     /* CMD Misc register, only difference to NOC*/
     idma_setup_as_copy_cmdbuf_0(false);
-    DEVICE_PRINT("HERE 2\n");
     /* Vcs = IDMA channel*/
     setup_vcs_cmdbuf_0(false);
-    DEVICE_PRINT("HERE 3\n");
 
     set_src_cmdbuf_0(src_addr);
-    DEVICE_PRINT("HERE 4\n");
     set_dest_cmdbuf_0(dst_addr);
-    DEVICE_PRINT("HERE 5\n");
     set_len_cmdbuf_0(total_bytes);
-    DEVICE_PRINT("HERE 6\n");
 
     issue_cmdbuf_0();
-    DEVICE_PRINT("HERE 7\n");
 
     /* wait on IDMA to finish */
     while (!idma_acked_cmdbuf_0()) {
     }
 
-    DEVICE_PRINT("IDMA 1D strided done: {} elements", num_elements);
+    DEVICE_PRINT("IDMA 1D strided done: {} elements, total_bytes: {} \n", num_elements, total_bytes);
 }

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/kernels/idma_basic_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/kernels/idma_basic_example.cpp
@@ -12,7 +12,7 @@
 //   4. Wait for IDMA ack
 
 #include "api/dataflow/dataflow_api.h"
-#include "api/debug/dprint.h"
+#include "api/debug/device_print.h"
 #include "experimental/kernel_args.h"
 #include "internal/tt-2xx/quasar/overlay/cmdbuff_api.hpp"
 #include <cstdint>
@@ -28,20 +28,28 @@ void kernel_main() {
     constexpr uint32_t dst_addr = get_arg(args::dst_addr);
 
     reset_cmdbuf_0();
+    DEVICE_PRINT("HERE \n");
 
     /* CMD Misc register, only difference to NOC*/
     idma_setup_as_copy_cmdbuf_0(false);
+    DEVICE_PRINT("HERE 2\n");
     /* Vcs = IDMA channel*/
     setup_vcs_cmdbuf_0(false);
+    DEVICE_PRINT("HERE 3\n");
 
     set_src_cmdbuf_0(src_addr);
+    DEVICE_PRINT("HERE 4\n");
     set_dest_cmdbuf_0(dst_addr);
+    DEVICE_PRINT("HERE 5\n");
     set_len_cmdbuf_0(total_bytes);
+    DEVICE_PRINT("HERE 6\n");
 
     issue_cmdbuf_0();
+    DEVICE_PRINT("HERE 7\n");
 
     /* wait on IDMA to finish */
-    while (!idma_acked_cmdbuf_0());
+    while (!idma_acked_cmdbuf_0()) {
+    }
 
-    DPRINT << "IDMA basic done: " << DEC() << num_elements << " elements (" << total_bytes << " B)" << ENDL();
+    DEVICE_PRINT("IDMA 1D strided done: {} elements", num_elements);
 }

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/test_idma_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/test_idma_example.cpp
@@ -67,17 +67,37 @@ static void run_kernel(
     distributed::EnqueueMeshWorkload(cq, workload, true);
 }
 
+// Allocates a pair of same-sized replicated L1 buffers on the mesh for use as IDMA src/dst.
+// Buffers are returned (not just their addresses) so the caller keeps them alive for the
+// lifetime of the test; letting the MeshBuffers be destroyed would free the allocation.
+struct IdmaSrcDstBuffers {
+    std::shared_ptr<distributed::MeshBuffer> src;
+    std::shared_ptr<distributed::MeshBuffer> dst;
+};
+
+IdmaSrcDstBuffers make_idma_src_dst_buffers(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t total_bytes) {
+    distributed::DeviceLocalBufferConfig local_buffer_config = {
+        .page_size = total_bytes, .buffer_type = tt::tt_metal::BufferType::L1};
+    distributed::ReplicatedBufferConfig buffer_config = {.size = total_bytes};
+    return {
+        .src = distributed::MeshBuffer::create(buffer_config, local_buffer_config, mesh_device.get()),
+        .dst = distributed::MeshBuffer::create(buffer_config, local_buffer_config, mesh_device.get()),
+    };
+}
+
 // Basic: 16 elements * 8 B = 128 B linear copy from src to dst
 bool run_idma_basic_test(const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
     constexpr CoreCoord core = {0, 0};
-    constexpr uint32_t src_base = 0x10000;
-    constexpr uint32_t dst_base = 0x20000;
     constexpr uint32_t num_elements = 16;
     constexpr uint32_t elem_size = 8;
     constexpr uint32_t total_bytes = num_elements * elem_size;
     constexpr uint32_t num_words = total_bytes / sizeof(uint32_t);
 
     IDevice* device = mesh_device->get_devices()[0];
+    auto buffers = make_idma_src_dst_buffers(mesh_device, total_bytes);
+    const uint32_t src_base = buffers.src->address();
+    const uint32_t dst_base = buffers.dst->address();
 
     std::vector<uint32_t> src_data(num_words);
     for (uint32_t i = 0; i < num_words; i++) {
@@ -110,11 +130,13 @@ bool run_idma_basic_test(const std::shared_ptr<distributed::MeshDevice>& mesh_de
 // dst[i] = src[i * src_stride] (every other 8 B element from src)
 bool run_idma_1d_strided_test(const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
     constexpr CoreCoord core = {0, 0};
-    constexpr uint32_t src_base = 0x10000;
-    constexpr uint32_t dst_base = 0x20000;
     constexpr uint32_t num_elements = 10;
     constexpr uint32_t elem_size = 8;
     constexpr uint32_t src_stride = 2 * elem_size;  // 16 B
+    constexpr uint32_t total_bytes = num_elements * src_stride;
+    auto buffers = make_idma_src_dst_buffers(mesh_device, total_bytes);
+    const uint32_t src_base = buffers.src->address();
+    const uint32_t dst_base = buffers.dst->address();
 
     // src region covers num_elements * src_stride = 160 B = 40 words
     constexpr uint32_t src_num_words = (num_elements * src_stride) / sizeof(uint32_t);

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/test_idma_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/test_idma_example.cpp
@@ -165,7 +165,7 @@ bool run_idma_1d_strided_test(const std::shared_ptr<distributed::MeshDevice>& me
 // Test Suite: Quasar IDMA
 // =============================================================================
 
-class QuasarIdmaOps : public MeshDeviceSingleCardFixture {};
+class QuasarIdmaOps : public QuasarMeshDeviceSingleCardFixture {};
 
 TEST_F(QuasarIdmaOps, IDMA_Basic) {
     if (unit_tests::dm::quasar_idma::should_skip_test()) {

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord_2_0.cpp
@@ -77,13 +77,13 @@ void kernel_main() {
     // Dispatcher Kernel is able to finish.
     // Device::close() requires fast-dispatch kernels to finish.
     volatile tt_l1_ptr go_msg_t* go_message_in = GET_MAILBOX_ADDRESS_DEV(go_messages[0]);
-#if defined(COMPILE_FOR_DM)
+    // #if defined(COMPILE_FOR_DM)
     // SD signaling: Quasar DM requires RUN_MSG_DONE. TODO: remove once FD is enabled on Quasar.
     go_message_in->signal = RUN_MSG_DONE;
-#else
-    uint64_t dispatch_addr = calculate_dispatch_addr(go_message_in);
-    notify_dispatch_core_done(dispatch_addr, noc_index);
-#endif
+    // #else
+    //     uint64_t dispatch_addr = calculate_dispatch_addr(go_message_in);
+    //     notify_dispatch_core_done(dispatch_addr, noc_index);
+    // #endif
 
     if (l1_overflow_addr) {
         CoreLocalMem<std::uint32_t> l1_overflow_buffer(l1_overflow_addr);

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord_2_0.cpp
@@ -77,13 +77,13 @@ void kernel_main() {
     // Dispatcher Kernel is able to finish.
     // Device::close() requires fast-dispatch kernels to finish.
     volatile tt_l1_ptr go_msg_t* go_message_in = GET_MAILBOX_ADDRESS_DEV(go_messages[0]);
-    // #if defined(COMPILE_FOR_DM)
+#if defined(COMPILE_FOR_DM)
     // SD signaling: Quasar DM requires RUN_MSG_DONE. TODO: remove once FD is enabled on Quasar.
     go_message_in->signal = RUN_MSG_DONE;
-    // #else
-    //     uint64_t dispatch_addr = calculate_dispatch_addr(go_message_in);
-    //     notify_dispatch_core_done(dispatch_addr, noc_index);
-    // #endif
+#else
+    uint64_t dispatch_addr = calculate_dispatch_addr(go_message_in);
+    notify_dispatch_core_done(dispatch_addr, noc_index);
+#endif
 
     if (l1_overflow_addr) {
         CoreLocalMem<std::uint32_t> l1_overflow_buffer(l1_overflow_addr);


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes https://github.com/tenstorrent/tt-metal/issues/50278

`QuasarIdmaOps.IDMA_Basic` and `QuasarIdmaOps.IDMA_1D_Strided` used hardcoded L1 addresses (`0x10000` / `0x20000`) for the IDMA src/dst buffers. This clobbered L1 mailbox memory and caused hangs.

Fix: allocate src/dst buffers via `distributed::MeshBuffer::create()` with  instead of raw addresses.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadkarni/idma_repro)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadkarni/idma_repro)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=snadkarni/idma_repro)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:snadkarni/idma_repro)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=snadkarni/idma_repro)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:snadkarni/idma_repro)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/idma_repro)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/idma_repro)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=snadkarni/idma_repro)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:snadkarni/idma_repro)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/idma_repro)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/idma_repro)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/idma_repro)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/idma_repro)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/idma_repro)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/idma_repro)