### PR TITLE
[skip ci] Remove env vars set in ttop

### DIFF
--- a/.github/workflows/blaze-models-prefill-tests-impl.yaml
+++ b/.github/workflows/blaze-models-prefill-tests-impl.yaml
@@ -125,20 +125,9 @@ jobs:
     name: ${{ matrix.test-group.name }}
     needs: load-test-matrix
     env:
-      OMPI_MCA_btl_tcp_if_include: ens5f0np0
-      PRTE_MCA_plm_ssh_args: "-o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
-      PRTE_MCA_plm_ssh_pass_libpath: /opt/openmpi-v5.0.7-ulfm/lib
-      PRTE_MCA_prte_launch_agent: /opt/openmpi-v5.0.7-ulfm/bin/prted
-      PRTE_MCA_prte_default_hostfile: /etc/ttop/hostfile
-      PRTE_MCA_prte_fwd_environment: "true"
       PATH: "/opt/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
       VIRTUAL_ENV: /opt/venv
       HOME: /home/user
-      PIP_CACHE_DIR: /home/user/.cache/pip
-      LD_LIBRARY_PATH: /home/user/tt-metal/build/lib
-      TT_METAL_HOME: /home/user/tt-metal
-      TT_METAL_RUNTIME_ROOT: /home/user/tt-metal
-      TT_METAL_CACHE: /home/user/.cache
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/demo-sp-multihost-impl.yaml
+++ b/.github/workflows/demo-sp-multihost-impl.yaml
@@ -83,20 +83,9 @@ jobs:
     name: ${{ matrix.test-group.name }}
     needs: load-test-matrix
     env:
-      OMPI_MCA_btl_tcp_if_include: ens5f0np0
-      PRTE_MCA_plm_ssh_args: "-o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
-      PRTE_MCA_plm_ssh_pass_libpath: /opt/openmpi-v5.0.7-ulfm/lib
-      PRTE_MCA_prte_launch_agent: /opt/openmpi-v5.0.7-ulfm/bin/prted
-      PRTE_MCA_prte_default_hostfile: /etc/ttop/hostfile
-      PRTE_MCA_prte_fwd_environment: "true"
       PATH: "/opt/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
       VIRTUAL_ENV: /opt/venv
       HOME: /home/user
-      PIP_CACHE_DIR: /home/user/.cache/pip
-      LD_LIBRARY_PATH: /home/user/tt-metal/build/lib
-      TT_METAL_HOME: /home/user/tt-metal
-      TT_METAL_RUNTIME_ROOT: /home/user/tt-metal
-      TT_METAL_CACHE: /home/user/.cache
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/fabric-multihost-exabox.yaml
+++ b/.github/workflows/fabric-multihost-exabox.yaml
@@ -65,20 +65,9 @@ jobs:
       group: exabox
       labels: exabox-multihost-with-nfs
     env:
-      OMPI_MCA_btl_tcp_if_include: ens5f0np0
-      PRTE_MCA_plm_ssh_args: "-o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
-      PRTE_MCA_plm_ssh_pass_libpath: /opt/openmpi-v5.0.7-ulfm/lib
-      PRTE_MCA_prte_launch_agent: /opt/openmpi-v5.0.7-ulfm/bin/prted
-      PRTE_MCA_prte_default_hostfile: /etc/ttop/hostfile
-      PRTE_MCA_prte_fwd_environment: "true"
       PATH: "/opt/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
       VIRTUAL_ENV: /opt/venv
       HOME: /home/user
-      PIP_CACHE_DIR: /home/user/.cache/pip
-      LD_LIBRARY_PATH: /home/user/tt-metal/build/lib
-      TT_METAL_HOME: /home/user/tt-metal
-      TT_METAL_RUNTIME_ROOT: /home/user/tt-metal
-      TT_METAL_CACHE: /home/user/.cache
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
[MINFRA-1253](https://tenstorrent.atlassian.net/jira/software/c/projects/MINFRA/boards/6108?assignee=712020%3A62e0c202-1824-435c-8468-80057a9fa512&selectedIssue=MINFRA-1253)

### PR Category
Cleanup

### Summary
This env vars are now set on infra level in [multihost-arc](https://github.com/tenstorrent/tt-orchestration/blob/f44949bb2d8d5d65923cd2269d4635eb5ba6ad63/charts/multihost-arc/values.exabox-with-volume.yaml#L21) and this are all duplicates

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/fabric-multihost-exabox.yaml/badge.svg?branch=dpopov-remove-env-vars-set-in-ttop)](https://github.com/tenstorrent/tt-metal/actions/workflows/fabric-multihost-exabox.yaml?query=branch:dpopov-remove-env-vars-set-in-ttop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=dpopov-remove-env-vars-set-in-ttop)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml?query=branch:dpopov-remove-env-vars-set-in-ttop) - failures are not related to this changes
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=dpopov-remove-env-vars-set-in-ttop)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:dpopov-remove-env-vars-set-in-ttop) - failures are not related to this changes