### PR TITLE
Implement DRAM footprint tracker

### DIFF
--- a/tt-train/sources/examples/train/callbacks.py
+++ b/tt-train/sources/examples/train/callbacks.py
@@ -16,6 +16,7 @@ from ttml.trainers import SFTTrainer, TrainerCallback
 import moe_activation_logger
 
 MemoryUsageTracker = ttml.core.utils.MemoryUsageTracker
+DramFootprintTracker = ttml.core.utils.DramFootprintTracker
 
 
 class ThroughputCallback(TrainerCallback):
@@ -61,23 +62,78 @@ class ThroughputCallback(TrainerCallback):
 
 
 class MemoryTrackerCallback(TrainerCallback):
-    """In-loop FORWARD_PASS / BACKWARD_PASS / FIRST_ITERATION_COMPLETE snapshots over step 1, then deregister.
+    """In-loop per-micro-step snapshots over step 1, then deregister.
 
     run_training opens the capture session (so its ENTRY/MODEL_CREATION/OPTIMIZER_CREATION setup
     snapshots are included); this callback only adds the per-step snapshots and closes the session.
+
+    Each grad-accumulation micro-step gets a *uniquely named* snapshot (FORWARD_PASS_i / BACKWARD_PASS_i).
+    Reusing one name per pass overwrote the stored trace, collapsing every micro-step to the last one --
+    which hides the gradient buffers allocated on micro-step 1 and retained across the rest, so the
+    stitched cumulative peak under-reports by that amount. Unique names keep each micro-step's real net.
     """
 
+    def __init__(self) -> None:
+        self._micro_step = 0
+
     def on_after_forward(self, trainer: SFTTrainer, batch: Batch, loss: float) -> None:
-        MemoryUsageTracker.snapshot("FORWARD_PASS")
+        self._micro_step += 1
+        MemoryUsageTracker.snapshot(f"FORWARD_PASS_{self._micro_step}")
 
     def on_after_backward(self, trainer: SFTTrainer, batch: Batch) -> None:
-        MemoryUsageTracker.snapshot("BACKWARD_PASS")
+        MemoryUsageTracker.snapshot(f"BACKWARD_PASS_{self._micro_step}")
 
     def on_step_end(self, trainer: SFTTrainer, step: int, *args: Any, **kwargs: Any) -> None:
         MemoryUsageTracker.end_capture("FIRST_ITERATION_COMPLETE")
         MemoryUsageTracker.print_memory_usage()
         MemoryUsageTracker.clear()
         trainer.remove_callback(self)
+
+
+class DramFootprintCallback(TrainerCallback):
+    """Track the peak DRAM footprint over the step, then print it and stop.
+
+    The peak lands in the first step's backward (all activations + gradients + loss transients
+    co-resident) -- no need to track the whole run. Near-zero
+    overhead (a running max/min sampled on the allocation path), so it is always on.
+    Once the window closes (during training) it prints the footprint and deregisters.
+    """
+
+    # Peak usage lands in step 1. Tunable.
+    _PEAK_WINDOW_STEPS = 1
+
+    def __init__(self) -> None:
+        self.footprint: Any = None  # DramFootprint (per device) captured over the window
+        self._active = False
+
+    def on_train_begin(self, trainer: SFTTrainer) -> None:
+        DramFootprintTracker.begin()
+        self._active = True
+
+    def on_step_end(self, trainer: SFTTrainer, step: int, *args: Any, **kwargs: Any) -> None:
+        if self._active and step >= self._PEAK_WINDOW_STEPS:
+            self._close_and_report(step)
+            trainer.remove_callback(self)
+
+    def on_train_end(self, trainer: SFTTrainer) -> None:
+        # Run ended before the window closed (fewer steps than the window): capture and report.
+        if self._active:
+            self._close_and_report(trainer.step)
+
+    def _close_and_report(self, steps: int) -> None:
+        self.footprint = DramFootprintTracker.end()
+        self._active = False
+        mb = 1024 * 1024
+        arena = ttml.core.utils.dram_arena_bytes()
+        reserved = ttml.core.utils.dram_reserved_bytes()
+        peak = self.footprint.peak_allocated_bytes
+        pct = 100 * peak / arena if arena else 0.0
+        print(f"=== DRAM footprint ===")
+        print(f"  peak usage: {peak / mb:,.0f} MB/device ({pct:.1f}% of {arena / mb:,.0f} MB arena)")
+        print(f"  reserved (outside arena): {reserved / mb:,.0f} MB/device")
+        print(
+            f"  largest allocatable block at the tightest point: {self.footprint.min_largest_free_bytes / mb:,.0f} MB/device"
+        )
 
 
 class MoECallback(TrainerCallback):

--- a/tt-train/sources/examples/train/train.py
+++ b/tt-train/sources/examples/train/train.py
@@ -54,6 +54,7 @@ from formatting import HEADER_WIDTH, print_footer, print_header, shorten_home
 from model_builders import FLOPS_REGISTRY, Model, ModelConfig, instantiate_model_from_config, parse_model_config
 from callbacks import (
     AverageLossCallback,
+    DramFootprintCallback,
     MemoryTrackerCallback,
     MoECallback,
     ThroughputCallback,
@@ -501,6 +502,10 @@ def run_training(
     callbacks.append(ThroughputCallback(flops_per_token, peak_tflops, log_interval=1))
     avg_loss_cb = AverageLossCallback()
     callbacks.append(avg_loss_cb)
+
+    # Peak DRAM footprint over the first few steps, which cover the peak. Near-zero overhead, always on;
+    # prints the footprint during training once its window closes.
+    callbacks.append(DramFootprintCallback())
 
     # Diagnostics.
     if args.track_memory:

--- a/tt-train/sources/ttml/nanobind/nb_core.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_core.cpp
@@ -562,6 +562,77 @@ void py_module(nb::module_& m) {
                 Not thread safe.
             )doc");
     }
+
+    // DramFootprintTracker bindings under core.utils
+    {
+        auto py_utils = static_cast<nb::module_>(m.attr("utils"));
+
+        nb::class_<ttml::utils::DramFootprint>(
+            py_utils, "DramFootprint", "Peak DRAM footprint over a tracking window, bytes per device.")
+            .def_ro("peak_allocated_bytes", &ttml::utils::DramFootprint::peak_allocated_bytes, "Highest usage reached.")
+            .def_ro(
+                "min_largest_free_bytes",
+                &ttml::utils::DramFootprint::min_largest_free_bytes,
+                "Largest single buffer still allocatable at the tightest point (the OOM-limiting contiguity).");
+
+        py_utils.def(
+            "dram_reserved_bytes",
+            &ttml::utils::dram_reserved_bytes,
+            R"doc(
+            DRAM reserved outside the allocator arena, in bytes per device (physical - arena).
+            A static device property (firmware base + any trace region), independent of footprint tracking.
+            )doc");
+
+        py_utils.def(
+            "dram_arena_bytes",
+            &ttml::utils::dram_arena_bytes,
+            R"doc(
+            DRAM arena (allocatable) size, in bytes per device -- the budget peak usage competes for.
+            OOM is gated by this, not physical DRAM. physical = arena + reserved.
+            )doc");
+
+        py_utils.def_submodule(
+            "DramFootprintTracker", "Zero-overhead peak DRAM footprint tracking via the real device allocator.");
+        auto py_tracker = static_cast<nb::module_>(py_utils.attr("DramFootprintTracker"));
+
+        py_tracker.def(
+            "begin",
+            &ttml::utils::DramFootprintTracker::begin,
+            R"doc(
+            Begin zero-overhead peak DRAM footprint tracking on the active device; resets the footprint.
+
+            While active, every DRAM allocation samples the allocator on the allocation path itself
+            (O(size classes) -- no op hooks, no capture buffers), so it measures the true peak DRAM
+            footprint of the enclosed region at effectively zero cost, without perturbing op timings.
+            Unlike MemoryUsageTracker this reads the real device allocator rather than an op-graph estimate.
+
+            Raises:
+                RuntimeError: if tracking is already active (not nestable).
+
+            Note:
+                Not thread safe. Prefer the ttml.track_dram_footprint() context manager.
+            )doc");
+
+        py_tracker.def(
+            "footprint",
+            &ttml::utils::DramFootprintTracker::footprint,
+            R"doc(
+            The DramFootprint since begin() (peak_allocated_bytes, min_largest_free_bytes), or zeros if not active.
+
+            Note:
+                Not thread safe.
+            )doc");
+
+        py_tracker.def(
+            "end",
+            &ttml::utils::DramFootprintTracker::end,
+            R"doc(
+            Stop tracking and return the final DramFootprint (zeros, with a warning, if not active).
+
+            Note:
+                Not thread safe.
+            )doc");
+    }
 }
 
 }  // namespace ttml::nanobind::core

--- a/tt-train/sources/ttml/ttml/__init__.py
+++ b/tt-train/sources/ttml/ttml/__init__.py
@@ -9,6 +9,8 @@ extension are explicitly re-exported here and in subpackage __init__.py files.
 """
 
 import sys
