### PR TITLE
[LLK][test] Cover experimental mul_reduce_scalar LLK (Blackhole)

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/test_mul_reduce_scalar.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_mul_reduce_scalar.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Fused multiply + reduce-to-scalar LLK test (experimental, Blackhole only).
+
+Exercises the experimental ``mul_reduce_scalar`` LLKs
+(``llk_math_mul_reduce_scalar.h`` / ``llk_unpack_mul_reduce_scalar.h``):
+
+    result = sum_over_all_tiles_and_elements(A * B)
+
+stored in element ``[0]`` of a single output tile. The packer applies the
+REDUCE_SCALAR mask, so every other output datum is zero.
+
+Kernel B is held at 1.0 (matching the on-silicon gtest and the
+``fuser_config/fpu_reduce_scalar.yaml`` recipe), so the multiply reduces to
+``sum(A)`` and the golden is the per-tile GAPOOL scalar reduce accumulated
+across tiles. Coverage: bf16 (num_tiles up to 8, matching DEST half-sync
+capacity) plus native fp32 DEST (up to 4 tiles), for HiFi2/HiFi4.
+"""
+
+import pytest
+import torch
+from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
+from helpers.format_config import DataFormat
+from helpers.llk_params import (
+    DestAccumulation,
+    MathFidelity,
+    format_dict,
+)
+from helpers.param_config import input_output_formats, parametrize
+from helpers.stimuli_config import StimuliConfig
+from helpers.stimuli_generator import generate_stimuli
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import MATH_FIDELITY, TILE_COUNT
+from helpers.tile_shape import construct_tile_shape
+from helpers.utils import passed_test
+
+# 32x32 bf16 tile: 4 faces of 16x16.
+ELEMENTS_PER_TILE = 1024
+TILE_DIMENSIONS = [32, 32]
+
+
+def _dest_acc_for_output(output_format):
+    """Native fp32 DEST is required whenever the output is Float32."""
+    return (
+        DestAccumulation.Yes
+        if output_format == DataFormat.Float32
+        else DestAccumulation.No
+    )
+
+
+def _num_tiles_for_dest(dest_acc):
+    """DEST half-sync holds 8 bf16 tiles or 4 fp32 tiles; all products of the
+    multiply phase must be resident before the reduce phase consumes them."""
+    return [1, 2, 3, 7, 8] if dest_acc == DestAccumulation.No else [1, 2, 3, 4]
+
+
+@parametrize(
+    formats=input_output_formats(
+        [DataFormat.Float16_b, DataFormat.Float32], same=False
+    ),
+    math_fidelity=[MathFidelity.HiFi2, MathFidelity.HiFi4],
+    num_tiles=[1, 2, 3, 4, 7, 8],
+)
+def test_mul_reduce_scalar(formats, math_fidelity, num_tiles):
+    if get_chip_architecture() != ChipArchitecture.BLACKHOLE:
+        pytest.skip("mul_reduce_scalar is a Blackhole-only experimental LLK")
+
+    # Inputs are always bf16; only the DEST/output precision varies.
+    if formats.input_format != DataFormat.Float16_b:
+        pytest.skip("mul_reduce_scalar consumes bf16 inputs")
+
+    dest_acc = _dest_acc_for_output(formats.output_format)
+    if num_tiles not in _num_tiles_for_dest(dest_acc):
+        pytest.skip(f"num_tiles={num_tiles} exceeds DEST capacity for {dest_acc}")
+
+    tile_shape = construct_tile_shape(TILE_DIMENSIONS)
+    input_dimensions = [num_tiles * TILE_DIMENSIONS[0], TILE_DIMENSIONS[1]]
+
+    src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=input_dimensions,
+    )
+    # B == 1.0 everywhere (matching the on-silicon gtest and fpu_reduce_scalar.yaml):
+    # A * B == A, so the fused op reduces to sum(A) over all tiles/elements.
+    src_B = torch.ones(
+        tile_cnt_B * ELEMENTS_PER_TILE, dtype=format_dict[formats.input_format]
+    )
+
+    # Golden mirrors the on-silicon reference (test_mul_reduce_scalar.cpp): the
+    # element-wise product summed over every element of every tile, accumulated
+    # in fp32, landing in element [0]. The REDUCE_SCALAR pack mask zeros the rest.
+    # (For a single tile this equals ReduceGapoolGolden's scalar reduce.)
+    scalar = float((src_A.to(torch.float32) * src_B.to(torch.float32)).sum().item())
+    golden_tensor = torch.zeros(
+        ELEMENTS_PER_TILE, dtype=format_dict[formats.output_format]
+    )
+    golden_tensor[0] = scalar
+
+    configuration = TestConfig(
+        "sources/mul_reduce_scalar_test.cpp",
+        formats,
+        templates=[
+            MATH_FIDELITY(math_fidelity),
+        ],
+        runtimes=[
+            TILE_COUNT(num_tiles),
+        ],
+        variant_stimuli=StimuliConfig(
+            src_A,
+            formats.input_format,
+            src_B,
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=tile_cnt_A,
+            tile_count_B=tile_cnt_B,
+            tile_count_res=1,
+            sfpu=False,
+        ),
+        dest_acc=dest_acc,
+    )
+
+    res_from_L1 = configuration.run().result
+
+    assert len(res_from_L1) == len(
+        golden_tensor
+    ), f"Result length {len(res_from_L1)} != golden length {len(golden_tensor)}"
+
+    res_tensor = torch.tensor(res_from_L1, dtype=format_dict[formats.output_format])
+    assert passed_test(
+        golden_tensor, res_tensor, formats.output_format, tile_shape=tile_shape
+    ), "mul_reduce_scalar result does not match golden"

--- a/tt_metal/tt-llk/tests/python_tests/test_mul_reduce_scalar.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_mul_reduce_scalar.py
@@ -16,7 +16,9 @@ other lanes are unspecified — so the test validates the reduced scalar alone.
 Kernel B is held at 1.0 (matching the on-silicon gtest and the
 ``fuser_config/fpu_reduce_scalar.yaml`` recipe), so the multiply reduces to
 ``sum(A)``. Coverage: bf16 (num_tiles up to 8, the DEST half-sync capacity)
-plus native fp32 DEST (up to 4 tiles), for HiFi2/HiFi4.
+plus native fp32 DEST (up to 4 tiles), for HiFi2/HiFi4, across the full 32x32
+tile (num_faces=4) and the 16x32 (num_faces=2) / 16x16 (num_faces=1) "tiny
+tiles" — mirroring the on-silicon MulReduceScalarTinyTile gtest suite.
 """
 
 import pytest
@@ -28,18 +30,25 @@ from helpers.param_config import parametrize
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import StimuliSpec, generate_stimuli
 from helpers.test_config import TestConfig
-from helpers.test_variant_parameters import MATH_FIDELITY, TILE_COUNT
+from helpers.test_variant_parameters import (
+    MATH_FIDELITY,
+    NUM_FACES_C_DIM,
+    NUM_FACES_R_DIM,
+    TILE_COUNT,
+)
+from helpers.tile_shape import construct_tile_shape
 from helpers.utils import tolerances
-
-# 32x32 bf16 tile: 4 faces of 16x16.
-ELEMENTS_PER_TILE = 1024
-TILE_DIMENSIONS = [32, 32]
 
 # Inputs are always bf16; only the DEST/output precision varies.
 FORMATS = [
     InputOutputFormat(DataFormat.Float16_b, DataFormat.Float16_b),
     InputOutputFormat(DataFormat.Float16_b, DataFormat.Float32),
 ]
+
+# Full 32x32 tile (4 faces) plus the tiny tiles: 16x32 (2 faces, num_faces=2)
+# and 16x16 (1 face, num_faces=1). The reduce collapses every element to [0]
+# regardless of tile geometry.
+TILE_DIMENSIONS = [[32, 32], [16, 32], [16, 16]]
 
 
 def _dest_acc(output_format):
