### PR TITLE
[Performance] Add pack Quasar performance test

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_pack_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_pack_quasar.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from helpers.llk_params import PERF_RUN_TYPES_QUASAR
+from helpers.param_config import parametrize
+from quasar.test_pack_quasar import PERF_PACK_COMBINATIONS
+from quasar.test_pack_quasar import test_pack_quasar as run_pack
+
+@pytest.mark.perf
+@pytest.mark.quasar
+@parametrize(
+    formats_dest_acc_sync_dims_relu=PERF_PACK_COMBINATIONS,
+    run_types=PERF_RUN_TYPES_QUASAR,
+    loop_factor=[32],
+    is_perf=[True],
+)
+def test_perf_pack_quasar(
+    perf_report,
+    formats_dest_acc_sync_dims_relu,
+    run_types,
+    loop_factor,
+    is_perf,
+):
+    run_pack(
+        formats_dest_acc_sync_dims_relu,
+        run_types=run_types,
+        loop_factor=loop_factor,
+        is_perf=is_perf,
+        perf_report=perf_report,
+    )

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_pack_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_pack_quasar.py
@@ -7,6 +7,7 @@ from helpers.param_config import parametrize
 from quasar.test_pack_quasar import PERF_PACK_COMBINATIONS
 from quasar.test_pack_quasar import test_pack_quasar as run_pack
 
