### PR TITLE
[Performance] Add unpack_reduce_col_tilizeA_strided Quasar performance test

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_unpack_reduce_col_tilizeA_strided_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_unpack_reduce_col_tilizeA_strided_quasar.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from helpers.llk_params import PERF_RUN_TYPES_QUASAR
+from helpers.param_config import parametrize
+from quasar.test_unpack_reduce_col_tilizeA_strided_quasar import (
+    PERF_UNPACK_REDUCE_COL_TILIZEA_STRIDED_COMBINATIONS,
+)
+from quasar.test_unpack_reduce_col_tilizeA_strided_quasar import (
+    test_unpack_reduce_col_tilizeA_strided_quasar as run_unpack_reduce_col_tilizeA_strided,
+)
+from quasar.test_unpack_reduce_col_tilizeA_strided_quasar import (
+    unpack_reduce_col_tilizeA_strided_implied_math_formats,
+)
+
+
+@pytest.mark.perf
+@pytest.mark.quasar
+@parametrize(
+    formats_dest_acc_sync_unpack_reduce_col_tilizeA_strided_sel_dims=PERF_UNPACK_REDUCE_COL_TILIZEA_STRIDED_COMBINATIONS,
+    implied_math_format=lambda: unpack_reduce_col_tilizeA_strided_implied_math_formats(
+        is_perf=True
+    ),
+    run_types=PERF_RUN_TYPES_QUASAR,
+    loop_factor=[32],
+    is_perf=[True],
+)
+def test_perf_unpack_reduce_col_tilizeA_strided_quasar(
+    perf_report,
+    formats_dest_acc_sync_unpack_reduce_col_tilizeA_strided_sel_dims,
+    implied_math_format,
+    run_types,
+    loop_factor,
+    is_perf,
+):
+    run_unpack_reduce_col_tilizeA_strided(
+        formats_dest_acc_sync_unpack_reduce_col_tilizeA_strided_sel_dims,
+        implied_math_format,
+        run_types=run_types,
+        loop_factor=loop_factor,
+        is_perf=is_perf,
+        perf_report=perf_report,
+    )

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_reduce_col_tilizeA_strided_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_reduce_col_tilizeA_strided_quasar.py
@@ -22,6 +22,7 @@ from helpers.llk_params import (
     ImpliedMathFormat,
     MathFidelity,
     MathOperation,
+    PerfRunType,
     ReduceDimension,
     ReducePool,
     format_dict,
@@ -31,15 +32,18 @@ from helpers.param_config import (
     parametrize,
     runtime,
 )
+from helpers.perf import PerfConfig
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
 from helpers.test_config import BootMode, TestConfig
 from helpers.test_variant_parameters import (
     DEST_SYNC,
     IMPLIED_MATH_FORMAT,
+    LOOP_FACTOR,
     MATH_FIDELITY,
     MATH_OP,
     NUM_FACES,
+    PERF_RUN_TYPE,
     TEST_FACE_DIMS,
     TILE_COUNT,
     generate_input_dim,
@@ -49,6 +53,8 @@ from helpers.utils import passed_test
 
 def generate_unpack_reduce_col_tilizeA_strided_combinations(
     formats_list: List[FormatConfig],
+    *,
+    is_perf=False,
 ):
     """
     Generate unpack_reduce_col_tilizeA_strided test combinations for Quasar.
@@ -96,6 +102,12 @@ def generate_unpack_reduce_col_tilizeA_strided_combinations(
         ],
     }
 
+    if is_perf:
+        unpack_reduce_col_tilizeA_strided_dims = {
+            (DestSync.Half, DestAccumulation.No): [[32, 32]],
+            (DestSync.Half, DestAccumulation.Yes): [[32, 32]],
+        }
+
     combinations = []
 
     for fmt in get_valid_data_format_conversions(formats_list):
@@ -110,7 +122,9 @@ def generate_unpack_reduce_col_tilizeA_strided_combinations(
                 and acc == DestAccumulation.No
             ):
                 continue
-            for dest_sync in (DestSync.Half, DestSync.Full):
+            for dest_sync in (
+                (DestSync.Half,) if is_perf else (DestSync.Half, DestSync.Full)
+            ):
                 for dimensions in unpack_reduce_col_tilizeA_strided_dims[
                     (dest_sync, acc)
                 ]:
@@ -143,18 +157,39 @@ ALL_UNPACK_REDUCE_COL_TILIZEA_STRIDED_COMBINATIONS = (
         UNPACK_REDUCE_COL_TILIZEA_STRIDED_FORMATS
     )
 )
+PERF_UNPACK_REDUCE_COL_TILIZEA_STRIDED_COMBINATIONS = (
+    generate_unpack_reduce_col_tilizeA_strided_combinations(
+        UNPACK_REDUCE_COL_TILIZEA_STRIDED_FORMATS,
+        is_perf=True,
+    )
+)
+
+
+def unpack_reduce_col_tilizeA_strided_implied_math_formats(*, is_perf=False):
+    return [ImpliedMathFormat.No]
 
 
 @pytest.mark.quasar
 @parametrize(
     formats_dest_acc_sync_unpack_reduce_col_tilizeA_strided_sel_dims=ALL_UNPACK_REDUCE_COL_TILIZEA_STRIDED_COMBINATIONS,
+    implied_math_format=lambda: unpack_reduce_col_tilizeA_strided_implied_math_formats(
+        is_perf=False
+    ),
+    run_types=[[PerfRunType.L1_TO_L1]],
+    loop_factor=[1],
 )
 def test_unpack_reduce_col_tilizeA_strided_quasar(
     formats_dest_acc_sync_unpack_reduce_col_tilizeA_strided_sel_dims,
+    implied_math_format,
+    run_types,
+    loop_factor,
     boot_mode=BootMode.DEFAULT,
+    *,
+    is_perf=False,
+    perf_report=None,
 ):
     (formats, dest_acc, dest_sync_mode, input_dimensions, pool_type) = (
-        formats_dest_acc_sync_unpack_reduce_col_tilizeA_strided_sel_dims[0]
+        formats_dest_acc_sync_unpack_reduce_col_tilizeA_strided_sel_dims
     )
 
     num_faces = 4
@@ -186,15 +221,16 @@ def test_unpack_reduce_col_tilizeA_strided_quasar(
         golden_src_A, input_dimensions, formats.input_format, num_faces=num_faces
     )
 
-    reduce_gen = get_golden_generator(ReduceGolden)
-    golden_tensor = reduce_gen(
-        golden_A,
-        reduce_dim,
-        pool_type,
-        formats.output_format,
-        tile_cnt_A,
-        input_format=input_fmt,
-    )
+    if not is_perf:
+        reduce_gen = get_golden_generator(ReduceGolden)
+        golden_tensor = reduce_gen(
+            golden_A,
+            reduce_dim,
+            pool_type,
+            formats.output_format,
+            tile_cnt_A,
+            input_format=input_fmt,
+        )
 
     mathop = {
         ReduceDimension.Row: MathOperation.ReduceRow,
@@ -202,22 +238,26 @@ def test_unpack_reduce_col_tilizeA_strided_quasar(
         ReduceDimension.Scalar: MathOperation.ReduceScalar,
     }[reduce_dim]
 
-    configuration = TestConfig(
-        "sources/quasar/unpack_reduce_col_tilizeA_strided_quasar_test.cpp",
-        formats,
-        templates=[
-            IMPLIED_MATH_FORMAT(ImpliedMathFormat.No),
+    if is_perf and perf_report is None:
+        raise ValueError("perf_report must be provided when is_perf=True")
+
+    test_config_kwargs = {
+        "test_name": "sources/quasar/unpack_reduce_col_tilizeA_strided_quasar_test.cpp",
+        "formats": formats,
+        "templates": [
+            IMPLIED_MATH_FORMAT(implied_math_format),
             MATH_OP(mathop=mathop, pool_type=pool_type),
             MATH_FIDELITY(math_fidelity),
             DEST_SYNC(dest_sync_mode),
         ],
-        runtimes=[
+        "runtimes": [
             generate_input_dim(input_dimensions, input_dimensions),
             TILE_COUNT(tile_cnt_A),
             TEST_FACE_DIMS(),
             NUM_FACES(),
+            LOOP_FACTOR(loop_factor),
         ],
-        variant_stimuli=StimuliConfig(
+        "variant_stimuli": StimuliConfig(
             src_A,
             formats.input_format,
             src_B,
@@ -228,11 +268,23 @@ def test_unpack_reduce_col_tilizeA_strided_quasar(
             tile_count_res=tile_cnt_A,
             num_faces=num_faces,
         ),
-        unpack_to_dest=False,
-        dest_acc=dest_acc,
-        boot_mode=boot_mode,
-    )
+        "unpack_to_dest": False,
+        "dest_acc": dest_acc,
+        "boot_mode": boot_mode,
+    }
 
+    if is_perf:
+        configuration = PerfConfig(run_types=run_types, **test_config_kwargs)
+        configuration.run(perf_report)
+        return
+
+    configuration = TestConfig(
+        **{
+            **test_config_kwargs,
+            "templates": test_config_kwargs["templates"]
+            + [PERF_RUN_TYPE(PerfRunType.L1_TO_L1)],
+        },
+    )
     res_from_L1 = configuration.run().result
 
     assert len(res_from_L1) == len(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_reduce_col_tilizeA_strided_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_reduce_col_tilizeA_strided_quasar.py
@@ -270,7 +270,6 @@ def test_unpack_reduce_col_tilizeA_strided_quasar(
         ),
         "unpack_to_dest": False,
         "dest_acc": dest_acc,
-        "boot_mode": boot_mode,
     }
 
     if is_perf:
@@ -283,6 +282,7 @@ def test_unpack_reduce_col_tilizeA_strided_quasar(
             **test_config_kwargs,
             "templates": test_config_kwargs["templates"]
             + [PERF_RUN_TYPE(PerfRunType.L1_TO_L1)],
+            "boot_mode": boot_mode,
         },
     )
     res_from_L1 = configuration.run().result

--- a/tt_metal/tt-llk/tests/sources/quasar/unpack_reduce_col_tilizeA_strided_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/unpack_reduce_col_tilizeA_strided_quasar_test.cpp
@@ -177,7 +177,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             {
                 for (std::uint32_t i = 0; i < TILE_CNT; ++i)
                 {
-                    _llk_math_reduce_(i);
+                    _llk_math_reduce_<POOL_TYPE, REDUCE_DIM>(i, ckernel::DEFAULT_TENSOR_SHAPE);
                 }
             }
         }
@@ -187,7 +187,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             {
                 for (std::uint32_t i = 0; i < TILE_CNT; ++i)
                 {
-                    _llk_math_reduce_(i);
+                    _llk_math_reduce_<POOL_TYPE, REDUCE_DIM>(i, ckernel::DEFAULT_TENSOR_SHAPE);
                 }
                 _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
             }

--- a/tt_metal/tt-llk/tests/sources/quasar/unpack_reduce_col_tilizeA_strided_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/unpack_reduce_col_tilizeA_strided_quasar_test.cpp
@@ -8,6 +8,8 @@
 #include "ckernel.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
+#include "perf.h"
+#include "profiler.h"
 #include "sfpu_stub.h"
 
 #ifdef LLK_TRISC_UNPACK
@@ -21,51 +23,92 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
+#ifndef SPEED_OF_LIGHT
+    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT        = params.TILE_CNT;
+    const std::uint32_t num_faces       = params.num_faces;
+    const std::uint32_t BLOCK_RT_DIM    = params.BLOCK_RT_DIM;
+    const std::uint32_t BLOCK_CT_DIM    = params.BLOCK_CT_DIM;
+    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
+    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
+    const std::uint32_t FULL_CT_DIM     = params.FULL_CT_DIM;
+    const Operand& buffer_A             = params.buffer_A;
+    const Operand& buffer_B             = params.buffer_B;
+#endif
     const std::uint32_t buf_desc_id_a = 0;
     const std::uint32_t buf_desc_id_b = 1;
 
-    set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
-
-    buffer_descriptor_u bd_val_A {};
-    bd_val_A.f.l1_addr_16B = L1_ADDRESS(params.buffer_A[0]);
-    bd_val_A.f.format      = static_cast<std::uint8_t>(formats.unpack_A_src);
-    bd_val_A.f.x_dim       = params.TEST_FACE_C_DIM;
-    bd_val_A.f.y_dim       = 1;
-    bd_val_A.f.z_dim       = 1;
-
-    tdma_descriptor_t td_val_A;
-    td_val_A.buf_desc        = bd_val_A;
-    td_val_A.buf_desc_id     = buf_desc_id_a;
-    td_val_A.reg_data_format = static_cast<std::uint8_t>(formats.unpack_A_dst);
-
-    buffer_descriptor_u bd_val_B {};
-    bd_val_B.f.l1_addr_16B = L1_ADDRESS(params.buffer_B[0]);
-    bd_val_B.f.format      = static_cast<std::uint8_t>(formats.unpack_B_src);
-    bd_val_B.f.x_dim       = params.TEST_FACE_C_DIM;
-    bd_val_B.f.y_dim       = params.TEST_FACE_R_DIM;
-    bd_val_B.f.z_dim       = params.num_faces;
-
-    tdma_descriptor_t td_val_B;
-    td_val_B.buf_desc        = bd_val_B;
-    td_val_B.buf_desc_id     = buf_desc_id_b;
-    td_val_B.reg_data_format = static_cast<std::uint8_t>(formats.unpack_B_dst);
-
-    _configure_buf_desc_table_(td_val_A.buf_desc_id, td_val_A.buf_desc);
-    _configure_buf_desc_table_(td_val_B.buf_desc_id, td_val_B.buf_desc);
-    _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val_A, td_val_B);
-
-    constexpr ckernel::TensorShape tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE;
-    _llk_unpack_reduce_col_tilizeA_strided_init_(buf_desc_id_a, buf_desc_id_b, params.FULL_CT_DIM, tensor_shape);
-
-    std::uint32_t y_stride_external = params.FULL_CT_DIM * tensor_shape.num_faces_r_dim * tensor_shape.face_r_dim;
-    for (std::uint32_t block_rt = 0; block_rt < params.BLOCK_RT_DIM; block_rt++)
     {
-        std::uint32_t offset = block_rt * y_stride_external;
-        for (std::uint32_t block_ct = 0; block_ct < params.BLOCK_CT_DIM; block_ct++)
+        ZONE_SCOPED("INIT")
+        buffer_descriptor_u bd_val_A {};
+        bd_val_A.f.l1_addr_16B = L1_ADDRESS(buffer_A[0]);
+        bd_val_A.f.format      = static_cast<std::uint8_t>(formats.unpack_A_src);
+        bd_val_A.f.x_dim       = TEST_FACE_C_DIM;
+        bd_val_A.f.y_dim       = 1;
+        bd_val_A.f.z_dim       = 1;
+
+        tdma_descriptor_t td_val_A;
+        td_val_A.buf_desc        = bd_val_A;
+        td_val_A.buf_desc_id     = buf_desc_id_a;
+        td_val_A.reg_data_format = static_cast<std::uint8_t>(formats.unpack_A_dst);
+
+        buffer_descriptor_u bd_val_B {};
+        bd_val_B.f.l1_addr_16B = L1_ADDRESS(buffer_B[0]);
+        bd_val_B.f.format      = static_cast<std::uint8_t>(formats.unpack_B_src);
+        bd_val_B.f.x_dim       = TEST_FACE_C_DIM;
+        bd_val_B.f.y_dim       = TEST_FACE_R_DIM;
+        bd_val_B.f.z_dim       = num_faces;
+
+        tdma_descriptor_t td_val_B;
+        td_val_B.buf_desc        = bd_val_B;
+        td_val_B.buf_desc_id     = buf_desc_id_b;
+        td_val_B.reg_data_format = static_cast<std::uint8_t>(formats.unpack_B_dst);
+
+        _configure_buf_desc_table_(td_val_A.buf_desc_id, td_val_A.buf_desc);
+        _configure_buf_desc_table_(td_val_B.buf_desc_id, td_val_B.buf_desc);
+        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val_A, td_val_B);
+
+        constexpr ckernel::TensorShape tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE;
+        _llk_unpack_reduce_col_tilizeA_strided_init_(buf_desc_id_a, buf_desc_id_b, FULL_CT_DIM, tensor_shape);
+        PROFILER_SYNC();
+    }
+    {
+        ZONE_SCOPED("TILE_LOOP")
+        constexpr ckernel::TensorShape tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE;
+        std::uint32_t y_stride_external             = FULL_CT_DIM * tensor_shape.num_faces_r_dim * tensor_shape.face_r_dim;
+
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
         {
-            const std::uint32_t l1_unpack_tilize_idx = offset + block_ct;
-            _llk_unpack_reduce_col_tilizeA_strided_(tensor_shape, l1_unpack_tilize_idx, 0);
         }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                for (std::uint32_t tile = 0; tile < TILE_CNT; tile++)
+                {
+                    // The strided reduce MOP emits one SrcB scale face and
+                    // all SrcA data faces for each tile.
+                    _perf_unpack_loop_set_valid<false, true>(1);
+                    _perf_unpack_loop_set_valid<true, false>(num_faces);
+                }
+            }
+        }
+        else
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                for (std::uint32_t block_rt = 0; block_rt < BLOCK_RT_DIM; block_rt++)
+                {
+                    std::uint32_t offset = block_rt * y_stride_external;
+                    for (std::uint32_t block_ct = 0; block_ct < BLOCK_CT_DIM; block_ct++)
+                    {
+                        const std::uint32_t l1_unpack_tilize_idx = offset + block_ct;
+                        _llk_unpack_reduce_col_tilizeA_strided_(tensor_shape, l1_unpack_tilize_idx, 0);
+                    }
+                }
+            }
+        }
+        PROFILER_SYNC();
     }
 }
 
@@ -85,27 +128,72 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
-
-    DataFormat math_format     = static_cast<DataFormat>(formats.math);
-    DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
-    if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)
+#ifndef SPEED_OF_LIGHT
+    const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT    = params.TILE_CNT;
+    const std::uint32_t num_faces   = params.num_faces;
+#endif
     {
-        _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
+        ZONE_SCOPED("INIT")
+        // PACK_ISOLATE measures pack alone (WH/BH style): skip FPU→PACK dest-dvalid.
+        if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
+        {
+            set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+        }
+
+        DataFormat math_format     = static_cast<DataFormat>(formats.math);
+        DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
+        if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)
+        {
+            _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
+        }
+        else
+        {
+            _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*int32_dest*/>(math_format, math_format);
+        }
+
+        _llk_math_reduce_init_<POOL_TYPE, REDUCE_DIM, MATH_FIDELITY>(ckernel::DEFAULT_TENSOR_SHAPE);
+        PROFILER_SYNC();
     }
-    else
     {
-        _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*int32_dest*/>(math_format, math_format);
+        ZONE_SCOPED("TILE_LOOP")
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
+        {
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                for (std::uint32_t tile = 0; tile < TILE_CNT; tile++)
+                {
+                    _perf_math_loop_clear_valid<true, false>(num_faces);
+                    _perf_math_loop_clear_valid<false, true>(1);
+                }
+            }
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                for (std::uint32_t i = 0; i < TILE_CNT; ++i)
+                {
+                    _llk_math_reduce_(i);
+                }
+            }
+        }
+        else
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                for (std::uint32_t i = 0; i < TILE_CNT; ++i)
+                {
+                    _llk_math_reduce_(i);
+                }
+                _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+            }
+        }
+        PROFILER_SYNC();
     }
-
-    _llk_math_reduce_init_<POOL_TYPE, REDUCE_DIM, MATH_FIDELITY>(ckernel::DEFAULT_TENSOR_SHAPE);
-
-    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
-    {
-        _llk_math_reduce_<POOL_TYPE, REDUCE_DIM>(i, ckernel::DEFAULT_TENSOR_SHAPE);
-    }
-
-    _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
 }
 
 #endif
@@ -121,31 +209,74 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
+#ifndef SPEED_OF_LIGHT
+    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT        = params.TILE_CNT;
+    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
+    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
+    const std::uint32_t num_faces       = params.num_faces;
+    const Operand& buffer_Res           = params.buffer_Res;
+#endif
     std::uint32_t const buf_desc_id        = 8;
-    const std::uint32_t num_tiles_per_pack = params.TILE_CNT;
+    const std::uint32_t num_tiles_per_pack = TILE_CNT;
 
-    set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+    {
+        ZONE_SCOPED("INIT")
+        // Match WH/BH PACK_ISOLATE: no math↔pack handshake; pack from whatever is in dest.
+        // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        {
+            auto cfg                                    = (std::uint32_t volatile*)TENSIX_CFG_BASE;
+            cfg[PACK_DEST_DVALID_CTRL_wait_mask_ADDR32] = 0;
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
+        {
+            set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+        }
 
-    buffer_descriptor_u bd_val = {0};
-    bd_val.f.l1_addr_16B       = L1_ADDRESS(params.buffer_Res[0]);
-    bd_val.f.format            = static_cast<std::uint8_t>(formats.pack_dst);
-    bd_val.f.x_dim             = params.TEST_FACE_C_DIM;
-    bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
-    bd_val.f.z_dim             = params.num_faces;
+        buffer_descriptor_u bd_val = {0};
+        bd_val.f.l1_addr_16B       = L1_ADDRESS(buffer_Res[0]);
+        bd_val.f.format            = static_cast<std::uint8_t>(formats.pack_dst);
+        bd_val.f.x_dim             = TEST_FACE_C_DIM;
+        bd_val.f.y_dim             = TEST_FACE_R_DIM;
+        bd_val.f.z_dim             = num_faces;
 
-    tdma_descriptor_t tdma_desc;
-    tdma_desc.buf_desc        = bd_val;
-    tdma_desc.buf_desc_id     = buf_desc_id;
-    tdma_desc.reg_data_format = static_cast<std::uint8_t>(formats.pack_src);
+        tdma_descriptor_t tdma_desc;
+        tdma_desc.buf_desc        = bd_val;
+        tdma_desc.buf_desc_id     = buf_desc_id;
+        tdma_desc.reg_data_format = static_cast<std::uint8_t>(formats.pack_src);
 
-    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
-    _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc, ckernel::ReluConfig::none());
+        _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
+        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc, ckernel::ReluConfig::none());
 
-    _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
-    _llk_pack_reduce_mask_config_<REDUCE_DIM>(ckernel::DEFAULT_TENSOR_SHAPE);
-    _llk_pack_(0, 0, ckernel::DEFAULT_TENSOR_SHAPE);
-    _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
-    _llk_pack_reduce_mask_clear_();
+        _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
+        _llk_pack_reduce_mask_config_<REDUCE_DIM>(ckernel::DEFAULT_TENSOR_SHAPE);
+        PROFILER_SYNC();
+    }
+    {
+        ZONE_SCOPED("TILE_LOOP")
+        if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE || PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)
+        {
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        {
+            // No dest-dvalid section_done: WH/BH isolate packs without math handshake.
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                _llk_pack_(0, 0, ckernel::DEFAULT_TENSOR_SHAPE);
+            }
+        }
+        else
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                _llk_pack_(0, 0, ckernel::DEFAULT_TENSOR_SHAPE);
+                _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+            }
+        }
+        _llk_pack_reduce_mask_clear_();
+        PROFILER_SYNC();
+    }
 }
 
 #endif


### PR DESCRIPTION
### PR Category
Performance

### Summary
Adds Quasar performance coverage for `unpack_reduce_col_tilizeA_strided` by introducing its perf test and adapting the matching Python and C++ tests.

Closes #50581

### Notes for reviewers
This PR is intentionally limited to the three operation-specific test files split from `ndivnic/backup_remaining_perf_tests_quasar`.

Builds and tests were not run; any resulting failures will be addressed separately.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/unpack_reduce_col_tilizeA_strided_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/unpack_reduce_col_tilizeA_strided_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/unpack_reduce_col_tilizeA_strided_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/unpack_reduce_col_tilizeA_strided_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ndivnic/unpack_reduce_col_tilizeA_strided_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ndivnic/unpack_reduce_col_tilizeA_strided_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/unpack_reduce_col_tilizeA_strided_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/unpack_reduce_col_tilizeA_strided_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/unpack_reduce_col_tilizeA_strided_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/unpack_reduce_col_tilizeA_strided_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/unpack_reduce_col_tilizeA_strided_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/unpack_reduce_col_tilizeA_strided_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/unpack_reduce_col_tilizeA_strided_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/unpack_reduce_col_tilizeA_strided_perf_test_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/unpack_reduce_col_tilizeA_strided_perf_test_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/unpack_reduce_col_tilizeA_strided_perf_test_quasar)