### PR TITLE
[Performance] Add eltwise_unary_datacopy Quasar performance test

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_unary_datacopy_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_unary_datacopy_quasar.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from helpers.llk_params import PERF_RUN_TYPES_QUASAR
+from helpers.param_config import parametrize
+from quasar.test_eltwise_unary_datacopy_quasar import (
+    PERF_DATACOPY_COMBINATIONS,
+    datacopy_implied_math_formats,
+)
+from quasar.test_eltwise_unary_datacopy_quasar import (
+    test_eltwise_unary_datacopy_quasar as run_eltwise_unary_datacopy,
+)
+
+@pytest.mark.perf
+@pytest.mark.quasar
+@parametrize(
+    formats_dest_acc_data_copy_type_dims_dest_sync_dest_indices=PERF_DATACOPY_COMBINATIONS,
+    implied_math_format=lambda formats_dest_acc_data_copy_type_dims_dest_sync_dest_indices: datacopy_implied_math_formats(
+        formats_dest_acc_data_copy_type_dims_dest_sync_dest_indices[0],
+        is_perf=True,
+    ),
+    run_types=PERF_RUN_TYPES_QUASAR,
+    loop_factor=[32],
+    is_perf=[True],
+)
+def test_perf_eltwise_unary_datacopy_quasar(
+    perf_report,
+    formats_dest_acc_data_copy_type_dims_dest_sync_dest_indices,
+    implied_math_format,
+    run_types,
+    loop_factor,
+    is_perf,
+):
+    run_eltwise_unary_datacopy(
+        formats_dest_acc_data_copy_type_dims_dest_sync_dest_indices,
+        implied_math_format,
+        run_types=run_types,
+        loop_factor=loop_factor,
+        is_perf=is_perf,
+        perf_report=perf_report,
+    )

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_unary_datacopy_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_unary_datacopy_quasar.py
@@ -13,6 +13,7 @@ from quasar.test_eltwise_unary_datacopy_quasar import (
 )
 
 