+from contextlib import contextmanager
+
 import ttnn
 
 # Try to import _ttml from the build directory first (when using .pth file with
@@ -59,3 +61,68 @@ def manual_seed(seed: int) -> None:
     """Seed all of ttml's RNGs from a single call."""
     init.manual_seed(seed)
     autograd.AutoContext.get_instance().set_seed(seed)
+
+
+class DramFootprintScope:
+    """Live DRAM footprint (bytes per device) yielded by :func:`track_dram_footprint`.
+
+    ``peak_allocated_bytes`` is the highest usage; ``min_largest_free_bytes`` is the largest single buffer
+    still allocatable at the tightest point (the contiguity that gates OOM under fragmentation, and
+    runs out before total free does). Both read live while the scope is open, frozen once it closes.
+    """
+
+    def __init__(self) -> None:
+        self._final = None  # DramFootprint, set once the scope closes
+
+    def _snapshot(self):
+        return self._final if self._final is not None else core.utils.DramFootprintTracker.footprint()
+
+    @property
+    def peak_allocated_bytes(self) -> int:
+        """Peak DRAM usage in bytes per device."""
+        return self._snapshot().peak_allocated_bytes
+
+    @property
+    def min_largest_free_bytes(self) -> int:
+        """Largest single buffer still allocatable at the tightest point, in bytes per device."""
+        return self._snapshot().min_largest_free_bytes
+
+    @property
+    def reserved_bytes(self) -> int:
+        """DRAM reserved outside the allocator arena (physical - arena), in bytes per device.
+
+        A static device property, so it reads the same whether or not the scope is open.
+        """
+        return core.utils.dram_reserved_bytes()
+
+    @property
+    def arena_bytes(self) -> int:
+        """DRAM arena (allocatable) size, in bytes per device -- the budget peak usage competes for.
+
+        A static device property. ``peak_allocated_bytes`` is a fraction of this; OOM is gated by it.
+        """
+        return core.utils.dram_arena_bytes()
+
+
+@contextmanager
+def track_dram_footprint():
+    """Measure the real peak DRAM footprint (per device) of the enclosed block, at ~zero cost.
+
+    Reads the device allocator directly rather than capturing the op graph, so it reflects true
+    usage and fragmentation without perturbing op timings. The yielded scope exposes ``peak_allocated_bytes``
+    and ``min_largest_free_bytes`` (the OOM-limiting contiguity), live while open and final once closed.
+
+    Example::
+
+        with ttml.track_dram_footprint() as dram:
+            loss = model(batch); loss.backward(); optimizer.step()
+        print(dram.peak_allocated_bytes, dram.min_largest_free_bytes)   # finals, bytes per device
+
+    Not nestable and not thread safe: there is one tracking session per device.
+    """
+    scope = DramFootprintScope()
+    core.utils.DramFootprintTracker.begin()
+    try:
+        yield scope
+    finally:
+        scope._final = core.utils.DramFootprintTracker.end()

