### PR TITLE
[tt-train] [Test Only] Split merge gate tests into 2 groups

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -138,7 +138,7 @@ ttnn:
 
 train:
   merge_gate:
-    wh_n150_civ2: 20
+    wh_n150_civ2: 30
   unit:
     wh_n150_civ2: 90
     wh_n300_civ2: 90

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -385,7 +385,7 @@ jobs:
   # test list: train_merge_gate_tests.yaml
   # ===========================================================================
 
-  train-smoke-tests:
+  train-merge-gate-tests:
     needs: [build, find-changes]
     if: ${{ github.event_name == 'workflow_dispatch' ||
             github.ref_name == 'main' ||
@@ -516,14 +516,14 @@ jobs:
         contains(join(needs.*.result, ','), 'failure')
       }}
 
-    needs: [static-checks, docker-images, find-changes, build, build-tsan, build-sweeps, runtime-smoke-tests, runtime-basic-tests, triage-tests, ttnn-smoke-tests, ttnn-basic-tests, ttnn-merge-gate-tests, models-smoke-tests, train-smoke-tests, scaleout-unit-tests, llk-unit-tests]
+    needs: [static-checks, docker-images, find-changes, build, build-tsan, build-sweeps, runtime-smoke-tests, runtime-basic-tests, triage-tests, ttnn-smoke-tests, ttnn-basic-tests, ttnn-merge-gate-tests, models-smoke-tests, train-merge-gate-tests, scaleout-unit-tests, llk-unit-tests]
     runs-on: ubuntu-slim
     steps:
       - name: Check if all jobs passed
         uses: tenstorrent/tt-metal/.github/actions/workflow-status@main
         with:
           required-jobs: "static-checks, find-changes"
-          optional-jobs: "build, build-tsan, build-sweeps, runtime-smoke-tests, runtime-basic-tests, triage-tests, ttnn-smoke-tests, ttnn-basic-tests, ttnn-merge-gate-tests, models-smoke-tests, train-smoke-tests, scaleout-unit-tests, llk-unit-tests"
+          optional-jobs: "build, build-tsan, build-sweeps, runtime-smoke-tests, runtime-basic-tests, triage-tests, ttnn-smoke-tests, ttnn-basic-tests, ttnn-merge-gate-tests, models-smoke-tests, train-merge-gate-tests, scaleout-unit-tests, llk-unit-tests"
         env:
           NEEDS_CONTEXT: "${{ toJSON(needs) }}"
       - if: (failure() && contains(join(needs.*.result, ','), 'failure') && github.event_name == 'merge_group')

--- a/tests/pipeline_reorg/train_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/train_merge_gate_tests.yaml
@@ -12,9 +12,24 @@
 # For max allowed timeout refer to .github/time_budget.yaml.
 # Logical SKUs only; merge_group prio routing is via sku_config merge_queue_sku.
 
-# Non-nightly smoke tests
-- name: tt-train cpp smoke tests
+# Non-nightly merge gate tests
+# TODO: Split into two groups due to inconsistent durations: https://github.com/tenstorrent/tt-metal/issues/50449
+- name: tt-train cpp merge gate tests (id 0)
   cmd: |
+    export GTEST_TOTAL_SHARDS=2
+    export GTEST_SHARD_INDEX=0
+    mkdir -p generated/test_reports
+    build/tt-train/tests/ttml_tests --gtest_output=xml:generated/test_reports/ctest_report.xml --gtest_filter="-*NIGHTLY*"
+  skus:
+    wh_n150_civ2:
+      timeout: 15
+  owner_id: U07K00A281X # Kevin Wu
+  team: train
+
+- name: tt-train cpp merge gate tests (id 1)
+  cmd: |
+    export GTEST_TOTAL_SHARDS=2
+    export GTEST_SHARD_INDEX=1
     mkdir -p generated/test_reports
     build/tt-train/tests/ttml_tests --gtest_output=xml:generated/test_reports/ctest_report.xml --gtest_filter="-*NIGHTLY*"
   skus:


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Currently, tt-train merge gate tests take about 6 minutes to run in some instances but more than 15 minutes in others. Since the currently policy restricts each job to 15 minutes max, this issue causes a lot of timeouts. This PR splits the tt-train merge gate tests into two groups for the time being while the issue is being debugged.

Using `GTEST_TOTAL_SHARDS`, the test suite is split between first and second halves.
[tt-train cpp merge gate tests (id 0)](https://github.com/tenstorrent/tt-metal/actions/runs/29763757312/job/88427538415)
[tt-train cpp merge gate tests (id 1)](https://github.com/tenstorrent/tt-metal/actions/runs/29763757312/job/88427538467)

*** 
Tracking ticket created here: https://github.com/tenstorrent/tt-metal/issues/50449

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ctr-kevinwu/split-merge-gate-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ctr-kevinwu/split-merge-gate-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ctr-kevinwu/split-merge-gate-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ctr-kevinwu/split-merge-gate-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ctr-kevinwu/split-merge-gate-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ctr-kevinwu/split-merge-gate-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ctr-kevinwu/split-merge-gate-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ctr-kevinwu/split-merge-gate-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ctr-kevinwu/split-merge-gate-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ctr-kevinwu/split-merge-gate-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ctr-kevinwu/split-merge-gate-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ctr-kevinwu/split-merge-gate-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ctr-kevinwu/split-merge-gate-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ctr-kevinwu/split-merge-gate-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ctr-kevinwu/split-merge-gate-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ctr-kevinwu/split-merge-gate-tests)