### PR TITLE
SFPU: don't re-program config reg per-op in exp/recip/snake init (fix #50381)

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
@@ -386,11 +386,13 @@ inline void calculate_reciprocal() {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool legacy_compat = false>
 void recip_init() {
-    // Common SFPU init inlined (SFPU config register + ADDR_MOD_7 + reciprocal's ADDR_MOD_6 + counter
+    // Common SFPU init inlined (ADDR_MOD_7 + reciprocal's ADDR_MOD_6 + counter
     // reset), then the op-specific reciprocal setup below -- one self-contained init, matching exp_init.
     // SDPA runs reciprocal in its softmax after matmul/exp, so the general SFPU state is re-established
     // here, not just reset. Reciprocal uses ADDR_MOD_6 (dest incr 2) on Blackhole.
-    sfpu::_init_sfpu_config_reg();
+    // NOTE: the SFPU config register is programmed once per kernel by the hoisted llk_math_sfpu_init_once()
+    // and must NOT be re-programmed per op -- doing so corrupts the Blackhole fp32 SFPLOADMACRO reciprocal
+    // (issue #50381). Only the op's ADDR_MOD state + counter reset are re-established here.
     addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 0}}.set(ADDR_MOD_7);
     addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 2}}.set(ADDR_MOD_6);
     math::reset_counters(p_setrwc::SET_ABD_F);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
@@ -121,11 +121,14 @@ inline void calculate_reciprocal() {
 
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, bool legacy_compat = false>
 void recip_init() {
-    // Common SFPU init inlined (SFPU config register + ADDR_MOD_7 + counter reset), then the op-specific
+    // Common SFPU init inlined (ADDR_MOD_7 + counter reset), then the op-specific
     // reciprocal setup below -- one self-contained init, matching exp_init. SDPA runs reciprocal in its
     // softmax after matmul/exp, so the general SFPU state is re-established here, not just reset.
     // Reciprocal uses only ADDR_MOD_7 on Wormhole (no op-specific ADDR_MOD_6).
-    sfpu::_init_sfpu_config_reg();
+    // NOTE: the SFPU config register is programmed once per kernel by the hoisted llk_math_sfpu_init_once(),
+    // not per op. On Blackhole, re-programming it per op corrupts the fp32 SFPLOADMACRO reciprocal (#50381);
+    // Wormhole reciprocal has no such path, but the once-per-kernel invariant is kept consistent across arches.
+    // Only the op's ADDR_MOD state + counter reset are re-established here.
     addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 0}}.set(ADDR_MOD_7);
     math::reset_counters(p_setrwc::SET_ABD_F);
     if constexpr (!legacy_compat) {


### PR DESCRIPTION
## Fix #50381 — BH fp32 ring-joint SDPA accuracy regression

**Root cause (from #49529):** `exp_init`/`recip_init`/`snake_beta_init` were made to call `_init_sfpu_config_reg()` (`TTI_SFPCONFIG(0,0xF,1)`) on **every** op init. The SFPU config register is a **once-per-kernel** invariant already set by the hoisted `llk_math_sfpu_init_once()`. Re-programming it per-op corrupts the Blackhole **fp32** SFPLOADMACRO reciprocal (`_init_reciprocal_fast_24b_5c_`) → fp32 softmax accuracy loss → ring-joint SDPA `fp32_acc` PCC/RMSE failures (#50381). bf16 reciprocals are simple Newton-Raphson and unaffected — which is why **only `fp32_acc`** failed.

Confirmed by A/B: reverting #49529 (PR #50382) makes the 6 tests pass (PCC ~0.9997); main fails them (PCC 0.70–0.98).

**Fix:** drop the per-op `_init_sfpu_config_reg()`; keep the `ADDR_MOD` re-establishment (the matmul-clobbered state — the real reason recip/exp re-init after matmul) + `reset_counters`. Config reg stays as the hoisted once-per-kernel value.

**Validation:** BH QB2 (`test_ring_joint_sdpa.py` fp32_acc, #50381) must pass, AND WH ring-joint SDPA (the original regression #49529's config-reg add was fixing) must still pass.

Supersedes the standby revert #50382 if green.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ncvetkovic/fix-sfpu-fp32-recip-50381)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ncvetkovic/fix-sfpu-fp32-recip-50381)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ncvetkovic/fix-sfpu-fp32-recip-50381)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ncvetkovic/fix-sfpu-fp32-recip-50381)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ncvetkovic/fix-sfpu-fp32-recip-50381)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ncvetkovic/fix-sfpu-fp32-recip-50381)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ncvetkovic/fix-sfpu-fp32-recip-50381)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ncvetkovic/fix-sfpu-fp32-recip-50381)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ncvetkovic/fix-sfpu-fp32-recip-50381)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ncvetkovic/fix-sfpu-fp32-recip-50381)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ncvetkovic/fix-sfpu-fp32-recip-50381)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ncvetkovic/fix-sfpu-fp32-recip-50381)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ncvetkovic/fix-sfpu-fp32-recip-50381)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ncvetkovic/fix-sfpu-fp32-recip-50381)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ncvetkovic/fix-sfpu-fp32-recip-50381)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ncvetkovic/fix-sfpu-fp32-recip-50381)