### PR TITLE
[Feature] Allow explicit `TT_METAL_DRAM_BACKED_CQ` override on Quasar simulator

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -1063,6 +1063,16 @@ inline bool is_quasar_sim() {
            tt::tt_metal::MetalContext::instance().hal().get_arch() == tt::ARCH::QUASAR;
 }
 
+// Honour an explicit TT_METAL_DRAM_BACKED_CQ value, otherwise retain the DRAM-backed default required by the Quasar
+// simulator.
+inline bool is_quasar_cq_dram_backed() {
+    if (!is_quasar_sim()) {
+        return false;
+    }
+    const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+    return !rtoptions.is_dram_backed_cq_specified() || rtoptions.get_dram_backed_cq();
+}
+
 // Wrapper template that marks any base fixture as the Quasar-simulator-only variant; the constructor
 // sets quasar_simulator_variant_ before gtest's SetUp() reads it.
 template <class FDFixture>
@@ -1134,9 +1144,17 @@ protected:
         // Initialize common pointers
         auto& mcq = mesh_device_->mesh_command_queue();
         fdcq_ = &dynamic_cast<distributed::FDMeshCommandQueue&>(mcq);
-        // mgr_ = &FDMeshCQTestAccessor::sysmem(*fdcq_);
         device_ = mesh_device_->get_devices()[0];
         mgr_ = &device_->sysmem_manager();  // Use Chip 0's SystemMemoryManager
+
+        if (Common::is_quasar_sim()) {
+            TT_FATAL(
+                mgr_->is_dram_backed() == Common::is_quasar_cq_dram_backed(),
+                "Quasar CQ backing configuration mismatch: SystemMemoryManager reports DRAM-backed={}, "
+                "but the test policy expects DRAM-backed={}",
+                mgr_->is_dram_backed(),
+                Common::is_quasar_cq_dram_backed());
+        }
 
         // Initialize common HW properties
         host_alignment_ = tt_metal::MetalContext::instance().hal().get_alignment(tt_metal::HalMemType::HOST);
@@ -1175,18 +1193,16 @@ protected:
     }
 
     // SD (slow dispatch) issue + completion queue sizes. Must fit in one device's hugepage slot
-    // (MAX_DEV_CHANNEL_SIZE = 256 MB) on WH/BH; an even 50/50 split gives 128 MB each. On Quasar simulation host
-    // hugepages are not available, so command queues must be stored in DRAM, and only 64 MB of physical DRAM space
-    // (QUASAR_SIMULATION_PHYSICAL_DRAM_SIZE) is available even though the bank size is 1 GB. The remaining addresses
-    // alias this physical space. The SD command queue must therefore fit in a single 64-MB window, so each half is
-    // capped at 8 MB on the Quasar simulator.
+    // (MAX_DEV_CHANNEL_SIZE = 256 MB) on WH/BH; an even 50/50 split gives 128 MB each. Quasar's default
+    // DRAM-backed policy uses fixed 8 MB queues in its 64 MB physical-DRAM window. An explicit
+    // TT_METAL_DRAM_BACKED_CQ=0 uses the same mapped-host split as WH/BH.
     uint32_t sd_issue_queue_size() const {
-        return Common::is_quasar_sim() ? QUASAR_SIMULATION_ISSUE_QUEUE_SIZE
-                                       : DispatchSettings::MAX_DEV_CHANNEL_SIZE / 2;
+        return Common::is_quasar_cq_dram_backed() ? QUASAR_SIMULATION_ISSUE_QUEUE_SIZE
+                                                  : DispatchSettings::MAX_DEV_CHANNEL_SIZE / 2;
     }
     uint32_t sd_completion_queue_size() const {
-        return Common::is_quasar_sim() ? QUASAR_SIMULATION_COMPLETION_QUEUE_SIZE
-                                       : DispatchSettings::MAX_DEV_CHANNEL_SIZE / 2;
+        return Common::is_quasar_cq_dram_backed() ? QUASAR_SIMULATION_COMPLETION_QUEUE_SIZE
+                                                  : DispatchSettings::MAX_DEV_CHANNEL_SIZE / 2;
     }
 
     // Helper function that polls completion queue until expected data is written into by dispatcher
