### PR TITLE
prefill runner: add connected sub-torus (Y/XY) mesh-graph descriptors

### DIFF
--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_2galaxy_connected_mesh_graph_descriptor.textproto
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_2galaxy_connected_mesh_graph_descriptor.textproto
@@ -5,14 +5,18 @@
 # (models/demos/deepseek_v3_b1/scaleout_configs/blitz_decode_mesh_graph_descriptor_superpod.textproto),
 # which chains 64 4x2 meshes 0<->1<->...<->63 with count:8 RELAXED links and NO pinnings (pure
 # discovery) on these same machines. We keep that connection format but use the prefill 8x4
-# full-galaxy geometry ([LINE, RING], validated by the single-galaxy run) — one mesh per galaxy,
-# one inter-galaxy link. d07u02<->d07u08 are directly cabled (UMD topology: 4 matched remote chips),
-# so discovery maps mesh 0 -> first --host, mesh 1 -> second, and binds the inter-galaxy link.
+# full-galaxy geometry — one mesh per galaxy, one inter-galaxy link. d07u02<->d07u08 are directly
+# cabled (UMD topology: 4 matched remote chips), so discovery maps mesh 0 -> first --host, mesh 1 ->
+# second, and binds the inter-galaxy link.
+#
+# dim_types [RING, RING]: each galaxy is an XY torus (rows/SP and cols/TP both wrap). This MUST be
+# paired with PREFILL_FABRIC_MODE=2d_torus_xy in the rank binding — a mismatch between the descriptor
+# wrap and the fabric mode hangs at fabric bring-up. Requires the 2d_torus_* modes from #48711.
 
 mesh_descriptors {
   name: "M0"
   arch: BLACKHOLE
-  device_topology { dims: [ 8, 4 ] dim_types: [ LINE, RING ] }
+  device_topology { dims: [ 8, 4 ] dim_types: [ RING, RING ] }
   host_topology   { dims: [ 1, 1 ] }
   channels { count: 2 policy: RELAXED }
 }

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_4galaxy_connected_mesh_graph_descriptor.textproto
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_4galaxy_connected_mesh_graph_descriptor.textproto
@@ -8,11 +8,15 @@
 # connections require consecutive hosts to be physically cabled. List the --host slots in the order
 # the galaxies are cabled in the superpod chain (verify with the UMD topology tool if a boundary's
 # fabric fails to train).
+#
+# dim_types [RING, RING]: each galaxy is an XY torus (rows/SP and cols/TP both wrap). This MUST be
+# paired with PREFILL_FABRIC_MODE=2d_torus_xy in the rank binding — a mismatch between the descriptor
+# wrap and the fabric mode hangs at fabric bring-up. Requires the 2d_torus_* modes from #48711.
 
 mesh_descriptors {
   name: "M0"
   arch: BLACKHOLE
-  device_topology { dims: [ 8, 4 ] dim_types: [ LINE, RING ] }
+  device_topology { dims: [ 8, 4 ] dim_types: [ RING, RING ] }
   host_topology   { dims: [ 1, 1 ] }
   channels { count: 2 policy: RELAXED }
 }

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_8galaxy_connected_mesh_graph_descriptor.textproto
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_8galaxy_connected_mesh_graph_descriptor.textproto
@@ -11,7 +11,7 @@
 mesh_descriptors {
   name: "M0"
   arch: BLACKHOLE
-  device_topology { dims: [ 8, 4 ] dim_types: [ LINE, RING ] }
+  device_topology { dims: [ 8, 4 ] dim_types: [ RING, RING ] }
   host_topology   { dims: [ 1, 1 ] }
   channels { count: 2 policy: RELAXED }
 }

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_rank_binding_2rank_d2d.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_rank_binding_2rank_d2d.yaml
@@ -25,7 +25,7 @@ mesh_graph_desc_path: models/demos/common/prefill/runners/topology_configuration
 global_env:
   PREFILL_STANDALONE: "1"   # merged runner: standalone (bring-up/pipeline) mode, not the production request loop
   # Device-to-device socket transport (needs the connected MGD + 2D fabric below).
