### PR TITLE
[Performance] Add eltwise_binary_reuse_dest Quasar performance test

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_binary_reuse_dest_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_binary_reuse_dest_quasar.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from helpers.llk_params import EltwiseBinaryReuseDestType, PERF_RUN_TYPES_QUASAR
+from helpers.param_config import parametrize, runtime
+from quasar.test_eltwise_binary_reuse_dest_quasar import (
+    INPUT_DIMENSIONS,
+    OUTPUT_DIMENSIONS,
+    REUSE_DEST_FORMATS,
+    reuse_dest_dest_sync_modes,
+    reuse_dest_math_fidelities,
+    reuse_dest_mathops,
+)
+from quasar.test_eltwise_binary_reuse_dest_quasar import (
+    test_eltwise_binary_reuse_dest_quasar as run_eltwise_binary_reuse_dest,
+)
+
+@pytest.mark.perf
+@pytest.mark.quasar
+@parametrize(
+    formats=REUSE_DEST_FORMATS,
+    mathop=lambda formats: reuse_dest_mathops(formats, is_perf=True),
+    math_fidelity=lambda mathop: reuse_dest_math_fidelities(mathop, is_perf=True),
+    reuse_dest_type=[
+        EltwiseBinaryReuseDestType.DEST_TO_SRCA,
+        EltwiseBinaryReuseDestType.DEST_TO_SRCB,
+    ],
+    dest_sync_mode=lambda: reuse_dest_dest_sync_modes(is_perf=True),
+    input_dimensions=runtime(INPUT_DIMENSIONS),
+    output_dimensions=runtime(OUTPUT_DIMENSIONS),
+    run_types=PERF_RUN_TYPES_QUASAR,
+    loop_factor=[32],
+    is_perf=[True],
+)
+def test_perf_eltwise_binary_reuse_dest_quasar(
+    perf_report,
+    formats,
+    mathop,
+    reuse_dest_type,
+    math_fidelity,
+    dest_sync_mode,
+    input_dimensions,
+    output_dimensions,
+    run_types,
+    loop_factor,
+    is_perf,
+):
+    run_eltwise_binary_reuse_dest(
+        formats,
+        mathop,
+        reuse_dest_type,
+        math_fidelity,
+        dest_sync_mode,
+        input_dimensions,
+        output_dimensions,
+        run_types=run_types,
+        loop_factor=loop_factor,
+        is_perf=is_perf,
+        perf_report=perf_report,
+    )

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_binary_reuse_dest_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_binary_reuse_dest_quasar.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from helpers.llk_params import EltwiseBinaryReuseDestType, PERF_RUN_TYPES_QUASAR
+from helpers.llk_params import PERF_RUN_TYPES_QUASAR, EltwiseBinaryReuseDestType
 from helpers.param_config import parametrize, runtime
 from quasar.test_eltwise_binary_reuse_dest_quasar import (
     INPUT_DIMENSIONS,
@@ -15,6 +15,7 @@ from quasar.test_eltwise_binary_reuse_dest_quasar import (
 from quasar.test_eltwise_binary_reuse_dest_quasar import (
     test_eltwise_binary_reuse_dest_quasar as run_eltwise_binary_reuse_dest,
 )
+
 
 @pytest.mark.perf
 @pytest.mark.quasar

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_reuse_dest_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_reuse_dest_quasar.py
@@ -17,6 +17,7 @@ from helpers.llk_params import (
     ImpliedMathFormat,
     MathFidelity,
     MathOperation,
+    PerfRunType,
     format_dict,
 )
 from helpers.param_config import (
@@ -26,6 +27,7 @@ from helpers.param_config import (
     parametrize,
     runtime,
 )
+from helpers.perf import PerfConfig
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import BootMode, TestConfig
@@ -33,12 +35,14 @@ from helpers.test_variant_parameters import (
     DEST_SYNC,
     IMPLIED_MATH_FORMAT,
     INPUT_TILE_CNT,
+    LOOP_FACTOR,
     MATH_FIDELITY,
     MATH_OP,
     NUM_BLOCKS,
     NUM_FACES,
     NUM_TILES_IN_BLOCK,
     OUTPUT_TILE_CNT,
+    PERF_RUN_TYPE,
     REUSE_DEST_TYPE,
     TEST_FACE_DIMS,
     generate_input_dim,
@@ -54,7 +58,61 @@ OUTPUT_DIMENSIONS = [
     [128, 32],
 ]
 
+REUSE_DEST_FORMATS = input_output_formats(
+    [
+        DataFormat.Float16_b,
+        DataFormat.Float16,
+        DataFormat.MxFp8R,
+        DataFormat.MxFp8P,
+        DataFormat.MxFp4,
+        DataFormat.MxInt8,
+        DataFormat.MxInt4,
+        DataFormat.MxInt2,
+    ],
+)
+
 TILE_DIMENSIONS = [32, 32]
+
+
+def reuse_dest_dest_sync_modes(*, is_perf=False):
+    return [DestSync.Half] if is_perf else [DestSync.Half, DestSync.Full]
+
+
+def reuse_dest_input_dimensions(*, is_perf=False):
+    return INPUT_DIMENSIONS if is_perf else INPUT_DIMENSIONS
+
+
+def reuse_dest_output_dimensions(*, is_perf=False):
+    return OUTPUT_DIMENSIONS if is_perf else OUTPUT_DIMENSIONS
+
+
+def reuse_dest_mathops(formats, *, is_perf=False):
+    if is_perf:
+        return [MathOperation.Elwadd]
+    if (
+        formats.input_format == DataFormat.MxFp8R
+        or formats.input_format == DataFormat.MxFp8P
+    ):
+        return [MathOperation.Elwadd, MathOperation.Elwsub]
+    return [MathOperation.Elwadd, MathOperation.Elwsub, MathOperation.Elwmul]
+
+
+def reuse_dest_math_fidelities(mathop, *, is_perf=False):
+    if is_perf or mathop in [MathOperation.Elwadd, MathOperation.Elwsub]:
+        return [MathFidelity.LoFi]
+    return [
+        MathFidelity.LoFi,
+        MathFidelity.HiFi2,
+        MathFidelity.HiFi3,
+        MathFidelity.HiFi4,
+    ]
+
+
+def reuse_dest_implied_math_format(formats, *, is_perf=False):
+    use_mx = formats.input_format.is_mx_format() or formats.output_format.is_mx_format()
+    if is_perf or use_mx:
+        return ImpliedMathFormat.Yes
+    return ImpliedMathFormat.No
 
 
 def _reuse_dest_tile_count(dimensions) -> int:
@@ -99,52 +157,18 @@ def valid_output_dimensions(formats, dest_sync_mode, input_dimensions) -> list:
 
 @pytest.mark.quasar
 @parametrize(
-    formats=input_output_formats(
-        [
-            DataFormat.Float16_b,
-            DataFormat.Float16,
-            DataFormat.MxFp8R,
-            DataFormat.MxFp8P,
-            DataFormat.MxFp4,
-            DataFormat.MxInt8,
-            DataFormat.MxInt4,
-            DataFormat.MxInt2,
-        ],
-    ),
-    # Elwmul with MxFp8R or MxFp8P input and reuse_dest has rounding differences; skip to avoid flaky tolerance failures
-    mathop=lambda formats: (
-        [
-            MathOperation.Elwadd,
-            MathOperation.Elwsub,
-        ]
-        if (
-            formats.input_format == DataFormat.MxFp8R
-            or formats.input_format == DataFormat.MxFp8P
-        )
-        else [
-            MathOperation.Elwadd,
-            MathOperation.Elwsub,
-            MathOperation.Elwmul,
-        ]
-    ),
-    # Math fidelity only affects multiplication; for add/sub only LoFi is meaningful.
-    math_fidelity=lambda mathop: (
-        [MathFidelity.LoFi]
-        if mathop in [MathOperation.Elwadd, MathOperation.Elwsub]
-        else [
-            MathFidelity.LoFi,
-            MathFidelity.HiFi2,
-            MathFidelity.HiFi3,
-            MathFidelity.HiFi4,
-        ]
-    ),
+    formats=REUSE_DEST_FORMATS,
+    mathop=lambda formats: reuse_dest_mathops(formats, is_perf=False),
+    math_fidelity=lambda mathop: reuse_dest_math_fidelities(mathop, is_perf=False),
     reuse_dest_type=[
         EltwiseBinaryReuseDestType.DEST_TO_SRCA,
         EltwiseBinaryReuseDestType.DEST_TO_SRCB,
     ],
-    dest_sync_mode=[DestSync.Half, DestSync.Full],
+    dest_sync_mode=lambda: reuse_dest_dest_sync_modes(is_perf=False),
     input_dimensions=runtime(INPUT_DIMENSIONS),
     output_dimensions=runtime(valid_output_dimensions),
+    run_types=[[PerfRunType.L1_TO_L1]],
+    loop_factor=[1],
 )
 def test_eltwise_binary_reuse_dest_quasar(
     formats,
@@ -154,12 +178,16 @@ def test_eltwise_binary_reuse_dest_quasar(
     dest_sync_mode,
     input_dimensions,
     output_dimensions,
+    run_types,
+    loop_factor,
     boot_mode=BootMode.DEFAULT,
+    *,
+    is_perf=False,
+    perf_report=None,
 ):
 
-    # MX formats require implied_math_format=Yes on Quasar; set it and disable_format_inference so golden matches.
+    implied_math_format = reuse_dest_implied_math_format(formats, is_perf=is_perf)
     use_mx = formats.input_format.is_mx_format() or formats.output_format.is_mx_format()
-    implied_math_format = ImpliedMathFormat.Yes if use_mx else ImpliedMathFormat.No
     disable_format_inference = use_mx
 
     tile_rows, tile_cols = TILE_DIMENSIONS
@@ -225,94 +253,98 @@ def test_eltwise_binary_reuse_dest_quasar(
             src_B_t.to(torch.bfloat16), formats.input_format
         )
 
-    # On Quasar with IMPLIED_MATH_FORMAT=Yes the HW dest accumulator's physical
-    # storage is implied from the SrcA tag: Float16 input → FP16A (S1E5M10);
-    # Float16_b and plain MX inputs → BF16 (S1E8M7). Match that here so the
-    # golden's multi-tile accumulation rounds the same way as HW. The pack
-    # stage widens dest to (sign, 8-bit exp, 23-bit mantissa) without a bf16
-    # detour, so the post-loop tensor is kept in fp32 — feeding bf16 into the
-    # MX quantize would discard 3 mantissa bits the HW preserves.
-    if use_mx:
-        internal_dtype = (
-            torch.float16
-            if formats.input_format == DataFormat.Float16
-            else torch.bfloat16
+    if not is_perf:
+        # On Quasar with IMPLIED_MATH_FORMAT=Yes the HW dest accumulator's physical
+        # storage is implied from the SrcA tag: Float16 input → FP16A (S1E5M10);
+        # Float16_b and plain MX inputs → BF16 (S1E8M7). Match that here so the
+        # golden's multi-tile accumulation rounds the same way as HW. The pack
+        # stage widens dest to (sign, 8-bit exp, 23-bit mantissa) without a bf16
+        # detour, so the post-loop tensor is kept in fp32 — feeding bf16 into the
+        # MX quantize would discard 3 mantissa bits the HW preserves.
+        if use_mx:
+            internal_dtype = (
+                torch.float16
+                if formats.input_format == DataFormat.Float16
+                else torch.bfloat16
+            )
+            golden_dtype = torch.float32
+        else:
+            internal_dtype = torch_format
+            golden_dtype = torch_format
+        golden_tensor = torch.zeros(tile_cnt_output * tile_elements, dtype=golden_dtype)
+
+        eltwise_golden = (
+            EltwiseBinaryGolden()
+            if (mathop == MathOperation.Elwmul and math_fidelity == MathFidelity.LoFi)
+            else None
         )
-        golden_dtype = torch.float32
-    else:
-        internal_dtype = torch_format
-        golden_dtype = torch_format
-    golden_tensor = torch.zeros(tile_cnt_output * tile_elements, dtype=golden_dtype)
 
-    eltwise_golden = (
-        EltwiseBinaryGolden()
-        if (mathop == MathOperation.Elwmul and math_fidelity == MathFidelity.LoFi)
-        else None
-    )
+        math_format_for_fidelity = (
+            (DataFormat.Float16_b if use_mx else formats.output_format)
+            if eltwise_golden is not None
+            else None
+        )
 
-    math_format_for_fidelity = (
-        (DataFormat.Float16_b if use_mx else formats.output_format)
-        if eltwise_golden is not None
-        else None
-    )
+        for out_t in range(tile_cnt_output):
+            block_idx = out_t // output_tiles_in_block
+            tile_in_block = out_t % output_tiles_in_block
+            out_start = out_t * tile_elements
+            dest = src_A_t[out_start : out_start + tile_elements].to(internal_dtype)
 
-    for out_t in range(tile_cnt_output):
-        block_idx = out_t // output_tiles_in_block
-        tile_in_block = out_t % output_tiles_in_block
-        out_start = out_t * tile_elements
-        dest = src_A_t[out_start : out_start + tile_elements].to(internal_dtype)
+            for i in range(inner_dim):
+                input_tile_idx = (
+                    block_idx * input_tiles_in_block
+                    + i * output_tiles_in_block
+                    + tile_in_block
+                )
+                start = input_tile_idx * tile_elements
+                end = start + tile_elements
+                a_tile = src_A_t[start:end].to(internal_dtype)
+                b_tile = src_B_t[start:end].to(internal_dtype)
+                srcA, srcB = (
+                    (dest.clone(), b_tile)
+                    if reuse_dest_type == EltwiseBinaryReuseDestType.DEST_TO_SRCA
+                    else (a_tile, dest.clone())
+                )
 
-        for i in range(inner_dim):
-            input_tile_idx = (
-                block_idx * input_tiles_in_block
-                + i * output_tiles_in_block
-                + tile_in_block
-            )
-            start = input_tile_idx * tile_elements
-            end = start + tile_elements
-            a_tile = src_A_t[start:end].to(internal_dtype)
-            b_tile = src_B_t[start:end].to(internal_dtype)
-            srcA, srcB = (
-                (dest.clone(), b_tile)
-                if reuse_dest_type == EltwiseBinaryReuseDestType.DEST_TO_SRCA
-                else (a_tile, dest.clone())
-            )
+                if mathop == MathOperation.Elwadd:
+                    dest = srcA + srcB
+                elif mathop == MathOperation.Elwsub:
+                    dest = srcA - srcB
+                elif mathop == MathOperation.Elwmul:
+                    if eltwise_golden is not None:
+                        mask_dtype = format_dict[math_format_for_fidelity]
+                        srcA_m, srcB_m = eltwise_golden._apply_fidelity_masking(
+                            math_format_for_fidelity,
+                            srcA.to(mask_dtype),
+                            srcB.to(mask_dtype),
+                            0,
+                        )
+                        product = (
+                            (srcA_m.to(torch.float32) * srcB_m.to(torch.float32))
+                            .to(srcA_m.dtype)
+                            .to(internal_dtype)
+                        )
+                        dest = product
+                    else:
+                        dest = srcA * srcB
 
-            if mathop == MathOperation.Elwadd:
-                dest = srcA + srcB
-            elif mathop == MathOperation.Elwsub:
-                dest = srcA - srcB
-            elif mathop == MathOperation.Elwmul:
-                if eltwise_golden is not None:
-                    mask_dtype = format_dict[math_format_for_fidelity]
-                    srcA_m, srcB_m = eltwise_golden._apply_fidelity_masking(
-                        math_format_for_fidelity,
-                        srcA.to(mask_dtype),
-                        srcB.to(mask_dtype),
-                        0,
-                    )
-                    product = (
-                        (srcA_m.to(torch.float32) * srcB_m.to(torch.float32))
-                        .to(srcA_m.dtype)
-                        .to(internal_dtype)
-                    )
-                    dest = product
-                else:
-                    dest = srcA * srcB
+            golden_tensor[out_start : out_start + tile_elements] = dest.to(golden_dtype)
 
-        golden_tensor[out_start : out_start + tile_elements] = dest.to(golden_dtype)
+    if is_perf and perf_report is None:
+        raise ValueError("perf_report must be provided when is_perf=True")
 
-    configuration = TestConfig(
-        "sources/quasar/eltwise_binary_reuse_dest_quasar_test.cpp",
-        formats,
-        templates=[
+    test_config_kwargs = {
+        "test_name": "sources/quasar/eltwise_binary_reuse_dest_quasar_test.cpp",
+        "formats": formats,
+        "templates": [
             MATH_FIDELITY(math_fidelity),
             MATH_OP(mathop=mathop),
             IMPLIED_MATH_FORMAT(implied_math_format),
             REUSE_DEST_TYPE(reuse_dest_type),
             DEST_SYNC(dest_sync_mode),
         ],
-        runtimes=[
+        "runtimes": [
             generate_input_dim(input_dimensions, input_dimensions),
             INPUT_TILE_CNT(tile_cnt_input),
             OUTPUT_TILE_CNT(tile_cnt_output),
@@ -328,8 +360,9 @@ def test_eltwise_binary_reuse_dest_quasar(
             ),
             NUM_FACES(num_faces),
             TEST_FACE_DIMS(face_r_dim=face_r_dim, face_c_dim=FACE_C_DIM),
+            LOOP_FACTOR(loop_factor),
         ],
-        variant_stimuli=StimuliConfig(
+        "variant_stimuli": StimuliConfig(
             src_A_t,
             formats.input_format,
             src_B_t,
@@ -343,12 +376,24 @@ def test_eltwise_binary_reuse_dest_quasar(
             tile_dimensions=[tile_rows, tile_cols],
             use_dense_tile_dimensions=True,
         ),
-        unpack_to_dest=False,
-        dest_acc=DestAccumulation.No,
-        boot_mode=boot_mode,
-        disable_format_inference=disable_format_inference,
-    )
+        "unpack_to_dest": False,
+        "dest_acc": DestAccumulation.No,
+        "boot_mode": boot_mode,
+        "disable_format_inference": disable_format_inference,
+    }
 
+    if is_perf:
+        configuration = PerfConfig(run_types=run_types, **test_config_kwargs)
+        configuration.run(perf_report)
+        return
+
+    configuration = TestConfig(
+        **{
+            **test_config_kwargs,
+            "templates": test_config_kwargs["templates"]
+            + [PERF_RUN_TYPE(PerfRunType.L1_TO_L1)],
+        },
+    )
     res_from_L1 = configuration.run().result
 
     # Verify results match golden

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_reuse_dest_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_reuse_dest_quasar.py
@@ -378,7 +378,6 @@ def test_eltwise_binary_reuse_dest_quasar(
         ),
         "unpack_to_dest": False,
         "dest_acc": DestAccumulation.No,
-        "boot_mode": boot_mode,
         "disable_format_inference": disable_format_inference,
     }
 
@@ -390,6 +389,7 @@ def test_eltwise_binary_reuse_dest_quasar(
     configuration = TestConfig(
         **{
             **test_config_kwargs,
+            "boot_mode": boot_mode,
             "templates": test_config_kwargs["templates"]
             + [PERF_RUN_TYPE(PerfRunType.L1_TO_L1)],
         },

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_reuse_dest_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_reuse_dest_quasar.py
@@ -78,14 +78,6 @@ def reuse_dest_dest_sync_modes(*, is_perf=False):
     return [DestSync.Half] if is_perf else [DestSync.Half, DestSync.Full]
 
 
-def reuse_dest_input_dimensions(*, is_perf=False):
-    return INPUT_DIMENSIONS if is_perf else INPUT_DIMENSIONS
-
-
-def reuse_dest_output_dimensions(*, is_perf=False):
-    return OUTPUT_DIMENSIONS if is_perf else OUTPUT_DIMENSIONS
-
-
 def reuse_dest_mathops(formats, *, is_perf=False):
     if is_perf:
         return [MathOperation.Elwadd]

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_reuse_dest_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_reuse_dest_quasar_test.cpp
@@ -10,6 +10,8 @@
 #include "ckernel.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
+#include "perf.h"
+#include "profiler.h"
 #include "sfpu_stub.h"
 
 // Globals
@@ -28,57 +30,93 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
+#ifndef SPEED_OF_LIGHT
+    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
+    const std::uint32_t INPUT_TILE_CNT  = params.INPUT_TILE_CNT;
+    const std::uint32_t num_faces       = params.num_faces;
+    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
+    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
+    const Operand& buffer_A             = params.buffer_A;
+    const Operand& buffer_B             = params.buffer_B;
+#endif
     tdma_descriptor_t td_val_A, td_val_B;
-    const std::uint32_t buf_desc_id_a = 0;
-    const std::uint32_t buf_desc_id_b = 1;
-    constexpr bool TRANSPOSE_EN       = false;
-    constexpr bool IS_32B_DEST_EN     = false;
-
-    // Setup data valid scheme
-    set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
-
-    // Configure Source A buffer descriptor — BD base points to tile 0;
-    // tile_idx=i in each unpack call offsets automatically: buffer_A[0] + i*stride = buffer_A[i]
-    buffer_descriptor_u bd_val_A {};
-    bd_val_A.f.l1_addr_16B = L1_ADDRESS(params.buffer_A[0]);
-    bd_val_A.f.format      = static_cast<std::uint8_t>(formats.unpack_A_src);
-    bd_val_A.f.x_dim       = params.TEST_FACE_C_DIM;
-    bd_val_A.f.y_dim       = params.TEST_FACE_R_DIM;
-    bd_val_A.f.z_dim       = params.num_faces;
-
-    td_val_A.buf_desc        = bd_val_A;
-    td_val_A.buf_desc_id     = buf_desc_id_a;
-    td_val_A.reg_data_format = static_cast<std::uint8_t>(formats.unpack_A_dst);
-
-    // Configure Source B buffer descriptor — BD base points to tile 0
-    buffer_descriptor_u bd_val_B {};
-    bd_val_B.f.l1_addr_16B = L1_ADDRESS(params.buffer_B[0]);
-    bd_val_B.f.format      = static_cast<std::uint8_t>(formats.unpack_B_src);
-    bd_val_B.f.x_dim       = params.TEST_FACE_C_DIM;
-    bd_val_B.f.y_dim       = params.TEST_FACE_R_DIM;
-    bd_val_B.f.z_dim       = params.num_faces;
-
-    td_val_B.buf_desc        = bd_val_B;
-    td_val_B.buf_desc_id     = buf_desc_id_b;
-    td_val_B.reg_data_format = static_cast<std::uint8_t>(formats.unpack_B_dst);
-
-    _configure_buf_desc_table_(td_val_A.buf_desc_id, td_val_A.buf_desc);
-    _configure_buf_desc_table_(td_val_B.buf_desc_id, td_val_B.buf_desc);
-    _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val_A, td_val_B);
-
-    _llk_unpack_unary_operand_init_<p_unpacr::UNP_A, TRANSPOSE_EN, IS_32B_DEST_EN>(buf_desc_id_a, ckernel::DEFAULT_TENSOR_SHAPE, 1);
-    for (int i = 0; i < params.INPUT_TILE_CNT; ++i)
-    {
-        _llk_unpack_unary_operand_<p_unpacr::UNP_A>(i, ckernel::DEFAULT_TENSOR_SHAPE);
-    }
-
+    const std::uint32_t buf_desc_id_a          = 0;
+    const std::uint32_t buf_desc_id_b          = 1;
+    constexpr bool TRANSPOSE_EN                = false;
+    constexpr bool IS_32B_DEST_EN              = false;
     constexpr std::uint32_t buf_desc_id_phase2 = (REUSE_DEST_TYPE == EltwiseBinaryReuseDestType::DEST_TO_SRCB) ? buf_desc_id_a : buf_desc_id_b;
-    // Phase 2: unpack the other operand. DEST_TO_SRCA → SrcB from buffer B (UNP_B); DEST_TO_SRCB → SrcA from buffer A (UNP_A).
-    constexpr std::uint32_t unp_sel_phase2 = (REUSE_DEST_TYPE == EltwiseBinaryReuseDestType::DEST_TO_SRCA) ? p_unpacr::UNP_B : p_unpacr::UNP_A;
-    _llk_unpack_unary_operand_init_<unp_sel_phase2, TRANSPOSE_EN, IS_32B_DEST_EN, REUSE_DEST_TYPE>(buf_desc_id_phase2, ckernel::DEFAULT_TENSOR_SHAPE, 1);
-    for (int i = 0; i < params.INPUT_TILE_CNT; ++i)
+    constexpr std::uint32_t unp_sel_phase2     = (REUSE_DEST_TYPE == EltwiseBinaryReuseDestType::DEST_TO_SRCA) ? p_unpacr::UNP_B : p_unpacr::UNP_A;
+
     {
-        _llk_unpack_unary_operand_<unp_sel_phase2, REUSE_DEST_TYPE>(i, ckernel::DEFAULT_TENSOR_SHAPE);
+        ZONE_SCOPED("INIT")
+        // Setup data valid scheme
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+
+        buffer_descriptor_u bd_val_A {};
+        bd_val_A.f.l1_addr_16B = L1_ADDRESS(buffer_A[0]);
+        bd_val_A.f.format      = static_cast<std::uint8_t>(formats.unpack_A_src);
+        bd_val_A.f.x_dim       = TEST_FACE_C_DIM;
+        bd_val_A.f.y_dim       = TEST_FACE_R_DIM;
+        bd_val_A.f.z_dim       = num_faces;
+
+        td_val_A.buf_desc        = bd_val_A;
+        td_val_A.buf_desc_id     = buf_desc_id_a;
+        td_val_A.reg_data_format = static_cast<std::uint8_t>(formats.unpack_A_dst);
+
+        buffer_descriptor_u bd_val_B {};
+        bd_val_B.f.l1_addr_16B = L1_ADDRESS(buffer_B[0]);
+        bd_val_B.f.format      = static_cast<std::uint8_t>(formats.unpack_B_src);
+        bd_val_B.f.x_dim       = TEST_FACE_C_DIM;
+        bd_val_B.f.y_dim       = TEST_FACE_R_DIM;
+        bd_val_B.f.z_dim       = num_faces;
+
+        td_val_B.buf_desc        = bd_val_B;
+        td_val_B.buf_desc_id     = buf_desc_id_b;
+        td_val_B.reg_data_format = static_cast<std::uint8_t>(formats.unpack_B_dst);
+
+        _configure_buf_desc_table_(td_val_A.buf_desc_id, td_val_A.buf_desc);
+        _configure_buf_desc_table_(td_val_B.buf_desc_id, td_val_B.buf_desc);
+        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val_A, td_val_B);
+
+        PROFILER_SYNC();
+    }
+    {
+        ZONE_SCOPED("TILE_LOOP")
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
+        {
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                // Phase 1 datacopy consumes SrcA once per tile.
+                _perf_unpack_loop_set_valid<true, false>(INPUT_TILE_CNT);
+                // Phase 2 reuse-dest binary consumes both sources per face.
+                _perf_unpack_loop_set_valid<true, true>(INPUT_TILE_CNT * num_faces);
+            }
+        }
+        else
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                // Phase 1 and phase 2 share unpack's bank0 instruction
+                // buffer, so select the phase 1 MOP before executing it.
+                _llk_unpack_unary_operand_init_<p_unpacr::UNP_A, TRANSPOSE_EN, IS_32B_DEST_EN>(buf_desc_id_a, ckernel::DEFAULT_TENSOR_SHAPE, 1);
+                for (std::uint32_t i = 0; i < INPUT_TILE_CNT; ++i)
+                {
+                    _llk_unpack_unary_operand_<p_unpacr::UNP_A>(i, ckernel::DEFAULT_TENSOR_SHAPE);
+                }
+
+                // Select the reuse-dest phase 2 MOP after phase 1 completes.
+                _llk_unpack_unary_operand_init_<unp_sel_phase2, TRANSPOSE_EN, IS_32B_DEST_EN, REUSE_DEST_TYPE>(
+                    buf_desc_id_phase2, ckernel::DEFAULT_TENSOR_SHAPE, 1);
+                for (std::uint32_t i = 0; i < INPUT_TILE_CNT; ++i)
+                {
+                    _llk_unpack_unary_operand_<unp_sel_phase2, REUSE_DEST_TYPE>(i, ckernel::DEFAULT_TENSOR_SHAPE);
+                }
+            }
+        }
+        PROFILER_SYNC();
     }
 }
 
@@ -99,38 +137,99 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
-
-    DataFormat src_format = static_cast<DataFormat>(formats.math);
-    _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*int32*/>(src_format, src_format);
-
-    const int num_total_tiles = params.INPUT_NUM_TILES_IN_BLOCK * params.INPUT_NUM_BLOCKS;
-    const int tiles_in_block  = params.OUTPUT_NUM_TILES_IN_BLOCK;
-    const int num_tiles_accum = params.INPUT_NUM_TILES_IN_BLOCK / tiles_in_block;
-    const int num_blocks      = params.INPUT_NUM_BLOCKS;
-
-    // Datacopy src_A from SrcA to DEST (all input tiles)
-    _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en>(params.num_faces * params.TEST_FACE_R_DIM, 1);
-    for (int i = 0; i < num_total_tiles; ++i)
+#ifndef SPEED_OF_LIGHT
+    const std::uint32_t LOOP_FACTOR               = params.LOOP_FACTOR;
+    const std::uint32_t INPUT_TILE_CNT            = params.INPUT_TILE_CNT;
+    const std::uint32_t num_faces                 = params.num_faces;
+    const std::uint32_t TEST_FACE_R_DIM           = params.TEST_FACE_R_DIM;
+    const std::uint32_t INPUT_NUM_TILES_IN_BLOCK  = params.INPUT_NUM_TILES_IN_BLOCK;
+    const std::uint32_t INPUT_NUM_BLOCKS          = params.INPUT_NUM_BLOCKS;
+    const std::uint32_t OUTPUT_NUM_TILES_IN_BLOCK = params.OUTPUT_NUM_TILES_IN_BLOCK;
+#endif
     {
-        _llk_math_eltwise_unary_datacopy_(i);
-    }
-
-    // Binary with reuse_dest: SrcA = DEST (from datacopy), SrcB = unpacked B. Compute op(SrcA, SrcB) -> DEST.
-    _llk_math_eltwise_binary_init_<ELTWISE_BINARY_OP, MATH_FIDELITY, REUSE_DEST_TYPE>(ckernel::DEFAULT_TENSOR_SHAPE); // tiny-tile testing not yet supported
-
-    for (int block = 0; block < num_blocks; block++)
-    {
-        for (int n = 0; n < num_tiles_accum; n++)
+        ZONE_SCOPED("INIT")
+        // PACK_ISOLATE measures pack alone (WH/BH style): skip FPU→PACK dest-dvalid.
+        if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
-            for (int tile = 0; tile < tiles_in_block; tile++)
+            set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+        }
+
+        DataFormat src_format = static_cast<DataFormat>(formats.math);
+        _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*int32*/>(src_format, src_format);
+
+        PROFILER_SYNC();
+    }
+    {
+        ZONE_SCOPED("TILE_LOOP")
+        const int num_total_tiles = INPUT_NUM_TILES_IN_BLOCK * INPUT_NUM_BLOCKS;
+        const int tiles_in_block  = OUTPUT_NUM_TILES_IN_BLOCK;
+        const int num_tiles_accum = INPUT_NUM_TILES_IN_BLOCK / tiles_in_block;
+        const int num_blocks      = INPUT_NUM_BLOCKS;
+
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
+        {
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
-                const int global_tile_idx = block * tiles_in_block + tile;
-                _llk_math_eltwise_binary_<ELTWISE_BINARY_OP, REUSE_DEST_TYPE>(
-                    global_tile_idx, ckernel::DEFAULT_TENSOR_SHAPE, is_fp32_dest_acc_en /*clear_fp32_mode*/);
+                _perf_math_loop_clear_valid<true, false>(INPUT_TILE_CNT);
+                _perf_math_loop_clear_valid<true, true>(INPUT_TILE_CNT * num_faces);
             }
         }
-        _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                // Datacopy and binary share math's bank0 instruction buffer.
+                _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en>(num_faces * TEST_FACE_R_DIM, 1);
+                for (int i = 0; i < num_total_tiles; ++i)
+                {
+                    _llk_math_eltwise_unary_datacopy_(i);
+                }
+
+                _llk_math_eltwise_binary_init_<ELTWISE_BINARY_OP, MATH_FIDELITY, REUSE_DEST_TYPE>(ckernel::DEFAULT_TENSOR_SHAPE);
+                for (int block = 0; block < num_blocks; block++)
+                {
+                    for (int n = 0; n < num_tiles_accum; n++)
+                    {
+                        for (int tile = 0; tile < tiles_in_block; tile++)
+                        {
+                            const int global_tile_idx = block * tiles_in_block + tile;
+                            _llk_math_eltwise_binary_<ELTWISE_BINARY_OP, REUSE_DEST_TYPE>(
+                                global_tile_idx, ckernel::DEFAULT_TENSOR_SHAPE, is_fp32_dest_acc_en /*clear_fp32_mode*/);
+                        }
+                    }
+                }
+            }
+        }
+        else
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en>(num_faces * TEST_FACE_R_DIM, 1);
+                for (int i = 0; i < num_total_tiles; ++i)
+                {
+                    _llk_math_eltwise_unary_datacopy_(i);
+                }
+
+                _llk_math_eltwise_binary_init_<ELTWISE_BINARY_OP, MATH_FIDELITY, REUSE_DEST_TYPE>(ckernel::DEFAULT_TENSOR_SHAPE);
+                for (int block = 0; block < num_blocks; block++)
+                {
+                    for (int n = 0; n < num_tiles_accum; n++)
+                    {
+                        for (int tile = 0; tile < tiles_in_block; tile++)
+                        {
+                            const int global_tile_idx = block * tiles_in_block + tile;
+                            _llk_math_eltwise_binary_<ELTWISE_BINARY_OP, REUSE_DEST_TYPE>(
+                                global_tile_idx, ckernel::DEFAULT_TENSOR_SHAPE, is_fp32_dest_acc_en /*clear_fp32_mode*/);
+                        }
+                    }
+                    _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+                }
+            }
+        }
+        PROFILER_SYNC();
     }
 }
 
