### PR TITLE
[DS Prefill] Adapt masked_bincount to accept TILE interleaved expert_indices

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_masked_bincount.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_masked_bincount.py
@@ -116,15 +116,10 @@ def test_masked_bincount(
             hist = torch_masked_bincount(chip_indices, dispatch_table[group], n_routed_experts)
             torch_histograms[(group, chip)] = hist
 
-    # Height-shard config matching the gate module pattern: 8x8 core grid
+    # masked_bincount consumes the gate's output directly: UINT16, TILE, L1-interleaved. The op
+    # untiles in-kernel and splits the token rows across a fixed 8x8 (64-core) grid internally.
     num_cores = 64
     assert sp_dim % num_cores == 0, f"sp_dim={sp_dim} must be divisible by {num_cores}"
-    sharded_mem_config = ttnn.create_sharded_memory_config(
-        shape=(sp_dim // num_cores, topk),
-        core_grid=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 7))}),
-        strategy=ttnn.ShardStrategy.HEIGHT,
-        use_height_and_width_as_shard_shape=True,
-    )
 
     # Shard dim 0 across the dispatch axis, replicate across TP axis
     mesh_mapper = ttnn.ShardTensor2dMesh(
@@ -133,15 +128,15 @@ def test_masked_bincount(
         dims=(0, None) if sp_axis == 0 else (None, 0),
     )
 
-    # UINT16 as required by the kernel
+    # UINT16, TILE, L1-interleaved: mirrors the gate's actual indices output that the op consumes.
     tt_indices = ttnn.from_torch(
         indices.to(torch.int16),
         mesh_mapper=mesh_mapper,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
+        layout=ttnn.TILE_LAYOUT,
         device=mesh_device,
         dtype=ttnn.uint16,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
     )
-    tt_indices = ttnn.to_memory_config(tt_indices, sharded_mem_config)
 
     tt_dispatch_table = ttnn.from_torch(
         dispatch_table,
@@ -230,14 +225,6 @@ def test_masked_bincount_tree_reduction_race(mesh_device):
     for e in range(num_present):
         dispatch_table[0, e] = 0
 
-    # Height-shard config matching the gate module pattern: 8x8 core grid
-    sharded_mem_config = ttnn.create_sharded_memory_config(
-        shape=(rows_per_core, topk),
-        core_grid=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 7))}),
-        strategy=ttnn.ShardStrategy.HEIGHT,
-        use_height_and_width_as_shard_shape=True,
-    )
-
     # Place dispatch table on device (static across iterations)
     tt_dispatch_table = ttnn.from_torch(
         dispatch_table,
@@ -267,15 +254,15 @@ def test_masked_bincount_tree_reduction_race(mesh_device):
         # Torch reference
         reference = torch_masked_bincount(indices, dispatch_table[0], n_routed_experts)
 
-        # Place indices on device
+        # Place indices on device: UINT16, TILE, L1-interleaved (as the gate emits; untiled in-kernel)
         tt_indices = ttnn.from_torch(
             indices.to(torch.int16),
             mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_device.shape, dims=(0, None)),
-            layout=ttnn.ROW_MAJOR_LAYOUT,
+            layout=ttnn.TILE_LAYOUT,
             device=mesh_device,
             dtype=ttnn.uint16,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
         )
