### PR TITLE
[Feature] Allow DFB instance multi-binding (on Gen1 only) in Metal 2.0

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -3311,6 +3311,64 @@ TEST_F(ProgramSpecTestGen1, DFBMultipleConsumersOnSameNodeSucceedsWithFlag) {
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }
 
+TEST_F(ProgramSpecTestGen1, DFBMixedKindProducersOnSameNodeFailsWithoutFlag) {
+    // Baseline: a single role mixing a compute and a DM kernel is rejected by the per-role
+    // kind-uniformity check (the DFB's hardware config nominally carries one processor mask per role).
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.name = "mixed_kind";
+
+    auto producer_compute = MakeMinimalGen1ComputeKernel("producer_compute");
+    auto producer_dm = MakeMinimalGen1DMKernel("producer_dm", DataMovementProcessor::RISCV_0);
+    auto consumer = MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
+
+    auto dfb = MakeMinimalDFB("dfb");
+    dfb.data_format_metadata = tt::DataFormat::Float16_b;
+
+    producer_compute.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb"}, "out"));
+    producer_dm.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb"}, "out"));
+    consumer.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb"}, "in"));
+
+    spec.kernels = {producer_compute, producer_dm, consumer};
+    spec.dataflow_buffers = {dfb};
+    spec.work_units = std::vector<WorkUnitSpec>{
+        MakeMinimalWorkUnit("work_unit", node, {"producer_compute", "producer_dm", "consumer"})};
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("mixing compute and data-movement kinds")));
+}
+
+TEST_F(ProgramSpecTestGen1, DFBMixedKindProducersOnSameNodeSucceedsWithFlag) {
+    // The escape hatch imposes no RISC-type restriction on Gen1: a compute kernel and a DM kernel may
+    // both produce to one DFB on one node (it lowers to a plain shared circular buffer). Identical to
+    // the FailsWithoutFlag case except for the flag, which is what drops the kind-uniformity check.
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.name = "mixed_kind";
+
+    auto producer_compute = MakeMinimalGen1ComputeKernel("producer_compute");
+    auto producer_dm = MakeMinimalGen1DMKernel("producer_dm", DataMovementProcessor::RISCV_0);
+    auto consumer = MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
+
+    auto dfb = MakeMinimalDFB("dfb");
+    dfb.data_format_metadata = tt::DataFormat::Float16_b;
+    dfb.advanced_options.allow_instance_multi_binding = true;
+
+    producer_compute.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb"}, "out"));
+    producer_dm.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb"}, "out"));
+    consumer.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb"}, "in"));
+
+    spec.kernels = {producer_compute, producer_dm, consumer};
+    spec.dataflow_buffers = {dfb};
+    spec.work_units = std::vector<WorkUnitSpec>{
+        MakeMinimalWorkUnit("work_unit", node, {"producer_compute", "producer_dm", "consumer"})};
+
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
+}
+
 TEST_F(ProgramSpecTestGen1, MultiThreadedDMKernelFails) {
     NodeCoord node{0, 0};
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -589,6 +589,34 @@ TEST_F(ProgramSpecTestQuasar, DFBWithMultipleProducersInDifferentWorkUnitsSuccee
     EXPECT_NO_THROW({ MakeProgramFromSpec(*mesh_device_, spec); });
 }
 
+TEST_F(ProgramSpecTestQuasar, MultiBindingFlagOnGen2Fails) {
+    // allow_instance_multi_binding is a Gen1-only escape hatch. Setting it on a Gen2 target is a hard
+    // error regardless of whether any instance is actually multi-bound — here the DFB is a plain
+    // single-producer/single-consumer buffer that would otherwise be perfectly valid.
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.name = "test_program";
+
+    auto producer = MakeMinimalGen2DMKernel("producer");
+    auto consumer = MakeMinimalGen2ComputeKernel("consumer");
+
+    auto dfb = MakeMinimalDFB("dfb");
+    dfb.data_format_metadata = tt::DataFormat::Float16_b;
+    dfb.advanced_options.allow_instance_multi_binding = true;
+
+    producer.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb"}, "out"));
+    consumer.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb"}, "in"));
+
+    spec.kernels = {producer, consumer};
+    spec.dataflow_buffers = {dfb};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("only supported on Gen1")));
+}
+
 TEST_F(ProgramSpecTestQuasar, DFBProducerConsumerCoverageMismatchFails) {
     NodeCoord node0{0, 0};
     NodeCoord node1{1, 0};
@@ -3191,6 +3219,94 @@ TEST_F(ProgramSpecTestGen1, TwoDMKernelsDifferentProcessorsSucceeds) {
 
     spec.kernels = {k0, k1};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"k0", "k1"})};
