### PR TITLE
Fix WAR in multi-core topk local writer (barrier before CB slot reuse)

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -393,18 +393,16 @@ def test_topk_preallocated_dtype_raise(value_dtype, index_dtype, device, expect_
 @pytest.mark.parametrize("largest", [True, False])
 def test_topk_multicore_local_write_correctness(largest, device):
     """
-    Guards the multi-core topk local-writer path (input width >= multi_core_min_width=8192,
-    so it routes to TopKMultiCoreProgramFactory + writer_local_topk).
+    Correctness guard for the multi-core topk local-writer path: an input width >= multi_core_min_width
+    (8192) routes to TopKMultiCoreProgramFactory + writer_local_topk, which NoC-writes each local-topk
+    tile from its CB slot to the final core and then cb_pop_front releases the slot back to the compute
+    producer. Correct aggregation at the final core relies on each write being drained before its slot is
+    reused; a regression there -- e.g. a WAR hazard where the producer's next pack_tile overwrites the
+    slot while the NoC write's source-read is still in flight -- would corrupt the landed values and make
+    this check fail.
 
-    writer_local_topk NoC-writes each local-topk tile from its CB slot to the final core, then
-    cb_pop_front releases that slot to the compute producer.  Without a write barrier before the
-    pop, the producer's next pack_tile can overwrite the slot while the NoC write's source-read is
-    still in flight (WAR), corrupting the values landed at the final core.  This checks the
-    multi-core aggregation produces correct top-k values.
-
-    The race is latent (masked by the compute-pack latency), so this does not fail deterministically
-    on the pre-fix code; it is a fast correctness guard for the multi-core write path (a
-    forced-corruption reproducer that clobbers the source slot before the flush is documented in the PR).
+    This is a value-correctness guard, not a deterministic race reproducer: such a WAR is latent (masked
+    by compute-pack latency), so it would not necessarily surface on every run.
     """
     torch.manual_seed(2005)
     W, k = 8192, 32  # W >= 8192 -> multi-core path; k=32 -> Kt=1

--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -340,7 +340,7 @@ def test_topk_bfloat8_with_inf(N, C, H, W, dim, k, sub_core_grids, device):
         (torch.int32, ttnn.int32),
     ],
 )
-def test_topk_input_dtypes_raise(torch_input_tensor_dtype, ttnn_input_tensor_dtype, device):
+def test_topk_input_dtypes_raise(torch_input_tensor_dtype, ttnn_input_tensor_dtype, device, expect_error):
     torch.manual_seed(0)
     shape = [1, 1, 32, 64]
 
@@ -351,7 +351,7 @@ def test_topk_input_dtypes_raise(torch_input_tensor_dtype, ttnn_input_tensor_dty
 
     ttnn_input = ttnn.from_torch(input_torch, ttnn_input_tensor_dtype, layout=ttnn.Layout.TILE, device=device)
 
-    with pytest.raises(Exception):
+    with expect_error(RuntimeError, "Input tensor must be BFLOAT16, or BFLOAT8_B"):
         ttnn.topk(ttnn_input, k=32, dim=-1, largest=True, sorted=True)
 
 
@@ -366,18 +366,28 @@ def test_topk_input_dtypes_raise(torch_input_tensor_dtype, ttnn_input_tensor_dty
         (ttnn.bfloat16, ttnn.bfloat16),
     ],
 )
-def test_topk_preallocated_dtype_raise(value_dtype, index_dtype, device):
+def test_topk_preallocated_dtype_raise(value_dtype, index_dtype, device, expect_error):
     torch.manual_seed(0)
+    k = 32
     shape = [1, 1, 32, 64]
+    output_shape = [1, 1, 32, k]
 
     input_torch = torch.randn(shape, dtype=torch.bfloat16)
     ttnn_input = ttnn.from_torch(input_torch, ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device)
 
-    value_tensor = ttnn.empty_like(ttnn_input, dtype=value_dtype)
-    index_tensor = ttnn.empty_like(ttnn_input, dtype=index_dtype)
+    # Preallocated outputs must carry the topk output shape ([..., k]); allocating at the input shape would
+    # trip the shape check in topk() before dtype validation is reached and defeat the purpose of this test.
+    output_torch = torch.zeros(output_shape, dtype=torch.bfloat16)
+    value_tensor = ttnn.from_torch(output_torch, value_dtype, layout=ttnn.Layout.TILE, device=device)
+    index_tensor = ttnn.from_torch(output_torch, index_dtype, layout=ttnn.Layout.TILE, device=device)
 