+
 @pytest.mark.perf
 @pytest.mark.quasar
 @parametrize(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_quasar.py
@@ -64,9 +64,12 @@ def generate_qsr_pack_combinations(
 
     Args:
         formats_list: List of input/output format pairs
+        is_perf: Restrict combinations to SyncHalf, NoRelu, a 16x16 tile,
+            and a 32x32 input for performance measurements.
 
     Returns:
-        List of (format, dest_acc, input_dimensions, relu_type) tuples
+        List of (format, dest_acc, dest_sync, input_dimensions, relu_type,
+        tile_dimensions) tuples.
     """
 
     def is_supported_format_conversion(in_fmt, out_fmt):
@@ -136,11 +139,10 @@ def generate_qsr_pack_combinations(
         for dest_acc in get_dest_acc_modes(in_fmt):
             if is_supported_dest_mode_dependent_conversion(in_fmt, out_fmt, dest_acc):
                 if is_perf:
-                    tile_dims = (16, 16)
+                    tile_dims = MX_SUPPORTED_TILE_SIZES[0]
                     if is_mx_unsupported_tile_dims(in_fmt, out_fmt, tile_dims):
                         continue
-                    tile_shape = construct_tile_shape(tile_dims)
-                    dimensions = [32, 32]
+                    input_dimensions = [32, 32]  # [rows, columns]
                     for dest_sync in dest_sync_modes:
                         for relu_type in relu_types:
                             combinations.append(
@@ -148,7 +150,7 @@ def generate_qsr_pack_combinations(
                                     fmt,
                                     dest_acc,
                                     dest_sync,
-                                    runtime(dimensions),
+                                    runtime(input_dimensions),
                                     runtime(relu_type),
                                     runtime(tile_dims),
                                 )

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_quasar.py
@@ -336,7 +336,6 @@ def test_pack_quasar(
         ),
         "unpack_to_dest": unpack_to_dest,
         "dest_acc": dest_acc,
-        "boot_mode": boot_mode,
         "disable_format_inference": (formats.input_format.is_mx_format()),
     }
 
@@ -353,6 +352,7 @@ def test_pack_quasar(
         )
 
     configuration = TestConfig(
+        boot_mode=boot_mode,
         **{
             **test_config_kwargs,
             "templates": test_config_kwargs["templates"]

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_quasar.py
@@ -18,6 +18,7 @@ from helpers.llk_params import (
     DestSync,
     ImpliedMathFormat,
     PackerReluType,
+    PerfRunType,
     format_dict,
 )
 from helpers.param_config import (
@@ -26,6 +27,7 @@ from helpers.param_config import (
     parametrize,
     runtime,
 )
+from helpers.perf import PerfConfig
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import (  # generate_stimuli_w_tile_dimensions
     generate_stimuli,
@@ -34,9 +36,11 @@ from helpers.test_config import BootMode, TestConfig
 from helpers.test_variant_parameters import (
     DEST_SYNC,
     IMPLIED_MATH_FORMAT,
+    LOOP_FACTOR,
     NUM_FACES,
     NUM_FACES_C_DIM,
     NUM_FACES_R_DIM,
+    PERF_RUN_TYPE,
     RELU_CONFIG,
     TEST_FACE_DIMS,
     TILE_COUNT,
@@ -52,6 +56,8 @@ from helpers.utils import passed_test
 
 def generate_qsr_pack_combinations(
     formats_list: List[FormatConfig],
+    *,
+    is_perf=False,
 ):
     """
     Generate pack combinations for Quasar pack tests.
@@ -107,7 +113,7 @@ def generate_qsr_pack_combinations(
         PackerReluType.MaxThresholdRelu,
     ]
 
-    dest_sync_modes = (DestSync.Half, DestSync.Full)
+    dest_sync_modes = (DestSync.Half,) if is_perf else (DestSync.Half, DestSync.Full)
 
     combinations = []
     for fmt in formats_list:
@@ -119,12 +125,35 @@ def generate_qsr_pack_combinations(
         # Threshold ReLU modes are not supported for integer pack_src formats
         # (mirroring the pytest.skip guard in the test body).
         relu_types = (
-            [PackerReluType.NoRelu, PackerReluType.ZeroRelu]
-            if in_fmt.is_integer()
-            else all_relu_types
+            [PackerReluType.NoRelu]
+            if is_perf
+            else (
+                [PackerReluType.NoRelu, PackerReluType.ZeroRelu]
+                if in_fmt.is_integer()
+                else all_relu_types
+            )
         )
         for dest_acc in get_dest_acc_modes(in_fmt):
             if is_supported_dest_mode_dependent_conversion(in_fmt, out_fmt, dest_acc):
+                if is_perf:
+                    tile_dims = (16, 16)
+                    if is_mx_unsupported_tile_dims(in_fmt, out_fmt, tile_dims):
+                        continue
+                    tile_shape = construct_tile_shape(tile_dims)
+                    dimensions = [32, 32]
+                    for dest_sync in dest_sync_modes:
+                        for relu_type in relu_types:
+                            combinations.append(
+                                (
+                                    fmt,
+                                    dest_acc,
+                                    dest_sync,
+                                    runtime(dimensions),
+                                    runtime(relu_type),
+                                    runtime(tile_dims),
+                                )
+                            )
+                    continue
                 for dest_sync in dest_sync_modes:
                     for tile_dims in SUPPORTED_TILE_SIZES:
                         if is_mx_unsupported_tile_dims(in_fmt, out_fmt, tile_dims):
@@ -170,13 +199,25 @@ PACK_FORMATS = input_output_formats(
         DataFormat.MxInt2,
     ]
 )
+ALL_PACK_COMBINATIONS = generate_qsr_pack_combinations(PACK_FORMATS)
+PERF_PACK_COMBINATIONS = generate_qsr_pack_combinations(PACK_FORMATS, is_perf=True)
 
 
 @pytest.mark.quasar
 @parametrize(
-    formats_dest_acc_sync_dims_relu=generate_qsr_pack_combinations(PACK_FORMATS),
+    formats_dest_acc_sync_dims_relu=ALL_PACK_COMBINATIONS,
+    run_types=[[PerfRunType.L1_TO_L1]],
+    loop_factor=[1],
 )
-def test_pack_quasar(formats_dest_acc_sync_dims_relu, boot_mode=BootMode.DEFAULT):
+def test_pack_quasar(
+    formats_dest_acc_sync_dims_relu,
+    run_types,
+    loop_factor,
+    boot_mode=BootMode.DEFAULT,
+    *,
+    is_perf=False,
+    perf_report=None,
+):
     (
         formats,
         dest_acc,
@@ -184,7 +225,7 @@ def test_pack_quasar(formats_dest_acc_sync_dims_relu, boot_mode=BootMode.DEFAULT
         input_dimensions,
         relu_type,
         tile_dimensions,
-    ) = formats_dest_acc_sync_dims_relu[0]
+    ) = formats_dest_acc_sync_dims_relu
 
     tile_shape = construct_tile_shape(tile_dimensions)
 
@@ -209,73 +250,77 @@ def test_pack_quasar(formats_dest_acc_sync_dims_relu, boot_mode=BootMode.DEFAULT
         unpacking_to_dest=unpack_to_dest,
     )
 
-    # HW flow with relu: unpack input -> dest -> apply relu in pack_src
-    # space -> pack to output (one MX quantization, block scale derived at pack
-    # time from post-relu values). DataCopyGolden, given an MX output format,
-    # does a pre-relu MxInt4 quantization that HW doesn't do. That extra
-    # quantization can shift values across the relu threshold, producing
-    # divergence from HW that grows with threshold-relu (most visible for
-    # MxFp4 -> MxInt4 + MaxThresholdRelu). For MX outputs we route through
-    # pack_src instead and apply the single output MX quantization ourselves
-    # after relu. Non-MX outputs keep the existing path (saturate_integer etc.).
-
-    generate_golden = get_golden_generator(DataCopyGolden)
-    datacopy_out_format = (
-        data_formats.pack_src
-        if formats.output_format.is_mx_format()
-        else formats.output_format
-    )
-    golden_tensor = generate_golden(
-        src_A,
-        datacopy_out_format,
-        num_faces=num_faces,
-        face_r_dim=tile_shape.face_r_dim,
-        input_dimensions=input_dimensions,
-        input_format=formats.input_format,
-        tile_shape=tile_shape,
-    )
-
-    tensor_average = (
-        torch.mean(golden_tensor).item()
-        if not formats.output_format.is_integer()
-        else 0.0
-    )
-
     relu_config = PackGolden.generate_relu_config(
         relu_type,
-        relu_threshold=tensor_average,
+        relu_threshold=0.0,
         intermediate_format=data_formats.pack_src,
     )
 
-    golden_tensor = PackGolden.apply_relu(
-        golden_tensor,
-        relu_config,
-        data_formats.pack_src,
-    )
+    if not is_perf:
+        # HW flow with relu: unpack input -> dest -> apply relu in pack_src
+        # space -> pack to output (one MX quantization, block scale derived at pack
+        # time from post-relu values). DataCopyGolden, given an MX output format,
+        # does a pre-relu MxInt4 quantization that HW doesn't do. That extra
+        # quantization can shift values across the relu threshold, producing
+        # divergence from HW that grows with threshold-relu (most visible for
+        # MxFp4 -> MxInt4 + MaxThresholdRelu). For MX outputs we route through
+        # pack_src instead and apply the single output MX quantization ourselves
+        # after relu. Non-MX outputs keep the existing path (saturate_integer etc.).
 
-    # Single output MX quantization, after relu — matches HW's pack-time
-    # block-scale derivation from post-relu values.
-    if formats.output_format.is_mx_format():
-        golden_tensor = quantize_mx_tensor_chunked(
-            golden_tensor.to(torch.bfloat16), formats.output_format
+        generate_golden = get_golden_generator(DataCopyGolden)
+        datacopy_out_format = (
+            data_formats.pack_src
+            if formats.output_format.is_mx_format()
+            else formats.output_format
+        )
+        golden_tensor = generate_golden(
+            src_A,
+            datacopy_out_format,
+            num_faces=num_faces,
+            face_r_dim=tile_shape.face_r_dim,
+            input_dimensions=input_dimensions,
+            input_format=formats.input_format,
+            tile_shape=tile_shape,
         )
 
-    configuration = TestConfig(
-        "sources/quasar/pack_quasar_test.cpp",
-        formats,
-        templates=[
+        tensor_average = (
+            torch.mean(golden_tensor).item()
+            if not formats.output_format.is_integer()
+            else 0.0
+        )
+
+        relu_config = PackGolden.generate_relu_config(
+            relu_type,
+            relu_threshold=tensor_average,
+            intermediate_format=data_formats.pack_src,
+        )
+
+        golden_tensor = PackGolden.apply_relu(
+            golden_tensor,
+            relu_config,
+            data_formats.pack_src,
+        )
+
+    if is_perf and perf_report is None:
+        raise ValueError("perf_report must be provided when is_perf=True")
+
+    test_config_kwargs = {
+        "test_name": "sources/quasar/pack_quasar_test.cpp",
+        "formats": formats,
+        "templates": [
             IMPLIED_MATH_FORMAT(ImpliedMathFormat.Yes),
             DEST_SYNC(dest_sync_mode),
         ],
-        runtimes=[
+        "runtimes": [
             TEST_FACE_DIMS(tile_shape.face_r_dim),
             NUM_FACES(num_faces),
             TILE_COUNT(tile_cnt_A),
             RELU_CONFIG(relu_config),
             NUM_FACES_R_DIM(tile_shape.num_faces_r_dim),
             NUM_FACES_C_DIM(tile_shape.num_faces_c_dim),
+            LOOP_FACTOR(loop_factor),
         ],
-        variant_stimuli=StimuliConfig(
+        "variant_stimuli": StimuliConfig(
             src_A,
             formats.input_format,
             src_B,
@@ -289,10 +334,30 @@ def test_pack_quasar(formats_dest_acc_sync_dims_relu, boot_mode=BootMode.DEFAULT
             tile_dimensions=tile_dimensions,
             use_dense_tile_dimensions=True,
         ),
-        unpack_to_dest=unpack_to_dest,
-        dest_acc=dest_acc,
-        boot_mode=boot_mode,
-        disable_format_inference=(formats.input_format.is_mx_format()),
+        "unpack_to_dest": unpack_to_dest,
+        "dest_acc": dest_acc,
+        "boot_mode": boot_mode,
+        "disable_format_inference": (formats.input_format.is_mx_format()),
+    }
+
+    if is_perf:
+        configuration = PerfConfig(run_types=run_types, **test_config_kwargs)
+        configuration.run(perf_report)
+        return
+
+    # Single output MX quantization, after relu — matches HW's pack-time
+    # block-scale derivation from post-relu values.
+    if formats.output_format.is_mx_format():
+        golden_tensor = quantize_mx_tensor_chunked(
+            golden_tensor.to(torch.bfloat16), formats.output_format
+        )
+
+    configuration = TestConfig(
+        **{
+            **test_config_kwargs,
+            "templates": test_config_kwargs["templates"]
+            + [PERF_RUN_TYPE(PerfRunType.L1_TO_L1)],
+        },
     )
 
     res_from_L1 = configuration.run().result

--- a/tt_metal/tt-llk/tests/sources/quasar/pack_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/pack_quasar_test.cpp
@@ -43,6 +43,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
             {
                 set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::PACK});
             }
+            else
+            {
+                // CFG persists across run types, so isolates must not inherit
+                // the L1_TO_L1 unpack-to-dest handshake.
+                std::uint32_t volatile* cfg                      = (std::uint32_t volatile*)TENSIX_CFG_BASE;
+                cfg[UNPACK_TO_DEST_DVALID_CTRL_wait_mask_ADDR32] = 0;
+            }
 
             DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
             if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Float32)
@@ -137,7 +144,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         {
             ZONE_SCOPED("INIT")
-            // PACK_ISOLATE measures pack alone (WH/BH style): skip FPU→PACK dest-dvalid.
+            // Only L1_TO_L1 and MATH_ISOLATE use the FPU→PACK dest-dvalid
+            // handshake; the remaining isolate modes have no FPU consumer.
             if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
             {
                 set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
@@ -232,7 +240,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            auto cfg                                    = (std::uint32_t volatile*)TENSIX_CFG_BASE;
+            std::uint32_t volatile* cfg                 = (std::uint32_t volatile*)TENSIX_CFG_BASE;
             cfg[PACK_DEST_DVALID_CTRL_wait_mask_ADDR32] = 0;
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)

--- a/tt_metal/tt-llk/tests/sources/quasar/pack_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/pack_quasar_test.cpp
@@ -9,6 +9,8 @@
 #include "ckernel.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
+#include "perf.h"
+#include "profiler.h"
 #include "quasar_test_common.h"
 #include "sfpu_stub.h"
 
@@ -24,55 +26,93 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
+#ifndef SPEED_OF_LIGHT
+    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT        = params.TILE_CNT;
+    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
+    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
+    const int num_faces_r_dim_A         = params.num_faces_r_dim_A;
+    const int num_faces_c_dim_A         = params.num_faces_c_dim_A;
+    const Operand& buffer_A             = params.buffer_A;
+#endif
     const std::uint32_t SELECTED_UNPACKER    = unpack_to_dest ? p_unpacr::UNP_DEST : p_unpacr::UNP_A;
     const std::uint32_t buf_desc_id          = 0;
-    const std::uint32_t num_tiles_per_unpack = params.TILE_CNT;
+    const std::uint32_t num_tiles_per_unpack = TILE_CNT;
 
-    // Setup data valid scheme
-    if constexpr (unpack_to_dest)
     {
-        set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::PACK});
+        ZONE_SCOPED("INIT")
+        if constexpr (unpack_to_dest)
+        {
+            if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
+            {
+                set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::PACK});
+            }
 
-        DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
-        if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Float32)
-        {
-            _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, true /*fp32_dest*/, false /*int32_dest*/>();
+            DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
+            if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Float32)
+            {
+                _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, true /*fp32_dest*/, false /*int32_dest*/>();
+            }
+            else if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)
+            {
+                _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>();
+            }
+            else
+            {
+                _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, false /*int32_dest*/>();
+            }
         }
-        else if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)
+
+        const auto tensor_shape_A = tensor_shape_from_face_dims(TEST_FACE_R_DIM, TEST_FACE_C_DIM, num_faces_r_dim_A, num_faces_c_dim_A);
+
+        tdma_descriptor_t td_val =
+            ckernel::trisc::construct_tdma_desc(tensor_shape_A, L1_ADDRESS(buffer_A[0]), formats.unpack_A_src, buf_desc_id, formats.unpack_A_dst);
+
+        _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
+        if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
         {
-            _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>();
+            _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val, td_val);
         }
         else
         {
-            _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, false /*int32_dest*/>();
+            _llk_unpack_configure_unary_<SELECTED_UNPACKER>(td_val);
         }
