### PR TITLE
[LLK] Fix eltwise binary dest-reuse for ELWMUL and HiFi partial faces.

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_binary.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_binary.py
@@ -322,7 +322,6 @@ def test_eltwise_binary(
             ]
         )
         if fmt.input_format == DataFormat.Bfp4_b
-        # or fmt.output_format == DataFormat.Bfp4_b
     ],
     broadcast_type=[
         BroadcastType.None_,
@@ -334,7 +333,6 @@ def test_eltwise_binary(
     transpose_srca=Transpose.No,
     math_op=[MathOperation.Elwadd, MathOperation.Elwsub],
     input_dimensions=[[32, 32], [64, 32], [32, 64], [256, 32]],
-    # tile_dimensions=[[32, 32], [16,32]],
     tile_dimensions=lambda transpose_srca, broadcast_type: _get_valid_tile_dimensions(
         transpose_srca, broadcast_type
     ),
@@ -507,29 +505,8 @@ def test_eltwise_binary_bfp4_b(
     ), "Assert against golden failed"
 
 
-@parametrize(
-    reuse_dest_type=[
-        EltwiseBinaryReuseDestType.DEST_TO_SRCA,
-        EltwiseBinaryReuseDestType.DEST_TO_SRCB,
-    ],
-    formats=lambda: input_output_formats(
-        [DataFormat.Float16_b, DataFormat.Float32, DataFormat.Bfp8_b],
-        same=True,
-    ),
-    math_fidelity=[MathFidelity.LoFi],
-    math_op=[MathOperation.Elwadd, MathOperation.Elwsub, MathOperation.Elwmul],
-    input_dimensions=[[512, 32]],
-    output_dimensions=[[128, 32]],
-    tile_dimensions=[[32, 32], [16, 32]],
-)
-def test_eltwise_binary_dest_reuse(
-    reuse_dest_type,
-    formats,
-    math_fidelity,
-    math_op,
-    input_dimensions,
-    output_dimensions,
-    tile_dimensions,
+def _prepare_dest_reuse_inputs(
+    formats, input_dimensions, output_dimensions, tile_dimensions
 ):
     face_r_dim, num_faces_r_dim, num_faces_c_dim = get_tile_params(tile_dimensions)
     num_faces = num_faces_r_dim * num_faces_c_dim
@@ -546,6 +523,8 @@ def test_eltwise_binary_dest_reuse(
         f"Input tile count ({tile_cnt_input}) must be divisible by "
         f"output tile count ({tile_cnt_output})"
     )
+    inner_dim = tile_cnt_input // tile_cnt_output
+    assert inner_dim > 1, "Dest reuse requires at least one reuse accumulation"
 
     src_A, _, src_B, _ = generate_stimuli(
         stimuli_format_A=formats.input_format,
@@ -555,7 +534,6 @@ def test_eltwise_binary_dest_reuse(
         tile_dimensions=tile_dimensions,
     )
 
-    # Compute block/tile counts for output (determines dest register blocking)
     effective_dest_acc = (
         DestAccumulation.Yes
         if formats.output_format == DataFormat.Float32
@@ -569,75 +547,150 @@ def test_eltwise_binary_dest_reuse(
         tile_dimensions,
         BlocksCalculationAlgorithm.Standard,
     )
-
-    # Input has the same block count, but more tiles per block
-    inner_dim = tile_cnt_input // tile_cnt_output
     input_tiles_in_block = inner_dim * output_tiles_in_block
-    input_num_blocks = output_num_blocks
 
-    # Tilize inputs
-    src_A_tilized = tilize_block(
+    src_A_tilized_flat = tilize_block(
         src_A,
         dimensions=input_dimensions,
         stimuli_format=formats.input_format,
         num_faces=num_faces,
         tile_dimensions=tile_dimensions,
         face_r_dim=face_r_dim,
-    )
-    src_B_tilized = tilize_block(
+    ).flatten()
+    src_B_tilized_flat = tilize_block(
         src_B,
         dimensions=input_dimensions,
         stimuli_format=formats.input_format,
         num_faces=num_faces,
         tile_dimensions=tile_dimensions,
         face_r_dim=face_r_dim,
+    ).flatten()
+
+    return {
+        "face_r_dim": face_r_dim,
+        "num_faces_r_dim": num_faces_r_dim,
+        "num_faces_c_dim": num_faces_c_dim,
+        "num_faces": num_faces,
+        "tile_cnt_input": tile_cnt_input,
+        "tile_cnt_output": tile_cnt_output,
+        "inner_dim": inner_dim,
+        "output_num_blocks": output_num_blocks,
+        "output_tiles_in_block": output_tiles_in_block,
+        "input_tiles_in_block": input_tiles_in_block,
+        "input_num_blocks": output_num_blocks,
+        "src_A_tilized_flat": src_A_tilized_flat,
+        "src_B_tilized_flat": src_B_tilized_flat,
+        "tile_elements": num_faces * face_r_dim * FACE_C_DIM,
+        "torch_format": format_dict[formats.output_format],
+    }
+
+
+def _apply_dest_reuse_op(
+    math_op, math_fidelity, formats, torch_format, binary_golden, srcA, srcB
+):
+    if math_op != MathOperation.Elwmul:
+        return (srcA + srcB) if math_op == MathOperation.Elwadd else (srcA - srcB)
+
+    # Mask from the original operands each fidelity phase. Do not use
+    # _compute_eltwise: it mutates t1/t2 across iterations, so later phases
+    # mask already-truncated values and collapse to ~LoFi.
+    fidelity_iters = {
+        MathFidelity.LoFi: 1,
+        MathFidelity.HiFi2: 2,
+        MathFidelity.HiFi3: 3,
+        MathFidelity.HiFi4: 4,
+    }[math_fidelity]
+    result = None
+    for fidelity_iter in range(fidelity_iters):
+        a_m, b_m = binary_golden._apply_fidelity_masking(
+            formats.output_format, srcA, srcB, fidelity_iter
+        )
+        phase = a_m.to(torch.float32) * b_m.to(torch.float32)
+        result = phase if result is None else result + phase
+    return result.to(torch_format)
+
+
+def _compute_dest_reuse_golden(
+    math_op, reuse_dest_type, math_fidelity, formats, prepared
+):
+    """Simulate seeded dest reuse (seed first tile, then fold via DEST_TO_SRCA/B)."""
+    tile_elements = prepared["tile_elements"]
+    torch_format = prepared["torch_format"]
+    src_A = prepared["src_A_tilized_flat"]
+    src_B = prepared["src_B_tilized_flat"]
+    golden_tensor = torch.zeros(
+        prepared["tile_cnt_output"] * tile_elements, dtype=torch_format
     )
+    # Instantiate directly: get_golden_generator returns a DummyGoldenGenerator
+    # during compile-producer, which has no _apply_fidelity_masking helper.
+    binary_golden = EltwiseBinaryGolden()
 
-    src_A_tilized_flat = src_A_tilized.flatten()
-    src_B_tilized_flat = src_B_tilized.flatten()
-
-    stimuli_A = src_A_tilized_flat
-    stimuli_B = src_B_tilized_flat
-
-    # Golden: simulate dest reuse.
-    # move_d2a/move_d2b copies old_dest into srcA/srcB (replacing the unpacked value).
-    # ELWADD/ELWSUB: new_dest = srcA op srcB  (overwrites dest)
-    # ELWMUL:        new_dest = old_dest + srcA * srcB  (always accumulates)
-    tile_elements = num_faces * face_r_dim * FACE_C_DIM
-    torch_format = format_dict[formats.output_format]
-    golden_tensor = torch.zeros(tile_cnt_output * tile_elements, dtype=torch_format)
-
-    for out_t in range(tile_cnt_output):
-        block_idx = out_t // output_tiles_in_block
-        tile_in_block = out_t % output_tiles_in_block
+    for out_t in range(prepared["tile_cnt_output"]):
+        block_idx = out_t // prepared["output_tiles_in_block"]
+        tile_in_block = out_t % prepared["output_tiles_in_block"]
         dest = torch.zeros(tile_elements, dtype=torch_format)
 
-        for i in range(inner_dim):
+        for i in range(prepared["inner_dim"]):
             input_tile_idx = (
-                block_idx * input_tiles_in_block
-                + i * output_tiles_in_block
+                block_idx * prepared["input_tiles_in_block"]
+                + i * prepared["output_tiles_in_block"]
                 + tile_in_block
             )
             start = input_tile_idx * tile_elements
             end = start + tile_elements
+            a_tile = src_A[start:end].to(torch_format)
+            b_tile = src_B[start:end].to(torch_format)
 
-            a_tile = src_A_tilized_flat[start:end].to(torch_format)
-            b_tile = src_B_tilized_flat[start:end].to(torch_format)
-
-            if reuse_dest_type == EltwiseBinaryReuseDestType.DEST_TO_SRCA:
+            if i == 0:
+                srcA, srcB = a_tile, b_tile
+            elif reuse_dest_type == EltwiseBinaryReuseDestType.DEST_TO_SRCA:
                 srcA, srcB = dest.clone(), b_tile
             else:
                 srcA, srcB = a_tile, dest.clone()
 
-            if math_op == MathOperation.Elwadd:
-                dest = srcA + srcB
-            elif math_op == MathOperation.Elwsub:
-                dest = srcA - srcB
-            elif math_op == MathOperation.Elwmul:
-                dest = dest + srcA * srcB
+            dest = _apply_dest_reuse_op(
+                math_op, math_fidelity, formats, torch_format, binary_golden, srcA, srcB
+            )
 
         out_start = out_t * tile_elements
         golden_tensor[out_start : out_start + tile_elements] = dest
+
+    return golden_tensor
+
+
+@parametrize(
+    reuse_dest_type=[
+        EltwiseBinaryReuseDestType.DEST_TO_SRCA,
+        EltwiseBinaryReuseDestType.DEST_TO_SRCB,
+    ],
+    math_op=[MathOperation.Elwadd, MathOperation.Elwsub, MathOperation.Elwmul],
+    # Bfp8_b dest-reuse ELWMUL mismatches golden (block shared-exp + dest-reuse
+    # precision); keep Bfp8 for add/sub only.
+    formats=lambda math_op: input_output_formats(
+        [DataFormat.Float16_b, DataFormat.Float32]
+        + ([] if math_op == MathOperation.Elwmul else [DataFormat.Bfp8_b]),
+        same=True,
+    ),
+    math_fidelity=lambda formats, math_op: _get_valid_math_fidelity(formats, math_op),
+    tile_dimensions=[[32, 32], [16, 32], [8, 32]],
+    input_dimensions=[[512, 32]],
+    output_dimensions=[[128, 32]],
+)
+def test_eltwise_binary_dest_reuse(
+    reuse_dest_type,
+    math_op,
+    formats,
+    math_fidelity,
+    tile_dimensions,
+    input_dimensions,
+    output_dimensions,
+):
+    prepared = _prepare_dest_reuse_inputs(
+        formats, input_dimensions, output_dimensions, tile_dimensions
+    )
+    golden_tensor = _compute_dest_reuse_golden(
+        math_op, reuse_dest_type, math_fidelity, formats, prepared
+    )
 
     configuration = TestConfig(
         "sources/eltwise_binary_test.cpp",
@@ -654,30 +707,30 @@ def test_eltwise_binary_dest_reuse(
             UNPACK_TRANS_FACES(Transpose.No),
             UNPACK_TRANS_WITHIN_FACE(Transpose.No),
             NUM_TILES_IN_BLOCK(
-                output_tiles_in_block,
-                input_num_tiles_in_block=input_tiles_in_block,
-                output_num_tiles_in_block=output_tiles_in_block,
+                prepared["output_tiles_in_block"],
+                input_num_tiles_in_block=prepared["input_tiles_in_block"],
+                output_num_tiles_in_block=prepared["output_tiles_in_block"],
             ),
             NUM_BLOCKS(
-                output_num_blocks,
-                input_num_blocks=input_num_blocks,
-                output_num_blocks=output_num_blocks,
+                prepared["output_num_blocks"],
+                input_num_blocks=prepared["input_num_blocks"],
+                output_num_blocks=prepared["output_num_blocks"],
             ),
-            NUM_FACES_R_DIM(num_faces_r_dim),
-            NUM_FACES_C_DIM(num_faces_c_dim),
-            TEST_FACE_DIMS(face_r_dim=face_r_dim),
+            NUM_FACES_R_DIM(prepared["num_faces_r_dim"]),
+            NUM_FACES_C_DIM(prepared["num_faces_c_dim"]),
+            TEST_FACE_DIMS(face_r_dim=prepared["face_r_dim"]),
         ],
         variant_stimuli=StimuliConfig(
-            stimuli_A,
+            prepared["src_A_tilized_flat"],
             formats.input_format,
-            stimuli_B,
+            prepared["src_B_tilized_flat"],
             formats.input_format,
             formats.output_format,
-            tile_count_A=tile_cnt_input,
-            tile_count_B=tile_cnt_input,
-            tile_count_res=tile_cnt_output,
-            num_faces=num_faces,
-            face_r_dim=face_r_dim,
+            tile_count_A=prepared["tile_cnt_input"],
+            tile_count_B=prepared["tile_cnt_input"],
+            tile_count_res=prepared["tile_cnt_output"],
+            num_faces=prepared["num_faces"],
+            face_r_dim=prepared["face_r_dim"],
             tile_dimensions=tile_dimensions,
             use_dense_tile_dimensions=True,
         ),
@@ -686,15 +739,14 @@ def test_eltwise_binary_dest_reuse(
     )
 
     res_from_L1 = configuration.run().result
-
     assert len(res_from_L1) == len(
         golden_tensor
     ), "Result tensor and golden tensor are not of the same length"
 
-    res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
-
-    test_passed = passed_test(golden_tensor, res_tensor, formats.output_format)
-    assert test_passed, "Assert against golden failed"
+    res_tensor = torch.tensor(res_from_L1, dtype=prepared["torch_format"])
+    assert passed_test(
+        golden_tensor, res_tensor, formats.output_format
+    ), "Assert against golden failed"
 
 
 @parametrize(

--- a/tt_metal/tt-llk/tests/sources/eltwise_binary_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_binary_test.cpp
@@ -98,23 +98,30 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
 
 #ifdef EN_DEST_REUSE
+    // Dest-reuse path: seed with a non-reuse op on the first tile of each
+    // accumulation group, then fold remaining tiles via DEST_TO_SRCA/B.
+    // Seeding is required for ELWMUL (zero is the multiplicative annihilator)
+    // and is used for add/sub too so one path covers all ops.
     const std::uint32_t tiles_in_block          = params.OUTPUT_NUM_TILES_IN_BLOCK;
     const std::uint32_t num_tiles_accumulations = params.INPUT_NUM_TILES_IN_BLOCK / tiles_in_block;
     const std::uint32_t num_blocks              = params.INPUT_NUM_BLOCKS;
-#else
-    const std::uint32_t tiles_in_block          = params.NUM_TILES_IN_BLOCK;
-    const std::uint32_t num_tiles_accumulations = 1;
-    const std::uint32_t num_blocks              = params.NUM_BLOCKS;
-    constexpr auto REUSE_DEST_TYPE              = ckernel::EltwiseBinaryReuseDestType::NONE;
-#endif
 
-    _llk_math_eltwise_binary_init_<ELTWISE_BINARY_OP, BROADCAST_TYPE, MATH_FIDELITY, REUSE_DEST_TYPE>(tensor_shape, ACC_TO_DEST);
-
-    // Perform element-wise operation
     for (std::uint32_t block = 0; block < num_blocks; block++)
     {
         _llk_math_wait_for_dest_available_<dest_sync>();
-        for (std::uint32_t n = 0; n < num_tiles_accumulations; n++)
+
+        _llk_math_eltwise_binary_init_<ELTWISE_BINARY_OP, BROADCAST_TYPE, MATH_FIDELITY, EltwiseBinaryReuseDestType::NONE>(tensor_shape, ACC_TO_DEST);
+        for (std::uint32_t tile = 0; tile < tiles_in_block; tile++)
+        {
+            LLK_ASSERT(
+                (static_cast<std::uint32_t>(tile) < get_dest_max_tiles<dest_sync, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()),
+                "Block tile index exceeds maximum destination tiles");
+            _llk_math_eltwise_binary_<ELTWISE_BINARY_OP, BROADCAST_TYPE, dest_sync, is_fp32_dest_acc_en, MATH_FIDELITY, EltwiseBinaryReuseDestType::NONE>(
+                tensor_shape, tile /* dst_index */, false /* clear_fp32_dst_acc */);
+        }
+
+        _llk_math_eltwise_binary_init_<ELTWISE_BINARY_OP, BROADCAST_TYPE, MATH_FIDELITY, REUSE_DEST_TYPE>(tensor_shape, ACC_TO_DEST);
+        for (std::uint32_t n = 1; n < num_tiles_accumulations; n++)
         {
             for (std::uint32_t tile = 0; tile < tiles_in_block; tile++)
             {
@@ -127,6 +134,27 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         _llk_math_dest_section_done_<dest_sync, is_fp32_dest_acc_en>();
     }
+#else
+    const std::uint32_t tiles_in_block = params.NUM_TILES_IN_BLOCK;
+    const std::uint32_t num_blocks     = params.NUM_BLOCKS;
+    constexpr auto REUSE_DEST_TYPE     = ckernel::EltwiseBinaryReuseDestType::NONE;
+
+    _llk_math_eltwise_binary_init_<ELTWISE_BINARY_OP, BROADCAST_TYPE, MATH_FIDELITY, REUSE_DEST_TYPE>(tensor_shape, ACC_TO_DEST);
+
+    for (std::uint32_t block = 0; block < num_blocks; block++)
+    {
+        _llk_math_wait_for_dest_available_<dest_sync>();
+        for (std::uint32_t tile = 0; tile < tiles_in_block; tile++)
+        {
+            LLK_ASSERT(
+                (static_cast<std::uint32_t>(tile) < get_dest_max_tiles<dest_sync, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()),
+                "Block tile index exceeds maximum destination tiles");
+            _llk_math_eltwise_binary_<ELTWISE_BINARY_OP, BROADCAST_TYPE, dest_sync, is_fp32_dest_acc_en, MATH_FIDELITY, REUSE_DEST_TYPE>(
+                tensor_shape, tile /* dst_index */, false /* clear_fp32_dst_acc */);
+        }
+        _llk_math_dest_section_done_<dest_sync, is_fp32_dest_acc_en>();
+    }
+#endif
 }
 
 #endif

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary.h
@@ -290,8 +290,7 @@ inline void _llk_math_eltwise_binary_standard_(const ckernel::TensorShape &tenso
                     {
                         if (tensor_shape.face_r_dim <= MAX_FPU_ROWS)
                         {
-                            // HiFi: only advance dest register, src was cleared by ADDR_MOD_3
-                            TTI_INCRWC(0, MAX_FPU_ROWS, 0, 0);
+                            TTI_INCRWC(p_setrwc::CR_D, MAX_FPU_ROWS, 0, 0);
                         }
                     }
                     // LoFi: MOP handles face spacing internally via loop_op1, no runtime INCRWC needed
@@ -312,8 +311,7 @@ inline void _llk_math_eltwise_binary_standard_(const ckernel::TensorShape &tenso
                 {
                     if (tensor_shape.face_r_dim <= MAX_FPU_ROWS)
                     {
-                        // HiFi: only advance dest register, src was cleared by ADDR_MOD_3
-                        TTI_INCRWC(0, MAX_FPU_ROWS, 0, 0);
+                        TTI_INCRWC(p_setrwc::CR_D, MAX_FPU_ROWS, 0, 0);
                     }
                 }
                 // LoFi: MOP handles face spacing internally via loop_op1, no runtime INCRWC needed
@@ -409,11 +407,6 @@ inline void eltwise_binary_configure_mop_with_dest_reuse(const std::uint32_t acc
             tmp.set_last_inner_loop_instr(eltwise_binary_func<EltwiseBinaryType::ELWMUL>(0 /*clr_src*/, 0 /*acc_to_dest*/, broadcast_type, ADDR_MOD_2));
             tmp.set_last_outer_loop_instr(eltwise_binary_func<EltwiseBinaryType::ELWMUL>(CLR_SRC, 0 /*acc_to_dest*/, broadcast_type, ADDR_MOD_3));
 
-            if (tensor_shape.face_r_dim <= MAX_FPU_ROWS)
-            {
-                // HiFi: only advance dest and carry register, src was cleared by ADDR_MOD_3
-                tmp.set_end_op(TT_OP_INCRWC(MAX_FPU_ROWS, MAX_FPU_ROWS, 0, 0));
-            }
             tmp.program();
         }
         else if (tensor_shape.face_r_dim <= MAX_FPU_ROWS)
@@ -471,14 +464,20 @@ inline void _llk_math_eltwise_binary_with_dest_reuse_init_(const ckernel::Tensor
  *
  * @tparam is_fp32_dest_acc_en: Enable FP32 accumulation in the destination register (halves tiles per bank and gates the zero-flag clear).
  * @tparam binary_reuse_dest: Reuse destination as source type, values = <DEST_TO_SRCA/DEST_TO_SRCB>
+ * @tparam math_fidelity: Math fidelity for controlling precision, values = <LoFi/HiFi2/HiFi3/HiFi4>
  * @param loop_count: Number of faces to process.
  * @param face_offset: Index of the first face within the tile.
  * @param clear_fp32_dst_acc: Clear the FP32 dest accumulator face when FP32 mode is enabled.
  * @param dst_index: Tile index into the destination register.
+ * @param face_r_dim: Face row dimension; used for HiFi partial-face dest spacing.
  */
-template <bool is_fp32_dest_acc_en, EltwiseBinaryReuseDestType binary_reuse_dest>
+template <bool is_fp32_dest_acc_en, EltwiseBinaryReuseDestType binary_reuse_dest, MathFidelity math_fidelity = MathFidelity::LoFi>
 inline void eltwise_binary_run_with_dest_reuse(
-    const std::uint32_t loop_count, const std::uint32_t face_offset, const bool clear_fp32_dst_acc, const std::uint32_t dst_index)
+    const std::uint32_t loop_count,
+    const std::uint32_t face_offset,
+    const bool clear_fp32_dst_acc,
+    const std::uint32_t dst_index,
+    const std::uint32_t face_r_dim)
 {
     constexpr std::uint32_t ZERO_ACC_MODE = p_zeroacc::CLR_16;
 
@@ -494,6 +493,14 @@ inline void eltwise_binary_run_with_dest_reuse(
         TT_ZEROACC(ZERO_ACC_MODE, clear_fp32, 0, ADDR_MOD_1, get_dest_index_in_faces(local_tile, face_offset + n));
 
         ckernel_template::run();
+
+        if constexpr (is_high_fidelity(math_fidelity))
+        {
+            if (face_r_dim <= MAX_FPU_ROWS)
+            {
+                TTI_INCRWC(p_setrwc::CR_D, MAX_FPU_ROWS, 0, 0);
+            }
+        }
     }
 }
 
@@ -581,14 +588,16 @@ inline void _llk_math_eltwise_binary_with_dest_reuse_(const ckernel::TensorShape
             {
                 // face_offset = face_row * num_faces_c_dim (position in face array)
                 const std::uint32_t face_offset = face_row * num_faces_c_dim;
-                eltwise_binary_run_with_dest_reuse<is_fp32_dest_acc_en, binary_reuse_dest>(num_faces_c_dim, face_offset, clear_fp32_dst_acc, dst_index);
+                eltwise_binary_run_with_dest_reuse<is_fp32_dest_acc_en, binary_reuse_dest, math_fidelity>(
+                    num_faces_c_dim, face_offset, clear_fp32_dst_acc, dst_index, tensor_shape.face_r_dim);
                 TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, 0);
             }
         }
         else
         {
             // NONE/ROW/SCALAR: process all faces with ZEROACC
-            eltwise_binary_run_with_dest_reuse<is_fp32_dest_acc_en, binary_reuse_dest>(num_faces, 0 /*face_offset*/, clear_fp32_dst_acc, dst_index);
+            eltwise_binary_run_with_dest_reuse<is_fp32_dest_acc_en, binary_reuse_dest, math_fidelity>(
+                num_faces, 0 /*face_offset*/, clear_fp32_dst_acc, dst_index, tensor_shape.face_r_dim);
 
             if constexpr (src_b_bcast_type == BroadcastType::SCALAR)
             {

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_binary.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_binary.h
@@ -285,8 +285,7 @@ inline void _llk_math_eltwise_binary_standard_(const ckernel::TensorShape &tenso
                     {
                         if (tensor_shape.face_r_dim <= MAX_FPU_ROWS)
                         {
-                            // HiFi: only advance dest register, src was cleared by ADDR_MOD_3
-                            TTI_INCRWC(0, MAX_FPU_ROWS, 0, 0);
+                            TTI_INCRWC(p_setrwc::CR_D, MAX_FPU_ROWS, 0, 0);
                         }
                     }
                     // LoFi: MOP handles face spacing internally via loop_op1, no runtime INCRWC needed
@@ -307,8 +306,7 @@ inline void _llk_math_eltwise_binary_standard_(const ckernel::TensorShape &tenso
                 {
                     if (tensor_shape.face_r_dim <= MAX_FPU_ROWS)
                     {
-                        // HiFi: only advance dest register, src was cleared by ADDR_MOD_3
-                        TTI_INCRWC(0, MAX_FPU_ROWS, 0, 0);
+                        TTI_INCRWC(p_setrwc::CR_D, MAX_FPU_ROWS, 0, 0);
                     }
                 }
                 // LoFi: MOP handles face spacing internally via loop_op1, no runtime INCRWC needed
@@ -404,11 +402,6 @@ inline void eltwise_binary_configure_mop_with_dest_reuse(const std::uint32_t acc
             tmp.set_last_inner_loop_instr(eltwise_binary_func<EltwiseBinaryType::ELWMUL>(0 /*clr_src*/, 0 /*acc_to_dest*/, broadcast_type, ADDR_MOD_2));
             tmp.set_last_outer_loop_instr(eltwise_binary_func<EltwiseBinaryType::ELWMUL>(CLR_SRC, 0 /*acc_to_dest*/, broadcast_type, ADDR_MOD_3));
 
-            if (tensor_shape.face_r_dim <= MAX_FPU_ROWS)
-            {
-                // HiFi: only advance dest and carry register, src was cleared by ADDR_MOD_3
-                tmp.set_end_op(TT_OP_INCRWC(MAX_FPU_ROWS, MAX_FPU_ROWS, 0, 0));
-            }
             tmp.program();
         }
         else if (tensor_shape.face_r_dim <= MAX_FPU_ROWS)
@@ -467,14 +460,20 @@ inline void _llk_math_eltwise_binary_with_dest_reuse_init_(const ckernel::Tensor
  *
  * @tparam is_fp32_dest_acc_en: Enable FP32 accumulation in the destination register (halves tiles per bank and gates the zero-flag clear).
  * @tparam binary_reuse_dest: Reuse destination as source type, values = <DEST_TO_SRCA/DEST_TO_SRCB>
+ * @tparam math_fidelity: Math fidelity for controlling precision, values = <LoFi/HiFi2/HiFi3/HiFi4>
  * @param loop_count: Number of faces to process.
  * @param face_offset: Index of the first face within the tile.
  * @param clear_fp32_dst_acc: Clear the FP32 dest accumulator face when FP32 mode is enabled.
  * @param dst_index: Tile index into the destination register.
+ * @param face_r_dim: Face row dimension; used for HiFi partial-face dest spacing.
  */
-template <bool is_fp32_dest_acc_en, EltwiseBinaryReuseDestType binary_reuse_dest>
+template <bool is_fp32_dest_acc_en, EltwiseBinaryReuseDestType binary_reuse_dest, MathFidelity math_fidelity = MathFidelity::LoFi>
 inline void eltwise_binary_run_with_dest_reuse(
-    const std::uint32_t loop_count, const std::uint32_t face_offset, const bool clear_fp32_dst_acc, const std::uint32_t dst_index)
+    const std::uint32_t loop_count,
+    const std::uint32_t face_offset,
+    const bool clear_fp32_dst_acc,
+    const std::uint32_t dst_index,
+    const std::uint32_t face_r_dim)
 {
     constexpr std::uint32_t ZERO_ACC_MODE = p_zeroacc::CLR_16;
 
@@ -497,6 +496,14 @@ inline void eltwise_binary_run_with_dest_reuse(
         }
 
         ckernel_template::run();
+
+        if constexpr (is_high_fidelity(math_fidelity))
+        {
+            if (face_r_dim <= MAX_FPU_ROWS)
+            {
+                TTI_INCRWC(p_setrwc::CR_D, MAX_FPU_ROWS, 0, 0);
+            }
+        }
     }
 }
 
@@ -583,14 +590,16 @@ inline void _llk_math_eltwise_binary_with_dest_reuse_(const ckernel::TensorShape
             {
                 // face_offset = face_row * num_faces_c_dim (position in face array)
                 const std::uint32_t face_offset = face_row * num_faces_c_dim;
-                eltwise_binary_run_with_dest_reuse<is_fp32_dest_acc_en, binary_reuse_dest>(num_faces_c_dim, face_offset, clear_fp32_dst_acc, dst_index);
+                eltwise_binary_run_with_dest_reuse<is_fp32_dest_acc_en, binary_reuse_dest, math_fidelity>(
+                    num_faces_c_dim, face_offset, clear_fp32_dst_acc, dst_index, tensor_shape.face_r_dim);
                 TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, 0);
             }
         }
         else
         {
             // NONE/ROW/SCALAR: process all faces with ZEROACC
-            eltwise_binary_run_with_dest_reuse<is_fp32_dest_acc_en, binary_reuse_dest>(num_faces, 0 /*face_offset*/, clear_fp32_dst_acc, dst_index);
+            eltwise_binary_run_with_dest_reuse<is_fp32_dest_acc_en, binary_reuse_dest, math_fidelity>(
+                num_faces, 0 /*face_offset*/, clear_fp32_dst_acc, dst_index, tensor_shape.face_r_dim);
 
             if constexpr (src_b_bcast_type == BroadcastType::SCALAR)
             {


### PR DESCRIPTION
Seed dest before reuse so multiply folds are non-vacuous, and advance Dst/Dst_Cr once per face for HiFi dest-reuse instead of MOP end_op.

### PR Category
Bug fix

### Summary
Fix known dest-reuse issues in eltwise binary (vacuous ELWMUL coverage + HiFi partial-face dest addressing). Test infra was also not strong enough to catch this.

### Why this fix works

**1. ELWMUL dest-reuse seeding**

Dest reuse means: copy the previous dest into SrcA or SrcB (`move_d2a` / `move_d2b`), then run `SrcA ⊕ SrcB` into dest.

For ELWMUL specifically, the dest-reuse path also **ZEROACCs dest after the copy**, then multiplies into the cleared dest. So each step is effectively:

```text
old_dest → SrcA (or SrcB)
ZEROACC dest
dest = SrcA * SrcB   # i.e. old_dest * other_operand
```

If dest starts at 0 (pack clears the half between sections; first use is also zero), then `0 * x = 0` forever. The old test golden modeled that and compared zeros to zeros — so ELWMUL dest-reuse was a **no-op pass**.

Add/sub do not need seeding to avoid getting stuck (zero is an additive identity), but ELWMUL does because zero is a multiplicative annihilator.

**Fix:** seed dest with a normal (non-reuse) `A₀ ⊕ B₀` of the first tile in each accumulation group, then fold remaining tiles via `DEST_TO_SRCA` / `DEST_TO_SRCB`. That gives a non-zero starting dest for ELWMUL, so later reuse steps actually multiply non-trivial values. Add/sub use the same seeded path so one kernel covers all ops.

**2. HiFi partial-face Dst / Dst_Cr advancement**

For HiFi ELWMUL on partial faces (`face_r_dim <= MAX_FPU_ROWS`), the MOP's last fidelity phase only advances dest by `MAX_FPU_ROWS` via `ADDR_MOD_3`. A second `MAX_FPU_ROWS` bump is needed for full 16-row face spacing.

Previously that second bump was a MOP `end_op` INCRWC. `end_op` runs **once per fidelity-phase outer-loop iteration**, so on HiFi2/3/4 it fired N times per face — over-advancing dest and moving it **between** fidelity phases (corrupting per-phase accumulation).

**Fix:** remove the HiFi INCRWC from MOP `end_op`, and do a single runtime `TTI_INCRWC(CR_D, MAX_FPU_ROWS, …)` **once per face** after the MOP in `eltwise_binary_run_with_dest_reuse`. Using `CR_D` also updates `Dst_Cr`, which matters because the next face's first fidelity phase uses `ADDR_MOD_2` (`Dst ← Dst_Cr`); a stale `Dst_Cr` would snap writes back into the previous face.

### Notes for reviewers
- Before this change, ELWMUL dest-reuse tests essentially checked `0 == 0`. Please verify the seeded fold golden (`A₀*B₀`, then `dest*Bᵢ` or `Aᵢ*dest`) matches the intended product-fold semantics.
- Bfp8 ELWMUL dest-reuse is still excluded (shared-exp / precision mismatch); Bfp8 remains covered for add/sub dest-reuse.
- WH + BH LLK headers are updated in lockstep.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=halgh/dest_reuse_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:halgh/dest_reuse_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=halgh/dest_reuse_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:halgh/dest_reuse_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=halgh/dest_reuse_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:halgh/dest_reuse_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=halgh/dest_reuse_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:halgh/dest_reuse_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=halgh/dest_reuse_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:halgh/dest_reuse_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=halgh/dest_reuse_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:halgh/dest_reuse_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=halgh/dest_reuse_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:halgh/dest_reuse_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=halgh/dest_reuse_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:halgh/dest_reuse_fix)