### PR TITLE
TT-Metal + TT-LLM-Engine and TT-Blaze Sockets are out of sync

### DIFF
--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -574,7 +574,12 @@ std::unique_ptr<D2HSocket> D2HSocket::connect(const std::string& socket_id, std:
     socket->fifo_size_ = desc.fifo_size;
     socket->config_buffer_address_ = desc.config_buffer_address;
     socket->pcie_alignment_ = desc.pcie_alignment;
-    socket->sender_core_ = MeshCoreCoord(MeshCoordinate(0, 0), CoreCoord(desc.core_x, desc.core_y));
+    // Must match the owner-side coord; empty mesh_coord (pre-mesh-coord descriptors) defaults to (0, 0).
+    MeshCoordinate device_coord =
+        desc.mesh_coord.empty()
+            ? MeshCoordinate(0, 0)
+            : MeshCoordinate(tt::stl::Span<const uint32_t>(desc.mesh_coord.data(), desc.mesh_coord.size()));
+    socket->sender_core_ = MeshCoreCoord(device_coord, CoreCoord(desc.core_x, desc.core_y));
     socket->bytes_acked_device_offset_ = desc.bytes_acked_device_offset;
 
     socket->shm_ = std::make_unique<NamedShm>(NamedShm::open(desc.shm_name, desc.shm_size));

--- a/tt_metal/distributed/flatbuffer/hd_socket_descriptor.fbs
+++ b/tt_metal/distributed/flatbuffer/hd_socket_descriptor.fbs
@@ -36,6 +36,15 @@ table HDSocketDescriptor {
     // Used by connectors to restore page_size / fifo_curr_size / bytes_sent /
     // bytes_acked / write_ptr / read_ptr from the previous driver process.
     connector_state_offset: uint32;
+
+    // Mesh coordinate of the owning device within the mesh. Variable-length
+    // to accommodate arbitrary-rank meshes; typically 2 entries (row, col).
+    // Used by the connector so its sockets report the right coord via
+    // `H2DSocket::get_active_cores()` — downstream container-level lookups
+    // (e.g. shard-by-coord in a DistributedHostBuffer) depend on it.
+    // Appended last so old readers that don't know about this field still
+    // parse the descriptor correctly.
+    mesh_coord: [uint32];
 }
 
 root_type HDSocketDescriptor;

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -470,7 +470,12 @@ std::unique_ptr<H2DSocket> H2DSocket::connect(const std::string& socket_id, std:
     socket->fifo_size_ = desc.fifo_size;
     socket->config_buffer_address_ = desc.config_buffer_address;
     socket->pcie_alignment_ = desc.pcie_alignment;
-    socket->recv_core_ = MeshCoreCoord(MeshCoordinate(0, 0), CoreCoord(desc.core_x, desc.core_y));
+    // Must match the owner-side coord; empty mesh_coord (pre-mesh-coord descriptors) defaults to (0, 0).
+    MeshCoordinate device_coord =
+        desc.mesh_coord.empty()
+            ? MeshCoordinate(0, 0)
+            : MeshCoordinate(tt::stl::Span<const uint32_t>(desc.mesh_coord.data(), desc.mesh_coord.size()));
+    socket->recv_core_ = MeshCoreCoord(device_coord, CoreCoord(desc.core_x, desc.core_y));
     socket->h2d_mode_ = static_cast<H2DMode>(desc.h2d_mode);
     socket->aligned_data_buf_start_ = desc.aligned_data_buf_start;
     socket->shm_ = std::make_unique<NamedShm>(NamedShm::open(desc.shm_name, desc.shm_size));

--- a/tt_metal/distributed/hd_socket_descriptor.cpp
+++ b/tt_metal/distributed/hd_socket_descriptor.cpp
@@ -9,6 +9,7 @@
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/distributed.hpp>
 #include "impl/context/metal_context.hpp"
+#include <umd/device/pcie/pci_device.hpp>
 
 #include <cerrno>
 #include <chrono>
@@ -33,9 +34,24 @@ void HDSocketDescriptor::populate_from_owner(
     data_offset = 0;
     fifo_size = fifo_size_arg;
     config_buffer_address = config_buffer_address_arg;
-    device_id = static_cast<uint32_t>(mesh_device->get_device(core.device_coord)->id());
+    // Resolve to the *physical* PCIe device number (/dev/tenstorrent/N) rather than
+    // the UMD logical chip id. The logical id is an index into the (possibly
+    // TT_VISIBLE_DEVICES-filtered) device enumeration and is therefore not stable
+    // across processes: an owner that sets TT_VISIBLE_DEVICES and a connector that
+    // does not would disagree on what a given logical id refers to. The physical
+    // device number is identical in every process on the host, so the connector can
+    // translate it back to its own local logical id (see PCIeCoreWriter). This must
+    // match the tt-llm-engine connector's tt-metal, which exports the physical id.
+    uint32_t logical_device_id = static_cast<uint32_t>(mesh_device->get_device(core.device_coord)->id());
+    auto physical_device_num = tt::umd::PCIDevice::get_pci_device_id(static_cast<int>(logical_device_id));
+    TT_FATAL(
+        physical_device_num.has_value(),
+        "Failed to resolve physical PCIe device for logical chip id {} while exporting H2D socket descriptor.",
+        logical_device_id);
+    device_id = static_cast<uint32_t>(physical_device_num.value());
     core_x = core.core_coord.x;
     core_y = core.core_coord.y;
+    mesh_coord.assign(core.device_coord.coords().begin(), core.device_coord.coords().end());
     auto vc = mesh_device->worker_core_from_logical_core(core.core_coord);
     virtual_core_x = vc.x;
     virtual_core_y = vc.y;
@@ -46,6 +62,7 @@ void HDSocketDescriptor::write_to_file(const std::string& path) const {
     flatbuffers::FlatBufferBuilder builder(512);
     auto fb_socket_type = builder.CreateString(socket_type);
     auto fb_shm_name = builder.CreateString(shm_name);
+    auto fb_mesh_coord = builder.CreateVector(mesh_coord);
 
     auto fb_desc = flatbuffer::CreateHDSocketDescriptor(
         builder,
@@ -66,7 +83,8 @@ void HDSocketDescriptor::write_to_file(const std::string& path) const {
         virtual_core_y,
         pcie_alignment,
         bytes_acked_device_offset,
-        connector_state_offset);
+        connector_state_offset,
+        fb_mesh_coord);
     builder.Finish(fb_desc);
 
     std::string tmp_path = path + ".tmp";
@@ -117,6 +135,9 @@ HDSocketDescriptor HDSocketDescriptor::read_from_file(const std::string& path) {
     desc.pcie_alignment = fb->pcie_alignment();
     desc.bytes_acked_device_offset = fb->bytes_acked_device_offset();
     desc.connector_state_offset = fb->connector_state_offset();
+    if (const auto* mc = fb->mesh_coord()) {
+        desc.mesh_coord.assign(mc->begin(), mc->end());
+    }
 
     return desc;
 }

--- a/tt_metal/distributed/hd_socket_descriptor.hpp
+++ b/tt_metal/distributed/hd_socket_descriptor.hpp
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 #include <fmt/format.h>
 #include <tt-metalium/experimental/sockets/mesh_socket.hpp>
 
@@ -58,6 +59,9 @@ struct HDSocketDescriptor {
     uint32_t pcie_alignment = 0;             // PCIe page alignment in bytes (e.g. 64 for Blackhole)
     uint32_t bytes_acked_device_offset = 0;  // D2H: L1 offset of bytes_acked within config buffer
     uint32_t connector_state_offset = 0;     // Offset of HDSocketConnectorState within the SHM region
+
+    // Owning device's mesh coordinate (1 entry per mesh dim), so the connector can rebuild the MeshCoreCoord.
+    std::vector<uint32_t> mesh_coord;
 
     /**
      * @brief Populate common fields from the owner socket's state.

--- a/tt_metal/distributed/pcie_core_writer.cpp
+++ b/tt_metal/distributed/pcie_core_writer.cpp
@@ -5,12 +5,32 @@
 #include "tt_metal/distributed/pcie_core_writer.hpp"
 
 #include <umd/device/cluster.hpp>
+#include <umd/device/pcie/pci_device.hpp>
 #include <umd/device/types/core_coordinates.hpp>
+#include <tt_stl/assert.hpp>
 
 namespace tt::tt_metal::distributed {
 
 std::mutex PCIeCoreWriter::cluster_cache_mutex_;
 std::unordered_map<uint32_t, std::unique_ptr<tt::umd::Cluster>> PCIeCoreWriter::cluster_cache_;
+
+// The descriptor carries the *physical* PCIe device number (/dev/tenstorrent/N), which is
+// stable across processes regardless of TT_VISIBLE_DEVICES. UMD's Cluster, however, addresses
+// chips by *logical* id (the index into this process's device enumeration). Translate the
+// physical device number into this process's local logical chip id. This matches the exporter
+// (hd_socket_descriptor.cpp), which now stamps the physical id, and the tt-llm-engine connector.
+static uint32_t physical_to_local_logical_id(uint32_t physical_device_num) {
+    const auto enumerated = tt::umd::PCIDevice::enumerate_devices();
+    for (size_t i = 0; i < enumerated.size(); ++i) {
+        if (enumerated[i] == static_cast<int>(physical_device_num)) {
+            return static_cast<uint32_t>(i);
+        }
+    }
+    TT_THROW(
+        "H2D socket connector cannot find physical PCIe device /dev/tenstorrent/{} in this process. "
+        "Ensure the device is visible to the connector (check TT_VISIBLE_DEVICES).",
+        physical_device_num);
+}
 
 tt::umd::Cluster* PCIeCoreWriter::get_or_create_cluster(uint32_t device_id) {
     std::lock_guard lock(cluster_cache_mutex_);
@@ -27,8 +47,11 @@ tt::umd::Cluster* PCIeCoreWriter::get_or_create_cluster(uint32_t device_id) {
 }
 
 PCIeCoreWriter::PCIeCoreWriter(uint32_t device_id, uint32_t virtual_core_x, uint32_t virtual_core_y) :
-    device_id_(device_id), virtual_core_x_(virtual_core_x), virtual_core_y_(virtual_core_y) {
-    get_or_create_cluster(device_id);
+    device_id_(physical_to_local_logical_id(device_id)),
+    virtual_core_x_(virtual_core_x),
+    virtual_core_y_(virtual_core_y) {
+    // device_id_ is now the local logical chip id; the cache + write path address by logical id.
+    get_or_create_cluster(device_id_);
 }
 
 std::function<void(void*, uint32_t, uint64_t)> PCIeCoreWriter::get_pcie_writer() const {


### PR DESCRIPTION
  - TT-Metal uses physical device ids in the descriptors while TT-Blaze uses logical
  - This causes a logical id exported by TT-Blaze to be interpreted as a physical id when the H2D/D2H sockets connect to the Blaze Workload
  - Uplift Socket Descriptor specific changes to TT-Blaze (this is a subset of what exists on TT-Metal main and TT-LLM-Engine)
  - Compatibility and version control will be tracked by `kHDSocketConnectorStateVersion` going forward to fail fast

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=asaigal/blaze_socket_update)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:asaigal/blaze_socket_update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=asaigal/blaze_socket_update)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:asaigal/blaze_socket_update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=asaigal/blaze_socket_update)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:asaigal/blaze_socket_update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=asaigal/blaze_socket_update)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:asaigal/blaze_socket_update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=asaigal/blaze_socket_update)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:asaigal/blaze_socket_update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=asaigal/blaze_socket_update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:asaigal/blaze_socket_update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=asaigal/blaze_socket_update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:asaigal/blaze_socket_update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=asaigal/blaze_socket_update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:asaigal/blaze_socket_update)