### PR TITLE
[minimal_matmul] Flush granular output writes before releasing the CB slot (#50363)

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_minimal_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_minimal_matmul.py
@@ -168,13 +168,12 @@ def test_linear(device, M, K, N, M_block_size, K_block_size, N_block_size, subbl
     assert check_result["relative_rmse"] < 0.02
 
 
-# Regression guard for issue #50154 finding #19: the granular output-writer path
-# (write_block_sync_granular) must flush each row's write-source reads out of the cb_out slot before
-# cb_pop_front releases it back to the compute producer, otherwise the producer can repack the freed
-# slot while the writes are still reading it (WAR on the output CB) -> corrupt output. The race is
-# latent (timing-masked); this shape drives the output-writer core through the granular-write path
-# (verified: it corrupts under a forced source-slot clobber pre-fix) and turns a future ordering
-# regression into a PCC failure.
+# Correctness guard for the granular output-writer path (write_block_sync_granular): each row's
+# write-source reads out of the cb_out slot must be flushed before cb_pop_front releases it back to
+# the compute producer, otherwise the producer can repack the freed slot while the writes are still
+# reading it (WAR on the output CB) and corrupt the output. This shape drives the output-writer core
+# through the granular-write path and turns an ordering regression there into a PCC failure; the WAR
+# is timing-masked, so this is a value-correctness guard, not a deterministic reproducer.
 @pytest.mark.parametrize(
     "M, K, N",
     [(4096, 512, 2048)],
@@ -197,12 +196,10 @@ def test_linear_granular_write_ordering(
         subblock_h,
         subblock_w,
     )
-assert check_result["pcc"] > 0.999_500, (
-    f'Expected PCC > 0.999500, got {check_result["pcc"]}'
-)
-assert check_result["relative_rmse"] < 0.02, (
-    f'Expected relative RMSE < 0.02, got {check_result["relative_rmse"]}'
-)
+
+
+assert check_result["pcc"] > 0.999_500, f'Expected PCC > 0.999500, got {check_result["pcc"]}'
+assert check_result["relative_rmse"] < 0.02, f'Expected relative RMSE < 0.02, got {check_result["relative_rmse"]}'
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_minimal_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_minimal_matmul.py
@@ -168,6 +168,39 @@ def test_linear(device, M, K, N, M_block_size, K_block_size, N_block_size, subbl
     assert check_result["relative_rmse"] < 0.02
 
 
+# Regression guard for issue #50154 finding #19: the granular output-writer path
+# (write_block_sync_granular) must flush each row's write-source reads out of the cb_out slot before
+# cb_pop_front releases it back to the compute producer, otherwise the producer can repack the freed
+# slot while the writes are still reading it (WAR on the output CB) -> corrupt output. The race is
+# latent (timing-masked); this shape drives the output-writer core through the granular-write path
+# (verified: it corrupts under a forced source-slot clobber pre-fix) and turns a future ordering
+# regression into a PCC failure.
+@pytest.mark.parametrize(
+    "M, K, N",
+    [(4096, 512, 2048)],
+)
+@pytest.mark.parametrize(
+    "M_block_size, K_block_size, N_block_size, subblock_h, subblock_w",
+    [(8, 8, 8, 2, 2)],
+)
+def test_linear_granular_write_ordering(
+    device, M, K, N, M_block_size, K_block_size, N_block_size, subblock_h, subblock_w
+):
+    check_result = run_test_linear(
+        device,
+        M,
+        K,
+        N,
+        M_block_size,
+        K_block_size,
+        N_block_size,
+        subblock_h,
+        subblock_w,
+    )
+    assert check_result["pcc"] > 0.999_500
+    assert check_result["relative_rmse"] < 0.02
+
+
 @pytest.mark.parametrize(
     "M, K, N, M_block_size, K_block_size, N_block_size, subblock_h, subblock_w",
     [(512, 512, 512, 1, 1, 1, 1, 1)],

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_minimal_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_minimal_matmul.py
@@ -197,9 +197,8 @@ def test_linear_granular_write_ordering(
         subblock_w,
     )
 
-
-assert check_result["pcc"] > 0.999_500, f'Expected PCC > 0.999500, got {check_result["pcc"]}'
-assert check_result["relative_rmse"] < 0.02, f'Expected relative RMSE < 0.02, got {check_result["relative_rmse"]}'
+    assert check_result["pcc"] > 0.999_500, f'Expected PCC > 0.999500, got {check_result["pcc"]}'
+    assert check_result["relative_rmse"] < 0.02, f'Expected relative RMSE < 0.02, got {check_result["relative_rmse"]}'
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_minimal_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_minimal_matmul.py
@@ -197,8 +197,12 @@ def test_linear_granular_write_ordering(
         subblock_h,
         subblock_w,
     )
-    assert check_result["pcc"] > 0.999_500
-    assert check_result["relative_rmse"] < 0.02
+assert check_result["pcc"] > 0.999_500, (
+    f'Expected PCC > 0.999500, got {check_result["pcc"]}'
+)
+assert check_result["relative_rmse"] < 0.02, (
+    f'Expected relative RMSE < 0.02, got {check_result["relative_rmse"]}'
+)
 
 
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/matmul_dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/matmul_dataflow_common.hpp
@@ -330,7 +330,6 @@ void write_block_sync_granular(
         noc_async_writes_flushed();
         cb_pop_front(cb_id_out, N_block_tiles);
     }
-    noc_async_writes_flushed();
 }
 
 /**
@@ -462,5 +461,4 @@ void write_block_sync_granular_split(
         noc_async_writes_flushed();
         cb_pop_front(cb_id_out, N_block_tiles);
     }
-    noc_async_writes_flushed();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/matmul_dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/matmul_dataflow_common.hpp
@@ -327,8 +327,6 @@ void write_block_sync_granular(
         // Drain this row's outstanding write-source reads out of the cb_out L1 slot BEFORE cb_pop_front
         // releases it back to the compute producer. Otherwise the producer can repack the freed slot while
         // the noc_async_write_page reads are still in flight (WAR on the output CB source) -> corrupt output.
-        // The pre-fix code kept a single trailing flush that drained the reads only after every slot had
-        // already been released. See issue #50154 (finding #19).
         noc_async_writes_flushed();
         cb_pop_front(cb_id_out, N_block_tiles);
     }
@@ -460,7 +458,7 @@ void write_block_sync_granular_split(
             }
         }
         // Flush this row's write-source reads out of the cb_out slot before releasing it (same WAR on the
-        // output CB as write_block_sync_granular above; issue #50154 finding #19).
+        // output CB as write_block_sync_granular above).
         noc_async_writes_flushed();
         cb_pop_front(cb_id_out, N_block_tiles);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/matmul_dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/matmul_dataflow_common.hpp
@@ -324,6 +324,12 @@ void write_block_sync_granular(
                 out_read_ptr += tile_size_bytes;
             }
         }
+        // Drain this row's outstanding write-source reads out of the cb_out L1 slot BEFORE cb_pop_front
+        // releases it back to the compute producer. Otherwise the producer can repack the freed slot while
+        // the noc_async_write_page reads are still in flight (WAR on the output CB source) -> corrupt output.
+        // The pre-fix code kept a single trailing flush that drained the reads only after every slot had
+        // already been released. See issue #50154 (finding #19).
+        noc_async_writes_flushed();
         cb_pop_front(cb_id_out, N_block_tiles);
     }
     noc_async_writes_flushed();
@@ -453,6 +459,9 @@ void write_block_sync_granular_split(
                 out_read_ptr += tile_size_bytes;
             }
         }
+        // Flush this row's write-source reads out of the cb_out slot before releasing it (same WAR on the
+        // output CB as write_block_sync_granular above; issue #50154 finding #19).
+        noc_async_writes_flushed();
         cb_pop_front(cb_id_out, N_block_tiles);
     }
     noc_async_writes_flushed();


### PR DESCRIPTION
## Summary
Fixes #50363 (sub-issue of #50154, finding #19).

The granular output-writer helpers `write_block_sync_granular` and `write_block_sync_granular_split`
(`minimal_matmul/device/kernels/matmul_dataflow_common.hpp`) release each output-CB row back to the
compute producer with `cb_pop_front` **before** the row's output `noc_async_write_page`s have drained.
The only `noc_async_writes_flushed()` was a single trailing flush *after* the whole per-row loop:

```cpp
for (m_id ...) {
    cb_wait_front(cb_id_out, N_block_tiles);
    ... noc_async_write_page(tile_id, tensor_accessor, out_read_ptr) ...  // reads the cb_out slot
    cb_pop_front(cb_id_out, N_block_tiles);                               // frees the slot to compute
}
noc_async_writes_flushed();                                              // drains AFTER every pop
```

`cb_pop_front` hands the `cb_out` L1 slot back to the compute (packer) producer, but the row's output
writes are still reading it. The compute producer can repack the freed slot while the write engine is
still sourcing from it — a **WAR on the output CB source** → corrupt output tiles. (The non-granular
`write_block_sync` is safe: it never pops inside the loop; its caller pops the block only after the
flush.)

Latent on WormholeB0 because the output write normally departs before the compute producer catches up
and repacks the slot.

## Reproduction (deterministic, via forced perturbation)
The race is timing-masked, so — as with the argmax/sort race PRs — it is reproduced by forcing the
timing. In `write_block_sync_granular`, poison the just-written source slot immediately after issuing
its `noc_async_write_page`s and before `cb_pop_front` (standing in for the compute producer's early
repack of the popped slot):

```cpp
... noc_async_write_page(...) ...
// forced perturbation (not shipped): poison the source slot before it is released
volatile tt_l1_ptr uint32_t* pp = (volatile tt_l1_ptr uint32_t*)row_base;
for (uint32_t w = 0; w < (N_block_tiles * tile_size_bytes) >> 2; w++) pp[w] = 0x7f7f7f7f;
cb_pop_front(cb_id_out, N_block_tiles);
```

`test_minimal_matmul.py::test_linear` (and the new `test_linear_granular_write_ordering`, shape
M=4096,K=512,N=2048, which drives the output-writer core through the granular path), WormholeB0:
- **without the fix** → output corrupt (poison lands in DRAM, `relative_rmse=inf`), 3/3
- **with the fix** (flush before the pop) → correct output (PCC 0.9999915), 3/3
- identical perturbation both times; the fix is the only difference.

## Fix
Move `noc_async_writes_flushed()` to **before** `cb_pop_front` inside the per-row loop in both
`write_block_sync_granular` and `write_block_sync_granular_split`, so each row's write-source reads are
drained out of the slot before it is released to the producer. `noc_async_writes_flushed()` (writes
departed L1) is the minimal source-reuse-safety primitive; the compute producer already gates the next
row via `cb_wait_front`, so the per-row drain overlaps with compute.

## Test
Adds `test_linear_granular_write_ordering`: a matmul shape that routes work through the granular
output-writer path and asserts PCC/RMSE. The race is latent (needs timing pressure), so this guards
correctness of the granular path and converts a future ordering regression into a PCC failure rather
than a naturally-failing pre-fix test.

## Verification (WormholeB0, on-device)
- Forced discriminator: buggy+clobber corrupts (rmse=inf) 3/3; fixed+clobber correct 3/3; identical perturbation.
- `test_minimal_matmul.py::test_linear` + `test_linear_granular_write_ordering`: **2 passed** (no perturbation).
- `test_minimal_matmul_split.py` (granular_split path): 31 passed (subset covering split-path shapes/bias/variable-chunks).

Refs #50154 (finding #19).


🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/minimal-matmul-granular-flush-before-pop)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/minimal-matmul-granular-flush-before-pop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/minimal-matmul-granular-flush-before-pop)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/minimal-matmul-granular-flush-before-pop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/minimal-matmul-granular-flush-before-pop)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/minimal-matmul-granular-flush-before-pop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/minimal-matmul-granular-flush-before-pop)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/minimal-matmul-granular-flush-before-pop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/minimal-matmul-granular-flush-before-pop)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/minimal-matmul-granular-flush-before-pop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/minimal-matmul-granular-flush-before-pop)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/minimal-matmul-granular-flush-before-pop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/minimal-matmul-granular-flush-before-pop)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/minimal-matmul-granular-flush-before-pop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/minimal-matmul-granular-flush-before-pop)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/minimal-matmul-granular-flush-before-pop)