@@ -53,7 +62,8 @@ def _dest_acc(output_format):
 
 def _num_tiles_for_format(formats):
     """DEST half-sync holds 8 bf16 tiles or 4 fp32 tiles; every multiply-phase
-    product must be resident before the reduce phase consumes it."""
+    product must be resident before the reduce phase consumes it. The cap is in
+    DEST tile-slots, so it applies to tiny tiles too (matching the gtest)."""
     return (
         [1, 2, 3, 4]
         if _dest_acc(formats.output_format) == DestAccumulation.Yes
@@ -65,27 +75,32 @@ def _num_tiles_for_format(formats):
     formats=FORMATS,
     math_fidelity=[MathFidelity.HiFi2, MathFidelity.HiFi4],
     num_tiles=_num_tiles_for_format,
+    tile_dimensions=TILE_DIMENSIONS,
 )
-def test_mul_reduce_scalar(formats, math_fidelity, num_tiles):
+def test_mul_reduce_scalar(formats, math_fidelity, num_tiles, tile_dimensions):
     if get_chip_architecture() != ChipArchitecture.BLACKHOLE:
         pytest.skip("mul_reduce_scalar is a Blackhole-only experimental LLK")
 
+    tile_shape = construct_tile_shape(tile_dimensions)
+    elements_per_tile = tile_shape.total_tile_size()
     dest_acc = _dest_acc(formats.output_format)
-    input_dimensions = [num_tiles * TILE_DIMENSIONS[0], TILE_DIMENSIONS[1]]
+    input_dimensions = [num_tiles * tile_dimensions[0], tile_dimensions[1]]
 
     # A ~ U[0, 1] mirrors the on-silicon gtest and keeps the accumulated sum
-    # well inside bf16's dynamic range for the larger tile counts.
+    # well inside bf16's dynamic range for the larger tile counts. Passing
+    # tile_dimensions puts the generator in dense mode (real tiny-tile layout).
     src_A, tile_cnt_A, _, tile_cnt_B = generate_stimuli(
         stimuli_format_A=formats.input_format,
         input_dimensions_A=input_dimensions,
         stimuli_format_B=formats.input_format,
         input_dimensions_B=input_dimensions,
+        tile_dimensions=tile_dimensions,
         spec_A=StimuliSpec.uniform(low=0.0, high=1.0),
     )
     # B == 1.0 everywhere (matching the gtest and fpu_reduce_scalar.yaml):
     # A * B == A, so the fused op reduces to sum(A) over all tiles/elements.
     src_B = torch.ones(
-        tile_cnt_B * ELEMENTS_PER_TILE, dtype=format_dict[formats.input_format]
+        tile_cnt_B * elements_per_tile, dtype=format_dict[formats.input_format]
     )
 
     # Golden mirrors the on-silicon reference (test_mul_reduce_scalar.cpp): the
@@ -102,6 +117,8 @@ def test_mul_reduce_scalar(formats, math_fidelity, num_tiles):
         ],
         runtimes=[
             TILE_COUNT(num_tiles),
+            NUM_FACES_R_DIM(tile_shape.num_faces_r_dim, tile_shape.num_faces_r_dim),
+            NUM_FACES_C_DIM(tile_shape.num_faces_c_dim, tile_shape.num_faces_c_dim),
         ],
         variant_stimuli=StimuliConfig(
             src_A,
@@ -112,6 +129,10 @@ def test_mul_reduce_scalar(formats, math_fidelity, num_tiles):
             tile_count_A=tile_cnt_A,
             tile_count_B=tile_cnt_B,
             tile_count_res=1,
+            num_faces=tile_shape.total_num_faces(),
+            face_r_dim=tile_shape.face_r_dim,
+            tile_dimensions=tile_dimensions,
+            use_dense_tile_dimensions=True,
             sfpu=False,
         ),
         dest_acc=dest_acc,
@@ -120,8 +141,8 @@ def test_mul_reduce_scalar(formats, math_fidelity, num_tiles):
     res_from_L1 = configuration.run().result
 
     assert (
-        len(res_from_L1) == ELEMENTS_PER_TILE
-    ), f"Expected one {ELEMENTS_PER_TILE}-element output tile, got {len(res_from_L1)}"
+        len(res_from_L1) == elements_per_tile
+    ), f"Expected one {elements_per_tile}-element output tile, got {len(res_from_L1)}"
 
     # The reduced scalar lives in element [0]; every other lane is unspecified.
     device_scalar = float(res_from_L1[0])
@@ -130,5 +151,5 @@ def test_mul_reduce_scalar(formats, math_fidelity, num_tiles):
         golden_scalar
     ), (
         f"mul_reduce_scalar mismatch: device={device_scalar} golden={golden_scalar} "
-        f"(num_tiles={num_tiles}, fidelity={math_fidelity.name})"
+        f"(num_tiles={num_tiles}, tile={tile_dimensions}, fidelity={math_fidelity.name})"
     )

--- a/tt_metal/tt-llk/tests/python_tests/test_mul_reduce_scalar.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_mul_reduce_scalar.py
@@ -9,8 +9,9 @@ Exercises the experimental ``mul_reduce_scalar`` LLKs
 
     result = sum_over_all_tiles_and_elements(A * B)
 
-stored in element ``[0]`` of a single output tile. The packer applies the
-REDUCE_SCALAR mask, so every other output datum is zero.
+stored in element ``[0]`` of the output tile. Per the op's contract (Compute
+API doc + on-silicon gtest), only element ``[0]`` is defined — the packer's
+other lanes are unspecified — so the test validates the reduced scalar alone.
 
 Kernel B is held at 1.0 (matching the on-silicon gtest and the
 ``fuser_config/fpu_reduce_scalar.yaml`` recipe), so the multiply reduces to
@@ -28,8 +29,7 @@ from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import StimuliSpec, generate_stimuli
 from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import MATH_FIDELITY, TILE_COUNT
-from helpers.tile_shape import construct_tile_shape
-from helpers.utils import passed_test
+from helpers.utils import tolerances
 
 # 32x32 bf16 tile: 4 faces of 16x16.
 ELEMENTS_PER_TILE = 1024
@@ -71,7 +71,6 @@ def test_mul_reduce_scalar(formats, math_fidelity, num_tiles):
         pytest.skip("mul_reduce_scalar is a Blackhole-only experimental LLK")
 
     dest_acc = _dest_acc(formats.output_format)
-    tile_shape = construct_tile_shape(TILE_DIMENSIONS)
     input_dimensions = [num_tiles * TILE_DIMENSIONS[0], TILE_DIMENSIONS[1]]
 
     # A ~ U[0, 1] mirrors the on-silicon gtest and keeps the accumulated sum
@@ -90,15 +89,10 @@ def test_mul_reduce_scalar(formats, math_fidelity, num_tiles):
     )
 
     # Golden mirrors the on-silicon reference (test_mul_reduce_scalar.cpp): the
-    # element-wise product summed over every element of every tile, landing in
-    # element [0]; the REDUCE_SCALAR pack mask zeros the rest. Since the golden
-    # is one-hot, passed_test's PCC term is trivially 1.0 — the isclose term on
-    # element [0] is what actually validates the reduced scalar.
-    scalar = float((src_A.to(torch.float32) * src_B.to(torch.float32)).sum().item())
-    golden_tensor = torch.zeros(
-        ELEMENTS_PER_TILE, dtype=format_dict[formats.output_format]
+    # element-wise product summed over every element of every tile, in fp32.
+    golden_scalar = float(
+        (src_A.to(torch.float32) * src_B.to(torch.float32)).sum().item()
     )
-    golden_tensor[0] = scalar
 
     configuration = TestConfig(
         "sources/mul_reduce_scalar_test.cpp",
@@ -125,11 +119,16 @@ def test_mul_reduce_scalar(formats, math_fidelity, num_tiles):
 
     res_from_L1 = configuration.run().result
 
-    assert len(res_from_L1) == len(
-        golden_tensor
-    ), f"Result length {len(res_from_L1)} != golden length {len(golden_tensor)}"
+    assert (
+        len(res_from_L1) == ELEMENTS_PER_TILE
+    ), f"Expected one {ELEMENTS_PER_TILE}-element output tile, got {len(res_from_L1)}"
 
-    res_tensor = torch.tensor(res_from_L1, dtype=format_dict[formats.output_format])
-    assert passed_test(
-        golden_tensor, res_tensor, formats.output_format, tile_shape=tile_shape
-    ), "mul_reduce_scalar result does not match golden"
+    # The reduced scalar lives in element [0]; every other lane is unspecified.
+    device_scalar = float(res_from_L1[0])
+    tol = tolerances[formats.output_format]
+    assert abs(device_scalar - golden_scalar) <= tol.atol + tol.rtol * abs(
+        golden_scalar
+    ), (
+        f"mul_reduce_scalar mismatch: device={device_scalar} golden={golden_scalar} "
+        f"(num_tiles={num_tiles}, fidelity={math_fidelity.name})"
+    )

--- a/tt_metal/tt-llk/tests/python_tests/test_mul_reduce_scalar.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_mul_reduce_scalar.py
@@ -14,23 +14,18 @@ REDUCE_SCALAR mask, so every other output datum is zero.
 
 Kernel B is held at 1.0 (matching the on-silicon gtest and the
 ``fuser_config/fpu_reduce_scalar.yaml`` recipe), so the multiply reduces to
-``sum(A)`` and the golden is the per-tile GAPOOL scalar reduce accumulated
-across tiles. Coverage: bf16 (num_tiles up to 8, matching DEST half-sync
-capacity) plus native fp32 DEST (up to 4 tiles), for HiFi2/HiFi4.
+``sum(A)``. Coverage: bf16 (num_tiles up to 8, the DEST half-sync capacity)
+plus native fp32 DEST (up to 4 tiles), for HiFi2/HiFi4.
 """
 
 import pytest
 import torch
 from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
