### PR TITLE
#47644: Extend universal input/output support for ttnn::fold

### DIFF
--- a/models/demos/vision/classification/vit/blackhole/tt/ttnn_optimized_sharded_vit_bh.py
+++ b/models/demos/vision/classification/vit/blackhole/tt/ttnn_optimized_sharded_vit_bh.py
@@ -193,7 +193,7 @@ def vit_patch_embeddings(config, pixel_values, *, parameters, unittest_check=Fal
     stride_h = patch_size
     stride_w = 1
 
-    folded_pixel_values = ttnn.fold(pixel_values, stride_h, stride_w)  # 1568, 1024
+    folded_pixel_values = ttnn.fold(pixel_values, stride_h, stride_w, collapse_output=True)  # 1568, 1024
     ttnn.deallocate(pixel_values)
     folded_pixel_values = ttnn.to_memory_config(folded_pixel_values, memory_config=ttnn.L1_MEMORY_CONFIG)
     # Convert back to interleaved or otherwise to_layout will fail

--- a/models/demos/vision/classification/vit/blackhole/tt/ttnn_optimized_sharded_vit_hiRes_bh.py
+++ b/models/demos/vision/classification/vit/blackhole/tt/ttnn_optimized_sharded_vit_hiRes_bh.py
@@ -223,7 +223,7 @@ def vit_patch_embeddings(config, pixel_values, *, parameters, unittest_check=Fal
     stride_h = patch_size
     stride_w = 1
 
-    folded_pixel_values = ttnn.fold(pixel_values, stride_h, stride_w)  # 1568, 1024
+    folded_pixel_values = ttnn.fold(pixel_values, stride_h, stride_w, collapse_output=True)  # 1568, 1024
     ttnn.deallocate(pixel_values)
     folded_pixel_values = ttnn.to_memory_config(folded_pixel_values, memory_config=ttnn.L1_MEMORY_CONFIG)
     # Convert back to interleaved or otherwise to_layout will fail

--- a/models/demos/vision/classification/vit/common/tt/ttnn_functional_vit.py
+++ b/models/demos/vision/classification/vit/common/tt/ttnn_functional_vit.py
@@ -21,7 +21,7 @@ def vit_patch_embeddings(config, pixel_values, *, parameters, unittest_check=Fal
     stride_w = 1
 
     pixel_values = ttnn.reshape(pixel_values, (batch_size, img_h, img_w // patch_size, 4 * patch_size))
-    pixel_values = ttnn.fold(pixel_values, stride_h, stride_w)
+    pixel_values = ttnn.fold(pixel_values, stride_h, stride_w, collapse_output=True)
     pixel_values = ttnn.to_layout(pixel_values, layout=ttnn.TILE_LAYOUT)
 
     if unittest_check:

--- a/models/demos/vision/classification/vit/common/tt/ttnn_functional_vit_highres.py
+++ b/models/demos/vision/classification/vit/common/tt/ttnn_functional_vit_highres.py
@@ -20,7 +20,7 @@ def vit_patch_embeddings(config, pixel_values, *, parameters, unittest_check=Fal
     stride_w = 1
 
     pixel_values = ttnn.reshape(pixel_values, (batch_size, img_h, img_w // patch_size, 4 * patch_size))
-    pixel_values = ttnn.fold(pixel_values, stride_h, stride_w)
+    pixel_values = ttnn.fold(pixel_values, stride_h, stride_w, collapse_output=True)
     pixel_values = ttnn.to_layout(pixel_values, layout=ttnn.TILE_LAYOUT)
 
     if unittest_check:

--- a/models/demos/vision/classification/vit/common/tt/ttnn_optimized_interleaved_vit.py
+++ b/models/demos/vision/classification/vit/common/tt/ttnn_optimized_interleaved_vit.py
@@ -24,7 +24,7 @@ def vit_patch_embeddings(config, pixel_values, *, parameters, unittest_check=Fal
     stride_h = patch_size
     stride_w = 1
 
-    folded_pixel_values = ttnn.fold(pixel_values, stride_h, stride_w)  # 1568, 1024
+    folded_pixel_values = ttnn.fold(pixel_values, stride_h, stride_w, collapse_output=True)  # 1568, 1024
     ttnn.deallocate(pixel_values)
     x = ttnn.reallocate(folded_pixel_values)
     folded_pixel_values = ttnn.to_layout(x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat8_b)

--- a/models/demos/vision/classification/vit/wormhole/tt/ttnn_optimized_sharded_vit_wh.py
+++ b/models/demos/vision/classification/vit/wormhole/tt/ttnn_optimized_sharded_vit_wh.py
@@ -194,7 +194,7 @@ def vit_patch_embeddings(config, pixel_values, *, parameters, unittest_check=Fal
     stride_h = patch_size
     stride_w = 1
 
-    folded_pixel_values = ttnn.fold(pixel_values, stride_h, stride_w)  # 1568, 1024
+    folded_pixel_values = ttnn.fold(pixel_values, stride_h, stride_w, collapse_output=True)  # 1568, 1024
     ttnn.deallocate(pixel_values)
     folded_pixel_values = ttnn.to_memory_config(folded_pixel_values, memory_config=ttnn.L1_MEMORY_CONFIG)
     # Convert back to interleaved or otherwise to_layout will fail

--- a/models/experimental/openvla/tt/tt_optimized_openvla_vision.py
+++ b/models/experimental/openvla/tt/tt_optimized_openvla_vision.py
@@ -29,7 +29,7 @@ def vit_patch_embeddings_weight_vars(
     stride_w = 1
 
     pixel_values = ttnn.reshape(pixel_values, (batch_size, img_h, img_w // patch_size, 4 * patch_size))
-    pixel_values = ttnn.fold(pixel_values, stride_h, stride_w)
+    pixel_values = ttnn.fold(pixel_values, stride_h, stride_w, collapse_output=True)
     pixel_values = ttnn.to_layout(pixel_values, layout=ttnn.TILE_LAYOUT)
 
     patch_embedding_output = ttnn.linear(
@@ -61,7 +61,7 @@ def siglip_patch_embeddings(
     stride_w = 1
 
     pixel_values = ttnn.reshape(pixel_values, (batch_size, img_h, img_w // patch_size, 4 * patch_size))
-    pixel_values = ttnn.fold(pixel_values, stride_h, stride_w)
+    pixel_values = ttnn.fold(pixel_values, stride_h, stride_w, collapse_output=True)
     pixel_values = ttnn.to_layout(pixel_values, layout=ttnn.TILE_LAYOUT)
 
     patch_embedding_output = ttnn.linear(

--- a/models/experimental/smolvla/tt/smol_vla.py
+++ b/models/experimental/smolvla/tt/smol_vla.py
@@ -403,7 +403,7 @@ def smolvla_patch_embeddings_tt(
 
     # Reshape for fold operation
     pixel_values = ttnn.reshape(pixel_values, (batch_size, img_h, img_w // patch_size, 4 * patch_size))
-    pixel_values = ttnn.fold(pixel_values, stride_h, stride_w)
+    pixel_values = ttnn.fold(pixel_values, stride_h, stride_w, collapse_output=True)
     pixel_values = ttnn.to_layout(pixel_values, layout=ttnn.TILE_LAYOUT)
 
     # Linear projection
@@ -1340,7 +1340,7 @@ class SmolVLAVisionEncoder(nn.Module):
 
         # Fold the image into patches
         pixel_values = ttnn.reshape(pixel_values, (batch_size, img_h, img_h // patch_size, 4 * patch_size))
-        pixel_values = ttnn.fold(pixel_values, stride_h=patch_size, stride_w=1)
+        pixel_values = ttnn.fold(pixel_values, stride_h=patch_size, stride_w=1, collapse_output=True)
         pixel_values = ttnn.to_layout(pixel_values, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat8_b)
 
         # Linear projection

--- a/models/experimental/smolvla/tt/ttnn_optimized_vit_smolvla.py
+++ b/models/experimental/smolvla/tt/ttnn_optimized_vit_smolvla.py
@@ -86,7 +86,7 @@ def smolvla_patch_embeddings(
 
     # Fold patches: each patch becomes a row
     # stride_h = patch_size folds vertically, stride_w = 1 keeps horizontal
-    pixel_values = ttnn.fold(pixel_values, patch_size, 1)
+    pixel_values = ttnn.fold(pixel_values, patch_size, 1, collapse_output=True)
 
     # Convert to tile layout for efficient matmul
     pixel_values = ttnn.to_layout(pixel_values, layout=ttnn.TILE_LAYOUT)

--- a/models/experimental/tt_symbiote/modules/conv.py
+++ b/models/experimental/tt_symbiote/modules/conv.py
@@ -520,7 +520,7 @@ class TTNNPatchEmbedding(TTNNModule):
         stride_h = patch_size
         stride_w = 1
         pixel_values = ttnn.reshape(pixel_values, (batch_size, img_h, img_w // patch_size, 4 * patch_size))
-        folded_pixel_values = ttnn.fold(pixel_values, stride_h, stride_w)  # 1568, 1024
+        folded_pixel_values = ttnn.fold(pixel_values, stride_h, stride_w, collapse_output=True)  # 1568, 1024
         ttnn.deallocate(pixel_values)
         folded_pixel_values = ttnn.to_memory_config(folded_pixel_values, memory_config=ttnn.L1_MEMORY_CONFIG)
         # Convert back to interleaved or otherwise to_layout will fail

--- a/tests/sweep_framework/sweeps/model_traced/fold_model_traced.py
+++ b/tests/sweep_framework/sweeps/model_traced/fold_model_traced.py
@@ -145,11 +145,6 @@ def run(
 
     torch_output_tensor = fold_torch(_golden_input, stride_h, stride_w)
 
-    # ttnn.fold outputs in TTNN format [1, 1, N*H'*W', C'] — reshape golden to match
-    if torch_output_tensor.ndim == 4:
-        N_out, H_out, W_out, C_out = torch_output_tensor.shape
-        torch_output_tensor = torch_output_tensor.reshape(1, 1, N_out * H_out * W_out, C_out)
-
     # Check if storage_type is HOST - if so, don't pass device to from_torch
     is_host = storage_type and "HOST" in str(storage_type)
 
@@ -186,15 +181,8 @@ def run(
     # fold expects stride_h and stride_w as positional args
     output_tensor = ttnn.fold(input_tensor_a, stride_h, stride_w, **op_kwargs)
     if _permuted and is_mesh_device:
-        # The re-laid-out NHWC input was replicated across the mesh (a Shard
-        # placement is materialized replicated on this device), so each chip holds
-        # the full fold result — read one device instead of concatenating (which
-        # would multiply the batch by the mesh factor). The DRAM fold returns a 4D
-        # [N, H', W', C']; flatten to the [1, 1, N*H'*W', C'] form the golden uses.
+        # Replicated placement — read one device instead of concatenating (which would multiply the batch by the mesh factor).
         output_tensor = mesh_tensor_to_torch(output_tensor, device, force_single_device=True)
-        if output_tensor.ndim == 4:
-            _n, _h, _w, _c = output_tensor.shape
-            output_tensor = output_tensor.reshape(1, 1, _n * _h * _w, _c)
     else:
         mesh_composer = get_mesh_composer(device, input_a_tensor_placement) if is_mesh_device else None
         output_tensor = mesh_tensor_to_torch(

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_fold.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_fold.py
@@ -1,0 +1,861 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Universal input/output tests for ttnn.fold — one case per routing path (RM/TILE × interleaved/H/W/B sharded × L1/DRAM × override × collapse_output × padding × legacy transpose). Default output is folded_4d (N, H/sh, W/sw, C*sh*sw); collapse_output=True emits (1, 1, N*H'*W', C*sh*sw) directly via compute_output_specs."""
+
+import pytest
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+_TTNN_TO_TORCH_DTYPE = {
+    ttnn.bfloat16: torch.bfloat16,
+    ttnn.float32: torch.float32,
+}
+
+L1_INTERLEAVED = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
+DRAM_INTERLEAVED = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+
+
+def _fold_golden(x_nhwc, stride_h, stride_w):
+    """NHWC pixel_unshuffle — matches ttnn.fold's (N, H/sh, W/sw, C*sh*sw) output."""
+    N, H, W, C = x_nhwc.shape
+    r = x_nhwc.reshape(N, H // stride_h, stride_h, W // stride_w, stride_w, C)
+    return r.permute(0, 1, 3, 2, 4, 5).reshape(N, H // stride_h, W // stride_w, C * stride_h * stride_w)
+
+
+def _height_shard_rm(
+    shape, device, num_cores=4, buffer_type=ttnn.BufferType.L1, orientation=ttnn.ShardOrientation.ROW_MAJOR
+):
+    """HEIGHT-sharded RM config with shard_h a multiple of (W * stride_h) — matches fold's fast-path pre-condition."""
+    N, H, W, C = shape
+    total_h = N * H * W
+    grid = device.compute_with_storage_grid_size()
+    num_cores = min(num_cores, grid.x * grid.y)
+    while num_cores > 1 and total_h % num_cores != 0:
+        num_cores -= 1
+    shard_grid = ttnn.num_cores_to_corerangeset(num_cores, grid, True)
+    return ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        buffer_type,
+        ttnn.ShardSpec(shard_grid, [total_h // num_cores, C], orientation),
+    )
+
+
+def _width_shard_rm(shape, device, num_cores=4, orientation=ttnn.ShardOrientation.ROW_MAJOR):
+    """WIDTH-sharded L1 RM config over the channel dim."""
+    N, H, W, C = shape
+    grid = device.compute_with_storage_grid_size()
+    num_cores = min(num_cores, grid.x * grid.y)
+    while num_cores > 1 and C % num_cores != 0:
+        num_cores -= 1
+    shard_grid = ttnn.num_cores_to_corerangeset(num_cores, grid, True)
+    return ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(shard_grid, [N * H * W, C // num_cores], orientation),
+    )
+
+
+def _block_shard_rm(shape, device, grid_y=2, grid_x=2, orientation=ttnn.ShardOrientation.ROW_MAJOR):
+    """BLOCK-sharded L1 RM config."""
+    N, H, W, C = shape
+    grid = device.compute_with_storage_grid_size()
+    grid_y = min(grid_y, grid.y)
+    grid_x = min(grid_x, grid.x)
+    while grid_y > 1 and (N * H * W) % grid_y != 0:
+        grid_y -= 1
+    while grid_x > 1 and C % grid_x != 0:
+        grid_x -= 1
+    return ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_x - 1, grid_y - 1))}),
+            [(N * H * W) // grid_y, C // grid_x],
+            orientation,
+        ),
+    )
+
+
+def _tile_width_shard(shape, device, num_cores=4):
+    """Tile-aligned WIDTH-sharded L1 config. Requires C divisible by num_cores * 32."""
+    N, H, W, C = shape
+    grid = device.compute_with_storage_grid_size()
+    num_cores = min(num_cores, grid.x * grid.y)
+    shard_grid = ttnn.num_cores_to_corerangeset(num_cores, grid, True)
+    return ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(shard_grid, [N * H * W, C // num_cores], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+
+
+def _tile_block_shard(shape, device, grid_y=2, grid_x=2):
+    """Tile-aligned BLOCK-sharded L1 config."""
+    N, H, W, C = shape
+    grid = device.compute_with_storage_grid_size()
+    grid_y = min(grid_y, grid.y)
+    grid_x = min(grid_x, grid.x)
+    return ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_x - 1, grid_y - 1))}),
+            [(N * H * W) // grid_y, C // grid_x],
+            ttnn.ShardOrientation.ROW_MAJOR,
+        ),
+    )
+
+
+def _run_fold(
+    shape,
+    stride_h,
+    stride_w,
+    layout,
+    input_mem_config,
+    output_mem_config,
+    device,
+    pcc=0.9999,
+    dtype=ttnn.bfloat16,
+    expected_shard_orientation=None,
+    use_transpose_as_fold=False,
+    padding=None,
+    collapse_output=False,
+):
+    """Run fold; assert output shape, memory config (layout + orientation), and PCC vs golden — collapse_output=True flattens ref via reshape for rank-matched PCC."""
+    torch.manual_seed(12345)
+    torch_dtype = _TTNN_TO_TORCH_DTYPE[dtype]
+    x = torch.rand(shape, dtype=torch_dtype)
+
+    ttnn_in = ttnn.from_torch(x, layout=layout, dtype=dtype, device=device, memory_config=input_mem_config)
+    kwargs = {}
+    if output_mem_config is not None:
+        kwargs["override_memory_config"] = output_mem_config
+    if use_transpose_as_fold:
+        kwargs["use_transpose_as_fold"] = True
+    if padding is not None:
+        kwargs["padding"] = padding
+    if collapse_output:
+        kwargs["collapse_output"] = True
+    result = ttnn.fold(ttnn_in, stride_h, stride_w, **kwargs)
+
+    N, H, W, C = shape
+    ph_top = ph_bot = pw_l = pw_r = pc_f = pc_b = 0
+    if padding is not None:
+        p = list(padding)
+        if len(p) == 2:
+            ph_top = ph_bot = p[0]
+            pw_l = pw_r = p[1]
+        elif len(p) == 4:
+            ph_top, ph_bot, pw_l, pw_r = p
+        else:
+            ph_top, ph_bot, pw_l, pw_r, pc_f, pc_b = p
+    H_eff = H + ph_top + ph_bot
+    W_eff = W + pw_l + pw_r
+    C_eff = C + pc_f + pc_b
+    Hp = H_eff // stride_h
+    Wp = W_eff // stride_w
+    Cp = C_eff * stride_h * stride_w
+    expected_shape = (1, 1, N * Hp * Wp, Cp) if collapse_output else (N, Hp, Wp, Cp)
+    assert tuple(result.shape) == expected_shape, f"Expected shape {expected_shape}, got {tuple(result.shape)}"
+
+    if output_mem_config is not None:
+        actual = result.memory_config()
+        assert (
+            actual.memory_layout == output_mem_config.memory_layout
+        ), f"Expected memory_layout {output_mem_config.memory_layout}, got {actual.memory_layout}"
+        assert (
+            actual.buffer_type == output_mem_config.buffer_type
+        ), f"Expected buffer_type {output_mem_config.buffer_type}, got {actual.buffer_type}"
+        if output_mem_config.memory_layout != ttnn.TensorMemoryLayout.INTERLEAVED:
+            assert actual.shard_spec is not None, "Sharded output requested but result has no shard_spec"
+            if expected_shard_orientation is not None:
+                assert (
+                    actual.shard_spec.orientation == expected_shard_orientation
+                ), f"Expected shard orientation {expected_shard_orientation}, got {actual.shard_spec.orientation}"
+
+    x_padded = torch.nn.functional.pad(x, (pc_f, pc_b, pw_l, pw_r, ph_top, ph_bot)) if padding is not None else x
+    ref = _fold_golden(x_padded, stride_h, stride_w)
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    if collapse_output:
+        ref = ref.reshape(1, 1, N * Hp * Wp, Cp)
+    assert_with_pcc(ref.float(), got.float(), pcc)
+
+
+# Interleaved routing — RM goes through MultiCoreDRAMFold RM branch; TILE untilizes first.
+
+
+@pytest.mark.parametrize(
+    "layout, shape, input_mc, output_mc",
+    [
+        pytest.param(ttnn.ROW_MAJOR_LAYOUT, (1, 16, 16, 8), L1_INTERLEAVED, L1_INTERLEAVED, id="rm_L1_to_L1"),
+        pytest.param(ttnn.ROW_MAJOR_LAYOUT, (1, 16, 16, 8), DRAM_INTERLEAVED, DRAM_INTERLEAVED, id="rm_DRAM_to_DRAM"),
+        pytest.param(ttnn.ROW_MAJOR_LAYOUT, (1, 16, 16, 8), L1_INTERLEAVED, DRAM_INTERLEAVED, id="rm_L1_to_DRAM"),
+        pytest.param(ttnn.ROW_MAJOR_LAYOUT, (1, 16, 16, 8), DRAM_INTERLEAVED, L1_INTERLEAVED, id="rm_DRAM_to_L1"),
+        pytest.param(ttnn.TILE_LAYOUT, (1, 32, 32, 32), L1_INTERLEAVED, L1_INTERLEAVED, id="tile_L1_to_L1"),
+        pytest.param(ttnn.TILE_LAYOUT, (1, 32, 32, 32), DRAM_INTERLEAVED, DRAM_INTERLEAVED, id="tile_DRAM_to_DRAM"),
+        pytest.param(ttnn.TILE_LAYOUT, (1, 32, 32, 32), L1_INTERLEAVED, DRAM_INTERLEAVED, id="tile_L1_to_DRAM"),
+    ],
+)
+def test_fold_interleaved(layout, shape, input_mc, output_mc, device):
+    _run_fold(shape, 2, 2, layout, input_mc, output_mc, device)
+
+
+# RM + HEIGHT_SHARDED L1 — zero-NOC fast path; parametrized over shape/stride/ncores + col_major + multi-batch.
+
+
+@pytest.mark.parametrize(
+    "shape, stride, ncores, orientation",
+    [
+        pytest.param((1, 16, 16, 8), (2, 2), 4, ttnn.ShardOrientation.ROW_MAJOR, id="16x16x8_2x2_4c"),
+        pytest.param((1, 32, 32, 16), (2, 2), 8, ttnn.ShardOrientation.ROW_MAJOR, id="32x32x16_2x2_8c"),
+        pytest.param((2, 16, 16, 8), (4, 4), 4, ttnn.ShardOrientation.ROW_MAJOR, id="N2_16x16x8_4x4_4c_multi_batch"),
+        pytest.param((2, 16, 16, 8), (2, 2), 4, ttnn.ShardOrientation.ROW_MAJOR, id="N2_16x16x8_2x2_4c_multi_batch"),
+        pytest.param((4, 16, 16, 8), (2, 2), 4, ttnn.ShardOrientation.ROW_MAJOR, id="N4_16x16x8_2x2_4c_multi_batch"),
+        pytest.param((1, 16, 16, 8), (2, 2), 4, ttnn.ShardOrientation.COL_MAJOR, id="16x16x8_2x2_4c_col_major"),
+    ],
+)
+def test_fold_height_sharded_fastpath(shape, stride, ncores, orientation, device):
+    """Default output — HEIGHT_SHARDED L1 propagates through the fast path with rescaled shard; orientation preserved end-to-end."""
+    in_mc = _height_shard_rm(shape, device, num_cores=ncores, orientation=orientation)
+    _run_fold(shape, stride[0], stride[1], ttnn.ROW_MAJOR_LAYOUT, in_mc, None, device)
+
+
+# HEIGHT_SHARDED input × (L1/DRAM buffer) × (native / interleaved override) — fast path + optional tail to_memory_config.
+
+
+@pytest.mark.parametrize(
+    "input_buffer_type, output_mc",
+    [
+        pytest.param(ttnn.BufferType.L1, L1_INTERLEAVED, id="L1_in_to_L1"),
+        pytest.param(ttnn.BufferType.L1, DRAM_INTERLEAVED, id="L1_in_to_DRAM"),
+        pytest.param(ttnn.BufferType.DRAM, None, id="DRAM_in_native"),
+        pytest.param(ttnn.BufferType.DRAM, L1_INTERLEAVED, id="DRAM_in_to_L1"),
+    ],
+)
+def test_fold_height_sharded_input_variants(input_buffer_type, output_mc, device):
+    """H-sharded RM input × {L1, DRAM} × {native output preserves sharding, override → interleaved}."""
+    shape = (1, 16, 16, 8)
+    in_mc = _height_shard_rm(shape, device, num_cores=4, buffer_type=input_buffer_type)
+    _run_fold(shape, 2, 2, ttnn.ROW_MAJOR_LAYOUT, in_mc, output_mc, device)
+
+
+# RM + WIDTH/BLOCK-sharded input × (sub-align / aligned / col_major) → interleaved output.
+
+
+@pytest.mark.parametrize(
+    "shard_factory, shape, orientation",
+    [
+        pytest.param(_width_shard_rm, (1, 16, 16, 8), ttnn.ShardOrientation.ROW_MAJOR, id="width_sub_align"),
+        pytest.param(_block_shard_rm, (1, 16, 16, 8), ttnn.ShardOrientation.ROW_MAJOR, id="block_sub_align"),
+        pytest.param(_width_shard_rm, (1, 16, 16, 64), ttnn.ShardOrientation.ROW_MAJOR, id="width_aligned_native"),
+        pytest.param(_block_shard_rm, (1, 16, 16, 64), ttnn.ShardOrientation.ROW_MAJOR, id="block_aligned_native"),
+        pytest.param(_width_shard_rm, (1, 16, 16, 8), ttnn.ShardOrientation.COL_MAJOR, id="width_col_major"),
+        pytest.param(_block_shard_rm, (1, 16, 16, 8), ttnn.ShardOrientation.COL_MAJOR, id="block_col_major"),
+    ],
+)
+def test_fold_wb_sharded_input(shard_factory, shape, orientation, device):
+    """C=8 (sub-align): stages via L1 interleaved. C=64 (aligned): native RM factory. COL_MAJOR: orientation not carried into interleaved output."""
+    in_mc = shard_factory(shape, device, orientation=orientation)
+    _run_fold(shape, 2, 2, ttnn.ROW_MAJOR_LAYOUT, in_mc, L1_INTERLEAVED, device)
+
+
+# RM aligned W/B-sharded input → native W/B-sharded output (no override) — MultiCoreDRAMFold writes via noc_async_write_sharded; direct folded_4d PCC vs golden.
+@pytest.mark.parametrize(
+    "shard_factory, expected_layout",
+    [
+        pytest.param(_width_shard_rm, ttnn.TensorMemoryLayout.WIDTH_SHARDED, id="width_aligned_native_folded_4d"),
+        pytest.param(_block_shard_rm, ttnn.TensorMemoryLayout.BLOCK_SHARDED, id="block_aligned_native_folded_4d"),
+    ],
+)
+def test_fold_wb_sharded_native_output(shard_factory, expected_layout, device):
+    """Aligned W/B-sharded RM input + no override → output stays W/B-sharded (compute_output_specs)."""
+    shape = (1, 16, 16, 64)
+    in_mc = shard_factory(shape, device)
+    torch.manual_seed(0)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(x, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=in_mc)
+    result = ttnn.fold(ttnn_in, 2, 2)
+    assert tuple(result.shape) == (1, 8, 8, 256)
+    assert result.memory_config().memory_layout == expected_layout
+    ref = _fold_golden(x, 2, 2)
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    assert_with_pcc(ref.float(), got.float(), 0.9999)
+
+
+# Interleaved input → sharded output — prim + tail to_memory_config.
+
+
+@pytest.mark.parametrize(
+    "output_mc_factory",
+    [
+        pytest.param(_height_shard_rm, id="to_height_sh"),
+        pytest.param(_width_shard_rm, id="to_width_sh"),
+        pytest.param(_block_shard_rm, id="to_block_sh"),
+    ],
+)
+@pytest.mark.parametrize(
+    "input_mc",
+    [
+        pytest.param(L1_INTERLEAVED, id="L1_in"),
+        pytest.param(DRAM_INTERLEAVED, id="DRAM_in"),
+    ],
+)
+def test_fold_rm_interleaved_to_sharded(input_mc, output_mc_factory, device):
+    shape = (1, 16, 16, 8)
+    out_shape = (1, 8, 8, 32)
+    out_mc = output_mc_factory(out_shape, device)
+    _run_fold(shape, 2, 2, ttnn.ROW_MAJOR_LAYOUT, input_mc, out_mc, device)
+
+
+# TILE + W/B-sharded input — composite untilize + stage L1 interleaved.
+
+
+@pytest.mark.parametrize(
+    "input_mc_factory",
+    [
+        pytest.param(_tile_width_shard, id="width_sh_in"),
+        pytest.param(_tile_block_shard, id="block_sh_in"),
+    ],
+)
+def test_fold_tile_wb_sharded_input(input_mc_factory, device):
+    """TILE input in W/B-sharded config → interleaved output — exercises composite staging path."""
+    shape = (1, 32, 32, 128)
+    in_mc = input_mc_factory(shape, device)
+    _run_fold(shape, 2, 2, ttnn.TILE_LAYOUT, in_mc, L1_INTERLEAVED, device)
+
+
+# Sharded → sharded cross-layout — composite reshard on output.
+
+
+@pytest.mark.parametrize(
+    "in_factory, out_factory",
+    [
+        pytest.param(_height_shard_rm, _block_shard_rm, id="height_to_block"),
+        pytest.param(_width_shard_rm, _height_shard_rm, id="width_to_height"),
+    ],
+)
+def test_fold_rm_sharded_cross_layout(in_factory, out_factory, device):
+    shape = (1, 16, 16, 8)
+    out_shape = (1, 8, 8, 32)
+    in_mc = in_factory(shape, device, num_cores=4) if in_factory is _height_shard_rm else in_factory(shape, device)
+    out_mc = (
+        out_factory(out_shape, device, num_cores=4)
+        if out_factory is _height_shard_rm
+        else out_factory(out_shape, device)
+    )
+    _run_fold(shape, 2, 2, ttnn.ROW_MAJOR_LAYOUT, in_mc, out_mc, device)
+
+
+def test_fold_rm_interleaved_to_height_sharded_col_major_output(device):
+    """Interleaved in → HEIGHT-sh COL_MAJOR out — tail to_memory_config sets orientation."""
+    shape = (1, 16, 16, 8)
+    out_shape = (1, 8, 8, 32)
+    out_mc = _height_shard_rm(out_shape, device, num_cores=4, orientation=ttnn.ShardOrientation.COL_MAJOR)
+    _run_fold(
+        shape,
+        2,
+        2,
+        ttnn.ROW_MAJOR_LAYOUT,
+        L1_INTERLEAVED,
+        out_mc,
+        device,
+        expected_shard_orientation=ttnn.ShardOrientation.COL_MAJOR,
+    )
+
+
+# f32 dtype coverage — representative paths.
+
+
+@pytest.mark.parametrize(
+    "shape, layout, in_mc_factory",
+    [
+        pytest.param((1, 16, 16, 8), ttnn.ROW_MAJOR_LAYOUT, lambda _s, _d: L1_INTERLEAVED, id="f32_rm_l1"),
+        pytest.param((1, 16, 16, 8), ttnn.ROW_MAJOR_LAYOUT, lambda _s, _d: DRAM_INTERLEAVED, id="f32_rm_dram"),
+        pytest.param(
+            (1, 16, 16, 8),
+            ttnn.ROW_MAJOR_LAYOUT,
+            lambda s, d: _height_shard_rm(s, d, num_cores=4),
+            id="f32_rm_hsharded_fastpath",
+        ),
+    ],
+)
+def test_fold_f32_dtype(shape, layout, in_mc_factory, device):
+    _run_fold(shape, 2, 2, layout, in_mc_factory(shape, device), None, device, dtype=ttnn.float32)
+
+
+# Non-standard strides — asymmetric, non-power-of-two (e.g. 3x5, 2x3).
+
+
+@pytest.mark.parametrize(
+    "shape, stride",
+    [
+        pytest.param((1, 24, 30, 8), (3, 5), id="stride_3x5_asym"),
+        pytest.param((1, 12, 24, 8), (2, 3), id="stride_2x3_asym"),
+    ],
+)
+def test_fold_asymmetric_stride(shape, stride, device):
+    _run_fold(shape, stride[0], stride[1], ttnn.ROW_MAJOR_LAYOUT, L1_INTERLEAVED, L1_INTERLEAVED, device)
+
+
+# Explicit padding — 2/4/6-elem variants; composite pads before prim::fold.
+
+
+@pytest.mark.parametrize(
+    "shape, stride, padding",
+    [
+        pytest.param((1, 14, 14, 8), (2, 2), [1, 1], id="sym_h1_w1"),  # 2-elem: symmetric [pad_h, pad_w].
+        pytest.param((1, 14, 14, 8), (2, 2), [1, 1, 1, 1], id="asym_h1_w1"),  # 4-elem: [top, bot, l, r].
+        pytest.param((1, 16, 16, 8), (2, 2), [0, 0, 0, 0, 0, 8], id="c_pad_only"),  # 6-elem: with C padding.
+    ],
+)
+def test_fold_padding(shape, stride, padding, device):
+    _run_fold(
+        shape,
+        stride[0],
+        stride[1],
+        ttnn.ROW_MAJOR_LAYOUT,
+        L1_INTERLEAVED,
+        L1_INTERLEAVED,
+        device,
+        padding=padding,
+    )
+
+
+# use_transpose_as_fold=True — legacy pad+transpose+reshape+slice smoke (deep coverage lives in test_fold_op.py).
+
+
+def test_fold_use_transpose_as_fold_smoke(device):
+    """Legacy pad+transpose+reshape+slice branch still runs (retirement blocked on #29514)."""
+    shape = (1, 16, 16, 4)
+    torch.manual_seed(0)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(
+        x, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=L1_INTERLEAVED
+    )
+    result = ttnn.fold(ttnn_in, 2, 2, use_transpose_as_fold=True)
+    assert result is not None and len(result.shape) == 4
+
+
+# Negative test — invalid shard shape must FATAL, not silently truncate.
+
+
+def test_fold_invalid_shard_shape_fatals(device):
+    """Fast path requires shard_h % (input_W * stride_h) == 0; non-divisible height must be repaired by reshard_if_needed or FATAL cleanly (no SIGFPE)."""
+    shape = (1, 16, 16, 8)
+    total_h = 1 * 16 * 16
+    grid = device.compute_with_storage_grid_size()
+    num_cores = 16
+    if grid.x * grid.y < num_cores:
+        pytest.skip("Not enough cores for this negative test")
+    shard_grid = ttnn.num_cores_to_corerangeset(num_cores, grid, True)
+    bad_mc = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(shard_grid, [total_h // num_cores, 8], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(x, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=bad_mc)
+    try:
+        result = ttnn.fold(ttnn_in, 2, 2)
+        # reshard_if_needed may repair the shard height; if so, verify correctness.
+        ref = _fold_golden(x, 2, 2)
+        got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+        assert_with_pcc(ref.float(), got.float(), 0.9999)
+    except RuntimeError as e:
+        # Clean FATAL — must not be a SIGFPE / segfault.
+        assert "shard height" in str(e).lower() or "stride" in str(e).lower(), f"Unexpected FATAL message: {e}"
+
+
+# collapse_output=True — device op emits (1,1,N*H'*W',C·sh·sw) via compute_output_specs across every routing path.
+
+
+@pytest.mark.parametrize(
+    "layout, shape, in_mc_factory, out_mc",
+    [
+        # RM interleaved.
+        pytest.param(
+            ttnn.ROW_MAJOR_LAYOUT, (1, 16, 16, 8), lambda s, d: L1_INTERLEAVED, L1_INTERLEAVED, id="rm_l1_interleaved"
+        ),
+        pytest.param(
+            ttnn.ROW_MAJOR_LAYOUT,
+            (1, 16, 16, 8),
+            lambda s, d: DRAM_INTERLEAVED,
+            DRAM_INTERLEAVED,
+            id="rm_dram_interleaved",
+        ),
+        # RM sharded (aligned, native).
+        pytest.param(
+            ttnn.ROW_MAJOR_LAYOUT, (1, 16, 16, 64), _height_shard_rm, None, id="rm_l1_height_sharded_fastpath"
+        ),
+        pytest.param(ttnn.ROW_MAJOR_LAYOUT, (1, 16, 16, 64), _width_shard_rm, None, id="rm_l1_width_sharded_native"),
+        pytest.param(ttnn.ROW_MAJOR_LAYOUT, (1, 16, 16, 64), _block_shard_rm, None, id="rm_l1_block_sharded_native"),
+        # RM sub-alignment W/B (composite L1-interleaved staging hop).
+        pytest.param(ttnn.ROW_MAJOR_LAYOUT, (1, 16, 16, 8), _width_shard_rm, None, id="rm_width_sh_sub_align"),
+        pytest.param(ttnn.ROW_MAJOR_LAYOUT, (1, 16, 16, 8), _block_shard_rm, None, id="rm_block_sh_sub_align"),
+        # DRAM H-sharded RM (native RM factory, not fast-path).
+        pytest.param(
+            ttnn.ROW_MAJOR_LAYOUT,
+            (1, 16, 16, 8),
+            lambda s, d: _height_shard_rm(s, d, num_cores=4, buffer_type=ttnn.BufferType.DRAM),
+            None,
+            id="rm_dram_height_sharded",
+        ),
+        # TILE interleaved (composite untilize hop).
+        pytest.param(ttnn.TILE_LAYOUT, (1, 16, 16, 8), lambda s, d: L1_INTERLEAVED, None, id="tile_l1_interleaved"),
+        pytest.param(ttnn.TILE_LAYOUT, (1, 16, 16, 8), lambda s, d: DRAM_INTERLEAVED, None, id="tile_dram_interleaved"),
+        # TILE W/B-sharded (composite untilize + L1-interleaved staging).
+        pytest.param(ttnn.TILE_LAYOUT, (1, 32, 32, 128), _tile_width_shard, None, id="tile_width_sh"),
+        pytest.param(ttnn.TILE_LAYOUT, (1, 32, 32, 128), _tile_block_shard, None, id="tile_block_sh"),
+    ],
+)
+def test_fold_collapse_output(layout, shape, in_mc_factory, out_mc, device):
+    """collapse_output cross-product over every input routing path — shape asserted collapsed, bytes equal to folded_4d + reshape reference."""
+    in_mc = in_mc_factory(shape, device)
+    _run_fold(shape, 2, 2, layout, in_mc, out_mc, device, collapse_output=True)
+
+
+def test_fold_collapse_output_shape_bytes_invariance(device):
+    """folded_4d and collapsed outputs are byte-identical (metadata-only difference); verified via torch.equal."""
+    torch.manual_seed(0)
+    shape = (1, 16, 16, 8)
+    stride_h, stride_w = 2, 2
+    x = torch.rand(shape, dtype=torch.bfloat16)
+
+    ttnn_in = ttnn.from_torch(x, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16, device=device)
+
+    folded_4d = ttnn.fold(ttnn_in, stride_h, stride_w)
+    collapsed = ttnn.fold(ttnn_in, stride_h, stride_w, collapse_output=True)
+
+    N, H, W, C = shape
+    Hp = H // stride_h
+    Wp = W // stride_w
+    Cp = C * stride_h * stride_w
+
+    assert tuple(folded_4d.shape) == (N, Hp, Wp, Cp)
+    assert tuple(collapsed.shape) == (1, 1, N * Hp * Wp, Cp)
+
+    t_folded = ttnn.to_torch(folded_4d.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    t_collapsed = ttnn.to_torch(collapsed.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    assert torch.equal(t_folded.reshape(1, 1, N * Hp * Wp, Cp), t_collapsed), "Byte equality broken between shapes"
+
+
+def test_fold_collapse_output_preserves_sharded_memory_config(device):
+    """H-sharded input + collapse_output: shard spec identical to folded_4d (rows_per_core = N·H'·W'/n_cores, orientation preserved)."""
+    shape = (1, 16, 16, 8)
+    in_mc = _height_shard_rm(shape, device, num_cores=4)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(x, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=in_mc)
+
+    r_folded = ttnn.fold(ttnn_in, 2, 2)
+    r_collapsed = ttnn.fold(ttnn_in, 2, 2, collapse_output=True)
+
+    assert r_folded.memory_config().memory_layout == ttnn.TensorMemoryLayout.HEIGHT_SHARDED
+    assert r_collapsed.memory_config().memory_layout == ttnn.TensorMemoryLayout.HEIGHT_SHARDED
+    assert (
+        r_folded.memory_config().shard_spec.shape == r_collapsed.memory_config().shard_spec.shape
+    ), "Shard spec must be invariant under folded_4d ↔ collapsed rewrite"
+    assert (
+        r_folded.memory_config().shard_spec.orientation == r_collapsed.memory_config().shard_spec.orientation
+    ), "Shard orientation must be preserved"
+
+
+def test_fold_collapse_output_override_memory_config(device):
+    """collapse_output + override_memory_config compose: shape reflects collapse, memconfig reflects override."""
+    shape = (1, 16, 16, 8)
+    in_mc = _height_shard_rm(shape, device, num_cores=4)
+    _run_fold(
+        shape,
+        2,
+        2,
+        ttnn.ROW_MAJOR_LAYOUT,
+        in_mc,
+        L1_INTERLEAVED,
+        device,
+        collapse_output=True,
+    )
+
+
+def test_fold_collapse_output_rejects_use_transpose_as_fold(device, expect_error):
+    """Legacy composite bypasses prim::fold → collapse_output has no plug-in point; must FATAL, not silently ignore."""
+    shape = (1, 16, 16, 8)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(x, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16, device=device)
+    with expect_error(RuntimeError, "collapse_output.*use_transpose_as_fold"):
+        ttnn.fold(ttnn_in, 2, 2, use_transpose_as_fold=True, collapse_output=True)
+
+
+# Specless sharded override — helper either reuses input's rescaled spec (matching layout) or synthesises fresh.
+
+
+def _l1_interleaved_factory(_shape, _device):
+    return L1_INTERLEAVED
+
+
+@pytest.mark.parametrize(
+    "layout_in, shape, in_mc_factory, override_layout, collapse_output",
+    [
+        # Interleaved input + specless H/W/B override → fresh synthesis.
+        pytest.param(
+            ttnn.ROW_MAJOR_LAYOUT,
+            (1, 16, 16, 64),
+            _l1_interleaved_factory,
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            False,
+            id="rm_l1_in_H_override",
+        ),
+        pytest.param(
+            ttnn.ROW_MAJOR_LAYOUT,
+            (1, 16, 16, 64),
+            _l1_interleaved_factory,
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            False,
+            id="rm_l1_in_W_override",
+        ),
+        pytest.param(
+            ttnn.ROW_MAJOR_LAYOUT,
+            (1, 16, 16, 64),
+            _l1_interleaved_factory,
+            ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            False,
+            id="rm_l1_in_B_override",
+        ),
+        # Sharded input + specless override (matching-layout → reuse; cross-layout → fresh).
+        pytest.param(
+            ttnn.ROW_MAJOR_LAYOUT,
+            (1, 16, 16, 64),
+            _height_shard_rm,
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            False,
+            id="H_in_H_override_reuse",
+        ),
+        pytest.param(
+            ttnn.ROW_MAJOR_LAYOUT,
+            (1, 16, 16, 64),
+            _height_shard_rm,
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            False,
+            id="H_in_W_override_fresh",
+        ),
+        pytest.param(
+            ttnn.ROW_MAJOR_LAYOUT,
+            (1, 16, 16, 64),
+            _height_shard_rm,
+            ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            False,
+            id="H_in_B_override_fresh",
+        ),
+        # TILE input + specless sharded override (untilize hop + tail synth).
+        pytest.param(
+            ttnn.TILE_LAYOUT,
+            (1, 16, 16, 64),
+            _l1_interleaved_factory,
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            False,
+            id="tile_in_H_override",
+        ),
+        # Sub-align W/B → H-sharded override (composite stage + tail synth).
+        pytest.param(
+            ttnn.ROW_MAJOR_LAYOUT,
+            (1, 16, 16, 8),
+            _width_shard_rm,
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            False,
+            id="W_sub_align_H_override",
+        ),
+        pytest.param(
+            ttnn.ROW_MAJOR_LAYOUT,
+            (1, 16, 16, 8),
+            _block_shard_rm,
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            False,
+            id="B_sub_align_H_override",
+        ),
+        # collapse_output + specless override.
+        pytest.param(
+            ttnn.ROW_MAJOR_LAYOUT,
+            (1, 16, 16, 64),
+            _l1_interleaved_factory,
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            True,
+            id="collapse_l1_in_H_override",
+        ),
+    ],
+)
+def test_fold_specless_sharded_override_e2e(layout_in, shape, in_mc_factory, override_layout, collapse_output, device):
+    """E2E specless override cross-product — PCC vs golden covers both reuse and fresh-synthesis paths in the helper."""
+    in_mc = in_mc_factory(shape, device)
+    out_mc = ttnn.MemoryConfig(override_layout, ttnn.BufferType.L1)
+    _run_fold(shape, 2, 2, layout_in, in_mc, out_mc, device, collapse_output=collapse_output)
+
+
+# Matching-layout specless override — reuse branch must preserve input grid + orientation across aligned/sub-align/COL_MAJOR.
+
+
+@pytest.mark.parametrize(
+    "shard_factory, override_layout, orientation, shape",
+    [
+        pytest.param(
+            _height_shard_rm,
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.ShardOrientation.ROW_MAJOR,
+            (1, 16, 16, 64),
+            id="H_aligned_row_major",
+        ),
+        pytest.param(
+            _height_shard_rm,
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.ShardOrientation.COL_MAJOR,
+            (1, 16, 16, 64),
+            id="H_aligned_col_major",
+        ),
+        pytest.param(
+            _width_shard_rm,
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.ShardOrientation.ROW_MAJOR,
+            (1, 16, 16, 8),
+            id="W_sub_align_row_major",
+        ),
+        pytest.param(
+            _width_shard_rm,
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.ShardOrientation.COL_MAJOR,
+            (1, 16, 16, 8),
+            id="W_sub_align_col_major",
+        ),
+        pytest.param(
+            _block_shard_rm,
+            ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            ttnn.ShardOrientation.ROW_MAJOR,
+            (1, 16, 16, 8),
+            id="B_sub_align_row_major",
+        ),
+    ],
+)
+def test_fold_specless_matching_layout_preserves_input_geometry(
+    shard_factory, override_layout, orientation, shape, device
+):
+    """Matching-layout specless override must reuse input's grid + orientation (not synthesise full compute grid)."""
+    in_mc = shard_factory(shape, device, orientation=orientation)
+    out_mc = ttnn.MemoryConfig(override_layout, ttnn.BufferType.L1)
+    torch.manual_seed(0)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(x, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=in_mc)
+    result = ttnn.fold(ttnn_in, 2, 2, override_memory_config=out_mc)
+    mc = result.memory_config()
+    assert mc.memory_layout == override_layout
+    assert mc.shard_spec is not None
+    assert (
+        mc.shard_spec.grid == in_mc.shard_spec.grid
+    ), f"Matching-layout reuse must preserve input grid; got {mc.shard_spec.grid} vs input {in_mc.shard_spec.grid}"
+    assert (
+        mc.shard_spec.orientation == orientation
+    ), f"Matching-layout reuse must preserve input orientation; got {mc.shard_spec.orientation}"
+    ref = _fold_golden(x, 2, 2)
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    assert_with_pcc(ref.float(), got.float(), 0.9999)
+
+
+# COL_MAJOR sharded input + cross-layout specless override — fresh-synth inherits input's orientation (was silently ROW_MAJOR before).
+@pytest.mark.parametrize(
+    "override_layout",
+    [
+        pytest.param(ttnn.TensorMemoryLayout.WIDTH_SHARDED, id="H_col_major_in_W_override"),
+        pytest.param(ttnn.TensorMemoryLayout.BLOCK_SHARDED, id="H_col_major_in_B_override"),
+    ],
+)
+def test_fold_specless_cross_layout_override_inherits_input_orientation(override_layout, device):
+    """Cross-layout fresh-synth branch must inherit input's orientation, not silently emit ROW_MAJOR."""
+    shape = (1, 16, 16, 64)
+    in_mc = _height_shard_rm(shape, device, orientation=ttnn.ShardOrientation.COL_MAJOR)
+    out_mc = ttnn.MemoryConfig(override_layout, ttnn.BufferType.L1)
+    torch.manual_seed(0)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(x, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=in_mc)
+    result = ttnn.fold(ttnn_in, 2, 2, override_memory_config=out_mc)
+    mc = result.memory_config()
+    assert mc.shard_spec is not None
+    assert (
+        mc.shard_spec.orientation == ttnn.ShardOrientation.COL_MAJOR
+    ), f"Cross-layout fresh-synth must inherit input's COL_MAJOR; got {mc.shard_spec.orientation}"
+    ref = _fold_golden(x, 2, 2)
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    assert_with_pcc(ref.float(), got.float(), 0.9999)
+
+
+def test_fold_from_torch_rejects_specless_sharded_input(device, expect_error):
+    """Doc: from_torch refuses specless sharded MC — fold's has_value() input guards are defensive-only."""
+    x = torch.rand(1, 16, 16, 8, dtype=torch.bfloat16)
+    specless_mc = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1)
+    with expect_error(RuntimeError, "[Ss]hard spec must not be None"):
+        ttnn.from_torch(x, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=specless_mc)
+
+
+@pytest.mark.parametrize(
+    "shape,override_layout",
+    [
+        pytest.param(
+            (1, 8, 8, 64), ttnn.TensorMemoryLayout.HEIGHT_SHARDED, id="H_shrinks"
+        ),  # post-fold rows=16 → 16 cores (not 64).
+        pytest.param(
+            (1, 4, 4, 64), ttnn.TensorMemoryLayout.BLOCK_SHARDED, id="B_shrinks"
+        ),  # post-fold 4×256 → 4x8=32 cores (not 64).
+    ],
+)
+def test_fold_specless_sharded_override_grid_shrinks_when_rows_lt_max_cores(shape, override_layout, device):
+    """rows < max_cores after fold → synthesised grid must size to actual populated shards, not full compute grid."""
+    in_mc = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
+    out_mc = ttnn.MemoryConfig(override_layout, ttnn.BufferType.L1)
+    torch.manual_seed(0)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(x, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=in_mc)
+    result = ttnn.fold(ttnn_in, 2, 2, override_memory_config=out_mc)
+    max_cores = device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y
+    mc = result.memory_config()
+    assert mc.shard_spec is not None
+    assert (
+        mc.shard_spec.grid.num_cores() < max_cores
+    ), f"Synthesised grid over-declared cores: {mc.shard_spec.grid.num_cores()} == max {max_cores}"
+    ref = _fold_golden(x, 2, 2)
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    assert_with_pcc(ref.float(), got.float(), 0.9999)
+
+
+# Coverage-gap tests — TILE H-sharded input, fast-path reshard trigger.
+
+
+def test_fold_tile_height_sharded_input(device):
+    """TILE + L1 H-sharded input → composite untilizes to RM H-sharded and then falls into the zero-NOC fast path (mirrors transpose's tile-then-untilize pattern)."""
+    shape = (1, 32, 32, 32)
+    total_h = shape[0] * shape[1] * shape[2]
+    grid = device.compute_with_storage_grid_size()
+    num_cores = 4
+    shard_grid = ttnn.num_cores_to_corerangeset(num_cores, grid, True)
+    in_mc = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(shard_grid, [total_h // num_cores, shape[3]], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    _run_fold(shape, 2, 2, ttnn.TILE_LAYOUT, in_mc, L1_INTERLEAVED, device)
+
+
+def test_fold_fast_path_reshard_trigger_specless_matching_layout_override(device):
+    """Fast-path input misaligned to (W*stride_h) → reshard_if_needed fires; tail helper must rescale post-reshard geometry, not original."""
+    # total_H=24, W*stride_h=8, patch=4; shard_h=6 trips reshard AND 6%4=2 (would under-cover if pre-reshard geometry were used).
+    shape = (1, 6, 4, 64)
+    in_mc = _height_shard_rm(shape, device, num_cores=4)
+    assert in_mc.shard_spec.shape[0] % (shape[2] * 2) != 0, "test setup must trip reshard_if_needed"
+    assert in_mc.shard_spec.shape[0] % (2 * 2) != 0, "test setup must expose the integer-truncation bug on pre-fix path"
+    out_mc = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1)  # specless matching-layout.
+    torch.manual_seed(0)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(x, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=in_mc)
+    result = ttnn.fold(ttnn_in, 2, 2, override_memory_config=out_mc)
+    ref = _fold_golden(x, 2, 2)
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    assert_with_pcc(ref.float(), got.float(), 0.9999)

--- a/tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py
+++ b/tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py
@@ -390,7 +390,6 @@ def test_fold(act_shape, stride_h, stride_w, device):
     torch_input = torch.randn(act_shape, dtype=torch.bfloat16)
 
     expected = fold_torch(torch_input, stride_h, stride_w)
-    expected = expected.reshape(1, 1, -1, expected.shape[-1])
 
     tt_input = torch2tt_tensor(
         torch_input,
@@ -414,7 +413,6 @@ def run_fold_sharded_test(device, act_shape, stride_h, stride_w, padding, core_g
         torch_input = torch.randn(shape, dtype=torch.bfloat16)
 
         expected = fold_torch(torch_input, stride_h, stride_w, padding=padding)
-        expected = expected.reshape(1, 1, -1, expected.shape[-1])
 
         if core_grid is None:
             # Fit to max cores that divides total elements without padding. In case of padding cases,

--- a/tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py
+++ b/tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py
@@ -400,7 +400,6 @@ def test_fold(act_shape, stride_h, stride_w, device):
     torch_input = torch.randn(act_shape, dtype=torch.bfloat16)
 
     expected = fold_torch(torch_input, stride_h, stride_w)
-    expected = expected.reshape(1, 1, -1, expected.shape[-1])
 
     tt_input = torch2tt_tensor(
         torch_input,
@@ -424,7 +423,6 @@ def run_fold_sharded_test(device, act_shape, stride_h, stride_w, padding, core_g
         torch_input = torch.randn(shape, dtype=torch.bfloat16)
 
         expected = fold_torch(torch_input, stride_h, stride_w, padding=padding)
-        expected = expected.reshape(1, 1, -1, expected.shape[-1])
 
         if core_grid is None:
             # Fit to max cores that divides total elements without padding. In case of padding cases,

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
@@ -5,96 +5,146 @@
 #include "fold_device_op.hpp"
 #include "ttnn/device_operation.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
+#include <tt-metalium/math.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/work_split.hpp>
 
 namespace ttnn::operations::data_movement {
 
-Fold::program_factory_t Fold::select_program_factory(
-    const operation_attributes_t& op_attr, const tensor_args_t& /*tensors*/) {
-    if (op_attr.is_sharded) {
-        return MultiCore{};
-    }
-    return MultiCoreDRAMFold{};
+bool is_fast_path_input(const Tensor& t) {
+    return t.memory_config().is_l1() && t.is_sharded() && t.shard_spec().has_value() &&
+           t.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED && t.layout() == Layout::ROW_MAJOR;
 }
 
-void validate_fold(const std::vector<Tensor>& input_tensors, bool is_sharded, uint32_t stride_h, uint32_t stride_w) {
-    const Tensor& input_tensor = input_tensors.at(0);
+tt::tt_metal::ShardSpec synthesize_fold_output_shard_spec(
+    const Tensor& input_tensor, tt::tt_metal::TensorMemoryLayout layout, uint32_t rows, uint32_t cols) {
+    auto* device = input_tensor.device();
+    const auto grid = device->compute_with_storage_grid_size();
+    const uint32_t max_cores = grid.x * grid.y;
+    std::array<uint32_t, 2> shape = {0, 0};
+    CoreRangeSet cores;
+    switch (layout) {
+        case TensorMemoryLayout::HEIGHT_SHARDED: {
+            shape = {tt::div_up(rows, max_cores), cols};
+            cores = tt::tt_metal::num_cores_to_corerangeset(tt::div_up(rows, shape[0]), grid, /*row_wise=*/true);
+            break;
+        }
+        case TensorMemoryLayout::WIDTH_SHARDED: {
+            shape = {rows, tt::div_up(cols, max_cores)};
+            cores = tt::tt_metal::num_cores_to_corerangeset(tt::div_up(cols, shape[1]), grid, /*row_wise=*/true);
+            break;
+        }
+        default: {  // BLOCK_SHARDED
+            shape = {tt::div_up(rows, grid.y), tt::div_up(cols, grid.x)};
+            const uint32_t n_rows = tt::div_up(rows, shape[0]);
+            const uint32_t n_cols = tt::div_up(cols, shape[1]);
+            cores = CoreRangeSet(CoreRange({0, 0}, {n_cols - 1, n_rows - 1}));
+            break;
+        }
+    }
+    // Inherit input's orientation when available (mirrors generate_transpose_shard_spec); ROW_MAJOR fallback for
+    // non-sharded inputs.
+    tt::tt_metal::ShardOrientation orientation = input_tensor.shard_spec().has_value()
+                                                     ? input_tensor.shard_spec()->orientation
+                                                     : tt::tt_metal::ShardOrientation::ROW_MAJOR;
+    return tt::tt_metal::ShardSpec(cores, shape, orientation);
+}
 
+Fold::program_factory_t Fold::select_program_factory(
+    const operation_attributes_t& /*op_attr*/, const tensor_args_t& tensors) {
+    return is_fast_path_input(tensors.input_tensor) ? program_factory_t{MultiCore{}}
+                                                    : program_factory_t{MultiCoreDRAMFold{}};
+}
+
+void validate_fold(const std::vector<Tensor>& input_tensors, uint32_t stride_h, uint32_t stride_w) {
+    const Tensor& input_tensor = input_tensors.at(0);
     const auto& input_shape = input_tensor.padded_shape();
 
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Fold: Expect input tensor to be stored on device.");
     TT_FATAL(input_tensor.buffer() != nullptr, "Fold: Expect input tensor to be allocated on a device buffer.");
-    if (is_sharded) {
-        TT_FATAL(
-            input_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED,
-            "Fold: Only height-sharded input tensors are supported.");
 
+    // Reject zero strides before any modulo/div; guards both fast + composite paths and compute_output_specs.
+    TT_FATAL(stride_h > 0 && stride_w > 0, "Fold: stride_h ({}) and stride_w ({}) must be > 0.", stride_h, stride_w);
+    // H/W divisibility applies to both paths (fast-path's shard-shape check does not imply width divisibility).
+    TT_FATAL(
+        input_shape[1] % stride_h == 0,
+        "Fold: Input height ({}) must be divisible by stride_h ({}).",
+        input_shape[1],
+        stride_h);
+    TT_FATAL(
+        input_shape[2] % stride_w == 0,
+        "Fold: Input width ({}) must be divisible by stride_w ({}).",
+        input_shape[2],
+        stride_w);
+
+    if (is_fast_path_input(input_tensor)) {
         auto shard_shape = input_tensor.shard_spec().value().shape;
         TT_FATAL(
             shard_shape[0] % (input_shape[2] * stride_h) == 0,
-            "Fold: Shard height must be divisible by input width times stride_h for proper folding operation.");
-        TT_FATAL(input_tensor.layout() == Layout::ROW_MAJOR, "Fold: Expect sharded input tensor in row-major layout.");
-    } else {
-        TT_FATAL(input_shape[1] % stride_h == 0, "Fold: Input height must be divisible by stride_h.");
-        TT_FATAL(input_shape[2] % stride_w == 0, "Fold: Input width must be divisible by stride_w.");
+            "Fold (fast path): shard height must be divisible by input width times stride_h.");
+    } else if (input_tensor.is_sharded() && input_tensor.shard_spec().has_value()) {
+        // Per-shard sticks must be patch_size-divisible; else fold silently truncates. Specless → compute_output_specs
+        // synthesises.
+        const auto& spec = input_tensor.shard_spec().value();
+        const uint32_t patch_size = stride_h * stride_w;
+        TT_FATAL(
+            spec.shape[0] % patch_size == 0,
+            "Fold: sharded input shard height ({}) must be divisible by patch_size ({}).",
+            spec.shape[0],
+            patch_size);
     }
 }
 
 void Fold::validate_on_program_cache_miss(const operation_attributes_t& op_attr, const tensor_args_t& tensors) {
-    validate_fold({tensors.input_tensor}, op_attr.is_sharded, op_attr.stride_h, op_attr.stride_w);
+    validate_fold({tensors.input_tensor}, op_attr.stride_h, op_attr.stride_w);
 }
 
 void Fold::validate_on_program_cache_hit(const operation_attributes_t& op_attr, const tensor_args_t& tensors) {
-    validate_fold({tensors.input_tensor}, op_attr.is_sharded, op_attr.stride_h, op_attr.stride_w);
+    validate_fold({tensors.input_tensor}, op_attr.stride_h, op_attr.stride_w);
 }
 
 Fold::spec_return_value_t Fold::compute_output_specs(
     const operation_attributes_t& op_attr, const tensor_args_t& tensors) {
-    auto input_tensor = tensors.input_tensor;
+    const auto& input_tensor = tensors.input_tensor;
     const ttnn::Shape& input_shape = input_tensor.logical_shape();
     auto input_dtype = input_tensor.dtype();
 
     tt::tt_metal::DataType output_dtype =
-        (input_dtype == tt::tt_metal::DataType::FLOAT32 ||
-         input_dtype == tt::tt_metal::DataType::UINT16)
+        (input_dtype == tt::tt_metal::DataType::FLOAT32 || input_dtype == tt::tt_metal::DataType::UINT16)
             ? input_dtype
             : tt::tt_metal::DataType::BFLOAT16;
 
-    // we concatenate (stride_h sticks in H-dim) * (stride_w in W-dim) into 1 stick along C-dim
-    ttnn::Shape output_shape(
-        {1,
-         1,
-         input_shape[0] * input_shape[1] * input_shape[2] / (op_attr.stride_h * op_attr.stride_w),
-         input_shape[3] * op_attr.stride_h * op_attr.stride_w});
+    // NHWC pixel_unshuffle; folded_4d vs collapsed picked upfront — shard bytes identical.
+    const uint32_t out_N = input_shape[0];
+    const uint32_t out_H = input_shape[1] / op_attr.stride_h;
+    const uint32_t out_W = input_shape[2] / op_attr.stride_w;
+    const uint32_t out_C = input_shape[3] * op_attr.stride_h * op_attr.stride_w;
+    ttnn::Shape output_shape = op_attr.collapse_output ? ttnn::Shape({1, 1, out_N * out_H * out_W, out_C})
+                                                       : ttnn::Shape({out_N, out_H, out_W, out_C});
 
-    if (op_attr.is_sharded) {
-        auto shard_spec = input_tensor.shard_spec().value();
-        shard_spec.shape[0] /= op_attr.stride_h * op_attr.stride_w;
-        shard_spec.shape[1] *= op_attr.stride_h * op_attr.stride_w;
-        auto mem_config = MemoryConfig(
-            input_tensor.memory_config().memory_layout(), input_tensor.memory_config().buffer_type(), shard_spec);
+    tt::tt_metal::MemoryConfig out_mem_config = input_tensor.memory_config();
+    if (input_tensor.is_sharded()) {
+        const uint32_t patch_size = op_attr.stride_h * op_attr.stride_w;
+        // Concrete spec → rescale (h/=patch, w*=patch); specless → synthesise via shared helper.
+        tt::tt_metal::ShardSpec output_spec =
+            input_tensor.shard_spec().has_value()
+                ? [&] {
+                      auto s = input_tensor.shard_spec().value();
+                      s.shape[0] /= patch_size;
+                      s.shape[1] *= patch_size;
+                      return s;
+                  }()
+                : synthesize_fold_output_shard_spec(input_tensor, input_tensor.memory_config().memory_layout(), out_N * out_H * out_W, out_C);
+        out_mem_config = MemoryConfig(
+            input_tensor.memory_config().memory_layout(), input_tensor.memory_config().buffer_type(), output_spec);
+    }
 
-        return {tt::tt_metal::TensorSpec(
-            output_shape,
-            tt::tt_metal::TensorLayout(
-                output_dtype, tt::tt_metal::PageConfig(tt::tt_metal::Layout::ROW_MAJOR), mem_config))};
-    }
-    // Interleaved tensors (DRAM or L1)
-    ttnn::Shape output_logical_shape = output_shape;
-    if (input_tensor.memory_config().is_dram()) {
-        // DRAM path preserves 4D shape; for tiled inputs the caller reshapes afterward
-        output_logical_shape = ttnn::Shape({input_shape[0], input_shape[1], input_shape[2], input_shape[3]});
-        if (input_tensor.layout() == Layout::ROW_MAJOR) {
-            output_logical_shape = ttnn::Shape(
-                {input_shape[0],
-                 input_shape[1] / op_attr.stride_h,
-                 input_shape[2] / op_attr.stride_w,
-                 input_shape[3] * op_attr.stride_h * op_attr.stride_w});
-        }
-    }
+    // Single output-shape rule — folded_4d (or collapsed) for every mem_cfg/layout; composite (fold.cpp) handles any
+    // TILE-input post-reshape it needs from the fixed contract.
     return {tt::tt_metal::TensorSpec(
-        output_logical_shape,
+        output_shape,
         tt::tt_metal::TensorLayout(
-            output_dtype, tt::tt_metal::PageConfig(Layout::ROW_MAJOR), input_tensor.memory_config()))};
+            output_dtype, tt::tt_metal::PageConfig(tt::tt_metal::Layout::ROW_MAJOR), out_mem_config))};
 }
 
 Fold::tensor_return_value_t Fold::create_output_tensors(
@@ -106,10 +156,10 @@ Fold::tensor_return_value_t Fold::create_output_tensors(
 
 namespace ttnn::prim {
 ttnn::operations::data_movement::Fold::tensor_return_value_t fold(
-    const ttnn::Tensor& input_tensor, uint32_t stride_h, uint32_t stride_w) {
+    const ttnn::Tensor& input_tensor, uint32_t stride_h, uint32_t stride_w, bool collapse_output) {
     using OperationType = ttnn::operations::data_movement::Fold;
     auto operation_attributes = OperationType::operation_attributes_t{
-        .stride_h = stride_h, .stride_w = stride_w, .is_sharded = input_tensor.is_sharded()};
+        .stride_h = stride_h, .stride_w = stride_w, .collapse_output = collapse_output};
     auto tensor_args = OperationType::tensor_args_t{.input_tensor = input_tensor};
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.hpp
@@ -13,11 +13,21 @@
 
 namespace ttnn::operations::data_movement {
 
+// Fast path: L1 + HS + RM + concrete shard_spec. Shared by composite and device_op.
+bool is_fast_path_input(const Tensor& t);
+
+// Fresh shard-spec for specless sharded outputs, sized to the populated shard count (not the
+// full compute grid): H/W → num_cores_to_corerangeset over used cores; B → rectangular CoreRange.
+// Shared by compute_output_specs and derive_effective_override_memory_config.
+tt::tt_metal::ShardSpec synthesize_fold_output_shard_spec(
+    const Tensor& input_tensor, tt::tt_metal::TensorMemoryLayout layout, uint32_t rows, uint32_t cols);
+
 struct Fold {
     struct operation_attributes_t {
         uint32_t stride_h{};
         uint32_t stride_w{};
-        bool is_sharded{};
+        // true → emit collapsed (1,1,N·H'·W',C·sh·sw); false → folded_4d.
+        bool collapse_output{};
     };
 
     struct tensor_args_t {
@@ -54,5 +64,5 @@ struct Fold {
 
 namespace ttnn::prim {
 ttnn::operations::data_movement::Fold::tensor_return_value_t fold(
-    const ttnn::Tensor& input_tensor, uint32_t stride_h, uint32_t stride_w);
+    const ttnn::Tensor& input_tensor, uint32_t stride_h, uint32_t stride_w, bool collapse_output = false);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
@@ -30,6 +30,8 @@ using namespace tt::tt_metal;
 
 namespace {
 
+// TILE-native factory (unreachable): tile-index math only correct for (N,32,32,C≤32); composite untilizes before
+// dispatch. Rewrite would remove the untilize hop.
 ProgramDescriptor fold_multi_core_tiled_interleaved(
     const Tensor& input_tensor, const Tensor& output, const uint32_t stride_h, const uint32_t stride_w) {
     auto* device = input_tensor.device();
@@ -150,8 +152,7 @@ ProgramDescriptor fold_multi_core_tiled_interleaved(
     writer_desc.compile_time_args = std::move(writer_compile_time_args);
     writer_desc.config = WriterConfigDescriptor{};
 
-    // Compute kernel arguments — main grid and (optional) cliff grid handle the
-    // last core when the work doesn't divide evenly.
+    // Compute kernel args; main grid + optional cliff grid handle non-evenly-divisible work.
     std::vector<uint32_t> compute_compile_time_args = {
         nblocks_per_core * tiles_per_width_dim,
         tiles_per_channel_dim,
@@ -274,16 +275,21 @@ ProgramDescriptor fold_multi_core_row_major_interleaved(
     log_debug(tt::LogOp, "output_tensor_shape: {}", output.padded_shape());
 
     uint32_t patches_per_core = tt::div_up(total_patches, num_cores_total);
+    // Only launch on cores that actually hold work; per-core work is a runtime arg so the cliff core carries a partial
+    // tail.
+    uint32_t num_active_cores = tt::div_up(total_patches, patches_per_core);
 
     log_debug(
         tt::LogOp,
-        "total_patches: {}, num_cores_total: {}, patches_per_core: {}",
+        "total_patches: {}, num_cores_total: {}, patches_per_core: {}, num_active_cores: {}",
         total_patches,
         num_cores_total,
-        patches_per_core);
+        patches_per_core,
+        num_active_cores);
 
-    CoreRangeSet all_cores{CoreRange({0, 0}, {num_cores_x - 1, num_cores_y - 1})};
-    auto cores = grid_to_cores(num_cores_total, num_cores_x, num_cores_y, true);
+    CoreRangeSet active_cores =
+        tt::tt_metal::num_cores_to_corerangeset(num_active_cores, compute_grid_size, /*row_wise=*/true);
+    auto cores = grid_to_cores(num_active_cores, num_cores_x, num_cores_y, /*row_wise=*/true);
 
     const uint32_t cb_src0_index = tt::CBIndex::c_0;
 
@@ -304,7 +310,7 @@ ProgramDescriptor fold_multi_core_row_major_interleaved(
     {
         CBDescriptor cb;
         cb.total_size = double_buffer * aligned_stick_nbytes * stride_w * stride_h;
-        cb.core_ranges = all_cores;
+        cb.core_ranges = active_cores;
         cb.format_descriptors.push_back(CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(cb_src0_index),
             .data_format = cb_data_format,
@@ -321,7 +327,7 @@ ProgramDescriptor fold_multi_core_row_major_interleaved(
         log_debug(tt::LogOp, "Using intermediate L1 scratch buffer for src1");
         CBDescriptor cb;
         cb.total_size = stick_nbytes * stride_w * stride_h;
-        cb.core_ranges = all_cores;
+        cb.core_ranges = active_cores;
         cb.format_descriptors.push_back(CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(cb_src1_index),
             .data_format = cb_data_format,
@@ -330,7 +336,7 @@ ProgramDescriptor fold_multi_core_row_major_interleaved(
         desc.cbs.push_back(std::move(cb));
     }
 
-    // Common compile-time args shared by reader and writer (indices 0..8)
+    // Common compile-time args shared by reader and writer. work_per_core is a runtime arg now.
     std::vector<uint32_t> common_compile_time_args(
         {stick_nbytes,
          cb_src0_index,
@@ -338,7 +344,6 @@ ProgramDescriptor fold_multi_core_row_major_interleaved(
          stride_h,
          stride_w,
          input_width,
-         patches_per_core,
          cb_src1_index,
          is_l1_aligned});
 
@@ -347,9 +352,9 @@ ProgramDescriptor fold_multi_core_row_major_interleaved(
     TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
     KernelDescriptor reader_desc;
     reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2cb_for_rm_input.cpp";
+        "ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_input2cb_for_rm.cpp";
     reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores;
+    reader_desc.core_ranges = active_cores;
     reader_desc.compile_time_args = std::move(reader_compile_time_args);
     reader_desc.config = ReaderConfigDescriptor{};
 
@@ -358,9 +363,9 @@ ProgramDescriptor fold_multi_core_row_major_interleaved(
     TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
     KernelDescriptor writer_desc;
     writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2dram_for_rm_input.cpp";
+        "ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2output_for_rm.cpp";
     writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
+    writer_desc.core_ranges = active_cores;
     writer_desc.compile_time_args = std::move(writer_compile_time_args);
     writer_desc.config = WriterConfigDescriptor{};
 
@@ -369,31 +374,23 @@ ProgramDescriptor fold_multi_core_row_major_interleaved(
     const uint32_t output_width = input_width / stride_w;
     const uint32_t patch_size = stride_h * stride_w;
     const uint32_t output_hw = output_height * output_width;
-    uint32_t curr_patches = 0;
-    uint32_t src_idx = 0;
-    uint32_t dst_idx = 0;
-    uint32_t src_col_offset = 0;
     for (uint32_t i = 0; i < cores.size(); i++) {
         CoreCoord core = cores[i];
+        const uint32_t output_offset = i * patches_per_core;
+        const uint32_t patches_this_core =
+            (output_offset + patches_per_core <= total_patches) ? patches_per_core : (total_patches - output_offset);
+        const uint32_t batch_idx = output_offset / output_hw;
+        const uint32_t batch_offset = output_offset % output_hw;
+        const uint32_t out_height = batch_offset / output_width;
+        const uint32_t out_width = batch_offset % output_width;
 
-        if (curr_patches < total_patches) {
-            uint32_t output_offset = i * patches_per_core;
-            uint32_t batch_idx = output_offset / output_hw;
-            uint32_t batch_offset = output_offset % output_hw;
-            uint32_t out_height = batch_offset / output_width;
-            uint32_t out_width = batch_offset % output_width;
+        const uint32_t src_batch_offset = batch_idx * output_height * output_width * patch_size;
+        const uint32_t src_row_offset = out_height * stride_h * input_width;
+        const uint32_t src_col_offset = out_width * stride_w;
+        const uint32_t src_idx = src_batch_offset + src_row_offset + src_col_offset;
 
-            uint32_t src_batch_offset = batch_idx * output_height * output_width * patch_size;
-            uint32_t src_row_offset = out_height * stride_h * input_width;
-            src_col_offset = out_width * stride_w;
-
-            src_idx = src_batch_offset + src_row_offset + src_col_offset;
-            dst_idx = output_offset;
-        }
-
-        curr_patches += patches_per_core;
-        reader_desc.emplace_runtime_args(core, {src0_buffer, src_idx, src_col_offset});
-        writer_desc.emplace_runtime_args(core, {dst_buffer, dst_idx});
+        reader_desc.emplace_runtime_args(core, {src0_buffer, patches_this_core, src_idx, src_col_offset});
+        writer_desc.emplace_runtime_args(core, {dst_buffer, patches_this_core, output_offset});
     }
 
     desc.kernels.push_back(std::move(reader_desc));
@@ -408,6 +405,7 @@ ProgramDescriptor Fold::MultiCoreDRAMFold::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output_tensor) {
+    // TILE branch unreachable — composite untilizes first; see comment above the factory.
     if (tensor_args.input_tensor.layout() == Layout::TILE) {
         log_debug(tt::LogOp, "Fold operation with DRAM tiled input");
         return fold_multi_core_tiled_interleaved(

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_dram_program_factory.cpp
@@ -41,6 +41,8 @@ DataflowBufferSpec make_dfb(
     };
 }
 
+// TILE-native factory (unreachable): tile-index math only correct for (N,32,32,C≤32); composite untilizes before
+// dispatch. Rewrite would remove the untilize hop.
 ttnn::device_operation::ProgramArtifacts fold_multi_core_tiled_interleaved(
     const Tensor& input_tensor, const Tensor& output, const uint32_t stride_h, const uint32_t stride_w) {
     auto* device = input_tensor.device();
@@ -316,16 +318,21 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_row_major_interleaved(
     log_debug(tt::LogOp, "output_tensor_shape: {}", output.padded_shape());
 
     uint32_t patches_per_core = tt::div_up(total_patches, num_cores_total);
+    // Only launch cores that actually hold work; per-core work is a runtime arg so the cliff core carries a partial
+    // tail without over-reading past total_patches.
+    uint32_t num_active_cores = tt::div_up(total_patches, patches_per_core);
 
     log_debug(
         tt::LogOp,
-        "total_patches: {}, num_cores_total: {}, patches_per_core: {}",
+        "total_patches: {}, num_cores_total: {}, patches_per_core: {}, num_active_cores: {}",
         total_patches,
         num_cores_total,
-        patches_per_core);
+        patches_per_core,
+        num_active_cores);
 
-    CoreRangeSet all_cores{CoreRange({0, 0}, {num_cores_x - 1, num_cores_y - 1})};
-    auto cores = grid_to_cores(num_cores_total, num_cores_x, num_cores_y, true);
+    CoreRangeSet all_cores =
+        tt::tt_metal::num_cores_to_corerangeset(num_active_cores, compute_grid_size, /*row_wise=*/true);
+    auto cores = grid_to_cores(num_active_cores, num_cores_x, num_cores_y, /*row_wise=*/true);
 
     uint32_t stick_nbytes = input_tensor.padded_shape()[3] * tt::datum_size(dfb_data_format);
     // Align to DRAM read alignment.
@@ -352,13 +359,13 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_row_major_interleaved(
     TensorParameter input_param{.unique_id = INPUT, .spec = input_tensor.tensor_spec()};
     TensorParameter output_param{.unique_id = OUTPUT, .spec = output.tensor_spec()};
 
+    // work_per_core is per-core runtime (see active-core split above); every other arg is uniform across cores.
     const KernelSpec::CompileTimeArgs common_cta{
         {"stick_nbytes", stick_nbytes},
         {"aligned_stick_nbytes_dram", aligned_stick_nbytes},
         {"stride_h", stride_h},
         {"stride_w", stride_w},
         {"input_width", input_width},
-        {"work_per_core", patches_per_core},
     };
 
     // Emit the NOT_L1_ALIGNED define to the writer only when the src1 scratch is bound
@@ -375,7 +382,7 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_row_major_interleaved(
             .dfb_spec_name = SRC0, .accessor_name = "in0", .endpoint_type = DFBEndpointType::PRODUCER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT, .accessor_name = "src"}},
         .compile_time_args = common_cta,
-        .runtime_arg_schema = {.runtime_arg_names = {"src_index", "curr_src_row_index"}},
+        .runtime_arg_schema = {.runtime_arg_names = {"work_per_core", "src_index", "curr_src_row_index"}},
         .hw_config = ttnn::create_reader_datamovement_config(device->arch()),
     };
 
@@ -395,7 +402,7 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_row_major_interleaved(
         .dfb_bindings = writer_dfbs,
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = OUTPUT, .accessor_name = "dst"}},
         .compile_time_args = common_cta,
-        .runtime_arg_schema = {.runtime_arg_names = {"dst_index"}},
+        .runtime_arg_schema = {.runtime_arg_names = {"work_per_core", "dst_index"}},
         .hw_config = ttnn::create_writer_datamovement_config(device->arch()),
     };
 
@@ -407,32 +414,36 @@ ttnn::device_operation::ProgramArtifacts fold_multi_core_row_major_interleaved(
     const uint32_t output_width = input_width / stride_w;
     const uint32_t patch_size = stride_h * stride_w;
     const uint32_t output_hw = output_height * output_width;
-    uint32_t curr_patches = 0;
-    uint32_t src_idx = 0;
-    uint32_t dst_idx = 0;
-    uint32_t src_col_offset = 0;
     for (uint32_t i = 0; i < cores.size(); i++) {
         CoreCoord core = cores[i];
 
-        if (curr_patches < total_patches) {
-            uint32_t output_offset = i * patches_per_core;
-            uint32_t batch_idx = output_offset / output_hw;
-            uint32_t batch_offset = output_offset % output_hw;
-            uint32_t out_height = batch_offset / output_width;
-            uint32_t out_width = batch_offset % output_width;
+        const uint32_t output_offset = i * patches_per_core;
+        // Cliff core carries a partial tail: patches_this_core = min(patches_per_core, total_patches - output_offset).
+        const uint32_t patches_this_core =
+            (output_offset + patches_per_core <= total_patches) ? patches_per_core : (total_patches - output_offset);
 
-            uint32_t src_batch_offset = batch_idx * output_height * output_width * patch_size;
-            uint32_t src_row_offset = out_height * stride_h * input_width;
-            src_col_offset = out_width * stride_w;
+        const uint32_t batch_idx = output_offset / output_hw;
+        const uint32_t batch_offset = output_offset % output_hw;
+        const uint32_t out_height = batch_offset / output_width;
+        const uint32_t out_width = batch_offset % output_width;
 
-            src_idx = src_batch_offset + src_row_offset + src_col_offset;
-            dst_idx = output_offset;
-        }
+        const uint32_t src_batch_offset = batch_idx * output_height * output_width * patch_size;
+        const uint32_t src_row_offset = out_height * stride_h * input_width;
+        const uint32_t src_col_offset = out_width * stride_w;
 
-        curr_patches += patches_per_core;
+        const uint32_t src_idx = src_batch_offset + src_row_offset + src_col_offset;
+        const uint32_t dst_idx = output_offset;
+
         AddRuntimeArgsForNode(
-            reader_run.runtime_arg_values, core, {{"src_index", src_idx}, {"curr_src_row_index", src_col_offset}});
-        AddRuntimeArgsForNode(writer_run.runtime_arg_values, core, {{"dst_index", dst_idx}});
+            reader_run.runtime_arg_values,
+            core,
+            {{"work_per_core", patches_this_core},
+             {"src_index", src_idx},
+             {"curr_src_row_index", src_col_offset}});
+        AddRuntimeArgsForNode(
+            writer_run.runtime_arg_values,
+            core,
+            {{"work_per_core", patches_this_core}, {"dst_index", dst_idx}});
     }
 
     ProgramSpec spec{

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2dfb_for_rm_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_dram2dfb_for_rm_input.cpp
@@ -7,6 +7,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/dataflow_buffer.h"
 #include "experimental/kernel_args.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 void kernel_main() {
@@ -15,24 +16,28 @@ void kernel_main() {
     constexpr uint32_t stride_h = get_arg(args::stride_h);
     constexpr uint32_t stride_w = get_arg(args::stride_w);
     constexpr uint32_t input_width = get_arg(args::input_width);
-    constexpr uint32_t work_per_core = get_arg(args::work_per_core);
 
+    // Generic accessor + noc_async_read_sharded helper: compile-time dispatch to noc.async_read for interleaved /
+    // H-sharded inputs and per-shard reads for W/B-sharded inputs.
     const auto s_in = TensorAccessor(tensor::src);
 
     Noc noc;
     DataflowBuffer dfb_in0(dfb::in0);
 
+    // work_per_core is runtime (per-core) so unused cores skip iteration and the cliff core can carry a partial tail.
+    uint32_t work_per_core = get_arg(args::work_per_core);
     uint32_t src_index = get_arg(args::src_index);
     uint32_t curr_src_row_index = get_arg(args::curr_src_row_index);
     for (uint32_t input_idx = 0; input_idx < work_per_core; input_idx++) {
         uint32_t curr_src_offset = src_index;
         dfb_in0.reserve_back(1);
-        uint32_t l1_offset = 0;
+        uint32_t l1_write_addr = dfb_in0.get_write_ptr();
         for (uint32_t i = 0; i < stride_h; i++) {
             for (uint32_t j = 0; j < stride_w; j++) {
-                noc.async_read(s_in, dfb_in0, stick_nbytes, {.page_id = curr_src_offset}, {.offset_bytes = l1_offset});
+                tt::data_movement::common::noc_async_read_sharded(
+                    noc, l1_write_addr, s_in, curr_src_offset, /*offset=*/0, /*size=*/stick_nbytes);
                 curr_src_offset++;
-                l1_offset += aligned_stick_nbytes_dram;
+                l1_write_addr += aligned_stick_nbytes_dram;
             }
             curr_src_offset += input_width - stride_w;
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_input2cb_for_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/reader_input2cb_for_rm.cpp
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
 
 void kernel_main() {
@@ -14,26 +15,31 @@ void kernel_main() {
     constexpr uint32_t stride_h = get_compile_time_arg_val(3);
     constexpr uint32_t stride_w = get_compile_time_arg_val(4);
     constexpr uint32_t input_width = get_compile_time_arg_val(5);
-    constexpr uint32_t work_per_core = get_compile_time_arg_val(6);
-    constexpr auto src_args = TensorAccessorArgs<9>();
+    // work_per_core is now runtime (per-core) so unused cores skip iteration and the cliff core can carry a partial
+    // tail.
+    constexpr auto src_args = TensorAccessorArgs<8>();
 
     uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t work_per_core = get_arg_val<uint32_t>(1);
+    // Generic accessor + noc_async_read_sharded helper: compile-time dispatch to noc.async_read for interleaved /
+    // H-sharded inputs and per-shard reads for W/B-sharded inputs.
     const auto s_in = TensorAccessor(src_args, src_addr);
 
     Noc noc;
     experimental::CB cb_in0(cb_id_in0);
 
-    uint32_t src_index = get_arg_val<uint32_t>(1);
-    uint32_t curr_src_row_index = get_arg_val<uint32_t>(2);
+    uint32_t src_index = get_arg_val<uint32_t>(2);
+    uint32_t curr_src_row_index = get_arg_val<uint32_t>(3);
     for (uint32_t input_idx = 0; input_idx < work_per_core; input_idx++) {
         uint32_t curr_src_offset = src_index;
         cb_in0.reserve_back(1);
-        uint32_t l1_offset = 0;
+        uint32_t l1_write_addr = cb_in0.get_write_ptr();
         for (uint32_t i = 0; i < stride_h; i++) {
             for (uint32_t j = 0; j < stride_w; j++) {
-                noc.async_read(s_in, cb_in0, stick_nbytes, {.page_id = curr_src_offset}, {.offset_bytes = l1_offset});
+                tt::data_movement::common::noc_async_read_sharded(
+                    noc, l1_write_addr, s_in, curr_src_offset, /*offset=*/0, /*size=*/stick_nbytes);
                 curr_src_offset++;
-                l1_offset += aligned_stick_nbytes_dram;
+                l1_write_addr += aligned_stick_nbytes_dram;
             }
             curr_src_offset += input_width - stride_w;
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2output_for_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_cb2output_for_rm.cpp
@@ -16,46 +16,42 @@ void kernel_main() {
     constexpr uint32_t stride_h = get_compile_time_arg_val(3);
     constexpr uint32_t stride_w = get_compile_time_arg_val(4);
     constexpr uint32_t input_width = get_compile_time_arg_val(5);
-    constexpr uint32_t work_per_core = get_compile_time_arg_val(6);
-    constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(7);
-    constexpr bool is_l1_aligned = get_compile_time_arg_val(8);
-    constexpr auto dst_args = TensorAccessorArgs<9>();
+    // work_per_core is now runtime (per-core) so unused cores skip iteration and the cliff core can carry a partial
+    // tail.
+    constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(6);
+    constexpr bool is_l1_aligned = get_compile_time_arg_val(7);
+    constexpr auto dst_args = TensorAccessorArgs<8>();
 
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    uint32_t work_per_core = get_arg_val<uint32_t>(1);
     constexpr uint32_t patch_size = stride_h * stride_w;
+    constexpr uint32_t output_stick_nbytes = stick_nbytes * patch_size;
+    // Generic accessor + noc_async_write_sharded helper: compile-time dispatch to noc.async_write for interleaved /
+    // H-sharded outputs and per-shard writes for W/B-sharded outputs.
     const auto s_out = TensorAccessor(dst_args, dst_addr);
-    uint32_t dst_index = get_arg_val<uint32_t>(1);
+    uint32_t dst_index = get_arg_val<uint32_t>(2);
 
     Noc noc;
     experimental::CB cb_in0(cb_id_in0);
     experimental::CB cb_in1(cb_id_in1);
 
     uint32_t intermed_l1_scratch = cb_in1.get_write_ptr();
-    // Datatypes will be multiple of 2 bytes only so it is safe to use uint16_t pointer
     volatile tt_l1_ptr uint16_t* patch_data = (volatile uint16_t*)intermed_l1_scratch;
     for (uint32_t input_idx = 0; input_idx < work_per_core; input_idx++) {
-        uint32_t idx = 0;
         cb_in0.wait_front(1);
-        uint32_t l1_addr = cb_in0.get_read_ptr();
+        uint32_t l1_read_addr = cb_in0.get_read_ptr();
         if constexpr (!is_l1_aligned) {
+            uint32_t idx = 0;
+            uint32_t l1_addr = l1_read_addr;
             for (uint32_t i = 0; i < patch_size; i++) {
                 for (uint32_t j = 0; j < (stick_nbytes / 2); j++) {
                     patch_data[idx++] = *(volatile uint16_t*)(l1_addr + j * 2);
                 }
                 l1_addr += aligned_stick_nbytes_dram;
             }
-        }
-        if constexpr (!is_l1_aligned) {
-            // Scratch buffer (cb_in1) is populated at its WRITE_PTR; no push_back has advanced it yet.
-            noc.async_write(
-                use<experimental::CB::AddrSelector::WRITE_PTR>(cb_in1),
-                s_out,
-                stick_nbytes * patch_size,
-                {},
-                {.page_id = dst_index});
+            noc_async_write_sharded(noc, intermed_l1_scratch, s_out, dst_index, /*offset=*/0, output_stick_nbytes);
         } else {
-            // If L1 aligned, write directly from the circular buffer
-            noc.async_write(cb_in0, s_out, stick_nbytes * patch_size, {}, {.page_id = dst_index});
+            noc_async_write_sharded(noc, l1_read_addr, s_out, dst_index, /*offset=*/0, output_stick_nbytes);
         }
         noc.async_write_barrier();
         cb_in0.pop_front(1);

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_dfb2dram_for_rm_input.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/kernels/dataflow/writer_dfb2dram_for_rm_input.cpp
@@ -17,14 +17,19 @@ void kernel_main() {
     constexpr uint32_t stride_h = get_arg(args::stride_h);
     constexpr uint32_t stride_w = get_arg(args::stride_w);
     constexpr uint32_t input_width = get_arg(args::input_width);
-    constexpr uint32_t work_per_core = get_arg(args::work_per_core);
 
     constexpr uint32_t patch_size = stride_h * stride_w;
+    constexpr uint32_t output_stick_nbytes = stick_nbytes * patch_size;
+    // Generic accessor + noc_async_write_sharded helper: compile-time dispatch to noc.async_write for interleaved /
+    // H-sharded outputs and per-shard writes for W/B-sharded outputs.
     const auto s_out = TensorAccessor(tensor::dst);
-    uint32_t dst_index = get_arg(args::dst_index);
 
     Noc noc;
     DataflowBuffer dfb_in0(dfb::in0);
+
+    // work_per_core is runtime (per-core) so unused cores skip iteration and the cliff core can carry a partial tail.
+    uint32_t work_per_core = get_arg(args::work_per_core);
+    uint32_t dst_index = get_arg(args::dst_index);
 
     // The src1 scratch DFB is bound (and used) only when the stick is not L1-aligned.
     // Its binding, and every reference to it, is #ifdef-gated on the same condition the host
@@ -48,18 +53,12 @@ void kernel_main() {
                 }
                 l1_addr += aligned_stick_nbytes_dram;
             }
-            // Scratch buffer (dfb_in1) is populated at its WRITE_PTR; no push_back has advanced it yet.
-            noc.async_write(
-                CoreLocalMem<uint32_t>(dfb_in1.get_write_ptr()),
-                s_out,
-                stick_nbytes * patch_size,
-                {},
-                {.page_id = dst_index});
+            noc_async_write_sharded(noc, intermed_l1_scratch, s_out, dst_index, /*offset=*/0, output_stick_nbytes);
         }
 #else
         {
-            // If L1 aligned, write directly from the circular buffer.
-            noc.async_write(dfb_in0, s_out, stick_nbytes * patch_size, {}, {.page_id = dst_index});
+            noc_async_write_sharded(
+                noc, dfb_in0.get_read_ptr(), s_out, dst_index, /*offset=*/0, output_stick_nbytes);
         }
 #endif
         noc.async_write_barrier();

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
@@ -276,7 +276,7 @@ std::vector<Tensor> fold_with_transpose_sharded_(
     return output_tensors;
 }
 
-// Extract padding values from variant
+// Normalise 2/4/6-elem pad specs to [top, bot, left, right, c_front, c_back].
 static std::array<uint32_t, 6> extract_padding_values(
     const std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>, std::array<uint32_t, 6>>& padding) {
     return std::visit(
@@ -286,8 +286,7 @@ static std::array<uint32_t, 6> extract_padding_values(
                 // [pad_h, pad_w] -> [pad_h, pad_h, pad_w, pad_w, 0, 0]
                 return {pad_array[0], pad_array[0], pad_array[1], pad_array[1], 0, 0};
             } else if constexpr (std::is_same_v<T, std::array<uint32_t, 4>>) {
-                // [pad_h_top, pad_h_bottom, pad_w_left, pad_w_right] -> [pad_h_top, pad_h_bottom, pad_w_left,
-                // pad_w_right, 0, 0]
+                // [pad_h_top, pad_h_bottom, pad_w_left, pad_w_right] -> same with c_front=c_back=0
                 return {pad_array[0], pad_array[1], pad_array[2], pad_array[3], 0, 0};
             } else {
                 // [pad_h_top, pad_h_bottom, pad_w_left, pad_w_right, pad_c_front, pad_c_back]
@@ -297,14 +296,12 @@ static std::array<uint32_t, 6> extract_padding_values(
         padding);
 }
 
-// Helper function to validate height sharding
 static void validate_height_sharding(const Tensor& tensor) {
     if (tensor.is_sharded() && tensor.memory_config().memory_layout() != TensorMemoryLayout::HEIGHT_SHARDED) {
         TT_THROW("fold op does not support non height-sharding!");
     }
 }
 
-// Helper function to apply halo padding to sharded tensors
 static Tensor apply_halo_padding(
     const Tensor& input_tensor, uint32_t pad_top, uint32_t pad_bottom, uint32_t pad_left, uint32_t pad_right) {
     using namespace ttnn::operations::sliding_window;
@@ -343,11 +340,7 @@ static Tensor apply_halo_padding(
     return ttnn::reshape(halo_output, padded_shape);
 }
 
-// Each core needs to process multiple of (stride_h * input_width) rows to ensure that
-// the fold operation can be performed locally and do not need to read from remote cores.
-// This function checks if the current shard height is divisible by (stride_h * input_width).
-// If not, it calculates an optimal number of cores and corresponding shard height
-// to enable efficient fold computation across the tensor dimensions.
+// Reshard so shard_h is a multiple of stride_h·input_width (zero-NOC pre-condition).
 Tensor reshard_if_needed(const Tensor& input, const uint32_t stride_h, const uint32_t /*stride_w*/) {
     ttnn::Shape input_shape = input.logical_shape();
     uint32_t input_width = input_shape[2];
@@ -382,6 +375,42 @@ Tensor reshard_if_needed(const Tensor& input, const uint32_t stride_h, const uin
     return input;
 }
 
+// Fill in shard_spec for a sharded override that has none.
+MemoryConfig derive_effective_override_memory_config(
+    const Tensor& input_tensor,
+    const Tensor& fold_output,
+    const MemoryConfig& override_memory_config,
+    uint32_t stride_h,
+    uint32_t stride_w) {
+    if (!override_memory_config.is_sharded() || override_memory_config.shard_spec().has_value()) {
+        return override_memory_config;
+    }
+
+    // Use logical_shape (in lock-step with compute_output_specs, which sizes from logical too).
+    const auto& shape = fold_output.logical_shape();
+    const uint32_t rows = shape[0] * shape[1] * shape[2];
+    const uint32_t cols = shape[3];
+    const auto layout = override_memory_config.memory_layout();
+
+    // Matching-layout override → rescale the input's own spec (patch_size = stride_h*stride_w). Preserves grid +
+    // orientation even when the composite staged input through L1 interleaved (sub-align W/B RM), so fold_output
+    // has no spec of its own. Mirrors compute_output_specs' rescale.
+    if (input_tensor.is_sharded() && input_tensor.shard_spec().has_value() &&
+        input_tensor.memory_config().memory_layout() == layout) {
+        auto s = input_tensor.shard_spec().value();
+        const uint32_t patch_size = stride_h * stride_w;
+        s.shape[0] = s.shape[0] / patch_size;
+        s.shape[1] = s.shape[1] * patch_size;
+        return MemoryConfig(layout, override_memory_config.buffer_type(), s);
+    }
+
+    // Cross-layout or non-sharded input → synthesise via shared helper (in lock-step with compute_output_specs).
+    return MemoryConfig(
+        layout,
+        override_memory_config.buffer_type(),
+        synthesize_fold_output_shard_spec(input_tensor, layout, rows, cols));
+}
+
 }  // namespace ttnn::operations::data_movement
 
 namespace ttnn {
@@ -394,7 +423,8 @@ Tensor fold(
     const std::optional<const ttnn::Shape>& output_shape,
     std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>, std::array<uint32_t, 6>> padding,
     const std::optional<CoreRangeSet>& core_grid,
-    const std::optional<MemoryConfig>& override_memory_config) {
+    const std::optional<MemoryConfig>& override_memory_config,
+    bool collapse_output) {
     // Extract padding values
     const std::array<uint32_t, 6> padding_values = operations::data_movement::extract_padding_values(padding);
     const uint32_t pad_top = padding_values[0];
@@ -412,7 +442,12 @@ Tensor fold(
     const Tensor& input_tensor = input_tensor_;
     TT_ASSERT(input_tensor.logical_shape().rank() == 4, "Fold op only supports 4D tensors");
 
-    // Legacy transpose-based fold (TODO: remove when #29514 is solved)
+    // use_transpose_as_fold takes a legacy composite path that bypasses prim::fold, so collapse_output cannot be
+    // honoured there.
+    TT_FATAL(
+        !(use_transpose_as_fold && collapse_output),
+        "Fold: collapse_output=True is not supported with use_transpose_as_fold=True "
+        "(legacy path bypasses prim::fold). Drop use_transpose_as_fold to use collapse_output.");
     if (use_transpose_as_fold) {
         if (input_tensor.is_sharded()) {
             operations::data_movement::validate_height_sharding(input_tensor);
@@ -432,19 +467,25 @@ Tensor fold(
                    input_tensor, output_shape, stride_h, stride_w, pad_c, pad_h, pad_w)
             .at(0);
     }
-    // Modern sharded tensor path
-    if (input_tensor.memory_config().is_l1() && input_tensor.is_sharded()) {
+    // Shared with select_program_factory; TILE branch is untilized below before prim dispatch.
+    const bool fast_path_input =
+        operations::data_movement::is_fast_path_input(input_tensor) ||
+        (input_tensor.memory_config().is_l1() && input_tensor.is_sharded() && input_tensor.shard_spec().has_value() &&
+         input_tensor.memory_config().memory_layout() == tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED &&
+         input_tensor.layout() == Layout::TILE);
+
+    // Hoisted: the tensor prim::fold actually consumes. The tail helper below rescales this (not input_tensor) so a
+    // matching-layout specless override sees the post-reshard / post-staging geometry, not the pre-repair original.
+    Tensor processed_tensor = input_tensor;
+    Tensor result;
+    if (fast_path_input) {
         operations::data_movement::validate_height_sharding(input_tensor);
 
-        Tensor processed_tensor = input_tensor;
-
-        // Apply H,W padding using halo if needed
         if (has_hw_padding) {
             processed_tensor = operations::data_movement::apply_halo_padding(
                 processed_tensor, pad_top, pad_bottom, pad_left, pad_right);
         }
 
-        // Apply channel padding separately if needed
         if (has_c_padding) {
             const auto current_shape = processed_tensor.logical_shape();
             const ttnn::Array4D padded_shape = {
@@ -455,51 +496,75 @@ Tensor fold(
             processed_tensor = ::ttnn::pad(processed_tensor, padded_shape, ttnn::Array4D({0, 0, 0, pad_c_front}), 0);
         }
 
-        // If processed tensor is tiled, convert to row-major.
         if (processed_tensor.layout() == Layout::TILE) {
             processed_tensor = ttnn::to_layout(processed_tensor, Layout::ROW_MAJOR);
         }
-        // Reshard if needed for optimal fold computation
         processed_tensor = operations::data_movement::reshard_if_needed(processed_tensor, stride_h, stride_w);
 
-        return ttnn::prim::fold(processed_tensor, stride_h, stride_w);
+        result = ttnn::prim::fold(processed_tensor, stride_h, stride_w, collapse_output);
+    } else {
+        // Composite path: sub-L1-align W/B RM stages through L1 interleaved; TILE untilizes to RM.
+        const auto l1_interleaved =
+            tt::tt_metal::MemoryConfig(tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::L1);
+
+        const auto in_ml = processed_tensor.memory_config().memory_layout();
+        // Specless sharded → prim path (compute_output_specs synthesises the output spec).
+        const bool wb_sharded_rm = processed_tensor.layout() == Layout::ROW_MAJOR && processed_tensor.is_sharded() &&
+                                   processed_tensor.shard_spec().has_value() &&
+                                   (in_ml == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED ||
+                                    in_ml == tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED);
+        const bool sub_alignment_wb_sharded_rm = [&] {
+            if (!wb_sharded_rm) {
+                return false;
+            }
+            const auto& spec = processed_tensor.shard_spec().value();
+            const uint32_t shard_row_bytes = spec.shape[1] * processed_tensor.element_size();
+            // Match the alignment the TensorAccessor / noc_async_read_sharded pair will actually enforce for this
+            // buffer type.
+            const bool is_dram = processed_tensor.memory_config().buffer_type() == tt::tt_metal::BufferType::DRAM;
+            const uint32_t alignment =
+                is_dram ? tt::tt_metal::hal::get_dram_alignment() : tt::tt_metal::hal::get_l1_alignment();
+            return shard_row_bytes % alignment != 0;
+        }();
+        if (sub_alignment_wb_sharded_rm) {
+            processed_tensor = ttnn::to_memory_config(processed_tensor, l1_interleaved, std::nullopt);
+        }
+
+        if (has_hw_padding || has_c_padding) {
+            ttsl::SmallVector<ttnn::operations::data_movement::PadSpecDim> padding_spec;
+            padding_spec.push_back({0, 0});
+            padding_spec.push_back({pad_top, pad_bottom});
+            padding_spec.push_back({pad_left, pad_right});
+            padding_spec.push_back({pad_c_front, pad_c_back});
+            processed_tensor = ttnn::pad(processed_tensor, padding_spec, 0.0f, true, std::nullopt);
+        }
+
+        if (processed_tensor.layout() == Layout::TILE) {
+            // TILE-native factory is broken (see fold_multi_core_tiled_interleaved) → untilize→RM.
+            processed_tensor = ttnn::to_layout(processed_tensor, Layout::ROW_MAJOR);
+        }
+
+        result = ttnn::prim::fold(processed_tensor, stride_h, stride_w, collapse_output);
     }
-    // Interleaved tensor path (DRAM or L1)
-    Tensor processed_tensor = input_tensor;
 
-    // Apply padding if needed
-    if (has_hw_padding || has_c_padding) {
-        ttsl::SmallVector<ttnn::operations::data_movement::PadSpecDim> padding_spec;
-        padding_spec.push_back({0, 0});                     // N dimension
-        padding_spec.push_back({pad_top, pad_bottom});      // H dimension
-        padding_spec.push_back({pad_left, pad_right});      // W dimension
-        padding_spec.push_back({pad_c_front, pad_c_back});  // C dimension
-
-        processed_tensor = ttnn::pad(processed_tensor, padding_spec, 0.0f, true, std::nullopt);
+    // Universal-IO tail: honour override_memory_config via to_memory_config. Prefer processed_tensor's spec (fast-path
+    // reshard_if_needed can change shard geometry → must rescale the post-reshard shape, not the pre-reshard original,
+    // else integer truncation under-covers the output). Fall back to input_tensor when processed_tensor lost its
+    // sharded spec via staging (sub-align W/B → L1 interleaved) so the caller's expressed grid is still reusable.
+    if (override_memory_config.has_value()) {
+        const auto& tensor_for_derive =
+            (processed_tensor.is_sharded() && processed_tensor.shard_spec().has_value() &&
+             processed_tensor.memory_config().memory_layout() == override_memory_config->memory_layout())
+                ? processed_tensor
+                : input_tensor;
+        const auto effective = operations::data_movement::derive_effective_override_memory_config(
+            tensor_for_derive, result, override_memory_config.value(), stride_h, stride_w);
+        if (effective != result.memory_config()) {
+            result = ttnn::to_memory_config(result, effective, std::nullopt);
+        }
     }
 
-    const auto shape = processed_tensor.logical_shape();
-    const auto batch_size = shape[0];
-    const auto input_height = shape[1];
-    const auto input_width = shape[2];
-    const auto in_channels = shape[3];
-    const bool was_tiled = processed_tensor.layout() == Layout::TILE;
-
-    // The interleaved fold kernels operate on row-major data, so untilize first.
-    if (was_tiled) {
-        processed_tensor = ttnn::to_layout(processed_tensor, Layout::ROW_MAJOR);
-    }
-
-    auto output_tensor = ttnn::prim::fold(processed_tensor, stride_h, stride_w);
-
-    // Reshape output if input was tiled
-    if (was_tiled) {
-        const ttnn::Shape final_shape(
-            {batch_size, input_height / stride_h, input_width / stride_w, in_channels * stride_h * stride_w});
-        return ttnn::reshape(output_tensor, final_shape);
-    }
-
-    return output_tensor;
+    return result;
 }
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold.hpp
@@ -19,6 +19,7 @@ ttnn::Tensor fold(
     std::variant<std::array<uint32_t, 2>, std::array<uint32_t, 4>, std::array<uint32_t, 6>> padding =
         std::array<uint32_t, 2>{0, 0},
     const std::optional<CoreRangeSet>& core_grid = std::nullopt,
-    const std::optional<MemoryConfig>& override_memory_config = std::nullopt);
+    const std::optional<MemoryConfig>& override_memory_config = std::nullopt,
+    bool collapse_output = false);
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold_nanobind.cpp
@@ -22,14 +22,19 @@ namespace ttnn::operations::data_movement {
 
 void bind_fold_operation(nb::module_& mod) {
     const auto* doc = R"doc(
-        Fold TT Tensor.
-        Input tensor must be on TT accelerator device, in ROW_MAJOR.
-        Output tensor will be on TT accelerator device, in ROW_MAJOR.
+        NHWC space-to-depth. Packs every stride_h * stride_w neighbourhood at position
+        (h * stride_h, w * stride_w) into the channel dim at position (h, w). Shapes below
+        use the padded H/W/C (any HW / channel padding is applied before folding).
+
+        Output shape: (N, Hp/stride_h, Wp/stride_w, Cp * stride_h * stride_w)
+        where Hp, Wp, Cp are the padded input dims.
 
         Args:
-            input (ttnn.Tensor): Input tensor to be folded. Tensor of shape [N, H, W, C].
-            stride_h (int): Stride along the H-dimension.
-            stride_w (int): Stride along the W-dimension.
+            input (ttnn.Tensor): Input tensor [N, H, W, C].
+            stride_h (int): Stride along H.
+            stride_w (int): Stride along W.
+            collapse_output (bool, optional): Default False. When True, returns
+                (1, 1, N * Hp/stride_h * Wp/stride_w, Cp * stride_h * stride_w) instead.
     )doc";
 
     ttnn::bind_function<"fold">(
@@ -43,7 +48,8 @@ void bind_fold_operation(nb::module_& mod) {
         nb::arg("output_shape") = nb::none(),
         nb::arg("padding") = std::array<uint32_t, 2>{0, 0},
         nb::arg("grid_size") = nb::none(),
-        nb::arg("override_memory_config") = nb::none());
+        nb::arg("override_memory_config") = nb::none(),
+        nb::arg("collapse_output") = false);
 }
 
 }  // namespace ttnn::operations::data_movement


### PR DESCRIPTION
### Ticket
Link to Github Issue #47644

### Problem
`ttnn::fold` had no universal input/output story. Only the L1 HEIGHT-sharded ROW_MAJOR zero-NOC fast path was correct end-to-end; every other (layout × memory_layout) combination either fell through to a wrong-shape output, silently truncated on non-patch-aligned shards, or crashed inside `MultiCoreDRAMFold`. On top of that the op returned **two different output shapes** depending on the input's memory config — L1/HEIGHT-sharded/RM gave a collapsed `(1, 1, N·H'·W', C·sh·sw)`, DRAM interleaved gave folded `(N, H', W', C·sh·sw)`, TILE + L1 interleaved was papered over with a composite reshape hack — so downstream consumers had to reason about which one they got. `override_memory_config` was ignored on every path except the fast one, and a sharded override without a `shard_spec` (the `transpose` / `slice` "specless" convention) hit `bad_optional_access` in `compute_output_specs`.
### Motivating example (ViT patch embedding)

Input: `(1, 224, 224, 3)`, `(stride_h, stride_w) = (16, 16)`.

| Input memory config | `main` output shape | This PR (default) | This PR (`collapse_output=True`) |
|---|---|---|---|
| RM + L1 interleaved | `(1, 1, 196, 768)` collapsed | `(1, 14, 14, 768)` folded_4d | `(1, 1, 196, 768)` |
| RM + DRAM interleaved | `(1, 14, 14, 768)` folded_4d | `(1, 14, 14, 768)` folded_4d | `(1, 1, 196, 768)` |
| RM + L1 HEIGHT-sharded (fast path) | `(1, 1, 196, 768)` collapsed | `(1, 14, 14, 768)` folded_4d | `(1, 1, 196, 768)` |

Device bytes are byte-identical across every row; only tensor metadata differs. The `main` behaviour of returning two different output shapes for the *same input* depending on where it lives (`L1_INTERLEAVED` → collapsed, `DRAM_INTERLEAVED` → folded_4d) is what forced downstream consumers to branch on memory config. This PR eliminates that coupling — the default is always folded_4d — and offers `collapse_output=True` as an opt-in for callers who still want the legacy 3D-ish shape. `collapse_output=True` is emitted directly by `compute_output_specs`; no internal reshape op is dispatched (same pattern `main` used for its L1 RM path).


### What this PR does
- **Composite-first universal I/O in `fold.cpp`** — keep the HEIGHT-sharded + L1 + ROW_MAJOR zero-NOC fast path; route every other input through an L1-interleaved staging hop (`to_memory_config` for sharded, `to_layout(RM)` for TILE, `pad` for HW/C padding), then dispatch through `prim::fold` and resolve the caller's requested output via a tail `to_memory_config`. Sub-L1-alignment W/B-sharded RM inputs are staged through L1 interleaved first (mirrors `transpose::irregular_hw`).
- **Single output-shape rule in `compute_output_specs`** — always emit folded_4d `(N, H/sh, W/sw, C·sh·sw)`, unconditionally. Memory config now decides *where* the tensor lives, never *what shape* it has. NHWC space-to-depth with packing order `(block-row, block-col, C_in)` inside the fused channel axis (ttnn `space_to_depth` family convention). The 3-variant contract on `main` (collapsed / folded_4d / composite-reshape) collapses to one.
- **Opt-in `collapse_output` kwarg** — direct emission of the legacy `(1, 1, N·H'·W', C·sh·sw)` shape via `compute_output_specs`, threaded through `operation_attributes_t::collapse_output` into `prim::fold`. No internal reshape/view op is dispatched (same pattern main used for its L1 RM path). Bytes/shard-spec are invariant between folded_4d and collapsed; default stays folded_4d so callers who don't opt in never see the legacy shape. Rejected in combination with `use_transpose_as_fold=true` (legacy path bypasses `prim::fold`).
- **Honor `override_memory_config` on every path** — a `derive_effective_override_memory_config` helper fills in `shard_spec` for specless sharded overrides (mirrors `transpose::derive_effective_output_memory_config`): prefers the fold-rescaled input geometry when the layout matches, otherwise synthesises a fresh full-grid spec via the shared helper. Reused for the composite tail's single `to_memory_config` on every path (fast + fallback).
- **Specless-sharded input handling in `compute_output_specs`** — concrete spec → rescale (`shard[0] /= patch`, `shard[1] *= patch`, shard-bytes invariant). Specless sharded input (e.g. from `ttnn::to_memory_config(t, sharded_mc_no_spec)`) → synthesise a fresh full-grid spec via the shared helper. All `.shard_spec().value()` call sites (`is_fast_path_input`, `validate_fold`, `compute_output_specs`, `reshard_if_needed`, `apply_halo_padding`, sub-alignment check) are now guarded by `has_value()` (mirrors transpose's defensive style).
- **Shared predicate + shard-spec synthesiser** — `is_fast_path_input(const Tensor&)` and `synthesize_fold_output_shard_spec(input, layout, rows, cols)` live in `fold_device_op.hpp` and are called from both `fold.cpp` (composite) and `fold_device_op.cpp` (device_op). Routing and shape-derivation cannot drift out of sync.
- **Cleanup** — removed the dead `is_sharded` field from `operation_attributes_t` (set but never read); replaced three `TODO(#47644)` self-references with descriptive comments explaining that the TILE-native factory in `MultiCoreDRAMFold` is broken for `(N, H≠32, W≠32, C>32)` and the composite untilizes before dispatch.
- **Rewrite the `fold_nanobind.cpp` docstring** — single-shape contract, output shape formula, `collapse_output` kwarg documented alongside.
- **Migrate cohort C caller sites (ViT / VLA / smolvla / openvla / tt_symbiote — 10 files)** — every caller that relied on `fold → to_layout(TILE) → linear` treating the collapsed shape as a free flatten now issues an explicit `ttnn.reshape` to `(1, 1, N·H'·W', C·sh·sw)` after fold. `ttnn.reshape` in this shape is a `view` fast-path metadata op (verified in graph reports: 0 kernels, 0 tracy zones) so trace-mode dispatch is unchanged. Callers can migrate to `collapse_output=True` at any point (single-kwarg diff).
- **Sweep + regression golden updates** — dropped the defensive `.reshape(1, 1, -1, C)` in `tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py` and `tests/sweep_framework/sweeps/model_traced/fold_model_traced.py`; both now expect folded_4d directly.
- **Add comprehensive test suite (`test_universal_input_tm_fold.py`, nightly, 84 cases across 26 test functions)** — universal I/O over every (input × output memconfig) × RM/TILE, sub-L1-alignment W/B-sharded staging, DRAM height-sharded inputs, sharded → sharded cross-layout, COL_MAJOR shard orientation preservation, f32 dtype, asymmetric strides, HW + C padding, `collapse_output={False, True}` cross-product with byte-equality vs the folded_4d + `ttnn.reshape` reference and preserved shard spec / orientation, specless-sharded overrides (from interleaved / matching sharded / cross-layout / with `collapse_output`), specless override on TILE inputs, sub-alignment W/B + specless override with input geometry preservation, COL_MAJOR input + specless override, multi-batch H-sharded, `use_transpose_as_fold=True` smoke, negative tests (`ttnn.from_torch` rejects specless sharded inputs; invalid shard-shape → clean `TT_FATAL`, no SIGFPE; `collapse_output=True` + `use_transpose_as_fold=True` rejected).

### Tests
All on Wormhole B0:
- `tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_fold.py` — **84 passed in ~16 s** (26 test functions covering every (input × output memconfig) × RM/TILE, sub-alignment W/B staging, specless-sharded overrides, `collapse_output`, `override_memory_config`, COL_MAJOR orientation, f32 dtype, asymmetric strides, HW+C padding, negative-path FATALs).
- `tests/ttnn/unit_tests/operations/conv/data_movement/test_fold_op.py` — **198 passed, 252 skipped** (skips pre-existing: `bfloat8_b + row major`, `TILE front-pad`, `invalid padding combos` for stride 32, FP32 fold DFBs exceeding per-core L1 for 320-channel × 32×32 stride).
- `tests/ttnn/unit_tests/operations/conv/test_prepare_conv_weights.py` — fold-touching subset — **all passed**.

### Notes for Reviewers
- Supersedes the earlier draft [#47896](https://github.com/tenstorrent/tt-metal/pull/47896) (closed).

### Additional correctness fixes

- **`synthesize_fold_output_shard_spec` — right-size the CoreRangeSet.** Small specless-override tensors (`rows < num_cores` for HEIGHT_SHARDED, or `(n_rows, n_cols) < (grid.y, grid.x)` for BLOCK_SHARDED) no longer over-declare cores. The synthesizer now sizes the grid via `num_cores_to_corerangeset` (H/W) or a rectangular `CoreRange` (BLOCK) to the actually-populated shard count. New regression `test_fold_specless_sharded_override_grid_shrinks_when_rows_lt_max_cores` (H shrinks 64→16, B shrinks 64→32). Note: `transpose::generate_transpose_shard_spec` still over-declares; tracked as a follow-up in [#50684](https://github.com/tenstorrent/tt-metal/issues/50684).
- **`validate_fold` — hoisted zero-stride guard + H/W divisibility for both paths.** Fast path previously only validated the shard-height / (`input_W * stride_h`) relation; a non-`stride_w`-divisible `input_W` (or `stride == 0`) would slip through and get silently truncated inside `MultiCore`. Now `stride_h > 0 && stride_w > 0` and both `input_H % stride_h == 0` and `input_W % stride_w == 0` are asserted for every input.
- **`fold.cpp` sub-alignment predicate — pick buffer-specific alignment.** The W/B-sharded RM staging check used `hal::get_l1_alignment()` unconditionally; a DRAM-buffered W/B-sharded row that is 16-byte aligned but not DRAM-aligned would skip staging while `TensorAccessor::get_aligned_page_size()` still advanced by the larger DRAM page, mis-aligning `noc_async_read_sharded`. Now the predicate uses `hal::get_dram_alignment()` for DRAM buffers and `hal::get_l1_alignment()` for L1.
- **`MultiCoreDRAMFold` work-split — restrict to active cores + per-core work count.** Previously kernels dispatched over the full compute grid with `work_per_core` as a compile-time arg equal to `ceil(total_patches / num_cores_total)`, so idle cores (`i >= num_active`) received stale `src_idx / dst_idx` from the last active core and re-issued the same NOC read/write (harmless for small-tensor tests because they wrote the same data but a race hazard in general), and the cliff core over-read when `total_patches` was not divisible by `patches_per_core`. `work_per_core` is now a runtime arg; kernels launch only on `num_active_cores = div_up(total_patches, patches_per_core)` via `num_cores_to_corerangeset(..., row_wise=true)`; the cliff core carries `total_patches - i * patches_per_core` as its tail.
- **`fold_nanobind.cpp` docstring — output shapes in padded terms.** HW / channel padding is applied before folding, so the docstring formulas now reference `(N, Hp/stride_h, Wp/stride_w, Cp * stride_h * stride_w)` (and the collapsed analogue) with `Hp / Wp / Cp` explicitly labelled as padded dims.
- **`compute_output_specs` — single output-shape rule for DRAM interleaved too.** The DRAM-interleaved branch previously recomputed the output shape inline for RM (and returned `input_shape` for TILE), silently discarding `op_attr.collapse_output` on both. Since `output_shape` (computed once at the top of `compute_output_specs`) is already the correct folded_4d / collapsed shape for every layout × mem-config, the `is_dram()` special case was redundant; deleting it lets the flag flow through unconditionally. Covered by the existing `test_fold_collapse_output[rm_dram_interleaved]` and `test_fold_collapse_output_tile_interleaved[tile_dram_interleaved]` cases.
- **Composite tail helper — pass the post-repair tensor, not the original.** `derive_effective_override_memory_config` was called with `input_tensor` (the caller's original). On the fast path, `reshard_if_needed` can rewrite `shard_shape[0]` and the core grid — so when a specless matching-layout override arrived, the helper rescaled the *pre-reshard* shard shape via integer division, potentially under-covering the fold output (e.g. `shard_h=6, patch=4 → 6/4=1` truncates from 6 → 1 rows-per-shard). The tail now prefers `processed_tensor`'s spec when it's still sharded at the matching layout (fast-path reshard case), and falls back to the original only when staging demoted `processed_tensor` to L1 interleaved (sub-align W/B case). New regression `test_fold_fast_path_reshard_trigger_specless_matching_layout_override`.
- **Default-shape API change.** The default is intentionally changing from `(1, 1, N·H'·W', C·sh·sw)` to `(N, H', W', C·sh·sw)` — this is the whole point of the single output-shape rule. In-repo callers (cohort C: ViT × 6, OpenVLA, SmolVLA, `tt_symbiote/modules/conv.py`) are migrated in-tree; downstream users who need the legacy shape pass `collapse_output=True` (or a pure-metadata `ttnn.reshape`).

### Follow-ups
- [#50840](https://github.com/tenstorrent/tt-metal/issues/50840) — native TILE-input factory in `MultiCoreDRAMFold`. TILE inputs are untilized to RM in the composite today; a working tiled factory would remove that hop.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/fold_rework)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/fold_rework)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mouliraj/fold_rework)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mouliraj/fold_rework)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mouliraj/fold_rework)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mouliraj/fold_rework)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/fold_rework)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/fold_rework)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mouliraj/fold_rework)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mouliraj/fold_rework)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/fold_rework)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/fold_rework)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/fold_rework)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/fold_rework)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/fold_rework)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/fold_rework)








