### PR TITLE
[Performance] Add eltwise_binary_broadcast Quasar performance test

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_binary_broadcast_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_binary_broadcast_quasar.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from helpers.constraints import get_valid_dest_accumulation_modes
+from helpers.llk_params import BroadcastType, MathOperation, PERF_RUN_TYPES_QUASAR
+from helpers.param_config import parametrize
+from quasar.test_eltwise_binary_broadcast_quasar import (
+    BINARY_BROADCAST_FORMATS,
+    binary_broadcast_dest_sync_modes,
+    binary_broadcast_implied_math_formats,
+    binary_broadcast_input_dimensions,
+    binary_broadcast_math_fidelities,
+)
+from quasar.test_eltwise_binary_broadcast_quasar import (
+    test_eltwise_binary_broadcast_quasar as run_eltwise_binary_broadcast,
+)
+
+@pytest.mark.perf
+@pytest.mark.quasar
+@parametrize(
+    formats=BINARY_BROADCAST_FORMATS,
+    dest_acc=get_valid_dest_accumulation_modes,
+    mathop=[MathOperation.Elwadd],
+    broadcast_type=[BroadcastType.Scalar],
+    math_fidelity=lambda formats, mathop: binary_broadcast_math_fidelities(
+        formats, mathop, is_perf=True
+    ),
+    implied_math_format=lambda formats: binary_broadcast_implied_math_formats(
+        formats, is_perf=True
+    ),
+    dest_sync_mode=lambda: binary_broadcast_dest_sync_modes(is_perf=True),
+    input_dimensions=lambda dest_acc, dest_sync_mode: binary_broadcast_input_dimensions(
+        dest_acc, dest_sync_mode, is_perf=True
+    ),
+    run_types=PERF_RUN_TYPES_QUASAR,
+    loop_factor=[32],
+    is_perf=[True],
+)
+def test_perf_eltwise_binary_broadcast_quasar(
+    perf_report,
+    formats,
+    dest_acc,
+    mathop,
+    broadcast_type,
+    math_fidelity,
+    implied_math_format,
+    dest_sync_mode,
+    input_dimensions,
+    run_types,
+    loop_factor,
+    is_perf,
+):
+    run_eltwise_binary_broadcast(
+        formats,
+        dest_acc,
+        mathop,
+        broadcast_type,
+        math_fidelity,
+        implied_math_format,
+        dest_sync_mode,
+        input_dimensions,
+        run_types=run_types,
+        loop_factor=loop_factor,
+        is_perf=is_perf,
+        perf_report=perf_report,
+    )

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_binary_broadcast_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_binary_broadcast_quasar.py
@@ -3,7 +3,7 @@
 
 import pytest
 from helpers.constraints import get_valid_dest_accumulation_modes
