### PR TITLE
[Performance] Add reduce Quasar performance test

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf.py
@@ -714,7 +714,13 @@ class PerfConfig(TestConfig):
 
         # Setting header fields that are always there
         names = (
-            ["formats.input_A", "formats.input_B", "formats.output"]
+            [
+                "formats.input_A",
+                "formats.input_B",
+                "formats.register_A",
+                "formats.register_B",
+                "formats.output",
+            ]
             if self.formats_config
             else []
         )
@@ -722,6 +728,8 @@ class PerfConfig(TestConfig):
             [
                 self.formats_config[0].unpack_A_src,
                 self.formats_config[0].unpack_B_src,
+                self.formats_config[0].unpack_A_dst,
+                self.formats_config[0].unpack_B_dst,
                 self.formats_config[0].output_format,
             ]
             if self.formats_config[0]

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_reduce_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_reduce_quasar.py
@@ -25,6 +25,7 @@ from quasar.test_reduce_quasar import (
 
 @pytest.mark.perf
 @pytest.mark.quasar
+@pytest.mark.nightly
 @parametrize(
     formats=REDUCE_FORMATS,
     tile_dimensions=[(32, 32)],

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_reduce_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_reduce_quasar.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
+from helpers.format_config import DataFormat, InputOutputFormat
+from helpers.llk_params import (
+    PERF_RUN_TYPES_QUASAR,
+    MathFidelity,
+    ReduceDimension,
+    ReducePool,
+)
+from helpers.param_config import parametrize
+from quasar.test_reduce_quasar import (
+    REDUCE_FORMATS,
+    reduce_dest_acc_modes,
+    reduce_dest_sync_modes,
+    reduce_implied_math_formats,
+    reduce_pool_type_and_math_fidelity_combinations,
+)
+from quasar.test_reduce_quasar import test_reduce_quasar as run_reduce_quasar
+from quasar.test_reduce_quasar import (
+    test_reduce_quasar_mxfp4_2x_gapool as run_reduce_quasar_mxfp4_2x_gapool,
+)
+
+_ARCH = get_chip_architecture()
+
+
+@pytest.mark.perf
+@pytest.mark.quasar
+@parametrize(
+    formats=REDUCE_FORMATS,
+    tile_dimensions=[(32, 32)],
+    dest_acc=lambda: reduce_dest_acc_modes(is_perf=True),
+    reduce_dim=[ReduceDimension.Row, ReduceDimension.Column, ReduceDimension.Scalar],
+    pool_type_and_math_fidelity=lambda: reduce_pool_type_and_math_fidelity_combinations(
+        is_perf=True
+    ),
+    dest_sync_mode=lambda: reduce_dest_sync_modes(is_perf=True),
+    implied_math_format=lambda formats: reduce_implied_math_formats(
+        formats, is_perf=True
+    ),
+    run_types=PERF_RUN_TYPES_QUASAR,
+    loop_factor=[32],
+    is_perf=[True],
+)
+def test_perf_reduce_quasar(
+    perf_report,
+    formats,
+    tile_dimensions,
+    dest_acc,
+    reduce_dim,
+    pool_type_and_math_fidelity,
+    dest_sync_mode,
+    implied_math_format,
+    run_types,
+    loop_factor,
+    is_perf,
+):
+    if (
+        formats.input_format == DataFormat.MxInt8
+        or formats.output_format == DataFormat.MxInt8
+    ):
+        pytest.skip(
+            "Hangs on Quasar MxInt8 reduce perf cases (observed L1_TO_L1 stall)"
+        )
+    run_reduce_quasar(
+        formats,
+        tile_dimensions,
+        dest_acc,
+        reduce_dim,
+        pool_type_and_math_fidelity,
+        dest_sync_mode,
+        implied_math_format,
+        run_types=run_types,
+        loop_factor=loop_factor,
+        is_perf=is_perf,
+        perf_report=perf_report,
+    )
+
+
+@pytest.mark.perf
+@pytest.mark.quasar
+@pytest.mark.skipif(
+    _ARCH != ChipArchitecture.QUASAR,
+    reason="MxFp4_2x GAPOOL reduce is op_mmul-family-only and exists on Quasar. Architecture derivations don't support it.",
+)
+@parametrize(
+    register_format_hint=[DataFormat.MxFp4_2x_A, DataFormat.MxFp4_2x_B],
+    formats=lambda register_format_hint: [
+        InputOutputFormat(
+            DataFormat.MxFp4,
+            DataFormat.Float16,
+            register_format_hint=register_format_hint,
+        ),
+        InputOutputFormat(
+            DataFormat.MxFp4,
+            DataFormat.Float16_b,
+            register_format_hint=register_format_hint,
+        ),
+    ],
+    dest_acc=lambda: reduce_dest_acc_modes(is_perf=True),
+    reduce_dim=[ReduceDimension.Column],
+    pool_type=[ReducePool.Sum, ReducePool.Average],
+    math_fidelity=[MathFidelity.LoFi],
+    dest_sync_mode=lambda: reduce_dest_sync_modes(is_perf=True),
+    run_types=PERF_RUN_TYPES_QUASAR,
+    loop_factor=[32],
+    is_perf=[True],
+)
+def test_perf_reduce_quasar_mxfp4_2x_gapool(
+    perf_report,
+    register_format_hint,
+    formats,
+    dest_acc,
+    reduce_dim,
+    pool_type,
+    math_fidelity,
+    dest_sync_mode,
+    run_types,
+    loop_factor,
+    is_perf,
+):
+    run_reduce_quasar_mxfp4_2x_gapool(
+        register_format_hint,
+        formats,
+        dest_acc,
+        reduce_dim,
+        pool_type,
+        math_fidelity,
+        dest_sync_mode,
+        run_types=run_types,
+        loop_factor=loop_factor,
+        is_perf=is_perf,
+        perf_report=perf_report,
+    )

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_reduce_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_reduce_quasar.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
 from helpers.format_config import DataFormat, InputOutputFormat
 from helpers.llk_params import (
     PERF_RUN_TYPES_QUASAR,
@@ -22,8 +21,6 @@ from quasar.test_reduce_quasar import test_reduce_quasar as run_reduce_quasar
 from quasar.test_reduce_quasar import (
     test_reduce_quasar_mxfp4_2x_gapool as run_reduce_quasar_mxfp4_2x_gapool,
 )
-
-_ARCH = get_chip_architecture()
 
 
 @pytest.mark.perf
@@ -57,13 +54,6 @@ def test_perf_reduce_quasar(
     loop_factor,
     is_perf,
 ):
-    if (
-        formats.input_format == DataFormat.MxInt8
-        or formats.output_format == DataFormat.MxInt8
-    ):
-        pytest.skip(
-            "Hangs on Quasar MxInt8 reduce perf cases (observed L1_TO_L1 stall)"
-        )
     run_reduce_quasar(
         formats,
         tile_dimensions,
@@ -81,10 +71,6 @@ def test_perf_reduce_quasar(
 
 @pytest.mark.perf
 @pytest.mark.quasar
-@pytest.mark.skipif(
-    _ARCH != ChipArchitecture.QUASAR,
-    reason="MxFp4_2x GAPOOL reduce is op_mmul-family-only and exists on Quasar. Architecture derivations don't support it.",
-)
 @parametrize(
     register_format_hint=[DataFormat.MxFp4_2x_A, DataFormat.MxFp4_2x_B],
     formats=lambda register_format_hint: [

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_reduce_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_reduce_quasar.py
@@ -19,22 +19,26 @@ from helpers.llk_params import (
     ImpliedMathFormat,
     MathFidelity,
     MathOperation,
+    PerfRunType,
     ReduceDimension,
     ReducePool,
     format_dict,
 )
 from helpers.param_config import input_output_formats, parametrize
+from helpers.perf import PerfConfig
 from helpers.stimuli_config import StimuliConfig
-from helpers.stimuli_generator import StimuliSpec, generate_stimuli
+from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import (
     DEST_SYNC,
     IMPLIED_MATH_FORMAT,
+    LOOP_FACTOR,
     MATH_FIDELITY,
     MATH_OP,
     NUM_FACES,
     NUM_FACES_C_DIM,
     NUM_FACES_R_DIM,
+    PERF_RUN_TYPE,
     TEST_FACE_DIMS,
     TILE_COUNT,
     UNPACKER_ENGINE_SEL,
@@ -59,13 +63,56 @@ MATH_FIDELITY_MODES = [
 POOL_TYPES = [ReducePool.Max, ReducePool.Sum, ReducePool.Average]
 
 
-def generate_pool_type_and_math_fidelity_combinations():
+REDUCE_FORMATS = input_output_formats(
+    [
+        DataFormat.Float16_b,
+        DataFormat.Float16,
+        DataFormat.MxFp4,
+        DataFormat.MxInt8,
+        DataFormat.MxInt4,
+        DataFormat.MxInt2,
+    ],
+)
+
+
+def reduce_dest_sync_modes(*, is_perf=False):
+    return [DestSync.Half] if is_perf else [DestSync.Half, DestSync.Full]
+
+
+def reduce_dest_acc_modes(*, is_perf=False):
+    return (
+        [DestAccumulation.No]
+        if is_perf
+        else [DestAccumulation.No, DestAccumulation.Yes]
+    )
+
+
+def reduce_implied_math_formats(formats, *, is_perf=False):
+    if is_perf:
+        return [ImpliedMathFormat.Yes]
+    if formats.input_format.is_mx_format():
+        return [ImpliedMathFormat.Yes]
+    return [ImpliedMathFormat.No, ImpliedMathFormat.Yes]
+
+
+def reduce_input_dimensions(*, is_perf=False):
+    return [64, 64]
+
+
+def generate_pool_type_and_math_fidelity_combinations(*, is_perf=False):
     def is_valid_combination(pool_type, math_fidelity):
         # Max pool only supports LoFi
         if pool_type == ReducePool.Max:
             return math_fidelity == MathFidelity.LoFi
         # Sum and Average support all fidelities
         return True
+
+    if is_perf:
+        return [
+            combo
+            for combo in product(POOL_TYPES, [MathFidelity.LoFi])
+            if is_valid_combination(*combo)
+        ]
 
     return [
         combo
@@ -74,62 +121,31 @@ def generate_pool_type_and_math_fidelity_combinations():
     ]
 
 
-def generate_int8_pool_type_and_math_fidelity_combinations():
-    # Int8 reduce is exact-integer accumulation: only LoFi
-    return [
-        (ReducePool.Max, MathFidelity.LoFi),
-        (ReducePool.Sum, MathFidelity.LoFi),
-    ]
+def reduce_pool_type_and_math_fidelity_combinations(*, is_perf=False):
+    return generate_pool_type_and_math_fidelity_combinations(is_perf=is_perf)
 
 
 @pytest.mark.quasar
 @parametrize(
-    formats=input_output_formats(
-        [
-            DataFormat.Float16_b,
-            DataFormat.Float16,
-            DataFormat.MxFp4,
-            DataFormat.MxInt8,
-            DataFormat.MxInt4,
-            DataFormat.MxInt2,
-        ],
-    )
-    + [InputOutputFormat(DataFormat.Int8, DataFormat.Int32)],
-    # Int8 reduce uses int32 dest accumulation
-    dest_acc=lambda formats: (
-        [DestAccumulation.Yes]
-        if formats.input_format == DataFormat.Int8
-        else [DestAccumulation.No, DestAccumulation.Yes]
-    ),
-    reduce_dim=[ReduceDimension.Column, ReduceDimension.Row, ReduceDimension.Scalar],
-    pool_type_and_math_fidelity=lambda formats: (
-        generate_int8_pool_type_and_math_fidelity_combinations()
-        if formats.input_format == DataFormat.Int8
-        else generate_pool_type_and_math_fidelity_combinations()
-    ),
-    # Int8→Int32 FPU reduce is 32x32-only for now (no tiny-tile int path yet).
-    tile_dimensions=lambda formats: (
-        [(32, 32)]
-        if formats.input_format == DataFormat.Int8
-        else [
-            td
-            for td in SUPPORTED_TILE_SIZES
-            if not is_mx_unsupported_tile_dims(
-                formats.input_format, formats.output_format, td
-            )
-        ]
-    ),
-    dest_sync_mode=[DestSync.Half, DestSync.Full],
-    # MX formats REQUIRE implied_math_format=Yes on Quasar (bypass format inference pipeline)
-    implied_math_format=lambda formats: (
-        [ImpliedMathFormat.No]
-        if formats.input_format == DataFormat.Int8
-        else (
-            [ImpliedMathFormat.Yes]
-            if formats.input_format.is_mx_format()
-            else [ImpliedMathFormat.No, ImpliedMathFormat.Yes]
+    formats=REDUCE_FORMATS,
+    tile_dimensions=lambda formats: [
+        td
+        for td in SUPPORTED_TILE_SIZES
+        if not is_mx_unsupported_tile_dims(
+            formats.input_format, formats.output_format, td
         )
+    ],
+    dest_acc=lambda: reduce_dest_acc_modes(is_perf=False),
+    reduce_dim=[ReduceDimension.Row, ReduceDimension.Column, ReduceDimension.Scalar],
+    pool_type_and_math_fidelity=lambda: reduce_pool_type_and_math_fidelity_combinations(
+        is_perf=False
     ),
+    dest_sync_mode=lambda: reduce_dest_sync_modes(is_perf=False),
+    implied_math_format=lambda formats: reduce_implied_math_formats(
+        formats, is_perf=False
+    ),
+    run_types=[[PerfRunType.L1_TO_L1]],
+    loop_factor=[1],
 )
 def test_reduce_quasar(
     formats,
@@ -139,17 +155,15 @@ def test_reduce_quasar(
     pool_type_and_math_fidelity,
     dest_sync_mode,
     implied_math_format,
+    run_types,
+    loop_factor,
+    *,
+    is_perf=False,
+    perf_report=None,
 ):
 
     pool_type, math_fidelity = pool_type_and_math_fidelity
     tile_shape = construct_tile_shape(tile_dimensions)
-
-    if (
-        formats.input_format == DataFormat.Int8
-        and reduce_dim == ReduceDimension.Scalar
-        and pool_type in (ReducePool.Sum, ReducePool.Average)
-    ):
-        pytest.skip("Int8->Int32 scalar SUM/AVG reduce is not supported yet on Quasar ")
 
     if (
         formats.input_format == DataFormat.MxInt8
@@ -170,20 +184,18 @@ def test_reduce_quasar(
             "Row reduce variants, so the residual is accepted as expected."
         )
 
-    input_dimensions = [tile_dimensions[0] * 2, tile_dimensions[1] * 2]
+    input_dimensions = (
+        reduce_input_dimensions(is_perf=True)
+        if is_perf
+        else [tile_dimensions[0] * 2, tile_dimensions[1] * 2]
+    )
 
-    if formats.input_format == DataFormat.Int8:
-        stimuli_spec = StimuliSpec.uniform(low=-127, high=127)
-    else:
-        stimuli_spec = StimuliSpec.uniform(low=0.0, high=1.0)
     src_A, tile_cnt, _, _ = generate_stimuli(
         stimuli_format_A=formats.input_format,
         input_dimensions_A=input_dimensions,
         stimuli_format_B=formats.input_format,
         input_dimensions_B=tile_dimensions,
         tile_dimensions=tile_dimensions,
-        spec_A=stimuli_spec,
-        spec_B=stimuli_spec,
     )
 
     if pool_type in [
@@ -203,51 +215,56 @@ def test_reduce_quasar(
                 1 / math.sqrt(tile_dimensions[0] * tile_dimensions[1]),
             )
 
-    if pool_type == ReducePool.Max:
-        generate_golden = get_golden_generator(ReduceGolden)
-        golden_tensor = generate_golden(
-            src_A,
-            reduce_dim,
-            pool_type,
-            formats.output_format,
-            tile_cnt,
-            tile_shape=tile_shape,
-            input_format=formats.input_format,
-        )
-    else:
-        generate_golden = get_golden_generator(ReduceGapoolGolden)
-        golden_tensor = generate_golden(
-            src_A,
-            src_B,
-            formats.output_format,
-            reduce_dim,
-            math_fidelity,
-            tile_cnt,
-            tile_shape=tile_shape,
-            input_format=formats.input_format,
-            dest_acc=dest_acc,
-        )
+    if not is_perf:
+        if pool_type == ReducePool.Max:
+            generate_golden = get_golden_generator(ReduceGolden)
+            golden_tensor = generate_golden(
+                src_A,
+                reduce_dim,
+                pool_type,
+                formats.output_format,
+                tile_cnt,
+                tile_shape=tile_shape,
+                input_format=formats.input_format,
+            )
+        else:
+            generate_golden = get_golden_generator(ReduceGapoolGolden)
+            golden_tensor = generate_golden(
+                src_A,
+                src_B,
+                formats.output_format,
+                reduce_dim,
+                math_fidelity,
+                tile_cnt,
+                tile_shape=tile_shape,
+                input_format=formats.input_format,
+                dest_acc=dest_acc,
+            )
 
     mathop = mathop_mapping[reduce_dim]
 
-    configuration = TestConfig(
-        "sources/quasar/reduce_quasar_test.cpp",
-        formats,
-        templates=[
+    if is_perf and perf_report is None:
+        raise ValueError("perf_report must be provided when is_perf=True")
+
+    test_config_kwargs = {
+        "test_name": "sources/quasar/reduce_quasar_test.cpp",
+        "formats": formats,
+        "templates": [
             MATH_FIDELITY(math_fidelity),
             MATH_OP(mathop=mathop, pool_type=pool_type),
             UNPACKER_ENGINE_SEL(),
             IMPLIED_MATH_FORMAT(implied_math_format),
             DEST_SYNC(dest_sync_mode),
         ],
-        runtimes=[
+        "runtimes": [
             TILE_COUNT(tile_cnt),
             TEST_FACE_DIMS(tile_shape.face_r_dim, tile_shape.face_c_dim),
             NUM_FACES_R_DIM(tile_shape.num_faces_r_dim),
             NUM_FACES_C_DIM(tile_shape.num_faces_c_dim),
             NUM_FACES(tile_shape.total_num_faces()),
+            LOOP_FACTOR(loop_factor),
         ],
-        variant_stimuli=StimuliConfig(
+        "variant_stimuli": StimuliConfig(
             src_A,
             formats.input_format,
             src_B,
@@ -261,14 +278,28 @@ def test_reduce_quasar(
             tile_dimensions=tile_dimensions,
             use_dense_tile_dimensions=True,
         ),
-        unpack_to_dest=(
+        "unpack_to_dest": (
             formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
         ),
-        dest_acc=dest_acc,
-        # MX formats require disable_format_inference to match C++ IMPLIED_MATH_FORMAT setting
-        disable_format_inference=formats.input_format.is_mx_format(),
-    )
+        "dest_acc": dest_acc,
+        "disable_format_inference": (
+            implied_math_format == ImpliedMathFormat.Yes
+            and formats.input_format.is_mx_format()
+        ),
+    }
 
+    if is_perf:
+        configuration = PerfConfig(run_types=run_types, **test_config_kwargs)
+        configuration.run(perf_report)
+        return
+
+    configuration = TestConfig(
+        **{
+            **test_config_kwargs,
+            "templates": test_config_kwargs["templates"]
+            + [PERF_RUN_TYPE(PerfRunType.L1_TO_L1)],
+        },
+    )
     res_from_L1 = configuration.run().result
 
     assert len(res_from_L1) == len(
@@ -325,7 +356,9 @@ _ARCH = get_chip_architecture()
     reduce_dim=[ReduceDimension.Column],
     pool_type=[ReducePool.Sum, ReducePool.Average],
     math_fidelity=MATH_FIDELITY_MODES,
-    dest_sync_mode=[DestSync.Half, DestSync.Full],
+    dest_sync_mode=lambda: reduce_dest_sync_modes(is_perf=False),
+    run_types=[[PerfRunType.L1_TO_L1]],
+    loop_factor=[1],
 )
 def test_reduce_quasar_mxfp4_2x_gapool(
     register_format_hint,
@@ -335,8 +368,13 @@ def test_reduce_quasar_mxfp4_2x_gapool(
     pool_type,
     math_fidelity,
     dest_sync_mode,
+    run_types,
+    loop_factor,
+    *,
+    is_perf=False,
+    perf_report=None,
 ):
-    input_dimensions = [64, 64]
+    input_dimensions = reduce_input_dimensions(is_perf=is_perf)
     tile_shape = construct_tile_shape((32, 32))
 
     src_A, tile_cnt, _, _ = generate_stimuli(
@@ -353,38 +391,42 @@ def test_reduce_quasar_mxfp4_2x_gapool(
     else:  # Average
         src_B = torch.full((tile_shape.total_tile_size(),), 1 / 32)
 
-    generate_golden = get_golden_generator(ReduceGapoolGolden)
-    golden_tensor = generate_golden(
-        src_A,
-        src_B,
-        formats.output_format,
-        reduce_dim,
-        math_fidelity,
-        tile_cnt,
-        input_format=formats.input_format,
-    )
+    if not is_perf:
+        generate_golden = get_golden_generator(ReduceGapoolGolden)
+        golden_tensor = generate_golden(
+            src_A,
+            src_B,
+            formats.output_format,
+            reduce_dim,
+            math_fidelity,
+            tile_cnt,
+            input_format=formats.input_format,
+        )
 
     mathop = mathop_mapping[reduce_dim]
 
-    configuration = TestConfig(
-        "sources/quasar/reduce_quasar_test.cpp",
-        formats,
-        templates=[
+    if is_perf and perf_report is None:
+        raise ValueError("perf_report must be provided when is_perf=True")
+
+    test_config_kwargs = {
+        "test_name": "sources/quasar/reduce_quasar_test.cpp",
+        "formats": formats,
+        "templates": [
             MATH_FIDELITY(math_fidelity),
             MATH_OP(mathop=mathop, pool_type=pool_type),
             UNPACKER_ENGINE_SEL(),
-            # MX input -> implied math format on the kernel side (matches matmul 2x).
             IMPLIED_MATH_FORMAT(ImpliedMathFormat.Yes),
             DEST_SYNC(dest_sync_mode),
         ],
-        runtimes=[
+        "runtimes": [
             TILE_COUNT(tile_cnt),
             TEST_FACE_DIMS(tile_shape.face_r_dim, tile_shape.face_c_dim),
             NUM_FACES_R_DIM(tile_shape.num_faces_r_dim),
             NUM_FACES_C_DIM(tile_shape.num_faces_c_dim),
             NUM_FACES(tile_shape.total_num_faces()),
+            LOOP_FACTOR(loop_factor),
         ],
-        variant_stimuli=StimuliConfig(
+        "variant_stimuli": StimuliConfig(
             src_A,
             formats.input_format,
             src_B,
@@ -398,11 +440,23 @@ def test_reduce_quasar_mxfp4_2x_gapool(
             tile_dimensions=(32, 32),
             use_dense_tile_dimensions=True,
         ),
-        unpack_to_dest=False,
-        dest_acc=dest_acc,
-        disable_format_inference=False,
-    )
+        "unpack_to_dest": False,
+        "dest_acc": dest_acc,
+        "disable_format_inference": False,
+    }
 
+    if is_perf:
+        configuration = PerfConfig(run_types=run_types, **test_config_kwargs)
+        configuration.run(perf_report)
+        return
+
+    configuration = TestConfig(
+        **{
+            **test_config_kwargs,
+            "templates": test_config_kwargs["templates"]
+            + [PERF_RUN_TYPE(PerfRunType.L1_TO_L1)],
+        },
+    )
     res_from_L1 = configuration.run().result
 
     assert len(res_from_L1) == len(

--- a/tt_metal/tt-llk/tests/sources/quasar/reduce_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/reduce_quasar_test.cpp
@@ -9,6 +9,8 @@
 #include "ckernel.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
+#include "perf.h"
+#include "profiler.h"
 #include "quasar_test_common.h"
 #include "sfpu_stub.h"
 #include "tensor_shape.h"
@@ -24,28 +26,61 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
+#ifndef SPEED_OF_LIGHT
+    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT        = params.TILE_CNT;
+    const std::uint32_t num_faces       = params.num_faces;
+    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
+    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
+    const Operand& buffer_A             = params.buffer_A;
+    const Operand& buffer_B             = params.buffer_B;
+#endif
     tdma_descriptor_t td_val_A;
     tdma_descriptor_t td_val_B;
     const std::uint32_t buf_desc_id_a = 0;
     const std::uint32_t buf_desc_id_b = 1;
+    const auto tensor_shape_A         = tensor_shape_from_params(params);
 
-    // Setup data valid scheme
-    set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
-
-    const auto tensor_shape_A = tensor_shape_from_params(params);
-
-    td_val_A = ckernel::trisc::construct_tdma_desc(tensor_shape_A, L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src, buf_desc_id_a, formats.unpack_A_dst);
-    td_val_B = ckernel::trisc::construct_tdma_desc(tensor_shape_A, L1_ADDRESS(params.buffer_B[0]), formats.unpack_B_src, buf_desc_id_b, formats.unpack_B_dst);
-
-    _configure_buf_desc_table_(td_val_A.buf_desc_id, td_val_A.buf_desc);
-    _configure_buf_desc_table_(td_val_B.buf_desc_id, td_val_B.buf_desc);
-    _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val_A, td_val_B);
-
-    _llk_unpack_reduce_init_<POOL_TYPE, REDUCE_DIM>(buf_desc_id_a, buf_desc_id_b, tensor_shape_A, 1 /*num_tiles_per_unpack*/);
-
-    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {
-        _llk_unpack_reduce_(i, 0, tensor_shape_A);
+        ZONE_SCOPED("INIT")
+        td_val_A = ckernel::trisc::construct_tdma_desc(tensor_shape_A, L1_ADDRESS(buffer_A[0]), formats.unpack_A_src, buf_desc_id_a, formats.unpack_A_dst);
+        td_val_B = ckernel::trisc::construct_tdma_desc(tensor_shape_A, L1_ADDRESS(buffer_B[0]), formats.unpack_B_src, buf_desc_id_b, formats.unpack_B_dst);
+
+        _configure_buf_desc_table_(td_val_A.buf_desc_id, td_val_A.buf_desc);
+        _configure_buf_desc_table_(td_val_B.buf_desc_id, td_val_B.buf_desc);
+        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val_A, td_val_B);
+        _llk_unpack_reduce_init_<POOL_TYPE, REDUCE_DIM>(buf_desc_id_a, buf_desc_id_b, tensor_shape_A, 1 /*num_tiles_per_unpack*/);
+        PROFILER_SYNC();
+    }
+    {
+        ZONE_SCOPED("TILE_LOOP")
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
+        {
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                for (std::uint32_t tile = 0; tile < TILE_CNT; tile++)
+                {
+                    // Reduce unpack emits one persistent SrcB scale face,
+                    // followed by all SrcA faces for each tile.
+                    _perf_unpack_loop_set_valid<false, true>(1);
+                    _perf_unpack_loop_set_valid<true, false>(num_faces);
+                }
+            }
+        }
+        else
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                for (std::uint32_t i = 0; i < TILE_CNT; ++i)
+                {
+                    _llk_unpack_reduce_(i, 0, tensor_shape_A);
+                }
+            }
+        }
+        PROFILER_SYNC();
     }
 }
 
@@ -64,46 +99,65 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    // Setup data valid scheme
-    set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
-
-    DataFormat src_format         = static_cast<DataFormat>(formats.math);
-    DataFormat pack_src_format    = static_cast<DataFormat>(formats.pack_src);
-    const bool use_int32_dest_alu = is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32;
-    const bool is_int_fpu_en      = use_int32_dest_alu && (REDUCE_DIM == ReduceDim::REDUCE_ROW || REDUCE_DIM == ReduceDim::REDUCE_SCALAR);
-
-    const auto tensor_shape_A = tensor_shape_from_params(params);
-
-    if (use_int32_dest_alu)
+#ifndef SPEED_OF_LIGHT
+    const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT    = params.TILE_CNT;
+    const std::uint32_t num_faces   = params.num_faces;
+#endif
     {
-        _llk_math_srcAB_hw_configure_<false, false /*fp32_dest*/, true /*int32_dest*/>(src_format, src_format);
-    }
-    else
-    {
-        _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*int32_dest*/>(src_format, src_format);
-    }
-
-    if (is_int_fpu_en)
-    {
-        // Int Scalar SUM is unsupported, see SFPU reduce.
-        if constexpr (!(REDUCE_DIM == ReduceDim::REDUCE_SCALAR && POOL_TYPE == PoolType::SUM))
+        ZONE_SCOPED("INIT")
+        // PACK_ISOLATE measures pack alone (WH/BH style): skip FPU→PACK dest-dvalid.
+        if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
-            _llk_math_reduce_init_<POOL_TYPE, REDUCE_DIM, MATH_FIDELITY, true /*is_int_fpu_en*/>(tensor_shape_A);
-            for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+            set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+        }
+
+        DataFormat src_format     = static_cast<DataFormat>(formats.math);
+        const auto tensor_shape_A = tensor_shape_from_params(params);
+
+        _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /* int32 dest */>(src_format, src_format);
+        _llk_math_reduce_init_<POOL_TYPE, REDUCE_DIM, MATH_FIDELITY>(tensor_shape_A);
+        PROFILER_SYNC();
+    }
+    {
+        ZONE_SCOPED("TILE_LOOP")
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
+        {
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
-                _llk_math_reduce_<POOL_TYPE, REDUCE_DIM, true /*is_int_fpu_en*/>(i, tensor_shape_A);
+                for (std::uint32_t tile = 0; tile < TILE_CNT; tile++)
+                {
+                    _perf_math_loop_clear_valid<true, false>(num_faces);
+                    _perf_math_loop_clear_valid<false, true>(1);
+                }
             }
         }
-    }
-    else
-    {
-        _llk_math_reduce_init_<POOL_TYPE, REDUCE_DIM, MATH_FIDELITY, false /*is_int_fpu_en*/>(tensor_shape_A);
-        for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
-            _llk_math_reduce_<POOL_TYPE, REDUCE_DIM, false /*is_int_fpu_en*/>(i, tensor_shape_A);
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                for (std::uint32_t i = 0; i < TILE_CNT; ++i)
+                {
+                    _llk_math_reduce_(i);
+                }
+            }
         }
+        else
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                for (std::uint32_t i = 0; i < TILE_CNT; ++i)
+                {
+                    _llk_math_reduce_(i);
+                }
+                _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+            }
+        }
+        PROFILER_SYNC();
     }
-    _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
 }
 
 #endif
@@ -119,24 +173,69 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    std::uint32_t const buf_desc_id = 8;
+#ifndef SPEED_OF_LIGHT
+    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT        = params.TILE_CNT;
+    const std::uint32_t num_faces       = params.num_faces;
+    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
+    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
+    const Operand& buffer_Res           = params.buffer_Res;
+#endif
+    const std::uint32_t buf_desc_id = 8;
+    const auto tensor_shape_A       = tensor_shape_from_params(params);
 
-    set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
-
-    const auto tensor_shape_A = tensor_shape_from_params(params);
-
-    tdma_descriptor_t tdma_desc =
-        ckernel::trisc::construct_tdma_desc(tensor_shape_A, L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst, buf_desc_id, formats.pack_src);
-
-    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
-    _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc, ckernel::ReluConfig::none());
-    _llk_pack_init_(buf_desc_id, tensor_shape_A, 1 /*num_tiles_per_pack*/);
-    _llk_pack_reduce_mask_config_<REDUCE_DIM>(tensor_shape_A);
-    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {
-        _llk_pack_(i, i, tensor_shape_A);
+        ZONE_SCOPED("INIT")
+        // Match WH/BH PACK_ISOLATE: no math↔pack handshake; pack from whatever is in dest.
+        // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        {
+            auto cfg                                    = (std::uint32_t volatile*)TENSIX_CFG_BASE;
+            cfg[PACK_DEST_DVALID_CTRL_wait_mask_ADDR32] = 0;
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
+        {
+            set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+        }
+
+        tdma_descriptor_t tdma_desc =
+            ckernel::trisc::construct_tdma_desc(tensor_shape_A, L1_ADDRESS(buffer_Res[0]), formats.pack_dst, buf_desc_id, formats.pack_src);
+
+        _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
+        _llk_pack_hw_configure_<p_pacr::PACK0>(tdma_desc);
+        _llk_pack_init_(buf_desc_id, tensor_shape_A, 1 /*num_tiles_per_pack*/);
+        _llk_pack_reduce_mask_config_<REDUCE_DIM>(tensor_shape_A);
+        PROFILER_SYNC();
     }
-    _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
-    _llk_pack_reduce_mask_clear_();
+    {
+        ZONE_SCOPED("TILE_LOOP")
+        if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE || PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)
+        {
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        {
+            // No dest-dvalid section_done: WH/BH isolate packs without math handshake.
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                for (std::uint32_t i = 0; i < TILE_CNT; ++i)
+                {
+                    _llk_pack_(i, i, tensor_shape_A);
+                }
+            }
+        }
+        else
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                for (std::uint32_t i = 0; i < TILE_CNT; ++i)
+                {
+                    _llk_pack_(i, i, tensor_shape_A);
+                }
+                _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+            }
+        }
+        _llk_pack_reduce_mask_clear_();
+        PROFILER_SYNC();
+    }
 }
 #endif

--- a/tt_metal/tt-llk/tests/sources/quasar/reduce_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/reduce_quasar_test.cpp
@@ -102,6 +102,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t TILE_CNT    = params.TILE_CNT;
     const std::uint32_t num_faces   = params.num_faces;
 #endif
+    DataFormat src_format         = static_cast<DataFormat>(formats.math);
+    DataFormat pack_src_format    = static_cast<DataFormat>(formats.pack_src);
+    const bool use_int32_dest_alu = is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32;
+    const bool is_int_fpu_en      = use_int32_dest_alu && (REDUCE_DIM == ReduceDim::REDUCE_ROW || REDUCE_DIM == ReduceDim::REDUCE_SCALAR);
+    const auto tensor_shape_A     = tensor_shape_from_params(params);
+
     {
         ZONE_SCOPED("INIT")
         // PACK_ISOLATE measures pack alone (WH/BH style): skip FPU→PACK dest-dvalid.
@@ -110,11 +116,27 @@ void run_kernel(RUNTIME_PARAMETERS params)
             set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
         }
 
-        DataFormat src_format     = static_cast<DataFormat>(formats.math);
-        const auto tensor_shape_A = tensor_shape_from_params(params);
+        if (use_int32_dest_alu)
+        {
+            _llk_math_srcAB_hw_configure_<false, false /* fp32 dest */, true /* int32 dest */>(src_format, src_format);
+        }
+        else
+        {
+            _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /* int32 dest */>(src_format, src_format);
+        }
 
-        _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /* int32 dest */>(src_format, src_format);
-        _llk_math_reduce_init_<POOL_TYPE, REDUCE_DIM, MATH_FIDELITY>(tensor_shape_A);
+        if (is_int_fpu_en)
+        {
+            // Int Scalar SUM is unsupported, see SFPU reduce.
+            if constexpr (!(REDUCE_DIM == ReduceDim::REDUCE_SCALAR && POOL_TYPE == PoolType::SUM))
+            {
+                _llk_math_reduce_init_<POOL_TYPE, REDUCE_DIM, MATH_FIDELITY, true /* is_int_fpu_en */>(tensor_shape_A);
+            }
+        }
+        else
+        {
+            _llk_math_reduce_init_<POOL_TYPE, REDUCE_DIM, MATH_FIDELITY, false /* is_int_fpu_en */>(tensor_shape_A);
+        }
         PROFILER_SYNC();
     }
     {
@@ -133,25 +155,38 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 }
             }
         }
-        else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
-        {
-            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
-            {
-                for (std::uint32_t i = 0; i < TILE_CNT; ++i)
-                {
-                    _llk_math_reduce_(i);
-                }
-            }
-        }
         else
         {
-            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            if (is_int_fpu_en)
             {
-                for (std::uint32_t i = 0; i < TILE_CNT; ++i)
+                if constexpr (!(REDUCE_DIM == ReduceDim::REDUCE_SCALAR && POOL_TYPE == PoolType::SUM))
                 {
-                    _llk_math_reduce_(i);
+                    for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+                    {
+                        for (std::uint32_t i = 0; i < TILE_CNT; ++i)
+                        {
+                            _llk_math_reduce_<POOL_TYPE, REDUCE_DIM, true /* is_int_fpu_en */>(i, tensor_shape_A);
+                        }
+                        if constexpr (PERF_RUN_TYPE != PerfRunType::MATH_ISOLATE)
+                        {
+                            _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+                        }
+                    }
                 }
-                _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+            }
+            else
+            {
+                for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+                {
+                    for (std::uint32_t i = 0; i < TILE_CNT; ++i)
+                    {
+                        _llk_math_reduce_<POOL_TYPE, REDUCE_DIM, false /* is_int_fpu_en */>(i, tensor_shape_A);
+                    }
+                    if constexpr (PERF_RUN_TYPE != PerfRunType::MATH_ISOLATE)
+                    {
+                        _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+                    }
+                }
             }
         }
         PROFILER_SYNC();
@@ -197,7 +232,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             ckernel::trisc::construct_tdma_desc(tensor_shape_A, L1_ADDRESS(buffer_Res[0]), formats.pack_dst, buf_desc_id, formats.pack_src);
 
         _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
-        _llk_pack_hw_configure_<p_pacr::PACK0>(tdma_desc);
+        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc, ckernel::ReluConfig::none());
         _llk_pack_init_(buf_desc_id, tensor_shape_A, 1 /*num_tiles_per_pack*/);
         _llk_pack_reduce_mask_config_<REDUCE_DIM>(tensor_shape_A);
         PROFILER_SYNC();
@@ -207,17 +242,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
         if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE || PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)
         {
         }
-        else if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
-        {
-            // No dest-dvalid section_done: WH/BH isolate packs without math handshake.
-            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
-            {
-                for (std::uint32_t i = 0; i < TILE_CNT; ++i)
-                {
-                    _llk_pack_(i, i, tensor_shape_A);
-                }
-            }
-        }
         else
         {
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
@@ -226,7 +250,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 {
                     _llk_pack_(i, i, tensor_shape_A);
                 }
-                _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+                if constexpr (PERF_RUN_TYPE != PerfRunType::PACK_ISOLATE && PERF_RUN_TYPE != PerfRunType::L1_CONGESTION)
+                {
+                    _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+                }
             }
         }
         _llk_pack_reduce_mask_clear_();

--- a/tt_metal/tt-llk/tests/sources/quasar/reduce_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/reduce_quasar_test.cpp
@@ -27,13 +27,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifndef SPEED_OF_LIGHT
-    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
-    const std::uint32_t TILE_CNT        = params.TILE_CNT;
-    const std::uint32_t num_faces       = params.num_faces;
-    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
-    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
-    const Operand& buffer_A             = params.buffer_A;
-    const Operand& buffer_B             = params.buffer_B;
+    const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT    = params.TILE_CNT;
+    const std::uint32_t num_faces   = params.num_faces;
+    const Operand& buffer_A         = params.buffer_A;
+    const Operand& buffer_B         = params.buffer_B;
 #endif
     tdma_descriptor_t td_val_A;
     tdma_descriptor_t td_val_B;
@@ -174,12 +172,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifndef SPEED_OF_LIGHT
-    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
-    const std::uint32_t TILE_CNT        = params.TILE_CNT;
-    const std::uint32_t num_faces       = params.num_faces;
-    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
-    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
-    const Operand& buffer_Res           = params.buffer_Res;
+    const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT    = params.TILE_CNT;
+    const Operand& buffer_Res       = params.buffer_Res;
 #endif
     const std::uint32_t buf_desc_id = 8;
     const auto tensor_shape_A       = tensor_shape_from_params(params);


### PR DESCRIPTION
### PR Category
Performance

### Summary
Adds Quasar performance coverage for `reduce` by introducing its perf test and adapting the matching Python and C++ tests.

Closes #50578

### Notes for reviewers
This PR is intentionally limited to the three operation-specific test files split from `ndivnic/backup_remaining_perf_tests_quasar`.

Builds and tests were not run; any resulting failures will be addressed separately.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/reduce_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/reduce_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/reduce_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/reduce_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ndivnic/reduce_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ndivnic/reduce_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/reduce_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/reduce_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/reduce_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/reduce_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/reduce_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/reduce_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/reduce_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/reduce_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/reduce_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/reduce_perf_test_quasar)