### PR TITLE
[DS Prefill] Remove typecasts from DEVICE_FP32 MoE gate

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
@@ -93,7 +93,7 @@ def test_deepseek_v3_moe_perf_galaxy_pad50():
 
     run_model_device_perf_test_with_merge(
         command=_CMD_8X4_pad50,
-        expected_device_perf_ns_per_iteration=27_159_208,  # Recalibrated 2026-07-18 (perf improvement, was 38_028_230).
+        expected_device_perf_ns_per_iteration=17_297_505,  # Recalibrated 2026-07-22 (perf improvement, was 27_159_208).
         subdir="deepseek_v3_moe",
         model_name="deepseek_v3_moe_glx_8x4_pad50",
         num_iterations=1,

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
@@ -53,10 +53,8 @@ def test_deepseek_v3_moe_perf_loudbox():
         expected_ns_8x1=17_151_588,
         model_name_8x1="deepseek_v3_moe_lb_8x1_dispatch_combine",
         command_2x4=_CMD_2X4,
-        # Recalibrated 2026-06-24 on BH LoudBox 2x4 for the same in-place direct-write
-        # change (no full-buffer device fill per layer): 35.13 ms -> 32.31 ms. UP_SPLIT
-        # was already baked in (39_194_517 -> 35_127_772). Was 35_127_772.
-        expected_ns_2x4=31_331_606,
+        # Recalibrated 2026-07-21 on BH LoudBox 2x4.
+        expected_ns_2x4=30_380_713,
         model_name_2x4="deepseek_v3_moe_lb_2x4_gate",
         subdir="deepseek_v3_moe",
         margin=0.03,

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
@@ -644,7 +644,11 @@ class TtMoEGatePrefill(LightweightModule):
         padding_side: str = "right",
         padding_config: ttnn.Tensor = None,
     ) -> tuple[ttnn.Tensor, ttnn.Tensor]:
-        """Run moe_grouped_topk on device with fp32 typecast.
+        """Run moe_grouped_topk on device.
+
+        The (bf16) logits and bias are fed directly to the op, which upcasts them to fp32 inside
+        the kernel; no host-side fp32 typecast is needed (the method name is kept for the DEVICE_FP32
+        gate mode it serves).
 
         When actual_isl is set, padded token rows get sentinel expert
         indices (= n_routed_experts) so downstream masked_bincount/dispatch/
@@ -659,11 +663,12 @@ class TtMoEGatePrefill(LightweightModule):
         if owns_padding_config:
             padding_config = self.build_padding_config(actual_isl, padding_side) if actual_isl is not None else None
 
-        logits_f32 = ttnn.typecast(logits, ttnn.float32)
-        bias_f32 = ttnn.typecast(self.bias, ttnn.float32)
+        # moe_grouped_topk upcasts the (bf16) logits and bias to fp32 inside the kernel, so the
+        # previous host-side ttnn.typecast ops are gone. They were very short (2-5us) and created
+        # op-to-op gaps that fast-dispatch could not hide.
         ttnn_scores, ttnn_top_k_experts_indices = ttnn.experimental.deepseek_prefill.moe_grouped_topk(
-            logits_f32,
-            bias_f32,
+            logits,
+            self.bias,
             n_groups=self.config.n_expert_groups,
             summed_experts_per_group=self.config.n_expert_groups // self.config.n_limited_groups,
             topk_groups=self.config.n_limited_groups,
@@ -674,8 +679,6 @@ class TtMoEGatePrefill(LightweightModule):
             score_func=self.config.score_func,
             padding_config=padding_config,
         )
-        ttnn.deallocate(logits_f32)
-        ttnn.deallocate(bias_f32)
         if owns_padding_config and padding_config is not None:
             ttnn.deallocate(padding_config)
         return ttnn_scores, ttnn_top_k_experts_indices
