### PR TITLE
[skip ci] Move CPM dependency cache to Garage S3

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -422,6 +422,8 @@ jobs:
       TOOLCHAIN: ${{ inputs.toolchain || needs.parse-platform.outputs.toolchain }}
       CCACHE_S3_BUCKET: ccache
       CCACHE_S3_PREFIX: tt-metal
+      CPM_S3_BUCKET: cpm
+      CPM_S3_PREFIX: cpm/tt-metal
       CCACHE_S3_READONLY: "false"
       CCACHE_S3_DEBUG: "false"
     container:
@@ -591,13 +593,12 @@ jobs:
         # and let CMake configure fetch CPM sources from scratch.
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
         env:
-          CPM_S3_PREFIX: tt-metal/cpm
           CACHE_KEY: ${{ steps.cpm-key.outputs.key }}
         run: |
           set -u
           SIGV4="aws:amz:garage:s3"
           CREDS="${AWS_ACCESS_KEY_ID}:${AWS_SECRET_ACCESS_KEY}"
-          URL="${AWS_ENDPOINT_URL_S3}/${CCACHE_S3_BUCKET}/${CPM_S3_PREFIX}/${CACHE_KEY}.tar.zst"
+          URL="${AWS_ENDPOINT_URL_S3}/${CPM_S3_BUCKET}/${CPM_S3_PREFIX}/${CACHE_KEY}.tar.zst"
           echo "Restoring CPM cache from: ${URL}"
           # -f => non-2xx (incl. 404 miss) exits non-zero; --retry rides out transient blips.
           if curl -fsS --retry 3 --retry-delay 2 --max-time 120 \
@@ -667,7 +668,6 @@ jobs:
           steps.cpm-cache.outputs.hit != 'true' &&
           (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
         env:
-          CPM_S3_PREFIX: tt-metal/cpm
           CACHE_KEY: ${{ steps.cpm-key.outputs.key }}
         run: |
           set -u
@@ -677,7 +677,7 @@ jobs:
           fi
           SIGV4="aws:amz:garage:s3"
           CREDS="${AWS_ACCESS_KEY_ID}:${AWS_SECRET_ACCESS_KEY}"
-          URL="${AWS_ENDPOINT_URL_S3}/${CCACHE_S3_BUCKET}/${CPM_S3_PREFIX}/${CACHE_KEY}.tar.zst"
+          URL="${AWS_ENDPOINT_URL_S3}/${CPM_S3_BUCKET}/${CPM_S3_PREFIX}/${CACHE_KEY}.tar.zst"
           echo "Saving CPM cache to: ${URL} ($(du -h .cpmcache.tar.zst | cut -f1))"
           # Use --upload-file instead of --data-binary so curl streams the tarball
           # from disk. A 1.2 GB CPM archive caused OOM with --data-binary @file.

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -679,9 +679,12 @@ jobs:
           CREDS="${AWS_ACCESS_KEY_ID}:${AWS_SECRET_ACCESS_KEY}"
           URL="${AWS_ENDPOINT_URL_S3}/${CCACHE_S3_BUCKET}/${CPM_S3_PREFIX}/${CACHE_KEY}.tar.zst"
           echo "Saving CPM cache to: ${URL} ($(du -h .cpmcache.tar.zst | cut -f1))"
+          # Use --upload-file instead of --data-binary so curl streams the tarball
+          # from disk. A 1.2 GB CPM archive caused OOM with --data-binary @file.
           if curl -fsS --retry 3 --retry-delay 2 --max-time 300 \
-               -X PUT --aws-sigv4 "${SIGV4}" --user "${CREDS}" \
-               "${URL}" --data-binary @.cpmcache.tar.zst -o /dev/null; then
+               --upload-file .cpmcache.tar.zst \
+               --aws-sigv4 "${SIGV4}" --user "${CREDS}" \
+               "${URL}" -o /dev/null; then
             echo "CPM cache saved."
           else
             echo "::warning::CPM cache upload to Garage failed; build succeeds, next run rebuilds cache."

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -577,17 +577,39 @@ jobs:
           # ownership mismatch (host uid vs container root). Add /work to safe.directory.
           git config --global --add safe.directory /work
 
-      - name: 📦 Restore CPM source cache
+      - name: 📦 Compute CPM cache key
+        id: cpm-key
+        run: |
+          echo "key=cpm-z22-${{ hashFiles(
+            'third_party/CMakeLists.txt',
+            'tt_metal/third_party/umd/third_party/CMakeLists.txt',
+            'tt-train/cmake/dependencies.cmake') }}" >> "$GITHUB_OUTPUT"
+
+      - name: 📦 Restore CPM source cache (Garage S3)
         id: cpm-cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: .cpmcache.tar.zst
