### PR TITLE
[add_2_integers_in_riscv] Force RISC store to land before the NoC reads it (50367)

### DIFF
--- a/tt_metal/programming_examples/add_2_integers_in_riscv/kernels/reader_writer_add_in_riscv.cpp
+++ b/tt_metal/programming_examples/add_2_integers_in_riscv/kernels/reader_writer_add_in_riscv.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "ckernel.h"
+
 void kernel_main() {
     uint32_t src0_dram = get_arg_val<uint32_t>(0);
     uint32_t src1_dram = get_arg_val<uint32_t>(1);
@@ -39,6 +41,15 @@ void kernel_main() {
     DPRINT("Adding integers: {} + {}\n", *dat0, *dat1);
 
     (*out0) = (*dat0) + (*dat1);
+
+    // The line above is a baby-RISCV store to L1. Such a store can *retire* before its write-request is
+    // actually processed into the L1 bank, and the RISCV core and the NoC are different L1 clients with no
+    // program-order guarantee between them (see WormholeB0/TensixTile/BabyRISCV/MemoryOrdering.md). The
+    // noc_async_write below reads dst_l1 as its *source*, so without forcing the store to land first the
+    // NoC could read a stale value. load_blocking issues the load, blocks the pipeline on a dependent
+    // instruction, and adds a memory clobber; per the ISA doc this guarantees the store has been processed
+    // before the subsequent NoC request is issued. (issue #50154 finding #8)
+    (void)ckernel::load_blocking(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dst_l1));
 
     // Write data from L1 -> DRAM. Again this is a non-blocking operation.
     // Thus we need to use noc_async_write_barrier() to wait until the data is

--- a/tt_metal/programming_examples/add_2_integers_in_riscv/kernels/reader_writer_add_in_riscv.cpp
+++ b/tt_metal/programming_examples/add_2_integers_in_riscv/kernels/reader_writer_add_in_riscv.cpp
@@ -42,13 +42,10 @@ void kernel_main() {
 
     (*out0) = (*dat0) + (*dat1);
 
-    // The line above is a baby-RISCV store to L1. Such a store can *retire* before its write-request is
-    // actually processed into the L1 bank, and the RISCV core and the NoC are different L1 clients with no
-    // program-order guarantee between them (see WormholeB0/TensixTile/BabyRISCV/MemoryOrdering.md). The
-    // noc_async_write below reads dst_l1 as its *source*, so without forcing the store to land first the
-    // NoC could read a stale value. load_blocking issues the load, blocks the pipeline on a dependent
-    // instruction, and adds a memory clobber; per the ISA doc this guarantees the store has been processed
-    // before the subsequent NoC request is issued. (issue #50154 finding #8)
+    // Force the store above to land in L1 before the noc_async_write below reads dst_l1 as its source.
+    // A baby-RISCV store can retire before it lands, and the RISCV and NoC are independent L1 clients with
+    // no ordering between them (MemoryOrdering.md), so the NoC could otherwise read a stale value.
+    // load_blocking stalls the pipeline until the store is processed.
     (void)ckernel::load_blocking(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dst_l1));
 
     // Write data from L1 -> DRAM. Again this is a non-blocking operation.


### PR DESCRIPTION
## Summary
Fixes #50367 (sub-issue of #50154, finding #8) — see #50367.

The kernel stores the sum into `dst_l1` with a baby-RISCV store, then issues `noc_async_write` whose
**source** is `dst_l1`. Per `WormholeB0/TensixTile/BabyRISCV/MemoryOrdering.md` a store can retire
before its write-request is processed into the L1 bank, and the RISCV core and NoC are different L1
clients synchronizing only at the bank (arrival order) — so the NoC can read a stale value.

## Fix
Use `ckernel::load_blocking` (blocking load + memory clobber) to read the sum back before
`noc_async_write`. Per the ISA doc, a same-address load-back that is consumed guarantees the store has
been processed before the subsequent NoC request is issued.

## Why this isn't covered by a fails-without/passes-with test
It's a **single store** masked by timing; there is no way to delay one store's landing on baby-RISCV
(`fence` is a no-op) and no reusable source slot to clobber. The window can only be widened
**probabilistically** via same-L1-bank contention — a flaky amplifier, not a deterministic discriminator.
Full reasoning in the sub-issue.

> Note: this finding was audited on Wormhole B0 (#50154); the baby-RISCV store / NoC memory-ordering it relies on holds identically on Blackhole, where the verification below was run.
## Verification (Blackhole p150b)
- Builds clean (`metal_example_add_2_integers_in_riscv`).
- Runs and prints **`Success: Result is 21`** (the example's own golden check) — no functional regression.

Refs #50154 (finding #8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/add2int-store-visibility-before-noc-read)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/add2int-store-visibility-before-noc-read)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/add2int-store-visibility-before-noc-read)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/add2int-store-visibility-before-noc-read)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/add2int-store-visibility-before-noc-read)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/add2int-store-visibility-before-noc-read)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/add2int-store-visibility-before-noc-read)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/add2int-store-visibility-before-noc-read)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/add2int-store-visibility-before-noc-read)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/add2int-store-visibility-before-noc-read)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/add2int-store-visibility-before-noc-read)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/add2int-store-visibility-before-noc-read)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/add2int-store-visibility-before-noc-read)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/add2int-store-visibility-before-noc-read)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/add2int-store-visibility-before-noc-read)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/add2int-store-visibility-before-noc-read)