### PR TITLE
[Performance] Add pack_l1_acc Quasar performance test

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_pack_l1_acc_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_pack_l1_acc_quasar.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from helpers.llk_params import PERF_RUN_TYPES_QUASAR
+from helpers.param_config import parametrize, runtime
+from quasar.test_pack_l1_acc_quasar import (
+    ALL_PACK_L1_ACC_COMBINATIONS,
+    PERF_ONLY_INPUT_DIMENSIONS,
+    pack_l1_acc_dest_sync_modes,
+    pack_l1_acc_implied_math_formats,
+)
+from quasar.test_pack_l1_acc_quasar import test_pack_l1_acc_quasar as run_pack_l1_acc
+
+@pytest.mark.perf
+@pytest.mark.quasar
+@parametrize(
+    formats_dest_acc=ALL_PACK_L1_ACC_COMBINATIONS,
+    implied_math_format=lambda formats_dest_acc: pack_l1_acc_implied_math_formats(
+        formats_dest_acc, is_perf=True
+    ),
+    dest_sync_mode=lambda: pack_l1_acc_dest_sync_modes(is_perf=True),
+    input_dimensions=runtime(PERF_ONLY_INPUT_DIMENSIONS),
+    run_types=PERF_RUN_TYPES_QUASAR,
+    loop_factor=[32],
+    is_perf=[True],
+)
+def test_perf_pack_l1_acc_quasar(
+    perf_report,
+    formats_dest_acc,
+    implied_math_format,
+    dest_sync_mode,
+    input_dimensions,
+    run_types,
+    loop_factor,
+    is_perf,
+):
+    run_pack_l1_acc(
+        formats_dest_acc,
+        implied_math_format,
+        dest_sync_mode,
+        input_dimensions,
+        run_types=run_types,
+        loop_factor=loop_factor,
+        is_perf=is_perf,
+        perf_report=perf_report,
+    )

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_pack_l1_acc_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_pack_l1_acc_quasar.py
@@ -12,6 +12,7 @@ from quasar.test_pack_l1_acc_quasar import (
 )
 from quasar.test_pack_l1_acc_quasar import test_pack_l1_acc_quasar as run_pack_l1_acc
 
