### PR TITLE
[skip ci] ci: revert codeowners post-comment job to ubuntu-latest

### DIFF
--- a/.github/workflows/codeowners-group-analysis.yaml
+++ b/.github/workflows/codeowners-group-analysis.yaml
@@ -923,7 +923,7 @@ jobs:
   post-comment:
     needs: [find-pr, analyze-codeowners, get-reviews, parse-comment]
     if: always() && needs.find-pr.outputs.pr-exists == 'true' && needs.parse-comment.outputs.is-bypass-command != 'true'
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
       - name: Generate comment data
         id: generate-comment


### PR DESCRIPTION
## Summary
- The `post-comment` job in `codeowners-group-analysis.yaml` (specifically the "Generate comment data" step) has been intermittently hanging for the full 15-minute job timeout and getting cancelled, since the switch to `ubuntu-slim` in #49992 (merged 2026-07-19).
- Confirmed via CI history: 0 cancelled/failed runs of this workflow in the 100 runs prior to the switch (Jul 1-18); at least 6 cancelled + 1 failure on 2026-07-20 alone, across 5 different users (not isolated to one PR/account).
- The step makes many sequential `curl` calls to the GitHub API with no `--max-time`/`--connect-timeout`, so any single stalled connection burns the entire job budget with no useful error. `ubuntu-slim` runs as a containerized "Hosted Compute Agent" rather than a dedicated VM, which is the likely source of the increased connection flakiness.
- This PR scopes the revert to just the `post-comment` job (the only one observed hanging); the other 6 jobs stay on `ubuntu-slim`.

## Test plan
- [x] Confirm `post-comment` runs on a dedicated `ubuntu-latest` VM in the next triggered run
- [ ] Monitor for further cancellations/hangs on this workflow over the next few days

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=Aswinmcw/revert-codeowners-ubuntu-slim)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:Aswinmcw/revert-codeowners-ubuntu-slim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=Aswinmcw/revert-codeowners-ubuntu-slim)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:Aswinmcw/revert-codeowners-ubuntu-slim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=Aswinmcw/revert-codeowners-ubuntu-slim)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:Aswinmcw/revert-codeowners-ubuntu-slim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Aswinmcw/revert-codeowners-ubuntu-slim)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/revert-codeowners-ubuntu-slim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=Aswinmcw/revert-codeowners-ubuntu-slim)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:Aswinmcw/revert-codeowners-ubuntu-slim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Aswinmcw/revert-codeowners-ubuntu-slim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/revert-codeowners-ubuntu-slim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Aswinmcw/revert-codeowners-ubuntu-slim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/revert-codeowners-ubuntu-slim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Aswinmcw/revert-codeowners-ubuntu-slim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/revert-codeowners-ubuntu-slim)