### PR TITLE
[Bug fix] Validate dynamic trace allocations across live traces

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_trace.cpp
+++ b/tests/tt_metal/distributed/test_mesh_trace.cpp
@@ -4,6 +4,7 @@
 
 #include <boost/move/utility_core.hpp>
 #include <fmt/base.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <cstdint>
 #include <tt-metalium/bfloat16.hpp>
@@ -43,6 +44,7 @@
 #include <tt_stl/span.hpp>
 #include <tt_stl/strong_type.hpp>
 #include <tt-metalium/sub_device_types.hpp>
+#include "tt_metal/distributed/mesh_trace.hpp"
 #include "tests/tt_metal/distributed/utils.hpp"
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 #include "tests/tt_metal/tt_metal/dispatch/sub_device_test_utils.hpp"
@@ -842,6 +844,74 @@ TEST_F(MeshTraceDynamicAllocationTestSuite, TraceWithSmallAllocationsDuringCaptu
     Finish(mesh_device_->mesh_command_queue());
 
     mesh_device_->release_mesh_trace(trace_id);
+}
+
+TEST_F(MeshTraceDynamicAllocationTestSuite, MultipleLiveTracesValidateAgainstMaxHighWaterMark) {
+    MeshCoordinateRange all_devices(mesh_device_->shape());
+
+    MeshWorkload workload;
+    auto programs = tt::tt_metal::distributed::test::utils::create_random_programs(
+        1, mesh_device_->compute_with_storage_grid_size(), 321);
+    workload.add_program(all_devices, std::move(*programs[0]));
+
+    const auto worker_grid_size = mesh_device_->compute_with_storage_grid_size();
+    SubDevice sub_device(std::array{CoreRangeSet(CoreRange({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1}))});
+    auto sub_device_manager = mesh_device_->create_sub_device_manager({sub_device}, 0);
+
+    // Warm up the workload under both managers before trace capture.
+    EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), workload, false);
+    Finish(mesh_device_->mesh_command_queue());
+    mesh_device_->load_sub_device_manager(sub_device_manager);
+    EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), workload, false);
+    Finish(mesh_device_->mesh_command_queue());
+    mesh_device_->clear_loaded_sub_device_manager();
+
+    // First measure where an otherwise identical trace is placed and how much per-bank address space it occupies.
+    // Releasing this calibration trace restores the allocator to the state used by the traces under test.
+    auto calibration_trace_id = BeginTraceCapture(mesh_device_.get(), 0);
+    EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), workload, false);
+    mesh_device_->end_mesh_trace(0, calibration_trace_id);
+    auto calibration_trace = mesh_device_->get_mesh_trace(calibration_trace_id);
+    auto* calibration_backing_buffer = calibration_trace->mesh_buffer->get_backing_buffer();
+
+    const DeviceAddr trace_buffer_address = calibration_trace->mesh_buffer->address();
+    const DeviceAddr dram_alignment = calibration_backing_buffer->alignment();
+    mesh_device_->release_mesh_trace(calibration_trace_id);
+    calibration_trace.reset();
+
+    // Find the lowest allocatable DRAM address. The HWM buffer is sized to occupy the address range from this
+    // address up to, but not including, trace_buffer_address.
+    const uint32_t num_dram_banks = mesh_device_->allocator()->get_num_banks(BufferType::DRAM);
+    ReplicatedBufferConfig probe_config{.size = dram_alignment * num_dram_banks};
+    DeviceLocalBufferConfig lowest_address_config{
+        .page_size = dram_alignment, .buffer_type = BufferType::DRAM, .bottom_up = true};
+    auto probe = MeshBuffer::create(probe_config, lowest_address_config, mesh_device_.get());
+    const DeviceAddr dram_base_address = probe->address();
+    probe.reset();
+
+    const DeviceAddr hwm_size_per_bank = trace_buffer_address - dram_base_address;
+    ReplicatedBufferConfig hwm_buffer_config{.size = hwm_size_per_bank * num_dram_banks};
+
+    // Trace A records a high water mark at the start of its own top-down trace buffer. This is valid for A.
+    auto trace_a_id = BeginTraceCapture(mesh_device_.get(), 0);
+    EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), workload, false);
+    auto hwm_buffer = MeshBuffer::create(hwm_buffer_config, lowest_address_config, mesh_device_.get());
+    hwm_buffer.reset();
+    mesh_device_->end_mesh_trace(0, trace_a_id);
+
+    // Trace B belongs to another manager and has no DRAM activity of its own. Its address is immediately lower than
+    // A's, inside A's replay footprint.
+    mesh_device_->load_sub_device_manager(sub_device_manager);
+    auto trace_b_id = BeginTraceCapture(mesh_device_.get(), 0);
+    EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), workload, false);
+    EXPECT_THAT(
+        [&]() { mesh_device_->end_mesh_trace(0, trace_b_id); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("maximum live trace high water mark")));
+
+    mesh_device_->release_mesh_trace(trace_b_id);
+    mesh_device_->clear_loaded_sub_device_manager();
+    mesh_device_->release_mesh_trace(trace_a_id);
+    mesh_device_->remove_sub_device_manager(sub_device_manager);
 }
 
 TEST_F(MeshTraceDynamicAllocationTestSuite, TraceOverlapDetection) {

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -1382,16 +1382,6 @@ void MeshDeviceImpl::end_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id) 
     }
 
     trace_buffer->dram_high_water_mark = std::max(dram_allocation_high_water_mark, dram_deletion_high_water_mark);