-    with pytest.raises(Exception):
-        ttnn.topk(ttnn_input, k=32, dim=-1, largest=True, sorted=True, output_tensor=(value_tensor, index_tensor))
+    # The value dtype must be BFLOAT16/BFLOAT8_B and the index dtype UINT16/UINT32; match whichever is
+    # violated first for the given parametrization.
+    with expect_error(
+        RuntimeError,
+        "Preallocated (output tensor must be BFLOAT16 or BFLOAT8_B|indices tensor must be UINT16 or UINT32)",
+    ):
+        ttnn.topk(ttnn_input, k=k, dim=-1, largest=True, sorted=True, output_tensor=(value_tensor, index_tensor))
 
 
 @pytest.mark.parametrize("largest", [True, False])

--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -378,3 +378,36 @@ def test_topk_preallocated_dtype_raise(value_dtype, index_dtype, device):
 
     with pytest.raises(Exception):
         ttnn.topk(ttnn_input, k=32, dim=-1, largest=True, sorted=True, output_tensor=(value_tensor, index_tensor))
+
+
+@pytest.mark.parametrize("largest", [True, False])
+def test_topk_multicore_local_write_correctness(largest, device):
+    """
+    Guards the multi-core topk local-writer path (input width >= multi_core_min_width=8192,
+    so it routes to TopKMultiCoreProgramFactory + writer_local_topk).
+
+    writer_local_topk NoC-writes each local-topk tile from its CB slot to the final core, then
+    cb_pop_front releases that slot to the compute producer.  Without a write barrier before the
+    pop, the producer's next pack_tile can overwrite the slot while the NoC write's source-read is
+    still in flight (WAR), corrupting the values landed at the final core.  This checks the
+    multi-core aggregation produces correct top-k values.
+
+    The race is latent (masked by the compute-pack latency), so this does not fail deterministically
+    on the pre-fix code; it is a fast correctness guard for the multi-core write path (a
+    forced-corruption reproducer that clobbers the source slot before the flush is documented in the PR).
+    """
+    torch.manual_seed(2005)
+    W, k = 8192, 32  # W >= 8192 -> multi-core path; k=32 -> Kt=1
+    t = torch.randn((1, 1, 32, W), dtype=torch.bfloat16)
+    x = ttnn.from_torch(t, ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    v, i = ttnn.topk(x, k, dim=-1, largest=largest, sorted=True)
+    ttnn.synchronize_device(device)
+
+    got = ttnn.to_torch(v).float()
+    ref, _ = torch.topk(t.float(), k, dim=-1, largest=largest, sorted=True)
+    # Compare the (order-insensitive) set of top-k values per row.
+    got_s = got.sort(dim=-1, descending=True).values
+    ref_s = ref.sort(dim=-1, descending=True).values
+    assert torch.allclose(
+        got_s, ref_s, atol=1e-2
+    ), f"multi-core topk values mismatch (WAR regression?): max_diff={(got_s - ref_s).abs().max():.4f}"

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_local_topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_local_topk.cpp
@@ -13,17 +13,17 @@ void kernel_main() {
     const uint32_t start_wt = get_arg_val<uint32_t>(0);
 
     // Compile time args
-    constexpr uint32_t receiver_sem_id = get_compile_time_arg_val(0);                // Final core readiness signal
-    constexpr uint32_t sender_sem_id = get_compile_time_arg_val(1);                  // Local core completion signal
-    constexpr uint32_t noc_final_x = get_compile_time_arg_val(2);                    // Final core X coordinate
-    constexpr uint32_t noc_final_y = get_compile_time_arg_val(3);                    // Final core Y coordinate
-    constexpr uint32_t Ht = get_compile_time_arg_val(4);                             // Height tiles to process
-    constexpr uint32_t K = get_compile_time_arg_val(5);                              // TopK value
-    constexpr uint32_t Kt = get_compile_time_arg_val(6);                             // TopK in tile units (ceil(K/32))
-    constexpr uint32_t values_cb_index = get_compile_time_arg_val(7);                // Local TopK values output
-    constexpr uint32_t output_ind_cb_index = get_compile_time_arg_val(8);            // Local TopK indices output
-    constexpr uint32_t final_values_cb_index = get_compile_time_arg_val(9);          // Final aggregation values buffer
-    constexpr uint32_t final_indices_cb_index = get_compile_time_arg_val(10);        // Final aggregation indices buffer
+    constexpr uint32_t receiver_sem_id = get_compile_time_arg_val(0);          // Final core readiness signal
+    constexpr uint32_t sender_sem_id = get_compile_time_arg_val(1);            // Local core completion signal
+    constexpr uint32_t noc_final_x = get_compile_time_arg_val(2);              // Final core X coordinate
+    constexpr uint32_t noc_final_y = get_compile_time_arg_val(3);              // Final core Y coordinate
+    constexpr uint32_t Ht = get_compile_time_arg_val(4);                       // Height tiles to process
+    constexpr uint32_t K = get_compile_time_arg_val(5);                        // TopK value
+    constexpr uint32_t Kt = get_compile_time_arg_val(6);                       // TopK in tile units (ceil(K/32))
+    constexpr uint32_t values_cb_index = get_compile_time_arg_val(7);          // Local TopK values output
+    constexpr uint32_t output_ind_cb_index = get_compile_time_arg_val(8);      // Local TopK indices output
+    constexpr uint32_t final_values_cb_index = get_compile_time_arg_val(9);    // Final aggregation values buffer
+    constexpr uint32_t final_indices_cb_index = get_compile_time_arg_val(10);  // Final aggregation indices buffer
 
     // Constants
     constexpr uint32_t onetile = 1;
@@ -67,6 +67,11 @@ void kernel_main() {
                 tile_bytes_values,
                 {.offset_bytes = 0},
                 {.noc_x = noc_final_x, .noc_y = noc_final_y, .addr = final_values_base + i * tile_bytes_values});
+            // Drain the write's source-read before releasing the slot for reuse by the compute
+            // producer: cb_pop_front only advances the read pointer, so without this barrier the
+            // producer's next pack_tile could overwrite this slot while the NoC write is still
+            // reading it (WAR), corrupting the data landed at the final core.
+            noc.async_write_barrier();
             values_cb.pop_front(onetile);
         }  // i loop
 
@@ -82,11 +87,11 @@ void kernel_main() {
                 tile_bytes_ind,
                 {.offset_bytes = 0},
                 {.noc_x = noc_final_x, .noc_y = noc_final_y, .addr = final_indices_base + i * tile_bytes_ind});
+            noc.async_write_barrier();  // drain before releasing the slot for producer reuse (WAR)
             indices_cb.pop_front(onetile);
         }  // i loop
 
