### PR TITLE
[Feature] Add --speed-of-light support to LLK test runners

### DIFF
--- a/tt_metal/tt-llk/.claude/scripts/run_test.sh
+++ b/tt_metal/tt-llk/.claude/scripts/run_test.sh
@@ -35,6 +35,7 @@
 #   --lock-timeout N  Seconds to wait for the lock (default: 900)
 #   --sim-path PATH   Override TT_UMD_SIMULATOR_PATH
 #                     (default: /proj_sw/user_dev/$USER/tt-umd-simulators/build/emu-<arch>-1x3)
+#   --speed-of-light  Pass pytest --speed-of-light (compile-time formats / SOL path).
 #   --no-split        Skip compile-producer step; run pytest --run-simulator without
 #                     --compile-consumer (combined compile+run in one pytest invocation).
 #                     Use for issue-solver tests that don't pre-build ELFs.
@@ -112,6 +113,7 @@ LOCKFILE=""  # set in _validate based on ARCH if not user-overridden
 LOCK_TIMEOUT="900"
 SIM_PATH=""
 NO_SPLIT="false"
+SPEED_OF_LIGHT="false"
 LOG_DIR=""
 PROGRESS_ENABLED="false"
 PROGRESS_INTERVAL="30"
@@ -134,6 +136,7 @@ while [[ $# -gt 0 ]]; do
     --log-dir)       LOG_DIR="$2";       shift 2 ;;
     --progress)      PROGRESS_ENABLED="true"; shift ;;
     --progress-interval) PROGRESS_INTERVAL="$2"; shift 2 ;;
+    --speed-of-light) SPEED_OF_LIGHT="true"; shift ;;
     --no-split)      NO_SPLIT="true";    shift   ;;
     --verbose|-v)    VERBOSE="true";     shift   ;;
     --help|-h)
@@ -428,7 +431,7 @@ _do_count() {
 
 _do_compile() {
   _validate
-  _vlog "compile: ${TEST_FILE} (arch=${ARCH}, -n ${JOBS}${K_FILTER:+, -k '${K_FILTER}'})"
+  _vlog "compile: ${TEST_FILE} (arch=${ARCH}, -n ${JOBS}${K_FILTER:+, -k '${K_FILTER}'}$([[ "$SPEED_OF_LIGHT" == true ]] && echo ', sol'))"
 
   # The two-phase flow requires compile and simulate to filter to the same set:
   # simulate's --compile-consumer reads per-variant artifacts that producer
@@ -443,6 +446,7 @@ _do_compile() {
   else
     pytest_args=("$TEST_FILE")
   fi
+  [[ "$SPEED_OF_LIGHT" == "true" ]] && pytest_args=(--speed-of-light "${pytest_args[@]}")
 
   # Background pytest so the progress ticker can run alongside. If progress is
   # disabled we still pay the (negligible) cost of background+wait — keeps the
@@ -522,6 +526,7 @@ _do_simulate() {
     pytest_flags="${pytest_flags} --run-simulator --port=${PORT}"
   fi
   [[ "$NO_SPLIT" == "false" ]] && pytest_flags="${pytest_flags} --compile-consumer"
+  [[ "$SPEED_OF_LIGHT" == "true" ]] && pytest_flags="${pytest_flags} --speed-of-light"
   [[ -n "$MAXFAIL" ]] && pytest_flags="${pytest_flags} --maxfail=${MAXFAIL}"
 
   # Determine the test target (file, -k filter, or single variant by ID)

--- a/tt_metal/tt-llk/.cursor/scripts/run_test.sh
+++ b/tt_metal/tt-llk/.cursor/scripts/run_test.sh
@@ -37,6 +37,7 @@
 #   --lock-timeout N  Seconds to wait for the lock (default: 900)
 #   --sim-path PATH   Override TT_UMD_SIMULATOR_PATH
 #                     (default: /proj_sw/user_dev/$USER/tt-umd-simulators/build/emu-<arch>-1x3)
+#   --speed-of-light  Pass pytest --speed-of-light (compile-time formats / SOL path).
 #   --no-split        Skip compile-producer step; run pytest --run-simulator without
 #                     --compile-consumer (combined compile+run in one pytest invocation).
 #                     Use for issue-solver tests that don't pre-build ELFs.
@@ -97,6 +98,7 @@ LOCKFILE=""  # set in _validate based on ARCH if not user-overridden
 LOCK_TIMEOUT="900"
 SIM_PATH=""
 NO_SPLIT="false"
+SPEED_OF_LIGHT="false"
 LOG_DIR=""
 VERBOSE="false"
 
@@ -115,6 +117,7 @@ while [[ $# -gt 0 ]]; do
     --lock-timeout)  LOCK_TIMEOUT="$2";  shift 2 ;;
     --sim-path)      SIM_PATH="$2";      shift 2 ;;
     --log-dir)       LOG_DIR="$2";       shift 2 ;;
+    --speed-of-light) SPEED_OF_LIGHT="true"; shift ;;
     --no-split)      NO_SPLIT="true";    shift   ;;
     --verbose|-v)    VERBOSE="true";     shift   ;;
     --help|-h)