-from helpers.format_config import DataFormat
-from helpers.llk_params import (
-    DestAccumulation,
-    MathFidelity,
-    format_dict,
-)
-from helpers.param_config import input_output_formats, parametrize
+from helpers.format_config import DataFormat, InputOutputFormat
+from helpers.llk_params import DestAccumulation, MathFidelity, format_dict
+from helpers.param_config import parametrize
 from helpers.stimuli_config import StimuliConfig
-from helpers.stimuli_generator import generate_stimuli
+from helpers.stimuli_generator import StimuliSpec, generate_stimuli
 from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import MATH_FIDELITY, TILE_COUNT
 from helpers.tile_shape import construct_tile_shape
@@ -40,8 +35,14 @@ from helpers.utils import passed_test
 ELEMENTS_PER_TILE = 1024
 TILE_DIMENSIONS = [32, 32]
 
+# Inputs are always bf16; only the DEST/output precision varies.
+FORMATS = [
+    InputOutputFormat(DataFormat.Float16_b, DataFormat.Float16_b),
+    InputOutputFormat(DataFormat.Float16_b, DataFormat.Float32),
+]
 
-def _dest_acc_for_output(output_format):
+
+def _dest_acc(output_format):
     """Native fp32 DEST is required whenever the output is Float32."""
     return (
         DestAccumulation.Yes
@@ -50,50 +51,49 @@ def _dest_acc_for_output(output_format):
     )
 
 
-def _num_tiles_for_dest(dest_acc):
-    """DEST half-sync holds 8 bf16 tiles or 4 fp32 tiles; all products of the
-    multiply phase must be resident before the reduce phase consumes them."""
-    return [1, 2, 3, 7, 8] if dest_acc == DestAccumulation.No else [1, 2, 3, 4]
+def _num_tiles_for_format(formats):
+    """DEST half-sync holds 8 bf16 tiles or 4 fp32 tiles; every multiply-phase
+    product must be resident before the reduce phase consumes it."""
+    return (
+        [1, 2, 3, 4]
+        if _dest_acc(formats.output_format) == DestAccumulation.Yes
+        else [1, 2, 3, 7, 8]
+    )
 
 
 @parametrize(
-    formats=input_output_formats(
-        [DataFormat.Float16_b, DataFormat.Float32], same=False
-    ),
+    formats=FORMATS,
     math_fidelity=[MathFidelity.HiFi2, MathFidelity.HiFi4],
-    num_tiles=[1, 2, 3, 4, 7, 8],
+    num_tiles=_num_tiles_for_format,
 )
 def test_mul_reduce_scalar(formats, math_fidelity, num_tiles):
     if get_chip_architecture() != ChipArchitecture.BLACKHOLE:
         pytest.skip("mul_reduce_scalar is a Blackhole-only experimental LLK")
 
-    # Inputs are always bf16; only the DEST/output precision varies.
-    if formats.input_format != DataFormat.Float16_b:
-        pytest.skip("mul_reduce_scalar consumes bf16 inputs")
-
-    dest_acc = _dest_acc_for_output(formats.output_format)
-    if num_tiles not in _num_tiles_for_dest(dest_acc):
-        pytest.skip(f"num_tiles={num_tiles} exceeds DEST capacity for {dest_acc}")
-
+    dest_acc = _dest_acc(formats.output_format)
     tile_shape = construct_tile_shape(TILE_DIMENSIONS)
     input_dimensions = [num_tiles * TILE_DIMENSIONS[0], TILE_DIMENSIONS[1]]
 
-    src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
+    # A ~ U[0, 1] mirrors the on-silicon gtest and keeps the accumulated sum
+    # well inside bf16's dynamic range for the larger tile counts.
+    src_A, tile_cnt_A, _, tile_cnt_B = generate_stimuli(
         stimuli_format_A=formats.input_format,
         input_dimensions_A=input_dimensions,
         stimuli_format_B=formats.input_format,
         input_dimensions_B=input_dimensions,
+        spec_A=StimuliSpec.uniform(low=0.0, high=1.0),
     )
-    # B == 1.0 everywhere (matching the on-silicon gtest and fpu_reduce_scalar.yaml):
+    # B == 1.0 everywhere (matching the gtest and fpu_reduce_scalar.yaml):
     # A * B == A, so the fused op reduces to sum(A) over all tiles/elements.
     src_B = torch.ones(
         tile_cnt_B * ELEMENTS_PER_TILE, dtype=format_dict[formats.input_format]
     )
 
     # Golden mirrors the on-silicon reference (test_mul_reduce_scalar.cpp): the
-    # element-wise product summed over every element of every tile, accumulated
-    # in fp32, landing in element [0]. The REDUCE_SCALAR pack mask zeros the rest.
-    # (For a single tile this equals ReduceGapoolGolden's scalar reduce.)
+    # element-wise product summed over every element of every tile, landing in
+    # element [0]; the REDUCE_SCALAR pack mask zeros the rest. Since the golden
+    # is one-hot, passed_test's PCC term is trivially 1.0 — the isclose term on
+    # element [0] is what actually validates the reduced scalar.
     scalar = float((src_A.to(torch.float32) * src_B.to(torch.float32)).sum().item())
     golden_tensor = torch.zeros(
         ELEMENTS_PER_TILE, dtype=format_dict[formats.output_format]

--- a/tt_metal/tt-llk/tests/sources/mul_reduce_scalar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/mul_reduce_scalar_test.cpp
@@ -29,11 +29,11 @@ std::uint32_t math_sync_tile_dst_index = 0;
 
 static constexpr DstSync DST_SYNC = DstSync::SyncHalf;
 
-// The reduce runs over the full 32x32 tile: 2x2 faces of 16x16 (FACE_R_DIM x
-// FACE_C_DIM). Declared once and shared by all three threads; this is exactly
-// ckernel::DEFAULT_TENSOR_SHAPE ({MAX_FACE_R_DIM, MAX_FACE_C_DIM,
-// MAX_NUM_FACES_R_DIM, MAX_NUM_FACES_C_DIM}).
-static constexpr ckernel::TensorShape TENSOR_SHAPE = ckernel::DEFAULT_TENSOR_SHAPE;
+// The tile geometry is parametrized by the Python test: the full 32x32 tile
+// (2x2 faces, num_faces=4) plus the 16x32 (1x2, num_faces=2) and 16x16 (1x1,
+// num_faces=1) "tiny tiles". Only num_faces_{r,c}_dim vary; face_r_dim /
+// face_c_dim stay at the full 16 (FACE_R_DIM / FACE_C_DIM). Each thread rebuilds
+// the shape from the runtime params, matching the reduce_test.cpp idiom.
 
 #ifdef LLK_TRISC_UNPACK
 
@@ -42,21 +42,30 @@ static constexpr ckernel::TensorShape TENSOR_SHAPE = ckernel::DEFAULT_TENSOR_SHA
 #include "llk_unpack_common.h"
 #include "params.h"
 
-// 32x32 tile has 4 faces; the reduce phase reuses the whole tile as source.
-// Same 4-face count TENSOR_SHAPE encodes (MAX_NUM_FACES_R_DIM * MAX_NUM_FACES_C_DIM).
-static constexpr std::uint32_t NUM_FACES = ckernel::MAX_NUM_FACES;
-
 void run_kernel(RUNTIME_PARAMETERS params)
 {
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
+    const ckernel::TensorShape tensor_shape = {
+        static_cast<std::uint8_t>(FACE_R_DIM),
+        static_cast<std::uint8_t>(FACE_C_DIM),
+        static_cast<std::uint8_t>(params.num_faces_r_dim_A),
+        static_cast<std::uint8_t>(params.num_faces_c_dim_A)};
+
     // compute_kernel_hw_startup
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
-        formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, NUM_FACES, NUM_FACES);
+        formats.unpack_A_src,
+        formats.unpack_B_src,
+        formats.unpack_A_dst,
+        formats.unpack_B_dst,
+        tensor_shape.face_r_dim,
+        tensor_shape.face_r_dim,
+        tensor_shape.total_num_faces(),
+        tensor_shape.total_num_faces());
 
     // mul_reduce_scalar_init: unpack A and B, no broadcast/transpose.
