### PR TITLE
[feature] add TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES as force-disable override

### DIFF
--- a/tt_metal/impl/context/metal_env.cpp
+++ b/tt_metal/impl/context/metal_env.cpp
@@ -126,13 +126,26 @@ namespace {
 // Decide whether to register Blackhole DRAM programmable cores (the "DRAM-core" / tensor-prefetcher
 // path) in the HAL. Queryable afterwards via Hal::has_programmable_core_type(HalProgrammableCoreType::DRAM).
 //
-// Two independent constraints, both about the application owning the right DRAM RISC core:
+// A tri-state env var (TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES) overrides the auto-detect:
+//   =1 → force enable, =0 → force disable, unset → auto-detect (below).
+//
+// Two independent constraints for auto-detect, both about the application owning the right DRAM RISC core:
 //   - Firmware must support it (arch + firmware-bundle floor) -- resolved by check_firmware_capabilities.
 //   - Topology: with DRAM harvesting the specific core the application must write to for GCB credits can
 //     differ per device, which breaks our programming model that the cores look identical on every
 //     device. A single device has no cross-device consistency to break, and an unharvested multi-device
 //     system lines the cores up the same way -- so require no harvested DRAM channels, OR a single device.
-bool should_enable_blackhole_dram_programmable_cores(const Cluster& cluster) {
+bool should_enable_blackhole_dram_programmable_cores(const Cluster& cluster, const llrt::RunTimeOptions& rtoptions) {
+    const auto override = rtoptions.get_blackhole_dram_programmable_cores_override();
+    if (override.has_value()) {
+        log_info(
+            tt::LogMetal,
+            "TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES={} — {} DRAM programmable cores",
+            *override ? "1" : "0",
+            *override ? "force enabling" : "force disabling");
+        return *override;
+    }
+
     FirmwareCapabilityRequest req;
     req.dram_programmable_cores = true;
     FirmwareCapabilityResult res;
@@ -191,7 +204,7 @@ void MetalEnvImpl::initialize_base_objects() {
         get_profiler_dram_bank_size_for_hal_allocation(*this->rtoptions_),
         this->rtoptions_->get_dram_backed_cq(),
         this->rtoptions_->get_simulator_enabled(),
-        should_enable_blackhole_dram_programmable_cores(*this->cluster_));
+        should_enable_blackhole_dram_programmable_cores(*this->cluster_, *this->rtoptions_));
 
     this->rtoptions_->ParseAllFeatureEnv(*hal_);
     this->cluster_->set_hal(hal_.get());

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -116,6 +116,7 @@ enum class EnvVarID {
     TT_METAL_DISABLE_SFPLOADMACRO,             // Disable use of SFPLOADMACRO instructions
     TT_METAL_DRAM_BACKED_CQ,                   // Store command queues in device DRAM
     TT_METAL_SIMULATOR_DIRECT_TENSOR_WRITES,   // Simulator tensor preload bypasses FD CQ copies
+    TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES,  // Override Blackhole DRAM programmable cores
 
     // ========================================
     // PROFILING & PERFORMANCE
@@ -807,6 +808,14 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         // Usage: export TT_METAL_SIMULATOR_DIRECT_TENSOR_WRITES=1
         case EnvVarID::TT_METAL_SIMULATOR_DIRECT_TENSOR_WRITES:
             this->simulator_direct_tensor_writes = is_env_enabled(value);
+            break;
+
+        // TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES
+        // Controls Blackhole DRAM programmable cores in the HAL:
+        //   =1 → force enable, =0 → force disable, unset → auto-detect (firmware + topology)
+        // Usage: export TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES=0
+        case EnvVarID::TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES:
+            this->blackhole_dram_programmable_cores_override = is_env_enabled(value);
             break;
 
         // ========================================

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -293,6 +293,12 @@ class RunTimeOptions {
     // feature flag to enable 2-erisc mode on Blackhole (general, not fabric-specific)
     bool enable_2_erisc_mode = true;
 
+    // Tri-state override for Blackhole DRAM programmable cores in the HAL:
+    //   nullopt = auto-detect (firmware + topology), the default
+    //   true    = force enable (TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES=1)
+    //   false   = force disable (TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES=0)
+    std::optional<bool> blackhole_dram_programmable_cores_override;
+
     // Log kernels compilation commands
     bool log_kernels_compilation_commands = false;
 
@@ -715,6 +721,10 @@ public:
     bool get_enable_2_erisc_mode() const { return enable_2_erisc_mode; }
 
     void set_enable_2_erisc_mode(bool enable) { enable_2_erisc_mode = enable; }
+
+    std::optional<bool> get_blackhole_dram_programmable_cores_override() const {
+        return blackhole_dram_programmable_cores_override;
+    }
 
     bool is_custom_fabric_mesh_graph_desc_path_specified() const { return is_custom_fabric_mesh_graph_desc_path_set; }
     std::string get_custom_fabric_mesh_graph_desc_path() const { return custom_fabric_mesh_graph_desc_path; }


### PR DESCRIPTION
## Summary

PR #48527 removed the `TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES` env var and auto-enabled DRAM programmable cores based on firmware version + topology. This re-adds the env var as a **tri-state override** on top of the existing auto-detect.

| Value | Behavior |
|-------|----------|
| `=1` | Force enable (skip auto-detect) |
| `=0` | Force disable (skip auto-detect) |
| unset | Auto-detect (existing behavior from #48527) |

## Motivation

Disaggregation workloads use a sideband DRISC service kernel (launched via raw UMD, outside Metal) that owns the DRISC cores. Without this override, Metal's GCB/prefetcher path claims the same DRISC cores and clashes with the sideband kernel.

Setting `TT_METAL_ENABLE_BLACKHOLE_DRAM_PROGRAMMABLE_CORES=0` in the model process prevents Metal from registering DRAM programmable cores in the HAL, leaving them free for the sideband DRISC service kernel.

## Changes

- `rtoptions.hpp`: Add `std::optional<bool>` field + getter
- `rtoptions.cpp`: Re-add env var enum entry + handler
- `metal_env.cpp`: Add override check before auto-detect

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snijjar/dram-programmable-cores-disable-switch)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snijjar/dram-programmable-cores-disable-switch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=snijjar/dram-programmable-cores-disable-switch)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:snijjar/dram-programmable-cores-disable-switch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=snijjar/dram-programmable-cores-disable-switch)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:snijjar/dram-programmable-cores-disable-switch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snijjar/dram-programmable-cores-disable-switch)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snijjar/dram-programmable-cores-disable-switch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=snijjar/dram-programmable-cores-disable-switch)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:snijjar/dram-programmable-cores-disable-switch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snijjar/dram-programmable-cores-disable-switch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snijjar/dram-programmable-cores-disable-switch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snijjar/dram-programmable-cores-disable-switch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snijjar/dram-programmable-cores-disable-switch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snijjar/dram-programmable-cores-disable-switch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snijjar/dram-programmable-cores-disable-switch)