### PR TITLE
[ttnn] kv_cache/update_cache: replace get_dynamic_runtime_args with override_runtime_arguments

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py
@@ -184,7 +184,7 @@ def test_update_cache_decode_program_cache_hits(in_sharded, input_dtype, device)
 
     UpdateKVCacheOperation::compute_program_hash excludes update_idx (cache_idx)
     and batch_offset, so repeated update_cache calls that differ ONLY in those
-    values hit the program cache. get_dynamic_runtime_args must re-apply the
+    values hit the program cache. override_runtime_arguments must re-apply the
     per-dispatch write/read offsets (cache_start_id / tile_update_offset /
     batch_read_offset) on every hit; if any froze at the first cache-miss value
     the update would land at (or read from) the wrong position and the
@@ -194,7 +194,7 @@ def test_update_cache_decode_program_cache_hits(in_sharded, input_dtype, device)
 
     This exercises the branch the reviewer flagged: the pre-existing
     test_update_cache_decode calls update_cache only once per (freshly built)
-    program, so the get_dynamic re-application path is never taken.
+    program, so the cache-hit re-application path is never taken.
     """
     head_dim = 64
     max_seq_len = 4096
@@ -269,7 +269,79 @@ def test_update_cache_decode_program_cache_hits(in_sharded, input_dtype, device)
     assert eq_cache, out_cache
 
     # Exactly one program built: the first call missed, all later calls were
-    # genuine cache hits (so get_dynamic_runtime_args re-applied the offsets).
+    # genuine cache hits (so override_runtime_arguments re-applied the offsets).
+    assert (
+        num_new_cache_entries == 1
+    ), f"Expected a single program-cache entry (genuine hits after first), got {num_new_cache_entries}"
+
+
+@skip_for_blackhole("Mismatching on BH, see #12349")
+@pytest.mark.parametrize("in_sharded", [False, True])
+@pytest.mark.parametrize("input_dtype", [ttnn.bfloat16])
+def test_fill_cache_program_cache_hits(in_sharded, input_dtype, device):
+    """Cache-hit coverage for the FILL path's hash-excluded write offset.
+
+    compute_program_hash also excludes batch_idx/update_idx for FILL, so repeated
+    fill_cache calls that differ ONLY in those values hit the SAME program.
+    override_runtime_arguments (FILL branch of select) must re-apply the per-core
+    writer cache_start_id every hit; a frozen offset would clobber the wrong
+    (batch_idx, update_idx) slab and the per-iteration comp_equal would fail. We
+    also assert exactly one program-cache entry (all calls after the first hit).
+    """
+    head_dim = 64
+    max_seq_len = 512
+    num_users = 4
+    num_heads = 2
+    slab_seq_len = 32
+    cache_dtype = input_dtype
+
+    cache_shape = [num_users, num_heads, max_seq_len, head_dim]
+    cache = torch.zeros(cache_shape).bfloat16().float()
+    cachett = ttnn.Tensor(cache, cache_dtype).to(ttnn.TILE_LAYOUT).to(device)
+
+    input_shape = [1, num_heads, slab_seq_len, head_dim]
+    # Distinct (batch_idx, update_idx) slabs never overlap -> every fill must land
+    # at its own position; shapes/dtype/sharding stay identical -> single program.
+    positions = [(0, 0), (1, 32), (3, 64), (2, 128), (0, 480)]
+
+    num_new_cache_entries = 0
+    for batch_idx, update_idx in positions:
+        x = torch.randn(input_shape).bfloat16().float()
+        xt = ttnn.Tensor(x, input_dtype).to(ttnn.TILE_LAYOUT)
+        if in_sharded:
+            compute_grid_size = device.compute_with_storage_grid_size()
+            num_cores = min(slab_seq_len // 32 * num_heads, 32)
+            shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, True)
+            input_shard_spec = ttnn.ShardSpec(
+                shard_grid,
+                [xt.volume() // xt.padded_shape[-1] // num_cores, xt.padded_shape[-1]],
+                ttnn.ShardOrientation.ROW_MAJOR,
+            )
+            input_mem_config = ttnn.MemoryConfig(
+                ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, input_shard_spec
+            )
+            xt = xt.to(device, input_mem_config)
+        else:
+            xt = xt.to(device)
+
+        entries_before = device.num_program_cache_entries()
+        cachett = ttnn.fill_cache(cachett, xt, batch_idx, update_idx=update_idx)
+        num_new_cache_entries += device.num_program_cache_entries() - entries_before
+
+        cache[batch_idx : batch_idx + 1, :, update_idx : update_idx + slab_seq_len, :] = x
+
+        tt_got_back = cachett.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+        eq_update, out_update = comp_equal(
+            x, tt_got_back[batch_idx : batch_idx + 1, :, update_idx : update_idx + slab_seq_len, :]
+        )
+        logger.info(f"batch_idx={batch_idx} update_idx={update_idx}: {out_update}")
+        assert eq_update, out_update
+
+    tt_got_back = cachett.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+    eq_cache, out_cache = comp_equal(cache, tt_got_back)
+    logger.info(out_cache)
+    assert eq_cache, out_cache
+
     assert (
         num_new_cache_entries == 1
     ), f"Expected a single program-cache entry (genuine hits after first), got {num_new_cache_entries}"

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/fill_cache_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/fill_cache_multi_core_program_factory.cpp
@@ -112,8 +112,8 @@ ProgramDescriptor FillCacheMultiCoreProgramFactory::create_descriptor(
     uint32_t num_blocks_of_work = input_tensor.padded_shape()[1] * input_tensor.padded_shape()[-2] / TILE_HEIGHT;
 
     // Wt is the only shape-derived geometry create_descriptor still needs directly; the
-    // batch_idx/update_idx-dependent cache_start_id lives in compute_fill_cache_start_ids so the
-    // cache-miss and cache-hit (get_dynamic_runtime_args) paths share one source of truth.
+    // batch_idx/update_idx-dependent cache_start_id lives in compute_fill_cache_start_ids, which
+    // create_descriptor re-runs every dispatch (miss and, via override_runtime_arguments, hit).
     uint32_t Wt = cache_tensor.padded_shape()[-1] / TILE_WIDTH;
     tt::tt_metal::IDevice* device = input_tensor.device();
 
@@ -220,9 +220,9 @@ ProgramDescriptor FillCacheMultiCoreProgramFactory::create_descriptor(
     // framework patches the (possibly reallocated) addresses directly on cache hits (fast path).
     // The per-core writer cache_start_id derives from operation_attributes (batch_idx, update_idx)
     // which UpdateKVCacheOperation::compute_program_hash deliberately excludes from the
-    // program-cache key, so it is NOT stable across cache hits: it is re-patched every dispatch by
-    // UpdateKVCacheOperation::get_dynamic_runtime_args. compute_fill_cache_start_ids is the shared
-    // single source of truth for the work-split and cache_start_id formula so the two paths agree.
+    // program-cache key, so it is NOT stable across cache hits: create_descriptor re-derives it here
+    // every dispatch (miss and, via override_runtime_arguments, hit). compute_fill_cache_start_ids
+    // is the single source of truth for the work-split and cache_start_id formula.
     const auto start_ids = compute_fill_cache_start_ids(operation_attributes, tensor_args);
     for (uint32_t i = 0, num_blocks_written = 0; i < num_cores; i++) {
         const CoreCoord& core = cores.at(i);

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/fill_cache_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/fill_cache_multi_core_program_factory.cpp
@@ -112,8 +112,8 @@ ProgramDescriptor FillCacheMultiCoreProgramFactory::create_descriptor(
     uint32_t num_blocks_of_work = input_tensor.padded_shape()[1] * input_tensor.padded_shape()[-2] / TILE_HEIGHT;
 
     // Wt is the only shape-derived geometry create_descriptor still needs directly; the
-    // batch_idx/update_idx-dependent cache_start_id lives in compute_fill_cache_start_ids, which
-    // create_descriptor re-runs every dispatch (miss and, via override_runtime_arguments, hit).
+    // batch_idx/update_idx-dependent cache_start_id lives in compute_fill_cache_start_ids, shared
+    // with override_runtime_arguments.
     uint32_t Wt = cache_tensor.padded_shape()[-1] / TILE_WIDTH;
     tt::tt_metal::IDevice* device = input_tensor.device();
 
@@ -217,12 +217,12 @@ ProgramDescriptor FillCacheMultiCoreProgramFactory::create_descriptor(
     const auto& cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, row_major);
 
     // Per-core runtime args. src/dst base addresses are declared as Buffer* bindings so the
-    // framework patches the (possibly reallocated) addresses directly on cache hits (fast path).
-    // The per-core writer cache_start_id derives from operation_attributes (batch_idx, update_idx)
-    // which UpdateKVCacheOperation::compute_program_hash deliberately excludes from the
-    // program-cache key, so it is NOT stable across cache hits: create_descriptor re-derives it here
-    // every dispatch (miss and, via override_runtime_arguments, hit). compute_fill_cache_start_ids
-    // is the single source of truth for the work-split and cache_start_id formula.
+    // descriptor carries the buffer identity; on a cache hit override_runtime_arguments below
+    // re-applies the (possibly reallocated) addresses. The per-core writer cache_start_id derives
+    // from operation_attributes (batch_idx, update_idx) which
+    // UpdateKVCacheOperation::compute_program_hash deliberately excludes from the program-cache key,
+    // so it is NOT stable across cache hits either. compute_fill_cache_start_ids is the single
+    // source of truth for the work-split and cache_start_id formula.
     const auto start_ids = compute_fill_cache_start_ids(operation_attributes, tensor_args);
     for (uint32_t i = 0, num_blocks_written = 0; i < num_cores; i++) {
         const CoreCoord& core = cores.at(i);
@@ -257,6 +257,48 @@ ProgramDescriptor FillCacheMultiCoreProgramFactory::create_descriptor(
     desc.kernels.push_back(std::move(writer_desc));
 
     return desc;
+}
+
+void FillCacheMultiCoreProgramFactory::override_runtime_arguments(
+    tt::tt_metal::Program& program,
+    const KvCacheParams& operation_attributes,
+    const KvCacheInputs& tensor_args,
+    Tensor& /*tensor_return_value*/,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+    // Runs on EVERY program-cache hit, so it patches the cached program in place and never calls
+    // create_descriptor(): that would pay the cache-miss host cost (work-split, CoreRangeSet,
+    // TensorAccessorArgs, kernel-source strings, a fresh per-core arg vector) on a hit.
+    // Kernel push order in create_descriptor: reader(0), writer(1).
+    constexpr uint32_t kReaderKernelIdx = 0;
+    constexpr uint32_t kWriterKernelIdx = 1;
+    constexpr uint32_t kReaderSrcAddrArgIdx = 0;
+    constexpr uint32_t kWriterDstAddrArgIdx = 0;
+    constexpr uint32_t kWriterCacheStartIdArgIdx = 2;
+
+    // Buffer-address slots: create_descriptor emplaces these as Buffer*, and this hook supersedes
+    // resolve_bindings, so re-applying them is ours. The cache tensor is also the output (in-place).
+    auto* src_buffer = tensor_args.input.buffer();
+    auto* dst_buffer = tensor_args.cache.buffer();
+    const uint32_t src_addr = src_buffer->address();
+    const uint32_t dst_addr = dst_buffer->address();
+
+    // Same helper create_descriptor uses: identical core set, order and cache_start_id formula.
+    // Everything else (reader args 1-2, writer arg 1) is num_blocks_per_core/num_blocks_written * Wt
+    // — pure work-split/shape values, and the shapes are in the hash, so a hit means they match.
+    for (const auto& [core, cache_start_id] : compute_fill_cache_start_ids(operation_attributes, tensor_args)) {
+        tt::tt_metal::GetRuntimeArgs(program, kReaderKernelIdx, core)[kReaderSrcAddrArgIdx] = src_addr;
+        auto& writer_args = tt::tt_metal::GetRuntimeArgs(program, kWriterKernelIdx, core);
+        writer_args[kWriterDstAddrArgIdx] = dst_addr;
+        writer_args[kWriterCacheStartIdArgIdx] = cache_start_id;
+    }
+
+    // desc.cbs[0] is globally allocated on the input buffer for sharded inputs (whether the input is
+    // sharded is hashed, so the cached program has the dynamic CB iff we take this branch). CB
+    // positions in program.circular_buffers() match desc.cbs, as in apply_descriptor_runtime_args.
+    if (tensor_args.input.shard_spec().has_value()) {
+        constexpr uint32_t kSrc0CbPos = 0;
+        UpdateDynamicCircularBufferAddress(program, program.circular_buffers()[kSrc0CbPos]->id(), *src_buffer);
+    }
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/fill_cache_multi_core_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/fill_cache_multi_core_program_factory.hpp
@@ -23,10 +23,9 @@ struct FillCacheMultiCoreProgramFactory {
 // Per-core writer cache_start_id, in the SAME core order create_descriptor emits runtime args.
 // cache_start_id derives from operation_attributes (batch_idx, update_idx) which
 // UpdateKVCacheOperation::compute_program_hash deliberately EXCLUDES from the program-cache key
-// (so two fills that differ only in those cache-hit), yet it is baked into a writer runtime arg —
-// so it must be re-patched on every cache hit via UpdateKVCacheOperation::get_dynamic_runtime_args.
-// This helper is the single source of truth for the work-split + formula: both create_descriptor
-// (cache miss) and get_dynamic_runtime_args (cache hit) call it, so the two paths cannot drift.
+// (so two fills that differ only in those cache-hit), yet it is baked into a writer runtime arg.
+// create_descriptor re-derives it from the current attrs on every dispatch (cache miss and, via
+// override_runtime_arguments, cache hit), so it never freezes.
 std::vector<std::pair<tt::tt_metal::CoreCoord, uint32_t>> compute_fill_cache_start_ids(
     const KvCacheParams& operation_attributes, const KvCacheInputs& tensor_args);
 

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/fill_cache_multi_core_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/fill_cache_multi_core_program_factory.hpp
@@ -3,29 +3,41 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <optional>
 #include <utility>
 #include <vector>
+#include <tt-metalium/program.hpp>
 #include <tt-metalium/program_descriptors.hpp>
 #include "update_cache_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
+#include "ttnn/distributed/types.hpp"
 
 namespace ttnn::prim {
 
 // Descriptor-based factory: builds a ProgramDescriptor declaratively. The framework owns
-// program construction, caching, dynamic CB address patching (via CBDescriptor::buffer)
-// and runtime arg copy on cache hits, so this struct no longer needs shared_variables_t,
-// cached_program_t, create() or override_runtime_arguments().
+// program construction and caching, so this struct needs no shared_variables_t/cached_program_t/create().
 struct FillCacheMultiCoreProgramFactory {
     static tt::tt_metal::ProgramDescriptor create_descriptor(
         const KvCacheParams& operation_attributes, const KvCacheInputs& tensor_args, Tensor& tensor_return_value);
+
+    // Cache-hit hook: patches the per-dispatch runtime args of the cached program in place. The
+    // framework calls it on the factory that actually built the cached program, and uses neither
+    // resolve_bindings nor get_dynamic_runtime_args, so this owns every buffer address too.
+    static void override_runtime_arguments(
+        tt::tt_metal::Program& program,
+        const KvCacheParams& operation_attributes,
+        const KvCacheInputs& tensor_args,
+        Tensor& tensor_return_value,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 
 // Per-core writer cache_start_id, in the SAME core order create_descriptor emits runtime args.
 // cache_start_id derives from operation_attributes (batch_idx, update_idx) which
 // UpdateKVCacheOperation::compute_program_hash deliberately EXCLUDES from the program-cache key
 // (so two fills that differ only in those cache-hit), yet it is baked into a writer runtime arg.
-// create_descriptor re-derives it from the current attrs on every dispatch (cache miss and, via
-// override_runtime_arguments, cache hit), so it never freezes.
+// Single source of truth for the work-split + formula: create_descriptor (cache miss) and
+// override_runtime_arguments (cache hit) both call it, so the core order and the arg values cannot
+// drift between the two.
 std::vector<std::pair<tt::tt_metal::CoreCoord, uint32_t>> compute_fill_cache_start_ids(
     const KvCacheParams& operation_attributes, const KvCacheInputs& tensor_args);
 

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.cpp
@@ -4,6 +4,8 @@
 
 #include "update_cache_device_operation.hpp"
 #include "ttnn/device_operation.hpp"
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::prim {
 
@@ -163,51 +165,21 @@ tt::tt_metal::operation::Hash UpdateKVCacheOperation::compute_program_hash(
         args.op_type, std::vector<Tensor>{tensor_args.cache, tensor_args.input});
 }
 
-std::vector<tt::tt_metal::DynamicRuntimeArg> UpdateKVCacheOperation::get_dynamic_runtime_args(
+void UpdateKVCacheOperation::override_runtime_arguments(
+    tt::tt_metal::Program& program,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& /*tensor_return_value*/,
+    tensor_return_value_t& tensor_return_value,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    // The work-split (hence the core set) depends only on shapes, which ARE in the program hash, so
-    // the active core set is identical on every cache hit — no freeze hazard from growing cores.
-    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
-
-    if (operation_attributes.op_type == UpdateCacheOpType::FILL) {
-        // FILL: kernel push order in FillCacheMultiCoreProgramFactory::create_descriptor is
-        // reader(0), writer(1). Only writer arg 2 (cache_start_id) is derived from the
-        // hash-excluded batch_idx/update_idx; the reader args are shape-only.
-        constexpr uint32_t kWriterKernelIdx = 1;
-        constexpr uint32_t kCacheStartIdArgIdx = 2;
-        const auto start_ids = compute_fill_cache_start_ids(operation_attributes, tensor_args);
-        dynamic_args.reserve(start_ids.size());
-        for (const auto& [core, cache_start_id] : start_ids) {
-            dynamic_args.push_back({kWriterKernelIdx, core, kCacheStartIdArgIdx, cache_start_id});
-        }
-        return dynamic_args;
-    }
-
-    // UPDATE: kernel push order in UpdateCacheMultiCoreProgramFactory::create_descriptor is
-    // reader(0), writer(1), compute(2), [optional compute(3)]. The hash-excluded values are:
-    //   reader arg 8  = cache_start_id (per core)
-    //   writer arg 7  = cache_start_id (per core)
-    //   writer arg 10 = tile_update_offset (op-wide)
-    //   writer arg 11 = batch_read_offset (op-wide)
-    constexpr uint32_t kReaderKernelIdx = 0;
-    constexpr uint32_t kWriterKernelIdx = 1;
-    constexpr uint32_t kReaderCacheStartIdArgIdx = 8;
-    constexpr uint32_t kWriterCacheStartIdArgIdx = 7;
-    constexpr uint32_t kWriterTileUpdateOffsetArgIdx = 10;
-    constexpr uint32_t kWriterBatchReadOffsetArgIdx = 11;
-
-    const auto dyn = compute_update_cache_dynamic_args(operation_attributes, tensor_args);
-    dynamic_args.reserve(dyn.cache_start_ids.size() * 4);
-    for (const auto& [core, cache_start_id] : dyn.cache_start_ids) {
-        dynamic_args.push_back({kReaderKernelIdx, core, kReaderCacheStartIdArgIdx, cache_start_id});
-        dynamic_args.push_back({kWriterKernelIdx, core, kWriterCacheStartIdArgIdx, cache_start_id});
-        dynamic_args.push_back({kWriterKernelIdx, core, kWriterTileUpdateOffsetArgIdx, dyn.tile_update_offset});
-        dynamic_args.push_back({kWriterKernelIdx, core, kWriterBatchReadOffsetArgIdx, dyn.batch_read_offset});
-    }
-    return dynamic_args;
+    // Re-derive the descriptor from the single source of truth (create_descriptor) for the current
+    // tensors/attrs and re-apply its per-core args + tensor-backed CB/buffer addresses to the cached
+    // program. No rebuild; supersedes get_dynamic/resolve_bindings. Mirror select_program_factory.
+    auto desc = operation_attributes.op_type == UpdateCacheOpType::FILL
+                    ? FillCacheMultiCoreProgramFactory::create_descriptor(
+                          operation_attributes, tensor_args, tensor_return_value)
+                    : UpdateCacheMultiCoreProgramFactory::create_descriptor(
+                          operation_attributes, tensor_args, tensor_return_value);
+    tt::tt_metal::apply_descriptor_runtime_args(program, desc);
 }
 
 Tensor update_cache(

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.cpp
@@ -4,8 +4,6 @@
 
 #include "update_cache_device_operation.hpp"
 #include "ttnn/device_operation.hpp"
-#include <tt-metalium/program.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::prim {
 
@@ -163,23 +161,6 @@ tt::tt_metal::operation::Hash UpdateKVCacheOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     return tt::tt_metal::operation::hash_operation<UpdateKVCacheOperation>(
         args.op_type, std::vector<Tensor>{tensor_args.cache, tensor_args.input});
-}
-
-void UpdateKVCacheOperation::override_runtime_arguments(
-    tt::tt_metal::Program& program,
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value,
-    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    // Re-derive the descriptor from the single source of truth (create_descriptor) for the current
-    // tensors/attrs and re-apply its per-core args + tensor-backed CB/buffer addresses to the cached
-    // program. No rebuild; supersedes get_dynamic/resolve_bindings. Mirror select_program_factory.
-    auto desc = operation_attributes.op_type == UpdateCacheOpType::FILL
-                    ? FillCacheMultiCoreProgramFactory::create_descriptor(
-                          operation_attributes, tensor_args, tensor_return_value)
-                    : UpdateCacheMultiCoreProgramFactory::create_descriptor(
-                          operation_attributes, tensor_args, tensor_return_value);
-    tt::tt_metal::apply_descriptor_runtime_args(program, desc);
 }
 
 Tensor update_cache(

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.hpp
@@ -35,13 +35,10 @@ struct UpdateKVCacheOperation {
         const operation_attributes_t& args, const tensor_args_t& tensor_args);
     static tt::tt_metal::operation::Hash compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 
-    // batch_idx, update_idx and batch_offset are excluded from compute_program_hash (so calls
-    // differing only in them cache-hit), yet the factories bake the values they derive
-    // (cache_start_id, tile_update_offset, batch_read_offset) into runtime args. Those must be
-    // re-applied to the cached program on every dispatch or they freeze at the first cache-miss
-    // value — corrupting the write offset. The buffer base addresses are handled separately by the
-    // Buffer* bindings the factories declare via emplace_runtime_args.
-    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+    // Cache-hit re-apply of all per-dispatch state (per-core args + tensor-backed CB/buffer
+    // addresses), since compute_program_hash excludes batch_idx/update_idx/batch_offset. See the .cpp.
+    static void override_runtime_arguments(
+        tt::tt_metal::Program& program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& tensor_return_value,

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.hpp
@@ -35,14 +35,10 @@ struct UpdateKVCacheOperation {
         const operation_attributes_t& args, const tensor_args_t& tensor_args);
     static tt::tt_metal::operation::Hash compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 
-    // Cache-hit re-apply of all per-dispatch state (per-core args + tensor-backed CB/buffer
-    // addresses), since compute_program_hash excludes batch_idx/update_idx/batch_offset. See the .cpp.
-    static void override_runtime_arguments(
-        tt::tt_metal::Program& program,
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value,
-        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
+    // Cache-hit re-apply of all per-dispatch state (buffer addresses + the args derived from the
+    // batch_idx/update_idx/batch_offset that compute_program_hash excludes) lives on each program
+    // factory as override_runtime_arguments(); the framework calls it on the factory that built the
+    // cached program.
 };
 
 Tensor update_cache(

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_multi_core_program_factory.cpp
@@ -369,11 +369,10 @@ ProgramDescriptor UpdateCacheMultiCoreProgramFactory::create_descriptor(
     // framework patches the (possibly reallocated) addresses directly on cache hits (fast path).
     // cache_start_id, tile_update_offset and batch_read_offset depend on operation_attributes
     // (update_idx, batch_offset) which UpdateKVCacheOperation::compute_program_hash deliberately
-    // excludes from the program-cache key, so they are NOT stable across cache hits: they are
-    // re-patched every dispatch by UpdateKVCacheOperation::get_dynamic_runtime_args.
-    // compute_update_cache_dynamic_args is the shared single source of truth for the work-split and
-    // formulas so the two paths agree. input_start_id and batch_start_id are shape-only (in the
-    // hash), so they stay computed inline here.
+    // excludes from the program-cache key, so they are NOT stable across cache hits: create_descriptor
+    // re-derives them here every dispatch (miss and, via override_runtime_arguments, hit).
+    // compute_update_cache_dynamic_args is the single source of truth for the work-split and formulas.
+    // input_start_id and batch_start_id are shape-only (in the hash), so they stay computed inline here.
     const auto dyn = compute_update_cache_dynamic_args(operation_attributes, tensor_args);
     uint32_t input_start_id = 0;
     uint32_t batch_start_id = 0;

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_multi_core_program_factory.cpp
@@ -54,6 +54,7 @@ UpdateCacheDynamicArgs compute_update_cache_dynamic_args(
     UpdateCacheDynamicArgs result;
     result.tile_update_offset = update_idx % tt::constants::TILE_HEIGHT * Wbytes;
     result.batch_read_offset = batch_offset * Wbytes;  // Offset to read from input tensor
+    result.Wbytes = Wbytes;
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
@@ -366,12 +367,12 @@ ProgramDescriptor UpdateCacheMultiCoreProgramFactory::create_descriptor(
     const auto& cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, row_major);
 
     // Per-core runtime args. src/dst base addresses are declared as Buffer* bindings so the
-    // framework patches the (possibly reallocated) addresses directly on cache hits (fast path).
-    // cache_start_id, tile_update_offset and batch_read_offset depend on operation_attributes
-    // (update_idx, batch_offset) which UpdateKVCacheOperation::compute_program_hash deliberately
-    // excludes from the program-cache key, so they are NOT stable across cache hits: create_descriptor
-    // re-derives them here every dispatch (miss and, via override_runtime_arguments, hit).
-    // compute_update_cache_dynamic_args is the single source of truth for the work-split and formulas.
+    // descriptor carries the buffer identity; on a cache hit override_runtime_arguments below
+    // re-applies the (possibly reallocated) addresses. cache_start_id, tile_update_offset and
+    // batch_read_offset depend on operation_attributes (update_idx, batch_offset) which
+    // UpdateKVCacheOperation::compute_program_hash deliberately excludes from the program-cache key,
+    // so they are NOT stable across cache hits either. compute_update_cache_dynamic_args is the
+    // single source of truth for the work-split and those formulas, shared with the override.
     // input_start_id and batch_start_id are shape-only (in the hash), so they stay computed inline here.
     const auto dyn = compute_update_cache_dynamic_args(operation_attributes, tensor_args);
     uint32_t input_start_id = 0;
@@ -414,7 +415,7 @@ ProgramDescriptor UpdateCacheMultiCoreProgramFactory::create_descriptor(
              cache_head_num_tiles,
              cache_start_id,
              batch_start_id,
-             Wbytes,
+             dyn.Wbytes,
              dyn.tile_update_offset,
              dyn.batch_read_offset});
         total_batched_heads += num_batched_heads_per_core;
@@ -430,6 +431,65 @@ ProgramDescriptor UpdateCacheMultiCoreProgramFactory::create_descriptor(
     }
 
     return desc;
+}
+
+void UpdateCacheMultiCoreProgramFactory::override_runtime_arguments(
+    tt::tt_metal::Program& program,
+    const KvCacheParams& operation_attributes,
+    const KvCacheInputs& tensor_args,
+    Tensor& /*tensor_return_value*/,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+    // Runs on EVERY program-cache hit, so it patches the cached program in place and never calls
+    // create_descriptor(): that would pay the cache-miss host cost (work-split, CoreRangeSet,
+    // get_compute_kernel_config_args, TensorAccessorArgs, kernel-source strings, a fresh per-core arg
+    // vector) on a hit.
+    // Kernel push order in create_descriptor: reader(0), writer(1), compute group_1(2),
+    // [compute group_2(3)]. The compute kernels take no runtime args.
+    constexpr uint32_t kReaderKernelIdx = 0;
+    constexpr uint32_t kWriterKernelIdx = 1;
+    constexpr uint32_t kReaderDstAddrArgIdx = 0;
+    constexpr uint32_t kReaderSrcAddrArgIdx = 1;
+    constexpr uint32_t kReaderCacheStartIdArgIdx = 8;
+    constexpr uint32_t kWriterDstAddrArgIdx = 0;
+    constexpr uint32_t kWriterCacheStartIdArgIdx = 7;
+    constexpr uint32_t kWriterWbytesArgIdx = 9;
+    constexpr uint32_t kWriterTileUpdateOffsetArgIdx = 10;
+    constexpr uint32_t kWriterBatchReadOffsetArgIdx = 11;
+
+    // Buffer-address slots: create_descriptor emplaces these as Buffer*, and this hook supersedes
+    // resolve_bindings, so re-applying them is ours. The reader reads BOTH tensors (cache first, then
+    // input); the writer only writes the cache, which is also the output (in-place).
+    auto* src_buffer = tensor_args.input.buffer();
+    auto* dst_buffer = tensor_args.cache.buffer();
+    const uint32_t src_addr = src_buffer->address();
+    const uint32_t dst_addr = dst_buffer->address();
+
+    // Same helper create_descriptor uses: identical core set, order and formulas. Everything else
+    // (Wt, Bcache, num_batched_heads_per_core, cache_*_num_tiles, input_start_id, batch_start_id) is
+    // derived from the tensor specs and the shape-driven work split, which the hash covers.
+    const auto dyn = compute_update_cache_dynamic_args(operation_attributes, tensor_args);
+    for (const auto& [core, cache_start_id] : dyn.cache_start_ids) {
+        auto& reader_args = tt::tt_metal::GetRuntimeArgs(program, kReaderKernelIdx, core);
+        reader_args[kReaderDstAddrArgIdx] = dst_addr;
+        reader_args[kReaderSrcAddrArgIdx] = src_addr;
+        reader_args[kReaderCacheStartIdArgIdx] = cache_start_id;
+
+        auto& writer_args = tt::tt_metal::GetRuntimeArgs(program, kWriterKernelIdx, core);
+        writer_args[kWriterDstAddrArgIdx] = dst_addr;
+        writer_args[kWriterCacheStartIdArgIdx] = cache_start_id;
+        writer_args[kWriterWbytesArgIdx] = dyn.Wbytes;
+        writer_args[kWriterTileUpdateOffsetArgIdx] = dyn.tile_update_offset;
+        writer_args[kWriterBatchReadOffsetArgIdx] = dyn.batch_read_offset;
+    }
+
+    // desc.cbs[1] (the input CB) is globally allocated on the input buffer for sharded inputs (whether
+    // the input is sharded is hashed, so the cached program has the dynamic CB iff we take this
+    // branch); cbs[0]/[2]/[3]/[4] are plain L1 scratch. CB positions in program.circular_buffers()
+    // match desc.cbs, as in apply_descriptor_runtime_args.
+    if (tensor_args.input.shard_spec().has_value()) {
+        constexpr uint32_t kSrc1CbPos = 1;
+        UpdateDynamicCircularBufferAddress(program, program.circular_buffers()[kSrc1CbPos]->id(), *src_buffer);
+    }
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_multi_core_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_multi_core_program_factory.hpp
@@ -24,10 +24,8 @@ struct UpdateCacheMultiCoreProgramFactory {
 // Runtime-arg values that derive from operation_attributes (update_idx, batch_offset) which
 // UpdateKVCacheOperation::compute_program_hash deliberately EXCLUDES from the program-cache key
 // (so two updates that differ only in those cache-hit), yet are baked into reader/writer runtime
-// args — so they must be re-patched on every cache hit via
-// UpdateKVCacheOperation::get_dynamic_runtime_args. compute_update_cache_dynamic_args is the single
-// source of truth for the work-split + formulas: both create_descriptor (cache miss) and
-// get_dynamic_runtime_args (cache hit) call it, so the two paths cannot drift.
+// args. create_descriptor re-derives them from the current attrs on every dispatch (cache miss and,
+// via override_runtime_arguments, cache hit), so they never freeze.
 //   - cache_start_ids: per-core, in the SAME core order create_descriptor emits runtime args.
 //   - tile_update_offset / batch_read_offset: identical on every core (op-wide scalars).
 struct UpdateCacheDynamicArgs {

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_multi_core_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_multi_core_program_factory.hpp
@@ -4,34 +4,49 @@
 
 #pragma once
 #include <cstdint>
+#include <optional>
 #include <utility>
 #include <vector>
+#include <tt-metalium/program.hpp>
 #include <tt-metalium/program_descriptors.hpp>
 #include "update_cache_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
+#include "ttnn/distributed/types.hpp"
 
 namespace ttnn::prim {
 
 // Descriptor-based factory: builds a ProgramDescriptor declaratively. The framework owns
-// program construction, caching, dynamic CB address patching (via CBDescriptor::buffer)
-// and runtime arg copy on cache hits, so this struct no longer needs shared_variables_t,
-// cached_program_t, create() or override_runtime_arguments().
+// program construction and caching, so this struct needs no shared_variables_t/cached_program_t/create().
 struct UpdateCacheMultiCoreProgramFactory {
     static tt::tt_metal::ProgramDescriptor create_descriptor(
         const KvCacheParams& operation_attributes, const KvCacheInputs& tensor_args, Tensor& tensor_return_value);
+
+    // Cache-hit hook: patches the per-dispatch runtime args of the cached program in place. The
+    // framework calls it on the factory that actually built the cached program, and uses neither
+    // resolve_bindings nor get_dynamic_runtime_args, so this owns every buffer address too.
+    static void override_runtime_arguments(
+        tt::tt_metal::Program& program,
+        const KvCacheParams& operation_attributes,
+        const KvCacheInputs& tensor_args,
+        Tensor& tensor_return_value,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 
 // Runtime-arg values that derive from operation_attributes (update_idx, batch_offset) which
 // UpdateKVCacheOperation::compute_program_hash deliberately EXCLUDES from the program-cache key
 // (so two updates that differ only in those cache-hit), yet are baked into reader/writer runtime
-// args. create_descriptor re-derives them from the current attrs on every dispatch (cache miss and,
-// via override_runtime_arguments, cache hit), so they never freeze.
+// args. Single source of truth for the work-split + formulas: create_descriptor (cache miss) and
+// override_runtime_arguments (cache hit) both call it, so the core order and the arg values cannot
+// drift between the two.
 //   - cache_start_ids: per-core, in the SAME core order create_descriptor emits runtime args.
 //   - tile_update_offset / batch_read_offset: identical on every core (op-wide scalars).
+//   - Wbytes: op-wide; not attribute-derived, but it depends on fp32_dest_acc_en, which the hash
+//     excludes along with the rest of compute_kernel_config, so the override re-applies it too.
 struct UpdateCacheDynamicArgs {
     std::vector<std::pair<tt::tt_metal::CoreCoord, uint32_t>> cache_start_ids;
     uint32_t tile_update_offset = 0;
     uint32_t batch_read_offset = 0;
+    uint32_t Wbytes = 0;
 };
 
 UpdateCacheDynamicArgs compute_update_cache_dynamic_args(


### PR DESCRIPTION
## What
Migrates `kv_cache/update_cache` off the legacy `get_dynamic_runtime_args` cache-hit hook to `override_runtime_arguments` (#49828 mechanism). `get_dynamic_runtime_args` removed entirely.

## Why
Eliminating `get_dynamic_runtime_args` across all descriptor ops (fragile hand-mirrored re-application, slated for deletion). The override re-derives per-dispatch state correct-by-construction.

## Metrics (Wormhole B0, host cache-hit dispatch, min-of-medians 3×100)
- **perf:** 32→35 µs (+11%) (small host-side regression; acceptable — correctness + get_dynamic removal is the goal)
- **PCC:** cache-hit output correct (program-cache test)
- **cache-hit:** entry count stable across the hash-excluded dynamic value / addr change ✅
- 0 parity failures under `-DENABLE_DESCRIPTOR_PATCHING_PARITY_CHECK=ON` (single-chip). Mesh path (paged) validated in CI.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/gd-kv-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/gd-kv-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/gd-kv-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/gd-kv-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/gd-kv-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/gd-kv-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/gd-kv-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/gd-kv-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/gd-kv-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/gd-kv-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/gd-kv-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/gd-kv-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/gd-kv-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/gd-kv-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/gd-kv-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/gd-kv-update)