### PR TITLE
[Bug fix] emule: skip RISC-V kernel link for Emule programs

### DIFF
--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -2340,11 +2340,9 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
         return;
     }
 
-    // Emule never links a real RISC-V kernel binary: DispatchCompiledProgramToDevice's Emule branch
-    // (tt_metal.cpp) skips this function entirely and lazily JIT-compiles the kernel source to x86
-    // inside execute_program_emulated instead. Eager callers (MakeProgramFromSpec /
-    // MakeMeshWorkloadFromSpecs) reach this generic compile() directly, before dispatch ever gets a
-    // chance to take that branch, so it must also skip the RISC-V generate_binaries()/link() step here.
+    // Emule never links a real RISC-V kernel binary -- DispatchCompiledProgramToDevice already skips
+    // this function for Emule, JIT-compiling to x86 in execute_program_emulated instead. Eager callers
+    // (MakeProgramFromSpec/MakeMeshWorkloadFromSpecs) reach compile() directly, so skip here too.
     if (cluster.get_target_device_type() == tt::TargetDevice::Emule) {
         compiled_.insert(build_env.build_key());
         Inspector::program_compile_finished(this, device, build_env.build_key());

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -2340,6 +2340,17 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
         return;
     }
 
+    // Emule never links a real RISC-V kernel binary: DispatchCompiledProgramToDevice's Emule branch
+    // (tt_metal.cpp) skips this function entirely and lazily JIT-compiles the kernel source to x86
+    // inside execute_program_emulated instead. Eager callers (MakeProgramFromSpec /
+    // MakeMeshWorkloadFromSpecs) reach this generic compile() directly, before dispatch ever gets a
+    // chance to take that branch, so it must also skip the RISC-V generate_binaries()/link() step here.
+    if (cluster.get_target_device_type() == tt::TargetDevice::Emule) {
+        compiled_.insert(build_env.build_key());
+        Inspector::program_compile_finished(this, device, build_env.build_key());
+        return;
+    }
+
     TT_FATAL(
         device->is_initialized(),
         "Device needs to be initialized before program {} compilation! Generating headers for banking information is "


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

`DispatchCompiledProgramToDevice` (`tt_metal.cpp`) already special-cases Emule to bypass `ProgramImpl::compile()` entirely, lazily JIT-compiling kernel source to x86 inside `execute_program_emulated` instead — Emule has never linked a real RISC-V kernel binary, and its precompiled-firmware coverage / live `build_firmware()` fallback were never wired up to support it.

`MakeProgramFromSpec` / `MakeMeshWorkloadFromSpecs` (#49437) now call `compile_and_allocate()` eagerly at Program-construction time, reaching this generic (device-type-agnostic) `compile()` directly instead of going through dispatch — hitting the missing firmware symbol for the first time:

```
kernel_brisc.ld: non constant or forward reference address expression for section .text
```

This affects every kernel compiled through the Metal 2.0 `ProgramSpec` API on `GenericMeshDeviceFixture` under tt-emule (not just the 8 tests originally reported — confirmed the `_2_0`-suffixed siblings and other Metal-2.0-authored data-movement tests hit the same failure, while legacy `CreateKernel`-based tests are unaffected).

This mirrors the existing Quasar-mock skip added alongside the eager-compile change in #49437: gate on `cluster.get_target_device_type() == TargetDevice::Emule`, the same signal `DispatchCompiledProgramToDevice` and `RiscFirmwareInitializer` already branch on.

Relates to tenstorrent/tt-emule#280.

### Notes for reviewers

- Root cause bisected to commit `7b36e769200` ("[Feature] Metal 2.0 MakeMeshWorkloadFromSpecs (#49437)") — confirmed by diffing directly against its parent, not by reading `git log`/`git show` alone.


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=arminale/emule-280)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:arminale/emule-280)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=arminale/emule-280)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:arminale/emule-280)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=arminale/emule-280)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:arminale/emule-280)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=arminale/emule-280)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:arminale/emule-280)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=arminale/emule-280)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:arminale/emule-280)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=arminale/emule-280)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:arminale/emule-280)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=arminale/emule-280)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:arminale/emule-280)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=arminale/emule-280)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:arminale/emule-280)
