### PR TITLE
Rebase Wan power test branch onto main

### DIFF
--- a/models/tt_dit/models/transformers/wan2_2/attention_wan.py
+++ b/models/tt_dit/models/transformers/wan2_2/attention_wan.py
@@ -25,8 +25,8 @@ class WanAttention(Module):
         (False, 2, 4): (256, 256),
         (False, 8, 4): (256, 256),
         (True, 2, 2): (128, 512),
-        (True, 8, 4): (288, 512),
-        (True, 32, 4): (224, 512),
+        (True, 8, 4): (128, 512),
+        (True, 32, 4): (128, 128),
     }
     default_sdpa_chunk_size = (256, 256)
 

--- a/models/tt_dit/models/transformers/wan2_2/transformer_wan.py
+++ b/models/tt_dit/models/transformers/wan2_2/transformer_wan.py
@@ -656,6 +656,23 @@ class WanTransformer3DModel(Module):
 
         return spatial_1BNI
 
+    @staticmethod
+    def device_to_host(tt_tensor: ttnn.Tensor) -> torch.Tensor:
+        """Move a ttnn device tensor to a torch host tensor."""
+
+        mesh_device = tt_tensor.device()
+        view = mesh_device.get_view() if ttnn.using_distributed_env() else None
+        coords = list(tt_tensor.tensor_topology().mesh_coords())
+        device_tensors = ttnn.get_device_tensors(tt_tensor)
+
+        for coord, device_tensor in zip(coords, device_tensors):
+            if view is None or view.is_local(coord):
+                torch_tensor = ttnn.to_torch(device_tensor)
+                break
+
+        assert torch_tensor is not None, "Failed to get tensor"
+        return torch_tensor
+
     # Prep run is False because we warmup the entire pipeline first. Remove if this is not desired.
     @traced_function(device=lambda self: self.mesh_device, clone_prep_inputs=False, prep_run=False)
     def combined_step(

--- a/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
@@ -99,6 +99,15 @@ def t2v_metrics(mesh_device, height):
             "vae": 5.0,
             "total": 80.5,
         }
+    elif tuple(mesh_device.shape) == (4, 32):
+        assert is_blackhole(), "4x32 is only supported for blackhole"
+        assert height == 720, "4x32 is only supported for 720p"
+        expected_metrics = {
+            "encoder": 115.0,
+            "denoising": 120.0,
+            "vae": 20.0,
+            "total": 255.0,
+        }
     else:
         assert False, f"Unknown mesh device for performance comparison: {mesh_device}"
     return expected_metrics

--- a/models/tt_dit/tests/models/wan2_2/test_transformer_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_transformer_wan.py
@@ -19,7 +19,13 @@ from ....utils.golden import load_golden, save_golden
 from ....utils.mochi import get_rot_transformation_mat, stack_cos_sin
 from ....utils.padding import pad_vision_seq_parallel
 from ....utils.tensor import bf16_tensor, bf16_tensor_2dshard, float32_tensor, from_torch, local_device_to_torch
-from ....utils.test import line_params_req_exact_devices, ring_params_req_exact_devices, skip_if_unsupported_num_links
+from ....utils.test import (
+    line_params,
+    line_params_req_exact_devices,
+    ring_params,
+    ring_params_req_exact_devices,
+    skip_if_unsupported_num_links,
+)
 
 # ---------------------------------------------------------------------------
 # Wan2.2-T2V-14B model configuration
