### PR TITLE
[Test Only] Validate both KV caches (kvpe + DSA index) in pairwise migration

### DIFF
--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_glm51_1galaxy_scheduler_migration.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_glm51_1galaxy_scheduler_migration.yaml
@@ -1,0 +1,79 @@
+# GLM-5.1 SINGLE-RANK (one 8x4 BH galaxy) end-to-end KV migration, SCHEDULER-driven.
+#
+# One rank owns the whole 78-layer model (is_first == is_last), so there is no D2D pipeline and no
+# per-rank slice: the single rank populates the ENTIRE KV cache, then the external scheduler driver
+# migrates the src->dst pairs over the migration layer and writes the DONE sentinel. With the 2-user
+# glm51_run.json the driver migrates 2 pairs: src slots 0,1 -> dst slots 2,3 (dst_i = num_users + i),
+# so the runner allocates 2*num_users = 4 slots. This yaml turns on BOTH post-prefill PCC gates the
+# runner supports for a single rank:
+#
+#   1. PREFILL_REQUEST_LOOP_PCC=1  -> after the request loop, PCC the populated KV cache vs the golden
+#      trace (prefill correctness).
+#   2. PREFILL_VALIDATE_MIGRATION=1 + PREFILL_MIGRATE_PAIRWISE=1 -> wait for the driver's DONE sentinel,
+#      then assert each migrated dst slot == its src slot (migration fidelity, threshold below).
+#
+# REQUIRES the migration_endpoint running on THIS host first (launch_migration_endpoints.sh, endpoint
+# id 1, /mig_ep1_* queues) and the migration client .so at PREFILL_MIGRATION_CLIENT_DIR.
+#
+# Three terminals (all on the single host $MASTER_HOST):
+#   A) endpoint:  ./disaggregation/migration/launch_migration_endpoints.sh \
+#                   --name_server_host $MASTER_HOST --prefill_hosts $MASTER_HOST --prefill_endpoint_id 1
+#   B) runner:    ./models/demos/common/prefill/runners/run_pipeline_prefill.sh \
+#                   models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_glm51_1galaxy_scheduler_migration.yaml \
+#                   $MASTER_HOST:1
+#   C) driver (after rank 0 logs WORKER_READY / the h2d descriptor):
+#        MIGRATION_DONE_FILE=/tmp/migration_done.sentinel \
+#        PREFILL_MIGRATION_CMD_QUEUE=/mig_ep1_cmd PREFILL_MIGRATION_TABLE_QUEUE=/mig_ep1_table \
+#        PREFILL_MIGRATION_RESP_QUEUE=/mig_ep1_resp \
+#          ./build-full/prefill_scheduler_driver --manifest $ENGINE/glm51_run.json
+#
+# NOTE: MIGRATION_DONE_FILE here (runner, waits on it) MUST equal the driver's MIGRATION_DONE_FILE
+# (writes it). Both use /tmp/migration_done.sentinel below.
+
+rank_bindings:
+  - {rank: 0, mesh_id: 0, mesh_host_rank: 0, env_overrides: {}}
+
+mesh_graph_desc_path: tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_x_graph_descriptor.textproto
+
+global_env:
+  PREFILL_MANIFEST: "models/demos/deepseek_v3_d_p/tt/runners/manifests/glm51.json"
+
+  # Model geometry (MUST match the driver / glm51_run.json). Single rank => all 78 layers here.
+  PREFILL_NUM_LAYERS: "78"
+  PREFILL_CHUNK_SIZE: "5120"
+  PREFILL_MAX_SEQ_LEN: "56320"       # 5120 * 11 chunks
+  # Scheduler pairwise: N manifest users => src slots 0..N-1 migrate to dst slots N..2N-1, so the
+  # runner must allocate 2*N slots. glm51_run.json has 2 users => 4 slots (src 0,1 -> dst 2,3).
+  PREFILL_NUM_USERS: "4"
+  PREFILL_SP: "8"
+  PREFILL_TP: "4"
+  PREFILL_KV_ONLY_LAST_LAYER: "0"    # keep EVERY layer's KV (migration copies all layers)
+  PREFILL_GATE_FALLBACK_MODE: "DEVICE_FP32"
+  PREFILL_H2D_SERVICE_ID: "ds_prefill"
+  # PREFILL_FABRIC_MODE auto-derives to 1d for SP<=8 (single galaxy has no D2D) -- leave unset.
+
+  # PCC gate 1: prefill KV cache vs golden trace, after the request loop.
+  PREFILL_REQUEST_LOOP_PCC: "1"
+  PREFILL_TRACE_DIR: "/mnt/models/deepseek-prefill-cache/golden/structured_traces/glm_51_code_debug_55k_vllm"
+  PREFILL_STANDALONE_CHUNKED_PCC: "0.8"   # min per-layer prefill PCC threshold
+
+  # Migration: attach to endpoint 1, publish the merged KV chunk table, block on WORKER_READY,
+  # then (post-loop) wait for the scheduler's DONE sentinel and validate the migrated pair(s).
+  PREFILL_ENABLE_MIGRATION: "1"
+  PREFILL_MIGRATION_ENDPOINT_ID: "1"
+  PREFILL_MIGRATION_CMD_QUEUE: "/mig_ep1_cmd"
+  PREFILL_MIGRATION_TABLE_QUEUE: "/mig_ep1_table"
+  PREFILL_MIGRATION_RESP_QUEUE: "/mig_ep1_resp"
+  # Migration client .so dir (this same absolute path must hold _migration_client*.so).
+  PREFILL_MIGRATION_CLIENT_DIR: "/data/yeongyun/tt-llm-engine/disaggregation/migration/build_RelWithDebInfo/python"
+  MIGRATION_DONE_FILE: "/data/yeongyun/disagg_run/migration_done.sentinel"
+
+  # Request-loop exit count. In migration mode the driver never sends the shutdown sentinel, so the
+  # runner exits its loop after this many H2D chunks, then runs validate_after_prefill. MUST equal the
+  # total chunks the driver pushes: N_users * chunks_per_user. glm51_run.json = 2 users * 11 chunks = 22.
+  PREFILL_STANDALONE_CHUNKED_NCHUNKS: "22"
+
+  # PCC gate 2: migration dst==src fidelity (scheduler-driven; NOT the internal loopback selftest).
+  PREFILL_VALIDATE_MIGRATION: "1"
+  PREFILL_MIGRATE_PAIRWISE: "1"     # 1 = exact dst==src byte check (BOTH kvpe+index); 0 = golden PCC (kvpe only)
+  PREFILL_MIGRATE_PAIRWISE_PCC: "0.99"   # byte-copy loopback migrate should be ~1.0

