### PR TITLE
[ttnn] rand: Metal 2.0 in descriptors -- static/dynamic attrs, override, no custom hash

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
+++ b/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
@@ -836,5 +836,72 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_CommonScalarMatching
     EXPECT_NO_THROW(resolve_bindings(program, desc, std::vector<Buffer*>{buf_a.get()}));
 }
 
+// ============================================================================
+// Metal 2.0 named-binding descriptor path (rand is the reference op)
+// ============================================================================
+
+// A valid DFB binding (accessor -> a named CBDescriptor in the same descriptor) builds a Metal 2.0
+// kernel without error.
+TEST_F(DescriptorPatchingDeviceTest, Metal2Bindings_ValidDFBReference_Builds) {
+    ProgramDescriptor desc;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2048,
+        .core_ranges = CoreRangeSet{CoreRange{{0, 0}}},
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = 0,
+            .data_format = tt::DataFormat::Float16_b,
+            .page_size = 2048,
+        }}},
+        .name = "intermed",
+    });
+    KernelDescriptor kd = MakeBlankReaderKernel({0, 0});
+    kd.dfb_bindings = {{.accessor_name = "cb", .cb_name = "intermed"}};
+    desc.kernels = {kd};
+
+    EXPECT_NO_THROW({ Program program{desc}; });
+}
+
+// A DFB binding referencing a CB name with no matching named CBDescriptor must fail loudly rather than
+// silently bind the kernel to an unrelated circular buffer.
+TEST_F(DescriptorPatchingDeviceTest, Metal2Bindings_DanglingDFBReference_Throws) {
+    ProgramDescriptor desc;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = 2048,
+        .core_ranges = CoreRangeSet{CoreRange{{0, 0}}},
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = 0,
+            .data_format = tt::DataFormat::Float16_b,
+            .page_size = 2048,
+        }}},
+        .name = "intermed",
+    });
+    KernelDescriptor kd = MakeBlankReaderKernel({0, 0});
+    kd.dfb_bindings = {{.accessor_name = "cb", .cb_name = "does_not_exist"}};
+    desc.kernels = {kd};
+
+    EXPECT_ANY_THROW({ Program program{desc}; });
+}
+
+// Two named CBDescriptors sharing a name would let a DFB binding resolve to the wrong CB; the build
+// must reject the duplicate.
+TEST_F(DescriptorPatchingDeviceTest, Metal2Bindings_DuplicateCBName_Throws) {
+    ProgramDescriptor desc;
+    for (uint32_t idx : {0u, 1u}) {
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = 2048,
+            .core_ranges = CoreRangeSet{CoreRange{{0, 0}}},
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = idx,
+                .data_format = tt::DataFormat::Float16_b,
+                .page_size = 2048,
+            }}},
+            .name = "intermed",
+        });
+    }
+    desc.kernels = {MakeBlankReaderKernel({0, 0})};
+
+    EXPECT_ANY_THROW({ Program program{desc}; });
+}
+
 }  // namespace
 }  // namespace tt::tt_metal

--- a/tests/ttnn/nightly/unit_tests/operations/rand/test_rand.py
+++ b/tests/ttnn/nightly/unit_tests/operations/rand/test_rand.py
@@ -219,6 +219,45 @@ def test_rand_different_seed_values(device):
     device.disable_and_clear_program_cache()
 
 
