### PR TITLE
[Performance] Add pack_untilize Quasar performance test

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_pack_untilize_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_pack_untilize_quasar.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from helpers.llk_params import PERF_RUN_TYPES_QUASAR
+from helpers.param_config import parametrize
+from quasar.test_pack_untilize_quasar import (
+    PERF_PACK_UNTILIZE_COMBINATIONS,
+)
+from quasar.test_pack_untilize_quasar import (
+    test_pack_untilize_quasar as run_pack_untilize,
+)
+
+@pytest.mark.perf
+@pytest.mark.quasar
+@parametrize(
+    formats_dest_acc_sync_dimensions=PERF_PACK_UNTILIZE_COMBINATIONS,
+    run_types=PERF_RUN_TYPES_QUASAR,
+    loop_factor=[32],
+    is_perf=[True],
+)
+def test_perf_pack_untilize_quasar(
+    perf_report,
+    formats_dest_acc_sync_dimensions,
+    run_types,
+    loop_factor,
+    is_perf,
+):
+    run_pack_untilize(
+        formats_dest_acc_sync_dimensions,
+        run_types=run_types,
+        loop_factor=loop_factor,
+        is_perf=is_perf,
+        perf_report=perf_report,
+    )

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_pack_untilize_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_pack_untilize_quasar.py
@@ -11,6 +11,7 @@ from quasar.test_pack_untilize_quasar import (
     test_pack_untilize_quasar as run_pack_untilize,
 )
 
