### PR TITLE
[LLK][test] Reconfig-escape / empty-uninit sweep for experimental LLKs

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/test_experimental_reconfig_escape.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_experimental_reconfig_escape.py
@@ -119,6 +119,22 @@ class SEQUENCE(TemplateParameter):
         return f"#define SEQUENCE {int(self.sequence)}"
 
 
+# bf16 and a real fp32 data format. bf16 exercises the ADDR_MOD / Haloize holes (and,
+# with dest_acc=Yes, the ALU_ACC_CTRL / ALU_FORMAT_SPEC hole); fp32 additionally drives the
+# ops with 32-bit operands so the format-spec state under test is genuinely fp32, not bf16.
+_BF16 = InputOutputFormat(DataFormat.Float16_b, DataFormat.Float16_b)
+_FP32 = InputOutputFormat(DataFormat.Float32, DataFormat.Float32)
+
+
+def _formats(polluter):
+    # reduce_block_max_row requires bf16 operand+scaler by its LLK contract ("Operand and
+    # scaler data format is bfloat16_b"), so it is bf16-only. matmul_custom_no_mop and the
+    # SDPA sub+bcast-col pair also run with a real fp32 data format.
+    if polluter == 1:
+        return [_BF16]
+    return [_BF16, _FP32]
+
+
 def _sequences(polluter):
     # reduce_block_max_row (1) is FORWARD-only: validating it as the run-1 op would
     # duplicate the fuser reduce test (masked-scalar pack + ReduceBlockMaxRowGolden).
@@ -127,11 +143,15 @@ def _sequences(polluter):
     return [Sequence.FORWARD, Sequence.REVERSE, Sequence.REPEAT]
 
 
-def _dest_accs(sequence):
-    # fp32 DEST only widens the escape surface for FORWARD: the ALU_ACC_CTRL /
-    # ALU_FORMAT_SPEC hole is "experimental init sets it, the following canonical op
-    # must reset it". In REVERSE/REPEAT the experimental op both sets and consumes it,
-    # so there is no cross-op escape to pin — bf16 is sufficient there.
+def _dest_accs(formats, sequence):
+    # A real fp32 data format needs a 32-bit DEST register (dest_acc=Yes).
+    if formats.output_format == DataFormat.Float32:
+        return [DestAccumulation.Yes]
+    # bf16: sweep both DEST widths on FORWARD. fp32 DEST arms the reduce polluter's
+    # ALU_ACC_CTRL_Zero_Flag_disabled_src / ALU_FORMAT_SPEC RMW (its only route to that
+    # cfg-reg hole, since reduce cannot use an fp32 data format), which the following
+    # canonical op must reset. In REVERSE/REPEAT the experimental op both sets and consumes
+    # that state, so there is no cross-op escape to pin — bf16 / No is sufficient there.
     if sequence == Sequence.FORWARD:
         return [DestAccumulation.No, DestAccumulation.Yes]
     return [DestAccumulation.No]
@@ -191,14 +211,16 @@ def _sdpa_sub_bcast_col_golden(src_A_tile, src_B_tile, formats, math_fidelity):
 
 
 @parametrize(
-    formats=[InputOutputFormat(DataFormat.Float16_b, DataFormat.Float16_b)],
+    # Conditional axes (resolved in dependency order): formats and sequence depend on
+    # polluter (reduce is bf16-only and FORWARD-only); dest_acc depends on formats and
+    # sequence (fp32 forces 32-bit DEST; bf16 sweeps both DEST widths on FORWARD).
+    polluter=list(POLLUTERS.keys()),
+    formats=_formats,
     # Two high-fidelity levels: HiFi2 and HiFi4 both take the matmul_no_mop high-fidelity
     # branch (identical ADDR_MOD_5 fidelity-increment programming; ADDR_MOD_6 is throttle-gated
     # and not written at THROTTLE_LEVEL 0), but drive a different fidelity-phase replay count,
     # so the polluter runs a longer MVMUL walk over its clobbered ADDR_MOD state at HiFi4.
     math_fidelity=[MathFidelity.HiFi2, MathFidelity.HiFi4],
-    polluter=list(POLLUTERS.keys()),
-    # Conditional axes: reduce is FORWARD-only; fp32 DEST is swept only for FORWARD.
     sequence=_sequences,
     dest_acc=_dest_accs,
 )

--- a/tt_metal/tt-llk/tests/python_tests/test_experimental_reconfig_escape.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_experimental_reconfig_escape.py
@@ -6,18 +6,28 @@
 Several experimental LLKs have an empty or no-op ``uninit`` even though their
 ``init`` clobbers persistent HW state (ADDR_MODs, cfg regs such as
 ``THCON_SEC0_REG2_Haloize_mode``). This is the #1 contract hole in the
-experimental-LLK inventory: state could leak into the following op.
+experimental-LLK inventory: state could leak between an experimental op and the
+op next to it. Each parametrized case runs a two-op sequence and validates the
+SECOND op (run 1); run 0 is packed to a scratch buffer and discarded.
 
-Each parametrized case runs a two-op sequence:
+``sequence`` selects the two ops and therefore which invariant is pinned:
 
-    run 0 (POLLUTER): the selected experimental op (init + one op + its empty
-                      uninit). Its packed output is discarded to a scratch buffer.
-    run 1 (VICTIM):   a canonical datacopy (A2D) of a fresh, known input tile,
-                      packed to the result buffer and validated against its input.
+    FORWARD (X -> datacopy): experimental op X, then a canonical A2D datacopy of
+        a fresh, known tile (buffer_A[1]), validated against its input. Pins that
+        X's empty ``uninit`` leaves no escape the datacopy's own init doesn't
+        re-establish.
+    REVERSE (datacopy -> X): a canonical datacopy first, then experimental op X,
+        validating X. Pins that X's own init is self-sufficient and does not
+        silently rely on leftover clean state from a preceding canonical op.
+    REPEAT (X -> X): experimental op X twice, validating the second. Pins that
+        X's empty ``uninit`` is safe for back-to-back reuse.
 
-The victim datacopy runs ONLY its own standard init (no extra reinit help). A
-green result **pins** the invariant that the experimental op's empty ``uninit``
-leaves no escape the canonical op's own init doesn't already re-establish:
+REVERSE / REPEAT validate the experimental op itself, so they only run for the
+polluters with a clean single-tile golden: ``matmul_custom_no_mop`` (0) and the
+SDPA sub+bcast-col pair (2). ``reduce_block_max_row`` (1) is FORWARD-only — its
+validated-op behavior is already covered by the fuser reduce test.
+
+Why a green result pins the invariant:
 
   * The MATH polluters clobber ADDR_MODs; the datacopy init reprograms exactly
     the ADDR_MODs it consumes (ADDR_MOD_0/2/3), so those clobbers cannot corrupt
@@ -25,29 +35,49 @@ leaves no escape the canonical op's own init doesn't already re-establish:
   * The UNPACK polluter (``sub_bcast_col``) RMWs ``Haloize_mode`` (transpose
     within face); the victim's ``_llk_unpack_A_init_`` rewrites ``Haloize_mode``,
     so the transpose bit cannot leak.
+  * Under fp32 DEST, the reduce polluter's unpack init additionally RMWs
+    ``ALU_ACC_CTRL_Zero_Flag_disabled_src`` (and ``ALU_FORMAT_SPEC`` SrcA) and its
+    uninit does NOT restore them; the victim's own datacopy format reconfig +
+    init is what must reset them. The sweep runs both bf16 and fp32 DEST so this
+    cfg-reg hole is armed, not just the ADDR_MOD / Haloize ones.
 
