### PR TITLE
ds_prefill(single_routed_expert_tests) - refactor into ISL sweep tests

### DIFF
--- a/models/demos/deepseek_v3_d_p/utils/smbus_telemetry.py
+++ b/models/demos/deepseek_v3_d_p/utils/smbus_telemetry.py
@@ -25,3 +25,26 @@ def get_ddr_speed():
         if ddr_speed_hex:
             return int(ddr_speed_hex, 16)
     return None
+
+
+def get_board_type():
+    """Board type string reported by tt-smi (e.g. ``"p150b"``, ``"p100"``, ``"n300"``), or None."""
+    data = get_smbus_telemetry()
+    if data and data.get("device_info"):
+        return data["device_info"][0].get("board_info", {}).get("board_type")
+    return None
+
+
+def is_p150():
+    """True iff the host's board is a P150 (any revision, e.g. ``p150``/``p150b``).
+
+    Reads board type via tt-smi (SMBus/sysfs), which does NOT open the compute device
+    or take the CHIP_IN_USE lock — so, unlike ``ttnn.cluster.get_cluster_type()``, it is
+    safe to call from a pytest ``skipif`` at collection time. Returns False on any error
+    (tt-smi missing/failed/timeout) so callers degrade to skipping rather than erroring.
+    """
+    try:
+        board_type = get_board_type()
+    except Exception:
+        return False
+    return board_type is not None and board_type.lower().startswith("p150")

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert.py
@@ -204,13 +204,10 @@ def _xfail_blackhole(request, silicon_arch_name):
 # first `active_tokens` holding real data; the rest is zero padding.
 _ISL_ALLOCATED_TOKENS = 5120
 
-# Functional sweep: a few active-token counts across every model, on both WH and BH. Two off-tile-
-# boundary primes (one below 256, one above 3K) plus a round 1K.
-_ISL_FUNCTIONAL_SWEEP = [251, 1024, 3001]
+# Functional sweep: a few active-token counts across every model
+_ISL_FUNCTIONAL_SWEEP = [251, 768, 3001]
 
