### PR TITLE
tt-llk tests: accept Python 3.10 or newer in external env setup

### DIFF
--- a/tt_metal/tt-llk/tests/setup_external_testing_env.sh
+++ b/tt_metal/tt-llk/tests/setup_external_testing_env.sh
@@ -31,6 +31,7 @@ check_deps() {
 # Check for supported Python version
 check_python_version() {
     PYTHON_VERSION=$(python3 --version 2>&1 | cut -d' ' -f2)
+    local PYTHON_MAJOR PYTHON_MINOR
     PYTHON_MAJOR=$(printf '%s' "$PYTHON_VERSION" | cut -d. -f1)
     PYTHON_MINOR=$(printf '%s' "$PYTHON_VERSION" | cut -d. -f2)
     if ! [[ "$PYTHON_MAJOR" =~ ^[0-9]+$ && "$PYTHON_MINOR" =~ ^[0-9]+$ ]]; then

--- a/tt_metal/tt-llk/tests/setup_external_testing_env.sh
+++ b/tt_metal/tt-llk/tests/setup_external_testing_env.sh
@@ -31,8 +31,14 @@ check_deps() {
 # Check for supported Python version
 check_python_version() {
     PYTHON_VERSION=$(python3 --version 2>&1 | cut -d' ' -f2)
-    if [[ "$PYTHON_VERSION" != "3.10"* ]]; then
-        echo "Error: Only Python 3.10 is supported. Detected: $PYTHON_VERSION" >&2
+    PYTHON_MAJOR=$(printf '%s' "$PYTHON_VERSION" | cut -d. -f1)
+    PYTHON_MINOR=$(printf '%s' "$PYTHON_VERSION" | cut -d. -f2)
+    if ! [[ "$PYTHON_MAJOR" =~ ^[0-9]+$ && "$PYTHON_MINOR" =~ ^[0-9]+$ ]]; then
+        echo "Error: Unable to parse Python version: $PYTHON_VERSION" >&2
+        exit 1
+    fi
+    if (( PYTHON_MAJOR < 3 || (PYTHON_MAJOR == 3 && PYTHON_MINOR < 10) )); then
+        echo "Error: Python 3.10 or newer is required. Detected: $PYTHON_VERSION" >&2
         exit 1
     fi
     echo "Supported Python version detected: $PYTHON_VERSION"


### PR DESCRIPTION
## What

Relax the Python version gate in
`tt_metal/tt-llk/tests/setup_external_testing_env.sh` from an exact
`3.10` prefix match to `>= 3.10`, so the test-environment bootstrap no
longer hard-stops on modern interpreters.

```diff
-    if [[ "$PYTHON_VERSION" != "3.10"* ]]; then
-        echo "Error: Only Python 3.10 is supported. Detected: $PYTHON_VERSION" >&2
+    PYTHON_MAJOR=$(printf '%s' "$PYTHON_VERSION" | cut -d. -f1)
+    PYTHON_MINOR=$(printf '%s' "$PYTHON_VERSION" | cut -d. -f2)
+    if ! [[ "$PYTHON_MAJOR" =~ ^[0-9]+$ && "$PYTHON_MINOR" =~ ^[0-9]+$ ]]; then
+        echo "Error: Unable to parse Python version: $PYTHON_VERSION" >&2
+        exit 1
+    fi
+    if (( PYTHON_MAJOR < 3 || (PYTHON_MAJOR == 3 && PYTHON_MINOR < 10) )); then
+        echo "Error: Python 3.10 or newer is required. Detected: $PYTHON_VERSION" >&2
```

## Why

The script currently rejects any interpreter that does not start with
`3.10`:

> `Error: Only Python 3.10 is supported. Detected: 3.12.x`

This blocks users on distros whose default interpreter is newer --
Ubuntu 24.04 ships Python 3.12, Ubuntu 26.04 ships Python 3.14 -- before
the test dependencies and simulator tests even run.

The `3.10 only` restriction has **no documented rationale**: it is
absent from `tests/README.md` and `docs/tests/getting_started.md`, and
the gate line is unchanged since the file was imported. The script is
the documented community entry point for the LLK test environment
(`tests/README.md`: `source ./setup_external_testing_env.sh`), so this
benefits all external users on modern distros.

## Scope

Minimal, single-concern change (+8/-2): parse major/minor and require
`>= 3.10`. No other behavior change; `bash -n` passes.

## Validation

The relaxed gate has been exercised downstream across a 9-target
community distro matrix (Python 3.12 / 3.13 / 3.14), where the LLK
runtime smoke completes successfully on all targets that have the
required wheels:
https://github.com/tetsuh/tt-metal-community-distro-matrix#compatibility-status