### PR TITLE
[Bug fix] Fix TensixLegallyModifyRTArgsDataMovement CRTA double-set

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -524,9 +524,18 @@ TEST_F(MeshDeviceFixture, TensixLegallyModifyRTArgsDataMovement) {
         auto workload2 =
             unit_tests::runtime_args::initialize_program_data_movement_rta(mesh_device, core_range_set, 4, true);
         auto& program2 = workload2.get_programs().at(device_range);
-        // Set common runtime args, automatically sent to all cores used by kernel.
+        // The kernel declares its common runtime args via the Metal 2.0 spec schema
+        // (num_common_runtime_varargs), so MakeProgramFromSpec has already reserved the CRTA buffer.
+        // Common runtime args can only be set once; write the values into the reserved buffer in place
+        // rather than calling SetCommonRuntimeArgs a second time. Args are sent to all cores used by kernel.
         std::vector<uint32_t> common_runtime_args = {0x30303030, 0x60606060, 0x90909090, 1234};
-        SetCommonRuntimeArgs(program2, 0, common_runtime_args);
+        RuntimeArgsData& common_rt_args = GetCommonRuntimeArgs(program2, 0);
+        TT_FATAL(
+            common_rt_args.size() == common_runtime_args.size(),
+            "Reserved common runtime args size {} does not match expected {}",
+            common_rt_args.size(),
+            common_runtime_args.size());
+        std::copy(common_runtime_args.begin(), common_runtime_args.end(), common_rt_args.data());
         detail::WriteRuntimeArgsToDevice(device, program2);
         distributed::EnqueueMeshWorkload(cq, workload2, false);
         distributed::Finish(cq);


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes the `MeshDeviceFixture.TensixLegallyModifyRTArgsDataMovement` unit test, which has been failing on every runtime `runtime_sd_api` job since #49437 landed (regression window 2026-07-12 → 2026-07-18) with:

```
TT_FATAL @ kernel.cpp:742: set_rt_args.empty()
Illegal Common Runtime Args: Can only set common runtime args once. Get and modify args in place instead.
```

Root cause: the DM kernel in this test declares its common runtime args through the Metal 2.0 spec schema (`num_common_runtime_varargs`). Since #49437, `MakeProgramFromSpec` pre-reserves the CRTA buffer via `reserve_runtime_arg_buffers()` (`set_common_runtime_args(zeros)`). The test then called `SetCommonRuntimeArgs` a second time on the same kernel, which the "set once" guard now rejects. The compute variant (`TensixLegallyModifyRTArgsCompute`) is unaffected because it still uses the legacy `CreateKernel` path with no pre-reservation.

The fix follows the guidance in the assertion itself — get and modify the args in place. The test now writes its values into the already-reserved CRTA buffer via `GetCommonRuntimeArgs` instead of calling `SetCommonRuntimeArgs` twice.

Closes #50419
Closes #50417
Closes #50420

### Notes for reviewers
- Test-only change, scoped to the `SetCommonRuntimeArgs` → in-place-write in `TensixLegallyModifyRTArgsDataMovement`.
- Root cause confirmed by tracing `MakeProgramFromSpec` → `compile_and_allocate` → `reserve_runtime_arg_buffers()` (`program.cpp`), which calls `set_common_runtime_args(zeros)` for any kernel with `num_common_runtime_varargs > 0`; this same "first-time reserve, patch in place after" pattern is what `install_crtas` in `program_run_args.cpp` already relies on.
- The added `TT_FATAL` size check documents the invariant that the reserved buffer already matches the expected arg count (4 words).
- Not built/run locally — no Tenstorrent hardware in the authoring environment. Relying on CI (`runtime_sd_api` on bh_p300 / bh_p150b_civ2 / wh_n150_civ2, the three jobs from the linked issues) to confirm green. Opened as **draft** for that reason.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/fix-crta-double-set-runtime-args-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/fix-crta-double-set-runtime-args-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/fix-crta-double-set-runtime-args-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/fix-crta-double-set-runtime-args-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=riverwu/fix-crta-double-set-runtime-args-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:riverwu/fix-crta-double-set-runtime-args-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/fix-crta-double-set-runtime-args-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/fix-crta-double-set-runtime-args-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/fix-crta-double-set-runtime-args-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/fix-crta-double-set-runtime-args-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/fix-crta-double-set-runtime-args-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/fix-crta-double-set-runtime-args-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/fix-crta-double-set-runtime-args-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/fix-crta-double-set-runtime-args-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/fix-crta-double-set-runtime-args-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/fix-crta-double-set-runtime-args-test)