+        _llk_unpack_unary_operand_init_<SELECTED_UNPACKER, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, tensor_shape_A, num_tiles_per_unpack);
+        PROFILER_SYNC();
     }
-    else
     {
-        set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
-    }
+        ZONE_SCOPED("TILE_LOOP")
+        const auto tensor_shape_A = tensor_shape_from_face_dims(TEST_FACE_R_DIM, TEST_FACE_C_DIM, num_faces_r_dim_A, num_faces_c_dim_A);
 
-    const auto tensor_shape_A = tensor_shape_from_params(params);
-
-    tdma_descriptor_t td_val =
-        ckernel::trisc::construct_tdma_desc(tensor_shape_A, L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src, buf_desc_id, formats.unpack_A_dst);
-
-    _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
-    if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
-    {
-        // If Dst fmt is 32b and operation is Mov2D, we need both SrcA/B fmts to be configured since Mov2D will be implemented via ELWADD
-        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val, td_val);
-    }
-    else
-    {
-        _llk_unpack_configure_unary_<SELECTED_UNPACKER>(td_val);
-    }
-    _llk_unpack_unary_operand_init_<SELECTED_UNPACKER, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, tensor_shape_A, num_tiles_per_unpack);
-    _llk_unpack_unary_operand_<SELECTED_UNPACKER>(0, tensor_shape_A);
-
-    if constexpr (unpack_to_dest)
-    {
-        _llk_unpack_dest_dvalid_section_done_<dest_sync>();
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
+        {
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
+        {
+            if constexpr (!unpack_to_dest)
+            {
+                if constexpr (is_fp32_dest_acc_en)
+                {
+                    _perf_unpack_loop_set_valid<true, true>(LOOP_FACTOR * TILE_CNT);
+                }
+                else
+                {
+                    _perf_unpack_loop_set_valid<true, false>(LOOP_FACTOR * TILE_CNT);
+                }
+            }
+        }
+        else
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                _llk_unpack_unary_operand_<SELECTED_UNPACKER>(0, tensor_shape_A);
+                if constexpr (unpack_to_dest && PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
+                {
+                    _llk_unpack_dest_dvalid_section_done_<dest_sync>();
+                }
+            }
+        }
+        PROFILER_SYNC();
     }
 }
 
