### PR TITLE
[deepseek_grouped_gate] Drain first-line fill before loop-back replication read (#50373)

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_grouped_gate/device/kernels/dataflow/writer_deepseek_grouped_gate.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_grouped_gate/device/kernels/dataflow/writer_deepseek_grouped_gate.cpp
@@ -51,7 +51,7 @@ FORCE_INLINE void generate_index_tile(
         // A baby-RISCV store can retire before its write-request lands, and the RISCV core and the NoC are
         // different L1 clients with no program-order guarantee (WormholeB0/.../MemoryOrdering.md); read the
         // last written word (blocking load + memory clobber) so the fill is visible before the NoC read is
-        // issued. See issue #50154 (finding #23).
+        // issued.
         (void)ckernel::load_blocking(index_cb_ptr + ((columns_per_face / 2) - 1));
         // then use noc to write the rest of the face
         uint32_t dm_engine_index_write_offset = index_write_face_offset + face_line_bytes;

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_grouped_gate/device/kernels/dataflow/writer_deepseek_grouped_gate.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_grouped_gate/device/kernels/dataflow/writer_deepseek_grouped_gate.cpp
@@ -9,6 +9,7 @@
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
+#include "ckernel.h"
 
 // Tile geometry constants for bf16 32x32 tiles with 16x16 faces
 namespace tile_constants {
@@ -45,6 +46,13 @@ FORCE_INLINE void generate_index_tile(
             index_cb_ptr[i] = (current_index + 1) << 16 | current_index;
             current_index += 2;
         }
+        // Force the first-line RISC stores above to be processed into L1 before the loop-back
+        // noc_async_read below reads that line (base_index_noc_addr) to replicate it to the other rows.
+        // A baby-RISCV store can retire before its write-request lands, and the RISCV core and the NoC are
+        // different L1 clients with no program-order guarantee (WormholeB0/.../MemoryOrdering.md); read the
+        // last written word (blocking load + memory clobber) so the fill is visible before the NoC read is
+        // issued. See issue #50154 (finding #23).
+        (void)ckernel::load_blocking(index_cb_ptr + ((columns_per_face / 2) - 1));
         // then use noc to write the rest of the face
         uint32_t dm_engine_index_write_offset = index_write_face_offset + face_line_bytes;
         for (uint32_t i = 1; i < rows_per_face; i++) {


### PR DESCRIPTION
## Summary
Fixes #50373 (sub-issue of #50154, finding #23).

`generate_index_tile` fills the first line of each face with baby-RISCV stores, then loop-back
`noc_async_read`s that line to replicate it to the other rows. A baby-RISCV store can retire before its
write-request lands in L1, and the RISCV core and NoC are different L1 clients with no program-order
guarantee (`WormholeB0/TensixTile/BabyRISCV/MemoryOrdering.md`), so the loop-back read can replicate a
partially-written line.

## Fix
`ckernel::load_blocking` the last written word of the first line before the loop-back read, forcing the
fill to be processed first.

## Why this isn't covered by a fails-without/passes-with test
Same store-visibility class as #8/#13/#16: a small fill masked by timing, no lever to delay baby-RISCV
stores, no source slot to clobber; only same-L1-bank contention amplifies it, probabilistically. Detail
in the sub-issue.

> Note: this finding was audited on Wormhole B0 (#50154); the baby-RISCV store / NoC memory-ordering it relies on holds identically on Blackhole, where the verification below was run.
## Verification (Blackhole p150b)
- `test_deepseek_grouped_gate.py`: **6 passed** (exhaustive per-row validation) with the fix compiled in.
  No regression.

Refs #50154 (finding #23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/grouped-gate-fill-store-visibility)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/grouped-gate-fill-store-visibility)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/grouped-gate-fill-store-visibility)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/grouped-gate-fill-store-visibility)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/grouped-gate-fill-store-visibility)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/grouped-gate-fill-store-visibility)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/grouped-gate-fill-store-visibility)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/grouped-gate-fill-store-visibility)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/grouped-gate-fill-store-visibility)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/grouped-gate-fill-store-visibility)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/grouped-gate-fill-store-visibility)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/grouped-gate-fill-store-visibility)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/grouped-gate-fill-store-visibility)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/grouped-gate-fill-store-visibility)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/grouped-gate-fill-store-visibility)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/grouped-gate-fill-store-visibility)