### PR TITLE
Fix latent deadlock in DRAM multi-core sort (split cores->coordinator semaphore)

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
@@ -701,9 +701,15 @@ def test_sort_multi_row_multi_core_no_deadlock(descending, device):
     That race is latent (the exact-match poll normally out-races the NoC atomics, so
     it needs timing pressure to surface), so this test does not deterministically
     reproduce the hang.  What it *does* guarantee is that the multi-core Ht >= 2 path
-    -- otherwise only exercised at Ht == 1 -- runs to completion with correct output,
-    and, via the worker-thread watchdog + pytest-timeout, that a regression which
-    makes it deadlock FAILS with an assertion instead of hanging the test session.
+    -- otherwise only exercised at Ht == 1 -- runs to completion with correct output.
+
+    The worker-thread watchdog + pytest-timeout are a best-effort regression guard,
+    not a clean recovery mechanism: a genuine deadlock wedges the device (which needs
+    a reset regardless), so the join times out and the assertion below fires, but the
+    function-scoped `device` fixture teardown (close_device) may then block until the
+    process-level pytest-timeout terminates the run.  The guarantee is only that a
+    regression surfaces as a CI *failure* (never a silent pass); cleanly isolating a
+    hang from teardown would require running the op in a killable subprocess.
 
     The multi-core factory is only selected when the (power-of-two padded) tile width
     exceeds total_cores * 128, so the width is sized from the device grid.

