### PR TITLE
[DeepSeek] Recalibrate MoE galaxy pad50 device-perf baseline

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
@@ -95,7 +95,7 @@ def test_deepseek_v3_moe_perf_galaxy_pad50():
 
     run_model_device_perf_test_with_merge(
         command=_CMD_8X4_pad50,
-        expected_device_perf_ns_per_iteration=38_028_230,
+        expected_device_perf_ns_per_iteration=27_159_208,  # Recalibrated 2026-07-18 (perf improvement, was 38_028_230).
         subdir="deepseek_v3_moe",
         model_name="deepseek_v3_moe_glx_8x4_pad50",
         num_iterations=1,


### PR DESCRIPTION
## Summary

`test_deepseek_v3_moe_perf_galaxy_pad50` was failing on the nightly (Release) Model Status for Console Deployment pipeline because of a **perf improvement**: the measured `AVG DEVICE KERNEL DURATION` dropped to ~27.16 ms, falling below the old expected region centered on `38_028_230 ns` (range 36.89–39.17 ms).

```
AVG DEVICE KERNEL DURATION [ns] 27159207.71875 is outside of expected range (36887383.1, 39169076.9)
```

## Change

- Move the expected baseline in `models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py` from `38_028_230` → `27_159_208` ns.
- **Margin unchanged** at `0.03` (tolerance not increased) — only the region moved. New passing range: `(26,344,432, 27,973,984)` ns, with the measured value at center.

## Verification

CI run from this branch (`kgrujcic/50322`): https://github.com/tenstorrent/tt-metal/actions/runs/29638427940

`(Galaxy) DeepSeek Prefill Perf tests [bh_galaxy]` passes — `test_deepseek_v3_moe_perf_galaxy_pad50` → `1 passed in 81.58s`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kgrujcic/50322)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kgrujcic/50322)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kgrujcic/50322)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kgrujcic/50322)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=kgrujcic/50322)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:kgrujcic/50322)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kgrujcic/50322)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kgrujcic/50322)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kgrujcic/50322)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kgrujcic/50322)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kgrujcic/50322)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kgrujcic/50322)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kgrujcic/50322)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kgrujcic/50322)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kgrujcic/50322)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kgrujcic/50322)