### PR TITLE
Perf improvements for fp8 compression and decompression

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_per_token_cast.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_per_token_cast.py
@@ -242,9 +242,10 @@ def test_cast_to_fp8_power_of_two_scale_e4m3fn_boundary(device):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize("narrow_scales_to_bf16", [False, True], ids=["scales_kept_at_fp32", "scales_narrow_to_bf16"])
 @pytest.mark.parametrize("out_dtype", ["bfloat16", "float32"])
 @pytest.mark.parametrize("shape", SHAPES)
-def test_cast_back_dequant(device, out_dtype, shape):
+def test_cast_back_dequant(device, out_dtype, shape, narrow_scales_to_bf16):
     torch.manual_seed(0)
     torch_dtype = getattr(torch, out_dtype)
     ttnn_dtype = getattr(ttnn, out_dtype)
@@ -260,10 +261,15 @@ def test_cast_back_dequant(device, out_dtype, shape):
         device=device,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
-    out_tt = ttnn.experimental.deepseek_prefill.per_token_cast_back(e4m3_tt, scale_tt, output_dtype=ttnn_dtype)
+    out_tt = ttnn.experimental.deepseek_prefill.per_token_cast_back(
+        e4m3_tt, scale_tt, output_dtype=ttnn_dtype, narrow_scales_to_bf16=narrow_scales_to_bf16
+    )
     out = ttnn.to_torch(out_tt).float()
 
-    golden = input_e4m3.float() * input_scale.repeat_interleave(BLOCK_W, dim=-1)
+    # apples-to-apples: on the bf16 path the device narrows the scale to bf16 before the multiply,
+    # so the golden narrows it too
+    golden_scale = input_scale.to(torch.bfloat16).float() if narrow_scales_to_bf16 else input_scale
+    golden = input_e4m3.float() * golden_scale.repeat_interleave(BLOCK_W, dim=-1)
     if out_dtype == "bfloat16":
         golden = golden.to(torch_dtype).float()
 
@@ -273,13 +279,16 @@ def test_cast_back_dequant(device, out_dtype, shape):
 
     # Restrict to normal e4m3 values where relative tolerance is meaningful.
     normal = input_e4m3.float().abs() > 2.0**-6