@@ -91,32 +131,80 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
+#ifndef SPEED_OF_LIGHT
+    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT        = params.TILE_CNT;
+    const std::uint32_t num_faces       = params.num_faces;
+    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
+#endif
     if constexpr (!unpack_to_dest)
     {
-        set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+        {
+            ZONE_SCOPED("INIT")
+            // PACK_ISOLATE measures pack alone (WH/BH style): skip FPU→PACK dest-dvalid.
+            if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
+            {
+                set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+            }
 
-        DataFormat math_format     = static_cast<DataFormat>(formats.math);
-        DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
-        if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Float32)
-        {
-            _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, true /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
-        }
-        else if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)
-        {
-            _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
-        }
-        else
-        {
-            _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
-        }
+            DataFormat math_format     = static_cast<DataFormat>(formats.math);
+            DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
+            if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Float32)
+            {
+                _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, true /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
+            }
+            else if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)
+            {
+                _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
+            }
+            else
+            {
+                _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
+            }
 
-        _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en>(
-            params.num_faces * params.TEST_FACE_R_DIM /*num_rows_per_matrix*/, 1 /*num_matrices*/);
-        for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
-        {
-            _llk_math_eltwise_unary_datacopy_(i);
+            _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en>(
+                num_faces * TEST_FACE_R_DIM /*num_rows_per_matrix*/, 1 /*num_matrices*/);
+            PROFILER_SYNC();
         }
