### PR TITLE
[Feature] Parametrize k_chunk_size for DRAMZeroFill

### DIFF
--- a/models/demos/deepseek_v3_b1/micro_ops/dram_zero_fill/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/dram_zero_fill/op.py
@@ -76,6 +76,8 @@ class DRAMZeroFill:
         if mesh_shape is None:
             mesh_shape = (mesh_rows, mesh_cols)
 
+        if k_chunk_size <= 0:
+            raise ValueError(f"k_chunk_size must be positive; got {k_chunk_size}")
         program_config = FlashMLADecode.ProgramConfig(k_chunk_size=k_chunk_size, exp_approx_mode=False)
         if per_device_seq % program_config.k_chunk_size != 0:
             raise ValueError(

--- a/models/demos/deepseek_v3_b1/micro_ops/dram_zero_fill/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/dram_zero_fill/op.py
@@ -36,6 +36,7 @@ class DRAMZeroFill:
         *,
         num_users: int = 1,
         max_seq_len: int = DEFAULT_MAX_SEQ_LEN,
+        k_chunk_size: int = DEFAULT_K_CHUNK_SIZE,
         kvpe_dim: int = DEFAULT_KVPE_DIM,
         dtype: ttnn.DataType = ttnn.bfloat8_b,
         mesh_shape: tuple[int, int] | None = None,
@@ -51,6 +52,7 @@ class DRAMZeroFill:
             device: Single device or MeshDevice to allocate on.
             num_users: Batch / user count (first dimension).
             max_seq_len: Total (global) sequence length across all mesh rows.
+            k_chunk_size: Size of the chunk to decode for FlashMLADecode.
             kvpe_dim: Combined KNOPE + KROPE feature dimension.
             dtype: Data type for the cache (default bfloat8_b).
             mesh_shape: (rows, cols) mesh shape for the tensor topology.
@@ -74,7 +76,7 @@ class DRAMZeroFill:
         if mesh_shape is None:
             mesh_shape = (mesh_rows, mesh_cols)
 
-        program_config = FlashMLADecode.ProgramConfig(k_chunk_size=DEFAULT_K_CHUNK_SIZE, exp_approx_mode=False)
+        program_config = FlashMLADecode.ProgramConfig(k_chunk_size=k_chunk_size, exp_approx_mode=False)
         if per_device_seq % program_config.k_chunk_size != 0:
             raise ValueError(
                 "Per-device sequence length must be divisible by k_chunk_size for KV cache allocation: "

--- a/models/demos/deepseek_v3_b1/tests/run_isolated_unit_tests.py
+++ b/models/demos/deepseek_v3_b1/tests/run_isolated_unit_tests.py
@@ -199,14 +199,18 @@ BUCKETS: tuple[Bucket, ...] = (
             "test_ccl_broadcast[blackhole-True-device_params0-1-30-15-"
             "DataType.BFLOAT16-Layout.TILE-4-2-1-0-output_shape0-input_shard_shape0-"
             "TensorMemoryLayout.WIDTH_SHARDED]",
-            f"{UNIT_TEST_DIR}/test_dram_zero_fill.py::" "test_dram_zero_fill[blackhole-True-1-65536-device_params0]",
-            f"{UNIT_TEST_DIR}/test_dram_zero_fill.py::" "test_dram_zero_fill[blackhole-True-1-131072-device_params0]",
-            f"{UNIT_TEST_DIR}/test_dram_zero_fill.py::" "test_dram_zero_fill[blackhole-True-32-32768-device_params0]",
-            f"{UNIT_TEST_DIR}/test_dram_zero_fill.py::" "test_dram_zero_fill[blackhole-True-32-65536-device_params0]",
-            f"{UNIT_TEST_DIR}/test_dram_zero_fill.py::" "test_dram_zero_fill[blackhole-True-32-131072-device_params0]",
-            f"{UNIT_TEST_DIR}/test_dram_zero_fill.py::" "test_dram_zero_fill[blackhole-True-64-32768-device_params0]",
-            f"{UNIT_TEST_DIR}/test_dram_zero_fill.py::" "test_dram_zero_fill[blackhole-True-64-65536-device_params0]",
-            f"{UNIT_TEST_DIR}/test_dram_zero_fill.py::" "test_dram_zero_fill[blackhole-True-64-131072-device_params0]",
+            f"{UNIT_TEST_DIR}/test_dram_zero_fill.py::"
+            "test_dram_zero_fill[blackhole-True-128-1-131072-device_params0]",
+            f"{UNIT_TEST_DIR}/test_dram_zero_fill.py::"
+            "test_dram_zero_fill[blackhole-True-128-32-131072-device_params0]",
+            f"{UNIT_TEST_DIR}/test_dram_zero_fill.py::"
+            "test_dram_zero_fill[blackhole-True-128-64-131072-device_params0]",
+            f"{UNIT_TEST_DIR}/test_dram_zero_fill.py::"
+            "test_dram_zero_fill[blackhole-True-256-1-131072-device_params0]",
+            f"{UNIT_TEST_DIR}/test_dram_zero_fill.py::"
+            "test_dram_zero_fill[blackhole-True-256-32-131072-device_params0]",
+            f"{UNIT_TEST_DIR}/test_dram_zero_fill.py::"
+            "test_dram_zero_fill[blackhole-True-256-64-131072-device_params0]",
         ),
     ),
     Bucket(

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_zero_fill.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_zero_fill.py
@@ -82,8 +82,9 @@ def test_dram_zero_fill_row_major_formats(bh_2d_mesh_device, dtype, layout):
 )
 @pytest.mark.parametrize("max_seq_len", [1024 * 32, 1024 * 64, 1024 * 128])
 @pytest.mark.parametrize("num_users", [1, 32, 64])
+@pytest.mark.parametrize("k_chunk_size", [128, 256])
 @pytest.mark.requires_grid_size((12, 10))
-def test_dram_zero_fill(bh_2d_mesh_device, num_users: int, max_seq_len: int) -> None:
+def test_dram_zero_fill(bh_2d_mesh_device, num_users: int, max_seq_len: int, k_chunk_size: int) -> None:
     """Zero-fill a KV-cache-shaped DRAM tensor and verify all zeros."""
     if is_slow_dispatch() and (num_users > 1 or max_seq_len > 1024 * 32):
         pytest.skip("Host readback (ttnn.to_torch) for this shape is too slow in slow dispatch mode")
@@ -112,6 +113,7 @@ def test_dram_zero_fill(bh_2d_mesh_device, num_users: int, max_seq_len: int) -> 
         submesh,
         num_users=num_users,
         max_seq_len=max_seq_len,
+        k_chunk_size=k_chunk_size,
         kvpe_dim=KVPE_DIM,
         mesh_shape=(mesh_rows, mesh_cols),
     )