-If any case ever fails, that is a genuine reconfig escape (a polluter left state
-that the canonical op does not reset) — a real finding to document, not to mask.
+If any case ever fails, that is a genuine reconfig escape (an op left state that
+the following op does not reset) — a real finding to document, not to mask.
 """
 
 from dataclasses import dataclass
+from enum import IntEnum
 
 import pytest
 import torch
 from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
 from helpers.format_config import DataFormat, InputOutputFormat
-from helpers.golden_generators import DataCopyGolden, get_golden_generator
-from helpers.llk_params import DestAccumulation, MathFidelity
+from helpers.golden_generators import (
+    BroadcastGolden,
+    DataCopyGolden,
+    EltwiseBinaryGolden,
+    MatmulGolden,
+    get_golden_generator,
+)
+from helpers.llk_params import (
+    BroadcastType,
+    DestAccumulation,
+    MathFidelity,
+    MathOperation,
+)
 from helpers.param_config import parametrize
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import StimuliSpec, generate_stimuli
 from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import MATH_FIDELITY, TemplateParameter
+from helpers.tilize_untilize import tilize_block, untilize_block
 from helpers.utils import passed_test
 
 # 32x32 tile: 4 faces of 16x16.
 ELEMENTS_PER_TILE = 1024
 TILE_DIMENSIONS = [32, 32]
+FACE_R_DIM = 16
+NUM_FACES = 4
 
 # Experimental polluter selector (matches the POLLUTER switch in the CPP kernel).
 # Scenario 2 runs the paired SDPA fused sub+bcast-col op, which exercises BOTH the
@@ -60,15 +90,104 @@ POLLUTERS = {
 }
 
 
+class Sequence(IntEnum):
+    """Two-op ordering; matches the SEQUENCE switch in the CPP kernel."""
+
+    FORWARD = 0  # experimental op -> canonical datacopy (validate datacopy)
+    REVERSE = 1  # canonical datacopy -> experimental op (validate experimental)
+    REPEAT = 2  # experimental op -> experimental op (validate the second)
+
+
 @dataclass
 class POLLUTER(TemplateParameter):
-    """Selects which experimental op runs as the run-0 polluter."""
+    """Selects which experimental op X is."""
 
     polluter: int = 0
 
     def convert_to_cpp(self) -> str:
         # A #define (not a constexpr) so the CPP kernel can switch on it with #if.
         return f"#define POLLUTER {self.polluter}"
+
+
+@dataclass
+class SEQUENCE(TemplateParameter):
+    """Selects the two-op ordering (FORWARD / REVERSE / REPEAT)."""
+
+    sequence: int = 0
+
+    def convert_to_cpp(self) -> str:
+        return f"#define SEQUENCE {int(self.sequence)}"
+
+
+def _sequences(polluter):
+    # reduce_block_max_row (1) is FORWARD-only: validating it as the run-1 op would
+    # duplicate the fuser reduce test (masked-scalar pack + ReduceBlockMaxRowGolden).
+    if polluter == 1:
+        return [Sequence.FORWARD]
+    return [Sequence.FORWARD, Sequence.REVERSE, Sequence.REPEAT]
+
+
+def _dest_accs(sequence):
+    # fp32 DEST only widens the escape surface for FORWARD: the ALU_ACC_CTRL /
+    # ALU_FORMAT_SPEC hole is "experimental init sets it, the following canonical op
+    # must reset it". In REVERSE/REPEAT the experimental op both sets and consumes it,
+    # so there is no cross-op escape to pin — bf16 is sufficient there.
+    if sequence == Sequence.FORWARD:
+        return [DestAccumulation.No, DestAccumulation.Yes]
+    return [DestAccumulation.No]
+
+
+def _tilize_tile(tile, input_format):
+    """Tilize one 32x32 tile (row-major -> face layout) so an experimental unpacker
+    that expects tiled input reads it correctly."""
+    return tilize_block(
+        tile,
+        TILE_DIMENSIONS,
+        input_format,
+        num_faces=NUM_FACES,
+        tile_dimensions=TILE_DIMENSIONS,
+        face_r_dim=FACE_R_DIM,
+    ).flatten()
+
+
+def _tilize_two_tile_buffer(src, input_format):
+    """Tilize both tiles of a [64, 32] buffer independently; buffer[0] then holds a
+    correctly-tiled tile for the experimental op (buffer[1] feeds the discarded
+    run-0 datacopy in REVERSE and is otherwise unused)."""
+    t0 = _tilize_tile(src[:ELEMENTS_PER_TILE], input_format)
+    t1 = _tilize_tile(src[ELEMENTS_PER_TILE : 2 * ELEMENTS_PER_TILE], input_format)
+    return torch.cat([t0, t1])
+
+
+def _sdpa_sub_bcast_col_golden(src_A_tile, src_B_tile, formats, math_fidelity):
+    """Golden for the SDPA fused SUB with column-broadcast srcB (single tile, ct_dim=1).
+    Mirrors test_eltwise_bcast_col_custom: broadcast srcB across the face column, then
+    subtract from srcA."""
+    fmt = formats.input_format
+    src_B_tilized = _tilize_tile(src_B_tile, fmt)
+    src_B_broadcasted_tilized = get_golden_generator(BroadcastGolden)(
+        BroadcastType.Column,
+        src_B_tilized,
+        fmt,
+        num_faces=NUM_FACES,
+        tile_cnt=1,
+        face_r_dim=FACE_R_DIM,
+    )
+    src_B_golden = untilize_block(
+        src_B_broadcasted_tilized,
+        fmt,
+        TILE_DIMENSIONS,
+        num_faces=NUM_FACES,
+        tile_dimensions=TILE_DIMENSIONS,
+        face_r_dim=FACE_R_DIM,
+    ).flatten()
+    return get_golden_generator(EltwiseBinaryGolden)(
+        MathOperation.Elwsub,
+        src_A_tile,
+        src_B_golden,
+        formats.output_format,
+        math_fidelity,
+    )
 
 
 @parametrize(
@@ -79,20 +198,20 @@ class POLLUTER(TemplateParameter):
     # so the polluter runs a longer MVMUL walk over its clobbered ADDR_MOD state at HiFi4.
     math_fidelity=[MathFidelity.HiFi2, MathFidelity.HiFi4],
     polluter=list(POLLUTERS.keys()),
+    # Conditional axes: reduce is FORWARD-only; fp32 DEST is swept only for FORWARD.
+    sequence=_sequences,
+    dest_acc=_dest_accs,
 )
-def test_experimental_reconfig_escape(formats, math_fidelity, polluter):
+def test_experimental_reconfig_escape(
+    formats, math_fidelity, polluter, sequence, dest_acc
+):
     if get_chip_architecture() == ChipArchitecture.QUASAR:
         pytest.skip(
             "experimental reconfig-escape sweep targets Blackhole and Wormhole B0"
         )
 
-    # bf16 DEST throughout (dest_acc=No): the escape under test is the named
-    # ADDR_MOD / Haloize contract hole, independent of the fp32 zero-flag path.
-    dest_acc = DestAccumulation.No
-
-    # buffer_A[0]/buffer_B[0] feed the discarded polluter; buffer_A[1] is the
-    # fresh, known tile the victim datacopy reads (and must reproduce). Two A
-    # tiles + one B tile are laid out contiguously by StimuliConfig.
+    # buffer_A[0]/buffer_B[0] feed the experimental op; buffer_A[1] is the fresh, known
+    # tile the canonical datacopy reads. Two A tiles + two B tiles laid out contiguously.
     input_dimensions = [2 * TILE_DIMENSIONS[0], TILE_DIMENSIONS[1]]
     src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
         stimuli_format_A=formats.input_format,
@@ -103,14 +222,44 @@ def test_experimental_reconfig_escape(formats, math_fidelity, polluter):
         spec_B=StimuliSpec.uniform(low=0.0, high=1.0),
     )
 
-    # The victim copies the SECOND A tile (buffer_A[1]).
-    victim_tile = src_A[ELEMENTS_PER_TILE : 2 * ELEMENTS_PER_TILE]
-    datacopy_golden = get_golden_generator(DataCopyGolden)
-    golden = datacopy_golden(
-        victim_tile,
-        formats.output_format,
-        input_format=formats.input_format,
-    )
+    # Build the run-1 golden and the stimuli the kernel actually consumes. FORWARD always
+    # validates the canonical datacopy of buffer_A[1]; REVERSE/REPEAT validate the
+    # experimental op (which consumes tiled operands out of buffer_A[0]/buffer_B[0]).
+    untilize_result = False
+    if sequence == Sequence.FORWARD:
+        stim_A, stim_B = src_A, src_B
+        victim_tile = src_A[ELEMENTS_PER_TILE : 2 * ELEMENTS_PER_TILE]
+        golden = get_golden_generator(DataCopyGolden)(
+            victim_tile,
+            formats.output_format,
+            input_format=formats.input_format,
+        )
+    elif polluter == 0:
+        # matmul_custom_no_mop: A2 = buffer_A[0] x buffer_B[0]. Kernel consumes tiled
+        # operands; the golden tilizes its own output to match the HW tiled pack layout.
+        stim_A = _tilize_two_tile_buffer(src_A, formats.input_format)
+        stim_B = _tilize_two_tile_buffer(src_B, formats.input_format)
+        golden = get_golden_generator(MatmulGolden)(
+            src_A[:ELEMENTS_PER_TILE],
+            src_B[:ELEMENTS_PER_TILE],
+            formats.output_format,
+            math_fidelity,
+            input_A_dimensions=TILE_DIMENSIONS,
+            input_B_dimensions=TILE_DIMENSIONS,
+            tilize=True,
+            input_A_format=formats.input_format,
+            input_B_format=formats.input_format,
+        )
+    else:  # polluter == 2: SDPA sub+bcast-col
+        stim_A = _tilize_two_tile_buffer(src_A, formats.input_format)
+        stim_B = _tilize_two_tile_buffer(src_B, formats.input_format)
+        golden = _sdpa_sub_bcast_col_golden(
+            src_A[:ELEMENTS_PER_TILE],
+            src_B[:ELEMENTS_PER_TILE],
+            formats,
+            math_fidelity,
+        )
+        untilize_result = True
 
     configuration = TestConfig(
         "sources/experimental_reconfig_escape_test.cpp",
@@ -118,11 +267,12 @@ def test_experimental_reconfig_escape(formats, math_fidelity, polluter):
         templates=[
             MATH_FIDELITY(math_fidelity),
             POLLUTER(polluter=polluter),
+            SEQUENCE(sequence=int(sequence)),
         ],
         variant_stimuli=StimuliConfig(
-            src_A,
+            stim_A,
             formats.input_format,
-            src_B,
+            stim_B,
             formats.input_format,
             formats.output_format,
             tile_count_A=tile_cnt_A,
@@ -135,12 +285,22 @@ def test_experimental_reconfig_escape(formats, math_fidelity, polluter):
 
     res_from_L1 = configuration.run().result
 
+    if untilize_result:
+        res_from_L1 = untilize_block(
+            res_from_L1,
+            formats.output_format,
+            TILE_DIMENSIONS,
+            num_faces=NUM_FACES,
+            tile_dimensions=TILE_DIMENSIONS,
+            face_r_dim=FACE_R_DIM,
+        ).flatten()
+
     assert (
         len(res_from_L1) == ELEMENTS_PER_TILE
     ), f"Expected one {ELEMENTS_PER_TILE}-element output tile, got {len(res_from_L1)}"
 
     res_tensor = torch.tensor(res_from_L1, dtype=torch.float32)
     assert passed_test(golden, res_tensor, formats.output_format), (
-        f"reconfig escape from experimental '{POLLUTERS[polluter]}' (empty uninit): "
-        f"victim datacopy diverged from its input"
+        f"reconfig escape (sequence={sequence.name}, polluter='{POLLUTERS[polluter]}', "
+        f"dest_acc={dest_acc.name}): validated run-1 op diverged from its golden"
     )

--- a/tt_metal/tt-llk/tests/python_tests/test_experimental_reconfig_escape.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_experimental_reconfig_escape.py
@@ -73,8 +73,10 @@ class POLLUTER(TemplateParameter):
 
 @parametrize(
     formats=[InputOutputFormat(DataFormat.Float16_b, DataFormat.Float16_b)],
-    # Both fidelities: the matmul_no_mop polluter programs different fidelity-phase
-    # ADDR_MODs (ADDR_MOD_5/6) at HiFi vs LoFi, so sweeping catches a wider ADDR_MOD set.
+    # Two high-fidelity levels: HiFi2 and HiFi4 both take the matmul_no_mop high-fidelity
+    # branch (identical ADDR_MOD_5 fidelity-increment programming; ADDR_MOD_6 is throttle-gated
+    # and not written at THROTTLE_LEVEL 0), but drive a different fidelity-phase replay count,
+    # so the polluter runs a longer MVMUL walk over its clobbered ADDR_MOD state at HiFi4.
     math_fidelity=[MathFidelity.HiFi2, MathFidelity.HiFi4],
     polluter=list(POLLUTERS.keys()),
 )

--- a/tt_metal/tt-llk/tests/python_tests/test_experimental_reconfig_escape.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_experimental_reconfig_escape.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reconfig-escape / empty-``uninit`` sweep for the experimental LLKs (BH + WH B0).
+
+Several experimental LLKs have an empty or no-op ``uninit`` even though their
+``init`` clobbers persistent HW state (ADDR_MODs, cfg regs such as
+``THCON_SEC0_REG2_Haloize_mode``). This is the #1 contract hole in the
+experimental-LLK inventory: state could leak into the following op.
+
+Each parametrized case runs a two-op sequence:
+
+    run 0 (POLLUTER): the selected experimental op (init + one op + its empty
+                      uninit). Its packed output is discarded to a scratch buffer.
+    run 1 (VICTIM):   a canonical datacopy (A2D) of a fresh, known input tile,
+                      packed to the result buffer and validated against its input.
+
+The victim datacopy runs ONLY its own standard init (no extra reinit help). A
+green result **pins** the invariant that the experimental op's empty ``uninit``
+leaves no escape the canonical op's own init doesn't already re-establish:
+
+  * The MATH polluters clobber ADDR_MODs; the datacopy init reprograms exactly
+    the ADDR_MODs it consumes (ADDR_MOD_0/2/3), so those clobbers cannot corrupt
+    the copy.
+  * The UNPACK polluter (``sub_bcast_col``) RMWs ``Haloize_mode`` (transpose
+    within face); the victim's ``_llk_unpack_A_init_`` rewrites ``Haloize_mode``,
+    so the transpose bit cannot leak.
+
+If any case ever fails, that is a genuine reconfig escape (a polluter left state
+that the canonical op does not reset) — a real finding to document, not to mask.
+"""
+
+from dataclasses import dataclass
+
+import pytest
+import torch
+from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
+from helpers.format_config import DataFormat, InputOutputFormat
+from helpers.golden_generators import DataCopyGolden, get_golden_generator
+from helpers.llk_params import DestAccumulation, MathFidelity
+from helpers.param_config import parametrize
+from helpers.stimuli_config import StimuliConfig
+from helpers.stimuli_generator import StimuliSpec, generate_stimuli
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import MATH_FIDELITY, TemplateParameter
+from helpers.utils import passed_test
+
+# 32x32 tile: 4 faces of 16x16.
+ELEMENTS_PER_TILE = 1024
+TILE_DIMENSIONS = [32, 32]
+
+# Experimental polluter selector (matches the POLLUTER switch in the CPP kernel).
+# Scenario 2 runs the paired SDPA fused sub+bcast-col op, which exercises BOTH the
+# eltwise_binary_custom (MATH) and unpack_AB_sub_bcast_col_custom (UNPACK) empty uninits
+# at once — they only run correctly as a pair.
+POLLUTERS = {
+    0: "matmul_custom_no_mop",
+    1: "reduce_block_max_row",
+    2: "eltwise_binary_custom + unpack_AB_sub_bcast_col_custom (SDPA sub+bcast-col)",
+}
+
+
+@dataclass
+class POLLUTER(TemplateParameter):
+    """Selects which experimental op runs as the run-0 polluter."""
+
+    polluter: int = 0
+
+    def convert_to_cpp(self) -> str:
+        # A #define (not a constexpr) so the CPP kernel can switch on it with #if.
+        return f"#define POLLUTER {self.polluter}"
+
+
+@parametrize(
+    formats=[InputOutputFormat(DataFormat.Float16_b, DataFormat.Float16_b)],
+    # Both fidelities: the matmul_no_mop polluter programs different fidelity-phase
+    # ADDR_MODs (ADDR_MOD_5/6) at HiFi vs LoFi, so sweeping catches a wider ADDR_MOD set.
+    math_fidelity=[MathFidelity.HiFi2, MathFidelity.HiFi4],
+    polluter=list(POLLUTERS.keys()),
+)
+def test_experimental_reconfig_escape(formats, math_fidelity, polluter):
+    if get_chip_architecture() == ChipArchitecture.QUASAR:
+        pytest.skip(
+            "experimental reconfig-escape sweep targets Blackhole and Wormhole B0"
+        )
+
+    # bf16 DEST throughout (dest_acc=No): the escape under test is the named
+    # ADDR_MOD / Haloize contract hole, independent of the fp32 zero-flag path.
+    dest_acc = DestAccumulation.No
+
+    # buffer_A[0]/buffer_B[0] feed the discarded polluter; buffer_A[1] is the
+    # fresh, known tile the victim datacopy reads (and must reproduce). Two A
+    # tiles + one B tile are laid out contiguously by StimuliConfig.
+    input_dimensions = [2 * TILE_DIMENSIONS[0], TILE_DIMENSIONS[1]]
+    src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=input_dimensions,
+        spec_A=StimuliSpec.uniform(low=0.0, high=1.0),
+        spec_B=StimuliSpec.uniform(low=0.0, high=1.0),
+    )
+
+    # The victim copies the SECOND A tile (buffer_A[1]).
+    victim_tile = src_A[ELEMENTS_PER_TILE : 2 * ELEMENTS_PER_TILE]
+    datacopy_golden = get_golden_generator(DataCopyGolden)
+    golden = datacopy_golden(
+        victim_tile,
+        formats.output_format,
+        input_format=formats.input_format,
+    )
+
+    configuration = TestConfig(
+        "sources/experimental_reconfig_escape_test.cpp",
+        formats,
+        templates=[
+            MATH_FIDELITY(math_fidelity),
+            POLLUTER(polluter=polluter),
+        ],
+        variant_stimuli=StimuliConfig(
+            src_A,
+            formats.input_format,
+            src_B,
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=tile_cnt_A,
+            tile_count_B=tile_cnt_B,
+            tile_count_res=1,
+            sfpu=False,
+        ),
+        dest_acc=dest_acc,
+    )
+
+    res_from_L1 = configuration.run().result
+
+    assert (
+        len(res_from_L1) == ELEMENTS_PER_TILE
+    ), f"Expected one {ELEMENTS_PER_TILE}-element output tile, got {len(res_from_L1)}"
+
+    res_tensor = torch.tensor(res_from_L1, dtype=torch.float32)
+    assert passed_test(golden, res_tensor, formats.output_format), (
+        f"reconfig escape from experimental '{POLLUTERS[polluter]}' (empty uninit): "
+        f"victim datacopy diverged from its input"
+    )

