### PR TITLE
[Cleanup] Fix incorrect helper method names

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_helpers.hpp
@@ -106,24 +106,24 @@ inline KernelSpec MakeMinimalGen1DMKernel(
 }
 
 // Helper to create a minimal valid KernelSpec for data movement whose Gen1 config is built
-// from the READER role via CreateReader1xxDataMovementConfig (Gen1/WH/BH).
+// from the READER role via CreateReaderGen1DataMovementConfig (Gen1/WH/BH).
 inline KernelSpec MakeMinimalReaderDMKernel(std::string name) {
     return KernelSpec{
         .unique_id = KernelSpecName{std::move(name)},
         .source = KernelSpec::SourceCode{MINIMAL_KERNEL_SOURCE},
         .num_threads = 1,
-        .hw_config = CreateReader1xxDataMovementConfig(),
+        .hw_config = CreateReaderGen1DataMovementConfig(),
     };
 }
 
 // Helper to create a minimal valid KernelSpec for data movement whose Gen1 config is built
-// from the WRITER role via CreateWriter1xxDataMovementConfig (Gen1/WH/BH).
+// from the WRITER role via CreateWriterGen1DataMovementConfig (Gen1/WH/BH).
 inline KernelSpec MakeMinimalWriterDMKernel(std::string name) {
     return KernelSpec{
         .unique_id = KernelSpecName{std::move(name)},
         .source = KernelSpec::SourceCode{MINIMAL_KERNEL_SOURCE},
         .num_threads = 1,
-        .hw_config = CreateWriter1xxDataMovementConfig(),
+        .hw_config = CreateWriterGen1DataMovementConfig(),
     };
 }
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -592,7 +592,7 @@ TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
             "tests/tt_metal/tt_metal/test_kernels/dataflow/semaphore_accessor_loopback_producer.cpp",
         .num_threads = 1,
         .semaphore_bindings = {{.semaphore_spec_name = SemaphoreSpecName{"only_sem"}, .accessor_name = "signal"}},
-        .hw_config = CreateWriter1xxDataMovementConfig(),
+        .hw_config = CreateWriterGen1DataMovementConfig(),
     };
     KernelSpec consumer{
         .unique_id = KernelSpecName{"consumer"},
@@ -601,7 +601,7 @@ TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
             "tests/tt_metal/tt_metal/test_kernels/dataflow/semaphore_accessor_loopback_consumer.cpp",
         .num_threads = 1,
         .semaphore_bindings = {{.semaphore_spec_name = SemaphoreSpecName{"only_sem"}, .accessor_name = "waiter"}},
-        .hw_config = CreateReader1xxDataMovementConfig(),
+        .hw_config = CreateReaderGen1DataMovementConfig(),
     };
 
     // A WorkUnitSpec describes the kernels that run on a shared set of nodes.

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/data_movement_hardware_config.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/data_movement_hardware_config.hpp
@@ -32,8 +32,8 @@ namespace tt::tt_metal::experimental {
 // NOC a kernel uses. This selection is performance-critical.
 //
 // The common case is handled for you by role-specific factory functions:
-//  - For a DM kernel that reads from DRAM: CreateReader1xxDataMovementConfig()
-//  - For a DM kernel that writes to DRAM:  CreateWriter1xxDataMovementConfig()
+//  - For a DM kernel that reads from DRAM: CreateReaderGen1DataMovementConfig()
+//  - For a DM kernel that writes to DRAM:  CreateWriterGen1DataMovementConfig()
 //
 // Power users can override these conventions by constructing a
 // DataMovementGen1Config directly.
@@ -55,7 +55,7 @@ struct DataMovementGen1Config {
 
 // Factory helper:
 // Default config for a reader DM kernel (i.e. that reads from DRAM)
-inline DataMovementGen1Config CreateReader1xxDataMovementConfig() noexcept {
+inline DataMovementGen1Config CreateReaderGen1DataMovementConfig() noexcept {
     return DataMovementGen1Config{
         // On Wormhole, RISCV_1 runs faster than RISCV_0 due to its dedicated
         // instruction memory. Since DM reader kernels are usually more complex than
@@ -85,7 +85,7 @@ inline DataMovementGen1Config CreateReader1xxDataMovementConfig() noexcept {
 
 // Factory helper:
 // Default config for a writer DM kernel (i.e. that writes to DRAM)
-inline DataMovementGen1Config CreateWriter1xxDataMovementConfig() noexcept {
+inline DataMovementGen1Config CreateWriterGen1DataMovementConfig() noexcept {
     return DataMovementGen1Config{
         // DM kernels on the same node must be assigned to different RISC-V cores.
         // Since RISCV_1 is preferred for readers, place writers on RISCV_0.

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -827,7 +827,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
                     std::holds_alternative<DataMovementGen1Config>(data_movement_config),
                     "KernelSpec '{}' targets Gen1 (WH/BH) but its DataMovementHardwareConfig holds a "
                     "DataMovementGen2Config. Supply a Gen1 config (e.g. "
-                    "CreateReader1xxDataMovementConfig()/CreateWriter1xxDataMovementConfig()).",
+                    "CreateReaderGen1DataMovementConfig()/CreateWriterGen1DataMovementConfig()).",
                     kernel.unique_id);
 
                 // Gen1 has exactly two DM processors: RISCV_0 (BRISC) and RISCV_1 (NCRISC).

--- a/ttnn/cpp/ttnn/operations/core/data_movement_kernel/datamovement_kernel_config.hpp
+++ b/ttnn/cpp/ttnn/operations/core/data_movement_kernel/datamovement_kernel_config.hpp
@@ -29,7 +29,7 @@ inline tt::tt_metal::experimental::DataMovementHardwareConfig create_reader_data
         return tt::tt_metal::experimental::DataMovementGen2Config{
             .disable_dfb_implicit_sync_for_all = disable_dfb_implicit_sync_for_all};
     }
-    return tt::tt_metal::experimental::CreateReader1xxDataMovementConfig();
+    return tt::tt_metal::experimental::CreateReaderGen1DataMovementConfig();
 }
 
 inline tt::tt_metal::experimental::DataMovementHardwareConfig create_writer_datamovement_config(
@@ -38,7 +38,7 @@ inline tt::tt_metal::experimental::DataMovementHardwareConfig create_writer_data
         return tt::tt_metal::experimental::DataMovementGen2Config{
             .disable_dfb_implicit_sync_for_all = disable_dfb_implicit_sync_for_all};
     }
-    return tt::tt_metal::experimental::CreateWriter1xxDataMovementConfig();
+    return tt::tt_metal::experimental::CreateWriterGen1DataMovementConfig();
 }
 
 }  // namespace ttnn


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
When https://github.com/tenstorrent/tt-metal/pull/49516 was submitted, we decided based on review comments to use the "Gen1" and "Gen2" terminology rather than "1xx" and "2xx", which reviewers found confusing.

The helper methods `CreateReader1xxDataMovementConfig` and `CreateWriter1xxDataMovementConfig` were accidentally left on 1xx naming scheme. This PR renames them to `CreateReaderGen1DataMovementConfig` and `CreateWriterGen1DataMovementConfig`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/fix-wrong-names)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/fix-wrong-names)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/fix-wrong-names)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/fix-wrong-names)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=akertesz/fix-wrong-names)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:akertesz/fix-wrong-names)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/fix-wrong-names)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/fix-wrong-names)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/fix-wrong-names)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/fix-wrong-names)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/fix-wrong-names)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/fix-wrong-names)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/fix-wrong-names)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/fix-wrong-names)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/fix-wrong-names)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/fix-wrong-names)