### PR TITLE
[LLK] Use 2's complement on sfpu shift on BH

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_shift.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_shift.h
@@ -5,40 +5,71 @@
 #pragma once
 
 #include <cstdint>
-#include <type_traits>
 
 #include "ckernel_addrmod.h"
 #include "ckernel_ops.h"
 #include "sfpi.h"
 
+// Blackhole binary integer shift kernels, migrated from raw-TTI microcode to SFPI.
+//
+// The previous hand-written microcode operated on raw LREG bit patterns and hand-rolled
+// both the sign extension (arithmetic right shift) and the out-of-range predication. That
+// only produced correct results for a sign-magnitude LREG representation and diverged from
+// the two's-complement golden for negative operands under INT32_2S_COMP.
+//
+// Dst physically stores int32 in sign-magnitude, so operands must be read through sfpi's
+// `DataLayout::SM32` mode: on load it applies smag_to_int() to yield true two's-complement
+// `vInt` lanes, and on store it applies int_to_smag() to convert back. (Plain `DataLayout::I32`
+// reads/writes the raw sign-magnitude bits and is only correct for non-negative values.)
+// Blackhole's native arithmetic right shift (`vInt >> vUInt`) then sign-extends without any
+// manual bit twiddling. See docs/SFPU_INT32_SHIFT.md for the full analysis.
+//
+// Semantics (per element, matching BinarySFPUGolden):
+//   shift < 0 OR shift >= 32          -> 0   (all three ops)
+//   right shift (32-bit)              -> arithmetic (sign-extending)
+//   logical right shift               -> unsigned (zero-fill)
+//   left shift                        -> plain left shift
+// The shift amount is a per-lane second operand, so the out-of-range mask is evaluated
+// per lane. INT32_MIN cannot round-trip through the sign-magnitude Dst and is unsupported.
+//
+// The template signature is kept identical to the raw-TTI version so the compute-API and
+// test call sites are unchanged; INSTRUCTION_MODE only selects the element width
+// (LO16 -> 16-bit lanes, otherwise 32-bit). SIGN_MAGNITUDE_FORMAT is no longer needed
+// because sfpi's typed layouts handle the Dst representation.
+
 namespace ckernel {
 namespace sfpu {
+
+// sfpi's dst_reg[] indexes in sfpi row units (32 rows/tile), unlike the raw TT_SFPLOAD
+// immediate which used 64.
+constexpr std::uint32_t dst_tile_size_sfpi_shift = 32;
 
 template <bool APPROXIMATION_MODE, int ITERATIONS, InstrModLoadStore INSTRUCTION_MODE, bool SIGN_MAGNITUDE_FORMAT>
 inline void calculate_binary_left_shift(
     const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
     static_assert(
         is_valid_instruction_mode(INSTRUCTION_MODE), "INSTRUCTION_MODE must be one of: INT32_2S_COMP, INT32, LO16.");
-
-    constexpr InstrModLoadStore sfpload_instr_mod =
-        SIGN_MAGNITUDE_FORMAT ? InstrModLoadStore::INT32_2S_COMP : INSTRUCTION_MODE;
-    // SFPU microcode
+    constexpr bool is_16bit = (INSTRUCTION_MODE == InstrModLoadStore::LO16);
+#pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        // size of each tile in Dest is 64 rows
-        constexpr std::uint32_t dst_tile_size = 64;
-        // load
-        TT_SFPLOAD(p_sfpu::LREG0, sfpload_instr_mod, ADDR_MOD_7, dst_index_in0 * dst_tile_size);
-        TT_SFPLOAD(p_sfpu::LREG1, sfpload_instr_mod, ADDR_MOD_7, dst_index_in1 * dst_tile_size);
-        // if (shift_amount < 0 OR shift_amount >= 32) -> result should be 0
-        TTI_SFPSETCC(0, p_sfpu::LREG1, p_sfpu::LREG0, 4);
-        TTI_SFPIADD(0xFE0, p_sfpu::LREG1, p_sfpu::LREG2, 1);  // 0xFE0 = -32
-        TTI_SFPCOMPC(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
-        TTI_SFPMOV(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
-        TTI_SFPENCC(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
-        // shift left
-        TTI_SFPSHFT(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);
-        // store result
-        TT_SFPSTORE(p_sfpu::LREG0, sfpload_instr_mod, ADDR_MOD_7, dst_index_out * dst_tile_size);
+        if constexpr (is_16bit) {
+            sfpi::vUInt v = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi_shift].mode<sfpi::DataLayout::U16>();
+            sfpi::vUInt amt = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi_shift].mode<sfpi::DataLayout::U16>();
+            sfpi::vUInt res = v << amt;
+            v_if(amt >= sfpi::vUInt(32u)) { res = sfpi::vUInt(0u); }
+            v_endif;
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi_shift].mode<sfpi::DataLayout::U16>() = res;
+        } else {
+            sfpi::vInt v = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi_shift].mode<sfpi::DataLayout::SM32>();
+            sfpi::vInt amt = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi_shift].mode<sfpi::DataLayout::SM32>();
+            sfpi::vInt res = v << sfpi::as<sfpi::vUInt>(amt);
+            // shift amount outside [0, 31] -> 0
+            v_if(amt < 0) { res = sfpi::vInt(0); }
+            v_endif;
+            v_if(amt >= 32) { res = sfpi::vInt(0); }
+            v_endif;
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi_shift].mode<sfpi::DataLayout::SM32>() = res;
+        }
         sfpi::dst_reg++;
     }
 }