-# Exhaustive sweep: the full fill range from empty to fully-packed, restricted to the two largest
-# models to keep runtime bounded. Blackhole-only, since active < allocated exercises device-side
-# count-aware sparsity (skipping matmuls on the inactive padding rows), which is a Blackhole feature.
+# Exhaustive sweep: the full range from empty to fully-packed
 _ISL_EXHAUSTIVE_SWEEP = [0, 128, 256, 512, 1024, 2048, 4096, 5120]
 _ISL_EXHAUSTIVE_MODELS = ("kimi_k26", "glm_51")
 

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert.py
@@ -46,22 +46,31 @@ _TOKEN_SWEEP = [
 def run_single_routed_expert(
     mesh_device,
     device_params,
-    num_tokens: int,
+    allocated_tokens: int,
     emb_dim: int,
     hidden_dim: int,
+    active_tokens: int = None,
     x_row_major: bool = False,
 ):
     """
     Simplest scenario: 1 chip, 1 expert. Shared body for the per-model entrypoints below — they
     differ only on the (emb_dim, hidden_dim) shape axis and the x input layout.
 
-    Perfect for profiling the core FFN computation without any mesh complexity.
+    The single expert's dispatch buffer is sized for ``allocated_tokens`` but only the first
+    ``active_tokens`` rows hold real data; the rest is zero padding. When ``active_tokens`` is
+    None it defaults to ``allocated_tokens`` (a fully-active buffer), which is the plain
+    profiling case. With ``active_tokens < allocated_tokens`` this exercises device-side
+    count-aware sparsity: the kernel must (a) produce correct output on the active slice and
+    (b) not do matmuls on the inactive padding rows. The ROW_MAJOR variant additionally drives
+    the reader's clamp-read of the inactive rows past the runtime count.
     """
+    if active_tokens is None:
+        active_tokens = allocated_tokens
     experts_per_chip = 1
 
-    signpost(f"SingleRoutedExpert {num_tokens=} {emb_dim=} {hidden_dim=}")
+    signpost(f"SingleRoutedExpert {allocated_tokens=} {active_tokens=} {emb_dim=} {hidden_dim=}")
 
-    logger.debug(f"Testing single routed expert: {num_tokens=}, {emb_dim=}, {hidden_dim=}")
+    logger.debug(f"Testing single routed expert: {allocated_tokens=}, {active_tokens=}, {emb_dim=}, {hidden_dim=}")
     logger.debug(f"Mesh: {mesh_device.shape}, num_devices={mesh_device.get_num_devices()}")
 
     # Create random weights
@@ -75,17 +84,20 @@ def run_single_routed_expert(
     # Create torch reference
     torch_expert = TorchExpert(emb_dim, hidden_dim, weights)
 
-    # 2D input (num_tokens, emb_dim) — the single expert's dispatch buffer.
-    torch_input = torch.randn(num_tokens, emb_dim, dtype=torch.float32)
+    # 2D input (allocated_tokens, emb_dim) — the single expert's dispatch buffer. The first
+    # active_tokens rows hold real data; the rest is zero padding (a no-op when active==allocated).
+    torch_active = torch.randn(active_tokens, emb_dim, dtype=torch.float32)
+    torch_input = torch.zeros(allocated_tokens, emb_dim, dtype=torch.float32)
+    torch_input[:active_tokens] = torch_active
     logger.debug(f"Input shape: {torch_input.shape}")
 
-    # Run torch reference
+    # Run torch reference over the active slice only.
     logger.debug("Running torch reference...")
     with torch.no_grad():
-        torch_output = torch_expert(torch_input)
-    logger.debug(f"Torch output shape: {torch_output.shape}")
+        torch_output_active = torch_expert(torch_active)
+    logger.debug(f"Torch output shape: {torch_output_active.shape}")
 
-    # Create TTNN input: 2D (num_tokens, emb_dim), replicated across the 1-device mesh.
+    # Create TTNN input: 2D (allocated_tokens, emb_dim), replicated across the 1-device mesh.
     # The composite op branches on x layout: ROW_MAJOR is bf16 (tilized and bf8-packed
     # inside the op), TILE is consumed directly as bf8. Pair the dtype with the layout so
     # each variation drives its real device path.
@@ -99,9 +111,9 @@ def run_single_routed_expert(
     logger.debug(f"TTNN input shape: {tt_input.shape}")
 
     # Single-expert auxiliaries (1D, length 1, UINT32 ROW_MAJOR DRAM):
-    #   - global_expert_idx_table[0] = 0   (local 0 -> global 0)
-    #   - expert_token_counts[0]     = num_tokens
-    #   - expert_region_offsets[0]   = 0   (expert's slice starts at row 0)
+    #   - global_expert_idx_table[0] = 0             (local 0 -> global 0)
+    #   - expert_token_counts[0]     = active_tokens (runtime count; drives count sparsity)
+    #   - expert_region_offsets[0]   = 0             (expert's slice starts at row 0)
     def _make_idx_tensor(values):
         return ttnn.from_torch(
             torch.tensor(values, dtype=torch.int32),
@@ -111,7 +123,7 @@ def run_single_routed_expert(
         )
 
     global_expert_idx_tt = _make_idx_tensor([0])
-    expert_token_counts_tt = _make_idx_tensor([num_tokens])
+    expert_token_counts_tt = _make_idx_tensor([active_tokens])
     expert_region_offsets_tt = _make_idx_tensor([0])
 
     # Create TtRoutedExpert
@@ -122,7 +134,7 @@ def run_single_routed_expert(
         global_expert_idx_table=global_expert_idx_tt,
         emb_dim=emb_dim,
         hidden_dim=hidden_dim,
-        max_tokens=num_tokens,
+        max_tokens=allocated_tokens,
         torch_weights=[weights],  # List with single expert weights
         activations_dtype=ttnn.bfloat8_b,
         weights_dtype=ttnn.bfloat4_b,
@@ -141,16 +153,17 @@ def run_single_routed_expert(
         mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0),
     )
     logger.debug(f"TTNN output (torch) shape: {tt_output_torch.shape}")
+    tt_output_active = tt_output_torch[:active_tokens]
 
-    # Compare PCC
-    _, pcc = comp_pcc(torch_output, tt_output_torch)
-    logger.debug(f"PCC: {pcc:.6f}")
+    # Compare PCC over the active slice.
+    _, pcc = comp_pcc(torch_output_active, tt_output_active)
+    logger.debug(f"PCC over active slice ({active_tokens} rows): {pcc:.6f}")
 
     # Validate
     pcc_threshold = 0.97
     assert pcc >= pcc_threshold, f"PCC {pcc:.6f} below threshold {pcc_threshold}"
-    assert not torch.isnan(tt_output_torch).any(), "Output contains NaN"
-    assert not torch.isinf(tt_output_torch).any(), "Output contains Inf"
+    assert not torch.isnan(tt_output_active).any(), "Active output contains NaN"
+    assert not torch.isinf(tt_output_active).any(), "Active output contains Inf"
 
     logger.debug("Test PASSED!")
 
@@ -220,7 +233,7 @@ def _xfail_blackhole_token_sweep(request, silicon_arch_name):
 def test_single_routed_expert_models(
     mesh_device, device_params, num_tokens: int, emb_dim: int, hidden_dim: int, x_row_major: bool
 ):
-    run_single_routed_expert(mesh_device, device_params, num_tokens, emb_dim, hidden_dim, x_row_major)
+    run_single_routed_expert(mesh_device, device_params, num_tokens, emb_dim, hidden_dim, x_row_major=x_row_major)
 
 
 # (allocated_tokens, active_tokens, id) sweep for the count-aware sparsity test, applied per
@@ -229,96 +242,6 @@ _FAKED_SWEEP = [
     (1024, 0, "1k-alloc-0k-active"),
     (25600, 4096, "25k-alloc-4k-active"),
 ]
-
-
-def run_single_routed_expert_faked_token_count(
-    mesh_device,
-    device_params,
-    allocated_tokens: int,
-    active_tokens: int,
-    emb_dim: int,
-    hidden_dim: int,
-    x_row_major: bool = False,
-):
-    """
-    Verifies the unified kernel honors expert_token_counts and skips work on
-    inactive padding rows. Shared body for the per-model entrypoints below — they differ only on
-    the (emb_dim, hidden_dim) shape axis.
-
-    Dispatch buffer sized for ``allocated_tokens`` but only the first
-    ``active_tokens`` rows hold real data; the rest is zero padding. The
-    kernel must (a) produce correct output on the active slice and (b) not
-    do matmuls on the inactive padding rows (device-side count sparsity).
-    """
-    experts_per_chip = 1
-
-    signpost(f"SingleRoutedExpertFaked {allocated_tokens=} {active_tokens=} {emb_dim=} {hidden_dim=}")
-
-    torch.manual_seed(42)
-    weights = {
-        "gate_proj": torch.randn(hidden_dim, emb_dim, dtype=torch.float32) * 0.02,
-        "up_proj": torch.randn(hidden_dim, emb_dim, dtype=torch.float32) * 0.02,
-        "down_proj": torch.randn(emb_dim, hidden_dim, dtype=torch.float32) * 0.02,
-    }
-    torch_expert = TorchExpert(emb_dim, hidden_dim, weights)
-
-    torch_active = torch.randn(active_tokens, emb_dim, dtype=torch.float32)
-    torch_input = torch.zeros(allocated_tokens, emb_dim, dtype=torch.float32)
-    torch_input[:active_tokens] = torch_active
-
-    with torch.no_grad():
-        torch_output_active = torch_expert(torch_active)
-
-    # ROW_MAJOR is bf16 (tilized + bf8-packed in-op), TILE is consumed directly as bf8.
-    # With active_tokens < allocated_tokens the ROW_MAJOR variant is what exercises the
-    # reader's clamp-read of the inactive rows past the runtime count.
-    tt_input = ttnn.from_torch(
-        torch_input,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
-        layout=ttnn.ROW_MAJOR_LAYOUT if x_row_major else ttnn.TILE_LAYOUT,
-        device=mesh_device,
-        dtype=ttnn.bfloat16 if x_row_major else ttnn.bfloat8_b,
-    )
-
-    def _make_idx_tensor(values):
-        return ttnn.from_torch(
-            torch.tensor(values, dtype=torch.int32),
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-            device=mesh_device,
-            dtype=ttnn.uint32,
-        )
-
-    global_expert_idx_tt = _make_idx_tensor([0])
-    expert_token_counts_tt = _make_idx_tensor([active_tokens])
-    expert_region_offsets_tt = _make_idx_tensor([0])
-
-    tt_expert = TtRoutedExpert(
-        mesh_device=mesh_device,
-        experts_per_chip=experts_per_chip,
-        global_expert_idx_table=global_expert_idx_tt,
-        emb_dim=emb_dim,
-        hidden_dim=hidden_dim,
-        max_tokens=allocated_tokens,
-        torch_weights=[weights],
-        activations_dtype=ttnn.bfloat8_b,
-        weights_dtype=ttnn.bfloat4_b,
-        activation=ttnn.RoutedExpertActivation.Silu,
-    )
-
-    tt_output = tt_expert(tt_input, expert_token_counts_tt, expert_region_offsets_tt)
-
-    tt_output_torch = ttnn.to_torch(
-        tt_output,
-        mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0),
-    )
-    tt_output_active = tt_output_torch[:active_tokens]
-
-    _, pcc = comp_pcc(torch_output_active, tt_output_active)
-    logger.debug(f"PCC over active slice ({active_tokens} rows): {pcc:.6f}")
-
-    assert pcc >= 0.97, f"PCC {pcc:.6f} below threshold 0.97"
-    assert not torch.isnan(tt_output_active).any(), "Active output contains NaN"
-    assert not torch.isinf(tt_output_active).any(), "Active output contains Inf"
 
 
 def single_routed_expert_faked_params():
@@ -360,6 +283,12 @@ def test_single_routed_expert_faked_token_count_models(
     hidden_dim: int,
     x_row_major: bool,
 ):
-    run_single_routed_expert_faked_token_count(
-        mesh_device, device_params, allocated_tokens, active_tokens, emb_dim, hidden_dim, x_row_major
+    run_single_routed_expert(
+        mesh_device,
+        device_params,
+        allocated_tokens,
+        emb_dim,
+        hidden_dim,
+        active_tokens=active_tokens,
+        x_row_major=x_row_major,
     )

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert.py
@@ -35,13 +35,6 @@ SINGLE_CHIP_MESH_PARAMS = [
     ),
 ]
 
-# Token-count sweep for the single-expert profiling test, applied per model with that model's
-# (emb_dim, hidden_dim). The (num_tokens, id) pairs are model-independent.
-_TOKEN_SWEEP = [
-    (1024, "1k"),
-    (25600, "25k"),
-]
-
 
 def run_single_routed_expert(
     mesh_device,
@@ -182,99 +175,109 @@ SINGLE_EXPERT_MODELS = [
 ]
 
 
-# Registry of currently-failing single-routed-expert cases, keyed by the exact "{model}-{tag}"
-# param id -> xfail reason (with tracking issue), so CI stays green while linked issues are worked
-# on. _TOKEN_SWEEP_XFAIL is applied (strict) only on blackhole by _xfail_blackhole_token_sweep;
-# _FAKED_XFAIL by single_routed_expert_faked_params. Both are empty: the factory's adaptive L1 guard
-# (shrinks per-core CBs to fit L1 and picks an in0_block_w_gu that divides K_gate_tiles) resolved the
-# prior dsv4_pro L1 and gptoss_120b K_gate failures. Add an entry when a new blackhole-specific
-# failure appears (these pass on other arches); delete it once resolved.
-_TOKEN_SWEEP_XFAIL = {}
-_FAKED_XFAIL = {}
-
-
-def single_routed_expert_token_sweep_params():
-    """Build the per-model (num_tokens, emb_dim, hidden_dim) parametrization over _TOKEN_SWEEP.
-    Non-baseline models carry the extended_model marker so they stay gated as before; the
-    _TOKEN_SWEEP_XFAIL cases are xfail'd per-arch by _xfail_blackhole_token_sweep, not here."""
-    params = []
-    for name, config, extended in SINGLE_EXPERT_MODELS:
-        for num_tokens, tag in _TOKEN_SWEEP:
-            test_id = f"{name}-{tag}"
-            marks = (pytest.mark.extended_model,) if extended else ()
-            params.append(
-                pytest.param(num_tokens, config.EMB_SIZE, config.MOE_INTERMEDIATE_SIZE, marks=marks, id=test_id)
-            )
-    return params
+# Registry of currently-failing single-routed-expert cases -> xfail reason (with tracking issue), so
+# CI stays green while linked issues are worked on. Applied strict, only on blackhole, by
+# _xfail_blackhole (these cases pass on other arches, where an unconditional strict xfail would turn
+# CI red on XPASS). Each key is a space-separated set of id tokens that must ALL appear in the param
+# id, so a case can be scoped by any combination of layout ("x_tile"/"x_rm") and model/isl id.
+#   - gptoss_120b on the TILE x layout: the factory picks an in0_block_w_gu that does not divide
+#     K_gate_tiles for gptoss dims (K_gate_tiles % in0_block_w_gu == 0 TT_FATAL). The ROW_MAJOR x
+#     layout passes, so scope the xfail to x_tile only.
+_XFAIL = {
+    "x_tile gptoss_120b": "gptoss_120b K_gate tiling: factory picks in0_block_w_gu that does not divide K_gate_tiles on the TILE x layout (unified_routed_expert_ffn_program_factory.cpp:404)",
+}
 
 
 @pytest.fixture(autouse=True)
-def _xfail_blackhole_token_sweep(request, silicon_arch_name):
-    """Strict-xfail the _TOKEN_SWEEP_XFAIL cases only on blackhole: the K_gate / L1 issues are
-    blackhole-specific and these cases pass on other arches, where an unconditional strict xfail
-    would turn CI red on XPASS. Keyed by the full param id so each (model, token-count) is marked
-    independently."""
-    if silicon_arch_name != "blackhole" or request.node.name.split("[")[0] != "test_single_routed_expert_models":
+def _xfail_blackhole(request, silicon_arch_name):
+    """Strict-xfail the _XFAIL cases only on blackhole: the K_gate / L1 issues are blackhole-specific
+    and these cases pass on other arches, where an unconditional strict xfail would turn CI red on
+    XPASS. A case matches when every whitespace-separated token of the key appears in the param id."""
+    if silicon_arch_name != "blackhole":
         return
     callspec = getattr(request.node, "callspec", None)
     if callspec is None:
         return
-    for param_id, reason in _TOKEN_SWEEP_XFAIL.items():
-        if callspec.id.endswith(param_id):
+    for key, reason in _XFAIL.items():
+        if all(token in callspec.id for token in key.split()):
             request.applymarker(pytest.mark.xfail(reason=reason, strict=True))
             break
 
 
-@pytest.mark.parametrize("num_tokens, emb_dim, hidden_dim", single_routed_expert_token_sweep_params())
-@pytest.mark.parametrize(
-    "mesh_device, device_params", SINGLE_CHIP_MESH_PARAMS, indirect=["mesh_device", "device_params"]
-)
-@pytest.mark.parametrize("x_row_major", [True, False], ids=["x_rm", "x_tile"])
-def test_single_routed_expert_models(
-    mesh_device, device_params, num_tokens: int, emb_dim: int, hidden_dim: int, x_row_major: bool
-):
-    run_single_routed_expert(mesh_device, device_params, num_tokens, emb_dim, hidden_dim, x_row_major=x_row_major)
+# All active-token sweeps run against a fixed 5K allocated buffer: 5120 dispatch rows with only the
+# first `active_tokens` holding real data; the rest is zero padding.
+_ISL_ALLOCATED_TOKENS = 5120
+
+# Functional sweep: a few active-token counts across every model, on both WH and BH. Two off-tile-
+# boundary primes (one below 256, one above 3K) plus a round 1K.
+_ISL_FUNCTIONAL_SWEEP = [251, 1024, 3001]
+
+# Exhaustive sweep: the full fill range from empty to fully-packed, restricted to the two largest
+# models to keep runtime bounded. Blackhole-only, since active < allocated exercises device-side
+# count-aware sparsity (skipping matmuls on the inactive padding rows), which is a Blackhole feature.
+_ISL_EXHAUSTIVE_SWEEP = [0, 128, 256, 512, 1024, 2048, 4096, 5120]
+_ISL_EXHAUSTIVE_MODELS = ("kimi_k26", "glm_51")
 
 
-# (allocated_tokens, active_tokens, id) sweep for the count-aware sparsity test, applied per
-# model with that model's (emb_dim, hidden_dim). The alloc/active pairs are model-independent.
-_FAKED_SWEEP = [
-    (1024, 0, "1k-alloc-0k-active"),
-    (25600, 4096, "25k-alloc-4k-active"),
-]
-
-
-def single_routed_expert_faked_params():
-    """Build the per-model (allocated_tokens, active_tokens, emb_dim, hidden_dim) parametrization
-    over _FAKED_SWEEP. Reuses SINGLE_EXPERT_MODELS, so non-baseline models stay gated behind the
-    extended_model marker exactly as the separate tests were."""
+def _isl_params(active_sweep, only_models=None):
+    """Build the per-model (allocated_tokens, active_tokens, emb_dim, hidden_dim) parametrization over
+    `active_sweep`, all against the fixed _ISL_ALLOCATED_TOKENS buffer. Reuses SINGLE_EXPERT_MODELS so
+    non-baseline models stay gated behind the extended_model marker; `only_models` restricts to a
+    subset of model names."""
     params = []
     for name, config, extended in SINGLE_EXPERT_MODELS:
-        for alloc, active, tag in _FAKED_SWEEP:
-            test_id = f"{name}-{tag}"
+        if only_models is not None and name not in only_models:
+            continue
+        for active in active_sweep:
             marks = (pytest.mark.extended_model,) if extended else ()
-            if test_id in _FAKED_XFAIL:
-                marks += (pytest.mark.xfail(reason=_FAKED_XFAIL[test_id], strict=True),)
             params.append(
                 pytest.param(
-                    alloc,
+                    _ISL_ALLOCATED_TOKENS,
                     active,
                     config.EMB_SIZE,
                     config.MOE_INTERMEDIATE_SIZE,
                     marks=marks,
-                    id=test_id,
+                    id=f"{name}-isl-{active}",
                 )
             )
     return params
 
 
-@pytest.mark.parametrize("allocated_tokens, active_tokens, emb_dim, hidden_dim", single_routed_expert_faked_params())
+@pytest.mark.parametrize("allocated_tokens, active_tokens, emb_dim, hidden_dim", _isl_params(_ISL_FUNCTIONAL_SWEEP))
+@pytest.mark.parametrize(
+    "mesh_device, device_params", SINGLE_CHIP_MESH_PARAMS, indirect=["mesh_device", "device_params"]
+)
+@pytest.mark.parametrize("x_row_major", [True, False], ids=["x_rm", "x_tile"])
+def test_single_routed_expert_functional(
+    mesh_device,
+    device_params,
+    allocated_tokens: int,
+    active_tokens: int,
+    emb_dim: int,
+    hidden_dim: int,
+    x_row_major: bool,
+):
+    run_single_routed_expert(
+        mesh_device,
+        device_params,
+        allocated_tokens,
+        emb_dim,
+        hidden_dim,
+        active_tokens=active_tokens,
+        x_row_major=x_row_major,
+    )
+
+
+@pytest.mark.parametrize(
+    "allocated_tokens, active_tokens, emb_dim, hidden_dim",
+    _isl_params(_ISL_EXHAUSTIVE_SWEEP, only_models=_ISL_EXHAUSTIVE_MODELS),
+)
 @pytest.mark.parametrize(
     "mesh_device, device_params", SINGLE_CHIP_MESH_PARAMS, indirect=["mesh_device", "device_params"]
 )
 @pytest.mark.parametrize("x_row_major", [True, False], ids=["x_rm", "x_tile"])
 @pytest.mark.skipif(not is_blackhole(), reason="device-side count-aware sparsity is Blackhole-only")
-def test_single_routed_expert_faked_token_count_models(
+def test_single_routed_expert_isl_sweep(
     mesh_device,
     device_params,
     allocated_tokens: int,

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert.py
@@ -180,12 +180,9 @@ SINGLE_EXPERT_MODELS = [
 # _xfail_blackhole (these cases pass on other arches, where an unconditional strict xfail would turn
 # CI red on XPASS). Each key is a space-separated set of id tokens that must ALL appear in the param
 # id, so a case can be scoped by any combination of layout ("x_tile"/"x_rm") and model/isl id.
-#   - gptoss_120b on the TILE x layout: the factory picks an in0_block_w_gu that does not divide
-#     K_gate_tiles for gptoss dims (K_gate_tiles % in0_block_w_gu == 0 TT_FATAL). The ROW_MAJOR x
-#     layout passes, so scope the xfail to x_tile only.
-_XFAIL = {
-    "x_tile gptoss_120b": "gptoss_120b K_gate tiling: factory picks in0_block_w_gu that does not divide K_gate_tiles on the TILE x layout (unified_routed_expert_ffn_program_factory.cpp:404)",
-}
+# Empty: the program factory now snaps in0_block_w_gu to a divisor of K_gate_tiles on every path
+# (not just when the L1 guard fires), so the prior gptoss_120b TILE-layout K_gate failure is fixed.
+_XFAIL = {}
 
 
 @pytest.fixture(autouse=True)

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert.py
@@ -37,8 +37,7 @@ SINGLE_CHIP_MESH_PARAMS = [
 
 
 def run_single_routed_expert(
-    mesh_device,
-    device_params,
+    device,
     allocated_tokens: int,
     emb_dim: int,
     hidden_dim: int,
@@ -64,7 +63,7 @@ def run_single_routed_expert(
     signpost(f"SingleRoutedExpert {allocated_tokens=} {active_tokens=} {emb_dim=} {hidden_dim=}")
 
     logger.debug(f"Testing single routed expert: {allocated_tokens=}, {active_tokens=}, {emb_dim=}, {hidden_dim=}")
-    logger.debug(f"Mesh: {mesh_device.shape}, num_devices={mesh_device.get_num_devices()}")
+    logger.debug(f"Mesh: {device.shape}, num_devices={device.get_num_devices()}")
 
     # Create random weights
     torch.manual_seed(42)
@@ -96,9 +95,9 @@ def run_single_routed_expert(
     # each variation drives its real device path.
     tt_input = ttnn.from_torch(
         torch_input,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        mesh_mapper=ttnn.ReplicateTensorToMesh(device),
         layout=ttnn.ROW_MAJOR_LAYOUT if x_row_major else ttnn.TILE_LAYOUT,
-        device=mesh_device,
+        device=device,
         dtype=ttnn.bfloat16 if x_row_major else ttnn.bfloat8_b,
     )
     logger.debug(f"TTNN input shape: {tt_input.shape}")
@@ -111,7 +110,7 @@ def run_single_routed_expert(
         return ttnn.from_torch(
             torch.tensor(values, dtype=torch.int32),
             layout=ttnn.ROW_MAJOR_LAYOUT,
-            device=mesh_device,
+            device=device,
             dtype=ttnn.uint32,
         )
 
@@ -122,7 +121,7 @@ def run_single_routed_expert(
     # Create TtRoutedExpert
     logger.debug("Creating TtRoutedExpert...")
     tt_expert = TtRoutedExpert(
-        mesh_device=mesh_device,
+        mesh_device=device,
         experts_per_chip=experts_per_chip,
         global_expert_idx_table=global_expert_idx_tt,
         emb_dim=emb_dim,
@@ -143,7 +142,7 @@ def run_single_routed_expert(
     # ConcatMeshToTensor(dim=0) with 1 slice is a no-op that returns the tensor.
     tt_output_torch = ttnn.to_torch(
         tt_output,
-        mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0),
+        mesh_composer=ttnn.ConcatMeshToTensor(device, dim=0),
     )
     logger.debug(f"TTNN output (torch) shape: {tt_output_torch.shape}")
     tt_output_active = tt_output_torch[:active_tokens]
@@ -241,13 +240,9 @@ def _isl_params(active_sweep, only_models=None):
 
 
 @pytest.mark.parametrize("allocated_tokens, active_tokens, emb_dim, hidden_dim", _isl_params(_ISL_FUNCTIONAL_SWEEP))
-@pytest.mark.parametrize(
-    "mesh_device, device_params", SINGLE_CHIP_MESH_PARAMS, indirect=["mesh_device", "device_params"]
-)
 @pytest.mark.parametrize("x_row_major", [True, False], ids=["x_rm", "x_tile"])
 def test_single_routed_expert_functional(
-    mesh_device,
-    device_params,
+    device,
     allocated_tokens: int,
     active_tokens: int,
     emb_dim: int,
@@ -255,8 +250,7 @@ def test_single_routed_expert_functional(
     x_row_major: bool,
 ):
     run_single_routed_expert(
-        mesh_device,
-        device_params,
+        device,
         allocated_tokens,
         emb_dim,
         hidden_dim,
@@ -269,14 +263,10 @@ def test_single_routed_expert_functional(
     "allocated_tokens, active_tokens, emb_dim, hidden_dim",
     _isl_params(_ISL_EXHAUSTIVE_SWEEP, only_models=_ISL_EXHAUSTIVE_MODELS),
 )
-@pytest.mark.parametrize(
-    "mesh_device, device_params", SINGLE_CHIP_MESH_PARAMS, indirect=["mesh_device", "device_params"]
-)
 @pytest.mark.parametrize("x_row_major", [True, False], ids=["x_rm", "x_tile"])
 @pytest.mark.skipif(not is_blackhole(), reason="device-side count-aware sparsity is Blackhole-only")
 def test_single_routed_expert_isl_sweep(
-    mesh_device,
-    device_params,
+    device,
     allocated_tokens: int,
     active_tokens: int,
     emb_dim: int,
@@ -284,8 +274,7 @@ def test_single_routed_expert_isl_sweep(
     x_row_major: bool,
 ):
     run_single_routed_expert(
-        mesh_device,
-        device_params,
+        device,
         allocated_tokens,
         emb_dim,
         hidden_dim,

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert_perf.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert_perf.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Device performance test for the unified routed expert FFN op.
+
+Perf counterpart to ``test_single_routed_expert_isl_sweep``: for kimi and glm
+across the exhaustive ISL (active-token) sweep against the fixed 5K allocated
+buffer, spawn one worker per (model, active) that runs ``run_single_routed_expert``
+on device under Tracy, and assert the ``UnifiedRoutedExpertFfnDeviceOperation``
+device time against a per-case baseline. One op per worker, so a regression
+localizes to the FFN kernel.
+
+The ROW_MAJOR x layout (``x_rm``) is measured — the Blackhole fused-tilize
+production fast path (x tilized + bf8-packed inside the op, fresh output).
+
+Baselines in ``_EXPECTED_NS`` were MEASURED LOCALLY on a BH board on 2026-07-20
+and must be RECALIBRATED on the perf CI runner: device times are DDR-speed
+dependent, so the canonical baselines have to come from the CI runner the check
+actually runs on (mirrors the dated recalibration comments in the sibling
+``test_moe_perf`` / ``test_dispatch_combine_perf``).
+"""
+
+import pytest
+
+from models.demos.deepseek_v3_d_p.utils.perf_utils import run_model_device_perf_test_per_op
+from models.demos.deepseek_v3_d_p.utils.smbus_telemetry import is_p150
+from tests.ttnn.nightly.unit_tests.operations.experimental.deepseek_prefill.test_single_routed_expert import (
+    _ISL_EXHAUSTIVE_MODELS,
+    _ISL_EXHAUSTIVE_SWEEP,
+)
+
+# Device-op code emitted by the routed expert FFN; the harness sums the rows whose
+# OP CODE contains this substring, so incidental setup ops are excluded.
+_OP_CODE = "UnifiedRoutedExpertFfnDeviceOperation"
+
+# Worker that runs the op on device (its signposts + the op launch land in the
+# Tracy CSV the harness reads back).
+_WORKER = (
+    "tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/"
+    "test_single_routed_expert.py::test_single_routed_expert_isl_sweep"
+)
+_LAYOUT_ID = "x_rm"  # Blackhole fused-tilize production fast path (ROW_MAJOR bf16 input)
+
+# Per-(model, active) UnifiedRoutedExpertFfnDeviceOperation device time in ns, measured
+# on a Blackhole P150. Recalibrate on the perf CI runner (device times are HW-dependent).
+_EXPECTED_NS: dict[tuple[str, int], int] = {
+    ("kimi_k26", 0): 3_968,
+    ("kimi_k26", 128): 685_713,
+    ("kimi_k26", 256): 690_787,
+    ("kimi_k26", 512): 714_651,
+    ("kimi_k26", 1024): 709_885,
+    ("kimi_k26", 2048): 1_270_645,
+    ("kimi_k26", 4096): 1_896_629,
+    ("kimi_k26", 5120): 1_932_320,
+    ("glm_51", 0): 3_947,
+    ("glm_51", 128): 672_022,
+    ("glm_51", 256): 669_477,
+    ("glm_51", 512): 673_966,
+    ("glm_51", 1024): 674_371,
+    ("glm_51", 2048): 1_166_843,
+    ("glm_51", 4096): 1_705_639,
+    ("glm_51", 5120): 1_745_545,
+}
+
+_MARGIN = 0.03
+
+
+def _k_filter(model: str, active: int) -> str:
+    """Pin exactly one ``test_single_routed_expert_isl_sweep`` case: model + isl +
+    layout. Disambiguate substring collisions in the pytest ``-k`` match — e.g.
+    ``isl-512`` is a substring of ``isl-5120`` — by excluding any other sweep value
+    whose id contains this one."""
+    parts = [f"{model}-isl-{active}", _LAYOUT_ID]
+    parts += [
+        f"not isl-{other}" for other in _ISL_EXHAUSTIVE_SWEEP if other != active and f"isl-{active}" in f"isl-{other}"
+    ]
+    return " and ".join(parts)
+
+
+def _perf_params():
+    params = []
+    for model in _ISL_EXHAUSTIVE_MODELS:
+        for active in _ISL_EXHAUSTIVE_SWEEP:
+            command = f"pytest {_WORKER} -k '{_k_filter(model, active)}'"
+            params.append(
+                pytest.param(
+                    command,
+                    {_OP_CODE: _EXPECTED_NS[(model, active)]},
+                    f"single_routed_expert_{model}_isl{active}_{_LAYOUT_ID}",
+                    id=f"{model}-isl-{active}",
+                )
+            )
+    return params
+
+
+@pytest.mark.parametrize("command, expected_per_op, model_name", _perf_params())
+@pytest.mark.models_device_performance_bare_metal
+# Gate to P150 via tt-smi board telemetry (SMBus). This also skips Wormhole and any
+# other board. Do NOT use ttnn.cluster.get_cluster_type() here: it opens and locks the
+# chip, and since skipif is evaluated at collection time in the parent process, the
+# spawned Tracy worker then deadlocks on CHIP_IN_USE. is_p150() reads tt-smi only, so
+# it takes no device lock.
+@pytest.mark.skipif(not is_p150(), reason="perf baselines are P150-specific; skip on any other board")
+def test_single_routed_expert_perf(command, expected_per_op, model_name):
+    run_model_device_perf_test_per_op(
+        command=command,
+        expected_per_op=expected_per_op,
+        subdir="prefill_single_routed_expert",
+        model_name=model_name,
+        margin=_MARGIN,
+        comments=model_name,
+    )

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
@@ -235,6 +235,20 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         in0_block_w_gu = best_ibw;
     }
 
+    // in0_block_w_gu (the gate/up K-loop block width) must divide K_gate_tiles.
+    // The short_seq picker above already restricts itself to divisors, but the
+    // general 2D path leaves the default 16 unchanged — valid only when emb is a
+    // multiple of 512 (=> K_gate_tiles a multiple of 16). Models with a different
+    // emb (e.g. GPT-OSS 120B: emb 2880 => K_gate_tiles 90) need the default
+    // snapped down to the largest divisor of K_gate_tiles that does not exceed
+    // it. No-op for short_seq and for every shipped 512-multiple emb; the L1
+    // guard below may narrow it further. Previously divisor-snapping only ran as
+    // a side effect of the L1-overflow guard, so non-512 emb slipped through on
+    // the TILE x layout — whose smaller footprint fits at 16 and skips the guard.
+    while (in0_block_w_gu > 1 && (K_gate_tiles % in0_block_w_gu) != 0) {
+        --in0_block_w_gu;
+    }
+
     const uint32_t per_core_N_gu = (N_gate_tiles_full + GRID_X - 1) / GRID_X;
     const uint32_t per_core_N_d = (N_down_tiles_full + GRID_X - 1) / GRID_X;
     const uint32_t N_gate_tiles_padded = per_core_N_gu * GRID_X;
@@ -413,9 +427,9 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         chunk_M_tiles = per_core_M * GRID_Y;
     }
 
-    // in0_block_w_gu must divide K_gate_tiles (the gate/up K-loop bound); holds
-    // for every value the guard above picks and for the default 16 on all
-    // shipped models (emb a multiple of 512 => K_gate_tiles a multiple of 16).
+    // in0_block_w_gu must divide K_gate_tiles (the gate/up K-loop bound); the
+    // divisor-snap after the short_seq picker and the L1 guard above both
+    // preserve this, so this is a defensive invariant check.
     TT_FATAL(
         K_gate_tiles % in0_block_w_gu == 0,
         "K_gate_tiles ({}) must be divisible by in0_block_w_gu ({})",


### PR DESCRIPTION
## Summary

**Test refactor**
- Collapse `run_single_routed_expert` and `run_single_routed_expert_faked_token_count` into a single `run_single_routed_expert` helper: allocated/active token counts are set explicitly, and `active_tokens` defaults to `allocated_tokens` when `None`.
- Replace `test_single_routed_expert_models` / `test_single_routed_expert_faked_token_count_models` with two ISL (active-token) sweeps against a fixed 5K (5120-row) allocated buffer:
  - `test_single_routed_expert_functional`: all models at active `251 / 1024 / 3001` (two off-tile-boundary primes + 1K), on WH and BH.
  - `test_single_routed_expert_isl_sweep`: kimi/glm across the full `0..5120` fill range, Blackhole-only (device-side count-aware sparsity).
- Keep the strict-xfail registry (token-subset matched so a case can be scoped by layout); currently empty.
- Switch the functional / isl_sweep tests (and the shared `run_single_routed_expert` helper) from the `mesh_device` + `device_params` parametrize to the plain function-scoped `device` fixture — single-chip test, so the 1-device mesh indirection added nothing, and `device` restores the default device on teardown.

**Factory fix — `in0_block_w_gu` divisor of `K_gate_tiles` on all paths**
- The unified routed expert factory only guaranteed `in0_block_w_gu` divides `K_gate_tiles` on the short_seq path and as a side effect of the L1-overflow guard. The general 2D path kept the hardcoded default `16`, valid only when emb is a multiple of 512 (=> `K_gate_tiles` a multiple of 16).
- **Regression from `97a2898fc21` (#49744, "Fuse tilize with unified routed expert for Blackhole"):** gptoss_120b (emb 2880 => `K_gate_tiles` 90) hit `K_gate_tiles (90) must be divisible by in0_block_w_gu (16)` on the **TILE x layout**. ROW_MAJOR passed only because its larger L1 footprint tripped the L1 guard (which snaps to a divisor); the TILE path fit at 16, skipped that guard, and the invalid default survived.
- Fix: snap `in0_block_w_gu` down to the largest divisor of `K_gate_tiles` not exceeding its requested value, right after the short_seq/general paths converge. No-op for short_seq and every shipped 512-multiple-emb model; gptoss now uses 15.

**Device-perf test**
- `test_single_routed_expert_perf`: perf counterpart to the ISL sweep for kimi/glm across the exhaustive `0..5120` sweep. One worker per (model, active) runs the FFN on device under Tracy (ROW_MAJOR x — the Blackhole fused-tilize production path) and asserts `UnifiedRoutedExpertFfnDeviceOperation` device time vs a per-case baseline (3% margin; measured on P150, recalibrate on the perf CI runner).
- Tagged `@pytest.mark.models_device_performance_bare_metal`, so the experimental `-k "not performance"` run **skips it** (the marker keyword contains "performance") — it does not run in this PR's CI. It spawns a Tracy subprocess that needs exclusive device access; making it run inside the shared L2-nightly experimental process without deadlocking on `CHIP_IN_USE` is handled in the stacked follow-up **#50850** (new `ttnn.ReleaseOwnership()` binding + fixture).
- Gated to P150 via a new `is_p150()` in `smbus_telemetry.py` that reads board type from `tt-smi` (SMBus). This avoids `ttnn.cluster.get_cluster_type()`, which opens/locks the compute device — as a `skipif` it runs at collection time and would deadlock the spawned Tracy worker on `CHIP_IN_USE`.

## Test plan
- L2 nightly, experimental ops (WH + BH) — covers the functional / isl_sweep tests. The perf test is device-perf-tagged and skipped in this run; it is exercised via the stacked **#50850**.
- Local Blackhole: full `test_single_routed_expert` suite passes (functional all models + kimi/glm exhaustive); `test_single_routed_expert_perf` 16 cases pass at 3% (run directly, bypassing the tag).

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mbezulj/refactor_single_routed_expert_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mbezulj/refactor_single_routed_expert_test) L2 Nightly (experimental) - MMIO failed - routed expert tests passed

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mbezulj/refactor_single_routed_expert_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mbezulj/refactor_single_routed_expert_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mbezulj/refactor_single_routed_expert_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mbezulj/refactor_single_routed_expert_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mbezulj/refactor_single_routed_expert_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mbezulj/refactor_single_routed_expert_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mbezulj/refactor_single_routed_expert_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mbezulj/refactor_single_routed_expert_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mbezulj/refactor_single_routed_expert_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mbezulj/refactor_single_routed_expert_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mbezulj/refactor_single_routed_expert_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mbezulj/refactor_single_routed_expert_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mbezulj/refactor_single_routed_expert_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mbezulj/refactor_single_routed_expert_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mbezulj/refactor_single_routed_expert_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mbezulj/refactor_single_routed_expert_test)
