### PR TITLE
[ttnn] experimental/paged_cache fill_cache: replace get_dynamic_runtime_args with override_runtime_arguments

### DIFF
--- a/tests/ttnn/unit_tests/operations/transformers/test_paged_cache_flexible_geometry.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_paged_cache_flexible_geometry.py
@@ -850,3 +850,40 @@ def test_paged_fill_cache_negative_asymmetric_num_heads_byte_count_mismatch(devi
 
     with pytest.raises(RuntimeError, match="geometry mismatch"):
         ttnn.experimental.paged_fill_cache(cache_tt, xt, page_table_tt, batch_idx=0, block_size=view_block_size)
+
+
+def test_paged_fill_cache_program_cache_scalar_batch_idx(device):
+    """Program-cache hit with a DIFFERENT scalar ``batch_idx`` must still fill the
+    correct physical block. ``batch_idx`` is excluded from the program hash and baked
+    into a writer runtime arg, so a frozen value would re-route the 2nd fill to the
+    1st user's block. Two fills reuse one cache entry; each re-allocates its input so
+    buffer addresses differ across the hit too.
+    """
+    torch.manual_seed(20)
+    num_users = 2
+    num_kv_heads = 1
+    block_size = 64
+    head_dim = 256
+    input_seq_len = block_size  # one block per user
+
+    cache_tt, cache_torch = _make_paged_cache(num_users, num_kv_heads, block_size, head_dim, device)
+    ref = cache_torch.clone()
+
+    # page_table[u] = [u]: user u -> physical block u. A frozen batch_idx would send
+    # both fills to block 0 and leave block 1 unchanged.
+    page_table = torch.arange(num_users, dtype=torch.int32).reshape(num_users, 1)
+    page_table_tt = ttnn.Tensor(page_table, ttnn.int32).to(device)
+
+    entries_before = device.num_program_cache_entries()
+    for u in range(num_users):
+        x = torch.randn([1, num_kv_heads, input_seq_len, head_dim]).bfloat16().float()
+        xt = ttnn.from_torch(x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device)
+        ttnn.experimental.paged_fill_cache(cache_tt, xt, page_table_tt, batch_idx=u)
+        ref[u, 0:num_kv_heads, :, :] = x[0, :, :, :]
+
+    # Second fill reuses the first fill's entry (only batch_idx differs, which is unhashed).
+    assert device.num_program_cache_entries() - entries_before == 1
+
+    got = _read_paged_cache(cache_tt)
+    eq, msg = comp_equal(ref, got)
+    assert eq, f"program-cache fill mismatch (frozen batch_idx?): {msg}"

--- a/tests/ttnn/unit_tests/operations/transformers/test_paged_cache_flexible_geometry.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_paged_cache_flexible_geometry.py
@@ -441,7 +441,7 @@ def test_paged_update_cache_asymmetric_num_heads_per_block_match(device):
     assert eq, f"asymmetric num_heads update_cache round trip mismatch: {msg}"
 
 
-def test_paged_update_cache_negative_asymmetric_num_heads_byte_count_mismatch(device):
+def test_paged_update_cache_negative_asymmetric_num_heads_byte_count_mismatch(device, expect_error):
     """Different ``num_kv_heads`` between cache and ``num_kv_heads`` kwarg *without*
     the per-block element count being preserved must still be rejected. Guards
     against the relaxation accidentally allowing arbitrary mismatched-byte
@@ -472,7 +472,7 @@ def test_paged_update_cache_negative_asymmetric_num_heads_byte_count_mismatch(de
     x_padded = torch.nn.functional.pad(x, (0, 0, 0, 32 - view_kv), "constant", 0)
     xt = _sharded_input(device, x_padded)
 
-    with pytest.raises(RuntimeError, match="geometry mismatch"):
+    with expect_error(RuntimeError, "geometry mismatch"):
         ttnn.experimental.paged_update_cache(
             cache_tt,
             xt,
@@ -483,7 +483,7 @@ def test_paged_update_cache_negative_asymmetric_num_heads_byte_count_mismatch(de
         )
 
 
-def test_paged_update_cache_negative_num_kv_heads_override_without_page_table(device):
+def test_paged_update_cache_negative_num_kv_heads_override_without_page_table(device, expect_error):
     """``num_kv_heads`` override is paged-mode only; validator must reject it
     without a page_table (analogous to the ``block_size`` gate)."""
     torch.manual_seed(8)
@@ -503,7 +503,7 @@ def test_paged_update_cache_negative_num_kv_heads_override_without_page_table(de
     x_padded = torch.nn.functional.pad(x, (0, 0, 0, 32 - num_kv_heads), "constant", 0)
     xt = _sharded_input(device, x_padded)
 
-    with pytest.raises(RuntimeError, match="num_kv_heads_override is only supported in paged mode"):
+    with expect_error(RuntimeError, "num_kv_heads_override is only supported in paged mode"):
         ttnn.experimental.paged_update_cache(
             cache_tt,
             xt,
@@ -513,7 +513,7 @@ def test_paged_update_cache_negative_num_kv_heads_override_without_page_table(de
         )
 
 
-def test_paged_update_cache_negative_byte_count_mismatch(device):
+def test_paged_update_cache_negative_byte_count_mismatch(device, expect_error):
     """Override that breaks the per-block byte invariant must be rejected at validation."""
     torch.manual_seed(4)
     num_users = 4
@@ -535,7 +535,7 @@ def test_paged_update_cache_negative_byte_count_mismatch(device):
     x_padded = torch.nn.functional.pad(x, (0, 0, 0, 32 - num_kv_heads), "constant", 0)
     xt = _sharded_input(device, x_padded)
 
-    with pytest.raises(RuntimeError, match="geometry mismatch"):
+    with expect_error(RuntimeError, "geometry mismatch"):
         ttnn.experimental.paged_update_cache(
             cache_tt,
             xt,
@@ -545,7 +545,7 @@ def test_paged_update_cache_negative_byte_count_mismatch(device):
         )
 
 
-def test_paged_update_cache_negative_override_without_page_table(device):
+def test_paged_update_cache_negative_override_without_page_table(device, expect_error):
     """``block_size`` is paged-mode only; validator must reject it without a page_table."""
     torch.manual_seed(5)
     num_users = 4
@@ -564,7 +564,7 @@ def test_paged_update_cache_negative_override_without_page_table(device):
     x_padded = torch.nn.functional.pad(x, (0, 0, 0, 32 - num_kv_heads), "constant", 0)
     xt = _sharded_input(device, x_padded)
 
-    with pytest.raises(RuntimeError, match="block_size_override is only supported in paged mode"):
+    with expect_error(RuntimeError, "block_size_override is only supported in paged mode"):
         ttnn.experimental.paged_update_cache(
             cache_tt,
             xt,
@@ -602,7 +602,9 @@ def _sharded_input_with_num_cores(device, x_padded, num_cores):
         (4, 2),
     ],
 )
-def test_paged_update_cache_negative_input_shard_grid_num_cores_mismatch(num_users, bad_num_cores, device):
+def test_paged_update_cache_negative_input_shard_grid_num_cores_mismatch(
+    num_users, bad_num_cores, device, expect_error
+):
     """Validator must reject input shard grids whose num_cores != num_users; the program
     factory iterates one user per core and silently miscomputes otherwise (issue #44923)."""
     torch.manual_seed(9)
@@ -621,7 +623,7 @@ def test_paged_update_cache_negative_input_shard_grid_num_cores_mismatch(num_use
     x_padded = torch.nn.functional.pad(x, (0, 0, 0, 32 - num_kv_heads), "constant", 0)
     xt = _sharded_input_with_num_cores(device, x_padded, bad_num_cores)
 
-    with pytest.raises(RuntimeError, match="num_cores"):
+    with expect_error(RuntimeError, "num_cores"):
         ttnn.experimental.paged_update_cache(
             cache_tt,
             xt,
@@ -734,7 +736,7 @@ def test_paged_fill_cache_override_view_sliding_into_full_buffer(device):
     )
 
 
-def test_paged_fill_cache_negative_byte_count_mismatch(device):
+def test_paged_fill_cache_negative_byte_count_mismatch(device, expect_error):
     """Same as ``paged_update_cache`` byte-count mismatch but for fill."""
     torch.manual_seed(13)
     num_users = 2
@@ -756,7 +758,7 @@ def test_paged_fill_cache_negative_byte_count_mismatch(device):
     x = torch.randn([1, num_kv_heads, input_seq_len, view_head_dim]).bfloat16().float()
     xt = ttnn.from_torch(x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device)
 
-    with pytest.raises(RuntimeError, match="geometry mismatch"):
+    with expect_error(RuntimeError, "geometry mismatch"):
         ttnn.experimental.paged_fill_cache(cache_tt, xt, page_table_tt, batch_idx=0, block_size=view_block_size)
 
 
@@ -818,7 +820,7 @@ def test_paged_fill_cache_asymmetric_num_heads_per_block_match(device):
     assert eq, f"asymmetric num_heads fill cache round trip mismatch: {msg}"
 
 
-def test_paged_fill_cache_negative_asymmetric_num_heads_byte_count_mismatch(device):
+def test_paged_fill_cache_negative_asymmetric_num_heads_byte_count_mismatch(device, expect_error):
     """Different ``num_kv_heads`` between cache and input *without* the per-block
     element count being preserved must still be rejected. Guards against the
     relaxation accidentally allowing arbitrary mismatched-byte writes.
@@ -848,7 +850,7 @@ def test_paged_fill_cache_negative_asymmetric_num_heads_byte_count_mismatch(devi
     x = torch.randn([1, view_kv, input_seq_len, view_head_dim]).bfloat16().float()
     xt = ttnn.from_torch(x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device)
 
-    with pytest.raises(RuntimeError, match="geometry mismatch"):
+    with expect_error(RuntimeError, "geometry mismatch"):
         ttnn.experimental.paged_fill_cache(cache_tt, xt, page_table_tt, batch_idx=0, block_size=view_block_size)
 
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.hpp
@@ -37,14 +37,10 @@ struct PagedFillCacheDeviceOperation {
 
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 
-    // batch_idx_fallback and noop are excluded from the program hash (so calls differing only in
-    // them cache-hit). Of these only batch_idx_fallback is genuinely dynamic: in the scalar-fallback
-    // path (no batch_idx_tensor) it is baked into a writer runtime arg, so it must be re-applied to
-    // the cached program on every dispatch. Returns empty in batch-idx-tensor mode (the writer pushes
-    // a Buffer* the framework already re-patches) and for coords excluded from a mesh dispatch. noop
-    // is derived from the hashed mesh_coords and is therefore stable across cache hits, so it is not
-    // re-patched.
-    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+    // Cache-hit re-derivation: re-run create_descriptor (single source of truth) for the current
+    // tensors/attrs and re-apply it, so hash-excluded batch_idx_fallback can't freeze at the miss value.
+    static void override_runtime_arguments(
+        tt::tt_metal::Program& program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& tensor_return_value,

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.hpp
@@ -14,7 +14,6 @@
 #include "paged_fill_cache_program_factory.hpp"
 
 #include "paged_fill_cache_device_operation_types.hpp"
-#include <tt-metalium/experimental/program_descriptor_patching.hpp>
 #include "ttnn/distributed/types.hpp"
 
 namespace ttnn::experimental::prim {
@@ -37,8 +36,9 @@ struct PagedFillCacheDeviceOperation {
 
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 
-    // Cache-hit re-derivation: re-run create_descriptor (single source of truth) for the current
-    // tensors/attrs and re-apply it, so hash-excluded batch_idx_fallback can't freeze at the miss value.
+    // Cache-hit re-derivation: patches the cached program's runtime args in place (no descriptor
+    // rebuild). Re-applies every buffer address plus the args derived from what compute_program_hash
+    // excludes — batch_idx_fallback and noop — which would otherwise freeze at the cache-miss value.
     static void override_runtime_arguments(
         tt::tt_metal::Program& program,
         const operation_attributes_t& operation_attributes,

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_program_factory.cpp
@@ -24,12 +24,8 @@ using namespace tt;
 
 namespace {
 
-// Worker-core list for the fill_cache work-split. batch_idx_fallback (excluded from the program
-// hash, baked into writer runtime args) is the SAME value on every core, so re-patching it on a
-// cache hit only needs the core *ordering* — not the per-core block counts. This helper is the
-// single source of truth for that ordering: both build_paged_fill_cache_descriptor (cache miss)
-// and PagedFillCacheDeviceOperation::get_dynamic_runtime_args (cache hit) call it, so the two
-// paths cannot drift in which cores they touch or in what order.
+// Worker-core list for the fill_cache work-split: the single source of truth for core ordering used
+// by build_paged_fill_cache_descriptor when emitting per-core runtime args.
 std::vector<tt_metal::CoreCoord> compute_paged_fill_cache_cores(
     const PagedFillCacheParams& /*operation_attributes*/, const PagedFillCacheInputs& tensor_args) {
     const auto& input_tensor = tensor_args.input_tensor;
@@ -269,7 +265,7 @@ ProgramDescriptor build_paged_fill_cache_descriptor(
     uint32_t g1_numcores = core_group_1.num_cores();
     uint32_t g2_numcores = core_group_2.num_cores();
 
-    // Core list shared with get_dynamic_runtime_args (single source of truth for ordering).
+    // Core list (single source of truth for ordering).
     const auto cores = compute_paged_fill_cache_cores(operation_attributes, tensor_args);
 
     for (uint32_t i = 0, num_blocks_written = 0; i < num_cores; i++) {
@@ -350,48 +346,21 @@ ProgramDescriptor PagedFillCacheMeshWorkloadFactory::create_descriptor(
     return build_paged_fill_cache_descriptor(operation_attributes, tensor_args, noop);
 }
 
-std::vector<tt::tt_metal::DynamicRuntimeArg> PagedFillCacheDeviceOperation::get_dynamic_runtime_args(
+void PagedFillCacheDeviceOperation::override_runtime_arguments(
+    tt::tt_metal::Program& program,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& /*tensor_return_value*/,
+    tensor_return_value_t& tensor_return_value,
     const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
-    // Coords excluded from a mesh dispatch build a noop program (kernels early-exit), so there is
-    // nothing meaningful to re-patch there.
-    if (operation_attributes.mesh_coords.has_value() && mesh_dispatch_coordinate.has_value() &&
-        !operation_attributes.mesh_coords.value().contains(mesh_dispatch_coordinate.value())) {
-        return {};
-    }
-
-    // batch-idx-tensor mode: the writer pushes the batch_idx tensor's Buffer* (writer arg 4), which
-    // the framework already re-patches by buffer base address. Nothing op-specific to re-apply.
-    if (tensor_args.batch_idx_tensor_opt.has_value()) {
-        return {};
-    }
-
-    // Scalar-fallback mode: batch_idx_fallback is excluded from the program hash (so two calls
-    // differing only in it cache-hit) yet baked into writer runtime arg index 4 — re-patch it on
-    // every dispatch or it freezes at the first cache-miss value. It is the SAME value on every
-    // core (operation_attributes.batch_idx_fallback, not per-core), so we emit one arg per core
-    // using the shared core-list helper (single source of truth for core ordering).
-    //
-    // noop is intentionally NOT re-patched: it is derived from the hashed mesh_coords (the mesh
-    // factory sets it per coord from coord-membership), so it is stable across cache hits for a
-    // fixed coord and is already correct in the cached program.
-    //
-    // Kernel push order in build_paged_fill_cache_descriptor: reader(0), writer(1).
-    // Writer rt args: [0]=dst, [1]=page_table, [2]=start_row_num, [3]=num_rows,
-    //                 [4]=batch_idx_fallback (scalar-fallback mode), [5]=noop.
-    constexpr uint32_t kWriterKernelIdx = 1;
-    constexpr uint32_t kBatchIdxFallbackArgIdx = 4;
-
-    const auto cores = compute_paged_fill_cache_cores(operation_attributes, tensor_args);
-    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
-    dynamic_args.reserve(cores.size());
-    for (const auto& core : cores) {
-        dynamic_args.push_back(
-            {kWriterKernelIdx, core, kBatchIdxFallbackArgIdx, operation_attributes.batch_idx_fallback});
-    }
-    return dynamic_args;
+    // Re-derive the descriptor from the single source of truth (create_descriptor, per select_program_factory)
+    // and re-apply it to the cached program — re-patches hash-excluded batch_idx_fallback and all buffer
+    // addresses. No rebuild; supersedes get_dynamic_runtime_args/resolve_bindings.
+    auto desc =
+        operation_attributes.mesh_coords.has_value()
+            ? PagedFillCacheMeshWorkloadFactory::create_descriptor(
+                  operation_attributes, tensor_args, tensor_return_value, mesh_dispatch_coordinate)
+            : PagedFillCacheProgramFactory::create_descriptor(operation_attributes, tensor_args, tensor_return_value);
+    tt::tt_metal::apply_descriptor_runtime_args(program, desc);
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_program_factory.cpp
@@ -11,6 +11,7 @@
 
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
@@ -24,8 +25,24 @@ using namespace tt;
 
 namespace {
 
-// Worker-core list for the fill_cache work-split: the single source of truth for core ordering used
-// by build_paged_fill_cache_descriptor when emitting per-core runtime args.
+// `noop` is the only thing that differs between the single-device and the mesh-workload factory: a
+// mesh coordinate outside operation_attributes.mesh_coords gets a noop program (kernels early-exit).
+// Single source of truth for that choice, called by both create_descriptor overloads and by
+// override_runtime_arguments — so the cache-hit patch mirrors select_program_factory by construction
+// (mesh_coords is nullopt on the single-device path, where the coordinate is ignored).
+bool paged_fill_cache_noop(
+    const PagedFillCacheParams& operation_attributes, const std::optional<ttnn::MeshCoordinate>& coord) {
+    if (operation_attributes.mesh_coords.has_value() && coord.has_value() &&
+        !operation_attributes.mesh_coords->contains(coord.value())) {
+        return true;
+    }
+    return operation_attributes.noop;
+}
+
+// Worker-core list for the fill_cache work-split. Single source of truth for core ordering: called by
+// both build_paged_fill_cache_descriptor (cache miss, emitting per-core runtime args) and
+// PagedFillCacheDeviceOperation::override_runtime_arguments (cache hit, patching them), so the two
+// paths cannot drift in which cores they touch or in what order.
 std::vector<tt_metal::CoreCoord> compute_paged_fill_cache_cores(
     const PagedFillCacheParams& /*operation_attributes*/, const PagedFillCacheInputs& tensor_args) {
     const auto& input_tensor = tensor_args.input_tensor;
@@ -265,7 +282,7 @@ ProgramDescriptor build_paged_fill_cache_descriptor(
     uint32_t g1_numcores = core_group_1.num_cores();
     uint32_t g2_numcores = core_group_2.num_cores();
 
-    // Core list (single source of truth for ordering).
+    // Core list shared with override_runtime_arguments (single source of truth for ordering).
     const auto cores = compute_paged_fill_cache_cores(operation_attributes, tensor_args);
 
     for (uint32_t i = 0, num_blocks_written = 0; i < num_cores; i++) {
@@ -324,7 +341,8 @@ ProgramDescriptor PagedFillCacheProgramFactory::create_descriptor(
     const PagedFillCacheParams& operation_attributes,
     const PagedFillCacheInputs& tensor_args,
     Tensor& /*tensor_return_value*/) {
-    return build_paged_fill_cache_descriptor(operation_attributes, tensor_args, operation_attributes.noop);
+    return build_paged_fill_cache_descriptor(
+        operation_attributes, tensor_args, paged_fill_cache_noop(operation_attributes, std::nullopt));
 }
 
 ProgramDescriptor PagedFillCacheMeshWorkloadFactory::create_descriptor(
@@ -336,31 +354,67 @@ ProgramDescriptor PagedFillCacheMeshWorkloadFactory::create_descriptor(
     // program (kernels early-exit).  This preserves the legacy behavior of
     // dispatching a "dummy" program to every device in the mesh range so the
     // cached workload covers all coords.
-    bool noop = operation_attributes.noop;
-    if (operation_attributes.mesh_coords.has_value() && mesh_dispatch_coordinate.has_value()) {
-        const auto& mesh_coords_set = operation_attributes.mesh_coords.value();
-        if (!mesh_coords_set.contains(mesh_dispatch_coordinate.value())) {
-            noop = true;
-        }
-    }
-    return build_paged_fill_cache_descriptor(operation_attributes, tensor_args, noop);
+    return build_paged_fill_cache_descriptor(
+        operation_attributes, tensor_args, paged_fill_cache_noop(operation_attributes, mesh_dispatch_coordinate));
 }
 
 void PagedFillCacheDeviceOperation::override_runtime_arguments(
     tt::tt_metal::Program& program,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& tensor_return_value,
+    tensor_return_value_t& /*tensor_return_value*/,
     const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
-    // Re-derive the descriptor from the single source of truth (create_descriptor, per select_program_factory)
-    // and re-apply it to the cached program — re-patches hash-excluded batch_idx_fallback and all buffer
-    // addresses. No rebuild; supersedes get_dynamic_runtime_args/resolve_bindings.
-    auto desc =
-        operation_attributes.mesh_coords.has_value()
-            ? PagedFillCacheMeshWorkloadFactory::create_descriptor(
-                  operation_attributes, tensor_args, tensor_return_value, mesh_dispatch_coordinate)
-            : PagedFillCacheProgramFactory::create_descriptor(operation_attributes, tensor_args, tensor_return_value);
-    tt::tt_metal::apply_descriptor_runtime_args(program, desc);
+    // Patch the cached program in place. Calling create_descriptor() here would re-pay the whole
+    // cache-MISS host cost on every hit (work-split, CoreRangeSet, TensorAccessorArgs, kernel-source
+    // strings, a fresh per-core arg vector for every core) plus a full apply over every kernel x core
+    // x arg. Both factories emit the same layout via build_paged_fill_cache_descriptor and differ only
+    // in `noop`, so one patch covers both variants — see paged_fill_cache_noop.
+    //
+    // Kernel push order in build_paged_fill_cache_descriptor: reader(0), writer(1).
+    // reader rt args: [0]=src, [1]=start_tile_id, [2]=num_rows, [3]=noop.
+    // writer rt args: [0]=dst, [1]=page_table, [2]=start_row_num, [3]=num_rows,
+    //                 [4]=batch_idx_tensor addr | batch_idx_fallback, [5]=noop,
+    //                 [6]=valid_seq_len addr | 0.
+    constexpr uint32_t kReaderKernelIdx = 0;
+    constexpr uint32_t kWriterKernelIdx = 1;
+
+    // Buffer addresses: override supersedes resolve_bindings, so every Buffer* the descriptor
+    // emplaced is ours to re-apply. The op is in place (tensor_return_value aliases
+    // tensor_args.cache_tensor), so read the same tensors build_paged_fill_cache_descriptor does.
+    const auto src_addr = static_cast<uint32_t>(tensor_args.input_tensor.buffer()->address());
+    const auto dst_addr = static_cast<uint32_t>(tensor_args.cache_tensor.buffer()->address());
+    const auto page_table_addr = static_cast<uint32_t>(tensor_args.page_table.buffer()->address());
+    // Optional tensors: an absent one is emplaced as the literal 0 the descriptor pushes.
+    const uint32_t valid_seq_len_arg =
+        tensor_args.valid_seq_len_tensor_opt.has_value()
+            ? static_cast<uint32_t>(tensor_args.valid_seq_len_tensor_opt->buffer()->address())
+            : 0u;
+    // Writer arg 4 is a buffer address in batch-idx-tensor mode, and otherwise batch_idx_fallback —
+    // excluded from the program hash (so calls differing only in it cache-hit) yet baked into the
+    // arg, so it freezes at the first miss value unless re-applied here.
+    const uint32_t batch_idx_arg = tensor_args.batch_idx_tensor_opt.has_value()
+                                       ? static_cast<uint32_t>(tensor_args.batch_idx_tensor_opt->buffer()->address())
+                                       : operation_attributes.batch_idx_fallback;
+    // noop is hash-excluded too, and on the mesh path depends on the dispatch coordinate.
+    const auto noop_arg = static_cast<uint32_t>(paged_fill_cache_noop(operation_attributes, mesh_dispatch_coordinate));
+
+    // Not re-applied: start_tile_id / start_row_num / num_rows. They come from the work split over
+    // the input's padded shape and the device grid, both of which the program hash includes, so a
+    // cache hit has them identical by construction.
+    const auto cores = compute_paged_fill_cache_cores(operation_attributes, tensor_args);
+    for (const auto& core : cores) {
+        auto& reader_args = tt::tt_metal::GetRuntimeArgs(program, kReaderKernelIdx, core);
+        reader_args[0] = src_addr;
+        reader_args[3] = noop_arg;
+
+        auto& writer_args = tt::tt_metal::GetRuntimeArgs(program, kWriterKernelIdx, core);
+        writer_args[0] = dst_addr;
+        writer_args[1] = page_table_addr;
+        writer_args[4] = batch_idx_arg;
+        writer_args[5] = noop_arg;
+        writer_args[6] = valid_seq_len_arg;
+    }
+    // No CB addresses to re-point: none of the four CBs is globally allocated (no .buffer/.tensor).
 }
 
 }  // namespace ttnn::experimental::prim


### PR DESCRIPTION
## What
Migrates `experimental/paged_cache fill_cache` off the legacy `get_dynamic_runtime_args` cache-hit hook to `override_runtime_arguments` (#49828 mechanism). `get_dynamic_runtime_args` removed entirely.

## Why
Eliminating `get_dynamic_runtime_args` across all descriptor ops (fragile hand-mirrored re-application, slated for deletion). The override re-derives per-dispatch state correct-by-construction.

## Metrics (Wormhole B0, host cache-hit dispatch, min-of-medians 3×100)
- **perf:** 27→30 µs (+11%) (small host-side regression; acceptable — correctness + get_dynamic removal is the goal)
- **PCC:** cache-hit output correct (program-cache test)
- **cache-hit:** entry count stable across the hash-excluded dynamic value / addr change ✅
- 0 parity failures under `-DENABLE_DESCRIPTOR_PATCHING_PARITY_CHECK=ON` (single-chip). Mesh path (paged) validated in CI.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/gd-paged-fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/gd-paged-fill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/gd-paged-fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/gd-paged-fill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/gd-paged-fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/gd-paged-fill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/gd-paged-fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/gd-paged-fill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/gd-paged-fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/gd-paged-fill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/gd-paged-fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/gd-paged-fill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/gd-paged-fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/gd-paged-fill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/gd-paged-fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/gd-paged-fill)