### PR TITLE
[LLK] SFPU: single self-contained init for exp/recip/snake via mutex::SFPU (sanitizer follow-up)

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -9,6 +9,7 @@
 #include <limits>
 
 #include "ckernel_addrmod.h"
+#include "ckernel_mutex_guard.h"
 #include "ckernel_ops.h"
 // clang-format off: sfpi_inline must be defined before ckernel_sfpu_polyval.h
 #include "sfpi.h"
@@ -481,6 +482,116 @@ sfpi_inline sfpi::vFloat _ckernel_sfpu_exp_accurate_(sfpi::vFloat val, const std
     return result;
 }
 
+// SHARED per-lane macro state for the APPROX+CLAMP exp path: InstructionTemplate 0 (SWAP) + backdoor-loaded
+// macro instruction registers 5/6/7 (MAD/STOCHRND/SHFT) + Macro Sequence[0..1] + Misc, all programmed via
+// SFPCONFIG. This LoadMacroConfig backend is a single per-lane resource shared across MATH (TRISC1) and PACK
+// (TRISC2) and is NOT protected by Auto TTSync (tt-metal#50381). Pulled out of exp_init so the consume path
+// can reprogram it under the mutex::SFPU guard before every use, making cross-thread clobbering benign.
+// Note: the per-thread LReg operand constants (LREG12=A, LREG13=B-C, LREG14=-88.5) stay in exp_init.
+inline void _program_exp_macros_() {
+    // Next, set up the macro instructions which will be necessary
+    //  - for the sanitize function: we will need a SWAP instruction
+    //  - for the main computation function: we will need MAD, ROUND, and SHIFT instructions
+
+    // There are two ways to program the macro instruction registers, and this setup leverages both ways
+    //  - we can either use the SFPCONFIG flow, by setting up the bits of the instruction into LREG[0] and then
+    //  targeting the Macro instruction register
+    //  - or we can use the shortcut / backdoor load method which relies on having some illegal destination register
+    //  values as part of the instruction
+
+    // Use SFPCONFIG method for the SWAP instruction, since we want the SWAP itself to use a destination register
+    // which is not normally a legal value
+    //      (we are cheating a bit here, since we only care about one half of the swap and we want to use a constant
+    //      for the other half)
+    //
+    //              imm12 = 0,       lreg_src_c = 0 (will be fed by value loaded from Dest into Loadmacro
+    //              lreg_dest),  lreg_dest = LREG[14] = - 88.5, instr_mod1 = 1 swap the values with the larger of
+    //              the two ending up in lreg_dest -> but we will use the Loadmacro lreg_dest register as output
+    // TTI_SFP_SWAP(0,               0, 14,                            1);
+    TTI_SFPLOADI(0, 0xA, 0x00E1);
+    TTI_SFPLOADI(0, 0x8, 0x9200);
+    TTI_SFPCONFIG(
+        0, 0, 0);  // SFPCONFIG Dest 0 = Programmable Macro instruction 0: TTI_SFPSWAP(0, 0, 14, 1); // compare
+                   // against LREG[14] (-88.5), and put the larger value into LREG[loadmacro_lreg_dest]
+    TTI_SFPNOP;
+
+    // Backdoor load of Macro Instruction 1
+    // Dummy version of MAD instruction with lreg_dest = 4'b11_01 = 13 to install into Programmable Macro
+    // instruction register 1, which is Macro Instruction Register 5
+    TTI_SFPMAD(12, 0, 13, 13, 0);  // MACRO Instruction 1 <--- lreg X = lreg[12] (A) * lreg[0] (y) + lreg[13] (B-C)
+
+    // Backdoor load of Macro Instruction 2
+    // ROUND instruction to convert FP32 result into an integer value (int16)
+    //                Stochastic = 0,  Imm(Descale),  SrcB(unused),   SrcC(input value),  Lreg_dest = 14 to install
+    //                in Programmable Macro Instruction reg 2'b10,  instr_mod1 = 14 to treat input as fp32, output
+    //                as unsigned int16, use imm as descale
+    TTI_SFP_STOCH_RND(0, 0, 0, 0, 14, 14);  // Round to unsigned Int16
+
+    // Backdoor load of Macro Instruction 3
+    // If using the unsigned int rounding mode, then shift by 15; SHL to move integer bits to exponent;
+    TTI_SFPSHFT(
+        15,
+        0,
+        15,
+        1);  // imm = 15 to shift left by 15 bits; lreg_c = 0 (will use macro reg); lreg_dest = 15 to install in
+             // Programmable Macro Instruction reg 2'b11, which is Macro Instruction Register 7
+
+    // So at this point, we have the following instructions loaded into our macro registers:
+    //
+    // 00: (no macro instruction, just execute whatever is issued from Tensix) <-- these are fixed / not
+    // programmable 01: ( Rsvd                                                            ) <-- these are fixed /
+    // not programmable 02: ( NOP                                                             ) <-- these are fixed
+    // / not programmable 03: ( SFPSTORE                                                        ) <-- these are
+    // fixed / not programmable 04: TTI_SFPSWAP       (0, 0, 11, 1) 05: TTI_SFPMAD        (12, 0, 13, 13, 0) 06:
+    // TTI_SFP_STOCH_RND (1, 0, 0, 0, 14, 14) 07: TTI_SFPSHFT       (15,0,15,1)
+
+    // Now we want to set up our two sequences
+
+    // Sequence 1 setup: we want to Load, SWAP, <delay>, Store
+    //       Delay slot:                  0     1        2
+    //                                                                                                                                                                                                 Use
+    //                                                                                                                                                                                                 Loaded  Result          Macro
+    //                                                                                                                                                                                                 Value   Value   Delay   Instruction
+    //                                                                                                                                                                                                 SRCB    Stage   Slot    Select
+    TTI_SFPLOADI(
+        0,
+        0xA,
+        0x0004);  // slot1 : SIMPLE UNIT, want SWAP  instruction which is in macro instruction mux[4], delayed by 0
+                  // ; not using staging flop as dest; not using load reg as srcb : 8'b0_______0_______000_____100
+                  // = 0x04 slot2 : MAD    UNIT, unused : 8'b0_______0_______000_____000          = 0x00
+    TTI_SFPLOADI(
+        0, 0x8, 0x1300);  // slot3 : ROUND  UNIT, unused : 8'b0_______0_______000_____000          = 0x00 slot4 :
+                          // STORE  UNIT, want STORE instruction which is in macro instruction mux[3], delayed by 2
+                          // ; not using staging flop as src ; : 8'b0_______0_______010_____011          = 0x13
+    TTI_SFPCONFIG(0, 5, 0);  // SFPCONFIG Dest 5 = Macro Sequence Register 1
+
+    // Sequence 0 setup: we want to Load, MAD, <delay>, ROUND, SHIFT, Store
+    //       Delay slot:                  0    1        2      3      4
+    //                                                                                                                                                                                                 Use
+    //                                                                                                                                                                                                 Loaded  Result          Macro
+    //                                                                                                                                                                                                 Value   Value   Delay   Instruction
+    //                                                                                                                                                                                                 SRCB    Stage   Slot    Select
+    TTI_SFPLOADI(
+        0,
+        0xA,
+        0x85DF);  // slot1 : SIMPLE UNIT, want SHIFT instruction which is in macro instruction mux[7], delayed by 3
+                  // ;     using staging flop as dest; using load reg as srcb : 8'b1_______1_______011_____111 =
+                  // 0xDF slot2 : MAD    UNIT, want MAD   instruction which is in macro instruction mux[5], delayed
+                  // by 0 ; not using staging flop as dest;     using load reg as srcb :
+                  // 8'b1_______0_______000_____101 = 0x85
+    TTI_SFPLOADI(
+        0,
+        0x8,
+        0x6316);  // slot3 : ROUND  UNIT, want ROUND instruction which is in macro instruction mux[6], delayed by 2
+                  // ; not using staging flop as dest; using : 8'b0_______0_______010_____110          = 0x16 slot4
+                  // : STORE  UNIT, want STORE instruction which is in macro instruction mux[3], delayed by 4 ;
+                  // using staging flop as src ;     using                  : 8'b0_______1_______100_____011 = 0x63
+    TTI_SFPCONFIG(0, 4, 0);  // Load it into macro sequence register 0 (destination = 4)
+
+    // Reset LoadMacroConfig[Lane].Misc for all lanes, in case it has been previously set by another use of macros.
+    TTI_SFPCONFIG(0, 8, 1);
+}
+
 template <
     bool APPROXIMATION_MODE,
     bool is_fp32_dest_acc_en,
