### PR TITLE
[Cleanup] Remove deprecated use_legacy flag from ttnn.std/ttnn.var

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reduction/generic/generic_reductions.cpp
@@ -729,8 +729,7 @@ Tensor std(
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
     float scalar,
     bool correction,
-    const std::optional<CoreRangeSet>& sub_core_grids,
-    bool /*use_legacy - deprecated and non-functional, kept for API compatibility*/) {
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     return operations::experimental::quasar::reduce<reduction_common::ReduceType::Std>(
         input_tensor_arg,
         dim_arg,
@@ -750,8 +749,7 @@ Tensor var(
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
     float scalar,
     bool correction,
-    const std::optional<CoreRangeSet>& sub_core_grids,
-    bool /*use_legacy - deprecated and non-functional, kept for API compatibility*/) {
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     return operations::experimental::quasar::reduce<reduction_common::ReduceType::Var>(
         input_tensor_arg,
         dim_arg,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reduction/generic/generic_reductions.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reduction/generic/generic_reductions.hpp
@@ -64,8 +64,6 @@ Tensor min(
     bool correction = true,
     const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 
-// use_legacy is deprecated and non-functional: the Welford implementation is always
-// used. The parameter is kept only for API compatibility and will be removed.
 Tensor std(
     const Tensor& input_tensor_arg,
     const std::optional<std::variant<int, int64_t, ttsl::SmallVector<int>>>& dim_arg = std::nullopt,
@@ -74,11 +72,8 @@ Tensor std(
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
     float scalar = 1.0f,
     bool correction = true,
-    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
-    bool use_legacy = false);
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 
-// use_legacy is deprecated and non-functional: the Welford implementation is always
-// used. The parameter is kept only for API compatibility and will be removed.
 Tensor var(
     const Tensor& input_tensor_arg,
     const std::optional<std::variant<int, int64_t, ttsl::SmallVector<int>>>& dim_arg = std::nullopt,
@@ -87,7 +82,6 @@ Tensor var(
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
     float scalar = 1.0f,
     bool correction = true,
-    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
-    bool use_legacy = false);
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 
 }  // namespace ttnn::operations::experimental::quasar

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -749,8 +749,7 @@ Tensor std(
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
     float scalar,
     bool correction,
-    const std::optional<CoreRangeSet>& sub_core_grids,
-    bool /*use_legacy - deprecated and non-functional, kept for API compatibility*/) {
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     return operations::reduction::reduce<reduction_common::ReduceType::Std>(
         input_tensor_arg,
         dim_arg,
@@ -770,8 +769,7 @@ Tensor var(
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
     float scalar,
     bool correction,
-    const std::optional<CoreRangeSet>& sub_core_grids,
-    bool /*use_legacy - deprecated and non-functional, kept for API compatibility*/) {
+    const std::optional<CoreRangeSet>& sub_core_grids) {
     return operations::reduction::reduce<reduction_common::ReduceType::Var>(
         input_tensor_arg,
         dim_arg,

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.hpp
@@ -71,8 +71,6 @@ Tensor min(
     bool correction = true,
     const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 
-// use_legacy is deprecated and non-functional: the Welford implementation is always
-// used. The parameter is kept only for API compatibility and will be removed.
 Tensor std(
     const Tensor& input_tensor_arg,
     const std::optional<std::variant<int, int64_t, ttsl::SmallVector<int>>>& dim_arg = std::nullopt,
@@ -81,11 +79,8 @@ Tensor std(
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
     float scalar = 1.0f,
     bool correction = true,
-    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
-    bool use_legacy = false);
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 
-// use_legacy is deprecated and non-functional: the Welford implementation is always
-// used. The parameter is kept only for API compatibility and will be removed.
 Tensor var(
     const Tensor& input_tensor_arg,
     const std::optional<std::variant<int, int64_t, ttsl::SmallVector<int>>>& dim_arg = std::nullopt,
@@ -94,7 +89,6 @@ Tensor var(
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
     float scalar = 1.0f,
     bool correction = true,
-    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt,
-    bool use_legacy = false);
+    const std::optional<CoreRangeSet>& sub_core_grids = std::nullopt);
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/reduction/generic/std_var_reductions_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/std_var_reductions_nanobind.cpp
@@ -34,7 +34,6 @@ static std::string get_std_var_reduction_doc(const char* op_name, const char* qu
             scalar (float, optional): A scaling factor to be applied to the input tensor. Defaults to `1.0`.
             correction (bool, optional): Whether to apply Bessel's correction (i.e. N-1). Defaults to `True`.
             sub_core_grids (ttnn.CoreRangeSet, optional): Subcore grids to use for the operation. Defaults to `None`, which will use all cores.
-            use_legacy (bool, optional): Deprecated and non-functional. The numerically stable Welford algorithm is always used. This argument is ignored and will be removed at some point. Defaults to False.
 
         Returns:
             ttnn.Tensor: the output tensor.
@@ -79,8 +78,7 @@ void bind_std_var_reductions(nb::module_& mod) {
         nb::arg("compute_kernel_config") = nb::none(),
         nb::arg("scalar") = 1.0f,
         nb::arg("correction") = true,
-        nb::arg("sub_core_grids") = nb::none(),
-        nb::arg("use_legacy") = false);
+        nb::arg("sub_core_grids") = nb::none());
 
     const auto var_doc = get_std_var_reduction_doc("var", "ttnn.var");
     ttnn::bind_function<"var">(
@@ -95,8 +93,7 @@ void bind_std_var_reductions(nb::module_& mod) {
         nb::arg("compute_kernel_config") = nb::none(),
         nb::arg("scalar") = 1.0f,
         nb::arg("correction") = true,
-        nb::arg("sub_core_grids") = nb::none(),
-        nb::arg("use_legacy") = false);
+        nb::arg("sub_core_grids") = nb::none());
 }
 
 }  // namespace ttnn::operations::reduction::detail


### PR DESCRIPTION
## Summary
 
- Resolves: #46651
- Removes the deprecated, non-functional `use_legacy` parameter from `ttnn.std` and `ttnn.var` - from both the C++ signatures and the nanobind bindings, along with its docstring entry.
 
## Problem Description
 
#46692 made the Welford implementation the only code path for `ttnn.std`/`ttnn.var` and turned `use_legacy` into a no-op. That PR intentionally **kept** the parameter for a 30-day API-compatibility window and marked it deprecated in the docstring (*"non-functional... will be removed at some point"*).
 
- The grace window has elapsed, so this follow-up removes the parameter for good.
- The flag did nothing - it was accepted, ignored, and Welford always ran regardless of its value.
 
## What's Changed
 
Removed `use_legacy` from the three places it still lived:
 
- `generic_reductions.hpp` - dropped the trailing `bool use_legacy = false` param (and its now-stale comment) from the `std` and `var` declarations.
- `generic_reductions.cpp` - dropped the matching unused param from the `std` and `var` definitions.
- `std_var_reductions_nanobind.cpp` - dropped `nb::arg("use_legacy") = false` from both bindings and removed the `use_legacy` line from the shared docstring.
 
No behavior change: `std`/`var` continue to run through the same `reduce<ReduceType::Std/Var>()` path. Confirmed no callers (C++ or Python) pass `use_legacy`.
 
## Tests
 
No new tests needed - `#46692` already stripped all `use_legacy` parametrizations from the reduction suites. Re-ran the existing `std`/`var` coverage to confirm the signature change is behavior-neutral:
 
- `tests/ttnn/unit_tests/operations/reduce/test_reduction.py` - `test_std`, `test_var`, `test_var_fp32_translation_invariance`, `test_var_fp32_doscale_wt_gt_1`
 
**Result:** `266 passed, 0 failed` on `wormhole_b0`.
 
```bash
pytest tests/ttnn/unit_tests/operations/reduce/test_reduction.py -k "test_std or test_var"
```
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/remove-legacy-flag-46651)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/remove-legacy-flag-46651)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/remove-legacy-flag-46651)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/remove-legacy-flag-46651)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ign/remove-legacy-flag-46651)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ign/remove-legacy-flag-46651)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/remove-legacy-flag-46651)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/remove-legacy-flag-46651)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/remove-legacy-flag-46651)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/remove-legacy-flag-46651)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/remove-legacy-flag-46651)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/remove-legacy-flag-46651)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/remove-legacy-flag-46651)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/remove-legacy-flag-46651)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/remove-legacy-flag-46651)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/remove-legacy-flag-46651)