### PR TITLE
[Fix] minimal_matmul: rename local copy_block to fix ambiguous overload (#50386)

### DIFF
--- a/tt-train/sources/ttml/metal/ops/variable_matmul/device/kernels/compute/compute.cpp
+++ b/tt-train/sources/ttml/metal/ops/variable_matmul/device/kernels/compute/compute.cpp
@@ -11,7 +11,10 @@
 #include "api/dataflow/circular_buffer.h"
 #include "tools/profiler/kernel_profiler.hpp"
 
-void copy_block(uint32_t in_cb, uint32_t out_cb, uint32_t M_block_tiles, uint32_t N_block_tiles) {
+// Renamed from copy_block to avoid an ambiguous overload with ckernel::copy_block (added to
+// api/compute/tile_move_copy.h in #49070), which has the identical (uint32_t, uint32_t, uint32_t,
+// uint32_t) signature and is in scope here. See tt-metal#50386.
+void copy_and_pack_block(uint32_t in_cb, uint32_t out_cb, uint32_t M_block_tiles, uint32_t N_block_tiles) {
     copy_tile_to_dst_init_short(in_cb);
     reconfig_data_format_srca(in_cb);
     pack_reconfig_data_format(out_cb);
@@ -275,8 +278,8 @@ void kernel_main() {
             cb_interm.reserve_back(out_block_num_tiles);
             if (K_num_blocks == 0U) {
                 // Empty K-axis offset (empty expert): K-loop skipped, intermediate_cb would
-                // hold uninitialized state. Zero the FULL M_block × N_block region (copy_block
-                // later reads it whole) so `add_grad` downstream contributes nothing.
+                // hold uninitialized state. Zero the FULL M_block × N_block region
+                // (copy_and_pack_block later reads it whole) so `add_grad` downstream contributes nothing.
                 zero_blocks(intermediate_cb, M_block_tiles, N_block_tiles, N_block_tiles, subblock_h, subblock_w);
             }
             for (uint32_t k_block = 0; k_block < K_num_blocks; k_block++) {
@@ -355,7 +358,7 @@ void kernel_main() {
 
             cb_out.reserve_back(out_block_num_tiles);
             cb_interm.wait_front(out_block_num_tiles);
-            copy_block(intermediate_cb, out_cb, M_block_tiles, N_block_tiles);
+            copy_and_pack_block(intermediate_cb, out_cb, M_block_tiles, N_block_tiles);
             cb_interm.pop_front(out_block_num_tiles);
         }
     }

--- a/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/minimal_matmul/device/kernels/compute.cpp
@@ -15,7 +15,10 @@
 #include "api/compute/eltwise_binary_sfpu.h"
 #include "api/dataflow/circular_buffer.h"
 
-void copy_block(uint32_t in_cb, uint32_t out_cb, uint32_t M_block_tiles, uint32_t N_block_tiles) {
+// Renamed from copy_block to avoid an ambiguous overload with ckernel::copy_block (added to
+// api/compute/tile_move_copy.h in #49070), which has the identical (uint32_t, uint32_t, uint32_t,
+// uint32_t) signature and is in scope here via `using namespace ckernel`. See tt-metal#50386.
+void copy_and_pack_block(uint32_t in_cb, uint32_t out_cb, uint32_t M_block_tiles, uint32_t N_block_tiles) {
     CircularBuffer cb_out(out_cb);
     copy_tile_to_dst_init_short(in_cb);
     reconfig_data_format_srca(in_cb);
@@ -525,7 +528,7 @@ void kernel_main() {
             cb_out.reserve_back(out_block_num_tiles);
             cb_intermediate.wait_front(out_block_num_tiles);
 #ifndef FUSE_BIAS
-            copy_block(intermediate_cb, out_cb, M_block_tiles, N_block_tiles);
+            copy_and_pack_block(intermediate_cb, out_cb, M_block_tiles, N_block_tiles);
 #else
             cb_in2.wait_front(N_block_tiles);
             add_bias_block(intermediate_cb, in2_cb, out_cb, M_block_tiles, N_block_tiles);


### PR DESCRIPTION
Fixes #50414 (duplicate of #50386 — same minimal_matmul copy_block collision, different test path).

Fixes #50386.

## Problem

#49070 added `ckernel::copy_block(uint32_t, uint32_t, uint32_t, uint32_t)` to `api/compute/tile_move_copy.h`. The `minimal_matmul` compute kernel defines a **file-local** `copy_block` with the **identical signature** and calls it unqualified while `using namespace ckernel` is in scope, so the JIT build now fails:

```
compute.cpp:528:23: error: call of overloaded 'copy_block(...)' is ambiguous
  candidate 1: void copy_block(uint32_t, uint32_t, uint32_t, uint32_t)  [local, line 18]
  candidate 2: void ckernel::copy_block(uint32_t, uint32_t, uint32_t, uint32_t)  [tile_move_copy.h]
```

This broke **`t3k_mochi_tests`** (`test_mochi_attention`) — first failing commit `35a716ccced5` (the #49070 merge).

## Fix

Rename the kernel-local helper `copy_block` → **`copy_and_pack_block`** (+ its single call site). It copies a block from `in_cb` to `out_cb` tile-by-tile with optional fused activation — semantically distinct from `ckernel::copy_block`. Pure rename, no behavior change.

Renaming (rather than `::`-qualifying the call) is the robust fix: with `using namespace ckernel` at global scope, even `::copy_block` qualified lookup would still find both candidates.

## Scope

- Only `minimal_matmul` collides. The `all_gather_minimal_matmul_async` twin's local `copy_block` takes `CircularBuffer&` args (distinct signature) — not ambiguous — so it's left unchanged.

## Testing

Reproduce/verify:
```bash
pytest models/tt_dit/tests/models/mochi/test_attention_mochi.py \
  -k 'test_mochi_attention[wormhole_b0-device_params0-yes_context_pre-yes_fsdp-short_seq-1x1sp0tp1]' --timeout=300
```

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ncvetkovic/fix-copy-block-collision-50386)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ncvetkovic/fix-copy-block-collision-50386)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ncvetkovic/fix-copy-block-collision-50386)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ncvetkovic/fix-copy-block-collision-50386)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ncvetkovic/fix-copy-block-collision-50386)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ncvetkovic/fix-copy-block-collision-50386)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ncvetkovic/fix-copy-block-collision-50386)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ncvetkovic/fix-copy-block-collision-50386)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ncvetkovic/fix-copy-block-collision-50386)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ncvetkovic/fix-copy-block-collision-50386)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ncvetkovic/fix-copy-block-collision-50386)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ncvetkovic/fix-copy-block-collision-50386)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ncvetkovic/fix-copy-block-collision-50386)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ncvetkovic/fix-copy-block-collision-50386)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ncvetkovic/fix-copy-block-collision-50386)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ncvetkovic/fix-copy-block-collision-50386)