### PR TITLE
[Feature] #DIIM-247: recover.sh and run_validation.sh optimizations and new features

### DIFF
--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -19,8 +19,10 @@ Required Options:
 
 Optional:
     --config <4x32|8x16>                    Mesh configuration (default: 4x32)
-    --use-docker <docker-image>             Run validation via mpi-docker with the given image
-                                            (if not provided, uses plain mpirun with local build)
+    --use-docker [docker-image]             Run validation via mpi-docker. If an image is given, uses it;
+                                            if the flag is passed with no image, uses the default:
+                                            $DOCKER_IMAGE_DEFAULT
+                                            (if the flag is omitted entirely, uses plain mpirun with local build)
     --num-iterations <number>               Number of validation iterations (default: 5)
                                             This is the inner per-run validation loop.
     --max-attempts <number>                 Number of times to run the full recovery (reset + validation)
@@ -37,7 +39,8 @@ Optional:
                                             (auto-detected if not specified)
     --mpi-args <args>                       Extra arguments passed directly to mpirun (quoted string)
                                             e.g. --mpi-args "--tag-output"
-    --output <directory>                    Output directory for logs and validation artifacts (default: recover-logs).
+    --output <directory>                    Output directory for logs and validation artifacts
+                                            (default: "<comma-separated-hosts>-<timestamp>").
                                             Passed to run_cluster_validation as --output-path so the
                                             unretrainable_channels.yaml artifact lands here too.
 
@@ -88,6 +91,7 @@ EOF
 HOSTS=""
 CONFIG="4x32"
 DOCKER_IMAGE=""
+DOCKER_IMAGE_DEFAULT="ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-glx:v0.74.0-dev20260620-6-gd9d52dfe7b6"
 NUM_ITERATIONS=5
 MAX_ATTEMPTS=1
 SLEEP_DURATION=5
@@ -99,7 +103,7 @@ CHECK=false
 MPI_IF=""
 MPI_IF_EXPLICIT=false
 MPI_EXTRA_ARGS=()
-OUTPUT_DIR="recover-logs"
+OUTPUT_DIR=""  # default computed after --hosts is known: "<comma-separated-hosts>-<timestamp>"
 RERUN_ON_RETRAIN=false
 VALIDATION_EXTRA_ARGS=()
 REGENERATE_ON_FAILURE=true
@@ -144,11 +148,13 @@ while [[ $# -gt 0 ]]; do
             ;;
         --use-docker)
             if [[ -z "$2" ]] || [[ "$2" == --* ]]; then
-                echo "Error: --use-docker requires a non-empty value"
-                exit 1
+                # No value provided: fall back to the default image.
+                DOCKER_IMAGE="$DOCKER_IMAGE_DEFAULT"
+                shift
+            else
+                DOCKER_IMAGE="$2"
+                shift 2
             fi
-            DOCKER_IMAGE="$2"
-            shift 2
             ;;
         --num-iterations)
             if [[ -z "$2" ]] || [[ "$2" == --* ]]; then
@@ -331,6 +337,12 @@ else
         echo "Error: MPI interface auto-detection failed" >&2
         exit 1
     fi
+fi
+
+# Default output dir when not overridden by --output: the comma-separated host list followed by a
+# timestamp, e.g. "bh-glx-c01u02,bh-glx-c01u08-20260720_131500". Keeps each run's artifacts distinct.
+if [[ -z "$OUTPUT_DIR" ]]; then
+    OUTPUT_DIR="${HOSTS}-$(date +%Y%m%d_%H%M%S)"
 fi
 
 # Set log file path inside output directory (captures actual start time).

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -32,7 +32,7 @@ Optional:
     --skip-reset                            Skip tt-smi reset, only run validation
     --skip-validation                       Skip validation, only run tt-smi reset
     --skip-version-check                     Skip the tt-smi/KMD/firmware version checks run on all hosts
-                                            before recovery (see minimum versions at top of this script)
+                                            before recovery (see minimum versions in utils/host_utils.sh)
     --no-send-traffic                       Disable --send-traffic in cluster validation
     --check                                 Dry run: verify MPI can reach all hosts via hostname, then exit
     --mpi-if <interface>                    Network interface for MPI TCP transport
@@ -108,11 +108,8 @@ RERUN_ON_RETRAIN=false
 VALIDATION_EXTRA_ARGS=()
 REGENERATE_ON_FAILURE=true
 
-# Minimum required versions, checked on every host before recovery (see --skip-version-check).
-# Bump these as the required baseline moves.
-TT_SMI_MIN_VERSION="5.2.0"   # `tt-smi --version`
-KMD_MIN_VERSION="2.9.0"      # `cat /sys/module/tenstorrent/version`
-FW_MIN_VERSION="19.11"       # `cat /sys/class/tenstorrent/tenstorrent!<n>/tt_fw_bundle_ver`
+# Minimum required tt-smi/KMD/firmware versions (TT_SMI_MIN_VERSION, KMD_MIN_VERSION,
+# FW_MIN_VERSION) and the check itself live in utils/host_utils.sh, shared with run_validation.sh.
 
 CABLING_DESCRIPTOR_PATH_DEFAULT="/data/scaleout_configs/bh_glx_exabox/cabling_descriptor.textproto"
 DEPLOYMENT_DESCRIPTOR_PATH_DEFAULT="/data/scaleout_configs/bh_glx_exabox/deployment_descriptor.textproto"