--- a/tt_metal/tt-llk/tests/python_tests/test_experimental_reconfig_escape.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_experimental_reconfig_escape.py
@@ -105,8 +105,8 @@ class POLLUTER(TemplateParameter):
     polluter: int = 0
 
     def convert_to_cpp(self) -> str:
-        # A #define (not a constexpr) so the CPP kernel can switch on it with #if.
-        return f"#define POLLUTER {self.polluter}"
+        # A constexpr (the CPP kernel switches on it with `if constexpr`, not `#if`).
+        return f"constexpr int POLLUTER = {self.polluter};"
 
 
 @dataclass
@@ -116,7 +116,7 @@ class SEQUENCE(TemplateParameter):
     sequence: int = 0
 
     def convert_to_cpp(self) -> str:
-        return f"#define SEQUENCE {int(self.sequence)}"
+        return f"constexpr int SEQUENCE = {int(self.sequence)};"
 
 
 # bf16 and a real fp32 data format. bf16 exercises the ADDR_MOD / Haloize holes (and,

--- a/tt_metal/tt-llk/tests/sources/experimental_reconfig_escape_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/experimental_reconfig_escape_test.cpp
@@ -19,7 +19,9 @@
 // input. A green result pins the invariant "empty uninit + canonical op's own init == correct".
 //
 // POLLUTER selects which experimental op runs first:
-//   0 = matmul_custom_no_mop     (MATH: clobbers ADDR_MOD_0..6, loads a replay image; empty uninit)
+//   0 = matmul_custom_no_mop     (MATH: at THROTTLE_LEVEL 0 clobbers ADDR_MODs — BH full-tile path
+//                                 writes 0/1/2/4/5, WH writes 0..5; ADDR_MOD_6 is programmed only at
+//                                 nonzero throttling — and loads a replay image; empty uninit)
 //   1 = reduce_block_max_row     (MATH: clobbers ADDR_MOD_1/2/3/6 + programs a MOP template; empty uninit)
 //   2 = sdpa_sub_bcast_col       (the paired SDPA fused sub+bcast-col op, exercising BOTH empty uninits:
 //                                 UNPACK unpack_AB_sub_bcast_col_custom (RMW THCON_SEC0_REG2_Haloize_mode
@@ -132,7 +134,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     // ---- Run 0: POLLUTER math ----
 #if POLLUTER == 0
-    // matmul_custom_no_mop: init clobbers ADDR_MOD_0..6 and records the replay image; empty uninit.
+    // matmul_custom_no_mop: this THROTTLE_LEVEL 0 full-tile init clobbers ADDR_MODs (BH writes
+    // 0/1/2/4/5 — no ADDR_MOD_3 in the full-tile custom path; WH writes 0..5) and records the
+    // replay image; empty uninit. ADDR_MOD_6 is only programmed at nonzero throttling.
     _llk_math_matmul_init_no_mop_<MATH_FIDELITY, 0>(TILE_R_DIM, TILE_C_DIM, TILE_R_DIM, TILE_C_DIM, false, 0, 1, 1);
     _llk_math_wait_for_dest_available_<DST_SYNC>();
     _llk_math_matmul_no_mop_<MATH_FIDELITY, 0>(0 /* dst_index */, 1, 1);