+
 @pytest.mark.perf
 @pytest.mark.quasar
 @parametrize(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_untilize_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_untilize_quasar.py
@@ -69,6 +69,8 @@ def generate_pack_untilize_combinations(
 
     Args:
         formats_list: List of input-output format pairs
+        is_perf: Restrict combinations to performance-test dimensions, tile
+            sizes, and destination synchronization modes.
 
     Returns: List of (format, dest_acc, dest_sync, input_dimensions, tile_dimensions) tuples
     """

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_untilize_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_untilize_quasar.py
@@ -91,18 +91,6 @@ def generate_pack_untilize_combinations(
             return (DestAccumulation.Yes,)
         return (DestAccumulation.No, DestAccumulation.Yes)
 
-    dimensions_cache = (
-        None
-        if is_perf
-        else {
-            (dest_acc, dest_sync): tuple(
-                generate_unary_input_dimensions(dest_acc, dest_sync)
-            )
-            for dest_acc in (DestAccumulation.No, DestAccumulation.Yes)
-            for dest_sync in (DestSync.Half, DestSync.Full)
-        }
-    )
-
     dest_sync_modes = pack_untilize_dest_sync_modes(is_perf=is_perf)
     perf_dimensions = pack_untilize_input_dimensions(is_perf=is_perf)
     combinations = []

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_untilize_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_untilize_quasar.py
@@ -18,23 +18,37 @@ from helpers.param_config import (
     generate_unary_input_dimensions,
     input_output_formats,
     parametrize,
+    runtime,
 )
 from helpers.perf import PerfConfig
 from helpers.stimuli_config import StimuliConfig
-from helpers.stimuli_generator import generate_stimuli
+from helpers.stimuli_generator import StimuliSpec, generate_stimuli
 from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import (
     DEST_SYNC,
     IMPLIED_MATH_FORMAT,
     LOOP_FACTOR,
     NUM_FACES,
+    NUM_FACES_C_DIM,
+    NUM_FACES_R_DIM,
     PERF_RUN_TYPE,
     TEST_FACE_DIMS,
     TILE_COUNT,
     UNPACKER_ENGINE_SEL,
     generate_input_dim,
 )
+from helpers.tile_constants import (
+    MX_SUPPORTED_TILE_SIZES,
+    is_mx_unsupported_tile_dims,
+)
+from helpers.tile_shape import construct_tile_shape
 from helpers.utils import passed_test
+
+PACK_UNTILIZE_TILE_SIZES = [
+    (32, 32),
+    (1, 32),
+    (2, 32),
+]
 
 
 def pack_untilize_dest_sync_modes(*, is_perf=False):
@@ -56,7 +70,7 @@ def generate_pack_untilize_combinations(
     Args:
         formats_list: List of input-output format pairs
 
-    Returns: List of (format, dest_acc, dest_sync, input_dimensions) tuples
+    Returns: List of (format, dest_acc, dest_sync, input_dimensions, tile_dimensions) tuples
     """
 
     def is_supported_format_conversion(in_fmt, out_fmt):
@@ -104,13 +118,34 @@ def generate_pack_untilize_combinations(
 
         for dest_acc in get_dest_acc_modes(in_fmt):
             for dest_sync in dest_sync_modes:
-                dimensions_list = (
-                    [perf_dimensions]
-                    if is_perf
-                    else dimensions_cache[(dest_acc, dest_sync)]
-                )
-                for dimensions in dimensions_list:
-                    combinations.append((fmt, dest_acc, dest_sync, dimensions))
+                tile_sizes = [(32, 32)] if is_perf else PACK_UNTILIZE_TILE_SIZES
+                for tile_dims in tile_sizes:
+                    if is_mx_unsupported_tile_dims(in_fmt, out_fmt, tile_dims):
+                        continue
+                    if (
+                        in_fmt.is_32_bit()
+                        and dest_acc == DestAccumulation.Yes
+                        and tile_dims not in MX_SUPPORTED_TILE_SIZES
+                    ):
+                        continue
+                    tile_shape = construct_tile_shape(tile_dims)
+                    dimensions_list = (
+                        [perf_dimensions]
+                        if is_perf
+                        else generate_unary_input_dimensions(
+                            dest_acc, dest_sync=dest_sync, tile_shape=tile_shape
+                        )
+                    )
+                    for dimensions in dimensions_list:
+                        combinations.append(
+                            (
+                                fmt,
+                                dest_acc,
+                                dest_sync,
+                                runtime(dimensions),
+                                runtime(tile_dims),
+                            )
+                        )
 
     return combinations
 
@@ -138,27 +173,34 @@ PERF_PACK_UNTILIZE_COMBINATIONS = generate_pack_untilize_combinations(
 
 @pytest.mark.quasar
 @parametrize(
-    formats_dest_acc_sync_dimensions=ALL_PACK_UNTILIZE_COMBINATIONS,
+    formats_dest_acc_sync_dimensions_tile_dims=ALL_PACK_UNTILIZE_COMBINATIONS,
     run_types=[[PerfRunType.L1_TO_L1]],
     loop_factor=[1],
 )
 def test_pack_untilize_quasar(
-    formats_dest_acc_sync_dimensions,
+    formats_dest_acc_sync_dimensions_tile_dims,
     run_types,
     loop_factor,
     *,
     is_perf=False,
     perf_report=None,
 ):
-    (formats, dest_acc, dest_sync_mode, input_dimensions) = (
-        formats_dest_acc_sync_dimensions
-    )
+    combination = formats_dest_acc_sync_dimensions_tile_dims
+    if len(combination) == 1 and isinstance(combination[0], tuple):
+        combination = combination[0]
+    (formats, dest_acc, dest_sync_mode, input_dimensions, tile_dimensions) = combination
 
+    tile_shape = construct_tile_shape(tile_dimensions)
+
+    sequential_spec = StimuliSpec.sequential()
     src_A, tile_cnt_A, src_B, _ = generate_stimuli(
         stimuli_format_A=formats.input_format,
         input_dimensions_A=input_dimensions,
         stimuli_format_B=formats.input_format,
         input_dimensions_B=input_dimensions,
+        tile_dimensions=tile_dimensions,
+        spec_A=sequential_spec,
+        spec_B=sequential_spec,
     )
 
     generate_golden = get_golden_generator(UntilizeGolden)
@@ -168,9 +210,10 @@ def test_pack_untilize_quasar(
             formats.output_format,
             input_dimensions,
             input_format=formats.input_format,
+            tile_dimensions=tile_dimensions,
         )
 
-    num_faces = 4
+    num_faces = tile_shape.total_num_faces()
 
     if is_perf and perf_report is None:
         raise ValueError("perf_report must be provided when is_perf=True")
@@ -179,16 +222,20 @@ def test_pack_untilize_quasar(
         "test_name": "sources/quasar/pack_untilize_quasar_test.cpp",
         "formats": formats,
         "templates": [
-            generate_input_dim(input_dimensions, input_dimensions),
+            generate_input_dim(
+                input_dimensions, input_dimensions, tile_dimensions=tile_dimensions
+            ),
             IMPLIED_MATH_FORMAT(ImpliedMathFormat.Yes),
             DEST_SYNC(dest_sync_mode),
             UNPACKER_ENGINE_SEL(),
         ],
         "runtimes": [
-            TEST_FACE_DIMS(),
+            TEST_FACE_DIMS(tile_shape.face_r_dim),
             NUM_FACES(num_faces),
             TILE_COUNT(tile_cnt_A),
             LOOP_FACTOR(loop_factor),
+            NUM_FACES_R_DIM(tile_shape.num_faces_r_dim),
+            NUM_FACES_C_DIM(tile_shape.num_faces_c_dim),
         ],
         "variant_stimuli": StimuliConfig(
             src_A,
@@ -200,6 +247,9 @@ def test_pack_untilize_quasar(
             tile_count_B=tile_cnt_A,
             tile_count_res=tile_cnt_A,
             num_faces=num_faces,
+            face_r_dim=tile_shape.face_r_dim,
+            tile_dimensions=tile_dimensions,
+            use_dense_tile_dimensions=True,
         ),
         "unpack_to_dest": (
             formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
@@ -235,4 +285,5 @@ def test_pack_untilize_quasar(
         golden_tensor,
         res_tensor,
         formats.output_format,
+        tile_shape=tile_shape,
     ), "Assert against golden failed"

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_untilize_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_untilize_quasar.py
@@ -11,44 +11,44 @@ from helpers.llk_params import (
     DestAccumulation,
     DestSync,
     ImpliedMathFormat,
+    PerfRunType,
     format_dict,
 )
 from helpers.param_config import (
     generate_unary_input_dimensions,
     input_output_formats,
     parametrize,
-    runtime,
 )
+from helpers.perf import PerfConfig
 from helpers.stimuli_config import StimuliConfig
-from helpers.stimuli_generator import StimuliSpec, generate_stimuli
+from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import (
     DEST_SYNC,
     IMPLIED_MATH_FORMAT,
+    LOOP_FACTOR,
     NUM_FACES,
-    NUM_FACES_C_DIM,
-    NUM_FACES_R_DIM,
+    PERF_RUN_TYPE,
     TEST_FACE_DIMS,
     TILE_COUNT,
     UNPACKER_ENGINE_SEL,
     generate_input_dim,
 )
-from helpers.tile_constants import (
-    MX_SUPPORTED_TILE_SIZES,
-    is_mx_unsupported_tile_dims,
-)
-from helpers.tile_shape import construct_tile_shape
 from helpers.utils import passed_test
 
-PACK_UNTILIZE_TILE_SIZES = [
-    (32, 32),
-    (1, 32),
-    (2, 32),
-]
+
+def pack_untilize_dest_sync_modes(*, is_perf=False):
+    return [DestSync.Half] if is_perf else [DestSync.Half, DestSync.Full]
+
+
+def pack_untilize_input_dimensions(*, is_perf=False):
+    return [32, 32] if is_perf else None
 
 
 def generate_pack_untilize_combinations(
     formats_list: List[FormatConfig],
+    *,
+    is_perf=False,
 ):
     """
     Generate pack_untilize combinations.
@@ -56,7 +56,7 @@ def generate_pack_untilize_combinations(
     Args:
         formats_list: List of input-output format pairs
 
-    Returns: List of (format, dest_acc, dest_sync, input_dimensions, tile_dimensions) tuples
+    Returns: List of (format, dest_acc, dest_sync, input_dimensions) tuples
     """
 
     def is_supported_format_conversion(in_fmt, out_fmt):
@@ -77,7 +77,20 @@ def generate_pack_untilize_combinations(
             return (DestAccumulation.Yes,)
         return (DestAccumulation.No, DestAccumulation.Yes)
 
-    dest_sync_modes = (DestSync.Half, DestSync.Full)
+    dimensions_cache = (
+        None
+        if is_perf
+        else {
+            (dest_acc, dest_sync): tuple(
+                generate_unary_input_dimensions(dest_acc, dest_sync)
+            )
+            for dest_acc in (DestAccumulation.No, DestAccumulation.Yes)
+            for dest_sync in (DestSync.Half, DestSync.Full)
+        }
+    )
+
+    dest_sync_modes = pack_untilize_dest_sync_modes(is_perf=is_perf)
+    perf_dimensions = pack_untilize_input_dimensions(is_perf=is_perf)
     combinations = []
     for fmt in formats_list:
         in_fmt, out_fmt = fmt.input_format, fmt.output_format
@@ -91,28 +104,13 @@ def generate_pack_untilize_combinations(
 
         for dest_acc in get_dest_acc_modes(in_fmt):
             for dest_sync in dest_sync_modes:
-                for tile_dims in PACK_UNTILIZE_TILE_SIZES:
-                    if is_mx_unsupported_tile_dims(in_fmt, out_fmt, tile_dims):
-                        continue
-                    if (
-                        in_fmt.is_32_bit()
-                        and dest_acc == DestAccumulation.Yes
-                        and tile_dims not in MX_SUPPORTED_TILE_SIZES
-                    ):
-                        continue
-                    tile_shape = construct_tile_shape(tile_dims)
-                    for dimensions in generate_unary_input_dimensions(
-                        dest_acc, dest_sync=dest_sync, tile_shape=tile_shape
-                    ):
-                        combinations.append(
-                            (
-                                fmt,
-                                dest_acc,
-                                dest_sync,
-                                runtime(dimensions),
-                                runtime(tile_dims),
-                            )
-                        )
+                dimensions_list = (
+                    [perf_dimensions]
+                    if is_perf
+                    else dimensions_cache[(dest_acc, dest_sync)]
+                )
+                for dimensions in dimensions_list:
+                    combinations.append((fmt, dest_acc, dest_sync, dimensions))
 
     return combinations
 
@@ -132,59 +130,67 @@ PACK_UNTILIZE_FORMATS = input_output_formats(
 ALL_PACK_UNTILIZE_COMBINATIONS = generate_pack_untilize_combinations(
     PACK_UNTILIZE_FORMATS
 )
+PERF_PACK_UNTILIZE_COMBINATIONS = generate_pack_untilize_combinations(
+    PACK_UNTILIZE_FORMATS,
+    is_perf=True,
+)
 
 
 @pytest.mark.quasar
 @parametrize(
-    formats_dest_acc_sync_dimensions_tile_dims=ALL_PACK_UNTILIZE_COMBINATIONS,
+    formats_dest_acc_sync_dimensions=ALL_PACK_UNTILIZE_COMBINATIONS,
+    run_types=[[PerfRunType.L1_TO_L1]],
+    loop_factor=[1],
 )
-def test_pack_untilize_quasar(formats_dest_acc_sync_dimensions_tile_dims):
-    (formats, dest_acc, dest_sync_mode, input_dimensions, tile_dimensions) = (
-        formats_dest_acc_sync_dimensions_tile_dims[0]
+def test_pack_untilize_quasar(
+    formats_dest_acc_sync_dimensions,
+    run_types,
+    loop_factor,
+    *,
+    is_perf=False,
+    perf_report=None,
+):
+    (formats, dest_acc, dest_sync_mode, input_dimensions) = (
+        formats_dest_acc_sync_dimensions
     )
 
-    tile_shape = construct_tile_shape(tile_dimensions)
-
-    sequential_spec = StimuliSpec.sequential()
     src_A, tile_cnt_A, src_B, _ = generate_stimuli(
         stimuli_format_A=formats.input_format,
         input_dimensions_A=input_dimensions,
         stimuli_format_B=formats.input_format,
         input_dimensions_B=input_dimensions,
-        tile_dimensions=tile_dimensions,
-        spec_A=sequential_spec,
-        spec_B=sequential_spec,
     )
 
     generate_golden = get_golden_generator(UntilizeGolden)
-    golden_tensor = generate_golden(
-        src_A,
-        formats.output_format,
-        input_dimensions,
-        input_format=formats.input_format,
-        tile_dimensions=tile_dimensions,
-    )
+    if not is_perf:
+        golden_tensor = generate_golden(
+            src_A,
+            formats.output_format,
+            input_dimensions,
+            input_format=formats.input_format,
+        )
 
-    num_faces = tile_shape.total_num_faces()
-    configuration = TestConfig(
-        "sources/quasar/pack_untilize_quasar_test.cpp",
-        formats,
-        templates=[
-            generate_input_dim(
-                input_dimensions, input_dimensions, tile_dimensions=tile_dimensions
-            ),
+    num_faces = 4
+
+    if is_perf and perf_report is None:
+        raise ValueError("perf_report must be provided when is_perf=True")
+
+    test_config_kwargs = {
+        "test_name": "sources/quasar/pack_untilize_quasar_test.cpp",
+        "formats": formats,
+        "templates": [
+            generate_input_dim(input_dimensions, input_dimensions),
             IMPLIED_MATH_FORMAT(ImpliedMathFormat.Yes),
             DEST_SYNC(dest_sync_mode),
             UNPACKER_ENGINE_SEL(),
         ],
-        runtimes=[
-            TEST_FACE_DIMS(tile_shape.face_r_dim),
+        "runtimes": [
+            TEST_FACE_DIMS(),
             NUM_FACES(num_faces),
             TILE_COUNT(tile_cnt_A),
-            NUM_FACES_R_DIM(tile_shape.num_faces_r_dim),
-            NUM_FACES_C_DIM(tile_shape.num_faces_c_dim),
+            LOOP_FACTOR(loop_factor),
         ],
-        variant_stimuli=StimuliConfig(
+        "variant_stimuli": StimuliConfig(
             src_A,
             formats.input_format,
             src_B,
@@ -194,18 +200,27 @@ def test_pack_untilize_quasar(formats_dest_acc_sync_dimensions_tile_dims):
             tile_count_B=tile_cnt_A,
             tile_count_res=tile_cnt_A,
             num_faces=num_faces,
-            face_r_dim=tile_shape.face_r_dim,
-            tile_dimensions=tile_dimensions,
-            use_dense_tile_dimensions=True,
         ),
-        unpack_to_dest=(
+        "unpack_to_dest": (
             formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
         ),
-        dest_acc=dest_acc,
-        # MX formats require disable_format_inference to match C++ IMPLIED_MATH_FORMAT setting.
-        disable_format_inference=(
+        "dest_acc": dest_acc,
+        "disable_format_inference": (
             formats.input_format.is_mx_format() or formats.output_format.is_mx_format()
         ),
+    }
+
+    if is_perf:
+        configuration = PerfConfig(run_types=run_types, **test_config_kwargs)
+        configuration.run(perf_report)
+        return
+
+    configuration = TestConfig(
+        **{
+            **test_config_kwargs,
+            "templates": test_config_kwargs["templates"]
+            + [PERF_RUN_TYPE(PerfRunType.L1_TO_L1)],
+        },
     )
 
     res_from_L1 = configuration.run().result
@@ -220,5 +235,4 @@ def test_pack_untilize_quasar(formats_dest_acc_sync_dimensions_tile_dims):
         golden_tensor,
         res_tensor,
         formats.output_format,
-        tile_shape=tile_shape,
     ), "Assert against golden failed"

--- a/tt_metal/tt-llk/tests/sources/quasar/pack_untilize_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/pack_untilize_quasar_test.cpp
@@ -9,7 +9,8 @@
 #include "ckernel.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
-#include "quasar_test_common.h"
+#include "perf.h"
+#include "profiler.h"
 #include "sfpu_stub.h"
 
 #ifdef LLK_TRISC_UNPACK
@@ -24,76 +25,127 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
+#ifndef SPEED_OF_LIGHT
+    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT        = params.TILE_CNT;
+    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
+    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
+    const std::uint32_t num_faces       = params.num_faces;
+    const Operand& buffer_A             = params.buffer_A;
+#endif
     const std::uint32_t SELECTED_UNPACKER = unpack_to_dest ? p_unpacr::UNP_DEST : p_unpacr::UNP_A;
     tdma_descriptor_t td_val;
     const std::uint32_t buf_desc_id          = 0;
-    const std::uint32_t num_tiles_per_unpack = params.TILE_CNT;
+    const std::uint32_t num_tiles_per_unpack = TILE_CNT;
 
-    // Setup data valid scheme
-    if constexpr (unpack_to_dest)
     {
-        set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::PACK});
-
-        DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
-        if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Float32)
+        ZONE_SCOPED("INIT")
+        if constexpr (unpack_to_dest)
         {
-            _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, true /*fp32_dest*/, false /*int32_dest*/>();
-        }
-        else if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)
-        {
-            _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>();
-        }
-        else
-        {
-            _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, false /*int32_dest*/>();
-        }
-    }
-    else
-    {
-        set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
-    }
+            // Only the end-to-end path uses the unpack→pack dest-dvalid
+            // handshake. Isolates deliberately have no consumer.
+            if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
+            {
+                set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::PACK});
+            }
 
-    const auto tensor_shape_A = tensor_shape_from_params(params);
-
-    unsigned l1_addr_16B;
-    if constexpr (UNPACKER_ENGINE_SEL == p_unpacr::UNP_B)
-    {
-        l1_addr_16B = L1_ADDRESS(params.buffer_B[0]);
-    }
-    else
-    {
-        l1_addr_16B = L1_ADDRESS(params.buffer_A[0]);
-    }
-
-    td_val = ckernel::trisc::construct_tdma_desc(tensor_shape_A, l1_addr_16B, formats.unpack_A_src, buf_desc_id, formats.unpack_A_dst);
-
-    _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
-    if constexpr (unpack_to_dest)
-    {
-        _llk_unpack_configure_unary_<SELECTED_UNPACKER>(td_val);
-        // Unpack one tile row at a time for double-buffering with packer (SyncHalf).
-        // Writing all tiles at once would cause _llk_pack_dest_dvalid_section_done_'s
-        // ZEROACC to wipe subsequent tile rows after packing the first one.
-        _llk_unpack_unary_operand_init_<SELECTED_UNPACKER, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, tensor_shape_A, BLOCK_CT_DIM);
-        for (std::uint32_t block_rt = 0; block_rt < BLOCK_RT_DIM; block_rt++)
-        {
-            _llk_unpack_unary_operand_<SELECTED_UNPACKER>(block_rt * BLOCK_CT_DIM, tensor_shape_A);
-            _llk_unpack_dest_dvalid_section_done_<dest_sync>();
-        }
-    }
-    else
-    {
-        if constexpr (is_fp32_dest_acc_en)
-        {
-            // If Dst fmt is 32b and operation is Mov2D, we need both SrcA/B fmts to be configured since Mov2D will be implemented via ELWADD
-            _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val, td_val);
+            DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
+            if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Float32)
+            {
+                _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, true /*fp32_dest*/, false /*int32_dest*/>();
+            }
+            else if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)
+            {
+                _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>();
+            }
+            else
+            {
+                _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, false /*int32_dest*/>();
+            }
         }
         else
+        {
+            set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+        }
+
+        buffer_descriptor_u bd_val = {0};
+
+        bd_val.f.l1_addr_16B = buffer_A[0] / 16;
+        bd_val.f.format      = static_cast<std::uint8_t>(formats.unpack_A_src);
+        bd_val.f.x_dim       = TEST_FACE_C_DIM;
+        bd_val.f.y_dim       = TEST_FACE_R_DIM;
+        bd_val.f.z_dim       = num_faces;
+
+        td_val.buf_desc        = bd_val;
+        td_val.buf_desc_id     = buf_desc_id;
+        td_val.reg_data_format = static_cast<std::uint8_t>(formats.unpack_A_dst);
+
+        _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
+        if constexpr (unpack_to_dest)
         {
             _llk_unpack_configure_unary_<SELECTED_UNPACKER>(td_val);
+            _llk_unpack_unary_operand_init_<SELECTED_UNPACKER, false /*transpose*/, is_fp32_dest_acc_en>(
+                buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, BLOCK_CT_DIM);
         }
-        _llk_unpack_unary_operand_init_<SELECTED_UNPACKER, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, tensor_shape_A, num_tiles_per_unpack);
-        _llk_unpack_unary_operand_<SELECTED_UNPACKER>(0, tensor_shape_A);
+        else
+        {
+            if constexpr (is_fp32_dest_acc_en)
+            {
+                _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val, td_val);
+            }
+            else
+            {
+                _llk_unpack_configure_unary_<SELECTED_UNPACKER>(td_val);
+            }
+            _llk_unpack_unary_operand_init_<SELECTED_UNPACKER, false /*transpose*/, is_fp32_dest_acc_en>(
+                buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_unpack);
+        }
+        PROFILER_SYNC();
+    }
+    {
+        ZONE_SCOPED("TILE_LOOP")
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
+        {
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
+        {
+            if constexpr (!unpack_to_dest)
+            {
+                // Math consumes every tile in every block row.
+                if constexpr (is_fp32_dest_acc_en)
+                {
+                    // 32-bit datacopy uses ELWADD and consumes both SrcA
+                    // and the dummy SrcB produced by unpack.
+                    _perf_unpack_loop_set_valid<true, true>(LOOP_FACTOR * TILE_CNT);
+                }
+                else
+                {
+                    _perf_unpack_loop_set_valid<true, false>(LOOP_FACTOR * TILE_CNT);
+                }
+            }
+        }
+        else if constexpr (unpack_to_dest)
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                for (std::uint32_t block_rt = 0; block_rt < BLOCK_RT_DIM; block_rt++)
+                {
+                    _llk_unpack_unary_operand_<SELECTED_UNPACKER>(block_rt * BLOCK_CT_DIM, ckernel::DEFAULT_TENSOR_SHAPE);
+                    if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
+                    {
+                        _llk_unpack_dest_dvalid_section_done_<dest_sync>();
+                    }
+                }
+            }
+        }
+        else
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                _llk_unpack_unary_operand_<SELECTED_UNPACKER>(0, ckernel::DEFAULT_TENSOR_SHAPE);
+            }
+        }
+        PROFILER_SYNC();
     }
 }
 
