### PR TITLE
[LLK][test] Deepen reduce_block_max_row coverage (standalone + runtime/reinit variants)

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
@@ -352,6 +352,36 @@ class CLOBBER_OP(TemplateParameter):
 
 
 @dataclass
+class RESPECT_TRIGGER(TemplateParameter):
+    """Enable the reduce_block_max_row producer/consumer trigger handshake.
+
+    When true, the unpack splits the block reduce into two half-width MOP runs
+    separated by a HW semaphore wait (FPU_SFPU), so the reduce can start on the
+    first half of the block before the second half is signalled. The test's PACK
+    thread plays the producer (posts the tokens). Requires an even block_ct_dim
+    (the unpack MOP outerloop is block_ct_dim / 2)."""
+
+    respect_trigger: bool = False
+
+    def convert_to_cpp(self) -> str:
+        return f"constexpr bool RESPECT_TRIGGER = {str(self.respect_trigger).lower()};"
+
+
+@dataclass
+class OVERLAP_FIRST_HALF(TemplateParameter):
+    """Overlap the first-half reduce with the second-half pack (runtime family only).
+
+    When true (and RESPECT_TRIGGER + USE_RUNTIME), the unpack's first half gates on
+    the early UNPACK_MATH_DONE token instead of FPU_SFPU, so run()#1 overlaps the
+    second-half pack. Ignored by the compile-time unpack family (no overlap path)."""
+
+    overlap_first_half: bool = False
+
+    def convert_to_cpp(self) -> str:
+        return f"constexpr bool OVERLAP_FIRST_HALF = {str(self.overlap_first_half).lower()};"
+
+
+@dataclass
 class ITERATIONS(TemplateParameter):
     iterations: int = 8
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
@@ -314,26 +314,6 @@ class BLOCK_CT_DIM(TemplateParameter):
 
 
 @dataclass
-class RESPECT_TRIGGER(TemplateParameter):
-    """Enables the SDPA MOP-split trigger optimization in reduce_block_max_row."""
-
-    respect_trigger: bool = False
-
-    def convert_to_cpp(self) -> str:
-        return f"constexpr bool RESPECT_TRIGGER = {str(self.respect_trigger).lower()};"
-
-
-@dataclass
-class OVERLAP_FIRST_HALF(TemplateParameter):
-    """Enables the overlap-first-half trigger token in the runtime reduce_block_max_row."""
-
-    overlap_first_half: bool = False
-
-    def convert_to_cpp(self) -> str:
-        return f"constexpr bool OVERLAP_FIRST_HALF = {str(self.overlap_first_half).lower()};"
-
-
-@dataclass
 class USE_RUNTIME(TemplateParameter):
     """Selects the runtime (dynamic block_ct_dim) reduce_block_max_row LLK family."""
 
@@ -351,6 +331,17 @@ class REINIT_MODE(TemplateParameter):
 
     def convert_to_cpp(self) -> str:
         return f"constexpr int REINIT_MODE = {self.reinit_mode};"
+
+
+@dataclass
+class CLOBBER_OP(TemplateParameter):
+    """Op run between reduce init and reinit to overwrite the reduce MOP/addrmods:
+    0=none, 1=eltwise binary (reconfig-escape guard for the reinit paths)."""
+
+    clobber_op: int = 0
+
+    def convert_to_cpp(self) -> str:
+        return f"constexpr int CLOBBER_OP = {self.clobber_op};"
 
 
 @dataclass

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
@@ -304,6 +304,56 @@ class APPROX_MODE(TemplateParameter):
 
 
 @dataclass
+class BLOCK_CT_DIM(TemplateParameter):
+    """Compile-time block width (in tiles) for the block-based reduce_block_max_row LLKs."""
+
+    block_ct_dim: int
+
+    def convert_to_cpp(self) -> str:
+        return f"constexpr std::uint32_t BLOCK_CT_DIM = {self.block_ct_dim};"
+
+
+@dataclass
+class RESPECT_TRIGGER(TemplateParameter):
+    """Enables the SDPA MOP-split trigger optimization in reduce_block_max_row."""
+
+    respect_trigger: bool = False
+
+    def convert_to_cpp(self) -> str:
+        return f"constexpr bool RESPECT_TRIGGER = {str(self.respect_trigger).lower()};"
+
+
+@dataclass
+class OVERLAP_FIRST_HALF(TemplateParameter):
+    """Enables the overlap-first-half trigger token in the runtime reduce_block_max_row."""
+
+    overlap_first_half: bool = False
+
+    def convert_to_cpp(self) -> str:
+        return f"constexpr bool OVERLAP_FIRST_HALF = {str(self.overlap_first_half).lower()};"
+
+
+@dataclass
+class USE_RUNTIME(TemplateParameter):
+    """Selects the runtime (dynamic block_ct_dim) reduce_block_max_row LLK family."""
+
+    use_runtime: bool = False
+
+    def convert_to_cpp(self) -> str:
+        return f"constexpr bool USE_RUNTIME = {str(self.use_runtime).lower()};"
+
+
+@dataclass
+class REINIT_MODE(TemplateParameter):
+    """Selects the reduce_block_max_row re-arm path: 0=none, 1=short, 2=minimal."""
+
+    reinit_mode: int = 0
+
+    def convert_to_cpp(self) -> str:
+        return f"constexpr int REINIT_MODE = {self.reinit_mode};"
+
+
+@dataclass
 class ITERATIONS(TemplateParameter):
     iterations: int = 8
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
@@ -304,13 +304,18 @@ class APPROX_MODE(TemplateParameter):
 
 
 @dataclass
-class BLOCK_CT_DIM(TemplateParameter):
-    """Compile-time block width (in tiles) for the block-based reduce_block_max_row LLKs."""
+class REDUCE_BLOCK_CT_DIM(TemplateParameter):
+    """Compile-time block width (in tiles) for the block-based reduce_block_max_row LLKs.
+
+    Emits a dedicated ``REDUCE_BLOCK_CT_DIM`` symbol (not ``BLOCK_CT_DIM``) so it cannot
+    collide with the ``BLOCK_CT_DIM`` that ``INPUT_DIMENSIONS`` already emits — the header
+    generator concatenates every param's ``convert_to_cpp()`` with no de-dup.
+    """
 
     block_ct_dim: int
 
     def convert_to_cpp(self) -> str:
-        return f"constexpr std::uint32_t BLOCK_CT_DIM = {self.block_ct_dim};"
+        return f"constexpr std::uint32_t REDUCE_BLOCK_CT_DIM = {self.block_ct_dim};"
 
 
 @dataclass
@@ -335,8 +340,10 @@ class REINIT_MODE(TemplateParameter):
 
 @dataclass
 class CLOBBER_OP(TemplateParameter):
-    """Op run between reduce init and reinit to overwrite the reduce MOP/addrmods:
-    0=none, 1=eltwise binary (reconfig-escape guard for the reinit paths)."""
+    """Op run between reduce init and reinit to overwrite the reduce MOP/addrmods
+    (reconfig-escape guard for the reinit paths):
+    0=none, 1=eltwise binary (all addrmods + MOP), 2=minimal_safe (ADDR_MOD_1/2/6 only).
+    """
 
     clobber_op: int = 0
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
@@ -307,9 +307,15 @@ class APPROX_MODE(TemplateParameter):
 class REDUCE_BLOCK_CT_DIM(TemplateParameter):
     """Compile-time block width (in tiles) for the block-based reduce_block_max_row LLKs.
 
-    Emits a dedicated ``REDUCE_BLOCK_CT_DIM`` symbol (not ``BLOCK_CT_DIM``) so it cannot
-    collide with the ``BLOCK_CT_DIM`` that ``INPUT_DIMENSIONS`` already emits — the header
-    generator concatenates every param's ``convert_to_cpp()`` with no de-dup.
+    A standalone one-line constant, deliberately *not* routed through the matmul-centric
+    ``INPUT_DIMENSIONS`` bundle: this pure block-reduce test has no use for that bundle's
+    other fields (``FULL_RT_DIM`` / ``FULL_CT_DIM`` / ``BLOCK_RT_DIM``) or its
+    ``generate_input_dim`` tile-shape validation, and it needs only a plain compile-time
+    block width. The distinct name (``REDUCE_BLOCK_CT_DIM``, not ``BLOCK_CT_DIM``) also
+    preempts a redefinition clash if ``INPUT_DIMENSIONS`` — the sole emitter of
+    ``BLOCK_CT_DIM`` — is ever added to this test: the header generator concatenates every
+    param's ``convert_to_cpp()`` with no de-dup, so two same-named ``constexpr`` lines would
+    fail to compile. (This test does not currently emit ``BLOCK_CT_DIM``.)
     """
 
     block_ct_dim: int

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
@@ -338,7 +338,8 @@ class USE_RUNTIME(TemplateParameter):
 
 @dataclass
 class REINIT_MODE(TemplateParameter):
-    """Selects the reduce_block_max_row re-arm path: 0=none, 1=short, 2=minimal."""
+    """Selects the reduce_block_max_row re-arm path: 0=none, 1=short (MOP + addrmods),
+    2=minimal (ADDR_MOD_1/2/6), 3=addrmod-only reinit (ADDR_MOD_1/2/3/6)."""
 
     reinit_mode: int = 0
 
@@ -350,7 +351,8 @@ class REINIT_MODE(TemplateParameter):
 class CLOBBER_OP(TemplateParameter):
     """Op run between reduce init and reinit to overwrite the reduce MOP/addrmods
     (reconfig-escape guard for the reinit paths):
-    0=none, 1=eltwise binary (all addrmods + MOP), 2=minimal_safe (ADDR_MOD_1/2/6 only).
+    0=none, 1=eltwise binary (all addrmods + MOP), 2=minimal_safe (ADDR_MOD_1/2/6 only),
+    3=addrmod_all (ADDR_MOD_1/2/3/6).
     """
 
     clobber_op: int = 0

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
@@ -318,10 +318,12 @@ class REDUCE_BLOCK_CT_DIM(TemplateParameter):
     fail to compile. (This test does not currently emit ``BLOCK_CT_DIM``.)
     """
 
-    block_ct_dim: int
+    reduce_block_ct_dim: int
 
     def convert_to_cpp(self) -> str:
-        return f"constexpr std::uint32_t REDUCE_BLOCK_CT_DIM = {self.block_ct_dim};"
+        return (
+            f"constexpr std::uint32_t REDUCE_BLOCK_CT_DIM = {self.reduce_block_ct_dim};"
+        )
 
 
 @dataclass

--- a/tt_metal/tt-llk/tests/python_tests/test_reduce_block_max.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_reduce_block_max.py
@@ -30,14 +30,13 @@ import torch
 from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
 from helpers.format_config import DataFormat, InputOutputFormat
 from helpers.golden_generators import ReduceBlockMaxRowGolden, get_golden_generator
-from helpers.llk_params import DestAccumulation, MathFidelity
+from helpers.llk_params import DestAccumulation
 from helpers.param_config import parametrize
 from helpers.stimuli_config import StimuliConfig
 from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import (
     BLOCK_CT_DIM,
     CLOBBER_OP,
-    MATH_FIDELITY,
     REINIT_MODE,
     USE_RUNTIME,
 )
@@ -73,7 +72,6 @@ def _dest_acc(output_format):
 
 def _run_reduce_block_max(
     formats,
-    math_fidelity,
     block_ct_dim,
     use_runtime=False,
     reinit="none",
@@ -120,7 +118,6 @@ def _run_reduce_block_max(
         formats,
         templates=[
             BLOCK_CT_DIM(block_ct_dim),
-            MATH_FIDELITY(math_fidelity),
             USE_RUNTIME(use_runtime),
             REINIT_MODE(_REINIT_DEFINE[reinit]),
             CLOBBER_OP(_CLOBBER_DEFINE[clobber]),
@@ -163,37 +160,39 @@ def _run_reduce_block_max(
         d = float(res[pr, 0])
         assert abs(d - g) <= tol.atol + tol.rtol * abs(g), (
             f"reduce_block_max_row mismatch at row {pr}: device={d} golden={g} "
-            f"(block_ct_dim={block_ct_dim}, fidelity={math_fidelity.name})"
+            f"(block_ct_dim={block_ct_dim})"
         )
 
 
+# Math fidelity is intentionally not swept: reduce_block_max_row is a pure MAX pool
+# (scaler fixed at 1.0) and the reduce LLKs take no fidelity template, so HiFi2/HiFi4
+# would produce identical kernels.
+
+
 @parametrize(
     formats=FORMATS,
-    math_fidelity=[MathFidelity.HiFi2, MathFidelity.HiFi4],
     block_ct_dim=[1, 2, 3, 4, 8],
 )
-def test_reduce_block_max(formats, math_fidelity, block_ct_dim):
+def test_reduce_block_max(formats, block_ct_dim):
     """Compile-time block_ct_dim sweep, bf16 and fp32-dest."""
-    _run_reduce_block_max(formats, math_fidelity, block_ct_dim)
+    _run_reduce_block_max(formats, block_ct_dim)
 
 
 @parametrize(
     formats=FORMATS,
-    math_fidelity=[MathFidelity.HiFi2, MathFidelity.HiFi4],
     block_ct_dim=[1, 2, 4, 8],
 )
-def test_reduce_block_max_runtime(formats, math_fidelity, block_ct_dim):
+def test_reduce_block_max_runtime(formats, block_ct_dim):
     """Runtime (dynamic block_ct_dim) path."""
-    _run_reduce_block_max(formats, math_fidelity, block_ct_dim, use_runtime=True)
+    _run_reduce_block_max(formats, block_ct_dim, use_runtime=True)
 
 
 @parametrize(
     formats=FORMATS,
-    math_fidelity=[MathFidelity.HiFi2, MathFidelity.HiFi4],
     block_ct_dim=[2, 4],
     reinit=["short", "minimal"],
 )
-def test_reduce_block_max_reinit(formats, math_fidelity, block_ct_dim, reinit):
+def test_reduce_block_max_reinit(formats, block_ct_dim, reinit):
     """Reinit / reprogram after a clobbering op (reconfig-escape guard).
 
     An eltwise binary op runs between init and reinit to overwrite the reduce MOP