-        _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+        {
+            ZONE_SCOPED("TILE_LOOP")
+            if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
+            {
+            }
+            else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+            {
+                if constexpr (is_fp32_dest_acc_en)
+                {
+                    _perf_math_loop_clear_valid<true, true>(LOOP_FACTOR * TILE_CNT);
+                }
+                else
+                {
+                    _perf_math_loop_clear_valid<true, false>(LOOP_FACTOR * TILE_CNT);
+                }
+            }
+            else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
+            {
+                for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+                {
+                    for (std::uint32_t i = 0; i < TILE_CNT; ++i)
+                    {
+                        _llk_math_eltwise_unary_datacopy_(i);
+                    }
+                }
+            }
+            else
+            {
+                for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+                {
+                    for (std::uint32_t i = 0; i < TILE_CNT; ++i)
+                    {
+                        _llk_math_eltwise_unary_datacopy_(i);
+                    }
+                    _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+                }
+            }
+            PROFILER_SYNC();
+        }
     }
 }
 
@@ -133,29 +221,76 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
+#ifndef SPEED_OF_LIGHT
+    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT        = params.TILE_CNT;
+    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
+    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
+    const int num_faces_r_dim_A         = params.num_faces_r_dim_A;
+    const int num_faces_c_dim_A         = params.num_faces_c_dim_A;
+    const int RELU_CONFIG               = params.RELU_CONFIG;
+    const Operand& buffer_Res           = params.buffer_Res;
+#endif
     std::uint32_t const buf_desc_id        = 8;