@@ -112,35 +164,84 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
+#ifndef SPEED_OF_LIGHT
+    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
+    const std::uint32_t num_faces       = params.num_faces;
+    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
+#endif
     if constexpr (!unpack_to_dest)
     {
-        // Setup data valid scheme
-        set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
-
-        DataFormat math_format     = static_cast<DataFormat>(formats.math);
-        DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
-        if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Float32)
         {
-            _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, true /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
-        }
-        else if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)
-        {
-            _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
-        }
-        else
-        {
-            _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
-        }
-
-        _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en>(
-            params.num_faces * params.TEST_FACE_R_DIM /*num_rows_per_matrix*/, 1 /*num_matrices*/);
-        for (std::uint32_t block_rt = 0; block_rt < BLOCK_RT_DIM; block_rt++)
-        {
-            for (std::uint32_t block_ct = 0; block_ct < BLOCK_CT_DIM; block_ct++)
+            ZONE_SCOPED("INIT")
+            // PACK_ISOLATE measures pack alone (WH/BH style): skip FPU→PACK dest-dvalid.
+            if constexpr (PERF_RUN_TYPE != PerfRunType::PACK_ISOLATE && PERF_RUN_TYPE != PerfRunType::L1_CONGESTION)
             {
-                _llk_math_eltwise_unary_datacopy_(block_ct);
+                set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
             }
-            _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+
+            DataFormat math_format     = static_cast<DataFormat>(formats.math);
+            DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
+            if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Float32)
+            {
+                _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, true /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
+            }
+            else if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)
+            {
+                _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
+            }
+            else
+            {
+                _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
+            }
+
+            _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en>(
+                num_faces * TEST_FACE_R_DIM /*num_rows_per_matrix*/, 1 /*num_matrices*/);
+            PROFILER_SYNC();
+        }
+        {
+            ZONE_SCOPED("TILE_LOOP")
+            if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
+            {
+            }
+            else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+            {
+                if constexpr (is_fp32_dest_acc_en)
+                {
+                    _perf_math_loop_clear_valid<true, true>(LOOP_FACTOR * BLOCK_RT_DIM * BLOCK_CT_DIM);
+                }
+                else
+                {
+                    _perf_math_loop_clear_valid<true, false>(LOOP_FACTOR * BLOCK_RT_DIM * BLOCK_CT_DIM);
+                }
+            }
+            else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
+            {
+                for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+                {
+                    for (std::uint32_t block_rt = 0; block_rt < BLOCK_RT_DIM; block_rt++)
+                    {
+                        for (std::uint32_t block_ct = 0; block_ct < BLOCK_CT_DIM; block_ct++)
+                        {
+                            _llk_math_eltwise_unary_datacopy_(block_ct);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+                {
+                    for (std::uint32_t block_rt = 0; block_rt < BLOCK_RT_DIM; block_rt++)
+                    {
+                        for (std::uint32_t block_ct = 0; block_ct < BLOCK_CT_DIM; block_ct++)
+                        {
+                            _llk_math_eltwise_unary_datacopy_(block_ct);
+                        }
+                        _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+                    }
+                }
+            }
+            PROFILER_SYNC();
         }
     }
 }
@@ -149,7 +250,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
-#include "cpack_common.h"
 #include "llk_pack_common.h"
 #include "llk_pack_untilize.h"
 #include "params.h"
@@ -159,62 +259,87 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    if constexpr (unpack_to_dest)
+#ifndef SPEED_OF_LIGHT
+    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
+    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
+    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
+    const std::uint32_t num_faces       = params.num_faces;
+    const Operand& buffer_Res           = params.buffer_Res;
+#endif
     {
-        set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::PACK});
-    }
-    else
-    {
-        set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
-    }
-
-    const auto tensor_shape = tensor_shape_from_params(params);
-
-    tdma_descriptor_t tdma_desc;
-    std::uint32_t const buf_desc_id = 31;
-
-    if (tensor_shape.face_r_dim < ckernel::pack::PACR_STRIDE_OFFSET_ROWS)
-    {
-        // PACR_STRIDE quirk: tiny-tiles index L1 rows as tiles, so the BD is built with y_dim = 1.
-        tdma_desc = ckernel::trisc::construct_tdma_desc<ckernel::trisc::L1AccessMode::Strided>(
-            tensor_shape, L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst, buf_desc_id, formats.pack_src);
-    }
-    else
-    {
-        tdma_desc = ckernel::trisc::construct_tdma_desc(tensor_shape, L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst, buf_desc_id, formats.pack_src);
-    }
-
-    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
-    _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc, ckernel::ReluConfig::none());
-
-    // _llk_pack_untilize_ packs one block ct_dim of tiles (one tile row) at a time
-    std::uint32_t y_stride_external;
-
-    if (tensor_shape.total_num_faces() == NUM_FACES)
-    {
-        _llk_pack_untilize_init_<FULL_CT_DIM, BLOCK_CT_DIM>(buf_desc_id, tensor_shape);
-        y_stride_external = FULL_CT_DIM * tensor_shape.num_faces_r_dim * tensor_shape.face_r_dim;
-    }
-    else
-    {
-        _llk_pack_untilize_strided_init_<FULL_CT_DIM, BLOCK_CT_DIM>(buf_desc_id, tensor_shape);
-    }
-
-    for (std::uint32_t y = 0; y < BLOCK_RT_DIM; y++)
-    {
-        // Both unpack_to_dest and !unpack_to_dest produce one tile row at a time
-        // into alternating banks (SyncHalf). Read from start of current bank (dest_idx 0);
-        // section_done zeroes that bank and switches packer to the other bank.
-        if (tensor_shape.total_num_faces() == NUM_FACES)
+        ZONE_SCOPED("INIT")
+        // Match WH/BH PACK_ISOLATE: no math↔pack handshake; pack from whatever is in dest.
+        // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            _llk_pack_untilize_(0, y * y_stride_external);
-            _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+            auto cfg                                    = (std::uint32_t volatile*)TENSIX_CFG_BASE;
+            cfg[PACK_DEST_DVALID_CTRL_wait_mask_ADDR32] = 0;
         }
         else
         {
-            _llk_pack_untilize_strided_<FULL_CT_DIM>(buf_desc_id, tensor_shape, y * FULL_CT_DIM, 0);
-            _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+            if constexpr (unpack_to_dest)
+            {
+                set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::PACK});
+            }
+            else
+            {
+                set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+            }
         }