-    const auto min_live_trace_buffer_address = sub_device_manager_tracker_->get_min_trace_buffer_address();
-    TT_FATAL(
-        trace_region_size != 0 || !min_live_trace_buffer_address.has_value() ||
-            min_live_trace_buffer_address.value() >= trace_buffer->dram_high_water_mark,
-        "DRAM activity captured by trace {} has a high water mark of {}, which overlaps with an existing live trace "
-        "buffer at address {}. Release the existing trace before capturing this trace or set a non-zero "
-        "trace_region_size.",
-        *trace_id,
-        trace_buffer->dram_high_water_mark,
-        min_live_trace_buffer_address.value_or(0));
 
     const DeviceAddr max_live_trace_high_water_mark = sub_device_manager_tracker_->get_max_trace_high_water_mark();
     MeshTrace::populate_mesh_buffer(

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -1376,8 +1376,25 @@ void MeshDeviceImpl::end_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id) 
         dram_deletion_high_water_mark = this->allocator_impl()->get_dram_deletion_high_water_mark();
     }
 
+    trace_buffer->dram_high_water_mark = std::max(dram_allocation_high_water_mark, dram_deletion_high_water_mark);
+    const auto min_live_trace_buffer_address = sub_device_manager_tracker_->get_min_trace_buffer_address();
+    TT_FATAL(
+        trace_region_size != 0 || !min_live_trace_buffer_address.has_value() ||
+            min_live_trace_buffer_address.value() >= trace_buffer->dram_high_water_mark,
+        "DRAM activity captured by trace {} has a high water mark of {}, which overlaps with an existing live trace "
+        "buffer at address {}. Release the existing trace before capturing this trace or set a non-zero "
+        "trace_region_size.",
+        *trace_id,
+        trace_buffer->dram_high_water_mark,
+        min_live_trace_buffer_address.value_or(0));
+
+    const DeviceAddr max_live_trace_high_water_mark = sub_device_manager_tracker_->get_max_trace_high_water_mark();
     MeshTrace::populate_mesh_buffer(
-        *(mesh_command_queues_[cq_id]), trace_buffer, dram_allocation_high_water_mark, dram_deletion_high_water_mark);
+        *(mesh_command_queues_[cq_id]),
+        trace_buffer,
+        dram_allocation_high_water_mark,
+        dram_deletion_high_water_mark,
+        max_live_trace_high_water_mark);
     this->mark_allocations_unsafe();
 }
 

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -1381,8 +1381,6 @@ void MeshDeviceImpl::end_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id) 
         dram_deletion_high_water_mark = this->allocator_impl()->get_dram_deletion_high_water_mark();
     }
 
