### PR TITLE
[pad] Force pad-fill stores to land before the loop-back read of cb_pad (#50369)

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved_v2.cpp
@@ -11,6 +11,7 @@
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "ckernel.h"
 
 inline __attribute__((always_inline)) void fill_pad_cb_with_val(
     const uint32_t cb_id, const uint32_t num_bytes, const uint32_t val) {
@@ -96,6 +97,14 @@ void kernel_main() {
     const uint32_t pad_align_addr = dfb_pad_align_exp.get_read_ptr();
 
     fill_pad_cb_with_val(cb_pad, stick_size_padded, packed_pad_value);
+    // The fill above is baby-RISCV stores; the per-stick loop below loop-back noc.async_read's cb_pad as
+    // its source. A baby-RISCV store can retire before its write-request lands in L1, and the RISCV core
+    // and NoC are different L1 clients with no program-order guarantee between them
+    // (WormholeB0/TensixTile/BabyRISCV/MemoryOrdering.md). load_blocking the last filled word (blocking
+    // load + memory clobber) to force the fill to be processed before the first loop-back read is issued.
+    // One-time cost, outside the per-stick loop. See issue #50154 (finding #13).
+    (void)ckernel::load_blocking(
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(pad_val_addr) + (stick_size_padded / 2) - 1);
 
     uint32_t i_page = start_page_id;
     uint32_t curr_c = start_dim_offset[2], curr_h = start_dim_offset[1], curr_n = start_dim_offset[3];

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved_v2.cpp
@@ -18,7 +18,7 @@ inline __attribute__((always_inline)) void fill_pad_cb_with_val(
     DataflowBuffer dfb(cb_id);
     volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dfb.get_write_ptr());
 
-    for (uint32_t i = 0; i < num_bytes / 2; ++i) {
+    for (uint32_t i = 0; i < num_bytes / sizeof(uint32_t); ++i) {
         ptr[i] = val;
     }
 }
@@ -104,7 +104,7 @@ void kernel_main() {
     // load + memory clobber) to force the fill to be processed before the first loop-back read is issued.
     // One-time cost, outside the per-stick loop.
     (void)ckernel::load_blocking(
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(pad_val_addr) + (stick_size_padded / 2) - 1);
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(pad_val_addr) + (stick_size_padded / sizeof(uint32_t)) - 1);
 
     uint32_t i_page = start_page_id;
     uint32_t curr_c = start_dim_offset[2], curr_h = start_dim_offset[1], curr_n = start_dim_offset[3];

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved_v2.cpp
@@ -102,7 +102,7 @@ void kernel_main() {
     // and NoC are different L1 clients with no program-order guarantee between them
     // (WormholeB0/TensixTile/BabyRISCV/MemoryOrdering.md). load_blocking the last filled word (blocking
     // load + memory clobber) to force the fill to be processed before the first loop-back read is issued.
-    // One-time cost, outside the per-stick loop. See issue #50154 (finding #13).
+    // One-time cost, outside the per-stick loop.
     (void)ckernel::load_blocking(
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(pad_val_addr) + (stick_size_padded / 2) - 1);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved_v2.cpp
@@ -18,7 +18,9 @@ inline __attribute__((always_inline)) void fill_pad_cb_with_val(
     DataflowBuffer dfb(cb_id);
     volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dfb.get_write_ptr());
 
-    for (uint32_t i = 0; i < num_bytes / sizeof(uint32_t); ++i) {
+    // Round up so a non-4-byte-aligned tail stick is fully filled (the loop-back read consumes all num_bytes).
+    const uint32_t num_words = (num_bytes + sizeof(uint32_t) - 1) / sizeof(uint32_t);
+    for (uint32_t i = 0; i < num_words; ++i) {
         ptr[i] = val;
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved_v2.cpp
@@ -25,7 +25,9 @@
 inline __attribute__((always_inline)) void fill_pad_dfb_with_val(
     DataflowBuffer& cb, const uint32_t num_bytes, const uint32_t val) {
     volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb.get_write_ptr());
-    for (uint32_t i = 0; i < num_bytes / sizeof(uint32_t); ++i) {
+    // Round up so a non-4-byte-aligned tail stick is fully filled (the loop-back read consumes all num_bytes).
+    const uint32_t num_words = (num_bytes + sizeof(uint32_t) - 1) / sizeof(uint32_t);
+    for (uint32_t i = 0; i < num_words; ++i) {
         ptr[i] = val;
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved_v2.cpp
@@ -25,7 +25,7 @@
 inline __attribute__((always_inline)) void fill_pad_dfb_with_val(
     DataflowBuffer& cb, const uint32_t num_bytes, const uint32_t val) {
     volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb.get_write_ptr());
-    for (uint32_t i = 0; i < num_bytes / 2; ++i) {
+    for (uint32_t i = 0; i < num_bytes / sizeof(uint32_t); ++i) {
         ptr[i] = val;
     }
 }


### PR DESCRIPTION
## Summary
Fixes #50369 (sub-issue of #50154, finding #13).

`reader_pad_dims_rm_interleaved_v2.cpp` fills `cb_pad` with baby-RISCV stores, then the per-stick loop
loop-back `noc.async_read`s `cb_pad` as its source. A baby-RISCV store can retire before its
write-request lands in L1, and the RISCV core and NoC are different L1 clients with no program-order
guarantee (`WormholeB0/TensixTile/BabyRISCV/MemoryOrdering.md`), so the NoC could read a partially-filled
pad buffer.

## Fix
After the fill, `ckernel::load_blocking` the last filled word of `cb_pad` once (before the loop), forcing
the fill to be processed before the first loop-back read. **One-time cost, outside the per-stick loop.**

The auditor classified this pattern **by-design / pervasive** (the one-time fill lands well before the
first read in practice); this makes the ordering explicit per the ISA doc.

## Why this isn't covered by a fails-without/passes-with test
Same class as finding #8: a bounded store set masked by timing, no lever to delay stores on baby-RISCV,
no source slot to clobber; only same-L1-bank contention can amplify it, probabilistically. Detail in the
sub-issue.

> Note: this finding was audited on Wormhole B0 (#50154); the baby-RISCV store / NoC memory-ordering it relies on holds identically on Blackhole, where the verification below was run.
## Verification (Blackhole p150b)
- `test_pad.py::test_pad_rm` + `test_pad_rm_small_to_large_width`: **21 passed** (no regression).

Refs #50154 (finding #13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/pad-v2-fill-store-visibility)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/pad-v2-fill-store-visibility)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/pad-v2-fill-store-visibility)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/pad-v2-fill-store-visibility)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/pad-v2-fill-store-visibility)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/pad-v2-fill-store-visibility)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/pad-v2-fill-store-visibility)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/pad-v2-fill-store-visibility)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/pad-v2-fill-store-visibility)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/pad-v2-fill-store-visibility)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/pad-v2-fill-store-visibility)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/pad-v2-fill-store-visibility)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/pad-v2-fill-store-visibility)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/pad-v2-fill-store-visibility)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/pad-v2-fill-store-visibility)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/pad-v2-fill-store-visibility)