+
+        tdma_descriptor_t tdma_desc;
+        std::uint32_t const buf_desc_id = 31;
+
+        buffer_descriptor_u bd_val = {0};
+
+        bd_val.f.l1_addr_16B = buffer_Res[0] / 16;
+        bd_val.f.format      = static_cast<std::uint8_t>(formats.pack_dst);
+        bd_val.f.x_dim       = TEST_FACE_C_DIM;
+        bd_val.f.y_dim       = TEST_FACE_R_DIM;
+        bd_val.f.z_dim       = num_faces;
+
+        tdma_desc.buf_desc        = bd_val;
+        tdma_desc.buf_desc_id     = buf_desc_id;
+        tdma_desc.reg_data_format = static_cast<std::uint8_t>(formats.pack_src);
+
+        constexpr ckernel::TensorShape tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE;
+
+        _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
+        _llk_pack_hw_configure_<p_pacr::PACK0>(tdma_desc);
+        _llk_pack_untilize_init_<FULL_CT_DIM, BLOCK_CT_DIM>(buf_desc_id, tensor_shape);
+        PROFILER_SYNC();
+    }
+    {
+        ZONE_SCOPED("TILE_LOOP")
+        constexpr ckernel::TensorShape tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE;
+        const std::uint32_t y_stride_external       = FULL_CT_DIM * tensor_shape.num_faces_r_dim * tensor_shape.face_r_dim;
+
+        if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE || PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)
+        {
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        {
+            // No dest-dvalid section_done: WH/BH isolate packs without math handshake.
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                for (std::uint32_t y = 0; y < BLOCK_RT_DIM; y++)
+                {
+                    _llk_pack_untilize_(0, y * y_stride_external);
+                }
+            }
+        }
+        else
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                for (std::uint32_t y = 0; y < BLOCK_RT_DIM; y++)
+                {
+                    _llk_pack_untilize_(0, y * y_stride_external);
+                    _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+                }
+            }
+        }
+        PROFILER_SYNC();
     }
 }
 