--- a/tt_metal/tt-llk/tests/sources/experimental_reconfig_escape_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/experimental_reconfig_escape_test.cpp
@@ -1,0 +1,222 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Reconfig-escape / empty-uninit test for the experimental LLKs (Blackhole + Wormhole B0).
+//
+// Several experimental LLKs have an empty or no-op `uninit` even though their `init`
+// clobbers persistent HW state (ADDR_MODs, cfg regs such as THCON_SEC0_REG2_Haloize_mode).
+// This test PINS that no such state leaks into a following canonical op:
+//
+//   run 0 (POLLUTER): the selected experimental op runs its init + one op + its (empty)
+//                     uninit. Its packed output goes to a scratch buffer and is discarded.
+//   run 1 (VICTIM):   a canonical datacopy (A2D) of a fresh, known input tile
+//                     (buffer_A[1]) into DEST, packed to buffer_Res[0] and validated.
+//
+// The victim datacopy runs ONLY its own standard init (no extra reinit/reconfig help). If
+// the polluter's empty uninit let stale ADDR_MOD / cfg state survive, and the datacopy
+// init does not re-establish the state it consumes, the datacopy output diverges from its
+// input. A green result pins the invariant "empty uninit + canonical op's own init == correct".
+//
+// POLLUTER selects which experimental op runs first:
+//   0 = matmul_custom_no_mop     (MATH: clobbers ADDR_MOD_0..6, loads a replay image; empty uninit)
+//   1 = reduce_block_max_row     (MATH: clobbers ADDR_MOD_1/2/3/6 + programs a MOP template; empty uninit)
+//   2 = sdpa_sub_bcast_col       (the paired SDPA fused sub+bcast-col op, exercising BOTH empty uninits:
+//                                 UNPACK unpack_AB_sub_bcast_col_custom (RMW THCON_SEC0_REG2_Haloize_mode
+//                                 + SETADCXX x_end) and MATH eltwise_binary_custom (ADDR_MOD_7 +
+//                                 CLR_DVALID_SrcA disable). These two ops only run correctly as a pair.)
+
+#include <cstdint>
+
+#include "ckernel.h"
+#include "llk_defs.h"
+#include "tensor_shape.h"
+
+using namespace ckernel;
+
+// Globals
+std::uint32_t unp_cfg_context          = 0;
+std::uint32_t pack_sync_tile_dst_ptr   = 0;
+std::uint32_t math_sync_tile_dst_index = 0;
+
+// POLLUTER (which experimental op runs as run 0) is #defined by the generated
+// build.h, pulled in via params.h inside each per-thread block below.
+
+static constexpr DstSync DST_SYNC = DstSync::SyncHalf;
+
+// 32x32 tile, 4 faces of 16x16 — the geometry every polluter and the victim use.
+static constexpr std::uint32_t NUM_FACES = 4;
+
+// Scratch L1 address for the discarded run-0 (polluter) packed output.
+static constexpr std::uint32_t buffer_polluter_scratch = 0xA0000;
+
+#ifdef LLK_TRISC_UNPACK
+
+#include "experimental/llk_unpack_AB_reduce_custom.h"
+#include "experimental/llk_unpack_AB_sub_bcast_col_custom.h"
+#include "llk_unpack_A.h"
+#include "llk_unpack_AB.h"
+#include "llk_unpack_AB_matmul.h"
+#include "llk_unpack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    [[maybe_unused]] const ckernel::TensorShape tensor_shape = {FACE_R_DIM, FACE_C_DIM, 2 /* num_faces_r_dim */, 2 /* num_faces_c_dim */};
+
+    // compute_kernel_hw_startup
+    _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
+        formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, NUM_FACES, NUM_FACES);
+
+    // ---- Run 0: POLLUTER unpack ----
+#if POLLUTER == 2
+    // sdpa_sub_bcast_col: RMW Haloize_mode=0 (transpose within face) + set both unpacker x_end.
+    // Loads srcB once + ct_dim srcA tiles, paired with the MATH bcast-col reuse scaffold.
+    _llk_unpack_AB_sub_bcast_col_init_custom_(tensor_shape);
+    _llk_unpack_AB_sub_bcast_col_custom_(L1_ADDRESS(params.buffer_A[0]), L1_ADDRESS(params.buffer_B[0]), 1 /* ct_dim */);
+    _llk_unpack_AB_sub_bcast_col_uninit_custom_();
+#elif POLLUTER == 1
+    // reduce_block_max_row: SrcA + SrcB (scaler) streamed via the paired custom AB-reduce unpack.
+    _llk_unpack_AB_reduce_block_max_row_init_<1 /* block_ct_dim */, is_fp32_dest_acc_en>(tensor_shape);
+    _llk_unpack_AB_reduce_block_max_row_(L1_ADDRESS(params.buffer_A[0]), L1_ADDRESS(params.buffer_B[0]));
+    _llk_unpack_AB_reduce_block_max_row_uninit_();
+#else
+    // matmul_custom_no_mop (0): in0 -> SrcB, in1 -> SrcA via the regular matmul unpacker
+    // (the no-mop MATH replay consumes SrcA/SrcB in the matmul dvalid pattern).
+    const std::uint32_t mm_tile_size = FACE_R_DIM * FACE_C_DIM * NUM_FACES / (is_fp32_dest_acc_en ? 1 : 2);
+    _llk_unpack_AB_matmul_init_<>(0 /* transpose */, 1 /* ct_dim */, 1 /* rt_dim */, 1 /* kt_dim */);
+    _llk_unpack_AB_matmul_<>(L1_ADDRESS(params.buffer_A[0]), L1_ADDRESS(params.buffer_B[0]), 0, 0, mm_tile_size, mm_tile_size);
+#endif
+
+    // Wait until the run-0 packer has drained before touching unpacker state for the victim.
+    t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(semaphore::PACK_DONE);
+    t6_semaphore_get<>(semaphore::PACK_DONE);
+
+    // ---- Run 1: VICTIM canonical datacopy (unpack A2D) of a fresh, known tile ----
+    // Only its own standard init runs; if the polluter left the unpacker in a stale state
+    // (e.g. a leaked Haloize transpose), this datacopy would read buffer_A[1] wrong.
+    _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, false /* unpack_to_dest */>(
+        0 /* transpose_of_faces */,
+        0 /* within_face_16x16_transpose */,
+        ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, NUM_FACES),
+        formats.unpack_A_src,
+        formats.unpack_A_dst);
+    _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, false /* unpack_to_dest */>(
+        L1_ADDRESS(params.buffer_A[1]), formats.unpack_A_src, formats.unpack_A_dst);
+}
+
+#endif
+
+#ifdef LLK_TRISC_MATH
+
+#include "experimental/llk_math_eltwise_binary_custom.h"
+#include "experimental/llk_math_matmul_custom_no_mop.h"
+#include "experimental/llk_math_reduce_custom.h"
+#include "llk_math_common.h"
+#include "llk_math_eltwise_unary_datacopy.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    [[maybe_unused]] const ckernel::TensorShape tensor_shape = {FACE_R_DIM, FACE_C_DIM, 2 /* num_faces_r_dim */, 2 /* num_faces_c_dim */};
+
+    // compute_kernel_hw_startup
+    _llk_math_pack_sync_init_<DST_SYNC, is_fp32_dest_acc_en>();
+    _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
+
+    // ---- Run 0: POLLUTER math ----
+#if POLLUTER == 0
+    // matmul_custom_no_mop: init clobbers ADDR_MOD_0..6 and records the replay image; empty uninit.
+    _llk_math_matmul_init_no_mop_<MATH_FIDELITY, 0>(TILE_R_DIM, TILE_C_DIM, TILE_R_DIM, TILE_C_DIM, false, 0, 1, 1);
+    _llk_math_wait_for_dest_available_<DST_SYNC>();
+    _llk_math_matmul_no_mop_<MATH_FIDELITY, 0>(0 /* dst_index */, 1, 1);
+    _llk_math_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
+    _llk_math_matmul_uninit_no_mop_();
+#elif POLLUTER == 1
+    // reduce_block_max_row: init sets ADDR_MOD_1/2/3/6 + a MOP template; empty uninit.
+    _llk_math_reduce_block_max_row_init_<1 /* block_ct_dim */, is_fp32_dest_acc_en>(tensor_shape);
+    _llk_math_wait_for_dest_available_<DST_SYNC>();
+    _llk_math_reduce_block_max_row_<1 /* block_ct_dim */, is_fp32_dest_acc_en>(0 /* dst_index */, tensor_shape);
+    _llk_math_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
+    _llk_math_reduce_block_max_row_uninit_<is_fp32_dest_acc_en>();
+#elif POLLUTER == 2
+    // eltwise_binary_custom paired with the sub_bcast_col unpacker (the SDPA fused SUB op).
+    // init sets ADDR_MOD_7 + CLR_DVALID_SrcA disable; empty uninit. The SUB bcast-col reuse
+    // scaffold is the only eltwise_binary_custom entry point common to BH and WH.
+    _llk_math_eltwise_binary_init_custom_<EltwiseBinaryType::ELWSUB, BroadcastType::COL>(NUM_FACES);
+    _llk_math_wait_for_dest_available_<DST_SYNC>();
+    _llk_math_sub_bcast_cols_reuse_custom_(1 /* ct_dim */, tensor_shape, 0 /* dst_index */);
+    _llk_math_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
+    _llk_math_eltwise_binary_uninit_custom_();
+#endif
+
+    // ---- Run 1: VICTIM canonical datacopy (A2D) ----
+    // Only the standard datacopy init runs (it reprograms the ADDR_MODs it consumes:
+    // ADDR_MOD_0/2/3). If a polluter's empty uninit leaked state the datacopy init does NOT
+    // reset, the copy would be corrupted.
+    _llk_math_reconfig_data_format_<is_fp32_dest_acc_en, false>(formats.math, formats.math);
+    _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false /* is_int_fpu_en */>(NUM_FACES, formats.math);
+    _llk_math_wait_for_dest_available_<DST_SYNC>();
+    _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DST_SYNC, is_fp32_dest_acc_en, BroadcastType::NONE, false /* unpack_to_dest */>(
+        0 /* dst_index */, formats.math, formats.math);
+    _llk_math_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
+}
+
+#endif
+
+#ifdef LLK_TRISC_PACK
+
+#include "llk_lib_pack_wrappers.h"
+#include "llk_pack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    const ckernel::TensorShape tensor_shape = {FACE_R_DIM, FACE_C_DIM, 2 /* num_faces_r_dim */, 2 /* num_faces_c_dim */};
+
+    const std::uint32_t tile_size = tensor_shape.total_tensor_size();
+    const std::uint32_t num_faces = tensor_shape.total_num_faces();
+    const bool partial_face       = tensor_shape.face_r_dim < FACE_R_DIM;
+    const bool narrow_tile        = tensor_shape.num_faces_c_dim == 1;
+
+    // compute_kernel_hw_startup
+    _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, PackMode::Default>(
+        formats.pack_src, formats.pack_dst, tile_size, tensor_shape.face_r_dim, tensor_shape.total_col_dim(), num_faces, partial_face, narrow_tile);
+    _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(
+        formats.pack_dst, tensor_shape.face_r_dim, tensor_shape.total_col_dim(), num_faces, partial_face, narrow_tile);
+    _llk_pack_dest_init_wrapper_<DST_SYNC, is_fp32_dest_acc_en, PackMode::Default>(tensor_shape.face_r_dim, narrow_tile);
+
+#if POLLUTER == 1
+    // reduce_block_max_row emits a masked (REDUCE_ROW) scalar; mask so the discarded
+    // polluter output packs without asserting, then clear it before the victim pack.
+    _llk_pack_reduce_mask_config_<ReduceDim::REDUCE_ROW>();
+#endif
+
+    // ---- Run 0: pack the discarded polluter result to scratch ----
+    _llk_packer_wait_for_math_done_();
+    _llk_pack_<DST_SYNC, is_fp32_dest_acc_en, ckernel::PackMode::Default>(0 /* dst_index */, L1_ADDRESS(buffer_polluter_scratch));
+    _llk_pack_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
+
+#if POLLUTER == 1
+    _llk_pack_reduce_mask_clear_();
+#endif
+
+    // Signal the unpacker that run-0 has fully drained.
+    t6_semaphore_post<>(semaphore::PACK_DONE);
+
+    // ---- Run 1: pack the victim datacopy result to the output buffer ----
+    _llk_packer_wait_for_math_done_();
+    _llk_pack_<DST_SYNC, is_fp32_dest_acc_en, ckernel::PackMode::Default>(0 /* dst_index */, L1_ADDRESS(params.buffer_Res[0]));
+    _llk_pack_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
+}
+
+#endif