-    _llk_unpack_AB_init_<BroadcastType::NONE>(TENSOR_SHAPE, ckernel::Transpose::None);
+    _llk_unpack_AB_init_<BroadcastType::NONE>(tensor_shape, ckernel::Transpose::None);
 
     // Multiply phase: stream A[i] and B[i] into SrcA/SrcB for each tile.
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
@@ -88,7 +97,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    const std::uint32_t tile_cnt = params.TILE_CNT;
+    const std::uint32_t tile_cnt            = params.TILE_CNT;
+    const ckernel::TensorShape tensor_shape = {
+        static_cast<std::uint8_t>(FACE_R_DIM),
+        static_cast<std::uint8_t>(FACE_C_DIM),
+        static_cast<std::uint8_t>(params.num_faces_r_dim_A),
+        static_cast<std::uint8_t>(params.num_faces_c_dim_A)};
 
     // compute_kernel_hw_startup
     _llk_math_pack_sync_init_<DST_SYNC, is_fp32_dest_acc_en>();
@@ -100,7 +114,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     // mul_reduce_scalar_init: element-wise multiply, no accumulate-to-dest.
     _llk_math_eltwise_binary_init_<EltwiseBinaryType::ELWMUL, BroadcastType::NONE, MATH_FIDELITY, EltwiseBinaryReuseDestType::NONE>(
-        TENSOR_SHAPE, 0 /* acc_to_dest */);
+        tensor_shape, 0 /* acc_to_dest */);
 
     _llk_math_wait_for_dest_available_<DST_SYNC>();
 
@@ -114,7 +128,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             DST_SYNC,
             is_fp32_dest_acc_en,
             MATH_FIDELITY,
-            EltwiseBinaryReuseDestType::NONE>(TENSOR_SHAPE, i, true /* clear_fp32_dst_acc */);
+            EltwiseBinaryReuseDestType::NONE>(tensor_shape, i, true /* clear_fp32_dst_acc */);
     }
 
     // Step 3 - initialize the reduce phase (addr mods + counter reset).
@@ -130,11 +144,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     // Step 6 - column-reduce every tile, accumulating into DEST[0].
     // (narrow_tile / num_faces are derived internally from the TensorShape.)
-    _llk_math_mul_reduce_column_<MATH_FIDELITY>(0 /* dst_index */, TENSOR_SHAPE);
+    _llk_math_mul_reduce_column_<MATH_FIDELITY>(0 /* dst_index */, tensor_shape);
     for (std::uint32_t i = 1; i < tile_cnt; ++i)
     {
         _llk_math_mul_reduce_scalar_move_dest_to_src_<EltwiseBinaryReuseDestType::DEST_TO_SRCA>(i);
-        _llk_math_mul_reduce_column_<MATH_FIDELITY>(0 /* dst_index */, TENSOR_SHAPE);
+        _llk_math_mul_reduce_column_<MATH_FIDELITY>(0 /* dst_index */, tensor_shape);
     }
 
     // Step 7 - collapse DEST[0] to a single scalar.
@@ -159,22 +173,28 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    const std::uint32_t tile_size = TENSOR_SHAPE.total_tensor_size();
-    const std::uint32_t num_faces = TENSOR_SHAPE.total_num_faces();
-    const bool partial_face       = TENSOR_SHAPE.face_r_dim < FACE_R_DIM;
-    const bool narrow_tile        = TENSOR_SHAPE.num_faces_c_dim == 1;
+    const ckernel::TensorShape tensor_shape = {
+        static_cast<std::uint8_t>(FACE_R_DIM),
+        static_cast<std::uint8_t>(FACE_C_DIM),
+        static_cast<std::uint8_t>(params.num_faces_r_dim_A),
+        static_cast<std::uint8_t>(params.num_faces_c_dim_A)};
+
+    const std::uint32_t tile_size = tensor_shape.total_tensor_size();
+    const std::uint32_t num_faces = tensor_shape.total_num_faces();
+    const bool partial_face       = tensor_shape.face_r_dim < FACE_R_DIM;
+    const bool narrow_tile        = tensor_shape.num_faces_c_dim == 1;
 
     // compute_kernel_hw_startup
     _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, PackMode::Default>(
-        formats.pack_src, formats.pack_dst, tile_size, TENSOR_SHAPE.face_r_dim, TENSOR_SHAPE.total_col_dim(), num_faces, partial_face, narrow_tile);
+        formats.pack_src, formats.pack_dst, tile_size, tensor_shape.face_r_dim, tensor_shape.total_col_dim(), num_faces, partial_face, narrow_tile);
 
     _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(
-        formats.pack_dst, TENSOR_SHAPE.face_r_dim, TENSOR_SHAPE.total_col_dim(), num_faces, partial_face, narrow_tile);
+        formats.pack_dst, tensor_shape.face_r_dim, tensor_shape.total_col_dim(), num_faces, partial_face, narrow_tile);
 
     // mul_reduce_scalar_tile step 5: mask so only the reduced scalar [0] is packed.
     _llk_pack_reduce_mask_config_<ReduceDim::REDUCE_SCALAR>();
 
-    _llk_pack_dest_init_wrapper_<DST_SYNC, is_fp32_dest_acc_en, PackMode::Default>(TENSOR_SHAPE.face_r_dim, narrow_tile);
+    _llk_pack_dest_init_wrapper_<DST_SYNC, is_fp32_dest_acc_en, PackMode::Default>(tensor_shape.face_r_dim, narrow_tile);
 
     // Single output tile: the scalar lives in DEST[0].
     _llk_packer_wait_for_math_done_();

--- a/tt_metal/tt-llk/tests/sources/mul_reduce_scalar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/mul_reduce_scalar_test.cpp
@@ -44,7 +44,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    const ckernel::TensorShape tensor_shape = {FACE_R_DIM, FACE_C_DIM, 2, 2};
+    const ckernel::TensorShape tensor_shape = {FACE_R_DIM, FACE_C_DIM, 2 /* num_faces_r_dim */, 2 /* num_faces_c_dim */};
 
     // compute_kernel_hw_startup
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
@@ -84,7 +84,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
     const std::uint32_t tile_cnt            = params.TILE_CNT;
-    const ckernel::TensorShape tensor_shape = {FACE_R_DIM, FACE_C_DIM, 2, 2};
+    const ckernel::TensorShape tensor_shape = {FACE_R_DIM, FACE_C_DIM, 2 /* num_faces_r_dim */, 2 /* num_faces_c_dim */};
 
     // compute_kernel_hw_startup
     _llk_math_pack_sync_init_<DST_SYNC, is_fp32_dest_acc_en>();