-        tt_indices = ttnn.to_memory_config(tt_indices, sharded_mem_config)
 
         # Run TTNN op
         tt_hist = ttnn.experimental.deepseek_prefill.masked_bincount(

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ttnn_dispatch_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ttnn_dispatch_combine.py
@@ -203,7 +203,6 @@ def run_dispatch_combine(
     tt_dispatch_offsets, tt_expert_token_counts, tt_expert_region_offsets, _ = tt_moe_routing_setup(
         ttnn_top_k_experts_indices=indices,
         num_routed_experts=num_routed_experts,
-        seq_len_per_chip=seq_len_per_chip,
         num_experts_per_tok=num_experts_per_tok,
     )
 
@@ -621,7 +620,6 @@ def test_ttnn_dispatch_combine_overflow(mesh_device, num_links, topology, overfl
     tt_dispatch_offsets, tt_expert_token_counts, tt_expert_region_offsets, _ = tt_moe_routing_setup(
         ttnn_top_k_experts_indices=indices,
         num_routed_experts=num_routed_experts,
-        seq_len_per_chip=seq_len_per_chip,
         num_experts_per_tok=num_experts_per_tok,
     )
 

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_routing_setup.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_routing_setup.py
@@ -231,8 +231,14 @@ def test_prep_dispatch_combine(
         dims=(sp_axis, None),
     )
 
+    # masked_bincount consumes the gate's UINT16, TILE, L1-interleaved indices directly (untiled in-kernel).
     tt_indices = ttnn.from_torch(
-        indices, mesh_mapper=mesh_mapper_replicated, layout=ttnn.ROW_MAJOR_LAYOUT, device=mesh_device, dtype=ttnn.uint16
+        indices,
+        mesh_mapper=mesh_mapper_replicated,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        dtype=ttnn.uint16,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
     )
 
     # Create expert dispatch table

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_routing_setup.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_routing_setup.py
@@ -281,7 +281,6 @@ def test_prep_dispatch_combine(
     ) = tt_gate_outputs(
         ttnn_top_k_experts_indices=tt_indices,
         num_routed_experts=num_routed_experts,
-        seq_len_per_chip=seq_len_per_chip,
         num_experts_per_tok=num_experts_per_tok,
     )
 

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -468,8 +468,6 @@ class TtMoe(LightweightModule):
         # ========================================
         # Gate: compute weights/indices/offsets/counts from x
         # ========================================
-        # Reshape 3D -> 2D for gate: (batch, seq, emb) -> (batch*seq, emb)
-
         # Padding awareness is only validated/safe for RIGHT padding. With right padding,
         # real tokens have the lowest indices, so they are packed first in every expert
         # region and stay within the shortened FFN/dispatch bound. For left padding the
@@ -501,13 +499,12 @@ class TtMoe(LightweightModule):
             padding_config=padding_config,
         )
 
-        signpost(header="moe_gate_calculate_dispatch_offsets")
         tt_expert_offsets, tt_expert_token_counts, tt_expert_region_offsets, _ = self.routing_setup(
             ttnn_top_k_experts_indices=indices,
             num_routed_experts=self.num_routed_experts,
             num_experts_per_tok=self.num_experts_per_tok,
         )
-        signpost(header="moe_gate_calculate_dispatch_offsets")
+
         gate_logits = (
             ttnn.to_memory_config(gate_logits, ttnn.DRAM_MEMORY_CONFIG)
             if return_intermediates

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -505,7 +505,6 @@ class TtMoe(LightweightModule):
         tt_expert_offsets, tt_expert_token_counts, tt_expert_region_offsets, _ = self.routing_setup(
             ttnn_top_k_experts_indices=indices,
             num_routed_experts=self.num_routed_experts,
-            seq_len_per_chip=self.seq_len_per_chip,
             num_experts_per_tok=self.num_experts_per_tok,
         )
         signpost(header="moe_gate_calculate_dispatch_offsets")

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
@@ -11,7 +11,6 @@ from typing import Optional
 import torch
 import torch.nn.functional as F
 from loguru import logger
-from tracy import signpost
 
 import ttnn
 from models.common.lightweightmodule import LightweightModule
@@ -756,7 +755,6 @@ class TtMoEGatePrefill(LightweightModule):
         logger.debug(f"[MoeGate] fallback_mode={mode.value}")
 
         # ---- Phase 1: Logits (matmul) ----
-        signpost(header="moe_gate_linear")
         if mode in (
             GateComputeMode.DEVICE,
             GateComputeMode.DEVICE_FP32,
@@ -768,10 +766,8 @@ class TtMoEGatePrefill(LightweightModule):
             pass  # the reference HashRouter computes logits from composed host x in Phase 2
         else:  # HOST_MATMUL, HOST_ALL
             host_logits = self._host_matmul(x)
-        signpost(header="moe_gate_linear")
 
         # ---- Phase 2: Grouped gate ----
-        signpost(header="moe_gate_grouped_gate")
         # The device gate kernels select the routing rule from n_expert_groups: with a single expert
         # group (n_expert_groups == 1, e.g. Kimi) the grouped-topk op collapses to a plain top-k.
         single_group = self.config.n_expert_groups == 1
@@ -824,7 +820,6 @@ class TtMoEGatePrefill(LightweightModule):
                 padding_side=padding_side,
                 padding_config=padding_config,
             )
-        signpost(header="moe_gate_grouped_gate")
 
         return (
             ttnn_scores,

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_routing_setup.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_routing_setup.py
@@ -161,7 +161,6 @@ class TtMoERoutingSetup(LightweightModule):
         self,
         ttnn_top_k_experts_indices: ttnn.Tensor | torch.Tensor,
         num_routed_experts: int,
-        seq_len_per_chip: int,
         num_experts_per_tok: int,
     ):
         """
@@ -174,8 +173,6 @@ class TtMoERoutingSetup(LightweightModule):
                 direct output; no untilize/reshard). A torch.Tensor is also accepted and converted to
                 the same TILE, interleaved layout.
             num_routed_experts: Total number of routed experts across all chips (e.g. 64 or 256)
-            seq_len_per_chip: Number of tokens per chip. Must be divisible by 64 (the 8x8 core grid
-                masked_bincount splits the token rows across).
             num_experts_per_tok: Number of experts each token is routed to (e.g. 2 for top-2 routing)
 
         Returns:
@@ -212,42 +209,20 @@ class TtMoERoutingSetup(LightweightModule):
                 mesh_mapper=mesh_mapper,
             )
 
-        # masked_bincount consumes the gate's expert-index output directly (UINT16, TILE,
-        # L1 interleaved) and untiles in-kernel.
-        assert ttnn_top_k_experts_indices.dtype == ttnn.uint16, "Expected uint16 dtype for expert indices"
-
-        num_cores = 64  # masked_bincount uses a fixed 8x8 core grid
-        assert (
-            seq_len_per_chip % num_cores == 0
-        ), f"seq_len_per_chip ({seq_len_per_chip}) must be divisible by num_cores ({num_cores})"
+        # The device gate (DEVICE / DEVICE_FP32 / HASH_DEVICE) emits TILE indices, so this is a no-op
+        # on the perf-critical path. The host-fallback gates (HOST_ALL / HOST_MATMUL / HOST_GROUPED_GATE
+        # / HASH_HOST) emit ROW_MAJOR indices; The tilize only ever runs on the (non-perf) host path.
+        if ttnn_top_k_experts_indices.layout != ttnn.TILE_LAYOUT:
+            ttnn_top_k_experts_indices = ttnn.to_layout(ttnn_top_k_experts_indices, ttnn.TILE_LAYOUT)
 
         if len(ttnn_top_k_experts_indices.shape) == 3:
             ttnn_top_k_experts_indices = ttnn.squeeze(ttnn_top_k_experts_indices, 0)
         logger.debug(f"{ttnn_top_k_experts_indices.shape=}")
 
-        # Constraint imposed by masked_bincount
-        if len(self.experts_in_dispatch_group.shape) != 1:
-            assert (
-                self.experts_in_dispatch_group.shape[0] == 1
-            ), "Expected first dimension to be 1 after sharding expert dispatch table"
-        logger.debug(f"{self.experts_in_dispatch_group.shape=}")
-
         expert_histograms = ttnn.experimental.deepseek_prefill.masked_bincount(
             ttnn_top_k_experts_indices, self.experts_in_dispatch_group, num_routed_experts, num_experts_per_tok
         )
 
-        # offset_cumsum outputs are tiny UINT32 vectors placed in DRAM
-        # (downstream ops — ttnn::extract / ttnn::insert in the routed-expert
-        # moe composite, plus ttnn::combine — read them device-side, no perf
-        # impact). DRAM placement was originally needed to keep L1 clear of
-        # the unified routed-expert FFN's static CB region on the
-        # 256-expert / 32-per-chip configuration; the FFN no longer reads
-        # region_offsets directly, but DRAM placement is kept defensively.
-        #
-        # Contract: expert_region_offsets entries are TOKEN rows, tile-aligned
-        # (multiples of TILE_HEIGHT=32). ttnn::extract / ttnn::insert rely
-        # on this alignment when slicing dispatched_buffer into per-expert
-        # token tensors.
         (
             global_dispatch_offsets,
             total_counts_per_expert,
@@ -263,6 +238,5 @@ class TtMoERoutingSetup(LightweightModule):
             # device is opened with l1_small_size > 0 (e.g. the Kimi chunked test).
             use_l1_small_for_semaphores=self.use_l1_small_for_semaphores,
         )
-        signpost(header="moe_gate_calculate_global_dispatch_offsets")
 
         return global_dispatch_offsets, total_counts_per_expert, expert_region_offsets, expert_histograms

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_routing_setup.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_routing_setup.py
@@ -11,15 +11,17 @@ indices) and the dispatch module (TtDispatchModule) which physically moves token
 This is a TTNN wrapper around two device operations executed in sequence:
 
   1. masked_bincount — Builds a per-expert histogram counting how many tokens each expert
-     receives from the local chip. Uses a height-sharded parallel algorithm where BRISC and
-     NCRISC cooperatively count on each core, followed by a binary-tree reduction across
-     cores. The expert_dispatch_table acts as a mask: experts with mask[e] < 0 are not
-     present on this device and are skipped.
+     receives from the local chip. It consumes the gate's expert-index output directly (TILE,
+     interleaved) and untiles in-kernel; internally it assigns each of a fixed 8x8 core grid
+     (64 cores) a contiguous range of token rows, where BRISC and NCRISC cooperatively count,
+     followed by a binary-tree reduction across cores. The expert_dispatch_table acts as a
+     mask: experts with mask[e] < 0 are not present on this device and are skipped.
 
      Input:  ttnn_top_k_experts_indices
-               Shape per device: (seq_len_per_chip, num_experts_per_tok), uint16, height-sharded
-               across an 8x8 core grid (64 cores). Padded to min width of 8 if
-               num_experts_per_tok < 8 (L1 alignment = 16 bytes / 2 bytes per uint16).
+               Shape per device: (seq_len_per_chip, num_experts_per_tok), uint16, TILE,
+               interleaved (the gate emits L1-interleaved). seq_len_per_chip must be a multiple
+               of 64. The op reads only columns [0, num_experts_per_tok); the TILE width padding
+               (up to 32) is ignored, so no explicit width padding is needed.
              experts_in_dispatch_group
                Shape per device: (num_routed_experts,), int32, interleaved DRAM
                Mask where values >= 0 indicate experts present on this device, -1 means absent.
@@ -168,11 +170,12 @@ class TtMoERoutingSetup(LightweightModule):
         Args:
             ttnn_top_k_experts_indices: Top-k expert indices from the gate.
                 Shape per device: (seq_len_per_chip, num_experts_per_tok), uint16
-                Can be a torch.Tensor (will be converted and sharded automatically) or
-                a pre-sharded ttnn.Tensor.
+                Passed to masked_bincount as-is: a UINT16, TILE, interleaved ttnn.Tensor (the gate's
+                direct output; no untilize/reshard). A torch.Tensor is also accepted and converted to
+                the same TILE, interleaved layout.
             num_routed_experts: Total number of routed experts across all chips (e.g. 64 or 256)
             seq_len_per_chip: Number of tokens per chip. Must be divisible by 64 (the 8x8 core grid
-                used for height sharding in masked_bincount).
+                masked_bincount splits the token rows across).
             num_experts_per_tok: Number of experts each token is routed to (e.g. 2 for top-2 routing)
 
         Returns:
@@ -194,53 +197,29 @@ class TtMoERoutingSetup(LightweightModule):
         signpost(header="MoERoutingSetup")
 
         if isinstance(ttnn_top_k_experts_indices, torch.Tensor):
+            # Standalone/test path: build the same UINT16, TILE, L1 interleaved tensor the gate emits.
             mesh_mapper = ttnn.ShardTensor2dMesh(
                 self.mesh_device,
                 mesh_shape=self.mesh_device.shape,
-                dims=(0, None),  # shard cols; replicate rows
+                dims=(0, None),
             )
             ttnn_top_k_experts_indices = ttnn.from_torch(
                 ttnn_top_k_experts_indices,
                 device=self.mesh_device,
                 dtype=ttnn.uint16,
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                layout=ttnn.ROW_MAJOR_LAYOUT,
+                memory_config=ttnn.L1_MEMORY_CONFIG,
+                layout=ttnn.TILE_LAYOUT,
                 mesh_mapper=mesh_mapper,
             )
-        else:
-            ttnn_top_k_experts_indices = ttnn.to_layout(ttnn_top_k_experts_indices, ttnn.ROW_MAJOR_LAYOUT)
 
-        L1_ALIGNMENT_BYTES = 16
-        UINT16_BYTES = 2
+        # masked_bincount consumes the gate's expert-index output directly (UINT16, TILE,
+        # L1 interleaved) and untiles in-kernel.
         assert ttnn_top_k_experts_indices.dtype == ttnn.uint16, "Expected uint16 dtype for expert indices"
 
-        min_shard_width = L1_ALIGNMENT_BYTES // UINT16_BYTES  # 8
-
-        shard_width = num_experts_per_tok
-        if num_experts_per_tok < min_shard_width:
-            shard_width = min_shard_width
-            ttnn_top_k_experts_indices = ttnn.pad(
-                ttnn_top_k_experts_indices,
-                padding=((0, 0), (0, shard_width - num_experts_per_tok)),
-                value=(num_routed_experts + 1),
-            )
-
-        bincount_core_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 7))})
-        num_cores = bincount_core_grid.num_cores()
+        num_cores = 64  # masked_bincount uses a fixed 8x8 core grid
         assert (
             seq_len_per_chip % num_cores == 0
-        ), f"seq_len_per_chip ({seq_len_per_chip}) must be divisible by num_cores ({num_cores}) for sharding to work correctly"
-
-        self.expert_index_sharded_mem_config = ttnn.create_sharded_memory_config(
-            shape=(seq_len_per_chip // num_cores, shard_width),
-            core_grid=bincount_core_grid,
-            strategy=ttnn.ShardStrategy.HEIGHT,
-            use_height_and_width_as_shard_shape=True,
-        )
-
-        ttnn_top_k_experts_indices = ttnn.to_memory_config(
-            ttnn_top_k_experts_indices, self.expert_index_sharded_mem_config
-        )
+        ), f"seq_len_per_chip ({seq_len_per_chip}) must be divisible by num_cores ({num_cores})"
 
         if len(ttnn_top_k_experts_indices.shape) == 3:
             ttnn_top_k_experts_indices = ttnn.squeeze(ttnn_top_k_experts_indices, 0)

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_routing_setup.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_routing_setup.py
@@ -99,7 +99,6 @@ This is a TTNN wrapper around two device operations executed in sequence:
 
 import torch
 from loguru import logger
-from tracy import signpost
 
 import ttnn
 from models.common.lightweightmodule import LightweightModule
@@ -191,7 +190,6 @@ class TtMoERoutingSetup(LightweightModule):
             expert_histograms: Per-device token count per expert (before cross-chip aggregation).
                 Shape per device: (num_routed_experts,), uint32
         """
-        signpost(header="MoERoutingSetup")
 
         if isinstance(ttnn_top_k_experts_indices, torch.Tensor):
             # Standalone/test path: build the same UINT16, TILE, L1 interleaved tensor the gate emits.

--- a/models/demos/gpt_oss/tt/experts_throughput/prefill.py
+++ b/models/demos/gpt_oss/tt/experts_throughput/prefill.py
@@ -325,7 +325,6 @@ def _forward_prefill_deepseek_chunk(
     tt_offsets, tt_counts, expert_region_offsets, _ = pc.routing_setup(
         ttnn_top_k_experts_indices=idx_for_routing,
         num_routed_experts=config.num_experts,
-        seq_len_per_chip=pc.seq_len_per_chip,
         num_experts_per_tok=config.num_experts_per_tok,
     )
     ttnn.deallocate(idx_for_routing)

--- a/models/demos/minimax_m3/tt/moe/tt_minimax_moe.py
+++ b/models/demos/minimax_m3/tt/moe/tt_minimax_moe.py
@@ -186,7 +186,6 @@ class TtMiniMaxMoE(LightweightModule):
         tt_expert_offsets, tt_expert_token_counts, tt_expert_region_offsets, _ = self.routing_setup(
             ttnn_top_k_experts_indices=indices,
             num_routed_experts=self.num_routed_experts,
-            seq_len_per_chip=self.seq_len_per_chip,
             num_experts_per_tok=self.num_experts_per_tok,
         )
         indices = ttnn.to_layout(indices, ttnn.ROW_MAJOR_LAYOUT)

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/kernels/reader_masked_bincount.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/kernels/reader_masked_bincount.cpp
@@ -80,8 +80,9 @@ void kernel_main() {
     constexpr uint32_t cb_gather_tmp = get_compile_time_arg_val(11);
     constexpr uint32_t cb_mask = get_compile_time_arg_val(15);
     constexpr uint32_t mask_page_size = get_compile_time_arg_val(16);
+    constexpr uint32_t tile_h = get_compile_time_arg_val(17);
 
-    constexpr uint32_t src_accessor_offset = 17;
+    constexpr uint32_t src_accessor_offset = 18;
     constexpr auto src_args = TensorAccessorArgs<src_accessor_offset>();
     const auto src_accessor = TensorAccessor(src_args, src_addr);
 
@@ -102,14 +103,23 @@ void kernel_main() {
     uint32_t out_addr = cb_out.get_write_ptr();
     uint32_t mask_l1_addr = cb_mask_obj.get_write_ptr();
 
-    // Phase 1: Read this core's shard pages
-    for (uint32_t h = 0; h < h_count; h++) {
-        noc.async_read(
-            src_accessor,
-            CoreLocalMem<uint32_t>(in_base_addr + h * input_page_size),
-            input_page_size,
-            {.page_id = h_start + h},
-            {});
+    // Phase 1: Read the TILE pages covering this RISC's global row range [h_start, h_start + h_count).
+    // The input is TILE-interleaved; page_id indexes 32-row tiles (width is padded to a single tile).
+    // Row ranges are not tile-aligned in general, so adjacent RISCs/cores may read a shared boundary
+    // tile — each reads independently and counts only its own rows.
+    uint32_t first_tile = 0;
+    if (h_count > 0) {
+        first_tile = h_start / tile_h;
+        uint32_t last_tile = (h_start + h_count - 1) / tile_h;
+        uint32_t num_tiles = last_tile - first_tile + 1;
+        for (uint32_t t = 0; t < num_tiles; t++) {
+            noc.async_read(
+                src_accessor,
+                CoreLocalMem<uint32_t>(in_base_addr + t * input_page_size),
+                input_page_size,
+                {.page_id = first_tile + t},
+                {});
+        }
     }
 
     // Phase 2: Local histogram counting (BRISC/NCRISC cooperate on same core)
@@ -133,11 +143,23 @@ void kernel_main() {
     const uint8_t my_noc_id = noc.get_noc_id();
     const uint32_t my_noc_x = my_x[my_noc_id];
     const uint32_t my_noc_y = my_y[my_noc_id];
-    for (uint32_t h = 0; h < h_count; h++) {
-        volatile tt_l1_ptr uint16_t* row =
-            reinterpret_cast<volatile tt_l1_ptr uint16_t*>(in_base_addr + h * input_page_size);
+
+    // Untile in place: a 32x32 tile stores four 16x16 faces (face0,face1,face2,face3, row-major within
+    // each). Experts occupy columns [0, num_experts_per_token) which fall in the left faces (0 and 2),
+    // so element (row r within a tile, column c) sits at uint16 offset:
+    //   (r / 16) * 2 * 256 + (r % 16) * 16 + c
+    constexpr uint32_t FACE_DIM = 16;
+    constexpr uint32_t FACE_SIZE = FACE_DIM * FACE_DIM;  // 256 uint16 per face
+    const uint32_t tile_elems = input_page_size / 2;     // uint16 per tile page
+    volatile tt_l1_ptr uint16_t* in_u16 = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(in_base_addr);
+    for (uint32_t j = 0; j < h_count; j++) {
+        uint32_t global_row = h_start + j;
+        uint32_t tile_local = global_row / tile_h - first_tile;
+        uint32_t within = global_row % tile_h;
+        uint32_t row_base =
+            tile_local * tile_elems + (within / FACE_DIM) * 2 * FACE_SIZE + (within % FACE_DIM) * FACE_DIM;
         for (uint32_t w = 0; w < num_experts_per_token; w++) {
-            uint32_t expert_idx = row[w];
+            uint32_t expert_idx = in_u16[row_base + w];
             if (expert_idx < n_routed_experts && mask[expert_idx] >= 0) {
                 // TODO: D2.0 has no wrapper for atomic-increment on an arbitrary L1 word
                 // (the target here is a histogram bin, not a registered semaphore). The

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/masked_bincount_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/masked_bincount_device_operation.cpp
@@ -12,20 +12,24 @@ void MaskedBincountDeviceOperation::validate_on_program_cache_miss(
     const auto& input_tensor = tensor_args.input_tensor;
     const auto& expert_mask = tensor_args.expert_mask;
 
+    // The op consumes the gate's expert-index output directly: UINT16, TILE, interleaved. It untiles
+    // in-kernel (reading only columns [0, num_experts_per_token)) so the caller no longer needs a
+    // separate untilize_with_unpadding + interleaved_to_sharded before this op.
     TT_FATAL(input_tensor.dtype() == tt::tt_metal::DataType::UINT16, "Only UINT16 is supported for input!");
-    TT_FATAL(input_tensor.layout() == tt::tt_metal::Layout::ROW_MAJOR, "Only ROW_MAJOR layout is supported for input!");
+    TT_FATAL(input_tensor.layout() == tt::tt_metal::Layout::TILE, "Only TILE layout is supported for input!");
     const auto& input_shape = input_tensor.padded_shape();
     TT_FATAL(
         input_shape.size() == 2, "Input tensor must be 2D [sp_dim, topk_dim], got {} dimensions", input_shape.size());
     TT_FATAL(
-        input_tensor.memory_config().memory_layout() == tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
-        "Input tensor must be height sharded!");
-    TT_FATAL(input_tensor.shard_spec().has_value(), "Input tensor must have a shard spec!");
+        input_tensor.memory_config().memory_layout() == tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
+        "Input tensor must be interleaved!");
     TT_FATAL(args.n_routed_experts > 0, "n_routed_experts must be > 0");
+    // The logical width is the real topk (e.g. 8); the padded TILE width is 32. Check against logical.
+    const uint32_t logical_topk = input_tensor.logical_shape()[input_tensor.logical_shape().size() - 1];
     TT_FATAL(
-        args.num_experts_per_token > 0 && args.num_experts_per_token <= input_shape[input_shape.size() - 1],
+        args.num_experts_per_token > 0 && args.num_experts_per_token <= logical_topk,
         "num_experts_per_token must be in (0, {}], got {}",
-        input_shape[input_shape.size() - 1],
+        logical_topk,
         args.num_experts_per_token);
 
     TT_FATAL(expert_mask.dtype() == tt::tt_metal::DataType::INT32, "Expert dispatch table must be INT32!");

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/masked_bincount_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/masked_bincount_device_operation.cpp
@@ -23,6 +23,15 @@ void MaskedBincountDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(
         input_tensor.memory_config().memory_layout() == tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
         "Input tensor must be interleaved!");
+    // The op splits the token rows across a fixed 8x8 (64-core) grid, so the token count must be
+    // divisible by 64 (which also keeps every core's row range tile-aligned in aggregate).
+    constexpr uint32_t kNumCores = 64;
+    const uint32_t tokens = input_tensor.logical_shape()[0];
+    TT_FATAL(
+        tokens % kNumCores == 0,
+        "Token count ({}) must be divisible by the {}-core grid used by masked_bincount",
+        tokens,
+        kNumCores);
     TT_FATAL(args.n_routed_experts > 0, "n_routed_experts must be > 0");
     // The logical width is the real topk (e.g. 8); the padded TILE width is 32. Check against logical.
     const uint32_t logical_topk = input_tensor.logical_shape()[input_tensor.logical_shape().size() - 1];

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/masked_bincount_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/masked_bincount_device_operation.cpp
@@ -33,12 +33,42 @@ void MaskedBincountDeviceOperation::validate_on_program_cache_miss(
         tokens,
         kNumCores);
     TT_FATAL(args.n_routed_experts > 0, "n_routed_experts must be > 0");
+
+    // Reader geometry contract (see kernels/reader_masked_bincount.cpp): the reader treats a page id as
+    // a row-tile index and untiles rows through the two left 16-wide faces of a 32x32 tile. Inputs
+    // outside that contract would read the wrong pages / face offsets and silently miscount, so reject
+    // them here rather than returning an inflated or garbage histogram.
+    constexpr uint32_t kTileDim = 32;
+    constexpr uint32_t kFaceDim = 16;
+    const auto& tile = input_tensor.tensor_spec().page_config().get_tile();
+    TT_FATAL(
+        tile.get_height() == kTileDim && tile.get_width() == kTileDim,
+        "Only {}x{} tiles are supported (the in-kernel untilize assumes four {}x{} faces), got {}x{}",
+        kTileDim,
+        kTileDim,
+        kFaceDim,
+        kFaceDim,
+        tile.get_height(),
+        tile.get_width());
+    // A page id is used directly as the row-tile index, which only holds for a single tile column.
+    TT_FATAL(
+        input_shape[1] == tile.get_width(),
+        "topk_dim must fit in a single tile column (padded width {}), got padded width {}",
+        tile.get_width(),
+        input_shape[1]);
+
     // The logical width is the real topk (e.g. 8); the padded TILE width is 32. Check against logical.
     const uint32_t logical_topk = input_tensor.logical_shape()[input_tensor.logical_shape().size() - 1];
     TT_FATAL(
         args.num_experts_per_token > 0 && args.num_experts_per_token <= logical_topk,
         "num_experts_per_token must be in (0, {}], got {}",
         logical_topk,
+        args.num_experts_per_token);
+    // Columns >= 16 live in faces 1/3, which the reader's face-offset math does not address.
+    TT_FATAL(
+        args.num_experts_per_token <= kFaceDim,
+        "num_experts_per_token must be <= {} (the reader untiles only the left faces of each tile), got {}",
+        kFaceDim,
         args.num_experts_per_token);
 
     TT_FATAL(expert_mask.dtype() == tt::tt_metal::DataType::INT32, "Expert dispatch table must be INT32!");

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/masked_bincount_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/masked_bincount_program_factory.cpp
@@ -27,19 +27,30 @@ MaskedBincountProgramFactory::cached_program_t MaskedBincountProgramFactory::cre
         tt::tt_metal::datatype_to_dataformat_converter(tt::tt_metal::DataType::UINT32);
     uint32_t n_routed_experts = operation_attributes.n_routed_experts;
 
-    const auto& shard_spec = input.shard_spec().value();
-    auto all_cores = shard_spec.grid;
+    // Input is TILE + interleaved (no shard spec). Derive the work split from the shape: keep the
+    // fixed 8x8 (64-core) grid and the binary-tree reduction, giving each core a contiguous range of
+    // token rows. Each core reads the TILE pages covering its rows from interleaved memory and untiles
+    // in-kernel. tile_h (32) is the tile height; the token count is tile-aligned by construction.
+    const uint32_t tile_h = input.tensor_spec().page_config().get_tile().get_height();
+    const uint32_t tokens = input.padded_shape()[0];
+
+    CoreRangeSet all_cores(CoreRange(CoreCoord(0, 0), CoreCoord(7, 7)));
     uint32_t num_cores = all_cores.num_cores();
-    uint32_t shard_height = shard_spec.shape[0];
+    TT_FATAL(tokens % num_cores == 0, "Token count ({}) must be divisible by the {}-core grid", tokens, num_cores);
+    uint32_t shard_height = tokens / num_cores;  // rows per core
 
     uint32_t h_brisc = shard_height / 2;
     uint32_t h_ncrisc = shard_height - h_brisc;
+
+    // Max TILE pages a RISC's row range can span (misaligned ranges straddle one extra tile).
+    uint32_t max_tiles_brisc = (h_brisc + tile_h - 1) / tile_h + 1;
+    uint32_t max_tiles_ncrisc = (h_ncrisc + tile_h - 1) / tile_h + 1;
 
     auto* src_buffer = input.buffer();
     auto* dst_buffer = tensor_return_value.buffer();
     auto* mask_buffer = expert_mask.buffer();
 
-    uint32_t input_page_size = src_buffer->aligned_page_size();
+    uint32_t input_page_size = src_buffer->aligned_page_size();  // one TILE (32x32 uint16)
     uint32_t output_page_size = dst_buffer->aligned_page_size();
     uint32_t mask_page_size = mask_buffer->aligned_page_size();
 
@@ -53,7 +64,7 @@ MaskedBincountProgramFactory::cached_program_t MaskedBincountProgramFactory::cre
     // CB 0: BRISC input pages (per-shard)
     uint32_t cb_in_brisc = tt::CBIndex::c_0;
     tt::tt_metal::CircularBufferConfig cb_in_brisc_config =
-        tt::tt_metal::CircularBufferConfig(h_brisc * input_page_size, {{cb_in_brisc, input_cb_data_format}})
+        tt::tt_metal::CircularBufferConfig(max_tiles_brisc * input_page_size, {{cb_in_brisc, input_cb_data_format}})
             .set_page_size(cb_in_brisc, input_page_size);
     tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_in_brisc_config);
 
@@ -67,7 +78,7 @@ MaskedBincountProgramFactory::cached_program_t MaskedBincountProgramFactory::cre
     // CB 2: NCRISC input pages (per-shard)
     uint32_t cb_in_ncrisc = tt::CBIndex::c_2;
     tt::tt_metal::CircularBufferConfig cb_in_ncrisc_config =
-        tt::tt_metal::CircularBufferConfig(h_ncrisc * input_page_size, {{cb_in_ncrisc, input_cb_data_format}})
+        tt::tt_metal::CircularBufferConfig(max_tiles_ncrisc * input_page_size, {{cb_in_ncrisc, input_cb_data_format}})
             .set_page_size(cb_in_ncrisc, input_page_size);
     tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_in_ncrisc_config);
 
@@ -116,6 +127,7 @@ MaskedBincountProgramFactory::cached_program_t MaskedBincountProgramFactory::cre
         num_cores,
         cb_mask,
         mask_page_size,
+        tile_h,
     };
     ct_args_brisc.insert(ct_args_brisc.end(), accessor_args.begin(), accessor_args.end());
 
@@ -138,6 +150,7 @@ MaskedBincountProgramFactory::cached_program_t MaskedBincountProgramFactory::cre
         num_cores,
         cb_mask,
         mask_page_size,
+        tile_h,
     };
     ct_args_ncrisc.insert(ct_args_ncrisc.end(), accessor_args.begin(), accessor_args.end());
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/masked_bincount_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/masked_bincount_nanobind.cpp
@@ -20,8 +20,11 @@ void bind_experimental_masked_bincount_operation(nb::module_& mod) {
             dispatch groups).
 
             Args:
-                * :attr:`input_tensor`: 2D UINT16 height-sharded ROW_MAJOR tensor of shape [sp_dim, topk_dim]
-                  containing expert indices selected for each token.
+                * :attr:`input_tensor`: 2D UINT16 TILE, interleaved tensor of shape [sp_dim, topk_dim]
+                  containing the expert indices selected for each token. This is the gate's expert-index
+                  output consumed directly (no untilize/reshard needed): the op untiles in-kernel and
+                  splits the token rows across a fixed 8x8 (64-core) grid internally. sp_dim must be a
+                  multiple of 64. Both DRAM- and L1-interleaved inputs are accepted (the gate emits L1).
                 * :attr:`expert_mask`: INT32 ROW_MAJOR tensor of shape [N] or [1, N] where N >= n_routed_experts,
                   mapping experts to chip IDs. Negative (-1) means the expert is absent (belongs to different dispatch
                   groups); non-negative values (chip IDs) mean the expert is present in this dispatch group and will
@@ -29,8 +32,8 @@ void bind_experimental_masked_bincount_operation(nb::module_& mod) {
                   reads mask entries at index < n_routed_experts, so padded tokens (sentinel index == n_routed_experts)
                   are skipped and never counted.
                 * :attr:`n_routed_experts`: Number of routed experts (output dimension size).
-                * :attr:`num_experts_per_token`: Number of expert columns per row to count (must be <= topk_dim).
-                  Columns beyond this index are ignored, allowing padded shard widths.
+                * :attr:`num_experts_per_token`: Number of expert columns per row to count (must be <= the logical
+                  topk_dim). Columns beyond this index (including the TILE width padding up to 32) are ignored.
 
             Returns:
                 A 1D UINT32 tensor of shape [n_routed_experts] where each element is the count of how many


### PR DESCRIPTION
## Overview

Removes the two tiny data-movement ops (`untilize_with_unpadding` + `interleaved_to_sharded`, 1–10µs each) that sat between the MoE gate and `masked_bincount`. Both were very short ops whose op-to-op gaps fast-dispatch could not hide. `masked_bincount` now consumes the gate's expert-index output **directly** (UINT16, TILE, L1-interleaved) and untiles in-kernel.

Closes #50240.

## Key Changes

- **`MaskedBincountDeviceOperation`** now accepts a **UINT16, TILE, interleaved** input (was ROW_MAJOR + height-sharded). Validation checks only `INTERLEAVED` memory layout, so both L1- and DRAM-interleaved inputs work (the gate emits L1).
- **Program factory** derives the work split from the tensor shape instead of a shard spec: it keeps the fixed 8×8 (64-core) grid and the binary-tree reduction, giving each core a contiguous range of token rows and sizing the input CBs in whole tiles.
- **Reader kernel** reads the TILE pages covering each core's row range from the interleaved buffer and untiles in-kernel via face addressing (columns `0..topk-1`), reading only the real experts (TILE width padding ignored). Counting + cross-core tree reduction are unchanged.
- **`tt_moe_routing_setup.py`** drops the `to_layout` (untilize) and `to_memory_config` (shard) conversions plus the old min-shard-width padding, and passes the gate tensor straight through.
- Docs (nanobind + module/forward docstrings) and the two tests updated to the new TILE/L1-interleaved contract.

## Trade-off note

The op reads whole 32-wide tiles (only `topk` columns are used) and adjacent cores may re-read a shared boundary tile, so raw bytes moved inside the op increase. The tensor is tiny (~100 KB), so that is negligible; the win is eliminating two full op launches and their dispatch gaps, which was the actual bottleneck.

## Testing (Blackhole)

- `test_masked_bincount` — exact match vs torch for tile-aligned (4096) and misaligned (1600, spans tile boundaries) inputs.
- `test_moe_routing_setup` (FABRIC_1D mesh-4x2, seq=3200 misaligned) — all 4 configs (pad0/pad50 × predictable/random) pass.
- Full MoE `test_ds_moe` (FABRIC_1D mesh-4x2, pcc-device-256, pad0) — gate recall 4/4; routed 0.971 / final 0.9869 / reference 0.9869, identical to baseline.
- Note: the `fabric2d-mesh-4x2` variant is a known pre-existing hang on `main` (owned separately), so it was validated on the FABRIC_1D analog.

## Measurements
`python -m tracy -r -m pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_ds_moe[blackhole-deepseek_v3-mesh-4x2-pad0-perf-device-256]`

We can observe that `UntilizeWithUnpaddingDeviceOperation` was reduced by approximately 8us and `InterleavedToShardedDeviceOperation` was completely gone, while `MaskedBincountDeviceOperation` stayed unchanged.

### Main (4a2b49d4b020)
<img width="1276" height="399" alt="image" src="https://github.com/user-attachments/assets/37b8451d-bb87-45f8-a3c4-e80dde418a7e" />

### Branch
<img width="1276" height="385" alt="image" src="https://github.com/user-attachments/assets/ecb9cbc3-a70e-454f-95fc-6629a2e642d2" />


## CI Pipelines

* * *

[![Blaze Models Prefill](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=fbajraktari/50240-masked-bincount-tile-interleaved)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml?query=branch%3Afbajraktari%2F50240-masked-bincount-tile-interleaved)  
[![T3K e2e DeepSeek Prefill](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=fbajraktari/50240-masked-bincount-tile-interleaved)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch%3Afbajraktari%2F50240-masked-bincount-tile-interleaved)  
[![SP Release DeepSeek Prefill](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=fbajraktari/50240-masked-bincount-tile-interleaved)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch%3Afbajraktari%2F50240-masked-bincount-tile-interleaved)  
[![BH e2e DeepSeek Prefill](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=fbajraktari/50240-masked-bincount-tile-interleaved)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch%3Afbajraktari%2F50240-masked-bincount-tile-interleaved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fbajraktari/50240-masked-bincount-tile-interleaved)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fbajraktari/50240-masked-bincount-tile-interleaved)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fbajraktari/50240-masked-bincount-tile-interleaved)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fbajraktari/50240-masked-bincount-tile-interleaved)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=fbajraktari/50240-masked-bincount-tile-interleaved)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:fbajraktari/50240-masked-bincount-tile-interleaved)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fbajraktari/50240-masked-bincount-tile-interleaved)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fbajraktari/50240-masked-bincount-tile-interleaved)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fbajraktari/50240-masked-bincount-tile-interleaved)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fbajraktari/50240-masked-bincount-tile-interleaved)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fbajraktari/50240-masked-bincount-tile-interleaved)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fbajraktari/50240-masked-bincount-tile-interleaved)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fbajraktari/50240-masked-bincount-tile-interleaved)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fbajraktari/50240-masked-bincount-tile-interleaved)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fbajraktari/50240-masked-bincount-tile-interleaved)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fbajraktari/50240-masked-bincount-tile-interleaved)