### PR TITLE
Allow overriding the fabric handshake NoC in open_connections

### DIFF
--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -431,7 +431,8 @@ void FabricUnicastCommon(
     NocPacketType noc_packet_type,
     const std::vector<std::tuple<RoutingDirection, uint32_t /*num_hops*/>>& pair_ordered_dirs,
     FabricApiType api_type = FabricApiType::Linear,
-    bool with_state = false);
+    bool with_state = false,
+    bool use_non_default_handshake_noc = false);
 
 void UDMFabricUnicastCommon(
     BaseFabricFixture* fixture,

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_linear_api_unicast_write_sender.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_linear_api_unicast_write_sender.cpp
@@ -67,7 +67,13 @@ void kernel_main() {
 
     auto route_id = PacketHeaderPool::allocate_header_n(num_send_dir);
     tt::tt_fabric::RoutingPlaneConnectionManager connections;
+#ifdef TEST_NON_DEFAULT_HANDSHAKE_NOC
+    // Exercise the explicit template path with the NoC opposite the helper's default.
+    constexpr uint8_t worker_handshake_noc = 1 - tt::tt_fabric::get_fabric_worker_noc();
+    open_connections<worker_handshake_noc>(connections, num_send_dir, rt_arg_idx);
+#else
     open_connections(connections, num_send_dir, rt_arg_idx);
+#endif
 
     zero_l1_buf(test_results, test_results_size_bytes);
     test_results[TT_FABRIC_STATUS_INDEX] = TT_FABRIC_STATUS_STARTED;
@@ -372,7 +378,11 @@ void kernel_main() {
     }
 
     uint64_t cycles_elapsed = get_timestamp() - start_timestamp;
+#ifdef TEST_NON_DEFAULT_HANDSHAKE_NOC
+    close_connections<worker_handshake_noc>(connections);
+#else
     close_connections(connections);
+#endif
 
     noc_async_write_barrier();
 

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -1897,6 +1897,15 @@ TEST_F(Galaxy1x32Fabric1DFixture, TestUnicastRaw_AllHops) {
 }
 
 TEST_F(Fabric1DFixture, TestUnicastConnAPI) { RunTestUnicastConnAPI(this, 1); }
+TEST_F(Fabric1DFixture, TestUnicastNonDefaultHandshakeNoc) {
+    FabricUnicastCommon(
+        this,
+        NocPacketType::NOC_UNICAST_WRITE,
+        {std::make_tuple(RoutingDirection::E, 1)},
+        FabricApiType::Linear,
+        false,
+        true);
+}
 TEST_F(Fabric1DFixture, TestUnicastConnAPIDRAM) { RunTestUnicastConnAPI(this, 1, RoutingDirection::E, true); }
 TEST_F(Fabric1DFixture, TestUnicastTGGateways) { RunTestUnicastTGGateways(this); }
 TEST_F(Fabric1DFixture, TestMCastConnAPI) { RunTestMCastConnAPI(this); }
@@ -2112,7 +2121,8 @@ void FabricUnicastCommon(
     NocPacketType noc_packet_type,
     const std::vector<std::tuple<RoutingDirection, uint32_t>>& pair_ordered_dirs,
     FabricApiType api_type,
-    bool with_state) {
+    bool with_state,
+    bool use_non_default_handshake_noc) {
     tt::tt_metal::CoreCoord sender_logical_core = {0, 0};
     tt::tt_metal::CoreCoord receiver_logical_core = {1, 0};
     uint32_t num_packets = 10;
@@ -2192,6 +2202,11 @@ void FabricUnicastCommon(
         worker_mem_map.packet_payload_size_bytes = 4;
     }
 
+    std::map<std::string, std::string> sender_defines;
+    if (use_non_default_handshake_noc) {
+        sender_defines["TEST_NON_DEFAULT_HANDSHAKE_NOC"] = "1";
+    }
+
     auto sender_kernel = tt_metal::CreateKernel(
         sender_program,
         (noc_packet_type == NocPacketType::NOC_FUSED_UNICAST_ATOMIC_INC ||
@@ -2203,7 +2218,8 @@ void FabricUnicastCommon(
         tt_metal::DataMovementConfig{
             .processor = tt_metal::DataMovementProcessor::RISCV_0,
             .noc = tt_metal::NOC::RISCV_0_default,
-            .compile_args = compile_time_args});
+            .compile_args = compile_time_args,
+            .defines = sender_defines});
 
     std::vector<uint32_t> sender_runtime_args = {
         worker_mem_map.source_l1_buffer_address,

--- a/tt_metal/fabric/hw/inc/api_common.h
+++ b/tt_metal/fabric/hw/inc/api_common.h
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 #include <type_traits>
+#include "tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_utils.hpp"
 #include "tt_metal/fabric/hw/inc/tt_fabric_mux_interface.hpp"
 
 namespace tt::tt_fabric {

--- a/tt_metal/fabric/hw/inc/api_common.h
+++ b/tt_metal/fabric/hw/inc/api_common.h
@@ -443,14 +443,14 @@ static FORCE_INLINE void populate_unicast_fused_scatter_write_atomic_inc_fields(
  * | rt_arg_idx                            | Runtime-args cursor (advanced as parsed)| size_t&                                        | True     |
  */
 // clang-format on
-template <uint8_t noc = get_fabric_worker_noc()>
 FORCE_INLINE void open_connections(
     tt::tt_fabric::RoutingPlaneConnectionManager& connection_manager,
     uint32_t num_connections_to_build,
-    size_t& rt_arg_idx) {
+    size_t& rt_arg_idx,
+    uint8_t noc = tt::tt_fabric::get_fabric_worker_noc()) {
     connection_manager = tt::tt_fabric::RoutingPlaneConnectionManager::template build_from_args<
-        tt::tt_fabric::RoutingPlaneConnectionManager::BUILD_AND_OPEN_CONNECTION, noc>(
-        rt_arg_idx, num_connections_to_build);
+        tt::tt_fabric::RoutingPlaneConnectionManager::BUILD_AND_OPEN_CONNECTION>(
+        rt_arg_idx, num_connections_to_build, noc);
 }
 
 // clang-format off

--- a/tt_metal/fabric/hw/inc/api_common.h
+++ b/tt_metal/fabric/hw/inc/api_common.h
@@ -442,8 +442,6 @@ static FORCE_INLINE void populate_unicast_fused_scatter_write_atomic_inc_fields(
  * | rt_arg_idx                            | Runtime-args cursor (advanced as parsed)| size_t&                                        | True     |
  */
 // clang-format on
-// noc must be a non-type template param: the handshake open path takes
-// WORKER_HANDSHAKE_NOC as a compile-time template argument on the adapter.
 template <uint8_t noc = get_fabric_worker_noc()>
 FORCE_INLINE void open_connections(
     tt::tt_fabric::RoutingPlaneConnectionManager& connection_manager,

--- a/tt_metal/fabric/hw/inc/api_common.h
+++ b/tt_metal/fabric/hw/inc/api_common.h
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 #include <type_traits>
+
 #include "tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_utils.hpp"
 #include "tt_metal/fabric/hw/inc/tt_fabric_mux_interface.hpp"
 
@@ -433,39 +434,44 @@ static FORCE_INLINE void populate_unicast_fused_scatter_write_atomic_inc_fields(
 /**
  * Opens fabric routing-plane connections for all headers associated with the given route.
  * Reads connection parameters from runtime arguments and initializes headers with routing metadata.
+ * Use the same WORKER_HANDSHAKE_NOC for the connection's packet traffic and close handshake.
  *
  * Return value: None
  *
  * | Argument                              | Description                             | Type                                           | Required |
  * |---------------------------------------|-----------------------------------------|------------------------------------------------|----------|
+ * | WORKER_HANDSHAKE_NOC                  | Template parameter: NoC for open        | uint8_t                                        | False    |
  * | connection_manager                    | Connection manager to build and open    | RoutingPlaneConnectionManager&                 | True     |
  * | num_connections_to_build              | Number of connections to build/open     | uint32_t                                       | True     |
  * | rt_arg_idx                            | Runtime-args cursor (advanced as parsed)| size_t&                                        | True     |
  */
 // clang-format on
+template <uint8_t WORKER_HANDSHAKE_NOC = tt::tt_fabric::get_fabric_worker_noc()>
 FORCE_INLINE void open_connections(
     tt::tt_fabric::RoutingPlaneConnectionManager& connection_manager,
     uint32_t num_connections_to_build,
-    size_t& rt_arg_idx,
-    uint8_t noc = tt::tt_fabric::get_fabric_worker_noc()) {
+    size_t& rt_arg_idx) {
     connection_manager = tt::tt_fabric::RoutingPlaneConnectionManager::template build_from_args<
-        tt::tt_fabric::RoutingPlaneConnectionManager::BUILD_AND_OPEN_CONNECTION>(
-        rt_arg_idx, num_connections_to_build, noc);
+        tt::tt_fabric::RoutingPlaneConnectionManager::BUILD_AND_OPEN_CONNECTION,
+        WORKER_HANDSHAKE_NOC>(rt_arg_idx, num_connections_to_build);
 }
 
 // clang-format off
 /**
  * Closes all connections owned by the provided connection manager.
+ * WORKER_HANDSHAKE_NOC must match the NoC used to open the connections.
  *
  * Return value: None
  *
  * | Argument                              | Description                             | Type                                           | Required |
  * |---------------------------------------|-----------------------------------------|------------------------------------------------|----------|
+ * | WORKER_HANDSHAKE_NOC                  | Template parameter: NoC used for open   | uint8_t                                        | False    |
  * | connection_manager                    | Connection manager to be closed         | RoutingPlaneConnectionManager&                 | True     |
  */
 // clang-format on
+template <uint8_t WORKER_HANDSHAKE_NOC = tt::tt_fabric::get_fabric_worker_noc()>
 FORCE_INLINE void close_connections(tt::tt_fabric::RoutingPlaneConnectionManager& connection_manager) {
-    connection_manager.close();
+    connection_manager.close<WORKER_HANDSHAKE_NOC>();
 }
 
 }  // namespace tt::tt_fabric::common::experimental

--- a/tt_metal/fabric/hw/inc/api_common.h
+++ b/tt_metal/fabric/hw/inc/api_common.h
@@ -442,12 +442,16 @@ static FORCE_INLINE void populate_unicast_fused_scatter_write_atomic_inc_fields(
  * | rt_arg_idx                            | Runtime-args cursor (advanced as parsed)| size_t&                                        | True     |
  */
 // clang-format on
+// noc must be a non-type template param: the handshake open path takes
+// WORKER_HANDSHAKE_NOC as a compile-time template argument on the adapter.
+template <uint8_t noc = get_fabric_worker_noc()>
 FORCE_INLINE void open_connections(
     tt::tt_fabric::RoutingPlaneConnectionManager& connection_manager,
     uint32_t num_connections_to_build,
     size_t& rt_arg_idx) {
     connection_manager = tt::tt_fabric::RoutingPlaneConnectionManager::template build_from_args<
-        tt::tt_fabric::RoutingPlaneConnectionManager::BUILD_AND_OPEN_CONNECTION>(rt_arg_idx, num_connections_to_build);
+        tt::tt_fabric::RoutingPlaneConnectionManager::BUILD_AND_OPEN_CONNECTION, noc>(
+        rt_arg_idx, num_connections_to_build);
 }
 
 // clang-format off

--- a/tt_metal/fabric/hw/inc/api_common.h
+++ b/tt_metal/fabric/hw/inc/api_common.h
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 #include <type_traits>
+#include "tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_utils.hpp"
 #include "tt_metal/fabric/hw/inc/tt_fabric_mux_interface.hpp"
 
 namespace tt::tt_fabric::common::experimental {

--- a/tt_metal/fabric/hw/inc/api_common.h
+++ b/tt_metal/fabric/hw/inc/api_common.h
@@ -422,8 +422,6 @@ static FORCE_INLINE void populate_unicast_fused_scatter_write_atomic_inc_fields(
  * | rt_arg_idx                            | Runtime-args cursor (advanced as parsed)| size_t&                                        | True     |
  */
 // clang-format on
-// noc must be a non-type template param: the handshake open path takes
-// WORKER_HANDSHAKE_NOC as a compile-time template argument on the adapter.
 template <uint8_t noc = get_fabric_worker_noc()>
 FORCE_INLINE void open_connections(
     tt::tt_fabric::RoutingPlaneConnectionManager& connection_manager,

--- a/tt_metal/fabric/hw/inc/api_common.h
+++ b/tt_metal/fabric/hw/inc/api_common.h
@@ -422,12 +422,16 @@ static FORCE_INLINE void populate_unicast_fused_scatter_write_atomic_inc_fields(
  * | rt_arg_idx                            | Runtime-args cursor (advanced as parsed)| size_t&                                        | True     |
  */
 // clang-format on
+// noc must be a non-type template param: the handshake open path takes
+// WORKER_HANDSHAKE_NOC as a compile-time template argument on the adapter.
+template <uint8_t noc = get_fabric_worker_noc()>
 FORCE_INLINE void open_connections(
     tt::tt_fabric::RoutingPlaneConnectionManager& connection_manager,
     uint32_t num_connections_to_build,
     size_t& rt_arg_idx) {
     connection_manager = tt::tt_fabric::RoutingPlaneConnectionManager::template build_from_args<
-        tt::tt_fabric::RoutingPlaneConnectionManager::BUILD_AND_OPEN_CONNECTION>(rt_arg_idx, num_connections_to_build);
+        tt::tt_fabric::RoutingPlaneConnectionManager::BUILD_AND_OPEN_CONNECTION, noc>(
+        rt_arg_idx, num_connections_to_build);
 }
 
 // clang-format off

--- a/tt_metal/fabric/hw/inc/api_common.h
+++ b/tt_metal/fabric/hw/inc/api_common.h
@@ -423,14 +423,14 @@ static FORCE_INLINE void populate_unicast_fused_scatter_write_atomic_inc_fields(
  * | rt_arg_idx                            | Runtime-args cursor (advanced as parsed)| size_t&                                        | True     |
  */
 // clang-format on
-template <uint8_t noc = get_fabric_worker_noc()>
 FORCE_INLINE void open_connections(
     tt::tt_fabric::RoutingPlaneConnectionManager& connection_manager,
     uint32_t num_connections_to_build,
-    size_t& rt_arg_idx) {
+    size_t& rt_arg_idx,
+    uint8_t noc = tt::tt_fabric::get_fabric_worker_noc()) {
     connection_manager = tt::tt_fabric::RoutingPlaneConnectionManager::template build_from_args<
-        tt::tt_fabric::RoutingPlaneConnectionManager::BUILD_AND_OPEN_CONNECTION, noc>(
-        rt_arg_idx, num_connections_to_build);
+        tt::tt_fabric::RoutingPlaneConnectionManager::BUILD_AND_OPEN_CONNECTION>(
+        rt_arg_idx, num_connections_to_build, noc);
 }
 
 // clang-format off

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -668,8 +668,11 @@ struct WorkerToFabricEdmSenderBase {
 
     // NoC used for the entire worker->fabric path (open handshake, packet sends, close). Overridable
     // per-connection so callers can steer this path off a NoC lane reserved by e.g. a persistent
-    // linked mcast (#1819). Defaults to the RISC's fabric worker NoC for byte-identical legacy behavior.
-    uint8_t send_noc = get_fabric_worker_noc();
+    // linked mcast (#1819). Set by build_from_args()/init() (both default to get_fabric_worker_noc()
+    // for byte-identical legacy behavior); left uninitialized here like the other members so the
+    // class keeps a trivial default constructor (static-storage instances of this type -- e.g.
+    // CQRelayClient's embedded WorkerToFabricMuxSender -- are declared before init() ever runs).
+    uint8_t send_noc;
 
 private:
     template <bool STATEFUL_NOC>

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -88,7 +88,8 @@ struct WorkerToFabricEdmSenderBase {
     WorkerToFabricEdmSenderBase() = default;
 
     template <ProgrammableCoreType my_core_type>
-    static WorkerToFabricEdmSenderBase build_from_args(std::size_t& arg_idx) {
+    static WorkerToFabricEdmSenderBase build_from_args(
+        std::size_t& arg_idx, uint8_t noc = get_fabric_worker_noc()) {
         constexpr bool is_persistent_fabric = true;
         uint8_t direction;
         uint8_t edm_worker_x;
@@ -171,7 +172,8 @@ struct WorkerToFabricEdmSenderBase {
             worker_free_slots_stream_id,
             my_fc_stream_channel_id,
             write_reg_cmd_buf,
-            write_at_cmd_buf);
+            write_at_cmd_buf,
+            noc);
     }
 
     template <ProgrammableCoreType my_core_type = ProgrammableCoreType::ACTIVE_ETH>
@@ -196,7 +198,8 @@ struct WorkerToFabricEdmSenderBase {
             worker_credits_stream_id,  // To locally track downstream EDM's free slots. Only used by EDM. Sending EDM
                                        // decrements locally. Downstream EDM increments over noc when a slot is freed.
         uint8_t data_noc_cmd_buf = write_reg_cmd_buf,
-        uint8_t sync_noc_cmd_buf = write_at_cmd_buf) {
+        uint8_t sync_noc_cmd_buf = write_at_cmd_buf,
+        uint8_t noc = get_fabric_worker_noc()) {
         this->edm_buffer_addr = edm_buffer_base_addr;
         this->worker_credits_stream_id = worker_credits_stream_id.get();
 
@@ -235,6 +238,7 @@ struct WorkerToFabricEdmSenderBase {
         this->edm_noc_y = edm_worker_y;
         this->data_noc_cmd_buf = data_noc_cmd_buf;
         this->sync_noc_cmd_buf = sync_noc_cmd_buf;
+        this->send_noc = noc;
 
         if constexpr (I_USE_STREAM_REG_FOR_CREDIT_RECEIVE) {
             // The EDM is guaranteed to know the number of free slots of the downstream EDM
@@ -265,7 +269,8 @@ struct WorkerToFabricEdmSenderBase {
         uint32_t sender_channel_credits_stream_id,
         StreamId worker_credits_stream_id,
         uint8_t data_noc_cmd_buf = write_reg_cmd_buf,
-        uint8_t sync_noc_cmd_buf = write_at_cmd_buf) {
+        uint8_t sync_noc_cmd_buf = write_at_cmd_buf,
+        uint8_t noc = get_fabric_worker_noc()) {
         this->init<my_core_type>(
             connected_to_persistent_fabric,
             edm_worker_x,
@@ -282,7 +287,8 @@ struct WorkerToFabricEdmSenderBase {
             sender_channel_credits_stream_id,
             worker_credits_stream_id,
             data_noc_cmd_buf,
-            sync_noc_cmd_buf);
+            sync_noc_cmd_buf,
+            noc);
     }
 
     FORCE_INLINE uint32_t get_num_free_write_slots() const {
@@ -440,10 +446,9 @@ struct WorkerToFabricEdmSenderBase {
     // Must be called alongside (before) open_finish().
     template <
         bool SEND_CREDIT_ADDR = false,
-        bool posted = false,
-        uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
+        bool posted = false>
     void open_start() {
-        const auto dest_noc_addr_coord_only = get_noc_addr(this->edm_noc_x, this->edm_noc_y, 0, WORKER_HANDSHAKE_NOC);
+        const auto dest_noc_addr_coord_only = get_noc_addr(this->edm_noc_x, this->edm_noc_y, 0, this->send_noc);
 
         tt::tt_fabric::EDMChannelWorkerLocationInfo* worker_location_info_ptr =
             reinterpret_cast<tt::tt_fabric::EDMChannelWorkerLocationInfo*>(edm_worker_location_info_addr);
@@ -458,7 +463,7 @@ struct WorkerToFabricEdmSenderBase {
                 remote_producer_cursor_addr,
                 local_producer_cursor_addr,
                 sizeof(tt::tt_fabric::SenderChannelProducerCursor),
-                WORKER_HANDSHAKE_NOC);
+                this->send_noc);
 
             const uint64_t edm_read_free_slots_or_read_counter_addr =
                 dest_noc_addr_coord_only | reinterpret_cast<size_t>(
@@ -469,7 +474,7 @@ struct WorkerToFabricEdmSenderBase {
                 edm_read_free_slots_or_read_counter_addr,
                 reinterpret_cast<size_t>(this->edm_buffer_local_free_slots_read_ptr),
                 sizeof(uint32_t),  // also want to read the local write counter
-                WORKER_HANDSHAKE_NOC);
+                this->send_noc);
         }
         const uint64_t dest_edm_location_info_addr =
             dest_noc_addr_coord_only |
@@ -482,13 +487,13 @@ struct WorkerToFabricEdmSenderBase {
                 dest_edm_location_info_addr,
                 reinterpret_cast<size_t>(edm_buffer_local_free_slots_update_ptr),
                 0xf,
-                WORKER_HANDSHAKE_NOC);
+                this->send_noc);
         } else {
             noc_inline_dw_write<InlineWriteDst::L1, posted>(
                 dest_edm_location_info_addr,
                 reinterpret_cast<size_t>(edm_buffer_local_free_slots_update_ptr),
                 0xf,
-                WORKER_HANDSHAKE_NOC);
+                this->send_noc);
         }
         const uint64_t edm_teardown_semaphore_address_address =
             dest_noc_addr_coord_only |
@@ -498,23 +503,23 @@ struct WorkerToFabricEdmSenderBase {
             edm_teardown_semaphore_address_address,
             reinterpret_cast<size_t>(worker_teardown_addr),
             0xf,
-            WORKER_HANDSHAKE_NOC);
+            this->send_noc);
         // Write out core noc-xy coord to EDM
         const uint64_t connection_worker_xy_address =
             dest_noc_addr_coord_only | reinterpret_cast<uint64_t>(&(worker_location_info_ptr->worker_xy));
         noc_inline_dw_write<InlineWriteDst::L1, posted>(
-            connection_worker_xy_address, WorkerXY(my_x[0], my_y[0]).to_uint32(), 0xf, WORKER_HANDSHAKE_NOC);
+            connection_worker_xy_address, WorkerXY(my_x[0], my_y[0]).to_uint32(), 0xf, this->send_noc);
     }
 
     // Advanced usage API:
     // Completes the connection opening process. Induces a read barrier
     // !!! IMPORTANT !!!
     // Must be called alongside (after) open_start().
-    template <bool posted = false, uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
+    template <bool posted = false>
     void open_finish() {
         const uint64_t edm_connection_handshake_noc_addr =
-            get_noc_addr(this->edm_noc_x, this->edm_noc_y, edm_connection_handshake_l1_addr, WORKER_HANDSHAKE_NOC);
-        noc_async_read_barrier(WORKER_HANDSHAKE_NOC);
+            get_noc_addr(this->edm_noc_x, this->edm_noc_y, edm_connection_handshake_l1_addr, this->send_noc);
+        noc_async_read_barrier(this->send_noc);
         // Order here is important
         // We need to write our read counter value to the register before we signal the EDM
         // As EDM will potentially increment the register as well
@@ -541,7 +546,7 @@ struct WorkerToFabricEdmSenderBase {
             edm_connection_handshake_noc_addr,
             tt::tt_fabric::connection_interface::open_connection_value,
             0xf,
-            WORKER_HANDSHAKE_NOC);
+            this->send_noc);
         *this->worker_teardown_addr = 0;
         if constexpr (!USER_DEFINED_NUM_BUFFER_SLOTS) {
             this->edm_buffer_addr =
@@ -553,11 +558,10 @@ struct WorkerToFabricEdmSenderBase {
     //                   or some legacy code which skips connection info copy on Tensix L1 static address
     template <
         bool SEND_CREDIT_ADDR = false,
-        bool posted = false,
-        uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
+        bool posted = false>
     void open() {
-        open_start<SEND_CREDIT_ADDR, posted, WORKER_HANDSHAKE_NOC>();
-        open_finish<posted, WORKER_HANDSHAKE_NOC>();
+        open_start<SEND_CREDIT_ADDR, posted>();
+        open_finish<posted>();
     }
 
     // Advanced usage API:
@@ -661,6 +665,11 @@ struct WorkerToFabricEdmSenderBase {
     // the cmd buffer is used for edm-edm path
     uint8_t data_noc_cmd_buf;
     uint8_t sync_noc_cmd_buf;
+
+    // NoC used for the entire worker->fabric path (open handshake, packet sends, close). Overridable
+    // per-connection so callers can steer this path off a NoC lane reserved by e.g. a persistent
+    // linked mcast (#1819). Defaults to the RISC's fabric worker NoC for byte-identical legacy behavior.
+    uint8_t send_noc = get_fabric_worker_noc();
 
 private:
     template <bool STATEFUL_NOC>
@@ -787,8 +796,8 @@ private:
     FORCE_INLINE void send_payload_impl(uint32_t cb_id, uint32_t num_pages, uint32_t page_size) {
         uint64_t buffer_address = this->compute_dest_buffer_slot_noc_addr();
         ASSERT(num_pages * page_size <= this->buffer_size_bytes);
-        send_chunk<blocking_mode>(cb_id, num_pages, page_size, buffer_address);
-        post_send_payload_increment_pointers();
+        send_chunk<blocking_mode>(cb_id, num_pages, page_size, buffer_address, this->send_noc);
+        post_send_payload_increment_pointers(this->send_noc);
     }
 };
 

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -794,7 +794,7 @@ private:
 
     template <EDM_IO_BLOCKING_MODE blocking_mode>
     FORCE_INLINE void send_payload_impl(uint32_t cb_id, uint32_t num_pages, uint32_t page_size) {
-        uint64_t buffer_address = this->compute_dest_buffer_slot_noc_addr();
+        uint64_t buffer_address = this->compute_dest_buffer_slot_noc_addr(this->send_noc);
         ASSERT(num_pages * page_size <= this->buffer_size_bytes);
         send_chunk<blocking_mode>(cb_id, num_pages, page_size, buffer_address, this->send_noc);
         post_send_payload_increment_pointers(this->send_noc);

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -88,8 +88,7 @@ struct WorkerToFabricEdmSenderBase {
     WorkerToFabricEdmSenderBase() = default;
 
     template <ProgrammableCoreType my_core_type>
-    static WorkerToFabricEdmSenderBase build_from_args(
-        std::size_t& arg_idx, uint8_t noc = get_fabric_worker_noc()) {
+    static WorkerToFabricEdmSenderBase build_from_args(std::size_t& arg_idx) {
         constexpr bool is_persistent_fabric = true;
         uint8_t direction;
         uint8_t edm_worker_x;
@@ -172,8 +171,7 @@ struct WorkerToFabricEdmSenderBase {
             worker_free_slots_stream_id,
             my_fc_stream_channel_id,
             write_reg_cmd_buf,
-            write_at_cmd_buf,
-            noc);
+            write_at_cmd_buf);
     }
 
     template <ProgrammableCoreType my_core_type = ProgrammableCoreType::ACTIVE_ETH>
@@ -198,8 +196,7 @@ struct WorkerToFabricEdmSenderBase {
             worker_credits_stream_id,  // To locally track downstream EDM's free slots. Only used by EDM. Sending EDM
                                        // decrements locally. Downstream EDM increments over noc when a slot is freed.
         uint8_t data_noc_cmd_buf = write_reg_cmd_buf,
-        uint8_t sync_noc_cmd_buf = write_at_cmd_buf,
-        uint8_t noc = get_fabric_worker_noc()) {
+        uint8_t sync_noc_cmd_buf = write_at_cmd_buf) {
         this->edm_buffer_addr = edm_buffer_base_addr;
         this->worker_credits_stream_id = worker_credits_stream_id.get();
 
@@ -238,7 +235,6 @@ struct WorkerToFabricEdmSenderBase {
         this->edm_noc_y = edm_worker_y;
         this->data_noc_cmd_buf = data_noc_cmd_buf;
         this->sync_noc_cmd_buf = sync_noc_cmd_buf;
-        this->send_noc = noc;
 
         if constexpr (I_USE_STREAM_REG_FOR_CREDIT_RECEIVE) {
             // The EDM is guaranteed to know the number of free slots of the downstream EDM
@@ -269,8 +265,7 @@ struct WorkerToFabricEdmSenderBase {
         uint32_t sender_channel_credits_stream_id,
         StreamId worker_credits_stream_id,
         uint8_t data_noc_cmd_buf = write_reg_cmd_buf,
-        uint8_t sync_noc_cmd_buf = write_at_cmd_buf,
-        uint8_t noc = get_fabric_worker_noc()) {
+        uint8_t sync_noc_cmd_buf = write_at_cmd_buf) {
         this->init<my_core_type>(
             connected_to_persistent_fabric,
             edm_worker_x,
@@ -287,8 +282,7 @@ struct WorkerToFabricEdmSenderBase {
             sender_channel_credits_stream_id,
             worker_credits_stream_id,
             data_noc_cmd_buf,
-            sync_noc_cmd_buf,
-            noc);
+            sync_noc_cmd_buf);
     }
 
     FORCE_INLINE uint32_t get_num_free_write_slots() const {
@@ -446,9 +440,10 @@ struct WorkerToFabricEdmSenderBase {
     // Must be called alongside (before) open_finish().
     template <
         bool SEND_CREDIT_ADDR = false,
-        bool posted = false>
+        bool posted = false,
+        uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
     void open_start() {
-        const auto dest_noc_addr_coord_only = get_noc_addr(this->edm_noc_x, this->edm_noc_y, 0, this->send_noc);
+        const auto dest_noc_addr_coord_only = get_noc_addr(this->edm_noc_x, this->edm_noc_y, 0, WORKER_HANDSHAKE_NOC);
 
         tt::tt_fabric::EDMChannelWorkerLocationInfo* worker_location_info_ptr =
             reinterpret_cast<tt::tt_fabric::EDMChannelWorkerLocationInfo*>(edm_worker_location_info_addr);
@@ -463,7 +458,7 @@ struct WorkerToFabricEdmSenderBase {
                 remote_producer_cursor_addr,
                 local_producer_cursor_addr,
                 sizeof(tt::tt_fabric::SenderChannelProducerCursor),
-                this->send_noc);
+                WORKER_HANDSHAKE_NOC);
 
             const uint64_t edm_read_free_slots_or_read_counter_addr =
                 dest_noc_addr_coord_only | reinterpret_cast<size_t>(
@@ -474,7 +469,7 @@ struct WorkerToFabricEdmSenderBase {
                 edm_read_free_slots_or_read_counter_addr,
                 reinterpret_cast<size_t>(this->edm_buffer_local_free_slots_read_ptr),
                 sizeof(uint32_t),  // also want to read the local write counter
-                this->send_noc);
+                WORKER_HANDSHAKE_NOC);
         }
         const uint64_t dest_edm_location_info_addr =
             dest_noc_addr_coord_only |
@@ -487,13 +482,13 @@ struct WorkerToFabricEdmSenderBase {
                 dest_edm_location_info_addr,
                 reinterpret_cast<size_t>(edm_buffer_local_free_slots_update_ptr),
                 0xf,
-                this->send_noc);
+                WORKER_HANDSHAKE_NOC);
         } else {
             noc_inline_dw_write<InlineWriteDst::L1, posted>(
                 dest_edm_location_info_addr,
                 reinterpret_cast<size_t>(edm_buffer_local_free_slots_update_ptr),
                 0xf,
-                this->send_noc);
+                WORKER_HANDSHAKE_NOC);
         }
         const uint64_t edm_teardown_semaphore_address_address =
             dest_noc_addr_coord_only |
@@ -503,23 +498,23 @@ struct WorkerToFabricEdmSenderBase {
             edm_teardown_semaphore_address_address,
             reinterpret_cast<size_t>(worker_teardown_addr),
             0xf,
-            this->send_noc);
+            WORKER_HANDSHAKE_NOC);
         // Write out core noc-xy coord to EDM
         const uint64_t connection_worker_xy_address =
             dest_noc_addr_coord_only | reinterpret_cast<uint64_t>(&(worker_location_info_ptr->worker_xy));
         noc_inline_dw_write<InlineWriteDst::L1, posted>(
-            connection_worker_xy_address, WorkerXY(my_x[0], my_y[0]).to_uint32(), 0xf, this->send_noc);
+            connection_worker_xy_address, WorkerXY(my_x[0], my_y[0]).to_uint32(), 0xf, WORKER_HANDSHAKE_NOC);
     }
 
     // Advanced usage API:
     // Completes the connection opening process. Induces a read barrier
     // !!! IMPORTANT !!!
     // Must be called alongside (after) open_start().
-    template <bool posted = false>
+    template <bool posted = false, uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
     void open_finish() {
         const uint64_t edm_connection_handshake_noc_addr =
-            get_noc_addr(this->edm_noc_x, this->edm_noc_y, edm_connection_handshake_l1_addr, this->send_noc);
-        noc_async_read_barrier(this->send_noc);
+            get_noc_addr(this->edm_noc_x, this->edm_noc_y, edm_connection_handshake_l1_addr, WORKER_HANDSHAKE_NOC);
+        noc_async_read_barrier(WORKER_HANDSHAKE_NOC);
         // Order here is important
         // We need to write our read counter value to the register before we signal the EDM
         // As EDM will potentially increment the register as well
@@ -546,7 +541,7 @@ struct WorkerToFabricEdmSenderBase {
             edm_connection_handshake_noc_addr,
             tt::tt_fabric::connection_interface::open_connection_value,
             0xf,
-            this->send_noc);
+            WORKER_HANDSHAKE_NOC);
         *this->worker_teardown_addr = 0;
         if constexpr (!USER_DEFINED_NUM_BUFFER_SLOTS) {
             this->edm_buffer_addr =
@@ -558,10 +553,11 @@ struct WorkerToFabricEdmSenderBase {
     //                   or some legacy code which skips connection info copy on Tensix L1 static address
     template <
         bool SEND_CREDIT_ADDR = false,
-        bool posted = false>
+        bool posted = false,
+        uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
     void open() {
-        open_start<SEND_CREDIT_ADDR, posted>();
-        open_finish<posted>();
+        open_start<SEND_CREDIT_ADDR, posted, WORKER_HANDSHAKE_NOC>();
+        open_finish<posted, WORKER_HANDSHAKE_NOC>();
     }
 
     // Advanced usage API:
@@ -569,10 +565,10 @@ struct WorkerToFabricEdmSenderBase {
     // for the ack from the fabric before returning, saving some cycles for advanced users.
     // !!! IMPORTANT !!!
     // Must be called alongside (before) close_finish().
-    template <bool posted = false>
+    template <bool posted = false, uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
     void close_start() {
         const auto dest_noc_addr_coord_only =
-            get_noc_addr(this->edm_noc_x, this->edm_noc_y, 0, this->send_noc) & ~(uint64_t)NOC_COORDINATE_MASK;
+            get_noc_addr(this->edm_noc_x, this->edm_noc_y, 0, WORKER_HANDSHAKE_NOC) & ~(uint64_t)NOC_COORDINATE_MASK;
 
         // Persist the producer cursor for the next connection on this channel. Only
         // worker-style producers participate in this protocol: the block is read back
@@ -583,12 +579,12 @@ struct WorkerToFabricEdmSenderBase {
                 remote_producer_cursor_addr + offsetof(tt::tt_fabric::SenderChannelProducerCursor, write_counter),
                 this->buffer_slot_write_counter.counter,
                 0xF,
-                this->send_noc);
+                WORKER_HANDSHAKE_NOC);
             noc_inline_dw_write<InlineWriteDst::L1, posted>(
                 remote_producer_cursor_addr + offsetof(tt::tt_fabric::SenderChannelProducerCursor, write_index),
                 static_cast<uint32_t>(this->get_buffer_slot_index()),
                 0xF,
-                this->send_noc);
+                WORKER_HANDSHAKE_NOC);
         } else {
             // Deliberate no-op: stream-reg (EDM-style) producers never read the cursor
             // block in open_start(), so there is nothing to hand off. This must stay a
@@ -600,20 +596,20 @@ struct WorkerToFabricEdmSenderBase {
             dest_edm_connection_state_addr,
             tt::tt_fabric::connection_interface::close_connection_request_value,
             0xF,
-            this->send_noc);
+            WORKER_HANDSHAKE_NOC);
     }
 
     // Advanced usage API:
     // Completes the connection closing process. Induces a write barrier
     // !!! IMPORTANT !!!
     // Must be called alongside (after) close_start().
-    template <bool posted = false>
+    template <bool posted = false, uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
     void close_finish() {
         WAYPOINT("FCFW");
         if constexpr (posted) {
-            noc_async_posted_writes_flushed(this->send_noc);
+            noc_async_posted_writes_flushed(WORKER_HANDSHAKE_NOC);
         }
-        noc_async_write_barrier(this->send_noc);
+        noc_async_write_barrier(WORKER_HANDSHAKE_NOC);
 
         // Need to wait for the ack to teardown notice, from edm
         while (*this->worker_teardown_addr != 1) {
@@ -623,10 +619,10 @@ struct WorkerToFabricEdmSenderBase {
         *(this->worker_teardown_addr) = 0;
     }
 
-    template <bool posted = false>
+    template <bool posted = false, uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
     void close() {
-        close_start<posted>();
-        close_finish<posted>();
+        close_start<posted, WORKER_HANDSHAKE_NOC>();
+        close_finish<posted, WORKER_HANDSHAKE_NOC>();
     }
 
     uint32_t edm_buffer_addr;
@@ -665,15 +661,6 @@ struct WorkerToFabricEdmSenderBase {
     // the cmd buffer is used for edm-edm path
     uint8_t data_noc_cmd_buf;
     uint8_t sync_noc_cmd_buf;
-
-    // NoC used for the entire worker->fabric path (open handshake, packet sends, close). This is runtime
-    // connection state so split-phase operations cannot select different NoCs through independent template
-    // arguments. Callers can steer this path off a NoC lane reserved by e.g. a persistent linked mcast
-    // (#1819). Set by build_from_args()/init() (both default to get_fabric_worker_noc()
-    // for byte-identical legacy behavior); left uninitialized here like the other members so the
-    // class keeps a trivial default constructor (static-storage instances of this type -- e.g.
-    // CQRelayClient's embedded WorkerToFabricMuxSender -- are declared before init() ever runs).
-    uint8_t send_noc;
 
 private:
     template <bool STATEFUL_NOC>
@@ -798,10 +785,10 @@ private:
 
     template <EDM_IO_BLOCKING_MODE blocking_mode>
     FORCE_INLINE void send_payload_impl(uint32_t cb_id, uint32_t num_pages, uint32_t page_size) {
-        uint64_t buffer_address = this->compute_dest_buffer_slot_noc_addr(this->send_noc);
+        uint64_t buffer_address = this->compute_dest_buffer_slot_noc_addr();
         ASSERT(num_pages * page_size <= this->buffer_size_bytes);
-        send_chunk<blocking_mode>(cb_id, num_pages, page_size, buffer_address, this->send_noc);
-        post_send_payload_increment_pointers(this->send_noc);
+        send_chunk<blocking_mode>(cb_id, num_pages, page_size, buffer_address);
+        post_send_payload_increment_pointers();
     }
 };
 

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -569,10 +569,10 @@ struct WorkerToFabricEdmSenderBase {
     // for the ack from the fabric before returning, saving some cycles for advanced users.
     // !!! IMPORTANT !!!
     // Must be called alongside (before) close_finish().
-    template <bool posted = false, uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
+    template <bool posted = false>
     void close_start() {
         const auto dest_noc_addr_coord_only =
-            get_noc_addr(this->edm_noc_x, this->edm_noc_y, 0, WORKER_HANDSHAKE_NOC) & ~(uint64_t)NOC_COORDINATE_MASK;
+            get_noc_addr(this->edm_noc_x, this->edm_noc_y, 0, this->send_noc) & ~(uint64_t)NOC_COORDINATE_MASK;
 
         // Persist the producer cursor for the next connection on this channel. Only
         // worker-style producers participate in this protocol: the block is read back
@@ -583,12 +583,12 @@ struct WorkerToFabricEdmSenderBase {
                 remote_producer_cursor_addr + offsetof(tt::tt_fabric::SenderChannelProducerCursor, write_counter),
                 this->buffer_slot_write_counter.counter,
                 0xF,
-                WORKER_HANDSHAKE_NOC);
+                this->send_noc);
             noc_inline_dw_write<InlineWriteDst::L1, posted>(
                 remote_producer_cursor_addr + offsetof(tt::tt_fabric::SenderChannelProducerCursor, write_index),
                 static_cast<uint32_t>(this->get_buffer_slot_index()),
                 0xF,
-                WORKER_HANDSHAKE_NOC);
+                this->send_noc);
         } else {
             // Deliberate no-op: stream-reg (EDM-style) producers never read the cursor
             // block in open_start(), so there is nothing to hand off. This must stay a
@@ -600,20 +600,20 @@ struct WorkerToFabricEdmSenderBase {
             dest_edm_connection_state_addr,
             tt::tt_fabric::connection_interface::close_connection_request_value,
             0xF,
-            WORKER_HANDSHAKE_NOC);
+            this->send_noc);
     }
 
     // Advanced usage API:
     // Completes the connection closing process. Induces a write barrier
     // !!! IMPORTANT !!!
     // Must be called alongside (after) close_start().
-    template <bool posted = false, uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
+    template <bool posted = false>
     void close_finish() {
         WAYPOINT("FCFW");
         if constexpr (posted) {
-            noc_async_posted_writes_flushed(WORKER_HANDSHAKE_NOC);
+            noc_async_posted_writes_flushed(this->send_noc);
         }
-        noc_async_write_barrier(WORKER_HANDSHAKE_NOC);
+        noc_async_write_barrier(this->send_noc);
 
         // Need to wait for the ack to teardown notice, from edm
         while (*this->worker_teardown_addr != 1) {
@@ -623,10 +623,10 @@ struct WorkerToFabricEdmSenderBase {
         *(this->worker_teardown_addr) = 0;
     }
 
-    template <bool posted = false, uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
+    template <bool posted = false>
     void close() {
-        close_start<posted, WORKER_HANDSHAKE_NOC>();
-        close_finish<posted, WORKER_HANDSHAKE_NOC>();
+        close_start<posted>();
+        close_finish<posted>();
     }
 
     uint32_t edm_buffer_addr;
@@ -666,9 +666,10 @@ struct WorkerToFabricEdmSenderBase {
     uint8_t data_noc_cmd_buf;
     uint8_t sync_noc_cmd_buf;
 
-    // NoC used for the entire worker->fabric path (open handshake, packet sends, close). Overridable
-    // per-connection so callers can steer this path off a NoC lane reserved by e.g. a persistent
-    // linked mcast (#1819). Set by build_from_args()/init() (both default to get_fabric_worker_noc()
+    // NoC used for the entire worker->fabric path (open handshake, packet sends, close). This is runtime
+    // connection state so split-phase operations cannot select different NoCs through independent template
+    // arguments. Callers can steer this path off a NoC lane reserved by e.g. a persistent linked mcast
+    // (#1819). Set by build_from_args()/init() (both default to get_fabric_worker_noc()
     // for byte-identical legacy behavior); left uninitialized here like the other members so the
     // class keeps a trivial default constructor (static-storage instances of this type -- e.g.
     // CQRelayClient's embedded WorkerToFabricMuxSender -- are declared before init() ever runs).

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -536,40 +536,40 @@ struct WorkerToFabricEdmSenderBase {
     // for the ack from the fabric before returning, saving some cycles for advanced users.
     // !!! IMPORTANT !!!
     // Must be called alongside (before) close_finish().
-    template <bool posted = false, uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
+    template <bool posted = false>
     void close_start() {
         const auto dest_noc_addr_coord_only =
-            get_noc_addr(this->edm_noc_x, this->edm_noc_y, 0, WORKER_HANDSHAKE_NOC) & ~(uint64_t)NOC_COORDINATE_MASK;
+            get_noc_addr(this->edm_noc_x, this->edm_noc_y, 0, this->send_noc) & ~(uint64_t)NOC_COORDINATE_MASK;
 
         // buffer index stored at location after handshake addr
         if (!I_USE_STREAM_REG_FOR_CREDIT_RECEIVE) {
             const uint64_t remote_buffer_index_addr = dest_noc_addr_coord_only | edm_copy_of_wr_counter_addr;
             noc_inline_dw_write<InlineWriteDst::L1, posted>(
-                remote_buffer_index_addr, this->buffer_slot_write_counter.counter, 0xF, WORKER_HANDSHAKE_NOC);
+                remote_buffer_index_addr, this->buffer_slot_write_counter.counter, 0xF, this->send_noc);
         } else {
             const uint64_t remote_buffer_index_addr = dest_noc_addr_coord_only | edm_copy_of_wr_counter_addr;
             noc_inline_dw_write<InlineWriteDst::L1, posted>(
-                remote_buffer_index_addr, this->get_buffer_slot_index(), 0xF, WORKER_HANDSHAKE_NOC);
+                remote_buffer_index_addr, this->get_buffer_slot_index(), 0xF, this->send_noc);
         }
         const uint64_t dest_edm_connection_state_addr = dest_noc_addr_coord_only | edm_connection_handshake_l1_addr;
         noc_inline_dw_write<InlineWriteDst::L1, posted>(
             dest_edm_connection_state_addr,
             tt::tt_fabric::connection_interface::close_connection_request_value,
             0xF,
-            WORKER_HANDSHAKE_NOC);
+            this->send_noc);
     }
 
     // Advanced usage API:
     // Completes the connection closing process. Induces a write barrier
     // !!! IMPORTANT !!!
     // Must be called alongside (after) close_start().
-    template <bool posted = false, uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
+    template <bool posted = false>
     void close_finish() {
         WAYPOINT("FCFW");
         if constexpr (posted) {
-            noc_async_posted_writes_flushed(WORKER_HANDSHAKE_NOC);
+            noc_async_posted_writes_flushed(this->send_noc);
         }
-        noc_async_write_barrier(WORKER_HANDSHAKE_NOC);
+        noc_async_write_barrier(this->send_noc);
 
         // Need to wait for the ack to teardown notice, from edm
         while (*this->worker_teardown_addr != 1) {
@@ -579,10 +579,10 @@ struct WorkerToFabricEdmSenderBase {
         *(this->worker_teardown_addr) = 0;
     }
 
-    template <bool posted = false, uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
+    template <bool posted = false>
     void close() {
-        close_start<posted, WORKER_HANDSHAKE_NOC>();
-        close_finish<posted, WORKER_HANDSHAKE_NOC>();
+        close_start<posted>();
+        close_finish<posted>();
     }
 
     uint32_t edm_buffer_addr;

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -748,7 +748,7 @@ private:
 
     template <EDM_IO_BLOCKING_MODE blocking_mode>
     FORCE_INLINE void send_payload_impl(uint32_t cb_id, uint32_t num_pages, uint32_t page_size) {
-        uint64_t buffer_address = this->compute_dest_buffer_slot_noc_addr();
+        uint64_t buffer_address = this->compute_dest_buffer_slot_noc_addr(this->send_noc);
         ASSERT(num_pages * page_size <= this->buffer_size_bytes);
         send_chunk<blocking_mode>(cb_id, num_pages, page_size, buffer_address, this->send_noc);
         post_send_payload_increment_pointers(this->send_noc);

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -88,7 +88,8 @@ struct WorkerToFabricEdmSenderBase {
     WorkerToFabricEdmSenderBase() = default;
 
     template <ProgrammableCoreType my_core_type>
-    static WorkerToFabricEdmSenderBase build_from_args(std::size_t& arg_idx) {
+    static WorkerToFabricEdmSenderBase build_from_args(
+        std::size_t& arg_idx, uint8_t noc = get_fabric_worker_noc()) {
         constexpr bool is_persistent_fabric = true;
         uint8_t direction;
         uint8_t edm_worker_x;
@@ -171,7 +172,8 @@ struct WorkerToFabricEdmSenderBase {
             worker_free_slots_stream_id,
             my_fc_stream_channel_id,
             write_reg_cmd_buf,
-            write_at_cmd_buf);
+            write_at_cmd_buf,
+            noc);
     }
 
     template <ProgrammableCoreType my_core_type = ProgrammableCoreType::ACTIVE_ETH>
@@ -196,7 +198,8 @@ struct WorkerToFabricEdmSenderBase {
             worker_credits_stream_id,  // To locally track downstream EDM's free slots. Only used by EDM. Sending EDM
                                        // decrements locally. Downstream EDM increments over noc when a slot is freed.
         uint8_t data_noc_cmd_buf = write_reg_cmd_buf,
-        uint8_t sync_noc_cmd_buf = write_at_cmd_buf) {
+        uint8_t sync_noc_cmd_buf = write_at_cmd_buf,
+        uint8_t noc = get_fabric_worker_noc()) {
         this->edm_buffer_addr = edm_buffer_base_addr;
         this->worker_credits_stream_id = worker_credits_stream_id.get();
 
@@ -230,6 +233,7 @@ struct WorkerToFabricEdmSenderBase {
         this->edm_noc_y = edm_worker_y;
         this->data_noc_cmd_buf = data_noc_cmd_buf;
         this->sync_noc_cmd_buf = sync_noc_cmd_buf;
+        this->send_noc = noc;
 
         if constexpr (I_USE_STREAM_REG_FOR_CREDIT_RECEIVE) {
             // The EDM is guaranteed to know the number of free slots of the downstream EDM
@@ -260,7 +264,8 @@ struct WorkerToFabricEdmSenderBase {
         uint32_t sender_channel_credits_stream_id,
         StreamId worker_credits_stream_id,
         uint8_t data_noc_cmd_buf = write_reg_cmd_buf,
-        uint8_t sync_noc_cmd_buf = write_at_cmd_buf) {
+        uint8_t sync_noc_cmd_buf = write_at_cmd_buf,
+        uint8_t noc = get_fabric_worker_noc()) {
         this->init<my_core_type>(
             connected_to_persistent_fabric,
             edm_worker_x,
@@ -277,7 +282,8 @@ struct WorkerToFabricEdmSenderBase {
             sender_channel_credits_stream_id,
             worker_credits_stream_id,
             data_noc_cmd_buf,
-            sync_noc_cmd_buf);
+            sync_noc_cmd_buf,
+            noc);
     }
 
     FORCE_INLINE uint32_t get_num_free_write_slots() const {
@@ -417,10 +423,9 @@ struct WorkerToFabricEdmSenderBase {
     // Must be called alongside (before) open_finish().
     template <
         bool SEND_CREDIT_ADDR = false,
-        bool posted = false,
-        uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
+        bool posted = false>
     void open_start() {
-        const auto dest_noc_addr_coord_only = get_noc_addr(this->edm_noc_x, this->edm_noc_y, 0, WORKER_HANDSHAKE_NOC);
+        const auto dest_noc_addr_coord_only = get_noc_addr(this->edm_noc_x, this->edm_noc_y, 0, this->send_noc);
 
         tt::tt_fabric::EDMChannelWorkerLocationInfo* worker_location_info_ptr =
             reinterpret_cast<tt::tt_fabric::EDMChannelWorkerLocationInfo*>(edm_worker_location_info_addr);
@@ -435,7 +440,7 @@ struct WorkerToFabricEdmSenderBase {
                 remote_buffer_index_addr,
                 reinterpret_cast<size_t>(this->worker_teardown_addr),
                 sizeof(uint32_t),
-                WORKER_HANDSHAKE_NOC);
+                this->send_noc);
 
             const uint64_t edm_read_free_slots_or_read_counter_addr =
                 dest_noc_addr_coord_only | reinterpret_cast<size_t>(
@@ -446,7 +451,7 @@ struct WorkerToFabricEdmSenderBase {
                 edm_read_free_slots_or_read_counter_addr,
                 reinterpret_cast<size_t>(this->edm_buffer_local_free_slots_read_ptr),
                 sizeof(uint32_t),  // also want to read the local write counter
-                WORKER_HANDSHAKE_NOC);
+                this->send_noc);
         }
         const uint64_t dest_edm_location_info_addr =
             dest_noc_addr_coord_only |
@@ -459,13 +464,13 @@ struct WorkerToFabricEdmSenderBase {
                 dest_edm_location_info_addr,
                 reinterpret_cast<size_t>(edm_buffer_local_free_slots_update_ptr),
                 0xf,
-                WORKER_HANDSHAKE_NOC);
+                this->send_noc);
         } else {
             noc_inline_dw_write<InlineWriteDst::L1, posted>(
                 dest_edm_location_info_addr,
                 reinterpret_cast<size_t>(edm_buffer_local_free_slots_update_ptr),
                 0xf,
-                WORKER_HANDSHAKE_NOC);
+                this->send_noc);
         }
         const uint64_t edm_teardown_semaphore_address_address =
             dest_noc_addr_coord_only |
@@ -475,23 +480,23 @@ struct WorkerToFabricEdmSenderBase {
             edm_teardown_semaphore_address_address,
             reinterpret_cast<size_t>(worker_teardown_addr),
             0xf,
-            WORKER_HANDSHAKE_NOC);
+            this->send_noc);
         // Write out core noc-xy coord to EDM
         const uint64_t connection_worker_xy_address =
             dest_noc_addr_coord_only | reinterpret_cast<uint64_t>(&(worker_location_info_ptr->worker_xy));
         noc_inline_dw_write<InlineWriteDst::L1, posted>(
-            connection_worker_xy_address, WorkerXY(my_x[0], my_y[0]).to_uint32(), 0xf, WORKER_HANDSHAKE_NOC);
+            connection_worker_xy_address, WorkerXY(my_x[0], my_y[0]).to_uint32(), 0xf, this->send_noc);
     }
 
     // Advanced usage API:
     // Completes the connection opening process. Induces a read barrier
     // !!! IMPORTANT !!!
     // Must be called alongside (after) open_start().
-    template <bool posted = false, uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
+    template <bool posted = false>
     void open_finish() {
         const uint64_t edm_connection_handshake_noc_addr =
-            get_noc_addr(this->edm_noc_x, this->edm_noc_y, edm_connection_handshake_l1_addr, WORKER_HANDSHAKE_NOC);
-        noc_async_read_barrier(WORKER_HANDSHAKE_NOC);
+            get_noc_addr(this->edm_noc_x, this->edm_noc_y, edm_connection_handshake_l1_addr, this->send_noc);
+        noc_async_read_barrier(this->send_noc);
         // Order here is important
         // We need to write our read counter value to the register before we signal the EDM
         // As EDM will potentially increment the register as well
@@ -508,7 +513,7 @@ struct WorkerToFabricEdmSenderBase {
             edm_connection_handshake_noc_addr,
             tt::tt_fabric::connection_interface::open_connection_value,
             0xf,
-            WORKER_HANDSHAKE_NOC);
+            this->send_noc);
         *this->worker_teardown_addr = 0;
         if constexpr (!USER_DEFINED_NUM_BUFFER_SLOTS) {
             this->edm_buffer_addr =
@@ -520,11 +525,10 @@ struct WorkerToFabricEdmSenderBase {
     //                   or some legacy code which skips connection info copy on Tensix L1 static address
     template <
         bool SEND_CREDIT_ADDR = false,
-        bool posted = false,
-        uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
+        bool posted = false>
     void open() {
-        open_start<SEND_CREDIT_ADDR, posted, WORKER_HANDSHAKE_NOC>();
-        open_finish<posted, WORKER_HANDSHAKE_NOC>();
+        open_start<SEND_CREDIT_ADDR, posted>();
+        open_finish<posted>();
     }
 
     // Advanced usage API:
@@ -615,6 +619,11 @@ struct WorkerToFabricEdmSenderBase {
     // the cmd buffer is used for edm-edm path
     uint8_t data_noc_cmd_buf;
     uint8_t sync_noc_cmd_buf;
+
+    // NoC used for the entire worker->fabric path (open handshake, packet sends, close). Overridable
+    // per-connection so callers can steer this path off a NoC lane reserved by e.g. a persistent
+    // linked mcast (#1819). Defaults to the RISC's fabric worker NoC for byte-identical legacy behavior.
+    uint8_t send_noc = get_fabric_worker_noc();
 
 private:
     template <bool STATEFUL_NOC>
@@ -741,8 +750,8 @@ private:
     FORCE_INLINE void send_payload_impl(uint32_t cb_id, uint32_t num_pages, uint32_t page_size) {
         uint64_t buffer_address = this->compute_dest_buffer_slot_noc_addr();
         ASSERT(num_pages * page_size <= this->buffer_size_bytes);
-        send_chunk<blocking_mode>(cb_id, num_pages, page_size, buffer_address);
-        post_send_payload_increment_pointers();
+        send_chunk<blocking_mode>(cb_id, num_pages, page_size, buffer_address, this->send_noc);
+        post_send_payload_increment_pointers(this->send_noc);
     }
 };
 

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -622,8 +622,11 @@ struct WorkerToFabricEdmSenderBase {
 
     // NoC used for the entire worker->fabric path (open handshake, packet sends, close). Overridable
     // per-connection so callers can steer this path off a NoC lane reserved by e.g. a persistent
-    // linked mcast (#1819). Defaults to the RISC's fabric worker NoC for byte-identical legacy behavior.
-    uint8_t send_noc = get_fabric_worker_noc();
+    // linked mcast (#1819). Set by build_from_args()/init() (both default to get_fabric_worker_noc()
+    // for byte-identical legacy behavior); left uninitialized here like the other members so the
+    // class keeps a trivial default constructor (static-storage instances of this type -- e.g.
+    // CQRelayClient's embedded WorkerToFabricMuxSender -- are declared before init() ever runs).
+    uint8_t send_noc;
 
 private:
     template <bool STATEFUL_NOC>

--- a/tt_metal/fabric/hw/inc/edm_fabric/routing_plane_connection_manager.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/routing_plane_connection_manager.hpp
@@ -53,8 +53,6 @@ public:
 
     RoutingPlaneConnectionManager() : num_active_(0) {}
 
-    // noc must be a non-type template param: open_start/open_finish take
-    // WORKER_HANDSHAKE_NOC as a compile-time template argument.
     template <
         BuildFromArgsMode build_mode = BuildFromArgsMode::BUILD_ONLY,
         uint8_t noc = get_fabric_worker_noc()>

--- a/tt_metal/fabric/hw/inc/edm_fabric/routing_plane_connection_manager.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/routing_plane_connection_manager.hpp
@@ -53,7 +53,11 @@ public:
 
     RoutingPlaneConnectionManager() : num_active_(0) {}
 
-    template <BuildFromArgsMode build_mode = BuildFromArgsMode::BUILD_ONLY>
+    // noc must be a non-type template param: open_start/open_finish take
+    // WORKER_HANDSHAKE_NOC as a compile-time template argument.
+    template <
+        BuildFromArgsMode build_mode = BuildFromArgsMode::BUILD_ONLY,
+        uint8_t noc = get_fabric_worker_noc()>
     static RoutingPlaneConnectionManager build_from_args(std::size_t& arg_idx, uint32_t num_connections_to_build) {
         constexpr bool connect = build_mode == BuildFromArgsMode::BUILD_AND_OPEN_CONNECTION ||
                                  build_mode == BuildFromArgsMode::BUILD_AND_OPEN_CONNECTION_START_ONLY;
@@ -68,7 +72,7 @@ public:
             conn.sender =
                 tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(arg_idx);
             if constexpr (connect) {
-                conn.sender.open_start();
+                conn.sender.template open_start<false, false, noc>();
             }
         }
 
@@ -76,7 +80,7 @@ public:
 
         if constexpr (connect && wait_for_connection_open_finish) {
             for (uint32_t i = 0; i < mgr.num_active_; ++i) {
-                mgr.slots_[i].sender.open_finish();
+                mgr.slots_[i].sender.template open_finish<false, noc>();
             }
         }
 

--- a/tt_metal/fabric/hw/inc/edm_fabric/routing_plane_connection_manager.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/routing_plane_connection_manager.hpp
@@ -126,32 +126,38 @@ public:
         }
     }
 
-    template <bool SEND_CREDIT_ADDR = false>
+    template <bool SEND_CREDIT_ADDR = false, uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
     inline void open_start() {
-        for_each([&](Sender& s, uint32_t, uint32_t) { s.open_start<SEND_CREDIT_ADDR>(); });
+        for_each([&](Sender& s, uint32_t, uint32_t) {
+            s.template open_start<SEND_CREDIT_ADDR, false, WORKER_HANDSHAKE_NOC>();
+        });
     }
 
+    template <uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
     inline void open_finish() {
-        for_each([&](Sender& s, uint32_t, uint32_t) { s.open_finish(); });
+        for_each([&](Sender& s, uint32_t, uint32_t) { s.template open_finish<false, WORKER_HANDSHAKE_NOC>(); });
     }
 
-    template <bool SEND_CREDIT_ADDR = false>
+    template <bool SEND_CREDIT_ADDR = false, uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
     inline void open() {
-        open_start<SEND_CREDIT_ADDR>();
-        open_finish();
+        open_start<SEND_CREDIT_ADDR, WORKER_HANDSHAKE_NOC>();
+        open_finish<WORKER_HANDSHAKE_NOC>();
     }
 
+    template <uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
     inline void close_start() {
-        for_each([&](Sender& s, uint32_t, uint32_t) { s.close_start(); });
+        for_each([&](Sender& s, uint32_t, uint32_t) { s.template close_start<false, WORKER_HANDSHAKE_NOC>(); });
     }
 
+    template <uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
     inline void close_finish() {
-        for_each([&](Sender& s, uint32_t, uint32_t) { s.close_finish(); });
+        for_each([&](Sender& s, uint32_t, uint32_t) { s.template close_finish<false, WORKER_HANDSHAKE_NOC>(); });
     }
 
+    template <uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
     inline void close() {
-        close_start();
-        close_finish();
+        close_start<WORKER_HANDSHAKE_NOC>();
+        close_finish<WORKER_HANDSHAKE_NOC>();
     }
 
     inline uint32_t active_count() const { return num_active_; }

--- a/tt_metal/fabric/hw/inc/edm_fabric/routing_plane_connection_manager.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/routing_plane_connection_manager.hpp
@@ -53,9 +53,10 @@ public:
 
     RoutingPlaneConnectionManager() : num_active_(0) {}
 
-    template <BuildFromArgsMode build_mode = BuildFromArgsMode::BUILD_ONLY>
-    static RoutingPlaneConnectionManager build_from_args(
-        std::size_t& arg_idx, uint32_t num_connections_to_build, uint8_t noc = get_fabric_worker_noc()) {
+    template <
+        BuildFromArgsMode build_mode = BuildFromArgsMode::BUILD_ONLY,
+        uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
+    static RoutingPlaneConnectionManager build_from_args(std::size_t& arg_idx, uint32_t num_connections_to_build) {
         constexpr bool connect = build_mode == BuildFromArgsMode::BUILD_AND_OPEN_CONNECTION ||
                                  build_mode == BuildFromArgsMode::BUILD_AND_OPEN_CONNECTION_START_ONLY;
         constexpr bool wait_for_connection_open_finish = build_mode == BuildFromArgsMode::BUILD_AND_OPEN_CONNECTION;
@@ -67,9 +68,9 @@ public:
             auto& conn = mgr.slots_[i];
             conn.tag = static_cast<uint8_t>(get_arg_val<uint32_t>(arg_idx++));
             conn.sender =
-                tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(arg_idx, noc);
+                tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(arg_idx);
             if constexpr (connect) {
-                conn.sender.open_start();
+                conn.sender.open_start<false, false, WORKER_HANDSHAKE_NOC>();
             }
         }
 
@@ -77,7 +78,7 @@ public:
 
         if constexpr (connect && wait_for_connection_open_finish) {
             for (uint32_t i = 0; i < mgr.num_active_; ++i) {
-                mgr.slots_[i].sender.open_finish();
+                mgr.slots_[i].sender.open_finish<false, WORKER_HANDSHAKE_NOC>();
             }
         }
 
@@ -125,32 +126,36 @@ public:
         }
     }
 
-    template <bool SEND_CREDIT_ADDR = false>
+    template <bool SEND_CREDIT_ADDR = false, uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
     inline void open_start() {
-        for_each([&](Sender& s, uint32_t, uint32_t) { s.open_start<SEND_CREDIT_ADDR>(); });
+        for_each([&](Sender& s, uint32_t, uint32_t) { s.open_start<SEND_CREDIT_ADDR, false, WORKER_HANDSHAKE_NOC>(); });
     }
 
+    template <uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
     inline void open_finish() {
-        for_each([&](Sender& s, uint32_t, uint32_t) { s.open_finish(); });
+        for_each([&](Sender& s, uint32_t, uint32_t) { s.open_finish<false, WORKER_HANDSHAKE_NOC>(); });
     }
 
-    template <bool SEND_CREDIT_ADDR = false>
+    template <bool SEND_CREDIT_ADDR = false, uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
     inline void open() {
-        open_start<SEND_CREDIT_ADDR>();
-        open_finish();
+        open_start<SEND_CREDIT_ADDR, WORKER_HANDSHAKE_NOC>();
+        open_finish<WORKER_HANDSHAKE_NOC>();
     }
 
+    template <uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
     inline void close_start() {
-        for_each([&](Sender& s, uint32_t, uint32_t) { s.close_start(); });
+        for_each([&](Sender& s, uint32_t, uint32_t) { s.close_start<false, WORKER_HANDSHAKE_NOC>(); });
     }
 
+    template <uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
     inline void close_finish() {
-        for_each([&](Sender& s, uint32_t, uint32_t) { s.close_finish(); });
+        for_each([&](Sender& s, uint32_t, uint32_t) { s.close_finish<false, WORKER_HANDSHAKE_NOC>(); });
     }
 
+    template <uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
     inline void close() {
-        close_start();
-        close_finish();
+        close_start<WORKER_HANDSHAKE_NOC>();
+        close_finish<WORKER_HANDSHAKE_NOC>();
     }
 
     inline uint32_t active_count() const { return num_active_; }

--- a/tt_metal/fabric/hw/inc/edm_fabric/routing_plane_connection_manager.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/routing_plane_connection_manager.hpp
@@ -53,10 +53,9 @@ public:
 
     RoutingPlaneConnectionManager() : num_active_(0) {}
 
-    template <
-        BuildFromArgsMode build_mode = BuildFromArgsMode::BUILD_ONLY,
-        uint8_t noc = get_fabric_worker_noc()>
-    static RoutingPlaneConnectionManager build_from_args(std::size_t& arg_idx, uint32_t num_connections_to_build) {
+    template <BuildFromArgsMode build_mode = BuildFromArgsMode::BUILD_ONLY>
+    static RoutingPlaneConnectionManager build_from_args(
+        std::size_t& arg_idx, uint32_t num_connections_to_build, uint8_t noc = get_fabric_worker_noc()) {
         constexpr bool connect = build_mode == BuildFromArgsMode::BUILD_AND_OPEN_CONNECTION ||
                                  build_mode == BuildFromArgsMode::BUILD_AND_OPEN_CONNECTION_START_ONLY;
         constexpr bool wait_for_connection_open_finish = build_mode == BuildFromArgsMode::BUILD_AND_OPEN_CONNECTION;
@@ -68,9 +67,9 @@ public:
             auto& conn = mgr.slots_[i];
             conn.tag = static_cast<uint8_t>(get_arg_val<uint32_t>(arg_idx++));
             conn.sender =
-                tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(arg_idx);
+                tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(arg_idx, noc);
             if constexpr (connect) {
-                conn.sender.template open_start<false, false, noc>();
+                conn.sender.open_start();
             }
         }
 
@@ -78,7 +77,7 @@ public:
 
         if constexpr (connect && wait_for_connection_open_finish) {
             for (uint32_t i = 0; i < mgr.num_active_; ++i) {
-                mgr.slots_[i].sender.template open_finish<false, noc>();
+                mgr.slots_[i].sender.open_finish();
             }
         }
 
@@ -126,38 +125,32 @@ public:
         }
     }
 
-    template <bool SEND_CREDIT_ADDR = false, uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
+    template <bool SEND_CREDIT_ADDR = false>
     inline void open_start() {
-        for_each([&](Sender& s, uint32_t, uint32_t) {
-            s.template open_start<SEND_CREDIT_ADDR, false, WORKER_HANDSHAKE_NOC>();
-        });
+        for_each([&](Sender& s, uint32_t, uint32_t) { s.open_start<SEND_CREDIT_ADDR>(); });
     }
 
-    template <uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
     inline void open_finish() {
-        for_each([&](Sender& s, uint32_t, uint32_t) { s.template open_finish<false, WORKER_HANDSHAKE_NOC>(); });
+        for_each([&](Sender& s, uint32_t, uint32_t) { s.open_finish(); });
     }
 
-    template <bool SEND_CREDIT_ADDR = false, uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
+    template <bool SEND_CREDIT_ADDR = false>
     inline void open() {
-        open_start<SEND_CREDIT_ADDR, WORKER_HANDSHAKE_NOC>();
-        open_finish<WORKER_HANDSHAKE_NOC>();
+        open_start<SEND_CREDIT_ADDR>();
+        open_finish();
     }
 
-    template <uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
     inline void close_start() {
-        for_each([&](Sender& s, uint32_t, uint32_t) { s.template close_start<false, WORKER_HANDSHAKE_NOC>(); });
+        for_each([&](Sender& s, uint32_t, uint32_t) { s.close_start(); });
     }
 
-    template <uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
     inline void close_finish() {
-        for_each([&](Sender& s, uint32_t, uint32_t) { s.template close_finish<false, WORKER_HANDSHAKE_NOC>(); });
+        for_each([&](Sender& s, uint32_t, uint32_t) { s.close_finish(); });
     }
 
-    template <uint8_t WORKER_HANDSHAKE_NOC = get_fabric_worker_noc()>
     inline void close() {
-        close_start<WORKER_HANDSHAKE_NOC>();
-        close_finish<WORKER_HANDSHAKE_NOC>();
+        close_start();
+        close_finish();
     }
 
     inline uint32_t active_count() const { return num_active_; }


### PR DESCRIPTION
#### What changed
- Added a compile-time `WORKER_HANDSHAKE_NOC` override to `open_connections` and `close_connections`.
- Threaded the template parameter through `RoutingPlaneConnectionManager::build_from_args` and its split-phase `open_start`, `open_finish`, `close_start`, and `close_finish` helpers.
- Kept `get_fabric_worker_noc()` as the default, so existing callers retain their current behavior.
- Kept NoC selection explicit rather than storing it as runtime state in `WorkerToFabricEdmSenderBase`. This matches the existing sender APIs, where packet traffic can already specify its NoC.

#### Why
- Fabric workers using dynamic NoC mode may need to keep their handshake and packet traffic off a NoC occupied by persistent traffic such as linked multicast.
- The lower-level sender handshake APIs already support selecting the NoC at compile time, but `RoutingPlaneConnectionManager` and the public `open_connections` helper did not expose that selection.
- Callers selecting a non-default NoC must use the same NoC for the connection handshake, packet traffic, and close handshake.

Example call

```cpp
constexpr uint8_t worker_to_fabric_noc = 0;

open_connections<worker_to_fabric_noc>(
    fabric_connection, num_connections, fabric_arg_idx);

sender.send_payload_flush_blocking_from_address(
    source_address, size_bytes, worker_to_fabric_noc);

close_connections<worker_to_fabric_noc>(fabric_connection);
```

Existing callers can continue to use the default NoC without specifying the template argument:

```cpp
open_connections(fabric_connection, num_connections, fabric_arg_idx);
close_connections(fabric_connection);
```

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nkodkani/1819-fabric-open-noc)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nkodkani/1819-fabric-open-noc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nkodkani/1819-fabric-open-noc)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nkodkani/1819-fabric-open-noc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nkodkani/1819-fabric-open-noc)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nkodkani/1819-fabric-open-noc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nkodkani/1819-fabric-open-noc)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nkodkani/1819-fabric-open-noc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nkodkani/1819-fabric-open-noc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nkodkani/1819-fabric-open-noc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nkodkani/1819-fabric-open-noc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nkodkani/1819-fabric-open-noc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nkodkani/1819-fabric-open-noc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nkodkani/1819-fabric-open-noc)
