### PR TITLE
[ci] experiment: optional perf host profiling for ttnn-sanity-tests

### DIFF
--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -76,8 +76,8 @@ on:
         description: "Exact TTNN sanity test-group name to profile (e.g. 'ttnn eltwise group 1'). Required when enable-perf-host-profiling is true."
       perf-sample-frequency:
         required: false
-        type: number
-        default: 1000
+        type: string
+        default: "1000"
         description: "perf sample frequency in Hz"
       perf-install-package:
         required: false
@@ -187,8 +187,8 @@ on:
         description: "Exact TTNN sanity test-group name to profile (e.g. 'ttnn eltwise group 1'). Required when enable-perf-host-profiling is true."
       perf-sample-frequency:
         required: false
-        type: number
-        default: 1000
+        type: string
+        default: "1000"
         description: "perf sample frequency in Hz"
       perf-install-package:
         required: false
@@ -329,7 +329,7 @@ jobs:
       ref: ${{ inputs.ref || github.sha }}
       enable-perf-host-profiling: ${{ inputs.enable-perf-host-profiling || false }}
       perf-target-group: ${{ inputs.perf-target-group || '' }}
-      perf-sample-frequency: ${{ inputs.perf-sample-frequency || 1000 }}
+      perf-sample-frequency: ${{ inputs.perf-sample-frequency || '1000' }}
       perf-install-package: ${{ inputs.perf-install-package || 'linux-tools-common linux-tools-generic' }}
   t3000-apc-fast-tests:
     if: ${{ always() && !cancelled() && needs.resolve-artifacts.result == 'success' && needs.tests-to-run.outputs.t3000-apc-fast-tests == 'true' }}

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -63,6 +63,27 @@ on:
         type: string
         default: ""
         description: "Commit SHA to test (default: HEAD)"
+      # EXPERIMENT: optional Linux perf host profiling for the TTNN sanity tests.
+      enable-perf-host-profiling:
+        required: false
+        default: false
+        type: boolean
+        description: "EXPERIMENT: profile one TTNN sanity HW test group with `perf record -g` and upload perf.data. Default off."
+      perf-target-group:
+        required: false
+        type: string
+        default: ""
+        description: "Exact TTNN sanity test-group name to profile (e.g. 'ttnn eltwise group 1'). Required when enable-perf-host-profiling is true."
+      perf-sample-frequency:
+        required: false
+        type: number
+        default: 1000
+        description: "perf sample frequency in Hz"
+      perf-install-package:
+        required: false
+        type: string
+        default: "linux-tools-common linux-tools-generic"
+        description: "packages to install for perf"
       # Pre-built artifacts (optional - if provided, skips build-artifact job)
       dev-docker-image:
         required: false
@@ -153,6 +174,27 @@ on:
         type: string
         default: ""
         description: "Commit SHA to test (default: HEAD)"
+      # EXPERIMENT: optional Linux perf host profiling for the TTNN sanity tests.
+      enable-perf-host-profiling:
+        required: false
+        default: false
+        type: boolean
+        description: "EXPERIMENT: profile one TTNN sanity HW test group with `perf record -g` and upload perf.data. Default off."
+      perf-target-group:
+        required: false
+        type: string
+        default: ""
+        description: "Exact TTNN sanity test-group name to profile (e.g. 'ttnn eltwise group 1'). Required when enable-perf-host-profiling is true."
+      perf-sample-frequency:
+        required: false
+        type: number
+        default: 1000
+        description: "perf sample frequency in Hz"
+      perf-install-package:
+        required: false
+        type: string
+        default: "linux-tools-common linux-tools-generic"
+        description: "packages to install for perf"
   push:
     branches: ["main"]
 
@@ -285,6 +327,10 @@ jobs:
       enable-lightweight-kernel-asserts: ${{ inputs.enable-lightweight-kernel-asserts || false }}
       enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
       ref: ${{ inputs.ref || github.sha }}
+      enable-perf-host-profiling: ${{ inputs.enable-perf-host-profiling || false }}
+      perf-target-group: ${{ inputs.perf-target-group || '' }}
+      perf-sample-frequency: ${{ inputs.perf-sample-frequency || 1000 }}
+      perf-install-package: ${{ inputs.perf-install-package || 'linux-tools-common linux-tools-generic' }}
   t3000-apc-fast-tests:
     if: ${{ always() && !cancelled() && needs.resolve-artifacts.result == 'success' && needs.tests-to-run.outputs.t3000-apc-fast-tests == 'true' }}
     needs: [resolve-artifacts, tests-to-run]

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -79,11 +79,6 @@ on:
         type: string
         default: "1000"
         description: "perf sample frequency in Hz"
-      perf-install-package:
-        required: false
-        type: string
-        default: "linux-tools-common linux-tools-generic"
-        description: "packages to install for perf"
       # Pre-built artifacts (optional - if provided, skips build-artifact job)
       dev-docker-image:
         required: false
@@ -190,11 +185,6 @@ on:
         type: string
         default: "1000"
         description: "perf sample frequency in Hz"
-      perf-install-package:
-        required: false
-        type: string
-        default: "linux-tools-common linux-tools-generic"
-        description: "packages to install for perf"
   push:
     branches: ["main"]
 
@@ -330,7 +320,6 @@ jobs:
       enable-perf-host-profiling: ${{ inputs.enable-perf-host-profiling || false }}
       perf-target-group: ${{ inputs.perf-target-group || '' }}
       perf-sample-frequency: ${{ inputs.perf-sample-frequency || '1000' }}
-      perf-install-package: ${{ inputs.perf-install-package || 'linux-tools-common linux-tools-generic' }}
   t3000-apc-fast-tests:
     if: ${{ always() && !cancelled() && needs.resolve-artifacts.result == 'success' && needs.tests-to-run.outputs.t3000-apc-fast-tests == 'true' }}
     needs: [resolve-artifacts, tests-to-run]