@@ -430,77 +427,13 @@ echo "Regenerate on failure: $REGENERATE_ON_FAILURE"
 echo "=========================================="
 echo ""
 
-# Step 0: assert minimum tt-smi / KMD / firmware versions on every host.
-# These are host-level (independent of --use-docker), so the check always runs via plain mpirun.
+# Step 0: assert minimum tt-smi / KMD / firmware versions on every host (see check_cluster_versions
+# in utils/host_utils.sh). These are host-level (independent of --use-docker), so the check always
+# runs via plain mpirun.
 if [[ "$SKIP_VERSION_CHECK" == false ]]; then
     echo "Checking tt-smi/KMD/firmware versions on all hosts..."
-    # Single-quoted heredoc: nothing expands locally. Minimum versions are passed as positional
-    # args ($1/$2/$3) so the script body stays literal and runs identically on every rank.
-    read -r -d '' VERSION_CHECK_CMD <<'VERSION_CHECK_CMD' || true
-set -o pipefail
-h=$(hostname)
-tt_smi_min="$1"
-kmd_min="$2"
-fw_min="$3"
-fail=0
-
-# version_ge A B -> true (0) if A >= B, using version-aware ordering.
-version_ge() {
-    [[ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -n1)" == "$2" ]]
-}
-
-# 1) tt-smi version
-tt_smi_ver=$(tt-smi --version 2>/dev/null | grep -oE '[0-9]+(\.[0-9]+)+' | head -n1)
-if [[ -z "$tt_smi_ver" ]]; then
-    printf '[%s] ERROR: could not determine tt-smi version (is tt-smi installed?)\n' "$h"
-    fail=1
-elif ! version_ge "$tt_smi_ver" "$tt_smi_min"; then
-    printf '[%s] ERROR: tt-smi version %s < required %s\n' "$h" "$tt_smi_ver" "$tt_smi_min"
-    fail=1
-else
-    printf '[%s] OK: tt-smi version %s (>= %s)\n' "$h" "$tt_smi_ver" "$tt_smi_min"
-fi
-
-# 2) KMD (kernel driver) version
-kmd_ver=$(cat /sys/module/tenstorrent/version 2>/dev/null)
-if [[ -z "$kmd_ver" ]]; then
-    printf '[%s] ERROR: could not read /sys/module/tenstorrent/version (is the tenstorrent KMD loaded?)\n' "$h"
-    fail=1
-elif ! version_ge "$kmd_ver" "$kmd_min"; then
-    printf '[%s] ERROR: KMD version %s < required %s\n' "$h" "$kmd_ver" "$kmd_min"
-    fail=1
-else
-    printf '[%s] OK: KMD version %s (>= %s)\n' "$h" "$kmd_ver" "$kmd_min"
-fi
-
-# 3) Firmware bundle version, checked on every tenstorrent device present on the host
-fw_found=0
-for f in /sys/class/tenstorrent/tenstorrent!*/tt_fw_bundle_ver; do
-    [[ -e "$f" ]] || continue
-    fw_found=1
-    fw_ver=$(cat "$f" 2>/dev/null)
-    if [[ -z "$fw_ver" ]]; then
-        printf '[%s] ERROR: could not read %s\n' "$h" "$f"
-        fail=1
-    elif ! version_ge "$fw_ver" "$fw_min"; then
-        printf '[%s] ERROR: firmware version %s on %s < required %s\n' "$h" "$fw_ver" "$f" "$fw_min"
-        fail=1
-    fi
-done
-if [[ "$fw_found" -eq 0 ]]; then
-    printf '[%s] ERROR: no tenstorrent devices found under /sys/class/tenstorrent\n' "$h"
-    fail=1
-elif [[ "$fail" -eq 0 ]]; then
-    printf '[%s] OK: firmware version >= %s on all devices\n' "$h" "$fw_min"
-fi
-
-exit "$fail"
-VERSION_CHECK_CMD
     # `if !` suspends `set -e`, so a failing rank is handled here instead of aborting abruptly.
-    if ! mpirun --host "$HOSTS" \
-        --mca btl_tcp_if_include "$MPI_IF" \
-        "${MPI_EXTRA_ARGS[@]}" \
-        bash -c "$VERSION_CHECK_CMD" _ "$TT_SMI_MIN_VERSION" "$KMD_MIN_VERSION" "$FW_MIN_VERSION"; then
+    if ! check_cluster_versions "$HOSTS" "$MPI_IF" "${MPI_EXTRA_ARGS[@]}"; then
         echo ""
         echo "Error: version check failed on one or more hosts (see above)."
         echo "       Required: tt-smi >= $TT_SMI_MIN_VERSION, KMD >= $KMD_MIN_VERSION, firmware >= $FW_MIN_VERSION."

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -25,6 +25,8 @@ Optional:
     --sleep-duration <seconds>              Sleep duration after reset, before validation (default: 5)
     --skip-reset                            Skip tt-smi reset, only run validation
     --skip-validation                       Skip validation, only run tt-smi reset
+    --skip-version-check                     Skip the tt-smi/KMD/firmware version checks run on all hosts
+                                            before recovery (see minimum versions at top of this script)
     --no-send-traffic                       Disable --send-traffic in cluster validation
     --check                                 Dry run: verify MPI can reach all hosts via hostname, then exit
     --mpi-if <interface>                    Network interface for MPI TCP transport
@@ -86,6 +88,7 @@ NUM_ITERATIONS=5
 SLEEP_DURATION=5
 SKIP_RESET=false
 SKIP_VALIDATION=false
+SKIP_VERSION_CHECK=false
 SEND_TRAFFIC=true
 CHECK=false
 MPI_IF=""
@@ -95,6 +98,12 @@ OUTPUT_DIR="recover-logs"
 RERUN_ON_RETRAIN=false
 VALIDATION_EXTRA_ARGS=()
 REGENERATE_ON_FAILURE=true
+
+# Minimum required versions, checked on every host before recovery (see --skip-version-check).
+# Bump these as the required baseline moves.
+TT_SMI_MIN_VERSION="5.2.0"   # `tt-smi --version`
+KMD_MIN_VERSION="2.9.0"      # `cat /sys/module/tenstorrent/version`
+FW_MIN_VERSION="19.11"       # `cat /sys/class/tenstorrent/tenstorrent!<n>/tt_fw_bundle_ver`
 
 CABLING_DESCRIPTOR_PATH_DEFAULT="/data/scaleout_configs/bh_glx_exabox/cabling_descriptor.textproto"
 DEPLOYMENT_DESCRIPTOR_PATH_DEFAULT="/data/scaleout_configs/bh_glx_exabox/deployment_descriptor.textproto"
@@ -166,6 +175,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --skip-validation)
             SKIP_VALIDATION=true
