### PR TITLE
[pad_multi_core] Barrier the loop-back read before reusing the pad-align scratch (#50365)

### DIFF
--- a/tech_reports/prog_examples/pad_multi_core/pad_multi_core.md
+++ b/tech_reports/prog_examples/pad_multi_core/pad_multi_core.md
@@ -275,6 +275,10 @@ In the reader kernel, we specify the DRAM buffer address generators for the inpu
                     noc_async_read(read_noc_addr, get_write_ptr(cb_pad_align), stick_size_bytes);
                     noc_async_read_barrier();
                     noc_async_read(pad_align_noc_addr, l1_write_addr, stick_size_bytes);
+                    // Drain the loop-back read (which sources from cb_pad_align) before the next
+                    // stick's read-in writes into cb_pad_align, or that read-in can land while this
+                    // read is still sourcing from it (WAR on the shared scratch).
+                    noc_async_read_barrier();
                 } else {
                     noc_async_read(read_noc_addr, l1_write_addr, stick_size_bytes);
                 }

--- a/tech_reports/prog_examples/pad_multi_core/pad_multi_core.md
+++ b/tech_reports/prog_examples/pad_multi_core/pad_multi_core.md
@@ -275,9 +275,9 @@ In the reader kernel, we specify the DRAM buffer address generators for the inpu
                     noc_async_read(read_noc_addr, get_write_ptr(cb_pad_align), stick_size_bytes);
                     noc_async_read_barrier();
                     noc_async_read(pad_align_noc_addr, l1_write_addr, stick_size_bytes);