-    const std::uint32_t num_tiles_per_pack = params.TILE_CNT;
+    const std::uint32_t num_tiles_per_pack = TILE_CNT;
 
-    if constexpr (unpack_to_dest)
     {
-        set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::PACK});
+        ZONE_SCOPED("INIT")
+        // Match WH/BH PACK_ISOLATE: no math↔pack handshake; pack from whatever is in dest.
+        // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        {
+            auto cfg                                    = (std::uint32_t volatile*)TENSIX_CFG_BASE;
+            cfg[PACK_DEST_DVALID_CTRL_wait_mask_ADDR32] = 0;
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
+        {
+            if constexpr (unpack_to_dest)
+            {
+                set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::PACK});
+            }
+            else
+            {
+                set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+            }
+        }
+
+        const auto tensor_shape_A = tensor_shape_from_face_dims(TEST_FACE_R_DIM, TEST_FACE_C_DIM, num_faces_r_dim_A, num_faces_c_dim_A);
+
+        tdma_descriptor_t tdma_desc =
+            ckernel::trisc::construct_tdma_desc(tensor_shape_A, L1_ADDRESS(buffer_Res[0]), formats.pack_dst, buf_desc_id, formats.pack_src);
+
+        _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
+        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc, ckernel::ReluConfig::none());
+        const ckernel::ReluConfig relu_config = ckernel::ReluConfig::from_packed(RELU_CONFIG);
+        _llk_pack_init_(buf_desc_id, tensor_shape_A, num_tiles_per_pack);
+        _llk_pack_relu_config_<p_pacr::PACK0, is_fp32_dest_acc_en>(relu_config);
+        PROFILER_SYNC();
     }
