### PR TITLE
SetCommonRuntimeArgs is tolerant of pre allocated CRTA buffers

### DIFF
--- a/tt_metal/impl/dispatch/dispatch_telemetry.cpp
+++ b/tt_metal/impl/dispatch/dispatch_telemetry.cpp
@@ -50,7 +50,7 @@ std::optional<SMCRuntimeTelemetryBuffer> discover_smc_dispatch_telemetry_control
 
     auto size = firmware_info_provider->get_runtime_telemetry_buffer_size();
     if (!size.has_value()) {
-        log_warning(tt::LogMetal, "Dispatch telemetry SMC buffer is unavailable");
+        log_debug(tt::LogMetal, "Dispatch telemetry SMC buffer is unavailable");
         return std::nullopt;
     }
     if (size.value() < sizeof(dispatch_telemetry_types::SMCDispatchTelemetryControl)) {

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -737,9 +737,18 @@ void Kernel::set_runtime_args(const CoreCoord& logical_core, stl::Span<const uin
 
 void Kernel::set_common_runtime_args(stl::Span<const uint32_t> common_runtime_args) {
     auto& set_rt_args = this->common_runtime_args_;
-    TT_FATAL(
-        set_rt_args.empty(),
-        "Illegal Common Runtime Args: Can only set common runtime args once. Get and modify args in place instead.");
+
+    // Metal 2.0 may preallocate the common runtime-argument buffer from the
+    // ProgramSpec schema. Preserve that allocation and populate it in place.
+    if (!set_rt_args.empty()) {
+        TT_FATAL(
+            this->common_runtime_args_data_.size() == common_runtime_args.size(),
+            "Illegal Common Runtime Args: Cannot change the number of common runtime args from {} to {}.",
+            this->common_runtime_args_data_.size(),
+            common_runtime_args.size());
+        std::copy(common_runtime_args.begin(), common_runtime_args.end(), this->common_runtime_args_data_.data());
+        return;
+    }
 
     size_t effective_crta_limit = common_runtime_args.size() + watcher_count_word_offset_;
 


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes #50421 
* Ensured current usage of SetCommonRuntimeArgs is not broken when MakeProgramFromSpec is used
* Changed noisy telemetry warning to log_debug

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=anashTT/crta-utest-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:anashTT/crta-utest-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=anashTT/crta-utest-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:anashTT/crta-utest-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=anashTT/crta-utest-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:anashTT/crta-utest-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=anashTT/crta-utest-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:anashTT/crta-utest-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=anashTT/crta-utest-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:anashTT/crta-utest-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=anashTT/crta-utest-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:anashTT/crta-utest-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=anashTT/crta-utest-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:anashTT/crta-utest-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=anashTT/crta-utest-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:anashTT/crta-utest-fix)