+
 @pytest.mark.perf
 @pytest.mark.quasar
 @parametrize(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_l1_acc_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_l1_acc_quasar.py
@@ -15,6 +15,7 @@ from helpers.llk_params import (
     DestAccumulation,
     DestSync,
     ImpliedMathFormat,
+    PerfRunType,
     ReluConfig,
     format_dict,
 )
@@ -25,15 +26,18 @@ from helpers.param_config import (
     parametrize,
     runtime,
 )
+from helpers.perf import PerfConfig
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import BootMode, TestConfig
 from helpers.test_variant_parameters import (
     DEST_SYNC,
     IMPLIED_MATH_FORMAT,
+    LOOP_FACTOR,
     NUM_BLOCKS,
     NUM_FACES,
     NUM_TILES_IN_BLOCK,
+    PERF_RUN_TYPE,
     RELU_CONFIG,
     TEST_FACE_DIMS,
     TILE_COUNT,
@@ -43,6 +47,10 @@ from helpers.tile_constants import FACE_C_DIM, get_tile_params
 from helpers.utils import passed_test
 
 INPUT_DIMENSIONS = [[512, 64], [192, 512]]
+# Nested list of [H, W] pairs: a flat [H, W] is expanded by parametrize into
+# input_dimensions=H (int) and breaks generate_stimuli / rows, cols = dims.
+PERF_INPUT_DIMENSIONS = [[512, 64]]
+PERF_ONLY_INPUT_DIMENSIONS = [[512, 64]]
 TILE_DIMENSIONS = [32, 32]
 # Complete list of formats that are supported with L1 accumulation as the
 # OUTPUT format. MX formats (MxInt8) are allowed only as INPUT — accumulation
@@ -125,24 +133,50 @@ def generate_qsr_pack_l1_acc_combinations(
     return combinations
 
 
+def pack_l1_acc_dest_sync_modes(*, is_perf=False):
+    return [DestSync.Half] if is_perf else [DestSync.Half, DestSync.Full]
+
+
+def pack_l1_acc_implied_math_formats(formats_dest_acc, *, is_perf=False):
+    if is_perf:
+        return [ImpliedMathFormat.Yes]
+    formats = formats_dest_acc[0]
+    if formats.input_format.is_mx_format():
+        return [ImpliedMathFormat.Yes]
+    return [ImpliedMathFormat.No, ImpliedMathFormat.Yes]
+
+
+def pack_l1_acc_input_dimensions(*, is_perf=False):
+    return PERF_ONLY_INPUT_DIMENSIONS if is_perf else INPUT_DIMENSIONS
+
+
+ALL_PACK_L1_ACC_COMBINATIONS = generate_qsr_pack_l1_acc_combinations(
+    PACK_L1_ACC_FORMATS
+)
+
+
 @pytest.mark.quasar
 @parametrize(
-    formats_dest_acc=generate_qsr_pack_l1_acc_combinations(PACK_L1_ACC_FORMATS),
-    # don't generate the No variant for them. formats_dest_acc[0] is the InputOutputFormat (input/output pair).
-    implied_math_format=lambda formats_dest_acc: (
-        [ImpliedMathFormat.Yes]
-        if formats_dest_acc[0].input_format.is_mx_format()
-        else [ImpliedMathFormat.No, ImpliedMathFormat.Yes]
+    formats_dest_acc=ALL_PACK_L1_ACC_COMBINATIONS,
+    implied_math_format=lambda formats_dest_acc: pack_l1_acc_implied_math_formats(
+        formats_dest_acc
     ),
-    dest_sync_mode=[DestSync.Half, DestSync.Full],
-    input_dimensions=runtime(INPUT_DIMENSIONS),
+    dest_sync_mode=lambda: pack_l1_acc_dest_sync_modes(is_perf=False),
+    input_dimensions=runtime(lambda: pack_l1_acc_input_dimensions(is_perf=False)),
+    run_types=[[PerfRunType.L1_TO_L1]],
+    loop_factor=[1],
 )
 def test_pack_l1_acc_quasar(
     formats_dest_acc,
     implied_math_format,
     dest_sync_mode,
     input_dimensions,
+    run_types,
+    loop_factor,
     boot_mode=BootMode.DEFAULT,
+    *,
+    is_perf=False,
+    perf_report=None,
 ):
     (formats, dest_acc) = formats_dest_acc
 
@@ -172,48 +206,52 @@ def test_pack_l1_acc_quasar(
         tile_dimensions=TILE_DIMENSIONS,
     )
 
-    # Quantize MX input through the source lattice so the golden sees what HW
-    # sees after unpacking from L1. Without this, raw bfloat16 stimuli flow
-    # into PackGolden while HW reads MxInt4-quantized values; per-block
-    # accumulation then amplifies the per-element drift.
-    src_A_golden = (
-        quantize_mx_tensor_chunked(src_A, formats.input_format)
-        if formats.input_format.is_mx_format()
-        else src_A
-    )
+    if not is_perf:
+        # Quantize MX input through the source lattice so the golden sees what HW
+        # sees after unpacking from L1. Without this, raw bfloat16 stimuli flow
+        # into PackGolden while HW reads MxInt4-quantized values; per-block
+        # accumulation then amplifies the per-element drift.
+        src_A_golden = (
+            quantize_mx_tensor_chunked(src_A, formats.input_format)
+            if formats.input_format.is_mx_format()
+            else src_A
+        )
 
-    generate_golden = get_golden_generator(PackGolden)
-    full_golden = generate_golden(
-        src_A_golden,
-        formats.output_format,
-        num_faces=num_faces,
-        input_dimensions=input_dimensions,
-        face_r_dim=face_r_dim,
-    )
+        generate_golden = get_golden_generator(PackGolden)
+        full_golden = generate_golden(
+            src_A_golden,
+            formats.output_format,
+            num_faces=num_faces,
+            input_dimensions=input_dimensions,
+            face_r_dim=face_r_dim,
+        )
 
-    # This test accumulates the results of each block on top of each other
-    # Slice the full golden into per-block partials and accumulate
-    elements_per_block = output_tiles_in_block * num_faces * face_r_dim * FACE_C_DIM
-    partials = [
-        full_golden[block * elements_per_block : (block + 1) * elements_per_block]
-        for block in range(output_num_blocks)
-    ]
-    golden_tensor = generate_golden.accumulate_l1(
-        partials, data_format=formats.output_format
-    )
+        # This test accumulates the results of each block on top of each other
+        # Slice the full golden into per-block partials and accumulate
+        elements_per_block = output_tiles_in_block * num_faces * face_r_dim * FACE_C_DIM
+        partials = [
+            full_golden[block * elements_per_block : (block + 1) * elements_per_block]
+            for block in range(output_num_blocks)
+        ]
+        golden_tensor = generate_golden.accumulate_l1(
+            partials, data_format=formats.output_format
+        )
 
     unpack_to_dest = (
         formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
     )
 
-    configuration = TestConfig(
-        "sources/quasar/pack_l1_acc_quasar_test.cpp",
-        formats,
-        templates=[
+    if is_perf and perf_report is None:
+        raise ValueError("perf_report must be provided when is_perf=True")
+
+    test_config_kwargs = {
+        "test_name": "sources/quasar/pack_l1_acc_quasar_test.cpp",
+        "formats": formats,
+        "templates": [
             IMPLIED_MATH_FORMAT(implied_math_format),
             DEST_SYNC(dest_sync_mode),
         ],
-        runtimes=[
+        "runtimes": [
             generate_input_dim(input_dimensions, input_dimensions),
             TILE_COUNT(tile_cnt),
             NUM_FACES(num_faces),
@@ -229,8 +267,9 @@ def test_pack_l1_acc_quasar(
             ),
             TEST_FACE_DIMS(face_r_dim=face_r_dim, face_c_dim=FACE_C_DIM),
             RELU_CONFIG(ReluConfig.NoRelu.value),
+            LOOP_FACTOR(loop_factor),
         ],
-        variant_stimuli=StimuliConfig(
+        "variant_stimuli": StimuliConfig(
             src_A,
             formats.input_format,
             src_B,
@@ -244,12 +283,23 @@ def test_pack_l1_acc_quasar(
             tile_dimensions=TILE_DIMENSIONS,
             use_dense_tile_dimensions=True,
         ),
-        unpack_to_dest=unpack_to_dest,
-        dest_acc=dest_acc,
-        boot_mode=boot_mode,
-        # MX inputs need format inference disabled so the C++ side's
-        # IMPLIED_MATH_FORMAT setting drives the math format.
-        disable_format_inference=formats.input_format.is_mx_format(),
+        "unpack_to_dest": unpack_to_dest,
+        "dest_acc": dest_acc,
+        "boot_mode": boot_mode,
+        "disable_format_inference": formats.input_format.is_mx_format(),
+    }
+
+    if is_perf:
+        configuration = PerfConfig(run_types=run_types, **test_config_kwargs)
+        configuration.run(perf_report)
+        return
+
+    configuration = TestConfig(
+        **{
+            **test_config_kwargs,
+            "templates": test_config_kwargs["templates"]
+            + [PERF_RUN_TYPE(PerfRunType.L1_TO_L1)],
+        },
     )
 
     res_from_L1 = configuration.run().result

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_l1_acc_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_l1_acc_quasar.py
@@ -285,7 +285,6 @@ def test_pack_l1_acc_quasar(
         ),
         "unpack_to_dest": unpack_to_dest,
         "dest_acc": dest_acc,
-        "boot_mode": boot_mode,
         "disable_format_inference": formats.input_format.is_mx_format(),
     }
 
@@ -299,6 +298,7 @@ def test_pack_l1_acc_quasar(
             **test_config_kwargs,
             "templates": test_config_kwargs["templates"]
             + [PERF_RUN_TYPE(PerfRunType.L1_TO_L1)],
+            "boot_mode": boot_mode,
         },
     )
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_l1_acc_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_l1_acc_quasar.py
@@ -49,7 +49,6 @@ from helpers.utils import passed_test
 INPUT_DIMENSIONS = [[512, 64], [192, 512]]
 # Nested list of [H, W] pairs: a flat [H, W] is expanded by parametrize into
 # input_dimensions=H (int) and breaks generate_stimuli / rows, cols = dims.
-PERF_INPUT_DIMENSIONS = [[512, 64]]
 PERF_ONLY_INPUT_DIMENSIONS = [[512, 64]]
 TILE_DIMENSIONS = [32, 32]
 # Complete list of formats that are supported with L1 accumulation as the

--- a/tt_metal/tt-llk/tests/sources/quasar/pack_l1_acc_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/pack_l1_acc_quasar_test.cpp
@@ -86,6 +86,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         if constexpr (unpack_to_dest)
         {
             const std::uint32_t tiles_in_block = OUTPUT_NUM_TILES_IN_BLOCK;
+            // ISSUE tt-llk #988: For unpack to dest cannot init the unpacker with 1 tile per unpack, because it will
+            // keep writing to dest_idx=0.
             _llk_unpack_unary_operand_init_<SELECTED_UNPACKER, false /*transpose*/, is_fp32_dest_acc_en>(
                 buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, tiles_in_block /*num_tiles_per_unpack*/);
         }

--- a/tt_metal/tt-llk/tests/sources/quasar/pack_l1_acc_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/pack_l1_acc_quasar_test.cpp
@@ -8,6 +8,8 @@
 #include "ckernel.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
+#include "perf.h"
+#include "profiler.h"
 #include "sfpu_stub.h"
 
 #ifdef LLK_TRISC_UNPACK
@@ -22,78 +24,125 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
+#ifndef SPEED_OF_LIGHT
+    const std::uint32_t LOOP_FACTOR               = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT                  = params.TILE_CNT;
+    const std::uint32_t TEST_FACE_C_DIM           = params.TEST_FACE_C_DIM;
+    const std::uint32_t TEST_FACE_R_DIM           = params.TEST_FACE_R_DIM;
+    const std::uint32_t num_faces                 = params.num_faces;
+    const std::uint32_t OUTPUT_NUM_TILES_IN_BLOCK = params.OUTPUT_NUM_TILES_IN_BLOCK;
+    const std::uint32_t OUTPUT_NUM_BLOCKS         = params.OUTPUT_NUM_BLOCKS;
+    const Operand& buffer_A                       = params.buffer_A;
+#endif
     const std::uint32_t SELECTED_UNPACKER = unpack_to_dest ? p_unpacr::UNP_DEST : p_unpacr::UNP_A;
     tdma_descriptor_t td_val;
     const std::uint32_t buf_desc_id = 0;
 
-    // Setup data valid scheme
-    if constexpr (unpack_to_dest)
     {
-        set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::PACK});
+        ZONE_SCOPED("INIT")
+        if constexpr (unpack_to_dest)
+        {
+            if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
+            {
+                set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::PACK});
+            }
 
-        DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
-        if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Float32)
-        {
-            _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, true /*fp32_dest*/, false /*int32_dest*/>();
+            DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
+            if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Float32)
+            {
+                _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, true /*fp32_dest*/, false /*int32_dest*/>();
+            }
+            else if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)
+            {
+                _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>();
+            }
+            else
+            {
+                _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, false /*int32_dest*/>();
+            }
         }
-        else if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)
+
+        buffer_descriptor_u bd_val = {0};
+        bd_val.f.l1_addr_16B       = L1_ADDRESS(buffer_A[0]);
+        bd_val.f.format            = static_cast<std::uint8_t>(formats.unpack_A_src);
+        bd_val.f.x_dim             = TEST_FACE_C_DIM;
+        bd_val.f.y_dim             = TEST_FACE_R_DIM;
+        bd_val.f.z_dim             = num_faces;
+
+        td_val.buf_desc        = bd_val;
+        td_val.buf_desc_id     = buf_desc_id;
+        td_val.reg_data_format = static_cast<std::uint8_t>(formats.unpack_A_dst);
+
+        _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
+        if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
         {
-            _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>();
+            _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val, td_val);
         }
         else
         {
-            _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, false /*int32_dest*/>();
+            _llk_unpack_configure_unary_<SELECTED_UNPACKER>(td_val);
         }
