### PR TITLE
Llama-3.1-8B P150 decode: 40.2 → 51.5 tok/s/u 

### DIFF
--- a/models/tt_transformers/tests/sweeps/README.md
+++ b/models/tt_transformers/tests/sweeps/README.md
@@ -1,0 +1,52 @@
+# tt_transformers op program-config sweeps
+
+Standalone CLI tools that sweep the program configuration (core grid, block
+sizes, memory layout, math fidelity, dtype) of individual decode ops, time each
+candidate on device, and report the fastest passing config. Useful for tuning a
+new model shape or re-tuning an op on a new board.
+
+All sweeps take the model/op shape as arguments (with `--preset` shortcuts for
+common models) so they are not tied to a single model.
+
+## Device-kernel timing
+
+The op sweeps rank by **device kernel duration** captured from the profiler
+(`ReadDeviceProfiler` + `get_latest_programs_perf_data`). This requires a
+profiler build and the three env vars below; without them, rows fall back to
+host wall-clock (dispatch-dominated) and are flagged `src=host` — do not use
+those for ranking.
+
+```bash
+export TT_METAL_HOME=$(pwd) PYTHONPATH=$(pwd) MESH_DEVICE=P150
+export TT_METAL_DEVICE_PROFILER=1 TT_METAL_PROFILER_MID_RUN_DUMP=1 TT_METAL_PROFILER_CPP_POST_PROCESS=1
+```
+
+## Files
+
+| File | What it sweeps |
+|------|----------------|
+| `sweep_common.py` | Shared device-open / profiler-capture / CSV helpers (imported by the op sweeps). |
+| `sweep_create_heads.py` | `nlp_create_qkv_heads_decode`: input shard grid, `overlap_qk_coregrid`, input/output memory layout. |
+| `sweep_sdpa_decode.py` | `scaled_dot_product_attention_decode`: compute grid, q/k chunk sizes, `exp_approx_mode`, fidelity, KV/output buffer type. |
+| `sweep_llama_mm_v2.py` | Decode matmuls (QKV/WO/FF1_FF3/FF2/LMHEAD): core grid, `in0_block_w`, `per_core_N`, factory (DRAM-sharded vs 1D-mcast), fidelity, dtype, output memcfg. Reports GB/s and DRAM-bandwidth utilisation. |
+| `matmul_sweep.py` | General GEMM sweep for arbitrary `--M/--K/--N` across `minimal_matmul`, 2D-mcast and 1D-mcast, with PCC checked against a torch reference. |
+
+## Examples
+
+```bash
+# Attention op sweeps (Llama-3.1-8B is the default shape)
+python models/tt_transformers/tests/sweeps/sweep_create_heads.py --csv ch.csv
+python models/tt_transformers/tests/sweeps/sweep_sdpa_decode.py --kv-len 1024 --sweep-chunks --sweep-fid --csv sdpa.csv
+
+# Another model via preset (see PRESETS in each file: llama3-8b/70b/1b/3b, mistral-7b, qwen2-7b)
+python models/tt_transformers/tests/sweeps/sweep_sdpa_decode.py --preset qwen2-7b --kv-len 2048
+
+# Decode matmul sweep
+python models/tt_transformers/tests/sweeps/sweep_llama_mm_v2.py --shapes FF2 QKV WO --factory both --csv mm.csv
+
+# Arbitrary GEMM
+python models/tt_transformers/tests/sweeps/matmul_sweep.py --M 32 --K 4096 --N 14336
+```
+
+Each sweep writes a CSV (one row per config, including failures with the reason
+in a `note`/`status` column) and prints the BEST (fastest passing) config.

