### PR TITLE
[MiniMax-M3] prefill perf harness: whole-sequence + last-chunk timing

### DIFF
--- a/models/demos/minimax_m3/tests/galaxy_prefill_kv_pcc.py
+++ b/models/demos/minimax_m3/tests/galaxy_prefill_kv_pcc.py
@@ -13,6 +13,7 @@ Env:
   PREFILL_CHUNKED     "1" -> chunked prefill (chunk loop, cache-read path); "0" -> one-shot  [default 0]
   PREFILL_CHUNK_SIZE  chunk size in tokens (chunked mode)                                  [default 5120]
   PREFILL_TPS_ITERS   prefill repetitions for the throughput measurement (less noise)      [default 1]
+  PREFILL_SKIP_PCC    "1" -> perf only: skip the per-layer golden KV PCC (no kv_cache/ needed) [default 0]
   PREFILL_NUM_LAYERS  build/run only the first N decoder layers (faster partial-model runs; also auto-sets
                       M3_LOAD_NLAYERS so only those layers' weight shards are read)          [default: all]
   EXPERT_DTYPE        MoE routed-expert weight dtype: "bf4" or "bf8" (cache holds both)      [default bf4]
@@ -248,37 +249,68 @@ def main():
         print(f"[prefill-pcc] compiling ({num_layers}L, SP=8 × TP=4 + EP=32) ...", flush=True)
         runtime.compile(kv_cache)
 
-        # --- throughput: each iteration re-fills slot 0; the cache is valid after the last ---
+        # --- throughput. Each iteration re-fills slot 0 (valid for the PCC check after the loop) and
+        # times two distinct full-prefill passes, each with syncs placed so it pays for no extra barrier:
+        #   WHOLE SEQUENCE  all n_chunks cold from an empty cache, ONE sync at the very end
+        #                   -> time to prefill the whole prompt         (e.g. 55k @ 0 cache)
+        #   LAST CHUNK      pre-fill chunks 0..n-2, sync ONCE (barrier, NOT timed), then time only the
+        #                   final chunk against that accumulated cache   (e.g. 5k @ 50k cache)
         padded = token_ids + [0] * (total - n_tokens)
+        a_last = (n_chunks - 1) * chunk  # context tokens already in cache ahead of the final chunk
+        last_len = min(a_last + chunk, total) - a_last  # width of the final chunk (incl pad)
 
-        def run_once():
+        def prefill_chunk(c):
+            a = c * chunk
+            inp = runtime.make_chunk_input(padded[a : a + chunk])
+            runtime.prefill_chunk(inp, kv_cache, slot_id=0, actual_start=a, actual_end=min(a + chunk, n_tokens))
+
+        def run_whole():  # cold, no mid-loop syncs — one barrier at the end
             for c in range(n_chunks):
-                a = c * chunk
-                inp = runtime.make_chunk_input(padded[a : a + chunk])
-                runtime.prefill_chunk(inp, kv_cache, slot_id=0, actual_start=a, actual_end=min(a + chunk, n_tokens))
+                prefill_chunk(c)
             ttnn.synchronize_device(mesh)
 
-        times = []
+        def run_last_chunk():  # returns the timed last-chunk wall seconds
+            for c in range(n_chunks - 1):
+                prefill_chunk(c)
+            ttnn.synchronize_device(mesh)  # barrier before the timed region — NOT counted
+            t0 = time.perf_counter()
+            prefill_chunk(n_chunks - 1)
+            ttnn.synchronize_device(mesh)
+            return time.perf_counter() - t0
+
+        whole_times, last_times = [], []
         for i in range(tps_iters):
             t0 = time.perf_counter()
-            run_once()
-            dt = time.perf_counter() - t0
-            times.append(dt)
+            run_whole()
+            whole_times.append(time.perf_counter() - t0)
+            last_times.append(run_last_chunk())
             print(
-                f"[prefill-pcc] iter {i}: {dt * 1000:.1f} ms  "
-                f"{n_tokens / dt:.1f} tok/s (real)  {total / dt:.1f} tok/s (incl pad)",
+                f"[prefill-pcc] iter {i}: whole {whole_times[-1] * 1000:.1f} ms  "
+                f"last_chunk {last_times[-1] * 1000:.1f} ms",
                 flush=True,
             )
-        med = statistics.median(times)
+
+        w = statistics.median(whole_times)
         print(
-            f"[prefill-pcc] THROUGHPUT over {tps_iters} iters: median {n_tokens / med:.1f} tok/s (real prompt), "
-            f"{total / med:.1f} tok/s (processed); wall median {med * 1000:.1f} ms "
-            f"[min {min(times) * 1000:.1f}, max {max(times) * 1000:.1f}]",
+            f"[prefill-pcc] WHOLE SEQUENCE over {tps_iters} iters: {n_tokens} tok @ 0 cache, "
+            f"median {n_tokens / w:.1f} tok/s (real prompt), {total / w:.1f} tok/s (processed); "
+            f"wall median {w * 1000:.1f} ms [min {min(whole_times) * 1000:.1f}, max {max(whole_times) * 1000:.1f}]",
+            flush=True,
+        )
+        lc = statistics.median(last_times)
+        print(
+            f"[prefill-pcc] LAST CHUNK over {tps_iters} iters: {last_len} tok @ {a_last} cache, "
+            f"median {last_len / lc:.1f} tok/s; "
+            f"wall median {lc * 1000:.1f} ms [min {min(last_times) * 1000:.1f}, max {max(last_times) * 1000:.1f}]",
             flush=True,
         )
 
-        # --- accuracy: per-layer KV PCC vs golden ---
-        check_kv_pcc(runtime, kv_cache, golden_dir, n_tokens, num_layers, hf_config)
+        # --- accuracy: per-layer KV PCC vs golden (skipped in perf-only mode; synthetic
+        # traces carry only metadata.json, so there is no golden KV cache to compare against) ---
+        if os.environ.get("PREFILL_SKIP_PCC") == "1":
+            print("[prefill-pcc] PREFILL_SKIP_PCC=1 -> skipping per-layer KV PCC", flush=True)
+        else:
+            check_kv_pcc(runtime, kv_cache, golden_dir, n_tokens, num_layers, hf_config)
         print("[prefill-pcc] DONE", flush=True)
     finally:
         ttnn.close_mesh_device(mesh)


### PR DESCRIPTION
## Small tweak to galaxy_prefill_kv_pcc.py (perf-measurement harness only, no model/runtime code):

- Two timing passes per iteration instead of one:
  - `WHOLE SEQUENCE` — all chunks cold from an empty cache (e.g. 55k @ 0 cache)
  - `LAST CHUNK` — pre-fill all but the last chunk, sync (untimed), then time only the final chunk against the accumulated cache (e.g. 5k @ 50k cache)
  - Syncs are placed so neither measurement pays for an extra barrier.
- `PREFILL_SKIP_PCC=1` — skip the per-layer golden KV PCC for perf-only runs (synthetic traces have only metadata.json, no golden kv_cache/ to compare against).

Test-only change; no functional impact on the model

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=philei/m3-prefill-perf-whole-last-chunk)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:philei/m3-prefill-perf-whole-last-chunk)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=philei/m3-prefill-perf-whole-last-chunk)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:philei/m3-prefill-perf-whole-last-chunk)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=philei/m3-prefill-perf-whole-last-chunk)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:philei/m3-prefill-perf-whole-last-chunk)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=philei/m3-prefill-perf-whole-last-chunk)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:philei/m3-prefill-perf-whole-last-chunk)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=philei/m3-prefill-perf-whole-last-chunk)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:philei/m3-prefill-perf-whole-last-chunk)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=philei/m3-prefill-perf-whole-last-chunk)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:philei/m3-prefill-perf-whole-last-chunk)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=philei/m3-prefill-perf-whole-last-chunk)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:philei/m3-prefill-perf-whole-last-chunk)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=philei/m3-prefill-perf-whole-last-chunk)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:philei/m3-prefill-perf-whole-last-chunk)