### PR TITLE
[LLK] Extend ckernel::load_blocking to support 16-bit operands

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel.h
@@ -136,20 +136,20 @@ inline volatile void *memcpy_blocking(volatile void *dst, const volatile void *s
 
 /**
  * @brief Issues a load transaction that will block the core until the transaction is completed.
- * @tparam T 32-bit type to load
+ * @tparam T 16-bit or 32-bit type to load
  * @param ptr address to read from
  * @return value read from the address
  */
 template <typename T, typename = std::enable_if_t<std::is_trivially_copyable_v<T>>>
 inline T load_blocking(volatile T *ptr)
 {
-    static_assert(sizeof(T) == sizeof(std::uint32_t), "load_blocking: operand must be 32-bit");
+    static_assert(sizeof(T) == sizeof(std::uint16_t) || sizeof(T) == sizeof(std::uint32_t), "load_blocking: operand must be 16-bit or 32-bit");
 
     // https://github.com/tenstorrent/tt-isa-documentation/tree/main/BlackholeA0/TensixTile/BabyRISCV/MemoryOrdering.md
 
     // this code provides a blocking load by doing the following:
     // - issue a LOAD transaction to the address
-    //     - actual load that was requested
+    //     - actual load that was requested (lw for 32-bit, lhu for 16-bit)
     // - issue an instruction that requires the data from the LOAD transaction
     //     - block the pipeline until the LOAD transaction completes
     // - memory clobber
@@ -157,12 +157,24 @@ inline T load_blocking(volatile T *ptr)
 
     std::uint32_t raw;
 
-    asm volatile(
-        "lw %[raw], (%[ptr])\n\t"
-        "and x0, x0, %[raw]"
-        : [raw] "=r"(raw)
-        : [ptr] "r"(ptr)
-        : "memory");
+    if constexpr (sizeof(T) == sizeof(std::uint16_t))
+    {
+        asm volatile(
+            "lhu %[raw], (%[ptr])\n\t"
+            "and x0, x0, %[raw]"
+            : [raw] "=r"(raw)
+            : [ptr] "r"(ptr)
+            : "memory");
+    }
+    else
+    {
+        asm volatile(
+            "lw %[raw], (%[ptr])\n\t"
+            "and x0, x0, %[raw]"
+            : [raw] "=r"(raw)
+            : [ptr] "r"(ptr)
+            : "memory");
+    }
 
     T val;
     std::memcpy(&val, &raw, sizeof(T));

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel.h
@@ -141,14 +141,14 @@ inline volatile void *memcpy_blocking(volatile void *dst, const volatile void *s
 
 /**
  * @brief Issues a load transaction that will block the core until the transaction is completed.
- * @tparam T 32-bit type to load
+ * @tparam T 16-bit or 32-bit type to load
  * @param ptr address to read from
  * @return value read from the address
  */
 template <typename T, typename = std::enable_if_t<std::is_trivially_copyable_v<T>>>
 inline T load_blocking(volatile T *ptr)
 {
-    static_assert(sizeof(T) == sizeof(std::uint32_t), "load_blocking: operand must be 32-bit");
+    static_assert(sizeof(T) == sizeof(std::uint16_t) || sizeof(T) == sizeof(std::uint32_t), "load_blocking: operand must be 16-bit or 32-bit");
 
     // https://github.com/tenstorrent/tt-isa-documentation/tree/main/WormholeB0/TensixTile/BabyRISCV/MemoryOrdering.md
 
@@ -156,7 +156,7 @@ inline T load_blocking(volatile T *ptr)
     //
     // this code provides a blocking load by doing the following:
     // - issue a LOAD transaction to the address
-    //     - actual load that was requested
+    //     - actual load that was requested (lw for 32-bit, lhu for 16-bit)
     // - issue an instruction that requires the data from the LOAD transaction
     //     - block the pipeline until the LOAD transaction completes
     // - memory clobber
@@ -164,12 +164,24 @@ inline T load_blocking(volatile T *ptr)
 
     std::uint32_t raw;
 
-    asm volatile(
-        "lw %[raw], (%[ptr])\n\t"
-        "and %[raw], %[raw], %[raw]"
-        : [raw] "=r"(raw)
-        : [ptr] "r"(ptr)
-        : "memory");
+    if constexpr (sizeof(T) == sizeof(std::uint16_t))
+    {
+        asm volatile(
+            "lhu %[raw], (%[ptr])\n\t"
+            "and %[raw], %[raw], %[raw]"
+            : [raw] "=r"(raw)
+            : [ptr] "r"(ptr)
+            : "memory");
+    }
+    else
+    {
+        asm volatile(
+            "lw %[raw], (%[ptr])\n\t"
+            "and %[raw], %[raw], %[raw]"
+            : [raw] "=r"(raw)
+            : [ptr] "r"(ptr)
+            : "memory");
+    }
 
     T val;
     std::memcpy(&val, &raw, sizeof(T)); // trickery to return T loaded into register


### PR DESCRIPTION
Needed for some ttnn ops which use 16 bit data.

### Problem

`ckernel::load_blocking` (WH + BH) is the canonical baby-RISC blocking-load primitive: it issues a load and a dependent consume so the pipeline stalls until the read-response arrives, ordering a preceding same-address store before any subsequent cross-core signal (per `WormholeB0`/`BlackholeA0` `TensixTile/BabyRISCV/MemoryOrdering.md`). It only accepted **32-bit** operands (`static_assert(sizeof(T) == 4)`, always `lw`).

A ttnn dataflow kernel that must order a **`uint16_t`** L1 store before signalling a remote NoC reader (groupnorm Welford receiver, #50305) therefore cannot use it, and currently duplicates the idiom in a local `l1_store_barrier.h` with a hand-written `lhu` variant.

### What changed

Widen `load_blocking` to accept **16-bit or 32-bit** operands, dispatching on `sizeof(T)`:
- 2-byte → `lhu` (load halfword unsigned)
- 4-byte → `lw` (load word)

The blocking mechanism (dependent `and` consume + memory clobber) and the return-via-`memcpy` are unchanged. Applied to both `tt_llk_wormhole_b0` and `tt_llk_blackhole` (each keeps its own `and` form). Quasar has no `load_blocking`, so it is untouched.

**Additive / backward-compatible:** the function signature is unchanged and every existing 32-bit caller keeps the `lw` path, so no metal-integration propagation is required.

### Test / verification

- Both instantiations compile for `rv32i` with the sfpi RISC-V toolchain and emit the expected sequences: 16-bit → `lhu` + `and`, 32-bit → `lw` + `and` (dependent consume preserved in both).
- `clang-format` and the LLK-scoped pre-commit hooks pass.
- No existing caller uses the 16-bit path yet, so tt-llk's own build exercises only the (unchanged) 32-bit branch; the 16-bit branch is first exercised by the consumer PR #50305, which will drop its local helper and call `ckernel::load_blocking`.

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/ckernel-load-blocking-16bit)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/ckernel-load-blocking-16bit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/ckernel-load-blocking-16bit)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/ckernel-load-blocking-16bit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/ckernel-load-blocking-16bit)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/ckernel-load-blocking-16bit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/ckernel-load-blocking-16bit)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/ckernel-load-blocking-16bit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/ckernel-load-blocking-16bit)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/ckernel-load-blocking-16bit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/ckernel-load-blocking-16bit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/ckernel-load-blocking-16bit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/ckernel-load-blocking-16bit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/ckernel-load-blocking-16bit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/ckernel-load-blocking-16bit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/ckernel-load-blocking-16bit)