### PR TITLE
[Perf]: Improve dfb initialization time

### DIFF
--- a/tests/tt_metal/tt_metal/api/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/api/CMakeLists.txt
@@ -97,6 +97,32 @@ set_target_properties(
             ${PROJECT_BINARY_DIR}/test/tt_metal
 )
 
+# Quasar-only DFB init timing benchmarks (standalone; not linked into unit_tests_api).
+add_executable(dfb_init_timing_bench dataflow_buffer/dfb_init_timing_bench.cpp)
+target_include_directories(
+    dfb_init_timing_bench
+    BEFORE
+    PRIVATE
+        "$<TARGET_PROPERTY:Metalium::Metal,INCLUDE_DIRECTORIES>"
+        ${PROJECT_SOURCE_DIR}/tests
+        ${PROJECT_SOURCE_DIR}/tests/tt_metal/tt_metal/common
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/common
+)
+target_link_libraries(
+    dfb_init_timing_bench
+    PRIVATE
+        test_metal_common_libs
+        Boost::smart_ptr
+)
+target_precompile_headers(dfb_init_timing_bench REUSE_FROM metal_common_pch)
+set_target_properties(
+    dfb_init_timing_bench
+    PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY
+            ${PROJECT_BINARY_DIR}/test/tt_metal
+)
+
 if(TT_METAL_USE_EMULE)
     target_link_options(unit_tests_api PRIVATE -rdynamic)
 

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_init_timing_bench.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_init_timing_bench.cpp
@@ -1,0 +1,1425 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Quasar-only DFB init timing benchmarks
+// Device rdcycle instrumentation is gated by TT_METAL_MEASURE_DFB_INIT_TIME=1.
+//
+// Usage:
+//   export TT_METAL_SLOW_DISPATCH_MODE=1
+//   export TT_METAL_MEASURE_DFB_INIT_TIME=1
+//   ./build/test/tt_metal/dfb_init_timing_bench [--case base|two|...|all]
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <tt_stl/assert.hpp>
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-logger/tt-logger.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+#include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
+#include <tt-metalium/experimental/tensor/spec/tensor_spec.hpp>
+#include <tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp>
+#include <tt-metalium/experimental/tensor/spec/layout/page_config.hpp>
+
+#include "impl/context/metal_context.hpp"
+#include "impl/dataflow_buffer/dataflow_buffer.hpp"
+#include "impl/dataflow_buffer/dataflow_buffer_impl.hpp"
+#include "impl/kernels/kernel.hpp"
+#include "impl/program/program_impl.hpp"
+#include "tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h"
+#include "tt_metal/impl/host_api/temp_quasar_api.hpp"
+
+namespace tt::tt_metal {
+
+struct DfbInitTimingBenchContext {
+    std::shared_ptr<distributed::MeshDevice> mesh_device;
+    IDevice* device = nullptr;
+};
+
+DfbInitTimingBenchContext create_dfb_init_timing_bench_context() {
+    if (!std::getenv("TT_METAL_SLOW_DISPATCH_MODE")) {
+        TT_FATAL(false, "Set TT_METAL_SLOW_DISPATCH_MODE=1 to run dfb_init_timing_bench");
+    }
+    if (MetalContext::instance().get_cluster().arch() != ARCH::QUASAR) {
+        TT_FATAL(false, "dfb_init_timing_bench requires Quasar");
+    }
+    if (!MetalContext::instance().rtoptions().get_measure_dfb_init_time_enabled()) {
+        TT_FATAL(false, "Set TT_METAL_MEASURE_DFB_INIT_TIME=1 to run dfb_init_timing_bench");
+    }
+
+    std::vector<ChipId> ids;
+    for (ChipId id : MetalContext::instance().get_cluster().mmio_chip_ids()) {
+        ids.push_back(id);
+    }
+    TT_FATAL(!ids.empty(), "No MMIO devices available");
+
+    const auto& dispatch_core_config = MetalContext::instance().rtoptions().get_dispatch_core_config();
+    auto id_to_device = distributed::MeshDevice::create_unit_meshes(
+        ids,
+        DEFAULT_L1_SMALL_SIZE,
+        DEFAULT_TRACE_REGION_SIZE,
+        1,
+        dispatch_core_config);
+
+    DfbInitTimingBenchContext ctx;
+    ctx.mesh_device = id_to_device.begin()->second;
+    ctx.device = ctx.mesh_device->get_devices()[0];
+    return ctx;
+}
+
+inline tt::tt_metal::TensorSpec make_flat_dram_tensor_spec(uint32_t entry_size, uint32_t total_entries) {
+    const uint32_t entry_size_words = entry_size / sizeof(uint32_t);
+    auto page_config = tt::tt_metal::PageConfig(tt::tt_metal::Layout::ROW_MAJOR);
+    auto memory_config =
+        tt::tt_metal::MemoryConfig{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM};
+    auto tensor_layout = tt::tt_metal::TensorLayout(tt::tt_metal::DataType::UINT32, page_config, memory_config);
+    return tt::tt_metal::TensorSpec(tt::tt_metal::Shape{total_entries, entry_size_words}, tensor_layout);
+}
+
+namespace {
+constexpr tt::DataFormat kDfbBenchDataFormat = tt::DataFormat::Float16_b;
+
+experimental::DataflowBufferSpec MakeBenchDfbSpec(
+    experimental::DFBSpecName id, uint32_t entry_size, uint32_t num_entries) {
+    return experimental::DataflowBufferSpec{
+        .unique_id = std::move(id),
+        .entry_size = entry_size,
+        .num_entries = num_entries,
+        .data_format_metadata = kDfbBenchDataFormat,
+    };
+}
+
+constexpr const char* kDfbInitTimingSlotNames[::dfb::DFB_INIT_TIMING_NUM_SLOTS] = {
+    "DM0",
+    "DM1",
+    "DM2",
+    "DM3",
+    "DM4",
+    "DM5",
+    "DM6",
+    "DM7",
+    "Neo0 unpack",
+    "Neo0 pack",
+    "Neo1 unpack",
+    "Neo1 pack",
+    "Neo2 unpack",
+    "Neo2 pack",
+    "Neo3 unpack",
+    "Neo3 pack",
+};
+
+void ClearDfbInitTimingL1(IDevice* device, const CoreCoord& core) {
+    std::vector<uint32_t> zeros(::dfb::DFB_INIT_TIMING_REGION_BYTES / sizeof(uint32_t), 0u);
+    detail::WriteToDeviceL1(device, core, ::dfb::DFB_INIT_TIMING_L1_BYTE_OFFSET, zeros);
+}
+
+// Slots that this program's DFB participants are expected to write.
+// DM0 (ISR) and DM1 (remapper) always run coordinator paths for any DFB program.
+// DM2-7 / Neo unpack+pack are included only when their risc bit appears in a DFB mask.
+uint16_t DfbInitTimingUsedSlotsMask(Program& program, const CoreCoord& core) {
+    uint16_t mask = (1u << 0) | (1u << 1);
+    for (const auto& dfb : program.impl().dataflow_buffers_on_core(core)) {
+        const uint16_t combined =
+            static_cast<uint16_t>(dfb->config.producer_risc_mask | dfb->config.consumer_risc_mask);
+        for (uint8_t dm = 0; dm < 8; ++dm) {
+            if (combined & (1u << dm)) {
+                mask |= static_cast<uint16_t>(1u << dm);
+            }
+        }
+        for (uint8_t neo = 0; neo < 4; ++neo) {
+            if (combined & (1u << (::dfb::TENSIX_RISC_OFFSET + neo))) {
+                mask |= static_cast<uint16_t>(1u << (8u + neo * 2u));      // unpack
+                mask |= static_cast<uint16_t>(1u << (8u + neo * 2u + 1u));  // pack
+            }
+        }
+    }
+    return mask;
+}
+
+void LogDfbInitTimingFromL1(
+    IDevice* device, const CoreCoord& core, const char* benchmark_name, uint16_t used_slots_mask) {
+    if (!MetalContext::instance().rtoptions().get_measure_dfb_init_time_enabled()) {
+        log_info(
+            tt::LogTest,
+            "DFB init timing [{}]: disabled (set TT_METAL_MEASURE_DFB_INIT_TIME=1)",
+            benchmark_name);
+        return;
+    }
+
+    log_info(
+        tt::LogTest,
+        "DFB init timing [{}] @ L1 0x{:x} (used_slots_mask=0x{:x}):",
+        benchmark_name,
+        ::dfb::DFB_INIT_TIMING_L1_BYTE_OFFSET,
+        used_slots_mask);
+
+    const uint32_t dfb_init_timing_slot_bytes =
+        static_cast<uint32_t>(::dfb::DFB_INIT_TIMING_WORDS_PER_SLOT) * sizeof(uint32_t);
+
+    for (uint8_t slot = 0; slot < ::dfb::DFB_INIT_TIMING_NUM_SLOTS; ++slot) {
+        if ((used_slots_mask & (1u << slot)) == 0u) {
+            continue;
+        }
+
+        const uint32_t slot_l1_addr =
+            ::dfb::DFB_INIT_TIMING_L1_BYTE_OFFSET + static_cast<uint32_t>(slot) * dfb_init_timing_slot_bytes;
+        std::vector<uint32_t> timing_words;
+        detail::ReadFromDeviceL1(device, core, slot_l1_addr, dfb_init_timing_slot_bytes, timing_words);
+        const uint32_t* words = timing_words.data();
+
+        if (words[::dfb::DFB_INIT_TIMING_W_VALID] != 1u ||
+            words[::dfb::DFB_INIT_TIMING_W_MAGIC] != ::dfb::DFB_INIT_TIMING_MAGIC) {
+            log_info(tt::LogTest, "  {}: (not written)", kDfbInitTimingSlotNames[slot]);
+            continue;
+        }
+
+        const uint8_t role = static_cast<uint8_t>(words[::dfb::DFB_INIT_TIMING_W_ROLE]);
+        const uint32_t e2e = words[::dfb::DFB_INIT_TIMING_W_E2E];
+        const uint32_t metric_a = words[::dfb::DFB_INIT_TIMING_W_METRIC_A];
+        const uint32_t metric_b = words[::dfb::DFB_INIT_TIMING_W_METRIC_B];
+        const uint32_t metric_c = words[::dfb::DFB_INIT_TIMING_W_METRIC_C];
+        const uint32_t metric_d = words[::dfb::DFB_INIT_TIMING_W_METRIC_D];
+        const uint32_t metric_e = words[::dfb::DFB_INIT_TIMING_W_METRIC_E];
+        const uint32_t metric_f = words[::dfb::DFB_INIT_TIMING_W_METRIC_F];
+        const uint32_t metric_g = words[::dfb::DFB_INIT_TIMING_W_METRIC_G];
+        const uint32_t metric_h = words[::dfb::DFB_INIT_TIMING_W_METRIC_H];
+        const uint32_t metric_i = words[::dfb::DFB_INIT_TIMING_W_METRIC_I];
+        const uint32_t metric_j = words[::dfb::DFB_INIT_TIMING_W_METRIC_J];
+        const uint32_t start_time = words[::dfb::DFB_INIT_TIMING_W_START];
+        const uint32_t end_time = words[::dfb::DFB_INIT_TIMING_W_END];
+
+        if (role == ::dfb::DFB_INIT_TIMING_ROLE_DM0_ISR) {
+            log_info(
+                tt::LogTest,
+                "  {}: e2e={} pre_loop_sw={} subpassB_desc={} between_dfb_sw={} subpassB_l1_read={} "
+                "subpassB_rocc_issue={} subpassB_hw={} first_ie_rmw={} second_ie_rmw={} isr_enable={} "
+                "start={} end={}",
+                kDfbInitTimingSlotNames[slot],
+                e2e,
+                metric_a,
+                metric_b,
+                metric_c,
+                metric_d,
+                metric_e,
+                metric_j,
+                metric_f,
+                metric_g,
+                metric_h,
+                start_time,
+                end_time);
+        } else if (role == ::dfb::DFB_INIT_TIMING_ROLE_DM1_RMP) {
+            log_info(
+                tt::LogTest,
+                "  {}: e2e={} blob_l1_read_sw={} blob_loop_ovhd={} pairs_reg_hw={} enable_remapper_hw={} "
+                "first_pair_clientR_hw={} first_pair_clientL_hw={} last_pair_hw={} pairs_slots_written={} "
+                "start={} end={}",
+                kDfbInitTimingSlotNames[slot],
+                e2e,
+                metric_a,
+                metric_b,
+                metric_c,
+                metric_d,
+                metric_e,
+                metric_f,
+                metric_g,
+                metric_j,
+                start_time,
+                end_time);
+        } else {
+            log_info(
+                tt::LogTest,
+                "  {}: e2e={} merged_sw={} remapper_spin={} tc_hw={} wait_all={} tc_reset_hw={} "
+                "tc_capacity_hw={} pre_loop={} entry_hdr={} tc_slots={} sig_write={} start={} end={}",
+                kDfbInitTimingSlotNames[slot],
+                e2e,
+                metric_a,
+                metric_b,
+                metric_c,
+                metric_d,
+                metric_e,
+                metric_f,
+                metric_g,
+                metric_h,
+                metric_i,
+                metric_j,
+                start_time,
+                end_time);
+        }
+    }
+}
+
+void LaunchAndLogDfbInitTiming(
+    IDevice* device, Program& program, const CoreCoord& core, const char* benchmark_name) {
+    ClearDfbInitTimingL1(device, core);
+    detail::LaunchProgram(device, program, true /*wait_until_cores_done*/);
+    LogDfbInitTimingFromL1(device, core, benchmark_name, DfbInitTimingUsedSlotsMask(program, core));
+}
+}  // namespace
+
+// Base-case DFB init benchmark.
+//
+// One 1Sx1S DM→Tensix DFB on core (0,0) — same configuration as
+// DFBImplicitSyncParamFixture.DMTensixTest1xDFB1Sx1S/ImplicitSyncTrue:
+//   entry_size=1024, num_entries=16, 1 STRIDED producer, 1 STRIDED consumer,
+//   implicit sync enabled, no remapper.
+//
+// Reuses dfb_producer.cpp and dfb_t6_consumer.cpp (same kernels as DMTensixTest1xDFB1Sx1S).
+// Data movement is commented out in those kernels so measured time reflects DFB init overhead.
+void run_benchmark_case_base(DfbInitTimingBenchContext& ctx) {
+    auto mesh_device = ctx.mesh_device;
+    IDevice* device = ctx.device;
+    CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));
+
+    constexpr uint32_t ENTRY_SIZE = 1024;
+    constexpr uint32_t NUM_ENTRIES = 16;
+    constexpr uint8_t NUM_PRODUCERS = 1;
+    constexpr uint8_t NUM_CONSUMERS = 1;
+    constexpr uint32_t NUM_ENTRIES_PER_PRODUCER = NUM_ENTRIES;
+    constexpr uint32_t NUM_ENTRIES_PER_CONSUMER = NUM_ENTRIES;
+
+    const experimental::DFBSpecName DFB{"dfb"};
+    const experimental::KernelSpecName PRODUCER{"producer"};
+    const experimental::KernelSpecName CONSUMER{"consumer"};
+    const experimental::TensorParamName IN_TENSOR{"in_tensor"};
+
+    const experimental::DataMovementHardwareConfig dm_producer_cfg = experimental::DataMovementGen2Config{};
+
+    auto in_tensor = MeshTensor::allocate_on_device(*mesh_device, make_flat_dram_tensor_spec(ENTRY_SIZE, NUM_ENTRIES));
+
+    experimental::DataflowBufferSpec dfb_spec = MakeBenchDfbSpec(DFB, ENTRY_SIZE, NUM_ENTRIES);
+
+    experimental::KernelSpec producer_spec{
+        .unique_id = PRODUCER,
+        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp",
+        .num_threads = NUM_PRODUCERS,
+        .dfb_bindings = {experimental::ProducerOf(DFB, "out")},
+        .tensor_bindings = {{
+            .tensor_parameter_name = IN_TENSOR,
+            .accessor_name = "src_tensor",
+        }},
+        .compile_time_args =
+            {
+                {"num_entries_per_producer", NUM_ENTRIES_PER_PRODUCER},
+                {"implicit_sync", 1u},
+                {"num_producers", static_cast<uint32_t>(NUM_PRODUCERS)},
+            },
+        .runtime_arg_schema = {.runtime_arg_names = {"chunk_offset", "entries_per_core"}},
+        .hw_config = dm_producer_cfg,
+    };
+
+    experimental::KernelSpec consumer_spec{
+        .unique_id = CONSUMER,
+        .source = "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_consumer.cpp",
+        .num_threads = NUM_CONSUMERS,
+        .dfb_bindings = {experimental::StridedConsumerOf(DFB, "in")},
+        .compile_time_args = {{"num_entries_per_consumer", NUM_ENTRIES_PER_CONSUMER}},
+        .hw_config = experimental::ComputeGen2Config{},
+    };
+
+    experimental::WorkUnitSpec wu{
+        .name = "bench_base_wu",
+        .kernels = {PRODUCER, CONSUMER},
+        .target_nodes = core_range_set,
+    };
+
+    experimental::ProgramSpec spec{
+        .name = "bench_base",
+        .kernels = {producer_spec, consumer_spec},
+        .dataflow_buffers = {dfb_spec},
+        .tensor_parameters = {{.unique_id = IN_TENSOR, .spec = in_tensor.tensor_spec()}},
+        .work_units = {wu},
+    };
+
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+
+    experimental::ProgramRunArgs run_args;
+    experimental::ProgramRunArgs::KernelRunArgs producer_params{};
+    producer_params.kernel = PRODUCER;
+    producer_params.runtime_arg_values = experimental::MakeRuntimeArgsForSingleNode(
+        experimental::NodeCoord{0, 0},
+        {{"chunk_offset", 0u}, {"entries_per_core", NUM_ENTRIES}});
+    experimental::ProgramRunArgs::KernelRunArgs consumer_params{};
+    consumer_params.kernel = CONSUMER;
+    run_args.kernel_run_args = {producer_params, consumer_params};
+    run_args.tensor_args.emplace(IN_TENSOR, experimental::TensorArgument{in_tensor});
+    experimental::SetProgramRunArgs(program, run_args);
+
+    LaunchAndLogDfbInitTiming(device, program, CoreCoord(0, 0), "BenchmarkCaseBase");
+}
+
+void run_benchmark_case_two(DfbInitTimingBenchContext& ctx) {
+    IDevice* device = ctx.device;
+    CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));
+
+    constexpr uint32_t ENTRY_SIZE  = 1024;
+    constexpr uint32_t NUM_ENTRIES = 16;
+    constexpr uint8_t  NUM_IN_THREADS = 4;
+    constexpr uint8_t  NUM_OUT_THREADS = 2;
+
+    const experimental::DFBSpecName DFB_SS{"dfb_ss"};   // 4Sx4S DM→Tensix
+    const experimental::DFBSpecName DFB_SA{"dfb_sa"};   // 4Sx4A DM→Tensix
+    const experimental::DFBSpecName DFB_T6{"dfb_t6"};   // 4Sx4S Tensix→DM
+    const experimental::KernelSpecName READER{"reader_dm"};
+    const experimental::KernelSpecName COMPUTE{"compute"};
+    const experimental::KernelSpecName WRITER{"writer_dm"};
+
+    const experimental::DataMovementHardwareConfig gen2_dm_hw = experimental::DataMovementGen2Config{};
+
+    experimental::DataflowBufferSpec dfb_ss_spec = MakeBenchDfbSpec(DFB_SS, ENTRY_SIZE, NUM_ENTRIES);
+    experimental::DataflowBufferSpec dfb_sa_spec = MakeBenchDfbSpec(DFB_SA, ENTRY_SIZE, NUM_ENTRIES);
+    experimental::DataflowBufferSpec dfb_t6_spec = MakeBenchDfbSpec(DFB_T6, ENTRY_SIZE, NUM_ENTRIES);
+
+    // Reader DM: producer on DFB_SS (STRIDED) and DFB_SA (STRIDED)
+    experimental::KernelSpec reader_spec{
+        .unique_id = READER,
+        .source =
+            "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_bench_avg_reader_dm.cpp",
+        .num_threads = NUM_IN_THREADS,
+        .dfb_bindings = {
+            experimental::ProducerOf(DFB_SS, "ss_out"),
+            experimental::ProducerOf(DFB_SA, "sa_out"),
+        },
+        .hw_config = gen2_dm_hw,
+    };
+
+    // Compute: STRIDED consumer on DFB_SS, ALL consumer on DFB_SA, STRIDED producer on DFB_T6
+    experimental::KernelSpec compute_spec{
+        .unique_id = COMPUTE,
+        .source = "tests/tt_metal/tt_metal/test_kernels/compute/dfb_bench_avg_compute.cpp",
+        .num_threads = NUM_IN_THREADS,
+        .dfb_bindings = {
+            experimental::StridedConsumerOf(DFB_SS, "ss_in"),
+            experimental::AllConsumerOf(DFB_SA, "sa_in"),
+            experimental::ProducerOf(DFB_T6, "t6_out"),
+        },
+        .hw_config = experimental::ComputeGen2Config{},
+    };
+
+    // Writer DM: STRIDED consumer on DFB_T6
+    experimental::KernelSpec writer_spec{
+        .unique_id = WRITER,
+        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_bench_avg_writer_dm.cpp",
+        .num_threads = NUM_OUT_THREADS,
+        .dfb_bindings = {experimental::StridedConsumerOf(DFB_T6, "t6_in")},
+        .hw_config = gen2_dm_hw,
+    };
+
+    experimental::WorkUnitSpec wu{
+        .name = "bench_avg_wu",
+        .kernels = {READER, COMPUTE, WRITER},
+        .target_nodes = core_range_set,
+    };
+
+    experimental::ProgramSpec spec{
+        .name = "bench_avg",
+        .kernels = {reader_spec, compute_spec, writer_spec},
+        .dataflow_buffers = {dfb_ss_spec, dfb_sa_spec, dfb_t6_spec},
+        .work_units = {wu},
+    };
+
+    Program program = experimental::MakeProgramFromSpec(*ctx.mesh_device, spec);
+
+    experimental::ProgramRunArgs run_args;
+    run_args.kernel_run_args = {
+        experimental::ProgramRunArgs::KernelRunArgs{.kernel = READER},
+        experimental::ProgramRunArgs::KernelRunArgs{.kernel = COMPUTE},
+        experimental::ProgramRunArgs::KernelRunArgs{.kernel = WRITER},
+    };
+    experimental::SetProgramRunArgs(program, run_args);
+
+    LaunchAndLogDfbInitTiming(device, program, CoreCoord(0, 0), "BenchmarkCaseTwo");
+}
+
+// Worst-case DFB init benchmark.
+//
+// Three concurrent 4Sx4A DM→Tensix DFBs are the hardware worst case for
+// DM0's setup_local_dfb_interfaces.
+//
+// Per-tensix TC budget (16 DM-visible TCs per tensix):
+//   Each DFB allocates 5 TCs on each of the consumer tensix IDs:
+//     - 1 producer TC (DM k → tensix k)
+//     - 4 consumer TCs (Neo k gets 1 TC per DM producer × 4 producers, all on tensix k)
+//   So each DFB uses 5 TCs on tensix 0–3 → max DFBs = floor(16/5) = 3.
+//   3 DFBs × 5 = 15/16 TCs used per tensix.
+//
+// Remapper: 3 DFBs × 4 producers (each 1-to-4 fan-out) = 12/16 1-to-many entries used.
+// This yields 12 remapper write_all_configs() calls with 4 set_clientR_slot writes
+// each = 48 total clientR writes — the maximum achievable given the TC constraint.
+//
+// Drains the full 16-entry ring per DFB (num_entries=16, 4 producers / 4 ALL consumers):
+//   reader: 4 implicit reads per DFB per DM
+//   compute: 16 copy_tile+pop_front per Neo per DFB (4 ALL TCs × 4 entries)
+void run_benchmark_case_four(DfbInitTimingBenchContext& ctx) {
+    IDevice* device = ctx.device;
+    CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));
+
+    constexpr uint32_t ENTRY_SIZE    = 1024;
+    constexpr uint32_t NUM_ENTRIES   = 16;
+    constexpr uint8_t  NUM_PRODUCERS = 4;  // DM STRIDED producers per DFB
+    constexpr uint8_t  NUM_CONSUMERS = 4;  // Tensix ALL consumers per DFB
+
+    const experimental::DFBSpecName DFB0{"dfb0"};
+    const experimental::DFBSpecName DFB1{"dfb1"};
+    const experimental::DFBSpecName DFB2{"dfb2"};
+    const experimental::KernelSpecName READER{"reader_dm"};
+    const experimental::KernelSpecName COMPUTE{"compute"};
+
+    const experimental::DataMovementHardwareConfig gen2_dm_hw = experimental::DataMovementGen2Config{};
+
+    // Reader DM: 4 STRIDED producers on all three DFBs
+    experimental::KernelSpec reader_spec{
+        .unique_id = READER,
+        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_bench_worst_reader_dm.cpp",
+        .num_threads = NUM_PRODUCERS,
+        .dfb_bindings = {
+            experimental::ProducerOf(DFB0, "out0"),
+            experimental::ProducerOf(DFB1, "out1"),
+            experimental::ProducerOf(DFB2, "out2"),
+        },
+        .hw_config = gen2_dm_hw,
+    };
+
+    // Compute: 4 ALL consumers on all three DFBs (each Neo gets a full copy via remapper)
+    experimental::KernelSpec compute_spec{
+        .unique_id = COMPUTE,
+        .source = "tests/tt_metal/tt_metal/test_kernels/compute/dfb_bench_worst_compute.cpp",
+        .num_threads = NUM_CONSUMERS,
+        .dfb_bindings = {
+            experimental::AllConsumerOf(DFB0, "in0"),
+            experimental::AllConsumerOf(DFB1, "in1"),
+            experimental::AllConsumerOf(DFB2, "in2"),
+        },
+        .hw_config = experimental::ComputeGen2Config{},
+    };
+
+    experimental::WorkUnitSpec wu{
+        .name = "bench_worst_wu",
+        .kernels = {READER, COMPUTE},
+        .target_nodes = core_range_set,
+    };
+
+    experimental::ProgramSpec spec{
+        .name = "bench_worst",
+        .kernels = {reader_spec, compute_spec},
+        .dataflow_buffers = {
+            MakeBenchDfbSpec(DFB0, ENTRY_SIZE, NUM_ENTRIES),
+            MakeBenchDfbSpec(DFB1, ENTRY_SIZE, NUM_ENTRIES),
+            MakeBenchDfbSpec(DFB2, ENTRY_SIZE, NUM_ENTRIES),
+        },
+        .work_units = {wu},
+    };
+
+    Program program = experimental::MakeProgramFromSpec(*ctx.mesh_device, spec);
+
+    experimental::ProgramRunArgs run_args;
+    run_args.kernel_run_args = {
+        experimental::ProgramRunArgs::KernelRunArgs{.kernel = READER},
+        experimental::ProgramRunArgs::KernelRunArgs{.kernel = COMPUTE},
+    };
+    experimental::SetProgramRunArgs(program, run_args);
+
+    LaunchAndLogDfbInitTiming(device, program, CoreCoord(0, 0), "BenchmarkCaseFour");
+}
+
+// Average-case-two DFB init benchmark.
+//
+// Three concurrent 4Sx4S DM→Tensix DFBs: 4 STRIDED DM producers, 4 STRIDED
+// Tensix consumers. This is a STRIDED-STRIDED variant of BenchmarkCaseWorst
+// (which uses ALL consumers). No remapper is used, making this a clean mid-point
+// between BenchmarkCaseBase (1 DFB, no remapper) and BenchmarkCaseWorst (remapper).
+//
+// Per-tensix TC budget:
+//   Each 4Sx4S DFB uses 1 TC per (producer, consumer) pair, all on the same tensix.
+//   4 pairs × 3 DFBs = 12 TCs total, 3 per tensix (12/16 used).
+//   No remapper entries.
+//
+// Drains the full 16-entry ring per DFB (num_entries=16, 4 producers / 4 consumers):
+//   reader: 4 implicit reads per DFB per DM
+//   compute: 4 copy_tile+pop_front per Neo per DFB (eltwise_copy tile_regs pattern)
+void run_benchmark_case_three(DfbInitTimingBenchContext& ctx) {
+    IDevice* device = ctx.device;
+    CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));
+
+    constexpr uint32_t ENTRY_SIZE    = 1024;
+    constexpr uint32_t NUM_ENTRIES   = 16;
+    constexpr uint8_t  NUM_PRODUCERS = 4;  // DM STRIDED producers per DFB
+    constexpr uint8_t  NUM_CONSUMERS = 4;  // Tensix STRIDED consumers per DFB
+
+    const experimental::DFBSpecName DFB0{"avg2_dfb0"};
+    const experimental::DFBSpecName DFB1{"avg2_dfb1"};
+    const experimental::DFBSpecName DFB2{"avg2_dfb2"};
+    const experimental::KernelSpecName READER{"reader_dm"};
+    const experimental::KernelSpecName COMPUTE{"compute"};
+
+    const experimental::DataMovementHardwareConfig gen2_dm_hw = experimental::DataMovementGen2Config{};
+
+    // Reader DM: 4 STRIDED producers on all three DFBs.
+    experimental::KernelSpec reader_spec{
+        .unique_id = READER,
+        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_bench_avg2_reader_dm.cpp",
+        .num_threads = NUM_PRODUCERS,
+        .dfb_bindings = {
+            experimental::ProducerOf(DFB0, "out0"),
+            experimental::ProducerOf(DFB1, "out1"),
+            experimental::ProducerOf(DFB2, "out2"),
+        },
+        .hw_config = gen2_dm_hw,
+    };
+
+    // Compute: 4 STRIDED consumers on all three DFBs.
+    experimental::KernelSpec compute_spec{
+        .unique_id = COMPUTE,
+        .source = "tests/tt_metal/tt_metal/test_kernels/compute/dfb_bench_avg2_compute.cpp",
+        .num_threads = NUM_CONSUMERS,
+        .dfb_bindings = {
+            experimental::StridedConsumerOf(DFB0, "in0"),
+            experimental::StridedConsumerOf(DFB1, "in1"),
+            experimental::StridedConsumerOf(DFB2, "in2"),
+        },
+        .hw_config = experimental::ComputeGen2Config{},
+    };
+
+    experimental::WorkUnitSpec wu{
+        .name = "bench_avg2_wu",
+        .kernels = {READER, COMPUTE},
+        .target_nodes = core_range_set,
+    };
+
+    experimental::ProgramSpec spec{
+        .name = "bench_avg2",
+        .kernels = {reader_spec, compute_spec},
+        .dataflow_buffers = {
+            MakeBenchDfbSpec(DFB0, ENTRY_SIZE, NUM_ENTRIES),
+            MakeBenchDfbSpec(DFB1, ENTRY_SIZE, NUM_ENTRIES),
+            MakeBenchDfbSpec(DFB2, ENTRY_SIZE, NUM_ENTRIES),
+        },
+        .work_units = {wu},
+    };
+
+    Program program = experimental::MakeProgramFromSpec(*ctx.mesh_device, spec);
+
+    experimental::ProgramRunArgs run_args;
+    run_args.kernel_run_args = {
+        experimental::ProgramRunArgs::KernelRunArgs{.kernel = READER},
+        experimental::ProgramRunArgs::KernelRunArgs{.kernel = COMPUTE},
+    };
+    experimental::SetProgramRunArgs(program, run_args);
+
+    LaunchAndLogDfbInitTiming(device, program, CoreCoord(0, 0), "BenchmarkCaseThree");
+}
+
+// Worst-case-two DFB init benchmark.
+//
+// Stresses the DFB init loop with the maximum number of DFBs achievable under
+// the TC budget when a single 4-thread compute kernel consumes all of them.
+//
+// With a single compute kernel (num_threads=4), all 4 Neo threads consume EVERY
+// DFB via the ALL pattern. This forces every DFB to be 1Sx4A (1 DM producer,
+// 4 Neo consumers). TC cost per DFB:
+//   - 1 producer TC on producer tensix
+//   - 1 consumer TC per Neo tensix (Neo k shares tensix k with DM k → 2 TCs
+//     on the producer tensix, 1 TC on each other tensix) = 5 TCs total
+//
+// Cycling 4 DMs with 3 DFBs each: each tensix accumulates 3×2 + 3×1×3 = 15 TCs.
+// Maximum: 4 DMs × 3 DFBs = 12 DFBs (60/64 TCs used, 15 per tensix).
+//
+// Contrast with BenchmarkCaseWorst (3×4Sx4A):
+//   - Same 12 remapper entries (1-to-4), same 48 set_clientR_slot writes.
+//   - 4× more DFBs (12 vs 3) → 4× more init loop iterations per RISC.
+//   - 4 separate single-thread DM readers vs 1 four-thread DM reader.
+//
+// Remapper: 12 entries (all 1-to-4), 48 set_clientR_slot writes.
+//
+// TxnId budget: 12 DFBs × 2 txn IDs = 24, exactly filling the DFB pool [8,31].
+//
+// Drains the full 16-entry ring per DFB (num_entries=16, 1 producer / 4 ALL consumers):
+//   reader: 16 implicit reads per DFB per DM (single producer)
+//   compute: 16 copy_tile+pop_front per Neo per DFB across all 12 DFBs
+void run_benchmark_case_five(DfbInitTimingBenchContext& ctx) {
+    IDevice* device = ctx.device;
+    CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));
+
+    constexpr uint32_t ENTRY_SIZE  = 1024;
+    constexpr uint32_t NUM_ENTRIES = 16;
+
+    auto dfb_id = [](char group, int i) -> experimental::DFBSpecName {
+        return experimental::DFBSpecName{std::string("dfb_") + group + std::to_string(i)};
+    };
+
+    const experimental::DataMovementHardwareConfig gen2_dm_hw = experimental::DataMovementGen2Config{};
+
+    // Each reader: single DM, 1Sx4A, 16 reads per DFB (full ring).
+    const char* READER_SRC =
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_bench_worst2_reader_dm.cpp";
+    const char* COMPUTE_SRC =
+        "tests/tt_metal/tt_metal/test_kernels/compute/dfb_bench_worst2_compute.cpp";
+
+    // Each reader: 1 DM thread, STRIDED producer on 3 DFBs.
+    auto make_reader_bindings = [&](char group) -> std::vector<experimental::DFBBinding> {
+        std::vector<experimental::DFBBinding> bindings;
+        bindings.reserve(3);
+        for (int i = 0; i < 3; i++) {
+            bindings.push_back(experimental::ProducerOf(dfb_id(group, i), "out" + std::to_string(i)));
+        }
+        return bindings;
+    };
+
+    // Single compute kernel: 4 Neo threads, ALL consumer on all 12 DFBs.
+    std::vector<experimental::DFBBinding> compute_bindings;
+    {
+        int in_idx = 0;
+        for (char g : {'a', 'b', 'c', 'd'}) {
+            for (int i = 0; i < 3; i++) {
+                compute_bindings.push_back(
+                    experimental::AllConsumerOf(dfb_id(g, i), "in" + std::to_string(in_idx++)));
+            }
+        }
+    }
+
+    std::vector<experimental::KernelSpec> kernels;
+    for (char g : {'a', 'b', 'c', 'd'}) {
+        kernels.push_back({
+            .unique_id = experimental::KernelSpecName{std::string("reader_") + g},
+            .source = READER_SRC,
+            .num_threads = 1,
+            .dfb_bindings = make_reader_bindings(g),
+            .hw_config = gen2_dm_hw,
+        });
+    }
+    kernels.push_back({
+        .unique_id = experimental::KernelSpecName{"compute_all"},
+        .source = COMPUTE_SRC,
+        .num_threads = 4,
+        .dfb_bindings = compute_bindings,
+        .hw_config = experimental::ComputeGen2Config{},
+    });
+
+    // 12 DFB specs: 3 per group × 4 groups.
+    std::vector<experimental::DataflowBufferSpec> dfb_specs;
+    for (char g : {'a', 'b', 'c', 'd'}) {
+        for (int i = 0; i < 3; i++) {
+            dfb_specs.push_back(MakeBenchDfbSpec(dfb_id(g, i), ENTRY_SIZE, NUM_ENTRIES));
+        }
+    }
+
+    std::vector<experimental::KernelSpecName> all_kernel_ids = {
+        experimental::KernelSpecName{"reader_a"},
+        experimental::KernelSpecName{"reader_b"},
+        experimental::KernelSpecName{"reader_c"},
+        experimental::KernelSpecName{"reader_d"},
+        experimental::KernelSpecName{"compute_all"},
+    };
+
+    experimental::WorkUnitSpec wu{
+        .name = "bench_worst2_wu",
+        .kernels = all_kernel_ids,
+        .target_nodes = core_range_set,
+    };
+
+    experimental::ProgramSpec spec{
+        .name = "bench_worst2",
+        .kernels = kernels,
+        .dataflow_buffers = dfb_specs,
+        .work_units = {wu},
+    };
+
+    Program program = experimental::MakeProgramFromSpec(*ctx.mesh_device, spec);
+
+    experimental::ProgramRunArgs run_args;
+    for (const auto& kid : all_kernel_ids) {
+        run_args.kernel_run_args.push_back(experimental::ProgramRunArgs::KernelRunArgs{.kernel = kid});
+    }
+    experimental::SetProgramRunArgs(program, run_args);
+
+    LaunchAndLogDfbInitTiming(device, program, CoreCoord(0, 0), "BenchmarkCaseFive");
+}
+
+// Worst-case-three DFB init benchmark.
+//
+// Uses the experimental explicit producer_risc_mask / consumer_risc_mask APIs
+// to mix 6 independent DM producers with a single 4-thread compute consumer,
+// creating 32 DFBs that are impossible to express through the standard binding
+// API (which can only select the first N DMs for an N-thread kernel).
+//
+// Configuration: 16 × 1Sx1S + 16 × 1Sx2A = 32 DFBs, 64/64 TCs, 6 DMs active
+//
+//   1Sx1S DFBs (0–15): one DM producer, one Neo STRIDED consumer (no remapper)
+//     DFB  0– 3 : DM4 (t0) → Neo0 (t0)   [4 TCs on t0]
+//     DFB  4– 7 : DM5 (t1) → Neo1 (t1)   [4 TCs on t1]
+//     DFB  8–11 : DM4 (t0) → Neo2 (t2)   [4 TCs on t2]
+//     DFB 12–15 : DM5 (t1) → Neo3 (t3)   [4 TCs on t3]
+//
+//   1Sx2A DFBs (16–31): one DM producer, two Neo ALL consumers (remapper 1-to-2)
+//     DFB 16–19 : DM2 (t2) → {Neo0, Neo2}  [t0:+4, t2:+8]
+//     DFB 20–23 : DM3 (t3) → {Neo0, Neo2}  [t0:+4, t2:+4, t3:+4]
+//     DFB 24–27 : DM4 (t0) → {Neo1, Neo3}  [t0:+4, t1:+4, t3:+4]
+//     DFB 28–31 : DM5 (t1) → {Neo1, Neo3}  [t1:+8, t3:+4]
+//
+// TC totals: t0=16, t1=16, t2=16, t3=16 (64/64 used).
+// Remapper:  16 × 1-to-2 entries — exhausts all 16 one-to-many remapper slots.
+//            32 set_clientR_slot writes.
+//
+// The DFB transaction-id pool is [8,31], so at most 24 DFBs can use one ID each.
+// To retain the full 32-DFB / 64-TC / 16-remapper topology, producer implicit
+// sync is disabled on 8 DFBs (two on each of DM2-DM5). The other 24 DFBs use
+// one ID each because num_entries=1 is not divisible by any n in [2,4].
+//
+// Cases 6/7 use entry_size=2048 (not 1024): num_entries=1 cannot use the Cases 2–5
+// workaround where a default 2048 B unpack over-reads into the next ring slot.
+// Quasar copy_tile requires standard 32×32 tile geometry (narrow/partial tiles fault).
+void run_benchmark_case_seven(DfbInitTimingBenchContext& ctx) {
+    IDevice* device = ctx.device;
+    CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));
+
+    constexpr uint32_t ENTRY_SIZE  = 2048;
+    // num_entries=1 is intentional: compute_optimal_txn_id_count iterates n=2..4
+    // looking for num_entries % (n * num_producers * num_tcs_per_risc) == 0.
+    // With num_entries=1 no n≥2 divides 1, so the function returns 1 txn ID per DFB.
+    // Producer implicit sync is enabled on 24 DFBs and disabled on 8, exactly
+    // filling the 24-ID DFB pool.
+    constexpr uint32_t NUM_ENTRIES = 1;
+
+    // risc_mask bit positions
+    // DM k  → bit k        (bits 0–7)
+    // Neo k → bit (8 + k)  (bits 8–11)
+    constexpr uint16_t DM2  = (1u << 2);
+    constexpr uint16_t DM3  = (1u << 3);
+    constexpr uint16_t DM4  = (1u << 4);
+    constexpr uint16_t DM5  = (1u << 5);
+    constexpr uint16_t NEO0 = (1u << 8);
+    constexpr uint16_t NEO1 = (1u << 9);
+    constexpr uint16_t NEO2 = (1u << 10);
+    constexpr uint16_t NEO3 = (1u << 11);
+
+    Program program = CreateProgram();
+
+    // -----------------------------------------------------------------------
+    // 1Sx1S DFBs (IDs 0–15): STRIDED producer, STRIDED consumer, no remapper.
+    // TC is shared on the Neo consumer's tensix.
+    // -----------------------------------------------------------------------
+    auto make_1sx1s = [&](uint16_t producer_dm, uint16_t consumer_neo, bool producer_implicit_sync = true) {
+        return experimental::dfb::DataflowBufferConfig{
+            .entry_size = ENTRY_SIZE,
+            .num_entries = NUM_ENTRIES,
+            .producer_risc_mask = producer_dm,
+            .num_producers = 1,
+            .pap = dfb::AccessPattern::STRIDED,
+            .consumer_risc_mask = consumer_neo,
+            .num_consumers = 1,
+            .cap = dfb::AccessPattern::STRIDED,
+            .enable_producer_implicit_sync = producer_implicit_sync,
+            .enable_consumer_implicit_sync = true,
+            .data_format = kDfbBenchDataFormat,
+        };
+    };
+
+    // DFBs 0–3: DM4 → Neo0
+    for (int i = 0; i < 4; i++) {
+        experimental::dfb::CreateDataflowBuffer(program, core_range_set, make_1sx1s(DM4, NEO0, i >= 2));
+    }
+    // DFBs 4–7: DM5 → Neo1
+    for (int i = 0; i < 4; i++) {
+        experimental::dfb::CreateDataflowBuffer(program, core_range_set, make_1sx1s(DM5, NEO1, i >= 2));
+    }
+    // DFBs 8–11: DM4 → Neo2
+    for (int i = 0; i < 4; i++) {
+        experimental::dfb::CreateDataflowBuffer(program, core_range_set, make_1sx1s(DM4, NEO2));
+    }
+    // DFBs 12–15: DM5 → Neo3
+    for (int i = 0; i < 4; i++) {
+        experimental::dfb::CreateDataflowBuffer(program, core_range_set, make_1sx1s(DM5, NEO3));
+    }
+
+    // -----------------------------------------------------------------------
+    // 1Sx2A DFBs (IDs 16–31): STRIDED producer, ALL consumer, remapper 1-to-2.
+    // 1 prod TC on DM's tensix + 1 cons TC on each Neo consumer's tensix.
+    // -----------------------------------------------------------------------
+    auto make_1sx2a = [&](uint16_t producer_dm, uint16_t consumer_neos, bool producer_implicit_sync = true) {
+        return experimental::dfb::DataflowBufferConfig{
+            .entry_size = ENTRY_SIZE,
+            .num_entries = NUM_ENTRIES,
+            .producer_risc_mask = producer_dm,
+            .num_producers = 1,
+            .pap = dfb::AccessPattern::STRIDED,
+            .consumer_risc_mask = consumer_neos,
+            .num_consumers = 2,
+            .cap = dfb::AccessPattern::ALL,
+            .enable_producer_implicit_sync = producer_implicit_sync,
+            .enable_consumer_implicit_sync = true,
+            .data_format = kDfbBenchDataFormat,
+        };
+    };
+
+    // DFBs 16–19: DM2 (t2) → {Neo0 (t0), Neo2 (t2)}
+    for (int i = 0; i < 4; i++) {
+        experimental::dfb::CreateDataflowBuffer(program, core_range_set, make_1sx2a(DM2, NEO0 | NEO2, i >= 2));
+    }
+    // DFBs 20–23: DM3 (t3) → {Neo0 (t0), Neo2 (t2)}
+    for (int i = 0; i < 4; i++) {
+        experimental::dfb::CreateDataflowBuffer(program, core_range_set, make_1sx2a(DM3, NEO0 | NEO2, i >= 2));
+    }
+    // DFBs 24–27: DM4 (t0) → {Neo1 (t1), Neo3 (t3)}
+    for (int i = 0; i < 4; i++) {
+        experimental::dfb::CreateDataflowBuffer(program, core_range_set, make_1sx2a(DM4, NEO1 | NEO3));
+    }
+    // DFBs 28–31: DM5 (t1) → {Neo1 (t1), Neo3 (t3)}
+    for (int i = 0; i < 4; i++) {
+        experimental::dfb::CreateDataflowBuffer(program, core_range_set, make_1sx2a(DM5, NEO1 | NEO3));
+    }
+
+    // -----------------------------------------------------------------------
+    // Kernels: created with the low-level experimental Quasar API.
+    // DFB risc masks are already set above; no BindDataflowBufferToProducerConsumerKernels call needed.
+    // -----------------------------------------------------------------------
+    constexpr const char* DM_KERNEL_SRC =
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_bench_worst3_dm.cpp";
+    constexpr const char* COMPUTE_KERNEL_SRC =
+        "tests/tt_metal/tt_metal/test_kernels/compute/dfb_bench_worst3_compute.cpp";
+
+    // 6-thread DM kernel (DM0–DM5 launched; DM0/DM1 coordinators only).
+    // Producers DM2–DM5; each checks mhartid for DFBs in producer_risc_mask.
+    // DM4: DFBs 0-3, 8-11 (1Sx1S), 24-27 (1Sx2A). DM5: 4-7, 12-15 (1Sx1S), 28-31 (1Sx2A).
+    experimental::quasar::CreateKernel(
+        program,
+        DM_KERNEL_SRC,
+        core_range_set,
+        experimental::quasar::QuasarDataMovementConfig{
+            .num_threads_per_cluster = 6,
+        });
+
+    // 4-thread compute kernel: Neo0–Neo3 all run the same source; each checks
+    // NEO_ID and operates only on DFBs for which its bit is set in consumer_risc_mask.
+    experimental::quasar::CreateKernel(
+        program,
+        COMPUTE_KERNEL_SRC,
+        core_range_set,
+        experimental::quasar::QuasarComputeConfig{
+            .num_threads_per_cluster = 4,
+        });
+
+    LaunchAndLogDfbInitTiming(device, program, CoreCoord(0, 0), "BenchmarkCaseSeven");
+}
+
+// BenchmarkWorstCaseFour — exhausts all 16 one-to-many remapper slots AND exercises
+// 8 of the 48 one-to-one remapper slots simultaneously, for 24 total remapper entries.
+//
+// This is the first test to use both remapper slot types at once.
+//
+// DFB layout (24 DFBs total):
+//   1Sx2A (DFBs  0–15): 16 × 1-to-2 remapper entries (all 16 one-to-many slots)
+//     DFB  0– 3: DM2 → {Neo0, Neo2}
+//     DFB  4– 7: DM3 → {Neo0, Neo2}
+//     DFB  8–11: DM4 → {Neo1, Neo3}
+//     DFB 12–15: DM5 → {Neo1, Neo3}
+//
+//   1Sx1A (DFBs 16–23): 8 × 1-to-1 remapper entries (from the 48 one-to-one slots)
+//     DFB 16–17: DM2 → Neo1
+//     DFB 18–19: DM3 → Neo1
+//     DFB 20–21: DM2 → Neo3
+//     DFB 22–23: DM4 → Neo0
+//
+// TC budget: 64/64 (exactly 16 per tensix):
+//   t0: 4(DM4 prod 8-11) + 4(Neo0 cons DM2) + 4(Neo0 cons DM3) + 2(DM4 prod 22-23) + 2(Neo0 cons 22-23) = 16
+//   t1: 4(DM5 prod 12-15)+ 4(Neo1 cons DM4) + 4(Neo1 cons DM5) + 2(Neo1 cons 16-17) + 2(Neo1 cons 18-19) = 16
+//   t2: 4(DM2 prod 0-3)  + 4(Neo2 cons DM2) + 4(Neo2 cons DM3) + 2(DM2 prod 16-17)  + 2(DM2 prod 20-21)  = 16
+//   t3: 4(DM3 prod 4-7)  + 4(Neo3 cons DM4) + 4(Neo3 cons DM5) + 2(DM3 prod 18-19)  + 2(Neo3 cons 20-21) = 16
+//
+// Remapper: 16 × 1-to-2 (all 16 one-to-many slots) + 8 × 1-to-1 (8 of 48 one-to-one slots)
+//           = 24 total remapper entries, 16×2 + 8×1 = 40 set_clientR_slot writes.
+// TxnId budget: 24 DFBs × 1 txn ID = 24, exactly filling the DFB pool [8,31].
+// num_entries=1 is required; 16 entries would need 2 txn IDs per DFB.
+//
+// Traffic per DFB (num_entries=1): DM issues 1 implicit read + finish; Neo drains via
+// copy_tile. entry_size=2048 matches default 32×32 Float16_b JIT unpack (see Case Seven comment).
+void run_benchmark_case_six(DfbInitTimingBenchContext& ctx) {
+    IDevice* device = ctx.device;
+    CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));
+
+    constexpr uint32_t ENTRY_SIZE  = 2048;
+    // num_entries=1: each DFB consumes exactly 1 TxnId (24 DFBs × 1 = the 24-ID pool)
+    // while keeping implicit sync enabled to exercise ISR setup.
+    constexpr uint32_t NUM_ENTRIES = 1;
+
+    // risc_mask bit positions: DM k → bit k (bits 0–7), Neo k → bit (8+k) (bits 8–11)
+    constexpr uint16_t DM2  = (1u << 2);
+    constexpr uint16_t DM3  = (1u << 3);
+    constexpr uint16_t DM4  = (1u << 4);
+    constexpr uint16_t DM5  = (1u << 5);
+    constexpr uint16_t NEO0 = (1u << 8);
+    constexpr uint16_t NEO1 = (1u << 9);
+    constexpr uint16_t NEO2 = (1u << 10);
+    constexpr uint16_t NEO3 = (1u << 11);
+
+    Program program = CreateProgram();
+
+    // -----------------------------------------------------------------------
+    // 1Sx2A DFBs (IDs 0–15): STRIDED producer, ALL consumer — 16 × 1-to-2 remapper
+    // entries, consuming all 16 one-to-many remapper slots.
+    // Each DFB: 1 prod TC on DM's tensix + 1 cons TC on each of 2 Neo tensixes = 3 TCs.
+    // -----------------------------------------------------------------------
+    auto make_1sx2a = [&](uint16_t producer_dm, uint16_t consumer_neos) {
+        return experimental::dfb::DataflowBufferConfig{
+            .entry_size          = ENTRY_SIZE,
+            .num_entries         = NUM_ENTRIES,
+            .producer_risc_mask  = producer_dm,
+            .num_producers       = 1,
+            .pap                 = dfb::AccessPattern::STRIDED,
+            .consumer_risc_mask  = consumer_neos,
+            .num_consumers       = 2,
+            .cap                 = dfb::AccessPattern::ALL,
+            .enable_producer_implicit_sync = true,
+            .enable_consumer_implicit_sync = true,
+            .data_format         = kDfbBenchDataFormat,
+        };
+    };
+
+    // DFBs 0–3: DM2(t2) → {Neo0(t0), Neo2(t2)}
+    for (int i = 0; i < 4; i++) {
+        experimental::dfb::CreateDataflowBuffer(program, core_range_set, make_1sx2a(DM2, NEO0 | NEO2));
+    }
+    // DFBs 4–7: DM3(t3) → {Neo0(t0), Neo2(t2)}
+    for (int i = 0; i < 4; i++) {
+        experimental::dfb::CreateDataflowBuffer(program, core_range_set, make_1sx2a(DM3, NEO0 | NEO2));
+    }
+    // DFBs 8–11: DM4(t0) → {Neo1(t1), Neo3(t3)}
+    for (int i = 0; i < 4; i++) {
+        experimental::dfb::CreateDataflowBuffer(program, core_range_set, make_1sx2a(DM4, NEO1 | NEO3));
+    }
+    // DFBs 12–15: DM5(t1) → {Neo1(t1), Neo3(t3)}
+    for (int i = 0; i < 4; i++) {
+        experimental::dfb::CreateDataflowBuffer(program, core_range_set, make_1sx2a(DM5, NEO1 | NEO3));
+    }
+
+    // -----------------------------------------------------------------------
+    // 1Sx1A DFBs (IDs 16–23): STRIDED producer, ALL consumer (1 Neo) — 8 × 1-to-1
+    // remapper entries, exercising 8 of the 48 one-to-one remapper slots.
+    // Each DFB: 1 prod TC on DM's tensix + 1 cons TC on Neo's tensix = 2 TCs.
+    // -----------------------------------------------------------------------
+    auto make_1sx1a = [&](uint16_t producer_dm, uint16_t consumer_neo) {
+        return experimental::dfb::DataflowBufferConfig{
+            .entry_size          = ENTRY_SIZE,
+            .num_entries         = NUM_ENTRIES,
+            .producer_risc_mask  = producer_dm,
+            .num_producers       = 1,
+            .pap                 = dfb::AccessPattern::STRIDED,
+            .consumer_risc_mask  = consumer_neo,
+            .num_consumers       = 1,
+            .cap                 = dfb::AccessPattern::ALL,
+            .enable_producer_implicit_sync = true,
+            .enable_consumer_implicit_sync = true,
+            .data_format         = kDfbBenchDataFormat,
+        };
+    };
+
+    // DFBs 16–17: DM2(t2) → Neo1(t1)  [+2 prod on t2, +2 cons on t1]
+    for (int i = 0; i < 2; i++) {
+        experimental::dfb::CreateDataflowBuffer(program, core_range_set, make_1sx1a(DM2, NEO1));
+    }
+    // DFBs 18–19: DM3(t3) → Neo1(t1)  [+2 prod on t3, +2 cons on t1]
+    for (int i = 0; i < 2; i++) {
+        experimental::dfb::CreateDataflowBuffer(program, core_range_set, make_1sx1a(DM3, NEO1));
+    }
+    // DFBs 20–21: DM2(t2) → Neo3(t3)  [+2 prod on t2, +2 cons on t3]
+    for (int i = 0; i < 2; i++) {
+        experimental::dfb::CreateDataflowBuffer(program, core_range_set, make_1sx1a(DM2, NEO3));
+    }
+    // DFBs 22–23: DM4(t0) → Neo0(t0)  [+2 prod on t0, +2 cons on t0]
+    for (int i = 0; i < 2; i++) {
+        experimental::dfb::CreateDataflowBuffer(program, core_range_set, make_1sx1a(DM4, NEO0));
+    }
+
+    // -----------------------------------------------------------------------
+    // Kernels: 6-thread DM kernel (DM0–DM5 launched; DM0/DM1 coordinators only;
+    // producers DM2–DM5) and 4-thread compute kernel (Neo0–Neo3).
+    // -----------------------------------------------------------------------
+    constexpr const char* DM_KERNEL_SRC =
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_bench_worst4_dm.cpp";
+    constexpr const char* COMPUTE_KERNEL_SRC =
+        "tests/tt_metal/tt_metal/test_kernels/compute/dfb_bench_worst4_compute.cpp";
+
+    experimental::quasar::CreateKernel(
+        program,
+        DM_KERNEL_SRC,
+        core_range_set,
+        experimental::quasar::QuasarDataMovementConfig{
+            .num_threads_per_cluster = 6,
+        });
+
+    experimental::quasar::CreateKernel(
+        program,
+        COMPUTE_KERNEL_SRC,
+        core_range_set,
+        experimental::quasar::QuasarComputeConfig{
+            .num_threads_per_cluster = 4,
+        });
+
+    log_info(tt::LogTest, "BenchmarkCaseSix: ENTRY_SIZE={} NUM_ENTRIES={}", ENTRY_SIZE, NUM_ENTRIES);
+
+    // Host preflight: catch stale builds where blobs still carry entry_size=1024.
+    program.impl().finalize_dataflow_buffer_configs();
+    program.impl().allocate_dataflow_buffers(device);
+    const CoreCoord bench_core(0, 0);
+    const auto dfbs = program.impl().dataflow_buffers_on_core(bench_core);
+    TT_FATAL(dfbs.size() == 24u, "Expected 24 DFBs, got {}", dfbs.size());
+    for (const auto& dfb : dfbs) {
+        TT_FATAL(dfb->config.entry_size == ENTRY_SIZE, "DFB {} entry_size mismatch", dfb->id);
+    }
+    std::vector<uint8_t> cfg_buf(256 * 1024, 0);
+    const size_t cfg_bytes =
+        experimental::dfb::detail::serialize_dfb_config_for_core(bench_core, dfbs, cfg_buf);
+    TT_FATAL(cfg_bytes > 0u, "serialize_dfb_config_for_core returned 0 bytes");
+    const auto* ghdr = reinterpret_cast<const dfb_global_header_t*>(cfg_buf.data());
+    constexpr uint8_t kNeo0Hart = ::dfb::TENSIX_RISC_OFFSET;  // Neo0 unpack hart
+    const auto* neo0_e0 = reinterpret_cast<const dfb_hart_init_entry_t*>(
+        cfg_buf.data() + ghdr->hart_blob_offset[kNeo0Hart]);
+    const auto* neo0_tc0 = reinterpret_cast<const dfb_blob_tc_pair_t*>(
+        cfg_buf.data() + ghdr->hart_blob_offset[kNeo0Hart] + sizeof(dfb_hart_init_entry_t));
+    log_info(
+        tt::LogTest,
+        "BenchmarkCaseSix preflight: Neo0 dfb{} entry_size={} tc0 base=0x{:x} limit=0x{:x} ring_tiles={}",
+        neo0_e0->logical_dfb_id,
+        neo0_e0->entry_size,
+        neo0_tc0->base_addr,
+        neo0_tc0->limit,
+        neo0_tc0->limit - neo0_tc0->base_addr);
+    TT_FATAL(neo0_e0->entry_size == ENTRY_SIZE, "Neo0 entry_size preflight mismatch");
+    TT_FATAL(neo0_tc0->limit - neo0_tc0->base_addr == ENTRY_SIZE / 16u, "Neo0 ring_tiles preflight mismatch");
+
+    LaunchAndLogDfbInitTiming(device, program, CoreCoord(0, 0), "BenchmarkCaseSix");
+}
+
+// Minimal 1Sx1A isolation variant of BenchmarkCaseSix for remapper debugging.
+// Single DFB via CreateDataflowBuffer: DM4 (STRIDED producer) → Neo0 (ALL consumer),
+// 1-to-1 remapper, num_entries=1, entry_size=2048, copy_tile drain.
+// Producer uses explicit reserve_back/push_back (implicit_sync=false), matching
+// DMTensixTest1xDFB1Sx1S. With implicit_sync=true the DM kernel hangs in finish()
+// at handle_final_credits WTP1 waiting for ISR-posted producer TC credits.
+// Pass/fail here isolates ALL+remapper consumer TC init from multi-DFB TC pressure.
+void run_benchmark_case_six_debug(DfbInitTimingBenchContext& ctx) {
+    IDevice* device = ctx.device;
+    CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));
+
+    constexpr uint32_t ENTRY_SIZE  = 2048;
+    constexpr uint32_t NUM_ENTRIES = 1;
+
+    constexpr uint16_t DM4  = (1u << 4);
+    constexpr uint16_t NEO0 = (1u << 8);
+
+    Program program = CreateProgram();
+
+    experimental::dfb::CreateDataflowBuffer(
+        program,
+        core_range_set,
+        experimental::dfb::DataflowBufferConfig{
+            .entry_size          = ENTRY_SIZE,
+            .num_entries         = NUM_ENTRIES,
+            .producer_risc_mask  = DM4,
+            .num_producers       = 1,
+            .pap                 = dfb::AccessPattern::STRIDED,
+            .consumer_risc_mask  = NEO0,
+            .num_consumers       = 1,
+            .cap                 = dfb::AccessPattern::ALL,
+            .enable_producer_implicit_sync = false,
+            .enable_consumer_implicit_sync = false,
+            .data_format         = kDfbBenchDataFormat,
+        });
+
+    constexpr const char* DM_KERNEL_SRC =
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_bench_case6_debug_dm.cpp";
+    constexpr const char* COMPUTE_KERNEL_SRC =
+        "tests/tt_metal/tt_metal/test_kernels/compute/dfb_bench_case6_debug_compute.cpp";
+
+    experimental::quasar::CreateKernel(
+        program,
+        DM_KERNEL_SRC,
+        core_range_set,
+        experimental::quasar::QuasarDataMovementConfig{
+            .num_threads_per_cluster = 6,
+        });
+
+    experimental::quasar::CreateKernel(
+        program,
+        COMPUTE_KERNEL_SRC,
+        core_range_set,
+        experimental::quasar::QuasarComputeConfig{
+            .num_threads_per_cluster = 4,
+        });
+
+    log_info(
+        tt::LogTest,
+        "BenchmarkCaseSixDebug: 1×1Sx1A DFB (DM4→Neo0) ENTRY_SIZE={} NUM_ENTRIES={}",
+        ENTRY_SIZE,
+        NUM_ENTRIES);
+
+    program.impl().finalize_dataflow_buffer_configs();
+    program.impl().allocate_dataflow_buffers(device);
+    const CoreCoord bench_core(0, 0);
+    const auto dfbs = program.impl().dataflow_buffers_on_core(bench_core);
+    TT_FATAL(dfbs.size() == 1u, "Expected 1 DFB");
+    TT_FATAL(dfbs[0]->config.entry_size == ENTRY_SIZE, "DFB entry_size mismatch");
+
+    std::vector<uint8_t> cfg_buf(256 * 1024, 0);
+    const size_t cfg_bytes =
+        experimental::dfb::detail::serialize_dfb_config_for_core(bench_core, dfbs, cfg_buf);
+    TT_FATAL(cfg_bytes > 0u, "serialize_dfb_config_for_core returned 0 bytes");
+    const auto* ghdr = reinterpret_cast<const dfb_global_header_t*>(cfg_buf.data());
+    constexpr uint8_t kNeo0Hart = ::dfb::TENSIX_RISC_OFFSET;
+    const auto* neo0_e0 = reinterpret_cast<const dfb_hart_init_entry_t*>(
+        cfg_buf.data() + ghdr->hart_blob_offset[kNeo0Hart]);
+    const auto* neo0_tc0 = reinterpret_cast<const dfb_blob_tc_pair_t*>(
+        cfg_buf.data() + ghdr->hart_blob_offset[kNeo0Hart] + sizeof(dfb_hart_init_entry_t));
+    log_info(
+        tt::LogTest,
+        "BenchmarkCaseSixDebug preflight: Neo0 dfb{} entry_size={} tc0 base=0x{:x} limit=0x{:x} ring_tiles={}",
+        neo0_e0->logical_dfb_id,
+        neo0_e0->entry_size,
+        neo0_tc0->base_addr,
+        neo0_tc0->limit,
+        neo0_tc0->limit - neo0_tc0->base_addr);
+    TT_FATAL(neo0_e0->logical_dfb_id == 0u, "Neo0 logical_dfb_id preflight mismatch");
+    TT_FATAL(neo0_e0->entry_size == ENTRY_SIZE, "Neo0 entry_size preflight mismatch");
+    TT_FATAL(neo0_tc0->limit - neo0_tc0->base_addr == ENTRY_SIZE / 16u, "Neo0 ring_tiles preflight mismatch");
+
+    LaunchAndLogDfbInitTiming(device, program, CoreCoord(0, 0), "BenchmarkCaseSixDebug");
+}
+
+// Same 1Sx1A topology as BenchmarkCaseSixDebug but with implicit_sync enabled.
+// Uses a single-producer DM kernel that forces num_sw_threads=1 before finish()
+// (see dfb_bench_case6_debug_implicit_dm.cpp). Without that, finish()'s internal
+// sync_threads(get_num_threads()) waits for all 6 launched DM harts even though
+// only DM4 issues the implicit read.
+void run_benchmark_case_six_debug_implicit_sync(DfbInitTimingBenchContext& ctx) {
+    IDevice* device = ctx.device;
+    CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));
+
+    constexpr uint32_t ENTRY_SIZE  = 2048;
+    constexpr uint32_t NUM_ENTRIES = 1;
+
+    constexpr uint16_t DM4  = (1u << 4);
+    constexpr uint16_t NEO0 = (1u << 8);
+
+    Program program = CreateProgram();
+
+    experimental::dfb::CreateDataflowBuffer(
+        program,
+        core_range_set,
+        experimental::dfb::DataflowBufferConfig{
+            .entry_size          = ENTRY_SIZE,
+            .num_entries         = NUM_ENTRIES,
+            .producer_risc_mask  = DM4,
+            .num_producers       = 1,
+            .pap                 = dfb::AccessPattern::STRIDED,
+            .consumer_risc_mask  = NEO0,
+            .num_consumers       = 1,
+            .cap                 = dfb::AccessPattern::ALL,
+            .enable_producer_implicit_sync = true,
+            .enable_consumer_implicit_sync = true,
+            .data_format         = kDfbBenchDataFormat,
+        });
+
+    constexpr const char* DM_KERNEL_SRC =
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_bench_case6_debug_implicit_dm.cpp";
+    constexpr const char* COMPUTE_KERNEL_SRC =
+        "tests/tt_metal/tt_metal/test_kernels/compute/dfb_bench_case6_debug_compute.cpp";
+
+    experimental::quasar::CreateKernel(
+        program,
+        DM_KERNEL_SRC,
+        core_range_set,
+        experimental::quasar::QuasarDataMovementConfig{
+            .num_threads_per_cluster = 6,
+        });
+
+    experimental::quasar::CreateKernel(
+        program,
+        COMPUTE_KERNEL_SRC,
+        core_range_set,
+        experimental::quasar::QuasarComputeConfig{
+            .num_threads_per_cluster = 4,
+        });
+
+    log_info(
+        tt::LogTest,
+        "BenchmarkCaseSixDebugImplicitSync: 1×1Sx1A DFB (DM4→Neo0) implicit_sync ENTRY_SIZE={} NUM_ENTRIES={}",
+        ENTRY_SIZE,
+        NUM_ENTRIES);
+
+    LaunchAndLogDfbInitTiming(device, program, CoreCoord(0, 0), "BenchmarkCaseSixDebugImplicitSync");
+}
+
+void run_benchmark_case_six_debug_implicit_sync_program_spec(DfbInitTimingBenchContext& ctx) {
+    auto mesh_device = ctx.mesh_device;
+    IDevice* device = ctx.device;
+    CoreRangeSet core_range_set(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));
+
+    constexpr uint32_t ENTRY_SIZE = 2048;
+    constexpr uint32_t NUM_ENTRIES = 1;
+    constexpr uint8_t NUM_PRODUCERS = 1;
+    constexpr uint8_t NUM_CONSUMERS = 1;
+
+    const experimental::DFBSpecName DFB{"dfb"};
+    const experimental::KernelSpecName PRODUCER{"producer"};
+    const experimental::KernelSpecName CONSUMER{"consumer"};
+    const experimental::TensorParamName IN_TENSOR{"in_tensor"};
+
+    const experimental::DataMovementHardwareConfig dm_producer_cfg = experimental::DataMovementGen2Config{};
+
+    auto in_tensor = MeshTensor::allocate_on_device(*mesh_device, make_flat_dram_tensor_spec(ENTRY_SIZE, NUM_ENTRIES));
+
+    experimental::DataflowBufferSpec dfb_spec = MakeBenchDfbSpec(DFB, ENTRY_SIZE, NUM_ENTRIES);
+
+    experimental::KernelSpec producer_spec{
+        .unique_id = PRODUCER,
+        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp",
+        .num_threads = NUM_PRODUCERS,
+        .dfb_bindings = {experimental::ProducerOf(DFB, "out")},
+        .tensor_bindings = {{
+            .tensor_parameter_name = IN_TENSOR,
+            .accessor_name = "src_tensor",
+        }},
+        .compile_time_args =
+            {
+                {"num_entries_per_producer", NUM_ENTRIES},
+                {"implicit_sync", 1u},
+                {"num_producers", static_cast<uint32_t>(NUM_PRODUCERS)},
+            },
+        .runtime_arg_schema = {.runtime_arg_names = {"chunk_offset", "entries_per_core"}},
+        .hw_config = dm_producer_cfg,
+    };
+
+    experimental::KernelSpec consumer_spec{
+        .unique_id = CONSUMER,
+        .source = "tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_consumer.cpp",
+        .num_threads = NUM_CONSUMERS,
+        .dfb_bindings = {experimental::AllConsumerOf(DFB, "in")},
+        .compile_time_args = {{"num_entries_per_consumer", NUM_ENTRIES}},
+        .hw_config = experimental::ComputeGen2Config{},
+    };
+
+    experimental::WorkUnitSpec wu{
+        .name = "bench_case6_program_spec_wu",
+        .kernels = {PRODUCER, CONSUMER},
+        .target_nodes = core_range_set,
+    };
+
+    experimental::ProgramSpec spec{
+        .name = "bench_case6_program_spec",
+        .kernels = {producer_spec, consumer_spec},
+        .dataflow_buffers = {dfb_spec},
+        .tensor_parameters = {{.unique_id = IN_TENSOR, .spec = in_tensor.tensor_spec()}},
+        .work_units = {wu},
+    };
+
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+
+    experimental::ProgramRunArgs run_args;
+    experimental::ProgramRunArgs::KernelRunArgs producer_params{};
+    producer_params.kernel = PRODUCER;
+    producer_params.runtime_arg_values = experimental::MakeRuntimeArgsForSingleNode(
+        experimental::NodeCoord{0, 0},
+        {{"chunk_offset", 0u}, {"entries_per_core", NUM_ENTRIES}});
+    experimental::ProgramRunArgs::KernelRunArgs consumer_params{};
+    consumer_params.kernel = CONSUMER;
+    run_args.kernel_run_args = {producer_params, consumer_params};
+    run_args.tensor_args.emplace(IN_TENSOR, experimental::TensorArgument{in_tensor});
+    experimental::SetProgramRunArgs(program, run_args);
+
+    LaunchAndLogDfbInitTiming(device, program, CoreCoord(0, 0), "BenchmarkCaseSixDebugImplicitSyncProgramSpec");
+}
+
+struct DfbInitTimingBenchCase {
+    const char* cli_name;
+    void (*run)(DfbInitTimingBenchContext&);
+};
+
+void print_usage(const char* argv0) {
+    std::cerr
+        << "Usage: " << argv0 << " [--case NAME]\n"
+        << "  NAME: base, two, three, four, five, six, seven,\n"
+        << "        six-debug, six-debug-implicit-sync, six-debug-implicit-sync-program-spec, all\n"
+        << "\nRequires TT_METAL_SLOW_DISPATCH_MODE=1 and TT_METAL_MEASURE_DFB_INIT_TIME=1 on Quasar.\n";
+}
+
+}  // namespace tt::tt_metal
+
+int main(int argc, char** argv) {
+    using namespace tt::tt_metal;
+
+    std::string case_name = "all";
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "--help" || arg == "-h") {
+            print_usage(argv[0]);
+            return 0;
+        }
+        if (arg == "--case" && i + 1 < argc) {
+            case_name = argv[++i];
+            continue;
+        }
+        std::cerr << "Unknown argument: " << arg << "\n";
+        print_usage(argv[0]);
+        return 1;
+    }
+
+    static const DfbInitTimingBenchCase kCases[] = {
+        {"base", run_benchmark_case_base},
+        {"two", run_benchmark_case_two},
+        {"three", run_benchmark_case_three},
+        {"four", run_benchmark_case_four},
+        {"five", run_benchmark_case_five},
+        {"six", run_benchmark_case_six},
+        {"seven", run_benchmark_case_seven},
+        // {"six-debug", run_benchmark_case_six_debug},
+        // {"six-debug-implicit-sync", run_benchmark_case_six_debug_implicit_sync},
+        // {"six-debug-implicit-sync-program-spec", run_benchmark_case_six_debug_implicit_sync_program_spec},
+    };
+
+    std::unordered_set<std::string> selected;
+    if (case_name == "all") {
+        for (const auto& bench_case : kCases) {
+            selected.insert(bench_case.cli_name);
+        }
+    } else {
+        selected.insert(case_name);
+    }
+
+    // Reuse one MeshDevice across cases so we can catch residual DFB HW state.
+    // Prefer fixing that over open/close (which masks the bug). Enable
+    // TT_METAL_DPRINT_CORES / watcher dprint to compare cold vs warm case-two init.
+    auto ctx = create_dfb_init_timing_bench_context();
+    bool ran_any = false;
+    for (const auto& bench_case : kCases) {
+        if (!selected.contains(bench_case.cli_name)) {
+            continue;
+        }
+        log_info(tt::LogTest, "Running DFB init timing benchmark case: {}", bench_case.cli_name);
+        bench_case.run(ctx);
+        ran_any = true;
+    }
+
+    if (!ran_any) {
+        std::cerr << "Unknown benchmark case: " << case_name << "\n";
+        print_usage(argv[0]);
+        return 1;
+    }
+
+    return 0;
+}

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
@@ -272,6 +272,181 @@ TEST_F(MeshDeviceFixture, DMTensixTest1xDFB1Sx1SConfig) {
     validate_dfb_tile_counters(program, logical_core, config, expectation);
 }
 
+// Host-only: validates Quasar L1 packing (96B header + per-hart blobs + producer-ready region).
+TEST_F(MeshDeviceFixture, DfbSerializeGlobalHeader1Sx1S) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+    }
+    experimental::dfb::DataflowBufferConfig config{
+        .entry_size = 1024,
+        .num_entries = 16,
+        .producer_risc_mask = 0x1,
+        .num_producers = 1,
+        .pap = dfb::AccessPattern::STRIDED,
+        .consumer_risc_mask = 0x10,
+        .num_consumers = 1,
+        .cap = dfb::AccessPattern::STRIDED,
+        .enable_producer_implicit_sync = false,
+        .enable_consumer_implicit_sync = false};
+
+    Program program = CreateProgram();
+    CoreCoord logical_core = CoreCoord(0, 0);
+    experimental::dfb::CreateDataflowBuffer(program, logical_core, config);
+    program.impl().finalize_dataflow_buffer_configs();
+    program.impl().allocate_dataflow_buffers(this->devices_.at(0)->get_devices()[0]);
+
+    const auto& dfbs = program.impl().dataflow_buffers_on_core(logical_core);
+    ASSERT_EQ(dfbs.size(), 1u);
+
+    std::vector<uint8_t> buf(8192, 0);
+    const size_t nbytes = experimental::dfb::detail::serialize_dfb_config_for_core(logical_core, dfbs, buf);
+    ASSERT_GT(nbytes, 0u);
+
+    const auto* ghdr = reinterpret_cast<const dfb_global_header_t*>(buf.data());
+    EXPECT_EQ(ghdr->num_dfbs, 1u);
+    EXPECT_EQ(sizeof(dfb_global_header_t), 96u);  // new 96B header
+    EXPECT_EQ(dfb_config_header_size(), 96u);
+
+    // Header is at offset 0; DM1 blob starts immediately after.
+    EXPECT_EQ(ghdr->dm1_remapper_blob_offset, dfb_config_header_size());
+    EXPECT_GE(ghdr->dm0_isr_blob_offset, ghdr->dm1_remapper_blob_offset);
+    // No implicit sync → has_dm0_isr=0, dm0_isr_blob_region_size=0.
+    EXPECT_EQ(experimental::dfb::detail::dm0_isr_blob_region_size(dfbs), 0u);
+    EXPECT_EQ(ghdr->has_dm0_isr, 0u);
+    EXPECT_EQ(ghdr->dm0_isr_ready, 0u);
+    EXPECT_EQ(sizeof(dfb_dm0_isr_txn_threshold_t), 4u);
+
+    // hart_blob_offset[] must be set for the two participating harts (0=producer, 4=consumer).
+    EXPECT_GT(ghdr->hart_blob_offset[0], 0u);
+    EXPECT_GT(ghdr->hart_blob_offset[4], 0u);
+    // Non-participating harts must also have a valid (minimal) blob offset.
+    for (uint8_t h = 0; h < ::dfb::NUM_PARTICIPATING_HARTIDS; ++h) {
+        EXPECT_GT(ghdr->hart_blob_offset[h], 0u) << "hart " << static_cast<int>(h);
+    }
+
+    // Signal region: per-producer byte slots (zeroed) then dfb_expected_signal[NUM_DFBS].
+    EXPECT_GT(ghdr->dfb_signal_region_off, 0u);
+    EXPECT_LT(static_cast<size_t>(ghdr->dfb_signal_region_off), nbytes);
+    // Slot for producer 0 of DFB 0 must be zero (not yet written by producer at runtime).
+    constexpr uint32_t kMaxProd = ::dfb::MAX_PRODUCERS_PER_DFB;
+    EXPECT_EQ(buf[ghdr->dfb_signal_region_off + 0 * kMaxProd + 0], 0u);
+    // dfb_expected_signal[0] must be 1 (single producer, bit 0).
+    constexpr uint32_t kExpectedOff = ::dfb::NUM_DFBS * kMaxProd;
+    const auto* dfb_expected = reinterpret_cast<const uint32_t*>(
+        buf.data() + ghdr->dfb_signal_region_off + kExpectedOff);
+    EXPECT_EQ(dfb_expected[0], 1u);
+
+    // DFB 0 init entry for hart 0 (producer): participation_mask bit set, one init entry.
+    EXPECT_EQ(ghdr->participation_mask[0], 1u);
+    const auto* entry0 = reinterpret_cast<const dfb_hart_init_entry_t*>(
+        buf.data() + ghdr->hart_blob_offset[0]);
+    EXPECT_EQ(entry0->logical_dfb_id, 0u);
+    EXPECT_NE(entry0->flags & DFB_HART_FLAG_IS_PRODUCER, 0);
+    EXPECT_EQ(entry0->entry_size, 1024u);
+    EXPECT_EQ(entry0->producer_signal_bit, 0u);  // first producer, bit 0
+
+    // DFB 0 init entry for hart 4 (consumer): no IS_PRODUCER flag.
+    EXPECT_EQ(ghdr->participation_mask[4], 1u);
+    const auto* entry4 = reinterpret_cast<const dfb_hart_init_entry_t*>(
+        buf.data() + ghdr->hart_blob_offset[4]);
+    EXPECT_EQ(entry4->logical_dfb_id, 0u);
+    EXPECT_EQ(entry4->flags & DFB_HART_FLAG_IS_PRODUCER, 0);
+    EXPECT_EQ(dfb_read_init_entry_producer_signal_bit(reinterpret_cast<const uint8_t*>(entry4), true), 0xFFu);
+
+    // participation_mask drives device init entry count; non-participating harts are zero.
+    for (uint8_t h = 0; h < ::dfb::NUM_PARTICIPATING_HARTIDS; ++h) {
+        if (h != 0 && h != 4) {
+            EXPECT_EQ(ghdr->participation_mask[h], 0u) << "hart " << static_cast<int>(h);
+        }
+    }
+
+    experimental::dfb::detail::verify_dfb_global_header_participation(*ghdr, dfbs);
+    experimental::dfb::detail::verify_dfb_hart_blobs(
+        std::span<const uint8_t>(buf.data(), nbytes), dfbs);
+    EXPECT_EQ(nbytes, experimental::dfb::detail::compute_dfb_config_serialized_size(dfbs));
+}
+
+TEST_F(MeshDeviceFixture, DfbSerializeTxnCentricImplicitSync1Sx1S) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
+    }
+    experimental::dfb::DataflowBufferConfig config{
+        .entry_size = 1024,
+        .num_entries = 16,
+        .producer_risc_mask = 0x1,
+        .num_producers = 1,
+        .pap = dfb::AccessPattern::STRIDED,
+        .consumer_risc_mask = 0x10,
+        .num_consumers = 1,
+        .cap = dfb::AccessPattern::STRIDED,
+        .enable_producer_implicit_sync = true,
+        .enable_consumer_implicit_sync = true};
+
+    Program program = CreateProgram();
+    CoreCoord logical_core = CoreCoord(0, 0);
+    experimental::dfb::CreateDataflowBuffer(program, logical_core, config);
+    program.impl().finalize_dataflow_buffer_configs();
+    program.impl().allocate_dataflow_buffers(this->devices_.at(0)->get_devices()[0]);
+
+    const auto& dfbs = program.impl().dataflow_buffers_on_core(logical_core);
+    ASSERT_EQ(dfbs.size(), 1u);
+
+    std::vector<uint8_t> buf(4096, 0);
+    const size_t nbytes = experimental::dfb::detail::serialize_dfb_config_for_core(logical_core, dfbs, buf);
+    ASSERT_GT(nbytes, 0u);
+
+    const auto* ghdr = reinterpret_cast<const dfb_global_header_t*>(buf.data());
+    const uint32_t dm0_region = experimental::dfb::detail::dm0_isr_blob_region_size(dfbs);
+    ASSERT_GT(dm0_region, 0u);
+    EXPECT_EQ(ghdr->has_dm0_isr, 1u);
+    // dfb_signal_region_off is after per-hart blobs, which are after the DM0 blob.
+    EXPECT_GT(ghdr->dfb_signal_region_off, ghdr->dm0_isr_blob_offset + dm0_region);
+
+    const auto* dm0_core_hdr = reinterpret_cast<const dfb_dm0_isr_blob_core_header_t*>(
+        buf.data() + ghdr->dm0_isr_blob_offset);
+    uint32_t expected_prod_mask = 0;
+    uint32_t expected_cons_mask = 0;
+    for (uint8_t i = 0; i < dfbs[0]->producer_txn_descriptor.num_txn_ids; ++i) {
+        expected_prod_mask |= 1u << dfbs[0]->producer_txn_descriptor.txn_ids[i];
+    }
+    for (uint8_t i = 0; i < dfbs[0]->consumer_txn_descriptor.num_txn_ids; ++i) {
+        expected_cons_mask |= 1u << dfbs[0]->consumer_txn_descriptor.txn_ids[i];
+    }
+    EXPECT_EQ(dm0_core_hdr->producer_txn_id_mask, expected_prod_mask);
+    EXPECT_EQ(dm0_core_hdr->consumer_txn_id_mask, expected_cons_mask);
+
+    const uint32_t txn_hw_off = ghdr->dm0_isr_blob_offset + sizeof(dfb_dm0_isr_blob_core_header_t);
+    const uint32_t txn_hw_bytes = dm0_isr_txn_hw_pool_byte_size(expected_prod_mask, expected_cons_mask);
+    const uint32_t desc_pool_bytes = dm0_isr_txn_desc_pool_byte_size(expected_prod_mask, expected_cons_mask);
+    // DM0 blob ends before hart blobs; verify txn pool + desc pool fits inside the DM0 blob region.
+    EXPECT_EQ(txn_hw_off + txn_hw_bytes + desc_pool_bytes,
+              ghdr->dm0_isr_blob_offset + dm0_region);
+
+    const auto* txn_threshold_table =
+        reinterpret_cast<const dfb_dm0_isr_txn_threshold_t*>(buf.data() + txn_hw_off);
+    const uint32_t all_mask = expected_prod_mask | expected_cons_mask;
+    // Pools hold one slot per used txn id, so the threshold for an id lives at its dense slot.
+    EXPECT_EQ(
+        txn_hw_bytes,
+        dm0_isr_txn_slot_count(expected_prod_mask, expected_cons_mask) * sizeof(dfb_dm0_isr_txn_threshold_t));
+    uint32_t pending = expected_prod_mask;
+    while (pending) {
+        const uint32_t txn_id = static_cast<uint32_t>(__builtin_ctz(pending));
+        EXPECT_EQ(
+            txn_threshold_table[dm0_isr_txn_slot_index(all_mask, txn_id)].threshold,
+            dfbs[0]->producer_txn_descriptor.num_entries_to_process_threshold);
+        pending &= (pending - 1u);
+    }
+    pending = expected_cons_mask;
+    while (pending) {
+        const uint32_t txn_id = static_cast<uint32_t>(__builtin_ctz(pending));
+        EXPECT_EQ(
+            txn_threshold_table[dm0_isr_txn_slot_index(all_mask, txn_id)].threshold,
+            dfbs[0]->consumer_txn_descriptor.num_entries_to_process_threshold);
+        pending &= (pending - 1u);
+    }
+}
+
 TEST_F(MeshDeviceFixture, DMTest1xDFB1Sx4SConfig) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -334,9 +334,10 @@ void RunTestOnCore(
     bool use_write_with_state = false;
     bool use_inline_dw_write_from_state = false;
     bool use_inline_dw_write_with_state = false;
-    // WH/BH: NOC_MAX_TRANSACTION_ID == 0xF. Quasar user pool: USER_TXN_ID_MAX == 15. Same bound.
-    constexpr uint32_t k_max_user_txn_id = 15;
-    constexpr uint32_t k_invalid_txn_id = k_max_user_txn_id + 1;
+    // WH/BH expose trids [0,15]. Quasar reserves [8,31] for DFB implicit sync,
+    // leaving user kernels [0,7].
+    const uint32_t k_max_user_txn_id = is_quasar ? 7 : 15;
+    const uint32_t k_invalid_txn_id = k_max_user_txn_id + 1;
     uint32_t invalid_txn_id = 0;
     switch (feature) {
         case SanitizeNOCAddress:

--- a/tests/tt_metal/tt_metal/scripts/parse_dfb_init_timing_logs.py
+++ b/tests/tt_metal/tt_metal/scripts/parse_dfb_init_timing_logs.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Parse DFB init timing lines from unit test logs into CSV.
+
+Reads LogDfbInitTimingFromL1() output emitted by the dfb_init_timing_bench binary
+(requires TT_METAL_MEASURE_DFB_INIT_TIME=1).
+
+Example:
+    ./build/test/tt_metal/dfb_init_timing_bench --case all 2>&1 | tee case-all.log
+    python3 tests/tt_metal/tt_metal/scripts/parse_dfb_init_timing_logs.py \\
+        case-*-75.log -o dfb_init_timing.csv --summary dfb_init_summary.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import glob
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+TIMING_HEADER_RE = re.compile(
+    r"DFB init timing \[(?P<benchmark>[^\]]+)\] @ L1 0x[0-9a-fA-F]+" r"(?: \(used_slots_mask=0x[0-9a-fA-F]+\))?:"
+)
+TEST_RESULT_RE = re.compile(r"\[\s*(PASSED|FAILED)\s*\]\s+\d+ test")
+
+DM0_RE = re.compile(
+    r"(?P<hart>DM0): e2e=(?P<e2e>\d+) "
+    r"pre_loop_sw=(?P<pre_loop_sw>\d+) subpassB_desc=(?P<subpassB_desc>\d+) "
+    r"(?:between_dfb_sw|hw_reg_write_cycles)=(?P<between_dfb_sw>\d+) "
+    r"subpassB_l1_read=(?P<subpassB_l1_read>\d+) "
+    r"subpassB_rocc_issue=(?P<subpassB_rocc_issue>\d+) subpassB_hw=(?P<subpassB_hw>\d+) "
+    r"first_ie_rmw=(?P<first_ie_rmw>\d+) second_ie_rmw=(?P<second_ie_rmw>\d+) "
+    r"isr_enable=(?P<isr_enable>\d+) "
+    r"(?:(?:implicit_sync_stores|hw_reg_writes)=(?P<implicit_sync_stores>\d+) )?"
+    r"start=(?P<start>\d+) end=(?P<end>\d+)"
+)
+
+DM1_RE = re.compile(
+    r"(?P<hart>DM1): e2e=(?P<e2e>\d+) "
+    r"blob_l1_read_sw=(?P<blob_l1_read_sw>\d+) blob_loop_ovhd=(?P<blob_loop_ovhd>\d+) "
+    r"pairs_reg_hw=(?P<pairs_reg_hw>\d+) enable_remapper_hw=(?P<enable_remapper_hw>\d+) "
+    r"first_pair_clientR_hw=(?P<first_pair_clientR_hw>\d+) "
+    r"first_pair_clientL_hw=(?P<first_pair_clientL_hw>\d+) "
+    r"last_pair_hw=(?P<last_pair_hw>\d+) "
+    r"(?:pairs_slots_written=\d+ )?"
+    r"(?:hw_reg_write_cycles=\d+ hw_reg_writes=\d+ )?"
+    r"pairs_slots_written=(?P<pairs_slots_written>\d+) "
+    r"start=(?P<start>\d+) end=(?P<end>\d+)"
+)
+
+DM1_RE_LEGACY = re.compile(
+    r"(?P<hart>DM1): e2e=(?P<e2e>\d+) "
+    r"blob_l1_read_sw=(?P<blob_l1_read_sw>\d+) blob_loop_ovhd=(?P<blob_loop_ovhd>\d+) "
+    r"pairs_reg_hw=(?P<pairs_reg_hw>\d+) enable_remapper_hw=(?P<enable_remapper_hw>\d+) "
+    r"first_pair_clientR_hw=(?P<first_pair_clientR_hw>\d+) "
+    r"first_pair_clientL_hw=(?P<first_pair_clientL_hw>\d+) "
+    r"last_pair_hw=(?P<last_pair_hw>\d+) "
+    r"hw_reg_write_cycles=(?P<hw_reg_write_cycles>\d+) hw_reg_writes=(?P<hw_reg_writes>\d+) "
+    r"pairs_slots_written=(?P<pairs_slots_written>\d+) "
+    r"start=(?P<start>\d+) end=(?P<end>\d+)"
+)
+
+DM_LOCAL_RE = re.compile(
+    r"(?P<hart>DM[2-7]): e2e=(?P<e2e>\d+) "
+    r"merged_sw=(?P<merged_sw>\d+) remapper_spin=(?P<remapper_spin>\d+) "
+    r"tc_hw=(?P<tc_hw>\d+) (?:wait_all|hw_reg_writes)=(?P<wait_all>\d+) "
+    r"tc_reset_hw=(?P<tc_reset_hw>\d+) tc_capacity_hw=(?P<tc_capacity_hw>\d+) "
+    r"pre_loop=(?P<pre_loop>\d+) entry_hdr=(?P<entry_hdr>\d+) "
+    r"tc_slots=(?P<tc_slots>\d+) sig_write=(?P<sig_write>\d+) "
+    r"start=(?P<start>\d+) end=(?P<end>\d+)"
+)
+
+TRISC_RE = re.compile(
+    r"(?P<hart>Neo\d+ (?:unpack|pack)): e2e=(?P<e2e>\d+) "
+    r"merged_sw=(?P<merged_sw>\d+) remapper_spin=(?P<remapper_spin>\d+) "
+    r"tc_hw=(?P<tc_hw>\d+) (?:wait_all|hw_reg_writes)=(?P<wait_all>\d+) "
+    r"tc_reset_hw=(?P<tc_reset_hw>\d+) tc_capacity_hw=(?P<tc_capacity_hw>\d+) "
+    r"pre_loop=(?P<pre_loop>\d+) entry_hdr=(?P<entry_hdr>\d+) "
+    r"tc_slots=(?P<tc_slots>\d+) sig_write=(?P<sig_write>\d+) "
+    r"start=(?P<start>\d+) end=(?P<end>\d+)"
+)
+
+NOT_WRITTEN_RE = re.compile(r"(?P<hart>DM\d|Neo\d+ (?:unpack|pack)): \(not written\)")
+
+DETAIL_COLUMNS = [
+    "pre_loop_sw",
+    "subpassB_desc",
+    "between_dfb_sw",
+    "subpassB_l1_read",
+    "subpassB_rocc_issue",
+    "subpassB_hw",
+    "first_ie_rmw",
+    "second_ie_rmw",
+    "isr_enable",
+    "implicit_sync_stores",
+    "hw_reg_write_cycles",
+    "hw_reg_writes",
+    "blob_l1_read_sw",
+    "blob_loop_ovhd",
+    "pairs_reg_hw",
+    "enable_remapper_hw",
+    "first_pair_clientR_hw",
+    "first_pair_clientL_hw",
+    "last_pair_hw",
+    "pairs_slots_written",
+    "merged_sw",
+    "remapper_spin",
+    "tc_hw",
+    "wait_all",
+    "tc_reset_hw",
+    "tc_capacity_hw",
+    "pre_loop",
+    "entry_hdr",
+    "tc_slots",
+    "sig_write",
+]
+
+ROW_COLUMNS = [
+    "log_file",
+    "case_name",
+    "benchmark_name",
+    "test_result",
+    "hart",
+    "role",
+    "written",
+    "e2e",
+    "start",
+    "end",
+    *DETAIL_COLUMNS,
+]
+
+SUMMARY_COLUMNS = [
+    "log_file",
+    "case_name",
+    "benchmark_name",
+    "test_result",
+    "num_harts_written",
+    "worst_e2e",
+    "worst_hart",
+    "dm0_e2e",
+    "dm1_e2e",
+    "max_dm2_7_e2e",
+    "max_dm2_7_hart",
+    "max_neo_e2e",
+    "max_neo_hart",
+]
+
+
+@dataclass
+class TimingRow:
+    log_file: str
+    case_name: str
+    benchmark_name: str
+    test_result: str
+    hart: str
+    role: str
+    written: bool
+    e2e: int | None = None
+    start: int | None = None
+    end: int | None = None
+    details: dict[str, int] = field(default_factory=dict)
+
+    def to_csv_row(self) -> dict[str, str | int]:
+        row: dict[str, str | int] = {
+            "log_file": self.log_file,
+            "case_name": self.case_name,
+            "benchmark_name": self.benchmark_name,
+            "test_result": self.test_result,
+            "hart": self.hart,
+            "role": self.role,
+            "written": int(self.written),
+            "e2e": self.e2e if self.e2e is not None else "",
+            "start": self.start if self.start is not None else "",
+            "end": self.end if self.end is not None else "",
+        }
+        for col in DETAIL_COLUMNS:
+            row[col] = self.details.get(col, "")
+        return row
+
+
+def infer_role(hart: str) -> str:
+    if hart == "DM0":
+        return "dm0_isr"
+    if hart == "DM1":
+        return "dm1_remapper"
+    if hart.startswith("DM"):
+        return "dm_local"
+    return "trisc_local"
+
+
+def parse_log_file(path: Path) -> list[TimingRow]:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    case_name = path.stem
+    log_file = path.name
+
+    result_match = TEST_RESULT_RE.search(text)
+    test_result = result_match.group(1) if result_match else "UNKNOWN"
+
+    rows: list[TimingRow] = []
+    current_benchmark = ""
+
+    for line in text.splitlines():
+        header_match = TIMING_HEADER_RE.search(line)
+        if header_match:
+            current_benchmark = header_match.group("benchmark")
+            continue
+
+        if not current_benchmark:
+            continue
+
+        for regex, role in (
+            (DM0_RE, "dm0_isr"),
+            (DM1_RE_LEGACY, "dm1_remapper"),
+            (DM1_RE, "dm1_remapper"),
+            (DM_LOCAL_RE, "dm_local"),
+            (TRISC_RE, "trisc_local"),
+        ):
+            match = regex.search(line)
+            if match:
+                data = match.groupdict()
+                hart = data.pop("hart")
+                e2e = int(data.pop("e2e"))
+                start = int(data.pop("start"))
+                end = int(data.pop("end"))
+                # Optional named groups (legacy field aliases) are None when absent.
+                details = {k: int(v) for k, v in data.items() if v is not None}
+                rows.append(
+                    TimingRow(
+                        log_file=log_file,
+                        case_name=case_name,
+                        benchmark_name=current_benchmark,
+                        test_result=test_result,
+                        hart=hart,
+                        role=role,
+                        written=True,
+                        e2e=e2e,
+                        start=start,
+                        end=end,
+                        details=details,
+                    )
+                )
+                break
+        else:
+            not_written = NOT_WRITTEN_RE.search(line)
+            if not_written:
+                hart = not_written.group("hart")
+                rows.append(
+                    TimingRow(
+                        log_file=log_file,
+                        case_name=case_name,
+                        benchmark_name=current_benchmark,
+                        test_result=test_result,
+                        hart=hart,
+                        role=infer_role(hart),
+                        written=False,
+                    )
+                )
+
+    return rows
+
+
+def summarize(rows: Iterable[TimingRow]) -> list[dict[str, str | int]]:
+    by_case: dict[tuple[str, str, str], list[TimingRow]] = {}
+    for row in rows:
+        if not row.written:
+            continue
+        key = (row.log_file, row.case_name, row.benchmark_name)
+        by_case.setdefault(key, []).append(row)
+
+    summaries: list[dict[str, str | int]] = []
+    for (log_file, case_name, benchmark_name), case_rows in sorted(by_case.items()):
+        worst = max(case_rows, key=lambda r: r.e2e or 0)
+        dm0 = next((r for r in case_rows if r.hart == "DM0"), None)
+        dm1 = next((r for r in case_rows if r.hart == "DM1"), None)
+        dm_prod = [r for r in case_rows if r.hart.startswith("DM") and r.hart not in {"DM0", "DM1"}]
+        neo = [r for r in case_rows if r.hart.startswith("Neo")]
+
+        max_dm = max(dm_prod, key=lambda r: r.e2e or 0) if dm_prod else None
+        max_neo = max(neo, key=lambda r: r.e2e or 0) if neo else None
+
+        summaries.append(
+            {
+                "log_file": log_file,
+                "case_name": case_name,
+                "benchmark_name": benchmark_name,
+                "test_result": case_rows[0].test_result,
+                "num_harts_written": len(case_rows),
+                "worst_e2e": worst.e2e,
+                "worst_hart": worst.hart,
+                "dm0_e2e": dm0.e2e if dm0 else "",
+                "dm1_e2e": dm1.e2e if dm1 else "",
+                "max_dm2_7_e2e": max_dm.e2e if max_dm else "",
+                "max_dm2_7_hart": max_dm.hart if max_dm else "",
+                "max_neo_e2e": max_neo.e2e if max_neo else "",
+                "max_neo_hart": max_neo.hart if max_neo else "",
+            }
+        )
+    return summaries
+
+
+def expand_inputs(patterns: list[str]) -> list[Path]:
+    paths: list[Path] = []
+    for pattern in patterns:
+        matches = sorted(glob.glob(pattern))
+        if matches:
+            paths.extend(Path(p) for p in matches)
+        else:
+            candidate = Path(pattern)
+            if candidate.is_file():
+                paths.append(candidate)
+    # Preserve order while deduplicating.
+    seen: set[Path] = set()
+    unique: list[Path] = []
+    for path in paths:
+        if path not in seen:
+            seen.add(path)
+            unique.append(path)
+    return unique
+
+
+def write_csv(path: Path, columns: list[str], rows: Iterable[dict[str, str | int]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=columns, extrasaction="ignore")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "logs",
+        nargs="+",
+        help="Log file paths or glob patterns (e.g. case-*-75.log)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=Path("dfb_init_timing.csv"),
+        help="Per-hart CSV output path (default: dfb_init_timing.csv)",
+    )
+    parser.add_argument(
+        "--summary",
+        type=Path,
+        default=None,
+        help="Optional per-case worst-e2e summary CSV path",
+    )
+    args = parser.parse_args()
+
+    log_paths = expand_inputs(args.logs)
+    if not log_paths:
+        print("No log files matched.", file=sys.stderr)
+        return 1
+
+    all_rows: list[TimingRow] = []
+    for path in log_paths:
+        parsed = parse_log_file(path)
+        if not parsed:
+            print(f"warning: no DFB init timing block in {path}", file=sys.stderr)
+        all_rows.extend(parsed)
+
+    if not all_rows:
+        print("No timing rows parsed.", file=sys.stderr)
+        return 1
+
+    write_csv(args.output, ROW_COLUMNS, (row.to_csv_row() for row in all_rows))
+    print(f"Wrote {len(all_rows)} rows to {args.output}")
+
+    if args.summary:
+        summary_rows = summarize(all_rows)
+        write_csv(args.summary, SUMMARY_COLUMNS, summary_rows)
+        print(f"Wrote {len(summary_rows)} summary rows to {args.summary}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tt_metal/tt_metal/test_kernels/compute/dfb_bench_avg2_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dfb_bench_avg2_compute.cpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Benchmark compute kernel for BenchmarkCaseThree (average-case-two init benchmark).
+//
+// Modeled on eltwise_copy_2_0.cpp (reader_datacopy_writer in test_direct.cpp):
+//   tile_regs_acquire/wait → wait_front → copy_tile → pop_front → commit/release
+//
+// Acts as STRIDED CONSUMER on three 4Sx4S DM→Tensix DFBs:
+//   dfb::in0, dfb::in1, dfb::in2
+//
+// Drains the full 16-entry ring per DFB (num_entries=16, 4 Neos):
+//   4 tiles per Neo per DFB (1 strided TC each)
+//
+// finish() is called by the reader DM kernels (producer side).
+
+#include "api/compute/common.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/dataflow/dataflow_buffer.h"
+
+namespace {
+constexpr uint32_t kNumEntries = 16u;
+constexpr uint32_t kNumNeos = 4u;
+constexpr uint32_t kTilesPerNeo = kNumEntries / kNumNeos;
+}  // namespace
+
+void kernel_main() {
+    DataflowBuffer in0(dfb::in0);
+    DataflowBuffer in1(dfb::in1);
+    DataflowBuffer in2(dfb::in2);
+
+    unary_op_init_common(dfb::in0, dfb::in0);
+    for (uint32_t i = 0; i < kTilesPerNeo; i++) {
+        tile_regs_acquire();
+        tile_regs_wait();
+
+        in0.wait_front(1);
+        copy_tile(dfb::in0, 0, 0);
+        in0.pop_front(1);
+
+        tile_regs_commit();
+        tile_regs_release();
+    }
+
+    unary_op_init_common(dfb::in1, dfb::in1);
+    for (uint32_t i = 0; i < kTilesPerNeo; i++) {
+        tile_regs_acquire();
+        tile_regs_wait();
+
+        in1.wait_front(1);
+        copy_tile(dfb::in1, 0, 0);
+        in1.pop_front(1);
+
+        tile_regs_commit();
+        tile_regs_release();
+    }
+
+    unary_op_init_common(dfb::in2, dfb::in2);
+    for (uint32_t i = 0; i < kTilesPerNeo; i++) {
+        tile_regs_acquire();
+        tile_regs_wait();
+
+        in2.wait_front(1);
+        copy_tile(dfb::in2, 0, 0);
+        in2.pop_front(1);
+
+        tile_regs_commit();
+        tile_regs_release();
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/dfb_bench_avg_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dfb_bench_avg_compute.cpp
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Benchmark compute kernel for the average-case DFB ISR latency benchmark.
+//
+// Modeled on eltwise_copy_2_0.cpp (reader_datacopy_writer in test_direct.cpp):
+//   tile_regs_acquire/wait → wait_front → copy_tile → pop_front → commit/release
+//
+// Participates in three DFBs:
+//   dfb::ss_in   - DM→Tensix, 4Sx4S STRIDED consumer (paired with reader_dm ss_out)
+//   dfb::sa_in   - DM→Tensix, 4Sx4A ALL consumer     (paired with reader_dm sa_out)
+//   dfb::t6_out  - Tensix→DM, STRIDED producer        (paired with writer_dm t6_in)
+//
+// Drains the full 16-entry ring (num_entries=16, 4 Neos):
+//   ss_in:  4 tiles per Neo (1 strided TC)
+//   sa_in: 16 tiles per Neo (4 ALL TCs × 4 entries each)
+//   t6_out: 4 tiles per Neo (reserve/push, no upstream copy)
+//
+// finish() is called by the reader (ss/sa producer) and writer (t6 consumer) kernels.
+
+#include "api/compute/common.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/dataflow/dataflow_buffer.h"
+
+namespace {
+constexpr uint32_t kNumEntries = 16u;
+constexpr uint32_t kNumNeos = 4u;
+constexpr uint32_t kSaTcsPerNeo = 4u;
+constexpr uint32_t kTilesPerNeo = kNumEntries / kNumNeos;
+constexpr uint32_t kSaTilesPerNeo = kTilesPerNeo * kSaTcsPerNeo;
+constexpr uint32_t kT6TilesPerNeo = kTilesPerNeo;
+}  // namespace
+
+void kernel_main() {
+    DataflowBuffer ss_in(dfb::ss_in);
+    DataflowBuffer sa_in(dfb::sa_in);
+    DataflowBuffer t6_out(dfb::t6_out);
+
+    unary_op_init_common(dfb::ss_in, dfb::ss_in);
+    for (uint32_t i = 0; i < kTilesPerNeo; i++) {
+        tile_regs_acquire();
+        tile_regs_wait();
+
+        ss_in.wait_front(1);
+        copy_tile(dfb::ss_in, 0, 0);
+        ss_in.pop_front(1);
+
+        tile_regs_commit();
+        tile_regs_release();
+    }
+
+    unary_op_init_common(dfb::sa_in, dfb::sa_in);
+    for (uint32_t i = 0; i < kSaTilesPerNeo; i++) {
+        tile_regs_acquire();
+        tile_regs_wait();
+
+        sa_in.wait_front(1);
+        copy_tile(dfb::sa_in, 0, 0);
+        sa_in.pop_front(1);
+
+        tile_regs_commit();
+        tile_regs_release();
+    }
+
+    unary_op_init_common(dfb::t6_out, dfb::t6_out);
+    for (uint32_t i = 0; i < kT6TilesPerNeo; i++) {
+        tile_regs_acquire();
+        tile_regs_wait();
+
+        t6_out.reserve_back(1);
+        t6_out.push_back(1);
+
+        tile_regs_commit();
+        tile_regs_release();
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/dfb_bench_case6_debug_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dfb_bench_case6_debug_compute.cpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Compute consumer kernel for BenchmarkCaseSixDebug.
+//
+// Single 1Sx1A DFB (logical id 0): Neo0 drains via wait_front → copy_tile → pop_front.
+// Host uses entry_size=2048 (default 32×32 Float16_b unpack).
+
+#include "api/compute/common.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/dataflow/dataflow_buffer.h"
+
+void kernel_main() {
+    uint32_t neo_id = ckernel::csr_read<ckernel::CSR::NEO_ID>();
+    if (neo_id != 0) {
+        return;
+    }
+
+    unary_op_init_common(0, 0);
+
+    DataflowBuffer dfb(0);
+    tile_regs_acquire();
+    tile_regs_wait();
+    dfb.wait_front(1);
+    copy_tile(0, 0, 0);
+    dfb.pop_front(1);
+    tile_regs_commit();
+    tile_regs_release();
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/dfb_bench_worst2_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dfb_bench_worst2_compute.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Benchmark compute kernel for BenchmarkCaseFive (worst-case-two init benchmark).
+//
+// Modeled on eltwise_copy_2_0.cpp (reader_datacopy_writer in test_direct.cpp):
+//   tile_regs_acquire/wait → wait_front → copy_tile → pop_front → commit/release
+//
+// Single compute kernel with num_threads=4 (Neo0–Neo3). Acts as ALL consumer on
+// 12 DFBs (12 × 1Sx4A): every Neo receives every DFB via 1-to-4 remapper fan-out.
+//
+// Drains the full 16-entry ring per DFB (num_entries=16, 1 producer):
+//   16 tiles per Neo per DFB (1 ALL TC × 16 entries)
+//
+// finish() is called by the reader DM kernels (producer side).
+
+#include "api/compute/common.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/dataflow/dataflow_buffer.h"
+
+namespace {
+constexpr uint32_t kNumEntries = 16u;
+constexpr uint32_t kTilesPerNeoPerDfb = kNumEntries;
+}  // namespace
+
+#define DRAIN_ALL_DFB(dfb_handle, dfb_operand)                       \
+    do {                                                             \
+        unary_op_init_common(dfb_operand, dfb_operand);              \
+        for (uint32_t _i = 0; _i < kTilesPerNeoPerDfb; _i++) {       \
+            tile_regs_acquire();                                     \
+            tile_regs_wait();                                        \
+            (dfb_handle).wait_front(1);                              \
+            copy_tile(dfb_operand, 0, 0);                            \
+            (dfb_handle).pop_front(1);                               \
+            tile_regs_commit();                                      \
+            tile_regs_release();                                     \
+        }                                                            \
+    } while (0)
+
+void kernel_main() {
+    DataflowBuffer in0(dfb::in0);
+    DataflowBuffer in1(dfb::in1);
+    DataflowBuffer in2(dfb::in2);
+    DataflowBuffer in3(dfb::in3);
+    DataflowBuffer in4(dfb::in4);
+    DataflowBuffer in5(dfb::in5);
+    DataflowBuffer in6(dfb::in6);
+    DataflowBuffer in7(dfb::in7);
+    DataflowBuffer in8(dfb::in8);
+    DataflowBuffer in9(dfb::in9);
+    DataflowBuffer in10(dfb::in10);
+    DataflowBuffer in11(dfb::in11);
+
+    DRAIN_ALL_DFB(in0, dfb::in0);
+    DRAIN_ALL_DFB(in1, dfb::in1);
+    DRAIN_ALL_DFB(in2, dfb::in2);
+    DRAIN_ALL_DFB(in3, dfb::in3);
+    DRAIN_ALL_DFB(in4, dfb::in4);
+    DRAIN_ALL_DFB(in5, dfb::in5);
+    DRAIN_ALL_DFB(in6, dfb::in6);
+    DRAIN_ALL_DFB(in7, dfb::in7);
+    DRAIN_ALL_DFB(in8, dfb::in8);
+    DRAIN_ALL_DFB(in9, dfb::in9);
+    DRAIN_ALL_DFB(in10, dfb::in10);
+    DRAIN_ALL_DFB(in11, dfb::in11);
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/dfb_bench_worst3_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dfb_bench_worst3_compute.cpp
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Compute consumer kernel for BenchmarkCaseSeven (worst-case-three init benchmark).
+//
+// Four Neo threads (Neo0–Neo3) run this kernel. Each Neo checks its NEO_ID CSR
+// and drains the DFBs it consumes. DFB IDs use the low-level uint16_t constructor
+// (no kernel_bindings_generated.h).
+//
+// Modeled on eltwise_copy_2_0.cpp / dfb_bench_worst4_compute.cpp:
+//   tile_regs_acquire/wait → wait_front → copy_tile → pop_front → commit/release
+//
+// DFB layout (32 DFBs total, 16×1Sx1S + 16×1Sx2A):
+//   1Sx1S (DFBs 0–15): STRIDED consumer — each Neo consumes its own slice
+//     Neo0: DFBs  0– 3   (produced by DM4)
+//     Neo1: DFBs  4– 7   (produced by DM5)
+//     Neo2: DFBs  8–11   (produced by DM4)
+//     Neo3: DFBs 12–15   (produced by DM5)
+//
+//   1Sx2A (DFBs 16–31): ALL consumer — two Neos share each group via remapper
+//     DFBs 16–23 → Neo0 + Neo2  (produced by DM2 and DM3)
+//     DFBs 24–31 → Neo1 + Neo3  (produced by DM4 and DM5)
+//
+// Drains the full ring per DFB (num_entries=1): 1 tile per DFB.
+// Producer finish() is called by the DM kernel after each implicit read.
+
+#include "api/compute/common.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/dataflow/dataflow_buffer.h"
+
+namespace {
+constexpr uint32_t kTilesPerDfb = 1u;
+}  // namespace
+
+#define DRAIN_ALL_DFB(dfb_id)                                          \
+    do {                                                               \
+        DataflowBuffer _dfb(dfb_id);                                   \
+    } while (0)
+
+void kernel_main() {
+    uint32_t neo_id = ckernel::csr_read<ckernel::CSR::NEO_ID>();
+
+    unary_op_init_common(0, 0);
+
+    if (neo_id == 0) {
+        DRAIN_ALL_DFB(0);
+        DRAIN_ALL_DFB(1);
+        DRAIN_ALL_DFB(2);
+        DRAIN_ALL_DFB(3);
+        DRAIN_ALL_DFB(16);
+        DRAIN_ALL_DFB(17);
+        DRAIN_ALL_DFB(18);
+        DRAIN_ALL_DFB(19);
+        DRAIN_ALL_DFB(20);
+        DRAIN_ALL_DFB(21);
+        DRAIN_ALL_DFB(22);
+        DRAIN_ALL_DFB(23);
+    } else if (neo_id == 1) {
+        DRAIN_ALL_DFB(4);
+        DRAIN_ALL_DFB(5);
+        DRAIN_ALL_DFB(6);
+        DRAIN_ALL_DFB(7);
+        DRAIN_ALL_DFB(24);
+        DRAIN_ALL_DFB(25);
+        DRAIN_ALL_DFB(26);
+        DRAIN_ALL_DFB(27);
+        DRAIN_ALL_DFB(28);
+        DRAIN_ALL_DFB(29);
+        DRAIN_ALL_DFB(30);
+        DRAIN_ALL_DFB(31);
+    } else if (neo_id == 2) {
+        DRAIN_ALL_DFB(8);
+        DRAIN_ALL_DFB(9);
+        DRAIN_ALL_DFB(10);
+        DRAIN_ALL_DFB(11);
+        DRAIN_ALL_DFB(16);
+        DRAIN_ALL_DFB(17);
+        DRAIN_ALL_DFB(18);
+        DRAIN_ALL_DFB(19);
+        DRAIN_ALL_DFB(20);
+        DRAIN_ALL_DFB(21);
+        DRAIN_ALL_DFB(22);
+        DRAIN_ALL_DFB(23);
+    } else {
+        DRAIN_ALL_DFB(12);
+        DRAIN_ALL_DFB(13);
+        DRAIN_ALL_DFB(14);
+        DRAIN_ALL_DFB(15);
+        DRAIN_ALL_DFB(24);
+        DRAIN_ALL_DFB(25);
+        DRAIN_ALL_DFB(26);
+        DRAIN_ALL_DFB(27);
+        DRAIN_ALL_DFB(28);
+        DRAIN_ALL_DFB(29);
+        DRAIN_ALL_DFB(30);
+        DRAIN_ALL_DFB(31);
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/dfb_bench_worst4_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dfb_bench_worst4_compute.cpp
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Compute consumer kernel for BenchmarkCaseSix (worst-case-four init benchmark).
+//
+// Four Neo threads (Neo0–Neo3) run this kernel. Each Neo checks its NEO_ID CSR
+// and drains the DFBs it consumes. DFB IDs use the low-level uint16_t constructor
+// (no kernel_bindings_generated.h).
+//
+// Modeled on eltwise_copy_2_0.cpp / dfb_bench_worst2_compute.cpp:
+//   tile_regs_acquire/wait → wait_front → copy_tile → pop_front → commit/release
+//
+// Host uses entry_size=2048 with default 32×32 tile (no .tile override).
+//
+// Drains the full ring per DFB (num_entries=1): 1 tile per DFB.
+// Producer finish() is called by the DM kernel after each implicit read.
+
+#include "api/compute/common.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/dataflow/dataflow_buffer.h"
+
+namespace {
+constexpr uint32_t kTilesPerDfb = 1u;
+}  // namespace
+
+#define DRAIN_ALL_DFB(dfb_id)                                          \
+    do {                                                               \
+        DataflowBuffer _dfb(dfb_id);                                   \
+    } while (0)
+
+void kernel_main() {
+    uint32_t neo_id = ckernel::csr_read<ckernel::CSR::NEO_ID>();
+
+    unary_op_init_common(0, 0);
+
+    if (neo_id == 0) {
+        DRAIN_ALL_DFB(0);
+        DRAIN_ALL_DFB(1);
+        DRAIN_ALL_DFB(2);
+        DRAIN_ALL_DFB(3);
+        DRAIN_ALL_DFB(4);
+        DRAIN_ALL_DFB(5);
+        DRAIN_ALL_DFB(6);
+        DRAIN_ALL_DFB(7);
+        DRAIN_ALL_DFB(22);
+        DRAIN_ALL_DFB(23);
+    } else if (neo_id == 1) {
+        DRAIN_ALL_DFB(8);
+        DRAIN_ALL_DFB(9);
+        DRAIN_ALL_DFB(10);
+        DRAIN_ALL_DFB(11);
+        DRAIN_ALL_DFB(12);
+        DRAIN_ALL_DFB(13);
+        DRAIN_ALL_DFB(14);
+        DRAIN_ALL_DFB(15);
+        DRAIN_ALL_DFB(16);
+        DRAIN_ALL_DFB(17);
+        DRAIN_ALL_DFB(18);
+        DRAIN_ALL_DFB(19);
+    } else if (neo_id == 2) {
+        DRAIN_ALL_DFB(0);
+        DRAIN_ALL_DFB(1);
+        DRAIN_ALL_DFB(2);
+        DRAIN_ALL_DFB(3);
+        DRAIN_ALL_DFB(4);
+        DRAIN_ALL_DFB(5);
+        DRAIN_ALL_DFB(6);
+        DRAIN_ALL_DFB(7);
+    } else {
+        DRAIN_ALL_DFB(8);
+        DRAIN_ALL_DFB(9);
+        DRAIN_ALL_DFB(10);
+        DRAIN_ALL_DFB(11);
+        DRAIN_ALL_DFB(12);
+        DRAIN_ALL_DFB(13);
+        DRAIN_ALL_DFB(14);
+        DRAIN_ALL_DFB(15);
+        DRAIN_ALL_DFB(20);
+        DRAIN_ALL_DFB(21);
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/dfb_bench_worst_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dfb_bench_worst_compute.cpp
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Benchmark compute kernel for BenchmarkCaseFour (worst-case init benchmark).
+//
+// Modeled on eltwise_copy_2_0.cpp (reader_datacopy_writer in test_direct.cpp):
+//   tile_regs_acquire/wait → wait_front → copy_tile → pop_front → commit/release
+//
+// Acts as ALL CONSUMER on three 4Sx4A DM→Tensix DFBs:
+//   dfb::in0, dfb::in1, dfb::in2
+//
+// Drains the full 16-entry ring per DFB (num_entries=16, 4 Neos):
+//   16 tiles per Neo per DFB (4 ALL TCs × 4 entries each, remapper fan-out)
+//
+// finish() is called by the reader DM kernels (producer side).
+
+#include "api/compute/common.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/dataflow/dataflow_buffer.h"
+
+namespace {
+constexpr uint32_t kNumEntries = 16u;
+constexpr uint32_t kNumNeos = 4u;
+constexpr uint32_t kAllTcsPerNeo = 4u;
+constexpr uint32_t kTilesPerNeo = kNumEntries / kNumNeos;
+constexpr uint32_t kTilesPerNeoPerDfb = kTilesPerNeo * kAllTcsPerNeo;
+}  // namespace
+
+void kernel_main() {
+    DataflowBuffer in0(dfb::in0);
+    DataflowBuffer in1(dfb::in1);
+    DataflowBuffer in2(dfb::in2);
+
+    unary_op_init_common(dfb::in0, dfb::in0);
+    for (uint32_t i = 0; i < kTilesPerNeoPerDfb; i++) {
+        tile_regs_acquire();
+        tile_regs_wait();
+
+        in0.wait_front(1);
+        copy_tile(dfb::in0, 0, 0);
+        in0.pop_front(1);
+
+        tile_regs_commit();
+        tile_regs_release();
+    }
+
+    unary_op_init_common(dfb::in1, dfb::in1);
+    for (uint32_t i = 0; i < kTilesPerNeoPerDfb; i++) {
+        tile_regs_acquire();
+        tile_regs_wait();
+
+        in1.wait_front(1);
+        copy_tile(dfb::in1, 0, 0);
+        in1.pop_front(1);
+
+        tile_regs_commit();
+        tile_regs_release();
+    }
+
+    unary_op_init_common(dfb::in2, dfb::in2);
+    for (uint32_t i = 0; i < kTilesPerNeoPerDfb; i++) {
+        tile_regs_acquire();
+        tile_regs_wait();
+
+        in2.wait_front(1);
+        copy_tile(dfb::in2, 0, 0);
+        in2.pop_front(1);
+
+        tile_regs_commit();
+        tile_regs_release();
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/dfb_intra_and_consume_all.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dfb_intra_and_consume_all.cpp
@@ -12,17 +12,11 @@
 //   dfb(1) - Intra-tensix, N packer-producer -> N unpacker-consumer pairs (hidden TCs, no remapper).
 //            This kernel acts as both producer and consumer for dfb(1).
 //
-// Execution order (all 4 TRISCs per Neo run kernel_main concurrently):
-//
-//   Phase 1 - blocked consumer of dfb(0):
-//     UNPACK TRISC: wait_front / pop_front for every entry (active).
-//     PACK / MATH TRISCs: wait_front and pop_front are no-ops; they race through Phase 1.
-//
-//   Phase 2 - intra-tensix on dfb(1):
-//     PACK TRISC:   reserve_back -> increment words in entry (+1) -> push_back
-//                   [then wait_front / pop_front are no-ops for PACK]
-//     UNPACK TRISC: [reserve_back / push_back are no-ops for UNPACK]
-//                   wait_front -> increment words in entry (+1) -> pop_front
+// Every TRISC must call wait_front / copy_tile / pop_front in the same loop iteration.
+// copy_tile self-gates per-TRISC (UNPACK=llk_unpack_A, MATH=llk_math_datacopy); only UNPACK
+// actually blocks in wait/pop, but MATH must still execute copy_tile in program order after
+// wait_front. Splitting PACK out or gating wait_front to UNPACK-only desyncs MATH from UNPACK
+// and traps TRISC1 (ERROR_TRISC1 / 0x19).
 //
 // Net result for dfb(1) L1 ring: every word = original_value + 2.
 //
@@ -32,6 +26,9 @@
 //   [2] words_per_entry      - words per dfb(1) entry for in-place increment
 
 #include "api/dataflow/dataflow_buffer.h"
+#include "api/compute/common.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "experimental/kernel_args.h"
 
 void kernel_main() {
@@ -39,34 +36,30 @@ void kernel_main() {
     constexpr uint32_t entries_per_neo = get_arg(args::entries_per_neo);
     constexpr uint32_t words_per_entry = get_arg(args::words_per_entry);
 
-    // Phase 1: consume all entries from the DM-produced strided x blocked DFB.
-    // UNPACK TRISC: each Neo's unpacker waits for its own TC credit (remapper fans out 1 DM post
-    // to N consumer TCs so every blocked UNPACK TRISC sees the full set of entries).
-    // PACK / MATH TRISCs: wait_front and pop_front are no-ops; they exit Phase 1 immediately.
+    // Phase 1: blocked consumer of the DM-produced strided x blocked DFB.
     DataflowBuffer dfb_consumer(dfb::remapper_in);
+
+    unary_op_init_common(dfb::remapper_in, dfb::remapper_in);
+
     for (uint32_t i = 0; i < num_entries_consumer; i++) {
+        acquire_dst();
         dfb_consumer.wait_front(1);
+        copy_tile(dfb::remapper_in, 0, 0);
         dfb_consumer.pop_front(1);
+        release_dst();
     }
     dfb_consumer.finish();
 
-    // Phase 2: intra-tensix DFB credit flow (packer -> unpacker, hidden TC per Neo).
-    // PACK TRISC fills its Neo's TC slot; UNPACK TRISC drains it.
-    // Because PACK races through Phase 1 (no-ops), it can pre-fill the entire TC capacity
-    // of dfb(1) before the UNPACK TRISC arrives from Phase 1. PACK then blocks in finish()
-    // until UNPACK has consumed all entries and called its own finish().
-    //
-    // Both PRODUCER ("intra_out") and CONSUMER ("intra_in") bindings on this kernel
-    // reference the same self-looped intra DFB, so either accessor resolves to the same ID.
+    // Phase 2: intra-tensix credit flow (packer -> unpacker, hidden TC per Neo).
     DataflowBuffer dfb_intra(dfb::intra_out);
 
 #ifdef UCK_CHLKC_UNPACK
     uint32_t trisc_id = ckernel::csr_read<ckernel::CSR::TRISC_ID>();
 #endif
 
+    unary_op_init_common(dfb::intra_out, dfb::intra_out);
+
     for (uint32_t i = 0; i < entries_per_neo; i++) {
-        // PACK: wait for a free ring slot, increment the entry in-place, post credit.
-        // UNPACK / MATH: reserve_back and push_back are no-ops.
         dfb_intra.reserve_back(1);
 #ifdef UCK_CHLKC_PACK
         {
@@ -78,9 +71,9 @@ void kernel_main() {
 #endif
         dfb_intra.push_back(1);
 
-        // UNPACK: wait for credit, increment the entry in-place, pop credit.
-        // PACK / MATH: wait_front and pop_front are no-ops.
+        acquire_dst();
         dfb_intra.wait_front(1);
+        copy_tile(dfb::intra_out, 0, 0);
 #ifdef UCK_CHLKC_UNPACK
         if (trisc_id == 0) {
             volatile uint32_t* entry = reinterpret_cast<volatile uint32_t*>(dfb_intra.get_read_ptr() << 4);
@@ -90,6 +83,7 @@ void kernel_main() {
         }
 #endif
         dfb_intra.pop_front(1);
+        release_dst();
     }
     dfb_intra.finish();
 }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/dfb_intra_and_consume_all_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dfb_intra_and_consume_all_2_0.cpp
@@ -78,6 +78,7 @@ void kernel_main() {
 
         acquire_dst();
         dfb_intra.wait_front(1);
+        copy_tile(dfb_intra.get_id(), 0, 0);  // UNPACR -> satisfies pop_front read-done
 #ifdef UCK_CHLKC_UNPACK
         if (trisc_id == 0) {
             volatile uint32_t* entry = reinterpret_cast<volatile uint32_t*>(dfb_intra.get_read_ptr() << 4);
@@ -86,7 +87,6 @@ void kernel_main() {
             }
         }
 #endif
-        copy_tile(dfb_intra.get_id(), 0, 0);  // UNPACR -> satisfies pop_front read-done
         dfb_intra.pop_front(1);
         release_dst();
     }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_consumer.cpp
@@ -4,6 +4,8 @@
 
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/compute/common.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/debug/dprint.h"
 #include "experimental/kernel_args.h"
 
@@ -11,13 +13,20 @@ void kernel_main() {
     constexpr uint32_t num_entries_per_consumer = get_arg(args::num_entries_per_consumer);
     DataflowBuffer dfb(dfb::in);
 
+    unary_op_init_common(dfb::in, dfb::in);
+
     // Each consumer pops exactly num_entries_per_consumer entries from its own TC(s).
     // No modulo-skip is needed: the DFB hardware delivers only this consumer's entries
     // to its TC, so every wait_front/pop_front here is for a tile this consumer owns.
     for (uint32_t tile_id = 0; tile_id < num_entries_per_consumer; tile_id++) {
+        tile_regs_acquire();
+        tile_regs_wait();
         dfb.wait_front(1);
+        copy_tile(dfb::in, 0, 0);
         DPRINT_UNPACK("unpack consumer tile id {}\n", tile_id);
         dfb.pop_front(1);
+        tile_regs_commit();
+        tile_regs_release();
         DPRINT_PACK("pack consumer tile id {}\n", tile_id);
     }
     DPRINT("CBWW\n");

--- a/tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_intra.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6_intra.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_buffer.h"
+#include "api/compute/common.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "experimental/kernel_args.h"
 
 void kernel_main() {
@@ -17,6 +20,8 @@ void kernel_main() {
     uint32_t trisc_id = ckernel::csr_read<ckernel::CSR::TRISC_ID>();
 #endif
 
+    unary_op_init_common(dfb::out, dfb::out);
+
     for (uint32_t i = 0; i < entries_per_neo; i++) {
         // Pack TRISC: wait for free space, increment entry in-place, post credit.
         dfb.reserve_back(1);
@@ -30,19 +35,20 @@ void kernel_main() {
 #endif
         dfb.push_back(1);
 
-        // Unpack TRISC: wait for credit, increment entry in-place, consume credit.
+        acquire_dst();
         dfb.wait_front(1);
+        copy_tile(dfb::out, 0, 0);
 #ifdef UCK_CHLKC_UNPACK
-        {
-            if (trisc_id == 0) {
-                volatile uint32_t* entry = reinterpret_cast<volatile uint32_t*>(dfb.get_read_ptr() << 4);
-                for (uint32_t w = 0; w < words_per_entry; w++) {
-                    entry[w] += 1;
-                }
+        if (trisc_id == 0) {
+            volatile uint32_t* entry = reinterpret_cast<volatile uint32_t*>(dfb.get_read_ptr() << 4);
+            for (uint32_t w = 0; w < words_per_entry; w++) {
+                entry[w] += 1;
             }
         }
 #endif
         dfb.pop_front(1);
+        release_dst();
     }
+
     dfb.finish();
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_bench_avg2_reader_dm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_bench_avg2_reader_dm.cpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Benchmark reader DM kernel for BenchmarkCaseThree (average-case-two init benchmark).
+//
+// Acts as STRIDED PRODUCER on three 4Sx4S DM→Tensix DFBs:
+//   dfb::out0, dfb::out1, dfb::out2
+//
+// Drains the full 16-entry ring per DFB (num_entries=16, 4 strided producers):
+//   each DM issues 16 / 4 = 4 implicit reads per DFB.
+
+#include "dfb_implicit_read_helper.h"
+
+namespace {
+constexpr uint32_t kNumEntries = 16u;
+constexpr uint32_t kNumProducers = 4u;
+constexpr uint32_t kReadsPerDm = kNumEntries / kNumProducers;
+}  // namespace
+
+void kernel_main() {
+    Noc noc;
+    DataflowBuffer out0(dfb::out0);
+    DataflowBuffer out1(dfb::out1);
+    DataflowBuffer out2(dfb::out2);
+
+    for (uint32_t i = 0; i < kReadsPerDm; i++) {
+        dfb_issue_implicit_read(noc, out0);
+        dfb_issue_implicit_read(noc, out1);
+        dfb_issue_implicit_read(noc, out2);
+    }
+
+    out0.finish();
+    out1.finish();
+    out2.finish();
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_bench_avg_reader_dm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_bench_avg_reader_dm.cpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Benchmark reader DM kernel for the average-case DFB ISR latency benchmark.
+//
+// Acts as PRODUCER on two DFBs:
+//   dfb::ss_out  - DM→Tensix, 4Sx4S (strided producer x strided consumer)
+//   dfb::sa_out  - DM→Tensix, 4Sx4A (strided producer x ALL consumer)
+//
+// Drains the full 16-entry ring (num_entries=16, 4 strided producers):
+//   each DM issues 16 / 4 = 4 implicit reads per DFB.
+
+#include "dfb_implicit_read_helper.h"
+
+namespace {
+constexpr uint32_t kNumEntries = 16u;
+constexpr uint32_t kNumProducers = 4u;
+constexpr uint32_t kReadsPerDm = kNumEntries / kNumProducers;
+}  // namespace
+
+void kernel_main() {
+    Noc noc;
+    DataflowBuffer dfb_ss(dfb::ss_out);
+    DataflowBuffer dfb_sa(dfb::sa_out);
+
+    for (uint32_t i = 0; i < kReadsPerDm; i++) {
+        dfb_issue_implicit_read(noc, dfb_ss);
+        dfb_issue_implicit_read(noc, dfb_sa);
+    }
+
+    dfb_ss.finish();
+    dfb_sa.finish();
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_bench_avg_writer_dm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_bench_avg_writer_dm.cpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Benchmark writer DM kernel for the average-case DFB ISR latency benchmark.
+//
+// Acts as CONSUMER on one DFB:
+//   dfb::t6_in  - Tensix→DM, 4Sx4S (strided producer × strided consumer)
+//
+// Drains the full 16-entry ring (num_entries=16, 2 strided consumers):
+//   each writer pops 16 / 2 = 8 tiles.
+
+#include "api/dataflow/dataflow_buffer.h"
+
+namespace {
+constexpr uint32_t kNumEntries = 16u;
+constexpr uint32_t kNumConsumers = 2u;
+constexpr uint32_t kTilesPerWriter = kNumEntries / kNumConsumers;
+}  // namespace
+
+void kernel_main() {
+    DataflowBuffer dfb(dfb::t6_in);
+
+    for (uint32_t i = 0; i < kTilesPerWriter; i++) {
+        dfb.wait_front(1);
+        dfb.pop_front(1);
+    }
+
+    dfb.finish();
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_bench_case6_debug_dm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_bench_case6_debug_dm.cpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// DM producer kernel for BenchmarkCaseSixDebug.
+//
+// Single 1Sx1A DFB (logical id 0): DM4 (t0) → Neo0 (t0).
+// Uses explicit reserve_back / push_back (implicit_sync=false) so producer
+// finish() does not spin in handle_final_credits WTP1 waiting for ISR-posted
+// producer TC credits. Matches the passing DMTensixTest1xDFB1Sx1S producer path.
+
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/dataflow/noc.h"
+
+void kernel_main() {
+    uint32_t dm_id;
+    asm volatile("csrr %0, mhartid" : "=r"(dm_id));
+
+    if (dm_id != 4) {
+        return;
+    }
+
+    Noc noc;
+    DataflowBuffer dfb(0);
+    const uint32_t entry_size = dfb.get_entry_size();
+
+    AllocatorBank<AllocatorBankType::DRAM> dram{};
+    dfb.reserve_back(1);
+    noc.async_read(dram, dfb, entry_size, {.bank_id = 0, .addr = 0}, {});
+    noc.async_read_barrier();
+    dfb.push_back(1);
+    dfb.finish();
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_bench_case6_debug_implicit_dm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_bench_case6_debug_implicit_dm.cpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// DM producer kernel for BenchmarkCaseSixDebugImplicitSync.
+//
+// Single 1Sx1A DFB (logical id 0): DM4 → Neo0, implicit_sync enabled.
+//
+// Quasar launches this kernel on num_threads_per_cluster DM harts, but only DM4
+// produces. finish() -> handle_final_credits() calls sync_threads(get_num_threads()),
+// so we force num_sw_threads=1 on the producer hart to avoid waiting for DMs that
+// returned early without calling finish().
+
+#include "api/kernel_thread_globals.h"
+#include "dfb_implicit_read_helper.h"
+
+void kernel_main() {
+    uint32_t dm_id;
+    asm volatile("csrr %0, mhartid" : "=r"(dm_id));
+
+    if (dm_id != 4) {
+        return;
+    }
+
+    num_sw_threads = 1;
+
+    Noc noc;
+    DataflowBuffer dfb(0);
+    dfb_issue_implicit_read(noc, dfb);
+    dfb.finish();
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_bench_finish_helper.h
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_bench_finish_helper.h
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Benchmark-only producer finish for single-producer implicit-sync DFBs.
+//
+// DataflowBuffer::finish() -> handle_final_credits() unconditionally calls
+// sync_threads(get_num_threads()). Quasar benchmark kernels are often launched
+// with num_threads_per_cluster > 1 while only one DM produces on a given DFB,
+// which deadlocks in that barrier.
+//
+// Call dfb_finish_single_implicit_read_producer() after exactly one
+// dfb_issue_implicit_read() on the same DFB handle. Skips the collective
+// sync_threads barrier (not needed when a single DM owns the producer side)
+// but otherwise mirrors finish_impl() for one implicit-sync read.
+
+#pragma once
+
+#include "api/dataflow/dataflow_buffer.h"
+#include "internal/tt-2xx/dataflow_buffer/dataflow_buffer_interface.h"
+#include "internal/tt-2xx/quasar/overlay/llk_intf_api.hpp"
+#include "internal/tt-2xx/quasar/overlay/rocc_instructions.hpp"
+
+FORCE_INLINE void dfb_finish_single_implicit_read_producer(DataflowBuffer& dfb) {
+    LocalDFBInterface& iface = get_local_dfb_interface(dfb.get_id());
+
+    // State after exactly one commit_implicit_read() from a fresh DataflowBuffer.
+    constexpr uint16_t transactions_issued = 1;
+    const uint8_t txn_id_index = (transactions_issued % iface.num_entries_per_txn_id == 0)
+                                       ? static_cast<uint8_t>((0 + 1) % iface.num_txn_ids)
+                                       : 0;
+
+    const uint8_t tail_txn_idx = (transactions_issued % iface.num_entries_per_txn_id == 0)
+                                     ? static_cast<uint8_t>((txn_id_index + iface.num_txn_ids - 1) % iface.num_txn_ids)
+                                     : txn_id_index;
+    const uint8_t tail_txn_id = iface.txn_ids[tail_txn_idx];
+
+    const uint8_t N = iface.num_tcs_to_rr;
+    const dfb::PackedTileCounter ptc0 = iface.tc_slots[0].packed_tile_counter;
+    const uint16_t expected_slot0 = transactions_issued / N + (0u < (transactions_issued % N) ? 1u : 0u);
+
+    auto read_actual_slot0 = [&]() -> uint16_t {
+        return static_cast<uint16_t>(
+            overlay::fast_llk_intf_read_posted(dfb::get_tensix_id(ptc0), dfb::get_counter_id(ptc0)));
+    };
+
+    while (read_actual_slot0() < expected_slot0) {
+        const uint64_t tack  = CMDBUF_TR_ACK_TRID(OVERLAY_RD_CMD_BUF, tail_txn_id);
+        const uint64_t tiles = CMDBUF_READ_TILES_TO_PROCESS_TR_ACK(OVERLAY_RD_CMD_BUF, tail_txn_id);
+        if (tack == 0 && tiles > 0) {
+            break;
+        }
+    }
+
+    if (read_actual_slot0() >= expected_slot0) {
+        // ISR posted credits; fall through to drain wait below.
+    } else {
+        const uint16_t global_threshold = iface.threshold;
+        while (read_actual_slot0() < expected_slot0) {
+            const uint64_t tiles = CMDBUF_READ_TILES_TO_PROCESS_TR_ACK(OVERLAY_RD_CMD_BUF, tail_txn_id);
+            if (tiles > 0 && tiles < global_threshold) {
+                break;
+            }
+        }
+
+        const uint16_t actual_slot0 = read_actual_slot0();
+        if (actual_slot0 < expected_slot0) {
+            for (uint8_t i = 0; i < N; i++) {
+                const dfb::PackedTileCounter ptc = iface.tc_slots[i].packed_tile_counter;
+                const uint8_t tensix_id = dfb::get_tensix_id(ptc);
+                const uint8_t tc_id     = dfb::get_counter_id(ptc);
+                const uint16_t expected = transactions_issued / N + (i < (transactions_issued % N) ? 1u : 0u);
+                const uint16_t actual = static_cast<uint16_t>(overlay::fast_llk_intf_read_posted(tensix_id, tc_id));
+                if (actual < expected) {
+                    overlay::fast_llk_intf_inc_posted(tensix_id, tc_id, expected - actual);
+                }
+            }
+        }
+    }
+
+    bool all_acked = false;
+    while (!all_acked) {
+        all_acked = true;
+        for (uint8_t i = 0; i < iface.num_tcs_to_rr; i++) {
+            const dfb::PackedTileCounter packed_tc = iface.tc_slots[i].packed_tile_counter;
+            const uint8_t tc_id = dfb::get_counter_id(packed_tc);
+            const uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
+            const uint32_t read_posted = overlay::fast_llk_intf_read_posted(tensix_id, tc_id);
+            const uint32_t read_acked = overlay::fast_llk_intf_read_acked(tensix_id, tc_id);
+            if (read_acked != read_posted) {
+                all_acked = false;
+            }
+        }
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_bench_worst2_reader.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_bench_worst2_reader.cpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Benchmark reader DM kernel for the worst-case-two DFB init benchmark.
+//
+// Each of the four reader kernels (A/B/C/D) is a single-thread DM that acts
+// as STRIDED (1 of 1) producer on 8 DFBs using the 1-to-1 ALL consumer pattern.
+// All four reader kernel instances share this source file; the specific DFBs
+// bound to each instance differ only in their host-side KernelSpec bindings.
+//
+// All DFBs are finished immediately without posting entries.
+
+#include "api/dataflow/dataflow_buffer.h"
+
+void kernel_main() {
+    DataflowBuffer dfb0(dfb::out0);
+    DataflowBuffer dfb1(dfb::out1);
+    DataflowBuffer dfb2(dfb::out2);
+    DataflowBuffer dfb3(dfb::out3);
+    DataflowBuffer dfb4(dfb::out4);
+    DataflowBuffer dfb5(dfb::out5);
+    DataflowBuffer dfb6(dfb::out6);
+    DataflowBuffer dfb7(dfb::out7);
+    dfb0.finish();
+    dfb1.finish();
+    dfb2.finish();
+    dfb3.finish();
+    dfb4.finish();
+    dfb5.finish();
+    dfb6.finish();
+    dfb7.finish();
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_bench_worst2_reader_dm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_bench_worst2_reader_dm.cpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Benchmark reader DM kernel for BenchmarkCaseFive (worst-case-two init benchmark).
+//
+// Each of the four single-thread DM reader kernels (one per 3-DFB group) runs
+// this kernel, bound to dfb::out0, dfb::out1, dfb::out2.
+//
+// DFB config: 1Sx4A, num_entries=16, num_producers=1, num_consumers=4
+//
+// Drains the full 16-entry ring per DFB: the sole DM producer issues all
+// 16 implicit reads per DFB.
+
+#include "dfb_implicit_read_helper.h"
+
+namespace {
+constexpr uint32_t kNumEntries = 16u;
+constexpr uint32_t kReadsPerDm = kNumEntries;
+}  // namespace
+
+void kernel_main() {
+    Noc noc;
+    DataflowBuffer out0(dfb::out0);
+    DataflowBuffer out1(dfb::out1);
+    DataflowBuffer out2(dfb::out2);
+
+    for (uint32_t i = 0; i < kReadsPerDm; i++) {
+        dfb_issue_implicit_read(noc, out0);
+        dfb_issue_implicit_read(noc, out1);
+        dfb_issue_implicit_read(noc, out2);
+    }
+
+    out0.finish();
+    out1.finish();
+    out2.finish();
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_bench_worst3_dm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_bench_worst3_dm.cpp
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// DM producer kernel for BenchmarkCaseSeven ISR latency benchmark.
+//
+// Six DM threads (DM0–DM5) run this kernel. Each DM checks its mhartid and
+// issues one implicit NOC read per DFB it produces, then calls finish().
+// DFB IDs are addressed via the low-level uint16_t constructor since
+// kernel_bindings_generated.h has no constants (DFBs are created with
+// explicit risc masks, not kernel bindings).
+//
+// DFB layout (32 DFBs total, 16×1Sx1S + 16×1Sx2A):
+//   1Sx1S (DFBs 0–15): one DM producer, one Neo STRIDED consumer
+//     DFB  0– 3 : DM4 → Neo0
+//     DFB  4– 7 : DM5 → Neo1
+//     DFB  8–11 : DM4 → Neo2
+//     DFB 12–15 : DM5 → Neo3
+//
+//   1Sx2A (DFBs 16–31): one DM producer, two Neo ALL consumers via remapper
+//     DFB 16–19 : DM2 → {Neo0, Neo2}
+//     DFB 20–23 : DM3 → {Neo0, Neo2}
+//     DFB 24–27 : DM4 → {Neo1, Neo3}
+//     DFB 28–31 : DM5 → {Neo1, Neo3}
+//
+// TC budget (16 per tensix, 64 total):
+//   t0: 4(1Sx1S Neo0) + 4(DM4 prod 24-27) + 4(Neo0 cons DM2) + 4(Neo0 cons DM3) = 16
+//   t1: 4(1Sx1S Neo1) + 4(DM5 prod 28-31) + 4(Neo1 cons DM4) + 4(Neo1 cons DM5) = 16
+//   t2: 4(1Sx1S Neo2) + 4(DM2 prod 16-19) + 4(Neo2 cons DM2) + 4(Neo2 cons DM3) = 16
+//   t3: 4(1Sx1S Neo3) + 4(DM3 prod 20-23) + 4(Neo3 cons DM4) + 4(Neo3 cons DM5) = 16
+// Remapper: 16 × 1-to-2 entries (all 16 one-to-many slots), 32 set_clientR_slot writes.
+//
+// Producer implicit sync is enabled for 24 DFBs and disabled for IDs
+// 0, 1, 4, 5, 16, 17, 20, and 21 so the benchmark fits the 24-ID DFB pool.
+//
+// Threshold table (implicit-sync DFBs, num_entries=1, num_producers=1):
+//   num_txn_ids   = 1  (no n≥2 divides 1; falls back to 1)
+//   hw_threshold  = 1  (1 / 1 = 1 total read per txn ID)
+//   per_txn       = 1  (each DM issues exactly 1 read to fire the ISR)
+//   tiles_to_post = 1
+//
+// Each implicit-sync DM issues 1 read per DFB → ISR fires → posts 1 credit to consumer TC.
+//
+// Source: DRAM bank 0 offset 0 (data content irrelevant; ISR timing is the goal).
+
+#include "dfb_implicit_read_helper.h"
+
+void kernel_main() {
+    uint32_t dm_id;
+    asm volatile("csrr %0, mhartid" : "=r"(dm_id));
+
+    Noc noc;
+
+    auto issue_and_finish = [&](uint16_t id) {
+        DataflowBuffer dfb(id);
+        // dfb_issue_implicit_read(noc, dfb);
+        // dfb.finish();
+    };
+
+    if (dm_id == 4) {
+        // 1Sx1S DFBs 0–3 (→ Neo0) and 8–11 (→ Neo2)
+        issue_and_finish(0);  issue_and_finish(1);
+        issue_and_finish(2);  issue_and_finish(3);
+        issue_and_finish(8);  issue_and_finish(9);
+        issue_and_finish(10); issue_and_finish(11);
+        // 1Sx2A DFBs 24–27 (→ {Neo1, Neo3})
+        issue_and_finish(24); issue_and_finish(25);
+        issue_and_finish(26); issue_and_finish(27);
+    } else if (dm_id == 5) {
+        // 1Sx1S DFBs 4–7 (→ Neo1) and 12–15 (→ Neo3)
+        issue_and_finish(4);  issue_and_finish(5);
+        issue_and_finish(6);  issue_and_finish(7);
+        issue_and_finish(12); issue_and_finish(13);
+        issue_and_finish(14); issue_and_finish(15);
+        // 1Sx2A DFBs 28–31 (→ {Neo1, Neo3})
+        issue_and_finish(28); issue_and_finish(29);
+        issue_and_finish(30); issue_and_finish(31);
+    } else if (dm_id == 2) {
+        // 1Sx2A DFBs 16–19 (→ {Neo0, Neo2})
+        issue_and_finish(16); issue_and_finish(17);
+        issue_and_finish(18); issue_and_finish(19);
+    } else if (dm_id == 3) {
+        // 1Sx2A DFBs 20–23 (→ {Neo0, Neo2})
+        issue_and_finish(20); issue_and_finish(21);
+        issue_and_finish(22); issue_and_finish(23);
+    }
+    // DM0/DM1 coordinators; DM6–DM7 unused.
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_bench_worst4_dm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_bench_worst4_dm.cpp
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// DM producer kernel for BenchmarkCaseSix (worst-case-four init benchmark).
+//
+// Six DM threads (DM0–DM5) run this kernel. Each DM checks its mhartid and
+// issues one implicit NOC read per DFB it produces, then calls
+// dfb_finish_single_implicit_read_producer() (no collective thread sync).
+// DFB IDs use the low-level uint16_t constructor (explicit risc masks, no bindings).
+//
+// Drains the full ring per DFB (num_entries=1): 1 implicit read + finish per DFB.
+//
+// DFB layout (24 DFBs total, 16×1Sx2A + 8×1Sx1A):
+//
+//   1Sx2A (DFBs 0–15): STRIDED producer, ALL consumer — 1-to-2 remapper entry each.
+//     DFB  0– 3 : DM2 → {Neo0, Neo2}
+//     DFB  4– 7 : DM3 → {Neo0, Neo2}
+//     DFB  8–11 : DM4 → {Neo1, Neo3}
+//     DFB 12–15 : DM5 → {Neo1, Neo3}
+//
+//   1Sx1A (DFBs 16–23): STRIDED producer, ALL consumer — 1-to-1 remapper entry each.
+//     DFB 16–17 : DM2 → Neo1
+//     DFB 18–19 : DM3 → Neo1
+//     DFB 20–21 : DM2 → Neo3
+//     DFB 22–23 : DM4 → Neo0
+//
+// Quasar launches this kernel on num_threads_per_cluster=6 DM harts, but each DFB
+// has a single producer. Use dfb_finish_single_implicit_read_producer() instead of
+// finish() to skip the collective sync_threads barrier in handle_final_credits.
+
+#include "dfb_bench_finish_helper.h"
+#include "dfb_implicit_read_helper.h"
+
+void kernel_main() {
+    uint32_t dm_id;
+    asm volatile("csrr %0, mhartid" : "=r"(dm_id));
+
+    Noc noc;
+
+    auto issue_and_finish = [&](uint16_t id) {
+        DataflowBuffer dfb(id);
+        // dfb_issue_implicit_read(noc, dfb);
+        // dfb_finish_single_implicit_read_producer(dfb);
+    };
+
+    if (dm_id == 4) {
+        issue_and_finish(8);
+        issue_and_finish(9);
+        issue_and_finish(10);
+        issue_and_finish(11);
+        issue_and_finish(22);
+        issue_and_finish(23);
+    } else if (dm_id == 5) {
+        issue_and_finish(12);
+        issue_and_finish(13);
+        issue_and_finish(14);
+        issue_and_finish(15);
+    } else if (dm_id == 2) {
+        issue_and_finish(0);
+        issue_and_finish(1);
+        issue_and_finish(2);
+        issue_and_finish(3);
+        issue_and_finish(16);
+        issue_and_finish(17);
+        issue_and_finish(20);
+        issue_and_finish(21);
+    } else if (dm_id == 3) {
+        issue_and_finish(4);
+        issue_and_finish(5);
+        issue_and_finish(6);
+        issue_and_finish(7);
+        issue_and_finish(18);
+        issue_and_finish(19);
+    }
+    // DM0/DM1 coordinators; DM6–DM7 unused.
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_bench_worst_reader_dm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_bench_worst_reader_dm.cpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Benchmark reader DM kernel for BenchmarkCaseFour (worst-case init benchmark).
+//
+// Acts as STRIDED PRODUCER on three 4Sx4A DM→Tensix DFBs:
+//   dfb::out0, dfb::out1, dfb::out2
+//
+// Drains the full 16-entry ring per DFB (num_entries=16, 4 strided producers):
+//   each DM issues 16 / 4 = 4 implicit reads per DFB.
+
+#include "dfb_implicit_read_helper.h"
+
+namespace {
+constexpr uint32_t kNumEntries = 16u;
+constexpr uint32_t kNumProducers = 4u;
+constexpr uint32_t kReadsPerDm = kNumEntries / kNumProducers;
+}  // namespace
+
+void kernel_main() {
+    Noc noc;
+    DataflowBuffer out0(dfb::out0);
+    DataflowBuffer out1(dfb::out1);
+    DataflowBuffer out2(dfb::out2);
+
+    for (uint32_t i = 0; i < kReadsPerDm; i++) {
+        dfb_issue_implicit_read(noc, out0);
+        dfb_issue_implicit_read(noc, out1);
+        dfb_issue_implicit_read(noc, out2);
+    }
+
+    out0.finish();
+    out1.finish();
+    out2.finish();
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_implicit_read_helper.h
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_implicit_read_helper.h
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Shared helper for DFB ISR-to-credit latency benchmarks.
+//
+// dfb_issue_implicit_read() issues one implicit-sync NOC read for a DFB
+// producer, which will cause the ISR to fire once hw_threshold total reads
+// have accumulated across all sharing DMs. Call this exactly per_txn times
+// per DFB (per txn ID) to hit the threshold.
+//
+// Implementation details:
+//   - The source is DRAM bank 0 at offset 0; data content is irrelevant since
+//     the benchmark cares only about ISR timing, not data correctness.
+//   - AllocatorBank<DRAM> resolves bank coordinates via the device-side
+//     dram_bank_to_noc_xy[] table; no host-side address passing is needed.
+//   - The DFB manages its txn ID, L1 destination (write_ptr), and entry size
+//     internally; the caller provides only the Noc instance and DFB handle.
+
+#pragma once
+
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/dataflow/noc.h"
+
+// Issues one implicit-sync NOC read for a DFB producer.
+// Call per_txn times per DFB to trigger the ISR threshold.
+FORCE_INLINE void dfb_issue_implicit_read(const Noc& noc, DataflowBuffer& dfb) {
+    AllocatorBank<AllocatorBankType::DRAM> dram{};
+    noc.async_read<NocOptions::TXN_ID>(dram, dfb, {.bank_id = 0, .addr = 0}, {});
+}

--- a/tt_metal/hw/firmware/src/tt-2xx/dispatch_dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dispatch_dm.cc
@@ -91,6 +91,7 @@ inline void wait_subordinates() {
 }
 
 thread_local LocalDFBInterface g_dfb_interface[dfb::NUM_DFBS] __attribute__((used));
+thread_local uintptr_t g_dfb_config_base_addr __attribute__((used));
 overlay::RemapperAPI g_remapper_configurator __attribute__((used));
 volatile TxnDFBDescriptor g_txn_dfb_descriptor[32] __attribute__((used));
 volatile KernelBarrier g_kernel_barrier[NUM_KERNEL_BARRIERS] __attribute__((used));

--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -137,6 +137,7 @@ void deassert_trisc() {
 }
 
 thread_local LocalDFBInterface g_dfb_interface[dfb::NUM_DFBS] __attribute__((used));
+thread_local uintptr_t g_dfb_config_base_addr __attribute__((used));
 overlay::RemapperAPI g_remapper_configurator __attribute__((used));
 volatile TxnDFBDescriptor g_txn_dfb_descriptor[32] __attribute__((used));
 volatile KernelBarrier g_kernel_barrier[NUM_KERNEL_BARRIERS] __attribute__((used));
@@ -205,6 +206,13 @@ inline void start_subordinate_kernel_run_early(uint32_t enables) {
     }
 }
 
+// Wake DM1 to run setup_dfb_remapper in parallel with DM0's ISR setup.
+// DM1 has a dedicated DFB-init-only loop and never runs user kernels.
+// Called before DM0's setup_dfb_implicit_sync so both run concurrently.
+inline void start_dm1_dfb_init() {
+    *((volatile uint8_t*)&(subordinate_sync->dm1)) = RUN_SYNC_MSG_GO;
+}
+
 inline void wait_subordinates() {
     WAYPOINT("NTW");
     // Set subordinate_sync->padding to 0 to make checks against subordinate_sync->allDMs correct.
@@ -231,6 +239,11 @@ extern "C" uint32_t _start1() {
     }
     extern uint32_t __ldm_tdata_init[];
     do_thread_crt1(__ldm_tdata_init);
+
+    // Remapper can always stay enabled even if no remapper pairs are configured.
+    // The default mirroring scheme is used if a particular remapper entry's clientR[0] valid bit is not set.
+    g_remapper_configurator.enable_remapper();
+
     while ((*GET_MAILBOX_ADDRESS_DEV(fw_shared_globals_ready))[0] != SHARED_GLOBALS_READY_GO) {
     }
     WAYPOINT("I");
@@ -350,47 +363,16 @@ extern "C" uint32_t _start1() {
                 // prev_noc_mode = noc_mode;
 
                 uint32_t tt_l1_ptr* dfb_l1_base =
-                    (uint32_t tt_l1_ptr*)(MEM_L1_UNCACHED_BASE + kernel_config_base +
+                    (uint32_t tt_l1_ptr*)(kernel_config_base +
                                           launch_msg_address->kernel_config.local_cb_offset);
                 start_subordinate_kernel_run_early(enables);
 
                 // DM0 needs to setup DFBs to program implicit synchronization regardless of whether it runs a kernel or not.
                 uint32_t num_local_dfbs = launch_msg_address->kernel_config.local_cb_mask;
-                setup_local_dfb_interfaces(dfb_l1_base, num_local_dfbs);
-
-                // Run the kernel
-                int index = static_cast<std::underlying_type<TensixProcessorTypes>::type>(TensixProcessorTypes::DM0);
+                // Kick DM1 to run remapper config in parallel with DM0's ISR setup.
+                start_dm1_dfb_init();
                 WAYPOINT("R");
-                if (enables & (1u << index)) {
-                    uintptr_t kernel_lma =
-                        (static_cast<uint32_t>(kernel_config_base) +
-                         launch_msg_address->kernel_config.kernel_text_offset[index]);
-                    // Invalidate the i$ now the kernels have loaded and before running
-                    invalidate_kernel_binary_l2_cache(kernel_lma, launch_msg_address, index);
-                    invalidate_l1_icache();
-                    auto stack_free = reinterpret_cast<uint32_t (*)()>(kernel_lma)();
-                    record_stack_usage(stack_free);
-                } else {
-#if defined(PROFILE_KERNEL)
-                    // This was not initialized in the kernel
-                    // Currently FW does not issue a barrier except when using profiler
-                    // if (noc_mode == DM_DEDICATED_NOC) {
-                    //     noc_local_state_init(noc_index);
-                    // }
-#endif
-                    // DM0 is responsible for issuing any noc cmds needed when initializing remote cbs
-                    // So have DM0 setup remote cb interfaces even when DM0 is not in use
-                    // if (launch_msg_address->kernel_config.enables) {
-                    //     cb_l1_base =
-                    //         (uint32_t tt_l1_ptr*)(kernel_config_base +
-                    //         launch_msg_address->kernel_config.remote_cb_offset);
-                    //     uint32_t end_cb_index = launch_msg_address->kernel_config.min_remote_cb_start_index;
-                    //     experimental::setup_remote_cb_interfaces<true>(
-                    //         cb_l1_base, end_cb_index, noc_index, noc_mode, true, cmd_buf);
-                    //     barrier_remote_cb_interface_setup(noc_index, end_cb_index);
-                    // }
-                    wait_for_go_message();
-                }
+                setup_dfb_implicit_sync(dfb_l1_base, num_local_dfbs);
                 WAYPOINT("D");
 
                 wait_subordinates();
@@ -398,10 +380,9 @@ extern "C" uint32_t _start1() {
                 trigger_sync_register_init();
 
                 // Need to ensure that Remapper state is cleared for next kernel launch
-                if (g_remapper_configurator.is_remapper_enabled()) {
-                    g_remapper_configurator.clear_all_pairs();
-                    g_remapper_configurator.disable_remapper();
-                }
+                // Remapper initialization by DM1 tracks which pairs were configured. This will clear valid bits for all configured remappings.
+                g_remapper_configurator.clear_clientL_valid_up_to_high_watermark_hw();
+                g_remapper_configurator.reset_pair_high_watermark();
             }
 
             // Signal host/dispatcher completion after the DM0-FW zone above has finalized, so DM0's markers
@@ -446,11 +427,18 @@ extern "C" uint32_t _start1() {
         uintptr_t kernel_lma =
             static_cast<uint32_t>(kernel_config_base) + launch_msg->kernel_config.kernel_text_offset[index];
 
-        uint32_t tt_l1_ptr* dfb_l1_base = (uint32_t tt_l1_ptr*)(MEM_L1_UNCACHED_BASE + kernel_config_base +
+        uint32_t tt_l1_ptr* dfb_l1_base = (uint32_t tt_l1_ptr*)(kernel_config_base +
                                                                 launch_msg->kernel_config.local_cb_offset);
         uint32_t num_local_dfbs = launch_msg->kernel_config.local_cb_mask;
 
+        if (hartid == 1) {
+            setup_dfb_remapper(dfb_l1_base, num_local_dfbs);
+            *((volatile uint8_t*)&(subordinate_sync->dm1)) = RUN_SYNC_MSG_DONE;
+            continue;
+        }
+
         setup_local_dfb_interfaces(dfb_l1_base, num_local_dfbs);
+
         my_relative_x_ = my_logical_x_ - launch_msg->kernel_config.sub_device_origin_x;
         my_relative_y_ = my_logical_y_ - launch_msg->kernel_config.sub_device_origin_y;
         overlay_cmd_buff_init(MEM_NOC_ATOMIC_RET_VAL_ADDR);

--- a/tt_metal/hw/firmware/src/tt-2xx/dmk.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dmk.cc
@@ -49,14 +49,7 @@ uint32_t _start() {
     uint32_t my_kt = launch_msg->kernel_config.kernel_text_offset[hartid];
     uint32_t thread_0_hartid = hartid;
     if (launch_msg->kernel_config.enables & (1u << hartid)) {
-        for (uint32_t j = 0; j < MaxDMProcessorsPerCoreType; j++) {
-            // DM0 and DM1 are reserved, so their kernel_text_offset[] slots are
-            // left zero-initialized. Skip reserved slots here, otherwise if the
-            // user binary happens to land at offset 0 (e.g. no RTAs/CRTAs/sems/CBs/DFBs
-            // precede it in the kernel-config ring buffer), the search would falsely
-            // match slot 0 and set thread_0_hartid = 0. DM0 never sets
-            // shared_globals_ready[0] = GO, so the user DMs hang forever in the
-            // wait loop below.
+        for (uint32_t j = 2; j < MaxDMProcessorsPerCoreType; j++) {
             if ((launch_msg->kernel_config.enables & (1u << j)) &&
                 launch_msg->kernel_config.kernel_text_offset[j] == my_kt) {
                 thread_0_hartid = j;

--- a/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
@@ -56,6 +56,10 @@ thread_local uint8_t g_dfb_logical_to_compact[dfb::NUM_DFBS] __attribute__((used
 thread_local LocalDFBInterface g_dfb_interface[dfb::NUM_DFBS] __attribute__((used));
 #endif
 #endif
+// Defined for all TRISC types (including math) so kernels that include dataflow_buffer headers link cleanly.
+// For math TRISC, setup_local_dfb_interfaces is not called, so this stays 0; dfb_ensure_ready
+// returns immediately for any DFB math TRISC is not a participant in (expected_signal == 0).
+thread_local uintptr_t g_dfb_config_base_addr __attribute__((used));
 
 namespace ckernel {
 
@@ -158,7 +162,7 @@ extern "C" uint32_t _start1() {
             uintptr_t kernel_config_base = launch_msg->kernel_config.kernel_config_base[ProgrammableCoreType::TENSIX];
 
 #if defined(UCK_CHLKC_UNPACK) || defined(UCK_CHLKC_PACK)
-            uint32_t tt_l1_ptr* dfb_l1_base = (uint32_t tt_l1_ptr*)(MEM_L1_UNCACHED_BASE + kernel_config_base +
+            uint32_t tt_l1_ptr* dfb_l1_base = (uint32_t tt_l1_ptr*)(kernel_config_base +
                                                                     launch_msg->kernel_config.local_cb_offset);
             uint32_t num_local_dfbs = launch_msg->kernel_config.local_cb_mask;
             setup_local_dfb_interfaces(dfb_l1_base, num_local_dfbs);

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer.inl
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer.inl
@@ -25,10 +25,14 @@
 #endif
 
 #if DFB_IS_COMPUTE_MATH
-inline DataflowBuffer::DataflowBuffer(uint16_t logical_dfb_id) : logical_dfb_id_(logical_dfb_id) {}
+inline DataflowBuffer::DataflowBuffer(uint16_t logical_dfb_id) : logical_dfb_id_(logical_dfb_id) {
+    dfb_ensure_ready(g_dfb_config_base_addr, static_cast<uint8_t>(logical_dfb_id));
+}
 #else
 inline DataflowBuffer::DataflowBuffer(uint16_t logical_dfb_id)
-    : logical_dfb_id_(logical_dfb_id), local_dfb_interface_(get_local_dfb_interface(logical_dfb_id)) {}
+    : logical_dfb_id_(logical_dfb_id), local_dfb_interface_(get_local_dfb_interface(logical_dfb_id)) {
+    dfb_ensure_ready(g_dfb_config_base_addr, static_cast<uint8_t>(logical_dfb_id));
+}
 #endif
 
 inline uint32_t DataflowBuffer::get_entry_size() const {
@@ -257,21 +261,29 @@ inline void DataflowBuffer::finish_impl() {
             dfb::PackedTileCounter packed_tc = local_dfb_interface_.tc_slots[i].packed_tile_counter;
             uint8_t tc_id = dfb::get_counter_id(packed_tc);
 #if defined(COMPILE_FOR_TRISC) && (defined(UCK_CHLKC_UNPACK) || defined(UCK_CHLKC_PACK))
-            // TRISC drain: finish() must not return until this TC is empty (posted == 0) -
-            // covers the consumer (UNPACK), the Tensix->DM producer (PACK), and both sides of
-            // an INTRA self-loop. The consumer also skips TCs this TRISC doesn't own via
-            // tensix_trisc_mask, which exists only in the UNPACK-side LocalDFBInterface, so the
-            // gate sits under an inner UNPACK guard (the PACK struct has no such member).
+            // TRISC drain: finish() must not return until this TC is empty (posted == 0).
+            // On TRISC, tile_counters[].f.posted/.acked are live occupancy / free-space
+            // (tiles-available / space-available), NOT the cumulative read_posted/read_acked
+            // totals used by the DM overlay path below. The consumer also skips TCs this TRISC
+            // doesn't own via tensix_trisc_mask, which exists only in the UNPACK-side
+            // LocalDFBInterface, so the gate sits under an inner UNPACK guard (the PACK struct
+            // has no such member).
 #ifdef UCK_CHLKC_UNPACK
             if ((local_dfb_interface_.tensix_trisc_mask & (1u << ckernel::csr_read<ckernel::CSR::TRISC_ID>())) == 0) {
                 continue;
             }
 #endif
-            all_acked = all_acked && (ckernel::trisc::tile_counters[tc_id].f.posted == 0);
+            const uint32_t tiles_avail = ckernel::trisc::tile_counters[tc_id].f.posted & 0xFFFFu;
+            if (tiles_avail != 0) {
+                all_acked = false;
+            }
 #elif !defined(COMPILE_FOR_TRISC)
             uint8_t tensix_id = dfb::get_tensix_id(packed_tc);
-            all_acked &=
-                (overlay::fast_llk_intf_read_acked(tensix_id, tc_id) == overlay::fast_llk_intf_read_posted(tensix_id, tc_id));
+            const uint32_t read_posted = overlay::fast_llk_intf_read_posted(tensix_id, tc_id);
+            const uint32_t read_acked = overlay::fast_llk_intf_read_acked(tensix_id, tc_id);
+            if (read_acked != read_posted) {
+                all_acked = false;
+            }
 #endif
         }
     }

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h
@@ -11,9 +11,9 @@
 //   user / kernel : [0, USER_TXN_ID_MAX]
 //   DFB / runtime : [DFB_TXN_ID_BASE, HW_TXN_ID_MAX]  (allocated top-down)
 constexpr uint8_t HW_TXN_ID_MAX = 31;
-constexpr uint8_t USER_TXN_ID_MAX = 15;
-constexpr uint8_t DFB_TXN_ID_BASE = USER_TXN_ID_MAX + 1;                       // 16
-constexpr uint8_t NUM_DFB_POOL_TXN_IDS = HW_TXN_ID_MAX - DFB_TXN_ID_BASE + 1;  // 16
+constexpr uint8_t USER_TXN_ID_MAX = 7;
+constexpr uint8_t DFB_TXN_ID_BASE = USER_TXN_ID_MAX + 1;                       // 8
+constexpr uint8_t NUM_DFB_POOL_TXN_IDS = HW_TXN_ID_MAX - DFB_TXN_ID_BASE + 1;  // 24
 static_assert(USER_TXN_ID_MAX >= 1);
 static_assert(DFB_TXN_ID_BASE > USER_TXN_ID_MAX);
 
@@ -39,13 +39,23 @@ constexpr uint8_t NUM_REMAPPER_PAIRINGS = 64;
 // Max txn ids assigned to one DFB producer or consumer side
 constexpr uint8_t NUM_TXN_IDS = 4;
 static_assert(NUM_DFB_POOL_TXN_IDS >= NUM_TXN_IDS);
+// Max TCs a single risc RR-walks for one DFB; also the per-DFB producer signal-slot
+// stride. Quasar reserves DM0 (ISR) and DM1 (remapper), so at most DM2–7 (=6) can
+// participate as producers/consumers — keep these limits identical.
 constexpr uint8_t MAX_NUM_TILE_COUNTERS_TO_RR = 6;
-// Max tile counter ids that can be collected for one side (producer or consumer) of a DFB during
-// init, summed across that side's riscs. Bounded by TxnDFBDescriptor::tile_counters, the ISR
-// descriptor the collected ids are copied into, so the two must never diverge.
-constexpr uint8_t MAX_TILE_COUNTERS_PER_SIDE = 18;
+constexpr uint8_t MAX_PRODUCERS_PER_DFB = MAX_NUM_TILE_COUNTERS_TO_RR;
+// DM0 blob constants
+constexpr uint8_t MAX_DM0_REMAPPER_SLOTS = 8;  // max DM producer RISCs
+constexpr uint8_t MAX_CLIENT_RS          = 4;   // max consumers per remapper slot (4 Tensix or 4 DM clientR IDs)
+// Must match TxnDFBDescriptor::tile_counters[18] (32-byte ISR blob slot).
+// Worst consumer case: 4 ALL DMs × 4 producer TCs = 16; worst producer case: 6 DM producers × 1 TC.
+constexpr uint8_t MAX_TCS_PER_TXN        = 18;
+// Alias used by TxnDFBDescriptor / main-line overflow guards. Keep identical to MAX_TCS_PER_TXN.
+constexpr uint8_t MAX_TILE_COUNTERS_PER_SIDE = MAX_TCS_PER_TXN;
 
 constexpr uint16_t TENSIX_RISC_OFFSET = 8; // First 8 represent DMs
+// Hartids 0-7 = DM0-7, 8-11 = Neo0-3 (TRISC init uses 8 + neo_id).
+constexpr uint8_t NUM_PARTICIPATING_HARTIDS = 12;
 
 using PackedTileCounter = uint8_t;  // bits 5-6: tensix_id (2 bits), bits 0-4: counter_id (5 bits)
 
@@ -71,20 +81,166 @@ inline __attribute__((always_inline)) constexpr uint8_t get_counter_id(PackedTil
 }  // namespace dfb
 
 /*
-    tensix + dm or tensix + tensix via remapper dfb
-    LogicalDFB 0:
-    | dfb_initializer_t |
-    | dfb_initializer_per_risc_t | risc 0
-    | dfb_initializer_per_risc_t | risc 1
-    ...
-    | dfb_initializer_per_risc_t | risc 11
-    LogicalDFB 1:
-    | dfb_initializer_t |
-    | dfb_initializer_per_risc_t | risc 0
-    | dfb_initializer_per_risc_t | risc 1
-    ...
-    (36 + (62 * 12)) * 16 = 12480 bytes
+    DFB config region layout (Quasar / tt-2xx):
+
+    [dfb_config_base]:
+      dfb_global_header_t (96B) — fixed-size; DM1/DM0 blob offsets stored inside.
+
+    [dfb_config_base + dm1_remapper_blob_offset]:
+      DM1 remapper blob — core-wide flat layout, read by DM1:
+        [dfb_dm1_remapper_core_header_t(4B) + dfb_dm1_remapper_slot_t × num_slots]
+
+    [dfb_config_base + dm0_isr_blob_offset]:
+      DM0 ISR blob — core-wide, read by DM0:
+        [dfb_dm0_isr_blob_core_header_t(8B): precomputed producer/consumer txn IE masks]
+        [txn_threshold_pool: dfb_dm0_isr_txn_threshold_t, one slot per used txn id (see
+                             dm0_isr_txn_slot_index), ascending id order]
+        [txn_desc_pool: dfb_dm0_txn_descriptor_image_t, same dense slot order, contiguous after txn_hw_pool]
+        ...
+
+    [dfb_config_base + ghdr->hart_blob_offset[h]]:
+      Per-hart sequential init blob (one per participating hartid):
+        dfb_hart_init_entry_t[num_entries]  — one per DFB this hart participates in
+        (4B-padded end)
+      Entry count is NOT stored in the blob; device derives it from participation_mask[h].
+      hart_blob_offset[h] points at the first init entry (4B-aligned).
+      Non-participating harts have a minimal 4-byte {0,0,0,0} blob.
+
+    [dfb_config_base + dfb_signal_region_off]:
+      uint8_t  dfb_signal[NUM_DFBS * MAX_PRODUCERS_PER_DFB]  — 192B; producer i of DFB d writes
+                                                                       byte 1 to slot [d*MAX_PRODUCERS_PER_DFB+i].
+      uint32_t dfb_expected_signal[NUM_DFBS]                        — 128B; host-computed bitmask of which
+                                                                       producer bits are active per DFB.
+      Producers use a plain volatile store + fence (no AMO). Consumers iterate over bits in
+      dfb_expected_signal[d] and poll each producer's byte slot in dfb_signal.
+
+    DM1 reads linearly through only remapper slot data (unchanged).
+    DM0 reads linearly through only ISR txn data (unchanged).
+    DM2-7 + TRISC each walk their own sequential init blob — no pointer-table indirection.
+
+    Memory (worst case 4Sx4A, 5 riscs, 4 rmp slots, 8 DFBs):
+      96 + (4+4*16) + (8+20)*8 + per_hart_blobs(~3.2KB) + signal_region(256B) ≈ 3.7KB
 */
+
+// Fixed header at the start of the DFB config region.
+struct dfb_global_header_t {
+    uint32_t dm1_remapper_blob_offset;  // → DM1 remapper blob
+    uint32_t dm0_isr_blob_offset;       // → DM0 ISR blob (core header + txn pools)
+    uint32_t dfb_signal_region_off;     // → signal region: per-producer byte slots then dfb_expected_signal[NUM_DFBS]
+    uint8_t  num_dfbs;
+    uint8_t  dm0_isr_ready;             // cleared by host; set by DM0 when ISR is armed
+    uint8_t  has_dm0_isr;               // 1 if any DFB uses implicit sync (replaces per_dfb_layout_offset > dm0 check)
+    uint8_t  _pad;
+    // participation_mask[h] bit i set → hartid h participates in DFB i.
+    // Device init uses popcount(participation_mask[h]) as this hart's init/wait entry count.
+    uint32_t participation_mask[dfb::NUM_PARTICIPATING_HARTIDS];  // 48B
+    // Byte offset from config_base to each hartid's init blob (first init entry).
+    // Non-participating harts point to an emitted minimal {0,0,0,0} blob.
+    uint16_t hart_blob_offset[dfb::NUM_PARTICIPATING_HARTIDS];    // 24B
+    uint8_t  _pad2[8];  // pad to 96B
+};
+
+// DM1/DM0 blobs begin immediately after the header; no prefix tables.
+inline uint32_t dfb_config_header_size() { return sizeof(dfb_global_header_t); }
+
+// Number of init/wait entries in a hart blob (= popcount of participation_mask[h]).
+inline uint8_t dfb_hart_participation_count(uint32_t participation_mask) {
+    return static_cast<uint8_t>(__builtin_popcount(participation_mask));
+}
+
+// Flag bits for dfb_hart_init_entry_t::flags
+constexpr uint8_t DFB_HART_FLAG_IS_PRODUCER  = (1u << 7);
+constexpr uint8_t DFB_HART_FLAG_REMAPPER_EN  = (1u << 6);
+constexpr uint8_t DFB_HART_FLAG_BROADCAST_TC = (1u << 5);
+constexpr uint8_t DFB_HART_FLAG_TRISC_MASK   = 0x0Fu;  // bits 3:0 = tensix_trisc_mask (which TRISC(s) run DFB ops)
+
+// Layout: dfb_blob_tc_pair_t[num_tcs] immediately after the 28B header, followed by
+// uint8_t packed_tile_counter[num_tcs] padded to the next 4B boundary.
+// This keeps base_addr and limit for the same slot adjacent (8B apart, same cache line).
+// Total TC section = num_tcs*9B rounded up to 4B.
+struct dfb_blob_tc_pair_t {
+    uint32_t base_addr;  // TRISC: tile units (host >> cb_addr_shift); DM: raw byte addresses
+    uint32_t limit;      // TRISC: tile units (host >> cb_addr_shift); DM: raw byte addresses
+};
+static_assert(sizeof(dfb_blob_tc_pair_t) == 8, "dfb_blob_tc_pair_t must be 8B");
+
+// Per-(hart, DFB) init entry in this hart's sequential blob.
+// Fixed 28B header, followed by dfb_blob_tc_pair_t[num_tcs] (8B each), then
+// uint8_t packed_tile_counter[num_tcs] padded to 4B.
+// Total entry size = 28 + ceil9(num_tcs) where ceil9(n) = (n*9 + 3) & ~3.
+struct dfb_hart_init_entry_t {
+    uint8_t  logical_dfb_id;
+    uint8_t  num_tcs;
+    uint8_t  flags;                          // DFB_HART_FLAG_* bits above; bits3:0 = tensix_trisc_mask
+    uint8_t  capacity;                       // producer: TC capacity; consumer: 0
+    uint32_t entry_size;                     // raw bytes; device applies >> cb_addr_shift
+    // Host precomputes the ready-to-copy stride_size per hart type:
+    //   DM harts:    stride_size_precomp = entry_size_raw * stride_in_entries  (raw bytes)
+    //   TRISC harts: stride_size_precomp = (entry_size_raw >> cb_addr_shift) * stride_in_entries  (tile units)
+    uint32_t stride_size_precomp;
+    uint8_t  stride_size_tiles;              // TRISC: stride in entries; DM: unused (see dm scalar pack below)
+    uint8_t  num_txn_ids;                    // TRISC layout byte 13; DM pack uses byte 21 (see below)
+    uint8_t  threshold;                      // TRISC layout; DM pack byte 18
+    uint8_t  num_entries_per_txn_id;         // TRISC layout; DM pack byte 19
+    uint8_t  num_entries_per_txn_id_per_tc;  // TRISC layout byte 16; DM pack byte 20
+    uint8_t  producer_signal_bit;            // TRISC layout byte 17; DM pack byte 13 (transport)
+    uint8_t  txn_ids[dfb::NUM_TXN_IDS];     // TRISC layout bytes 18-21; DM pack bytes 14-17
+    uint8_t  remapper_pair_index;            // TRISC layout byte 22; DM pack remapper at byte 23
+    uint8_t  _pad;                           // byte 23; DM pack p[11] overwrites with remapper_pair_index
+    uint16_t num_entries;                    // bytes 24-25; ring entry count (main update_size path)
+    uint8_t  _pad2[2];                       // pad header to 28B → 4B-aligned TC arrays follow
+} __attribute__((packed));
+static_assert(sizeof(dfb_hart_init_entry_t) == 28, "dfb_hart_init_entry_t must be 28B");
+
+// DM only: bytes [12,24) of the init entry header mirror LocalDFBInterface bytes [8,20)
+// (num_tcs_to_rr through _tc_align_pad). Host writes this 12B span in DTCM order; device
+// unpacks w3–w5 in dfb_unpack_entry_header_dm and stores via dfb_write_dm_iface_scalars_from_hdr.
+// Byte 13 carries producer_signal_bit for init decode (device sets tc_idx=0 after scalar write).
+constexpr uint32_t DFB_INIT_ENTRY_DM_SCALAR_PACK_BYTE_OFF = 12u;
+constexpr uint32_t DFB_INIT_ENTRY_DM_SCALAR_PACK_BYTES = 12u;
+constexpr uint32_t DFB_INIT_ENTRY_DM_PRODUCER_SIGNAL_BYTE_OFF = 13u;
+
+inline void dfb_write_dm_scalar_pack_to_blob(
+    uint8_t* entry_bytes,
+    uint8_t num_tcs,
+    uint8_t producer_signal_bit,
+    const uint8_t txn_ids[dfb::NUM_TXN_IDS],
+    uint8_t threshold,
+    uint8_t num_entries_per_txn_id,
+    uint8_t num_entries_per_txn_id_per_tc,
+    uint8_t num_txn_ids,
+    uint8_t broadcast_tc,
+    uint8_t remapper_pair_index) {
+    uint8_t* const p = entry_bytes + DFB_INIT_ENTRY_DM_SCALAR_PACK_BYTE_OFF;
+    p[0] = num_tcs;
+    p[1] = producer_signal_bit;
+    p[2] = txn_ids[0];
+    p[3] = txn_ids[1];
+    p[4] = txn_ids[2];
+    p[5] = txn_ids[3];
+    p[6] = threshold;
+    p[7] = num_entries_per_txn_id;
+    p[8] = num_entries_per_txn_id_per_tc;
+    p[9] = num_txn_ids;
+    p[10] = broadcast_tc;
+    p[11] = remapper_pair_index;
+}
+
+inline uint8_t dfb_read_init_entry_producer_signal_bit(const uint8_t* entry_bytes, bool is_dm_hart) {
+    if (is_dm_hart) {
+        return entry_bytes[DFB_INIT_ENTRY_DM_PRODUCER_SIGNAL_BYTE_OFF];
+    }
+    return reinterpret_cast<const dfb_hart_init_entry_t*>(entry_bytes)->producer_signal_bit;
+}
+
+// Returns total serialized bytes for one dfb_hart_init_entry_t with num_tcs TC slots.
+// num_tcs pairs (8B each) + num_tcs ptc bytes, rounded up to 4B.
+// = sizeof(header) + ((num_tcs * 9 + 3) & ~3).
+inline constexpr uint32_t dfb_hart_init_entry_byte_size(uint32_t num_tcs) {
+    const uint32_t tc_bytes = num_tcs * 9u;
+    return static_cast<uint32_t>(sizeof(dfb_hart_init_entry_t)) + ((tc_bytes + 3u) & ~3u);
+}
+
 struct dfb_txn_id_descriptor_t {
     uint8_t txn_ids[dfb::NUM_TXN_IDS];
     uint8_t num_entries_to_process_threshold; // entries each txn ID tracks before posting/acking
@@ -93,58 +249,180 @@ struct dfb_txn_id_descriptor_t {
     uint8_t num_entries_per_txn_id_per_tc;
 } __attribute__((packed));
 
-struct dfb_initializer_t {  // 36 bytes
-    uint32_t logical_id;
+// Every field is naturally aligned at its current offset:
+// entry_size/stride_in_entries (u32) at 0/4, capacity/num_entries (u16) at 8/10,
+// risc_mask_bits (u16 bitfield) at 12, producer/consumer txn descriptors (packed, alignment 1) at 14/22,
+// trailing u8 fields at 30-33 (struct size 36 with tail padding).
+struct dfb_initializer_t {
     uint32_t entry_size;
     uint32_t stride_in_entries;
     uint16_t capacity;
     uint16_t num_entries;
     struct {
-        uint16_t dm_mask : 8;         // bits 0-7: DM RISC mask
-        uint16_t tensix_mask : 4;     // bits 8-11: Neo RISC mask
-        uint16_t tensix_trisc_mask : 4;        // bits 12-15: indicates which triscs use the DFB (tensix producer uses trisc2 and tensix consumer can use trisc0 or trisc3)
+        uint16_t dm_mask : 8;             // bits 0-7: DM RISC mask
+        uint16_t tensix_mask : 4;         // bits 8-11: Neo RISC mask
+        uint16_t tensix_trisc_mask : 4;   // bits 12-15: which TRISC(s) on the Neo run DFB ops (see dataflow_buffer.inl)
     } risc_mask_bits;
+    // Participant mask (DM/Neo hartids, per_risc layout, popcount): dm_mask | (tensix_mask << 8).
+    // tensix_trisc_mask is separate — TRISC-side only, not OR'd into that mask.
     // For DM-to-DM DFBs, producer and consumer would have different set of transaction ids
     dfb_txn_id_descriptor_t producer_txn_descriptor;
     dfb_txn_id_descriptor_t consumer_txn_descriptor;
     uint8_t num_producers;
-    uint8_t implicit_sync_configured; // 0: init state, 1: configured
+    uint8_t _pad[3];                  // reserved (was dm0_blob_size; DM0 blob is now a separate global region)
+};
+static_assert(sizeof(dfb_initializer_t) == 36, "dfb_initializer_t size changed — check field alignment");
+
+// Core-wide header for the DM1 remapper blob.
+// Followed by dfb_dm1_remapper_slot_t[num_slots] aggregated in ascending DFB id order.
+struct dfb_dm1_remapper_core_header_t {  // 4 bytes
+    uint16_t num_slots;
+    uint8_t _pad[2];
 } __attribute__((packed));
 
-struct dfb_initializer_per_risc_t {  // 62 bytes
-    uint32_t base_addr[dfb::MAX_NUM_TILE_COUNTERS_TO_RR];
-    uint32_t limit[dfb::MAX_NUM_TILE_COUNTERS_TO_RR];
-    uint32_t consumer_tcs;  // used to program remapper, for a L:R mapping contains all the TCs on the consumer side
-                            // (R). TC can be value between 0 and 31 (5 bits, max of 4 TCs)
-    dfb::PackedTileCounter packed_tile_counter[dfb::MAX_NUM_TILE_COUNTERS_TO_RR];
-    struct {
-        uint8_t num_tcs_to_rr : 4;   // 0..15, number of TCs to round-robin (max 6 for 6 user-programmable DM cores)
-        uint8_t tc_init_done : 1;
-        uint8_t broadcast_tc : 1;    // DM-DM ALL: producer posts to all TCs instead of round-robin
-        uint8_t reserved : 2;
-    } __attribute__((packed)) num_tcs_and_init;
-    struct {
-        uint8_t remapper_pair_index : 6;  // bits 0-5: 0..63
-        uint8_t remapper_en : 1;          // bit 6
-        uint8_t is_producer : 1;  // bit 7: indicates if this RISC is a producer
-    } __attribute__((packed)) flags;
-    uint8_t remapper_consumer_ids_mask;  // Bitmask of clientTypes (id_R) for this producer's consumers
-    uint8_t producer_client_type;        // clientL for this producer when using remapper
-} __attribute__((packed));
+// Core-wide header at dm0_isr_blob_offset (before txn threshold + descriptor pools).
+// Host ORs txn ids across all DFBs on this core; DM0 loads once for CMDBUF IE programming.
+struct dfb_dm0_isr_blob_core_header_t {
+    uint32_t producer_txn_id_mask;
+    uint32_t consumer_txn_id_mask;
+};
 
-// intra tensix dfb
-// (24 * 16) * 4 = 1,536 bytes
-struct dfb_initializer_intra_tensix_t {  // 24 bytes
-    uint32_t logical_id;
-    uint32_t entry_size;
-    uint32_t stride_size;
-    uint32_t base_addr;
-    uint32_t limit;
-    uint16_t capacity;
-    dfb::PackedTileCounter packed_tile_counter;
-    uint8_t tensix_mask;
-} __attribute__((packed));
+// CMDBUF threshold for one txn id (role/path implied by producer/consumer masks in core_hdr).
+// 4B stride so the DM0 ISR blob + following hart blobs stay 4B-aligned.
+struct dfb_dm0_isr_txn_threshold_t {
+    uint8_t threshold;
+    uint8_t _pad[3];
+};
 
+// 32-byte image matching TxnDFBDescriptor layout in dataflow_buffer_interface.h.
+struct dfb_dm0_txn_descriptor_image_t {
+    uint8_t num_counters;
+    uint8_t tile_counters[18];
+    uint8_t tiles_to_post_or_ack;  // union post/ack share offset in TxnDFBDescriptor
+    uint8_t _pad[12];
+};
+
+// One entry per producer RISC that uses the remapper.
+// 12 bytes: pair_index + pre-computed clientR/clientL register values.
+//
+// clientR_val / clientL_val are pre-computed on the host using the same bitfield layout
+// as tClientR_Config_Reg_u / tClientL_Config_Reg_u in remapper_common.hpp:
+//
+//   clientR_val  [31:0]:
+//     slot r occupies bits [r*8+7 : r*8]:  id_r[2:0] at bit r*8, cnt_sel_r[4:0] at bit r*8+3
+//     for each consumer r: clientR_val |= (id_R & 0x7) << (r*8) | (tc_R & 0x1F) << (r*8 + 3)
+//
+//   clientL_val  [31:0]:
+//     [2:0]  = producer_client_type (id_L)
+//     [7:3]  = tc_id (cnt_sel_L)
+//     [11:8] = (1 << num_clientRs) - 1  (valid mask)
+//     [12]   = 1  (clientl_is_producer, always 1 for DFB producers)
+//     [13]   = 1  (clientr_group, always 1 for DFB fan-out)
+//     [14]   = 0  (distribute, always 0)
+//
+// Device side: setup_dfb_remapper() writes clientR_val/clientL_val directly to remapper HW
+// registers (no staging through g_remapper_configurator arrays).
+struct dfb_dm1_remapper_slot_t {
+    uint8_t  pair_index;   // remapper pair index for this producer
+    uint8_t  _pad[3];      // pad to 8 bytes
+    uint32_t clientR_val;  // pre-computed ClientR config register value
+    uint32_t clientL_val;  // pre-computed ClientL config register value
+} __attribute__((packed));
+static_assert(sizeof(dfb_dm1_remapper_slot_t) == 12, "dfb_dm1_remapper_slot_t must be 12 bytes");
+
+static_assert(sizeof(dfb_dm0_isr_blob_core_header_t) == 8, "dfb_dm0_isr_blob_core_header_t must be 8 bytes");
+static_assert(sizeof(dfb_dm0_txn_descriptor_image_t) == 32, "dfb_dm0_txn_descriptor_image_t must be 32 bytes");
+static_assert(sizeof(dfb_dm0_isr_txn_threshold_t) == 4, "dfb_dm0_isr_txn_threshold_t must be 4 bytes");
+
+// Both pools hold one slot per txn id actually in use, in ascending id order, so their size
+// depends on how many ids a core uses and not on where those ids sit in [0, HW_TXN_ID_MAX].
+// DFB ids are allocated from the top of the pool, so indexing by raw txn id would make even a
+// single-DFB core emit (and invalidate) a full 32-slot table.
+inline uint32_t dm0_isr_txn_slot_count(uint32_t producer_txn_id_mask, uint32_t consumer_txn_id_mask) {
+    return static_cast<uint32_t>(__builtin_popcount(producer_txn_id_mask | consumer_txn_id_mask));
+}
+
+// Dense slot for txn_id: how many used ids precede it. txn_id must be set in all_mask.
+inline uint32_t dm0_isr_txn_slot_index(uint32_t all_mask, uint32_t txn_id) {
+    return static_cast<uint32_t>(__builtin_popcount(all_mask & ((1u << txn_id) - 1u)));
+}
+
+inline uint32_t dm0_isr_txn_hw_pool_byte_size(uint32_t producer_txn_id_mask, uint32_t consumer_txn_id_mask) {
+    return dm0_isr_txn_slot_count(producer_txn_id_mask, consumer_txn_id_mask) * sizeof(dfb_dm0_isr_txn_threshold_t);
+}
+
+inline uint32_t dm0_isr_txn_desc_pool_byte_size(uint32_t producer_txn_id_mask, uint32_t consumer_txn_id_mask) {
+    return dm0_isr_txn_slot_count(producer_txn_id_mask, consumer_txn_id_mask) * sizeof(dfb_dm0_txn_descriptor_image_t);
+}
+
+inline uint32_t dm0_isr_blob_byte_size(uint32_t producer_txn_id_mask, uint32_t consumer_txn_id_mask) {
+    return sizeof(dfb_dm0_isr_blob_core_header_t) + dm0_isr_txn_hw_pool_byte_size(producer_txn_id_mask, consumer_txn_id_mask) +
+           dm0_isr_txn_desc_pool_byte_size(producer_txn_id_mask, consumer_txn_id_mask);
+}
+
+static_assert(sizeof(dfb_global_header_t) == 96, "dfb_global_header_t size changed — check field alignment");
+static_assert(sizeof(dfb_dm1_remapper_core_header_t) == 4, "dfb_dm1_remapper_core_header_t must be 4 bytes");
 static_assert(sizeof(dfb_initializer_t) == 36, "dfb_initializer_t size is incorrect");
-static_assert(sizeof(dfb_initializer_per_risc_t) == 62, "dfb_initializer_per_risc_t size is incorrect");
-static_assert(sizeof(dfb_initializer_intra_tensix_t) == 24, "dfb_initializer_intra_tensix_t size is incorrect");
+static_assert(sizeof(dfb_hart_init_entry_t) == 28, "dfb_hart_init_entry_t must be 28B");
+
+namespace dfb {
+
+// ---------------------------------------------------------------------------
+// DFB init timing scratch (written by device during setup_*; host reads after benchmarks).
+// Layout: 16 fixed slots × 16 uint32 words (64 B each), 1024 B total in cached L1
+// (tail of the 4 MiB region so host watcher reads succeed and DFB config is not clobbered).
+//
+// Slot order:
+//   0-7:  DM0-DM7
+//   8-15: Neo0 unpack, Neo0 pack, Neo1 unpack, Neo1 pack, Neo2 unpack, Neo2 pack,
+//         Neo3 unpack, Neo3 pack
+//
+// Per-role metrics (A..J = METRIC_A..METRIC_J):
+//   DM0_ISR: A=pre_loop_sw B=subpassB_desc C=hw_reg_write_cycles D=subpassB_l1_read
+//            E=subpassB_rocc_issue F=first_ie_rmw G=second_ie_rmw H=isr_enable
+//            I=unused J=subpassB_hw
+//   DM1_RMP: A=blob_l1_read_sw B=blob_loop_ovhd C=pairs_reg_hw D=enable_remapper_hw
+//            E=first_pair_clientR_hw F=first_pair_clientL_hw G=last_pair_hw
+//            H=hw_reg_write_cycles I=hw_reg_writes J=pairs_slots_written
+//   DM_LOCAL/TRISC: A=merged_sw B=remapper_spin C=tc_hw D=hw_reg_writes E=tc_reset_hw
+//                   F=tc_capacity_hw G=pre_loop H=entry_hdr I=tc_slots J=sig_write
+// ---------------------------------------------------------------------------
+constexpr uint8_t DFB_INIT_TIMING_NUM_SLOTS = 16;
+constexpr uint8_t DFB_INIT_TIMING_WORDS_PER_SLOT = 16;
+constexpr uint32_t DFB_INIT_TIMING_REGION_BYTES =
+    static_cast<uint32_t>(DFB_INIT_TIMING_NUM_SLOTS) * static_cast<uint32_t>(DFB_INIT_TIMING_WORDS_PER_SLOT) *
+    sizeof(uint32_t);
+// Cached L1 byte offset for host reads (DEBUG_VALID_L1_ADDR allows [0, 4 MiB)).
+// Device writes use MEM_L1_UNCACHED_BASE + this offset so TL1 is updated without L2 flush.
+constexpr uint32_t DFB_INIT_TIMING_L1_BYTE_OFFSET =
+    (4u * 1024u * 1024u) - DFB_INIT_TIMING_REGION_BYTES;
+
+constexpr uint32_t DFB_INIT_TIMING_MAGIC = 0xDFB07100u;
+
+enum DfbInitTimingRole : uint8_t {
+    DFB_INIT_TIMING_ROLE_DM0_ISR = 0,
+    DFB_INIT_TIMING_ROLE_DM1_RMP = 1,
+    DFB_INIT_TIMING_ROLE_DM_LOCAL = 2,
+    DFB_INIT_TIMING_ROLE_TRISC_LOCAL = 3,
+};
+
+enum DfbInitTimingWord : uint8_t {
+    DFB_INIT_TIMING_W_MAGIC = 0,
+    DFB_INIT_TIMING_W_VALID = 1,
+    DFB_INIT_TIMING_W_ROLE = 2,
+    DFB_INIT_TIMING_W_E2E = 3,
+    DFB_INIT_TIMING_W_METRIC_A = 4,
+    DFB_INIT_TIMING_W_METRIC_B = 5,
+    DFB_INIT_TIMING_W_METRIC_C = 6,
+    DFB_INIT_TIMING_W_METRIC_D = 7,
+    DFB_INIT_TIMING_W_METRIC_E = 8,
+    DFB_INIT_TIMING_W_METRIC_F = 9,
+    DFB_INIT_TIMING_W_START = 10,
+    DFB_INIT_TIMING_W_END = 11,
+    DFB_INIT_TIMING_W_METRIC_G = 12,
+    DFB_INIT_TIMING_W_METRIC_H = 13,
+    DFB_INIT_TIMING_W_METRIC_I = 14,
+    DFB_INIT_TIMING_W_METRIC_J = 15,
+};
+
+}  // namespace dfb

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 
 #include "internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h"
@@ -11,386 +12,900 @@
 #include "internal/tt-2xx/dataflow_buffer/dataflow_buffer_isr.h"
 #include "internal/tt-2xx/quasar/overlay/remapper_api.hpp"
 #include "internal/circular_buffer_interface.h"  // for cb_addr_shift
+#include "internal/tt-2xx/quasar/dev_mem_map.h"
+#include "internal/tt-2xx/risc_common.h"
 #ifndef COMPILE_FOR_TRISC
 #include "internal/tt-2xx/quasar/overlay/llk_intf_api.hpp"
 #else
 #include "ckernel_trisc_common.h"
 #endif
 
-#include "api/debug/dprint.h"
-
-
-FORCE_INLINE void wait_all_tcs_initialized(uint32_t tt_l1_ptr* dfb_config_base, uint32_t num_dfbs, uint64_t hartid) {
-    WAYPOINT("TCIW");
-    bool all_tcs_initialized = false;
-    while (!all_tcs_initialized) {
-        all_tcs_initialized = true;
-        volatile uint8_t* base_ptr = reinterpret_cast<volatile uint8_t*>(dfb_config_base);
-
-        for (uint32_t logical_dfb_id = 0; logical_dfb_id < num_dfbs; logical_dfb_id++) {
-            volatile dfb_initializer_t* init_ptr = reinterpret_cast<volatile dfb_initializer_t*>(base_ptr);
-
-            if (hartid == 0) {
-                // At this point DM0 configured the ISR. Other DMs need to ensure that the ISR is configured before they start running kernels.
-                init_ptr->implicit_sync_configured = 1;
-            }
-
-            uint16_t risc_mask = (init_ptr->risc_mask_bits.tensix_mask << 8) | init_ptr->risc_mask_bits.dm_mask;
-            uint8_t num_riscs = static_cast<uint8_t>(__builtin_popcount(risc_mask));
-
-            volatile dfb_initializer_per_risc_t* per_risc_base =
-                reinterpret_cast<volatile dfb_initializer_per_risc_t*>(base_ptr + sizeof(dfb_initializer_t));
-
-            // Loop over per_risc: count producers that have set tc_init_done (each per_risc is separate cache line)
-            uint8_t producers_done = 0;
-            for (uint8_t i = 0; i < num_riscs; i++) {
-                if (per_risc_base[i].flags.is_producer && per_risc_base[i].num_tcs_and_init.tc_init_done) {
-                    producers_done++;
-                }
-            }
-            all_tcs_initialized &= ((producers_done == init_ptr->num_producers) && (init_ptr->implicit_sync_configured == 1));
-
-            base_ptr += sizeof(dfb_initializer_t) + (num_riscs * sizeof(dfb_initializer_per_risc_t));
-        }
-    }
-    WAYPOINT("TCID");
-    // DPRINT("all_tcs_initialized\n");
+// Map a cached TL1 byte address to the uncached alias (DM↔TRISC visibility).
+FORCE_INLINE volatile uint8_t* dfb_l1_uncached_byte_ptr(uintptr_t cached_l1_addr) {
+    return reinterpret_cast<volatile uint8_t*>(
+        static_cast<uintptr_t>(MEM_L1_UNCACHED_BASE) + (cached_l1_addr - static_cast<uintptr_t>(MEM_L1_BASE)));
 }
 
-FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base, uint32_t local_dfb_mask) {
-    uint64_t hartid;
-#ifdef COMPILE_FOR_TRISC
-    std::uint32_t neo_id = ckernel::csr_read<ckernel::CSR::NEO_ID>();
-    // Building up g_dfb_interface is not at granularity of trisc in a Neo so only need Neo ID here
-    // The initialization structs track producers/consumers for a given DFB and they would only be used by one of the
-    // unpacker or packer
-    hartid = 8 + neo_id;
-#else
-    asm volatile("csrr %0, mhartid" : "=r"(hartid));
-#endif
-    uint16_t hart_bit = 1 << hartid;
+FORCE_INLINE volatile uint32_t* dfb_l1_uncached_u32_ptr(uintptr_t cached_l1_addr) {
+    return reinterpret_cast<volatile uint32_t*>(dfb_l1_uncached_byte_ptr(cached_l1_addr));
+}
 
-    uint32_t num_dfbs =
-        local_dfb_mask;  // kernel config holds local_cb_mask but it gets hijacked to hold number of dfbs
-    volatile uint8_t* base_ptr = reinterpret_cast<volatile uint8_t*>(dfb_config_base);
+// Header fields shared across DM↔TRISC must be read via uncached alias on Quasar sim.
+FORCE_INLINE uint32_t dfb_read_participation_mask(uintptr_t config_cached, uint8_t hart_u8) {
+    return *dfb_l1_uncached_u32_ptr(
+        config_cached + offsetof(dfb_global_header_t, participation_mask[0]) +
+        static_cast<uintptr_t>(hart_u8) * sizeof(uint32_t));
+}
+
+FORCE_INLINE uint16_t dfb_read_hart_blob_offset(uintptr_t config_cached, uint8_t hart_u8) {
+    return *reinterpret_cast<volatile uint16_t*>(dfb_l1_uncached_byte_ptr(
+        config_cached + offsetof(dfb_global_header_t, hart_blob_offset[0]) +
+        static_cast<uintptr_t>(hart_u8) * sizeof(uint16_t)));
+}
+
+// End of hart h's init blob. The host emits one blob per hart, contiguously and in ascending
+// hart order (non-participating harts get a 4B stub), so the next hart's offset is this blob's
+// end and the signal region bounds the last hart.
+FORCE_INLINE uint32_t dfb_read_hart_blob_end(uintptr_t config_cached, uint8_t hart_u8, uint32_t signal_region_off) {
+    return (static_cast<uint32_t>(hart_u8) + 1u < static_cast<uint32_t>(::dfb::NUM_PARTICIPATING_HARTIDS))
+               ? static_cast<uint32_t>(dfb_read_hart_blob_offset(config_cached, hart_u8 + 1u))
+               : signal_region_off;
+}
+
+FORCE_INLINE uint32_t dfb_read_blob_u32(uintptr_t blob_addr, uint32_t byte_off) {
+    return *dfb_l1_uncached_u32_ptr(blob_addr + byte_off);
+}
+
+// Device-side shadow of dfb_hart_init_entry_t, populated by dfb_read_init_entry_header.
+// Mirrors the 28B on-disk layout captured in 7 u32 reads.
+struct dfb_init_entry_hdr_t {
+    uint8_t logical_dfb_id;
+    uint8_t num_tcs;
+    uint8_t flags;
+    uint8_t capacity;
+    uint32_t entry_size;
+    uint32_t stride_size_precomp;  // host pre-computed: DM=raw bytes, TRISC=tile units (no device multiply needed)
+    uint8_t stride_size_tiles;
+    uint8_t num_txn_ids;
+    uint8_t threshold;
+    uint8_t num_entries_per_txn_id;
+    uint8_t num_entries_per_txn_id_per_tc;
+    uint8_t producer_signal_bit;  // bit position in dfb_signal[dfb_id]; 0xFF if consumer
+    uint8_t txn_ids[dfb::NUM_TXN_IDS];  // bytes 18–21 (DM only; 0 elsewhere)
+    uint8_t broadcast_tc;         // DM pack byte 22 → iface.broadcast_tc (DM unpack only)
+    uint8_t remapper_pair_index;  // TRISC byte 22; DM pack byte 23
+    uint16_t num_entries;         // bytes 24–25
+};
+
+// Read the entire 28B dfb_hart_init_entry_t (__attribute__((packed))) as 7 u32s.
+// Two variants with identical unpack logic; only the pointer type differs:
+//   - dfb_read_init_entry_header        — uncached alias (TRISC path, no L2 coherency)
+//   - dfb_read_init_entry_header_cached — cached TL1 pointer (DM path, after L2 invalidate)
+//
+// Little-endian byte layout:
+//   w0 [7:0]=logical_dfb_id  [15:8]=num_tcs  [23:16]=flags  [31:24]=capacity
+//   w1 = entry_size (u32)
+//   w2 = stride_size_precomp (u32): host pre-computed per hart type — DM=raw bytes, TRISC=tile units
+//   w3 [7:0]=stride_size_tiles  [15:8]=num_txn_ids  [23:16]=threshold  [31:24]=num_entries_per_txn_id
+//   w4 [7:0]=num_entries_per_txn_id_per_tc  [15:8]=producer_signal_bit  [23:16]=txn_ids[0]  [31:24]=txn_ids[1]
+//   w5 [7:0]=txn_ids[2]  [15:8]=txn_ids[3]  [23:16]=remapper_pair_index  [31:24]=_pad (TRISC) / remapper (DM pack)
+//   w6 [15:0]=num_entries  [31:16]=_pad2
+
+// Shared unpack helper: TRISC blob w3–w6 (legacy SoA byte layout).
+template <typename PtrT>
+FORCE_INLINE dfb_init_entry_hdr_t dfb_unpack_entry_header(PtrT s) {
+    const uint32_t w0 = s[0], w1 = s[1], w2 = s[2], w3 = s[3], w4 = s[4], w5 = s[5], w6 = s[6];
+    dfb_init_entry_hdr_t h;
+    h.logical_dfb_id             = static_cast<uint8_t>(w0);
+    h.num_tcs                    = static_cast<uint8_t>(w0 >> 8);
+    h.flags                      = static_cast<uint8_t>(w0 >> 16);
+    h.capacity                   = static_cast<uint8_t>(w0 >> 24);
+    h.entry_size                 = w1;
+    h.stride_size_precomp        = w2;
+    h.stride_size_tiles          = static_cast<uint8_t>(w3);
+    h.num_txn_ids                = static_cast<uint8_t>(w3 >> 8);
+    h.threshold                  = static_cast<uint8_t>(w3 >> 16);
+    h.num_entries_per_txn_id     = static_cast<uint8_t>(w3 >> 24);
+    h.num_entries_per_txn_id_per_tc = static_cast<uint8_t>(w4);
+    h.producer_signal_bit        = static_cast<uint8_t>(w4 >> 8);
+    h.txn_ids[0]                 = static_cast<uint8_t>(w4 >> 16);
+    h.txn_ids[1]                 = static_cast<uint8_t>(w4 >> 24);
+    h.txn_ids[2]                 = static_cast<uint8_t>(w5);
+    h.txn_ids[3]                 = static_cast<uint8_t>(w5 >> 8);
+    h.broadcast_tc               = 0;
+    h.remapper_pair_index        = static_cast<uint8_t>(w5 >> 16);
+    h.num_entries                = static_cast<uint16_t>(w6);
+    return h;
+}
+
+// DM unpack: w3–w5 are the 12B scalar pack in LocalDFBInterface DTCM order.
+// See dfb_write_dm_scalar_pack_to_blob.
+template <typename PtrT>
+FORCE_INLINE dfb_init_entry_hdr_t dfb_unpack_entry_header_dm(PtrT s) {
+    const uint32_t w0 = s[0], w1 = s[1], w2 = s[2], w3 = s[3], w4 = s[4], w5 = s[5], w6 = s[6];
+    dfb_init_entry_hdr_t h;
+    h.logical_dfb_id             = static_cast<uint8_t>(w0);
+    h.num_tcs                    = static_cast<uint8_t>(w0 >> 8);
+    h.flags                      = static_cast<uint8_t>(w0 >> 16);
+    h.capacity                   = static_cast<uint8_t>(w0 >> 24);
+    h.entry_size                 = w1;
+    h.stride_size_precomp        = w2;
+    h.stride_size_tiles          = 0;
+    h.producer_signal_bit        = static_cast<uint8_t>(w3 >> 8);
+    h.txn_ids[0]                 = static_cast<uint8_t>(w3 >> 16);
+    h.txn_ids[1]                 = static_cast<uint8_t>(w3 >> 24);
+    h.txn_ids[2]                 = static_cast<uint8_t>(w4);
+    h.txn_ids[3]                 = static_cast<uint8_t>(w4 >> 8);
+    h.threshold                  = static_cast<uint8_t>(w4 >> 16);
+    h.num_entries_per_txn_id     = static_cast<uint8_t>(w4 >> 24);
+    h.num_entries_per_txn_id_per_tc = static_cast<uint8_t>(w5);
+    h.num_txn_ids                = static_cast<uint8_t>(w5 >> 8);
+    h.broadcast_tc               = static_cast<uint8_t>(w5 >> 16);
+    h.remapper_pair_index        = static_cast<uint8_t>(w5 >> 24);
+    h.num_entries                = static_cast<uint16_t>(w6);
+    return h;
+}
+
+#ifndef COMPILE_FOR_TRISC
+// Write iface bytes [8,20) from the unpacked header as three u32 stores (matches DM blob
+// scalar-pack layout). Avoids a second L1 read of header bytes 12–23.
+FORCE_INLINE void dfb_write_dm_iface_scalars_from_hdr(LocalDFBInterface& iface, const dfb_init_entry_hdr_t& eh) {
+    const uint32_t pack_w0 = static_cast<uint32_t>(eh.num_tcs) | (static_cast<uint32_t>(eh.txn_ids[0]) << 16) |
+                             (static_cast<uint32_t>(eh.txn_ids[1]) << 24);
+    const uint32_t pack_w1 = static_cast<uint32_t>(eh.txn_ids[2]) | (static_cast<uint32_t>(eh.txn_ids[3]) << 8) |
+                             (static_cast<uint32_t>(eh.threshold) << 16) |
+                             (static_cast<uint32_t>(eh.num_entries_per_txn_id) << 24);
+    const uint32_t pack_w2 = static_cast<uint32_t>(eh.num_entries_per_txn_id_per_tc) |
+                             (static_cast<uint32_t>(eh.num_txn_ids) << 8) |
+                             (static_cast<uint32_t>(eh.broadcast_tc) << 16) |
+                             (static_cast<uint32_t>(eh.remapper_pair_index) << 24);
+    uint32_t* const dm_scalar = reinterpret_cast<uint32_t*>(&iface.num_tcs_to_rr);
+    dm_scalar[0] = pack_w0;
+    dm_scalar[1] = pack_w1;
+    dm_scalar[2] = pack_w2;
+    iface.tc_idx = 0;
+}
+#endif
+
+// Uncached variant — used by TRISC (no private L2 cache).
+FORCE_INLINE dfb_init_entry_hdr_t dfb_read_init_entry_header(uintptr_t entry_addr) {
+    return dfb_unpack_entry_header(dfb_l1_uncached_u32_ptr(entry_addr));
+}
+
+// Cached variant — used by DM after invalidate_l2_cache_range covers the blob.
+// Plain (non-volatile) pointer: no TL1 bypass; reads go through L2->D$->TL1
+// Bytes [12,24) are in LocalDFBInterface DTCM order (host writes via dfb_write_dm_scalar_pack_to_blob).
+FORCE_INLINE dfb_init_entry_hdr_t dfb_read_init_entry_header_cached(uintptr_t entry_addr) {
+    return dfb_unpack_entry_header_dm(reinterpret_cast<const uint32_t*>(entry_addr));
+}
+
+FORCE_INLINE volatile uint32_t* dfb_init_timing_slot_words(uint8_t slot) {
+    // Device writes via uncached L1 alias; host reads the mirrored cached offset (TL1 @ 0x3ffc00).
+    return reinterpret_cast<volatile uint32_t*>(
+        static_cast<uintptr_t>(MEM_L1_UNCACHED_BASE) +
+        static_cast<uintptr_t>(dfb::DFB_INIT_TIMING_L1_BYTE_OFFSET) +
+        static_cast<uint32_t>(slot) * dfb::DFB_INIT_TIMING_WORDS_PER_SLOT * sizeof(uint32_t));
+}
+
+FORCE_INLINE void dfb_init_timing_write_slot(
+    uint8_t slot,
+    uint8_t role,
+    uint32_t e2e,
+    uint32_t metric_a,
+    uint32_t metric_b,
+    uint32_t metric_c,
+    uint32_t metric_d,
+    uint32_t metric_e,
+    uint32_t metric_f,
+    uint32_t start_time,
+    uint32_t end_time,
+    uint32_t metric_g = 0,
+    uint32_t metric_h = 0,
+    uint32_t metric_i = 0,
+    uint32_t metric_j = 0) {
+#ifdef DFB_INIT_TIMING_ENABLED
+    volatile uint32_t* words = dfb_init_timing_slot_words(slot);
+    // Publish pattern: write payload first, VALID last. Uncached stores land in TL1 directly.
+    words[dfb::DFB_INIT_TIMING_W_MAGIC] = dfb::DFB_INIT_TIMING_MAGIC;
+    words[dfb::DFB_INIT_TIMING_W_ROLE] = role;
+    words[dfb::DFB_INIT_TIMING_W_E2E] = e2e;
+    words[dfb::DFB_INIT_TIMING_W_METRIC_A] = metric_a;
+    words[dfb::DFB_INIT_TIMING_W_METRIC_B] = metric_b;
+    words[dfb::DFB_INIT_TIMING_W_METRIC_C] = metric_c;
+    words[dfb::DFB_INIT_TIMING_W_METRIC_D] = metric_d;
+    words[dfb::DFB_INIT_TIMING_W_METRIC_E] = metric_e;
+    words[dfb::DFB_INIT_TIMING_W_METRIC_F] = metric_f;
+    words[dfb::DFB_INIT_TIMING_W_START] = start_time;
+    words[dfb::DFB_INIT_TIMING_W_END] = end_time;
+    words[dfb::DFB_INIT_TIMING_W_METRIC_G] = metric_g;
+    words[dfb::DFB_INIT_TIMING_W_METRIC_H] = metric_h;
+    words[dfb::DFB_INIT_TIMING_W_METRIC_I] = metric_i;
+    words[dfb::DFB_INIT_TIMING_W_METRIC_J] = metric_j;
+    asm volatile("fence w, w" ::: "memory");
+    words[dfb::DFB_INIT_TIMING_W_VALID] = 1u;
+    asm volatile("fence w, w" ::: "memory");
+#else
+    (void)slot;
+    (void)role;
+    (void)e2e;
+    (void)metric_a;
+    (void)metric_b;
+    (void)metric_c;
+    (void)metric_d;
+    (void)metric_e;
+    (void)metric_f;
+    (void)start_time;
+    (void)end_time;
+    (void)metric_g;
+    (void)metric_h;
+    (void)metric_i;
+    (void)metric_j;
+#endif
+}
+
+#ifdef COMPILE_FOR_TRISC
+FORCE_INLINE uint8_t dfb_init_timing_trisc_slot_index() {
+    const uint32_t neo_id = ckernel::csr_read<ckernel::CSR::NEO_ID>();
+#if defined(UCK_CHLKC_PACK)
+    return static_cast<uint8_t>(8u + neo_id * 2u + 1u);
+#else
+    return static_cast<uint8_t>(8u + neo_id * 2u);
+#endif
+}
+#endif
+
+inline uint32_t rdcycle() {
+#ifdef DFB_INIT_TIMING_ENABLED
+    uint32_t c;
+    asm volatile("rdcycle %0" : "=r"(c));
+    return c;
+#else
+    return 0;
+#endif
+}
+
+// Poll until all producers for DFB `dfb_id` have published their signal byte and
+// (for DMs with implicit sync) DM0 has armed the ISR.
+//
+// Signal region layout at dfb_signal_region_off:
+//   uint8_t  dfb_signal[NUM_DFBS * MAX_PRODUCERS_PER_DFB]  — per-producer byte slots (192B)
+//   uint32_t dfb_expected_signal[NUM_DFBS]                 — host-computed bitmask (128B)
+//
+// Producer i of DFB d writes byte 1 to slot [d * MAX_PRODUCERS_PER_DFB + i] (plain volatile, no AMO).
+// Consumer reads dfb_expected_signal[d] (bitmask), then polls each set bit's byte slot.
+//
+// Runs for DMs unconditionally, and for TRISCs only when compiling for unpack or pack.
+// Math (TRISC1) and TRISC3 compile this to an empty function so they never spin on
+// uninitialised config data and never block DM0's wait_subordinates().
+FORCE_INLINE void dfb_ensure_ready(uintptr_t config_cached, uint8_t dfb_id) {
+#if defined(COMPILE_FOR_TRISC) && !defined(UCK_CHLKC_UNPACK) && !defined(UCK_CHLKC_PACK)
+    return;
+#endif
+    const uint32_t sig_off = *dfb_l1_uncached_u32_ptr(
+        config_cached + offsetof(dfb_global_header_t, dfb_signal_region_off));
+
+    // dfb_expected_signal[dfb_id] sits after all producer byte slots.
+    constexpr uint32_t kSlotStride = static_cast<uint32_t>(::dfb::MAX_PRODUCERS_PER_DFB);
+    constexpr uint32_t kExpectedBase = static_cast<uint32_t>(::dfb::NUM_DFBS) * kSlotStride;
+    const volatile uint32_t* exp_ptr = reinterpret_cast<const volatile uint32_t*>(
+        dfb_l1_uncached_byte_ptr(
+            config_cached + sig_off + kExpectedBase + static_cast<uint32_t>(dfb_id) * sizeof(uint32_t)));
+
+    const uint32_t expected = *exp_ptr;
+    if (expected == 0) {
+        return;
+    }
+
+#ifndef COMPILE_FOR_TRISC
+    const bool need_isr_gate =
+        (*dfb_l1_uncached_byte_ptr(config_cached + offsetof(dfb_global_header_t, has_dm0_isr)) != 0);
+    const volatile uint8_t* isr_ready_ptr =
+        dfb_l1_uncached_byte_ptr(config_cached + offsetof(dfb_global_header_t, dm0_isr_ready));
+#endif
+
+    WAYPOINT("DFW");
+    // Poll each producer's byte slot; remove from remaining when non-zero.
+    uint32_t remaining = expected;
+    while (remaining != 0u) {
+        const uint8_t bit = static_cast<uint8_t>(__builtin_ctz(remaining));
+        const volatile uint8_t* slot = dfb_l1_uncached_byte_ptr(
+            config_cached + sig_off +
+            static_cast<uint32_t>(dfb_id) * kSlotStride + bit);
+        if (*slot != 0u) {
+            remaining &= remaining - 1u;
+        }
+    }
+#ifndef COMPILE_FOR_TRISC
+    if (need_isr_gate) {
+        while (*isr_ready_ptr != 1u) {
+        }
+    }
+#endif
+    WAYPOINT("DFD");
+}
+
+// Slot index into dfb_signal[]: d * MAX_PRODUCERS_PER_DFB + producer_bit.
+FORCE_INLINE constexpr uint32_t dfb_signal_slot_index(uint32_t logical_dfb_id, uint32_t producer_signal_bit) {
+    constexpr uint32_t k_slot_stride = static_cast<uint32_t>(::dfb::MAX_PRODUCERS_PER_DFB);
+    return logical_dfb_id * k_slot_stride + producer_signal_bit;
+}
+
+// Publish producer readiness: write byte 1 into this producer's unique slot in dfb_signal.
+// producer_signal_bit == 0xFF means consumer (no signal slot) → no-op.
+// dfb_signal_base must be the uncached alias of (config_base + dfb_signal_region_off),
+// hoisted once before the init loop so per-entry publish is index + store only.
+// A compiler barrier prevents the signal write from being hoisted before any preceding TC init.
+FORCE_INLINE void dfb_publish_producer_ready(
+    volatile uint8_t* dfb_signal_base, uint8_t logical_dfb_id, uint8_t producer_signal_bit) {
+    if (producer_signal_bit == 0xFFu) {
+        return;
+    }
+    asm volatile("" ::: "memory");  // compiler barrier only; no hardware fence needed
+    dfb_signal_base[dfb_signal_slot_index(logical_dfb_id, producer_signal_bit)] = 1u;
+    WAYPOINT("PPR");
+}
+
+#ifndef COMPILE_FOR_TRISC
+
+FORCE_INLINE void setup_dfb_implicit_sync(uint32_t tt_l1_ptr* dfb_config_base, uint32_t num_dfbs) {
+    // No DFB config was serialized; host will not read timing slots. Still disarm ISR
+    // so a prior launch cannot leak into this one.
+    if (num_dfbs == 0) {
+        disable_dfb_tile_isr();
+        return;
+    }
+
+    uint32_t start_time = rdcycle();
+
+    const uintptr_t config_cached = reinterpret_cast<uintptr_t>(dfb_config_base);
+    const uint8_t has_dm0_isr = *dfb_l1_uncached_byte_ptr(config_cached + offsetof(dfb_global_header_t, has_dm0_isr));
+    if (has_dm0_isr == 0) {
+        disable_dfb_tile_isr();
+        // Header is valid; preserve prior "DM0 finished setup" signaling for consumers
+        // that only gate on has_dm0_isr (they will not wait on ready).
+        *dfb_l1_uncached_byte_ptr(config_cached + offsetof(dfb_global_header_t, dm0_isr_ready)) = 1u;
+        asm volatile("fence w, w" ::: "memory");
+        const uint32_t end_time = rdcycle();
+        dfb_init_timing_write_slot(
+            0,
+            dfb::DFB_INIT_TIMING_ROLE_DM0_ISR,
+            end_time - start_time,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            start_time,
+            end_time,
+            0,
+            0,
+            0,
+            0);
+        return;
+    }
+
+    // uncached bootstrap of offset/masks, one invalidate over threshold+desc pools, then cached walks (non-volatile after inv).
+    const uint32_t dm0_isr_blob_offset = *dfb_l1_uncached_u32_ptr(
+        config_cached + offsetof(dfb_global_header_t, dm0_isr_blob_offset));
+    const uintptr_t dm0_blob_base = config_cached + dm0_isr_blob_offset;
+
+    const uint32_t producer_txn_id_mask = dfb_read_blob_u32(dm0_blob_base, 0);
+    const uint32_t consumer_txn_id_mask = dfb_read_blob_u32(dm0_blob_base, 4);
+
+    const uint32_t txn_hw_bytes =
+        dm0_isr_txn_hw_pool_byte_size(producer_txn_id_mask, consumer_txn_id_mask);
+    const uint32_t pool_bytes = dm0_isr_txn_desc_pool_byte_size(producer_txn_id_mask, consumer_txn_id_mask);
+    // Core header already read uncached — invalidate only the pools the cached walk touches.
+    const uintptr_t pools_base = dm0_blob_base + sizeof(dfb_dm0_isr_blob_core_header_t);
+    invalidate_l2_cache_range(pools_base, txn_hw_bytes + pool_bytes);
+
+    WAYPOINT("IS1");
+
+    const uint8_t* pool_base =
+        reinterpret_cast<const uint8_t*>(pools_base + txn_hw_bytes);
+    const dfb_dm0_isr_txn_threshold_t* txn_threshold_table =
+        reinterpret_cast<const dfb_dm0_isr_txn_threshold_t*>(pools_base);
+
+    const uint32_t all_mask = producer_txn_id_mask | consumer_txn_id_mask;
+
+    const uint32_t t_before_desc_copy = rdcycle();
+    if (pool_bytes != 0) {
+        // Pools are dense (slot per used id, ascending), so walking set bits also walks slots in order.
+        uint32_t slot = 0;
+        uint32_t pending_desc = all_mask;
+        while (pending_desc) {
+            const uint32_t txn_id = static_cast<uint32_t>(__builtin_ctz(pending_desc));
+            const uint32_t* s = reinterpret_cast<const uint32_t*>(pool_base + (slot++) * 32u);
+            volatile uint32_t* d = reinterpret_cast<volatile uint32_t*>(&g_txn_dfb_descriptor[txn_id]);
+            d[0] = s[0]; d[1] = s[1]; d[2] = s[2]; d[3] = s[3];
+            d[4] = s[4]; d[5] = s[5]; d[6] = s[6]; d[7] = s[7];
+            pending_desc &= (pending_desc - 1u);
+        }
+    }
+    const uint32_t t_after_desc_copy = rdcycle();
+
+    uint32_t total_l1_read = 0;
+    uint32_t total_rocc_issue = 0;
+    uint32_t hw_reg_write_cycles = 0;
+    const uint32_t t_before_cmdbuf = t_after_desc_copy;
+
+    // One walk over all_mask keeps the dense slot a running counter; role comes from the masks.
+    uint32_t threshold_slot = 0;
+    uint32_t pending = all_mask;
+    while (pending) {
+        const uint32_t txn_id = static_cast<uint32_t>(__builtin_ctz(pending));
+        const uint32_t txn_bit = 1u << txn_id;
+        const uint32_t t_slot_start = rdcycle();
+        const uint32_t threshold = txn_threshold_table[threshold_slot++].threshold;
+        const uint32_t t_after_l1 = rdcycle();
+        total_l1_read += t_after_l1 - t_slot_start;
+        const uint32_t t_wr_start = rdcycle();
+        if (producer_txn_id_mask & txn_bit) {
+            CMDBUF_CLEAR_TILES_TO_PROCESS_TR_ACK(OVERLAY_RD_CMD_BUF, txn_id);
+            asm volatile("nop");
+            SET_TILES_TO_PROCESS_THRES_TR_ACK(txn_id, threshold);
+        }
+        if (consumer_txn_id_mask & txn_bit) {
+            CMDBUF_CLEAR_TILES_TO_PROCESS_WR_SENT(OVERLAY_WR_CMD_BUF, txn_id);
+            asm volatile("nop");
+            SET_TILES_TO_PROCESS_THRES_WR_SENT(txn_id, threshold);
+        }
+        hw_reg_write_cycles += rdcycle() - t_wr_start;
+        const uint32_t t_after_rocc = rdcycle();
+        total_rocc_issue += t_after_rocc - t_after_l1;
+        pending &= (pending - 1u);
+    }
+    const uint32_t t_after_cmdbuf = rdcycle();
+
+    const uint32_t t_before_ie = rdcycle();
+    uint64_t reg_val = CMDBUF_RD_REG(OVERLAY_RD_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_PER_TR_ID_IE_1_REG_OFFSET);
+    reg_val = (reg_val & 0x00000000FFFFFFFFULL) | ((uint64_t)(producer_txn_id_mask & 0xFFFFFFFFULL) << 32);
+    CMDBUF_WR_REG(OVERLAY_RD_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_PER_TR_ID_IE_1_REG_OFFSET, reg_val);
+    const uint32_t t_after_first_ie_rmw = rdcycle();
+
+    reg_val = CMDBUF_RD_REG(OVERLAY_WR_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_PER_TR_ID_IE_2_REG_OFFSET);
+    reg_val = (reg_val & 0xFFFFFFFF00000000ULL) | (consumer_txn_id_mask & 0xFFFFFFFFULL);
+    CMDBUF_WR_REG(OVERLAY_WR_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_PER_TR_ID_IE_2_REG_OFFSET, reg_val);
+    const uint32_t t_after_isr_ie_writes = rdcycle();
+    hw_reg_write_cycles += t_after_isr_ie_writes - t_before_ie;
+
+    if ((producer_txn_id_mask | consumer_txn_id_mask) != 0) {
+        const uint32_t t_isr_start = rdcycle();
+        enable_dfb_tile_isr();
+        hw_reg_write_cycles += rdcycle() - t_isr_start;
+    } else {
+        const uint32_t t_isr_start = rdcycle();
+        disable_dfb_tile_isr();
+        hw_reg_write_cycles += rdcycle() - t_isr_start;
+    }
+    const uint32_t end_isr_enable_time = rdcycle();
+
+    *dfb_l1_uncached_byte_ptr(
+        reinterpret_cast<uintptr_t>(dfb_config_base) + offsetof(dfb_global_header_t, dm0_isr_ready)) = 1u;
+    asm volatile("fence w, w" ::: "memory");
+
+    WAYPOINT("ISD");
+
+    const uint32_t end_time = rdcycle();
+
+    const uint32_t pre_loop_sw = t_before_desc_copy - start_time;
+    const uint32_t subpassB_desc = t_after_desc_copy - t_before_desc_copy;
+    const uint32_t subpassB_hw = t_after_cmdbuf - t_before_cmdbuf;
+    const uint32_t first_ie_rmw = t_after_first_ie_rmw - t_before_ie;
+    const uint32_t second_ie_rmw = t_after_isr_ie_writes - t_after_first_ie_rmw;
+    const uint32_t isr_enable = (end_isr_enable_time > t_after_isr_ie_writes)
+                                    ? end_isr_enable_time - t_after_isr_ie_writes
+                                    : 0;
+    dfb_init_timing_write_slot(
+        0,
+        dfb::DFB_INIT_TIMING_ROLE_DM0_ISR,
+        end_time - start_time,
+        pre_loop_sw,
+        subpassB_desc,
+        hw_reg_write_cycles,
+        total_l1_read,
+        total_rocc_issue,
+        first_ie_rmw,
+        start_time,
+        end_time,
+        second_ie_rmw,
+        isr_enable,
+        0,  // METRIC_I unused (was hw_reg_writes count)
+        subpassB_hw);
+}
+
+FORCE_INLINE void setup_dfb_remapper(uint32_t tt_l1_ptr* dfb_config_base, uint32_t num_dfbs) {
+    if (num_dfbs == 0) {
+        return;
+    }
+
+    const uint32_t start_time = rdcycle();
+
+    const uintptr_t config_cached = reinterpret_cast<uintptr_t>(dfb_config_base);
+
+    // Host may rewrite overlapping L1 across programs: uncached bootstrap of offset/num_slots,
+    // one invalidate over slots when non-empty, then cached remapper slot walk.
+    const uint32_t dm1_remapper_blob_offset = *dfb_l1_uncached_u32_ptr(
+        config_cached + offsetof(dfb_global_header_t, dm1_remapper_blob_offset));
+    const uintptr_t dm1_blob_base = config_cached + dm1_remapper_blob_offset;
+    const uint16_t num_slots_bootstrap = *reinterpret_cast<volatile uint16_t*>(
+        dfb_l1_uncached_byte_ptr(dm1_blob_base + offsetof(dfb_dm1_remapper_core_header_t, num_slots)));
+    // Skip invalidate when empty: no cached slot walk.
+    // Header already bootstrapped uncached — invalidate only the slot array.
+    if (num_slots_bootstrap > 0u) {
+        const uintptr_t slots_base = dm1_blob_base + sizeof(dfb_dm1_remapper_core_header_t);
+        invalidate_l2_cache_range(
+            slots_base, static_cast<uint32_t>(num_slots_bootstrap) * sizeof(dfb_dm1_remapper_slot_t));
+    }
+
+    WAYPOINT("RS");
+
+    uint32_t blob_l1_read_sw = 0;
+    uint32_t pairs_reg_hw = 0;
+    uint32_t blob_loop_ovhd = 0;
+    uint32_t pairs_slots_written = 0;
+    uint32_t first_pair_clientR_hw = 0;
+    uint32_t first_pair_clientL_hw = 0;
+    uint32_t last_pair_hw = 0;
+    bool first_slot_written = false;
+    uint32_t max_pair_idx = 0;
+
+    const uint32_t t_loop_start = rdcycle();
+    const uint16_t num_slots = num_slots_bootstrap;
+    const dfb_dm1_remapper_slot_t* slots = reinterpret_cast<const dfb_dm1_remapper_slot_t*>(
+        dm1_blob_base + sizeof(dfb_dm1_remapper_core_header_t));
+    const uint32_t t_after_hdr = rdcycle();
+    blob_l1_read_sw = t_after_hdr - t_loop_start;
+
+    WAYPOINT("RS2");
+
+    for (uint16_t s = 0; s < num_slots; s++) {
+        const uint32_t t_slot_read_start = rdcycle();
+        const uint32_t pair_idx = slots[s].pair_index;
+        const uint32_t clientR_val = slots[s].clientR_val;
+        const uint32_t clientL_val = slots[s].clientL_val;
+        const uint32_t t_after_slot_read = rdcycle();
+        blob_l1_read_sw += t_after_slot_read - t_slot_read_start;
+
+        const uint32_t t_clientR_start = rdcycle();
+        WRITE_REG32(REMAP_CLIENT_R_CONFIG_REG_ADDR32(pair_idx), clientR_val);
+        const uint32_t t_after_clientR = rdcycle();
+        if (!first_slot_written) {
+            first_pair_clientR_hw = t_after_clientR - t_clientR_start;
+        }
+
+        const uint32_t t_clientL_start = rdcycle();
+        WRITE_REG32(REMAP_CLIENT_L_CONFIG_REG_ADDR32(pair_idx), clientL_val);
+        const uint32_t t_after_clientL = rdcycle();
+        if (!first_slot_written) {
+            first_pair_clientL_hw = t_after_clientL - t_clientL_start;
+            first_slot_written = true;
+        }
+
+        const uint32_t pair_reg_hw = (t_after_clientR - t_clientR_start) + (t_after_clientL - t_clientL_start);
+        pairs_reg_hw += pair_reg_hw;
+        last_pair_hw = pair_reg_hw;
+        pairs_slots_written++;
+        if (pair_idx > max_pair_idx) {
+            max_pair_idx = pair_idx;
+        }
+    }
+
+    const uint32_t t_loop_end = rdcycle();
+    blob_loop_ovhd = (t_loop_end - t_loop_start) - blob_l1_read_sw - pairs_reg_hw;
+
+    if (pairs_slots_written > 0u) {
+        g_remapper_configurator.set_pair_high_watermark(max_pair_idx);
+    }
+
+    WAYPOINT("RSD");
+    const uint32_t end_time = rdcycle();
+
+    dfb_init_timing_write_slot(
+        1,
+        dfb::DFB_INIT_TIMING_ROLE_DM1_RMP,
+        end_time - start_time,
+        blob_l1_read_sw,
+        blob_loop_ovhd,
+        pairs_reg_hw,
+        0,
+        first_pair_clientR_hw,
+        first_pair_clientL_hw,
+        start_time,
+        end_time,
+        last_pair_hw,
+        pairs_reg_hw,                        // METRIC_H: hw_reg_write_cycles
+        pairs_slots_written * 2u,            // METRIC_I: hw_reg_writes (clientR + clientL per slot)
+        pairs_slots_written);
+}
+
+#endif  // !COMPILE_FOR_TRISC
+
+// DM2-7 + TRISC: walk this hart's pre-computed sequential init blob; TC readiness is published
+// via store to dfb_publish_producer_ready and consumers poll in DataflowBuffer::DataflowBuffer().
+FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base, uint32_t num_dfbs) {
+    if (num_dfbs == 0) {
+        return;
+    }
+
+    const uint32_t start_time = rdcycle();
+
+#ifdef COMPILE_FOR_TRISC
+    const uint32_t neo_id = ckernel::csr_read<ckernel::CSR::NEO_ID>();
+    const uint8_t hart_u8 = static_cast<uint8_t>(8u + neo_id);
+#else
+    uint64_t hartid_raw;
+    asm volatile("csrr %0, mhartid" : "=r"(hartid_raw));
+    const uint8_t hart_u8 = static_cast<uint8_t>(hartid_raw);
+#endif
+
+    const uintptr_t config_cached = reinterpret_cast<uintptr_t>(dfb_config_base);
+    g_dfb_config_base_addr = config_cached;
+
+    const uint32_t participation_mask = dfb_read_participation_mask(config_cached, hart_u8);
+    const uint32_t dfb_signal_region_off = *dfb_l1_uncached_u32_ptr(
+        config_cached + offsetof(dfb_global_header_t, dfb_signal_region_off));
+    // Hoist uncached signal-region base; per-entry publish adds dfb_id×stride + signal_bit only.
+    volatile uint8_t* const dfb_signal_base =
+        dfb_l1_uncached_byte_ptr(config_cached + dfb_signal_region_off);
+
+    // One load: this hart's blob offset from the header.
+    const volatile uint8_t* p = reinterpret_cast<const volatile uint8_t*>(
+        config_cached + dfb_read_hart_blob_offset(config_cached, hart_u8));
+
+    uint32_t total_remapper_spin = 0;
+    uint32_t total_tc_hw = 0;
+    uint32_t total_tc_reset_hw = 0;
+    uint32_t total_tc_capacity_hw = 0;
+    uint32_t total_hw_reg_writes = 0;
+    // Sub-breakdown metrics (g–j):
+    //   g: pre-loop fixed overhead (3 uncached header reads before the loop)
+    //   h: time in dfb_read_init_entry_header (6 u32 reads × N entries)
+    //   i: time in TC-slot read+write loop (all entries)
+    //   j: sig_slot address compute + uncached store (producers only)
+    uint32_t total_entry_hdr = 0;
+    uint32_t total_tc_slots  = 0;
+    uint32_t total_sig_write = 0;
+
 #if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
     uint8_t compact_dfb_count = 0;
 #endif
 
-    // each RISC populates its own g_dfb_interface entry
-    for (uint32_t logical_dfb_id = 0; logical_dfb_id < num_dfbs; logical_dfb_id++) {
-        // Read dfb_initializer_t (shared config)
-        volatile dfb_initializer_t* init_ptr = reinterpret_cast<volatile dfb_initializer_t*>(base_ptr);
-        uint16_t risc_mask = (init_ptr->risc_mask_bits.tensix_mask << 8) | init_ptr->risc_mask_bits.dm_mask;
-        uint8_t num_riscs = static_cast<uint8_t>(__builtin_popcount(risc_mask));
+    // g: capture time before the loop (3 uncached header reads above + blob-offset load)
+    const uint32_t t_loop_start = rdcycle();
+    const uint32_t pre_loop = t_loop_start - start_time;
 
-        // Per-risc configs start after dfb_initializer_t
-        volatile dfb_initializer_per_risc_t* per_risc_base =
-            reinterpret_cast<volatile dfb_initializer_per_risc_t*>(base_ptr + sizeof(dfb_initializer_t));
+    // -----------------------------------------------------------------------
+    // Sequential init blob walk: no pointer-table lookups, no per-DFB indirection.
+    // Entry count = popcount(participation_mask[hart_u8]); blob starts at init entries.
+    // Each entry header is loaded as packed u32 words; TC arrays are read as u32 pairs.
+    // DM invalidates L2 over the blob once, then walks with cached TL1 pointers.
+    // -----------------------------------------------------------------------
 
-        // DPRINT("hartid: 0x{:x} risc_mask: 0x{:x} hart_bit: 0x{:x}\n", hartid, risc_mask, hart_bit);
-        if (risc_mask & hart_bit) {
-            // Find this risc's per-risc config by counting set bits before this position
-            uint8_t risc_index = static_cast<uint8_t>(__builtin_popcount(risc_mask & ((1 << hartid) - 1)));
-            volatile dfb_initializer_per_risc_t* per_risc_ptr = per_risc_base + risc_index;
+    // Widen walk counters to uint32_t so RV64 codegen avoids zext.b/zext.w on every
+    // increment / compare. Blob fields stay uint8_t; only locals are widened.
+    const uint32_t num_init = dfb_hart_participation_count(participation_mask);
 
-            // The kernel-facing dfb::<name> accessor is the DFB's PROGRAM-WIDE (global) id, but this
-            // loop's `logical_dfb_id` counter is only the per-core sequential position (num_dfbs is the
-            // per-core count and the host writes configs compacted per core). Those differ whenever cores
-            // host heterogeneous DFB sets (e.g. a decoy DFB on one core only), which made a producer read a
-            // zeroed interface slot and issue a 0-byte NoC read. Index the global-id-keyed arrays by the
-            // true global id carried in the config (init_ptr->logical_id), not the loop counter. For a
-            // homogeneous layout global id == loop position, so this is a no-op there.
-            const uint32_t global_dfb_id = init_ptr->logical_id;
-
-            // Populate LocalDFBInterface from combined dfb_initializer_t + dfb_initializer_per_risc_t
-#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
-            ASSERT(compact_dfb_count < dfb::MAX_ACTIVE_DFBS_PACK);
-            // Pack TRISC has smaller local memory so the LocalDFBInterface is tightly packed and a
-            // second lookup table is needed to map the logical DFB ID to the tightly packed index.
-            const uint8_t compact_dfb_id = compact_dfb_count++;
-            g_dfb_logical_to_compact[global_dfb_id] = compact_dfb_id;
-            LocalDFBInterface& dfb_interface = g_dfb_interface[compact_dfb_id];
-#else
-            LocalDFBInterface& dfb_interface = g_dfb_interface[global_dfb_id];
+    // DM: invalidate L2 over this hart's init blob so subsequent reads go through
+    // L1 D$ + L2. Global header fields and the signal region stay on the uncached
+    // alias (cross-hart visibility without cache management). The range is the blob's
+    // exact extent: bounding it by num_init × the largest entry size (6 TCs → 84B)
+    // overshoots more than 2x for the common 1-2 TC entry and spills into the
+    // neighbouring harts' blobs, discarding lines those harts are concurrently walking.
+#ifndef COMPILE_FOR_TRISC
+    if (num_init > 0) {
+        const uintptr_t blob_start = reinterpret_cast<uintptr_t>(p);
+        const uintptr_t blob_end =
+            config_cached + dfb_read_hart_blob_end(config_cached, hart_u8, dfb_signal_region_off);
+        invalidate_l2_cache_range(blob_start, blob_end - blob_start);
+    }
 #endif
 
-            // DPRINT("risc_index: {}\n", static_cast<uint32_t>(risc_index));
-            dfb_interface.num_tcs_to_rr = per_risc_ptr->num_tcs_and_init.num_tcs_to_rr;
-            // DPRINT("num_tcs_to_rr: {}\n", static_cast<uint32_t>(dfb_interface.num_tcs_to_rr));
+    for (uint32_t i = 0; i < num_init; i++) {
+        const uintptr_t e_addr = reinterpret_cast<uintptr_t>(p);
 
-            // Address fields are in bytes on host; convert to 16B units on TRISC (cb_addr_shift=4), keep bytes on DM
-            // (cb_addr_shift=0)
+        const uint32_t t_hdr_start = rdcycle();
 #ifdef COMPILE_FOR_TRISC
-            dfb_interface.entry_size = static_cast<uint16_t>(init_ptr->entry_size >> cb_addr_shift);
-            dfb_interface.stride_size = static_cast<uint16_t>(
-                static_cast<uint32_t>(dfb_interface.entry_size) * static_cast<uint32_t>(init_ptr->stride_in_entries));
-            dfb_interface.num_entries = init_ptr->num_entries;
-            dfb_interface.stride_size_tiles = static_cast<uint8_t>(init_ptr->stride_in_entries);
+        const dfb_init_entry_hdr_t eh = dfb_read_init_entry_header(e_addr);
+#else
+        const dfb_init_entry_hdr_t eh = dfb_read_init_entry_header_cached(e_addr);
+#endif
+        total_entry_hdr += rdcycle() - t_hdr_start;
+
+        const uint32_t num_tcs = eh.num_tcs;
+
+        // Advance to the next entry: 28B header + ((num_tcs*9 + 3) & ~3).
+        const uint32_t entry_bytes = dfb_hart_init_entry_byte_size(num_tcs);
+        p = reinterpret_cast<const volatile uint8_t*>(e_addr + entry_bytes);
+
+        // AoP TC tail starts right after the 28B header: pairs first, ptc bytes after all pairs.
+        const uintptr_t tc_base_addr = e_addr + sizeof(dfb_hart_init_entry_t);
+
+        WAYPOINT("L1");
+
+        // --- Resolve g_dfb_interface slot ---
+#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
+        ASSERT(compact_dfb_count < dfb::MAX_ACTIVE_DFBS_PACK);
+        const uint8_t compact_id = compact_dfb_count++;
+        g_dfb_logical_to_compact[eh.logical_dfb_id] = compact_id;
+        LocalDFBInterface& iface = g_dfb_interface[compact_id];
+#else
+        LocalDFBInterface& iface = g_dfb_interface[eh.logical_dfb_id];
+#endif
+
+        // --- Common scalar fields ---
+#if defined(COMPILE_FOR_TRISC)
+        iface.num_tcs_to_rr = static_cast<uint8_t>(num_tcs);
+        iface.tc_idx = 0;
+#endif
+
+        WAYPOINT("L2");
+
+        // --- Role-specific scalar fields ---
+#ifdef COMPILE_FOR_TRISC
+        iface.entry_size        = static_cast<uint16_t>(eh.entry_size >> cb_addr_shift);
+        // Host precomputes stride in tile units: (entry_size >> shift) * stride_in_entries.
+        iface.stride_size       = static_cast<uint16_t>(eh.stride_size_precomp);
+        iface.stride_size_tiles = eh.stride_size_tiles;
 #if defined(UCK_CHLKC_PACK)
-            dfb_interface.wr_entry_ptr = 0;
-#else
-            dfb_interface.tensix_trisc_mask = static_cast<uint8_t>(init_ptr->risc_mask_bits.tensix_trisc_mask);
+        iface.wr_entry_ptr = 0;
+#else  // unpack TRISC
+        iface.tensix_trisc_mask = static_cast<uint8_t>(eh.flags & DFB_HART_FLAG_TRISC_MASK);
 #endif
-#else
-            dfb_interface.entry_size = init_ptr->entry_size >> cb_addr_shift;
-            dfb_interface.stride_size = dfb_interface.entry_size * init_ptr->stride_in_entries;
-            dfb_interface.num_entries = init_ptr->num_entries;
+        iface.num_entries = eh.num_entries;
+#else  // DM
+        iface.entry_size  = eh.entry_size >> cb_addr_shift;
+        // Host precomputes stride in raw bytes: entry_size_raw * stride_in_entries.
+        iface.stride_size = eh.stride_size_precomp;
+        // Store scalar pack as three u32s from the already-unpacked header.
+        dfb_write_dm_iface_scalars_from_hdr(iface, eh);
+        iface.num_entries = eh.num_entries;
 #endif
 
-            for (uint8_t i = 0; i < per_risc_ptr->num_tcs_and_init.num_tcs_to_rr; i++) {
-                uint32_t base = per_risc_ptr->base_addr[i] >> cb_addr_shift;
-                uint32_t limit_s = per_risc_ptr->limit[i] >> cb_addr_shift;
-                // ring_size (TRISC): linear span limit_s - base for this TC—the same bound legacy wr_ptr/rd_ptr used.
-                // In STRIDED layouts that span includes other producers' interleaved entries between this TC's tiles.
-                // uint32 L1 units (full Quasar L1). Cursor byte-offset is derived from *_entry_idx (not stored).
+        WAYPOINT("L3");
+
+        // --- TC slot population ---
+        // AoP TC tail: dfb_blob_tc_pair_t[num_tcs] (8B each, base+limit adjacent per slot)
+        // immediately after the 28B header, then uint8_t ptc[num_tcs] padded to 4B.
+        // Preload ptc as 1–2 word reads before the loop; in-loop ptc is a register bit-extract.
+        // Running pair pointer advances 8B per slot. DM uses a cached pointer (blob already
+        // invalidated into L2); TRISC uses the uncached alias.
+        const uintptr_t ptc_base_addr = tc_base_addr + (static_cast<uintptr_t>(num_tcs) << 3u);
+#ifdef COMPILE_FOR_TRISC
+        const volatile dfb_blob_tc_pair_t* pairs = reinterpret_cast<const volatile dfb_blob_tc_pair_t*>(
+            dfb_l1_uncached_u32_ptr(tc_base_addr));
+        const uint32_t ptc_w0 = (num_tcs > 0u) ? *dfb_l1_uncached_u32_ptr(ptc_base_addr) : 0u;
+        const uint32_t ptc_w1 = (num_tcs > 4u) ? *dfb_l1_uncached_u32_ptr(ptc_base_addr + 4u) : 0u;
+#else
+        const dfb_blob_tc_pair_t* pairs = reinterpret_cast<const dfb_blob_tc_pair_t*>(tc_base_addr);
+        const uint32_t ptc_w0 = (num_tcs > 0u) ? *reinterpret_cast<const uint32_t*>(ptc_base_addr) : 0u;
+        const uint32_t ptc_w1 = (num_tcs > 4u) ? *reinterpret_cast<const uint32_t*>(ptc_base_addr + 4u) : 0u;
+#endif
+        const uint32_t t_slots_start = rdcycle();
+        for (uint32_t t = 0; t < num_tcs; t++, pairs++) {
+            // Host pre-shifts TRISC TC addresses to tile units at serialization; DM blobs keep byte addresses.
+            const uint32_t base      = pairs->base_addr;
+            const uint32_t limit     = pairs->limit;
+            const uint8_t  ptc       = static_cast<uint8_t>((t < 4u ? ptc_w0 : ptc_w1) >> ((t & 3u) * 8u));
+            iface.tc_slots[t].packed_tile_counter = ptc;
+
 #if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
-                dfb_interface.tc_slots[i].base_addr = base;
-                dfb_interface.tc_slots[i].ring_size = limit_s - base;
-                dfb_interface.tc_slots[i].packed_tile_counter = per_risc_ptr->packed_tile_counter[i];
-                dfb_interface.tc_slots[i].base_entry_idx = static_cast<uint16_t>(
-                    (base - dfb_interface.tc_slots[0].base_addr) / dfb_interface.entry_size);
-                dfb_interface.tc_slots[i].wr_entry_idx = dfb_interface.tc_slots[i].base_entry_idx;
-#elif defined(COMPILE_FOR_TRISC)
-                dfb_interface.tc_slots[i].base_addr = base;
-                dfb_interface.tc_slots[i].ring_size = limit_s - base;
-                dfb_interface.tc_slots[i].packed_tile_counter = per_risc_ptr->packed_tile_counter[i];
-                dfb_interface.tc_slots[i].base_entry_idx = static_cast<uint16_t>(
-                    (base - dfb_interface.tc_slots[0].base_addr) / dfb_interface.entry_size);
-                dfb_interface.tc_slots[i].rd_entry_idx = dfb_interface.tc_slots[i].base_entry_idx;
-#else
-                dfb_interface.tc_slots[i].base_addr = base;
-                dfb_interface.tc_slots[i].limit = limit_s;
-                dfb_interface.tc_slots[i].rd_ptr = base;
-                dfb_interface.tc_slots[i].wr_ptr = base;
-                dfb_interface.tc_slots[i].packed_tile_counter = per_risc_ptr->packed_tile_counter[i];
-#endif
-            }
-
-            dfb_interface.tc_idx = 0;
-#ifndef COMPILE_FOR_TRISC
-            dfb_interface.broadcast_tc = per_risc_ptr->num_tcs_and_init.broadcast_tc;
-#endif
-
-#ifndef COMPILE_FOR_TRISC
-            if (per_risc_ptr->flags.is_producer) {
-                dfb_interface.num_txn_ids = init_ptr->producer_txn_descriptor.num_txn_ids;
-                dfb_interface.threshold = init_ptr->producer_txn_descriptor.num_entries_to_process_threshold;
-                dfb_interface.num_entries_per_txn_id = init_ptr->producer_txn_descriptor.num_entries_per_txn_id;
-                dfb_interface.num_entries_per_txn_id_per_tc =
-                    init_ptr->producer_txn_descriptor.num_entries_per_txn_id_per_tc;
-                for (uint8_t i = 0; i < dfb_interface.num_txn_ids; i++) {
-                    dfb_interface.txn_ids[i] = init_ptr->producer_txn_descriptor.txn_ids[i];
-                }
-            } else {
-                dfb_interface.num_txn_ids = init_ptr->consumer_txn_descriptor.num_txn_ids;
-                dfb_interface.threshold = init_ptr->consumer_txn_descriptor.num_entries_to_process_threshold;
-                dfb_interface.num_entries_per_txn_id = init_ptr->consumer_txn_descriptor.num_entries_per_txn_id;
-                dfb_interface.num_entries_per_txn_id_per_tc =
-                    init_ptr->consumer_txn_descriptor.num_entries_per_txn_id_per_tc;
-                for (uint8_t i = 0; i < dfb_interface.num_txn_ids; i++) {
-                    dfb_interface.txn_ids[i] = init_ptr->consumer_txn_descriptor.txn_ids[i];
-                }
-            }
+            iface.tc_slots[t].base_addr      = base;
+            // ring_size is uint32 L1 units (full Quasar L1). Cursor byte-offset is derived
+            // from wr_entry_idx (not stored).
+            iface.tc_slots[t].ring_size      = limit - base;
+            iface.tc_slots[t].base_entry_idx = static_cast<uint16_t>(
+                (base - iface.tc_slots[0].base_addr) / iface.entry_size);
+            iface.tc_slots[t].wr_entry_idx   = iface.tc_slots[t].base_entry_idx;
+#elif defined(COMPILE_FOR_TRISC)  // unpack
+            iface.tc_slots[t].base_addr      = base;
+            iface.tc_slots[t].ring_size      = limit - base;
+            iface.tc_slots[t].base_entry_idx = static_cast<uint16_t>(
+                (base - iface.tc_slots[0].base_addr) / iface.entry_size);
+            iface.tc_slots[t].rd_entry_idx   = iface.tc_slots[t].base_entry_idx;
+#else  // DM
+            iface.tc_slots[t].base_addr = base;
+            iface.tc_slots[t].limit     = limit;
+            iface.tc_slots[t].rd_ptr    = base;
+            iface.tc_slots[t].wr_ptr    = base;
 #endif
         }
+        total_tc_slots += rdcycle() - t_slots_start;
 
-        // Jump to next DFB: skip dfb_initializer_t + (num_riscs * dfb_initializer_per_risc_t)
-        base_ptr += sizeof(dfb_initializer_t) + (num_riscs * sizeof(dfb_initializer_per_risc_t));
-    }
+        WAYPOINT("L4");
 
-#ifndef COMPILE_FOR_TRISC
-    // DM0 handles all remapper configuration and transaction id ISR initialization
-    if (hartid == 0) {
-        // Pass A: configure remapper for all DM producers across all DFBs, then enable
-        bool enable_remapper = false;
-        base_ptr = reinterpret_cast<volatile uint8_t*>(dfb_config_base);
-        // These masks track which transaction ids should trigger the implicit sync ISR
-        uint32_t producer_txn_id_mask = 0;
-        uint32_t consumer_txn_id_mask = 0;
-        for (uint32_t logical_dfb_id = 0; logical_dfb_id < num_dfbs; logical_dfb_id++) {
-            volatile dfb_initializer_t* init_ptr = reinterpret_cast<volatile dfb_initializer_t*>(base_ptr);
-            uint16_t risc_mask = (init_ptr->risc_mask_bits.tensix_mask << 8) | init_ptr->risc_mask_bits.dm_mask;
-            uint8_t num_riscs = static_cast<uint8_t>(__builtin_popcount(risc_mask));
-
-            volatile dfb_initializer_per_risc_t* per_risc_base =
-                reinterpret_cast<volatile dfb_initializer_per_risc_t*>(base_ptr + sizeof(dfb_initializer_t));
-
-            // Sized to the ISR descriptor these ids are copied into (see MAX_TILE_COUNTERS_PER_SIDE).
-            // The two sides are adjacent stack locals, so an unbounded fill of one silently
-            // overwrites the other's ids; the collection loops below must stay in bounds.
-            uint8_t num_producer_tcs = 0;
-            uint8_t producer_tcs[dfb::MAX_TILE_COUNTERS_PER_SIDE] = {};
-            uint8_t num_consumer_tcs = 0;
-            uint8_t consumer_tcs[dfb::MAX_TILE_COUNTERS_PER_SIDE] = {};
-            // Only collect a side's ids when that side actually programs a TxnDFBDescriptor below.
-            // A side with no transaction ids (e.g. a Tensix-only consumer, which never gets one)
-            // would otherwise gather ids that are never read - wasted work that can also exceed the
-            // staging capacity, e.g. 6 producers x 4 ALL Tensix consumers needs 24 ids.
-            const bool collect_producer_tcs = init_ptr->producer_txn_descriptor.num_txn_ids > 0;
-            const bool collect_consumer_tcs = init_ptr->consumer_txn_descriptor.num_txn_ids > 0;
-            for (uint8_t i = 0; i < num_riscs; i++) {
-                volatile dfb_initializer_per_risc_t* per_risc_ptr = per_risc_base + i;
-
-                if (per_risc_ptr->flags.is_producer) {
-                    if (per_risc_ptr->flags
-                            .remapper_en) {  // Configure remapper for all producers with remapper_en (DM and Tensix)
-                        enable_remapper = true;
-                        uint8_t remapper_consumer_ids_mask = per_risc_ptr->remapper_consumer_ids_mask;
-                        uint8_t producer_client_type = per_risc_ptr->producer_client_type;
-                        uint8_t num_clientRs = static_cast<uint8_t>(__builtin_popcount(remapper_consumer_ids_mask));
-                        uint8_t clientR_valid_mask = (1u << num_clientRs) - 1;
-                        g_remapper_configurator.set_pair_index(
-                            static_cast<uint32_t>(per_risc_ptr->flags.remapper_pair_index));
-                        // DPRINT("Setting clientL fields clientL={} tc: {} mask: {}\n", producer_client_type,
-                        // dfb::get_counter_id(per_risc_ptr->packed_tile_counter[0]), clientR_valid_mask);
-                        g_remapper_configurator.configure_clientL_all_fields(
-                            producer_client_type,
-                            dfb::get_counter_id(per_risc_ptr->packed_tile_counter[0]),
-                            clientR_valid_mask,
-                            1,  // is_producer
-                            1,  // group mode
-                            0   // distribute mode
-                        );
-                        uint8_t mask_remaining = remapper_consumer_ids_mask;
-                        for (uint8_t clientR_idx = 0; clientR_idx < num_clientRs; clientR_idx++) {
-                            uint8_t id_R = static_cast<uint8_t>(__builtin_ctz(mask_remaining));
-                            mask_remaining &= mask_remaining - 1;
-                            uint8_t tc_R = (per_risc_ptr->consumer_tcs >> (clientR_idx * 5)) & 0x1F;
-                            // DPRINT("Setting clientR slot {} id: {} tc: {}\n", clientR_idx, id_R, tc_R);
-                            g_remapper_configurator.set_clientR_slot(clientR_idx, id_R, tc_R);
-                        }
-                        // DPRINT("Writing all remapper configs\n");
-                        g_remapper_configurator.write_all_configs();
-                    }
-
-                    for (uint8_t i = 0; collect_producer_tcs && i < per_risc_ptr->num_tcs_and_init.num_tcs_to_rr; i++) {
-                        ASSERT(num_producer_tcs < dfb::MAX_TILE_COUNTERS_PER_SIDE);
-                        if (num_producer_tcs >= dfb::MAX_TILE_COUNTERS_PER_SIDE) {
-                            break;
-                        }
-                        producer_tcs[num_producer_tcs++] = per_risc_ptr->packed_tile_counter[i];
-                    }
-                } else {
-                    for (uint8_t i = 0; collect_consumer_tcs && i < per_risc_ptr->num_tcs_and_init.num_tcs_to_rr; i++) {
-                        ASSERT(num_consumer_tcs < dfb::MAX_TILE_COUNTERS_PER_SIDE);
-                        if (num_consumer_tcs >= dfb::MAX_TILE_COUNTERS_PER_SIDE) {
-                            break;
-                        }
-                        consumer_tcs[num_consumer_tcs++] = per_risc_ptr->packed_tile_counter[i];
-                    }
-                }
-            }
-
-            // Got all info from producers and consumers, now set up the TxnDFBDescriptor for producer and consumer
-            for (uint8_t i = 0; i < init_ptr->producer_txn_descriptor.num_txn_ids; i++) {
-                uint8_t txn_id = init_ptr->producer_txn_descriptor.txn_ids[i];
-                producer_txn_id_mask |= (1u << txn_id);
-                volatile TxnDFBDescriptor& dst = g_txn_dfb_descriptor[txn_id];
-                dst.num_counters = static_cast<uint8_t>(num_producer_tcs);
-                for (uint8_t j = 0; j < dst.num_counters; j++) {
-                    dst.tile_counters[j] = producer_tcs[j];
-                }
-                dst.tiles_to_post = init_ptr->producer_txn_descriptor.num_entries_per_txn_id_per_tc;
-                // To avoid DM synchronization, the final credit sync that manually posts credits in
-                // DataflowBuffer::finish doesn't clear tiles to process do that here to avoid raising spurious
-                // interrupts
-                CMDBUF_CLEAR_TILES_TO_PROCESS_TR_ACK(OVERLAY_RD_CMD_BUF, txn_id);
-                asm volatile("nop");
-
-                SET_TILES_TO_PROCESS_THRES_TR_ACK(
-                    txn_id, init_ptr->producer_txn_descriptor.num_entries_to_process_threshold);
-            }
-            for (uint8_t i = 0; i < init_ptr->consumer_txn_descriptor.num_txn_ids; i++) {
-                uint8_t txn_id = init_ptr->consumer_txn_descriptor.txn_ids[i];
-                consumer_txn_id_mask |= (1u << txn_id);
-                volatile TxnDFBDescriptor& dst = g_txn_dfb_descriptor[txn_id];
-                dst.num_counters = static_cast<uint8_t>(num_consumer_tcs);
-                for (uint8_t j = 0; j < dst.num_counters; j++) {
-                    dst.tile_counters[j] = consumer_tcs[j];
-                }
-                // To avoid DM synchronization, the final credit sync that manually posts credits in
-                // DataflowBuffer::finish doesn't clear tiles to process do that here to avoid raising spurious
-                // interrupts
-                CMDBUF_CLEAR_TILES_TO_PROCESS_WR_SENT(OVERLAY_WR_CMD_BUF, txn_id);
-                asm volatile("nop");
-
-                dst.tiles_to_ack = init_ptr->consumer_txn_descriptor.num_entries_per_txn_id_per_tc;
-                SET_TILES_TO_PROCESS_THRES_WR_SENT(
-                    txn_id, init_ptr->consumer_txn_descriptor.num_entries_to_process_threshold);
-            }
-            base_ptr += sizeof(dfb_initializer_t) + (num_riscs * sizeof(dfb_initializer_per_risc_t));
-        }
-
-        // Program which transaction ids should trigger the implicit sync ISR
-        // per_trid_tiles_to_process_set_interrupt_enable_cmdbuf_x(producer_txn_id_mask);
-        uint64_t reg_val = CMDBUF_RD_REG(OVERLAY_RD_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_PER_TR_ID_IE_1_REG_OFFSET);
-        reg_val = (reg_val & 0x00000000FFFFFFFFULL) | ((uint64_t)(producer_txn_id_mask & 0xFFFFFFFFULL) << 32);
-        CMDBUF_WR_REG(OVERLAY_RD_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_PER_TR_ID_IE_1_REG_OFFSET, reg_val);
-
-        // per_trid_wr_tiles_to_process_set_interrupt_enable_cmdbuf_x(consumer_txn_id_mask);
-        reg_val = CMDBUF_RD_REG(OVERLAY_WR_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_PER_TR_ID_IE_2_REG_OFFSET);
-        reg_val = (reg_val & 0xFFFFFFFF00000000ULL) | (consumer_txn_id_mask & 0xFFFFFFFFULL);
-        CMDBUF_WR_REG(OVERLAY_WR_CMD_BUF, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_PER_TR_ID_IE_2_REG_OFFSET, reg_val);
-
-        if (enable_remapper) {
-            // DPRINT("Enabling remapper\n");
-            g_remapper_configurator.enable_remapper();
-        }
-
-        if ((producer_txn_id_mask | consumer_txn_id_mask) != 0) {
-            enable_dfb_tile_isr();
-        } else {
-            disable_dfb_tile_isr();
-        }
-
-    }  // end if (hartid == 0)
-#endif
-
-    // Each DM and Tensix producer initialized their own TC
-    base_ptr = reinterpret_cast<volatile uint8_t*>(dfb_config_base);
-    for (uint32_t logical_dfb_id = 0; logical_dfb_id < num_dfbs; logical_dfb_id++) {
-        volatile dfb_initializer_t* init_ptr = reinterpret_cast<volatile dfb_initializer_t*>(base_ptr);
-        uint16_t risc_mask = (init_ptr->risc_mask_bits.tensix_mask << 8) | init_ptr->risc_mask_bits.dm_mask;
-        uint8_t num_riscs = static_cast<uint8_t>(__builtin_popcount(risc_mask));
-
-        volatile dfb_initializer_per_risc_t* per_risc_base =
-            reinterpret_cast<volatile dfb_initializer_per_risc_t*>(base_ptr + sizeof(dfb_initializer_t));
-
-        if (risc_mask & hart_bit) {
-            uint8_t risc_index = static_cast<uint8_t>(__builtin_popcount(risc_mask & ((1 << hartid) - 1)));
-            volatile dfb_initializer_per_risc_t* per_risc_ptr = per_risc_base + risc_index;
-
-            if (per_risc_ptr->flags.is_producer) {
-                while (per_risc_ptr->flags.remapper_en && !overlay::RemapperAPI::is_remapper_enabled());
-
-                // Note: resetting tile counters does not reset the buffer capacity to 0
-                for (uint8_t tc = 0; tc < per_risc_ptr->num_tcs_and_init.num_tcs_to_rr; tc++) {
-                    dfb::PackedTileCounter ptc = per_risc_ptr->packed_tile_counter[tc];
-                    uint8_t tc_id = dfb::get_counter_id(ptc);
-#if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
-                    // DPRINT("dfb {} initializing tc_id: {}\n", logical_dfb_id, tc_id);
-                    ckernel::trisc::tile_counters[tc_id].f.reset = 1;
-                    ckernel::trisc::tile_counters[tc_id].f.buf_capacity = init_ptr->capacity;
-#elif !defined(COMPILE_FOR_TRISC)
-                    uint8_t tensix_id = dfb::get_tensix_id(ptc);
-                    // DPRINT("dfb {} initializing tc tensix_id: {} tc_id: {}\n", logical_dfb_id, tensix_id,
-                    // tc_id);
-                    overlay::llk_intf_reset(tensix_id, tc_id);
-                    overlay::llk_intf_set_capacity(tensix_id, tc_id, init_ptr->capacity);
-#endif
-                }
-                // Only the RISC that actually performed the TC hardware init sets tc_init_done.
+        // --- Producer-only: wait for remapper pair + TC HW init + publish ready ---
 #if !defined(COMPILE_FOR_TRISC) || defined(UCK_CHLKC_PACK)
-                per_risc_ptr->num_tcs_and_init.tc_init_done = 1;
+        if (eh.flags & DFB_HART_FLAG_IS_PRODUCER) {
+            // Remapped producers: spin until DM1 has written this pair's ClientL config with
+            // non-zero valid bits (bits [11:8]). No global remapper-enable wait is needed.
+            if (eh.flags & DFB_HART_FLAG_REMAPPER_EN) {
+                const uint32_t spin_start = rdcycle();
+                const uint32_t pair_idx = eh.remapper_pair_index;
+                WAYPOINT("RMSW");
+                while (overlay::RemapperAPI::get_clientL_valid_hw(pair_idx) == 0u) {
+                }
+                WAYPOINT("RMSD");
+                total_remapper_spin += rdcycle() - spin_start;
+            }
+
+            const uint32_t tc_hw_start = rdcycle();
+            for (uint32_t t = 0; t < num_tcs; t++) {
+                const uint8_t packed_ptc = iface.tc_slots[t].packed_tile_counter;
+                const uint8_t tc_id = dfb::get_counter_id(packed_ptc);
+#ifndef COMPILE_FOR_TRISC
+                const uint8_t tensix_id = dfb::get_tensix_id(packed_ptc);
+                const uint32_t t_reset = rdcycle();
+                overlay::fast_llk_intf_reset(tensix_id, tc_id);
+                total_tc_reset_hw += rdcycle() - t_reset;
+                total_hw_reg_writes++;
+#elif defined(UCK_CHLKC_PACK)
+                const uint32_t t_reset = rdcycle();
+                ckernel::trisc::tile_counters[tc_id].f.reset = 1;
+                total_tc_reset_hw += rdcycle() - t_reset;
+                total_hw_reg_writes++;
 #endif
             }
-        }
+#ifndef COMPILE_FOR_TRISC
+            asm volatile("fence w, w" ::: "memory");
+#endif
+            for (uint32_t t = 0; t < num_tcs; t++) {
+                const uint8_t packed_ptc = iface.tc_slots[t].packed_tile_counter;
+                const uint8_t tc_id = dfb::get_counter_id(packed_ptc);
+#ifndef COMPILE_FOR_TRISC
+                const uint8_t tensix_id = dfb::get_tensix_id(packed_ptc);
+                const uint32_t t_cap = rdcycle();
+                overlay::fast_llk_intf_set_capacity(tensix_id, tc_id, eh.capacity);
+                total_tc_capacity_hw += rdcycle() - t_cap;
+                total_hw_reg_writes++;
+#elif defined(UCK_CHLKC_PACK)
+                const uint32_t t_cap = rdcycle();
+                ckernel::trisc::tile_counters[tc_id].f.buf_capacity = eh.capacity;
+                total_tc_capacity_hw += rdcycle() - t_cap;
+                total_hw_reg_writes++;
+#endif
+            }
+#ifndef COMPILE_FOR_TRISC
+            asm volatile("fence w, w" ::: "memory");
+#endif
+            total_tc_hw += rdcycle() - tc_hw_start;
 
-        base_ptr += sizeof(dfb_initializer_t) + (num_riscs * sizeof(dfb_initializer_per_risc_t));
+            const uint32_t t_sig_start = rdcycle();
+            dfb_publish_producer_ready(dfb_signal_base, eh.logical_dfb_id, eh.producer_signal_bit);
+            total_sig_write += rdcycle() - t_sig_start;
+        }
+#endif  // !COMPILE_FOR_TRISC || UCK_CHLKC_PACK
+
+        WAYPOINT("L5");
     }
 
-    // After setting up g_dfb_interface, wait for all TCs to be initialized
-    wait_all_tcs_initialized(dfb_config_base, num_dfbs, hartid);
-    // DPRINT("all_tcs_initialized\n");
+    const uint32_t t_after_merged_loop = rdcycle();
+
+    WAYPOINT("L12");
+    const uint32_t end_time = rdcycle();
+
+#ifdef COMPILE_FOR_TRISC
+    const uint8_t timing_slot = dfb_init_timing_trisc_slot_index();
+    const uint8_t timing_role = dfb::DFB_INIT_TIMING_ROLE_TRISC_LOCAL;
+#else
+    const uint8_t timing_slot = hart_u8;
+    const uint8_t timing_role = dfb::DFB_INIT_TIMING_ROLE_DM_LOCAL;
+#endif
+    dfb_init_timing_write_slot(
+        timing_slot,
+        timing_role,
+        end_time - start_time,
+        t_after_merged_loop - start_time,   // METRIC_A: merged_sw (full loop wall time)
+        total_remapper_spin,                 // METRIC_B: remapper_spin
+        total_tc_hw,                         // METRIC_C: tc_hw
+        total_hw_reg_writes,                 // METRIC_D: hw_reg_writes (TC reset + capacity per producer TC)
+        total_tc_reset_hw,                   // METRIC_E: tc_reset_hw
+        total_tc_capacity_hw,                // METRIC_F: tc_capacity_hw
+        start_time,
+        end_time,
+        pre_loop,                            // METRIC_G: pre_loop overhead (3 uncached header loads)
+        total_entry_hdr,                     // METRIC_H: entry_hdr (6 u32 bulk reads × N entries)
+        total_tc_slots,                      // METRIC_I: tc_slots (base/limit/ptc reads + iface writes)
+        total_sig_write);                    // METRIC_J: sig_write (uncached store to signal region)
 }

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_interface.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_interface.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include "dataflow_buffer_config.h"
 #ifndef COMPILE_FOR_TRISC
@@ -21,8 +22,11 @@ extern thread_local uint8_t g_dfb_logical_to_compact[dfb::NUM_DFBS];
 #else
 extern thread_local LocalDFBInterface g_dfb_interface[dfb::NUM_DFBS];
 #endif
+
+// Cached L1 byte address of the DFB config region; set once during setup_local_dfb_interfaces
+// so DataflowBuffer::DataflowBuffer() can call dfb_ensure_ready without a separate parameter.
+extern thread_local uintptr_t g_dfb_config_base_addr;
 #ifndef COMPILE_FOR_TRISC
-// TODO: make this a constant when we clean up number of txn ids
 extern volatile TxnDFBDescriptor g_txn_dfb_descriptor[32];
 extern overlay::RemapperAPI g_remapper_configurator;
 #endif
@@ -82,37 +86,41 @@ static_assert(sizeof(LocalDFBInterface) == 88, "LocalDFBInterface (unpack TRISC)
 
 #else
 
-// Per–tile-counter slot (DM)
+// Per–tile-counter slot (DM).
+//
+// All u32 fields are at 4B-aligned offsets and the struct pads to 20B to keep every
+// tc_slots[] element 4B-aligned within LocalDFBInterface.
 struct DFBTCSlot {
     uint32_t rd_ptr;
     uint32_t wr_ptr;
     uint32_t base_addr;
     uint32_t limit;
     dfb::PackedTileCounter packed_tile_counter;
-} __attribute__((packed));
+    uint8_t _align[3];  // pad 17 → 20B so every slot in tc_slots[] is 4B-aligned
+};
 
-// on WH/BH arrays will be sized to 1
 struct LocalDFBInterface {
     uint32_t entry_size;
     uint32_t stride_size;
-    uint16_t num_entries;
 
     uint8_t num_tcs_to_rr;
     uint8_t tc_idx;
 
     uint8_t txn_ids[dfb::NUM_TXN_IDS];
-    uint8_t threshold;         // When this value is met, ISR to post/ack credits will fire. Used when last reads don't meet this value.
-    uint8_t
-        num_entries_per_txn_id;
+    uint8_t threshold;        // When this value is met, ISR to post/ack credits will fire.
+    uint8_t num_entries_per_txn_id;
     uint8_t num_entries_per_txn_id_per_tc;
     uint8_t num_txn_ids;
     uint8_t broadcast_tc;  // DM-DM ALL producer: post to all TCs instead of round-robin
+    uint8_t _tc_align_pad;  // pad bytes [8,20) → 20B so tc_slots[] stays 4B-aligned
+
+    uint16_t num_entries;
 
     DFBTCSlot tc_slots[dfb::MAX_NUM_TILE_COUNTERS_TO_RR];
-} __attribute__((packed));
+};
 
-static_assert(sizeof(DFBTCSlot) == 17, "DFBTCSlot size is incorrect");
-static_assert(sizeof(LocalDFBInterface) == 123, "LocalDFBInterface size is incorrect");
+static_assert(sizeof(DFBTCSlot) == 20, "DFBTCSlot size is incorrect");
+static_assert(sizeof(LocalDFBInterface) == 144, "LocalDFBInterface size is incorrect");
 
 #endif
 
@@ -136,8 +144,9 @@ inline LocalDFBInterface& get_local_dfb_interface(uint32_t logical_dfb_id) {
 #endif
 }
 
-// Holds metadata for transaction ID based ISR handling
-// It is used by the ISR to understand which tile counters need to update which credits (post/ack)
+// Holds metadata for transaction ID based ISR handling.
+// It is used by the ISR to understand which tile counters need to update which credits (post/ack).
+// Padded to 32 bytes so g_txn_dfb_descriptor[trid] compiles to base + (trid << 5) instead of a multiply-by-20.
 struct TxnDFBDescriptor {
     uint8_t num_counters;
     dfb::PackedTileCounter tile_counters[dfb::MAX_TILE_COUNTERS_PER_SIDE];
@@ -145,4 +154,18 @@ struct TxnDFBDescriptor {
         uint8_t tiles_to_post;
         uint8_t tiles_to_ack;
     } __attribute__((packed));
+    uint8_t _pad[12];  // pad 20 → 32 bytes
 };
+static_assert(sizeof(TxnDFBDescriptor) == 32, "TxnDFBDescriptor size is incorrect");
+static_assert(
+    sizeof(TxnDFBDescriptor) == sizeof(dfb_dm0_txn_descriptor_image_t),
+    "TxnDFBDescriptor must match dfb_dm0_txn_descriptor_image_t for ISR blob memcpy");
+static_assert(
+    offsetof(TxnDFBDescriptor, num_counters) == offsetof(dfb_dm0_txn_descriptor_image_t, num_counters),
+    "TxnDFBDescriptor field layout must match dfb_dm0_txn_descriptor_image_t");
+static_assert(
+    offsetof(TxnDFBDescriptor, tile_counters) == offsetof(dfb_dm0_txn_descriptor_image_t, tile_counters),
+    "TxnDFBDescriptor field layout must match dfb_dm0_txn_descriptor_image_t");
+static_assert(
+    offsetof(TxnDFBDescriptor, tiles_to_post) == offsetof(dfb_dm0_txn_descriptor_image_t, tiles_to_post_or_ack),
+    "TxnDFBDescriptor tiles_to_post must match dfb_dm0_txn_descriptor_image_t tiles_to_post_or_ack");

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/remapper_api.hpp
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/remapper_api.hpp
@@ -52,6 +52,9 @@ private:
     tClientR_Config_Reg_u clientR_configs[REMAP_NUM_PAIRS]{};
     tClientL_Config_Reg_u clientL_configs[REMAP_NUM_PAIRS]{};
     uint32_t current_pair_idx;
+    // Highest pair index programmed to HW since last reset (0 if none yet).
+    // Updated by set_pair_high_watermark(); teardown clears [0, pair_high_watermark_].
+    uint32_t pair_high_watermark_ = 0;
 
 public:
     /**
@@ -86,6 +89,21 @@ public:
      * @return Current pair index
      */
     uint32_t get_pair_index() const { return current_pair_idx; }
+
+    /**
+     * @brief Reset the configured-pair high watermark
+     */
+    void reset_pair_high_watermark() { pair_high_watermark_ = 0; }
+
+    /**
+     * @brief Set the configured-pair high watermark after a bulk remapper init loop.
+     *
+     * @param pair_idx Largest pair index programmed (0-63); teardown clears [0, pair_idx].
+     */
+    void set_pair_high_watermark(uint32_t pair_idx) {
+        ASSERT(pair_idx < REMAP_NUM_PAIRS);
+        pair_high_watermark_ = pair_idx;
+    }
 
     // ========================================================================
     // ClientR Configuration Methods
@@ -455,6 +473,22 @@ public:
     }
 
     /**
+     * @brief Read ClientL valid bits [11:8] from remapper hardware for a specific pair.
+     *
+     * Used by remapped DFB producers to wait until DM1 has programmed this pair's ClientL
+     * register (valid mask non-zero) before resetting the producer TC and publishing ready.
+     *
+     * @param pair_idx Pair index (0-63)
+     * @return Valid bits value (0-15), read from live hardware
+     */
+    static uint32_t get_clientL_valid_hw(uint32_t pair_idx) {
+        if (pair_idx >= REMAP_NUM_PAIRS) {
+            return 0;
+        }
+        return (READ_REG32(REMAP_CLIENT_L_CONFIG_REG_ADDR32(pair_idx)) >> 8u) & 0xFu;
+    }
+
+    /**
      * @brief Set ClientL producer/consumer mode (uses current pair)
      *
      * @param is_producer 1 if ClientL is producer, 0 if consumer
@@ -543,6 +577,26 @@ public:
 
         // Write back modified value
         WRITE_REG32(REMAP_CLIENT_L_CONFIG_REG_ADDR32(pair_idx), modified_val);
+    }
+
+    // ClientL.f.valid occupies bits [11:8]; bit (8 + slot) enables ClientR slot `slot`.
+    static constexpr uint32_t CLIENTL_VALID_FIELD_LSB = 8u;
+
+    /**
+     * @brief Clear ClientL valid bits [11:8] on every configured pair (hardware RMW).
+     *
+     * Iterates pairs [0, pair_high_watermark_] inclusive — skips unconfigured pairs above.
+     * Preserves id_L, cnt_sel_L, and control flags; disables all ClientR slot routing.
+     */
+    void clear_clientL_valid_up_to_high_watermark_hw() {
+        constexpr uint32_t valid_field_mask = 0xFu << CLIENTL_VALID_FIELD_LSB;
+        const uint32_t limit = (pair_high_watermark_ + 1u < REMAP_NUM_PAIRS)
+                                   ? pair_high_watermark_ + 1u
+                                   : REMAP_NUM_PAIRS;
+        for (uint32_t pair_idx = 0; pair_idx < limit; pair_idx++) {
+            const uint32_t addr = REMAP_CLIENT_L_CONFIG_REG_ADDR32(pair_idx);
+            WRITE_REG32(addr, READ_REG32(addr) & ~valid_field_mask);
+        }
     }
 
     /**

--- a/tt_metal/hw/inc/internal/tt-2xx/risc_common.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/risc_common.h
@@ -267,6 +267,7 @@ inline __attribute__((always_inline)) void flush_l2_cache_range(uintptr_t start_
 
 // Invalidate a range of addresses from L2 to TL1.
 // Invalidates all cache lines covering [start_addr, start_addr + size).
+// Fence once around the loop (same pattern as flush_l2_cache_full) — per-line
 inline __attribute__((always_inline)) void invalidate_l2_cache_range(uintptr_t start_addr, size_t size) {
     if (size == 0) {
         return;
@@ -274,9 +275,12 @@ inline __attribute__((always_inline)) void invalidate_l2_cache_range(uintptr_t s
     uintptr_t aligned_start = start_addr & ~(uintptr_t)63;  // align to 64B
     uintptr_t end_addr = start_addr + size;
 
+    __asm__ __volatile__("fence" ::: "memory");
+    volatile uint64_t* inv_reg = (volatile uint64_t*)L2_INVALIDATE_ADDR;
     for (uintptr_t addr = aligned_start; addr < end_addr; addr += 64) {
-        invalidate_l2_cache_line(addr);
+        *inv_reg = (uint64_t)addr;
     }
+    __asm__ __volatile__("fence" ::: "memory");
 }
 
 // Flush entire L2 cache to TL1.

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -7,9 +7,10 @@
 #include "impl/dataflow_buffer/dataflow_buffer.hpp"
 
 #include <algorithm>
+#include <cstddef>
+#include <cstring>
 #include <limits>
-#include <tuple>
-#include <utility>
+#include <string>
 
 #include "impl/context/metal_context.hpp"
 #include "jit_build/jit_build_options.hpp"
@@ -18,6 +19,714 @@
 #include "tt_metal/impl/program/program_impl.hpp"
 #include "tt_metal/impl/kernels/kernel.hpp"
 #include "tt_metal/tools/profiler/tracy_debug_zones.hpp"
+
+namespace tt::tt_metal::experimental::dfb::detail {
+
+namespace {
+
+uint32_t align_dfb_config_transfer_size(uint32_t payload_bytes) {
+    if (payload_bytes == 0) {
+        return 0;
+    }
+    const auto& hal = MetalContext::instance().hal();
+    // RTL sim and DMA paths move L1 in uint32_t chunks; also honor HAL L1 alignment for the region.
+    const uint32_t min_align = hal.has_tile_counter_registers() ? static_cast<uint32_t>(sizeof(uint32_t)) : 1u;
+    const uint32_t align_bytes = std::max(min_align, hal.get_alignment(HalMemType::L1));
+    return static_cast<uint32_t>(tt::align(payload_bytes, align_bytes));
+}
+
+dfb_dm0_txn_descriptor_image_t build_dm0_txn_descriptor_image(
+    uint8_t num_tcs,
+    const std::vector<::dfb::PackedTileCounter>& tcs,
+    uint8_t tiles_to_post_or_ack) {
+    dfb_dm0_txn_descriptor_image_t img = {};
+    img.num_counters = num_tcs;
+    for (uint8_t j = 0; j < num_tcs && j < ::dfb::MAX_TCS_PER_TXN; ++j) {
+        img.tile_counters[j] = tcs[j];
+    }
+    img.tiles_to_post_or_ack = tiles_to_post_or_ack;
+    return img;
+}
+
+uint32_t compute_dm0_isr_txn_desc_pool_byte_size(uint32_t producer_txn_id_mask, uint32_t consumer_txn_id_mask) {
+    return dm0_isr_txn_desc_pool_byte_size(producer_txn_id_mask, consumer_txn_id_mask);
+}
+
+uint32_t compute_dm0_isr_txn_hw_pool_byte_size(uint32_t producer_txn_id_mask, uint32_t consumer_txn_id_mask) {
+    return dm0_isr_txn_hw_pool_byte_size(producer_txn_id_mask, consumer_txn_id_mask);
+}
+
+std::vector<uint8_t> serialize_dm0_isr_txn_hw_pool_for_core(
+    const std::vector<std::shared_ptr<DataflowBufferImpl>>& dfbs_on_core,
+    uint32_t producer_txn_id_mask,
+    uint32_t consumer_txn_id_mask) {
+    const uint32_t hw_bytes = compute_dm0_isr_txn_hw_pool_byte_size(producer_txn_id_mask, consumer_txn_id_mask);
+    if (hw_bytes == 0) {
+        return {};
+    }
+
+    const uint32_t all_mask = producer_txn_id_mask | consumer_txn_id_mask;
+    std::vector<uint8_t> pool(hw_bytes, 0);
+    auto write_threshold = [&](uint8_t txn_id, uint8_t threshold) {
+        dfb_dm0_isr_txn_threshold_t entry = {};
+        entry.threshold = threshold;
+        std::memcpy(
+            pool.data() + dm0_isr_txn_slot_index(all_mask, txn_id) * sizeof(dfb_dm0_isr_txn_threshold_t),
+            &entry,
+            sizeof(entry));
+    };
+    for (const auto& dfb : dfbs_on_core) {
+        for (uint8_t i = 0; i < dfb->producer_txn_descriptor.num_txn_ids; i++) {
+            write_threshold(
+                dfb->producer_txn_descriptor.txn_ids[i],
+                dfb->producer_txn_descriptor.num_entries_to_process_threshold);
+        }
+        for (uint8_t i = 0; i < dfb->consumer_txn_descriptor.num_txn_ids; i++) {
+            write_threshold(
+                dfb->consumer_txn_descriptor.txn_ids[i],
+                dfb->consumer_txn_descriptor.num_entries_to_process_threshold);
+        }
+    }
+    return pool;
+}
+
+std::vector<uint8_t> serialize_dm0_isr_txn_desc_pool_for_core(
+    const CoreCoord& core,
+    const std::vector<std::shared_ptr<DataflowBufferImpl>>& dfbs_on_core,
+    uint32_t producer_txn_id_mask,
+    uint32_t consumer_txn_id_mask) {
+    const uint32_t pool_bytes = compute_dm0_isr_txn_desc_pool_byte_size(producer_txn_id_mask, consumer_txn_id_mask);
+    if (pool_bytes == 0) {
+        return {};
+    }
+
+    const uint32_t all_mask = producer_txn_id_mask | consumer_txn_id_mask;
+    std::vector<uint8_t> pool(pool_bytes, 0);
+    for (const auto& dfb : dfbs_on_core) {
+        auto it = dfb->core_lookup_.find(core);
+        if (it == dfb->core_lookup_.end()) {
+            continue;
+        }
+        const auto& [group_idx, alloc_addr] = it->second;
+        (void)alloc_addr;
+        const auto& hw_risc_configs = dfb->groups[group_idx].hw_risc_configs;
+
+        std::vector<::dfb::PackedTileCounter> blob_producer_tcs;
+        std::vector<::dfb::PackedTileCounter> blob_consumer_tcs;
+        for (int bit = 0; bit < 16; bit++) {
+            if (!(dfb->risc_mask & (1 << bit))) {
+                continue;
+            }
+            const DFBRiscConfig* rc = nullptr;
+            for (const auto& c : hw_risc_configs) {
+                if (c.risc_id == static_cast<uint8_t>(bit)) {
+                    rc = &c;
+                    break;
+                }
+            }
+            if (rc == nullptr) {
+                continue;
+            }
+            for (uint8_t j = 0; j < rc->config.num_tcs_to_rr; j++) {
+                if (rc->is_producer) {
+                    blob_producer_tcs.push_back(rc->config.packed_tile_counter[j]);
+                } else {
+                    blob_consumer_tcs.push_back(rc->config.packed_tile_counter[j]);
+                }
+            }
+        }
+
+        const uint8_t num_prod_tcs = static_cast<uint8_t>(blob_producer_tcs.size());
+        const uint8_t num_cons_tcs = static_cast<uint8_t>(blob_consumer_tcs.size());
+        const auto prod_desc = build_dm0_txn_descriptor_image(
+            num_prod_tcs, blob_producer_tcs, dfb->producer_txn_descriptor.num_entries_per_txn_id_per_tc);
+        const auto cons_desc = build_dm0_txn_descriptor_image(
+            num_cons_tcs, blob_consumer_tcs, dfb->consumer_txn_descriptor.num_entries_per_txn_id_per_tc);
+
+        for (uint8_t i = 0; i < dfb->producer_txn_descriptor.num_txn_ids; i++) {
+            const uint8_t txn_id = dfb->producer_txn_descriptor.txn_ids[i];
+            std::memcpy(
+                pool.data() + dm0_isr_txn_slot_index(all_mask, txn_id) * sizeof(dfb_dm0_txn_descriptor_image_t),
+                &prod_desc,
+                sizeof(prod_desc));
+        }
+        for (uint8_t i = 0; i < dfb->consumer_txn_descriptor.num_txn_ids; i++) {
+            const uint8_t txn_id = dfb->consumer_txn_descriptor.txn_ids[i];
+            std::memcpy(
+                pool.data() + dm0_isr_txn_slot_index(all_mask, txn_id) * sizeof(dfb_dm0_txn_descriptor_image_t),
+                &cons_desc,
+                sizeof(cons_desc));
+        }
+    }
+    return pool;
+}
+
+}  // namespace
+
+std::pair<uint32_t, uint32_t> compute_dm0_isr_blob_core_masks(
+    const std::vector<std::shared_ptr<DataflowBufferImpl>>& dfbs_on_core) {
+    uint32_t producer_mask = 0;
+    uint32_t consumer_mask = 0;
+    for (const auto& dfb : dfbs_on_core) {
+        for (uint8_t i = 0; i < dfb->producer_txn_descriptor.num_txn_ids; ++i) {
+            producer_mask |= 1u << dfb->producer_txn_descriptor.txn_ids[i];
+        }
+        for (uint8_t i = 0; i < dfb->consumer_txn_descriptor.num_txn_ids; ++i) {
+            consumer_mask |= 1u << dfb->consumer_txn_descriptor.txn_ids[i];
+        }
+    }
+    return {producer_mask, consumer_mask};
+}
+
+uint32_t dm0_isr_blob_region_size(const std::vector<std::shared_ptr<DataflowBufferImpl>>& dfbs_on_core) {
+    const auto [producer_mask, consumer_mask] = compute_dm0_isr_blob_core_masks(dfbs_on_core);
+    if ((producer_mask | consumer_mask) == 0) {
+        return 0;
+    }
+    const uint32_t txn_hw_bytes = compute_dm0_isr_txn_hw_pool_byte_size(producer_mask, consumer_mask);
+    const uint32_t pool_bytes = compute_dm0_isr_txn_desc_pool_byte_size(producer_mask, consumer_mask);
+    return static_cast<uint32_t>(sizeof(dfb_dm0_isr_blob_core_header_t)) + txn_hw_bytes + pool_bytes;
+}
+
+uint32_t dm1_remapper_blob_core_size(const std::vector<std::shared_ptr<DataflowBufferImpl>>& dfbs_on_core) {
+    if (!MetalContext::instance().hal().has_tile_counter_registers()) {
+        return 0;
+    }
+    uint32_t num_slots = 0;
+    for (const auto& dfb : dfbs_on_core) {
+        num_slots += dfb->dm1_remapper_slot_count();
+    }
+    return static_cast<uint32_t>(sizeof(dfb_dm1_remapper_core_header_t)) +
+           num_slots * static_cast<uint32_t>(sizeof(dfb_dm1_remapper_slot_t));
+}
+
+std::vector<uint8_t> serialize_dm1_remapper_core_blob(
+    const CoreCoord& core, const std::vector<std::shared_ptr<DataflowBufferImpl>>& dfbs_on_core) {
+    if (!MetalContext::instance().hal().has_tile_counter_registers()) {
+        return {};
+    }
+
+    uint16_t num_slots = 0;
+    for (const auto& dfb : dfbs_on_core) {
+        const uint32_t slot_count = dfb->dm1_remapper_slot_count();
+        TT_FATAL(
+            num_slots + slot_count <= UINT16_MAX,
+            "DM1 remapper slot count overflow on core ({},{})",
+            core.x,
+            core.y);
+        num_slots = static_cast<uint16_t>(num_slots + slot_count);
+    }
+
+    std::vector<uint8_t> data;
+    data.reserve(dm1_remapper_blob_core_size(dfbs_on_core));
+
+    dfb_dm1_remapper_core_header_t hdr = {};
+    hdr.num_slots = num_slots;
+    const auto* hdr_bytes = reinterpret_cast<const uint8_t*>(&hdr);
+    data.insert(data.end(), hdr_bytes, hdr_bytes + sizeof(hdr));
+
+    for (const auto& dfb : dfbs_on_core) {
+        dfb->append_dm1_remapper_slots_for_core(core, data);
+    }
+    return data;
+}
+
+// Returns the serialized byte size of one hart's init blob (init entries only, no wait entries).
+// Accounts for per-entry variable TC arrays and 4B end-padding.
+static uint32_t hart_blob_byte_size(
+    uint8_t hartid, const std::vector<std::shared_ptr<DataflowBufferImpl>>& dfbs_on_core) {
+    uint32_t sz = 0u;
+    uint8_t n = 0;
+    for (const auto& dfb : dfbs_on_core) {
+        if (!(dfb->risc_mask & (1u << hartid))) { continue; }
+        n++;
+        // Find num_tcs for this hart in this DFB (use first group; all groups share same hw_risc_configs shape).
+        uint8_t num_tcs = 1;
+        for (const auto& rc : dfb->groups[0].hw_risc_configs) {
+            if (rc.risc_id == hartid) { num_tcs = rc.config.num_tcs_to_rr; break; }
+        }
+        sz += dfb_hart_init_entry_byte_size(num_tcs);
+    }
+    if (n == 0) {
+        sz = 4u;  // minimal {0,0,0,0} blob for non-participating hart
+    }
+    return (sz + 3u) & ~3u;  // 4B-aligned
+}
+
+uint32_t compute_dfb_config_serialized_size(
+    const std::vector<std::shared_ptr<DataflowBufferImpl>>& dfbs_on_core) {
+    if (dfbs_on_core.empty()) { return 0; }
+    const auto& hal = MetalContext::instance().hal();
+    TT_FATAL(hal.has_tile_counter_registers(), "compute_dfb_config_serialized_size requires Quasar");
+
+    uint32_t payload = dfb_config_header_size();
+    payload += dm1_remapper_blob_core_size(dfbs_on_core);
+    payload += dm0_isr_blob_region_size(dfbs_on_core);
+    for (uint8_t h = 0; h < ::dfb::NUM_PARTICIPATING_HARTIDS; h++) {
+        payload += hart_blob_byte_size(h, dfbs_on_core);
+    }
+    // Signal region: per-producer byte slots (NUM_DFBS * MAX_PRODUCERS_PER_DFB) + uint32_t expected per DFB.
+    payload += static_cast<uint32_t>(::dfb::NUM_DFBS) * static_cast<uint32_t>(::dfb::MAX_PRODUCERS_PER_DFB) +
+               static_cast<uint32_t>(::dfb::NUM_DFBS) * static_cast<uint32_t>(sizeof(uint32_t));
+    return align_dfb_config_transfer_size(payload);
+}
+
+void populate_dfb_global_header_participation(
+    dfb_global_header_t& ghdr, const std::vector<std::shared_ptr<DataflowBufferImpl>>& dfbs_on_core) {
+    std::fill(std::begin(ghdr.participation_mask), std::end(ghdr.participation_mask), 0u);
+    ghdr.num_dfbs = static_cast<uint8_t>(dfbs_on_core.size());
+    TT_FATAL(
+        dfbs_on_core.size() <= ::dfb::NUM_DFBS,
+        "DFB count {} exceeds maximum {}",
+        dfbs_on_core.size(),
+        ::dfb::NUM_DFBS);
+    uint32_t id_mask = 0;
+    for (const auto& dfb : dfbs_on_core) {
+        TT_FATAL(dfb->id < ghdr.num_dfbs, "DFB id {} out of range (num_dfbs {})", dfb->id, ghdr.num_dfbs);
+        id_mask |= (1u << dfb->id);
+        for (uint8_t hartid = 0; hartid < ::dfb::NUM_PARTICIPATING_HARTIDS; ++hartid) {
+            if (dfb->risc_mask & (1u << hartid)) {
+                ghdr.participation_mask[hartid] |= (1u << dfb->id);
+            }
+        }
+    }
+    const uint32_t expected_id_mask =
+        ghdr.num_dfbs >= 32 ? ~0u : ((1u << ghdr.num_dfbs) - 1u);
+    TT_FATAL(
+        id_mask == expected_id_mask,
+        "DFB ids must be contiguous 0..{}-1 (id_mask=0x{:x})",
+        ghdr.num_dfbs,
+        id_mask);
+}
+
+void verify_dfb_hart_blobs(
+    std::span<const uint8_t> config_bytes, const std::vector<std::shared_ptr<DataflowBufferImpl>>& dfbs_on_core) {
+    (void)dfbs_on_core;
+    TT_FATAL(config_bytes.size() >= sizeof(dfb_global_header_t), "DFB config too small for hart blob verify");
+    const auto* ghdr = reinterpret_cast<const dfb_global_header_t*>(config_bytes.data());
+
+    for (uint8_t hartid = 0; hartid < ::dfb::NUM_PARTICIPATING_HARTIDS; ++hartid) {
+        const uint32_t blob_off = ghdr->hart_blob_offset[hartid];
+        const uint8_t num_entries = dfb_hart_participation_count(ghdr->participation_mask[hartid]);
+        TT_FATAL(
+            blob_off <= config_bytes.size(),
+            "hart_blob_offset[{}]={} out of range (config size {})",
+            hartid, blob_off, config_bytes.size());
+        const uint32_t blob_end = (hartid + 1u < ::dfb::NUM_PARTICIPATING_HARTIDS) ? ghdr->hart_blob_offset[hartid + 1u]
+                                                                                   : ghdr->dfb_signal_region_off;
+        TT_FATAL(
+            blob_off <= blob_end && blob_end <= config_bytes.size(),
+            "hart {} blob [{}, {}) is not an ascending in-range extent (config size {}); DM init derives "
+            "its invalidate range from consecutive hart_blob_offset entries",
+            hartid,
+            blob_off,
+            blob_end,
+            config_bytes.size());
+
+        if (num_entries == 0) {
+            TT_FATAL(
+                blob_off + 4u <= config_bytes.size(),
+                "hart {} minimal blob overflows config",
+                hartid);
+            continue;
+        }
+
+        TT_FATAL(
+            blob_off % 4u == 0u,
+            "hart {} blob offset {} is not 4B-aligned",
+            hartid,
+            blob_off);
+
+        const uint8_t* blob = config_bytes.data() + blob_off;
+
+        // Walk init entries and verify they are self-consistent with DFB data.
+        uint32_t cursor = 0u;
+        for (uint8_t e = 0; e < num_entries; e++) {
+            TT_FATAL(
+                blob_off + cursor + sizeof(dfb_hart_init_entry_t) <= config_bytes.size(),
+                "hart {} init entry {} header overflows config", hartid, e);
+            const auto* entry = reinterpret_cast<const dfb_hart_init_entry_t*>(blob + cursor);
+            const uint32_t entry_sz = dfb_hart_init_entry_byte_size(entry->num_tcs);
+            TT_FATAL(
+                blob_off + cursor + entry_sz <= config_bytes.size(),
+                "hart {} init entry {} (num_tcs={}) TC arrays overflow config", hartid, e, entry->num_tcs);
+            TT_FATAL(
+                entry->logical_dfb_id < ghdr->num_dfbs,
+                "hart {} init entry {} logical_dfb_id={} >= num_dfbs={}",
+                hartid, e, entry->logical_dfb_id, ghdr->num_dfbs);
+            TT_FATAL(
+                (ghdr->participation_mask[hartid] & (1u << entry->logical_dfb_id)) != 0,
+                "hart {} init entry {} logical_dfb_id={} not in participation_mask=0x{:x}",
+                hartid, e, entry->logical_dfb_id, ghdr->participation_mask[hartid]);
+            cursor += entry_sz;
+        }
+        TT_FATAL(
+            blob_off + cursor <= blob_end,
+            "hart {} entries span {} bytes but its blob extent is [{}, {}); DM init would invalidate less "
+            "than it walks",
+            hartid,
+            cursor,
+            blob_off,
+            blob_end);
+    }
+}
+
+void verify_dfb_global_header_participation(
+    const dfb_global_header_t& ghdr, const std::vector<std::shared_ptr<DataflowBufferImpl>>& dfbs_on_core) {
+    const uint32_t valid_dfb_mask =
+        ghdr.num_dfbs >= 32 ? ~0u : ((1u << ghdr.num_dfbs) - 1u);
+    for (uint8_t hartid = 0; hartid < ::dfb::NUM_PARTICIPATING_HARTIDS; ++hartid) {
+        uint32_t expected = 0;
+        for (const auto& dfb : dfbs_on_core) {
+            if (dfb->risc_mask & (1u << hartid)) {
+                expected |= (1u << dfb->id);
+            }
+        }
+        TT_FATAL(
+            ghdr.participation_mask[hartid] == expected,
+            "participation_mask[{}]=0x{:x} != expected 0x{:x} from risc_mask",
+            hartid,
+            ghdr.participation_mask[hartid],
+            expected);
+        TT_FATAL(
+            (ghdr.participation_mask[hartid] & ~valid_dfb_mask) == 0,
+            "participation_mask[{}]=0x{:x} has bits >= num_dfbs {}",
+            hartid,
+            ghdr.participation_mask[hartid],
+            ghdr.num_dfbs);
+    }
+}
+
+size_t serialize_dfb_config_for_core(
+    const CoreCoord& core,
+    const std::vector<std::shared_ptr<DataflowBufferImpl>>& dfbs_on_core,
+    std::span<uint8_t> out) {
+    if (dfbs_on_core.empty()) { return 0; }
+    const auto& hal = MetalContext::instance().hal();
+    TT_FATAL(hal.has_tile_counter_registers(), "serialize_dfb_config_for_core requires Quasar");
+
+    // ---------------------------------------------------------------------------
+    // 1. Collect per-core risc configs for every DFB (base/limit resolved per core).
+    //    Assign producer_signal_bit: per-producer bit position in dfb_signal[logical_dfb_id].
+    // ---------------------------------------------------------------------------
+    // per_core_configs[dfb_idx] = per-risc configs with base_addr/limit resolved.
+    std::vector<std::vector<DFBRiscConfig>> per_core_configs;
+    per_core_configs.reserve(dfbs_on_core.size());
+    for (const auto& dfb : dfbs_on_core) {
+        per_core_configs.push_back(dfb->compute_per_core_risc_configs(core));
+    }
+
+    // producer_signal_bit[dfb_idx][hart] = bit position (0-based) in dfb_signal[logical_dfb_id]; 0xFF if consumer.
+    // dfb_expected_signal_vals[logical_dfb_id] = OR of all producer bits for that DFB.
+    // Every producer gets a unique bit; consumers wait for the full bitmask.
+    std::vector<std::array<uint8_t, ::dfb::NUM_PARTICIPATING_HARTIDS>> producer_signal_bit(dfbs_on_core.size());
+    for (auto& arr : producer_signal_bit) { arr.fill(0xFFu); }
+    std::array<uint32_t, ::dfb::NUM_DFBS> dfb_expected_signal_vals{};
+    dfb_expected_signal_vals.fill(0u);
+    std::array<uint8_t, ::dfb::NUM_DFBS> next_producer_bit{};
+    next_producer_bit.fill(0u);
+    for (size_t di = 0; di < dfbs_on_core.size(); di++) {
+        const auto& dfb = dfbs_on_core[di];
+        const uint8_t logical_dfb_id = static_cast<uint8_t>(dfb->id);
+        for (uint8_t h = 0; h < ::dfb::NUM_PARTICIPATING_HARTIDS; h++) {
+            if (!(dfb->risc_mask & (1u << h))) { continue; }
+            const auto& rcs = per_core_configs[di];
+            for (const auto& rc : rcs) {
+                if (rc.risc_id == h && rc.is_producer) {
+                    const uint8_t bit = next_producer_bit[logical_dfb_id]++;
+                    TT_FATAL(
+                        bit < ::dfb::MAX_PRODUCERS_PER_DFB,
+                        "DFB {}: producer signal bit {} exceeds MAX_PRODUCERS_PER_DFB {} "
+                        "(signal region stride; DM0/DM1 reserved)",
+                        dfb->id,
+                        bit,
+                        ::dfb::MAX_PRODUCERS_PER_DFB);
+                    producer_signal_bit[di][h] = bit;
+                    dfb_expected_signal_vals[logical_dfb_id] |= (1u << bit);
+                    break;
+                }
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // 2. Build the header (all offsets computed after blob sizes are known).
+    // ---------------------------------------------------------------------------
+    dfb_global_header_t ghdr = {};
+    populate_dfb_global_header_participation(ghdr, dfbs_on_core);
+    verify_dfb_global_header_participation(ghdr, dfbs_on_core);
+
+    // has_dm0_isr: any DFB with implicit-sync txns?
+    ghdr.has_dm0_isr = (dm0_isr_blob_region_size(dfbs_on_core) > 0) ? 1u : 0u;
+    ghdr.dm0_isr_ready = 0;
+
+    const uint32_t header_size = dfb_config_header_size();  // 96B
+    const uint32_t total_dm1_blob_size = dm1_remapper_blob_core_size(dfbs_on_core);
+    const uint32_t total_dm0_isr_blob_size = dm0_isr_blob_region_size(dfbs_on_core);
+
+    ghdr.dm1_remapper_blob_offset = header_size;
+    ghdr.dm0_isr_blob_offset      = ghdr.dm1_remapper_blob_offset + total_dm1_blob_size;
+    const uint32_t hart_blobs_base = ghdr.dm0_isr_blob_offset + total_dm0_isr_blob_size;
+
+    // Pre-compute per-hart blob sizes to fill hart_blob_offset[].
+    std::array<uint32_t, ::dfb::NUM_PARTICIPATING_HARTIDS> hart_blob_sizes{};
+    uint32_t running = hart_blobs_base;
+    for (uint8_t h = 0; h < ::dfb::NUM_PARTICIPATING_HARTIDS; h++) {
+        uint32_t sz = hart_blob_byte_size(h, dfbs_on_core);
+        ghdr.hart_blob_offset[h] = static_cast<uint16_t>(running);
+        hart_blob_sizes[h] = sz;
+        running += sz;
+    }
+    ghdr.dfb_signal_region_off = running;
+
+    // ---------------------------------------------------------------------------
+    // 3. Emit header.
+    // ---------------------------------------------------------------------------
+    uint32_t offset = 0;
+    TT_FATAL(out.size() >= header_size, "DFB config buffer too small for header");
+    std::memcpy(out.data(), &ghdr, sizeof(ghdr));
+    offset = header_size;
+
+    // ---------------------------------------------------------------------------
+    // 4. Emit DM1 remapper blob (core-wide flat layout).
+    // ---------------------------------------------------------------------------
+    {
+        auto blob = serialize_dm1_remapper_core_blob(core, dfbs_on_core);
+        TT_FATAL(offset + blob.size() <= out.size(), "DFB config overflow (DM1 blob)");
+        std::memcpy(out.data() + offset, blob.data(), blob.size());
+        offset += static_cast<uint32_t>(blob.size());
+    }
+
+    // ---------------------------------------------------------------------------
+    // 5. Emit DM0 ISR blob (unchanged).
+    // ---------------------------------------------------------------------------
+    if (total_dm0_isr_blob_size > 0) {
+        const auto [producer_mask, consumer_mask] = compute_dm0_isr_blob_core_masks(dfbs_on_core);
+        dfb_dm0_isr_blob_core_header_t core_hdr = {
+            .producer_txn_id_mask = producer_mask,
+            .consumer_txn_id_mask = consumer_mask,
+        };
+        TT_FATAL(offset + sizeof(core_hdr) <= out.size(), "DFB config overflow (DM0 ISR core hdr)");
+        std::memcpy(out.data() + offset, &core_hdr, sizeof(core_hdr));
+        offset += sizeof(core_hdr);
+
+        auto txn_hw_pool = serialize_dm0_isr_txn_hw_pool_for_core(dfbs_on_core, producer_mask, consumer_mask);
+        if (!txn_hw_pool.empty()) {
+            TT_FATAL(offset + txn_hw_pool.size() <= out.size(), "DFB config overflow (DM0 txn hw pool)");
+            std::memcpy(out.data() + offset, txn_hw_pool.data(), txn_hw_pool.size());
+            offset += static_cast<uint32_t>(txn_hw_pool.size());
+        }
+
+        auto desc_pool = serialize_dm0_isr_txn_desc_pool_for_core(core, dfbs_on_core, producer_mask, consumer_mask);
+        if (!desc_pool.empty()) {
+            TT_FATAL(offset + desc_pool.size() <= out.size(), "DFB config overflow (DM0 txn desc pool)");
+            std::memcpy(out.data() + offset, desc_pool.data(), desc_pool.size());
+            offset += static_cast<uint32_t>(desc_pool.size());
+        }
+    }
+    TT_FATAL(
+        offset == hart_blobs_base,
+        "DFB config: offset {} != hart_blobs_base {} after DM0/DM1 blobs", offset, hart_blobs_base);
+
+    // ---------------------------------------------------------------------------
+    // 6. Emit per-hart sequential init blobs (init entries only; no wait entries).
+    //    Layout of each blob:
+    //      [dfb_hart_init_entry_t × num_entries] (variable, 4B-aligned each)
+    //      (4B-padded end)
+    //    num_entries = popcount(participation_mask[h]); not stored in the blob.
+    // ---------------------------------------------------------------------------
+    for (uint8_t h = 0; h < ::dfb::NUM_PARTICIPATING_HARTIDS; h++) {
+        const uint32_t blob_start = offset;
+        TT_FATAL(
+            static_cast<uint16_t>(blob_start) == ghdr.hart_blob_offset[h],
+            "hart {} blob offset mismatch: offset {} vs header {}", h, blob_start, ghdr.hart_blob_offset[h]);
+
+        // Count participating DFBs for this hart.
+        uint8_t num_entries = 0;
+        for (const auto& dfb : dfbs_on_core) {
+            if (dfb->risc_mask & (1u << h)) {
+                num_entries++;
+            }
+        }
+
+        if (num_entries == 0) {
+            // Minimal 4-byte blob: {0, 0, 0, 0}
+            TT_FATAL(offset + 4u <= out.size(), "DFB config overflow (minimal hart blob h={})", h);
+            std::memset(out.data() + offset, 0, 4u);
+            offset += 4u;
+            continue;
+        }
+
+        TT_FATAL(
+            blob_start % 4u == 0u,
+            "hart {} blob offset {} is not 4B-aligned",
+            h,
+            blob_start);
+
+        // Init entries: one per participating DFB, variable size.
+        for (size_t di = 0; di < dfbs_on_core.size(); di++) {
+            const auto& dfb = dfbs_on_core[di];
+            if (!(dfb->risc_mask & (1u << h))) {
+                continue;
+            }
+            const auto& rcs = per_core_configs[di];
+            const DFBRiscConfig* rc_ptr = nullptr;
+            for (const auto& rc : rcs) {
+                if (rc.risc_id == h) { rc_ptr = &rc; break; }
+            }
+            TT_FATAL(rc_ptr != nullptr,
+                "DFB {}: no risc_config for hart {} on core ({},{})", dfb->id, h, core.x, core.y);
+            const DFBRiscConfig& rc = *rc_ptr;
+            const uint8_t num_tcs = rc.config.num_tcs_to_rr;
+            const uint32_t entry_sz = dfb_hart_init_entry_byte_size(num_tcs);
+            TT_FATAL(offset + entry_sz <= out.size(),
+                "DFB config overflow (init entry dfb={} hart={})", dfb->id, h);
+
+            // Header (28B fixed).
+            dfb_hart_init_entry_t entry = {};
+            entry.logical_dfb_id = static_cast<uint8_t>(dfb->id);
+            entry.num_tcs        = num_tcs;
+            entry.capacity       = rc.is_producer ? static_cast<uint8_t>(dfb->capacity) : 0u;
+            entry.entry_size = dfb->config.entry_size;
+            entry.num_entries = static_cast<uint16_t>(dfb->config.num_entries);
+            // Precompute hart-type-specific stride_size so device can copy it directly:
+            //   DM harts   (h < TENSIX_RISC_OFFSET): stride_size = entry_size_raw * stride_in_entries
+            //   TRISC harts (h >= TENSIX_RISC_OFFSET): stride_size = (entry_size_raw >> 4) * stride_in_entries
+            // kTRISCCbAddrShift == 4 matches the cb_addr_shift constant in dataflow_buffer_init.h.
+            constexpr uint32_t kTRISCCbAddrShift = 4u;
+            if (h < ::dfb::TENSIX_RISC_OFFSET) {
+                entry.stride_size_precomp = dfb->config.entry_size * dfb->stride_in_entries;
+            } else {
+                entry.stride_size_precomp = (dfb->config.entry_size >> kTRISCCbAddrShift) * dfb->stride_in_entries;
+            }
+            entry.stride_size_tiles = static_cast<uint8_t>(dfb->stride_in_entries);
+
+            uint8_t flags = 0;
+            // Every producer initializes its own TCs and publishes a readiness signal bit.
+            if (rc.is_producer) {
+                flags |= DFB_HART_FLAG_IS_PRODUCER;
+            }
+            if (dfb->use_remapper) {
+                flags |= DFB_HART_FLAG_REMAPPER_EN;
+            }
+            if (rc.config.broadcast_tc) {
+                flags |= DFB_HART_FLAG_BROADCAST_TC;
+            }
+            flags |= static_cast<uint8_t>(dfb->tensix_trisc_mask & DFB_HART_FLAG_TRISC_MASK);
+            entry.flags = flags;
+
+            // Txn descriptor (DM harts 0-7 only; TRISC leaves zero).
+            if (h < ::dfb::TENSIX_RISC_OFFSET) {
+                const dfb_txn_id_descriptor_t& txn =
+                    rc.is_producer ? dfb->producer_txn_descriptor : dfb->consumer_txn_descriptor;
+                entry.num_txn_ids               = txn.num_txn_ids;
+                entry.threshold                 = txn.num_entries_to_process_threshold;
+                entry.num_entries_per_txn_id    = txn.num_entries_per_txn_id;
+                entry.num_entries_per_txn_id_per_tc = txn.num_entries_per_txn_id_per_tc;
+                for (uint8_t t = 0; t < txn.num_txn_ids && t < ::dfb::NUM_TXN_IDS; t++) {
+                    entry.txn_ids[t] = txn.txn_ids[t];
+                }
+            }
+            entry.producer_signal_bit = producer_signal_bit[di][h];
+            entry.remapper_pair_index = (dfb->use_remapper && rc.is_producer)
+                ? rc.config.remapper_pair_index
+                : 0xFFu;
+
+            // Zero the full entry region first (covers padding between packed_tc and next 4B boundary).
+            std::memset(out.data() + offset, 0, entry_sz);
+
+            // Write fixed header.
+            std::memcpy(out.data() + offset, &entry, sizeof(entry));
+
+            // DM harts: mirror bytes [12,24) in LocalDFBInterface DTCM order so
+            // dfb_unpack_entry_header_dm stays consistent with on-disk layout.
+            if (h < ::dfb::TENSIX_RISC_OFFSET) {
+                dfb_write_dm_scalar_pack_to_blob(
+                    out.data() + offset,
+                    num_tcs,
+                    producer_signal_bit[di][h],
+                    entry.txn_ids,
+                    entry.threshold,
+                    entry.num_entries_per_txn_id,
+                    entry.num_entries_per_txn_id_per_tc,
+                    entry.num_txn_ids,
+                    static_cast<uint8_t>((flags & DFB_HART_FLAG_BROADCAST_TC) ? 1u : 0u),
+                    entry.remapper_pair_index);
+            }
+
+            // Write AoP TC tail: dfb_blob_tc_pair_t[num_tcs] immediately after the 28B header,
+            // followed by uint8_t packed_tile_counter[num_tcs] padded to 4B.
+            // Each pair is {base_addr(4B), limit(4B)} = 8B; ptc bytes are packed contiguously.
+            // Total TC section = (num_tcs*9 + 3) & ~3 — identical to original SoA byte count.
+            // Device reads: running pair pointer (8B stride, base+limit adjacent per slot) +
+            // two preloaded ptc words covering all TCs before the loop (zero in-loop memory traffic).
+            uint32_t tc_pairs_off = offset + static_cast<uint32_t>(sizeof(entry));
+            for (uint8_t t = 0; t < num_tcs; t++) {
+                dfb_blob_tc_pair_t pair = {};
+                if (h >= ::dfb::TENSIX_RISC_OFFSET) {
+                    pair.base_addr = rc.config.base_addr[t] >> kTRISCCbAddrShift;
+                    pair.limit     = rc.config.limit[t] >> kTRISCCbAddrShift;
+                } else {
+                    pair.base_addr = rc.config.base_addr[t];
+                    pair.limit     = rc.config.limit[t];
+                }
+                std::memcpy(out.data() + tc_pairs_off, &pair, sizeof(pair));
+                tc_pairs_off += static_cast<uint32_t>(sizeof(pair));
+            }
+            // ptc bytes follow all pairs (region already zero-initialised by memset above).
+            for (uint8_t t = 0; t < num_tcs; t++) {
+                out[tc_pairs_off + t] = rc.config.packed_tile_counter[t];
+            }
+
+            offset += entry_sz;
+        }
+
+        // Pad blob to 4B boundary.
+        const uint32_t blob_end_padded = (offset + 3u) & ~3u;
+        if (blob_end_padded > offset) {
+            std::memset(out.data() + offset, 0, blob_end_padded - offset);
+            offset = blob_end_padded;
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // 7. Emit signal region:
+    //    [dfb_signal[NUM_DFBS * MAX_PRODUCERS_PER_DFB]] (byte slots, zeroed)
+    //    [dfb_expected_signal[NUM_DFBS]] (uint32_t bitmasks, host-computed)
+    //
+    //    Producer i of DFB d writes byte 1 to slot [d * MAX_PRODUCERS_PER_DFB + i] at runtime.
+    //    Consumer polls each set bit in dfb_expected_signal[d].
+    // ---------------------------------------------------------------------------
+    TT_FATAL(
+        offset == ghdr.dfb_signal_region_off,
+        "DFB config: offset {} != dfb_signal_region_off {}", offset, ghdr.dfb_signal_region_off);
+    {
+        constexpr uint32_t kMaxProd = static_cast<uint32_t>(::dfb::MAX_PRODUCERS_PER_DFB);
+        constexpr uint32_t kSlotBytes = static_cast<uint32_t>(::dfb::NUM_DFBS) * kMaxProd;
+        constexpr uint32_t kExpectedBytes = static_cast<uint32_t>(::dfb::NUM_DFBS) * sizeof(uint32_t);
+        TT_FATAL(offset + kSlotBytes + kExpectedBytes <= out.size(), "DFB config overflow (signal region)");
+        // Per-producer byte slots — zeroed; each producer writes 1 via uncached alias at runtime.
+        std::memset(out.data() + offset, 0, kSlotBytes);
+        offset += kSlotBytes;
+        // dfb_expected_signal[NUM_DFBS] — host-computed bitmask of active producer bits per DFB.
+        for (uint32_t i = 0; i < static_cast<uint32_t>(::dfb::NUM_DFBS); i++) {
+            std::memcpy(out.data() + offset, &dfb_expected_signal_vals[i], sizeof(uint32_t));
+            offset += sizeof(uint32_t);
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // 8. Verify and pad to transfer alignment.
+    // ---------------------------------------------------------------------------
+    verify_dfb_hart_blobs(std::span<const uint8_t>(out.data(), offset), dfbs_on_core);
+
+    const uint32_t aligned_size = align_dfb_config_transfer_size(offset);
+    TT_FATAL(out.size() >= aligned_size, "DFB config buffer too small for aligned payload");
+    if (aligned_size > offset) { std::memset(out.data() + offset, 0, aligned_size - offset); }
+    return aligned_size;
+}
+
+}  // namespace tt::tt_metal::experimental::dfb::detail
 
 namespace tt::tt_metal::experimental::dfb {
 
@@ -58,8 +767,9 @@ void BindDataflowBufferToProducerConsumerKernels(Program& program, uint32_t dfb_
             static_cast<uint16_t>(((1u << dfb->config.num_producers) - 1u) << ::dfb::TENSIX_RISC_OFFSET);
     } else if (auto dm_producer = std::dynamic_pointer_cast<experimental::quasar::QuasarDataMovementKernel>(producer_kernel)) {
         TT_FATAL(
-            dfb->config.num_producers >= 1 && dfb->config.num_producers <= 8,
-            "DM producer count must be between 1 and 8, got {}",
+            dfb->config.num_producers >= 1 && dfb->config.num_producers <= ::dfb::MAX_PRODUCERS_PER_DFB,
+            "DM producer count must be between 1 and {} (DM0/DM1 reserved; signal region stride), got {}",
+            ::dfb::MAX_PRODUCERS_PER_DFB,
             dfb->config.num_producers);
         const auto& producer_dm_riscvs = dm_producer->get_dm_processors();
         for (DataMovementProcessor dm : producer_dm_riscvs) {
@@ -86,8 +796,9 @@ void BindDataflowBufferToProducerConsumerKernels(Program& program, uint32_t dfb_
             static_cast<uint16_t>(((1u << dfb->config.num_consumers) - 1u) << ::dfb::TENSIX_RISC_OFFSET);
     } else if (auto dm_consumer = std::dynamic_pointer_cast<experimental::quasar::QuasarDataMovementKernel>(consumer_kernel)) {
         TT_FATAL(
-            dfb->config.num_consumers >= 1 && dfb->config.num_consumers <= 8,
-            "DM consumer count must be between 1 and 8, got {}",
+            dfb->config.num_consumers >= 1 && dfb->config.num_consumers <= ::dfb::MAX_PRODUCERS_PER_DFB,
+            "DM consumer count must be between 1 and {} (DM0/DM1 reserved), got {}",
+            ::dfb::MAX_PRODUCERS_PER_DFB,
             dfb->config.num_consumers);
         const auto& consumer_dm_riscvs = dm_consumer->get_dm_processors();
         for (DataMovementProcessor dm : consumer_dm_riscvs) {
@@ -285,85 +996,6 @@ bool has_dm_risc(uint16_t risc_mask) { return (risc_mask & 0xFF) != 0; }
 
 bool has_tensix_risc(uint16_t risc_mask) { return (risc_mask & 0x0F00) != 0; }
 
-uint8_t calculate_num_tile_counters(const DataflowBufferConfig& config, bool is_producer) {
-    if (config.cap == ::dfb::AccessPattern::ALL) {
-        bool producer_has_dm = has_dm_risc(config.producer_risc_mask);
-        bool consumer_has_dm = has_dm_risc(config.consumer_risc_mask);
-        bool producer_is_tensix_only = !producer_has_dm && has_tensix_risc(config.producer_risc_mask);
-        bool consumer_is_tensix_only = !consumer_has_dm && has_tensix_risc(config.consumer_risc_mask);
-        bool dm_dm_all = !producer_is_tensix_only && !consumer_is_tensix_only;
-        if (is_producer) {
-            if (dm_dm_all) {
-                return config.num_consumers;
-            }
-            return 1;
-        }
-        return config.num_producers;
-    }
-    // Strided mode:
-    // Producer: num_consumers / num_producers (number of consumers each producer is paired with)
-    // Consumer: num_producers / num_consumers (number of producers each consumer is paired with)
-    // When the ratio is < 1, use 1 (each pairs with exactly one of the other)
-    if (is_producer) {
-        if (config.num_consumers >= config.num_producers) {
-            TT_FATAL(
-                config.num_consumers % config.num_producers == 0,
-                "num_consumers {} must be divisible by num_producers {} for strided producer",
-                config.num_consumers,
-                config.num_producers);
-            return config.num_consumers / config.num_producers;
-        }
-        // More producers than consumers: each producer pairs with 1 consumer
-        return 1;
-    }
-
-    if (config.num_producers >= config.num_consumers) {
-        TT_FATAL(
-            config.num_producers % config.num_consumers == 0,
-            "num_producers {} must be divisible by num_consumers {} for strided consumer",
-            config.num_producers,
-            config.num_consumers);
-        return config.num_producers / config.num_consumers;
-    }
-    // More consumers than producers: each consumer pairs with 1 producer
-    return 1;
-}
-
-// Extract tensix IDs from risc_mask (bits 8-11)
-// Returns vector of tensix_ids (0-3) that are being used
-std::vector<uint8_t> extract_tensix_ids(uint16_t risc_mask) {
-    std::vector<uint8_t> tensix_ids;
-    uint16_t tensix_mask = (risc_mask >> 8) & 0x0F;  // bits 8-11
-    for (uint8_t i = 0; i < ::dfb::NUM_TENSIX; i++) {
-        if (tensix_mask & (1 << i)) {
-            tensix_ids.push_back(i);
-        }
-    }
-    return tensix_ids;
-}
-
-// Get tensix_id for allocation when only DM RISCs are used
-// Round-robins through 0-3 based on pair index
-uint8_t get_dm_tensix_id_for_pair(uint8_t pair_index) { return pair_index % 4; }
-
-// Holds tile counters allocated together for a producer-consumer group
-struct TileCounterGroup {
-    ::dfb::PackedTileCounter producer_tc{};
-    std::vector<::dfb::PackedTileCounter> consumer_tcs;
-};
-
-uint32_t DataflowBufferImpl::serialized_size() const {
-    // On WH/BH: one 4-word CB-format config entry per DFB (identical to a circular buffer config)
-    if (!MetalContext::instance().hal().has_tile_counter_registers()) {
-        return 4 * sizeof(uint32_t);
-    }
-    // On Quasar: one dfb_initializer_t + one dfb_initializer_per_risc_t per risc.
-    // All groups have the same number of RISC configs
-    TT_FATAL(!groups.empty(), "DFB {} has no groups (configs not finalized?)", id);
-    return sizeof(dfb_initializer_t) +
-           (groups[0].hw_risc_configs.size() * sizeof(dfb_initializer_per_risc_t));
-}
-
 static std::pair<uint8_t, uint8_t> get_tc_counts(const DfbGroup& group) {
     uint8_t num_producer_tcs = 0;
     uint8_t num_consumer_tcs = 0;
@@ -377,236 +1009,6 @@ static std::pair<uint8_t, uint8_t> get_tc_counts(const DfbGroup& group) {
     return {num_producer_tcs, num_consumer_tcs};
 }
 
-std::vector<uint8_t> DataflowBufferImpl::serialize_for_core(const CoreCoord& core) const {
-    TT_FATAL(this->configs_finalized, "DFB {} configs not finalized before serialization", this->id);
-
-    // On WH/BH: emit the same 4-word format used for circular buffers so the existing
-    // setup_local_cb_read_write_interfaces firmware path can initialise the DFB slot.
-    // Layout: [base_addr, total_size_bytes, num_pages, page_size_bytes]
-    if (!MetalContext::instance().hal().has_tile_counter_registers()) {
-        auto it = this->core_lookup_.find(core);
-        TT_FATAL(
-            it != this->core_lookup_.end(), "DFB {} has no config for core ({}, {})", this->id, core.x, core.y);
-        const uint32_t alloc_addr = it->second.second;
-        TT_FATAL(
-            !this->borrows_memory() || alloc_addr != 0,
-            "DFB {} uses borrowed memory but set_borrowed_memory_base_addr() was not called before serialization",
-            this->id);
-
-        std::vector<uint8_t> data;
-        data.reserve(4 * sizeof(uint32_t));
-        const uint32_t words[4] = {
-            alloc_addr,                                     // fifo_addr (base)
-            this->config.entry_size * this->config.num_entries,  // fifo_size
-            this->config.num_entries,                       // fifo_num_pages
-            this->config.entry_size,                        // fifo_page_size
-        };
-        const auto* bytes = reinterpret_cast<const uint8_t*>(words);
-        data.insert(data.end(), bytes, bytes + sizeof(words));
-        return data;
-    }
-
-    auto it = this->core_lookup_.find(core);
-    TT_FATAL(it != this->core_lookup_.end(), "DFB {} has no config for core ({}, {})", this->id, core.x, core.y);
-    const auto& [group_idx, alloc_addr] = it->second;
-    TT_FATAL(
-        !this->borrows_memory() || alloc_addr != 0,
-        "DFB {} uses borrowed memory but set_borrowed_memory_base_addr() was not called before serialization",
-        this->id);
-    const DfbGroup* core_group = &this->groups[group_idx];
-
-    const auto& hw_risc_configs = core_group->hw_risc_configs;
-
-    std::vector<uint8_t> data;
-    data.reserve(serialized_size());
-
-    dfb_initializer_t init = {};
-    init.logical_id = this->id;
-    init.entry_size = this->config.entry_size;
-    init.stride_in_entries = this->stride_in_entries;
-    init.capacity = this->capacity;
-    init.risc_mask_bits.dm_mask = this->risc_mask & 0xFF;
-    init.risc_mask_bits.tensix_mask = (this->risc_mask >> 8) & 0x0F;
-    init.risc_mask_bits.tensix_trisc_mask = this->tensix_trisc_mask & 0x0F;
-    init.num_producers = this->config.num_producers;
-    init.producer_txn_descriptor = this->producer_txn_descriptor;
-    init.consumer_txn_descriptor = this->consumer_txn_descriptor;
-    init.implicit_sync_configured = 0;
-    TT_FATAL(
-        this->config.num_entries <= std::numeric_limits<uint16_t>::max(),
-        "DFB {}: num_entries ({}) exceeds the maximum {} representable on device",
-        this->id,
-        this->config.num_entries,
-        std::numeric_limits<uint16_t>::max());
-    init.num_entries = static_cast<uint16_t>(this->config.num_entries);
-
-    log_debug(
-        tt::LogMetal,
-        "Serializing DFB {} for core ({},{}) with {} producers and {} consumers. risc_mask: 0x{:x} use_remapper: {}",
-        this->id,
-        core.x,
-        core.y,
-        this->config.num_producers,
-        this->config.num_consumers,
-        this->risc_mask,
-        this->use_remapper);
-
-    log_debug(tt::LogMetal, "Entry size: {}", this->config.entry_size);
-    log_debug(tt::LogMetal, "Stride in entries: {}", this->stride_in_entries);
-    log_debug(tt::LogMetal, "Capacity: {}", this->capacity);
-    log_debug(tt::LogMetal, "Risc mask: 0x{:x}", this->risc_mask);
-    log_debug(tt::LogMetal, "Producer txn descriptor: num_txn_ids={} threshold={} per_txn={} per_tc={}",
-        this->producer_txn_descriptor.num_txn_ids,
-        this->producer_txn_descriptor.num_entries_to_process_threshold,
-        this->producer_txn_descriptor.num_entries_per_txn_id,
-        this->producer_txn_descriptor.num_entries_per_txn_id_per_tc);
-    log_debug(tt::LogMetal, "Consumer txn descriptor: num_txn_ids={} threshold={} per_txn={} per_tc={}",
-        this->consumer_txn_descriptor.num_txn_ids,
-        this->consumer_txn_descriptor.num_entries_to_process_threshold,
-        this->consumer_txn_descriptor.num_entries_per_txn_id,
-        this->consumer_txn_descriptor.num_entries_per_txn_id_per_tc);
-
-    const auto* init_bytes = reinterpret_cast<const uint8_t*>(&init);
-    data.insert(data.end(), init_bytes, init_bytes + sizeof(init));
-
-    const uint32_t entry_size = this->config.entry_size;
-    // const uint32_t max_prod_cons = std::max(this->config.num_producers, this->config.num_consumers);
-
-    // num_producer_tcs / num_consumer_tcs derived from this core's finalized HW config.
-    const auto [num_producer_tcs, num_consumer_tcs] = get_tc_counts(*core_group);
-
-    // Address arithmetic for L1 base/limit/step:
-    //   - STRIDED (stride_in_entries = max_prod_cons): interleaved layout.
-    //     Each producer occupies 1 slot per round → base step = entry_size.
-    //   - ALL (stride_in_entries = 1): contiguous block per producer/TC.
-    //     Each producer occupies `capacity` consecutive slots → base step = capacity * entry_size.
-    //     This applies to both DM-DM ALL (broadcast_tc) and Tensix-involved ALL (remapper).
-    //     The hardware derives the per-pop stride from (limit - base - entry_size) / (capacity - 1),
-    //     which equals entry_size for ALL and max_prod_cons * entry_size for STRIDED.
-    const uint32_t effective_stride = this->stride_in_entries;
-    const uint32_t base_step = (effective_stride > 1) ? entry_size : (this->capacity * entry_size);
-
-    std::vector<DFBRiscConfig> per_core_rc = hw_risc_configs;
-    uint32_t base = alloc_addr;
-    for (uint8_t tc = 0; tc < num_producer_tcs; tc++) {
-        for (auto& rc : per_core_rc) {
-            if (rc.is_producer && tc < rc.config.num_tcs_to_rr) {
-                rc.config.base_addr[tc] = base;
-                rc.config.limit[tc] =
-                    rc.config.base_addr[tc] + ((entry_size * effective_stride) * (this->capacity - 1)) + entry_size;
-                // Always advance base so each producer/TC gets its own L1 slot range.
-                // broadcast_tc only governs device-side credit posting, not L1 addressing.
-                base += base_step;
-            }
-        }
-    }
-    base = alloc_addr;
-    for (uint8_t tc = 0; tc < num_consumer_tcs; tc++) {
-        for (auto& rc : per_core_rc) {
-            if (rc.is_producer) {
-                continue;
-            }
-            rc.config.base_addr[tc] = base;
-            rc.config.limit[tc] =
-                rc.config.base_addr[tc] + ((entry_size * effective_stride) * (this->capacity - 1)) + entry_size;
-            // In strided case each consumer maps to a different producer region, so advance base per consumer.
-            if (this->config.cap == dfb::AccessPattern::STRIDED && tc < rc.config.num_tcs_to_rr) {
-                base += base_step;
-            }
-        }
-        // In ALL case all consumers share the producer address regions as they see every producer's data.
-        if (this->config.cap == dfb::AccessPattern::ALL && this->config.num_producers > 1 &&
-            tc < num_consumer_tcs) {
-            base += base_step;
-        }
-    }
-
-    // Mirrors the device's per-side tile-counter staging, which sums num_tcs_to_rr across that
-    // side's riscs in risc_mask order before copying the ids into a TxnDFBDescriptor.
-    uint32_t total_producer_tcs = 0;
-    uint32_t total_consumer_tcs = 0;
-    // Write one dfb_initializer_per_risc_t per risc, in risc_mask order
-    for (int bit = 0; bit < 16; bit++) {
-        if (!(this->risc_mask & (1 << bit))) {
-            continue;
-        }
-        const DFBRiscConfig* rc = nullptr;
-        for (const auto& c : per_core_rc) {
-            if (c.risc_id == static_cast<uint8_t>(bit)) {
-                rc = &c;
-                break;
-            }
-        }
-        TT_FATAL(rc != nullptr, "DFB {}: no risc_config for risc_id {} on core ({},{})", this->id, bit, core.x, core.y);
-
-        log_debug(tt::LogMetal, "New risc config (risc_id={}, is_producer={})", rc->risc_id, rc->is_producer);
-        dfb_initializer_per_risc_t per_risc = {};
-
-        per_risc.num_tcs_and_init.num_tcs_to_rr = rc->config.num_tcs_to_rr;
-        (rc->is_producer ? total_producer_tcs : total_consumer_tcs) += rc->config.num_tcs_to_rr;
-        per_risc.num_tcs_and_init.tc_init_done = 0;  // set by device when this producer finishes TC init
-        per_risc.num_tcs_and_init.broadcast_tc = rc->config.broadcast_tc;
-        log_debug(tt::LogMetal, "Num tcs to rr: {}", rc->config.num_tcs_to_rr);
-        // Copy per-risc arrays
-        for (int i = 0; i < rc->config.num_tcs_to_rr; i++) {
-            per_risc.base_addr[i] = rc->config.base_addr[i];
-            per_risc.limit[i] = rc->config.limit[i];
-            per_risc.packed_tile_counter[i] = rc->config.packed_tile_counter[i];
-            log_trace(tt::LogMetal, "Base addr {}: {}", i, static_cast<uint32_t>(per_risc.base_addr[i]));
-            log_trace(tt::LogMetal, "Limit {}: {}", i, static_cast<uint32_t>(per_risc.limit[i]));
-            log_trace(tt::LogMetal, "Packed tile counter {}: {}", i, (uint32_t)per_risc.packed_tile_counter[i]);
-        }
-        per_risc.flags.remapper_pair_index = static_cast<uint8_t>(rc->config.remapper_pair_index) & 0x3F;
-        per_risc.flags.remapper_en = this->use_remapper;
-        per_risc.flags.is_producer = rc->is_producer;
-        per_risc.consumer_tcs = rc->config.consumer_tcs;
-        // Per-producer remapper fields
-        per_risc.remapper_consumer_ids_mask = rc->config.remapper_consumer_ids_mask;
-        per_risc.producer_client_type = rc->config.producer_client_type;
-        log_debug(tt::LogMetal, "Is producer: {}", rc->is_producer);
-        log_debug(tt::LogMetal, "Remapper en: {}", this->use_remapper);
-        if (this->use_remapper && rc->is_producer) {
-            log_debug(
-                tt::LogMetal,
-                "Producer remapper: pair_idx={}, clientL={}, consumer_ids_mask=0x{:02x}",
-                rc->config.remapper_pair_index,
-                rc->config.producer_client_type,
-                rc->config.remapper_consumer_ids_mask);
-        }
-
-        const auto* cfg_bytes = reinterpret_cast<const uint8_t*>(&per_risc);
-        data.insert(data.end(), cfg_bytes, cfg_bytes + sizeof(per_risc));
-    }
-
-    // A side only programs a TxnDFBDescriptor when it has transaction ids (implicit sync, and not
-    // Tensix-only). Such a side must fit the descriptor, otherwise the device would have to drop
-    // counter ids and the ISR would never credit them. Sides with no descriptor collect ids that
-    // are never read, so they are exempt.
-    TT_FATAL(
-        producer_txn_descriptor.num_txn_ids == 0 || total_producer_tcs <= ::dfb::MAX_TILE_COUNTERS_PER_SIDE,
-        "DFB {}: producer side needs {} tile counters ({} producers) but a transaction descriptor holds at "
-        "most {}.",
-        this->id,
-        total_producer_tcs,
-        this->config.num_producers,
-        static_cast<uint32_t>(::dfb::MAX_TILE_COUNTERS_PER_SIDE));
-    TT_FATAL(
-        consumer_txn_descriptor.num_txn_ids == 0 || total_consumer_tcs <= ::dfb::MAX_TILE_COUNTERS_PER_SIDE,
-        "DFB {}: consumer side needs {} tile counters ({} consumers x {} producers) but a transaction "
-        "descriptor holds at most {}.",
-        this->id,
-        total_consumer_tcs,
-        this->config.num_consumers,
-        this->config.num_producers,
-        static_cast<uint32_t>(::dfb::MAX_TILE_COUNTERS_PER_SIDE));
-
-    log_debug(tt::LogMetal, "Serialized DFB {} for core ({},{}) size: {}", this->id, core.x, core.y, data.size());
-
-    return data;
-}
-
-// Recompute {capacity, stride_in_entries} from the DFB's num_entries / access pattern. Re-validates the
-// producer/consumer divisibility constraints.
 static std::pair<uint16_t, uint32_t> compute_capacity_and_stride(const DataflowBufferImpl& dfb) {
     const DataflowBufferConfig& config = dfb.config;
     uint32_t capacity = 0;
@@ -725,9 +1127,174 @@ static dfb_txn_id_descriptor_t make_txn_descriptor(
         is_producer ? config.pap : config.cap);
 }
 
+uint8_t calculate_num_tile_counters(const DataflowBufferConfig& config, bool is_producer) {
+    if (config.cap == ::dfb::AccessPattern::ALL) {
+        bool producer_has_dm = has_dm_risc(config.producer_risc_mask);
+        bool consumer_has_dm = has_dm_risc(config.consumer_risc_mask);
+        bool producer_is_tensix_only = !producer_has_dm && has_tensix_risc(config.producer_risc_mask);
+        bool consumer_is_tensix_only = !consumer_has_dm && has_tensix_risc(config.consumer_risc_mask);
+        bool dm_dm_all = !producer_is_tensix_only && !consumer_is_tensix_only;
+        if (is_producer) {
+            if (dm_dm_all) {
+                return config.num_consumers;
+            }
+            return 1;
+        }
+        return config.num_producers;
+    }
+    // Strided mode:
+    // Producer: num_consumers / num_producers (number of consumers each producer is paired with)
+    // Consumer: num_producers / num_consumers (number of producers each consumer is paired with)
+    // When the ratio is < 1, use 1 (each pairs with exactly one of the other)
+    if (is_producer) {
+        if (config.num_consumers >= config.num_producers) {
+            TT_FATAL(
+                config.num_consumers % config.num_producers == 0,
+                "num_consumers {} must be divisible by num_producers {} for strided producer",
+                config.num_consumers,
+                config.num_producers);
+            return config.num_consumers / config.num_producers;
+        }
+        // More producers than consumers: each producer pairs with 1 consumer
+        return 1;
+    }
+
+    if (config.num_producers >= config.num_consumers) {
+        TT_FATAL(
+            config.num_producers % config.num_consumers == 0,
+            "num_producers {} must be divisible by num_consumers {} for strided consumer",
+            config.num_producers,
+            config.num_consumers);
+        return config.num_producers / config.num_consumers;
+    }
+    // More consumers than producers: each consumer pairs with 1 producer
+    return 1;
+}
+
+// Get tensix_id for allocation when only DM RISCs are used
+// Round-robins through 0-3 based on pair index
+uint8_t get_dm_tensix_id_for_pair(uint8_t pair_index) { return pair_index % 4; }
+
+// Holds tile counters allocated together for a producer-consumer group
+struct TileCounterGroup {
+    ::dfb::PackedTileCounter producer_tc{};
+    std::vector<::dfb::PackedTileCounter> consumer_tcs;
+};
+
+// WH/BH: one 4-word CB-format config per DFB.  Quasar: per-DFB layout folded into per-hart blobs.
+static uint32_t dfb_wh_bh_serialized_size() { return 4u * sizeof(uint32_t); }
+
+uint16_t DataflowBufferImpl::dm1_remapper_slot_count() const {
+    if (!MetalContext::instance().hal().has_tile_counter_registers()) {
+        return 0;
+    }
+    return use_remapper ? static_cast<uint16_t>(config.num_producers) : 0;
+}
+
+void DataflowBufferImpl::append_dm1_remapper_slots_for_core(const CoreCoord& core, std::vector<uint8_t>& data) const {
+    TT_FATAL(this->configs_finalized, "DFB {} configs not finalized before serialization", this->id);
+    if (!MetalContext::instance().hal().has_tile_counter_registers()) {
+        return;
+    }
+
+    const uint16_t num_rmp = dm1_remapper_slot_count();
+    if (num_rmp == 0) {
+        return;
+    }
+
+    auto it = this->core_lookup_.find(core);
+    TT_FATAL(it != this->core_lookup_.end(), "DFB {} has no config for core ({}, {})", this->id, core.x, core.y);
+    const auto& [group_idx, _] = it->second;
+    const auto& hw_risc_configs = this->groups[group_idx].hw_risc_configs;
+
+    // Remapper slots: one per producer RISC that uses the remapper, in risc_mask bit order.
+    for (int bit = 0; bit < 16; bit++) {
+        if (!(this->risc_mask & (1 << bit))) {
+            continue;
+        }
+        const DFBRiscConfig* rc = nullptr;
+        for (const auto& c : hw_risc_configs) {
+            if (c.risc_id == static_cast<uint8_t>(bit)) { rc = &c; break; }
+        }
+        if (!rc->is_producer) {
+            continue;
+        }
+
+        uint8_t num_clientRs =
+            static_cast<uint8_t>(__builtin_popcount(rc->config.remapper_consumer_ids_mask));
+        uint8_t producer_client_type = rc->config.producer_client_type;
+        uint8_t tc_id = ::dfb::get_counter_id(rc->config.packed_tile_counter[0]);
+        uint8_t valid_mask = static_cast<uint8_t>((1u << num_clientRs) - 1);
+
+        uint32_t clientR_val = 0;
+        uint8_t mask_remaining = rc->config.remapper_consumer_ids_mask;
+        for (uint8_t r = 0; r < num_clientRs && r < ::dfb::MAX_CLIENT_RS; r++) {
+            uint8_t id_R = static_cast<uint8_t>(__builtin_ctz(mask_remaining));
+            mask_remaining &= mask_remaining - 1;
+            uint8_t tc_R = static_cast<uint8_t>((rc->config.consumer_tcs >> (r * 5)) & 0x1F);
+            clientR_val |= (static_cast<uint32_t>(id_R & 0x7u) << (r * 8)) |
+                           (static_cast<uint32_t>(tc_R & 0x1Fu) << (r * 8 + 3));
+        }
+        uint32_t clientL_val =
+            (static_cast<uint32_t>(producer_client_type & 0x7u)) |
+            (static_cast<uint32_t>(tc_id    & 0x1Fu) << 3) |
+            (static_cast<uint32_t>(valid_mask & 0xFu) << 8) |
+            (1u << 12) |  // clientl_is_producer = 1
+            (1u << 13);   // clientr_group = 1, distribute = 0
+
+        dfb_dm1_remapper_slot_t slot = {};
+        slot.pair_index  = rc->config.remapper_pair_index;
+        slot.clientR_val = clientR_val;
+        slot.clientL_val = clientL_val;
+        const auto* slot_bytes = reinterpret_cast<const uint8_t*>(&slot);
+        data.insert(data.end(), slot_bytes, slot_bytes + sizeof(slot));
+    }
+}
+
+// WH/BH only: emit the 4-word CB-format config for the legacy firmware path.
+std::vector<uint8_t> DataflowBufferImpl::serialize_for_core(const CoreCoord& core) const {
+    TT_FATAL(this->configs_finalized, "DFB {} configs not finalized before serialization", this->id);
+    TT_FATAL(
+        !MetalContext::instance().hal().has_tile_counter_registers(),
+        "serialize_for_core is only used on WH/BH; Quasar uses serialize_dfb_config_for_core");
+
+    auto it = this->core_lookup_.find(core);
+    TT_FATAL(it != this->core_lookup_.end(), "DFB {} has no config for core ({}, {})", this->id, core.x, core.y);
+    const uint32_t alloc_addr = it->second.second;
+    TT_FATAL(
+        !this->borrows_memory() || alloc_addr != 0,
+        "DFB {} uses borrowed memory but set_borrowed_memory_base_addr() was not called before serialization",
+        this->id);
+
+    std::vector<uint8_t> data;
+    data.reserve(dfb_wh_bh_serialized_size());
+    const uint32_t words[4] = {
+        alloc_addr,
+        this->config.entry_size * this->config.num_entries,
+        this->config.num_entries,
+        this->config.entry_size,
+    };
+    const auto* bytes = reinterpret_cast<const uint8_t*>(words);
+    data.insert(data.end(), bytes, bytes + sizeof(words));
+    return data;
+}
+
+uint32_t DataflowBufferImpl::serialized_size() const {
+    if (!MetalContext::instance().hal().has_tile_counter_registers()) {
+        return dfb_wh_bh_serialized_size();
+    }
+    // Quasar: per-hart init entry sizes are fixed for a finalized TC assignment.
+    TT_FATAL(!groups.empty(), "DFB {} has no groups (configs not finalized?)", id);
+    uint32_t sz = 0;
+    for (const auto& rc : groups[0].hw_risc_configs) {
+        sz += dfb_hart_init_entry_byte_size(rc.config.num_tcs_to_rr);
+    }
+    return sz;
+}
+
 void DataflowBufferImpl::update_size(std::optional<uint32_t> new_entry_size, std::optional<uint32_t> new_num_entries) {
     if (!new_entry_size.has_value() && !new_num_entries.has_value()) {
-        return;  // no-op: nothing to override
+        return;
     }
 
     const uint32_t es = new_entry_size.value_or(config.entry_size);
@@ -735,40 +1302,23 @@ void DataflowBufferImpl::update_size(std::optional<uint32_t> new_entry_size, std
     TT_FATAL(es > 0, "DFB {}: entry_size override must be > 0", id);
     TT_FATAL(ne > 0, "DFB {}: num_entries override must be > 0", id);
 
-    // The kernel-config dfb_size region is frozen after the first launch (finalize_offsets runs once).
-    // A size override must never change the serialized size.
     const std::optional<uint32_t> serialized_size_before =
         configs_finalized ? std::optional<uint32_t>(serialized_size()) : std::nullopt;
 
     config.entry_size = es;
     config.num_entries = ne;
 
-    // Recompute capacity + stride (re-validates divisibility vs producers/consumers).
     std::tie(capacity, stride_in_entries) = compute_capacity_and_stride(*this);
-
-    // Re-run the TRISC ring-extent uint16 validation (only done inside finalize otherwise).
     validate_ring_extent(*this);
 
-    // Re-entry only: finalize_dataflow_buffer_configs() skips already-finalized DFBs, so the
-    // size-derived txn descriptors must be recomputed in place. Preserve the already-allocated
-    // transaction IDs (reuse the stored txn_ids array) and TC assignment (do not touch groups,
-    // configs_finalized, or the allocators). On first launch (!configs_finalized) finalize computes
-    // these fresh from the updated config, so nothing is needed here.
     if (configs_finalized && MetalContext::instance().hal().has_tile_counter_registers()) {
         const bool producer_is_tensix_only =
             !has_dm_risc(config.producer_risc_mask) && has_tensix_risc(config.producer_risc_mask);
         const bool consumer_is_tensix_only =
             !has_dm_risc(config.consumer_risc_mask) && has_tensix_risc(config.consumer_risc_mask);
-        // configs_finalized implies groups is non-empty. The TC counts are group-invariant (see
-        // get_tc_counts), and the txn descriptors are DFB-global (not per-core), so groups[0] is the
-        // representative group here.
         TT_FATAL(!groups.empty(), "DFB {}: finalized but has no groups; cannot recompute txn descriptors", id);
         const auto [num_producer_tcs, num_consumer_tcs] = get_tc_counts(groups[0]);
 
-        // The transaction-id count is preserved on re-entry, so the new num_entries must keep the same
-        // divisibility that compute_txn_descriptor() enforces. Check up front with an actionable message.
-        // TODO: #46893 tracks re-deriving/reassigning the txn-id count on resize (e.g. double->quad
-        // buffering).
         auto check_divisor = [&](bool is_producer, uint8_t num_txn_ids, uint8_t num_tcs) {
             const bool consumes_all = !is_producer && (config.cap == ::dfb::AccessPattern::ALL);
             const uint8_t num_pc = is_producer ? config.num_producers : config.num_consumers;
@@ -786,8 +1336,6 @@ void DataflowBufferImpl::update_size(std::optional<uint32_t> new_entry_size, std
                 static_cast<uint32_t>(num_tcs));
         };
 
-        // Recompute one side's txn descriptor in place, preserving its already-allocated transaction
-        // IDs (only the thresholds change). No-op when that side has no implicit sync / is Tensix-only.
         auto recompute_txn_descriptor = [&](bool is_producer,
                                             dfb_txn_id_descriptor_t& desc,
                                             bool is_tensix_only,
@@ -814,6 +1362,27 @@ void DataflowBufferImpl::update_size(std::optional<uint32_t> new_entry_size, std
             num_consumer_tcs);
     }
 
+    if (configs_finalized && MetalContext::instance().hal().has_tile_counter_registers()) {
+        log_info(
+            tt::LogMetal,
+            "DFB {} size override applied: entry_size={} num_entries={} prod_threshold={} prod_per_tc={} "
+            "cons_threshold={} cons_per_tc={}",
+            id,
+            config.entry_size,
+            config.num_entries,
+            producer_txn_descriptor.num_entries_to_process_threshold,
+            producer_txn_descriptor.num_entries_per_txn_id_per_tc,
+            consumer_txn_descriptor.num_entries_to_process_threshold,
+            consumer_txn_descriptor.num_entries_per_txn_id_per_tc);
+    } else {
+        log_debug(
+            tt::LogMetal,
+            "DFB {} size override applied: entry_size={} num_entries={}",
+            id,
+            config.entry_size,
+            config.num_entries);
+    }
+
     if (serialized_size_before.has_value()) {
         TT_FATAL(
             serialized_size() == *serialized_size_before,
@@ -829,6 +1398,129 @@ void DataflowBufferImpl::update_size(std::optional<uint32_t> new_entry_size, std
         id,
         config.entry_size,
         config.num_entries);
+}
+
+std::vector<DFBRiscConfig> DataflowBufferImpl::compute_per_core_risc_configs(const CoreCoord& core) const {
+    TT_FATAL(this->configs_finalized, "DFB {} configs not finalized before computing per-core risc configs", this->id);
+
+    auto it = this->core_lookup_.find(core);
+    TT_FATAL(it != this->core_lookup_.end(), "DFB {} has no config for core ({}, {})", this->id, core.x, core.y);
+    const auto& [group_idx, alloc_addr] = it->second;
+    TT_FATAL(
+        !this->borrows_memory() || alloc_addr != 0,
+        "DFB {} uses borrowed memory but set_borrowed_memory_base_addr() was not called before serialization",
+        this->id);
+
+    const auto& hw_risc_configs = this->groups[group_idx].hw_risc_configs;
+
+    log_debug(
+        tt::LogMetal,
+        "DFB {} core ({},{}) {} producers {} consumers risc_mask=0x{:x} use_remapper={}",
+        this->id, core.x, core.y,
+        this->config.num_producers, this->config.num_consumers,
+        this->risc_mask, this->use_remapper);
+
+    uint8_t num_producer_tcs = 0, num_consumer_tcs = 0;
+    for (const auto& rc : hw_risc_configs) {
+        if (rc.is_producer) {
+            num_producer_tcs = std::max(num_producer_tcs, rc.config.num_tcs_to_rr);
+        } else {
+            num_consumer_tcs = std::max(num_consumer_tcs, rc.config.num_tcs_to_rr);
+        }
+    }
+
+    // Address arithmetic: see inline comments in old serialize_for_core for rationale.
+    const uint32_t entry_size      = this->config.entry_size;
+    const uint32_t effective_stride = this->stride_in_entries;
+    const uint32_t base_step = (effective_stride > 1) ? entry_size : (this->capacity * entry_size);
+
+    std::vector<DFBRiscConfig> per_core_rc = hw_risc_configs;
+    uint32_t base = alloc_addr;
+    for (uint8_t tc = 0; tc < num_producer_tcs; tc++) {
+        for (auto& rc : per_core_rc) {
+            if (rc.is_producer && tc < rc.config.num_tcs_to_rr) {
+                rc.config.base_addr[tc] = base;
+                rc.config.limit[tc] =
+                    base + ((entry_size * effective_stride) * (this->capacity - 1)) + entry_size;
+                base += base_step;
+            }
+        }
+    }
+    base = alloc_addr;
+    for (uint8_t tc = 0; tc < num_consumer_tcs; tc++) {
+        for (auto& rc : per_core_rc) {
+            if (rc.is_producer) {
+                continue;
+            }
+            rc.config.base_addr[tc] = base;
+            rc.config.limit[tc] =
+                base + ((entry_size * effective_stride) * (this->capacity - 1)) + entry_size;
+            if (this->config.cap == dfb::AccessPattern::STRIDED && tc < rc.config.num_tcs_to_rr) {
+                base += base_step;
+            }
+        }
+        if (this->config.cap == dfb::AccessPattern::ALL && this->config.num_producers > 1 &&
+            tc < num_consumer_tcs) {
+            base += base_step;
+        }
+    }
+
+    // RTL-sim correlation: log producer/consumer TC and txn-id assignments.
+    {
+        auto fmt_tcs = [](const DFBRiscConfig& rc) {
+            std::string s;
+            for (uint8_t t = 0; t < rc.config.num_tcs_to_rr; t++) {
+                if (t) {
+                    s += ",";
+                }
+                s += fmt::format(
+                    "(t{},c{})",
+                    ::dfb::get_tensix_id(rc.config.packed_tile_counter[t]),
+                    ::dfb::get_counter_id(rc.config.packed_tile_counter[t]));
+            }
+            return s;
+        };
+        auto fmt_txn_ids = [](const dfb_txn_id_descriptor_t& desc) -> std::string {
+            if (desc.num_txn_ids == 0) {
+                return "-";
+            }
+            std::string s;
+            for (uint8_t i = 0; i < desc.num_txn_ids; i++) {
+                if (i) {
+                    s += ",";
+                }
+                s += std::to_string(desc.txn_ids[i]);
+            }
+            return s;
+        };
+        std::string prod_part, cons_part;
+        for (const auto& rc : per_core_rc) {
+            if (rc.is_producer) {
+                if (!prod_part.empty()) {
+                    prod_part += "  ";
+                }
+                prod_part += fmt::format("r{}:[{}]", rc.risc_id, fmt_tcs(rc));
+                if (this->use_remapper) {
+                    prod_part += fmt::format("(rmp={})", rc.config.remapper_pair_index);
+                }
+            } else {
+                if (!cons_part.empty()) {
+                    cons_part += "  ";
+                }
+                cons_part += fmt::format("r{}:[{}]", rc.risc_id, fmt_tcs(rc));
+            }
+        }
+        log_debug(
+            tt::LogMetal,
+            "DFB {} corr: prod_txns=[{}] prod_tcs={{ {} }} | cons_txns=[{}] cons_tcs={{ {} }}",
+            this->id,
+            fmt_txn_ids(this->producer_txn_descriptor),
+            prod_part.empty() ? "-" : prod_part,
+            fmt_txn_ids(this->consumer_txn_descriptor),
+            cons_part.empty() ? "-" : cons_part);
+    }
+
+    return per_core_rc;
 }
 
 uint32_t finalize_dfbs(
@@ -851,17 +1543,26 @@ uint32_t finalize_dfbs(
         auto kernel_config = kg->launch_msg.view().kernel_config();
         kernel_config.local_cb_offset() = base_offset;
 
-        uint32_t kg_dfb_size = 0;
+        bool kg_has_dfb = false;
         for (const auto& dfb : dataflow_buffers) {
             TT_ASSERT(dfb->configs_finalized, "DFB {} configs not finalized before serialization", dfb->id);
             for (const CoreRange& kg_range : kg->core_ranges.ranges()) {
-                if (dfb->core_ranges.intersects(kg_range)) {
-                    kg_dfb_size += dfb->serialized_size();
-                    break;
-                }
+                if (dfb->core_ranges.intersects(kg_range)) { kg_has_dfb = true; break; }
             }
         }
+        // compute_dfb_config_serialized_size covers the full layout: header + DM1/DM0 blobs +
+        // per-hart sequential blobs + producer-ready region + alignment padding.
+        uint32_t kg_dfb_size = (kg_has_dfb && hal.has_tile_counter_registers())
+                                   ? compute_dfb_config_serialized_size(dataflow_buffers)
+                                   : 0u;
+        if (!hal.has_tile_counter_registers() && kg_has_dfb) {
+            // WH/BH: one 4-word CB-format entry per DFB.
+            kg_dfb_size = static_cast<uint32_t>(dataflow_buffers.size()) * dfb_wh_bh_serialized_size();
+        }
 
+        if (hal.has_tile_counter_registers() && kg_dfb_size > 0) {
+            kg_dfb_size = align_dfb_config_transfer_size(kg_dfb_size);
+        }
         dfb_size = std::max(dfb_size, kg_dfb_size);
     }
 
@@ -942,7 +1643,30 @@ uint32_t ProgramImpl::add_dataflow_buffer(const CoreRangeSet& core_range_set, co
         config.num_producers,
         config.num_consumers);
 
-    std::tie(dfb->capacity, dfb->stride_in_entries) = compute_capacity_and_stride(*dfb);
+    uint32_t capacity;
+    switch (config.cap) {
+        case dfb::AccessPattern::STRIDED:
+            TT_FATAL(
+                config.num_entries % std::max(config.num_producers, config.num_consumers) == 0,
+                "Num entries in DFB {} must be divisible by max of num producers and consumers {}",
+                config.num_entries,
+                std::max(config.num_producers, config.num_consumers));
+            capacity = config.num_entries / std::max(config.num_producers, config.num_consumers);
+            dfb->stride_in_entries = std::max(config.num_producers, config.num_consumers);
+            break;
+        case dfb::AccessPattern::ALL:
+            TT_FATAL(
+                config.num_entries % config.num_producers == 0,
+                "Num entries in DFB {} must be divisible by num producers {}",
+                config.num_entries,
+                config.num_producers);
+            capacity = config.num_entries / config.num_producers;
+            dfb->stride_in_entries = 1;
+            break;
+        default: TT_FATAL(false, "Invalid access pattern", (uint32_t)config.cap);
+    }
+    dfb->capacity = capacity;
+    log_debug(tt::LogMetal, "Capacity: {}", capacity);
 
     dfb->configs_finalized = false;
 
@@ -1513,8 +2237,14 @@ void ProgramImpl::finalize_single_dfb_config(
                 config.num_entries, config.num_producers, num_producer_tcs,
                 /*consumes_all=*/false);
             auto producer_txn_ids = txn_id_allocator_.allocate(num_prod_txn_ids);
-            dfb->producer_txn_descriptor =
-                make_txn_descriptor(*dfb, /*is_producer=*/true, producer_txn_ids, num_producer_tcs);
+            dfb->producer_txn_descriptor = compute_txn_descriptor(
+                config.num_entries,
+                config.num_producers,
+                config.num_consumers,
+                /*is_producer=*/true,
+                producer_txn_ids,
+                num_producer_tcs,
+                config.pap);
             log_info(
                 tt::LogMetal,
                 "DFB {} implicit sync: producer txn_ids=[{}] threshold={} per_txn={} per_tc={}",
@@ -1531,8 +2261,14 @@ void ProgramImpl::finalize_single_dfb_config(
                 config.num_entries, config.num_consumers, num_consumer_tcs,
                 /*consumes_all=*/consumes_all);
             auto consumer_txn_ids = txn_id_allocator_.allocate(num_cons_txn_ids);
-            dfb->consumer_txn_descriptor =
-                make_txn_descriptor(*dfb, /*is_producer=*/false, consumer_txn_ids, num_consumer_tcs);
+            dfb->consumer_txn_descriptor = compute_txn_descriptor(
+                config.num_entries,
+                config.num_producers,
+                config.num_consumers,
+                /*is_producer=*/false,
+                consumer_txn_ids,
+                num_consumer_tcs,
+                config.cap);
             log_info(
                 tt::LogMetal,
                 "DFB {} implicit sync: consumer txn_ids=[{}] threshold={} per_txn={} per_tc={}",
@@ -1682,8 +2418,6 @@ void ProgramImpl::apply_dfb_size_overrides(const std::vector<DfbSizeOverride>& o
         return;
     }
 
-    // (a) Resolve each override to its new total_size (entry_size * num_entries), filling unset fields
-    //     from the current config. Indexed by dfb_id for the alias-group agreement check below.
     std::unordered_map<uint32_t, uint64_t> new_total_by_id;
     new_total_by_id.reserve(overrides.size());
     for (const auto& o : overrides) {
@@ -1693,9 +2427,6 @@ void ProgramImpl::apply_dfb_size_overrides(const std::vector<DfbSizeOverride>& o
         new_total_by_id[o.dfb_id] = static_cast<uint64_t>(es) * ne;
     }
 
-    // (b) Alias-group coherence gate. Aliased DFBs total-size change is only safe if the whole group
-    //     agrees on one new total size. A change with total_size unchanged does not disturb the shared
-    //     region and is allowed.
     for (const auto& o : overrides) {
         auto dfb = get_dataflow_buffer(o.dfb_id);
         bool is_aliased = dfb->alias_primary_id.has_value() || !dfb->alias_secondary_ids.empty();
@@ -1703,10 +2434,8 @@ void ProgramImpl::apply_dfb_size_overrides(const std::vector<DfbSizeOverride>& o
             continue;
         }
         if (new_total_by_id.at(o.dfb_id) == dfb->total_size()) {
-            continue;  // isolated change -> footprint unchanged -> safe
+            continue;
         }
-        // total_size changes on an aliased member: every member of the group must be overridden to the
-        // same new total size. The primary sets the agreed size.
         uint32_t primary_id = dfb->alias_primary_id.value_or(o.dfb_id);
         auto primary = get_dataflow_buffer(primary_id);
         std::vector<uint32_t> group;
@@ -1740,14 +2469,10 @@ void ProgramImpl::apply_dfb_size_overrides(const std::vector<DfbSizeOverride>& o
         }
     }
 
-    // (c) Apply: mutate each DFB's size.
     for (const auto& o : overrides) {
         get_dataflow_buffer(o.dfb_id)->update_size(o.entry_size, o.num_entries);
     }
 
-    // (d) Force allocate_dataflow_buffers() to recompute the L1 layout for the new total_size() on the next
-    //     launch. For ephemeral DFBs this re-lays-out the region (and may shift later DFBs); for borrowed
-    //     DFBs the base address is unchanged but this keeps the bookkeeping consistent.
     invalidate_dataflow_buffer_allocation();
 }
 

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
@@ -9,6 +9,7 @@
 #include <memory>
 #include <optional>
 #include <unordered_map>
+#include <span>
 #include <vector>
 
 #include <tt_stl/assert.hpp>
@@ -24,7 +25,6 @@ struct KernelGroup;
 
 namespace tt::tt_metal::experimental::dfb::detail {
 
-// Per-risc config matching dfb_initializer_per_risc_t
 struct LocalDFBInterfaceHost {
     std::array<uint32_t, ::dfb::MAX_NUM_TILE_COUNTERS_TO_RR> base_addr = {0};
     std::array<uint32_t, ::dfb::MAX_NUM_TILE_COUNTERS_TO_RR> limit = {0};
@@ -105,7 +105,14 @@ struct DataflowBufferImpl {
 
     uint32_t total_size() const { return config.entry_size * config.num_entries; }
     uint32_t serialized_size() const;
-    std::vector<uint8_t> serialize_for_core(const CoreCoord& core) const;
+    uint16_t dm1_remapper_slot_count() const;  // slots this DFB contributes to the core-wide DM1 blob
+    void append_dm1_remapper_slots_for_core(const CoreCoord& core, std::vector<uint8_t>& data) const;
+
+    std::vector<uint8_t> serialize_for_core(const CoreCoord& core) const;  // WH/BH only (4-word CB format)
+
+    // Returns per-core DFBRiscConfig with base_addr/limit resolved for core's alloc_addr.
+    // Used by serialize_dfb_config_for_core to build per-hart init blobs.
+    std::vector<DFBRiscConfig> compute_per_core_risc_configs(const CoreCoord& core) const;
 
     // Override entry_size and/or num_entries. Recomputes capacity/stride and, on a re-entry
     // (already-finalized) DFB with implicit sync, recomputes the txn descriptors in place while
@@ -119,6 +126,37 @@ struct DataflowBufferImpl {
         return core_lookup_.begin()->second.second;
     }
 };
+
+// Host-precomputed init indices in dfb_global_header_t (participation masks; dfb_byte_offset filled during layout
+// write). Device uses these instead of walking all DFBs on the merged-loop hot path.
+void populate_dfb_global_header_participation(
+    dfb_global_header_t& ghdr, const std::vector<std::shared_ptr<DataflowBufferImpl>>& dfbs_on_core);
+
+void verify_dfb_global_header_participation(
+    const dfb_global_header_t& ghdr, const std::vector<std::shared_ptr<DataflowBufferImpl>>& dfbs_on_core);
+
+// Verifies that each hart's blob in the serialized config is internally consistent.
+void verify_dfb_hart_blobs(
+    std::span<const uint8_t> config_bytes, const std::vector<std::shared_ptr<DataflowBufferImpl>>& dfbs_on_core);
+
+// Packed Quasar config size for [prefix | DM1 blobs | DM0 blobs | layouts], including L1 transfer padding.
+uint32_t compute_dfb_config_serialized_size(
+    const std::vector<std::shared_ptr<DataflowBufferImpl>>& dfbs_on_core);
+
+// DM0 ISR blob region: core header + txn_id-indexed hw pool + txn desc pool.
+uint32_t dm0_isr_blob_region_size(const std::vector<std::shared_ptr<DataflowBufferImpl>>& dfbs_on_core);
+
+// DM1 remapper blob: core header + contiguous remapper slots across all DFBs on core.
+uint32_t dm1_remapper_blob_core_size(const std::vector<std::shared_ptr<DataflowBufferImpl>>& dfbs_on_core);
+
+std::vector<uint8_t> serialize_dm1_remapper_core_blob(
+    const CoreCoord& core, const std::vector<std::shared_ptr<DataflowBufferImpl>>& dfbs_on_core);
+
+// Packs Quasar DFB config: [header | offset table | DM1 blobs | DM0 blobs | per-DFB layouts]. Returns bytes written.
+size_t serialize_dfb_config_for_core(
+    const CoreCoord& core,
+    const std::vector<std::shared_ptr<DataflowBufferImpl>>& dfbs_on_core,
+    std::span<uint8_t> out);
 
 class TileCounterAllocator {
 public:

--- a/tt_metal/impl/host_api/tt_metal.cpp
+++ b/tt_metal/impl/host_api/tt_metal.cpp
@@ -1132,12 +1132,21 @@ bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool force_sl
                     log_info(tt::LogMetal, "DFB size: {}", program.impl().get_program_config(index).dfb_size);
                     std::vector<uint8_t> dfb_config_vec(
                         program.impl().get_program_config(index).dfb_size / sizeof(uint8_t));
-                    uint32_t offset = 0;
-                    for (const auto& dfb : dfbs_on_core) {
-                        auto serialized = dfb->serialize_for_core(logical_core);
-                        std::memcpy(dfb_config_vec.data() + offset, serialized.data(), serialized.size());
-                        offset += serialized.size();
+
+                    size_t bytes_written = 0;
+                    if (MetalContext::instance().hal().has_tile_counter_registers()) {
+                        bytes_written = tt::tt_metal::experimental::dfb::detail::serialize_dfb_config_for_core(
+                            logical_core, dfbs_on_core, dfb_config_vec);
+                    } else {
+                        uint32_t offset = 0;
+                        for (const auto& dfb : dfbs_on_core) {
+                            auto serialized = dfb->serialize_for_core(logical_core);
+                            std::memcpy(dfb_config_vec.data() + offset, serialized.data(), serialized.size());
+                            offset += serialized.size();
+                        }
+                        bytes_written = offset;
                     }
+
                     uint64_t addr = kernel_config_base + program.impl().get_program_config(index).dfb_offset;
                     log_info(
                         tt::LogMetal,
@@ -1147,8 +1156,9 @@ bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool force_sl
                         addr,
                         kernel_config_base,
                         program.impl().get_program_config(index).dfb_offset,
-                        dfb_config_vec.size());
-                    MetalContext::instance().get_cluster().write_core(device_id, physical_core, dfb_config_vec, addr);
+                        bytes_written);
+                    MetalContext::instance().get_cluster().write_core(
+                        device_id, physical_core, std::span<const uint8_t>(dfb_config_vec.data(), bytes_written), addr);
                 }
             }
             program.impl().init_semaphores(*device, logical_core, index);

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -1376,24 +1376,20 @@ public:
             const CoreCoord logical_representative = core_range.start_coord;
 
             size_t max_byte_end = 0;
-            size_t sequential_byte_offset = 0;
-            for (const auto& dfb : dfbs_on_corerange) {
-                size_t dfb_byte_offset = 0;
-                if (!hal.has_tile_counter_registers()) {
-                    // WH/BH: DFBs reuse the CB slot format; slot N starts at N * 4 words.
-                    dfb_byte_offset =
+            if (!hal.has_tile_counter_registers()) {
+                // WH/BH: DFBs reuse the CB slot format; slot N starts at N * 4 words.
+                for (const auto& dfb : dfbs_on_corerange) {
+                    size_t dfb_byte_offset =
                         static_cast<size_t>(dfb->id) * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
-                } else {
-                    // Quasar: DFBs are laid out sequentially in the dfb config region.
-                    dfb_byte_offset = sequential_byte_offset;
-                    sequential_byte_offset += dfb->serialized_size();
+                    auto serialized = dfb->serialize_for_core(logical_representative);
+                    TT_ASSERT(dfb_byte_offset + serialized.size() <= payload.size());
+                    std::copy(serialized.begin(), serialized.end(), payload.begin() + dfb_byte_offset);
+                    max_byte_end = std::max(max_byte_end, dfb_byte_offset + serialized.size());
                 }
-
-                auto serialized = dfb->serialize_for_core(logical_representative);
-                TT_ASSERT(serialized.size() == dfb->serialized_size());
-                TT_ASSERT(dfb_byte_offset + serialized.size() <= payload.size());
-                std::copy(serialized.begin(), serialized.end(), payload.begin() + dfb_byte_offset);
-                max_byte_end = std::max(max_byte_end, dfb_byte_offset + serialized.size());
+            } else {
+                max_byte_end = tt::tt_metal::experimental::dfb::detail::serialize_dfb_config_for_core(
+                    logical_representative, dfbs_on_corerange, payload);
+                TT_ASSERT(max_byte_end <= payload.size());
             }
 
             CoreRange virtual_range(virtual_start, virtual_end);

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -240,6 +240,10 @@ void JitBuildEnv::init(
         this->defines_ += "-DDEBUG_EARLY_RETURN_KERNELS ";
     }
 
+    if (rtoptions.get_measure_dfb_init_time_enabled()) {
+        this->defines_ += "-DDFB_INIT_TIMING_ENABLED ";
+    }
+
     if (rtoptions.get_watcher_debug_delay()) {
         this->defines_ += "-DWATCHER_DEBUG_DELAY=" + to_string(rtoptions.get_watcher_debug_delay()) + " ";
     }

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -118,6 +118,7 @@ enum class EnvVarID {
     TT_METAL_DRAM_BACKED_CQ,                   // Store command queues in device DRAM
     TT_METAL_SIMULATOR_DIRECT_TENSOR_WRITES,   // Simulator tensor preload bypasses FD CQ copies
     TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES,  // Override Blackhole DRAM programmable cores
+    TT_METAL_MEASURE_DFB_INIT_TIME,                     // Temporary DFB init rdcycle instrumentation (deprecate once device profiler covers this).
 
     // ========================================
     // PROFILING & PERFORMANCE
@@ -832,6 +833,15 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         // Usage: export TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES=0
         case EnvVarID::TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES:
             this->blackhole_dram_programmable_cores_override = is_env_enabled(value);
+            break;
+
+        // TT_METAL_MEASURE_DFB_INIT_TIME
+        // Enables rdcycle-based DFB init timing slots in device firmware (Quasar only).
+        // Deprecate once the device profiler subsumes this instrumentation.
+        // Default: false (rdcycle timing disabled; device uses no-op counters)
+        // Usage: export TT_METAL_MEASURE_DFB_INIT_TIME=1
+        case EnvVarID::TT_METAL_MEASURE_DFB_INIT_TIME:
+            this->measure_dfb_init_time_enabled = is_env_enabled(value);
             break;
 
         // ========================================

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -231,6 +231,9 @@ class RunTimeOptions {
     // should remain the same size as normal, unlike with null_kernels.
     bool kernels_early_return = false;
 
+    // Temporary: rdcycle DFB init timing in device firmware. Deprecate once profiler covers this.
+    bool measure_dfb_init_time_enabled = false;
+
     bool clear_l1 = false;
     bool clear_dram = false;
 
@@ -603,10 +606,11 @@ public:
     }
     std::string get_compile_hash_string() const {
         std::string compile_hash_str = fmt::format(
-            "{}_{}_{}_{}_{}_{}",
+            "{}_{}_{}_{}_{}_{}_{}",
             get_watcher_hash(),
             get_sanitizer_hash(),
             get_kernels_early_return(),
+            get_measure_dfb_init_time_enabled(),
             get_erisc_iram_enabled(),
             get_enable_2_erisc_mode(),
             get_disable_fabric_2_erisc_mode());
@@ -655,6 +659,8 @@ public:
 
     void set_kernels_early_return(bool v) { kernels_early_return = v; }
     bool get_kernels_early_return() const { return kernels_early_return; }
+
+    bool get_measure_dfb_init_time_enabled() const { return measure_dfb_init_time_enabled; }
 
     bool get_clear_l1() const { return clear_l1; }
     void set_clear_l1(bool clear) { clear_l1 = clear; }


### PR DESCRIPTION
### PR Category
Performance

### Summary of changes:

#### Firmware role split: DM0 / DM1 no longer run user kernels
- DM0 and DM1 are already reserved on host, carried that through FW (`dmk.cc` skips DM0/1) to take them out of LocalDFBInterface setup
- DM0 now owns implicit sync ISR setup and DM1 only does DFB remapper set up. These run in parallel with DM2-7 and Triscs set up of `LocalDFBInterface`
**Note:** Remapper is now always enabled. When kernel execution is finished, a high watermark clear is used to deprogram the remapped entries

#### Synchronization
Previous: DFB initialization would stall all kernels until all DFBs were programmed. This would stall until ISRs were configured, remapped pairs set, and producers reset/set buffer capacities on the Tile Counters

Current: Producers only need to wait for the remapped pairs they care about to be configured before they can reset/set buffer capacities on Tile Counters. Producers publish readiness in a designated signal region. Consumers don't wait for Tile Counter programming to complete and there is no global wait for all DFBs to be finished. The wait is pushed to when kernels construct their DFB objects. The constructor polls on the producer's signal region. @jbaumanTT this might be unsafe if we update this area with the next programs config. I can revisit where this signal lives or if it should be in local mem. 

#### Config Structure
- Flattened DM1 remapper config so it isn't nested per DFB 
- Compact global header + per risc sequential init blobs, TC addresses (base and limit) share a cache line
- Added participation mask + risc offsets to drive single sequential walk per risc
- Old dense per DFB config struct in worst case used 12480B new layout is fixed header + DM0/DM1 blobs + participating risc entries + signal region in worst case is 3.7 KB

#### Caching
- DM0: uncached read of masks, invalidation over config and cached walks/copies during setup
- DM1: uncached read of offset/num_slots, invalidation if non-empty, cached walk
- I found that invalidating larger portion of DM0/DM1 config would make it slower
- LocalDFBInterface setup: one invalidation over the riscs config, cached entry walk, cross risc (DM->Tensix) signals stay uncached

#### Micro-ops based on disassembly 
- Compact header unpack 
- Entry size look up table 
- Unrolled txn-id stores
- remapper watermark updated once rather than per slot bookkeeping 

#### Measurement
- using `rdcycle` to get timing 
- 7 cases added in `dfb_init_timing_bench` 
- run via: `TT_METAL_MEASURE_DFB_INIT_TIME=1 ./build/test/tt_metal/dfb_init_timing_bench` 
- `TT_METAL_MEASURE_DFB_INIT_TIME` allows `rdcycle` to be called and dumps results to L1 for benchmarks to read out
- Log parser script added to generate csv
- Results tracked [here](https://docs.google.com/spreadsheets/d/1bJum6VkHqPpnDAmmtiUPqFCfGjfj3Yieyl3f6Bip1fY/edit?gid=0#gid=0)
**Note:** We aren't at the goal. This effort is paused for now but will be revisited to help make worst case closet to 1us

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abhullar/dfb-init-time-rbsq)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/dfb-init-time-rbsq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=abhullar/dfb-init-time-rbsq)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:abhullar/dfb-init-time-rbsq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=abhullar/dfb-init-time-rbsq)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:abhullar/dfb-init-time-rbsq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abhullar/dfb-init-time-rbsq)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abhullar/dfb-init-time-rbsq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=abhullar/dfb-init-time-rbsq)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:abhullar/dfb-init-time-rbsq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=abhullar/dfb-init-time-rbsq)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:abhullar/dfb-init-time-rbsq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=abhullar/dfb-init-time-rbsq)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:abhullar/dfb-init-time-rbsq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=abhullar/dfb-init-time-rbsq)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:abhullar/dfb-init-time-rbsq)