@@ -309,6 +315,135 @@ def test_wan_transformer_block(
     tt_spatial_out = tt_spatial_out[:, :, :spatial_seq_len, :]
 
     assert_quality(torch_spatial_out, tt_spatial_out, pcc=MIN_PCC, relative_rmse=MAX_RMSE)
+
+
+@pytest.mark.timeout(0) # Disable pytest timeout
+@pytest.mark.parametrize(
+    ("mesh_device", "mesh_shape", "sp_axis", "tp_axis", "num_links", "device_params", "topology", "is_fsdp"),
+    [
+        pytest.param((4, 8), (4, 8), 1, 0, 2, ring_params, ttnn.Topology.Ring, False, id="ring_bh_4x8sp1tp0"),
+        pytest.param((4, 8), (4, 8), 1, 0, 2, line_params, ttnn.Topology.Linear, False, id="line_bh_4x8sp1tp0"),
+    ],
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize(
+    ("B", "T", "H", "W", "prompt_seq_len"),
+    [
+        pytest.param(1, 21, 90, 160, 512, id="14b-720p"),
+    ],
+)
+@pytest.mark.parametrize("test_duration_s", [100, 200, 500, 1000], ids=["100s", "200s", "500s", "1000s"])
+def test_wan_workload_power(
+    mesh_device: ttnn.MeshDevice,
+    mesh_shape: tuple[int, int],
+    sp_axis: int,
+    tp_axis: int,
+    num_links: int,
+    B: int,
+    T: int,
+    H: int,
+    W: int,
+    prompt_seq_len: int,
+    is_fsdp: bool,
+    topology: ttnn.Topology,
+    test_duration_s: int,
+    reset_seeds,
+) -> None:
+    MIN_PCC = 0.999_500
+    MAX_RMSE = 0.032
+
+    parent_mesh_device = mesh_device
+    mesh_device = parent_mesh_device.create_submesh(ttnn.MeshShape(*mesh_shape))
+
+    sp_factor = tuple(mesh_device.shape)[sp_axis]
+    parallel_config = _make_parallel_config(mesh_device, sp_axis, tp_axis)
+    ccl_manager = _make_ccl_manager(mesh_device, num_links, topology)
+
+    p_t, p_h, p_w = PATCH_SIZE
+    spatial_seq_len = (T // p_t) * (H // p_h) * (W // p_w)
+
+    # Load Wan2.2-T2V-14B transformer model from HuggingFace
+    torch_model = TorchWanTransformer3DModel(num_layers=1).blocks[0]
+    torch_model.eval()
+
+    # Create TT model
+    tt_model = WanTransformerBlock(
+        dim=DIM,
+        ffn_dim=FFN_DIM,
+        num_heads=NUM_HEADS,
+        cross_attention_norm=CROSS_ATTN_NORM,
+        eps=EPS,
+        mesh_device=mesh_device,
+        ccl_manager=ccl_manager,
+        parallel_config=parallel_config,
+        is_fsdp=is_fsdp,
+    )
+    tt_model.load_torch_state_dict(torch_model.state_dict())
+
+    # Create input tensors
+    torch.manual_seed(0)
+    spatial_input = torch.randn((B, spatial_seq_len, DIM), dtype=torch.float32)
+    prompt_input = torch.randn((B, prompt_seq_len, DIM), dtype=torch.float32)
+    temb_input = torch.randn((B, 6, DIM), dtype=torch.float32)
+
+    # Create ROPE embeddings
+    rope_cos = torch.randn(B, spatial_seq_len, 1, HEAD_DIM // 2)
+    rope_sin = torch.randn(B, spatial_seq_len, 1, HEAD_DIM // 2)
+    torch_rope_cos, torch_rope_sin = stack_cos_sin(rope_cos, rope_sin)
+
+    rope_cos_stack = torch_rope_cos.permute(0, 2, 1, 3)
+    rope_sin_stack = torch_rope_sin.permute(0, 2, 1, 3)
+
+    spatial_padded = pad_vision_seq_parallel(spatial_input.unsqueeze(0), num_devices=sp_factor)
+    rope_cos_padded = pad_vision_seq_parallel(rope_cos_stack, num_devices=sp_factor)
+    rope_sin_padded = pad_vision_seq_parallel(rope_sin_stack, num_devices=sp_factor)
+
+    # Create TT tensors
+    tt_spatial = bf16_tensor_2dshard(spatial_padded, device=mesh_device, shard_mapping={sp_axis: 2, tp_axis: 3})
+    tt_prompt = bf16_tensor(prompt_input.unsqueeze(0), device=mesh_device)
+    tt_temb = from_torch(temb_input.unsqueeze(0), device=mesh_device, dtype=ttnn.float32, mesh_axes=[..., tp_axis])
+    tt_rope_cos = from_torch(rope_cos_padded, device=mesh_device, dtype=ttnn.float32, mesh_axes=[..., sp_axis, None])
+    tt_rope_sin = from_torch(rope_sin_padded, device=mesh_device, dtype=ttnn.float32, mesh_axes=[..., sp_axis, None])
+    tt_trans_mat = bf16_tensor(get_rot_transformation_mat(), device=mesh_device)
+
+    # Run TT model
+    logger.info(
+        f"Running TT model with spatial shape {tt_spatial.shape}, prompt shape {tt_prompt.shape}, rope_cos shape {tt_rope_cos.shape}, rope_sin shape {tt_rope_sin.shape}"
+    )
+    tt_spatial_out = tt_model(
+        spatial_1BND=tt_spatial,
+        prompt_1BLP=tt_prompt,
+        temb_1BTD=tt_temb,
+        N=spatial_seq_len,
+        rope_cos=tt_rope_cos,
+        rope_sin=tt_rope_sin,
+        trans_mat=tt_trans_mat,
+    )
+    
+    logger.info(f"Warmup iteration complete")
+    
+    start = time.time()
+    
+    itr = 0
+    while time.time() - start < test_duration_s:
+        ttnn.synchronize_device(mesh_device)
+        logger.info(f"Running iteration {itr}, time elapsed: {time.time() - start:.3f} seconds")
+        for _ in range(40):
+            tt_spatial_out = tt_model(
+                spatial_1BND=tt_spatial,
+                prompt_1BLP=tt_prompt,
+                temb_1BTD=tt_temb,
+                N=spatial_seq_len,
+                rope_cos=tt_rope_cos,
+                rope_sin=tt_rope_sin,
+                trans_mat=tt_trans_mat,
+            )
+        itr += 1
+    
+    end = time.time()
+    logger.info(f"Completed test after: {end - start} seconds")
+    
+
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What

Rebases `cglagovich/wan_power_2` onto latest `main` (was based on a Feb 2026 merge-base, ~5 months stale).

The original 13 commits collapsed to **4** — the other 9 were already upstream or superseded by main's own evolution:

| Kept commit | Content after rebase |
|---|---|
| Add 4x32 option to transformer block test / SDPA chunk size | Only the branch's `sdpa_chunk_size_map` values in `attention_wan.py` (see note below) |
| Workaround concat-mesh-to-tensor in Wan forward | `WanTransformer3DModel.device_to_host` static method |
| enable 4x32 Wan perf test | `(4,32)` expected-metrics branch in `test_performance_wan.py` |
| Add Wan power test. MMs use 11x10 grid | `test_wan_workload_power` in `test_transformer_wan.py` (the deliverable) |

Dropped/superseded on main: the 11x10 matmul grid clamp, `grid_11_10_configs`, 4x32 pipeline/vae/perf test configs, the `cherry-pick 4437132` (UMT5 encoder, already merged as #37984), the whole old `WanPipeline.create_pipeline` architecture (main uses `WanPipelineConfig`/`WanCheckpoint`), and the conftest torch-threads change (already on main).

## Review notes

- **Fixed a rebase-induced breakage:** the power test references `ring_params`/`line_params`, but main's `test_transformer_wan.py` only imported the `*_req_exact_devices` variants → would `NameError` at collection. Added the missing imports. `pyflakes` now reports no undefined names.
- **Behavior divergence to confirm:** this rebase preserves the branch's `sdpa_chunk_size_map` values `(True,8,4)->(128,512)` and `(True,32,4)->(128,128)`, which differ from main's newer tuning `(288,512)`/`(224,512)`. This affects all Wan configs using those keys, not just the power test.
- `device_to_host` is effectively unused after rebase (the power test doesn't read back to host, and main's pipeline uses its own path) — kept as a harmless branch addition.

Not verified on hardware (requires Blackhole Galaxy); review is read-based + static (`py_compile`, `pyflakes`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=cglagovich/wan_power_2_rebase)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:cglagovich/wan_power_2_rebase)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=cglagovich/wan_power_2_rebase)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:cglagovich/wan_power_2_rebase)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=cglagovich/wan_power_2_rebase)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:cglagovich/wan_power_2_rebase)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=cglagovich/wan_power_2_rebase)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:cglagovich/wan_power_2_rebase)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=cglagovich/wan_power_2_rebase)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:cglagovich/wan_power_2_rebase)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=cglagovich/wan_power_2_rebase)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:cglagovich/wan_power_2_rebase)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=cglagovich/wan_power_2_rebase)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:cglagovich/wan_power_2_rebase)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=cglagovich/wan_power_2_rebase)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:cglagovich/wan_power_2_rebase)