--- a/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_glm51_1galaxy_scheduler_migration.yaml
+++ b/models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_glm51_1galaxy_scheduler_migration.yaml
@@ -1,34 +1,4 @@
-# GLM-5.1 SINGLE-RANK (one 8x4 BH galaxy) end-to-end KV migration, SCHEDULER-driven.
-#
-# One rank owns the whole 78-layer model (is_first == is_last), so there is no D2D pipeline and no
-# per-rank slice: the single rank populates the ENTIRE KV cache, then the external scheduler driver
-# migrates the src->dst pairs over the migration layer and writes the DONE sentinel. With the 2-user
-# glm51_run.json the driver migrates 2 pairs: src slots 0,1 -> dst slots 2,3 (dst_i = num_users + i),
-# so the runner allocates 2*num_users = 4 slots. This yaml turns on BOTH post-prefill PCC gates the
-# runner supports for a single rank:
-#
-#   1. PREFILL_REQUEST_LOOP_PCC=1  -> after the request loop, PCC the populated KV cache vs the golden
-#      trace (prefill correctness).
-#   2. PREFILL_VALIDATE_MIGRATION=1 + PREFILL_MIGRATE_PAIRWISE=1 -> wait for the driver's DONE sentinel,
-#      then assert each migrated dst slot == its src slot (migration fidelity, threshold below).
-#
-# REQUIRES the migration_endpoint running on THIS host first (launch_migration_endpoints.sh, endpoint
-# id 1, /mig_ep1_* queues) and the migration client .so at PREFILL_MIGRATION_CLIENT_DIR.
-#
-# Three terminals (all on the single host $MASTER_HOST):
-#   A) endpoint:  ./disaggregation/migration/launch_migration_endpoints.sh \
-#                   --name_server_host $MASTER_HOST --prefill_hosts $MASTER_HOST --prefill_endpoint_id 1
-#   B) runner:    ./models/demos/common/prefill/runners/run_pipeline_prefill.sh \
-#                   models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_glm51_1galaxy_scheduler_migration.yaml \
-#                   $MASTER_HOST:1
-#   C) driver (after rank 0 logs WORKER_READY / the h2d descriptor):
-#        MIGRATION_DONE_FILE=/tmp/migration_done.sentinel \
-#        PREFILL_MIGRATION_CMD_QUEUE=/mig_ep1_cmd PREFILL_MIGRATION_TABLE_QUEUE=/mig_ep1_table \
-#        PREFILL_MIGRATION_RESP_QUEUE=/mig_ep1_resp \
-#          ./build-full/prefill_scheduler_driver --manifest $ENGINE/glm51_run.json
-#
-# NOTE: MIGRATION_DONE_FILE here (runner, waits on it) MUST equal the driver's MIGRATION_DONE_FILE
-# (writes it). Both use /tmp/migration_done.sentinel below.
+# GLM-5.1 single-rank (one 8x4 BH galaxy) scheduler-driven KV migration + post-prefill pairwise validation.
 
 rank_bindings:
   - {rank: 0, mesh_id: 0, mesh_host_rank: 0, env_overrides: {}}
