### PR TITLE
[Bug fix] ROW_MAJOR ttnn.typecast

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_copy_ops.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_copy_ops.py
@@ -438,6 +438,61 @@ def test_typecast_row_major(shape, memory_config, input_dtype, output_dtype, dev
 
 
 @pytest.mark.parametrize(
+    "input_dtype",
+    (
+        ttnn.bfloat16,
+        ttnn.float32,
+    ),
+    ids=[
+        "BFLOAT16",
+        "FLOAT32",
+    ],
+)
+@pytest.mark.parametrize(
+    "output_dtype",
+    (
+        ttnn.int32,
+        ttnn.bfloat16,
+        ttnn.float32,
+    ),
+    ids=[
+        "INT32",
+        "BFLOAT16",
+        "FLOAT32",
+    ],
+)
+def test_typecast_row_major_short_row_is_deterministic(input_dtype, output_dtype, device):
+    """Regression for CB page overlap when a row is shorter than one hardware tile."""
+    if input_dtype == output_dtype:
+        pytest.skip("Input and output data types are the same")
+    torch.manual_seed(54321)
+    torch_input = torch.rand((1, 1, 361, 512), dtype=get_ttnn_torch_dtype(input_dtype))
+    expected = torch_input.to(get_ttnn_torch_dtype(output_dtype))
+    input_tensor = ttnn.from_torch(
+        torch_input,
+        dtype=input_dtype,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    first_output = None
+    for run_idx in range(5):
+        output = ttnn.typecast(
+            input_tensor,
+            dtype=output_dtype,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        torch_output = ttnn.to_torch(output)
+
+        assert torch.equal(torch_output, expected), f"Incorrect output on run {run_idx}"
+        if first_output is None:
+            first_output = torch_output
+        else:
+            assert torch.equal(torch_output, first_output), f"Non-deterministic output on run {run_idx}"
+
+
+@pytest.mark.parametrize(
     "shape",
     [
         (1, 32, 64),

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_rm_chunked_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_rm_chunked_program_factory.cpp
@@ -21,23 +21,24 @@ struct ChunkSizeConfig {
     uint32_t output_full_chunk_size_bytes;         // actual bytes written to DRAM per full chunk
     uint32_t input_partial_chunk_size_bytes;       // actual bytes read from DRAM for partial chunk
     uint32_t output_partial_chunk_size_bytes;      // actual bytes written to DRAM for partial chunk
-    uint32_t padded_input_full_chunk_size_bytes;   // CB page size (rounded up to 32-element boundary)
-    uint32_t padded_output_full_chunk_size_bytes;  // CB page size (rounded up to 32-element boundary)
+    uint32_t padded_input_full_chunk_size_bytes;   // CB page size (one full hardware tile)
+    uint32_t padded_output_full_chunk_size_bytes;  // CB page size (one full hardware tile)
     uint32_t full_chunks_per_row;
     uint32_t partial_chunks_per_row;
 };
 
 ChunkSizeConfig calculate_chunk_config(
     uint32_t row_width_elements, uint32_t input_element_size, uint32_t output_element_size) {
-    constexpr uint32_t max_elements_per_chunk = 1024;
+    constexpr uint32_t max_elements_per_chunk = TILE_HW;
     const uint32_t elements_per_full_chunk = std::min(max_elements_per_chunk, row_width_elements);
 
     // Actual chunk sizes in bytes (for DRAM reads/writes)
     const uint32_t input_full_chunk_size_bytes = elements_per_full_chunk * input_element_size;
     const uint32_t output_full_chunk_size_bytes = elements_per_full_chunk * output_element_size;
 
-    // CB page sizes: round up to next multiple of 32 elements for the unpacker.
-    const uint32_t padded_full_elements = tt::align(elements_per_full_chunk, 32u);
+    // copy_tile and pack_tile always access a full hardware tile. Keep each CB page at least
+    // that large so an LLK operation cannot cross into the next double-buffered page.
+    constexpr uint32_t padded_full_elements = TILE_HW;
     const uint32_t padded_input_full_chunk_size_bytes = padded_full_elements * input_element_size;
     const uint32_t padded_output_full_chunk_size_bytes = padded_full_elements * output_element_size;
 


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
https://github.com/tenstorrent/tt-metal/issues/49361

For width 512, the factory allocates CB pages for 512 elements, but copy_tile()/pack_tile() operate on a default 32x32 tile - 1024 elements. Each LLK invocation therefore crosses into the next double-buffered page. The CB accounting still reserves/pushes one undersized page, so concurrent reader, compute, and writer kernels can overwrite data.

Always allocate full tile using TILE_HW constant.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vlad/fix-p0-typecast)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vlad/fix-p0-typecast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vlad/fix-p0-typecast)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vlad/fix-p0-typecast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=vlad/fix-p0-typecast)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:vlad/fix-p0-typecast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vlad/fix-p0-typecast)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vlad/fix-p0-typecast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vlad/fix-p0-typecast)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vlad/fix-p0-typecast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vlad/fix-p0-typecast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vlad/fix-p0-typecast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vlad/fix-p0-typecast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vlad/fix-p0-typecast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vlad/fix-p0-typecast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vlad/fix-p0-typecast)