### PR TITLE
[skip] Gate sparse_sdpa_msa block-cyclic multidevice test to Blackhole

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa_msa_block_cyclic_multidevice.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa_msa_block_cyclic_multidevice.py
@@ -19,6 +19,7 @@ import torch
 
 import ttnn
 
+from models.common.utility_functions import run_for_blackhole
 from tests.ttnn.unit_tests.operations.sdpa.sparse_sdpa_msa_test_utils import (
     BLK_KV,
     make_msa_inputs,
@@ -38,6 +39,7 @@ def _natural_to_block_cyclic(t, sp, n_chunks, chunk_local):
     return t.reshape(1, H, T, d).contiguous()
 
 
+@run_for_blackhole()  # sparse_sdpa_msa is Blackhole-only; nightly runs this dir on wh_n300 too
 @pytest.mark.parametrize("mesh_device", [(1, 2), (1, 4)], indirect=True)  # SP along cols; fixture skips if absent
 @pytest.mark.parametrize("n_chunks", [8])
 @pytest.mark.parametrize("causal", [False, True])  # True: diagonal-block mask must stay on the logical id


### PR DESCRIPTION
### Problem
`test_msa_native_block_cyclic_sp_gt1_matches_plain` (added in #49490) dispatches the Blackhole-only `sparse_sdpa_msa` op but is missing `@run_for_blackhole()`. L2 nightly runs the whole `nightly/.../sdpa` dir on `wh_n300` too, so it tripped `TT_FATAL: sparse_sdpa_msa is Blackhole-only`.

### Fix
Add `@run_for_blackhole()`, matching every other device test in the suite (e.g. `test_msa_native_causal_per_rank_sp`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/gate-msa-block-cyclic-blackhole)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/gate-msa-block-cyclic-blackhole)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/gate-msa-block-cyclic-blackhole)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/gate-msa-block-cyclic-blackhole)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=fix/gate-msa-block-cyclic-blackhole)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:fix/gate-msa-block-cyclic-blackhole)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/gate-msa-block-cyclic-blackhole)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/gate-msa-block-cyclic-blackhole)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/gate-msa-block-cyclic-blackhole)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/gate-msa-block-cyclic-blackhole)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/gate-msa-block-cyclic-blackhole)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/gate-msa-block-cyclic-blackhole)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/gate-msa-block-cyclic-blackhole)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/gate-msa-block-cyclic-blackhole)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/gate-msa-block-cyclic-blackhole)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/gate-msa-block-cyclic-blackhole)