@@ -262,6 +265,8 @@ _do_compile() {
   # wrote, so an unfiltered producer + filtered consumer would either rebuild
   # variants the consumer skips or miss variants the consumer needs.
   local -a kflag=()
+  local -a solflag=()
+  [[ "$SPEED_OF_LIGHT" == "true" ]] && solflag=(--speed-of-light)
   local -a pytest_targets=("${TEST_FILES[@]}")
   local target_label="$(_test_label)"
   if [[ -n "$TEST_ID" ]]; then
@@ -271,7 +276,7 @@ _do_compile() {
     kflag=(-k "$K_FILTER")
   fi
 
-  _vlog "compile: ${target_label} (arch=${ARCH}, -n ${JOBS}${kflag[*]:+, -k '${K_FILTER}'})"
+  _vlog "compile: ${target_label} (arch=${ARCH}, -n ${JOBS}${kflag[*]:+, -k '${K_FILTER}'}$([[ "$SPEED_OF_LIGHT" == true ]] && echo ', sol'))"
 
   if [[ -n "$LOG_DIR" ]]; then
     mkdir -p "$LOG_DIR"
@@ -279,14 +284,14 @@ _do_compile() {
       # shellcheck disable=SC1091
       source "${VENV}/bin/activate"
       cd "${TEST_DIR}"
-      CHIP_ARCH="${ARCH}" pytest --compile-producer -n "${JOBS}" "${kflag[@]}" "${pytest_targets[@]}"
+      CHIP_ARCH="${ARCH}" pytest --compile-producer -n "${JOBS}" "${solflag[@]}" "${kflag[@]}" "${pytest_targets[@]}"
     ) > >(tee -a "${LOG_DIR}/compile.log") 2> >(tee -a "${LOG_DIR}/compile.log" >&2)
   else
     (
       # shellcheck disable=SC1091
       source "${VENV}/bin/activate"
       cd "${TEST_DIR}"
-      CHIP_ARCH="${ARCH}" pytest --compile-producer -n "${JOBS}" "${kflag[@]}" "${pytest_targets[@]}"
+      CHIP_ARCH="${ARCH}" pytest --compile-producer -n "${JOBS}" "${solflag[@]}" "${kflag[@]}" "${pytest_targets[@]}"
     )
   fi
 }
@@ -326,6 +331,7 @@ _do_simulate() {
     pytest_flags="${pytest_flags} --run-simulator --port=${PORT}"
   fi
   [[ "$NO_SPLIT" == "false" ]] && pytest_flags="${pytest_flags} --compile-consumer"
+  [[ "$SPEED_OF_LIGHT" == "true" ]] && pytest_flags="${pytest_flags} --speed-of-light"
   [[ -n "$MAXFAIL" ]] && pytest_flags="${pytest_flags} --maxfail=${MAXFAIL}"
 
   # Determine the test target (file, -k filter, or single variant by ID)


### PR DESCRIPTION
### Ticket

Closes #50651

### Problem description

LLK performance tests need to run with pytest's `--speed-of-light` mode, but the Claude and Cursor test runner scripts do not currently accept or forward that option through their split compile/simulate flow.

### What's changed

- Add and document a `--speed-of-light` option in both LLK test runner scripts.
- Forward the option to pytest's compile-producer invocation.
- Forward the option to simulator and compile-consumer invocations.
- Include SOL mode in verbose compile logging.
- Validate both updated scripts with `bash -n`.

The option is available to every simulation, allowing performance tests to enable SOL mode while preserving existing behavior when it is omitted.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

### Checklist

- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Sanity](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml) CI passes (if applicable)
- [ ] [Assert validation](https://github.com/tenstorrent/tt-llk/blob/main/docs/Introduction_to_asserts.md) Complied with assert doc (if applicable)

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/add_support_for_sol)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/add_support_for_sol)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/add_support_for_sol)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/add_support_for_sol)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ndivnic/add_support_for_sol)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ndivnic/add_support_for_sol)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/add_support_for_sol)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/add_support_for_sol)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/add_support_for_sol)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/add_support_for_sol)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/add_support_for_sol)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/add_support_for_sol)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/add_support_for_sol)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/add_support_for_sol)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/add_support_for_sol)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/add_support_for_sol)