@@ -117,7 +117,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_math_mul_reduce_scalar_init_<is_fp32_dest_acc_en, MATH_FIDELITY, false /* enforce_fp32_accumulation */>();
 
     // Step 4 - stage tile 0 into SrcA, fill SrcB with the scaler, clear DEST[0].
-    _llk_math_mul_reduce_scalar_move_dest_to_src_<EltwiseBinaryReuseDestType::DEST_TO_SRCA>(0);
+    _llk_math_mul_reduce_scalar_move_dest_to_src_<EltwiseBinaryReuseDestType::DEST_TO_SRCA>(0 /* idst */);
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::_calculate_fill_<false /* APPROX */, 2 /* ITERATIONS */>, 0 /* dst_index */, VectorMode::RC_custom, REDUCE_SCALER);
     _llk_math_mul_reduce_scalar_move_dest_to_src_<EltwiseBinaryReuseDestType::DEST_TO_SRCB>(0);
@@ -126,11 +126,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     // Step 6 - column-reduce every tile, accumulating into DEST[0].
     // (narrow_tile / num_faces are derived internally from the TensorShape.)
-    _llk_math_mul_reduce_column_<MATH_FIDELITY>(0, tensor_shape);
+    _llk_math_mul_reduce_column_<MATH_FIDELITY>(0 /* dst_index */, tensor_shape);
     for (std::uint32_t i = 1; i < tile_cnt; ++i)
     {
         _llk_math_mul_reduce_scalar_move_dest_to_src_<EltwiseBinaryReuseDestType::DEST_TO_SRCA>(i);
-        _llk_math_mul_reduce_column_<MATH_FIDELITY>(0, tensor_shape);
+        _llk_math_mul_reduce_column_<MATH_FIDELITY>(0 /* dst_index */, tensor_shape);
     }
 
     // Step 7 - collapse DEST[0] to a single scalar.
@@ -155,7 +155,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    const ckernel::TensorShape tensor_shape = {FACE_R_DIM, FACE_C_DIM, 2, 2};
+    const ckernel::TensorShape tensor_shape = {FACE_R_DIM, FACE_C_DIM, 2 /* num_faces_r_dim */, 2 /* num_faces_c_dim */};
 
     const std::uint32_t tile_size = tensor_shape.total_tensor_size();
     const std::uint32_t num_faces = tensor_shape.total_num_faces();
@@ -176,7 +176,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     // Single output tile: the scalar lives in DEST[0].
     _llk_packer_wait_for_math_done_();
-    _llk_pack_<DST_SYNC, is_fp32_dest_acc_en, ckernel::PackMode::Default>(0, L1_ADDRESS(params.buffer_Res[0]));
+    _llk_pack_<DST_SYNC, is_fp32_dest_acc_en, ckernel::PackMode::Default>(0 /* dst_index */, L1_ADDRESS(params.buffer_Res[0]));
     _llk_pack_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
 
     // mul_reduce_scalar_uninit

--- a/tt_metal/tt-llk/tests/sources/mul_reduce_scalar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/mul_reduce_scalar_test.cpp
@@ -28,10 +28,6 @@ std::uint32_t pack_sync_tile_dst_ptr   = 0;
 std::uint32_t math_sync_tile_dst_index = 0;
 
 static constexpr DstSync DST_SYNC = DstSync::SyncHalf;
-// The reduce phase reuses DEST as source, so the whole tile (4 faces) is live.
-static constexpr std::uint32_t NUM_FACES = 4;
-// Scaler multiplier applied to the reduction (matches the Compute API default).
-static constexpr float REDUCE_SCALER = 1.0f;
 
 #ifdef LLK_TRISC_UNPACK
 
@@ -39,6 +35,9 @@ static constexpr float REDUCE_SCALER = 1.0f;
 #include "llk_unpack_AB.h"
 #include "llk_unpack_common.h"
 #include "params.h"
