### PR TITLE
[masked_bincount] Drain tree-add stores before signaling the parent (#50371)

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/kernels/reader_masked_bincount.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/kernels/reader_masked_bincount.cpp
@@ -57,6 +57,7 @@
 #include "api/dataflow/noc_semaphore.h"
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
+#include "ckernel.h"
 
 void kernel_main() {
     Noc noc;
@@ -195,6 +196,13 @@ void kernel_main() {
         }
 
         if (parent_noc_x != 0xFFFFFFFF) {
+            // Force the tree-add stores into local_hist (== out_addr) to be processed into L1 BEFORE we
+            // signal the parent, which then NoC-reads this core's out_addr. A baby-RISCV store can retire
+            // before its write-request lands, and gather_sem.up() is an MMIO/NoC store that can race ahead
+            // of the L1 stores (WormholeB0/.../MemoryOrdering.md; NoC/Ordering.md: an MMIO write can race
+            // ahead of an L1 write). load_blocking the last accumulated word (blocking load + memory
+            // clobber) to drain the tree-add stores first. See issue #50154 (finding #16).
+            (void)ckernel::load_blocking(local_hist + (n_routed_experts - 1));
             // Bump parent's gather_sem (a real semaphore id resolved on each core).
             gather_sem.up(noc, parent_noc_x, parent_noc_y, 1);
             noc.async_atomic_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/kernels/reader_masked_bincount.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/kernels/reader_masked_bincount.cpp
@@ -201,7 +201,7 @@ void kernel_main() {
             // before its write-request lands, and gather_sem.up() is an MMIO/NoC store that can race ahead
             // of the L1 stores (WormholeB0/.../MemoryOrdering.md; NoC/Ordering.md: an MMIO write can race
             // ahead of an L1 write). load_blocking the last accumulated word (blocking load + memory
-            // clobber) to drain the tree-add stores first. See issue #50154 (finding #16).
+            // clobber) to drain the tree-add stores first.
             (void)ckernel::load_blocking(local_hist + (n_routed_experts - 1));
             // Bump parent's gather_sem (a real semaphore id resolved on each core).
             gather_sem.up(noc, parent_noc_x, parent_noc_y, 1);


### PR DESCRIPTION
## Summary
Fixes #50371 (sub-issue of #50154, finding #16).

In the histogram tree reduction, each node accumulates children's counts into `local_hist` (==
`out_addr`) with baby-RISCV stores, then `gather_sem.up()`'s its parent, which NoC-reads this node's
`out_addr`. A baby-RISCV store can retire before its write-request lands in L1, and `gather_sem.up()` is
an MMIO/NoC store that can race ahead of the L1 stores
(`WormholeB0/TensixTile/BabyRISCV/MemoryOrdering.md`; `NoC/Ordering.md`) — so the parent can read a
partially-accumulated histogram.

## Fix
Before the `up()`, `ckernel::load_blocking` the last accumulated word (`local_hist[n_routed_experts-1]`),
forcing the tree-add stores to be processed before the signal is issued.

## Why this isn't covered by a fails-without/passes-with test
The signal is a NoC round-trip (up → parent wakes → parent reads back), so the stores land with huge
margin; same store-visibility class as #8/#13 (no lever to delay baby-RISCV stores, no source slot to
clobber; only same-L1-bank contention amplifies it, probabilistically). Detail in the sub-issue.

> Note: this finding was audited on Wormhole B0 (#50154); the baby-RISCV store / NoC memory-ordering it relies on holds identically on Blackhole, where the verification below was run.
## Verification (Blackhole p150b)
- `test_masked_bincount.py`: the runnable (single-topology) case **passes** with the fix compiled in
  (correct histograms vs torch); others skipped for lack of mesh topology. No regression.

Refs #50154 (finding #16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/masked-bincount-store-before-signal)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/masked-bincount-store-before-signal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/masked-bincount-store-before-signal)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/masked-bincount-store-before-signal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/masked-bincount-store-before-signal)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/masked-bincount-store-before-signal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/masked-bincount-store-before-signal)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/masked-bincount-store-before-signal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/masked-bincount-store-before-signal)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/masked-bincount-store-before-signal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/masked-bincount-store-before-signal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/masked-bincount-store-before-signal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/masked-bincount-store-before-signal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/masked-bincount-store-before-signal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/masked-bincount-store-before-signal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/masked-bincount-store-before-signal)