### PR TITLE
Add exact float32 support to ttnn.topk

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -20,11 +20,19 @@ def run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_g
     if dtype == ttnn.bfloat8_b:
         pytest.xfail("BFLOAT8_B not supported by pad operation in topk")
 
+    # float32 sorts at full 32-bit precision (no bf16 downcast), so its single-core compute
+    # buffers are ~2x the bf16 size. The result-prep (2*Kt) + output (Kt) tiles dominate L1, so
+    # the ceiling is a tile count, not a width: measured max is 54 output tiles (k <= 1728) in
+    # Wormhole's ~1.5MB per-core L1; beyond that the buffers overflow. Multi-core can't help
+    # here (it requires k <= 64). Kt = ceil(k/32).
+    if dtype == ttnn.float32 and (k + 31) // 32 > 54:
+        pytest.skip("exact float32 top-K exceeds single-core L1 beyond k=1728 (54 output tiles)")
+
     # Input tensor
     shape = [N, C, H, W]
     ttnn_indices_dtype = ttnn.uint16 if W <= UINT16_MAX else ttnn.uint32
     torch_indices_dtype = torch.uint16 if W <= UINT16_MAX else torch.uint32
-    torch_dtype = torch.bfloat16
+    torch_dtype = torch.float32 if dtype == ttnn.float32 else torch.bfloat16
     input = torch.randn(shape, dtype=torch_dtype) * 0.9
     ttnn_input = ttnn.from_torch(input, dtype, layout=ttnn.Layout.TILE, device=device)
     ttnn_input = ttnn.fill_implicit_tile_padding(ttnn_input, TEST_PADDING_VALUE)
