### PR TITLE
[ttnn] rand: replace get_dynamic_runtime_args with override_runtime_arguments

### DIFF
--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -452,7 +452,22 @@ public:
         // full re-derivation, correct by construction.  This is the target mechanism; resolve_bindings
         // and get_dynamic are the legacy paths being migrated out (and, eventually, deleted with
         // Metal 2.0 native bindings).
-        static consteval bool has_override_runtime_arguments() {
+        //
+        // The hook lives on the program factory (its natural home — alongside create_descriptor):
+        // factory_has_override_runtime_arguments() below. For DirectDescriptorFactory the factory has
+        // no override, so we also accept it on the DeviceOperation itself, preserving direct ops that
+        // predate the factory-struct shape.
+        static consteval bool factory_has_override_runtime_arguments() {
+            return requires(
+                tt::tt_metal::Program& program,
+                const operation_attributes_t& attrs,
+                const tensor_args_t& tensor_args,
+                tensor_return_value_t& tensor_return_value,
+                const std::optional<ttnn::MeshCoordinate>& coord) {
+                DescriptorFactory::override_runtime_arguments(program, attrs, tensor_args, tensor_return_value, coord);
+            };
+        }
+        static consteval bool device_op_has_override_runtime_arguments() {
             return requires(
                 tt::tt_metal::Program& program,
                 const operation_attributes_t& attrs,
@@ -461,6 +476,9 @@ public:
                 const std::optional<ttnn::MeshCoordinate>& coord) {
                 DeviceOperation::override_runtime_arguments(program, attrs, tensor_args, tensor_return_value, coord);
             };
+        }
+        static consteval bool has_override_runtime_arguments() {
+            return factory_has_override_runtime_arguments() || device_op_has_override_runtime_arguments();
         }
 
         static consteval bool has_get_dynamic_runtime_args() {
@@ -641,13 +659,23 @@ public:
                     // override_runtime_arguments()): re-apply ALL per-dispatch state — every runtime arg
                     // AND every tensor-backed CB address — for the current tensors.  No resolve_bindings
                     // (address inference) and no get_dynamic; correct by construction for in-place,
-                    // mixed-aliasing, and work-set shifts.
-                    DeviceOperation::override_runtime_arguments(
-                        program,
-                        attrs,
-                        tensor_args,
-                        tensor_return_value,
-                        std::optional<ttnn::MeshCoordinate>(coordinate_range.start_coord()));
+                    // mixed-aliasing, and work-set shifts. Prefer the factory's hook; fall back to the
+                    // DeviceOperation for direct ops that predate the factory-struct shape.
+                    if constexpr (factory_has_override_runtime_arguments()) {
+                        DescriptorFactory::override_runtime_arguments(
+                            program,
+                            attrs,
+                            tensor_args,
+                            tensor_return_value,
+                            std::optional<ttnn::MeshCoordinate>(coordinate_range.start_coord()));
+                    } else {
+                        DeviceOperation::override_runtime_arguments(
+                            program,
+                            attrs,
+                            tensor_args,
+                            tensor_return_value,
+                            std::optional<ttnn::MeshCoordinate>(coordinate_range.start_coord()));
+                    }
 #ifdef TT_DESCRIPTOR_PATCHING_PARITY_CHECK
                     // Same regression net as the legacy fast path: assert the op's override reproduced a
                     // full rebuild exactly (rt-args AND CB addresses).

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
@@ -5,7 +5,8 @@
 #pragma once
 
 #include <optional>
-
+#include <tuple>
+#include <variant>
 #include <vector>
 
 #include "ttnn/device_operation.hpp"
@@ -27,10 +28,10 @@ struct RandDeviceOperation {
         uint32_t seed;
         ttsl::SmallVector<bool> mesh_dim_is_sharded;
 
-        // Program identity. seed/from/to are re-applied via get_dynamic_runtime_args (excluded
-        // here). `device` must be FIRST: rand has no input tensor, so the framework discovers the
-        // mesh device via get_first_object_of_type over attribute_values(), and its tuple path only
-        // inspects element 0.
+        // Cache key. seed/from/to are omitted (re-applied per dispatch via override_runtime_arguments,
+        // so calls differing only in those values reuse the cached program). `device` must be FIRST:
+        // rand has no input tensor, so the framework discovers the mesh device via
+        // get_first_object_of_type over attribute_values(), whose tuple path inspects only element 0.
         static constexpr auto attribute_names =
             std::forward_as_tuple("device", "shape", "dtype", "layout", "memory_config");
         auto attribute_values() const { return std::forward_as_tuple(device, shape, dtype, layout, memory_config); }
@@ -41,27 +42,26 @@ struct RandDeviceOperation {
     using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output,
-        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
+    struct RandProgramFactory {
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output,
+            const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
+
+        static void override_runtime_arguments(
+            tt::tt_metal::Program& program,
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output,
+            const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
+    };
+    using program_factory_t = std::variant<RandProgramFactory>;
 
     static void validate_inputs(const operation_attributes_t& attributes, const tensor_args_t& tensor_args);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    // seed/from/to are excluded from the program hash (so calls differing only in
-    // those values cache-hit instead of recompiling).  They are therefore DYNAMIC: this returns the
-    // current per-core (seed) and per-call (from/to) values so the framework re-applies them to the
-    // cached program on every dispatch.  Must mirror the seed/from/to runtime args built in
-    // create_descriptor() — the test_rand_different_seed_values regression test enforces this.
-    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output,
-        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 
 }  // namespace ttnn::operations::rand

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
@@ -8,6 +8,7 @@
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/work_split.hpp>
+#include <tt-metalium/host_api.hpp>
 #include "ttnn/tensor/types.hpp"
 #include "rand_device_operation.hpp"
 #include <tt-metalium/tensor_accessor_args.hpp>
@@ -28,7 +29,7 @@ constexpr const char* WRITER_KERNEL_PATH = "ttnn/cpp/ttnn/operations/uniform/dev
 constexpr const char* COMPUTE_KERNEL_PATH = "ttnn/cpp/ttnn/operations/uniform/device/kernels/compute_uniform.cpp";
 
 // Work split + per-device seed offset, shared by create_descriptor (cache miss) and
-// get_dynamic_runtime_args (cache hit) so both derive the identical core list and seed offset.
+// override_runtime_arguments (cache hit) so both derive the identical core list and seed offset.
 struct RandWorkSplit {
     uint32_t num_cores = 0;
     CoreRangeSet all_cores;
@@ -83,23 +84,43 @@ uint32_t rand_seed_for_core(
     return attrs.seed != 0 ? attrs.seed + i + device_seed_offset : get_random_seed();
 }
 
+// Per-core work assignment. Single-sourced so the cache-miss build (create_descriptor) and the
+// cache-hit patch (override_runtime_arguments) can never drift on core-group selection or tile_offset
+// accumulation — each derives its runtime args from the same layout.
+struct RandCoreWork {
+    CoreCoord core;
+    uint32_t units_per_core;
+    uint32_t tile_offset;
+};
+std::vector<RandCoreWork> rand_core_layout(const RandWorkSplit& ws) {
+    std::vector<RandCoreWork> layout;
+    layout.reserve(ws.cores.size());
+    uint32_t tile_offset = 0;
+    for (const auto& core : ws.cores) {
+        uint32_t units_per_core;
+        if (ws.core_group_1.contains(core)) {
+            units_per_core = ws.units_per_core_group_1;
+        } else if (ws.core_group_2.contains(core)) {
+            units_per_core = ws.units_per_core_group_2;
+        } else {
+            TT_THROW("Core not in specified core ranges");
+        }
+        layout.push_back({core, units_per_core, tile_offset});
+        tile_offset += units_per_core;
+    }
+    return layout;
+}
+
 }  // namespace
 
-ProgramDescriptor RandDeviceOperation::create_descriptor(
+ProgramDescriptor RandDeviceOperation::RandProgramFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& /*tensor_args*/,
     tensor_return_value_t& output,
     const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
-    auto
-        [num_cores,
-         all_cores,
-         core_group_1,
-         core_group_2,
-         units_per_core_group_1,
-         units_per_core_group_2,
-         cores,
-         device_seed_offset] = compute_rand_work_split(operation_attributes, output, mesh_dispatch_coordinate);
-    const auto num_cores_total = cores.size();
+    const auto ws = compute_rand_work_split(operation_attributes, output, mesh_dispatch_coordinate);
+    const auto& all_cores = ws.all_cores;
+    const auto num_cores_total = ws.cores.size();
 
     DataType output_dtype = output.dtype();
     auto out_data_format = datatype_to_dataformat_converter(output_dtype);
@@ -174,30 +195,19 @@ ProgramDescriptor RandDeviceOperation::create_descriptor(
     const uint32_t from_bits = std::bit_cast<uint32_t>(operation_attributes.from);
     const uint32_t to_bits = std::bit_cast<uint32_t>(operation_attributes.to - eps);
 
-    uint32_t tile_offset = 0;
-    for (int i = 0; i < static_cast<int>(cores.size()); ++i) {
-        const auto& core = cores[i];
-        uint32_t units_per_core;
-        if (core_group_1.contains(core)) {
-            units_per_core = units_per_core_group_1;
-        } else if (core_group_2.contains(core)) {
-            units_per_core = units_per_core_group_2;
-        } else {
-            TT_THROW("Core not in specified core ranges");
-        }
+    const auto layout = rand_core_layout(ws);
+    for (int i = 0; i < static_cast<int>(layout.size()); ++i) {
+        const auto& [core, units_per_core, tile_offset] = layout[i];
+        const uint32_t seed = rand_seed_for_core(operation_attributes, i, ws.device_seed_offset);
 
-        uint32_t seed = rand_seed_for_core(operation_attributes, i, device_seed_offset);
-
-        // seed/from/to are DYNAMIC (excluded from compute_program_hash): baked here for the
-        // cache-miss build, and re-applied on every cache hit via get_dynamic_runtime_args().
+        // seed/from/to are DYNAMIC (omitted from the cache key / attribute_names): baked here for the
+        // cache-miss build, and re-applied on every cache hit via override_runtime_arguments().
         compute_desc.runtime_args.emplace_back(
             core, KernelDescriptor::CoreRuntimeArgs{seed, from_bits, to_bits, tile_offset, units_per_core});
 
         // Register the output address as a Buffer* binding so rand takes the fast cache-hit path
         // (real program caching) with the address correctly re-patched each dispatch.
         writer_desc.emplace_runtime_args(core, {output.buffer(), tile_offset, units_per_core});
-
-        tile_offset += units_per_core;
     }
 
     desc.kernels.push_back(std::move(writer_desc));
@@ -206,29 +216,41 @@ ProgramDescriptor RandDeviceOperation::create_descriptor(
     return desc;
 }
 
-std::vector<tt::tt_metal::DynamicRuntimeArg> RandDeviceOperation::get_dynamic_runtime_args(
+void RandDeviceOperation::RandProgramFactory::override_runtime_arguments(
+    tt::tt_metal::Program& program,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& /*tensor_args*/,
     tensor_return_value_t& output,
     const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
-    // compute is kernel 1; its runtime args are {seed, from_bits, to_bits, tile_offset, units_per_core}.
-    // seed/from/to are excluded from the hash and re-applied here; the rest are static.
-    constexpr uint32_t kComputeKernelIdx = 1;
-    auto ws = compute_rand_work_split(operation_attributes, output, mesh_dispatch_coordinate);
+    // Re-derive every per-dispatch arg on each cache hit from the same builder create_descriptor uses:
+    // compute's seed/from/to and the writer's output address. override replaces resolve_bindings, so
+    // the address is ours to re-apply too. Push order in create_descriptor: writer 0, compute 1.
+    constexpr uint32_t writer_kernel_idx = 0;
+    constexpr uint32_t compute_kernel_idx = 1;
 
+    const auto ws = compute_rand_work_split(operation_attributes, output, mesh_dispatch_coordinate);
     const float eps = 1e-6f;
     const uint32_t from_bits = std::bit_cast<uint32_t>(operation_attributes.from);
     const uint32_t to_bits = std::bit_cast<uint32_t>(operation_attributes.to - eps);
+    const uint32_t out_addr = output.buffer()->address();
 
-    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
-    dynamic_args.reserve(ws.cores.size() * 3);
-    for (int i = 0; i < static_cast<int>(ws.cores.size()); ++i) {
+    const auto layout = rand_core_layout(ws);
+    for (int i = 0; i < static_cast<int>(layout.size()); ++i) {
+        const auto& [core, units_per_core, tile_offset] = layout[i];
         const uint32_t seed = rand_seed_for_core(operation_attributes, i, ws.device_seed_offset);
-        dynamic_args.push_back({kComputeKernelIdx, ws.cores[i], 0, seed});
-        dynamic_args.push_back({kComputeKernelIdx, ws.cores[i], 1, from_bits});
-        dynamic_args.push_back({kComputeKernelIdx, ws.cores[i], 2, to_bits});
+
+        auto& compute_args = tt::tt_metal::GetRuntimeArgs(program, compute_kernel_idx, core);
+        compute_args[0] = seed;
+        compute_args[1] = from_bits;
+        compute_args[2] = to_bits;
+        compute_args[3] = tile_offset;
+        compute_args[4] = units_per_core;
+
+        auto& writer_args = tt::tt_metal::GetRuntimeArgs(program, writer_kernel_idx, core);
+        writer_args[0] = out_addr;
+        writer_args[1] = tile_offset;
+        writer_args[2] = units_per_core;
     }
-    return dynamic_args;
 }
 
 }  // namespace ttnn::operations::rand

--- a/ttnn/cursor/DEVICE_OPERATION_MIGRATION_GUIDE.md
+++ b/ttnn/cursor/DEVICE_OPERATION_MIGRATION_GUIDE.md
@@ -601,6 +601,27 @@ ttsl::hash::hash_t UnaryDeviceOperation::compute_program_hash(
 }
 ```
 
+### Step 8b: Re-apply hash-excluded values on a cache hit — `override_runtime_arguments`, never `get_dynamic_runtime_args`
+
+A program-cache hit does not rebuild the program, so anything excluded from `compute_program_hash` — a dynamic scalar (RNG seed, `from`/`to`, `lr`/`step`) or a buffer address — must be re-applied to the cached program. Use **`override_runtime_arguments`**. **Never `get_dynamic_runtime_args`**: it is deprecated, and the adapter `static_assert`s if an op declares both.
+
+> **Scope.** This applies to `ProgramFactory` and `ProgramDescriptor` factories. The `WorkloadDescriptor` variant has no `override_runtime_arguments` path yet — the adapter re-applies its hash-excluded values via `get_dynamic_runtime_args` on a cache hit, so a WorkloadDescriptor factory must keep that hook until override support is added there.
+
+```cpp
+static void override_runtime_arguments(
+    tt::tt_metal::Program& program,
+    const operation_attributes_t& attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output,
+    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
+```
+
+Re-derive **all** per-dispatch state — every per-core runtime arg *and* every tensor-backed buffer address — for the current `attributes`/tensors, from the same builder the cache-miss path uses (share one work-split/args helper so miss and hit stay identical). `override_runtime_arguments` supersedes both legacy hit mechanisms — `get_dynamic_runtime_args` (scalars only) and `resolve_bindings` (addresses only); the framework runs neither when it is present, so re-apply buffer addresses here too or they freeze at the first miss. Write in place with `GetRuntimeArgs(program, kernel_index, core)` (kernel index = push order in the factory).
+
+It is correct by construction — nothing is inferred from `Buffer*` identity, so in-place aliasing (`out == in`) cannot mis-patch — and faster than `get_dynamic_runtime_args`, which built an intermediate arg vector and matched buffers by pointer.
+
+Most ops need none of this: if the only per-dispatch change is tensor addresses, register them as `Buffer*` bindings and the framework re-patches them automatically. Reach for `override_runtime_arguments` only for a hash-excluded scalar the framework cannot track — e.g. `rand`'s per-core seed.
+
 ---
 
 ## Examples
@@ -686,6 +707,7 @@ Use this checklist to ensure all steps are completed:
 3. **Not including values that affect the program structure in hash**: Every parameter that has an effect on program structure must be taken into account in the hash
 4. **Redundant tensors in tensor_args_t**: Do not add redundant arguments like `preallocated_output`, if legacy operation did not handle that explicitly in `create_output_tensors`
 5. **Mesh workload factories not working with `mesh_coords`**: If your operation supports `mesh_coords` filtering, you MUST create a separate mesh workload factory. The infrastructure's `MeshWorkloadFactoryAdapter` will create programs for ALL tensor coordinates, ignoring `mesh_coords`. Only factories that implement `MeshWorkloadFactoryConcept` (and NOT `ProgramFactoryConcept`) will use the direct path that allows coordinate filtering.
+6. **Using `get_dynamic_runtime_args`**: deprecated for `ProgramFactory`/`ProgramDescriptor` factories. Use `override_runtime_arguments` (Step 8b), which re-applies runtime args *and* buffer addresses in place and stays correct under in-place aliasing. Declaring both on one op is a compile error. (Exception: `WorkloadDescriptor` factories have no override path yet and must still use `get_dynamic_runtime_args` — see Step 8b scope note.)
 
 ---
 


### PR DESCRIPTION
### What
Migrate `rand`'s program-cache-hit re-application from `get_dynamic_runtime_args` to `override_runtime_arguments`, and make its cache-key exclusion explicit. `rand` stays a `ProgramDescriptor` op — this is a descriptor-framework change (get_dynamic-elimination campaign), **not** a Metal 2.0 / spec migration.

### Why
- `override_runtime_arguments` re-derives ALL per-dispatch state on every cache hit — per-core seed/from/to **and** the writer's output buffer address — from the same builder `create_descriptor` uses. It supersedes both legacy hit mechanisms: `get_dynamic_runtime_args` (scalars only) and `resolve_bindings` (addresses only). The adapter runs neither when `override` is declared, so the output address is re-applied here too (a get_dynamic-only port would freeze it → stale writes on cache hit).
- Perf: **~5.8% faster** host cache-hit dispatch (25.9 vs 27.5 µs/call, 256×256 fp32 on Wormhole; symbol-verified A/B). `override` writes args in place; `get_dynamic` allocated a `DynamicRuntimeArg` vector + pointer-matched buffers.
- Cache key is declared via `attribute_names`/`attribute_values()` listing only the key fields (`device`/`shape`/`dtype`/`layout`/`memory_config`); `seed`/`from`/`to` are omitted and re-applied on a cache hit by `override_runtime_arguments`. No custom `compute_program_hash` — the reflection contract is the key. `device` is listed first so the no-input-op mesh-device discovery (`get_first_object_of_type<MeshDevice*>`) finds it.
- `create_descriptor` and `override_runtime_arguments` live on a `RandProgramFactory` struct (`program_factory_t`); the adapter resolves `override_runtime_arguments` on the factory, falling back to the DeviceOperation for legacy direct-descriptor ops.

### Testing
- `pytest tests/ttnn/nightly/unit_tests/operations/rand/test_rand.py`: 44 passed (WH). Cache-hit contract verified: `test_rand_different_seed_values` (different seed → cache hit → different output) and `test_rand_different_from_to_values` (from/to re-applied on hit) both pass.
- Built with `./build_metal.sh --build-tests`.

### Notes
- Pre-existing/unrelated: intermittent RNG mean-bias in `ttnn.rand`/`uniform` on `seed=0` (shared `compute_uniform.cpp`, untouched here) — filed as #50487.
- Includes a `DEVICE_OPERATION_MIGRATION_GUIDE.md` update (Step 8b + pitfall) codifying "cache-hit re-application uses `override_runtime_arguments`, never `get_dynamic_runtime_args`" (scoped to ProgramFactory/ProgramDescriptor; the WorkloadDescriptor variant still uses `get_dynamic_runtime_args`).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/rand-metal2-recipe)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/rand-metal2-recipe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/rand-metal2-recipe)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/rand-metal2-recipe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/rand-metal2-recipe)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/rand-metal2-recipe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/rand-metal2-recipe)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/rand-metal2-recipe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/rand-metal2-recipe)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/rand-metal2-recipe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/rand-metal2-recipe)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/rand-metal2-recipe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/rand-metal2-recipe)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/rand-metal2-recipe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/rand-metal2-recipe)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/rand-metal2-recipe)
