### PR TITLE
[skip ci] [Cleanup] Document --mode selector in accuracy tests docs

### DIFF
--- a/tt_metal/tt-llk/docs/tests/accuracy_tests.md
+++ b/tt_metal/tt-llk/docs/tests/accuracy_tests.md
@@ -27,13 +27,17 @@ CHIP_ARCH=wormhole pytest accuracy/test_examples_accuracy.py -s
 ## Run modes
 
 The same op/format matrix can run in three modes, selected with `--mode`. All
-three run the one merged kernel (`sources/eltwise_unary_sfpu_perf.cpp`); they
-differ only in what they measure:
+three run the one merged kernel (`sources/eltwise_unary_sfpu_perf.cpp`), but they
+differ in workload as well as in what they measure: `accuracy` sweeps 2048 points
+with a single loop, while `perf` and `both` use 8192 points and loop 16× for
+stable timings. So the numbers are not directly comparable across modes:
 
 - `accuracy` (default) — run on hardware and compare against the torch golden,
   writing the per-op error files described below.
 - `perf` — profile every scenario for timings only (no golden compare, no file).
-- `both` — do both in one pass: profile *and* write the accuracy files.
+- `both` — profile *and* write the accuracy files in one pass. Restricted to the
+  `L1_TO_L1` scenario (the only one whose L1 output can be read back and compared
+  to the golden), so its timings are narrower than `perf` mode's.
 
 ```bash
 # accuracy only (default — --mode can be omitted)

--- a/tt_metal/tt-llk/docs/tests/accuracy_tests.md
+++ b/tt_metal/tt-llk/docs/tests/accuracy_tests.md
@@ -24,6 +24,31 @@ CHIP_ARCH=wormhole pytest accuracy/test_examples_accuracy.py -s
 `--op` takes a `MathOperation` name (case-insensitive, exact), is repeatable
 (`--op=Exp --op=Log`), and composes with `-k`/`-m`.
 
+## Run modes
+
+The same op/format matrix can run in three modes, selected with `--mode`. All
+three run the one merged kernel (`sources/eltwise_unary_sfpu_perf.cpp`); they
+differ only in what they measure:
+
+- `accuracy` (default) — run on hardware and compare against the torch golden,
+  writing the per-op error files described below.
+- `perf` — profile every scenario for timings only (no golden compare, no file).
+- `both` — do both in one pass: profile *and* write the accuracy files.
+
+```bash
+# accuracy only (default — --mode can be omitted)
+CHIP_ARCH=wormhole pytest accuracy/test_sfpu_accuracy.py
+
+# perf only
+CHIP_ARCH=wormhole pytest accuracy/test_sfpu_accuracy.py --mode=perf
+
+# accuracy + perf in one run
+CHIP_ARCH=wormhole pytest accuracy/test_sfpu_accuracy.py --mode=both
+```
+
+`--mode` keeps only the matching sweep and deselects the other two. It defaults
+to `accuracy`, and can be combined with `--op`.
+
 ## Output
 
 Results go to `accuracy/_csv_output/<arch>/` (e.g. `wh/`, `bh/`), one file per op


### PR DESCRIPTION
### Summary
Docs-only. Adds a "Run modes" section to `docs/tests/accuracy_tests.md`
documenting the `--mode` selector (`accuracy` | `perf` | `both`) introduced by
the accuracy/perf test merge. Existing content is unchanged.

### Notes for reviewers
- No code changes — one file, `docs/tests/accuracy_tests.md`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jmacanovic/accuracy-tests-docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jmacanovic/accuracy-tests-docs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jmacanovic/accuracy-tests-docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jmacanovic/accuracy-tests-docs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jmacanovic/accuracy-tests-docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jmacanovic/accuracy-tests-docs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jmacanovic/accuracy-tests-docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jmacanovic/accuracy-tests-docs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jmacanovic/accuracy-tests-docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jmacanovic/accuracy-tests-docs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jmacanovic/accuracy-tests-docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jmacanovic/accuracy-tests-docs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jmacanovic/accuracy-tests-docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jmacanovic/accuracy-tests-docs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jmacanovic/accuracy-tests-docs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jmacanovic/accuracy-tests-docs)