-    }
-    else
-    {
-        set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
-    }
 
-    buffer_descriptor_u bd_val = {0};
-    bd_val.f.l1_addr_16B       = L1_ADDRESS(params.buffer_A[0]);
-    bd_val.f.format            = static_cast<std::uint8_t>(formats.unpack_A_src);
-    bd_val.f.x_dim             = params.TEST_FACE_C_DIM;
-    bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
-    bd_val.f.z_dim             = params.num_faces;
-
-    td_val.buf_desc        = bd_val;
-    td_val.buf_desc_id     = buf_desc_id;
-    td_val.reg_data_format = static_cast<std::uint8_t>(formats.unpack_A_dst);
-
-    _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
-    if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
-    {
-        // If Dst fmt is 32b and operation is Mov2D, we need both SrcA/B fmts to be configured since Mov2D will be implemented via ELWADD
-        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val, td_val);
-    }
-    else
-    {
-        _llk_unpack_configure_unary_<SELECTED_UNPACKER>(td_val);
-    }
-
-    if constexpr (unpack_to_dest)
-    {
-        const std::uint32_t tiles_in_block = params.OUTPUT_NUM_TILES_IN_BLOCK;
-        const std::uint32_t num_blocks     = static_cast<std::uint32_t>(params.OUTPUT_NUM_BLOCKS);
-
-        // ISSUE tt-llk #988: For unpack to dest cannot init the unpacker with 1 tile per unpack, because it will keep writing to dest_idx=0
-        _llk_unpack_unary_operand_init_<SELECTED_UNPACKER, false /*transpose*/, is_fp32_dest_acc_en>(
-            buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, tiles_in_block /*num_tiles_per_unpack*/);
-        for (std::uint32_t block = 0; block < num_blocks; block++)
+        if constexpr (unpack_to_dest)
         {
-            _llk_unpack_unary_operand_<SELECTED_UNPACKER>(block * tiles_in_block, ckernel::DEFAULT_TENSOR_SHAPE);
-            _llk_unpack_dest_dvalid_section_done_<dest_sync>();
+            const std::uint32_t tiles_in_block = OUTPUT_NUM_TILES_IN_BLOCK;
+            _llk_unpack_unary_operand_init_<SELECTED_UNPACKER, false /*transpose*/, is_fp32_dest_acc_en>(
+                buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, tiles_in_block /*num_tiles_per_unpack*/);
         }
-    }
-    else
-    {
-        _llk_unpack_unary_operand_init_<SELECTED_UNPACKER, false /*transpose*/, is_fp32_dest_acc_en>(
-            buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_unpack*/);
-        for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+        else
         {
-            _llk_unpack_unary_operand_<SELECTED_UNPACKER>(i, ckernel::DEFAULT_TENSOR_SHAPE);
+            _llk_unpack_unary_operand_init_<SELECTED_UNPACKER, false /*transpose*/, is_fp32_dest_acc_en>(
+                buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_unpack*/);
         }
+        PROFILER_SYNC();
+    }
+    {
+        ZONE_SCOPED("TILE_LOOP")
+        const std::uint32_t tiles_in_block = OUTPUT_NUM_TILES_IN_BLOCK;
+        const std::uint32_t num_blocks     = static_cast<std::uint32_t>(OUTPUT_NUM_BLOCKS);
+
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
+        {
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
+        {
+            if constexpr (!unpack_to_dest)
+            {
+                if constexpr (is_fp32_dest_acc_en)
+                {
+                    _perf_unpack_loop_set_valid<true, true>(LOOP_FACTOR * TILE_CNT);
+                }
+                else
+                {
+                    _perf_unpack_loop_set_valid<true, false>(LOOP_FACTOR * TILE_CNT);
+                }
+            }
+        }
+        else if constexpr (unpack_to_dest)
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                for (std::uint32_t block = 0; block < num_blocks; block++)
+                {
+                    _llk_unpack_unary_operand_<SELECTED_UNPACKER>(block * tiles_in_block, ckernel::DEFAULT_TENSOR_SHAPE);
+                    if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
+                    {
+                        _llk_unpack_dest_dvalid_section_done_<dest_sync>();
+                    }
+                }
+            }
+        }
+        else
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                for (std::uint32_t i = 0; i < TILE_CNT; ++i)
+                {
+                    _llk_unpack_unary_operand_<SELECTED_UNPACKER>(i, ckernel::DEFAULT_TENSOR_SHAPE);
+                }
+            }
+        }
+        PROFILER_SYNC();
     }
 }
 