@@ -519,6 +630,16 @@ void calculate_exponential(const uint exp_base_scale_factor = p_sfpu::kCONST_1_F
         // Code below is hand-unrolled for 8 iterations
         // so it doesn't respect ITERATIONS. TODO: tt-llk#1486
         // static_assert(ITERATIONS == 8);
+
+        // The SHARED LoadMacroConfig (templates/sequence/Misc) is programmed by both PACK (exp) and MATH
+        // (fp32 recip) with no Auto TTSync (tt-metal#50381). Guard the whole consume with mutex::SFPU and
+        // REPROGRAM the shared slots under the lock, so whatever a peer left behind is overwritten before the
+        // SFPLOADMACROs issue. The critical section MUST end with an explicit SFPU drain BEFORE the guard
+        // releases: ATRELM does not drain the SFPU backend, and SFPLOADMACRO schedules future-cycle work that
+        // stays in-flight after issue.
+        ckernel::T6MutexLockGuard _sfpu_lock(ckernel::mutex::SFPU);
+
+        _program_exp_macros_();
 
         // Sanitize the input values by loading from DEST, comparing against the value -88.5, and if the input value is
         // more negative than that, swap the input value with -88.5 and store back to DEST
@@ -637,6 +758,11 @@ void calculate_exponential(const uint exp_base_scale_factor = p_sfpu::kCONST_1_F
         TTI_SFPNOP;
         // TTI_SFPNOP;
         // TTI_SFPNOP;
+
+        // DRAIN: wait for the SFPU backend to finish all scheduled macro work before the guard destructor
+        // (ATRELM) releases mutex::SFPU at the end of this branch, otherwise a peer could reprogram the
+        // shared slots while our SFPLOADMACRO work is still in flight.
+        TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
 #endif
     }
 #ifdef DISABLE_SFPLOADMACRO
@@ -774,107 +900,10 @@ void exp_init() {
         TTI_SFPCONFIG(0, 13, 0);  // SFPCONFIG Dest 13 = LREG[13] = (B-C) =  32500.818359375       = 0x46fde9a3
 
 #ifndef DISABLE_SFPLOADMACRO
-        // Next, set up the macro instructions which will be necessary
-        //  - for the sanitize function: we will need a SWAP instruction
-        //  - for the main computation function: we will need MAD, ROUND, and SHIFT instructions
-
-        // There are two ways to program the macro instruction registers, and this setup leverages both ways
-        //  - we can either use the SFPCONFIG flow, by setting up the bits of the instruction into LREG[0] and then
-        //  targeting the Macro instruction register
-        //  - or we can use the shortcut / backdoor load method which relies on having some illegal destination register
-        //  values as part of the instruction
-
-        // Use SFPCONFIG method for the SWAP instruction, since we want the SWAP itself to use a destination register
-        // which is not normally a legal value
-        //      (we are cheating a bit here, since we only care about one half of the swap and we want to use a constant
-        //      for the other half)
-        //
-        //              imm12 = 0,       lreg_src_c = 0 (will be fed by value loaded from Dest into Loadmacro
-        //              lreg_dest),  lreg_dest = LREG[14] = - 88.5, instr_mod1 = 1 swap the values with the larger of
-        //              the two ending up in lreg_dest -> but we will use the Loadmacro lreg_dest register as output
-        // TTI_SFP_SWAP(0,               0, 14,                            1);
-        TTI_SFPLOADI(0, 0xA, 0x00E1);
-        TTI_SFPLOADI(0, 0x8, 0x9200);
-        TTI_SFPCONFIG(
-            0, 0, 0);  // SFPCONFIG Dest 0 = Programmable Macro instruction 0: TTI_SFPSWAP(0, 0, 14, 1); // compare
-                       // against LREG[14] (-88.5), and put the larger value into LREG[loadmacro_lreg_dest]
-        TTI_SFPNOP;
-
-        // Backdoor load of Macro Instruction 1
-        // Dummy version of MAD instruction with lreg_dest = 4'b11_01 = 13 to install into Programmable Macro
-        // instruction register 1, which is Macro Instruction Register 5
-        TTI_SFPMAD(12, 0, 13, 13, 0);  // MACRO Instruction 1 <--- lreg X = lreg[12] (A) * lreg[0] (y) + lreg[13] (B-C)
-
-        // Backdoor load of Macro Instruction 2
-        // ROUND instruction to convert FP32 result into an integer value (int16)
-        //                Stochastic = 0,  Imm(Descale),  SrcB(unused),   SrcC(input value),  Lreg_dest = 14 to install
-        //                in Programmable Macro Instruction reg 2'b10,  instr_mod1 = 14 to treat input as fp32, output
-        //                as unsigned int16, use imm as descale
-        TTI_SFP_STOCH_RND(0, 0, 0, 0, 14, 14);  // Round to unsigned Int16
-
-        // Backdoor load of Macro Instruction 3
-        // If using the unsigned int rounding mode, then shift by 15; SHL to move integer bits to exponent;
-        TTI_SFPSHFT(
-            15,
-            0,
-            15,
-            1);  // imm = 15 to shift left by 15 bits; lreg_c = 0 (will use macro reg); lreg_dest = 15 to install in
-                 // Programmable Macro Instruction reg 2'b11, which is Macro Instruction Register 7
-
-        // So at this point, we have the following instructions loaded into our macro registers:
-        //
-        // 00: (no macro instruction, just execute whatever is issued from Tensix) <-- these are fixed / not
-        // programmable 01: ( Rsvd                                                            ) <-- these are fixed /
-        // not programmable 02: ( NOP                                                             ) <-- these are fixed
-        // / not programmable 03: ( SFPSTORE                                                        ) <-- these are
-        // fixed / not programmable 04: TTI_SFPSWAP       (0, 0, 11, 1) 05: TTI_SFPMAD        (12, 0, 13, 13, 0) 06:
-        // TTI_SFP_STOCH_RND (1, 0, 0, 0, 14, 14) 07: TTI_SFPSHFT       (15,0,15,1)
-
-        // Now we want to set up our two sequences
-
-        // Sequence 1 setup: we want to Load, SWAP, <delay>, Store
-        //       Delay slot:                  0     1        2
-        //                                                                                                                                                                                                 Use
-        //                                                                                                                                                                                                 Loaded  Result          Macro
-        //                                                                                                                                                                                                 Value   Value   Delay   Instruction
-        //                                                                                                                                                                                                 SRCB    Stage   Slot    Select
-        TTI_SFPLOADI(
-            0,
-            0xA,
-            0x0004);  // slot1 : SIMPLE UNIT, want SWAP  instruction which is in macro instruction mux[4], delayed by 0
-                      // ; not using staging flop as dest; not using load reg as srcb : 8'b0_______0_______000_____100
-                      // = 0x04 slot2 : MAD    UNIT, unused : 8'b0_______0_______000_____000          = 0x00
-        TTI_SFPLOADI(
-            0, 0x8, 0x1300);  // slot3 : ROUND  UNIT, unused : 8'b0_______0_______000_____000          = 0x00 slot4 :
-                              // STORE  UNIT, want STORE instruction which is in macro instruction mux[3], delayed by 2
-                              // ; not using staging flop as src ; : 8'b0_______0_______010_____011          = 0x13
-        TTI_SFPCONFIG(0, 5, 0);  // SFPCONFIG Dest 5 = Macro Sequence Register 1
-
-        // Sequence 0 setup: we want to Load, MAD, <delay>, ROUND, SHIFT, Store
-        //       Delay slot:                  0    1        2      3      4
-        //                                                                                                                                                                                                 Use
-        //                                                                                                                                                                                                 Loaded  Result          Macro
-        //                                                                                                                                                                                                 Value   Value   Delay   Instruction
-        //                                                                                                                                                                                                 SRCB    Stage   Slot    Select
-        TTI_SFPLOADI(
-            0,
-            0xA,
-            0x85DF);  // slot1 : SIMPLE UNIT, want SHIFT instruction which is in macro instruction mux[7], delayed by 3
-                      // ;     using staging flop as dest; using load reg as srcb : 8'b1_______1_______011_____111 =
-                      // 0xDF slot2 : MAD    UNIT, want MAD   instruction which is in macro instruction mux[5], delayed
-                      // by 0 ; not using staging flop as dest;     using load reg as srcb :
-                      // 8'b1_______0_______000_____101 = 0x85
-        TTI_SFPLOADI(
-            0,
-            0x8,
-            0x6316);  // slot3 : ROUND  UNIT, want ROUND instruction which is in macro instruction mux[6], delayed by 2
-                      // ; not using staging flop as dest; using : 8'b0_______0_______010_____110          = 0x16 slot4
-                      // : STORE  UNIT, want STORE instruction which is in macro instruction mux[3], delayed by 4 ;
-                      // using staging flop as src ;     using                  : 8'b0_______1_______100_____011 = 0x63
-        TTI_SFPCONFIG(0, 4, 0);  // Load it into macro sequence register 0 (destination = 4)
-
-        // Reset LoadMacroConfig[Lane].Misc for all lanes, in case it has been previously set by another use of macros.
-        TTI_SFPCONFIG(0, 8, 1);
+        // Program the SHARED macro slots + Misc once here as well, so a lone init (without an interleaved
+        // peer) leaves the backend in the expected state. The consume path re-runs this under mutex::SFPU
+        // before every use, so a cross-thread clobber between init and consume is benign.
+        _program_exp_macros_();
 #endif
     } else if constexpr (APPROXIMATION_MODE) {
         // ===================================================================

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
@@ -9,6 +9,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "ckernel_mutex_guard.h"
 #include "llk_math_eltwise_unary_sfpu.h"
 #include "sfpi.h"
 #include "sfpu/ckernel_sfpu_rsqrt_compat.h"
@@ -17,6 +18,11 @@ using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {
+
+// Forward declaration: shared macro-slot programmer for the fp32 recip path, defined below with
+// _init_reciprocal_fast_24b_5c_. Declared here so the consume path (_calculate_reciprocal_fast_24b_5c_,
+// which appears earlier in the file) can call it under the mutex::SFPU guard.
+inline void _program_reciprocal_24b_5c_macros_();
 
 // Computes the reciprocal of a floating point value x.
 template <int max_iter = 2>
@@ -191,23 +197,38 @@ inline void _calculate_reciprocal_fast_24b_5c_(const int iterations) {
     // 2 |      |                        |                         |         |
     // 3 |      |                        |                         | [z] L16 |
 
-    lltt::replay(0, 4);
-    TTI_SFPLOAD(7, 0, ADDR_MOD_6, 0);
+    // The SHARED LoadMacroConfig (templates/sequence/Misc) is programmed by both MATH (fp32 recip) and PACK
+    // (exp) with no Auto TTSync (tt-metal#50381). Guard the whole consume with mutex::SFPU and REPROGRAM the
+    // shared slots under the lock, so whatever a peer left behind is overwritten before we replay. The
+    // critical section MUST end with an explicit SFPU drain BEFORE the guard releases: ATRELM does not drain
+    // the SFPU backend, and SFPLOADMACRO schedules future-cycle work that stays in-flight after issue.
+    {
+        ckernel::T6MutexLockGuard _sfpu_lock(ckernel::mutex::SFPU);
+
+        _program_reciprocal_24b_5c_macros_();
+
+        lltt::replay(0, 4);
+        TTI_SFPLOAD(7, 0, ADDR_MOD_6, 0);
 
 #pragma GCC unroll 7
-    for (int d = 0; d < iterations - 1; d++) {
-        lltt::replay(0, 5);
-    }
+        for (int d = 0; d < iterations - 1; d++) {
+            lltt::replay(0, 5);
+        }
 
-    TTI_SFPNOP;
-    lltt::replay(1, 1);
-    TTI_SFPNOP;
-    lltt::replay(3, 2);
+        TTI_SFPNOP;
+        lltt::replay(1, 1);
+        TTI_SFPNOP;
+        lltt::replay(3, 2);
 
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-    TTI_SFPNOP;
-    TTI_SFPNOP;
+        TTI_SFPNOP;
+        TTI_SFPNOP;
+        TTI_SFPNOP;
+        TTI_SFPNOP;
+
+        // DRAIN: wait for the SFPU backend to finish all scheduled macro work before releasing the mutex,
+        // otherwise a peer could reprogram the shared slots while our SFPLOADMACRO work is still in flight.
+        TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::MATH | p_stall::WAIT_SFPU);
+    }  // guard destructor (ATRELM) runs here, after the drain
 #endif
 }
 
@@ -278,12 +299,14 @@ inline void _init_reciprocal_fast_8b_3c_() {
 #endif
 }
 
-inline void _init_reciprocal_fast_24b_5c_() {
-#ifndef DISABLE_SFPLOADMACRO
-    constexpr int e = p_sfpu::LREG0;
+// SHARED per-lane macro state: InstructionTemplate[0..3] + Macro Sequence[0..3] + Misc, all programmed via
+// SFPCONFIG (dest 0-3 = templates, 4-7 = sequence, 8 = Misc). This LoadMacroConfig backend is a single
+// per-lane resource shared across MATH (TRISC1) and PACK (TRISC2) and is NOT protected by Auto TTSync
+// (tt-metal#50381). Pulled out of _init_reciprocal_fast_24b_5c_ so the consume path can reprogram it under
+// the mutex::SFPU guard before every use, making cross-thread clobbering benign.
+inline void _program_reciprocal_24b_5c_macros_() {
     constexpr int t2 = p_sfpu::LREG1;
     constexpr int z = p_sfpu::LREG2;
-    constexpr int y = p_sfpu::LREG3;
 
     // InstructionTemplate[0]
     TTI_SFPARECIP(0, 0, 12, sfpi::SFPARECIP_MOD1_RECIP);
@@ -344,7 +367,23 @@ inline void _init_reciprocal_fast_24b_5c_() {
 
     // Misc: {UsesLoadMod0ForStore=1, WaitForElapsedInstructions=1} for all macros.
     TTI_SFPCONFIG(0xff0, 8, 1);
+}
 
+inline void _init_reciprocal_fast_24b_5c_() {
+#ifndef DISABLE_SFPLOADMACRO
+    constexpr int e = p_sfpu::LREG0;
+    constexpr int t2 = p_sfpu::LREG1;
+    constexpr int z = p_sfpu::LREG2;
+    constexpr int y = p_sfpu::LREG3;
+
+    // Program the SHARED macro slots + Misc once here as well, so a lone init (without an interleaved peer)
+    // leaves the backend in the expected state. The consume path re-runs this under mutex::SFPU before every
+    // use, so a cross-thread clobber between init and consume is benign.
+    _program_reciprocal_24b_5c_macros_();
+
+    // PER-THREAD replay recording. The SFPU replay buffer is a per-thread frontend resource (not the
+    // tt-metal#50381 collision); recording it once here is safe. It stores SFPLOADMACRO encodings by
+    // macro-slot index; the shared slots above must hold the matching contents at replay time.
     constexpr std::uint32_t prev_offset = -2 & 0x3ff;
     constexpr std::uint32_t offset = 0;
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_init.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_init.h
@@ -16,7 +16,13 @@ inline void llk_math_eltwise_ternary_sfpu_init() {
 
 template <SfpuType sfpu_op, class F, class... ARGS>
 inline void llk_math_eltwise_ternary_sfpu_init(F&& init_func, ARGS&&... args) {
-    _llk_math_eltwise_ternary_sfpu_init_<sfpu_op>();
+    // snake_beta runs as a single self-contained sfpu::snake_beta_init() (no generic prefix) for the sanitizer's
+    // per-op operation_init hook; its init_func already inlines the common init, and it uses the scalar
+    // reciprocal path (no SFPLOADMACRO), so there is no shared-macro race and no mutex is needed. Other ternary
+    // ops keep the prefix + init_func split.
+    if constexpr (sfpu_op != SfpuType::snake_beta) {
+        _llk_math_eltwise_ternary_sfpu_init_<sfpu_op>();
+    }
     init_func(static_cast<ARGS&&>(args)...);
 }
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_init.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_init.h
@@ -250,13 +250,19 @@ inline void llk_math_eltwise_unary_sfpu_init() {
 }
 
 // Callback init entry point (SFPU_UNARY_INIT_FN / _FN_ARGS / two-arg SFPU_UNARY_INIT). The per-op common init
-// (config reg + ADDR_MOD_7 + counter reset) runs first, then the op-specific init_func. Consolidated per-op
-// (#50381) rather than hoisted: re-asserting the shared SFPU config/addrmod state on every init -- on both the
-// MATH and PACK threads -- keeps the exp(PACK)/fp32-reciprocal(MATH) shared macro/replay programming from
-// interleaving destructively, which was the #50381 fp32 SDPA accuracy regression.
+// (config reg + ADDR_MOD_7 + counter reset) runs first, then the op-specific init_func.
+//
+// EXCEPTION -- exponential and reciprocal must run as a SINGLE self-contained sfpu::<op>_init() with no separate
+// generic prefix, so the sanitizer's per-op operation_init hook sees exactly one LLK init. Their init_func
+// already inlines the common init, and the shared SFPLOADMACRO macro slots + Load-Macro-Control Misc (the
+// exp-on-PACK / fp32-recip-on-MATH #50381 collision) are serialized with mutex::SFPU at the consume site rather
+// than masked by re-asserting config here. So the prefix is skipped for these two ops. All other callback ops
+// keep the prefix + init_func split.
 template <SfpuType sfpu_op, class F, class... ARGS>
 inline void llk_math_eltwise_unary_sfpu_init(F&& init_func, ARGS&&... args) {
-    _llk_math_eltwise_unary_sfpu_init_<sfpu_op>();
+    if constexpr (sfpu_op != SfpuType::exponential && sfpu_op != SfpuType::reciprocal) {
+        _llk_math_eltwise_unary_sfpu_init_<sfpu_op>();
+    }
     init_func(std::forward<ARGS>(args)...);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_init.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_init.h
@@ -16,7 +16,13 @@ inline void llk_math_eltwise_ternary_sfpu_init() {
 
 template <SfpuType sfpu_op, class F, class... ARGS>
 inline void llk_math_eltwise_ternary_sfpu_init(F&& init_func, ARGS&&... args) {
-    _llk_math_eltwise_ternary_sfpu_init_<sfpu_op>();
+    // snake_beta runs as a single self-contained sfpu::snake_beta_init() (no generic prefix) for the sanitizer's
+    // per-op operation_init hook; its init_func already inlines the common init, and it uses the scalar
+    // reciprocal path (no SFPLOADMACRO), so there is no shared-macro race and no mutex is needed. Other ternary
+    // ops keep the prefix + init_func split.
+    if constexpr (sfpu_op != SfpuType::snake_beta) {
+        _llk_math_eltwise_ternary_sfpu_init_<sfpu_op>();
+    }
     init_func(static_cast<ARGS&&>(args)...);
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_init.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_init.h
@@ -250,13 +250,18 @@ inline void llk_math_eltwise_unary_sfpu_init() {
 }
 
 // Callback init entry point (SFPU_UNARY_INIT_FN / _FN_ARGS / two-arg SFPU_UNARY_INIT). The per-op common init
-// (config reg + ADDR_MOD_7 + counter reset) runs first, then the op-specific init_func. Consolidated per-op
-// (#50381) rather than hoisted: re-asserting the shared SFPU config/addrmod state on every init -- on both the
-// MATH and PACK threads -- keeps the exp(PACK)/fp32-reciprocal(MATH) shared macro/replay programming from
-// interleaving destructively, which was the #50381 fp32 SDPA accuracy regression.
+// (config reg + ADDR_MOD_7 + counter reset) runs first, then the op-specific init_func.
+//
+// EXCEPTION -- exponential and reciprocal skip the prefix so each runs as a SINGLE self-contained
+// sfpu::<op>_init() (their init_func already inlines the common init), which the sanitizer's per-op
+// operation_init hook requires. The exp(PACK)/fp32-recip(MATH) shared-SFPLOADMACRO collision behind #50381 is a
+// Blackhole concern, serialized there with mutex::SFPU at the consume site; on Wormhole the reciprocal is plain
+// Newton-Raphson (no SFPLOADMACRO), so there is no macro race and no guard is needed here.
 template <SfpuType sfpu_op, class F, class... ARGS>
 inline void llk_math_eltwise_unary_sfpu_init(F&& init_func, ARGS&&... args) {
-    _llk_math_eltwise_unary_sfpu_init_<sfpu_op>();
+    if constexpr (sfpu_op != SfpuType::exponential && sfpu_op != SfpuType::reciprocal) {
+        _llk_math_eltwise_unary_sfpu_init_<sfpu_op>();
+    }
     init_func(std::forward<ARGS>(args)...);
 }
 


### PR DESCRIPTION
### What / why
Follow-up to #50399 (which fixed the #50381 BH fp32 SDPA race by re-adding a per-init generic prefix that *masked* the collision). This makes **exp / reciprocal / snake** each a **single self-contained `sfpu::<op>_init()`** so the tt-llk sanitizer's per-op `llk::san::operation_init` hook sees exactly one LLK init — and replaces the timing-mask with a real cross-thread guard.

### Change
1. **Delegate (unary + ternary, BH+WH):** drop the `_llk_math_eltwise_unary/ternary_sfpu_init_<op>()` generic prefix for `exponential`/`reciprocal`/`snake_beta` (scoped `if constexpr`) → single self-contained init. All other ops keep prefix + init_func.
2. **`mutex::SFPU` guard (Blackhole only):** the prefix was masking the exp(PACK)/fp32-recip(MATH) collision on the **shared, Auto-TTSync-unprotected** SFPLOADMACRO macro slots (0–3) + Load-Macro-Control `Misc`. Extract the shared macro/Misc programming into `_program_exp_macros_()` / `_program_reciprocal_24b_5c_macros_()`, and at the consume site wrap `[reprogram shared macros → replay/SFPLOADMACRO consume → TTI_STALLWAIT(STALL_CFG, MATH|WAIT_SFPU) drain]` in `T6MutexLockGuard(mutex::SFPU)`. The drain is **required** — `ATGETM`/`ATRELM` gate instruction *issue* only, not SFPU backend completion (confirmed vs tt-isa-documentation) — and sits inside the scope so it runs before the RAII release. Per-thread state (replay recording, exp `LREG12–14` operand constants) stays in init.
3. **Wormhole:** no guard — reciprocal is plain Newton-Raphson (no SFPLOADMACRO), so no macro race. **snake_beta:** scalar reciprocal path (no macro) → only the single-init delegate change.

### Validation
- **Compile** (sfpi 7.67.0, local): BH + WH Reciprocal+Exp — 128 passed each.
- **Static race-audit:** mutex balance ✓, drain-before-release ✓, no cross-thread wait in-lock (no deadlock) ✓; exp `LREG12–14` disjoint from recip `LREG0–3` and both consumes serialized by `mutex::SFPU` → LReg constants stable without being under the guard ✓.
- **HW (this run):** BH `test_sparse_mla_determinism` (the race detector — must stay bit-exact) + 6 ring-joint fp32_acc + sparse-MLA suite + WH no-regression + LLK perf.

cc reviewers (CODEOWNERS). Sanitizer hook points: @sstanisicTT @ndivnicTT — this restores the single-hook for exp/recip/snake; please confirm `operation_init` fires once per op with `LLK_SAN_ENABLE`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ncvetkovic/sfpu-single-init-mutex-sanitizer)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ncvetkovic/sfpu-single-init-mutex-sanitizer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ncvetkovic/sfpu-single-init-mutex-sanitizer)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ncvetkovic/sfpu-single-init-mutex-sanitizer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ncvetkovic/sfpu-single-init-mutex-sanitizer)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ncvetkovic/sfpu-single-init-mutex-sanitizer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ncvetkovic/sfpu-single-init-mutex-sanitizer)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ncvetkovic/sfpu-single-init-mutex-sanitizer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ncvetkovic/sfpu-single-init-mutex-sanitizer)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ncvetkovic/sfpu-single-init-mutex-sanitizer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ncvetkovic/sfpu-single-init-mutex-sanitizer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ncvetkovic/sfpu-single-init-mutex-sanitizer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ncvetkovic/sfpu-single-init-mutex-sanitizer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ncvetkovic/sfpu-single-init-mutex-sanitizer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ncvetkovic/sfpu-single-init-mutex-sanitizer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ncvetkovic/sfpu-single-init-mutex-sanitizer)