--- a/.github/workflows/ttnn-sanity-tests-impl.yaml
+++ b/.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -58,8 +58,8 @@ on:
         description: "Exact matrix test-group name to profile with perf (e.g. 'ttnn eltwise group 1'). Required when enable-perf-host-profiling is true."
       perf-sample-frequency:
         required: false
-        type: number
-        default: 1000
+        type: string
+        default: "1000"
         description: "perf sample frequency in Hz"
       perf-install-package:
         required: false

--- a/.github/workflows/ttnn-sanity-tests-impl.yaml
+++ b/.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -46,6 +46,26 @@ on:
         type: boolean
         default: false
         description: "When true, collect LLVM profraw data and upload per-job profdata artifact for coverage aggregation."
+      enable-perf-host-profiling:
+        required: false
+        type: boolean
+        default: false
+        description: "EXPERIMENT: run the selected HW test group under `perf record -g` and upload perf.data as an artifact. Default off, no overhead when disabled."
+      perf-target-group:
+        required: false
+        type: string
+        default: ""
+        description: "Exact matrix test-group name to profile with perf (e.g. 'ttnn eltwise group 1'). Required when enable-perf-host-profiling is true."
+      perf-sample-frequency:
+        required: false
+        type: number
+        default: 1000
+        description: "perf sample frequency in Hz"
+      perf-install-package:
+        required: false
+        type: string
+        default: "linux-tools-common linux-tools-generic"
+        description: "packages to install for perf"
 
 jobs:
   load-test-matrix:
@@ -234,14 +254,71 @@ jobs:
           mkdir -p /work/coverage
           echo "LLVM_PROFILE_FILE=/work/coverage/%p-%m.profraw" >> "$GITHUB_ENV"
 
+      # EXPERIMENT (perf host profiling): the following three steps are only active when
+      # inputs.enable-perf-host-profiling is true. They validate the target group, install
+      # linux perf on the HW runner, and confirm perf is callable. All are no-ops (skipped)
+      # when the experiment is disabled, so there is zero overhead on the default path.
+      - name: Validate perf profiling target (host profiling)
+        if: ${{ inputs.enable-perf-host-profiling && !startsWith(matrix.test-group.sku, 'sim_') }}
+        run: |
+          if [ -z "${{ inputs.perf-target-group }}" ]; then
+            echo "::error::enable-perf-host-profiling is true but perf-target-group is empty."
+            echo "::error::You must supply the exact matrix test-group name to profile (e.g. 'ttnn eltwise group 1')."
+            exit 1
+          fi
+          echo "perf host profiling requested for target group: '${{ inputs.perf-target-group }}'"
+
+      - name: Install perf (host profiling)
+        if: ${{ inputs.enable-perf-host-profiling && !startsWith(matrix.test-group.sku, 'sim_') && matrix.test-group.name == inputs.perf-target-group }}
+        run: |
+          # Non-failing on purpose: if the perf package can't be installed (kernel/version mismatch
+          # on the runner), leave a clear signal in the logs but don't fail the job.
+          apt-get update || true
+          apt-get install -y ${{ inputs.perf-install-package }} || true
+
+      - name: Check perf availability (host profiling)
+        if: ${{ inputs.enable-perf-host-profiling && !startsWith(matrix.test-group.sku, 'sim_') && matrix.test-group.name == inputs.perf-target-group }}
+        run: |
+          perf --version || echo "::warning::perf is not available; the profiled run will fall back to running the command without perf."
+
       - name: ${{ matrix.test-group.name }} tests
         if: ${{ !startsWith(matrix.test-group.sku, 'sim_') }}
         timeout-minutes: ${{ inputs.timeout-minutes-override > 0 && inputs.timeout-minutes-override || matrix.test-group.timeout }}
+        env:
+          # Whether THIS matrix leg should be profiled: experiment on + this is the chosen HW group.
+          # (Never true on sim legs — this step's `if` already excludes sim_* SKUs.)
+          PERF_PROFILE_THIS: ${{ inputs.enable-perf-host-profiling && matrix.test-group.name == inputs.perf-target-group }}
+          PERF_SAMPLE_FREQUENCY: ${{ inputs.perf-sample-frequency }}
+          TEST_GROUP_NAME: ${{ matrix.test-group.name }}
+          TEST_GROUP_CMD: ${{ matrix.test-group.cmd }}
         run: |
+          # Build the inner command passed to the power sidecar's `bash -c`. Use a shell variable
+          # for the pytest command (from $TEST_GROUP_CMD) to avoid YAML/shell quoting hell.
+          #
+          # Non-profiled path (default): byte-for-byte the original behaviour — run the group cmd
+          # directly under the power sidecar.
+          # Profiled path (experiment): wrap the group cmd in `perf record -g -F <freq> -o <out>`,
+          # writing perf.data to /work so the host mount at ${{ github.workspace }}/docker-job can
+          # upload it. If perf isn't installed, fall back to running the cmd unwrapped.
+          if [ "$PERF_PROFILE_THIS" = "true" ]; then
+            # Sanitize the group name for use in a filename: spaces and any non [A-Za-z0-9._-] -> '_'.
+            SANITIZED=$(printf '%s' "$TEST_GROUP_NAME" | sed -E 's/[^A-Za-z0-9._-]+/_/g')
+            PERF_OUTPUT="/work/perf_${SANITIZED}.data"
+            echo "perf host profiling ENABLED for '$TEST_GROUP_NAME' -> $PERF_OUTPUT (freq ${PERF_SAMPLE_FREQUENCY}Hz)"
+            if command -v perf >/dev/null 2>&1; then
+              INNER="perf record -g -F ${PERF_SAMPLE_FREQUENCY} -o ${PERF_OUTPUT} -- ${TEST_GROUP_CMD}"
+            else
+              echo "::warning::perf not found; running '$TEST_GROUP_NAME' without profiling."
+              INNER="${TEST_GROUP_CMD}"
+            fi
+          else
+            INNER="${TEST_GROUP_CMD}"
+          fi
+
           python3 tools/tt-power-sidecar/tt_power_sidecar.py \
             --backend sysfs \
             --out /work/power_report.json \
