### PR TITLE
prefill: default LOGURU_LEVEL=INFO in runner bindings

### DIFF
--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_rank_binding_2rank_d2d.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_rank_binding_2rank_d2d.yaml
@@ -23,6 +23,10 @@ rank_bindings:
 mesh_graph_desc_path: models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_2galaxy_connected_mesh_graph_descriptor.textproto
 
 global_env:
+  # Default to INFO so ttnn per-op DEBUG logging stays off the host dispatch path. Must live in
+  # global_env (ttrun forwards it to every rank before loguru is imported), not the manifest
+  # (applied at runtime, after loguru has already read its level).
+  LOGURU_LEVEL: "INFO"
   PREFILL_STANDALONE: "1"   # merged runner: standalone (bring-up/pipeline) mode, not the production request loop
   # Device-to-device socket transport (needs the connected MGD + 2D fabric below).
   PREFILL_FABRIC_MODE: "2d"

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_rank_binding_4rank_d2d.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_rank_binding_4rank_d2d.yaml
@@ -32,6 +32,10 @@ rank_bindings:
 mesh_graph_desc_path: models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_4galaxy_connected_mesh_graph_descriptor.textproto
 
 global_env:
+  # Default to INFO so ttnn per-op DEBUG logging stays off the host dispatch path. Must live in
+  # global_env (ttrun forwards it to every rank before loguru is imported), not the manifest
+  # (applied at runtime, after loguru has already read its level).
+  LOGURU_LEVEL: "INFO"
   # Model config (PREFILL_MODEL + model-specific knobs) lives in a per-model manifest, applied via
   # setdefault before the runner's env reads. This binding stays model-agnostic: point PREFILL_MANIFEST
   # at any model's manifest to run it on this topology. ttrun does not propagate shell PREFILL_*, so

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_real_1galaxy_1rank.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_real_1galaxy_1rank.yaml
@@ -27,6 +27,10 @@ rank_bindings:
 mesh_graph_desc_path: tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_x_graph_descriptor.textproto
 
 global_env:
+  # Default to INFO so ttnn per-op DEBUG logging stays off the host dispatch path. Must live in
+  # global_env (ttrun forwards it to every rank before loguru is imported), not the manifest
+  # (applied at runtime, after loguru has already read its level).
+  LOGURU_LEVEL: "INFO"
   PREFILL_STANDALONE: "1"   # merged runner: standalone (bring-up/pipeline) mode, not the production request loop
   # Per-rank KV-cache PCC gate against the golden trace.
   PREFILL_STANDALONE_PCC: "1"

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_1rank.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_1rank.yaml
@@ -4,6 +4,10 @@ rank_bindings:
   - {rank: 0, mesh_id: 0, mesh_host_rank: 0, env_overrides: {}}
 mesh_graph_desc_path: tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_x_graph_descriptor.textproto
 global_env:
+  # Default to INFO so ttnn per-op DEBUG logging stays off the host dispatch path. Must live in
+  # global_env (ttrun forwards it to every rank before loguru is imported), not the manifest
+  # (applied at runtime, after loguru has already read its level).
+  LOGURU_LEVEL: "INFO"
   PREFILL_FABRIC_MODE: "2d"
   PREFILL_MAX_SEQ_LEN: "56320"
   PREFILL_H2D_SERVICE_ID: "ds_prefill"

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_2rank.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_2rank.yaml
@@ -6,6 +6,10 @@ rank_bindings:
   - {rank: 1, mesh_id: 1, mesh_host_rank: 0, env_overrides: {}}
 mesh_graph_desc_path: models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_2galaxy_connected_mesh_graph_descriptor.textproto
 global_env:
+  # Default to INFO so ttnn per-op DEBUG logging stays off the host dispatch path. Must live in
+  # global_env (ttrun forwards it to every rank before loguru is imported), not the manifest
+  # (applied at runtime, after loguru has already read its level).
+  LOGURU_LEVEL: "INFO"
   PREFILL_FABRIC_MODE: "2d"
   PREFILL_MAX_SEQ_LEN: "56320"
   PREFILL_H2D_SERVICE_ID: "ds_prefill"

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_4rank.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_4rank.yaml
@@ -8,6 +8,10 @@ rank_bindings:
   - {rank: 3, mesh_id: 3, mesh_host_rank: 0, env_overrides: {}}
 mesh_graph_desc_path: models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_4galaxy_connected_mesh_graph_descriptor.textproto
 global_env:
+  # Default to INFO so ttnn per-op DEBUG logging stays off the host dispatch path. Must live in
+  # global_env (ttrun forwards it to every rank before loguru is imported), not the manifest
+  # (applied at runtime, after loguru has already read its level).
+  LOGURU_LEVEL: "INFO"
   PREFILL_FABRIC_MODE: "2d"
   PREFILL_MAX_SEQ_LEN: "56320"
   PREFILL_H2D_SERVICE_ID: "ds_prefill"


### PR DESCRIPTION
loguru reads its level at import, so this must sit in global_env (ttrun sets it per-rank before python starts); the manifest is applied too late. Keeps ttnn per-op DEBUG logging off the host dispatch path — ~0.6% E2E on 2-rank DS-V3, and a ~3.7x smaller runner log for triage.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jjovicic/prefill-loguru-info)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jjovicic/prefill-loguru-info)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jjovicic/prefill-loguru-info)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jjovicic/prefill-loguru-info)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jjovicic/prefill-loguru-info)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jjovicic/prefill-loguru-info)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jjovicic/prefill-loguru-info)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jjovicic/prefill-loguru-info)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jjovicic/prefill-loguru-info)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jjovicic/prefill-loguru-info)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jjovicic/prefill-loguru-info)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jjovicic/prefill-loguru-info)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jjovicic/prefill-loguru-info)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jjovicic/prefill-loguru-info)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jjovicic/prefill-loguru-info)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jjovicic/prefill-loguru-info)