### PR TITLE
[ttnn] data_movement/move: replace get_dynamic_runtime_args with override_runtime_arguments

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_move_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_move_sharded.py
@@ -244,6 +244,55 @@ def test_move_sharded_custom_grid(device):
     )
 
 
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+def test_move_sharded_program_cache(dtype, device):
+    """Cache-hit correctness for the sharded factory: reallocate inputs each iteration so buffer
+    addresses (and the address-derived reader args chunk = dst_addr - src_addr) differ on every hit,
+    while the program stays a single cache entry. Guards the override_runtime_arguments re-derivation."""
+    torch.manual_seed(2024)
+
+    compute_grid_size = device.compute_with_storage_grid_size()
+    core_count = min(8, compute_grid_size.x * compute_grid_size.y)
+    height_per_core = 128
+    width = 64
+    shape = [1, 1, core_count * height_per_core, width]
+    layout = ttnn.ROW_MAJOR_LAYOUT
+    shard_grid = get_shard_grid_from_num_cores(core_count, device)
+    shard_spec = ttnn.ShardSpec(shard_grid, [height_per_core, width], ttnn.ShardOrientation.ROW_MAJOR)
+    mem_config = ttnn.MemoryConfig(
+        memory_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        buffer_type=ttnn.BufferType.L1,
+        shard_spec=shard_spec,
+    )
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+
+    # A varying number of live dummy shards shifts the allocator so src/dst land at different
+    # addresses (hence a different chunk size) on each iteration while the hash is unchanged.
+    for n_dummy in [0, 1, 2, 1]:
+        dummies = [
+            ttnn.from_torch(
+                torch.zeros(shape, dtype=torch_dtype),
+                dtype=dtype,
+                layout=layout,
+                device=device,
+                memory_config=mem_config,
+            )
+            for _ in range(n_dummy)
+        ]
+        torch_tensor = torch.randn(shape, dtype=torch_dtype)
+        tt_tensor = ttnn.from_torch(torch_tensor, dtype=dtype, layout=layout, device=device, memory_config=mem_config)
+        for d in dummies:
+            d.deallocate()
+
+        output = ttnn.move(tt_tensor, memory_config=mem_config)
+        got = output.cpu().to(layout).to_torch().to(torch_tensor.dtype)
+        assert torch.equal(got, torch_tensor), f"sharded move mismatch with {n_dummy} dummy shards"
+        output.deallocate()
+        tt_tensor.deallocate()
+
+    assert device.num_program_cache_entries() == 1
+
+
 def test_move_sharded_to_interleaved_rejected(device, expect_error):
     """Verify move rejects sharded-to-interleaved conversion (output must be sharded)."""
     torch.manual_seed(42)

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_device_operation.hpp
@@ -45,14 +45,14 @@ struct MoveDeviceOperation {
         const tensor_args_t& tensor_args,
         tensor_return_value_t& tensor_return_value);
 