--- a/models/tt_transformers/tests/sweeps/matmul_sweep.py
+++ b/models/tt_transformers/tests/sweeps/matmul_sweep.py
@@ -1,0 +1,539 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generalized matmul program-config sweep — a CLI tool.
+
+Give it M, K, N (the GEMM dims, A[M,K] @ B[K,N] = C[M,N]) and it sweeps the
+program configuration, memory configuration, math fidelity and dest/accumulation
+modes for one or more matmul implementations, timing each on device and checking
+PCC against a torch reference. It prints a RESULT line per config, writes a CSV,
+and reports the BEST (fastest PCC-passing) config per implementation.
+
+Implementations (choose with --impl, default: all):
+  minmatmul  ttnn.experimental.minimal_matmul  (MinimalMatmulConfig: M/K/N block + subblock)
+  matmul2d   ttnn.matmul + MatmulMultiCoreReuseMultiCastProgramConfig   (2D mcast)
+  matmul1d   ttnn.matmul + MatmulMultiCoreReuseMultiCast1DProgramConfig (1D mcast)
+
+The sweep OWNS config generation: from M,K,N and the core grid it derives valid
+per-core / block sizes, enumerates the tunable block + subblock params, and skips
+combinations that violate the known hardware constraints (DST-register cap,
+divisibility) up front so the run isn't just a wall of failures.
+
+Examples
+  # BGE-M3 MLP Wi shape (M=12*8192, K=1024, N=4096), all impls, default sweep
+  python models/demos/wormhole/bge_m3/tests/generalize/matmul_sweep.py --M 98304 --K 1024 --N 4096
+
+  # Just minimal_matmul, wider block sweep, save CSV
+  python models/demos/wormhole/bge_m3/tests/generalize/matmul_sweep.py --M 98304 --K 4096 --N 1024 \
+      --impl minmatmul --csv models/demos/wormhole/bge_m3/tests/generalize/out/mlpwo.csv
+
+  # Fixed fidelity/dtype, cap the number of configs tried
+  python models/demos/wormhole/bge_m3/tests/generalize/matmul_sweep.py --M 8192 --K 8192 --N 8192 \
+      --dtypes bfloat8_b --fidelities LoFi --max-configs 40
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import itertools
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import torch
+
+import ttnn
+
+TILE = 32
+
+DTYPES = {
+    "bfloat16": ttnn.bfloat16,
+    "bfloat8_b": ttnn.bfloat8_b,
+    "bfloat4_b": ttnn.bfloat4_b,
+}
+FIDELITIES = {
+    "LoFi": ttnn.MathFidelity.LoFi,
+    "HiFi2": ttnn.MathFidelity.HiFi2,
+    "HiFi4": ttnn.MathFidelity.HiFi4,
+}
+MEMCFGS = {
+    "dram": ttnn.DRAM_MEMORY_CONFIG,
+    "l1": ttnn.L1_MEMORY_CONFIG,
+}
+
+
+# ----------------------------------------------------------------------------
+# Config generation helpers
+# ----------------------------------------------------------------------------
+def divisors(n: int) -> list[int]:
+    return [d for d in range(1, n + 1) if n % d == 0]
+
+
+def subblock_candidates(block_h: int, block_w: int, dst_cap: int) -> list[tuple[int, int]]:
+    """(subblock_h, subblock_w) with h*w <= dst_cap, h | block_h, w | block_w.
+
+    dst_cap is the number of output tiles that fit in the DST register per
+    acquire: 8 for bf16/bf8 dest, 4 when fp32_dest_acc_en=True (fp32 halves it).
+    Larger subblocks amortize the acquire/release + math-init overhead.
+    """
+    out = []
+    for h in divisors(block_h):
+        for w in divisors(block_w):
+            if h * w <= dst_cap and h * w >= 1:
+                out.append((h, w))
+    # Prefer larger subblocks first (usually faster) so early results are good.
+    out.sort(key=lambda hw: -(hw[0] * hw[1]))
+    return out
+
+
+def dst_cap_for(fp32_dest_acc_en: bool) -> int:
+    return 4 if fp32_dest_acc_en else 8
+
+
+@dataclass
+class Trial:
+    impl: str
+    label: str
+    program_config: object
+    out_memcfg_name: str
+    dtype_name: str
+    fidelity_name: str
+    fp32_dest_acc_en: bool
+    packer_l1_acc: bool
+    est_out_cb_bytes: int = 0
+    extra: dict = field(default_factory=dict)
+
+
+def gen_minmatmul(M_t, K_t, N_t, grid, args, dtype_name, fid_name, fp32_dest, packer_l1):
+    """MinimalMatmulConfig: block sizes are in TILES; factory splits M/N across
+    the grid and iterates ceil(per_core / block) blocks. Bigger M/K block cuts
+    iteration overhead but grows the double-buffered CB L1 footprint."""
+    cap = dst_cap_for(fp32_dest)
+    m_blocks = [b for b in args.m_blocks if b <= max(M_t, 1)]
+    k_blocks = [b for b in args.k_blocks if b <= max(K_t, 1)]
+    n_blocks = [b for b in args.n_blocks if b <= max(N_t, 1)]
+    trials = []
+    for mb, kb, nb in itertools.product(m_blocks, k_blocks, n_blocks):
+        for sh, sw in subblock_candidates(mb, nb, cap):
+            cfg = ttnn.MinimalMatmulConfig(
+                M_block_size=mb,
+                K_block_size=kb,
+                N_block_size=nb,
+                subblock_h=sh,
+                subblock_w=sw,
+                compute_with_storage_grid_size=ttnn.CoreCoord(grid[0], grid[1]),
+            )
+            tile_bytes = 2048 if dtype_name == "bfloat16" else (1088 if dtype_name == "bfloat8_b" else 576)
+            est = 2 * (mb * kb + kb * nb + mb * nb) * tile_bytes  # double-buffered CBs
+            trials.append(
+                Trial(
+                    "minmatmul",
+                    f"m{mb}k{kb}n{nb}_sb{sh}x{sw}",
+                    cfg,
+                    "?",
+                    dtype_name,
+                    fid_name,
+                    fp32_dest,
+                    packer_l1,
+                    est_out_cb_bytes=est,
+                    extra={"M_block": mb, "K_block": kb, "N_block": nb, "sbh": sh, "sbw": sw},
+                )
+            )
+    return trials
+
+
+def _percore_and_subblocks(M_t, N_t, grid, cap, transpose_mcast):
+    """per_core_M/N from grid + valid out_subblock candidates."""
+    gx, gy = grid
+    # 2D convention: M parallelised on grid rows (y), N on grid cols (x)
+    cores_m = gx if transpose_mcast else gy
+    cores_n = gy if transpose_mcast else gx
+    per_core_M = max(1, -(-M_t // cores_m))  # ceil
+    per_core_N = max(1, -(-N_t // cores_n))
+    subs = subblock_candidates(per_core_M, per_core_N, cap)
+    return per_core_M, per_core_N, subs
+
+
+def gen_matmul2d(M_t, K_t, N_t, grid, args, dtype_name, fid_name, fp32_dest, packer_l1):
+    cap = dst_cap_for(fp32_dest)
+    trials = []
+    for transpose_mcast in (False, True):
+        per_core_M, per_core_N, subs = _percore_and_subblocks(M_t, N_t, grid, cap, transpose_mcast)
+        for in0_block_w in [w for w in divisors(K_t) if w in args.in0_block_w or not args.in0_block_w]:
+            for sh, sw in subs:
+                if per_core_M % sh or per_core_N % sw:
+                    continue
+                try:
+                    cfg = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                        compute_with_storage_grid_size=ttnn.CoreCoord(grid[0], grid[1]),
+                        in0_block_w=in0_block_w,
+                        out_subblock_h=sh,
+                        out_subblock_w=sw,
+                        per_core_M=per_core_M,
+                        per_core_N=per_core_N,
+                        transpose_mcast=transpose_mcast,
+                        fuse_batch=True,
+                    )
+                except Exception:
+                    continue
+                trials.append(
+                    Trial(
+                        "matmul2d",
+                        f"pcM{per_core_M}pcN{per_core_N}_ib{in0_block_w}_sb{sh}x{sw}_t{int(transpose_mcast)}",
+                        cfg,
+                        "?",
+                        dtype_name,
+                        fid_name,
+                        fp32_dest,
+                        packer_l1,
+                        extra={
+                            "per_core_M": per_core_M,
+                            "per_core_N": per_core_N,
+                            "in0_block_w": in0_block_w,
+                            "sbh": sh,
+                            "sbw": sw,
+                            "transpose_mcast": transpose_mcast,
+                        },
+                    )
+                )
+    return trials
+
+
+def gen_matmul1d(M_t, K_t, N_t, grid, args, dtype_name, fid_name, fp32_dest, packer_l1):
+    cap = dst_cap_for(fp32_dest)
+    gx, gy = grid
+    num_cores = gx * gy
+    trials = []
+    for mcast_in0 in (True, False):
+        # 1D lays all cores in a line. mcast_in0=True: split N across cores, M
+        # replicated per core. mcast_in0=False (gather): split M across cores.
+        if mcast_in0:
+            per_core_M = max(1, M_t)
+            per_core_N = max(1, -(-N_t // num_cores))
+        else:
+            per_core_M = max(1, -(-M_t // num_cores))
+            per_core_N = max(1, N_t)
+        subs = subblock_candidates(per_core_M, per_core_N, cap)
+        for in0_block_w in [w for w in divisors(K_t) if w in args.in0_block_w or not args.in0_block_w]:
+            for sh, sw in subs:
+                if per_core_M % sh or per_core_N % sw:
+                    continue
+                try:
+                    cfg = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                        compute_with_storage_grid_size=ttnn.CoreCoord(grid[0], grid[1]),
+                        in0_block_w=in0_block_w,
+                        out_subblock_h=sh,
+                        out_subblock_w=sw,
+                        per_core_M=per_core_M,
+                        per_core_N=per_core_N,
+                        fuse_batch=True,
+                        mcast_in0=mcast_in0,
+                    )
+                except Exception:
+                    continue
+                trials.append(
+                    Trial(
+                        "matmul1d",
+                        f"pcM{per_core_M}pcN{per_core_N}_ib{in0_block_w}_sb{sh}x{sw}_mc{int(mcast_in0)}",
+                        cfg,
+                        "?",
+                        dtype_name,
+                        fid_name,
+                        fp32_dest,
+                        packer_l1,
+                        extra={
+                            "per_core_M": per_core_M,
+                            "per_core_N": per_core_N,
+                            "in0_block_w": in0_block_w,
+                            "sbh": sh,
+                            "sbw": sw,
+                            "mcast_in0": mcast_in0,
+                        },
+                    )
+                )
+    return trials
+
+
+GENERATORS = {"minmatmul": gen_minmatmul, "matmul2d": gen_matmul2d, "matmul1d": gen_matmul1d}
+
+
+# ----------------------------------------------------------------------------
+# Execution
+# ----------------------------------------------------------------------------
+def pcc(a: torch.Tensor, b: torch.Tensor) -> float:
+    a = a.flatten().to(torch.float64)
+    b = b.flatten().to(torch.float64)
+    a = a - a.mean()
+    b = b - b.mean()
+    denom = (a.norm() * b.norm()).item()
+    return 1.0 if denom == 0 else (torch.dot(a, b).item() / denom)
+
+
+_OOM_MARKERS = (
+    "out of memory",
+    "oom",
+    "clash with l1",
+    "beyond max l1",
+    "circular buffer",
+    "bank_manager",
+    "allocator",
+    "not enough space",
+    "failed to allocate",
+)
+
+
+def _looks_like_oom(exc: BaseException) -> bool:
+    """Classify an exception as an L1/DRAM capacity failure for reporting."""
+    s = str(exc).lower()
+    return any(m in s for m in _OOM_MARKERS)
+
+
+def _device_alive(dev) -> bool:
+    """Cheap probe: round-trip a tiny tensor. Returns False if the device is
+    wedged/unresponsive so the sweep can abort cleanly instead of spinning."""
+    try:
+        x = ttnn.from_torch(
+            torch.zeros(TILE, TILE, dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=dev,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        ttnn.synchronize_device(dev)
+        _safe_dealloc(x)
+        return True
+    except Exception:
+        return False
+
+
+def _safe_dealloc(t):
+    """Deallocate a device tensor, swallowing any error (already-freed, bad
+    state, etc.) so cleanup never masks the real failure."""
+    if t is None:
+        return
+    try:
+        ttnn.deallocate(t)
+    except Exception:
+        pass
+
+
+def run_trial(dev, a_t, b_t, ref, trial: Trial, out_memcfg_name, iters):
+    dtype = DTYPES[trial.dtype_name]
+    memcfg = MEMCFGS[out_memcfg_name]
+    a = b = None
+    outs = []  # track every output so we can free them even on mid-loop failure
+    try:
+        a = ttnn.from_torch(
+            a_t, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=dev, memory_config=ttnn.DRAM_MEMORY_CONFIG
+        )
+        b = ttnn.from_torch(
+            b_t, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=dev, memory_config=ttnn.DRAM_MEMORY_CONFIG
+        )
+        ck = ttnn.init_device_compute_kernel_config(
+            dev.arch(),
+            math_fidelity=FIDELITIES[trial.fidelity_name],
+            math_approx_mode=False,
+            fp32_dest_acc_en=trial.fp32_dest_acc_en,
+            packer_l1_acc=trial.packer_l1_acc,
+        )
+
+        def once():
+            if trial.impl == "minmatmul":
+                return ttnn.experimental.minimal_matmul(
+                    input_tensor=a,
+                    weight_tensor=b,
+                    bias_tensor=None,
+                    config=trial.program_config,
+                    memory_config=memcfg,
+                    dtype=dtype,
+                    compute_kernel_config=ck,
+                )
+            return ttnn.matmul(
+                a, b, program_config=trial.program_config, memory_config=memcfg, compute_kernel_config=ck
+            )
+
+        # correctness (warm + compile). A bad program config / L1 OOM / TT_FATAL
+        # throws HERE (at program build, before launch) -> caught by the caller.
+        out = once()
+        outs.append(out)
+        ttnn.synchronize_device(dev)
+        got = ttnn.to_torch(out).to(torch.float32).reshape(ref.shape)
+        p = pcc(ref, got)
+        _safe_dealloc(out)
+        outs.clear()
+
+        # timing (median of iters)
+        samples = []
+        for _ in range(iters):
+            t0 = time.perf_counter()
+            out = once()
+            outs.append(out)
+            ttnn.synchronize_device(dev)
+            samples.append((time.perf_counter() - t0) * 1e3)
+            _safe_dealloc(out)
+            outs.clear()
+        samples.sort()
+        return samples[len(samples) // 2], samples[0], p
+    finally:
+        # Always free inputs + any straggler outputs so a failed trial does not
+        # leak L1/DRAM and cause phantom OOMs on the configs that follow.
+        for o in outs:
+            _safe_dealloc(o)
+        _safe_dealloc(a)
+        _safe_dealloc(b)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Generalized matmul program-config sweep")
+    ap.add_argument("--M", type=int, required=True, help="rows of A / output (elements)")
+    ap.add_argument("--K", type=int, required=True, help="contraction dim (elements)")
+    ap.add_argument("--N", type=int, required=True, help="cols of B / output (elements)")
+    ap.add_argument(
+        "--impl",
+        nargs="+",
+        default=["minmatmul", "matmul2d", "matmul1d"],
+        choices=list(GENERATORS.keys()),
+        help="which implementations to sweep",
+    )
+    ap.add_argument("--dtypes", nargs="+", default=["bfloat8_b"], choices=list(DTYPES.keys()))
+    ap.add_argument("--fidelities", nargs="+", default=["LoFi", "HiFi2"], choices=list(FIDELITIES.keys()))
+    ap.add_argument("--out-memcfgs", nargs="+", default=["dram", "l1"], choices=list(MEMCFGS.keys()))
+    ap.add_argument(
+        "--fp32-dest", nargs="+", type=int, default=[0], choices=[0, 1], help="fp32_dest_acc_en values to sweep (0/1)"
+    )
+    ap.add_argument("--packer-l1-acc", nargs="+", type=int, default=[1], choices=[0, 1])
+    ap.add_argument("--grid", type=int, nargs=2, default=[8, 8], help="core grid x y")
+    ap.add_argument("--iters", type=int, default=3, help="timing samples per config (median reported)")
+    ap.add_argument("--max-configs", type=int, default=200, help="cap total trials")
+    ap.add_argument("--pcc", type=float, default=0.99, help="PCC threshold to count as passing")
+    ap.add_argument("--m-blocks", type=int, nargs="+", default=[8, 16, 24, 32], help="minmatmul M_block tiles")
+    ap.add_argument("--k-blocks", type=int, nargs="+", default=[4, 8, 16, 32], help="minmatmul K_block tiles")
+    ap.add_argument("--n-blocks", type=int, nargs="+", default=[2, 4, 8], help="minmatmul N_block tiles")
+    ap.add_argument(
+        "--in0-block-w", type=int, nargs="*", default=[], help="fix matmul1d/2d in0_block_w (tiles); empty=all divisors"
+    )
+    ap.add_argument("--csv", type=str, default="", help="write results CSV to this path")
+    ap.add_argument("--seed", type=int, default=0)
+    args = ap.parse_args()
+
+    if args.M % TILE or args.K % TILE or args.N % TILE:
+        raise SystemExit(f"M,K,N must be multiples of {TILE} (tile dim). Got {args.M},{args.K},{args.N}")
+    M_t, K_t, N_t = args.M // TILE, args.K // TILE, args.N // TILE
+    print(
+        f"# GEMM A[{args.M},{args.K}] @ B[{args.K},{args.N}] = C[{args.M},{args.N}]  "
+        f"({M_t}x{K_t}x{N_t} tiles), grid={args.grid}",
+        flush=True,
+    )
+
+    torch.manual_seed(args.seed)
+    a_t = torch.randn(args.M, args.K, dtype=torch.bfloat16)
+    b_t = torch.randn(args.K, args.N, dtype=torch.bfloat16)
+    ref = a_t.to(torch.float32) @ b_t.to(torch.float32)
+
+    # Build the trial list across all axes.
+    trials: list[Trial] = []
+    for impl in args.impl:
+        for dt, fid, fp32, pl1 in itertools.product(args.dtypes, args.fidelities, args.fp32_dest, args.packer_l1_acc):
+            trials += GENERATORS[impl](M_t, K_t, N_t, tuple(args.grid), args, dt, fid, bool(fp32), bool(pl1))
+    # Expand over output memcfgs (cheap axis, keep last so program configs cluster).
+    expanded = []
+    for t in trials:
+        for mc in args.out_memcfgs:
+            t2 = Trial(**{**t.__dict__})
+            t2.out_memcfg_name = mc
+            expanded.append(t2)
+    trials = expanded
+    if len(trials) > args.max_configs:
+        print(f"# generated {len(trials)} trials, capping to --max-configs={args.max_configs}", flush=True)
+        trials = trials[: args.max_configs]
+    else:
+        print(f"# generated {len(trials)} trials", flush=True)
+
+    def _base_row(t, status, note="", **num):
+        return {
+            "impl": t.impl,
+            "label": t.label,
+            "dtype": t.dtype_name,
+            "fidelity": t.fidelity_name,
+            "fp32_dest": int(t.fp32_dest_acc_en),
+            "packer_l1_acc": int(t.packer_l1_acc),
+            "out_memcfg": t.out_memcfg_name,
+            "status": status,
+            "est_out_cb_bytes": t.est_out_cb_bytes,
+            "median_ms": "",
+            "min_ms": "",
+            "pcc": "",
+            "note": note,
+            **num,
+            **t.extra,
+        }
+
+    dev = ttnn.open_mesh_device(ttnn.MeshShape(1, 1))
+    rows = []
+    best = {}
+    n_ok = n_skip = n_fatal = 0
+    try:
+        for i, t in enumerate(trials):
+            full = (
+                f"{t.impl}|{t.label}|{t.dtype_name}|{t.fidelity_name}|"
+                f"fp32d{int(t.fp32_dest_acc_en)}|pl1{int(t.packer_l1_acc)}|out_{t.out_memcfg_name}"
+            )
+            try:
+                med, mn, p = run_trial(dev, a_t, b_t, ref, t, t.out_memcfg_name, args.iters)
+                status = "PASS" if p >= args.pcc else "LOWPCC"
+                print(f"RESULT {full} median_ms={med:.3f} min_ms={mn:.3f} pcc={p:.4f} [{status}]", flush=True)
+                rows.append(_base_row(t, status, median_ms=round(med, 3), min_ms=round(mn, 3), pcc=round(p, 4)))
+                n_ok += 1
+                if status == "PASS" and (t.impl not in best or med < best[t.impl][0]):
+                    best[t.impl] = (med, full)
+            except KeyboardInterrupt:
+                print("\n# interrupted by user - writing partial results", flush=True)
+                break
+            except (RuntimeError, ValueError, MemoryError, RuntimeWarning) as exc:
+                # Expected, recoverable per-config failures: L1/DRAM OOM, bad
+                # program config, TT_FATAL/TT_THROW at program build, PCC-time
+                # reshape mismatch. These throw at COMPILE (before launch), so the
+                # device is not wedged - log and keep sweeping.
+                msg = f"{type(exc).__name__}: {str(exc)[:180]}"
+                kind = "OOM" if _looks_like_oom(exc) else "SKIP"
+                print(f"{kind} {full}: {msg}", flush=True)
+                rows.append(_base_row(t, kind, note=msg))
+                n_skip += 1
+            except BaseException as exc:  # noqa: BLE001 - last-resort guard
+                # Anything unexpected (e.g. a hard device error). Record it,
+                # probe device health, and continue if the device still responds.
+                msg = f"{type(exc).__name__}: {str(exc)[:180]}"
+                print(f"FATAL {full}: {msg}", flush=True)
+                rows.append(_base_row(t, "FATAL", note=msg))
+                n_fatal += 1
+                if not _device_alive(dev):
+                    print("# device no longer responsive - aborting sweep, writing partial results", flush=True)
+                    break
+    finally:
+        try:
+            ttnn.close_mesh_device(dev)
+        except Exception:
+            pass
+    print(f"\n# trials: {n_ok} ran, {n_skip} skipped/oom, {n_fatal} fatal", flush=True)
+
+    print("\n# ==== BEST (fastest PCC-passing) per implementation ====")
+    for impl in args.impl:
+        if impl in best:
+            print(f"BEST {impl}: median_ms={best[impl][0]:.3f}  {best[impl][1]}")
+        else:
+            print(f"BEST {impl}: (no PCC-passing config)")
+
+    if args.csv:
+        p = Path(args.csv)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        cols = sorted({k for r in rows for k in r})
+        with open(p, "w", newline="") as f:
+            w = csv.DictWriter(f, fieldnames=cols)
+            w.writeheader()
+            w.writerows(rows)
+        print(f"# wrote {len(rows)} rows to {p}")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/tt_transformers/tests/sweeps/sweep_common.py
+++ b/models/tt_transformers/tests/sweeps/sweep_common.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Shared helpers for the Llama-3.1-8B decode op sweeps (Blackhole P150).
+
+PRIMARY metric = device kernel duration captured from the profiler
+(ReadDeviceProfiler + get_latest_programs_perf_data), matching teja's
+tt_llama_p150_matmul_sweep.py methodology. Host wall-clock is only a
+diagnostic fallback and is flagged src=host so it is never confused with a
+real device measurement.
+
+Run every sweep with ALL THREE profiler env vars or rows fall back to src=host
+(host wall-clock is dispatch-dominated and must NOT be used for ranking):
+  export TT_METAL_HOME=$(pwd) PYTHONPATH=$(pwd) MESH_DEVICE=P150
+  export TT_METAL_DEVICE_PROFILER=1 TT_METAL_PROFILER_MID_RUN_DUMP=1 TT_METAL_PROFILER_CPP_POST_PROCESS=1
+Verified: with only TT_METAL_DEVICE_PROFILER=1, get_latest_programs_perf_data
+returns nothing and everything is src=host (~70us noise). With all three, the
+same create-heads op reports src=prof (~7-17us device kernel time).
+"""
+import csv
+import time
+
+import ttnn
+
+
+def open_dev():
+    dev = ttnn.open_device(device_id=0)
+    dev.enable_program_cache()
+    return dev
+
+
+def device_kernel_ns(device):
+    """Return (max_device_kernel_ns, core_count) from the profiler, or None."""
+    try:
+        ttnn.ReadDeviceProfiler(device)
+        latest = ttnn.get_latest_programs_perf_data()
+    except Exception:
+        return None
+    if not latest:
+        return None
+    dev_id = device.get_device_ids()[0] if hasattr(device, "get_device_ids") else 0
+    progs = latest.get(dev_id) if latest else None
+    if not progs:
+        return None
+    dur_ns, cores = None, 0
+    for p in progs:
+        r = p.program_analyses_results.get("DEVICE KERNEL DURATION [ns]")
+        if r and r.duration is not None and (dur_ns is None or r.duration > dur_ns):
+            dur_ns, cores = r.duration, p.core_count
+    if not dur_ns:
+        return None
+    return dur_ns, cores
+
+
+def timed_run(device, fn, iterations=30):
+    """Run fn() iterations times; return dict(dur_ns, cores, src).
+
+    fn must return the output tensor (deallocated here). Device-kernel time is
+    preferred; host wall-clock/iter is only used if the profiler yields nothing.
+    """
+    # warmup + flush profiler so we only capture steady-state programs
+    out = fn()
+    ttnn.synchronize_device(device)
+    try:
+        if out is not None:
+            out.deallocate(True)
+    except Exception:
+        pass
+    try:
+        ttnn.ReadDeviceProfiler(device)
+    except Exception:
+        pass
+
+    t0 = time.perf_counter()
+    for _ in range(iterations):
+        out = fn()
+        ttnn.synchronize_device(device)
+        try:
+            if out is not None:
+                out.deallocate(True)
+        except Exception:
+            pass
+    host_ns = (time.perf_counter() - t0) * 1e9 / iterations
+
+    prof = device_kernel_ns(device)
+    if prof:
+        return dict(dur_ns=prof[0], cores=prof[1], src="prof")
+    return dict(dur_ns=host_ns, cores=0, src="host")
+
+
+class CSVLog:
+    def __init__(self, path, header):
+        self.path = path
+        with open(path, "w", newline="") as f:
+            csv.writer(f).writerow(header)
+
+    def row(self, values):
+        with open(self.path, "a", newline="") as f:
+            csv.writer(f).writerow(values)

--- a/models/tt_transformers/tests/sweeps/sweep_create_heads.py
+++ b/models/tt_transformers/tests/sweeps/sweep_create_heads.py
@@ -1,0 +1,238 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+nlp_create_qkv_heads_decode program-config sweep — generalized CLI tool.
+
+Give it the attention shape (--n-q-heads / --n-kv-heads / --head-dim, or a
+--preset) and it sweeps the INPUT shard grid (which is what this op inherits its
+parallelism from) plus overlap_qk_coregrid, timing each config on device and
+reporting the fastest.
+
+Problem it targets (Llama-3.1-8B decode tracy profile):
+NLPCreateQKVHeadsDecodeDeviceOperation ran on **1 core** at ~16.8us avg (1.08ms
+total over decode) — the most under-utilized op. It splits the fused QKV row
+[1,1,32,(n_q+2*n_kv)*hd] into Q/K/V head tensors and inherits parallelism from
+the INPUT shard grid; if the input arrives interleaved it collapses to 1 core.
+Width-sharding the fused-QKV input across N cores parallelizes it.
+
+Correctness: this is a pure data-shuffle (no math) so the output is bit-identical
+regardless of grid; we assert Q/K/V shapes. Ranked by device kernel time.
+
+PRIMARY metric = device kernel duration (profiler). Run with ALL THREE profiler
+env vars or rows fall back to src=host (dispatch-dominated, not for ranking):
+  export TT_METAL_HOME=$(pwd) PYTHONPATH=$(pwd):$(pwd)/.auto MESH_DEVICE=P150
+  export TT_METAL_DEVICE_PROFILER=1 TT_METAL_PROFILER_MID_RUN_DUMP=1 TT_METAL_PROFILER_CPP_POST_PROCESS=1
+
+Examples
+  # Llama-3.1-8B (default): n_q=32 n_kv=8 hd=128
+  python models/tt_transformers/tests/sweeps/sweep_create_heads.py --csv ch_8b.csv
+
+  # Llama-3.2-1B via preset
+  python models/tt_transformers/tests/sweeps/sweep_create_heads.py --preset llama3-1b --csv ch_1b.csv
+
+  # arbitrary shape (e.g. MHA, no GQA: n_kv == n_q)
+  python models/tt_transformers/tests/sweeps/sweep_create_heads.py --n-q-heads 32 --n-kv-heads 32 --head-dim 128
+"""
+import argparse
+import itertools
+import os
+import sys
+
+import torch
+
+import ttnn
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from sweep_common import CSVLog, open_dev, timed_run
+
+# Preset attention shapes: (n_q_heads, n_kv_heads, head_dim)
+PRESETS = {
+    "llama3-8b": (32, 8, 128),
+    "llama3-70b": (64, 8, 128),
+    "llama3-1b": (32, 8, 64),
+    "llama3-3b": (24, 8, 128),
+    "mistral-7b": (32, 8, 128),
+    "qwen2-7b": (28, 4, 128),
+}
+
+
+# Input memory layouts to sweep. "width_sharded" uses the core grid (this is what
+# parallelizes the op); the interleaved variants collapse the op to 1 core but let
+# us measure the L1-vs-DRAM residence cost of the baseline path.
+INPUT_LAYOUTS = ["interleaved_l1", "interleaved_dram", "width_sharded"]
+# Output memory configs to sweep.
+OUTPUT_LAYOUTS = ["height_sharded_l1", "interleaved_l1", "interleaved_dram"]
+
+
+def build_fused_qkv(device, input_layout, grid_xy, dtype, qkv_w):
+    """Fused QKV [1,1,32,qkv_w] in the requested input memory layout.
+
+    interleaved_l1 / interleaved_dram -> op runs on 1 core (baseline paths).
+    width_sharded  -> width-sharded across grid_xy cores in L1 (parallelized).
+    """
+    x = torch.randn(1, 1, 32, qkv_w).bfloat16().float()
+    if input_layout == "interleaved_l1":
+        return ttnn.from_torch(
+            x, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
+        )
+    if input_layout == "interleaved_dram":
+        return ttnn.from_torch(
+            x, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+        )
+    # width_sharded (requires a grid)
+    gx, gy = grid_xy
+    ncores = gx * gy
+    t = ttnn.from_torch(x, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    mem = ttnn.create_sharded_memory_config(
+        shape=(32, qkv_w // ncores),
+        core_grid=ttnn.CoreGrid(y=gy, x=gx),
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+    return ttnn.to_memory_config(t, mem)
+
+
+def build_out_mem(output_layout, head_dim):
+    """Output memory config for the Q/K/V head tensors."""
+    if output_layout == "height_sharded_l1":
+        return ttnn.create_sharded_memory_config(
+            shape=(ttnn.TILE_SIZE, head_dim),
+            core_grid=ttnn.CoreGrid(y=4, x=8),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    if output_layout == "interleaved_l1":
+        return ttnn.L1_MEMORY_CONFIG
+    return ttnn.DRAM_MEMORY_CONFIG
+
+
+def grid_candidates(qkv_w, max_x=8, max_y=8):
+    # width shards need ncores to divide qkv_w/32 tiles cleanly
+    tiles = qkv_w // 32
+    grids = []
+    for gy in range(1, max_y + 1):
+        for gx in range(1, max_x + 1):
+            nc = gx * gy
+            if tiles % nc == 0 and nc >= 1:
+                grids.append((gx, gy))
+    return grids
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Generalized nlp_create_qkv_heads_decode sweep")
+    ap.add_argument(
+        "--preset",
+        choices=list(PRESETS.keys()),
+        default=None,
+        help="attention shape preset (overridden by explicit --n-q-heads etc.)",
+    )
+    ap.add_argument("--n-q-heads", type=int, default=None, help="number of query heads")
+    ap.add_argument("--n-kv-heads", type=int, default=None, help="number of KV heads (GQA); == n_q for MHA")
+    ap.add_argument("--head-dim", type=int, default=None, help="per-head dimension")
+    ap.add_argument("--iters", type=int, default=40)
+    ap.add_argument("--dtype", choices=["bf8", "bf16"], default="bf16")
+    ap.add_argument(
+        "--input-layouts", nargs="+", default=INPUT_LAYOUTS, choices=INPUT_LAYOUTS, help="input memory layouts to sweep"
+    )
+    ap.add_argument(
+        "--out-layouts",
+        nargs="+",
+        default=["height_sharded_l1"],
+        choices=OUTPUT_LAYOUTS,
+        help="output memory configs to sweep",
+    )
+    ap.add_argument("--csv", type=str, default="sweep_create_heads.csv")
+    args = ap.parse_args()
+
+    # Resolve shape: preset supplies defaults, explicit flags override individually.
+    pq, pk, ph = PRESETS.get(args.preset or "llama3-8b")
+    n_q = args.n_q_heads if args.n_q_heads is not None else pq
+    n_kv = args.n_kv_heads if args.n_kv_heads is not None else pk
+    head_dim = args.head_dim if args.head_dim is not None else ph
+    qkv_w = (n_q + 2 * n_kv) * head_dim
+
+    dtype = ttnn.bfloat8_b if args.dtype == "bf8" else ttnn.bfloat16
+    dev = open_dev()
+    log = CSVLog(
+        args.csv,
+        [
+            "n_q",
+            "n_kv",
+            "head_dim",
+            "qkv_w",
+            "input_layout",
+            "input_grid",
+            "num_cores",
+            "out_layout",
+            "overlap_qk",
+            "src",
+            "dur_us",
+            "status",
+            "note",
+        ],
+    )
+    print(f"\n===== nlp_create_qkv_heads_decode  n_q={n_q} n_kv={n_kv} hd={head_dim} qkv_w={qkv_w} =====")
+    print(f"{'in_layout':>17s} {'in_grid':>9s} {'nc':>4s} {'out_layout':>18s} {'ovl':>4s} {'src':>4s} {'us':>9s}")
+
+    grids = grid_candidates(qkv_w)
+    best = None
+    n_ok = n_err = 0
+    for input_layout, out_layout, overlap in itertools.product(args.input_layouts, args.out_layouts, [True, False]):
+        # width_sharded fans out over the grid; interleaved variants are 1-core, so
+        # only enumerate grids for the sharded path (avoid redundant duplicate rows).
+        layout_grids = grids if input_layout == "width_sharded" else [None]
+        for grid_xy in layout_grids:
+            label = "1core" if grid_xy is None else f"({grid_xy[0]},{grid_xy[1]})"
+            nc = 1 if grid_xy is None else grid_xy[0] * grid_xy[1]
+            rb = [n_q, n_kv, head_dim, qkv_w, input_layout, label, nc, out_layout, overlap]
+            inp = None
+            try:
+                out_mem = build_out_mem(out_layout, head_dim)
+                inp = build_fused_qkv(dev, input_layout, grid_xy, dtype, qkv_w)
+
+                def run():
+                    q, k, v = ttnn.experimental.nlp_create_qkv_heads_decode(
+                        inp,
+                        num_heads=n_q,
+                        num_kv_heads=n_kv,
+                        overlap_qk_coregrid=overlap,
+                        memory_config=out_mem,
+                    )
+                    ttnn.deallocate(k)
+                    ttnn.deallocate(v)
+                    return q
+
+                r = timed_run(dev, run, args.iters)
+            except Exception as e:
+                n_err += 1
+                msg = str(e).strip().split("\n")[0][:80] or type(e).__name__
+                log.row(rb + ["", "", "ERR", msg])
+                if inp is not None:
+                    try:
+                        inp.deallocate(True)
+                    except Exception:
+                        pass
+                continue
+            n_ok += 1
+            log.row(rb + [r["src"], f"{r['dur_ns']/1000:.2f}", "OK", ""])
+            print(
+                f"{input_layout:>17s} {label:>9s} {nc:4d} {out_layout:>18s} "
+                f"{str(overlap)[0]:>4s} {r['src']:>4s} {r['dur_ns']/1000:9.2f}"
+            )
+            try:
+                inp.deallocate(True)
+            except Exception:
+                pass
+            if best is None or r["dur_ns"] < best[0]:
+                best = (r["dur_ns"], input_layout, label, nc, out_layout, overlap, r["src"])
+
+    print(f"\n  [create_heads] OK={n_ok} ERR={n_err}")
+    if best:
+        d, il, label, nc, ol, overlap, src = best
+        print(f"  BEST: input={il} grid={label} ({nc}c) out={ol} overlap_qk={overlap} " f"-> {d/1000:.2f}us [{src}]")
+    ttnn.close_device(dev)
+
+
+if __name__ == "__main__":
+    main()

--- a/models/tt_transformers/tests/sweeps/sweep_llama_mm_v2.py
+++ b/models/tt_transformers/tests/sweeps/sweep_llama_mm_v2.py
@@ -1,0 +1,518 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Llama-3.1-8B decode matmul sweep v2 (Blackhole P150) — robust edition.
+
+Differences vs tt_llama_p150_matmul_sweep.py:
+  * Every candidate is built + measured inside its own try/except; the exact
+    exception text is recorded in the CSV `note` column (so FF2/QKV/WO/LMHEAD
+    failures are explained, not just "OOM/ERR").
+  * Tensors are (re)built per-config so a failure never poisons later configs.
+  * Two program-config factories are attempted per candidate:
+        - dram_sharded : MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig
+        - mcast_1d     : MatmulMultiCoreReuseMultiCast1DProgramConfig
+    (FF2's K=14336 shard often only builds under one of them.)
+  * PRIMARY metric = device kernel duration captured via the profiler
+    (ReadDeviceProfiler + get_latest_programs_perf_data), exactly like
+    tt_llama_p150_matmul_sweep.py. Host wall-clock is only a diagnostic
+    fallback: host-timed rows are marked src=host, status=HOST_ONLY and are
+    EXCLUDED from BEST ranking (unless --allow-host-rank). Run with the
+    profiler env vars below or every row will be host-only.
+
+  Required env for device-kernel capture (teja's methodology):
+    export TT_METAL_DEVICE_PROFILER=1 TT_METAL_PROFILER_MID_RUN_DUMP=1 \
+           TT_METAL_PROFILER_CPP_POST_PROCESS=1
+  * Expanded axes: --sweep-dtype/-fid/-packer/-fp32/-percoreN/-factory.
+
+Run (profiler build recommended):
+  export TT_METAL_HOME=$(pwd) PYTHONPATH=$(pwd) MESH_DEVICE=P150
+  python_env/bin/python models/tt_transformers/tests/sweeps/sweep_llama_mm_v2.py \
+      --shapes FF2 QKV WO LMHEAD --factory both --sweep-percoreN --csv sweep_v2.csv
+"""
+import argparse
+import csv
+import itertools
+import math
+import time
+
+import torch
+
+import ttnn
+
+DRAM_PEAK_GBPS = 512.0
+DRAM_ACHIEVABLE_GBPS = 377.0
+TILE_BYTES = {ttnn.bfloat8_b: 1088, ttnn.bfloat4_b: 576, ttnn.bfloat16: 2048, ttnn.float32: 4096}
+BYTES_PER_ELEM = {ttnn.bfloat8_b: 1.0625, ttnn.bfloat4_b: 0.5625, ttnn.bfloat16: 2.0}
+CYCLES_PER_TILE = {ttnn.MathFidelity.LoFi: 16, ttnn.MathFidelity.HiFi2: 32, ttnn.MathFidelity.HiFi4: 64}
+DEVICE_FREQ_HZ = 1350e6
+DRAM_ALIGN = 64
+L1_BUDGET_KB_DEFAULT = 1400
+
+SHAPES = {
+    "QKV": dict(M=32, K=4096, N=6144, dtype=ttnn.bfloat8_b, fid=ttnn.MathFidelity.HiFi2),
+    "WO": dict(M=32, K=4096, N=4096, dtype=ttnn.bfloat8_b, fid=ttnn.MathFidelity.HiFi2),
+    "FF1_FF3": dict(M=32, K=4096, N=14336, dtype=ttnn.bfloat4_b, fid=ttnn.MathFidelity.LoFi),
+    "FF2": dict(M=32, K=14336, N=4096, dtype=ttnn.bfloat8_b, fid=ttnn.MathFidelity.HiFi2),
+    "LMHEAD": dict(M=32, K=4096, N=16032, dtype=ttnn.bfloat8_b, fid=ttnn.MathFidelity.HiFi2),
+}
+
+
+def align_up(x, a):
+    return x if x % a == 0 else x + (a - x % a)
+
+
+def pad_to_dram_banks(n, num_banks):
+    lcm = 32 * num_banks
+    r = n % lcm
+    return n if r == 0 else n + (lcm - r)
+
+
+def grid_from_cores(nc, max_x=13, max_y=10):
+    for rows in range(1, max_y + 1):
+        if nc % rows == 0 and nc // rows <= max_x:
+            return (nc // rows, rows)
+    return None
+
+
+def find_largest_divisor(n, max_divisor=8):
+    for i in range(max_divisor, 0, -1):
+        if n % i == 0:
+            return i
+    return 1
+
+
+def all_divisors(n):
+    return [d for d in range(1, n + 1) if n % d == 0]
+
+
+def model_baseline_cores(K_tiles, N_tiles, max_cores=64):
+    cand = [c for c in range(1, max_cores + 1) if K_tiles % c == 0 and N_tiles % c == 0]
+    return max(cand) if cand else None
+
+
+def candidate_cores(K_tiles, N_tiles, cap=130, require_n_div=False):
+    """Core counts that divide K tiles (for in0 width-shard). Optionally also require
+    N divisibility (some factories need per_core_N exact)."""
+    out = []
+    for c in range(1, cap + 1):
+        if K_tiles % c != 0:
+            continue
+        if require_n_div and N_tiles % c != 0:
+            continue
+        if grid_from_cores(c):
+            out.append(c)
+    return out
+
+
+def estimate_l1_kb(
+    per_core_M, per_core_N, in0_block_w, K_tiles, in0_slice_tiles, in1_dtype, packer_l1_acc, fp32_dest, has_bias=False
+):
+    in0_tile = TILE_BYTES[ttnn.bfloat16]
+    in1_tile = align_up(TILE_BYTES[in1_dtype], DRAM_ALIGN)
+    out_tile = TILE_BYTES[ttnn.bfloat16]
+    num_blocks = max(1, K_tiles // max(1, in0_block_w))
+    double = num_blocks > 1
+    packer_en = packer_l1_acc and num_blocks > 1
+    if packer_en:
+        interm_tile = TILE_BYTES[ttnn.float32] if fp32_dest else TILE_BYTES[ttnn.bfloat16]
+    else:
+        interm_tile = TILE_BYTES[ttnn.float32] if fp32_dest else out_tile
+    pcn = per_core_N + 3
+    in0_CB = per_core_M * in0_block_w * in0_tile * (2 if double else 1)
+    in1_CB = pcn * in0_block_w * in1_tile * (3 if double else 1)
+    out_CB = per_core_M * pcn * out_tile
+    interm_CB = per_core_M * pcn * interm_tile
+    reshard_CB = per_core_M * pcn * out_tile
+    in2_CB = per_core_M * in0_slice_tiles * in0_tile
+    in3_CB = pcn * align_up(TILE_BYTES[in1_dtype], DRAM_ALIGN) if has_bias else 0
+    return (in0_CB + in1_CB + out_CB + interm_CB + reshard_CB + in2_CB + in3_CB) / 1024.0
+
+
+def build_in1(device, K, N, in1_dtype, num_banks):
+    N_padded = pad_to_dram_banks(N, num_banks)
+    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_banks - 1, 0))})
+    in1_spec = ttnn.ShardSpec(shard_grid, [K, N_padded // num_banks], ttnn.ShardOrientation.ROW_MAJOR)
+    in1_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, in1_spec)
+    in1 = torch.randn([1, 1, K, N]).bfloat16().float()
+    return ttnn.from_torch(in1, dtype=in1_dtype, layout=ttnn.TILE_LAYOUT, device=device, memory_config=in1_mem)
+
+
+def build_in1_interleaved(device, K, N, in1_dtype):
+    dram_il = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+    in1 = torch.randn([1, 1, K, N]).bfloat16().float()
+    return ttnn.from_torch(in1, dtype=in1_dtype, layout=ttnn.TILE_LAYOUT, device=device, memory_config=dram_il)
+
+
+def build_in0_sharded(device, M, K, num_cores, grid_xy):
+    K_tiles = K // 32
+    in0_slice_tiles = K_tiles // num_cores
+    dram_il = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+    in0 = torch.randn([1, 1, M, K]).bfloat16().float()
+    in0_t = ttnn.from_torch(in0, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=dram_il)
+    in0_t = ttnn.interleaved_to_sharded(
+        in0_t,
+        grid_xy,
+        [M, in0_slice_tiles * 32],
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    return in0_t, in0_slice_tiles
+
+
+def build_in0_dram(device, M, K):
+    dram_il = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+    in0 = torch.randn([1, 1, M, K]).bfloat16().float()
+    return ttnn.from_torch(in0, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=dram_il)
+
+
+def make_pc(factory, in0_block_w, M, per_core_N, grid_xy, K_tiles, num_cores):
+    if factory == "dram_sharded":
+        return ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(
+            in0_block_w=in0_block_w,
+            per_core_M=M // 32,
+            per_core_N=per_core_N,
+            fused_activation=None,
+        )
+    elif factory == "mcast_1d":
+        return ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=grid_xy,
+            in0_block_w=in0_block_w,
+            out_subblock_h=1,
+            out_subblock_w=find_largest_divisor(per_core_N, 4),
+            per_core_M=M // 32,
+            per_core_N=per_core_N,
+            fuse_batch=True,
+            fused_activation=None,
+            mcast_in0=True,
+        )
+    raise ValueError(f"unknown factory {factory}")
+
+
+def time_kernel_profiler(device):
+    try:
+        ttnn.ReadDeviceProfiler(device)
+        latest = ttnn.get_latest_programs_perf_data()
+    except Exception:
+        return None
+    if not latest:
+        return None
+    dev_id = device.get_device_ids()[0] if hasattr(device, "get_device_ids") else 0
+    progs = latest.get(dev_id) if latest else None
+    if not progs:
+        return None
+    dur_ns, cores = None, 0
+    for p in progs:
+        r = p.program_analyses_results.get("DEVICE KERNEL DURATION [ns]")
+        if r and r.duration is not None and (dur_ns is None or r.duration > dur_ns):
+            dur_ns, cores = r.duration, p.core_count
+    if not dur_ns:
+        return None
+    return dur_ns, cores
+
+
+def measure(
+    device,
+    factory,
+    in0_t,
+    in1_t,
+    out_mem,
+    M,
+    K,
+    N,
+    in1_dtype,
+    fidelity,
+    in0_block_w,
+    per_core_N,
+    grid_xy,
+    K_tiles,
+    num_cores,
+    packer,
+    fp32,
+    out_dtype,
+    iterations,
+):
+    pc = make_pc(factory, in0_block_w, M, per_core_N, grid_xy, K_tiles, num_cores)
+    ckc = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=fidelity,
+        math_approx_mode=True,
+        fp32_dest_acc_en=fp32,
+        packer_l1_acc=packer,
+    )
+    # warmup + profiler flush
+    out = ttnn.matmul(
+        in0_t, in1_t, program_config=pc, memory_config=out_mem, dtype=out_dtype, compute_kernel_config=ckc
+    )
+    ttnn.synchronize_device(device)
+    out.deallocate(True)
+    try:
+        ttnn.ReadDeviceProfiler(device)
+    except Exception:
+        pass
+
+    t0 = time.perf_counter()
+    for _ in range(iterations):
+        out = ttnn.matmul(
+            in0_t, in1_t, program_config=pc, memory_config=out_mem, dtype=out_dtype, compute_kernel_config=ckc
+        )
+        ttnn.synchronize_device(device)
+        out.deallocate(True)
+    host_ns = (time.perf_counter() - t0) * 1e9 / iterations
+
+    prof = time_kernel_profiler(device)
+    if prof:
+        dur_ns, cores = prof
+        src = "prof"
+    else:
+        dur_ns, cores = host_ns, num_cores
+        src = "host"
+
+    weight_bytes = K * N * BYTES_PER_ELEM[in1_dtype]
+    bw = weight_bytes / dur_ns
+    ideal = ((M // 32) * K_tiles * (N // 32) * CYCLES_PER_TILE[fidelity]) / max(cores, 1)
+    actual = dur_ns * 1e-9 * DEVICE_FREQ_HZ
+    util = 100.0 * ideal / actual if actual else 0.0
+    return dict(
+        dur_ns=dur_ns,
+        cores=cores,
+        bw_gbps=bw,
+        src=src,
+        dram_pct=100 * bw / DRAM_PEAK_GBPS,
+        ach_pct=100 * bw / DRAM_ACHIEVABLE_GBPS,
+        util=util,
+    )
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--shapes", nargs="*", default=list(SHAPES.keys()))
+    ap.add_argument("--iters", type=int, default=20)
+    ap.add_argument("--factory", choices=["dram_sharded", "mcast_1d", "both"], default="dram_sharded")
+    ap.add_argument("--sweep-dtype", action="store_true")
+    ap.add_argument("--sweep-fid", action="store_true")
+    ap.add_argument("--sweep-packer", action="store_true")
+    ap.add_argument("--sweep-fp32", action="store_true")
+    ap.add_argument("--sweep-percoreN", action="store_true", help="also try per_core_N multiples (pad N distribution)")
+    ap.add_argument("--sweep-outdtype", action="store_true", help="also sweep bf16 vs bf8 output")
+    ap.add_argument(
+        "--out-mems",
+        nargs="+",
+        default=["l1_ws"],
+        choices=["l1_ws", "l1_il", "dram_il"],
+        help="output memory configs: l1_ws=L1 width-sharded, l1_il=L1 interleaved, dram_il=DRAM interleaved",
+    )
+    ap.add_argument("--max-cores", type=int, default=130)
+    ap.add_argument("--max-in0-block-w", type=int, default=0)
+    ap.add_argument("--l1-budget", type=int, default=L1_BUDGET_KB_DEFAULT)
+    ap.add_argument("--no-l1-filter", action="store_true", help="skip analytic L1 prefilter; rely on try/except")
+    ap.add_argument("--csv", type=str, default="sweep_v2.csv")
+    args = ap.parse_args()
+
+    factories = ["dram_sharded", "mcast_1d"] if args.factory == "both" else [args.factory]
+
+    device = ttnn.open_device(device_id=0)
+    device.enable_program_cache()
+    num_banks = device.dram_grid_size().x
+
+    with open(args.csv, "w", newline="") as f:
+        csv.writer(f).writerow(
+            [
+                "shape",
+                "factory",
+                "M",
+                "K",
+                "N",
+                "num_cores",
+                "grid",
+                "in0_block_w",
+                "per_core_N",
+                "in1_dtype",
+                "out_dtype",
+                "out_mem",
+                "fidelity",
+                "packer_l1_acc",
+                "fp32_dest",
+                "l1_kb_est",
+                "src",
+                "dur_us",
+                "bw_gbps",
+                "dram_pct",
+                "ach_pct",
+                "util_pct",
+                "status",
+                "note",
+            ]
+        )
+
+    def row_out(row):
+        with open(args.csv, "a", newline="") as f:
+            csv.writer(f).writerow(row)
+
+    hdr = (
+        f"{'fac':>12s} {'nc':>4s} {'grid':>7s} {'bw':>5s} {'pcN':>4s} {'pk':>2s} {'f32':>3s} "
+        f"{'odt':>4s} {'L1KB':>6s} {'src':>4s} {'us':>8s} {'GB/s':>7s} {'ach%':>6s} {'note':>10s}"
+    )
+
+    try:
+        for sname in args.shapes:
+            base = SHAPES[sname]
+            M, K, N = base["M"], base["K"], base["N"]
+            K_tiles, N_tiles = K // 32, N // 32
+            baseline_nc = model_baseline_cores(K_tiles, N_tiles)
+            dtypes = [ttnn.bfloat8_b, ttnn.bfloat4_b] if args.sweep_dtype else [base["dtype"]]
+            fids = (
+                [ttnn.MathFidelity.LoFi, ttnn.MathFidelity.HiFi2, ttnn.MathFidelity.HiFi4]
+                if args.sweep_fid
+                else [base["fid"]]
+            )
+            packers = [True, False] if args.sweep_packer else [True]
+            fp32s = [True, False] if args.sweep_fp32 else [True]
+            out_dtypes = [ttnn.bfloat16, ttnn.bfloat8_b] if args.sweep_outdtype else [ttnn.bfloat16]
+
+            print(
+                f"\n===== {sname}  M={M} K={K} N={N}  (model baseline={baseline_nc}c, "
+                f"in0bw={find_largest_divisor(K_tiles // baseline_nc) if baseline_nc else '?'}) ====="
+            )
+            print(hdr)
+
+            n_ok = n_l1 = n_err = 0
+            best = None
+            cores_list = candidate_cores(K_tiles, N_tiles, args.max_cores)
+            out_mem_map = {
+                "l1_ws": ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1),
+                "l1_il": ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
+                "dram_il": ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+            }
+            for factory, in1_dtype, out_mem_name in itertools.product(factories, dtypes, args.out_mems):
+                out_mem = out_mem_map[out_mem_name]
+                for nc in cores_list:
+                    grid_xy = grid_from_cores(nc)
+                    in0_slice_tiles = K_tiles // nc
+                    base_pcN = math.ceil(N_tiles / nc)
+                    pcN_list = [base_pcN]
+                    if args.sweep_percoreN:
+                        for mult in (base_pcN + 1, base_pcN + 2):
+                            if mult not in pcN_list:
+                                pcN_list.append(mult)
+                    blk_cap = args.max_in0_block_w or in0_slice_tiles
+                    blk_cands = [b for b in all_divisors(in0_slice_tiles) if b <= blk_cap]
+                    for in0_block_w, per_core_N, fid, packer, fp32, odt in itertools.product(
+                        blk_cands, pcN_list, fids, packers, fp32s, out_dtypes
+                    ):
+                        l1_kb = estimate_l1_kb(
+                            M // 32, per_core_N, in0_block_w, K_tiles, in0_slice_tiles, in1_dtype, packer, fp32
+                        )
+                        rb = [
+                            sname,
+                            factory,
+                            M,
+                            K,
+                            N,
+                            nc,
+                            str(grid_xy),
+                            in0_block_w,
+                            per_core_N,
+                            str(in1_dtype).split(".")[-1],
+                            str(odt).split(".")[-1],
+                            out_mem_name,
+                            str(fid).split(".")[-1],
+                            packer,
+                            fp32,
+                            f"{l1_kb:.0f}",
+                        ]
+                        if (not args.no_l1_filter) and l1_kb > args.l1_budget:
+                            n_l1 += 1
+                            row_out(rb + ["", "", "", "", "", "", "SKIP_L1", ""])
+                            continue
+                        in0_t = in1_t = None
+                        try:
+                            if factory == "dram_sharded":
+                                in1_t = build_in1(device, K, N, in1_dtype, num_banks)
+                                in0_t, _ = build_in0_sharded(device, M, K, nc, grid_xy)
+                            else:  # mcast_1d
+                                in1_t = build_in1_interleaved(device, K, N, in1_dtype)
+                                in0_t, _ = build_in0_sharded(device, M, K, nc, grid_xy)
+                            r = measure(
+                                device,
+                                factory,
+                                in0_t,
+                                in1_t,
+                                out_mem,
+                                M,
+                                K,
+                                N,
+                                in1_dtype,
+                                fid,
+                                in0_block_w,
+                                per_core_N,
+                                grid_xy,
+                                K_tiles,
+                                nc,
+                                packer,
+                                fp32,
+                                odt,
+                                args.iters,
+                            )
+                        except Exception as e:
+                            n_err += 1
+                            msg = str(e).strip().split("\n")[0][:80] or type(e).__name__
+                            row_out(rb + ["", "", "", "", "", "", "ERR", msg])
+                            continue
+                        finally:
+                            for t in (in0_t, in1_t):
+                                try:
+                                    if t is not None:
+                                        t.deallocate(True)
+                                except Exception:
+                                    pass
+                        n_ok += 1
+                        row_out(
+                            rb
+                            + [
+                                r["src"],
+                                f"{r['dur_ns']/1000:.1f}",
+                                f"{r['bw_gbps']:.1f}",
+                                f"{r['dram_pct']:.1f}",
+                                f"{r['ach_pct']:.1f}",
+                                f"{r['util']:.1f}",
+                                "OK",
+                                "",
+                            ]
+                        )
+                        print(
+                            f"{factory:>12s} {nc:4d} {str(grid_xy):>7s} {in0_block_w:5d} {per_core_N:4d} "
+                            f"{'Y' if packer else 'N':>2s} {'Y' if fp32 else 'N':>3s} "
+                            f"{str(odt).split('.')[-1][:4]:>4s} {l1_kb:6.0f} {r['src']:>4s} "
+                            f"{r['dur_ns']/1000:8.1f} {r['bw_gbps']:7.1f} {r['ach_pct']:5.1f}%"
+                        )
+                        if best is None or r["dur_ns"] < best[0]:
+                            best = (
+                                r["dur_ns"],
+                                factory,
+                                nc,
+                                in0_block_w,
+                                per_core_N,
+                                fid,
+                                packer,
+                                fp32,
+                                in1_dtype,
+                                odt,
+                                r["bw_gbps"],
+                                r["ach_pct"],
+                                r["src"],
+                            )
+
+            print(f"  [{sname}] OK={n_ok} SKIP_L1={n_l1} ERR={n_err}")
+            if best:
+                (d, fac, nc, bw, pcN, fid, pk, f32, idt, odt, gbps, ach, src) = best
+                print(
+                    f"  BEST {sname}: {fac} {nc}c in0bw={bw} pcN={pcN} fid={str(fid).split('.')[-1]} "
+                    f"pk={pk} f32={f32} in1={str(idt).split('.')[-1]} out={str(odt).split('.')[-1]} "
+                    f"-> {d/1000:.1f}us {gbps:.0f}GB/s ({ach:.0f}% ach) [{src}]"
+                )
+        print(f"\nFull results -> {args.csv}")
+    finally:
+        ttnn.close_device(device)
+
+
+if __name__ == "__main__":
+    main()

--- a/models/tt_transformers/tests/sweeps/sweep_sdpa_decode.py
+++ b/models/tt_transformers/tests/sweeps/sweep_sdpa_decode.py
@@ -1,0 +1,278 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+SDPA-decode program-config sweep — generalized CLI tool (Blackhole P150).
+
+Give it the attention shape (--n-q-heads / --n-kv-heads / --head-dim, or a
+--preset) plus a KV/context length, and it sweeps:
+  - compute grid size (num cores)
+  - q_chunk_size / k_chunk_size
+  - exp_approx_mode (softmax exp approximation on/off)
+  - compute fidelity
+timing each on device and reporting the fastest.
+
+Problem it targets (Llama-3.1-8B decode tracy profile): SdpaDecodeDeviceOperation
+ran on 64 cores at ~10us avg; the model hard-codes
+compute_with_storage_grid_size=(8,8) and q_chunk=k_chunk=0 (auto).
+
+Ranked by device kernel duration (profiler). Every candidate is guarded by
+try/except and the failure reason is written to the CSV.
+
+Run with ALL THREE profiler env vars for device-kernel capture:
+  export TT_METAL_HOME=$(pwd) PYTHONPATH=$(pwd):$(pwd)/.auto MESH_DEVICE=P150
+  export TT_METAL_DEVICE_PROFILER=1 TT_METAL_PROFILER_MID_RUN_DUMP=1 TT_METAL_PROFILER_CPP_POST_PROCESS=1
+
+Examples
+  # Llama-3.1-8B (default), context 1024, full sweep
+  python models/tt_transformers/tests/sweeps/sweep_sdpa_decode.py --kv-len 1024 --sweep-chunks --sweep-fid --csv sweep_sdpa.csv
+
+  # Llama-3.2-1B preset, longer context
+  python models/tt_transformers/tests/sweeps/sweep_sdpa_decode.py --preset llama3-1b --kv-len 4096 --csv sdpa_1b.csv
+
+  # arbitrary GQA shape
+  python models/tt_transformers/tests/sweeps/sweep_sdpa_decode.py --n-q-heads 28 --n-kv-heads 4 --head-dim 128 --kv-len 2048
+"""
+import argparse
+import itertools
+import os
+import sys
+
+import torch
+
+import ttnn
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from sweep_common import CSVLog, open_dev, timed_run
+
+# Preset attention shapes: (n_q_heads, n_kv_heads, head_dim)
+PRESETS = {
+    "llama3-8b": (32, 8, 128),
+    "llama3-70b": (64, 8, 128),
+    "llama3-1b": (32, 8, 64),
+    "llama3-3b": (24, 8, 128),
+    "mistral-7b": (32, 8, 128),
+    "qwen2-7b": (28, 4, 128),
+}
+
+
+# KV-cache buffer types to sweep. DRAM is the normal residence for a decode KV
+# cache; L1 is included to measure the ceiling if the cache fit on-chip.
+KV_MEMCFGS = {"dram": ttnn.DRAM_MEMORY_CONFIG, "l1": ttnn.L1_MEMORY_CONFIG}
+OUT_MEMCFGS = {"dram": ttnn.DRAM_MEMORY_CONFIG, "l1": ttnn.L1_MEMORY_CONFIG}
+
+
+def build_kv(device, n_kv, kv_len, head_dim, dtype, memcfg):
+    """KV cache [B=32, n_kv, kv_len, head_dim] in the requested buffer type.
+
+    Non-paged decode SDPA expects batch in dim 0 equal to B (=32). (TT_FATAL:
+    k_shape[0] == B.)
+    """
+    k = torch.randn(32, n_kv, kv_len, head_dim).bfloat16().float()
+    v = torch.randn(32, n_kv, kv_len, head_dim).bfloat16().float()
+    kt = ttnn.from_torch(k, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, memory_config=memcfg)
+    vt = ttnn.from_torch(v, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, memory_config=memcfg)
+    return kt, vt
+
+
+def build_q(device, n_q, head_dim, dtype):
+    """Decode query [1, batch(32), n_q_heads, head_dim].
+
+    SDPA-decode expects Q as [1, B, n_q_heads, D] with D == K/V head_dim (128),
+    NOT a flattened [1,1,32,n_q*head_dim]. (TT_FATAL: k_shape[-1] == D.)
+    """
+    q = torch.randn(1, 32, n_q, head_dim).bfloat16().float()
+    return ttnn.from_torch(
+        q, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+
+def grid_candidates(max_x=8, max_y=8):
+    grids = []
+    for y in range(1, max_y + 1):
+        for x in range(1, max_x + 1):
+            if x * y >= 8:  # skip trivially tiny grids
+                grids.append((x, y))
+    # de-dup by core count keeping a few shapes; keep all — cheap
+    return grids
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Generalized SDPA-decode program-config sweep")
+    ap.add_argument(
+        "--preset",
+        choices=list(PRESETS.keys()),
+        default=None,
+        help="attention shape preset (overridden by explicit --n-q-heads etc.)",
+    )
+    ap.add_argument("--n-q-heads", type=int, default=None, help="number of query heads")
+    ap.add_argument("--n-kv-heads", type=int, default=None, help="number of KV heads (GQA)")
+    ap.add_argument("--head-dim", type=int, default=None, help="per-head dimension")
+    ap.add_argument("--kv-len", type=int, default=1024, help="KV/context length for decode SDPA")
+    ap.add_argument("--iters", type=int, default=30)
+    ap.add_argument("--sweep-chunks", action="store_true", help="also sweep q/k chunk sizes")
+    ap.add_argument("--sweep-exp", action="store_true", help="also sweep exp_approx_mode on/off")
+    ap.add_argument("--sweep-fid", action="store_true", help="also sweep LoFi/HiFi2/HiFi4")
+    ap.add_argument("--kv-dtype", choices=["bf8", "bf16"], default="bf8")
+    ap.add_argument(
+        "--kv-memcfgs",
+        nargs="+",
+        default=["dram"],
+        choices=list(KV_MEMCFGS.keys()),
+        help="KV-cache buffer types to sweep (dram/l1)",
+    )
+    ap.add_argument(
+        "--out-memcfgs",
+        nargs="+",
+        default=["dram"],
+        choices=list(OUT_MEMCFGS.keys()),
+        help="output buffer types to sweep (dram/l1)",
+    )
+    ap.add_argument("--csv", type=str, default="sweep_sdpa.csv")
+    args = ap.parse_args()
+
+    # Resolve shape: preset supplies defaults, explicit flags override individually.
+    pq, pk, ph = PRESETS.get(args.preset or "llama3-8b")
+    n_q = args.n_q_heads if args.n_q_heads is not None else pq
+    n_kv = args.n_kv_heads if args.n_kv_heads is not None else pk
+    head_dim = args.head_dim if args.head_dim is not None else ph
+
+    kv_dtype = ttnn.bfloat8_b if args.kv_dtype == "bf8" else ttnn.bfloat16
+    dev = open_dev()
+
+    log = CSVLog(
+        args.csv,
+        [
+            "n_q",
+            "n_kv",
+            "head_dim",
+            "grid",
+            "num_cores",
+            "q_chunk",
+            "k_chunk",
+            "exp_approx",
+            "fidelity",
+            "kv_len",
+            "kv_mem",
+            "out_mem",
+            "src",
+            "dur_us",
+            "status",
+            "note",
+        ],
+    )
+    hdr = (
+        f"{'grid':>7s} {'nc':>4s} {'qch':>5s} {'kch':>5s} {'exp':>4s} {'fid':>6s} "
+        f"{'kvm':>4s} {'om':>4s} {'src':>4s} {'us':>9s}"
+    )
+    print(f"\n===== SDPA-decode  n_q={n_q} n_kv={n_kv} hd={head_dim} kv_len={args.kv_len} =====")
+    print(hdr)
+
+    chunks = [(0, 0)]
+    if args.sweep_chunks:
+        chunks += [(32, 32), (64, 64), (128, 128), (0, 128), (0, 256), (0, 512)]
+    exps = [False, True] if args.sweep_exp else [False]
+    fids = (
+        [ttnn.MathFidelity.LoFi, ttnn.MathFidelity.HiFi2, ttnn.MathFidelity.HiFi4]
+        if args.sweep_fid
+        else [ttnn.MathFidelity.HiFi2]
+    )
+
+    qt = build_q(dev, n_q, head_dim, ttnn.bfloat16)
+    cur_pos = ttnn.from_torch(
+        torch.tensor([args.kv_len - 1] * 32, dtype=torch.int32), device=dev, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    best = None
+    n_ok = n_err = 0
+    # KV tensors depend only on the buffer type, so build them once per kv_mem
+    # (outer loop) and reuse across the program-config sweep to save rebuilds.
+    for kv_mem in args.kv_memcfgs:
+        kt = vt = None
+        try:
+            kt, vt = build_kv(dev, n_kv, args.kv_len, head_dim, kv_dtype, KV_MEMCFGS[kv_mem])
+        except Exception as e:
+            msg = str(e).strip().split("\n")[0][:80] or type(e).__name__
+            print(f"  (skip kv_mem={kv_mem}: {msg})")
+            for t in (kt, vt):
+                try:
+                    if t is not None:
+                        t.deallocate(True)
+                except Exception:
+                    pass
+            continue
+        for (gx, gy), (qch, kch), exp_approx, fid, out_mem in itertools.product(
+            grid_candidates(), chunks, exps, fids, args.out_memcfgs
+        ):
+            pc = ttnn.SDPAProgramConfig(
+                compute_with_storage_grid_size=(gx, gy),
+                exp_approx_mode=exp_approx,
+                q_chunk_size=qch,
+                k_chunk_size=kch,
+            )
+            ckc = ttnn.init_device_compute_kernel_config(
+                dev.arch(),
+                math_fidelity=fid,
+                math_approx_mode=True,
+                fp32_dest_acc_en=False,
+                packer_l1_acc=False,
+            )
+
+            def run():
+                return ttnn.transformer.scaled_dot_product_attention_decode(
+                    qt,
+                    kt,
+                    vt,
+                    cur_pos_tensor=cur_pos,
+                    program_config=pc,
+                    compute_kernel_config=ckc,
+                    memory_config=OUT_MEMCFGS[out_mem],
+                )
+
+            rb = [
+                n_q,
+                n_kv,
+                head_dim,
+                f"({gx},{gy})",
+                gx * gy,
+                qch,
+                kch,
+                exp_approx,
+                str(fid).split(".")[-1],
+                args.kv_len,
+                kv_mem,
+                out_mem,
+            ]
+            try:
+                r = timed_run(dev, run, args.iters)
+            except Exception as e:
+                n_err += 1
+                msg = str(e).strip().split("\n")[0][:80] or type(e).__name__
+                log.row(rb + ["", "", "ERR", msg])
+                continue
+            n_ok += 1
+            log.row(rb + [r["src"], f"{r['dur_ns']/1000:.2f}", "OK", ""])
+            print(
+                f"({gx},{gy}){'':>2s} {gx*gy:4d} {qch:5d} {kch:5d} {str(exp_approx)[0]:>4s} "
+                f"{str(fid).split('.')[-1]:>6s} {kv_mem:>4s} {out_mem:>4s} {r['src']:>4s} {r['dur_ns']/1000:9.2f}"
+            )
+            if best is None or r["dur_ns"] < best[0]:
+                best = (r["dur_ns"], gx, gy, qch, kch, exp_approx, fid, kv_mem, out_mem, r["src"])
+        for t in (kt, vt):
+            try:
+                if t is not None:
+                    t.deallocate(True)
+            except Exception:
+                pass
+
+    print(f"\n  [SDPA] OK={n_ok} ERR={n_err}")
+    if best:
+        d, gx, gy, qch, kch, exp_approx, fid, kv_mem, out_mem, src = best
+        print(
+            f"  BEST: grid=({gx},{gy})={gx*gy}c q_chunk={qch} k_chunk={kch} "
+            f"exp_approx={exp_approx} fid={str(fid).split('.')[-1]} kv_mem={kv_mem} out_mem={out_mem} "
+            f"-> {d/1000:.2f}us [{src}]"
+        )
+    ttnn.close_device(dev)
+
+
+if __name__ == "__main__":
+    main()

--- a/models/tt_transformers/tt/attention.py
+++ b/models/tt_transformers/tt/attention.py
@@ -635,8 +635,16 @@ class Attention(LightweightModule):
         else:
             # bfloat16 is required by nlp_create_qkv_heads_decode
             if self.prefetcher is None:
-                xqkv_fused = ttnn.sharded_to_interleaved(xqkv_fused_sharded, ttnn.L1_MEMORY_CONFIG, ttnn.bfloat16)
-                ttnn.deallocate(xqkv_fused_sharded)
+                # EXPERIMENT (single P150): the old sharded_to_interleaved collapsed the
+                # fused-QKV to an interleaved L1 tensor, which made nlp_create_qkv_heads_decode
+                # run on 1 core (~17.5us). Keep it width-sharded (32c from the QKV matmul)
+                # so create-heads parallelizes (~7.9us in isolation). Pure data-shuffle -> lossless.
+                # nlp_create_qkv_heads_decode requires bf16 input, so cast in place if needed.
+                if xqkv_fused_sharded.dtype != ttnn.bfloat16:
+                    xqkv_fused = ttnn.typecast(xqkv_fused_sharded, ttnn.bfloat16)
+                    ttnn.deallocate(xqkv_fused_sharded)
+                else:
+                    xqkv_fused = xqkv_fused_sharded
             else:
                 xqkv_fused = xqkv_fused_sharded
         # Reshape such that true unpadded batch is tracked in shape

--- a/models/tt_transformers/tt/lm_head.py
+++ b/models/tt_transformers/tt/lm_head.py
@@ -10,6 +10,7 @@ import ttnn
 from models.common.lightweightmodule import LightweightModule
 from models.tt_transformers.tt.ccl import tt_all_reduce
 from models.tt_transformers.tt.common import Mode
+from models.tt_transformers.tt.model_config import MathFidelitySetting, OpGroup
 
 
 class LMHead(LightweightModule):
@@ -132,12 +133,26 @@ class LMHead(LightweightModule):
                         )
                     )
 
-        self.compute_kernel_config = ttnn.WormholeComputeKernelConfig(
-            math_fidelity=ttnn.MathFidelity.HiFi2,
-            math_approx_mode=False,
-            fp32_dest_acc_en=False,
-            packer_l1_acc=True,
+        # LM-head compute fidelity is config-driven via the LI_LM_HEAD OpGroup.
+        # The config's HiFi2 kernel (math_approx_mode=True, fp32_dest_acc_en=True) differs
+        # from the LM-head's original hardcoded HiFi2 (both False), so only take the
+        # config value when it actually differs from the default HiFi2 setting (i.e. the
+        # performance-mode LoFi override). Otherwise preserve the exact original config to
+        # avoid silently changing accuracy/default behavior for all other models.
+        lm_head_fidelity = args.decoders_optimizations.decoder_optimizations[0].op_fidelity_settings.get(
+            OpGroup.LI_LM_HEAD, MathFidelitySetting.HIFI2
         )
+        if lm_head_fidelity == MathFidelitySetting.HIFI2:
+            self.compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+                math_fidelity=ttnn.MathFidelity.HiFi2,
+                math_approx_mode=False,
+                fp32_dest_acc_en=False,
+                packer_l1_acc=True,
+            )
+        else:
+            self.compute_kernel_config = args.decoders_optimizations.get_math_fidelity(
+                decoder_id=0, op=OpGroup.LI_LM_HEAD, configuration=args
+            )
 
     def forward(self, x: ttnn.Tensor, debug_input_torch=None, debug_weight_torch=None):
         outputs = []

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -93,6 +93,7 @@ class OpGroup(Enum):
     LI_QKV_PREFILL = "li_qkv_prefill"
     LI_O_PREFILL = "li_o_prefill"
     SDPA_PREFILL = "sdpa_prefill"
+    LI_LM_HEAD = "li_lm_head"  # final vocab projection (logits), runs every decode token
     ACCURACY = "accuracy"  # This is a special group for accuracy mode, not an actual operator group
 
 
@@ -225,7 +226,18 @@ class ModelOptimizations:
         else:
             settings = {
                 "TensorPrecision": {TensorGroup.FF1_FF3: PrecisionSetting.BFP4},
-                "OpFidelity": {OpGroup.LI_FF1_FF3: MathFidelitySetting.LOFI},
+                # EXPERIMENT (single P150): keep FF2 weights BFP8 but drop compute fidelity
+                # HiFi2_FP16 -> LoFi (fewer math cycles, mantissa bits preserved). Gated by PCC.
+                # exp6: also drop QKV-decode and O-decode fidelity HiFi2 -> LoFi.
+                # exp9: LM-head vocab matmul HiFi2 -> LoFi (config-driven, replaces the old
+                # hardcoded HiFi2 in lm_head.py).
+                "OpFidelity": {
+                    OpGroup.LI_FF1_FF3: MathFidelitySetting.LOFI,
+                    OpGroup.LI_FF2: MathFidelitySetting.LOFI,
+                    OpGroup.LI_QKV_DECODE: MathFidelitySetting.LOFI,
+                    OpGroup.LI_O_DECODE: MathFidelitySetting.LOFI,
+                    OpGroup.LI_LM_HEAD: MathFidelitySetting.LOFI,
+                },
             }
             if model_name.startswith("Phi-3-mini"):  # TODO: Only do this for N150
                 logger.info(
@@ -313,6 +325,8 @@ class ModelOptimizations:
                 OpGroup.LI_QKV_PREFILL: MathFidelitySetting.HIFI2,
                 OpGroup.SDPA_PREFILL: MathFidelitySetting.HIFI4,
                 OpGroup.LI_O_PREFILL: MathFidelitySetting.HIFI2,  # FP32 accumulate is important here
+                # LM head: default HiFi2 preserves prior hardcoded lm_head.py behavior
+                OpGroup.LI_LM_HEAD: MathFidelitySetting.HIFI2,
                 OpGroup.ACCURACY: MathFidelitySetting.HIFI4_FP32,
             },
         }
@@ -767,6 +781,12 @@ class ModelArgs:
             self.mlp_core_grid = (
                 self.dram_shard_core_grid_for_k(self.dim)
                 if self.is_galaxy
+                # SWEEP-TUNED (single P150): FF1/FF3 K=4096. Default k_and_n heuristic picks
+                # 64c -> in0_block_w collapses to 2 tiles -> 187 GB/s. Forcing 32c (8x4) makes
+                # find_largest_divisor(128/32)=4 -> ~292 GB/s (1.56x) while fitting L1 (16c
+                # would give in0bw=8/306 GB/s but overflows L1 with full-model residents).
+                else ttnn.CoreGrid(x=8, y=4)
+                if self.num_devices == 1
                 else self.dram_shard_core_grid_for_k_and_n(self.dim, self.hidden_dim // self.num_devices)
             )
 
@@ -1072,7 +1092,8 @@ class ModelArgs:
                 "rs_memory_config": ttnn.DRAM_MEMORY_CONFIG,
             }
             default_sampling_force_argmax = {
-                "allow_force_argmax": False,
+                # Single-chip only: argmax fast-path speeds up greedy decode on P150 (PR #48886)
+                "allow_force_argmax": self.num_devices == 1,
                 "num_links": 1,
                 "chunks_per_sync": 10,
                 "num_workers_per_link": 2,


### PR DESCRIPTION
## Performance

Single-P150 Llama-3.1-8B batch-1 decode.

| Change | tok/s/u |
|--------|---------|
| Baseline | 40.2 |
| create-heads: keep QKV width-sharded (lossless) | 40.8 |
| FF2 fidelity HiFi2 → LoFi | 45.4 |
| QKV-decode + O-decode fidelity → LoFi | 49.7 |
| LM-head fidelity → LoFi | **51.5** |

**Result: 40.2 → 51.5 tok/s/u (+28%).** Accuracy gated at each step (PCC ≥ 0.86; token-accuracy top-1 91.6% vs 90.8% baseline).

## Running perf and tracy

Environment:
```bash
cd <repo>; export TT_METAL_HOME=$(pwd) PYTHONPATH=$(pwd) MESH_DEVICE=P150 \
  HF_MODEL=meta-llama/Llama-3.1-8B-Instruct HF_HUB_OFFLINE=1
source python_env/bin/activate
```

Perf (tok/s/u):
```bash
pytest "models/tt_transformers/demo/simple_text_demo.py::test_demo_text" \
  -k "performance-batch-1" --timeout 0
```

Tracy device profile (all layers, 2 decode tokens):
```bash
python -m tracy -r --op-support-count 40000 -o profile_out -m pytest \
  "models/tt_transformers/demo/simple_text_demo.py::test_demo_text" \
  -k "performance-batch-1" --max_generated_tokens 2 --disable_trace --timeout 0
```
`--op-support-count 40000` avoids profiler DRAM-buffer overflow with trace disabled.

## Sweeps

Program-config sweep tools in `models/tt_transformers/tests/sweeps/`. Each ranks configs by device kernel time, writes a per-config CSV, and prints the best.

```bash
# create-QKV-heads: grid, overlap, memory layout
python models/tt_transformers/tests/sweeps/sweep_create_heads.py --csv ch.csv

# SDPA-decode: grid, chunks, exp_approx, fidelity, KV/out buffers
python models/tt_transformers/tests/sweeps/sweep_sdpa_decode.py --kv-len 1024 --sweep-chunks --sweep-fid --csv sdpa.csv

# decode matmuls: grid, blocks, factory, fidelity, dtype, out memcfg
python models/tt_transformers/tests/sweeps/sweep_llama_mm_v2.py --shapes FF2 QKV WO --csv mm.csv

# general GEMM, arbitrary M/K/N with PCC check
python models/tt_transformers/tests/sweeps/matmul_sweep.py --M 32 --K 4096 --N 14336
```

Shapes are CLI args with `--preset` shortcuts (llama3-8b/70b/1b/3b, mistral-7b, qwen2-7b). See `models/tt_transformers/tests/sweeps/README.md` for details and required profiler env vars.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llama_p150_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llama_p150_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llama_p150_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llama_p150_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=llama_p150_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:llama_p150_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llama_p150_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llama_p150_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llama_p150_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llama_p150_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llama_p150_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llama_p150_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llama_p150_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llama_p150_optimization)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llama_p150_optimization)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llama_p150_optimization)