### PR TITLE
[Bug fix] ttnn: neighbor_pad_async - set runtime args for no-work cores (fix stale args)

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/neighbor_pad_async/device/neighbor_pad_async_program_factory.cpp
@@ -663,20 +663,24 @@ NeighborPadAsyncMeshWorkloadFactory::cached_program_t NeighborPadAsyncMeshWorklo
             for (uint32_t i = 0; i < num_local_cores; ++i) {
                 const uint32_t units_for_core = base + (i < rem ? 1u : 0u);
                 const uint32_t a_count = a_base + (i < a_rem ? 1u : 0u);
-                if (units_for_core == 0 && a_count == 0) {
-                    continue;
-                }
 
                 const CoreCoord& logical_core = local_cores[i];
-                local_copy_core_coords.push_back(logical_core);
 
-                // Per-core unique args: work distribution for Phase B (copy) and Phase A (zero-fill)
+                // Per-core unique args: work distribution for Phase B (copy) and Phase A (zero-fill).
+                // These MUST be set for every core the kernels are placed on -- including cores with no
+                // work -- otherwise a no-work core reuses stale runtime args from a prior program and
+                // reads/writes garbage. Set args first, then skip bookkeeping for no-work cores.
                 SetRuntimeArgs(program, local_reader_kernel_id, {logical_core}, {unit_offset, units_for_core});
                 SetRuntimeArgs(
                     program,
                     local_writer_kernel_id,
                     {logical_core},
                     {unit_offset, units_for_core, a_offset, a_count});
+
+                if (units_for_core == 0 && a_count == 0) {
+                    continue;
+                }
+                local_copy_core_coords.push_back(logical_core);
 
                 unit_offset += units_for_core;
                 a_offset += a_count;


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
`NeighborPadAsyncMeshWorkloadFactory` skipped `SetRuntimeArgs` for cores with no work via an early `continue` (`units_for_core == 0 && a_count == 0`). On mesh-workload cache reuse, such a core kept **stale per-core runtime args** from a prior program and read/wrote garbage.

Fix: set the reader + local_copy writer runtime args for **every** placed core first, then `continue` to skip only the bookkeeping (`local_copy_core_coords`, offset accumulation) for no-work cores. The local_copy reader/writer kernels safely no-op on zero counts once args are set.

This is a shared-codebase bug (independently hit on Flux.2). Ideogram-4 exercises `neighbor_pad_async` in the VAE decode path (`conv3d.py`, `vae_mochi.py`, `vae_wan2_1.py`).

### Notes for reviewers
Single-file change to `neighbor_pad_async_program_factory.cpp`. Validated locally on Blackhole: `test_neighbor_pad_async.py -k "check and 1link"` → 2 passed, PCC=1.0 (incl. the mochi_vae VAE-shaped case). In CI the neighbor_pad regression runs in the T3000 CCL group (`run_t3000_ccl_tests`), covered by the t3k fast-tests badge below.

### CI Status
_Badges filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-fast-tests.yaml/badge.svg?branch=cglagovich/fix-neighborpad-nowork-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-fast-tests.yaml?query=branch:cglagovich/fix-neighborpad-nowork-args) t3k fast tests
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=cglagovich/fix-neighborpad-nowork-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:cglagovich/fix-neighborpad-nowork-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=cglagovich/fix-neighborpad-nowork-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:cglagovich/fix-neighborpad-nowork-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=cglagovich/fix-neighborpad-nowork-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:cglagovich/fix-neighborpad-nowork-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=cglagovich/fix-neighborpad-nowork-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:cglagovich/fix-neighborpad-nowork-args)