--- a/tt_metal/tt-llk/tests/sources/quasar/pack_untilize_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/pack_untilize_quasar_test.cpp
@@ -11,6 +11,7 @@
 #include "llk_memory_checks.h"
 #include "perf.h"
 #include "profiler.h"
+#include "quasar_test_common.h"
 #include "sfpu_stub.h"
 
 #ifdef LLK_TRISC_UNPACK
@@ -26,27 +27,30 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifndef SPEED_OF_LIGHT
-    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
-    const std::uint32_t TILE_CNT        = params.TILE_CNT;
-    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
-    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
-    const std::uint32_t num_faces       = params.num_faces;
-    const Operand& buffer_A             = params.buffer_A;
+    const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT    = params.TILE_CNT;
 #endif
     const std::uint32_t SELECTED_UNPACKER = unpack_to_dest ? p_unpacr::UNP_DEST : p_unpacr::UNP_A;
     tdma_descriptor_t td_val;
     const std::uint32_t buf_desc_id          = 0;
     const std::uint32_t num_tiles_per_unpack = TILE_CNT;
+    const auto tensor_shape_A                = tensor_shape_from_params(params);
 
     {
         ZONE_SCOPED("INIT")
         if constexpr (unpack_to_dest)
         {
             // Only the end-to-end path uses the unpack→pack dest-dvalid
-            // handshake. Isolates deliberately have no consumer.
+            // handshake. Isolates deliberately have no consumer, so clear the
+            // persisted wait mask rather than leaving UNP_DEST blocked.
             if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
             {
                 set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::PACK});
+            }
+            else
+            {
+                auto cfg                                         = (std::uint32_t volatile*)TENSIX_CFG_BASE;
+                cfg[UNPACK_TO_DEST_DVALID_CTRL_wait_mask_ADDR32] = 0;
             }
 
             DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