-  PREFILL_FABRIC_MODE: "2d"
+  PREFILL_FABRIC_MODE: "2d_torus_xy"
 
   # Per-rank KV-cache PCC gate.
   PREFILL_STANDALONE_PCC: "1"

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_rank_binding_2rank_d2d.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_rank_binding_2rank_d2d.yaml
@@ -26,4 +26,4 @@ mesh_graph_desc_path: models/demos/common/prefill/runners/topology_configuration
 # Topology + transport only — model and run-profile (PCC, chunk count, model knobs) come from PREFILL_MANIFEST.
 global_env:
   PREFILL_STANDALONE: "1"   # standalone (bring-up/pipeline) mode, not the production request loop
-  PREFILL_FABRIC_MODE: "2d"  # D2D socket transport needs FABRIC_2D
+  PREFILL_FABRIC_MODE: "2d_torus_xy"  # XY sub-torus per galaxy; needs the 2d_torus_* modes from #48711

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_rank_binding_4rank_d2d.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_rank_binding_4rank_d2d.yaml
@@ -38,6 +38,6 @@ global_env:
   # the manifest path (like the rest of global_env) must live here.
   PREFILL_MANIFEST: "models/demos/deepseek_v3_d_p/tt/runners/manifests/kimi.json"
   PREFILL_STANDALONE: "1"   # standalone bring-up/pipeline mode, not the production request loop
-  PREFILL_FABRIC_MODE: "2d"   # D2D pipeline transport needs FABRIC_2D
+  PREFILL_FABRIC_MODE: "2d_torus_xy"   # XY sub-torus per galaxy; needs the 2d_torus_* modes from #48711
   PREFILL_STANDALONE_PCC: "0"
   PREFILL_STANDALONE_NCHUNKS: "11"

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_rank_binding_4rank_d2d.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_rank_binding_4rank_d2d.yaml
@@ -36,4 +36,4 @@ mesh_graph_desc_path: models/demos/common/prefill/runners/topology_configuration
 # Topology + transport only — model and run-profile (PCC, chunk count, model knobs) come from PREFILL_MANIFEST.
 global_env:
   PREFILL_STANDALONE: "1"   # standalone bring-up/pipeline mode, not the production request loop
-  PREFILL_FABRIC_MODE: "2d"  # D2D pipeline transport needs FABRIC_2D
+  PREFILL_FABRIC_MODE: "2d_torus_xy"   # XY sub-torus per galaxy; needs the 2d_torus_* modes from #48711

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_rank_binding_8rank_d2d.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_rank_binding_8rank_d2d.yaml
@@ -53,4 +53,4 @@ mesh_graph_desc_path: models/demos/common/prefill/runners/topology_configuration
 # Topology + transport only — model and run-profile (PCC, chunk count, model knobs) come from PREFILL_MANIFEST.
 global_env:
   PREFILL_STANDALONE: "1"   # standalone bring-up/pipeline mode, not the production request loop
-  PREFILL_FABRIC_MODE: "2d"  # D2D pipeline transport needs FABRIC_2D
+  PREFILL_FABRIC_MODE: "2d_torus_xy"  # XY sub-torus per galaxy; needs the 2d_torus_* modes from #48711

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_real_1galaxy_1rank.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_real_1galaxy_1rank.yaml
@@ -3,13 +3,13 @@
 # Single rank, full galaxy: is_first == is_last == True, so the runner builds the WHOLE
 # 61-layer model (embedding + all layers + norm + LM head) and runs it with NO cross-rank
 # transport. Confirms, in isolation from the 2-host path, that:
