### PR TITLE
[tt-train] Removing Reshape in Qwen3 Attention

### DIFF
--- a/tt-train/sources/examples/qwen3/model_qwen3_distributed.py
+++ b/tt-train/sources/examples/qwen3/model_qwen3_distributed.py
@@ -238,22 +238,16 @@ class DistributedQwen3Attention(AbstractModuleBase):
         k = self.k_proj(hidden_states)
         v = self.v_proj(hidden_states)
 
-        q_shape, k_shape = q.shape(), k.shape()
-        B, S = q_shape[0], q_shape[2]
-
-        q = ttml.ops.reshape.reshape(q, [B, 1, S * self.num_local_heads, self.head_dim])
-        k = ttml.ops.reshape.reshape(k, [B, 1, S * self.num_local_kv_heads, self.head_dim])
-        q = self.q_norm(q)
-        k = self.k_norm(k)
-        q = ttml.ops.reshape.reshape(q, q_shape)
-        k = ttml.ops.reshape.reshape(k, k_shape)
-
         kvs = ConcatLastDim.apply(k, v)
         (
             query_heads,
             key_heads,
             value_heads,
         ) = ttml.ops.multi_head_utils.grouped_heads_creation(q, kvs, self.num_local_heads, self.num_local_kv_heads)
+
+        # Per-head QK-Norm, before RoPE (matches HF Qwen3 ordering). V is left unnormed.
+        query_heads = self.q_norm(query_heads)
+        key_heads = self.k_norm(key_heads)
 
         query_heads = ttml.ops.rope.rope(query_heads, self.rope_params, position_offset)
         key_heads = ttml.ops.rope.rope(key_heads, self.rope_params, position_offset)

