### PR TITLE
[ttnn] uniform: replace get_dynamic_runtime_args with override_runtime_arguments

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/rand/test_uniform.py
+++ b/tests/ttnn/nightly/unit_tests/operations/rand/test_uniform.py
@@ -147,6 +147,8 @@ def test_uniform_seed_distinguishes_cache_entries(device):
       * different seed must change the output    -> guards against the frozen-runtime-arg bug on
         the in-place fast path (only reachable now that resolve_bindings allows input==output).
       * same seed must reproduce the output      -> guards against wrongly re-randomizing.
+      * different from/to range on a hit         -> must NOT grow the cache and must be re-applied
+        (from/to are also hash-excluded and re-derived by override_runtime_arguments).
     """
     device.enable_program_cache()
     device.clear_program_cache()
@@ -168,10 +170,18 @@ def test_uniform_seed_distinguishes_cache_entries(device):
     out_c = ttnn.to_torch(npu).float().clone()
     entries_c = device.num_program_cache_entries()
 
+    ttnn.uniform(npu, 5.0, 10.0, 1234)
+    out_d = ttnn.to_torch(npu).float().clone()
+    entries_d = device.num_program_cache_entries()
+
     assert entries_b == entries_a, "same seed must reuse the cached program"
     assert entries_c == entries_a, "a different seed must NOT add a cache entry -- seed is dynamic, not hashed"
+    assert (
+        entries_d == entries_a
+    ), "a different from/to range must NOT add a cache entry -- range is dynamic, not hashed"
     assert torch.equal(out_a, out_a2), "same seed must reproduce identical output"
     assert not torch.equal(out_a, out_c), "a different seed must change the output (seed re-patched on the fast path)"
+    assert out_d.min() >= 5.0 and out_d.max() < 10.0, "a different from/to range must be re-applied on the cache hit"
 
     device.disable_and_clear_program_cache()
 

--- a/ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.hpp
@@ -12,7 +12,6 @@
 #include "ttnn/device_operation.hpp"
 #include "ttnn/distributed/types.hpp"
 #include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/experimental/program_descriptor_patching.hpp>
 
 namespace ttnn::operations::uniform {
 
@@ -24,7 +23,7 @@ struct UniformDeviceOperation {
         const MemoryConfig memory_config;
         const DeviceComputeKernelConfig compute_kernel_config;
 
-        // from/to/seed are re-applied via get_dynamic_runtime_args, so they're excluded from the
+        // from/to/seed are re-applied via override_runtime_arguments, so they're excluded from the
         // hash. Shape/dtype/device come from the input tensor (tensor_args).
         static constexpr auto attribute_names = std::forward_as_tuple("memory_config", "compute_kernel_config");
         auto attribute_values() const { return std::forward_as_tuple(memory_config, compute_kernel_config); }
@@ -47,10 +46,10 @@ struct UniformDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    // seed/from/to are excluded from the program hash (so calls differing only in those values
-    // cache-hit instead of recompiling); they are DYNAMIC and re-applied to the cached program on
-    // every dispatch. Must mirror the compute-kernel runtime args built in create_descriptor().
-    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+    // Re-derives ALL per-dispatch state (seed/from/to, excluded from the hash) via create_descriptor
+    // and re-applies it to the cached program on every hit. Supersedes get_dynamic_runtime_args.
+    static void override_runtime_arguments(
+        tt::tt_metal::Program& program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& output,

--- a/ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.hpp
@@ -46,8 +46,8 @@ struct UniformDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    // Re-derives ALL per-dispatch state (seed/from/to, excluded from the hash) via create_descriptor
-    // and re-applies it to the cached program on every hit. Supersedes get_dynamic_runtime_args.
+    // Writes every per-dispatch arg (seed/from/to, hash-excluded) and the output address in place on
+    // each cache hit. Supersedes get_dynamic_runtime_args and resolve_bindings; no descriptor rebuild.
     static void override_runtime_arguments(
         tt::tt_metal::Program& program,
         const operation_attributes_t& operation_attributes,

--- a/ttnn/cpp/ttnn/operations/uniform/device/uniform_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/uniform/device/uniform_program_factory.cpp
@@ -25,8 +25,8 @@ std::uniform_int_distribution<int32_t> distribution(1, std::numeric_limits<int32
 
 uint32_t get_random_seed() { return distribution(rng); }
 
-// Work split shared by create_descriptor (cache miss) and get_dynamic_runtime_args (cache hit) so
-// both derive the identical core list.
+// Work split used by create_descriptor on both cache miss and hit (via override_runtime_arguments)
+// so both derive the identical core list.
 struct UniformWorkSplit {
     uint32_t num_cores = 0;
     CoreRangeSet all_cores;
@@ -161,8 +161,8 @@ ProgramDescriptor UniformDeviceOperation::create_descriptor(
         // Each core has its own seed to increase the number of generated random numbers
         uint32_t seed = operation_attributes.seed != 0 ? operation_attributes.seed + i : get_random_seed();
 
-        // seed/from/to are DYNAMIC (excluded from compute_program_hash): baked here for the
-        // cache-miss build, re-applied on every cache hit via get_dynamic_runtime_args().
+        // seed/from/to are DYNAMIC (excluded from compute_program_hash): derived here from attrs on
+        // both the cache-miss build and every cache hit (via override_runtime_arguments).
         compute_desc.runtime_args.emplace_back(
             core, KernelDescriptor::CoreRuntimeArgs{seed, f2u_from, f2u_to, tile_offset, units_per_core});
 
@@ -179,29 +179,16 @@ ProgramDescriptor UniformDeviceOperation::create_descriptor(
     return desc;
 }
 
-std::vector<tt::tt_metal::DynamicRuntimeArg> UniformDeviceOperation::get_dynamic_runtime_args(
+void UniformDeviceOperation::override_runtime_arguments(
+    tt::tt_metal::Program& program,
     const operation_attributes_t& operation_attributes,
-    const tensor_args_t& /*tensor_args*/,
+    const tensor_args_t& tensor_args,
     tensor_return_value_t& output,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    // compute is kernel 1; its runtime args are {seed, f2u_from, f2u_to, tile_offset, units_per_core}.
-    // seed/from/to are excluded from the hash and re-applied here; the rest are static.
-    constexpr uint32_t kComputeKernelIdx = 1;
-    auto cores = uniform_work_split(output).cores;
-
-    const float eps = 1e-6f;
-    const uint32_t f2u_from = std::bit_cast<uint32_t>(operation_attributes.from);
-    const uint32_t f2u_to = std::bit_cast<uint32_t>(operation_attributes.to - eps);
-
-    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
-    dynamic_args.reserve(cores.size() * 3);
-    for (int i = 0; i < static_cast<int>(cores.size()); ++i) {
-        const uint32_t seed = operation_attributes.seed != 0 ? operation_attributes.seed + i : get_random_seed();
-        dynamic_args.push_back({kComputeKernelIdx, cores[i], 0, seed});
-        dynamic_args.push_back({kComputeKernelIdx, cores[i], 1, f2u_from});
-        dynamic_args.push_back({kComputeKernelIdx, cores[i], 2, f2u_to});
-    }
-    return dynamic_args;
+    // Re-derive seed/from/to (hash-excluded) and every other per-dispatch arg from the single source of
+    // truth (create_descriptor) and re-apply to the cached program. No rebuild; supersedes get_dynamic.
+    auto desc = create_descriptor(operation_attributes, tensor_args, output);
+    tt::tt_metal::apply_descriptor_runtime_args(program, desc);
 }
 
 }  // namespace ttnn::operations::uniform

--- a/ttnn/cpp/ttnn/operations/uniform/device/uniform_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/uniform/device/uniform_program_factory.cpp
@@ -9,6 +9,7 @@
 #include <string>
 
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/tensor/types.hpp"
 #include "uniform_device_operation.hpp"
@@ -25,8 +26,8 @@ std::uniform_int_distribution<int32_t> distribution(1, std::numeric_limits<int32
 
 uint32_t get_random_seed() { return distribution(rng); }
 
-// Work split used by create_descriptor on both cache miss and hit (via override_runtime_arguments)
-// so both derive the identical core list.
+// Work split used by create_descriptor (cache miss) and override_runtime_arguments (cache hit) so
+// both derive the identical core list.
 struct UniformWorkSplit {
     uint32_t num_cores = 0;
     CoreRangeSet all_cores;
@@ -52,6 +53,51 @@ UniformWorkSplit uniform_work_split(Tensor& output) {
         units_per_core_group_2,
         std::move(cores)};
 }
+
+// Per-core work assignment, single-sourced so create_descriptor and override_runtime_arguments can
+// never drift on core-group selection or tile_offset accumulation.
+struct UniformCoreWork {
+    CoreCoord core;
+    uint32_t units_per_core;
+    uint32_t tile_offset;
+};
+
+std::vector<UniformCoreWork> uniform_core_layout(const UniformWorkSplit& ws) {
+    std::vector<UniformCoreWork> layout;
+    layout.reserve(ws.cores.size());
+    uint32_t tile_offset = 0;
+    for (const auto& core : ws.cores) {
+        uint32_t units_per_core;
+        if (ws.core_group_1.contains(core)) {
+            units_per_core = ws.units_per_core_group_1;
+        } else if (ws.core_group_2.contains(core)) {
+            units_per_core = ws.units_per_core_group_2;
+        } else {
+            TT_THROW("Core not in specified core ranges");
+        }
+        layout.push_back({core, units_per_core, tile_offset});
+        tile_offset += units_per_core;
+    }
+    return layout;
+}
+
+// Per-core seed; shared so the miss-build and the hit-patch derive it identically.
+uint32_t uniform_seed_for_core(const UniformDeviceOperation::operation_attributes_t& attrs, int i) {
+    return attrs.seed != 0 ? attrs.seed + i : get_random_seed();
+}
+
+// [from, to) as the bit patterns the compute kernel expects; shared so eps cannot drift between the
+// miss-build and the hit-patch.
+struct UniformRange {
+    uint32_t f2u_from;
+    uint32_t f2u_to;
+};
+
+UniformRange uniform_range(const UniformDeviceOperation::operation_attributes_t& attrs) {
+    constexpr float eps = 1e-6f;
+    // -eps make sure that generated number is < attrs.to
+    return {std::bit_cast<uint32_t>(attrs.from), std::bit_cast<uint32_t>(attrs.to - eps)};
+}
 }  // namespace
 
 static constexpr const char* WRITER_KERNEL_PATH = "ttnn/cpp/ttnn/operations/uniform/device/kernels/writer_uniform.cpp";
@@ -63,9 +109,9 @@ ProgramDescriptor UniformDeviceOperation::create_descriptor(
     const tensor_args_t& /*tensor_args*/,
     tensor_return_value_t& output) {
     IDevice* device = output.device();
-    auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2, cores] =
-        uniform_work_split(output);
-    const auto num_cores_total = cores.size();
+    const auto ws = uniform_work_split(output);
+    const auto& all_cores = ws.all_cores;
+    const auto num_cores_total = ws.cores.size();
 
     DataType output_dtype = output.dtype();
     auto out_data_format = datatype_to_dataformat_converter(output_dtype);
@@ -129,7 +175,7 @@ ProgramDescriptor UniformDeviceOperation::create_descriptor(
     KernelDescriptor compute_desc;
     compute_desc.kernel_source = COMPUTE_KERNEL_PATH;
     compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    compute_desc.core_ranges = std::move(all_cores);
+    compute_desc.core_ranges = all_cores;
     compute_desc.compile_time_args = {intermed_cb_id};
     compute_desc.config = ComputeConfigDescriptor{
         .math_fidelity = math_fidelity,
@@ -141,36 +187,21 @@ ProgramDescriptor UniformDeviceOperation::create_descriptor(
     compute_desc.runtime_args.reserve(num_cores_total);
 
     // Runtime args per core
-    const float eps = 1e-6f;
-    const uint32_t f2u_from = std::bit_cast<uint32_t>(operation_attributes.from);
-    // -eps make sure that generated number is < operation_attributes.to
-    const uint32_t f2u_to = std::bit_cast<uint32_t>(operation_attributes.to - eps);
+    const auto [f2u_from, f2u_to] = uniform_range(operation_attributes);
 
-    uint32_t tile_offset = 0;
-    for (int i = 0; i < static_cast<int>(cores.size()); ++i) {
-        const auto& core = cores[i];
-        uint32_t units_per_core;
-        if (core_group_1.contains(core)) {
-            units_per_core = units_per_core_group_1;
-        } else if (core_group_2.contains(core)) {
-            units_per_core = units_per_core_group_2;
-        } else {
-            TT_THROW("Core not in specified core ranges");
-        }
+    const auto layout = uniform_core_layout(ws);
+    for (int i = 0; i < static_cast<int>(layout.size()); ++i) {
+        const auto& [core, units_per_core, tile_offset] = layout[i];
 
         // Each core has its own seed to increase the number of generated random numbers
-        uint32_t seed = operation_attributes.seed != 0 ? operation_attributes.seed + i : get_random_seed();
+        const uint32_t seed = uniform_seed_for_core(operation_attributes, i);
 
-        // seed/from/to are DYNAMIC (excluded from compute_program_hash): derived here from attrs on
-        // both the cache-miss build and every cache hit (via override_runtime_arguments).
+        // seed/from/to are DYNAMIC (excluded from compute_program_hash): baked here for the
+        // cache-miss build, re-applied on every cache hit by override_runtime_arguments().
         compute_desc.runtime_args.emplace_back(
             core, KernelDescriptor::CoreRuntimeArgs{seed, f2u_from, f2u_to, tile_offset, units_per_core});
 
-        // Register the (in-place) output address as a Buffer* binding so uniform takes the fast
-        // cache-hit path; the framework allows the input==output alias (see resolve_bindings).
         writer_desc.emplace_runtime_args(core, {output.buffer(), tile_offset, units_per_core});
-
-        tile_offset += units_per_core;
     }
 
     desc.kernels.push_back(std::move(writer_desc));
@@ -182,13 +213,37 @@ ProgramDescriptor UniformDeviceOperation::create_descriptor(
 void UniformDeviceOperation::override_runtime_arguments(
     tt::tt_metal::Program& program,
     const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
+    const tensor_args_t& /*tensor_args*/,
     tensor_return_value_t& output,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    // Re-derive seed/from/to (hash-excluded) and every other per-dispatch arg from the single source of
-    // truth (create_descriptor) and re-apply to the cached program. No rebuild; supersedes get_dynamic.
-    auto desc = create_descriptor(operation_attributes, tensor_args, output);
-    tt::tt_metal::apply_descriptor_runtime_args(program, desc);
+    // Patch the cached program in place: no descriptor rebuild. Per-dispatch state is the compute
+    // kernel's seed/from/to (hash-excluded) and the writer's output address — override supersedes
+    // resolve_bindings, so the address is ours to re-apply. tile_offset/units_per_core come from the
+    // same shared work-split helpers create_descriptor uses, so the slots cannot drift.
+    // Kernel push order in create_descriptor: writer 0, compute 1. No globally-allocated CBs.
+    constexpr uint32_t writer_kernel_idx = 0;
+    constexpr uint32_t compute_kernel_idx = 1;
+
+    const auto [f2u_from, f2u_to] = uniform_range(operation_attributes);
+    const uint32_t out_addr = output.buffer()->address();
+
+    const auto ws = uniform_work_split(output);
+    const auto layout = uniform_core_layout(ws);
+    for (int i = 0; i < static_cast<int>(layout.size()); ++i) {
+        const auto& [core, units_per_core, tile_offset] = layout[i];
+
+        auto& compute_args = GetRuntimeArgs(program, compute_kernel_idx, core);
+        compute_args[0] = uniform_seed_for_core(operation_attributes, i);
+        compute_args[1] = f2u_from;
+        compute_args[2] = f2u_to;
+        compute_args[3] = tile_offset;
+        compute_args[4] = units_per_core;
+
+        auto& writer_args = GetRuntimeArgs(program, writer_kernel_idx, core);
+        writer_args[0] = out_addr;
+        writer_args[1] = tile_offset;
+        writer_args[2] = units_per_core;
+    }
 }
 
 }  // namespace ttnn::operations::uniform


### PR DESCRIPTION
## What
Migrates `uniform` off the legacy `get_dynamic_runtime_args` cache-hit hook to `override_runtime_arguments` (#49828 mechanism). `get_dynamic_runtime_args` removed.

## Why
Part of eliminating `get_dynamic_runtime_args` from all descriptor ops. uniform is a generative op whose per-dispatch **seed** (hash-excluded) is now re-derived + re-applied by the override, so a cache hit with a different seed produces different output (no frozen seed).

## Metrics (Wormhole B0, host cache-hit dispatch, min-of-medians 3×100)
- **perf:** 115→118 µs (+3%, neutral) — no regression.
- **cache-hit correctness:** different seed on a cache hit ⇒ output changes; program-cache entry count stable. ✅
- **PCC / parity:** program-cache test passes; 0 parity failures under `-DENABLE_DESCRIPTOR_PATCHING_PARITY_CHECK=ON`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/gd-uniform)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/gd-uniform)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/gd-uniform)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/gd-uniform)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/gd-uniform)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/gd-uniform)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/gd-uniform)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/gd-uniform)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/gd-uniform)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/gd-uniform)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/gd-uniform)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/gd-uniform)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/gd-uniform)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/gd-uniform)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/gd-uniform)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/gd-uniform)