-    else
     {
-        set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+        ZONE_SCOPED("TILE_LOOP")
+        const auto tensor_shape_A = tensor_shape_from_face_dims(TEST_FACE_R_DIM, TEST_FACE_C_DIM, num_faces_r_dim_A, num_faces_c_dim_A);
+
+        if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE || PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)
+        {
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        {
+            // No dest-dvalid section_done: WH/BH isolate packs without math handshake.
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                _llk_pack_(0, 0, tensor_shape_A);
+            }
+        }
+        else
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                _llk_pack_(0, 0, tensor_shape_A);
+                _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+            }
+        }
+        PROFILER_SYNC();
     }
-
-    const auto tensor_shape_A = tensor_shape_from_params(params);
-
-    tdma_descriptor_t tdma_desc =
-        ckernel::trisc::construct_tdma_desc(tensor_shape_A, L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst, buf_desc_id, formats.pack_src);
-
-    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
-    _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc, ckernel::ReluConfig::none());
-    const ckernel::ReluConfig relu_config = ckernel::ReluConfig::from_packed(params.RELU_CONFIG);
-    _llk_pack_init_(buf_desc_id, tensor_shape_A, num_tiles_per_pack);
-    _llk_pack_relu_config_<p_pacr::PACK0, is_fp32_dest_acc_en>(relu_config);
-    _llk_pack_(0, 0, tensor_shape_A);
-    _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
 }
 #endif

