### PR TITLE
[GroupNorm][Welford] Fix receiver store-before-signal L1 ordering race (#50304)

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_gn.cpp
@@ -6,6 +6,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
 #include "welford_combine.h"
+#include "ckernel.h"
 #include "noc_parameters.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
@@ -176,6 +177,16 @@ void kernel_main() {
             auto p_global_vars = reinterpret_cast<volatile uint16_t*>(global_vars_ptr);
             p_global_means[0] = local_result.mean;
             p_global_vars[0] = local_result.variance;
+
+            // Force both L1 stores to be processed into their L1 banks before we signal the sender,
+            // which immediately NoC-reads these exact addresses back. Without this, the baby-RISC
+            // store can still be in flight when the sender's read-back reaches the L1 bank -> the
+            // sender aggregates a stale partial. A blocking load of the same address orders after the
+            // store and stalls the pipeline until the store has landed (see ckernel.h load_blocking /
+            // MemoryOrdering.md). Both addresses are drained because they lie in different L1 words
+            // (single_tile_size_bytes apart) and may map to different L1 banks.
+            ckernel::load_blocking(p_global_means);
+            ckernel::load_blocking(p_global_vars);
 
             // Signal to sender that our partial data is ready
             reduce_receiver_sem.up(noc, mcast_sender_noc_x, mcast_sender_noc_y, 1);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_sharded_gn_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_sharded_gn_v2.cpp
@@ -6,6 +6,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
 #include "welford_combine.h"
+#include "ckernel.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/noc_semaphore.h"
@@ -101,6 +102,17 @@ void kernel_main() {
             auto p_global_vars = reinterpret_cast<volatile uint16_t*>(global_vars_ptr);
             p_global_means[0] = local_result.mean;
             p_global_vars[0] = local_result.variance;
+
+            // Force both L1 stores to be processed into their L1 banks before we signal the sender,
+            // which immediately NoC-reads these exact addresses back (see the sender's async_read of
+            // global_means/global_vars). Without this, the baby-RISC store can still be in flight
+            // when the sender's read-back reaches the L1 bank -> the sender aggregates a stale
+            // partial. A blocking load of the same address orders after the store and stalls the
+            // pipeline until the store has landed (see ckernel.h load_blocking / MemoryOrdering.md).
+            // Both addresses are drained because they lie in different L1 words
+            // (single_tile_size_bytes apart) and may map to different L1 banks.
+            ckernel::load_blocking(p_global_means);
+            ckernel::load_blocking(p_global_vars);
 
             // Signal to sender that our partial data is ready
             reduce_receiver_sem.up(noc, mcast_sender_noc_x, mcast_sender_noc_y, 1);


### PR DESCRIPTION
## Summary
Fixes #50304 (sub-issue of #48586, item 9).

The Welford group-norm **reduce receiver** kernels compute their combined per-group mean/variance on the baby-RISC and write them into `cb_ex_global` with plain `volatile uint16_t` stores, then **immediately** signal the sender (`reduce_receiver_sem.up`). The sender responds by NoC-reading those **exact L1 addresses back** to aggregate the global statistic (`welford_reader_mcast_sender_unary_sharded_gn_v2.cpp`).

Per `WormholeB0/TensixTile/BabyRISCV/MemoryOrdering.md`: a baby-RISC store **retires before its write-request is processed** into the L1 bank, and NoC write barriers/flushes drain NoC *writes*, **not** a RISC store to local L1. So the receiver's store can still be in flight when the sender's read-back reaches the L1 bank → the sender aggregates a **stale partial → wrong global mean/var → intermittent PCC failure** (the flaky block-sharded-v2 `use_welford` signature).

## Fix
Before signalling, drain each just-written address with `ckernel::load_blocking` — the shared baby-RISC blocking-load helper in `ckernel.h` (now 16-bit capable, so it can drain the `uint16_t` mean/var stores directly). Per the ISA-doc "Cross-core signalling" idiom, a store then a load of the *same* address are processed in order, and the blocking load stalls the pipeline until its read-response arrives — so the store has landed before the signal is emitted. Both mean and var are drained because they lie in different L1 words that may map to different L1 banks.

This revision replaces the local `l1_store_barrier.h` helper (an earlier hand-rolled copy of the same idiom) with the upstream `ckernel::load_blocking`.

## Test / verification
Per policy this PR does **not** add a perturbation-based test — the race is timing/L1-bank-contention dependent and cannot be forced deterministically. The correctness argument (the ISA memory-ordering contract plus the existing data-before-signal sibling idioms) is the acceptance basis; CI flaky-rate on the block-sharded-v2 welford shapes over time is the long-run signal.

Re-verified on **Blackhole (p100a, single chip)** after switching to `ckernel::load_blocking` (both target arches — WH and BH — provide the helper; CI exercises WH):

- Both modified receiver kernels JIT-recompile cleanly with the 16-bit `ckernel::load_blocking`.
- `test_group_norm` block-sharded-v2 8x4 `use_welford` — **3/3 pass** (sharded-v2 receiver).
- `test_group_norm_DRAM` welford — **72/72 pass** (non-sharded receiver).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/fix-groupnorm-welford-l1-store-ordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/fix-groupnorm-welford-l1-store-ordering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/fix-groupnorm-welford-l1-store-ordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/fix-groupnorm-welford-l1-store-ordering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/fix-groupnorm-welford-l1-store-ordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/fix-groupnorm-welford-l1-store-ordering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/fix-groupnorm-welford-l1-store-ordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/fix-groupnorm-welford-l1-store-ordering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/fix-groupnorm-welford-l1-store-ordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/fix-groupnorm-welford-l1-store-ordering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/fix-groupnorm-welford-l1-store-ordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/fix-groupnorm-welford-l1-store-ordering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/fix-groupnorm-welford-l1-store-ordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/fix-groupnorm-welford-l1-store-ordering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/fix-groupnorm-welford-l1-store-ordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/fix-groupnorm-welford-l1-store-ordering)
