### PR TITLE
prefill: add Kimi-K2.7 model adapter

### DIFF
--- a/models/demos/common/prefill/adapter.py
+++ b/models/demos/common/prefill/adapter.py
@@ -236,6 +236,8 @@ ADAPTER_PATHS = {
     "glm_5_1": "models.demos.deepseek_v3_d_p.tt.runners.adapters.glm_5_1:GLM51Adapter",
     "glm_5_2": "models.demos.deepseek_v3_d_p.tt.runners.adapters.glm_5_2:GLM52Adapter",
     "kimi_k2_6": "models.demos.deepseek_v3_d_p.tt.runners.adapters.kimi_k2_6:KimiK26Adapter",
+    # Kimi-K2.7: same architecture as K2.6, new checkpoint (adapters/kimi_k2_7.py).
+    "kimi_k2_7": "models.demos.deepseek_v3_d_p.tt.runners.adapters.kimi_k2_7:KimiK27Adapter",
     "minimax_m3": "models.demos.minimax_m3.tt.runners.adapters.minimax_m3:MiniMaxM3PrefillAdapter",
 }
 

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k2_7.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k2_7.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""Kimi-K2.7 prefill adapter.
+
+Architecturally identical to Kimi-K2.6 (same MLA + MoE dims, same reference model and
+device knobs) — only the checkpoint differs. So it subclasses ``KimiK26Adapter`` and
+overrides just the identity and the default cache/trace paths. Its tilized weights were
+populated under the K2.6 adapter name, so ``weight_cache_name`` points the cache lookup
+back at the ``kimi_k2_6`` dir rather than re-tilizing a terabyte of weights.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from models.demos.deepseek_v3_d_p.tt.runners.adapters.kimi_k2_6 import KimiK26Adapter
+
+
+class KimiK27Adapter(KimiK26Adapter):
+    # --- identity & runner defaults ---
+    name = "kimi_k2_7"
+    # Weights live under the K2.6-named cache subdir (populated via the K2.6 adapter); reuse it.
+    weight_cache_name = "kimi_k2_6"
+    ttnn_cache_default = "/mnt/models/moonshotai/Kimi-K2_7-Code-Cache/Kimi-K2_7-Code-Cache-prefill"
+    prefill_trace_default = "/mnt/models/deepseek-prefill-cache/golden/structured_traces/vllm-kimi-k27-codedebug-56320"
+
+    # --- test metadata (HF download coordinates) ---
+    env_var = "KIMI_K2_7_HF_MODEL"
+    default_local_path = Path("/mnt/models/moonshotai/Kimi-K2_7-Code-dequantized")
+    test_prefill_trace_default = (
+        "/mnt/models/deepseek-prefill-cache/golden/structured_traces/vllm-kimi-k27-codedebug-56320"
+    )

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k2_7.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k2_7.py
@@ -5,9 +5,7 @@
 
 Architecturally identical to Kimi-K2.6 (same MLA + MoE dims, same reference model and
 device knobs) — only the checkpoint differs. So it subclasses ``KimiK26Adapter`` and