+            shift
+            ;;
+        --skip-version-check)
+            SKIP_VERSION_CHECK=true
             shift
             ;;
         --no-send-traffic)
@@ -376,6 +389,7 @@ echo "Send traffic: $SEND_TRAFFIC"
 echo "Sleep after reset: ${SLEEP_DURATION}s"
 echo "Skip reset: $SKIP_RESET"
 echo "Skip validation: $SKIP_VALIDATION"
+echo "Skip version check: $SKIP_VERSION_CHECK"
 echo "Output directory: $OUTPUT_DIR"
 echo "Log file: $LOG_FILE"
 echo "Rerun on retrain: $RERUN_ON_RETRAIN"
@@ -385,6 +399,90 @@ fi
 echo "Regenerate on failure: $REGENERATE_ON_FAILURE"
 echo "=========================================="
 echo ""
+
+# Step 0: assert minimum tt-smi / KMD / firmware versions on every host.
+# These are host-level (independent of --use-docker), so the check always runs via plain mpirun.
+if [[ "$SKIP_VERSION_CHECK" == false ]]; then
+    echo "Checking tt-smi/KMD/firmware versions on all hosts..."
+    # Single-quoted heredoc: nothing expands locally. Minimum versions are passed as positional
+    # args ($1/$2/$3) so the script body stays literal and runs identically on every rank.
+    read -r -d '' VERSION_CHECK_CMD <<'VERSION_CHECK_CMD' || true
+set -o pipefail
+h=$(hostname)
+tt_smi_min="$1"
+kmd_min="$2"
+fw_min="$3"
+fail=0
+
+# version_ge A B -> true (0) if A >= B, using version-aware ordering.
+version_ge() {
+    [[ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -n1)" == "$2" ]]
+}
+
+# 1) tt-smi version
+tt_smi_ver=$(tt-smi --version 2>/dev/null | grep -oE '[0-9]+(\.[0-9]+)+' | head -n1)
+if [[ -z "$tt_smi_ver" ]]; then
+    printf '[%s] ERROR: could not determine tt-smi version (is tt-smi installed?)\n' "$h"
+    fail=1
+elif ! version_ge "$tt_smi_ver" "$tt_smi_min"; then
+    printf '[%s] ERROR: tt-smi version %s < required %s\n' "$h" "$tt_smi_ver" "$tt_smi_min"
+    fail=1
+else
+    printf '[%s] OK: tt-smi version %s (>= %s)\n' "$h" "$tt_smi_ver" "$tt_smi_min"
+fi
+
+# 2) KMD (kernel driver) version
+kmd_ver=$(cat /sys/module/tenstorrent/version 2>/dev/null)
+if [[ -z "$kmd_ver" ]]; then
+    printf '[%s] ERROR: could not read /sys/module/tenstorrent/version (is the tenstorrent KMD loaded?)\n' "$h"
+    fail=1
+elif ! version_ge "$kmd_ver" "$kmd_min"; then
+    printf '[%s] ERROR: KMD version %s < required %s\n' "$h" "$kmd_ver" "$kmd_min"
+    fail=1
+else
+    printf '[%s] OK: KMD version %s (>= %s)\n' "$h" "$kmd_ver" "$kmd_min"
+fi
+
+# 3) Firmware bundle version, checked on every tenstorrent device present on the host
+fw_found=0
+for f in /sys/class/tenstorrent/tenstorrent!*/tt_fw_bundle_ver; do
+    [[ -e "$f" ]] || continue
+    fw_found=1
+    fw_ver=$(cat "$f" 2>/dev/null)
+    if [[ -z "$fw_ver" ]]; then
+        printf '[%s] ERROR: could not read %s\n' "$h" "$f"
+        fail=1
+    elif ! version_ge "$fw_ver" "$fw_min"; then
+        printf '[%s] ERROR: firmware version %s on %s < required %s\n' "$h" "$fw_ver" "$f" "$fw_min"
+        fail=1
+    fi
+done
+if [[ "$fw_found" -eq 0 ]]; then
+    printf '[%s] ERROR: no tenstorrent devices found under /sys/class/tenstorrent\n' "$h"
+    fail=1
+elif [[ "$fail" -eq 0 ]]; then
+    printf '[%s] OK: firmware version >= %s on all devices\n' "$h" "$fw_min"
+fi
+
+exit "$fail"
+VERSION_CHECK_CMD
+    # `if !` suspends `set -e`, so a failing rank is handled here instead of aborting abruptly.
+    if ! mpirun --host "$HOSTS" \
+        --mca btl_tcp_if_include "$MPI_IF" \
+        "${MPI_EXTRA_ARGS[@]}" \
+        bash -c "$VERSION_CHECK_CMD" _ "$TT_SMI_MIN_VERSION" "$KMD_MIN_VERSION" "$FW_MIN_VERSION"; then
+        echo ""
+        echo "Error: version check failed on one or more hosts (see above)."
+        echo "       Required: tt-smi >= $TT_SMI_MIN_VERSION, KMD >= $KMD_MIN_VERSION, firmware >= $FW_MIN_VERSION."
+        echo "       Re-run with --skip-version-check to bypass."
+        exit 1
+    fi
+    echo "Version check passed on all hosts."
+    echo ""
+else
+    echo "Skipping version check (--skip-version-check)"
+    echo ""
+fi
 
 # Step 1: tt-smi reset
 # Note: tt-smi -glx_reset is deprecated as of tt-smi 3.1.1; use tt-smi -r if available

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -22,6 +22,10 @@ Optional:
     --use-docker <docker-image>             Run validation via mpi-docker with the given image
                                             (if not provided, uses plain mpirun with local build)
     --num-iterations <number>               Number of validation iterations (default: 5)
+                                            This is the inner per-run validation loop.
+    --max-attempts <number>                 Number of times to run the full recovery (reset + validation)
+                                            before giving up, or until it succeeds (default: 1).
+                                            This is the outer loop wrapping the whole recovery.
     --sleep-duration <seconds>              Sleep duration after reset, before validation (default: 5)
     --skip-reset                            Skip tt-smi reset, only run validation
     --skip-validation                       Skip validation, only run tt-smi reset
@@ -85,6 +89,7 @@ HOSTS=""
 CONFIG="4x32"
 DOCKER_IMAGE=""
 NUM_ITERATIONS=5
+MAX_ATTEMPTS=1
 SLEEP_DURATION=5
 SKIP_RESET=false
 SKIP_VALIDATION=false
@@ -155,6 +160,18 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             NUM_ITERATIONS="$2"
+            shift 2
+            ;;
+        --max-attempts)
+            if [[ -z "$2" ]] || [[ "$2" == --* ]]; then
+                echo "Error: --max-attempts requires a non-empty value"
+                exit 1
+            fi
+            if ! [[ "$2" =~ ^[1-9][0-9]*$ ]]; then
+                echo "Error: --max-attempts must be a positive integer, got '$2'"
+                exit 1
+            fi
+            MAX_ATTEMPTS="$2"
             shift 2
             ;;
         --sleep-duration)
