### PR TITLE
[emule] Bound JIT compile fan-out to the fd limit (fix EMFILE on large mesh programs)

### DIFF
--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -10,6 +10,7 @@
 #include <dlfcn.h>
 #include <unistd.h>
 #include <sys/types.h>
+#include <sys/resource.h>  // getrlimit(RLIMIT_NOFILE) — bound JIT compile fan-out under the fd limit
 #include <csignal>
 #if defined(__x86_64__) && defined(__linux__)
 #include <ucontext.h>
@@ -19,6 +20,8 @@
 #include <bit>
 #include <atomic>
 #include <cassert>
+#include <cerrno>
+#include <limits>
 #include <tt_stl/assert.hpp>
 #include <cstdio>
 #include <cstdlib>
@@ -31,6 +34,7 @@
 #include <memory>
 #include <mutex>
 #include <regex>
+#include <semaphore>
 #include <set>
 #include <sstream>
 #include <stdexcept>
@@ -1753,6 +1757,68 @@ static std::mutex g_compile_inflight_mutex;
 static std::unordered_map<std::string, std::shared_future<std::function<void()>>> g_compile_inflight;
 static std::atomic<uint64_t> g_compile_tmp_seq{0};
 
+// Max jit_compile_kernel calls allowed to run concurrently. Each in-flight compile
+// holds a burst of open file descriptors (patched-header mirror writes, header reads,
+// the clang subprocess pipes — order tens of fds each), so an UNBOUNDED std::async
+// fan-out over every cache-miss makes peak fd use scale with the kernel count.
+// A large mesh program (8-chip loudbox on the full 14x10 grid compiles ~hundreds
+// of distinct kernels) then blows past a container's RLIMIT_NOFILE soft limit
+// (commonly 1024) → open() fails mid-compile → "kernel_patcher: cannot read/write"
+// (and the failing file varies run-to-run with the interleaving). A dev box with a
+// high fd limit (e.g. 65536) never hits it, so this is CI/container-only. Bounding
+// concurrent compiles keeps peak fds (and concurrent clang processes) under the
+// limit. Note this bounds concurrent *compiles*, not the thread count: std::async
+// still spawns one thread per cache-miss which then blocks on the gate — the fd/
+// clang-process footprint is what EMFILE cares about here.
+static unsigned jit_compile_concurrency_cap() {
+    // First, opportunistically raise the soft fd limit to the hard limit — unprivileged
+    // and enough on its own in most containers (large hard limit), so the throttle
+    // rarely engages on well-provisioned hosts. Kept as a floor because some containers
+    // pin the hard limit at 1024 too; derive the cap from the (possibly raised) soft limit.
+    struct rlimit rl {};
+    if (getrlimit(RLIMIT_NOFILE, &rl) == 0 && rl.rlim_cur != rl.rlim_max) {
+        rl.rlim_cur = rl.rlim_max;
+        setrlimit(RLIMIT_NOFILE, &rl);
+        getrlimit(RLIMIT_NOFILE, &rl);  // re-read the effective soft limit
+    }
+
+    unsigned cap = std::max(1u, std::thread::hardware_concurrency());
+    if (rl.rlim_cur != RLIM_INFINITY) {
+        // Budget the fd limit across concurrent compiles. kReserve covers the process's
+        // baseline fds (libs, python, fibers, the cached kernel .sos); kFdsPerCompile is
+        // an estimate of the fds one compile holds at its peak (patched-header writes +
+        // header reads + clang pipes). Both are conservative estimates, not measured; the
+        // soft→hard raise above and TT_EMULE_JIT_COMPILE_JOBS relieve any over-throttling.
+        constexpr rlim_t kReserve = 512;
+        constexpr rlim_t kFdsPerCompile = 48;
+        rlim_t budget = rl.rlim_cur > kReserve ? (rl.rlim_cur - kReserve) / kFdsPerCompile : 1;
+        cap = std::min<unsigned>(cap, std::max<rlim_t>(1, budget));
+    }
+
+    // Explicit override for tuning/debug. Only a fully-parsed, in-range, nonzero value
+    // wins; anything malformed (sign, trailing junk, overflow, 0) keeps the fd-derived
+    // cap rather than silently disabling the gate (e.g. "-1" must not become UINT_MAX).
+    if (const char* s = std::getenv("TT_EMULE_JIT_COMPILE_JOBS")) {
+        errno = 0;
+        char* end = nullptr;
+        unsigned long v = std::strtoul(s, &end, 10);
+        if (end != s && *end == '\0' && errno == 0 && v > 0 && v <= std::numeric_limits<unsigned>::max()) {
+            cap = static_cast<unsigned>(v);
+        }
+    }
+    return std::max(1u, cap);
+}
+
+// Counting gate limiting concurrently-executing jit_compile_kernel calls to the
+// fd-safe cap above. Process-global so it also bounds the total across the several
+// jit_compile_pending calls a multi-chip mesh setup may run in parallel. Each
+// compile acquires a slot for the duration of its (fd-heavy) work and releases it
+// via RAII, so peak open fds stay bounded regardless of the kernel count.
+static std::counting_semaphore<>& compile_slots() {
+    static std::counting_semaphore<> slots(jit_compile_concurrency_cap());
+    return slots;
+}
+
 static void jit_compile_pending(
     std::map<std::string, DeferredCompile>& deferred_compiles,
     std::unordered_map<std::string, std::function<void()>>& resolved_fns,
@@ -1784,6 +1850,14 @@ static void jit_compile_pending(
                     std::string cache_path = disk_cache_so_path(key);
                     DeferredCompile dc_copy = dc;  // own a copy: the future may outlive this call's map
                     fut = std::async(std::launch::async, [dc_copy, cache_path]() {
+                              // Bound concurrent compiles to the fd-safe cap: a slot is
+                              // held for the whole (fd-heavy) compile and released even if
+                              // it throws. std::async spawns the thread eagerly, but the
+                              // fd-consuming work waits here until a slot frees.
+                              compile_slots().acquire();
+                              struct SlotGuard {
+                                  ~SlotGuard() { compile_slots().release(); }
+                              } slot_guard;
                               std::string tmp_path = cache_path + ".tmp." + std::to_string(::getpid()) + "." +
                                                      std::to_string(g_compile_tmp_seq.fetch_add(1));
                               auto fn = jit_compile_kernel(


### PR DESCRIPTION
## Problem
The emule software emulator JIT-compiles kernels at runtime. `jit_compile_pending` launched one `std::async(std::launch::async)` per cache-missed kernel with **no concurrency bound**. Each in-flight compile holds a burst of open file descriptors — the kernel_patcher mirrors patched headers (writes), reads the transitive include tree, and `std::system` spawns a clang subprocess (pipes) — on the order of tens of fds each.

A large mesh program compiles many distinct kernels at once. An 8-chip mesh on the full 14×10 Blackhole grid compiles ~hundreds, so peak open fds scale with the kernel count and exceed the process `RLIMIT_NOFILE` soft limit (commonly **1024** in CI containers). `open()` then fails mid-compile with **EMFILE**, surfacing as `RuntimeError: kernel_patcher: cannot read/write <file>` — on whichever file happens to open next, so the failing file varies run to run and looks nondeterministic. A single-chip run stays under the limit; a dev box with `ulimit -n 65536` never hits it, so this reproduces only in fd-constrained (CI/container) environments.

Confirmed diagnosis (fd limit, not disk): `errno=24 (Too many open files)`, with 116 GB free on the target filesystem.

## Fix
Bound the number of concurrently-executing compiles to an fd-safe cap derived from `RLIMIT_NOFILE` (reserve baseline-fd headroom, budget ~48 fds/compile), clamped to `hardware_concurrency`. A process-global `CompileSlots` gate is acquired for the duration of each compile's fd-heavy work and released via RAII (so a throwing compile still frees its slot). `TT_EMULE_JIT_COMPILE_JOBS` overrides the cap for tuning/debug. This also caps the hundreds-of-threads / clang-process explosion, which matters as meshes scale (Galaxy).

The change is confined to `tt_metal/impl/emulation/` — emule-only code (compiled only with `-DTT_METAL_USE_EMULE=ON`); non-emule builds are unaffected.

## Verification
Deterministic reproduction via `ulimit -n` on the emule loudbox (8×P150) regression:
- Before: at `ulimit -n 1024` the gate failed with EMFILE on the multicast/gather kernels.
- After: **13/13 green at `ulimit -n 1024`** (and passes at 256). Single-chip p150 gate unaffected.

Companion emule-blaze change: tenstorrent/tt-emule-blaze#92 (repins onto this fix on the emule fork).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=xchin/emule-bound-jit-compile-fd)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:xchin/emule-bound-jit-compile-fd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=xchin/emule-bound-jit-compile-fd)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:xchin/emule-bound-jit-compile-fd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=xchin/emule-bound-jit-compile-fd)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:xchin/emule-bound-jit-compile-fd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=xchin/emule-bound-jit-compile-fd)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:xchin/emule-bound-jit-compile-fd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=xchin/emule-bound-jit-compile-fd)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:xchin/emule-bound-jit-compile-fd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=xchin/emule-bound-jit-compile-fd)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:xchin/emule-bound-jit-compile-fd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=xchin/emule-bound-jit-compile-fd)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:xchin/emule-bound-jit-compile-fd)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=xchin/emule-bound-jit-compile-fd)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:xchin/emule-bound-jit-compile-fd)