### PR TITLE
Fix sparse SDPA FP8 unpack reconfiguration

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sparse_sdpa_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sparse_sdpa_compute.cpp
@@ -93,8 +93,8 @@ void kernel_main() {
 
     const uint32_t tok_count = get_arg_val<uint32_t>(1);
 
-    compute_kernel_hw_startup<SrcOrder::Reverse>(cb_q_in, cb_k_in, cb_out_im);
-    matmul_init(cb_q_in, cb_k_in);  // one-time full matmul init; the no_mop matmuls reinit off this
+    // Q tilize is the first operation, so startup must configure raw-Q -> tiled-Q.
+    compute_kernel_hw_startup(cb_q_rm, cb_q_in);
 
     scale_cb.wait_front(1);  // persistent reduce scaler; the streaming reduce assumes it is ready
 
@@ -119,9 +119,9 @@ void kernel_main() {
             // tilize K rows -> [Skt, DHt] (waits on reader cb_k_rm -> absorbs the K-read stall)
             compute_kernel_lib::tilize<DHt, cb_k_rm, cb_k_in>(
                 /*num_blocks=*/Skt, /*total_input_pages=*/Skt * tt::constants::TILE_HEIGHT);
-            // fp8 K tilize leaves srcA in fp8. QK reads K (transposed -> srcA) and Q (srcB), so restore
-            // srcA=cb_k_in (bfp8 for fp8 K), srcB=cb_q_in. No-op for bf16; mm_no_mop_init_short does not reconfig.
-            reconfig_data_format(cb_k_in, cb_q_in);
+            // QK reads K (transposed -> srcA) and Q (srcB). Reconfigure both formats and the tiled descriptor
+            // geometry/strides; mm_no_mop_init_short only programs the matmul MOP.
+            reconfig_data_format<false /* to_from_int8 */, true /* is_tile_dim_reconfig_en */>(cb_k_in, cb_q_in);
             // K tilize also leaves the packer in cb_k_in's format+strides (bfp8 for fp8). Restore bf16 once per
             // chunk for the downstream packs (cb_qk_im/max/sum/out share its geometry); configure_pack_width in
             // the qg loop refreshes only the MOP. No-op for bf16.


### PR DESCRIPTION
Fixes Sparse SDPA FP8 nondeterminism across repeated executions.

The raw-FP8 K tilize → tiled QK matmul transition reconfigured data format but left stale UNPACK descriptor geometry/strides. Reconfigure tile dimensions at that boundary and start in the raw-Q tilize configuration; remove the legacy full `matmul_init`.

Validation: local Sparse SDPA suite (78 passed, 4 single-host skips), LLK-assert determinism, and perf tests passed with no measurable regression.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/sparse-sdpa-unpack-reconfig)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/sparse-sdpa-unpack-reconfig)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/sparse-sdpa-unpack-reconfig)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/sparse-sdpa-unpack-reconfig)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pjosipovic/sparse-sdpa-unpack-reconfig)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pjosipovic/sparse-sdpa-unpack-reconfig)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/sparse-sdpa-unpack-reconfig)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/sparse-sdpa-unpack-reconfig)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/sparse-sdpa-unpack-reconfig)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/sparse-sdpa-unpack-reconfig)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/sparse-sdpa-unpack-reconfig)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/sparse-sdpa-unpack-reconfig)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/sparse-sdpa-unpack-reconfig)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/sparse-sdpa-unpack-reconfig)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/sparse-sdpa-unpack-reconfig)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/sparse-sdpa-unpack-reconfig)