--- a/tt-train/sources/ttml/utils/memory_utils.cpp
+++ b/tt-train/sources/ttml/utils/memory_utils.cpp
@@ -4,6 +4,13 @@
 
 #include "memory_utils.hpp"
 
+#include <fmt/format.h>
+
+#include <tt-metalium/allocator.hpp>
+#include <tt-metalium/buffer_types.hpp>
+
+#include "autograd/auto_context.hpp"
+
 namespace ttml::utils {
 using namespace ttnn::graph;
 
@@ -160,5 +167,71 @@ void clear() {
 }
 
 }  // namespace MemoryUsageTracker
+
+namespace DramFootprintTracker {
+
+namespace {
+bool is_tracking_active = false;
+
+// The allocator reports per-bank; per-device bytes = value * num_banks (the same convention as ttnn's
+// get_memory_view / get_available_device_memory_in_bytes).
+DramFootprint to_device(const tt::tt_metal::DramFootprint& per_bank) {
+    const auto& allocator = autograd::ctx().get_device().allocator();
+    const auto num_banks = static_cast<uint64_t>(allocator->get_num_banks(tt::tt_metal::BufferType::DRAM));
+    return {
+        .peak_allocated_bytes = per_bank.peak_allocated_bytes * num_banks,
+        .min_largest_free_bytes = per_bank.min_largest_free_bytes * num_banks,
+    };
+}
+}  // namespace
+
+void begin() {
+    if (is_tracking_active) {
+        throw std::runtime_error("DramFootprintTracker: tracking is already active (begin called twice; not nestable)");
+    }
+    autograd::ctx().get_device().allocator()->begin_dram_footprint_tracking();
+    is_tracking_active = true;
+}
+
+DramFootprint footprint() {
+    if (!is_tracking_active) {
+        return {};
+    }
+    return to_device(autograd::ctx().get_device().allocator()->get_dram_footprint());
+}
+
+DramFootprint end() {
+    if (!is_tracking_active) {
+        fmt::print("WARNING: DramFootprintTracker::end() called while tracking is not active\n");
+        return {};
+    }
+    const auto result = to_device(autograd::ctx().get_device().allocator()->end_dram_footprint_tracking());
+    is_tracking_active = false;
+    return result;
+}
+
+}  // namespace DramFootprintTracker
+
+DramFootprintScope::DramFootprintScope() {
+    DramFootprintTracker::begin();
+}
+DramFootprintScope::~DramFootprintScope() {
+    DramFootprintTracker::end();
+}
+DramFootprint DramFootprintScope::footprint() const {
+    return DramFootprintTracker::footprint();
+}
+
+uint64_t dram_reserved_bytes() {
+    const auto& allocator = autograd::ctx().get_device().allocator();
+    const auto num_banks = static_cast<uint64_t>(allocator->get_num_banks(tt::tt_metal::BufferType::DRAM));
+    return static_cast<uint64_t>(allocator->get_dram_reserved_bytes()) * num_banks;
+}
+
+uint64_t dram_arena_bytes() {
+    const auto& allocator = autograd::ctx().get_device().allocator();
+    const auto num_banks = static_cast<uint64_t>(allocator->get_num_banks(tt::tt_metal::BufferType::DRAM));
+    return static_cast<uint64_t>(allocator->get_bank_size(tt::tt_metal::BufferType::DRAM)) * num_banks;
+}
 
 }  // namespace ttml::utils