@@ -125,6 +127,7 @@ def test_dram_zero_fill(bh_2d_mesh_device, num_users: int, max_seq_len: int) -> 
         submesh,
         num_users=num_users,
         max_seq_len=max_seq_len,
+        k_chunk_size=k_chunk_size,
         kvpe_dim=KVPE_DIM,
         mesh_shape=(mesh_rows, mesh_cols),
     )

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_zero_fill.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_dram_zero_fill.py
@@ -23,13 +23,13 @@ from models.demos.deepseek_v3_b1.micro_ops.flash_mla.op import FlashMLADecode
 KVPE_DIM = 576
 
 
-def _build_reference_kv_tensor(submesh, num_users, max_seq_len):
+def _build_reference_kv_tensor(submesh, num_users, max_seq_len, k_chunk_size):
     """Create a KV cache via the original from_torch + ShardTensor2dMesh path."""
     mesh_rows = submesh.shape[0]
     mesh_cols = submesh.shape[1]
     per_device_seq = max_seq_len // mesh_rows
 
-    program_config = FlashMLADecode.ProgramConfig(k_chunk_size=128, exp_approx_mode=False)
+    program_config = FlashMLADecode.ProgramConfig(k_chunk_size=k_chunk_size, exp_approx_mode=False)
     kv_nd_shard_spec = ttnn.NdShardSpec(
         shard_shape=[1, 1, program_config.k_chunk_size, KVPE_DIM],
         grid=program_config.grid.optimal_dram_grid(),
@@ -148,7 +148,7 @@ def test_dram_zero_fill(bh_2d_mesh_device, num_users: int, max_seq_len: int, k_c
     )
 
     # Verify topology matches reference from_torch + ShardTensor2dMesh path
-    ref_tensor = _build_reference_kv_tensor(submesh, num_users, max_seq_len)
+    ref_tensor = _build_reference_kv_tensor(submesh, num_users, max_seq_len, k_chunk_size)
 
     ref_topo = ref_tensor.tensor_topology()
     out_topo = output_tensor.tensor_topology()


### PR DESCRIPTION
### PR Category
Feature

### Summary
Parametrize k_chunk_size for DRAMZeroFill to support different chunk sizes for MLA.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aho/fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aho/fill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=aho/fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:aho/fill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=aho/fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:aho/fill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aho/fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aho/fill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=aho/fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:aho/fill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aho/fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aho/fill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aho/fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aho/fill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aho/fill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aho/fill)