--- a/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
@@ -690,18 +690,18 @@ def test_sort_multi_row_multi_core_no_deadlock(descending, device):
     """
     Guard for the DRAM multi-core sort path (SortProgramFactorySingleRowMultiCore).
 
-    The coordinator core used to collect two logically different worker signals --
-    the reader's per-row "ready" and the writer's per-pair "done" confirmations --
-    on a single cores->coordinator semaphore, consumed with an exact-match wait().
-    At a tile-row boundary (Ht >= 2) a fast reader's next-row readiness increment
-    could push that shared counter past the exact confirmation target so the wait
-    never matched -> deadlock.  The fix splits the channel into two semaphores
-    (ready + done), one producer signal each.
+    The coordinator core collects two logically distinct worker signals -- the reader's
+    per-row "ready" and the writer's per-pair "done" -- on two separate cores->coordinator
+    semaphores, one producer signal each.  They are kept separate so each coordinator wait
+    has an exact, monotonic per-producer target: were both folded onto one shared counter,
+    at a tile-row boundary (Ht >= 2) a fast reader's next-row "ready" increment could push
+    the counter past the "done" target an exact-match wait is looking for, stranding the
+    wait and deadlocking the op.
 
-    That race is latent (the exact-match poll normally out-races the NoC atomics, so
-    it needs timing pressure to surface), so this test does not deterministically
-    reproduce the hang.  What it *does* guarantee is that the multi-core Ht >= 2 path
-    -- otherwise only exercised at Ht == 1 -- runs to completion with correct output.
+    This exercises the multi-core Ht >= 2 path -- otherwise only covered at Ht == 1 -- and
+    checks it runs to completion with correct output.  It is not a deterministic deadlock
+    reproducer: the mismatch a shared counter would cause is timing-dependent (the exact-match
+    poll normally out-races the NoC atomics), so it needs timing pressure to surface.
 
     The worker-thread watchdog + pytest-timeout are a best-effort regression guard,
     not a clean recovery mechanism: a genuine deadlock wedges the device (which needs

--- a/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
@@ -640,7 +640,7 @@ def test_fp32_non_last_dim_index_validation(shape, dim, device):
     assert_allclose(gathered.float(), ref_vals.float(), rtol=1e-2, atol=1e-2)
 
 
-def test_fp32_input_uint16_preallocated_index_rejected(device):
+def test_fp32_input_uint16_preallocated_index_rejected(device, expect_error):
     shape = [TILE_HEIGHT, 2 * TILE_WIDTH]
     t = torch.randn(shape, dtype=torch.float32)
     x = ttnn.from_torch(
@@ -653,7 +653,7 @@ def test_fp32_input_uint16_preallocated_index_rejected(device):
         shape, dtype=ttnn.uint16, device=device, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
     )
 
-    with pytest.raises((RuntimeError, Exception)):
+    with expect_error(RuntimeError, "must be UINT32 when input dtype is FLOAT32"):
         ttnn.sort(x, dim=-1, out=(out_v, out_i))
 
 

--- a/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
@@ -2,6 +2,8 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import threading
+
 import pytest
 import torch
 import ttnn
@@ -673,6 +675,77 @@ def test_width_sharded(layout, device):
     ), f"values mismatch max_diff={(out - ref_vals.float()).abs().max():.4f}"
     gathered = torch.gather(t, -1, ttnn.to_torch(i).to(torch.int64))
     assert torch.allclose(gathered.float(), ref_vals.float(), rtol=1e-2, atol=1e-2), "index gather mismatch"
+
+
+def _next_pow2(n):
+    p = 1
+    while p < n:
+        p <<= 1
+    return p
+
+
+@pytest.mark.timeout(600, method="thread")
+@pytest.mark.parametrize("descending", [False, True])
+def test_sort_multi_row_multi_core_no_deadlock(descending, device):
+    """
+    Guard for the DRAM multi-core sort path (SortProgramFactorySingleRowMultiCore).
+
+    The coordinator core used to collect two logically different worker signals --
+    the reader's per-row "ready" and the writer's per-pair "done" confirmations --
+    on a single cores->coordinator semaphore, consumed with an exact-match wait().
+    At a tile-row boundary (Ht >= 2) a fast reader's next-row readiness increment
+    could push that shared counter past the exact confirmation target so the wait
+    never matched -> deadlock.  The fix splits the channel into two semaphores
+    (ready + done), one producer signal each.
+
+    That race is latent (the exact-match poll normally out-races the NoC atomics, so
+    it needs timing pressure to surface), so this test does not deterministically
+    reproduce the hang.  What it *does* guarantee is that the multi-core Ht >= 2 path
+    -- otherwise only exercised at Ht == 1 -- runs to completion with correct output,
+    and, via the worker-thread watchdog + pytest-timeout, that a regression which
+    makes it deadlock FAILS with an assertion instead of hanging the test session.
+
+    The multi-core factory is only selected when the (power-of-two padded) tile width
+    exceeds total_cores * 128, so the width is sized from the device grid.
+    """
+    torch.manual_seed(0)
+
+    grid = device.compute_with_storage_grid_size()
+    total_cores = grid.x * grid.y
+    wt = _next_pow2(total_cores * 128 + 1)  # smallest pow2 Wt on the DRAM multi-core path
+    shape = [1, 1, 2 * TILE_HEIGHT, wt * TILE_WIDTH]  # Ht = 2
+
+    input_t = torch.randn(shape, dtype=torch.bfloat16)
+    ttnn_input = ttnn.from_torch(input_t, ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device)
+
+    result = {}
+
+    def _run():
+        try:
+            values, indices = ttnn.sort(ttnn_input, dim=-1, descending=descending)
+            ttnn.synchronize_device(device)
+            result["values"] = values
+            result["indices"] = indices
+        except Exception as exc:  # surface device/compile errors to the main thread
+            result["error"] = exc
+
+    worker = threading.Thread(target=_run, daemon=True)
+    worker.start()
+    worker.join(timeout=300.0)
+
+    assert not worker.is_alive(), (
+        "ttnn.sort did not complete on the DRAM multi-core path (Ht=2): the coordinator's "
+        "cores->coordinator wait was starved -- likely a regression of the ready/done "
+        "semaphore split."
+    )
+    if "error" in result:
+        raise result["error"]
+
+    torch_values, _ = torch.sort(input_t, dim=-1, descending=descending)
+    assert list(result["values"].shape) == shape
+    assert_equal(torch_values, ttnn.to_torch(result["values"]))
+    ttnn_gathered = torch.gather(input_t, -1, ttnn.to_torch(result["indices"]).to(torch.int64))
+    assert_equal(torch_values, ttnn_gathered)
 
 
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/coordinator_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/coordinator_single_row_multi_core.cpp
@@ -63,12 +63,12 @@ void kernel_main() {
 
     // Semaphore setup
     Semaphore<> coordinator_to_cores_sem(coordinator_to_cores_semaphore_arg);
-    // Two separate up-channels from the worker cores.  A single shared semaphore was
-    // fed by both the reader's per-row readiness and the writer's per-pair
-    // confirmations; at a tile-row boundary a fast reader's next-row readiness could
-    // land during the confirmation window and push the counter past the exact target,
-    // so the exact-match wait() below never matched -> latent deadlock at Ht >= 2.
-    // Readiness -> ready sem; per-pair confirmations -> done sem.
+    // Two separate up-channels from the worker cores: the reader's per-row readiness ->
+    // ready sem, the writer's per-pair confirmations -> done sem.  They are kept on
+    // distinct semaphores so each exact-match wait() below has its own monotonic target;
+    // folded onto one shared counter, at a tile-row boundary (Ht >= 2) a fast reader's
+    // next-row readiness could land during the confirmation window and push the counter
+    // past the done target, so the wait would never match and the op would deadlock.
     Semaphore<> cores_to_coordinator_ready_sem(cores_to_coordinator_ready_semaphore_arg);
     Semaphore<> cores_to_coordinator_done_sem(cores_to_coordinator_done_semaphore_arg);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/coordinator_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/coordinator_single_row_multi_core.cpp
@@ -19,11 +19,12 @@ void kernel_main() {
     const uint32_t end_core_physical_coord_x = get_arg_val<uint32_t>(2);
     const uint32_t end_core_physical_coord_y = get_arg_val<uint32_t>(3);
     const uint32_t coordinator_to_cores_semaphore_arg = get_arg_val<uint32_t>(4);
-    const uint32_t cores_to_coordinator_semaphore_arg = get_arg_val<uint32_t>(5);
-    const uint32_t number_of_dest = get_arg_val<uint32_t>(6);
-    const uint32_t input_tensor_buffer_addr = get_arg_val<uint32_t>(7);
-    const uint32_t output_tensor_buffer_addr = get_arg_val<uint32_t>(8);
-    const uint32_t output_index_tensor_buffer_addr = get_arg_val<uint32_t>(9);
+    const uint32_t cores_to_coordinator_ready_semaphore_arg = get_arg_val<uint32_t>(5);
+    const uint32_t cores_to_coordinator_done_semaphore_arg = get_arg_val<uint32_t>(6);
+    const uint32_t number_of_dest = get_arg_val<uint32_t>(7);
+    const uint32_t input_tensor_buffer_addr = get_arg_val<uint32_t>(8);
+    const uint32_t output_tensor_buffer_addr = get_arg_val<uint32_t>(9);
+    const uint32_t output_index_tensor_buffer_addr = get_arg_val<uint32_t>(10);
 
     // Compile time args
     constexpr uint32_t total_work_units = get_compile_time_arg_val(0);
@@ -62,7 +63,14 @@ void kernel_main() {
 
     // Semaphore setup
     Semaphore<> coordinator_to_cores_sem(coordinator_to_cores_semaphore_arg);
-    Semaphore<> cores_to_coordinator_sem(cores_to_coordinator_semaphore_arg);
+    // Two separate up-channels from the worker cores.  A single shared semaphore was
+    // fed by both the reader's per-row readiness and the writer's per-pair
+    // confirmations; at a tile-row boundary a fast reader's next-row readiness could
+    // land during the confirmation window and push the counter past the exact target,
+    // so the exact-match wait() below never matched -> latent deadlock at Ht >= 2.
+    // Readiness -> ready sem; per-pair confirmations -> done sem.
+    Semaphore<> cores_to_coordinator_ready_sem(cores_to_coordinator_ready_semaphore_arg);
+    Semaphore<> cores_to_coordinator_done_sem(cores_to_coordinator_done_semaphore_arg);
 
     const uint32_t number_of_confirmations = Wt / 2;
 
@@ -160,8 +168,8 @@ void kernel_main() {
         }  // Wt loop
 
         // Wait until all cores are ready to start
-        cores_to_coordinator_sem.wait(number_of_dest);
-        cores_to_coordinator_sem.set(0);  // Reset the semaphore
+        cores_to_coordinator_ready_sem.wait(number_of_dest);
+        cores_to_coordinator_ready_sem.set(0);  // Reset the semaphore
 
         // Set signal to start processing
         coordinator_to_cores_sem.set_multicast<NocOptions::DEFAULT>(
@@ -192,8 +200,8 @@ void kernel_main() {
                 noc.async_write_barrier();
 
                 // Wait until cores will process and save data
-                cores_to_coordinator_sem.wait(number_of_confirmations);
-                cores_to_coordinator_sem.set(0);  // Reset the semaphore
+                cores_to_coordinator_done_sem.wait(number_of_confirmations);
+                cores_to_coordinator_done_sem.set(0);  // Reset the semaphore
             }  // sub loop
         }  // stage loop
     }  // Ht loop

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/reader_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/reader_single_row_multi_core.cpp
@@ -17,7 +17,7 @@ void kernel_main() {
     const uint32_t coordinator_core_physical_coord_x = get_arg_val<uint32_t>(2);
     const uint32_t coordinator_core_physical_coord_y = get_arg_val<uint32_t>(3);
     const uint32_t coordinator_to_cores_semaphore_arg = get_arg_val<uint32_t>(4);
-    const uint32_t cores_to_coordinator_semaphore_arg = get_arg_val<uint32_t>(5);
+    const uint32_t cores_to_coordinator_ready_semaphore_arg = get_arg_val<uint32_t>(5);
 
     // Compile time args
     constexpr uint32_t input_tensor_cb_index = get_compile_time_arg_val(0);
@@ -55,7 +55,7 @@ void kernel_main() {
 
     // Semaphore setup
     Semaphore<> coordinator_to_cores_sem(coordinator_to_cores_semaphore_arg);
-    Semaphore<> cores_to_coordinator_sem(cores_to_coordinator_semaphore_arg);
+    Semaphore<> cores_to_coordinator_ready_sem(cores_to_coordinator_ready_semaphore_arg);
     coordinator_to_cores_sem.set(VALID);  // Reset the semaphore (Valid - we wait for 0)
 
     for (uint32_t h = 0; h < Ht; h++) {
@@ -64,7 +64,7 @@ void kernel_main() {
             get_absolute_logical_y() * compute_with_storage_grid_size_x + get_absolute_logical_x();
 
         // Indicate to the coordinator that the core is ready
-        cores_to_coordinator_sem.up(noc, coordinator_core_physical_coord_x, coordinator_core_physical_coord_y, 1);
+        cores_to_coordinator_ready_sem.up(noc, coordinator_core_physical_coord_x, coordinator_core_physical_coord_y, 1);
         noc.async_atomic_barrier();
         coordinator_to_cores_sem.wait(0);     // Wait for coordinator to signal to start
         coordinator_to_cores_sem.set(VALID);  // Reset the semaphore

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/writer_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/writer_single_row_multi_core.cpp
@@ -15,7 +15,7 @@ void kernel_main() {
     const uint32_t coordinator_core_physical_coord_x = get_arg_val<uint32_t>(2);
     const uint32_t coordinator_core_physical_coord_y = get_arg_val<uint32_t>(3);
     const uint32_t coordinator_to_cores_semaphore_arg = get_arg_val<uint32_t>(4);
-    const uint32_t cores_to_coordinator_semaphore_arg = get_arg_val<uint32_t>(5);
+    const uint32_t cores_to_coordinator_done_semaphore_arg = get_arg_val<uint32_t>(5);
 
     // Compile time args
     constexpr uint32_t input_tensor_output_cb_index = get_compile_time_arg_val(0);
@@ -52,7 +52,7 @@ void kernel_main() {
     constexpr uint32_t index_tensor_tile_size = get_tile_size(index_tensor_output_cb_index);
 
     // Semaphore setup
-    Semaphore<> cores_to_coordinator_sem(cores_to_coordinator_semaphore_arg);
+    Semaphore<> cores_to_coordinator_done_sem(cores_to_coordinator_done_semaphore_arg);
 
     for (uint32_t h = 0; h < Ht; h++) {
         // Get core start value
@@ -150,7 +150,7 @@ void kernel_main() {
                             }
 
                             // Signalize readiness to the coordinator
-                            cores_to_coordinator_sem.up(
+                            cores_to_coordinator_done_sem.up(
                                 noc, coordinator_core_physical_coord_x, coordinator_core_physical_coord_y, 1);
                             noc.async_atomic_barrier();
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_program_factory.cpp
@@ -1179,11 +1179,11 @@ ProgramDescriptor SortProgramFactorySingleRowMultiCore::create_descriptor(
         });
     }
 
-    // Semaphores.  The cores->coordinator channel is split into two so a fast
+    // Semaphores.  The cores->coordinator channel uses two separate semaphores so a fast
     // reader's next-row readiness increment can never be miscounted as a sub-stage
-    // confirmation (a shared counter let it overshoot the coordinator's exact-match
-    // wait, deadlocking the op at Ht >= 2).  Readiness -> ready sem; per-pair
-    // confirmations -> done sem.
+    // confirmation: on one shared counter it could overshoot the coordinator's exact-match
+    // wait and deadlock the op at Ht >= 2.  Readiness -> ready sem; per-pair confirmations
+    // -> done sem.
     constexpr uint32_t coordinator_to_cores_semaphore_id = 0;
     constexpr uint32_t cores_to_coordinator_ready_semaphore_id = 1;
     constexpr uint32_t cores_to_coordinator_done_semaphore_id = 2;

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/sort_program_factory.cpp
@@ -1179,9 +1179,14 @@ ProgramDescriptor SortProgramFactorySingleRowMultiCore::create_descriptor(
         });
     }
 
-    // Semaphores
+    // Semaphores.  The cores->coordinator channel is split into two so a fast
+    // reader's next-row readiness increment can never be miscounted as a sub-stage
+    // confirmation (a shared counter let it overshoot the coordinator's exact-match
+    // wait, deadlocking the op at Ht >= 2).  Readiness -> ready sem; per-pair
+    // confirmations -> done sem.
     constexpr uint32_t coordinator_to_cores_semaphore_id = 0;
-    constexpr uint32_t cores_to_coordinator_semaphore_id = 1;
+    constexpr uint32_t cores_to_coordinator_ready_semaphore_id = 1;
+    constexpr uint32_t cores_to_coordinator_done_semaphore_id = 2;
     desc.semaphores.push_back(SemaphoreDescriptor{
         .id = coordinator_to_cores_semaphore_id,
         .core_type = tt::CoreType::WORKER,
@@ -1189,7 +1194,13 @@ ProgramDescriptor SortProgramFactorySingleRowMultiCore::create_descriptor(
         .initial_value = 0,
     });
     desc.semaphores.push_back(SemaphoreDescriptor{
-        .id = cores_to_coordinator_semaphore_id,
+        .id = cores_to_coordinator_ready_semaphore_id,
+        .core_type = tt::CoreType::WORKER,
+        .core_ranges = all_core_set,
+        .initial_value = 0,
+    });
+    desc.semaphores.push_back(SemaphoreDescriptor{
+        .id = cores_to_coordinator_done_semaphore_id,
         .core_type = tt::CoreType::WORKER,
         .core_ranges = all_core_set,
         .initial_value = 0,
@@ -1237,7 +1248,8 @@ ProgramDescriptor SortProgramFactorySingleRowMultiCore::create_descriptor(
          static_cast<uint32_t>(end_core_physical_coord.x),
          static_cast<uint32_t>(end_core_physical_coord.y),
          coordinator_to_cores_semaphore_id,
-         cores_to_coordinator_semaphore_id,
+         cores_to_coordinator_ready_semaphore_id,
+         cores_to_coordinator_done_semaphore_id,
          static_cast<uint32_t>(core_range.num_cores()),
          input_buffer,
          value_buffer,
@@ -1289,7 +1301,6 @@ ProgramDescriptor SortProgramFactorySingleRowMultiCore::create_descriptor(
     writer_compile_time_args.push_back(W_tile_bytes);
     writer_compile_time_args.push_back(W_index_bytes);
 
-
     KernelDescriptor writer_desc;
     writer_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/writer_single_row_multi_core.cpp";
@@ -1309,7 +1320,7 @@ ProgramDescriptor SortProgramFactorySingleRowMultiCore::create_descriptor(
                  static_cast<uint32_t>(coordinator_core_physical_coord.x),
                  static_cast<uint32_t>(coordinator_core_physical_coord.y),
                  coordinator_to_cores_semaphore_id,
-                 cores_to_coordinator_semaphore_id});
+                 cores_to_coordinator_ready_semaphore_id});
             writer_desc.emplace_runtime_args(
                 core,
                 {value_buffer,
@@ -1317,7 +1328,7 @@ ProgramDescriptor SortProgramFactorySingleRowMultiCore::create_descriptor(
                  static_cast<uint32_t>(coordinator_core_physical_coord.x),
                  static_cast<uint32_t>(coordinator_core_physical_coord.y),
                  coordinator_to_cores_semaphore_id,
-                 cores_to_coordinator_semaphore_id});
+                 cores_to_coordinator_done_semaphore_id});
         }
     }
 


### PR DESCRIPTION
### Problem

`ttnn.sort` on the **DRAM multi-core path** (`SortProgramFactorySingleRowMultiCore`) has a **latent deadlock** in the coordinator↔worker synchronization.

The coordinator collects two logically different worker signals on a **single** `cores_to_coordinator` semaphore:
- **readiness** — each reader increments it once per tile-row;
- **per-pair confirmations** — each writer increments it once per processed pair.

It consumes that counter with an **exact-match** wait (`noc_semaphore_wait` → `while (*sem != val)`). At a tile-row boundary (`Ht >= 2`) a fast reader's **next-row readiness** increment can land during the coordinator's confirmation window and push the counter **past** the exact target, so the wait never matches → the coordinator spins at `NSW` forever and all workers block on their CBs.

Naturally the exact-match poll out-races NoC-atomic increment spacing, so it is not hit on shipping shapes — but it is a real race.

### Reproduction (deterministic, via timing perturbation)

The multi-core path is only reached at power-of-two-padded `Wt > total_cores * 128` (e.g. `Wt = 16384`). Widening the readiness/confirmation overlap with a one-shot coordinator delay makes it deterministic:

```cpp
// coordinator_single_row_multi_core.cpp, right before the confirmation wait:
if (stage == stages && sub == 1) {
    for (volatile uint32_t k = 0; k < 300000000; ++k) { asm volatile("nop"); }
}
```

On `ttnn.sort([1,1,64,16384*32])` (Ht=2), WormholeB0, each run on a freshly `tt-smi -r` reset device:
- **without this fix** → deadlocks (3/3)
- **with this fix** → completes correctly (4/4)

### Fix

Split the overloaded `cores_to_coordinator` semaphore into two, one per producer signal:
- `cores_to_coordinator_ready` — reader readiness → coordinator readiness gate;
- `cores_to_coordinator_done` — writer per-pair confirmations → coordinator confirmation gate.

Each counter is then fed by a single signal type, so it always rests exactly on its target and the exact-match wait can never overshoot. Touches the coordinator/reader/writer dataflow kernels and `sort_program_factory.cpp` (adds a third `SemaphoreDescriptor`; passes ready/done to the kernels).

### Test

Adds `test_sort_multi_row_multi_core_no_deadlock`: sizes the width from the device grid so it lands on the DRAM multi-core factory, runs `Ht = 2`, and executes the op in a worker thread with a watchdog (+ `pytest-timeout`) so a deadlock **regression fails with an assertion instead of hanging the session**. Note: since the race is latent (needs timing pressure to surface), this test does not deterministically reproduce the hang on the pre-fix code — it guards correctness of the previously-`Ht==1`-only multi-core path and converts any future hang into a failure.

### Verification (WormholeB0, on-device)
- New test: passes (both `descending` params).
- `test_sort_long_tensor` (incl. the `Wt=16384` multi-core case): 7/7 pass.
- No regression: `test_sort_standard` + `test_sort_program_cache` + `test_sort_residual_core_range`: 42/42 pass.
- Forced-repro discriminator: buggy hangs 3/3, fixed completes 4/4 (identical perturbation, fresh-reset devices).

Fixes #50312. Refs #50154 (finding #6).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/sort-multicore-deadlock-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/sort-multicore-deadlock-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/sort-multicore-deadlock-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/sort-multicore-deadlock-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/sort-multicore-deadlock-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/sort-multicore-deadlock-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/sort-multicore-deadlock-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/sort-multicore-deadlock-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/sort-multicore-deadlock-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/sort-multicore-deadlock-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/sort-multicore-deadlock-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/sort-multicore-deadlock-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/sort-multicore-deadlock-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/sort-multicore-deadlock-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/sort-multicore-deadlock-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/sort-multicore-deadlock-fix)