### PR TITLE
[test] requires_grid_size: enforce every marker, not just the closest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -799,14 +799,23 @@ def _check_requires_grid_size(device_or_mesh, marker):
 
 @pytest.fixture(autouse=True)
 def check_requires_grid_size(request):
-    """Autouse fixture: skips the test when it has requires_grid_size mark and device worker grid is too small. Supports device, bh_2d_mesh_device, and mesh_device. Tests only need @pytest.mark.requires_grid_size((x,y)) or @pytest.mark.requires_grid_size(n_cores)."""
-    marker = request.node.get_closest_marker("requires_grid_size")
-    if marker is None:
+    """Autouse fixture: skips the test when it has requires_grid_size mark and device worker grid is too small. Supports device, bh_2d_mesh_device, and mesh_device. Tests only need @pytest.mark.requires_grid_size((x,y)) or @pytest.mark.requires_grid_size(n_cores).
+
+    Enforces *every* requires_grid_size marker on the item, not just the closest
+    one. A parametrized case commonly carries both a function-level default
+    requirement and a stricter per-param requirement (via pytest.param(marks=...));
+    get_closest_marker() would return only one of them and silently drop the other,
+    letting an under-provisioned grid (e.g. a harvested board) run a case that needs
+    more cores. Applying all markers makes the strictest requirement win.
+    """
+    markers = list(request.node.iter_markers("requires_grid_size"))
+    if not markers:
         return
     for name in ("bh_2d_mesh_device", "mesh_device", "device"):
         if name in request.fixturenames:
             device_or_mesh = request.getfixturevalue(name)
-            _check_requires_grid_size(device_or_mesh, marker)
+            for marker in markers:
+                _check_requires_grid_size(device_or_mesh, marker)
             return
     pytest.skip(
         "requires_grid_size mark requires one of: device, bh_2d_mesh_device, mesh_device (none requested by test)"


### PR DESCRIPTION
### Problem

`check_requires_grid_size` (the autouse fixture backing
`@pytest.mark.requires_grid_size`) resolves the requirement with
`request.node.get_closest_marker("requires_grid_size")`, which returns only a
single marker. A parametrized test commonly stacks two:

- a function-level default requirement, e.g. `@pytest.mark.requires_grid_size((11, 10))`, and
- a stricter per-parameter requirement applied via `pytest.param(..., marks=pytest.mark.requires_grid_size((13, 10)))`.

`get_closest_marker()` returns just one of them and silently drops the other.
When the dropped marker is the stricter one, an under-provisioned worker grid
(e.g. a harvested board whose `compute_with_storage_grid_size()` is smaller than
the parametrized case needs) runs a case it cannot fit instead of skipping. The
failure then surfaces downstream as an allocation
`TT_FATAL (num_shards <= num_compute_banks)` at tensor-creation time rather than
as the intended clean skip.

### Fix

Iterate **every** `requires_grid_size` marker on the item via `iter_markers()`
and enforce each one, so the strictest requirement wins. Tests carrying a single
marker are unaffected.

### Test

- A case stacking function-level `(11, 10)` + per-param `(13, 10)` now correctly
  **skips** on an 11×10 worker grid (previously ran and hit the allocation
  TT_FATAL) and still **runs** on a 13×10+ grid.
- No change for single-marker tests; full local regression suites remain green.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sgholamiTT/requires-grid-size-enforce-all-markers)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sgholamiTT/requires-grid-size-enforce-all-markers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sgholamiTT/requires-grid-size-enforce-all-markers)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sgholamiTT/requires-grid-size-enforce-all-markers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=sgholamiTT/requires-grid-size-enforce-all-markers)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:sgholamiTT/requires-grid-size-enforce-all-markers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sgholamiTT/requires-grid-size-enforce-all-markers)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sgholamiTT/requires-grid-size-enforce-all-markers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sgholamiTT/requires-grid-size-enforce-all-markers)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sgholamiTT/requires-grid-size-enforce-all-markers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sgholamiTT/requires-grid-size-enforce-all-markers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sgholamiTT/requires-grid-size-enforce-all-markers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sgholamiTT/requires-grid-size-enforce-all-markers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sgholamiTT/requires-grid-size-enforce-all-markers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sgholamiTT/requires-grid-size-enforce-all-markers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sgholamiTT/requires-grid-size-enforce-all-markers)