### PR TITLE
Fix WAR on source_buffer in row-major interleaved reshape

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_reshape.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_reshape.py
@@ -907,3 +907,31 @@ def test_reshape_4d_5d_layout(device):
 
     diff = (result.float() - expected.float()).abs().max().item()
     assert diff == 0.0
+
+
+@pytest.mark.parametrize(
+    "input_shape, output_shape",
+    [
+        ((128, 4096), (64, 8192)),  # 128 source rows -> >1 page per core; wide rows (multi-packet writes)
+        ((256, 2048), (128, 4096)),
+    ],
+)
+def test_reshape_rm_interleaved_wide_multi_page(device, input_shape, output_shape):
+    """
+    Guards the row-major interleaved reshape data-movement kernel (rm_reshape_interleaved) on the
+    write-after-read-prone path: DRAM row-major input, 16B-aligned wide rows (the clean async_write
+    branch), and >1 source page per core.
+
+    That kernel reuses a single L1 source_buffer slot every iteration; the next iteration's read can
+    overwrite it while the previous iteration's async_write is still reading it (WAR).  A
+    noc.async_writes_flushed() before the read closes the window.  The race is latent (masked by
+    read/write latency), so this is a correctness guard for that path; a forced-corruption reproducer
+    (clobbering source_buffer before the read) is documented in the PR.
+    """
+    torch.manual_seed(0)
+    t = torch.randn(*input_shape, dtype=torch.bfloat16)
+    x = ttnn.from_torch(
+        t, ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    y = ttnn.reshape(x, output_shape)
+    assert_equal(t.reshape(*output_shape), ttnn.to_torch(y))

--- a/tests/ttnn/unit_tests/base_functionality/test_reshape.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_reshape.py
@@ -918,15 +918,14 @@ def test_reshape_4d_5d_layout(device):
 )
 def test_reshape_rm_interleaved_wide_multi_page(device, input_shape, output_shape):
     """
-    Guards the row-major interleaved reshape data-movement kernel (rm_reshape_interleaved) on the
-    write-after-read-prone path: DRAM row-major input, 16B-aligned wide rows (the clean async_write
+    Correctness guard for the row-major interleaved reshape data-movement kernel (rm_reshape_interleaved)
+    on the wide multi-page path: DRAM row-major input, 16B-aligned wide rows (the clean async_write
     branch), and >1 source page per core.
 
-    That kernel reuses a single L1 source_buffer slot every iteration; the next iteration's read can
-    overwrite it while the previous iteration's async_write is still reading it (WAR).  A
-    noc.async_writes_flushed() before the read closes the window.  The race is latent (masked by
-    read/write latency), so this is a correctness guard for that path; a forced-corruption reproducer
-    (clobbering source_buffer before the read) is documented in the PR.
+    The kernel reuses a single L1 source_buffer slot every iteration, so correct output relies on each
+    async_write draining before the next iteration's read reuses that slot; otherwise the read would
+    overwrite the buffer while the prior write is still sourcing from it (WAR) and corrupt the result.
+    This checks the wide multi-page RM path produces the expected reshape.
     """
     torch.manual_seed(0)
     t = torch.randn(*input_shape, dtype=torch.bfloat16)

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/rm_reshape_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/rm_reshape_interleaved.cpp
@@ -111,11 +111,11 @@ void kernel_main() {
         }
 
         readable = source_page_size_bytes;