@@ -38,42 +8,32 @@ mesh_graph_desc_path: tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_to
 global_env:
   PREFILL_MANIFEST: "models/demos/deepseek_v3_d_p/tt/runners/manifests/glm51.json"
 
-  # Model geometry (MUST match the driver / glm51_run.json). Single rank => all 78 layers here.
+  # Geometry must match the driver / glm51_run.json.
   PREFILL_NUM_LAYERS: "78"
   PREFILL_CHUNK_SIZE: "5120"
-  PREFILL_MAX_SEQ_LEN: "56320"       # 5120 * 11 chunks
-  # Scheduler pairwise: N manifest users => src slots 0..N-1 migrate to dst slots N..2N-1, so the
-  # runner must allocate 2*N slots. glm51_run.json has 2 users => 4 slots (src 0,1 -> dst 2,3).
-  PREFILL_NUM_USERS: "4"
+  PREFILL_MAX_SEQ_LEN: "56320"
+  PREFILL_NUM_USERS: "4"             # 2*N: N manifest users, src 0..N-1 -> dst N..2N-1 (N=2 => 4 slots)
   PREFILL_SP: "8"
   PREFILL_TP: "4"
-  PREFILL_KV_ONLY_LAST_LAYER: "0"    # keep EVERY layer's KV (migration copies all layers)
+  PREFILL_KV_ONLY_LAST_LAYER: "0"
   PREFILL_GATE_FALLBACK_MODE: "DEVICE_FP32"
   PREFILL_H2D_SERVICE_ID: "ds_prefill"
-  # PREFILL_FABRIC_MODE auto-derives to 1d for SP<=8 (single galaxy has no D2D) -- leave unset.
 
-  # PCC gate 1: prefill KV cache vs golden trace, after the request loop.
   PREFILL_REQUEST_LOOP_PCC: "1"
   PREFILL_TRACE_DIR: "/mnt/models/deepseek-prefill-cache/golden/structured_traces/glm_51_code_debug_55k_vllm"
