### PR TITLE
[Test Only] Improve DPRINT test teardown

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
@@ -252,9 +252,18 @@ protected:
 
 class DevicePrintFixture : public DebugToolsMeshFixture {
 protected:
-    int memfd_;
+    int memfd_ = -1;
+    tt::llrt::TargetSelection dprint_previous_targets_{};
+    bool test_mode_previous_{};
 
     void SetUp() override {
+        // Save previous DPRINT / test-mode state so TearDown can restore it. TearDown runs even
+        // when SetUp skips or fails later, so capture before mutating rtoptions.
+        auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+        dprint_previous_targets_ = rtoptions.get_feature_targets(tt::llrt::RunTimeDebugFeatureDprint);
+        test_mode_previous_ = rtoptions.get_test_mode_enabled();
+        watcher_previous_enabled = rtoptions.get_watcher_enabled();
+
         const testing::TestInfo* test_info = testing::UnitTest::GetInstance()->current_test_info();
         std::string test_desc =
             fmt::format("dprint_{}_{}_{}", getpid(), test_info->test_suite_name(), test_info->name());
@@ -266,28 +275,21 @@ protected:
         // Use /proc/self/fd path which works transparently with ofstream/ifstream
         dprint_file_name = fmt::format("/proc/self/fd/{}", memfd_);
 
-        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_enabled(
-            tt::llrt::RunTimeDebugFeatureDprint, true);
-        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_prepend_device_core_risc(
-            tt::llrt::RunTimeDebugFeatureDprint, false);
-        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_all_cores(
+        rtoptions.set_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint, true);
+        rtoptions.set_feature_prepend_device_core_risc(tt::llrt::RunTimeDebugFeatureDprint, false);
+        rtoptions.set_feature_all_cores(
             tt::llrt::RunTimeDebugFeatureDprint, CoreType::WORKER, tt::llrt::RunTimeDebugClassWorker);
-        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_all_cores(
+        rtoptions.set_feature_all_cores(
             tt::llrt::RunTimeDebugFeatureDprint, CoreType::ETH, tt::llrt::RunTimeDebugClassWorker);
-        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_all_cores(
+        rtoptions.set_feature_all_cores(
             tt::llrt::RunTimeDebugFeatureDprint, CoreType::DRAM, tt::llrt::RunTimeDebugClassWorker);
-        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_all_chips(
-            tt::llrt::RunTimeDebugFeatureDprint, true);
-        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_mesh_coords(
-            tt::llrt::RunTimeDebugFeatureDprint, {});
-        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_chip_ids(
-            tt::llrt::RunTimeDebugFeatureDprint, {});
+        rtoptions.set_feature_all_chips(tt::llrt::RunTimeDebugFeatureDprint, true);
+        rtoptions.set_feature_mesh_coords(tt::llrt::RunTimeDebugFeatureDprint, {});
+        rtoptions.set_feature_chip_ids(tt::llrt::RunTimeDebugFeatureDprint, {});
         // Send output to a file so the test can check after program is run.
-        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_file_name(
-            tt::llrt::RunTimeDebugFeatureDprint, dprint_file_name);
-        tt::tt_metal::MetalContext::instance().rtoptions().set_test_mode_enabled(true);
-        watcher_previous_enabled = tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled();
-        tt::tt_metal::MetalContext::instance().rtoptions().set_watcher_enabled(false);
+        rtoptions.set_feature_file_name(tt::llrt::RunTimeDebugFeatureDprint, dprint_file_name);
+        rtoptions.set_test_mode_enabled(true);
+        rtoptions.set_watcher_enabled(false);
 
         ExtraSetUp();
 
@@ -300,7 +302,15 @@ protected:
         DebugToolsMeshFixture::TearDown();
         ExtraTearDown();
 
-        tt::tt_metal::MetalContext::instance().rtoptions().set_watcher_enabled(watcher_previous_enabled);
+        auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+        rtoptions.set_feature_targets(tt::llrt::RunTimeDebugFeatureDprint, dprint_previous_targets_);
+        rtoptions.set_test_mode_enabled(test_mode_previous_);
+        rtoptions.set_watcher_enabled(watcher_previous_enabled);
+
+        if (memfd_ >= 0) {
+            close(memfd_);
+            memfd_ = -1;
+        }
     }
 
     // Override this function in child classes for additional setup commands between DPRINT setup


### PR DESCRIPTION
### PR Category
Test Only

### Summary
DPRINT unit tests turn of DPRINT options, but don't turn them off again at the end of the test. This means that any unit tests that run after a DPRINT unit test will have DPRINT on, which can lead to false failures if watcher or other binary-increasing features are enabled by those tests.

This change captures the environment settings during setup for DPRINT tests, then reverts to the original environment during teardown for DPRINT tests. After this change, watcher tests run successfully after DPRINT tests.

### Notes for reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kstevens/dprint_teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kstevens/dprint_teardown)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kstevens/dprint_teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kstevens/dprint_teardown)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=kstevens/dprint_teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:kstevens/dprint_teardown)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kstevens/dprint_teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kstevens/dprint_teardown)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kstevens/dprint_teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kstevens/dprint_teardown)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kstevens/dprint_teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kstevens/dprint_teardown)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kstevens/dprint_teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kstevens/dprint_teardown)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kstevens/dprint_teardown)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kstevens/dprint_teardown)