@@ -48,35 +79,28 @@ inline void calculate_binary_right_shift(
     const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
     static_assert(
         is_valid_instruction_mode(INSTRUCTION_MODE), "INSTRUCTION_MODE must be one of: INT32_2S_COMP, INT32, LO16.");
-
-    constexpr InstrModLoadStore sfpload_instr_mod =
-        SIGN_MAGNITUDE_FORMAT ? InstrModLoadStore::INT32_2S_COMP : INSTRUCTION_MODE;
-    // SFPU microcode
+    constexpr bool is_16bit = (INSTRUCTION_MODE == InstrModLoadStore::LO16);
+#pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        // size of each tile in Dest is 64 rows
-        constexpr std::uint32_t dst_tile_size = 64;
-        // load
-        TT_SFPLOAD(p_sfpu::LREG0, sfpload_instr_mod, ADDR_MOD_7, dst_index_in0 * dst_tile_size);
-        TT_SFPLOAD(p_sfpu::LREG1, sfpload_instr_mod, ADDR_MOD_7, dst_index_in1 * dst_tile_size);
-        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG4, 0);  // save shift_value for later
-        // if (shift_amount < 0 OR shift_amount >= 32) -> result should be 0
-        TTI_SFPSETCC(0, p_sfpu::LREG1, p_sfpu::LREG0, 4);
-        TTI_SFPIADD(0xFE0, p_sfpu::LREG1, p_sfpu::LREG2, p_sfpu::LCONST_0);  // 0xFE0 = -32
-        TTI_SFPMOV(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
-        TTI_SFPENCC(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
-        TTI_SFPIADD(0, p_sfpu::LCONST_0, p_sfpu::LREG1, 6);  // take negative of shift_amount to shift right
-        // shift right
-        TTI_SFPSHFT(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);
-        // if shift_value was negative, need to shift in 1's manually
-        TTI_SFPSETCC(0, p_sfpu::LREG4, p_sfpu::LREG0, 0);     // only run if shift_value is negative
-        TTI_SFPSETCC(0, p_sfpu::LREG1, p_sfpu::LREG0, 2);     // only needed if shift_amount>0
-        TTI_SFPIADD(0x020, p_sfpu::LREG1, p_sfpu::LREG2, 5);  // take 32-shift_amount (0x020 = 32)
-        TTI_SFPNOT(0, p_sfpu::LCONST_0, p_sfpu::LREG3, 0);    // put all 1's into LREG3
-        TTI_SFPSHFT(0, p_sfpu::LREG2, p_sfpu::LREG3, 0);      // shift all 1's by 32-shift_amount
-        TTI_SFPOR(0, p_sfpu::LREG3, p_sfpu::LREG0, 0);        // OR in the 1's
-        TTI_SFPENCC(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
-        // store result
-        TT_SFPSTORE(p_sfpu::LREG0, sfpload_instr_mod, ADDR_MOD_7, dst_index_out * dst_tile_size);
+        if constexpr (is_16bit) {
+            sfpi::vUInt v = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi_shift].mode<sfpi::DataLayout::U16>();
+            sfpi::vUInt amt = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi_shift].mode<sfpi::DataLayout::U16>();
+            sfpi::vUInt res = v >> amt;
+            v_if(amt >= sfpi::vUInt(32u)) { res = sfpi::vUInt(0u); }
+            v_endif;
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi_shift].mode<sfpi::DataLayout::U16>() = res;
+        } else {
+            sfpi::vInt v = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi_shift].mode<sfpi::DataLayout::SM32>();
+            sfpi::vInt amt = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi_shift].mode<sfpi::DataLayout::SM32>();
+            // Native Blackhole arithmetic (sign-extending) right shift on true 2's-comp lanes.
+            sfpi::vInt res = v >> sfpi::as<sfpi::vUInt>(amt);
+            // shift amount outside [0, 31] -> 0
+            v_if(amt < 0) { res = sfpi::vInt(0); }
+            v_endif;
+            v_if(amt >= 32) { res = sfpi::vInt(0); }
+            v_endif;
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi_shift].mode<sfpi::DataLayout::SM32>() = res;
+        }
         sfpi::dst_reg++;
     }
 }