+
+// 32x32 tile has 4 faces; the reduce phase reuses the whole tile as source.
+static constexpr std::uint32_t NUM_FACES = 4;
 
 void run_kernel(RUNTIME_PARAMETERS params)
 {
@@ -75,6 +74,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #include "llk_math_eltwise_unary_sfpu_params.h"
 #include "params.h"
 #include "sfpu/ckernel_sfpu_fill.h"
+
+// Scaler multiplier applied to the reduction (matches the Compute API default).
+static constexpr float REDUCE_SCALER = 1.0f;
 
 void run_kernel(RUNTIME_PARAMETERS params)
 {

--- a/tt_metal/tt-llk/tests/sources/mul_reduce_scalar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/mul_reduce_scalar_test.cpp
@@ -1,0 +1,184 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Fused multiply + reduce-to-scalar LLK test (experimental, Blackhole only).
+//
+// Mirrors the ttnn compute-kernel flow of ckernel::mul_reduce_scalar_tile:
+//   1. Multiply phase: C[i] = A[i] * B[i] element-wise (ELWMUL) into DEST tiles.
+//   2. Switch UNPACK -> reduce phase (DEST reused as SrcA/SrcB via MOVD2A/MOVD2B).
+//   3. Column-reduce every tile with GAPOOL, accumulating into DEST[0].
+//   4. Collapse DEST[0] to a single scalar (transpose + GAPOOL).
+// The packer applies the REDUCE_SCALAR mask so only element [0] is emitted.
+//
+// This expands the Compute API (api/compute/experimental/mul_reduce_scalar.h)
+// into its underlying _llk_* calls so the kernel runs inside the tt-llk harness.
+
+#include <cstdint>
+
+#include "ckernel.h"
+#include "llk_defs.h"
+#include "tensor_shape.h"
+
+using namespace ckernel;
+
+// Globals
+std::uint32_t unp_cfg_context          = 0;
+std::uint32_t pack_sync_tile_dst_ptr   = 0;
+std::uint32_t math_sync_tile_dst_index = 0;
+
+static constexpr DstSync DST_SYNC = DstSync::SyncHalf;
+// The reduce phase reuses DEST as source, so the whole tile (4 faces) is live.
+static constexpr std::uint32_t NUM_FACES = 4;
+// Scaler multiplier applied to the reduction (matches the Compute API default).
+static constexpr float REDUCE_SCALER = 1.0f;
+
+#ifdef LLK_TRISC_UNPACK
+
+#include "experimental/llk_unpack_mul_reduce_scalar.h"
+#include "llk_unpack_AB.h"
+#include "llk_unpack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    const ckernel::TensorShape tensor_shape = {FACE_R_DIM, FACE_C_DIM, 2, 2};
+
+    // compute_kernel_hw_startup
+    _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
+        formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, NUM_FACES, NUM_FACES);
+
+    // mul_reduce_scalar_init: unpack A and B, no broadcast/transpose.
+    _llk_unpack_AB_init_<BroadcastType::NONE>(tensor_shape, ckernel::Transpose::None);
+
+    // Multiply phase: stream A[i] and B[i] into SrcA/SrcB for each tile.
+    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+    {
+        _llk_unpack_AB_<BroadcastType::NONE>(L1_ADDRESS(params.buffer_A[i]), L1_ADDRESS(params.buffer_B[i]));
+    }
+
+    // Switch to the reduce phase: reset counters and re-arm SrcA/SrcB DVALID so
+    // MATH can reuse DEST as source operands.
+    _llk_unpack_mul_reduce_scalar_switch_to_reduce_();
+}
+
+#endif
+
+#ifdef LLK_TRISC_MATH
+
+#include "experimental/llk_math_mul_reduce_scalar.h"
+#include "llk_math_common.h"
+#include "llk_math_eltwise_binary.h"
+#include "llk_math_eltwise_unary_sfpu_params.h"
+#include "params.h"
+#include "sfpu/ckernel_sfpu_fill.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    const std::uint32_t tile_cnt            = params.TILE_CNT;
+    const ckernel::TensorShape tensor_shape = {FACE_R_DIM, FACE_C_DIM, 2, 2};
+
+    // compute_kernel_hw_startup
+    _llk_math_pack_sync_init_<DST_SYNC, is_fp32_dest_acc_en>();
+    _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
+    // compute_kernel_hw_startup programs the SFPU config register once per
+    // kernel; this standalone harness bypasses it, so run the idempotent
+    // once-init before the reduce-phase _calculate_fill_ SFPU stores.
+    _llk_math_eltwise_unary_sfpu_init_once_();
+
+    // mul_reduce_scalar_init: element-wise multiply, no accumulate-to-dest.
+    _llk_math_eltwise_binary_init_<EltwiseBinaryType::ELWMUL, BroadcastType::NONE, MATH_FIDELITY, EltwiseBinaryReuseDestType::NONE>(
+        tensor_shape, 0 /* acc_to_dest */);
+
+    _llk_math_wait_for_dest_available_<DST_SYNC>();
+
+    // Step 1 - multiply phase: C[i] = A[i] * B[i] into DEST[i].
+    for (std::uint32_t i = 0; i < tile_cnt; ++i)
+    {
+        LLK_ASSERT((i < get_dest_max_tiles<DST_SYNC, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()), "Multiply tile index exceeds maximum destination tiles");
+        _llk_math_eltwise_binary_<
+            EltwiseBinaryType::ELWMUL,
+            BroadcastType::NONE,
+            DST_SYNC,
+            is_fp32_dest_acc_en,
+            MATH_FIDELITY,
+            EltwiseBinaryReuseDestType::NONE>(tensor_shape, i, true /* clear_fp32_dst_acc */);
+    }
+
+    // Step 3 - initialize the reduce phase (addr mods + counter reset).
+    _llk_math_mul_reduce_scalar_init_<is_fp32_dest_acc_en, MATH_FIDELITY, false /* enforce_fp32_accumulation */>();
+
+    // Step 4 - stage tile 0 into SrcA, fill SrcB with the scaler, clear DEST[0].
+    _llk_math_mul_reduce_scalar_move_dest_to_src_<EltwiseBinaryReuseDestType::DEST_TO_SRCA>(0);
+    _llk_math_eltwise_unary_sfpu_params_(
+        ckernel::sfpu::_calculate_fill_<false /* APPROX */, 2 /* ITERATIONS */>, 0 /* dst_index */, VectorMode::RC_custom, REDUCE_SCALER);
+    _llk_math_mul_reduce_scalar_move_dest_to_src_<EltwiseBinaryReuseDestType::DEST_TO_SRCB>(0);
+    _llk_math_eltwise_unary_sfpu_params_(
+        ckernel::sfpu::_calculate_fill_<false /* APPROX */, 2 /* ITERATIONS */>, 0 /* dst_index */, VectorMode::RC_custom, 0.0f /* clear DEST[0] */);
+
+    // Step 6 - column-reduce every tile, accumulating into DEST[0].
+    // (narrow_tile / num_faces are derived internally from the TensorShape.)
+    _llk_math_mul_reduce_column_<MATH_FIDELITY>(0, tensor_shape);
+    for (std::uint32_t i = 1; i < tile_cnt; ++i)
+    {
+        _llk_math_mul_reduce_scalar_move_dest_to_src_<EltwiseBinaryReuseDestType::DEST_TO_SRCA>(i);
+        _llk_math_mul_reduce_column_<MATH_FIDELITY>(0, tensor_shape);
+    }
+
+    // Step 7 - collapse DEST[0] to a single scalar.
+    _llk_math_mul_reduce_scalar_<MATH_FIDELITY>();
+
+    // Step 8 - clear DVALID flags.
+    _llk_math_mul_reduce_scalar_clear_dvalid_();
+
+    _llk_math_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
+}
+
+#endif
+
+#ifdef LLK_TRISC_PACK
+
+#include "llk_lib_pack_wrappers.h"
+#include "llk_pack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    const ckernel::TensorShape tensor_shape = {FACE_R_DIM, FACE_C_DIM, 2, 2};
+
+    const std::uint32_t tile_size = tensor_shape.total_tensor_size();
+    const std::uint32_t num_faces = tensor_shape.total_num_faces();
+    const bool partial_face       = tensor_shape.face_r_dim < FACE_R_DIM;
+    const bool narrow_tile        = tensor_shape.num_faces_c_dim == 1;
+
+    // compute_kernel_hw_startup
+    _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, PackMode::Default>(
+        formats.pack_src, formats.pack_dst, tile_size, tensor_shape.face_r_dim, tensor_shape.total_col_dim(), num_faces, partial_face, narrow_tile);
+
+    _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(
+        formats.pack_dst, tensor_shape.face_r_dim, tensor_shape.total_col_dim(), num_faces, partial_face, narrow_tile);
+
+    // mul_reduce_scalar_tile step 5: mask so only the reduced scalar [0] is packed.
+    _llk_pack_reduce_mask_config_<ReduceDim::REDUCE_SCALAR>();
+
+    _llk_pack_dest_init_wrapper_<DST_SYNC, is_fp32_dest_acc_en, PackMode::Default>(tensor_shape.face_r_dim, narrow_tile);
+
+    // Single output tile: the scalar lives in DEST[0].
+    _llk_packer_wait_for_math_done_();
+    _llk_pack_<DST_SYNC, is_fp32_dest_acc_en, ckernel::PackMode::Default>(0, L1_ADDRESS(params.buffer_Res[0]));
+    _llk_pack_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
+
+    // mul_reduce_scalar_uninit
+    _llk_pack_reduce_mask_clear_();
+}
+
+#endif

--- a/tt_metal/tt-llk/tests/sources/mul_reduce_scalar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/mul_reduce_scalar_test.cpp
@@ -29,6 +29,12 @@ std::uint32_t math_sync_tile_dst_index = 0;
 
 static constexpr DstSync DST_SYNC = DstSync::SyncHalf;
 
+// The reduce runs over the full 32x32 tile: 2x2 faces of 16x16 (FACE_R_DIM x
+// FACE_C_DIM). Declared once and shared by all three threads; this is exactly
+// ckernel::DEFAULT_TENSOR_SHAPE ({MAX_FACE_R_DIM, MAX_FACE_C_DIM,
+// MAX_NUM_FACES_R_DIM, MAX_NUM_FACES_C_DIM}).
+static constexpr ckernel::TensorShape TENSOR_SHAPE = ckernel::DEFAULT_TENSOR_SHAPE;
+
 #ifdef LLK_TRISC_UNPACK
 
 #include "experimental/llk_unpack_mul_reduce_scalar.h"
@@ -37,21 +43,20 @@ static constexpr DstSync DST_SYNC = DstSync::SyncHalf;
 #include "params.h"
 
 // 32x32 tile has 4 faces; the reduce phase reuses the whole tile as source.
-static constexpr std::uint32_t NUM_FACES = 4;
+// Same 4-face count TENSOR_SHAPE encodes (MAX_NUM_FACES_R_DIM * MAX_NUM_FACES_C_DIM).
+static constexpr std::uint32_t NUM_FACES = ckernel::MAX_NUM_FACES;
 
 void run_kernel(RUNTIME_PARAMETERS params)
 {
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    const ckernel::TensorShape tensor_shape = {FACE_R_DIM, FACE_C_DIM, 2 /* num_faces_r_dim */, 2 /* num_faces_c_dim */};
-
     // compute_kernel_hw_startup
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, NUM_FACES, NUM_FACES);
 
     // mul_reduce_scalar_init: unpack A and B, no broadcast/transpose.
-    _llk_unpack_AB_init_<BroadcastType::NONE>(tensor_shape, ckernel::Transpose::None);
+    _llk_unpack_AB_init_<BroadcastType::NONE>(TENSOR_SHAPE, ckernel::Transpose::None);
 
     // Multiply phase: stream A[i] and B[i] into SrcA/SrcB for each tile.
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
@@ -83,8 +88,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    const std::uint32_t tile_cnt            = params.TILE_CNT;
-    const ckernel::TensorShape tensor_shape = {FACE_R_DIM, FACE_C_DIM, 2 /* num_faces_r_dim */, 2 /* num_faces_c_dim */};
+    const std::uint32_t tile_cnt = params.TILE_CNT;
 
     // compute_kernel_hw_startup
     _llk_math_pack_sync_init_<DST_SYNC, is_fp32_dest_acc_en>();