-  PREFILL_STANDALONE_CHUNKED_PCC: "0.8"   # min per-layer prefill PCC threshold
+  PREFILL_STANDALONE_CHUNKED_PCC: "0.88"
 
-  # Migration: attach to endpoint 1, publish the merged KV chunk table, block on WORKER_READY,
-  # then (post-loop) wait for the scheduler's DONE sentinel and validate the migrated pair(s).
+  # runner/driver MIGRATION_DONE_FILE must match.
   PREFILL_ENABLE_MIGRATION: "1"
   PREFILL_MIGRATION_ENDPOINT_ID: "1"
   PREFILL_MIGRATION_CMD_QUEUE: "/mig_ep1_cmd"
   PREFILL_MIGRATION_TABLE_QUEUE: "/mig_ep1_table"
   PREFILL_MIGRATION_RESP_QUEUE: "/mig_ep1_resp"
-  # Migration client .so dir (this same absolute path must hold _migration_client*.so).
   PREFILL_MIGRATION_CLIENT_DIR: "/data/yeongyun/tt-llm-engine/disaggregation/migration/build_RelWithDebInfo/python"
   MIGRATION_DONE_FILE: "/data/yeongyun/disagg_run/migration_done.sentinel"
 
-  # Request-loop exit count. In migration mode the driver never sends the shutdown sentinel, so the
-  # runner exits its loop after this many H2D chunks, then runs validate_after_prefill. MUST equal the
-  # total chunks the driver pushes: N_users * chunks_per_user. glm51_run.json = 2 users * 11 chunks = 22.
-  PREFILL_STANDALONE_CHUNKED_NCHUNKS: "22"
+  PREFILL_STANDALONE_CHUNKED_NCHUNKS: "22"   # must equal driver's total pushes: users * chunks (2*11)
 
-  # PCC gate 2: migration dst==src fidelity (scheduler-driven; NOT the internal loopback selftest).
   PREFILL_VALIDATE_MIGRATION: "1"
-  PREFILL_MIGRATE_PAIRWISE: "1"     # 1 = exact dst==src byte check (BOTH kvpe+index); 0 = golden PCC (kvpe only)
-  PREFILL_MIGRATE_PAIRWISE_PCC: "0.99"   # byte-copy loopback migrate should be ~1.0
+  PREFILL_MIGRATE_PAIRWISE: "1"              # 1 = dst==src PCC on both caches (kvpe+index); 0 = each pair vs golden
+  PREFILL_MIGRATE_PAIRWISE_PCC: "0.99"

--- a/models/demos/common/prefill/runners/validation.py
+++ b/models/demos/common/prefill/runners/validation.py
@@ -65,6 +65,10 @@ def validate_migrations_pairwise(runtime, kv_cache, pairs):
     (a positional comma list of per-slot .pt paths, same order as the driver's --token-json)."""
     thr = float(os.environ.get("PREFILL_MIGRATE_PAIRWISE_PCC", "0.99"))
 
+    # read_slot_kv returns one tensor per engine-owned cache; name them so the log states EXACTLY which
+    # caches were validated (index 0 = primary kvpe, 1 = sparse-DSA index cache; fallback cache{ti}).
+    _cache_name = lambda ti: ("kvpe", "index")[ti] if ti < 2 else f"cache{ti}"
+
     failures = []
     for src, dst in pairs:
         src_blocks = runtime.read_slot_kv(kv_cache, src)
@@ -73,24 +77,32 @@ def validate_migrations_pairwise(runtime, kv_cache, pairs):
             f"[kv-migrate-validate] src_slot={src} dst_slot={dst}: cache tensor count mismatch "
             f"{len(src_blocks)} != {len(dst_blocks)}"
         )
-        min_pcc, worst = 1.0, None
+        # Per-cache min PCC so both kvpe AND the index cache are reported explicitly (not folded into one).
+        per_cache = []  # (name, min_pcc, worst)
         for ti, (sb, db) in enumerate(zip(src_blocks, dst_blocks)):
             assert sb.shape == db.shape, (
                 f"[kv-migrate-validate] src_slot={src} dst_slot={dst}: tensor {ti} shape mismatch "
                 f"{tuple(sb.shape)} != {tuple(db.shape)}"
             )