--- a/tt_metal/tt-llk/tests/sources/quasar/pack_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/pack_quasar_test.cpp
@@ -27,13 +27,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifndef SPEED_OF_LIGHT
-    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
-    const std::uint32_t TILE_CNT        = params.TILE_CNT;
-    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
-    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
-    const int num_faces_r_dim_A         = params.num_faces_r_dim_A;
-    const int num_faces_c_dim_A         = params.num_faces_c_dim_A;
-    const Operand& buffer_A             = params.buffer_A;
+    const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT    = params.TILE_CNT;
+    const Operand& buffer_A         = params.buffer_A;
 #endif
     const std::uint32_t SELECTED_UNPACKER    = unpack_to_dest ? p_unpacr::UNP_DEST : p_unpacr::UNP_A;
     const std::uint32_t buf_desc_id          = 0;
@@ -63,7 +59,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             }
         }
 
-        const auto tensor_shape_A = tensor_shape_from_face_dims(TEST_FACE_R_DIM, TEST_FACE_C_DIM, num_faces_r_dim_A, num_faces_c_dim_A);
+        const auto tensor_shape_A = tensor_shape_from_params(params);
 
         tdma_descriptor_t td_val =
             ckernel::trisc::construct_tdma_desc(tensor_shape_A, L1_ADDRESS(buffer_A[0]), formats.unpack_A_src, buf_desc_id, formats.unpack_A_dst);
@@ -82,7 +78,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     }
     {
         ZONE_SCOPED("TILE_LOOP")
-        const auto tensor_shape_A = tensor_shape_from_face_dims(TEST_FACE_R_DIM, TEST_FACE_C_DIM, num_faces_r_dim_A, num_faces_c_dim_A);
+        const auto tensor_shape_A = tensor_shape_from_params(params);
 
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
         {
@@ -222,14 +218,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifndef SPEED_OF_LIGHT
-    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
-    const std::uint32_t TILE_CNT        = params.TILE_CNT;
-    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
-    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
-    const int num_faces_r_dim_A         = params.num_faces_r_dim_A;
-    const int num_faces_c_dim_A         = params.num_faces_c_dim_A;
-    const int RELU_CONFIG               = params.RELU_CONFIG;
-    const Operand& buffer_Res           = params.buffer_Res;
+    const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT    = params.TILE_CNT;
+    const int RELU_CONFIG           = params.RELU_CONFIG;
+    const Operand& buffer_Res       = params.buffer_Res;
 #endif
     std::uint32_t const buf_desc_id        = 8;
     const std::uint32_t num_tiles_per_pack = TILE_CNT;
@@ -255,7 +247,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             }
         }
 
-        const auto tensor_shape_A = tensor_shape_from_face_dims(TEST_FACE_R_DIM, TEST_FACE_C_DIM, num_faces_r_dim_A, num_faces_c_dim_A);
+        const auto tensor_shape_A = tensor_shape_from_params(params);
 
         tdma_descriptor_t tdma_desc =
             ckernel::trisc::construct_tdma_desc(tensor_shape_A, L1_ADDRESS(buffer_Res[0]), formats.pack_dst, buf_desc_id, formats.pack_src);
@@ -269,7 +261,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     }
     {
         ZONE_SCOPED("TILE_LOOP")
-        const auto tensor_shape_A = tensor_shape_from_face_dims(TEST_FACE_R_DIM, TEST_FACE_C_DIM, num_faces_r_dim_A, num_faces_c_dim_A);
+        const auto tensor_shape_A = tensor_shape_from_params(params);
 
         if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE || PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)
         {


### PR DESCRIPTION
### PR Category
Performance

### Summary
Adds Quasar performance coverage for `pack` by introducing its perf test and adapting the matching Python and C++ tests.

Closes #50575

### Notes for reviewers
This PR is intentionally limited to the three operation-specific test files split from `ndivnic/backup_remaining_perf_tests_quasar`.

Builds and tests were not run; any resulting failures will be addressed separately.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/pack_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/pack_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/pack_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/pack_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ndivnic/pack_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ndivnic/pack_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/pack_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/pack_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/pack_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/pack_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/pack_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/pack_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/pack_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/pack_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/pack_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/pack_perf_test_quasar)