@@ -96,7 +100,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     // mul_reduce_scalar_init: element-wise multiply, no accumulate-to-dest.
     _llk_math_eltwise_binary_init_<EltwiseBinaryType::ELWMUL, BroadcastType::NONE, MATH_FIDELITY, EltwiseBinaryReuseDestType::NONE>(
-        tensor_shape, 0 /* acc_to_dest */);
+        TENSOR_SHAPE, 0 /* acc_to_dest */);
 
     _llk_math_wait_for_dest_available_<DST_SYNC>();
 
@@ -110,7 +114,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             DST_SYNC,
             is_fp32_dest_acc_en,
             MATH_FIDELITY,
-            EltwiseBinaryReuseDestType::NONE>(tensor_shape, i, true /* clear_fp32_dst_acc */);
+            EltwiseBinaryReuseDestType::NONE>(TENSOR_SHAPE, i, true /* clear_fp32_dst_acc */);
     }
 
     // Step 3 - initialize the reduce phase (addr mods + counter reset).
@@ -126,11 +130,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     // Step 6 - column-reduce every tile, accumulating into DEST[0].
     // (narrow_tile / num_faces are derived internally from the TensorShape.)
-    _llk_math_mul_reduce_column_<MATH_FIDELITY>(0 /* dst_index */, tensor_shape);
+    _llk_math_mul_reduce_column_<MATH_FIDELITY>(0 /* dst_index */, TENSOR_SHAPE);
     for (std::uint32_t i = 1; i < tile_cnt; ++i)
     {
         _llk_math_mul_reduce_scalar_move_dest_to_src_<EltwiseBinaryReuseDestType::DEST_TO_SRCA>(i);
-        _llk_math_mul_reduce_column_<MATH_FIDELITY>(0 /* dst_index */, tensor_shape);
+        _llk_math_mul_reduce_column_<MATH_FIDELITY>(0 /* dst_index */, TENSOR_SHAPE);
     }
 
     // Step 7 - collapse DEST[0] to a single scalar.
@@ -155,24 +159,22 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    const ckernel::TensorShape tensor_shape = {FACE_R_DIM, FACE_C_DIM, 2 /* num_faces_r_dim */, 2 /* num_faces_c_dim */};
-
-    const std::uint32_t tile_size = tensor_shape.total_tensor_size();
-    const std::uint32_t num_faces = tensor_shape.total_num_faces();
-    const bool partial_face       = tensor_shape.face_r_dim < FACE_R_DIM;
-    const bool narrow_tile        = tensor_shape.num_faces_c_dim == 1;
+    const std::uint32_t tile_size = TENSOR_SHAPE.total_tensor_size();
+    const std::uint32_t num_faces = TENSOR_SHAPE.total_num_faces();
+    const bool partial_face       = TENSOR_SHAPE.face_r_dim < FACE_R_DIM;
+    const bool narrow_tile        = TENSOR_SHAPE.num_faces_c_dim == 1;
 
     // compute_kernel_hw_startup
     _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, PackMode::Default>(
-        formats.pack_src, formats.pack_dst, tile_size, tensor_shape.face_r_dim, tensor_shape.total_col_dim(), num_faces, partial_face, narrow_tile);
+        formats.pack_src, formats.pack_dst, tile_size, TENSOR_SHAPE.face_r_dim, TENSOR_SHAPE.total_col_dim(), num_faces, partial_face, narrow_tile);
 
     _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(
-        formats.pack_dst, tensor_shape.face_r_dim, tensor_shape.total_col_dim(), num_faces, partial_face, narrow_tile);
+        formats.pack_dst, TENSOR_SHAPE.face_r_dim, TENSOR_SHAPE.total_col_dim(), num_faces, partial_face, narrow_tile);
 
     // mul_reduce_scalar_tile step 5: mask so only the reduced scalar [0] is packed.
     _llk_pack_reduce_mask_config_<ReduceDim::REDUCE_SCALAR>();
 
-    _llk_pack_dest_init_wrapper_<DST_SYNC, is_fp32_dest_acc_en, PackMode::Default>(tensor_shape.face_r_dim, narrow_tile);
+    _llk_pack_dest_init_wrapper_<DST_SYNC, is_fp32_dest_acc_en, PackMode::Default>(TENSOR_SHAPE.face_r_dim, narrow_tile);
 
     // Single output tile: the scalar lives in DEST[0].
     _llk_packer_wait_for_math_done_();

--- a/tt_metal/tt-llk/tests/sources/mul_reduce_scalar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/mul_reduce_scalar_test.cpp
@@ -29,6 +29,10 @@ std::uint32_t math_sync_tile_dst_index = 0;
 
 static constexpr DstSync DST_SYNC = DstSync::SyncHalf;
 
+// The reduction collapses everything into DEST[0], so every DEST access in this
+// kernel targets index 0. Name it once instead of repeating the bare literal.
+static constexpr std::uint32_t DST_INDEX = 0;
+
 // The tile geometry is parametrized by the Python test: the full 32x32 tile
 // (2x2 faces, num_faces=4) plus the 16x32 (1x2, num_faces=2) and 16x16 (1x1,
 // num_faces=1) "tiny tiles". Only num_faces_{r,c}_dim vary; face_r_dim /
@@ -135,20 +139,20 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_math_mul_reduce_scalar_init_<is_fp32_dest_acc_en, MATH_FIDELITY, false /* enforce_fp32_accumulation */>();
 
     // Step 4 - stage tile 0 into SrcA, fill SrcB with the scaler, clear DEST[0].
-    _llk_math_mul_reduce_scalar_move_dest_to_src_<EltwiseBinaryReuseDestType::DEST_TO_SRCA>(0 /* idst */);
+    _llk_math_mul_reduce_scalar_move_dest_to_src_<EltwiseBinaryReuseDestType::DEST_TO_SRCA>(DST_INDEX);
     _llk_math_eltwise_unary_sfpu_params_(
-        ckernel::sfpu::_calculate_fill_<false /* APPROX */, 2 /* ITERATIONS */>, 0 /* dst_index */, VectorMode::RC_custom, REDUCE_SCALER);
-    _llk_math_mul_reduce_scalar_move_dest_to_src_<EltwiseBinaryReuseDestType::DEST_TO_SRCB>(0);
+        ckernel::sfpu::_calculate_fill_<false /* APPROX */, 2 /* ITERATIONS */>, DST_INDEX, VectorMode::RC_custom, REDUCE_SCALER);
+    _llk_math_mul_reduce_scalar_move_dest_to_src_<EltwiseBinaryReuseDestType::DEST_TO_SRCB>(DST_INDEX);
     _llk_math_eltwise_unary_sfpu_params_(
-        ckernel::sfpu::_calculate_fill_<false /* APPROX */, 2 /* ITERATIONS */>, 0 /* dst_index */, VectorMode::RC_custom, 0.0f /* clear DEST[0] */);
+        ckernel::sfpu::_calculate_fill_<false /* APPROX */, 2 /* ITERATIONS */>, DST_INDEX, VectorMode::RC_custom, 0.0f /* clear DEST[0] */);
 
     // Step 6 - column-reduce every tile, accumulating into DEST[0].
     // (narrow_tile / num_faces are derived internally from the TensorShape.)
-    _llk_math_mul_reduce_column_<MATH_FIDELITY>(0 /* dst_index */, tensor_shape);
+    _llk_math_mul_reduce_column_<MATH_FIDELITY>(DST_INDEX, tensor_shape);
     for (std::uint32_t i = 1; i < tile_cnt; ++i)
     {
         _llk_math_mul_reduce_scalar_move_dest_to_src_<EltwiseBinaryReuseDestType::DEST_TO_SRCA>(i);
-        _llk_math_mul_reduce_column_<MATH_FIDELITY>(0 /* dst_index */, tensor_shape);
+        _llk_math_mul_reduce_column_<MATH_FIDELITY>(DST_INDEX, tensor_shape);
     }
 
     // Step 7 - collapse DEST[0] to a single scalar.
