### PR TITLE
[Bug fix] Reset DPRINT state when reasserting Quasar TRISC reset

### DIFF
--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -102,8 +102,23 @@ void invalidate_trisc_instruction_cache() {
 
 void deassert_trisc() {
     // Temporary workaround due to race vs. host deasserting TRISC reset.
+    // Workaround includes both the assert_trisc_reset() and the DPRINT workaround.
     // https://github.com/tenstorrent/tt-metal/issues/48064
     assert_trisc_reset();
+#if defined(DEBUG_PRINT_ENABLED) && !defined(FORCE_DPRINT_OFF)
+    // Host may have released TRISCs early; a TRISC can hold the shared compute DPRINT lock
+    // (or leave wpos/rpos mid-print) when we assert reset. Clear that state while TRISCs are
+    // held so the next boot cannot hang in acquire_lock / wait_for_space before writing DONE.
+    {
+        auto* trisc_print = GET_MAILBOX_ADDRESS_DEV(dprint_buf.buffer_triscs);
+        trisc_print->aux.lock = 0;
+        uint32_t wpos = trisc_print->aux.wpos;
+        if (wpos != DEBUG_PRINT_SERVER_DISABLED_MAGIC && wpos != DEBUG_PRINT_SERVER_STARTING_MAGIC) {
+            trisc_print->aux.wpos = 0;
+            trisc_print->aux.rpos = 0;
+        }
+    }
+#endif
     subordinate_sync->allNeo0 = RUN_SYNC_MSG_ALL_INIT;
     subordinate_sync->allNeo1 = RUN_SYNC_MSG_ALL_INIT;
     subordinate_sync->allNeo2 = RUN_SYNC_MSG_ALL_INIT;


### PR DESCRIPTION
### PR Category
Bug fix: #50427

### Summary
The Quasar workaround to assert trisc resets in dm.cc prior to deasserting trisc resets can cause hangs when DPRINT is enabled. To solve this, after asserting the trisc rest, clear the DPRINT data so everything comes up in a clean state.

Tested by running DPRINT tests back-to-back, and by running regular tests back-to-back with DPRINT enabled. Prior to this change, a hang would occur somewhere between iteration 2-6. After this change, 20 iterations would run consistently (and the tests would pass) with no hangs.

### Notes for reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kstevens/issue_50427)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kstevens/issue_50427)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kstevens/issue_50427)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kstevens/issue_50427)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=kstevens/issue_50427)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:kstevens/issue_50427)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kstevens/issue_50427)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kstevens/issue_50427)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kstevens/issue_50427)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kstevens/issue_50427)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kstevens/issue_50427)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kstevens/issue_50427)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kstevens/issue_50427)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kstevens/issue_50427)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kstevens/issue_50427)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kstevens/issue_50427)