### PR TITLE
[Performance] Add eltwise_binary Quasar performance test

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
@@ -633,10 +633,10 @@ class NUM_GUARD_TILES(RuntimeParameter):
 
 @dataclass
 class INPUT_TILE_CNT(RuntimeParameter):
-    tile_cnt: int = 0
+    input_tile_cnt: int = 0
 
     def convert_to_cpp(self) -> str:
-        return f"constexpr int INPUT_TILE_CNT = {self.tile_cnt};"
+        return f"constexpr int INPUT_TILE_CNT = {self.input_tile_cnt};"
 
     def convert_to_struct_fields(self) -> tuple[str, str]:
         return "int INPUT_TILE_CNT;", "i"
@@ -644,10 +644,10 @@ class INPUT_TILE_CNT(RuntimeParameter):
 
 @dataclass
 class OUTPUT_TILE_CNT(RuntimeParameter):
-    tile_cnt: int = 0
+    output_tile_cnt: int = 0
 
     def convert_to_cpp(self) -> str:
-        return f"constexpr int OUTPUT_TILE_CNT = {self.tile_cnt};"
+        return f"constexpr int OUTPUT_TILE_CNT = {self.output_tile_cnt};"
 
     def convert_to_struct_fields(self) -> tuple[str, str]:
         return "int OUTPUT_TILE_CNT;", "i"

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_binary_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_binary_quasar.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from helpers.llk_params import PERF_RUN_TYPES_QUASAR, MathOperation
+from helpers.param_config import parametrize
+from quasar.test_eltwise_binary_quasar import (
+    ELTWISE_FORMATS,
+    eltwise_binary_dest_sync_dest_acc,
+    eltwise_binary_implied_math_formats,
+    eltwise_binary_input_dimensions,
+    eltwise_binary_math_fidelities,
+)
+from quasar.test_eltwise_binary_quasar import test_eltwise_binary as run_eltwise_binary
+
+
+@pytest.mark.perf
+@pytest.mark.quasar
+@parametrize(
+    formats=ELTWISE_FORMATS,
+    mathop=[MathOperation.Elwadd],
+    math_fidelity=lambda mathop, formats: eltwise_binary_math_fidelities(
+        mathop, formats, is_perf=True
+    ),
+    implied_math_format=lambda formats: eltwise_binary_implied_math_formats(
+        formats, is_perf=True
+    ),
+    dest_sync_dest_acc=lambda formats: eltwise_binary_dest_sync_dest_acc(
+        formats, is_perf=True
+    ),
+    input_dimensions=lambda dest_sync_dest_acc: eltwise_binary_input_dimensions(
+        dest_sync_dest_acc, is_perf=True
+    ),
+    acc_to_dest=[False],
+    num_faces=[4],
+    run_types=PERF_RUN_TYPES_QUASAR,
+    loop_factor=[32],
+    is_perf=[True],
+)
+def test_perf_eltwise_binary_quasar(
+    perf_report,
+    formats,
+    mathop,
+    math_fidelity,
+    implied_math_format,
+    dest_sync_dest_acc,
+    input_dimensions,
+    acc_to_dest,
+    num_faces,
+    run_types,
+    loop_factor,
+    is_perf,
+):
+    run_eltwise_binary(
+        formats,
+        mathop,
+        math_fidelity,
+        implied_math_format,
+        dest_sync_dest_acc,
+        input_dimensions,
+        acc_to_dest,
+        num_faces,
+        run_types=run_types,
+        loop_factor=loop_factor,
+        is_perf=is_perf,
+        perf_report=perf_report,
+    )

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_quasar.py
@@ -14,6 +14,7 @@ from helpers.llk_params import (
     ImpliedMathFormat,
     MathFidelity,
     MathOperation,
+    PerfRunType,
     format_dict,
 )
 from helpers.param_config import (
@@ -22,6 +23,7 @@ from helpers.param_config import (
     parametrize,
     runtime,
 )
+from helpers.perf import PerfConfig
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import StimuliSpec, generate_stimuli
 from helpers.test_config import BootMode, TestConfig
@@ -30,23 +32,66 @@ from helpers.test_variant_parameters import (
     DEST_SYNC,
     IMPLIED_MATH_FORMAT,
     INPUT_TILE_CNT,
+    LOOP_FACTOR,
     MATH_FIDELITY,
     MATH_OP,
     NUM_FACES,
     NUM_TILES_IN_BLOCK,
     OUTPUT_TILE_CNT,
+    PERF_RUN_TYPE,
     TEST_FACE_DIMS,
 )
 from helpers.tile_shape import construct_tile_shape
 from helpers.utils import passed_test
 
 
-def _eltwise_dest_acc_sync(dest_acc_modes):
+def _eltwise_dest_acc_sync(dest_acc_modes, *, is_perf=False):
+    dest_sync_modes = (DestSync.Half,) if is_perf else (DestSync.Half, DestSync.Full)
     return [
         (dest_sync, dest_acc)
-        for dest_sync in (DestSync.Half, DestSync.Full)
+        for dest_sync in dest_sync_modes
         for dest_acc in dest_acc_modes
     ]
+
+
+def eltwise_binary_dest_sync_dest_acc(formats, *, is_perf=False):
+    dest_acc_modes = (
+        (DestAccumulation.Yes,)
+        if formats.input_format == DataFormat.Int8
+        else (DestAccumulation.No,)
+    )
+    return _eltwise_dest_acc_sync(dest_acc_modes, is_perf=is_perf)
+
+
+def eltwise_binary_implied_math_formats(formats, *, is_perf=False):
+    if is_perf:
+        return [ImpliedMathFormat.Yes]
+    if formats.input_format.is_mx_format():
+        return [ImpliedMathFormat.Yes]
+    return [ImpliedMathFormat.No, ImpliedMathFormat.Yes]
+
+
+def eltwise_binary_math_fidelities(mathop, formats, *, is_perf=False):
+    if (
+        is_perf
+        or mathop in [MathOperation.Elwadd, MathOperation.Elwsub]
+        or formats.input_format == DataFormat.Int8
+    ):
+        return [MathFidelity.LoFi]
+    return [
+        MathFidelity.LoFi,
+        MathFidelity.HiFi2,
+        MathFidelity.HiFi3,
+        MathFidelity.HiFi4,
+    ]
+
+
+def eltwise_binary_input_dimensions(dest_sync_dest_acc, *, is_perf=False):
+    if is_perf:
+        # Nested list: parametrize treats a flat list as multiple values, so
+        # [32, 32] would become input_dimensions=32 (int) and break generate_stimuli.
+        return [[32, 32]]
+    return generate_unary_input_dimensions(dest_sync_dest_acc[1], dest_sync_dest_acc[0])
 
 
 # For acc_to_dest setting, accumulate two result tiles into dest. Can be extended.
@@ -95,38 +140,24 @@ ELTWISE_FORMATS = input_output_formats(
         MathOperation.Elwsub,
         MathOperation.Elwmul,
     ],
-    # Math fidelity only affects multiplication; for add/sub and Int8 only LoFi is meaningful.
-    math_fidelity=lambda mathop, formats: (
-        [MathFidelity.LoFi]
-        if mathop in [MathOperation.Elwadd, MathOperation.Elwsub]
-        or formats.input_format == DataFormat.Int8
-        else [
-            MathFidelity.LoFi,
-            MathFidelity.HiFi2,
-            MathFidelity.HiFi3,
-            MathFidelity.HiFi4,
-        ]
+    math_fidelity=lambda mathop, formats: eltwise_binary_math_fidelities(
+        mathop, formats, is_perf=False
     ),
-    implied_math_format=lambda formats: (
-        [
-            ImpliedMathFormat.No,
-            ImpliedMathFormat.Yes,
-        ]
-        if not formats.input_format.is_mx_format()
-        else [ImpliedMathFormat.Yes]
+    implied_math_format=lambda formats: eltwise_binary_implied_math_formats(
+        formats, is_perf=False
     ),
-    dest_sync_dest_acc=lambda formats: (
-        _eltwise_dest_acc_sync((DestAccumulation.Yes,))
-        if formats.input_format == DataFormat.Int8
-        else _eltwise_dest_acc_sync((DestAccumulation.No,))
+    dest_sync_dest_acc=lambda formats: eltwise_binary_dest_sync_dest_acc(
+        formats, is_perf=False
     ),
     input_dimensions=runtime(
-        lambda dest_sync_dest_acc: generate_unary_input_dimensions(
-            dest_sync_dest_acc[1], dest_sync_dest_acc[0]
+        lambda dest_sync_dest_acc: eltwise_binary_input_dimensions(
+            dest_sync_dest_acc, is_perf=False
         )
     ),
     acc_to_dest=valid_acc_to_dest,
     num_faces=[4],
+    run_types=[[PerfRunType.L1_TO_L1]],
+    loop_factor=[1],
 )
 def test_eltwise_binary(
     formats,
@@ -137,7 +168,12 @@ def test_eltwise_binary(
     input_dimensions,
     acc_to_dest,
     num_faces,
+    run_types,
+    loop_factor,
     boot_mode=BootMode.DEFAULT,
+    *,
+    is_perf=False,
+    perf_report=None,
 ):
     dest_sync_mode, dest_acc = dest_sync_dest_acc
 
@@ -174,24 +210,28 @@ def test_eltwise_binary(
         num_tiles_per_accumulation=num_tiles_per_accumulation,
     )
 
-    configuration = TestConfig(
-        "sources/quasar/eltwise_binary_test.cpp",
-        formats,
-        templates=[
+    if is_perf and perf_report is None:
+        raise ValueError("perf_report must be provided when is_perf=True")
+
+    test_config_kwargs = {
+        "test_name": "sources/quasar/eltwise_binary_test.cpp",
+        "formats": formats,
+        "templates": [
             MATH_FIDELITY(math_fidelity),
             MATH_OP(mathop=mathop),
             IMPLIED_MATH_FORMAT(implied_math_format),
             DEST_SYNC(dest_sync_mode),
             ACC_TO_DEST(acc_to_dest),
         ],
-        runtimes=[
+        "runtimes": [
             INPUT_TILE_CNT(tile_cnt_A),
             OUTPUT_TILE_CNT(tile_cnt_res),
             NUM_FACES(num_faces),
             TEST_FACE_DIMS(),
             NUM_TILES_IN_BLOCK(num_tiles_per_accumulation),
+            LOOP_FACTOR(loop_factor),
         ],
-        variant_stimuli=StimuliConfig(
+        "variant_stimuli": StimuliConfig(
             src_A,
             formats.input_format,
             src_B,
@@ -202,17 +242,26 @@ def test_eltwise_binary(
             tile_count_res=tile_cnt_res,
             num_faces=num_faces,
         ),
-        # Determine unpack_to_dest based on format and accumulation mode
-        unpack_to_dest=(
+        "unpack_to_dest": (
             formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
         ),
-        dest_acc=dest_acc,
-        boot_mode=boot_mode,
-        # MX formats require disable_format_inference to match C++ IMPLIED_MATH_FORMAT setting
-        # This ensures Python-side format inference uses Float16_b for MX internal math
-        disable_format_inference=formats.input_format.is_mx_format(),
-    )
+        "dest_acc": dest_acc,
+        "disable_format_inference": formats.input_format.is_mx_format(),
+    }
 
+    if is_perf:
+        configuration = PerfConfig(run_types=run_types, **test_config_kwargs)
+        configuration.run(perf_report)
+        return
+
+    configuration = TestConfig(
+        **{
+            **test_config_kwargs,
+            "boot_mode": boot_mode,
+            "templates": test_config_kwargs["templates"]
+            + [PERF_RUN_TYPE(PerfRunType.L1_TO_L1)],
+        },
+    )
     res_from_L1 = configuration.run().result
 
     # Verify results match golden

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
@@ -7,6 +7,8 @@
 
 #include "ckernel.h"
 #include "llk_defs.h"
+#include "perf.h"
+#include "profiler.h"
 #include "sfpu_stub.h"
 
 // Globals
@@ -25,49 +27,71 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    // Configure buffer descriptors for both operands
+#ifndef SPEED_OF_LIGHT
+    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
+    const std::uint32_t INPUT_TILE_CNT  = params.INPUT_TILE_CNT;
+    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
+    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
+    const std::uint32_t num_faces       = params.num_faces;
+    const Operand& buffer_A             = params.buffer_A;
+    const Operand& buffer_B             = params.buffer_B;
+#endif
     tdma_descriptor_t td_val_A, td_val_B;
     const std::uint32_t buf_desc_id_a = 0;
     const std::uint32_t buf_desc_id_b = 1;
 
-    // Setup data valid scheme - binary operations always write to SrcA/SrcB, never DEST
-    set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
-
-    // Configure Source A buffer descriptor
-    buffer_descriptor_u bd_val_A {};
-    bd_val_A.f.l1_addr_16B = params.buffer_A[0] / 16;
-    bd_val_A.f.format      = static_cast<std::uint8_t>(formats.unpack_A_src);
-    bd_val_A.f.x_dim       = params.TEST_FACE_C_DIM;
-    bd_val_A.f.y_dim       = params.TEST_FACE_R_DIM;
-    bd_val_A.f.z_dim       = params.num_faces;
-
-    td_val_A.buf_desc        = bd_val_A;
-    td_val_A.buf_desc_id     = buf_desc_id_a;
-    td_val_A.reg_data_format = static_cast<std::uint8_t>(formats.unpack_A_dst);
-
-    // Configure Source B buffer descriptor
-    buffer_descriptor_u bd_val_B {};
-    bd_val_B.f.l1_addr_16B = params.buffer_B[0] / 16;
-    bd_val_B.f.format      = static_cast<std::uint8_t>(formats.unpack_B_src);
-    bd_val_B.f.x_dim       = params.TEST_FACE_C_DIM;
-    bd_val_B.f.y_dim       = params.TEST_FACE_R_DIM;
-    bd_val_B.f.z_dim       = params.num_faces;
-
-    td_val_B.buf_desc        = bd_val_B;
-    td_val_B.buf_desc_id     = buf_desc_id_b;
-    td_val_B.reg_data_format = static_cast<std::uint8_t>(formats.unpack_B_dst);
-
-    // Configure hardware for binary operations
-    _configure_buf_desc_table_(td_val_A.buf_desc_id, td_val_A.buf_desc);
-    _configure_buf_desc_table_(td_val_B.buf_desc_id, td_val_B.buf_desc);
-    _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val_A, td_val_B);
-
-    // Initialize binary operands unpacker - unpack 1 tile per MOP run
-    _llk_unpack_binary_operands_init_(buf_desc_id_a, buf_desc_id_b, 1);
-
-    for (std::uint32_t i = 0; i < static_cast<std::uint32_t>(params.INPUT_TILE_CNT); ++i)
     {
-        _llk_unpack_binary_operands_(i, i);
+        ZONE_SCOPED("INIT")
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+
+        buffer_descriptor_u bd_val_A {};
+        bd_val_A.f.l1_addr_16B = buffer_A[0] / 16;
+        bd_val_A.f.format      = static_cast<std::uint8_t>(formats.unpack_A_src);
+        bd_val_A.f.x_dim       = TEST_FACE_C_DIM;
+        bd_val_A.f.y_dim       = TEST_FACE_R_DIM;
+        bd_val_A.f.z_dim       = num_faces;
+
+        td_val_A.buf_desc        = bd_val_A;
+        td_val_A.buf_desc_id     = buf_desc_id_a;
+        td_val_A.reg_data_format = static_cast<std::uint8_t>(formats.unpack_A_dst);
+
+        buffer_descriptor_u bd_val_B {};
+        bd_val_B.f.l1_addr_16B = buffer_B[0] / 16;
+        bd_val_B.f.format      = static_cast<std::uint8_t>(formats.unpack_B_src);
+        bd_val_B.f.x_dim       = TEST_FACE_C_DIM;
+        bd_val_B.f.y_dim       = TEST_FACE_R_DIM;
+        bd_val_B.f.z_dim       = num_faces;
+
+        td_val_B.buf_desc        = bd_val_B;
+        td_val_B.buf_desc_id     = buf_desc_id_b;
+        td_val_B.reg_data_format = static_cast<std::uint8_t>(formats.unpack_B_dst);
+
+        _configure_buf_desc_table_(td_val_A.buf_desc_id, td_val_A.buf_desc);
+        _configure_buf_desc_table_(td_val_B.buf_desc_id, td_val_B.buf_desc);
+        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val_A, td_val_B);
+        _llk_unpack_binary_operands_init_(buf_desc_id_a, buf_desc_id_b, 1);
+        PROFILER_SYNC();
+    }
+    {
+        ZONE_SCOPED("TILE_LOOP")
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
+        {
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
+        {
+            _perf_unpack_loop_set_valid<true, true>(LOOP_FACTOR * INPUT_TILE_CNT);
+        }
+        else
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                for (std::uint32_t i = 0; i < INPUT_TILE_CNT; ++i)
+                {
+                    _llk_unpack_binary_operands_(i, i);
+                }
+            }
+        }
+        PROFILER_SYNC();
     }
 }
 
@@ -93,38 +117,63 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    // Setup synchronization - FPU writes to DEST, PACK reads from DEST
-    set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
-
-    // Configure math hardware with proper Quasar API
-    DataFormat math_format     = static_cast<DataFormat>(formats.math);
-    DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
-    if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)
+#ifndef SPEED_OF_LIGHT
+    const std::uint32_t LOOP_FACTOR        = params.LOOP_FACTOR;
+    const std::uint32_t INPUT_TILE_CNT     = params.INPUT_TILE_CNT;
+    const std::uint32_t NUM_TILES_IN_BLOCK = params.NUM_TILES_IN_BLOCK;
+#endif
     {
-        _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
-    }
-    else
-    {
-        _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*int32_dest*/>(math_format, math_format);
-    }
-    // Initialize eltwise binary operation with default 32x32 tensor shape
-    _llk_math_eltwise_binary_init_<ELTWISE_BINARY_OP, MATH_FIDELITY>(ckernel::DEFAULT_TENSOR_SHAPE, ACC_TO_DEST); // tiny-tile testing not yet supported
-
-    // Perform eltwise binary operation for each tile
-    std::uint32_t dest_idx = 0;
-    for (std::uint32_t remaining_tiles = static_cast<std::uint32_t>(params.INPUT_TILE_CNT); remaining_tiles > 0;
-         remaining_tiles -= std::min(remaining_tiles, params.NUM_TILES_IN_BLOCK))
-    {
-        const std::uint32_t num_tiles_in_block = std::min(remaining_tiles, params.NUM_TILES_IN_BLOCK);
-        for (std::uint32_t tile = 0; tile < num_tiles_in_block; ++tile)
+        ZONE_SCOPED("INIT")
+        // Only L1_TO_L1 has a math-to-pack consumer.
+        if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
         {
-            _llk_math_eltwise_binary_<ELTWISE_BINARY_OP>(dest_idx, ckernel::DEFAULT_TENSOR_SHAPE);
+            set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
         }
-        ++dest_idx;
-    }
 
-    // Signal math completion
-    _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+        DataFormat math_format     = static_cast<DataFormat>(formats.math);
+        DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
+        if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)
+        {
+            _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
+        }
+        else
+        {
+            _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*int32_dest*/>(math_format, math_format);
+        }
+        _llk_math_eltwise_binary_init_<ELTWISE_BINARY_OP, MATH_FIDELITY>(ckernel::DEFAULT_TENSOR_SHAPE, ACC_TO_DEST);
+        PROFILER_SYNC();
+    }
+    {
+        ZONE_SCOPED("TILE_LOOP")
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
+        {
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        {
+            _perf_math_loop_clear_valid<true, true>(LOOP_FACTOR * INPUT_TILE_CNT);
+        }
+        else
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                std::uint32_t dest_idx = 0;
+                for (std::uint32_t remaining_tiles = INPUT_TILE_CNT; remaining_tiles > 0; remaining_tiles -= std::min(remaining_tiles, NUM_TILES_IN_BLOCK))
+                {
+                    const std::uint32_t num_tiles_in_block = std::min(remaining_tiles, NUM_TILES_IN_BLOCK);
+                    for (std::uint32_t tile = 0; tile < num_tiles_in_block; ++tile)
+                    {
+                        _llk_math_eltwise_binary_<ELTWISE_BINARY_OP>(dest_idx, ckernel::DEFAULT_TENSOR_SHAPE);
+                    }
+                    ++dest_idx;
+                }
+                if constexpr (PERF_RUN_TYPE != PerfRunType::MATH_ISOLATE)
+                {
+                    _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+                }
+            }
+        }
+        PROFILER_SYNC();
+    }
 }
 
 #endif
@@ -140,39 +189,67 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
+#ifndef SPEED_OF_LIGHT
+    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
+    const std::uint32_t OUTPUT_TILE_CNT = params.OUTPUT_TILE_CNT;
+    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
+    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
+    const std::uint32_t num_faces       = params.num_faces;
+    const Operand& buffer_Res           = params.buffer_Res;
+#endif
     std::uint32_t const buf_desc_id = 8;
 
-    // Setup synchronization - PACK waits for FPU to write to DEST
-    set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
-
-    // Configure output buffer descriptor
-    buffer_descriptor_u bd_val {};
-
-    bd_val.f.l1_addr_16B = params.buffer_Res[0] / 16;
-    bd_val.f.format      = static_cast<std::uint8_t>(formats.pack_dst);
-    bd_val.f.x_dim       = params.TEST_FACE_C_DIM;
-    bd_val.f.y_dim       = params.TEST_FACE_R_DIM;
-    bd_val.f.z_dim       = params.num_faces; // Match matmul pattern: set z_dim to actual params.num_faces
-
-    tdma_descriptor_t tdma_desc;
-
-    tdma_desc.buf_desc        = bd_val;
-    tdma_desc.buf_desc_id     = buf_desc_id;
-    tdma_desc.reg_data_format = static_cast<std::uint8_t>(formats.pack_src);
-
-    // Configure and initialize pack hardware
-    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
-    _llk_pack_hw_configure_<p_pacr::PACK0>(tdma_desc);
-    _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, 1);
-
-    // Pack all result tiles
-    for (std::uint32_t i = 0; i < static_cast<std::uint32_t>(params.OUTPUT_TILE_CNT); ++i)
     {
-        _llk_pack_(i, i, ckernel::DEFAULT_TENSOR_SHAPE);
-    }
+        ZONE_SCOPED("INIT")
+        // Clear a stale FPU-to-PACK wait in modes without a math handshake.
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        {
+            volatile std::uint32_t* cfg                 = (volatile std::uint32_t*)TENSIX_CFG_BASE;
+            cfg[PACK_DEST_DVALID_CTRL_wait_mask_ADDR32] = 0;
+        }
+        else
+        {
+            set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+        }
 
