### PR TITLE
[Performance] Add transpose_dest Quasar performance test

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_transpose_dest_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_transpose_dest_quasar.py
@@ -19,9 +19,7 @@ from quasar.test_transpose_dest_quasar import (
 @pytest.mark.quasar
 @parametrize(
     formats_dest_acc_sync_transpose_dims=PERF_TRANSPOSE_DEST_COMBINATIONS,
-    implied_math_format=lambda formats_dest_acc_sync_transpose_dims: transpose_dest_implied_math_formats(
-        is_perf=True
-    ),
+    implied_math_format=lambda: transpose_dest_implied_math_formats(is_perf=True),
     run_types=PERF_RUN_TYPES_QUASAR,
     loop_factor=[32],
     is_perf=[True],

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_transpose_dest_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_transpose_dest_quasar.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from helpers.llk_params import PERF_RUN_TYPES_QUASAR
+from helpers.param_config import parametrize
+from quasar.test_transpose_dest_quasar import (
+    PERF_TRANSPOSE_DEST_COMBINATIONS,
+)
+from quasar.test_transpose_dest_quasar import (
+    test_transpose_dest_quasar as run_transpose_dest,
+)
+from quasar.test_transpose_dest_quasar import (
+    transpose_dest_implied_math_formats,
+)
+
+@pytest.mark.perf
+@pytest.mark.quasar
+@parametrize(
+    formats_dest_acc_sync_transpose_dims=PERF_TRANSPOSE_DEST_COMBINATIONS,
+    implied_math_format=lambda formats_dest_acc_sync_transpose_dims: transpose_dest_implied_math_formats(
+        is_perf=True
+    ),
+    run_types=PERF_RUN_TYPES_QUASAR,
+    loop_factor=[32],
+    is_perf=[True],
+)
+def test_perf_transpose_dest_quasar(
+    perf_report,
+    formats_dest_acc_sync_transpose_dims,
+    implied_math_format,
+    run_types,
+    loop_factor,
+    is_perf,
+):
+    run_transpose_dest(
+        formats_dest_acc_sync_transpose_dims,
+        implied_math_format,
+        run_types=run_types,
+        loop_factor=loop_factor,
+        is_perf=is_perf,
+        perf_report=perf_report,
+    )

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_transpose_dest_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_transpose_dest_quasar.py
@@ -14,6 +14,7 @@ from quasar.test_transpose_dest_quasar import (
     transpose_dest_implied_math_formats,
 )
 
+
 @pytest.mark.perf
 @pytest.mark.quasar
 @parametrize(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_transpose_dest_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_transpose_dest_quasar.py
@@ -17,6 +17,7 @@ from helpers.llk_params import (
     DestAccumulation,
     DestSync,
     ImpliedMathFormat,
+    PerfRunType,
     Transpose,
     UnpackerEngine,
     format_dict,
@@ -27,6 +28,7 @@ from helpers.param_config import (
     parametrize,
     runtime,
 )
+from helpers.perf import PerfConfig
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import TestConfig
@@ -35,8 +37,10 @@ from helpers.test_variant_parameters import (
     DEST_INDEX,
     DEST_SYNC,
     IMPLIED_MATH_FORMAT,
+    LOOP_FACTOR,
     MATH_TRANSPOSE_FACES,
     NUM_FACES,
+    PERF_RUN_TYPE,
     TEST_FACE_DIMS,
     TILE_COUNT,
     UNPACKER_ENGINE_SEL,
@@ -46,6 +50,8 @@ from helpers.utils import passed_test
 
 def generate_qsr_transpose_dest_combinations(
     formats_list: List[FormatConfig],
+    *,
+    is_perf=False,
 ):
     """
     Generate transpose dest combinations for Quasar tests.
@@ -99,8 +105,11 @@ def generate_qsr_transpose_dest_combinations(
         for dest_sync in (DestSync.Half, DestSync.Full)
     }
 
-    dest_sync_modes = (DestSync.Half, DestSync.Full)
-    transpose_faces_modes = (Transpose.No, Transpose.Yes)
+    dest_sync_modes = (DestSync.Half,) if is_perf else (DestSync.Half, DestSync.Full)
+    transpose_faces_modes = (
+        (Transpose.No,) if is_perf else (Transpose.No, Transpose.Yes)
+    )
+    perf_dimensions = [32, 32]
 
     combinations = []
     for fmt in formats_list:
@@ -113,6 +122,17 @@ def generate_qsr_transpose_dest_combinations(
             if is_supported_dest_mode_dependent_conversion(in_fmt, out_fmt, dest_acc):
                 for dest_sync in dest_sync_modes:
                     for math_transpose_faces in transpose_faces_modes:
+                        if is_perf:
+                            combinations.append(
+                                (
+                                    fmt,
+                                    dest_acc,
+                                    dest_sync,
+                                    math_transpose_faces,
+                                    runtime(perf_dimensions),
+                                )
+                            )
+                            continue
                         for dimensions in dimensions_cache[(dest_acc, dest_sync)]:
                             combinations.append(
                                 (
@@ -125,6 +145,14 @@ def generate_qsr_transpose_dest_combinations(
                             )
 
     return combinations
+
+
+def transpose_dest_implied_math_formats(*, is_perf=False):
+    return (
+        [ImpliedMathFormat.Yes]
+        if is_perf
+        else [ImpliedMathFormat.No, ImpliedMathFormat.Yes]
+    )
 
 
 TRANSPOSE_DEST_FORMATS = input_output_formats(
@@ -140,6 +168,10 @@ TRANSPOSE_DEST_FORMATS = input_output_formats(
         DataFormat.MxInt2,
     ],
 )
+PERF_TRANSPOSE_DEST_COMBINATIONS = generate_qsr_transpose_dest_combinations(
+    TRANSPOSE_DEST_FORMATS,
+    is_perf=True,
+)
 
 
 @pytest.mark.quasar
@@ -147,11 +179,18 @@ TRANSPOSE_DEST_FORMATS = input_output_formats(
     formats_dest_acc_sync_transpose_dims=generate_qsr_transpose_dest_combinations(
         TRANSPOSE_DEST_FORMATS
     ),
-    implied_math_format=[ImpliedMathFormat.No, ImpliedMathFormat.Yes],
+    implied_math_format=lambda: transpose_dest_implied_math_formats(is_perf=False),
+    run_types=[[PerfRunType.L1_TO_L1]],
+    loop_factor=[1],
 )
 def test_transpose_dest_quasar(
     formats_dest_acc_sync_transpose_dims,
     implied_math_format,
+    run_types,
+    loop_factor,
+    *,
+    is_perf=False,
+    perf_report=None,
 ):
     (formats, dest_acc, dest_sync, math_transpose_faces, input_dimensions) = (
         formats_dest_acc_sync_transpose_dims
@@ -233,14 +272,16 @@ def test_transpose_dest_quasar(
         )
 
     unpack_to_dest = (
-        True
-        if formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
-        else False
+        formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
     )
-    configuration = TestConfig(
-        "sources/quasar/transpose_dest_quasar_test.cpp",
-        formats,
-        templates=[
+
+    if is_perf and perf_report is None:
+        raise ValueError("perf_report must be provided when is_perf=True")
+
+    test_config_kwargs = {
+        "test_name": "sources/quasar/transpose_dest_quasar_test.cpp",
+        "formats": formats,
+        "templates": [
             IMPLIED_MATH_FORMAT(implied_math_format),
             DATA_COPY_TYPE(data_copy_type),
             UNPACKER_ENGINE_SEL(
@@ -249,13 +290,14 @@ def test_transpose_dest_quasar(
             DEST_SYNC(dest_sync),
             MATH_TRANSPOSE_FACES(math_transpose_faces),
         ],
-        runtimes=[
+        "runtimes": [
             TILE_COUNT(tile_cnt_A),
             NUM_FACES(num_faces),
             TEST_FACE_DIMS(),
             DEST_INDEX(),
+            LOOP_FACTOR(loop_factor),
         ],
-        variant_stimuli=StimuliConfig(
+        "variant_stimuli": StimuliConfig(
             src_A,
             formats.input_format,
             src_B,
@@ -266,10 +308,22 @@ def test_transpose_dest_quasar(
             tile_count_res=tile_cnt_A,
             num_faces=num_faces,
         ),
-        unpack_to_dest=unpack_to_dest,
-        dest_acc=dest_acc,
-    )
+        "unpack_to_dest": unpack_to_dest,
+        "dest_acc": dest_acc,
+    }
 
+    if is_perf:
+        configuration = PerfConfig(run_types=run_types, **test_config_kwargs)
+        configuration.run(perf_report)
+        return
+
+    configuration = TestConfig(
+        **{
+            **test_config_kwargs,
+            "templates": test_config_kwargs["templates"]
+            + [PERF_RUN_TYPE(PerfRunType.L1_TO_L1)],
+        },
+    )
     res_from_L1 = configuration.run().result
 
     assert len(res_from_L1) == len(

--- a/tt_metal/tt-llk/tests/sources/quasar/transpose_dest_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/transpose_dest_quasar_test.cpp
@@ -46,6 +46,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
             {
                 set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::FPU, dest_dvalid_client::PACK});
             }
+            else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+            {
+                // L1_TO_L1 leaves UNPACK waiting for DEST ownership. Isolate
+                // modes have no consumer pulse, so clear the persistent wait.
+                volatile std::uint32_t* cfg                      = (volatile std::uint32_t*)TENSIX_CFG_BASE;
+                cfg[UNPACK_TO_DEST_DVALID_CTRL_wait_mask_ADDR32] = 0;
+            }
         }
         else
         {
@@ -121,6 +128,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
                     }
                 }
 
+                // After datacopy consumes SrcA and clears its dvalid, provide
+                // dummy SrcA+SrcB dvalid so transpose dest can use srcA/B.
                 for (std::uint32_t i = 0; i < TILE_CNT; ++i)
                 {
                     _llk_unpack_set_srcB_dummy_valid_();
@@ -141,6 +150,45 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #include "params.h"
 
 using namespace ckernel;
+
+template <bool set_dvalid>
+inline void run_datacopy_transpose_loop(
+    const DataFormat math_format,
+    const std::uint32_t loop_factor,
+    const std::uint32_t tile_cnt,
+    const std::uint32_t num_faces,
+    const std::uint32_t face_r_dim,
+    const int dst_index)
+{
+    for (std::uint32_t loop = 0; loop < loop_factor; loop++)
+    {
+        if constexpr (!unpack_to_dest)
+        {
+            // Datacopy and transpose both use bank0's instruction buffer, so
+            // each operation must program its MOP immediately before execution.
+            _configure_default_alu_data_format_state_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en>(math_format, math_format);
+            _llk_math_eltwise_unary_datacopy_init_<DATA_COPY_TYPE, is_fp32_dest_acc_en>(num_faces * face_r_dim /*num_rows_per_matrix*/, 1 /*num_matrices*/);
+            for (std::uint32_t i = 0; i < tile_cnt; ++i)
+            {
+                _llk_math_eltwise_unary_datacopy_(dst_index + i);
+            }
+        }
+
+        // Int32/Float32 transpose dest requires non-default SrcA/SrcB format
+        // settings and disables implied math format.
+        _configure_mov_ops_explicit_alu_data_format_state_<is_fp32_dest_acc_en>(math_format, math_format);
+        _llk_math_transpose_dest_init_<MATH_TRANSPOSE_FACES, is_fp32_dest_acc_en>();
+        for (std::uint32_t i = 0; i < tile_cnt; ++i)
+        {
+            _llk_math_transpose_dest_(dst_index + i);
+        }
+
+        if constexpr (set_dvalid)
+        {
+            _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+        }
+    }
+}
 
 void run_kernel(RUNTIME_PARAMETERS params)
 {
@@ -211,51 +259,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
-            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
-            {
-                if constexpr (!unpack_to_dest)
-                {
-                    // Datacopy and transpose both use bank0's instruction
-                    // buffer, so each operation must program its MOP before
-                    // execution. Initializing both in INIT overwrites datacopy.
-                    _configure_default_alu_data_format_state_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en>(math_format, math_format);
-                    _llk_math_eltwise_unary_datacopy_init_<DATA_COPY_TYPE, is_fp32_dest_acc_en>(
-                        num_faces * TEST_FACE_R_DIM /*num_rows_per_matrix*/, 1 /*num_matrices*/);
-                    for (std::uint32_t i = 0; i < TILE_CNT; ++i)
-                    {
-                        _llk_math_eltwise_unary_datacopy_(DST_INDEX + i);
-                    }
-                }
-                _configure_mov_ops_explicit_alu_data_format_state_<is_fp32_dest_acc_en>(math_format, math_format);
-                _llk_math_transpose_dest_init_<MATH_TRANSPOSE_FACES, is_fp32_dest_acc_en>();
-                for (std::uint32_t i = 0; i < TILE_CNT; ++i)
-                {
-                    _llk_math_transpose_dest_(DST_INDEX + i);
-                }
-            }
+            run_datacopy_transpose_loop<false>(math_format, LOOP_FACTOR, TILE_CNT, num_faces, TEST_FACE_R_DIM, DST_INDEX);
         }
         else
         {
-            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
-            {
-                if constexpr (!unpack_to_dest)
-                {
-                    _configure_default_alu_data_format_state_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en>(math_format, math_format);
-                    _llk_math_eltwise_unary_datacopy_init_<DATA_COPY_TYPE, is_fp32_dest_acc_en>(
-                        num_faces * TEST_FACE_R_DIM /*num_rows_per_matrix*/, 1 /*num_matrices*/);
-                    for (std::uint32_t i = 0; i < TILE_CNT; ++i)
-                    {
-                        _llk_math_eltwise_unary_datacopy_(DST_INDEX + i);
-                    }
-                }
-                _configure_mov_ops_explicit_alu_data_format_state_<is_fp32_dest_acc_en>(math_format, math_format);
-                _llk_math_transpose_dest_init_<MATH_TRANSPOSE_FACES, is_fp32_dest_acc_en>();
-                for (std::uint32_t i = 0; i < TILE_CNT; ++i)
-                {
-                    _llk_math_transpose_dest_(DST_INDEX + i);
-                }
-                _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
-            }
+            run_datacopy_transpose_loop<true>(math_format, LOOP_FACTOR, TILE_CNT, num_faces, TEST_FACE_R_DIM, DST_INDEX);
         }
         PROFILER_SYNC();
     }
@@ -292,7 +300,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            auto cfg                                    = (std::uint32_t volatile*)TENSIX_CFG_BASE;
+            auto cfg                                    = (volatile std::uint32_t*)TENSIX_CFG_BASE;
             cfg[PACK_DEST_DVALID_CTRL_wait_mask_ADDR32] = 0;
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)

--- a/tt_metal/tt-llk/tests/sources/quasar/transpose_dest_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/transpose_dest_quasar_test.cpp
@@ -9,6 +9,8 @@
 #include "ckernel.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
+#include "perf.h"
+#include "profiler.h"
 #include "sfpu_stub.h"
 
 #ifdef LLK_TRISC_UNPACK
@@ -23,66 +25,109 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
+#ifndef SPEED_OF_LIGHT
+    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT        = params.TILE_CNT;
+    const std::uint32_t num_faces       = params.num_faces;
+    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
+    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
+    const Operand& buffer_A             = params.buffer_A;
+    const Operand& buffer_B             = params.buffer_B;
+#endif
     tdma_descriptor_t td_val;
     const std::uint32_t buf_desc_id          = 0;
-    const std::uint32_t num_tiles_per_unpack = params.TILE_CNT;
+    const std::uint32_t num_tiles_per_unpack = TILE_CNT;
 
-    if constexpr (unpack_to_dest)
     {
-        set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+        ZONE_SCOPED("INIT")
+        if constexpr (unpack_to_dest)
+        {
+            if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
+            {
+                set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+            }
+        }
+        else
+        {
+            set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+        }
+
+        buffer_descriptor_u bd_val = {0};
+
+        unsigned l1_addr_16B;
+        if constexpr (UNPACKER_ENGINE_SEL == p_unpacr::UNP_B)
+        {
+            l1_addr_16B = L1_ADDRESS(buffer_B[0]);
+        }
+        else
+        {
+            l1_addr_16B = L1_ADDRESS(buffer_A[0]);
+        }
+
+        bd_val.f.l1_addr_16B = l1_addr_16B;
+        bd_val.f.format      = static_cast<std::uint8_t>(formats.unpack_A_src);
+        bd_val.f.x_dim       = TEST_FACE_C_DIM;
+        bd_val.f.y_dim       = TEST_FACE_R_DIM;
+        bd_val.f.z_dim       = num_faces;
+
+        td_val.buf_desc        = bd_val;
+        td_val.buf_desc_id     = buf_desc_id;
+        td_val.reg_data_format = static_cast<std::uint8_t>(formats.unpack_A_dst);
+
+        _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
+        if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
+        {
+            _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val, td_val);
+        }
+        else
+        {
+            _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(td_val);
+        }
+
+        _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(
+            buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_unpack);
+        PROFILER_SYNC();
     }
-    else
     {
-        set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
-    }
+        ZONE_SCOPED("TILE_LOOP")
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
+        {
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
+        {
+            // Real unpack produces all SrcA tiles first, then the dummy SrcB
+            // tiles consumed by transpose. Preserve that ordering: the two
+            // MOPs cannot be mocked as one simultaneous SrcAB handshake.
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                if constexpr (!unpack_to_dest)
+                {
+                    _perf_unpack_loop_set_valid<true, false>(TILE_CNT);
+                }
+                _perf_unpack_loop_set_valid<false, true>(TILE_CNT);
+            }
+        }
+        else
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                _llk_unpack_unary_operand_<UNPACKER_ENGINE_SEL>(0, ckernel::DEFAULT_TENSOR_SHAPE);
 
-    buffer_descriptor_u bd_val = {0};
+                if constexpr (unpack_to_dest)
+                {
+                    if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
+                    {
+                        _llk_unpack_dest_dvalid_section_done_<dest_sync>();
+                    }
+                }
 
-    unsigned l1_addr_16B;
-    if constexpr (UNPACKER_ENGINE_SEL == p_unpacr::UNP_B)
-    {
-        l1_addr_16B = L1_ADDRESS(params.buffer_B[0]);
-    }
-    else
-    {
-        l1_addr_16B = L1_ADDRESS(params.buffer_A[0]);
-    }
-
-    bd_val.f.l1_addr_16B = l1_addr_16B;
-    bd_val.f.format      = static_cast<std::uint8_t>(formats.unpack_A_src);
-    bd_val.f.x_dim       = params.TEST_FACE_C_DIM;
-    bd_val.f.y_dim       = params.TEST_FACE_R_DIM;
-    bd_val.f.z_dim       = params.num_faces;
-
-    td_val.buf_desc        = bd_val;
-    td_val.buf_desc_id     = buf_desc_id;
-    td_val.reg_data_format = static_cast<std::uint8_t>(formats.unpack_A_dst);
-
-    _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
-    if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
-    {
-        // If Dst fmt is 32b and operation is Mov2D, we need both SrcA/B fmts to be configured since Mov2D will be implemented via ELWADD
-        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val, td_val);
-    }
-    else
-    {
-        _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(td_val);
-    }
-
-    _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(
-        buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_unpack);
-    _llk_unpack_unary_operand_<UNPACKER_ENGINE_SEL>(0, ckernel::DEFAULT_TENSOR_SHAPE);
-
-    if constexpr (unpack_to_dest)
-    {
-        _llk_unpack_dest_dvalid_section_done_<dest_sync>();
-    }
-
-    // After datacopy consumes SrcA and clears its dvalid, provide dummy SrcA+SrcB dvalid
-    // so that transpose dest can use srcA/B.
-    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
-    {
-        _llk_unpack_set_srcB_dummy_valid_();
+                for (std::uint32_t i = 0; i < TILE_CNT; ++i)
+                {
+                    _llk_unpack_set_srcB_dummy_valid_();
+                }
+            }
+        }
+        PROFILER_SYNC();
     }
 }
 
@@ -102,56 +147,118 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    // Set up dest dvalid scheme
-    if constexpr (!unpack_to_dest)
+#ifndef SPEED_OF_LIGHT
+    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT        = params.TILE_CNT;
+    const std::uint32_t num_faces       = params.num_faces;
+    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
+    const int DST_INDEX                 = params.DST_INDEX;
+#endif
+    const DataFormat math_format     = static_cast<DataFormat>(formats.math);
+    const DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
     {
-        set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
-    }
-    else
-    {
-        set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::UNPACK, dest_dvalid_client::FPU, dest_dvalid_client::PACK});
-    }
-
-    DataFormat math_format     = static_cast<DataFormat>(formats.math);
-    DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
-    if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Float32)
-    {
-        _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, true /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
-    }
-    else if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)
-    {
-        _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
-    }
-    else
-    {
-        _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
-    }
-
-    if constexpr (!unpack_to_dest)
-    {
-        // Perform datacopy if not unpack_to_dest
-        _configure_default_alu_data_format_state_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en>(math_format, math_format);
-        _llk_math_eltwise_unary_datacopy_init_<DATA_COPY_TYPE, is_fp32_dest_acc_en>(
-            params.num_faces * params.TEST_FACE_R_DIM /*num_rows_per_matrix*/, 1 /*num_matrices*/);
-        for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+        ZONE_SCOPED("INIT")
+        if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
         {
-            _llk_math_eltwise_unary_datacopy_(params.DST_INDEX + i);
+            if constexpr (!unpack_to_dest)
+            {
+                set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+            }
+            else
+            {
+                set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::UNPACK, dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+            }
         }
-    }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE && unpack_to_dest)
+        {
+            // L1_TO_L1 leaves FPU configured as the middle client in the
+            // UNPACK→FPU→PACK chain. Math isolate has no unpack destination
+            // pulse, so make FPU the producer and restore immediate ownership
+            // of the destination register.
+            set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+        }
 
-    // Perform transpose dest
-    // For Int32 dest, transpose dest requires opposite settings that what is usually set for Int32 dest,
-    // also, Int32 and Fp32 transpose dest sets Int32/Fp32 as srcA/B formats,
-    // all transpose dest operations disable implied math format,
-    // this is why a non-default ALU data format state is used for transpose dest.
-    _configure_mov_ops_explicit_alu_data_format_state_<is_fp32_dest_acc_en>(math_format, math_format);
-    _llk_math_transpose_dest_init_<MATH_TRANSPOSE_FACES, is_fp32_dest_acc_en>();
-    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+        if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Float32)
+        {
+            _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, true /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
+        }
+        else if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)
+        {
+            _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
+        }
+        else
+        {
+            _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
+        }
+        PROFILER_SYNC();
+    }
     {
-        _llk_math_transpose_dest_(params.DST_INDEX + i);
+        ZONE_SCOPED("TILE_LOOP")
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
+        {
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        {
+            // Real unpack emits SrcA and dummy SrcB as two ordered batches.
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                if constexpr (!unpack_to_dest)
+                {
+                    _perf_math_loop_clear_valid<true, false>(TILE_CNT);
+                }
+                _perf_math_loop_clear_valid<false, true>(TILE_CNT);
+            }
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                if constexpr (!unpack_to_dest)
+                {
+                    // Datacopy and transpose both use bank0's instruction
+                    // buffer, so each operation must program its MOP before
+                    // execution. Initializing both in INIT overwrites datacopy.
+                    _configure_default_alu_data_format_state_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en>(math_format, math_format);
+                    _llk_math_eltwise_unary_datacopy_init_<DATA_COPY_TYPE, is_fp32_dest_acc_en>(
+                        num_faces * TEST_FACE_R_DIM /*num_rows_per_matrix*/, 1 /*num_matrices*/);
+                    for (std::uint32_t i = 0; i < TILE_CNT; ++i)
+                    {
+                        _llk_math_eltwise_unary_datacopy_(DST_INDEX + i);
+                    }
+                }
+                _configure_mov_ops_explicit_alu_data_format_state_<is_fp32_dest_acc_en>(math_format, math_format);
+                _llk_math_transpose_dest_init_<MATH_TRANSPOSE_FACES, is_fp32_dest_acc_en>();
+                for (std::uint32_t i = 0; i < TILE_CNT; ++i)
+                {
+                    _llk_math_transpose_dest_(DST_INDEX + i);
+                }
+            }
+        }
+        else
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                if constexpr (!unpack_to_dest)
+                {
+                    _configure_default_alu_data_format_state_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en>(math_format, math_format);
+                    _llk_math_eltwise_unary_datacopy_init_<DATA_COPY_TYPE, is_fp32_dest_acc_en>(
+                        num_faces * TEST_FACE_R_DIM /*num_rows_per_matrix*/, 1 /*num_matrices*/);
+                    for (std::uint32_t i = 0; i < TILE_CNT; ++i)
+                    {
+                        _llk_math_eltwise_unary_datacopy_(DST_INDEX + i);
+                    }
+                }
+                _configure_mov_ops_explicit_alu_data_format_state_<is_fp32_dest_acc_en>(math_format, math_format);
+                _llk_math_transpose_dest_init_<MATH_TRANSPOSE_FACES, is_fp32_dest_acc_en>();
+                for (std::uint32_t i = 0; i < TILE_CNT; ++i)
+                {
+                    _llk_math_transpose_dest_(DST_INDEX + i);
+                }
+                _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+            }
+        }
+        PROFILER_SYNC();
     }
-
-    _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
 }
 
 #endif
@@ -167,35 +274,79 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
+#ifndef SPEED_OF_LIGHT
+    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT        = params.TILE_CNT;
+    const std::uint32_t num_faces       = params.num_faces;
+    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
+    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
+    const int DST_INDEX                 = params.DST_INDEX;
+    const Operand& buffer_Res           = params.buffer_Res;
+#endif
     std::uint32_t const buf_desc_id        = 8;
-    const std::uint32_t num_tiles_per_pack = params.TILE_CNT;
+    const std::uint32_t num_tiles_per_pack = TILE_CNT;
 
-    if constexpr (unpack_to_dest)
     {
-        set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+        ZONE_SCOPED("INIT")
+        // Match WH/BH PACK_ISOLATE: no math↔pack handshake; pack from whatever is in dest.
+        // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        {
+            auto cfg                                    = (std::uint32_t volatile*)TENSIX_CFG_BASE;
+            cfg[PACK_DEST_DVALID_CTRL_wait_mask_ADDR32] = 0;
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
+        {
+            if constexpr (unpack_to_dest)
+            {
+                set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+            }
+            else
+            {
+                set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+            }
+        }
+
+        buffer_descriptor_u bd_val = {0};
+        tdma_descriptor_t tdma_desc;
+
+        bd_val.f.l1_addr_16B = L1_ADDRESS(buffer_Res[0]);
+        bd_val.f.format      = static_cast<std::uint8_t>(formats.pack_dst);
+        bd_val.f.x_dim       = TEST_FACE_C_DIM;
+        bd_val.f.y_dim       = TEST_FACE_R_DIM;
+        bd_val.f.z_dim       = num_faces;
+
+        tdma_desc.buf_desc        = bd_val;
+        tdma_desc.buf_desc_id     = buf_desc_id;
+        tdma_desc.reg_data_format = static_cast<std::uint8_t>(formats.pack_src);
+
+        _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
+        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc, ckernel::ReluConfig::none());
+        _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
+        PROFILER_SYNC();
     }
-    else
     {
-        set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+        ZONE_SCOPED("TILE_LOOP")
+        if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE || PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)
+        {
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        {
+            // No dest-dvalid section_done: WH/BH isolate packs without math handshake.
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                _llk_pack_(DST_INDEX, 0, ckernel::DEFAULT_TENSOR_SHAPE);
+            }
+        }
+        else
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                _llk_pack_(DST_INDEX, 0, ckernel::DEFAULT_TENSOR_SHAPE);
+                _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+            }
+        }
+        PROFILER_SYNC();
     }
-
-    buffer_descriptor_u bd_val = {0};
-    tdma_descriptor_t tdma_desc;
-
-    bd_val.f.l1_addr_16B = L1_ADDRESS(params.buffer_Res[0]);
-    bd_val.f.format      = static_cast<std::uint8_t>(formats.pack_dst);
-    bd_val.f.x_dim       = params.TEST_FACE_C_DIM;
-    bd_val.f.y_dim       = params.TEST_FACE_R_DIM;
-    bd_val.f.z_dim       = params.num_faces;
-
-    tdma_desc.buf_desc        = bd_val;
-    tdma_desc.buf_desc_id     = buf_desc_id;
-    tdma_desc.reg_data_format = static_cast<std::uint8_t>(formats.pack_src);
-
-    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
-    _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc, ckernel::ReluConfig::none());
-    _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
-    _llk_pack_(params.DST_INDEX, 0, ckernel::DEFAULT_TENSOR_SHAPE);
-    _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
 }
 #endif


### PR DESCRIPTION
### PR Category
Performance

### Summary
Adds Quasar performance coverage for `transpose_dest` by introducing its perf test and adapting the matching Python and C++ tests.

Closes #50579

### Notes for reviewers
This PR is intentionally limited to the three operation-specific test files split from `ndivnic/backup_remaining_perf_tests_quasar`.

Builds and tests were not run; any resulting failures will be addressed separately.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/transpose_dest_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/transpose_dest_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/transpose_dest_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/transpose_dest_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ndivnic/transpose_dest_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ndivnic/transpose_dest_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/transpose_dest_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/transpose_dest_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/transpose_dest_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/transpose_dest_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/transpose_dest_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/transpose_dest_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/transpose_dest_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/transpose_dest_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/transpose_dest_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/transpose_dest_perf_test_quasar)