### PR TITLE
auto_shard text transformer demo; works on Gemma3, Llama3.1, Qwen2.5,…

### DIFF
--- a/models/tt_transformers/demo/simple_text_demo_auto_shard.py
+++ b/models/tt_transformers/demo/simple_text_demo_auto_shard.py
@@ -1,0 +1,1832 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import hashlib
+import json
+import math
+import os
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+from typing import List
+
+import pytest
+import requests
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.sampling import SamplingParams
+from models.common.utility_functions import is_blackhole, is_wormhole_b0
+from models.demos.utils.llm_demo_utils import create_benchmark_data, verify_accuracy, verify_perf
+from models.demos.utils.model_targets import resolve_accuracy_targets, resolve_perf_targets
+from models.perf.benchmarking_utils import BenchmarkProfiler
+from models.tt_transformers.tt.common import (
+    PagedAttentionConfig,
+    create_tt_model,
+    preprocess_inputs_prefill,
+    sample_host,
+)
+from models.tt_transformers.tt import inline_profile
+from models.tt_transformers.tt.generator import Generator, SamplingParams, create_submeshes
+from models.tt_transformers.tt.auto_shard.cost_model.mesh_selection import select_mesh_plan
+from models.tt_transformers.tt.model_config import DecodersPrecision, determine_device_name, parse_decoder_json
+from models.tt_transformers.tt.prefetcher import is_prefetcher_supported
+from models.tt_transformers.tt.auto_shard.cost_model.sharding import workload_from_config
+
+# Auto-shard variant: identical to simple_text_demo.py, but the model is built from the
+# auto-shard stack. Importing model_auto_shard rebinds both model.TransformerBlock (auto-shard
+# decoder block) and model.Transformer (replicated-residual-stream model) so create_tt_model()
+# builds the auto-shard model + layers instead of the stock fractured ones.
+import models.tt_transformers.tt.auto_shard.model_auto_shard  # noqa: F401  (import for side-effect wiring)
+
+# Gemma-3 needs a different ModelArgs (unit-offset norms, embedding scale) and a different decoder
+# block (pre/post feed-forward norms). This swaps both in, but only when HF_MODEL is a Gemma model;
+# for every other model it is a no-op and this demo is unchanged.
+import models.tt_transformers.tt.gemma_dispatch  # noqa: F401  (import for side-effect wiring)
+
+# Issue: https://github.com/tenstorrent/tt-metal/issues/34763
+models_not_supported_for_device_sampling = ["Mistral-7B"]
+
+
+class TokenAccuracy:
+    def __init__(self, model_name):
+        self.gt_pos = -1
+        self.store_predicted_tokens = []
+        reference_data_file = os.path.join("models/tt_transformers/tests/reference_outputs/", model_name) + ".refpt"
+        assert os.path.exists(reference_data_file)
+        logger.info(f"Loading reference data from {reference_data_file}")
+        reference_data = torch.load(reference_data_file)
+        reference_tokens = reference_data["reference_tokens"]
+        split_point = reference_tokens.shape[-1] // 2
+        self.input_prompt = reference_tokens[0, :split_point]
+        self.reference_tokens = reference_tokens[0, split_point:]
+        self.top5_tokens = reference_data["top5_tokens"][split_point - 1 :, :]
+        self.maxindex = len(self.reference_tokens) - 1
+
+    def prepare_ref_tokens(self, tokenizer):
+        text_data = tokenizer.decode(self.input_prompt.tolist())
+        return text_data
+
+    def collect_predicted_tokens(self, tokens):
+        self.store_predicted_tokens.append(tokens)
+        self.gt_pos += 1
+        return self.reference_tokens[min(self.gt_pos, self.maxindex)].unsqueeze(-1).unsqueeze(-1)
+
+    def compute_accuracy(self):
+        count = 0
+        count_t5 = 0
+        matching_sz = min(len(self.reference_tokens), len(self.store_predicted_tokens))
+        for i in range(matching_sz):
+            if self.top5_tokens[i, 0].item() == self.store_predicted_tokens[i]:
+                count += 1
+            if self.store_predicted_tokens[i] in self.top5_tokens[i, :]:
+                count_t5 += 1
+        accuracy_top1 = count / matching_sz
+        accuracy_top5 = count_t5 / matching_sz
+
+        return accuracy_top1, accuracy_top5
+
+
+def get_accuracy_thresholds(model_args, seq_len: int, batch_size: int = 1):
+    """Resolve accuracy thresholds from centralized model targets."""
+    centralized_targets = resolve_accuracy_targets(
+        model_name=model_args.base_model_name,
+        sku=model_args.device_name,
+        batch_size=batch_size,
+        seq_len=seq_len,
+    )
+    if not centralized_targets or "top1" not in centralized_targets or "top5" not in centralized_targets:
+        raise ValueError(
+            "Could not find centralized accuracy targets for "
+            f"{model_args.base_model_name} on {model_args.device_name} "
+            f"(batch_size={batch_size}, seq_len={seq_len})"
+        )
+
+    # Preserve previous behavior for integer-rounded CI checks.
+    return float(centralized_targets["top1"]) - 0.5, float(centralized_targets["top5"]) - 0.5
+
+
+def load_and_cache_context(context_url, cache_dir, max_length=None):
+    cache_file = cache_dir / hashlib.md5(context_url.encode()).hexdigest()
+
+    if cache_file.exists():
+        with open(cache_file, "r") as f:
+            context_text = f.read()
+        logger.info(f"Loaded context from cache: {context_url}")
+    else:
+        try:
+            response = requests.get(context_url)
+            if response.status_code == 200:
+                context_text = response.text
+                with open(cache_file, "w") as f:
+                    f.write(context_text)
+                logger.info(f"Downloaded and cached context: {context_url}")
+            else:
+                logger.warning(f"Failed to fetch context from URL: {context_url}. Status code: {response.status_code}")
+                context_text = ""
+        except Exception as e:
+            logger.error(f"Error fetching context from URL: {context_url}. Error: {str(e)}")
+            context_text = ""
+
+    # Clip the context to the max length provided
+    if max_length:
+        context_text = context_text[:max_length]
+        logger.info(f"Clipped the context text to {max_length} characters")
+
+    return context_text
+
+
+# load input prompts from json, return as a list
+def load_inputs(user_input, batch, instruct):
+    if isinstance(user_input, str):
+        with open(user_input, "r") as f:
+            user_input = json.load(f)
+
+    if len(user_input) < batch:
+        logger.warning(
+            f"Number of users in the file is less than the provided batch={batch}. Repeating the prompts to match the batch size."
+        )
+        user_input = user_input * batch
+
+    in_prompt = []
+    all_prompts = []
+    cache_dir = Path("models/tt_transformers/demo/context_cache")
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    # The demo supports a custom prompt file, where the context is provided by a link to a book from the gutenberg project
+    # It clips the excerpt to the max length provided to allow testing different long context lengths
+    for i in range(len(user_input)):
+        prompt = user_input[i]["prompt"]
+        if "context" in user_input[i]:
+            if "max_length" in user_input[i]:  # Clip the context to the max length provided
+                context_text = load_and_cache_context(
+                    user_input[i]["context"], cache_dir, max_length=user_input[i]["max_length"]
+                )
+            else:
+                context_text = load_and_cache_context(user_input[i]["context"], cache_dir)
+            if instruct:
+                prompt = (
+                    "```" + context_text + "```\n\n" + prompt
+                )  # Add the markdown block to the context to comply with the prompt
+            else:
+                prompt = context_text
+        all_prompts.append(prompt)  # return all the prompts taken from the input file to be used when repeat_batch > 1
+        if i in range(batch):
+            in_prompt.append(prompt)
+    return in_prompt, all_prompts
+
+
+def create_tt_page_table(global_batch_size, data_parallel, paged_attention_config: PagedAttentionConfig):
+    page_table = None
+
+    if paged_attention_config:
+        # Implied shuffling of blocks
+        permutation = torch.randperm(paged_attention_config.max_num_blocks)
+        # Page table which maps virtual blocks to physical
+        reverse_permutation = torch.argsort(permutation).repeat(data_parallel)
+        page_table = reverse_permutation.reshape(
+            global_batch_size, paged_attention_config.max_num_blocks // (global_batch_size // data_parallel)
+        )
+    return page_table
+
+
+def submesh_has_local_devices(submesh):
+    """Return True if this submesh has at least one device local to the current host rank."""
+    view = submesh.get_view()
+    return any(
+        view.is_local(ttnn.MeshCoordinate(row, col))
+        for row in range(submesh.shape[0])
+        for col in range(submesh.shape[1])
+    )
+
+
+def get_local_submesh_indices(submesh_devices):
+    """Return indices of submeshes that own at least one local device on this host rank."""
+    return [i for i, submesh in enumerate(submesh_devices) if submesh_has_local_devices(submesh)]
+
+
+def select_local_data_parallel_items(items, batch_size, data_parallel, local_submesh_indices):
+    """Select the per-DP-group slices corresponding to local submeshes."""
+    assert (
+        len(items) >= batch_size * data_parallel
+    ), f"Expected at least {batch_size * data_parallel} items, got {len(items)}"
+    return [item for dp_idx in local_submesh_indices for item in items[dp_idx * batch_size : (dp_idx + 1) * batch_size]]
+
+
+def slice_sampling_params_for_local_submeshes(sampling_params, batch_size, data_parallel, local_submesh_indices):
+    """Slice list-valued sampling params so each host rank keeps only its local DP groups."""
+    result = dict(sampling_params)
+    total_items = batch_size * data_parallel
+
+    for key, value in sampling_params.items():
+        if not isinstance(value, list):
+            continue
+        if len(value) == total_items:
+            result[key] = select_local_data_parallel_items(value, batch_size, data_parallel, local_submesh_indices)
+        elif len(value) == data_parallel:
+            result[key] = [value[i] for i in local_submesh_indices]
+
+    return result
+
+
+def get_default_mesh_device_param():
+    """
+    Select a safe default mesh size for parameterized tests.
+
+    In distributed runs, use the global system mesh size from the mesh graph descriptor
+    instead of len(get_device_ids()), which can reflect host-local visibility.
+    """
+    if ttnn.using_distributed_env():
+        try:
+            return ttnn._ttnn.multi_device.SystemMeshDescriptor().shape().mesh_size()
+        except Exception as e:
+            logger.warning(f"Falling back to local device count for default mesh sizing: {e}")
+    return len(ttnn.get_device_ids())
+
+
+def prepare_generator_args(
+    num_devices,
+    data_parallel,
+    mesh_device,
+    instruct,
+    global_batch_size,
+    optimizations,
+    max_seq_len,
+    page_params,
+    paged_attention,
+    num_layers,
+    use_prefetcher,
+    use_hf_rope,
+    max_generated_tokens=None,
+):
+    all_submesh_devices = create_submeshes(mesh_device, data_parallel)
+    local_submesh_indices = get_local_submesh_indices(all_submesh_devices)
+    submesh_devices = [all_submesh_devices[i] for i in local_submesh_indices]
+
+    if not submesh_devices:
+        raise RuntimeError("No local submeshes available on this host rank for the requested configuration")
+
+    if len(submesh_devices) != len(all_submesh_devices):
+        logger.info(
+            f"Distributed mode detected: using local submeshes {local_submesh_indices} "
+            f"({len(submesh_devices)}/{len(all_submesh_devices)}) on this host rank"
+        )
+
+    state_dict = None
+
+    # Hybrid requires a model per submesh
+    model_args = []
+    model = []
+    tt_kv_cache = []
+
+    paged_attention_config = (
+        PagedAttentionConfig(
+            block_size=page_params["page_block_size"],
+            max_num_blocks=page_params["page_max_num_blocks_per_dp"],
+        )
+        if paged_attention
+        else None
+    )
+
+    max_batch_size_per_dp_group = global_batch_size // data_parallel
+
+    for submesh in submesh_devices:
+        model_args_i, model_i, tt_kv_cache_i, state_dict = create_tt_model(
+            submesh,
+            instruct=instruct,
+            max_batch_size=max_batch_size_per_dp_group,
+            optimizations=optimizations,
+            max_seq_len=max_seq_len,
+            paged_attention_config=paged_attention_config,
+            dtype=ttnn.bfloat8_b,
+            state_dict=state_dict,
+            num_layers=num_layers,
+            use_prefetcher=use_prefetcher,
+            use_hf_rope=use_hf_rope,
+            max_generated_tokens=max_generated_tokens,
+        )
+        model_args.append(model_args_i)
+        model.append(model_i)
+        tt_kv_cache.append(tt_kv_cache_i)
+
+    local_data_parallel = len(submesh_devices)
+    local_batch_size = max_batch_size_per_dp_group * local_data_parallel
+    page_table = create_tt_page_table(
+        global_batch_size=local_batch_size,
+        data_parallel=local_data_parallel,
+        paged_attention_config=paged_attention_config,
+    )
+    # Host code, safe to reuse tokenizer from the 1st model
+    tokenizer = model_args[
+        0
+    ].tokenizer  # TODO Should we support Data Parallel different models? If so, we need to support multiple tokenizers
+    processor = model_args[0].processor
+    return model_args, model, page_table, tt_kv_cache, tokenizer, processor, local_data_parallel, local_submesh_indices
+
+
+# List of supported Parameters for demo.py
+#
+# input_prompts (string): input json file with prompts to process. See models/tt_transformers/demo/*.json for list of input files
+# instruct (bool): Whether to use instruct weights or general weights
+# repeat_batches (int): Number of consecutive batches of users to run (default: 1)
+# max_seq_len (int): Maximum context length supported by the model (Llama-3.1 and Llama-3.2 models have a maximum context length of 128k, i.e., 128 * 1024)
+# batch_size (int): Number of users in a batch (Supports 1/2/4/8/16/32 batches)
+# max_generated_tokens (int): Maximum number of tokens to generate for each user (Note that the users will stop generation before this limit if they reach a EoS token)
+# paged_attention (bool): Whether to use paged attention or default attention (vLLM requires paged attention)
+# page_params (dict): Page parameters for paged attention (block_size, max_num_blocks) For smaller context lengths use block_size=32 and max_num_blocks=1024, for larger context use block_size=64 and max_num_blocks=2048
+# sampling_params (dict): Sampling parameters for decoding (temperature, top_p). If temperature is set to 0, argmax (greedy decode) is used.
+# stop_at_eos (bool): Whether to stop decoding when the model generates an EoS token
+# ci_only (bool): Whether to run the demo in CI only mode
+# data_parallel (int): Number of data parallel groups to use
+# token_accuracy (bool): Whether to compute token accuracy
+# stress_test (bool): Whether to run the demo in stress test mode
+# enable_trace (bool): Whether to enable tracing
+# num_layers (int): Number of layers to use
+# mode (str): Mode to run the demo in (full, prefill, decode), full will run both prefill and decode
+# optimization (ModelOptimizations): Optimization level to use for the model (performance or accuracy)
+# MESH_DEVICE (str): Fake device to use for testing (N150, N300, T3K, TG). Usage: `export MESH_DEVICE=N150`, will enable running a single-chip demo on a multi-chip system.
+_trace_region_size = (
+    100000000
+    if (is_blackhole() and os.environ.get("HF_MODEL", "").endswith(("Qwen2.5-72B-Instruct", "Qwen2.5-32B-Instruct")))
+    else 50000000
+)
+
+
+_MESH_SHAPES = {
+    "N150": (1, 1),
+    "N300": (1, 2),
+    "N300x1x4": (1, 4),
+    "N300x2x2": (2, 2),
+    "N150x4": (2, 2),
+    "T3K": (1, 8),
+    "TG": (8, 4),
+    "P150": (1, 1),
+    "P300": (1, 2),
+    "P150x4": (1, 4),
+    "P150x8": (1, 8),
+    "BHGLX": (8, 4),
+}
+
+# MESH_DEVICE values that run the model on a submesh of a larger opened mesh: name -> (open, run).
+#
+# Fabric has to own every device in the system: opening a mesh smaller than the machine dies with
+# "Fabric is being used but Device N is not active ... To launch on a subset of devices, first create
+# a MeshDevice of the full system size, then create submeshes accordingly" (device_manager.cpp:436).
+# So a 2-chip run on Boromir (2x N300 = a 2x2 of 4 chips) opens the whole 2x2 and carves a 1x2 out of
+# it. The plain "N300" entry above stays a real 1x2 open, which is what a single-N300 machine wants.
+#
+# Both orientations are here because the two axes are different wires: axis 1 (1x2, two columns)
+# crosses cards over QSFP-DD/WARP100, axis 0 (2x1, two rows) is the intra-card TRACE link.
+_SUBMESH_SHAPES = {
+    "N300x1x2": ((2, 2), (1, 2)),
+    "N300x2x1": ((2, 2), (2, 1)),
+}
+
+# MESH_DEVICE=AUTO hands the shape choice to mesh_selection. Every other MESH_DEVICE value keeps
+# meaning exactly what it meant before.
+#
+# The plan is picked HERE, at import: the fixture opens devices during the test, and the descriptor
+# (TT_MESH_GRAPH_DESC_PATH, read at fabric init), the opened shape, and the fabric config are all
+# fixed by that open. Choosing afterwards would be choosing after they were already frozen. A plan
+# supplies the first two directly; the fabric follows from its open_shape via _fabric_config_for,
+# which is what gets the 1x4 candidate a ring and the 2x2 candidate plain FABRIC_1D.
+_AUTO = "AUTO"
+
+
+def _auto_mesh():
+    return os.environ.get("MESH_DEVICE") == _AUTO
+
+
+def _resolve_mesh_shape_param():
+    """The mesh this run opens, from MESH_DEVICE. A tuple (rows, cols), or an int device count."""
+    if _auto_plan:
+        return _auto_plan.open_shape
+    name = os.environ.get("MESH_DEVICE")
+    if name in _SUBMESH_SHAPES:
+        return _SUBMESH_SHAPES[name][0]
+    return _MESH_SHAPES.get(name, get_default_mesh_device_param())
+
+
+def _resolve_submesh_shape():
+    """The submesh this run carves out of the opened mesh, or None to use the whole thing."""
+    if _auto_plan:
+        return _auto_plan.submesh
+    entry = _SUBMESH_SHAPES.get(os.environ.get("MESH_DEVICE"))
+    return entry[1] if entry else None
+
+
+def _maybe_submesh(mesh_device):
+    """Carve out the submesh this run asked for, if it asked for one.
+
+    Everything downstream (num_devices, cluster_shape, the auto-shard placement search) reads the
+    mesh off this object, so substituting it here is all a smaller run needs. The mesh_device fixture
+    closes submeshes before the parent, so the carved mesh doesn't leak. An auto-mesh plan carves
+    through this same path -- its submesh is just decided at import instead of read off MESH_DEVICE.
+    """
+    shape = _resolve_submesh_shape()
+    if shape is None or not isinstance(mesh_device, ttnn.MeshDevice):
+        return mesh_device
+    submesh = mesh_device.create_submeshes(ttnn.MeshShape(*shape))[0]
+    logger.info(f"Running on a {shape} submesh of the opened {tuple(mesh_device.shape)} mesh")
+    return submesh
+
+
+def _fabric_config_for(shape):
+    """Ring fabric on a line, plain 1D on a genuine 2D mesh -- mirrors toy_problem's fabric_for().
+
+    A line (one dim == 1) closes into a ring, so bring the fabric up as a ring; ccl_topology() then
+    returns Ring off its first branch (the one that actually checks the fabric). A real 2D mesh does
+    not close into a ring on either axis, and ccl_topology() runs Linear collectives there, so a ring
+    fabric would just be a lie.
+
+    Never pass True here: a bool coerces to enum value 1 == FABRIC_1D_NEIGHBOR_EXCHANGE ("1D topology
+    with no forwarding between non-adjacent devices"), so any collective needing a multi-hop route --
+    e.g. a Ring's wrap-around on a mesh whose logical order isn't the physical cycle -- dies with
+    "Could not find any forwarding direction from src ... to dst ...".
+    """
+    # TODO: this should actually check for a wraparound wire, or be something the user can set
+    # An int param is a flat device count, which the fixture opens as a line.
+    is_line = (1 in tuple(shape)) if isinstance(shape, tuple) else True
+    return ttnn.FabricConfig.FABRIC_1D_RING if is_line else ttnn.FabricConfig.FABRIC_1D
+
+
+# Hoisted out of the parametrize decorator so mesh selection can read the workload off the case that
+# is about to run (see _demo_workload) -- the decorator's arguments are evaluated at import, which is
+# also the only moment the mesh is still choosable. Re-applied to test_demo_text below, in its
+# original position relative to the other decorators.
+_DEMO_PARAMS = "input_prompts, instruct, repeat_batches, max_seq_len, batch_size, max_generated_tokens, paged_attention, page_params, sampling_params, stop_at_eos, ci_only, data_parallel, token_accuracy, stress_test, enable_trace, num_layers, mode"
+_DEMO_CASES = [
+        (  # Batch-1 run (Latency) - single user, small prompt
+            "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
+            True,  # instruct mode
+            1,  # repeat_batches
+            1024,  # max_seq_len
+            1,  # batch_size
+            200,  # max_generated_tokens
+            True,  # paged_attention
+            {"page_block_size": 32, "page_max_num_blocks_per_dp": 1024},  # page_params
+            {"temperature": 0, "top_p": 0.08, "top_k": 32},  # sampling_params (argmax)
+            True,  # stop_at_eos
+            False,  # ci_only
+            1,
+            False,  # token_accuracy
+            False,  # stress_test
+            True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
+        ),
+        (  # Batch-32 run (Throughput) - 32 users, small prompt
+            "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
+            True,  # instruct mode
+            1,  # repeat_batches
+            1024,  # max_seq_len
+            32,  # batch_size
+            200,  # max_generated_tokens
+            True,  # paged_attention
+            {"page_block_size": 32, "page_max_num_blocks_per_dp": 1024},  # page_params
+            {
+                "temperature": torch.linspace(0.0, 1.0, steps=32).tolist(),
+                "top_p": torch.linspace(0.08, 1.0, steps=32).tolist(),
+                "top_k": torch.arange(1, 33).tolist(),  # 1 to 32 inclusive
+                "frequency_penalty": torch.linspace(0.0, 1.0, steps=32).tolist(),
+                "presence_penalty": torch.linspace(0.0, 1.0, steps=32).tolist(),
+                "repetition_penalty": torch.linspace(0.0, 1.0, steps=32).tolist(),
+            },  # sampling_params (non-uniform)
+            True,  # stop_at_eos
+            False,  # ci_only
+            1,  # data_parallel
+            False,  # token_accuracy
+            False,  # stress_test
+            True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
+        ),
+        (  # Batch-32 run (Throughput) - 32 users, small prompt with log-probs
+            "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
+            True,  # instruct mode
+            1,  # repeat_batches
+            1024,  # max_seq_len
+            32,  # batch_size
+            200,  # max_generated_tokens
+            True,  # paged_attention
+            {"page_block_size": 32, "page_max_num_blocks_per_dp": 1024},  # page_params
+            {
+                "temperature": torch.linspace(0.0, 1.0, steps=32).tolist(),
+                "top_p": torch.linspace(0.08, 1.0, steps=32).tolist(),
+                "top_k": torch.arange(1, 33).tolist(),  # 1 to 32 inclusive
+                "enable_log_probs": [True] * 32,
+            },  # sampling_params (non-uniform)
+            True,  # stop_at_eos
+            False,  # ci_only
+            1,  # data_parallel
+            False,  # token_accuracy
+            False,  # stress_test
+            True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
+        ),
+        (  # long-context-64k run - Single user, long prompt (may vary based on the model's tokenizer)
+            "models/tt_transformers/demo/sample_prompts/input_data_long_64k.json",  # input_prompts
+            True,  # instruct mode
+            1,  # repeat_batches
+            128 * 1024,  # max_seq_len
+            1,  # batch_size
+            200,  # max_generated_tokens
+            True,  # paged_attention
+            {"page_block_size": 64, "page_max_num_blocks_per_dp": 2048},  # page_params
+            {"temperature": 0, "top_p": 0.08, "top_k": 32},  # sampling_params (argmax)
+            True,  # stop_at_eos
+            False,  # ci_only
+            1,  # data_parallel
+            False,  # token_accuracy
+            False,  # stress_test
+            True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
+        ),
+        (  # Long-context-32k run - Single user, long prompt (may vary based on the model's tokenizer)
+            "models/tt_transformers/demo/sample_prompts/input_data_long_32k.json",  # input_prompts
+            True,  # instruct mode
+            1,  # repeat_batches
+            64 * 1024,  # max_seq_len
+            1,  # batch_size
+            200,  # max_generated_tokens
+            True,  # paged_attention
+            {"page_block_size": 64, "page_max_num_blocks_per_dp": 1024},  # page_params
+            {"temperature": 0, "top_p": 0.08, "top_k": 32},  # sampling_params (argmax)
+            True,  # stop_at_eos
+            False,  # ci_only
+            1,  # data_parallel
+            False,  # token_accuracy
+            False,  # stress_test
+            True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
+        ),
+        (  # Long-context-16k run - Single user, long prompt (may vary based on the model's tokenizer)
+            "models/tt_transformers/demo/sample_prompts/input_data_long_16k.json",  # input_prompts
+            True,  # instruct mode
+            1,  # repeat_batches
+            32 * 1024,  # max_seq_len
+            1,  # batch_size
+            200,  # max_generated_tokens
+            True,  # paged_attention
+            {"page_block_size": 32, "page_max_num_blocks_per_dp": 1024},  # page_params
+            {"temperature": 0, "top_p": 0.08, "top_k": 32},  # sampling_params (argmax)
+            True,  # stop_at_eos
+            False,  # ci_only
+            1,  # data_parallel
+            False,  # token_accuracy
+            False,  # stress_test
+            True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
+        ),
+        (  # reasoning-1 - single user, small prompt, long thinking time
+            "models/tt_transformers/demo/input_data_questions_reasoning.json",  # input_prompts
+            True,  # instruct mode
+            1,  # repeat_batches
+            16 * 1024,  # max_seq_len
+            1,  # batch_size
+            15000,  # max_generated_tokens
+            True,  # paged_attention
+            {
+                "page_block_size": 32,
+                "page_max_num_blocks_per_dp": 1024,
+            },  # page_params  # TODO This will be serviced by vLLM
+            {"temperature": 0, "top_p": 0.08, "top_k": 32},  # sampling_params (argmax)
+            False,  # stop_at_eos
+            False,  # ci_only
+            1,  # data_parallel
+            False,  # token_accuracy
+            False,  # stress_test
+            True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
+        ),
+        (  # ci-1 [CI-only] - Measures the performance of a single user over 4096 iterations
+            "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
+            True,  # instruct mode
+            1,  # repeat_batches
+            8192,  # max_seq_len
+            1,  # batch_size
+            4096,  # max_generated_tokens
+            True,  # paged_attention
+            {"page_block_size": 32, "page_max_num_blocks_per_dp": 1024},  # page_params
+            {"temperature": 0, "top_p": 0.08, "top_k": 32},  # sampling_params (argmax)
+            False,  # stop_at_eos
+            True,  # ci_only
+            1,  # data_parallel
+            False,  # token_accuracy
+            False,  # stress_test
+            True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
+        ),
+        (  # ci-32 [CI-only] - Measures the performance of 32 users over 4096 iterations
+            "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
+            True,  # instruct mode
+            1,  # repeat_batches
+            2048,  # max_seq_len
+            32,  # batch_size
+            1024,  # max_generated_tokens  # TODO Update this to 4096, and make sure it fits in DRAM with correct page_params
+            True,  # paged_attention  # TODO Find the correct paged_attn params to avoid hangs in this config with long context generation
+            {"page_block_size": 64, "page_max_num_blocks_per_dp": 1024},  # page_params
+            {"temperature": 0, "top_p": 0.08, "top_k": 32},  # sampling_params (argmax)
+            False,  # stop_at_eos
+            True,  # ci_only
+            1,  # data_parallel
+            False,  # token_accuracy
+            False,  # stress_test
+            True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
+        ),
+        (  # DP-4-b1 - single user, data-parallel=4, small prompt
+            "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
+            True,  # instruct mode
+            1,  # repeat_batches
+            1024,  # max_seq_len
+            1,  # batch_size
+            200,  # max_generated_tokens
+            True,  # paged_attention
+            {"page_block_size": 32, "page_max_num_blocks_per_dp": 1024},  # page_params
+            {"temperature": 0, "top_p": 0.08, "top_k": 32},  # sampling_params (argmax)
+            True,  # stop_at_eos
+            False,  # ci_only
+            4,  # data_parallel
+            False,  # token_accuracy
+            False,  # stress_test
+            True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
+        ),
+        (  # DP-8-b1 - single user, data-parallel=8, small prompt
+            "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
+            True,  # instruct mode
+            1,  # repeat_batches
+            1024,  # max_seq_len
+            1,  # batch_size
+            200,  # max_generated_tokens
+            True,  # paged_attention
+            {"page_block_size": 32, "page_max_num_blocks_per_dp": 1024},  # page_params
+            {"temperature": 0, "top_p": 0.08, "top_k": 32},  # sampling_params (argmax)
+            True,  # stop_at_eos
+            False,  # ci_only
+            8,  # data_parallel
+            False,  # token_accuracy
+            False,  # stress_test
+            True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
+        ),
+        (  # DP-4-b32 - 32 users, data-parallel=4, small prompt
+            "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
+            True,  # instruct mode
+            1,  # repeat_batches
+            1024,  # max_seq_len
+            32,  # batch_size
+            200,  # max_generated_tokens
+            True,  # paged_attention
+            {"page_block_size": 32, "page_max_num_blocks_per_dp": 1024},  # page_params
+            {"temperature": 0, "top_p": 0.08, "top_k": 32},  # sampling_params (argmax)
+            True,  # stop_at_eos
+            False,  # ci_only
+            4,  # data_parallel
+            False,  # token_accuracy
+            False,  # stress_test
+            True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
+        ),
+        (  # ci-b1-DP-4 [CI-Only] - single user, data-parallel=4, small prompt
+            "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
+            True,  # instruct mode
+            1,  # repeat_batches
+            4096,  # max_seq_len
+            1,  # batch_size
+            2048,  # max_generated_tokens
+            True,  # paged_attention
+            {"page_block_size": 32, "page_max_num_blocks_per_dp": 1024},  # page_params
+            {"temperature": 0, "top_p": 0.08, "top_k": 32},  # sampling_params (argmax)
+            False,  # stop_at_eos
+            True,  # ci_only
+            4,  # data_parallel
+            False,  # token_accuracy
+            False,  # stress_test
+            True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
+        ),
+        (  # ci-b1-DP-8 [CI-Only] - single user, data-parallel=8, small prompt
+            "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
+            True,  # instruct mode
+            1,  # repeat_batches
+            4096,  # max_seq_len
+            1,  # batch_size
+            2048,  # max_generated_tokens
+            True,  # paged_attention
+            {"page_block_size": 32, "page_max_num_blocks_per_dp": 1024},  # page_params
+            {"temperature": 0, "top_p": 0.08, "top_k": 32},  # sampling_params (argmax)
+            False,  # stop_at_eos
+            True,  # ci_only
+            8,  # data_parallel
+            False,  # token_accuracy
+            False,  # stress_test
+            True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
+        ),
+        (  # ci-b1-DP-16 [CI-Only] - single user, data-parallel=16, small prompt
+            "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
+            True,  # instruct mode
+            1,  # repeat_batches
+            1024,  # max_seq_len
+            1,  # batch_size
+            200,  # max_generated_tokens
+            True,  # paged_attention
+            {"page_block_size": 32, "page_max_num_blocks_per_dp": 1024},  # page_params
+            {"temperature": 0, "top_p": 0.08, "top_k": 32},  # sampling_params (argmax)
+            True,  # stop_at_eos
+            True,  # ci_only
+            16,  # data_parallel
+            False,  # token_accuracy
+            False,  # stress_test
+            True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
+        ),
+        (  # ci-b1-DP-32 [CI-Only] - single user, data-parallel=32, small prompt
+            "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
+            True,  # instruct mode
+            1,  # repeat_batches
+            1024,  # max_seq_len
+            1,  # batch_size
+            200,  # max_generated_tokens
+            True,  # paged_attention
+            {"page_block_size": 32, "page_max_num_blocks_per_dp": 1024},  # page_params
+            {"temperature": 0, "top_p": 0.08, "top_k": 32},  # sampling_params (argmax)
+            True,  # stop_at_eos
+            True,  # ci_only
+            32,  # data_parallel
+            False,  # token_accuracy
+            False,  # stress_test
+            True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
+        ),
+        (  # ci-stress-1 [CI-only] stress test - Runs a short prefill (128) and loops the same iteration over 20000 times
+            "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
+            True,  # instruct mode
+            1,  # repeat_batches
+            128 * 1024,  # max_seq_len
+            1,  # batch_size
+            20000,  # max_generated_tokens
+            True,  # paged_attention
+            {"page_block_size": 64, "page_max_num_blocks_per_dp": 2048},  # page_params
+            {"temperature": 0, "top_p": 0.08, "top_k": 32},  # sampling_params (argmax)
+            False,  # stop_at_eos
+            True,  # ci_only
+            1,  # data_parallel
+            False,  # token_accuracy
+            True,  # stress_test
+            True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
+        ),
+        (  # ci-token-matching run - Measures token matching accuracy of a single user over 500 iterations
+            "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
+            False,  # instruct mode
+            1,  # repeat_batches
+            1024,  # max_seq_len
+            1,  # batch_size
+            500,  # max_generated_tokens
+            True,  # paged_attention
+            {"page_block_size": 32, "page_max_num_blocks_per_dp": 1024},  # page_params
+            {"temperature": 0, "top_p": 0.08, "top_k": 32},  # sampling_params (argmax)
+            True,  # stop_at_eos
+            True,  # ci_only
+            1,  # data_parallel
+            True,  # token_accuracy
+            False,  # stress_test
+            False,  # enable_trace -> Teacher forcing does not work if it is on
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
+        ),
+        (  # ci-eval-1 - 6 repeat batches with output comparison
+            "models/tt_transformers/demo/sample_prompts/eval_repeat_prompts_batch1.json",  # input_prompts
+            True,  # instruct mode
+            6,  # repeat_batches
+            1024,  # max_seq_len
+            1,  # batch_size
+            200,  # max_generated_tokens
+            True,  # paged_attention
+            {"page_block_size": 32, "page_max_num_blocks_per_dp": 1024},  # page_params
+            {"temperature": 0, "top_p": 0.08, "top_k": 32},  # sampling_params (argmax)
+            True,  # stop_at_eos
+            True,  # ci_only
+            1,  # data_parallel
+            False,  # token_accuracy
+            False,  # stress_test
+            True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
+        ),
+        (  # ci-eval-32 - 32 users with 3 repeat batches and shifting prompts
+            "models/tt_transformers/demo/sample_prompts/eval_repeat_prompts_batch32.json",  # input_prompts
+            True,  # instruct mode
+            3,  # repeat_batches
+            1024,  # max_seq_len
+            32,  # batch_size
+            200,  # max_generated_tokens
+            True,  # paged_attention
+            {"page_block_size": 32, "page_max_num_blocks_per_dp": 1024},  # page_params
+            {"temperature": 0, "top_p": 0.08, "top_k": 32},  # sampling_params (argmax)
+            True,  # stop_at_eos
+            True,  # ci_only
+            1,  # data_parallel
+            False,  # token_accuracy
+            False,  # stress_test
+            True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
+        ),
+        (  # [CI only] Long-context-16k run - Single user, long prompt (may vary based on the model's tokenizer)
+            "models/tt_transformers/demo/sample_prompts/input_data_long_16k.json",  # input_prompts
+            True,  # instruct mode
+            1,  # repeat_batches
+            32 * 1024,  # max_seq_len
+            1,  # batch_size
+            200,  # max_generated_tokens
+            True,  # paged_attention
+            {"page_block_size": 32, "page_max_num_blocks_per_dp": 1024},  # page_params
+            {"temperature": 0, "top_p": 0.08, "top_k": 32},  # sampling_params (argmax)
+            True,  # stop_at_eos
+            True,  # ci_only
+            1,  # data_parallel
+            False,  # token_accuracy
+            False,  # stress_test
+            True,  # enable_trace
+            None,  # num_layers, if None -> defaults to all layers
+            "full",  # performs both prefill and decode
+        ),
+        (  # device-perf - Measures device performance of a prefill or decode run (by default runs prefill but test_device_perf uses args to override defaults)
+            "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
+            False,  # instruct mode
+            1,  # repeat_batches
+            1024,  # max_seq_len
+            1,  # batch_size
+            2,  # max_generated_tokens
+            True,  # paged_attention
+            {"page_block_size": 32, "page_max_num_blocks_per_dp": 1024},  # page_params
+            {"temperature": 0, "top_p": 0.08, "top_k": 32},  # sampling_params (argmax)
+            True,  # stop_at_eos
+            True,  # ci_only
+            1,  # data_parallel
+            False,  # token_accuracy
+            False,  # stress_test
+            True,  # enable_trace
+            10,  # num_layers, if None -> defaults to all layers
+            "prefill",  # mode
+        ),
+]
+_DEMO_IDS = [
+    "batch-1",  # latency
+    "batch-32",  # throughput
+    "batch-32-log-probs",  # throughput with log-probs
+    "long-context-64k",  # 64k context, max_seq_len=128k
+    "long-context-32k",  # 32k context, max_seq_len=32k
+    "long-context-16k",  # 16k context, max_seq_len=32k
+    "reasoning-1",  # reasoning
+    "ci-1",  # CI batch 1
+    "ci-32",  # CI batch 32
+    "DP-4-b1",  # DP 4 latency
+    "DP-8-b1",  # DP 8 latency
+    "DP-4-b32",  # DP 4 throughput
+    "ci-b1-DP-4",  # CI DP 4 batch 1
+    "ci-b1-DP-8",  # CI DP 8 batch 1
+    "ci-b1-DP-16",  # CI DP 16 batch 1
+    "ci-b1-DP-32",  # CI DP 32 batch 1
+    "ci-stress-1",  # CI Stress test batch-1
+    "ci-token-matching",  # CI performs token accuracy matching with reference procomputed tokens
+    "ci-eval-1",  # CI 6 repeat batches with output comparison
+    "ci-eval-32",  # CI batch 32 with 3 repeat batches and output comparison
+    "ci-long-context-16k",  # 16k context, max_seq_len=32k, used for testing --max_seq_len=16k override
+    "device-perf",  # Device perf
+]
+
+
+def _case_value(case, name):
+    """One field of a _DEMO_CASES tuple, by its name in _DEMO_PARAMS (the file warns that the
+    parameter order is load-bearing, so read by name rather than by index)."""
+    return case[[p.strip() for p in _DEMO_PARAMS.split(",")].index(name)]
+
+
+def _cli_int(flag):
+    """`--flag=N` or `--flag N` off the pytest command line, or None.
+
+    The demo's own conftest defines --max_seq_len/--max_generated_tokens and the test applies them
+    over the case's values; mesh selection runs before pytest parses argv, so read them the hard way.
+    """
+    for i, arg in enumerate(sys.argv):
+        if arg == flag and i + 1 < len(sys.argv):
+            return int(sys.argv[i + 1])
+        if arg.startswith(f"{flag}="):
+            return int(arg.split("=", 1)[1])
+    return None
+
+
+def _demo_workload():
+    """(prefill_len, decode_steps) for the case about to run, for the mesh cost model.
+
+    The mesh has to be chosen at import, but which case runs is decided later by -k, so infer it: an
+    id that appears in the -k expression is a case pytest will select. Only a unique match is
+    usable -- one mesh is opened for the whole session, so if -k selects several cases with different
+    workloads there is no single right answer and the params.py defaults (None) are the honest reply.
+
+    Returns None to mean "use the defaults", which is also what a non-auto run gets.
+    """
+    kexpr = next((sys.argv[i + 1] for i, a in enumerate(sys.argv) if a == "-k" and i + 1 < len(sys.argv)), "")
+    # -k selects a case when one of its terms is a SUBSTRING of the id, not when the id appears in
+    # -k: `-k batch-32` runs "batch-32" and "batch-32-log-probs" both, and is therefore ambiguous.
+    # Terms naming another parametrize axis ("performance") simply match no id and drop out.
+    terms = [t for t in re.split(r"[\s()]+", kexpr) if t and t not in ("and", "or", "not")]
+    matched = [i for i, name in enumerate(_DEMO_IDS) if any(t in name for t in terms)]
+    if len(matched) != 1:
+        logger.warning(
+            f"auto-mesh: -k {kexpr!r} matches {len(matched)} demo cases, cannot tell which workload to "
+            f"size the mesh for; falling back to the params.py default"
+        )
+        return None
+    case = _DEMO_CASES[matched[0]]
+    max_seq_len = _cli_int("--max_seq_len") or _case_value(case, "max_seq_len")
+    max_generated_tokens = _cli_int("--max_generated_tokens") or _case_value(case, "max_generated_tokens")
+    # Reuse sharding's convention (largest prompt that fits, then that many decodes) rather than
+    # restating it -- it only reads these two attributes off whatever it is handed.
+    workload = workload_from_config(SimpleNamespace(max_seq_len=max_seq_len, max_generated_tokens=max_generated_tokens))
+    logger.info(f"auto-mesh: sizing for demo case {_DEMO_IDS[matched[0]]!r} -> prefill_len={workload[0]}, decode_steps={workload[1]}")
+    return workload
+
+
+# Import-time, and it has to stay that way -- see the _AUTO note above. Also sets
+# TT_MESH_GRAPH_DESC_PATH. Down here rather than beside _auto_mesh because _demo_workload needs
+# _DEMO_CASES, and the decorators that consume _mesh_shape_param are all below this point.
+_auto_plan = select_mesh_plan(_demo_workload()) if _auto_mesh() else None
+_mesh_shape_param = _resolve_mesh_shape_param()
+
+
+@pytest.mark.parametrize(_DEMO_PARAMS, _DEMO_CASES, ids=_DEMO_IDS)
+# NOTE: Please do not add new pytest parameters between optimizations and the demo parameters above, certain tests ids depend on the order of the parameters.
+@pytest.mark.parametrize(
+    "optimizations",
+    [
+        lambda model_args: DecodersPrecision.performance(model_args.n_layers, model_args.model_name),
+        lambda model_args: DecodersPrecision.accuracy(model_args.n_layers, model_args.model_name),
+    ],
+    ids=["performance", "accuracy"],
+)
+@pytest.mark.parametrize(
+    "use_prefetcher",
+    ([False]),
+)
+@pytest.mark.parametrize(
+    "device_params",
+    # RELAXED_INIT because STRICT auto-discovery can't map Boromir's 2xN300 (see toy_problem/utils.py).
+    [
+        {
+            "fabric_config": _fabric_config_for(_mesh_shape_param),
+            "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
+            "trace_region_size": _trace_region_size,
+            "num_command_queues": 1,
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "mesh_device",
+    [_mesh_shape_param],
+    indirect=True,
+)
+def test_demo_text(
+    input_prompts,
+    instruct,
+    repeat_batches,
+    max_seq_len,
+    batch_size,
+    max_generated_tokens,
+    paged_attention,
+    page_params,
+    sampling_params,
+    optimizations,
+    stop_at_eos,
+    mesh_device,
+    is_ci_env,
+    is_ci_v2_env,
+    ci_only,
+    data_parallel,
+    reset_seeds,
+    request,
+    token_accuracy,
+    stress_test,
+    enable_trace,
+    model_location_generator,
+    num_layers,
+    mode,
+    use_prefetcher,
+):
+    """
+    Simple demo with limited dependence on reference code.
+    """
+    hf_dir = os.getenv("HF_MODEL", "")
+    mesh_device = _maybe_submesh(mesh_device)
+    num_devices = mesh_device.get_num_devices() if isinstance(mesh_device, ttnn.MeshDevice) else 1
+
+    test_id = request.node.callspec.id
+    if is_ci_env:
+        if not ci_only:
+            pytest.skip("CI only runs the CI-only tests")
+        if "accuracy" in test_id and "ci-token-matching" not in test_id:
+            pytest.skip("CI only runs the tests with performance optimizations except for ci-token-matching case")
+
+    # TODO: Remove this once all batch sizes are supported on TG
+    if os.environ.get("MESH_DEVICE") == "TG" and batch_size not in [1, 32]:
+        pytest.skip("TG only supports batch 1 and 32")
+
+    print_to_file = False  # Enable this flag to print the output of all users to a file
+
+    # Override parameters from command line if they are provided
+    input_prompts = request.config.getoption("--input_prompts") or input_prompts
+    if request.config.getoption("--instruct") in [
+        0,
+        1,
+    ]:  # If the flag is provided, use it. Take an int instead of bool due to parser limitations
+        instruct = request.config.getoption("--instruct")
+    repeat_batches = request.config.getoption("--repeat_batches") or repeat_batches
+    max_seq_len = request.config.getoption("--max_seq_len") or max_seq_len
+    batch_size = request.config.getoption("--batch_size") or batch_size
+    max_generated_tokens = request.config.getoption("--max_generated_tokens") or max_generated_tokens
+    data_parallel = request.config.getoption("--data_parallel") or data_parallel
+    paged_attention = request.config.getoption("--paged_attention") or paged_attention
+    page_params = request.config.getoption("--page_params") or page_params
+    if isinstance(page_params, str):  # Required for proper load of a dictionary from the override command
+        page_params = json.loads(page_params)
+    sampling_params = request.config.getoption("--sampling_params") or sampling_params
+    json_config_file = request.config.getoption("--decoder_config_file")
+    token_accuracy = request.config.getoption("--token_accuracy") or token_accuracy
+    stress_test = request.config.getoption("--stress_test") or stress_test
+    arg_enable_trace = request.config.getoption("--enable_trace")
+    if arg_enable_trace is not None:
+        enable_trace = arg_enable_trace
+    num_layers = request.config.getoption("--num_layers") or num_layers
+    mode = request.config.getoption("--mode") or mode
+    use_prefetcher = request.config.getoption("--use_prefetcher") or use_prefetcher
+    if use_prefetcher and not is_blackhole():
+        logger.warning("--use_prefetcher requested but DRAM prefetcher is only supported on Blackhole; disabling.")
+        use_prefetcher = False
+    use_prefetcher = (
+        use_prefetcher and is_prefetcher_supported(hf_dir, num_devices) and "Llama" in hf_dir and "8B" in hf_dir
+    )
+    global_batch_size = batch_size * data_parallel  # input batch_size is interpreted as size per DP group
+    use_hf_rope = request.config.getoption("--use_hf_rope")
+    is_device_perf_test = "device-perf" in test_id
+
+    if stress_test and token_accuracy:
+        pytest.skip("Stress test cannot be run with token accuracy mode")
+
+    if json_config_file:
+        optimizations = parse_decoder_json(json_config_file)
+    else:
+        optimizations = request.config.getoption("--optimizations") or optimizations
+
+    if request.config.getoption("--stop_at_eos") in [
+        0,
+        1,
+    ]:  # If the flag is provided, use it. Take an int instead of bool due to parser limitations
+        stop_at_eos = request.config.getoption("--stop_at_eos")
+
+    if "phi-3-mini-128k-instruct" in hf_dir.lower():
+        max_context_supported = 32 * 1024 * num_devices
+        # This condition is present since Phi3 mini has a limit of context length 32k for N150
+        # It makes sure neither the total_page_cache nor the max_seq_length exceeds this limit.
+        if (max_context_supported < max_seq_len) or (
+            max_context_supported < page_params["page_block_size"] * page_params["page_max_num_blocks_per_dp"]
+        ):
+            pytest.skip(
+                f"Max sequence length: {max_seq_len} for batch: {batch_size} not supported for model: {hf_dir} on device: {mesh_device}"
+            )
+
+    # uneven split of devices per DP group not supported
+    if data_parallel > num_devices or num_devices % data_parallel != 0:
+        pytest.skip(f"Invalid number of DP groups: {data_parallel}, for {num_devices} devices")
+
+    if is_ci_env:
+        hf_model = os.getenv("HF_MODEL", "")
+        is_33_70b = "3.3-70B" in hf_model
+        is_32_1b = "3.2-1B" in hf_model
+        is_31_8b = "3.1-8B" in hf_model
+
+        tg_enabled = (data_parallel == 4 and is_33_70b) or (data_parallel in [4, 16, 32] and is_31_8b)
+
+        if num_devices == 32 and not tg_enabled:
+            pytest.skip("CI only runs Llama3 70b DP = 4, TP = 8 or Llama3 8b DP = 4/16/32, TP = 8/2/1 on TG")
+        if num_devices == 8 and data_parallel > 1 and not (is_32_1b or is_31_8b) and is_wormhole_b0():
+            pytest.skip("CI only runs hybrid Llama3 1b and 8b on T3K")
+
+    if is_ci_v2_env:
+        hf_model = os.getenv("HF_MODEL", "")
+        model_location = model_location_generator(hf_model, download_if_ci_v2=True, ci_v2_timeout_in_s=900)
+        # update env var HF_MODEL to the model location
+        os.environ["HF_MODEL"] = str(model_location)
+
+    if not stop_at_eos:
+        logger.info(f"The decode generation will only stop at the max_generated_tokens limit == {max_generated_tokens}")
+
+    if print_to_file:
+        # Creat batch output file
+        timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        output_directory = "models/tt_transformers/demo/output"
+        os.makedirs(output_directory, exist_ok=True)
+        os.chmod(output_directory, 0o755)
+        output_filename = f"{output_directory}/llama_text_demo_output_{timestamp}.txt"
+
+    # Start profiler
+    logger.info(f"Start profiler")
+    profiler = BenchmarkProfiler()
+    profiler.start("run")
+
+    logger.info(f"Reading inputs...")
+    profiler.start("loading_inputs")
+    if len(input_prompts) == 1:  # Manual input
+        input_prompts = input_prompts * global_batch_size
+        all_prompts = input_prompts
+    else:  # Inputs from file
+        input_prompts, all_prompts = load_inputs(input_prompts, global_batch_size, instruct)
+    profiler.end("loading_inputs")
+    # To simulate a deployment environment, the demo supports repeating batched prompts.
+    # This loop will rotate the prompts between the users for each batch, to simulate users sending different requests
+    # If batch_size=1, the same prompt is repeated for each batch
+
+    (
+        model_args,
+        model,
+        page_table,
+        tt_kv_cache,
+        tokenizer,
+        processor,
+        local_data_parallel,
+        local_submesh_indices,
+    ) = prepare_generator_args(
+        num_devices=num_devices,
+        data_parallel=data_parallel,
+        mesh_device=mesh_device,
+        instruct=instruct,
+        global_batch_size=global_batch_size,
+        optimizations=optimizations,
+        max_seq_len=max_seq_len,
+        page_params=page_params,
+        paged_attention=paged_attention,
+        num_layers=num_layers,
+        use_prefetcher=use_prefetcher,
+        use_hf_rope=use_hf_rope,
+        max_generated_tokens=max_generated_tokens,
+    )
+
+    global_batch_size = batch_size * local_data_parallel
+    input_prompts = select_local_data_parallel_items(input_prompts, batch_size, data_parallel, local_submesh_indices)
+    sampling_params = slice_sampling_params_for_local_submeshes(
+        sampling_params, batch_size, data_parallel, local_submesh_indices
+    )
+
+    # Skip ci-eval tests on P100 devices
+    if ("ci-eval-1" in test_id or "ci-eval-32" in test_id) and model_args[0].device_name == "P100":
+        pytest.skip("ci-eval-1 and ci-eval-32 tests are not supported on P100 devices")
+
+    if token_accuracy:
+        token_acc = TokenAccuracy(model_name=model_args[0].model_name)
+
+    for m_args in model_args:
+        if m_args.max_context_len < max_seq_len:
+            pytest.skip(
+                f"Max seq len {max_seq_len} not supported by model {m_args.model_name}. The model's max context len is {m_args.max_context_len}"
+            )
+
+    generator = Generator(model, model_args, mesh_device, processor=processor, tokenizer=tokenizer)
+
+    if token_accuracy:
+        input_prompts[0] = token_acc.prepare_ref_tokens(tokenizer)
+
+    repeat_batch_prompts = []
+    for i in range(repeat_batches):
+        # For token accuracy, use input_prompts without rotation
+        if token_accuracy:
+            repeat_batch_prompts.append(input_prompts)
+        else:
+            global_prompts_for_batch = [all_prompts[(j + i) % len(all_prompts)] for j in range(len(all_prompts))][
+                : batch_size * data_parallel
+            ]
+            repeat_batch_prompts.append(
+                select_local_data_parallel_items(
+                    global_prompts_for_batch, batch_size, data_parallel, local_submesh_indices
+                )
+            )
+
+    num_tokens_generated_decode = []
+
+    logger.info("Starting inference...")
+    for batch_idx, input_prompts in enumerate(repeat_batch_prompts):
+        logger.info(f"Processing batch {batch_idx}")
+        profiler.start(f"preprocess_prefill_inputs", iteration=batch_idx)
+        # Preprocess initial prompt inputs
+        (
+            input_tokens_prefill_pt,
+            encoded_prompts,
+            decoding_pos,
+            prefill_lens,
+        ) = preprocess_inputs_prefill(
+            input_prompts, tokenizer, model_args, instruct, max_generated_tokens, max_prefill_len=max_seq_len
+        )
+
+        max_encoded_prompt_len = max(len(p) for p in encoded_prompts)
+        assert (
+            max_generated_tokens + max_encoded_prompt_len <= max_seq_len
+        ), f"Prompt prefill tokens ({max_encoded_prompt_len}) + maximum number of decoded iterations ({max_generated_tokens}) needs to be <= than max_seq_len ({max_seq_len})"
+
+        if paged_attention:
+            paged_cache_max_seq_len = (
+                page_params["page_block_size"] * page_params["page_max_num_blocks_per_dp"] / batch_size
+            )
+            assert (
+                max_generated_tokens + max_encoded_prompt_len <= paged_cache_max_seq_len
+            ), f"max_generated_tokens ({max_generated_tokens}) needs to be <= than paged_cache_max_seq_len ({paged_cache_max_seq_len})"
+        profiler.end(f"preprocess_prefill_inputs", iteration=batch_idx)
+
+        # when doing repeating batches, set kv-caches to zero, to avoid context leaking
+
+        if batch_idx != 0:
+            for i in range(len(model)):
+                for layer in model[i].layers:
+                    k_cache, v_cache = layer.attention.layer_past
+                    k_cache = ttnn.mul(k_cache, 0, output_tensor=k_cache)
+                    v_cache = ttnn.mul(v_cache, 0, output_tensor=v_cache)
+            generator.prev_page_table = None
+
+        input_tokens_prefill_pt = torch.stack(input_tokens_prefill_pt).view(global_batch_size, -1)
+        # Use device sampling for all cases when supported (prefill + decode)
+        device_sampling_params = (
+            SamplingParams(
+                temperature=sampling_params["temperature"],
+                top_k=sampling_params["top_k"],
+                top_p=sampling_params["top_p"],
+                seed=sampling_params["seed"] if "seed" in sampling_params else None,
+                frequency_penalty=sampling_params["frequency_penalty"]
+                if "frequency_penalty" in sampling_params
+                else 0.0,
+                presence_penalty=sampling_params["presence_penalty"] if "presence_penalty" in sampling_params else 0.0,
+                repetition_penalty=sampling_params["repetition_penalty"]
+                if "repetition_penalty" in sampling_params
+                else 1.0,
+                enable_log_probs=sampling_params["enable_log_probs"]
+                if "enable_log_probs" in sampling_params
+                else False,
+            )
+            if model[0]._supports_on_device_sampling
+            else None
+        )
+
+        # Override the sampling params for some models
+        # Issue: https://github.com/tenstorrent/tt-metal/issues/34763
+        if model_args[0].base_model_name in models_not_supported_for_device_sampling:
+            device_sampling_params = None
+
+        if device_sampling_params is None and isinstance(sampling_params["temperature"], List):
+            # host sampling only supports single sample param for all users in a batch
+            sampling_params["temperature"] = sampling_params["temperature"][0]
+            sampling_params["top_p"] = sampling_params["top_p"][0]
+            sampling_params["enable_log_probs"] = sampling_params["enable_log_probs"][0]
+
+        prefill_sampling_params = device_sampling_params if device_sampling_params is not None else None
+
+        if mode == "prefill" or mode == "full":
+            logger.info("Starting prefill warmup...")
+            profiler.start(f"compile_prefill", iteration=batch_idx)
+            logits = generator.prefill_forward_text(
+                input_tokens_prefill_pt,  # Prefill warmup for all users, in case some users have different seqlens than others
+                page_table=page_table,
+                kv_cache=tt_kv_cache,
+                prompt_lens=decoding_pos,
+                sampling_params=prefill_sampling_params,
+                warmup_prefill=not is_device_perf_test,
+                enable_trace=enable_trace,
+            )
+            profiler.end(f"compile_prefill", iteration=batch_idx)
+            logger.info("Finished prefill warmup")
+
+            logger.info(f"Starting prefill...")
+            profiler.start(f"inference_prefill", iteration=batch_idx)
+            prefill_out = generator.prefill_forward_text(
+                input_tokens_prefill_pt,
+                page_table=page_table,
+                kv_cache=tt_kv_cache,
+                prompt_lens=decoding_pos,
+                sampling_params=prefill_sampling_params,
+                warmup_prefill=not is_device_perf_test,
+                enable_trace=enable_trace,
+            )
+            if prefill_sampling_params is not None and isinstance(prefill_out, tuple):
+                prefilled_token, prefill_log_probs = prefill_out
+            else:
+                logits = prefill_out
+                prefilled_token = torch.argmax(logits, dim=-1)
+            profiler.end(f"inference_prefill", iteration=batch_idx)
+            logger.info(f"Prefill finished")
+        else:
+            # CI expects profiler to have these measurement keys so
+            # they must be inserted regardless of whether we run prefill or not
+            profiler.start(f"compile_prefill", iteration=batch_idx)
+            profiler.end(f"compile_prefill", iteration=batch_idx)
+            profiler.start(f"inference_prefill", iteration=batch_idx)
+            profiler.end(f"inference_prefill", iteration=batch_idx)
+            logger.info(f"Skipping prefill forward pass when decode mode is enabled")
+
+            prefilled_token = torch.zeros(global_batch_size, 1, 1)
+
+        # Keep track of generated outputs to print out every iteration
+        all_outputs = [encoded_prompts[b][: prefill_lens[b]] for b in range(global_batch_size)]
+        for user in range(global_batch_size):
+            user_tok = int(prefilled_token[user].item())
+            all_outputs[user].append(user_tok)
+
+        user_done = [False] * global_batch_size  # Keeps track when a user reaches EoD token
+
+        # Initial positions
+        current_pos = torch.tensor([decoding_pos[b] if mode == "full" else 0 for b in range(global_batch_size)])
+
+        # Start decoding
+        iteration = 0
+        users_decoding = True
+
+        out_tok = prefilled_token
+
+        logger.info(f"Starting decode loop...")
+
+        # Log total inference (accounting for compile_decode as well)
+        profiler.start(f"inference_decode", iteration=batch_idx)
+
+        if mode == "prefill":
+            # CI expects profiler to have these measurement keys so
+            # they must be inserted regardless of whether we run decode or not
+            profiler.start(f"compile_decode", iteration=batch_idx)
+            profiler.end(f"compile_decode", iteration=batch_idx)
+            profiler.start(f"inference_decode_time_{1}", iteration=batch_idx)
+            profiler.end(f"inference_decode_time_{1}", iteration=batch_idx)
+            logger.info(f"Skipping decode forward pass when prefill mode is enabled")
+
+        while users_decoding and mode != "prefill":
+            if iteration == 0:  # First iteration also accounts for compile time
+                profiler.start(f"compile_decode", iteration=batch_idx)
+            else:
+                profiler.start(f"inference_decode_time_{iteration}", iteration=batch_idx)
+            # below the collect method also applies teacher forcing which is necessary for exact token matching
+            if token_accuracy:
+                out_tok[0] = token_acc.collect_predicted_tokens(out_tok[0].item())
+
+            # Run decode forward
+            logits, log_probs = generator.decode_forward(
+                out_tok,
+                current_pos,
+                enable_trace=enable_trace,
+                page_table=page_table,
+                kv_cache=tt_kv_cache,
+                reset_batch=(iteration == 0),
+                sampling_params=device_sampling_params,
+                prompt_tokens=input_tokens_prefill_pt,
+                output_tokens=out_tok,
+            )
+
+            # Get the next token
+            if device_sampling_params is not None:
+                out_tok = logits.unsqueeze(1)
+
+            else:
+                # TODO Fix use case with temperature > 0
+                _, out_tok = sample_host(
+                    logits,
+                    temperature=sampling_params["temperature"],
+                    top_p=sampling_params["top_p"],
+                    on_host=True,
+                )
+
+            if iteration == 0:  # First iteration will account the compile time
+                profiler.end(f"compile_decode", iteration=batch_idx)
+                decode_iteration_time = profiler.get_duration("compile_decode", iteration=batch_idx)
+                # Everything so far is prefill plus this JIT-compile step; drop it so the
+                # AUTO_SHARD_PROFILE table reports steady-state decode only.
+                inline_profile.reset()
+            else:
+                profiler.end(f"inference_decode_time_{iteration}", iteration=batch_idx)
+                decode_iteration_time = profiler.get_duration(f"inference_decode_time_{iteration}", iteration=batch_idx)
+
+            # Print perf after every iteration (skip in CI to avoid performance overhead)
+            tokens_per_second_per_user = 1 / decode_iteration_time
+            logger.debug(
+                f"Iteration {iteration}: {1000 * decode_iteration_time:.0f}ms @ {tokens_per_second_per_user:.1f} tok/s/user ({global_batch_size * tokens_per_second_per_user:.1f} tok/s throughput)"
+            )
+
+            if not stress_test:  # During stress test runs we will iterate over the same position for X iterations
+                current_pos += 1
+            # Save output token to print out later
+            for user in range(global_batch_size):
+                user_tok = out_tok[user].item()
+                if (
+                    user_tok not in tokenizer.stop_tokens and user_done[user] == False
+                ):  # Read until an eos token (e.g. <|eot_id|>); create_tokenizer adds stop_tokens to HF tokenizers
+                    all_outputs[user].append(user_tok)
+                else:
+                    if (
+                        stop_at_eos
+                    ):  # For performance gathering in CI, we want to sometimes force decoding for a fixed number of iterations
+                        user_done[user] = True
+                        logger.trace(f"[User {user}] Finished decoding at iteration {iteration}")
+                        if all(user_done):
+                            users_decoding = False
+                    else:
+                        all_outputs[user].append(user_tok)
+
+            # Print out generated outputs for each user at the end of every iteration
+            for user in range(global_batch_size):
+                text = "".join(tokenizer.decode(all_outputs[user]))
+                if len(text) > 100:
+                    text = "..." + text[-97:]
+                text = text.replace("\n", " ")
+                logger.debug("[User {}] {}".format(user, text))
+
+            iteration += 1
+
+            # Upper limit of generated tokens for each user
+            if iteration >= max_generated_tokens:
+                users_decoding = False
+
+        # Final print
+        if not users_decoding:
+            profiler.start(f"log_saving_file", iteration=batch_idx)
+            logger.info("Finished decoding, printing the final outputs...\n")
+            for i, (output, prompt) in enumerate(zip(all_outputs, input_prompts)):
+                text = tokenizer.decode(output)
+                prompt_including_assistant_tags = tokenizer.decode(
+                    model_args[0].encode_prompt(prompt, instruct=instruct)
+                )
+                text_after_prompt = text.replace(prompt_including_assistant_tags, "", 1)
+                if print_to_file:
+                    with open(output_filename, "a") as f:
+                        f.write(f"\nbatch: {batch_idx} user: {i}\nprompt: {prompt} \noutput:\n{text_after_prompt}\n")
+                else:
+                    # Strip leading newlines from output when sent to terminal
+                    short_prompt = (
+                        (prompt[:100] + "\n<long prompt not printed in full>\n" + prompt[-100:])
+                        if len(prompt) > 200
+                        else prompt
+                    )
+                    logger.info(
+                        f"\n==REPEAT BATCH {batch_idx}\n==USER {i} - PROMPT\n{short_prompt} \n==USER {i} - OUTPUT\n{text_after_prompt.strip()}\n"
+                    )
+            profiler.end(f"log_saving_file", iteration=batch_idx)
+
+        num_tokens_generated_decode.append(iteration)  # Save the number of tokens generated for each repeat batch
+
+        # Store outputs for repeat batch tests
+        if "ci-eval-1" in test_id:
+            if not hasattr(test_demo_text, "batch_outputs"):
+                test_demo_text.batch_outputs = []
+            if batch_idx == 0:
+                test_demo_text.batch_outputs = []
+
+            if all_outputs and len(all_outputs) > 0:
+                final_output_text = tokenizer.decode(all_outputs[0])
+                test_demo_text.batch_outputs.append(final_output_text)
+                logger.info(f"Stored output for batch {batch_idx}: {final_output_text[:100]}...")
+
+        if "ci-eval-32" in test_id:
+            if not hasattr(test_demo_text, "batch32_outputs"):
+                test_demo_text.batch32_outputs = []
+            if batch_idx == 0:
+                test_demo_text.batch32_outputs = []
+
+            batch_outputs = []
+            if all_outputs and len(all_outputs) > 0:
+                for user_idx in range(len(all_outputs)):
+                    final_output_text = tokenizer.decode(all_outputs[user_idx])
+                    batch_outputs.append(final_output_text)
+                test_demo_text.batch32_outputs.append(batch_outputs)
+                logger.info(f"Stored outputs for batch {batch_idx}: {len(batch_outputs)} users")
+
+        if token_accuracy:
+            acc = token_acc.compute_accuracy()
+            logger.info(f"=== Top1 and Top5 Token Accuracy ===")
+            logger.info(f" Top1 Accuracy: {acc[0] * 100:.2f}%, Top5 Accuracy: {acc[1] * 100:.2f}%")
+
+        profiler.end(f"inference_decode", iteration=batch_idx)
+
+    # Finish profiling at the end of inference for all repeated batches
+    profiler.end("run")
+
+    # Quick sanity check that the model doesn't produce special tokens=garbage output
+    is_special_tokens_produced = [False] * len(all_outputs)
+    for i, output in enumerate(all_outputs):
+        output = output[len(encoded_prompts[i]) :]
+        is_eos = [token in tokenizer.stop_tokens for token in output]
+        if any(is_eos):
+            output = output[: is_eos.index(True)]
+        is_special_tokens_produced[i] = any(token in tokenizer.all_special_ids for token in output)
+    if any(is_special_tokens_produced):
+        logger.warning(f"{sum(is_special_tokens_produced)}/{len(all_outputs)} users produced special tokens")
+        if is_ci_env:
+            assert False, "model produced special tokens"
+
+    # Prepare profile benchmark metrics for the first repeat batch only
+    compile_prefill_time = profiler.get_duration("compile_prefill") if mode != "decode" else 0
+    compile_decode_time = profiler.get_duration("compile_decode") if mode != "prefill" else 0
+
+    total_inference_prefill_time = profiler.get_duration("inference_prefill") if mode != "decode" else 0
+    total_inference_decode_time = 0
+    for i in range(1, num_tokens_generated_decode[0]):  # Iteration 0 is the compile time
+        total_inference_decode_time += profiler.get_duration(f"inference_decode_time_{i}")
+
+    # Average prefill time for each user
+    avg_time_to_first_token = total_inference_prefill_time / global_batch_size
+
+    # Average decode time per batch iteration
+    avg_decode_iteration_time = (
+        total_inference_decode_time / (num_tokens_generated_decode[0] - 1) if iteration > 1 else 0
+    )
+
+    prefill_tok_s = prefill_lens[0] / total_inference_prefill_time * global_batch_size if mode != "decode" else 0
+    decode_tok_s_user = (
+        (num_tokens_generated_decode[0] - 1) / total_inference_decode_time if mode != "prefill" and iteration > 1 else 0
+    )  # Remove the compile time
+    decode_tok_s = (
+        ((num_tokens_generated_decode[0] - 1) / total_inference_decode_time * global_batch_size)
+        if mode != "prefill" and iteration > 1
+        else 0
+    )  # Remove the compile time
+
+    measurements = {
+        # Required measurements
+        "compile_prefill": compile_prefill_time,
+        "compile_decode": compile_decode_time,
+        "inference_prefill": total_inference_prefill_time,
+        "inference_decode": total_inference_decode_time,
+        "prefill_time_to_token": avg_time_to_first_token,
+        "prefill_t/s": prefill_tok_s,  # tokens/s
+        "decode_t/s/u": decode_tok_s_user,  # tokens/s/u
+        "decode_t/s": decode_tok_s,  # tokens/s
+        # Optional measurements
+        "Total compile time": compile_prefill_time + compile_decode_time,
+        "Full demo runtime": profiler.get_duration("run"),
+    }
+
+    # Decode performance for some specific tokens
+    tok_1_perf = (
+        profiler.get_duration(f"inference_decode_time_{1}") if 1 < num_tokens_generated_decode[0] else 0
+    )  # Iteration 0 is compile time
+    tok_128_perf = profiler.get_duration(f"inference_decode_time_{127}") if 127 < num_tokens_generated_decode[0] else 0
+    tok_1024_perf = (
+        profiler.get_duration(f"inference_decode_time_{1023}") if 1023 < num_tokens_generated_decode[0] else 0
+    )
+    tok_4096_perf = (
+        profiler.get_duration(f"inference_decode_time_{4095}") if 4095 < num_tokens_generated_decode[0] else 0
+    )
+
+    if not stop_at_eos:
+        logger.info(f"Please note that 'stop_at_eos' is disabled. Output repetition is expected.")
+
+    logger.info("")
+    logger.info(f"=== Performance metrics ===")
+    if tok_1_perf > 0:
+        logger.info(
+            f"1st token decode time: {tok_1_perf * 1000:.2f}ms [{round(1 / tok_1_perf, 2)} t/s/u, {round((1 / tok_1_perf) * global_batch_size, 2)} t/s]"
+        )
+    if tok_128_perf > 0:
+        logger.info(
+            f"128th token decode time: {tok_128_perf * 1000:.2f}ms [{round(1 / tok_128_perf, 2)} t/s/u, {round((1 / tok_128_perf) * global_batch_size, 2)} t/s]"
+        )
+    if tok_1024_perf > 0:
+        logger.info(
+            f"1024th token decode time: {tok_1024_perf * 1000:.2f}ms [{round(1 / tok_1024_perf, 2)} t/s/u, {round((1 / tok_1024_perf) * global_batch_size, 2)} t/s]"
+        )
+    if tok_4096_perf > 0:
+        logger.info(
+            f"4096th token decode time: {tok_4096_perf * 1000:.2f}ms [{round(1 / tok_4096_perf, 2)} t/s/u, {round((1 / tok_4096_perf) * global_batch_size, 2)} t/s]"
+        )
+
+    # Print some of the perf metrics
+    logger.info("==")
+    logger.info(f"Prefill compile time: {round(compile_prefill_time, 2)}s")
+    logger.info(f"Decode compile time: {round(compile_decode_time, 2)}s")
+    logger.info("")
+    logger.info(f"Average Time to First Token (TTFT): {round(avg_time_to_first_token * 1000, 2)}ms")
+    logger.info(
+        f"Average speed: {round(avg_decode_iteration_time * 1000, 2)}ms @ {round(decode_tok_s_user, 2)} tok/s/user ({round(decode_tok_s, 2)} tok/s throughput)"
+    )
+
+    # Benchmark targets
+    tt_device_name = determine_device_name(mesh_device)  # submesh device should not decide performance target
+    model_name = model_args[0].base_model_name
+    resolved_perf_targets = resolve_perf_targets(
+        model_name=model_name,
+        sku=tt_device_name,
+        batch_size=global_batch_size,
+        seq_len=max_seq_len,
+    )
+    if not resolved_perf_targets:
+        logger.info(
+            f"Model {model_name} does not have centralized performance targets set for "
+            f"device {tt_device_name}, batch_size={global_batch_size}, seq_len={max_seq_len}"
+        )
+        targets = {}
+    else:
+        targets = {
+            "prefill_t/s": resolved_perf_targets.get("prefill_t/s"),
+            "decode_t/s": resolved_perf_targets.get("decode_t/s"),
+            "decode_t/s/u": resolved_perf_targets.get("decode_t/s/u"),
+        }
+
+    # Save benchmark data for CI dashboard
+    if is_ci_env:
+        # Instead of running warmup iterations, the demo profiles the initial compile iteration
+        bench_n_warmup_iter = {"inference_prefill": 0, "inference_decode": 1}
+        benchmark_data = create_benchmark_data(profiler, measurements, bench_n_warmup_iter, targets)
+
+        # Save the decode performance of every iteration for plotting in superset
+        for i in range(1, num_tokens_generated_decode[0]):
+            benchmark_data.add_measurement(
+                profiler,
+                0,
+                "inference_decode",
+                f"time_to_token_{i}",
+                profiler.get_duration(f"inference_decode_time_{i}") * 1000,
+                step_warm_up_num_iterations=None,
+                target=None,
+            )
+
+        # Also save the avg decode performance for the 128 iterations (excluding the compile time)
+        num_iterations_for_avg = min(128, num_tokens_generated_decode[0])
+        inference_decode_time_first_128 = sum(
+            profiler.get_duration(f"inference_decode_time_{i}") for i in range(1, num_iterations_for_avg)
+        )
+        benchmark_data.add_measurement(
+            profiler,
+            0,
+            "inference_decode",
+            "avg_decode_time_first_128",
+            inference_decode_time_first_128 * 1000 / max(1, num_iterations_for_avg - 1),
+            step_warm_up_num_iterations=None,
+            target=None,
+        )
+        if token_accuracy:
+            benchmark_data.add_measurement(
+                profiler,
+                0,
+                "inference_decode",
+                "top1_token_accuracy",
+                acc[0] * 100,
+                step_warm_up_num_iterations=None,
+                target=None,
+            )
+            benchmark_data.add_measurement(
+                profiler,
+                0,
+                "inference_decode",
+                "top5_token_accuracy",
+                acc[1] * 100,
+                step_warm_up_num_iterations=None,
+                target=None,
+            )
+        benchmark_data.save_partial_run_json(
+            profiler,
+            run_type="demo",
+            ml_model_name=model_name,
+            ml_model_type="llm",
+            device_name=tt_device_name,
+            num_layers=model_args[0].n_layers,
+            batch_size=global_batch_size,
+            config_params={"data_parallel": data_parallel, "tensor_parallel": num_devices // data_parallel},
+            input_sequence_length=max(prefill_lens),
+            output_sequence_length=num_tokens_generated_decode[0],
+        )
+
+        # check measurements against CI performance targets -- for batch size 32
+        if "performance" in test_id and "ci-32" in test_id:
+            logger.info(
+                f"Checking measurements against CI performance targets for batch size 32 of {model_name} on {tt_device_name}"
+            )
+            verify_perf(
+                measurements,
+                expected_measurements={
+                    "prefill_time_to_token": True,
+                    "decode_t/s": True,
+                    "decode_t/s/u": True,
+                },
+                model_name=model_name,
+                sku=tt_device_name,
+                batch_size=global_batch_size,
+                seq_len=max_seq_len,
+            )
+    if token_accuracy:
+        total_top1_acc = math.ceil(acc[0] * 100)
+        total_top5_acc = math.ceil(acc[1] * 100)
+
+        if not json_config_file:
+            # Get accuracy thresholds from centralized model targets unless the config is loaded from json.
+            min_top1_acc, min_top5_acc = get_accuracy_thresholds(model_args[0], seq_len=max(prefill_lens))
+            verify_accuracy(
+                measurements={
+                    "top1_token_accuracy": total_top1_acc,
+                    "top5_token_accuracy": total_top5_acc,
+                },
+                expected_accuracy_metrics={"top1": min_top1_acc, "top5": min_top5_acc},
+            )
+            logger.info("Checks of top-1 and top-5 accuracy against centralized model targets passed")
+
+    if (
+        "ci-eval-1" in test_id
+        and hasattr(test_demo_text, "batch_outputs")
+        and len(test_demo_text.batch_outputs) == repeat_batches
+    ):
+        logger.info("=== Repeat Batch Output Comparison ===")
+
+        # Compare paired batches (A<->A, B<->B, C<->C)
+        comparisons = [(i, i + 1) for i in range(0, repeat_batches, 2)]
+        comparison_names = [f"Batch{i // 2 + 1}<->Batch{i // 2 + 1}" for i in range(0, repeat_batches, 2)]
+
+        all_matches = True
+        for i, (batch1_idx, batch2_idx) in enumerate(comparisons):
+            output1 = test_demo_text.batch_outputs[batch1_idx]
+            output2 = test_demo_text.batch_outputs[batch2_idx]
+
+            if output1 == output2:
+                logger.info(
+                    f"{comparison_names[i]} comparison PASSED: Batches {batch1_idx + 1} and {batch2_idx + 1} outputs match"
+                )
+            else:
+                logger.warning(
+                    f"{comparison_names[i]} comparison FAILED: Batches {batch1_idx + 1} and {batch2_idx + 1} outputs differ"
+                )
+                logger.info(f"  Batch {batch1_idx + 1} output: {output1[:100]}...")
+                logger.info(f"  Batch {batch2_idx + 1} output: {output2[:100]}...")
+                all_matches = False
+
+        assert all_matches, "Repeat batch outputs should be identical"
+
+    if (
+        "ci-eval-32" in test_id
+        and hasattr(test_demo_text, "batch32_outputs")
+        and len(test_demo_text.batch32_outputs) > 1
+    ):
+        logger.info("=== Batch32 Shifting Test Output Comparison ===")
+
+        num_batches = len(test_demo_text.batch32_outputs)
+        num_users = len(test_demo_text.batch32_outputs[0])
+
+        logger.info(f"Comparing {num_batches} batches with {num_users} users each")
+
+        consistency_checks = []
+
+        for batch_idx in range(num_batches - 1):
+            current_batch = test_demo_text.batch32_outputs[batch_idx]
+            next_batch = test_demo_text.batch32_outputs[batch_idx + 1]
+
+            logger.info(f"Comparing batch {batch_idx} vs batch {batch_idx + 1}")
+
+            for user_offset in range(num_users):
+                current_user_idx = (user_offset + 1) % num_users
+                next_user_idx = user_offset
+
+                current_output = current_batch[current_user_idx]
+                next_output = next_batch[next_user_idx]
+
+                expected_prompt_idx = (user_offset + batch_idx + 1) % num_users
+
+                if current_output == next_output:
+                    consistency_checks.append(True)
+                    logger.info(
+                        f"User {current_user_idx} (batch {batch_idx}) matches User {next_user_idx} (batch {batch_idx + 1}) - both used prompt[{expected_prompt_idx}]"
+                    )
+                else:
+                    consistency_checks.append(False)
+                    logger.warning(
+                        f"User {current_user_idx} (batch {batch_idx}) differs from User {next_user_idx} (batch {batch_idx + 1}) - both should use prompt[{expected_prompt_idx}]"
+                    )
+                    logger.info(f"  Batch {batch_idx} User {current_user_idx}: {current_output[:50]}...")
+                    logger.info(f"  Batch {batch_idx + 1} User {next_user_idx}: {next_output[:50]}...")
+
+        all_consistent = all(consistency_checks)
+        failed_checks = sum(1 for check in consistency_checks if not check)
+        total_checks = len(consistency_checks)
+
+        assert (
+            all_consistent
+        ), f"Batch32 repeat batch outputs should be identical - {failed_checks} out of {total_checks} consistency checks failed"

--- a/models/tt_transformers/tt/auto_shard/attention_auto_shard.py
+++ b/models/tt_transformers/tt/auto_shard/attention_auto_shard.py
@@ -1,0 +1,1156 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+
+import torch
+
+import ttnn
+from models.common.lightweightmodule import LightweightModule
+from models.common.rmsnorm import RMSNorm
+from models.common.utility_functions import nearest_32
+from models.tt_transformers.tt.auto_shard.ccl_auto_shard import (
+    all_reduce,
+    core_grid_program_config,
+    log_default_grid,
+    matmul_reduce_scatter,
+)
+from models.tt_transformers.tt.common import Mode
+from models.tt_transformers.tt.model_config import OpGroup, TensorGroup, num_to_corerange
+from models.tt_transformers.tt.auto_shard.cost_model.sharding import (
+    AttentionShapes,
+    MemoryParams,
+    cache_tag,
+    select_sharding,
+    workload_from_config,
+)
+
+
+class Attention(LightweightModule):
+    def __init__(
+        self,
+        mesh_device,
+        tt_ccl,
+        args,
+        state_dict,
+        weight_cache_path,
+        layer_num,
+        dtype,
+        transformation_mats,
+        configuration,
+        paged_attention_config=None,
+        use_paged_kv_cache=False,
+        prefetcher=None,
+        toy=False,
+        auto_shard=None,  # FIXME: auto-sharding
+    ):
+        print("Auto Sharding Attention")
+        super().__init__()
+        self.args = args
+        self.mesh_device = mesh_device
+        self.tt_ccl = tt_ccl
+        self.num_devices = configuration.num_devices
+        self.hidden_size = configuration.dim
+        self.n_heads = configuration.n_heads
+        self.head_dim = configuration.head_dim
+        self.max_seq_len = configuration.max_seq_len
+        self.max_batch_size = configuration.max_batch_size
+        self.n_kv_heads = configuration.n_kv_heads
+        self.paged_attention_config = paged_attention_config
+        self.ccl_dtype = configuration.ccl_dtype
+        self.MAX_QKV_MM_SEQ_LEN = configuration.MAX_QKV_MM_SEQ_LEN
+        self.tile_size = configuration.tile_size
+        self.rms_norm_add_unit_offset = configuration.rms_norm_add_unit_offset
+        self.configuration = configuration
+
+        # FIXME: auto-shard
+        # One sharding descriptor drives the whole module: it fixes the wqkv/wo mesh placements
+        # and the two all-reduce axes, so decode and prefill run a single code path on any mesh.
+        shapes = AttentionShapes(
+            self.n_heads, self.n_kv_heads, self.head_dim, self.hidden_size, configuration.qkv_size
+        )
+        # Rank placements for the real run's workload (prefill = max prompt that fits, decode =
+        # max_generated_tokens), falling back to params.py when the demo didn't plumb it. Drop any
+        # placement whose per-device DRAM footprint (weights + KV cache, all layers) won't fit;
+        # raises a clear OOM error here instead of failing mid-allocation on device.
+        prefill_len, decode_steps = workload_from_config(configuration)
+        self.sharding = select_sharding(
+            self.mesh_device,
+            shapes,
+            tuple(configuration.cluster_shape),
+            memory_params=MemoryParams.from_config(configuration),
+            prefill_len=prefill_len,
+            decode_steps=decode_steps,
+        )
+        
+        
+        self.num_devices_per_group = self.sharding.num_intermediate_shards  # heads split -> n_local_heads
+        self.num_device_groups = self.sharding.num_model_shards            # orthogonal (batch/model) axis
+        self.batch_size_per_device_group = self.max_batch_size      # batch is not split on small meshes
+
+        self.n_local_heads = self.n_heads // self.num_devices_per_group
+        self.n_local_kv_heads = self.n_kv_heads // self.num_devices_per_group
+
+        # The KV-prefill height-shard sizes to the actual local KV heads (from num_intermediate_shards),
+        # not the model_config default's cluster_shape[1] assumption -- so any placement fits, including
+        # full replication (num_intermediate_shards=1, so n_local_kv_heads = n_kv_heads).
+        self.min_kv_prefill_shard_seqlen = (ttnn.TILE_SIZE * 8 * 8) / self.n_local_kv_heads
+
+        self.use_qk_fused = configuration.use_qk_fused
+        self.use_hf_rope = configuration.use_hf_rope
+        self.arch_name = configuration.arch_name
+        self.dtype = dtype
+
+        self.max_seq_len = configuration.max_seq_len
+        self.grid_size = configuration.max_grid_size
+
+        self.compute_kernel_config_hifi2 = configuration.compute_kernel_config_hifi2
+        self.compute_kernel_config_hifi2_fp16 = configuration.compute_kernel_config_hifi2_fp16
+
+        self.compute_kernel_config_hifi4 = configuration.compute_kernel_config_hifi4
+
+        self.transformation_mats = transformation_mats
+        self.is_sliding = (
+            configuration.layer_types[layer_num] == "sliding_attention" if configuration.layer_types else False
+        )
+        self.sliding_window = configuration.sliding_window if self.is_sliding else None
+
+        self.model_config = configuration.get_model_config()
+        self.ccl_topology = configuration.ccl_topology()
+        
+        self.is_multichip = configuration.is_multichip
+
+        # When prefetcher is enabled, use consistent dtypes across all layers to avoid
+        # race conditions caused by different block sizes
+        use_prefetcher = prefetcher is not None
+
+        decoders_optimizations = self.args.decoders_optimizations
+        self.activation_dtype = decoders_optimizations.get_tensor_dtype(
+            decoder_id=layer_num, tensor=TensorGroup.ACTIVATION, prefetcher=use_prefetcher
+        )
+        self.wqkv_dtype = decoders_optimizations.get_tensor_dtype(
+            decoder_id=layer_num, tensor=TensorGroup.WQKV, prefetcher=use_prefetcher
+        )
+        self.wo_dtype = decoders_optimizations.get_tensor_dtype(
+            decoder_id=layer_num, tensor=TensorGroup.WO, prefetcher=use_prefetcher
+        )
+        self.kv_cache_dtype = decoders_optimizations.get_tensor_dtype(
+            decoder_id=layer_num, tensor=TensorGroup.KV_CACHE, prefetcher=use_prefetcher
+        )
+        self.li_qkv_decode_compute_kernel_cfg = decoders_optimizations.get_math_fidelity(
+            decoder_id=layer_num, op=OpGroup.LI_QKV_DECODE, configuration=configuration
+        )
+        self.sdpa_decode_compute_kernel_cfg = decoders_optimizations.get_math_fidelity(
+            decoder_id=layer_num, op=OpGroup.SDPA_DECODE, configuration=configuration
+        )
+        self.li_o_decode_compute_kernel_cfg = decoders_optimizations.get_math_fidelity(
+            decoder_id=layer_num, op=OpGroup.LI_O_DECODE, configuration=configuration
+        )
+        self.sdpa_prefill_compute_kernel_cfg = decoders_optimizations.get_math_fidelity(
+            decoder_id=layer_num, op=OpGroup.SDPA_PREFILL, configuration=configuration
+        )
+        self.li_qkv_prefill_compute_kernel_cfg = decoders_optimizations.get_math_fidelity(
+            decoder_id=layer_num, op=OpGroup.LI_QKV_PREFILL, configuration=configuration
+        )
+        self.li_o_prefill_compute_kernel_cfg = decoders_optimizations.get_math_fidelity(
+            decoder_id=layer_num, op=OpGroup.LI_O_PREFILL, configuration=configuration
+        )
+
+        layer_name = configuration.get_state_dict_prefix(self.__class__.__name__, layer_num)
+        # Tagged with the mesh shape AND the placement, so layouts can't clobber each other -- see
+        # sharding.cache_tag. Without a cache every layer redoes the full torch -> ttnn conversion
+        # (tilize + quantize + shard) on every run, which is most of this path's start-up cost.
+        tag = cache_tag(self.sharding, configuration.cluster_shape)
+        if configuration.dummy_weights or (weight_cache_path is None):
+            cache_name = lambda _: None
+        else:
+            cache_name = lambda name: weight_cache_path / (f"{layer_name}.{name}_{tag}")
+
+        # Select rotary embedding implementation for decode
+        if self.use_hf_rope and self.use_qk_fused:
+            raise NotImplementedError("Fused QK is not implemented for HF-style rope")
+        if self.use_hf_rope:
+            self.rotary_embedding_decode = self._hf_rope_decode
+        elif self.use_qk_fused:
+            self.rotary_embedding_decode = self._mllama_rope_fused_qk_decode
+        else:
+            self.rotary_embedding_decode = self._mllama_rope_decode
+
+        # Select rotary embedding implementation for prefill
+        if self.use_hf_rope:
+            self.rotary_embedding_prefill = self._hf_rope_prefill
+        else:
+            self.rotary_embedding_prefill = self._mllama_rope_prefill
+
+        wq_str = f"{layer_name}.wq"
+        wk_str = f"{layer_name}.wk"
+        wv_str = f"{layer_name}.wv"
+        wo_str = f"{layer_name}.wo"
+        q_norm_str = f"{layer_name}.q_norm"
+        k_norm_str = f"{layer_name}.k_norm"
+
+        # Initialize bias tensors as None
+        self.wqkv_bias_decode = None
+        self.wqkv_bias_prefill = None
+
+        # Create combined QKV bias if present in state dict
+        if f"{wq_str}.bias" in state_dict:
+            # AUTO-SHARD FIX: chunk by num_devices_per_group (the head/intermediate shard count),
+            # matching the wqkv weight below -- NOT by the total chip count. The two agree only on a
+            # 1D mesh; on a 2x2 the weight splits qkv 2 ways while num_devices=4 split the bias 4
+            # ways, and the prefill bias add blew up (2304 vs 1152).
+            qkv_bias = torch.concat(
+                [
+                    torch.concat(
+                        [
+                            torch.chunk(state_dict[f"{wq_str}.bias"], self.num_devices_per_group)[i],
+                            torch.chunk(state_dict[f"{wk_str}.bias"], self.num_devices_per_group)[i],
+                            torch.chunk(state_dict[f"{wv_str}.bias"], self.num_devices_per_group)[i],
+                        ],
+                        dim=-1,
+                    )
+                    for i in range(self.num_devices_per_group)
+                ],
+                dim=-1,
+            )
+
+            # The bias rides the same placement as wqkv: split the qkv width over intermediate_axis,
+            # and hold one copy along model_axis. Dims are negative so this works at either rank
+            # (prefill bias is a row, decode's is batch rows); -1/-2 mirror col_dims' 3/2.
+            bias_dims = [None, None]
+            if self.sharding.placement.intermediate_axis is not None:
+                bias_dims[self.sharding.placement.intermediate_axis] = -1
+            if self.sharding.placement.model_axis is not None:
+                bias_dims[self.sharding.placement.model_axis] = -2
+            bias_dims = tuple(bias_dims)
+
+            def bias_to_mesh(b, cache_key):
+                # The bias is added to the qkv matmul output *before* the all-reduce over
+                # model_axis, so a replicated copy would be summed num_model_shards times. Give the
+                # real bias to rank 0 of model_axis and zeros to the rest: the reduce then sums to
+                # exactly one bias, with no scaling and no reordering of the add.
+                rows = b.shape[-2]
+                stacked = torch.zeros(rows * self.num_device_groups, b.shape[-1], dtype=b.dtype)
+                stacked[:rows] = b
+                return ttnn.as_tensor(
+                    stacked,
+                    device=self.mesh_device,
+                    mesh_mapper=ttnn.ShardTensor2dMesh(
+                        self.mesh_device,
+                        dims=bias_dims,
+                        mesh_shape=configuration.cluster_shape,
+                    ),
+                    dtype=ttnn.bfloat16,
+                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                    layout=ttnn.TILE_LAYOUT,
+                    cache_file_name=cache_name(cache_key),
+                )
+
+            # Prefill can use broadcasting on the bias add so wants a single row
+            self.wqkv_bias_prefill = bias_to_mesh(qkv_bias.unsqueeze(0), "wqkv_bias_prefill_sharded")
+            # as_tensor returns (32, dim) which is incorrect, this reshape updates the padded size to the correct size
+            self.wqkv_bias_prefill = ttnn.reshape(
+                self.wqkv_bias_prefill,
+                (1, 1, 1, self.wqkv_bias_prefill.shape[-1]),
+                (1, 1, self.wqkv_bias_prefill.shape[-2], self.wqkv_bias_prefill.shape[-1]),
+            )
+
+            # Broadcasting does not seem to be supported inside execute_trace so expand to the whole batch size
+            # Create a list of bias tensors for each multiple of tile_size up to max_batch_size
+            self.wqkv_bias_decode = []
+            for batch_size in range(
+                configuration.tile_size,
+                configuration.tile_padded_batch_rows + configuration.tile_size,
+                configuration.tile_size,
+            ):
+                qkv_bias_decode = qkv_bias.unsqueeze(0).expand(batch_size, -1)
+                self.wqkv_bias_decode.append(
+                    bias_to_mesh(qkv_bias_decode, f"wqkv_bias_decode_sharded_{batch_size}")
+                )
+
+        # when splitting the devices, we need to make sure that the number of heads is divisible by the number of devices
+        assert self.n_heads % self.num_devices_per_group == 0
+        assert self.n_kv_heads % self.num_devices_per_group == 0
+        assert configuration.qkv_size % self.num_devices_per_group == 0
+        assert configuration.dim % self.num_devices_per_group == 0
+
+        qkv_list = []
+        for i in range(self.num_devices_per_group):
+            # Chunk weights
+            wq_selected = torch.chunk(state_dict[f"{wq_str}.weight"], self.num_devices_per_group, dim=0)[i]
+            wk_selected = torch.chunk(state_dict[f"{wk_str}.weight"], self.num_devices_per_group, dim=0)[i]
+            wv_selected = torch.chunk(state_dict[f"{wv_str}.weight"], self.num_devices_per_group, dim=0)[i]
+
+            # Transpose the selected chunks
+            wq = torch.transpose(wq_selected, -2, -1)
+            wk = torch.transpose(wk_selected, -2, -1)
+            wv = torch.transpose(wv_selected, -2, -1)
+
+            qkv = torch.cat([wq, wk, wv], dim=-1)
+            qkv_list.append(qkv)
+
+        qkv_cat = torch.cat(qkv_list, dim=-1).unsqueeze(0).unsqueeze(0)
+
+        self.wqkv = ttnn.as_tensor(
+            qkv_cat,
+            dtype=self.wqkv_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=self.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                self.mesh_device,
+                dims=self.sharding.col_dims,
+                mesh_shape=configuration.cluster_shape,
+            ),
+            cache_file_name=cache_name("wqkv_sharded_2d"),
+        )
+
+        def norm_reshard(x, norm, mode, norm_config):
+            """Hack until RMSNorm supports height-sharded output config"""
+            if mode == Mode.DECODE:
+                mem_cfg = x.memory_config()
+                x = ttnn.to_memory_config(x, ttnn.L1_MEMORY_CONFIG, dtype=x.dtype)
+            x = norm(x, mode, norm_config=norm_config)
+            if mode == Mode.DECODE:
+                x = ttnn.to_memory_config(x, mem_cfg, dtype=x.dtype)
+            return x
+
+        if f"{q_norm_str}.weight" in state_dict:
+            fn_q_norm = RMSNorm(
+                device=self.mesh_device,
+                dim=self.head_dim,
+                eps=configuration.norm_eps,
+                state_dict=state_dict,
+                state_dict_prefix=None,  # we already prefix q_norm_str
+                weight_cache_path=None if configuration.dummy_weights else weight_cache_path,
+                weight_dtype=ttnn.bfloat16,
+                weight_key=q_norm_str,
+                add_unit_offset=self.rms_norm_add_unit_offset,
+                is_distributed=False,
+                tt_ccl=self.tt_ccl,
+            )
+            self.q_norm = lambda x, mode, norm_config: norm_reshard(x, fn_q_norm, mode, norm_config)
+        else:
+            self.q_norm = lambda x, mode, norm_config: x
+
+        if f"{k_norm_str}.weight" in state_dict:
+            fn_k_norm = RMSNorm(
+                device=self.mesh_device,
+                dim=self.head_dim,
+                eps=configuration.norm_eps,
+                state_dict=state_dict,
+                state_dict_prefix=None,  # we already prefix k_norm_str
+                weight_cache_path=None if configuration.dummy_weights else weight_cache_path,
+                weight_dtype=ttnn.bfloat16,
+                weight_key=k_norm_str,
+                add_unit_offset=self.rms_norm_add_unit_offset,
+                is_distributed=False,
+                tt_ccl=self.tt_ccl,
+            )
+            self.k_norm = lambda x, mode, norm_config: norm_reshard(x, fn_k_norm, mode, norm_config)
+        else:
+            self.k_norm = lambda x, mode, norm_config: x
+
+        pt_wo = state_dict[f"{wo_str}.weight"].transpose(-1, -2).unsqueeze(0).unsqueeze(0)
+
+        self.wo = ttnn.as_tensor(
+            pt_wo,
+            dtype=self.wo_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            device=self.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                self.mesh_device,
+                dims=self.sharding.row_dims,
+                mesh_shape=configuration.cluster_shape,
+            ),
+            cache_file_name=cache_name("wo_width_sharded_2d"),
+        )
+        if not use_paged_kv_cache:
+            # vLLM provides its own kv cache
+            self.init_kv_cache(configuration, weight_cache_path)
+
+        if configuration.query_pre_attn_scalar is not None:
+            self.scale = configuration.query_pre_attn_scalar**-0.5
+        else:
+            self.scale = self.head_dim**-0.5
+
+    def _kv_prefill_mem_config(self, seq_len):
+        """Height-sharded config for the KV cache fill, sized to this placement's local KV heads."""
+        return ttnn.create_sharded_memory_config(
+            ((self.n_local_kv_heads * seq_len // (8 * 8)), self.head_dim),
+            ttnn.CoreGrid(y=8, x=8),
+            ttnn.ShardStrategy.HEIGHT,
+            ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+
+    def init_kv_cache(self, configuration, weight_cache_path):
+        """
+        Generates empty KV cache and pushed to device memory
+        """
+
+        if self.paged_attention_config:
+            cache_k = torch.zeros(
+                (
+                    self.paged_attention_config.max_num_blocks,
+                    self.n_local_kv_heads,
+                    self.paged_attention_config.block_size,
+                    self.head_dim,
+                )
+            )
+            cache_v = torch.zeros(
+                (
+                    self.paged_attention_config.max_num_blocks,
+                    self.n_local_kv_heads,
+                    self.paged_attention_config.block_size,
+                    self.head_dim,
+                )
+            )
+        else:
+            cache_k = torch.zeros(
+                (
+                    self.batch_size_per_device_group,
+                    self.n_local_kv_heads,
+                    self.max_seq_len,
+                    self.head_dim,
+                )
+            )
+            cache_v = torch.zeros(
+                (
+                    self.batch_size_per_device_group,
+                    self.n_local_kv_heads,
+                    self.max_seq_len,
+                    self.head_dim,
+                )
+            )
+
+        self.layer_past = [
+            ttnn.as_tensor(
+                k_or_v,
+                dtype=self.kv_cache_dtype,
+                layout=self.args.get_attn_weights_layout(),
+                device=self.mesh_device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+                cache_file_name=(
+                    f"{weight_cache_path}/kvcache_{k_or_v.shape}"
+                    if weight_cache_path and not configuration.dummy_weights
+                    else None
+                ),
+            )
+            for k_or_v in [cache_k, cache_v]
+        ]
+
+    def to_qk_fused_memory_config(self, q_tensor: ttnn.Tensor, k_tensor: ttnn.Tensor):
+        """
+        Convert Q and K tensors to height-sharded memory layouts suitable for
+        fused QK ops such as rotary_embedding_llama_fused_qk and the subsequent
+        QK matmul/attention score computation.
+
+        This function:
+        - Infers the number of Q heads and KV heads from the input tensors
+        - Shards Q and K along the batch dimension using HEIGHT sharding
+        - Places Q and K on disjoint core regions to avoid overlap within sub_core_grids
+        - Uses row-major shard orientation with explicit shard shapes
+
+        The resulting memory layouts are compatible with fused attention
+        kernels that expect Q and K to be distributed across separate
+        core ranges while preserving per-head contiguity.
+
+        Args:
+            q_tensor (ttnn.Tensor):
+                Query tensor with shape [..., batch, num_q_heads, head_dim].
+
+            k_tensor (ttnn.Tensor):
+                Key tensor with shape [..., batch, num_kv_heads, head_dim].
+
+            sub_core_grids (ttnn.CoreRangeSet):
+                The available core grids to place Q and K tensors on.
+
+        Returns:
+            Tuple[ttnn.Tensor, ttnn.Tensor]:
+                (q_tensor, k_tensor) converted to sharded memory configurations.
+        """
+        n_q_heads = q_tensor.shape[2]
+        n_kv_heads = k_tensor.shape[2]
+        q_batch = q_tensor.shape[1]
+        k_batch = k_tensor.shape[1]
+        assert q_batch == k_batch
+
+        row_size = 8  # We assume a row size of 8 cores
+        k_start_core = ttnn.CoreCoord(q_batch % row_size, q_batch // row_size)
+
+        q_core_grid = ttnn.CoreRangeSet({num_to_corerange(q_batch)})
+        k_core_grid = ttnn.CoreRangeSet({num_to_corerange(k_batch, start_core=k_start_core)})
+
+        q_mem_config = ttnn.create_sharded_memory_config(
+            shape=(nearest_32(n_q_heads), self.head_dim),
+            core_grid=q_core_grid,
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+        k_mem_config = ttnn.create_sharded_memory_config(
+            shape=(nearest_32(n_kv_heads), self.head_dim),
+            core_grid=k_core_grid,
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+        q_tensor = ttnn.to_memory_config(q_tensor, q_mem_config)
+        k_tensor = ttnn.to_memory_config(k_tensor, k_mem_config)
+        return q_tensor, k_tensor
+
+    def _mllama_rope_decode(self, q_heads_pre_rot_1BQD, k_heads_pre_rot_1BKD, rot_mats, current_pos):
+        # Q Rotary Embeddings
+        q_heads_1BQD = ttnn.experimental.rotary_embedding_llama(
+            q_heads_pre_rot_1BQD, rot_mats[0], rot_mats[1], self.transformation_mats["decode"], is_decode_mode=True
+        )
+
+        # K Rotary Embeddings
+        k_heads_1BKD = ttnn.experimental.rotary_embedding_llama(
+            k_heads_pre_rot_1BKD, rot_mats[0], rot_mats[1], self.transformation_mats["decode"], is_decode_mode=True
+        )
+        return q_heads_1BQD, k_heads_1BKD
+
+    def _mllama_rope_fused_qk_decode(self, q_heads_pre_rot_1BQD, k_heads_pre_rot_1BKD, rot_mats, current_pos):
+        q_heads_pre_rot_1BQD, k_heads_pre_rot_1BKD = self.to_qk_fused_memory_config(
+            q_heads_pre_rot_1BQD, k_heads_pre_rot_1BKD
+        )
+
+        q_heads_1BQD, k_heads_1BKD = ttnn.experimental.rotary_embedding_llama_fused_qk(
+            q_heads_pre_rot_1BQD, k_heads_pre_rot_1BKD, rot_mats[0], rot_mats[1], self.transformation_mats["decode"]
+        )
+        return q_heads_1BQD, k_heads_1BKD
+
+    def _hf_rope_decode(self, q_heads_pre_rot_1BQD, k_heads_pre_rot_1BKD, rot_mats, current_pos):
+        if q_heads_pre_rot_1BQD.dtype != ttnn.bfloat16:
+            q_heads_pre_rot_1BQD = ttnn.typecast(q_heads_pre_rot_1BQD, dtype=ttnn.bfloat16)
+        if k_heads_pre_rot_1BKD.dtype != ttnn.bfloat16:
+            k_heads_pre_rot_1BKD = ttnn.typecast(k_heads_pre_rot_1BKD, dtype=ttnn.bfloat16)
+
+        q_heads_1BQD = ttnn.experimental.rotary_embedding_hf(
+            q_heads_pre_rot_1BQD,
+            rot_mats[0],
+            rot_mats[1],
+            is_decode_mode=True,
+        )
+        k_heads_1BKD = ttnn.experimental.rotary_embedding_hf(
+            k_heads_pre_rot_1BKD,
+            rot_mats[0],
+            rot_mats[1],
+            is_decode_mode=True,
+        )
+        return q_heads_1BQD, k_heads_1BKD
+
+    def _mllama_rope_prefill(self, q_heads_1QSD_pre_rot, k_heads_1KSD_pre_rot, rot_mats):
+        # FIXME: (for 2d) rotary_embedding_llama requires bf16 inputs. On 2D meshes the QKV all-reduce
+        # downcasts to ccl_dtype (bf8), so cast back here (matches _hf_rope_prefill).
+        if q_heads_1QSD_pre_rot.dtype != ttnn.bfloat16:
+            q_heads_1QSD_pre_rot = ttnn.typecast(q_heads_1QSD_pre_rot, dtype=ttnn.bfloat16)
+        if k_heads_1KSD_pre_rot.dtype != ttnn.bfloat16:
+            k_heads_1KSD_pre_rot = ttnn.typecast(k_heads_1KSD_pre_rot, dtype=ttnn.bfloat16)
+
+        q_heads_1QSD = ttnn.experimental.rotary_embedding_llama(
+            q_heads_1QSD_pre_rot,
+            rot_mats[0],
+            rot_mats[1],
+            self.transformation_mats["prefill"],
+            is_decode_mode=False,
+        )
+
+        k_heads_1KSD = ttnn.experimental.rotary_embedding_llama(
+            k_heads_1KSD_pre_rot,
+            rot_mats[0],
+            rot_mats[1],
+            self.transformation_mats["prefill"],
+            is_decode_mode=False,
+        )
+
+        return q_heads_1QSD, k_heads_1KSD
+
+    def _hf_rope_prefill(self, q_heads_1QSD_pre_rot, k_heads_1KSD_pre_rot, rot_mats):
+        if q_heads_1QSD_pre_rot.dtype != ttnn.bfloat16:
+            q_heads_1QSD_pre_rot = ttnn.typecast(q_heads_1QSD_pre_rot, dtype=ttnn.bfloat16)
+
+        q_heads_1QSD = ttnn.experimental.rotary_embedding_hf(
+            q_heads_1QSD_pre_rot,
+            rot_mats[0],
+            rot_mats[1],
+            is_decode_mode=False,
+        )
+
+        if k_heads_1KSD_pre_rot.dtype != ttnn.bfloat16:
+            k_heads_1KSD_pre_rot = ttnn.typecast(k_heads_1KSD_pre_rot, dtype=ttnn.bfloat16)
+
+        k_heads_1KSD = ttnn.experimental.rotary_embedding_hf(
+            k_heads_1KSD_pre_rot,
+            rot_mats[0],
+            rot_mats[1],
+            is_decode_mode=False,
+        )
+
+        return q_heads_1QSD, k_heads_1KSD
+
+    def forward_decode(self, x: ttnn.Tensor, current_pos, rot_mats=None, page_table=None, kv_cache=None) -> ttnn.Tensor:
+        """
+        x: (seq_len, 1, batch, dim)
+        current_pos: (batch_size), current token position in the sequence for each user
+        """
+        ###
+        # QKV matmuls
+        # Use HiFi2 for DRAM-sharded matmuls as they are otherwise flop-bound. Loses 1 bit of activation precision.
+        ###
+        # Bias (select by row-tile count) is added to the matmul output before the reduce, whether
+        # unfused or fused. Compute it up front from x's seq dim (== the matmul output's rows).
+        wqkv_bias = None
+        if self.wqkv_bias_decode:
+            # WARNING: must not change the batch size between compiling and executing a trace
+            num_tiles = int(math.ceil(x.shape[-2] / self.tile_size))
+            wqkv_bias = self.wqkv_bias_decode[num_tiles - 1]
+
+        # --- unfused path (kept for reference) ---
+        # xqkv_fused = ttnn.linear(
+        #     x,
+        #     self.wqkv,
+        #     # wqkv is DRAM-interleaved + 2D-sharded, so a plain matmul with a DRAM output (like prefill).
+        #     memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        #     compute_kernel_config=self.li_qkv_decode_compute_kernel_cfg,
+        #     dtype=self.activation_dtype or ttnn.bfloat16,
+        # )
+        # if wqkv_bias is not None:  # FIXME: File bug against dram-sharded matmuls with bias
+        #     xqkv_fused = xqkv_fused + wqkv_bias
+        # ttnn.deallocate(x)
+        # # Reduce the QKV partials over the hidden axis; a no-op when the hidden isn't split.
+        # # replicate=True: every chip needs the full qkv to create its heads.
+        # xqkv_fused = all_reduce(xqkv_fused, self.mesh_device, axis=self.sharding.reduce_col_over,
+        #                         replicate=True, dtype=self.ccl_dtype, topology=self.ccl_topology)
+
+        # --- fused path: matmul + reduce_scatter overlapped (bias folded in, added pre-reduce;
+        # replicate=True -> trailing all_gather gives every chip the full qkv for head creation). ---
+        # ATTN_QKV_CORES=<n> forces the QKV matmul core grid; unset = ttnn default.
+        log_default_grid(x, self.wqkv, "ATTN qkv")
+        qkv_pc = core_grid_program_config(
+            self.args, "ATTN_QKV_CORES", x.shape[-2], x.shape[-1], self.wqkv.shape[-1], "ATTN qkv"
+        )
+        xqkv_fused = matmul_reduce_scatter(
+            x,
+            self.wqkv,
+            self.mesh_device,
+            self.tt_ccl,
+            axis=self.sharding.reduce_col_over,
+            replicate=True,
+            bias=wqkv_bias,
+            dtype=self.ccl_dtype,
+            compute_kernel_config=self.li_qkv_decode_compute_kernel_cfg,
+            program_config=qkv_pc,
+            topology=self.ccl_topology,
+            label="ATTN qkv [decode]",
+        )
+        ttnn.deallocate(x)
+
+        # bfloat16 (in L1) is required by nlp_create_qkv_heads_decode.
+        xqkv_fused = ttnn.to_memory_config(xqkv_fused, ttnn.L1_MEMORY_CONFIG, ttnn.bfloat16)
+
+        # Reshape such that true unpadded batch is tracked in shape
+        fqkv_shape = xqkv_fused.shape
+        xqkv_fused = ttnn.reshape(
+            xqkv_fused, (1, 1, self.batch_size_per_device_group, fqkv_shape[3]), (1, 1, 32, fqkv_shape[3])
+        )
+
+        ###
+        # Reshape and rotary embeddings
+        ###
+        (
+            q_heads_pre_rot_1BQD,
+            k_heads_pre_rot_1BKD,
+            v_heads_1BKD,
+        ) = ttnn.experimental.nlp_create_qkv_heads_decode(
+            xqkv_fused,
+            num_heads=self.n_local_heads,
+            num_kv_heads=self.n_local_kv_heads,
+            memory_config=self.args.get_attn_create_head_output_mem_config(Mode.DECODE, None),
+        )
+        norm_config = self.args.get_norm_config("attn", Mode.DECODE, None)
+        q_heads_pre_rot_1BQD = self.q_norm(q_heads_pre_rot_1BQD, mode=Mode.DECODE, norm_config=norm_config)
+        k_heads_pre_rot_1BKD = self.k_norm(k_heads_pre_rot_1BKD, mode=Mode.DECODE, norm_config=norm_config)
+        ttnn.deallocate(xqkv_fused)
+
+        # Q, K Rotary Embeddings
+        q_heads_1BQD, k_heads_1BKD = self.rotary_embedding_decode(
+            q_heads_pre_rot_1BQD, k_heads_pre_rot_1BKD, rot_mats, current_pos
+        )
+
+        ttnn.deallocate(q_heads_pre_rot_1BQD)
+        ttnn.deallocate(k_heads_pre_rot_1BKD)
+        ###
+        # KV update
+        ###
+        if kv_cache:
+            keys = kv_cache[0]
+            values = kv_cache[1]
+        else:
+            keys = self.layer_past[0]
+            values = self.layer_past[1]
+
+        # k_heads, [seqlen, n_kv_heads, bsz, head_dim]
+        # v_heads [seqlen, n_kv_heads, bsz, head_dim]
+        # keys, [max_batch_size, n_kv_heads // configuration.num_devices, max_seq_len, head_dim]
+
+        if self.use_qk_fused:
+            ttnn.experimental.paged_fused_update_cache(
+                keys, k_heads_1BKD, values, v_heads_1BKD, update_idxs_tensor=current_pos, page_table=page_table
+            )
+        else:
+            ttnn.experimental.paged_update_cache(
+                keys, k_heads_1BKD, update_idxs_tensor=current_pos, page_table=page_table
+            )
+            ttnn.experimental.paged_update_cache(
+                values, v_heads_1BKD, update_idxs_tensor=current_pos, page_table=page_table
+            )
+        ttnn.deallocate(k_heads_1BKD)
+        ttnn.deallocate(v_heads_1BKD)
+        # NOTE: Varying the batch size will result in slightly different outputs.
+        # For example, a prompt w/ 1 user vs, the same prompt repeated N times for N users, will produce different outputs
+        # This is because the SDPA op in decode mode has different number of reductions depending on batch size
+        # Which leads to slightly different outputs from attention (due to accumulated errors)
+        sdpa_decode_prog_cfg = self.args.get_attn_sdpa_decode_program_config(None)
+        if page_table is not None:
+            attn_output_1G4D = ttnn.transformer.paged_scaled_dot_product_attention_decode(
+                q_heads_1BQD,
+                keys,
+                values,
+                page_table_tensor=page_table,
+                cur_pos_tensor=current_pos,
+                scale=self.scale,
+                sliding_window_size=self.sliding_window,
+                program_config=sdpa_decode_prog_cfg,
+                compute_kernel_config=self.sdpa_decode_compute_kernel_cfg,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+        else:
+            attn_output_1G4D = ttnn.transformer.scaled_dot_product_attention_decode(
+                q_heads_1BQD,
+                keys,
+                values,
+                cur_pos_tensor=current_pos,
+                scale=self.scale,
+                sliding_window_size=self.sliding_window,
+                program_config=sdpa_decode_prog_cfg,
+                compute_kernel_config=self.sdpa_decode_compute_kernel_cfg,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,  # FIXME: why not L1 height sharded e.g. SCORES_BATCHED_MM_OUTPUT_MEMCFG?
+            )
+
+        ttnn.deallocate(q_heads_1BQD)
+        attn_output_11BH = ttnn.to_memory_config(
+            attn_output_1G4D,
+            memory_config=self.args.get_attn_sdpa_output_mem_config(
+                Mode.DECODE, self.batch_size_per_device_group, None
+            ),
+        )
+
+        attn_output_cat = ttnn.experimental.nlp_concat_heads_decode(
+            attn_output_11BH,
+            num_heads=self.n_local_heads,
+        )
+        ttnn.deallocate(attn_output_11BH)
+        ttnn.deallocate(attn_output_1G4D)
+
+        # Heads are sharded on the head axis and replicated across the group axis, so there is no
+        # users all-gather: each device runs its own Wo matmul and the head-split partials are
+        # summed by the Wo all-reduce below.
+        attn_output = ttnn.to_memory_config(attn_output_cat, ttnn.DRAM_MEMORY_CONFIG)
+
+        # wo is DRAM-interleaved + 2D-sharded -> plain matmul, DRAM output.
+
+        # --- unfused path (kept for reference) ---
+        # dense_out = ttnn.linear(
+        #     attn_output,
+        #     self.wo,
+        #     program_config=None,
+        #     memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        #     compute_kernel_config=self.li_o_decode_compute_kernel_cfg,
+        # )
+        # ttnn.deallocate(attn_output_cat)
+        # # Reduce the Wo partials over the head axis; a no-op when the heads aren't split.
+        # # replicate=False: on a line the output stays split along the head axis (a reduce_scatter).
+        # dense_out = all_reduce(dense_out, self.mesh_device, axis=self.sharding.reduce_row_over,
+        #                        replicate=False, dtype=self.ccl_dtype, topology=self.ccl_topology)
+
+        # --- fused path: matmul + reduce_scatter overlapped (replicate=False -> no trailing
+        # all_gather; the head-split result is what the decoder's residual expects). ---
+        log_default_grid(attn_output, self.wo, "ATTN dense_out")
+        dense_out = matmul_reduce_scatter(
+            attn_output,
+            self.wo,
+            self.mesh_device,
+            self.tt_ccl,
+            axis=self.sharding.reduce_row_over,
+            replicate=False,
+            dtype=self.ccl_dtype,
+            compute_kernel_config=self.li_o_decode_compute_kernel_cfg,
+            topology=self.ccl_topology,
+            label="ATTN dense_out [decode]",
+        )
+        ttnn.deallocate(attn_output_cat)
+
+        return dense_out
+
+    def forward_prefill(
+        self,
+        x_11SH,
+        rot_mats,
+        user_id: int = 0,
+        page_table=None,
+        chunk_page_table=None,
+        chunk_start_idx=None,
+        kv_cache=None,
+    ):
+        # For batched prefill, x_11SH has shape [B, 1, S, H] where B is batch_size
+        # concat before QKV matmul, then reshape back to batch after
+        batch_size = x_11SH.shape[0]
+        if batch_size > 1:
+            # Concatenate batch dimension into sequence for matmul compatibility
+            x_11SH = ttnn.reshape(x_11SH, [1, 1, x_11SH.shape[-2] * x_11SH.shape[-3] * x_11SH.shape[-4], -1])
+
+        seq_len = x_11SH.shape[-2]
+        original_seq_len = seq_len  # Track original for later unpadding
+        assert seq_len % 128 == 0 and seq_len > 0, "Seqlen must be divisible by 128"
+        ###
+        # QKV matmuls
+        ###
+
+        # reshaping long sequence to matmul fit on device
+        # Pad seq_len to nearest multiple of MAX_QKV_MM_SEQ_LEN if needed
+        if seq_len > self.MAX_QKV_MM_SEQ_LEN and seq_len % self.MAX_QKV_MM_SEQ_LEN != 0:
+            padded_seq_len = (
+                (seq_len + self.MAX_QKV_MM_SEQ_LEN - 1) // self.MAX_QKV_MM_SEQ_LEN
+            ) * self.MAX_QKV_MM_SEQ_LEN
+            pad_len = padded_seq_len - seq_len
+            x_11SH = ttnn.pad(x_11SH, padding=[(0, 0), (0, 0), (0, pad_len), (0, 0)], value=0.0)
+            seq_len = padded_seq_len
+
+        if seq_len > self.MAX_QKV_MM_SEQ_LEN:
+            x_11SH = ttnn.reshape(x_11SH, [1, seq_len // self.MAX_QKV_MM_SEQ_LEN, self.MAX_QKV_MM_SEQ_LEN, -1])
+
+        if self.args.use_minimal_qkv_prefill_matmul(seq_len):
+            # TODO: current path
+            xqkv_fused = ttnn.experimental.minimal_matmul(
+                x_11SH,
+                self.wqkv,
+                compute_kernel_config=self.li_qkv_prefill_compute_kernel_cfg,
+                config=self.args.get_attn_qkv_program_config(Mode.PREFILL, seq_len, None),
+            )
+        else:
+            xqkv_fused = ttnn.linear(
+                x_11SH,
+                self.wqkv,
+                dtype=self.activation_dtype or ttnn.bfloat16,
+                memory_config=self.args.get_attn_qkv_mm_mem_config(Mode.PREFILL, None),
+                compute_kernel_config=self.li_qkv_prefill_compute_kernel_cfg,
+                # AUTO-SHARD FIX: pass the real head-shard count so per_core_N matches the actual
+                # per-device QKV output width (not the hardcoded cluster_shape[1] assumption).
+                program_config=self.args.get_attn_qkv_program_config(
+                    Mode.PREFILL, seq_len, None, num_head_shards=self.sharding.num_intermediate_shards
+                ),
+            )
+
+        # FIXME: surely ttnn.linear bias should work?
+        if self.wqkv_bias_prefill is not None:
+            xqkv_fused = xqkv_fused + self.wqkv_bias_prefill
+
+        # Reduce the QKV partials over the hidden axis; a no-op when the hidden isn't split.
+        # replicate=True: every chip needs the full qkv to create its heads.
+        xqkv_fused = all_reduce(
+            xqkv_fused,
+            self.mesh_device,
+            axis=self.sharding.reduce_col_over,
+            replicate=True,
+            dtype=self.ccl_dtype,
+            topology=self.ccl_topology,
+        )
+
+        if seq_len > self.MAX_QKV_MM_SEQ_LEN:
+            xqkv_fused = ttnn.reshape(xqkv_fused, [1, 1, seq_len, -1])
+
+        # Slice back to original seq_len if we padded earlier
+        if original_seq_len != seq_len:
+            xqkv_fused = xqkv_fused[:, :, :original_seq_len, :]
+            seq_len = original_seq_len
+
+        if batch_size > 1:
+            xqkv_fused = ttnn.reshape(xqkv_fused, [batch_size, 1, seq_len // batch_size, -1])
+
+        ttnn.deallocate(x_11SH)
+        
+
+        # split qkv into heads
+        (
+            q_heads_1QSD_pre_rot,
+            k_heads_1KSD_pre_rot,
+            v_heads_1VSD,
+        ) = ttnn.experimental.nlp_create_qkv_heads(
+            xqkv_fused,
+            num_heads=self.n_local_heads,
+            num_kv_heads=self.n_local_kv_heads,
+            transpose_k_heads=False,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+        norm_config = self.args.get_norm_config("attn", Mode.PREFILL, None)
+        q_heads_1QSD_pre_rot = self.q_norm(q_heads_1QSD_pre_rot, mode=Mode.PREFILL, norm_config=norm_config)
+        k_heads_1KSD_pre_rot = self.k_norm(k_heads_1KSD_pre_rot, mode=Mode.PREFILL, norm_config=norm_config)
+
+        ttnn.deallocate(xqkv_fused)
+
+        ###
+        # Rotary embeddings
+        ###
+
+        # Apply rotary embeddings using the selected implementation
+        q_heads_1QSD, k_heads_1KSD = self.rotary_embedding_prefill(q_heads_1QSD_pre_rot, k_heads_1KSD_pre_rot, rot_mats)
+        ttnn.deallocate(q_heads_1QSD_pre_rot)
+        ttnn.deallocate(k_heads_1KSD_pre_rot)
+
+        # Fill KV-Cache
+        if kv_cache:
+            keys_BKSD, values_BKSD = kv_cache[0], kv_cache[1]
+        else:
+            keys_BKSD, values_BKSD = self.layer_past[0], self.layer_past[1]
+
+        k_heads_1KSD_8b = ttnn.typecast(k_heads_1KSD, dtype=keys_BKSD.dtype)
+        ttnn.deallocate(k_heads_1KSD)
+
+        # sharding k_fill to deal with update_cache memory limitation
+        if seq_len >= self.min_kv_prefill_shard_seqlen and page_table is None:
+            k_fill = ttnn.interleaved_to_sharded(k_heads_1KSD_8b, self._kv_prefill_mem_config(seq_len))
+        else:
+            k_fill = k_heads_1KSD_8b
+
+        v_heads_1VSD_8b = ttnn.typecast(v_heads_1VSD, dtype=values_BKSD.dtype)
+
+        ttnn.deallocate(v_heads_1VSD)
+
+        # sharding v_fill to deal with update_cache memory limitation
+        if seq_len >= self.min_kv_prefill_shard_seqlen and page_table is None:
+            v_fill = ttnn.interleaved_to_sharded(v_heads_1VSD_8b, self._kv_prefill_mem_config(seq_len))
+        else:
+            v_fill = v_heads_1VSD_8b
+
+        # Subset to this group's chips only under DATA parallelism, where each group holds a
+        # different user's cache and writing every chip would clobber the other users.
+        #
+        # num_device_groups is num_model_shards, a TENSOR-parallel axis, so the old condition
+        # (both > 1) also fired for pure TP -- i0/m1 on a 2x2. There the striding is wrong: the
+        # cache is ReplicateTensorToMesh sized for this chip's head group, and k_fill is already
+        # split on the head axis and identical along the model axis (the column matmul's all-reduce
+        # replicates on a 2D mesh), so every chip already holds exactly what it must store. Striding
+        # by num_model_shards writes one chip per head group and leaves the other half of the mesh
+        # with an unfilled cache -- Qwen2.5-7B on 2x2 at i0/m1 generates correctly for ~60 tokens and
+        # then degenerates, which is that stale cache taking over as decode leans on it.
+        #
+        # batch is not split in this path (batch_size_per_device_group == max_batch_size), so this
+        # is currently always False; kept as the real condition rather than deleted.
+        batch_is_split_across_groups = self.batch_size_per_device_group < self.max_batch_size
+        if batch_is_split_across_groups and self.num_device_groups > 1 and self.num_devices_per_group > 1:
+            k_fill = self.prefill_prepare_tensor_for_kv_cache(k_fill, user_id)
+            v_fill = self.prefill_prepare_tensor_for_kv_cache(v_fill, user_id)
+        if page_table is not None:
+            # In the case that the tokens have been padded along the seq len dimension, we need to fill the cache with the unpadded k/v values.
+            # Assume that the page table does not have padding, so we can use it to get the unpadded page len.
+            block_size = keys_BKSD.shape[2]
+            # If chunked prefill, use chunk_page_table if given, otherwise use page_table.
+            fill_page_table = chunk_page_table if chunk_page_table is not None else page_table
+
+        if batch_size > 1:
+            # For batched prefill, loop over VALID users only and fill each user's cache separately
+            # k_fill/v_fill have shape [padded_batch, n_kv_heads, seq_len_per_user, head_dim]
+            # The paged_fill_cache kernel reads batch_idx_ptr[0] for all positions,
+            # so we must call it once per user with their specific K/V slice
+            #
+            # IMPORTANT: user_id is a list of valid slot indices for batched prefill.
+            # Empty slots have page_table entries of -1, so we must skip them to avoid
+            # writing to invalid memory blocks.
+            seq_len_per_user = k_fill.shape[2]
+            page_len = fill_page_table.shape[1] * block_size
+
+            # user_id is a list of valid slot indices (e.g., [0, 1, 2, ..., N-1] for N users)
+            # Each slot index tells us which row in k_fill and page_table to use
+            valid_slots = user_id if isinstance(user_id, (list, tuple)) else list(range(batch_size))
+
+            for slot_idx in valid_slots:
+                # Extract this slot's K/V slice: [1, n_kv_heads, seq_len_per_user, head_dim]
+                k_user = k_fill[slot_idx : slot_idx + 1, :, :, :]
+                v_user = v_fill[slot_idx : slot_idx + 1, :, :, :]
+
+                # Slice to page length if needed (same as single-user path)
+                k_user_sliced = k_user[:, :, :page_len, :] if page_len < seq_len_per_user else k_user
+                v_user_sliced = v_user[:, :, :page_len, :] if page_len < seq_len_per_user else v_user
+
+                # Fill cache for this specific slot with scalar batch_idx
+                ttnn.experimental.paged_fill_cache(keys_BKSD, k_user_sliced, fill_page_table, batch_idx=slot_idx)
+                ttnn.experimental.paged_fill_cache(values_BKSD, v_user_sliced, fill_page_table, batch_idx=slot_idx)
+        elif page_table is not None:
+            # Single user path with page_table
+            page_len = fill_page_table.shape[1] * block_size
+            k_fill_sliced = k_fill[:, :, :page_len, :] if page_len < k_fill.shape[2] else k_fill
+            v_fill_sliced = v_fill[:, :, :page_len, :] if page_len < v_fill.shape[2] else v_fill
+            ttnn.experimental.paged_fill_cache(keys_BKSD, k_fill_sliced, fill_page_table, batch_idx=user_id)
+            ttnn.experimental.paged_fill_cache(values_BKSD, v_fill_sliced, fill_page_table, batch_idx=user_id)
+        else:
+            # Single user path without page_table
+            ttnn.fill_cache(
+                keys_BKSD,
+                k_fill,
+                user_id % self.batch_size_per_device_group,
+            )
+            ttnn.fill_cache(
+                values_BKSD,
+                v_fill,
+                user_id % self.batch_size_per_device_group,
+            )
+        if seq_len >= self.min_kv_prefill_shard_seqlen and page_table is None:
+            ttnn.deallocate(k_fill)
+            ttnn.deallocate(v_fill)
+
+        # SDPA
+        q_heads_1QSD_8b = ttnn.typecast(q_heads_1QSD, dtype=self.activation_dtype or ttnn.bfloat8_b)
+        ttnn.deallocate(q_heads_1QSD)
+
+        if chunk_start_idx is not None:
+            if self.sliding_window is not None:
+                raise NotImplementedError("Sliding window not supported for chunked prefill SDPA")
+            if isinstance(chunk_start_idx, ttnn.Tensor):
+                attn_output_84SD = ttnn.transformer.chunked_scaled_dot_product_attention(
+                    input_tensor_q=q_heads_1QSD_8b,
+                    input_tensor_k=keys_BKSD,
+                    input_tensor_v=values_BKSD,
+                    page_table_tensor=page_table,
+                    chunk_start_idx=None,
+                    chunk_start_idx_tensor=chunk_start_idx,
+                    compute_kernel_config=self.sdpa_prefill_compute_kernel_cfg,
+                    program_config=self.args.get_attn_sdpa_program_config(Mode.PREFILL, seq_len, 0, None),
+                )
+            else:
+                attn_output_84SD = ttnn.transformer.chunked_scaled_dot_product_attention(
+                    input_tensor_q=q_heads_1QSD_8b,
+                    input_tensor_k=keys_BKSD,
+                    input_tensor_v=values_BKSD,
+                    page_table_tensor=page_table,
+                    chunk_start_idx=chunk_start_idx,
+                    compute_kernel_config=self.sdpa_prefill_compute_kernel_cfg,
+                    program_config=self.args.get_attn_sdpa_program_config(Mode.PREFILL, seq_len, chunk_start_idx, None),
+                )
+        else:
+            # For batched prefill, the actual per-user seq_len is seq_len // batch_size
+            # since the tensors have shape [batch_size, n_heads, seq_len_per_user, head_dim]
+            sdpa_seq_len = seq_len // batch_size if batch_size > 1 else seq_len
+            attn_output_84SD = ttnn.transformer.scaled_dot_product_attention(
+                q_heads_1QSD_8b,
+                k_heads_1KSD_8b,
+                v_heads_1VSD_8b,
+                is_causal=True,
+                sliding_window_size=self.sliding_window,
+                scale=self.scale,
+                compute_kernel_config=self.sdpa_prefill_compute_kernel_cfg,
+                program_config=self.args.get_attn_sdpa_program_config(Mode.PREFILL, sdpa_seq_len, None, None),
+            )
+
+        # deallocate keys and values
+        ttnn.deallocate(q_heads_1QSD_8b)
+        ttnn.deallocate(k_heads_1KSD_8b)
+        ttnn.deallocate(v_heads_1VSD_8b)
+
+        # For single-user prefill, reshape to expected format for nlp_concat_heads
+        # For batched prefill (batch_size > 1), skip this reshape - nlp_concat_heads handles [B, H, S, D]
+        # IMPORTANT: Reshaping [B, H, S, D] to [1, H, B*S, D] BEFORE concat_heads would scramble data
+        # because batch and sequence dimensions are separated by heads. Must reshape AFTER concat_heads.
+        if batch_size == 1:
+            attn_output_1QSD = ttnn.reshape(attn_output_84SD, [1, self.n_local_heads, -1, self.head_dim])
+        else:
+            attn_output_1QSD = attn_output_84SD
+
+        ###
+        # Output matmul
+        ###
+        attn_output_11SH = ttnn.experimental.nlp_concat_heads(
+            attn_output_1QSD,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        ttnn.deallocate(attn_output_1QSD)
+
+        # For batched prefill, reshape to concatenate batch dimension into sequence
+        # This MUST happen AFTER nlp_concat_heads to preserve correct data layout
+        # nlp_concat_heads outputs [B, 1, S_per_user, H*D], reshape to [1, 1, B*S, H*D]
+        if batch_size > 1:
+            attn_output_11SH = ttnn.reshape(attn_output_11SH, [1, 1, seq_len, -1])
+
+        # reshaping long sequence to matmul fit on device
+        if seq_len > 1024:
+            attn_output_11SH = ttnn.reshape(attn_output_11SH, [1, seq_len // 1024, 1024, -1])
+
+        output_11SH = ttnn.linear(
+            attn_output_11SH,
+            self.wo,
+            compute_kernel_config=self.li_o_prefill_compute_kernel_cfg,
+            dtype=self.activation_dtype or ttnn.bfloat8_b,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            program_config=self.args.get_attn_wo_program_config(Mode.PREFILL, seq_len, None),
+        )
+
+        if seq_len > 1024:
+            output_11SH = ttnn.reshape(output_11SH, [1, 1, seq_len, -1])
+        ttnn.deallocate(attn_output_11SH)
+
+        # Reduce the Wo partials over the head axis; a no-op when the heads aren't split.
+        # replicate=False: on a line the output stays split along the head axis (a reduce_scatter).
+        output_11SH = all_reduce(
+            output_11SH,
+            self.mesh_device,
+            axis=self.sharding.reduce_row_over,
+            replicate=False,
+            dtype=self.ccl_dtype,
+            topology=self.ccl_topology,
+        )
+
+        return output_11SH
+
+    def forward(
+        self,
+        x,
+        current_pos,
+        rot_mats=None,
+        user_id=0,
+        mode=Mode.DECODE,
+        page_table=None,
+        chunk_page_table=None,
+        chunk_start_idx=None,
+        kv_cache=None,
+    ):
+        if mode == Mode.PREFILL:
+            return self.forward_prefill(
+                x,
+                rot_mats,
+                user_id,
+                page_table=page_table,
+                chunk_page_table=chunk_page_table,
+                chunk_start_idx=chunk_start_idx,
+                kv_cache=kv_cache,
+            )
+        else:
+            return self.forward_decode(x, current_pos, rot_mats, page_table=page_table, kv_cache=kv_cache)
+
+    def prefill_prepare_tensor_for_kv_cache(self, key_or_value_layer, user_id):
+        tensor_copy = ttnn.clone(key_or_value_layer)
+        # key_or_value_layer.deallocate(True)
+        # Get all tensors from multi-device tensor
+        tensors = ttnn.get_device_tensors(tensor_copy)
+        # Get only tensors from specific column chips
+        # Get every 4th tensor starting from user_id // 8
+        single_column_tensors = tensors[user_id // self.batch_size_per_device_group :: self.num_device_groups]
+        # Create multi-device tensor
+        multi_device_tensor = ttnn.combine_device_tensors(tensors=single_column_tensors)
+
+        return multi_device_tensor

--- a/models/tt_transformers/tt/auto_shard/ccl_auto_shard.py
+++ b/models/tt_transformers/tt/auto_shard/ccl_auto_shard.py
@@ -1,0 +1,307 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Collectives for auto-sharded layers, on top of reduce_scatter and all_gather.
+
+sharding.py picks which mesh axis a matmul's contraction was split over; these run the collective
+across that named axis, so they work on a 2D mesh too.
+"""
+
+import math
+import os
+
+import ttnn
+from loguru import logger
+
+from models.tt_transformers.tt.inline_profile import section
+
+WIDTH = 3  # tensors are [1, 1, seq, hidden]; we always collect along hidden
+
+
+# Pin the width-sharded matmul to <env_var>=<n> cores, or None for ttnn's default grid.
+# num_cores must be <=8 or a multiple of 8.
+# TODO(auto-shard): drive core selection from the cost model instead of an env var.
+def core_grid_program_config(args, env_var, M, K, N, label):
+    n = os.environ.get(env_var)
+    if not n:
+        return None
+    grid = _num_to_coregrid(int(n))
+    pc = args.matmul_1d_config(m=M, k=K, n=N, grid=grid)
+    logger.info(
+        f"[cores] {label}: 1D width-sharded grid=(x={grid.x}, y={grid.y}) = {grid.num_cores} cores (M={M} K={K} N={N})"
+    )
+    return pc
+
+
+def _num_to_coregrid(x):
+    if x <= 8:
+        return ttnn.CoreGrid(y=1, x=x)
+    if x % 8 == 0:
+        return ttnn.CoreGrid(y=x // 8, x=8)
+    raise ValueError(f"{x} cores: use <=8, or a multiple of 8")
+
+
+_logged_grids = set()
+
+
+def log_default_grid(x, weight, label):
+    # ttnn won't tell us the grid it picks for an interleaved matmul, so run one throwaway
+    # width-sharded matmul and read the core count off its shard spec.
+    if not os.environ.get("AUTO_SHARD_LOG_CORES") or label in _logged_grids:
+        return
+    if x.shape[-2] > 32:
+        return  # the probe hits out_subblock limits on large-M prefill
+    try:
+        probe = ttnn.linear(x, weight, memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG)
+        ss = probe.memory_config().shard_spec
+        cores = ss.grid.num_cores() if ss is not None else "interleaved(?)"
+        logger.info(f"[cores] {label}: ttnn default auto grid = {cores} cores (K={x.shape[-1]} N={weight.shape[-1]})")
+        ttnn.deallocate(probe)
+    except Exception as e:
+        logger.info(f"[cores] {label}: probe failed ({type(e).__name__}: {e}); K={x.shape[-1]} N={weight.shape[-1]}")
+    _logged_grids.add(label)
+
+
+def all_reduce(
+    tensor,
+    mesh_device,
+    axis,
+    *,
+    replicate,
+    dtype=ttnn.bfloat16,
+    topology=ttnn.Topology.Linear,
+    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    label="all_reduce",
+):
+    """Sum `tensor`'s partials across mesh `axis`.
+
+    axis=None (or a size-1 axis) means nothing was split there, so there's nothing to reduce.
+    replicate=True leaves the full sum on every chip; on a 1D line, replicate=False stops after
+    the reduce_scatter so each chip keeps only its summed slice. A 2D reduce always replicates.
+    `label` names this collective in the AUTO_SHARD_PROFILE=1 table.
+    """
+    mesh_shape = tuple(mesh_device.shape)
+    if axis is None or mesh_shape[axis] == 1:
+        return tensor
+
+    # AUTO_SHARD_NO_CCL=1 measures tok/s without the collectives. Each all_reduce is undone by the
+    # decoder's paired all_gather (also stubbed), so shapes still line up. Output is garbage.
+    if os.environ.get("AUTO_SHARD_NO_CCL") == "1":
+        return tensor
+
+    with section(label, mesh_device):
+        if tensor.dtype != dtype:
+            tensor = ttnn.typecast(tensor, dtype)
+
+        tensor = ttnn.reduce_scatter(
+            tensor, dim=WIDTH, cluster_axis=axis, topology=topology, memory_config=memory_config
+        )
+
+        if replicate or 1 not in mesh_shape:
+            tensor = ttnn.all_gather(
+                tensor, dim=WIDTH, cluster_axis=axis, topology=topology, memory_config=memory_config
+            )
+
+    return tensor
+
+
+def all_gather(
+    tensor,
+    mesh_device,
+    axis,
+    *,
+    topology=ttnn.Topology.Ring,
+    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    label="all_gather",
+):
+    """Reassemble a width-sharded `tensor` into a full replicated copy across mesh `axis`.
+
+    axis=None (or a size-1 axis) means nothing was split over it, so there's nothing to gather.
+    `label` names this collective in the AUTO_SHARD_PROFILE=1 table.
+    """
+    mesh_shape = tuple(mesh_device.shape)
+    if axis is None or mesh_shape[axis] == 1:
+        return tensor
+
+    # See all_reduce. Only the decoder's gathers are skipped, since those cancel with a stubbed
+    # all_reduce. The embedding and lm_head gathers aren't paired, so skipping them would fracture
+    # the tensor rather than just slow it down.
+    if os.environ.get("AUTO_SHARD_NO_CCL") == "1" and label.startswith("decoder"):
+        return tensor
+
+    with section(label, mesh_device):
+        out = ttnn.all_gather(tensor, dim=WIDTH, cluster_axis=axis, topology=topology, memory_config=memory_config)
+    return out
+
+
+# The matmul and the reduce_scatter workers run concurrently, so they must not share cores -- two
+# data-movement kernels on one core trip "Illegal NOC usage". Matmul gets rows [0, _RS_GRID_ROW),
+# the RS workers get the rest. Same split as
+# tests/ttnn/unit_tests/operations/ccl/test_new_matmul_reduce_scatter.py.
+_RS_GRID_ROW = 6
+_RS_CORE_GRID_OFFSET = (0, _RS_GRID_ROW)
+
+
+# Persistent buffers for the fused op, keyed per call site so two sites with the same shape don't
+# alias. These must be allocated once, not per call: ttnn.zeros writes from the host, which is
+# illegal during trace capture. The eager compile run fills the cache before capture starts.
+_rs_buffers = {}
+
+
+def _persistent_rs_buffers(mesh_device, label, M, N, num_devices, dtype, memory_config):
+    key = (label, M, N, num_devices, dtype)
+    if key not in _rs_buffers:
+        alloc = lambda width: ttnn.zeros(  # noqa: E731
+            [1, 1, M, width], dtype=dtype, layout=ttnn.TILE_LAYOUT, device=mesh_device, memory_config=memory_config
+        )
+        # intermediate holds the per-chip matmul output; output holds this chip's scattered slice
+        _rs_buffers[key] = (alloc(N), alloc(N // num_devices))
+    return _rs_buffers[key]
+
+
+def _rs_matmul_program_config(x, weight, mesh_device):
+    """Build the 2D-multicast matmul program config the fused matmul_reduce_scatter op requires.
+
+    matmul_reduce_scatter_async won't auto-pick a grid (it derefs program_config unconditionally,
+    so None gives "bad optional access") and only accepts MatmulMultiCoreReuseMultiCastProgramConfig.
+    in0_block_w=1 and 1x1 out-subblocks are always legal, so this works for any M/K/N.
+    """
+    grid = mesh_device.compute_with_storage_grid_size()
+    if grid.y <= _RS_GRID_ROW:
+        raise ValueError(
+            f"fused matmul_reduce_scatter needs a compute grid taller than {_RS_GRID_ROW} rows to keep "
+            f"the matmul and reduce_scatter workers apart, but this device has {grid.x}x{grid.y}. "
+            f"Lower _RS_GRID_ROW, or run with AUTO_SHARD_FUSE_RS unset to use linear + reduce_scatter."
+        )
+    rows = _RS_GRID_ROW
+    M, N = x.shape[-2], weight.shape[-1]
+    per_core_M = max(1, math.ceil(M / ttnn.TILE_SIZE / rows))
+    per_core_N = max(1, math.ceil(N / ttnn.TILE_SIZE / grid.x))
+    return ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+        compute_with_storage_grid_size=(grid.x, rows),
+        in0_block_w=1,
+        out_subblock_h=1,
+        out_subblock_w=1,
+        per_core_M=per_core_M,
+        per_core_N=per_core_N,
+        transpose_mcast=False,
+        fused_activation=None,
+        fuse_batch=False,
+    )
+
+
+def matmul_reduce_scatter(
+    x,
+    weight,
+    mesh_device,
+    tt_ccl,
+    axis,
+    *,
+    replicate,
+    bias=None,
+    dtype=ttnn.bfloat16,
+    compute_kernel_config=None,
+    program_config=None,
+    topology=ttnn.Topology.Linear,
+    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    activation=None,
+    label="matmul_reduce_scatter",
+):
+    """Fused matmul + reduce_scatter: overlap the matmul with the reduce over `axis`.
+
+    Drop-in for a serialized `ttnn.linear(x, weight)` -> `all_reduce(...)`. `replicate=True` still
+    needs a trailing all_gather, since only the reduce_scatter half is fused. `bias` is added
+    before the reduce_scatter, matching unfused numerics exactly.
+
+    The fused kernel rings over the whole mesh (no cluster_axis), so it only applies on a 1D ring.
+    Anything else falls back to linear + all_reduce.
+    """
+    mesh_shape = tuple(mesh_device.shape)
+
+    # Fusion is off by default: on a 1x4 at batch 1 it loses in both regimes -- prefill 48ms fused
+    # vs 45ms unfused, decode 33 vs 41.5 tok/s.
+    #
+    # Decode's loss is structural. The 2D-multicast matmul maps M across core rows, and decode has
+    # M=32 (one tile), so one row works and the rest idle. Decode is DRAM-bound anyway, with no
+    # compute to hide the collective behind. You'd need M>=192 to fill the grid.
+    #
+    # Prefill should win (M=3584 fills the grid, compute-bound) but loses by ~3ms. Untested
+    # suspects: the grid split leaves the matmul 48 cores instead of 64, and
+    # _rs_matmul_program_config picks the worst legal config for shape-independence. Tuning both
+    # might flip it, but prefill is <1% of a 200-token generation.
+    is_prefill = x.shape[-2] > ttnn.TILE_SIZE
+    fused_ok = (
+        os.environ.get("AUTO_SHARD_FUSE_RS") == "1"
+        and is_prefill  # decode is a guaranteed loss
+        and axis is not None
+        and mesh_shape[axis] > 1
+        and 1 in mesh_shape  # 1D line/ring only
+        and topology == ttnn.Topology.Ring
+    )
+
+    if not fused_ok:
+        with section(f"{label} linear", mesh_device):
+            out = ttnn.linear(
+                x,
+                weight,
+                bias=bias,
+                dtype=dtype,
+                compute_kernel_config=compute_kernel_config,
+                program_config=program_config,
+                memory_config=memory_config,
+            )
+        # all_reduce opens its own section; nesting would double-count it
+        out = all_reduce(
+            out,
+            mesh_device,
+            axis,
+            replicate=replicate,
+            dtype=dtype,
+            topology=topology,
+            memory_config=memory_config,
+            label=f"{label} all_reduce",
+        )
+        return out
+
+    M, N = x.shape[-2], weight.shape[-1]
+    num_devices = mesh_shape[axis]
+    # Override whatever the caller passed: the fused op only takes a 2D-multicast config, and the
+    # grid isn't free anyway since it has to dodge the reduce_scatter workers.
+    program_config = _rs_matmul_program_config(x, weight, mesh_device)
+    intermediate_buffer, output_buffer = _persistent_rs_buffers(
+        mesh_device, label, M, N, num_devices, dtype, memory_config
+    )
+    _, reduced = ttnn.experimental.matmul_reduce_scatter_async(
+        x,
+        weight,
+        persistent_intermediate_buffer=intermediate_buffer,
+        persistent_output_buffer=output_buffer,
+        dim=WIDTH,
+        multi_device_global_semaphore=tt_ccl.get_and_cycle_rs_semaphore_handles(axis),
+        reduce_scatter_core_grid_offset=_RS_CORE_GRID_OFFSET,
+        bias=bias,
+        num_links=tt_ccl.get_num_links(axis),
+        memory_config_rs=memory_config,
+        memory_config_mm=memory_config,
+        topology=topology,
+        dtype=dtype,
+        program_config=program_config,
+        activation=activation,
+        compute_kernel_config=compute_kernel_config,
+    )
+
+    if replicate:
+        reduced = all_gather(reduced, mesh_device, axis, topology=topology, memory_config=memory_config)
+    return reduced
+
+
+def partition(tensor, mesh_device, axis, *, memory_config=ttnn.DRAM_MEMORY_CONFIG):
+    """Shard a replicated `tensor`'s width across mesh `axis`, each chip keeping its slice.
+
+    The inverse of all_gather, for a module that splits its contraction over `axis`. axis=None (or
+    a size-1 axis) means the module wants the full width. No network traffic -- data is on-chip.
+    """
+    mesh_shape = tuple(mesh_device.shape)
+    if axis is None or mesh_shape[axis] == 1:
+        return tensor
+    return ttnn.mesh_partition(tensor, dim=WIDTH, cluster_axis=axis, memory_config=memory_config)

--- a/models/tt_transformers/tt/auto_shard/cost_model/cost_models.py
+++ b/models/tt_transformers/tt/auto_shard/cost_model/cost_models.py
@@ -1,0 +1,137 @@
+# cost models to pass into sharding.py
+#
+# The workload is one prefill followed by DECODE_STEPS single-token decodes per layer. The two
+# regimes cost very differently, so we model them separately: total = prefill + DECODE_STEPS * decode.
+# Prefill is throughput-bound, so a split genuinely divides the work; decode is latency-bound and
+# falls off more slowly (see DECODE_SPLIT_EXPONENT).
+#
+# Constants live in params.py so cost_models and the stack tests stay in sync; re-run
+# calibrate_cost_model.py to recalibrate. The ranking depends on the prefill/decode mix, so
+# select_sharding forwards the real workload; PREFILL_LEN/DECODE_STEPS are fallbacks.
+
+from toy_problem.utils import fabric_link_report
+
+from models.tt_transformers.tt.params import (  # noqa: F401
+    ALPHA,
+    BETA,
+    BYTES,
+    DECODE_SPLIT_EXPONENT,
+    DECODE_STEPS,
+    PREFILL_LEN,
+    TFLOPS_DECODE,
+    TFLOPS_PREFILL,
+)
+
+
+def cost_model(mesh_device, placements, shapes=None, mesh_shape=None, prefill_len=PREFILL_LEN, decode_steps=DECODE_STEPS, debug=False, interconnect_aware=True):
+    return cost_model_analytical(mesh_device, placements, shapes, mesh_shape, prefill_len, decode_steps, debug, interconnect_aware)
+
+
+def _axis_size(mesh_shape, axis):
+    return 1 if axis is None else mesh_shape[axis]
+
+
+def _flops_and_comm(shapes):
+    """Per-token flops and the two collective payloads for one forward pass of a block.
+
+    Attention and MLP have the same shape: a column-parallel matmul feeding a row-parallel one.
+    MLP just has two column matmuls (w1, w3), which doubles the column flops and its all-reduce.
+
+    Returns (flops_per_token, col_out, row_out, n_col_reduces), where col_out/row_out are the
+    column and row matmul output widths and n_col_reduces is 1 for attention, 2 for MLP.
+    """
+    if hasattr(shapes, "hidden_dim"):  # MLP: w1, w3 [dim, hidden_dim]; w2 [hidden_dim, dim]
+        flops = 2 * (2 * shapes.dim * shapes.hidden_dim) + 2 * shapes.hidden_dim * shapes.dim
+        return flops, shapes.hidden_dim, shapes.dim, 2
+    # attention: wqkv [dim, qkv_size]; wo [n_heads*head_dim, dim]
+    flops = 2 * shapes.dim * shapes.qkv_size + 2 * shapes.n_heads * shapes.head_dim * shapes.dim
+    return flops, shapes.qkv_size, shapes.dim, 1
+
+
+def placement_cost(p, shapes, mesh_shape, beta, prefill_len=PREFILL_LEN, decode_steps=DECODE_STEPS):
+    """Seconds for one layer under placement `p`, given an explicit per-axis beta (bytes/s). No device.
+
+    The device-free seam: cost_model_analytical reads beta off the live fabric to rank placements
+    within a mesh, and mesh_selection.mesh_cost builds beta from a static table pre-open to rank
+    whole meshes. Same arithmetic either way, so the two cost models can't drift.
+
+    Per-layer cost only. The fixed per-token work outside the block stack (embedding, final norm,
+    lm_head, sampling) doesn't scale with layer count and belongs in
+    mesh_selection.fixed_decode_cost, which mesh_cost adds on.
+    """
+    prefill = _regime(p, shapes, mesh_shape, prefill_len, TFLOPS_PREFILL, latency_bound=False, beta=beta)
+    decode = _regime(p, shapes, mesh_shape, 1, TFLOPS_DECODE, latency_bound=True, beta=beta)
+    return prefill + decode_steps * decode
+
+
+def _regime(p, shapes, mesh_shape, tokens, tflops, latency_bound, beta):
+    """Seconds for one column + row matmul pass at `tokens` tokens under placement `p`.
+
+    `beta` is a per-axis bandwidth (bytes/s): each all-reduce is charged at the speed of the axis it
+    runs on. Pass a uniform beta for the interconnect-agnostic baseline.
+    """
+    intermediate = _axis_size(mesh_shape, p.intermediate_axis)
+    model = _axis_size(mesh_shape, p.model_axis)
+
+    flops_per_token, col_out, row_out, n_col_reduces = _flops_and_comm(shapes)
+    flops = tokens * flops_per_token
+
+    # Product of the two axis sizes, not the chip count: i1/mNone on a 2x2 splits 2 ways and
+    # replicates twice.
+    split = intermediate * model
+
+    # Prefill's split genuinely divides the work. Decode falls off more slowly (measured ~1.3x over
+    # a 2x split), so it gets a fitted exponent; see params.py.
+    if latency_bound:
+        compute = flops / tflops * split**-DECODE_SPLIT_EXPONENT
+    else:
+        compute = flops / split / tflops
+
+    # 0, 1, or 2 all-reduces: one per axis the split contracts over, each at that axis's speed
+    comm = 0.0
+    if model > 1:  # column matmuls contract over the model axis
+        comm += n_col_reduces * (ALPHA + 2 * (model - 1) / model * tokens * (col_out / intermediate) * BYTES / beta[p.model_axis])
+    if intermediate > 1:  # row matmul contracts over the intermediate axis
+        comm += ALPHA + 2 * (intermediate - 1) / intermediate * tokens * (row_out / model) * BYTES / beta[p.intermediate_axis]
+
+    return compute + comm
+
+
+def cost_model_analytical(
+    mesh_device, placements, shapes=None, mesh_shape=None, prefill_len=PREFILL_LEN, decode_steps=DECODE_STEPS, debug=False, interconnect_aware=True
+):
+    report = fabric_link_report(mesh_device)
+    axis_bw = [report["axes"][a]["bandwidth"] for a in range(len(mesh_shape))]  # GB/s per axis
+    axis_wires = [report["axes"][a]["wires"] for a in range(len(mesh_shape))]  # used wires per axis
+    faster_axis = report["faster_axis"]
+
+    # axis_bw is relative, not absolute, so scale the calibrated BETA by each axis's share of the
+    # fastest. A linkless axis falls back to BETA, but a split over it never fires a comm term
+    # anyway. Calibrating _CABLE_BW in real bytes/s would let this go absolute.
+    ref = max(axis_bw) or 1.0
+    beta = [BETA * bw / ref if bw > 0 else BETA for bw in axis_bw]
+    if debug:
+        print(f"per-axis wires={axis_wires} bandwidth={axis_bw} beta={beta} faster_axis={faster_axis} interconnect_aware={interconnect_aware}")
+
+    # Interconnect-aware charges each all-reduce at its axis's bandwidth; the agnostic baseline
+    # uses one global BETA everywhere.
+    beta_used = beta if interconnect_aware else [BETA] * len(mesh_shape)
+
+    def regime(p, tokens, tflops, latency_bound):
+        return _regime(p, shapes, mesh_shape, tokens, tflops, latency_bound, beta_used)
+
+    def cost(p):
+        return placement_cost(p, shapes, mesh_shape, beta_used, prefill_len, decode_steps)
+
+    if debug:
+        print(f"cost model ranking on mesh {mesh_shape} (prefill_len={prefill_len}, decode_steps={decode_steps}):")
+        for p in sorted(placements, key=cost):
+            prefill = regime(p, prefill_len, TFLOPS_PREFILL, latency_bound=False)
+            decode = regime(p, 1, TFLOPS_DECODE, latency_bound=True)
+            print(
+                f"  intermediate={str(p.intermediate_axis):>4} model={str(p.model_axis):>4}  "
+                f"prefill={prefill*1e3:7.3f} ms + {decode_steps}*decode={decode_steps*decode*1e3:7.3f} ms  "
+                f"= {cost(p)*1e3:7.3f} ms/step"
+            )
+
+    return min(placements, key=cost)

--- a/models/tt_transformers/tt/auto_shard/cost_model/mesh_selection.py
+++ b/models/tt_transformers/tt/auto_shard/cost_model/mesh_selection.py
@@ -1,0 +1,255 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pick the mesh shape a run uses. sharding.py shards weights on a mesh; this picks the mesh.
+
+Must run before any device is opened, since opening one freezes the descriptor path, the fixture's
+shape param, and the fabric config. Constants here come from COST_MODEL_DATA.md.
+"""
+
+import os
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Union
+
+from loguru import logger
+from toy_problem.utils import _CABLE_BW
+
+from models.tt_transformers.tt.auto_shard.cost_model.cost_models import placement_cost
+from models.tt_transformers.tt.params import BETA, DECODE_STEPS, PREFILL_LEN
+from models.tt_transformers.tt.auto_shard.cost_model.sharding import (
+    AttentionShapes,
+    MLPShapes,
+    _drop_all_replicated,
+    legal_correct_placements,
+    legal_mlp_placements,
+)
+
+_DESCRIPTORS = Path(__file__).resolve().parents[5] / "tt_metal" / "fabric" / "mesh_graph_descriptors"
+
+# The 0<->1 edge has 6 eth channels, the other three have 2, and a descriptor's count applies to the
+# whole mesh. So runs confined to 0<->1 can claim 6; anything wider must use 2 or routing setup
+# fails on the thin edges (control_plane.cpp:1194).
+_COUNT6 = str(_DESCRIPTORS / "n300_2x2_mesh_graph_descriptor.textproto")
+_COUNT2 = str(_DESCRIPTORS / "n300_2x2_count2_mesh_graph_descriptor.textproto")
+
+
+@dataclass(frozen=True)
+class MeshPlan:
+    """How to bring the machine up for one candidate shape."""
+
+    shape: tuple  # shape the model runs on
+    open_shape: Union[tuple, int]  # fixture param; an int opens a line
+    descriptor: str  # TT_MESH_GRAPH_DESC_PATH
+    submesh: Optional[tuple]  # carve out of the opened mesh, or None for the whole thing
+
+
+# Fabric must own every device, so sub-machine shapes open the 2x2 and carve. The 1x4 opens as a
+# line and comes up as a ring; the 2x2 opens 2D and gets FABRIC_1D (Linear).
+PLANS = {
+    (1, 1): MeshPlan((1, 1), (2, 2), _COUNT6, (1, 1)),
+    (1, 2): MeshPlan((1, 2), (2, 2), _COUNT6, (1, 2)),  # == MESH_DEVICE=N300x1x2
+    (2, 2): MeshPlan((2, 2), (2, 2), _COUNT2, None),  # == MESH_DEVICE=N300x2x2
+    (1, 4): MeshPlan((1, 4), 4, _COUNT2, None),  # == no MESH_DEVICE
+}
+
+
+@dataclass(frozen=True)
+class ModelShapes:
+    attn: AttentionShapes
+    mlp: MLPShapes
+    n_layers: int
+    vocab_size: int  # picks the sampling path, see fixed_decode_cost
+
+
+def model_shapes():
+    """Weight shapes for $HF_MODEL, without opening a device.
+
+    ModelArgs needs a mesh_device, and its _set_hf_params just calls AutoConfig on the same env
+    var, so read that directly.
+    """
+    from transformers import AutoConfig
+
+    name = os.getenv("HF_MODEL")
+    if not name:
+        raise ValueError("MESH_DEVICE=AUTO needs HF_MODEL set to pick a mesh (e.g. meta-llama/Llama-3.1-8B)")
+    c = AutoConfig.from_pretrained(name).to_dict()
+    c = {**c.get("text_config", {}), **{k: v for k, v in c.items() if k != "text_config"}}
+
+    dim, n_heads = c["hidden_size"], c["num_attention_heads"]
+    n_kv_heads = c.get("num_key_value_heads", n_heads)
+    head_dim = c.get("head_dim") or dim // n_heads
+    return ModelShapes(
+        attn=AttentionShapes(
+            n_heads=n_heads,
+            n_kv_heads=n_kv_heads,
+            head_dim=head_dim,
+            dim=dim,
+            qkv_size=head_dim * (n_heads + 2 * n_kv_heads),
+        ),
+        mlp=MLPShapes(dim=dim, hidden_dim=c["intermediate_size"]),
+        n_layers=c["num_hidden_layers"],
+        vocab_size=c["vocab_size"],
+    )
+
+
+# Wires per mesh axis, as cable classes; stands in for fabric_link_report before open. Axis 1
+# (columns) crosses cards over QSFP-DD/WARP100, axis 0 (rows) is the intra-card TRACE link, None is
+# a size-1 axis that never splits.
+#
+#   (1,2)  on the fat 0<->1 edge, count-6 descriptor claims all 6 wires
+#   (2,2)  one TRACE wire is dispatch-only; columns capped at the thin 3<->2 edge's 2 wires
+#   (1,4)  a path across the 2x2 can't use column edges alone, so it crosses a TRACE hop
+_LINKS = {
+    (1, 1): (None, None),
+    (1, 2): (None, ("QSFP_DD",) * 4 + ("WARP100",) * 2),
+    (2, 2): (("TRACE",), ("QSFP_DD",) * 2),
+    (1, 4): (None, ("TRACE",)),
+}
+
+
+def _beta(shape):
+    """Per-axis all-reduce bandwidth (bytes/s), absolute.
+
+    cost_model_analytical normalizes within one mesh, which makes every mesh's fastest axis BETA
+    and is useless for comparing meshes. BETA was measured on the 1x4, whose only live axis is one
+    TRACE hop, so treat it as the speed of a TRACE unit and scale with _CABLE_BW.
+    """
+    unit = BETA / _CABLE_BW["TRACE"]
+    return [sum(_CABLE_BW[c] for c in wires) * unit if wires else BETA for wires in _LINKS[shape]]
+
+
+# Measured per-decode-token seconds for everything after the last block: final norm, lm_head,
+# sampling. Largest mesh-dependent term, and discontinuous, because the mesh shape decides which
+# sampling path runs. model.py takes the on-device path only when vocab_size // num_devices <= 64K;
+# model_auto_shard forces host on any 2D mesh.
+#
+# On-device cost is set by the padded TopK width, where doubling costs ~6.5x (issue #40399) and the
+# lm_head matmul is noise. Host has no TopK, so lm_head dominates and cost tracks 2*dim*vocab flops.
+_SAMPLING_ON_DEVICE_S = {32768: 3.4e-3, 65536: 22.0e-3}
+_ON_DEVICE_VOCAB_LIMIT = 64 * 1024
+
+# Host path, three additive terms:
+#
+#   C = base + PER_FLOP * (2 * dim * vocab)     lm_head matvec + host argmax, every mesh
+#     + GATHER                                  logits gather, only when devices > 1
+#     + GATHER_2D                               second gather over axis 0, only on a 2D mesh
+#
+# Least squares over six host measurements (Qwen 1x1/1x2/2x2/1x4, Llama 1x4, Gemma 1x4), worst
+# residual 2.1%. Implied lm_head rate is 2.1e11 flop/s, about half TFLOPS_DECODE.
+#
+# A flat 7.0e-3 fit Llama and Qwen but only by coincidence -- Qwen's smaller dim cancels its larger
+# vocab, so their lm_heads are within 4% in flops. Gemma has 2.7x the flops at 15.5 ms, where the
+# flat constant was 2.2x low. Vocab alone doesn't fit either (off 10-13% on the 7-8B models).
+_SAMPLING_HOST_BASE_S = 2.542e-4
+_SAMPLING_HOST_PER_FLOP_S = 4.868e-12
+_SAMPLING_HOST_GATHER_S = 1.518e-3
+# Only one sample constrains this (Qwen 2x2), so it's unknown whether the second gather is constant
+# or scales with payload; additive is the conservative read. A Gemma 2x2 sweep would settle it.
+_SAMPLING_HOST_GATHER_2D_S = 1.782e-3
+
+
+def _next_pow2(x):
+    return 1 << (x - 1).bit_length()
+
+
+def fixed_decode_cost(shape, model):
+    """Seconds of per-token work outside the block stack."""
+    devices = shape[0] * shape[1]
+    # model.py hardcodes a split of 2 on a [1,1] mesh instead of using num_devices.
+    sampling_splits = devices if devices > 1 else 2
+    per_device_vocab = model.vocab_size // sampling_splits
+
+    # Mirrors model.py's gate and model_auto_shard's 2D override. If either moves, this silently
+    # ranks meshes on a path they no longer take.
+    is_2d = shape[0] > 1 and shape[1] > 1
+    if per_device_vocab > _ON_DEVICE_VOCAB_LIMIT or is_2d:
+        # lm_head is unsplit here, so it costs the same everywhere; only the gathers vary by shape.
+        host = _SAMPLING_HOST_BASE_S + _SAMPLING_HOST_PER_FLOP_S * 2 * model.attn.dim * model.vocab_size
+        if devices > 1:
+            host += _SAMPLING_HOST_GATHER_S
+        if is_2d:
+            host += _SAMPLING_HOST_GATHER_2D_S
+        return host
+
+    width = _next_pow2(per_device_vocab)
+    if width in _SAMPLING_ON_DEVICE_S:
+        return _SAMPLING_ON_DEVICE_S[width]
+    # The table covers the only two widths our models reach on 4 chips. Falling back to the nearest
+    # is a guess, and a bad one given the 6.5x step between entries.
+    nearest = min(_SAMPLING_ON_DEVICE_S, key=lambda w: abs(w - width))
+    logger.warning(f"auto-mesh: no sampling measurement for width {width}; using the {nearest} entry")
+    return _SAMPLING_ON_DEVICE_S[nearest]
+
+
+def _best_placement(shapes, shape, beta, prefill_len, decode_steps):
+    """Sharding this mesh would actually run for one layer kind, and its cost.
+
+    Same enumerators and cost function as select_sharding, so dry run and live run agree.
+    """
+    attention = isinstance(shapes, AttentionShapes)
+    placements = legal_correct_placements(shapes, shape) if attention else legal_mlp_placements(shapes, shape)
+    placements = _drop_all_replicated(placements, shape)
+    if not placements:
+        raise ValueError(f"no legal sharding for {shapes} on candidate mesh {shape}")
+    cost = lambda p: placement_cost(p, shapes, shape, beta, prefill_len, decode_steps)  # noqa: E731
+    best = min(placements, key=cost)
+    return best, cost(best)
+
+
+def mesh_cost(shape, model, prefill_len=PREFILL_LEN, decode_steps=DECODE_STEPS):
+    """Cost of running `model` on `shape`, as t = C + n_layers * P. Host-only.
+
+    Each mesh is scored at its own best sharding, so the comparison is best-vs-best. C is charged
+    per decode step, not per layer: per-layer cost barely varies with mesh shape (under 4% across
+    these two models) while C alone swings 3.4 -> 22.8 ms.
+
+    Not modeled:
+      * Prefill's fixed cost, so prefill-heavy workloads rank on per-layer terms alone.
+        COST_MODEL_DATA.md has the TTFT numbers to fit it.
+      * Batch. Every constant is batch 1 and tt_sampling pads to 32, so the two sampling paths
+        converge as batch rises and may swap order.
+      * Hop count. ALPHA is flat per all-reduce, so a 4-chip reduce costs the same as a 2-chip one.
+        Measured comm doesn't grow with mesh size either, so the error is small.
+      * DRAM feasibility. No memory_params here (batch and max_seq_len are pytest params, unknown
+        at import), so a mesh too small for the weights gets costed instead of rejected.
+    """
+    beta = _beta(shape)
+    chosen, costs = {}, []
+    for kind, shapes in (("attn", model.attn), ("mlp", model.mlp)):
+        chosen[kind], cost = _best_placement(shapes, shape, beta, prefill_len, decode_steps)
+        costs.append(cost)
+    total = sum(costs) * model.n_layers + decode_steps * fixed_decode_cost(shape, model)
+    return total, chosen
+
+
+def select_mesh_plan(workload=None):
+    """Cheapest candidate by mesh_cost, ties broken at random.
+
+    `workload` is the (prefill_len, decode_steps) the run will actually do, read off the case the
+    demo is about to run. Ranking depends on that mix, so the params.py defaults are a fallback.
+
+    Assigns TT_MESH_GRAPH_DESC_PATH outright rather than setdefault-ing, since toy_problem.utils
+    setdefaults it at import and would pin every shape to the count-6 descriptor. Must run before
+    the mesh_device fixture opens anything.
+    """
+    model = model_shapes()
+    prefill_len, decode_steps = workload or (PREFILL_LEN, DECODE_STEPS)
+    logger.info(f"auto-mesh: ranking for prefill_len={prefill_len}, decode_steps={decode_steps}")
+    scored = {shape: mesh_cost(shape, model, prefill_len, decode_steps) for shape in PLANS}
+
+    cheapest = min(cost for cost, _ in scored.values())
+    dearest = max(cost for cost, _ in scored.values())
+    plan = PLANS[random.choice([s for s, (cost, _) in scored.items() if cost == cheapest])]
+    os.environ["TT_MESH_GRAPH_DESC_PATH"] = plan.descriptor
+
+    axes = lambda p: f"i{p.intermediate_axis}/m{p.model_axis}"  # noqa: E731
+    for shape, (cost, chosen) in sorted(scored.items(), key=lambda kv: kv[1][0]):
+        picked = " ".join(f"{kind}={axes(p)}" for kind, p in chosen.items())
+        logger.info(f"auto-mesh: {str(shape):>6} {cost * 1e3:9.1f} ms  best sharding {picked}")
+    logger.info(
+        f"auto-mesh: spread {(dearest / cheapest - 1) * 100:.2f}% -> picked {plan.shape} "
+        f"(opens {plan.open_shape}, submesh {plan.submesh}, {os.path.basename(plan.descriptor)})"
+    )
+    return plan

--- a/models/tt_transformers/tt/auto_shard/cost_model/sharding.py
+++ b/models/tt_transformers/tt/auto_shard/cost_model/sharding.py
@@ -1,0 +1,381 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pick how to shard a layer's weights across a 2D mesh. Host-only, no device ops.
+
+A layer is column-parallel -> row-parallel (dim -> intermediate -> dim), and two choices decide
+everything:
+
+    intermediate_axis  mesh axis the intermediate dim splits on (attn heads / ffn inner dim), or None
+    model_axis         mesh axis the model dim splits on, or None
+
+The intermediate dim is the column matmul's output and the row matmul's input; the model dim is the
+column matmul's input and the row matmul's output:
+
+    wqkv [dim, qkv_size]         in = model, out = intermediate (heads)
+    wo   [n_heads*head_dim, dim] in = intermediate (heads), out = model
+
+MLP is the same shape with the ffn inner dim in place of the heads (w1/w3 like wqkv, w2 like wo).
+
+Splitting a contraction leaves partial sums, so each matmul is followed by an all-reduce over the
+axis that was split: the column matmul over model_axis, the row matmul over intermediate_axis (each
+a no-op if that axis isn't split). ccl_auto_shard.all_reduce runs them.
+"""
+
+import functools
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import yaml
+from loguru import logger
+
+from models.tt_transformers.tt import params
+from models.tt_transformers.tt.auto_shard.cost_model.cost_models import DECODE_STEPS, PREFILL_LEN, cost_model
+
+# ttnn weights are 4D [1, 1, in, out]. The column weight (wqkv / w1,w3) is [model, intermediate];
+# the row weight (wo / w2) is [intermediate, model].
+COL_INTERMEDIATE = 3
+COL_MODEL = 2
+ROW_INTERMEDIATE = 2
+ROW_MODEL = 3
+TILE = 32
+
+
+@dataclass(frozen=True)
+class AttentionShapes:
+    n_heads: int
+    n_kv_heads: int
+    head_dim: int
+    dim: int
+    qkv_size: int
+    tile: int = TILE
+
+
+@dataclass(frozen=True)
+class MLPShapes:
+    dim: int
+    hidden_dim: int  # the ffn inner dim, in the role attention gives the heads
+    tile: int = TILE
+
+
+@dataclass
+class Placement:
+    """Which mesh axis each dim splits on (None = replicated)."""
+
+    intermediate_axis: Optional[int]
+    model_axis: Optional[int]
+
+
+@dataclass(frozen=True)
+class Sharding:
+    """What a module needs to build its weights and collectives.
+
+    Neutral to attention/MLP: the column weight takes col_dims, the row weight takes row_dims.
+    """
+
+    placement: Placement
+    col_dims: tuple  # ShardTensor2dMesh dims for the column weight
+    row_dims: tuple  # ShardTensor2dMesh dims for the row weight
+    num_intermediate_shards: int
+    num_model_shards: int
+    reduce_col_over: Optional[int]  # axis to all-reduce after the column matmul, or None
+    reduce_row_over: Optional[int]  # axis to all-reduce after the row matmul, or None
+
+
+## Legality
+
+
+def _divides_tiled(total, n, tile):
+    """n divides total, and each shard is a whole number of tiles."""
+    return total % n == 0 and (total // n) % tile == 0
+
+
+def _axis_size(mesh_shape, axis):
+    """Chips along this axis, or 1 if it's replicated (None)."""
+    return 1 if axis is None else mesh_shape[axis]
+
+
+def is_legal(placement, shapes, mesh_shape):
+    """Attention placement builds and tile-aligns. GQA means the KV heads must divide too."""
+    if placement.intermediate_axis is not None and placement.intermediate_axis == placement.model_axis:
+        return False  # one mesh axis can't carry two dims
+    i = _axis_size(mesh_shape, placement.intermediate_axis)
+    m = _axis_size(mesh_shape, placement.model_axis)
+    heads_fit = shapes.n_heads % i == 0 and shapes.n_kv_heads % i == 0 and _divides_tiled(shapes.qkv_size, i, shapes.tile)
+    return heads_fit and _divides_tiled(shapes.dim, m, shapes.tile)
+
+
+def mlp_is_legal(placement, shapes, mesh_shape):
+    """Same, without the GQA constraint."""
+    if placement.intermediate_axis is not None and placement.intermediate_axis == placement.model_axis:
+        return False
+    i = _axis_size(mesh_shape, placement.intermediate_axis)
+    m = _axis_size(mesh_shape, placement.model_axis)
+    return _divides_tiled(shapes.hidden_dim, i, shapes.tile) and _divides_tiled(shapes.dim, m, shapes.tile)
+
+
+def is_correct(placement, mesh_shape):
+    """Reject attention layouts the KV-cache code can't handle.
+
+    The cache is ReplicateTensorToMesh, a full copy on every chip, sharded only logically by the
+    per-chip head count. Prefill can write it two ways:
+
+      * 2D mesh, heads split (intermediate=0, model=1): prefill_prepare_tensor_for_kv_cache picks
+        one group's chips by striding the device list by num_model_shards, which lands on the right
+        chips only when the group axis is 1 and the heads are on axis 0.
+      * Line mesh, heads replicated (intermediate=None): no orthogonal head axis to gather, so the
+        cache is fully replicated and prefill writes every chip (see the num_devices_per_group
+        guard, which skips the striding).
+
+    Any other split model dim writes the wrong chips. A replicated model dim always works.
+    """
+    model_split = placement.model_axis is not None and mesh_shape[placement.model_axis] > 1
+    if not model_split:
+        return True
+    if placement.model_axis == 1 and placement.intermediate_axis == 0:
+        return True
+    return 1 in mesh_shape and placement.intermediate_axis is None
+
+
+## DRAM footprint
+
+# Bytes per element from the 32x32 tile table, so bfloat8/4 block overhead is counted.
+_BYTES_PER_ELEM = {"bfloat16": 2.0, "bfloat8_b": 1.0625, "bfloat4_b": 0.5625, "float32": 4.0}
+
+_SOC_YAML = {"blackhole": "blackhole_140_arch.yaml", "wormhole": "wormhole_b0_80_arch.yaml"}
+
+
+@functools.lru_cache(maxsize=None)
+def _device_dram_bytes(arch_name):
+    """One device's DRAM in bytes, from the SoC yaml (WH = 12 GiB, BH ~= 32 GiB).
+
+    Cached because MemoryParams.from_config is evaluated as a select_sharding *argument*, so it runs
+    once per layer whatever select_sharding's own cache does. Keyed on the arch name so it holds no
+    reference to a config or device.
+    """
+    key = "blackhole" if "blackhole" in arch_name.lower() else "wormhole"
+    root = Path(__file__).resolve().parents[5]
+    d = yaml.safe_load(open(root / "tt_metal" / "soc_descriptors" / _SOC_YAML[key]))
+    return d["dram_bank_size"] * len(d["dram"])
+
+
+@dataclass(frozen=True)
+class MemoryParams:
+    """What attention_footprint needs on top of the weight shapes."""
+
+    n_layers: int
+    max_seq_len: int
+    batch: int
+    wqkv_bytes: float
+    wo_bytes: float
+    kv_bytes: float
+    dram_bytes_per_device: int
+    usable_fraction: float = 0.95  # headroom for activations and fragmentation
+
+    @classmethod
+    def from_config(cls, configuration):
+        """Read these off a ModelArgs. Layer 0's dtypes stand in for all layers."""
+        import ttnn
+        from models.tt_transformers.tt.model_config import TensorGroup
+
+        def dbytes(group):
+            dtype = configuration.decoders_optimizations.get_tensor_dtype(0, group) or ttnn.bfloat16
+            # str(ttnn.bfloat8_b) is "DataType.BFLOAT8_B" -> "bfloat8_b"
+            return _BYTES_PER_ELEM[str(dtype).rsplit(".", 1)[-1].lower()]
+
+        return cls(
+            n_layers=configuration.n_layers,
+            max_seq_len=configuration.max_seq_len,
+            batch=configuration.batch_size_per_device_group,
+            wqkv_bytes=dbytes(TensorGroup.WQKV),
+            wo_bytes=dbytes(TensorGroup.WO),
+            kv_bytes=dbytes(TensorGroup.KV_CACHE),
+            dram_bytes_per_device=_device_dram_bytes(configuration.arch_name),
+        )
+
+
+def attention_footprint(placement, shapes, mesh_shape, memory_params):
+    """DRAM one device holds under this placement: weights + KV cache, all layers.
+
+    Weights split on both axes. The KV cache is replicated across the model (group) axis, so it only
+    shrinks with the head split.
+    """
+    intermediate_shards = _axis_size(mesh_shape, placement.intermediate_axis)
+    model_shards = _axis_size(mesh_shape, placement.model_axis)
+
+    wqkv = (shapes.dim / model_shards) * (shapes.qkv_size / intermediate_shards) * memory_params.wqkv_bytes
+    wo = (shapes.n_heads * shapes.head_dim / intermediate_shards) * (shapes.dim / model_shards) * memory_params.wo_bytes
+    weights = (wqkv + wo) * memory_params.n_layers
+
+    # 2 (k + v) * batch * kv_heads * seq_len * head_dim
+    kv_cache = (
+        2 * memory_params.batch * (shapes.n_kv_heads / intermediate_shards) * memory_params.max_seq_len * shapes.head_dim * memory_params.kv_bytes
+    ) * memory_params.n_layers
+
+    return {"weights": weights, "kv_cache": kv_cache, "total": weights + kv_cache}
+
+
+def is_memory_legal(placement, shapes, mesh_shape, memory_params=None):
+    """Footprint fits in DRAM with headroom. memory_params=None skips the check."""
+    if memory_params is None:
+        return True
+    budget = memory_params.dram_bytes_per_device * memory_params.usable_fraction
+    return attention_footprint(placement, shapes, mesh_shape, memory_params)["total"] <= budget
+
+
+## Enumerate + pick
+
+
+def _real_axes(mesh_shape):
+    # splitting a size-1 axis is the same as replicating
+    return [a for a in (0, 1) if mesh_shape[a] > 1]
+
+
+def _drop_all_replicated(placements, mesh_shape):
+    """Drop the split-nothing placement on a multichip mesh, unless it's the only option.
+
+    Replicating both dims runs the whole layer on every chip, so each reads the full weights. The
+    cost model prices that correctly now (split=1 is its most expensive case), so this is a guard
+    rather than a correction. It mattered when the decode term was a flat floor and charged every
+    split alike. Keep it until layers can take replicated activations.
+    """
+    if mesh_shape[0] * mesh_shape[1] <= 1:
+        return placements
+    sharded = [p for p in placements if not (p.intermediate_axis is None and p.model_axis is None)]
+    return sharded or placements
+
+
+def legal_correct_placements(shapes, mesh_shape, memory_params=None):
+    """Attention placements that are legal, KV-correct, and (with memory_params) fit in DRAM."""
+    axes = _real_axes(mesh_shape) + [None]
+    return [
+        p
+        for intermediate_axis in axes
+        for model_axis in axes
+        if is_legal((p := Placement(intermediate_axis, model_axis)), shapes, mesh_shape)
+        and is_correct(p, mesh_shape)
+        and is_memory_legal(p, shapes, mesh_shape, memory_params)
+    ]
+
+
+def legal_mlp_placements(shapes, mesh_shape):
+    """MLP placements that are legal. No KV-correctness rule, no DRAM check."""
+    axes = _real_axes(mesh_shape) + [None]
+    return [
+        p
+        for intermediate_axis in axes
+        for model_axis in axes
+        if mlp_is_legal((p := Placement(intermediate_axis, model_axis)), shapes, mesh_shape)
+    ]
+
+
+def _place(intermediate_axis, intermediate_dim, model_axis, model_dim):
+    # put each dim's index on its mesh axis; the other axis stays None (replicated)
+    dims = [None, None]
+    if intermediate_axis is not None:
+        dims[intermediate_axis] = intermediate_dim
+    if model_axis is not None:
+        dims[model_axis] = model_dim
+    return tuple(dims)
+
+
+def _build_sharding(placement, mesh_shape):
+    return Sharding(
+        placement=placement,
+        col_dims=_place(placement.intermediate_axis, COL_INTERMEDIATE, placement.model_axis, COL_MODEL),
+        row_dims=_place(placement.intermediate_axis, ROW_INTERMEDIATE, placement.model_axis, ROW_MODEL),
+        num_intermediate_shards=_axis_size(mesh_shape, placement.intermediate_axis),
+        num_model_shards=_axis_size(mesh_shape, placement.model_axis),
+        reduce_col_over=placement.model_axis,  # column matmul splits the model dim -> reduce there
+        reduce_row_over=placement.intermediate_axis,  # row matmul splits the intermediate -> reduce there
+    )
+
+
+def cache_tag(sharding, mesh_shape):
+    """Filename tag for the on-disk layout a Sharding produces.
+
+    weight_cache_path's device_name keys only on device count (4 chips -> "N150x4"), so a 1x4 and a
+    2x2 already share a cache dir. The bytes depend on the placement too: it fixes which dim each
+    weight splits on and num_intermediate_shards, which sets the MLP's fused gate_up interleave. One
+    mesh can pick different placements for different workloads (workload_from_config reads
+    max_seq_len/max_generated_tokens), so tagging by mesh shape alone would let two layouts collide
+    on one filename and a run would silently load wrong-layout weights.
+    """
+    axis = lambda a: "R" if a is None else str(a)  # noqa: E731. R = replicated
+    mesh = "x".join(str(d) for d in mesh_shape)
+    return f"mesh{mesh}_i{axis(sharding.placement.intermediate_axis)}m{axis(sharding.placement.model_axis)}"
+
+
+def _no_placement_message(shapes, mesh_shape, memory_params):
+    """Error text for when nothing works; name DRAM if that's what ruled everything out."""
+    msg = f"no legal sharding for shapes {shapes} on mesh {mesh_shape}"
+    if memory_params is None:
+        return msg
+    feasible = legal_correct_placements(shapes, mesh_shape)  # ignore memory this time
+    if not feasible:
+        return msg  # nothing was legal anyway, so memory isn't the cause
+    best = min(attention_footprint(p, shapes, mesh_shape, memory_params)["total"] for p in feasible)
+    budget = memory_params.dram_bytes_per_device * memory_params.usable_fraction
+    return (
+        f"{msg}; smallest footprint {best / 2**30:.2f} GiB exceeds DRAM budget "
+        f"{budget / 2**30:.2f} GiB ({memory_params.usable_fraction:.0%} of {memory_params.dram_bytes_per_device / 2**30:.0f} GiB)"
+    )
+
+
+def workload_from_config(configuration):
+    """The real (prefill_len, decode_steps) to cost against, from a ModelArgs.
+
+    The demo runs a prompt of up to (max_seq_len - max_generated_tokens) tokens then that many
+    single-token decodes, so take the largest prompt that fits and the generated-token count. Falls
+    back to the params.py defaults for callers that never plumbed max_generated_tokens.
+    """
+    decode_steps = getattr(configuration, "max_generated_tokens", None)
+    if not decode_steps:
+        return PREFILL_LEN, DECODE_STEPS
+    prefill_len = max(configuration.max_seq_len - decode_steps, TILE)
+    return prefill_len, decode_steps
+
+
+# One decision per distinct (mesh, shapes, workload). Every layer of a Llama/Qwen stack passes
+# identical arguments, so a 32-layer model would otherwise rank the same placements 64 times and
+# re-query the live fabric on each. Keyed on the arguments rather than on an assumption that layers
+# match, so a model that varied a layer still gets its own decision. Mesh identity, not just shape:
+# data-parallel builds one model per submesh, and two submeshes of the same shape can sit on
+# different chips with different links.
+_CACHE = {}
+
+
+def select_sharding(mesh_device, shapes, mesh_shape, memory_params=None, prefill_len=PREFILL_LEN, decode_steps=DECODE_STEPS):
+    """Rank the legal placements with the cost model and build the winner.
+
+    Takes AttentionShapes or MLPShapes. The workload is one prefill of prefill_len tokens plus
+    decode_steps decodes. Pass memory_params (attention only) to also drop placements that overflow
+    DRAM.
+    """
+    key = (id(mesh_device), shapes, tuple(mesh_shape), memory_params, prefill_len, decode_steps)
+    kind = "MLP" if isinstance(shapes, MLPShapes) else "attention"
+    if key not in _CACHE:
+        _CACHE[key] = _select_sharding(mesh_device, shapes, mesh_shape, memory_params, prefill_len, decode_steps)
+    else:
+        logger.info(f"auto-shard: loaded cached {kind} sharding {_CACHE[key].placement} for mesh {tuple(mesh_shape)}")
+    return _CACHE[key]
+
+
+def _select_sharding(mesh_device, shapes, mesh_shape, memory_params, prefill_len, decode_steps):
+    mesh_shape = tuple(mesh_shape)
+    if isinstance(shapes, MLPShapes):
+        placements = legal_mlp_placements(shapes, mesh_shape)
+    else:
+        placements = legal_correct_placements(shapes, mesh_shape, memory_params=memory_params)
+    if not placements:
+        raise ValueError(_no_placement_message(shapes, mesh_shape, memory_params))
+    placements = _drop_all_replicated(placements, mesh_shape)
+
+    placement = cost_model(mesh_device, placements, shapes, mesh_shape, prefill_len=prefill_len, decode_steps=decode_steps, debug=params.DEBUG)
+    
+    # To pin a placement by hand, assign it here, e.g. Placement(intermediate_axis=0, model_axis=1).
+    # placement = Placement(intermediate_axis=1, model_axis=0)
+
+    logger.info(f"auto-shard: picked {placement} from {placements} for {shapes} on mesh {mesh_shape}")
+    return _build_sharding(placement, mesh_shape)

--- a/models/tt_transformers/tt/auto_shard/decoder_auto_shard.py
+++ b/models/tt_transformers/tt/auto_shard/decoder_auto_shard.py
@@ -1,0 +1,293 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Auto-sharded TransformerBlock: same wiring as decoder.py (attention_norm -> attention -> residual
+-> ff_norm -> MLP -> residual) with the auto-sharded 2D-mesh Attention and MLP submodules.
+
+Single clean path: no galaxy (TG) branches, no MoE, and no Gemma pre/post feed-forward norms.
+
+Residual stream is kept fully replicated (full hidden dim on every chip), so the norm is a plain
+local RMSNorm and the residual adds always line up regardless of how attention and MLP each shard.
+The decoder adapts at each module boundary: `partition` the replicated input onto the module's
+contraction axis if it splits the dim, then `all_gather` the module's fractured output back to
+replicated. This works for any placement on any mesh (line or 2D); the cost is one full-width gather
+after each module.
+
+Stack-fractured fast path (enabled by the model via enable_stack_fractured): when every block keeps
+its residual fractured on the same mesh axis, the model leaves the residual fractured across the
+WHOLE stack and gathers once at the very end. A block in this mode takes a fractured input and
+returns a fractured output, does both norms distributed over that axis, and skips the per-block
+partition/gather entirely.
+"""
+
+import ttnn
+from models.common.lightweightmodule import LightweightModule
+from models.tt_transformers.tt.auto_shard.attention_auto_shard import Attention
+from models.tt_transformers.tt.auto_shard.ccl_auto_shard import all_gather, partition
+from models.tt_transformers.tt.common import Mode
+from models.tt_transformers.tt.auto_shard.mlp_auto_shard import MLP
+from models.tt_transformers.tt.model_config import TensorGroup
+from models.tt_transformers.tt.auto_shard.rmsnorm_auto_shard import RMSNorm
+
+
+class TransformerBlock(LightweightModule):
+    def __init__(
+        self,
+        args,
+        mesh_device,
+        tt_ccl,
+        dtype,
+        state_dict,
+        layer_num,
+        weight_cache_path,
+        transformation_mats,
+        paged_attention_config=None,
+        use_paged_kv_cache=False,
+        attention_class=None,  # accepted for API parity with decoder.py; auto-shard always uses its own Attention
+        prefetcher=None,
+    ):
+        super().__init__()
+
+        self.mesh_device = mesh_device
+        self.tt_ccl = tt_ccl
+        self.prefetcher = prefetcher
+        self.num_devices = args.num_devices
+        self.args = args
+        self.hidden_size = args.dim
+        self.n_heads = args.n_heads
+        self.head_dim = self.hidden_size // self.n_heads
+        self.max_seq_len = args.max_seq_len
+        self.dim = args.dim
+        self.max_batch_size = args.max_batch_size
+        self.n_kv_heads = args.n_kv_heads
+        self.current = 0
+        self.model_config = args.get_model_config()
+        self.layer_num = layer_num
+        # Residual-stream gathers run on the same fabric topology as the in-module collectives
+        # (Ring on a ring fabric, Linear otherwise). Cached so the per-layer gathers don't re-call
+        # ccl_topology() (which logs) on every forward.
+        self.ccl_topology = args.ccl_topology()
+
+        self.attention = Attention(
+            mesh_device=mesh_device,
+            tt_ccl=self.tt_ccl,
+            args=args,
+            state_dict=state_dict,
+            weight_cache_path=weight_cache_path,
+            layer_num=layer_num,
+            dtype=dtype,
+            transformation_mats=transformation_mats,
+            configuration=args,
+            paged_attention_config=paged_attention_config,
+            use_paged_kv_cache=use_paged_kv_cache,
+            prefetcher=prefetcher,
+        )
+
+        self.feed_forward = MLP(
+            mesh_device=mesh_device,
+            tt_ccl=self.tt_ccl,
+            args=args,
+            state_dict=state_dict,
+            weight_cache_path=weight_cache_path,
+            layer_num=layer_num,
+            dtype=dtype,
+            model_config=self.model_config,
+            prefetcher=prefetcher,
+        )
+
+        # Fast path: when attention fractures its output onto exactly the axis MLP wants as its input
+        # (they picked matching placements and that axis is really split), we can keep the residual
+        # stream sharded on that axis between the two modules instead of re-replicating after each.
+        # That drops a full-width all_gather; the price is a distributed ff_norm over the same axis.
+        self._fuse_axis = self._fused_residual_axis()
+        self.fuse_residual = self._fuse_axis is not None
+
+        # The norm sees whatever layout the residual is in: attention always takes the replicated
+        # block input (axis=None -> local norm); ff_norm sees a residual fractured on _fuse_axis on
+        # the fast path (axis=_fuse_axis -> stats gathered over that axis), else replicated.
+        def norm(weight_key, axis):
+            return RMSNorm(
+                device=mesh_device,
+                dim=args.dim,
+                eps=args.norm_eps,
+                state_dict=state_dict,
+                state_dict_prefix=args.get_state_dict_prefix("", layer_num),
+                weight_key=weight_key,
+                axis=axis,
+                add_unit_offset=self.args.rms_norm_add_unit_offset,
+            )
+
+        self._make_norm = norm  # kept so enable_stack_fractured can rebuild attention_norm distributed
+
+        # attention_norm sees a replicated block input by default (local norm); ff_norm sees a residual
+        # fractured on _fuse_axis on the within-block fast path. Stack-fractured mode (see below) later
+        # rebuilds attention_norm distributed too.
+        self.attention_norm = norm("attention_norm", axis=None)
+        self.ff_norm = norm("ffn_norm", axis=self._fuse_axis)
+
+        # Off unless the model turns it on for the whole stack (enable_stack_fractured).
+        self.stack_fractured = False
+
+    def _output_axis(self, sharding):
+        """Mesh axis a module's output dim ends up sharded on (None = already replicated).
+
+        The row matmul places the output on model_axis, and on a line the intermediate-axis
+        reduce-scatter leaves the dim split there too (on a 2D mesh that axis is gathered inside the
+        module).
+        """
+        p = sharding.placement
+        mesh_shape = tuple(self.mesh_device.shape)
+        if p.model_axis is not None and mesh_shape[p.model_axis] > 1:
+            return p.model_axis
+        if 1 in mesh_shape and p.intermediate_axis is not None and mesh_shape[p.intermediate_axis] > 1:
+            return p.intermediate_axis
+        return None
+
+    def _fused_residual_axis(self):
+        """Mesh axis to keep the residual sharded on across the block, or None to re-replicate.
+
+        Valid only when attention's fractured output already sits on the axis MLP wants to contract
+        over (so no gather+partition is needed between them) and MLP's output returns to that same
+        axis (so the final residual add lines up). Placement equality is the by-chance trigger; the
+        axis checks are what actually make it safe. None everywhere disables the fast path.
+        """
+        attn_sharding = self.attention.sharding
+        mlp_sharding = self.feed_forward.sharding
+        if attn_sharding.placement != mlp_sharding.placement:
+            return None
+        axis = self._output_axis(attn_sharding)
+        if axis is None or axis != mlp_sharding.reduce_col_over or axis != self._output_axis(mlp_sharding):
+            return None
+        return axis
+
+    def enable_stack_fractured(self):
+        """Switch this block into the stack-fractured residual scheme.
+
+        The model keeps the residual fractured on _fuse_axis across the WHOLE stack (one gather at the
+        very end) instead of re-replicating after every block. That only changes this block's entry
+        contract: the residual now arrives fractured on _fuse_axis, so attention_norm becomes a
+        distributed norm over that axis (ff_norm already is), and forward() neither partitions the
+        input (already fractured onto the attention contraction axis) nor gathers the output.
+        """
+        assert self._fuse_axis is not None, "stack-fractured requires a fused residual axis"
+        self.stack_fractured = True
+        self.attention_norm = self._make_norm("attention_norm", axis=self._fuse_axis)
+
+    def forward(
+        self,
+        x,
+        current_pos,
+        rot_mats_global=None,
+        rot_mats_local=None,
+        user_id=0,
+        mode="decode",
+        page_table=None,
+        chunk_page_table=None,
+        chunk_start_idx=None,
+        kv_cache=None,
+        batch_size=1,
+    ) -> ttnn.Tensor:
+        # replicated (full hidden dim on every chip) by default; fractured on _fuse_axis in
+        # stack-fractured mode. DRAM-interleaved throughout either way.
+        residual = x
+
+        # Choose the correct rotation matrices based on the mode
+        rot_mats = (
+            rot_mats_local if (hasattr(self.attention, "is_sliding") and self.attention.is_sliding) else rot_mats_global
+        )
+
+        # attention: norm -> (fracture onto its contraction axis) -> run. In stack-fractured mode the
+        # input is already fractured on _fuse_axis (== attention's contraction axis) and attention_norm
+        # is distributed over it, so there is nothing to partition.
+
+        attn_in = self.attention_norm(x)
+        if not self.stack_fractured:
+            attn_in = partition(attn_in, self.mesh_device, self.attention.sharding.reduce_col_over)
+
+        # Reshape to [B, 1, S_per_user, H] so attention infers batch_size from shape[0]
+        if batch_size > 1:
+            attn_in = ttnn.reshape(attn_in, [batch_size, 1, attn_in.shape[-2] // batch_size, -1])
+
+        attn_out = self.attention.forward(
+            attn_in,
+            current_pos,
+            rot_mats,
+            user_id,
+            mode,
+            page_table=page_table,
+            chunk_page_table=chunk_page_table,
+            chunk_start_idx=chunk_start_idx,
+            kv_cache=kv_cache,
+        )
+        # Match the batch-related reshape inside attention (prefill with batched prefill).
+        if mode == Mode.PREFILL and batch_size > 1:
+            residual = ttnn.reshape(residual, [1, 1, residual.shape[-2] * residual.shape[-3] * residual.shape[0], -1])
+
+        activation_dtype = self.args.decoders_optimizations.get_tensor_dtype(
+            decoder_id=self.layer_num, tensor=TensorGroup.ACTIVATION
+        )
+
+        if self.stack_fractured:
+            print("in stack-fractured path\n")
+            # Residual stays fractured on _fuse_axis for the whole stack: no gather after attention,
+            # no partition before MLP, no gather at the block end. attn_out is already fractured on
+            # _fuse_axis (attention's output axis), so it lines up with the fractured residual; the
+            # model gathers exactly once after the last block.
+            hidden_states = ttnn.add(residual, attn_out)
+            residual = hidden_states
+            if mode == "prefill":
+                x.deallocate(True)
+            ttnn.deallocate(attn_out)
+
+            # ff_norm gathers its RMS stats over _fuse_axis; its output is the fractured input MLP wants.
+            ff_in = self.ff_norm(hidden_states)
+            ff_out = self.feed_forward.forward(ff_in, mode)
+            return ttnn.add(residual, ff_out, dtype=activation_dtype or ttnn.bfloat16)  # stays fractured
+
+        if self.fuse_residual:
+            print("in fused path")
+            # Keep the residual sharded on _fuse_axis across the block: skip the full-width gather
+            # after attention and the partition before MLP; one gather re-replicates at the end.
+            residual = partition(residual, self.mesh_device, self._fuse_axis)  # free -- data already on-chip
+            hidden_states = ttnn.add(residual, attn_out)
+            residual = hidden_states
+            if mode == "prefill":
+                x.deallocate(True)
+            ttnn.deallocate(attn_out)
+
+            # ff_norm gathers its RMS stats over _fuse_axis; its output is already the fractured input MLP wants.
+            ff_in = self.ff_norm(hidden_states)
+            ff_out = self.feed_forward.forward(ff_in, mode)
+            out = ttnn.add(residual, ff_out, dtype=activation_dtype or ttnn.bfloat16)
+            return all_gather(out, self.mesh_device, self._fuse_axis, topology=self.ccl_topology)  # replicate for the next block
+
+        # Default path: re-replicate the residual after each module (works for any placement).
+        attn_out = all_gather(
+            attn_out,
+            self.mesh_device,
+            self._output_axis(self.attention.sharding),
+            topology=self.ccl_topology,
+            label=f"decoder attn_out all_gather [{mode}]",
+        )
+        hidden_states = ttnn.add(residual, attn_out)
+        residual = hidden_states
+        if mode == "prefill":
+            x.deallocate(True)
+        ttnn.deallocate(attn_out)
+
+        # MLP: local norm, fracture, run, gather back to replicated.
+        ff_in = self.ff_norm(hidden_states)
+        ff_in = partition(ff_in, self.mesh_device, self.feed_forward.sharding.reduce_col_over)
+        ff_out = self.feed_forward.forward(ff_in, mode)
+        ff_out = all_gather(
+            ff_out,
+            self.mesh_device,
+            self._output_axis(self.feed_forward.sharding),
+            topology=self.ccl_topology,
+            label=f"decoder ff_out all_gather [{mode}]",
+        )
+
+        out = ttnn.add(residual, ff_out, dtype=activation_dtype or ttnn.bfloat16)
+
+        return out  # replicated across devices

--- a/models/tt_transformers/tt/auto_shard/decoder_gemma_auto_shard.py
+++ b/models/tt_transformers/tt/auto_shard/decoder_gemma_auto_shard.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Auto-sharded TransformerBlock for Gemma-3.
+
+decoder_auto_shard's block is the Llama wiring -- residual add, then ff_norm, then MLP. Gemma-3 norms
+the attention output BEFORE the residual add and wraps the MLP in two more norms, so the block is
+
+    attention_norm -> attention -> ff_norm -> +residual -> pre_ff_norm -> MLP -> post_ff_norm -> +residual
+
+which is decoder.py's pre_ff_norm branch (decoder.py:276-336). Note ff_norm here is Gemma's
+post_attention_layernorm: load_checkpoints maps that HF key onto the name "ffn_norm", and what makes
+it Gemma rather than Llama is only where it sits relative to the residual add.
+
+Only the replicated-residual default path is implemented. _fused_residual_axis() returns None, which
+turns off this block's fuse_residual path and also keeps Transformer._stack_fractured_axis() at None
+for the whole stack, so the model never calls enable_stack_fractured(). Because the stream is
+replicated at every norm point, all four norms are plain local RMSNorms (axis=None) and none of
+decoder.py's mesh_partition juggling is needed -- that code exists only to re-align a fractured
+residual, which this path does not have.
+
+pre/post_ff_norm are built only when the checkpoint has them, so a non-Gemma model routed through
+this block degrades to the stock ordering rather than breaking.
+"""
+
+import ttnn
+from models.tt_transformers.tt.auto_shard.ccl_auto_shard import all_gather, partition
+from models.tt_transformers.tt.common import Mode
+from models.tt_transformers.tt.auto_shard.decoder_auto_shard import TransformerBlock
+from models.tt_transformers.tt.model_config import TensorGroup
+from models.tt_transformers.tt.auto_shard.rmsnorm_auto_shard import RMSNorm
+
+
+class GemmaTransformerBlock(TransformerBlock):
+    def __init__(self, **kwargs):
+        # Transformer.__init__ builds layers with keyword arguments only (model.py:105-118).
+        super().__init__(**kwargs)
+
+        args = kwargs["args"]
+        state_dict = kwargs["state_dict"]
+        prefix = args.get_state_dict_prefix("", kwargs["layer_num"])
+
+        def norm(weight_key):
+            if f"{prefix}{weight_key}.weight" not in state_dict:
+                return None
+            return RMSNorm(
+                device=kwargs["mesh_device"],
+                dim=args.dim,
+                state_dict=state_dict,
+                weight_key=weight_key,
+                axis=None,
+                state_dict_prefix=prefix,
+                eps=args.norm_eps,
+                add_unit_offset=args.rms_norm_add_unit_offset,
+                # Gemma-3's hidden dim is wide enough that fp32 norm accumulation overflows L1;
+                # see the note in rmsnorm_auto_shard.
+                fp32_dest_acc_en=False,
+            )
+
+        # The parent built attention_norm/ff_norm with fp32 accumulation on. Rebuild them here so
+        # every norm in a Gemma block uses the same L1 budget; the parent's versions never run.
+        self.attention_norm = norm("attention_norm")
+        self.ff_norm = norm("ffn_norm")
+        self.pre_ff_norm = norm("pre_feedforward_layernorm")
+        self.post_ff_norm = norm("post_feedforward_layernorm")
+
+    def _fused_residual_axis(self):
+        """Replicated residual only -- see the module docstring."""
+        return None
+
+    def forward(
+        self,
+        x,
+        current_pos,
+        rot_mats_global=None,
+        rot_mats_local=None,
+        user_id=0,
+        mode="decode",
+        page_table=None,
+        chunk_page_table=None,
+        chunk_start_idx=None,
+        kv_cache=None,
+        batch_size=1,
+    ) -> ttnn.Tensor:
+        residual = x  # replicated: full hidden dim on every chip
+
+        rot_mats = rot_mats_local if self.attention.is_sliding else rot_mats_global
+
+        attn_in = self.attention_norm(x)
+        attn_in = partition(attn_in, self.mesh_device, self.attention.sharding.reduce_col_over)
+
+        # Reshape to [B, 1, S_per_user, H] so attention infers batch_size from shape[0]
+        if batch_size > 1:
+            attn_in = ttnn.reshape(attn_in, [batch_size, 1, attn_in.shape[-2] // batch_size, -1])
+
+        attn_out = self.attention.forward(
+            attn_in,
+            current_pos,
+            rot_mats,
+            user_id,
+            mode,
+            page_table=page_table,
+            chunk_page_table=chunk_page_table,
+            chunk_start_idx=chunk_start_idx,
+            kv_cache=kv_cache,
+        )
+        # Match the batch-related reshape inside attention (prefill with batched prefill).
+        if mode == Mode.PREFILL and batch_size > 1:
+            residual = ttnn.reshape(residual, [1, 1, residual.shape[-2] * residual.shape[-3] * residual.shape[0], -1])
+
+        attn_out = all_gather(
+            attn_out,
+            self.mesh_device,
+            self._output_axis(self.attention.sharding),
+            topology=self.ccl_topology,
+            label=f"gemma decoder attn_out all_gather [{mode}]",
+        )
+
+        activation_dtype = self.args.decoders_optimizations.get_tensor_dtype(
+            decoder_id=self.layer_num, tensor=TensorGroup.ACTIVATION
+        )
+
+        # Gemma: norm the attention output, THEN add the residual.
+        if self.pre_ff_norm is not None:
+            hidden_states = self.ff_norm(attn_out)
+            ttnn.deallocate(attn_out)  # only safe once ff_norm has produced a separate tensor
+        else:
+            hidden_states = attn_out  # stock ordering; aliases attn_out, so do not deallocate it
+        hidden_states = ttnn.add(residual, hidden_states)
+        residual = hidden_states
+        if mode == "prefill":
+            x.deallocate(True)
+
+        # MLP: pre-norm, fracture, run, gather back to replicated, post-norm.
+        ff_in = self.pre_ff_norm(hidden_states) if self.pre_ff_norm is not None else self.ff_norm(hidden_states)
+        ff_in = partition(ff_in, self.mesh_device, self.feed_forward.sharding.reduce_col_over)
+        ff_out = self.feed_forward.forward(ff_in, mode)
+        ff_out = all_gather(
+            ff_out,
+            self.mesh_device,
+            self._output_axis(self.feed_forward.sharding),
+            topology=self.ccl_topology,
+            label=f"gemma decoder ff_out all_gather [{mode}]",
+        )
+
+        if self.post_ff_norm is not None:
+            ff_out = self.post_ff_norm(ff_out)
+
+        return ttnn.add(residual, ff_out, dtype=activation_dtype or ttnn.bfloat16)

--- a/models/tt_transformers/tt/auto_shard/lm_head_auto_shard.py
+++ b/models/tt_transformers/tt/auto_shard/lm_head_auto_shard.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Auto-shard LM head: the stock LMHead with its tail all-reduce removed.
+
+The weight is vocab-sharded (ShardTensorToMesh(dim=-1), k = full hidden), and the auto-shard stack
+hands it a *replicated* full-hidden input, so each device computes the correct, complete logits for
+its own vocab slice -- there are no partial sums to combine. The stock LMHead ends with a
+`tt_all_reduce(cluster_axis=1, dim=3 if is_galaxy else 0)`; on a flat (non-galaxy) mesh that reduce is
+either a degenerate no-op (1xN line: scatter a size-1 batch dim) or outright wrong (2x2: it sums
+distinct vocab slices across axis 1). It only exists for the galaxy layout, where axis 1 is a
+replication axis orthogonal to the vocab shard.
+
+Assembling the full logits is done downstream exactly as for the stock model, on any mesh:
+  * decode host sampling: model.ttnn_decode_forward all_gathers dim=3 over the whole mesh
+    (cluster_axis=None) so every device holds full logits;
+  * prefill: concat_host_output stitches the per-device vocab shards on the host;
+  * on-device sampling: consumes the vocab-sharded logits directly.
+
+So this head just drops the tail reduce and returns the vocab-sharded logits. Rebinding model.LMHead
+(see model_auto_shard) makes Transformer.__init__ build this instead of the stock one.
+"""
+
+import ttnn
+from models.tt_transformers.tt.common import Mode
+from models.tt_transformers.tt.lm_head import LMHead
+
+
+class LMHeadAutoShard(LMHead):
+    def forward(self, x: ttnn.Tensor, debug_input_torch=None, debug_weight_torch=None):
+        use_prefetcher = self.prefetcher is not None and self.prefetcher.mode == Mode.DECODE
+        split_sizes = self.split_sizes_ring_mm if use_prefetcher else self.split_sizes_dram_sharded
+        program_configs = [
+            self.args.get_lm_head_program_config(split_size, self.prefetcher if use_prefetcher else None)
+            for split_size in split_sizes
+        ]
+        output_weights = self.output_weights_ring_mm if use_prefetcher else self.output_weights_dram_sharded
+
+        self.lm_head_output_memory_config = self.args.get_lm_head_output_mem_config(
+            Mode.DECODE if use_prefetcher else Mode.PREFILL, self.prefetcher if use_prefetcher else None
+        )
+
+        outputs = []
+        for i, (weight, pc) in enumerate(zip(output_weights, program_configs)):
+            output = ttnn.linear(
+                x,
+                weight,
+                compute_kernel_config=self.compute_kernel_config,
+                program_config=pc,
+                memory_config=self.lm_head_output_memory_config,
+                dtype=self.args.lm_head_dtype if hasattr(self.args, "lm_head_dtype") else ttnn.bfloat8_b,
+                sub_device_id=self.prefetcher.worker_sub_device_id if use_prefetcher else None,
+            )
+            output = ttnn.to_memory_config(
+                output,
+                memory_config=self.args.get_lm_head_sharded_output_mem_config(
+                    self.prefetcher if use_prefetcher else None
+                ),
+            )
+            outputs.append(output)
+
+        ttnn.deallocate(x)
+
+        # Concatenate this device's weight-splits into its full vocab slice.
+        output = ttnn.concat(
+            outputs,
+            dim=-1,
+            memory_config=ttnn.L1_MEMORY_CONFIG if not use_prefetcher else ttnn.DRAM_MEMORY_CONFIG,
+            sub_core_grids=self.prefetcher.all_worker_cores_range_set if use_prefetcher else None,
+        )
+        if use_prefetcher:
+            output = ttnn.to_memory_config(
+                output,
+                memory_config=self.args.get_lm_head_reshard_mem_config(self.prefetcher),
+            )
+
+        # No tail all-reduce: the vocab shards are assembled downstream (see module docstring).
+        return output

--- a/models/tt_transformers/tt/auto_shard/mlp_auto_shard.py
+++ b/models/tt_transformers/tt/auto_shard/mlp_auto_shard.py
@@ -1,0 +1,287 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Auto-sharded MLP for a 2D mesh.
+
+MLP is the same column-parallel -> row-parallel pattern as attention, so it is driven by the same
+Sharding descriptor (sharding.select_sharding):
+
+    w1, w3 [dim, hidden_dim]   column-parallel (like wqkv): intermediate split on the head axis,
+                               dim (the contraction) split on the hidden axis. Each is followed by
+                               an all-reduce over the hidden axis.
+    w2     [hidden_dim, dim]   row-parallel (like wo): intermediate (the contraction) split on the
+                               head axis, dim (the output) split on the hidden axis. Followed by an
+                               all-reduce over the head axis.
+
+One code path runs decode and prefill on any mesh; there is no galaxy / prefetcher special-casing.
+"""
+
+import torch
+
+import ttnn
+from models.common.lightweightmodule import LightweightModule
+from models.tt_transformers.tt.auto_shard.ccl_auto_shard import (
+    all_reduce,
+    core_grid_program_config,
+    log_default_grid,
+    matmul_reduce_scatter,
+)
+from models.tt_transformers.tt.common import Mode, pad_to_size
+from models.tt_transformers.tt.model_config import OpGroup, TensorGroup
+from models.tt_transformers.tt.auto_shard.cost_model.sharding import MLPShapes, cache_tag, select_sharding, workload_from_config
+
+
+class MLP(LightweightModule):
+    def __init__(
+        self,
+        mesh_device,
+        tt_ccl,
+        args,
+        state_dict,
+        weight_cache_path,
+        layer_num,
+        dtype,
+        model_config,
+        state_dict_prefix=None,
+        prefetcher=None,
+    ):
+        print("Auto Sharding MLP")
+        super().__init__()
+
+        self.mesh_device = mesh_device
+        self.tt_ccl = tt_ccl
+        self.args = args
+        self.dim = args.dim
+        self.hidden_dim = args.hidden_dim
+        self.model_config = model_config
+        self.layer_num = layer_num
+        self.ccl_dtype = args.ccl_dtype
+        self.ccl_topology = args.ccl_topology()
+
+        # One sharding descriptor fixes the w1/w3/w2 mesh placements and the two all-reduce axes.
+        # Rank for the real run's workload (same source as attention), params.py fallback otherwise.
+        shapes = MLPShapes(self.dim, self.hidden_dim)
+        prefill_len, decode_steps = workload_from_config(args)
+        self.sharding = select_sharding(
+            mesh_device, shapes, tuple(args.cluster_shape), prefill_len=prefill_len, decode_steps=decode_steps
+        )
+
+        layer = max(layer_num, 0)  # cross_block uses the configuration of the first decoder
+        decoders_optimizations = args.decoders_optimizations
+        ff1_3_dtype = decoders_optimizations.get_tensor_dtype(decoder_id=layer, tensor=TensorGroup.FF1_FF3)
+        ff2_dtype = decoders_optimizations.get_tensor_dtype(decoder_id=layer, tensor=TensorGroup.FF2)
+        self.activation_dtype = decoders_optimizations.get_tensor_dtype(decoder_id=layer, tensor=TensorGroup.ACTIVATION)
+        self.li_ff1_3_compute_kernel_cfg = decoders_optimizations.get_math_fidelity(
+            decoder_id=layer, op=OpGroup.LI_FF1_FF3, configuration=args
+        )
+        self.li_ff2_compute_kernel_cfg = decoders_optimizations.get_math_fidelity(
+            decoder_id=layer, op=OpGroup.LI_FF2, configuration=args
+        )
+
+        state_dict_prefix = state_dict_prefix or args.get_state_dict_prefix(self.__class__.__name__, layer_num)
+
+        # Tagged with the mesh shape AND the placement (see sharding.cache_tag): the fused gate_up
+        # interleave below is built around num_intermediate_shards, so its bytes are placement-
+        # specific and a mesh-only tag would let two layouts collide on one filename. Without a cache
+        # every layer redoes the transpose/pad/chunk-cat plus the tilize+quantize+shard on every run.
+        tag = cache_tag(self.sharding, args.cluster_shape)
+        if args.dummy_weights or (weight_cache_path is None):
+            cache_name = lambda _: None
+        else:
+            cache_name = lambda name: weight_cache_path / (f"{state_dict_prefix}.{name}_{tag}")
+
+        def as_sharded_tensor(name, dtype, dims, pad_dim):
+            # stored weight is [out, in]; transpose to [in, out], pad the hidden_dim axis, make 4D.
+            w = state_dict[f"{state_dict_prefix}.{name}.weight"].transpose(-2, -1)
+            w = pad_to_size(w, dim=pad_dim, size=args.hidden_dim)
+            w = w.unsqueeze(0).unsqueeze(0)
+            return ttnn.as_tensor(
+                w,
+                dtype=dtype,
+                device=mesh_device,
+                mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=dims, mesh_shape=args.cluster_shape),
+                layout=ttnn.TILE_LAYOUT,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                cache_file_name=cache_name(f"{name}_sharded"),
+            )
+
+        # --- unfused path (kept for reference) ---
+        # w1, w3 are column-parallel (col_dims); w2 is row-parallel (row_dims). hidden_dim is the
+        # last axis of w1/w3 ([dim, hidden_dim] -> pad -1) and the second-to-last of w2
+        # ([hidden_dim, dim] -> pad -2).
+        # self.w1 = as_sharded_tensor("w1", ff1_3_dtype, self.sharding.col_dims, pad_dim=-1)
+        # self.w3 = as_sharded_tensor("w3", ff1_3_dtype, self.sharding.col_dims, pad_dim=-1)
+
+        # --- fused gate+up path ---
+        # w1 (gate) and w3 (up) are fused into one column-parallel weight [dim, 2*hidden_dim].
+        # The mesh splits the hidden axis into S = num_intermediate_shards chunks, so we interleave
+        # per shard -> [gate_0|up_0 | gate_1|up_1 | ...] and device i receives a contiguous
+        # [gate_i | up_i]. That lets forward() recover the two halves with one mid-point split.
+        def load_col_weight(name):
+            # stored [out=hidden, in=dim]; transpose to [dim, hidden] then pad the hidden axis.
+            w = state_dict[f"{state_dict_prefix}.{name}.weight"].transpose(-2, -1)
+            return pad_to_size(w, dim=-1, size=args.hidden_dim)
+
+        S = self.sharding.num_intermediate_shards
+        w1 = load_col_weight("w1")
+        w3 = load_col_weight("w3")
+        gate_up = torch.cat(
+            [
+                torch.cat([torch.chunk(w1, S, dim=-1)[i], torch.chunk(w3, S, dim=-1)[i]], dim=-1)
+                for i in range(S)
+            ],
+            dim=-1,
+        )
+        gate_up = gate_up.unsqueeze(0).unsqueeze(0)  # [1, 1, dim, 2*hidden_dim]
+        self.w1_w3 = ttnn.as_tensor(
+            gate_up,
+            dtype=ff1_3_dtype,
+            device=mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=self.sharding.col_dims, mesh_shape=args.cluster_shape),
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            cache_file_name=cache_name("w1_w3_fused"),
+        )
+
+        # w2 (down) is row-parallel (row_dims). hidden_dim is the second-to-last axis
+        # ([hidden_dim, dim] -> pad -2).
+        self.w2 = as_sharded_tensor("w2", ff2_dtype, self.sharding.row_dims, pad_dim=-2)
+
+        self.activation_type = (
+            args.mlp_activation_type if hasattr(args, "mlp_activation_type") else ttnn.UnaryOpType.SILU
+        )
+
+    def forward(self, x: ttnn.Tensor, mode: Mode) -> ttnn.Tensor:
+        """
+        w1 -> gate_proj, w3 -> up_proj, w2 -> down_proj
+        HF reference: self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
+        """
+        seq_len = x.shape[-2]
+
+        # Reshape long prefill sequences to fit on device and parallelize the matmul.
+        if mode == Mode.PREFILL and seq_len >= self.args.prefill_len_cutoff:
+            x = ttnn.reshape(x, [1, seq_len // self.args.prefill_len_cutoff, self.args.prefill_len_cutoff, -1])
+
+        # === VERSION 1: unfused w1/w3 (kept for reference) ===
+        # w1 (gate) and w3 (up): column-parallel. Reduce each over the hidden axis (replicate=True:
+        # every chip needs its full intermediate slice for the elementwise product and w2).
+        # w1_out = ttnn.linear(
+        #     x,
+        #     self.w1,
+        #     dtype=self.activation_dtype or ttnn.bfloat16,
+        #     compute_kernel_config=self.li_ff1_3_compute_kernel_cfg,
+        #     memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        # )
+        # w3_out = ttnn.linear(
+        #     x,
+        #     self.w3,
+        #     dtype=self.activation_dtype or ttnn.bfloat16,
+        #     compute_kernel_config=self.li_ff1_3_compute_kernel_cfg,
+        #     memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        # )
+        # ttnn.deallocate(x)
+        # w1_out = all_reduce(w1_out, self.mesh_device, axis=self.sharding.reduce_col_over,
+        #                     replicate=True, dtype=self.ccl_dtype, topology=self.ccl_topology)
+        # w3_out = all_reduce(w3_out, self.mesh_device, axis=self.sharding.reduce_col_over,
+        #                     replicate=True, dtype=self.ccl_dtype, topology=self.ccl_topology)
+
+        # === VERSION 2: fused gate+up matmul, unfused (serialized) all_reduce (kept for reference) ===
+        # One matmul against the fused [dim, 2*hidden_dim] weight, then a separate all-reduce over
+        # the hidden axis (replicate=True: every chip needs its full intermediate slice).
+        # gate_up = ttnn.linear(
+        #     x,
+        #     self.w1_w3,
+        #     dtype=self.activation_dtype or ttnn.bfloat16,
+        #     compute_kernel_config=self.li_ff1_3_compute_kernel_cfg,
+        #     memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        # )
+        # ttnn.deallocate(x)
+        # gate_up = all_reduce(gate_up, self.mesh_device, axis=self.sharding.reduce_col_over,
+        #                      replicate=True, dtype=self.ccl_dtype, topology=self.ccl_topology)
+
+        # === VERSION 3: fused gate+up matmul + fused reduce_scatter (overlapped) ===
+        # replicate=True -> only the reduce_scatter half fuses/overlaps with the matmul; the helper
+        # still appends a (serialized) all_gather to give every chip the full slice for the product.
+        # MLP_FF13_CORES=<n> pins the FF1/FF3 (gate_up) width-sharded matmul grid; unset = ttnn default.
+        log_default_grid(x, self.w1_w3, "MLP gate_up")
+        ff13_pc = core_grid_program_config(
+            self.args, "MLP_FF13_CORES", x.shape[-2], x.shape[-1], self.w1_w3.shape[-1], "MLP gate_up"
+        )
+        gate_up = matmul_reduce_scatter(
+            x,
+            self.w1_w3,
+            self.mesh_device,
+            self.tt_ccl,
+            axis=self.sharding.reduce_col_over,
+            replicate=True,
+            dtype=self.ccl_dtype,
+            compute_kernel_config=self.li_ff1_3_compute_kernel_cfg,
+            program_config=ff13_pc,
+            topology=self.ccl_topology,
+            label=f"MLP gate_up [{mode}]",
+        )
+        ttnn.deallocate(x)
+
+        # Each device holds a contiguous [gate_i | up_i]; slice down the middle to recover both.
+        # (ttnn.split's two-chunk kernel is currently broken to build, so use two slices.)
+        shape = list(gate_up.shape)
+        half = shape[-1] // 2
+        ends_gate = shape[:-1] + [half]
+        begins_up = [0] * (len(shape) - 1) + [half]
+        w1_out = ttnn.slice(gate_up, [0] * len(shape), ends_gate)
+        w3_out = ttnn.slice(gate_up, begins_up, shape)
+        ttnn.deallocate(gate_up)
+
+        # SILU(w1) * w3
+        w2_in = ttnn.mul(
+            w1_out,
+            w3_out,
+            input_tensor_a_activations=[self.activation_type],
+            dtype=self.activation_dtype or ttnn.bfloat8_b,
+            memory_config=w1_out.memory_config(),
+        )
+        ttnn.deallocate(w1_out)
+        ttnn.deallocate(w3_out)
+
+        # w2 (down): row-parallel. Reduce over the head axis (replicate=False: on a line the output
+        # stays split along the head axis, matching the fractured residual the decoder expects).
+
+        # --- unfused path (kept for reference) ---
+        # w2_out = ttnn.linear(
+        #     w2_in,
+        #     self.w2,
+        #     dtype=self.activation_dtype or ttnn.bfloat16,
+        #     compute_kernel_config=self.li_ff2_compute_kernel_cfg,
+        #     memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        # )
+        # ttnn.deallocate(w2_in)
+        # w2_out = all_reduce(w2_out, self.mesh_device, axis=self.sharding.reduce_row_over,
+        #                     replicate=False, dtype=self.ccl_dtype, topology=self.ccl_topology)
+
+        # --- fused path: matmul + reduce_scatter overlapped (replicate=False -> no trailing
+        # all_gather; the width-sharded result is exactly what the decoder's residual expects).
+        # Falls back to the unfused numerics on anything but a 1D ring.
+        # MLP_FF2_CORES=<n> forces the FF2 (down) matmul core grid; unset = ttnn default.
+        log_default_grid(w2_in, self.w2, "MLP down")
+        ff2_pc = core_grid_program_config(
+            self.args, "MLP_FF2_CORES", w2_in.shape[-2], w2_in.shape[-1], self.w2.shape[-1], "MLP down"
+        )
+        w2_out = matmul_reduce_scatter(
+            w2_in,
+            self.w2,
+            self.mesh_device,
+            self.tt_ccl,
+            axis=self.sharding.reduce_row_over,
+            replicate=False,
+            dtype=self.ccl_dtype,
+            compute_kernel_config=self.li_ff2_compute_kernel_cfg,
+            program_config=ff2_pc,
+            topology=self.ccl_topology,
+            label=f"MLP down [{mode}]",
+        )
+        ttnn.deallocate(w2_in)
+
+        # Collapse the prefill parallelism dims back to [1, 1, seq, dim].
+        s = w2_out.shape
+        return ttnn.reshape(w2_out, (1, 1, s[-4] * s[-3] * s[-2], s[-1]))

--- a/models/tt_transformers/tt/auto_shard/model_auto_shard.py
+++ b/models/tt_transformers/tt/auto_shard/model_auto_shard.py
@@ -1,0 +1,296 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Auto-shard Transformer: the stock Transformer, but with a *replicated* residual stream.
+
+The auto-shard decoder block (decoder_auto_shard.py) and RMSNorm (rmsnorm_auto_shard.py) keep the
+hidden activation replicated -- full hidden dim on every chip -- across the whole stack; each module
+fractures/gathers internally. Stock model.py instead fractures the hidden dim across the mesh and
+leans on DistributedNorm to regather it, which is what breaks when the auto-shard block (expecting
+replicated) is dropped in.
+
+This subclass keeps everything stock (embedding, rope, lm_head, prepare_inputs, tracing) except:
+  * decoder layers are the auto-shard block (model.TransformerBlock is rebound below),
+  * the final norm is an auto-shard RMSNorm with axis=None -- a plain local norm on the replicated
+    full hidden dim -- replacing DistributedNorm, and
+  * forward() gathers the fractured embedding output to replicated once up front, then runs the
+    stack + final norm + lm_head on the replicated stream (no per-layer residual resharding).
+
+Stack-fractured fast path: when every block agrees on one fused residual axis (matching placements
+across attention and MLP) and that axis is the embedding's fracture axis, forward() skips the up-front
+gather, keeps the residual fractured on that axis through the whole stack, and gathers exactly once
+before the final norm -- one all_gather per forward instead of two per layer. See _stack_fractured_axis
+and decoder_auto_shard.enable_stack_fractured. It falls back to the replicated path automatically when
+the placements don't line up.
+
+The lm_head is untouched: its weight is k=args.dim (full hidden), vocab-sharded, so it already wants
+the replicated full-hidden input the auto-shard final norm hands it -- byte-for-byte the layout
+DistributedNorm feeds it in the stock model.
+
+Scope: the single-axis-fractured demo path (1xN mesh, e.g. 1x4), prefill (get_last_token) + decode,
+no prefetcher, non-Galaxy. The stock batched-prefill/trace helpers (_apply_norm_and_lm_head,
+process_*) call self.norm(x, mode=, norm_config=) and are not part of this path.
+
+Importing this module wires everything; a consumer only needs to `import` it before create_tt_model.
+"""
+
+import os
+
+import torch
+
+import ttnn
+
+import models.tt_transformers.tt.model as _model
+from models.tt_transformers.tt.auto_shard.ccl_auto_shard import all_gather
+from models.tt_transformers.tt.common import Mode
+from models.tt_transformers.tt.inline_profile import section
+from models.tt_transformers.tt.auto_shard.decoder_auto_shard import TransformerBlock as _AutoShardTransformerBlock
+from models.tt_transformers.tt.auto_shard.lm_head_auto_shard import LMHeadAutoShard as _AutoShardLMHead
+from models.tt_transformers.tt.auto_shard.rmsnorm_auto_shard import RMSNorm as _AutoShardRMSNorm
+
+# Decoder layers are built from the auto-shard block (Transformer.__init__ reads this name).
+_model.TransformerBlock = _AutoShardTransformerBlock
+
+# LM head drops the stock tail all-reduce (Transformer.__init__ reads this name to build self.lm_head).
+# Its vocab shards are assembled downstream by ttnn_decode_forward / concat_host_output on any mesh.
+_model.LMHead = _AutoShardLMHead
+
+
+def _hidden_shard_axis(mesh_device):
+    """Mesh axis the stock embedding fractures the hidden dim on (last axis with size > 1)."""
+    shape = tuple(mesh_device.shape)
+    for axis in reversed(range(len(shape))):
+        if shape[axis] > 1:
+            return axis
+    return None
+
+
+class Transformer(_model.Transformer):
+    def __init__(self, *args, **kwargs):
+        state_dict = kwargs["state_dict"]  # create_tt_model passes everything by keyword
+        super().__init__(*args, **kwargs)
+        self._hidden_axis = _hidden_shard_axis(self.mesh_device)
+        # Fabric topology for the stack-level residual/logit gathers (Ring on a ring fabric, Linear
+        # otherwise). Cached so per-forward gathers don't re-call ccl_topology() (which logs).
+        self._ccl_topology = self.args.ccl_topology()
+
+        # Fully-fractured stack: if every block keeps its residual fractured on the SAME mesh axis --
+        # and that's the axis the embedding already fractures the hidden dim on -- leave the residual
+        # fractured across the whole stack and gather exactly once at the end, instead of
+        # re-replicating after every block. Falls back to the per-block replicated path otherwise
+        # (mixed placements, replicated hidden, etc.).
+        self._fractured_axis = self._stack_fractured_axis()
+        if self._fractured_axis is not None:
+            for layer in self.layers:
+                layer.enable_stack_fractured()
+            print(f"auto-shard: stack-fractured residual on mesh axis {self._fractured_axis} "
+                  f"(one all_gather per forward)\n")
+
+        # On-device sampling shards the vocab along a single mesh axis (tt_penalties: num_devices =
+        # max(rows, cols)). On a 1xN line that matches the lm_head's flat vocab shard, so leave it
+        # on. On a 2D mesh they disagree (2x2: 64128 vs 32064 per device) and the penalty ops fail
+        # to broadcast, so fall back to host sampling only there -- host sampling consumes the full
+        # logits assembled by ttnn_decode_forward's all_gather / process_output_prefill.
+        rows, cols = tuple(self.mesh_device.shape)
+        if rows > 1 and cols > 1:
+            self._supports_on_device_sampling = False
+
+        # EXPERIMENT (temporary -- revert with `git checkout`): FORCE_HOST_SAMPLING=1 takes the host
+        # path regardless of mesh. The stock gate (model.py) is vocab_size // num_devices <= 64K, and
+        # Qwen2.5-7B's 152064 straddles it -- host at 1x2 (76032), on-device at 1x4 (38016) -- so the
+        # two meshes are not running the same code after the last block. This pins them to one path.
+        # Unlike the other knobs here, host sampling is a supported path: output stays valid.
+        if os.environ.get("FORCE_HOST_SAMPLING") == "1":
+            self._supports_on_device_sampling = False
+
+        # Replicated-stream final norm: full hidden dim on every chip -> plain local rms_norm.
+        self.norm = _AutoShardRMSNorm(
+            device=self.mesh_device,
+            dim=self.args.dim,
+            state_dict=state_dict,
+            weight_key="norm",
+            axis=None,
+            state_dict_prefix=self.args.get_state_dict_prefix("", None),
+            eps=self.args.norm_eps,
+            add_unit_offset=self.args.rms_norm_add_unit_offset,
+        )
+
+    def _stack_fractured_axis(self):
+        """The mesh axis to keep the residual fractured on across the whole stack, or None.
+
+        Requires every block to agree on one non-None fused axis (identical placements everywhere, so
+        each block's attention output, MLP input, and MLP output all sit on it) and that axis to be
+        the one the embedding already fractures the hidden dim on (so the stack's fractured input is
+        the embedding output as-is -- no up-front gather). None disables the fast path.
+        """
+        axes = {getattr(layer, "_fuse_axis", None) for layer in self.layers}
+        if len(axes) != 1:
+            return None
+        axis = axes.pop()
+        if axis is None or axis != self._hidden_axis:
+            return None
+        return axis
+
+    def forward(
+        self,
+        x,
+        current_pos,
+        rot_mats_global=None,
+        rot_mats_local=None,
+        user_id=0,
+        mode=Mode.DECODE,
+        page_table=None,
+        chunk_page_table=None,
+        chunk_start_idx=None,
+        get_last_token=-1,
+        kv_cache=None,
+        batch_size=1,
+        page_tables_per_layer=None,
+    ):
+        # Embedding fractures the hidden dim across the mesh. Default: gather to replicated once up
+        # front, then each block re-replicates internally. Stack-fractured: leave x fractured on
+        # _fractured_axis (== the embedding's fracture axis) and keep it fractured to the end.
+        if self._fractured_axis is None:
+            x = all_gather(x, self.mesh_device, self._hidden_axis, topology=self._ccl_topology)
+
+        if mode == Mode.PREFILL:
+            rot_mats_global = self._slice_prefill_rot_mats(rot_mats_global, chunk_start_idx)
+            if rot_mats_local is not None:
+                rot_mats_local = self._slice_prefill_rot_mats(rot_mats_local, chunk_start_idx)
+
+        for i, layer in enumerate(self.layers):
+            layer_page_table = page_tables_per_layer[i] if page_tables_per_layer is not None else page_table
+            x = layer(
+                x,
+                current_pos,
+                rot_mats_global=rot_mats_global,
+                rot_mats_local=rot_mats_local,
+                user_id=user_id,
+                mode=mode,
+                page_table=layer_page_table,
+                chunk_page_table=chunk_page_table,
+                chunk_start_idx=chunk_start_idx,
+                kv_cache=kv_cache[i] if kv_cache is not None else None,
+                batch_size=batch_size,
+            )
+
+        if mode == Mode.PREFILL and get_last_token == -1:
+            # Chunked-prefill hidden-state return: hand back the replicated layout stock expects.
+            if self._fractured_axis is not None:
+                x = all_gather(x, self.mesh_device, self._fractured_axis, topology=self._ccl_topology)
+            return x
+
+        # The one gather: reassemble the full hidden dim the final norm + lm_head need. In the default
+        # path x is already replicated, so this is skipped (fractured_axis is None).
+        if self._fractured_axis is not None:
+            x = all_gather(x, self.mesh_device, self._fractured_axis, topology=self._ccl_topology)
+
+        if get_last_token != -1:
+            x = ttnn.slice(x, (0, 0, get_last_token, 0), (1, 1, get_last_token + 32, x.shape[-1]))
+
+        # Final norm on the replicated full hidden dim, then the stock lm_head (unchanged).
+        x = self.norm(x)
+
+        # lm_head expects a width-sharded input (same sharded config for prefill and decode when
+        # no prefetcher), so reshard to match.
+        #
+        # x is USUALLY interleaved here, because the last thing the block stack did was an all_gather
+        # and that returns interleaved DRAM. It is not interleaved on a single-chip mesh: every
+        # collective short-circuits on a size-1 axis, so the gather never runs and the block's own
+        # width-sharded output (which the norm preserves) arrives here untouched. Go through
+        # interleaved in that case -- interleaved_to_sharded rejects an already-sharded input.
+        lm_head_input_mem_cfg = self.args.get_lm_head_input_mem_config(mode, None)
+        if lm_head_input_mem_cfg.is_sharded():
+            if x.memory_config().is_sharded():
+                x = ttnn.sharded_to_interleaved(x, ttnn.DRAM_MEMORY_CONFIG)
+            x = ttnn.interleaved_to_sharded(x, lm_head_input_mem_cfg)
+
+        x = self.lm_head(x)
+        if mode == Mode.PREFILL:
+            x = ttnn.to_memory_config(x, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        return x
+
+    def process_output_prefill(self, tt_out, last_token_idx):
+        """Assemble full logits from the flat vocab-sharded lm_head output.
+
+        The lm_head shards the vocab across ALL mesh devices (ShardTensorToMesh(dim=-1)), so the
+        shards sit in linear device order. Stock concat_host_output assumes vocab-on-columns with
+        rows as a separate (DP/replicate) axis: on a 2D mesh it concatenates each row's shards on
+        the vocab dim but stacks the rows on dim 1, so [0, 0, ...] returns only the first row's half
+        of the vocab. Concatenate every device's shard on the vocab dim in device order instead --
+        correct on a 1xN line and a 2D mesh alike.
+        """
+        assert tt_out.storage_type() == ttnn.StorageType.HOST, "Expected host tensor"
+        shards = [ttnn.to_torch(x) for x in ttnn.get_device_tensors(tt_out)]
+        full = torch.cat(shards, dim=-1)
+        return full[0, 0, last_token_idx, : self.vocab_size]
+
+    def ttnn_decode_forward(
+        self,
+        x,
+        current_pos,
+        rot_mat_idxs=None,
+        page_table=None,
+        kv_cache=None,
+        on_device_logits=False,
+        page_tables_per_layer=None,
+    ):
+        """Same contract as stock ttnn_decode_forward, but assembles the vocab-sharded logits with
+        the axis-aware ccl_auto_shard.all_gather over each real mesh axis instead of the stock
+        experimental all_gather_async(cluster_axis=None).
+
+        The lm_head shards the vocab flat across the whole mesh, so full logits need a whole-mesh
+        gather. The stock single collective hops D0->D1->D2->D3 as one chain, which a 2D fabric can't
+        route (D1->D2 is diagonal on a 2x2). Gathering one axis at a time is an adjacent-hop
+        collective that routes on any mesh: gather the inner (column) axis first, then the outer
+        (row) axis, so the row-major ShardTensorToMesh shards reassemble in order. all_gather no-ops
+        on a size-1 axis, so a 1xN line runs exactly one gather.
+        """
+        rot_mats_global = self.rope_setup.get_rot_mats(rot_mat_idxs)
+        rot_mats_local = self.rope_local_setup.get_rot_mats(rot_mat_idxs) if hasattr(self, "rope_local_setup") else None
+
+        x_embed = self._transform_decode_inputs_device(x)
+
+        if page_tables_per_layer is None:
+            page_tables_per_layer = getattr(self, "_active_page_tables_per_layer", None)
+        page_tables_per_layer = self._page_tables_to_ttnn(page_tables_per_layer)
+
+        with section("TOTAL decode step", self.mesh_device):
+            tt_logits = self.forward(
+                x_embed,
+                current_pos,
+                rot_mats_global=rot_mats_global,
+                rot_mats_local=rot_mats_local,
+                mode=Mode.DECODE,
+                page_table=page_table,
+                kv_cache=kv_cache,
+                page_tables_per_layer=page_tables_per_layer,
+            )
+
+        if on_device_logits:
+            assert self.sampling is not None, (
+                "ttnn_decode_forward got on_device_logits=True but no on-device sampling "
+                "module exists (self.sampling is None)."
+            )
+            self._increment_decode_positions_device(current_pos, rot_mat_idxs)
+            return tt_logits
+
+        # Assemble full logits from the flat vocab shard: inner (column, axis 1) then outer (row,
+        # axis 0). Axis-local hops route on any mesh; a size-1 axis is a no-op.
+        if self.args.num_devices > 1:
+            tt_logits = all_gather(tt_logits, self.mesh_device, 1, topology=self._ccl_topology)
+            tt_logits = all_gather(tt_logits, self.mesh_device, 0, topology=self._ccl_topology)
+
+        tt_logits = ttnn.untilize(
+            tt_logits,
+            use_multicore=True,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            sub_core_grids=self.prefetcher.all_worker_cores_range_set if self.prefetcher is not None else None,
+        )
+
+        return tt_logits, None
+
+
+# Rebind so create_tt_model's function-local `from ...model import Transformer` builds this one.
+# The subclass captured the stock base at definition time, so this doesn't affect inheritance.
+_model.Transformer = Transformer

--- a/models/tt_transformers/tt/auto_shard/model_gemma_auto_shard.py
+++ b/models/tt_transformers/tt/auto_shard/model_gemma_auto_shard.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Activate the Gemma-3 auto-shard stack.
+
+model_auto_shard rebinds model.Transformer and model.LMHead on import; this swaps the decoder block
+on top of that, so create_tt_model builds the Gemma block instead of the stock auto-shard one. Import
+this module (instead of model_auto_shard) from a Gemma entry point. Importing neither leaves every
+existing path untouched -- nothing here runs unless something imports it.
+
+The ModelArgs still has to be the Gemma subclass in models/demos/multimodal/gemma3/tt/model_config.py:
+the base class leaves rms_norm_add_unit_offset False and embed_scale None, and neither is inferable
+from the HF config. models/demos/multimodal/gemma3/demo/text_demo.py already builds that ModelArgs
+and the same model.Transformer this rebinds, so adding an import of this module there is the whole
+wiring.
+"""
+
+import models.tt_transformers.tt.model as _model
+import models.tt_transformers.tt.auto_shard.model_auto_shard  # noqa: F401  (rebinds Transformer + LMHead)
+from models.tt_transformers.tt.auto_shard.decoder_gemma_auto_shard import GemmaTransformerBlock
+from models.tt_transformers.tt.auto_shard.rmsnorm_auto_shard import RMSNorm
+
+# Transformer.__init__ reads this name when building self.layers (model.py:105).
+_model.TransformerBlock = GemmaTransformerBlock
+
+
+class GemmaTransformer(_model.Transformer):
+    """Auto-shard Transformer whose final norm fits Gemma-3's hidden dim in L1.
+
+    Identical to the auto-shard model except the final norm is rebuilt without fp32 accumulation --
+    it is the same width as the block norms, so it hits the same L1 ceiling (see rmsnorm_auto_shard).
+    """
+
+    def __init__(self, *args, **kwargs):
+        state_dict = kwargs["state_dict"]  # create_tt_model passes everything by keyword
+        super().__init__(*args, **kwargs)
+        self.norm = RMSNorm(
+            device=self.mesh_device,
+            dim=self.args.dim,
+            state_dict=state_dict,
+            weight_key="norm",
+            axis=None,
+            state_dict_prefix=self.args.get_state_dict_prefix("", None),
+            eps=self.args.norm_eps,
+            add_unit_offset=self.args.rms_norm_add_unit_offset,
+            fp32_dest_acc_en=False,
+        )
+
+
+_model.Transformer = GemmaTransformer

--- a/models/tt_transformers/tt/auto_shard/rmsnorm_auto_shard.py
+++ b/models/tt_transformers/tt/auto_shard/rmsnorm_auto_shard.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""RMSNorm that matches the auto-shard residual stream's actual layout.
+
+The stream is only ever one of two layouts, and this norms each in place -- no forced full-activation
+gather like the stock DistributedNorm, and no axis-blind ring:
+
+    axis=None   replicated activation (full dim on every chip): a plain local rms_norm, zero collectives.
+    axis=a      activation fractured on mesh axis a: compute partial stats on the local shard, all-gather
+                just the STATS over that named axis (cheap, and 2D-safe), then normalize the shard. The
+                activation stays fractured; the weight is sharded on the same axis to match.
+"""
+
+import ttnn
+from models.common.lightweightmodule import LightweightModule
+from models.tt_transformers.tt.auto_shard.ccl_auto_shard import all_gather
+
+TILE = 32  # rms_norm weight is laid out [1, 1, dim // TILE, TILE]
+
+
+class RMSNorm(LightweightModule):
+    def __init__(
+        self,
+        device,
+        dim,
+        state_dict,
+        weight_key,
+        axis,
+        layer_num=None,
+        state_dict_prefix=None,
+        weight_dtype=ttnn.bfloat16,
+        eps: float = 1e-05,
+        add_unit_offset=False,
+        fp32_dest_acc_en=True,
+    ):
+        super().__init__()
+        self.mesh_device = device
+        self.eps = eps
+        self.axis = axis  # mesh axis the hidden dim is fractured on, or None (replicated)
+
+        if state_dict_prefix:
+            weight_name = f"{state_dict_prefix}{weight_key}.weight"
+        elif layer_num is None:
+            weight_name = f"{weight_key}.weight"
+        else:
+            weight_name = f"layers.{layer_num}.{weight_key}.weight"
+
+        w = state_dict[weight_name].unsqueeze(0).view(1, 1, dim).reshape([1, 1, dim // TILE, TILE])
+        if add_unit_offset:  # Gemma-style: weights are stored as (1 + w)
+            w = w + 1.0
+
+        # Replicated stream -> replicate the weight; fractured stream -> shard the weight's hidden dim
+        # (tensor dim 2) on the same mesh axis, so each chip normalizes its shard with its weight slice.
+        if axis is None:
+            mesh_mapper = ttnn.ReplicateTensorToMesh(device)
+        else:
+            dims = [None, None]
+            dims[axis] = 2
+            mesh_mapper = ttnn.ShardTensor2dMesh(device, dims=tuple(dims), mesh_shape=tuple(device.shape))
+
+        self.weight = ttnn.as_tensor(
+            w,
+            device=device,
+            dtype=weight_dtype,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=mesh_mapper,
+        )
+
+        # fp32_dest_acc_en doubles the norm's intermediate circular buffers, which scale with the
+        # hidden dim: 168 tiles for Gemma-3-27B's 5376 vs 128 for Llama-8B's 4096. That is enough to
+        # push a replicated norm past the 1499136 B L1 budget, so wide models pass False here. Same
+        # workaround decoder.py:102-120 applies to Qwen and to Llama-8B on a Galaxy row submesh.
+        self.compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            math_approx_mode=False,
+            fp32_dest_acc_en=fp32_dest_acc_en,
+            packer_l1_acc=True,
+        )
+
+    def forward(self, x, mode=None, norm_config=None):
+        # mode/norm_config are accepted so this norm is a drop-in for the stock DistributedNorm at the
+        # inherited trace/batched-prefill helpers (_apply_norm_and_lm_head, process_*). They don't
+        # affect an axis=None local norm or a stats-gather fractured norm, so they're ignored here.
+        if self.axis is None:
+            # Replicated: every chip has the full hidden vector, so norm locally.
+            return ttnn.rms_norm(x, epsilon=self.eps, weight=self.weight, compute_kernel_config=self.compute_kernel_config)
+
+        # Fractured: local partial stats -> gather just the stats over the shard axis -> normalize the shard.
+        # rms_norm_pre_all_gather (like the stock DistributedNorm) only takes an interleaved input; in
+        # decode the residual is L1 width-sharded, so pull it back to DRAM interleaved first.
+        if x.is_sharded():
+            x = ttnn.sharded_to_interleaved(x, ttnn.DRAM_MEMORY_CONFIG)
+        stats = ttnn.rms_norm_pre_all_gather(x, compute_kernel_config=self.compute_kernel_config, dtype=ttnn.bfloat16)
+        stats = all_gather(stats, self.mesh_device, self.axis, label="rmsnorm stats all_gather")
+        out = ttnn.rms_norm_post_all_gather(
+            x, stats, epsilon=self.eps, weight=self.weight, compute_kernel_config=self.compute_kernel_config
+        )
+        stats.deallocate(True)
+        return out


### PR DESCRIPTION
**Tested on Llama3.1, Qwen2.5, Gemma3, Phi3.5.**

Full auto sharding path. Supports:

1. **Automatic Mesh Selection** (1x2, 1x4, 2x2, ...)
2. **Automatic Attention + MLP weight sharding specification** (QKV, WO; W1, W2, W3)
3. Full decoder + residual pipeline support for any legal mesh+sharding combination

**Cost Model:**

Picks both the mesh shape to open and how each layer's weights split across it, analytically, with no trial runs. One cost function serves both, so the pre-open estimate and the live one can't drift.

Model. A placement is two choices: which mesh axis the intermediate dim (heads / FFN inner dim) splits on, and which the model dim splits on. A layer costs prefill + decode_steps * decode, where decode follows a power law split**-0.557 and each split axis adds an α–β all-reduce term.

The power law is the point. Decode is neither a flat floor (exponent 0) nor a clean divide (exponent 1). Fitted over splits of 1/2/4 on Llama-3.1-8B and Qwen2.5-7B, with modeled comm subtracted first — worst residual 6.8%. It replaced an Amdahl form that fit two points exactly only because two constants determine two points; the single-chip point refuted it (implied constant moved 29–33% by choice of pair, vs 5% here).

Validated out-of-sample on Gemma-3-27B, at 1.89x Llama's per-layer flops: predicted P comes in −3.8%, between the two in-sample residuals. The leading hypothesis that the achieved-flops rate R varies with matmul shape is also dead — backing comm out of all three models gives a 6% spread with Gemma in the middle. Mesh ranking held too: 1x4 predicted ahead of 2x2 by 15.5%, measured 11.3%.

Sharding. select_sharding enumerates ≤9 placements, filters on tile/GQA divisibility, KV-cache write correctness, and per-device DRAM footprint, then takes the argmin. Per-axis bandwidth comes from the live fabric, so asymmetric interconnects steer collectives onto the fat axis.

Mesh. select_mesh_plan runs pre-open (opening a device freezes the descriptor and fabric config), scoring each candidate at its own best sharding. The fixed per-token term dominates: per-layer cost varies <4% across meshes, while sampling swings 3.4 → 22.8 ms depending on which path the mesh shape forces.

Also fixed here: Gemma on 2x2 is the first run the cost model ever sent to a split model dim (i0/m1), which surfaced a KV-cache prefill bug — the code strided the device list by num_model_shards, a data-parallel operation applied to a tensor-parallel axis, leaving half the mesh with an unfilled cache. Not Gemma-specific; Qwen pinned to that placement fails identically. That placement is how 27B fits on a 2x2 at all (6.68 vs 13.36 GiB/chip).

Gaps. Prefill is charged as a clean divide but measures an exponent of 0.3–0.7 that halves between splits, so no single power law fits it; prefill's fixed cost isn't modeled at all. Mesh selection doesn't check DRAM (the per-layer check catches it). Constants are batch-1. Decode exponent is a compromise between 0.35 (Llama) and 0.43 (Qwen).