@@ -1353,7 +1369,7 @@ protected:
         const std::chrono::duration<double> elapsed = end - start;
         log_info(tt::LogTest, "Ran in {:f} ms (for {} iterations)", elapsed.count() * 1000.0, num_iterations);
 
-        // On the Quasar simulator the completion queue is DRAM-backed; sync the host staging mirror before validating.
+        // DRAM-backed Quasar CQs require a host staging-buffer refresh before validation.
         this->refresh_completion_data();
 
         // Validate results
@@ -1398,8 +1414,11 @@ inline std::map<std::string, std::string> make_sd_dispatch_defines(
     const auto upstream_virtual = device_->virtual_noc0_coordinate(upstream_noc, phys_spoof);
     const auto downstream_virtual = device_->virtual_noc0_coordinate(tt_metal::NOC::NOC_0, CoreCoord{0, 0});
 
+    const bool cq_dram_backed = Common::is_quasar_cq_dram_backed();
+    const std::string is_cq_dram_backed = cq_dram_backed ? "1" : "0";
+
     return {
-        {"IS_CQ_DRAM_BACKED", Common::is_quasar_sim() ? "1" : "0"},
+        {"IS_CQ_DRAM_BACKED", is_cq_dram_backed},
         {"DRAM_BACKED_CQ_BANK_ID", "0"},
         {"DISPATCH_CB_BASE", std::to_string(dispatch_cb_base)},
         {"DISPATCH_CB_LOG_PAGE_SIZE", std::to_string(DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE)},
@@ -1525,6 +1544,10 @@ inline std::map<std::string, std::string> make_sd_prefetch_defines(
     const CoreCoord& phys_dispatch) {
     const auto my_virtual = device->virtual_noc0_coordinate(tt_metal::NOC::NOC_0, phys_prefetch);
     const auto downstream_virtual = device->virtual_noc0_coordinate(tt_metal::NOC::NOC_0, phys_dispatch);
+
+    const bool cq_dram_backed = Common::is_quasar_cq_dram_backed();
+    const std::string is_cq_dram_backed = cq_dram_backed ? "1" : "0";
+
     return {
         {"MY_NOC_X", std::to_string(my_virtual.x)},
         {"MY_NOC_Y", std::to_string(my_virtual.y)},
@@ -1543,7 +1566,7 @@ inline std::map<std::string, std::string> make_sd_prefetch_defines(
         // these share a slot id; on Quasar (prefetch+dispatch same core) they are distinct slots.
         {"MY_DOWNSTREAM_CB_SEM_ID", std::to_string(dispatch_cb_sem_id)},
         {"DOWNSTREAM_CB_SEM_ID", std::to_string(downstream_cb_sem_id)},
-        {"IS_CQ_DRAM_BACKED", Common::is_quasar_sim() ? "1" : "0"},
+        {"IS_CQ_DRAM_BACKED", is_cq_dram_backed},
         {"DRAM_BACKED_CQ_BANK_ID", "0"},
         {"PCIE_BASE", std::to_string(pcie_base)},
         {"PCIE_SIZE", std::to_string(pcie_size)},

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -777,7 +777,7 @@ private:
         const std::chrono::duration<double> elapsed = end - start;
         log_info(tt::LogTest, "Ran in {:.3f} ms (for {} iterations)", elapsed.count() * 1000.0, num_iterations);
 
-        // On the Quasar simulator the completion queue is DRAM-backed; sync the host staging mirror before validating.
+        // DRAM-backed Quasar CQs require a host staging-buffer refresh before validation.
         fixture.refresh_completion_data();
 
         // Validate results
@@ -2647,9 +2647,8 @@ public:
 
         this->init_params(this->GetParam());
 
-        // On Quasar simulator, the issue queue is fixed at QUASAR_SIMULATION_ISSUE_QUEUE_BASE. If the exec_buf base
-        // address would overlap the issue queue, skip the test rather than overrun the CQ region.
-        if (Common::is_quasar_sim() &&
+        // DRAM-backed Quasar queues use a fixed issue region. Skip only when the exec buffer would collide with it.
+        if (Common::is_quasar_cq_dram_backed() &&
             this->compute_exec_buf_base_addr() >= Common::QUASAR_SIMULATION_ISSUE_QUEUE_BASE) {
             GTEST_SKIP() << "exec_buf base " << this->compute_exec_buf_base_addr()
                          << " reaches the Quasar simulator issue queue at "
@@ -2707,13 +2706,11 @@ public:
         const uint32_t dispatch_telemetry_addr =
             memmap.get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_TELEMETRY, cq_id);
 
-        // Hugepage addressing
-        // WH/BH stage commands in the PCIe hugepage (same region the FD runtime uses for the issue
-        // queue; safe since SD mode never runs the FD runtime concurrently). Quasar simulator has no PCIe
-        // hugepage — commands are staged in DRAM at QUASAR_SIMULATION_ISSUE_QUEUE_BASE instead.
+        // Queue backing. WH/BH and Quasar with TT_METAL_DRAM_BACKED_CQ=0 stage commands in the mapped
+        // host region. DRAM-backed Quasar uses the fixed physical-DRAM queue window instead.
         uint32_t dev_hugepage_base = 0;
         void* host_hugepage_base = nullptr;
-        if (!Common::is_quasar_sim()) {
+        if (!Common::is_quasar_cq_dram_backed()) {
             dev_hugepage_base = memmap.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
             const ChipId mmio_id =
                 tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(this->device_->id());
@@ -2761,14 +2758,14 @@ public:
 
         const uint32_t host_align = tt_metal::MetalContext::instance().hal().get_alignment(tt_metal::HalMemType::HOST);
 
-        // write_prefetcher_cmd: streaming-store cmd to hugepage (WH/BH) or DRAM (Quasar simulator), then write one
-        // FetchQ entry via TLB. cmd_size_bytes must be a multiple of 64 (host alignment) and cmd_size_entry is the
-        // pre-computed FetchQ value (may have MSB stall flag set for exec_buf).
+        // write_prefetcher_cmd stages commands in the configured queue backing, then writes one FetchQ entry via TLB.
+        // cmd_size_bytes must be a multiple of 64 (host alignment) and cmd_size_entry is the pre-computed FetchQ
+        // value (which may have the MSB stall flag set for exec_buf).
         auto write_prefetcher_cmd = [&](const uint32_t* src, uint32_t cmd_size_bytes, uint32_t cmd_size_entry) {
-            if (Common::is_quasar_sim()) {
+            if (Common::is_quasar_cq_dram_backed()) {
                 TT_FATAL(
-                    dram_write_offset + cmd_size_bytes <= Common::QUASAR_SIMULATION_ISSUE_QUEUE_SIZE,
-                    "SD prefetch: command stream exceeds QUASAR_SIMULATION_ISSUE_QUEUE_SIZE");
+                    dram_write_offset + cmd_size_bytes <= this->sd_issue_queue_size(),
+                    "SD prefetch: command stream exceeds DRAM-backed issue queue");
                 tt::tt_metal::detail::WriteToDeviceDRAMChannel(
                     this->device_,
                     0,
@@ -2819,16 +2816,15 @@ public:
         write_cmd(CommandBuilder::build_dispatch_terminate(/*include_dispatch_s*/ false));
         write_cmd(CommandBuilder::build_prefetch_terminate());
 
-        if (Common::is_quasar_sim()) {
+        if (Common::is_quasar_cq_dram_backed()) {
             // Flush all DRAM command writes so the kernel sees them when it starts.
             cluster.dram_barrier(this->device_->id());
             // Pre-fill the completion DRAM with the dirty pattern so page padding matches
             // HOST_DATA_DIRTY_PATTERN validation in DeviceData::validate().
             static constexpr uint32_t kChunkBytes = 64 * 1024;
             std::vector<uint32_t> chunk(kChunkBytes / sizeof(uint32_t), this->HOST_DATA_DIRTY_PATTERN);
-            for (uint32_t offset = 0; offset < Common::QUASAR_SIMULATION_COMPLETION_QUEUE_SIZE; offset += kChunkBytes) {
-                const uint32_t chunk_bytes =
-                    std::min(kChunkBytes, Common::QUASAR_SIMULATION_COMPLETION_QUEUE_SIZE - offset);
+            for (uint32_t offset = 0; offset < this->sd_completion_queue_size(); offset += kChunkBytes) {
+                const uint32_t chunk_bytes = std::min(kChunkBytes, this->sd_completion_queue_size() - offset);
                 tt::tt_metal::detail::WriteToDeviceDRAMChannel(
                     this->device_,
                     0,
@@ -2950,9 +2946,8 @@ public:
         tt_metal::detail::LaunchProgram(this->device_, program);
         // Ensure host CPU sees any PCIe-written completion queue data before validating.
         tt_driver_atomics::mfence();
-        // On the Quasar simulator the completion queue lives in DRAM (host hugepages are unavailable);
-        // read it back into the host staging buffer before validate() (which reads from
-        // get_completion_queue_buffer()).
+        // DRAM-backed Quasar CQs need a staging-buffer readback before validation; host-backed queues are
+        // directly readable.
         this->refresh_completion_data();
         EXPECT_TRUE(device_data.validate(this->device_)) << "SD prefetch test failed validation";
     }
@@ -2991,12 +2986,11 @@ public:
     // we set up ourselves (dev_hugepage_base + sd_issue_queue_size()), not to a
     // runtime-managed FDMeshCommandQueue completion queue.
     //
-    // WH/BH: points into the host-mapped hugepage at dev_hugepage_base + issue_queue_size.
-    // Quasar simulator: points into a host-side staging buffer; refresh_completion_data() fills it from DRAM at
-    // QUASAR_SIMULATION_COMPLETION_QUEUE_BASE before validate() is called.
+    // Host-backed queues point into the mapped host region at dev_hugepage_base + issue_queue_size.
+    // DRAM-backed Quasar queues use a host-side staging buffer populated before validation.
     void* get_completion_queue_buffer() override {
-        if (Common::is_quasar_sim()) {
-            quasar_completion_buf_.resize(Common::QUASAR_SIMULATION_COMPLETION_QUEUE_SIZE);
+        if (Common::is_quasar_cq_dram_backed()) {
+            quasar_completion_buf_.resize(this->sd_completion_queue_size());
             return quasar_completion_buf_.data();
         }
         const auto& memmap = Common::sd_dispatch_mem_map(device_);
@@ -3013,9 +3007,9 @@ public:
     uint32_t get_completion_queue_buffer_size() override { return this->sd_completion_queue_size(); }
 
     void refresh_completion_data() override {
-        if (Common::is_quasar_sim()) {
-            // Read the dispatch kernel's DRAM completion writes into the host staging buffer so
-            // device_data.validate() sees the correct data.
+        if (Common::is_quasar_cq_dram_backed()) {
+            // Read the dispatch kernel's DRAM completion writes into the host staging buffer so device_data.validate()
+            // sees the correct data.
             const auto& memmap = Common::sd_dispatch_mem_map(device_);
             const CoreCoord phys_disp = Common::sd_virtual_core(this->device_, Common::dispatch_core(this->device_));
             const tt_cxy_pair dispatch_cxy(this->device_->id(), phys_disp);
@@ -3036,10 +3030,10 @@ public:
             }
             const uint32_t bytes_written = (wr_ptr_16B - completion_base_16B) * 16;
             TT_FATAL(
-                bytes_written <= Common::QUASAR_SIMULATION_COMPLETION_QUEUE_SIZE,
+                bytes_written <= this->sd_completion_queue_size(),
                 "Quasar simulator completion readback exceeds queue size ({} > {})",
                 bytes_written,
-                Common::QUASAR_SIMULATION_COMPLETION_QUEUE_SIZE);
+                this->sd_completion_queue_size());
 
             tt::tt_metal::detail::ReadFromDeviceDRAMChannel(
                 this->device_,
@@ -3064,9 +3058,14 @@ class PrefetcherLinearPackedReadQuasarSimulatorTestFixture
     : public Common::QuasarSimulatorVariant<PrefetcherLinearPackedReadTestFixture> {};
 class PrefetcherHostQuasarSimulatorTestFixture : public Common::QuasarSimulatorVariant<PrefetcherHostTestFixture> {
 public:
-    // On the Quasar simulator the completion queue is DRAM-backed. Validate against a host-side staging
-    // buffer that refresh_completion_data() fills from DRAM before validate().
+    // On the Quasar simulator the completion queue is DRAM-backed by default (no host hugepages). Validate
+    // against a host-side staging buffer that refresh_completion_data() fills from DRAM before validate().
+    // An explicit TT_METAL_DRAM_BACKED_CQ=0 opts out of DRAM-backed CQs; in that case defer to the base
+    // (hugepage-backed) completion-buffer behavior so the test matches the runtime CQ configuration.
     void* get_completion_queue_buffer() override {
+        if (!mgr_->is_dram_backed()) {
+            return PrefetcherHostTestFixture::get_completion_queue_buffer();
+        }
         quasar_completion_buf_.resize(this->get_completion_queue_buffer_size());
         return quasar_completion_buf_.data();
     }
@@ -3075,6 +3074,9 @@ public:
     // dispatcher writes into. On the Quasar simulator that memory is DRAM, so dirty there too.
     void dirty_host_completion_buffer(void* completion_queue_buffer, uint32_t size_bytes) override {
         PrefetcherHostTestFixture::dirty_host_completion_buffer(completion_queue_buffer, size_bytes);
+        if (!mgr_->is_dram_backed()) {
+            return;
+        }
         std::vector<uint32_t> dirty(size_bytes / sizeof(uint32_t), HOST_DATA_DIRTY_PATTERN);
         tt::tt_metal::MetalContext::instance().get_cluster().write_dram_vec(
             dirty.data(), size_bytes, this->device_->id(), completion_dram_channel(), completion_dram_addr());
@@ -3082,7 +3084,12 @@ public:
 
     // Read the dispatcher-written prefix of the DRAM completion queue into the staging buffer so
     // device_data.validate() sees real data. Padding past the written span keeps its dirty fill.
+    // Skipped when DRAM-backed CQs are explicitly disabled (TT_METAL_DRAM_BACKED_CQ=0); the base
+    // (hugepage-backed) completion buffer is directly readable, so no DRAM readback is needed.
     void refresh_completion_data() override {
+        if (!mgr_->is_dram_backed()) {
+            return;
+        }
         const uint8_t cq_id = fdcq_->id();
         std::atomic<bool> exit_condition{false};
         const uint32_t write_ptr_bytes = (mgr_->completion_queue_wait_front(cq_id, exit_condition) & 0x7fffffff) << 4;

--- a/tt_metal/impl/context/metal_env.cpp
+++ b/tt_metal/impl/context/metal_env.cpp
@@ -176,8 +176,10 @@ void MetalEnvImpl::initialize_base_objects() {
     cluster_ = std::make_unique<Cluster>(*this->rtoptions_);
     this->verify_fw_capabilities();
 
-    if (platform_arch == tt::ARCH::QUASAR && this->rtoptions_->get_fast_dispatch()) {
-        if (this->cluster_->get_target_device_type() == tt::TargetDevice::Simulator) {
+    if (platform_arch == tt::ARCH::QUASAR && this->rtoptions_->get_fast_dispatch() &&
+        this->cluster_->get_target_device_type() == tt::TargetDevice::Simulator) {
+        // An explicit TT_METAL_DRAM_BACKED_CQ setting (including =0) wins over the force-enable.
+        if (!this->rtoptions_->is_dram_backed_cq_specified()) {
             log_info(
                 tt::LogMetal,
                 "Enabling DRAM-backed command queues for Quasar simulator because host hugepages are not available");

--- a/tt_metal/impl/context/metal_env.cpp
+++ b/tt_metal/impl/context/metal_env.cpp
@@ -176,8 +176,7 @@ void MetalEnvImpl::initialize_base_objects() {
     cluster_ = std::make_unique<Cluster>(*this->rtoptions_);
     this->verify_fw_capabilities();
 
-    if (platform_arch == tt::ARCH::QUASAR && this->rtoptions_->get_fast_dispatch() &&
-        this->cluster_->get_target_device_type() == tt::TargetDevice::Simulator) {
+    if (platform_arch == tt::ARCH::QUASAR && this->rtoptions_->get_fast_dispatch()) {
         // An explicit TT_METAL_DRAM_BACKED_CQ setting (including =0) wins over the force-enable.
         if (!this->rtoptions_->is_dram_backed_cq_specified()) {
             log_info(

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -812,7 +812,10 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         // Store command queues in device DRAM.
         // Default: false (use hugepages)
         // Usage: export TT_METAL_DRAM_BACKED_CQ=1
-        case EnvVarID::TT_METAL_DRAM_BACKED_CQ: this->dram_backed_cq = is_env_enabled(value); break;
+        case EnvVarID::TT_METAL_DRAM_BACKED_CQ:
+            this->dram_backed_cq_env_var_set = true;
+            this->dram_backed_cq = is_env_enabled(value);
+            break;
 
         // TT_METAL_SIMULATOR_DIRECT_TENSOR_WRITES
         // Use synchronous direct buffer writes for simulator tensor preloads instead of FD CQ copies.

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -350,6 +350,7 @@ class RunTimeOptions {
     bool force_jit_compile = false;
 
     // Store command queues in device DRAM
+    bool dram_backed_cq_env_var_set = false;
     bool dram_backed_cq = false;
 
     // Bypass FD CQ payload copies for simulator tensor preloads (TT_METAL_SIMULATOR_DIRECT_TENSOR_WRITES=1)
@@ -847,6 +848,7 @@ public:
 
     bool get_numa_based_affinity() const { return numa_based_affinity; }
 
+    bool is_dram_backed_cq_specified() const { return dram_backed_cq_env_var_set; }
     bool get_dram_backed_cq() const { return dram_backed_cq; }
     void set_dram_backed_cq(bool enable) { dram_backed_cq = enable; }
 


### PR DESCRIPTION
### PR Category
Feature

### Summary
This change makes the `TT_METAL_DRAM_BACKED_CQ` environment variable take priority over the Quasar simulator's automatic DRAM-backed command queue override.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_override_dram_backed_cq)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sagarwal/qsr_override_dram_backed_cq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_override_dram_backed_cq)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sagarwal/qsr_override_dram_backed_cq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_override_dram_backed_cq)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:sagarwal/qsr_override_dram_backed_cq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sagarwal/qsr_override_dram_backed_cq)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sagarwal/qsr_override_dram_backed_cq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sagarwal/qsr_override_dram_backed_cq)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sagarwal/qsr_override_dram_backed_cq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sagarwal/qsr_override_dram_backed_cq)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sagarwal/qsr_override_dram_backed_cq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sagarwal/qsr_override_dram_backed_cq)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sagarwal/qsr_override_dram_backed_cq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sagarwal/qsr_override_dram_backed_cq)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sagarwal/qsr_override_dram_backed_cq)