-    trace_buffer->dram_high_water_mark = std::max(dram_allocation_high_water_mark, dram_deletion_high_water_mark);
-
     const DeviceAddr max_live_trace_high_water_mark = sub_device_manager_tracker_->get_max_trace_high_water_mark();
     MeshTrace::populate_mesh_buffer(
         *(mesh_command_queues_[cq_id]),

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -40,6 +40,7 @@
 #include "profiler_types.hpp"
 #include <experimental/fabric/routing_table_generator.hpp>
 #include "shape_base.hpp"
+#include <tt_stl/cleanup.hpp>
 #include <tt_stl/span.hpp>
 #include <tt_stl/strong_type.hpp>
 #include "impl/threading/thread_pool.hpp"
@@ -1351,6 +1352,10 @@ void MeshDeviceImpl::begin_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id
 
 void MeshDeviceImpl::end_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id) {
     TracyTTMetalEndMeshTrace(this->get_device_ids(), *trace_id);
+
+    // Ensure allocations are marked unsafe on any exit, including thrown exceptions
+    auto mark_unsafe_on_exit = ttsl::make_cleanup([this]() { this->mark_allocations_unsafe(); });
+
     TT_FATAL(
         this->mesh_command_queues_[cq_id]->trace_id() == trace_id,
         "CQ {} is not being used for tracing tid {}",
@@ -1395,7 +1400,6 @@ void MeshDeviceImpl::end_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id) 
         dram_allocation_high_water_mark,
         dram_deletion_high_water_mark,
         max_live_trace_high_water_mark);