-    // #48928: the sharded factory re-runs create_descriptor on every cache hit only to recompute the
-    // reader's address-derived rt-args (chunk = dst_addr - src_addr). Recompute just those on a hit.
-    // Defined in move_sharded_program_factory.cpp to reuse its arg arithmetic.
-    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
-        const operation_attributes_t&,
-        const tensor_args_t&,
-        tensor_return_value_t&,
-        const std::optional<ttnn::MeshCoordinate>& = std::nullopt);
+    // Cache-hit re-apply of all per-dispatch state (per-core args + tensor-backed CB/buffer addresses)
+    // from the same create_descriptor the miss path uses. See the .cpp.
+    static void override_runtime_arguments(
+        tt::tt_metal::Program& program,
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_sharded_program_factory.cpp
@@ -98,20 +98,16 @@ ProgramDescriptor MoveShardedProgramFactory::create_descriptor(
     reader_desc.compile_time_args = std::move(reader_compile_time_args);
     reader_desc.config = DataMovementConfigDescriptor{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_1};
 
-    // Runtime args derive from the address arithmetic (output_addr - input_addr) and
-    // therefore must be recomputed every call.  We deliberately emit them as plain
-    // scalars (no Buffer* / BufferBinding) so the adapter's resolved bindings stay
-    // empty and the slow cache-hit path runs create_descriptor() again — which
-    // recomputes move_chunk_size_bytes, num_chunks, remainder_chunk_size_bytes
-    // from the freshly-allocated buffer addresses.  CB addresses are still patched
-    // via desc.cbs[*].buffer in apply_descriptor_runtime_args().
+    // Reader args derive from the address arithmetic (output_addr - input_addr) and are recomputed
+    // every dispatch by override_runtime_arguments re-running create_descriptor (#48928). CB
+    // addresses are re-patched via desc.cbs[*].buffer in apply_descriptor_runtime_args().
     const auto cores = corerange_to_cores(shard_grid, std::nullopt, true);
     for (const auto& core : cores) {
         reader_desc.emplace_runtime_args(
             core,
             {total_size_bytes,
              num_chunks,
-             move_chunk_size_bytes,  // smuggled-rta-ok: re-applied on cache hit via get_dynamic_runtime_args (#48928)
+             move_chunk_size_bytes,  // re-applied on cache hit via override_runtime_arguments (#48928)
              remainder_chunk_size_bytes});
     }
 
@@ -120,38 +116,28 @@ ProgramDescriptor MoveShardedProgramFactory::create_descriptor(
     return desc;
 }
 
-// #48928: on a cache hit, recompute only the reader's address-derived scalar args (arg 0
-// total_size_bytes is shape-constant; args 1-3 ride on chunk = dst_addr - src_addr) instead of
-// re-running create_descriptor. Trips the descriptor fast path (which also re-patches the sharded
-// CB addresses). Returns empty for the non-sharded factories so they are unaffected.
-std::vector<tt::tt_metal::DynamicRuntimeArg> MoveDeviceOperation::get_dynamic_runtime_args(
-    const MoveOperationAttributes& operation_attributes,
-    const MoveTensorArgs& tensor_args,
-    Tensor& tensor_return_value,
-    const std::optional<ttnn::MeshCoordinate>& /*mesh_coordinate*/) {
-    if (operation_attributes.move_op_parallelization_strategy != MoveOpParallelizationStrategy::MULTI_CORE_SHARDED) {
-        return {};
+// Re-derive ALL per-dispatch state from the same create_descriptor the miss path uses (mirror
+// select_program_factory) and re-apply to the cached program. Supersedes get_dynamic + resolve_bindings.
+void MoveDeviceOperation::override_runtime_arguments(
+    tt::tt_metal::Program& program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+    ProgramDescriptor desc;
+    switch (operation_attributes.move_op_parallelization_strategy) {
+        case MoveOpParallelizationStrategy::MULTI_CORE_SHARDED:
+            desc = MoveShardedProgramFactory::create_descriptor(operation_attributes, tensor_args, tensor_return_value);
+            break;
+        case MoveOpParallelizationStrategy::MULTI_CORE_OVERLAP:
+            desc = MoveOverlapProgramFactory::create_descriptor(operation_attributes, tensor_args, tensor_return_value);
+            break;
+        case MoveOpParallelizationStrategy::MULTI_CORE:
+            desc = MoveProgramFactory::create_descriptor(operation_attributes, tensor_args, tensor_return_value);
+            break;
+        default: TT_FATAL(false, "Invalid move operation parallelization strategy");
     }
-    Buffer* src_buffer = tensor_args.input_tensor.buffer();
-    Buffer* dst_buffer = tensor_return_value.buffer();
-    const uint32_t total_size_bytes = src_buffer->aligned_size_per_bank();
-    const uint32_t move_chunk_size_bytes = dst_buffer->address() - src_buffer->address();
-    if (move_chunk_size_bytes == 0) {
-        return {};  // degenerate dst==src (unreachable for a real move); avoids div-by-zero below.
-    }
-    const uint32_t num_chunks = total_size_bytes / move_chunk_size_bytes;
-    const uint32_t remainder_chunk_size_bytes = total_size_bytes % move_chunk_size_bytes;
-
-    const auto cores = corerange_to_cores(tensor_args.input_tensor.shard_spec().value().grid, std::nullopt, true);
-    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
-    dynamic_args.reserve(cores.size() * 3);
-    for (const auto& core : cores) {
-        dynamic_args.push_back({0, core, 1, num_chunks});
-        dynamic_args.push_back(
-            {0, core, 2, move_chunk_size_bytes});  // smuggled-rta-ok: this IS the get_dynamic re-application (#48928)
-        dynamic_args.push_back({0, core, 3, remainder_chunk_size_bytes});
-    }
-    return dynamic_args;
+    tt::tt_metal::apply_descriptor_runtime_args(program, desc);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/move_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/move_sharded_program_factory.cpp
@@ -135,7 +135,7 @@ void MoveDeviceOperation::override_runtime_arguments(
         case MoveOpParallelizationStrategy::MULTI_CORE:
             desc = MoveProgramFactory::create_descriptor(operation_attributes, tensor_args, tensor_return_value);
             break;
-        default: TT_FATAL(false, "Invalid move operation parallelization strategy");
+        default: TT_THROW("Invalid move operation parallelization strategy");
     }
     tt::tt_metal::apply_descriptor_runtime_args(program, desc);
 }


### PR DESCRIPTION
Migrates `move` (multi-factory: interleaved/overlap/sharded) off `get_dynamic_runtime_args` to `override_runtime_arguments` (#49828). get_dynamic removed. **Correctness:** program-cache tests pass (sharded addr-change on hit, entry count stable). **Perf:** small host regression in the data-movement range (≤~20%); confirmed in CI (op consumes its input, so not cleanly micro-benchable here).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/gd-move)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/gd-move)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/gd-move)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/gd-move)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/gd-move)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/gd-move)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/gd-move)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/gd-move)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/gd-move)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/gd-move)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/gd-move)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/gd-move)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/gd-move)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/gd-move)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/gd-move)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/gd-move)