+            c_min, c_worst = 1.0, None
             for layer in range(sb.shape[0]):
                 for head in range(sb.shape[1]):
                     pcc = _pcc_safe(sb[layer, head], db[layer, head])
-                    if pcc < min_pcc:
-                        min_pcc, worst = pcc, f"t{ti}[L{layer},h{head}]"
+                    if pcc < c_min:
+                        c_min, c_worst = pcc, f"L{layer},h{head}"
+            per_cache.append((_cache_name(ti), c_min, c_worst))
         del src_blocks, dst_blocks
+        min_pcc = min((p for _, p, _ in per_cache), default=1.0)
         status = "PASS" if min_pcc >= thr else "FAIL"
-        logger.info(
-            f"[kv-migrate-validate] pairwise src_slot={src} dst_slot={dst} min_pcc={min_pcc:.6f} "
-            f"(worst {worst}) -> {status}"
+        detail = " | ".join(
+            f"{name} min_pcc={p:.6f}" + (f" (worst {w})" if w is not None else "") for name, p, w in per_cache
         )
-        print(f"[kv-migrate-validate] AFTER pairwise src={src} dst={dst} min_pcc={min_pcc:.6f}")
+        logger.info(
+            f"[kv-migrate-validate] pairwise src_slot={src} dst_slot={dst}: {detail} -> {status} "
+            f"({len(per_cache)} cache(s))"
+        )
+        for name, p, _ in per_cache:
+            print(f"[kv-migrate-validate] AFTER pairwise src={src} dst={dst} {name} min_pcc={p:.6f}")
         if min_pcc < thr:
             failures.append((src, dst, min_pcc))
 

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
@@ -330,36 +330,61 @@ class TtPrefillRuntime:
         )
 
     def read_slot_kv(self, kv_caches: MlaKvCaches, slot: int):
-        """Read one slot's KV cache from device to host: the `.kvpe` block as a single host tensor
-        ``[num_layers, 1, seq_cache, kvpe]`` (one TP replica), in the raw on-device (block-cyclic) layout —
-        not un-rotated to natural token order. DRAM_MEMORY_CONFIG on the slice is REQUIRED — the cache is
-        ND-sharded ROUND_ROBIN_1D, and slicing into another ND-shard miscomputes the DRAM core on host
-        read-back."""
+        """Read one slot's KV cache(s) from device to host as a list of host tensors
+        ``[num_layers, 1, seq_cache, head_dim]`` (one TP replica), in the raw on-device (block-cyclic)
+        layout — not un-rotated to natural token order. Returns ``[kvpe]`` for dense MLA, or
+        ``[kvpe, index]`` for sparse-DSA (v3.2 / GLM), so the pairwise migration validator PCCs BOTH the
+        primary KVPE cache and the lightning-indexer key cache. DRAM_MEMORY_CONFIG on the slice is REQUIRED
+        — the cache is ND-sharded ROUND_ROBIN_1D, and slicing into another ND-shard miscomputes the DRAM
+        core on host read-back."""
         mesh_device = self.mesh_device
         num_layers = self.config.num_layers