+
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
+}
+
+TEST_F(ProgramSpecTestGen1, DFBMultipleProducersOnSameNodeFailsWithoutFlag) {
+    // Baseline: without allow_instance_multi_binding, two producer instances on one node are rejected
+    // by the per-node census even on Gen1. This is the counterpart the escape-hatch test unlocks.
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.name = "multi_producer";
+
+    auto producer1 = MakeMinimalGen1DMKernel("producer1", DataMovementProcessor::RISCV_0);
+    auto producer2 = MakeMinimalGen1DMKernel("producer2", DataMovementProcessor::RISCV_1);
+    auto consumer = MakeMinimalGen1ComputeKernel("consumer");
+
+    auto dfb = MakeMinimalDFB("dfb");
+    dfb.data_format_metadata = tt::DataFormat::Float16_b;
+
+    producer1.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb"}, "out"));
+    producer2.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb"}, "out"));
+    consumer.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb"}, "in"));
+
+    spec.kernels = {producer1, producer2, consumer};
+    spec.dataflow_buffers = {dfb};
+    spec.work_units =
+        std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer1", "producer2", "consumer"})};
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("2 producer instance(s)")));
+}
+
+TEST_F(ProgramSpecTestGen1, DFBMultipleProducersOnSameNodeSucceedsWithFlag) {
+    // The allow_instance_multi_binding escape hatch: on Gen1 a DFB lowers to a plain circular buffer,
+    // so one node may host more than one producer instance — here a RISCV_0 and a RISCV_1 DM kernel
+    // both feeding one DFB, drained by a compute consumer. Identical to the FailsWithoutFlag case
+    // except for the flag, which is what makes the per-node census accept the second producer.
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.name = "multi_producer";
+
+    auto producer1 = MakeMinimalGen1DMKernel("producer1", DataMovementProcessor::RISCV_0);
+    auto producer2 = MakeMinimalGen1DMKernel("producer2", DataMovementProcessor::RISCV_1);
+    auto consumer = MakeMinimalGen1ComputeKernel("consumer");
+
+    auto dfb = MakeMinimalDFB("dfb");
+    dfb.data_format_metadata = tt::DataFormat::Float16_b;
+    dfb.advanced_options.allow_instance_multi_binding = true;
+
+    producer1.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb"}, "out"));
+    producer2.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb"}, "out"));
+    consumer.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb"}, "in"));
+
+    spec.kernels = {producer1, producer2, consumer};
+    spec.dataflow_buffers = {dfb};
+    spec.work_units =
+        std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer1", "producer2", "consumer"})};
+
+    EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
+}
+
+TEST_F(ProgramSpecTestGen1, DFBMultipleConsumersOnSameNodeSucceedsWithFlag) {
+    // Mirror of the multi-producer escape-hatch case: a compute producer feeding two DM consumers
+    // (RISCV_0 and RISCV_1) on one node. (Two DM consumers exhaust both DM processors, so the
+    // producer must be the compute engine.) Unlocked by the flag.
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.name = "multi_consumer";
+
+    auto producer = MakeMinimalGen1ComputeKernel("producer");
+    auto consumer1 = MakeMinimalGen1DMKernel("consumer1", DataMovementProcessor::RISCV_0);
+    auto consumer2 = MakeMinimalGen1DMKernel("consumer2", DataMovementProcessor::RISCV_1);
+
+    auto dfb = MakeMinimalDFB("dfb");
+    dfb.data_format_metadata = tt::DataFormat::Float16_b;
+    dfb.advanced_options.allow_instance_multi_binding = true;
+
+    producer.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb"}, "out"));
+    consumer1.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb"}, "in"));
+    consumer2.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb"}, "in"));
+
+    spec.kernels = {producer, consumer1, consumer2};
+    spec.dataflow_buffers = {dfb};
+    spec.work_units =
+        std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer1", "consumer2"})};
 
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
 }

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -121,6 +121,39 @@ struct DFBAdvancedOptions {
     //   - All members must target the same node set
     //     (derived from their bound kernels' WorkUnitSpecs).
     Group<DFBSpecName> alias_with;
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // DFB multi-bindings
+    ////////////////////////////////////////////////////////////////////////////////
+
+    // A DFB is a software FIFO. By default, a DFB instance (i.e., a DFB on a
+    // particular node) must have exactly one producer kernel instance and exactly
+    // one consumer kernel instance.
+    //
+    // This invariant holds at the INSTANCE level; a *DFBSpec* (spanning multiple
+    // nodes) can have more than one KernelSpec producer or more consumer bindings,
+    // as long as every node's DFB instance has one producer and one consumer.
+    // (This enables, for example, a grid-spanning compute kernel to be fed data by
+    // different types of producer kernels on different nodes.)
+    //
+    // "Multi-binding" refers to a DFB instance that has more than one producer
+    // and/or more than one consumer kernel instance. Gen1 hardware (Wormhole and
+    // Blackhole) is technically capable of supporting multi-binding: a DFB lowers
+    // to a plain circular buffer there, so the FIFO pointers are shared L1 state
+    // that any number of producer/consumer RISCs can drive.
+    // However, this configuration is unsafe and its use is discouraged.
+    //
+    // CAUTION:
+    // Multi-binding a DFB instance is UNSAFE in most circumstances.
+    // The kernel logic must explicitly ensure access safety and synchronization.
+    // Multi-binding forfeits the protections of the FIFO synchronization mechanics.
+    // There is a high likelihood of race conditions and non-deterministic behavior.
+    //
+    // NOTE:
+    // This feature is included for backwards compatibility with legacy APIs.
+    // It is NOT supported on Gen2 architectures: setting this flag on a Gen2
+    // target is a hard error, whether or not any instance is actually multi-bound.
+    bool allow_instance_multi_binding = false;
 };
 
 struct AdvancedKernelRunArgs {

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -1243,6 +1243,20 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             dfb.unique_id);
     }
 