-        noc_async_read_barrier();
+        noc.async_read_barrier();
 
         // Write to dest
         while (readable > 0) {
-            noc_async_write_barrier();
+            noc.async_write_barrier();
             if (readable < writable) {
                 if constexpr (can_be_clean) {
                     tt::data_movement::common::enhanced_noc_async_write<dest_page_size_bytes, false>(
@@ -127,7 +127,7 @@ void kernel_main() {
                     if (i == read_end_page - 1) {
                         tt::data_movement::common::enhanced_noc_async_write<dest_page_size_bytes, false>(
                             noc, dest_buffer + begin_write_offset, dst_noc_addr, end_to_write);
-                        noc_async_write_barrier();
+                        noc.async_write_barrier();
                         return;
                     }
                     write_offset = write_offset + readable;
@@ -151,7 +151,7 @@ void kernel_main() {
                 writable = dest_page_size_bytes;
                 readable = 0;
                 if (i == read_end_page - 1) {
-                    noc_async_write_barrier();
+                    noc.async_write_barrier();
                     return;
                 }
                 write_page++;
@@ -186,6 +186,6 @@ void kernel_main() {
             }
         }
     }
-    noc_async_write_barrier();
+    noc.async_write_barrier();
     return;
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/rm_reshape_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/rm_reshape_interleaved.cpp
@@ -35,9 +35,10 @@ Runtime arguments
 void kernel_main() {
     // We are guaranteed to be in 2D going to 2D
 
-    const uint32_t src_addr                 = get_arg_val<uint32_t>(0);
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
     const uint32_t dst_addr = get_arg_val<uint32_t>(1);
-    //If DDR this is source_page_size_bytes + 64 (rounded up to next 64B), if L1 this is source_page_size_bytes + 16 (rounded up to next 16B)
+    // If DDR this is source_page_size_bytes + 64 (rounded up to next 64B), if L1 this is source_page_size_bytes + 16
+    // (rounded up to next 16B)
     const uint32_t source_read_size_bytes = get_arg_val<uint32_t>(2);
     const uint32_t read_start_page = get_arg_val<uint32_t>(3);
     const uint32_t read_end_page = get_arg_val<uint32_t>(4);
@@ -54,9 +55,9 @@ void kernel_main() {
     constexpr auto src_args = TensorAccessorArgs<6>();
     constexpr auto dst_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
 
-    //Since we need to operate on a grid of cores but sometimes pages don't split properly, if nop then don't use this core
-    if (nop == 1)
-    {
+    // Since we need to operate on a grid of cores but sometimes pages don't split properly, if nop then don't use this
+    // core
+    if (nop == 1) {
         return;
     }
 
@@ -70,8 +71,8 @@ void kernel_main() {
     uint32_t end_to_write = 0;
     uint32_t transaction = 0;
     uint32_t writable = dest_page_size_bytes - write_start_offset;
-    //cb_id_in0 is a CB source_read_size_bytes page size, 1 page
-    //cb_id_in1 is a CB dest_page_size_bytes + allignment_to_64 page size, 1 page
+    // cb_id_in0 is a CB source_read_size_bytes page size, 1 page
+    // cb_id_in1 is a CB dest_page_size_bytes + allignment_to_64 page size, 1 page
     cb_reserve_back(cb_id_in0, 1);
     cb_reserve_back(cb_id_in1, 1);
     const uint32_t source_buffer = get_write_ptr(cb_id_in0);
@@ -85,8 +86,14 @@ void kernel_main() {
     constexpr bool can_be_clean = ((source_page_size_bytes % 16) == 0 && (dest_page_size_bytes % 16) == 0);
     uint64_t dst_noc_addr_offset = 0;
     for (uint32_t i = read_start_page; i < read_end_page; i++) {
-        //Read from source
-        uint64_t src_noc_addr = s.get_noc_addr(i,0);
+        // Drain any prior iteration's writes that read source_buffer before this iteration's read
+        // overwrites it: source_buffer is a single fixed CB slot reused every iteration, and the
+        // clean-path enhanced_noc_async_write below reads it asynchronously.  Without this flush the
+        // next read can overwrite the slot while the previous write's source-read is still in flight
+        // (write-after-read), corrupting the output.  Uses the object-noc flush to match the writes.
+        noc.async_writes_flushed();
+        // Read from source
+        uint64_t src_noc_addr = s.get_noc_addr(i, 0);
 
         if constexpr (src_aligned_to_64 || ((!src_args.is_dram) && src_aligned_to_16)) {  // Aligned to 64 bytes or 16
                                                                                           // bytes but L1
@@ -106,12 +113,10 @@ void kernel_main() {
         readable = source_page_size_bytes;
         noc_async_read_barrier();
 
-        //Write to dest
-        while (readable > 0)
-        {
+        // Write to dest
+        while (readable > 0) {
             noc_async_write_barrier();
-            if (readable < writable)
-            {
+            if (readable < writable) {
                 if constexpr (can_be_clean) {
                     tt::data_movement::common::enhanced_noc_async_write<dest_page_size_bytes, false>(
                         noc, source_buffer + read_offset, dst_noc_addr + dst_noc_addr_offset, readable);
@@ -131,9 +136,7 @@ void kernel_main() {
                 writable = writable - readable;
                 readable = 0;
 
-            }
-            else if (readable == writable)
-            {
+            } else if (readable == writable) {
                 if constexpr (can_be_clean) {
                     tt::data_movement::common::enhanced_noc_async_write<dest_page_size_bytes, false>(
                         noc, source_buffer + read_offset, dst_noc_addr + dst_noc_addr_offset, readable);
@@ -158,9 +161,7 @@ void kernel_main() {
                     write_offset = dst_noc_addr & OFFSET_16;
                     begin_write_offset = write_offset;
                 }
-            }
-            else
-            {
+            } else {
                 if constexpr (can_be_clean) {
                     tt::data_movement::common::enhanced_noc_async_write<dest_page_size_bytes, false>(
                         noc, source_buffer + read_offset, dst_noc_addr + dst_noc_addr_offset, writable);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/device/device/rm_reshape_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/device/device/rm_reshape_interleaved.cpp
@@ -90,6 +90,12 @@ void kernel_main() {
     constexpr bool can_be_clean = ((source_page_size_bytes % 16) == 0 && (dest_page_size_bytes % 16) == 0);
     uint64_t dst_noc_addr_offset = 0;
     for (uint32_t i = read_start_page; i < read_end_page; i++) {
+        // Drain any prior iteration's writes that read source_buffer before this iteration's read
+        // overwrites it: source_buffer is a single fixed CB slot reused every iteration, and the
+        // clean-path enhanced_noc_async_write below reads it asynchronously.  Without this flush the
+        // next read can overwrite the slot while the previous write's source-read is still in flight
+        // (write-after-read), corrupting the output.  Uses the object-noc flush to match the writes.
+        noc.async_writes_flushed();
         // Read from source
         uint64_t src_noc_addr = s.get_noc_addr(i, 0);
 


### PR DESCRIPTION
## Summary
`rm_reshape_interleaved` (row-major interleaved reshape) has a **latent WAR** on its single fixed L1 `source_buffer` slot. Each loop iteration reads a source page into `source_buffer`, then the clean-path `enhanced_noc_async_write` reads `source_buffer` asynchronously to the destination. The next iteration's read overwrites `source_buffer` with no barrier draining the previous write's source-read first → a straggler write can read the next page's data (write-after-read) → corrupted output.

## Reproduction (forced)
Clobbering `source_buffer` at the top of the loop (collapsing the WAR margin): `ttnn.reshape([128,4096]→[64,8192])` (RM/DRAM, >1 page per core, wide rows) mismatches `torch.reshape` by thousands of elements; with the flush before the read it's bit-exact. Latent in production (clean reshape is correct).

## Fix
`noc.async_writes_flushed()` before each iteration's read. Note: must use the **object** noc that issued the writes — the global `noc_async_writes_flushed()` targets a different NoC and does not drain them (a refinement of the audit's suggested fix).

Refs #50154 (finding #14). Fixes this issue.

Verification (WormholeB0): buggy+clobber corrupts ([128,4096]->[64,8192], thousands of mismatches); fix+clobber correct; clean reshape correctness across shapes unaffected; new wide multi-page RM guard added. Fixes #50323. Refs #50154 (finding #14).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/reshape-rm-war-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/reshape-rm-war-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/reshape-rm-war-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/reshape-rm-war-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/reshape-rm-war-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/reshape-rm-war-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/reshape-rm-war-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/reshape-rm-war-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/reshape-rm-war-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/reshape-rm-war-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/reshape-rm-war-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/reshape-rm-war-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/reshape-rm-war-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/reshape-rm-war-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/reshape-rm-war-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/reshape-rm-war-flush)