-overrides just the identity and the default cache/trace paths. Its tilized weights were
-populated under the K2.6 adapter name, so ``weight_cache_name`` points the cache lookup
-back at the ``kimi_k2_6`` dir rather than re-tilizing a terabyte of weights.
+overrides just the identity and the default cache/trace paths.
 """
 
 from __future__ import annotations
@@ -20,8 +18,6 @@ from models.demos.deepseek_v3_d_p.tt.runners.adapters.kimi_k2_6 import KimiK26Ad
 class KimiK27Adapter(KimiK26Adapter):
     # --- identity & runner defaults ---
     name = "kimi_k2_7"
-    # Weights live under the K2.6-named cache subdir (populated via the K2.6 adapter); reuse it.
-    weight_cache_name = "kimi_k2_6"
     ttnn_cache_default = "/mnt/models/moonshotai/Kimi-K2_7-Code-Cache/Kimi-K2_7-Code-Cache-prefill"
     prefill_trace_default = "/mnt/models/deepseek-prefill-cache/golden/structured_traces/vllm-kimi-k27-codedebug-56320"
 

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/mla.py
@@ -57,11 +57,6 @@ def unwrap_multimodal_config(cfg):
 class MLAPrefillAdapter(PrefillModelAdapter):
     """DeepSeek-V3-family prefill adapter (MLA + MoE over TtPrefillRuntime)."""
 
-    # Weight-cache dir prefix; defaults to `name`. A model whose weights were tilized under a
-    # different model's name overrides this to ride on that populated cache (e.g. Kimi-K2.7 reuses
-    # the K2.6 cache — same architecture, only the checkpoint differs).
-    weight_cache_name: Optional[str] = None
-
     # ------------------------------------------------------------------
     # HF config
     # ------------------------------------------------------------------
@@ -87,8 +82,7 @@ class MLAPrefillAdapter(PrefillModelAdapter):
         arch = "bh" if is_blackhole() else "wh"
         num_devices = ttnn.get_num_devices()
         sp, tp = mesh_shape
-        cache_name = self.weight_cache_name or self.name
-        path = Path(env_cache) / f"{cache_name}_{arch}_{num_devices}dev" / f"{sp}x{tp}"
+        path = Path(env_cache) / f"{self.name}_{arch}_{num_devices}dev" / f"{sp}x{tp}"
         path.mkdir(parents=True, exist_ok=True)
         return path
 

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/mla.py
@@ -57,6 +57,11 @@ def unwrap_multimodal_config(cfg):
 class MLAPrefillAdapter(PrefillModelAdapter):
     """DeepSeek-V3-family prefill adapter (MLA + MoE over TtPrefillRuntime)."""
 
+    # Weight-cache dir prefix; defaults to `name`. A model whose weights were tilized under a
+    # different model's name overrides this to ride on that populated cache (e.g. Kimi-K2.7 reuses
+    # the K2.6 cache — same architecture, only the checkpoint differs).
+    weight_cache_name: Optional[str] = None
+
     # ------------------------------------------------------------------
     # HF config
     # ------------------------------------------------------------------
@@ -82,7 +87,8 @@ class MLAPrefillAdapter(PrefillModelAdapter):
         arch = "bh" if is_blackhole() else "wh"
         num_devices = ttnn.get_num_devices()
         sp, tp = mesh_shape
-        path = Path(env_cache) / f"{self.name}_{arch}_{num_devices}dev" / f"{sp}x{tp}"
+        cache_name = self.weight_cache_name or self.name
+        path = Path(env_cache) / f"{cache_name}_{arch}_{num_devices}dev" / f"{sp}x{tp}"
         path.mkdir(parents=True, exist_ok=True)
         return path
 


### PR DESCRIPTION
1. Add one line to the binding's global_env — models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_1rank.yaml:

global_env:
  PREFILL_MODEL: "kimi_k2_7"          # <-- add this line
  PREFILL_FABRIC_MODE: "2d"
  PREFILL_MAX_SEQ_LEN: "56320"
  PREFILL_H2D_SERVICE_ID: "ds_prefill"
  PREFILL_GATE_FALLBACK_MODE: "DEVICE_FP32"

2. Run the runner with that binding:

cd <repo> && source python_env/bin/activate
./models/demos/common/prefill/runners/run_pipeline_prefill.sh \
  models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_request_1rank.yaml \
  <host>:1 <iface>

Same architecture as K2.6 (reuses its config, reference model, and device knobs); only the checkpoint differs. weight_cache_name reuses the K2.6-populated tilized cache instead of re-tilizing. 3049 tok/s on single BH galaxy, 56320 tokens.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jjovicic/kimi-k27-adapter)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jjovicic/kimi-k27-adapter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jjovicic/kimi-k27-adapter)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jjovicic/kimi-k27-adapter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jjovicic/kimi-k27-adapter)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jjovicic/kimi-k27-adapter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jjovicic/kimi-k27-adapter)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jjovicic/kimi-k27-adapter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jjovicic/kimi-k27-adapter)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jjovicic/kimi-k27-adapter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jjovicic/kimi-k27-adapter)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jjovicic/kimi-k27-adapter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jjovicic/kimi-k27-adapter)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jjovicic/kimi-k27-adapter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jjovicic/kimi-k27-adapter)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jjovicic/kimi-k27-adapter)