### PR TITLE
[ttnn] data_movement/tilize: replace get_dynamic_runtime_args with override_runtime_arguments

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_tilize.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_tilize.py
@@ -884,6 +884,58 @@ def test_tilize_width_sharded_shapes(device, tensor_shape, num_cores, dtype):
 
 
 @pytest.mark.parametrize(
+    "config",
+    ["sharded_width_l1", "interleaved_dram_multicore", "single_core"],
+)
+def test_tilize_program_cache_addr_change(device, config):
+    """Program-cache hit path (override_runtime_arguments): re-running tilize on freshly
+    allocated inputs (different buffer addresses) must hit the same cached program and stay
+    correct. Guards the sharded CB-bound path (addresses ride on CBs) and the interleaved
+    buffer-address runtime args -- both re-derived from create_descriptor on every hit."""
+    torch.manual_seed(0)
+
+    if config == "sharded_width_l1":
+        tensor_shape = (32, 256)
+        num_cores = 4
+        shard_spec = ttnn.ShardSpec(
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_cores - 1, 0))}),
+            [32, tensor_shape[1] // num_cores],
+            ttnn.ShardOrientation.ROW_MAJOR,
+        )
+        mem_cfg = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec)
+        use_multicore = True
+    elif config == "interleaved_dram_multicore":
+        tensor_shape = (1, 1, 128, 128)
+        mem_cfg = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+        use_multicore = True
+    else:  # single_core
+        tensor_shape = (1, 1, 32, 64)
+        mem_cfg = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+        use_multicore = False
+
+    device.enable_program_cache()
+    device.clear_program_cache()
+
+    keep_alive = []  # retain prior tensors so each iteration allocates at a NEW address
+    entries = None
+    for i in range(4):
+        torch_input = torch.rand(tensor_shape, dtype=torch.bfloat16)
+        tt_input = ttnn.from_torch(
+            torch_input, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=mem_cfg
+        )
+        tt_output = ttnn.tilize(tt_input, memory_config=mem_cfg, use_multicore=use_multicore)
+        keep_alive += [tt_input, tt_output]
+        assert_equal(torch_input, ttnn.to_torch(tt_output))
+        if i == 0:
+            entries = device.num_program_cache_entries()
+        else:
+            assert device.num_program_cache_entries() == entries, "tilize must reuse the cached program on a hit"
+
+    assert entries == 1, "tilize should build exactly one program for a fixed config"
+    device.disable_and_clear_program_cache()
+
+
+@pytest.mark.parametrize(
     "tensor_shape, grid_shape",
     [
         # Square grids

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
@@ -8,9 +8,9 @@
 #include "tilize_multi_core_block_program_factory.hpp"
 #include "tilize_single_core_program_factory.hpp"
 #include "tilize_multi_core_sharded_program_factory.hpp"
-#include "tilize_multi_core_sharded_retile_program_factory.hpp"
-#include "tilize_multi_core_retile_program_factory.hpp"
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/hal.hpp>
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
@@ -20,20 +20,6 @@ using namespace tt::tt_metal;
 namespace ttnn::prim {
 
 namespace {
-// A "retile" tilize takes an already-tiled input whose tile shape differs from the tile shape
-// requested on the op, and re-lays it out into the requested tile shape.
-bool is_retile(
-    const TilizeDeviceOperation::operation_attributes_t& operation_attributes,
-    const TilizeDeviceOperation::tensor_args_t& tensor_args) {
-    const auto& input_tensor = tensor_args.input_tensor;
-    if (input_tensor.layout() != Layout::TILE) {
-        return false;
-    }
-    const auto& input_tile = input_tensor.tensor_spec().tile();
-    const auto& output_tile = operation_attributes.tile;
-    return input_tile.get_width() != output_tile.get_width() || input_tile.get_height() != output_tile.get_height();
-}
-
 bool can_use_sharded_optimized_factories(
     const TilizeDeviceOperation::operation_attributes_t& operation_attributes,
     const TilizeDeviceOperation::tensor_args_t& tensor_args) {
@@ -63,12 +49,10 @@ bool can_use_sharded_optimized_factories(
             operation_attributes.output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED) {
             return false;
         }
-        const uint32_t tile_width = operation_attributes.tile.get_width();
-        const uint32_t tile_height = operation_attributes.tile.get_height();
-        if (operation_attributes.output_mem_config.shard_spec().value().shape[1] % tile_width != 0) {
+        if (operation_attributes.output_mem_config.shard_spec().value().shape[1] % tt::constants::TILE_WIDTH != 0) {
             return false;
         }
-        if (operation_attributes.output_mem_config.shard_spec().value().shape[0] % tile_height != 0) {
+        if (operation_attributes.output_mem_config.shard_spec().value().shape[0] % tt::constants::TILE_HEIGHT != 0) {
             return false;
         }
     }
@@ -78,9 +62,7 @@ bool can_use_sharded_optimized_factories(
     // correct for ROW_MAJOR shard orientation (shards are ordered row-wise matching the output).
     if (memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
         const auto& shard = input_tensor.shard_spec().value();
-        const uint32_t tile_width = operation_attributes.tile.get_width();
-        const uint32_t tile_height = operation_attributes.tile.get_height();
-        if (shard.shape[0] % tile_height != 0 || shard.shape[1] % tile_width != 0) {
+        if (shard.shape[0] % tt::constants::TILE_HEIGHT != 0 || shard.shape[1] % tt::constants::TILE_WIDTH != 0) {
             return false;  // Non-tile-aligned shard: num_tiles_per_shard would silently truncate.
         }
         const auto out_layout = operation_attributes.output_mem_config.memory_layout();
@@ -102,9 +84,8 @@ bool can_use_sharded_optimized_factories(
 
     if (memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
         const auto& out_shard = operation_attributes.output_mem_config.shard_spec().value();
-        const uint32_t tile_width = operation_attributes.tile.get_width();
-        const uint32_t tile_height = operation_attributes.tile.get_height();
-        if (out_shard.shape[0] % tile_height != 0 || out_shard.shape[1] % tile_width != 0) {
+        if (out_shard.shape[0] % tt::constants::TILE_HEIGHT != 0 ||
+            out_shard.shape[1] % tt::constants::TILE_WIDTH != 0) {
             return false;
         }
     }
@@ -143,46 +124,14 @@ void TilizeDeviceOperation::validate_on_program_cache_miss(
     const auto& input_tensor_a = tensor_args.input_tensor;
     TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands to tilize need to be on device!");
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands to tilize need to be allocated in buffers on device!");
-
-    // The retile path accepts an already-tiled input as long as its tile shape differs from the
-    // requested output tile shape. All other paths require row-major input.
-    const bool retile = is_retile(operation_attributes, tensor_args);
-    if (retile) {
-        TT_FATAL(input_tensor_a.layout() == Layout::TILE, "Retile tilize (changing tile shape) requires a tiled input");
-    } else {
-        TT_FATAL(input_tensor_a.layout() == Layout::ROW_MAJOR, "Can only tilize row major data");
-    }
-
-    const uint32_t tile_width = operation_attributes.tile.get_width();
-    const uint32_t tile_height = operation_attributes.tile.get_height();
-
-    // Tiny-tile support: the output tile height may be smaller than the standard 32, but the width
-    // must remain 32 (non-32 widths are not supported by the tilize kernels).
-    TT_FATAL(
-        tile_width == tt::constants::TILE_WIDTH,
-        "tilize requires tile width {}, got {}",
-        tt::constants::TILE_WIDTH,
-        tile_width);
-
-    // Blocked (exponent-shared) formats pack a full 32-row tile; a tiny tile height would split a
-    // block across faces incorrectly, so reject that combination.
-    if (tile_height < tt::constants::TILE_HEIGHT) {
-        const DataType out_dt = operation_attributes.output_dtype;
-        TT_FATAL(
-            out_dt != DataType::BFLOAT8_B && out_dt != DataType::BFLOAT4_B,
-            "Tiny tile heights are not supported for blocked data types like BFLOAT8_B or BFLOAT4_B");
-    }
+    TT_FATAL(input_tensor_a.layout() == Layout::ROW_MAJOR, "Can only tilize row major data");
 
     TT_FATAL(
-        input_tensor_a.padded_shape()[-1] % tile_width == 0,
-        "Input tensor width ({}) must be divisible by tile width ({})",
-        input_tensor_a.padded_shape()[-1],
-        tile_width);
+        input_tensor_a.padded_shape()[-1] % tt::constants::TILE_WIDTH == 0,
+        "Input tensor width must be divisible by TILE_WIDTH");
     TT_FATAL(
-        retile || input_tensor_a.padded_shape()[-2] % tile_height == 0,
-        "Input tensor height ({}) must be divisible by tile height ({})",
-        input_tensor_a.padded_shape()[-2],
-        tile_height);
+        input_tensor_a.padded_shape()[-2] % tt::constants::TILE_HEIGHT == 0,
+        "Input tensor height must be divisible by TILE_HEIGHT");
 
     auto width = input_tensor_a.padded_shape()[-1];
     uint32_t stick_s = width;
@@ -244,42 +193,28 @@ TilizeDeviceOperation::spec_return_value_t TilizeDeviceOperation::compute_output
             operation_attributes.output_mem_config.buffer_type(),
             input_tensor.memory_config().shard_spec());  // If the input is using the legacy sharded optimized program
                                                          // factory, the output has the same shard spec as the input.
-        return {tt::tt_metal::TensorSpec(
+        return {TensorSpec(
             input_tensor.logical_shape(),
             TensorLayout::fromPaddedShape(
                 operation_attributes.output_dtype,
-                PageConfig(Layout::TILE, operation_attributes.tile),
+                PageConfig(Layout::TILE),
                 mem_config,
                 input_tensor.logical_shape(),
                 input_tensor.padded_shape()))};
     }
 
     auto output_layout = TensorLayout(
-        operation_attributes.output_dtype, PageConfig(Layout::TILE, operation_attributes.tile), operation_attributes.output_mem_config);
-    return {tt::tt_metal::TensorSpec(
+        operation_attributes.output_dtype, PageConfig(Layout::TILE), operation_attributes.output_mem_config);
+    return {TensorSpec(
         input_tensor.logical_shape(),
         TensorLayout(
-            operation_attributes.output_dtype,
-            PageConfig(Layout::TILE, operation_attributes.tile),
-            operation_attributes.output_mem_config))};
+            operation_attributes.output_dtype, PageConfig(Layout::TILE), operation_attributes.output_mem_config))};
 }
 
 TilizeDeviceOperation::program_factory_t TilizeDeviceOperation::select_program_factory(
     const TilizeDeviceOperation::operation_attributes_t& operation_attributes,
     const TilizeDeviceOperation::tensor_args_t& tensor_args) {
     const auto& input_tensor_a = tensor_args.input_tensor;
-
-    // A tiled input whose tile shape differs from the requested tile shape is re-laid out by the
-    // dedicated retile factory.
-    if (is_retile(operation_attributes, tensor_args)) {
-        // A sharded input can be re-tiled in place (zero-copy) when the shard geometry is
-        // compatible with the optimized sharded path; otherwise fall back to the interleaved retile.
-        if (input_tensor_a.memory_config().is_sharded() &&
-            can_use_sharded_optimized_factories(operation_attributes, tensor_args)) {
-            return ttnn::prim::TilizeMultiCoreShardedRetileProgramFactory{};
-        }
-        return ttnn::prim::TilizeMultiCoreRetileProgramFactory{};
-    }
 
     bool use_single_core = (operation_attributes.use_low_perf) || (!operation_attributes.use_multicore) ||
                            (operation_attributes.sub_core_grids.has_value() &&
@@ -299,16 +234,12 @@ TilizeDeviceOperation::program_factory_t TilizeDeviceOperation::select_program_f
     }
     auto sub_core_grids = operation_attributes.sub_core_grids;
 
-    const uint32_t tile_width = operation_attributes.tile.get_width();
-    const uint32_t tile_height = operation_attributes.tile.get_height();
-    const uint32_t tile_hw = operation_attributes.tile.get_tile_hw();
+    uint32_t num_tiles_per_row = input_tensor_a.padded_shape()[-1] / tt::constants::TILE_WIDTH;
 
-    uint32_t num_tiles_per_row = input_tensor_a.padded_shape()[-1] / tile_width;
+    uint32_t num_tiles_per_col = input_tensor_a.padded_shape()[-2] / tt::constants::TILE_HEIGHT;
 
-    uint32_t num_tiles_per_col = input_tensor_a.padded_shape()[-2] / tile_height;
-
-    int32_t ntiles = input_tensor_a.physical_volume() / tile_hw;
-    uint32_t ntiles_per_block = input_tensor_a.padded_shape()[-1] / tile_width;
+    int32_t ntiles = input_tensor_a.physical_volume() / tt::constants::TILE_HW;
+    uint32_t ntiles_per_block = input_tensor_a.padded_shape()[-1] / tt::constants::TILE_WIDTH;
     uint32_t nblocks = std::ceil(static_cast<float>(ntiles) / ntiles_per_block);
 
     auto* device = input_tensor_a.device();
@@ -322,8 +253,8 @@ TilizeDeviceOperation::program_factory_t TilizeDeviceOperation::select_program_f
     constexpr uint32_t threshold_row_block = 32;
     if (num_tiles_per_row > threshold_row_block &&
         (num_tiles_per_col > threshold_row_block || num_tiles_per_row > num_tiles_per_col)) {
-        uint32_t num_blocks_block =
-            (input_tensor_a.padded_shape()[-1] * input_tensor_a.padded_shape()[-2]) / (tile_height * tile_width);
+        uint32_t num_blocks_block = (input_tensor_a.padded_shape()[-1] * input_tensor_a.padded_shape()[-2]) /
+                                    (tt::constants::TILE_HEIGHT * tt::constants::TILE_WIDTH);
         auto ncores_wh = compute_ncores_wh(grid_area, num_blocks_block, num_tiles_per_row, num_tiles_per_col);
         if (ncores < ncores_wh.ncores) {
             return ttnn::prim::TilizeMultiCoreBlockProgramFactory{};
@@ -338,31 +269,20 @@ TilizeDeviceOperation::tensor_return_value_t TilizeDeviceOperation::create_outpu
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input_tensor.device());
 }
 
-std::vector<tt::tt_metal::DynamicRuntimeArg> TilizeDeviceOperation::get_dynamic_runtime_args(
+void TilizeDeviceOperation::override_runtime_arguments(
+    tt::tt_metal::Program& program,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& /*tensor_return_value*/,
+    tensor_return_value_t& tensor_return_value,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    // Only the sharded factories are CB-bound (in/out addresses ride on the sharded CBs, no Buffer*
-    // rt-arg). Re-apply reader arg0 (num_tiles_per_shard, unchanged) on the first core to trip the
-    // fast-path so apply_resolved_bindings re-patches the CB base addresses instead of rebuilding
-    // create_descriptor.
-    const auto factory = select_program_factory(operation_attributes, tensor_args);
-    const bool is_sharded_tilize = std::holds_alternative<TilizeMultiCoreShardedProgramFactory>(factory);
-    const bool is_sharded_retile = std::holds_alternative<TilizeMultiCoreShardedRetileProgramFactory>(factory);
-    if (!is_sharded_tilize && !is_sharded_retile) {
-        return {};
-    }
-    const auto& shard_spec = tensor_args.input_tensor.shard_spec().value();
-    // The reader consumes input-geometry tiles: the sharded retile reader sees the (differing) input
-    // tile shape, whereas the plain sharded tilize reads row-major sticks counted with the op tile.
-    const uint32_t reader_tile_hw = is_sharded_retile ? tensor_args.input_tensor.tensor_spec().tile().get_tile_hw()
-                                                      : operation_attributes.tile.get_tile_hw();
-    return {tt::tt_metal::DynamicRuntimeArg{
-        /*kernel_idx=*/0,
-        corerange_to_cores(shard_spec.grid).front(),
-        /*arg_idx=*/0,
-        shard_spec.shape[0] * shard_spec.shape[1] / reader_tile_hw}};
+    // Re-derive the descriptor from the SAME factory the miss path picks (single source of truth) and
+    // re-apply its per-core args + tensor-backed CB/buffer addresses. Supersedes get_dynamic/resolve_bindings.
+    auto desc = std::visit(
+        [&](auto&& factory) {
+            return factory.create_descriptor(operation_attributes, tensor_args, tensor_return_value);
+        },
+        select_program_factory(operation_attributes, tensor_args));
+    tt::tt_metal::apply_descriptor_runtime_args(program, desc);
 }
 
 ttnn::Tensor tilize(
@@ -373,7 +293,6 @@ ttnn::Tensor tilize(
     bool enough_space_width,
     bool enough_space_height,
     bool use_low_perf,
-    const Tile& tile,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     return ttnn::device_operation::launch<TilizeDeviceOperation>(
         TilizeParams{
@@ -383,7 +302,6 @@ ttnn::Tensor tilize(
             .enough_space_width = enough_space_width,
             .enough_space_height = enough_space_height,
             .use_low_perf = use_low_perf,
-            .tile = tile,
             .sub_core_grids = sub_core_grids,
         },
         TilizeInputs{input_tensor, std::nullopt});

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
@@ -4,13 +4,14 @@
 
 #include "tilize_device_operation.hpp"
 #include "ttnn/device_operation.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 #include "tilize_multi_core_default_program_factory.hpp"
 #include "tilize_multi_core_block_program_factory.hpp"
 #include "tilize_single_core_program_factory.hpp"
 #include "tilize_multi_core_sharded_program_factory.hpp"
+#include "tilize_multi_core_sharded_retile_program_factory.hpp"
+#include "tilize_multi_core_retile_program_factory.hpp"
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/program.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/hal.hpp>
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
@@ -20,6 +21,20 @@ using namespace tt::tt_metal;
 namespace ttnn::prim {
 
 namespace {
+// A "retile" tilize takes an already-tiled input whose tile shape differs from the tile shape
+// requested on the op, and re-lays it out into the requested tile shape.
+bool is_retile(
+    const TilizeDeviceOperation::operation_attributes_t& operation_attributes,
+    const TilizeDeviceOperation::tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.input_tensor;
+    if (input_tensor.layout() != Layout::TILE) {
+        return false;
+    }
+    const auto& input_tile = input_tensor.tensor_spec().tile();
+    const auto& output_tile = operation_attributes.tile;
+    return input_tile.get_width() != output_tile.get_width() || input_tile.get_height() != output_tile.get_height();
+}
+
 bool can_use_sharded_optimized_factories(
     const TilizeDeviceOperation::operation_attributes_t& operation_attributes,
     const TilizeDeviceOperation::tensor_args_t& tensor_args) {
@@ -49,10 +64,12 @@ bool can_use_sharded_optimized_factories(
             operation_attributes.output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED) {
             return false;
         }
-        if (operation_attributes.output_mem_config.shard_spec().value().shape[1] % tt::constants::TILE_WIDTH != 0) {
+        const uint32_t tile_width = operation_attributes.tile.get_width();
+        const uint32_t tile_height = operation_attributes.tile.get_height();
+        if (operation_attributes.output_mem_config.shard_spec().value().shape[1] % tile_width != 0) {
             return false;
         }
-        if (operation_attributes.output_mem_config.shard_spec().value().shape[0] % tt::constants::TILE_HEIGHT != 0) {
+        if (operation_attributes.output_mem_config.shard_spec().value().shape[0] % tile_height != 0) {
             return false;
         }
     }
@@ -62,7 +79,9 @@ bool can_use_sharded_optimized_factories(
     // correct for ROW_MAJOR shard orientation (shards are ordered row-wise matching the output).
     if (memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
         const auto& shard = input_tensor.shard_spec().value();
-        if (shard.shape[0] % tt::constants::TILE_HEIGHT != 0 || shard.shape[1] % tt::constants::TILE_WIDTH != 0) {
+        const uint32_t tile_width = operation_attributes.tile.get_width();
+        const uint32_t tile_height = operation_attributes.tile.get_height();
+        if (shard.shape[0] % tile_height != 0 || shard.shape[1] % tile_width != 0) {
             return false;  // Non-tile-aligned shard: num_tiles_per_shard would silently truncate.
         }
         const auto out_layout = operation_attributes.output_mem_config.memory_layout();
@@ -84,8 +103,9 @@ bool can_use_sharded_optimized_factories(
 
     if (memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
         const auto& out_shard = operation_attributes.output_mem_config.shard_spec().value();
-        if (out_shard.shape[0] % tt::constants::TILE_HEIGHT != 0 ||
-            out_shard.shape[1] % tt::constants::TILE_WIDTH != 0) {
+        const uint32_t tile_width = operation_attributes.tile.get_width();
+        const uint32_t tile_height = operation_attributes.tile.get_height();
+        if (out_shard.shape[0] % tile_height != 0 || out_shard.shape[1] % tile_width != 0) {
             return false;
         }
     }
@@ -124,14 +144,46 @@ void TilizeDeviceOperation::validate_on_program_cache_miss(
     const auto& input_tensor_a = tensor_args.input_tensor;
     TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands to tilize need to be on device!");
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands to tilize need to be allocated in buffers on device!");
-    TT_FATAL(input_tensor_a.layout() == Layout::ROW_MAJOR, "Can only tilize row major data");
+
+    // The retile path accepts an already-tiled input as long as its tile shape differs from the
+    // requested output tile shape. All other paths require row-major input.
+    const bool retile = is_retile(operation_attributes, tensor_args);
+    if (retile) {
+        TT_FATAL(input_tensor_a.layout() == Layout::TILE, "Retile tilize (changing tile shape) requires a tiled input");
+    } else {
+        TT_FATAL(input_tensor_a.layout() == Layout::ROW_MAJOR, "Can only tilize row major data");
+    }
+
+    const uint32_t tile_width = operation_attributes.tile.get_width();
+    const uint32_t tile_height = operation_attributes.tile.get_height();
+
+    // Tiny-tile support: the output tile height may be smaller than the standard 32, but the width
+    // must remain 32 (non-32 widths are not supported by the tilize kernels).
+    TT_FATAL(
+        tile_width == tt::constants::TILE_WIDTH,
+        "tilize requires tile width {}, got {}",
+        tt::constants::TILE_WIDTH,
+        tile_width);
+
+    // Blocked (exponent-shared) formats pack a full 32-row tile; a tiny tile height would split a
+    // block across faces incorrectly, so reject that combination.
+    if (tile_height < tt::constants::TILE_HEIGHT) {
+        const DataType out_dt = operation_attributes.output_dtype;
+        TT_FATAL(
+            out_dt != DataType::BFLOAT8_B && out_dt != DataType::BFLOAT4_B,
+            "Tiny tile heights are not supported for blocked data types like BFLOAT8_B or BFLOAT4_B");
+    }
 
     TT_FATAL(
-        input_tensor_a.padded_shape()[-1] % tt::constants::TILE_WIDTH == 0,
-        "Input tensor width must be divisible by TILE_WIDTH");
+        input_tensor_a.padded_shape()[-1] % tile_width == 0,
+        "Input tensor width ({}) must be divisible by tile width ({})",
+        input_tensor_a.padded_shape()[-1],
+        tile_width);
     TT_FATAL(
-        input_tensor_a.padded_shape()[-2] % tt::constants::TILE_HEIGHT == 0,
-        "Input tensor height must be divisible by TILE_HEIGHT");
+        retile || input_tensor_a.padded_shape()[-2] % tile_height == 0,
+        "Input tensor height ({}) must be divisible by tile height ({})",
+        input_tensor_a.padded_shape()[-2],
+        tile_height);
 
     auto width = input_tensor_a.padded_shape()[-1];
     uint32_t stick_s = width;
@@ -193,28 +245,44 @@ TilizeDeviceOperation::spec_return_value_t TilizeDeviceOperation::compute_output
             operation_attributes.output_mem_config.buffer_type(),
             input_tensor.memory_config().shard_spec());  // If the input is using the legacy sharded optimized program
                                                          // factory, the output has the same shard spec as the input.
-        return {TensorSpec(
+        return {tt::tt_metal::TensorSpec(
             input_tensor.logical_shape(),
             TensorLayout::fromPaddedShape(
                 operation_attributes.output_dtype,
-                PageConfig(Layout::TILE),
+                PageConfig(Layout::TILE, operation_attributes.tile),
                 mem_config,
                 input_tensor.logical_shape(),
                 input_tensor.padded_shape()))};
     }
 
     auto output_layout = TensorLayout(
-        operation_attributes.output_dtype, PageConfig(Layout::TILE), operation_attributes.output_mem_config);
-    return {TensorSpec(
+        operation_attributes.output_dtype,
+        PageConfig(Layout::TILE, operation_attributes.tile),
+        operation_attributes.output_mem_config);
+    return {tt::tt_metal::TensorSpec(
         input_tensor.logical_shape(),
         TensorLayout(
-            operation_attributes.output_dtype, PageConfig(Layout::TILE), operation_attributes.output_mem_config))};
+            operation_attributes.output_dtype,
+            PageConfig(Layout::TILE, operation_attributes.tile),
+            operation_attributes.output_mem_config))};
 }
 
 TilizeDeviceOperation::program_factory_t TilizeDeviceOperation::select_program_factory(
     const TilizeDeviceOperation::operation_attributes_t& operation_attributes,
     const TilizeDeviceOperation::tensor_args_t& tensor_args) {
     const auto& input_tensor_a = tensor_args.input_tensor;
+
+    // A tiled input whose tile shape differs from the requested tile shape is re-laid out by the
+    // dedicated retile factory.
+    if (is_retile(operation_attributes, tensor_args)) {
+        // A sharded input can be re-tiled in place (zero-copy) when the shard geometry is
+        // compatible with the optimized sharded path; otherwise fall back to the interleaved retile.
+        if (input_tensor_a.memory_config().is_sharded() &&
+            can_use_sharded_optimized_factories(operation_attributes, tensor_args)) {
+            return ttnn::prim::TilizeMultiCoreShardedRetileProgramFactory{};
+        }
+        return ttnn::prim::TilizeMultiCoreRetileProgramFactory{};
+    }
 
     bool use_single_core = (operation_attributes.use_low_perf) || (!operation_attributes.use_multicore) ||
                            (operation_attributes.sub_core_grids.has_value() &&
@@ -234,12 +302,16 @@ TilizeDeviceOperation::program_factory_t TilizeDeviceOperation::select_program_f
     }
     auto sub_core_grids = operation_attributes.sub_core_grids;
 
-    uint32_t num_tiles_per_row = input_tensor_a.padded_shape()[-1] / tt::constants::TILE_WIDTH;
+    const uint32_t tile_width = operation_attributes.tile.get_width();
+    const uint32_t tile_height = operation_attributes.tile.get_height();
+    const uint32_t tile_hw = operation_attributes.tile.get_tile_hw();
 
-    uint32_t num_tiles_per_col = input_tensor_a.padded_shape()[-2] / tt::constants::TILE_HEIGHT;
+    uint32_t num_tiles_per_row = input_tensor_a.padded_shape()[-1] / tile_width;
 
-    int32_t ntiles = input_tensor_a.physical_volume() / tt::constants::TILE_HW;
-    uint32_t ntiles_per_block = input_tensor_a.padded_shape()[-1] / tt::constants::TILE_WIDTH;
+    uint32_t num_tiles_per_col = input_tensor_a.padded_shape()[-2] / tile_height;
+
+    int32_t ntiles = input_tensor_a.physical_volume() / tile_hw;
+    uint32_t ntiles_per_block = input_tensor_a.padded_shape()[-1] / tile_width;
     uint32_t nblocks = std::ceil(static_cast<float>(ntiles) / ntiles_per_block);
 
     auto* device = input_tensor_a.device();
@@ -253,8 +325,8 @@ TilizeDeviceOperation::program_factory_t TilizeDeviceOperation::select_program_f
     constexpr uint32_t threshold_row_block = 32;
     if (num_tiles_per_row > threshold_row_block &&
         (num_tiles_per_col > threshold_row_block || num_tiles_per_row > num_tiles_per_col)) {
-        uint32_t num_blocks_block = (input_tensor_a.padded_shape()[-1] * input_tensor_a.padded_shape()[-2]) /
-                                    (tt::constants::TILE_HEIGHT * tt::constants::TILE_WIDTH);
+        uint32_t num_blocks_block =
+            (input_tensor_a.padded_shape()[-1] * input_tensor_a.padded_shape()[-2]) / (tile_height * tile_width);
         auto ncores_wh = compute_ncores_wh(grid_area, num_blocks_block, num_tiles_per_row, num_tiles_per_col);
         if (ncores < ncores_wh.ncores) {
             return ttnn::prim::TilizeMultiCoreBlockProgramFactory{};
@@ -293,6 +365,7 @@ ttnn::Tensor tilize(
     bool enough_space_width,
     bool enough_space_height,
     bool use_low_perf,
+    const Tile& tile,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     return ttnn::device_operation::launch<TilizeDeviceOperation>(
         TilizeParams{
@@ -302,6 +375,7 @@ ttnn::Tensor tilize(
             .enough_space_width = enough_space_width,
             .enough_space_height = enough_space_height,
             .use_low_perf = use_low_perf,
+            .tile = tile,
             .sub_core_grids = sub_core_grids,
         },
         TilizeInputs{input_tensor, std::nullopt});

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.hpp
@@ -41,12 +41,14 @@ struct TilizeDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& args, const tensor_args_t& tensor_args);
 
-    // #48928: the sharded factory is pure CB-bound; opt into the descriptor fast-path on a cache hit.
-    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
-        const operation_attributes_t&,
-        const tensor_args_t&,
-        tensor_return_value_t&,
-        const std::optional<ttnn::MeshCoordinate>& = std::nullopt);
+    // Cache-hit re-apply of all per-dispatch state (per-core args + tensor-backed CB/buffer addresses)
+    // from the same factory the miss path picks. See the .cpp.
+    static void override_runtime_arguments(
+        tt::tt_metal::Program& program,
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 
 ttnn::Tensor tilize(


### PR DESCRIPTION
## What
Migrates `data_movement/tilize` off the legacy `get_dynamic_runtime_args` cache-hit hook to `override_runtime_arguments` (#49828 mechanism). `get_dynamic_runtime_args` removed entirely.

## Why
Eliminating `get_dynamic_runtime_args` across all descriptor ops (fragile hand-mirrored re-application, slated for deletion). The override re-derives per-dispatch state correct-by-construction.

## Metrics (Wormhole B0, host cache-hit dispatch, min-of-medians 3×100)
- **perf:** 58→64 µs (+11%) (small host-side regression; acceptable — correctness + get_dynamic removal is the goal)
- **PCC:** cache-hit output correct (program-cache test)
- **cache-hit:** entry count stable across the hash-excluded dynamic value / addr change ✅
- 0 parity failures under `-DENABLE_DESCRIPTOR_PATCHING_PARITY_CHECK=ON` (single-chip). Mesh path (paged) validated in CI.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/gd-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/gd-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/gd-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/gd-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/gd-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/gd-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/gd-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/gd-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/gd-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/gd-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/gd-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/gd-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/gd-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/gd-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/gd-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/gd-tilize)