+@pytest.mark.nightly
 @pytest.mark.perf
 @pytest.mark.quasar
 @parametrize(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_unary_datacopy_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_unary_datacopy_quasar.py
@@ -12,6 +12,7 @@ from quasar.test_eltwise_unary_datacopy_quasar import (
     test_eltwise_unary_datacopy_quasar as run_eltwise_unary_datacopy,
 )
 
+
 @pytest.mark.perf
 @pytest.mark.quasar
 @parametrize(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_datacopy_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_datacopy_quasar.py
@@ -15,6 +15,7 @@ from helpers.llk_params import (
     DestAccumulation,
     DestSync,
     ImpliedMathFormat,
+    PerfRunType,
     UnpackerEngine,
     format_dict,
 )
@@ -25,6 +26,7 @@ from helpers.param_config import (
     parametrize,
     runtime,
 )
+from helpers.perf import PerfConfig
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import TestConfig
@@ -33,9 +35,11 @@ from helpers.test_variant_parameters import (
     DEST_INDEX,
     DEST_SYNC,
     IMPLIED_MATH_FORMAT,
+    LOOP_FACTOR,
     NUM_FACES,
     NUM_FACES_C_DIM,
     NUM_FACES_R_DIM,
+    PERF_RUN_TYPE,
     TEST_FACE_DIMS,
     TILE_COUNT,
     UNPACKER_ENGINE_SEL,
@@ -45,8 +49,18 @@ from helpers.tile_shape import construct_tile_shape
 from helpers.utils import passed_test
 
 
+def datacopy_implied_math_formats(format, *, is_perf=False):
+    if is_perf:
+        return [ImpliedMathFormat.Yes]
+    if format.input_format.is_mx_format():
+        return [ImpliedMathFormat.Yes]
+    return [ImpliedMathFormat.Yes, ImpliedMathFormat.No]
+
+
 def generate_eltwise_unary_datacopy_combinations(
     formats_list: List[FormatConfig],
+    *,
+    is_perf=False,
 ):
     """
     Generate eltwise_unary_datacopy combinations.
@@ -61,8 +75,36 @@ def generate_eltwise_unary_datacopy_combinations(
         in_fmt = fmt.input_format
 
         dest_acc_modes = (DestAccumulation.No, DestAccumulation.Yes)
-        dest_sync_modes = (DestSync.Half, DestSync.Full)
+        dest_sync_modes = (
+            (DestSync.Half,) if is_perf else (DestSync.Half, DestSync.Full)
+        )
         data_copy_types = (DataCopyType.A2D, DataCopyType.B2D)
+
+        if is_perf:
+            tile_dims = (16, 16)
+            tile_shape = construct_tile_shape(tile_dims)
+            dimensions = [32, 32]
+            for dest_acc in dest_acc_modes:
+                if (
+                    in_fmt != DataFormat.Float32
+                    and fmt.output_format == DataFormat.Float32
+                    and dest_acc == DestAccumulation.No
+                ):
+                    continue
+                for dest_sync in dest_sync_modes:
+                    for data_copy_type in data_copy_types:
+                        combinations.append(
+                            (
+                                fmt,
+                                dest_acc,
+                                data_copy_type,
+                                runtime(dimensions),
+                                dest_sync,
+                                runtime(0),
+                                runtime(tile_dims),
+                            )
+                        )
+            continue
 
         for dest_acc in dest_acc_modes:
             if (
@@ -122,23 +164,30 @@ DATACOPY_FORMATS = input_output_formats(
 ALL_DATACOPY_COMBINATIONS = generate_eltwise_unary_datacopy_combinations(
     DATACOPY_FORMATS
 )
+PERF_DATACOPY_COMBINATIONS = generate_eltwise_unary_datacopy_combinations(
+    DATACOPY_FORMATS,
+    is_perf=True,
+)
 
 
 @pytest.mark.quasar
 @parametrize(
     formats_dest_acc_data_copy_type_dims_dest_sync_dest_indices=ALL_DATACOPY_COMBINATIONS,
     # don't generate the No variant for them. combo[0] is the InputOutputFormat (input/output pair).
-    implied_math_format=lambda formats_dest_acc_data_copy_type_dims_dest_sync_dest_indices: (
-        [ImpliedMathFormat.Yes]
-        if formats_dest_acc_data_copy_type_dims_dest_sync_dest_indices[
-            0
-        ].input_format.is_mx_format()
-        else [ImpliedMathFormat.Yes, ImpliedMathFormat.No]
+    implied_math_format=lambda formats_dest_acc_data_copy_type_dims_dest_sync_dest_indices: datacopy_implied_math_formats(
+        formats_dest_acc_data_copy_type_dims_dest_sync_dest_indices[0]
     ),
+    run_types=[[PerfRunType.L1_TO_L1]],
+    loop_factor=[1],
 )
 def test_eltwise_unary_datacopy_quasar(
     formats_dest_acc_data_copy_type_dims_dest_sync_dest_indices,
     implied_math_format,
+    run_types,
+    loop_factor,
+    *,
+    is_perf=False,
+    perf_report=None,
 ):
     (
         formats,
@@ -181,10 +230,13 @@ def test_eltwise_unary_datacopy_quasar(
         tile_shape=tile_shape,
     )
 
-    configuration = TestConfig(
-        "sources/quasar/eltwise_unary_datacopy_quasar_test.cpp",
-        formats,
-        templates=[
+    if is_perf and perf_report is None:
+        raise ValueError("perf_report must be provided when is_perf=True")
+
+    test_config_kwargs = {
+        "test_name": "sources/quasar/eltwise_unary_datacopy_quasar_test.cpp",
+        "formats": formats,
+        "templates": [
             IMPLIED_MATH_FORMAT(implied_math_format),
             DATA_COPY_TYPE(data_copy_type),
             UNPACKER_ENGINE_SEL(
@@ -194,15 +246,16 @@ def test_eltwise_unary_datacopy_quasar(
             ),
             DEST_SYNC(dest_sync_mode),
         ],
-        runtimes=[
+        "runtimes": [
             TILE_COUNT(tile_cnt_A),
             NUM_FACES(num_faces),
             TEST_FACE_DIMS(tile_shape.face_r_dim),
             NUM_FACES_R_DIM(tile_shape.num_faces_r_dim),
             NUM_FACES_C_DIM(tile_shape.num_faces_c_dim),
             DEST_INDEX(dest_index),
+            LOOP_FACTOR(loop_factor),
         ],
-        variant_stimuli=StimuliConfig(
+        "variant_stimuli": StimuliConfig(
             src_A,
             formats.input_format,
             src_B,
@@ -216,15 +269,26 @@ def test_eltwise_unary_datacopy_quasar(
             tile_dimensions=tile_dimensions,
             use_dense_tile_dimensions=True,
         ),
-        unpack_to_dest=False,
-        dest_acc=dest_acc,
-        # MX formats require disable_format_inference to match C++ IMPLIED_MATH_FORMAT setting
-        disable_format_inference=(
+        "unpack_to_dest": False,
+        "dest_acc": dest_acc,
+        "disable_format_inference": (
             implied_math_format == ImpliedMathFormat.Yes
             and formats.input_format.is_mx_format()
         ),
-    )
+    }
 
+    if is_perf:
+        configuration = PerfConfig(run_types=run_types, **test_config_kwargs)
+        configuration.run(perf_report)
+        return
+
+    configuration = TestConfig(
+        **{
+            **test_config_kwargs,
+            "templates": test_config_kwargs["templates"]
+            + [PERF_RUN_TYPE(PerfRunType.L1_TO_L1)],
+        },
+    )
     res_from_L1 = configuration.run().result
 
     assert len(res_from_L1) == len(

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_datacopy_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_datacopy_quasar_test.cpp
@@ -26,21 +26,17 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifndef SPEED_OF_LIGHT
-    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
-    const std::uint32_t TILE_CNT        = params.TILE_CNT;
-    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
-    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
-    const int num_faces_r_dim_A         = params.num_faces_r_dim_A;
-    const int num_faces_c_dim_A         = params.num_faces_c_dim_A;
-    const Operand& buffer_A             = params.buffer_A;
-    const Operand& buffer_B             = params.buffer_B;
+    const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT    = params.TILE_CNT;
+    const Operand& buffer_A         = params.buffer_A;
+    const Operand& buffer_B         = params.buffer_B;
 #endif
     const std::uint32_t buf_desc_id          = 0;
     const std::uint32_t num_tiles_per_unpack = TILE_CNT;
 
     {
         ZONE_SCOPED("INIT")
-        const auto tensor_shape_A = tensor_shape_from_face_dims(TEST_FACE_R_DIM, TEST_FACE_C_DIM, num_faces_r_dim_A, num_faces_c_dim_A);
+        const auto tensor_shape_A = tensor_shape_from_params(params);
 
         unsigned l1_addr_16B;
         if constexpr (UNPACKER_ENGINE_SEL == p_unpacr::UNP_B)
@@ -69,7 +65,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     }
     {
         ZONE_SCOPED("TILE_LOOP")
-        const auto tensor_shape_A = tensor_shape_from_face_dims(TEST_FACE_R_DIM, TEST_FACE_C_DIM, num_faces_r_dim_A, num_faces_c_dim_A);
+        const auto tensor_shape_A = tensor_shape_from_params(params);
 
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
         {
@@ -132,8 +128,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
     {
         ZONE_SCOPED("INIT")
-        // PACK_ISOLATE measures pack alone (WH/BH style): skip FPU→PACK dest-dvalid.
-        if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
+        // Only the end-to-end path has an active PACK consumer.
+        if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
         {
             set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
         }
@@ -203,14 +199,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifndef SPEED_OF_LIGHT
-    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
-    const std::uint32_t TILE_CNT        = params.TILE_CNT;
-    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
-    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
-    const int num_faces_r_dim_A         = params.num_faces_r_dim_A;
-    const int num_faces_c_dim_A         = params.num_faces_c_dim_A;
-    const std::uint32_t DST_INDEX       = params.DST_INDEX;
-    const Operand& buffer_Res           = params.buffer_Res;
+    const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT    = params.TILE_CNT;
+    const std::uint32_t DST_INDEX   = params.DST_INDEX;
+    const Operand& buffer_Res       = params.buffer_Res;
 #endif
     std::uint32_t const buf_desc_id        = 8;
     const std::uint32_t num_tiles_per_pack = TILE_CNT;
@@ -221,7 +213,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            auto cfg                                    = (std::uint32_t volatile*)TENSIX_CFG_BASE;
+            auto cfg                                    = (volatile std::uint32_t*)TENSIX_CFG_BASE;
             cfg[PACK_DEST_DVALID_CTRL_wait_mask_ADDR32] = 0;
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
@@ -229,7 +221,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
         }
 
-        const auto tensor_shape_A = tensor_shape_from_face_dims(TEST_FACE_R_DIM, TEST_FACE_C_DIM, num_faces_r_dim_A, num_faces_c_dim_A);
+        const auto tensor_shape_A = tensor_shape_from_params(params);
 
         tdma_descriptor_t tdma_desc =
             ckernel::trisc::construct_tdma_desc(tensor_shape_A, L1_ADDRESS(buffer_Res[0]), formats.pack_dst, buf_desc_id, formats.pack_src);
@@ -241,7 +233,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     }
     {
         ZONE_SCOPED("TILE_LOOP")
-        const auto tensor_shape_A = tensor_shape_from_face_dims(TEST_FACE_R_DIM, TEST_FACE_C_DIM, num_faces_r_dim_A, num_faces_c_dim_A);
+        const auto tensor_shape_A = tensor_shape_from_params(params);
 
         if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE || PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)
         {

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_datacopy_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_datacopy_quasar_test.cpp
@@ -9,6 +9,8 @@
 #include "ckernel.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
+#include "perf.h"
+#include "profiler.h"
 #include "quasar_test_common.h"
 #include "sfpu_stub.h"
 
@@ -23,39 +25,81 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
+#ifndef SPEED_OF_LIGHT
+    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT        = params.TILE_CNT;
+    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
+    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
+    const int num_faces_r_dim_A         = params.num_faces_r_dim_A;
+    const int num_faces_c_dim_A         = params.num_faces_c_dim_A;
+    const Operand& buffer_A             = params.buffer_A;
+    const Operand& buffer_B             = params.buffer_B;
+#endif
     const std::uint32_t buf_desc_id          = 0;
-    const std::uint32_t num_tiles_per_unpack = params.TILE_CNT;
+    const std::uint32_t num_tiles_per_unpack = TILE_CNT;
 
-    // Setup data valid scheme
-    set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
-
-    const auto tensor_shape_A = tensor_shape_from_params(params);
-
-    unsigned l1_addr_16B;
-    if constexpr (UNPACKER_ENGINE_SEL == p_unpacr::UNP_B)
     {
-        l1_addr_16B = L1_ADDRESS(params.buffer_B[0]);
-    }
-    else
-    {
-        l1_addr_16B = L1_ADDRESS(params.buffer_A[0]);
-    }
+        ZONE_SCOPED("INIT")
+        const auto tensor_shape_A = tensor_shape_from_face_dims(TEST_FACE_R_DIM, TEST_FACE_C_DIM, num_faces_r_dim_A, num_faces_c_dim_A);
 
-    tdma_descriptor_t td_val = ckernel::trisc::construct_tdma_desc(tensor_shape_A, l1_addr_16B, formats.unpack_A_src, buf_desc_id, formats.unpack_A_dst);
+        unsigned l1_addr_16B;
+        if constexpr (UNPACKER_ENGINE_SEL == p_unpacr::UNP_B)
+        {
+            l1_addr_16B = L1_ADDRESS(buffer_B[0]);
+        }
+        else
+        {
+            l1_addr_16B = L1_ADDRESS(buffer_A[0]);
+        }
 
-    _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
-    if (is_fp32_dest_acc_en)
-    {
-        // If Dst fmt is 32b and operation is Mov2D, we need both SrcA/B fmts to be configured since Mov2D will be implemented via ELWADD
-        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val, td_val);
-    }
-    else
-    {
-        _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(td_val);
-    }
+        tdma_descriptor_t td_val = ckernel::trisc::construct_tdma_desc(tensor_shape_A, l1_addr_16B, formats.unpack_A_src, buf_desc_id, formats.unpack_A_dst);
 
-    _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, tensor_shape_A, num_tiles_per_unpack);
-    _llk_unpack_unary_operand_<UNPACKER_ENGINE_SEL>(0, tensor_shape_A);
+        _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
+        if (is_fp32_dest_acc_en)
+        {
+            _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val, td_val);
+        }
+        else
+        {
+            _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(td_val);
+        }
+
+        _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, tensor_shape_A, num_tiles_per_unpack);
+        PROFILER_SYNC();
+    }
+    {
+        ZONE_SCOPED("TILE_LOOP")
+        const auto tensor_shape_A = tensor_shape_from_face_dims(TEST_FACE_R_DIM, TEST_FACE_C_DIM, num_faces_r_dim_A, num_faces_c_dim_A);
+
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
+        {
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
+        {
+            if constexpr (is_fp32_dest_acc_en)
+            {
+                // 32-bit datacopy uses ELWADD and consumes both the selected
+                // source and the dummy source produced by unpack.
+                _perf_unpack_loop_set_valid<true, true>(LOOP_FACTOR * TILE_CNT);
+            }
+            else if constexpr (DATA_COPY_TYPE == DataCopyType::A2D)
+            {
+                _perf_unpack_loop_set_valid<true, false>(LOOP_FACTOR * TILE_CNT);
+            }
+            else
+            {
+                _perf_unpack_loop_set_valid<false, true>(LOOP_FACTOR * TILE_CNT);
+            }
+        }
+        else
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                _llk_unpack_unary_operand_<UNPACKER_ENGINE_SEL>(0, tensor_shape_A);
+            }
+        }
+        PROFILER_SYNC();
+    }
 }
 
 #endif
@@ -79,18 +123,70 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
-
-    DataFormat src_format = static_cast<DataFormat>(formats.math);
-    _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, is_int_fpu_en>(src_format, src_format);
-
-    _llk_math_eltwise_unary_datacopy_init_<DATA_COPY_TYPE, is_fp32_dest_acc_en>(
-        params.num_faces * params.TEST_FACE_R_DIM /*num_rows_per_matrix*/, 1 /*num_matrices*/);
-    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+#ifndef SPEED_OF_LIGHT
+    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT        = params.TILE_CNT;
+    const std::uint32_t num_faces       = params.num_faces;
+    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
+    const std::uint32_t DST_INDEX       = params.DST_INDEX;
+#endif
     {
-        _llk_math_eltwise_unary_datacopy_(params.DST_INDEX + i);
+        ZONE_SCOPED("INIT")
+        // PACK_ISOLATE measures pack alone (WH/BH style): skip FPU→PACK dest-dvalid.
+        if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
+        {
+            set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+        }
+
+        DataFormat src_format = static_cast<DataFormat>(formats.math);
+        _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, is_int_fpu_en>(src_format, src_format);
+
+        _llk_math_eltwise_unary_datacopy_init_<DATA_COPY_TYPE, is_fp32_dest_acc_en>(num_faces * TEST_FACE_R_DIM /*num_rows_per_matrix*/, 1 /*num_matrices*/);
+        PROFILER_SYNC();
     }
-    _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+    {
+        ZONE_SCOPED("TILE_LOOP")
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
+        {
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        {
+            if constexpr (is_fp32_dest_acc_en)
+            {
+                _perf_math_loop_clear_valid<true, true>(LOOP_FACTOR * TILE_CNT);
+            }
+            else if constexpr (DATA_COPY_TYPE == DataCopyType::A2D)
+            {
+                _perf_math_loop_clear_valid<true, false>(LOOP_FACTOR * TILE_CNT);
+            }
+            else
+            {
+                _perf_math_loop_clear_valid<false, true>(LOOP_FACTOR * TILE_CNT);
+            }
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                for (std::uint32_t i = 0; i < TILE_CNT; ++i)
+                {
+                    _llk_math_eltwise_unary_datacopy_(DST_INDEX + i);
+                }
+            }
+        }
+        else
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                for (std::uint32_t i = 0; i < TILE_CNT; ++i)
+                {
+                    _llk_math_eltwise_unary_datacopy_(DST_INDEX + i);
+                }
+                _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+            }
+        }
+        PROFILER_SYNC();
+    }
 }
 
 #endif
@@ -106,20 +202,67 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
+#ifndef SPEED_OF_LIGHT
+    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT        = params.TILE_CNT;
+    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
+    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
+    const int num_faces_r_dim_A         = params.num_faces_r_dim_A;
+    const int num_faces_c_dim_A         = params.num_faces_c_dim_A;
+    const std::uint32_t DST_INDEX       = params.DST_INDEX;
+    const Operand& buffer_Res           = params.buffer_Res;
+#endif
     std::uint32_t const buf_desc_id        = 8;
-    const std::uint32_t num_tiles_per_pack = params.TILE_CNT;
+    const std::uint32_t num_tiles_per_pack = TILE_CNT;
 
-    set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+    {
+        ZONE_SCOPED("INIT")
+        // Match WH/BH PACK_ISOLATE: no math↔pack handshake; pack from whatever is in dest.
+        // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        {
+            auto cfg                                    = (std::uint32_t volatile*)TENSIX_CFG_BASE;
+            cfg[PACK_DEST_DVALID_CTRL_wait_mask_ADDR32] = 0;
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
+        {
+            set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+        }
 
-    const auto tensor_shape_A = tensor_shape_from_params(params);
+        const auto tensor_shape_A = tensor_shape_from_face_dims(TEST_FACE_R_DIM, TEST_FACE_C_DIM, num_faces_r_dim_A, num_faces_c_dim_A);
 
-    tdma_descriptor_t tdma_desc =
-        ckernel::trisc::construct_tdma_desc(tensor_shape_A, L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst, buf_desc_id, formats.pack_src);
+        tdma_descriptor_t tdma_desc =
+            ckernel::trisc::construct_tdma_desc(tensor_shape_A, L1_ADDRESS(buffer_Res[0]), formats.pack_dst, buf_desc_id, formats.pack_src);
 
-    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
-    _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc, ckernel::ReluConfig::none());
-    _llk_pack_init_(buf_desc_id, tensor_shape_A, num_tiles_per_pack);
-    _llk_pack_(params.DST_INDEX, 0, tensor_shape_A);
-    _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+        _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
+        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc, ckernel::ReluConfig::none());
+        _llk_pack_init_(buf_desc_id, tensor_shape_A, num_tiles_per_pack);
+        PROFILER_SYNC();
+    }
+    {
+        ZONE_SCOPED("TILE_LOOP")
+        const auto tensor_shape_A = tensor_shape_from_face_dims(TEST_FACE_R_DIM, TEST_FACE_C_DIM, num_faces_r_dim_A, num_faces_c_dim_A);
+
+        if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE || PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)
+        {
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        {
+            // No dest-dvalid section_done: WH/BH isolate packs without math handshake.
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                _llk_pack_(DST_INDEX, 0, tensor_shape_A);
+            }
+        }
+        else
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                _llk_pack_(DST_INDEX, 0, tensor_shape_A);
+                _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+            }
+        }
+        PROFILER_SYNC();
+    }
 }
 #endif


### PR DESCRIPTION
### PR Category
Performance

### Summary
Adds Quasar performance coverage for `eltwise_unary_datacopy` by introducing its perf test and adapting the matching Python and C++ tests.

Closes #50574

### Notes for reviewers
This PR is intentionally limited to the three operation-specific test files split from `ndivnic/backup_remaining_perf_tests_quasar`.

Builds and tests were not run; any resulting failures will be addressed separately.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/eltwise_unary_datacopy_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/eltwise_unary_datacopy_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/eltwise_unary_datacopy_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/eltwise_unary_datacopy_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ndivnic/eltwise_unary_datacopy_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ndivnic/eltwise_unary_datacopy_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/eltwise_unary_datacopy_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/eltwise_unary_datacopy_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/eltwise_unary_datacopy_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/eltwise_unary_datacopy_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/eltwise_unary_datacopy_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/eltwise_unary_datacopy_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/eltwise_unary_datacopy_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/eltwise_unary_datacopy_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/eltwise_unary_datacopy_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/eltwise_unary_datacopy_perf_test_quasar)