### PR TITLE
[deepseek_prefill][dispatch] Invalidate L1 cache in tile-layout poll loop (#50310)

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_sender_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_sender_dispatch.cpp
@@ -338,6 +338,10 @@ void kernel_main() {
             // read each iteration we can spin forever on a stale data_avail==0 (deadlock) or read
             // stale route_info and forward garbage route/dst over the fabric. Mirrors the sibling
             // reader_combine.cpp poll loop.
+            // On Wormhole this is unnecessary: the RISC has no L1 read cache at all (the whole
+            // set_l1_data_cache() control is Blackhole-only), so L1 reads always go straight to L1
+            // and observe the latest NoC write -- there is nothing to invalidate. invalidate_l1_cache()
+            // is an empty no-op there, so keeping the call unconditional is both correct and free.
             invalidate_l1_cache();
             if (*ring_data_avail_ptr[s] >= consumed[s] + 1) {
                 uint32_t slot = consumed[s] % writer_cb_size;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_sender_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_sender_dispatch.cpp
@@ -338,10 +338,10 @@ void kernel_main() {
             // read each iteration we can spin forever on a stale data_avail==0 (deadlock) or read
             // stale route_info and forward garbage route/dst over the fabric. Mirrors the sibling
             // reader_combine.cpp poll loop.
-            // On Wormhole this is unnecessary: the RISC has no L1 read cache at all (the whole
-            // set_l1_data_cache() control is Blackhole-only), so L1 reads always go straight to L1
-            // and observe the latest NoC write -- there is nothing to invalidate. invalidate_l1_cache()
-            // is an empty no-op there, so keeping the call unconditional is both correct and free.
+            // On Wormhole this is unnecessary: the baby RISCV has no L0 data cache over L1 (that
+            // cache and its set_l1_data_cache() control exist only on Blackhole), so L1 reads always
+            // observe the latest NoC write -- there is nothing to invalidate, and invalidate_l1_cache()
+            // (which compiles to a `fence`, itself a no-op on Wormhole) does nothing there.
             invalidate_l1_cache();
             if (*ring_data_avail_ptr[s] >= consumed[s] + 1) {
                 uint32_t slot = consumed[s] % writer_cb_size;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_sender_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_sender_dispatch.cpp
@@ -332,6 +332,13 @@ void kernel_main() {
             if (done[s]) {
                 continue;
             }
+            // On Blackhole the RISC caches L1 reads (write-through cache), so a remote NoC write into
+            // this core's L1 does not invalidate a cached copy. Both *ring_data_avail_ptr[s] and the
+            // route_info slot read below are written REMOTELY by the untilizer, so without a fresh L1
+            // read each iteration we can spin forever on a stale data_avail==0 (deadlock) or read
+            // stale route_info and forward garbage route/dst over the fabric. Mirrors the sibling
+            // reader_combine.cpp poll loop.
+            invalidate_l1_cache();
             if (*ring_data_avail_ptr[s] >= consumed[s] + 1) {
                 uint32_t slot = consumed[s] % writer_cb_size;
                 volatile tt_l1_ptr uint32_t* route_info =


### PR DESCRIPTION
## Summary
Fixes #50310 (sub-issue of #48586, item 5).

The `IS_TILE_LAYOUT` drain loop in `writer_dispatch.cpp` busy-polls two L1 locations written **remotely** by the untilizer — the `data_avail` semaphore (`*ring_data_avail_ptr[s]`) and the `route_info` slot — with plain loads and **no `invalidate_l1_cache()`**. On Blackhole the RISC core caches L1 reads (write-through cache), so a remote NoC write into L1 does not invalidate the cached copy: the poll can spin forever on a stale `data_avail==0` (deadlock) or read stale `route_info` and forward garbage route/dst over the fabric. Producer side is already correct; this is purely consumer-side.

## Fix
Add `invalidate_l1_cache()` as the first statement in the per-ring poll body (after the `done[s]` guard, before reading `*ring_data_avail_ptr[s]`), refreshing both the semaphore line and the `route_info` slot each iteration. Mirrors the sibling `reader_combine.cpp:311` poll loop and the framework's `noc_semaphore_wait` spin contract.

## Test / verification

**Root-caused and runtime-reproduced on Blackhole (p150b).** This is a Blackhole-only hazard by construction, and the fix is correct on both arches from a single source:

- **Arch scope.** `invalidate_l1_cache()` is defined in both `tt_metal/hw/inc/internal/tt-2xx/risc_common.h` (BH) and `tt-1xx/risc_common.h` (WH) as `#if defined(ARCH_BLACKHOLE) asm("fence"); #endif` — i.e. a **no-op on Wormhole**, which has no RISC L1 read cache. On WH the volatile poll is already coherent with remote NoC writes, so the loop is correct there and this change is inert. No `ENABLE_L1_DATA_CACHE` guard is needed at the call site (or wanted): the arch gate lives inside the function, and the cache can be enabled without that define via a direct `set_l1_data_cache<true>()` (e.g. `tt_fabric_mux.cpp`), so the invalidate must fire whenever the cache *could* be on — matching every existing poll (`reader_combine.cpp`, `noc_semaphore_wait`, `socket_api.h`, `remote_circular_buffer.h`), which all call it unconditionally.
- **Why `volatile` is insufficient.** The pointers are already `volatile tt_l1_ptr`. `volatile` forces the compiler to re-issue the load each iteration, but the load still hits the BH L1 write-through data cache, which is not snooped by NoC writes. Only the cache invalidate (`asm("fence")`) forces a re-fetch from L1.
- **Default-latent.** The BH L1 data cache is disabled by default (`firmware_common.h::configure_l1_data_cache`), so this bug is latent on a stock build and becomes load-bearing whenever the cache is enabled (`TT_METAL_ENABLE_L1_DATA_CACHE_*`, or `set_l1_data_cache<true>()`).

**Repro (fail-without-fix / pass-with-fix) on p150b.** A standalone single-chip programming-example faithfully replicates the poll: the producer NoC-writes `route_info`, barriers, then `noc_semaphore_inc`s `data_avail` (data-before-signal, exactly like `writer_untilize_dispatch`); the consumer runs the exact poll body, once buggy and once with `invalidate_l1_cache()`.
- Cache **off** (default): buggy poll converges (~17 iters) — fix is defensive.
- Cache **on** (`TT_METAL_ENABLE_L1_DATA_CACHE_CORES=worker TT_METAL_ENABLE_L1_DATA_CACHE_RISCVS=BR`; the writer runs on RISCV_0 = BR): buggy poll **deadlocks** — `data_avail` stuck at the stale cached `0`, hitting the 5,000,000-iter cap — while the `invalidate_l1_cache()` poll converges on iter 0 with the real route. This is the exact #50310 deadlock, reproduced deterministically on real Blackhole silicon.

The change is a minimal, mechanical addition that makes this poll loop consistent with the already-correct sibling `reader_combine.cpp` and with `noc_semaphore_wait`. The drain-loop path is selected by TILE layout (not FP8), so it is reachable on BH with BF16/TILE input as well as FP8.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/fix-deepseek-prefill-dispatch-invalidate-l1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/fix-deepseek-prefill-dispatch-invalidate-l1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/fix-deepseek-prefill-dispatch-invalidate-l1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/fix-deepseek-prefill-dispatch-invalidate-l1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/fix-deepseek-prefill-dispatch-invalidate-l1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/fix-deepseek-prefill-dispatch-invalidate-l1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/fix-deepseek-prefill-dispatch-invalidate-l1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/fix-deepseek-prefill-dispatch-invalidate-l1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/fix-deepseek-prefill-dispatch-invalidate-l1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/fix-deepseek-prefill-dispatch-invalidate-l1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/fix-deepseek-prefill-dispatch-invalidate-l1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/fix-deepseek-prefill-dispatch-invalidate-l1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/fix-deepseek-prefill-dispatch-invalidate-l1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/fix-deepseek-prefill-dispatch-invalidate-l1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/fix-deepseek-prefill-dispatch-invalidate-l1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/fix-deepseek-prefill-dispatch-invalidate-l1)