-    this->mark_allocations_unsafe();
 }
 
 void MeshDeviceImpl::replay_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id, bool blocking) {

--- a/tt_metal/distributed/mesh_trace.cpp
+++ b/tt_metal/distributed/mesh_trace.cpp
@@ -50,7 +50,8 @@ void MeshTrace::populate_mesh_buffer(
     MeshCommandQueue& mesh_cq,
     std::shared_ptr<MeshTraceBuffer>& trace_buffer,
     DeviceAddr dram_allocation_high_water_mark,
-    DeviceAddr dram_deletion_high_water_mark) {
+    DeviceAddr dram_deletion_high_water_mark,
+    DeviceAddr max_live_trace_high_water_mark) {
     uint64_t unpadded_size = trace_buffer->desc->total_trace_size;
     size_t page_size = trace_dispatch::compute_interleaved_trace_buf_page_size(
         unpadded_size, mesh_cq.device()->allocator()->get_num_banks(BufferType::DRAM));
@@ -93,18 +94,28 @@ void MeshTrace::populate_mesh_buffer(
     trace_buffer->mesh_buffer =
         MeshBuffer::create(global_trace_buf_config, device_local_trace_buf_config, mesh_cq.device());
 
-    // In dynamic allocation mode, validate that trace buffer doesn't overlap with allocations during trace
-    DeviceAddr dram_high_water_mark = std::max(dram_allocation_high_water_mark, dram_deletion_high_water_mark);
-    if (trace_region_size == 0 && dram_high_water_mark > 0) {
+    // In dynamic allocation mode, validate that the new trace buffer is outside the replay footprint of every live
+    // trace.
+    const DeviceAddr effective_high_water_mark =
+        std::max({dram_allocation_high_water_mark, dram_deletion_high_water_mark, max_live_trace_high_water_mark});
+    if (trace_region_size == 0 && effective_high_water_mark > 0) {
         DeviceAddr trace_buffer_address = trace_buffer->mesh_buffer->address();
-        if (trace_buffer_address < dram_high_water_mark) {
+        if (trace_buffer_address < effective_high_water_mark) {
             // Determine which high water mark caused the overlap for a more specific error message
             bool allocation_overlap =
                 dram_allocation_high_water_mark > 0 && trace_buffer_address < dram_allocation_high_water_mark;
             bool deletion_overlap =
                 dram_deletion_high_water_mark > 0 && trace_buffer_address < dram_deletion_high_water_mark;
 
-            if (allocation_overlap && deletion_overlap) {
+            if (!allocation_overlap && !deletion_overlap) {
+                TT_FATAL(
+                    false,
+                    "Trace buffer at address {} overlaps with DRAM activity captured by another live trace "
+                    "(maximum live trace high water mark: {}). "
+                    "Release the existing trace before capturing this trace or set a non-zero trace_region_size.",
+                    trace_buffer_address,
+                    max_live_trace_high_water_mark);
+            } else if (allocation_overlap && deletion_overlap) {
                 TT_FATAL(
                     false,
                     "Trace buffer at address {} overlaps with DRAM activity during trace capture. "

--- a/tt_metal/distributed/mesh_trace.cpp
+++ b/tt_metal/distributed/mesh_trace.cpp
@@ -96,8 +96,8 @@ void MeshTrace::populate_mesh_buffer(
 
     // In dynamic allocation mode, validate that the new trace buffer is outside the replay footprint of every live
     // trace.
-    const DeviceAddr effective_high_water_mark =
-        std::max({dram_allocation_high_water_mark, dram_deletion_high_water_mark, max_live_trace_high_water_mark});
+    trace_buffer->dram_high_water_mark = std::max(dram_allocation_high_water_mark, dram_deletion_high_water_mark);
+    const DeviceAddr effective_high_water_mark = std::max({trace_buffer->dram_high_water_mark, max_live_trace_high_water_mark});
     if (trace_region_size == 0 && effective_high_water_mark > 0) {
         DeviceAddr trace_buffer_address = trace_buffer->mesh_buffer->address();
         if (trace_buffer_address < effective_high_water_mark) {
@@ -107,15 +107,7 @@ void MeshTrace::populate_mesh_buffer(
             bool deletion_overlap =
                 dram_deletion_high_water_mark > 0 && trace_buffer_address < dram_deletion_high_water_mark;
 
-            if (!allocation_overlap && !deletion_overlap) {
-                TT_FATAL(
-                    false,
-                    "Trace buffer at address {} overlaps with DRAM activity captured by another live trace "
-                    "(maximum live trace high water mark: {}). "
-                    "Release the existing trace before capturing this trace or set a non-zero trace_region_size.",
-                    trace_buffer_address,
-                    max_live_trace_high_water_mark);
-            } else if (allocation_overlap && deletion_overlap) {
+            if (allocation_overlap && deletion_overlap) {
                 TT_FATAL(
                     false,
                     "Trace buffer at address {} overlaps with DRAM activity during trace capture. "
@@ -132,7 +124,7 @@ void MeshTrace::populate_mesh_buffer(
                     "Avoid deallocating DRAM buffers during trace capture or set a non-zero trace_region_size.",
                     trace_buffer_address,
                     dram_deletion_high_water_mark);
-            } else {
+            } else if (allocation_overlap) {
                 TT_FATAL(
                     false,
                     "Trace buffer at address {} overlaps with buffers allocated during trace capture "
@@ -140,6 +132,14 @@ void MeshTrace::populate_mesh_buffer(
                     "Reduce allocations during trace capture or set a non-zero trace_region_size.",
                     trace_buffer_address,
                     dram_allocation_high_water_mark);
+            } else {
+                TT_FATAL(
+                    false,
+                    "Trace buffer at address {} overlaps with DRAM activity captured by another live trace "
+                    "(maximum live trace high water mark: {}). "
+                    "Release the existing trace before capturing this trace or set a non-zero trace_region_size.",
+                    trace_buffer_address,
+                    max_live_trace_high_water_mark);
             }
         }
     }

--- a/tt_metal/distributed/mesh_trace.hpp
+++ b/tt_metal/distributed/mesh_trace.hpp
@@ -45,6 +45,8 @@ struct MeshTraceBuffer {
     // The MeshBuffer this trace will be serialized to, before being run on a
     // MeshDevice
     std::shared_ptr<MeshBuffer> mesh_buffer = nullptr;
+    // Highest DRAM address that may be accessed when this trace is replayed.
+    DeviceAddr dram_high_water_mark = 0;
 
     ~MeshTraceBuffer();
 };
@@ -65,7 +67,8 @@ public:
         MeshCommandQueue& mesh_cq,
         std::shared_ptr<MeshTraceBuffer>& trace_buffer,
         DeviceAddr dram_allocation_high_water_mark = 0,
-        DeviceAddr dram_deletion_high_water_mark = 0);
+        DeviceAddr dram_deletion_high_water_mark = 0,
+        DeviceAddr max_live_trace_high_water_mark = 0);
 };
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/impl/sub_device/sub_device_manager.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.cpp
@@ -10,6 +10,7 @@
 #include <sub_device_types.hpp>
 #include <tt_align.hpp>
 #include <tt_stl/span.hpp>
+#include <algorithm>
 #include <limits>
 #include <utility>
 #include <vector>
@@ -46,8 +47,7 @@ static_assert(
 
 std::atomic<uint64_t> SubDeviceManager::next_sub_device_manager_id_ = 0;
 
-SubDeviceManager::SubDeviceManager(
-    ttsl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size, IDevice* device) :
+SubDeviceManager::SubDeviceManager(ttsl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size, IDevice* device) :
     id_(next_sub_device_manager_id_++), sub_devices_(sub_devices.begin(), sub_devices.end()), device_(device) {
     TT_ASSERT(device != nullptr, "Device must not be null");
     context_id_ = extract_context_id(device);
@@ -148,6 +148,29 @@ std::shared_ptr<MeshTraceBuffer> SubDeviceManager::get_trace(const MeshTraceId& 
         return trace->second;
     }
     return nullptr;
+}
+
+DeviceAddr SubDeviceManager::get_max_trace_high_water_mark() const {
+    DeviceAddr max_high_water_mark = 0;
+    for (const auto& trace_entry : trace_buffer_pool_) {
+        const auto& trace_buffer = trace_entry.second;
+        max_high_water_mark = std::max(max_high_water_mark, trace_buffer->dram_high_water_mark);
+    }
+    return max_high_water_mark;
+}
+
+std::optional<DeviceAddr> SubDeviceManager::get_min_trace_buffer_address() const {
+    std::optional<DeviceAddr> min_trace_buffer_address;
+    for (const auto& trace_entry : trace_buffer_pool_) {
+        const auto& trace_buffer = trace_entry.second;
+        if (trace_buffer->mesh_buffer == nullptr) {
+            continue;
+        }
+        const DeviceAddr trace_buffer_address = trace_buffer->mesh_buffer->address();
+        min_trace_buffer_address =
+            std::min(min_trace_buffer_address.value_or(trace_buffer_address), trace_buffer_address);
+    }
+    return min_trace_buffer_address;
 }
 
 bool SubDeviceManager::has_allocations() const {

--- a/tt_metal/impl/sub_device/sub_device_manager.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.cpp
@@ -159,20 +159,6 @@ DeviceAddr SubDeviceManager::get_max_trace_high_water_mark() const {
     return max_high_water_mark;
 }
 
-std::optional<DeviceAddr> SubDeviceManager::get_min_trace_buffer_address() const {
-    std::optional<DeviceAddr> min_trace_buffer_address;
-    for (const auto& trace_entry : trace_buffer_pool_) {
-        const auto& trace_buffer = trace_entry.second;
-        if (trace_buffer->mesh_buffer == nullptr) {
-            continue;
-        }
-        const DeviceAddr trace_buffer_address = trace_buffer->mesh_buffer->address();
-        min_trace_buffer_address =
-            std::min(min_trace_buffer_address.value_or(trace_buffer_address), trace_buffer_address);
-    }
-    return min_trace_buffer_address;
-}
-
 bool SubDeviceManager::has_allocations() const {
     for (const auto& allocator : sub_device_allocators_) {
         if (allocator && allocator->get_num_allocated_buffers() > 0) {

--- a/tt_metal/impl/sub_device/sub_device_manager.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.cpp
@@ -47,7 +47,8 @@ static_assert(
 
 std::atomic<uint64_t> SubDeviceManager::next_sub_device_manager_id_ = 0;
 
-SubDeviceManager::SubDeviceManager(ttsl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size, IDevice* device) :
+SubDeviceManager::SubDeviceManager(
+    ttsl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size, IDevice* device) :
     id_(next_sub_device_manager_id_++), sub_devices_(sub_devices.begin(), sub_devices.end()), device_(device) {
     TT_ASSERT(device != nullptr, "Device must not be null");
     context_id_ = extract_context_id(device);

--- a/tt_metal/impl/sub_device/sub_device_manager.hpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.hpp
@@ -63,6 +63,8 @@ public:
     std::shared_ptr<distributed::MeshTraceBuffer>& create_trace(const distributed::MeshTraceId& trace_id);
     void release_trace(const distributed::MeshTraceId& trace_id);
     std::shared_ptr<distributed::MeshTraceBuffer> get_trace(const distributed::MeshTraceId& trace_id);
+    DeviceAddr get_max_trace_high_water_mark() const;
+    std::optional<DeviceAddr> get_min_trace_buffer_address() const;
 
     uint8_t num_sub_devices() const;
     bool has_allocations() const;

--- a/tt_metal/impl/sub_device/sub_device_manager.hpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.hpp
@@ -64,7 +64,6 @@ public:
     void release_trace(const distributed::MeshTraceId& trace_id);
     std::shared_ptr<distributed::MeshTraceBuffer> get_trace(const distributed::MeshTraceId& trace_id);
     DeviceAddr get_max_trace_high_water_mark() const;
-    std::optional<DeviceAddr> get_min_trace_buffer_address() const;
 
     uint8_t num_sub_devices() const;
     bool has_allocations() const;

--- a/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
@@ -141,6 +141,26 @@ SubDeviceManager* SubDeviceManagerTracker::get_default_sub_device_manager() cons
     return default_sub_device_manager_;
 }
 
+DeviceAddr SubDeviceManagerTracker::get_max_trace_high_water_mark() const {
+    DeviceAddr max_high_water_mark = 0;
+    for (const auto& entry : sub_device_managers_) {
+        max_high_water_mark = std::max(max_high_water_mark, entry.second->get_max_trace_high_water_mark());
+    }
+    return max_high_water_mark;
+}
+
+std::optional<DeviceAddr> SubDeviceManagerTracker::get_min_trace_buffer_address() const {
+    std::optional<DeviceAddr> min_trace_buffer_address;
+    for (const auto& entry : sub_device_managers_) {
+        const auto manager_min_address = entry.second->get_min_trace_buffer_address();
+        if (manager_min_address.has_value()) {
+            const DeviceAddr& address = manager_min_address.value();
+            min_trace_buffer_address = std::min(min_trace_buffer_address.value_or(address), address);
+        }
+    }
+    return min_trace_buffer_address;
+}
+
 SubDeviceManagerId SubDeviceManagerTracker::get_active_sub_device_manager_id() const {
     return active_sub_device_manager_->id();
 }

--- a/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
@@ -149,18 +149,6 @@ DeviceAddr SubDeviceManagerTracker::get_max_trace_high_water_mark() const {
     return max_high_water_mark;
 }
 
-std::optional<DeviceAddr> SubDeviceManagerTracker::get_min_trace_buffer_address() const {
-    std::optional<DeviceAddr> min_trace_buffer_address;
-    for (const auto& entry : sub_device_managers_) {
-        const auto manager_min_address = entry.second->get_min_trace_buffer_address();
-        if (manager_min_address.has_value()) {
-            const DeviceAddr& address = manager_min_address.value();
-            min_trace_buffer_address = std::min(min_trace_buffer_address.value_or(address), address);
-        }
-    }
-    return min_trace_buffer_address;
-}
-
 SubDeviceManagerId SubDeviceManagerTracker::get_active_sub_device_manager_id() const {
     return active_sub_device_manager_->id();
 }

--- a/tt_metal/impl/sub_device/sub_device_manager_tracker.hpp
+++ b/tt_metal/impl/sub_device/sub_device_manager_tracker.hpp
@@ -47,6 +47,9 @@ public:
 
     SubDeviceManager* get_default_sub_device_manager() const;
 
+    DeviceAddr get_max_trace_high_water_mark() const;
+    std::optional<DeviceAddr> get_min_trace_buffer_address() const;
+
     // Used for caching program state by manager and buffers to check that the required manager is still active
     SubDeviceManagerId get_active_sub_device_manager_id() const;
 

--- a/tt_metal/impl/sub_device/sub_device_manager_tracker.hpp
+++ b/tt_metal/impl/sub_device/sub_device_manager_tracker.hpp
@@ -48,7 +48,6 @@ public:
     SubDeviceManager* get_default_sub_device_manager() const;
 
     DeviceAddr get_max_trace_high_water_mark() const;
-    std::optional<DeviceAddr> get_min_trace_buffer_address() const;
 
     // Used for caching program state by manager and buffers to check that the required manager is still active
     SubDeviceManagerId get_active_sub_device_manager_id() const;


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Closes #48869 

* Store each captured trace’s DRAM high-water mark until release
* Aggregate trace-buffer addresses and HWMs across all sub-device managers
* Reject dynamic trace buffers that overlap any live trace’s replay footprint
* Detect DRAM activity that overlaps an existing live trace buffer
* Add cross-manager regression coverage for multiple unreleased traces

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=anashTT/48869-multi-trace-HWM-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:anashTT/48869-multi-trace-HWM-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=anashTT/48869-multi-trace-HWM-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:anashTT/48869-multi-trace-HWM-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=anashTT/48869-multi-trace-HWM-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:anashTT/48869-multi-trace-HWM-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=anashTT/48869-multi-trace-HWM-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:anashTT/48869-multi-trace-HWM-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=anashTT/48869-multi-trace-HWM-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:anashTT/48869-multi-trace-HWM-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=anashTT/48869-multi-trace-HWM-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:anashTT/48869-multi-trace-HWM-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=anashTT/48869-multi-trace-HWM-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:anashTT/48869-multi-trace-HWM-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=anashTT/48869-multi-trace-HWM-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:anashTT/48869-multi-trace-HWM-validation)