+    // The allow_instance_multi_binding escape hatch is Gen1-only. On Gen2 the DFB's per-RISC
+    // tile-counter / remapper machinery is driven by the producer/consumer masks, so a multi-bound
+    // instance cannot be lowered. Reject the flag itself on Gen2, independent of whether any instance
+    // is actually multi-bound — a Gen2 spec carrying it is never valid.
+    if (is_gen2_arch()) {
+        for (const auto& dfb : spec.dataflow_buffers) {
+            TT_FATAL(
+                !dfb.advanced_options.allow_instance_multi_binding,
+                "DFB '{}' sets allow_instance_multi_binding, which is only supported on Gen1 (WH/BH) "
+                "architectures. On Gen2 a DFB instance must have exactly one producer and one consumer.",
+                dfb.unique_id);
+        }
+    }
+
     // Validate local DFB endpoint placement and multi-binding consistency.
     //
     // The hardware invariant is local: a local DFB lives in shared SRAM on each node, so at every
@@ -1354,12 +1368,21 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             return names;
         };
 
+        // Normally each node must host *exactly* one producer and one consumer (the local-DFB FIFO
+        // safety invariant). The allow_instance_multi_binding escape hatch (Gen1-only; the flag is
+        // rejected on Gen2 earlier in this function) relaxes the upper bound to permit legacy
+        // multi-producer / multi-consumer circular-buffer patterns, so a node may host more than one
+        // instance of a role. The connectivity requirement stays: every node must still host at least
+        // one producer AND at least one consumer, or the FIFO is half-wired.
+        const bool allow_multi = dfb.advanced_options.allow_instance_multi_binding;
         for (const NodeCoord& node : footprint) {
             auto p_it = producers_on_node.find(node);
             auto c_it = consumers_on_node.find(node);
             const size_t num_producers = p_it == producers_on_node.end() ? 0 : p_it->second.size();
             const size_t num_consumers = c_it == consumers_on_node.end() ? 0 : c_it->second.size();
-            if (num_producers == 1 && num_consumers == 1) {
+            const bool node_ok =
+                allow_multi ? (num_producers >= 1 && num_consumers >= 1) : (num_producers == 1 && num_consumers == 1);
+            if (node_ok) {
                 continue;
             }
             std::string_view guidance;
@@ -2848,6 +2871,16 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
     //   are deterministic from num_threads, which is uniform per role. So on Gen2 the uniformity
     //   property is guaranteed by construction; the check is retained as a defensive assertion.
     for (const auto& dfb : spec.dataflow_buffers) {
+        // Instance-multi-binding (Gen1-only) intentionally binds same-role kernels on distinct RISCs
+        // (e.g. a BRISC producer and an NCRISC producer on one node), so their risc_masks differ by
+        // design and the uniform-mask requirement does not apply. On Gen1 the DFB lowers to a plain
+        // circular buffer where the mask is inert (it never reaches the device blob), so the single
+        // representative mask MakeDataflowBufferConfig takes from the first binding is harmless. (The
+        // flag is rejected on Gen2 in ValidateProgramSpec, so under normal validation any DFB reaching
+        // here with it set is Gen1.)
+        if (dfb.advanced_options.allow_instance_multi_binding) {
+            continue;
+        }
         const auto& endpoints = collected.dfb_endpoints.at(dfb.unique_id);
         auto check_uniform_mask = [&](const auto& records, std::string_view role) {
             if (records.size() < 2) {

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -1276,11 +1276,19 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     for (const auto& dfb : spec.dataflow_buffers) {
         const auto& endpoints = collected.dfb_endpoints.at(dfb.unique_id);
 
+        // allow_instance_multi_binding (Gen1-only; rejected on Gen2 earlier in this function) turns
+        // the per-node DFB into a plain shared circular buffer, which has no per-role hardware config
+        // to share — no processor mask, DFB scheduler, or credit machinery. Every per-role uniformity
+        // requirement below exists solely to guarantee such a shared config, so none apply under the
+        // flag: the role-uniformity checks are skipped and the per-node census relaxes its "exactly
+        // one" counts to "at least one".
+        const bool allow_multi = dfb.advanced_options.allow_instance_multi_binding;
+
         // (3) and (4): per-role uniformity of binding-site parameters, plus kernel kind.
         // Kind (compute vs DM) must agree because the DFB's hardware config carries a single
         // processor mask per role, and compute / DM masks live in disjoint bit ranges (bits
         // 0-7 vs 8-15 on Gen2; orthogonal RISC encodings on Gen1) — mismatched kinds cannot
-        // share a mask.
+        // share a mask. (All three are skipped under allow_multi — see above.)
         auto check_role_uniformity = [&](const auto& records, std::string_view role) {
             if (records.size() < 2) {
                 return;
@@ -1321,8 +1329,10 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                     first_is_compute ? "data-movement" : "compute");
             }
         };
-        check_role_uniformity(endpoints.producers, "PRODUCER");
-        check_role_uniformity(endpoints.consumers, "CONSUMER");
+        if (!allow_multi) {
+            check_role_uniformity(endpoints.producers, "PRODUCER");
+            check_role_uniformity(endpoints.consumers, "CONSUMER");
+        }
 
         // (1)/(2) Placement — per-node census. A local DFB lives in shared SRAM on each node, so
         // every node it is instantiated on must run exactly one producer instance and exactly one
@@ -1368,13 +1378,9 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             return names;
         };
 
-        // Normally each node must host *exactly* one producer and one consumer (the local-DFB FIFO
-        // safety invariant). The allow_instance_multi_binding escape hatch (Gen1-only; the flag is
-        // rejected on Gen2 earlier in this function) relaxes the upper bound to permit legacy
-        // multi-producer / multi-consumer circular-buffer patterns, so a node may host more than one
-        // instance of a role. The connectivity requirement stays: every node must still host at least
-        // one producer AND at least one consumer, or the FIFO is half-wired.
-        const bool allow_multi = dfb.advanced_options.allow_instance_multi_binding;
+        // Per-node census. Under allow_multi (see top of loop) the "exactly one" upper bound relaxes
+        // to "at least one": a node may host multiple instances of a role, but must still host at
+        // least one producer AND one consumer, or the FIFO is half-wired.
         for (const NodeCoord& node : footprint) {
             auto p_it = producers_on_node.find(node);
             auto c_it = consumers_on_node.find(node);


### PR DESCRIPTION
## PR Category
Feature

## Summary
A DataflowBuffer is a SW FIFO (or multi-threaded SW FIFO abstraction) with one producer and one consumer. By default, Metal 2.0 enforces a strict legality check that a DFB instance on any given node must have exactly one producer kernel instance and exactly one consumer kernel instance.

However, in legacy kernels, there are rare (and exotic) instances where more than two kernels access the same CircularBuffer. This is an advanced use case (with a very high potential for creating race conditions).

To enable legacy parity on Gen1 architectures, this PR introduces a DFB advanced option: `allow_instance_multi_binding`:
 - Enabling this feature on Gen1 (WH/BH) lifts the "single producer, single consumer" per instance legality check.
 - The header comments carefully document the dangers and discouraging using the feature.
 - This cannot be used on Gen2 architectures. Attempting to set this flag will trigger a hard error (even in the absence of multi-bound DFBs).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/allow-multibound-dfs)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/allow-multibound-dfs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/allow-multibound-dfs)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/allow-multibound-dfs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=akertesz/allow-multibound-dfs)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:akertesz/allow-multibound-dfs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/allow-multibound-dfs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/allow-multibound-dfs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/allow-multibound-dfs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/allow-multibound-dfs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/allow-multibound-dfs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/allow-multibound-dfs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/allow-multibound-dfs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/allow-multibound-dfs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/allow-multibound-dfs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/allow-multibound-dfs)