-          key: >-
-            cpm-z22-${{ hashFiles(
-              'third_party/CMakeLists.txt',
-              'tt_metal/third_party/umd/third_party/CMakeLists.txt',
-              'tt-train/cmake/dependencies.cmake') }}
-          restore-keys: cpm-z22-
+        # Same fork guard as the ccache S3 steps: forks have no secrets, so skip S3
+        # and let CMake configure fetch CPM sources from scratch.
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
+        env:
+          CPM_S3_PREFIX: tt-metal/cpm
+          CACHE_KEY: ${{ steps.cpm-key.outputs.key }}
+        run: |
+          set -u
+          SIGV4="aws:amz:garage:s3"
+          CREDS="${AWS_ACCESS_KEY_ID}:${AWS_SECRET_ACCESS_KEY}"
+          URL="${AWS_ENDPOINT_URL_S3}/${CCACHE_S3_BUCKET}/${CPM_S3_PREFIX}/${CACHE_KEY}.tar.zst"
+          echo "Restoring CPM cache from: ${URL}"
+          # -f => non-2xx (incl. 404 miss) exits non-zero; --retry rides out transient blips.
+          if curl -fsS --retry 3 --retry-delay 2 --max-time 120 \
+               --aws-sigv4 "${SIGV4}" --user "${CREDS}" \
+               "${URL}" -o .cpmcache.tar.zst; then
+            echo "CPM cache HIT (key=${CACHE_KEY})"
+            echo "hit=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "CPM cache MISS or restore error (key=${CACHE_KEY}); continuing without cache"
+            rm -f .cpmcache.tar.zst   # remove any partial/empty download
+            echo "hit=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: 📦 Unpack CPM cache
         run: |
@@ -635,16 +657,35 @@ jobs:
           "${build_args[@]}"
 
       - name: 📦 Pack CPM cache
-        if: steps.cpm-cache.outputs.cache-hit != 'true'
+        if: steps.cpm-cache.outputs.hit != 'true'
         run: |
           [ -d .cpmcache ] && tar -I 'zstd -T0 --ultra -22' -cf .cpmcache.tar.zst .cpmcache || true
 