+    # narrow_scales_to_bf16 runs the multiply in bf16/HiFi2 (vs fp32/HiFi4)
+    # which has a real precision cost, not a golden mismatch, so allow a slightly looser rtol.
+    rtol = 1.5e-2 if narrow_scales_to_bf16 else 1e-2
     assert_quality(
         out[normal],
         golden[normal],
         pcc_threshold=0.999,
-        rtol=1e-2,
+        rtol=rtol,
         atol=1e-3,
-        label=f"dequant {out_dtype} shape={shape}",
+        label=f"dequant {out_dtype} narrow_scales_to_bf16={narrow_scales_to_bf16} shape={shape}",
     )
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_per_token_cast_perf.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_per_token_cast_perf.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Device-perf tests for the FP8 per-token compression / decompression ops.
+
+Measures the device time of these operators on the 5K-token prefill chunks we run
+in production (the 640x7168 shape one chunk casts):
+
+  * per_token_cast_to_fp8 -> PerTokenCastToFp8DeviceOperation  (compression)
+  * per_token_cast_back   -> PerTokenCastBackDeviceOperation    (decompression)
+"""
+
+import pytest
+
+from models.demos.deepseek_v3_d_p.utils.perf_utils import run_model_device_perf_test_per_op
+from models.demos.deepseek_v3_d_p.utils.smbus_telemetry import is_p150
+
+# Functional test file whose op launches land in the Tracy CSV the harness reads back.
+_WORKER = (
+    "tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_per_token_cast.py"
+)
+
+# Production prefill shape: 640 tokens x 7168 hidden. Compression always sees this exact
+# shape; decompression is exercised at the same shape purely as a regression guard.
+_SEQ_LEN = 640
+_HIDDEN = 7168
+
+# Device-op codes emitted by each op; the harness sums the rows whose OP CODE contains the
+# substring, so incidental setup ops (host->device copies, etc.) are excluded.
+_COMPRESS_OP = "PerTokenCastToFp8DeviceOperation"
+_DECOMPRESS_OP = "PerTokenCastBackDeviceOperation"
+
+# Per-op device time in ns, measured on a Blackhole P150. Recalibrate on the perf CI runner.
+_COMPRESS_EXPECTED_NS = 56_700
+_DECOMPRESS_EXPECTED_NS = 65_450
+
+_MARGIN = 0.05
+
+
+def _k(extra: str) -> str:
+    """Pin exactly the 640x7168 case of the worker. ``640`` is a substring of ``6400``, so
+    exclude the 6400 shape explicitly (mirrors the isl-512/isl-5120 disambiguation in
+    ``test_single_routed_expert_perf._k_filter``)."""
+    return f"{_SEQ_LEN} and {extra} and not 6400"
+
+
+# Compression: ROW_MAJOR bf16 input -- the Blackhole production fast path (input tilized and
+# bf8-packed inside the op).
+_COMPRESS_WORKER = f"pytest {_WORKER}::test_cast_to_fp8_scale_values -k '{_k('bfloat16 and ROW_MAJOR')}'"
+# Decompression: bf16 output, scales kept at fp32 (full-precision fp32/HiFi4 multiply).
+_DECOMPRESS_WORKER = f"pytest {_WORKER}::test_cast_back_dequant -k '{_k('bfloat16 and scales_kept_at_fp32')}'"
+
+
+@pytest.mark.parametrize(
+    "command, expected_per_op, model_name, comments",
+    [
+        (
+            _COMPRESS_WORKER,
+            {_COMPRESS_OP: _COMPRESS_EXPECTED_NS},
+            f"deepseek_v3_compression_{_SEQ_LEN}x{_HIDDEN}",
+            f"per_token_cast_to_fp8 {_SEQ_LEN}x{_HIDDEN}",
+        ),
+        (
+            _DECOMPRESS_WORKER,
+            {_DECOMPRESS_OP: _DECOMPRESS_EXPECTED_NS},
+            f"deepseek_v3_decompression_{_SEQ_LEN}x{_HIDDEN}",
+            f"per_token_cast_back {_SEQ_LEN}x{_HIDDEN}",
+        ),
+    ],
+    ids=["compression", "decompression"],
+)
+@pytest.mark.models_device_performance_bare_metal
+# Gate to P150 via tt-smi board telemetry (SMBus). This also skips Wormhole and any other
+# board. Do NOT use ttnn.cluster.get_cluster_type() here: it opens and locks the chip, and
+# since skipif is evaluated at collection time in the parent process, the spawned Tracy worker
+# then deadlocks on CHIP_IN_USE. is_p150() reads tt-smi only, so it takes no device lock.
+@pytest.mark.skipif(not is_p150(), reason="perf baselines are P150-specific; skip on any other board")
+def test_per_token_cast_perf(command, expected_per_op, model_name, comments):
+    run_model_device_perf_test_per_op(
+        command=command,
+        expected_per_op=expected_per_op,
+        subdir="prefill_per_token_cast",
+        model_name=model_name,
+        margin=_MARGIN,
+        comments=comments,
+    )

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/kernels/compute/compute_per_token_cast_back.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/kernels/compute/compute_per_token_cast_back.cpp
@@ -2,20 +2,27 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// per_token_cast_back: out = decode(input_e4m3) * scale, where scale is one fp32
+// per_token_cast_back: out = cast(input_e4m3) * scale, where scale is one fp32
 // scalar per token (row) per 128-wide block. A 128-element block spans
 // 4 consecutive 32x32 tiles; within any tile the scale is a per-row scalar (constant across columns),
 // so we broadcast it with mul_tiles_bcast_cols (BroadcastType::COL = filled column 0, per notes §6).
 //
-// The reader builds one bcast operand tile in cb_scale_bcast with column 0 = scale[:, block_idx]
+// The reader builds one bcast operand tile in cb_scale_bcast_fp32 with column 0 = scale[:, block_idx]
 // (face-aware). There is no in-kernel column-shift LLK on Blackhole (notes §6), so the per-block
 // column selection lives in the reader's data layout, not a shift here.
 //
-// Per block = tile_h rows x 128 cols = 4 tiles for default 32-wide tiles:
-//   Phase 1 : input_e4m3 RM -> fp32 RM      (copy_tile, index 0)
-//   Phase 2a: tilize fp32 RM input -> tile  (cb_in_tile)
-//   Phase 2c: cb_out_tile = cb_in_tile * bcast(scale)
-//   Phase 3 : untilize cb_out_tile -> row-major output
+// CB naming: *_fp32 buffers always hold fp32, *_bf16 buffers always hold bf16; buffers whose format
+// follows the datapath/output (cb_in_tile, cb_out) carry no suffix and are reused across both paths.
+//
+// Per block = tile_h rows x 128 cols = 4 tiles for default 32-wide tiles.
+// fp32 datapath:
+//   Phase 1: cast fp8 (e4m3) rm -> fp32 rm
+//   Phase 2: tilize fp32 rm -> fp32 tiles
+//   Phase 3: multiply by fp32 broadcast scale and untilize to output
+// bf16 datapath:
+//   Phase 1: tilize casts fp8 (e4m3) rm -> bf16 tiles
+//   Phase 2: cast fp32 scale -> bf16 (packer) so SrcB matches the bf16 SrcA
+//   Phase 3: multiply by bf16 broadcast scale and untilize to output
 //
 // num_blocks source (TOKEN_COUNT_AWARE define):
 //   * plain             : passed as a runtime arg.
@@ -26,29 +33,39 @@
 
 #include "api/compute/common.h"
 #include "api/compute/tile_move_copy.h"
-#include "api/compute/tilize.h"
-#include "api/compute/untilize.h"
+#include "api/compute/pack_untilize.h"
 #include "api/compute/reconfig_data_format.h"
 #include "api/compute/bcast.h"
 #include "api/dataflow/circular_buffer.h"
+#include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
 
 void kernel_main() {
     constexpr uint32_t cb_input_e4m3_id = get_compile_time_arg_val(0);
     CircularBuffer cb_input_e4m3(cb_input_e4m3_id);
-    constexpr uint32_t cb_in_rm_id = get_compile_time_arg_val(1);
-    CircularBuffer cb_in_rm(cb_in_rm_id);
+    // fp32-only: copy-decoded e4m3 -> fp32 row-major block (used by the fp32 datapath only).
+    constexpr uint32_t cb_in_rm_fp32_id = get_compile_time_arg_val(1);
+    CircularBuffer cb_in_rm_fp32(cb_in_rm_fp32_id);
+    // reused: tilized input feeding the multiply; format follows the datapath (fp32 or bf16).
     constexpr uint32_t cb_in_tile_id = get_compile_time_arg_val(2);
     CircularBuffer cb_in_tile(cb_in_tile_id);
-    constexpr uint32_t cb_scale_bcast_id = get_compile_time_arg_val(3);
-    CircularBuffer cb_scale_bcast(cb_scale_bcast_id);
-    constexpr uint32_t cb_out_tile_id = get_compile_time_arg_val(4);
-    CircularBuffer cb_out_tile(cb_out_tile_id);
-    constexpr uint32_t cb_out_fp32_id = get_compile_time_arg_val(5);
-    CircularBuffer cb_out_fp32(cb_out_fp32_id);
+    // fp32: raw scale (column 0) from the reader, always fp32.
+    constexpr uint32_t cb_scale_bcast_fp32_id = get_compile_time_arg_val(3);
+    CircularBuffer cb_scale_bcast_fp32(cb_scale_bcast_fp32_id);
+    // reused: row-major output; format follows output_dtype (bf16 or fp32).
+    constexpr uint32_t cb_out_id = get_compile_time_arg_val(4);
+    CircularBuffer cb_out(cb_out_id);
     // Tile dims from the tensor's tile spec.
-    constexpr uint32_t tile_h = get_compile_time_arg_val(6);
-    constexpr uint32_t tile_w = get_compile_time_arg_val(7);
-    constexpr uint32_t cb_loop_count_id = get_compile_time_arg_val(8);
+    constexpr uint32_t tile_h = get_compile_time_arg_val(5);
+    constexpr uint32_t tile_w = get_compile_time_arg_val(6);
+    // 1 => run the datapath in bf16 (HiFi2): tilize decodes e4m3 straight into bf16 tiles and the fp32
+    // scale is narrowed to bf16 (packer -> cb_scale_bcast_bf16) so the multiply's SrcB matches SrcA.
+    constexpr uint32_t narrow_scales_to_bf16 = get_compile_time_arg_val(7);
+    // bf16: scale narrowed from fp32 to bf16 on-device (used by the bf16 datapath only).
+    constexpr uint32_t cb_scale_bcast_bf16_id = get_compile_time_arg_val(8);
+    CircularBuffer cb_scale_bcast_bf16(cb_scale_bcast_bf16_id);
+    // reused selector: the multiply reads whichever scale matches the datapath format.
+    constexpr uint32_t cb_scale_mul_id = narrow_scales_to_bf16 ? cb_scale_bcast_bf16_id : cb_scale_bcast_fp32_id;
+    constexpr uint32_t cb_loop_count_id = get_compile_time_arg_val(9);
     constexpr uint32_t block_w = 128;                // BlockW
     constexpr uint32_t block_wt = block_w / tile_w;  // BlockWt
     constexpr uint32_t block_ht = 1;                 // BlockHt
@@ -56,7 +73,7 @@ void kernel_main() {
 
     constexpr uint32_t IDST0 = 0;
 
-    compute_kernel_hw_startup(cb_input_e4m3_id, cb_out_fp32_id);
+    compute_kernel_hw_startup(cb_input_e4m3_id, cb_out_id);
 
 #ifdef TOKEN_COUNT_AWARE
     // num_blocks is computed by the reader and delivered via the loop-count mailbox.
@@ -70,69 +87,80 @@ void kernel_main() {
 
     for (uint32_t blk = 0; blk < num_blocks; ++blk) {
         {
-            // ----- Phase 1: input_e4m3 row-major -> fp32 row-major (one tile at a time, index 0) -----
-            reconfig_data_format_srca(cb_input_e4m3_id);
-            pack_reconfig_data_format(cb_in_rm_id);
-            copy_tile_init(cb_input_e4m3_id);
-            // One input_e4m3 page is one 32x32 row-major tile. A 128-wide block contains
-            // tiles_per_block such pages.
-            for (uint32_t s = 0; s < tiles_per_block; ++s) {
-                cb_input_e4m3.wait_front(1);
-                cb_in_rm.reserve_back(1);
+            if constexpr (narrow_scales_to_bf16) {
+                // ----- Phase 1 (bf16): tilize casts e4m3 straight into bf16 tiles -----
+                compute_kernel_lib::tilize<tiles_per_block, cb_input_e4m3_id, cb_in_tile_id>(block_ht);
+
+                // ----- Phase 2 (bf16): cast fp32 scale -> bf16 -----
+                // Packer narrows the fp32 scale to bf16 so the multiply's SrcB matches SrcA.
+                reconfig_data_format_srca(cb_scale_bcast_fp32_id);
+                pack_reconfig_data_format(cb_scale_bcast_bf16_id);
+                copy_tile_init(cb_scale_bcast_fp32_id);
+                cb_scale_bcast_fp32.wait_front(block_ht);
+                cb_scale_bcast_bf16.reserve_back(block_ht);
                 tile_regs_acquire();
-                copy_tile(cb_input_e4m3_id, 0, IDST0);
+                copy_tile(cb_scale_bcast_fp32_id, 0, IDST0);
                 tile_regs_commit();
                 tile_regs_wait();
-                pack_tile(IDST0, cb_in_rm_id);
+                pack_tile(IDST0, cb_scale_bcast_bf16_id);
                 tile_regs_release();
-                cb_in_rm.push_back(1);
-                cb_input_e4m3.pop_front(1);
-            }
-
-            // ----- Phase 2a: tilize fp32 input row-major -> tile -----
-            reconfig_data_format_srca(cb_in_rm_id);
-            pack_reconfig_data_format(cb_in_tile_id);
-            tilize_init(cb_in_rm_id, tiles_per_block, cb_in_tile_id);
-            cb_in_rm.wait_front(tiles_per_block);
-            cb_in_tile.reserve_back(tiles_per_block);
-            tilize_block(cb_in_rm_id, tiles_per_block, cb_in_tile_id);
-            cb_in_tile.push_back(tiles_per_block);
-            cb_in_rm.pop_front(tiles_per_block);
-            tilize_uninit(cb_in_rm_id, cb_in_tile_id);
-
-            // ----- Phase 2c: block broadcast multiply -----
-            // cb_scale_bcast holds block_ht tiles; tile block_h_idx has column 0 = scale[:, block_h_idx].
-            reconfig_data_format(cb_in_tile_id, cb_scale_bcast_id);
-            pack_reconfig_data_format(cb_out_tile_id);
-            mul_bcast_cols_init_short(cb_in_tile_id, cb_scale_bcast_id);
-            cb_in_tile.wait_front(tiles_per_block);
-            cb_scale_bcast.wait_front(block_ht);
-            cb_out_tile.reserve_back(tiles_per_block);
-            for (uint32_t block_h_idx = 0; block_h_idx < block_ht; ++block_h_idx) {
-                for (uint32_t k = 0; k < block_wt; ++k) {
-                    uint32_t in_idx = block_h_idx * block_wt + k;
+                cb_scale_bcast_bf16.push_back(block_ht);
+                cb_scale_bcast_fp32.pop_front(block_ht);
+            } else {
+                // ----- Phase 1: cast e4m3 -> fp32 -----
+                // tilize cannot cast e4m3 into a fp32 rm as done for bf16 datapath
+                reconfig_data_format_srca(cb_input_e4m3_id);
+                pack_reconfig_data_format(cb_in_rm_fp32_id);
+                copy_tile_init(cb_input_e4m3_id);
+                // One input_e4m3 page is one 32x32 row-major tile. A 128-wide block contains
+                // tiles_per_block such pages.
+                for (uint32_t s = 0; s < tiles_per_block; ++s) {
+                    cb_input_e4m3.wait_front(1);
+                    cb_in_rm_fp32.reserve_back(1);
                     tile_regs_acquire();
-                    mul_tiles_bcast_cols(cb_in_tile_id, cb_scale_bcast_id, in_idx, block_h_idx, IDST0);
+                    copy_tile(cb_input_e4m3_id, 0, IDST0);
                     tile_regs_commit();
                     tile_regs_wait();
-                    pack_tile(IDST0, cb_out_tile_id);
+                    pack_tile(IDST0, cb_in_rm_fp32_id);
                     tile_regs_release();
+                    cb_in_rm_fp32.push_back(1);
+                    cb_input_e4m3.pop_front(1);
                 }
-            }
-            cb_out_tile.push_back(tiles_per_block);
-            cb_in_tile.pop_front(tiles_per_block);
-            cb_scale_bcast.pop_front(block_ht);
 
-            // ----- Phase 3: untilize cb_out_tile -> fp32 row-major output -----
-            reconfig_data_format_srca(cb_out_tile_id);
-            pack_reconfig_data_format(cb_out_fp32_id);
-            untilize_init(cb_out_tile_id);
-            cb_out_tile.wait_front(tiles_per_block);
-            cb_out_fp32.reserve_back(tiles_per_block);
-            untilize_block(cb_out_tile_id, tiles_per_block, cb_out_fp32_id);
-            cb_out_fp32.push_back(tiles_per_block);
-            cb_out_tile.pop_front(tiles_per_block);
-            untilize_uninit(cb_out_tile_id);
+                // ----- Phase 2: tilize -----
+                compute_kernel_lib::tilize<tiles_per_block, cb_in_rm_fp32_id, cb_in_tile_id>(block_ht);
+            }
+
+            // ----- Phase 3: multiply by broadcast scale and untilize to output -----
+            // mul writes all tiles_per_block(=4) tiles into DEST, and pack_untilize_dest untilizes them
+            // to the row-major output in the packer, avoiding a separate output-tile L1 round-trip. In
+            // 32-bit DEST (fp32_dest_acc), the half-sync pack-untilize block cap is 4 tiles = one block.
+            reconfig_data_format(cb_in_tile_id, cb_scale_mul_id);
+            mul_bcast_cols_init_short(cb_in_tile_id, cb_scale_mul_id);
+            pack_untilize_dest_init<tiles_per_block, tiles_per_block>(cb_out_id);
+            cb_in_tile.wait_front(tiles_per_block);
+            if constexpr (narrow_scales_to_bf16) {
+                cb_scale_bcast_bf16.wait_front(block_ht);
+            } else {
+                cb_scale_bcast_fp32.wait_front(block_ht);
+            }
+            cb_out.reserve_back(tiles_per_block);
+            tile_regs_acquire();
+            for (uint32_t k = 0; k < block_wt; ++k) {
+                mul_tiles_bcast_cols(cb_in_tile_id, cb_scale_mul_id, k, 0, k);
+            }
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_untilize_dest<tiles_per_block>(cb_out_id);
+            tile_regs_release();
+            cb_out.push_back(tiles_per_block);
+            cb_in_tile.pop_front(tiles_per_block);
+            if constexpr (narrow_scales_to_bf16) {
+                cb_scale_bcast_bf16.pop_front(block_ht);
+            } else {
+                cb_scale_bcast_fp32.pop_front(block_ht);
+            }
+            pack_untilize_uninit(cb_out_id);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/kernels/dataflow/reader_per_token_cast_back.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/kernels/dataflow/reader_per_token_cast_back.cpp
@@ -45,7 +45,7 @@ void kernel_main() {
 #endif
 
     constexpr uint32_t cb_input_e4m3 = get_compile_time_arg_val(0);
-    constexpr uint32_t cb_scale_bcast = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_scale_bcast_fp32 = get_compile_time_arg_val(1);
     constexpr uint32_t cb_scale_scratch = get_compile_time_arg_val(2);
     constexpr uint32_t input_e4m3_block_bytes = get_compile_time_arg_val(3);    // 128 (1 byte/elem)
     constexpr uint32_t block_ht = get_compile_time_arg_val(4);                  // BlockHt = 1
@@ -88,7 +88,7 @@ void kernel_main() {
     const auto scale = TensorAccessor(scale_args, scale_addr);
     Noc noc;
     CircularBuffer cb_input_e4m3_obj(cb_input_e4m3);
-    CircularBuffer cb_scale_bcast_obj(cb_scale_bcast);
+    CircularBuffer cb_scale_bcast_fp32_obj(cb_scale_bcast_fp32);
     CircularBuffer cb_scale_scratch_obj(cb_scale_scratch);
 
     const uint32_t blocks_per_row = width >> 7;  // H / 128 (block_w = 128); one-time shift
@@ -221,9 +221,9 @@ void kernel_main() {
 
         // --- build the bcast operand: column 0 row r = scale[token_r][block_r] (face-aware walk) ---
         // (tok_off, block_idx_b) cursor walks the block rows in face order -> no per-row div/mod.
-        cb_scale_bcast_obj.reserve_back(1);
+        cb_scale_bcast_fp32_obj.reserve_back(1);
         CoreLocalMem<volatile uint32_t> scratch_mem(scratch);
-        CoreLocalMem<volatile uint32_t> page(cb_scale_bcast_obj.get_write_ptr());
+        CoreLocalMem<volatile uint32_t> page(cb_scale_bcast_fp32_obj.get_write_ptr());
         uint32_t tok_off = 0;  // (token - block_start_row) * scale_aligned_page_bytes
         uint32_t block_idx_b = block_start_idx;
         uint32_t s = 0;
@@ -244,7 +244,7 @@ void kernel_main() {
             }
             face_base_off += FACE_ROW_STRIDE_BYTES;
         }
-        cb_scale_bcast_obj.push_back(1);
+        cb_scale_bcast_fp32_obj.push_back(1);
         cb_input_e4m3_obj.push_back(tiles_per_block);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/kernels/dataflow/writer_per_token_cast_back.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/kernels/dataflow/writer_per_token_cast_back.cpp
@@ -36,7 +36,7 @@ void kernel_main() {
     uint32_t width = get_arg_val<uint32_t>(4);      // H (elements per row)
 #endif
 
-    constexpr uint32_t cb_out_fp32 = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_out = get_compile_time_arg_val(0);
     constexpr uint32_t out_block_bytes = get_compile_time_arg_val(1);  // 128 * out_elem_size
     constexpr uint32_t tile_h = get_compile_time_arg_val(2);
     constexpr uint32_t tiles_per_block = get_compile_time_arg_val(3);  // tiles per block (= 4 for 32-wide tiles)
@@ -55,7 +55,7 @@ void kernel_main() {
     constexpr auto dst_args = TensorAccessorArgs<ACCESSOR_CT_BASE>();
     const auto dst = TensorAccessor(dst_args, dst_addr);
     Noc noc;
-    CircularBuffer cb_out_fp32_obj(cb_out_fp32);
+    CircularBuffer cb_out_obj(cb_out);
 
     const uint32_t blocks_per_row = width >> 7;  // H / 128; one-time shift
 
@@ -134,14 +134,14 @@ void kernel_main() {
         const uint32_t remaining = total_blocks - base;
         const uint32_t real_in_block = remaining < tile_h ? remaining : tile_h;
 
-        cb_out_fp32_obj.wait_front(tiles_per_block);
+        cb_out_obj.wait_front(tiles_per_block);
         uint32_t slot = 0;
         while (slot < real_in_block && current_row < end_row) {
             uint32_t blocks_left_in_row = blocks_per_row - block_idx_in_row;
             uint32_t slots_left = real_in_block - slot;
             uint32_t run = blocks_left_in_row < slots_left ? blocks_left_in_row : slots_left;
             noc.async_write(
-                cb_out_fp32_obj,
+                cb_out_obj,
                 dst,
                 run * out_block_bytes,
                 {.offset_bytes = slot * out_block_bytes},
@@ -154,6 +154,6 @@ void kernel_main() {
             }
         }
         noc.async_write_barrier();
-        cb_out_fp32_obj.pop_front(tiles_per_block);
+        cb_out_obj.pop_front(tiles_per_block);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/per_token_cast_back_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/per_token_cast_back_device_operation.cpp
@@ -252,6 +252,7 @@ ttnn::Tensor per_token_cast_back(
     const Tensor& input_scale,
     tt::tt_metal::DataType output_dtype,
     const tt::tt_metal::MemoryConfig& output_memory_config,
+    bool narrow_scales_to_bf16,
     bool token_count_aware,
     const std::optional<Tensor>& expert_region_offsets,
     const std::optional<Tensor>& expert_token_counts,
@@ -262,6 +263,7 @@ ttnn::Tensor per_token_cast_back(
     auto operation_attributes = OperationType::operation_attributes_t{
         .output_dtype = output_dtype,
         .output_memory_config = output_memory_config,
+        .narrow_scales_to_bf16 = narrow_scales_to_bf16,
         .token_count_aware = token_count_aware,
         .experts_per_chip = experts_per_chip,
         .scales_from_metadata = scales_from_metadata};

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/per_token_cast_back_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/per_token_cast_back_device_operation.hpp
@@ -43,6 +43,7 @@ ttnn::Tensor per_token_cast_back(
     const Tensor& input_scale,
     tt::tt_metal::DataType output_dtype,
     const tt::tt_metal::MemoryConfig& output_memory_config,
+    bool narrow_scales_to_bf16 = false,
     bool token_count_aware = false,
     const std::optional<Tensor>& expert_region_offsets = std::nullopt,
     const std::optional<Tensor>& expert_token_counts = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/per_token_cast_back_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/per_token_cast_back_device_operation_types.hpp
@@ -14,6 +14,9 @@ namespace ttnn::experimental::prim::per_token_cast_back {
 struct PerTokenCastBackParams {
     tt::tt_metal::DataType output_dtype;
     tt::tt_metal::MemoryConfig output_memory_config;
+    // When true, the compute kernel narrows the fp32 scale to bf16 on-device and runs the broadcast
+    // multiply in bf16 (HiFi2); when false (default), the scale stays fp32 (HiFi4).
+    bool narrow_scales_to_bf16 = false;
 
     bool token_count_aware = false;
     // Number of local experts hosted on this chip (token-count-aware path only).

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/per_token_cast_back_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/per_token_cast_back_program_factory.cpp
@@ -156,12 +156,18 @@ PerTokenCastBackProgramFactory::cached_program_t PerTokenCastBackProgramFactory:
             split_work_to_cores(compute_grid, M);
     }
 
+    // narrow_scales_to_bf16: perform the multiply in bf16/HiFi2 (vs fp32/HiFi4)
+    const bool narrow_scales_to_bf16 = operation_attributes.narrow_scales_to_bf16;
+    const DataFormat compute_df = narrow_scales_to_bf16 ? DataFormat::Float16_b : fp32_df;
+    const uint32_t compute_tile_bytes = tile_h * tile_w * (narrow_scales_to_bf16 ? 2u : 4u);
+
     constexpr uint32_t cb_input_e4m3_idx = CBIndex::c_0;
-    constexpr uint32_t cb_in_rm_idx = CBIndex::c_1;
-    constexpr uint32_t cb_in_tile_idx = CBIndex::c_2;
-    constexpr uint32_t cb_loop_count_idx = CBIndex::c_3;  // token_count_aware: reader -> compute num_blocks mailbox
-    constexpr uint32_t cb_scale_bcast_idx = CBIndex::c_4;
-    constexpr uint32_t cb_out_tile_idx = CBIndex::c_5;
+    constexpr uint32_t cb_in_rm_fp32_idx = CBIndex::c_1;  // fp32 rm buffer (fp32 datapath only)
+    constexpr uint32_t cb_in_tile_idx = CBIndex::c_2;     // reused: tilized input
+    constexpr uint32_t cb_scale_bcast_bf16_idx =
+        CBIndex::c_3;  // bf16: packer packs fp32 scales to bf16 scales (bf16 datapath)
+    constexpr uint32_t cb_scale_bcast_fp32_idx = CBIndex::c_4;  // fp32: raw fp32 scales read from DRAM
+    constexpr uint32_t cb_loop_count_idx = CBIndex::c_5;  // token_count_aware: reader -> compute num_blocks mailbox
     constexpr uint32_t cb_scale_scratch_idx = CBIndex::c_6;
     constexpr uint32_t cb_region_scratch_r_idx = CBIndex::c_7;   // token_count_aware only
     constexpr uint32_t cb_counts_scratch_r_idx = CBIndex::c_8;   // token_count_aware only
@@ -169,7 +175,7 @@ PerTokenCastBackProgramFactory::cached_program_t PerTokenCastBackProgramFactory:
     constexpr uint32_t cb_region_scratch_w_idx = CBIndex::c_10;  // token_count_aware only
     constexpr uint32_t cb_counts_scratch_w_idx = CBIndex::c_11;  // token_count_aware only
     constexpr uint32_t cb_table_scratch_w_idx = CBIndex::c_12;   // token_count_aware only
-    constexpr uint32_t cb_out_idx = CBIndex::c_16;
+    constexpr uint32_t cb_out_idx = CBIndex::c_16;               // reused: output
 
     auto make_fp32_tile_cb = [&](uint32_t cb_idx, uint32_t num_tiles) {
         CircularBufferConfig cfg =
@@ -177,17 +183,30 @@ PerTokenCastBackProgramFactory::cached_program_t PerTokenCastBackProgramFactory:
         CreateCircularBuffer(program, all_cores, cfg);
     };
 
-    // cb_input_e4m3: input_e4m3, one tile per page; tiles_per_block pages = one block, double-buffered.
+    // Compute tiles carry the datapath format (bf16 or fp32) selected by narrow_scales_to_bf16.
+    auto make_compute_tile_cb = [&](uint32_t cb_idx, uint32_t num_tiles) {
+        CircularBufferConfig cfg = CircularBufferConfig(num_tiles * compute_tile_bytes, {{cb_idx, compute_df}})
+                                       .set_page_size(cb_idx, compute_tile_bytes);
+        CreateCircularBuffer(program, all_cores, cfg);
+    };
+
+    // cb_input_e4m3: input_e4m3, one tile per page; tiles_per_block pages = one block,
     // double-buffered. The reader fills the [tile_h x 128] block contiguously across these pages.
     CircularBufferConfig cb_input_e4m3_cfg =
         CircularBufferConfig(2 * tiles_per_block * input_e4m3_tile_bytes, {{cb_input_e4m3_idx, fp8_df}})
             .set_page_size(cb_input_e4m3_idx, input_e4m3_tile_bytes);
     CreateCircularBuffer(program, all_cores, cb_input_e4m3_cfg);
 
-    make_fp32_tile_cb(cb_in_rm_idx, tiles_per_block);     // input_e4m3 -> fp32 RM
-    make_fp32_tile_cb(cb_in_tile_idx, tiles_per_block);   // tilized fp32 input
-    make_fp32_tile_cb(cb_scale_bcast_idx, 2 * block_ht);  // col0 = scale
-    make_fp32_tile_cb(cb_out_tile_idx, tiles_per_block);  // divided tiles -> untilize
+    // Double-buffered so there is not stalling between the reader/compute/writer.
+    make_compute_tile_cb(cb_in_tile_idx, 2 * tiles_per_block);  // reused: tilized input
+    make_fp32_tile_cb(cb_scale_bcast_fp32_idx, 2 * block_ht);   // col0 = scale
+    if (narrow_scales_to_bf16) {
+        // bf16 datapath: scale narrowed to bf16 by the packer.
+        make_compute_tile_cb(cb_scale_bcast_bf16_idx, 2 * block_ht);
+    } else {
+        // fp32 datapath: fp8 e4m3 -> fp32 row-major before tilize.
+        make_fp32_tile_cb(cb_in_rm_fp32_idx, 2 * tiles_per_block);
+    }
 
     // cb_out: row-major output (bf16/fp32), one tile per page; tiles_per_block pages = one block,
     // double-buffered.
@@ -244,7 +263,7 @@ PerTokenCastBackProgramFactory::cached_program_t PerTokenCastBackProgramFactory:
     // compute.
     std::vector<uint32_t> reader_ct_args = {
         cb_input_e4m3_idx,
-        cb_scale_bcast_idx,
+        cb_scale_bcast_fp32_idx,
         cb_scale_scratch_idx,
         input_e4m3_block_bytes,
         block_ht,
@@ -315,26 +334,41 @@ PerTokenCastBackProgramFactory::cached_program_t PerTokenCastBackProgramFactory:
             .compile_args = writer_ct_args,
             .defines = token_count_aware_defines});
 
-    // Compute (TRISC): input_e4m3 -> fp32 RM -> tilize -> scale bcast multiply -> untilize to output.
+    // Compute (TRISC): input_e4m3 -> compute data format tiles -> scale bcast multiply -> untilize to output.
     // Plain: num_blocks arrives as a runtime arg. Token-count-aware: num_blocks arrives via cb_loop_count.
     std::vector<uint32_t> compute_ct_args = {
         cb_input_e4m3_idx,
-        cb_in_rm_idx,
+        cb_in_rm_fp32_idx,
         cb_in_tile_idx,
-        cb_scale_bcast_idx,
-        cb_out_tile_idx,
+        cb_scale_bcast_fp32_idx,
         cb_out_idx,
         tile_h,
         tile_w,
+        static_cast<uint32_t>(narrow_scales_to_bf16),
+        cb_scale_bcast_bf16_idx,
         cb_loop_count_idx};
-    // fp32_dest_acc_en=True required (input_e4m3 CB on core); HiFi4 (the ComputeConfig default) keeps the
-    // broadcast multiply precise.
+
+    // HiFi2: bf16 datapath; HiFi4: fp32 datapath.
+    const MathFidelity math_fidelity = narrow_scales_to_bf16 ? MathFidelity::HiFi2 : MathFidelity::HiFi4;
+    // Skip trip through srcA register. fp8 goes straight to the DEST.
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    unpack_to_dest_mode[cb_input_e4m3_idx] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+    // On the bf16 path the fp32 scale must unpack losslessly to DEST before the packer rounds it to bf16.
+    if (narrow_scales_to_bf16) {
+        unpack_to_dest_mode[cb_scale_bcast_fp32_idx] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+    }
     KernelHandle compute_kernel_id = CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/kernels/compute/"
         "compute_per_token_cast_back.cpp",
         all_cores,
-        ComputeConfig{.fp32_dest_acc_en = true, .compile_args = compute_ct_args, .defines = token_count_aware_defines});
+        ComputeConfig{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = true,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .compile_args = compute_ct_args,
+            .defines = token_count_aware_defines});
 
     auto all_cores_vec = corerange_to_cores(all_cores, num_cores, true);
     if (token_count_aware) {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/per_token_cast_back.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/per_token_cast_back.cpp
@@ -14,6 +14,7 @@ ttnn::Tensor per_token_cast_back(
     const std::optional<ttnn::Tensor>& input_scale,
     const std::optional<tt::tt_metal::DataType>& output_dtype,
     const std::optional<tt::tt_metal::MemoryConfig>& memory_config,
+    bool narrow_scales_to_bf16,
     bool token_count_aware,
     const std::optional<ttnn::Tensor>& expert_region_offsets,
     const std::optional<ttnn::Tensor>& expert_token_counts,
@@ -31,7 +32,7 @@ ttnn::Tensor per_token_cast_back(
             !metadata.has_value() && !expert_region_offsets.has_value() && !expert_token_counts.has_value() &&
                 !global_expert_idx_table.has_value(),
             "per_token_cast_back: metadata / expert_* tensors are only valid when token_count_aware=true");
-        return ttnn::prim::per_token_cast_back(input_e4m3, *input_scale, dtype, mem_config);
+        return ttnn::prim::per_token_cast_back(input_e4m3, *input_scale, dtype, mem_config, narrow_scales_to_bf16);
     }
 
     // Token-count-aware path. Exactly one scale source: either a plain fp32 (M, H/128) scale tensor, or
@@ -50,6 +51,7 @@ ttnn::Tensor per_token_cast_back(
         scale_source,
         dtype,
         mem_config,
+        narrow_scales_to_bf16,
         /*token_count_aware=*/true,
         expert_region_offsets,
         expert_token_counts,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/per_token_cast_back.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/per_token_cast_back.hpp
@@ -28,6 +28,7 @@ ttnn::Tensor per_token_cast_back(
     const std::optional<ttnn::Tensor>& input_scale = std::nullopt,
     const std::optional<tt::tt_metal::DataType>& output_dtype = std::nullopt,
     const std::optional<tt::tt_metal::MemoryConfig>& memory_config = std::nullopt,
+    bool narrow_scales_to_bf16 = false,
     bool token_count_aware = false,
     const std::optional<ttnn::Tensor>& expert_region_offsets = std::nullopt,
     const std::optional<ttnn::Tensor>& expert_token_counts = std::nullopt,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/per_token_cast_back_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/per_token_cast_back_nanobind.cpp
@@ -38,6 +38,8 @@ void bind_experimental_per_token_cast_back_operation(nb::module_& mod) {
                 * :attr:`output_dtype`: BFLOAT16 (default) or FLOAT32.
                 * :attr:`memory_config`: optional DRAM interleaved output memory config
                   (default: same as input_e4m3).
+                * :attr:`narrow_scales_to_bf16`: when True, narrow the fp32 scale to bf16 on-device and run the
+                  broadcast multiply in bf16 (HiFi2); when False (default), keep the fp32 (HiFi4) datapath.
                 * :attr:`token_count_aware`: enable the token-count-aware MoE-dispatch prefix path (default False).
                 * :attr:`expert_region_offsets`: UINT32 ROW_MAJOR DRAM interleaved, (1, num_routed_experts).
                   Required when token_count_aware=True.
@@ -61,6 +63,7 @@ void bind_experimental_per_token_cast_back_operation(nb::module_& mod) {
         nb::arg("input_scale") = nb::none(),
         nb::arg("output_dtype") = std::nullopt,
         nb::arg("memory_config") = std::nullopt,
+        nb::arg("narrow_scales_to_bf16") = false,
         nb::arg("token_count_aware") = false,
         nb::arg("expert_region_offsets") = nb::none(),
         nb::arg("expert_token_counts") = nb::none(),

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/device/kernels/compute/compute_per_token_cast_to_fp8.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/device/kernels/compute/compute_per_token_cast_to_fp8.cpp
@@ -6,11 +6,11 @@
 // per 128-element block.
 //
 // Per block = tile_h rows x 128 cols = 4 tiles for default 32-wide tiles:
-//   1. cb_in -> cb_tile: tilize (ROW_MAJOR input) or copy (INPUT_TILE_LAYOUT: input already tiled).
-//   2. compute per-row amax over the 128-element block, clamp(>=1e-4), multiply by 1/448
-//      -> scale (col 0) -> cb_scale_tiles. recip(scale) -> 1/scale -> cb_inv_scale_tiles.
-//   3. divide: out_tile = cb_tile * bcast_col(cb_inv_scale_tiles) per tile -> cb_out_tile.
-//   4. untilize cb_out_tile -> cb_output_e4m3 (scaled, cast to e4m3).
+//   Phase 1: cb_in -> cb_tile: tilize (ROW_MAJOR input) or copy (INPUT_TILE_LAYOUT: input already tiled).
+//   Phase 2: compute per-row amax over the 128-element block, clamp(>=1e-4), multiply by 1/448
+//            -> scale (col 0) -> cb_scale_tiles. recip(scale) -> 1/scale -> cb_inv_scale_tiles.
+//   Phase 3: divide (cb_tile * bcast_col(cb_inv_scale_tiles)) into DST, then pack_untilize_dest straight
+//            to cb_output_e4m3 (scaled, cast to e4m3) -- fused divide+untilize, no cb_out_tile round-trip.
 // The writer extracts column 0 of cb_scale_tiles into the scale output [..., M, H/128].
 //
 // fp32_dest_acc_en=True (required for e4m3 on Blackhole; also gives fp32 reduce/divide precision).
@@ -18,8 +18,6 @@
 #include <cstdint>
 
 #include "api/compute/common.h"
-#include "api/compute/tilize.h"
-#include "api/compute/untilize.h"
 #include "api/compute/reduce.h"
 #include "api/compute/reconfig_data_format.h"
 #include "api/compute/tile_move_copy.h"
@@ -30,7 +28,9 @@
 #include "api/compute/eltwise_unary/recip.h"
 #include "api/compute/eltwise_unary/clamp.h"
 #include "api/compute/eltwise_unary/binop_with_scalar.h"
+#include "api/compute/pack_untilize.h"
 #include "api/dataflow/circular_buffer.h"
+#include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
 
 #ifdef TRISC_MATH
 namespace ckernel::sfpu {
@@ -73,18 +73,16 @@ void kernel_main() {
     CircularBuffer cb_scale_tiles(cb_scale_tiles_id);
     constexpr uint32_t cb_inv_scale_tiles_id = get_compile_time_arg_val(5);
     CircularBuffer cb_inv_scale_tiles(cb_inv_scale_tiles_id);
-    constexpr uint32_t cb_out_tile_id = get_compile_time_arg_val(6);
-    CircularBuffer cb_out_tile(cb_out_tile_id);
-    constexpr uint32_t cb_output_e4m3_id = get_compile_time_arg_val(7);
+    constexpr uint32_t cb_output_e4m3_id = get_compile_time_arg_val(6);
     CircularBuffer cb_output_e4m3(cb_output_e4m3_id);
-    constexpr uint32_t clamp_min_bits = get_compile_time_arg_val(8);
-    constexpr uint32_t clamp_max_bits = get_compile_time_arg_val(9);
-    constexpr uint32_t inv_448_bits = get_compile_time_arg_val(10);
+    constexpr uint32_t clamp_min_bits = get_compile_time_arg_val(7);
+    constexpr uint32_t clamp_max_bits = get_compile_time_arg_val(8);
+    constexpr uint32_t inv_448_bits = get_compile_time_arg_val(9);
 
     // Tile width from the tensor's tile spec.
     constexpr uint32_t block_w = 128;  // BlockW
-    constexpr uint32_t tile_w = get_compile_time_arg_val(11);
-    constexpr bool round_scale_to_power_of_two = get_compile_time_arg_val(12) != 0;
+    constexpr uint32_t tile_w = get_compile_time_arg_val(10);
+    constexpr bool round_scale_to_power_of_two = get_compile_time_arg_val(11) != 0;
     constexpr uint32_t block_wt = block_w / tile_w;  // BlockWt
     constexpr uint32_t block_ht = 1;                 // BlockHt
     constexpr uint32_t tiles_per_block = block_ht * block_wt;
@@ -102,7 +100,7 @@ void kernel_main() {
 
     for (uint32_t blk = 0; blk < num_blocks; ++blk) {
         {
-            // ----- 1. get input tiles into fp32 cb_tile -----
+            // ----- Phase 1: get input tiles into fp32 cb_tile -----
 #ifdef INPUT_TILE_LAYOUT
             // TILE input is already tiled, so copy instead of tilize. The fp32 copy is also what makes
             // bf16 correct: reading bf16 cb_in into the reduce would expose only 2 faces (cols 0-15)
@@ -124,18 +122,10 @@ void kernel_main() {
             cb_in.pop_front(tiles_per_block);
 #else
             // ROW_MAJOR input: tilize the row-major block into tiles.
-            reconfig_data_format_srca(cb_in_id);
-            pack_reconfig_data_format(cb_tile_id);
-            tilize_init(cb_in_id, tiles_per_block, cb_tile_id);
-            cb_in.wait_front(tiles_per_block);
-            cb_tile.reserve_back(tiles_per_block);
-            tilize_block(cb_in_id, tiles_per_block, cb_tile_id);
-            cb_tile.push_back(tiles_per_block);
-            cb_in.pop_front(tiles_per_block);
-            tilize_uninit(cb_in_id, cb_tile_id);
+            compute_kernel_lib::tilize<tiles_per_block, cb_in_id, cb_tile_id>(block_ht);
 #endif
 
-            // ----- 2. block amax -> scale (col 0) and 1/scale (col 0) -----
+            // ----- Phase 2: block amax -> scale (col 0) and 1/scale (col 0) -----
             cb_tile.wait_front(tiles_per_block);  // read by index; popped after the divide
             for (uint32_t block_h_idx = 0; block_h_idx < block_ht; ++block_h_idx) {
                 // Abs the block row's tiles into cb_abs. Force the SrcA tile-dim/stride reconfig
@@ -202,37 +192,33 @@ void kernel_main() {
                 cb_abs.pop_front(block_wt);
             }
 
-            // ----- 3. divide: cb_out_tile = cb_tile * bcast_col(1/scale) -----
+            // ----- Phase 3: divide (cb_tile * bcast_col(1/scale)) into DST, then pack_untilize straight
+            // to e4m3 -- fused divide+untilize, no cb_out_tile L1 round-trip and no separate untilize pass.
+            // In 32-bit DST (fp32_dest_acc) the half-sync pack-untilize cap is 4 tiles = one block. -----
             reconfig_data_format(cb_tile_id, cb_inv_scale_tiles_id);
-            pack_reconfig_data_format(cb_out_tile_id);
             mul_bcast_cols_init_short(cb_tile_id, cb_inv_scale_tiles_id);
+            pack_untilize_dest_init<tiles_per_block, tiles_per_block>(cb_output_e4m3_id);
             cb_inv_scale_tiles.wait_front(block_ht);
-            cb_out_tile.reserve_back(tiles_per_block);
+            cb_output_e4m3.reserve_back(tiles_per_block);
+            tile_regs_acquire();
             for (uint32_t block_h_idx = 0; block_h_idx < block_ht; ++block_h_idx) {
                 for (uint32_t k = 0; k < block_wt; ++k) {
-                    tile_regs_acquire();
                     mul_tiles_bcast_cols(
-                        cb_tile_id, cb_inv_scale_tiles_id, block_h_idx * block_wt + k, block_h_idx, IDST0);
-                    tile_regs_commit();
-                    tile_regs_wait();
-                    pack_tile(IDST0, cb_out_tile_id);
-                    tile_regs_release();
+                        cb_tile_id,
+                        cb_inv_scale_tiles_id,
+                        block_h_idx * block_wt + k,
+                        block_h_idx,
+                        block_h_idx * block_wt + k);
                 }
             }
-            cb_out_tile.push_back(tiles_per_block);
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_untilize_dest<tiles_per_block>(cb_output_e4m3_id);
+            tile_regs_release();
+            cb_output_e4m3.push_back(tiles_per_block);
             cb_tile.pop_front(tiles_per_block);
             cb_inv_scale_tiles.pop_front(block_ht);
-
-            // ----- 4. untilize cb_out_tile -> output e4m3 (scaled) -----
-            reconfig_data_format_srca(cb_out_tile_id);
-            pack_reconfig_data_format(cb_output_e4m3_id);
-            untilize_init(cb_out_tile_id);
-            cb_out_tile.wait_front(tiles_per_block);
-            cb_output_e4m3.reserve_back(tiles_per_block);
-            untilize_block(cb_out_tile_id, tiles_per_block, cb_output_e4m3_id);
-            cb_output_e4m3.push_back(tiles_per_block);
-            cb_out_tile.pop_front(tiles_per_block);
-            untilize_uninit(cb_out_tile_id);
+            pack_untilize_uninit(cb_output_e4m3_id);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/device/per_token_cast_to_fp8_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/device/per_token_cast_to_fp8_program_factory.cpp
@@ -118,7 +118,6 @@ KernelIds build_kernels_and_cbs(
     constexpr uint32_t cb_scale_tiles_idx = CBIndex::c_5;
     constexpr uint32_t cb_scale_scratch_idx = CBIndex::c_6;
     constexpr uint32_t cb_inv_scale_tiles_idx = CBIndex::c_7;
-    constexpr uint32_t cb_out_tile_idx = CBIndex::c_8;
     constexpr uint32_t cb_output_e4m3_idx = CBIndex::c_16;
 
     auto make_fp32_tile_cb = [&](uint32_t cb_idx, uint32_t num_tiles) {
@@ -140,7 +139,6 @@ KernelIds build_kernels_and_cbs(
     make_fp32_tile_cb(cb_abs_idx, 2 * block_wt);              // abs tiles for one block row
     make_fp32_tile_cb(cb_scale_tiles_idx, 2 * block_ht);      // col0 = scale
     make_fp32_tile_cb(cb_inv_scale_tiles_idx, 2 * block_ht);  // col0 = 1/scale
-    make_fp32_tile_cb(cb_out_tile_idx, tiles_per_block);      // divided tiles -> untilize
 
     // cb_output_e4m3: e4m3 output, always row-major, one tile per page, double-buffered.
     // Identical for both input layouts (ROW_MAJOR and TILE).
@@ -209,7 +207,6 @@ KernelIds build_kernels_and_cbs(
         cb_abs_idx,
         cb_scale_tiles_idx,
         cb_inv_scale_tiles_idx,
-        cb_out_tile_idx,
         cb_output_e4m3_idx,
         clamp_min_bits,
         clamp_max_bits,


### PR DESCRIPTION
### Summary
Perf improvement for compression and decompression compute kernels.
- Reduced l1 round trips
- Fused different phases of the compute kernel (instead of going from dest to l1, we reuse dest)
- Added optional bf16-scale decompression (`compute_is_bf16`): narrows the fp32 scale to bf16 on-device and runs the multiply in bf16/HiFi2.

- As for the performance, our case is (640, 7168) input shape for the compression. Will add a perf CI test in another PR.

## 📊 Performance

<details>
<summary><b>Benchmark tables — device FW duration, Blackhole (p150b) — click to expand</b></summary>

<br>

### 1. Compression — `per_token_cast_to_fp8` (new vs main)

| Shape | in dtype | main (µs) | new (µs) | Δ |
|---|---|---:|---:|---:|
| (1, 1024) | bf16 | 7.1 | 5.5 | −22.5% |
| (1, 1024) | fp32 | 7.2 | 5.6 | −22.2% |
| (30, 1152) | bf16 | 7.4 | 5.8 | −21.6% |
| (30, 1152) | fp32 | 7.7 | 6.1 | −20.8% |
| (2, 3, 30, 1152) | bf16 | 9.1 | 7.5 | −17.6% |
| (2, 3, 30, 1152) | fp32 | 10.9 | 9.2 | −15.6% |
| (640, 7168) | bf16 | 70.0 | 57.1 | −18.4% |
| (640, 7168) | fp32 | 99.5 | 92.1 | −7.4% |
| (3200, 7168) | bf16 | 296.9 | 218.7 | −26.3% |
| (3200, 7168) | fp32 | 414.3 | 402.7 | −2.8% |
| (6400, 7168) | bf16 | 575.8 | 426.6 | −25.9% |
| (6400, 7168) | fp32 | 812.5 | 794.1 | −2.3% |

### 2. Decompression — `per_token_cast_back` (new vs main), fp32 vs bf16 scales

`main` is the shared baseline; `bf16 scales` uses `compute_is_bf16=True`. The last column is
how much faster the bf16-scale path is than the fp32-scale path.

| Shape | main (µs) | fp32 scales (µs) | bf16 scales (µs) | bf16 vs fp32 |
|---|---:|---:|---:|---:|
| (1, 1024) | 4.0 | 2.4 | 2.1 | −12.5% |
| (30, 1152) | 4.4 | 2.8 | 2.5 | −10.7% |
| (2, 3, 30, 1152) | 6.8 | 5.2 | 4.8 | −7.7% |
| (640, 7168) | 74.8 | 65.2 | 62.3 | −4.4% |
| (3200, 7168) | 354.8 | 314.7 | 299.0 | −5.0% |
| (6400, 7168) | 728.5 | 617.3 | 590.4 | −4.4% |

</details>

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nostojic/comp_decomp_perf_improvement)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nostojic/comp_decomp_perf_improvement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nostojic/comp_decomp_perf_improvement)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nostojic/comp_decomp_perf_improvement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nostojic/comp_decomp_perf_improvement)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nostojic/comp_decomp_perf_improvement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nostojic/comp_decomp_perf_improvement)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nostojic/comp_decomp_perf_improvement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nostojic/comp_decomp_perf_improvement)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nostojic/comp_decomp_perf_improvement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nostojic/comp_decomp_perf_improvement)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nostojic/comp_decomp_perf_improvement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nostojic/comp_decomp_perf_improvement)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nostojic/comp_decomp_perf_improvement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nostojic/comp_decomp_perf_improvement)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nostojic/comp_decomp_perf_improvement)

