### PR TITLE
[tt-triage] Disable dumping watcher ringbuffer when watcher is not enabled

### DIFF
--- a/tools/triage/configuration_provider.py
+++ b/tools/triage/configuration_provider.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Usage:
+    configuration_provider
+
+Description:
+    Data provider that fetches Inspector configuration (environment variables,
+    runtime options, TTNN configuration) once and caches it for other scripts.
+    Provides lookups by (scope, name).
+
+Owner:
+    onenezicTT
+"""
+
+from dataclasses import dataclass
+from triage import triage_singleton, ScriptConfig, run_script
+from inspector_data import run as get_inspector_data
+
+script_config = ScriptConfig(
+    data_provider=True,
+    depends=["inspector_data"],
+)
+
+
+@dataclass(frozen=True)
+class ConfigValue:
+    scope: str
+    name: str
+    value: str
+
+
+class ConfigurationProvider:
+    """Cached view of Inspector configuration entries."""
+
+    def __init__(self, inspector):
+        self._entries = [
+            ConfigValue(entry.scope, entry.name, entry.value) for entry in inspector.getConfiguration().entries
+        ]
+
+    def all(self) -> list[ConfigValue]:
+        return self._entries
+
+    def get(self, name: str, default: str | None = None) -> str | None:
+        # Names are unique across scopes (environment/rtOptions/ttnnConfig use disjoint conventions).
+        for entry in self._entries:
+            if entry.name == name:
+                return entry.value
+        return default
+
+    def get_bool(self, name: str, default: bool = False) -> bool:
+        value = self.get(name)
+        return default if value is None else value.lower() == "true"
+
+
+@triage_singleton
+def run(args, context) -> ConfigurationProvider:
+    return ConfigurationProvider(get_inspector_data(args, context))
+
+
+if __name__ == "__main__":
+    run_script()

--- a/tools/triage/dump_configuration.py
+++ b/tools/triage/dump_configuration.py
@@ -20,12 +20,12 @@ Owner:
 
 from dataclasses import dataclass
 from typing import Any
-from inspector_data import run as get_inspector_data, InspectorException
-from triage import ScriptConfig, ScriptPriority, log_check, triage_field, run_script
+from configuration_provider import run as get_configuration
+from triage import ScriptConfig, ScriptPriority, triage_field, run_script
 
 
 script_config = ScriptConfig(
-    depends=["inspector_data"],
+    depends=["configuration_provider"],
     priority=ScriptPriority.HIGH,
 )
 
@@ -40,14 +40,7 @@ class ConfigEntry:
 def run(args, context):
     scope_filter = args["--scope"]
 
-    try:
-        inspector = get_inspector_data(args, context)
-        result = inspector.getConfiguration()
-    except InspectorException as e:
-        log_check(False, f"Failed to get configuration from Inspector: {e}")
-        return None
-
-    entries = result.entries
+    entries = get_configuration(args, context).all()
 
     # Group by scope
     by_scope: dict[str, list[Any]] = {}

--- a/tools/triage/dump_watcher_ringbuffer.py
+++ b/tools/triage/dump_watcher_ringbuffer.py
@@ -5,11 +5,15 @@
 
 """
 Usage:
-    dump_watcher_ringbuffer
+    dump_watcher_ringbuffer [--force-watcher-ringbuffer]
+
+Options:
+    --force-watcher-ringbuffer  Dump the ring buffer even if watcher was not enabled in the run.
 
 Description:
     Dump watcher ring buffer contents for all cores, skipping cores with empty buffers. This ringbuffer can be written
     into by using the WATCHER_RING_BUFFER_PUSH macro in a kernel.
+    Skipped by default when watcher was not enabled; use --force-watcher-ringbuffer to run anyway.
 
 Owner:
     jbaumanTT
