### PR TITLE
[ttnn] sparse_sdpa: replace get_dynamic_runtime_args with override_runtime_arguments

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa.py
@@ -305,3 +305,50 @@ def test_sparse_sdpa_perf(device, S, T, TOPK, kc, nv, expected_ms):
 def test_sparse_sdpa_perf_scaled_fp8_production(device, H):
     """Production DeepSeek and GLM geometries using the scaled mixed-format cache."""
     _run_sparse_sdpa_perf(device, H, 640, 56320, 2048, 256, "dense", "scaled_fp8")
+
+
+@run_for_blackhole()
+@skip_with_watcher("Watcher perturbs host dispatch timing.")
+def test_sparse_sdpa_indexed_cache_hit_host_dispatch_is_cheap(device):
+    """The indexed cache hit must patch runtime args in place, not re-run create_descriptor. A rebuild-on-hit
+    stays one cache entry (invisible to entry-count asserts) yet its host cost scales with the full compute grid
+    and is paid on every indexed-decode dispatch. Host enqueue time is the only signal, so assert min-of-N stays
+    an order of magnitude below the >1ms a full-descriptor rebuild costs on the production grid."""
+    import time
+
+    H, S, T, TOPK, kc, B = 32, 64, 256, 64, 32, 8
+    device.clear_program_cache()
+    gen = torch.Generator().manual_seed(0)
+    q = torch.randn(1, H, S, K_DIM, generator=gen, dtype=torch.float32)
+    kv_full = torch.randn(B, 1, T, K_DIM, generator=gen, dtype=torch.float32)
+    indices = torch.stack([torch.randperm(T, generator=gen)[:TOPK] for _ in range(S)]).reshape(1, 1, S, TOPK)
+    tt_q = to_dev(q.to(torch.bfloat16), device, ttnn.bfloat16)
+    tt_kv = to_dev(kv_full.to(torch.bfloat16), device, ttnn.bfloat16)
+    tt_idx = to_dev(indices.to(torch.int32), device, ttnn.uint32)
+
+    def hit(cb):
+        return ttnn.transformer.sparse_sdpa(
+            tt_q,
+            tt_kv,
+            tt_idx,
+            V_DIM,
+            kv_format=ttnn.transformer.SparseKVFormat.BF16,
+            k_chunk_size=kc,
+            cache_batch_idx=cb,
+        )
+
+    hit(0)  # warm: cache miss / compile
+    entries = device.num_program_cache_entries()
+    samples = []
+    for i in range(200):
+        t0 = time.perf_counter_ns()
+        hit(i % B)  # vary the slot so the override actually re-applies kv_batch_page_offset
+        samples.append(time.perf_counter_ns() - t0)
+    ttnn.synchronize_device(device)
+    assert device.num_program_cache_entries() == entries, "timed calls must be pure cache hits"
+    min_us = min(samples) / 1000.0
+    logger.info(f"sparse_sdpa indexed cache-hit host dispatch: min={min_us:.1f}us over {len(samples)} hits")
+    assert min_us < 1000.0, (
+        f"indexed cache-hit host dispatch {min_us:.0f}us: override_runtime_arguments is rebuilding the full "
+        f"descriptor on every hit instead of patching the runtime-arg slots in place"
+    )

--- a/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa.py
@@ -404,11 +404,11 @@ def test_sparse_sdpa_indexed_kv_cache(device):
     assert n == 1, f"indexing into a different slot recompiled: {n} program-cache entries (expected 1)"
 
 
-# ---- override_runtime_arguments on a cache HIT must re-derive BOTH the excluded slot offset
+# ---- override_runtime_arguments on a cache HIT must re-apply BOTH the excluded slot offset
 # ---- (kv_batch_page_offset = cache_batch_idx*T) AND every tensor buffer address. Here each iteration changes
 # ---- cache_batch_idx AND freshly allocates q/kv/indices (prior tensors kept alive so the new buffers get
 # ---- different addresses) — correct PCC for every step, on ONE cache entry, proves the hit path re-applies
