### PR TITLE
[ttnn] sparse_sdpa_msa: replace get_dynamic_runtime_args with override_runtime_arguments

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa_msa.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa_msa.py
@@ -573,6 +573,23 @@ def test_msa_native_determinism(device, q_dtype, kv_dtype):
     assert mismatch == 0.0, "sparse_sdpa_msa output is not deterministic across repeated runs"
 
 
+# Causal chunk_start_idx is hash-excluded (only causal on/off is hashed), so it must be re-applied on cache
+# hits. cs=BLK_KV shifts every query one block forward, changing which selected blocks are masked; each
+# dispatch must match its own reference (a frozen offset fails the second) while reusing one cached program.
+@run_for_blackhole()
+def test_msa_native_causal_chunk_start_no_recompile(device):
+    d, H, n_kv, S, nblk = _D, 64, 4, 320, 16
+    T = nblk * BLK_KV
+    device.clear_program_cache()
+    q, k, v, indices = make_msa_inputs(H, n_kv, S, T, topk=nblk, d=d, causal=True, seed=31)
+    for cs in (0, BLK_KV):
+        gold = sparse_attention_ref_msa(q, k, v, indices, d**-0.5, causal=True, chunk_start_idx=cs)
+        out = run_op_msa_native(q, k, v, indices, device, chunk_start_idx=cs)
+        assert pcc(out, gold) > 0.99, f"chunk_start_idx={cs} pcc={pcc(out, gold)}"
+    n = device.num_program_cache_entries()
+    assert n == 1, f"changing chunk_start_idx recompiled: {n} entries (expected 1)"
+
+
 @pytest.mark.parametrize(
     "mesh_device, device_params",
     [((8, 4), {"fabric_config": ttnn.FabricConfig.FABRIC_1D})],

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.cpp
@@ -9,6 +9,8 @@
 #include "ttnn/operations/ccl/ccl_common.hpp"
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/hal.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/program_descriptors.hpp>
 #include <bit>
 
 namespace ttnn::prim {
@@ -244,104 +246,17 @@ uint32_t SparseSDPAMsaOperation::compute_chunk_start_local(
     return attrs.chunk_start_idx.value() + device_index * S;
 }
 
-std::vector<tt::tt_metal::DynamicRuntimeArg> SparseSDPAMsaOperation::get_dynamic_runtime_args(
+void SparseSDPAMsaOperation::override_runtime_arguments(
+    tt::tt_metal::Program& program,
     const SparseSDPAMsaParams& attrs,
     const SparseSDPAMsaInputs& t,
-    Tensor& /*output*/,
+    Tensor& tensor_return_value,
     const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
-    const uint32_t n_kv = t.k.logical_shape()[1];
-    const bool patch_kv = attrs.has_indexed_kv_cache() || n_kv > 1;
-    // n_kv==1 non-indexed programs use zero K/V tile offsets and need no per-group strides; but causal
-    // masking still patches the per-device chunk_start every dispatch, so don't early-return then.
-    if (!patch_kv && !attrs.causal_enabled()) {
-        return {};
-    }
-    const uint32_t chunk_start_local = compute_chunk_start_local(attrs, t, mesh_dispatch_coordinate);
-    // Indexed programs patch per-slot tile offsets on every dispatch. GQA programs also patch per-KV-group strides
-    // because interleaved K/V T is intentionally excluded from the program hash.
-    constexpr uint32_t tw = tt::constants::TILE_WIDTH;
-    constexpr uint32_t th = tt::constants::TILE_HEIGHT;
-    const uint32_t T = t.k.logical_shape()[2];
-    const uint32_t d = t.q.logical_shape()[3];
-    const uint32_t v_dim = t.v.logical_shape()[3];
-    const uint32_t s = attrs.cache_batch_idx.value_or(0);
-    const uint32_t tiles_per_row = T / th;
-    const uint32_t k_group_tile_stride = tiles_per_row * (d / tw);
-    const uint32_t v_group_tile_stride = tiles_per_row * (v_dim / tw);
-    const uint32_t k_batch_tile_offset = s * n_kv * k_group_tile_stride;
-    const uint32_t v_batch_tile_offset = s * n_kv * v_group_tile_stride;
-    const tt::tt_metal::CoreCoord grid = t.q.device()->compute_with_storage_grid_size();
-    const uint32_t num_cores = grid.x * grid.y;
-    std::vector<tt::tt_metal::DynamicRuntimeArg> args;
-    // Reader and writer both gather K/V halves, so patch both kernels.
-    args.reserve(
-        (attrs.has_indexed_kv_cache() ? 4 : 0) * num_cores + (n_kv > 1 ? 4 : 0) * num_cores +
-        (attrs.causal_enabled() ? 1 : 0) * num_cores);
-    for (uint32_t i = 0; i < num_cores; ++i) {
-        const tt::tt_metal::CoreCoord core = {i % grid.x, i / grid.x};
-        if (attrs.causal_enabled()) {
-            // Same per-device chunk_start on every core (the reader derives per-token global pos from it).
-            args.push_back(
-                {sparse_sdpa_msa_rt::kReaderKernelIdx,
-                 core,
-                 sparse_sdpa_msa_rt::kReaderChunkStartArg,
-                 chunk_start_local,
-                 /*is_common=*/false});
-        }
-        if (attrs.has_indexed_kv_cache()) {
-            args.push_back(
-                {sparse_sdpa_msa_rt::kReaderKernelIdx,
-                 core,
-                 sparse_sdpa_msa_rt::kReaderKBatchOffsetArg,
-                 k_batch_tile_offset,
-                 /*is_common=*/false});
-            args.push_back(
-                {sparse_sdpa_msa_rt::kReaderKernelIdx,
-                 core,
-                 sparse_sdpa_msa_rt::kReaderVBatchOffsetArg,
-                 v_batch_tile_offset,
-                 /*is_common=*/false});
-            args.push_back(
-                {sparse_sdpa_msa_rt::kWriterKernelIdx,
-                 core,
-                 sparse_sdpa_msa_rt::kWriterKBatchOffsetArg,
-                 k_batch_tile_offset,
-                 /*is_common=*/false});
-            args.push_back(
-                {sparse_sdpa_msa_rt::kWriterKernelIdx,
-                 core,
-                 sparse_sdpa_msa_rt::kWriterVBatchOffsetArg,
-                 v_batch_tile_offset,
-                 /*is_common=*/false});
-        }
-        if (n_kv > 1) {
-            args.push_back(
-                {sparse_sdpa_msa_rt::kReaderKernelIdx,
-                 core,
-                 sparse_sdpa_msa_rt::kReaderKGroupStrideArg,
-                 k_group_tile_stride,
-                 /*is_common=*/false});
-            args.push_back(
-                {sparse_sdpa_msa_rt::kReaderKernelIdx,
-                 core,
-                 sparse_sdpa_msa_rt::kReaderVGroupStrideArg,
-                 v_group_tile_stride,
-                 /*is_common=*/false});
-            args.push_back(
-                {sparse_sdpa_msa_rt::kWriterKernelIdx,
-                 core,
-                 sparse_sdpa_msa_rt::kWriterKGroupStrideArg,
-                 k_group_tile_stride,
-                 /*is_common=*/false});
-            args.push_back(
-                {sparse_sdpa_msa_rt::kWriterKernelIdx,
-                 core,
-                 sparse_sdpa_msa_rt::kWriterVGroupStrideArg,
-                 v_group_tile_stride,
-                 /*is_common=*/false});
-        }
-    }
-    return args;
+    // Re-derive the descriptor from the single source of truth (create_descriptor, threaded with this device's
+    // coordinate for the per-rank causal chunk_start) and re-apply its per-core args + buffer addresses to the
+    // cached program. No rebuild; supersedes get_dynamic_runtime_args and resolve_bindings.
+    auto desc = SparseSDPAMsaProgramFactory::create_descriptor(attrs, t, tensor_return_value, mesh_dispatch_coordinate);
+    tt::tt_metal::apply_descriptor_runtime_args(program, desc);
 }
 
 Tensor sparse_sdpa_msa(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.cpp
@@ -9,8 +9,9 @@
 #include "ttnn/operations/ccl/ccl_common.hpp"
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/hal.hpp>
+#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/program.hpp>
-#include <tt-metalium/program_descriptors.hpp>
+#include <algorithm>
 #include <bit>
 
 namespace ttnn::prim {
@@ -246,17 +247,101 @@ uint32_t SparseSDPAMsaOperation::compute_chunk_start_local(
     return attrs.chunk_start_idx.value() + device_index * S;
 }
 
+SparseSDPAMsaOperation::DispatchArgs SparseSDPAMsaOperation::compute_dispatch_args(
+    const SparseSDPAMsaParams& attrs,
+    const SparseSDPAMsaInputs& t,
+    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
+    const uint32_t S = t.q.logical_shape()[2];
+    const uint32_t n_kv = t.k.logical_shape()[1];
+    const uint32_t T = t.k.logical_shape()[2];
+    const uint32_t d = t.q.logical_shape()[3];
+    const uint32_t v_dim = t.v.logical_shape()[3];
+    const uint32_t tiles_per_row = T / tt::constants::TILE_HEIGHT;
+    const uint32_t k_group_tile_stride = tiles_per_row * (d / tt::constants::TILE_WIDTH);
+    const uint32_t v_group_tile_stride = tiles_per_row * (v_dim / tt::constants::TILE_WIDTH);
+    const uint32_t slot = attrs.cache_batch_idx.value_or(0);
+    const tt::tt_metal::CoreCoord grid = t.q.device()->compute_with_storage_grid_size();
+    const uint32_t num_cores = grid.x * grid.y;
+    const uint32_t total_work = S * n_kv;
+    return DispatchArgs{
+        .grid = grid,
+        .num_cores = num_cores,
+        .base_work = total_work / num_cores,
+        .extra = total_work % num_cores,
+        .k_batch_tile_offset = slot * n_kv * k_group_tile_stride,
+        .v_batch_tile_offset = slot * n_kv * v_group_tile_stride,
+        .k_group_tile_stride = k_group_tile_stride,
+        .v_group_tile_stride = v_group_tile_stride,
+        .chunk_start_local = compute_chunk_start_local(attrs, t, mesh_dispatch_coordinate),
+    };
+}
+
 void SparseSDPAMsaOperation::override_runtime_arguments(
     tt::tt_metal::Program& program,
     const SparseSDPAMsaParams& attrs,
     const SparseSDPAMsaInputs& t,
     Tensor& tensor_return_value,
     const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
-    // Re-derive the descriptor from the single source of truth (create_descriptor, threaded with this device's
-    // coordinate for the per-rank causal chunk_start) and re-apply its per-core args + buffer addresses to the
-    // cached program. No rebuild; supersedes get_dynamic_runtime_args and resolve_bindings.
-    auto desc = SparseSDPAMsaProgramFactory::create_descriptor(attrs, t, tensor_return_value, mesh_dispatch_coordinate);
-    tt::tt_metal::apply_descriptor_runtime_args(program, desc);
+    // Patch the cached program in place. Calling create_descriptor() here instead would pay the cache-MISS host
+    // cost on every hit (work split, CoreRangeSet, kernel sources, compute-config arch queries, accessor args,
+    // one heap-allocated arg vector per core) on a grid-wide op with three kernels.
+    //
+    // Every slot written below either holds a buffer address - the override supersedes resolve_bindings, so all
+    // of them are ours to re-apply - or derives from a value compute_program_hash excludes: interleaved K/V T
+    // and batch slots, n_kv, cache_batch_idx, and chunk_start_idx/cluster_axis (patched per coordinate, from
+    // the coordinate this program was built for). Nothing else is dynamic: kernel geometry and CB sizes are
+    // hash-pinned, all CBs are locally allocated (no `.buffer`/`.tensor` backing to re-point), and the only
+    // common runtime args come from the K/V TensorAccessorArgs, which exist solely when K/V are sharded - and
+    // sharded K/V shape and memory config are hashed.
+    //
+    // Kernel push order in create_descriptor(): reader(0), writer(1), compute(2).
+    constexpr uint32_t kReaderKernelIdx = 0;
+    constexpr uint32_t kWriterKernelIdx = 1;
+    constexpr uint32_t kComputeKernelIdx = 2;
+
+    const auto dyn = compute_dispatch_args(attrs, t, mesh_dispatch_coordinate);
+    const uint32_t q_addr = t.q.buffer()->address();
+    const uint32_t k_addr = t.k.buffer()->address();
+    const uint32_t v_addr = t.v.buffer()->address();
+    const uint32_t idx_addr = t.indices.buffer()->address();
+    const uint32_t out_addr = tensor_return_value.buffer()->address();
+
+    for (uint32_t i = 0; i < dyn.num_cores; ++i) {
+        const tt::tt_metal::CoreCoord core = {i % dyn.grid.x, i / dyn.grid.x};
+        const uint32_t work_start = i * dyn.base_work + std::min(i, dyn.extra);
+        const uint32_t work_count = dyn.base_work + (i < dyn.extra ? 1u : 0u);
+
+        // reader: {q, k, v, idx, work_start, work_count, k_batch_off, v_batch_off, k_stride, v_stride, chunk_start}
+        auto& reader = tt::tt_metal::GetRuntimeArgs(program, kReaderKernelIdx, core);
+        reader[0] = q_addr;
+        reader[1] = k_addr;
+        reader[2] = v_addr;
+        reader[3] = idx_addr;
+        reader[4] = work_start;
+        reader[5] = work_count;
+        reader[6] = dyn.k_batch_tile_offset;
+        reader[7] = dyn.v_batch_tile_offset;
+        reader[8] = dyn.k_group_tile_stride;
+        reader[9] = dyn.v_group_tile_stride;
+        reader[10] = dyn.chunk_start_local;
+
+        // writer: {out, work_start, work_count, k, v, k_batch_off, v_batch_off, k_stride, v_stride}
+        auto& writer = tt::tt_metal::GetRuntimeArgs(program, kWriterKernelIdx, core);
+        writer[0] = out_addr;
+        writer[1] = work_start;
+        writer[2] = work_count;
+        writer[3] = k_addr;
+        writer[4] = v_addr;
+        writer[5] = dyn.k_batch_tile_offset;
+        writer[6] = dyn.v_batch_tile_offset;
+        writer[7] = dyn.k_group_tile_stride;
+        writer[8] = dyn.v_group_tile_stride;
+
+        // compute: {work_start, work_count}
+        auto& compute = tt::tt_metal::GetRuntimeArgs(program, kComputeKernelIdx, core);
+        compute[0] = work_start;
+        compute[1] = work_count;
+    }
 }
 
 Tensor sparse_sdpa_msa(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.cpp
@@ -276,7 +276,7 @@ SparseSDPAMsaOperation::DispatchArgs SparseSDPAMsaOperation::compute_dispatch_ar
     };
 }
 
-void SparseSDPAMsaOperation::override_runtime_arguments(
+void SparseSDPAMsaOperation::SparseSDPAMsaProgramFactory::override_runtime_arguments(
     tt::tt_metal::Program& program,
     const SparseSDPAMsaParams& attrs,
     const SparseSDPAMsaInputs& t,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.cpp
@@ -311,36 +311,48 @@ void SparseSDPAMsaOperation::SparseSDPAMsaProgramFactory::override_runtime_argum
         const uint32_t work_start = i * dyn.base_work + std::min(i, dyn.extra);
         const uint32_t work_count = dyn.base_work + (i < dyn.extra ? 1u : 0u);
 
-        // reader: {q, k, v, idx, work_start, work_count, k_batch_off, v_batch_off, k_stride, v_stride, chunk_start}
         auto& reader = tt::tt_metal::GetRuntimeArgs(program, kReaderKernelIdx, core);
-        reader[0] = q_addr;
-        reader[1] = k_addr;
-        reader[2] = v_addr;
-        reader[3] = idx_addr;
-        reader[4] = work_start;
-        reader[5] = work_count;
-        reader[6] = dyn.k_batch_tile_offset;
-        reader[7] = dyn.v_batch_tile_offset;
-        reader[8] = dyn.k_group_tile_stride;
-        reader[9] = dyn.v_group_tile_stride;
-        reader[10] = dyn.chunk_start_local;
+        TT_FATAL(
+            reader.size() == kReaderArgCount,
+            "sparse_sdpa_msa reader expected {} runtime args, cached program has {}",
+            static_cast<uint32_t>(kReaderArgCount),
+            reader.size());
+        reader[kReaderQAddr] = q_addr;
+        reader[kReaderKAddr] = k_addr;
+        reader[kReaderVAddr] = v_addr;
+        reader[kReaderIdxAddr] = idx_addr;
+        reader[kReaderWorkStart] = work_start;
+        reader[kReaderWorkCount] = work_count;
+        reader[kReaderKBatchOffset] = dyn.k_batch_tile_offset;
+        reader[kReaderVBatchOffset] = dyn.v_batch_tile_offset;
+        reader[kReaderKGroupStride] = dyn.k_group_tile_stride;
+        reader[kReaderVGroupStride] = dyn.v_group_tile_stride;
+        reader[kReaderChunkStart] = dyn.chunk_start_local;
 
-        // writer: {out, work_start, work_count, k, v, k_batch_off, v_batch_off, k_stride, v_stride}
         auto& writer = tt::tt_metal::GetRuntimeArgs(program, kWriterKernelIdx, core);
-        writer[0] = out_addr;
-        writer[1] = work_start;
-        writer[2] = work_count;
-        writer[3] = k_addr;
-        writer[4] = v_addr;
-        writer[5] = dyn.k_batch_tile_offset;
-        writer[6] = dyn.v_batch_tile_offset;
-        writer[7] = dyn.k_group_tile_stride;
-        writer[8] = dyn.v_group_tile_stride;
+        TT_FATAL(
+            writer.size() == kWriterArgCount,
+            "sparse_sdpa_msa writer expected {} runtime args, cached program has {}",
+            static_cast<uint32_t>(kWriterArgCount),
+            writer.size());
+        writer[kWriterOutAddr] = out_addr;
+        writer[kWriterWorkStart] = work_start;
+        writer[kWriterWorkCount] = work_count;
+        writer[kWriterKAddr] = k_addr;
+        writer[kWriterVAddr] = v_addr;
+        writer[kWriterKBatchOffset] = dyn.k_batch_tile_offset;
+        writer[kWriterVBatchOffset] = dyn.v_batch_tile_offset;
+        writer[kWriterKGroupStride] = dyn.k_group_tile_stride;
+        writer[kWriterVGroupStride] = dyn.v_group_tile_stride;
 
-        // compute: {work_start, work_count}
         auto& compute = tt::tt_metal::GetRuntimeArgs(program, kComputeKernelIdx, core);
-        compute[0] = work_start;
-        compute[1] = work_count;
+        TT_FATAL(
+            compute.size() == kComputeArgCount,
+            "sparse_sdpa_msa compute expected {} runtime args, cached program has {}",
+            static_cast<uint32_t>(kComputeArgCount),
+            compute.size());
+        compute[kComputeWorkStart] = work_start;
+        compute[kComputeWorkCount] = work_count;
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.hpp
@@ -17,27 +17,6 @@
 
 namespace ttnn::prim {
 
-// Runtime-arg slots patched on cache hits for indexed K/V caches and runtime K/V group strides.
-// Keep these in sync with create_descriptor().
-namespace sparse_sdpa_msa_rt {
-inline constexpr uint32_t kReaderKernelIdx = 0;
-inline constexpr uint32_t kWriterKernelIdx = 1;
-// reader args: {q, k, v, idx, work_start, work_count, k_batch_tile_offset, v_batch_tile_offset,
-//               k_group_tile_stride, v_group_tile_stride}
-inline constexpr uint32_t kReaderKBatchOffsetArg = 6;
-inline constexpr uint32_t kReaderVBatchOffsetArg = 7;
-inline constexpr uint32_t kReaderKGroupStrideArg = 8;
-inline constexpr uint32_t kReaderVGroupStrideArg = 9;
-// Per-device causal chunk_start (chunk_start_idx + rank*S); patched at dispatch when causal masking is on.
-inline constexpr uint32_t kReaderChunkStartArg = 10;
-// writer args: {out, work_start, work_count, k, v, k_batch_tile_offset, v_batch_tile_offset,
-//               k_group_tile_stride, v_group_tile_stride}
-inline constexpr uint32_t kWriterKBatchOffsetArg = 5;
-inline constexpr uint32_t kWriterVBatchOffsetArg = 6;
-inline constexpr uint32_t kWriterKGroupStrideArg = 7;
-inline constexpr uint32_t kWriterVGroupStrideArg = 8;
-}  // namespace sparse_sdpa_msa_rt
-
 struct SparseSDPAMsaOperation {
     using operation_attributes_t = SparseSDPAMsaParams;
     using tensor_args_t = SparseSDPAMsaInputs;
@@ -65,18 +44,19 @@ struct SparseSDPAMsaOperation {
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 
     // Per-device causal start: chunk_start_idx + rank*S along cluster_axis (rank from the coordinate; 0 on a
-    // single device or when non-causal). Shared by create_descriptor (miss-bake) and get_dynamic_runtime_args
-    // (hit-patch) so the two paths cannot drift.
+    // single device or when non-causal). Shared by create_descriptor at miss and hit time so the two cannot drift.
     static uint32_t compute_chunk_start_local(
         const operation_attributes_t& attrs,
         const tensor_args_t& t,
         const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate);
 
-    // Patches per-slot K/V tile offsets and runtime K/V group strides on cache hits.
-    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
-        const operation_attributes_t& attrs,
+    // Cache-hit re-apply of all per-dispatch state (per-core K/V offsets, group strides, causal chunk_start,
+    // buffer addresses), since the hash excludes interleaved K/V T and cache_batch_idx. See the .cpp.
+    static void override_runtime_arguments(
+        tt::tt_metal::Program& program,
+        const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
-        tensor_return_value_t& output,
+        tensor_return_value_t& tensor_return_value,
         const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.hpp
@@ -54,8 +54,8 @@ struct SparseSDPAMsaOperation {
     // buffer addresses), since the hash excludes interleaved K/V T and cache_batch_idx. See the .cpp.
     static void override_runtime_arguments(
         tt::tt_metal::Program& program,
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
+        const operation_attributes_t& attrs,
+        const tensor_args_t& t,
         tensor_return_value_t& tensor_return_value,
         const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.hpp
@@ -44,14 +44,33 @@ struct SparseSDPAMsaOperation {
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 
     // Per-device causal start: chunk_start_idx + rank*S along cluster_axis (rank from the coordinate; 0 on a
-    // single device or when non-causal). Shared by create_descriptor at miss and hit time so the two cannot drift.
+    // single device or when non-causal).
     static uint32_t compute_chunk_start_local(
         const operation_attributes_t& attrs,
         const tensor_args_t& t,
         const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate);
 
-    // Cache-hit re-apply of all per-dispatch state (per-core K/V offsets, group strides, causal chunk_start,
-    // buffer addresses), since the hash excludes interleaved K/V T and cache_batch_idx. See the .cpp.
+    // Work split plus every scalar compute_program_hash excludes: interleaved K/V T and batch slots, n_kv,
+    // cache_batch_idx, chunk_start_idx/cluster_axis. Single-sourced so create_descriptor (miss-bake) and
+    // override_runtime_arguments (hit-patch) write the same values and cannot drift.
+    struct DispatchArgs {
+        tt::tt_metal::CoreCoord grid;  // per-core arg order: core i == {i % grid.x, i / grid.x}
+        uint32_t num_cores = 0;
+        uint32_t base_work = 0;  // total_work = S * n_kv over num_cores; the first `extra` cores take one more
+        uint32_t extra = 0;
+        uint32_t k_batch_tile_offset = 0;
+        uint32_t v_batch_tile_offset = 0;
+        uint32_t k_group_tile_stride = 0;
+        uint32_t v_group_tile_stride = 0;
+        uint32_t chunk_start_local = 0;
+    };
+    static DispatchArgs compute_dispatch_args(
+        const operation_attributes_t& attrs,
+        const tensor_args_t& t,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate);
+
+    // Cache-hit re-apply of all per-dispatch state (buffer addresses, per-core K/V offsets, group strides,
+    // causal chunk_start), since the hash excludes interleaved K/V T and cache_batch_idx. See the .cpp.
     static void override_runtime_arguments(
         tt::tt_metal::Program& program,
         const operation_attributes_t& attrs,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.hpp
@@ -32,6 +32,15 @@ struct SparseSDPAMsaOperation {
             const tensor_args_t& t,
             tensor_return_value_t& output,
             const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
+
+        // Cache-hit re-apply of all per-dispatch state (buffer addresses, per-core K/V offsets, group strides,
+        // causal chunk_start), since the hash excludes interleaved K/V T and cache_batch_idx. See the .cpp.
+        static void override_runtime_arguments(
+            tt::tt_metal::Program& program,
+            const operation_attributes_t& attrs,
+            const tensor_args_t& t,
+            tensor_return_value_t& tensor_return_value,
+            const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
     };
 
     using program_factory_t = std::variant<SparseSDPAMsaProgramFactory>;
@@ -68,15 +77,6 @@ struct SparseSDPAMsaOperation {
         const operation_attributes_t& attrs,
         const tensor_args_t& t,
         const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate);
-
-    // Cache-hit re-apply of all per-dispatch state (buffer addresses, per-core K/V offsets, group strides,
-    // causal chunk_start), since the hash excludes interleaved K/V T and cache_batch_idx. See the .cpp.
-    static void override_runtime_arguments(
-        tt::tt_metal::Program& program,
-        const operation_attributes_t& attrs,
-        const tensor_args_t& t,
-        tensor_return_value_t& tensor_return_value,
-        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 
 Tensor sparse_sdpa_msa(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_device_operation.hpp
@@ -45,6 +45,36 @@ struct SparseSDPAMsaOperation {
 
     using program_factory_t = std::variant<SparseSDPAMsaProgramFactory>;
 
+    // Runtime-arg slots, named so create_descriptor's emplace order and override_runtime_arguments'
+    // in-place writes reference the same symbols instead of agreeing on bare positions.
+    enum ReaderArg : uint32_t {
+        kReaderQAddr,
+        kReaderKAddr,
+        kReaderVAddr,
+        kReaderIdxAddr,
+        kReaderWorkStart,
+        kReaderWorkCount,
+        kReaderKBatchOffset,
+        kReaderVBatchOffset,
+        kReaderKGroupStride,
+        kReaderVGroupStride,
+        kReaderChunkStart,
+        kReaderArgCount,
+    };
+    enum WriterArg : uint32_t {
+        kWriterOutAddr,
+        kWriterWorkStart,
+        kWriterWorkCount,
+        kWriterKAddr,
+        kWriterVAddr,
+        kWriterKBatchOffset,
+        kWriterVBatchOffset,
+        kWriterKGroupStride,
+        kWriterVGroupStride,
+        kWriterArgCount,
+    };
+    enum ComputeArg : uint32_t { kComputeWorkStart, kComputeWorkCount, kComputeArgCount };
+
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     // Re-checks invariants excluded from the program hash, such as interleaved K/V length and cache_batch_idx.
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_program_factory.cpp
@@ -312,7 +312,8 @@ tt::tt_metal::ProgramDescriptor SparseSDPAMsaOperation::SparseSDPAMsaProgramFact
              v_batch_tile_offset,
              k_group_tile_stride,
              v_group_tile_stride,
-             chunk_start_local});  // arg 10: baked per-coordinate; re-patched on cache hits (get_dynamic_runtime_args)
+             chunk_start_local});  // arg 10: baked per-coordinate; re-applied on cache hits
+                                   // (override_runtime_arguments)
         // Writer args 5/6 are the K/V cache-slot offsets patched on cache hits.
         writer_desc.emplace_runtime_args(
             core,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_program_factory.cpp
@@ -96,13 +96,13 @@ tt::tt_metal::ProgramDescriptor SparseSDPAMsaOperation::SparseSDPAMsaProgramFact
     const tt::DataFormat out_df = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
     const uint32_t out_tile_bytes = tt::tile_size(out_df);
 
-    auto* device = t.q.device();
-    tt::tt_metal::CoreCoord grid = device->compute_with_storage_grid_size();
+    // Work split and the hash-excluded per-dispatch scalars (K/V slot offsets, group strides, per-coordinate
+    // causal chunk_start) come from the helper override_runtime_arguments also uses, so the values baked here
+    // and the ones patched on a cache hit cannot drift.
+    const auto dyn = SparseSDPAMsaOperation::compute_dispatch_args(attrs, t, mesh_dispatch_coordinate);
+    const tt::tt_metal::CoreCoord grid = dyn.grid;
     auto core_grid = tt::tt_metal::CoreRangeSet(tt::tt_metal::CoreRange({0, 0}, {grid.x - 1, grid.y - 1}));
-    const uint32_t num_cores = grid.x * grid.y;
-    const uint32_t total_work = S * n_kv;
-    const uint32_t base_work = total_work / num_cores;
-    const uint32_t extra = total_work % num_cores;
+    const uint32_t num_cores = dyn.num_cores;
 
     // ---- CBs (fixed order = SparseCB enum) ----
     const auto cb = [&](uint32_t page_size, uint32_t num_pages, tt::DataFormat df) {
@@ -285,20 +285,10 @@ tt::tt_metal::ProgramDescriptor SparseSDPAMsaOperation::SparseSDPAMsaProgramFact
     auto* v_buf = t.v.buffer();
     auto* idx_buf = t.indices.buffer();
     auto* out_buf = output.buffer();
-    const uint32_t cache_batch_idx = attrs.cache_batch_idx.value_or(0);
-    const uint32_t T = t.k.logical_shape()[2];
-    const uint32_t tiles_per_row = T / tt::constants::TILE_HEIGHT;
-    const uint32_t k_group_tile_stride = tiles_per_row * DHt;
-    const uint32_t v_group_tile_stride = tiles_per_row * vDHt;
-    const uint32_t k_batch_tile_offset = cache_batch_idx * n_kv * k_group_tile_stride;
-    const uint32_t v_batch_tile_offset = cache_batch_idx * n_kv * v_group_tile_stride;
-    // Baked per coordinate (one program per device) so each rank masks against its own global position.
-    const uint32_t chunk_start_local =
-        SparseSDPAMsaOperation::compute_chunk_start_local(attrs, t, mesh_dispatch_coordinate);
     for (uint32_t i = 0; i < num_cores; ++i) {
         tt::tt_metal::CoreCoord core = {i % grid.x, i / grid.x};
-        uint32_t work_start = i * base_work + std::min(i, extra);
-        uint32_t work_count = base_work + (i < extra ? 1u : 0u);
+        uint32_t work_start = i * dyn.base_work + std::min(i, dyn.extra);
+        uint32_t work_count = dyn.base_work + (i < dyn.extra ? 1u : 0u);
         // Cache slot offsets are patched on hits because cache_batch_idx is not hashed.
         reader_desc.emplace_runtime_args(
             core,
@@ -308,12 +298,12 @@ tt::tt_metal::ProgramDescriptor SparseSDPAMsaOperation::SparseSDPAMsaProgramFact
              idx_buf,
              work_start,
              work_count,
-             k_batch_tile_offset,
-             v_batch_tile_offset,
-             k_group_tile_stride,
-             v_group_tile_stride,
-             chunk_start_local});  // arg 10: baked per-coordinate; re-applied on cache hits
-                                   // (override_runtime_arguments)
+             dyn.k_batch_tile_offset,
+             dyn.v_batch_tile_offset,
+             dyn.k_group_tile_stride,
+             dyn.v_group_tile_stride,
+             dyn.chunk_start_local});  // arg 10: baked per-coordinate (one program per device, so each rank
+                                       // masks against its own global position); re-applied on cache hits
         // Writer args 5/6 are the K/V cache-slot offsets patched on cache hits.
         writer_desc.emplace_runtime_args(
             core,
@@ -322,10 +312,10 @@ tt::tt_metal::ProgramDescriptor SparseSDPAMsaOperation::SparseSDPAMsaProgramFact
              work_count,
              k_buf,
              v_buf,
-             k_batch_tile_offset,
-             v_batch_tile_offset,
-             k_group_tile_stride,
-             v_group_tile_stride});
+             dyn.k_batch_tile_offset,
+             dyn.v_batch_tile_offset,
+             dyn.k_group_tile_stride,
+             dyn.v_group_tile_stride});
         compute_desc.emplace_runtime_args(core, {work_start, work_count});
     }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_msa_program_factory.cpp
@@ -13,8 +13,16 @@
 #include <bit>
 #include <map>
 #include <string>
+#include <variant>
+#include <vector>
 
 namespace ttnn::prim {
+
+namespace {
+// emplace_runtime_args' vector overload registers each Buffer* as an address binding at its slot,
+// so the args can be filled by enum index instead of positionally.
+using RtArgs = std::vector<std::variant<uint32_t, tt::tt_metal::Buffer*>>;
+}  // namespace
 
 tt::tt_metal::ProgramDescriptor SparseSDPAMsaOperation::SparseSDPAMsaProgramFactory::create_descriptor(
     const SparseSDPAMsaParams& attrs,
@@ -289,34 +297,43 @@ tt::tt_metal::ProgramDescriptor SparseSDPAMsaOperation::SparseSDPAMsaProgramFact
         tt::tt_metal::CoreCoord core = {i % grid.x, i / grid.x};
         uint32_t work_start = i * dyn.base_work + std::min(i, dyn.extra);
         uint32_t work_count = dyn.base_work + (i < dyn.extra ? 1u : 0u);
-        // Cache slot offsets are patched on hits because cache_batch_idx is not hashed.
-        reader_desc.emplace_runtime_args(
-            core,
-            {q_buf,
-             k_buf,
-             v_buf,
-             idx_buf,
-             work_start,
-             work_count,
-             dyn.k_batch_tile_offset,
-             dyn.v_batch_tile_offset,
-             dyn.k_group_tile_stride,
-             dyn.v_group_tile_stride,
-             dyn.chunk_start_local});  // arg 10: baked per-coordinate (one program per device, so each rank
-                                       // masks against its own global position); re-applied on cache hits
-        // Writer args 5/6 are the K/V cache-slot offsets patched on cache hits.
-        writer_desc.emplace_runtime_args(
-            core,
-            {out_buf,
-             work_start,
-             work_count,
-             k_buf,
-             v_buf,
-             dyn.k_batch_tile_offset,
-             dyn.v_batch_tile_offset,
-             dyn.k_group_tile_stride,
-             dyn.v_group_tile_stride});
-        compute_desc.emplace_runtime_args(core, {work_start, work_count});
+        // Both sides index the same slot enums, so a reorder here cannot silently desync the
+        // cache-hit patch in override_runtime_arguments; Buffer* slots stay address bindings.
+        using RArg = SparseSDPAMsaOperation::ReaderArg;
+        RtArgs reader_rt(RArg::kReaderArgCount);
+        reader_rt[RArg::kReaderQAddr] = q_buf;
+        reader_rt[RArg::kReaderKAddr] = k_buf;
+        reader_rt[RArg::kReaderVAddr] = v_buf;
+        reader_rt[RArg::kReaderIdxAddr] = idx_buf;
+        reader_rt[RArg::kReaderWorkStart] = work_start;
+        reader_rt[RArg::kReaderWorkCount] = work_count;
+        reader_rt[RArg::kReaderKBatchOffset] = dyn.k_batch_tile_offset;
+        reader_rt[RArg::kReaderVBatchOffset] = dyn.v_batch_tile_offset;
+        reader_rt[RArg::kReaderKGroupStride] = dyn.k_group_tile_stride;
+        reader_rt[RArg::kReaderVGroupStride] = dyn.v_group_tile_stride;
+        // Baked per-coordinate (one program per device, so each rank masks against its own global
+        // position) and re-applied on cache hits.
+        reader_rt[RArg::kReaderChunkStart] = dyn.chunk_start_local;
+        reader_desc.emplace_runtime_args(core, reader_rt);
+
+        using WArg = SparseSDPAMsaOperation::WriterArg;
+        RtArgs writer_rt(WArg::kWriterArgCount);
+        writer_rt[WArg::kWriterOutAddr] = out_buf;
+        writer_rt[WArg::kWriterWorkStart] = work_start;
+        writer_rt[WArg::kWriterWorkCount] = work_count;
+        writer_rt[WArg::kWriterKAddr] = k_buf;
+        writer_rt[WArg::kWriterVAddr] = v_buf;
+        writer_rt[WArg::kWriterKBatchOffset] = dyn.k_batch_tile_offset;
+        writer_rt[WArg::kWriterVBatchOffset] = dyn.v_batch_tile_offset;
+        writer_rt[WArg::kWriterKGroupStride] = dyn.k_group_tile_stride;
+        writer_rt[WArg::kWriterVGroupStride] = dyn.v_group_tile_stride;
+        writer_desc.emplace_runtime_args(core, writer_rt);
+
+        using CArg = SparseSDPAMsaOperation::ComputeArg;
+        RtArgs compute_rt(CArg::kComputeArgCount);
+        compute_rt[CArg::kComputeWorkStart] = work_start;
+        compute_rt[CArg::kComputeWorkCount] = work_count;
+        compute_desc.emplace_runtime_args(core, compute_rt);
     }
 
     desc.kernels.push_back(std::move(reader_desc));


### PR DESCRIPTION
Migrates `sparse_sdpa_msa` off `get_dynamic_runtime_args` to `override_runtime_arguments` (#49828). Custom hash unchanged; get_dynamic removed. Per-coordinate override (causal chunk_start threaded via coord). n_kv confirmed structurally keyed (no under-keying). **Blackhole/multichip** — correctness + perf via CI.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/gd-sparse-sdpa-msa)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/gd-sparse-sdpa-msa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/gd-sparse-sdpa-msa)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/gd-sparse-sdpa-msa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/gd-sparse-sdpa-msa)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/gd-sparse-sdpa-msa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/gd-sparse-sdpa-msa)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/gd-sparse-sdpa-msa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/gd-sparse-sdpa-msa)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/gd-sparse-sdpa-msa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/gd-sparse-sdpa-msa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/gd-sparse-sdpa-msa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/gd-sparse-sdpa-msa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/gd-sparse-sdpa-msa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/gd-sparse-sdpa-msa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/gd-sparse-sdpa-msa)