### PR TITLE
Feature: Support multichip DRAM harvesting in tensor prefetcher

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_dram_sender_global_cb.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_sender_global_cb.cpp
@@ -10,7 +10,10 @@
 
 #include <gtest/gtest.h>
 #include <cstdint>
-#include <exception>
+#include <cstdlib>
+#include <iterator>
+#include <memory>
+#include <optional>
 #include <vector>
 
 #include <tt-metalium/buffer_types.hpp>
@@ -19,6 +22,8 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/global_circular_buffer.hpp>
 #include "impl/buffers/drisc_l1_arena.hpp"
+#include "impl/buffers/dram_sender_state_block.hpp"
+#include "distributed/mesh_device_impl.hpp"
 #include <tt-metalium/experimental/global_circular_buffer.hpp>
 
 #include "impl/kernels/kernel.hpp"  // DramConfig
@@ -55,6 +60,104 @@ protected:
     distributed::MeshDevice* mesh_device_{};
     IDevice* device_{};
 };
+
+class DramSenderGCBMultiDeviceFixture : public MeshDispatchFixture {
+protected:
+    void SetUp() override {
+        if (std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr) {
+            GTEST_SKIP() << "Requires TT_METAL_SLOW_DISPATCH_MODE=1";
+        }
+        if (tt::get_arch_from_string(tt::test_utils::get_umd_arch_name()) != tt::ARCH::BLACKHOLE) {
+            GTEST_SKIP() << "Requires Blackhole";
+        }
+
+        const auto& cluster = MetalContext::instance().get_cluster();
+        const auto& available_ids = cluster.user_exposed_chip_ids();
+        if (available_ids.size() < 2) {
+            GTEST_SKIP() << "Requires at least two devices";
+        }
+        std::vector<ChipId> device_ids(available_ids.begin(), std::next(available_ids.begin(), 2));
+        mesh_device_ = distributed::MeshDevice::create(
+            distributed::MeshDeviceConfig(distributed::MeshShape{1, 2}, std::nullopt, device_ids));
+        if (!MetalContext::instance(mesh_device_->impl().get_context_id())
+                 .hal()
+                 .has_programmable_core_type(HalProgrammableCoreType::DRAM)) {
+            GTEST_SKIP() << "DRAM programmable cores not enabled";
+        }
+    }
+
+    void TearDown() override {
+        if (mesh_device_) {
+            mesh_device_->close();
+            mesh_device_.reset();
+        }
+    }
+
+    std::shared_ptr<distributed::MeshDevice> mesh_device_;
+};
+
+TEST_F(DramSenderGCBMultiDeviceFixture, ConfigAndSenderStateUsePerDeviceDramTopology) {
+    constexpr uint32_t kGcbSize = 1024;
+    constexpr uint32_t kBankId = 0;
+    constexpr uint32_t kNumReceivers = 2;
+    CoreRangeSet receiver_cores(CoreRange({0, 0}, {kNumReceivers - 1, 0}));
+    auto gcb = experimental::CreateGlobalCircularBufferWithDramSenders(
+        *mesh_device_, {{kBankId, receiver_cores}}, kGcbSize, BufferType::L1, /*dual_senders_per_bank=*/true);
+    ASSERT_EQ(gcb.sender_receiver_core_mapping().size(), kNumReceivers);
+
+    const auto& hal = MetalContext::instance(mesh_device_->impl().get_context_id()).hal();
+    const uint64_t dram_l1_noc_offset = hal.get_l1_noc_offset(HalProgrammableCoreType::DRAM);
+    const uint64_t sender_state_addr =
+        dram_l1_noc_offset + static_cast<uint64_t>(experimental::sender_state_drisc_l1_base(gcb));
+    const auto receiver_logical_cores =
+        corerange_to_cores(receiver_cores, /*max_cores=*/std::nullopt, /*row_wise=*/true);
+
+    for (IDevice* device : mesh_device_->get_devices()) {
+        const std::vector<CoreCoord> device_senders = mesh_device_->impl().dram_sender_logical_cores(device, kBankId);
+        ASSERT_EQ(device_senders.size(), kNumReceivers);
+
+        for (uint32_t sender_role = 0; sender_role < kNumReceivers; ++sender_role) {
+            const CoreCoord expected_sender_virtual =
+                device->virtual_core_from_logical_core(device_senders[sender_role], CoreType::DRAM);
+
+            // Each receiver's config page stores the NOC XY to increment when returning
+            // pages_acked credits. With dual senders and two receivers, role s owns receiver s.
+            std::vector<uint32_t> receiver_config;
+            tt::tt_metal::detail::ReadFromDeviceL1(
+                device,
+                receiver_logical_cores[sender_role],
+                gcb.config_address(),
+                10 * sizeof(uint32_t),
+                receiver_config,
+                CoreType::WORKER);
+            ASSERT_GE(receiver_config.size(), 10u);
+            EXPECT_EQ(receiver_config[8], expected_sender_virtual.x)
+                << "device " << device->id() << ", sender role " << sender_role;
+            EXPECT_EQ(receiver_config[9], expected_sender_virtual.y)
+                << "device " << device->id() << ", sender role " << sender_role;
+
+            const CoreCoord expected_receiver_phys =
+                device->worker_core_from_logical_core(receiver_logical_cores[sender_role]);
+            const size_t sender_state_size = sizeof(DramSenderStateBlock) + 2 * sizeof(uint32_t);
+            std::vector<uint8_t> sender_state_bytes(sender_state_size, 0);
+            MetalContext::instance(mesh_device_->impl().get_context_id())
+                .get_cluster()
+                .read_core(
+                    sender_state_bytes.data(),
+                    sender_state_bytes.size(),
+                    tt_cxy_pair(device->id(), expected_sender_virtual),
+                    sender_state_addr);
+            const auto* sender_state = reinterpret_cast<const DramSenderStateBlock*>(sender_state_bytes.data());
+            EXPECT_EQ(sender_state->num_receivers, 1u);
+            const auto* receiver_xy =
+                reinterpret_cast<const uint32_t*>(sender_state_bytes.data() + sizeof(DramSenderStateBlock));
+            EXPECT_EQ(receiver_xy[0], expected_receiver_phys.x)
+                << "device " << device->id() << ", sender role " << sender_role;
+            EXPECT_EQ(receiver_xy[1], expected_receiver_phys.y)
+                << "device " << device->id() << ", sender role " << sender_role;
+        }
+    }
+}
 
 TEST_F(DramSenderGCBFixture, SmokeOneSenderFourReceivers) {
     // Layout: 4 receivers, each receives one 64-byte page.

--- a/tests/tt_metal/tt_metal/api/test_dram_sender_global_cb.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_sender_global_cb.cpp
@@ -209,23 +209,24 @@ TEST_F(DramSenderGCBMultiDeviceFixture, ConfigAndSenderStateUsePerDeviceDramTopo
     }
 }
 
-TEST_F(DramSenderGCBFixture, SmokeOneSenderFourReceivers) {
-    // Layout: 4 receivers, each receives one 64-byte page.
-    constexpr uint32_t kNumReceivers = 4;
+// One DRISC sender pushes a per-receiver page to every core in `receiver_cores` and checks each
+// landed its own stripe. Parameterized on the receiver set: a receiver's credit slot is its index
+// in a row-wise flatten of that set, so a set spanning both rows and columns is what catches a
+// sender NOC XY table ordered differently than the receivers' config pages.
+void run_one_sender_smoke(distributed::MeshDevice* mesh_device, const CoreRangeSet& receiver_cores) {
+    const uint32_t kNumReceivers = receiver_cores.num_cores();
     constexpr uint32_t kPageSize = 64;  // multiple of L1_ALIGNMENT (16 on BH)
     constexpr uint32_t kNumPages = 1;
     constexpr uint32_t kRemoteCBId = 31;
 
     // Sender: bank 0
     const uint32_t bank_id = 0;
-    // Receivers
-    CoreRangeSet receiver_cores(CoreRange({0, 0}, {kNumReceivers - 1, 0}));
     std::vector<std::pair<uint32_t, CoreRangeSet>> bank_to_receivers = {{bank_id, receiver_cores}};
 
     // Size: per-receiver fifo. Use 1KB.
     constexpr uint32_t kGcbSize = 1024;
     auto gcb = experimental::CreateGlobalCircularBufferForTensorPrefetcher(
-        *mesh_device_, bank_to_receivers, kGcbSize, BufferType::L1, /*support_multi_receiver_shards=*/true);
+        *mesh_device, bank_to_receivers, kGcbSize, BufferType::L1, /*support_multi_receiver_shards=*/true);
     // Use the sender coord the factory resolved; recomputing via pick_unused_dram_logical_core
     // would couple this test to the picker's current strategy.
     const CoreCoord sender_logical = gcb.sender_receiver_core_mapping().at(0).first;
@@ -263,14 +264,14 @@ TEST_F(DramSenderGCBFixture, SmokeOneSenderFourReceivers) {
             pattern[r * kPageSize / sizeof(uint32_t) + w] = 0xABCD0000u + r * 0x100u + w;
         }
     }
-    auto sender_virtual = mesh_device_->virtual_core_from_logical_core(sender_logical, CoreType::DRAM);
+    auto sender_virtual = mesh_device->virtual_core_from_logical_core(sender_logical, CoreType::DRAM);
     const uint64_t drisc_l1_noc_addr_base =
         hal.get_dev_noc_addr(HalProgrammableCoreType::DRAM, HalL1MemAddrType::UNRESERVED);
     const uint64_t data_noc_addr = drisc_l1_noc_addr_base + (data_addr - drisc_l1_unreserved);
     MetalContext::instance().get_cluster().write_core(
         pattern.data(),
         pattern.size() * sizeof(uint32_t),
-        tt_cxy_pair(mesh_device_->build_id(), sender_virtual),
+        tt_cxy_pair(mesh_device->build_id(), sender_virtual),
         data_noc_addr);
 
     // Build a single program with both sender (DRISC) and receiver (worker) kernels.
@@ -296,7 +297,7 @@ TEST_F(DramSenderGCBFixture, SmokeOneSenderFourReceivers) {
         sender_logical,
         DramConfig{.noc = NOC::NOC_0, .compile_args = sender_compile_args});
 
-    const std::vector<uint32_t> sender_rt_args = receiver_noc_xy_rt_args(gcb, mesh_device_);
+    const std::vector<uint32_t> sender_rt_args = receiver_noc_xy_rt_args(gcb, mesh_device);
     SetRuntimeArgs(program, sender_kernel_id, sender_logical, sender_rt_args);
 
     CircularBufferConfig cb_config(kPageSize);
@@ -313,19 +314,23 @@ TEST_F(DramSenderGCBFixture, SmokeOneSenderFourReceivers) {
 
     distributed::MeshWorkload workload;
     workload.add_program(device_range, std::move(program));
-    distributed::EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), workload, false);
-    distributed::Finish(mesh_device_->mesh_command_queue());
+    distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);
+    distributed::Finish(mesh_device->mesh_command_queue());
 
-    // Verify each receiver's L1 slice
-    auto receivers_vec = corerange_to_cores(receiver_cores);
+    // Verify each receiver's L1 slice. Walk the GCB's own receiver order (the same order the
+    // sender's NOC XY table and each receiver's credit slot are built from), not a fresh flatten
+    // of receiver_cores -- reusing the contract's order is what makes slot r mean receiver r.
+    const auto& receivers_vec = experimental::receiver_logical_cores_per_sender(gcb).at(0);
+    ASSERT_EQ(receivers_vec.size(), kNumReceivers);
     for (uint32_t r = 0; r < receivers_vec.size(); ++r) {
         std::vector<uint32_t> result;
         slow_dispatch::ReadFromL1(
-            *mesh_device_, receivers_vec[r], gcb.buffer_address(), kPageSize, result, CoreType::WORKER);
+            *mesh_device, receivers_vec[r], gcb.buffer_address(), kPageSize, result, CoreType::WORKER);
         for (uint32_t w = 0; w < kPageSize / sizeof(uint32_t); ++w) {
             uint32_t expected = 0xABCD0000u + r * 0x100u + w;
-            EXPECT_EQ(result[w], expected) << "Receiver " << r << " word " << w << " mismatch (expected 0x" << std::hex
-                                           << expected << ", got 0x" << result[w] << std::dec << ")";
+            EXPECT_EQ(result[w], expected)
+                << "Receiver " << r << " (" << receivers_vec[r].str() << ") word " << w << " mismatch (expected 0x"
+                << std::hex << expected << ", got 0x" << result[w] << std::dec << ")";
         }
     }
 