-                    // Drain the loop-back read (which sources from cb_pad_align) before the next
-                    // stick's read-in writes into cb_pad_align, or that read-in can land while this
-                    // read is still sourcing from it (WAR on the shared scratch).
+                    // Drain this loop-back read out of cb_pad_align before the next stick's read-in
+                    // overwrites that shared scratch, else the read-in can land while this read is still
+                    // sourcing from it (WAR on cb_pad_align).
                     noc_async_read_barrier();
                 } else {
                     noc_async_read(read_noc_addr, l1_write_addr, stick_size_bytes);

--- a/tt_metal/programming_examples/pad_multi_core/kernels/pad_reader_dims_rm_interleaved.cpp
+++ b/tt_metal/programming_examples/pad_multi_core/kernels/pad_reader_dims_rm_interleaved.cpp
@@ -93,7 +93,7 @@ void kernel_main() {
                     noc_async_read_barrier();
                     noc_async_read(pad_align_noc_addr, l1_write_addr, stick_size_bytes);
                     // Drain this stick's loop-back read OUT of cb_pad_align before the next stick's read
-                    // (above) overwrites cb_pad_align. Both target the same scratch, so without this barrier
+                    // (above) overwrites cb_pad_align. Both access the same scratch, so without this barrier
                     // the next read-in can land while this read-out is still sourcing from it (WAR on the
                     // shared scratch). See issue #50154 (finding #9).
                     noc_async_read_barrier();

--- a/tt_metal/programming_examples/pad_multi_core/kernels/pad_reader_dims_rm_interleaved.cpp
+++ b/tt_metal/programming_examples/pad_multi_core/kernels/pad_reader_dims_rm_interleaved.cpp
@@ -84,11 +84,19 @@ void kernel_main() {
                 if constexpr (front_padding) {
                     noc_async_read(read_noc_addr, get_write_ptr(cb_pad_align), stick_size_bytes);
                     noc_async_read_barrier();
-                    memmove((void*)(l1_write_addr + stick_size_padded_front), (void*)(get_read_ptr(cb_pad_align)), (size_t)(stick_size_bytes));
+                    memmove(
+                        (void*)(l1_write_addr + stick_size_padded_front),
+                        (void*)(get_read_ptr(cb_pad_align)),
+                        (size_t)(stick_size_bytes));
                 } else if constexpr (unaligned) {
                     noc_async_read(read_noc_addr, get_write_ptr(cb_pad_align), stick_size_bytes);
                     noc_async_read_barrier();
                     noc_async_read(pad_align_noc_addr, l1_write_addr, stick_size_bytes);
+                    // Drain this stick's loop-back read OUT of cb_pad_align before the next stick's read
+                    // (above) overwrites cb_pad_align. Both target the same scratch, so without this barrier
+                    // the next read-in can land while this read-out is still sourcing from it (WAR on the
+                    // shared scratch). See issue #50154 (finding #9).
+                    noc_async_read_barrier();
                 } else {
                     noc_async_read(read_noc_addr, l1_write_addr, stick_size_bytes);
                 }

--- a/tt_metal/programming_examples/pad_multi_core/kernels/pad_reader_dims_rm_interleaved.cpp
+++ b/tt_metal/programming_examples/pad_multi_core/kernels/pad_reader_dims_rm_interleaved.cpp
@@ -92,10 +92,9 @@ void kernel_main() {
                     noc_async_read(read_noc_addr, get_write_ptr(cb_pad_align), stick_size_bytes);
                     noc_async_read_barrier();
                     noc_async_read(pad_align_noc_addr, l1_write_addr, stick_size_bytes);
-                    // Drain this stick's loop-back read OUT of cb_pad_align before the next stick's read
-                    // (above) overwrites cb_pad_align. Both access the same scratch, so without this barrier
-                    // the next read-in can land while this read-out is still sourcing from it (WAR on the
-                    // shared scratch). See issue #50154 (finding #9).
+                    // Drain this loop-back read out of cb_pad_align before the next stick's read-in
+                    // overwrites that shared scratch, else the read-in can land while this read is still
+                    // sourcing from it (WAR on cb_pad_align).
                     noc_async_read_barrier();
                 } else {
                     noc_async_read(read_noc_addr, l1_write_addr, stick_size_bytes);


### PR DESCRIPTION
## Summary
Fixes #50365 (sub-issue of #50154, finding #9).

In the `unaligned` branch of `pad_reader_dims_rm_interleaved.cpp`, each stick reads its data into
`cb_pad_align`, then loops back and reads **out** of `cb_pad_align` into the destination:

```cpp
noc_async_read(read_noc_addr, get_write_ptr(cb_pad_align), stick_size_bytes);  // read IN
noc_async_read_barrier();                                                       // drains the read-IN only
noc_async_read(pad_align_noc_addr, l1_write_addr, stick_size_bytes);            // loop-back read OUT
```

The barrier covers only the read-IN. The loop-back read-OUT (source = `cb_pad_align`) has no barrier
before the **next** stick's read-IN overwrites the same `cb_pad_align` scratch. Both target the same L1
buffer, so the next read-in can land while the previous read-out is still sourcing from it — a **WAR on
the shared scratch**.

## Fix
Add `noc_async_read_barrier()` after the loop-back read, before the next stick can reissue its read-in.

## Why this isn't covered by a fails-without/passes-with test
The race is latent (timing-masked) and this is a **programming example** whose host only `printf`s the
tensors — there is no golden/assert to hang a regression test on, and the NoC-read-vs-read WAR can only
be amplified probabilistically (e.g. same-L1-bank contention), not turned into a deterministic
discriminator. See the sub-issue for detail.

> Note: this finding was audited on Wormhole B0 (#50154); the baby-RISCV store / NoC memory-ordering it relies on holds identically on Blackhole, where the verification below was run.
## Verification (Blackhole p150b)
- Builds clean (`metal_example_pad_multi_core`).
- Runs to completion and prints the expected padded output (real data followed by the pad value) — i.e.
  **no functional regression** from the added barrier.

Refs #50154 (finding #9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/pad-multi-core-loopback-war-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/pad-multi-core-loopback-war-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/pad-multi-core-loopback-war-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/pad-multi-core-loopback-war-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/pad-multi-core-loopback-war-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/pad-multi-core-loopback-war-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/pad-multi-core-loopback-war-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/pad-multi-core-loopback-war-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/pad-multi-core-loopback-war-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/pad-multi-core-loopback-war-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/pad-multi-core-loopback-war-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/pad-multi-core-loopback-war-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/pad-multi-core-loopback-war-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/pad-multi-core-loopback-war-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/pad-multi-core-loopback-war-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/pad-multi-core-loopback-war-barrier)

