### PR TITLE
indexer: run DSA q·kᵀ score matmul at LoFi

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -227,6 +227,12 @@ class TtIndexer:
         self.tp_factor = mesh_shape[tp_axis]
         self.default_compute_kernel_config = default_compute_kernel_config
         self.hifi4_fp32_compute_kernel_config = hifi4_fp32_compute_kernel_config
+        # The q·kᵀ score is the indexer's only compute-bound op, so run it at LoFi; the projections keep
+        # default_compute_kernel_config (HiFi2) — DRAM-bound, so lower fidelity buys nothing there.
+        # indexer_score_dsa honors only math_fidelity (fp32_dest_acc_en must stay False — already the default).
+        self._score_compute_kernel_config = ttnn.init_device_compute_kernel_config(
+            mesh_device.arch(), math_fidelity=ttnn.MathFidelity.LoFi
+        )
         self.weight_cache_path = weight_cache_path
         self.layer_idx = layer_idx
         # Total local layers in the shared key cache. The block-cyclic index_kv_cache is user-major
@@ -616,6 +622,7 @@ class TtIndexer:
             weights,
             chunk_start_idx=start_pos,
             program_config=cfg,
+            compute_kernel_config=self._score_compute_kernel_config,
             # Seq shard axes, outermost (SP ring) first. TP×SP adds the TP axis so the score adds each
             # device's tp_rank*Sq' block-cyclic sub-offset — rotation-EXACT (vs the flat [] path, which is
             # linear-approximate under a mid-slab start). SP-only ([sp]) when the query stays SP-sharded.


### PR DESCRIPTION
## What
Run the DSA lightning-indexer score op (`indexer_score_dsa` — the q·kᵀ logits) at **LoFi** math fidelity. The indexer projection matmuls (`wk`, `wq_b`, `weights_proj`) stay at HiFi2 — they are DRAM-bound and gain nothing from lower fidelity.

## Why
The q·kᵀ score is the indexer's **only compute-bound op** (roofline model + measured). LoFi halves its matmul cycles/tile (32 → 16), so the op runs materially faster at no accuracy cost.

## What we measured
`IndexerScoreDeviceOperation` device-kernel time via Tracy (`test_mla_chunked_perf`, glm_5_1, sparse, mesh-8×4):

| context | HiFi2 | LoFi | Δ |
|---|---|---|---|
| 55K (warm) | 310.1 µs | 195.0 µs | **−37%** |
| 500K (long) | 2578 µs | 1556.7 µs | **−40%** |

- Scales ∝ context length (the score is O(T)); the absolute saving grows ~9× from 55K→500K.
- It is 37–40% (not the full 50% of a raw matmul) because the op is `relu(q·k)·weights` summed over heads — only the q·k MAC halves; the relu / gate-mul / head-reduce are fidelity-independent.
- `SparseSDPAOperation` and the projection matmuls are unchanged HiFi2↔LoFi → the change is cleanly isolated to the score.
- ≈10% off the indexer as a whole (the score is ~30% of the full-indexer-layer time; top-k — larger than the score — is untouched).

**Per MLA layer.** The score is one op inside the sparse-MLA layer, whose critical path is dominated by the SP CCL gathers (`AllBroadcast` + `AllGatherAsync` ≈ 61% at 55K, 74% at 500K) and `TopK` (untouched). So the isolated −37/40% lands as a smaller share of the whole layer:

| context | MLA layer (crit. path) | IndexerScore share (HiFi2 → LoFi) | per-layer saving |
|---|---|---|---|
| 55K | ~12.9 ms | 2.4% → 1.5% | **~0.9%** (−0.12 ms) |
| 500K | ~57.5 ms | 4.5% → 2.8% | **~1.8%** (−1.02 ms) |

Free win, but small at the layer level — the score is a low-single-digit % of the sparse-MLA layer even at 500K.

## PCC (unchanged)
GLM-5.2 chunked prefill vs vLLM golden, L78, mesh-8×4, chunks1 + chunks11 (55K):

| metric | HiFi2 min | LoFi min | max \|Δ\| |
|---|---|---|---|
| decoder output | 0.8919 | 0.8922 | ~1e-3 |
| indexer-K cache | 0.9800 | 0.9802 | ~2e-4 |
| KVPE cache | 0.8622 | 0.8627 | ~2e-3 |

Across all 858 per-chunk × per-layer decoder points: mean |Δ| = 0.0004, max = 0.0016, mixed sign (LoFi is marginally *better* at the deep accumulation trough). No degradation.

<img width="925" height="461" alt="image" src="https://github.com/user-attachments/assets/34cbb02b-8086-4df9-89fd-84c78ad23e73" />

PCC per-layer output deltas are negligible
<img width="1216" height="459" alt="image" src="https://github.com/user-attachments/assets/0a6c1294-5c83-4053-9097-5ab9da64dbc2" />


## Scope / notes
- `indexer_score_dsa` is shared with `deepseek_v32`; only glm_5_2 was PCC-validated
- Perf test: `models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py::test_mla_chunked_perf` (`-k "glm_5_1 and <warm|long> and sparse"`).
- PCC test: `models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py::test_glm_prefill_transformer_chunked`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

[blackhole-e2e-tests (LoudBox (8xP150), bh_loudbox) / bh_lb_DeepSeek_DSA [bh_loudbox]](https://github.com/tenstorrent/tt-metal/actions/runs/29840632232/job/88678935384#logs)

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nmilicevic/indexer-score-lofi)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nmilicevic/indexer-score-lofi)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nmilicevic/indexer-score-lofi)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nmilicevic/indexer-score-lofi)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nmilicevic/indexer-score-lofi)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nmilicevic/indexer-score-lofi)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nmilicevic/indexer-score-lofi)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nmilicevic/indexer-score-lofi)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nmilicevic/indexer-score-lofi)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nmilicevic/indexer-score-lofi)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nmilicevic/indexer-score-lofi)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nmilicevic/indexer-score-lofi)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nmilicevic/indexer-score-lofi)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nmilicevic/indexer-score-lofi)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nmilicevic/indexer-score-lofi)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nmilicevic/indexer-score-lofi)