--- a/tt_metal/tt-llk/tests/sources/experimental_reconfig_escape_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/experimental_reconfig_escape_test.cpp
@@ -6,23 +6,36 @@
 //
 // Several experimental LLKs have an empty or no-op `uninit` even though their `init`
 // clobbers persistent HW state (ADDR_MODs, cfg regs such as THCON_SEC0_REG2_Haloize_mode).
-// This test PINS that no such state leaks into a following canonical op:
+// This test PINS that no such state leaks between an experimental op and a canonical op,
+// in both directions, by running a two-op sequence and validating the SECOND op:
 //
-//   run 0 (POLLUTER): the selected experimental op runs its init + one op + its (empty)
-//                     uninit. Its packed output goes to a scratch buffer and is discarded.
-//   run 1 (VICTIM):   a canonical datacopy (A2D) of a fresh, known input tile
-//                     (buffer_A[1]) into DEST, packed to buffer_Res[0] and validated.
+//   run 0: packed to a scratch buffer and discarded.
+//   run 1: packed to buffer_Res[0] and validated against its golden.
 //
-// The victim datacopy runs ONLY its own standard init (no extra reinit/reconfig help). If
-// the polluter's empty uninit let stale ADDR_MOD / cfg state survive, and the datacopy
-// init does not re-establish the state it consumes, the datacopy output diverges from its
-// input. A green result pins the invariant "empty uninit + canonical op's own init == correct".
+// SEQUENCE selects which two ops run, and therefore which invariant is pinned:
+//   0 = FORWARD (X -> datacopy): experimental op X then a canonical A2D datacopy of a fresh,
+//                 known tile (buffer_A[1]). Pins that X's empty uninit leaves no escape the
+//                 datacopy's own init doesn't re-establish (ADDR_MODs, Haloize, and under
+//                 fp32 DEST also ALU_ACC_CTRL_Zero_Flag_disabled_src / ALU_FORMAT_SPEC).
+//   1 = REVERSE (datacopy -> X): a canonical datacopy first, then experimental op X, validating
+//                 X. Pins that X's own init is self-sufficient and does not silently rely on
+//                 leftover clean state from a preceding canonical op.
+//   2 = REPEAT  (X -> X): experimental op X twice, validating the second. Pins that X's empty
+//                 uninit is safe for back-to-back reuse (the fused-kernel usage pattern).
 //
-// POLLUTER selects which experimental op runs first:
+// REVERSE / REPEAT validate the experimental op itself, so they only run for the polluters with
+// a clean single-tile golden — matmul_custom_no_mop (0) and the SDPA sub+bcast-col pair (2).
+// reduce_block_max_row (1) is FORWARD-only (its validated-op behavior is already covered by the
+// fuser reduce test); this is enforced in the Python parametrization.
+//
+// POLLUTER selects which experimental op X is:
 //   0 = matmul_custom_no_mop     (MATH: at THROTTLE_LEVEL 0 clobbers ADDR_MODs — BH full-tile path
 //                                 writes 0/1/2/4/5, WH writes 0..5; ADDR_MOD_6 is programmed only at
 //                                 nonzero throttling — and loads a replay image; empty uninit)
-//   1 = reduce_block_max_row     (MATH: clobbers ADDR_MOD_1/2/3/6 + programs a MOP template; empty uninit)
+//   1 = reduce_block_max_row     (MATH: clobbers ADDR_MOD_1/2/3/6 + programs a MOP template; empty uninit.
+//                                 UNPACK: RMWs Haloize_mode, and under fp32 DEST also
+//                                 ALU_ACC_CTRL_Zero_Flag_disabled_src + ALU_FORMAT_SPEC SrcA, none restored
+//                                 by its uninit — armed only when the sweep runs dest_acc=Yes.)
 //   2 = sdpa_sub_bcast_col       (the paired SDPA fused sub+bcast-col op, exercising BOTH empty uninits:
 //                                 UNPACK unpack_AB_sub_bcast_col_custom (RMW THCON_SEC0_REG2_Haloize_mode
 //                                 + SETADCXX x_end) and MATH eltwise_binary_custom (ADDR_MOD_7 +
@@ -41,15 +54,18 @@ std::uint32_t unp_cfg_context          = 0;
 std::uint32_t pack_sync_tile_dst_ptr   = 0;
 std::uint32_t math_sync_tile_dst_index = 0;
 
-// POLLUTER (which experimental op runs as run 0) is #defined by the generated
+// POLLUTER (which experimental op) and SEQUENCE (op ordering) are #defined by the generated
 // build.h, pulled in via params.h inside each per-thread block below.
+#define SEQ_FORWARD 0
+#define SEQ_REVERSE 1
+#define SEQ_REPEAT  2
 
 static constexpr DstSync DST_SYNC = DstSync::SyncHalf;
 
-// 32x32 tile, 4 faces of 16x16 — the geometry every polluter and the victim use.
+// 32x32 tile, 4 faces of 16x16 — the geometry every op uses.
 static constexpr std::uint32_t NUM_FACES = 4;
 
-// Scratch L1 address for the discarded run-0 (polluter) packed output.
+// Scratch L1 address for the discarded run-0 packed output.
 static constexpr std::uint32_t buffer_polluter_scratch = 0xA0000;
 
 #ifdef LLK_TRISC_UNPACK
@@ -62,18 +78,9 @@ static constexpr std::uint32_t buffer_polluter_scratch = 0xA0000;
 #include "llk_unpack_common.h"
 #include "params.h"
 
-void run_kernel(RUNTIME_PARAMETERS params)
+// Unpack side of the experimental (POLLUTER-selected) op. Reads buffer_A[0]/buffer_B[0].
+static inline void unpack_experimental_(RUNTIME_PARAMETERS params, [[maybe_unused]] const ckernel::TensorShape& tensor_shape)
 {
-#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
-    const FormatConfig& formats = params.formats;
-#endif
-    [[maybe_unused]] const ckernel::TensorShape tensor_shape = {FACE_R_DIM, FACE_C_DIM, 2 /* num_faces_r_dim */, 2 /* num_faces_c_dim */};
-
-    // compute_kernel_hw_startup
-    _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
-        formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, NUM_FACES, NUM_FACES);
-
-    // ---- Run 0: POLLUTER unpack ----
 #if POLLUTER == 2
     // sdpa_sub_bcast_col: RMW Haloize_mode=0 (transpose within face) + set both unpacker x_end.
     // Loads srcB once + ct_dim srcA tiles, paired with the MATH bcast-col reuse scaffold.
@@ -82,6 +89,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_unpack_AB_sub_bcast_col_uninit_custom_();
 #elif POLLUTER == 1
     // reduce_block_max_row: SrcA + SrcB (scaler) streamed via the paired custom AB-reduce unpack.
+    // Its init RMWs Haloize_mode, and under fp32 DEST also ALU_ACC_CTRL_Zero_Flag_disabled_src +
+    // ALU_FORMAT_SPEC SrcA (for MOVB2D hi16/lo16); its uninit restores none of them. The victim
+    // datacopy's own format reconfig + init must reset them — pinned only in the dest_acc=Yes sweep.
     _llk_unpack_AB_reduce_block_max_row_init_<1 /* block_ct_dim */, is_fp32_dest_acc_en>(tensor_shape);
     _llk_unpack_AB_reduce_block_max_row_(L1_ADDRESS(params.buffer_A[0]), L1_ADDRESS(params.buffer_B[0]));
     _llk_unpack_AB_reduce_block_max_row_uninit_();
@@ -92,14 +102,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_unpack_AB_matmul_init_<>(0 /* transpose */, 1 /* ct_dim */, 1 /* rt_dim */, 1 /* kt_dim */);
     _llk_unpack_AB_matmul_<>(L1_ADDRESS(params.buffer_A[0]), L1_ADDRESS(params.buffer_B[0]), 0, 0, mm_tile_size, mm_tile_size);
 #endif
+}
 