@@ -147,37 +246,87 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
+#ifndef SPEED_OF_LIGHT
+    const std::uint32_t LOOP_FACTOR               = params.LOOP_FACTOR;
+    const std::uint32_t TEST_FACE_C_DIM           = params.TEST_FACE_C_DIM;
+    const std::uint32_t TEST_FACE_R_DIM           = params.TEST_FACE_R_DIM;
+    const std::uint32_t num_faces                 = params.num_faces;
+    const std::uint32_t OUTPUT_NUM_TILES_IN_BLOCK = params.OUTPUT_NUM_TILES_IN_BLOCK;
+    const std::uint32_t OUTPUT_NUM_BLOCKS         = params.OUTPUT_NUM_BLOCKS;
+    const Operand& buffer_Res                     = params.buffer_Res;
+#endif
     std::uint32_t const buf_desc_id = 8;
 
-    set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
-
-    buffer_descriptor_u bd_val {};
-    bd_val.f.l1_addr_16B = L1_ADDRESS(params.buffer_Res[0]);
-    bd_val.f.format      = static_cast<std::uint8_t>(formats.pack_dst);
-    bd_val.f.x_dim       = params.TEST_FACE_C_DIM;
-    bd_val.f.y_dim       = params.TEST_FACE_R_DIM;
-    bd_val.f.z_dim       = params.num_faces;
-
-    tdma_descriptor_t tdma_desc;
-    tdma_desc.buf_desc        = bd_val;
-    tdma_desc.buf_desc_id     = buf_desc_id;
-    tdma_desc.reg_data_format = static_cast<std::uint8_t>(formats.pack_src);
-
-    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
-    _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc, ckernel::ReluConfig::none());
-    _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, 1);
-
-    const int output_tiles_in_block = params.OUTPUT_NUM_TILES_IN_BLOCK;
-    const int output_num_blocks     = params.OUTPUT_NUM_BLOCKS;
-
-    for (int block = 0; block < output_num_blocks; block++)
     {
-        for (int tile = 0; tile < output_tiles_in_block; tile++)
+        ZONE_SCOPED("INIT")
+        // Match WH/BH PACK_ISOLATE: no math↔pack handshake; pack from whatever is in dest.
+        // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            int res_tile_idx = (block * output_tiles_in_block) + tile;
-            _llk_pack_(res_tile_idx, res_tile_idx, ckernel::DEFAULT_TENSOR_SHAPE);
+            auto cfg                                    = (std::uint32_t volatile*)TENSIX_CFG_BASE;
+            cfg[PACK_DEST_DVALID_CTRL_wait_mask_ADDR32] = 0;
         }
