### PR TITLE
[reduce_to_root] Barrier inbound read before tt_memmove consumers (#50308)

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/root_receive_reader_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/root_receive_reader_kernel.cpp
@@ -195,6 +195,10 @@ void kernel_main() {
 
     uint64_t packet_noc_addr = get_noc_addr(core_noc_x, core_noc_y, intermediate_base_addr);
     noc_async_read(packet_noc_addr, packet_l1_addr, new_packet_size_bytes);
+    // Drain the inbound read before the tt_memmove consumers below: each tt_memmove is itself a NoC
+    // op whose SOURCE is packet_l1_addr, and on the weak NoC there is no read->read landing order, so
+    // the memmove could forward stale/partial packet data. Mirrors root2_receive_reader_kernel.cpp.
+    noc_async_read_barrier();
 
     // moving l tensor
     tt_memmove<true, false, false, 0>(noc, dest_page_base_addr, packet_l1_addr, packet_size_bytes);
@@ -217,8 +221,6 @@ void kernel_main() {
     cb_push_back(receiver_cb_id_m, 1);
 
     cb_push_back(packet_cb_id, 1);
-
-    noc_async_read_barrier();
 
     // now the similar behaviour when device 2 is sending data to device 1
     // will be waiting on another semaphore, and fabric is for the other 2 muxes
@@ -305,6 +307,8 @@ void kernel_main() {
     dest_page_base_addr = get_write_ptr(receiver_cb_id_l);
     packet_noc_addr = get_noc_addr(core_noc_x, core_noc_y, intermediate_base_addr);
     noc_async_read(packet_noc_addr, packet_l1_addr, new_packet_size_bytes);
+    // Drain the inbound read before the tt_memmove consumers (see first occurrence above).
+    noc_async_read_barrier();
 
     tt_memmove<true, false, false, 0>(noc, dest_page_base_addr, packet_l1_addr, packet_size_bytes);
     cb_push_back(receiver_cb_id_l, input_num_tiles);
@@ -324,6 +328,4 @@ void kernel_main() {
     cb_push_back(receiver_cb_id_s, 1);
     cb_push_back(receiver_cb_id_m, 1);
     cb_push_back(packet_cb_id, 1);
-
-    noc_async_read_barrier();
 }


### PR DESCRIPTION
## Summary
Fixes #50308 (sub-issue of #48586, item 1).

`root_receive_reader_kernel.cpp` issued an inbound `noc_async_read` into `packet_l1_addr` and then ran three `tt_memmove<true,false,false,0>` consumers **before** the matching `noc_async_read_barrier()` (which was deferred to after all consumers). Each `tt_memmove` (guaranteed_16B_aligned=true) lowers to `enhanced_noc_async_write(src=packet_l1_addr, ...)` — a NoC op whose **source** is the packet buffer. There is no ordering guarantee between the inbound read's response landing into `packet_l1_addr` and the memmove's later source-read of that same L1, so the write engine can forward **stale/partial** packet data before the inbound read has landed.

## Fix
Move `noc_async_read_barrier()` to immediately after each inbound `noc_async_read` (both sites), before the `tt_memmove` consumers, and drop the now-redundant deferred barriers. This matches the sibling `root2_receive_reader_kernel.cpp:186-187`, which already uses the correct ordering.

This kernel and op are **architecture-neutral shared code** — there are no arch guards in the kernel or program factory, so the same source is JIT-compiled and runs on both Wormhole and Blackhole; the fix applies to both. The op requires a **4-device box** (the root device must have both fabric neighbors, `reduce_to_root_op.cpp:171-174`).

## Why this is a real hazard (spec-grounded)
Per `WormholeB0/NoC/Ordering.md`, read-return data is a **response packet** whose virtual channel software cannot control (*"class bits will always be `0b11` … these types of packets can always get reordered or interleaved"*). None of the documented ordering guarantees (all request↔request on a controllable VC) cover a write's source-read of local L1 vs. a prior read's response landing into that L1. The doc's **"Stronger ordering"** rule — *"issue a request, wait for the response to arrive, and only then issue the next request"* — is exactly what `noc_async_read_barrier()` provides. So the deferred-barrier code relies on an ordering the architecture explicitly disclaims.

## Test / verification
Detection is a **poison probe**: `packet_l1_addr` is filled with a bf16-huge sentinel right before the inbound read, so a stale forward surfaces as a huge value in the output (real data is O(1); a leak = any output element > 1e6).

### Single-chip micro-reproducer on Blackhole — the fix is load-bearing on real hardware
A standalone one-core program (`programming_examples/r2r_race_repro`) isolates the exact hazard: a **local L1→L1** inbound `noc_async_read` into a poisoned `packet_l1`, followed by the consumer `noc_async_write` that source-reads `packet_l1` (faithful to `tt_memmove<true,...>`), with the read barrier either deferred (buggy) or inserted right after the read (this PR's fix). Run on a single Blackhole p150b, 1 tile:

| Case | Leak |
|------|------|
| Positive control (skip the inbound read) | 100% — probe validated |
| **Buggy**, natural timing | **0 / 512000** (500 iters) — does not fire naturally |
| **Buggy**, NIU read path backed up (≥8 outstanding reads) | **512000 / 512000 — 100%, deterministic (3/3)** |
| **Fixed** (this PR), same backpressure | **0 / 512000** |
| Fixed, extreme backpressure (1024 outstanding) | **0 / 204800** |

The graded threshold (congest 6 → 0%, 8 → 94%, 10+ → 100%) is the signature of a genuine timing window, not an all-or-nothing structural artifact. Same perturbation, the barrier is the only variable, and it flips 100% → 0%: a clean fail-without-fix / pass-with-fix demonstrated on Blackhole silicon.

### Interpretation
- Under **natural** timing the hazard does **not** fire on Blackhole (0 leaks over 500+ iters here; consistent with the earlier full-op poison probe, also 0 leaks). On Blackhole this is a **latent, timing-masked** race, exposed only once the NIU read-return path is backed up.
- The micro-repro is deliberately **more aggressive than the full op**: the consumer immediately follows the inbound read with no intervening RISC work. In the real `reduce_to_root` kernel the `cb_reserve_back` / `get_write_ptr` / aligned-size computation between the read and the memmove drains the outstanding reads first, which is why the full workload stays clean on Blackhole even under injected congestion. So the micro-repro proves the **hazard class is architecturally real on Blackhole hardware**; it does not claim the full `reduce_to_root` workload corrupts on Blackhole today.
- Combined with the Wormhole NoC ordering spec above (which permits the read-response reorder outright, even without backpressure), the barrier is **load-bearing on both architectures** — this fix is not redundant. A Wormhole-multichip owner can additionally run the full-op buggy-vs-fixed poison probe on a 4-chip T3000/Galaxy (harness available on request).

Note: the existing trace test (`test_reduce_to_root_trace.py`) cannot detect this race — it reuses identical inputs across iterations, so a stale read returns byte-identical prior-iteration data. Its `#39098` skip is a **separate, real compute-mismatch** (L wrong by ~0.25 abs / ~8.7% rel; S/M correct), present with and without this fix, so this PR does not unblock re-enabling that test.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/fix-reduce-to-root-read-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/fix-reduce-to-root-read-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/fix-reduce-to-root-read-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/fix-reduce-to-root-read-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/fix-reduce-to-root-read-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/fix-reduce-to-root-read-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/fix-reduce-to-root-read-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/fix-reduce-to-root-read-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/fix-reduce-to-root-read-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/fix-reduce-to-root-read-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/fix-reduce-to-root-read-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/fix-reduce-to-root-read-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/fix-reduce-to-root-read-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/fix-reduce-to-root-read-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/fix-reduce-to-root-read-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/fix-reduce-to-root-read-barrier)