-    // Wait until the run-0 packer has drained before touching unpacker state for the victim.
-    t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(semaphore::PACK_DONE);
-    t6_semaphore_get<>(semaphore::PACK_DONE);
-
-    // ---- Run 1: VICTIM canonical datacopy (unpack A2D) of a fresh, known tile ----
-    // Only its own standard init runs; if the polluter left the unpacker in a stale state
-    // (e.g. a leaked Haloize transpose), this datacopy would read buffer_A[1] wrong.
+// Unpack side of a canonical A2D datacopy of the fresh, known tile buffer_A[1].
+// Runs ONLY its own standard init; if a prior op left the unpacker in a stale state
+// (e.g. a leaked Haloize transpose), this datacopy would read buffer_A[1] wrong.
+static inline void unpack_datacopy_(RUNTIME_PARAMETERS params, const FormatConfig& formats)
+{
     _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, false /* unpack_to_dest */>(
         0 /* transpose_of_faces */,
         0 /* within_face_16x16_transpose */,
@@ -108,6 +117,36 @@ void run_kernel(RUNTIME_PARAMETERS params)
         formats.unpack_A_dst);
     _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, false /* unpack_to_dest */>(
         L1_ADDRESS(params.buffer_A[1]), formats.unpack_A_src, formats.unpack_A_dst);
+}
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    const ckernel::TensorShape tensor_shape = {FACE_R_DIM, FACE_C_DIM, 2 /* num_faces_r_dim */, 2 /* num_faces_c_dim */};
+
+    // compute_kernel_hw_startup
+    _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
+        formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, NUM_FACES, NUM_FACES);
+
+    // ---- Run 0 (discarded to scratch) ----
+#if SEQUENCE == SEQ_REVERSE
+    unpack_datacopy_(params, formats); // canonical op first
+#else
+    unpack_experimental_(params, tensor_shape); // FORWARD / REPEAT: experimental first
+#endif
+
+    // Wait until the run-0 packer has drained before touching unpacker state for run 1.
+    t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(semaphore::PACK_DONE);
+    t6_semaphore_get<>(semaphore::PACK_DONE);
+
+    // ---- Run 1 (validated, packed to buffer_Res[0]) ----
+#if SEQUENCE == SEQ_FORWARD
+    unpack_datacopy_(params, formats); // canonical victim datacopy
+#else
+    unpack_experimental_(params, tensor_shape); // REVERSE / REPEAT: experimental op is the victim
+#endif
 }
 
 #endif
@@ -121,18 +160,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #include "llk_math_eltwise_unary_datacopy.h"
 #include "params.h"
 
-void run_kernel(RUNTIME_PARAMETERS params)
+// Math side of the experimental (POLLUTER-selected) op.
+static inline void math_experimental_(RUNTIME_PARAMETERS params, [[maybe_unused]] const ckernel::TensorShape& tensor_shape)
 {
-#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
-    const FormatConfig& formats = params.formats;
-#endif
-    [[maybe_unused]] const ckernel::TensorShape tensor_shape = {FACE_R_DIM, FACE_C_DIM, 2 /* num_faces_r_dim */, 2 /* num_faces_c_dim */};
-
-    // compute_kernel_hw_startup
-    _llk_math_pack_sync_init_<DST_SYNC, is_fp32_dest_acc_en>();
-    _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
-
-    // ---- Run 0: POLLUTER math ----
 #if POLLUTER == 0
     // matmul_custom_no_mop: this THROTTLE_LEVEL 0 full-tile init clobbers ADDR_MODs (BH writes
     // 0/1/2/4/5 — no ADDR_MOD_3 in the full-tile custom path; WH writes 0..5) and records the
@@ -159,17 +189,44 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_math_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
     _llk_math_eltwise_binary_uninit_custom_();
 #endif
+}
 
-    // ---- Run 1: VICTIM canonical datacopy (A2D) ----
-    // Only the standard datacopy init runs (it reprograms the ADDR_MODs it consumes:
-    // ADDR_MOD_0/2/3). If a polluter's empty uninit leaked state the datacopy init does NOT
-    // reset, the copy would be corrupted.
+// Math side of a canonical A2D datacopy. Its own init reprograms the ADDR_MODs it consumes
+// (ADDR_MOD_0/2/3) and (via the format reconfig) the ALU format/acc-ctrl state it depends on.
+static inline void math_datacopy_(RUNTIME_PARAMETERS params, const FormatConfig& formats)
+{
     _llk_math_reconfig_data_format_<is_fp32_dest_acc_en, false>(formats.math, formats.math);
     _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false /* is_int_fpu_en */>(NUM_FACES, formats.math);
     _llk_math_wait_for_dest_available_<DST_SYNC>();
     _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DST_SYNC, is_fp32_dest_acc_en, BroadcastType::NONE, false /* unpack_to_dest */>(
         0 /* dst_index */, formats.math, formats.math);
     _llk_math_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
+}
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    const ckernel::TensorShape tensor_shape = {FACE_R_DIM, FACE_C_DIM, 2 /* num_faces_r_dim */, 2 /* num_faces_c_dim */};
+
+    // compute_kernel_hw_startup
+    _llk_math_pack_sync_init_<DST_SYNC, is_fp32_dest_acc_en>();
+    _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
+
+    // ---- Run 0 (discarded) ----
+#if SEQUENCE == SEQ_REVERSE
+    math_datacopy_(params, formats); // canonical op first
+#else
+    math_experimental_(params, tensor_shape); // FORWARD / REPEAT: experimental first
+#endif
+
+    // ---- Run 1 (validated) ----
+#if SEQUENCE == SEQ_FORWARD
+    math_datacopy_(params, formats); // canonical victim datacopy
+#else
+    math_experimental_(params, tensor_shape); // REVERSE / REPEAT: experimental op is the victim
+#endif
 }
 
 #endif
@@ -200,12 +257,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_dest_init_wrapper_<DST_SYNC, is_fp32_dest_acc_en, PackMode::Default>(tensor_shape.face_r_dim, narrow_tile);
 
 #if POLLUTER == 1
-    // reduce_block_max_row emits a masked (REDUCE_ROW) scalar; mask so the discarded
-    // polluter output packs without asserting, then clear it before the victim pack.
+    // reduce_block_max_row (FORWARD-only, so it is always run 0) emits a masked (REDUCE_ROW)
+    // scalar; mask so the discarded polluter output packs without asserting, then clear it
+    // before the victim pack.
     _llk_pack_reduce_mask_config_<ReduceDim::REDUCE_ROW>();
 #endif
 
-    // ---- Run 0: pack the discarded polluter result to scratch ----
+    // ---- Run 0: pack the discarded result to scratch ----
     _llk_packer_wait_for_math_done_();
     _llk_pack_<DST_SYNC, is_fp32_dest_acc_en, ckernel::PackMode::Default>(0 /* dst_index */, L1_ADDRESS(buffer_polluter_scratch));
     _llk_pack_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
@@ -217,7 +275,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // Signal the unpacker that run-0 has fully drained.
     t6_semaphore_post<>(semaphore::PACK_DONE);
 
-    // ---- Run 1: pack the victim datacopy result to the output buffer ----
+    // ---- Run 1: pack the validated result to the output buffer ----
     _llk_packer_wait_for_math_done_();
     _llk_pack_<DST_SYNC, is_fp32_dest_acc_en, ckernel::PackMode::Default>(0 /* dst_index */, L1_ADDRESS(params.buffer_Res[0]));
     _llk_pack_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/experimental_reconfig_escape_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/experimental_reconfig_escape_test.cpp
@@ -9,7 +9,7 @@
 // This test PINS that no such state leaks between an experimental op and a canonical op,
 // in both directions, by running a two-op sequence and validating the SECOND op:
 //
-//   run 0: packed to a scratch buffer and discarded.
+//   run 0: packed to buffer_Res[0] and discarded (immediately overwritten by run 1).
 //   run 1: packed to buffer_Res[0] and validated against its golden.
 //
 // SEQUENCE selects which two ops run, and therefore which invariant is pinned:
@@ -54,19 +54,18 @@ std::uint32_t unp_cfg_context          = 0;
 std::uint32_t pack_sync_tile_dst_ptr   = 0;
 std::uint32_t math_sync_tile_dst_index = 0;
 
-// POLLUTER (which experimental op) and SEQUENCE (op ordering) are #defined by the generated
-// build.h, pulled in via params.h inside each per-thread block below.
-#define SEQ_FORWARD 0
-#define SEQ_REVERSE 1
-#define SEQ_REPEAT  2
+// POLLUTER (which experimental op) and SEQUENCE (op ordering) are provided as `constexpr int`
+// by the generated build.h, pulled in via params.h inside each per-thread block below. They are
+// switched on with `if constexpr` (not `#if`), so every branch is type-checked on both arches.
+static constexpr int SEQ_FORWARD = 0;
+static constexpr int SEQ_REVERSE = 1;
+// REPEAT is validated via the same `else` branch as REVERSE, so it is documentary here.
+[[maybe_unused]] static constexpr int SEQ_REPEAT = 2;
 
 static constexpr DstSync DST_SYNC = DstSync::SyncHalf;
 
 // 32x32 tile, 4 faces of 16x16 — the geometry every op uses.
 static constexpr std::uint32_t NUM_FACES = 4;
-
-// Scratch L1 address for the discarded run-0 packed output.
-static constexpr std::uint32_t buffer_polluter_scratch = 0xA0000;
 
 #ifdef LLK_TRISC_UNPACK
 