@@ -385,6 +402,7 @@ else
     echo "Deployment descriptor: $DEPLOYMENT_DESCRIPTOR_PATH"
 fi
 echo "Num iterations: $NUM_ITERATIONS"
+echo "Max attempts: $MAX_ATTEMPTS"
 echo "Send traffic: $SEND_TRAFFIC"
 echo "Sleep after reset: ${SLEEP_DURATION}s"
 echo "Skip reset: $SKIP_RESET"
@@ -484,6 +502,16 @@ else
     echo ""
 fi
 
+# Outer recovery loop: run the full reset + validation up to MAX_ATTEMPTS times, or until
+# validation succeeds. --num-iterations controls the inner validation loop; this controls how
+# many times the whole recovery is retried. Descriptor regeneration (Step 3) runs once after the
+# loop, only if every attempt failed.
+VALIDATION_EXIT=0
+for (( ATTEMPT=1; ATTEMPT<=MAX_ATTEMPTS; ATTEMPT++ )); do
+echo "=========================================="
+echo "Recovery attempt $ATTEMPT of $MAX_ATTEMPTS"
+echo "=========================================="
+
 # Step 1: tt-smi reset
 # Note: tt-smi -glx_reset is deprecated as of tt-smi 3.1.1; use tt-smi -r if available
 if [[ "$SKIP_RESET" == false ]]; then
@@ -575,6 +603,22 @@ if [[ "$SKIP_VALIDATION" == false ]]; then
 else
     echo "Skipping validation (--skip-validation)"
 fi