@@ -68,24 +72,26 @@ void run_kernel(RUNTIME_PARAMETERS params)
             set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
         }
 
-        buffer_descriptor_u bd_val = {0};
+        unsigned l1_addr_16B;
+        if constexpr (UNPACKER_ENGINE_SEL == p_unpacr::UNP_B)
+        {
+            l1_addr_16B = L1_ADDRESS(params.buffer_B[0]);
+        }
+        else
+        {
+            l1_addr_16B = L1_ADDRESS(params.buffer_A[0]);
+        }
 
-        bd_val.f.l1_addr_16B = buffer_A[0] / 16;
-        bd_val.f.format      = static_cast<std::uint8_t>(formats.unpack_A_src);
-        bd_val.f.x_dim       = TEST_FACE_C_DIM;
-        bd_val.f.y_dim       = TEST_FACE_R_DIM;
-        bd_val.f.z_dim       = num_faces;
-
-        td_val.buf_desc        = bd_val;
-        td_val.buf_desc_id     = buf_desc_id;
-        td_val.reg_data_format = static_cast<std::uint8_t>(formats.unpack_A_dst);
+        td_val = ckernel::trisc::construct_tdma_desc(tensor_shape_A, l1_addr_16B, formats.unpack_A_src, buf_desc_id, formats.unpack_A_dst);
 
         _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
         if constexpr (unpack_to_dest)
         {
             _llk_unpack_configure_unary_<SELECTED_UNPACKER>(td_val);
-            _llk_unpack_unary_operand_init_<SELECTED_UNPACKER, false /*transpose*/, is_fp32_dest_acc_en>(
-                buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, BLOCK_CT_DIM);
+            // Unpack one tile row at a time for double-buffering with packer (SyncHalf).
+            // Writing all tiles at once would cause _llk_pack_dest_dvalid_section_done_'s
+            // ZEROACC to wipe subsequent tile rows after packing the first one.
+            _llk_unpack_unary_operand_init_<SELECTED_UNPACKER, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, tensor_shape_A, BLOCK_CT_DIM);
         }
         else
         {
@@ -97,8 +103,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             {
                 _llk_unpack_configure_unary_<SELECTED_UNPACKER>(td_val);
             }
-            _llk_unpack_unary_operand_init_<SELECTED_UNPACKER, false /*transpose*/, is_fp32_dest_acc_en>(
-                buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_unpack);
+            _llk_unpack_unary_operand_init_<SELECTED_UNPACKER, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, tensor_shape_A, num_tiles_per_unpack);
         }
         PROFILER_SYNC();
     }