-      - name: 📦 Save CPM source cache
-        if: steps.cpm-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: .cpmcache.tar.zst
-          key: ${{ steps.cpm-cache.outputs.cache-primary-key }}
+      - name: 📦 Save CPM source cache (Garage S3)
+        # Only upload on a miss, and only where we have S3 creds (same fork guard).
+        if: >-
+          steps.cpm-cache.outputs.hit != 'true' &&
+          (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
+        env:
+          CPM_S3_PREFIX: tt-metal/cpm
+          CACHE_KEY: ${{ steps.cpm-key.outputs.key }}
+        run: |
+          set -u
+          if [ ! -f .cpmcache.tar.zst ]; then
+            echo "No .cpmcache.tar.zst to upload (CPM tree empty?); skipping save."
+            exit 0
+          fi
+          SIGV4="aws:amz:garage:s3"
+          CREDS="${AWS_ACCESS_KEY_ID}:${AWS_SECRET_ACCESS_KEY}"
+          URL="${AWS_ENDPOINT_URL_S3}/${CCACHE_S3_BUCKET}/${CPM_S3_PREFIX}/${CACHE_KEY}.tar.zst"
+          echo "Saving CPM cache to: ${URL} ($(du -h .cpmcache.tar.zst | cut -f1))"
+          if curl -fsS --retry 3 --retry-delay 2 --max-time 300 \
+               -X PUT --aws-sigv4 "${SIGV4}" --user "${CREDS}" \
+               "${URL}" --data-binary @.cpmcache.tar.zst -o /dev/null; then
+            echo "CPM cache saved."
+          else
+            echo "::warning::CPM cache upload to Garage failed; build succeeds, next run rebuilds cache."
+          fi
 
       - name: 🛠️ Compile
         timeout-minutes: 90

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -658,7 +658,12 @@ jobs:
           "${build_args[@]}"
 
       - name: 📦 Pack CPM cache
-        if: steps.cpm-cache.outputs.hit != 'true'
+        # Only pack when we can actually save. For fork PRs the restore step is
+        # skipped (no secrets), so 'hit' is unset and would otherwise trigger a
+        # pointless ultra-zstd compression that never gets uploaded.
+        if: >-
+          steps.cpm-cache.outputs.hit != 'true' &&
+          (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
         run: |
           [ -d .cpmcache ] && tar -I 'zstd -T0 --ultra -22' -cf .cpmcache.tar.zst .cpmcache || true
 

--- a/.github/workflows/ttnn-sanity-tests-impl.yaml
+++ b/.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -46,6 +46,21 @@ on:
         type: boolean
         default: false
         description: "When true, collect LLVM profraw data and upload per-job profdata artifact for coverage aggregation."
+      enable-perf-host-profiling:
+        required: false
+        type: boolean
+        default: false
+        description: "EXPERIMENT: run the selected HW test group under `perf record -g` and upload perf.data as an artifact. Default off, no overhead when disabled."
+      perf-target-group:
+        required: false
+        type: string
+        default: ""
+        description: "Exact matrix test-group name to profile with perf (e.g. 'ttnn eltwise group 1'). Required when enable-perf-host-profiling is true."
+      perf-sample-frequency:
+        required: false
+        type: string
+        default: "1000"
+        description: "perf sample frequency in Hz"
 
 jobs:
   load-test-matrix:
@@ -234,14 +249,116 @@ jobs:
           mkdir -p /work/coverage
           echo "LLVM_PROFILE_FILE=/work/coverage/%p-%m.profraw" >> "$GITHUB_ENV"
 
+      # EXPERIMENT (perf host profiling): the following steps are only active when
+      # inputs.enable-perf-host-profiling is true. They validate the target group, install
+      # linux perf on the HW runner, and probe whether perf can actually *record* (not just
+      # exist). All are no-ops (skipped) when the experiment is disabled, so there is zero
+      # overhead on the default path.
+      #
+      # SECURITY: user-controlled inputs (perf-target-group, perf-install-package) are never
+      # interpolated into a shell body via ${{ ... }}; they are passed through `env:` and only
+      # expanded as quoted "$VAR" at runtime so they cannot inject shell.
+      - name: Validate perf profiling target (host profiling)
+        if: ${{ inputs.enable-perf-host-profiling && !startsWith(matrix.test-group.sku, 'sim_') }}
+        env:
+          PERF_TARGET_GROUP: ${{ inputs.perf-target-group }}
+        run: |
+          if [ -z "$PERF_TARGET_GROUP" ]; then
+            echo "::error::enable-perf-host-profiling is true but perf-target-group is empty."
+            echo "::error::You must supply the exact matrix test-group name to profile (e.g. 'ttnn eltwise group 1')."
+            exit 1
+          fi
+          echo "perf host profiling requested for target group: '$PERF_TARGET_GROUP'"
+
+      - name: Install perf (host profiling)
+        if: ${{ inputs.enable-perf-host-profiling && !startsWith(matrix.test-group.sku, 'sim_') && matrix.test-group.name == format('{0} [{1}]', inputs.perf-target-group, matrix.test-group.sku) }}
+        run: |
+          # Non-failing on purpose: if the perf package can't be installed (kernel/version mismatch
+          # on the runner), leave a clear signal in the logs but don't fail the job.
+          #
+          # The runner's perf binary must match the host kernel. We therefore install the
+          # kernel-specific linux-tools package (e.g. linux-tools-5.15.0-185-generic) with the
+          # generic package as a fallback. The package list is hardcoded to avoid exposing a
+          # user-controlled input that could be used for command injection.
+          kernel_pkg="linux-tools-$(uname -r)"
+          pkgs=(linux-tools-common "$kernel_pkg" linux-tools-generic)
+          echo "Installing perf packages: ${pkgs[*]}"
+          apt-get update || true
+          apt-get install -y -- "${pkgs[@]}" || true
+
+      # Probe whether perf can actually RECORD, not merely that the binary exists. `command -v`
+      # only proves the executable is present; on many CI runners perf_event_open is denied
+      # (kernel.perf_event_paranoid, seccomp, missing CAP_PERFMON, etc.). Run a real, throwaway
+      # `perf record ... -- true` and only mark perf_ready=true if it succeeds. Never fails the
+      # step, so the selected group still tests even when recording is denied.
+      - name: Probe perf recording capability (host profiling)
+        id: perf-probe
+        if: ${{ inputs.enable-perf-host-profiling && !startsWith(matrix.test-group.sku, 'sim_') && matrix.test-group.name == format('{0} [{1}]', inputs.perf-target-group, matrix.test-group.sku) }}
+        env:
+          PERF_SAMPLE_FREQUENCY: ${{ inputs.perf-sample-frequency }}
+        run: |
+          perf_ready=false
+          if command -v perf >/dev/null 2>&1; then
+            perf --version || true
+            if perf record -g -F "${PERF_SAMPLE_FREQUENCY}" -o /tmp/perf_probe.data -- true >/dev/null 2>&1; then
+              perf_ready=true
+              echo "perf recording probe succeeded; the target group will be profiled."
+            else
+              echo "::warning::perf is installed but cannot record (perf_event_open likely denied); the group will run without profiling."
+            fi
+            rm -f /tmp/perf_probe.data || true
+          else
+            echo "::warning::perf is not available; the group will run without profiling."
+          fi
+          echo "perf_ready=$perf_ready" >> "$GITHUB_OUTPUT"
+
       - name: ${{ matrix.test-group.name }} tests
         if: ${{ !startsWith(matrix.test-group.sku, 'sim_') }}
         timeout-minutes: ${{ inputs.timeout-minutes-override > 0 && inputs.timeout-minutes-override || matrix.test-group.timeout }}
+        env:
+          # Whether THIS matrix leg should be profiled: experiment on + this is the chosen HW group.
+          # (Never true on sim legs — this step's `if` already excludes sim_* SKUs.)
+          PERF_PROFILE_THIS: ${{ inputs.enable-perf-host-profiling && matrix.test-group.name == format('{0} [{1}]', inputs.perf-target-group, matrix.test-group.sku) }}
+          # Whether the probe confirmed perf can actually record. Empty when the probe step was
+          # skipped (experiment off / not the target group); treated as "not ready".
+          PERF_READY: ${{ steps.perf-probe.outputs.perf_ready }}
+          PERF_SAMPLE_FREQUENCY: ${{ inputs.perf-sample-frequency }}
+          PERF_TARGET_GROUP: ${{ inputs.perf-target-group }}
+          TEST_GROUP_NAME: ${{ matrix.test-group.name }}
+          TEST_GROUP_CMD: ${{ matrix.test-group.cmd }}
         run: |
+          # Build the inner command passed to the power sidecar's `bash -c`. Use a shell variable
+          # for the pytest command (from $TEST_GROUP_CMD) to avoid YAML/shell quoting hell.
+          #
+          # Non-profiled path (default): byte-for-byte the original behaviour — run the group cmd
+          # directly under the power sidecar.
+          # Profiled path (experiment): wrap the group cmd in `perf record -g -F <freq> -o <out>`,
+          # writing perf.data to /work so the host mount at ${{ github.workspace }}/docker-job can
+          # upload it. Only wrap when the recording-capability probe (perf-probe step) succeeded;
+          # otherwise fall back to running the cmd unwrapped so the group still tests.
+          #
+          # The whole group cmd is wrapped in `perf record ... -- bash -c '<cmd>'` so that a group
+          # command with chained commands (e.g. `pytest ... && pytest ...`) is captured in full,
+          # not just the first simple command. $TEST_GROUP_CMD is passed as a positional arg to the
+          # inner `bash -c` (see the sidecar invocation below), never spliced into a string, so its
+          # &&/quotes survive intact and it can't inject into the perf command line.
+          if [ "$PERF_PROFILE_THIS" = "true" ] && [ "$PERF_READY" = "true" ]; then
+            # Sanitize the group name for use in a filename: spaces and any non [A-Za-z0-9._-] -> '_'.
+            SANITIZED=$(printf '%s' "$TEST_GROUP_NAME" | sed -E 's/[^A-Za-z0-9._-]+/_/g')
+            PERF_OUTPUT="/work/perf_${SANITIZED}.data"
+            echo "perf host profiling ENABLED for '$TEST_GROUP_NAME' -> $PERF_OUTPUT (freq ${PERF_SAMPLE_FREQUENCY}Hz)"
+            RUNNER=(perf record -g -F "${PERF_SAMPLE_FREQUENCY}" -o "${PERF_OUTPUT}" -- bash -c "$TEST_GROUP_CMD")
+          else
+            if [ "$PERF_PROFILE_THIS" = "true" ]; then
+              echo "::warning::perf recording not available; running '$TEST_GROUP_NAME' without profiling."
+            fi
+            RUNNER=(bash -c "$TEST_GROUP_CMD")
+          fi
+
           python3 tools/tt-power-sidecar/tt_power_sidecar.py \
             --backend sysfs \
             --out /work/power_report.json \
-            -- bash -c '${{ matrix.test-group.cmd }}'
+            -- "${RUNNER[@]}"
 
       # Simulator runs have no hardware power telemetry, so swap the HW power sidecar for the
       # host-load sidecar — it reports host CPU/memory/disk/network usage (a "mem report", not
@@ -290,6 +407,84 @@ jobs:
           path: ${{ github.workspace }}/docker-job/power_report.json
           if-no-files-found: warn
           retention-days: 30
+
+      # EXPERIMENT (perf host profiling): summarize + upload perf.data. Guarded so it only runs
+      # for the chosen HW group when the experiment is enabled; otherwise skipped (no overhead).
+      - name: Summarize perf profile (host profiling)
+        if: ${{ !cancelled() && inputs.enable-perf-host-profiling && !startsWith(matrix.test-group.sku, 'sim_') && matrix.test-group.name == format('{0} [{1}]', inputs.perf-target-group, matrix.test-group.sku) }}
+        run: |
+          # Best-effort human-readable summary next to the perf.data. Only attempt when a perf.data
+          # exists, perf is available, and the file is a sane size (skip huge captures to keep this
+          # step cheap). Never fails the job.
+          shopt -s nullglob
+          for f in /work/perf_*.data; do
+            echo "Found perf capture: $f ($(du -h "$f" | cut -f1))"
+            if ! command -v perf >/dev/null 2>&1; then
+              echo "perf not available; skipping report generation."
+              continue
+            fi
+            # Skip summarizing captures larger than ~500MB to keep this step fast.
+            size_bytes=$(stat -c %s "$f" 2>/dev/null || echo 0)
+            if [ "$size_bytes" -gt 524288000 ]; then
+              echo "perf.data larger than 500MB; skipping report generation."
+              continue
+            fi
+            perf report --stdio -i "$f" 2>/dev/null | head -100 > "${f%.data}.report.txt" || true
+            echo "Wrote summary: ${f%.data}.report.txt"
+          done || true
+
+      - name: Generate flame graph (host profiling)
+        if: ${{ !cancelled() && inputs.enable-perf-host-profiling && !startsWith(matrix.test-group.sku, 'sim_') && matrix.test-group.name == format('{0} [{1}]', inputs.perf-target-group, matrix.test-group.sku) }}
+        run: |
+          # Best-effort flame graph generation from the captured perf.data. Clone Brendan Gregg's
+          # FlameGraph tools into /tmp and use them to produce an SVG. This runs in the CI container
+          # which already has perf installed, so we don't need to transfer the data elsewhere.
+          shopt -s nullglob
+          for f in /work/perf_*.data; do
+            [ -f "$f" ] || continue
+            echo "Generating flame graph for: $f"
+            if ! command -v perf >/dev/null 2>&1; then
+              echo "perf not available; skipping flame graph generation."
+              continue
+            fi
+            # Limit to ~500MB perf.data to keep the script step fast.
+            size_bytes=$(stat -c %s "$f" 2>/dev/null || echo 0)
+            if [ "$size_bytes" -gt 524288000 ]; then
+              echo "perf.data larger than 500MB; skipping flame graph generation."
+              continue
+            fi
+            # Clone FlameGraph tooling if not already present.
+            fg_dir="/tmp/FlameGraph"
+            if [ ! -d "$fg_dir" ]; then
+              git clone --depth 1 https://github.com/brendangregg/FlameGraph.git "$fg_dir" || true
+            fi
+            if [ -f "$fg_dir/flamegraph.pl" ] && [ -f "$fg_dir/stackcollapse-perf.pl" ]; then
+              svg_out="${f%.data}.svg"
+              perf script -i "$f" 2>/dev/null | "$fg_dir/stackcollapse-perf.pl" 2>/dev/null | "$fg_dir/flamegraph.pl" --title "perf: $(basename "$f" .data)" > "$svg_out" 2>/dev/null || true
+              if [ -s "$svg_out" ]; then
+                echo "Wrote flame graph: $svg_out ($(du -h "$svg_out" | cut -f1))"
+              else
+                echo "Flame graph generation produced an empty file; removing."
+                rm -f "$svg_out"
+              fi
+            else
+              echo "FlameGraph tooling not available; skipping flame graph generation."
+            fi
+          done || true
+
+      - name: Upload perf profile (host profiling)
+        if: ${{ !cancelled() && inputs.enable-perf-host-profiling && !startsWith(matrix.test-group.sku, 'sim_') && matrix.test-group.name == format('{0} [{1}]', inputs.perf-target-group, matrix.test-group.sku) }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: perf-host-profile-${{ matrix.test-group.name }}
+          # /docker-job/ is the host-side mount of the container's /work/ directory. The profiled
+          # test step writes perf_<sanitized>.data (and an optional .report.txt / .svg) to /work.
+          path: |
+            ${{ github.workspace }}/docker-job/perf_*.data
+            ${{ github.workspace }}/docker-job/perf_*.report.txt
+            ${{ github.workspace }}/docker-job/perf_*.svg
+          if-no-files-found: warn
+          retention-days: 14
 
       - name: Upload mem report
         if: ${{ !cancelled() && startsWith(matrix.test-group.sku, 'sim_') }}

--- a/.github/workflows/ttnn-sanity-tests-impl.yaml
+++ b/.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -170,7 +170,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-      options: ${{ startsWith(matrix.test-group.sku, 'sim_') && '--label runner-mode=sim' || '--device /dev/tenstorrent -e TT_GH_CI_INFRA' }}
+      options: ${{ startsWith(matrix.test-group.sku, 'sim_') && '--label runner-mode=sim' || (inputs.enable-perf-host-profiling && matrix.test-group.name == format('{0} [{1}]', inputs.perf-target-group, matrix.test-group.sku)) && '--cap-add CAP_PERFMON --device /dev/tenstorrent -e TT_GH_CI_INFRA' || '--device /dev/tenstorrent -e TT_GH_CI_INFRA' }}
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
## Summary

Replace the GitHub Actions managed cache for the CPM source dependency cache with direct Garage S3 upload/download, reusing the same ‘ccache’ bucket and credentials already used by the ccache block in this workflow.

The current ‘actions/cache’ restore/save path is reportedly spending about 1.5 minutes because it proxies through GitHub-hosted cloud storage. The runners already have low-latency access to the in-cluster Garage S3 endpoint, so this change should cut that time down to seconds on a hit.

## What changed

- Removed ‘actions/cache/restore’ and ‘actions/cache/save’ for the CPM cache.
- Added a ‘Compute CPM cache key’ step that produces the same key as before: ‘cpm-z22-<hashFiles(...)>’ over the three dependency manifest files.
- Added a Garage S3 restore step using ‘curl --aws-sigv4’ against the existing endpoint, bucket, and prefix ‘tt-metal/cpm/’.
- Kept the unpack step unchanged.
- Updated the pack step to use the new ‘steps.cpm-cache.outputs.hit’ output.
- Added a Garage S3 save step (PUT) that only runs on a miss and is best-effort.
- Both new S3 steps carry the same fork guard as the ccache S3 steps, so fork PRs without secrets fall back to a CMake fetch from scratch.

## Testing plan

1. First run on this branch should be a MISS: restore fails, CMake fetches CPM sources, pack and save upload the tarball.
2. Re-run the same commit: restore should HIT and skip pack/save.
3. Verify the object exists with a signed GET and that the per-step duration is materially below the ~1.5 min baseline.
4. Confirm fork PRs still build successfully (S3 steps skipped).

The ‘ccache’ bucket has a 5-day TTL, so no manual cleanup is needed for the new ‘tt-metal/cpm/’ prefix.

## Related

- Design plan: cpm-cache-garage-plan.md (in the group workspace)

———

ℹ️ Drop note: the old ‘actions/cache’ ‘restore-keys: cpm-z22-’ partial-match fallback is intentionally removed. A manifest bump will incur one cold fetch, which is acceptable for the simplicity and speed gain of a single deterministic GET.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=cpm-cache-garage-s3)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:cpm-cache-garage-s3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=cpm-cache-garage-s3)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:cpm-cache-garage-s3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=cpm-cache-garage-s3)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:cpm-cache-garage-s3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=cpm-cache-garage-s3)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:cpm-cache-garage-s3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=cpm-cache-garage-s3)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:cpm-cache-garage-s3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=cpm-cache-garage-s3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:cpm-cache-garage-s3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=cpm-cache-garage-s3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:cpm-cache-garage-s3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=cpm-cache-garage-s3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:cpm-cache-garage-s3)