@@ -86,28 +110,29 @@ inline void calculate_logical_right_shift(
     const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
     static_assert(
         is_valid_instruction_mode(INSTRUCTION_MODE), "INSTRUCTION_MODE must be one of: INT32_2S_COMP, INT32, LO16.");
-
-    constexpr InstrModLoadStore sfpload_instr_mod =
-        SIGN_MAGNITUDE_FORMAT ? InstrModLoadStore::INT32_2S_COMP : INSTRUCTION_MODE;
-
-    // SFPU microcode
+    constexpr bool is_16bit = (INSTRUCTION_MODE == InstrModLoadStore::LO16);
+#pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        // size of each tile in Dest is 64 rows
-        constexpr std::uint32_t dst_tile_size = 64;
-        // load
-        TT_SFPLOAD(p_sfpu::LREG0, sfpload_instr_mod, ADDR_MOD_7, dst_index_in0 * dst_tile_size);
-        TT_SFPLOAD(p_sfpu::LREG1, sfpload_instr_mod, ADDR_MOD_7, dst_index_in1 * dst_tile_size);
-        // if (shift_amount < 0 OR shift_amount >= 32) -> result should be 0
-        TTI_SFPSETCC(0, p_sfpu::LREG1, p_sfpu::LREG0, 4);
-        TTI_SFPIADD(0xFE0, p_sfpu::LREG1, p_sfpu::LREG2, 1);  // 0xFE0 = -32
-        TTI_SFPCOMPC(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
-        TTI_SFPMOV(0, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
-        TTI_SFPENCC(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
-        // shift right
-        TTI_SFPIADD(0, p_sfpu::LCONST_0, p_sfpu::LREG1, 6);  // take negative of shift_amount to shift right
-        TTI_SFPSHFT(0, p_sfpu::LREG1, p_sfpu::LREG0, 0);
-        // store result
-        TT_SFPSTORE(p_sfpu::LREG0, sfpload_instr_mod, ADDR_MOD_7, dst_index_out * dst_tile_size);
+        if constexpr (is_16bit) {
+            sfpi::vUInt v = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi_shift].mode<sfpi::DataLayout::U16>();
+            sfpi::vUInt amt = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi_shift].mode<sfpi::DataLayout::U16>();
+            sfpi::vUInt res = v >> amt;
+            v_if(amt >= sfpi::vUInt(32u)) { res = sfpi::vUInt(0u); }
+            v_endif;
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi_shift].mode<sfpi::DataLayout::U16>() = res;
+        } else {
+            sfpi::vInt v = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi_shift].mode<sfpi::DataLayout::SM32>();
+            sfpi::vInt amt = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi_shift].mode<sfpi::DataLayout::SM32>();
+            // Unsigned (logical, zero-fill) right shift regardless of the sign bit.
+            sfpi::vUInt res = sfpi::as<sfpi::vUInt>(v) >> sfpi::as<sfpi::vUInt>(amt);
+            // shift amount outside [0, 31] -> 0
+            v_if(amt < 0) { res = sfpi::vUInt(0u); }
+            v_endif;
+            v_if(amt >= 32) { res = sfpi::vUInt(0u); }
+            v_endif;
+            sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi_shift].mode<sfpi::DataLayout::SM32>() =
+                sfpi::as<sfpi::vInt>(res);
+        }
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_binary.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_binary.py
@@ -283,14 +283,6 @@ def test_sfpu_binary_int_shift_edge_cases(
     dest_acc,
     mathop,
 ):
-    if TestConfig.CHIP_ARCH == ChipArchitecture.BLACKHOLE:
-        pytest.skip(
-            reason="Blackhole shift kernels (left / arithmetic right / logical right) are "
-            "unmigrated TTI microcode whose predicated out-of-range/sign handling breaks "
-            "under INT32_2S_COMP for negative operands, so all three diverge from the "
-            "two's-complement golden. See SFPU_INT32_SHIFT.md."
-        )
-
     sfpu_binary(
         formats,
         dest_acc,


### PR DESCRIPTION

### Summary
BH currently runs these shift  kernels in sign magnitude mode which produces wrong results in some places. Moving to 2's complement and SFPI makes code more readable and makes all edge cases tests pass

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ldjurovic/fix_sfpu_shift_bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ldjurovic/fix_sfpu_shift_bh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ldjurovic/fix_sfpu_shift_bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ldjurovic/fix_sfpu_shift_bh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ldjurovic/fix_sfpu_shift_bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ldjurovic/fix_sfpu_shift_bh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ldjurovic/fix_sfpu_shift_bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ldjurovic/fix_sfpu_shift_bh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ldjurovic/fix_sfpu_shift_bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ldjurovic/fix_sfpu_shift_bh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ldjurovic/fix_sfpu_shift_bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ldjurovic/fix_sfpu_shift_bh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ldjurovic/fix_sfpu_shift_bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ldjurovic/fix_sfpu_shift_bh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ldjurovic/fix_sfpu_shift_bh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ldjurovic/fix_sfpu_shift_bh)