--- a/tt-train/sources/ttml/utils/memory_utils.hpp
+++ b/tt-train/sources/ttml/utils/memory_utils.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <nlohmann/json.hpp>
 
 #include "ttnn/common/guard.hpp"
@@ -104,4 +105,67 @@ void print_memory_usage();
 void clear();
 
 }  // namespace MemoryUsageTracker
+
+/// Peak DRAM footprint over a tracking window, in bytes per device.
+struct DramFootprint {
+    uint64_t peak_allocated_bytes = 0;    ///< Highest usage reached.
+    uint64_t min_largest_free_bytes = 0;  ///< Largest single buffer still allocatable at the tightest point.
+};
+
+/**
+ * @brief Zero-overhead peak DRAM footprint tracking via the real device allocator.
+ *
+ * Unlike @ref MemoryUsageTracker (which captures the op graph, adding per-op overhead and modeling
+ * an *estimated* peak), this reads the device allocator directly. While active, each DRAM allocation
+ * samples the allocator on the allocation path itself -- no hooks, no capture buffers -- so it
+ * measures the true peak DRAM footprint of the enclosed region at effectively zero cost, without
+ * perturbing op timings.
+ *
+ * Reports a @ref DramFootprint: peak usage, and the min largest-free block (the contiguity that
+ * limits allocation under fragmentation -- the first number to run out). Operates on the active
+ * device from @ref ttml::autograd::ctx.
+ */
+namespace DramFootprintTracker {
+
+/// Begin tracking; resets the footprint. Throws if already active. Not nestable, not thread safe.
+void begin();
+
+/// The footprint so far (running values), or zeros if not active. Not thread safe.
+[[nodiscard]] DramFootprint footprint();
+
+/// Stop tracking and return the final footprint, or zeros (with a warning) if not active. Not thread safe.
+DramFootprint end();
+
+}  // namespace DramFootprintTracker
+
+/**
+ * @brief RAII scope for @ref DramFootprintTracker: begins on construction, ends on destruction (so
+ * tracking is always released, even on an exception). Read @ref footprint while the scope is alive:
+ * @code
+ *   ttml::utils::DramFootprintScope scope;
+ *   run_training_step();
+ *   auto peak = scope.footprint();
+ * @endcode
+ */
+class DramFootprintScope {
+public:
+    DramFootprintScope();
+    ~DramFootprintScope();
+    DramFootprintScope(const DramFootprintScope&) = delete;
+    DramFootprintScope& operator=(const DramFootprintScope&) = delete;
+    DramFootprintScope(DramFootprintScope&&) = delete;
+    DramFootprintScope& operator=(DramFootprintScope&&) = delete;
+
+    /// The DRAM footprint so far within this scope, in bytes per device.
+    [[nodiscard]] DramFootprint footprint() const;
+};
+
+/// DRAM reserved outside the allocator arena, in bytes per device (physical - arena). A static device
+/// property (firmware base + any trace region), independent of any footprint tracking window.
+[[nodiscard]] uint64_t dram_reserved_bytes();
+
+/// DRAM arena (allocatable) size, in bytes per device -- the budget peak usage competes for. OOM is
+/// gated by this, not by physical DRAM (reserved is never allocatable). physical = arena + reserved.
+[[nodiscard]] uint64_t dram_arena_bytes();
+
 }  // namespace ttml::utils

--- a/tt_metal/api/tt-metalium/allocator.hpp
+++ b/tt_metal/api/tt-metalium/allocator.hpp
@@ -20,6 +20,16 @@ struct Statistics {
     size_t largest_free_block_bytes = 0;
 };
 
