### PR TITLE
Fix SD->FD->SD toggle segfault on mock/emulated devices

### DIFF
--- a/tests/tt_metal/distributed/test_dispatch_context.cpp
+++ b/tests/tt_metal/distributed/test_dispatch_context.cpp
@@ -41,6 +41,10 @@ TEST_F(DispatchContextFixture, TestWritesAndWorkloads) {
     if (rt_options.get_fast_dispatch()) {
         GTEST_SKIP() << "This test can only be run with Slow Dispatch mode.";
     }
+    if (MetalContext::instance().get_cluster().is_mock_or_emulated()) {
+        GTEST_SKIP() << "Mock/emulated devices cannot validate real data movement; see "
+                        "MockDeviceFdSdToggleIsNoOp for the mock-specific no-op behavior.";
+    }
     const MeshShape system_shape = MetalContext::instance().get_system_mesh().shape();
     auto mesh_device_ = MeshDevice::create(MeshDeviceConfig(system_shape));
 
@@ -98,6 +102,27 @@ TEST_F(DispatchContextFixture, TestWritesAndWorkloads) {
     }
 }
 
+// Regression test for https://github.com/tenstorrent/tt-metal/issues/50634:
+// A SD->FD->SD toggle must be a safe no-op on mock/emulated devices. These targets never create
+// hardware command queues, so the FD teardown previously dereferenced an empty command-queue vector
+// and segfaulted. Verify the round-trip completes and the device remains usable.
+TEST_F(DispatchContextFixture, MockDeviceFdSdToggleIsNoOp) {
+    const auto& rt_options = MetalContext::instance().rtoptions();
+    if (rt_options.get_fast_dispatch()) {
+        GTEST_SKIP() << "This test can only be run with Slow Dispatch mode.";
+    }
+    if (!MetalContext::instance().get_cluster().is_mock_or_emulated()) {
+        GTEST_SKIP() << "This test only applies to mock/emulated devices.";
+    }
+    const MeshShape system_shape = MetalContext::instance().get_system_mesh().shape();
+    auto mesh_device_ = MeshDevice::create(MeshDeviceConfig(system_shape));
+
+    // SD -> FD -> SD toggle should not crash and should leave the device usable.
+    experimental::DispatchContext::get().initialize_fast_dispatch(mesh_device_.get());
+    experimental::DispatchContext::get().terminate_fast_dispatch(mesh_device_.get());
+    Finish(mesh_device_->mesh_command_queue());
+}
+
 TEST(DispatchContext, DoubleInitWithoutTerminateShouldThrow) {
     const auto& rt_options = MetalContext::instance().rtoptions();
     if (rt_options.get_fast_dispatch()) {
@@ -107,6 +132,10 @@ TEST(DispatchContext, DoubleInitWithoutTerminateShouldThrow) {
     auto mesh_device_ = MeshDevice::create(MeshDeviceConfig(system_shape));
 
     const auto& cluster = MetalContext::instance().get_cluster();
+    if (cluster.is_mock_or_emulated()) {
+        GTEST_SKIP() << "FD/SD toggle is a no-op on mock/emulated devices; the throw invariants do not apply. See "
+                        "MockDeviceFdSdToggleIsNoOp.";
+    }
     if (!cluster.is_ubb_galaxy() && cluster.arch() != tt::ARCH::BLACKHOLE) {
         GTEST_SKIP()
             << "Manually setting up and tearing down Fast Dispatch is only supported on Galaxy and Blackhole clusters.";
@@ -132,6 +161,10 @@ TEST_F(DispatchContextFixture, RepeatedFdSdTransitionStress) {
     auto mesh_device_ = MeshDevice::create(MeshDeviceConfig(system_shape));
 
     const auto& cluster = MetalContext::instance().get_cluster();
+    if (cluster.is_mock_or_emulated()) {
+        GTEST_SKIP() << "Mock/emulated devices cannot validate real data movement; see "
+                        "MockDeviceFdSdToggleIsNoOp for the mock-specific no-op behavior.";
+    }
     if (!cluster.is_ubb_galaxy() && cluster.arch() != tt::ARCH::BLACKHOLE) {
         GTEST_SKIP()
             << "Manually setting up and tearing down Fast Dispatch is only supported on Galaxy and Blackhole clusters.";

--- a/tt_metal/distributed/dispatch_context.cpp
+++ b/tt_metal/distributed/dispatch_context.cpp
@@ -51,8 +51,18 @@ void DispatchContext::initialize_fast_dispatch(distributed::MeshDevice* mesh_dev
     }
 
     ContextId context_id = extract_context_id(mesh_device);
-    fast_dispatch_enabled_ = MetalContext::instance(context_id).rtoptions().get_fast_dispatch();
     const auto& cluster = MetalContext::instance(context_id).get_cluster();
+
+    // Mock/emulated devices skip firmware/dispatch entirely, so there is no real hardware to
+    // toggle between Slow and Fast Dispatch. Treat the transition as a no-op to avoid touching
+    // dispatch cores/command queues that are never created for these targets (init_command_queue_host
+    // leaves command_queues_ empty on mock/emulated), which otherwise segfaults on teardown.
+    // See https://github.com/tenstorrent/tt-metal/issues/50634.
+    if (cluster.is_mock_or_emulated()) {
+        return;
+    }
+
+    fast_dispatch_enabled_ = MetalContext::instance(context_id).rtoptions().get_fast_dispatch();
     TT_FATAL(
         !fast_dispatch_enabled_,
         "Fast Dispatch can only be manually enabled when running the workload with Slow Dispatch mode.");
@@ -118,10 +128,18 @@ void DispatchContext::terminate_fast_dispatch(distributed::MeshDevice* mesh_devi
         return;
     }
 
+    ContextId context_id = extract_context_id(mesh_device);
+    const auto& cluster = MetalContext::instance(context_id).get_cluster();
+
+    // Mirror initialize_fast_dispatch: the FD/SD toggle is a no-op on mock/emulated targets, so
+    // there is nothing to tear down. See https://github.com/tenstorrent/tt-metal/issues/50634.
+    if (cluster.is_mock_or_emulated()) {
+        return;
+    }
+
     TT_FATAL(fast_dispatch_enabled_, "Can only manually terminate fast dispatch after initializing it.");
     TT_FATAL(num_fd_inits_ == 1, "Fast Dispatch termination requires exactly one active manual Fast Dispatch session.");
 
-    ContextId context_id = extract_context_id(mesh_device);
     const auto& device_manager = MetalContext::instance(context_id).device_manager();
     const auto& active_devices = device_manager->get_all_active_devices_impl();
 


### PR DESCRIPTION
## Summary

`DispatchContext::initialize_fast_dispatch` / `terminate_fast_dispatch` drove real dispatch hardware unconditionally. On mock/emulated targets, `init_command_queue_host()` returns early and leaves `command_queues_` empty, so `terminate_fast_dispatch` dereferenced an empty command-queue vector (`command_queues_[cq_id]`) and segfaulted.

Repro (run with `TT_METAL_SLOW_DISPATCH_MODE=1 TT_METAL_MOCK_CLUSTER_DESC_PATH=...`):

    mesh_device = ttnn.open_mesh_device(ttnn.MeshShape(1, 1))
    try:
        with ttnn.device.setup_fast_dispatch(mesh_device):
            pass
        ttnn.synchronize_device(mesh_device)
    finally:
        ttnn.close_mesh_device(mesh_device)

## Changes

- Guard both `initialize_fast_dispatch` and `terminate_fast_dispatch` with `cluster.is_mock_or_emulated()` and treat the FD/SD transition as a no-op on these targets. This matches how the rest of the stack (device init, program dispatch, sysmem, sockets, fabric, etc.) already skips firmware/dispatch for mock/emulated devices.
- Add `MockDeviceFdSdToggleIsNoOp` regression test reproducing the issue.
- Make the existing real-hardware `DispatchContext` tests (`TestWritesAndWorkloads`, `RepeatedFdSdTransitionStress`, `DoubleInitWithoutTerminateShouldThrow`) skip on mock/emulated — a mock Blackhole otherwise slips past their `arch() == BLACKHOLE` guard.

## Test plan

- [x] New regression test `MockDeviceFdSdToggleIsNoOp` passes on mock (Blackhole P100 descriptor, slow dispatch).
- [x] Verified that without the fix the same test segfaults (exit 139) inside `terminate_fast_dispatch`; with the fix it is a clean no-op.
- [x] `DispatchContext` suite on mock: 2 passed, 3 appropriately skipped, 0 failed.
- [x] `MetalEnv.*` (18), `MetalContextTest.*` (12), `MetalContextIntegrationTest.*` (8 + 1 skip), `MetalEnvMockCCL.*` (3), `MockDeviceAPIFixture.*` (9), `MockAllocatorTest.*` (5): all pass.
- [x] Canonical mock suite (`run_mock_device_tests.sh`): `DevicePool` and `MeshDispatchFixture` unaffected. The only 2 red tests (`DataflowCb`, `DataflowDfb`) are pre-existing and unrelated — verified failing identically on clean `main` (they compare buffer readback that mock stubs to zeros; neither references `DispatchContext`).

Fixes #50634

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-sd-fd-sd-mock-segfault)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:msudumbrekar/fix-sd-fd-sd-mock-segfault)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-sd-fd-sd-mock-segfault)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:msudumbrekar/fix-sd-fd-sd-mock-segfault)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-sd-fd-sd-mock-segfault)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:msudumbrekar/fix-sd-fd-sd-mock-segfault)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=msudumbrekar/fix-sd-fd-sd-mock-segfault)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:msudumbrekar/fix-sd-fd-sd-mock-segfault)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=msudumbrekar/fix-sd-fd-sd-mock-segfault)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:msudumbrekar/fix-sd-fd-sd-mock-segfault)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=msudumbrekar/fix-sd-fd-sd-mock-segfault)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:msudumbrekar/fix-sd-fd-sd-mock-segfault)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=msudumbrekar/fix-sd-fd-sd-mock-segfault)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:msudumbrekar/fix-sd-fd-sd-mock-segfault)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=msudumbrekar/fix-sd-fd-sd-mock-segfault)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:msudumbrekar/fix-sd-fd-sd-mock-segfault)