@@ -164,7 +168,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
-#include "llk_lib_pack_wrappers.h"
+#include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
 
@@ -182,23 +186,25 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t tile_size = tensor_shape.total_tensor_size();
     const std::uint32_t num_faces = tensor_shape.total_num_faces();
     const bool partial_face       = tensor_shape.face_r_dim < FACE_R_DIM;
-    const bool narrow_tile        = tensor_shape.num_faces_c_dim == 1;
 
+    // Blackhole-only test: call the pack LLKs directly (the _wrapper_ helpers exist
+    // only to paper over the WH/BH signature split for dual-arch tests).
     // compute_kernel_hw_startup
-    _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, PackMode::Default>(
-        formats.pack_src, formats.pack_dst, tile_size, tensor_shape.face_r_dim, tensor_shape.total_col_dim(), num_faces, partial_face, narrow_tile);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(
+        formats.pack_src, formats.pack_dst, tile_size, tensor_shape.face_r_dim, tensor_shape.total_col_dim(), num_faces, partial_face);
 
-    _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(
-        formats.pack_dst, tensor_shape.face_r_dim, tensor_shape.total_col_dim(), num_faces, partial_face, narrow_tile);
+    // No-src init: packer strides are owned by the hw-configure above, so skip re-programming them here.
+    _llk_pack_init_<PackMode::Default, false /* zero_output */, false /* skip_addrmod_config */, true /* skip_packer_strides */>(
+        formats.pack_src, tensor_shape.face_r_dim, tensor_shape.total_col_dim(), num_faces, 1 /* num_tiles */, false /* skip_bh_tilize_workaround */);
 
     // mul_reduce_scalar_tile step 5: mask so only the reduced scalar [0] is packed.
     _llk_pack_reduce_mask_config_<ReduceDim::REDUCE_SCALAR>();
 
-    _llk_pack_dest_init_wrapper_<DST_SYNC, is_fp32_dest_acc_en, PackMode::Default>(tensor_shape.face_r_dim, narrow_tile);
+    _llk_pack_dest_init_<DST_SYNC, is_fp32_dest_acc_en>();
 
     // Single output tile: the scalar lives in DEST[0].
     _llk_packer_wait_for_math_done_();
-    _llk_pack_<DST_SYNC, is_fp32_dest_acc_en, ckernel::PackMode::Default>(0 /* dst_index */, L1_ADDRESS(params.buffer_Res[0]));
+    _llk_pack_<DST_SYNC, is_fp32_dest_acc_en, ckernel::PackMode::Default>(DST_INDEX, L1_ADDRESS(params.buffer_Res[0]));
     _llk_pack_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
 
     // mul_reduce_scalar_uninit

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_mul_reduce_scalar.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_mul_reduce_scalar.h
@@ -12,7 +12,6 @@
 #include "cmath_common.h"
 #include "llk_defs.h"
 #include "llk_math_common.h"
-#include "llk_operands.h"
 #include "tensor_shape.h"
 
 using namespace ckernel;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_mul_reduce_scalar.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_mul_reduce_scalar.h
@@ -12,7 +12,6 @@
 #include "cmath_common.h"
 #include "llk_defs.h"
 #include "llk_math_common.h"
-#include "llk_operands.h"
 #include "tensor_shape.h"
 
 using namespace ckernel;


### PR DESCRIPTION
## What

Adds tt-llk test coverage for the experimental **fused multiply + reduce-to-scalar** LLKs — `llk_math_mul_reduce_scalar` / `llk_unpack_mul_reduce_scalar` — which live in `experimental/` but had **zero** tests in the tt-llk suite.

- `tests/sources/mul_reduce_scalar_test.cpp`
- `tests/python_tests/test_mul_reduce_scalar.py`

Closes the `mul_reduce_scalar` half of #50200 (part of #47554, experimental-LLK coverage).

## How

The C++ kernel mirrors the on-silicon compute-kernel flow of `ckernel::mul_reduce_scalar_tile`, expanded down to the `_llk_*` layer and split across the UNPACK/MATH/PACK threads:

1. **Multiply** — `A[i] * B[i]` (ELWMUL) element-wise into `DEST[i]`.
2. **Switch to reduce** — `_llk_unpack_mul_reduce_scalar_switch_to_reduce_` re-arms SrcA/SrcB so MATH can reuse DEST as source operands.
3. **Column reduce** — GAPOOL over every tile, accumulating into `DEST[0]` (scaler staged into SrcB via an SFPU fill, matching the Compute API).
4. **Scalar collapse** — transpose + GAPOOL down to a single value at `DEST[0]`.

The packer applies the `REDUCE_SCALAR` mask, so only element `[0]` is emitted.

Because `compute_kernel_hw_startup` is not available in the standalone harness, the MATH thread runs the idempotent `_llk_math_eltwise_unary_sfpu_init_once_()` itself before the `_calculate_fill_` SFPU stores (same pattern the other mixed FPU+SFPU tt-llk tests use).

## Coverage

Blackhole only (BH-only kernel). Kernel B is held at `1.0` — matching the on-silicon gtest and `fuser_config/fpu_reduce_scalar.yaml` — so the fused op reduces to `sum(A)` and the golden is unambiguous:

| Output / DEST | `num_tiles` | Fidelity |
|---|---|---|
| bf16 | 1, 2, 3, 7, 8 | HiFi2, HiFi4 |
| native fp32 DEST | 1, 2, 3, 4 | HiFi2, HiFi4 |

`num_tiles` is capped by DEST half-sync capacity (8 bf16 / 4 fp32), since every multiply product must be resident before the reduce phase consumes it. The golden — `sum(A*B)` over all elements landing in `DEST[0]` — matches the existing metal gtest `tests/tt_metal/tt_metal/llk/test_mul_reduce_scalar.cpp` and the real consumer (`deepseek_v3_b1` rmsnorm).

## Trivial LLK alignment

Dropped a spurious, **unused** `#include "llk_operands.h"` from the BH and WH `experimental/llk_math_mul_reduce_scalar.h`. It pulled in a metal-layer header that isn't on the tt-llk include path, so the lib header couldn't compile standalone. No symbols from it were used — no behavioral change.

## On `fast_untilize` (the other half of #50200)

#50200 also lists `fast_untilize`, but that kernel is **already fully covered** on `main` by `test_fast_untilize.py` / `fast_untilize_test.cpp` (merged in #45103, after the issue's plan was drafted). The existing test spans `ct_dim` 2–16, `Float16_b`/`Float32`/`Bfp8_b`/`Bfp4_b`, both DEST-sync modes, plus an L1 overflow-guard test — which subsumes the issue's ask (unit_dim 2/3/4 for a 16-bit format + optional fp32). No new work needed there; this PR intentionally scopes to `mul_reduce_scalar`.

## Validation

- `pytest --compile-producer` (CHIP_ARCH=blackhole): all 18 active variants compile cleanly.
- pre-commit (clang-format / black / isort / pylint / codespell / license) green.
- Runtime correctness is exercised on Blackhole in CI (this box is a Wormhole n150; the kernel is BH-only and `skip`s elsewhere). Blackhole Sanity / Nightly pipelines are dispatched on this PR.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ncvetkovic/llk-test-mul-reduce-scalar)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ncvetkovic/llk-test-mul-reduce-scalar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ncvetkovic/llk-test-mul-reduce-scalar)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ncvetkovic/llk-test-mul-reduce-scalar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ncvetkovic/llk-test-mul-reduce-scalar)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ncvetkovic/llk-test-mul-reduce-scalar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ncvetkovic/llk-test-mul-reduce-scalar)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ncvetkovic/llk-test-mul-reduce-scalar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ncvetkovic/llk-test-mul-reduce-scalar)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ncvetkovic/llk-test-mul-reduce-scalar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ncvetkovic/llk-test-mul-reduce-scalar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ncvetkovic/llk-test-mul-reduce-scalar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ncvetkovic/llk-test-mul-reduce-scalar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ncvetkovic/llk-test-mul-reduce-scalar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ncvetkovic/llk-test-mul-reduce-scalar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ncvetkovic/llk-test-mul-reduce-scalar)