### PR TITLE
[MLA GLM] Keep indexer Q in BFP8 through scoring

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_deepseek_prefill_rotary_embedding_indexed.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_deepseek_prefill_rotary_embedding_indexed.py
@@ -64,17 +64,35 @@ def _rotated_chip_positions(kv_actual, sp, chunk_local):
     return positions
 
 
-@pytest.mark.parametrize("mesh_device", [(2, 2), (2, 4), (8, 4)], ids=["2x2", "2x4", "8x4"], indirect=True)
-@pytest.mark.parametrize(
-    "config_name, num_heads_local, new_isl_tiles_per_dev, cache_tokens_per_dev",
-    [
-        ("small", 2, 4, 512),  # small: 2 heads/dev, 4-tile chunk/dev
-        ("repr", 8, 20, 6400),  # representative: 8 heads/dev, 5k new isl + 50k cache on 8x4 (per-dev scaled)
-    ],
-    ids=["small", "repr"],
+_MESHES = [(2, 2), (2, 4), (8, 4)]
+_CONFIGS = [("small", 2, 4, 512), ("repr", 8, 20, 6400)]
+_CASES = [
+    pytest.param(
+        mesh,
+        *config,
+        tensor_kind,
+        scenario,
+        ttnn.bfloat16,
+        id=f"{mesh[0]}x{mesh[1]}-{config[0]}-{tensor_kind}-{scenario}-bf16",
+    )
+    for mesh in _MESHES
+    for config in _CONFIGS
+    for tensor_kind in ("Q", "KV")
+    for scenario in ("non_padded", "padded_partial")
+]
+_CASES.append(
+    pytest.param(
+        (2, 4), "small", 2, 4, 512, "Q", "padded_partial", ttnn.bfloat8_b, id="2x4-small-Q-padded_partial-bfp8"
+    )
 )
-@pytest.mark.parametrize("tensor_kind", ["Q", "KV"], ids=["Q", "KV"])
-@pytest.mark.parametrize("scenario", ["non_padded", "padded_partial"], ids=["non_padded", "padded_partial"])
+
+
+@pytest.mark.parametrize(
+    "mesh_device, config_name, num_heads_local, new_isl_tiles_per_dev, cache_tokens_per_dev, "
+    "tensor_kind, scenario, input_dtype",
+    _CASES,
+    indirect=["mesh_device"],
+)
 @pytest.mark.timeout(0)
 def test_rotary_embedding_indexed_multi_iteration_prefill(
     mesh_device,
@@ -84,6 +102,7 @@ def test_rotary_embedding_indexed_multi_iteration_prefill(
     cache_tokens_per_dev,
     tensor_kind,
     scenario,
+    input_dtype,
     is_ci_env,
     is_ci_v2_env,
 ):
@@ -102,7 +121,8 @@ def test_rotary_embedding_indexed_multi_iteration_prefill(
 
     Each iteration rotates a random chunk on device and PCCs every (chip, row) against a torch RoPE
     reference applied at that row's true global position. Also asserts program-cache reuse, proving
-    kv_actual_global is a runtime arg (not hashed)."""
+    kv_actual_global is a runtime arg (not hashed). The additional BFP8 Q case uses the same BF16
+    cos/sin and transformation matrix as the production path."""
     if (is_ci_env or is_ci_v2_env) and not (config_name == "small" and scenario == "padded_partial"):
         pytest.skip("CI runs only the small padded_partial case; the others are subsets of it")
 
@@ -129,7 +149,7 @@ def test_rotary_embedding_indexed_multi_iteration_prefill(
     assert cum_total <= cache_global, f"valid tokens ({cum_total}) must fit the cache ({cache_global})"
 
     logger.info(
-        f"tensor_kind={tensor_kind} n_heads={n_heads} sp={sp} tp={tp} chunk_local={C} "
+        f"tensor_kind={tensor_kind} dtype={input_dtype} n_heads={n_heads} sp={sp} tp={tp} chunk_local={C} "
         f"chunk_global={chunk_global} cache_global={cache_global}; "
         f"new_isl per iter={new_actual_isls} (cum_total={cum_total})"
     )
@@ -147,22 +167,26 @@ def test_rotary_embedding_indexed_multi_iteration_prefill(
     shard_dims[sp_axis] = 2  # SP-shard the seq dim; replicate across TP
     from_torch_kwargs = dict(
         device=mesh_device,
-        dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
     cos_tt = ttnn.from_torch(
         cos_re,
+        dtype=ttnn.bfloat16,
         mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims),
         **from_torch_kwargs,
     )
     sin_tt = ttnn.from_torch(
         sin_re,
+        dtype=ttnn.bfloat16,
         mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims),
         **from_torch_kwargs,
     )
     trans_tt = ttnn.from_torch(
-        get_rot_transformation_mat(), mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device), **from_torch_kwargs
+        get_rot_transformation_mat(),
+        dtype=ttnn.bfloat16,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        **from_torch_kwargs,
     )
 
     input_shard_dims = [None, None]
@@ -187,6 +211,7 @@ def test_rotary_embedding_indexed_multi_iteration_prefill(
         torch_input = torch.randn(1, n_heads, chunk_global, ROPE_HEAD_DIM, dtype=torch.bfloat16)
         tt_input = ttnn.from_torch(
             torch_input,
+            dtype=input_dtype,
             mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=input_shard_dims),
             **from_torch_kwargs,
         )
@@ -201,6 +226,7 @@ def test_rotary_embedding_indexed_multi_iteration_prefill(
             kv_actual_global=kv_actual,
             cluster_axis=sp_axis,
         )
+        assert tt_out.dtype == input_dtype
         if entries_after_first is None:
             ttnn.synchronize_device(mesh_device)
             entries_after_first = mesh_device.num_program_cache_entries()
@@ -217,6 +243,7 @@ def test_rotary_embedding_indexed_multi_iteration_prefill(
         sin_sel = sin_full[0, 0, flat, :].unsqueeze(0).unsqueeze(0)
         ref = (torch_input * cos_sel) + (rotate_half(torch_input, meta_style=True) * sin_sel)
 
+        assert torch.isfinite(out_host).all()
         _, msg = assert_with_pcc(ref, out_host, 0.99)
         logger.info(f"  iter {it}: PCC {msg}")
         kv_actual += new_actual_isl

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
@@ -597,8 +597,23 @@ def test_sparse_mla_rotated(
 @pytest.mark.skipif(not is_blackhole(), reason="DSA ops (indexer / sparse SDPA) are Blackhole-only")
 @pytest.mark.timeout(0)
 def test_sparse_mla_accuracy(
-    mesh_device, seq_len, device_params, variant, config_only, ds_layer, ds_checkpoint, ds_repo
+    mesh_device,
+    seq_len,
+    device_params,
+    variant,
+    config_only,
+    ds_layer,
+    ds_checkpoint,
+    ds_repo,
+    monkeypatch,
 ):
+    original = ttnn.experimental.indexer_score_dsa
+
+    def check_indexer_q_format(q, *args, **kwargs):
+        assert q.dtype == ttnn.bfloat8_b
+        return original(q, *args, **kwargs)
+
+    monkeypatch.setattr(ttnn.experimental, "indexer_score_dsa", check_indexer_q_format)
     topology = _topology_from_device_params(device_params)
     run_sparse_mla_accuracy_case(variant, config_only, mesh_device, seq_len, topology, ds_layer, ds_checkpoint, ds_repo)
 

--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -547,6 +547,8 @@ class TtIndexer:
             self._idx_wq_b,
             compute_kernel_config=self.default_compute_kernel_config,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            # Keep indexer Q in BFP8 from its first materialization through scoring.
+            dtype=ttnn.bfloat8_b,
         )  # [1, 1, S/sp, H_idx*D_idx] — ALL heads (wq_b replicated); queries stay SP-sharded (rotation-safe)
         q, _, _ = ttnn.experimental.nlp_create_qkv_heads(
             q, num_heads=a.index_n_heads, num_kv_heads=0, transpose_k_heads=False, memory_config=ttnn.DRAM_MEMORY_CONFIG

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
@@ -766,14 +766,14 @@ def test_indexer_score_rejects_fp32_dest_acc(device, expect_error):
 @pytest.mark.skipif(os.environ.get("CI") == "true", reason="perf test - run locally")
 @pytest.mark.parametrize("case_id, heads", GLX_CASES, ids=GLX_IDS)
 def test_indexer_score_perf(device, case_id, heads):
-    """Wall-clock latency per op for the GLX shape at the fullest causal rank (sp7), bfp8 k. Host-dispatched
-    single-op latency (includes enqueue overhead; use tracy for pure device time). Logged ms is the signal;
-    the assert is a coarse hang/regression guard (board-dependent)."""
+    """Wall-clock latency per op for the GLX shape at the fullest causal rank (sp7), with bfp8 q and k.
+    Host-dispatched single-op latency (includes enqueue overhead; use tracy for pure device time). Logged ms
+    is the signal; the assert is a coarse hang/regression guard (board-dependent)."""
     warmup_iters, measured_iters = 3, 20
     chunk_start = GLX_HISTORY + 7 * GLX_SQ
     cfg = glx_config(heads)
     q, k, w = make_inputs(heads, GLX_DIM, GLX_SQ, GLX_T)
-    q_dev = to_device(q, device)
+    q_dev = to_device(q, device, dtype=ttnn.bfloat8_b)
     k_dev = to_device(k, device, dtype=ttnn.bfloat8_b)
     w_dev = to_device(w, device)
 
@@ -791,10 +791,10 @@ def test_indexer_score_perf(device, case_id, heads):
     ms_per_op = (time.perf_counter() - start) / measured_iters * 1e3
 
     logger.info(
-        f"indexer_score {case_id} rank7 heads={heads} k=bfp8: "
+        f"indexer_score {case_id} rank7 heads={heads} q=k=bfp8: "
         f"{ms_per_op:.3f} ms/op (mean of {measured_iters} iters)"
     )
-    assert ms_per_op < 50.0, f"{case_id} rank7 k=bfp8: {ms_per_op:.3f} ms/op exceeds 50 ms guard (regression or hang)"
+    assert ms_per_op < 50.0, f"{case_id} rank7 q=k=bfp8: {ms_per_op:.3f} ms/op exceeds 50 ms guard (regression or hang)"
 
 
 # ---------------------------------------------------------------------------
@@ -805,7 +805,8 @@ def test_indexer_score_perf(device, case_id, heads):
 SP7_CHUNK_START = GLX_HISTORY + 7 * GLX_SQ  # fullest causal case (99.5% valid)
 
 # Blackhole matmul peak (tests/nightly/sdpa_perf_utils.py): 4096 mm FLOP/cycle/core at LoFi, halved per
-# extra math-fidelity phase. The band checks measure the deployed HiFi2 path (bf16 q, bfp8 k).
+# extra math-fidelity phase. The band checks measure the deployed LoFi path: indexer_score selects LoFi when
+# both Q and K are bfp8.
 _BH_CLOCK_GHZ = 1.35
 _MM_FLOPS_PER_CYCLE_PER_CORE = {"LoFi": 4096, "HiFi2": 2048, "HiFi3": 1365, "HiFi4": 1024}
 
@@ -824,16 +825,16 @@ def indexer_mm_flops(valid_tiles, heads):
     return valid_tiles * heads * (32 * 32) * (2 * GLX_DIM)
 
 
-# perf run helpers at the deployed HiFi2 dtypes (bf16 q + bfp8 k). Each builds its inputs and dispatches the
+# Perf run helpers at the deployed LoFi dtypes (bfp8 q + bfp8 k). Each builds its inputs and dispatches the
 # op once, returning the output -- the same shape as the SDPA sprint's run_sdpa closure. test_indexer_score_
 # math_util profiles one call with the real-time device profiler (one dispatch -> one record). No accuracy
 # check -- these exist solely to be profiled.
 
 
 def run_indexer_sp7(device, heads):
-    """DSA at GLX sp_rank 7 (bf16 q, bfp8 k). Dispatches indexer_score_dsa once and returns the output."""
+    """DSA at GLX sp_rank 7 (bfp8 q and k). Dispatches indexer_score_dsa once and returns the output."""
     q, k, w = make_inputs(heads, GLX_DIM, GLX_SQ, GLX_T)
-    q_dev = to_device(q, device, dtype=ttnn.bfloat16)
+    q_dev = to_device(q, device, dtype=ttnn.bfloat8_b)
     k_dev = to_device(k, device, dtype=ttnn.bfloat8_b)
     w_dev = to_device(w, device)
     cfg = glx_config(heads)
@@ -873,10 +874,10 @@ def short_config(heads):
 
 def run_indexer_short(device, heads):
     """GLM5/DSv32 resharded TP=1/SP=32 -- a SHORT 160-query chunk (QC=1) that under-fills the grid, so the
-    block-split scheduler replicates each q-group across num_blocks=2 row-blocks (110 cores). bf16 q + bfp8 k.
+    block-split scheduler replicates each q-group across num_blocks=2 row-blocks (110 cores). bfp8 q and k.
     Dispatches indexer_score_dsa once and returns the output."""
     q, k, w = make_inputs(heads, GLX_DIM, SHORT_SQ, GLX_T)
-    q_dev = to_device(q, device, dtype=ttnn.bfloat16)
+    q_dev = to_device(q, device, dtype=ttnn.bfloat8_b)
     k_dev = to_device(k, device, dtype=ttnn.bfloat8_b)
     w_dev = to_device(w, device)
     cfg = short_config(heads)
@@ -1238,10 +1239,10 @@ def m3_valid_tiles():
 
 
 def run_indexer_m3(device):
-    """One SP=8 x TP=4 M3 device (1 group, 640 q, 55296 kv, raw dot, scale=1/sqrt(d), bf16 q + bfp8 k).
+    """One SP=8 x TP=4 M3 device (1 group, 640 q, 55296 kv, raw dot, scale=1/sqrt(d), bfp8 q and k).
     Dispatches indexer_score_msa once and returns the output. No accuracy check."""
     q, k, _ = make_inputs(1, M3_DIM, M3_SQ, M3_T)
-    q_dev = to_device(q, device, dtype=ttnn.bfloat16)
+    q_dev = to_device(q, device, dtype=ttnn.bfloat8_b)
     k_dev = to_device(k, device, dtype=ttnn.bfloat8_b)
     # Deployed config: block_size=128 fuses the per-128-key block max (the writer emits the tiny block-score
     # tensor, not the full ~70 MB score that made the unfused path memory-bound). QC=2 + grid-aligned q/K
@@ -1259,8 +1260,8 @@ def run_indexer_m3(device):
 
 
 # ---------------------------------------------------------------------------
-# The math-utilization band checks (CI runs these on the IOMMU-enabled BH sku), all at the deployed HiFi2 dtypes
-# (bf16 q + bfp8 k): the deployed TP=4/SP=8 shapes GLM5, DSv32 and MiniMax-M3 at sp_rank 7, plus the resharded
+# The math-utilization band checks (CI runs these on the IOMMU-enabled BH sku), all at the deployed LoFi dtypes
+# (bfp8 q + bfp8 k): the deployed TP=4/SP=8 shapes GLM5, DSv32 and MiniMax-M3 at sp_rank 7, plus the resharded
 # TP=1/SP=32 grid-fill shapes glm5_tp1 and dsv32_tp1 (block-split, fullest causal). Each profiles one dispatch
 # of its op with the real-time device profiler, reads the device kernel duration, computes
 # math_util = matmul FLOPs / (cores x device cycles x matmul peak), and asserts it within +/-
@@ -1270,24 +1271,24 @@ def run_indexer_m3(device):
 # lower expected util than the multi-head DSA cases.)
 # ---------------------------------------------------------------------------
 _MATH_UTIL_CASES = [
-    # (case_id, run_fn(device) -> op output, mm_flops_thunk, expected_util) -- HiFi2 (bf16 q, bfp8 k)
+    # (case_id, run_fn(device) -> op output, mm_flops_thunk, expected_util) -- LoFi (bfp8 q and k)
     (
         "glm5",
         lambda device: run_indexer_sp7(device, 8),
         lambda: indexer_mm_flops(sp7_valid_tiles(), 8),
-        70.1,
+        36.48,
     ),
     (
         "dsv32",
         lambda device: run_indexer_sp7(device, 16),
         lambda: indexer_mm_flops(sp7_valid_tiles(), 16),
-        76.1,
+        64.11,
     ),
     (
         "minimax_m3",
         run_indexer_m3,
         lambda: m3_valid_tiles() * (32 * 32) * (2 * M3_DIM),
-        42.9,
+        21.62,
     ),
     # Block-split grid fill: GLM5/DSv32 resharded TP=1/SP=32 -- a short 160-query chunk (QC=1, 5 q-groups) the
     # scheduler spreads across num_blocks=2 row-blocks (110 cores); without the fill these would use only 55
@@ -1298,13 +1299,13 @@ _MATH_UTIL_CASES = [
         "dsv32_tp1",
         lambda device: run_indexer_short(device, 64),
         lambda: indexer_mm_flops(short_valid_tiles(), 64),
-        77.31,
+        70.72,
     ),
     (
         "glm5_tp1",
         lambda device: run_indexer_short(device, 32),
         lambda: indexer_mm_flops(short_valid_tiles(), 32),
-        75.54,
+        64.98,
     ),
 ]
 
@@ -1318,7 +1319,7 @@ _MATH_UTIL_CASES = [
 @skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
 @skip_with_watcher("Watcher perturbs kernel timing; perf checks are not meaningful with it enabled.")
 def test_indexer_score_math_util(device, case_id, run_fn, mm_flops_thunk, expected_util):
-    """Per-deployment HiFi2 (bf16 q, bfp8 k) matmul math utilization via real-time device program records,
+    """Per-deployment LoFi (bfp8 q and k) matmul math utilization via real-time device program records,
     asserted within +/- INDEXER_PERF_MARGIN: GLM5 / DSv32 / MiniMax-M3 at the deployed TP=4/SP=8, plus
     glm5_tp1 / dsv32_tp1 at the resharded TP=1/SP=32 grid-fill shapes. Profiles one dispatch of the case's op
     with the real-time device profiler and compares the achieved math_util to the expected value (measured on
@@ -1332,14 +1333,14 @@ def test_indexer_score_math_util(device, case_id, run_fn, mm_flops_thunk, expect
     _, perf_record = profile_realtime_program(device, lambda: run_fn(device))
     duration_ns = perf_record["duration_ns"]
     core_count = INDEXER_PERF_CORES
-    peak = _MM_FLOPS_PER_CYCLE_PER_CORE["HiFi2"]
+    peak = _MM_FLOPS_PER_CYCLE_PER_CORE["LoFi"]
     cycles = duration_ns * _BH_CLOCK_GHZ
     utilization = (mm_flops_thunk() / (core_count * cycles * peak)) * 100 if core_count > 0 else 0.0
 
     lower = expected_util * (1 - INDEXER_PERF_MARGIN)
     upper = expected_util * (1 + INDEXER_PERF_MARGIN)
     logger.info(
-        f"indexer_score math util {case_id} (HiFi2): duration={duration_ns / 1e6:.3f} ms, cores={core_count}, "
+        f"indexer_score math util {case_id} (LoFi): duration={duration_ns / 1e6:.3f} ms, cores={core_count}, "
         f"math_util={utilization:.2f}% (expected {expected_util:.2f}%, band [{lower:.2f}, {upper:.2f}])"
     )
     assert lower <= utilization <= upper, (

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/compute/rotary_embedding_llama.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/kernels/compute/rotary_embedding_llama.cpp
@@ -55,8 +55,8 @@ void kernel_main() {
     const uint32_t my_cos_sin_tiles = my_rotary_seq_tiles * Wt;
 
     compute_kernel_hw_startup<SrcOrder::Reverse>(in_cb, trans_mat_cb, out_cb);
-    matmul_init(in_cb, trans_mat_cb);
-    binary_op_init_common(rotated_in_interm_cb, cos_cb, out_cb);  // General Init for all binary ops
+    // Start from the state at the end of each iteration so same-format reconfigurations compile out.
+    binary_op_init_common(cos_interm_cb, sin_interm_cb, out_cb);
 
     // Get the trans_mat
     trans_mat_cb_obj.wait_front(onetile);
@@ -88,6 +88,9 @@ void kernel_main() {
                 out_cb_obj.reserve_back(Wt);
 
                 // // rotated = x @ trans_mat
+                // Matmul uses SrcOrder::Reverse: trans_mat is SrcA and input is SrcB.
+                reconfig_data_format(cos_interm_cb, trans_mat_cb, sin_interm_cb, in_cb);
+                pack_reconfig_data_format(out_cb, rotated_in_interm_cb);
                 matmul_init(in_cb, trans_mat_cb);
                 ACQ();
                 for (uint32_t j = 0; j < Wt; ++j) {
@@ -98,6 +101,8 @@ void kernel_main() {
                 rotated_in_interm_cb_obj.push_back(Wt);
                 rotated_in_interm_cb_obj.wait_front(Wt);
 
+                reconfig_data_format(trans_mat_cb, rotated_in_interm_cb, in_cb, sin_cb);
+                pack_reconfig_data_format(rotated_in_interm_cb, sin_interm_cb);
                 mul_tiles_init(rotated_in_interm_cb, sin_cb);
                 ACQ();
                 for (uint32_t j = 0; j < Wt; ++j) {
@@ -109,6 +114,8 @@ void kernel_main() {
                 sin_interm_cb_obj.push_back(Wt);
                 rotated_in_interm_cb_obj.pop_front(Wt);
 
+                reconfig_data_format(rotated_in_interm_cb, in_cb, sin_cb, cos_cb);
+                pack_reconfig_data_format(sin_interm_cb, cos_interm_cb);
                 ACQ();
                 for (uint32_t j = 0; j < Wt; ++j) {
                     // cos_interim = x * cos
@@ -125,6 +132,8 @@ void kernel_main() {
 
                 sin_interm_cb_obj.wait_front(Wt);
                 cos_interm_cb_obj.wait_front(Wt);
+                reconfig_data_format(in_cb, cos_interm_cb, cos_cb, sin_interm_cb);
+                pack_reconfig_data_format(cos_interm_cb, out_cb);
                 add_tiles_init(cos_interm_cb, sin_interm_cb);
                 ACQ();
                 for (uint32_t j = 0; j < Wt; ++j) {


### PR DESCRIPTION
Keep the sparse indexer Q tensor in bfloat8_b from its initial materialization at wq_b through Q-head creation, indexed RoPE, TP sequence partitioning, and indexer_score_dsa.

The indexed-RoPE compute kernel now supports BFP8 Q with the existing BF16 transformation, cosine, and sine tensors. It reconfigures unpacker and packer formats only at the actual format transitions, avoiding an extra transformation-matrix copy or runtime typecast while preserving the BF16 path.

No Hadamard transform is added. Direct bfloat8_b quantization retained sufficient accuracy in both the focused RoPE test and real-weight GLM MLA validation.

## Performance impact

Changing indexer Q from BF16 to BFP8 improves measured indexer_score_dsa device time by approximately 41–42%.

Most of the gain comes from the lower-fidelity compute path selected for BFP8 inputs. With compute fidelity fixed to HiFi2, reduced Q storage and bandwidth alone improved the op by approximately 0.53%.

This is an op-level measurement and is not a claim of a 41–42% end-to-end MLA speedup.

## Accuracy impact

Real pretrained layer-0 weights, sequence length 256, 2x4 Blackhole mesh:

| Model | MLA output PCC | KV cache PCC | PE cache PCC |
|---|---:|---:|---:|
| GLM-5.1 | 0.9995046224 | 0.9999004935 | 0.9999188584 |
| GLM-5.2 | 0.9995429701 | 0.9999001044 | 0.9999180668 |

The mixed-dtype indexed-RoPE test reaches approximately 0.999936 PCC across multiple iterations. The end-to-end accuracy test also asserts that indexer_score_dsa receives a bfloat8_b Q tensor.

## Testing

- ./build_metal.sh --release
- BFP8 indexed-RoPE multi-iteration Q test
- Existing BF16 indexed-RoPE regression test
- GLM-5.1 sparse MLA accuracy with pretrained layer-0 weights
- GLM-5.2 sparse MLA accuracy with pretrained layer-0 weights

All passed.

### Relevant workflows

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=pjosipovic/indexer-q-bfp8)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml?query=branch:pjosipovic/indexer-q-bfp8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pjosipovic/indexer-q-bfp8)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pjosipovic/indexer-q-bfp8)

Dispatched with the same focused setup as #50207:

- Blaze: `dsa_mla,dsa_mla_glm,glm_prefill_block`, Release on Ubuntu 22.04
- Blackhole E2E: `LoudBox (8xP150)`, `model=deepseek_prefill`, Release on Ubuntu 22.04
- Runs: [Blaze Models Prefill](https://github.com/tenstorrent/tt-metal/actions/runs/29847651566) · [Blackhole E2E](https://github.com/tenstorrent/tt-metal/actions/runs/29847654101)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/indexer-q-bfp8)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/indexer-q-bfp8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/indexer-q-bfp8)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/indexer-q-bfp8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pjosipovic/indexer-q-bfp8)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pjosipovic/indexer-q-bfp8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/indexer-q-bfp8)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/indexer-q-bfp8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/indexer-q-bfp8)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/indexer-q-bfp8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/indexer-q-bfp8)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/indexer-q-bfp8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/indexer-q-bfp8)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/indexer-q-bfp8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/indexer-q-bfp8)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/indexer-q-bfp8)
