### PR TITLE
[sort] Drain index-fill stores before the NoC write reads them (#50375)

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/coordinator_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/coordinator_single_row_multi_core.cpp
@@ -114,7 +114,7 @@ void kernel_main() {
                 // the RISCV core and NoC are different L1 clients with no program-order guarantee between
                 // them (WormholeB0/TensixTile/BabyRISCV/MemoryOrdering.md). load_blocking the 32-bit word
                 // holding the last filled byte (blocking load + memory clobber) to drain the fill so the
-                // NoC write cannot source a stale index buffer. See issue #50154 (finding #27).
+                // NoC write cannot source a stale index buffer.
                 {
                     const uint32_t idx_bytes = tile_width * (is_32_bit_data ? sizeof(uint32_t) : sizeof(uint16_t));
                     (void)ckernel::load_blocking(

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/coordinator_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/coordinator_single_row_multi_core.cpp
@@ -7,6 +7,7 @@
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/noc_semaphore.h"
 #include "api/tensor/noc_traits.h"
+#include "ckernel.h"
 
 #include "sort_dataflow_common.hpp"
 
@@ -107,6 +108,17 @@ void kernel_main() {
                     for (uint32_t c = 0; c < tile_width; c++) {
                         p[c] = static_cast<uint16_t>(idx_base + c);
                     }
+                }
+                // The index buffer above is filled with baby-RISCV stores; the noc.async_write below reads
+                // it as its source. A baby-RISCV store can retire before its write-request lands in L1, and
+                // the RISCV core and NoC are different L1 clients with no program-order guarantee between
+                // them (WormholeB0/TensixTile/BabyRISCV/MemoryOrdering.md). load_blocking the 32-bit word
+                // holding the last filled byte (blocking load + memory clobber) to drain the fill so the
+                // NoC write cannot source a stale index buffer. See issue #50154 (finding #27).
+                {
+                    const uint32_t idx_bytes = tile_width * (is_32_bit_data ? sizeof(uint32_t) : sizeof(uint16_t));
+                    (void)ckernel::load_blocking(
+                        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_idx) + (idx_bytes - 1) / sizeof(uint32_t));
                 }
                 for (uint32_t row = 0; row < TILE_H; row++) {
                     noc.async_write(


### PR DESCRIPTION
## Summary
Fixes #50375 (sub-issue of #50154, finding #27).

The SingleRowMultiCore sort coordinator fills `rm_coord_index_row` with baby-RISCV stores, then
`noc.async_write`s that buffer to the output index tensor. A baby-RISCV store can retire before its
write-request lands in L1, and the RISCV core and NoC are different L1 clients with no program-order
guarantee (`WormholeB0/TensixTile/BabyRISCV/MemoryOrdering.md`), so the NoC write can source a stale
index buffer.

## Fix
`ckernel::load_blocking` the 32-bit word holding the last filled byte before the NoC
write, forcing the fill to be processed first.

The auditor classified this **UNCERTAIN** (narrow, row-0 exposure; the fill lands in practice); this makes
the ordering explicit per the ISA doc.

## Why this isn't covered by a fails-without/passes-with test
Same store-visibility class as #8/#13/#16/#23: a bounded fill masked by timing, no lever to delay
baby-RISCV stores, no source slot to clobber; only same-L1-bank contention amplifies it,
probabilistically. Detail in the sub-issue.

> Note: this finding was audited on Wormhole B0 (#50154); the baby-RISCV store / NoC memory-ordering it relies on holds identically on Blackhole, where the verification below was run.
## Verification (Blackhole p150b)
- `test_sort.py::test_sort_residual_core_range` + `test_sort_long_tensor`: **8 passed** (the
  SingleRowMultiCore path) with the fix compiled in. No regression.

Refs #50154 (finding #27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/sort-coord-index-fill-store-visibility)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/sort-coord-index-fill-store-visibility)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/sort-coord-index-fill-store-visibility)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/sort-coord-index-fill-store-visibility)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/sort-coord-index-fill-store-visibility)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/sort-coord-index-fill-store-visibility)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/sort-coord-index-fill-store-visibility)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/sort-coord-index-fill-store-visibility)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/sort-coord-index-fill-store-visibility)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/sort-coord-index-fill-store-visibility)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/sort-coord-index-fill-store-visibility)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/sort-coord-index-fill-store-visibility)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/sort-coord-index-fill-store-visibility)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/sort-coord-index-fill-store-visibility)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/sort-coord-index-fill-store-visibility)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/sort-coord-index-fill-store-visibility)