+// Peak DRAM pressure over a tracking window (see Allocator::begin_dram_footprint_tracking). Both are
+// per-bank bytes -- multiply by get_num_banks(BufferType::DRAM) for per-device totals.
+struct DramFootprint {
+    // Highest live usage (sum of allocations) reached during the window.
+    size_t peak_allocated_bytes = 0;
+    // Smallest "largest free block" seen: the contiguity that actually gates allocation. A buffer's
+    // per-bank shard fails once it exceeds this, even while total free still looks ample (fragmentation).
+    size_t min_largest_free_bytes = 0;
+};
+
 class Buffer;
 enum class BufferType;
 class AllocatorState;
@@ -49,6 +59,24 @@ public:
     // this helper function is made for reports.cpp in TTNN and act as a transient member function.
     size_t get_worker_l1_size() const;
     Statistics get_statistics(const BufferType& buffer_type) const;
+
+    // DRAM footprint tracking. While active, every DRAM allocation samples the allocator on the
+    // allocation path itself (O(size classes) -- no per-op hooks, no capture buffers), so it measures
+    // the true peak DRAM footprint of a region at effectively zero overhead. Reports both metrics that
+    // predict OOM: peak usage, and the min largest-free block (the contiguity limit under fragmentation
+    // -- the number that actually runs out first). `get_dram_footprint` returns the running values;
+    // `end_...` stops tracking and returns the final ones.
+    //
+    // These are `const` on the handle: like the rest of this facade they drive the underlying
+    // (mutable) allocator through `impl`, and `IDevice::allocator()` only hands out a `const Allocator&`.
+    void begin_dram_footprint_tracking() const;
+    DramFootprint end_dram_footprint_tracking() const;
+    DramFootprint get_dram_footprint() const;
+
+    // DRAM reserved outside the allocator arena (physical bank size - arena), per bank.
+    // Fixed at device init (firmware base + any trace region). Multiply by get_num_banks(DRAM) for per-device.
+    DeviceAddr get_dram_reserved_bytes() const;
+
     // AllocatorState Methods
     // Extracts the current state of the allocator.
     AllocatorState extract_state() const;

--- a/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
+++ b/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <functional>
 #include <optional>