+
+# Outer-loop control: stop as soon as an attempt succeeds; otherwise retry until attempts exhausted.
+if [[ $VALIDATION_EXIT -eq 0 ]]; then
+    echo ""
+    echo "Recovery succeeded on attempt $ATTEMPT of $MAX_ATTEMPTS."
+    break
+fi
+echo ""
+echo "Recovery attempt $ATTEMPT of $MAX_ATTEMPTS failed (exit code $VALIDATION_EXIT)."
+if [[ $ATTEMPT -lt $MAX_ATTEMPTS ]]; then
+    echo "Retrying full recovery..."
+    echo ""
+else
+    echo "Exhausted all $MAX_ATTEMPTS recovery attempts."
+fi
+done
 
 # Step 3: Regenerate descriptors if validation hit unrecoverable state
 if [[ "$REGENERATE_ON_FAILURE" == true && $VALIDATION_EXIT -ne 0 ]]; then

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -506,14 +506,21 @@ fi
 # validation succeeds. --num-iterations controls the inner validation loop; this controls how
 # many times the whole recovery is retried. Descriptor regeneration (Step 3) runs once after the
 # loop, only if every attempt failed.
+UNRETRAINABLE_YAML="$OUTPUT_DIR/unretrainable_channels.yaml"
 VALIDATION_EXIT=0
 for (( ATTEMPT=1; ATTEMPT<=MAX_ATTEMPTS; ATTEMPT++ )); do
 echo "=========================================="
 echo "Recovery attempt $ATTEMPT of $MAX_ATTEMPTS"
 echo "=========================================="
 
+# All attempts share $OUTPUT_DIR, but unretrainable_channels.yaml is only (re)written on one
+# specific validation failure path. Clear any artifact from a prior attempt so Step 3 can only
+# regenerate descriptors from evidence produced by the current (latest post-reset) attempt.
+rm -f "$UNRETRAINABLE_YAML"
+
 # Step 1: tt-smi reset
 # Note: tt-smi -glx_reset is deprecated as of tt-smi 3.1.1; use tt-smi -r if available
+RESET_EXIT=0
 if [[ "$SKIP_RESET" == false ]]; then
     echo "Running tt-smi -glx_reset..."
     # Host-tag every reset line for attribution. tt-smi writes key progress to the tty (not stdout) so
@@ -541,22 +548,38 @@ if [[ $ec -eq 0 ]]; then
 else
     printf '[%s][%(%H:%M:%S)T] Reset failed | Exit code: %s\n' "$h" -1 "$ec"
 fi
+# Propagate tt-smi's status so mpirun (and the caller) sees per-host reset failures.
+exit "$ec"
 RESET_CMD
-    mpirun --host "$HOSTS" \
+    # Capture mpirun's status without tripping `set -e` (the `if` context suspends it) so a reset
+    # failure retries the attempt instead of aborting the whole script. The remote command exits with
+    # tt-smi's status, so mpirun returns non-zero if any host's reset failed.
+    if mpirun --host "$HOSTS" \
         --mca btl_tcp_if_include "$MPI_IF" \
         "${MPI_EXTRA_ARGS[@]}" \
-        bash -c "$RESET_CMD"
+        bash -c "$RESET_CMD"; then RESET_EXIT=0; else RESET_EXIT=$?; fi
 
-    echo ""
-    echo "Sleeping ${SLEEP_DURATION}s..."
-    sleep "$SLEEP_DURATION"
+    if [[ $RESET_EXIT -ne 0 ]]; then
+        echo ""
+        echo "Reset failed on one or more hosts (exit code $RESET_EXIT)."
+    else
+        echo ""
+        echo "Sleeping ${SLEEP_DURATION}s..."
+        sleep "$SLEEP_DURATION"
+    fi
 else
     echo "Skipping tt-smi reset (--skip-reset)"
 fi
 
 # Step 2: Cluster validation
+# VALIDATION_EXIT carries the whole attempt's outcome: a failed reset short-circuits validation and
+# fails the attempt so the outer loop retries (or the script exits non-zero once attempts run out).
 VALIDATION_EXIT=0
-if [[ "$SKIP_VALIDATION" == false ]]; then
+if [[ $RESET_EXIT -ne 0 ]]; then
+    echo ""
+    echo "Skipping validation because reset failed on this attempt."
+    VALIDATION_EXIT=$RESET_EXIT
+elif [[ "$SKIP_VALIDATION" == false ]]; then
     VALIDATION_ARGS=("${DESCRIPTOR_ARGS[@]}")
     if [[ "$SEND_TRAFFIC" == true ]]; then
         VALIDATION_ARGS+=(--send-traffic)
@@ -620,9 +643,10 @@ else
 fi
 done
 
-# Step 3: Regenerate descriptors if validation hit unrecoverable state
+# Step 3: Regenerate descriptors if validation hit unrecoverable state.
+# UNRETRAINABLE_YAML is cleared before each attempt, so any file present here was produced by the
+# final (failed) attempt and reflects the latest post-reset state.
 if [[ "$REGENERATE_ON_FAILURE" == true && $VALIDATION_EXIT -ne 0 ]]; then
-    UNRETRAINABLE_YAML="$OUTPUT_DIR/unretrainable_channels.yaml"
     if [[ -f "$UNRETRAINABLE_YAML" ]]; then
         if [[ -z "$CABLING_DESCRIPTOR_PATH" || -z "$DEPLOYMENT_DESCRIPTOR_PATH" ]]; then
             echo ""