-#   * per-galaxy FABRIC_1D trains with the [LINE, RING] 8x4 torus dim_types,
+#   * the per-galaxy XY sub-torus (FABRIC_2D_TORUS_XY, [RING, RING] 8x4) trains,
 #   * the model builds from the shared TTNN weight cache, and
 #   * the populated KV cache PCC-matches the golden trace.
 # It is the precursor to the multi-galaxy D2D pipeline split (pipeline_prefill_rank_binding_2rank_d2d.yaml).
 #
-# Uses the in-tree known-good single-galaxy descriptor (8x4, [LINE, RING]); our 2-galaxy
-# descriptor's two meshes are copies of it.
+# Uses the in-tree known-good single-galaxy XY-torus descriptor (8x4, [RING, RING]); our 2-galaxy
+# descriptor's two meshes are the same geometry.
 #
 # Launch:
 #   python3 "${TT_METAL_HOME}/ttnn/ttnn/distributed/ttrun.py" \
@@ -24,10 +24,12 @@ rank_bindings:
     mesh_host_rank: 0
     env_overrides: {}
 
-mesh_graph_desc_path: tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_x_graph_descriptor.textproto
+mesh_graph_desc_path: tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_xy_graph_descriptor.textproto
 
 global_env:
   PREFILL_STANDALONE: "1"   # merged runner: standalone (bring-up/pipeline) mode, not the production request loop
+  # XY sub-torus (both axes wrap); matches the [RING,RING] descriptor above. Needs #48711's 2d_torus_* modes.
+  PREFILL_FABRIC_MODE: "2d_torus_xy"
   # Per-rank KV-cache PCC gate against the golden trace.
   PREFILL_STANDALONE_PCC: "1"
   # 11 chunks (56320 tokens = full golden trace); single-rank baseline. max_seq_len auto-derives.

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_real_1galaxy_1rank.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_real_1galaxy_1rank.yaml
@@ -3,13 +3,13 @@
 # Single rank, full galaxy: is_first == is_last == True, so the runner builds the WHOLE
 # model (embedding + all layers + norm + LM head) and runs it with NO cross-rank
 # transport. Confirms, in isolation from the 2-host path, that:
-#   * per-galaxy FABRIC_1D trains with the [LINE, RING] 8x4 torus dim_types,
+#   * the per-galaxy XY sub-torus (FABRIC_2D_TORUS_XY, [RING, RING] 8x4) trains,
 #   * the model builds from the shared TTNN weight cache, and
 #   * the populated KV cache PCC-matches the golden trace.
 # It is the precursor to the multi-galaxy D2D pipeline split (pipeline_prefill_rank_binding_2rank_d2d.yaml).
 #
-# Uses the in-tree known-good single-galaxy descriptor (8x4, [LINE, RING]); our 2-galaxy
-# descriptor's two meshes are copies of it.
+# Uses the in-tree known-good single-galaxy XY-torus descriptor (8x4, [RING, RING]); our 2-galaxy
+# descriptor's two meshes are the same geometry.
 #
 # Launch (model chosen via PREFILL_MANIFEST):
 #   PREFILL_MANIFEST=models/demos/deepseek_v3_d_p/tt/runners/manifests/deepseek_v3.json \
@@ -23,8 +23,10 @@ rank_bindings:
     mesh_host_rank: 0
     env_overrides: {}
 
-mesh_graph_desc_path: tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_x_graph_descriptor.textproto
+mesh_graph_desc_path: tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_xy_graph_descriptor.textproto
 
 # Topology + transport only — model and run-profile (PCC, chunk count, model knobs) come from PREFILL_MANIFEST.
 global_env:
   PREFILL_STANDALONE: "1"   # standalone (bring-up/pipeline) mode, not the production request loop
+  # XY sub-torus (both axes wrap); matches the [RING,RING] descriptor above. Needs #48711's 2d_torus_* modes.
+  PREFILL_FABRIC_MODE: "2d_torus_xy"

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_1rank.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_1rank.yaml
@@ -2,9 +2,10 @@
 # H2D service + waits; drive it with prefill_producer.py on this host. Cache sized to 11 chunks.
 rank_bindings:
   - {rank: 0, mesh_id: 0, mesh_host_rank: 0, env_overrides: {}}