@@ -206,18 +205,15 @@ def test_reduce_block_max_reinit(formats, math_fidelity, block_ct_dim, reinit):
         pytest.skip(
             "compile-time reduce_block_max_row reinit is a Blackhole-only lib path"
         )
-    _run_reduce_block_max(
-        formats, math_fidelity, block_ct_dim, reinit=reinit, clobber="eltwise"
-    )
+    _run_reduce_block_max(formats, block_ct_dim, reinit=reinit, clobber="eltwise")
 
 
 @parametrize(
     formats=FORMATS,
-    math_fidelity=[MathFidelity.HiFi2, MathFidelity.HiFi4],
     block_ct_dim=[2, 4],
     reinit=["short", "minimal"],
 )
-def test_reduce_block_max_reinit_runtime(formats, math_fidelity, block_ct_dim, reinit):
+def test_reduce_block_max_reinit_runtime(formats, block_ct_dim, reinit):
     """Runtime reinit paths: reinit_short_runtime on both arches;
     reinit_minimal_runtime is a Blackhole-only lib fn."""
     if reinit == "minimal" and get_chip_architecture() != ChipArchitecture.BLACKHOLE:
@@ -225,10 +221,5 @@ def test_reduce_block_max_reinit_runtime(formats, math_fidelity, block_ct_dim, r
             "runtime reduce_block_max_row reinit_minimal is a Blackhole-only lib path"
         )
     _run_reduce_block_max(
-        formats,
-        math_fidelity,
-        block_ct_dim,
-        use_runtime=True,
-        reinit=reinit,
-        clobber="eltwise",
+        formats, block_ct_dim, use_runtime=True, reinit=reinit, clobber="eltwise"
     )

--- a/tt_metal/tt-llk/tests/python_tests/test_reduce_block_max.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_reduce_block_max.py
@@ -21,8 +21,9 @@ pure MAX and the scaler is a no-op multiplier.
 Coverage (Blackhole + Wormhole B0):
   * compile-time path, ``block_ct_dim`` sweep, bf16 and fp32-dest;
   * runtime path (dynamic ``block_ct_dim``);
-  * reinit_short / reinit_minimal (compile-time = Blackhole-only lib fns; runtime
-    = both arches) re-arm after the init, guarding the reconfig-escape path.
+  * reinit_short / reinit_minimal re-arm after the init, guarding the reconfig-escape
+    path. Compile-time reinit_short/minimal are Blackhole-only lib fns; runtime
+    reinit_short runs on both arches, runtime reinit_minimal is Blackhole-only.
 """
 
 import pytest
@@ -35,8 +36,8 @@ from helpers.param_config import parametrize
 from helpers.stimuli_config import StimuliConfig
 from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import (
-    BLOCK_CT_DIM,
     CLOBBER_OP,
+    REDUCE_BLOCK_CT_DIM,
     REINIT_MODE,
     USE_RUNTIME,
 )
@@ -122,7 +123,7 @@ def _run_reduce_block_max(
         "sources/reduce_block_max_test.cpp",
         formats,
         templates=[
-            BLOCK_CT_DIM(block_ct_dim),
+            REDUCE_BLOCK_CT_DIM(block_ct_dim),
             USE_RUNTIME(use_runtime),
             REINIT_MODE(_REINIT_DEFINE[reinit]),
             CLOBBER_OP(_CLOBBER_DEFINE[clobber]),
@@ -197,9 +198,13 @@ def test_reduce_block_max_runtime(formats, block_ct_dim):
 def test_reduce_block_max_reinit(formats, block_ct_dim, reinit):
     """Reinit / reprogram after a clobbering op (reconfig-escape guard).
 
-    An eltwise binary op runs between init and reinit to overwrite the reduce MOP
-    and addrmods (as matmul / sub_exp do in the SDPA inner loop); the reinit must
-    restore them for the reduce to match golden.
+    A clobber runs between init and reinit to overwrite the reduce config, then the
+    reinit must restore it for the reduce to match golden. The clobber matches each
+    reinit's restore contract (``_CLOBBER_FOR_REINIT``):
+      * reinit_short pairs with an eltwise binary op (reprograms all addrmods + MOP,
+        as matmul / sub_exp do in the SDPA inner loop);
+      * reinit_minimal pairs with ``minimal_safe`` (an ADDR_MOD_1/2/6-only scramble
+        leaving ADDR_MOD_3 + MOP intact — the narrow escape it expects).
 
     Compile-time short/minimal reinit lib fns are Blackhole-only; skip on WH.
     """

--- a/tt_metal/tt-llk/tests/python_tests/test_reduce_block_max.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_reduce_block_max.py
@@ -24,6 +24,10 @@ Coverage (Blackhole + Wormhole B0):
   * reinit_short / reinit_minimal re-arm after the init, guarding the reconfig-escape
     path. Compile-time reinit_short/minimal are Blackhole-only lib fns; runtime
     reinit_short runs on both arches, runtime reinit_minimal is Blackhole-only.
+  * trigger handshake (respect_trigger, + overlap_first_half on the runtime family):
+    the unpack splits the block reduce into two half-width MOP runs gated by HW
+    semaphores; the PACK thread plays the producer. Both arches. Validates split-MOP
+    correctness + semaphore balance (not the SDPA live-data overlap; see the C++ note).
 """
 
 import pytest
@@ -37,8 +41,10 @@ from helpers.stimuli_config import StimuliConfig
 from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import (
     CLOBBER_OP,
+    OVERLAP_FIRST_HALF,
     REDUCE_BLOCK_CT_DIM,
     REINIT_MODE,
+    RESPECT_TRIGGER,
     USE_RUNTIME,
 )
 from helpers.tilize_untilize import tilize, untilize
@@ -84,6 +90,8 @@ def _run_reduce_block_max(
     use_runtime=False,
     reinit="none",
     clobber="none",
+    respect_trigger=False,
+    overlap_first_half=False,
 ):
     dest_acc = _dest_acc(formats.output_format)
 
@@ -127,6 +135,8 @@ def _run_reduce_block_max(
             USE_RUNTIME(use_runtime),
             REINIT_MODE(_REINIT_DEFINE[reinit]),
             CLOBBER_OP(_CLOBBER_DEFINE[clobber]),
+            RESPECT_TRIGGER(respect_trigger),
+            OVERLAP_FIRST_HALF(overlap_first_half),
         ],
         variant_stimuli=StimuliConfig(
             src_A,
@@ -235,4 +245,36 @@ def test_reduce_block_max_reinit_runtime(formats, block_ct_dim, reinit):
         use_runtime=True,
         reinit=reinit,
         clobber=_CLOBBER_FOR_REINIT[reinit],
+    )
+
+
+# block_ct_dim must be even: respect_trigger splits the unpack MOP into two half-block
+# runs (outerloop = block_ct_dim / 2), so an odd width would drop a tile.
+@parametrize(
+    formats=FORMATS,
+    block_ct_dim=[2, 4, 8],
+)
+def test_reduce_block_max_trigger(formats, block_ct_dim):
+    """Compile-time trigger handshake: the unpack splits the block reduce into two
+    half-width MOP runs separated by a HW semaphore wait on FPU_SFPU, with the PACK
+    thread posting the data-ready token. Validates split-MOP Z-counter continuity and
+    semaphore post/wait/get balance; the reduce must still match golden. Both arches."""
+    _run_reduce_block_max(formats, block_ct_dim, respect_trigger=True)
+
+
+@parametrize(
+    formats=FORMATS,
+    block_ct_dim=[2, 4, 8],
+    overlap_first_half=[False, True],
+)
+def test_reduce_block_max_trigger_runtime(formats, block_ct_dim, overlap_first_half):
+    """Runtime trigger handshake. overlap_first_half switches run()#1's gate from
+    FPU_SFPU to the early UNPACK_MATH_DONE token (so the first-half reduce overlaps
+    the second-half pack); the PACK thread posts both tokens. Both arches."""
+    _run_reduce_block_max(
+        formats,
+        block_ct_dim,
+        use_runtime=True,
+        respect_trigger=True,
+        overlap_first_half=overlap_first_half,
     )

