### PR TITLE
Revert "[GroupNorm][Welford] Fix receiver store-before-signal L1 ordering race (#50305)"

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_gn.cpp
@@ -6,7 +6,6 @@
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
 #include "welford_combine.h"
-#include "ckernel.h"
 #include "noc_parameters.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
@@ -177,16 +176,6 @@ void kernel_main() {
             auto p_global_vars = reinterpret_cast<volatile uint16_t*>(global_vars_ptr);
             p_global_means[0] = local_result.mean;
             p_global_vars[0] = local_result.variance;
-
-            // Force both L1 stores to be processed into their L1 banks before we signal the sender,
-            // which immediately NoC-reads these exact addresses back. Without this, the baby-RISC
-            // store can still be in flight when the sender's read-back reaches the L1 bank -> the
-            // sender aggregates a stale partial. A blocking load of the same address orders after the
-            // store and stalls the pipeline until the store has landed (see ckernel.h load_blocking /
-            // MemoryOrdering.md). Both addresses are drained because they lie in different L1 words
-            // (single_tile_size_bytes apart) and may map to different L1 banks.
-            ckernel::load_blocking(p_global_means);
-            ckernel::load_blocking(p_global_vars);
 
             // Signal to sender that our partial data is ready
             reduce_receiver_sem.up(noc, mcast_sender_noc_x, mcast_sender_noc_y, 1);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_sharded_gn_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_sharded_gn_v2.cpp
@@ -6,7 +6,6 @@
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
 #include "welford_combine.h"
-#include "ckernel.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/noc_semaphore.h"
@@ -102,17 +101,6 @@ void kernel_main() {
             auto p_global_vars = reinterpret_cast<volatile uint16_t*>(global_vars_ptr);
             p_global_means[0] = local_result.mean;
             p_global_vars[0] = local_result.variance;
-
-            // Force both L1 stores to be processed into their L1 banks before we signal the sender,
-            // which immediately NoC-reads these exact addresses back (see the sender's async_read of
-            // global_means/global_vars). Without this, the baby-RISC store can still be in flight
-            // when the sender's read-back reaches the L1 bank -> the sender aggregates a stale
-            // partial. A blocking load of the same address orders after the store and stalls the
-            // pipeline until the store has landed (see ckernel.h load_blocking / MemoryOrdering.md).
-            // Both addresses are drained because they lie in different L1 words
-            // (single_tile_size_bytes apart) and may map to different L1 banks.
-            ckernel::load_blocking(p_global_means);
-            ckernel::load_blocking(p_global_vars);
 
             // Signal to sender that our partial data is ready
             reduce_receiver_sem.up(noc, mcast_sender_noc_x, mcast_sender_noc_y, 1);


### PR DESCRIPTION
## Summary

Reverts the Welford group-norm L1 store-ordering fix (#50305, commit `746fd1cf5ea`).

That fix added `ckernel::load_blocking` (16-bit / `lhu`) drains before the reduce-receiver
signals the sender. On the **sim_wormhole_b0** model those halfword loads trip
`NonContractualBehavior: rv32_mem_rd: unaligned addr=... size=2`, crashing the
`ttnn fused group [sim_wormhole_b0]` sanity job (#50539). The failure is
Wormhole-simulator-specific — the same tests pass on WH/BH silicon and on sim_blackhole.

Rather than carry a sim-only test skip, we revert the fix until the simulator issue is
resolved, then re-land it.

## Consequences

- **Re-opens the underlying race** (#50304): the receiver can again signal the sender
  before its partial mean/var stores have landed in L1. This is a latent, timing/L1-bank
  dependent PCC race — not reproduced deterministically — so main returns to its
  prior (pre-#50305) behavior.
- Unblocks `sim_wormhole_b0` CI without a test skip.

## Follow-up

The simulator-side issue is tracked in **tenstorrent/ttsim-private#605**. Once the
Wormhole model's handling of this access is fixed (or the access is confirmed
non-contractual and the fix reworked to an aligned 32-bit drain), the store-ordering
fix will be re-landed and #50304 closed again.

Refs #50539, #50304, #50305.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/revert-groupnorm-welford-l1-store-ordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/revert-groupnorm-welford-l1-store-ordering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/revert-groupnorm-welford-l1-store-ordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/revert-groupnorm-welford-l1-store-ordering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/revert-groupnorm-welford-l1-store-ordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/revert-groupnorm-welford-l1-store-ordering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/revert-groupnorm-welford-l1-store-ordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/revert-groupnorm-welford-l1-store-ordering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/revert-groupnorm-welford-l1-store-ordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/revert-groupnorm-welford-l1-store-ordering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/revert-groupnorm-welford-l1-store-ordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/revert-groupnorm-welford-l1-store-ordering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/revert-groupnorm-welford-l1-store-ordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/revert-groupnorm-welford-l1-store-ordering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/revert-groupnorm-welford-l1-store-ordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/revert-groupnorm-welford-l1-store-ordering)