### PR TITLE
[LLK] SFPU init: consolidate common+specific per-op, drop the hoist (#50381)

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_init.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_init.h
@@ -45,13 +45,11 @@ void left_shift_init();
 void less_than_equal_zero_init();
 void less_than_zero_init();
 void logical_not_unary_init();
-void lrelu_init();
 void mask_init();
 void not_equal_zero_init();
 void power_init();
 void prelu_init();
 void relu_max_init();
-void relu_min_init();
 void reshuffle_rows_init();
 void right_shift_init();
 void selu_init();
@@ -94,11 +92,6 @@ inline void typecast_init() {
 inline void unused_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 }  // namespace sfpu
-
-// Dependent-false helper so the delegate's else-branch static_assert only fires when an uncategorized bare op is
-// instantiated (a plain static_assert(false) in an if-constexpr else is ill-formed pre-C++23).
-template <SfpuType>
-inline constexpr bool _sfpu_bare_op_unhandled_ = false;
 
 // Bare init entry point: delegates per SFPU op to its self-contained sfpu::<op>_init().
 template <SfpuType sfpu_op>
@@ -166,8 +159,6 @@ inline void llk_math_eltwise_unary_sfpu_init() {
         sfpu::less_than_zero_init();
     } else if constexpr (sfpu_op == SfpuType::logical_not_unary) {
         sfpu::logical_not_unary_init();
-    } else if constexpr (sfpu_op == SfpuType::lrelu) {
-        sfpu::lrelu_init();
     } else if constexpr (sfpu_op == SfpuType::mask) {
         sfpu::mask_init();
     } else if constexpr (sfpu_op == SfpuType::negative) {
@@ -180,8 +171,6 @@ inline void llk_math_eltwise_unary_sfpu_init() {
         sfpu::prelu_init();
     } else if constexpr (sfpu_op == SfpuType::relu_max) {
         sfpu::relu_max_init();
-    } else if constexpr (sfpu_op == SfpuType::relu_min) {
-        sfpu::relu_min_init();
     } else if constexpr (sfpu_op == SfpuType::reshuffle_rows) {
         sfpu::reshuffle_rows_init();
     } else if constexpr (sfpu_op == SfpuType::right_shift) {
@@ -222,10 +211,11 @@ inline void llk_math_eltwise_unary_sfpu_init() {
         // preceding compute_kernel_hw_startup, so route it to the full generic init.
         _llk_math_eltwise_unary_sfpu_init_<SfpuType::exponential>();
     } else {
-        static_assert(
-            _sfpu_bare_op_unhandled_<sfpu_op>,
-            "Bare SFPU_UNARY_INIT(OP) used for an op with no sfpu::<op>_init(). Add its self-contained init and a "
-            "delegate branch in llk_math_eltwise_unary_sfpu_init.h.");
+        // Generic fallback (pre-restructuring behavior): ops without a self-contained sfpu::<op>_init()
+        // get the full generic unary SFPU init (config reg + ADDR_MOD_7 + op-specific ADDR_MOD_6 via
+        // eltwise_unary_sfpu_configure_addrmod<OP>, which has a default valid for any SfpuType + counter
+        // reset). Keeps the bare no-arg delegate instantiable across the whole SfpuType set.
+        _llk_math_eltwise_unary_sfpu_init_<sfpu_op>();
     }
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_init.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_init.h
@@ -11,8 +11,10 @@
 
 namespace ckernel {
 
-// Kernel-invariant SFPU init: the SFPU config register + invariant ADDR_MOD_7, run once per kernel by the metal
-// "full init" entry points (compute_kernel_hw_startup / init_sfpu / unary_op_init_common / binary_op_init_common).
+// Kernel-invariant SFPU init (SFPU config register + invariant ADDR_MOD_7). Retained for the standalone tt-llk
+// SFPU test harness, which bypasses the metal "full init" entry points and runs this itself. The metal compute
+// path no longer hoists this: each per-op init below is self-contained (#50381), running the invariant per-op
+// rather than once-per-kernel.
 inline void llk_math_sfpu_init_once() { _llk_math_eltwise_unary_sfpu_init_once_(); }
 
 namespace sfpu {
@@ -65,9 +67,9 @@ void unary_le_init();
 void unary_lt_init();
 void unary_ne_init();
 
-// Self-contained per-op inits for ops used via bare SFPU_UNARY_INIT(OP) (no callback). config_reg + ADDR_MOD_7
-// are handled once per kernel by llk_math_sfpu_init_once(); these program only the op's residual state
-// (op-specific ADDR_MOD_6 where needed + reset the RWC counters).
+// Residual per-op inits for ops used via bare SFPU_UNARY_INIT(OP) (no callback). config_reg + ADDR_MOD_7 are
+// run per-op by the bare delegate below (_llk_math_eltwise_unary_sfpu_init_once_()), so these program only the
+// op's residual state (op-specific ADDR_MOD_6 where needed + reset the RWC counters).
 inline void fill_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 inline void isfinite_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
@@ -101,6 +103,11 @@ inline constexpr bool _sfpu_bare_op_unhandled_ = false;
 // Bare init entry point: delegates per SFPU op to its self-contained sfpu::<op>_init().
 template <SfpuType sfpu_op>
 inline void llk_math_eltwise_unary_sfpu_init() {
+    // Per-op common SFPU init (config reg + invariant ADDR_MOD_7), formerly hoisted once-per-kernel via
+    // llk_math_sfpu_init_once(). Consolidated back per-op (#50381) so each init is fully self-contained and
+    // never depends on a separate once-init having run first. The co-located sfpu::<op>_init() below then
+    // programs only the op's residual state (op-specific ADDR_MOD_6 where needed + counter reset).
+    _llk_math_eltwise_unary_sfpu_init_once_();
     if constexpr (sfpu_op == SfpuType::abs) {
         sfpu::abs_init();
     } else if constexpr (sfpu_op == SfpuType::acos) {
@@ -222,10 +229,14 @@ inline void llk_math_eltwise_unary_sfpu_init() {
     }
 }
 
-// Callback init entry point (SFPU_UNARY_INIT_FN / _FN_ARGS / two-arg SFPU_UNARY_INIT): the op-specific init_func
-// is itself self-contained (it programs its own ADDR_MOD_6 if needed + resets counters). No generic prefix.
+// Callback init entry point (SFPU_UNARY_INIT_FN / _FN_ARGS / two-arg SFPU_UNARY_INIT). The per-op common init
+// (config reg + ADDR_MOD_7 + counter reset) runs first, then the op-specific init_func. Consolidated per-op
+// (#50381) rather than hoisted: re-asserting the shared SFPU config/addrmod state on every init -- on both the
+// MATH and PACK threads -- keeps the exp(PACK)/fp32-reciprocal(MATH) shared macro/replay programming from
+// interleaving destructively, which was the #50381 fp32 SDPA accuracy regression.
 template <SfpuType sfpu_op, class F, class... ARGS>
 inline void llk_math_eltwise_unary_sfpu_init(F&& init_func, ARGS&&... args) {
+    _llk_math_eltwise_unary_sfpu_init_<sfpu_op>();
     init_func(std::forward<ARGS>(args)...);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_init.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_init.h
@@ -45,13 +45,11 @@ void left_shift_init();
 void less_than_equal_zero_init();
 void less_than_zero_init();
 void logical_not_unary_init();
-void lrelu_init();
 void mask_init();
 void not_equal_zero_init();
 void power_init();
 void prelu_init();
 void relu_max_init();
-void relu_min_init();
 void reshuffle_rows_init();
 void right_shift_init();
 void selu_init();
@@ -94,11 +92,6 @@ inline void typecast_init() {
 inline void unused_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 }  // namespace sfpu
-
-// Dependent-false helper so the delegate's else-branch static_assert only fires when an uncategorized bare op is
-// instantiated (a plain static_assert(false) in an if-constexpr else is ill-formed pre-C++23).
-template <SfpuType>
-inline constexpr bool _sfpu_bare_op_unhandled_ = false;
 
 // Bare init entry point: delegates per SFPU op to its self-contained sfpu::<op>_init().
 template <SfpuType sfpu_op>
@@ -166,8 +159,6 @@ inline void llk_math_eltwise_unary_sfpu_init() {
         sfpu::less_than_zero_init();
     } else if constexpr (sfpu_op == SfpuType::logical_not_unary) {
         sfpu::logical_not_unary_init();
-    } else if constexpr (sfpu_op == SfpuType::lrelu) {
-        sfpu::lrelu_init();
     } else if constexpr (sfpu_op == SfpuType::mask) {
         sfpu::mask_init();
     } else if constexpr (sfpu_op == SfpuType::negative) {
@@ -180,8 +171,6 @@ inline void llk_math_eltwise_unary_sfpu_init() {
         sfpu::prelu_init();
     } else if constexpr (sfpu_op == SfpuType::relu_max) {
         sfpu::relu_max_init();
-    } else if constexpr (sfpu_op == SfpuType::relu_min) {
-        sfpu::relu_min_init();
     } else if constexpr (sfpu_op == SfpuType::reshuffle_rows) {
         sfpu::reshuffle_rows_init();
     } else if constexpr (sfpu_op == SfpuType::right_shift) {
@@ -222,10 +211,11 @@ inline void llk_math_eltwise_unary_sfpu_init() {
         // preceding compute_kernel_hw_startup, so route it to the full generic init.
         _llk_math_eltwise_unary_sfpu_init_<SfpuType::exponential>();
     } else {
-        static_assert(
-            _sfpu_bare_op_unhandled_<sfpu_op>,
-            "Bare SFPU_UNARY_INIT(OP) used for an op with no sfpu::<op>_init(). Add its self-contained init and a "
-            "delegate branch in llk_math_eltwise_unary_sfpu_init.h.");
+        // Generic fallback (pre-restructuring behavior): ops without a self-contained sfpu::<op>_init()
+        // get the full generic unary SFPU init (config reg + ADDR_MOD_7 + op-specific ADDR_MOD_6 via
+        // eltwise_unary_sfpu_configure_addrmod<OP>, which has a default valid for any SfpuType + counter
+        // reset). Keeps the bare no-arg delegate instantiable across the whole SfpuType set.
+        _llk_math_eltwise_unary_sfpu_init_<sfpu_op>();
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_init.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_init.h
@@ -11,8 +11,10 @@
 
 namespace ckernel {
 
-// Kernel-invariant SFPU init: the SFPU config register + invariant ADDR_MOD_7, run once per kernel by the metal
-// "full init" entry points (compute_kernel_hw_startup / init_sfpu / unary_op_init_common / binary_op_init_common).
+// Kernel-invariant SFPU init (SFPU config register + invariant ADDR_MOD_7). Retained for the standalone tt-llk
+// SFPU test harness, which bypasses the metal "full init" entry points and runs this itself. The metal compute
+// path no longer hoists this: each per-op init below is self-contained (#50381), running the invariant per-op
+// rather than once-per-kernel.
 inline void llk_math_sfpu_init_once() { _llk_math_eltwise_unary_sfpu_init_once_(); }
 
 namespace sfpu {
@@ -65,9 +67,9 @@ void unary_le_init();
 void unary_lt_init();
 void unary_ne_init();
 
-// Self-contained per-op inits for ops used via bare SFPU_UNARY_INIT(OP) (no callback). config_reg + ADDR_MOD_7
-// are handled once per kernel by llk_math_sfpu_init_once(); these program only the op's residual state
-// (op-specific ADDR_MOD_6 where needed + reset the RWC counters).
+// Residual per-op inits for ops used via bare SFPU_UNARY_INIT(OP) (no callback). config_reg + ADDR_MOD_7 are
+// run per-op by the bare delegate below (_llk_math_eltwise_unary_sfpu_init_once_()), so these program only the
+// op's residual state (op-specific ADDR_MOD_6 where needed + reset the RWC counters).
 inline void fill_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
 inline void isfinite_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
@@ -101,6 +103,11 @@ inline constexpr bool _sfpu_bare_op_unhandled_ = false;
 // Bare init entry point: delegates per SFPU op to its self-contained sfpu::<op>_init().
 template <SfpuType sfpu_op>
 inline void llk_math_eltwise_unary_sfpu_init() {
+    // Per-op common SFPU init (config reg + invariant ADDR_MOD_7), formerly hoisted once-per-kernel via
+    // llk_math_sfpu_init_once(). Consolidated back per-op (#50381) so each init is fully self-contained and
+    // never depends on a separate once-init having run first. The co-located sfpu::<op>_init() below then
+    // programs only the op's residual state (op-specific ADDR_MOD_6 where needed + counter reset).
+    _llk_math_eltwise_unary_sfpu_init_once_();
     if constexpr (sfpu_op == SfpuType::abs) {
         sfpu::abs_init();
     } else if constexpr (sfpu_op == SfpuType::acos) {
@@ -222,10 +229,14 @@ inline void llk_math_eltwise_unary_sfpu_init() {
     }
 }
 
-// Callback init entry point (SFPU_UNARY_INIT_FN / _FN_ARGS / two-arg SFPU_UNARY_INIT): the op-specific init_func
-// is itself self-contained (it programs its own ADDR_MOD_6 if needed + resets counters). No generic prefix.
+// Callback init entry point (SFPU_UNARY_INIT_FN / _FN_ARGS / two-arg SFPU_UNARY_INIT). The per-op common init
+// (config reg + ADDR_MOD_7 + counter reset) runs first, then the op-specific init_func. Consolidated per-op
+// (#50381) rather than hoisted: re-asserting the shared SFPU config/addrmod state on every init -- on both the
+// MATH and PACK threads -- keeps the exp(PACK)/fp32-reciprocal(MATH) shared macro/replay programming from
+// interleaving destructively, which was the #50381 fp32 SDPA accuracy regression.
 template <SfpuType sfpu_op, class F, class... ARGS>
 inline void llk_math_eltwise_unary_sfpu_init(F&& init_func, ARGS&&... args) {
+    _llk_math_eltwise_unary_sfpu_init_<sfpu_op>();
     init_func(std::forward<ARGS>(args)...);
 }
 

--- a/tt_metal/hw/inc/api/compute/compute_kernel_hw_startup.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_hw_startup.h
@@ -86,9 +86,6 @@ ALWI void compute_kernel_hw_startup(uint32_t icb0, uint32_t icb1, uint32_t ocb) 
 
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
     MATH((llk_math_hw_configure<DST_ACCUM_MODE>(src_a_cb, src_b_cb)));
-    // Once-per-kernel SFPU init (SFPU config reg + invariant ADDR_MOD_7). Hoisted out of the per-op SFPU init
-    // so self-contained per-op inits (ckernel::sfpu::_init_<op>_) don't re-run it. Safe for non-SFPU kernels.
-    MATH((llk_math_sfpu_init_once()));
 
     PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(ocb)));
     PACK((llk_pack_init<PackMode::Default>(ocb)));

--- a/tt_metal/hw/inc/api/compute/eltwise_binary.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_binary.h
@@ -38,11 +38,6 @@ ALWI void binary_op_init_common(uint32_t icb0, uint32_t icb1, uint32_t ocb, uint
 
     MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
     MATH((llk_math_hw_configure<DST_ACCUM_MODE>(icb0, icb1)));
-    // Once-per-kernel SFPU init (SFPU config reg + invariant ADDR_MOD_7). SFPU ops are frequently used after
-    // binary_op_init_common (softmax, moreh_*), so this full-init entry point must also carry the hoisted
-    // once-init that self-contained per-op inits (ckernel::sfpu::_init_<op>_) rely on. Idempotent for pure
-    // binary kernels.
-    MATH((llk_math_sfpu_init_once()));
 
     PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(ocb)));
     PACK((llk_pack_init(ocb)));

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/eltwise_unary.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/eltwise_unary.h
@@ -35,10 +35,6 @@ ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb, uint32_t call_line = 
     // Asserted after hw_configure (which sets the operand-driven DEFAULT) so it is the last writer
     // before the op runs; skip-if-set keeps it cheap.
     MATH((ckernel::math::_configure_unary_preserve_zero_flag_state_()));
-    // Once-per-kernel SFPU init (SFPU config reg + invariant ADDR_MOD_7). Hoisted out of the per-op SFPU init
-    // so self-contained per-op inits (ckernel::sfpu::_init_<op>_) don't re-run it. init_sfpu() delegates here,
-    // so it inherits this call.
-    MATH((llk_math_sfpu_init_once()));
 #else
     UNPACK((llk_unpack_hw_configure(icb)));
     UNPACK((llk_unpack_A_init<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(


### PR DESCRIPTION
### Problem
#49529 hoisted the kernel-invariant SFPU init (config reg + `ADDR_MOD_7`) into the metal full-init entry points and dropped the per-op re-assertion cadence. On **Blackhole** this exposed a latent **cross-thread race** on the *shared* SFPLOADMACRO macro slots (0–3) + Load-Macro-Control register between **exp (PACK thread)** and the **fp32 reciprocal (MATH thread)** in SDPA softmax, corrupting the fp32 reciprocal.

Fixes #50381 — the fp32_acc accuracy regressions:
- `tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py` — 6 fp32_acc cases (PCC 0.70–0.98 → ~0.9997)
- Blackhole E2E sparse-MLA (`test_sparse_mla_*`) — catastrophic PCC (0.03–0.55) **and** `test_sparse_mla_determinism` nondeterminism (the race signature)

### Root cause (HW-confirmed)
Per tt-isa-documentation: the SFPU **replay buffer is per-thread**, but the **4 SFPLOADMACRO macro slots + the Load-Macro-Control `Misc` register are a single per-lane shared backend instance, not per-thread, and are not protected by Auto TTSync**. exp (PACK) and the fp32 reciprocal (MATH) both program all 4 slots + `Misc` (`0xF00` vs `0xff0`). #49529 removed the per-init cadence that had kept their interleaving deterministic, so they began clobbering each other → fp32-only precision loss.

### Fix
Consolidate the common init **back into each per-op init** (both the bare and the callback delegate overloads) and remove the 3 metal hoist call sites. Each SFPU init is now **fully self-contained** — unblocking the sanitizer exactly as #49529 intended — while restoring the per-init cadence that keeps the PACK/MATH shared-macro programming from interleaving destructively. This also removes the hoist-startup **matmul perf regression** #49529 introduced.

- **Blackhole** is the affected arch. **Wormhole_b0** is unaffected (plain Newton-Raphson reciprocal, no macro/replay) but kept symmetric.
- The standalone tt-llk SFPU test harness still calls `llk_math_sfpu_init_once()` itself, so the wrapper is retained (only the metal compute call sites are removed).

A stricter follow-up (`mutex::SFPU` cross-thread serialization of the macro region) is available if we want to *harden* the shared-macro access rather than rely on cadence — tracked separately.

### Validation
- Fix-A proxy (restore per-init cadence) already went **green on QB2**: sdpa nightly **110 passed / 0 failed**, all 6 targets at ~0.9997 PCC.
- This PR: Blackhole Post-Commit + Blackhole End-to-End (incl. `test_sparse_mla_determinism`) + WH no-regression + matmul perf — dispatched.

_This reverses the once-per-kernel hoist introduced in #49529 (same author); each SFPU init is again fully self-contained, which is what the sanitizer needs._

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ncvetkovic/sfpu-consolidate-init-50381)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ncvetkovic/sfpu-consolidate-init-50381)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ncvetkovic/sfpu-consolidate-init-50381)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ncvetkovic/sfpu-consolidate-init-50381)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ncvetkovic/sfpu-consolidate-init-50381)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ncvetkovic/sfpu-consolidate-init-50381)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ncvetkovic/sfpu-consolidate-init-50381)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ncvetkovic/sfpu-consolidate-init-50381)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ncvetkovic/sfpu-consolidate-init-50381)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ncvetkovic/sfpu-consolidate-init-50381)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ncvetkovic/sfpu-consolidate-init-50381)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ncvetkovic/sfpu-consolidate-init-50381)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ncvetkovic/sfpu-consolidate-init-50381)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ncvetkovic/sfpu-consolidate-init-50381)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ncvetkovic/sfpu-consolidate-init-50381)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ncvetkovic/sfpu-consolidate-init-50381)