--- a/tools/scaleout/exabox/run_validation.sh
+++ b/tools/scaleout/exabox/run_validation.sh
@@ -8,15 +8,20 @@ source "$SCRIPT_DIR/utils/host_utils.sh"
 # Function to display help
 show_help() {
     cat << EOF
-Usage: $0 --hosts <comma-separated-host-list> --image <docker-image> [OPTIONS]
+Usage: $0 --hosts <comma-separated-host-list> [--image <docker-image>] [OPTIONS]
 
 Run cluster validation commands for multiple iterations.
 
 Required Options:
     --hosts <host-list>                     Comma-separated list of hosts
-    --image <docker-image>                  Docker image to use ("none" to use local build)
 
 Optional:
+    --image [docker-image]                  Docker image to use ("none" to use local build).
+                                            If an image is given, uses it; if the flag is passed with
+                                            no value, or omitted entirely, uses the default image:
+                                            $DOCKER_IMAGE_DEFAULT
+    --skip-version-check                     Skip the tt-smi/KMD/firmware version checks run on all hosts
+                                            before validation (see minimum versions in utils/host_utils.sh)
     --cabling-descriptor-path <path>        Path to cabling descriptor file
                                             (default: /data/scaleout_configs/bh_glx_exabox/cabling_descriptor.textproto)
     --deployment-descriptor-path <path>     Path to deployment descriptor file
@@ -26,7 +31,8 @@ Optional:
 
     --factory-descriptor-path <path>        Path to pregenerated factory system descriptor (FSD) file (.textproto)
                                             (if provided, cabling and deployment descriptors are ignored)
-    --output <directory>                    Output directory for log files (default: validation_output)
+    --output <directory>                    Output directory for log files
+                                            (default: "<comma-separated-hosts>-<timestamp>")
     --volume <host-path>                    Additional volume mount for Docker containers (can be repeated)
                                             /data/scaleout_configs is mounted by default when it exists on
                                             the host; each host path is mounted at the same path inside
@@ -58,12 +64,16 @@ EOF
 # Parse command line arguments
 HOSTS=""
 DOCKER_IMAGE=""
+# Default image used when --image is omitted (or passed with no value). Bump to the current
+# last-known-good tag as needed (see tools/scaleout/exabox/README.md).
+DOCKER_IMAGE_DEFAULT="ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-glx:v0.66.0-dev20260115-28-g6eccf7061a"
+SKIP_VERSION_CHECK=false
 CABLING_DESCRIPTOR_PATH="/data/scaleout_configs/bh_glx_exabox/cabling_descriptor.textproto"
 DEPLOYMENT_DESCRIPTOR_PATH="/data/scaleout_configs/bh_glx_exabox/deployment_descriptor.textproto"
 ITERATIONS=50
 
 FACTORY_DESCRIPTOR_PATH=""
-OUTPUT_DIR="validation_output"
+OUTPUT_DIR=""  # default computed after --hosts is known: "<comma-separated-hosts>-<timestamp>"
 # /data/scaleout_configs is a Markham-cluster convention. Only mount it when it
 # actually exists locally; otherwise Docker fails trying to auto-create the
 # missing bind-mount source path (mkdir: permission denied) and every rank dies
@@ -88,11 +98,17 @@ while [[ $# -gt 0 ]]; do
             ;;
         --image)
             if [[ -z "$2" ]] || [[ "$2" == --* ]]; then
-                echo "Error: --image requires a non-empty value"
-                exit 1
+                # No value provided: fall back to the default image.
+                DOCKER_IMAGE="$DOCKER_IMAGE_DEFAULT"
+                shift
+            else
+                DOCKER_IMAGE="$2"
+                shift 2
             fi
-            DOCKER_IMAGE="$2"
-            shift 2
+            ;;
+        --skip-version-check)
+            SKIP_VERSION_CHECK=true
+            shift
             ;;
         --cabling-descriptor-path)
             if [[ -z "$2" ]] || [[ "$2" == --* ]]; then
@@ -186,16 +202,16 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# --image is optional: fall back to the default image when omitted entirely.
+if [[ -z "$DOCKER_IMAGE" ]]; then
+    DOCKER_IMAGE="$DOCKER_IMAGE_DEFAULT"
+fi
+
 # If the operator forwarded --help / -h through --validation-args, just print
 # run_cluster_validation --help from the docker image and exit. Short-circuits
 # before --hosts validation since no cluster operation is performed.
 for _arg in "${VALIDATION_EXTRA_ARGS[@]}"; do
     if [[ "$_arg" == "--help" || "$_arg" == "-h" ]]; then
-        if [[ -z "$DOCKER_IMAGE" ]]; then
-            echo "Error: --validation-args \"--help\" requires --image <docker-image>"
-            echo "Example: $0 --image <ghcr-image> --validation-args \"--help\""
-            exit 1
-        fi
         exec docker run --rm --entrypoint='' "$DOCKER_IMAGE" \
             ./build/tools/scaleout/run_cluster_validation --help
     fi
@@ -211,13 +227,6 @@ fi
 
 check_duplicate_hosts "$HOSTS" || exit 1
 