-from helpers.llk_params import BroadcastType, MathOperation, PERF_RUN_TYPES_QUASAR
+from helpers.llk_params import PERF_RUN_TYPES_QUASAR, BroadcastType, MathOperation
 from helpers.param_config import parametrize
 from quasar.test_eltwise_binary_broadcast_quasar import (
     BINARY_BROADCAST_FORMATS,
@@ -15,6 +15,7 @@ from quasar.test_eltwise_binary_broadcast_quasar import (
 from quasar.test_eltwise_binary_broadcast_quasar import (
     test_eltwise_binary_broadcast_quasar as run_eltwise_binary_broadcast,
 )
+
 
 @pytest.mark.perf
 @pytest.mark.quasar

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_broadcast_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_broadcast_quasar.py
@@ -19,6 +19,7 @@ from helpers.llk_params import (
     ImpliedMathFormat,
     MathFidelity,
     MathOperation,
+    PerfRunType,
     format_dict,
 )
 from helpers.param_config import (
@@ -27,6 +28,7 @@ from helpers.param_config import (
     parametrize,
     runtime,
 )
+from helpers.perf import PerfConfig
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import StimuliSpec, generate_stimuli
 from helpers.test_config import BootMode, TestConfig
@@ -34,9 +36,11 @@ from helpers.test_variant_parameters import (
     BROADCAST_TYPE,
     DEST_SYNC,
     IMPLIED_MATH_FORMAT,
+    LOOP_FACTOR,
     MATH_FIDELITY,
     MATH_OP,
     NUM_FACES,
+    PERF_RUN_TYPE,
     TEST_FACE_DIMS,
     TILE_COUNT,
 )
@@ -45,20 +49,49 @@ from helpers.utils import passed_test
 TILE_ELEMS = 32 * 32
 FACE_ELEMS = 16 * 16
 
+BINARY_BROADCAST_FORMATS = input_output_formats(
+    [
+        DataFormat.Float16_b,
+        DataFormat.Float16,
+        DataFormat.MxFp4,
+        DataFormat.MxInt8,
+        DataFormat.MxInt4,
+        DataFormat.MxInt2,
+    ],
+) + [InputOutputFormat(DataFormat.Int8, DataFormat.Int32)]
+
+
+def binary_broadcast_dest_sync_modes(*, is_perf=False):
+    return [DestSync.Half] if is_perf else [DestSync.Half, DestSync.Full]
+
+
+def binary_broadcast_implied_math_formats(format, *, is_perf=False):
+    if is_perf:
+        return [ImpliedMathFormat.Yes]
+    if format.input_format.is_mx_format():
+        return [ImpliedMathFormat.Yes]
+    return [ImpliedMathFormat.No, ImpliedMathFormat.Yes]
+
+
+def binary_broadcast_math_fidelities(format, mathop, *, is_perf=False):
+    if format.input_format == DataFormat.Int8:
+        return [MathFidelity.LoFi]
+    if is_perf:
+        return [MathFidelity.LoFi]
+    return get_valid_math_fidelities(format, mathop)
+
+
+def binary_broadcast_input_dimensions(dest_acc, dest_sync_mode, *, is_perf=False):
+    if is_perf:
+        # Nested list: parametrize treats a flat list as multiple values, so
+        # [32, 32] would become input_dimensions=32 (int) and break generate_stimuli.
+        return [[32, 32]]
+    return generate_unary_input_dimensions(dest_acc, dest_sync_mode)
+
 
 @pytest.mark.quasar
 @parametrize(
-    formats=input_output_formats(
-        [
-            DataFormat.Float16_b,
-            DataFormat.Float16,
-            DataFormat.MxFp4,
-            DataFormat.MxInt8,
-            DataFormat.MxInt4,
-            DataFormat.MxInt2,
-        ],
-    )
-    + [InputOutputFormat(DataFormat.Int8, DataFormat.Int32)],
+    formats=BINARY_BROADCAST_FORMATS,
     dest_acc=lambda formats: get_valid_dest_accumulation_modes(formats),
     mathop=[
         MathOperation.Elwadd,
@@ -70,22 +103,18 @@ FACE_ELEMS = 16 * 16
         BroadcastType.Row,
         BroadcastType.Scalar,
     ],
-    math_fidelity=lambda formats, mathop: (
-        [MathFidelity.LoFi]
-        if formats.input_format == DataFormat.Int8
-        else get_valid_math_fidelities(formats, mathop)
+    math_fidelity=lambda formats, mathop: binary_broadcast_math_fidelities(
+        formats, mathop
     ),
-    implied_math_format=lambda formats: (
-        [ImpliedMathFormat.No, ImpliedMathFormat.Yes]
-        if not formats.input_format.is_mx_format()
-        else [ImpliedMathFormat.Yes]
-    ),
-    dest_sync_mode=[DestSync.Half, DestSync.Full],
+    implied_math_format=lambda formats: binary_broadcast_implied_math_formats(formats),
+    dest_sync_mode=lambda: binary_broadcast_dest_sync_modes(is_perf=False),
     input_dimensions=runtime(
-        lambda dest_acc, dest_sync_mode: generate_unary_input_dimensions(
-            dest_acc, dest_sync_mode
+        lambda dest_acc, dest_sync_mode: binary_broadcast_input_dimensions(
+            dest_acc, dest_sync_mode, is_perf=False
         )
     ),
+    run_types=[[PerfRunType.L1_TO_L1]],
+    loop_factor=[1],
 )
 def test_eltwise_binary_broadcast_quasar(
     formats,
@@ -96,7 +125,12 @@ def test_eltwise_binary_broadcast_quasar(
     implied_math_format,
     dest_sync_mode,
     input_dimensions,
+    run_types,
+    loop_factor,
     boot_mode=BootMode.DEFAULT,
+    *,
+    is_perf=False,
+    perf_report=None,
 ):
 
     if formats.input_format == DataFormat.Int8:
@@ -140,22 +174,26 @@ def test_eltwise_binary_broadcast_quasar(
         input_format_B=input_format_B,
     )
 
-    configuration = TestConfig(
-        "sources/quasar/eltwise_binary_broadcast_quasar_test.cpp",
-        formats,
-        templates=[
+    if is_perf and perf_report is None:
+        raise ValueError("perf_report must be provided when is_perf=True")
+
+    test_config_kwargs = {
+        "test_name": "sources/quasar/eltwise_binary_broadcast_quasar_test.cpp",
+        "formats": formats,
+        "templates": [
             MATH_FIDELITY(math_fidelity),
             MATH_OP(mathop=mathop),
             IMPLIED_MATH_FORMAT(implied_math_format),
             BROADCAST_TYPE(broadcast_type),
             DEST_SYNC(dest_sync_mode),
         ],
-        runtimes=[
+        "runtimes": [
             TILE_COUNT(tile_cnt_A),
             NUM_FACES(4),
             TEST_FACE_DIMS(),
+            LOOP_FACTOR(loop_factor),
         ],
-        variant_stimuli=StimuliConfig(
+        "variant_stimuli": StimuliConfig(
             src_A,
             formats.input_format,
             src_B,
@@ -166,13 +204,24 @@ def test_eltwise_binary_broadcast_quasar(
             tile_count_res=tile_cnt_A,
             num_faces=4,
         ),
-        unpack_to_dest=False,
-        dest_acc=dest_acc,
-        boot_mode=boot_mode,
-        # MX formats require disable_format_inference to match C++ IMPLIED_MATH_FORMAT setting.
-        disable_format_inference=formats.input_format.is_mx_format(),
-    )
+        "unpack_to_dest": False,
+        "dest_acc": dest_acc,
+        "boot_mode": boot_mode,
+        "disable_format_inference": formats.input_format.is_mx_format(),
+    }
 
+    if is_perf:
+        configuration = PerfConfig(run_types=run_types, **test_config_kwargs)
+        configuration.run(perf_report)
+        return
+
+    configuration = TestConfig(
+        **{
+            **test_config_kwargs,
+            "templates": test_config_kwargs["templates"]
+            + [PERF_RUN_TYPE(PerfRunType.L1_TO_L1)],
+        },
+    )
     res_from_L1 = configuration.run().result
 
     assert len(res_from_L1) == len(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_broadcast_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_broadcast_quasar.py
@@ -44,9 +44,10 @@ from helpers.test_variant_parameters import (
     TEST_FACE_DIMS,
     TILE_COUNT,
 )
+from helpers.tile_constants import DEFAULT_TILE_C_DIM, DEFAULT_TILE_R_DIM
 from helpers.utils import passed_test
 
-TILE_ELEMS = 32 * 32
+TILE_ELEMS = DEFAULT_TILE_R_DIM * DEFAULT_TILE_C_DIM
 FACE_ELEMS = 16 * 16
 
 BINARY_BROADCAST_FORMATS = input_output_formats(
@@ -85,7 +86,7 @@ def binary_broadcast_input_dimensions(dest_acc, dest_sync_mode, *, is_perf=False
     if is_perf:
         # Nested list: parametrize treats a flat list as multiple values, so
         # [32, 32] would become input_dimensions=32 (int) and break generate_stimuli.
-        return [[32, 32]]
+        return [[DEFAULT_TILE_R_DIM, DEFAULT_TILE_C_DIM]]
     return generate_unary_input_dimensions(dest_acc, dest_sync_mode)
 
 
@@ -206,7 +207,6 @@ def test_eltwise_binary_broadcast_quasar(
         ),
         "unpack_to_dest": False,
         "dest_acc": dest_acc,
-        "boot_mode": boot_mode,
         "disable_format_inference": formats.input_format.is_mx_format(),
     }
 
@@ -220,6 +220,7 @@ def test_eltwise_binary_broadcast_quasar(
             **test_config_kwargs,
             "templates": test_config_kwargs["templates"]
             + [PERF_RUN_TYPE(PerfRunType.L1_TO_L1)],
+            "boot_mode": boot_mode,
         },
     )
     res_from_L1 = configuration.run().result

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_broadcast_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_broadcast_quasar_test.cpp
@@ -154,16 +154,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
             // unmatched clear token, causing the ~2048-cycle stall.
             _perf_math_loop_clear_valid<true, true>(src_handshake_iters);
         }
-        else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
-        {
-            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
-            {
-                for (std::uint32_t i = 0; i < TILE_CNT; ++i)
-                {
-                    _llk_math_eltwise_binary_broadcast_(i);
-                }
-            }
-        }
         else
         {
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
@@ -172,7 +162,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 {
                     _llk_math_eltwise_binary_broadcast_(i);
                 }
-                _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+                if constexpr (PERF_RUN_TYPE != PerfRunType::MATH_ISOLATE)
+                {
+                    _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+                }
             }
         }
         PROFILER_SYNC();

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_broadcast_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_broadcast_quasar_test.cpp
@@ -7,6 +7,8 @@
 
 #include "ckernel.h"
 #include "llk_defs.h"
+#include "perf.h"
+#include "profiler.h"
 #include "sfpu_stub.h"
 
 #ifdef LLK_TRISC_UNPACK
@@ -20,43 +22,73 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
+#ifndef SPEED_OF_LIGHT
+    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT        = params.TILE_CNT;
+    const std::uint32_t num_faces       = params.num_faces;
+    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
+    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
+    const Operand& buffer_A             = params.buffer_A;
+    const Operand& buffer_B             = params.buffer_B;
+#endif
     tdma_descriptor_t td_val_A, td_val_B;
     const std::uint32_t buf_desc_id_a        = 0;
     const std::uint32_t buf_desc_id_b        = 1;
-    const std::uint32_t num_tiles_per_unpack = params.TILE_CNT;
+    const std::uint32_t num_tiles_per_unpack = TILE_CNT;
 
-    // Setup data valid scheme
-    set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+    {
+        ZONE_SCOPED("INIT")
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
 
-    // Configure Source A buffer descriptor
-    buffer_descriptor_u bd_val_A = {0};
-    bd_val_A.f.l1_addr_16B       = params.buffer_A[0] / 16;
-    bd_val_A.f.format            = static_cast<std::uint8_t>(formats.unpack_A_src);
-    bd_val_A.f.x_dim             = params.TEST_FACE_C_DIM;
-    bd_val_A.f.y_dim             = params.TEST_FACE_R_DIM;
-    bd_val_A.f.z_dim             = params.num_faces;
+        buffer_descriptor_u bd_val_A = {0};
+        bd_val_A.f.l1_addr_16B       = buffer_A[0] / 16;
+        bd_val_A.f.format            = static_cast<std::uint8_t>(formats.unpack_A_src);
+        bd_val_A.f.x_dim             = TEST_FACE_C_DIM;
+        bd_val_A.f.y_dim             = TEST_FACE_R_DIM;
+        bd_val_A.f.z_dim             = num_faces;
 
-    td_val_A.buf_desc        = bd_val_A;
-    td_val_A.buf_desc_id     = buf_desc_id_a;
-    td_val_A.reg_data_format = static_cast<std::uint8_t>(formats.unpack_A_dst);
+        td_val_A.buf_desc        = bd_val_A;
+        td_val_A.buf_desc_id     = buf_desc_id_a;
+        td_val_A.reg_data_format = static_cast<std::uint8_t>(formats.unpack_A_dst);
 
-    // Configure Source B buffer descriptor
-    buffer_descriptor_u bd_val_B = {0};
-    bd_val_B.f.l1_addr_16B       = params.buffer_B[0] / 16;
-    bd_val_B.f.format            = static_cast<std::uint8_t>(formats.unpack_B_src);
-    bd_val_B.f.x_dim             = params.TEST_FACE_C_DIM;
-    bd_val_B.f.y_dim             = params.TEST_FACE_R_DIM;
-    bd_val_B.f.z_dim             = params.num_faces;
+        buffer_descriptor_u bd_val_B = {0};
+        bd_val_B.f.l1_addr_16B       = buffer_B[0] / 16;
+        bd_val_B.f.format            = static_cast<std::uint8_t>(formats.unpack_B_src);
+        bd_val_B.f.x_dim             = TEST_FACE_C_DIM;
+        bd_val_B.f.y_dim             = TEST_FACE_R_DIM;
+        bd_val_B.f.z_dim             = num_faces;
 
-    td_val_B.buf_desc        = bd_val_B;
-    td_val_B.buf_desc_id     = buf_desc_id_b;
-    td_val_B.reg_data_format = static_cast<std::uint8_t>(formats.unpack_B_dst);
+        td_val_B.buf_desc        = bd_val_B;
+        td_val_B.buf_desc_id     = buf_desc_id_b;
+        td_val_B.reg_data_format = static_cast<std::uint8_t>(formats.unpack_B_dst);
 
-    _configure_buf_desc_table_(td_val_A.buf_desc_id, td_val_A.buf_desc);
-    _configure_buf_desc_table_(td_val_B.buf_desc_id, td_val_B.buf_desc);
-    _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val_A, td_val_B);
-    _llk_unpack_binary_broadcast_operands_init_<BROADCAST_TYPE>(buf_desc_id_a, buf_desc_id_b, num_tiles_per_unpack);
-    _llk_unpack_binary_broadcast_operands_(0, 0);
+        _configure_buf_desc_table_(td_val_A.buf_desc_id, td_val_A.buf_desc);
+        _configure_buf_desc_table_(td_val_B.buf_desc_id, td_val_B.buf_desc);
+        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val_A, td_val_B);
+        _llk_unpack_binary_broadcast_operands_init_<BROADCAST_TYPE>(buf_desc_id_a, buf_desc_id_b, num_tiles_per_unpack);
+        PROFILER_SYNC();
+    }
+    {
+        ZONE_SCOPED("TILE_LOOP")
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
+        {
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
+        {
+            // The SCALAR math MOP clears SrcAB only on the final outer-loop iteration,
+            // so mock unpack must produce one SrcA/SrcB handshake per tile.
+            const std::uint32_t dvalids_per_tile = (BROADCAST_TYPE == BroadcastType::SCALAR) ? 1u : num_faces;
+            _perf_unpack_loop_set_valid<true, true>(LOOP_FACTOR * TILE_CNT * dvalids_per_tile);
+        }
+        else // UNPACK_ISOLATE, L1_CONGESTION, L1_TO_L1
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                _llk_unpack_binary_broadcast_operands_(0, 0);
+            }
+        }
+        PROFILER_SYNC();
+    }
 }
 
 #endif
@@ -74,27 +106,77 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
-
-    DataFormat math_format     = static_cast<DataFormat>(formats.math);
-    DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
-    if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)
+#ifndef SPEED_OF_LIGHT
+    const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT    = params.TILE_CNT;
+    const std::uint32_t num_faces   = params.num_faces;
+#endif
+    // set_last_outer_loop_instr clears SrcAB once on the final face, not once per
+    // face. SCALAR unpack likewise produces one SrcA/SrcB dvalid pair per tile.
+    const std::uint32_t dvalids_per_tile    = (BROADCAST_TYPE == BroadcastType::SCALAR) ? 1u : num_faces;
+    const std::uint32_t src_handshake_iters = LOOP_FACTOR * TILE_CNT * dvalids_per_tile;
     {
-        _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
-    }
-    else
-    {
-        _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*int32_dest*/>(math_format, math_format);
-    }
+        ZONE_SCOPED("INIT")
+        // PACK_ISOLATE / L1_CONGESTION: skip FPU→PACK dest-dvalid (math is src-clear only
+        // in congestion; pulsing never happens — matches WH/BH isolate semantics).
+        if constexpr (PERF_RUN_TYPE != PerfRunType::PACK_ISOLATE && PERF_RUN_TYPE != PerfRunType::L1_CONGESTION)
+        {
+            set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+        }
 
-    // Matches TestConfig NUM_FACES(4) + TEST_FACE_DIMS() (full 32x32 tile).
-    _llk_math_eltwise_binary_broadcast_init_<ELTWISE_BINARY_OP, BROADCAST_TYPE, MATH_FIDELITY>(DEFAULT_TENSOR_SHAPE);
+        DataFormat math_format     = static_cast<DataFormat>(formats.math);
+        DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
+        if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)
+        {
+            _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
+        }
+        else
+        {
+            _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*int32_dest*/>(math_format, math_format);
+        }
 
-    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
-    {
-        _llk_math_eltwise_binary_broadcast_(i);
+        _llk_math_eltwise_binary_broadcast_init_<ELTWISE_BINARY_OP, BROADCAST_TYPE, MATH_FIDELITY>(DEFAULT_TENSOR_SHAPE);
+        PROFILER_SYNC();
     }
-    _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+    {
+        ZONE_SCOPED("TILE_LOOP")
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
+        {
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)
+        {
+            _perf_math_loop_clear_valid<true, true>(src_handshake_iters);
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        {
+            // Do exactly the handshakes produced by real unpack. An additional
+            // synthetic SET/CLEAR pair races the final unpack and leaves an
+            // unmatched clear token, causing the ~2048-cycle stall.
+            _perf_math_loop_clear_valid<true, true>(src_handshake_iters);
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                for (std::uint32_t i = 0; i < TILE_CNT; ++i)
+                {
+                    _llk_math_eltwise_binary_broadcast_(i);
+                }
+            }
+        }
+        else
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                for (std::uint32_t i = 0; i < TILE_CNT; ++i)
+                {
+                    _llk_math_eltwise_binary_broadcast_(i);
+                }
+                _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+            }
+        }
+        PROFILER_SYNC();
+    }
 }
 
 #endif
