### PR TITLE
#50748: Include c_1 staging CB in tilize block factory's L1 budget

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/common/common.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/common.cpp
@@ -420,10 +420,13 @@ uint32_t get_estimated_size_of_cbs(
     const Tensor& /*input_tensor_a*/,
     const uint32_t input_single_tile_size,
     const uint32_t output_single_tile_size,
-    const uint32_t num_tiles_per_row) {
+    const uint32_t num_tiles_per_row,
+    const uint32_t staging_bytes_per_tile,
+    const uint32_t fixed_staging_bytes) {
     uint32_t cb_src0_size = input_single_tile_size * num_tiles_per_row;
     uint32_t cb_output_size = output_single_tile_size * num_tiles_per_row;
-    return cb_src0_size + cb_output_size;
+    uint32_t cb_staging_size = staging_bytes_per_tile * num_tiles_per_row + fixed_staging_bytes;
+    return cb_src0_size + cb_output_size + cb_staging_size;
 }
 
 uint32_t get_max_l1_space(const Tensor& input_tensor_a) {
@@ -438,10 +441,17 @@ bool is_enough_space(
     const Tensor& input_tensor_a,
     const uint32_t input_single_tile_size,
     const uint32_t output_single_tile_size,
-    const uint32_t num_tiles_per_row) {
+    const uint32_t num_tiles_per_row,
+    const uint32_t staging_bytes_per_tile,
+    const uint32_t fixed_staging_bytes) {
     uint32_t max_l1_space = get_max_l1_space(input_tensor_a);
-    uint32_t estimated_size_of_cbs =
-        get_estimated_size_of_cbs(input_tensor_a, input_single_tile_size, output_single_tile_size, num_tiles_per_row);
+    uint32_t estimated_size_of_cbs = get_estimated_size_of_cbs(
+        input_tensor_a,
+        input_single_tile_size,
+        output_single_tile_size,
+        num_tiles_per_row,
+        staging_bytes_per_tile,
+        fixed_staging_bytes);
     return max_l1_space > estimated_size_of_cbs;
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/common/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/common.hpp
@@ -40,11 +40,14 @@ int common_tm_bw_model(
     bool bcast_local = false,
     bool concat_op = false);
 
+// Extra staging CBs (e.g. tilize block factory's c_1) must pass staging_bytes_per_tile / fixed_staging_bytes.
 uint32_t get_estimated_size_of_cbs(
     const Tensor& input_tensor_a,
     uint32_t input_single_tile_size,
     uint32_t output_single_tile_size,
-    uint32_t num_tiles_per_row);
+    uint32_t num_tiles_per_row,
+    uint32_t staging_bytes_per_tile = 0,
+    uint32_t fixed_staging_bytes = 0);
 
 uint32_t get_max_l1_space(const Tensor& input_tensor_a);
 
@@ -52,7 +55,9 @@ bool is_enough_space(
     const Tensor& input_tensor_a,
     uint32_t input_single_tile_size,
     uint32_t output_single_tile_size,
-    uint32_t num_tiles_per_row);
+    uint32_t num_tiles_per_row,
+    uint32_t staging_bytes_per_tile = 0,
+    uint32_t fixed_staging_bytes = 0);
 
 ttnn::Tensor pad_to_tile_vol(
     const ttnn::Tensor& tensor, float value, bool use_multicore, const std::optional<MemoryConfig>& memory_config);

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_block_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_block_program_factory.cpp
@@ -108,7 +108,13 @@ ProgramDescriptor TilizeMultiCoreBlockProgramFactory::create_descriptor(
     uint32_t num_tiles_per_row = output.padded_shape()[-1] / tile_width;
 
     uint32_t num_blocks = (output.padded_shape()[-1] * output.padded_shape()[-2]) / tile_hw;
-    uint32_t cb_block_size_limit = max_l1_size / (input_single_tile_size + output_single_tile_size);
+    const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
+    // Fold push_cb_pair's c_1 staging (bytes/tile + fixed) into the limit or the region overruns L1.
+    uint32_t staging_bytes_per_tile = input_single_tile_size / tile_height;
+    uint32_t fixed_staging_bytes = 2 * dram_alignment;
+    uint32_t budget_for_tiles = (max_l1_size > fixed_staging_bytes) ? (max_l1_size - fixed_staging_bytes) : 0;
+    uint32_t bytes_per_tile_pair = input_single_tile_size + output_single_tile_size + staging_bytes_per_tile;
+    uint32_t cb_block_size_limit = (bytes_per_tile_pair == 0) ? 0 : budget_for_tiles / bytes_per_tile_pair;
 
     auto
         [ncores,
@@ -141,8 +147,6 @@ ProgramDescriptor TilizeMultiCoreBlockProgramFactory::create_descriptor(
     Buffer* src0_buffer = a.buffer();
     Buffer* dst_buffer = output.buffer();
     TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
-
-    const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
 
     const TileDescriptor tile_descriptor(operation_attributes.tile);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize.cpp
@@ -9,6 +9,7 @@
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/operations/data_movement/reshape_view/reshape.hpp"
 
+#include <tt-metalium/hal.hpp>
 #include <tt-logger/tt-logger.hpp>
 
 using namespace tt::tt_metal;
@@ -61,10 +62,25 @@ ttnn::Tensor tilize(
     uint32_t num_tiles_per_row = input_tensor.padded_shape()[-1] / input_tile_width;
     uint32_t num_tiles_per_col = input_tensor.padded_shape()[-2] / input_tile_height;
 
+    // Fold in the block factory's c_1 staging CB so routing does not pick "fits" when only c_0+c_16 fit.
+    const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
+    const uint32_t staging_bytes_per_tile = input_single_tile_size / input_tile_height;
+    const uint32_t fixed_staging_bytes = 2 * dram_alignment;
+
     bool enough_space_width = ttnn::operations::data_movement::is_enough_space(
-        input_tensor, input_single_tile_size, output_single_tile_size, num_tiles_per_col);
+        input_tensor,
+        input_single_tile_size,
+        output_single_tile_size,
+        num_tiles_per_col,
+        staging_bytes_per_tile,
+        fixed_staging_bytes);
     bool enough_space_height = ttnn::operations::data_movement::is_enough_space(
-        input_tensor, input_single_tile_size, output_single_tile_size, num_tiles_per_row);
+        input_tensor,
+        input_single_tile_size,
+        output_single_tile_size,
+        num_tiles_per_row,
+        staging_bytes_per_tile,
+        fixed_staging_bytes);
 
     auto base_tilize = [=](const ttnn::Tensor& input_tensor) {
         // Workaround for https://github.com/tenstorrent/tt-metal/issues/45331:

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_block_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/factories/tilize_with_val_padding_multi_core_block_interleaved_program_factory.cpp
@@ -101,7 +101,13 @@ ProgramDescriptor TilizeWithValPaddingMultiCoreBlockInterleavedFactory::create_d
     uint32_t num_tiles_per_col = output.padded_shape()[-2] / TILE_HEIGHT;
     uint32_t num_tiles_per_row = output.padded_shape()[-1] / TILE_WIDTH;
     uint32_t num_blocks = (output.padded_shape()[-1] * output.padded_shape()[-2]) / (TILE_HEIGHT * TILE_WIDTH);
-    uint32_t cb_block_size_limit = max_l1_size / (input_single_tile_size + output_single_tile_size);
+    const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
+    // Fold push_padded_cb_pair's c_1 staging (bytes/tile + fixed) into the limit or the region overruns L1.
+    uint32_t staging_bytes_per_tile = input_single_tile_size / TILE_HEIGHT;
+    uint32_t fixed_staging_bytes = 2 * dram_alignment;
+    uint32_t budget_for_tiles = (max_l1_size > fixed_staging_bytes) ? (max_l1_size - fixed_staging_bytes) : 0;
+    uint32_t bytes_per_tile_pair = input_single_tile_size + output_single_tile_size + staging_bytes_per_tile;
+    uint32_t cb_block_size_limit = (bytes_per_tile_pair == 0) ? 0 : budget_for_tiles / bytes_per_tile_pair;
 
     auto
         [ncores,
@@ -135,8 +141,6 @@ ProgramDescriptor TilizeWithValPaddingMultiCoreBlockInterleavedFactory::create_d
     Buffer* src0_buffer = a.buffer();
     Buffer* dst_buffer = output.buffer();
     TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
-
-    const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
 
     ProgramDescriptor desc;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.cpp
@@ -9,6 +9,8 @@
 #include "ttnn/operations/data_movement/reshape_view/reshape.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
 
+#include <tt-metalium/hal.hpp>
+
 using namespace tt::tt_metal;
 
 namespace ttnn::operations::data_movement {
@@ -95,10 +97,25 @@ ttnn::Tensor tilize_with_val_padding(
     uint32_t num_tiles_per_row = output_padded_shape[-1] / tt::constants::TILE_WIDTH;
     uint32_t num_tiles_per_col = output_padded_shape[-2] / tt::constants::TILE_HEIGHT;
 
+    // Fold in the block factory's c_1 staging CB so routing sees the true CB budget.
+    const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
+    const uint32_t staging_bytes_per_tile = input_single_tile_size / tt::constants::TILE_HEIGHT;
+    const uint32_t fixed_staging_bytes = 2 * dram_alignment;
+
     bool enough_space_width = operations::data_movement::is_enough_space(
-        input_tensor, input_single_tile_size, output_single_tile_size, num_tiles_per_col);
+        input_tensor,
+        input_single_tile_size,
+        output_single_tile_size,
+        num_tiles_per_col,
+        staging_bytes_per_tile,
+        fixed_staging_bytes);
     bool enough_space_height = operations::data_movement::is_enough_space(
-        input_tensor, input_single_tile_size, output_single_tile_size, num_tiles_per_row);
+        input_tensor,
+        input_single_tile_size,
+        output_single_tile_size,
+        num_tiles_per_row,
+        staging_bytes_per_tile,
+        fixed_staging_bytes);
 
     auto base_tilize = [=](const ttnn::Tensor& input_tensor) {
         return ttnn::prim::tilize_with_val_padding(


### PR DESCRIPTION
### Ticket
Link to Github Issue #50748

### Problem
`TilizeMultiCoreBlockProgramFactory` and its `tilize_with_val_padding` twin allocate three CBs per sub-block via `push_cb_pair` / `push_padded_cb_pair` (`c_0` input, `c_16` output, and a `c_1` staging buffer sized `input_row_bytes * num_tiles + 2 * dram_alignment`), but the L1 budget math accounted for only two. `cb_block_size_limit` used `input_tile + output_tile` as its divisor and the front-door routing helper `is_enough_space` estimated only the paired CB size. Under tight L1 the chosen `single_sub_block_size` produced a static CB region larger than the free L1 and collided with the L1 heap at program launch (`Statically allocated circular buffers ... clash with L1 buffers`, `tt_metal/impl/program/program.cpp:1669`).

### What this PR does
- **Extend `get_estimated_size_of_cbs` / `is_enough_space`** — add optional `staging_bytes_per_tile` and `fixed_staging_bytes` in `data_movement/common`; defaults preserve every existing caller.
- **Fold `c_1` into `cb_block_size_limit`** — both tilize block factories now subtract the fixed overhead from `max_l1_size` and divide by `input_tile + output_tile + staging_bytes_per_tile`, so the sub-block size chosen by `split_blocks_for_tilize_wh` guarantees the full CB region fits. Divisors match each factory's actual `c_1` allocation: `tilize` uses `tile_height` (op-attribute, consistent with the recently refactored `push_cb_pair` signature), `tilize_with_val_padding` uses `tt::constants::TILE_HEIGHT`.
- **Thread staging estimate through both front-doors** — `ttnn::tilize` and `ttnn::tilize_with_val_padding` now pass the c_1 estimate to `is_enough_space`, so factory routing (`enough_space_height / enough_space_width`) sees the true budget instead of the paired-only one.

### Tests
All on Wormhole B0 (N150):
- Cold-cache synthetic repro (`(1,1,32,8192)` bf16 RM → TILE, L1 pressured to varying slack):
  - slack ≥ 8 KB — PASSED (pre-diff: silent CB-vs-heap clash).
  - slack 4–6 KB — clean `TT_FATAL: No solution found for single_block_size` (pre-diff: silent clash).
- No linter regressions on the six touched files.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/tilize_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/tilize_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mouliraj/tilize_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mouliraj/tilize_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mouliraj/tilize_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mouliraj/tilize_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/tilize_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/tilize_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mouliraj/tilize_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mouliraj/tilize_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/tilize_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/tilize_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/tilize_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/tilize_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/tilize_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/tilize_fix)