### PR TITLE
Fix latent deadlock in multi-core reduce_all argmax (exact-match start_sem wait -> wait_min)

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_argmax.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_argmax.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import threading
 from itertools import chain
 
 import pytest
@@ -220,3 +221,54 @@ def test_argmax_nc_preallocated_output(device):
     ttnn_out = ttnn.zeros(list(out_shape), dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
     result = ttnn.argmax(ttnn_in, dim=1, keepdim=True, output_tensor=ttnn_out)
     assert_equal(ref, ttnn.to_torch(ttnn.from_device(result)).to(torch.int32))
+
+
+@pytest.mark.timeout(120, method="thread")
+def test_argmax_reduce_all_multicore_no_deadlock(device):
+    """
+    Guard for the multi-core reduce_all (whole-tensor) argmax path.
+
+    The reduce core signals each iteration via start_sem (set + multicast) and the
+    workers waited on it with an exact-match wait(k+1).  In the reduce_all path there
+    is no per-iteration done_sem back-pressure (it is lifted out of the k-loop), so the
+    reduce core free-runs and can advance start_sem past (k+1) before a lagging worker
+    samples it -- the exact-match wait then never observes k+1 and the op deadlocks
+    (workers stuck at noc_semaphore_wait).  The fix uses wait_min(k+1) (>=) on the
+    monotonically-increasing start_sem.
+
+    A ROW_MAJOR tensor with dim=None routes to the multi-core reduce_all reader; the
+    shape is large enough to split across many cores and run several k-iterations.  The
+    race is latent (timing-masked), so this does not deterministically fail on the
+    pre-fix code -- it guards correctness of the reduce_all multi-core path and, via the
+    worker-thread watchdog + pytest-timeout, converts a deadlock regression into an
+    assertion failure instead of a hung session.
+    """
+    torch.manual_seed(0)
+    t = torch.randn((64, 4096), dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(t, ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+
+    result = {}
+
+    def _run():
+        try:
+            out = ttnn.argmax(ttnn_in)  # dim=None -> reduce_all multi-core path
+            ttnn.synchronize_device(device)
+            result["out"] = out
+        except Exception as exc:  # surface device/compile errors to the main thread
+            result["error"] = exc
+
+    worker = threading.Thread(target=_run, daemon=True)
+    worker.start()
+    worker.join(timeout=60.0)
+
+    assert not worker.is_alive(), (
+        "ttnn.argmax(dim=None) did not complete on the multi-core reduce_all path: a worker's "
+        "start_sem wait was starved -- likely a regression of the wait_min fix (exact-match "
+        "wait deadlock when the reduce core laps the workers)."
+    )
+    if "error" in result:
+        raise result["error"]
+
+    ref = int(torch.argmax(t.reshape(-1)))
+    got = int(ttnn.to_torch(ttnn.from_device(result["out"])).item())
+    assert got == ref, f"argmax reduce_all mismatch: got {got}, expected {ref}"

--- a/tests/ttnn/unit_tests/operations/reduce/test_argmax.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_argmax.py
@@ -228,20 +228,17 @@ def test_argmax_reduce_all_multicore_no_deadlock(device):
     """
     Guard for the multi-core reduce_all (whole-tensor) argmax path.
 
-    The reduce core signals each iteration via start_sem (set + multicast) and the
-    workers waited on it with an exact-match wait(k+1).  In the reduce_all path there
-    is no per-iteration done_sem back-pressure (it is lifted out of the k-loop), so the
-    reduce core free-runs and can advance start_sem past (k+1) before a lagging worker
-    samples it -- the exact-match wait then never observes k+1 and the op deadlocks
-    (workers stuck at noc_semaphore_wait).  The fix uses wait_min(k+1) (>=) on the
-    monotonically-increasing start_sem.
+    The reduce core signals each iteration via start_sem (set + multicast), which increases
+    monotonically.  In the reduce_all path there is no per-iteration done_sem back-pressure (it is
+    lifted out of the k-loop), so the reduce core free-runs and can advance start_sem past a given
+    value before a lagging worker samples it.  Workers therefore wait with wait_min(k+1) (>=) rather
+    than an exact match, so a skipped-over value cannot strand a worker at noc_semaphore_wait and
+    deadlock the op.
 
-    A ROW_MAJOR tensor with dim=None routes to the multi-core reduce_all reader; the
-    shape is large enough to split across many cores and run several k-iterations.  The
-    race is latent (timing-masked), so this does not deterministically fail on the
-    pre-fix code -- it guards correctness of the reduce_all multi-core path and, via the
-    worker-thread watchdog + pytest-timeout, converts a deadlock regression into an
-    assertion failure instead of a hung session.
+    A ROW_MAJOR tensor with dim=None routes to the multi-core reduce_all reader; the shape is large
+    enough to split across many cores and run several k-iterations.  The check guards correctness of
+    the reduce_all multi-core path and, via the worker-thread watchdog + pytest-timeout, converts a
+    deadlock into an assertion failure instead of a hung session.
     """
     torch.manual_seed(0)
     t = torch.randn((64, 4096), dtype=torch.bfloat16)
@@ -263,8 +260,8 @@ def test_argmax_reduce_all_multicore_no_deadlock(device):
 
     assert not worker.is_alive(), (
         "ttnn.argmax(dim=None) did not complete on the multi-core reduce_all path: a worker's "
-        "start_sem wait was starved -- likely a regression of the wait_min fix (exact-match "
-        "wait deadlock when the reduce core laps the workers)."
+        "start_sem wait was starved -- workers must wait_min(>=) on the monotonic start_sem, since "
+        "an exact-match wait can be lapped by the free-running reduce core."
     )
     if "error" in result:
         raise result["error"]

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp
@@ -374,17 +374,21 @@ void kernel_main() {
                 }
 
                 if (num_cores1 > 0) {
-                    start_sem.set_multicast(
-                        noc, start_core_x1, start_core_y1, end_core_x1, end_core_y1, num_cores1);
+                    start_sem.set_multicast(noc, start_core_x1, start_core_y1, end_core_x1, end_core_y1, num_cores1);
                 }
 
                 noc.async_write_barrier();
             }
         }
 
-        // Wait to start
+        // Wait to start.  Use wait_min (>=) rather than exact-match: in the
+        // reduce_all path there is no per-iteration done_sem back-pressure (it is
+        // lifted out of this loop), so the reduce core free-runs and can advance
+        // start_sem past (k+1) before a lagging worker samples it.  An exact-match
+        // wait(k+1) would then never observe k+1 and deadlock; start_sem is
+        // monotonically increasing, so wait_min(k+1) is correct for both paths.
         if (k > 0) {
-            start_sem.wait(k + 1);
+            start_sem.wait_min(k + 1);
         }
 
         find_argmax_for_core<reduce_all, src_cb_addr_data_format>(


### PR DESCRIPTION
### Problem

Multi-core `ttnn.argmax` on the **reduce_all** path (`dim=None`, ROW_MAJOR) has a **latent deadlock**.

The reduce core signals each iteration `k` via `start_sem.set(k+1)` + multicast, and every core waits with an **exact-match** `start_sem.wait(k+1)` (`reader_argmax_interleaved_multicore.cpp`). The **not-reduce_all** path back-pressures each iteration with `done_sem.wait(num_cores)`, so the reduce core can't get ahead. In **reduce_all** that `done_sem` handshake is lifted out of the k-loop, so the reduce core free-runs and can advance `start_sem` to `k+2` (overwriting the workers' copy) before a lagging worker samples it. The worker's exact-match `wait(k+1)` then never matches → hang; the post-loop `done_sem.wait(num_cores)` never completes.

### Reproduction (deterministic, via timing perturbation)

`start_sem` normally isn't overshot (the reduce core is the heaviest actor), but there's no hard bound. Delaying the workers before the wait forces the reduce core to lap them:

```cpp
if (!is_reduce_core) { for (volatile uint32_t j=0; j<50000000; ++j) asm volatile("nop"); }  // before wait
```

`ttnn.argmax(randn(64,4096) ROW_MAJOR, dim=None)`, WormholeB0, each run on a freshly `tt-smi -r` reset device:
- **without the fix** → deadlocks (workers frozen at `noc_semaphore_wait`)
- **with the fix** → completes, correct output (3/3)

### Fix

`start_sem.wait(k+1)` → `start_sem.wait_min(k+1)` (`>=`, already in `dataflow_api.h`). `start_sem` is monotonically increasing so `>=` is correct; the back-pressured not-reduce_all path never overshoots and is unaffected. One-line kernel change.

### Test

Adds `test_argmax_reduce_all_multicore_no_deadlock`: a ROW_MAJOR `dim=None` argmax on a shape that routes to the multi-core reduce_all path, run in a worker thread with a watchdog (+ `pytest-timeout`) so a deadlock regression **fails an assertion instead of hanging the session**. The race is latent (needs timing pressure), so this guards correctness of the reduce_all multi-core path and converts any future hang into a failure rather than deterministically failing pre-fix.

### Verification (WormholeB0, on-device)
- Forced discriminator: buggy hangs (workers at `noc_semaphore_wait`), fixed completes correct (3/3), identical perturbation, fresh-reset devices.
- Full `test_argmax.py`: **67 passed** (new test + existing, no regression).

Fixes #50314. Refs #50154 (finding #7).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/argmax-reduce-all-deadlock-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/argmax-reduce-all-deadlock-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/argmax-reduce-all-deadlock-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/argmax-reduce-all-deadlock-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/argmax-reduce-all-deadlock-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/argmax-reduce-all-deadlock-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/argmax-reduce-all-deadlock-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/argmax-reduce-all-deadlock-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/argmax-reduce-all-deadlock-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/argmax-reduce-all-deadlock-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/argmax-reduce-all-deadlock-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/argmax-reduce-all-deadlock-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/argmax-reduce-all-deadlock-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/argmax-reduce-all-deadlock-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/argmax-reduce-all-deadlock-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/argmax-reduce-all-deadlock-fix)