@@ -110,29 +192,74 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
+#ifndef SPEED_OF_LIGHT
+    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT        = params.TILE_CNT;
+    const std::uint32_t num_faces       = params.num_faces;
+    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
+    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
+    const Operand& buffer_Res           = params.buffer_Res;
+#endif
     std::uint32_t const buf_desc_id        = 8;
-    const std::uint32_t num_tiles_per_pack = params.TILE_CNT;
+    const std::uint32_t num_tiles_per_pack = TILE_CNT;
 
-    set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+    {
+        ZONE_SCOPED("INIT")
+        // PACK_ISOLATE / L1_CONGESTION: no math↔pack dest-dvalid handshake.
+        // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        {
+            auto cfg                                    = (std::uint32_t volatile*)TENSIX_CFG_BASE;
+            cfg[PACK_DEST_DVALID_CTRL_wait_mask_ADDR32] = 0;
+        }
+        else
+        {
+            set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+        }
 
-    buffer_descriptor_u bd_val = {0};
-    bd_val.f.l1_addr_16B       = params.buffer_Res[0] / 16;
-    bd_val.f.format            = static_cast<std::uint8_t>(formats.pack_dst);
-    bd_val.f.x_dim             = params.TEST_FACE_C_DIM;
-    bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
-    bd_val.f.z_dim             = params.num_faces;
+        buffer_descriptor_u bd_val = {0};
+        bd_val.f.l1_addr_16B       = buffer_Res[0] / 16;
+        bd_val.f.format            = static_cast<std::uint8_t>(formats.pack_dst);
+        bd_val.f.x_dim             = TEST_FACE_C_DIM;
+        bd_val.f.y_dim             = TEST_FACE_R_DIM;
+        bd_val.f.z_dim             = num_faces;
 