@@ -130,7 +135,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             {
                 for (std::uint32_t block_rt = 0; block_rt < BLOCK_RT_DIM; block_rt++)
                 {
-                    _llk_unpack_unary_operand_<SELECTED_UNPACKER>(block_rt * BLOCK_CT_DIM, ckernel::DEFAULT_TENSOR_SHAPE);
+                    _llk_unpack_unary_operand_<SELECTED_UNPACKER>(block_rt * BLOCK_CT_DIM, tensor_shape_A);
                     if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
                     {
                         _llk_unpack_dest_dvalid_section_done_<dest_sync>();
@@ -142,7 +147,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
-                _llk_unpack_unary_operand_<SELECTED_UNPACKER>(0, ckernel::DEFAULT_TENSOR_SHAPE);
+                _llk_unpack_unary_operand_<SELECTED_UNPACKER>(0, tensor_shape_A);
             }
         }
         PROFILER_SYNC();
@@ -173,7 +178,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         {
             ZONE_SCOPED("INIT")
-            // PACK_ISOLATE measures pack alone (WH/BH style): skip FPU→PACK dest-dvalid.
+            // PACK_ISOLATE and L1_CONGESTION measure pack without the
+            // FPU→PACK dest-dvalid handshake (WH/BH style).
             if constexpr (PERF_RUN_TYPE != PerfRunType::PACK_ISOLATE && PERF_RUN_TYPE != PerfRunType::L1_CONGESTION)
             {
                 set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
@@ -250,6 +256,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "cpack_common.h"
 #include "llk_pack_common.h"
 #include "llk_pack_untilize.h"
 #include "params.h"
@@ -260,15 +267,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifndef SPEED_OF_LIGHT
-    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
-    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
-    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
-    const std::uint32_t num_faces       = params.num_faces;
-    const Operand& buffer_Res           = params.buffer_Res;
+    const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
 #endif
+    const auto tensor_shape         = tensor_shape_from_params(params);
+    std::uint32_t const buf_desc_id = 31;
     {
         ZONE_SCOPED("INIT")
-        // Match WH/BH PACK_ISOLATE: no math↔pack handshake; pack from whatever is in dest.
+        // Match WH/BH PACK_ISOLATE and L1_CONGESTION: no math↔pack handshake;
+        // pack from whatever is in dest.
         // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
@@ -288,31 +294,34 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
 
         tdma_descriptor_t tdma_desc;
-        std::uint32_t const buf_desc_id = 31;
 
-        buffer_descriptor_u bd_val = {0};
-
-        bd_val.f.l1_addr_16B = buffer_Res[0] / 16;
-        bd_val.f.format      = static_cast<std::uint8_t>(formats.pack_dst);
-        bd_val.f.x_dim       = TEST_FACE_C_DIM;
-        bd_val.f.y_dim       = TEST_FACE_R_DIM;
-        bd_val.f.z_dim       = num_faces;
-
-        tdma_desc.buf_desc        = bd_val;
-        tdma_desc.buf_desc_id     = buf_desc_id;
-        tdma_desc.reg_data_format = static_cast<std::uint8_t>(formats.pack_src);
-
-        constexpr ckernel::TensorShape tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE;
+        if (tensor_shape.face_r_dim < ckernel::pack::PACR_STRIDE_OFFSET_ROWS)
+        {
+            // PACR_STRIDE quirk: tiny-tiles index L1 rows as tiles, so the BD is built with y_dim = 1.
+            tdma_desc = ckernel::trisc::construct_tdma_desc<ckernel::trisc::L1AccessMode::Strided>(
+                tensor_shape, L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst, buf_desc_id, formats.pack_src);
+        }
+        else
+        {
+            tdma_desc = ckernel::trisc::construct_tdma_desc(tensor_shape, L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst, buf_desc_id, formats.pack_src);
+        }
 
         _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
-        _llk_pack_hw_configure_<p_pacr::PACK0>(tdma_desc);
-        _llk_pack_untilize_init_<FULL_CT_DIM, BLOCK_CT_DIM>(buf_desc_id, tensor_shape);
+        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc, ckernel::ReluConfig::none());
+        if (tensor_shape.total_num_faces() == NUM_FACES)
+        {
+            _llk_pack_untilize_init_<FULL_CT_DIM, BLOCK_CT_DIM>(buf_desc_id, tensor_shape);
+        }
+        else
+        {
+            _llk_pack_untilize_strided_init_<FULL_CT_DIM, BLOCK_CT_DIM>(buf_desc_id, tensor_shape);
+        }
         PROFILER_SYNC();
     }
     {
         ZONE_SCOPED("TILE_LOOP")
-        constexpr ckernel::TensorShape tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE;
-        const std::uint32_t y_stride_external       = FULL_CT_DIM * tensor_shape.num_faces_r_dim * tensor_shape.face_r_dim;
+        // _llk_pack_untilize_ packs one block ct_dim of tiles (one tile row) at a time.
+        const std::uint32_t y_stride_external = FULL_CT_DIM * tensor_shape.num_faces_r_dim * tensor_shape.face_r_dim;
 
         if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE || PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)
         {
@@ -324,7 +333,17 @@ void run_kernel(RUNTIME_PARAMETERS params)
             {
                 for (std::uint32_t y = 0; y < BLOCK_RT_DIM; y++)
                 {
-                    _llk_pack_untilize_(0, y * y_stride_external);
+                    // Each tile row is produced in alternating banks (SyncHalf).
+                    // Read from dest_idx 0; section_done zeroes the current bank
+                    // and switches the packer to the other bank.
+                    if (tensor_shape.total_num_faces() == NUM_FACES)
+                    {
+                        _llk_pack_untilize_(0, y * y_stride_external);
+                    }
+                    else
+                    {
+                        _llk_pack_untilize_strided_<FULL_CT_DIM>(buf_desc_id, tensor_shape, y * FULL_CT_DIM, 0);
+                    }
                 }
             }
         }
@@ -334,7 +353,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
             {
                 for (std::uint32_t y = 0; y < BLOCK_RT_DIM; y++)
                 {
-                    _llk_pack_untilize_(0, y * y_stride_external);
+                    if (tensor_shape.total_num_faces() == NUM_FACES)
+                    {
+                        _llk_pack_untilize_(0, y * y_stride_external);
+                    }
+                    else
+                    {
+                        _llk_pack_untilize_strided_<FULL_CT_DIM>(buf_desc_id, tensor_shape, y * FULL_CT_DIM, 0);
+                    }
                     _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
                 }
             }


### PR DESCRIPTION
### PR Category
Performance

### Summary
Adds Quasar performance coverage for `pack_untilize` by introducing its perf test and adapting the matching Python and C++ tests.

Closes #50577

### Notes for reviewers
This PR is intentionally limited to the three operation-specific test files split from `ndivnic/backup_remaining_perf_tests_quasar`.

Builds and tests were not run; any resulting failures will be addressed separately.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/pack_untilize_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/pack_untilize_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/pack_untilize_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/pack_untilize_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ndivnic/pack_untilize_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ndivnic/pack_untilize_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/pack_untilize_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/pack_untilize_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/pack_untilize_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/pack_untilize_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/pack_untilize_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/pack_untilize_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/pack_untilize_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/pack_untilize_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/pack_untilize_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/pack_untilize_perf_test_quasar)