-        _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
+        {
+            set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+        }
+
+        buffer_descriptor_u bd_val {};
+        bd_val.f.l1_addr_16B = L1_ADDRESS(buffer_Res[0]);
+        bd_val.f.format      = static_cast<std::uint8_t>(formats.pack_dst);
+        bd_val.f.x_dim       = TEST_FACE_C_DIM;
+        bd_val.f.y_dim       = TEST_FACE_R_DIM;
+        bd_val.f.z_dim       = num_faces;
+
+        tdma_descriptor_t tdma_desc;
+        tdma_desc.buf_desc        = bd_val;
+        tdma_desc.buf_desc_id     = buf_desc_id;
+        tdma_desc.reg_data_format = static_cast<std::uint8_t>(formats.pack_src);
+
+        _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
+        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc, ckernel::ReluConfig::none());
+        _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, 1);
+        PROFILER_SYNC();
+    }
+    {
+        ZONE_SCOPED("TILE_LOOP")
+        const int output_tiles_in_block = OUTPUT_NUM_TILES_IN_BLOCK;
+        const int output_num_blocks     = OUTPUT_NUM_BLOCKS;
+
+        if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE || PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)
+        {
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        {
+            // No dest-dvalid section_done: WH/BH isolate packs without math handshake.
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                for (int block = 0; block < output_num_blocks; block++)
+                {
+                    for (int tile = 0; tile < output_tiles_in_block; tile++)
+                    {
+                        int res_tile_idx = (block * output_tiles_in_block) + tile;
+                        _llk_pack_(res_tile_idx, res_tile_idx, ckernel::DEFAULT_TENSOR_SHAPE);
+                    }
+                }
+            }
+        }
+        else
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                for (int block = 0; block < output_num_blocks; block++)
+                {
+                    for (int tile = 0; tile < output_tiles_in_block; tile++)
+                    {
+                        int res_tile_idx = (block * output_tiles_in_block) + tile;
+                        _llk_pack_(res_tile_idx, res_tile_idx, ckernel::DEFAULT_TENSOR_SHAPE);
+                    }
+                    _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+                }
+            }
+        }
+        PROFILER_SYNC();
     }
 }
 

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_reuse_dest_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_reuse_dest_quasar_test.cpp
@@ -148,7 +148,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
     {
         ZONE_SCOPED("INIT")
-        // PACK_ISOLATE measures pack alone (WH/BH style): skip FPU→PACK dest-dvalid.
+        // L1_TO_L1 / MATH_ISOLATE keep the math↔pack handshake: set up FPU→PACK dest-dvalid.
         if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
             set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
@@ -177,7 +177,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 _perf_math_loop_clear_valid<true, true>(INPUT_TILE_CNT * num_faces);
             }
         }