-            -- bash -c '${{ matrix.test-group.cmd }}'
+            -- bash -c "$INNER"
 
       # Simulator runs have no hardware power telemetry, so swap the HW power sidecar for the
       # host-load sidecar — it reports host CPU/memory/disk/network usage (a "mem report", not
@@ -290,6 +367,44 @@ jobs:
           path: ${{ github.workspace }}/docker-job/power_report.json
           if-no-files-found: warn
           retention-days: 30
+
+      # EXPERIMENT (perf host profiling): summarize + upload perf.data. Guarded so it only runs
+      # for the chosen HW group when the experiment is enabled; otherwise skipped (no overhead).
+      - name: Summarize perf profile (host profiling)
+        if: ${{ !cancelled() && inputs.enable-perf-host-profiling && !startsWith(matrix.test-group.sku, 'sim_') && matrix.test-group.name == inputs.perf-target-group }}
+        run: |
+          # Best-effort human-readable summary next to the perf.data. Only attempt when a perf.data
+          # exists, perf is available, and the file is a sane size (skip huge captures to keep this
+          # step cheap). Never fails the job.
+          shopt -s nullglob
+          for f in /work/perf_*.data; do
+            echo "Found perf capture: $f ($(du -h "$f" | cut -f1))"
+            if ! command -v perf >/dev/null 2>&1; then
+              echo "perf not available; skipping report generation."
+              continue
+            fi
+            # Skip summarizing captures larger than ~500MB to keep this step fast.
+            size_bytes=$(stat -c %s "$f" 2>/dev/null || echo 0)
+            if [ "$size_bytes" -gt 524288000 ]; then
+              echo "perf.data larger than 500MB; skipping report generation."
+              continue
+            fi
+            perf report --stdio -i "$f" 2>/dev/null | head -100 > "${f%.data}.report.txt" || true
+            echo "Wrote summary: ${f%.data}.report.txt"
+          done || true
+
+      - name: Upload perf profile (host profiling)
+        if: ${{ !cancelled() && inputs.enable-perf-host-profiling && !startsWith(matrix.test-group.sku, 'sim_') && matrix.test-group.name == inputs.perf-target-group }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: perf-host-profile-${{ matrix.test-group.name }}
+          # /docker-job/ is the host-side mount of the container's /work/ directory. The profiled
+          # test step writes perf_<sanitized>.data (and an optional .report.txt) to /work.
+          path: |
+            ${{ github.workspace }}/docker-job/perf_*.data
+            ${{ github.workspace }}/docker-job/perf_*.report.txt
+          if-no-files-found: warn
+          retention-days: 14
 
       - name: Upload mem report
         if: ${{ !cancelled() && startsWith(matrix.test-group.sku, 'sim_') }}

--- a/.github/workflows/ttnn-sanity-tests-impl.yaml
+++ b/.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -289,7 +289,12 @@ jobs:
           # names ([A-Za-z0-9][A-Za-z0-9+._-]*), rejecting anything that could carry shell
           # metacharacters or extra apt-get flags. Fall back to a fixed default set if the input
           # is empty or contains no valid names.
-          default_pkgs=(linux-tools-common linux-tools-generic)
+          #
+          # The runner's perf binary must match the host kernel. We therefore include the
+          # kernel-specific linux-tools package (e.g. linux-tools-5.15.0-185-generic) in the
+          # default set, with generic fallbacks if that exact package is unavailable.
+          kernel_pkg="linux-tools-$(uname -r)-generic"
+          default_pkgs=(linux-tools-common "$kernel_pkg" linux-tools-generic)
           pkgs=()
           # Split on whitespace and commas only.
           IFS=', ' read -r -a raw_pkgs <<< "$PERF_INSTALL_PACKAGE"

--- a/.github/workflows/ttnn-sanity-tests-impl.yaml
+++ b/.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -254,32 +254,85 @@ jobs:
           mkdir -p /work/coverage
           echo "LLVM_PROFILE_FILE=/work/coverage/%p-%m.profraw" >> "$GITHUB_ENV"
 
-      # EXPERIMENT (perf host profiling): the following three steps are only active when
+      # EXPERIMENT (perf host profiling): the following steps are only active when
       # inputs.enable-perf-host-profiling is true. They validate the target group, install
-      # linux perf on the HW runner, and confirm perf is callable. All are no-ops (skipped)
-      # when the experiment is disabled, so there is zero overhead on the default path.
+      # linux perf on the HW runner, and probe whether perf can actually *record* (not just
+      # exist). All are no-ops (skipped) when the experiment is disabled, so there is zero
+      # overhead on the default path.
+      #
+      # SECURITY: user-controlled inputs (perf-target-group, perf-install-package) are never
+      # interpolated into a shell body via ${{ ... }}; they are passed through `env:` and only
+      # expanded as quoted "$VAR" at runtime so they cannot inject shell.
       - name: Validate perf profiling target (host profiling)
         if: ${{ inputs.enable-perf-host-profiling && !startsWith(matrix.test-group.sku, 'sim_') }}
+        env:
+          PERF_TARGET_GROUP: ${{ inputs.perf-target-group }}
         run: |
-          if [ -z "${{ inputs.perf-target-group }}" ]; then
+          if [ -z "$PERF_TARGET_GROUP" ]; then
             echo "::error::enable-perf-host-profiling is true but perf-target-group is empty."
             echo "::error::You must supply the exact matrix test-group name to profile (e.g. 'ttnn eltwise group 1')."
             exit 1
           fi
-          echo "perf host profiling requested for target group: '${{ inputs.perf-target-group }}'"
+          echo "perf host profiling requested for target group: '$PERF_TARGET_GROUP'"
 
       - name: Install perf (host profiling)
         if: ${{ inputs.enable-perf-host-profiling && !startsWith(matrix.test-group.sku, 'sim_') && matrix.test-group.name == inputs.perf-target-group }}
+        env:
+          # Optional override: a space/comma-separated list of package names. Validated below and
+          # split into a safe array; never spliced verbatim into the apt-get command line.
+          PERF_INSTALL_PACKAGE: ${{ inputs.perf-install-package }}
         run: |
           # Non-failing on purpose: if the perf package can't be installed (kernel/version mismatch
           # on the runner), leave a clear signal in the logs but don't fail the job.
+          #
+          # SECURITY: build the package list into a bash array. Accept only well-formed package
+          # names ([A-Za-z0-9][A-Za-z0-9+._-]*), rejecting anything that could carry shell
+          # metacharacters or extra apt-get flags. Fall back to a fixed default set if the input
+          # is empty or contains no valid names.
+          default_pkgs=(linux-tools-common linux-tools-generic)
+          pkgs=()
+          # Split on whitespace and commas only.
+          IFS=', ' read -r -a raw_pkgs <<< "$PERF_INSTALL_PACKAGE"
+          for p in "${raw_pkgs[@]}"; do
+            if [[ "$p" =~ ^[A-Za-z0-9][A-Za-z0-9+._-]*$ ]]; then
+              pkgs+=("$p")
+            elif [ -n "$p" ]; then
+              echo "::warning::Ignoring invalid perf package name: '$p'"
+            fi
+          done
+          if [ "${#pkgs[@]}" -eq 0 ]; then
+            echo "No valid packages supplied; using default set: ${default_pkgs[*]}"
+            pkgs=("${default_pkgs[@]}")
+          fi
+          echo "Installing perf packages: ${pkgs[*]}"
           apt-get update || true
-          apt-get install -y ${{ inputs.perf-install-package }} || true
+          apt-get install -y -- "${pkgs[@]}" || true
 
-      - name: Check perf availability (host profiling)
+      # Probe whether perf can actually RECORD, not merely that the binary exists. `command -v`
+      # only proves the executable is present; on many CI runners perf_event_open is denied
+      # (kernel.perf_event_paranoid, seccomp, missing CAP_PERFMON, etc.). Run a real, throwaway
+      # `perf record ... -- true` and only mark perf_ready=true if it succeeds. Never fails the
+      # step, so the selected group still tests even when recording is denied.
+      - name: Probe perf recording capability (host profiling)
+        id: perf-probe
         if: ${{ inputs.enable-perf-host-profiling && !startsWith(matrix.test-group.sku, 'sim_') && matrix.test-group.name == inputs.perf-target-group }}
+        env:
+          PERF_SAMPLE_FREQUENCY: ${{ inputs.perf-sample-frequency }}
         run: |
-          perf --version || echo "::warning::perf is not available; the profiled run will fall back to running the command without perf."
+          perf_ready=false
+          if command -v perf >/dev/null 2>&1; then
+            perf --version || true
+            if perf record -g -F "${PERF_SAMPLE_FREQUENCY}" -o /tmp/perf_probe.data -- true >/dev/null 2>&1; then
+              perf_ready=true
+              echo "perf recording probe succeeded; the target group will be profiled."
+            else
+              echo "::warning::perf is installed but cannot record (perf_event_open likely denied); the group will run without profiling."
+            fi
+            rm -f /tmp/perf_probe.data || true
+          else
+            echo "::warning::perf is not available; the group will run without profiling."
+          fi
+          echo "perf_ready=$perf_ready" >> "$GITHUB_OUTPUT"
 
       - name: ${{ matrix.test-group.name }} tests
         if: ${{ !startsWith(matrix.test-group.sku, 'sim_') }}
@@ -288,7 +341,11 @@ jobs:
           # Whether THIS matrix leg should be profiled: experiment on + this is the chosen HW group.
           # (Never true on sim legs — this step's `if` already excludes sim_* SKUs.)
           PERF_PROFILE_THIS: ${{ inputs.enable-perf-host-profiling && matrix.test-group.name == inputs.perf-target-group }}
+          # Whether the probe confirmed perf can actually record. Empty when the probe step was
+          # skipped (experiment off / not the target group); treated as "not ready".
+          PERF_READY: ${{ steps.perf-probe.outputs.perf_ready }}
           PERF_SAMPLE_FREQUENCY: ${{ inputs.perf-sample-frequency }}
+          PERF_TARGET_GROUP: ${{ inputs.perf-target-group }}
           TEST_GROUP_NAME: ${{ matrix.test-group.name }}
           TEST_GROUP_CMD: ${{ matrix.test-group.cmd }}
         run: |
@@ -299,26 +356,31 @@ jobs:
           # directly under the power sidecar.
           # Profiled path (experiment): wrap the group cmd in `perf record -g -F <freq> -o <out>`,
           # writing perf.data to /work so the host mount at ${{ github.workspace }}/docker-job can
-          # upload it. If perf isn't installed, fall back to running the cmd unwrapped.
-          if [ "$PERF_PROFILE_THIS" = "true" ]; then
+          # upload it. Only wrap when the recording-capability probe (perf-probe step) succeeded;
+          # otherwise fall back to running the cmd unwrapped so the group still tests.
+          #
+          # The whole group cmd is wrapped in `perf record ... -- bash -c '<cmd>'` so that a group
+          # command with chained commands (e.g. `pytest ... && pytest ...`) is captured in full,
+          # not just the first simple command. $TEST_GROUP_CMD is passed as a positional arg to the
+          # inner `bash -c` (see the sidecar invocation below), never spliced into a string, so its
+          # &&/quotes survive intact and it can't inject into the perf command line.
+          if [ "$PERF_PROFILE_THIS" = "true" ] && [ "$PERF_READY" = "true" ]; then
             # Sanitize the group name for use in a filename: spaces and any non [A-Za-z0-9._-] -> '_'.
             SANITIZED=$(printf '%s' "$TEST_GROUP_NAME" | sed -E 's/[^A-Za-z0-9._-]+/_/g')
             PERF_OUTPUT="/work/perf_${SANITIZED}.data"
             echo "perf host profiling ENABLED for '$TEST_GROUP_NAME' -> $PERF_OUTPUT (freq ${PERF_SAMPLE_FREQUENCY}Hz)"
-            if command -v perf >/dev/null 2>&1; then
-              INNER="perf record -g -F ${PERF_SAMPLE_FREQUENCY} -o ${PERF_OUTPUT} -- ${TEST_GROUP_CMD}"
-            else
-              echo "::warning::perf not found; running '$TEST_GROUP_NAME' without profiling."
-              INNER="${TEST_GROUP_CMD}"
-            fi
+            RUNNER=(perf record -g -F "${PERF_SAMPLE_FREQUENCY}" -o "${PERF_OUTPUT}" -- bash -c "$TEST_GROUP_CMD")
           else
-            INNER="${TEST_GROUP_CMD}"
+            if [ "$PERF_PROFILE_THIS" = "true" ]; then
+              echo "::warning::perf recording not available; running '$TEST_GROUP_NAME' without profiling."
+            fi
+            RUNNER=(bash -c "$TEST_GROUP_CMD")
           fi
 
           python3 tools/tt-power-sidecar/tt_power_sidecar.py \
             --backend sysfs \
             --out /work/power_report.json \
-            -- bash -c "$INNER"
+            -- "${RUNNER[@]}"
 
       # Simulator runs have no hardware power telemetry, so swap the HW power sidecar for the
       # host-load sidecar — it reports host CPU/memory/disk/network usage (a "mem report", not

--- a/.github/workflows/ttnn-sanity-tests-impl.yaml
+++ b/.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -276,7 +276,7 @@ jobs:
           echo "perf host profiling requested for target group: '$PERF_TARGET_GROUP'"
 
       - name: Install perf (host profiling)
-        if: ${{ inputs.enable-perf-host-profiling && !startsWith(matrix.test-group.sku, 'sim_') && matrix.test-group.name == inputs.perf-target-group }}
+        if: ${{ inputs.enable-perf-host-profiling && !startsWith(matrix.test-group.sku, 'sim_') && matrix.test-group.name == format('{0} [{1}]', inputs.perf-target-group, matrix.test-group.sku) }}
         env:
           # Optional override: a space/comma-separated list of package names. Validated below and
           # split into a safe array; never spliced verbatim into the apt-get command line.
@@ -315,7 +315,7 @@ jobs:
       # step, so the selected group still tests even when recording is denied.
       - name: Probe perf recording capability (host profiling)
         id: perf-probe
-        if: ${{ inputs.enable-perf-host-profiling && !startsWith(matrix.test-group.sku, 'sim_') && matrix.test-group.name == inputs.perf-target-group }}
+        if: ${{ inputs.enable-perf-host-profiling && !startsWith(matrix.test-group.sku, 'sim_') && matrix.test-group.name == format('{0} [{1}]', inputs.perf-target-group, matrix.test-group.sku) }}
         env:
           PERF_SAMPLE_FREQUENCY: ${{ inputs.perf-sample-frequency }}
         run: |
@@ -340,7 +340,7 @@ jobs:
         env:
           # Whether THIS matrix leg should be profiled: experiment on + this is the chosen HW group.
           # (Never true on sim legs — this step's `if` already excludes sim_* SKUs.)
-          PERF_PROFILE_THIS: ${{ inputs.enable-perf-host-profiling && matrix.test-group.name == inputs.perf-target-group }}
+          PERF_PROFILE_THIS: ${{ inputs.enable-perf-host-profiling && matrix.test-group.name == format('{0} [{1}]', inputs.perf-target-group, matrix.test-group.sku) }}
           # Whether the probe confirmed perf can actually record. Empty when the probe step was
           # skipped (experiment off / not the target group); treated as "not ready".
           PERF_READY: ${{ steps.perf-probe.outputs.perf_ready }}
@@ -433,7 +433,7 @@ jobs:
       # EXPERIMENT (perf host profiling): summarize + upload perf.data. Guarded so it only runs
       # for the chosen HW group when the experiment is enabled; otherwise skipped (no overhead).
       - name: Summarize perf profile (host profiling)
-        if: ${{ !cancelled() && inputs.enable-perf-host-profiling && !startsWith(matrix.test-group.sku, 'sim_') && matrix.test-group.name == inputs.perf-target-group }}
+        if: ${{ !cancelled() && inputs.enable-perf-host-profiling && !startsWith(matrix.test-group.sku, 'sim_') && matrix.test-group.name == format('{0} [{1}]', inputs.perf-target-group, matrix.test-group.sku) }}
         run: |
           # Best-effort human-readable summary next to the perf.data. Only attempt when a perf.data
           # exists, perf is available, and the file is a sane size (skip huge captures to keep this
@@ -456,7 +456,7 @@ jobs:
           done || true
 
       - name: Upload perf profile (host profiling)
-        if: ${{ !cancelled() && inputs.enable-perf-host-profiling && !startsWith(matrix.test-group.sku, 'sim_') && matrix.test-group.name == inputs.perf-target-group }}
+        if: ${{ !cancelled() && inputs.enable-perf-host-profiling && !startsWith(matrix.test-group.sku, 'sim_') && matrix.test-group.name == format('{0} [{1}]', inputs.perf-target-group, matrix.test-group.sku) }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: perf-host-profile-${{ matrix.test-group.name }}

--- a/.github/workflows/ttnn-sanity-tests-impl.yaml
+++ b/.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -326,6 +326,13 @@ jobs:
           PERF_TARGET_GROUP: ${{ inputs.perf-target-group }}
           TEST_GROUP_NAME: ${{ matrix.test-group.name }}
           TEST_GROUP_CMD: ${{ matrix.test-group.cmd }}
+          # EXPERIMENT: cap PyTorch/ATen host-side OpenMP threads when profiling is active. The
+          # eltwise tests use torch for tiny reference-tensor operations on the host; an uncapped
+          # thread pool causes libgomp to burn CPU in busy-wait barriers. This env var only affects
+          # the wrapped test command (not the rest of the matrix) and helps isolate the real host
+          # work from OpenMP spin overhead.
+          OMP_NUM_THREADS: ${{ inputs.enable-perf-host-profiling && matrix.test-group.name == format('{0} [{1}]', inputs.perf-target-group, matrix.test-group.sku) && '1' || '' }}
+          MKL_NUM_THREADS: ${{ inputs.enable-perf-host-profiling && matrix.test-group.name == format('{0} [{1}]', inputs.perf-target-group, matrix.test-group.sku) && '1' || '' }}
         run: |
           # Build the inner command passed to the power sidecar's `bash -c`. Use a shell variable
           # for the pytest command (from $TEST_GROUP_CMD) to avoid YAML/shell quoting hell.

--- a/.github/workflows/ttnn-sanity-tests-impl.yaml
+++ b/.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -185,7 +185,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-      options: ${{ startsWith(matrix.test-group.sku, 'sim_') && '--label runner-mode=sim' || '--device /dev/tenstorrent -e TT_GH_CI_INFRA' }}
+      options: ${{ startsWith(matrix.test-group.sku, 'sim_') && '--label runner-mode=sim' || (inputs.enable-perf-host-profiling && matrix.test-group.name == format('{0} [{1}]', inputs.perf-target-group, matrix.test-group.sku)) && '--cap-add CAP_PERFMON --device /dev/tenstorrent -e TT_GH_CI_INFRA' || '--device /dev/tenstorrent -e TT_GH_CI_INFRA' }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ttnn-sanity-tests-impl.yaml
+++ b/.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -473,15 +473,26 @@ jobs:
           done || true
       - name: Upload perf profile (host profiling)
         if: ${{ !cancelled() && inputs.enable-perf-host-profiling && !startsWith(matrix.test-group.sku, 'sim_') && matrix.test-group.name == format('{0} [{1}]', inputs.perf-target-group, matrix.test-group.sku) }}
+        run: |
+          # Gather the perf outputs (.data, .report.txt, .svg) into one directory so we can upload
+          # them as a single artifact tree. This avoids issues with multiple glob patterns in the
+          # upload-artifact action and gives a clean artifact layout.
+          mkdir -p /work/perf_outputs
+          shopt -s nullglob
+          for f in /work/perf_*.data /work/perf_*.report.txt /work/perf_*.svg; do
+            [ -f "$f" ] || continue
+            cp -v "$f" /work/perf_outputs/ || true
+          done
+          ls -la /work/perf_outputs/
+
+      - name: Upload perf profile artifact (host profiling)
+        if: ${{ !cancelled() && inputs.enable-perf-host-profiling && !startsWith(matrix.test-group.sku, 'sim_') && matrix.test-group.name == format('{0} [{1}]', inputs.perf-target-group, matrix.test-group.sku) }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: perf-host-profile-${{ matrix.test-group.name }}
-          # /docker-job/ is the host-side mount of the container's /work/ directory. The profiled
-          # test step writes perf_<sanitized>.data (and an optional .report.txt / .svg) to /work.
-          path: |
-            ${{ github.workspace }}/docker-job/perf_*.data
-            ${{ github.workspace }}/docker-job/perf_*.report.txt
-            ${{ github.workspace }}/docker-job/perf_*.svg
+          # /docker-job/ is the host-side mount of the container's /work/ directory. The previous
+          # step copies perf_<sanitized>.data, .report.txt, and .svg into /work/perf_outputs/.
+          path: ${{ github.workspace }}/docker-job/perf_outputs/
           if-no-files-found: warn
           retention-days: 14
 

--- a/.github/workflows/ttnn-sanity-tests-impl.yaml
+++ b/.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -280,7 +280,7 @@ jobs:
           # kernel-specific linux-tools package (e.g. linux-tools-5.15.0-185-generic) with the
           # generic package as a fallback. The package list is hardcoded to avoid exposing a
           # user-controlled input that could be used for command injection.
-          kernel_pkg="linux-tools-$(uname -r)-generic"
+          kernel_pkg="linux-tools-$(uname -r)"
           pkgs=(linux-tools-common "$kernel_pkg" linux-tools-generic)
           echo "Installing perf packages: ${pkgs[*]}"
           apt-get update || true

--- a/.github/workflows/ttnn-sanity-tests-impl.yaml
+++ b/.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -61,11 +61,6 @@ on:
         type: string
         default: "1000"
         description: "perf sample frequency in Hz"
-      perf-install-package:
-        required: false
-        type: string
-        default: "linux-tools-common linux-tools-generic"
-        description: "packages to install for perf"
 
 jobs:
   load-test-matrix:
@@ -277,38 +272,16 @@ jobs:
 
       - name: Install perf (host profiling)
         if: ${{ inputs.enable-perf-host-profiling && !startsWith(matrix.test-group.sku, 'sim_') && matrix.test-group.name == format('{0} [{1}]', inputs.perf-target-group, matrix.test-group.sku) }}
-        env:
-          # Optional override: a space/comma-separated list of package names. Validated below and
-          # split into a safe array; never spliced verbatim into the apt-get command line.
-          PERF_INSTALL_PACKAGE: ${{ inputs.perf-install-package }}
         run: |
           # Non-failing on purpose: if the perf package can't be installed (kernel/version mismatch
           # on the runner), leave a clear signal in the logs but don't fail the job.
           #
-          # SECURITY: build the package list into a bash array. Accept only well-formed package
-          # names ([A-Za-z0-9][A-Za-z0-9+._-]*), rejecting anything that could carry shell
-          # metacharacters or extra apt-get flags. Fall back to a fixed default set if the input
-          # is empty or contains no valid names.
-          #
-          # The runner's perf binary must match the host kernel. We therefore include the
-          # kernel-specific linux-tools package (e.g. linux-tools-5.15.0-185-generic) in the
-          # default set, with generic fallbacks if that exact package is unavailable.
+          # The runner's perf binary must match the host kernel. We therefore install the
+          # kernel-specific linux-tools package (e.g. linux-tools-5.15.0-185-generic) with the
+          # generic package as a fallback. The package list is hardcoded to avoid exposing a
+          # user-controlled input that could be used for command injection.
           kernel_pkg="linux-tools-$(uname -r)-generic"
-          default_pkgs=(linux-tools-common "$kernel_pkg" linux-tools-generic)
-          pkgs=()
-          # Split on whitespace and commas only.
-          IFS=', ' read -r -a raw_pkgs <<< "$PERF_INSTALL_PACKAGE"
-          for p in "${raw_pkgs[@]}"; do
-            if [[ "$p" =~ ^[A-Za-z0-9][A-Za-z0-9+._-]*$ ]]; then
-              pkgs+=("$p")
-            elif [ -n "$p" ]; then
-              echo "::warning::Ignoring invalid perf package name: '$p'"
-            fi
-          done
-          if [ "${#pkgs[@]}" -eq 0 ]; then
-            echo "No valid packages supplied; using default set: ${default_pkgs[*]}"
-            pkgs=("${default_pkgs[@]}")
-          fi
+          pkgs=(linux-tools-common "$kernel_pkg" linux-tools-generic)
           echo "Installing perf packages: ${pkgs[*]}"
           apt-get update || true
           apt-get install -y -- "${pkgs[@]}" || true

--- a/.github/workflows/ttnn-sanity-tests-impl.yaml
+++ b/.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -331,8 +331,9 @@ jobs:
           # thread pool causes libgomp to burn CPU in busy-wait barriers. This env var only affects
           # the wrapped test command (not the rest of the matrix) and helps isolate the real host
           # work from OpenMP spin overhead.
-          OMP_NUM_THREADS: ${{ inputs.enable-perf-host-profiling && matrix.test-group.name == format('{0} [{1}]', inputs.perf-target-group, matrix.test-group.sku) && '1' || '' }}
-          MKL_NUM_THREADS: ${{ inputs.enable-perf-host-profiling && matrix.test-group.name == format('{0} [{1}]', inputs.perf-target-group, matrix.test-group.sku) && '1' || '' }}
+          OMP_NUM_THREADS: ${{ inputs.enable-perf-host-profiling && matrix.test-group.name == format('{0} [{1}]', inputs.perf-target-group, matrix.test-group.sku) && '2' || '' }}
+          MKL_NUM_THREADS: ${{ inputs.enable-perf-host-profiling && matrix.test-group.name == format('{0} [{1}]', inputs.perf-target-group, matrix.test-group.sku) && '2' || '' }}
+          OMP_WAIT_POLICY: ${{ inputs.enable-perf-host-profiling && matrix.test-group.name == format('{0} [{1}]', inputs.perf-target-group, matrix.test-group.sku) && 'passive' || '' }}
         run: |
           # Build the inner command passed to the power sidecar's `bash -c`. Use a shell variable
           # for the pytest command (from $TEST_GROUP_CMD) to avoid YAML/shell quoting hell.

--- a/.github/workflows/ttnn-sanity-tests-impl.yaml
+++ b/.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -433,16 +433,55 @@ jobs:
             echo "Wrote summary: ${f%.data}.report.txt"
           done || true
 
+      - name: Generate flame graph (host profiling)
+        if: ${{ !cancelled() && inputs.enable-perf-host-profiling && !startsWith(matrix.test-group.sku, 'sim_') && matrix.test-group.name == format('{0} [{1}]', inputs.perf-target-group, matrix.test-group.sku) }}
+        run: |
+          # Best-effort flame graph generation from the captured perf.data. Clone Brendan Gregg's
+          # FlameGraph tools into /tmp and use them to produce an SVG. This runs in the CI container
+          # which already has perf installed, so we don't need to transfer the data elsewhere.
+          shopt -s nullglob
+          for f in /work/perf_*.data; do
+            [ -f "$f" ] || continue
+            echo "Generating flame graph for: $f"
+            if ! command -v perf >/dev/null 2>&1; then
+              echo "perf not available; skipping flame graph generation."
+              continue
+            fi
+            # Limit to ~500MB perf.data to keep the script step fast.
+            size_bytes=$(stat -c %s "$f" 2>/dev/null || echo 0)
+            if [ "$size_bytes" -gt 524288000 ]; then
+              echo "perf.data larger than 500MB; skipping flame graph generation."
+              continue
+            fi
+            # Clone FlameGraph tooling if not already present.
+            fg_dir="/tmp/FlameGraph"
+            if [ ! -d "$fg_dir" ]; then
+              git clone --depth 1 https://github.com/brendangregg/FlameGraph.git "$fg_dir" || true
+            fi
+            if [ -f "$fg_dir/flamegraph.pl" ] && [ -f "$fg_dir/stackcollapse-perf.pl" ]; then
+              svg_out="${f%.data}.svg"
+              perf script -i "$f" 2>/dev/null | "$fg_dir/stackcollapse-perf.pl" 2>/dev/null | "$fg_dir/flamegraph.pl" --title "perf: $(basename "$f" .data)" > "$svg_out" 2>/dev/null || true
+              if [ -s "$svg_out" ]; then
+                echo "Wrote flame graph: $svg_out ($(du -h "$svg_out" | cut -f1))"
+              else
+                echo "Flame graph generation produced an empty file; removing."
+                rm -f "$svg_out"
+              fi
+            else
+              echo "FlameGraph tooling not available; skipping flame graph generation."
+            fi
+          done || true
       - name: Upload perf profile (host profiling)
         if: ${{ !cancelled() && inputs.enable-perf-host-profiling && !startsWith(matrix.test-group.sku, 'sim_') && matrix.test-group.name == format('{0} [{1}]', inputs.perf-target-group, matrix.test-group.sku) }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: perf-host-profile-${{ matrix.test-group.name }}
           # /docker-job/ is the host-side mount of the container's /work/ directory. The profiled
-          # test step writes perf_<sanitized>.data (and an optional .report.txt) to /work.
+          # test step writes perf_<sanitized>.data (and an optional .report.txt / .svg) to /work.
           path: |
             ${{ github.workspace }}/docker-job/perf_*.data
             ${{ github.workspace }}/docker-job/perf_*.report.txt
+            ${{ github.workspace }}/docker-job/perf_*.svg
           if-no-files-found: warn
           retention-days: 14
 

--- a/.github/workflows/ttnn-sanity-tests-impl.yaml
+++ b/.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -331,8 +331,8 @@ jobs:
           # thread pool causes libgomp to burn CPU in busy-wait barriers. This env var only affects
           # the wrapped test command (not the rest of the matrix) and helps isolate the real host
           # work from OpenMP spin overhead.
-          OMP_NUM_THREADS: ${{ inputs.enable-perf-host-profiling && matrix.test-group.name == format('{0} [{1}]', inputs.perf-target-group, matrix.test-group.sku) && '2' || '' }}
-          MKL_NUM_THREADS: ${{ inputs.enable-perf-host-profiling && matrix.test-group.name == format('{0} [{1}]', inputs.perf-target-group, matrix.test-group.sku) && '2' || '' }}
+          OMP_NUM_THREADS: ${{ inputs.enable-perf-host-profiling && matrix.test-group.name == format('{0} [{1}]', inputs.perf-target-group, matrix.test-group.sku) && '4' || '' }}
+          MKL_NUM_THREADS: ${{ inputs.enable-perf-host-profiling && matrix.test-group.name == format('{0} [{1}]', inputs.perf-target-group, matrix.test-group.sku) && '4' || '' }}
           OMP_WAIT_POLICY: ${{ inputs.enable-perf-host-profiling && matrix.test-group.name == format('{0} [{1}]', inputs.perf-target-group, matrix.test-group.sku) && 'passive' || '' }}
         run: |
           # Build the inner command passed to the power sidecar's `bash -c`. Use a shell variable
@@ -439,6 +439,11 @@ jobs:
             fi
             perf report --stdio -i "$f" 2>/dev/null | head -100 > "${f%.data}.report.txt" || true
             echo "Wrote summary: ${f%.data}.report.txt"
+            # EXPERIMENT (thread-scaling comparison): also print a flat, non-hierarchical
+            # per-shared-object breakdown so cumulative CPU % per DSO (e.g. libgomp.so.1) can be
+            # read straight from the job log without downloading and re-processing perf.data.
+            echo "--- DSO breakdown (flat, cumulative %) for $f ---"
+            perf report --stdio --sort dso -g none -i "$f" 2>/dev/null | head -30 || true
           done || true
 
       - name: Generate flame graph (host profiling)


### PR DESCRIPTION
## What

Opt-in experiment: run one selected TTNN sanity **HW** test group under `perf record -g` and upload the resulting `perf.data` (plus an optional `perf report` summary) as a CI artifact. **Default off**, no overhead when disabled, and the non-profiled path runs the same group command as before.

## Why

Give us a lightweight, on-demand way to grab a host CPU profile of a specific TTNN sanity group directly from CI, without standing up a separate profiling workflow or perturbing the normal matrix.

## Changes

**`ttnn-sanity-tests-impl.yaml`** (the reusable impl workflow):
- New `workflow_call` inputs, all `required: false` with safe defaults so existing callers still compile:
  - `enable-perf-host-profiling` (boolean, default `false`)
  - `perf-target-group` (string, default `""`)
  - `perf-sample-frequency` (number, default `1000`, Hz)
  - `perf-install-package` (string, default `linux-tools-common linux-tools-generic`)
- `Validate perf profiling target` — errors with a clear message if profiling is enabled but `perf-target-group` is empty.
- `Install perf` + `Check perf availability` — install perf on the HW runner (non-failing via `|| true`) and log `perf --version`. Only run for the chosen HW group.
- HW test step now builds the sidecar inner command from a shell variable (`$INNER`) to avoid YAML/shell quoting issues. When this leg is the target group, it wraps the pytest cmd as `perf record -g -F <freq> -o /work/perf_<sanitized>.data -- <cmd>`; otherwise it runs the original command unchanged. Falls back to the unwrapped command if perf isn't installed.
- New `Summarize perf profile` (best-effort `perf report --stdio`, size-capped) and `Upload perf profile` steps. Artifact name `perf-host-profile-<group>`, path `${{ github.workspace }}/docker-job/perf_*.data` (+ `.report.txt`), `if-no-files-found: warn`, `retention-days: 14`.

**`sanity-tests.yaml`** (the caller):
- Adds the same four inputs to both `workflow_call` and `workflow_dispatch`, and passes them through to `ttnn-sanity-tests-impl.yaml`.

## How to trigger

Run the **Sanity tests** workflow via `workflow_dispatch` with:
- `enable-perf-host-profiling: true`
- `perf-target-group:` the **exact** matrix group name, e.g. `ttnn eltwise group 1` (must match exactly — used for an equality check).

Then download the `perf-host-profile-<group>` artifact and analyze locally with `perf report -i perf_<group>.data`.

## Limitations

- **HW SKUs only.** Sim legs (`sim_*` on `ubuntu-latest`) are never profiled.
- Requires the **exact** group name; a typo means nothing gets profiled (the upload step is simply skipped).
- `perf` install/availability depends on the runner kernel/tools match. Install is non-failing and the run falls back to the unwrapped command if perf is missing, so the test itself won't be blocked by profiling issues — check the logs for warnings.
- The group's `pytest --timeout` values are unchanged; `perf record` adds some overhead, so a heavily loaded group could run closer to its budget.
- Only a single group is profiled per run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=experiment/perf-profiling-ttnn-sanity-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:experiment/perf-profiling-ttnn-sanity-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=experiment/perf-profiling-ttnn-sanity-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:experiment/perf-profiling-ttnn-sanity-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=experiment/perf-profiling-ttnn-sanity-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:experiment/perf-profiling-ttnn-sanity-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=experiment/perf-profiling-ttnn-sanity-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:experiment/perf-profiling-ttnn-sanity-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=experiment/perf-profiling-ttnn-sanity-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:experiment/perf-profiling-ttnn-sanity-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=experiment/perf-profiling-ttnn-sanity-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:experiment/perf-profiling-ttnn-sanity-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=experiment/perf-profiling-ttnn-sanity-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:experiment/perf-profiling-ttnn-sanity-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=experiment/perf-profiling-ttnn-sanity-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:experiment/perf-profiling-ttnn-sanity-tests)