+def test_rand_cache_hit_repoints_output_address(device):
+    """Regression guard for the output-buffer address re-application on a program-cache hit.
+
+    override_runtime_arguments must re-apply the writer's output buffer address on every cache
+    hit -- it replaces resolve_bindings, which the framework no longer runs for this op. If it
+    didn't, the cached program would keep writing to the FIRST call's output buffer.
+
+    The scalar seed/from/to contract is guarded by the tests above; this pins the address path,
+    which they do NOT robustly cover (the allocator usually hands the freed buffer back at the
+    same address, so a frozen address would still "work"). We force a fresh output address on the
+    cache hit by keeping the first tensor alive so its buffer cannot be reused. With a fixed seed
+    both calls must produce identical data -- but only if the cache-hit write landed in the second
+    tensor's (distinct) buffer; a frozen address leaves that buffer unwritten -> mismatch.
+    """
+    device.enable_program_cache()
+    device.clear_program_cache()
+
+    shape = (256, 256)
+    dtype = ttnn.float32
+
+    t1 = ttnn.rand(shape, device=device, dtype=dtype, seed=1234)
+    d1 = ttnn.to_torch(t1).float()
+    assert device.num_program_cache_entries() == 1
+
+    # Keep t1 alive so t2 is allocated at a DIFFERENT address, forcing the cache-hit path to
+    # re-point the writer's output address rather than reuse t1's.
+    t2 = ttnn.rand(shape, device=device, dtype=dtype, seed=1234)
+    d2 = ttnn.to_torch(t2).float()
+    assert device.num_program_cache_entries() == 1, "second rand must be a cache hit (no new entry)"
+
+    assert torch.equal(d1, d2), (
+        "cache-hit output address was not re-applied: the same fixed seed must reproduce identical "
+        "data in the second (distinct) output buffer. A mismatch means the writer kept the first "
+        "call's baked-in output address (frozen-address bug)."
+    )
+
+    device.disable_and_clear_program_cache()
+
+
 @pytest.mark.parametrize(
     "mesh_device",
     [pytest.param(2, id="1x2_grid"), pytest.param((2, 1), id="2x1_grid")],

--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -21,6 +21,7 @@
 #include <bitset>
 #include <filesystem>
 #include <optional>
+#include <string>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -73,6 +74,12 @@ struct CBDescriptor {
     CoreRangeSet core_ranges;
     FormatDescriptors format_descriptors;
     FormatDescriptors remote_format_descriptors;
+
+    // Metal 2.0 (optional): a name that a KernelDescriptor DFB binding can reference.
+    // When set, a kernel's DFBBinding{accessor_name, cb_name} exposes dfb::<accessor_name>
+    // bound to this CB (its first format descriptor's buffer_index becomes the DFB logical id).
+    // Empty for legacy CBs; has no effect on the legacy path.
+    std::string name;
 
     // TODO: Investigate avoiding storing pointers here
     Buffer* buffer = nullptr;
@@ -163,6 +170,55 @@ struct KernelDescriptor {
     // enabling O(1) patching on cache hits without calling create_descriptor() again.
     BufferBindings buffer_bindings;
     CommonBufferBindings common_buffer_bindings;
+
+    ///////////////////////////////////////////////////////////////////
+    // Metal 2.0 named bindings (optional).
+    //
+    // These mirror the ProgramSpec KernelSpec bindings. When ANY of them is non-empty
+    // (see has_metal2_bindings()), the kernel is built as a Metal 2.0 kernel and receives
+    // the JIT-generated binding headers (kernel_bindings_generated.h / kernel_args_generated.h),
+    // enabling kernel-side dfb::<name>, Semaphore(sem::<name>), TensorAccessor(tensor::<name>),
+    // and get_arg(args::<name>) — exactly like ProgramSpec kernels.
+    //
+    // When ALL are empty, the kernel is built exactly as a legacy CreateKernel kernel:
+    // no generated headers, no behavior change. (named_compile_time_args alone does NOT
+    // trigger the Metal 2.0 path — those already flow through the legacy macro mechanism.)
+    ///////////////////////////////////////////////////////////////////
+
+    // DFB (circular buffer) named binding: exposes dfb::<accessor_name> bound to the CB
+    // whose CBDescriptor::name == cb_name. The CB's (first) buffer_index is the DFB logical id.
+    struct DFBBinding {
+        std::string accessor_name;  // kernel-side symbol in the dfb:: namespace
+        std::string cb_name;        // refers to a named CBDescriptor in the same ProgramDescriptor
+    };
+    using DFBBindings = std::vector<DFBBinding>;
+    DFBBindings dfb_bindings;
+
+    // Tensor named binding (pass-through): exposes tensor::<accessor_name>.
+    // Unlike the ProgramSpec path there is no TensorParameter auto-resolution here, so the
+    // descriptor author supplies the resolved offsets directly. cta_offset is the first word
+    // index of this binding's TensorAccessorArgs payload within compile_time_args; addr_crta_offset
+    // is the byte offset of the base-address slot within common_runtime_args.
+    struct TensorBinding {
+        std::string accessor_name;
+        uint32_t cta_offset = 0;
+        uint32_t addr_crta_offset = 0;
+        uint32_t num_runtime_field_crta_words = 0;
+    };
+    using TensorBindings = std::vector<TensorBinding>;
+    TensorBindings tensor_bindings;
+
+    // Named per-core runtime-arg schema: exposes args::<name> as RtaArg. The order of names defines
+    // each arg's word offset within the named section, and must match the order values are supplied
+    // in runtime_args.
+    using ArgNames = std::vector<std::string>;
+    ArgNames runtime_arg_names;
+
+    // True when this kernel declares any Metal 2.0 named binding (see above). Drives whether the
+    // descriptor->Program build takes the Metal 2.0 kernel path (generated headers) or the legacy path.
+    bool has_metal2_bindings() const {
+        return !dfb_bindings.empty() || !tensor_bindings.empty() || !runtime_arg_names.empty();
+    }
 
     // Builder for dynamically-constructed runtime arg lists.  Buffer* entries
     // auto-register as buffer bindings; uint32_t entries embed their value.

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -44,6 +44,7 @@
 #include "impl/buffers/circular_buffer.hpp"
 #include "circular_buffer_constants.h"
 #include "core_coord.hpp"
+#include <tt-metalium/hal.hpp>
 #include "impl/context/metal_context.hpp"
 #include "impl/context/context_types.hpp"
 #include "hal_types.hpp"
@@ -384,8 +385,20 @@ Program::Program(const ProgramDescriptor& descriptor) : internal_(std::make_shar
     LIGHT_METAL_TRACE_FUNCTION_ENTRY();
     LIGHT_METAL_TRACE_FUNCTION_CALL(CaptureProgramConstructor, *this);
 
+    // Metal 2.0: map named CBs to their (first) buffer_index so a KernelDescriptor DFB binding
+    // (which references a CB by name) can resolve to the DFB logical id the kernel-side accessor uses.
+    std::unordered_map<std::string, uint16_t> cb_name_to_index;
     for (const auto& cb_descriptor : descriptor.cbs) {
         internal_->add_circular_buffer_(std::make_shared<CircularBufferImpl>(cb_descriptor));
+        if (!cb_descriptor.name.empty() && !cb_descriptor.format_descriptors.empty()) {
+            auto [it, inserted] = cb_name_to_index.emplace(
+                cb_descriptor.name, static_cast<uint16_t>(cb_descriptor.format_descriptors.front().buffer_index));
+            TT_FATAL(
+                inserted,
+                "Duplicate named CBDescriptor '{}' in ProgramDescriptor; a DFB binding could otherwise resolve to "
+                "the wrong circular buffer. CB names must be unique.",
+                cb_descriptor.name);
+        }
     }
 
     for (const auto& semaphore_descriptor : descriptor.semaphores) {
@@ -457,10 +470,101 @@ Program::Program(const ProgramDescriptor& descriptor) : internal_(std::make_shar
             },
             kernel_descriptor.config);
 
-        auto kernel_handle =
-            is_file
-                ? CreateKernel(*this, kernel_descriptor.kernel_source, kernel_descriptor.core_ranges, config)
-                : CreateKernelFromString(*this, kernel_descriptor.kernel_source, kernel_descriptor.core_ranges, config);
+        KernelHandle kernel_handle;
+        if (kernel_descriptor.has_metal2_bindings()) {
+            // Metal 2.0 path: construct the Kernel directly with named-binding metadata (mirrors the
+            // ProgramSpec build in program_spec.cpp) so it is flagged is_metal2_kernel and receives the
+            // JIT-generated binding headers. Resolve each binding category into the maps/handles the
+            // Kernel ctor (and, via it, JitBuildSettings/genfiles) consume.
+            //
+            // Gen1-only: this always constructs the Gen1 DataMovementKernel/ComputeKernel. The Gen2
+            // (Quasar) build selects QuasarDataMovementKernel/QuasarComputeKernel with processor sets
+            // (see program_spec.cpp), so building Gen1 kernels there would take the wrong path. Fail
+            // loudly until the descriptor path grows Gen2 support, rather than silently mis-dispatching.
+            TT_FATAL(
+                tt::tt_metal::hal::get_arch() != tt::ARCH::QUASAR,
+                "ProgramDescriptor Metal 2.0 named bindings are Gen1-only; not yet supported on Quasar (Gen2).");
+
+            DataflowBufferLocalAccessorHandleMap dfb_handles;
+            dfb_handles.reserve(kernel_descriptor.dfb_bindings.size());
+            for (const auto& b : kernel_descriptor.dfb_bindings) {
+                auto it = cb_name_to_index.find(b.cb_name);
+                TT_FATAL(
+                    it != cb_name_to_index.end(),
+                    "KernelDescriptor DFB binding '{}' references CB '{}' which is not a named CBDescriptor in this "
+                    "ProgramDescriptor",
+                    b.accessor_name,
+                    b.cb_name);
+                dfb_handles.emplace(b.accessor_name, it->second);
+            }
+
+            std::vector<TensorBindingHandle> tensor_handles;
+            tensor_handles.reserve(kernel_descriptor.tensor_bindings.size());
+            uint32_t binding_section_words = 0;
+            for (const auto& b : kernel_descriptor.tensor_bindings) {
+                TensorBindingHandle h;
+                h.accessor_name = b.accessor_name;
+                h.cta_offset = b.cta_offset;
+                h.addr_crta_offset = b.addr_crta_offset;
+                h.num_runtime_field_crta_words = b.num_runtime_field_crta_words;
+                binding_section_words += 1 + b.num_runtime_field_crta_words;
+                tensor_handles.push_back(std::move(h));
+            }
+
+            std::vector<std::string> rta_names(
+                kernel_descriptor.runtime_arg_names.begin(), kernel_descriptor.runtime_arg_names.end());
+
+            // Semaphore bindings and named common-runtime-args are not wired on the descriptor path yet
+            // (no op needs them); pass empty. A future op that needs them adds the fields + validation.
+            const SemaphoreLocalAccessorHandleMap sem_handles;
+            const std::vector<std::string> crta_names;
+
+            // CRTA buffer layout: [ tensor-binding section | (no scratchpad) | varargs ]. No named CRTAs.
+            KernelCrtaLayout crta_layout;
+            crta_layout.num_named_words = 0;
+            crta_layout.binding_section_words = binding_section_words;
+            crta_layout.scratchpad_section_words = 0;
+            crta_layout.vararg_section_offset = binding_section_words;
+
+            KernelSource kernel_src(
+                kernel_descriptor.kernel_source, is_file ? KernelSource::FILE_PATH : KernelSource::SOURCE_CODE);
+            constexpr bool is_metal2_kernel = true;
+            std::shared_ptr<Kernel> kernel = std::visit(
+                ttsl::overloaded{
+                    [&](const DataMovementConfig& dm_config) -> std::shared_ptr<Kernel> {
+                        return std::make_shared<DataMovementKernel>(
+                            kernel_src,
+                            kernel_descriptor.core_ranges,
+                            dm_config,
+                            is_metal2_kernel,
+                            dfb_handles,
+                            sem_handles,
+                            rta_names,
+                            crta_names,
+                            tensor_handles,
+                            crta_layout);
+                    },
+                    [&](const ComputeConfig& compute_config) -> std::shared_ptr<Kernel> {
+                        return std::make_shared<ComputeKernel>(
+                            kernel_src,
+                            kernel_descriptor.core_ranges,
+                            compute_config,
+                            is_metal2_kernel,
+                            dfb_handles,
+                            sem_handles,
+                            rta_names,
+                            crta_names,
+                            tensor_handles,
+                            crta_layout);
+                    }},
+                config);
+            kernel_handle = internal_->add_kernel(kernel, HalProgrammableCoreType::TENSIX);
+        } else {
+            kernel_handle =
+                is_file ? CreateKernel(*this, kernel_descriptor.kernel_source, kernel_descriptor.core_ranges, config)
+                        : CreateKernelFromString(
+                              *this, kernel_descriptor.kernel_source, kernel_descriptor.core_ranges, config);
+        }
 
         for (const auto& [core_coord, core_runtime_args] : kernel_descriptor.runtime_args) {
             SetRuntimeArgs(*this, kernel_handle, core_coord, core_runtime_args);

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -452,7 +452,22 @@ public:
         // full re-derivation, correct by construction.  This is the target mechanism; resolve_bindings
         // and get_dynamic are the legacy paths being migrated out (and, eventually, deleted with
         // Metal 2.0 native bindings).
-        static consteval bool has_override_runtime_arguments() {
+        //
+        // The hook lives on the program factory (its natural home — alongside create_descriptor):
+        // factory_has_override_runtime_arguments() below. For DirectDescriptorFactory the factory has
+        // no override, so we also accept it on the DeviceOperation itself, preserving direct ops that
+        // predate the factory-struct shape.
+        static consteval bool factory_has_override_runtime_arguments() {
+            return requires(
+                tt::tt_metal::Program& program,
+                const operation_attributes_t& attrs,
+                const tensor_args_t& tensor_args,
+                tensor_return_value_t& tensor_return_value,
+                const std::optional<ttnn::MeshCoordinate>& coord) {
+                DescriptorFactory::override_runtime_arguments(program, attrs, tensor_args, tensor_return_value, coord);
+            };
+        }
+        static consteval bool device_op_has_override_runtime_arguments() {
             return requires(
                 tt::tt_metal::Program& program,
                 const operation_attributes_t& attrs,
@@ -461,6 +476,9 @@ public:
                 const std::optional<ttnn::MeshCoordinate>& coord) {
                 DeviceOperation::override_runtime_arguments(program, attrs, tensor_args, tensor_return_value, coord);
             };
+        }
+        static consteval bool has_override_runtime_arguments() {
+            return factory_has_override_runtime_arguments() || device_op_has_override_runtime_arguments();
         }
 
         static consteval bool has_get_dynamic_runtime_args() {
@@ -641,13 +659,23 @@ public:
                     // override_runtime_arguments()): re-apply ALL per-dispatch state — every runtime arg
                     // AND every tensor-backed CB address — for the current tensors.  No resolve_bindings
                     // (address inference) and no get_dynamic; correct by construction for in-place,
-                    // mixed-aliasing, and work-set shifts.
-                    DeviceOperation::override_runtime_arguments(
-                        program,
-                        attrs,
-                        tensor_args,
-                        tensor_return_value,
-                        std::optional<ttnn::MeshCoordinate>(coordinate_range.start_coord()));
+                    // mixed-aliasing, and work-set shifts. Prefer the factory's hook; fall back to the
+                    // DeviceOperation for direct ops that predate the factory-struct shape.
+                    if constexpr (factory_has_override_runtime_arguments()) {
+                        DescriptorFactory::override_runtime_arguments(
+                            program,
+                            attrs,
+                            tensor_args,
+                            tensor_return_value,
+                            std::optional<ttnn::MeshCoordinate>(coordinate_range.start_coord()));
+                    } else {
+                        DeviceOperation::override_runtime_arguments(
+                            program,
+                            attrs,
+                            tensor_args,
+                            tensor_return_value,
+                            std::optional<ttnn::MeshCoordinate>(coordinate_range.start_coord()));
+                    }
 #ifdef TT_DESCRIPTOR_PATCHING_PARITY_CHECK
                     // Same regression net as the legacy fast path: assert the op's override reproduced a
                     // full rebuild exactly (rt-args AND CB addresses).

--- a/ttnn/cpp/ttnn/operations/rand/device/kernels/compute_rand.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/kernels/compute_rand.cpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 op-local compute kernel for rand. The RNG logic is unchanged from the legacy
+// uniform compute kernel (compute_uniform.cpp); only the resource bindings move to the Metal 2.0
+// namespaces (dfb::/args::). seed/from/to are per-enqueue named runtime args: they are excluded
+// from the program-cache key and re-applied on every dispatch via the factory's
+// create_program_run_args (SetProgramRunArgs on cache hit), so they are never frozen.
+
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/eltwise_unary/rand.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    const uint32_t seed = get_arg(args::seed);
+    union {
+        float f;
+        uint32_t u;
+    } f2u_from, f2u_to, f2u_scale;
+    f2u_from.u = get_arg(args::from_bits);
+    f2u_to.u = get_arg(args::to_bits);
+    f2u_scale.f = f2u_to.f - f2u_from.f;
+    const uint32_t start_id = get_arg(args::start_id);
+    const uint32_t num_tiles = get_arg(args::num_tiles);
+    const uint32_t end_id = start_id + num_tiles;
+
+    DataflowBuffer cb_intermed(dfb::cb_intermed);
+
+    init_sfpu(dfb::cb_intermed, dfb::cb_intermed);
+
+    rand_tile_init(seed);
+    for (uint32_t i = start_id; i < end_id; ++i) {
+        cb_intermed.reserve_back(1);
+
+        tile_regs_acquire();
+        rand_tile(0, f2u_from.u, f2u_scale.u);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, dfb::cb_intermed, 0);
+        tile_regs_release();
+
+        cb_intermed.push_back(1);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/rand/device/kernels/writer_rand.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/kernels/writer_rand.cpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 op-local writer for rand. rand's output is always FLOAT32 (rand.cpp forces FLOAT32 then
+// typecasts), so this only implements the direct FLOAT32 path: stream each generated tile out of the
+// intermed DataflowBuffer straight to the output tensor. The legacy uniform writer's bf16 conversion
+// staging CB (dst_cb / c_0) is dropped — it was unused on the FLOAT32 path — which also removes the
+// single-ended-FIFO shape the Metal 2.0 lowering rejects on a data-movement kernel.
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "api/tensor/tensor_accessor.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    const uint32_t start_id = get_arg(args::start_id);
+    const uint32_t num_tiles = get_arg(args::num_tiles);
+    constexpr uint32_t page_size = get_arg(args::page_size);
+
+    Noc noc;
+    DataflowBuffer cb_intermed(dfb::cb_intermed);
+    const auto out = TensorAccessor(tensor::output);
+
+    const uint32_t end_id = start_id + num_tiles;
+    for (uint32_t i = start_id; i < end_id; ++i) {
+        cb_intermed.wait_front(1);
+        noc.async_write(cb_intermed, out, page_size, {.offset_bytes = 0}, {.page_id = i});
+        noc.async_writes_flushed();
+        cb_intermed.pop_front(1);
+    }
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.cpp
@@ -5,13 +5,33 @@
 #include "rand_device_operation.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
 #include "ttnn/device_operation.hpp"
+#include <ctime>
+#include <limits>
 #include <memory>
+#include <random>
 
 namespace ttnn::operations::rand {
 
+namespace {
+// seed == 0 means "nondeterministic". Draw a concrete random base seed ONCE here, on the host, so the
+// device op is always deterministic given its attributes: override_runtime_arguments and the
+// descriptor-patching parity rebuild then derive identical per-core seeds from that base. A fresh base
+// is drawn per call, so seed == 0 still yields new data on every invocation.
+uint32_t resolve_seed(uint32_t seed) {
+    if (seed != 0) {
+        return seed;
+    }
+    // thread_local: seed==0 dispatches from different host threads must not race on the engine.
+    thread_local std::mt19937 rng(static_cast<std::mt19937::result_type>(std::time(nullptr)));
+    thread_local std::uniform_int_distribution<uint32_t> dist(1, std::numeric_limits<int32_t>::max());
+    return dist(rng);
+}
+}  // namespace
+
 void RandDeviceOperation::validate_inputs(
     const operation_attributes_t& operation_attributes, const tensor_args_t& /*tensor_args*/) {
-    TT_FATAL(operation_attributes.from < operation_attributes.to, "Rand: `from` argument must be < `to` argument");
+    TT_FATAL(
+        operation_attributes.from < operation_attributes.to, "Rand: `from` argument must be < `to` argument");
 }
 
 void RandDeviceOperation::validate_on_program_cache_miss(
@@ -57,15 +77,15 @@ ttnn::operations::rand::RandDeviceOperation::tensor_return_value_t uniform(
     using OperationType = ttnn::operations::rand::RandDeviceOperation;
     return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
-            shape,
-            dtype,
-            layout,
-            memory_config,
-            std::addressof(device),
-            from,
-            to,
-            seed,
-            std::move(mesh_dim_is_sharded)},
+            .shape = shape,
+            .dtype = dtype,
+            .layout = layout,
+            .memory_config = memory_config,
+            .device = std::addressof(device),
+            .from = from,
+            .to = to,
+            .seed = ttnn::operations::rand::resolve_seed(seed),
+            .mesh_dim_is_sharded = std::move(mesh_dim_is_sharded)},
         OperationType::tensor_args_t{});
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
@@ -5,7 +5,8 @@
 #pragma once
 
 #include <optional>
-
+#include <tuple>
+#include <variant>
 #include <vector>
 
 #include "ttnn/device_operation.hpp"
@@ -17,20 +18,22 @@ namespace ttnn::operations::rand {
 
 struct RandDeviceOperation {
     struct operation_attributes_t {
-        const ttnn::Shape shape;
+        ttnn::Shape shape;
         DataType dtype;
         Layout layout;
-        const MemoryConfig memory_config;
+        MemoryConfig memory_config;
         MeshDevice* device;
-        const float from;
-        const float to;
+        float from;
+        float to;
         uint32_t seed;
         ttsl::SmallVector<bool> mesh_dim_is_sharded;
 
-        // Program identity. seed/from/to are re-applied via get_dynamic_runtime_args (excluded
-        // here). `device` must be FIRST: rand has no input tensor, so the framework discovers the
-        // mesh device via get_first_object_of_type over attribute_values(), and its tuple path only
-        // inspects element 0.
+        // The cache key. from/to/seed/mesh_dim_is_sharded are deliberately excluded — they vary per
+        // dispatch and are re-applied on every cache hit by RandProgramFactory::override_runtime_arguments,
+        // so calls differing only in those values reuse the cached program.
+        // `device` must be listed FIRST: rand has no input tensor, so the framework discovers the mesh
+        // device by reflecting over attribute_values() (get_first_object_of_type), whose tuple path only
+        // inspects the first element.
         static constexpr auto attribute_names =
             std::forward_as_tuple("device", "shape", "dtype", "layout", "memory_config");
         auto attribute_values() const { return std::forward_as_tuple(device, shape, dtype, layout, memory_config); }
@@ -41,27 +44,32 @@ struct RandDeviceOperation {
     using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output,
-        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
+    // Descriptor program factory (Metal 2.0 named bindings). Owns both the cache-miss builder
+    // (create_descriptor) and the cache-hit re-application (override_runtime_arguments); the
+    // framework resolves both on the factory through program_factory_t.
+    struct RandProgramFactory {
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output,
+            const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
+
+        // Re-applies every per-dispatch arg on each cache hit (per-core seed/from/to and the output
+        // address), from the same builder create_descriptor uses. Replaces get_dynamic_runtime_args
+        // and resolve_bindings for this op.
+        static void override_runtime_arguments(
+            tt::tt_metal::Program& program,
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output,
+            const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
+    };
+    using program_factory_t = std::variant<RandProgramFactory>;
 
     static void validate_inputs(const operation_attributes_t& attributes, const tensor_args_t& tensor_args);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    // seed/from/to are excluded from the program hash (so calls differing only in
-    // those values cache-hit instead of recompiling).  They are therefore DYNAMIC: this returns the
-    // current per-core (seed) and per-call (from/to) values so the framework re-applies them to the
-    // cached program on every dispatch.  Must mirror the seed/from/to runtime args built in
-    // create_descriptor() — the test_rand_different_seed_values regression test enforces this.
-    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output,
-        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 
 }  // namespace ttnn::operations::rand

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
@@ -2,12 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #include <bit>
-#include <ctime>
-#include <limits>
-#include <random>
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/work_split.hpp>
+#include <tt-metalium/host_api.hpp>
 #include "ttnn/tensor/types.hpp"
 #include "rand_device_operation.hpp"
 #include <tt-metalium/tensor_accessor_args.hpp>
@@ -19,16 +17,13 @@ using namespace tt::tt_metal;
 
 namespace {
 
-std::mt19937 rng(std::time(nullptr));
-std::uniform_int_distribution distribution(1, std::numeric_limits<int32_t>::max());
-
-auto get_random_seed() -> uint32_t { return distribution(rng); }
-
-constexpr const char* WRITER_KERNEL_PATH = "ttnn/cpp/ttnn/operations/uniform/device/kernels/writer_uniform.cpp";
-constexpr const char* COMPUTE_KERNEL_PATH = "ttnn/cpp/ttnn/operations/uniform/device/kernels/compute_uniform.cpp";
+// Metal 2.0 op-local kernels: named resource bindings (dfb::/args::/tensor::) instead of positional
+// compile/runtime args. See writer_rand.cpp / compute_rand.cpp for the accessor names referenced below.
+constexpr const char* WRITER_KERNEL_PATH = "ttnn/cpp/ttnn/operations/rand/device/kernels/writer_rand.cpp";
+constexpr const char* COMPUTE_KERNEL_PATH = "ttnn/cpp/ttnn/operations/rand/device/kernels/compute_rand.cpp";
 
 // Work split + per-device seed offset, shared by create_descriptor (cache miss) and
-// get_dynamic_runtime_args (cache hit) so both derive the identical core list and seed offset.
+// override_runtime_arguments (cache hit) so both derive the identical core list and seed offset.
 struct RandWorkSplit {
     uint32_t num_cores = 0;
     CoreRangeSet all_cores;
@@ -77,15 +72,16 @@ RandWorkSplit compute_rand_work_split(
         device_seed_offset};
 }
 
-// Per-core seed; shared so the miss-build and the hit-patch produce identical values.
+// Per-core seed; shared so the miss-build and the hit-patch produce identical values. attrs.seed is
+// always concrete here (seed == 0 is resolved to a random base at the op entry, see resolve_seed).
 uint32_t rand_seed_for_core(
     const RandDeviceOperation::operation_attributes_t& attrs, int i, uint32_t device_seed_offset) {
-    return attrs.seed != 0 ? attrs.seed + i + device_seed_offset : get_random_seed();
+    return attrs.seed + i + device_seed_offset;
 }
 
 }  // namespace
 
-ProgramDescriptor RandDeviceOperation::create_descriptor(
+ProgramDescriptor RandDeviceOperation::RandProgramFactory::create_descriptor(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& /*tensor_args*/,
     tensor_return_value_t& output,
@@ -101,19 +97,23 @@ ProgramDescriptor RandDeviceOperation::create_descriptor(
          device_seed_offset] = compute_rand_work_split(operation_attributes, output, mesh_dispatch_coordinate);
     const auto num_cores_total = cores.size();
 
-    DataType output_dtype = output.dtype();
-    auto out_data_format = datatype_to_dataformat_converter(output_dtype);
-    const uint32_t dtype_tile_size = tile_size(out_data_format);
+    // rand.cpp always invokes ttnn::prim::uniform with DataType::FLOAT32 / Layout::TILE (any user dtype
+    // or layout is applied afterward by a separate typecast/to_layout op), so this device op's output is
+    // always FLOAT32 tiles. The Metal 2.0 writer streams intermed tiles straight to the output tensor
+    // (no dtype-conversion staging CB), so only the FLOAT32 path exists here.
+    TT_FATAL(
+        output.dtype() == DataType::FLOAT32,
+        "RandDeviceOperation: device output must be FLOAT32 (got {}); rand.cpp forces FLOAT32 then typecasts",
+        output.dtype());
     const uint32_t intermed_tile_size = tile_size(tt::DataFormat::Float32);
 
-    constexpr uint32_t in_out_num_tiles = 1;
     constexpr uint32_t intermed_num_tiles = 2;
-
     constexpr uint32_t intermed_cb_id = CBIndex::c_24;
-    constexpr uint32_t dst_cb_id = CBIndex::c_0;
 
     ProgramDescriptor desc;
 
+    // Named intermed CB: referenced kernel-side as dfb::cb_intermed by both the compute (producer) and
+    // writer (consumer) via their DFB bindings below.
     desc.cbs.push_back(CBDescriptor{
         .total_size = intermed_num_tiles * intermed_tile_size,
         .core_ranges = all_cores,
@@ -122,22 +122,12 @@ ProgramDescriptor RandDeviceOperation::create_descriptor(
             .data_format = tt::DataFormat::Float32,
             .page_size = intermed_tile_size,
         }}},
+        .name = "intermed",
     });
 
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = in_out_num_tiles * dtype_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = dst_cb_id,
-            .data_format = out_data_format,
-            .page_size = dtype_tile_size,
-        }}},
-    });
-
+    // Writer compile-time args: only the output tensor's static TensorAccessorArgs payload, starting at
+    // word 0 (cta_offset below). The CB id is no longer a positional CTA — it flows through the DFB binding.
     KernelDescriptor::CompileTimeArgs writer_ct_args;
-    writer_ct_args.reserve(8);
-    writer_ct_args.push_back(intermed_cb_id);
-    writer_ct_args.push_back(dst_cb_id);
     TensorAccessorArgs(*output.buffer()).append_to(writer_ct_args);
 
     KernelDescriptor writer_desc;
@@ -146,21 +136,26 @@ ProgramDescriptor RandDeviceOperation::create_descriptor(
     writer_desc.core_ranges = all_cores;
     writer_desc.compile_time_args = std::move(writer_ct_args);
     writer_desc.config = WriterConfigDescriptor{};
-    switch (output_dtype) {
-        case DataType::BFLOAT16: writer_desc.defines.emplace_back("OUTPUT_DTYPE_BFLOAT16", "1"); break;
-        case DataType::FLOAT32: writer_desc.defines.emplace_back("OUTPUT_DTYPE_FLOAT32", "1"); break;
-        default:
-            // The writer kernel only implements float32 and bfloat16 output paths.
-            // Fail fast here so we never instantiate a program that can hang at runtime.
-            TT_THROW("RandDeviceOperation: unsupported output dtype for writer kernel");
-    }
+    // Metal 2.0 named bindings for the writer:
+    //  - dfb::cb_intermed  -> the "intermed" CB above
+    //  - args::page_size   -> compile-time constant (bytes per tile), read as `constexpr get_arg(args::page_size)`
+    //  - args::start_id / args::num_tiles -> per-core RTAs (order matches the runtime_args pushed below)
+    //  - tensor::output    -> pass-through TensorBinding: static layout at cta_offset 0, base address in CRTA word 0
+    writer_desc.named_compile_time_args = {{"page_size", intermed_tile_size}};
+    writer_desc.dfb_bindings = {{.accessor_name = "cb_intermed", .cb_name = "intermed"}};
+    writer_desc.runtime_arg_names = {"start_id", "num_tiles"};
+    writer_desc.tensor_bindings = {
+        {.accessor_name = "output", .cta_offset = 0, .addr_crta_offset = 0, .num_runtime_field_crta_words = 0}};
+    // Output base address lives in the writer's single CRTA word (the tensor binding's address slot).
+    // DYNAMIC across dispatches: re-applied on every cache hit by override_runtime_arguments().
+    writer_desc.common_runtime_args = {static_cast<uint32_t>(output.buffer()->address())};
     writer_desc.runtime_args.reserve(num_cores_total);
 
     KernelDescriptor compute_desc;
     compute_desc.kernel_source = COMPUTE_KERNEL_PATH;
     compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     compute_desc.core_ranges = all_cores;
-    compute_desc.compile_time_args = {intermed_cb_id};
+    // No positional CTAs: the intermed CB flows through the DFB binding.
     compute_desc.config = ComputeConfigDescriptor{
         .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
         .fp32_dest_acc_en = true,  // if fp32_dest_acc_en set to false a precision error may occur which makes
@@ -168,6 +163,11 @@ ProgramDescriptor RandDeviceOperation::create_descriptor(
         .dst_full_sync_en = false,
         .math_approx_mode = true,
     };
+    // Metal 2.0 named bindings for the compute kernel:
+    //  - dfb::cb_intermed -> the "intermed" CB
+    //  - args::seed / from_bits / to_bits / start_id / num_tiles -> per-core RTAs (order matches runtime_args)
+    compute_desc.dfb_bindings = {{.accessor_name = "cb_intermed", .cb_name = "intermed"}};
+    compute_desc.runtime_arg_names = {"seed", "from_bits", "to_bits", "start_id", "num_tiles"};
     compute_desc.runtime_args.reserve(num_cores_total);
 
     const float eps = 1e-6f;
@@ -188,14 +188,14 @@ ProgramDescriptor RandDeviceOperation::create_descriptor(
 
         uint32_t seed = rand_seed_for_core(operation_attributes, i, device_seed_offset);
 
-        // seed/from/to are DYNAMIC (excluded from compute_program_hash): baked here for the
-        // cache-miss build, and re-applied on every cache hit via get_dynamic_runtime_args().
+        // Values are pushed positionally in runtime_arg_names order.
+        // compute: {seed, from_bits, to_bits, start_id, num_tiles}
+        //   seed/from/to are DYNAMIC (excluded from the cache key): baked here for the cache-miss build,
+        //   re-applied on every cache hit via override_runtime_arguments().
         compute_desc.runtime_args.emplace_back(
             core, KernelDescriptor::CoreRuntimeArgs{seed, from_bits, to_bits, tile_offset, units_per_core});
-
-        // Register the output address as a Buffer* binding so rand takes the fast cache-hit path
-        // (real program caching) with the address correctly re-patched each dispatch.
-        writer_desc.emplace_runtime_args(core, {output.buffer(), tile_offset, units_per_core});
+        // writer: {start_id, num_tiles}
+        writer_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{tile_offset, units_per_core});
 
         tile_offset += units_per_core;
     }
@@ -206,29 +206,60 @@ ProgramDescriptor RandDeviceOperation::create_descriptor(
     return desc;
 }
 
-std::vector<tt::tt_metal::DynamicRuntimeArg> RandDeviceOperation::get_dynamic_runtime_args(
+void RandDeviceOperation::RandProgramFactory::override_runtime_arguments(
+    tt::tt_metal::Program& program,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& /*tensor_args*/,
     tensor_return_value_t& output,
     const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
-    // compute is kernel 1; its runtime args are {seed, from_bits, to_bits, tile_offset, units_per_core}.
-    // seed/from/to are excluded from the hash and re-applied here; the rest are static.
-    constexpr uint32_t kComputeKernelIdx = 1;
-    auto ws = compute_rand_work_split(operation_attributes, output, mesh_dispatch_coordinate);
+    // Re-derive every per-dispatch arg on each cache hit from the same builder create_descriptor uses:
+    // compute's seed/from/to and the writer's output address. override replaces resolve_bindings, so
+    // the address is ours to re-apply too. Push order in create_descriptor: writer 0, compute 1.
+    constexpr uint32_t writer_kernel_idx = 0;
+    constexpr uint32_t compute_kernel_idx = 1;
 
+    const auto ws = compute_rand_work_split(operation_attributes, output, mesh_dispatch_coordinate);
     const float eps = 1e-6f;
     const uint32_t from_bits = std::bit_cast<uint32_t>(operation_attributes.from);
     const uint32_t to_bits = std::bit_cast<uint32_t>(operation_attributes.to - eps);
+    const uint32_t out_addr = output.buffer()->address();
 
-    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
-    dynamic_args.reserve(ws.cores.size() * 3);
+    // The writer's output base address is the tensor binding's CRTA slot (common across all cores):
+    // re-point it here so the cache-hit dispatch writes into THIS call's output buffer, not the
+    // first-miss buffer. Named-arg layout: CRTA word 0 == tensor::output address slot.
+    auto& writer_common = tt::tt_metal::GetCommonRuntimeArgs(program, writer_kernel_idx);
+    writer_common[0] = out_addr;
+
+    uint32_t tile_offset = 0;
     for (int i = 0; i < static_cast<int>(ws.cores.size()); ++i) {
+        const auto& core = ws.cores[i];
+        uint32_t units_per_core;
+        if (ws.core_group_1.contains(core)) {
+            units_per_core = ws.units_per_core_group_1;
+        } else if (ws.core_group_2.contains(core)) {
+            units_per_core = ws.units_per_core_group_2;
+        } else {
+            TT_THROW("Core not in specified core ranges");
+        }
         const uint32_t seed = rand_seed_for_core(operation_attributes, i, ws.device_seed_offset);
-        dynamic_args.push_back({kComputeKernelIdx, ws.cores[i], 0, seed});
-        dynamic_args.push_back({kComputeKernelIdx, ws.cores[i], 1, from_bits});
-        dynamic_args.push_back({kComputeKernelIdx, ws.cores[i], 2, to_bits});
+
+        // Named-arg RTA layout (values sit at the byte offsets the generated args:: header assigns,
+        // in runtime_arg_names order — named args occupy positions [0..N) so positional indexing holds):
+        //   compute: [seed, from_bits, to_bits, start_id, num_tiles]
+        auto& compute_args = tt::tt_metal::GetRuntimeArgs(program, compute_kernel_idx, core);
+        compute_args[0] = seed;
+        compute_args[1] = from_bits;
+        compute_args[2] = to_bits;
+        compute_args[3] = tile_offset;
+        compute_args[4] = units_per_core;
+
+        //   writer: [start_id, num_tiles]
+        auto& writer_args = tt::tt_metal::GetRuntimeArgs(program, writer_kernel_idx, core);
+        writer_args[0] = tile_offset;
+        writer_args[1] = units_per_core;
+
+        tile_offset += units_per_core;
     }
-    return dynamic_args;
 }
 
 }  // namespace ttnn::operations::rand

--- a/ttnn/cursor/DEVICE_OPERATION_MIGRATION_GUIDE.md
+++ b/ttnn/cursor/DEVICE_OPERATION_MIGRATION_GUIDE.md
@@ -601,6 +601,27 @@ ttsl::hash::hash_t UnaryDeviceOperation::compute_program_hash(
 }
 ```
 
+### Step 8b: Re-apply hash-excluded values on a cache hit — `override_runtime_arguments`, never `get_dynamic_runtime_args`
+
+A program-cache hit does not rebuild the program, so anything excluded from `compute_program_hash` — a dynamic scalar (RNG seed, `from`/`to`, `lr`/`step`) or a buffer address — must be re-applied to the cached program. Use **`override_runtime_arguments`**. **Never `get_dynamic_runtime_args`**: it is deprecated, and the adapter `static_assert`s if an op declares both.
+
+> **Scope.** This applies to `ProgramFactory` and `ProgramDescriptor` factories. The `WorkloadDescriptor` variant has no `override_runtime_arguments` path yet — the adapter re-applies its hash-excluded values via `get_dynamic_runtime_args` on a cache hit, so a WorkloadDescriptor factory must keep that hook until override support is added there.
+
+```cpp
+static void override_runtime_arguments(
+    tt::tt_metal::Program& program,
+    const operation_attributes_t& attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output,
+    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
+```
+
+Re-derive **all** per-dispatch state — every per-core runtime arg *and* every tensor-backed buffer address — for the current `attributes`/tensors, from the same builder the cache-miss path uses (share one work-split/args helper so miss and hit stay identical). `override_runtime_arguments` supersedes both legacy hit mechanisms — `get_dynamic_runtime_args` (scalars only) and `resolve_bindings` (addresses only); the framework runs neither when it is present, so re-apply buffer addresses here too or they freeze at the first miss. Write in place with `GetRuntimeArgs(program, kernel_index, core)` (kernel index = push order in the factory).
+
+It is correct by construction — nothing is inferred from `Buffer*` identity, so in-place aliasing (`out == in`) cannot mis-patch — and faster than `get_dynamic_runtime_args`, which built an intermediate arg vector and matched buffers by pointer.
+
+Most ops need none of this: if the only per-dispatch change is tensor addresses, register them as `Buffer*` bindings and the framework re-patches them automatically. Reach for `override_runtime_arguments` only for a hash-excluded scalar the framework cannot track — e.g. `rand`'s per-core seed.
+
 ---
 
 ## Examples
@@ -686,6 +707,7 @@ Use this checklist to ensure all steps are completed:
 3. **Not including values that affect the program structure in hash**: Every parameter that has an effect on program structure must be taken into account in the hash
 4. **Redundant tensors in tensor_args_t**: Do not add redundant arguments like `preallocated_output`, if legacy operation did not handle that explicitly in `create_output_tensors`
 5. **Mesh workload factories not working with `mesh_coords`**: If your operation supports `mesh_coords` filtering, you MUST create a separate mesh workload factory. The infrastructure's `MeshWorkloadFactoryAdapter` will create programs for ALL tensor coordinates, ignoring `mesh_coords`. Only factories that implement `MeshWorkloadFactoryConcept` (and NOT `ProgramFactoryConcept`) will use the direct path that allows coordinate filtering.
+6. **Using `get_dynamic_runtime_args`**: deprecated for `ProgramFactory`/`ProgramDescriptor` factories. Use `override_runtime_arguments` (Step 8b), which re-applies runtime args *and* buffer addresses in place and stays correct under in-place aliasing. Declaring both on one op is a compile error. (Exception: `WorkloadDescriptor` factories have no override path yet and must still use `get_dynamic_runtime_args` — see Step 8b scope note.)
 
 ---
 


### PR DESCRIPTION
### What
Make `ttnn.rand` a clean **Metal 2.0 reference op on the `ProgramDescriptor` path**, plus the framework support that enables it. Others can copy this op as the canonical pattern for descriptor-side Metal 2.0.

### Framework (descriptor kernels get Metal 2.0 named bindings)
- A `KernelDescriptor` may declare Metal 2.0 named bindings (`dfb::` / `tensor::` / `args::`, with `CBDescriptor::name`). When it does, `Program(ProgramDescriptor)` builds it as a Metal 2.0 kernel so the JIT emits the generated binding headers — mirroring the ProgramSpec build. When it declares none, the legacy `CreateKernel` path is **byte-for-byte unchanged**.
- **Gen1-only** for now: `TT_FATAL` on Quasar rather than silently building Gen1 kernels on Gen2.
- Guards: reject **duplicate named CBs** and **dangling DFB references**.
- Adapter resolves `override_runtime_arguments` on the **program factory**, falling back to the DeviceOperation for legacy direct ops.

### rand
- Own Metal 2.0 kernels (`compute_rand` / `writer_rand`) on the accessor API (`DataflowBuffer`, `TensorAccessor`, `get_arg`).
- `RandProgramFactory` owns both `create_descriptor` and `override_runtime_arguments`.
- **Cache key via `attribute_names`/`attribute_values`** (key fields only: shape/dtype/layout/memory_config/device). `from`/`to`/`seed`/`mesh_dim_is_sharded` are omitted from the key and re-applied on cache hit by `override_runtime_arguments`. **No custom `compute_program_hash`.** `device` is listed first so the no-input-op mesh-device discovery finds it.
- `seed == 0` is resolved to a concrete random base **once at the op entry**, so the op is deterministic given its attributes (lets the descriptor-patching parity check validate it) while still producing fresh data each call.

### Testing
- `test_rand.py`: **45 passed** (Wormhole), incl. cache-hit guards `test_rand_different_seed_values`, `test_rand_different_from_to_values`, `test_rand_cache_hit_repoints_output_address`.
- **New** C++ descriptor tests (`test_descriptor_patching.cpp`): valid DFB binding builds; dangling DFB reference throws; duplicate CB name throws.
- Built with `./build_metal.sh --build-tests`; rebased onto latest `main`.

### Notes
- Not a Metal 2.0 *spec* migration — `rand` stays a `ProgramDescriptor` op; the spec API can't re-apply per-dispatch scalars on a cache hit.
- Migration guide updated: `override_runtime_arguments` (never `get_dynamic_runtime_args`), scoped to ProgramFactory/ProgramDescriptor factories (WorkloadDescriptor still uses `get_dynamic`).
- Pre-existing lint: `prefer-expect-error` flags `test_rand.py`'s invalid-args test — not introduced here.
- Supersedes the interim override-only PR #50488.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/rand-metal2-descriptors)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/rand-metal2-descriptors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/rand-metal2-descriptors)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/rand-metal2-descriptors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/rand-metal2-descriptors)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/rand-metal2-descriptors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/rand-metal2-descriptors)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/rand-metal2-descriptors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/rand-metal2-descriptors)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/rand-metal2-descriptors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/rand-metal2-descriptors)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/rand-metal2-descriptors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/rand-metal2-descriptors)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/rand-metal2-descriptors)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/rand-metal2-descriptors)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/rand-metal2-descriptors)