@@ -109,9 +113,10 @@ def read_ring_buffer_for_block(
 
 def run(args, context: Context):
     """Entry point for triage framework."""
-    config = get_configuration(args, context)
-    if not config.get_bool("watcher_enabled", default=False):
-        return None
+    if not args["--force-watcher-ringbuffer"]:
+        config = get_configuration(args, context)
+        if not config.get_bool("watcher_enabled", default=False):
+            return None
 
     run_checks = get_run_checks(args, context)
     dispatcher_data = get_dispatcher_data(args, context)

--- a/tools/triage/dump_watcher_ringbuffer.py
+++ b/tools/triage/dump_watcher_ringbuffer.py
@@ -20,13 +20,14 @@ from triage import ScriptConfig, triage_field, run_script
 from run_checks import run as get_run_checks, RunChecks
 from elfs_cache import run as get_elfs_cache, ElfsCache
 from dispatcher_data import run as get_dispatcher_data, DispatcherData
+from configuration_provider import run as get_configuration
 from ttexalens.coordinate import OnChipCoordinate
 from ttexalens.context import Context
 from ttexalens.umd_device import TimeoutDeviceRegisterError
 
 
 script_config = ScriptConfig(
-    depends=["run_checks", "dispatcher_data", "elfs_cache"],
+    depends=["run_checks", "dispatcher_data", "elfs_cache", "configuration_provider"],
 )
 
 
@@ -108,6 +109,10 @@ def read_ring_buffer_for_block(
 
 def run(args, context: Context):
     """Entry point for triage framework."""
+    config = get_configuration(args, context)
+    if not config.get_bool("watcher_enabled", default=False):
+        return None
+
     run_checks = get_run_checks(args, context)
     dispatcher_data = get_dispatcher_data(args, context)
     elfs_cache = get_elfs_cache(args, context)

--- a/tools/triage/dump_watcher_ringbuffer.py
+++ b/tools/triage/dump_watcher_ringbuffer.py
@@ -5,15 +5,15 @@
 
 """
 Usage:
-    dump_watcher_ringbuffer [--force-watcher-ringbuffer]
+    dump_watcher_ringbuffer [--skip-watcher-enabled-check]
 
 Options:
-    --force-watcher-ringbuffer  Dump the ring buffer even if watcher was not enabled in the run.
+    --skip-watcher-enabled-check  Dump the ring buffer without checking whether watcher was enabled in the run.
 
 Description:
     Dump watcher ring buffer contents for all cores, skipping cores with empty buffers. This ringbuffer can be written
     into by using the WATCHER_RING_BUFFER_PUSH macro in a kernel.
-    Skipped by default when watcher was not enabled; use --force-watcher-ringbuffer to run anyway.
+    Skipped by default when watcher was not enabled; use --skip-watcher-enabled-check to run anyway.
 
 Owner:
     jbaumanTT
@@ -31,7 +31,7 @@ from ttexalens.umd_device import TimeoutDeviceRegisterError
 
 
 script_config = ScriptConfig(
-    depends=["run_checks", "dispatcher_data", "elfs_cache", "configuration_provider"],
+    depends=["run_checks", "dispatcher_data", "elfs_cache"],
 )
 
 
@@ -113,7 +113,7 @@ def read_ring_buffer_for_block(
 
 def run(args, context: Context):
     """Entry point for triage framework."""
-    if not args["--force-watcher-ringbuffer"]:
+    if not args["--skip-watcher-enabled-check"]:
         config = get_configuration(args, context)
         if not config.get_bool("watcher_enabled", default=False):
             return None

--- a/tools/triage/dump_watcher_ringbuffer.py
+++ b/tools/triage/dump_watcher_ringbuffer.py
@@ -115,7 +115,7 @@ def run(args, context: Context):
     """Entry point for triage framework."""
     if not args["--skip-watcher-enabled-check"]:
         config = get_configuration(args, context)
-        if not config.get_bool("watcher_enabled", default=False):
+        if not config.get_bool("watcher_enabled"):
             return None
 
     run_checks = get_run_checks(args, context)


### PR DESCRIPTION
Disables dumping watcher ringbuffer by default as it presents noise to the default user if watcher was not explicitly enabled during the metal run.

Move configuration into its own provider.

Users can still run the script by providing `--skip-watcher-enabled-check`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=onenezic/triage-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:onenezic/triage-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=onenezic/triage-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:onenezic/triage-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=onenezic/triage-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:onenezic/triage-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=onenezic/triage-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:onenezic/triage-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=onenezic/triage-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:onenezic/triage-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=onenezic/triage-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:onenezic/triage-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=onenezic/triage-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:onenezic/triage-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=onenezic/triage-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:onenezic/triage-config)