--- a/tt-train/sources/ttml/ops/rmsnorm_op.cpp
+++ b/tt-train/sources/ttml/ops/rmsnorm_op.cpp
@@ -31,7 +31,6 @@ autograd::TensorPtr rmsnorm(const autograd::TensorPtr &tensor, const autograd::T
 
     auto ashape_arr = a_shape.to_array_4D();
     [[maybe_unused]] auto [B, N, S, C] = ashape_arr;
-    assert((N == 1));  // one sequence per batch
 
     // one gain parameter per channel
     assert((gamma->get_value().logical_shape().to_array_4D() == std::array<uint32_t, 4>{1, 1, 1, C}));

--- a/tt-train/sources/ttml/ops/rmsnorm_op.cpp
+++ b/tt-train/sources/ttml/ops/rmsnorm_op.cpp
@@ -31,7 +31,6 @@ autograd::TensorPtr rmsnorm(const autograd::TensorPtr &tensor, const autograd::T
 
     auto ashape_arr = a_shape.to_array_4D();
     [[maybe_unused]] auto [B, N, S, C] = ashape_arr;
-    assert((N == 1));  // one sequence per batch
 
     // one gain parameter per channel
     assert((gamma->get_value().logical_shape().to_array_4D() == std::array<uint32_t, 4>{1, 1, 1, C}));
@@ -75,7 +74,6 @@ autograd::TensorPtr rmsnorm_composite(
 
     auto ashape_arr = a_shape.to_array_4D();
     [[maybe_unused]] auto [B, N, S, C] = ashape_arr;
-    assert((N == 1));  // one sequence per batch
 
     // one gain parameter per channel
     assert((gamma->get_value().logical_shape().to_array_4D() == std::array<uint32_t, 4>{1, 1, 1, C}));

--- a/tt-train/sources/ttml/ops/rmsnorm_op.cpp
+++ b/tt-train/sources/ttml/ops/rmsnorm_op.cpp
@@ -31,6 +31,7 @@ autograd::TensorPtr rmsnorm(const autograd::TensorPtr &tensor, const autograd::T
 
     auto ashape_arr = a_shape.to_array_4D();
     [[maybe_unused]] auto [B, N, S, C] = ashape_arr;
+    assert((N == 1));  // one sequence per batch
 
     // one gain parameter per channel
     assert((gamma->get_value().logical_shape().to_array_4D() == std::array<uint32_t, 4>{1, 1, 1, C}));

--- a/tt-train/sources/ttml/ttml/models/qwen3/attention.py
+++ b/tt-train/sources/ttml/ttml/models/qwen3/attention.py
@@ -104,18 +104,6 @@ class Qwen3Attention(AbstractModuleBase):
         k = self.k_proj(hidden_states)
         v = self.v_proj(hidden_states)
 
-        q_shape = q.shape()
-        k_shape = k.shape()
-        B, S = q_shape[0], q_shape[2]
-
-        # Reshape to (B, 1, S*num_heads, head_dim) for per-head QK-Norm
-        q = ttml.ops.reshape.reshape(q, [B, 1, S * self.num_heads, self.head_dim])
-        k = ttml.ops.reshape.reshape(k, [B, 1, S * self.num_kv_heads, self.head_dim])
-        q = self.q_norm(q)
-        k = self.k_norm(k)
-        q = ttml.ops.reshape.reshape(q, q_shape)
-        k = ttml.ops.reshape.reshape(k, k_shape)
-
         kvs = ConcatLastDim.apply(k, v)
 
         query_heads, key_heads, value_heads = ttml.ops.multi_head_utils.grouped_heads_creation(
@@ -124,6 +112,10 @@ class Qwen3Attention(AbstractModuleBase):
             self.num_heads,
             self.num_kv_heads,
         )
+
+        # Per-head QK-Norm, before RoPE (matches HF Qwen3 ordering). V is left unnormed.
+        query_heads = self.q_norm(query_heads)
+        key_heads = self.k_norm(key_heads)
 
         query_heads = ttml.ops.rope.rope(query_heads, self.rope_params, position_offset)
         key_heads = ttml.ops.rope.rope(key_heads, self.rope_params, position_offset)


### PR DESCRIPTION
### PR Category
Performance

### Summary
This PR removes the reshape device ops that were previously being called in the Qwen3 Attention block. By creating the grouped heads before the QK norm, the `head_dim` ends up in the last dimension, removing the need for the two `ttnn.reshape` calls before and after the QK norm. The result is about a 12-13% improvement in training step time, as well as a MFU going up +3.2% (measured on a single card BH p150 with Qwen3 1.7B on the Shakepeare dataset):

<img width="2054" height="1488" alt="image" src="https://github.com/user-attachments/assets/28410ee7-a7a8-4182-8af1-c584cb0bc149" />

Latest Qwen3-32B Boolq GRPO run with these changes:

<img width="2134" height="578" alt="image" src="https://github.com/user-attachments/assets/fa6bfefe-4cd4-4c1c-8a76-f14fbf868b04" />


### CI
- [x] [Sanity Tests](https://github.com/tenstorrent/tt-metal/actions/runs/29627940724)
- [x] [Blackhole Sanity](https://github.com/tenstorrent/tt-metal/actions/runs/29627926284)
- [x] [Nightly L2](https://github.com/tenstorrent/tt-metal/actions/runs/29627911690) - [main results](https://github.com/tenstorrent/tt-metal/actions/runs/29560896958)
- [x] [(Runtime) Sanity Tests](https://github.com/tenstorrent/tt-metal/actions/runs/29627859741)
- [x] New/Existing unit tests for this change

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=awliu/Qwen3_attention_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:awliu/Qwen3_attention_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=awliu/Qwen3_attention_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:awliu/Qwen3_attention_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=awliu/Qwen3_attention_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:awliu/Qwen3_attention_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=awliu/Qwen3_attention_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:awliu/Qwen3_attention_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=awliu/Qwen3_attention_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:awliu/Qwen3_attention_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=awliu/Qwen3_attention_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:awliu/Qwen3_attention_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=awliu/Qwen3_attention_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:awliu/Qwen3_attention_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=awliu/Qwen3_attention_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:awliu/Qwen3_attention_optimization)