-# ---- both from create_descriptor (not stale baked values). ----
+# ---- both (not stale baked values). ----
 @run_for_blackhole()
 def test_sparse_sdpa_indexed_addr_change_on_hit(device):
     H, S, T, TOPK, kc, B = 32, 64, 256, 64, 32, 3

--- a/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa.py
@@ -404,6 +404,32 @@ def test_sparse_sdpa_indexed_kv_cache(device):
     assert n == 1, f"indexing into a different slot recompiled: {n} program-cache entries (expected 1)"
 
 
+# ---- override_runtime_arguments on a cache HIT must re-derive BOTH the excluded slot offset
+# ---- (kv_batch_page_offset = cache_batch_idx*T) AND every tensor buffer address. Here each iteration changes
+# ---- cache_batch_idx AND freshly allocates q/kv/indices (prior tensors kept alive so the new buffers get
+# ---- different addresses) — correct PCC for every step, on ONE cache entry, proves the hit path re-applies
+# ---- both from create_descriptor (not stale baked values). ----
+@run_for_blackhole()
+def test_sparse_sdpa_indexed_addr_change_on_hit(device):
+    H, S, T, TOPK, kc, B = 32, 64, 256, 64, 32, 3
+    device.clear_program_cache()
+    scale = K_DIM**-0.5
+    keep_alive = []  # hold device tensors so each reallocation lands at a fresh address
+    for cb in range(B):
+        q, kv_full, indices = _indexed_inputs(H, S, T, TOPK, B, seed=cb)  # fresh data + fresh buffers each step
+        tt_q = to_dev(q.to(torch.bfloat16), device, ttnn.bfloat16)
+        tt_kv = to_dev(kv_full.to(torch.bfloat16), device, ttnn.bfloat16)
+        tt_idx = to_dev(indices.to(torch.int32), device, ttnn.uint32)
+        keep_alive += [tt_q, tt_kv, tt_idx]
+        tt_out = ttnn.transformer.sparse_sdpa(
+            tt_q, tt_kv, tt_idx, V_DIM, scale=scale, k_chunk_size=kc, cache_batch_idx=cb
+        )
+        p = pcc(ttnn.to_torch(tt_out), golden(q, kv_full[cb : cb + 1], indices, scale, V_DIM))
+        assert p >= 0.99, f"PCC {p:.5f} (cache_batch_idx={cb}, reallocated buffers)"
+    n = device.num_program_cache_entries()  # slot + address changes are runtime args, not a recompile
+    assert n == 1, f"addr/slot change on hit recompiled: {n} program-cache entries (expected 1)"
+
+
 # ---- indexed KV cache that is ND-sharded across DRAM banks (each batch slot is one shard). ----
 def _nd_sharded_dram_config(device, rows_per_shard, width=K_DIM):
     num_banks = device.dram_grid_size().x

