### PR TITLE
[ttnn] nlp_create_qkv_heads: replace get_dynamic_runtime_args with override_runtime_arguments

### DIFF
--- a/tests/ttnn/unit_tests/operations/experimental/transformer/test_nlp_create_qkv_heads_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/experimental/transformer/test_nlp_create_qkv_heads_program_cache.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Program-cache regression tests for ttnn.experimental.nlp_create_qkv_heads
+(NlpCreateHeadsDeviceOperation), covering both program factories.
+
+These pin the override_runtime_arguments cache-hit path (which replaced
+get_dynamic_runtime_args): every per-core runtime arg and tensor-backed CB
+address must be re-derived from the CURRENT tensors on a hit. The key case is
+re-running the SAME config with re-allocated buffers so input/output addresses
+differ on the hit -> all three outputs (Q, K, V) must still be correct.
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.common.utility_functions import comp_pcc, tt2torch_tensor, skip_for_blackhole
+
+
+@pytest.fixture
+def isolate_program_cache(device):
+    device.disable_and_clear_program_cache()
+    device.enable_program_cache()
+    yield
+    device.disable_and_clear_program_cache()
+
+
+def _refs_interleaved(A, batch, seq_len, head_dim, num_q_heads, num_kv_heads, transpose_k_heads):
+    ref_q, ref_k, ref_v = torch.split(
+        A, [num_q_heads * head_dim, num_kv_heads * head_dim, num_kv_heads * head_dim], dim=-1
+    )
+    ref_q = torch.reshape(ref_q, [batch, seq_len, num_q_heads, head_dim]).transpose(-3, -2)
+    ref_k = torch.reshape(ref_k, [batch, seq_len, num_kv_heads, head_dim]).transpose(-3, -2)
+    ref_v = torch.reshape(ref_v, [batch, seq_len, num_kv_heads, head_dim]).transpose(-3, -2)
+    if transpose_k_heads:
+        ref_k = ref_k.transpose(-2, -1)
+    return ref_q, ref_k, ref_v
+
+
+def _make_interleaved_input(device, batch, seq_len, head_dim, num_q_heads, num_kv_heads, dtype, mem_config, seed):
+    torch.manual_seed(seed)
+    A = torch.randn([batch, 1, seq_len, (num_q_heads + 2 * num_kv_heads) * head_dim])
+    return A, ttnn.Tensor(A, dtype).to(ttnn.TILE_LAYOUT).to(device, mem_config)
+
+
+def _run_interleaved(in0_t, num_q_heads, num_kv_heads, transpose_k_heads, mem_config):
+    return ttnn.experimental.nlp_create_qkv_heads(
+        in0_t,
+        None,
+        num_heads=num_q_heads,
+        num_kv_heads=num_kv_heads,
+        transpose_k_heads=transpose_k_heads,
+        memory_config=mem_config,
+    )
+
+
+def _check(outs, refs, pcc):
+    for got, ref, name in zip(outs, refs, ("Q", "K", "V")):
+        passing, val = comp_pcc(tt2torch_tensor(got), ref, pcc)
+        assert passing, f"{name} output mismatch on cache hit: pcc={val}"
+
+
+@pytest.mark.parametrize("transpose_k_heads", (False, True), ids=["no_transpose", "transpose_k"])
+def test_nlp_cqkv_interleaved_addr_change_on_hit(device, isolate_program_cache, transpose_k_heads):
+    """Interleaved factory: same config twice with re-allocated buffers -> 1 entry, all outputs correct.
+
+    Holding the first input alive forces the second input (and all outputs) to different addresses,
+    so a stale baked address on the cache hit would corrupt Q/K/V.
+    """
+    batch, seq_len, head_dim, num_q_heads, num_kv_heads = 1, 128, 64, 8, 2
+    dtype, mem_config = ttnn.bfloat16, ttnn.DRAM_MEMORY_CONFIG
+
+    A1, in1 = _make_interleaved_input(device, batch, seq_len, head_dim, num_q_heads, num_kv_heads, dtype, mem_config, 1)
+    outs1 = _run_interleaved(in1, num_q_heads, num_kv_heads, transpose_k_heads, mem_config)
+    _check(outs1, _refs_interleaved(A1, batch, seq_len, head_dim, num_q_heads, num_kv_heads, transpose_k_heads), 1.0)
+
+    A2, in2 = _make_interleaved_input(device, batch, seq_len, head_dim, num_q_heads, num_kv_heads, dtype, mem_config, 2)
+    assert in1.buffer_address() != in2.buffer_address(), "inputs must land at different addresses to exercise the hit"
+    outs2 = _run_interleaved(in2, num_q_heads, num_kv_heads, transpose_k_heads, mem_config)
+    _check(outs2, _refs_interleaved(A2, batch, seq_len, head_dim, num_q_heads, num_kv_heads, transpose_k_heads), 1.0)
+
+    assert device.num_program_cache_entries() == 1
+
+
+def test_nlp_cqkv_interleaved_shape_change(device, isolate_program_cache):
+    """Different input shape (seq_len) -> distinct entries (input TensorSpec is hashed)."""
+    head_dim, num_q_heads, num_kv_heads = 64, 8, 2
+    dtype, mem_config = ttnn.bfloat16, ttnn.DRAM_MEMORY_CONFIG
+    for seq_len in (128, 256):
+        A, in_t = _make_interleaved_input(device, 1, seq_len, head_dim, num_q_heads, num_kv_heads, dtype, mem_config, 1)
+        outs = _run_interleaved(in_t, num_q_heads, num_kv_heads, False, mem_config)
+        _check(outs, _refs_interleaved(A, 1, seq_len, head_dim, num_q_heads, num_kv_heads, False), 1.0)
+    assert device.num_program_cache_entries() == 2
+
+
+def _make_sharded_input(device, batch, seq_len, head_dim, num_q_heads, num_kv_heads, dtype, seed):
+    torch.manual_seed(seed)
+    compute_grid_size = device.compute_with_storage_grid_size()
+    num_cores = num_kv_heads
+    shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, True)
+    q_shape = [seq_len, 1, batch, num_cores, num_q_heads // num_cores * head_dim]
+    kv_shape = [seq_len, 1, batch, num_cores, num_kv_heads // num_cores * head_dim]
+    Q, K, V = torch.randn(q_shape), torch.randn(kv_shape), torch.randn(kv_shape)
+    A = torch.concat([Q.flatten(-2, -1), K.flatten(-2, -1), V.flatten(-2, -1)], -1)
+    A_interleaved = torch.concat([Q, K, V], -1).flatten(-2, -1)
+    in_shard_spec = ttnn.ShardSpec(
+        shard_grid, [seq_len * batch, A_interleaved.shape[-1] // num_cores], ttnn.ShardOrientation.ROW_MAJOR
+    )
+    in_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, in_shard_spec)
+    out_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, in_shard_spec)
+    in_t = ttnn.Tensor(A_interleaved, dtype).to(ttnn.TILE_LAYOUT).to(device, in_mem_config)
+    return A, in_t, out_mem_config
+
+
+def _refs_sharded(A, batch, seq_len, head_dim, num_q_heads, num_kv_heads):
+    ref_q, ref_k, ref_v = torch.split(
+        A, [num_q_heads * head_dim, num_kv_heads * head_dim, num_kv_heads * head_dim], dim=-1
+    )
+    ref_q = torch.reshape(ref_q, [seq_len, batch, num_q_heads, head_dim]).transpose(-3, -2)
+    ref_k = torch.reshape(ref_k, [seq_len, batch, num_kv_heads, head_dim]).transpose(-3, -2)
+    ref_v = torch.reshape(ref_v, [seq_len, batch, num_kv_heads, head_dim]).transpose(-3, -2)
+    return ref_q, ref_k, ref_v
+
+
+@skip_for_blackhole("L1 and Circular buffers are crashing on BH, see #12349")
+def test_nlp_cqkv_sharded_addr_change_on_hit(device, isolate_program_cache):
+    """Sharded factory: same config twice with re-allocated buffers -> 1 entry, all outputs correct.
+
+    The Sharded reader/writer bake q/k/v base + per-core start addresses as raw uint32 args, so this
+    is the case the old get_dynamic path guarded; override_runtime_arguments must re-derive them.
+    """
+    batch, seq_len, head_dim, num_q_heads, num_kv_heads = 32, 1, 64, 16, 8
+    dtype = ttnn.bfloat16
+
+    A1, in1, out_cfg1 = _make_sharded_input(device, batch, seq_len, head_dim, num_q_heads, num_kv_heads, dtype, 1)
+    q1, k1, v1 = ttnn.experimental.nlp_create_qkv_heads(
+        in1, None, num_heads=num_q_heads, num_kv_heads=num_kv_heads, transpose_k_heads=False, memory_config=out_cfg1
+    )
+    _check((q1, k1, v1), _refs_sharded(A1, batch, seq_len, head_dim, num_q_heads, num_kv_heads), 1.0)
+
+    A2, in2, out_cfg2 = _make_sharded_input(device, batch, seq_len, head_dim, num_q_heads, num_kv_heads, dtype, 2)
+    assert in1.buffer_address() != in2.buffer_address(), "inputs must land at different addresses to exercise the hit"
+    q2, k2, v2 = ttnn.experimental.nlp_create_qkv_heads(
+        in2, None, num_heads=num_q_heads, num_kv_heads=num_kv_heads, transpose_k_heads=False, memory_config=out_cfg2
+    )
+    _check((q2, k2, v2), _refs_sharded(A2, batch, seq_len, head_dim, num_q_heads, num_kv_heads), 1.0)
+
+    assert device.num_program_cache_entries() == 1

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.hpp
@@ -11,10 +11,10 @@
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/types.hpp"  // exposes ttnn::MemoryConfig alias used in member/signature declarations
-#include "ttnn/distributed/types.hpp"  // exposes ttnn::MeshCoordinate used in get_dynamic_runtime_args()
+#include "ttnn/distributed/types.hpp"  // exposes ttnn::MeshCoordinate used in override_runtime_arguments()
 
+#include <tt-metalium/program.hpp>
 #include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/experimental/program_descriptor_patching.hpp>
 
 namespace ttnn::operations::experimental::transformer {
 
@@ -70,17 +70,14 @@ struct NlpCreateHeadsDeviceOperation {
     // Create the output tensors based on the operation attributes and tensor args
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    // Re-apply the Sharded factory's computed input-buffer addresses on every cache hit.
-    // The Sharded reader/writer bake raw base addresses AND per-core `base + head_offset` start
-    // addresses as uint32 runtime args; a plain Buffer* binding can only express the bare base, so
-    // these address-derived slots are refreshed here instead (the output CBs are patched via their
-    // `.buffer` bindings).  Defined in nlp_create_qkv_heads_program_factory.cpp so it can reuse the
-    // shared per-core arg builder that create_descriptor() uses. Interleaved returns no dynamic args.
-    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
-        const operation_attributes_t&,
-        const tensor_args_t&,
-        tensor_return_value_t&,
-        const std::optional<ttnn::MeshCoordinate>& = std::nullopt);
+    // Re-derive ALL per-dispatch state (runtime args + tensor-backed CB addresses) on every cache hit
+    // by re-running the selected factory's create_descriptor and re-applying it to the cached program.
+    static void override_runtime_arguments(
+        tt::tt_metal::Program& program,
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 
 }  // namespace ttnn::operations::experimental::transformer

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.hpp
@@ -70,8 +70,11 @@ struct NlpCreateHeadsDeviceOperation {
     // Create the output tensors based on the operation attributes and tensor args
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    // Re-derive ALL per-dispatch state (runtime args + tensor-backed CB addresses) on every cache hit
-    // by re-running the selected factory's create_descriptor and re-applying it to the cached program.
+    // Patch the cached program's per-dispatch state in place on every cache hit: the buffer-address
+    // runtime args of whichever factory built it (the Sharded reader/writer bake raw base AND per-core
+    // `base + head_offset` start addresses, which a Buffer* binding cannot express) plus the Sharded
+    // output CB addresses.  Defined in nlp_create_qkv_heads_program_factory.cpp so it can reuse the
+    // same per-core builders create_descriptor() uses; no descriptor is rebuilt.
     static void override_runtime_arguments(
         tt::tt_metal::Program& program,
         const operation_attributes_t& operation_attributes,

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_program_factory.cpp
@@ -273,17 +273,6 @@ ProgramDescriptor NlpCreateHeadsDeviceOperation::Interleaved::create_descriptor(
 
 namespace {
 
-// Address-derived reader/writer runtime-arg slot indices for the Sharded factory.  These slots hold
-// input-buffer addresses (a raw base and per-core `base + head_offset` start addresses) that a plain
-// Buffer* binding cannot express, so they are re-applied on every cache hit via get_dynamic_runtime_args().
-// Kept next to the builder below so the baked layout and the re-applied layout cannot drift.
-constexpr uint32_t kReaderKernelIdx = 0;  // reader is pushed first in create_descriptor()
-constexpr uint32_t kWriterKernelIdx = 1;  // writer is pushed second
-constexpr uint32_t kQBaseAddrIdx = 6;     // q_base_addr
-constexpr uint32_t kQStartAddrIdx = 7;    // q_start_addr = q_base_addr + remote_q_head_start_idx * head_size
-constexpr uint32_t kKVBaseAddrIdx = 15;   // k_base_addr (reader) / v_base_addr or k_base_addr (writer)
-constexpr uint32_t kKVStartAddrIdx = 16;  // k_start_addr (reader) / v_start_addr or k_start_addr (writer)
-
 struct ShardedCoreArgs {
     CoreCoord core;
     std::vector<uint32_t> reader_args;
@@ -291,10 +280,8 @@ struct ShardedCoreArgs {
 };
 
 // Single source of truth for the Sharded per-core reader/writer runtime args, INCLUDING the
-// address-derived slots (q/k/v base + per-core start addresses).  create_descriptor() emplaces these
-// on a cache miss; get_dynamic_runtime_args() re-derives them and re-applies only the address slots on
-// every cache hit.  Both paths share this one builder so the baked and re-applied addresses cannot
-// drift (an off-by-one in a re-applied index would silently corrupt an address).
+// address-derived slots (q/k/v base + per-core start addresses).  create_descriptor() emplaces these,
+// and re-running create_descriptor on a cache hit re-derives them from the current tensors.
 std::vector<ShardedCoreArgs> build_sharded_core_args(
     const NlpCreateHeadsDeviceOperation::operation_attributes_t& operation_attributes,
     const NlpCreateHeadsDeviceOperation::tensor_args_t& tensor_args,
@@ -521,13 +508,9 @@ ProgramDescriptor NlpCreateHeadsDeviceOperation::Sharded::create_descriptor(
     writer_desc.compile_time_args = std::move(writer_compile_time_args);
     writer_desc.config = WriterConfigDescriptor{};
 
-    // Build the per-core reader/writer runtime args (including the address-derived slots) via the
-    // shared builder.  The reader/writer kernels bake raw q/k/v base addresses AND per-core
-    // `base + head_offset` start addresses as uint32 runtime args; a plain Buffer* binding can only
-    // express the bare base, so those address-derived slots cannot be registered as BufferBindings.
-    // Instead they are refreshed on every cache hit by get_dynamic_runtime_args() (which re-runs this
-    // same builder), tripping the descriptor fast-path while the output CBs are patched via their
-    // `.buffer` bindings.
+    // Build the per-core reader/writer runtime args (including the address-derived q/k/v base and
+    // per-core start-address slots) via the shared builder.  override_runtime_arguments() re-runs this
+    // whole factory on a cache hit, so every address slot is re-derived from the current tensors.
     auto per_core_args = build_sharded_core_args(operation_attributes, tensor_args, tensor_return_value);
     for (auto& e : per_core_args) {
         reader_desc.runtime_args.emplace_back(e.core, std::move(e.reader_args));
@@ -540,37 +523,18 @@ ProgramDescriptor NlpCreateHeadsDeviceOperation::Sharded::create_descriptor(
     return desc;
 }
 
-std::vector<tt::tt_metal::DynamicRuntimeArg> NlpCreateHeadsDeviceOperation::get_dynamic_runtime_args(
+void NlpCreateHeadsDeviceOperation::override_runtime_arguments(
+    tt::tt_metal::Program& program,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    // Only the Sharded factory smuggles computed addresses; the Interleaved factory binds its
-    // input/output buffers via emplace_runtime_args(Buffer*) and needs no dynamic re-application.
-    const auto factory = select_program_factory(operation_attributes, tensor_args);
-    if (!std::holds_alternative<Sharded>(factory)) {
-        return {};
-    }
-
-    // Re-run the shared per-core builder so the addresses re-applied here are, by construction,
-    // identical to those baked in create_descriptor().  For every active core re-apply the four
-    // address-derived slots on both the reader (kernel 0) and writer (kernel 1).  The active core
-    // set is fixed by the (hashed) output shard specs, so it never grows across hits and every core
-    // that received args on the cache miss also gets them here.
-    auto per_core_args = build_sharded_core_args(operation_attributes, tensor_args, tensor_return_value);
-    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
-    dynamic_args.reserve(per_core_args.size() * 8);
-    for (const auto& e : per_core_args) {
-        dynamic_args.push_back({kReaderKernelIdx, e.core, kQBaseAddrIdx, e.reader_args[kQBaseAddrIdx]});
-        dynamic_args.push_back({kReaderKernelIdx, e.core, kQStartAddrIdx, e.reader_args[kQStartAddrIdx]});
-        dynamic_args.push_back({kReaderKernelIdx, e.core, kKVBaseAddrIdx, e.reader_args[kKVBaseAddrIdx]});
-        dynamic_args.push_back({kReaderKernelIdx, e.core, kKVStartAddrIdx, e.reader_args[kKVStartAddrIdx]});
-        dynamic_args.push_back({kWriterKernelIdx, e.core, kQBaseAddrIdx, e.writer_args[kQBaseAddrIdx]});
-        dynamic_args.push_back({kWriterKernelIdx, e.core, kQStartAddrIdx, e.writer_args[kQStartAddrIdx]});
-        dynamic_args.push_back({kWriterKernelIdx, e.core, kKVBaseAddrIdx, e.writer_args[kKVBaseAddrIdx]});
-        dynamic_args.push_back({kWriterKernelIdx, e.core, kKVStartAddrIdx, e.writer_args[kKVStartAddrIdx]});
-    }
-    return dynamic_args;
+    // Re-derive ALL per-dispatch state from the picked factory's create_descriptor (single source of
+    // truth) and re-apply it to the cached program — no rebuild. Supersedes get_dynamic_runtime_args.
+    auto desc = std::visit(
+        [&](auto factory) { return factory.create_descriptor(operation_attributes, tensor_args, tensor_return_value); },
+        select_program_factory(operation_attributes, tensor_args));
+    tt::tt_metal::apply_descriptor_runtime_args(program, desc);
 }
 
 }  // namespace ttnn::operations::experimental::transformer

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_program_factory.cpp
@@ -3,7 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-metalium/buffer.hpp>
+#include <tt-metalium/circular_buffer.hpp>
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
@@ -16,6 +18,69 @@ using namespace tt::constants;
 using namespace tt;
 using namespace tt::tt_metal;
 
+namespace {
+
+// Runtime-arg slots holding buffer addresses, matched positionally by the kernels.  Both factories
+// pass addresses as plain uint32 runtime args, so override_runtime_arguments() re-applies exactly
+// these on every cache hit; every other slot is derived from state the program hash covers.
+constexpr uint32_t kInterleavedReaderIn0AddrIdx = 0;
+constexpr uint32_t kInterleavedReaderIn1AddrIdx = 1;  // literal 0 when there is no separate KV input
+constexpr uint32_t kInterleavedWriterQAddrIdx = 0;
+constexpr uint32_t kInterleavedWriterKAddrIdx = 1;
+constexpr uint32_t kInterleavedWriterVAddrIdx = 2;
+
+constexpr uint32_t kShardedQBaseAddrIdx = 6;
+constexpr uint32_t kShardedQStartAddrIdx = 7;    // q_base_addr + remote_q_head_start_idx * head_size
+constexpr uint32_t kShardedKVBaseAddrIdx = 15;   // k_base_addr on the reader, v_base_addr on the writer
+constexpr uint32_t kShardedKVStartAddrIdx = 16;  // ..._base_addr + remote_kv_head_start_idx * head_size
+
+// Single source of truth for the Interleaved factory's per-core work split.  create_descriptor() and
+// override_runtime_arguments() both walk `cores` in this order, so the core -> runtime-arg-slot
+// mapping cannot drift; it also carries the reader/writer kernel indices, which shift when the
+// transpose_k_heads compute kernels are present.
+struct InterleavedWorkSplit {
+    std::vector<CoreCoord> cores;
+    CoreRangeSet all_cores;
+    CoreRangeSet core_group_1;
+    CoreRangeSet core_group_2;
+    uint32_t num_blocks_per_core_group_1 = 0;
+    uint32_t num_blocks_per_core_group_2 = 0;
+    // Kernel push order in create_descriptor(): [compute core_group_1, [compute core_group_2,]]
+    // reader, writer.  The compute kernels exist only when transpose_k_heads, and the second one only
+    // when core_group_2 is non-empty.
+    uint32_t reader_kernel_idx = 0;
+    uint32_t writer_kernel_idx = 1;
+};
+
+InterleavedWorkSplit build_interleaved_work_split(
+    const NlpCreateHeadsDeviceOperation::operation_attributes_t& operation_attributes, const Tensor& input_tensor) {
+    const auto& input_shape = input_tensor.padded_shape();
+    const CoreCoord grid = input_tensor.device()->compute_with_storage_grid_size();
+    const uint32_t num_cores_y = grid.y;
+    // Block is a unit of work; ie. num of in0_w_tiles per core
+    const uint32_t num_blocks = input_shape[0] * input_shape[1] * input_shape[2] / TILE_HEIGHT;
+    auto [num_cores, all_cores, core_group_1, core_group_2, blocks_group_1, blocks_group_2] =
+        tt::tt_metal::split_work_to_cores(grid, num_blocks);
+
+    InterleavedWorkSplit split;
+    split.all_cores = std::move(all_cores);
+    split.core_group_1 = std::move(core_group_1);
+    split.core_group_2 = std::move(core_group_2);
+    split.num_blocks_per_core_group_1 = blocks_group_1;
+    split.num_blocks_per_core_group_2 = blocks_group_2;
+    split.cores.reserve(num_cores);
+    for (uint32_t i = 0; i < num_cores; ++i) {
+        split.cores.push_back(CoreCoord{i / num_cores_y, i % num_cores_y});
+    }
+    const uint32_t num_compute_kernels =
+        operation_attributes.transpose_k_heads ? (split.core_group_2.num_cores() > 0 ? 2 : 1) : 0;
+    split.reader_kernel_idx = num_compute_kernels;
+    split.writer_kernel_idx = num_compute_kernels + 1;
+    return split;
+}
+
+}  // namespace
+
 ProgramDescriptor NlpCreateHeadsDeviceOperation::Interleaved::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
@@ -27,7 +92,6 @@ ProgramDescriptor NlpCreateHeadsDeviceOperation::Interleaved::create_descriptor(
     const uint32_t head_dim = operation_attributes.head_dim;
     const bool transpose_k_heads = operation_attributes.transpose_k_heads;
     auto& output = tensor_return_value;
-    CoreCoord compute_with_storage_grid_size = input_tensor.device()->compute_with_storage_grid_size();
 
     const auto& input_shape = input_tensor.padded_shape();
 
@@ -67,11 +131,12 @@ ProgramDescriptor NlpCreateHeadsDeviceOperation::Interleaved::create_descriptor(
     uint32_t q_num_tiles = num_q_heads * q_out_w_tiles;
     uint32_t kv_num_tiles = num_kv_heads * q_out_w_tiles;
 
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
-    // Block is a unit of work; ie. num of in0_w_tiles per core
-    uint32_t num_blocks = input_shape[0] * input_shape[1] * input_shape[2] / TILE_HEIGHT;
-    auto [num_cores, all_cores, core_group_1, core_group_2, num_blocks_per_core_group_1, num_blocks_per_core_group_2] =
-        tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_blocks);
+    const auto split = build_interleaved_work_split(operation_attributes, input_tensor);
+    const auto& all_cores = split.all_cores;
+    const auto& core_group_1 = split.core_group_1;
+    const auto& core_group_2 = split.core_group_2;
+    const uint32_t num_blocks_per_core_group_1 = split.num_blocks_per_core_group_1;
+    const uint32_t num_blocks_per_core_group_2 = split.num_blocks_per_core_group_2;
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Grayskull Device Setup
@@ -216,8 +281,8 @@ ProgramDescriptor NlpCreateHeadsDeviceOperation::Interleaved::create_descriptor(
         });
     }
 
-    for (uint32_t i = 0, num_blocks_written = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+    uint32_t num_blocks_written = 0;
+    for (const CoreCoord& core : split.cores) {
         uint32_t num_blocks_per_core = 0;
         if (core_group_1.contains(core)) {
             num_blocks_per_core = num_blocks_per_core_group_1;
@@ -280,8 +345,10 @@ struct ShardedCoreArgs {
 };
 
 // Single source of truth for the Sharded per-core reader/writer runtime args, INCLUDING the
-// address-derived slots (q/k/v base + per-core start addresses).  create_descriptor() emplaces these,
-// and re-running create_descriptor on a cache hit re-derives them from the current tensors.
+// address-derived slots (q/k/v base + per-core start addresses).  create_descriptor() emplaces these
+// on a cache miss; override_runtime_arguments() re-runs this builder and patches only the address
+// slots in place on every cache hit.  Both paths share this one builder so the baked and the
+// re-applied addresses cannot drift (an off-by-one index would silently corrupt an address).
 std::vector<ShardedCoreArgs> build_sharded_core_args(
     const NlpCreateHeadsDeviceOperation::operation_attributes_t& operation_attributes,
     const NlpCreateHeadsDeviceOperation::tensor_args_t& tensor_args,
@@ -509,8 +576,10 @@ ProgramDescriptor NlpCreateHeadsDeviceOperation::Sharded::create_descriptor(
     writer_desc.config = WriterConfigDescriptor{};
 
     // Build the per-core reader/writer runtime args (including the address-derived q/k/v base and
-    // per-core start-address slots) via the shared builder.  override_runtime_arguments() re-runs this
-    // whole factory on a cache hit, so every address slot is re-derived from the current tensors.
+    // per-core start-address slots) via the shared builder.  The reader/writer kernels bake raw q/k/v
+    // base addresses AND per-core `base + head_offset` start addresses as uint32 runtime args; a plain
+    // Buffer* binding can only express the bare base, so those slots are re-applied on every cache hit
+    // by override_runtime_arguments() (which re-runs this same builder).
     auto per_core_args = build_sharded_core_args(operation_attributes, tensor_args, tensor_return_value);
     for (auto& e : per_core_args) {
         reader_desc.runtime_args.emplace_back(e.core, std::move(e.reader_args));
@@ -529,12 +598,64 @@ void NlpCreateHeadsDeviceOperation::override_runtime_arguments(
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    // Re-derive ALL per-dispatch state from the picked factory's create_descriptor (single source of
-    // truth) and re-apply it to the cached program — no rebuild. Supersedes get_dynamic_runtime_args.
-    auto desc = std::visit(
-        [&](auto factory) { return factory.create_descriptor(operation_attributes, tensor_args, tensor_return_value); },
-        select_program_factory(operation_attributes, tensor_args));
-    tt::tt_metal::apply_descriptor_runtime_args(program, desc);
+    auto& output = tensor_return_value;
+
+    // Mirror select_program_factory() so the patched slots belong to the factory that actually built
+    // this cached program.  Only per-dispatch state is re-applied: buffer addresses (override
+    // supersedes resolve_bindings, so nothing else re-points them) and the globally-allocated output
+    // CBs.  Every other slot derives from the operation attributes or the input/output TensorSpecs,
+    // which the program hash covers, so a cache hit means they are identical by construction.
+    if (std::holds_alternative<Sharded>(select_program_factory(operation_attributes, tensor_args))) {
+        // Kernel push order in Sharded::create_descriptor(): reader 0, writer 1.
+        constexpr uint32_t kReaderKernelIdx = 0;
+        constexpr uint32_t kWriterKernelIdx = 1;
+        constexpr uint32_t kAddrIdxs[] = {
+            kShardedQBaseAddrIdx, kShardedQStartAddrIdx, kShardedKVBaseAddrIdx, kShardedKVStartAddrIdx};
+
+        // The active core set is fixed by the (hashed) shard specs, so it never grows across hits:
+        // every core the miss emplaced args for is covered here.
+        for (const auto& e : build_sharded_core_args(operation_attributes, tensor_args, output)) {
+            auto& reader_args = GetRuntimeArgs(program, kReaderKernelIdx, e.core);
+            auto& writer_args = GetRuntimeArgs(program, kWriterKernelIdx, e.core);
+            for (const uint32_t idx : kAddrIdxs) {
+                reader_args[idx] = e.reader_args[idx];
+                writer_args[idx] = e.writer_args[idx];
+            }
+        }
+
+        // CB push order in Sharded::create_descriptor(): q 0, k 1, v 2 — each globally allocated on
+        // the matching output shard buffer, whose address moves on every re-allocation.
+        const auto cbs = program.circular_buffers();
+        UpdateDynamicCircularBufferAddress(program, cbs[0]->id(), *std::get<0>(output).buffer());
+        UpdateDynamicCircularBufferAddress(program, cbs[1]->id(), *std::get<1>(output).buffer());
+        UpdateDynamicCircularBufferAddress(program, cbs[2]->id(), *std::get<2>(output).buffer());
+        return;
+    }
+
+    // Interleaved: the reader takes the input (and optional KV input) addresses, the writer the three
+    // output addresses; the Interleaved CBs are not globally allocated, so there is nothing to
+    // re-point there.
+    const Tensor& input_tensor = tensor_args.input_tensor_q;
+    const auto split = build_interleaved_work_split(operation_attributes, input_tensor);
+
+    const uint32_t in0_addr = input_tensor.buffer()->address();
+    const bool read_from_input_tensor_kv = tensor_args.input_tensor_kv.has_value();
+    const uint32_t in1_addr = read_from_input_tensor_kv ? tensor_args.input_tensor_kv->buffer()->address() : 0;
+    const uint32_t q_addr = std::get<0>(output).buffer()->address();
+    const uint32_t k_addr = std::get<1>(output).buffer()->address();
+    const uint32_t v_addr = std::get<2>(output).buffer()->address();
+
+    for (const CoreCoord& core : split.cores) {
+        auto& reader_args = GetRuntimeArgs(program, split.reader_kernel_idx, core);
+        reader_args[kInterleavedReaderIn0AddrIdx] = in0_addr;
+        if (read_from_input_tensor_kv) {
+            reader_args[kInterleavedReaderIn1AddrIdx] = in1_addr;
+        }
+        auto& writer_args = GetRuntimeArgs(program, split.writer_kernel_idx, core);
+        writer_args[kInterleavedWriterQAddrIdx] = q_addr;
+        writer_args[kInterleavedWriterKAddrIdx] = k_addr;
+        writer_args[kInterleavedWriterVAddrIdx] = v_addr;
+    }
 }
 
 }  // namespace ttnn::operations::experimental::transformer


### PR DESCRIPTION
## What
Migrates `nlp_create_qkv_heads` off `get_dynamic_runtime_args` to `override_runtime_arguments` (#49828 mechanism). Multi-factory (interleaved/sharded) via `select_program_factory`. `get_dynamic_runtime_args` removed.

## Metrics (Wormhole B0, host cache-hit dispatch, min-of-medians 3×100)
- **perf:** 50→54 µs (+8%, within noise — no regression)
- **PCC:** 1.000 on Q/K/V (cache-hit with reallocated inputs)
- **cache-hit:** addr-change on hit (interleaved + sharded), entry count stable ✅

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/gd-nlp-qkv)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/gd-nlp-qkv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/gd-nlp-qkv)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/gd-nlp-qkv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/gd-nlp-qkv)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/gd-nlp-qkv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/gd-nlp-qkv)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/gd-nlp-qkv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/gd-nlp-qkv)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/gd-nlp-qkv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/gd-nlp-qkv)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/gd-nlp-qkv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/gd-nlp-qkv)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/gd-nlp-qkv)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/gd-nlp-qkv)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/gd-nlp-qkv)