-        kvpe = kv_caches.kvpe
-        s = list(kvpe.shape)
-        sl = ttnn.slice(
-            kvpe,
-            [slot * num_layers, 0, 0, 0],
-            [(slot + 1) * num_layers, s[1], s[2], s[3]],
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        )
-        block = ttnn.to_torch(
-            sl, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape)
-        ).float()[
-            :, :1
-        ]  # [num_layers, 1, seq_cache, kvpe]
-        ttnn.deallocate(sl)
-        return [block]
+        # Both caches use the same user-major layout (num_users * cache_layers slots), but the index
+        # cache may stack FEWER layers than kvpe (GLM-5.2 stores only the full-indexer layers; GLM-5.1
+        # stores all). Derive num_users from kvpe (its stack IS num_layers) and slice each cache by ITS
+        # OWN per-slot layer count, so a shorter index stack reads correctly instead of mis-slicing.
+        num_users = kv_caches.kvpe.shape[0] // num_layers
+
+        def _read_one(cache):
+            s = list(cache.shape)
+            cache_layers = s[0] // num_users
+            sl = ttnn.slice(
+                cache,
+                [slot * cache_layers, 0, 0, 0],
+                [(slot + 1) * cache_layers, s[1], s[2], s[3]],
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            block = ttnn.to_torch(
+                sl, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape)
+            ).float()[
+                :, :1
+            ]  # [cache_layers, 1, seq_cache, head_dim]
+            ttnn.deallocate(sl)
+            return block
+
+        blocks = [_read_one(kv_caches.kvpe)]
+        # sparse-DSA (GLM): also read the lightning-indexer key cache so the pairwise validator covers it.
+        if kv_caches.index is not None:
+            blocks.append(_read_one(kv_caches.index))
+        return blocks
 
     def kv_cache_pcc_check(
-        self, kv_caches: MlaKvCaches, *, slot_id: int, n_chunks: int, trace_dir=None, first_layer_idx: int = 0
+        self,
+        kv_caches: MlaKvCaches,
+        *,
+        slot_id: int,
+        n_chunks: int,
+        trace_dir=None,
+        real_len: int | None = None,
+        pt_path_override: str | None = None,
+        first_layer_idx: int = 0,
     ) -> float:
         """Optional bring-up hook (not part of the core runtime contract; never called in production
         serving). PCC the populated engine-owned primary KV cache (`.kvpe`) for `slot_id` against the
         golden trace; returns the min per-layer PCC and asserts on failure (unless
-        PREFILL_STANDALONE_CHUNKED_RECORD_ONLY=1). Thin forwarder into the model's validation module."""
+        PREFILL_STANDALONE_CHUNKED_RECORD_ONLY=1). Thin forwarder into the model's validation module.
+        `real_len` bounds the PCC to the real (non-pad) tokens; `pt_path_override` selects a
+        save_reference_cache .pt golden instead of the trace dir (both used by the migration validators)."""
         from models.demos.deepseek_v3_d_p.tt.runners.prefill_kv_validation import kv_cache_pcc_check
 
         return kv_cache_pcc_check(
@@ -368,5 +393,7 @@ class TtPrefillRuntime:
             slot_id=slot_id,
             n_chunks=n_chunks,
             trace_dir=trace_dir,
+            real_len=real_len,
+            pt_path_override=pt_path_override,
             first_layer_idx=first_layer_idx,
         )


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Extends the single-rank prefill migration check to cover both engine-owned KV caches for sparse-DSA models (GLM / v3.2), not just kvpe.

- `read_slot_kv` now returns a list — [`kvpe`] for dense MLA, [`kvpe, index`] for sparse-DSA — and slices each cache by its own per-slot layer count.
- `validate_migrations_pairwise` reports per-cache min PCC (kvpe and index separately) instead of one folded number.
Adds a single-galaxy GLM-5.1 scheduler-driven migration config (`pipeline_prefill_glm51_1galaxy_scheduler_migration.yaml`) that turns on both the prefill-PCC and migration-fidelity gates.

### Notes for reviewers
Don't merge. Only for testing.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=yeongyun/prefill-runner-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:yeongyun/prefill-runner-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=yeongyun/prefill-runner-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:yeongyun/prefill-runner-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=yeongyun/prefill-runner-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:yeongyun/prefill-runner-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=yeongyun/prefill-runner-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:yeongyun/prefill-runner-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=yeongyun/prefill-runner-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:yeongyun/prefill-runner-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=yeongyun/prefill-runner-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:yeongyun/prefill-runner-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=yeongyun/prefill-runner-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:yeongyun/prefill-runner-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=yeongyun/prefill-runner-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:yeongyun/prefill-runner-validation)