--- a/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa.py
@@ -422,7 +422,7 @@ def test_sparse_sdpa_indexed_addr_change_on_hit(device):
         tt_idx = to_dev(indices.to(torch.int32), device, ttnn.uint32)
         keep_alive += [tt_q, tt_kv, tt_idx]
         tt_out = ttnn.transformer.sparse_sdpa(
-            tt_q, tt_kv, tt_idx, V_DIM, scale=scale, k_chunk_size=kc, cache_batch_idx=cb
+            tt_q, tt_kv, tt_idx, V_DIM, kv_format=BF16_KV, scale=scale, k_chunk_size=kc, cache_batch_idx=cb
         )
         p = pcc(ttnn.to_torch(tt_out), golden(q, kv_full[cb : cb + 1], indices, scale, V_DIM))
         assert p >= 0.99, f"PCC {p:.5f} (cache_batch_idx={cb}, reallocated buffers)"

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.cpp
@@ -241,8 +241,8 @@ ttsl::hash::hash_t SparseSDPAOperation::compute_program_hash(const SparseSDPAPar
         // different cache size is a distinct program). A plain interleaved kv keeps T out of the hash by using
         // a sentinel shape, so changing only T does not recompile.
         (t.kv.memory_config().is_sharded() || attrs.has_block_cyclic()) ? t.kv.logical_shape() : tt::tt_metal::Shape{},
-        // Only whether kv is indexed (not which slot): cache_batch_idx's VALUE is a dynamic runtime arg
-        // (see get_dynamic_runtime_args), so indexing into a different slot reuses the same program.
+        // Only whether kv is indexed (not which slot): cache_batch_idx's VALUE is re-applied per dispatch
+        // (see override_runtime_arguments), so indexing into a different slot reuses the same program.
         attrs.has_indexed_kv_cache(),
         // Block-cyclic remap configuration is compile-time; distinct sp/chunk_local/cache-size values produce
         // distinct programs (T is hashed above). No runtime remap arg.
@@ -251,45 +251,6 @@ ttsl::hash::hash_t SparseSDPAOperation::compute_program_hash(const SparseSDPAPar
         attrs.block_cyclic.has_value() ? attrs.block_cyclic->chunk_local : 0u,
         t.indices.logical_shape(),
         t.indices.dtype());
-}
-
-std::vector<tt::tt_metal::DynamicRuntimeArg> SparseSDPAOperation::get_dynamic_runtime_args(
-    const SparseSDPAParams& attrs,
-    const SparseSDPAInputs& t,
-    Tensor& /*output*/,
-    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    // kv_batch_page_offset = cache_batch_idx*T depends on the runtime SLOT (and T, which is NOT hashed for an
-    // interleaved kv), so the same program is reused across slots/T — create_descriptor bakes it at build time
-    // and on a program-cache HIT it would be STALE, so re-apply it from the current slot/T every dispatch. The
-    // Block-cyclic remap configuration is compile-time, so only indexed programs need dynamic patching.
-    if (!attrs.has_indexed_kv_cache()) {
-        return {};
-    }
-    const uint32_t T = t.kv.logical_shape()[2];
-    const uint32_t kv_batch_page_offset = attrs.cache_batch_idx.value() * T;
-    const tt::tt_metal::CoreCoord grid = t.q.device()->compute_with_storage_grid_size();
-    const uint32_t num_cores = grid.x * grid.y;
-    // Arg slots/kernel indices are defined once in sparse_sdpa_rt (header), shared with the program factory's
-    // emit order so a reorder can't silently desync this re-apply path from the factory. The value is the same
-    // on every core but the slot is per-core, so emit one entry per core per kernel.
-    std::vector<tt::tt_metal::DynamicRuntimeArg> args;
-    args.reserve(static_cast<size_t>(2) * num_cores);
-    for (uint32_t i = 0; i < num_cores; ++i) {
-        const tt::tt_metal::CoreCoord core = {i % grid.x, i / grid.x};
-        args.push_back(
-            {sparse_sdpa_rt::kReaderKernelIdx,
-             core,
-             sparse_sdpa_rt::kReaderBatchOffsetArg,
-             kv_batch_page_offset,
-             /*is_common=*/false});
-        args.push_back(
-            {sparse_sdpa_rt::kWriterKernelIdx,
-             core,
-             sparse_sdpa_rt::kWriterBatchOffsetArg,
-             kv_batch_page_offset,
-             /*is_common=*/false});
-    }
-    return args;
 }
 
 Tensor sparse_sdpa(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.hpp
@@ -17,18 +17,6 @@
 
 namespace ttnn::prim {
 
-// Reader/writer runtime-arg layout — single source of truth shared by the program factory (which EMITS the
-// args in create_descriptor) and get_dynamic_runtime_args (which RE-APPLIES the indexed-cache page offset to
-// the cached program). kv_batch_page_offset sits at the fixed index below and is the only re-applied arg. If
-// the order before kv_batch_page_offset changes in the factory, update these indices here, or the dynamic
-// re-apply silently writes the wrong slot. Block-cyclic remap configuration is compile-time.
-namespace sparse_sdpa_rt {
-inline constexpr uint32_t kReaderKernelIdx = 0;
-inline constexpr uint32_t kWriterKernelIdx = 1;
-inline constexpr uint32_t kReaderBatchOffsetArg = 5;  // {q, kv, idx, tok_start, tok_count, [kv_batch_page_offset]}
-inline constexpr uint32_t kWriterBatchOffsetArg = 4;  // {out, tok_start, tok_count, kv, [kv_batch_page_offset]}
-}  // namespace sparse_sdpa_rt
-
 struct SparseSDPAOperation {
     using operation_attributes_t = SparseSDPAParams;
     using tensor_args_t = SparseSDPAInputs;
@@ -51,13 +39,13 @@ struct SparseSDPAOperation {
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 
-    // cache_batch_idx is excluded from the program hash, so it must be re-applied to the cached program on
-    // every dispatch (the non-Buffer analog of buffer-address patching). Returns the per-core gather page
-    // offset (cache_batch_idx * T) for the reader/writer when indexed; empty otherwise.
-    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
-        const operation_attributes_t& attrs,
+    // Cache-hit re-apply of ALL per-dispatch state (per-core args + tensor-backed CB/buffer addresses), since
+    // the hash excludes the kv length T and cache_batch_idx (kv_batch_page_offset). See the program factory.
+    static void override_runtime_arguments(
+        tt::tt_metal::Program& program,
+        const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output,
+        tensor_return_value_t& tensor_return_value,
         const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.hpp
@@ -39,8 +39,8 @@ struct SparseSDPAOperation {
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 
-    // Cache-hit re-apply of ALL per-dispatch state (per-core args + tensor-backed CB/buffer addresses), since
-    // the hash excludes the kv length T and cache_batch_idx (kv_batch_page_offset). See the program factory.
+    // Cache-hit re-apply of the per-dispatch state the hash excludes: buffer addresses and kv_batch_page_offset
+    // (cache_batch_idx * kv length T). See the program factory.
     static void override_runtime_arguments(
         tt::tt_metal::Program& program,
         const operation_attributes_t& operation_attributes,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_program_factory.cpp
@@ -8,6 +8,7 @@
 #include <tt-metalium/circular_buffer_constants.h>  // NUM_CIRCULAR_BUFFERS
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/hal.hpp>
+#include <tt-metalium/host_api.hpp>  // GetRuntimeArgs (cache-hit in-place patch)
 #include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <array>
@@ -352,10 +353,25 @@ void SparseSDPAOperation::override_runtime_arguments(
     const SparseSDPAInputs& tensor_args,
     Tensor& tensor_return_value,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    // Re-derive the descriptor from the single source of truth (create_descriptor) and re-apply its per-core
-    // args + tensor-backed CB/buffer addresses to the cached program. No rebuild; supersedes get_dynamic.
-    auto desc = SparseSDPAProgramFactory::create_descriptor(operation_attributes, tensor_args, tensor_return_value);
-    tt::tt_metal::apply_descriptor_runtime_args(program, desc);
+    // Only the buffer addresses and kv_batch_page_offset vary per dispatch (tok_start/tok_count are pinned by
+    // the hashed q shape); patch those slots in place instead of rebuilding the whole descriptor on every hit.
+    const SparseSDPAInputs& t = tensor_args;
+    const tt::tt_metal::CoreCoord grid = t.q.device()->compute_with_storage_grid_size();
+    const uint32_t offset = operation_attributes.cache_batch_idx.value_or(0) * t.kv.logical_shape()[2];
+    const uint32_t q = t.q.buffer()->address(), kv = t.kv.buffer()->address(), idx = t.indices.buffer()->address(),
+                   out = tensor_return_value.buffer()->address();
+    for (uint32_t i = 0; i < grid.x * grid.y; ++i) {
+        const tt::tt_metal::CoreCoord core = {i % grid.x, i / grid.x};
+        auto& r = tt::tt_metal::GetRuntimeArgs(program, 0, core);  // {q, kv, idx, tok_start, tok_count, offset}
+        auto& w = tt::tt_metal::GetRuntimeArgs(program, 1, core);  // {out, tok_start, tok_count, kv, offset}
+        r[0] = q;
+        r[1] = kv;
+        r[2] = idx;
+        r[5] = offset;
+        w[0] = out;
+        w[3] = kv;
+        w[4] = offset;
+    }
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_program_factory.cpp
@@ -327,17 +327,14 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
     auto* idx_buf = t.indices.buffer();
     auto* out_buf = output.buffer();
     // Indexed KV cache: the gather page ids are offset by cache_batch_idx * T to select the cache's batch
-    // slot. Baked here for the cache-miss build; re-applied on every dispatch by get_dynamic_runtime_args
-    // (so changing the slot doesn't recompile). 0 when not indexed (kv is a single [1,1,T,K_DIM] cache).
+    // slot. Re-derived here from the current attrs/tensor T on every dispatch (this factory is the single
+    // source of truth run by override_runtime_arguments on a hit). 0 when not indexed (single [1,1,T,K_DIM]).
     const uint32_t kv_T = t.kv.logical_shape()[2];
     const uint32_t kv_batch_page_offset = attrs.cache_batch_idx.value_or(0) * kv_T;
     for (uint32_t i = 0; i < num_cores; ++i) {
         tt::tt_metal::CoreCoord core = {i % grid.x, i / grid.x};
         uint32_t tok_start = i * base + std::min(i, extra);
         uint32_t tok_count = base + (i < extra ? 1u : 0u);
-        // kv_batch_page_offset sits at a fixed index (sparse_sdpa_rt::k{Reader,Writer}BatchOffsetArg), re-applied
-        // on a cache hit by get_dynamic_runtime_args (the slot changes per dispatch). If you reorder the args
-        // before it, update those constants or the re-apply targets the wrong slot.
         reader_desc.emplace_runtime_args(core, {q_buf, kv_buf, idx_buf, tok_start, tok_count, kv_batch_page_offset});
         writer_desc.emplace_runtime_args(core, {out_buf, tok_start, tok_count, kv_buf, kv_batch_page_offset});
         compute_desc.emplace_runtime_args(core, {tok_start, tok_count});
@@ -347,6 +344,18 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
     desc.kernels.push_back(std::move(writer_desc));
     desc.kernels.push_back(std::move(compute_desc));
     return desc;
+}
+
+void SparseSDPAOperation::override_runtime_arguments(
+    tt::tt_metal::Program& program,
+    const SparseSDPAParams& operation_attributes,
+    const SparseSDPAInputs& tensor_args,
+    Tensor& tensor_return_value,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+    // Re-derive the descriptor from the single source of truth (create_descriptor) and re-apply its per-core
+    // args + tensor-backed CB/buffer addresses to the cached program. No rebuild; supersedes get_dynamic.
+    auto desc = SparseSDPAProgramFactory::create_descriptor(operation_attributes, tensor_args, tensor_return_value);
+    tt::tt_metal::apply_descriptor_runtime_args(program, desc);
 }
 
 }  // namespace ttnn::prim


### PR DESCRIPTION
Migrates `sparse_sdpa` off `get_dynamic_runtime_args` to `override_runtime_arguments` (#49828). Custom compute_program_hash unchanged; get_dynamic removed. Single-factory ProgramDescriptor. **Blackhole-gated** — correctness + perf via CI.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/gd-sparse-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/gd-sparse-sdpa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/gd-sparse-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/gd-sparse-sdpa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/gd-sparse-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/gd-sparse-sdpa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/gd-sparse-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/gd-sparse-sdpa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/gd-sparse-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/gd-sparse-sdpa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/gd-sparse-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/gd-sparse-sdpa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/gd-sparse-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/gd-sparse-sdpa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/gd-sparse-sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/gd-sparse-sdpa)