### PR TITLE
[ttnn] experimental/dropout: replace get_dynamic_runtime_args with override_runtime_arguments

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_dropout.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_dropout.py
@@ -88,8 +88,36 @@ def test_dropout_seed_distinguishes_cache_entries(device, in_place):
     out_c = run(5678)
     entries_c = device.num_program_cache_entries()
 
+    assert entries_a == 1, "the first dispatch must create exactly one cache entry"
     assert entries_b == entries_a, "same seed must reuse the cached program"
     assert entries_c == entries_a, "a different seed must NOT add a cache entry -- seed is dynamic, not hashed"
     assert not torch.equal(out_a, out_c), "a different seed must change the dropout mask (seed re-patched on fast path)"
+
+    device.disable_and_clear_program_cache()
+
+
+def test_dropout_cache_hit_rederives_buffer_address(device):
+    """On a cache hit the override must re-derive the input/output buffer addresses from the current
+    tensors (not reuse the first-miss addresses). Reallocate a fresh input with different VALUES between
+    two same-shape dispatches: the kept (non-dropped) outputs must reflect the second input, proving the
+    program read the new buffer address."""
+    device.enable_program_cache()
+    device.clear_program_cache()
+
+    scale = 2.0
+    shape = (1, 1, 32, 64)
+
+    a = ttnn.from_torch(torch.ones(shape), device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+    ttnn.to_torch(ttnn.experimental.dropout(a, probability=0.5, scale=scale, seed=1234))  # miss
+
+    b = ttnn.from_torch(torch.full(shape, 3.0), device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+    out_b = ttnn.to_torch(ttnn.experimental.dropout(b, probability=0.5, scale=scale, seed=1234)).float()
+
+    assert device.num_program_cache_entries() == 1, "same-shape dispatch must reuse the cached program"
+    nonzero = out_b[out_b != 0.0]
+    assert nonzero.numel() > 0, "expected some elements to survive dropout"
+    assert torch.allclose(
+        nonzero, torch.full_like(nonzero, 3.0 * scale)
+    ), "kept outputs must be 3.0*scale -- proves the hit re-derived the new input buffer address"
 
     device.disable_and_clear_program_cache()

--- a/tests/ttnn/unit_tests/operations/data_movement/test_dropout.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_dropout.py
@@ -60,9 +60,14 @@ def test_dropout_output_tensor(device):
 
 
 @pytest.mark.parametrize("in_place", [False, True])
-def test_dropout_seed_distinguishes_cache_entries(device, in_place):
+@pytest.mark.parametrize("use_per_device_seed", [False, True])
+def test_dropout_seed_distinguishes_cache_entries(device, in_place, use_per_device_seed):
     """Regression guard for dropout's seed static/dynamic contract, on both the distinct-output and
-    in-place (output_tensor==input) fast paths.
+    in-place (output_tensor==input) fast paths, and both program factories.
+
+    `use_per_device_seed` selects the factory and the cache-hit seed-derivation branch in
+    override_runtime_arguments: True -> DropoutMeshWorkloadFactory (per-device offset), False ->
+    DropoutProgramFactory (raw seed, the branch distributed tt-train uses).
 
     `seed` is excluded from compute_program_hash (so calls differing only in seed cache-hit) but
     must be re-applied to the cached program on every dispatch. Pins both halves:
@@ -78,7 +83,9 @@ def test_dropout_seed_distinguishes_cache_entries(device, in_place):
 
     def run(seed):
         out_kwargs = {"output_tensor": tensor} if in_place else {}
-        out = ttnn.experimental.dropout(tensor, probability=0.5, scale=2.0, seed=seed, **out_kwargs)
+        out = ttnn.experimental.dropout(
+            tensor, probability=0.5, scale=2.0, seed=seed, use_per_device_seed=use_per_device_seed, **out_kwargs
+        )
         return ttnn.to_torch(out).float().clone()
 
     out_a = run(1234)
@@ -107,13 +114,23 @@ def test_dropout_cache_hit_rederives_buffer_address(device):
     scale = 2.0
     shape = (1, 1, 32, 64)
 
+    # Hold both inputs and both outputs alive across the two dispatches: the second input/output cannot
+    # reuse the first's freed slot, so their addresses are guaranteed to differ (asserted below). This
+    # makes the re-derivation actually exercised -- if the allocator handed back the first-miss address a
+    # frozen (never re-derived) dst_addr would still pass, a false negative.
     a = ttnn.from_torch(torch.ones(shape), device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
-    ttnn.to_torch(ttnn.experimental.dropout(a, probability=0.5, scale=scale, seed=1234))  # miss
+    out_a = ttnn.experimental.dropout(a, probability=0.5, scale=scale, seed=1234)  # miss
+    ttnn.to_torch(out_a)
 
     b = ttnn.from_torch(torch.full(shape, 3.0), device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
-    out_b = ttnn.to_torch(ttnn.experimental.dropout(b, probability=0.5, scale=scale, seed=1234)).float()
+    out_b_tensor = ttnn.experimental.dropout(b, probability=0.5, scale=scale, seed=1234)
+    out_b = ttnn.to_torch(out_b_tensor).float()
 
     assert device.num_program_cache_entries() == 1, "same-shape dispatch must reuse the cached program"
+    assert a.buffer_address() != b.buffer_address(), "second input must land at a different address"
+    assert (
+        out_a.buffer_address() != out_b_tensor.buffer_address()
+    ), "second output must land at a different address (dst_addr re-derivation)"
     nonzero = out_b[out_b != 0.0]
     assert nonzero.numel() > 0, "expected some elements to survive dropout"
     assert torch.allclose(

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.hpp
@@ -33,13 +33,14 @@ struct DropoutDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    // seed is excluded from the program hash (so calls differing only in seed cache-hit); it is
-    // DYNAMIC and re-applied to the cached program on every dispatch (per-device offset applied when
-    // use_per_device_seed). Must mirror the compute-kernel seed runtime arg in the factory.
-    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
-        const operation_attributes_t& args,
+    // Re-derives ALL per-dispatch state (seed, buffer addresses) on every cache hit by re-running the
+    // selected factory's create_descriptor. seed is hash-excluded (per-device offset applied when
+    // use_per_device_seed); supersedes get_dynamic_runtime_args and resolve_bindings.
+    static void override_runtime_arguments(
+        tt::tt_metal::Program& program,
+        const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output,
+        tensor_return_value_t& tensor_return_value,
         const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.hpp
@@ -33,8 +33,8 @@ struct DropoutDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    // Re-derives ALL per-dispatch state (seed, buffer addresses) on every cache hit by re-running the
-    // selected factory's create_descriptor. seed is hash-excluded (per-device offset applied when
+    // Patches ALL per-dispatch state (seed, src/dst addresses) into the cached program on every cache
+    // hit -- in place, no descriptor rebuild. seed is hash-excluded (per-device offset applied when
     // use_per_device_seed); supersedes get_dynamic_runtime_args and resolve_bindings.
     static void override_runtime_arguments(
         tt::tt_metal::Program& program,

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.hpp
@@ -32,16 +32,6 @@ struct DropoutDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    // Patches ALL per-dispatch state (seed, src/dst addresses) into the cached program on every cache
-    // hit -- in place, no descriptor rebuild. seed is hash-excluded (per-device offset applied when
-    // use_per_device_seed); supersedes get_dynamic_runtime_args and resolve_bindings.
-    static void override_runtime_arguments(
-        tt::tt_metal::Program& program,
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value,
-        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation_types.hpp
@@ -22,7 +22,7 @@ struct DropoutParams {
     const float prob = 0.0f;
     const float scale = 1.0f;
 
-    // `seed` is re-applied via get_dynamic_runtime_args, so it is excluded from the program hash
+    // `seed` is re-applied via override_runtime_arguments, so it is excluded from the program hash
     // (calls differing only in seed cache-hit). `prob`/`scale` are baked as compile-time args and
     // `use_per_device_seed` selects the program factory, so all three are structural and kept.
     static constexpr auto attribute_names =
@@ -35,8 +35,8 @@ struct DropoutParams {
 // tensor_args must stay a plain reflectable aggregate: the device-operation framework walks it
 // structurally to discover the Tensor leaves (output-spec counting, buffer extraction). Compile-time
 // attributes here would both be ambiguous against the Reflectable visitor and hide the Tensors, so
-// the input is hashed in full via its tt::tt_metal::TensorSpec (correct and stricter than the old volume-only
-// hash; the seed is still excluded via DropoutParams + get_dynamic_runtime_args).
+// the input is hashed in full via its TensorSpec (correct and stricter than the old volume-only
+// hash; the seed is still excluded via DropoutParams + override_runtime_arguments).
 struct DropoutInputs {
     const Tensor& input;
     std::optional<Tensor> preallocated_output;

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
@@ -143,7 +143,7 @@ inline tt::tt_metal::KernelDescriptor create_compute_kernel(
  * Set up the runtime arguments for the relevant kernels (reader, writer, compute G1, compute G2)
  *        for each core in the grid.
  */
-// Work split shared by create_descriptor (cache miss) and get_dynamic_runtime_args (cache hit).
+// Work split used by create_descriptor (miss and, via override_runtime_arguments, hit).
 struct DropoutCoreSplit {
     uint32_t num_cores = 0;
     uint32_t num_cores_y = 0;
@@ -211,8 +211,8 @@ inline void assign_per_core_runtime_args(
             TT_THROW("Core not in specified core ranges.");
         }
         // Reader kernel: (src_addr, number_of_tiles, offset_in_tiles).  src/dst go in as Buffer*
-        // bindings so the framework patches their addresses on the fast cache-hit path (the
-        // input==output in-place case is allowed by resolve_bindings).
+        // bindings so create_descriptor resolves their current addresses, re-applied on the cache-hit
+        // path by override_runtime_arguments (correct for the input==output in-place case).
         kernels.reader.emplace_runtime_args(core, {src_buffer, num_tiles_per_core, num_tiles_written});
 
         // Writer kernel: (dst_addr, number_of_tiles, offset_in_tiles)
@@ -344,42 +344,19 @@ tt::tt_metal::ProgramDescriptor DropoutMeshWorkloadFactory::create_descriptor(
     return DropoutProgramFactory::create_descriptor(effective_args, tensor_args, output);
 }
 
-std::vector<tt::tt_metal::DynamicRuntimeArg> DropoutDeviceOperation::get_dynamic_runtime_args(
-    const operation_attributes_t& args,
+void DropoutDeviceOperation::override_runtime_arguments(
+    tt::tt_metal::Program& program,
+    const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& /*output*/,
+    tensor_return_value_t& tensor_return_value,
     const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
-    using namespace tt::tt_metal;
-
-    // seed is the only dynamic arg (prob/scale are compile-time); per-device path offsets by device id.
-    const uint32_t seed = args.use_per_device_seed
-                              ? override_per_device_seed(args, mesh_dispatch_coordinate, tensor_args.input).seed
-                              : args.seed;
-
-    [[maybe_unused]] auto
-        [num_cores,
-         num_cores_y,
-         all_cores,
-         core_group_1,
-         core_group_2,
-         num_tiles_per_core_group_1,
-         num_tiles_per_core_group_2] = dropout_core_split(tensor_args.input);
-
-    // kernels are pushed reader(0), writer(1), compute_group_1(2), compute_group_2(3 if present).
-    constexpr uint32_t kComputeGroup1Idx = 2;
-    constexpr uint32_t kComputeGroup2Idx = 3;
-
-    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
-    dynamic_args.reserve(num_cores);
-    for (uint32_t i = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-        if (core_group_1.contains(core)) {
-            dynamic_args.push_back({kComputeGroup1Idx, core, 0, seed});
-        } else if (core_group_2.contains(core)) {
-            dynamic_args.push_back({kComputeGroup2Idx, core, 0, seed});
-        }
-    }
-    return dynamic_args;
+    // Re-derive the descriptor from the factory select_program_factory would pick (per-device path offsets
+    // the seed by device id via the coord) and re-apply it to the cached program. No rebuild (still a hit).
+    auto desc = operation_attributes.use_per_device_seed
+                    ? DropoutMeshWorkloadFactory::create_descriptor(
+                          operation_attributes, tensor_args, tensor_return_value, mesh_dispatch_coordinate)
+                    : DropoutProgramFactory::create_descriptor(operation_attributes, tensor_args, tensor_return_value);
+    tt::tt_metal::apply_descriptor_runtime_args(program, desc);
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
@@ -175,7 +175,7 @@ struct DropoutCoreWork {
 // override_runtime_arguments so the per-core layout the cache-hit patch writes cannot drift from the
 // one the cache-miss build baked.
 template <typename Fn>
-void for_each_dropout_core(const DropoutCoreSplit& split, Fn&& fn) {
+void for_each_dropout_core(const DropoutCoreSplit& split, const Fn& fn) {
     for (uint32_t i = 0, num_tiles_written = 0; i < split.num_cores; i++) {
         const tt::tt_metal::CoreCoord core = {i / split.num_cores_y, i % split.num_cores_y};
         const bool in_group_1 = split.core_group_1.contains(core);

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
@@ -27,18 +27,16 @@ constexpr auto kOutputCbIndex = tt::CBIndex::c_2;
 constexpr uint32_t kNumInputTiles = 2;
 constexpr uint32_t kNumOutputTiles = 2;
 
-// Overrides the seed with a per-device seed by using the device ID as an offset.
-DropoutParams override_per_device_seed(
+// Offsets the seed by the device ID so each device of a mesh draws a different mask.
+// Single-sourced: used by DropoutMeshWorkloadFactory::create_descriptor (cache miss) and by
+// override_runtime_arguments (cache hit), which must reproduce the same seed bit-for-bit.
+uint32_t per_device_seed(
     const DropoutParams& args,
     const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate,
     const ttnn::Tensor& input_tensor) {
-    DropoutParams args_with_per_device_seed = args;
-    if (mesh_dispatch_coordinate.has_value()) {
-        args_with_per_device_seed.seed += input_tensor.device()->get_device(*mesh_dispatch_coordinate)->id();
-    } else {
-        args_with_per_device_seed.seed += input_tensor.device()->id();
-    }
-    return args_with_per_device_seed;
+    auto* device = input_tensor.device();
+    return args.seed +
+           (mesh_dispatch_coordinate.has_value() ? device->get_device(*mesh_dispatch_coordinate)->id() : device->id());
 }
 
 }  // namespace
@@ -139,11 +137,7 @@ inline tt::tt_metal::KernelDescriptor create_compute_kernel(
     return descriptor;
 }
 
-/**
- * Set up the runtime arguments for the relevant kernels (reader, writer, compute G1, compute G2)
- *        for each core in the grid.
- */
-// Work split used by create_descriptor (miss and, via override_runtime_arguments, hit).
+// Work split used by create_descriptor (cache miss) and override_runtime_arguments (cache hit).
 struct DropoutCoreSplit {
     uint32_t num_cores = 0;
     uint32_t num_cores_y = 0;
@@ -169,57 +163,71 @@ DropoutCoreSplit dropout_core_split(const Tensor& input) {
         num_tiles_per_core_group_2};
 }
 
+// Per-core slice of the work split.
+struct DropoutCoreWork {
+    tt::tt_metal::CoreCoord core;
+    uint32_t num_tiles = 0;
+    uint32_t tile_offset = 0;
+    bool in_group_1 = false;  // otherwise in core_group_2
+};
+
+// Walks the cores in the exact order create_descriptor emplaces runtime args for them. Shared with
+// override_runtime_arguments so the per-core layout the cache-hit patch writes cannot drift from the
+// one the cache-miss build baked.
+template <typename Fn>
+void for_each_dropout_core(const DropoutCoreSplit& split, Fn&& fn) {
+    for (uint32_t i = 0, num_tiles_written = 0; i < split.num_cores; i++) {
+        const tt::tt_metal::CoreCoord core = {i / split.num_cores_y, i % split.num_cores_y};
+        const bool in_group_1 = split.core_group_1.contains(core);
+        TT_FATAL(
+            in_group_1 || split.core_group_2.contains(core),
+            "Core ({}, {}) is not in the specified core ranges",
+            core.x,
+            core.y);
+        const uint32_t num_tiles = in_group_1 ? split.num_tiles_per_core_group_1 : split.num_tiles_per_core_group_2;
+
+        fn(DropoutCoreWork{core, num_tiles, num_tiles_written, in_group_1});
+
+        num_tiles_written += num_tiles;
+    }
+}
+
+/**
+ * Set up the runtime arguments for the relevant kernels (reader, writer, compute G1, compute G2)
+ *        for each core in the grid.
+ */
 inline void assign_per_core_runtime_args(
     DropoutKernels& kernels,
     tt::tt_metal::Buffer* src_buffer,
     tt::tt_metal::Buffer* dst_buffer,
-    uint32_t num_cores,
-    uint32_t num_cores_y,
-    uint32_t num_tiles_per_core_group_1,
-    uint32_t num_tiles_per_core_group_2,
-    const tt::tt_metal::CoreRangeSet& core_group_1,
-    const tt::tt_metal::CoreRangeSet& core_group_2,
+    const DropoutCoreSplit& split,
     uint32_t seed) {
     using namespace tt::tt_metal;
 
-    kernels.reader.runtime_args.reserve(num_cores);
-    kernels.writer.runtime_args.reserve(num_cores);
-    kernels.compute_group_1.runtime_args.reserve(num_cores);
+    kernels.reader.runtime_args.reserve(split.num_cores);
+    kernels.writer.runtime_args.reserve(split.num_cores);
+    kernels.compute_group_1.runtime_args.reserve(split.num_cores);
     if (kernels.compute_group_2.has_value()) {
-        kernels.compute_group_2->runtime_args.reserve(num_cores);
+        kernels.compute_group_2->runtime_args.reserve(split.num_cores);
     }
 
-    for (uint32_t i = 0, num_tiles_written = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-
-        // Determine how many tiles this core will process
-        uint32_t num_tiles_per_core = 0;
-        if (core_group_1.contains(core)) {
-            num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.contains(core)) {
-            num_tiles_per_core = num_tiles_per_core_group_2;
+    for_each_dropout_core(split, [&](const DropoutCoreWork& work) {
+        // Compute kernel: (seed)
+        if (work.in_group_1) {
+            kernels.compute_group_1.runtime_args.emplace_back(work.core, KernelDescriptor::CoreRuntimeArgs{seed});
         } else {
-            TT_ASSERT(false, "Core not in specified core ranges");
-        }
-
-        if (core_group_1.contains(core)) {
-            kernels.compute_group_1.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{seed});
-        } else if (core_group_2.contains(core)) {
             TT_FATAL(kernels.compute_group_2.has_value(), "Core group 2 descriptor should be present");
-            kernels.compute_group_2->runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{seed});
-        } else {
-            TT_THROW("Core not in specified core ranges.");
+            kernels.compute_group_2->runtime_args.emplace_back(work.core, KernelDescriptor::CoreRuntimeArgs{seed});
         }
+
         // Reader kernel: (src_addr, number_of_tiles, offset_in_tiles).  src/dst go in as Buffer*
-        // bindings so create_descriptor resolves their current addresses, re-applied on the cache-hit
-        // path by override_runtime_arguments (correct for the input==output in-place case).
-        kernels.reader.emplace_runtime_args(core, {src_buffer, num_tiles_per_core, num_tiles_written});
+        // bindings so this cache-miss build resolves their current addresses; on a cache hit
+        // override_runtime_arguments re-applies them (correct for the input==output in-place case).
+        kernels.reader.emplace_runtime_args(work.core, {src_buffer, work.num_tiles, work.tile_offset});
 
         // Writer kernel: (dst_addr, number_of_tiles, offset_in_tiles)
-        kernels.writer.emplace_runtime_args(core, {dst_buffer, num_tiles_per_core, num_tiles_written});
-
-        num_tiles_written += num_tiles_per_core;
-    }
+        kernels.writer.emplace_runtime_args(work.core, {dst_buffer, work.num_tiles, work.tile_offset});
+    });
 }
 
 tt::tt_metal::ProgramDescriptor DropoutProgramFactory::create_descriptor(
@@ -240,14 +248,13 @@ tt::tt_metal::ProgramDescriptor DropoutProgramFactory::create_descriptor(
     uint32_t single_tile_size_in = tt::tile_size(data_fmt_in);
     uint32_t single_tile_size_out = tt::tile_size(data_fmt_out);
 
-    auto
-        [num_cores,
-         num_cores_y,
-         all_cores,
-         core_group_1,
-         core_group_2,
-         num_tiles_per_core_group_1,
-         num_tiles_per_core_group_2] = dropout_core_split(input);
+    // Kept whole so it can be handed to for_each_dropout_core, the walk shared with the cache-hit patch.
+    const auto split = dropout_core_split(input);
+    const auto& all_cores = split.all_cores;
+    const auto& core_group_1 = split.core_group_1;
+    const auto& core_group_2 = split.core_group_2;
+    const uint32_t num_tiles_per_core_group_1 = split.num_tiles_per_core_group_1;
+    const uint32_t num_tiles_per_core_group_2 = split.num_tiles_per_core_group_2;
 
     // -------------------------------------------------------------------------
     // 2) Create and configure circular buffers
@@ -309,17 +316,7 @@ tt::tt_metal::ProgramDescriptor DropoutProgramFactory::create_descriptor(
     // -------------------------------------------------------------------------
     // 5) Assign runtime args for each core
     // -------------------------------------------------------------------------
-    assign_per_core_runtime_args(
-        kernels,
-        src_buffer,
-        dst_buffer,
-        num_cores,
-        num_cores_y,
-        num_tiles_per_core_group_1,
-        num_tiles_per_core_group_2,
-        core_group_1,
-        core_group_2,
-        args.seed);
+    assign_per_core_runtime_args(kernels, src_buffer, dst_buffer, split, args.seed);
 
     // -------------------------------------------------------------------------
     // 6) Return the fully configured descriptor
@@ -340,7 +337,8 @@ tt::tt_metal::ProgramDescriptor DropoutMeshWorkloadFactory::create_descriptor(
     Tensor& output,
     const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
     TT_ASSERT(args.use_per_device_seed, "DropoutMeshWorkloadFactory should only be used if per-device seed is used.");
-    const auto effective_args = override_per_device_seed(args, mesh_dispatch_coordinate, tensor_args.input);
+    DropoutParams effective_args = args;
+    effective_args.seed = per_device_seed(args, mesh_dispatch_coordinate, tensor_args.input);
     return DropoutProgramFactory::create_descriptor(effective_args, tensor_args, output);
 }
 
@@ -350,13 +348,46 @@ void DropoutDeviceOperation::override_runtime_arguments(
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value,
     const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
-    // Re-derive the descriptor from the factory select_program_factory would pick (per-device path offsets
-    // the seed by device id via the coord) and re-apply it to the cached program. No rebuild (still a hit).
-    auto desc = operation_attributes.use_per_device_seed
-                    ? DropoutMeshWorkloadFactory::create_descriptor(
-                          operation_attributes, tensor_args, tensor_return_value, mesh_dispatch_coordinate)
-                    : DropoutProgramFactory::create_descriptor(operation_attributes, tensor_args, tensor_return_value);
-    tt::tt_metal::apply_descriptor_runtime_args(program, desc);
+    using namespace tt::tt_metal;
+
+    // Kernel indices are positions in create_descriptor's `descriptor.kernels` push order:
+    // reader(0), writer(1), compute group 1(2), compute group 2(3, only when core_group_2 is non-empty).
+    constexpr uint32_t kReaderIdx = 0;
+    constexpr uint32_t kWriterIdx = 1;
+    constexpr uint32_t kComputeGroup1Idx = 2;
+    constexpr uint32_t kComputeGroup2Idx = 3;
+
+    const auto& input = tensor_args.input;
+
+    // `seed` is excluded from the program hash, so the cached program still carries the first miss's
+    // seed and it must be re-derived here exactly as the selected factory derives it:
+    // DropoutMeshWorkloadFactory offsets it by the dispatch coordinate's device id.
+    const uint32_t seed = operation_attributes.use_per_device_seed
+                              ? per_device_seed(operation_attributes, mesh_dispatch_coordinate, input)
+                              : operation_attributes.seed;
+
+    // override_runtime_arguments supersedes resolve_bindings, so the buffer addresses the descriptor
+    // emplaced as Buffer* bindings are ours to re-apply. Each address comes from its own tensor, which
+    // is what makes the in-place case (input == output, so both addresses equal) correct.
+    const uint32_t src_addr = input.buffer()->address();
+    const uint32_t dst_addr = tensor_return_value.buffer()->address();
+
+    // Everything else the descriptor emplaced (tile counts/offsets) derives from the input spec and the
+    // compute grid, both fixed on a cache hit; rewritten anyway since the shared walk already has them.
+    // Both CBs are program-local (no .buffer/.tensor binding), so there is no CB address to re-point.
+    for_each_dropout_core(dropout_core_split(input), [&](const DropoutCoreWork& work) {
+        auto& reader_args = GetRuntimeArgs(program, kReaderIdx, work.core);
+        reader_args[0] = src_addr;
+        reader_args[1] = work.num_tiles;
+        reader_args[2] = work.tile_offset;
+
+        auto& writer_args = GetRuntimeArgs(program, kWriterIdx, work.core);
+        writer_args[0] = dst_addr;
+        writer_args[1] = work.num_tiles;
+        writer_args[2] = work.tile_offset;
+
+        GetRuntimeArgs(program, work.in_group_1 ? kComputeGroup1Idx : kComputeGroup2Idx, work.core)[0] = seed;
+    });
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
@@ -230,6 +230,14 @@ inline void assign_per_core_runtime_args(
     });
 }
 
+namespace {
+// Kernel indices: positions in the `descriptor.kernels` push order at the end of create_descriptor
+// (reader, writer, compute group 1, then compute group 2 only when core_group_2 is non-empty).
+// Single-sourced here, next to the pushes that define the order, so the cache-miss push order and the
+// cache-hit GetRuntimeArgs indices in override_runtime_arguments stay one edit apart.
+enum : uint32_t { kReaderIdx, kWriterIdx, kComputeGroup1Idx, kComputeGroup2Idx };
+}  // namespace
+
 tt::tt_metal::ProgramDescriptor DropoutProgramFactory::create_descriptor(
     const DropoutParams& args, const DropoutInputs& tensor_args, Tensor& output) {
     using namespace tt;
@@ -321,11 +329,11 @@ tt::tt_metal::ProgramDescriptor DropoutProgramFactory::create_descriptor(
     // -------------------------------------------------------------------------
     // 6) Return the fully configured descriptor
     // -------------------------------------------------------------------------
-    descriptor.kernels.push_back(std::move(kernels.reader));
-    descriptor.kernels.push_back(std::move(kernels.writer));
-    descriptor.kernels.push_back(std::move(kernels.compute_group_1));
+    descriptor.kernels.push_back(std::move(kernels.reader));           // kReaderIdx
+    descriptor.kernels.push_back(std::move(kernels.writer));           // kWriterIdx
+    descriptor.kernels.push_back(std::move(kernels.compute_group_1));  // kComputeGroup1Idx
     if (kernels.compute_group_2.has_value()) {
-        descriptor.kernels.push_back(std::move(*kernels.compute_group_2));
+        descriptor.kernels.push_back(std::move(*kernels.compute_group_2));  // kComputeGroup2Idx
     }
 
     return descriptor;
@@ -350,13 +358,8 @@ void DropoutDeviceOperation::override_runtime_arguments(
     const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
     using namespace tt::tt_metal;
 
-    // Kernel indices are positions in create_descriptor's `descriptor.kernels` push order:
-    // reader(0), writer(1), compute group 1(2), compute group 2(3, only when core_group_2 is non-empty).
-    constexpr uint32_t kReaderIdx = 0;
-    constexpr uint32_t kWriterIdx = 1;
-    constexpr uint32_t kComputeGroup1Idx = 2;
-    constexpr uint32_t kComputeGroup2Idx = 3;
-
+    // Kernel indices (kReaderIdx/kWriterIdx/kComputeGroup{1,2}Idx) are shared with create_descriptor's
+    // `descriptor.kernels` push order -- see the enum defined next to those pushes.
     const auto& input = tensor_args.input;
 
     // `seed` is excluded from the program hash, so the cached program still carries the first miss's

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
@@ -350,11 +350,11 @@ tt::tt_metal::ProgramDescriptor DropoutMeshWorkloadFactory::create_descriptor(
     return DropoutProgramFactory::create_descriptor(effective_args, tensor_args, output);
 }
 
-void DropoutDeviceOperation::override_runtime_arguments(
+void DropoutProgramFactory::override_runtime_arguments(
     tt::tt_metal::Program& program,
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value,
+    const DropoutParams& operation_attributes,
+    const DropoutInputs& tensor_args,
+    Tensor& tensor_return_value,
     const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
     using namespace tt::tt_metal;
 
@@ -402,6 +402,16 @@ void DropoutDeviceOperation::override_runtime_arguments(
         auto& compute_grid = work.in_group_1 ? compute_group_1_grid : *compute_group_2_grid;
         compute_grid[work.core.x][work.core.y][0] = seed;
     });
+}
+
+void DropoutMeshWorkloadFactory::override_runtime_arguments(
+    tt::tt_metal::Program& program,
+    const DropoutParams& operation_attributes,
+    const DropoutInputs& tensor_args,
+    Tensor& tensor_return_value,
+    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
+    DropoutProgramFactory::override_runtime_arguments(
+        program, operation_attributes, tensor_args, tensor_return_value, mesh_dispatch_coordinate);
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
@@ -378,18 +378,29 @@ void DropoutDeviceOperation::override_runtime_arguments(
     // Everything else the descriptor emplaced (tile counts/offsets) derives from the input spec and the
     // compute grid, both fixed on a cache hit; rewritten anyway since the shared walk already has them.
     // Both CBs are program-local (no .buffer/.tensor binding), so there is no CB address to re-point.
-    for_each_dropout_core(dropout_core_split(input), [&](const DropoutCoreWork& work) {
-        auto& reader_args = GetRuntimeArgs(program, kReaderIdx, work.core);
+    // Hoist the per-kernel lookup: the whole-kernel overload hands back the [x][y] grid, so this costs
+    // one lookup per kernel instead of one per core per kernel (same amortisation apply_resolved_bindings does).
+    const DropoutCoreSplit split = dropout_core_split(input);
+    auto& reader_grid = GetRuntimeArgs(program, kReaderIdx);
+    auto& writer_grid = GetRuntimeArgs(program, kWriterIdx);
+    auto& compute_group_1_grid = GetRuntimeArgs(program, kComputeGroup1Idx);
+    auto* compute_group_2_grid =
+        split.core_group_2.ranges().empty() ? nullptr : &GetRuntimeArgs(program, kComputeGroup2Idx);
+
+    for_each_dropout_core(split, [&](const DropoutCoreWork& work) {
+        auto& reader_args = reader_grid[work.core.x][work.core.y];
         reader_args[0] = src_addr;
         reader_args[1] = work.num_tiles;
         reader_args[2] = work.tile_offset;
 
-        auto& writer_args = GetRuntimeArgs(program, kWriterIdx, work.core);
+        auto& writer_args = writer_grid[work.core.x][work.core.y];
         writer_args[0] = dst_addr;
         writer_args[1] = work.num_tiles;
         writer_args[2] = work.tile_offset;
 
-        GetRuntimeArgs(program, work.in_group_1 ? kComputeGroup1Idx : kComputeGroup2Idx, work.core)[0] = seed;
+        TT_FATAL(work.in_group_1 || compute_group_2_grid != nullptr, "Core group 2 kernel should be present");
+        auto& compute_grid = work.in_group_1 ? compute_group_1_grid : *compute_group_2_grid;
+        compute_grid[work.core.x][work.core.y][0] = seed;
     });
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.hpp
@@ -12,6 +12,16 @@ namespace ttnn::experimental::prim {
 struct DropoutProgramFactory {
     static tt::tt_metal::ProgramDescriptor create_descriptor(
         const DropoutParams& args, const DropoutInputs& tensor_args, Tensor& output);
+
+    // Patches ALL per-dispatch state (seed, src/dst addresses) into the cached program on every cache
+    // hit -- in place, no descriptor rebuild. seed is hash-excluded (per-device offset applied when
+    // use_per_device_seed); supersedes get_dynamic_runtime_args and resolve_bindings.
+    static void override_runtime_arguments(
+        tt::tt_metal::Program& program,
+        const DropoutParams& operation_attributes,
+        const DropoutInputs& tensor_args,
+        Tensor& tensor_return_value,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 
 struct DropoutMeshWorkloadFactory {
@@ -24,6 +34,15 @@ struct DropoutMeshWorkloadFactory {
         const DropoutInputs& tensor_args,
         Tensor& output,
         const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate);
+
+    // Delegates to DropoutProgramFactory: both factories emit the same per-core layout, so one
+    // implementation keeps the cache-hit patch from drifting between them.
+    static void override_runtime_arguments(
+        tt::tt_metal::Program& program,
+        const DropoutParams& operation_attributes,
+        const DropoutInputs& tensor_args,
+        Tensor& tensor_return_value,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 
 }  // namespace ttnn::experimental::prim


### PR DESCRIPTION
## What
Migrates `experimental/dropout` off the legacy `get_dynamic_runtime_args` cache-hit hook to `override_runtime_arguments` (#49828 mechanism). `get_dynamic_runtime_args` removed entirely.

## Why
Eliminating `get_dynamic_runtime_args` across all descriptor ops (fragile hand-mirrored re-application, slated for deletion). The override re-derives per-dispatch state correct-by-construction.

## Metrics (Wormhole B0, host cache-hit dispatch, min-of-medians 3×100)
- **perf:** 53→59 µs (+10%) (small host-side regression; acceptable — correctness + get_dynamic removal is the goal)
- **PCC:** cache-hit output correct (program-cache test)
- **cache-hit:** entry count stable across the hash-excluded dynamic value / addr change ✅
- 0 parity failures under `-DENABLE_DESCRIPTOR_PATCHING_PARITY_CHECK=ON` (single-chip). Mesh path (paged) validated in CI.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/gd-dropout)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/gd-dropout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/gd-dropout)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/gd-dropout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/gd-dropout)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/gd-dropout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/gd-dropout)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/gd-dropout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/gd-dropout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/gd-dropout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/gd-dropout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/gd-dropout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/gd-dropout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/gd-dropout)