@@ -690,8 +693,9 @@ class TtMoEGatePrefill(LightweightModule):
     ) -> tuple[ttnn.Tensor, ttnn.Tensor]:
         """Run moe_hash_gate on device: fused tid2eid[input_ids] routing + score_func/normalize/scale.
 
-        Mirrors _device_grouped_gate_fp32's fp32 typecast and padding-config ownership, but expert
-        selection comes from the hash table instead of top-k.
+        Mirrors _device_grouped_gate_fp32's padding-config ownership, but expert selection comes
+        from the hash table instead of top-k. moe_hash_gate still requires an fp32 logits input, so
+        this path keeps the host-side typecast (unlike moe_grouped_topk, which upcasts internally).
         """
         if input_ids is None:
             raise ValueError("GateComputeMode.HASH_DEVICE forward requires input_ids for the tid2eid lookup.")

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_moe_grouped_topk.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_moe_grouped_topk.py
@@ -38,6 +38,12 @@ ROUTING_CONFIG_IDS = ["deepseek-8g256e", "kimi-1g384e", "dsv4flash-1g256e", "dsv
 SCORE_FUNCS = ["sigmoid", "sqrtsoftplus"]
 
 
+# Input dtype for logits/bias. The op upcasts internally bf16 input to fp32.
+INPUT_DTYPES = [ttnn.float32, ttnn.bfloat16]
+INPUT_DTYPE_IDS = ["in_fp32", "in_bf16"]
+
+
+@pytest.mark.parametrize("input_dtype", INPUT_DTYPES, ids=INPUT_DTYPE_IDS)
 @pytest.mark.parametrize("score_func", SCORE_FUNCS)
 @pytest.mark.parametrize(
     "n_groups,total_experts,summed_experts_per_group,topk_groups,n_activated_experts,route_scale",
@@ -59,6 +65,7 @@ def test_moe_grouped_topk(
     route_scale,
     padded_percent,
     score_func,
+    input_dtype,
 ):
     """Verify moe_grouped_topk matches the PyTorch golden reference using recall and PCC.
 
@@ -74,8 +81,15 @@ def test_moe_grouped_topk(
 
     epsilon = 1e-20
 
-    scores = distinct_logits((num_batches, batch_size, seq_len, total_experts))
+    # For the bf16 input path, generate/quantize inputs to bf16 first so the fp32 golden reference
+    # sees the exact same values the device does (the op upcasts bf16 -> fp32 internally).
+    is_bf16 = input_dtype == ttnn.bfloat16
+    logits_gen_dtype = torch.bfloat16 if is_bf16 else torch.float32
+
+    scores = distinct_logits((num_batches, batch_size, seq_len, total_experts), dtype=logits_gen_dtype).float()
     bias = torch.randn(num_batches, batch_size, seq_len, total_experts, dtype=torch.float32)
+    if is_bf16:
+        bias = bias.to(torch.bfloat16).float()
 
     ref_indices, ref_weights = grouped_gate_golden_act(
         scores,
@@ -95,8 +109,8 @@ def test_moe_grouped_topk(
     apply_padding = 0 < num_real < total_tokens
     padding_config = build_padding_config(device, num_real) if apply_padding else None
 
-    ttnn_scores_in = ttnn.from_torch(scores, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
-    ttnn_bias_in = ttnn.from_torch(bias, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_scores_in = ttnn.from_torch(scores, dtype=input_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_bias_in = ttnn.from_torch(bias, dtype=input_dtype, layout=ttnn.TILE_LAYOUT, device=device)
 
     ttnn_weights_out, ttnn_indices_out = ttnn.experimental.deepseek_prefill.moe_grouped_topk(
         ttnn_scores_in,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_grouped_topk/device/kernels/compute/moe_gate_common_compute.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_grouped_topk/device/kernels/compute/moe_gate_common_compute.hpp
@@ -35,6 +35,31 @@ namespace blocks {
 constexpr uint32_t SCORE_FUNC_SIGMOID = 0;       // DeepSeek-V3 / Kimi
 constexpr uint32_t SCORE_FUNC_SQRTSOFTPLUS = 1;  // DeepSeek-V4: sqrt(softplus(x))
 
+// Widen width_tiles input tiles from their (possibly bf16) source format into an fp32 output CB.
+// The whole gate pipeline computes in fp32, and the downstream two-operand ops (e.g. add_bias) need
+// every operand in a single format, so the bf16 gate logits/bias are upcast here (lossless) instead
+// of by a separate host-side ttnn.typecast op. When the input is already fp32 this is an identity copy.
+void upcast_tiles(uint32_t cb_in_id, uint32_t cb_out_fp32_id, uint32_t width_tiles) {
+    CircularBuffer cb_in(cb_in_id);
+    CircularBuffer cb_out(cb_out_fp32_id);
+    reconfig_data_format_srca(cb_in_id);
+    copy_tile_to_dst_init_short(cb_in_id);
+    pack_reconfig_data_format(cb_out_fp32_id);
+    for (uint32_t width_tile = 0; width_tile < width_tiles; width_tile++) {
+        cb_in.wait_front(1);
+        tile_regs_acquire();
+        copy_tile(cb_in_id, 0, 0);
+        tile_regs_commit();
+        cb_in.pop_front(1);
+
+        cb_out.reserve_back(1);
+        tile_regs_wait();
+        pack_tile(0, cb_out_fp32_id);
+        tile_regs_release();
+        cb_out.push_back(1);
+    }
+}
+
 // Applies the selected router affinity activation to each logits tile. The output CB (historically
 // "sigmoid" scores) holds the unbiased activated scores that the writer later gathers for the weights.
 template <uint32_t score_func>

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_grouped_topk/device/kernels/compute/moe_grouped_topk.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_grouped_topk/device/kernels/compute/moe_grouped_topk.cpp
@@ -11,6 +11,8 @@ void kernel_main() {
     // Circular buffer indices
     constexpr uint32_t cb_in_scores = get_named_compile_time_arg_val("cb_in_scores");
     constexpr uint32_t cb_in_bias = get_named_compile_time_arg_val("cb_in_bias");
+    constexpr uint32_t cb_scores_fp32 = get_named_compile_time_arg_val("cb_scores_fp32");
+    constexpr uint32_t cb_bias_fp32 = get_named_compile_time_arg_val("cb_bias_fp32");
     constexpr uint32_t cb_sigmoid_scores = get_named_compile_time_arg_val("cb_sigmoid_scores");
     constexpr uint32_t cb_biased_scores = get_named_compile_time_arg_val("cb_biased_scores");
     constexpr uint32_t cb_out_weights = get_named_compile_time_arg_val("cb_out_weights");
@@ -55,13 +57,18 @@ void kernel_main() {
 
     const uint32_t start_height_tile = get_arg_val<uint32_t>(0);
     const uint32_t end_height_tile = get_arg_val<uint32_t>(1);
-    binary_op_init_common(cb_in_scores, cb_in_bias, cb_biased_scores);
+    binary_op_init_common(cb_scores_fp32, cb_bias_fp32, cb_biased_scores);
 
     for (uint32_t height_tile = start_height_tile; height_tile < end_height_tile; height_tile++) {
-        blocks::apply_score_func<score_func>(cb_in_scores, cb_sigmoid_scores, width_tiles);
+        // Upcast the raw (possibly bf16) logits and bias to fp32 so the rest of the gate runs entirely
+        // in fp32 (the two-operand ops below require a single operand format). Identity when fp32 in.
+        blocks::upcast_tiles(cb_in_scores, cb_scores_fp32, width_tiles);
+        blocks::upcast_tiles(cb_in_bias, cb_bias_fp32, width_tiles);
+
+        blocks::apply_score_func<score_func>(cb_scores_fp32, cb_sigmoid_scores, width_tiles);
 
         // Perform add bias on activated scores
-        blocks::add_bias(cb_sigmoid_scores, cb_in_bias, cb_biased_scores, width_tiles);
+        blocks::add_bias(cb_sigmoid_scores, cb_bias_fp32, cb_biased_scores, width_tiles);
         // Note: cb_sigmoid_scores is NOT popped here - writer will pop it after gather
 
         if constexpr (n_groups == 1) {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_grouped_topk/device/moe_grouped_topk_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_grouped_topk/device/moe_grouped_topk_device_operation.cpp
@@ -19,9 +19,15 @@ void MoeGroupedTopkDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(scores.buffer() != nullptr, "Scores tensor must be allocated");
     TT_FATAL(bias.buffer() != nullptr, "Bias tensor must be allocated");
 
-    TT_FATAL(scores.dtype() == tt::tt_metal::DataType::FLOAT32, "Scores tensor must be FLOAT32");
+    // Inputs may be FLOAT32 or BFLOAT16: the op computes internally in fp32 for precision and the
+    // unpacker upcasts bf16 tiles for free.
+    TT_FATAL(
+        scores.dtype() == tt::tt_metal::DataType::FLOAT32 || scores.dtype() == tt::tt_metal::DataType::BFLOAT16,
+        "Scores tensor must be FLOAT32 or BFLOAT16");
     TT_FATAL(scores.layout() == tt::tt_metal::Layout::TILE, "Scores tensor must be TILE layout");
-    TT_FATAL(bias.dtype() == tt::tt_metal::DataType::FLOAT32, "Bias tensor must be FLOAT32");
+    TT_FATAL(
+        bias.dtype() == tt::tt_metal::DataType::FLOAT32 || bias.dtype() == tt::tt_metal::DataType::BFLOAT16,
+        "Bias tensor must be FLOAT32 or BFLOAT16");
     TT_FATAL(bias.layout() == tt::tt_metal::Layout::TILE, "Bias tensor must be TILE layout");
     TT_FATAL(scores.logical_shape() == bias.logical_shape(), "Scores and bias must have the same shape");
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_grouped_topk/device/moe_grouped_topk_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_grouped_topk/device/moe_grouped_topk_program_factory.cpp
@@ -62,7 +62,8 @@ MoeGroupedTopkDeviceOperation::ProgramFactory::cached_program_t MoeGroupedTopkDe
     auto weights_data_format = tt::tt_metal::datatype_to_dataformat_converter(output_weights.dtype());
     auto indices_data_format = tt::tt_metal::datatype_to_dataformat_converter(output_indices.dtype());
 
-    // All intermediate score CBs stay in fp32 regardless of the input dtype.
+    // The whole gate pipeline computes in fp32, so every intermediate score CB is fp32 regardless of
+    // the input dtype.
     const auto compute_data_format = tt::DataFormat::Float32;
     const uint32_t compute_page_size = tt::tile_size(compute_data_format);
 
@@ -72,6 +73,13 @@ MoeGroupedTopkDeviceOperation::ProgramFactory::cached_program_t MoeGroupedTopkDe
         cb_in_scores, program, all_cores, scores.buffer()->page_size(), 2 * width_tiles, scores_data_format);
     tt::tt_metal::create_cb(
         cb_in_bias, program, all_cores, bias.buffer()->page_size(), 2 * width_tiles, bias_data_format);
+
+    // fp32 upcast targets for the raw inputs (identity copy when the input is already fp32).
+    auto cb_scores_fp32 = tt::CBIndex::c_24;
+    auto cb_bias_fp32 = tt::CBIndex::c_25;
+    tt::tt_metal::create_cb(
+        cb_scores_fp32, program, all_cores, compute_page_size, 2 * width_tiles, compute_data_format);
+    tt::tt_metal::create_cb(cb_bias_fp32, program, all_cores, compute_page_size, 2 * width_tiles, compute_data_format);
     tt::tt_metal::create_cb(
         cb_out_weights,
         program,
@@ -211,6 +219,8 @@ MoeGroupedTopkDeviceOperation::ProgramFactory::cached_program_t MoeGroupedTopkDe
     std::unordered_map<std::string, uint32_t> compute_named_compile_time_args = {
         {"cb_in_scores", cb_in_scores},
         {"cb_in_bias", cb_in_bias},
+        {"cb_scores_fp32", cb_scores_fp32},
+        {"cb_bias_fp32", cb_bias_fp32},
         {"cb_sigmoid_scores", cb_sigmoid_scores},
         {"cb_biased_scores", cb_biased_scores},
         {"cb_out_weights", cb_out_weights},

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_grouped_topk/device/moe_grouped_topk_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_grouped_topk/device/moe_grouped_topk_program_factory.cpp
@@ -62,6 +62,10 @@ MoeGroupedTopkDeviceOperation::ProgramFactory::cached_program_t MoeGroupedTopkDe
     auto weights_data_format = tt::tt_metal::datatype_to_dataformat_converter(output_weights.dtype());
     auto indices_data_format = tt::tt_metal::datatype_to_dataformat_converter(output_indices.dtype());
 
+    // All intermediate score CBs stay in fp32 regardless of the input dtype.
+    const auto compute_data_format = tt::DataFormat::Float32;
+    const uint32_t compute_page_size = tt::tile_size(compute_data_format);
+
     uint32_t n_activated_expert_tiles = tt::div_up(operation_attributes.n_activated_experts, 32);
     uint32_t uint16_page_size = output_indices.buffer()->page_size();
     tt::tt_metal::create_cb(
@@ -85,16 +89,13 @@ MoeGroupedTopkDeviceOperation::ProgramFactory::cached_program_t MoeGroupedTopkDe
 
     auto cb_sigmoid_scores = tt::CBIndex::c_4;
     auto cb_biased_scores = tt::CBIndex::c_5;
-    tt::tt_metal::create_cb(
-        cb_sigmoid_scores, program, all_cores, scores.buffer()->page_size(), width_tiles, scores_data_format);
-    tt::tt_metal::create_cb(
-        cb_biased_scores, program, all_cores, scores.buffer()->page_size(), width_tiles, scores_data_format);
+    tt::tt_metal::create_cb(cb_sigmoid_scores, program, all_cores, compute_page_size, width_tiles, compute_data_format);
+    tt::tt_metal::create_cb(cb_biased_scores, program, all_cores, compute_page_size, width_tiles, compute_data_format);
 
     auto cb_sorted_group_scores = tt::CBIndex::c_6;
     auto cb_sorted_expert_indices_temp = tt::CBIndex::c_7;
     auto cb_expert_index_template = tt::CBIndex::c_8;
-    tt::tt_metal::create_cb(
-        cb_sorted_group_scores, program, all_cores, scores.buffer()->page_size(), 2, scores_data_format);
+    tt::tt_metal::create_cb(cb_sorted_group_scores, program, all_cores, compute_page_size, 2, compute_data_format);
     tt::tt_metal::create_cb(
         cb_sorted_expert_indices_temp, program, all_cores, uint16_page_size, 2, tt::DataFormat::UInt16);
     tt::tt_metal::create_cb(
@@ -111,11 +112,11 @@ MoeGroupedTopkDeviceOperation::ProgramFactory::cached_program_t MoeGroupedTopkDe
         cb_top_experts_per_group,
         program,
         all_cores,
-        scores.buffer()->page_size(),
+        compute_page_size,
         operation_attributes.summed_experts_per_group,
-        scores_data_format);
+        compute_data_format);
     tt::tt_metal::create_cb(
-        cb_group_summed_scores, program, all_cores, scores.buffer()->page_size(), num_group_tiles, scores_data_format);
+        cb_group_summed_scores, program, all_cores, compute_page_size, num_group_tiles, compute_data_format);
     tt::tt_metal::create_cb(
         cb_sorted_group_order,
         program,
@@ -130,9 +131,9 @@ MoeGroupedTopkDeviceOperation::ProgramFactory::cached_program_t MoeGroupedTopkDe
         cb_winning_group_scores,
         program,
         all_cores,
-        scores.buffer()->page_size(),
+        compute_page_size,
         operation_attributes.topk_groups,
-        scores_data_format);
+        compute_data_format);
     tt::tt_metal::create_cb(
         cb_winning_group_indices,
         program,
@@ -147,9 +148,9 @@ MoeGroupedTopkDeviceOperation::ProgramFactory::cached_program_t MoeGroupedTopkDe
         cb_reduce_intermediate,
         program,
         all_cores,
-        scores.buffer()->page_size(),
+        compute_page_size,
         2 * n_activated_expert_tiles,
-        scores_data_format);
+        compute_data_format);
     tt::tt_metal::create_cb(
         cb_final_indices_transposed,
         program,
@@ -159,42 +160,25 @@ MoeGroupedTopkDeviceOperation::ProgramFactory::cached_program_t MoeGroupedTopkDe
         tt::DataFormat::UInt16);
 
     auto cb_reduce_ones_scalar = tt::CBIndex::c_17;
-    tt::tt_metal::create_cb(
-        cb_reduce_ones_scalar, program, all_cores, scores.buffer()->page_size(), 1, scores_data_format);
+    tt::tt_metal::create_cb(cb_reduce_ones_scalar, program, all_cores, compute_page_size, 1, compute_data_format);
 
     auto cb_epsilon_scalar = tt::CBIndex::c_18;
-    tt::tt_metal::create_cb(cb_epsilon_scalar, program, all_cores, scores.buffer()->page_size(), 1, scores_data_format);
+    tt::tt_metal::create_cb(cb_epsilon_scalar, program, all_cores, compute_page_size, 1, compute_data_format);
 
     auto cb_route_scale_scalar = tt::CBIndex::c_19;
-    tt::tt_metal::create_cb(
-        cb_route_scale_scalar, program, all_cores, scores.buffer()->page_size(), 1, scores_data_format);
+    tt::tt_metal::create_cb(cb_route_scale_scalar, program, all_cores, compute_page_size, 1, compute_data_format);
 
     auto cb_normalized_scores = tt::CBIndex::c_20;
     tt::tt_metal::create_cb(
-        cb_normalized_scores,
-        program,
-        all_cores,
-        scores.buffer()->page_size(),
-        2 * n_activated_expert_tiles,
-        scores_data_format);
+        cb_normalized_scores, program, all_cores, compute_page_size, 2 * n_activated_expert_tiles, compute_data_format);
 
     auto cb_reciprocal_sums = tt::CBIndex::c_21;
     tt::tt_metal::create_cb(
-        cb_reciprocal_sums,
-        program,
-        all_cores,
-        scores.buffer()->page_size(),
-        2 * n_activated_expert_tiles,
-        scores_data_format);
+        cb_reciprocal_sums, program, all_cores, compute_page_size, 2 * n_activated_expert_tiles, compute_data_format);
 
     auto cb_gathered_sigmoid = tt::CBIndex::c_22;
     tt::tt_metal::create_cb(
-        cb_gathered_sigmoid,
-        program,
-        all_cores,
-        scores.buffer()->page_size(),
-        2 * n_activated_expert_tiles,
-        scores_data_format);
+        cb_gathered_sigmoid, program, all_cores, compute_page_size, 2 * n_activated_expert_tiles, compute_data_format);
 
     // Optional padding config: when absent, fall back to the output indices buffer so the writer's
     // TensorAccessor compile-time args still line up (a 0 runtime address then disables padding).

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_grouped_topk/moe_grouped_topk_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_grouped_topk/moe_grouped_topk_nanobind.cpp
@@ -16,11 +16,22 @@ void bind_moe_grouped_topk(nb::module_& mod) {
     ttnn::bind_function<"moe_grouped_topk", "ttnn.experimental.deepseek_prefill.">(
         mod,
         R"doc(
-            Gating mechanism for routing inputs in a mixture-of-experts (MoE) model, specifically optimized for DeepSeek. This operation post-processes the scores and bias from the linear gate projection. To each score, it applies a sigmoid, adds the bias, and reshapes the scores into groups. It then sorts the scores within each group, sums the scores of the top p experts in each group, and selects the top k groups. It then selects the top n experts from the selected groups and gathers the unbiased scores (original sigmoid output) based on the top k experts indices. It then normalizes the chosen scores and scales the normalized scores by the scales.
+            Gating mechanism for routing inputs in a mixture-of-experts (MoE) model, specifically
+            optimized for DeepSeek. It post-processes the scores and bias from the linear gate
+            projection through the following stages:
+
+              1. Activation: apply the router affinity activation (score_func) to each score.
+              2. Bias: add the bias and reshape the biased scores into ``n_groups`` groups.
+              3. Group ranking: sort scores within each group, sum the top ``summed_experts_per_group``
+                 experts per group, and select the top ``topk_groups`` groups by that sum.
+              4. Expert selection: select the top ``n_activated_experts`` experts from the selected
+                 groups, then gather the unbiased scores (the activation output, without the bias)
+                 for those experts.
+              5. Normalize and scale: normalize the gathered scores and scale them by ``route_scale``.
 
             Args:
-                scores (ttnn.Tensor): Input scores tensor (dtype must be FLOAT32, layout must be TILE). The shape should be [N, B, S, 256]. N, B and S can be any value. 256 is the number of experts in DeepSeek at each layer.
-                bias (ttnn.Tensor): Bias tensor (dtype must be FLOAT32, layout must be TILE). The shape should be [N, B, S, 256]. N, B and S can be any value. 256 is the number of experts in DeepSeek at each layer.
+                scores (ttnn.Tensor): Input scores tensor (dtype must be FLOAT32 or BFLOAT16, layout must be TILE). BFLOAT16 inputs are upcast to FLOAT32 inside the kernel, so the op computes in fp32 either way (this avoids a separate host-side typecast). The shape should be [N, B, S, 256]. N, B and S can be any value. 256 is the number of experts in DeepSeek at each layer.
+                bias (ttnn.Tensor): Bias tensor (dtype must be FLOAT32 or BFLOAT16, layout must be TILE). BFLOAT16 inputs are upcast to FLOAT32 inside the kernel. The shape should be [N, B, S, 256]. N, B and S can be any value. 256 is the number of experts in DeepSeek at each layer.
                 n_groups (int): Number of groups to partition the experts into. Right now this number must be 8.
                 summed_experts_per_group (int): Number of experts per group to sum prior to ranking groups. Right now this number must be 2.
                 topk_groups (int): Number of top groups to select from. Right now this number must be 4.


### PR DESCRIPTION
## Overview

Removes the two `ttnn.typecast` ops from the DEVICE_FP32 MoE gate path (`_device_grouped_gate_fp32`). Both typecasts (logits → fp32 and bias → fp32) were very short ops (2–5 µs) that created op-to-op gaps fast-dispatch could not hide.

Closes #50239.

## Key Changes

- **`MoeGroupedTopkDeviceOperation` now accepts `FLOAT32` **or** `BFLOAT16`** `scores` and `bias`. The op still computes internally in fp32:
  - All intermediate score CBs stay fp32 (the math runs with `fp32_dest_acc_en` and the writer's byte-offset arithmetic assumes fp32 tiles). Only `cb_in_scores` / `cb_in_bias` track the input format.
  - The unpacker upcasts `bf16 → fp32` for free on read, so the reader/compute/writer kernels are unchanged.
- **Gate (`tt_moe_gate_prefill.py`)** feeds the (bf16) logits and bias directly to `moe_grouped_topk`; the two host-side typecasts (and their deallocs) are gone.
- **Docs**: nanobind docstring updated (dtype now `FLOAT32 or BFLOAT16`, plus a readability pass on the op description); Python docstrings updated to reflect in-kernel upcast.
- **Test**: `test_moe_grouped_topk` gains a `bf16` input variant. For the bf16 case, logits/bias are quantized to bf16 before the fp32 golden runs, so the golden and device see identical values.

## Numerical Equivalence

This is numerically identical to the old path: `bf16 → fp32` is lossless, and the kernel already computed in fp32. Removing the host typecast just avoids materializing an fp32 copy on the host.

## CI Pipelines
------------

[![Blaze Models Prefill](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=fbajraktari/50239-remove-fp32-gate-typecasts)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml?query=branch%3Afbajraktari%2F50239-remove-fp32-gate-typecasts)  
[![T3K e2e DeepSeek Prefill](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=fbajraktari/50239-remove-fp32-gate-typecasts)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch%3Afbajraktari%2F50239-remove-fp32-gate-typecasts)  
[![SP Release DeepSeek Prefill](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=fbajraktari/50239-remove-fp32-gate-typecasts)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch%3Afbajraktari%2F50239-remove-fp32-gate-typecasts)  
[![BH e2e DeepSeek Prefill](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=fbajraktari/50239-remove-fp32-gate-typecasts)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch%3Afbajraktari%2F50239-remove-fp32-gate-typecasts)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fbajraktari/50239-remove-fp32-gate-typecasts)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fbajraktari/50239-remove-fp32-gate-typecasts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fbajraktari/50239-remove-fp32-gate-typecasts)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fbajraktari/50239-remove-fp32-gate-typecasts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=fbajraktari/50239-remove-fp32-gate-typecasts)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:fbajraktari/50239-remove-fp32-gate-typecasts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fbajraktari/50239-remove-fp32-gate-typecasts)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fbajraktari/50239-remove-fp32-gate-typecasts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fbajraktari/50239-remove-fp32-gate-typecasts)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fbajraktari/50239-remove-fp32-gate-typecasts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fbajraktari/50239-remove-fp32-gate-typecasts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fbajraktari/50239-remove-fp32-gate-typecasts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fbajraktari/50239-remove-fp32-gate-typecasts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fbajraktari/50239-remove-fp32-gate-typecasts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fbajraktari/50239-remove-fp32-gate-typecasts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fbajraktari/50239-remove-fp32-gate-typecasts)