@@ -113,38 +162,89 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
+#ifndef SPEED_OF_LIGHT
+    const std::uint32_t LOOP_FACTOR               = params.LOOP_FACTOR;
+    const std::uint32_t num_faces                 = params.num_faces;
+    const std::uint32_t TEST_FACE_R_DIM           = params.TEST_FACE_R_DIM;
+    const std::uint32_t OUTPUT_NUM_TILES_IN_BLOCK = params.OUTPUT_NUM_TILES_IN_BLOCK;
+    const std::uint32_t INPUT_NUM_BLOCKS          = params.INPUT_NUM_BLOCKS;
+#endif
     if constexpr (!unpack_to_dest)
     {
-        set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
-
-        DataFormat math_format     = static_cast<DataFormat>(formats.math);
-        DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
-        if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Float32)
         {
-            _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, true /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
-        }
-        else if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)
-        {
-            _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
-        }
-        else
-        {
-            _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
-        }
-
-        _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en>(
-            params.num_faces * params.TEST_FACE_R_DIM /*num_rows_per_matrix*/, 1 /*num_matrices*/);
-
-        const std::uint32_t tiles_in_block = params.OUTPUT_NUM_TILES_IN_BLOCK;
-        const std::uint32_t num_blocks     = static_cast<std::uint32_t>(params.INPUT_NUM_BLOCKS);
-
-        for (std::uint32_t block = 0; block < num_blocks; block++)
-        {
-            for (std::uint32_t tile = 0; tile < tiles_in_block; tile++)
+            ZONE_SCOPED("INIT")
+            // PACK_ISOLATE measures pack alone (WH/BH style): skip FPU→PACK dest-dvalid.
+            if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
             {
-                _llk_math_eltwise_unary_datacopy_(tile);
+                set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
             }
-            _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+
+            DataFormat math_format     = static_cast<DataFormat>(formats.math);
+            DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
+            if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Float32)
+            {
+                _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, true /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
+            }
+            else if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)
+            {
+                _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
+            }
+            else
+            {
+                _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
+            }
+
+            _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en>(
+                num_faces * TEST_FACE_R_DIM /*num_rows_per_matrix*/, 1 /*num_matrices*/);
+            PROFILER_SYNC();
+        }
+        {
+            ZONE_SCOPED("TILE_LOOP")
+            const std::uint32_t tiles_in_block = OUTPUT_NUM_TILES_IN_BLOCK;
+            const std::uint32_t num_blocks     = static_cast<std::uint32_t>(INPUT_NUM_BLOCKS);
+
+            if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
+            {
+            }
+            else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+            {
+                if constexpr (is_fp32_dest_acc_en)
+                {
+                    _perf_math_loop_clear_valid<true, true>(LOOP_FACTOR * num_blocks * tiles_in_block);
+                }
+                else
+                {
+                    _perf_math_loop_clear_valid<true, false>(LOOP_FACTOR * num_blocks * tiles_in_block);
+                }
+            }
+            else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
+            {
+                for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+                {
+                    for (std::uint32_t block = 0; block < num_blocks; block++)
+                    {
+                        for (std::uint32_t tile = 0; tile < tiles_in_block; tile++)
+                        {
+                            _llk_math_eltwise_unary_datacopy_(tile);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+                {
+                    for (std::uint32_t block = 0; block < num_blocks; block++)
+                    {
+                        for (std::uint32_t tile = 0; tile < tiles_in_block; tile++)
+                        {
+                            _llk_math_eltwise_unary_datacopy_(tile);
+                        }
+                        _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+                    }
+                }
+            }
+            PROFILER_SYNC();
         }
     }
 }
@@ -162,53 +262,101 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
+#ifndef SPEED_OF_LIGHT
+    const std::uint32_t LOOP_FACTOR               = params.LOOP_FACTOR;
+    const std::uint32_t TEST_FACE_C_DIM           = params.TEST_FACE_C_DIM;
+    const std::uint32_t TEST_FACE_R_DIM           = params.TEST_FACE_R_DIM;
+    const std::uint32_t num_faces                 = params.num_faces;
+    const int RELU_CONFIG                         = params.RELU_CONFIG;
+    const std::uint32_t OUTPUT_NUM_BLOCKS         = params.OUTPUT_NUM_BLOCKS;
+    const std::uint32_t OUTPUT_NUM_TILES_IN_BLOCK = params.OUTPUT_NUM_TILES_IN_BLOCK;
+    const Operand& buffer_Res                     = params.buffer_Res;
+#endif
 
     std::uint32_t const buf_desc_id = 8;
 
-    if constexpr (unpack_to_dest)
     {
-        set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::PACK});
-    }
-    else
-    {
-        set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
-    }
-
-    buffer_descriptor_u bd_val = {0};
-    tdma_descriptor_t tdma_desc;
-
-    bd_val.f.l1_addr_16B = L1_ADDRESS(params.buffer_Res[0]);
-    bd_val.f.format      = static_cast<std::uint8_t>(formats.pack_dst);
-    bd_val.f.x_dim       = params.TEST_FACE_C_DIM;
-    bd_val.f.y_dim       = params.TEST_FACE_R_DIM;
-    bd_val.f.z_dim       = params.num_faces;
-
-    tdma_desc.buf_desc        = bd_val;
-    tdma_desc.buf_desc_id     = buf_desc_id;
-    tdma_desc.reg_data_format = static_cast<std::uint8_t>(formats.pack_src);
-
-    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
-    _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc, ckernel::ReluConfig::none());
-    const ckernel::ReluConfig relu_config = ckernel::ReluConfig::from_packed(params.RELU_CONFIG);
-    _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);
-    _llk_pack_relu_config_<p_pacr::PACK0, is_fp32_dest_acc_en>(relu_config);
-
-    const std::uint32_t output_num_blocks     = static_cast<std::uint32_t>(params.OUTPUT_NUM_BLOCKS);
-    const std::uint32_t output_tiles_in_block = params.OUTPUT_NUM_TILES_IN_BLOCK;
-
-    for (std::uint32_t block = 0; block < output_num_blocks; block++)
-    {
-        // First iteration should have L1 accumulation disabled, otherwise partials will be accumulated on top of the L1 data left by the previous test variant
-        _llk_pack_set_l1_acc_<p_pacr::PACK0>(block == 0 ? false : true /*l1_acc_en*/);
-        for (std::uint32_t tile = 0; tile < output_tiles_in_block; tile++)
+        ZONE_SCOPED("INIT")
+        // Match WH/BH PACK_ISOLATE: no math↔pack handshake; pack from whatever is in dest.
+        // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            // Accumulate each block on top of the previous one
-            _llk_pack_(tile, tile, ckernel::DEFAULT_TENSOR_SHAPE);
+            auto cfg                                    = (std::uint32_t volatile*)TENSIX_CFG_BASE;
+            cfg[PACK_DEST_DVALID_CTRL_wait_mask_ADDR32] = 0;
         }