@@ -93,12 +101,12 @@ def run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_g
     (
         ttnn.bfloat16,
         ttnn.bfloat8_b,
-        # ttnn.float32, top bits in float32 get cut off somewhere, LLK does not work for this
+        ttnn.float32,
     ),
     ids=[
         "BFLOAT16_B",
         "BFLOAT8_B",
-        # "FLOAT32",
+        "FLOAT32",
     ],
 )
 @pytest.mark.parametrize(
@@ -335,7 +343,6 @@ def test_topk_bfloat8_with_inf(N, C, H, W, dim, k, sub_core_grids, device):
 @pytest.mark.parametrize(
     "torch_input_tensor_dtype, ttnn_input_tensor_dtype",
     [
-        (torch.float32, ttnn.float32),
         (torch.uint32, ttnn.uint32),
         (torch.int32, ttnn.int32),
     ],
@@ -344,14 +351,11 @@ def test_topk_input_dtypes_raise(torch_input_tensor_dtype, ttnn_input_tensor_dty
     torch.manual_seed(0)
     shape = [1, 1, 32, 64]
 
-    if torch_input_tensor_dtype == torch.float32:
-        input_torch = torch.randn(shape, dtype=torch_input_tensor_dtype)
-    else:
-        input_torch = torch.randint(0, 100, shape, dtype=torch_input_tensor_dtype)
+    input_torch = torch.randint(0, 100, shape, dtype=torch_input_tensor_dtype)
 
     ttnn_input = ttnn.from_torch(input_torch, ttnn_input_tensor_dtype, layout=ttnn.Layout.TILE, device=device)
 
-    with expect_error(RuntimeError, "Input tensor must be BFLOAT16, or BFLOAT8_B"):
+    with expect_error(RuntimeError, "Input tensor must be BFLOAT16, BFLOAT8_B, or FLOAT32"):
         ttnn.topk(ttnn_input, k=32, dim=-1, largest=True, sorted=True)
 
 
@@ -381,13 +385,24 @@ def test_topk_preallocated_dtype_raise(value_dtype, index_dtype, device, expect_
     value_tensor = ttnn.from_torch(output_torch, value_dtype, layout=ttnn.Layout.TILE, device=device)
     index_tensor = ttnn.from_torch(output_torch, index_dtype, layout=ttnn.Layout.TILE, device=device)
 
-    # The value dtype must be BFLOAT16/BFLOAT8_B and the index dtype UINT16/UINT32; match whichever is
-    # violated first for the given parametrization.
-    with expect_error(
-        RuntimeError,
-        "Preallocated (output tensor must be BFLOAT16 or BFLOAT8_B|indices tensor must be UINT16 or UINT32)",
-    ):
+    with expect_error(RuntimeError, "Preallocated"):
         ttnn.topk(ttnn_input, k=k, dim=-1, largest=True, sorted=True, output_tensor=(value_tensor, index_tensor))
+
+
+def test_topk_fp32_input_with_uint16_indices_tensor_raise(device, expect_error):
+    # fp32 input forces UINT32 index CBs; a UINT16 indices_tensor would silently produce wrong indices.
+    torch.manual_seed(0)
+    k = 32
+    shape = [1, 1, 32, 8192]
+
+    input_torch = torch.randn(shape, dtype=torch.bfloat16)
+    ttnn_input = ttnn.from_torch(input_torch, ttnn.float32, layout=ttnn.Layout.TILE, device=device)
+
+    indices_torch = torch.zeros(shape, dtype=torch.uint16)
+    indices_tensor = ttnn.from_torch(indices_torch, ttnn.uint16, layout=ttnn.Layout.TILE, device=device)
+
+    with expect_error(RuntimeError, "Optional indices tensor must be UINT32 when input tensor is FLOAT32"):
+        ttnn.topk(ttnn_input, k=k, dim=-1, largest=True, sorted=True, indices_tensor=indices_tensor)
 
 
 @pytest.mark.parametrize("largest", [True, False])

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/permute_tiled_program_factory.cpp
@@ -816,6 +816,16 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTiledGeneric::c
     bool fp32_dest_acc_en = cb_data_format == tt::DataFormat::Float32 || cb_data_format == tt::DataFormat::Int32 ||
                             cb_data_format == tt::DataFormat::UInt32;
 
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    if (cb_data_format == tt::DataFormat::Float32) {
+        // Keep both the tilize input (c_0) and its output (c_1, which feeds the
+        // transpose) in full Float32 on the unpack-to-dest path; otherwise the
+        // unpacker falls back to tf32 and drops the low mantissa bits.
+        unpack_to_dest_mode[src0_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[src1_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+    }
+
     KernelDescriptor compute_desc;
     compute_desc.kernel_source =
         "ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/compute/transpose_xw_tiled.cpp";
@@ -824,6 +834,7 @@ tt::tt_metal::ProgramDescriptor PermuteDeviceOperation::MultiCoreTiledGeneric::c
     compute_desc.compile_time_args = std::move(compute_kernel_args);
     compute_desc.config = ComputeConfigDescriptor{
         .fp32_dest_acc_en = fp32_dest_acc_en,
+        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
     };
 
     std::vector<uint32_t> writer_compile_time_args = {};

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation.cpp
@@ -82,7 +82,9 @@ TopKDeviceOperation::program_factory_t TopKDeviceOperation::select_program_facto
         // Determine data formats for memory cost calculation
         const tt::DataFormat value_cb_data_format =
             tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
-        const tt::DataFormat index_cb_data_format = tt::DataFormat::UInt16;  // Multi-core always uses UInt16
+        // fp32 forces UInt32 indices (see compute_output_specs); size them so the cost isn't undercounted.
+        const tt::DataFormat index_cb_data_format =
+            input_tensor.dtype() == DataType::FLOAT32 ? tt::DataFormat::UInt32 : tt::DataFormat::UInt16;
 
         // Calculate tile sizes for memory cost analysis
         const uint32_t value_tile_size = tile_size(value_cb_data_format);
@@ -154,8 +156,9 @@ void TopKDeviceOperation::validate_on_program_cache_miss(
     // Data type validation
     const auto input_tensor_dtype = input_tensor.dtype();
     TT_FATAL(
-        input_tensor_dtype == DataType::BFLOAT16 || input_tensor_dtype == DataType::BFLOAT8_B,
-        "Input tensor must be BFLOAT16, or BFLOAT8_B, got: {}",
+        input_tensor_dtype == DataType::BFLOAT16 || input_tensor_dtype == DataType::BFLOAT8_B ||
+            input_tensor_dtype == DataType::FLOAT32,
+        "Input tensor must be BFLOAT16, BFLOAT8_B, or FLOAT32, got: {}",
         input_tensor_dtype);
 
     // Optional indices tensor validation (for pre-allocated indices)
@@ -165,6 +168,10 @@ void TopKDeviceOperation::validate_on_program_cache_miss(
             indices_tensor_dtype == DataType::UINT16 || indices_tensor_dtype == DataType::UINT32,
             "Optional input tensor must be UINT16, or UINT32, got: {}",
             indices_tensor_dtype);
+        // fp32 input forces UINT32 index CBs (see compute_output_specs); UINT16 indices would be wrong.
+        TT_FATAL(
+            !(input_tensor_dtype == DataType::FLOAT32 && indices_tensor_dtype == DataType::UINT16),
+            "Optional indices tensor must be UINT32 when input tensor is FLOAT32, got UINT16");
     }
 
     // Preallocated output tensor validation
@@ -172,8 +179,9 @@ void TopKDeviceOperation::validate_on_program_cache_miss(
         const auto output_tensor0_dtype = std::get<0>(preallocated_outputs.value()).dtype();  // Values tensor
         const auto output_tensor1_dtype = std::get<1>(preallocated_outputs.value()).dtype();  // Indices tensor
         TT_FATAL(
-            output_tensor0_dtype == DataType::BFLOAT16 || output_tensor0_dtype == DataType::BFLOAT8_B,
-            "Preallocated output tensor must be BFLOAT16 or BFLOAT8_B got: {}",
+            output_tensor0_dtype == DataType::BFLOAT16 || output_tensor0_dtype == DataType::BFLOAT8_B ||
+                output_tensor0_dtype == DataType::FLOAT32,
+            "Preallocated output tensor must be BFLOAT16, BFLOAT8_B, or FLOAT32 got: {}",
             output_tensor0_dtype);
         TT_FATAL(
             output_tensor1_dtype == DataType::UINT16 || output_tensor1_dtype == DataType::UINT32,
@@ -200,7 +208,10 @@ void TopKDeviceOperation::validate_on_program_cache_miss(
     // Execution feasibility validation
     // Verify that the operation can be executed with available hardware resources
     bool can_run = false;
-    bool uint16_output = (input_shape[args.dim] <= std::numeric_limits<uint16_t>::max());
+    // fp32 forces UInt32 indices (see compute_output_specs), so exclude it here too — otherwise
+    // verify_single_core_cost models UInt16 index CBs and undercounts the fp32 single-core L1 footprint.
+    bool uint16_output =
+        (input_shape[args.dim] <= std::numeric_limits<uint16_t>::max()) && (input_tensor.dtype() != DataType::FLOAT32);
 
     // Try multi-core execution first if dimension is large enough
     if (input_shape[args.dim] >= ttnn::prim::constants::multi_core_min_width) {
@@ -208,7 +219,9 @@ void TopKDeviceOperation::validate_on_program_cache_miss(
 
         // Set up data formats for memory cost calculations
         tt::DataFormat value_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
-        tt::DataFormat index_cb_data_format = tt::DataFormat::UInt16;
+        // fp32 forces UInt32 indices (see compute_output_specs); size them so the cost isn't undercounted.
+        tt::DataFormat index_cb_data_format =
+            input_tensor.dtype() == DataType::FLOAT32 ? tt::DataFormat::UInt32 : tt::DataFormat::UInt16;
 
         uint32_t value_tile_size = tile_size(value_cb_data_format);
         uint32_t index_tile_size = tile_size(index_cb_data_format);
@@ -263,8 +276,11 @@ TopKDeviceOperation::spec_return_value_t TopKDeviceOperation::compute_output_spe
     output_shape[-1] = args.k;  // Set last dimension to K (number of top elements)
 
     ttnn::Shape input_shape = input_tensor.padded_shape();
-    // Choose index data type based on dimension size (16-bit vs 32-bit indices)
-    const bool uint16_output = (input_shape[args.dim] <= std::numeric_limits<uint16_t>::max());  // 65535
+    // Choose index data type based on dimension size (16-bit vs 32-bit indices).
+    // fp32 input sorts with fp32 dest accumulation, which loads indices as INT32, so it
+    // requires 32-bit (UINT32) indices regardless of dimension size.
+    const bool uint16_output = (input_shape[args.dim] <= std::numeric_limits<uint16_t>::max()) &&
+                               (input_tensor.dtype() != DataType::FLOAT32);  // 65535
 
     // Create values tensor specification (same data type as input)
     const auto values_spec = tt::tt_metal::TensorSpec(

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_multi_core_program_factory.cpp
@@ -86,6 +86,10 @@ tt::tt_metal::ProgramDescriptor TopKDeviceOperation::TopKMultiCoreProgramFactory
     // Use bf16 for compute intermediate buffers to avoid precision loss from bfp8/bfp4
     // shared-exponent grouping during sort (e.g. a single inf in a block makes all other
     // elements in that block encode to 0, corrupting the sort result).
+    // fp32 is kept full-width (no downcast): with fp32_dest_acc_en + UnpackToDestFp32 the value CBs
+    // stay fp32 and the sort's default SFPLOAD mode resolves to FP32, so the inter-core transfer
+    // and compute buffers stay fp32.
+    const bool is_fp32_input = input_cb_data_format == tt::DataFormat::Float32;
     const tt::DataFormat compute_cb_data_format =
         (input_cb_data_format == tt::DataFormat::Bfp8_b || input_cb_data_format == tt::DataFormat::Bfp4_b)
             ? tt::DataFormat::Float16_b
@@ -451,13 +455,24 @@ tt::tt_metal::ProgramDescriptor TopKDeviceOperation::TopKMultiCoreProgramFactory
         static_cast<std::uint32_t>(args.sorted),          // Output sorting requirement
     };
 
+    // fp32: unpack the value-holding CBs straight to fp32 dest (fp32 dest acc) so the sort's
+    // default SFPLOAD mode resolves to FP32 and reads full-precision values.
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_local(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    if (is_fp32_input) {
+        unpack_local[input_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        unpack_local[input_transposed_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+    }
+
     KernelDescriptor compute_local_desc;
     compute_local_desc.kernel_source = "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_local.cpp";
     compute_local_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     compute_local_desc.core_ranges = local_cores_range_set;  // Runs on all local processing cores
     compute_local_desc.compile_time_args = compute_args;
     compute_local_desc.config = ComputeConfigDescriptor{
+        .fp32_dest_acc_en = is_fp32_input,
         .dst_full_sync_en = false,
+        .unpack_to_dest_mode = unpack_local,
     };
 
     // Final compute - Global TopK Bitonic Merge
@@ -480,13 +495,23 @@ tt::tt_metal::ProgramDescriptor TopKDeviceOperation::TopKMultiCoreProgramFactory
         static_cast<std::uint32_t>(args.sorted),          // Output sorting requirement
     };
 
+    // Final-core value CBs (gathered input + final workspace) also unpack to fp32 dest.
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_final(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    if (is_fp32_input) {
+        unpack_final[gathered_values_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        unpack_final[final_values_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+    }
+
     KernelDescriptor compute_final_desc;
     compute_final_desc.kernel_source = "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_final.cpp";
     compute_final_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     compute_final_desc.core_ranges = final_cores_range_set;  // Runs only on final aggregation core
     compute_final_desc.compile_time_args = compute_args_final;
     compute_final_desc.config = ComputeConfigDescriptor{
+        .fp32_dest_acc_en = is_fp32_input,
         .dst_full_sync_en = false,
+        .unpack_to_dest_mode = unpack_final,
     };
 
     uint32_t core_id = 0;            // Width offset counter for core assignment

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_single_core_program_factory.cpp
@@ -42,6 +42,9 @@ tt::tt_metal::ProgramDescriptor TopKDeviceOperation::TopKSingleCoreProgramFactor
     // Use bf16 for compute intermediate buffers to avoid precision loss from bfp8/bfp4
     // shared-exponent grouping during sort (e.g. a single inf in a block makes all other
     // elements in that block encode to 0, corrupting the sort result).
+    // fp32 is kept as-is: with fp32_dest_acc_en + UnpackToDestFp32 the value CBs stay fp32 and the
+    // sort's default SFPLOAD mode resolves to FP32 under fp32 dest-acc, so no downcast is needed.
+    const bool is_fp32_input = input_cb_data_format == tt::DataFormat::Float32;
     const tt::DataFormat compute_cb_data_format =
         (input_cb_data_format == tt::DataFormat::Bfp8_b || input_cb_data_format == tt::DataFormat::Bfp4_b)
             ? tt::DataFormat::Float16_b
@@ -184,12 +187,14 @@ tt::tt_metal::ProgramDescriptor TopKDeviceOperation::TopKSingleCoreProgramFactor
 
     // Kernel Creations:
     std::vector<uint32_t> reader_compile_time_args = {
-        input_cb_index,                       // Input values
-        index_cb_index,                       // Generated indices
-        Ht,                                   // Height in tiles
-        Wt,                                   // Width in tiles
-        total_number_of_cores,                // Total number of cores
-        static_cast<uint32_t>(uint16_output)  // Index format flag
+        input_cb_index,         // Input values
+        index_cb_index,         // Generated indices
+        Ht,                     // Height in tiles
+        Wt,                     // Width in tiles
+        total_number_of_cores,  // Total number of cores
+        // Index width must match the index tensor dtype: fp32 requires 32-bit iota.
+        // 16-bit iota packs two indices per word, producing incorrect INT32 reads.
+        static_cast<uint32_t>(output_ind_cb_data_format == tt::DataFormat::UInt16)  // Index format flag
     };
     tt::tt_metal::TensorAccessorArgs(input_tensor).append_to(reader_compile_time_args);
     if (tensor_args.indices.has_value()) {
@@ -247,9 +252,20 @@ tt::tt_metal::ProgramDescriptor TopKDeviceOperation::TopKSingleCoreProgramFactor
     compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     compute_desc.core_ranges = core_range;
     compute_desc.compile_time_args = compute_args;
+    // fp32 input: unpack the value-holding CBs straight to fp32 dest (fp32 dest acc) so the sort's
+    // default SFPLOAD mode resolves to FP32 and compares full-precision values.
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    if (is_fp32_input) {
+        unpack_to_dest_mode[input_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[transposed_val_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        unpack_to_dest_mode[result_prep_val_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+    }
+
     compute_desc.config = ComputeConfigDescriptor{
-        .fp32_dest_acc_en = !uint16_output,
+        .fp32_dest_acc_en = !uint16_output || is_fp32_input,
         .dst_full_sync_en = false,
+        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
     };
 
     uint32_t id = 0;  // Offset for the next core in the group

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_utils.cpp
@@ -94,16 +94,18 @@ std::optional<TopKCoreConfig> find_topk_core_config(
         const uint32_t rem = width % split_size;                      // Remainder after even division
         const uint32_t num_cores = (width / split_size) + (rem > 0);  // Cores needed (extra for remainder)
 
-        // Gather cost: memory for collecting results from all cores.
-        // Factor of 2 accounts for intermediate storage during gather phase.
-        // c_4 (gathered values) is allocated with transposed_tile_size (bf16 when input is
-        // bfp8/bfp4) to avoid shared-exponent corruption on inter-core transfer; c_5
-        // (gathered indices) remains index_tile_size.
-        const uint32_t memory_cost_gather = 2 * num_cores * (transposed_tile_size + index_tile_size);
-
-        // Local cost: memory each core needs for its width chunk.
-        // Uses transposed_tile_size (bf16 when input is bfp8/bfp4) for the transposed CB.
-        const uint32_t memory_cost_local = (split_size / tile_width) * (transposed_tile_size + index_tile_size);
+        // Per-core L1 footprint mirroring the multi-core factory's CBs: charge the gather/output
+        // buffers to a single core (they live on one core), not amortised across all cores.
+        const uint32_t Wt_final = (num_cores * std::max(k, tile_width)) / tile_width;
+        const uint32_t Wt_local = split_size / tile_width;
+        const uint32_t shared_cost = 4 * (value_tile_size + index_tile_size) +              // c_0,c_1 input
+                                     Wt_final * (transposed_tile_size + index_tile_size) +  // c_4,c_5 gathered
+                                     2 * index_tile_size;                                   // c_9 local-index out
+        const uint32_t final_core_cost =  // + c_8 value, c_6/c_7 workspace
+            shared_cost + 2 * value_tile_size + Wt_final * (transposed_tile_size + index_tile_size);
+        const uint32_t local_core_cost =  // + c_2/c_3 transposed, c_8 value
+            shared_cost + Wt_local * (transposed_tile_size + index_tile_size) + 2 * transposed_tile_size;
+        const uint32_t per_core_cost = std::max(final_core_cost, local_core_cost);
 
         // Extract core grid dimensions from the available range
         const uint32_t max_x = core_range.end_coord.x - core_range.start_coord.x;
@@ -133,12 +135,12 @@ std::optional<TopKCoreConfig> find_topk_core_config(
             }
         }
         // Comprehensive validation: check all requirements for a valid configuration
-        if (num_cores <= max_cores &&                                                        // Core count feasible
-            memory_cost_gather + (memory_cost_local * num_cores) < (l1_size * num_cores) &&  // Memory fits
-            num_cores > 1 &&                                                                 // Multi-core beneficial
-            split_size >= min_dim &&                                                         // Hardware minimum met
-            contiguous_cores_available &&                                                    // Can arrange cores
-            rem == 0) {  // Perfect division (no remainder)
+        if (num_cores <= max_cores &&      // Core count feasible
+            per_core_cost < l1_size &&     // Memory fits
+            num_cores > 1 &&               // Multi-core beneficial
+            split_size >= min_dim &&       // Hardware minimum met
+            contiguous_cores_available &&  // Can arrange cores
+            rem == 0) {                    // Perfect division (no remainder)
 
             // Create configuration with all the calculated parameters
             TopKCoreConfig config{};
@@ -239,8 +241,10 @@ bool verify_single_core_cost(const ttnn::Tensor& input_tensor, uint32_t k, bool 
     const uint32_t value_tile_size = tt::tile_size(value_cb_data_format);
     const uint32_t index_tile_size = tt::tile_size(index_cb_data_format);
 
-    // Transposed (c_2) and result-prep (c_4) CBs use bf16 when input is bfp8/bfp4 to
-    // preserve precision during the sort.  Use the larger bf16 tile size for those buffers.
+    // Transposed (c_2) and result-prep (c_4) CBs use bf16 only when input is bfp8/bfp4 (those
+    // are upcast to bf16 for the sort). fp32 is kept at full width for the exact fp32 sort, so
+    // its compute buffers are fp32-sized — modeling that here lets large-K fp32 be rejected
+    // cleanly instead of overflowing L1 at CB-allocation time.
     const uint32_t compute_tile_size =
         (value_cb_data_format == tt::DataFormat::Bfp8_b || value_cb_data_format == tt::DataFormat::Bfp4_b)
             ? tt::tile_size(tt::DataFormat::Float16_b)

--- a/ttnn/cpp/ttnn/operations/reduction/topk/docs/TopK.md
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/docs/TopK.md
@@ -28,8 +28,8 @@ The operation returns both:
 
 ### Usage Limitations
 
-- Supported index tensor types: `uint16`, `uint32`
-- Supported value tensor types: `bfloat16`, `bfloat8_b`
+- Supported index tensor types: `uint16`, `uint32` (a user-provided `indices_tensor` must be `uint32` when the input tensor is `float32`, since fp32 forces UINT32 index CBs)
+- Supported value tensor types: `bfloat16`, `bfloat8_b`, `float32`
 - Input tensor must be in **TILE** layout
 - Input shape must be 4D (after internal transformations)
 - The dimension to select top K from must have at least 64 elements (min_dim_per_core)

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk_nanobind.cpp
@@ -58,7 +58,7 @@ void bind_reduction_topk_operation(nb::module_& mod) {
 
                     * - dtype
                       - layout
-                    * - BFLOAT8, BFLOAT16
+                    * - BFLOAT8, BFLOAT16, FLOAT32
                       - TILE
 
                 .. list-table:: index_tensor


### PR DESCRIPTION
### PR Category
Feature

### Summary
Closes #40086.

ttnn.topk previously accepted only bfloat16/bfloat8, forcing callers (including TTNNWorkaroundsPass) to downcast float32, which reduced precision in the returned values and could change the selected indices.
This PR adds native, bit-exact float32 support to ttnn.topk. Values are sorted entirely in FP32 within the existing SFPU bitonic-sort LLK, while indices are returned as uint32. For FP32 inputs, the output values match torch.topk exactly, and the implementation works on both single-core and multi-core paths.

### Notes for reviewers
**Review focus:**
* topk_single_core_program_factory.cpp for the reader index-width flag, which is now determined by the index CB dtype instead of destination accumulation mode. This also fixes incorrect indices observed during testing.
* topk_utils.cpp and topk_device_operation.cpp for the corrected multi-core L1 fit check (per-core footprint accounting) and FP32→uint32 index sizing.
* Added float32 cases to the existing topk single-core and multi-core test sweeps in `test_topk.py`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/topk_fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/topk_fp32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/topk_fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/topk_fp32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ign/topk_fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ign/topk_fp32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/topk_fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/topk_fp32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/topk_fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/topk_fp32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/topk_fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/topk_fp32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/topk_fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/topk_fp32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/topk_fp32)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/topk_fp32)
