### PR TITLE
[group_norm] Skip Welford variants on sim_wormhole_b0 (tt-sim NonContractualBehavior)

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -2,6 +2,8 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 import pytest
 
 import torch
@@ -10,12 +12,32 @@ from loguru import logger
 
 import ttnn
 
-from models.common.utility_functions import run_for_blackhole
+from models.common.utility_functions import is_wormhole_b0, run_for_blackhole
 from tests.ttnn.unit_tests.base_functionality.test_bh_20_cores_sharding import skip_if_not_blackhole_20_cores
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
 
 
 welford_flavors, welford_ids = (True, False), ("welford", "legacy")
+
+# tt-sim's Wormhole model (sim_wormhole_b0) aborts the Welford group-norm reduce-receiver
+# kernels with a NonContractualBehavior halfword-load error that does not reproduce on
+# WH/BH silicon or on sim_blackhole. Skip only that config until the tt-sim issue is fixed.
+# Tracking: tenstorrent/tt-metal#50539.
+_HARDCODED_WELFORD_TESTS = {"test_group_norm_dram_grid_size"}
+
+
+@pytest.fixture(autouse=True)
+def _skip_welford_on_sim_wormhole(request):
+    if not (os.environ.get("TT_METAL_SIMULATOR") and is_wormhole_b0()):
+        return
+    callspec = getattr(request.node, "callspec", None)
+    params = callspec.params if callspec is not None else {}
+    uses_welford = params.get("use_welford") is True or request.node.originalname in _HARDCODED_WELFORD_TESTS
+    if uses_welford:
+        pytest.skip(
+            "Welford group_norm aborts on sim_wormhole_b0 (https://github.com/tenstorrent/tt-metal/issues/50539)"
+        )
+
 
 TEST_PADDING_VALUE = -42
 

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -2,6 +2,8 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 import pytest
 
 import torch
@@ -13,11 +15,28 @@ import math
 
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
 from tests.ttnn.unit_tests.base_functionality.test_bh_20_cores_sharding import skip_if_not_blackhole_20_cores
-from models.common.utility_functions import is_blackhole, is_watcher_enabled, run_for_blackhole
+from models.common.utility_functions import is_blackhole, is_watcher_enabled, is_wormhole_b0, run_for_blackhole
 
 
 DEVICE_PARAMS_L1_SMALL_SIZE = [{"l1_small_size": 0}]
 WELFORD_MODES = ("legacy", "welford_normal", "welford_reciprocal")
+
+
+@pytest.fixture(autouse=True)
+def _skip_welford_on_sim_wormhole(request):
+    # tt-sim's Wormhole model (sim_wormhole_b0) aborts the Welford group-norm reduce-receiver
+    # kernels with a NonContractualBehavior halfword-load error that does not reproduce on
+    # WH/BH silicon or on sim_blackhole. Skip only that config until the tt-sim issue is fixed.
+    # Tracking: tenstorrent/tt-metal#50539.
+    if not (os.environ.get("TT_METAL_SIMULATOR") and is_wormhole_b0()):
+        return
+    callspec = getattr(request.node, "callspec", None)
+    params = callspec.params if callspec is not None else {}
+    if params.get("welford_mode") in ("welford_normal", "welford_reciprocal"):
+        pytest.skip(
+            "Welford group_norm aborts on sim_wormhole_b0 (https://github.com/tenstorrent/tt-metal/issues/50539)"
+        )
+
 
 GROUP_NORM_DRAM_SHAPES = [
     (8, 768, 1, 512, 32, 2, 8, 8),  # base case


### PR DESCRIPTION
## Summary

Skips the **Welford** group-norm variants on **`sim_wormhole_b0` only**, unblocking the
`ttnn fused group [sim_wormhole_b0]` sanity job (see #50539).

Under the Wormhole simulator model these tests abort with
`NonContractualBehavior: rv32_mem_rd: unaligned addr=... size=2` (a halfword load from
the Welford reduce-receiver store-visibility drain). The **same tests pass on WH and BH
silicon** (including LLK-assert nightly runs) **and on `sim_blackhole`** — so this is a
Wormhole-simulator-specific rejection, not a hardware defect. Reverting the underlying
fix is therefore unwarranted.

## Change

An `autouse` fixture in each affected file skips only when
`TT_METAL_SIMULATOR` is set **and** `is_wormhole_b0()`, and only for the Welford
configs:

- `test_group_norm.py` — `use_welford=True` params + the hard-coded-Welford
  `test_group_norm_dram_grid_size`.
- `test_group_norm_DRAM.py` — `welford_mode in {welford_normal, welford_reciprocal}`.

Legacy variants, all silicon, and `sim_blackhole` are unaffected.

## Verification

- Fixture selection + platform gate logic unit-tested across all Welford/legacy ×
  platform combinations (welford → skip on sim_wormhole_b0 only; legacy/silicon/
  sim_blackhole → run).
- The skip is unreachable off `sim_wormhole_b0`, so the authoritative check is the
  `ttnn fused group [sim_wormhole_b0]` CI job on this PR going green while
  `wh_n300_civ2` and `sim_blackhole` stay green.

## Follow-up

The simulator behavior itself is tracked in **tenstorrent/ttsim-private#605** — whether
the unaligned halfword read is genuinely non-contractual on Wormhole (→ fix the kernel
with an aligned 32-bit drain and remove this skip) or the Wormhole model is over-strict
vs silicon/`sim_blackhole` (→ fix the model and remove this skip). Either resolution
removes this skip.

Refs #50539.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/skip-groupnorm-welford-sim-wormhole)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/skip-groupnorm-welford-sim-wormhole)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/skip-groupnorm-welford-sim-wormhole)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/skip-groupnorm-welford-sim-wormhole)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/skip-groupnorm-welford-sim-wormhole)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/skip-groupnorm-welford-sim-wormhole)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/skip-groupnorm-welford-sim-wormhole)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/skip-groupnorm-welford-sim-wormhole)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/skip-groupnorm-welford-sim-wormhole)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/skip-groupnorm-welford-sim-wormhole)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/skip-groupnorm-welford-sim-wormhole)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/skip-groupnorm-welford-sim-wormhole)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/skip-groupnorm-welford-sim-wormhole)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/skip-groupnorm-welford-sim-wormhole)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/skip-groupnorm-welford-sim-wormhole)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/skip-groupnorm-welford-sim-wormhole)