-mesh_graph_desc_path: tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_x_graph_descriptor.textproto
+mesh_graph_desc_path: tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_xy_graph_descriptor.textproto
 global_env:
-  PREFILL_FABRIC_MODE: "2d"
+  # XY sub-torus (both axes wrap); matches the [RING,RING] descriptor above. Needs #48711's 2d_torus_* modes.
+  PREFILL_FABRIC_MODE: "2d_torus_xy"
   PREFILL_MAX_SEQ_LEN: "56320"
   PREFILL_H2D_SERVICE_ID: "ds_prefill"
   PREFILL_GATE_FALLBACK_MODE: "DEVICE_FP32"

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_2rank.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_2rank.yaml
@@ -6,7 +6,7 @@ rank_bindings:
   - {rank: 1, mesh_id: 1, mesh_host_rank: 0, env_overrides: {}}
 mesh_graph_desc_path: models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_2galaxy_connected_mesh_graph_descriptor.textproto
 global_env:
-  PREFILL_FABRIC_MODE: "2d"
+  PREFILL_FABRIC_MODE: "2d_torus_xy"
   PREFILL_MAX_SEQ_LEN: "56320"
   PREFILL_H2D_SERVICE_ID: "ds_prefill"
   PREFILL_GATE_FALLBACK_MODE: "DEVICE_FP32"

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_4rank.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_4rank.yaml
@@ -8,7 +8,7 @@ rank_bindings:
   - {rank: 3, mesh_id: 3, mesh_host_rank: 0, env_overrides: {}}
 mesh_graph_desc_path: models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_4galaxy_connected_mesh_graph_descriptor.textproto
 global_env:
-  PREFILL_FABRIC_MODE: "2d"
+  PREFILL_FABRIC_MODE: "2d_torus_xy"
   PREFILL_MAX_SEQ_LEN: "56320"
   PREFILL_H2D_SERVICE_ID: "ds_prefill"
   PREFILL_GATE_FALLBACK_MODE: "DEVICE_FP32"


### PR DESCRIPTION

<img width="589" height="354" alt="image" src="https://github.com/user-attachments/assets/79188fa0-f194-4fcc-b3a8-8578ade30843" />

- Trace amplifies the torus win. Untraced, CHUNK gains are −1.5% / +0.5% / −1.8% (near noise). Traced, they jump to −4.2% / −12.7% / −13.4%. Trace strips the per-op dispatch overhead, so CCL fabric cost becomes the dominant slice of each chunk — exactly what the XY torus speeds up. This is the real result.
- Trust CHUNK over the untraced tok/s. The trace-off tok/s column is junk: 2-rank reads 5667 (half of 1-rank), and 4-rank shows +12.7% while compute moved only −1.8%. Producer wall-clock untraced is dominated by pipeline fill/drain and D2D idle, not compute. Under trace the tok/s settles into a sane band (21k–26k) and tracks the compute deltas.
- Both legs bring up clean at all rank counts — [RING,RING] XY-torus trains, no fabric hang, sentinel teardown 4/4.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jjovicic/subtorus-runner-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jjovicic/subtorus-runner-integration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jjovicic/subtorus-runner-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jjovicic/subtorus-runner-integration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jjovicic/subtorus-runner-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jjovicic/subtorus-runner-integration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jjovicic/subtorus-runner-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jjovicic/subtorus-runner-integration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jjovicic/subtorus-runner-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jjovicic/subtorus-runner-integration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jjovicic/subtorus-runner-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jjovicic/subtorus-runner-integration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jjovicic/subtorus-runner-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jjovicic/subtorus-runner-integration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jjovicic/subtorus-runner-integration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jjovicic/subtorus-runner-integration)