-    tdma_descriptor_t tdma_desc;
+        tdma_descriptor_t tdma_desc;
 
-    tdma_desc.buf_desc        = bd_val;
-    tdma_desc.buf_desc_id     = buf_desc_id;
-    tdma_desc.reg_data_format = static_cast<std::uint8_t>(formats.pack_src);
+        tdma_desc.buf_desc        = bd_val;
+        tdma_desc.buf_desc_id     = buf_desc_id;
+        tdma_desc.reg_data_format = static_cast<std::uint8_t>(formats.pack_src);
 
-    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
-    _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc, ckernel::ReluConfig::none());
-    _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
-    _llk_pack_(0, 0, ckernel::DEFAULT_TENSOR_SHAPE);
-    _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+        _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
+        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc, ckernel::ReluConfig::none());
+        _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
+        PROFILER_SYNC();
+    }
+    {
+        ZONE_SCOPED("TILE_LOOP")
+
+        if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE || PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)
+        {
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        {
+            // No dest-dvalid section_done: WH/BH isolate packs without math handshake.
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                _llk_pack_(0, 0, ckernel::DEFAULT_TENSOR_SHAPE);
+            }
+        }
+        else
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                _llk_pack_(0, 0, ckernel::DEFAULT_TENSOR_SHAPE);
+                _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+            }
+        }
+
+        PROFILER_SYNC();
+    }
 }
 
 #endif


### PR DESCRIPTION
### PR Category
Performance

### Summary
Adds Quasar performance coverage for `eltwise_binary_broadcast` by introducing its perf test and adapting the matching Python and C++ tests.

Closes #50572

### Notes for reviewers
This PR is intentionally limited to the three operation-specific test files split from `ndivnic/backup_remaining_perf_tests_quasar`.

Builds and tests were not run; any resulting failures will be addressed separately.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/eltwise_binary_broadcast_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/eltwise_binary_broadcast_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/eltwise_binary_broadcast_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/eltwise_binary_broadcast_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ndivnic/eltwise_binary_broadcast_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ndivnic/eltwise_binary_broadcast_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/eltwise_binary_broadcast_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/eltwise_binary_broadcast_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/eltwise_binary_broadcast_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/eltwise_binary_broadcast_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/eltwise_binary_broadcast_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/eltwise_binary_broadcast_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/eltwise_binary_broadcast_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/eltwise_binary_broadcast_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/eltwise_binary_broadcast_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/eltwise_binary_broadcast_perf_test_quasar)