### PR TITLE
[dram_prefetcher] Fix writer_l1 flush for non-posted default-path writes (#50306)

### DIFF
--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/kernels/writer_l1.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/kernels/writer_l1.cpp
@@ -62,7 +62,20 @@ void kernel_main() {
                         curr_coalesced_num_pages,
                         curr_coalesced_page_size,
                         noc);
-                    noc_async_posted_writes_flushed();
+                    // The data writes and the credit inc issued by remote_cb_push_back_and_write_pages
+                    // are posted iff skip_ptr_update (remote_circular_buffer.h: posted = skip_ptr_update).
+                    // cb_pop_front below frees the local CB source page, so we must drain the writes
+                    // whose SOURCE is that page before releasing it. Posted and non-posted writes are
+                    // tracked by separate NoC counters, so the flush must match: in the default
+                    // (skip_ptr_update == false) path the writes are non-posted and
+                    // noc_async_posted_writes_flushed() polls the wrong (posted) counter -- it returns
+                    // immediately without waiting, letting the reader overwrite still-in-flight source
+                    // data. Use noc_async_writes_flushed() there.
+                    if constexpr (skip_ptr_update) {
+                        noc_async_posted_writes_flushed(noc);
+                    } else {
+                        noc_async_writes_flushed(noc);
+                    }
                     cb_pop_front(local_cb_id, max_block_num_tiles);
                 }
             }


### PR DESCRIPTION
## Summary
Fixes #50306 (sub-issue of #48586, item 6).

`writer_l1.cpp` drained its remote-CB data writes with `noc_async_posted_writes_flushed()` unconditionally. But `remote_cb_push_back_and_write_pages<skip_ptr_update>` issues those writes (and the credit inc) **posted iff `skip_ptr_update`** (`remote_circular_buffer.h`: `posted = skip_ptr_update`), and `skip_ptr_update == enable_performance_mode`, whose **default is false**. So in the common path the writes are **non-posted**, tracked by a different NoC counter than the posted one the flush polls — the flush sees `0 == 0` and returns immediately, draining nothing. `cb_pop_front` then frees the local CB page that is those writes' **source**, so under NoC backpressure the reader can overwrite still-in-flight source data → corrupted data multicast to receivers. Latent because triple-buffer slack usually lets the write depart first.

## Fix
```cpp
if constexpr (skip_ptr_update) { noc_async_posted_writes_flushed(noc); }
else                           { noc_async_writes_flushed(noc); }
```
`noc_async_writes_flushed()` waits on the non-posted counter (departure), which is what the local-source-reuse guarantee needs; it is lighter than `noc_async_write_barrier()` (acks). The `enable_performance_mode=true` (posted) path is unchanged.

## Test / verification
Per policy this PR does **not** add a perturbation-based test (the race requires NoC backpressure to manifest and cannot be forced deterministically without injected congestion). Documented findings on WH n150 (single-device default path — exactly the buggy non-posted path):

- **Pass-with-fix:** `test_run_prefetcher_post_commit` — 8/8 params pass; the modified kernel JIT-recompiles cleanly.
- **Repro-without-fix:** ran the bare (pre-fix) kernel in a loop — **240/240** passes (30× each of 8 params), i.e. the race did **not** reproduce on-demand. Expected: with the default triple-buffered CB the source page is typically re-filled only after the write has departed; the wrong-counter flush is a *missing guarantee* that only bites under NoC backpressure, not a deterministic failure. The fix restores the correct departure guarantee.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/fix-dram-prefetcher-writer-l1-nonposted-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/fix-dram-prefetcher-writer-l1-nonposted-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/fix-dram-prefetcher-writer-l1-nonposted-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/fix-dram-prefetcher-writer-l1-nonposted-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/fix-dram-prefetcher-writer-l1-nonposted-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/fix-dram-prefetcher-writer-l1-nonposted-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/fix-dram-prefetcher-writer-l1-nonposted-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/fix-dram-prefetcher-writer-l1-nonposted-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/fix-dram-prefetcher-writer-l1-nonposted-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/fix-dram-prefetcher-writer-l1-nonposted-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/fix-dram-prefetcher-writer-l1-nonposted-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/fix-dram-prefetcher-writer-l1-nonposted-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/fix-dram-prefetcher-writer-l1-nonposted-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/fix-dram-prefetcher-writer-l1-nonposted-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/fix-dram-prefetcher-writer-l1-nonposted-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/fix-dram-prefetcher-writer-l1-nonposted-flush)