-        _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
+        {
+            if constexpr (unpack_to_dest)
+            {
+                set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::PACK});
+            }
+            else
+            {
+                set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+            }
+        }
+
+        buffer_descriptor_u bd_val = {0};
+        tdma_descriptor_t tdma_desc;
+
+        bd_val.f.l1_addr_16B = L1_ADDRESS(buffer_Res[0]);
+        bd_val.f.format      = static_cast<std::uint8_t>(formats.pack_dst);
+        bd_val.f.x_dim       = TEST_FACE_C_DIM;
+        bd_val.f.y_dim       = TEST_FACE_R_DIM;
+        bd_val.f.z_dim       = num_faces;
+
+        tdma_desc.buf_desc        = bd_val;
+        tdma_desc.buf_desc_id     = buf_desc_id;
+        tdma_desc.reg_data_format = static_cast<std::uint8_t>(formats.pack_src);
+
+        _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
+        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc, ckernel::ReluConfig::none());
+        const ckernel::ReluConfig relu_config = ckernel::ReluConfig::from_packed(RELU_CONFIG);
+        _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);
+        _llk_pack_relu_config_<p_pacr::PACK0, is_fp32_dest_acc_en>(relu_config);
+        PROFILER_SYNC();
     }
-    // Disable L1 accumulation so that it does not affect tests that could run after the l1_acc test
-    _llk_pack_set_l1_acc_<p_pacr::PACK0>(false /*l1_acc_en*/);
+    {
+        ZONE_SCOPED("TILE_LOOP")
+        const std::uint32_t output_num_blocks     = static_cast<std::uint32_t>(OUTPUT_NUM_BLOCKS);
+        const std::uint32_t output_tiles_in_block = OUTPUT_NUM_TILES_IN_BLOCK;
+
+        if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE || PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)
+        {
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        {
+            // No dest-dvalid section_done: WH/BH isolate packs without math handshake.
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                for (std::uint32_t block = 0; block < output_num_blocks; block++)
+                {
+                    _llk_pack_set_l1_acc_<p_pacr::PACK0>(block == 0 ? false : true /*l1_acc_en*/);
+                    for (std::uint32_t tile = 0; tile < output_tiles_in_block; tile++)
+                    {
+                        _llk_pack_(tile, tile, ckernel::DEFAULT_TENSOR_SHAPE);
+                    }
+                }
+            }
+        }
+        else
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                for (std::uint32_t block = 0; block < output_num_blocks; block++)
+                {
+                    _llk_pack_set_l1_acc_<p_pacr::PACK0>(block == 0 ? false : true /*l1_acc_en*/);
+                    for (std::uint32_t tile = 0; tile < output_tiles_in_block; tile++)
+                    {
+                        _llk_pack_(tile, tile, ckernel::DEFAULT_TENSOR_SHAPE);
+                    }
+                    _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+                }
+            }
+        }
+        _llk_pack_set_l1_acc_<p_pacr::PACK0>(false /*l1_acc_en*/);
+        PROFILER_SYNC();
+    }
 }
 
 #endif


### PR DESCRIPTION
### PR Category
Performance

### Summary
Adds Quasar performance coverage for `pack_l1_acc` by introducing its perf test and adapting the matching Python and C++ tests.

Closes #50576

### Notes for reviewers
This PR is intentionally limited to the three operation-specific test files split from `ndivnic/backup_remaining_perf_tests_quasar`.

Builds and tests were not run; any resulting failures will be addressed separately.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/pack_l1_acc_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/pack_l1_acc_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/pack_l1_acc_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/pack_l1_acc_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ndivnic/pack_l1_acc_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ndivnic/pack_l1_acc_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/pack_l1_acc_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/pack_l1_acc_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/pack_l1_acc_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/pack_l1_acc_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/pack_l1_acc_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/pack_l1_acc_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/pack_l1_acc_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/pack_l1_acc_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/pack_l1_acc_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/pack_l1_acc_perf_test_quasar)