### PR TITLE
Performance: Migrate `reduce_scatter_async_minimal` (Ring) to Mux v2

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_ring_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/dim_zero_ring_reduce_scatter_minimal_async_writer.cpp
@@ -7,6 +7,7 @@
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/noc_semaphore.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
+#include "tt_metal/fabric/hw/inc/tt_fabric_mux_v2_sender.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_routing_utils.hpp"
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
@@ -40,17 +41,9 @@ constexpr uint32_t output_num_pages = get_named_compile_time_arg_val("output_num
 constexpr uint32_t batch_num_pages = get_named_compile_time_arg_val("batch_num_pages");
 constexpr uint32_t slice_B = get_named_compile_time_arg_val("slice_B");
 
-#ifdef USE_WORKER_MUX
-constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(0);
-constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(1);
-constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(2);
-constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(3);
-constexpr uint32_t num_mux_clients = get_compile_time_arg_val(4);
-
-constexpr uint32_t num_ct_args = 5;
-#else
+// The V2 fabric mux client (FabricMuxV2Sender) is built entirely from runtime args, so there are no
+// worker-side mux compile-time args in either the mux or the direct-fabric path.
 constexpr uint32_t num_ct_args = 0;
-#endif
 
 constexpr ccl_routing_utils::line_unicast_route_info_t forward_unicast_route_info =
     ccl_routing_utils::get_line_unicast_route_info_from_args<num_ct_args>();
@@ -85,24 +78,11 @@ void kernel_main() {
     const uint32_t start_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
 
 #ifdef USE_WORKER_MUX
-    const bool mux_connection_valid = get_arg_val<uint32_t>(arg_idx++) == 1;
-    const bool is_termination_master = get_arg_val<uint32_t>(arg_idx++);
-    const uint8_t fabric_mux_x = get_arg_val<uint32_t>(arg_idx++);
-    const uint8_t fabric_mux_y = get_arg_val<uint32_t>(arg_idx++);
-    const size_t fabric_mux_channel_base_address = get_arg_val<uint32_t>(arg_idx++);
-    const size_t fabric_mux_connection_info_address = get_arg_val<uint32_t>(arg_idx++);
-    const size_t fabric_mux_connection_handshake_address = get_arg_val<uint32_t>(arg_idx++);
-    const size_t fabric_mux_flow_control_address = get_arg_val<uint32_t>(arg_idx++);
-    const size_t fabric_mux_buffer_index_address = get_arg_val<uint32_t>(arg_idx++);
-    const uint8_t fabric_mux_channel_id = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t termination_sync_id = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t termination_sync_address = get_semaphore(termination_sync_id);
-    uint32_t local_fabric_mux_status_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
-    uint32_t local_flow_control_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
-    uint32_t local_teardown_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
-    uint32_t local_buffer_index_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
-    uint32_t termination_master_noc_x = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t termination_master_noc_y = get_arg_val<uint32_t>(arg_idx++);
+    // The V2 mux client args are the last runtime args; FabricMuxV2Sender::build_from_args consumes
+    // exactly what FabricMuxV2Config::append_client_connection_rt_args serialized on the host.
+    size_t mux_arg_idx = arg_idx;
+    auto mux_sender = tt::tt_fabric::FabricMuxV2Sender<>::build_from_args(mux_arg_idx);
+    arg_idx = mux_arg_idx;
 #endif
 
     const auto& unicast_route_info = (direction == 1) ? forward_unicast_route_info : backward_unicast_route_info;
@@ -121,26 +101,7 @@ void kernel_main() {
     CircularBuffer cb_compute_output(cb_compute_output_id);
     CircularBuffer cb_reader_output(cb_reader_output_id);
 
-#ifdef USE_WORKER_MUX
-    auto mux_connection_handle = tt::tt_fabric::build_connection_to_fabric_endpoint<fabric_mux_num_buffers_per_channel>(
-        fabric_mux_x,
-        fabric_mux_y,
-        fabric_mux_channel_id,
-        fabric_mux_num_buffers_per_channel,
-        fabric_mux_channel_buffer_size_bytes,
-        fabric_mux_channel_base_address,
-        fabric_mux_connection_info_address,
-        fabric_mux_connection_handshake_address,
-        fabric_mux_flow_control_address,
-        fabric_mux_buffer_index_address,
-        local_flow_control_address,
-        local_teardown_address,
-        local_buffer_index_address);
-
-    // need to wait for fabric mux to be ready to accept connections
-    tt::tt_fabric::wait_for_fabric_endpoint_ready(
-        fabric_mux_x, fabric_mux_y, fabric_mux_status_address, local_fabric_mux_status_address);
-#else
+#ifndef USE_WORKER_MUX
     size_t arg_for_fab = arg_idx;
     auto fabric_connection = FabricConnectionManager::build_from_args(arg_for_fab);
 #endif
@@ -155,8 +116,9 @@ void kernel_main() {
     ccl_routing_utils::fabric_set_line_unicast_route(pkt_hdr_seminc, unicast_route_info);
 
 #ifdef USE_WORKER_MUX
-    tt::tt_fabric::fabric_client_connect(mux_connection_handle);
-    auto* fabric_connection_ptr = &mux_connection_handle;
+    // Blocking open: waits for the mux to be READY, then requests the connection.
+    mux_sender.open();
+    auto* fabric_connection_ptr = &mux_sender;
 #else
     if (fabric_connection.is_logically_connected()) {
         fabric_connection.open();
@@ -401,17 +363,9 @@ void kernel_main() {
     noc_obj.async_atomic_barrier();
 
 #ifdef USE_WORKER_MUX
-    tt::tt_fabric::fabric_client_disconnect(mux_connection_handle);
-    if (is_termination_master) {
-        Semaphore<> termination_sync(termination_sync_id);
-        termination_sync.wait(num_mux_clients - 1);
-        tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x, fabric_mux_y, fabric_mux_termination_signal_address);
-    } else {
-        uint64_t dest_addr =
-            safe_get_noc_addr(termination_master_noc_x, termination_master_noc_y, termination_sync_address, 0);
-        noc_semaphore_inc(dest_addr, 1);
-        noc_obj.async_atomic_barrier();
-    }
+    // Close this client's connection. The V2 mux auto-terminates once all of its clients have closed,
+    // so no termination-master coordination or explicit terminate signal is needed.
+    mux_sender.close();
 #else
     if (fabric_connection.is_logically_connected()) {
         fabric_connection.close();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/kernels/ring_reduce_scatter_minimal_async_writer.cpp
@@ -7,6 +7,7 @@
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/noc_semaphore.h"
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
+#include "tt_metal/fabric/hw/inc/tt_fabric_mux_v2_sender.hpp"
 #include "tt_metal/fabric/hw/inc/noc_addr.h"
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_routing_utils.hpp"
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
@@ -46,17 +47,9 @@ constexpr uint32_t slice_C = get_named_compile_time_arg_val("slice_C");
 constexpr uint32_t slice_Ht = get_named_compile_time_arg_val("slice_Ht");
 constexpr uint32_t slice_Wt = get_named_compile_time_arg_val("slice_Wt");
 constexpr uint32_t dim = get_named_compile_time_arg_val("dim");
-#ifdef USE_WORKER_MUX
-constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(0);
-constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(1);
-constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(2);
-constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(3);
-constexpr uint32_t num_mux_clients = get_compile_time_arg_val(4);
-
-constexpr uint32_t num_ct_args = 5;
-#else
+// The V2 fabric mux client (FabricMuxV2Sender) is built entirely from runtime args, so there are no
+// worker-side mux compile-time args in either the mux or the direct-fabric path.
 constexpr uint32_t num_ct_args = 0;
-#endif
 
 // Routing info uses positional args after fabric mux args
 constexpr ccl_routing_utils::line_unicast_route_info_t forward_unicast_route_info =
@@ -95,24 +88,11 @@ void kernel_main() {
     const uint32_t start_tiles_read = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t start_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
 #ifdef USE_WORKER_MUX
-    const bool mux_connection_valid = get_arg_val<uint32_t>(arg_idx++) == 1;
-    const bool is_termination_master = get_arg_val<uint32_t>(arg_idx++);
-    const uint8_t fabric_mux_x = get_arg_val<uint32_t>(arg_idx++);
-    const uint8_t fabric_mux_y = get_arg_val<uint32_t>(arg_idx++);
-    const size_t fabric_mux_channel_base_address = get_arg_val<uint32_t>(arg_idx++);
-    const size_t fabric_mux_connection_info_address = get_arg_val<uint32_t>(arg_idx++);
-    const size_t fabric_mux_connection_handshake_address = get_arg_val<uint32_t>(arg_idx++);
-    const size_t fabric_mux_flow_control_address = get_arg_val<uint32_t>(arg_idx++);
-    const size_t fabric_mux_buffer_index_address = get_arg_val<uint32_t>(arg_idx++);
-    const uint8_t fabric_mux_channel_id = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t termination_sync_id = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t termination_sync_address = get_semaphore(termination_sync_id);
-    uint32_t local_fabric_mux_status_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
-    uint32_t local_flow_control_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
-    uint32_t local_teardown_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
-    uint32_t local_buffer_index_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
-    uint32_t termination_master_noc_x = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t termination_master_noc_y = get_arg_val<uint32_t>(arg_idx++);
+    // The V2 mux client args are the last runtime args; FabricMuxV2Sender::build_from_args consumes
+    // exactly what FabricMuxV2Config::append_client_connection_rt_args serialized on the host.
+    size_t mux_arg_idx = arg_idx;
+    auto mux_sender = tt::tt_fabric::FabricMuxV2Sender<>::build_from_args(mux_arg_idx);
+    arg_idx = mux_arg_idx;
 #endif
 
     const auto& unicast_route_info = (direction == 1) ? forward_unicast_route_info : backward_unicast_route_info;
@@ -127,26 +107,7 @@ void kernel_main() {
     constexpr auto output_tensor_args = TensorAccessorArgs<interm_tensor_args.next_compile_time_args_offset()>();
     auto output_tensor_accessor = TensorAccessor(output_tensor_args, output_tensor_address);
 
-#ifdef USE_WORKER_MUX
-    auto mux_connection_handle = tt::tt_fabric::build_connection_to_fabric_endpoint<fabric_mux_num_buffers_per_channel>(
-        fabric_mux_x,
-        fabric_mux_y,
-        fabric_mux_channel_id,
-        fabric_mux_num_buffers_per_channel,
-        fabric_mux_channel_buffer_size_bytes,
-        fabric_mux_channel_base_address,
-        fabric_mux_connection_info_address,
-        fabric_mux_connection_handshake_address,
-        fabric_mux_flow_control_address,
-        fabric_mux_buffer_index_address,
-        local_flow_control_address,
-        local_teardown_address,
-        local_buffer_index_address);
-
-    // need to wait for fabric mux to be ready to accept connections
-    tt::tt_fabric::wait_for_fabric_endpoint_ready(
-        fabric_mux_x, fabric_mux_y, fabric_mux_status_address, local_fabric_mux_status_address);
-#else
+#ifndef USE_WORKER_MUX
     size_t arg_for_fab = arg_idx;
     auto fabric_connection = FabricConnectionManager::build_from_args(arg_for_fab);
 #endif
@@ -166,8 +127,9 @@ void kernel_main() {
     ccl_routing_utils::fabric_set_line_unicast_route(pkt_hdr_fused_scatter, unicast_route_info);
 
 #ifdef USE_WORKER_MUX
-    tt::tt_fabric::fabric_client_connect(mux_connection_handle);
-    auto* fabric_direction_connection = &mux_connection_handle;
+    // Blocking open: waits for the mux to be READY, then requests the connection.
+    mux_sender.open();
+    auto* fabric_direction_connection = &mux_sender;
 #else
     if (fabric_connection.is_logically_connected()) {
         fabric_connection.open();
@@ -282,6 +244,7 @@ void kernel_main() {
     // semaphore chunk, so packets wider than 2 tiles cannot fuse (caller falls back to send_seminc).
     auto send_write_packet =
         [&](size_t l1_read_addr, uint32_t num_tiles, bool fuse_seminc, uint64_t sem_noc_addr) -> bool {
+
         if (fuse_seminc && num_tiles <= 2) {
             if (num_tiles == 2) {
                 fabric_unicast_noc_fused_scatter_write_atomic_inc_with_state<
@@ -571,17 +534,9 @@ void kernel_main() {
     noc_obj.async_write_barrier();
     noc_obj.async_atomic_barrier();
 #ifdef USE_WORKER_MUX
-    tt::tt_fabric::fabric_client_disconnect(mux_connection_handle);
-    if (is_termination_master) {
-        Semaphore<> termination_sync(termination_sync_id);
-        termination_sync.wait(num_mux_clients - 1);
-        tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x, fabric_mux_y, fabric_mux_termination_signal_address);
-    } else {
-        uint64_t dest_addr =
-            safe_get_noc_addr(termination_master_noc_x, termination_master_noc_y, termination_sync_address, 0);
-        noc_semaphore_inc(dest_addr, 1);
-        noc_obj.async_atomic_barrier();
-    }
+    // Close this client's connection. The V2 mux auto-terminates once all of its clients have closed,
+    // so no termination-master coordination or explicit terminate signal is needed.
+    mux_sender.close();
 #else
     if (fabric_connection.is_logically_connected()) {
         fabric_connection.close();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -415,7 +415,6 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
 
     std::vector<CoreRange> sender_worker_core_ranges;
     std::vector<CoreRange> mux_core_ranges;
-    std::vector<CoreRange> termination_master_core_ranges;
     if (num_mux_cores_per_direction_per_link) {
         uint32_t core_id = 0;
         for (uint32_t link = 0; link < num_links; link++) {
@@ -427,10 +426,6 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
                 for (uint32_t worker = 0; worker < num_workers_per_direction; worker++) {
                     const auto& worker_core = all_cores[core_id++];
                     sender_worker_core_ranges.emplace_back(worker_core);
-
-                    if (worker == 0) {
-                        termination_master_core_ranges.emplace_back(worker_core);
-                    }
                 }
             }
         }
@@ -561,7 +556,6 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
     }
 
     // KERNEL CREATION
-    std::vector<size_t> mux_termination_signal_addresses;
     if (fuse_op) {
         fused_op_signaler->init_reduce_scatter(program, mesh_device, sender_worker_core_range_set);
     }
@@ -570,29 +564,17 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
     const uint32_t l1_unreserved_base_address =
         mesh_device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
     const size_t mux_base_l1_address = l1_unreserved_base_address;
-    const auto num_full_size_channels = num_workers_per_direction;
-    constexpr auto num_header_only_channels = 0;
     const auto buffer_size_bytes_full_size_channel = tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes();
-    const auto mux_kernel_config = tt::tt_fabric::FabricMuxConfig(
-        num_full_size_channels,
-        num_header_only_channels,
-        num_buffers_full_size_channels,
-        0,
+    // Transient Fabric Mux V2: one mux core per (link, direction), serving num_workers_per_direction
+    // client channels (one channel per sender worker). The V2 mux auto-terminates once all of its
+    // clients close their connections, so no explicit termination signalling is required. The mux
+    // kernels themselves are created per-core in the loop below via add_fabric_mux_v2_to_program (each
+    // needs the src/dst fabric node ids + link for the direction it forwards to).
+    tt::tt_fabric::FabricMuxV2Config mux_config(
+        static_cast<uint8_t>(num_workers_per_direction),
+        static_cast<uint8_t>(num_buffers_full_size_channels),
         buffer_size_bytes_full_size_channel,
         mux_base_l1_address);
-    auto mux_kernel_id = 0;
-    if (num_mux_cores_per_direction_per_link) {
-        // Fabric mux kernel
-        mux_kernel_id = tt::tt_metal::CreateKernel(
-            program,
-            "tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp",
-            mux_core_range_set,
-            tt::tt_metal::DataMovementConfig{
-                .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
-                .noc = tt::tt_metal::NOC::RISCV_0_default,
-                .compile_args = mux_kernel_config.get_fabric_mux_compile_time_args(),
-                .opt_level = tt::tt_metal::KernelBuildOptLevel::O3});
-    }
 
     auto reader_named_compile_args = operations::experimental::ccl::detail::get_ring_reader_named_compile_args(
         ring_index,
@@ -657,15 +639,9 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
         slice_Wt,
         normalized_dim);
 
-    // Positional args: fabric_mux, routing info, TensorAccessorArgs
+    // Positional args: routing info, TensorAccessorArgs. The V2 fabric mux client needs no worker-side
+    // compile-time args (the device-side FabricMuxV2Sender is built entirely from runtime args).
     std::vector<uint32_t> writer_compile_args;
-    if (num_mux_cores_per_direction_per_link) {
-        append_fabric_mux_connection_ct_args(
-            tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL,
-            mux_kernel_config,
-            num_workers_per_direction,
-            writer_compile_args);
-    }
 
     writer_compile_args.insert(writer_compile_args.end(), unicast_forward_args.begin(), unicast_forward_args.end());
     writer_compile_args.insert(writer_compile_args.end(), mcast_forward_args.begin(), mcast_forward_args.end());
@@ -713,29 +689,20 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
 
     auto worker_core_iter = sender_worker_core_range_set.ranges().cbegin();
     auto mux_core_iter = mux_core_range_set.ranges().cbegin();
-    auto termination_master_core_iter = termination_master_core_ranges.cbegin();
     for (uint32_t link = 0; link < num_links; link++) {
         for (uint32_t dir = 0; dir < num_directions_per_link; dir++) {
-            CoreCoord termination_master_logical_core = CoreCoord{0, 0};
             CoreCoord mux_virtual_core = CoreCoord{0, 0};
             if (mux_connection_valid(dir) && num_mux_cores_per_direction_per_link) {
                 auto mux_logical_core = *((mux_core_iter++)->begin());
                 mux_virtual_core = mesh_device->worker_core_from_logical_core(mux_logical_core);
 
-                std::vector<uint32_t> mux_rt_args = {};
+                // Create the V2 mux kernel on this core, forwarding toward this direction's neighbor
+                // (forward_coord when dir==1, backward_coord when dir==0).
                 const auto src_node_id = mesh_device->get_fabric_node_id(sender_device_coord);
-                if (dir) {  // forward
-                    const auto dst_node_id = mesh_device->get_fabric_node_id(forward_coord.value());
-                    mux_rt_args = mux_kernel_config.get_fabric_mux_run_time_args(
-                        src_node_id, dst_node_id, link, program, {mux_logical_core});
-                } else {
-                    const auto dst_node_id = mesh_device->get_fabric_node_id(backward_coord.value());
-                    mux_rt_args = mux_kernel_config.get_fabric_mux_run_time_args(
-                        src_node_id, dst_node_id, link, program, {mux_logical_core});
-                }
-                tt::tt_metal::SetRuntimeArgs(program, mux_kernel_id, {mux_logical_core}, mux_rt_args);
-
-                termination_master_logical_core = *((termination_master_core_iter++)->begin());
+                const auto dst_node_id =
+                    mesh_device->get_fabric_node_id(dir ? forward_coord.value() : backward_coord.value());
+                tt::tt_fabric::add_fabric_mux_v2_to_program(
+                    program, mux_config, mux_logical_core, src_node_id, dst_node_id, link);
             }
 
             for (uint32_t worker = 0; worker < num_workers_per_direction; worker++) {
@@ -804,9 +771,6 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
 
                 tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, {core}, reader_rt_args);
 
-                CoreCoord termination_master_virtual_core =
-                    mesh_device->worker_core_from_logical_core(termination_master_logical_core);
-
                 // Writer RT args
                 std::vector<uint32_t> writer_rt_args;
                 if (normalized_dim == 0) {
@@ -849,16 +813,19 @@ ReduceScatterProgramArtifacts build_ring_reduce_scatter_minimal_async_program_ar
                     };
                 }
                 if (num_mux_cores_per_direction_per_link) {
-                    append_fabric_mux_connection_rt_args(
-                        mux_connection_valid(dir),
+                    // V2 fabric mux client connection: this worker is channel `worker` on its
+                    // direction's mux. Two per-worker semaphores (flow control + teardown) back the
+                    // connection; append_client_connection_rt_args serializes exactly the client args
+                    // the device-side FabricMuxV2Sender::build_from_args expects.
+                    const auto flow_control_sem_id = tt::tt_metal::CreateSemaphore(program, core, 0);
+                    const auto teardown_sem_id = tt::tt_metal::CreateSemaphore(program, core, 0);
+                    mux_config.append_client_connection_rt_args(
                         mux_virtual_core,
-                        tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL,
-                        mux_kernel_config,
-                        core,
-                        worker,
-                        worker == 0,
-                        termination_master_virtual_core,
-                        program,
+                        static_cast<uint8_t>(worker),
+                        tt::tt_fabric::FabricMuxV2Config::ClientSemaphores{
+                            .flow_control_sem_id = flow_control_sem_id,
+                            .teardown_sem_id = teardown_sem_id,
+                        },
                         writer_rt_args);
                 }
                 if (!num_mux_cores_per_direction_per_link) {


### PR DESCRIPTION
Small perf bump and cleaner code 


### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amorrison/rs-mux-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amorrison/rs-mux-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amorrison/rs-mux-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amorrison/rs-mux-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amorrison/rs-mux-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amorrison/rs-mux-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amorrison/rs-mux-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amorrison/rs-mux-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amorrison/rs-mux-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amorrison/rs-mux-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amorrison/rs-mux-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amorrison/rs-mux-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amorrison/rs-mux-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amorrison/rs-mux-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amorrison/rs-mux-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amorrison/rs-mux-v2)

No new failures that aren't WH Glx hardware failures.