@@ -336,7 +341,7 @@ TEST_F(DramSenderGCBFixture, SmokeOneSenderFourReceivers) {
     MetalContext::instance().get_cluster().read_core(
         pages_buf.data(),
         pages_buf.size() * sizeof(uint32_t),
-        tt_cxy_pair(mesh_device_->build_id(), sender_virtual),
+        tt_cxy_pair(mesh_device->build_id(), sender_virtual),
         pages_sent_noc_addr);
     for (uint32_t r = 0; r < kNumReceivers; ++r) {
         uint32_t sent = pages_buf[2 * r];
@@ -345,6 +350,20 @@ TEST_F(DramSenderGCBFixture, SmokeOneSenderFourReceivers) {
                                << ", acked=" << acked << ")";
         EXPECT_GT(sent, 0u) << "Sender did not push any pages to receiver " << r;
     }
+}
+
+TEST_F(DramSenderGCBFixture, SmokeOneSenderFourReceivers) {
+    // 4 receivers in one row, each receiving one 64-byte page.
+    run_one_sender_smoke(mesh_device_, CoreRangeSet(CoreRange({0, 0}, {3, 0})));
+}
+
+TEST_F(DramSenderGCBFixture, SmokeReceiverGridSpansRowsAndColumns) {
+    // Same flow over a 2x2 receiver grid, where row-wise and column-wise flattening disagree:
+    // (1,0) and (0,1) trade places. A sender whose NOC XY table is ordered one way while the
+    // receivers' pages_sent/pages_acked slots are assigned the other way credits the wrong
+    // receiver -- each side then waits on a counter nobody advances, so this hangs rather than
+    // returning bad data.
+    run_one_sender_smoke(mesh_device_, CoreRangeSet(CoreRange({0, 0}, {1, 1})));
 }
 
 // Same data flow as SmokeOneSenderFourReceivers, but the sender (DRISC) and receiver

--- a/tests/tt_metal/tt_metal/api/test_dram_sender_global_cb.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_sender_global_cb.cpp
@@ -101,8 +101,12 @@ TEST_F(DramSenderGCBMultiDeviceFixture, ConfigAndSenderStateUsePerDeviceDramTopo
     constexpr uint32_t kBankId = 0;
     constexpr uint32_t kNumReceivers = 2;
     CoreRangeSet receiver_cores(CoreRange({0, 0}, {kNumReceivers - 1, 0}));
-    auto gcb = experimental::CreateGlobalCircularBufferWithDramSenders(
-        *mesh_device_, {{kBankId, receiver_cores}}, kGcbSize, BufferType::L1, /*dual_senders_per_bank=*/true);
+    auto gcb = experimental::CreateGlobalCircularBufferForTensorPrefetcher(
+        *mesh_device_,
+        {{kBankId, receiver_cores}},
+        kGcbSize,
+        BufferType::L1,
+        /*support_multi_receiver_shards=*/false);
     ASSERT_EQ(gcb.sender_receiver_core_mapping().size(), kNumReceivers);
 
     const auto& hal = MetalContext::instance(mesh_device_->impl().get_context_id()).hal();
@@ -115,6 +119,14 @@ TEST_F(DramSenderGCBMultiDeviceFixture, ConfigAndSenderStateUsePerDeviceDramTopo
     for (IDevice* device : mesh_device_->get_devices()) {
         const std::vector<CoreCoord> device_senders = mesh_device_->impl().dram_sender_logical_cores(device, kBankId);
         ASSERT_EQ(device_senders.size(), kNumReceivers);
+
+        // Logical sender coords name an endpoint role, so they are the same on every device; only
+        // the physical subchannel they resolve to tracks that device's DRAM harvest mask. The GCB's
+        // one mapping is only valid for the whole mesh because of this.
+        for (uint32_t sender_role = 0; sender_role < kNumReceivers; ++sender_role) {
+            EXPECT_EQ(device_senders[sender_role], gcb.sender_receiver_core_mapping()[sender_role].first)
+                << "device " << device->id() << ", sender role " << sender_role;
+        }
 
         for (uint32_t sender_role = 0; sender_role < kNumReceivers; ++sender_role) {
             const CoreCoord expected_sender_virtual =

--- a/tests/tt_metal/tt_metal/api/test_dram_sender_global_cb.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_sender_global_cb.cpp
@@ -37,6 +37,7 @@
 #include <tt-metalium/experimental/dispatch_context.hpp>
 
 #include "device_fixture.hpp"
+#include "multi_device_fixture.hpp"
 #include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include "impl/context/metal_context.hpp"
 #include "llrt/hal.hpp"
@@ -61,113 +62,146 @@ protected:
     distributed::MeshDevice* mesh_device_{};
 };
 
-class DramSenderGCBMultiDeviceFixture : public MeshDispatchFixture {
+// MeshDevice1x2Fixture owns a single MeshDevice spanning two chips, which is what makes the
+// per-device fan-out inside one GCB observable. Deriving from a MeshDispatchFixture instead
+// would hand back unit meshes (one 1x1 MeshDevice per chip), collapsing every per-device loop
+// below to a single iteration, and its shared-device suite setup would be torn down twice.
+// Runs under fast dispatch (MeshDevice1x2Fixture's requirement, and what CI defaults to). Nothing
+// here needs slow dispatch: the receiver config lands via a blocking WriteShard and the sender
+// state block via cluster.write_core, so both have landed by the time the factory returns and the
+// raw L1 reads below are safe.
+class DramSenderGCBMultiDeviceFixture : public MeshDevice1x2Fixture {
 protected:
     void SetUp() override {
-        if (std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr) {
-            GTEST_SKIP() << "Requires TT_METAL_SLOW_DISPATCH_MODE=1";
-        }
         if (tt::get_arch_from_string(tt::test_utils::get_umd_arch_name()) != tt::ARCH::BLACKHOLE) {
             GTEST_SKIP() << "Requires Blackhole";
         }
-
-        const auto& cluster = MetalContext::instance().get_cluster();
-        const auto& available_ids = cluster.user_exposed_chip_ids();
-        if (available_ids.size() < 2) {
-            GTEST_SKIP() << "Requires at least two devices";
+        // Opens the 1x2 mesh, or skips when the system mesh is smaller than two devices.
+        MeshDevice1x2Fixture::SetUp();
+        if (mesh_device_ == nullptr) {
+            return;
         }
-        std::vector<ChipId> device_ids(available_ids.begin(), std::next(available_ids.begin(), 2));
-        mesh_device_ = distributed::MeshDevice::create(
-            distributed::MeshDeviceConfig(distributed::MeshShape{1, 2}, std::nullopt, device_ids));
         if (!MetalContext::instance(mesh_device_->impl().get_context_id())
                  .hal()
                  .has_programmable_core_type(HalProgrammableCoreType::DRAM)) {
             GTEST_SKIP() << "DRAM programmable cores not enabled";
         }
     }
-
-    void TearDown() override {
-        if (mesh_device_) {
-            mesh_device_->close();
-            mesh_device_.reset();
-        }
-    }
-
-    std::shared_ptr<distributed::MeshDevice> mesh_device_;
 };
 
 TEST_F(DramSenderGCBMultiDeviceFixture, ConfigAndSenderStateUsePerDeviceDramTopology) {
     constexpr uint32_t kGcbSize = 1024;
-    constexpr uint32_t kBankId = 0;
-    constexpr uint32_t kNumReceivers = 2;
-    CoreRangeSet receiver_cores(CoreRange({0, 0}, {kNumReceivers - 1, 0}));
+    constexpr uint32_t kSendersPerBank = 2;
+
+    // Sweep every bank rather than pinning bank 0. Logical bank ids are the compacted (harvested)
+    // view index, so a pair of devices that harvest different late channels still agrees on bank 0
+    // while diverging on some later bank; testing one bank can therefore miss the very divergence
+    // this test exists to catch.
+    const auto& soc_desc = MetalContext::instance(mesh_device_->impl().get_context_id())
+                               .get_cluster()
+                               .get_soc_desc(mesh_device_->get_devices().front()->id());
+    const uint32_t num_banks = soc_desc.get_num_dram_views();
+    ASSERT_GT(num_banks, 0u);
+
+    // Bank b's two receivers are the column (b, 0)..(b, 1), so every bank gets a disjoint receiver
+    // pair (one GCB cannot map the same worker to two senders) and the row-wise split inside
+    // build_dram_sender_mapping hands (b, 0) to role 0 and (b, 1) to role 1.
+    std::vector<std::pair<uint32_t, CoreRangeSet>> bank_to_receivers;
+    bank_to_receivers.reserve(num_banks);
+    for (uint32_t bank = 0; bank < num_banks; ++bank) {
+        bank_to_receivers.emplace_back(bank, CoreRangeSet(CoreRange({bank, 0}, {bank, kSendersPerBank - 1})));
+    }
+
     auto gcb = experimental::CreateGlobalCircularBufferForTensorPrefetcher(
-        *mesh_device_,
-        {{kBankId, receiver_cores}},
-        kGcbSize,
-        BufferType::L1,
-        /*support_multi_receiver_shards=*/false);
-    ASSERT_EQ(gcb.sender_receiver_core_mapping().size(), kNumReceivers);
+        *mesh_device_, bank_to_receivers, kGcbSize, BufferType::L1, /*support_multi_receiver_shards=*/false);
+    ASSERT_EQ(gcb.sender_receiver_core_mapping().size(), num_banks * kSendersPerBank);
 
     const auto& hal = MetalContext::instance(mesh_device_->impl().get_context_id()).hal();
     const uint64_t dram_l1_noc_offset = hal.get_l1_noc_offset(HalProgrammableCoreType::DRAM);
     const uint64_t sender_state_addr =
         dram_l1_noc_offset + static_cast<uint64_t>(experimental::sender_state_drisc_l1_base(gcb));
-    const auto receiver_logical_cores =
-        corerange_to_cores(receiver_cores, /*max_cores=*/std::nullopt, /*row_wise=*/true);
+
+    // Tracks whether this device pair actually places any sender differently. Harvest masks are a
+    // property of the silicon, so a homogeneous pair exercises the per-device path without
+    // distinguishing it from the old mesh-wide reference translation; say so rather than let a
+    // green run read as proof.
+    bool any_sender_placement_differs = false;
 
     for (IDevice* device : mesh_device_->get_devices()) {
-        const std::vector<CoreCoord> device_senders = mesh_device_->impl().dram_sender_logical_cores(device, kBankId);
-        ASSERT_EQ(device_senders.size(), kNumReceivers);
+        for (uint32_t bank = 0; bank < num_banks; ++bank) {
+            const std::vector<CoreCoord> device_senders = mesh_device_->impl().dram_sender_logical_cores(device, bank);
+            ASSERT_EQ(device_senders.size(), kSendersPerBank);
 
-        // Logical sender coords name an endpoint role, so they are the same on every device; only
-        // the physical subchannel they resolve to tracks that device's DRAM harvest mask. The GCB's
-        // one mapping is only valid for the whole mesh because of this.
-        for (uint32_t sender_role = 0; sender_role < kNumReceivers; ++sender_role) {
-            EXPECT_EQ(device_senders[sender_role], gcb.sender_receiver_core_mapping()[sender_role].first)
-                << "device " << device->id() << ", sender role " << sender_role;
+            const auto receiver_logical_cores =
+                corerange_to_cores(bank_to_receivers[bank].second, /*max_cores=*/std::nullopt, /*row_wise=*/true);
+
+            for (uint32_t sender_role = 0; sender_role < kSendersPerBank; ++sender_role) {
+                const size_t mapping_idx = (bank * kSendersPerBank) + sender_role;
+
+                // Logical sender coords name an endpoint role, so they are the same on every device;
+                // only the physical subchannel they resolve to tracks that device's DRAM harvest
+                // mask. The GCB's one mapping is only valid for the whole mesh because of this.
+                EXPECT_EQ(device_senders[sender_role], gcb.sender_receiver_core_mapping()[mapping_idx].first)
+                    << "device " << device->id() << ", bank " << bank << ", sender role " << sender_role;
+
+                const CoreCoord expected_sender_virtual =
+                    device->virtual_core_from_logical_core(device_senders[sender_role], CoreType::DRAM);
+                const CoreCoord reference_sender_virtual =
+                    mesh_device_->get_devices().front()->virtual_core_from_logical_core(
+                        device_senders[sender_role], CoreType::DRAM);
+                any_sender_placement_differs |= (expected_sender_virtual != reference_sender_virtual);
+
+                // Each receiver's config page stores the NOC XY to increment when returning
+                // pages_acked credits. With dual senders and two receivers, role s owns receiver s.
+                //
+                // Reads the physical IDevice, not the mesh: slow_dispatch::ReadFromL1 takes a
+                // MeshDevice and TT_FATALs unless it is a unit mesh, because it has no way to say
+                // which device to read. This mesh spans two devices and the whole point here is to
+                // read each one separately, so resolve the device ourselves -- which is what that
+                // helper does internally for the unit-mesh case anyway.
+                std::vector<uint32_t> receiver_config;
+                tt::tt_metal::detail::ReadFromDeviceL1(
+                    device,
+                    receiver_logical_cores[sender_role],
+                    gcb.config_address(),
+                    10 * sizeof(uint32_t),
+                    receiver_config,
+                    CoreType::WORKER);
+                ASSERT_GE(receiver_config.size(), 10u);
+                EXPECT_EQ(receiver_config[8], expected_sender_virtual.x)
+                    << "device " << device->id() << ", bank " << bank << ", sender role " << sender_role;
+                EXPECT_EQ(receiver_config[9], expected_sender_virtual.y)
+                    << "device " << device->id() << ", bank " << bank << ", sender role " << sender_role;
+
+                const CoreCoord expected_receiver_phys =
+                    device->worker_core_from_logical_core(receiver_logical_cores[sender_role]);
+                const size_t sender_state_size = sizeof(DramSenderStateBlock) + 2 * sizeof(uint32_t);
+                std::vector<uint8_t> sender_state_bytes(sender_state_size, 0);
+                MetalContext::instance(mesh_device_->impl().get_context_id())
+                    .get_cluster()
+                    .read_core(
+                        sender_state_bytes.data(),
+                        sender_state_bytes.size(),
+                        tt_cxy_pair(device->id(), expected_sender_virtual),
+                        sender_state_addr);
+                const auto* sender_state = reinterpret_cast<const DramSenderStateBlock*>(sender_state_bytes.data());
+                EXPECT_EQ(sender_state->num_receivers, 1u);
+                const auto* receiver_xy =
+                    reinterpret_cast<const uint32_t*>(sender_state_bytes.data() + sizeof(DramSenderStateBlock));
+                EXPECT_EQ(receiver_xy[0], expected_receiver_phys.x)
+                    << "device " << device->id() << ", bank " << bank << ", sender role " << sender_role;
+                EXPECT_EQ(receiver_xy[1], expected_receiver_phys.y)
+                    << "device " << device->id() << ", bank " << bank << ", sender role " << sender_role;
+            }
         }
+    }
 
-        for (uint32_t sender_role = 0; sender_role < kNumReceivers; ++sender_role) {
-            const CoreCoord expected_sender_virtual =
-                device->virtual_core_from_logical_core(device_senders[sender_role], CoreType::DRAM);
-
-            // Each receiver's config page stores the NOC XY to increment when returning
-            // pages_acked credits. With dual senders and two receivers, role s owns receiver s.
-            std::vector<uint32_t> receiver_config;
-            tt::tt_metal::detail::ReadFromDeviceL1(
-                device,
-                receiver_logical_cores[sender_role],
-                gcb.config_address(),
-                10 * sizeof(uint32_t),
-                receiver_config,
-                CoreType::WORKER);
-            ASSERT_GE(receiver_config.size(), 10u);
-            EXPECT_EQ(receiver_config[8], expected_sender_virtual.x)
-                << "device " << device->id() << ", sender role " << sender_role;
-            EXPECT_EQ(receiver_config[9], expected_sender_virtual.y)
-                << "device " << device->id() << ", sender role " << sender_role;
-
-            const CoreCoord expected_receiver_phys =
-                device->worker_core_from_logical_core(receiver_logical_cores[sender_role]);
-            const size_t sender_state_size = sizeof(DramSenderStateBlock) + 2 * sizeof(uint32_t);
-            std::vector<uint8_t> sender_state_bytes(sender_state_size, 0);
-            MetalContext::instance(mesh_device_->impl().get_context_id())
-                .get_cluster()
-                .read_core(
-                    sender_state_bytes.data(),
-                    sender_state_bytes.size(),
-                    tt_cxy_pair(device->id(), expected_sender_virtual),
-                    sender_state_addr);
-            const auto* sender_state = reinterpret_cast<const DramSenderStateBlock*>(sender_state_bytes.data());
-            EXPECT_EQ(sender_state->num_receivers, 1u);
-            const auto* receiver_xy =
-                reinterpret_cast<const uint32_t*>(sender_state_bytes.data() + sizeof(DramSenderStateBlock));
-            EXPECT_EQ(receiver_xy[0], expected_receiver_phys.x)
-                << "device " << device->id() << ", sender role " << sender_role;
-            EXPECT_EQ(receiver_xy[1], expected_receiver_phys.y)
-                << "device " << device->id() << ", sender role " << sender_role;
-        }
+    if (!any_sender_placement_differs) {
+        log_warning(
+            tt::LogTest,
+            "This device pair harvests DRAM identically, so no bank resolves to a different physical sender "
+            "across the mesh. The per-device assertions above still hold, but this run cannot distinguish "
+            "per-device translation from the mesh-wide reference translation it replaced.");
     }
 }
 

--- a/tests/tt_metal/tt_metal/api/test_dram_sender_global_cb.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_sender_global_cb.cpp
@@ -10,9 +10,6 @@
 
 #include <gtest/gtest.h>
 #include <cstdint>
-#include <cstdlib>
-#include <iterator>
-#include <memory>
 #include <optional>
 #include <vector>
 
@@ -62,22 +59,36 @@ protected:
     distributed::MeshDevice* mesh_device_{};
 };
 
-// MeshDevice1x2Fixture owns a single MeshDevice spanning two chips, which is what makes the
-// per-device fan-out inside one GCB observable. Deriving from a MeshDispatchFixture instead
-// would hand back unit meshes (one 1x1 MeshDevice per chip), collapsing every per-device loop
-// below to a single iteration, and its shared-device suite setup would be torn down twice.
-// Runs under fast dispatch (MeshDevice1x2Fixture's requirement, and what CI defaults to). Nothing
-// here needs slow dispatch: the receiver config lands via a blocking WriteShard and the sender
+// Sender 0's receivers as the physical NOC XY runtime args the smoke sender kernel expects,
+// translated through the device the program will run on.
+std::vector<uint32_t> receiver_noc_xy_rt_args(const experimental::GlobalCircularBuffer& gcb, IDevice* device) {
+    const auto& receivers = experimental::receiver_logical_cores_per_sender(gcb).at(0);
+    std::vector<uint32_t> rt_args;
+    rt_args.reserve(2 * receivers.size());
+    for (const auto& receiver_logical : receivers) {
+        const CoreCoord phys = device->worker_core_from_logical_core(receiver_logical);
+        rt_args.push_back(phys.x);
+        rt_args.push_back(phys.y);
+    }
+    return rt_args;
+}
+
+// One MeshDevice spanning two chips, which is what makes the per-device fan-out inside one GCB
+// observable. A MeshDispatchFixture would hand back unit meshes (one 1x1 MeshDevice per chip),
+// collapsing every per-device loop below to a single iteration, and its shared-device suite setup
+// would be torn down twice.
+// Runs under fast dispatch (MeshDeviceFixtureBase's requirement, and what CI defaults to). Nothing
+// here needs slow dispatch: the receiver config lands via a blocking shard write and the sender
 // state block via cluster.write_core, so both have landed by the time the factory returns and the
 // raw L1 reads below are safe.
-class DramSenderGCBMultiDeviceFixture : public MeshDevice1x2Fixture {
+class DramSenderGCBMultiDeviceFixture : public MeshDeviceFixtureBase {
 protected:
+    DramSenderGCBMultiDeviceFixture() :
+        MeshDeviceFixtureBase(Config{.mesh_shape = MeshShape{1, 2}, .arch = tt::ARCH::BLACKHOLE}) {}
+
     void SetUp() override {
-        if (tt::get_arch_from_string(tt::test_utils::get_umd_arch_name()) != tt::ARCH::BLACKHOLE) {
-            GTEST_SKIP() << "Requires Blackhole";
-        }
-        // Opens the 1x2 mesh, or skips when the system mesh is smaller than two devices.
-        MeshDevice1x2Fixture::SetUp();
+        // Opens the 1x2 mesh, or skips on a non-Blackhole arch / a system mesh smaller than two devices.
+        MeshDeviceFixtureBase::SetUp();
         if (mesh_device_ == nullptr) {
             return;
         }
@@ -97,19 +108,20 @@ TEST_F(DramSenderGCBMultiDeviceFixture, ConfigAndSenderStateUsePerDeviceDramTopo
     // view index, so a pair of devices that harvest different late channels still agrees on bank 0
     // while diverging on some later bank; testing one bank can therefore miss the very divergence
     // this test exists to catch.
-    const auto& soc_desc = MetalContext::instance(mesh_device_->impl().get_context_id())
-                               .get_cluster()
-                               .get_soc_desc(mesh_device_->get_devices().front()->id());
-    const uint32_t num_banks = soc_desc.get_num_dram_views();
+    const uint32_t num_banks = mesh_device_->dram_grid_size().x;
     ASSERT_GT(num_banks, 0u);
 
     // Bank b's two receivers are the column (b, 0)..(b, 1), so every bank gets a disjoint receiver
     // pair (one GCB cannot map the same worker to two senders) and the row-wise split inside
     // build_dram_sender_mapping hands (b, 0) to role 0 and (b, 1) to role 1.
     std::vector<std::pair<uint32_t, CoreRangeSet>> bank_to_receivers;
+    std::vector<std::vector<CoreCoord>> receivers_per_bank;
     bank_to_receivers.reserve(num_banks);
+    receivers_per_bank.reserve(num_banks);
     for (uint32_t bank = 0; bank < num_banks; ++bank) {
         bank_to_receivers.emplace_back(bank, CoreRangeSet(CoreRange({bank, 0}, {bank, kSendersPerBank - 1})));
+        receivers_per_bank.push_back(
+            corerange_to_cores(bank_to_receivers.back().second, /*max_cores=*/std::nullopt, /*row_wise=*/true));
     }
 
     auto gcb = experimental::CreateGlobalCircularBufferForTensorPrefetcher(
@@ -127,29 +139,29 @@ TEST_F(DramSenderGCBMultiDeviceFixture, ConfigAndSenderStateUsePerDeviceDramTopo
     // green run read as proof.
     bool any_sender_placement_differs = false;
 
+    IDevice* reference_device = mesh_device_->get_devices().front();
+    auto& cluster = MetalContext::instance(mesh_device_->impl().get_context_id()).get_cluster();
+    std::vector<uint8_t> sender_state_bytes(sizeof(DramSenderStateBlock) + 2 * sizeof(uint32_t));
+
     for (IDevice* device : mesh_device_->get_devices()) {
         for (uint32_t bank = 0; bank < num_banks; ++bank) {
             const std::vector<CoreCoord> device_senders = mesh_device_->impl().dram_sender_logical_cores(device, bank);
             ASSERT_EQ(device_senders.size(), kSendersPerBank);
 
-            const auto receiver_logical_cores =
-                corerange_to_cores(bank_to_receivers[bank].second, /*max_cores=*/std::nullopt, /*row_wise=*/true);
-
             for (uint32_t sender_role = 0; sender_role < kSendersPerBank; ++sender_role) {
+                SCOPED_TRACE(fmt::format("device {}, bank {}, sender role {}", device->id(), bank, sender_role));
                 const size_t mapping_idx = (bank * kSendersPerBank) + sender_role;
 
                 // Logical sender coords name an endpoint role, so they are the same on every device;
                 // only the physical subchannel they resolve to tracks that device's DRAM harvest
                 // mask. The GCB's one mapping is only valid for the whole mesh because of this.
-                EXPECT_EQ(device_senders[sender_role], gcb.sender_receiver_core_mapping()[mapping_idx].first)
-                    << "device " << device->id() << ", bank " << bank << ", sender role " << sender_role;
+                EXPECT_EQ(device_senders[sender_role], gcb.sender_receiver_core_mapping()[mapping_idx].first);
 
                 const CoreCoord expected_sender_virtual =
                     device->virtual_core_from_logical_core(device_senders[sender_role], CoreType::DRAM);
-                const CoreCoord reference_sender_virtual =
-                    mesh_device_->get_devices().front()->virtual_core_from_logical_core(
-                        device_senders[sender_role], CoreType::DRAM);
-                any_sender_placement_differs |= (expected_sender_virtual != reference_sender_virtual);
+                any_sender_placement_differs |=
+                    (expected_sender_virtual !=
+                     reference_device->virtual_core_from_logical_core(device_senders[sender_role], CoreType::DRAM));
 
                 // Each receiver's config page stores the NOC XY to increment when returning
                 // pages_acked credits. With dual senders and two receivers, role s owns receiver s.
@@ -162,36 +174,28 @@ TEST_F(DramSenderGCBMultiDeviceFixture, ConfigAndSenderStateUsePerDeviceDramTopo
                 std::vector<uint32_t> receiver_config;
                 tt::tt_metal::detail::ReadFromDeviceL1(
                     device,
-                    receiver_logical_cores[sender_role],
+                    receivers_per_bank[bank][sender_role],
                     gcb.config_address(),
                     10 * sizeof(uint32_t),
                     receiver_config,
                     CoreType::WORKER);
                 ASSERT_GE(receiver_config.size(), 10u);
-                EXPECT_EQ(receiver_config[8], expected_sender_virtual.x)
-                    << "device " << device->id() << ", bank " << bank << ", sender role " << sender_role;
-                EXPECT_EQ(receiver_config[9], expected_sender_virtual.y)
-                    << "device " << device->id() << ", bank " << bank << ", sender role " << sender_role;
+                EXPECT_EQ(receiver_config[8], expected_sender_virtual.x);
+                EXPECT_EQ(receiver_config[9], expected_sender_virtual.y);
 
                 const CoreCoord expected_receiver_phys =
-                    device->worker_core_from_logical_core(receiver_logical_cores[sender_role]);
-                const size_t sender_state_size = sizeof(DramSenderStateBlock) + 2 * sizeof(uint32_t);
-                std::vector<uint8_t> sender_state_bytes(sender_state_size, 0);
-                MetalContext::instance(mesh_device_->impl().get_context_id())
-                    .get_cluster()
-                    .read_core(
-                        sender_state_bytes.data(),
-                        sender_state_bytes.size(),
-                        tt_cxy_pair(device->id(), expected_sender_virtual),
-                        sender_state_addr);
+                    device->worker_core_from_logical_core(receivers_per_bank[bank][sender_role]);
+                cluster.read_core(
+                    sender_state_bytes.data(),
+                    sender_state_bytes.size(),
+                    tt_cxy_pair(device->id(), expected_sender_virtual),
+                    sender_state_addr);
                 const auto* sender_state = reinterpret_cast<const DramSenderStateBlock*>(sender_state_bytes.data());
                 EXPECT_EQ(sender_state->num_receivers, 1u);
                 const auto* receiver_xy =
                     reinterpret_cast<const uint32_t*>(sender_state_bytes.data() + sizeof(DramSenderStateBlock));
-                EXPECT_EQ(receiver_xy[0], expected_receiver_phys.x)
-                    << "device " << device->id() << ", bank " << bank << ", sender role " << sender_role;
-                EXPECT_EQ(receiver_xy[1], expected_receiver_phys.y)
-                    << "device " << device->id() << ", bank " << bank << ", sender role " << sender_role;
+                EXPECT_EQ(receiver_xy[0], expected_receiver_phys.x);
+                EXPECT_EQ(receiver_xy[1], expected_receiver_phys.y);
             }
         }
     }
@@ -292,13 +296,7 @@ TEST_F(DramSenderGCBFixture, SmokeOneSenderFourReceivers) {
         sender_logical,
         DramConfig{.noc = NOC::NOC_0, .compile_args = sender_compile_args});
 
-    std::vector<uint32_t> sender_rt_args;
-    sender_rt_args.reserve(2 * kNumReceivers);
-    const auto& receiver_phys = experimental::receiver_coords_per_sender(gcb).at(0);
-    for (const auto& c : receiver_phys) {
-        sender_rt_args.push_back(c.x);
-        sender_rt_args.push_back(c.y);
-    }
+    const std::vector<uint32_t> sender_rt_args = receiver_noc_xy_rt_args(gcb, mesh_device_);
     SetRuntimeArgs(program, sender_kernel_id, sender_logical, sender_rt_args);
 
     CircularBufferConfig cb_config(kPageSize);
@@ -421,12 +419,7 @@ TEST_F(DramSenderGCBFixture, SmokeTwoProgramsAsyncSlowDispatch) {
         "tests/tt_metal/tt_metal/test_kernels/misc/gcb_smoke_sender.cpp",
         sender_logical,
         DramConfig{.noc = NOC::NOC_0, .compile_args = sender_compile_args});
-    std::vector<uint32_t> sender_rt_args;
-    const auto& receiver_phys = experimental::receiver_coords_per_sender(gcb).at(0);
-    for (const auto& c : receiver_phys) {
-        sender_rt_args.push_back(c.x);
-        sender_rt_args.push_back(c.y);
-    }
+    const std::vector<uint32_t> sender_rt_args = receiver_noc_xy_rt_args(gcb, mesh_device_);
     SetRuntimeArgs(sender_program, sender_kernel_id, sender_logical, sender_rt_args);
 
     // --- Receiver program: worker kernel only, with c_31 attached to the GCB ---
@@ -569,12 +562,7 @@ TEST_F(DramSenderGCBFixture, MultiGcbDisjointPagesSent) {
             "tests/tt_metal/tt_metal/test_kernels/misc/gcb_smoke_sender.cpp",
             sender_logical,
             DramConfig{.noc = NOC::NOC_0, .compile_args = sender_compile_args});
-        std::vector<uint32_t> sender_rt_args;
-        const auto& receiver_phys = experimental::receiver_coords_per_sender(gcb).at(0);
-        for (const auto& c : receiver_phys) {
-            sender_rt_args.push_back(c.x);
-            sender_rt_args.push_back(c.y);
-        }
+        const std::vector<uint32_t> sender_rt_args = receiver_noc_xy_rt_args(gcb, mesh_device_);
         SetRuntimeArgs(program, sender_kernel_id, sender_logical, sender_rt_args);
 
         CircularBufferConfig cb_config(kPageSize);

--- a/tests/tt_metal/tt_metal/api/test_dram_sender_global_cb.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_sender_global_cb.cpp
@@ -10,7 +10,10 @@
 
 #include <gtest/gtest.h>
 #include <cstdint>
-#include <exception>
+#include <cstdlib>
+#include <iterator>
+#include <memory>
+#include <optional>
 #include <vector>
 
 #include <tt-metalium/buffer_types.hpp>
@@ -20,6 +23,8 @@
 #include <tt-metalium/global_circular_buffer.hpp>
 #include "impl/buffers/drisc_l1_arena.hpp"
 #include "impl/buffers/global_circular_buffer_dram_sender_internal.hpp"
+#include "impl/buffers/dram_sender_state_block.hpp"
+#include "distributed/mesh_device_impl.hpp"
 #include <tt-metalium/experimental/global_circular_buffer.hpp>
 
 #include "impl/kernels/kernel.hpp"  // DramConfig
@@ -55,6 +60,104 @@ protected:
 
     distributed::MeshDevice* mesh_device_{};
 };
+
+class DramSenderGCBMultiDeviceFixture : public MeshDispatchFixture {
+protected:
+    void SetUp() override {
+        if (std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr) {
+            GTEST_SKIP() << "Requires TT_METAL_SLOW_DISPATCH_MODE=1";
+        }
+        if (tt::get_arch_from_string(tt::test_utils::get_umd_arch_name()) != tt::ARCH::BLACKHOLE) {
+            GTEST_SKIP() << "Requires Blackhole";
+        }
+
+        const auto& cluster = MetalContext::instance().get_cluster();
+        const auto& available_ids = cluster.user_exposed_chip_ids();
+        if (available_ids.size() < 2) {
+            GTEST_SKIP() << "Requires at least two devices";
+        }
+        std::vector<ChipId> device_ids(available_ids.begin(), std::next(available_ids.begin(), 2));
+        mesh_device_ = distributed::MeshDevice::create(
+            distributed::MeshDeviceConfig(distributed::MeshShape{1, 2}, std::nullopt, device_ids));
+        if (!MetalContext::instance(mesh_device_->impl().get_context_id())
+                 .hal()
+                 .has_programmable_core_type(HalProgrammableCoreType::DRAM)) {
+            GTEST_SKIP() << "DRAM programmable cores not enabled";
+        }
+    }
+
+    void TearDown() override {
+        if (mesh_device_) {
+            mesh_device_->close();
+            mesh_device_.reset();
+        }
+    }
+
+    std::shared_ptr<distributed::MeshDevice> mesh_device_;
+};
+
+TEST_F(DramSenderGCBMultiDeviceFixture, ConfigAndSenderStateUsePerDeviceDramTopology) {
+    constexpr uint32_t kGcbSize = 1024;
+    constexpr uint32_t kBankId = 0;
+    constexpr uint32_t kNumReceivers = 2;
+    CoreRangeSet receiver_cores(CoreRange({0, 0}, {kNumReceivers - 1, 0}));
+    auto gcb = experimental::CreateGlobalCircularBufferWithDramSenders(
+        *mesh_device_, {{kBankId, receiver_cores}}, kGcbSize, BufferType::L1, /*dual_senders_per_bank=*/true);
+    ASSERT_EQ(gcb.sender_receiver_core_mapping().size(), kNumReceivers);
+
+    const auto& hal = MetalContext::instance(mesh_device_->impl().get_context_id()).hal();
+    const uint64_t dram_l1_noc_offset = hal.get_l1_noc_offset(HalProgrammableCoreType::DRAM);
+    const uint64_t sender_state_addr =
+        dram_l1_noc_offset + static_cast<uint64_t>(experimental::sender_state_drisc_l1_base(gcb));
+    const auto receiver_logical_cores =
+        corerange_to_cores(receiver_cores, /*max_cores=*/std::nullopt, /*row_wise=*/true);
+
+    for (IDevice* device : mesh_device_->get_devices()) {
+        const std::vector<CoreCoord> device_senders = mesh_device_->impl().dram_sender_logical_cores(device, kBankId);
+        ASSERT_EQ(device_senders.size(), kNumReceivers);
+
+        for (uint32_t sender_role = 0; sender_role < kNumReceivers; ++sender_role) {
+            const CoreCoord expected_sender_virtual =
+                device->virtual_core_from_logical_core(device_senders[sender_role], CoreType::DRAM);
+
+            // Each receiver's config page stores the NOC XY to increment when returning
+            // pages_acked credits. With dual senders and two receivers, role s owns receiver s.
+            std::vector<uint32_t> receiver_config;
+            tt::tt_metal::detail::ReadFromDeviceL1(
+                device,
+                receiver_logical_cores[sender_role],
+                gcb.config_address(),
+                10 * sizeof(uint32_t),
+                receiver_config,
+                CoreType::WORKER);
+            ASSERT_GE(receiver_config.size(), 10u);
+            EXPECT_EQ(receiver_config[8], expected_sender_virtual.x)
+                << "device " << device->id() << ", sender role " << sender_role;
+            EXPECT_EQ(receiver_config[9], expected_sender_virtual.y)
+                << "device " << device->id() << ", sender role " << sender_role;
+
+            const CoreCoord expected_receiver_phys =
+                device->worker_core_from_logical_core(receiver_logical_cores[sender_role]);
+            const size_t sender_state_size = sizeof(DramSenderStateBlock) + 2 * sizeof(uint32_t);
+            std::vector<uint8_t> sender_state_bytes(sender_state_size, 0);
+            MetalContext::instance(mesh_device_->impl().get_context_id())
+                .get_cluster()
+                .read_core(
+                    sender_state_bytes.data(),
+                    sender_state_bytes.size(),
+                    tt_cxy_pair(device->id(), expected_sender_virtual),
+                    sender_state_addr);
+            const auto* sender_state = reinterpret_cast<const DramSenderStateBlock*>(sender_state_bytes.data());
+            EXPECT_EQ(sender_state->num_receivers, 1u);
+            const auto* receiver_xy =
+                reinterpret_cast<const uint32_t*>(sender_state_bytes.data() + sizeof(DramSenderStateBlock));
+            EXPECT_EQ(receiver_xy[0], expected_receiver_phys.x)
+                << "device " << device->id() << ", sender role " << sender_role;
+            EXPECT_EQ(receiver_xy[1], expected_receiver_phys.y)
+                << "device " << device->id() << ", sender role " << sender_role;
+        }
+    }
+}
 
 TEST_F(DramSenderGCBFixture, SmokeOneSenderFourReceivers) {
     // Layout: 4 receivers, each receives one 64-byte page.

--- a/tests/tt_metal/tt_metal/api/test_dram_subchannel_helper.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_subchannel_helper.cpp
@@ -66,12 +66,10 @@ TEST_F(DramSubchannelHelperFixture, PicksUnreservedSubchannelPerBank) {
     }
 }
 
-// A logical DRAM coord's y is an index into dram_bank_endpoint_coords, and that table is ordered by
-// endpoint role: the NOC0 worker endpoint, then the NOC1 worker endpoint when it is a different
-// subchannel, then the bank's remaining subchannels ascending. The role ordering is what lets one
-// logical sender coord mean the same thing on every device in a mesh: which raw subchannel serves
-// which role is fixed per descriptor entry, but DRAM harvesting shifts which entry a bank maps to,
-// so a subchannel-ordered y would name a different role from one device to the next.
+// Pins the ordering contract documented on metal_SocDescriptor::dram_bank_endpoint_coords: y=0 is
+// the NOC0 worker endpoint, y=1 the NOC1 worker endpoint when that is a different subchannel, then
+// the bank's remaining subchannels ascending. That role ordering is what lets one logical sender
+// coord mean the same thing on every device in a mesh.
 TEST_F(DramSubchannelHelperFixture, LogicalSubchannelOrderFollowsEndpointRole) {
     auto mesh_device = devices_[0];
     auto* device = mesh_device->get_devices()[0];
@@ -82,40 +80,33 @@ TEST_F(DramSubchannelHelperFixture, LogicalSubchannelOrderFollowsEndpointRole) {
     ASSERT_GT(num_banks, 0u);
 
     for (uint32_t bank = 0; bank < num_banks; ++bank) {
-        const auto& endpoints = soc_desc.dram_bank_endpoint_coords.at(bank);
-        ASSERT_EQ(endpoints.size(), num_subchannels) << "bank " << bank;
-
+        SCOPED_TRACE(fmt::format("bank {}", bank));
         const CoreCoord noc0_endpoint = soc_desc.get_preferred_worker_core_for_dram_view(static_cast<int>(bank), 0);
         const CoreCoord noc1_endpoint = soc_desc.get_preferred_worker_core_for_dram_view(static_cast<int>(bank), 1);
-        EXPECT_EQ(endpoints[0], noc0_endpoint) << "bank " << bank << ": y=0 must be the NOC0 worker endpoint";
-        const uint32_t num_role_entries = (noc1_endpoint == noc0_endpoint) ? 1 : 2;
-        if (num_role_entries == 2) {
-            EXPECT_EQ(endpoints[1], noc1_endpoint) << "bank " << bank << ": y=1 must be the NOC1 worker endpoint";
+
+        // Rebuild the table the contract calls for -- role-named entries first, then the leftover
+        // subchannels ascending -- and compare it whole, rather than re-deriving each entry's
+        // subchannel index and re-checking the ordering rule piecewise.
+        const size_t channel = soc_desc.get_channel_for_dram_view(static_cast<int>(bank));
+        std::vector<CoreCoord> subchannel_coords;
+        subchannel_coords.reserve(num_subchannels);
+        for (uint32_t sub = 0; sub < num_subchannels; ++sub) {
+            const tt::umd::CoreCoord coord = soc_desc.get_dram_core_for_channel(
+                static_cast<int>(channel), static_cast<int>(sub), tt::CoordSystem::TRANSLATED);
+            subchannel_coords.push_back({coord.x, coord.y});
         }
 
-        // The entries past the role-named ones are the leftover subchannels, ascending.
-        const size_t channel = soc_desc.get_channel_for_dram_view(static_cast<int>(bank));
-        uint32_t prev_subchannel = 0;
-        bool have_prev = false;
-        for (uint32_t idx = num_role_entries; idx < num_subchannels; ++idx) {
-            uint32_t subchannel = num_subchannels;
-            for (uint32_t sub = 0; sub < num_subchannels; ++sub) {
-                const tt::umd::CoreCoord coord = soc_desc.get_dram_core_for_channel(
-                    static_cast<int>(channel), static_cast<int>(sub), tt::CoordSystem::TRANSLATED);
-                if (CoreCoord{coord.x, coord.y} == endpoints[idx]) {
-                    subchannel = sub;
-                    break;
-                }
-            }
-            ASSERT_LT(subchannel, num_subchannels) << "bank " << bank << ", y=" << idx << " is not a subchannel";
-            EXPECT_NE(endpoints[idx], noc0_endpoint) << "bank " << bank << ", y=" << idx;
-            EXPECT_NE(endpoints[idx], noc1_endpoint) << "bank " << bank << ", y=" << idx;
-            if (have_prev) {
-                EXPECT_GT(subchannel, prev_subchannel) << "bank " << bank << ", y=" << idx << " is out of order";
-            }
-            prev_subchannel = subchannel;
-            have_prev = true;
+        std::vector<CoreCoord> expected{noc0_endpoint};
+        if (noc1_endpoint != noc0_endpoint) {
+            expected.push_back(noc1_endpoint);
         }
+        for (const CoreCoord& coord : subchannel_coords) {
+            if (coord != noc0_endpoint && coord != noc1_endpoint) {
+                expected.push_back(coord);
+            }
+        }
+        ASSERT_EQ(expected.size(), num_subchannels) << "the NOC endpoints are not subchannels of their own bank";
+        EXPECT_EQ(soc_desc.dram_bank_endpoint_coords.at(bank), expected);
     }
 }
 

--- a/tests/tt_metal/tt_metal/api/test_dram_subchannel_helper.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_subchannel_helper.cpp
@@ -66,10 +66,12 @@ TEST_F(DramSubchannelHelperFixture, PicksUnreservedSubchannelPerBank) {
     }
 }
 
-// Pins the ordering contract documented on metal_SocDescriptor::dram_bank_endpoint_coords: y=0 is
-// the NOC0 worker endpoint, y=1 the NOC1 worker endpoint when that is a different subchannel, then
-// the bank's remaining subchannels ascending. That role ordering is what lets one logical sender
-// coord mean the same thing on every device in a mesh.
+// A DRAM sender mapping is resolved against one device and then reused for the whole mesh, which
+// only holds while a logical y names the same endpoint role on every bank and every device. That is
+// the property to hold the descriptor to -- not the order it happens to build the table in: y=0 the
+// syseng-owned NOC0 worker endpoint, y=1 the NOC1 worker endpoint, and the free subchannels a
+// sender may actually run on above both. dram_sender_logical_cores enforces the same invariant at
+// runtime.
 TEST_F(DramSubchannelHelperFixture, LogicalSubchannelOrderFollowsEndpointRole) {
     auto mesh_device = devices_[0];
     auto* device = mesh_device->get_devices()[0];
@@ -78,35 +80,44 @@ TEST_F(DramSubchannelHelperFixture, LogicalSubchannelOrderFollowsEndpointRole) {
     const uint32_t num_banks = soc_desc.get_num_dram_views();
     const uint32_t num_subchannels = soc_desc.get_grid_size(tt::CoreType::DRAM).y;
     ASSERT_GT(num_banks, 0u);
+    ASSERT_GT(num_subchannels, 2u) << "a bank needs a subchannel beyond its two worker endpoints to host a sender";
 
     for (uint32_t bank = 0; bank < num_banks; ++bank) {
         SCOPED_TRACE(fmt::format("bank {}", bank));
         const CoreCoord noc0_endpoint = soc_desc.get_preferred_worker_core_for_dram_view(static_cast<int>(bank), 0);
         const CoreCoord noc1_endpoint = soc_desc.get_preferred_worker_core_for_dram_view(static_cast<int>(bank), 1);
+        const auto& endpoints = soc_desc.dram_bank_endpoint_coords.at(bank);
 
-        // Rebuild the table the contract calls for -- role-named entries first, then the leftover
-        // subchannels ascending -- and compare it whole, rather than re-deriving each entry's
-        // subchannel index and re-checking the ordering rule piecewise.
+        // The table renames this bank's subchannels; it must not drop, duplicate, or invent one.
         const size_t channel = soc_desc.get_channel_for_dram_view(static_cast<int>(bank));
-        std::vector<CoreCoord> subchannel_coords;
-        subchannel_coords.reserve(num_subchannels);
+        std::set<std::pair<size_t, size_t>> subchannel_coords;
         for (uint32_t sub = 0; sub < num_subchannels; ++sub) {
             const tt::umd::CoreCoord coord = soc_desc.get_dram_core_for_channel(
                 static_cast<int>(channel), static_cast<int>(sub), tt::CoordSystem::TRANSLATED);
-            subchannel_coords.push_back({coord.x, coord.y});
+            subchannel_coords.emplace(coord.x, coord.y);
         }
+        std::set<std::pair<size_t, size_t>> table_coords;
+        for (const CoreCoord& coord : endpoints) {
+            table_coords.emplace(coord.x, coord.y);
+        }
+        ASSERT_EQ(endpoints.size(), num_subchannels);
+        EXPECT_EQ(table_coords, subchannel_coords) << "the table is not a permutation of the bank's subchannels";
 
-        std::vector<CoreCoord> expected{noc0_endpoint};
-        if (noc1_endpoint != noc0_endpoint) {
-            expected.push_back(noc1_endpoint);
-        }
-        for (const CoreCoord& coord : subchannel_coords) {
-            if (coord != noc0_endpoint && coord != noc1_endpoint) {
-                expected.push_back(coord);
-            }
-        }
-        ASSERT_EQ(expected.size(), num_subchannels) << "the NOC endpoints are not subchannels of their own bank";
-        EXPECT_EQ(soc_desc.dram_bank_endpoint_coords.at(bank), expected);
+        // Roles sit at fixed logical y. The NOC0/NOC1 split is what keeps them there: a descriptor
+        // naming one subchannel for both NOCs would let the free and NOC1 roles trade places
+        // between devices, and a mesh-wide sender mapping would then drive the wrong DRISC core.
+        ASSERT_NE(noc1_endpoint, noc0_endpoint) << "bank's NOC0 and NOC1 worker endpoints must be distinct";
+        EXPECT_EQ(endpoints.at(0), noc0_endpoint) << "logical y=0 must be the NOC0 worker endpoint";
+        EXPECT_EQ(endpoints.at(1), noc1_endpoint) << "logical y=1 must be the NOC1 worker endpoint";
+
+        // A sender only ever runs on a subchannel above the endpoints, on every bank alike.
+        const CoreCoord free_logical = mesh_device->impl().pick_unused_dram_logical_core(device, bank);
+        EXPECT_EQ(free_logical.x, bank);
+        EXPECT_GE(free_logical.y, 2u) << "the free subchannel collides with a worker endpoint role";
+
+        // The two sender roles the prefetcher provisions are exactly [free, NOC1 endpoint].
+        const std::vector<CoreCoord> senders = mesh_device->impl().dram_sender_logical_cores(device, bank);
+        EXPECT_EQ(senders, (std::vector<CoreCoord>{free_logical, CoreCoord(bank, 1)}));
     }
 }
 

--- a/tests/tt_metal/tt_metal/api/test_dram_subchannel_helper.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_subchannel_helper.cpp
@@ -66,6 +66,59 @@ TEST_F(DramSubchannelHelperFixture, PicksUnreservedSubchannelPerBank) {
     }
 }
 
+// A logical DRAM coord's y is an index into dram_bank_endpoint_coords, and that table is ordered by
+// endpoint role: the NOC0 worker endpoint, then the NOC1 worker endpoint when it is a different
+// subchannel, then the bank's remaining subchannels ascending. The role ordering is what lets one
+// logical sender coord mean the same thing on every device in a mesh: which raw subchannel serves
+// which role is fixed per descriptor entry, but DRAM harvesting shifts which entry a bank maps to,
+// so a subchannel-ordered y would name a different role from one device to the next.
+TEST_F(DramSubchannelHelperFixture, LogicalSubchannelOrderFollowsEndpointRole) {
+    auto mesh_device = devices_[0];
+    auto* device = mesh_device->get_devices()[0];
+    const auto& soc_desc = MetalContext::instance().get_cluster().get_soc_desc(device->id());
+
+    const uint32_t num_banks = soc_desc.get_num_dram_views();
+    const uint32_t num_subchannels = soc_desc.get_grid_size(tt::CoreType::DRAM).y;
+    ASSERT_GT(num_banks, 0u);
+
+    for (uint32_t bank = 0; bank < num_banks; ++bank) {
+        const auto& endpoints = soc_desc.dram_bank_endpoint_coords.at(bank);
+        ASSERT_EQ(endpoints.size(), num_subchannels) << "bank " << bank;
+
+        const CoreCoord noc0_endpoint = soc_desc.get_preferred_worker_core_for_dram_view(static_cast<int>(bank), 0);
+        const CoreCoord noc1_endpoint = soc_desc.get_preferred_worker_core_for_dram_view(static_cast<int>(bank), 1);
+        EXPECT_EQ(endpoints[0], noc0_endpoint) << "bank " << bank << ": y=0 must be the NOC0 worker endpoint";
+        const uint32_t num_role_entries = (noc1_endpoint == noc0_endpoint) ? 1 : 2;
+        if (num_role_entries == 2) {
+            EXPECT_EQ(endpoints[1], noc1_endpoint) << "bank " << bank << ": y=1 must be the NOC1 worker endpoint";
+        }
+
+        // The entries past the role-named ones are the leftover subchannels, ascending.
+        const size_t channel = soc_desc.get_channel_for_dram_view(static_cast<int>(bank));
+        uint32_t prev_subchannel = 0;
+        bool have_prev = false;
+        for (uint32_t idx = num_role_entries; idx < num_subchannels; ++idx) {
+            uint32_t subchannel = num_subchannels;
+            for (uint32_t sub = 0; sub < num_subchannels; ++sub) {
+                const tt::umd::CoreCoord coord = soc_desc.get_dram_core_for_channel(
+                    static_cast<int>(channel), static_cast<int>(sub), tt::CoordSystem::TRANSLATED);
+                if (CoreCoord{coord.x, coord.y} == endpoints[idx]) {
+                    subchannel = sub;
+                    break;
+                }
+            }
+            ASSERT_LT(subchannel, num_subchannels) << "bank " << bank << ", y=" << idx << " is not a subchannel";
+            EXPECT_NE(endpoints[idx], noc0_endpoint) << "bank " << bank << ", y=" << idx;
+            EXPECT_NE(endpoints[idx], noc1_endpoint) << "bank " << bank << ", y=" << idx;
+            if (have_prev) {
+                EXPECT_GT(subchannel, prev_subchannel) << "bank " << bank << ", y=" << idx << " is out of order";
+            }
+            prev_subchannel = subchannel;
+            have_prev = true;
+        }
+    }
+}
+
 // get_metal_dram_cores(LOGICAL) must name the same cores as get_metal_dram_cores(TRANSLATED), which is
 // the set firmware init and watcher's mailbox init write to. Resolving the logical coords back through
 // the same path a caller uses is what catches a coordinate-space mismatch: UMD's logical DRAM coord is

--- a/tests/tt_metal/tt_metal/api/test_dram_subchannel_helper.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_subchannel_helper.cpp
@@ -55,7 +55,8 @@ TEST_F(DramSubchannelHelperFixture, PicksUnreservedSubchannelPerBank) {
 
         const CoreCoord expected_logical =
             soc_desc.get_logical_dram_core_for_subchannel(static_cast<int>(bank), static_cast<int>(expected_free));
-        const CoreCoord picked_logical = mesh_device->impl().pick_unused_dram_logical_core(bank);
+        const CoreCoord picked_logical =
+            mesh_device->impl().pick_unused_dram_logical_core(mesh_device->get_devices()[0], bank);
         EXPECT_EQ(picked_logical, expected_logical) << "Mismatch for bank " << bank;
 
         tt::umd::CoreCoord picked_coord = soc_desc.get_dram_core_for_channel(
@@ -116,7 +117,7 @@ TEST_F(DramSubchannelHelperFixture, RejectsOutOfRangeBank) {
     auto mesh_device = devices_[0];
     const auto& soc_desc = MetalContext::instance().get_cluster().get_soc_desc(mesh_device->get_device_ids()[0]);
     const uint32_t num_banks = soc_desc.get_num_dram_views();
-    EXPECT_ANY_THROW(mesh_device->impl().pick_unused_dram_logical_core(num_banks));
+    EXPECT_ANY_THROW(mesh_device->impl().pick_unused_dram_logical_core(mesh_device->get_devices()[0], num_banks));
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_global_circular_buffers.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_global_circular_buffers.cpp
@@ -89,12 +89,14 @@ TEST_F(MeshDispatchFixture, TensixProgramGlobalCircularBuffers) {
 
     for (const auto& [sender_core, receiver_cores] : sender_receiver_core_mapping) {
         auto sender_noc_coords = mesh_device->worker_core_from_logical_core(sender_core);
+        // Row-wise, to match how the GCB itself flattens each sender's receivers: a receiver's index
+        // in this vector is its credit slot, which orders the sender's NOC XY table.
+        const auto& receiver_cores_vec =
+            corerange_to_cores(receiver_cores, /*max_cores=*/std::nullopt, /*row_wise=*/true);
         std::vector<CoreCoord> receiver_noc_coords;
-        for (const auto& receiver_core_range : receiver_cores.ranges()) {
-            const auto& receiver_cores_vec = corerange_to_cores(receiver_core_range);
-            for (const auto& receiver_core : receiver_cores_vec) {
-                receiver_noc_coords.push_back(mesh_device->worker_core_from_logical_core(receiver_core));
-            }
+        receiver_noc_coords.reserve(receiver_cores_vec.size());
+        for (const auto& receiver_core : receiver_cores_vec) {
+            receiver_noc_coords.push_back(mesh_device->worker_core_from_logical_core(receiver_core));
         }
         std::vector<uint32_t> sender_runtime_args(11 + (receiver_noc_coords.size() * 2));
         uint32_t sender_args_idx = 0;

--- a/tests/ttnn/unit_tests/base_functionality/test_dram_sender_global_cb_py.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_dram_sender_global_cb_py.py
@@ -15,9 +15,7 @@ pytestmark = run_for_blackhole("DramSenderGCB requires Blackhole")
 def _require_tensor_prefetcher(device):
     """Skip unless programmable DRAM cores are available on this device."""
     if not ttnn.experimental.is_tensor_prefetcher_supported(device):
-        pytest.skip(
-            "programmable DRAM cores unavailable (need Blackhole, firmware >= 19.12.0.0, and either no harvested DRAM channels or a single device)"
-        )
+        pytest.skip("programmable DRAM cores unavailable (need Blackhole and firmware >= 19.12.0.0)")
 
 
 def _single_recv(x: int, y: int) -> ttnn.CoreRangeSet:

--- a/tests/ttnn/unit_tests/base_functionality/test_dram_sender_global_cb_py.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_dram_sender_global_cb_py.py
@@ -6,6 +6,7 @@ import pytest
 import ttnn
 
 from models.common.utility_functions import run_for_blackhole
+from tests.ttnn.unit_tests.operations.prefetcher_common import require_tensor_prefetcher
 
 
 pytestmark = run_for_blackhole("DramSenderGCB requires Blackhole")
@@ -13,9 +14,7 @@ pytestmark = run_for_blackhole("DramSenderGCB requires Blackhole")
 
 @pytest.fixture(autouse=True)
 def _require_tensor_prefetcher(device):
-    """Skip unless programmable DRAM cores are available on this device."""
-    if not ttnn.experimental.is_tensor_prefetcher_supported(device):
-        pytest.skip("programmable DRAM cores unavailable (need Blackhole and firmware >= 19.12.0.0)")
+    require_tensor_prefetcher(device)
 
 
 def _single_recv(x: int, y: int) -> ttnn.CoreRangeSet:

--- a/tests/ttnn/unit_tests/base_functionality/test_dram_sender_global_cb_py.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_dram_sender_global_cb_py.py
@@ -6,7 +6,7 @@ import pytest
 import ttnn
 
 from models.common.utility_functions import run_for_blackhole
-from tests.ttnn.unit_tests.operations.prefetcher_common import require_tensor_prefetcher
+from tests.ttnn.unit_tests.operations.prefetcher_support import require_tensor_prefetcher
 
 
 pytestmark = run_for_blackhole("DramSenderGCB requires Blackhole")

--- a/tests/ttnn/unit_tests/operations/prefetcher_common.py
+++ b/tests/ttnn/unit_tests/operations/prefetcher_common.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import contextlib
-import pytest
 import torch
 import ttnn
 import math
@@ -24,6 +23,10 @@ from tests.ttnn.nightly.unit_tests.operations.matmul.test_matmul_1d_gather_in0 i
 )
 from tracy import signpost
 from models.demos.llama3_70b_galaxy.tt.prefetcher_common import get_core_ranges
+
+# Re-exported so the existing callers keep importing it from here; it lives in a leaf
+# module so tests that only need the skip gate can avoid this file's import chain.
+from tests.ttnn.unit_tests.operations.prefetcher_support import require_tensor_prefetcher
 
 
 def round_up(n, m):
@@ -114,12 +117,6 @@ def make_recv_contig_weight(
     )
     mem_config = ttnn.MemoryConfig(ttnn.BufferType.DRAM, nd_shard)
     return ttnn.as_tensor(pt_weight, device=device, dtype=dtype, memory_config=mem_config, layout=ttnn.TILE_LAYOUT)
-
-
-def require_tensor_prefetcher(device):
-    """Skip unless programmable DRAM cores are available on this device."""
-    if not ttnn.experimental.is_tensor_prefetcher_supported(device):
-        pytest.skip("programmable DRAM cores unavailable (need Blackhole and firmware >= 19.12.0.0)")
 
 
 @contextlib.contextmanager

--- a/tests/ttnn/unit_tests/operations/prefetcher_common.py
+++ b/tests/ttnn/unit_tests/operations/prefetcher_common.py
@@ -116,6 +116,12 @@ def make_recv_contig_weight(
     return ttnn.as_tensor(pt_weight, device=device, dtype=dtype, memory_config=mem_config, layout=ttnn.TILE_LAYOUT)
 
 
+def require_tensor_prefetcher(device):
+    """Skip unless programmable DRAM cores are available on this device."""
+    if not ttnn.experimental.is_tensor_prefetcher_supported(device):
+        pytest.skip("programmable DRAM cores unavailable (need Blackhole and firmware >= 19.12.0.0)")
+
+
 @contextlib.contextmanager
 def tensor_prefetcher_session(device):
     """Open a Tensor prefetcher Start/Stop window. Stop (and a device sync)

--- a/tests/ttnn/unit_tests/operations/prefetcher_support.py
+++ b/tests/ttnn/unit_tests/operations/prefetcher_support.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Leaf helpers for gating tests on tensor-prefetcher support.
+
+Kept free of model/tracy/nightly-test imports so a test that only needs the skip
+gate does not pull in prefetcher_common's dependency chain at collection time.
+"""
+
+import pytest
+import ttnn
+
+
+def require_tensor_prefetcher(device):
+    """Skip unless programmable DRAM cores are available on this device."""
+    if not ttnn.experimental.is_tensor_prefetcher_supported(device):
+        pytest.skip("programmable DRAM cores unavailable (need Blackhole and firmware >= 19.12.0.0)")

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH.py
@@ -30,6 +30,7 @@ from models.tt_transformers.tt.prefetcher import (
 )
 from models.tt_transformers.tt.common import Mode
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
+from tests.ttnn.unit_tests.operations.prefetcher_common import tensor_prefetcher_session
 
 
 def round_up(n, multiple):
@@ -581,6 +582,66 @@ def run_prefetcher_all_matmuls(
 # =============================================================================
 # Test Cases
 # =============================================================================
+@pytest.mark.skipif(not is_blackhole(), reason="This test only runs on Blackhole")
+@pytest.mark.parametrize("mesh_device", [(1, 2)], indirect=True)
+def test_tensor_prefetcher_multichip_dram_harvesting(mesh_device):
+    """Minimal public-API data-flow test for per-device harvested DRAM sender placement."""
+    if not ttnn.experimental.is_tensor_prefetcher_supported(mesh_device):
+        pytest.skip("programmable DRAM cores unavailable (need Blackhole and firmware >= 19.12.0.0)")
+
+    num_dram_banks = mesh_device.dram_grid_size().x
+    ring_size = num_dram_banks
+    K = 448
+    K_padded = round_up(K, ring_size * ttnn.TILE_SIZE)
+    n_tiles_per_receiver = 8
+    N = num_dram_banks * n_tiles_per_receiver * ttnn.TILE_SIZE
+    k_block_w_tiles = (K_padded // ttnn.TILE_SIZE) // ring_size
+    push_page_size = k_block_w_tiles * n_tiles_per_receiver * 2048  # bfloat16 tile bytes
+
+    torch.manual_seed(0xC0FFEE)
+    pt_weight = torch.zeros(1, 1, K_padded, N)
+    pt_weight[:, :, :K, :] = torch.randn(1, 1, K, N)
+    dram_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_dram_banks - 1, 0))})
+    weight_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.DRAM,
+        ttnn.ShardSpec(
+            dram_grid,
+            [K_padded, N // num_dram_banks],
+            ttnn.ShardOrientation.ROW_MAJOR,
+        ),
+    )
+    tt_weight = ttnn.as_tensor(
+        pt_weight,
+        device=mesh_device,
+        dtype=ttnn.bfloat16,
+        memory_config=weight_mem_config,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+    bank_to_receivers = [
+        (
+            bank,
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(bank, 0), ttnn.CoreCoord(bank, 0))}),
+        )
+        for bank in range(num_dram_banks)
+    ]
+    gcb = ttnn.experimental.create_global_circular_buffer_with_dram_senders(
+        mesh_device, bank_to_receivers, 4 * push_page_size
+    )
+
+    with tensor_prefetcher_session(mesh_device):
+        ttnn.experimental.queue_tensor_prefetcher_request(mesh_device, [(tt_weight, ring_size)], global_cb=gcb)
+        ttnn.experimental.test_dram_prefetcher_validator(
+            mesh_device,
+            tt_weight,
+            num_layers=1,
+            print_stride=max(1, ring_size // 4),
+            global_cb=gcb,
+        )
+
+
 @pytest.mark.skipif(not is_blackhole(), reason="This test only runs on Blackhole")
 @pytest.mark.parametrize("enable_trace", [True])
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH.py
@@ -30,7 +30,13 @@ from models.tt_transformers.tt.prefetcher import (
 )
 from models.tt_transformers.tt.common import Mode
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
-from tests.ttnn.unit_tests.operations.prefetcher_common import tensor_prefetcher_session
+from tests.ttnn.unit_tests.operations.prefetcher_common import (
+    bank_receivers_contiguous,
+    bytes_per_tile,
+    require_tensor_prefetcher,
+    ring_grid_cols,
+    tensor_prefetcher_session,
+)
 
 
 def round_up(n, multiple):
@@ -587,18 +593,15 @@ def run_prefetcher_all_matmuls(
 def test_tensor_prefetcher_multichip_dram_harvesting(mesh_device):
     """Minimal public-API data-flow test for per-device harvested DRAM sender placement.
 
-    This drives the prefetcher across a two-device mesh and validates the delivered bytes on
-    every device. Whether it distinguishes per-device sender translation from the mesh-wide
-    reference translation it replaced depends on the silicon: a pair of devices with identical
-    DRAM harvest masks resolves every bank to the same physical sender on both, so this passes
-    either way. The discriminating check -- comparing each bank's resolved sender across the mesh
-    and reporting when the pair is homogeneous -- lives in the C++ regression
-    (DramSenderGCBMultiDeviceFixture.ConfigAndSenderStateUsePerDeviceDramTopology), which can
-    reach the per-device SOC descriptors that are not exposed to Python.
+    Drives the prefetcher across a two-device mesh and validates the delivered bytes on every
+    device. The discriminating check -- comparing each bank's resolved sender across the mesh, and
+    reporting when the device pair is too homogeneous to tell the paths apart -- needs the
+    per-device SOC descriptors, which Python cannot reach; it lives in the C++ regression
+    DramSenderGCBMultiDeviceFixture.ConfigAndSenderStateUsePerDeviceDramTopology.
     """
-    if not ttnn.experimental.is_tensor_prefetcher_supported(mesh_device):
-        pytest.skip("programmable DRAM cores unavailable (need Blackhole and firmware >= 19.12.0.0)")
+    require_tensor_prefetcher(mesh_device)
 
+    dtype = ttnn.bfloat16
     num_dram_banks = mesh_device.dram_grid_size().x
     ring_size = num_dram_banks
     K = 448
@@ -606,7 +609,7 @@ def test_tensor_prefetcher_multichip_dram_harvesting(mesh_device):
     n_tiles_per_receiver = 8
     N = num_dram_banks * n_tiles_per_receiver * ttnn.TILE_SIZE
     k_block_w_tiles = (K_padded // ttnn.TILE_SIZE) // ring_size
-    push_page_size = k_block_w_tiles * n_tiles_per_receiver * 2048  # bfloat16 tile bytes
+    push_page_size = k_block_w_tiles * n_tiles_per_receiver * bytes_per_tile(dtype)
 
     torch.manual_seed(0xC0FFEE)
     pt_weight = torch.zeros(1, 1, K_padded, N)
@@ -624,17 +627,14 @@ def test_tensor_prefetcher_multichip_dram_harvesting(mesh_device):
     tt_weight = ttnn.as_tensor(
         pt_weight,
         device=mesh_device,
-        dtype=ttnn.bfloat16,
+        dtype=dtype,
         memory_config=weight_mem_config,
         layout=ttnn.TILE_LAYOUT,
         mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
     )
 
     bank_to_receivers = [
-        (
-            bank,
-            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(bank, 0), ttnn.CoreCoord(bank, 0))}),
-        )
+        (bank, bank_receivers_contiguous(bank, recv_per_bank=1, ring_cols=ring_grid_cols(num_dram_banks, ring_size)))
         for bank in range(num_dram_banks)
     ]
     gcb = ttnn.experimental.create_global_circular_buffer_for_tensor_prefetcher(

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH.py
@@ -585,7 +585,17 @@ def run_prefetcher_all_matmuls(
 @pytest.mark.skipif(not is_blackhole(), reason="This test only runs on Blackhole")
 @pytest.mark.parametrize("mesh_device", [(1, 2)], indirect=True)
 def test_tensor_prefetcher_multichip_dram_harvesting(mesh_device):
-    """Minimal public-API data-flow test for per-device harvested DRAM sender placement."""
+    """Minimal public-API data-flow test for per-device harvested DRAM sender placement.
+
+    This drives the prefetcher across a two-device mesh and validates the delivered bytes on
+    every device. Whether it distinguishes per-device sender translation from the mesh-wide
+    reference translation it replaced depends on the silicon: a pair of devices with identical
+    DRAM harvest masks resolves every bank to the same physical sender on both, so this passes
+    either way. The discriminating check -- comparing each bank's resolved sender across the mesh
+    and reporting when the pair is homogeneous -- lives in the C++ regression
+    (DramSenderGCBMultiDeviceFixture.ConfigAndSenderStateUsePerDeviceDramTopology), which can
+    reach the per-device SOC descriptors that are not exposed to Python.
+    """
     if not ttnn.experimental.is_tensor_prefetcher_supported(mesh_device):
         pytest.skip("programmable DRAM cores unavailable (need Blackhole and firmware >= 19.12.0.0)")
 
@@ -627,7 +637,7 @@ def test_tensor_prefetcher_multichip_dram_harvesting(mesh_device):
         )
         for bank in range(num_dram_banks)
     ]
-    gcb = ttnn.experimental.create_global_circular_buffer_with_dram_senders(
+    gcb = ttnn.experimental.create_global_circular_buffer_for_tensor_prefetcher(
         mesh_device, bank_to_receivers, 4 * push_page_size
     )
 

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bench.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bench.py
@@ -64,9 +64,7 @@ pytestmark = run_for_blackhole("Tensor prefetcher requires Blackhole")
 def _require_tensor_prefetcher(device):
     """Skip unless programmable DRAM cores are available on this device."""
     if not ttnn.experimental.is_tensor_prefetcher_supported(device):
-        pytest.skip(
-            "programmable DRAM cores unavailable (need Blackhole, firmware >= 19.12.0.0, and either no harvested DRAM channels or a single device)"
-        )
+        pytest.skip("programmable DRAM cores unavailable (need Blackhole and firmware >= 19.12.0.0)")
 
 
 def _select_num_dram_banks(available_banks: int) -> int:

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bench.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bench.py
@@ -54,6 +54,7 @@ from tests.ttnn.unit_tests.operations.prefetcher_common import (
     round_up as _round_up,
     ring_grid_cols as _ring_grid_cols,
     make_recv_contig_weight as _make_recv_contig_weight,
+    require_tensor_prefetcher,
 )
 
 
@@ -62,9 +63,7 @@ pytestmark = run_for_blackhole("Tensor prefetcher requires Blackhole")
 
 @pytest.fixture(autouse=True)
 def _require_tensor_prefetcher(device):
-    """Skip unless programmable DRAM cores are available on this device."""
-    if not ttnn.experimental.is_tensor_prefetcher_supported(device):
-        pytest.skip("programmable DRAM cores unavailable (need Blackhole and firmware >= 19.12.0.0)")
+    require_tensor_prefetcher(device)
 
 
 def _select_num_dram_banks(available_banks: int) -> int:

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bw_bench.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bw_bench.py
@@ -62,9 +62,7 @@ pytestmark = run_for_blackhole("Tensor prefetcher requires Blackhole")
 def _require_tensor_prefetcher(device):
     """Skip unless programmable DRAM cores are available on this device."""
     if not ttnn.experimental.is_tensor_prefetcher_supported(device):
-        pytest.skip(
-            "programmable DRAM cores unavailable (need Blackhole, firmware >= 19.12.0.0, and either no harvested DRAM channels or a single device)"
-        )
+        pytest.skip("programmable DRAM cores unavailable (need Blackhole and firmware >= 19.12.0.0)")
 
 
 _NUM_DRAM_BANKS = 8

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bw_bench.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bw_bench.py
@@ -52,6 +52,7 @@ from models.common.utility_functions import run_for_blackhole
 from tests.ttnn.unit_tests.operations.prefetcher_common import (
     round_up as _round_up,
     make_recv_contig_weight as _make_recv_contig_weight,
+    require_tensor_prefetcher,
 )
 
 
@@ -60,9 +61,7 @@ pytestmark = run_for_blackhole("Tensor prefetcher requires Blackhole")
 
 @pytest.fixture(autouse=True)
 def _require_tensor_prefetcher(device):
-    """Skip unless programmable DRAM cores are available on this device."""
-    if not ttnn.experimental.is_tensor_prefetcher_supported(device):
-        pytest.skip("programmable DRAM cores unavailable (need Blackhole and firmware >= 19.12.0.0)")
+    require_tensor_prefetcher(device)
 
 
 _NUM_DRAM_BANKS = 8

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_tensor_large.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_tensor_large.py
@@ -79,9 +79,7 @@ pytestmark = run_for_blackhole("Tensor prefetcher requires Blackhole")
 def _require_tensor_prefetcher(device):
     """Skip unless programmable DRAM cores are available on this device."""
     if not ttnn.experimental.is_tensor_prefetcher_supported(device):
-        pytest.skip(
-            "programmable DRAM cores unavailable (need Blackhole, firmware >= 19.12.0.0, and either no harvested DRAM channels or a single device)"
-        )
+        pytest.skip("programmable DRAM cores unavailable (need Blackhole and firmware >= 19.12.0.0)")
 
 
 def _bank_receivers_row_major(bank_idx: int, recv_per_bank: int, ring_cols: int):

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_tensor_large.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_tensor_large.py
@@ -80,9 +80,7 @@ pytestmark = run_for_blackhole("Tensor prefetcher requires Blackhole")
 def _require_tensor_prefetcher(device):
     """Skip unless programmable DRAM cores are available on this device."""
     if not ttnn.experimental.is_tensor_prefetcher_supported(device):
-        pytest.skip(
-            "programmable DRAM cores unavailable (need Blackhole, firmware >= 19.12.0.0, and either no harvested DRAM channels or a single device)"
-        )
+        pytest.skip("programmable DRAM cores unavailable (need Blackhole and firmware >= 19.12.0.0)")
 
 
 def _bank_receivers_row_major(bank_idx: int, recv_per_bank: int, ring_cols: int):

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_tensor_large.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_tensor_large.py
@@ -62,6 +62,7 @@ from tests.ttnn.unit_tests.operations.prefetcher_common import (
     bank_receivers_contiguous as _bank_receivers_contiguous,
     make_recv_contig_weight as _make_recv_contig_weight,
     tensor_prefetcher_session,
+    require_tensor_prefetcher,
 )
 
 
@@ -78,9 +79,7 @@ pytestmark = run_for_blackhole("Tensor prefetcher requires Blackhole")
 
 @pytest.fixture(autouse=True)
 def _require_tensor_prefetcher(device):
-    """Skip unless programmable DRAM cores are available on this device."""
-    if not ttnn.experimental.is_tensor_prefetcher_supported(device):
-        pytest.skip("programmable DRAM cores unavailable (need Blackhole and firmware >= 19.12.0.0)")
+    require_tensor_prefetcher(device)
 
 
 def _bank_receivers_row_major(bank_idx: int, recv_per_bank: int, ring_cols: int):

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_validator.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_validator.py
@@ -36,9 +36,7 @@ pytestmark = run_for_blackhole("Tensor prefetcher requires Blackhole")
 def _require_tensor_prefetcher(device):
     """Skip unless programmable DRAM cores are available on this device."""
     if not ttnn.experimental.is_tensor_prefetcher_supported(device):
-        pytest.skip(
-            "programmable DRAM cores unavailable (need Blackhole, firmware >= 19.12.0.0, and either no harvested DRAM channels or a single device)"
-        )
+        pytest.skip("programmable DRAM cores unavailable (need Blackhole and firmware >= 19.12.0.0)")
 
 
 _GCB_DEPTH_PAGES = 4  # small ring so the validator stresses reserve_back/wait_front handshakes

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_validator.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_validator.py
@@ -26,6 +26,7 @@ from tests.ttnn.unit_tests.operations.prefetcher_common import (
     bank_receivers_contiguous as _bank_receivers_contiguous,
     make_recv_contig_weight as _make_recv_contig_weight,
     tensor_prefetcher_session,
+    require_tensor_prefetcher,
 )
 
 
@@ -34,9 +35,7 @@ pytestmark = run_for_blackhole("Tensor prefetcher requires Blackhole")
 
 @pytest.fixture(autouse=True)
 def _require_tensor_prefetcher(device):
-    """Skip unless programmable DRAM cores are available on this device."""
-    if not ttnn.experimental.is_tensor_prefetcher_supported(device):
-        pytest.skip("programmable DRAM cores unavailable (need Blackhole and firmware >= 19.12.0.0)")
+    require_tensor_prefetcher(device)
 
 
 _GCB_DEPTH_PAGES = 4  # small ring so the validator stresses reserve_back/wait_front handshakes

--- a/tt_metal/api/tt-metalium/experimental/tensor_prefetcher.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor_prefetcher.hpp
@@ -37,10 +37,9 @@ class GlobalCircularBuffer;
 struct TensorPrefetcherConfig {};
 
 // Returns true if the Tensor prefetcher is supported on `mesh_device`, i.e.
-// programmable DRAM cores are available (Blackhole with firmware >= 19.12.0.0 and
-// either no harvested DRAM channels or a single device). When this returns false,
-// StartTensorPrefetcher would TT_FATAL, so callers (e.g. tests) can use this
-// to skip rather than fail.
+// programmable DRAM cores are available (Blackhole with firmware >= 19.12.0.0).
+// When this returns false, StartTensorPrefetcher would TT_FATAL, so callers
+// (e.g. tests) can use this to skip rather than fail.
 bool IsTensorPrefetcherSupported(const distributed::MeshDevice& mesh_device);
 
 // One prefetch work item: a weight tensor plus the number of K-blocks to split
@@ -98,7 +97,7 @@ struct TensorPrefetcherInput {
 // Preconditions (TT_FATAL):
 //   - No other prefetcher is currently active on this mesh device.
 //   - DRAM programmable cores are available on this mesh (Blackhole with firmware
-//     >= 19.12.0.0 and either no harvested DRAM channels or a single device).
+//     >= 19.12.0.0).
 void StartTensorPrefetcher(distributed::MeshDevice& mesh_device, const TensorPrefetcherConfig& config);
 
 // Queue one prefetch request. Non-blocking.

--- a/tt_metal/api/tt-metalium/experimental/tensor_prefetcher.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor_prefetcher.hpp
@@ -38,10 +38,9 @@ class GlobalCircularBuffer;
 struct TensorPrefetcherConfig {};
 
 // Returns true if the Tensor prefetcher is supported on `mesh_device`, i.e.
-// programmable DRAM cores are available (Blackhole with firmware >= 19.12.0.0 and
-// either no harvested DRAM channels or a single device). When this returns false,
-// StartTensorPrefetcher would TT_FATAL, so callers (e.g. tests) can use this
-// to skip rather than fail.
+// programmable DRAM cores are available (Blackhole with firmware >= 19.12.0.0).
+// When this returns false, StartTensorPrefetcher would TT_FATAL, so callers
+// (e.g. tests) can use this to skip rather than fail.
 bool IsTensorPrefetcherSupported(const distributed::MeshDevice& mesh_device);
 
 // One prefetch work item: a weight tensor plus the number of K-blocks to split
@@ -99,7 +98,7 @@ struct TensorPrefetcherInput {
 // Preconditions (TT_FATAL):
 //   - No other prefetcher is currently active on this mesh device.
 //   - DRAM programmable cores are available on this mesh (Blackhole with firmware
-//     >= 19.12.0.0 and either no harvested DRAM channels or a single device).
+//     >= 19.12.0.0).
 void StartTensorPrefetcher(distributed::MeshDevice& mesh_device, const TensorPrefetcherConfig& config);
 
 // Queue one prefetch request. Non-blocking.

--- a/tt_metal/api/tt-metalium/global_circular_buffer.hpp
+++ b/tt_metal/api/tt-metalium/global_circular_buffer.hpp
@@ -64,7 +64,10 @@ public:
     }
 
 private:
-    void setup_cb_buffers(BufferType buffer_type, uint32_t max_num_receivers_per_sender);
+    void setup_cb_buffers(
+        BufferType buffer_type,
+        uint32_t max_num_receivers_per_sender,
+        distributed::MeshDevice* dram_sender_mesh_device = nullptr);
     // Allocates and writes the per-GCB sender state block in DRISC L1. DRAM-sender flavour only.
     void initialize_dram_sender_state_block(
         distributed::MeshDevice* mesh_device, uint32_t max_num_receivers_per_sender);

--- a/tt_metal/api/tt-metalium/global_circular_buffer.hpp
+++ b/tt_metal/api/tt-metalium/global_circular_buffer.hpp
@@ -64,10 +64,13 @@ public:
     }
 
 private:
+    // `dram_sender_mesh_device` is required for the DRAM-sender flavour (it drives per-device
+    // sender placement) and must be null for the worker flavour. No default: both callers name
+    // the mode they mean.
     void setup_cb_buffers(
         BufferType buffer_type,
         uint32_t max_num_receivers_per_sender,
-        distributed::MeshDevice* dram_sender_mesh_device = nullptr);
+        distributed::MeshDevice* dram_sender_mesh_device);
     // Allocates and writes the per-GCB sender state block in DRISC L1. DRAM-sender flavour only.
     void initialize_dram_sender_state_block(
         distributed::MeshDevice* mesh_device, uint32_t max_num_receivers_per_sender);

--- a/tt_metal/api/tt-metalium/global_circular_buffer.hpp
+++ b/tt_metal/api/tt-metalium/global_circular_buffer.hpp
@@ -64,13 +64,7 @@ public:
     }
 
 private:
-    // `dram_sender_mesh_device` is required for the DRAM-sender flavour (it drives per-device
-    // sender placement) and must be null for the worker flavour. No default: both callers name
-    // the mode they mean.
-    void setup_cb_buffers(
-        BufferType buffer_type,
-        uint32_t max_num_receivers_per_sender,
-        distributed::MeshDevice* dram_sender_mesh_device);
+    void setup_cb_buffers(BufferType buffer_type, uint32_t max_num_receivers_per_sender);
     // Allocates and writes the per-GCB sender state block in DRISC L1. DRAM-sender flavour only.
     void initialize_dram_sender_state_block(
         distributed::MeshDevice* mesh_device, uint32_t max_num_receivers_per_sender);
@@ -113,7 +107,10 @@ private:
     // survives multi-GCB request switching. Layout in
     // tt_metal/impl/buffers/dram_sender_state_block.hpp.
     DeviceAddr sender_state_drisc_l1_base_ = 0;
-    std::vector<std::vector<CoreCoord>> receiver_coords_per_sender_;
+    // Per sender, its receivers' logical coords in row-wise order (see the ctor for why row-wise).
+    // Logical, not physical: the physical worker coord depends on the device being addressed, and
+    // the DRAM-sender flavour spans a mesh whose devices need not agree.
+    std::vector<std::vector<CoreCoord>> receiver_logical_cores_per_sender_;
     // RAII handle for the combined pages_sent + sender-state-block allocation in the
     // per-mesh DriscL1Arena. Held via shared_ptr so copies of the GCB share the same
     // backing range; released when the last GCB copy goes out of scope. Empty for

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -167,8 +167,8 @@ void H2DSocket::init_data_buffer(const std::shared_ptr<MeshDevice>& mesh_device,
         DeviceAddr raw_addr = svc.allocate_l1(recv_device, recv_core_.core_coord, alloc_size);
         svc_data_l1_addr_ = raw_addr;
 
-        auto shard_params = ShardSpecBuffer(
-            CoreRangeSet(recv_core_.core_coord), {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {1, 1});
+        auto shard_params =
+            ShardSpecBuffer(CoreRangeSet(recv_core_.core_coord), {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {1, 1});
         DeviceLocalBufferConfig data_buffer_specs = {
             .page_size = static_cast<uint32_t>(alloc_size),
             .buffer_type = buffer_type_,
@@ -269,8 +269,9 @@ void H2DSocket::init_receiver_tlb(const std::shared_ptr<MeshDevice>& mesh_device
     const CoreType recv_umd_core_type = (recv_core_type_ == RecvCoreType::Dram) ? CoreType::DRAM : CoreType::TENSIX;
 
     if (mesh_device) {
-        recv_device_id = mesh_device->get_device(recv_core_.device_coord)->id();
-        recv_virtual_core = mesh_device->virtual_core_from_logical_core(recv_core_.core_coord, recv_umd_core_type);
+        IDevice* recv_device = mesh_device->get_device(recv_core_.device_coord);
+        recv_device_id = recv_device->id();
+        recv_virtual_core = recv_device->virtual_core_from_logical_core(recv_core_.core_coord, recv_umd_core_type);
     } else {
         recv_device_id = device_id.value();
         recv_virtual_core = cluster.get_virtual_coordinate_from_logical_coordinates(
@@ -565,8 +566,7 @@ void H2DSocket::set_page_size(uint32_t page_size) {
     // non-power-of-two (e.g. 2560 = 5×512 for some shard sizes), where
     // tt::align(5120, 2560) returns 7168 instead of 5120. Use modular
     // arithmetic so this works for any positive alignment.
-    uint32_t next_fifo_wr_ptr =
-        ((write_ptr_ + page_size - 1) / page_size) * page_size;
+    uint32_t next_fifo_wr_ptr = ((write_ptr_ + page_size - 1) / page_size) * page_size;
     uint32_t fifo_page_aligned_size = fifo_size_ - (fifo_size_ % page_size);
 
     if (next_fifo_wr_ptr >= fifo_page_aligned_size) {
@@ -705,9 +705,10 @@ std::unique_ptr<H2DSocket> H2DSocket::connect_from_descriptor(const HDSocketDesc
     socket->config_buffer_address_ = desc.config_buffer_address;
     socket->pcie_alignment_ = desc.pcie_alignment;
     // Must match the owner-side coord; empty mesh_coord (pre-mesh-coord descriptors) defaults to (0, 0).
-    MeshCoordinate device_coord = desc.mesh_coord.empty()
-        ? MeshCoordinate(0, 0)
-        : MeshCoordinate(ttsl::SmallVector<uint32_t>(desc.mesh_coord.begin(), desc.mesh_coord.end()));
+    MeshCoordinate device_coord =
+        desc.mesh_coord.empty()
+            ? MeshCoordinate(0, 0)
+            : MeshCoordinate(ttsl::SmallVector<uint32_t>(desc.mesh_coord.begin(), desc.mesh_coord.end()));
     socket->recv_core_ = MeshCoreCoord(device_coord, CoreCoord(desc.core_x, desc.core_y));
     socket->h2d_mode_ = static_cast<H2DMode>(desc.h2d_mode);
     socket->aligned_data_buf_start_ = desc.aligned_data_buf_start;

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -298,9 +298,9 @@ void H2DSocket::init_receiver_tlb(const std::shared_ptr<MeshDevice>& mesh_device
                                      ->get_tlb_window(tt_xy_pair(recv_virtual_core.x, recv_virtual_core.y));
         }
     } else if (mesh_device) {
-        // Per-device translation: a logical DRAM sender coord resolves to a different physical
-        // subchannel on devices with different DRAM harvest masks, so the mesh-level (reference
-        // device) translation would name the wrong DRISC core.
+        // Per-device translation (see metal_SocDescriptor::dram_bank_endpoint_coords): the
+        // mesh-level translation validates that every device agrees and throws when they do not,
+        // which a logical DRAM coord on a harvested mesh does not.
         IDevice* recv_device = mesh_device->get_device(recv_core_.device_coord);
         recv_device_id = recv_device->id();
         recv_virtual_core = recv_device->virtual_core_from_logical_core(recv_core_.core_coord, recv_umd_core_type);

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -180,8 +180,8 @@ void H2DSocket::init_data_buffer(const std::shared_ptr<MeshDevice>& mesh_device,
         DeviceAddr raw_addr = svc.allocate_l1(recv_device, recv_core_.core_coord, alloc_size);
         svc_data_l1_addr_ = raw_addr;
 
-        auto shard_params = ShardSpecBuffer(
-            CoreRangeSet(recv_core_.core_coord), {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {1, 1});
+        auto shard_params =
+            ShardSpecBuffer(CoreRangeSet(recv_core_.core_coord), {1, 1}, ShardOrientation::ROW_MAJOR, {1, 1}, {1, 1});
         DeviceLocalBufferConfig data_buffer_specs = {
             .page_size = static_cast<uint32_t>(alloc_size),
             .buffer_type = buffer_type_,
@@ -298,8 +298,12 @@ void H2DSocket::init_receiver_tlb(const std::shared_ptr<MeshDevice>& mesh_device
                                      ->get_tlb_window(tt_xy_pair(recv_virtual_core.x, recv_virtual_core.y));
         }
     } else if (mesh_device) {
-        recv_device_id = mesh_device->get_device(recv_core_.device_coord)->id();
-        recv_virtual_core = mesh_device->virtual_core_from_logical_core(recv_core_.core_coord, recv_umd_core_type);
+        // Per-device translation: a logical DRAM sender coord resolves to a different physical
+        // subchannel on devices with different DRAM harvest masks, so the mesh-level (reference
+        // device) translation would name the wrong DRISC core.
+        IDevice* recv_device = mesh_device->get_device(recv_core_.device_coord);
+        recv_device_id = recv_device->id();
+        recv_virtual_core = recv_device->virtual_core_from_logical_core(recv_core_.core_coord, recv_umd_core_type);
     } else {
         recv_device_id = device_id.value();
         recv_virtual_core = cluster.get_virtual_coordinate_from_logical_coordinates(
@@ -760,8 +764,7 @@ void H2DSocket::set_page_size(uint32_t page_size) {
     // non-power-of-two (e.g. 2560 = 5×512 for some shard sizes), where
     // tt::align(5120, 2560) returns 7168 instead of 5120. Use modular
     // arithmetic so this works for any positive alignment.
-    uint32_t next_fifo_wr_ptr =
-        ((write_ptr_ + page_size - 1) / page_size) * page_size;
+    uint32_t next_fifo_wr_ptr = ((write_ptr_ + page_size - 1) / page_size) * page_size;
     uint32_t fifo_page_aligned_size = fifo_size_ - (fifo_size_ % page_size);
 
     if (next_fifo_wr_ptr >= fifo_page_aligned_size) {
@@ -904,9 +907,10 @@ std::unique_ptr<H2DSocket> H2DSocket::connect_from_descriptor(const HDSocketDesc
     socket->config_buffer_address_ = desc.config_buffer_address;
     socket->pcie_alignment_ = desc.pcie_alignment;
     // Must match the owner-side coord; empty mesh_coord (pre-mesh-coord descriptors) defaults to (0, 0).
-    MeshCoordinate device_coord = desc.mesh_coord.empty()
-        ? MeshCoordinate(0, 0)
-        : MeshCoordinate(ttsl::SmallVector<uint32_t>(desc.mesh_coord.begin(), desc.mesh_coord.end()));
+    MeshCoordinate device_coord =
+        desc.mesh_coord.empty()
+            ? MeshCoordinate(0, 0)
+            : MeshCoordinate(ttsl::SmallVector<uint32_t>(desc.mesh_coord.begin(), desc.mesh_coord.end()));
     socket->recv_core_ = MeshCoreCoord(device_coord, CoreCoord(desc.core_x, desc.core_y));
     socket->h2d_mode_ = static_cast<H2DMode>(desc.h2d_mode);
     socket->aligned_data_buf_start_ = desc.aligned_data_buf_start;

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -1491,7 +1491,7 @@ D2HSocket* MeshDeviceImpl::get_realtime_profiler_socket() const {
     TT_FATAL(
         drisc_l1_arena_ != nullptr,
         "DriscL1Arena not constructed; programmable DRAM cores auto-enable on Blackhole with firmware "
-        ">= 19.12.0.0 and either no harvested DRAM channels or a single device");
+        ">= 19.12.0.0");
     return *drisc_l1_arena_;
 }
 
@@ -1503,10 +1503,12 @@ TensorPrefetcherManager& MeshDeviceImpl::tensor_prefetcher(MeshDevice* mesh_devi
     return *tensor_prefetcher_;
 }
 
-CoreCoord MeshDeviceImpl::pick_unused_dram_logical_core(uint32_t bank_id) const {
-    const auto& soc_desc = MetalContext::instance(context_id_).get_cluster().get_soc_desc(reference_device()->id());
+CoreCoord MeshDeviceImpl::pick_unused_dram_logical_core(const IDevice* device, uint32_t bank_id) const {
+    TT_FATAL(device != nullptr, "Cannot select a DRAM sender core for a null device");
+    const auto& soc_desc = MetalContext::instance(context_id_).get_cluster().get_soc_desc(device->id());
     const uint32_t num_banks = soc_desc.get_num_dram_views();
-    TT_FATAL(bank_id < num_banks, "bank_id={} out of range (num_banks={})", bank_id, num_banks);
+    TT_FATAL(
+        bank_id < num_banks, "bank_id={} out of range for device {} (num_banks={})", bank_id, device->id(), num_banks);
 
     std::set<std::pair<size_t, size_t>> reserved;
     for (const auto& c : soc_desc.dram_view_worker_cores.at(bank_id)) {
@@ -1526,16 +1528,23 @@ CoreCoord MeshDeviceImpl::pick_unused_dram_logical_core(uint32_t bank_id) const 
         }
     }
     TT_THROW(
-        "No unused DRAM subchannel found for bank_id={}; all {} subchannels are reserved as worker/eth endpoints",
+        "No unused DRAM subchannel found for bank_id={} on device {}; all {} subchannels are reserved as "
+        "worker/eth endpoints",
         bank_id,
+        device->id(),
         num_subchannels);
 }
 
-std::vector<CoreCoord> MeshDeviceImpl::dram_sender_logical_cores(uint32_t bank_id) const {
-    const auto& soc_desc = MetalContext::instance(context_id_).get_cluster().get_soc_desc(reference_device()->id());
+CoreCoord MeshDeviceImpl::pick_unused_dram_logical_core(uint32_t bank_id) const {
+    return pick_unused_dram_logical_core(reference_device(), bank_id);
+}
+
+std::vector<CoreCoord> MeshDeviceImpl::dram_sender_logical_cores(const IDevice* device, uint32_t bank_id) const {
+    TT_FATAL(device != nullptr, "Cannot enumerate DRAM sender cores for a null device");
+    const auto& soc_desc = MetalContext::instance(context_id_).get_cluster().get_soc_desc(device->id());
 
     // Sender 0: the free non-endpoint subchannel.
-    const CoreCoord free_core = pick_unused_dram_logical_core(bank_id);
+    const CoreCoord free_core = pick_unused_dram_logical_core(device, bank_id);
 
     // Sender 1: the NOC1 worker-endpoint subchannel. Resolve its subchannel index by
     // matching the endpoint's physical (TRANSLATED) coord against this bank's
@@ -1552,14 +1561,22 @@ std::vector<CoreCoord> MeshDeviceImpl::dram_sender_logical_cores(uint32_t bank_i
                 soc_desc.get_logical_dram_core_for_subchannel(static_cast<int>(bank_id), static_cast<int>(sub));
             TT_FATAL(
                 noc1_core != free_core,
-                "DRAM bank {}: NOC1-endpoint subchannel collides with the free subchannel ({}, {})",
+                "DRAM bank {} on device {}: NOC1-endpoint subchannel collides with the free subchannel ({}, {})",
                 bank_id,
+                device->id(),
                 free_core.x,
                 free_core.y);
             return {free_core, noc1_core};
         }
     }
-    TT_THROW("Could not resolve the NOC1 worker-endpoint subchannel for DRAM bank_id={}", bank_id);
+    TT_THROW(
+        "Could not resolve the NOC1 worker-endpoint subchannel for DRAM bank_id={} on device {}",
+        bank_id,
+        device->id());
+}
+
+std::vector<CoreCoord> MeshDeviceImpl::dram_sender_logical_cores(uint32_t bank_id) const {
+    return dram_sender_logical_cores(reference_device(), bank_id);
 }
 
 program_cache::detail::ProgramCache& MeshDeviceImpl::get_program_cache() { return *program_cache_; }

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -1593,11 +1593,26 @@ std::vector<CoreCoord> MeshDeviceImpl::dram_sender_logical_cores(const IDevice* 
         if (coord.x == noc1_endpoint_phys.x && coord.y == noc1_endpoint_phys.y) {
             const CoreCoord noc1_core =
                 soc_desc.get_logical_dram_core_for_subchannel(static_cast<int>(bank_id), static_cast<int>(sub));
+            // A sender mapping resolves logical DRAM coords against one reference device and is then
+            // reused mesh-wide (see build_dram_sender_mapping), so a role must land on the same
+            // logical y on every device. dram_bank_endpoint_coords orders a bank as [NOC0 endpoint,
+            // NOC1 endpoint, remaining subchannels ascending], which pins the NOC1 endpoint to y == 1
+            // and every free subchannel above it -- but only while the bank's two worker endpoints are
+            // distinct subchannels. A descriptor that names one subchannel for both NOCs (Wormhole
+            // does) collapses that ordering and would let the free and NOC1 roles swap logical y
+            // between devices, which the per-device membership check cannot see. Wormhole has no DRAM
+            // senders, so require the split here rather than in the descriptor.
             TT_FATAL(
-                noc1_core != free_core,
-                "DRAM bank {} on device {}: NOC1-endpoint subchannel collides with the free subchannel ({}, {})",
+                noc1_core.y == 1 && free_core.y > noc1_core.y,
+                "DRAM bank {} on device {}: expected the NOC1 worker endpoint at logical y=1 with the free "
+                "subchannel above it, but found NOC1 at ({}, {}) and free at ({}, {}). A bank's NOC0 and NOC1 "
+                "worker endpoints must be distinct subchannels so that a sender's logical coord names the same "
+                "endpoint role on every device in the mesh; check this view's worker_endpoint pair in the SoC "
+                "descriptor.",
                 bank_id,
                 device->id(),
+                noc1_core.x,
+                noc1_core.y,
                 free_core.x,
                 free_core.y);
             return {free_core, noc1_core};

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -1573,10 +1573,6 @@ CoreCoord MeshDeviceImpl::pick_unused_dram_logical_core(const IDevice* device, u
         num_subchannels);
 }
 
-CoreCoord MeshDeviceImpl::pick_unused_dram_logical_core(uint32_t bank_id) const {
-    return pick_unused_dram_logical_core(reference_device(), bank_id);
-}
-
 std::vector<CoreCoord> MeshDeviceImpl::dram_sender_logical_cores(const IDevice* device, uint32_t bank_id) const {
     TT_FATAL(device != nullptr, "Cannot enumerate DRAM sender cores for a null device");
     const auto& soc_desc = MetalContext::instance(context_id_).get_cluster().get_soc_desc(device->id());
@@ -1611,10 +1607,6 @@ std::vector<CoreCoord> MeshDeviceImpl::dram_sender_logical_cores(const IDevice* 
         "Could not resolve the NOC1 worker-endpoint subchannel for DRAM bank_id={} on device {}",
         bank_id,
         device->id());
-}
-
-std::vector<CoreCoord> MeshDeviceImpl::dram_sender_logical_cores(uint32_t bank_id) const {
-    return dram_sender_logical_cores(reference_device(), bank_id);
 }
 
 program_cache::detail::ProgramCache& MeshDeviceImpl::get_program_cache() { return *program_cache_; }

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -1529,7 +1529,7 @@ RealtimeProfilerManager* MeshDeviceImpl::get_realtime_profiler() const { return 
     TT_FATAL(
         drisc_l1_arena_ != nullptr,
         "DriscL1Arena not constructed; programmable DRAM cores auto-enable on Blackhole with firmware "
-        ">= 19.12.0.0 and either no harvested DRAM channels or a single device");
+        ">= 19.12.0.0");
     return *drisc_l1_arena_;
 }
 
@@ -1541,10 +1541,12 @@ TensorPrefetcherManager& MeshDeviceImpl::tensor_prefetcher(MeshDevice* mesh_devi
     return *tensor_prefetcher_;
 }
 
-CoreCoord MeshDeviceImpl::pick_unused_dram_logical_core(uint32_t bank_id) const {
-    const auto& soc_desc = MetalContext::instance(context_id_).get_cluster().get_soc_desc(reference_device()->id());
+CoreCoord MeshDeviceImpl::pick_unused_dram_logical_core(const IDevice* device, uint32_t bank_id) const {
+    TT_FATAL(device != nullptr, "Cannot select a DRAM sender core for a null device");
+    const auto& soc_desc = MetalContext::instance(context_id_).get_cluster().get_soc_desc(device->id());
     const uint32_t num_banks = soc_desc.get_num_dram_views();
-    TT_FATAL(bank_id < num_banks, "bank_id={} out of range (num_banks={})", bank_id, num_banks);
+    TT_FATAL(
+        bank_id < num_banks, "bank_id={} out of range for device {} (num_banks={})", bank_id, device->id(), num_banks);
 
     std::set<std::pair<size_t, size_t>> reserved;
     for (const auto& c : soc_desc.dram_view_worker_cores.at(bank_id)) {
@@ -1564,16 +1566,23 @@ CoreCoord MeshDeviceImpl::pick_unused_dram_logical_core(uint32_t bank_id) const 
         }
     }
     TT_THROW(
-        "No unused DRAM subchannel found for bank_id={}; all {} subchannels are reserved as worker/eth endpoints",
+        "No unused DRAM subchannel found for bank_id={} on device {}; all {} subchannels are reserved as "
+        "worker/eth endpoints",
         bank_id,
+        device->id(),
         num_subchannels);
 }
 
-std::vector<CoreCoord> MeshDeviceImpl::dram_sender_logical_cores(uint32_t bank_id) const {
-    const auto& soc_desc = MetalContext::instance(context_id_).get_cluster().get_soc_desc(reference_device()->id());
+CoreCoord MeshDeviceImpl::pick_unused_dram_logical_core(uint32_t bank_id) const {
+    return pick_unused_dram_logical_core(reference_device(), bank_id);
+}
+
+std::vector<CoreCoord> MeshDeviceImpl::dram_sender_logical_cores(const IDevice* device, uint32_t bank_id) const {
+    TT_FATAL(device != nullptr, "Cannot enumerate DRAM sender cores for a null device");
+    const auto& soc_desc = MetalContext::instance(context_id_).get_cluster().get_soc_desc(device->id());
 
     // Sender 0: the free non-endpoint subchannel.
-    const CoreCoord free_core = pick_unused_dram_logical_core(bank_id);
+    const CoreCoord free_core = pick_unused_dram_logical_core(device, bank_id);
 
     // Sender 1: the NOC1 worker-endpoint subchannel. Resolve its subchannel index by
     // matching the endpoint's physical (TRANSLATED) coord against this bank's
@@ -1590,14 +1599,22 @@ std::vector<CoreCoord> MeshDeviceImpl::dram_sender_logical_cores(uint32_t bank_i
                 soc_desc.get_logical_dram_core_for_subchannel(static_cast<int>(bank_id), static_cast<int>(sub));
             TT_FATAL(
                 noc1_core != free_core,
-                "DRAM bank {}: NOC1-endpoint subchannel collides with the free subchannel ({}, {})",
+                "DRAM bank {} on device {}: NOC1-endpoint subchannel collides with the free subchannel ({}, {})",
                 bank_id,
+                device->id(),
                 free_core.x,
                 free_core.y);
             return {free_core, noc1_core};
         }
     }
-    TT_THROW("Could not resolve the NOC1 worker-endpoint subchannel for DRAM bank_id={}", bank_id);
+    TT_THROW(
+        "Could not resolve the NOC1 worker-endpoint subchannel for DRAM bank_id={} on device {}",
+        bank_id,
+        device->id());
+}
+
+std::vector<CoreCoord> MeshDeviceImpl::dram_sender_logical_cores(uint32_t bank_id) const {
+    return dram_sender_logical_cores(reference_device(), bank_id);
 }
 
 program_cache::detail::ProgramCache& MeshDeviceImpl::get_program_cache() { return *program_cache_; }

--- a/tt_metal/distributed/mesh_device_impl.hpp
+++ b/tt_metal/distributed/mesh_device_impl.hpp
@@ -318,8 +318,10 @@ public:
 
     // Returns the logical DRAM core for `bank_id` whose physical NoC coord isn't already
     // claimed by the SOC descriptor as a worker_endpoint or eth_endpoint — i.e. one
-    // safe for a DRISC kernel to occupy. Throws if no free subchannel exists, or
-    // TT_FATALs if bank_id is out of range. Used by the DRAM-sender GCB factory.
+    // safe for a DRISC kernel to occupy. The device overload resolves against that
+    // device's harvested DRAM topology; the compatibility overload uses reference_device().
+    // Throws if no free subchannel exists, or TT_FATALs if bank_id is out of range.
+    CoreCoord pick_unused_dram_logical_core(const IDevice* device, uint32_t bank_id) const;
     CoreCoord pick_unused_dram_logical_core(uint32_t bank_id) const;
 
     // Returns the ordered list of DRISC logical cores that drive a bank's DRAM-sender
@@ -327,9 +329,10 @@ public:
     // (pick_unused_dram_logical_core), element 1 is the bank's NOC1 worker-endpoint
     // subchannel (idle for NOC0 during matmul). Both run their kernels on NOC0; the
     // pair lets two DRISC cores share a bank's receiver set. Indices are derived
-    // per-bank from the SOC descriptor (they are not fixed across banks). Used by both
-    // the DRAM-sender GCB factory and the TensorPrefetcherManager so their sender
-    // cores always agree.
+    // per-bank and per-device from the SOC descriptor (they are not fixed across banks
+    // or devices with different DRAM harvest masks). The compatibility overload uses
+    // reference_device() to produce the canonical public GCB mapping.
+    std::vector<CoreCoord> dram_sender_logical_cores(const IDevice* device, uint32_t bank_id) const;
     std::vector<CoreCoord> dram_sender_logical_cores(uint32_t bank_id) const;
 
     bool close() override;

--- a/tt_metal/distributed/mesh_device_impl.hpp
+++ b/tt_metal/distributed/mesh_device_impl.hpp
@@ -326,10 +326,14 @@ public:
     // prefetcher on `device`: element 0 is the free non-endpoint subchannel
     // (pick_unused_dram_logical_core), element 1 is the bank's NOC1 worker-endpoint
     // subchannel (idle for NOC0 during matmul). Both run their kernels on NOC0; the
-    // pair lets two DRISC cores share a bank's receiver set. Indices are derived
-    // per-bank and per-device from the SOC descriptor (they are not fixed across banks,
-    // nor across devices with different DRAM harvest masks), so callers must name the
-    // device whose topology they mean — there is no mesh-wide answer.
+    // pair lets two DRISC cores share a bank's receiver set.
+    //
+    // A logical DRAM coord names an endpoint role, not a raw subchannel (see
+    // metal_SocDescriptor::dram_bank_endpoint_coords), so the returned (bank, role) pair is the
+    // same on every device in the mesh. What varies per device is which physical subchannel each
+    // role resolves to, which tracks that device's DRAM harvest mask — hence the `device`
+    // argument. Callers wanting the mesh-wide mapping may resolve it against any one device;
+    // callers addressing hardware must translate through the device they mean.
     std::vector<CoreCoord> dram_sender_logical_cores(const IDevice* device, uint32_t bank_id) const;
 
     bool close() override;

--- a/tt_metal/distributed/mesh_device_impl.hpp
+++ b/tt_metal/distributed/mesh_device_impl.hpp
@@ -316,24 +316,21 @@ public:
     // experimental::StartTensorPrefetcher / StopTensorPrefetcher delegate here.
     TensorPrefetcherManager& tensor_prefetcher(MeshDevice* mesh_device);
 
-    // Returns the logical DRAM core for `bank_id` whose physical NoC coord isn't already
-    // claimed by the SOC descriptor as a worker_endpoint or eth_endpoint — i.e. one
-    // safe for a DRISC kernel to occupy. The device overload resolves against that
-    // device's harvested DRAM topology; the compatibility overload uses reference_device().
+    // Returns the logical DRAM core for `bank_id` on `device` whose physical NoC coord isn't
+    // already claimed by the SOC descriptor as a worker_endpoint or eth_endpoint — i.e. one
+    // safe for a DRISC kernel to occupy. Resolved against `device`'s harvested DRAM topology.
     // Throws if no free subchannel exists, or TT_FATALs if bank_id is out of range.
     CoreCoord pick_unused_dram_logical_core(const IDevice* device, uint32_t bank_id) const;
-    CoreCoord pick_unused_dram_logical_core(uint32_t bank_id) const;
 
     // Returns the ordered list of DRISC logical cores that drive a bank's DRAM-sender
-    // prefetcher: element 0 is the free non-endpoint subchannel
+    // prefetcher on `device`: element 0 is the free non-endpoint subchannel
     // (pick_unused_dram_logical_core), element 1 is the bank's NOC1 worker-endpoint
     // subchannel (idle for NOC0 during matmul). Both run their kernels on NOC0; the
     // pair lets two DRISC cores share a bank's receiver set. Indices are derived
-    // per-bank and per-device from the SOC descriptor (they are not fixed across banks
-    // or devices with different DRAM harvest masks). The compatibility overload uses
-    // reference_device() to produce the canonical public GCB mapping.
+    // per-bank and per-device from the SOC descriptor (they are not fixed across banks,
+    // nor across devices with different DRAM harvest masks), so callers must name the
+    // device whose topology they mean — there is no mesh-wide answer.
     std::vector<CoreCoord> dram_sender_logical_cores(const IDevice* device, uint32_t bank_id) const;
-    std::vector<CoreCoord> dram_sender_logical_cores(uint32_t bank_id) const;
 
     bool close() override;
     bool close_impl(MeshDevice* pimpl_wrapper);

--- a/tt_metal/distributed/mesh_device_impl.hpp
+++ b/tt_metal/distributed/mesh_device_impl.hpp
@@ -328,12 +328,12 @@ public:
     // subchannel (idle for NOC0 during matmul). Both run their kernels on NOC0; the
     // pair lets two DRISC cores share a bank's receiver set.
     //
-    // A logical DRAM coord names an endpoint role, not a raw subchannel (see
-    // metal_SocDescriptor::dram_bank_endpoint_coords), so the returned (bank, role) pair is the
-    // same on every device in the mesh. What varies per device is which physical subchannel each
-    // role resolves to, which tracks that device's DRAM harvest mask — hence the `device`
-    // argument. Callers wanting the mesh-wide mapping may resolve it against any one device;
-    // callers addressing hardware must translate through the device they mean.
+    // The result names endpoint roles (see metal_SocDescriptor::dram_bank_endpoint_coords), so a
+    // well-formed descriptor set returns the same coords for every `device` in a mesh; the
+    // `device` argument exists because that is a property of the descriptors rather than one this
+    // function can guarantee, and because the physical subchannel each role resolves to does vary
+    // with the device's DRAM harvest mask. Callers addressing hardware must translate the returned
+    // coords through the device they mean.
     std::vector<CoreCoord> dram_sender_logical_cores(const IDevice* device, uint32_t bank_id) const;
 
     bool close() override;

--- a/tt_metal/impl/buffers/drisc_l1_arena.cpp
+++ b/tt_metal/impl/buffers/drisc_l1_arena.cpp
@@ -19,7 +19,7 @@ DriscL1Arena::DriscL1Arena(ContextId context_id) {
     TT_FATAL(
         hal.has_programmable_core_type(HalProgrammableCoreType::DRAM),
         "DriscL1Arena requires programmable DRAM cores, which auto-enable on Blackhole with firmware "
-        ">= 19.12.0.0 and either no harvested DRAM channels or a single device");
+        ">= 19.12.0.0");
 
     unreserved_base_ = hal.get_dev_addr(HalProgrammableCoreType::DRAM, HalL1MemAddrType::UNRESERVED);
     drisc_unreserved_size_ = hal.get_dev_size(HalProgrammableCoreType::DRAM, HalL1MemAddrType::UNRESERVED);

--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -211,11 +211,10 @@ std::vector<uint32_t> recv_index_bases_per_sender(const std::vector<std::pair<Co
 }
 
 // A DRAM-sender GCB exposes the reference device's logical sender coordinates for API
-// compatibility. Resolve that canonical coordinate to its stable sender role within the
-// bank, then select the corresponding logical core from the target device's harvested
-// topology.
-CoreCoord resolve_dram_sender_for_device(
-    distributed::MeshDevice* mesh_device, const IDevice* device, const CoreCoord& canonical_sender) {
+// compatibility. `canonical_sender_role` recovers a canonical coordinate's stable role
+// (its index within the bank's ordered sender list). It depends only on the reference
+// device, so callers resolve it once per sender rather than once per (sender, device).
+size_t canonical_sender_role(distributed::MeshDevice* mesh_device, const CoreCoord& canonical_sender) {
     const uint32_t bank_id = static_cast<uint32_t>(canonical_sender.x);
     const std::vector<CoreCoord> canonical_senders = mesh_device->impl().dram_sender_logical_cores(bank_id);
     const auto canonical_it = std::find(canonical_senders.begin(), canonical_senders.end(), canonical_sender);
@@ -225,8 +224,13 @@ CoreCoord resolve_dram_sender_for_device(
         canonical_sender.x,
         canonical_sender.y,
         bank_id);
-    const size_t sender_role = std::distance(canonical_senders.begin(), canonical_it);
+    return static_cast<size_t>(std::distance(canonical_senders.begin(), canonical_it));
+}
 
+// Selects the logical DRAM core that plays `sender_role` for `bank_id` on `device`'s
+// harvested topology.
+CoreCoord device_sender_for_role(
+    distributed::MeshDevice* mesh_device, const IDevice* device, uint32_t bank_id, size_t sender_role) {
     const std::vector<CoreCoord> device_senders = mesh_device->impl().dram_sender_logical_cores(device, bank_id);
     TT_FATAL(
         sender_role < device_senders.size(),
@@ -301,6 +305,10 @@ void GlobalCircularBuffer::initialize_dram_sender_state_block(
         hdr->num_receivers_and_remote_pages_sent_ptr =
             remote_cb_pack(this_num_receivers, static_cast<uint32_t>(pages_sent_worker_l1_base_));
 
+        // The canonical sender role is device-independent; resolve it once per sender.
+        const uint32_t bank_id = static_cast<uint32_t>(canonical_sender.x);
+        const size_t sender_role = canonical_sender_role(mesh_device, canonical_sender);
+
         for (IDevice* dev : devices) {
             for (uint32_t i = 0; i < max_num_receivers_per_sender; ++i) {
                 if (i < this_num_receivers) {
@@ -312,7 +320,7 @@ void GlobalCircularBuffer::initialize_dram_sender_state_block(
                     noc_xy_words[2 * i + 1] = 0;
                 }
             }
-            const CoreCoord sender_logical = resolve_dram_sender_for_device(mesh_device, dev, canonical_sender);
+            const CoreCoord sender_logical = device_sender_for_role(mesh_device, dev, bank_id, sender_role);
             const CoreCoord virtual_core = dev->virtual_core_from_logical_core(sender_logical, CoreType::DRAM);
             cluster.write_core(
                 dev->id(),
@@ -384,9 +392,23 @@ void GlobalCircularBuffer::setup_cb_buffers(
         pages_sent_worker_l1_base_ = pages_sent_address;
     }
 
+    // The canonical (reference-device) sender role for each mapping entry is device-independent;
+    // resolve it once here so the per-device config build only performs the target-device index lookup.
+    std::vector<std::pair<uint32_t, size_t>> canonical_roles;  // {bank_id, role}
+    if (sender_core_type == experimental::SenderCoreType::Dram) {
+        TT_FATAL(dram_sender_mesh_device != nullptr, "DRAM-sender GCB config requires its MeshDevice");
+        canonical_roles.reserve(sender_receiver_core_mapping_.size());
+        for (const auto& [canonical_sender, _receivers] : sender_receiver_core_mapping_) {
+            canonical_roles.emplace_back(
+                static_cast<uint32_t>(canonical_sender.x),
+                canonical_sender_role(dram_sender_mesh_device, canonical_sender));
+        }
+    }
+
     const auto make_config_host_buffer = [&](IDevice* config_device) {
         std::vector<uint32_t> cb_config_host_buffer(cb_config_size / sizeof(uint32_t), 0);
-        for (const auto& [canonical_sender, receiver_cores] : sender_receiver_core_mapping_) {
+        for (size_t s = 0; s < sender_receiver_core_mapping_.size(); ++s) {
+            const auto& [canonical_sender, receiver_cores] = sender_receiver_core_mapping_[s];
             const auto& receiver_cores_vec = corerange_to_cores(receiver_cores);
             uint32_t num_receivers = receiver_cores.num_cores();
 
@@ -416,7 +438,8 @@ void GlobalCircularBuffer::setup_cb_buffers(
             // DRAM virtual coord for the canonical sender's stable bank/role.
             const CoreCoord sender_logical =
                 (sender_core_type == experimental::SenderCoreType::Dram)
-                    ? resolve_dram_sender_for_device(dram_sender_mesh_device, config_device, canonical_sender)
+                    ? device_sender_for_role(
+                          dram_sender_mesh_device, config_device, canonical_roles[s].first, canonical_roles[s].second)
                     : canonical_sender;
             CoreCoord sender_physical_coord =
                 (sender_core_type == experimental::SenderCoreType::Worker)
@@ -453,7 +476,6 @@ void GlobalCircularBuffer::setup_cb_buffers(
 
     auto mesh_buffer = cb_config_buffer_.get_mesh_buffer();
     if (sender_core_type == experimental::SenderCoreType::Dram) {
-        TT_FATAL(dram_sender_mesh_device != nullptr, "DRAM-sender GCB config requires its MeshDevice");
         for (IDevice* config_device : dram_sender_mesh_device->get_devices()) {
             std::vector<uint32_t> cb_config_host_buffer = make_config_host_buffer(config_device);
             const distributed::MeshCoordinate device_coord =

--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -136,7 +136,7 @@ GlobalCircularBuffer::GlobalCircularBuffer(
     TT_FATAL(
         hal.has_programmable_core_type(HalProgrammableCoreType::DRAM),
         "DRAM-sender GlobalCircularBuffer requires programmable DRAM cores, which auto-enable on Blackhole "
-        "with firmware >= 19.12.0.0 and either no harvested DRAM channels or a single device");
+        "with firmware >= 19.12.0.0");
     uint32_t max_num_receivers_per_sender = 0;
     initialize_global_circular_buffer(
         mesh_device,
@@ -147,8 +147,10 @@ GlobalCircularBuffer::GlobalCircularBuffer(
         all_cores_,
         max_num_receivers_per_sender);
 
-    // Pre-compute physical worker NOC XY for each sender's receivers (the DRISC kernel
-    // pushes to these as runtime args).
+    // Preserve the reference device's physical worker NOC XY for the experimental
+    // receiver_coords_per_sender accessor. Device-bound sender-state initialization
+    // below resolves worker coordinates independently for every device.
+    IDevice* reference_device = mesh_device->get_devices().at(0);
     receiver_coords_per_sender_.reserve(sender_receiver_core_mapping.size());
     for (const auto& [_sender_core, receivers] : sender_receiver_core_mapping) {
         // Row-wise, to match both the dual-sender ceil/floor split (select_from_corerangeset
@@ -159,7 +161,7 @@ GlobalCircularBuffer::GlobalCircularBuffer(
         std::vector<CoreCoord> phys;
         phys.reserve(receivers_vec.size());
         for (const auto& r : receivers_vec) {
-            phys.emplace_back(device_->worker_core_from_logical_core(r));
+            phys.emplace_back(reference_device->worker_core_from_logical_core(r));
         }
         receiver_coords_per_sender_.push_back(std::move(phys));
     }
@@ -185,7 +187,7 @@ GlobalCircularBuffer::GlobalCircularBuffer(
     pages_sent_drisc_l1_base_ = drisc_sender_state_alloc_->addr();
     sender_state_drisc_l1_base_ = pages_sent_drisc_l1_base_ + pages_sent_region;
 
-    this->setup_cb_buffers(buffer_type, max_num_receivers_per_sender);
+    this->setup_cb_buffers(buffer_type, max_num_receivers_per_sender, mesh_device);
     this->initialize_dram_sender_state_block(mesh_device, max_num_receivers_per_sender);
 }
 
@@ -207,6 +209,34 @@ std::vector<uint32_t> recv_index_bases_per_sender(const std::vector<std::pair<Co
     }
     return bases;
 }
+
+// A DRAM-sender GCB exposes the reference device's logical sender coordinates for API
+// compatibility. Resolve that canonical coordinate to its stable sender role within the
+// bank, then select the corresponding logical core from the target device's harvested
+// topology.
+CoreCoord resolve_dram_sender_for_device(
+    distributed::MeshDevice* mesh_device, const IDevice* device, const CoreCoord& canonical_sender) {
+    const uint32_t bank_id = static_cast<uint32_t>(canonical_sender.x);
+    const std::vector<CoreCoord> canonical_senders = mesh_device->impl().dram_sender_logical_cores(bank_id);
+    const auto canonical_it = std::find(canonical_senders.begin(), canonical_senders.end(), canonical_sender);
+    TT_FATAL(
+        canonical_it != canonical_senders.end(),
+        "Canonical DRAM sender ({}, {}) is not a provisioned sender for bank {}",
+        canonical_sender.x,
+        canonical_sender.y,
+        bank_id);
+    const size_t sender_role = std::distance(canonical_senders.begin(), canonical_it);
+
+    const std::vector<CoreCoord> device_senders = mesh_device->impl().dram_sender_logical_cores(device, bank_id);
+    TT_FATAL(
+        sender_role < device_senders.size(),
+        "Device {} has {} DRAM senders for bank {}, but canonical sender role {} is required",
+        device->id(),
+        device_senders.size(),
+        bank_id,
+        sender_role);
+    return device_senders[sender_role];
+}
 }  // namespace
 
 void GlobalCircularBuffer::initialize_dram_sender_state_block(
@@ -226,8 +256,8 @@ void GlobalCircularBuffer::initialize_dram_sender_state_block(
     const uint32_t packed_num_recv_and_remote =
         remote_cb_pack(max_num_receivers_per_sender, static_cast<uint32_t>(pages_sent_worker_l1_base_));
 
-    // Block is identical across (device, sender) pairs; only the receiver NOC XY
-    // table varies per sender. Compose once, swap in the table per sender.
+    // The fixed header fields are common, while the receiver NOC XY table is composed
+    // separately for each (device, sender) pair.
     std::vector<uint8_t> block_bytes(state_block_size, 0);
     auto* hdr = reinterpret_cast<DramSenderStateBlock*>(block_bytes.data());
     hdr->config_ptr = config_block_addr;
@@ -261,9 +291,9 @@ void GlobalCircularBuffer::initialize_dram_sender_state_block(
     // when two senders share a bank, the second reads slabs that start where the first's end.
     const std::vector<uint32_t> recv_index_bases = recv_index_bases_per_sender(sender_receiver_core_mapping_);
     for (size_t s = 0; s < sender_receiver_core_mapping_.size(); ++s) {
-        const auto& [sender_logical, _receivers] = sender_receiver_core_mapping_[s];
-        const auto& recv_phys = receiver_coords_per_sender_[s];
-        const uint32_t this_num_receivers = static_cast<uint32_t>(recv_phys.size());
+        const auto& [canonical_sender, receivers] = sender_receiver_core_mapping_[s];
+        const auto receivers_vec = corerange_to_cores(receivers, /*max_cores=*/std::nullopt, /*row_wise=*/true);
+        const uint32_t this_num_receivers = static_cast<uint32_t>(receivers_vec.size());
 
         // Per-sender header fields (the rest of block_bytes is constant across senders).
         hdr->num_receivers = this_num_receivers;
@@ -271,13 +301,18 @@ void GlobalCircularBuffer::initialize_dram_sender_state_block(
         hdr->num_receivers_and_remote_pages_sent_ptr =
             remote_cb_pack(this_num_receivers, static_cast<uint32_t>(pages_sent_worker_l1_base_));
 
-        for (uint32_t i = 0; i < max_num_receivers_per_sender; ++i) {
-            const bool valid = i < this_num_receivers;
-            const auto& c = valid ? recv_phys[i] : CoreCoord{0, 0};
-            noc_xy_words[2 * i + 0] = valid ? static_cast<uint32_t>(c.x) : 0u;
-            noc_xy_words[2 * i + 1] = valid ? static_cast<uint32_t>(c.y) : 0u;
-        }
         for (IDevice* dev : devices) {
+            for (uint32_t i = 0; i < max_num_receivers_per_sender; ++i) {
+                if (i < this_num_receivers) {
+                    const CoreCoord receiver_phys = dev->worker_core_from_logical_core(receivers_vec[i]);
+                    noc_xy_words[2 * i + 0] = static_cast<uint32_t>(receiver_phys.x);
+                    noc_xy_words[2 * i + 1] = static_cast<uint32_t>(receiver_phys.y);
+                } else {
+                    noc_xy_words[2 * i + 0] = 0;
+                    noc_xy_words[2 * i + 1] = 0;
+                }
+            }
+            const CoreCoord sender_logical = resolve_dram_sender_for_device(mesh_device, dev, canonical_sender);
             const CoreCoord virtual_core = dev->virtual_core_from_logical_core(sender_logical, CoreType::DRAM);
             cluster.write_core(
                 dev->id(),
@@ -293,7 +328,8 @@ void GlobalCircularBuffer::initialize_dram_sender_state_block(
     }
 }
 
-void GlobalCircularBuffer::setup_cb_buffers(BufferType buffer_type, uint32_t max_num_receivers_per_sender) {
+void GlobalCircularBuffer::setup_cb_buffers(
+    BufferType buffer_type, uint32_t max_num_receivers_per_sender, distributed::MeshDevice* dram_sender_mesh_device) {
     TT_FATAL(
         buffer_type == BufferType::L1 or buffer_type == BufferType::L1_SMALL,
         "Global circular buffer can only be created for L1 buffer types");
@@ -336,7 +372,6 @@ void GlobalCircularBuffer::setup_cb_buffers(BufferType buffer_type, uint32_t max
     // Only block for the slow dispatch case
     auto config_buffer_address = cb_config_buffer_.get_buffer()->address();
     const auto& core_to_core_id = cb_config_buffer_.get_buffer()->get_buffer_page_mapping()->core_to_core_id;
-    std::vector<uint32_t> cb_config_host_buffer(cb_config_size / sizeof(uint32_t), 0);
     uint32_t noc_xy_address = config_buffer_address + (num_config_elements * sizeof(uint32_t));
     uint32_t pages_sent_address = tt::align(noc_xy_address + (num_noc_xy_words * sizeof(uint32_t)), l1_alignment);
     auto buffer_address = cb_buffer().address();
@@ -349,64 +384,92 @@ void GlobalCircularBuffer::setup_cb_buffers(BufferType buffer_type, uint32_t max
         pages_sent_worker_l1_base_ = pages_sent_address;
     }
 
-    for (const auto& [sender_core, receiver_cores] : sender_receiver_core_mapping_) {
-        const auto& receiver_cores_vec = corerange_to_cores(receiver_cores);
-        uint32_t num_receivers = receiver_cores.num_cores();
+    const auto make_config_host_buffer = [&](IDevice* config_device) {
+        std::vector<uint32_t> cb_config_host_buffer(cb_config_size / sizeof(uint32_t), 0);
+        for (const auto& [canonical_sender, receiver_cores] : sender_receiver_core_mapping_) {
+            const auto& receiver_cores_vec = corerange_to_cores(receiver_cores);
+            uint32_t num_receivers = receiver_cores.num_cores();
 
-        // Worker senders have their own config page in the sharded buffer; DRAM senders don't
-        // (the DRISC kernel hand-rolls the sender iface state from compile-time args).
-        if (sender_core_type == experimental::SenderCoreType::Worker) {
-            uint32_t sender_idx = core_to_core_id.at(sender_core) * cb_config_page_size / sizeof(uint32_t);
-            cb_config_host_buffer[sender_idx++] = 1;
-            cb_config_host_buffer[sender_idx++] = num_receivers;
-            cb_config_host_buffer[sender_idx++] = buffer_address;
-            cb_config_host_buffer[sender_idx++] = size_;
-            cb_config_host_buffer[sender_idx++] = buffer_address;
-            cb_config_host_buffer[sender_idx++] = noc_xy_address;
-            cb_config_host_buffer[sender_idx++] = pages_sent_address;
-            // Sharded GCB: the sender's NOC inc lands at the same L1 offset on the receiver's
-            // side, so the remote address equals aligned_pages_sent_ptr.
-            cb_config_host_buffer[sender_idx++] = pages_sent_address;
-            for (const auto& receiver_logical : receiver_cores_vec) {
-                auto receiver_physical_coord = device_->worker_core_from_logical_core(receiver_logical);
-                cb_config_host_buffer[sender_idx++] = receiver_physical_coord.x;
-                cb_config_host_buffer[sender_idx++] = receiver_physical_coord.y;
+            // Worker senders have their own config page in the sharded buffer; DRAM senders don't
+            // (the DRISC kernel hand-rolls the sender iface state from compile-time args).
+            if (sender_core_type == experimental::SenderCoreType::Worker) {
+                uint32_t sender_idx = core_to_core_id.at(canonical_sender) * cb_config_page_size / sizeof(uint32_t);
+                cb_config_host_buffer[sender_idx++] = 1;
+                cb_config_host_buffer[sender_idx++] = num_receivers;
+                cb_config_host_buffer[sender_idx++] = buffer_address;
+                cb_config_host_buffer[sender_idx++] = size_;
+                cb_config_host_buffer[sender_idx++] = buffer_address;
+                cb_config_host_buffer[sender_idx++] = noc_xy_address;
+                cb_config_host_buffer[sender_idx++] = pages_sent_address;
+                // Sharded GCB: the sender's NOC inc lands at the same L1 offset on the receiver's
+                // side, so the remote address equals aligned_pages_sent_ptr.
+                cb_config_host_buffer[sender_idx++] = pages_sent_address;
+                for (const auto& receiver_logical : receiver_cores_vec) {
+                    auto receiver_physical_coord = config_device->worker_core_from_logical_core(receiver_logical);
+                    cb_config_host_buffer[sender_idx++] = receiver_physical_coord.x;
+                    cb_config_host_buffer[sender_idx++] = receiver_physical_coord.y;
+                }
+            }
+
+            // Sender's physical NOC coord -- where the receiver's pages_acked NOC-inc lands. For
+            // worker senders this is the worker phys; for DRAM senders it is the target device's
+            // DRAM virtual coord for the canonical sender's stable bank/role.
+            const CoreCoord sender_logical =
+                (sender_core_type == experimental::SenderCoreType::Dram)
+                    ? resolve_dram_sender_for_device(dram_sender_mesh_device, config_device, canonical_sender)
+                    : canonical_sender;
+            CoreCoord sender_physical_coord =
+                (sender_core_type == experimental::SenderCoreType::Worker)
+                    ? config_device->worker_core_from_logical_core(sender_logical)
+                    : config_device->virtual_core_from_logical_core(sender_logical, CoreType::DRAM);
+
+            for (uint32_t i = 0; i < receiver_cores_vec.size(); i++) {
+                uint32_t receiver_idx =
+                    core_to_core_id.at(receiver_cores_vec[i]) * cb_config_page_size / sizeof(uint32_t);
+                cb_config_host_buffer[receiver_idx++] = 0;  // is_sender
+                cb_config_host_buffer[receiver_idx++] = num_receivers;
+                cb_config_host_buffer[receiver_idx++] = buffer_address;
+                cb_config_host_buffer[receiver_idx++] = size_;
+                cb_config_host_buffer[receiver_idx++] = buffer_address;
+                cb_config_host_buffer[receiver_idx++] = noc_xy_address;
+                // aligned_pages_sent_ptr; pages_acked for this receiver lives at +L1_ALIGNMENT.
+                cb_config_host_buffer[receiver_idx++] = pages_sent_address + 2 * i * l1_alignment;
+                // remote_pages_addr_override: the address on the SENDER's L1 where this receiver's
+                // NoC-inc for pages_acked lands. For a sharded GCB sender and receiver share an L1
+                // layout so this equals aligned_pages_acked_ptr. For a DRAM-sender GCB it points at
+                // the per-receiver pages_acked slot in DRISC L1 (packed at uint32 stride, mirroring
+                // the kernel's REMOTE_CB_LOCAL_PAGES_*).
+                constexpr uint32_t drisc_slot = sizeof(uint32_t);
+                cb_config_host_buffer[receiver_idx++] =
+                    (sender_core_type == experimental::SenderCoreType::Dram)
+                        ? static_cast<uint32_t>(pages_sent_drisc_l1_base_ + 2 * i * drisc_slot + drisc_slot)
+                        : (pages_sent_address + 2 * i * l1_alignment + l1_alignment);
+                cb_config_host_buffer[receiver_idx++] = sender_physical_coord.x;
+                cb_config_host_buffer[receiver_idx++] = sender_physical_coord.y;
             }
         }
+        return cb_config_host_buffer;
+    };
 
-        // Sender's physical NOC coord -- where the receiver's pages_acked NOC-inc lands. For
-        // worker senders this is the worker phys; for DRAM senders it's the DRAM virtual coord.
-        CoreCoord sender_physical_coord = (sender_core_type == experimental::SenderCoreType::Worker)
-                                              ? device_->worker_core_from_logical_core(sender_core)
-                                              : device_->virtual_core_from_logical_core(sender_core, CoreType::DRAM);
-
-        for (uint32_t i = 0; i < receiver_cores_vec.size(); i++) {
-            uint32_t receiver_idx = core_to_core_id.at(receiver_cores_vec[i]) * cb_config_page_size / sizeof(uint32_t);
-            cb_config_host_buffer[receiver_idx++] = 0;  // is_sender
-            cb_config_host_buffer[receiver_idx++] = num_receivers;
-            cb_config_host_buffer[receiver_idx++] = buffer_address;
-            cb_config_host_buffer[receiver_idx++] = size_;
-            cb_config_host_buffer[receiver_idx++] = buffer_address;
-            cb_config_host_buffer[receiver_idx++] = noc_xy_address;
-            // aligned_pages_sent_ptr; pages_acked for this receiver lives at +L1_ALIGNMENT.
-            cb_config_host_buffer[receiver_idx++] = pages_sent_address + 2 * i * l1_alignment;
-            // remote_pages_addr_override: the address on the SENDER's L1 where this receiver's
-            // NoC-inc for pages_acked lands. For a sharded GCB sender and receiver share an L1
-            // layout so this equals aligned_pages_acked_ptr. For a DRAM-sender GCB it points at
-            // the per-receiver pages_acked slot in DRISC L1 (packed at uint32 stride, mirroring
-            // the kernel's REMOTE_CB_LOCAL_PAGES_*).
-            constexpr uint32_t drisc_slot = sizeof(uint32_t);
-            cb_config_host_buffer[receiver_idx++] =
-                (sender_core_type == experimental::SenderCoreType::Dram)
-                    ? static_cast<uint32_t>(pages_sent_drisc_l1_base_ + 2 * i * drisc_slot + drisc_slot)
-                    : (pages_sent_address + 2 * i * l1_alignment + l1_alignment);
-            cb_config_host_buffer[receiver_idx++] = sender_physical_coord.x;
-            cb_config_host_buffer[receiver_idx++] = sender_physical_coord.y;
-        }
-    }
     auto mesh_buffer = cb_config_buffer_.get_mesh_buffer();
-    distributed::EnqueueWriteMeshBuffer(
-        mesh_buffer->device()->mesh_command_queue(), mesh_buffer, cb_config_host_buffer, false);
+    if (sender_core_type == experimental::SenderCoreType::Dram) {
+        TT_FATAL(dram_sender_mesh_device != nullptr, "DRAM-sender GCB config requires its MeshDevice");
+        for (IDevice* config_device : dram_sender_mesh_device->get_devices()) {
+            std::vector<uint32_t> cb_config_host_buffer = make_config_host_buffer(config_device);
+            const distributed::MeshCoordinate device_coord =
+                dram_sender_mesh_device->get_view().find_device(config_device->id());
+            distributed::WriteShard(
+                mesh_buffer->device()->mesh_command_queue(),
+                mesh_buffer,
+                cb_config_host_buffer,
+                device_coord,
+                /*blocking=*/true);
+        }
+    } else {
+        std::vector<uint32_t> cb_config_host_buffer = make_config_host_buffer(device_);
+        distributed::EnqueueWriteMeshBuffer(
+            mesh_buffer->device()->mesh_command_queue(), mesh_buffer, cb_config_host_buffer, false);
+    }
 }
 
 const Buffer& GlobalCircularBuffer::cb_buffer() const { return *cb_buffer_.get_buffer(); }

--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -211,43 +211,23 @@ std::vector<uint32_t> recv_index_bases_per_sender(const std::vector<std::pair<Co
     return bases;
 }
 
-// The device whose logical DRAM coordinates a DRAM-sender GCB's public
-// sender_receiver_core_mapping() is expressed in: the mesh's reference device. Logical DRAM
-// sender coords are per-device (harvest masks differ), so this is the one place that fixes
-// which device the mapping names; every device-bound use goes through device_sender_for_role.
-IDevice* canonical_sender_device(distributed::MeshDevice* mesh_device) { return mesh_device->get_devices().at(0); }
-
-// A DRAM-sender GCB exposes the canonical device's logical sender coordinates for API
-// compatibility. `canonical_sender_role` recovers a canonical coordinate's stable role
-// (its index within the bank's ordered sender list). It depends only on the canonical
-// device, so callers resolve it once per sender rather than once per (sender, device).
-size_t canonical_sender_role(distributed::MeshDevice* mesh_device, const CoreCoord& canonical_sender) {
-    const uint32_t bank_id = static_cast<uint32_t>(canonical_sender.x);
-    const std::vector<CoreCoord> canonical_senders =
-        mesh_device->impl().dram_sender_logical_cores(canonical_sender_device(mesh_device), bank_id);
-    const auto canonical_it = std::find(canonical_senders.begin(), canonical_senders.end(), canonical_sender);
-    TT_FATAL(
-        canonical_it != canonical_senders.end(),
-        "Canonical DRAM sender ({}, {}) is not a provisioned sender for bank {}",
-        canonical_sender.x,
-        canonical_sender.y,
-        bank_id);
-    return static_cast<size_t>(std::distance(canonical_senders.begin(), canonical_it));
-}
-
-// Selects the logical DRAM core that plays `sender_role` for `bank_id` on `device`'s
-// harvested topology.
-CoreCoord device_sender_for_role(
-    distributed::MeshDevice* mesh_device, const IDevice* device, uint32_t bank_id, size_t sender_role) {
+// A logical DRAM coordinate names an endpoint role rather than a raw subchannel (see
+// metal_SocDescriptor::dram_bank_endpoint_coords), so one sender mapping holds for every device in
+// the mesh even when their DRAM harvest masks differ: each device translates the same logical coord
+// to its own physical subchannel. Check that per device rather than trusting it — a descriptor whose
+// endpoint layout didn't reproduce the role would otherwise silently drive the wrong DRISC core, and
+// a sender that isn't provisioned for its bank would take credits nobody returns.
+void validate_dram_sender_on_device(
+    distributed::MeshDevice* mesh_device, const IDevice* device, const CoreCoord& sender_logical) {
+    const uint32_t bank_id = static_cast<uint32_t>(sender_logical.x);
     const std::vector<CoreCoord> device_senders = mesh_device->impl().dram_sender_logical_cores(device, bank_id);
     TT_FATAL(
-        sender_role < device_senders.size(),
-        "Device {} has {} DRAM senders for bank {}, but canonical sender role {} is required",
-        device->id(),
-        device_senders.size(),
+        std::find(device_senders.begin(), device_senders.end(), sender_logical) != device_senders.end(),
+        "DRAM sender ({}, {}) is not a provisioned sender for bank {} on device {}",
+        sender_logical.x,
+        sender_logical.y,
         bank_id,
-        sender_role);
-    return device_senders[sender_role];
+        device->id());
 }
 }  // namespace
 
@@ -303,7 +283,7 @@ void GlobalCircularBuffer::initialize_dram_sender_state_block(
     // when two senders share a bank, the second reads slabs that start where the first's end.
     const std::vector<uint32_t> recv_index_bases = recv_index_bases_per_sender(sender_receiver_core_mapping_);
     for (size_t s = 0; s < sender_receiver_core_mapping_.size(); ++s) {
-        const auto& [canonical_sender, receivers] = sender_receiver_core_mapping_[s];
+        const auto& [sender_logical, receivers] = sender_receiver_core_mapping_[s];
         const auto receivers_vec = corerange_to_cores(receivers, /*max_cores=*/std::nullopt, /*row_wise=*/true);
         const uint32_t this_num_receivers = static_cast<uint32_t>(receivers_vec.size());
 
@@ -313,11 +293,8 @@ void GlobalCircularBuffer::initialize_dram_sender_state_block(
         hdr->num_receivers_and_remote_pages_sent_ptr =
             remote_cb_pack(this_num_receivers, static_cast<uint32_t>(pages_sent_worker_l1_base_));
 
-        // The canonical sender role is device-independent; resolve it once per sender.
-        const uint32_t bank_id = static_cast<uint32_t>(canonical_sender.x);
-        const size_t sender_role = canonical_sender_role(mesh_device, canonical_sender);
-
         for (IDevice* dev : devices) {
+            validate_dram_sender_on_device(mesh_device, dev, sender_logical);
             for (uint32_t i = 0; i < max_num_receivers_per_sender; ++i) {
                 if (i < this_num_receivers) {
                     const CoreCoord receiver_phys = dev->worker_core_from_logical_core(receivers_vec[i]);
@@ -328,7 +305,6 @@ void GlobalCircularBuffer::initialize_dram_sender_state_block(
                     noc_xy_words[2 * i + 1] = 0;
                 }
             }
-            const CoreCoord sender_logical = device_sender_for_role(mesh_device, dev, bank_id, sender_role);
             const CoreCoord virtual_core = dev->virtual_core_from_logical_core(sender_logical, CoreType::DRAM);
             cluster.write_core(
                 dev->id(),
@@ -400,30 +376,21 @@ void GlobalCircularBuffer::setup_cb_buffers(
         pages_sent_worker_l1_base_ = pages_sent_address;
     }
 
-    // The canonical (reference-device) sender role for each mapping entry is device-independent;
-    // resolve it once here so the per-device config build only performs the target-device index lookup.
-    std::vector<std::pair<uint32_t, size_t>> canonical_roles;  // {bank_id, role}
     if (sender_core_type == experimental::SenderCoreType::Dram) {
         TT_FATAL(dram_sender_mesh_device != nullptr, "DRAM-sender GCB config requires its MeshDevice");
-        canonical_roles.reserve(sender_receiver_core_mapping_.size());
-        for (const auto& [canonical_sender, _receivers] : sender_receiver_core_mapping_) {
-            canonical_roles.emplace_back(
-                static_cast<uint32_t>(canonical_sender.x),
-                canonical_sender_role(dram_sender_mesh_device, canonical_sender));
-        }
     }
 
     const auto make_config_host_buffer = [&](IDevice* config_device) {
         std::vector<uint32_t> cb_config_host_buffer(cb_config_size / sizeof(uint32_t), 0);
         for (size_t s = 0; s < sender_receiver_core_mapping_.size(); ++s) {
-            const auto& [canonical_sender, receiver_cores] = sender_receiver_core_mapping_[s];
+            const auto& [sender_logical, receiver_cores] = sender_receiver_core_mapping_[s];
             const auto& receiver_cores_vec = corerange_to_cores(receiver_cores);
             uint32_t num_receivers = receiver_cores.num_cores();
 
             // Worker senders have their own config page in the sharded buffer; DRAM senders don't
             // (the DRISC kernel hand-rolls the sender iface state from compile-time args).
             if (sender_core_type == experimental::SenderCoreType::Worker) {
-                uint32_t sender_idx = core_to_core_id.at(canonical_sender) * cb_config_page_size / sizeof(uint32_t);
+                uint32_t sender_idx = core_to_core_id.at(sender_logical) * cb_config_page_size / sizeof(uint32_t);
                 cb_config_host_buffer[sender_idx++] = 1;
                 cb_config_host_buffer[sender_idx++] = num_receivers;
                 cb_config_host_buffer[sender_idx++] = buffer_address;
@@ -442,13 +409,12 @@ void GlobalCircularBuffer::setup_cb_buffers(
             }
 
             // Sender's physical NOC coord -- where the receiver's pages_acked NOC-inc lands. For
-            // worker senders this is the worker phys; for DRAM senders it is the target device's
-            // DRAM virtual coord for the canonical sender's stable bank/role.
-            const CoreCoord sender_logical =
-                (sender_core_type == experimental::SenderCoreType::Dram)
-                    ? device_sender_for_role(
-                          dram_sender_mesh_device, config_device, canonical_roles[s].first, canonical_roles[s].second)
-                    : canonical_sender;
+            // worker senders this is the worker phys; for DRAM senders it is the target device's own
+            // DRAM virtual coord for this sender's bank/role, which differs across devices with
+            // different DRAM harvest masks even though the logical coord does not.
+            if (sender_core_type == experimental::SenderCoreType::Dram) {
+                validate_dram_sender_on_device(dram_sender_mesh_device, config_device, sender_logical);
+            }
             CoreCoord sender_physical_coord =
                 (sender_core_type == experimental::SenderCoreType::Worker)
                     ? config_device->worker_core_from_logical_core(sender_logical)
@@ -613,9 +579,10 @@ std::vector<std::pair<CoreCoord, CoreRangeSet>> build_dram_sender_mapping(
     distributed::MeshDevice* mesh_device,
     const std::vector<std::pair<uint32_t, CoreRangeSet>>& bank_to_receivers,
     bool dual_senders_per_bank) {
-    // The mapping is keyed by canonical-device logical coords; per-device sender placement is
-    // resolved from each entry's (bank, role) when the GCB is written to a device.
-    const IDevice* canonical_device = canonical_sender_device(mesh_device);
+    // Logical DRAM sender coords name an endpoint role, so resolving them against any one device
+    // gives the mapping for the whole mesh; each device translates them to its own physical
+    // subchannel, and validate_dram_sender_on_device rechecks that when the GCB is written out.
+    const IDevice* reference_device = mesh_device->get_devices().at(0);
     std::vector<std::pair<CoreCoord, CoreRangeSet>> mapping;
     mapping.reserve((dual_senders_per_bank ? 2 : 1) * bank_to_receivers.size());
     std::unordered_set<uint32_t> seen_banks;
@@ -631,7 +598,7 @@ std::vector<std::pair<CoreCoord, CoreRangeSet>> build_dram_sender_mapping(
         if (!dual_senders_per_bank) {
             // Single sender per bank (the free non-endpoint subchannel).
             mapping.emplace_back(
-                mesh_device->impl().pick_unused_dram_logical_core(canonical_device, bank_id), receivers);
+                mesh_device->impl().pick_unused_dram_logical_core(reference_device, bank_id), receivers);
             continue;
         }
 
@@ -641,7 +608,7 @@ std::vector<std::pair<CoreCoord, CoreRangeSet>> build_dram_sender_mapping(
         // secondary parked — same as the single-sender path. Dual- and single-sender banks may
         // therefore coexist in one dual-mode GCB.
         const std::vector<CoreCoord> sender_cores =
-            mesh_device->impl().dram_sender_logical_cores(canonical_device, bank_id);
+            mesh_device->impl().dram_sender_logical_cores(reference_device, bank_id);
         if (n == 1) {
             mapping.emplace_back(sender_cores.at(0), receivers);
             continue;

--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -118,7 +118,7 @@ GlobalCircularBuffer::GlobalCircularBuffer(
         receiver_cores_,
         all_cores_,
         max_num_receivers_per_sender);
-    this->setup_cb_buffers(buffer_type, max_num_receivers_per_sender);
+    this->setup_cb_buffers(buffer_type, max_num_receivers_per_sender, /*dram_sender_mesh_device=*/nullptr);
 }
 
 GlobalCircularBuffer::GlobalCircularBuffer(

--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -377,7 +377,15 @@ void GlobalCircularBuffer::setup_cb_buffers(BufferType buffer_type, uint32_t max
     const auto make_config_host_buffer = [&](IDevice* config_device) {
         std::vector<uint32_t> cb_config_host_buffer(cb_config_size / sizeof(uint32_t), 0);
         for (const auto& [sender_logical, receiver_cores] : sender_receiver_core_mapping_) {
-            const auto& receiver_cores_vec = corerange_to_cores(receiver_cores);
+            // Row-wise: this vector's index is the receiver's credit slot -- it picks both the
+            // sender's NOC XY table order and each receiver's pages_sent/pages_acked offsets below,
+            // and the sender walks the two in lockstep. A DRAM sender's table is built from
+            // receiver_logical_cores_per_sender_ (also row-wise), so a column-wise order here would
+            // credit the wrong receiver whenever a sender's receiver set spans several rows and
+            // columns. Worker senders take their table from this same vector, so they stay
+            // self-consistent either way.
+            const auto& receiver_cores_vec =
+                corerange_to_cores(receiver_cores, /*max_cores=*/std::nullopt, /*row_wise=*/true);
             uint32_t num_receivers = receiver_cores.num_cores();
 
             // Worker senders have their own config page in the sharded buffer; DRAM senders don't
@@ -451,6 +459,13 @@ void GlobalCircularBuffer::setup_cb_buffers(BufferType buffer_type, uint32_t max
         std::vector<distributed::ShardDataTransfer> shard_data_transfers;
         shard_data_transfers.reserve(device_coords.shape().mesh_size());
         for (const auto& coord : device_coords) {
+            // A mesh view can span slots whose devices belong to another host/rank; get_device
+            // TT_FATALs on those. Writing only the local shards matches what the broadcast path
+            // below does (enqueue_write_shard_to_sub_grid skips non-local coords) -- each rank
+            // fills in its own.
+            if (!mesh_device->is_local(coord)) {
+                continue;
+            }
             per_device_config.push_back(make_config_host_buffer(mesh_device->get_device(coord)));
             shard_data_transfers.push_back(
                 distributed::ShardDataTransfer(coord).host_data(per_device_config.back().data()));
@@ -578,7 +593,13 @@ std::vector<std::pair<CoreCoord, CoreRangeSet>> build_dram_sender_mapping(
     bool dual_senders_per_bank) {
     // Sender coords name endpoint roles, so resolving them against any one device gives the
     // mapping for the whole mesh; the GCB ctor rechecks that against every device.
-    const IDevice* reference_device = mesh_device->get_devices().at(0);
+    const auto& devices = mesh_device->get_devices();
+    TT_FATAL(
+        !devices.empty(),
+        "Cannot build a DRAM sender mapping for a mesh with no local devices (shape {}); a submesh whose slots are "
+        "all owned by another host/rank has no device to resolve the senders' endpoint roles against.",
+        mesh_device->shape());
+    const IDevice* reference_device = devices.front();
     std::vector<std::pair<CoreCoord, CoreRangeSet>> mapping;
     mapping.reserve((dual_senders_per_bank ? 2 : 1) * bank_to_receivers.size());
     std::unordered_set<uint32_t> seen_banks;

--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -137,7 +137,7 @@ GlobalCircularBuffer::GlobalCircularBuffer(
     TT_FATAL(
         hal.has_programmable_core_type(HalProgrammableCoreType::DRAM),
         "DRAM-sender GlobalCircularBuffer requires programmable DRAM cores, which auto-enable on Blackhole "
-        "with firmware >= 19.12.0.0 and either no harvested DRAM channels or a single device");
+        "with firmware >= 19.12.0.0");
     uint32_t max_num_receivers_per_sender = 0;
     initialize_global_circular_buffer(
         mesh_device,
@@ -148,8 +148,10 @@ GlobalCircularBuffer::GlobalCircularBuffer(
         all_cores_,
         max_num_receivers_per_sender);
 
-    // Pre-compute physical worker NOC XY for each sender's receivers (the DRISC kernel
-    // pushes to these as runtime args).
+    // Preserve the reference device's physical worker NOC XY for the experimental
+    // receiver_coords_per_sender accessor. Device-bound sender-state initialization
+    // below resolves worker coordinates independently for every device.
+    IDevice* reference_device = mesh_device->get_devices().at(0);
     receiver_coords_per_sender_.reserve(sender_receiver_core_mapping.size());
     for (const auto& [_sender_core, receivers] : sender_receiver_core_mapping) {
         // Row-wise, to match both the dual-sender ceil/floor split (select_from_corerangeset
@@ -160,7 +162,7 @@ GlobalCircularBuffer::GlobalCircularBuffer(
         std::vector<CoreCoord> phys;
         phys.reserve(receivers_vec.size());
         for (const auto& r : receivers_vec) {
-            phys.emplace_back(device_->worker_core_from_logical_core(r));
+            phys.emplace_back(reference_device->worker_core_from_logical_core(r));
         }
         receiver_coords_per_sender_.push_back(std::move(phys));
     }
@@ -186,7 +188,7 @@ GlobalCircularBuffer::GlobalCircularBuffer(
     pages_sent_drisc_l1_base_ = drisc_sender_state_alloc_->addr();
     sender_state_drisc_l1_base_ = pages_sent_drisc_l1_base_ + pages_sent_region;
 
-    this->setup_cb_buffers(buffer_type, max_num_receivers_per_sender);
+    this->setup_cb_buffers(buffer_type, max_num_receivers_per_sender, mesh_device);
     this->initialize_dram_sender_state_block(mesh_device, max_num_receivers_per_sender);
 }
 
@@ -208,6 +210,34 @@ std::vector<uint32_t> recv_index_bases_per_sender(const std::vector<std::pair<Co
     }
     return bases;
 }
+
+// A DRAM-sender GCB exposes the reference device's logical sender coordinates for API
+// compatibility. Resolve that canonical coordinate to its stable sender role within the
+// bank, then select the corresponding logical core from the target device's harvested
+// topology.
+CoreCoord resolve_dram_sender_for_device(
+    distributed::MeshDevice* mesh_device, const IDevice* device, const CoreCoord& canonical_sender) {
+    const uint32_t bank_id = static_cast<uint32_t>(canonical_sender.x);
+    const std::vector<CoreCoord> canonical_senders = mesh_device->impl().dram_sender_logical_cores(bank_id);
+    const auto canonical_it = std::find(canonical_senders.begin(), canonical_senders.end(), canonical_sender);
+    TT_FATAL(
+        canonical_it != canonical_senders.end(),
+        "Canonical DRAM sender ({}, {}) is not a provisioned sender for bank {}",
+        canonical_sender.x,
+        canonical_sender.y,
+        bank_id);
+    const size_t sender_role = std::distance(canonical_senders.begin(), canonical_it);
+
+    const std::vector<CoreCoord> device_senders = mesh_device->impl().dram_sender_logical_cores(device, bank_id);
+    TT_FATAL(
+        sender_role < device_senders.size(),
+        "Device {} has {} DRAM senders for bank {}, but canonical sender role {} is required",
+        device->id(),
+        device_senders.size(),
+        bank_id,
+        sender_role);
+    return device_senders[sender_role];
+}
 }  // namespace
 
 void GlobalCircularBuffer::initialize_dram_sender_state_block(
@@ -227,8 +257,8 @@ void GlobalCircularBuffer::initialize_dram_sender_state_block(
     const uint32_t packed_num_recv_and_remote =
         remote_cb_pack(max_num_receivers_per_sender, static_cast<uint32_t>(pages_sent_worker_l1_base_));
 
-    // Block is identical across (device, sender) pairs; only the receiver NOC XY
-    // table varies per sender. Compose once, swap in the table per sender.
+    // The fixed header fields are common, while the receiver NOC XY table is composed
+    // separately for each (device, sender) pair.
     std::vector<uint8_t> block_bytes(state_block_size, 0);
     auto* hdr = reinterpret_cast<DramSenderStateBlock*>(block_bytes.data());
     hdr->config_ptr = config_block_addr;
@@ -262,9 +292,9 @@ void GlobalCircularBuffer::initialize_dram_sender_state_block(
     // when two senders share a bank, the second reads slabs that start where the first's end.
     const std::vector<uint32_t> recv_index_bases = recv_index_bases_per_sender(sender_receiver_core_mapping_);
     for (size_t s = 0; s < sender_receiver_core_mapping_.size(); ++s) {
-        const auto& [sender_logical, _receivers] = sender_receiver_core_mapping_[s];
-        const auto& recv_phys = receiver_coords_per_sender_[s];
-        const uint32_t this_num_receivers = static_cast<uint32_t>(recv_phys.size());
+        const auto& [canonical_sender, receivers] = sender_receiver_core_mapping_[s];
+        const auto receivers_vec = corerange_to_cores(receivers, /*max_cores=*/std::nullopt, /*row_wise=*/true);
+        const uint32_t this_num_receivers = static_cast<uint32_t>(receivers_vec.size());
 
         // Per-sender header fields (the rest of block_bytes is constant across senders).
         hdr->num_receivers = this_num_receivers;
@@ -272,13 +302,18 @@ void GlobalCircularBuffer::initialize_dram_sender_state_block(
         hdr->num_receivers_and_remote_pages_sent_ptr =
             remote_cb_pack(this_num_receivers, static_cast<uint32_t>(pages_sent_worker_l1_base_));
 
-        for (uint32_t i = 0; i < max_num_receivers_per_sender; ++i) {
-            const bool valid = i < this_num_receivers;
-            const auto& c = valid ? recv_phys[i] : CoreCoord{0, 0};
-            noc_xy_words[2 * i + 0] = valid ? static_cast<uint32_t>(c.x) : 0u;
-            noc_xy_words[2 * i + 1] = valid ? static_cast<uint32_t>(c.y) : 0u;
-        }
         for (IDevice* dev : devices) {
+            for (uint32_t i = 0; i < max_num_receivers_per_sender; ++i) {
+                if (i < this_num_receivers) {
+                    const CoreCoord receiver_phys = dev->worker_core_from_logical_core(receivers_vec[i]);
+                    noc_xy_words[2 * i + 0] = static_cast<uint32_t>(receiver_phys.x);
+                    noc_xy_words[2 * i + 1] = static_cast<uint32_t>(receiver_phys.y);
+                } else {
+                    noc_xy_words[2 * i + 0] = 0;
+                    noc_xy_words[2 * i + 1] = 0;
+                }
+            }
+            const CoreCoord sender_logical = resolve_dram_sender_for_device(mesh_device, dev, canonical_sender);
             const CoreCoord virtual_core = dev->virtual_core_from_logical_core(sender_logical, CoreType::DRAM);
             cluster.write_core(
                 dev->id(),
@@ -294,7 +329,8 @@ void GlobalCircularBuffer::initialize_dram_sender_state_block(
     }
 }
 
-void GlobalCircularBuffer::setup_cb_buffers(BufferType buffer_type, uint32_t max_num_receivers_per_sender) {
+void GlobalCircularBuffer::setup_cb_buffers(
+    BufferType buffer_type, uint32_t max_num_receivers_per_sender, distributed::MeshDevice* dram_sender_mesh_device) {
     TT_FATAL(
         buffer_type == BufferType::L1 or buffer_type == BufferType::L1_SMALL,
         "Global circular buffer can only be created for L1 buffer types");
@@ -337,7 +373,6 @@ void GlobalCircularBuffer::setup_cb_buffers(BufferType buffer_type, uint32_t max
     // Only block for the slow dispatch case
     auto config_buffer_address = cb_config_buffer_.get_buffer()->address();
     const auto& core_to_core_id = cb_config_buffer_.get_buffer()->get_buffer_page_mapping()->core_to_core_id;
-    std::vector<uint32_t> cb_config_host_buffer(cb_config_size / sizeof(uint32_t), 0);
     uint32_t noc_xy_address = config_buffer_address + (num_config_elements * sizeof(uint32_t));
     uint32_t pages_sent_address = tt::align(noc_xy_address + (num_noc_xy_words * sizeof(uint32_t)), l1_alignment);
     auto buffer_address = cb_buffer().address();
@@ -350,64 +385,92 @@ void GlobalCircularBuffer::setup_cb_buffers(BufferType buffer_type, uint32_t max
         pages_sent_worker_l1_base_ = pages_sent_address;
     }
 
-    for (const auto& [sender_core, receiver_cores] : sender_receiver_core_mapping_) {
-        const auto& receiver_cores_vec = corerange_to_cores(receiver_cores);
-        uint32_t num_receivers = receiver_cores.num_cores();
+    const auto make_config_host_buffer = [&](IDevice* config_device) {
+        std::vector<uint32_t> cb_config_host_buffer(cb_config_size / sizeof(uint32_t), 0);
+        for (const auto& [canonical_sender, receiver_cores] : sender_receiver_core_mapping_) {
+            const auto& receiver_cores_vec = corerange_to_cores(receiver_cores);
+            uint32_t num_receivers = receiver_cores.num_cores();
 
-        // Worker senders have their own config page in the sharded buffer; DRAM senders don't
-        // (the DRISC kernel hand-rolls the sender iface state from compile-time args).
-        if (sender_core_type == experimental::SenderCoreType::Worker) {
-            uint32_t sender_idx = core_to_core_id.at(sender_core) * cb_config_page_size / sizeof(uint32_t);
-            cb_config_host_buffer[sender_idx++] = 1;
-            cb_config_host_buffer[sender_idx++] = num_receivers;
-            cb_config_host_buffer[sender_idx++] = buffer_address;
-            cb_config_host_buffer[sender_idx++] = size_;
-            cb_config_host_buffer[sender_idx++] = buffer_address;
-            cb_config_host_buffer[sender_idx++] = noc_xy_address;
-            cb_config_host_buffer[sender_idx++] = pages_sent_address;
-            // Sharded GCB: the sender's NOC inc lands at the same L1 offset on the receiver's
-            // side, so the remote address equals aligned_pages_sent_ptr.
-            cb_config_host_buffer[sender_idx++] = pages_sent_address;
-            for (const auto& receiver_logical : receiver_cores_vec) {
-                auto receiver_physical_coord = device_->worker_core_from_logical_core(receiver_logical);
-                cb_config_host_buffer[sender_idx++] = receiver_physical_coord.x;
-                cb_config_host_buffer[sender_idx++] = receiver_physical_coord.y;
+            // Worker senders have their own config page in the sharded buffer; DRAM senders don't
+            // (the DRISC kernel hand-rolls the sender iface state from compile-time args).
+            if (sender_core_type == experimental::SenderCoreType::Worker) {
+                uint32_t sender_idx = core_to_core_id.at(canonical_sender) * cb_config_page_size / sizeof(uint32_t);
+                cb_config_host_buffer[sender_idx++] = 1;
+                cb_config_host_buffer[sender_idx++] = num_receivers;
+                cb_config_host_buffer[sender_idx++] = buffer_address;
+                cb_config_host_buffer[sender_idx++] = size_;
+                cb_config_host_buffer[sender_idx++] = buffer_address;
+                cb_config_host_buffer[sender_idx++] = noc_xy_address;
+                cb_config_host_buffer[sender_idx++] = pages_sent_address;
+                // Sharded GCB: the sender's NOC inc lands at the same L1 offset on the receiver's
+                // side, so the remote address equals aligned_pages_sent_ptr.
+                cb_config_host_buffer[sender_idx++] = pages_sent_address;
+                for (const auto& receiver_logical : receiver_cores_vec) {
+                    auto receiver_physical_coord = config_device->worker_core_from_logical_core(receiver_logical);
+                    cb_config_host_buffer[sender_idx++] = receiver_physical_coord.x;
+                    cb_config_host_buffer[sender_idx++] = receiver_physical_coord.y;
+                }
+            }
+
+            // Sender's physical NOC coord -- where the receiver's pages_acked NOC-inc lands. For
+            // worker senders this is the worker phys; for DRAM senders it is the target device's
+            // DRAM virtual coord for the canonical sender's stable bank/role.
+            const CoreCoord sender_logical =
+                (sender_core_type == experimental::SenderCoreType::Dram)
+                    ? resolve_dram_sender_for_device(dram_sender_mesh_device, config_device, canonical_sender)
+                    : canonical_sender;
+            CoreCoord sender_physical_coord =
+                (sender_core_type == experimental::SenderCoreType::Worker)
+                    ? config_device->worker_core_from_logical_core(sender_logical)
+                    : config_device->virtual_core_from_logical_core(sender_logical, CoreType::DRAM);
+
+            for (uint32_t i = 0; i < receiver_cores_vec.size(); i++) {
+                uint32_t receiver_idx =
+                    core_to_core_id.at(receiver_cores_vec[i]) * cb_config_page_size / sizeof(uint32_t);
+                cb_config_host_buffer[receiver_idx++] = 0;  // is_sender
+                cb_config_host_buffer[receiver_idx++] = num_receivers;
+                cb_config_host_buffer[receiver_idx++] = buffer_address;
+                cb_config_host_buffer[receiver_idx++] = size_;
+                cb_config_host_buffer[receiver_idx++] = buffer_address;
+                cb_config_host_buffer[receiver_idx++] = noc_xy_address;
+                // aligned_pages_sent_ptr; pages_acked for this receiver lives at +L1_ALIGNMENT.
+                cb_config_host_buffer[receiver_idx++] = pages_sent_address + 2 * i * l1_alignment;
+                // remote_pages_addr_override: the address on the SENDER's L1 where this receiver's
+                // NoC-inc for pages_acked lands. For a sharded GCB sender and receiver share an L1
+                // layout so this equals aligned_pages_acked_ptr. For a DRAM-sender GCB it points at
+                // the per-receiver pages_acked slot in DRISC L1 (packed at uint32 stride, mirroring
+                // the kernel's REMOTE_CB_LOCAL_PAGES_*).
+                constexpr uint32_t drisc_slot = sizeof(uint32_t);
+                cb_config_host_buffer[receiver_idx++] =
+                    (sender_core_type == experimental::SenderCoreType::Dram)
+                        ? static_cast<uint32_t>(pages_sent_drisc_l1_base_ + 2 * i * drisc_slot + drisc_slot)
+                        : (pages_sent_address + 2 * i * l1_alignment + l1_alignment);
+                cb_config_host_buffer[receiver_idx++] = sender_physical_coord.x;
+                cb_config_host_buffer[receiver_idx++] = sender_physical_coord.y;
             }
         }
+        return cb_config_host_buffer;
+    };
 
-        // Sender's physical NOC coord -- where the receiver's pages_acked NOC-inc lands. For
-        // worker senders this is the worker phys; for DRAM senders it's the DRAM virtual coord.
-        CoreCoord sender_physical_coord = (sender_core_type == experimental::SenderCoreType::Worker)
-                                              ? device_->worker_core_from_logical_core(sender_core)
-                                              : device_->virtual_core_from_logical_core(sender_core, CoreType::DRAM);
-
-        for (uint32_t i = 0; i < receiver_cores_vec.size(); i++) {
-            uint32_t receiver_idx = core_to_core_id.at(receiver_cores_vec[i]) * cb_config_page_size / sizeof(uint32_t);
-            cb_config_host_buffer[receiver_idx++] = 0;  // is_sender
-            cb_config_host_buffer[receiver_idx++] = num_receivers;
-            cb_config_host_buffer[receiver_idx++] = buffer_address;
-            cb_config_host_buffer[receiver_idx++] = size_;
-            cb_config_host_buffer[receiver_idx++] = buffer_address;
-            cb_config_host_buffer[receiver_idx++] = noc_xy_address;
-            // aligned_pages_sent_ptr; pages_acked for this receiver lives at +L1_ALIGNMENT.
-            cb_config_host_buffer[receiver_idx++] = pages_sent_address + 2 * i * l1_alignment;
-            // remote_pages_addr_override: the address on the SENDER's L1 where this receiver's
-            // NoC-inc for pages_acked lands. For a sharded GCB sender and receiver share an L1
-            // layout so this equals aligned_pages_acked_ptr. For a DRAM-sender GCB it points at
-            // the per-receiver pages_acked slot in DRISC L1 (packed at uint32 stride, mirroring
-            // the kernel's REMOTE_CB_LOCAL_PAGES_*).
-            constexpr uint32_t drisc_slot = sizeof(uint32_t);
-            cb_config_host_buffer[receiver_idx++] =
-                (sender_core_type == experimental::SenderCoreType::Dram)
-                    ? static_cast<uint32_t>(pages_sent_drisc_l1_base_ + 2 * i * drisc_slot + drisc_slot)
-                    : (pages_sent_address + 2 * i * l1_alignment + l1_alignment);
-            cb_config_host_buffer[receiver_idx++] = sender_physical_coord.x;
-            cb_config_host_buffer[receiver_idx++] = sender_physical_coord.y;
-        }
-    }
     auto mesh_buffer = cb_config_buffer_.get_mesh_buffer();
-    distributed::EnqueueWriteMeshBuffer(
-        mesh_buffer->device()->mesh_command_queue(), mesh_buffer, cb_config_host_buffer, false);
+    if (sender_core_type == experimental::SenderCoreType::Dram) {
+        TT_FATAL(dram_sender_mesh_device != nullptr, "DRAM-sender GCB config requires its MeshDevice");
+        for (IDevice* config_device : dram_sender_mesh_device->get_devices()) {
+            std::vector<uint32_t> cb_config_host_buffer = make_config_host_buffer(config_device);
+            const distributed::MeshCoordinate device_coord =
+                dram_sender_mesh_device->get_view().find_device(config_device->id());
+            distributed::WriteShard(
+                mesh_buffer->device()->mesh_command_queue(),
+                mesh_buffer,
+                cb_config_host_buffer,
+                device_coord,
+                /*blocking=*/true);
+        }
+    } else {
+        std::vector<uint32_t> cb_config_host_buffer = make_config_host_buffer(device_);
+        distributed::EnqueueWriteMeshBuffer(
+            mesh_buffer->device()->mesh_command_queue(), mesh_buffer, cb_config_host_buffer, false);
+    }
 }
 
 const Buffer& GlobalCircularBuffer::cb_buffer() const { return *cb_buffer_.get_buffer(); }

--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -212,11 +212,10 @@ std::vector<uint32_t> recv_index_bases_per_sender(const std::vector<std::pair<Co
 }
 
 // A DRAM-sender GCB exposes the reference device's logical sender coordinates for API
-// compatibility. Resolve that canonical coordinate to its stable sender role within the
-// bank, then select the corresponding logical core from the target device's harvested
-// topology.
-CoreCoord resolve_dram_sender_for_device(
-    distributed::MeshDevice* mesh_device, const IDevice* device, const CoreCoord& canonical_sender) {
+// compatibility. `canonical_sender_role` recovers a canonical coordinate's stable role
+// (its index within the bank's ordered sender list). It depends only on the reference
+// device, so callers resolve it once per sender rather than once per (sender, device).
+size_t canonical_sender_role(distributed::MeshDevice* mesh_device, const CoreCoord& canonical_sender) {
     const uint32_t bank_id = static_cast<uint32_t>(canonical_sender.x);
     const std::vector<CoreCoord> canonical_senders = mesh_device->impl().dram_sender_logical_cores(bank_id);
     const auto canonical_it = std::find(canonical_senders.begin(), canonical_senders.end(), canonical_sender);
@@ -226,8 +225,13 @@ CoreCoord resolve_dram_sender_for_device(
         canonical_sender.x,
         canonical_sender.y,
         bank_id);
-    const size_t sender_role = std::distance(canonical_senders.begin(), canonical_it);
+    return static_cast<size_t>(std::distance(canonical_senders.begin(), canonical_it));
+}
 
+// Selects the logical DRAM core that plays `sender_role` for `bank_id` on `device`'s
+// harvested topology.
+CoreCoord device_sender_for_role(
+    distributed::MeshDevice* mesh_device, const IDevice* device, uint32_t bank_id, size_t sender_role) {
     const std::vector<CoreCoord> device_senders = mesh_device->impl().dram_sender_logical_cores(device, bank_id);
     TT_FATAL(
         sender_role < device_senders.size(),
@@ -302,6 +306,10 @@ void GlobalCircularBuffer::initialize_dram_sender_state_block(
         hdr->num_receivers_and_remote_pages_sent_ptr =
             remote_cb_pack(this_num_receivers, static_cast<uint32_t>(pages_sent_worker_l1_base_));
 
+        // The canonical sender role is device-independent; resolve it once per sender.
+        const uint32_t bank_id = static_cast<uint32_t>(canonical_sender.x);
+        const size_t sender_role = canonical_sender_role(mesh_device, canonical_sender);
+
         for (IDevice* dev : devices) {
             for (uint32_t i = 0; i < max_num_receivers_per_sender; ++i) {
                 if (i < this_num_receivers) {
@@ -313,7 +321,7 @@ void GlobalCircularBuffer::initialize_dram_sender_state_block(
                     noc_xy_words[2 * i + 1] = 0;
                 }
             }
-            const CoreCoord sender_logical = resolve_dram_sender_for_device(mesh_device, dev, canonical_sender);
+            const CoreCoord sender_logical = device_sender_for_role(mesh_device, dev, bank_id, sender_role);
             const CoreCoord virtual_core = dev->virtual_core_from_logical_core(sender_logical, CoreType::DRAM);
             cluster.write_core(
                 dev->id(),
@@ -385,9 +393,23 @@ void GlobalCircularBuffer::setup_cb_buffers(
         pages_sent_worker_l1_base_ = pages_sent_address;
     }
 
+    // The canonical (reference-device) sender role for each mapping entry is device-independent;
+    // resolve it once here so the per-device config build only performs the target-device index lookup.
+    std::vector<std::pair<uint32_t, size_t>> canonical_roles;  // {bank_id, role}
+    if (sender_core_type == experimental::SenderCoreType::Dram) {
+        TT_FATAL(dram_sender_mesh_device != nullptr, "DRAM-sender GCB config requires its MeshDevice");
+        canonical_roles.reserve(sender_receiver_core_mapping_.size());
+        for (const auto& [canonical_sender, _receivers] : sender_receiver_core_mapping_) {
+            canonical_roles.emplace_back(
+                static_cast<uint32_t>(canonical_sender.x),
+                canonical_sender_role(dram_sender_mesh_device, canonical_sender));
+        }
+    }
+
     const auto make_config_host_buffer = [&](IDevice* config_device) {
         std::vector<uint32_t> cb_config_host_buffer(cb_config_size / sizeof(uint32_t), 0);
-        for (const auto& [canonical_sender, receiver_cores] : sender_receiver_core_mapping_) {
+        for (size_t s = 0; s < sender_receiver_core_mapping_.size(); ++s) {
+            const auto& [canonical_sender, receiver_cores] = sender_receiver_core_mapping_[s];
             const auto& receiver_cores_vec = corerange_to_cores(receiver_cores);
             uint32_t num_receivers = receiver_cores.num_cores();
 
@@ -417,7 +439,8 @@ void GlobalCircularBuffer::setup_cb_buffers(
             // DRAM virtual coord for the canonical sender's stable bank/role.
             const CoreCoord sender_logical =
                 (sender_core_type == experimental::SenderCoreType::Dram)
-                    ? resolve_dram_sender_for_device(dram_sender_mesh_device, config_device, canonical_sender)
+                    ? device_sender_for_role(
+                          dram_sender_mesh_device, config_device, canonical_roles[s].first, canonical_roles[s].second)
                     : canonical_sender;
             CoreCoord sender_physical_coord =
                 (sender_core_type == experimental::SenderCoreType::Worker)
@@ -454,7 +477,6 @@ void GlobalCircularBuffer::setup_cb_buffers(
 
     auto mesh_buffer = cb_config_buffer_.get_mesh_buffer();
     if (sender_core_type == experimental::SenderCoreType::Dram) {
-        TT_FATAL(dram_sender_mesh_device != nullptr, "DRAM-sender GCB config requires its MeshDevice");
         for (IDevice* config_device : dram_sender_mesh_device->get_devices()) {
             std::vector<uint32_t> cb_config_host_buffer = make_config_host_buffer(config_device);
             const distributed::MeshCoordinate device_coord =

--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -211,13 +211,20 @@ std::vector<uint32_t> recv_index_bases_per_sender(const std::vector<std::pair<Co
     return bases;
 }
 
-// A DRAM-sender GCB exposes the reference device's logical sender coordinates for API
+// The device whose logical DRAM coordinates a DRAM-sender GCB's public
+// sender_receiver_core_mapping() is expressed in: the mesh's reference device. Logical DRAM
+// sender coords are per-device (harvest masks differ), so this is the one place that fixes
+// which device the mapping names; every device-bound use goes through device_sender_for_role.
+IDevice* canonical_sender_device(distributed::MeshDevice* mesh_device) { return mesh_device->get_devices().at(0); }
+
+// A DRAM-sender GCB exposes the canonical device's logical sender coordinates for API
 // compatibility. `canonical_sender_role` recovers a canonical coordinate's stable role
-// (its index within the bank's ordered sender list). It depends only on the reference
+// (its index within the bank's ordered sender list). It depends only on the canonical
 // device, so callers resolve it once per sender rather than once per (sender, device).
 size_t canonical_sender_role(distributed::MeshDevice* mesh_device, const CoreCoord& canonical_sender) {
     const uint32_t bank_id = static_cast<uint32_t>(canonical_sender.x);
-    const std::vector<CoreCoord> canonical_senders = mesh_device->impl().dram_sender_logical_cores(bank_id);
+    const std::vector<CoreCoord> canonical_senders =
+        mesh_device->impl().dram_sender_logical_cores(canonical_sender_device(mesh_device), bank_id);
     const auto canonical_it = std::find(canonical_senders.begin(), canonical_senders.end(), canonical_sender);
     TT_FATAL(
         canonical_it != canonical_senders.end(),
@@ -606,6 +613,9 @@ std::vector<std::pair<CoreCoord, CoreRangeSet>> build_dram_sender_mapping(
     distributed::MeshDevice* mesh_device,
     const std::vector<std::pair<uint32_t, CoreRangeSet>>& bank_to_receivers,
     bool dual_senders_per_bank) {
+    // The mapping is keyed by canonical-device logical coords; per-device sender placement is
+    // resolved from each entry's (bank, role) when the GCB is written to a device.
+    const IDevice* canonical_device = canonical_sender_device(mesh_device);
     std::vector<std::pair<CoreCoord, CoreRangeSet>> mapping;
     mapping.reserve((dual_senders_per_bank ? 2 : 1) * bank_to_receivers.size());
     std::unordered_set<uint32_t> seen_banks;
@@ -620,7 +630,8 @@ std::vector<std::pair<CoreCoord, CoreRangeSet>> build_dram_sender_mapping(
 
         if (!dual_senders_per_bank) {
             // Single sender per bank (the free non-endpoint subchannel).
-            mapping.emplace_back(mesh_device->impl().pick_unused_dram_logical_core(bank_id), receivers);
+            mapping.emplace_back(
+                mesh_device->impl().pick_unused_dram_logical_core(canonical_device, bank_id), receivers);
             continue;
         }
 
@@ -629,7 +640,8 @@ std::vector<std::pair<CoreCoord, CoreRangeSet>> build_dram_sender_mapping(
         // actually maps, we can map just the primary sender for such a bank and leave the
         // secondary parked — same as the single-sender path. Dual- and single-sender banks may
         // therefore coexist in one dual-mode GCB.
-        const std::vector<CoreCoord> sender_cores = mesh_device->impl().dram_sender_logical_cores(bank_id);
+        const std::vector<CoreCoord> sender_cores =
+            mesh_device->impl().dram_sender_logical_cores(canonical_device, bank_id);
         if (n == 1) {
             mapping.emplace_back(sender_cores.at(0), receivers);
             continue;

--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -54,6 +54,32 @@ uint32_t remote_cb_pack(uint32_t num_receivers, uint32_t remote_pages_sent_ptr) 
            (remote_pages_sent_ptr & dev_msgs::REMOTE_CB_PACKED_ADDR_MASK);
 }
 
+// One sender mapping serves the whole mesh because a logical DRAM coord names an endpoint role
+// (see metal_SocDescriptor::dram_bank_endpoint_coords). Check that once here rather than trusting
+// it: a descriptor whose endpoint layout didn't reproduce the role would silently drive the wrong
+// DRISC core, and a sender that isn't provisioned for its bank would take credits nobody returns.
+void validate_dram_senders_across_mesh(
+    distributed::MeshDevice* mesh_device, const std::vector<std::pair<CoreCoord, CoreRangeSet>>& mapping) {
+    std::unordered_map<uint32_t, std::vector<CoreCoord>> senders_by_bank;
+    for (const IDevice* device : mesh_device->get_devices()) {
+        senders_by_bank.clear();
+        for (const auto& [sender_logical, _receivers] : mapping) {
+            const auto bank_id = static_cast<uint32_t>(sender_logical.x);
+            auto [it, inserted] = senders_by_bank.try_emplace(bank_id);
+            if (inserted) {
+                it->second = mesh_device->impl().dram_sender_logical_cores(device, bank_id);
+            }
+            TT_FATAL(
+                std::find(it->second.begin(), it->second.end(), sender_logical) != it->second.end(),
+                "DRAM sender ({}, {}) is not a provisioned sender for bank {} on device {}",
+                sender_logical.x,
+                sender_logical.y,
+                bank_id,
+                device->id());
+        }
+    }
+}
+
 // Body shared by the public Worker ctor and the private DRAM-sender ctor (with tag).
 // Populates the core sets and reports the per-sender max receiver count.
 void initialize_global_circular_buffer(
@@ -118,7 +144,7 @@ GlobalCircularBuffer::GlobalCircularBuffer(
         receiver_cores_,
         all_cores_,
         max_num_receivers_per_sender);
-    this->setup_cb_buffers(buffer_type, max_num_receivers_per_sender, /*dram_sender_mesh_device=*/nullptr);
+    this->setup_cb_buffers(buffer_type, max_num_receivers_per_sender);
 }
 
 GlobalCircularBuffer::GlobalCircularBuffer(
@@ -148,23 +174,16 @@ GlobalCircularBuffer::GlobalCircularBuffer(
         all_cores_,
         max_num_receivers_per_sender);
 
-    // Preserve the reference device's physical worker NOC XY for the experimental
-    // receiver_coords_per_sender accessor. Device-bound sender-state initialization
-    // below resolves worker coordinates independently for every device.
-    IDevice* reference_device = mesh_device->get_devices().at(0);
-    receiver_coords_per_sender_.reserve(sender_receiver_core_mapping.size());
+    validate_dram_senders_across_mesh(mesh_device, sender_receiver_core_mapping);
+
+    receiver_logical_cores_per_sender_.reserve(sender_receiver_core_mapping.size());
     for (const auto& [_sender_core, receivers] : sender_receiver_core_mapping) {
         // Row-wise, to match both the dual-sender ceil/floor split (select_from_corerangeset
         // with row_wise=true) and the validator's receiver flatten. The slab index
         // recv_index_base+r maps to the r-th receiver in this order, so all three must agree;
         // they only diverge when a bank's receiver set spans multiple rows and columns.
-        const auto& receivers_vec = corerange_to_cores(receivers, /*max_cores=*/std::nullopt, /*row_wise=*/true);
-        std::vector<CoreCoord> phys;
-        phys.reserve(receivers_vec.size());
-        for (const auto& r : receivers_vec) {
-            phys.emplace_back(reference_device->worker_core_from_logical_core(r));
-        }
-        receiver_coords_per_sender_.push_back(std::move(phys));
+        receiver_logical_cores_per_sender_.push_back(
+            corerange_to_cores(receivers, /*max_cores=*/std::nullopt, /*row_wise=*/true));
     }
 
     // Reserve a single per-GCB block in the per-mesh DRISC L1 arena holding both this
@@ -188,7 +207,7 @@ GlobalCircularBuffer::GlobalCircularBuffer(
     pages_sent_drisc_l1_base_ = drisc_sender_state_alloc_->addr();
     sender_state_drisc_l1_base_ = pages_sent_drisc_l1_base_ + pages_sent_region;
 
-    this->setup_cb_buffers(buffer_type, max_num_receivers_per_sender, mesh_device);
+    this->setup_cb_buffers(buffer_type, max_num_receivers_per_sender);
     this->initialize_dram_sender_state_block(mesh_device, max_num_receivers_per_sender);
 }
 
@@ -209,25 +228,6 @@ std::vector<uint32_t> recv_index_bases_per_sender(const std::vector<std::pair<Co
         recv_index_base += mapping[s].second.num_cores();
     }
     return bases;
-}
-
-// A logical DRAM coordinate names an endpoint role rather than a raw subchannel (see
-// metal_SocDescriptor::dram_bank_endpoint_coords), so one sender mapping holds for every device in
-// the mesh even when their DRAM harvest masks differ: each device translates the same logical coord
-// to its own physical subchannel. Check that per device rather than trusting it — a descriptor whose
-// endpoint layout didn't reproduce the role would otherwise silently drive the wrong DRISC core, and
-// a sender that isn't provisioned for its bank would take credits nobody returns.
-void validate_dram_sender_on_device(
-    distributed::MeshDevice* mesh_device, const IDevice* device, const CoreCoord& sender_logical) {
-    const uint32_t bank_id = static_cast<uint32_t>(sender_logical.x);
-    const std::vector<CoreCoord> device_senders = mesh_device->impl().dram_sender_logical_cores(device, bank_id);
-    TT_FATAL(
-        std::find(device_senders.begin(), device_senders.end(), sender_logical) != device_senders.end(),
-        "DRAM sender ({}, {}) is not a provisioned sender for bank {} on device {}",
-        sender_logical.x,
-        sender_logical.y,
-        bank_id,
-        device->id());
 }
 }  // namespace
 
@@ -283,8 +283,8 @@ void GlobalCircularBuffer::initialize_dram_sender_state_block(
     // when two senders share a bank, the second reads slabs that start where the first's end.
     const std::vector<uint32_t> recv_index_bases = recv_index_bases_per_sender(sender_receiver_core_mapping_);
     for (size_t s = 0; s < sender_receiver_core_mapping_.size(); ++s) {
-        const auto& [sender_logical, receivers] = sender_receiver_core_mapping_[s];
-        const auto receivers_vec = corerange_to_cores(receivers, /*max_cores=*/std::nullopt, /*row_wise=*/true);
+        const CoreCoord& sender_logical = sender_receiver_core_mapping_[s].first;
+        const std::vector<CoreCoord>& receivers_vec = receiver_logical_cores_per_sender_[s];
         const uint32_t this_num_receivers = static_cast<uint32_t>(receivers_vec.size());
 
         // Per-sender header fields (the rest of block_bytes is constant across senders).
@@ -294,7 +294,6 @@ void GlobalCircularBuffer::initialize_dram_sender_state_block(
             remote_cb_pack(this_num_receivers, static_cast<uint32_t>(pages_sent_worker_l1_base_));
 
         for (IDevice* dev : devices) {
-            validate_dram_sender_on_device(mesh_device, dev, sender_logical);
             for (uint32_t i = 0; i < max_num_receivers_per_sender; ++i) {
                 if (i < this_num_receivers) {
                     const CoreCoord receiver_phys = dev->worker_core_from_logical_core(receivers_vec[i]);
@@ -320,8 +319,7 @@ void GlobalCircularBuffer::initialize_dram_sender_state_block(
     }
 }
 
-void GlobalCircularBuffer::setup_cb_buffers(
-    BufferType buffer_type, uint32_t max_num_receivers_per_sender, distributed::MeshDevice* dram_sender_mesh_device) {
+void GlobalCircularBuffer::setup_cb_buffers(BufferType buffer_type, uint32_t max_num_receivers_per_sender) {
     TT_FATAL(
         buffer_type == BufferType::L1 or buffer_type == BufferType::L1_SMALL,
         "Global circular buffer can only be created for L1 buffer types");
@@ -376,14 +374,9 @@ void GlobalCircularBuffer::setup_cb_buffers(
         pages_sent_worker_l1_base_ = pages_sent_address;
     }
 
-    if (sender_core_type == experimental::SenderCoreType::Dram) {
-        TT_FATAL(dram_sender_mesh_device != nullptr, "DRAM-sender GCB config requires its MeshDevice");
-    }
-
     const auto make_config_host_buffer = [&](IDevice* config_device) {
         std::vector<uint32_t> cb_config_host_buffer(cb_config_size / sizeof(uint32_t), 0);
-        for (size_t s = 0; s < sender_receiver_core_mapping_.size(); ++s) {
-            const auto& [sender_logical, receiver_cores] = sender_receiver_core_mapping_[s];
+        for (const auto& [sender_logical, receiver_cores] : sender_receiver_core_mapping_) {
             const auto& receiver_cores_vec = corerange_to_cores(receiver_cores);
             uint32_t num_receivers = receiver_cores.num_cores();
 
@@ -409,12 +402,9 @@ void GlobalCircularBuffer::setup_cb_buffers(
             }
 
             // Sender's physical NOC coord -- where the receiver's pages_acked NOC-inc lands. For
-            // worker senders this is the worker phys; for DRAM senders it is the target device's own
-            // DRAM virtual coord for this sender's bank/role, which differs across devices with
-            // different DRAM harvest masks even though the logical coord does not.
-            if (sender_core_type == experimental::SenderCoreType::Dram) {
-                validate_dram_sender_on_device(dram_sender_mesh_device, config_device, sender_logical);
-            }
+            // worker senders this is the worker phys; for DRAM senders it is `config_device`'s own
+            // DRAM virtual coord for this sender's bank/role, which the logical coord does not pin
+            // down (see metal_SocDescriptor::dram_bank_endpoint_coords).
             CoreCoord sender_physical_coord =
                 (sender_core_type == experimental::SenderCoreType::Worker)
                     ? config_device->worker_core_from_logical_core(sender_logical)
@@ -449,22 +439,28 @@ void GlobalCircularBuffer::setup_cb_buffers(
     };
 
     auto mesh_buffer = cb_config_buffer_.get_mesh_buffer();
+    auto* mesh_device = mesh_buffer->device();
     if (sender_core_type == experimental::SenderCoreType::Dram) {
-        for (IDevice* config_device : dram_sender_mesh_device->get_devices()) {
-            std::vector<uint32_t> cb_config_host_buffer = make_config_host_buffer(config_device);
-            const distributed::MeshCoordinate device_coord =
-                dram_sender_mesh_device->get_view().find_device(config_device->id());
-            distributed::WriteShard(
-                mesh_buffer->device()->mesh_command_queue(),
-                mesh_buffer,
-                cb_config_host_buffer,
-                device_coord,
-                /*blocking=*/true);
+        // The DRAM sender's virtual coord is per device (its bank/role resolves against that
+        // device's DRAM harvest mask), so each device gets its own config page. One
+        // enqueue_write_shards fans the shards out in parallel and syncs once, rather than
+        // draining the queue per device.
+        const distributed::MeshCoordinateRange device_coords(mesh_device->shape());
+        std::vector<std::vector<uint32_t>> per_device_config;
+        per_device_config.reserve(device_coords.shape().mesh_size());
+        std::vector<distributed::ShardDataTransfer> shard_data_transfers;
+        shard_data_transfers.reserve(device_coords.shape().mesh_size());
+        for (const auto& coord : device_coords) {
+            per_device_config.push_back(make_config_host_buffer(mesh_device->get_device(coord)));
+            shard_data_transfers.push_back(
+                distributed::ShardDataTransfer(coord).host_data(per_device_config.back().data()));
         }
+        mesh_device->mesh_command_queue().enqueue_write_shards(mesh_buffer, shard_data_transfers, /*blocking=*/true);
     } else {
+        // Every device gets the same config page, so one broadcast write covers the mesh.
         std::vector<uint32_t> cb_config_host_buffer = make_config_host_buffer(device_);
         distributed::EnqueueWriteMeshBuffer(
-            mesh_buffer->device()->mesh_command_queue(), mesh_buffer, cb_config_host_buffer, false);
+            mesh_device->mesh_command_queue(), mesh_buffer, cb_config_host_buffer, false);
     }
 }
 
@@ -510,7 +506,8 @@ struct GlobalCircularBufferDramSenderInternals {
     static DeviceAddr pages_sent_drisc_l1_base(const GlobalCircularBuffer& gcb);
     static DeviceAddr pages_sent_worker_l1_base(const GlobalCircularBuffer& gcb);
     static DeviceAddr sender_state_drisc_l1_base(const GlobalCircularBuffer& gcb);
-    static const std::vector<std::vector<CoreCoord>>& receiver_coords_per_sender(const GlobalCircularBuffer& gcb);
+    static const std::vector<std::vector<CoreCoord>>& receiver_logical_cores_per_sender(
+        const GlobalCircularBuffer& gcb);
     static std::vector<std::vector<uint32_t>> receiver_slab_indices(const GlobalCircularBuffer& gcb);
 };
 
@@ -539,9 +536,9 @@ DeviceAddr GlobalCircularBufferDramSenderInternals::sender_state_drisc_l1_base(c
     return gcb.sender_state_drisc_l1_base_;
 }
 
-const std::vector<std::vector<CoreCoord>>& GlobalCircularBufferDramSenderInternals::receiver_coords_per_sender(
+const std::vector<std::vector<CoreCoord>>& GlobalCircularBufferDramSenderInternals::receiver_logical_cores_per_sender(
     const GlobalCircularBuffer& gcb) {
-    return gcb.receiver_coords_per_sender_;
+    return gcb.receiver_logical_cores_per_sender_;
 }
 
 std::vector<std::vector<uint32_t>> GlobalCircularBufferDramSenderInternals::receiver_slab_indices(
@@ -579,9 +576,8 @@ std::vector<std::pair<CoreCoord, CoreRangeSet>> build_dram_sender_mapping(
     distributed::MeshDevice* mesh_device,
     const std::vector<std::pair<uint32_t, CoreRangeSet>>& bank_to_receivers,
     bool dual_senders_per_bank) {
-    // Logical DRAM sender coords name an endpoint role, so resolving them against any one device
-    // gives the mapping for the whole mesh; each device translates them to its own physical
-    // subchannel, and validate_dram_sender_on_device rechecks that when the GCB is written out.
+    // Sender coords name endpoint roles, so resolving them against any one device gives the
+    // mapping for the whole mesh; the GCB ctor rechecks that against every device.
     const IDevice* reference_device = mesh_device->get_devices().at(0);
     std::vector<std::pair<CoreCoord, CoreRangeSet>> mapping;
     mapping.reserve((dual_senders_per_bank ? 2 : 1) * bank_to_receivers.size());
@@ -657,8 +653,9 @@ DeviceAddr sender_state_drisc_l1_base(const GlobalCircularBuffer& gcb) {
     return global_circular_buffer_dram_sender::GlobalCircularBufferDramSenderInternals::sender_state_drisc_l1_base(gcb);
 }
 
-const std::vector<std::vector<CoreCoord>>& receiver_coords_per_sender(const GlobalCircularBuffer& gcb) {
-    return global_circular_buffer_dram_sender::GlobalCircularBufferDramSenderInternals::receiver_coords_per_sender(gcb);
+const std::vector<std::vector<CoreCoord>>& receiver_logical_cores_per_sender(const GlobalCircularBuffer& gcb) {
+    return global_circular_buffer_dram_sender::GlobalCircularBufferDramSenderInternals::
+        receiver_logical_cores_per_sender(gcb);
 }
 
 std::vector<std::vector<uint32_t>> receiver_slab_indices(const GlobalCircularBuffer& gcb) {

--- a/tt_metal/impl/buffers/global_circular_buffer_dram_sender_internal.hpp
+++ b/tt_metal/impl/buffers/global_circular_buffer_dram_sender_internal.hpp
@@ -37,9 +37,10 @@ DeviceAddr pages_sent_worker_l1_base(const GlobalCircularBuffer& gcb);
 // Layout: tt_metal/impl/buffers/dram_sender_state_block.hpp. Zero for worker-sender GCBs.
 DeviceAddr sender_state_drisc_l1_base(const GlobalCircularBuffer& gcb);
 
-// Physical worker NOC XY for each sender's receivers. The DRISC kernel uses these as
-// runtime args. Empty for worker-sender GCBs.
-const std::vector<std::vector<CoreCoord>>& receiver_coords_per_sender(const GlobalCircularBuffer& gcb);
+// Each sender's receivers as logical coords, row-wise (the order the DRISC kernel's slab
+// indices follow). Logical rather than physical because the physical worker coord depends on
+// which device of the mesh is being addressed. Empty for worker-sender GCBs.
+const std::vector<std::vector<CoreCoord>>& receiver_logical_cores_per_sender(const GlobalCircularBuffer& gcb);
 
 // Per-sender bank-local slab indices: entry [s][r] is the bank-local slab index
 // (recv_index_base + r) that sender s's local receiver r reads, in

--- a/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
@@ -400,21 +400,43 @@ TensorPrefetcherManager::TensorPrefetcherManager(
 TensorPrefetcherManager::~TensorPrefetcherManager() { stop(); }
 
 void TensorPrefetcherManager::enumerate_dram_senders() {
+    TT_FATAL(!devices_.empty(), "Tensor prefetcher requires at least one device");
     const auto context_id = mesh_device_->impl().get_context_id();
-    const auto& soc_desc = MetalContext::instance(context_id)
-                               .get_cluster()
-                               .get_soc_desc(mesh_device_->get_view().get_devices().front()->id());
+    const auto& cluster = MetalContext::instance(context_id).get_cluster();
+    const auto& soc_desc = cluster.get_soc_desc(devices_.front()->id());
     const uint32_t num_banks = soc_desc.get_num_dram_views();
     num_banks_ = num_banks;
+
     sender_logical_cores_.clear();
-    sender_logical_cores_.reserve(2 * num_banks);
-    for (uint32_t b = 0; b < num_banks; ++b) {
-        // Two senders per bank: the free subchannel then the NOC1-endpoint subchannel.
-        // A queued GCB may use the primary only or both; PREFETCH fan-out targets its mapping.
-        for (const CoreCoord& core : mesh_device_->impl().dram_sender_logical_cores(b)) {
-            sender_logical_cores_.push_back(core);
+    sender_logical_cores_by_device_.assign(devices_.size(), {});
+    for (uint32_t d = 0; d < devices_.size(); ++d) {
+        const uint32_t device_num_banks = cluster.get_soc_desc(devices_[d]->id()).get_num_dram_views();
+        TT_FATAL(
+            device_num_banks == num_banks_,
+            "Tensor prefetcher requires the same DRAM bank count on every device: reference device {} has {}, "
+            "device {} has {}",
+            devices_.front()->id(),
+            num_banks_,
+            devices_[d]->id(),
+            device_num_banks);
+
+        auto& device_senders = sender_logical_cores_by_device_[d];
+        device_senders.reserve(2 * num_banks_);
+        for (uint32_t b = 0; b < num_banks_; ++b) {
+            // Two stable roles per bank: the free subchannel then the NOC1-endpoint
+            // subchannel. Their logical coordinates may differ across harvested devices.
+            const std::vector<CoreCoord> bank_senders = mesh_device_->impl().dram_sender_logical_cores(devices_[d], b);
+            TT_FATAL(
+                bank_senders.size() == 2,
+                "Tensor prefetcher expected two DRAM sender roles for bank {} on device {}, found {}",
+                b,
+                devices_[d]->id(),
+                bank_senders.size());
+            device_senders.insert(device_senders.end(), bank_senders.begin(), bank_senders.end());
         }
     }
+
+    sender_logical_cores_ = sender_logical_cores_by_device_.front();
     num_senders_ = static_cast<uint32_t>(sender_logical_cores_.size());
 }
 
@@ -450,10 +472,11 @@ void TensorPrefetcherManager::allocate_sockets() {
     auto mesh_device_sp = mesh_device_->shared_from_this();
     const uint64_t dram_l1_noc_offset = hal.get_l1_noc_offset(HalProgrammableCoreType::DRAM);
 
-    for (auto* device : devices_) {
+    for (uint32_t d = 0; d < devices_.size(); ++d) {
+        IDevice* device = devices_[d];
         const MeshCoordinate device_coord = mesh_device_->get_view().find_device(device->id());
         for (uint32_t s = 0; s < num_senders_; ++s) {
-            const CoreCoord sender_logical = sender_logical_cores_[s];
+            const CoreCoord sender_logical = sender_logical_cores_by_device_[d][s];
             // Uniform L1 layout per DRAM core: only one socket lives on each core
             // (the one for that core's own sender). Use the same offsets carved by
             // start() — socket_config_l1_addr_ then socket_data_l1_addr_.
@@ -484,7 +507,7 @@ void TensorPrefetcherManager::build_and_launch_programs(uint32_t stage_ring_base
         auto program = std::make_unique<Program>();
 
         for (uint32_t s = 0; s < num_senders_; ++s) {
-            const CoreCoord sender_logical = sender_logical_cores_[s];
+            const CoreCoord sender_logical = sender_logical_cores_by_device_[d][s];
 
             std::vector<uint32_t> compile_args = {
                 stage_ring_base,
@@ -514,8 +537,18 @@ void TensorPrefetcherManager::start() {
     TT_FATAL(
         hal.has_programmable_core_type(HalProgrammableCoreType::DRAM),
         "Tensor prefetcher requires programmable DRAM cores, which auto-enable on Blackhole with firmware "
-        ">= 19.12.0.0 and either no harvested DRAM channels or a single device");
+        ">= 19.12.0.0");
 
+    // Populate devices_ once before resolving sender slots: every device can map the
+    // same bank/role to a different logical DRAM core under heterogeneous harvesting.
+    // Build the coord->index map at the same time so worker_loop fan-out is O(targets).
+    devices_.clear();
+    device_index_by_coord_.clear();
+    for (auto* device : mesh_device_->get_view().get_devices()) {
+        const uint32_t d = static_cast<uint32_t>(devices_.size());
+        devices_.push_back(device);
+        device_index_by_coord_.emplace(mesh_device_->get_view().find_device(device->id()), d);
+    }
     enumerate_dram_senders();
 
     // DRISC L1 layout: the kernel working region (above the GCB zone) is now
@@ -573,16 +606,6 @@ void TensorPrefetcherManager::start() {
         kernel_region_size);
     ring_half_ = stage_ring_size_ / 2;
     stage_third_ = stage_ring_size_ / 3;
-
-    // Populate devices_ list once; both allocate_sockets and build_and_launch_programs use it.
-    // Build the coord->index map at the same time so worker_loop fan-out is O(targets).
-    devices_.clear();
-    device_index_by_coord_.clear();
-    for (auto* device : mesh_device_->get_view().get_devices()) {
-        const uint32_t d = static_cast<uint32_t>(devices_.size());
-        devices_.push_back(device);
-        device_index_by_coord_.emplace(mesh_device_->get_view().find_device(device->id()), d);
-    }
 
     allocate_sockets();
     build_and_launch_programs(stage_ring_base_, stage_ring_size_);
@@ -1036,10 +1059,11 @@ void TensorPrefetcherManager::enqueue_cq_signal_and_wait(
     std::vector<DeviceMemoryAddress> targets;
     targets.reserve(target_devices.size() * num_senders_);
     for (const auto& coord : target_devices) {
-        IDevice* device = devices_[device_index_by_coord_.at(coord)];
+        const uint32_t device_index = device_index_by_coord_.at(coord);
+        IDevice* device = devices_[device_index];
         for (uint32_t s = 0; s < num_senders_; ++s) {
-            const CoreCoord virtual_core =
-                device->virtual_core_from_logical_core(sender_logical_cores_[s], CoreType::DRAM);
+            const CoreCoord virtual_core = device->virtual_core_from_logical_core(
+                sender_logical_cores_by_device_[device_index][s], CoreType::DRAM);
             targets.push_back(DeviceMemoryAddress{coord, virtual_core, slot_addr});
         }
     }
@@ -1204,6 +1228,7 @@ void TensorPrefetcherManager::stop() {
     devices_.clear();
     device_index_by_coord_.clear();
     sender_logical_cores_.clear();
+    sender_logical_cores_by_device_.clear();
     trace_requests_.clear();
     num_senders_ = 0;
     active_ = false;

--- a/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
@@ -407,7 +407,6 @@ void TensorPrefetcherManager::enumerate_dram_senders() {
     const uint32_t num_banks = soc_desc.get_num_dram_views();
     num_banks_ = num_banks;
 
-    sender_logical_cores_.clear();
     sender_logical_cores_by_device_.assign(devices_.size(), {});
     for (uint32_t d = 0; d < devices_.size(); ++d) {
         const uint32_t device_num_banks = cluster.get_soc_desc(devices_[d]->id()).get_num_dram_views();
@@ -436,8 +435,7 @@ void TensorPrefetcherManager::enumerate_dram_senders() {
         }
     }
 
-    sender_logical_cores_ = sender_logical_cores_by_device_.front();
-    num_senders_ = static_cast<uint32_t>(sender_logical_cores_.size());
+    num_senders_ = static_cast<uint32_t>(sender_logical_cores_by_device_.front().size());
 }
 
 std::vector<uint32_t> TensorPrefetcherManager::sender_indices_for_gcb(
@@ -445,17 +443,19 @@ std::vector<uint32_t> TensorPrefetcherManager::sender_indices_for_gcb(
     const auto& mapping = gcb.sender_receiver_core_mapping();
     TT_FATAL(!mapping.empty(), "Tensor prefetcher: GCB sender mapping must not be empty");
 
+    // GCB sender coordinates are the canonical (reference-device) mapping; match against it.
+    const std::vector<CoreCoord>& canonical_senders = sender_logical_cores_by_device_.front();
     std::vector<uint32_t> sender_indices;
     sender_indices.reserve(mapping.size());
     for (const auto& [sender, _receivers] : mapping) {
-        const auto it = std::find(sender_logical_cores_.begin(), sender_logical_cores_.end(), sender);
+        const auto it = std::find(canonical_senders.begin(), canonical_senders.end(), sender);
         TT_FATAL(
-            it != sender_logical_cores_.end(),
+            it != canonical_senders.end(),
             "Tensor prefetcher: GCB sender core ({}, {}) is not one of the {} provisioned DRAM sender cores",
             sender.x,
             sender.y,
             num_senders_);
-        sender_indices.push_back(static_cast<uint32_t>(std::distance(sender_logical_cores_.begin(), it)));
+        sender_indices.push_back(static_cast<uint32_t>(std::distance(canonical_senders.begin(), it)));
     }
     return sender_indices;
 }
@@ -653,7 +653,8 @@ std::vector<std::vector<std::vector<uint8_t>>> TensorPrefetcherManager::serializ
     if (krow_compatible_mapping) {
         for (const auto& [sender, _receivers] : mapping) {
             const uint32_t bank = static_cast<uint32_t>(sender.x);
-            if (bank >= num_banks_ || primary_bank_seen[bank] || sender != sender_logical_cores_[2 * bank]) {
+            if (bank >= num_banks_ || primary_bank_seen[bank] ||
+                sender != sender_logical_cores_by_device_.front()[2 * bank]) {
                 krow_compatible_mapping = false;
                 break;
             }
@@ -1227,7 +1228,6 @@ void TensorPrefetcherManager::stop() {
     programs_.clear();
     devices_.clear();
     device_index_by_coord_.clear();
-    sender_logical_cores_.clear();
     sender_logical_cores_by_device_.clear();
     trace_requests_.clear();
     num_senders_ = 0;

--- a/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
@@ -402,45 +402,23 @@ TensorPrefetcherManager::~TensorPrefetcherManager() { stop(); }
 
 void TensorPrefetcherManager::enumerate_dram_senders() {
     TT_FATAL(!devices_.empty(), "Tensor prefetcher requires at least one device");
-    const auto context_id = mesh_device_->impl().get_context_id();
-    const auto& cluster = MetalContext::instance(context_id).get_cluster();
-    const auto& soc_desc = cluster.get_soc_desc(devices_.front()->id());
-    const uint32_t num_banks = soc_desc.get_num_dram_views();
-    num_banks_ = num_banks;
+    // dram_grid_size() already TT_FATALs unless every device in the mesh reports the same bank count.
+    num_banks_ = mesh_device_->dram_grid_size().x;
 
     // Logical DRAM coords name an endpoint role, so a bank's two senders have the same logical
     // coords on every device even when their DRAM harvest masks differ; only the physical
-    // subchannel each one resolves to changes. Build the list once from the reference device and
-    // check the rest agree, because everything downstream (socket placement, kernel placement, GCB
-    // sender indices) indexes senders by slot and would otherwise silently drive another device's
-    // wrong DRISC core.
+    // subchannel each one resolves to changes. Build the list from the reference device and check
+    // the rest agree, because everything downstream (socket placement, kernel placement, GCB sender
+    // indices) indexes senders by slot and would otherwise silently drive another device's wrong
+    // DRISC core.
     sender_logical_cores_.clear();
     sender_logical_cores_.reserve(2 * num_banks_);
-    for (uint32_t b = 0; b < num_banks_; ++b) {
-        // Two roles per bank: the free subchannel then the NOC1-endpoint subchannel.
-        const std::vector<CoreCoord> bank_senders = mesh_device_->impl().dram_sender_logical_cores(devices_.front(), b);
-        TT_FATAL(
-            bank_senders.size() == 2,
-            "Tensor prefetcher expected two DRAM sender roles for bank {} on device {}, found {}",
-            b,
-            devices_.front()->id(),
-            bank_senders.size());
-        sender_logical_cores_.insert(sender_logical_cores_.end(), bank_senders.begin(), bank_senders.end());
-    }
-    num_senders_ = static_cast<uint32_t>(sender_logical_cores_.size());
-
+    std::vector<CoreCoord> device_senders;
     for (IDevice* device : devices_) {
-        const uint32_t device_num_banks = cluster.get_soc_desc(device->id()).get_num_dram_views();
-        TT_FATAL(
-            device_num_banks == num_banks_,
-            "Tensor prefetcher requires the same DRAM bank count on every device: reference device {} has {}, "
-            "device {} has {}",
-            devices_.front()->id(),
-            num_banks_,
-            device->id(),
-            device_num_banks);
-
+        device_senders.clear();
+        device_senders.reserve(2 * num_banks_);
         for (uint32_t b = 0; b < num_banks_; ++b) {
+            // Two roles per bank: the free subchannel then the NOC1-endpoint subchannel.
             const std::vector<CoreCoord> bank_senders = mesh_device_->impl().dram_sender_logical_cores(device, b);
             TT_FATAL(
                 bank_senders.size() == 2,
@@ -448,23 +426,20 @@ void TensorPrefetcherManager::enumerate_dram_senders() {
                 b,
                 device->id(),
                 bank_senders.size());
-            for (uint32_t role = 0; role < bank_senders.size(); ++role) {
-                const CoreCoord& expected = sender_logical_cores_[2 * b + role];
-                TT_FATAL(
-                    bank_senders[role] == expected,
-                    "Tensor prefetcher: DRAM bank {} sender role {} is logical core ({}, {}) on reference device {} "
-                    "but ({}, {}) on device {}; sender slots must name the same role on every device",
-                    b,
-                    role,
-                    expected.x,
-                    expected.y,
-                    devices_.front()->id(),
-                    bank_senders[role].x,
-                    bank_senders[role].y,
-                    device->id());
-            }
+            device_senders.insert(device_senders.end(), bank_senders.begin(), bank_senders.end());
+        }
+        if (device == devices_.front()) {
+            sender_logical_cores_ = device_senders;
+        } else {
+            TT_FATAL(
+                device_senders == sender_logical_cores_,
+                "Tensor prefetcher: DRAM sender slots on device {} name different logical cores than on reference "
+                "device {}; every device must resolve slot s to the same (bank, role)",
+                device->id(),
+                devices_.front()->id());
         }
     }
+    num_senders_ = static_cast<uint32_t>(sender_logical_cores_.size());
 }
 
 std::vector<uint32_t> TensorPrefetcherManager::sender_indices_for_gcb(
@@ -1107,8 +1082,7 @@ void TensorPrefetcherManager::enqueue_cq_signal_and_wait(
     for (const auto& coord : target_devices) {
         IDevice* device = devices_[device_index_by_coord_.at(coord)];
         for (uint32_t s = 0; s < num_senders_; ++s) {
-            // Per-device translation: the same logical sender coord is a different physical DRAM
-            // subchannel on devices with different harvest masks.
+            // Per-device translation; see metal_SocDescriptor::dram_bank_endpoint_coords.
             const CoreCoord virtual_core =
                 device->virtual_core_from_logical_core(sender_logical_cores_[s], CoreType::DRAM);
             targets.push_back(DeviceMemoryAddress{coord, virtual_core, slot_addr});

--- a/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
@@ -401,21 +401,43 @@ TensorPrefetcherManager::TensorPrefetcherManager(
 TensorPrefetcherManager::~TensorPrefetcherManager() { stop(); }
 
 void TensorPrefetcherManager::enumerate_dram_senders() {
+    TT_FATAL(!devices_.empty(), "Tensor prefetcher requires at least one device");
     const auto context_id = mesh_device_->impl().get_context_id();
-    const auto& soc_desc = MetalContext::instance(context_id)
-                               .get_cluster()
-                               .get_soc_desc(mesh_device_->get_view().get_devices().front()->id());
+    const auto& cluster = MetalContext::instance(context_id).get_cluster();
+    const auto& soc_desc = cluster.get_soc_desc(devices_.front()->id());
     const uint32_t num_banks = soc_desc.get_num_dram_views();
     num_banks_ = num_banks;
+
     sender_logical_cores_.clear();
-    sender_logical_cores_.reserve(2 * num_banks);
-    for (uint32_t b = 0; b < num_banks; ++b) {
-        // Two senders per bank: the free subchannel then the NOC1-endpoint subchannel.
-        // A queued GCB may use the primary only or both; PREFETCH fan-out targets its mapping.
-        for (const CoreCoord& core : mesh_device_->impl().dram_sender_logical_cores(b)) {
-            sender_logical_cores_.push_back(core);
+    sender_logical_cores_by_device_.assign(devices_.size(), {});
+    for (uint32_t d = 0; d < devices_.size(); ++d) {
+        const uint32_t device_num_banks = cluster.get_soc_desc(devices_[d]->id()).get_num_dram_views();
+        TT_FATAL(
+            device_num_banks == num_banks_,
+            "Tensor prefetcher requires the same DRAM bank count on every device: reference device {} has {}, "
+            "device {} has {}",
+            devices_.front()->id(),
+            num_banks_,
+            devices_[d]->id(),
+            device_num_banks);
+
+        auto& device_senders = sender_logical_cores_by_device_[d];
+        device_senders.reserve(2 * num_banks_);
+        for (uint32_t b = 0; b < num_banks_; ++b) {
+            // Two stable roles per bank: the free subchannel then the NOC1-endpoint
+            // subchannel. Their logical coordinates may differ across harvested devices.
+            const std::vector<CoreCoord> bank_senders = mesh_device_->impl().dram_sender_logical_cores(devices_[d], b);
+            TT_FATAL(
+                bank_senders.size() == 2,
+                "Tensor prefetcher expected two DRAM sender roles for bank {} on device {}, found {}",
+                b,
+                devices_[d]->id(),
+                bank_senders.size());
+            device_senders.insert(device_senders.end(), bank_senders.begin(), bank_senders.end());
         }
     }
+
+    sender_logical_cores_ = sender_logical_cores_by_device_.front();
     num_senders_ = static_cast<uint32_t>(sender_logical_cores_.size());
 }
 
@@ -451,10 +473,11 @@ void TensorPrefetcherManager::allocate_sockets() {
     auto mesh_device_sp = mesh_device_->shared_from_this();
     const uint64_t dram_l1_noc_offset = hal.get_l1_noc_offset(HalProgrammableCoreType::DRAM);
 
-    for (auto* device : devices_) {
+    for (uint32_t d = 0; d < devices_.size(); ++d) {
+        IDevice* device = devices_[d];
         const MeshCoordinate device_coord = mesh_device_->get_view().find_device(device->id());
         for (uint32_t s = 0; s < num_senders_; ++s) {
-            const CoreCoord sender_logical = sender_logical_cores_[s];
+            const CoreCoord sender_logical = sender_logical_cores_by_device_[d][s];
             // Uniform L1 layout per DRAM core: only one socket lives on each core
             // (the one for that core's own sender). Use the same offsets carved by
             // start() — socket_config_l1_addr_ then socket_data_l1_addr_.
@@ -485,7 +508,7 @@ void TensorPrefetcherManager::build_and_launch_programs(uint32_t stage_ring_base
         auto program = std::make_unique<Program>();
 
         for (uint32_t s = 0; s < num_senders_; ++s) {
-            const CoreCoord sender_logical = sender_logical_cores_[s];
+            const CoreCoord sender_logical = sender_logical_cores_by_device_[d][s];
 
             std::vector<uint32_t> compile_args = {
                 stage_ring_base,
@@ -516,8 +539,18 @@ void TensorPrefetcherManager::start() {
     TT_FATAL(
         hal.has_programmable_core_type(HalProgrammableCoreType::DRAM),
         "Tensor prefetcher requires programmable DRAM cores, which auto-enable on Blackhole with firmware "
-        ">= 19.12.0.0 and either no harvested DRAM channels or a single device");
+        ">= 19.12.0.0");
 
+    // Populate devices_ once before resolving sender slots: every device can map the
+    // same bank/role to a different logical DRAM core under heterogeneous harvesting.
+    // Build the coord->index map at the same time so worker_loop fan-out is O(targets).
+    devices_.clear();
+    device_index_by_coord_.clear();
+    for (auto* device : mesh_device_->get_view().get_devices()) {
+        const uint32_t d = static_cast<uint32_t>(devices_.size());
+        devices_.push_back(device);
+        device_index_by_coord_.emplace(mesh_device_->get_view().find_device(device->id()), d);
+    }
     enumerate_dram_senders();
 
     // DRISC L1 layout: the kernel working region (above the GCB zone) is now
@@ -577,16 +610,6 @@ void TensorPrefetcherManager::start() {
         kernel_region_size);
     ring_half_ = stage_ring_size_ / 2;
     stage_third_ = stage_ring_size_ / 3;
-
-    // Populate devices_ list once; both allocate_sockets and build_and_launch_programs use it.
-    // Build the coord->index map at the same time so worker_loop fan-out is O(targets).
-    devices_.clear();
-    device_index_by_coord_.clear();
-    for (auto* device : mesh_device_->get_view().get_devices()) {
-        const uint32_t d = static_cast<uint32_t>(devices_.size());
-        devices_.push_back(device);
-        device_index_by_coord_.emplace(mesh_device_->get_view().find_device(device->id()), d);
-    }
 
     allocate_sockets();
     build_and_launch_programs(stage_ring_base_, stage_ring_size_);
@@ -1057,10 +1080,11 @@ void TensorPrefetcherManager::enqueue_cq_signal_and_wait(
     std::vector<DeviceMemoryAddress> targets;
     targets.reserve(target_devices.size() * num_senders_);
     for (const auto& coord : target_devices) {
-        IDevice* device = devices_[device_index_by_coord_.at(coord)];
+        const uint32_t device_index = device_index_by_coord_.at(coord);
+        IDevice* device = devices_[device_index];
         for (uint32_t s = 0; s < num_senders_; ++s) {
-            const CoreCoord virtual_core =
-                device->virtual_core_from_logical_core(sender_logical_cores_[s], CoreType::DRAM);
+            const CoreCoord virtual_core = device->virtual_core_from_logical_core(
+                sender_logical_cores_by_device_[device_index][s], CoreType::DRAM);
             targets.push_back(DeviceMemoryAddress{coord, virtual_core, slot_addr});
         }
     }
@@ -1242,6 +1266,7 @@ void TensorPrefetcherManager::stop() {
     devices_.clear();
     device_index_by_coord_.clear();
     sender_logical_cores_.clear();
+    sender_logical_cores_by_device_.clear();
     trace_requests_.clear();
     num_senders_ = 0;
     active_ = false;

--- a/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
@@ -408,7 +408,6 @@ void TensorPrefetcherManager::enumerate_dram_senders() {
     const uint32_t num_banks = soc_desc.get_num_dram_views();
     num_banks_ = num_banks;
 
-    sender_logical_cores_.clear();
     sender_logical_cores_by_device_.assign(devices_.size(), {});
     for (uint32_t d = 0; d < devices_.size(); ++d) {
         const uint32_t device_num_banks = cluster.get_soc_desc(devices_[d]->id()).get_num_dram_views();
@@ -437,8 +436,7 @@ void TensorPrefetcherManager::enumerate_dram_senders() {
         }
     }
 
-    sender_logical_cores_ = sender_logical_cores_by_device_.front();
-    num_senders_ = static_cast<uint32_t>(sender_logical_cores_.size());
+    num_senders_ = static_cast<uint32_t>(sender_logical_cores_by_device_.front().size());
 }
 
 std::vector<uint32_t> TensorPrefetcherManager::sender_indices_for_gcb(
@@ -446,17 +444,19 @@ std::vector<uint32_t> TensorPrefetcherManager::sender_indices_for_gcb(
     const auto& mapping = gcb.sender_receiver_core_mapping();
     TT_FATAL(!mapping.empty(), "Tensor prefetcher: GCB sender mapping must not be empty");
 
+    // GCB sender coordinates are the canonical (reference-device) mapping; match against it.
+    const std::vector<CoreCoord>& canonical_senders = sender_logical_cores_by_device_.front();
     std::vector<uint32_t> sender_indices;
     sender_indices.reserve(mapping.size());
     for (const auto& [sender, _receivers] : mapping) {
-        const auto it = std::find(sender_logical_cores_.begin(), sender_logical_cores_.end(), sender);
+        const auto it = std::find(canonical_senders.begin(), canonical_senders.end(), sender);
         TT_FATAL(
-            it != sender_logical_cores_.end(),
+            it != canonical_senders.end(),
             "Tensor prefetcher: GCB sender core ({}, {}) is not one of the {} provisioned DRAM sender cores",
             sender.x,
             sender.y,
             num_senders_);
-        sender_indices.push_back(static_cast<uint32_t>(std::distance(sender_logical_cores_.begin(), it)));
+        sender_indices.push_back(static_cast<uint32_t>(std::distance(canonical_senders.begin(), it)));
     }
     return sender_indices;
 }
@@ -657,7 +657,8 @@ std::vector<std::vector<std::vector<uint8_t>>> TensorPrefetcherManager::serializ
     if (krow_compatible_mapping) {
         for (const auto& [sender, _receivers] : mapping) {
             const uint32_t bank = static_cast<uint32_t>(sender.x);
-            if (bank >= num_banks_ || primary_bank_seen[bank] || sender != sender_logical_cores_[2 * bank]) {
+            if (bank >= num_banks_ || primary_bank_seen[bank] ||
+                sender != sender_logical_cores_by_device_.front()[2 * bank]) {
                 krow_compatible_mapping = false;
                 break;
             }
@@ -1265,7 +1266,6 @@ void TensorPrefetcherManager::stop() {
     programs_.clear();
     devices_.clear();
     device_index_by_coord_.clear();
-    sender_logical_cores_.clear();
     sender_logical_cores_by_device_.clear();
     trace_requests_.clear();
     num_senders_ = 0;

--- a/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
@@ -408,35 +408,63 @@ void TensorPrefetcherManager::enumerate_dram_senders() {
     const uint32_t num_banks = soc_desc.get_num_dram_views();
     num_banks_ = num_banks;
 
-    sender_logical_cores_by_device_.assign(devices_.size(), {});
-    for (uint32_t d = 0; d < devices_.size(); ++d) {
-        const uint32_t device_num_banks = cluster.get_soc_desc(devices_[d]->id()).get_num_dram_views();
+    // Logical DRAM coords name an endpoint role, so a bank's two senders have the same logical
+    // coords on every device even when their DRAM harvest masks differ; only the physical
+    // subchannel each one resolves to changes. Build the list once from the reference device and
+    // check the rest agree, because everything downstream (socket placement, kernel placement, GCB
+    // sender indices) indexes senders by slot and would otherwise silently drive another device's
+    // wrong DRISC core.
+    sender_logical_cores_.clear();
+    sender_logical_cores_.reserve(2 * num_banks_);
+    for (uint32_t b = 0; b < num_banks_; ++b) {
+        // Two roles per bank: the free subchannel then the NOC1-endpoint subchannel.
+        const std::vector<CoreCoord> bank_senders = mesh_device_->impl().dram_sender_logical_cores(devices_.front(), b);
+        TT_FATAL(
+            bank_senders.size() == 2,
+            "Tensor prefetcher expected two DRAM sender roles for bank {} on device {}, found {}",
+            b,
+            devices_.front()->id(),
+            bank_senders.size());
+        sender_logical_cores_.insert(sender_logical_cores_.end(), bank_senders.begin(), bank_senders.end());
+    }
+    num_senders_ = static_cast<uint32_t>(sender_logical_cores_.size());
+
+    for (IDevice* device : devices_) {
+        const uint32_t device_num_banks = cluster.get_soc_desc(device->id()).get_num_dram_views();
         TT_FATAL(
             device_num_banks == num_banks_,
             "Tensor prefetcher requires the same DRAM bank count on every device: reference device {} has {}, "
             "device {} has {}",
             devices_.front()->id(),
             num_banks_,
-            devices_[d]->id(),
+            device->id(),
             device_num_banks);
 
-        auto& device_senders = sender_logical_cores_by_device_[d];
-        device_senders.reserve(2 * num_banks_);
         for (uint32_t b = 0; b < num_banks_; ++b) {
-            // Two stable roles per bank: the free subchannel then the NOC1-endpoint
-            // subchannel. Their logical coordinates may differ across harvested devices.
-            const std::vector<CoreCoord> bank_senders = mesh_device_->impl().dram_sender_logical_cores(devices_[d], b);
+            const std::vector<CoreCoord> bank_senders = mesh_device_->impl().dram_sender_logical_cores(device, b);
             TT_FATAL(
                 bank_senders.size() == 2,
                 "Tensor prefetcher expected two DRAM sender roles for bank {} on device {}, found {}",
                 b,
-                devices_[d]->id(),
+                device->id(),
                 bank_senders.size());
-            device_senders.insert(device_senders.end(), bank_senders.begin(), bank_senders.end());
+            for (uint32_t role = 0; role < bank_senders.size(); ++role) {
+                const CoreCoord& expected = sender_logical_cores_[2 * b + role];
+                TT_FATAL(
+                    bank_senders[role] == expected,
+                    "Tensor prefetcher: DRAM bank {} sender role {} is logical core ({}, {}) on reference device {} "
+                    "but ({}, {}) on device {}; sender slots must name the same role on every device",
+                    b,
+                    role,
+                    expected.x,
+                    expected.y,
+                    devices_.front()->id(),
+                    bank_senders[role].x,
+                    bank_senders[role].y,
+                    device->id());
+            }
         }
     }
-
-    num_senders_ = static_cast<uint32_t>(sender_logical_cores_by_device_.front().size());
 }
 
 std::vector<uint32_t> TensorPrefetcherManager::sender_indices_for_gcb(
@@ -444,19 +472,17 @@ std::vector<uint32_t> TensorPrefetcherManager::sender_indices_for_gcb(
     const auto& mapping = gcb.sender_receiver_core_mapping();
     TT_FATAL(!mapping.empty(), "Tensor prefetcher: GCB sender mapping must not be empty");
 
-    // GCB sender coordinates are the canonical (reference-device) mapping; match against it.
-    const std::vector<CoreCoord>& canonical_senders = sender_logical_cores_by_device_.front();
     std::vector<uint32_t> sender_indices;
     sender_indices.reserve(mapping.size());
     for (const auto& [sender, _receivers] : mapping) {
-        const auto it = std::find(canonical_senders.begin(), canonical_senders.end(), sender);
+        const auto it = std::find(sender_logical_cores_.begin(), sender_logical_cores_.end(), sender);
         TT_FATAL(
-            it != canonical_senders.end(),
+            it != sender_logical_cores_.end(),
             "Tensor prefetcher: GCB sender core ({}, {}) is not one of the {} provisioned DRAM sender cores",
             sender.x,
             sender.y,
             num_senders_);
-        sender_indices.push_back(static_cast<uint32_t>(std::distance(canonical_senders.begin(), it)));
+        sender_indices.push_back(static_cast<uint32_t>(std::distance(sender_logical_cores_.begin(), it)));
     }
     return sender_indices;
 }
@@ -473,11 +499,10 @@ void TensorPrefetcherManager::allocate_sockets() {
     auto mesh_device_sp = mesh_device_->shared_from_this();
     const uint64_t dram_l1_noc_offset = hal.get_l1_noc_offset(HalProgrammableCoreType::DRAM);
 
-    for (uint32_t d = 0; d < devices_.size(); ++d) {
-        IDevice* device = devices_[d];
+    for (auto* device : devices_) {
         const MeshCoordinate device_coord = mesh_device_->get_view().find_device(device->id());
         for (uint32_t s = 0; s < num_senders_; ++s) {
-            const CoreCoord sender_logical = sender_logical_cores_by_device_[d][s];
+            const CoreCoord sender_logical = sender_logical_cores_[s];
             // Uniform L1 layout per DRAM core: only one socket lives on each core
             // (the one for that core's own sender). Use the same offsets carved by
             // start() — socket_config_l1_addr_ then socket_data_l1_addr_.
@@ -508,7 +533,7 @@ void TensorPrefetcherManager::build_and_launch_programs(uint32_t stage_ring_base
         auto program = std::make_unique<Program>();
 
         for (uint32_t s = 0; s < num_senders_; ++s) {
-            const CoreCoord sender_logical = sender_logical_cores_by_device_[d][s];
+            const CoreCoord sender_logical = sender_logical_cores_[s];
 
             std::vector<uint32_t> compile_args = {
                 stage_ring_base,
@@ -541,9 +566,9 @@ void TensorPrefetcherManager::start() {
         "Tensor prefetcher requires programmable DRAM cores, which auto-enable on Blackhole with firmware "
         ">= 19.12.0.0");
 
-    // Populate devices_ once before resolving sender slots: every device can map the
-    // same bank/role to a different logical DRAM core under heterogeneous harvesting.
-    // Build the coord->index map at the same time so worker_loop fan-out is O(targets).
+    // Populate devices_ before resolving sender slots: enumerate_dram_senders checks the slots
+    // against every device's DRAM topology. Build the coord->index map at the same time so
+    // worker_loop fan-out is O(targets).
     devices_.clear();
     device_index_by_coord_.clear();
     for (auto* device : mesh_device_->get_view().get_devices()) {
@@ -657,8 +682,7 @@ std::vector<std::vector<std::vector<uint8_t>>> TensorPrefetcherManager::serializ
     if (krow_compatible_mapping) {
         for (const auto& [sender, _receivers] : mapping) {
             const uint32_t bank = static_cast<uint32_t>(sender.x);
-            if (bank >= num_banks_ || primary_bank_seen[bank] ||
-                sender != sender_logical_cores_by_device_.front()[2 * bank]) {
+            if (bank >= num_banks_ || primary_bank_seen[bank] || sender != sender_logical_cores_[2 * bank]) {
                 krow_compatible_mapping = false;
                 break;
             }
@@ -1081,11 +1105,12 @@ void TensorPrefetcherManager::enqueue_cq_signal_and_wait(
     std::vector<DeviceMemoryAddress> targets;
     targets.reserve(target_devices.size() * num_senders_);
     for (const auto& coord : target_devices) {
-        const uint32_t device_index = device_index_by_coord_.at(coord);
-        IDevice* device = devices_[device_index];
+        IDevice* device = devices_[device_index_by_coord_.at(coord)];
         for (uint32_t s = 0; s < num_senders_; ++s) {
-            const CoreCoord virtual_core = device->virtual_core_from_logical_core(
-                sender_logical_cores_by_device_[device_index][s], CoreType::DRAM);
+            // Per-device translation: the same logical sender coord is a different physical DRAM
+            // subchannel on devices with different harvest masks.
+            const CoreCoord virtual_core =
+                device->virtual_core_from_logical_core(sender_logical_cores_[s], CoreType::DRAM);
             targets.push_back(DeviceMemoryAddress{coord, virtual_core, slot_addr});
         }
     }
@@ -1266,7 +1291,7 @@ void TensorPrefetcherManager::stop() {
     programs_.clear();
     devices_.clear();
     device_index_by_coord_.clear();
-    sender_logical_cores_by_device_.clear();
+    sender_logical_cores_.clear();
     trace_requests_.clear();
     num_senders_ = 0;
     active_ = false;

--- a/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
@@ -411,12 +411,9 @@ void TensorPrefetcherManager::enumerate_dram_senders() {
     // the rest agree, because everything downstream (socket placement, kernel placement, GCB sender
     // indices) indexes senders by slot and would otherwise silently drive another device's wrong
     // DRISC core.
-    sender_logical_cores_.clear();
-    sender_logical_cores_.reserve(2 * num_banks_);
-    std::vector<CoreCoord> device_senders;
-    for (IDevice* device : devices_) {
-        device_senders.clear();
-        device_senders.reserve(2 * num_banks_);
+    const auto senders_on = [this](const IDevice* device) {
+        std::vector<CoreCoord> senders;
+        senders.reserve(2 * num_banks_);
         for (uint32_t b = 0; b < num_banks_; ++b) {
             // Two roles per bank: the free subchannel then the NOC1-endpoint subchannel.
             const std::vector<CoreCoord> bank_senders = mesh_device_->impl().dram_sender_logical_cores(device, b);
@@ -426,18 +423,20 @@ void TensorPrefetcherManager::enumerate_dram_senders() {
                 b,
                 device->id(),
                 bank_senders.size());
-            device_senders.insert(device_senders.end(), bank_senders.begin(), bank_senders.end());
+            senders.insert(senders.end(), bank_senders.begin(), bank_senders.end());
         }
-        if (device == devices_.front()) {
-            sender_logical_cores_ = device_senders;
-        } else {
-            TT_FATAL(
-                device_senders == sender_logical_cores_,
-                "Tensor prefetcher: DRAM sender slots on device {} name different logical cores than on reference "
-                "device {}; every device must resolve slot s to the same (bank, role)",
-                device->id(),
-                devices_.front()->id());
-        }
+        return senders;
+    };
+
+    const IDevice* reference_device = devices_.front();
+    sender_logical_cores_ = senders_on(reference_device);
+    for (size_t d = 1; d < devices_.size(); ++d) {
+        TT_FATAL(
+            senders_on(devices_[d]) == sender_logical_cores_,
+            "Tensor prefetcher: DRAM sender slots on device {} name different logical cores than on reference "
+            "device {}; every device must resolve slot s to the same (bank, role)",
+            devices_[d]->id(),
+            reference_device->id());
     }
     num_senders_ = static_cast<uint32_t>(sender_logical_cores_.size());
 }
@@ -1268,6 +1267,7 @@ void TensorPrefetcherManager::stop() {
     sender_logical_cores_.clear();
     trace_requests_.clear();
     num_senders_ = 0;
+    num_banks_ = 0;
     active_ = false;
 }
 

--- a/tt_metal/impl/buffers/tensor_prefetcher_manager.hpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_manager.hpp
@@ -173,10 +173,13 @@ private:
     // write and the WAIT_CQ request value.
     std::array<uint32_t, kNumCqSignalSlots> cq_signal_counter_{};
 
-    // sender_logical_cores_[s] = logical DRAM core for sender s. Both available
-    // sender cores per bank are provisioned at start. Each queued GCB may map either
-    // the primary sender only or both senders; PREFETCH requests target that subset.
+    // sender_logical_cores_[s] is the canonical (reference-device) logical DRAM
+    // core for stable sender slot s. sender_logical_cores_by_device_[d][s] resolves
+    // that same (bank, primary/secondary role) slot against device d's harvested
+    // DRAM topology. Each queued GCB maps canonical senders to stable slots; all
+    // device-bound socket, program, and NOC operations use the per-device table.
     std::vector<CoreCoord> sender_logical_cores_;
+    std::vector<std::vector<CoreCoord>> sender_logical_cores_by_device_;
     uint32_t num_senders_ = 0;
     uint32_t num_banks_ = 0;
 

--- a/tt_metal/impl/buffers/tensor_prefetcher_manager.hpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_manager.hpp
@@ -173,12 +173,11 @@ private:
     // write and the WAIT_CQ request value.
     std::array<uint32_t, kNumCqSignalSlots> cq_signal_counter_{};
 
-    // sender_logical_cores_[s] is the canonical (reference-device) logical DRAM
-    // core for stable sender slot s. sender_logical_cores_by_device_[d][s] resolves
-    // that same (bank, primary/secondary role) slot against device d's harvested
-    // DRAM topology. Each queued GCB maps canonical senders to stable slots; all
-    // device-bound socket, program, and NOC operations use the per-device table.
-    std::vector<CoreCoord> sender_logical_cores_;
+    // sender_logical_cores_by_device_[d][s] is the logical DRAM core that plays stable
+    // sender slot s (a (bank, primary/secondary role) pair) on device d's harvested DRAM
+    // topology. Row [0] is the canonical (reference-device) mapping that queued GCBs match
+    // their sender coordinates against; all device-bound socket, program, and NOC operations
+    // use the per-device row.
     std::vector<std::vector<CoreCoord>> sender_logical_cores_by_device_;
     uint32_t num_senders_ = 0;
     uint32_t num_banks_ = 0;

--- a/tt_metal/impl/buffers/tensor_prefetcher_manager.hpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_manager.hpp
@@ -179,12 +179,11 @@ private:
     // write and the WAIT_CQ request value.
     std::array<uint32_t, kNumCqSignalSlots> cq_signal_counter_{};
 
-    // sender_logical_cores_[s] is the canonical (reference-device) logical DRAM
-    // core for stable sender slot s. sender_logical_cores_by_device_[d][s] resolves
-    // that same (bank, primary/secondary role) slot against device d's harvested
-    // DRAM topology. Each queued GCB maps canonical senders to stable slots; all
-    // device-bound socket, program, and NOC operations use the per-device table.
-    std::vector<CoreCoord> sender_logical_cores_;
+    // sender_logical_cores_by_device_[d][s] is the logical DRAM core that plays stable
+    // sender slot s (a (bank, primary/secondary role) pair) on device d's harvested DRAM
+    // topology. Row [0] is the canonical (reference-device) mapping that queued GCBs match
+    // their sender coordinates against; all device-bound socket, program, and NOC operations
+    // use the per-device row.
     std::vector<std::vector<CoreCoord>> sender_logical_cores_by_device_;
     uint32_t num_senders_ = 0;
     uint32_t num_banks_ = 0;

--- a/tt_metal/impl/buffers/tensor_prefetcher_manager.hpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_manager.hpp
@@ -182,9 +182,8 @@ private:
     // sender_logical_cores_[s] is the logical DRAM core for sender slot s, a (bank,
     // primary/secondary role) pair. Both sender cores per bank are provisioned at start; each
     // queued GCB may map the primary only or both, and PREFETCH requests target that subset.
-    // One list covers the whole mesh: a logical DRAM coord names an endpoint role, so it holds on
-    // every device regardless of DRAM harvesting (enumerate_dram_senders TT_FATALs if a device
-    // disagrees) while each device translates it to its own physical subchannel.
+    // One list covers the whole mesh (see metal_SocDescriptor::dram_bank_endpoint_coords);
+    // enumerate_dram_senders TT_FATALs if a device disagrees.
     std::vector<CoreCoord> sender_logical_cores_;
     uint32_t num_senders_ = 0;
     uint32_t num_banks_ = 0;

--- a/tt_metal/impl/buffers/tensor_prefetcher_manager.hpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_manager.hpp
@@ -179,12 +179,13 @@ private:
     // write and the WAIT_CQ request value.
     std::array<uint32_t, kNumCqSignalSlots> cq_signal_counter_{};
 
-    // sender_logical_cores_by_device_[d][s] is the logical DRAM core that plays stable
-    // sender slot s (a (bank, primary/secondary role) pair) on device d's harvested DRAM
-    // topology. Row [0] is the canonical (reference-device) mapping that queued GCBs match
-    // their sender coordinates against; all device-bound socket, program, and NOC operations
-    // use the per-device row.
-    std::vector<std::vector<CoreCoord>> sender_logical_cores_by_device_;
+    // sender_logical_cores_[s] is the logical DRAM core for sender slot s, a (bank,
+    // primary/secondary role) pair. Both sender cores per bank are provisioned at start; each
+    // queued GCB may map the primary only or both, and PREFETCH requests target that subset.
+    // One list covers the whole mesh: a logical DRAM coord names an endpoint role, so it holds on
+    // every device regardless of DRAM harvesting (enumerate_dram_senders TT_FATALs if a device
+    // disagrees) while each device translates it to its own physical subchannel.
+    std::vector<CoreCoord> sender_logical_cores_;
     uint32_t num_senders_ = 0;
     uint32_t num_banks_ = 0;
 

--- a/tt_metal/impl/buffers/tensor_prefetcher_manager.hpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_manager.hpp
@@ -179,10 +179,13 @@ private:
     // write and the WAIT_CQ request value.
     std::array<uint32_t, kNumCqSignalSlots> cq_signal_counter_{};
 
-    // sender_logical_cores_[s] = logical DRAM core for sender s. Both available
-    // sender cores per bank are provisioned at start. Each queued GCB may map either
-    // the primary sender only or both senders; PREFETCH requests target that subset.
+    // sender_logical_cores_[s] is the canonical (reference-device) logical DRAM
+    // core for stable sender slot s. sender_logical_cores_by_device_[d][s] resolves
+    // that same (bank, primary/secondary role) slot against device d's harvested
+    // DRAM topology. Each queued GCB maps canonical senders to stable slots; all
+    // device-bound socket, program, and NOC operations use the per-device table.
     std::vector<CoreCoord> sender_logical_cores_;
+    std::vector<std::vector<CoreCoord>> sender_logical_cores_by_device_;
     uint32_t num_senders_ = 0;
     uint32_t num_banks_ = 0;
 

--- a/tt_metal/impl/context/metal_env.cpp
+++ b/tt_metal/impl/context/metal_env.cpp
@@ -126,12 +126,9 @@ namespace {
 // Decide whether to register Blackhole DRAM programmable cores (the "DRAM-core" / tensor-prefetcher
 // path) in the HAL. Queryable afterwards via Hal::has_programmable_core_type(HalProgrammableCoreType::DRAM).
 //
-// Two independent constraints, both about the application owning the right DRAM RISC core:
-//   - Firmware must support it (arch + firmware-bundle floor) -- resolved by check_firmware_capabilities.
-//   - Topology: with DRAM harvesting the specific core the application must write to for GCB credits can
-//     differ per device, which breaks our programming model that the cores look identical on every
-//     device. A single device has no cross-device consistency to break, and an unharvested multi-device
-//     system lines the cores up the same way -- so require no harvested DRAM channels, OR a single device.
+// Firmware support (architecture + firmware-bundle floor) is resolved by check_firmware_capabilities.
+// DRAM harvesting does not disable the core type: DRAM programs and GCB credit targets resolve sender
+// coordinates from each device's SOC descriptor.
 bool should_enable_blackhole_dram_programmable_cores(const Cluster& cluster) {
     FirmwareCapabilityRequest req;
     req.dram_programmable_cores = true;
@@ -141,21 +138,7 @@ bool should_enable_blackhole_dram_programmable_cores(const Cluster& cluster) {
         {.firmware_bundle = cluster.get_cluster_desc()->get_cluster_firmware_bundle_version()},
         req,
         res);
-    if (!res.dram_programmable_cores) {
-        return false;
-    }
-
-    if (cluster.number_of_devices() == 1) {
-        return true;
-    }
-    // Multi-device: the GCB-credit core must be the same on every device, so reject if any device has
-    // a harvested DRAM channel (which would shift that core on that device).
-    for (const auto chip : cluster.all_chip_ids()) {
-        if (cluster.get_soc_desc(chip).harvesting_masks.dram_harvesting_mask != 0) {
-            return false;
-        }
-    }
-    return true;
+    return res.dram_programmable_cores;
 }
 }  // namespace
 

--- a/tt_metal/impl/context/metal_env.cpp
+++ b/tt_metal/impl/context/metal_env.cpp
@@ -133,12 +133,9 @@ namespace {
 // A tri-state env var (TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES) overrides the auto-detect:
 //   =1 → force enable, =0 → force disable, unset → auto-detect (below).
 //
-// Two independent constraints for auto-detect, both about the application owning the right DRAM RISC core:
-//   - Firmware must support it (arch + firmware-bundle floor) -- resolved by check_firmware_capabilities.
-//   - Topology: with DRAM harvesting the specific core the application must write to for GCB credits can
-//     differ per device, which breaks our programming model that the cores look identical on every
-//     device. A single device has no cross-device consistency to break, and an unharvested multi-device
-//     system lines the cores up the same way -- so require no harvested DRAM channels, OR a single device.
+// Auto-detect resolves firmware support only (architecture + firmware-bundle floor, via
+// check_firmware_capabilities). DRAM harvesting no longer disables the core type: DRAM programs and
+// GCB credit targets resolve sender coordinates from each device's SOC descriptor.
 bool should_enable_blackhole_dram_programmable_cores(const Cluster& cluster, const llrt::RunTimeOptions& rtoptions) {
     const auto override = rtoptions.get_blackhole_dram_programmable_cores_override();
     if (override.has_value()) {
@@ -158,21 +155,7 @@ bool should_enable_blackhole_dram_programmable_cores(const Cluster& cluster, con
         {.firmware_bundle = cluster.get_cluster_desc()->get_cluster_firmware_bundle_version()},
         req,
         res);
-    if (!res.dram_programmable_cores) {
-        return false;
-    }
-
-    if (cluster.number_of_devices() == 1) {
-        return true;
-    }
-    // Multi-device: the GCB-credit core must be the same on every device, so reject if any device has
-    // a harvested DRAM channel (which would shift that core on that device).
-    for (const auto chip : cluster.all_chip_ids()) {
-        if (cluster.get_soc_desc(chip).harvesting_masks.dram_harvesting_mask != 0) {
-            return false;
-        }
-    }
-    return true;
+    return res.dram_programmable_cores;
 }
 }  // namespace
 

--- a/tt_metal/impl/host_api/tt_metal.cpp
+++ b/tt_metal/impl/host_api/tt_metal.cpp
@@ -1596,8 +1596,7 @@ static KernelHandle CreateDramKernel(
         MetalContext::instance().get_cluster().arch() == ARCH::BLACKHOLE, "DramKernel is only supported on Blackhole.");
     TT_FATAL(
         MetalContext::instance().hal().has_programmable_core_type(HalProgrammableCoreType::DRAM),
-        "DRAM programmable cores are not enabled; they auto-enable on Blackhole with firmware >= 19.12.0.0 "
-        "and either no harvested DRAM channels or a single device.");
+        "DRAM programmable cores are not enabled; they auto-enable on Blackhole with firmware >= 19.12.0.0.");
     std::shared_ptr<Kernel> kernel = std::make_shared<DramKernel>(kernel_src, core_range_set, config);
     return program.impl().add_kernel(kernel, HalProgrammableCoreType::DRAM);
 }

--- a/tt_metal/impl/host_api/tt_metal.cpp
+++ b/tt_metal/impl/host_api/tt_metal.cpp
@@ -1666,8 +1666,7 @@ static KernelHandle CreateDramKernel(
     TT_FATAL(metal_context.get_cluster().arch() == ARCH::BLACKHOLE, "DramKernel is only supported on Blackhole.");
     TT_FATAL(
         metal_context.hal().has_programmable_core_type(HalProgrammableCoreType::DRAM),
-        "DRAM programmable cores are not enabled; they auto-enable on Blackhole with firmware >= 19.12.0.0 "
-        "and either no harvested DRAM channels or a single device.");
+        "DRAM programmable cores are not enabled; they auto-enable on Blackhole with firmware >= 19.12.0.0.");
     std::shared_ptr<Kernel> kernel = std::make_shared<DramKernel>(context_id, kernel_src, core_range_set, config);
     return program.impl().add_kernel(kernel, HalProgrammableCoreType::DRAM);
 }

--- a/tt_metal/llrt/metal_soc_descriptor.cpp
+++ b/tt_metal/llrt/metal_soc_descriptor.cpp
@@ -324,18 +324,32 @@ void metal_SocDescriptor::load_dram_metadata_from_device_descriptor() {
         this->dram_view_eth_cores.push_back(std::move(eth_dram_cores));
         this->dram_view_worker_cores.push_back(std::move(worker_dram_cores));
 
-        size_t num_subchannels = get_grid_size(tt::CoreType::DRAM).y;
-        size_t preferred_subchannel = worker_endpoints[0];
+        // Order a bank's endpoints by role, not by raw subchannel id: the worker endpoints in NOC
+        // order (NOC0 first, so logical y == 0 stays the endpoint CMFW also uses for DRAM telemetry,
+        // SYS-1419), then whatever subchannels are left, ascending. A role-ordered y means a logical
+        // DRAM CoreCoord denotes the same thing on every device: which raw subchannel serves which
+        // role is fixed per descriptor entry, but DRAM harvesting shifts which entry a bank maps to,
+        // so ordering by subchannel id would make (bank, y) name a different role from one device to
+        // the next. Endpoints that repeat a subchannel (Wormhole declares the same one for both NOCs)
+        // are placed once, which leaves those descriptors ordered exactly as before.
+        const size_t num_subchannels = get_grid_size(tt::CoreType::DRAM).y;
+        std::vector<bool> subchannel_placed(num_subchannels, false);
         std::vector<tt::tt_metal::CoreCoord> bank_endpoints;
         bank_endpoints.reserve(num_subchannels);
-        auto preferred_coord =
-            get_dram_core_for_channel(logical_channel, preferred_subchannel, tt::CoordSystem::TRANSLATED);
-        bank_endpoints.push_back({preferred_coord.x, preferred_coord.y});
-        for (size_t sub = 0; sub < num_subchannels; sub++) {
-            if (sub != preferred_subchannel) {
-                auto coord = get_dram_core_for_channel(logical_channel, sub, tt::CoordSystem::TRANSLATED);
-                bank_endpoints.push_back({coord.x, coord.y});
+        const auto place_subchannel = [&](size_t sub) {
+            if (sub >= num_subchannels || subchannel_placed[sub]) {
+                return;
             }
+            subchannel_placed[sub] = true;
+            const tt::umd::CoreCoord coord =
+                get_dram_core_for_channel(logical_channel, sub, tt::CoordSystem::TRANSLATED);
+            bank_endpoints.push_back({coord.x, coord.y});
+        };
+        for (const size_t worker_endpoint : worker_endpoints) {
+            place_subchannel(worker_endpoint);
+        }
+        for (size_t sub = 0; sub < num_subchannels; sub++) {
+            place_subchannel(sub);
         }
         this->dram_bank_endpoint_coords.push_back(std::move(bank_endpoints));
     }

--- a/tt_metal/llrt/metal_soc_descriptor.cpp
+++ b/tt_metal/llrt/metal_soc_descriptor.cpp
@@ -324,32 +324,36 @@ void metal_SocDescriptor::load_dram_metadata_from_device_descriptor() {
         this->dram_view_eth_cores.push_back(std::move(eth_dram_cores));
         this->dram_view_worker_cores.push_back(std::move(worker_dram_cores));
 
-        // Order a bank's endpoints by role, not by raw subchannel id: the worker endpoints in NOC
-        // order (NOC0 first, so logical y == 0 stays the endpoint CMFW also uses for DRAM telemetry,
-        // SYS-1419), then whatever subchannels are left, ascending. A role-ordered y means a logical
-        // DRAM CoreCoord denotes the same thing on every device: which raw subchannel serves which
-        // role is fixed per descriptor entry, but DRAM harvesting shifts which entry a bank maps to,
-        // so ordering by subchannel id would make (bank, y) name a different role from one device to
-        // the next. Endpoints that repeat a subchannel (Wormhole declares the same one for both NOCs)
-        // are placed once, which leaves those descriptors ordered exactly as before.
+        // Order a bank's endpoints by role (see dram_bank_endpoint_coords): the worker endpoints in
+        // NOC order first -- NOC0 at y == 0, the endpoint CMFW also uses for DRAM telemetry (SYS-1419)
+        // -- then whatever subchannels are left, ascending. Endpoints that repeat a subchannel
+        // (Wormhole declares the same one for both NOCs) are placed once, which leaves those
+        // descriptors ordered exactly as before.
         const size_t num_subchannels = get_grid_size(tt::CoreType::DRAM).y;
-        std::vector<bool> subchannel_placed(num_subchannels, false);
+        TT_FATAL(
+            !worker_endpoints.empty(),
+            "DRAM view {} declares no worker_endpoint, so its logical y=0 would not name the NOC0 worker endpoint",
+            this->dram_view_channels.size() - 1);
+        std::vector<bool> placed(num_subchannels, false);
         std::vector<tt::tt_metal::CoreCoord> bank_endpoints;
         bank_endpoints.reserve(num_subchannels);
-        const auto place_subchannel = [&](size_t sub) {
-            if (sub >= num_subchannels || subchannel_placed[sub]) {
-                return;
-            }
-            subchannel_placed[sub] = true;
+        const auto push_subchannel = [&](size_t sub) {
+            placed[sub] = true;
             const tt::umd::CoreCoord coord =
                 get_dram_core_for_channel(logical_channel, sub, tt::CoordSystem::TRANSLATED);
             bank_endpoints.push_back({coord.x, coord.y});
         };
+        // worker_endpoints entries were bounds-checked above; each subchannel is visited once by
+        // the second loop, so only the first needs the placed[] guard.
         for (const size_t worker_endpoint : worker_endpoints) {
-            place_subchannel(worker_endpoint);
+            if (!placed[worker_endpoint]) {
+                push_subchannel(worker_endpoint);
+            }
         }
         for (size_t sub = 0; sub < num_subchannels; sub++) {
-            place_subchannel(sub);
+            if (!placed[sub]) {
+                push_subchannel(sub);
+            }
         }
         this->dram_bank_endpoint_coords.push_back(std::move(bank_endpoints));
     }

--- a/tt_metal/llrt/metal_soc_descriptor.hpp
+++ b/tt_metal/llrt/metal_soc_descriptor.hpp
@@ -29,8 +29,10 @@ public:
     std::vector<std::vector<tt::tt_metal::CoreCoord>> dram_view_eth_cores;  // per dram view preferred eth endpoints for each noc
     std::vector<size_t> dram_view_address_offsets;            // starting address offset
 
-    // Per bank, ordered endpoint translated coordinates.
-    // Index 0 = preferred worker endpoint (NOC 0), indices 1..N = remaining endpoints on the same bank.
+    // Per bank, ordered endpoint translated coordinates. The index is the y of a logical DRAM
+    // CoreCoord, and the order is by role so that y means the same thing on every device regardless
+    // of DRAM harvesting: index 0 = worker endpoint for NOC 0, index 1 = worker endpoint for NOC 1
+    // (when it is a different subchannel), then the bank's remaining subchannels ascending.
     std::vector<std::vector<tt::tt_metal::CoreCoord>> dram_bank_endpoint_coords;
 
     uint64_t dram_core_size{};
@@ -66,7 +68,7 @@ public:
     tt::tt_metal::CoreCoord get_physical_tensix_core_from_logical(const tt::tt_metal::CoreCoord& logical_coord) const;
     tt::tt_metal::CoreCoord get_physical_dram_core_from_logical(const tt::tt_metal::CoreCoord& logical_coord) const;
     // Map a DRAM view + hardware subchannel to the logical CoreCoord used by CreateKernel(DramConfig).
-    // logical.y indexes dram_bank_endpoint_coords (worker endpoint first), not the raw subchannel id.
+    // logical.y indexes dram_bank_endpoint_coords (ordered by endpoint role), not the raw subchannel id.
     tt::tt_metal::CoreCoord get_logical_dram_core_for_subchannel(int dram_view, int subchannel) const;
     // Same logical space as get_logical_dram_core_for_subchannel, keyed by a TRANSLATED coord. Inverse
     // of get_physical_dram_core_from_logical. A DRAM view is a dram_view_size window of one hardware

--- a/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher_nanobind.cpp
@@ -20,8 +20,8 @@ void bind_tensor_prefetcher(nb::module_& mod) {
         mod,
         R"doc(
             Return True if the Tensor prefetcher (DRISC) is supported on `mesh_device`,
-            i.e. programmable DRAM cores are available (Blackhole with firmware >= 19.12.0.0
-            and either no harvested DRAM channels or a single device). When this returns False,
+            i.e. programmable DRAM cores are available (Blackhole with firmware >= 19.12.0.0).
+            When this returns False,
             start_tensor_prefetcher would raise, so callers can use this to skip instead.
 
             Args:


### PR DESCRIPTION
### PR Category
Feature

### Summary
Enable the tensor prefetcher and DRAM-sender Global Circular Buffer on multi-device Blackhole systems when sender placement differs between devices.

- Keep a stable mesh-wide `(bank_id, sender_role)` index while resolving its DRAM core per physical device.
- Generate per-device GCB credit configuration and sender-state receiver coordinates.
- Use per-device sender placement for H2D sockets, programs, and command-queue signals.
- Remove the topology-based programmable-DRAM gate while preserving architecture and firmware capability checks.
- Keep the tensor prefetcher and Global Circular Buffer public APIs unchanged.
- Add focused C++ configuration/state coverage and a two-device Python data-flow test.

### Notes for reviewers
The public GCB sender mapping remains canonical to the reference device for compatibility. Device-bound operations resolve the canonical bank/role through each device SOC descriptor before translating logical coordinates.

Verification:
- `~/bin-metal/build_metal.sh` passed.
- `pre-commit run --from-ref main --to-ref HEAD` passed.
- `DramSenderGCBFixture.SmokeOneSenderFourReceivers` passed with firmware 19.12.0.
- `test_validator_dram_sender[bench_default]` passed with firmware 19.12.0.
- The new two-device C++ and Python regressions collected successfully but skipped locally because this host exposes one device.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/tensor-prefetcher-multichip-dram-harvesting)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/tensor-prefetcher-multichip-dram-harvesting)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/tensor-prefetcher-multichip-dram-harvesting)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/tensor-prefetcher-multichip-dram-harvesting)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/tensor-prefetcher-multichip-dram-harvesting)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/tensor-prefetcher-multichip-dram-harvesting)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/tensor-prefetcher-multichip-dram-harvesting)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/tensor-prefetcher-multichip-dram-harvesting)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/tensor-prefetcher-multichip-dram-harvesting)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/tensor-prefetcher-multichip-dram-harvesting)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/tensor-prefetcher-multichip-dram-harvesting)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/tensor-prefetcher-multichip-dram-harvesting)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/tensor-prefetcher-multichip-dram-harvesting)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/tensor-prefetcher-multichip-dram-harvesting)