@@ -81,27 +80,38 @@ static constexpr std::uint32_t buffer_polluter_scratch = 0xA0000;
 // Unpack side of the experimental (POLLUTER-selected) op. Reads buffer_A[0]/buffer_B[0].
 static inline void unpack_experimental_(RUNTIME_PARAMETERS params, [[maybe_unused]] const ckernel::TensorShape& tensor_shape)
 {
-#if POLLUTER == 2
-    // sdpa_sub_bcast_col: RMW Haloize_mode=0 (transpose within face) + set both unpacker x_end.
-    // Loads srcB once + ct_dim srcA tiles, paired with the MATH bcast-col reuse scaffold.
-    _llk_unpack_AB_sub_bcast_col_init_custom_(tensor_shape);
-    _llk_unpack_AB_sub_bcast_col_custom_(L1_ADDRESS(params.buffer_A[0]), L1_ADDRESS(params.buffer_B[0]), 1 /* ct_dim */);
-    _llk_unpack_AB_sub_bcast_col_uninit_custom_();
-#elif POLLUTER == 1
-    // reduce_block_max_row: SrcA + SrcB (scaler) streamed via the paired custom AB-reduce unpack.
-    // Its init RMWs Haloize_mode, and under fp32 DEST also ALU_ACC_CTRL_Zero_Flag_disabled_src +
-    // ALU_FORMAT_SPEC SrcA (for MOVB2D hi16/lo16); its uninit restores none of them. The victim
-    // datacopy's own format reconfig + init must reset them — pinned only in the dest_acc=Yes sweep.
-    _llk_unpack_AB_reduce_block_max_row_init_<1 /* block_ct_dim */, is_fp32_dest_acc_en>(tensor_shape);
-    _llk_unpack_AB_reduce_block_max_row_(L1_ADDRESS(params.buffer_A[0]), L1_ADDRESS(params.buffer_B[0]));
-    _llk_unpack_AB_reduce_block_max_row_uninit_();
-#else
-    // matmul_custom_no_mop (0): in0 -> SrcB, in1 -> SrcA via the regular matmul unpacker
-    // (the no-mop MATH replay consumes SrcA/SrcB in the matmul dvalid pattern).
-    const std::uint32_t mm_tile_size = FACE_R_DIM * FACE_C_DIM * NUM_FACES / (is_fp32_dest_acc_en ? 1 : 2);
-    _llk_unpack_AB_matmul_init_<>(0 /* transpose */, 1 /* ct_dim */, 1 /* rt_dim */, 1 /* kt_dim */);
-    _llk_unpack_AB_matmul_<>(L1_ADDRESS(params.buffer_A[0]), L1_ADDRESS(params.buffer_B[0]), 0, 0, mm_tile_size, mm_tile_size);
-#endif
+    if constexpr (POLLUTER == 0)
+    {
+        // matmul_custom_no_mop (0): in0 -> SrcB, in1 -> SrcA via the regular matmul unpacker
+        // (the no-mop MATH replay consumes SrcA/SrcB in the matmul dvalid pattern).
+        const std::uint32_t mm_tile_size = FACE_R_DIM * FACE_C_DIM * NUM_FACES / (is_fp32_dest_acc_en ? 1 : 2);
+        _llk_unpack_AB_matmul_init_<>(0 /* transpose */, 1 /* ct_dim */, 1 /* rt_dim */, 1 /* kt_dim */);
+        _llk_unpack_AB_matmul_<>(
+            L1_ADDRESS(params.buffer_A[0]),
+            L1_ADDRESS(params.buffer_B[0]),
+            0 /* tile_index_a */,
+            0 /* tile_index_b */,
+            mm_tile_size /* tile_size_a */,
+            mm_tile_size /* tile_size_b */);
+    }
+    else if constexpr (POLLUTER == 1)
+    {
+        // reduce_block_max_row: SrcA + SrcB (scaler) streamed via the paired custom AB-reduce unpack.
+        // Its init RMWs Haloize_mode, and under fp32 DEST also ALU_ACC_CTRL_Zero_Flag_disabled_src +
+        // ALU_FORMAT_SPEC SrcA (for MOVB2D hi16/lo16); its uninit restores none of them. The victim
+        // datacopy's own format reconfig + init must reset them — pinned only in the dest_acc=Yes sweep.
+        _llk_unpack_AB_reduce_block_max_row_init_<1 /* block_ct_dim */, is_fp32_dest_acc_en>(tensor_shape);
+        _llk_unpack_AB_reduce_block_max_row_(L1_ADDRESS(params.buffer_A[0]), L1_ADDRESS(params.buffer_B[0]));
+        _llk_unpack_AB_reduce_block_max_row_uninit_();
+    }
+    else if constexpr (POLLUTER == 2)
+    {
+        // sdpa_sub_bcast_col: RMW Haloize_mode=0 (transpose within face) + set both unpacker x_end.
+        // Loads srcB once + ct_dim srcA tiles, paired with the MATH bcast-col reuse scaffold.
+        _llk_unpack_AB_sub_bcast_col_init_custom_(tensor_shape);
+        _llk_unpack_AB_sub_bcast_col_custom_(L1_ADDRESS(params.buffer_A[0]), L1_ADDRESS(params.buffer_B[0]), 1 /* ct_dim */);
+        _llk_unpack_AB_sub_bcast_col_uninit_custom_();
+    }
 }
 
 // Unpack side of a canonical A2D datacopy of the fresh, known tile buffer_A[1].
@@ -128,25 +138,38 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     // compute_kernel_hw_startup
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
-        formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, NUM_FACES, NUM_FACES);
+        formats.unpack_A_src,
+        formats.unpack_B_src,
+        formats.unpack_A_dst,
+        formats.unpack_B_dst,
+        FACE_R_DIM /* unpA_face_r_dim */,
+        FACE_R_DIM /* unpB_face_r_dim */,
+        NUM_FACES /* unpA_num_faces */,
+        NUM_FACES /* unpB_num_faces */);
 
-    // ---- Run 0 (discarded to scratch) ----
-#if SEQUENCE == SEQ_REVERSE
-    unpack_datacopy_(params, formats); // canonical op first
-#else
-    unpack_experimental_(params, tensor_shape); // FORWARD / REPEAT: experimental first
-#endif
+    // ---- Run 0 (discarded) ----
+    if constexpr (SEQUENCE == SEQ_REVERSE)
+    {
+        unpack_datacopy_(params, formats); // canonical op first
+    }
+    else
+    {
+        unpack_experimental_(params, tensor_shape); // FORWARD / REPEAT: experimental first
+    }
 
     // Wait until the run-0 packer has drained before touching unpacker state for run 1.
     t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(semaphore::PACK_DONE);
     t6_semaphore_get<>(semaphore::PACK_DONE);
 
     // ---- Run 1 (validated, packed to buffer_Res[0]) ----
-#if SEQUENCE == SEQ_FORWARD
-    unpack_datacopy_(params, formats); // canonical victim datacopy
-#else
-    unpack_experimental_(params, tensor_shape); // REVERSE / REPEAT: experimental op is the victim
-#endif
+    if constexpr (SEQUENCE == SEQ_FORWARD)
+    {
+        unpack_datacopy_(params, formats); // canonical victim datacopy
+    }
+    else
+    {
+        unpack_experimental_(params, tensor_shape); // REVERSE / REPEAT: experimental op is the victim
+    }
 }
 
 #endif
@@ -163,40 +186,54 @@ void run_kernel(RUNTIME_PARAMETERS params)
 // Math side of the experimental (POLLUTER-selected) op.
 static inline void math_experimental_(RUNTIME_PARAMETERS params, [[maybe_unused]] const ckernel::TensorShape& tensor_shape)
 {
-#if POLLUTER == 0
-    // matmul_custom_no_mop: this THROTTLE_LEVEL 0 full-tile init clobbers ADDR_MODs (BH writes
-    // 0/1/2/4/5 — no ADDR_MOD_3 in the full-tile custom path; WH writes 0..5) and records the
-    // replay image; empty uninit. ADDR_MOD_6 is only programmed at nonzero throttling.
-    _llk_math_matmul_init_no_mop_<MATH_FIDELITY, 0>(TILE_R_DIM, TILE_C_DIM, TILE_R_DIM, TILE_C_DIM, false, 0, 1, 1);
-    _llk_math_wait_for_dest_available_<DST_SYNC>();
-    _llk_math_matmul_no_mop_<MATH_FIDELITY, 0>(0 /* dst_index */, 1, 1);
-    _llk_math_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
-    _llk_math_matmul_uninit_no_mop_();
-#elif POLLUTER == 1
-    // reduce_block_max_row: init sets ADDR_MOD_1/2/3/6 + a MOP template; empty uninit.
-    _llk_math_reduce_block_max_row_init_<1 /* block_ct_dim */, is_fp32_dest_acc_en>(tensor_shape);
-    _llk_math_wait_for_dest_available_<DST_SYNC>();
-    _llk_math_reduce_block_max_row_<1 /* block_ct_dim */, is_fp32_dest_acc_en>(0 /* dst_index */, tensor_shape);
-    _llk_math_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
-    _llk_math_reduce_block_max_row_uninit_<is_fp32_dest_acc_en>();
-#elif POLLUTER == 2
-    // eltwise_binary_custom paired with the sub_bcast_col unpacker (the SDPA fused SUB op).
-    // init sets ADDR_MOD_7 + CLR_DVALID_SrcA disable; empty uninit. The SUB bcast-col reuse
-    // scaffold is the only eltwise_binary_custom entry point common to BH and WH.
-    _llk_math_eltwise_binary_init_custom_<EltwiseBinaryType::ELWSUB, BroadcastType::COL>(NUM_FACES);
-    _llk_math_wait_for_dest_available_<DST_SYNC>();
-    _llk_math_sub_bcast_cols_reuse_custom_(1 /* ct_dim */, tensor_shape, 0 /* dst_index */);
-    _llk_math_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
-    _llk_math_eltwise_binary_uninit_custom_();
-#endif
+    if constexpr (POLLUTER == 0)
+    {
+        // matmul_custom_no_mop: this THROTTLE_LEVEL 0 full-tile init clobbers ADDR_MODs (BH writes
+        // 0/1/2/4/5 — no ADDR_MOD_3 in the full-tile custom path; WH writes 0..5) and records the
+        // replay image; empty uninit. ADDR_MOD_6 is only programmed at nonzero throttling.
+        _llk_math_matmul_init_no_mop_<MATH_FIDELITY, 0 /* THROTTLE_LEVEL */>(
+            TILE_R_DIM /* in0_tile_r_dim */,
+            TILE_C_DIM /* in0_tile_c_dim */,
+            TILE_R_DIM /* in1_tile_r_dim */,
+            TILE_C_DIM /* in1_tile_c_dim */,
+            false /* partial_face */,
+            0 /* transpose */,
+            1 /* ct_dim */,
+            1 /* rt_dim */);
+        _llk_math_wait_for_dest_available_<DST_SYNC>();
+        _llk_math_matmul_no_mop_<MATH_FIDELITY, 0 /* THROTTLE_LEVEL */>(0 /* dst_index */, 1 /* ct_dim */, 1 /* rt_dim */);
+        _llk_math_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
+        _llk_math_matmul_uninit_no_mop_();
+    }
+    else if constexpr (POLLUTER == 1)
+    {
+        // reduce_block_max_row: init sets ADDR_MOD_1/2/3/6 + a MOP template; empty uninit.
+        _llk_math_reduce_block_max_row_init_<1 /* block_ct_dim */, is_fp32_dest_acc_en>(tensor_shape);
+        _llk_math_wait_for_dest_available_<DST_SYNC>();
+        _llk_math_reduce_block_max_row_<1 /* block_ct_dim */, is_fp32_dest_acc_en>(0 /* dst_index */, tensor_shape);
+        _llk_math_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
+        _llk_math_reduce_block_max_row_uninit_<is_fp32_dest_acc_en>();
+    }
+    else if constexpr (POLLUTER == 2)
+    {
+        // eltwise_binary_custom paired with the sub_bcast_col unpacker (the SDPA fused SUB op).
+        // init sets ADDR_MOD_7 + CLR_DVALID_SrcA disable; empty uninit. The SUB bcast-col reuse
+        // scaffold is the only eltwise_binary_custom entry point common to BH and WH.
+        _llk_math_eltwise_binary_init_custom_<EltwiseBinaryType::ELWSUB, BroadcastType::COL>(NUM_FACES /* num_faces */);
+        _llk_math_wait_for_dest_available_<DST_SYNC>();
+        _llk_math_sub_bcast_cols_reuse_custom_(1 /* ct_dim */, tensor_shape, 0 /* dst_index */);
+        _llk_math_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
+        _llk_math_eltwise_binary_uninit_custom_();
+    }
 }
 
 // Math side of a canonical A2D datacopy. Its own init reprograms the ADDR_MODs it consumes
 // (ADDR_MOD_0/2/3) and (via the format reconfig) the ALU format/acc-ctrl state it depends on.
 static inline void math_datacopy_(RUNTIME_PARAMETERS params, const FormatConfig& formats)
 {
-    _llk_math_reconfig_data_format_<is_fp32_dest_acc_en, false>(formats.math, formats.math);
-    _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false /* is_int_fpu_en */>(NUM_FACES, formats.math);
+    _llk_math_reconfig_data_format_<is_fp32_dest_acc_en, false /* to_from_int8 */>(formats.math, formats.math);
+    _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false /* is_int_fpu_en */>(
+        NUM_FACES /* num_faces */, formats.math);
     _llk_math_wait_for_dest_available_<DST_SYNC>();
     _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DST_SYNC, is_fp32_dest_acc_en, BroadcastType::NONE, false /* unpack_to_dest */>(
         0 /* dst_index */, formats.math, formats.math);
@@ -215,18 +252,24 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
 
     // ---- Run 0 (discarded) ----
-#if SEQUENCE == SEQ_REVERSE
-    math_datacopy_(params, formats); // canonical op first
-#else
-    math_experimental_(params, tensor_shape); // FORWARD / REPEAT: experimental first
-#endif
+    if constexpr (SEQUENCE == SEQ_REVERSE)
+    {
+        math_datacopy_(params, formats); // canonical op first
+    }
+    else
+    {
+        math_experimental_(params, tensor_shape); // FORWARD / REPEAT: experimental first
+    }
 
     // ---- Run 1 (validated) ----
-#if SEQUENCE == SEQ_FORWARD
-    math_datacopy_(params, formats); // canonical victim datacopy
-#else
-    math_experimental_(params, tensor_shape); // REVERSE / REPEAT: experimental op is the victim
-#endif
+    if constexpr (SEQUENCE == SEQ_FORWARD)
+    {
+        math_datacopy_(params, formats); // canonical victim datacopy
+    }
+    else
+    {
+        math_experimental_(params, tensor_shape); // REVERSE / REPEAT: experimental op is the victim
+    }
 }
 
 #endif