-        // Complete all pending NoC writes
-        noc.async_write_barrier();  // Ensure all data is transmitted before signaling
+        // All per-tile writes were drained before their slots were popped above.
 
         // Signal completion: increment sender semaphore by Kt (number of tiles sent)
         sender_sem.up(noc, noc_final_x, noc_final_y, Kt);


### PR DESCRIPTION
### Problem
Multi-core `ttnn.topk` (width ≥ 8192) has a latent WAR in `writer_local_topk`: each local-topk tile is NoC-written from its CB slot, then `cb_pop_front`'d (releasing the slot to the compute producer) while the only write barrier is *after* both send loops. The producer's next `pack_tile` can overwrite the slot while the write's source-read is still in flight → corrupted values at the final core.

### Reproduction (forced)
Clobbering the source slot right after the `async_write` (collapsing the WAR margin): `ttnn.topk(randn(1,1,32,8192), k=32)` returns the clobber pattern (mismatch vs torch); with the barrier before the pop → correct. Latent in production.

### Fix
`noc.async_write_barrier()` before each `cb_pop_front` (canonical wait_front→write→barrier→pop); trailing redundant barrier removed. Only touches the multi-core writer.

### Verification (WormholeB0)
- Forced discriminator: buggy+clobber corrupts (clobber pattern in output), fix+clobber correct.
- Multi-core correctness (W=8192/16384, k=32/64) matches torch; new fast W=8192 guard added; existing `test_topk_large_2d_shapes` (W=151936/128256) unaffected.

Fixes #50317. Refs #50154 (finding #25).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/topk-local-war-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/topk-local-war-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/topk-local-war-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/topk-local-war-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/topk-local-war-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/topk-local-war-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/topk-local-war-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/topk-local-war-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/topk-local-war-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/topk-local-war-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/topk-local-war-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/topk-local-war-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/topk-local-war-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/topk-local-war-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/topk-local-war-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/topk-local-war-flush)