+#include <ranges>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -71,6 +72,7 @@ FreeListOpt::FreeListOpt(
 void FreeListOpt::init() {
     max_size_bytes_ += shrink_size_;
     shrink_size_ = 0;
+    total_allocated_bytes_ = 0;
 
     block_address_.clear();
     block_size_.clear();
@@ -219,6 +221,9 @@ std::optional<DeviceAddr> FreeListOpt::allocate_at_address(DeviceAddr absolute_s
 }
 
 size_t FreeListOpt::allocate_in_block(size_t block_index, DeviceAddr alloc_size, size_t offset) {
+    // Every allocation funnels through here (both allocate() and allocate_at_address()), so it is the
+    // one place to keep the allocated-bytes counter current. The block ends up sized exactly alloc_size.
+    total_allocated_bytes_ += alloc_size;
     if (block_size_[block_index] == alloc_size && offset == 0) {
         block_is_allocated_[block_index] = true;
         insert_block_to_alloc_table(block_address_[block_index], block_index);
@@ -275,6 +280,8 @@ void FreeListOpt::deallocate(DeviceAddr absolute_address) {
     }
     size_t block_index = *block_index_opt;
     block_is_allocated_[block_index] = false;
+    // block_size_ is still the allocated size here (coalescing below only grows the free block).
+    total_allocated_bytes_ -= block_size_[block_index];
     ssize_t prev_block = block_prev_block_[block_index];
     ssize_t next_block = block_next_block_[block_index];
 
@@ -409,34 +416,37 @@ void FreeListOpt::free_meta_block(size_t block_index) {
 void FreeListOpt::clear() { init(); }
 
 Statistics FreeListOpt::get_statistics() const {
-    // TODO: Cache the statistics
-    size_t total_allocated_bytes = 0;
-    size_t total_free_bytes = 0;
-    size_t largest_free_block_bytes = 0;
-
-    for (size_t i = 0; i < block_address_.size(); i++) {
-        if (!meta_block_is_allocated_[i]) {
-            continue;
-        }
-        if (block_is_allocated_[i]) {
-            total_allocated_bytes += block_size_[i];
-        } else {
-            total_free_bytes += block_size_[i];
-            largest_free_block_bytes = std::max(block_size_[i], largest_free_block_bytes);
-        }
+    // Aggregates are maintained incrementally, avoiding the old O(blocks) scan: allocated bytes is a
+    // running counter, free is its complement, and the largest free block is queried from the size classes.
+    if (total_allocated_bytes_ == 0) {
+        return Statistics{
+            .total_allocatable_size_bytes = max_size_bytes_,
+            .total_allocated_bytes = 0,
+            .total_free_bytes = max_size_bytes_,
+            .largest_free_block_bytes = max_size_bytes_,
+        };
     }
-
-    if (total_allocated_bytes == 0) {
-        total_free_bytes = max_size_bytes_;
-        largest_free_block_bytes = max_size_bytes_;
-    }
-
     return Statistics{
         .total_allocatable_size_bytes = max_size_bytes_,
-        .total_allocated_bytes = total_allocated_bytes,
-        .total_free_bytes = total_free_bytes,
-        .largest_free_block_bytes = largest_free_block_bytes,
+        .total_allocated_bytes = total_allocated_bytes_,
+        .total_free_bytes = max_size_bytes_ - total_allocated_bytes_,
+        .largest_free_block_bytes = largest_free_block_bytes(),
     };
+}
+
+DeviceAddr FreeListOpt::largest_free_block_bytes() const {
+    // Size classes partition free blocks by floor(log2(size / base)): every block in a higher class is
+    // larger than any in a lower one, so the largest free block is the max of the highest non-empty class.
+    for (const auto& free_blocks : free_blocks_segregated_by_size_ | std::views::reverse) {
+        DeviceAddr largest = 0;
+        for (size_t block_index : free_blocks) {
+            largest = std::max(largest, block_size_[block_index]);
+        }
+        if (largest != 0) {
+            return largest;
+        }
+    }
+    return 0;
 }
 
 void FreeListOpt::dump_blocks(std::ostream& out) const {

--- a/tt_metal/impl/allocator/algorithms/free_list_opt.hpp
+++ b/tt_metal/impl/allocator/algorithms/free_list_opt.hpp
@@ -81,6 +81,10 @@ private:
     std::vector<uint8_t> block_is_allocated_;       // not using bool to avoid compacting
     std::vector<uint8_t> meta_block_is_allocated_;  // not using bool to avoid compacting
 
+    // Running sum of allocated bytes, maintained on alloc/dealloc so get_statistics() is O(size classes)
+    // instead of O(blocks) -- see largest_free_block_bytes() for the matching free-side query.
+    DeviceAddr total_allocated_bytes_ = 0;
+
     // Metadata block indices that is not currently used (to reuse blocks instead of always allocating new ones)
     std::vector<size_t> free_meta_block_indices_;
 
@@ -137,6 +141,9 @@ private:
     void update_lowest_occupied_address(DeviceAddr address);
 
     size_t find_free_block(DeviceAddr size, bool bottom_up);
+
+    // Largest free block, read from the highest non-empty size class (O(size classes), not O(blocks)).
+    DeviceAddr largest_free_block_bytes() const;
 
     SearchPolicy policy_;
 };

--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -499,6 +499,29 @@ DeviceAddr AllocatorImpl::get_dram_deletion_high_water_mark() const {
     return dram_manager_->get_deletion_high_water_mark();
 }
 
+void AllocatorImpl::begin_dram_footprint_tracking() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    dram_manager_->begin_footprint_tracking();
+}
+
+DramFootprint AllocatorImpl::end_dram_footprint_tracking() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return dram_manager_->end_footprint_tracking();
+}
+
+DramFootprint AllocatorImpl::get_dram_footprint() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return dram_manager_->get_footprint();
+}
+
+DeviceAddr AllocatorImpl::get_dram_reserved_bytes() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    // Physical bank size minus what the allocator arena manages == the region carved off the top
+    // (firmware/unreserved base + any trace region) before allocation begins. Access members directly;
+    // get_bank_size() would re-lock the non-recursive mutex_ and deadlock.
+    return config_->dram_bank_size - dram_manager_->bank_size();
+}
+
 void AllocatorImpl::clear() {
     std::lock_guard<std::mutex> lock(mutex_);
     dram_manager_->clear();
@@ -642,6 +665,14 @@ DeviceAddr Allocator::get_base_allocator_addr(const HalMemType& mem_type) const 
 uint32_t Allocator::get_alignment(BufferType buffer_type) const { return impl->get_alignment(buffer_type); }
 
 Statistics Allocator::get_statistics(const BufferType& buffer_type) const { return impl->get_statistics(buffer_type); }
+
+void Allocator::begin_dram_footprint_tracking() const { impl->begin_dram_footprint_tracking(); }
+
+DramFootprint Allocator::end_dram_footprint_tracking() const { return impl->end_dram_footprint_tracking(); }
+
+DramFootprint Allocator::get_dram_footprint() const { return impl->get_dram_footprint(); }
+
+DeviceAddr Allocator::get_dram_reserved_bytes() const { return impl->get_dram_reserved_bytes(); }
 
 AllocatorState Allocator::extract_state() const { return impl->extract_state(); }
 

--- a/tt_metal/impl/allocator/allocator.hpp
+++ b/tt_metal/impl/allocator/allocator.hpp
@@ -87,6 +87,10 @@ public:
     DeviceAddr get_dram_high_water_mark() const;
     DeviceAddr get_dram_allocation_high_water_mark() const;
     DeviceAddr get_dram_deletion_high_water_mark() const;
+    void begin_dram_footprint_tracking();
+    DramFootprint end_dram_footprint_tracking();
+    DramFootprint get_dram_footprint() const;
+    DeviceAddr get_dram_reserved_bytes() const;
 
     // what does clear even mean on an allocator???
     void clear();

--- a/tt_metal/impl/allocator/bank_manager.cpp
+++ b/tt_metal/impl/allocator/bank_manager.cpp
@@ -471,6 +471,9 @@ uint64_t BankManager::allocate_buffer(
             DeviceAddr end_address = address.value() + size_per_bank;
             allocation_high_water_mark_ = std::max(allocation_high_water_mark_, end_address);
         }
+        if (tracking_footprint_) {
+            record_footprint(alloc);
+        }
 
         // No neighbors, nothing to invalidate
         return address.value();
@@ -535,6 +538,9 @@ uint64_t BankManager::allocate_buffer(
         // are done in interleaved space where both allocations have the same bank offset applied
         DeviceAddr end_address = address.value() + size_per_bank;
         allocation_high_water_mark_ = std::max(allocation_high_water_mark_, end_address);
+    }
+    if (tracking_footprint_) {
+        record_footprint(alloc);
     }
 
     // Allocation in this allocator invalidates caches in allocators that depend on this allocator
@@ -633,6 +639,35 @@ DeviceAddr BankManager::get_high_water_mark() const {
 DeviceAddr BankManager::get_allocation_high_water_mark() const { return allocation_high_water_mark_; }
 
 DeviceAddr BankManager::get_deletion_high_water_mark() const { return deletion_high_water_mark_; }
+
+void BankManager::begin_footprint_tracking() {
+    tracking_footprint_ = true;
+    peak_allocated_bytes_ = 0;
+    min_largest_free_bytes_ = std::numeric_limits<size_t>::max();
+}
+
+DramFootprint BankManager::end_footprint_tracking() {
+    tracking_footprint_ = false;
+    return get_footprint();
+}
+
+DramFootprint BankManager::get_footprint() const {
+    return DramFootprint{
+        .peak_allocated_bytes = peak_allocated_bytes_,
+        // Normalize the unset min (SIZE_MAX) to 0. Read the pair to disambiguate: {peak==0, min==0} means
+        // nothing was recorded, whereas {peak>0, min==0} means contiguous free genuinely reached zero.
+        .min_largest_free_bytes =
+            min_largest_free_bytes_ == std::numeric_limits<size_t>::max() ? 0 : min_largest_free_bytes_,
+    };
+}
+
+void BankManager::record_footprint(const allocator::Algorithm* alloc) {
+    // Sampled right after an allocation -- the instant usage peaks and the largest free block bottoms out
+    // (deallocation only lowers usage and grows free), so tracking the allocate path alone suffices.
+    auto stats = alloc->get_statistics();
+    peak_allocated_bytes_ = std::max(peak_allocated_bytes_, stats.total_allocated_bytes);
+    min_largest_free_bytes_ = std::min(min_largest_free_bytes_, stats.largest_free_block_bytes);
+}
 
 void BankManager::dump_blocks(std::ostream& out, BankManager::AllocatorDependencies::AllocatorID allocator_id) const {
     const auto* alloc = this->get_allocator_from_id(allocator_id);

--- a/tt_metal/impl/allocator/bank_manager.hpp
+++ b/tt_metal/impl/allocator/bank_manager.hpp
@@ -14,8 +14,11 @@
 #include <vector>
 #include <algorithm>
 #include <functional>
+#include <limits>
 #include <tt_stl/small_vector.hpp>
 #include <tt_stl/strong_type.hpp>
+
+#include <tt-metalium/allocator.hpp>
 
 #include "algorithms/allocator_algorithm.hpp"
 #include "core_coord.hpp"
@@ -129,13 +132,16 @@ public:
         AllocatorDependencies::AllocatorID allocator_id = AllocatorDependencies::AllocatorID{0});
     void reset_size(AllocatorDependencies::AllocatorID allocator_id = AllocatorDependencies::AllocatorID{0});
 
-    // High water mark tracking for all allocations (both bottom-up and top-down)
-    // Tracks the maximum address extent reached during the tracking period, including deallocated buffers
+    // Address-extent high-water mark (max address ever touched, incl. freed buffers) for trace-buffer placement.
     void begin_high_water_mark_tracking();
     DeviceAddr end_high_water_mark_tracking();
     DeviceAddr get_high_water_mark() const;
     DeviceAddr get_allocation_high_water_mark() const;
     DeviceAddr get_deletion_high_water_mark() const;
+    // DRAM footprint (peak usage + min largest-free block) for OOM analysis.
+    void begin_footprint_tracking();
+    DramFootprint end_footprint_tracking();
+    DramFootprint get_footprint() const;
 
     // Cross-allocator mirroring: mark a region as allocated/deallocated in a specific sub-allocator.
     // Used to mirror lockstep allocations from the mesh-level allocator into per-device allocators.
@@ -185,10 +191,15 @@ private:
     // Per-allocator cache of: merged allocated ranges of all other dependent allocators
     ttsl::SmallVector<std::optional<std::vector<std::pair<DeviceAddr, DeviceAddr>>>> allocated_ranges_cache_{};
 
-    // High water mark tracking for allocations and deallocations
+    // Address-extent high-water-mark window (trace-buffer placement).
     bool tracking_high_water_mark_ = false;
-    DeviceAddr allocation_high_water_mark_ = 0;
-    DeviceAddr deletion_high_water_mark_ = 0;
+    DeviceAddr allocation_high_water_mark_ = 0;  // max address extent of live allocations
+    DeviceAddr deletion_high_water_mark_ = 0;    // max address extent of freed allocations
+    // DRAM footprint window (OOM analysis); independent of the high-water-mark window above.
+    bool tracking_footprint_ = false;
+    size_t peak_allocated_bytes_ = 0;  // running max of live usage; identity 0 == none recorded
+    size_t min_largest_free_bytes_ =
+        std::numeric_limits<size_t>::max();  // running min; identity max() == none recorded
 
     /*********************************
      * Allocator-independent methods *
@@ -199,6 +210,9 @@ private:
     /*******************************
      * Allocator-dependent methods *
      *******************************/
+    // Sample peak usage / min largest-free block after an allocation (get_statistics is O(size classes)).
+    void record_footprint(const allocator::Algorithm* alloc);
+
     // Returns allocator for the given allocator ID; returns nullptr if allocator ID is invalid
     allocator::Algorithm* get_allocator_from_id(AllocatorDependencies::AllocatorID allocator_id);
     const allocator::Algorithm* get_allocator_from_id(AllocatorDependencies::AllocatorID allocator_id) const;

--- a/ttnn/cpp/ttnn-nanobind/device.cpp
+++ b/ttnn/cpp/ttnn-nanobind/device.cpp
@@ -27,6 +27,7 @@
 #include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/string_view.h>
+#include <nanobind/stl/unordered_map.h>
 #include <nanobind/stl/vector.h>
 
 #include "small_vector_caster.hpp"


### PR DESCRIPTION
### PR Category

Feature

### Summary

Adds a zero-overhead, **real-allocator** DRAM footprint readout for training, and fixes a peak under-report in the existing op-graph `MemoryUsageTracker`.

#### Why
`MemoryUsageTracker` models memory from the op graph — great for per-phase attribution, but it's an estimate, it can't see fragmentation, and (see fix below) it under-reported the peak. This adds a second, complementary view read straight from the device allocator: the true peak, plus the contiguity that actually gates OOM.

#### What it adds

- **`DramFootprint`** — `{peak_allocated_bytes, min_largest_free_bytes}`, sampled on the allocation path in `BankManager` (a running max of usage + running min of the largest contiguous free block). Its own tracking window, independent of the address-extent high-water mark used by `mesh_trace`.
- Allocator facade: `begin/end_dram_footprint_tracking()`, `get_dram_footprint()`, `get_dram_reserved_bytes()`.
- ttml surface: `DramFootprintTracker`, `track_dram_footprint()` context manager, `dram_reserved_bytes()` / `dram_arena_bytes()` (nanobind).
- **`DramFootprintCallback`** — always on, near-zero overhead; tracks the first step (where the peak lands) and prints during training:
  === DRAM footprint ===
    peak usage: 32,036 MB/device (98.3% of 32,595 MB arena)
    reserved (outside arena): 45 MB/device
    largest allocatable block at the tightest point: 131 MB/device
`min_largest_free` is the OOM-relevant number: DRAM buffers are interleaved across banks, so you OOM when the largest **per-bank contiguous** block can't fit a buffer's shard — even with GBs of aggregate free.
- **`FreeListOpt::get_statistics()` is now O(size classes), not O(blocks)** — a running allocated-bytes counter + largest-free read from the top non-empty size class. Speeds up every caller (reports, memory-view snapshots), not just the footprint.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=imichalak/dram-footprint-tracker)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:imichalak/dram-footprint-tracker)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=imichalak/dram-footprint-tracker)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:imichalak/dram-footprint-tracker)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=imichalak/dram-footprint-tracker)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:imichalak/dram-footprint-tracker)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=imichalak/dram-footprint-tracker)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:imichalak/dram-footprint-tracker)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=imichalak/dram-footprint-tracker)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:imichalak/dram-footprint-tracker)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=imichalak/dram-footprint-tracker)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:imichalak/dram-footprint-tracker)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=imichalak/dram-footprint-tracker)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:imichalak/dram-footprint-tracker)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=imichalak/dram-footprint-tracker)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:imichalak/dram-footprint-tracker)