### PR TITLE
Bump ViT wormhole/t3000 trace_region_size to fix N300 TRACE OOM

### DIFF
--- a/models/demos/vision/classification/vit/t3000/demo/demo_vit_performant_imagenet_inference.py
+++ b/models/demos/vision/classification/vit/t3000/demo/demo_vit_performant_imagenet_inference.py
@@ -22,7 +22,7 @@ NUM_VALIDATION_IMAGES_IMAGENET = 49920
 @run_for_wormhole_b0()
 @pytest.mark.model_perf_t3000
 @pytest.mark.parametrize(
-    "device_params", [{"l1_small_size": 32768, "num_command_queues": 2, "trace_region_size": 1700000}], indirect=True
+    "device_params", [{"l1_small_size": 32768, "num_command_queues": 2, "trace_region_size": 2_000_000}], indirect=True
 )
 @pytest.mark.parametrize(
     "mesh_device",
@@ -137,7 +137,7 @@ def test_run_vit_trace_2cqs_inference(
 @run_for_wormhole_b0()
 @pytest.mark.model_perf_t3000
 @pytest.mark.parametrize(
-    "device_params", [{"l1_small_size": 32768, "num_command_queues": 2, "trace_region_size": 1700000}], indirect=True
+    "device_params", [{"l1_small_size": 32768, "num_command_queues": 2, "trace_region_size": 2_000_000}], indirect=True
 )
 @pytest.mark.parametrize(
     "mesh_device",

--- a/models/demos/vision/classification/vit/wormhole/demo/demo_vit_performant_imagenet_inference.py
+++ b/models/demos/vision/classification/vit/wormhole/demo/demo_vit_performant_imagenet_inference.py
@@ -19,7 +19,7 @@ NUM_VALIDATION_IMAGES_IMAGENET = 49920
 
 @run_for_wormhole_b0()
 @pytest.mark.parametrize(
-    "device_params", [{"l1_small_size": 32768, "num_command_queues": 2, "trace_region_size": 1700000}], indirect=True
+    "device_params", [{"l1_small_size": 32768, "num_command_queues": 2, "trace_region_size": 2_000_000}], indirect=True
 )
 @pytest.mark.parametrize(
     "batch_size_per_device, iterations",
@@ -124,7 +124,7 @@ def test_run_vit_trace_2cqs_inference(
 
 @run_for_wormhole_b0()
 @pytest.mark.parametrize(
-    "device_params", [{"l1_small_size": 24576, "trace_region_size": 1700000, "num_command_queues": 2}], indirect=True
+    "device_params", [{"l1_small_size": 24576, "trace_region_size": 2_000_000, "num_command_queues": 2}], indirect=True
 )
 @pytest.mark.parametrize(
     "batch_size_per_device, iterations",

--- a/models/demos/vision/classification/vit/wormhole/tests/test_demo_vit_ttnn_inference_perf_e2e_2cq_trace.py
+++ b/models/demos/vision/classification/vit/wormhole/tests/test_demo_vit_ttnn_inference_perf_e2e_2cq_trace.py
@@ -119,7 +119,13 @@ def run_trace_2cq_model(device, test_infra, num_warmup_iterations, num_measureme
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize(
-    "device_params", [{"l1_small_size": 32768, "num_command_queues": 2, "trace_region_size": 1753088}], indirect=True
+    # trace_region_size is the TOTAL trace budget across DRAM banks (#47122). The captured
+    # ViT 2CQ trace is ~1.70 MiB; with 12 banks and max page size 8192, each bank needs
+    # 147456 B. 1753088 only reserved 146112 B/bank under pre-#47766 dram_alignment
+    # rounding and OOM'd on N300 (#47887). 2_000_000 leaves headroom after page rounding.
+    "device_params",
+    [{"l1_small_size": 32768, "num_command_queues": 2, "trace_region_size": 2_000_000}],
+    indirect=True,
 )
 @pytest.mark.parametrize("batch_size", [8])
 def test_vit(device, batch_size, is_single_card_n300):


### PR DESCRIPTION
## Summary
- Fixes [#47887](https://github.com/tenstorrent/tt-metal/issues/47887): ViT N300 2CQ demo OOM when allocating the TRACE buffer in `end_trace_capture`.
- After [#47122](https://github.com/tenstorrent/tt-metal/pull/47122), `trace_region_size` is the **total** budget across DRAM banks. The captured ViT trace is ~1.70 MiB and needs 147456 B/bank (12 banks, 8192 page size), but `1753088` only reserved 146112 B/bank under the pre-[#47766](https://github.com/tenstorrent/tt-metal/pull/47766) `dram_alignment` rounding.
- Bump wormhole CI test + wormhole/t3000 ImageNet demos to `2_000_000` for page-rounding headroom.


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=arg/fix-vit-n300-trace-oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:arg/fix-vit-n300-trace-oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=arg/fix-vit-n300-trace-oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:arg/fix-vit-n300-trace-oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=arg/fix-vit-n300-trace-oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:arg/fix-vit-n300-trace-oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=arg/fix-vit-n300-trace-oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:arg/fix-vit-n300-trace-oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=arg/fix-vit-n300-trace-oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:arg/fix-vit-n300-trace-oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=arg/fix-vit-n300-trace-oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:arg/fix-vit-n300-trace-oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=arg/fix-vit-n300-trace-oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:arg/fix-vit-n300-trace-oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=arg/fix-vit-n300-trace-oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:arg/fix-vit-n300-trace-oom)