--- a/tt_metal/tt-llk/tests/python_tests/test_reduce_block_max.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_reduce_block_max.py
@@ -56,10 +56,17 @@ FORMATS = [
 # REINIT_MODE C++ selector: 0 = plain init, 1 = reinit_short, 2 = reinit_minimal.
 _REINIT_DEFINE = {"none": 0, "short": 1, "minimal": 2}
 
-# CLOBBER_OP C++ selector: op run between init and reinit to overwrite the reduce
-# MOP / addrmods, so the reinit path must actually restore them (reconfig-escape guard).
-# 0 = none, 1 = eltwise binary (ELWADD, clobbers the MOP + addrmods like matmul/sub_exp).
-_CLOBBER_DEFINE = {"none": 0, "eltwise": 1}
+# CLOBBER_OP C++ selector: op run between init and reinit to overwrite the reduce config,
+# so the reinit path must actually restore it (reconfig-escape guard).
+#   0 = none.
+#   1 = eltwise binary (ELWADD) init — clobbers ALL addrmods (incl. ADDR_MOD_3) + the MOP;
+#       paired with reinit_short (which reprograms the MOP and all addrmods).
+#   2 = scramble ADDR_MOD_1/2/6 only, preserving ADDR_MOD_3 + MOP; paired with reinit_minimal
+#       (which restores only 1/2/6 and relies on 3/MOP being intact, as matmul/sub_exp do).
+_CLOBBER_DEFINE = {"none": 0, "eltwise": 1, "minimal_safe": 2}
+
+# The clobber must match the reinit's restore contract, or the reduce hangs.
+_CLOBBER_FOR_REINIT = {"short": "eltwise", "minimal": "minimal_safe"}
 
 
 def _dest_acc(output_format):
@@ -205,7 +212,9 @@ def test_reduce_block_max_reinit(formats, block_ct_dim, reinit):
         pytest.skip(
             "compile-time reduce_block_max_row reinit is a Blackhole-only lib path"
         )
-    _run_reduce_block_max(formats, block_ct_dim, reinit=reinit, clobber="eltwise")
+    _run_reduce_block_max(
+        formats, block_ct_dim, reinit=reinit, clobber=_CLOBBER_FOR_REINIT[reinit]
+    )
 
 
 @parametrize(
@@ -221,5 +230,9 @@ def test_reduce_block_max_reinit_runtime(formats, block_ct_dim, reinit):
             "runtime reduce_block_max_row reinit_minimal is a Blackhole-only lib path"
         )
     _run_reduce_block_max(
-        formats, block_ct_dim, use_runtime=True, reinit=reinit, clobber="eltwise"
+        formats,
+        block_ct_dim,
+        use_runtime=True,
+        reinit=reinit,
+        clobber=_CLOBBER_FOR_REINIT[reinit],
     )

--- a/tt_metal/tt-llk/tests/python_tests/test_reduce_block_max.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_reduce_block_max.py
@@ -29,24 +29,23 @@ import pytest
 import torch
 from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
 from helpers.format_config import DataFormat, InputOutputFormat
+from helpers.golden_generators import ReduceBlockMaxRowGolden, get_golden_generator
 from helpers.llk_params import DestAccumulation, MathFidelity
 from helpers.param_config import parametrize
 from helpers.stimuli_config import StimuliConfig
-from helpers.stimuli_generator import StimuliSpec, generate_stimuli
 from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import (
     BLOCK_CT_DIM,
+    CLOBBER_OP,
     MATH_FIDELITY,
     REINIT_MODE,
     USE_RUNTIME,
 )
+from helpers.tilize_untilize import tilize, untilize
 from helpers.utils import tolerances
 
-# 32x32 bf16 tile, stored as 4 faces of 16x16 (2x2 face grid).
+# 32x32 bf16 tile.
 TILE_DIM = 32
-FACE_DIM = 16
-FACES_PER_ROW = 2  # num_faces_c_dim
-FACE_SIZE = FACE_DIM * FACE_DIM
 ELEMENTS_PER_TILE = TILE_DIM * TILE_DIM
 
 # Inputs are always bf16 (the op's contract); only the DEST/output precision varies.
@@ -58,6 +57,11 @@ FORMATS = [
 # REINIT_MODE C++ selector: 0 = plain init, 1 = reinit_short, 2 = reinit_minimal.
 _REINIT_DEFINE = {"none": 0, "short": 1, "minimal": 2}
 
+# CLOBBER_OP C++ selector: op run between init and reinit to overwrite the reduce
+# MOP / addrmods, so the reinit path must actually restore them (reconfig-escape guard).
+# 0 = none, 1 = eltwise binary (ELWADD, clobbers the MOP + addrmods like matmul/sub_exp).
+_CLOBBER_DEFINE = {"none": 0, "eltwise": 1}
+
 
 def _dest_acc(output_format):
     return (
@@ -67,67 +71,49 @@ def _dest_acc(output_format):
     )
 
 
-def _defined_output_indices():
-    """Flat (tilized) indices of the defined row-max lanes in the 32x32 output tile.
-
-    The row-max for each of the 32 physical rows lands in column [0], which in the
-    4-face tile layout is: face-row ``pr // 16`` (faces {0,1} or {2,3}), row
-    ``pr % 16``, col 0 → flat index (face_row * FACES_PER_ROW) * FACE_SIZE + within*16.
-    """
-    indices = []
-    for pr in range(TILE_DIM):
-        face_row = pr // FACE_DIM
-        within = pr % FACE_DIM
-        indices.append((face_row * FACES_PER_ROW) * FACE_SIZE + within * FACE_DIM)
-    return indices
-
-
-def _row_max_golden(src_a, block_ct_dim):
-    """Per-row MAX across the whole block width (block_ct_dim tiles x 32 cols).
-
-    Operand A is block_ct_dim contiguous 32x32 tiles in tilized (4-face) layout.
-    Returns a flat 1024-element tile with the row-max placed in column [0] of each
-    physical row (tilized layout); other lanes are left 0 (unspecified on HW).
-    Mirrors helpers.golden_generators.ReduceBlockMaxRowGolden semantics.
-    """
-    src = src_a.to(torch.float32)
-    out = torch.zeros(ELEMENTS_PER_TILE, dtype=torch.float32)
-    for pr in range(TILE_DIM):
-        face_row = pr // FACE_DIM
-        within = pr % FACE_DIM
-        row_vals = []
-        for t in range(block_ct_dim):
-            tile_base = t * ELEMENTS_PER_TILE
-            # The two faces holding physical row `pr` (left cols 0-15, right cols 16-31).
-            for fc in range(FACES_PER_ROW):
-                face = face_row * FACES_PER_ROW + fc
-                face_base = tile_base + face * FACE_SIZE + within * FACE_DIM
-                row_vals.append(src[face_base : face_base + FACE_DIM])
-        out_idx = (face_row * FACES_PER_ROW) * FACE_SIZE + within * FACE_DIM
-        out[out_idx] = torch.max(torch.cat(row_vals))
-    return out
-
-
 def _run_reduce_block_max(
-    formats, math_fidelity, block_ct_dim, use_runtime=False, reinit="none"
+    formats,
+    math_fidelity,
+    block_ct_dim,
+    use_runtime=False,
+    reinit="none",
+    clobber="none",
 ):
     dest_acc = _dest_acc(formats.output_format)
-    # Operand A is a single block of block_ct_dim tiles, laid out tile-major
-    # (each 32x32 tile contiguous), i.e. a 32-row x (block_ct_dim*32)-col operand.
-    input_dimensions = [TILE_DIM, block_ct_dim * TILE_DIM]
 
-    # A ~ U[0, 1] keeps every row-max well inside bf16's dynamic range.
-    src_A, tile_cnt_A, _, _ = generate_stimuli(
-        stimuli_format_A=formats.input_format,
-        input_dimensions_A=input_dimensions,
-        stimuli_format_B=formats.input_format,
-        input_dimensions_B=input_dimensions,
-        spec_A=StimuliSpec.uniform(low=0.0, high=1.0),
+    # Build operand A row-major (32 rows x block_ct_dim*32 cols), so the canonical
+    # ReduceBlockMaxRowGolden (which reshapes its operand to `dimensions` row-major)
+    # is unambiguous. A ~ U[0, 1] keeps every row-max well inside bf16's range.
+    dimensions = [TILE_DIM, block_ct_dim * TILE_DIM]
+    src_A_rowmajor = (
+        torch.empty(TILE_DIM * block_ct_dim * TILE_DIM)
+        .uniform_(0.0, 1.0)
+        .to(torch.bfloat16)
+    )
+
+    # Canonical golden: the established fuser oracle for this op. Returns a row-major
+    # tensor with the per-row max in column [0], every other column 0. (In the
+    # compile-producer phase get_golden_generator hands back a stub — the reshape is
+    # deferred until after run() below, where the real result is available.)
+    generate_golden = get_golden_generator(ReduceBlockMaxRowGolden)
+    golden_flat = generate_golden(
+        src_A_rowmajor.clone(), block_ct_dim, formats.output_format, dimensions
+    )
+
+    # Device operand is tilized per 32x32 tile (the layout the C++ reads from L1).
+    src_A = torch.cat(
+        [
+            tilize(
+                src_A_rowmajor.reshape(TILE_DIM, block_ct_dim * TILE_DIM)[
+                    :, t * TILE_DIM : (t + 1) * TILE_DIM
+                ].reshape(-1),
+                formats.input_format,
+            )
+            for t in range(block_ct_dim)
+        ]
     )
     # Scaler B: a single tile of 1.0 (F0 holds the scaler; the op multiplies by it).
     src_B = torch.ones(ELEMENTS_PER_TILE, dtype=torch.bfloat16)
-
-    golden = _row_max_golden(src_A, block_ct_dim)
 
     configuration = TestConfig(
         "sources/reduce_block_max_test.cpp",
@@ -137,6 +123,7 @@ def _run_reduce_block_max(
             MATH_FIDELITY(math_fidelity),
             USE_RUNTIME(use_runtime),
             REINIT_MODE(_REINIT_DEFINE[reinit]),
+            CLOBBER_OP(_CLOBBER_DEFINE[clobber]),
         ],
         variant_stimuli=StimuliConfig(
             src_A,
@@ -158,17 +145,24 @@ def _run_reduce_block_max(
         len(res_from_L1) == ELEMENTS_PER_TILE
     ), f"Expected one {ELEMENTS_PER_TILE}-element output tile, got {len(res_from_L1)}"
 
-    res = torch.tensor(res_from_L1, dtype=torch.float32)
+    # In the compile-producer phase the golden is a stub (no real reduction to check).
+    if golden_flat.numel() != TILE_DIM * block_ct_dim * TILE_DIM:
+        return
+    golden_rowmajor = golden_flat.reshape(TILE_DIM, block_ct_dim * TILE_DIM)
+
+    # Untilize the device output tile to row-major so both sides share layout.
+    res = untilize(
+        torch.tensor(res_from_L1, dtype=torch.float32), formats.output_format
+    ).reshape(TILE_DIM, TILE_DIM)
     tol = tolerances[formats.output_format]
 
     # Only column [0] of each physical row is defined (the row-max); the packer's
-    # REDUCE_ROW mask leaves every other lane unspecified, so validate those alone.
-    for pr, idx in enumerate(_defined_output_indices()):
-        g = float(golden[idx])
-        d = float(res[idx])
+    # REDUCE_ROW mask leaves every other lane unspecified, so validate column [0].
+    for pr in range(TILE_DIM):
+        g = float(golden_rowmajor[pr, 0])
+        d = float(res[pr, 0])
         assert abs(d - g) <= tol.atol + tol.rtol * abs(g), (
-            f"reduce_block_max_row mismatch at physical row {pr} (idx {idx}): "
-            f"device={d} golden={g} "
+            f"reduce_block_max_row mismatch at row {pr}: device={d} golden={g} "
             f"(block_ct_dim={block_ct_dim}, fidelity={math_fidelity.name})"
         )
 
@@ -200,7 +194,11 @@ def test_reduce_block_max_runtime(formats, math_fidelity, block_ct_dim):
     reinit=["short", "minimal"],
 )
 def test_reduce_block_max_reinit(formats, math_fidelity, block_ct_dim, reinit):
-    """Reinit / reprogram after init (reconfig-escape guard).
+    """Reinit / reprogram after a clobbering op (reconfig-escape guard).
+
+    An eltwise binary op runs between init and reinit to overwrite the reduce MOP
+    and addrmods (as matmul / sub_exp do in the SDPA inner loop); the reinit must
+    restore them for the reduce to match golden.
 
     Compile-time short/minimal reinit lib fns are Blackhole-only; skip on WH.
     """
@@ -208,7 +206,9 @@ def test_reduce_block_max_reinit(formats, math_fidelity, block_ct_dim, reinit):
         pytest.skip(
             "compile-time reduce_block_max_row reinit is a Blackhole-only lib path"
         )
-    _run_reduce_block_max(formats, math_fidelity, block_ct_dim, reinit=reinit)
+    _run_reduce_block_max(
+        formats, math_fidelity, block_ct_dim, reinit=reinit, clobber="eltwise"
+    )
 
 
 @parametrize(
@@ -225,5 +225,10 @@ def test_reduce_block_max_reinit_runtime(formats, math_fidelity, block_ct_dim, r
             "runtime reduce_block_max_row reinit_minimal is a Blackhole-only lib path"
         )
     _run_reduce_block_max(
-        formats, math_fidelity, block_ct_dim, use_runtime=True, reinit=reinit
+        formats,
+        math_fidelity,
+        block_ct_dim,
+        use_runtime=True,
+        reinit=reinit,
+        clobber="eltwise",
     )

--- a/tt_metal/tt-llk/tests/python_tests/test_reduce_block_max.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_reduce_block_max.py
@@ -97,9 +97,7 @@ def _run_reduce_block_max(
     )
 
     # Canonical golden: the established fuser oracle for this op. Returns a row-major
-    # tensor with the per-row max in column [0], every other column 0. (In the
-    # compile-producer phase get_golden_generator hands back a stub — the reshape is
-    # deferred until after run() below, where the real result is available.)
+    # tensor with the per-row max in column [0], every other column 0.
     generate_golden = get_golden_generator(ReduceBlockMaxRowGolden)
     golden_flat = generate_golden(
         src_A_rowmajor.clone(), block_ct_dim, formats.output_format, dimensions
@@ -149,9 +147,6 @@ def _run_reduce_block_max(
         len(res_from_L1) == ELEMENTS_PER_TILE
     ), f"Expected one {ELEMENTS_PER_TILE}-element output tile, got {len(res_from_L1)}"
 
-    # In the compile-producer phase the golden is a stub (no real reduction to check).
-    if golden_flat.numel() != TILE_DIM * block_ct_dim * TILE_DIM:
-        return
     golden_rowmajor = golden_flat.reshape(TILE_DIM, block_ct_dim * TILE_DIM)
 
     # Untilize the device output tile to row-major so both sides share layout.

--- a/tt_metal/tt-llk/tests/python_tests/test_reduce_block_max.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_reduce_block_max.py
@@ -1,0 +1,229 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Standalone block-based MAX-pool-along-ROW LLK test (experimental).
+
+Exercises the experimental ``reduce_block_max_row`` LLKs
+(``experimental/llk_{math,unpack_AB}_reduce_custom{,_runtime}.h``), which today
+are covered only inside the fuser and the ``sdpa_reinits`` chain. Semantics:
+
+    out[row] = max over the full block width (``block_ct_dim`` tiles, 32 cols
+               each) of operand A.
+
+The row-max lands in **column [0]** of the output tile; per the op's contract
+the packer's REDUCE_ROW mask leaves the other columns unspecified, so the test
+validates column [0] alone (mirroring ``ReduceBlockMaxRowGolden``).
+
+The scaler B is a single face of 1.0 in F0 (the op's contract), so the pool is a
+pure MAX and the scaler is a no-op multiplier.
+
+Coverage (Blackhole + Wormhole B0):
+  * compile-time path, ``block_ct_dim`` sweep, bf16 and fp32-dest;
+  * runtime path (dynamic ``block_ct_dim``);
+  * reinit_short / reinit_minimal (compile-time = Blackhole-only lib fns; runtime
+    = both arches) re-arm after the init, guarding the reconfig-escape path.
+"""
+
+import pytest
+import torch
+from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
+from helpers.format_config import DataFormat, InputOutputFormat
+from helpers.llk_params import DestAccumulation, MathFidelity
+from helpers.param_config import parametrize
+from helpers.stimuli_config import StimuliConfig
+from helpers.stimuli_generator import StimuliSpec, generate_stimuli
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import (
+    BLOCK_CT_DIM,
+    MATH_FIDELITY,
+    REINIT_MODE,
+    USE_RUNTIME,
+)
+from helpers.utils import tolerances
+
+# 32x32 bf16 tile, stored as 4 faces of 16x16 (2x2 face grid).
+TILE_DIM = 32
+FACE_DIM = 16
+FACES_PER_ROW = 2  # num_faces_c_dim
+FACE_SIZE = FACE_DIM * FACE_DIM
+ELEMENTS_PER_TILE = TILE_DIM * TILE_DIM
+
+# Inputs are always bf16 (the op's contract); only the DEST/output precision varies.
+FORMATS = [
+    InputOutputFormat(DataFormat.Float16_b, DataFormat.Float16_b),
+    InputOutputFormat(DataFormat.Float16_b, DataFormat.Float32),
+]
+
+# REINIT_MODE C++ selector: 0 = plain init, 1 = reinit_short, 2 = reinit_minimal.
+_REINIT_DEFINE = {"none": 0, "short": 1, "minimal": 2}
+
+
+def _dest_acc(output_format):
+    return (
+        DestAccumulation.Yes
+        if output_format == DataFormat.Float32
+        else DestAccumulation.No
+    )
+
+
+def _defined_output_indices():
+    """Flat (tilized) indices of the defined row-max lanes in the 32x32 output tile.
+
+    The row-max for each of the 32 physical rows lands in column [0], which in the
+    4-face tile layout is: face-row ``pr // 16`` (faces {0,1} or {2,3}), row
+    ``pr % 16``, col 0 → flat index (face_row * FACES_PER_ROW) * FACE_SIZE + within*16.
+    """
+    indices = []
+    for pr in range(TILE_DIM):
+        face_row = pr // FACE_DIM
+        within = pr % FACE_DIM
+        indices.append((face_row * FACES_PER_ROW) * FACE_SIZE + within * FACE_DIM)
+    return indices
+
+
+def _row_max_golden(src_a, block_ct_dim):
+    """Per-row MAX across the whole block width (block_ct_dim tiles x 32 cols).
+
+    Operand A is block_ct_dim contiguous 32x32 tiles in tilized (4-face) layout.
+    Returns a flat 1024-element tile with the row-max placed in column [0] of each
+    physical row (tilized layout); other lanes are left 0 (unspecified on HW).
+    Mirrors helpers.golden_generators.ReduceBlockMaxRowGolden semantics.
+    """
+    src = src_a.to(torch.float32)
+    out = torch.zeros(ELEMENTS_PER_TILE, dtype=torch.float32)
+    for pr in range(TILE_DIM):
+        face_row = pr // FACE_DIM
+        within = pr % FACE_DIM
+        row_vals = []
+        for t in range(block_ct_dim):
+            tile_base = t * ELEMENTS_PER_TILE
+            # The two faces holding physical row `pr` (left cols 0-15, right cols 16-31).
+            for fc in range(FACES_PER_ROW):
+                face = face_row * FACES_PER_ROW + fc
+                face_base = tile_base + face * FACE_SIZE + within * FACE_DIM
+                row_vals.append(src[face_base : face_base + FACE_DIM])
+        out_idx = (face_row * FACES_PER_ROW) * FACE_SIZE + within * FACE_DIM
+        out[out_idx] = torch.max(torch.cat(row_vals))
+    return out
+
+
+def _run_reduce_block_max(
+    formats, math_fidelity, block_ct_dim, use_runtime=False, reinit="none"
+):
+    dest_acc = _dest_acc(formats.output_format)
+    # Operand A is a single block of block_ct_dim tiles, laid out tile-major
+    # (each 32x32 tile contiguous), i.e. a 32-row x (block_ct_dim*32)-col operand.
+    input_dimensions = [TILE_DIM, block_ct_dim * TILE_DIM]
+
+    # A ~ U[0, 1] keeps every row-max well inside bf16's dynamic range.
+    src_A, tile_cnt_A, _, _ = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=input_dimensions,
+        spec_A=StimuliSpec.uniform(low=0.0, high=1.0),
+    )
+    # Scaler B: a single tile of 1.0 (F0 holds the scaler; the op multiplies by it).
+    src_B = torch.ones(ELEMENTS_PER_TILE, dtype=torch.bfloat16)
+
+    golden = _row_max_golden(src_A, block_ct_dim)
+
+    configuration = TestConfig(
+        "sources/reduce_block_max_test.cpp",
+        formats,
+        templates=[
+            BLOCK_CT_DIM(block_ct_dim),
+            MATH_FIDELITY(math_fidelity),
+            USE_RUNTIME(use_runtime),
+            REINIT_MODE(_REINIT_DEFINE[reinit]),
+        ],
+        variant_stimuli=StimuliConfig(
+            src_A,
+            formats.input_format,
+            src_B,
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=block_ct_dim,
+            tile_count_B=1,
+            tile_count_res=1,
+            sfpu=False,
+        ),
+        dest_acc=dest_acc,
+    )
+
+    res_from_L1 = configuration.run().result
+
+    assert (
+        len(res_from_L1) == ELEMENTS_PER_TILE
+    ), f"Expected one {ELEMENTS_PER_TILE}-element output tile, got {len(res_from_L1)}"
+
+    res = torch.tensor(res_from_L1, dtype=torch.float32)
+    tol = tolerances[formats.output_format]
+
+    # Only column [0] of each physical row is defined (the row-max); the packer's
+    # REDUCE_ROW mask leaves every other lane unspecified, so validate those alone.
+    for pr, idx in enumerate(_defined_output_indices()):
+        g = float(golden[idx])
+        d = float(res[idx])
+        assert abs(d - g) <= tol.atol + tol.rtol * abs(g), (
+            f"reduce_block_max_row mismatch at physical row {pr} (idx {idx}): "
+            f"device={d} golden={g} "
+            f"(block_ct_dim={block_ct_dim}, fidelity={math_fidelity.name})"
+        )
+
+
+@parametrize(
+    formats=FORMATS,
+    math_fidelity=[MathFidelity.HiFi2, MathFidelity.HiFi4],
+    block_ct_dim=[1, 2, 3, 4, 8],
+)
+def test_reduce_block_max(formats, math_fidelity, block_ct_dim):
+    """Compile-time block_ct_dim sweep, bf16 and fp32-dest."""
+    _run_reduce_block_max(formats, math_fidelity, block_ct_dim)
+
+
+@parametrize(
+    formats=FORMATS,
+    math_fidelity=[MathFidelity.HiFi2, MathFidelity.HiFi4],
+    block_ct_dim=[1, 2, 4, 8],
+)
+def test_reduce_block_max_runtime(formats, math_fidelity, block_ct_dim):
+    """Runtime (dynamic block_ct_dim) path."""
+    _run_reduce_block_max(formats, math_fidelity, block_ct_dim, use_runtime=True)
+
+
+@parametrize(
+    formats=FORMATS,
+    math_fidelity=[MathFidelity.HiFi2, MathFidelity.HiFi4],
+    block_ct_dim=[2, 4],
+    reinit=["short", "minimal"],
+)
+def test_reduce_block_max_reinit(formats, math_fidelity, block_ct_dim, reinit):
+    """Reinit / reprogram after init (reconfig-escape guard).
+
+    Compile-time short/minimal reinit lib fns are Blackhole-only; skip on WH.
+    """
+    if get_chip_architecture() != ChipArchitecture.BLACKHOLE:
+        pytest.skip(
+            "compile-time reduce_block_max_row reinit is a Blackhole-only lib path"
+        )
+    _run_reduce_block_max(formats, math_fidelity, block_ct_dim, reinit=reinit)
+
+
+@parametrize(
+    formats=FORMATS,
+    math_fidelity=[MathFidelity.HiFi2, MathFidelity.HiFi4],
+    block_ct_dim=[2, 4],
+    reinit=["short", "minimal"],
+)
+def test_reduce_block_max_reinit_runtime(formats, math_fidelity, block_ct_dim, reinit):
+    """Runtime reinit paths: reinit_short_runtime on both arches;
+    reinit_minimal_runtime is a Blackhole-only lib fn."""
+    if reinit == "minimal" and get_chip_architecture() != ChipArchitecture.BLACKHOLE:
+        pytest.skip(
+            "runtime reduce_block_max_row reinit_minimal is a Blackhole-only lib path"
+        )
+    _run_reduce_block_max(
+        formats, math_fidelity, block_ct_dim, use_runtime=True, reinit=reinit
+    )

--- a/tt_metal/tt-llk/tests/python_tests/test_reduce_block_max.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_reduce_block_max.py
@@ -21,9 +21,10 @@ pure MAX and the scaler is a no-op multiplier.
 Coverage (Blackhole + Wormhole B0):
   * compile-time path, ``block_ct_dim`` sweep, bf16 and fp32-dest;
   * runtime path (dynamic ``block_ct_dim``);
-  * reinit_short / reinit_minimal re-arm after the init, guarding the reconfig-escape
-    path. Compile-time reinit_short/minimal are Blackhole-only lib fns; runtime
-    reinit_short runs on both arches, runtime reinit_minimal is Blackhole-only.
+  * reinit_short / reinit_minimal / reinit (addrmod-only) re-arm after a clobbering op,
+    guarding the reconfig-escape path. Compile-time reinit_short/minimal are
+    Blackhole-only lib fns; runtime reinit_short and runtime reinit run on both arches,
+    runtime reinit_minimal is Blackhole-only.
   * trigger handshake (respect_trigger, + overlap_first_half on the runtime family):
     the unpack splits the block reduce into two half-width MOP runs gated by HW
     semaphores; the PACK thread plays the producer. Both arches. Validates split-MOP
@@ -60,8 +61,9 @@ FORMATS = [
     InputOutputFormat(DataFormat.Float16_b, DataFormat.Float32),
 ]
 
-# REINIT_MODE C++ selector: 0 = plain init, 1 = reinit_short, 2 = reinit_minimal.
-_REINIT_DEFINE = {"none": 0, "short": 1, "minimal": 2}
+# REINIT_MODE C++ selector: 0 = plain init, 1 = reinit_short, 2 = reinit_minimal,
+# 3 = reinit (addrmod-only, all four; runtime only).
+_REINIT_DEFINE = {"none": 0, "short": 1, "minimal": 2, "full": 3}
 
 # CLOBBER_OP C++ selector: op run between init and reinit to overwrite the reduce config,
 # so the reinit path must actually restore it (reconfig-escape guard).
@@ -70,10 +72,17 @@ _REINIT_DEFINE = {"none": 0, "short": 1, "minimal": 2}
 #       paired with reinit_short (which reprograms the MOP and all addrmods).
 #   2 = scramble ADDR_MOD_1/2/6 only, preserving ADDR_MOD_3 + MOP; paired with reinit_minimal
 #       (which restores only 1/2/6 and relies on 3/MOP being intact, as matmul/sub_exp do).
-_CLOBBER_DEFINE = {"none": 0, "eltwise": 1, "minimal_safe": 2}
+#   3 = scramble ADDR_MOD_1/2/3/6 (every addrmod the reduce consumes), preserving the MOP +
+#       replay buffer; paired with the addrmod-only reinit ("full"), which reprograms exactly
+#       those four and nothing else.
+_CLOBBER_DEFINE = {"none": 0, "eltwise": 1, "minimal_safe": 2, "addrmod_all": 3}
 
 # The clobber must match the reinit's restore contract, or the reduce hangs.
-_CLOBBER_FOR_REINIT = {"short": "eltwise", "minimal": "minimal_safe"}
+_CLOBBER_FOR_REINIT = {
+    "short": "eltwise",
+    "minimal": "minimal_safe",
+    "full": "addrmod_all",
+}
 
 
 def _dest_acc(output_format):
@@ -92,7 +101,14 @@ def _run_reduce_block_max(
     clobber="none",
     respect_trigger=False,
     overlap_first_half=False,
+    expect_mismatch=False,
 ):
+    """Run one reduce_block_max_row variant and validate column [0] against golden.
+
+    ``expect_mismatch`` inverts the verdict: the run must diverge from golden. Used by
+    the negative controls, which pin that a clobber left un-repaired really does corrupt
+    the reduce (so the reinit cases are not passing for free).
+    """
     dest_acc = _dest_acc(formats.output_format)
 
     # Build operand A row-major (32 rows x block_ct_dim*32 cols), so the canonical
@@ -168,12 +184,26 @@ def _run_reduce_block_max(
 
     # Only column [0] of each physical row is defined (the row-max); the packer's
     # REDUCE_ROW mask leaves every other lane unspecified, so validate column [0].
-    for pr in range(TILE_DIM):
-        g = float(golden_rowmajor[pr, 0])
-        d = float(res[pr, 0])
-        assert abs(d - g) <= tol.atol + tol.rtol * abs(g), (
+    mismatches = [
+        (pr, float(res[pr, 0]), float(golden_rowmajor[pr, 0]))
+        for pr in range(TILE_DIM)
+        if abs(float(res[pr, 0]) - float(golden_rowmajor[pr, 0]))
+        > tol.atol + tol.rtol * abs(float(golden_rowmajor[pr, 0]))
+    ]
+
+    if expect_mismatch:
+        assert mismatches, (
+            "expected the un-repaired clobber to corrupt the reduce, but every row "
+            f"matched golden (block_ct_dim={block_ct_dim}, reinit={reinit}, "
+            f"clobber={clobber}); this negative test is no longer meaningful"
+        )
+        return
+
+    if mismatches:
+        pr, d, g = mismatches[0]
+        raise AssertionError(
             f"reduce_block_max_row mismatch at row {pr}: device={d} golden={g} "
-            f"(block_ct_dim={block_ct_dim})"
+            f"(block_ct_dim={block_ct_dim}, {len(mismatches)} row(s) off)"
         )
 
 
@@ -230,11 +260,17 @@ def test_reduce_block_max_reinit(formats, block_ct_dim, reinit):
 @parametrize(
     formats=FORMATS,
     block_ct_dim=[2, 4],
-    reinit=["short", "minimal"],
+    reinit=["short", "minimal", "full"],
 )
 def test_reduce_block_max_reinit_runtime(formats, block_ct_dim, reinit):
-    """Runtime reinit paths: reinit_short_runtime on both arches;
-    reinit_minimal_runtime is a Blackhole-only lib fn."""
+    """Runtime reinit paths: reinit_short_runtime and reinit_runtime on both arches;
+    reinit_minimal_runtime is a Blackhole-only lib fn.
+
+    full is _llk_math_reduce_block_max_row_reinit_runtime_, the addrmod-only
+    re-arm that reprograms all four addrmods the reduce consumes (ADDR_MOD_1/2/3/6) and
+    nothing else. Its clobber (addrmod_all) scrambles exactly those four and leaves
+    the MOP intact, so dropping any one of them from the lib fn breaks this test.
+    """
     if reinit == "minimal" and get_chip_architecture() != ChipArchitecture.BLACKHOLE:
         pytest.skip(
             "runtime reduce_block_max_row reinit_minimal is a Blackhole-only lib path"
@@ -245,6 +281,37 @@ def test_reduce_block_max_reinit_runtime(formats, block_ct_dim, reinit):
         use_runtime=True,
         reinit=reinit,
         clobber=_CLOBBER_FOR_REINIT[reinit],
+    )
+
+
+@parametrize(
+    block_ct_dim=[2, 4],
+    reinit=["none", "minimal"],
+)
+def test_reduce_block_max_reinit_negative_control(block_ct_dim, reinit):
+    """Negative control for the `addrmod_all` clobber, so the reinit cases above
+    cannot silently go vacuous.
+
+    The clobber zeroes ADDR_MOD_1/2/3/6, which only reinit_runtime ("full")
+    reprograms in full. This test pins that the escape is real:
+      * `none`: clobber with no re-arm at all must diverge from golden;
+      * `minimal`: reinit_minimal_runtime restores 1/2/6 but deliberately not
+        ADDR_MOD_3, so it must also diverge. If it ever passed, the "full" case would
+        no longer prove that reinit_runtime restores ADDR_MOD_3.
+
+    bf16 only: the escape is a DEST addressing failure, independent of DEST precision.
+    """
+    if reinit == "minimal" and get_chip_architecture() != ChipArchitecture.BLACKHOLE:
+        pytest.skip(
+            "runtime reduce_block_max_row reinit_minimal is a Blackhole-only lib path"
+        )
+    _run_reduce_block_max(
+        FORMATS[0],
+        block_ct_dim,
+        use_runtime=True,
+        reinit=reinit,
+        clobber="addrmod_all",
+        expect_mismatch=True,
     )
 
 

--- a/tt_metal/tt-llk/tests/sources/reduce_block_max_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/reduce_block_max_test.cpp
@@ -18,12 +18,20 @@
 // (constexpr) switches, supplied by the Python driver, select the covered path:
 //
 //   * USE_RUNTIME   - the runtime (dynamic block_ct_dim) LLK family.
-//   * REINIT_MODE   - re-arm the reduce config right after init, matching the SDPA
+//   * CLOBBER_OP    - op run between init and reinit that overwrites the reduce
+//                     MOP/addrmods: 0 = none, 1 = eltwise binary init (as matmul /
+//                     sub_exp do in the SDPA inner loop).
+//   * REINIT_MODE   - re-arm the reduce config after the clobber, matching the SDPA
 //                     inner-loop reinit paths: 0 = none, 1 = reinit_short (reprogram
 //                     MOP + addrmods), 2 = reinit_minimal (ADDR_MOD_1/2/6 only).
 //
 // The compile-time short/minimal reinit lib fns are Blackhole-only, so the driver
-// only requests those on Blackhole; the runtime reinit fns exist on both arches.
+// only requests those on Blackhole; the runtime reinit fns exist on both arches
+// (runtime reinit_minimal is Blackhole-only).
+//
+// respect_trigger / overlap_first_half (the SDPA MOP-split producer/consumer
+// handshake) are out of scope here — they are owned by the packer layer two levels
+// above the LLK and need the SDPA compute-kernel scaffolding to drive faithfully.
 //
 // Reference: on-silicon compute kernels
 //   tests/tt_metal/tt_metal/test_kernels/misc/sdpa/reduce_block_max_row{,_runtime}/compute.cpp
@@ -97,7 +105,24 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #include "experimental/llk_math_reduce_custom.h"
 #include "experimental/llk_math_reduce_runtime_custom.h"
 #include "llk_math_common.h"
+#include "llk_math_eltwise_binary.h"
 #include "params.h"
+
+// CLOBBER_OP selector: an op run between reduce init and reinit that overwrites the
+// reduce MOP / addrmods, so the reinit path must actually restore them (reconfig-escape
+// guard). 0 = none, 1 = eltwise binary init (reprograms addr_mods + MOP, exactly like the
+// matmul / sub_exp that precede the reduce in the SDPA inner loop).
+static inline void clobber_reduce_config(const ckernel::TensorShape& tensor_shape)
+{
+    if constexpr (CLOBBER_OP == 1)
+    {
+        // ELWADD reprograms the addr_mods + MOP (the reduce state the reinit restores).
+        // ELWADD requires LoFi (HiFi is multiply-only); fidelity is irrelevant here since
+        // the op is never executed, only its init reconfigures the clobbered registers.
+        _llk_math_eltwise_binary_init_<EltwiseBinaryType::ELWADD, BroadcastType::NONE, MathFidelity::LoFi, EltwiseBinaryReuseDestType::NONE>(
+            tensor_shape, 0 /* acc_to_dest */);
+    }
+}
 
 void run_kernel(RUNTIME_PARAMETERS params)
 {
@@ -113,6 +138,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
     if constexpr (USE_RUNTIME)
     {
         _llk_math_reduce_block_max_row_init_runtime_<is_fp32_dest_acc_en>(BLOCK_CT_DIM, tensor_shape);
+
+        // Overwrite the reduce MOP/addrmods so the reinit below must restore them.
+        clobber_reduce_config(tensor_shape);
 
         if constexpr (REINIT_MODE == 1)
         {
@@ -136,6 +164,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
     else
     {
         _llk_math_reduce_block_max_row_init_<BLOCK_CT_DIM, is_fp32_dest_acc_en>(tensor_shape);
+
+        // Overwrite the reduce MOP/addrmods so the reinit below must restore them.
+        clobber_reduce_config(tensor_shape);
 
 #ifdef ARCH_BLACKHOLE
         if constexpr (REINIT_MODE == 1)

--- a/tt_metal/tt-llk/tests/sources/reduce_block_max_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/reduce_block_max_test.cpp
@@ -26,14 +26,23 @@
 //   * REINIT_MODE   - re-arm the reduce config after the clobber, matching the SDPA
 //                     inner-loop reinit paths: 0 = none, 1 = reinit_short (reprogram
 //                     MOP + addrmods), 2 = reinit_minimal (ADDR_MOD_1/2/6 only).
+//   * RESPECT_TRIGGER   - split the block reduce into two half-width unpack MOP runs
+//                     separated by a HW semaphore wait; the PACK thread plays the
+//                     producer and posts the tokens. Requires an even BLOCK_CT_DIM.
+//   * OVERLAP_FIRST_HALF - runtime family only: gate the first half on the early
+//                     UNPACK_MATH_DONE token instead of FPU_SFPU.
 //
 // The compile-time short/minimal reinit lib fns are Blackhole-only, so the driver
 // only requests those on Blackhole; the runtime reinit fns exist on both arches
 // (runtime reinit_minimal is Blackhole-only).
 //
-// respect_trigger / overlap_first_half (the SDPA MOP-split producer/consumer
-// handshake) are out of scope here — they are owned by the packer layer two levels
-// above the LLK and need the SDPA compute-kernel scaffolding to drive faithfully.
+// The trigger/overlap handshake here is driven by the test's own PACK thread as a
+// stand-in for the SDPA packer two levels above the LLK: because operand A is
+// pre-staged in L1, PACK posts the data-ready tokens up front (before it waits on
+// math), which releases the split unpack. This exercises the split-MOP Z-counter
+// continuity and the semaphore post/wait/get balance — it does NOT reproduce the
+// SDPA case where run()#1 reduces genuinely-earlier-arriving data while the packer
+// is still writing the second half (that needs a real block producer).
 //
 // Reference: on-silicon compute kernels
 //   tests/tt_metal/tt_metal/test_kernels/misc/sdpa/reduce_block_max_row{,_runtime}/compute.cpp
@@ -56,10 +65,7 @@ static constexpr DstSync DST_SYNC = DstSync::SyncHalf;
 // 32x32 operand tile: 4 faces (2x2 face grid).
 static constexpr std::uint32_t NUM_FACES = 4;
 
-// respect_trigger is a producer/consumer handshake owned by the packer layer above
-// the LLK; the standalone correctness sweep exercises the untriggered block reduce.
-static constexpr bool RESPECT_TRIGGER    = false;
-static constexpr bool OVERLAP_FIRST_HALF = false;
+// RESPECT_TRIGGER / OVERLAP_FIRST_HALF are supplied by the Python driver (params.h).
 
 #ifdef LLK_TRISC_UNPACK
 
@@ -238,6 +244,21 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_reduce_mask_config_<ReduceDim::REDUCE_ROW>(tensor_shape.face_r_dim);
 
     _llk_pack_dest_init_wrapper_<DST_SYNC, is_fp32_dest_acc_en, PackMode::Default>(tensor_shape.face_r_dim, narrow_tile);
+
+    // Producer half of the trigger handshake. Operand A is pre-staged in L1, so the
+    // second half is always "ready": post the data-ready tokens up front (before the
+    // math-done wait below) to release the split unpack — the unpack waits on these
+    // between its two half-block MOP runs and consumes them in its uninit.
+    //   * FPU_SFPU        - gates run()#2 (and run()#1 on the non-overlap path).
+    //   * UNPACK_MATH_DONE - the early first-half token (runtime overlap path only).
+    if constexpr (RESPECT_TRIGGER)
+    {
+        if constexpr (USE_RUNTIME && OVERLAP_FIRST_HALF)
+        {
+            t6_semaphore_post<>(ckernel::semaphore::UNPACK_MATH_DONE);
+        }
+        t6_semaphore_post<>(ckernel::semaphore::FPU_SFPU);
+    }
 
     // Single output tile: the per-row maxima live in column [0] of DEST[0].
     _llk_packer_wait_for_math_done_();

--- a/tt_metal/tt-llk/tests/sources/reduce_block_max_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/reduce_block_max_test.cpp
@@ -109,18 +109,33 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #include "params.h"
 
 // CLOBBER_OP selector: an op run between reduce init and reinit that overwrites the
-// reduce MOP / addrmods, so the reinit path must actually restore them (reconfig-escape
-// guard). 0 = none, 1 = eltwise binary init (reprograms addr_mods + MOP, exactly like the
-// matmul / sub_exp that precede the reduce in the SDPA inner loop).
-static inline void clobber_reduce_config(const ckernel::TensorShape& tensor_shape)
+// reduce config, so the reinit path must actually restore it (reconfig-escape guard).
+//   0 = none.
+//   1 = eltwise binary (ELWADD) init: reprograms ALL of ADDR_MOD_0..3 + the MOP — the
+//       full escape that reinit_short (reprogram MOP + reconfigure all addrmods) restores.
+//   2 = scramble ONLY ADDR_MOD_1/2/6, preserving ADDR_MOD_3 + the MOP — the narrow escape
+//       reinit_minimal expects (it restores 1/2/6 and relies on 3 + MOP being intact, as
+//       the real SDPA predecessors matmul / sub_exp / copy_tile_custom leave them).
+static inline void clobber_reduce_config([[maybe_unused]] const ckernel::TensorShape& tensor_shape)
 {
     if constexpr (CLOBBER_OP == 1)
     {
-        // ELWADD reprograms the addr_mods + MOP (the reduce state the reinit restores).
         // ELWADD requires LoFi (HiFi is multiply-only); fidelity is irrelevant here since
         // the op is never executed, only its init reconfigures the clobbered registers.
         _llk_math_eltwise_binary_init_<EltwiseBinaryType::ELWADD, BroadcastType::NONE, MathFidelity::LoFi, EltwiseBinaryReuseDestType::NONE>(
             tensor_shape, 0 /* acc_to_dest */);
+    }
+    else if constexpr (CLOBBER_OP == 2)
+    {
+        // Overwrite ADDR_MOD_1/2/6 with plainly wrong (zeroed) values; leave ADDR_MOD_3 and
+        // the reduce MOP intact, matching reinit_minimal's contract. reinit_minimal must then
+        // restore 1/2/6 for the reduce to produce the correct row-max.
+        ckernel::addr_mod_t {.srca = {.incr = 0, .clr = 0, .cr = 0}, .srcb = {.incr = 0, .clr = 0, .cr = 0}, .dest = {.incr = 0, .clr = 0, .cr = 0}}.set(
+            ckernel::ADDR_MOD_1);
+        ckernel::addr_mod_t {.srca = {.incr = 0, .clr = 0, .cr = 0}, .srcb = {.incr = 0, .clr = 0, .cr = 0}, .dest = {.incr = 0, .clr = 0, .cr = 0}}.set(
+            ckernel::ADDR_MOD_2);
+        ckernel::addr_mod_t {.srca = {.incr = 0, .clr = 0, .cr = 0}, .srcb = {.incr = 0, .clr = 0, .cr = 0}, .dest = {.incr = 0, .clr = 0, .cr = 0}}.set(
+            ckernel::ADDR_MOD_6);
     }
 }
 

--- a/tt_metal/tt-llk/tests/sources/reduce_block_max_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/reduce_block_max_test.cpp
@@ -7,7 +7,7 @@
 // Exercises the experimental reduce_block_max_row LLKs
 // (experimental/llk_{math,unpack_AB}_reduce_custom{,_runtime}.h):
 //
-//   out[row] = max over the whole block width (BLOCK_CT_DIM tiles, 32 cols each)
+//   out[row] = max over the whole block width (REDUCE_BLOCK_CT_DIM tiles, 32 cols each)
 //              of operand A, with the row-max landing in column [0] of the tile.
 //
 // The scaler B is a single face of 1.0 in F0 (the op's contract). The op does a
@@ -19,8 +19,10 @@
 //
 //   * USE_RUNTIME   - the runtime (dynamic block_ct_dim) LLK family.
 //   * CLOBBER_OP    - op run between init and reinit that overwrites the reduce
-//                     MOP/addrmods: 0 = none, 1 = eltwise binary init (as matmul /
-//                     sub_exp do in the SDPA inner loop).
+//                     MOP/addrmods: 0 = none, 1 = eltwise binary init (reprograms
+//                     ALL addrmods + MOP, as matmul / sub_exp do in the SDPA inner
+//                     loop), 2 = scramble ADDR_MOD_1/2/6 only (preserving ADDR_MOD_3
+//                     + MOP, the narrow escape reinit_minimal expects).
 //   * REINIT_MODE   - re-arm the reduce config after the clobber, matching the SDPA
 //                     inner-loop reinit paths: 0 = none, 1 = reinit_short (reprogram
 //                     MOP + addrmods), 2 = reinit_minimal (ADDR_MOD_1/2/6 only).
@@ -80,9 +82,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
     if constexpr (USE_RUNTIME)
     {
         // reduce_block_max_row_init_runtime
-        _llk_unpack_AB_reduce_block_max_row_init_runtime_<is_fp32_dest_acc_en>(BLOCK_CT_DIM, RESPECT_TRIGGER, tensor_shape);
+        _llk_unpack_AB_reduce_block_max_row_init_runtime_<is_fp32_dest_acc_en>(REDUCE_BLOCK_CT_DIM, RESPECT_TRIGGER, tensor_shape);
 
-        // Operand A is BLOCK_CT_DIM contiguous tiles; scaler B is a single tile of 1.0.
+        // Operand A is REDUCE_BLOCK_CT_DIM contiguous tiles; scaler B is a single tile of 1.0.
         _llk_unpack_AB_reduce_block_max_row_runtime_(L1_ADDRESS(params.buffer_A[0]), L1_ADDRESS(params.buffer_B[0]), RESPECT_TRIGGER, OVERLAP_FIRST_HALF);
 
         _llk_unpack_AB_reduce_block_max_row_uninit_runtime_(RESPECT_TRIGGER, OVERLAP_FIRST_HALF);
@@ -90,7 +92,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     else
     {
         // reduce_block_max_row_init
-        _llk_unpack_AB_reduce_block_max_row_init_<BLOCK_CT_DIM, is_fp32_dest_acc_en, RESPECT_TRIGGER>(tensor_shape);
+        _llk_unpack_AB_reduce_block_max_row_init_<REDUCE_BLOCK_CT_DIM, is_fp32_dest_acc_en, RESPECT_TRIGGER>(tensor_shape);
 
         _llk_unpack_AB_reduce_block_max_row_<RESPECT_TRIGGER>(L1_ADDRESS(params.buffer_A[0]), L1_ADDRESS(params.buffer_B[0]));
 
@@ -130,12 +132,11 @@ static inline void clobber_reduce_config([[maybe_unused]] const ckernel::TensorS
         // Overwrite ADDR_MOD_1/2/6 with plainly wrong (zeroed) values; leave ADDR_MOD_3 and
         // the reduce MOP intact, matching reinit_minimal's contract. reinit_minimal must then
         // restore 1/2/6 for the reduce to produce the correct row-max.
-        ckernel::addr_mod_t {.srca = {.incr = 0, .clr = 0, .cr = 0}, .srcb = {.incr = 0, .clr = 0, .cr = 0}, .dest = {.incr = 0, .clr = 0, .cr = 0}}.set(
-            ckernel::ADDR_MOD_1);
-        ckernel::addr_mod_t {.srca = {.incr = 0, .clr = 0, .cr = 0}, .srcb = {.incr = 0, .clr = 0, .cr = 0}, .dest = {.incr = 0, .clr = 0, .cr = 0}}.set(
-            ckernel::ADDR_MOD_2);
-        ckernel::addr_mod_t {.srca = {.incr = 0, .clr = 0, .cr = 0}, .srcb = {.incr = 0, .clr = 0, .cr = 0}, .dest = {.incr = 0, .clr = 0, .cr = 0}}.set(
-            ckernel::ADDR_MOD_6);
+        const ckernel::addr_mod_t zeroed = {
+            .srca = {.incr = 0, .clr = 0, .cr = 0}, .srcb = {.incr = 0, .clr = 0, .cr = 0}, .dest = {.incr = 0, .clr = 0, .cr = 0}};
+        zeroed.set(ckernel::ADDR_MOD_1);
+        zeroed.set(ckernel::ADDR_MOD_2);
+        zeroed.set(ckernel::ADDR_MOD_6);
     }
 }
 
@@ -152,7 +153,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     if constexpr (USE_RUNTIME)
     {
-        _llk_math_reduce_block_max_row_init_runtime_<is_fp32_dest_acc_en>(BLOCK_CT_DIM, tensor_shape);
+        _llk_math_reduce_block_max_row_init_runtime_<is_fp32_dest_acc_en>(REDUCE_BLOCK_CT_DIM, tensor_shape);
 
         // Overwrite the reduce MOP/addrmods so the reinit below must restore them.
         clobber_reduce_config(tensor_shape);
@@ -160,7 +161,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         if constexpr (REINIT_MODE == 1)
         {
             // reduce_block_max_row_reinit_short_runtime: reprogram MOP + restore addrmods (both arches).
-            _llk_math_reduce_block_max_row_reinit_short_runtime_<is_fp32_dest_acc_en>(BLOCK_CT_DIM, tensor_shape);
+            _llk_math_reduce_block_max_row_reinit_short_runtime_<is_fp32_dest_acc_en>(REDUCE_BLOCK_CT_DIM, tensor_shape);
         }
 #ifdef ARCH_BLACKHOLE
         else if constexpr (REINIT_MODE == 2)
@@ -178,7 +179,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     }
     else
     {
-        _llk_math_reduce_block_max_row_init_<BLOCK_CT_DIM, is_fp32_dest_acc_en>(tensor_shape);
+        _llk_math_reduce_block_max_row_init_<REDUCE_BLOCK_CT_DIM, is_fp32_dest_acc_en>(tensor_shape);
 
         // Overwrite the reduce MOP/addrmods so the reinit below must restore them.
         clobber_reduce_config(tensor_shape);
@@ -189,7 +190,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             // reduce_block_max_row_reinit_short == reduce_max_row_configure_addrmod + mop_reprogram_only
             // (matches llk_math_reduce_block_max_row_reinit_with_mop). Blackhole-only lib path.
             reduce_max_row_configure_addrmod();
-            _llk_math_reduce_block_max_row_mop_reprogram_only_<BLOCK_CT_DIM>(tensor_shape);
+            _llk_math_reduce_block_max_row_mop_reprogram_only_<REDUCE_BLOCK_CT_DIM>(tensor_shape);
         }
         else if constexpr (REINIT_MODE == 2)
         {
@@ -199,7 +200,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
         _llk_math_wait_for_dest_available_<DST_SYNC>();
-        _llk_math_reduce_block_max_row_<BLOCK_CT_DIM, is_fp32_dest_acc_en>(0 /* dst_index */, tensor_shape);
+        _llk_math_reduce_block_max_row_<REDUCE_BLOCK_CT_DIM, is_fp32_dest_acc_en>(0 /* dst_index */, tensor_shape);
         _llk_math_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
 
         _llk_math_reduce_block_max_row_uninit_<is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/reduce_block_max_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/reduce_block_max_test.cpp
@@ -1,0 +1,204 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Standalone block-based MAX-pool-along-ROW LLK test (experimental).
+//
+// Exercises the experimental reduce_block_max_row LLKs
+// (experimental/llk_{math,unpack_AB}_reduce_custom{,_runtime}.h):
+//
+//   out[row] = max over the whole block width (BLOCK_CT_DIM tiles, 32 cols each)
+//              of operand A, with the row-max landing in column [0] of the tile.
+//
+// The scaler B is a single face of 1.0 in F0 (the op's contract). The op does a
+// pure MAX pool, so the scaler is a no-op multiplier here.
+//
+// This expands the Compute API (api/compute/reduce_custom.h) into its underlying
+// _llk_* calls so the kernel runs inside the tt-llk harness. Compile-time
+// (constexpr) switches, supplied by the Python driver, select the covered path:
+//
+//   * USE_RUNTIME   - the runtime (dynamic block_ct_dim) LLK family.
+//   * REINIT_MODE   - re-arm the reduce config right after init, matching the SDPA
+//                     inner-loop reinit paths: 0 = none, 1 = reinit_short (reprogram
+//                     MOP + addrmods), 2 = reinit_minimal (ADDR_MOD_1/2/6 only).
+//
+// The compile-time short/minimal reinit lib fns are Blackhole-only, so the driver
+// only requests those on Blackhole; the runtime reinit fns exist on both arches.
+//
+// Reference: on-silicon compute kernels
+//   tests/tt_metal/tt_metal/test_kernels/misc/sdpa/reduce_block_max_row{,_runtime}/compute.cpp
+
+#include <cstdint>
+
+#include "ckernel.h"
+#include "llk_defs.h"
+#include "tensor_shape.h"
+
+using namespace ckernel;
+
+// Globals
+std::uint32_t unp_cfg_context          = 0;
+std::uint32_t pack_sync_tile_dst_ptr   = 0;
+std::uint32_t math_sync_tile_dst_index = 0;
+
+static constexpr DstSync DST_SYNC = DstSync::SyncHalf;
+
+// 32x32 operand tile: 4 faces (2x2 face grid).
+static constexpr std::uint32_t NUM_FACES = 4;
+
+// respect_trigger is a producer/consumer handshake owned by the packer layer above
+// the LLK; the standalone correctness sweep exercises the untriggered block reduce.
+static constexpr bool RESPECT_TRIGGER    = false;
+static constexpr bool OVERLAP_FIRST_HALF = false;
+
+#ifdef LLK_TRISC_UNPACK
+
+#include "experimental/llk_unpack_AB_reduce_custom.h"
+#include "experimental/llk_unpack_AB_reduce_custom_runtime.h"
+#include "llk_unpack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    const ckernel::TensorShape tensor_shape = {FACE_R_DIM, FACE_C_DIM, 2 /* num_faces_r_dim */, 2 /* num_faces_c_dim */};
+
+    // compute_kernel_hw_startup
+    _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
+        formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, NUM_FACES, NUM_FACES);
+
+    if constexpr (USE_RUNTIME)
+    {
+        // reduce_block_max_row_init_runtime
+        _llk_unpack_AB_reduce_block_max_row_init_runtime_<is_fp32_dest_acc_en>(BLOCK_CT_DIM, RESPECT_TRIGGER, tensor_shape);
+
+        // Operand A is BLOCK_CT_DIM contiguous tiles; scaler B is a single tile of 1.0.
+        _llk_unpack_AB_reduce_block_max_row_runtime_(L1_ADDRESS(params.buffer_A[0]), L1_ADDRESS(params.buffer_B[0]), RESPECT_TRIGGER, OVERLAP_FIRST_HALF);
+
+        _llk_unpack_AB_reduce_block_max_row_uninit_runtime_(RESPECT_TRIGGER, OVERLAP_FIRST_HALF);
+    }
+    else
+    {
+        // reduce_block_max_row_init
+        _llk_unpack_AB_reduce_block_max_row_init_<BLOCK_CT_DIM, is_fp32_dest_acc_en, RESPECT_TRIGGER>(tensor_shape);
+
+        _llk_unpack_AB_reduce_block_max_row_<RESPECT_TRIGGER>(L1_ADDRESS(params.buffer_A[0]), L1_ADDRESS(params.buffer_B[0]));
+
+        _llk_unpack_AB_reduce_block_max_row_uninit_<RESPECT_TRIGGER>();
+    }
+}
+
+#endif
+
+#ifdef LLK_TRISC_MATH
+
+#include "experimental/llk_math_reduce_custom.h"
+#include "experimental/llk_math_reduce_runtime_custom.h"
+#include "llk_math_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    const ckernel::TensorShape tensor_shape = {FACE_R_DIM, FACE_C_DIM, 2 /* num_faces_r_dim */, 2 /* num_faces_c_dim */};
+
+    // compute_kernel_hw_startup
+    _llk_math_pack_sync_init_<DST_SYNC, is_fp32_dest_acc_en>();
+    _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
+
+    if constexpr (USE_RUNTIME)
+    {
+        _llk_math_reduce_block_max_row_init_runtime_<is_fp32_dest_acc_en>(BLOCK_CT_DIM, tensor_shape);
+
+        if constexpr (REINIT_MODE == 1)
+        {
+            // reduce_block_max_row_reinit_short_runtime: reprogram MOP + restore addrmods (both arches).
+            _llk_math_reduce_block_max_row_reinit_short_runtime_<is_fp32_dest_acc_en>(BLOCK_CT_DIM, tensor_shape);
+        }
+#ifdef ARCH_BLACKHOLE
+        else if constexpr (REINIT_MODE == 2)
+        {
+            // reduce_block_max_row_reinit_minimal_runtime: restore ADDR_MOD_1/2/6 only (Blackhole-only lib fn).
+            _llk_math_reduce_block_max_row_reinit_minimal_runtime_();
+        }
+#endif
+
+        _llk_math_wait_for_dest_available_<DST_SYNC>();
+        _llk_math_reduce_block_max_row_runtime_<is_fp32_dest_acc_en>(0 /* dst_index */, tensor_shape);
+        _llk_math_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
+
+        _llk_math_reduce_block_max_row_uninit_runtime_<is_fp32_dest_acc_en>();
+    }
+    else
+    {
+        _llk_math_reduce_block_max_row_init_<BLOCK_CT_DIM, is_fp32_dest_acc_en>(tensor_shape);
+
+#ifdef ARCH_BLACKHOLE
+        if constexpr (REINIT_MODE == 1)
+        {
+            // reduce_block_max_row_reinit_short == reduce_max_row_configure_addrmod + mop_reprogram_only
+            // (matches llk_math_reduce_block_max_row_reinit_with_mop). Blackhole-only lib path.
+            reduce_max_row_configure_addrmod();
+            _llk_math_reduce_block_max_row_mop_reprogram_only_<BLOCK_CT_DIM>(tensor_shape);
+        }
+        else if constexpr (REINIT_MODE == 2)
+        {
+            // reduce_block_max_row_reinit_minimal: restore ADDR_MOD_1/2/6 only (Blackhole-only lib fn).
+            reduce_max_row_configure_addrmod_reinit_minimal();
+        }
+#endif
+
+        _llk_math_wait_for_dest_available_<DST_SYNC>();
+        _llk_math_reduce_block_max_row_<BLOCK_CT_DIM, is_fp32_dest_acc_en>(0 /* dst_index */, tensor_shape);
+        _llk_math_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
+
+        _llk_math_reduce_block_max_row_uninit_<is_fp32_dest_acc_en>();
+    }
+}
+
+#endif
+
+#ifdef LLK_TRISC_PACK
+
+#include "llk_lib_pack_wrappers.h"
+#include "llk_pack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    const ckernel::TensorShape tensor_shape = {FACE_R_DIM, FACE_C_DIM, 2 /* num_faces_r_dim */, 2 /* num_faces_c_dim */};
+
+    const std::uint32_t tile_size = tensor_shape.total_tensor_size();
+    const std::uint32_t num_faces = tensor_shape.total_num_faces();
+    const bool partial_face       = tensor_shape.face_r_dim < FACE_R_DIM;
+    const bool narrow_tile        = tensor_shape.num_faces_c_dim == 1;
+
+    // compute_kernel_hw_startup
+    _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, PackMode::Default>(
+        formats.pack_src, formats.pack_dst, tile_size, tensor_shape.face_r_dim, tensor_shape.total_col_dim(), num_faces, partial_face, narrow_tile);
+
+    _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(
+        formats.pack_dst, tensor_shape.face_r_dim, tensor_shape.total_col_dim(), num_faces, partial_face, narrow_tile);
+
+    // reduce_block_max_row_init: mask so only the reduced row-max column [0] is packed.
+    _llk_pack_reduce_mask_config_<ReduceDim::REDUCE_ROW>(tensor_shape.face_r_dim);
+
+    _llk_pack_dest_init_wrapper_<DST_SYNC, is_fp32_dest_acc_en, PackMode::Default>(tensor_shape.face_r_dim, narrow_tile);
+
+    // Single output tile: the per-row maxima live in column [0] of DEST[0].
+    _llk_packer_wait_for_math_done_();
+    _llk_pack_<DST_SYNC, is_fp32_dest_acc_en, ckernel::PackMode::Default>(0 /* dst_index */, L1_ADDRESS(params.buffer_Res[0]));
+    _llk_pack_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
+
+    // reduce_block_max_row_uninit
+    _llk_pack_reduce_mask_clear_();
+}
+
+#endif

--- a/tt_metal/tt-llk/tests/sources/reduce_block_max_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/reduce_block_max_test.cpp
@@ -22,10 +22,13 @@
 //                     MOP/addrmods: 0 = none, 1 = eltwise binary init (reprograms
 //                     ALL addrmods + MOP, as matmul / sub_exp do in the SDPA inner
 //                     loop), 2 = scramble ADDR_MOD_1/2/6 only (preserving ADDR_MOD_3
-//                     + MOP, the narrow escape reinit_minimal expects).
+//                     + MOP, the narrow escape reinit_minimal expects), 3 = scramble
+//                     ADDR_MOD_1/2/3/6 (preserving the MOP and replay buffer, the escape
+//                     the addrmod-only reinit expects).
 //   * REINIT_MODE   - re-arm the reduce config after the clobber, matching the SDPA
 //                     inner-loop reinit paths: 0 = none, 1 = reinit_short (reprogram
-//                     MOP + addrmods), 2 = reinit_minimal (ADDR_MOD_1/2/6 only).
+//                     MOP + addrmods), 2 = reinit_minimal (ADDR_MOD_1/2/6 only),
+//                     3 = reinit (all four addrmods; runtime only).
 //   * RESPECT_TRIGGER   - split the block reduce into two half-width unpack MOP runs
 //                     separated by a HW semaphore wait; the PACK thread plays the
 //                     producer and posts the tokens. Requires an even BLOCK_CT_DIM.
@@ -124,8 +127,17 @@ void run_kernel(RUNTIME_PARAMETERS params)
 //   2 = scramble ONLY ADDR_MOD_1/2/6, preserving ADDR_MOD_3 + the MOP — the narrow escape
 //       reinit_minimal expects (it restores 1/2/6 and relies on 3 + MOP being intact, as
 //       the real SDPA predecessors matmul / sub_exp / copy_tile_custom leave them).
+//   3 = scramble ADDR_MOD_1/2/3/6 (every addrmod the reduce consumes), but preserve the MOP
+//       and the replay buffer, which is the escape the addrmod-only reinit (mode 3) expects.
+//       Unlike clobber 2 this also destroys ADDR_MOD_3.
 static inline void clobber_reduce_config([[maybe_unused]] const ckernel::TensorShape& tensor_shape)
 {
+    // Plainly wrong (zeroed) addrmod: no counter advances at all, so a reduce that runs
+    // with it writes every transposed row on top of row 0 instead of striding through the
+    // faces.
+    [[maybe_unused]] const ckernel::addr_mod_t zeroed = {
+        .srca = {.incr = 0, .clr = 0, .cr = 0}, .srcb = {.incr = 0, .clr = 0, .cr = 0}, .dest = {.incr = 0, .clr = 0, .cr = 0}};
+
     if constexpr (CLOBBER_OP == 1)
     {
         // ELWADD requires LoFi (HiFi is multiply-only); fidelity is irrelevant here since
@@ -135,13 +147,19 @@ static inline void clobber_reduce_config([[maybe_unused]] const ckernel::TensorS
     }
     else if constexpr (CLOBBER_OP == 2)
     {
-        // Overwrite ADDR_MOD_1/2/6 with plainly wrong (zeroed) values; leave ADDR_MOD_3 and
-        // the reduce MOP intact, matching reinit_minimal's contract. reinit_minimal must then
-        // restore 1/2/6 for the reduce to produce the correct row-max.
-        const ckernel::addr_mod_t zeroed = {
-            .srca = {.incr = 0, .clr = 0, .cr = 0}, .srcb = {.incr = 0, .clr = 0, .cr = 0}, .dest = {.incr = 0, .clr = 0, .cr = 0}};
+        // Overwrite ADDR_MOD_1/2/6; leave ADDR_MOD_3 and the reduce MOP intact, matching
+        // reinit_minimal's contract. reinit_minimal must then restore 1/2/6 for the reduce
+        // to produce the correct row-max.
         zeroed.set(ckernel::ADDR_MOD_1);
         zeroed.set(ckernel::ADDR_MOD_2);
+        zeroed.set(ckernel::ADDR_MOD_6);
+    }
+    else if constexpr (CLOBBER_OP == 3)
+    {
+        // Overwrite every addrmod the reduce consumes.
+        zeroed.set(ckernel::ADDR_MOD_1);
+        zeroed.set(ckernel::ADDR_MOD_2);
+        zeroed.set(ckernel::ADDR_MOD_3);
         zeroed.set(ckernel::ADDR_MOD_6);
     }
 }
@@ -176,6 +194,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
             _llk_math_reduce_block_max_row_reinit_minimal_runtime_();
         }
 #endif
+        else if constexpr (REINIT_MODE == 3)
+        {
+            // reduce_block_max_row_reinit_runtime: restore all four addrmods the reduce consumes
+            // (ADDR_MOD_1/2/3/6) and nothing else. Paired with CLOBBER_OP 3 (addrmod-only scramble).
+            _llk_math_reduce_block_max_row_reinit_runtime_();
+        }
 
         _llk_math_wait_for_dest_available_<DST_SYNC>();
         _llk_math_reduce_block_max_row_runtime_<is_fp32_dest_acc_en>(0 /* dst_index */, tensor_shape);


### PR DESCRIPTION
## What

Adds standalone tt-llk test coverage for the experimental **block-based MAX-pool-along-ROW** LLKs — `reduce_block_max_row` (`experimental/llk_{math,unpack_AB}_reduce_custom{,_runtime}.h`). These were previously exercised **only** inside the fuser (`fuser/*/reduce_block_max*.py`) and the `sdpa_reinits` chain — there was no standalone correctness sweep, and the runtime / reinit variants were thinly covered.

- `tests/sources/reduce_block_max_test.cpp`
- `tests/python_tests/test_reduce_block_max.py`
- `tests/python_tests/helpers/test_variant_parameters.py` — new `BLOCK_CT_DIM` / `USE_RUNTIME` / `REINIT_MODE` / `RESPECT_TRIGGER` / `OVERLAP_FIRST_HALF` template params

Part of #50202 (#47554, experimental-LLK coverage).

## How

The C++ kernel expands the Compute API (`api/compute/reduce_custom.h`) down to the underlying `_llk_*` layer, split across the UNPACK / MATH / PACK threads, mirroring the on-silicon compute kernels (`tests/tt_metal/tt_metal/test_kernels/misc/sdpa/reduce_block_max_row{,_runtime}/compute.cpp`):

1. **init** — `_llk_{unpack_AB,math}_reduce_block_max_row_init{,_runtime}_` program the reduce MOP + addrmods; PACK sets the `REDUCE_ROW` mask.
2. **execute** — a single `_llk_..._reduce_block_max_row_{,runtime_}` streams the `BLOCK_CT_DIM` operand tiles (Z-counter increment) against the single 1.0 scaler face and column-reduces each row into `DEST[0]`.
3. **uninit** — `_llk_..._reduce_block_max_row_uninit_` + `_llk_pack_reduce_mask_clear_`.

Compile-time (constexpr) switches supplied by the Python driver select the path: `USE_RUNTIME` (dynamic `block_ct_dim`) and `REINIT_MODE` (0 = plain init, 1 = reinit_short, 2 = reinit_minimal — re-arming the reduce config right after init to guard the reconfig-escape path). The compile-time short/minimal reinit lib fns and the runtime reinit_minimal fn are **Blackhole-only**, so they are `#ifdef ARCH_BLACKHOLE`-guarded in the kernel and `pytest.skip`-ped on Wormhole.

## Coverage (Blackhole + Wormhole B0)

Inputs are bf16 (the op's contract); scaler B is held at 1.0 in F0 so the fused op is a pure MAX pool and the golden is unambiguous. The per-row maxima land in **column [0]** of the output tile; the packer's `REDUCE_ROW` mask leaves the other lanes unspecified, so the test validates column [0] alone (the defined tilized lanes), mirroring `ReduceBlockMaxRowGolden`.

| Test | `block_ct_dim` | Formats | Fidelity |
|---|---|---|---|
| `test_reduce_block_max` (compile-time) | 1, 2, 3, 4, 8 | bf16, fp32-dest | HiFi2, HiFi4 |
| `test_reduce_block_max_runtime` | 1, 2, 4, 8 | bf16, fp32-dest | HiFi2, HiFi4 |
| `test_reduce_block_max_reinit` (BH-only) | 2, 4 | bf16, fp32-dest | HiFi2, HiFi4 |
| `test_reduce_block_max_reinit_runtime` | 2, 4 | bf16, fp32-dest | HiFi2, HiFi4 |

## Validation

- **Compile**: both arches clean — Blackhole (68 variants), Wormhole B0 (44 + 24 BH-only skips).
- **Hardware (Wormhole B0, n150)**: full suite green — **44 passed, 24 skipped** (core sweep + runtime + runtime reinit_short). Blackhole-only paths deferred to the CI smoke gate.

## On `respect_trigger` / `overlap_first_half`

The trigger/overlap path is a producer/consumer semaphore handshake **owned by the packer layer two levels above the LLK** (the llk-lib waits/acquires `FPU_SFPU` / `UNPACK_MATH_DONE`; the compute kernel posts). It is deliberately left `false` in this standalone sweep — faithfully reproducing that cross-thread handshake requires the SDPA streaming compute-kernel scaffolding, not a standalone 3-thread harness. The `RESPECT_TRIGGER` / `OVERLAP_FIRST_HALF` template params are wired in for a follow-up. No LLK behavior change in this PR.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ncvetkovic/llk-test-reduce-block-max-row)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ncvetkovic/llk-test-reduce-block-max-row)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ncvetkovic/llk-test-reduce-block-max-row)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ncvetkovic/llk-test-reduce-block-max-row)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ncvetkovic/llk-test-reduce-block-max-row)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ncvetkovic/llk-test-reduce-block-max-row)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ncvetkovic/llk-test-reduce-block-max-row)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ncvetkovic/llk-test-reduce-block-max-row)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ncvetkovic/llk-test-reduce-block-max-row)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ncvetkovic/llk-test-reduce-block-max-row)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ncvetkovic/llk-test-reduce-block-max-row)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ncvetkovic/llk-test-reduce-block-max-row)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ncvetkovic/llk-test-reduce-block-max-row)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ncvetkovic/llk-test-reduce-block-max-row)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ncvetkovic/llk-test-reduce-block-max-row)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ncvetkovic/llk-test-reduce-block-max-row)