-    // Signal pack completion
-    _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+        buffer_descriptor_u bd_val {};
+        bd_val.f.l1_addr_16B = buffer_Res[0] / 16;
+        bd_val.f.format      = static_cast<std::uint8_t>(formats.pack_dst);
+        bd_val.f.x_dim       = TEST_FACE_C_DIM;
+        bd_val.f.y_dim       = TEST_FACE_R_DIM;
+        bd_val.f.z_dim       = num_faces;
+
+        tdma_descriptor_t tdma_desc;
+        tdma_desc.buf_desc        = bd_val;
+        tdma_desc.buf_desc_id     = buf_desc_id;
+        tdma_desc.reg_data_format = static_cast<std::uint8_t>(formats.pack_src);
+
+        _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
+        _llk_pack_hw_configure_<p_pacr::PACK0>(tdma_desc);
+        _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, 1);
+        PROFILER_SYNC();
+    }
+    {
+        ZONE_SCOPED("TILE_LOOP")
+        if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE || PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)
+        {
+        }
+        else
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                for (std::uint32_t i = 0; i < OUTPUT_TILE_CNT; ++i)
+                {
+                    _llk_pack_(i, i, ckernel::DEFAULT_TENSOR_SHAPE);
+                }
+                if constexpr (PERF_RUN_TYPE != PerfRunType::PACK_ISOLATE && PERF_RUN_TYPE != PerfRunType::L1_CONGESTION)
+                {
+                    _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+                }
+            }
+        }
+        PROFILER_SYNC();
+    }
 }
 
 #endif


### PR DESCRIPTION
### PR Category
Performance

### Summary
Adds Quasar performance coverage for `eltwise_binary` by introducing its perf test and adapting the matching Python and C++ tests.

Closes #50571

### Notes for reviewers
This PR is intentionally limited to the three operation-specific test files split from `ndivnic/backup_remaining_perf_tests_quasar`.

Builds and tests were not run; any resulting failures will be addressed separately.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/eltwise_binary_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/eltwise_binary_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/eltwise_binary_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/eltwise_binary_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ndivnic/eltwise_binary_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ndivnic/eltwise_binary_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/eltwise_binary_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/eltwise_binary_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/eltwise_binary_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/eltwise_binary_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/eltwise_binary_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/eltwise_binary_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/eltwise_binary_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/eltwise_binary_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/eltwise_binary_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/eltwise_binary_perf_test_quasar)