-        else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
+        else
         {
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
@@ -200,32 +200,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
                                 global_tile_idx, ckernel::DEFAULT_TENSOR_SHAPE, is_fp32_dest_acc_en /*clear_fp32_mode*/);
                         }
                     }
-                }
-            }
-        }
-        else
-        {
-            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
-            {
-                _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en>(num_faces * TEST_FACE_R_DIM, 1);
-                for (int i = 0; i < num_total_tiles; ++i)
-                {
-                    _llk_math_eltwise_unary_datacopy_(i);
-                }
-
-                _llk_math_eltwise_binary_init_<ELTWISE_BINARY_OP, MATH_FIDELITY, REUSE_DEST_TYPE>(ckernel::DEFAULT_TENSOR_SHAPE);
-                for (int block = 0; block < num_blocks; block++)
-                {
-                    for (int n = 0; n < num_tiles_accum; n++)
+                    if constexpr (PERF_RUN_TYPE != PerfRunType::MATH_ISOLATE)
                     {
-                        for (int tile = 0; tile < tiles_in_block; tile++)
-                        {
-                            const int global_tile_idx = block * tiles_in_block + tile;
-                            _llk_math_eltwise_binary_<ELTWISE_BINARY_OP, REUSE_DEST_TYPE>(
-                                global_tile_idx, ckernel::DEFAULT_TENSOR_SHAPE, is_fp32_dest_acc_en /*clear_fp32_mode*/);
-                        }
+                        _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
                     }
-                    _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
                 }
             }
         }
