### PR TITLE
Add Metal 2.0 migration facade to layernorm fusion pybind

### DIFF
--- a/models/experimental/ops/descriptors/normalization/_utils.py
+++ b/models/experimental/ops/descriptors/normalization/_utils.py
@@ -41,7 +41,7 @@ def _create_layernorm_op_descriptor(
         if input_tensor.is_sharded():
             core_range_set = input_tensor.memory_config().shard_spec.grid
         else:
-            core_range_set = ttnn.LayerNormMultiCoreProgramFactory.default_core_range(device)
+            core_range_set = ttnn.LayerNormDeviceOperation.default_core_range(device)
 
     if compute_kernel_config is None:
         raise ValueError("compute_kernel_config is required")
@@ -79,7 +79,7 @@ def _create_layernorm_op_descriptor(
     if recip_tensor is not None:
         tensor_args.recip_tensor = recip_tensor
 
-    h = ttnn.LayerNormDeviceOperation.compute_program_hash(operation_params, tensor_args)
+    h = ttnn.LayerNormDeviceOperation.program_cache_key(operation_params, tensor_args)
     base_key = int(h) & ((1 << 64) - 1)
     if input_tensor.is_sharded():
         program_cache_key = base_key
@@ -105,8 +105,7 @@ def _create_layernorm_op_descriptor(
 
     def _run_factory():
         out = outputs[0]
-        factory = ttnn.LayerNormDeviceOperation.select_program_factory(operation_params, tensor_args)
-        return factory.create_descriptor(operation_params, tensor_args, out, cr_arg)
+        return ttnn.LayerNormDeviceOperation.create_fused_program_descriptor(operation_params, tensor_args, out, cr_arg)
 
     return OpDescriptor(
         factory_fn=_run_factory,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm_nanobind.cpp
@@ -5,6 +5,7 @@
 #include "layernorm_nanobind.hpp"
 
 #include <optional>
+#include <variant>
 
 #include <fmt/format.h>
 #include <nanobind/nanobind.h>
@@ -313,6 +314,66 @@ void bind_normalization_layernorm_device_operation(nb::module_& mod) {
             Returns:
                 Union[LayerNormMultiCoreProgramFactory, LayerNormShardedProgramFactory]:
                     The appropriate program factory for the input tensor.
+            )doc")
+        // ── Metal 2.0 migration façade ──────────────────────────────────────
+        // Stable, framework-version-agnostic surface for the experimental fusion
+        // framework (models/experimental/ops/descriptors/). Fusion code depends on
+        // these three methods instead of reaching into compute_program_hash,
+        // select_program_factory, the per-factory create_descriptor bindings, or
+        // LayerNormMultiCoreProgramFactory::default_core_range — all of which the
+        // Metal 2.0 port removes or reshapes. After the port, only the C++ body of
+        // these methods changes; the Python fusion callers are untouched.
+        .def_static(
+            "program_cache_key",
+            [](const ttnn::prim::LayerNormParams& attrs, const ttnn::prim::LayerNormInputs& tensors) {
+                return ttnn::device_operation::detail::compute_program_hash<ttnn::prim::LayerNormDeviceOperation>(
+                    attrs, tensors);
+            },
+            nb::arg("operation_attributes"),
+            nb::arg("tensor_args"),
+            R"doc(
+            Stable program-identity key for the fusion build cache.
+
+            Today this mirrors compute_program_hash; after the Metal 2.0 port it
+            becomes the ProgramSpec-derived key. Fusion code should depend on this
+            rather than on compute_program_hash directly.
+            )doc")
+        .def_static(
+            "create_fused_program_descriptor",
+            [](const ttnn::prim::LayerNormParams& operation_attributes,
+               const ttnn::prim::LayerNormInputs& tensor_args,
+               Tensor& tensor_return_value,
+               const std::optional<CoreRangeSet>& core_range_set) {
+                auto factory =
+                    ttnn::prim::LayerNormDeviceOperation::select_program_factory(operation_attributes, tensor_args);
+                return std::visit(
+                    [&](auto&& f) {
+                        return f.create_descriptor(
+                            operation_attributes, tensor_args, tensor_return_value, core_range_set);
+                    },
+                    factory);
+            },
+            nb::arg("operation_attributes"),
+            nb::arg("tensor_args"),
+            nb::arg("tensor_return_value"),
+            nb::arg("core_range_set") = std::nullopt,
+            R"doc(
+            Build the ProgramDescriptor for this op, hiding factory selection.
+
+            Façade over select_program_factory + the chosen factory's
+            create_descriptor. Fusion code should call this instead of reaching
+            into the per-factory create_descriptor bindings, which the Metal 2.0
+            port removes.
+            )doc")
+        .def_static(
+            "default_core_range",
+            &ttnn::prim::LayerNormMultiCoreProgramFactory::default_core_range,
+            nb::arg("device"),
+            R"doc(
+            Default core range for non-sharded LayerNorm (device compute grid).
+
+            Device-op-level façade so fusion code need not name the program
+            factory class, which the Metal 2.0 port removes.
             )doc");
 }
 


### PR DESCRIPTION
## What

Adds a stable, framework-version-agnostic **pybind façade** on `LayerNormDeviceOperation` so the
experimental fusion framework (`models/experimental/ops/descriptors/`) stops depending on descriptor-
framework internals that the Metal 2.0 port removes or reshapes.

Three new device-op static methods:

- `program_cache_key(operation_attributes, tensor_args) -> int` — stable program-identity key for the
  fusion build cache. Today it mirrors `compute_program_hash`; after the Metal 2.0 port it becomes the
  `ProgramSpec`-derived key.
- `create_fused_program_descriptor(operation_attributes, tensor_args, tensor_return_value, core_range_set=None) -> ProgramDescriptor`
  — façade over `select_program_factory` + the chosen factory's `create_descriptor`.
- `default_core_range(device) -> CoreRangeSet` — device-op-level, so fusion code need not name the
  program-factory class.

The fusion consumer (`normalization/_utils.py`, shared by both `layer_norm` and `rms_norm`) is swapped
onto these three methods. After this change the fusion framework no longer references
`LayerNormMultiCoreProgramFactory`, `LayerNormShardedProgramFactory`, or `select_program_factory` for
layernorm at all.

## Why

Four descriptor ops expose their device-op internals to Python, and the fusion framework is the sole
consumer. A Metal 2.0 port removes `compute_program_hash` (spec-as-key), replaces per-factory
`create_descriptor(...) -> ProgramDescriptor` with `create_program_artifacts(...) -> ProgramArtifacts`,
and drops the pybind-only `core_range_set` param / `default_core_range` hook. This already silently
broke fusion coverage for the ported factories in `experimental/quasar/matmul`.

With this façade, porting layernorm to Metal 2.0 becomes a **C++-body-only change** to these three
methods; the Python fusion code is untouched. Layernorm is the first of four (matmul, data_movement/
slice, experimental/quasar/matmul to follow with the same pattern).

## Notes for reviewers

- No change to the C++ `LayerNormDeviceOperation` struct — the façade is implemented as `nb::class_`
  lambdas.
- The existing factory-class bindings and `select_program_factory` binding are intentionally left in
  place in this PR (kept `ttnn/__init__.py` exports valid, minimal diff). Removing them once nothing
  references them is a follow-up.
- `program_cache_key` wraps the same `compute_program_hash` call, so build-cache keys are byte-for-byte
  unchanged.

## Open risk (documented, not incurred here)

At actual migration time, `create_fused_program_descriptor` must still hand `generic_op` something
runnable. If the Metal 2.0 factory returns `ProgramArtifacts` and no `ProgramArtifacts ->
ProgramDescriptor` lowering exists, the porter must add that lowering or give `generic_op` a Metal 2.0
path. The façade contains that decision to one C++ method; it does not eliminate it.

## Test

- `tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_parallel_sequential.py`
- `tests/ttnn/unit_tests/operations/fused/parallel_sequential/test_fusion_cache.py`

Draft — do not merge; opened for design review.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/ln-fusion-facade)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/ln-fusion-facade)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/ln-fusion-facade)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/ln-fusion-facade)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/ln-fusion-facade)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/ln-fusion-facade)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/ln-fusion-facade)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/ln-fusion-facade)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/ln-fusion-facade)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/ln-fusion-facade)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/ln-fusion-facade)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/ln-fusion-facade)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/ln-fusion-facade)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/ln-fusion-facade)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/ln-fusion-facade)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/ln-fusion-facade)