@@ -256,21 +299,23 @@ void run_kernel(RUNTIME_PARAMETERS params)
         formats.pack_dst, tensor_shape.face_r_dim, tensor_shape.total_col_dim(), num_faces, partial_face, narrow_tile);
     _llk_pack_dest_init_wrapper_<DST_SYNC, is_fp32_dest_acc_en, PackMode::Default>(tensor_shape.face_r_dim, narrow_tile);
 
-#if POLLUTER == 1
-    // reduce_block_max_row (FORWARD-only, so it is always run 0) emits a masked (REDUCE_ROW)
-    // scalar; mask so the discarded polluter output packs without asserting, then clear it
-    // before the victim pack.
-    _llk_pack_reduce_mask_config_<ReduceDim::REDUCE_ROW>();
-#endif
+    if constexpr (POLLUTER == 1)
+    {
+        // reduce_block_max_row (FORWARD-only, so it is always run 0) emits a masked (REDUCE_ROW)
+        // scalar; mask so the discarded polluter output packs without asserting, then clear it
+        // before the victim pack.
+        _llk_pack_reduce_mask_config_<ReduceDim::REDUCE_ROW>();
+    }
 
-    // ---- Run 0: pack the discarded result to scratch ----
+    // ---- Run 0: pack the discarded result to buffer_Res[0] (overwritten by run 1) ----
     _llk_packer_wait_for_math_done_();
-    _llk_pack_<DST_SYNC, is_fp32_dest_acc_en, ckernel::PackMode::Default>(0 /* dst_index */, L1_ADDRESS(buffer_polluter_scratch));
+    _llk_pack_<DST_SYNC, is_fp32_dest_acc_en, ckernel::PackMode::Default>(0 /* dst_index */, L1_ADDRESS(params.buffer_Res[0]));
     _llk_pack_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
 
-#if POLLUTER == 1
-    _llk_pack_reduce_mask_clear_();
-#endif
+    if constexpr (POLLUTER == 1)
+    {
+        _llk_pack_reduce_mask_clear_();
+    }
 
     // Signal the unpacker that run-0 has fully drained.
     t6_semaphore_post<>(semaphore::PACK_DONE);


### PR DESCRIPTION
## What

Adds a **reconfig-escape / empty-`uninit`** test for the experimental LLKs. Several experimental LLKs have an **empty or no-op `uninit`** even though their `init` clobbers persistent HW state (ADDR_MODs, cfg regs such as `THCON_SEC0_REG2_Haloize_mode`). This is the #1 contract hole in the experimental-LLK inventory: state could leak into the next op. This test **pins** that no such escape occurs.

- `tests/sources/experimental_reconfig_escape_test.cpp`
- `tests/python_tests/test_experimental_reconfig_escape.py`

Closes #50203 (part of #47554, experimental-LLK coverage). Covers all four target LLKs:
`matmul_custom_no_mop`, `reduce_block_max_row`, `eltwise_binary_custom`, `unpack_AB_sub_bcast_col_custom`.

## How the escape pins work

Each parametrized case runs a **two-op sequence** and validates the *second* op:

1. **run 0 (POLLUTER)** — the experimental op runs its `init` + one op + its (empty) `uninit`. Its packed output goes to a scratch buffer and is **discarded**.
2. **run 1 (VICTIM)** — a canonical `datacopy` (A2D) of a *fresh, known* input tile (`buffer_A[1]`), packed to the result buffer and validated against its input.

The victim datacopy runs **only its own standard init** (no extra reinit/reconfig help). If a polluter's empty `uninit` let stale ADDR_MOD / cfg state survive *and* the datacopy init did not re-establish the state it consumes, the copy would diverge from its input. A green result pins the invariant **"empty uninit + canonical op's own init == correct"** — so if someone later removes an init's ADDR_MOD/Haloize reprogramming (relying on an uninit that doesn't exist), this test breaks.

Three polluter scenarios (`POLLUTER` compile-time selector):

| POLLUTER | Experimental op(s) | Clobbered state (empty uninit) |
|---|---|---|
| 0 | `matmul_custom_no_mop` (MATH) | ADDR_MOD_0..6 + replay image |
| 1 | `reduce_block_max_row` (MATH) | ADDR_MOD_1/2/3/6 + MOP template |
| 2 | `eltwise_binary_custom` (MATH) **paired with** `unpack_AB_sub_bcast_col_custom` (UNPACK) — the SDPA fused sub+bcast-col op | MATH: ADDR_MOD_7 + CLR_DVALID_SrcA disable · UNPACK: `THCON_SEC0_REG2_Haloize_mode` RMW + SETADCXX x_end |

`eltwise_binary_custom` and `unpack_AB_sub_bcast_col_custom` only run correctly *as a pair* (the SDPA SUB flow), so they are exercised together in scenario 2 — covering both the MATH-side and UNPACK-side empty uninits in one sequence.

## Reconfig escapes found

**None** — every scenario passes, which is the correct outcome and is exactly what the test pins:

- The **MATH** polluters clobber ADDR_MODs, but the victim datacopy's own init reprograms exactly the ADDR_MODs it consumes (ADDR_MOD_0/2/3, via `eltwise_unary_configure_addrmod`), so the clobbers cannot corrupt the copy.
- The **UNPACK** polluter (`sub_bcast_col`) RMWs `Haloize_mode` (transpose-within-face), but the victim's `_llk_unpack_A_init_` rewrites `Haloize_mode` (`config_unpacker`), so the transpose bit cannot leak.

The empty uninits are safe *because the next op's init is self-sufficient*. No LLK behavior change was needed (and, per the issue, none was made to hide anything). The fp32-DEST zero-flag path (`ALU_ACC_CTRL_Zero_Flag_disabled_src`, set without restore in the custom reduce unpack init) is deliberately out of scope here — the test runs bf16 DEST so it isolates the named ADDR_MOD / Haloize contract hole.

## Coverage

BH + WH B0. `formats` bf16, `math_fidelity` {HiFi2, HiFi4} × 3 polluter scenarios = 6 variants. Both fidelities are swept because `matmul_custom_no_mop` programs different fidelity-phase ADDR_MODs (ADDR_MOD_5/6) at HiFi vs LoFi.

## Header tweaks

None. The four experimental headers already compile standalone (no spurious `llk_operands.h` include to remove, unlike the sibling `mul_reduce_scalar` PR).

## Validation

- `compile` (compile-producer): all 6 variants compile cleanly on **Blackhole** and **Wormhole B0**.
- Runtime: all 6 variants **PASS on Wormhole B0 silicon** (this box is a WH n150). Blackhole runtime is exercised by CI.
- pre-commit (clang-format / black / isort / pylint / codespell / license) green.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ncvetkovic/llk-test-reconfig-escape)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ncvetkovic/llk-test-reconfig-escape)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ncvetkovic/llk-test-reconfig-escape)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ncvetkovic/llk-test-reconfig-escape)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ncvetkovic/llk-test-reconfig-escape)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ncvetkovic/llk-test-reconfig-escape)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ncvetkovic/llk-test-reconfig-escape)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ncvetkovic/llk-test-reconfig-escape)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ncvetkovic/llk-test-reconfig-escape)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ncvetkovic/llk-test-reconfig-escape)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ncvetkovic/llk-test-reconfig-escape)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ncvetkovic/llk-test-reconfig-escape)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ncvetkovic/llk-test-reconfig-escape)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ncvetkovic/llk-test-reconfig-escape)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ncvetkovic/llk-test-reconfig-escape)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ncvetkovic/llk-test-reconfig-escape)