@@ -296,21 +274,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
         if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE || PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)
         {
         }
-        else if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
-        {
-            // No dest-dvalid section_done: WH/BH isolate packs without math handshake.
-            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
-            {
-                for (int block = 0; block < output_num_blocks; block++)
-                {
-                    for (int tile = 0; tile < output_tiles_in_block; tile++)
-                    {
-                        int res_tile_idx = (block * output_tiles_in_block) + tile;
-                        _llk_pack_(res_tile_idx, res_tile_idx, ckernel::DEFAULT_TENSOR_SHAPE);
-                    }
-                }
-            }
-        }
         else
         {
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
@@ -322,7 +285,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
                         int res_tile_idx = (block * output_tiles_in_block) + tile;
                         _llk_pack_(res_tile_idx, res_tile_idx, ckernel::DEFAULT_TENSOR_SHAPE);
                     }
-                    _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+                    if constexpr (PERF_RUN_TYPE != PerfRunType::PACK_ISOLATE && PERF_RUN_TYPE != PerfRunType::L1_CONGESTION)
+                    {
+                        _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+                    }
                 }
             }
         }


### PR DESCRIPTION
### PR Category
Performance

### Summary
Adds Quasar performance coverage for `eltwise_binary_reuse_dest` by introducing its perf test and adapting the matching Python and C++ tests.

Closes #50573

### Notes for reviewers
This PR is intentionally limited to the three operation-specific test files split from `ndivnic/backup_remaining_perf_tests_quasar`.

Builds and tests were not run; any resulting failures will be addressed separately.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/eltwise_binary_reuse_dest_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/eltwise_binary_reuse_dest_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/eltwise_binary_reuse_dest_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/eltwise_binary_reuse_dest_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ndivnic/eltwise_binary_reuse_dest_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ndivnic/eltwise_binary_reuse_dest_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/eltwise_binary_reuse_dest_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/eltwise_binary_reuse_dest_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/eltwise_binary_reuse_dest_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/eltwise_binary_reuse_dest_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/eltwise_binary_reuse_dest_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/eltwise_binary_reuse_dest_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/eltwise_binary_reuse_dest_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/eltwise_binary_reuse_dest_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/eltwise_binary_reuse_dest_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/eltwise_binary_reuse_dest_perf_test_quasar)