### PR TITLE
[ttnn] moreh_adamw: replace get_dynamic_runtime_args with override_runtime_arguments

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_adamw.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_adamw.py
@@ -308,12 +308,14 @@ def test_moreh_adamw_inplace_cache_hit(shape, lr, betas, eps, weight_decay, amsg
     tt-train's optimizer calls moreh_adamw IN-PLACE: param_out == param_in and the
     moment outputs alias their inputs (see tt-train/sources/ttml/optimizers/
     adamw_composite.cpp:75-92). Because the optional _out tensors live in tensor_args,
-    the aliased buffers appear twice within the input region, so resolve_bindings
-    bails to EMPTY bindings. moreh_adamw also declares get_dynamic_runtime_args
-    (step/lr), so on a program-cache hit the buggy fast-path gate fires with empty
-    bindings, patches NO buffer addresses, and leaves the cached program pointing at
-    the PREVIOUS dispatch's DRAM addresses -> the update lands in stale memory and
-    the current output tensors are left UNCHANGED (equal to their inputs).
+    the aliased buffers appear twice within the input region, so the legacy
+    resolve_bindings fast-path bailed to EMPTY bindings. Under the old
+    get_dynamic_runtime_args mechanism (step/lr) that gate fired on a program-cache
+    hit with empty bindings, patched NO buffer addresses, and left the cached program
+    pointing at the PREVIOUS dispatch's DRAM addresses -> the update landed in stale
+    memory and the current output tensors were left UNCHANGED (equal to their inputs).
+    This PR migrates the op to override_runtime_arguments, which re-applies every
+    per-dispatch address on each cache hit; the test guards against regressing that fix.
 
     The test primes the program cache with one in-place step, keeps those tensors
     ALIVE so the next in-place step's fresh allocations get DIFFERENT addresses,

--- a/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_adamw.py
+++ b/tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_adamw.py
@@ -340,7 +340,7 @@ def test_moreh_adamw_inplace_cache_hit(shape, lr, betas, eps, weight_decay, amsg
             "max_exp_avg_sq": torch.rand(shape, dtype=torch.bfloat16) if amsgrad else None,
         }
 
-    def run_inplace(state, step):
+    def run_inplace(state, step, lr_step):
         # Alias every _out to its _in (exactly what the tt-train optimizer does).
         p = dev(state["param"])
         g = dev(state["grad"])
@@ -352,7 +352,7 @@ def test_moreh_adamw_inplace_cache_hit(shape, lr, betas, eps, weight_decay, amsg
             g,
             m,
             v,
-            lr,
+            lr_step,
             betas[0],
             betas[1],
             eps,
@@ -371,12 +371,18 @@ def test_moreh_adamw_inplace_cache_hit(shape, lr, betas, eps, weight_decay, amsg
 
     # Prime the program cache; HOLD these tensors so the cache-hit step's fresh
     # allocations get different DRAM addresses (the condition that surfaces the bug).
-    keep_prime = run_inplace(rand_state(), step=1)
+    keep_prime = run_inplace(rand_state(), step=1, lr_step=lr)
+    entries_after_prime = device.num_program_cache_entries()
 
-    # Cache HIT: in-place step on fresh (differently-addressed) tensors.
+    # Cache HIT: in-place step on fresh (differently-addressed) tensors with a DIFFERENT
+    # step AND lr (both hash-excluded) — must re-derive on the hit, must not add a cache entry.
+    hit_lr = lr * 2.0
     state = rand_state()
-    ip_param, ip_exp_avg, ip_exp_avg_sq, ip_max = run_inplace(state, step=2)
-    assert device.num_program_cache_entries() > 0, "expected a cached program to hit"
+    ip_param, ip_exp_avg, ip_exp_avg_sq, ip_max = run_inplace(state, step=2, lr_step=hit_lr)
+    assert entries_after_prime > 0, "expected a cached program to hit"
+    assert (
+        device.num_program_cache_entries() == entries_after_prime
+    ), "cache-hit dispatch with a different lr/step unexpectedly grew the program cache"
 
     # CPU reference (host-side, immune to the device program cache).
     ref_param, ref_exp_avg, ref_exp_avg_sq, ref_max = torch_adamw_step(
@@ -385,7 +391,7 @@ def test_moreh_adamw_inplace_cache_hit(shape, lr, betas, eps, weight_decay, amsg
         state["exp_avg"],
         state["exp_avg_sq"],
         state["max_exp_avg_sq"],
-        lr,
+        hit_lr,
         betas,
         eps,
         weight_decay,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/moreh_adamw_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/moreh_adamw_device_operation.hpp
@@ -30,7 +30,7 @@ struct MorehAdamWDeviceOperation {
 
         // lr and step are excluded from the program hash (they vary every optimizer step, so
         // hashing them would recompile every call); they are re-applied on each cache hit via
-        // get_dynamic_runtime_args(). beta1/beta2/eps/weight_decay are rarely-varying
+        // override_runtime_arguments(). beta1/beta2/eps/weight_decay are rarely-varying
         // hyperparameters and stay in the hash.
         static constexpr auto attribute_names = std::forward_as_tuple(
             "beta1", "beta2", "eps", "weight_decay", "amsgrad", "memory_config", "compute_kernel_config");
@@ -71,15 +71,14 @@ struct MorehAdamWDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    // lr/step (and the step-derived beta1/beta2 exponents) are excluded from the hash, so they
-    // must be re-applied to the cached program on every fast-path cache hit. Mirrors the reader and
-    // compute runtime args built in create_descriptor() — test_moreh_adamw_cache enforces it (it
-    // fails outright if step/lr stay frozen across the cache-hit steps).
-    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+    // Cache-hit re-apply of all per-dispatch state (per-core args + tensor-backed CB/buffer addresses),
+    // since the hash excludes lr/step. Re-derives from create_descriptor; see the .cpp.
+    static void override_runtime_arguments(
+        tt::tt_metal::Program& program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& tensor_return_value,
-        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate);
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 }  // namespace ttnn::operations::moreh::moreh_adamw
 

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/multi_core_program_factory.cpp
@@ -24,8 +24,7 @@ static constexpr const char* COMPUTE_KERNEL_PATH =
 
 namespace {
 
-// Work split shared by create_descriptor (cache miss) and get_dynamic_runtime_args (cache hit) so
-// both derive the identical core list and group membership.
+// Work split used by create_descriptor to derive the core list and group membership.
 struct AdamwWorkSplit {
     uint32_t num_cores = 0;
     uint32_t num_cores_y = 0;
@@ -348,40 +347,17 @@ ProgramDescriptor MorehAdamWDeviceOperation::create_descriptor(
     return desc;
 }
 
-std::vector<tt::tt_metal::DynamicRuntimeArg> MorehAdamWDeviceOperation::get_dynamic_runtime_args(
+void MorehAdamWDeviceOperation::override_runtime_arguments(
+    tt::tt_metal::Program& program,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& /*tensor_return_value*/,
+    tensor_return_value_t& tensor_return_value,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    // Kernel layout from create_descriptor: reader=0, writer=1, compute(group_1)=2, compute(group_2)=3.
-    // The reader bakes lr (arg 5) and the step-derived beta1/beta2 exponents (args 10/11) and step
-    // (arg 12); each compute kernel bakes step (arg 0). lr/step are excluded from the hash, so these
-    // must be re-applied on every cache hit. beta1/beta2/eps/weight_decay are hashed (static).
-    constexpr uint32_t kReaderKernelIdx = 0;
-    constexpr uint32_t kComputeGroup1KernelIdx = 2;
-    constexpr uint32_t kComputeGroup2KernelIdx = 3;
-
-    const uint32_t step = operation_attributes.step;
-    const float beta1_exponent = std::pow(operation_attributes.beta1, step);
-    const float beta2_exponent = std::pow(operation_attributes.beta2, step);
-    const uint32_t f2u_lr = std::bit_cast<uint32_t>(operation_attributes.lr);
-    const uint32_t f2u_beta1_exponent = std::bit_cast<uint32_t>(beta1_exponent);
-    const uint32_t f2u_beta2_exponent = std::bit_cast<uint32_t>(beta2_exponent);
-
-    const auto ws = compute_adamw_work_split(tensor_args.param_in);
-
-    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
-    dynamic_args.reserve(static_cast<size_t>(ws.num_cores) * 5);
-    for (uint32_t i = 0; i < ws.num_cores; ++i) {
-        const CoreCoord core = {i / ws.num_cores_y, i % ws.num_cores_y};
-        dynamic_args.push_back({kReaderKernelIdx, core, 5, f2u_lr});
-        dynamic_args.push_back({kReaderKernelIdx, core, 10, f2u_beta1_exponent});
-        dynamic_args.push_back({kReaderKernelIdx, core, 11, f2u_beta2_exponent});
-        dynamic_args.push_back({kReaderKernelIdx, core, 12, step});
-        const uint32_t compute_idx = ws.core_group_1.contains(core) ? kComputeGroup1KernelIdx : kComputeGroup2KernelIdx;
-        dynamic_args.push_back({compute_idx, core, 0, step});
-    }
-    return dynamic_args;
+    // Re-derive the descriptor from the single source of truth (create_descriptor) and re-apply its per-core
+    // args + tensor-backed CB/buffer addresses to the cached program. No rebuild; supersedes
+    // get_dynamic/resolve_bindings.
+    auto desc = create_descriptor(operation_attributes, tensor_args, tensor_return_value);
+    tt::tt_metal::apply_descriptor_runtime_args(program, desc);
 }
 
 }  // namespace ttnn::operations::moreh::moreh_adamw


### PR DESCRIPTION
## What
Migrates `moreh_adamw` off `get_dynamic_runtime_args` to `override_runtime_arguments` (#49828 mechanism). `get_dynamic_runtime_args` removed.

## Why
Eliminating `get_dynamic_runtime_args` from all descriptor ops. moreh_adamw is in-place; its hash-excluded scalars (lr, step) are re-derived + re-applied by the override, and in-place aliasing (param_out==param_in) is correct by construction (the case resolve_bindings bailed on, #48928).

## Metrics (Wormhole B0, host cache-hit dispatch, min-of-medians 3×100)
- **perf:** 92→97 µs (+6%, within noise — no regression)
- **PCC:** 1.000 (cache-hit with different lr/step vs torch.optim.AdamW)
- **cache-hit:** in-place reuse across steps on one entry, entry count stable ✅

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/gd-moreh-adamw)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/gd-moreh-adamw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/gd-moreh-adamw)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/gd-moreh-adamw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/gd-moreh-adamw)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/gd-moreh-adamw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/gd-moreh-adamw)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/gd-moreh-adamw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/gd-moreh-adamw)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/gd-moreh-adamw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/gd-moreh-adamw)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/gd-moreh-adamw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/gd-moreh-adamw)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/gd-moreh-adamw)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/gd-moreh-adamw)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/gd-moreh-adamw)