-if [[ -z "$DOCKER_IMAGE" ]]; then
-    echo "Error: --image is required"
-    echo ""
-    show_help
-    exit 1
-fi
-
 # Validate/auto-detect MPI interface with first host from the list
 FIRST_HOST="${HOSTS%%,*}"
 if [[ "$MPI_IF_EXPLICIT" == "true" ]]; then
@@ -229,6 +238,12 @@ else
         echo "Error: MPI interface auto-detection failed" >&2
         exit 1
     fi
+fi
+
+# Default output dir when not overridden by --output: the comma-separated host list followed by a
+# timestamp, e.g. "bh-glx-c01u02,bh-glx-c01u08-20260720_131500". Keeps each run's artifacts distinct.
+if [[ -z "$OUTPUT_DIR" ]]; then
+    OUTPUT_DIR="${HOSTS}-$(date +%Y%m%d_%H%M%S)"
 fi
 
 run_cluster_validation() {
@@ -352,11 +367,27 @@ if [[ "${#MPI_EXTRA_ARGS[@]}" -gt 0 ]]; then
     echo "MPI extra args: ${MPI_EXTRA_ARGS[*]}"
 fi
 echo "Number of iterations: $ITERATIONS"
+echo "Skip version check: $SKIP_VERSION_CHECK"
 echo "Output directory: $OUTPUT_DIR"
 if [[ ${#VALIDATION_EXTRA_ARGS[@]} -gt 0 ]]; then
     echo "Extra validation args: ${VALIDATION_EXTRA_ARGS[*]}"
 fi
 echo ""
+
+# Assert minimum tt-smi / KMD / firmware versions on every host before validation (see
+# check_cluster_versions in utils/host_utils.sh). Host-level check, always via plain mpirun.
+if [[ "$SKIP_VERSION_CHECK" == false ]]; then
+    echo "Checking tt-smi/KMD/firmware versions on all hosts..."
+    if ! check_cluster_versions "$HOSTS" "$MPI_IF" "${MPI_EXTRA_ARGS[@]}"; then
+        echo ""
+        echo "Error: version check failed on one or more hosts (see above)."
+        echo "       Required: tt-smi >= $TT_SMI_MIN_VERSION, KMD >= $KMD_MIN_VERSION, firmware >= $FW_MIN_VERSION."
+        echo "       Re-run with --skip-version-check to bypass."
+        exit 1
+    fi
+    echo "Version check passed on all hosts."
+    echo ""
+fi
 
 # Create output directory if it doesn't exist and resolve to an absolute path so
 # that paths passed into Docker containers refer to the same location on the host.

--- a/tools/scaleout/exabox/utils/host_utils.sh
+++ b/tools/scaleout/exabox/utils/host_utils.sh
@@ -35,3 +35,93 @@ check_duplicate_hosts() {
     fi
     return 0
 }
+
+# Minimum tool/driver/firmware versions required on every host before running recovery or
+# validation. Bump these as the supported baseline moves; both recover.sh and run_validation.sh
+# check against the same values.
+TT_SMI_MIN_VERSION="5.2.0"   # `tt-smi --version`
+KMD_MIN_VERSION="2.9.0"      # `cat /sys/module/tenstorrent/version`
+FW_MIN_VERSION="19.11"       # `cat /sys/class/tenstorrent/tenstorrent!<n>/tt_fw_bundle_ver`
+
+# Assert the minimum tt-smi / KMD / firmware versions on every host via mpirun. This is a host-level
+# check (independent of any Docker image), so it always runs via plain mpirun. Each rank prints
+# per-check OK/ERROR lines and exits non-zero if anything is below the baseline, so mpirun (and this
+# function) returns non-zero if any host fails.
+#
+# Usage: check_cluster_versions "$HOSTS" "$MPI_IF" [mpi_extra_args...]
+# Returns 0 if all hosts meet the minimums, non-zero otherwise.
+check_cluster_versions() {
+    local hosts="$1"
+    local mpi_if="$2"
+    shift 2
+    local mpi_extra_args=("$@")
+
+    local version_check_cmd
+    # Single-quoted heredoc: nothing expands here. Minimum versions are passed as positional args
+    # ($1/$2/$3) so the script body stays literal and runs identically on every rank.
+    read -r -d '' version_check_cmd <<'VERSION_CHECK_CMD' || true
+set -o pipefail
+h=$(hostname)
+tt_smi_min="$1"
+kmd_min="$2"
+fw_min="$3"
+fail=0
+
+# version_ge A B -> true (0) if A >= B, using version-aware ordering.
+version_ge() {
+    [[ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -n1)" == "$2" ]]
+}
+
+# 1) tt-smi version
+tt_smi_ver=$(tt-smi --version 2>/dev/null | grep -oE '[0-9]+(\.[0-9]+)+' | head -n1)
+if [[ -z "$tt_smi_ver" ]]; then
+    printf '[%s] ERROR: could not determine tt-smi version (is tt-smi installed?)\n' "$h"
+    fail=1
+elif ! version_ge "$tt_smi_ver" "$tt_smi_min"; then
+    printf '[%s] ERROR: tt-smi version %s < required %s\n' "$h" "$tt_smi_ver" "$tt_smi_min"
+    fail=1
+else
+    printf '[%s] OK: tt-smi version %s (>= %s)\n' "$h" "$tt_smi_ver" "$tt_smi_min"
+fi
+
+# 2) KMD (kernel driver) version
+kmd_ver=$(cat /sys/module/tenstorrent/version 2>/dev/null)
+if [[ -z "$kmd_ver" ]]; then
+    printf '[%s] ERROR: could not read /sys/module/tenstorrent/version (is the tenstorrent KMD loaded?)\n' "$h"
+    fail=1
+elif ! version_ge "$kmd_ver" "$kmd_min"; then
+    printf '[%s] ERROR: KMD version %s < required %s\n' "$h" "$kmd_ver" "$kmd_min"
+    fail=1
+else
+    printf '[%s] OK: KMD version %s (>= %s)\n' "$h" "$kmd_ver" "$kmd_min"
+fi
+
+# 3) Firmware bundle version, checked on every tenstorrent device present on the host
+fw_found=0
+for f in /sys/class/tenstorrent/tenstorrent!*/tt_fw_bundle_ver; do
+    [[ -e "$f" ]] || continue
+    fw_found=1
+    fw_ver=$(cat "$f" 2>/dev/null)
+    if [[ -z "$fw_ver" ]]; then
+        printf '[%s] ERROR: could not read %s\n' "$h" "$f"
+        fail=1
+    elif ! version_ge "$fw_ver" "$fw_min"; then
+        printf '[%s] ERROR: firmware version %s on %s < required %s\n' "$h" "$fw_ver" "$f" "$fw_min"
+        fail=1
+    fi
+done
+if [[ "$fw_found" -eq 0 ]]; then
+    printf '[%s] ERROR: no tenstorrent devices found under /sys/class/tenstorrent\n' "$h"
+    fail=1
+elif [[ "$fail" -eq 0 ]]; then
+    printf '[%s] OK: firmware version >= %s on all devices\n' "$h" "$fw_min"
+fi
+
+exit "$fail"
+VERSION_CHECK_CMD
+
+    mpirun --host "$hosts" \
+        --mca btl_tcp_if_include "$mpi_if" \
+        "${mpi_extra_args[@]}" \
+        bash -c "$version_check_cmd" _ "$TT_SMI_MIN_VERSION" "$KMD_MIN_VERSION" "$FW_MIN_VERSION"
+}


### PR DESCRIPTION
### Ticket

[DIIM-247]()

### Summary

- Added pre-recovery version checks: before any reset/validation, the script now verifies on every host that `tt-smi`, the `KMD`, and `firmware` meet minimum versions:

  - tt-smi --version ≥ 5.2.0
  - /sys/module/tenstorrent/version (KMD) ≥ 2.9.0
  - tt_fw_bundle_ver on every tenstorrent device ≥ 19.11

Added --skip-version-check to bypass.

- Added an outer recovery retry loop (--max-attempts, default 1): runs the full recovery (reset + validation) up to N times or until validation succeeds. Default of 1 preserves existing single-run behavior. This is distinct from --num-iterations, which remains the inner per-run validation loop. Descriptor regeneration still runs once after the loop, only if all attempts fail.
- Output directory name format
- Default docker image value

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mgajewskiTT/DIIM-247-supercluster-recovery-experience-is-too-high-friction-for-devs-and-prone-to-user-error)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mgajewskiTT/DIIM-247-supercluster-recovery-experience-is-too-high-friction-for-devs-and-prone-to-user-error)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mgajewskiTT/DIIM-247-supercluster-recovery-experience-is-too-high-friction-for-devs-and-prone-to-user-error)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mgajewskiTT/DIIM-247-supercluster-recovery-experience-is-too-high-friction-for-devs-and-prone-to-user-error)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mgajewskiTT/DIIM-247-supercluster-recovery-experience-is-too-high-friction-for-devs-and-prone-to-user-error)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mgajewskiTT/DIIM-247-supercluster-recovery-experience-is-too-high-friction-for-devs-and-prone-to-user-error)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mgajewskiTT/DIIM-247-supercluster-recovery-experience-is-too-high-friction-for-devs-and-prone-to-user-error)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mgajewskiTT/DIIM-247-supercluster-recovery-experience-is-too-high-friction-for-devs-and-prone-to-user-error)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mgajewskiTT/DIIM-247-supercluster-recovery-experience-is-too-high-friction-for-devs-and-prone-to-user-error)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mgajewskiTT/DIIM-247-supercluster-recovery-experience-is-too-high-friction-for-devs-and-prone-to-user-error)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mgajewskiTT/DIIM-247-supercluster-recovery-experience-is-too-high-friction-for-devs-and-prone-to-user-error)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mgajewskiTT/DIIM-247-supercluster-recovery-experience-is-too-high-friction-for-devs-and-prone-to-user-error)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mgajewskiTT/DIIM-247-supercluster-recovery-experience-is-too-high-friction-for-devs-and-prone-to-user-error)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mgajewskiTT/DIIM-247-supercluster-recovery-experience-is-too-high-friction-for-devs-and-prone-to-user-error)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mgajewskiTT/DIIM-247-supercluster-recovery-experience-is-too-high-friction-for-devs-and-prone-to-user-error)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mgajewskiTT/DIIM-247-supercluster-recovery-experience-is-too-high-friction-for-devs-and-prone-to-user-error)