### PR TITLE
Feature: Support tensor prefetcher with mcast-in0 matmul

### DIFF
--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_tensor_large.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_tensor_large.py
@@ -951,3 +951,120 @@ def test_tensor_prefetcher_streaming_matmul(
     passing, output_str = comp_pcc(expected, out_torch, pcc_threshold)
     logger.info(f"[{name} win={window_blocks} {distribution_strategy}] {output_str}")
     assert passing, f"[{name} win={window_blocks} {distribution_strategy}] PCC check failed: {output_str}"
+
+
+@pytest.mark.parametrize(
+    "distribution_strategy",
+    [ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D, ttnn.ShardDistributionStrategy.CONTIGUOUS_1D],
+    ids=["strided", "contiguous"],
+)
+def test_tensor_prefetcher_streaming_mcast_in0(device, distribution_strategy):
+    """Mcast-in0 consumes receiver-contiguous in1 K-blocks in natural FIFO order."""
+    num_dram_banks = device.dram_grid_size().x
+    recv_per_bank = 2
+    receiver_count = num_dram_banks * recv_per_bank
+    ring_cols = num_dram_banks
+    ring_rows = recv_per_bank
+    receiver_cores = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(ring_cols - 1, ring_rows - 1))}
+    )
+
+    dtype = ttnn.bfloat16
+    M = ttnn.TILE_SIZE
+    k_tiles = 2 * receiver_count
+    K = k_tiles * ttnn.TILE_SIZE
+    N = receiver_count * ttnn.TILE_SIZE
+    in0_block_w = 1
+    block_count = k_tiles // in0_block_w
+    assert block_count != receiver_count
+
+    torch.manual_seed(zlib.crc32(f"streaming_mcast_in0_{distribution_strategy}".encode()))
+    pt_weight = torch.randn(1, 1, K, N)
+    tt_weight = _make_recv_contig_weight(
+        device,
+        pt_weight,
+        num_dram_banks=num_dram_banks,
+        ring_size=receiver_count,
+        dtype=dtype,
+        distribution_strategy=distribution_strategy,
+    )
+
+    pt_act = torch.randn(1, 1, M, K)
+    act_mem_config = ttnn.create_sharded_memory_config(
+        shape=(M, K // receiver_count),
+        core_grid=receiver_cores,
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+    tt_act = ttnn.from_torch(pt_act, device=device, dtype=dtype, layout=ttnn.TILE_LAYOUT, memory_config=act_mem_config)
+
+    program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=(ring_cols, ring_rows),
+        in0_block_w=in0_block_w,
+        out_subblock_h=1,
+        out_subblock_w=1,
+        out_block_h=1,
+        out_block_w=1,
+        per_core_M=1,
+        per_core_N=1,
+        fuse_batch=True,
+        fused_activation=None,
+        mcast_in0=True,
+        gather_in0=False,
+        hop_cores=ttnn.CoreRangeSet([]),
+        num_global_cb_receivers=recv_per_bank,
+        untilize_out=False,
+        stream_in1=False,
+    )
+
+    if distribution_strategy == ttnn.ShardDistributionStrategy.CONTIGUOUS_1D:
+        bank_to_receivers = [
+            (b, _bank_receivers_contiguous(b, recv_per_bank, ring_cols=ring_cols)) for b in range(num_dram_banks)
+        ]
+    else:
+        bank_to_receivers = [
+            (b, _bank_receivers_strided(b, recv_per_bank, num_dram_banks, ring_cols=ring_cols))
+            for b in range(num_dram_banks)
+        ]
+
+    page_size_bytes = in0_block_w * program_config.per_core_N * _bytes_per_tile(dtype)
+    gcb = ttnn.experimental.create_global_circular_buffer_for_matmul_1d(
+        device,
+        [program_config],
+        [tt_weight],
+        bank_to_receivers=bank_to_receivers,
+        size=2 * page_size_bytes,
+    )
+    output_mem_config = ttnn.create_sharded_memory_config(
+        shape=(M, N // receiver_count),
+        core_grid=receiver_cores,
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+        dst_full_sync_en=True,
+    )
+
+    with tensor_prefetcher_session(device):
+        tt_out = ttnn.experimental.tensor_prefetcher_matmul.prefetch_and_linear(
+            tt_act,
+            tt_weight,
+            global_cb=gcb,
+            program_config=program_config,
+            memory_config=output_mem_config,
+            compute_kernel_config=compute_kernel_config,
+            dtype=dtype,
+        )
+
+    expected = pt_act.float() @ pt_weight.float()
+    out_torch = ttnn.to_torch(tt_out)
+    passing, output_str = comp_pcc(expected, out_torch, 0.999)
+    logger.info(f"[streaming_mcast_in0 {distribution_strategy}] {output_str}")
+    assert passing, f"streaming_mcast_in0 PCC failed: {output_str}"

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_tensor_large.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_tensor_large.py
@@ -1052,19 +1052,34 @@ def test_tensor_prefetcher_streaming_mcast_in0(device, distribution_strategy):
         dst_full_sync_en=True,
     )
 
-    with tensor_prefetcher_session(device):
-        tt_out = ttnn.experimental.tensor_prefetcher_matmul.prefetch_and_linear(
-            tt_act,
-            tt_weight,
-            global_cb=gcb,
-            program_config=program_config,
-            memory_config=output_mem_config,
-            compute_kernel_config=compute_kernel_config,
-            dtype=dtype,
-        )
-
     expected = pt_act.float() @ pt_weight.float()
-    out_torch = ttnn.to_torch(tt_out)
-    passing, output_str = comp_pcc(expected, out_torch, 0.999)
-    logger.info(f"[streaming_mcast_in0 {distribution_strategy}] {output_str}")
-    assert passing, f"streaming_mcast_in0 PCC failed: {output_str}"
+
+    # Run twice so the second invocation hits the program cache and exercises
+    # override_mcast_in0_program_parameters. The receiver-contiguous weight is
+    # ND-sharded, so a naive tensor-backed CB update would TT_FATAL on the
+    # GCB-backed in1 CB during the cache-hit path.
+    cache_entries_after_first = None
+    with tensor_prefetcher_session(device):
+        for run in range(2):
+            tt_out = ttnn.experimental.tensor_prefetcher_matmul.prefetch_and_linear(
+                tt_act,
+                tt_weight,
+                global_cb=gcb,
+                program_config=program_config,
+                memory_config=output_mem_config,
+                compute_kernel_config=compute_kernel_config,
+                dtype=dtype,
+            )
+            if run == 0:
+                cache_entries_after_first = device.num_program_cache_entries()
+
+            out_torch = ttnn.to_torch(tt_out)
+            passing, output_str = comp_pcc(expected, out_torch, 0.999)
+            logger.info(f"[streaming_mcast_in0 {distribution_strategy} run={run}] {output_str}")
+            assert passing, f"streaming_mcast_in0 run={run} PCC failed: {output_str}"
+
+    # The second run must reuse the cached program (no new entries), i.e. it took
+    # the override path rather than rebuilding.
+    assert (
+        device.num_program_cache_entries() == cache_entries_after_first
+    ), "second mcast_in0 invocation did not hit the program cache"

--- a/tt_metal/impl/buffers/prefetcher_matmul_design.md
+++ b/tt_metal/impl/buffers/prefetcher_matmul_design.md
@@ -392,6 +392,24 @@ src = bank_local_base[t]
     + sb  * sub_stride_bytes         // sub_stride_bytes = rows_per_sub * n_per_recv * tile_bytes
 ```
 
+#### Matmul consumer contracts
+
+Receiver-contiguous weights support two 1D matmul consumers:
+
+- **Ring gather-in0:** `block_count = receiver_count`. Batched mode uses no rotation and waits for
+  all blocks. `stream_in1=true` uses an identity rotation request so each receiver sees its
+  ring-rotated K-block sequence and can consume from a two-page GCB window.
+- **Mcast-in0:** `block_count = K_tiles / in0_block_w`. Every receiver sees K-blocks
+  `0..block_count-1` in natural FIFO order, so the request has an empty rotation and
+  `stream_in1=false`. The reader still consumes each page as it arrives, allowing the same
+  two-page GCB window. Initially this mode requires one output block per receiver and one effective
+  activation batch, so each prefetched stream is consumed exactly once.
+
+For both contracts one page contains
+`(K_tiles / block_count) * per_core_N` weight tiles for one receiver. The GCB receiver set must
+exactly match the matmul output workers, and the receiver-contiguous NdShardSpec must provide one
+full-K, `per_core_N`-wide shard per receiver.
+
 #### Fit ladder (receiver-contiguous)
 
 The receiver-contiguous path rotates through three stage slots

--- a/ttnn/api/ttnn/global_circular_buffer.hpp
+++ b/ttnn/api/ttnn/global_circular_buffer.hpp
@@ -37,7 +37,7 @@ GlobalCircularBuffer create_global_circular_buffer_for_tensor_prefetcher(
     BufferType buffer_type = BufferType::L1,
     bool support_multi_receiver_shards = true);
 
-// Build a DRAM-sender GCB shaped to feed one or more 1D ring matmuls (gather_in0=true) from the
+// Build a DRAM-sender GCB shaped to feed one or more gather-in0 or mcast-in0 1D matmuls from the
 // given weight tensors. The caller supplies `bank_to_receivers` (the same layout the low-level
 // `create_global_circular_buffer_for_tensor_prefetcher` takes); this factory validates it against
 // the matmul program configs and weight shapes and sizes the GCB accordingly.
@@ -52,12 +52,12 @@ GlobalCircularBuffer create_global_circular_buffer_for_tensor_prefetcher(
 //     evenly across receivers; matmul per_core_N == weight per-receiver N. `bank_to_receivers`
 //     shape is checked: num_senders * num_global_cb_receivers == ring_size, every bank owns exactly
 //     num_global_cb_receivers cores. `size` floor is one full layer (ring_size * largest in1 block).
-//   * Receiver-contiguous (NdShardSpec): num_shards == ring_size, each shard (full K, N/ring_size)
-//     owned by one receiver. Validated: num_shards == ring_size, weight K-tiles divisible by
-//     ring_size, per_core_N == per-receiver N. Receivers need NOT be uniform per bank (strided
-//     round-robin). `size` floor is ring_size * largest per-receiver page, relaxed to a
-//     double-buffer window when every config is stream_in1. This layout also permits dual senders
-//     per bank via `support_multi_receiver_shards=false` (see below).
+//   * Receiver-contiguous (NdShardSpec): num_shards == receiver_count, each shard
+//     (full K, N/receiver_count) owned by one receiver. Gather uses receiver_count K-blocks; mcast
+//     uses K_tiles / in0_block_w natural-order blocks. Validated: exact K divisibility and
+//     per_core_N == per-receiver N. Receivers need NOT be uniform per bank. `size` can use a
+//     double-buffer window for streaming gather or mcast FIFO consumers. This layout also permits
+//     dual senders per bank via `support_multi_receiver_shards=false` (see below).
 //
 // All configs must agree on compute_with_storage_grid_size (and, for legacy, num_global_cb_receivers)
 // — the GCB has one receiver rectangle shared across all consumer matmuls. The factory does NOT
@@ -86,19 +86,14 @@ GlobalCircularBuffer create_global_circular_buffer_for_matmul_1d(
     std::optional<bool> support_multi_receiver_shards = std::nullopt);
 
 // Compute the validated `block_count` to pair with `weight` in a TensorPrefetcherInput when feeding a
-// gather_in0 1D matmul (`program_config`) from a *receiver-contiguous* DRAM weight via `gcb`. This is the
-// single place that owns the recv-contig prefetcher↔matmul cross-checks that otherwise have to be
-// reproduced (and have drifted) at every call site. It validates, then returns `block_count`:
-//   * block_count == ring_size (the matmul does wait_front(ring_size) per layer);
-//   * the weight is an NdShardSpec DRAM tensor whose num_shards == ring_size (one shard per receiver),
-//     each shard spanning the full K and N/ring_size columns;
-//   * weight K-tiles is divisible by ring_size — otherwise the prefetcher ceil-rounds the K-block width
-//     and over-reads past the receiver's slab while the matmul waits on pages that never come;
+// gather-in0 or mcast-in0 1D matmul from a *receiver-contiguous* DRAM weight via `gcb`. Gather returns
+// the receiver/ring count; mcast returns `weight_K_tiles / program_config.in0_block_w`. It validates:
+//   * the weight is an NdShardSpec DRAM tensor with one full-K, N/receiver_count shard per receiver;
+//   * weight K-tiles divides the consumer's block count exactly;
 //   * the weight's per-receiver N (shard N in tiles) equals program_config.per_core_N — otherwise the
 //     prefetcher's pushed page size and the matmul's in1 remote-CB page size disagree and the page-credit
 //     accounting desyncs.
-// Throws (TT_FATAL) on any mismatch. Mirrors create_global_circular_buffer_for_matmul_1d's K-row-major
-// guards for the receiver-contiguous layout.
+// Mcast uses natural FIFO order and therefore requires `stream_in1=false`.
 uint32_t tensor_prefetcher_block_count_for_matmul_1d(
     const ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig& program_config,
     const ttnn::Tensor& weight,

--- a/ttnn/core/global_circular_buffer.cpp
+++ b/ttnn/core/global_circular_buffer.cpp
@@ -345,7 +345,10 @@ uint32_t validate_recv_contig_weight_for_matmul_1d(
     const uint32_t weight_K_tiles = shard_K / tile_h;
     uint32_t block_count = 0;
     if (program_config.gather_in0) {
-        // Gather consumes one rotated K-block per ring position.
+        // Gather consumes one rotated K-block per ring position. Silent-hang / over-read guard: K must
+        // divide evenly into receiver_count blocks. Otherwise the K-block width the prefetcher lays out
+        // rounds up, the kernel reads past the receiver's slab, and the matmul (which pads K to a
+        // multiple of receiver_count) waits on pages that never come.
         TT_FATAL(
             weight_K_tiles % receiver_count == 0,
             "weight K ({} tiles) must be divisible by receiver_count ({}) for gather_in0; remainder {}",
@@ -354,7 +357,9 @@ uint32_t validate_recv_contig_weight_for_matmul_1d(
             weight_K_tiles % receiver_count);
         block_count = receiver_count;
     } else {
-        // Mcast consumes the same natural K-block sequence on every output worker.
+        // Mcast consumes the same natural K-block sequence on every output worker. Same silent-hang /
+        // over-read guard, keyed on in0_block_w: an indivisible K rounds the block width up and the
+        // kernel over-reads while the matmul waits forever.
         TT_FATAL(program_config.in0_block_w > 0, "mcast_in0 requires in0_block_w > 0");
         TT_FATAL(
             weight_K_tiles % program_config.in0_block_w == 0,

--- a/ttnn/core/global_circular_buffer.cpp
+++ b/ttnn/core/global_circular_buffer.cpp
@@ -276,19 +276,24 @@ bool is_receiver_contiguous_weight(const ttnn::Tensor& weight) {
     return weight.nd_shard_spec().has_value();
 }
 
-// Shared receiver-contiguous weight ↔ matmul cross-checks, parameterized on ring_size so both the
-// block_count helper (ring_size from the GCB) and the GCB factory (ring_size from bank_to_receivers /
-// the program-config grid) can call it. See the header docs on the two public functions for the
-// rationale behind each guard.
-void validate_recv_contig_weight_for_matmul_1d(
+// Shared receiver-contiguous weight ↔ matmul cross-checks. Returns the number of K-blocks the
+// prefetcher must push per receiver: gather-in0 uses one block per ring position, while mcast-in0
+// uses the configured inner-dimension block width.
+uint32_t validate_recv_contig_weight_for_matmul_1d(
     const ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig& program_config,
     const ttnn::Tensor& weight,
-    uint32_t ring_size) {
-    TT_FATAL(program_config.gather_in0, "receiver-contiguous Tensor prefetcher requires gather_in0=true");
-    TT_FATAL(ring_size > 0, "ring_size must be > 0");
+    uint32_t receiver_count) {
+    TT_FATAL(
+        program_config.gather_in0 != program_config.mcast_in0,
+        "receiver-contiguous Tensor prefetcher requires exactly one of gather_in0 or mcast_in0 to be true");
+    TT_FATAL(
+        !program_config.mcast_in0 || !program_config.stream_in1,
+        "mcast_in0 consumes GCB blocks in natural FIFO order and requires stream_in1=false");
+    TT_FATAL(receiver_count > 0, "receiver_count must be > 0");
 
-    // The receiver-contiguous weight is an NdShardSpec DRAM tensor: num_shards == ring_size, each shard
-    // (full K, N/ring_size). This is also exactly what the manager's detect_layout_mode keys on.
+    // The receiver-contiguous weight is an NdShardSpec DRAM tensor: num_shards == receiver_count,
+    // each shard (full K, N/receiver_count). This is also exactly what the manager's
+    // detect_layout_mode keys on.
     TT_FATAL(weight.buffer() != nullptr && weight.buffer()->is_dram(), "weight must live in DRAM");
     const auto& nd_opt = weight.nd_shard_spec();
     TT_FATAL(
@@ -325,25 +330,42 @@ void validate_recv_contig_weight_for_matmul_1d(
     const auto& bds = weight.buffer()->buffer_distribution_spec();
     TT_FATAL(bds.has_value(), "receiver-contiguous weight buffer must have a BufferDistributionSpec");
     TT_FATAL(
-        static_cast<uint32_t>(bds->num_shards()) == ring_size,
-        "receiver-contiguous weight has {} shards but global_cb ring_size is {}; num_shards must equal "
-        "ring_size (one shard per receiver)",
+        static_cast<uint32_t>(bds->num_shards()) == receiver_count,
+        "receiver-contiguous weight has {} shards but global_cb has {} receivers; num_shards must equal "
+        "receiver_count (one shard per receiver)",
         bds->num_shards(),
-        ring_size);
-
-    // #1 silent-hang / over-read guard: K must divide evenly into ring_size blocks. Otherwise
-    // compute_tensor_layout_recv_contig ceil-rounds k_block_w_tiles and the kernel reads past the
-    // receiver's slab, and the matmul (which pads K to a multiple of ring_size) waits forever.
-    const uint32_t weight_K_tiles = shard_K / tile_h;
+        receiver_count);
     TT_FATAL(
-        weight_K_tiles % ring_size == 0,
-        "weight K ({} tiles) must be divisible by ring_size ({}) for the receiver-contiguous DRAM-core "
-        "prefetcher; remainder {}",
-        weight_K_tiles,
-        ring_size,
-        weight_K_tiles % ring_size);
+        static_cast<uint64_t>(shard_N) * receiver_count == static_cast<uint64_t>(wp[-1]),
+        "receiver-contiguous shard N ({}) * receiver_count ({}) must equal full weight N ({})",
+        shard_N,
+        receiver_count,
+        wp[-1]);
 
-    // B1 page-size guard: the matmul sizes its in1 remote-CB page from per_core_N; the prefetcher pushes
+    const uint32_t weight_K_tiles = shard_K / tile_h;
+    uint32_t block_count = 0;
+    if (program_config.gather_in0) {
+        // Gather consumes one rotated K-block per ring position.
+        TT_FATAL(
+            weight_K_tiles % receiver_count == 0,
+            "weight K ({} tiles) must be divisible by receiver_count ({}) for gather_in0; remainder {}",
+            weight_K_tiles,
+            receiver_count,
+            weight_K_tiles % receiver_count);
+        block_count = receiver_count;
+    } else {
+        // Mcast consumes the same natural K-block sequence on every output worker.
+        TT_FATAL(program_config.in0_block_w > 0, "mcast_in0 requires in0_block_w > 0");
+        TT_FATAL(
+            weight_K_tiles % program_config.in0_block_w == 0,
+            "weight K ({} tiles) must be divisible by mcast_in0 in0_block_w ({}); remainder {}",
+            weight_K_tiles,
+            program_config.in0_block_w,
+            weight_K_tiles % program_config.in0_block_w);
+        block_count = weight_K_tiles / static_cast<uint32_t>(program_config.in0_block_w);
+    }
+
+    // Page-size guard: the matmul sizes its in1 remote-CB page from per_core_N; the prefetcher pushes
     // pages of n_per_recv tiles. A mismatch desyncs the page-credit accounting (wrong output / hang).
     const uint32_t n_per_recv_tiles = shard_N / tile_w;
     TT_FATAL(
@@ -353,6 +375,7 @@ void validate_recv_contig_weight_for_matmul_1d(
         n_per_recv_tiles,
         shard_N,
         tile_w);
+    return block_count;
 }
 
 }  // namespace
@@ -361,11 +384,9 @@ uint32_t tensor_prefetcher_block_count_for_matmul_1d(
     const ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig& program_config,
     const ttnn::Tensor& weight,
     const GlobalCircularBuffer& gcb) {
-    // ring_size == total receivers == block_count (the matmul does wait_front(ring_size) per layer).
-    const uint32_t ring_size = gcb.receiver_cores().num_cores();
-    TT_FATAL(ring_size > 0, "global_cb has no receivers");
-    validate_recv_contig_weight_for_matmul_1d(program_config, weight, ring_size);
-    return ring_size;
+    const uint32_t receiver_count = gcb.receiver_cores().num_cores();
+    TT_FATAL(receiver_count > 0, "global_cb has no receivers");
+    return validate_recv_contig_weight_for_matmul_1d(program_config, weight, receiver_count);
 }
 
 // Builds the GCB for a receiver-contiguous (NdShardSpec) weight: num_shards == ring_size, each shard
@@ -382,60 +403,72 @@ static GlobalCircularBuffer build_matmul_1d_gcb_recv_contig(
     TT_FATAL(size > 0, "size must be > 0");
     TT_FATAL(!bank_to_receivers.empty(), "bank_to_receivers must be non-empty");
 
-    // ring_size for the recv-contig layout is the total receiver count (= num_shards). Unlike the
+    // receiver_count for the recv-contig layout is the total receiver count (= num_shards). Unlike the
     // K-row-major builder we do NOT require a uniform per-bank receiver count or a contiguous
     // bank->ring mapping — recv-contig uses a strided round-robin placement, and dual senders split
     // a bank's receivers across two DRISC cores.
-    uint32_t ring_size = 0;
+    uint32_t receiver_count = 0;
     for (const auto& [_bank, receivers] : bank_to_receivers) {
-        ring_size += receivers.num_cores();
+        receiver_count += receivers.num_cores();
     }
-    TT_FATAL(ring_size > 0, "bank_to_receivers has no receivers");
+    TT_FATAL(receiver_count > 0, "bank_to_receivers has no receivers");
 
     // All matmuls share the GCB receiver rectangle, so they must agree on the ring shape, and that
     // ring must match bank_to_receivers' total receiver count.
     uint32_t max_page_bytes = 0;
-    bool all_configs_stream = true;
+    uint32_t max_block_count = 0;
+    bool all_configs_fifo = true;
     for (size_t i = 0; i < program_configs.size(); ++i) {
         const auto& cfg = program_configs[i];
-        all_configs_stream = all_configs_stream && cfg.stream_in1;
         const auto& grid = cfg.compute_with_storage_grid_size;
-        const uint32_t cfg_ring_size = grid.x * grid.y;
-        TT_FATAL(
-            cfg_ring_size == ring_size,
-            "program_configs[{}] grid {}x{} = {} workers, but bank_to_receivers has {} total receivers; "
-            "they must match (one receiver per matmul worker)",
-            i,
-            grid.x,
-            grid.y,
-            cfg_ring_size,
-            ring_size);
+        const uint32_t grid_capacity = grid.x * grid.y;
+        if (cfg.gather_in0) {
+            TT_FATAL(
+                grid_capacity == receiver_count,
+                "gather_in0 program_configs[{}] grid {}x{} = {} workers, but bank_to_receivers has {} total "
+                "receivers; they must match",
+                i,
+                grid.x,
+                grid.y,
+                grid_capacity,
+                receiver_count);
+        } else {
+            TT_FATAL(
+                grid_capacity >= receiver_count,
+                "mcast_in0 program_configs[{}] grid {}x{} has capacity for {} workers, but bank_to_receivers has "
+                "{} receivers",
+                i,
+                grid.x,
+                grid.y,
+                grid_capacity,
+                receiver_count);
+        }
 
-        // Per-(config, weight) recv-contig cross-checks (num_shards == ring_size, K % ring_size == 0,
-        // per_core_N == per-receiver N). Shared with tensor_prefetcher_block_count_for_matmul_1d.
-        validate_recv_contig_weight_for_matmul_1d(cfg, weights[i], ring_size);
+        // Per-(config, weight) recv-contig cross-checks and consumer-specific K-block count.
+        const uint32_t block_count = validate_recv_contig_weight_for_matmul_1d(cfg, weights[i], receiver_count);
+        max_block_count = std::max(max_block_count, block_count);
+        all_configs_fifo = all_configs_fifo && (cfg.mcast_in0 || cfg.stream_in1);
 
-        // page_bytes_per_recv = (K_tiles / ring_size) * per_core_N * tile_bytes — one K-block per receiver.
+        // One GCB page is one consumer K-block for one receiver.
         const auto& w = weights[i];
         const auto& tile = w.tensor_spec().tile();
         const uint32_t weight_K_tiles = static_cast<uint32_t>(w.padded_shape()[-2]) / tile.get_height();
-        const uint32_t k_block_w_tiles = weight_K_tiles / ring_size;
+        const uint32_t k_block_w_tiles = weight_K_tiles / block_count;
         const uint32_t bytes_per_tile = tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(w.dtype()));
         const uint32_t page_bytes = k_block_w_tiles * cfg.per_core_N * bytes_per_tile;
         TT_FATAL(page_bytes > 0, "program_configs[{}] page_bytes computed as 0", i);
         max_page_bytes = std::max(max_page_bytes, page_bytes);
     }
 
-    // A batched matmul does wait_front(ring_size) per layer, so the GCB must hold at least one full
-    // layer's worth of pages. A stream_in1 matmul instead consumes K-blocks FIFO as they land, so a
-    // shallow window is valid -- and shrinking the GCB is the whole point of streaming. Relax the
-    // floor to a double-buffer (one page filling while another drains) when every matmul sharing this
-    // GCB streams; a GCB shared with any batched matmul keeps the full-layer floor. Same cap as the
+    // A batched gather matmul waits for all blocks before consuming. A stream_in1 gather or a
+    // GCB-backed mcast consumes K-blocks FIFO as they land, so a shallow window is valid. Relax the
+    // floor to a double-buffer when every matmul sharing this GCB is a FIFO consumer; otherwise keep
+    // enough space for the largest full tensor. Same cap as the
     // K-row-major builder (see create_global_circular_buffer_for_matmul_1d for why kMaxCbPagesBytes
     // exists); no L1 budget check — callers size to fit their own receiver L1.
     constexpr uint32_t kMaxCbPagesBytes = 131072u * 16u;
-    constexpr uint32_t kStreamMinWindowBlocks = 2;  // double-buffer floor for stream_in1
-    const uint32_t min_blocks = all_configs_stream ? kStreamMinWindowBlocks : ring_size;
+    constexpr uint32_t kFifoMinWindowBlocks = 2;
+    const uint32_t min_blocks = all_configs_fifo ? kFifoMinWindowBlocks : max_block_count;
     const uint32_t min_size = max_page_bytes * min_blocks;
     TT_FATAL(
         size >= min_size,
@@ -444,9 +477,8 @@ static GlobalCircularBuffer build_matmul_1d_gcb_recv_contig(
         min_blocks,
         max_page_bytes,
         min_size,
-        all_configs_stream ? "stream_in1 matmuls consume K-blocks FIFO but still need a double-buffered window."
-                           : "The matmul does wait_front(ring_size), so it needs a full layer buffered before "
-                             "it consumes.");
+        all_configs_fifo ? "FIFO matmuls consume K-blocks as they arrive but still need a double-buffered window."
+                         : "A batched gather matmul needs a full layer buffered before it consumes.");
     TT_FATAL(
         size <= kMaxCbPagesBytes,
         "GCB size ({} B) exceeds the remote-CB page-count cap ({} B). Reduce size.",
@@ -492,6 +524,13 @@ GlobalCircularBuffer create_global_circular_buffer_for_matmul_1d(
         const bool single_sender = support_multi_receiver_shards.value_or(false);
         return build_matmul_1d_gcb_recv_contig(
             mesh_device, program_configs, weights, bank_to_receivers, size, buffer_type, single_sender);
+    }
+
+    for (size_t i = 0; i < program_configs.size(); ++i) {
+        TT_FATAL(
+            program_configs[i].gather_in0,
+            "program_configs[{}] uses mcast_in0, which requires a receiver-contiguous NdShardSpec weight",
+            i);
     }
 
     // Legacy K-row-major is single-sender per bank by construction (a bank's shard feeds all its

--- a/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher_nanobind.cpp
@@ -171,15 +171,14 @@ void bind_tensor_prefetcher(nb::module_& mod) {
     ttnn::bind_function<"create_global_circular_buffer_for_matmul_1d", "ttnn.experimental.">(
         mod,
         R"doc(
-            Build a DRAM-sender GlobalCircularBuffer sized to feed one or more 1D ring matmuls
-            (gather_in0=true) with their weight tensors. The weight's DRAM layout is auto-detected
-            (legacy WIDTH_SHARDED K-row-major vs receiver-contiguous NdShardSpec) and validated/sized
-            accordingly, so callers do not choose a layout-specific factory. See notes in
-            ttnn/api/ttnn/global_circular_buffer.hpp.
+            Build a DRAM-sender GlobalCircularBuffer sized to feed one or more gather_in0 or
+            mcast_in0 1D matmuls with their weight tensors. The weight's DRAM layout is
+            auto-detected (legacy WIDTH_SHARDED K-row-major vs receiver-contiguous NdShardSpec)
+            and validated/sized accordingly.
 
             Args:
                 mesh_device: The mesh device.
-                program_configs: List of 1D mcast matmul program configs (each gather_in0=True).
+                program_configs: List of compatible 1D matmul program configs.
                 weights: List of DRAM in1 tensors, one per program_config. All must share the same
                     DRAM layout (all legacy WIDTH_SHARDED, or all receiver-contiguous NdShardSpec).
                 bank_to_receivers: List of (bank_id, receivers) pairs.
@@ -207,14 +206,12 @@ void bind_tensor_prefetcher(nb::module_& mod) {
         mod,
         R"doc(
             Compute and validate the block_count to pair with a receiver-contiguous DRAM weight
-            in queue_tensor_prefetcher_request, for a gather_in0 1D matmul fed via global_cb.
-            Centralizes the recv-contig prefetcher/matmul cross-checks (num_shards == ring_size,
-            weight K divisible by ring_size, weight per-receiver N == per_core_N) so call sites
-            don't re-derive (and mis-derive) them. Returns the block_count (== ring_size); raises
-            on any mismatch.
+            in queue_tensor_prefetcher_request for a gather_in0 or mcast_in0 1D matmul fed via
+            global_cb. Gather returns the receiver/ring count. Mcast returns
+            weight_K_tiles / in0_block_w and uses natural FIFO order.
 
             Args:
-                program_config: The gather_in0 1D mcast matmul program config that will consume the weight.
+                program_config: The 1D matmul program config that will consume the weight.
                 weight: The receiver-contiguous (NdShardSpec) DRAM weight tensor.
                 global_cb: The DRAM-sender GCB the prefetcher and matmul share.
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config_types.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config_types.hpp
@@ -66,12 +66,9 @@ struct MatmulMultiCoreReuseMultiCast1DProgramConfig {
     std::size_t num_global_cb_receivers{};
     bool untilize_out{};
     std::optional<CoreRangeSet> allowed_worker_cores = std::nullopt;
-    // Stream in1 from the GCB in ring-rotated FIFO order (gather_in0 + DRAM-sender GCB only):
-    // consume each weight block as it arrives instead of waiting for the whole tensor, so the
-    // GCB can be sized to a small window. The feeding prefetcher request MUST supply a per-receiver
-    // rotation (the `(weight, block_count, rotation)` form of queue_tensor_prefetcher_request) so it
-    // streams in matching ring-rotated FIFO order, else the matmul deadlocks (it waits for
-    // FIFO-order blocks the batched prefetcher delivers in natural order).
+    // Select ring-rotated FIFO delivery for gather_in0 with a DRAM-sender GCB. The feeding prefetcher
+    // request MUST supply a per-receiver rotation. GCB-backed mcast_in0 instead consumes natural FIFO
+    // order and requires this flag to remain false.
     bool stream_in1 = false;
 };
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -2932,6 +2932,7 @@ inline void override_mcast_in1_program_parameters(
 static void override_mcast_in0_program_parameters(
     tt_metal::Program& program,
     const MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t& override_variables,
+    const std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer>& global_cb,
     const ttnn::prim::MatmulInputs& tensor_args,
     const std::vector<ttnn::Tensor>& output_tensors) {
     const auto& input_tensors = tensor_args.input_tensors;
@@ -2972,7 +2973,13 @@ static void override_mcast_in0_program_parameters(
     }
 
     if (src1_sharded) {
-        UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(0), src_b_tensor);
+        // cbs[0] is cb_src1. For the receiver-contiguous GCB path it is a GlobalCircularBuffer whose
+        // address is owned by the GCB (not tensor-backed), so the tensor overload of
+        // UpdateDynamicCircularBufferAddress would TT_FATAL on a program-cache hit. Skip it there,
+        // mirroring the gather_in0 override.
+        if (!global_cb.has_value()) {
+            UpdateDynamicCircularBufferAddress(program, override_variables.cbs.at(0), src_b_tensor);
+        }
     }
 
     if (bias_tensor.has_value() && bias_tensor.value().is_sharded()) {
@@ -3053,7 +3060,8 @@ void override_program_parameters(
     const std::vector<ttnn::Tensor>& tensor_return_value) {
     switch (override_variables.type) {
         case ttnn::prim::Matmul1DType::MCAST_IN0:
-            override_mcast_in0_program_parameters(program, override_variables, tensor_args, tensor_return_value);
+            override_mcast_in0_program_parameters(
+                program, override_variables, global_cb, tensor_args, tensor_return_value);
             break;
         case ttnn::prim::Matmul1DType::GATHER_IN0: {
             override_gather_in0_program_parameters(

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -101,6 +101,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
     std::optional<UnaryWithParam> fused_activation,
     const MeshTensor& in0_tensor,
     const MeshTensor& in1_tensor,
+    const std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer>& global_cb,
     ttsl::optional_reference<const MeshTensor> bias_tensor,
     const MeshTensor& out_tensor,
     const tt::tt_metal::Tile& in0_tile,
@@ -120,6 +121,9 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
     bool row_broadcast_bias = true,
     CoreCoord sub_device_start_core = {0, 0}) {
     using tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids;
+
+    const bool use_global_cb = global_cb.has_value();
+    const bool in1_is_locally_sharded = in1_is_sharded && !use_global_cb;
 
     // currently only support transpose of the full tile
     bool in0_transpose_tile = in0_tile.get_transpose_of_faces() && in0_tile.get_transpose_within_face();
@@ -166,8 +170,9 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
     const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
     uint32_t in0_aligned_tile_size =
         in0_is_sharded ? in0_single_tile_size : tt::align(in0_single_tile_size, dram_alignment);
-    uint32_t in1_aligned_tile_size =
-        in1_is_sharded ? in1_single_tile_size : tt::align(in1_single_tile_size, dram_alignment);
+    uint32_t in1_aligned_tile_size = (in1_is_locally_sharded || use_global_cb)
+                                         ? in1_single_tile_size
+                                         : tt::align(in1_single_tile_size, dram_alignment);
     // Bias CB pages must be padded to the DRAM alignment so the reader's L1 write stride
     // matches the DRAM page stride (e.g. 64B on Blackhole for a 32B (1,16) bf16 bias tile).
     // Mirrors in0/in1 above. Sharded bias is backed by the L1 tensor buffer and keeps its
@@ -192,7 +197,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
     if (B * num_blocks > 1) {
         in1_CB_tiles *= operations::matmul::utilities::MCAST_INPUT_BUFFERING_DEPTH;
     }
-    if (in1_is_sharded) {
+    if (in1_is_locally_sharded) {
         uint32_t in1_shard_height_in_tiles = in1_tensor.shard_spec()->shape[0] / in1_tile.get_height();
         in1_CB_tiles = per_core_N * in1_shard_height_in_tiles;
     }
@@ -256,6 +261,13 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
 
     CoreRangeSet all_cores_with_work =
         num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores_with_work, matmul_core_rect, row_major);
+    if (use_global_cb) {
+        TT_FATAL(
+            global_cb->receiver_cores() == all_cores_with_work,
+            "mcast_in0 global_cb receivers {} must exactly match output worker cores {}",
+            global_cb->receiver_cores(),
+            all_cores_with_work);
+    }
     CoreRange in0_mcast_receiver_cores_bounding_box = all_cores_with_work.bounding_box();
     uint32_t in0_mcast_receiver_num_cores = in0_mcast_receiver_cores_bounding_box.size();  // always mcast to full grid
     uint32_t in0_mcast_receiver_num_dests = std::min(
@@ -531,8 +543,11 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
     ttnn::operations::compute_throttle_utils::throttle_mm_perf(
         device->arch(), num_cores, mm_kernel_defines, throttle_level);
 
-    if (in1_is_sharded) {
+    if (in1_is_locally_sharded) {
         mm_kernel_in1_sender_writer_defines["IN1_SHARDED"] = "1";
+    }
+    if (use_global_cb) {
+        mm_kernel_in1_sender_writer_defines["ENABLE_GLOBAL_CB"] = "1";
     }
 
     if (bias_is_sharded) {
@@ -799,23 +814,42 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
         in0_CB_size);
 
     uint32_t src1_cb_index = tt::CBIndex::c_1;
-    tt_metal::CircularBufferConfig src1_cb_config =
-        tt_metal::CircularBufferConfig(in1_CB_size, {{src1_cb_index, in1_data_format}})
-            .set_page_size(src1_cb_index, in1_aligned_tile_size)
-            .set_tile_dims(src1_cb_index, in1_tile);
-
-    if (in1_is_sharded) {
-        src1_cb_config = src1_cb_config.set_globally_allocated_address(in1_tensor);
+    tt::tt_metal::CBHandle cb_src1 = 0;
+    if (use_global_cb) {
+        const uint32_t remote_cb_index = tt::CBIndex::c_31;
+        const uint32_t in1_block_size_bytes = in1_block_tiles * in1_single_tile_size;
+        TT_FATAL(
+            global_cb->size() % in1_block_size_bytes == 0,
+            "mcast_in0 global_cb size {} must be a multiple of in1 K-block size {}",
+            global_cb->size(),
+            in1_block_size_bytes);
+        tt_metal::CircularBufferConfig remote_cb_config(global_cb->size());
+        remote_cb_config.remote_index(remote_cb_index)
+            .set_page_size(in1_block_size_bytes)
+            .set_data_format(in1_data_format);
+        remote_cb_config.index(src1_cb_index)
+            .set_page_size(in1_single_tile_size)
+            .set_data_format(in1_data_format)
+            .set_tile_dims(in1_tile);
+        cb_src1 =
+            tt_metal::experimental::CreateCircularBuffer(program, all_cores_with_work, remote_cb_config, *global_cb);
+    } else {
+        tt_metal::CircularBufferConfig src1_cb_config =
+            tt_metal::CircularBufferConfig(in1_CB_size, {{src1_cb_index, in1_data_format}})
+                .set_page_size(src1_cb_index, in1_aligned_tile_size)
+                .set_tile_dims(src1_cb_index, in1_tile);
+        if (in1_is_locally_sharded) {
+            src1_cb_config = src1_cb_config.set_globally_allocated_address(in1_tensor);
+        }
+        cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, src1_cb_config);
     }
-
-    auto cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, src1_cb_config);
     log_debug(
         LogOp,
         "CB {} :: PS = {}, NP = {}, TOTAL = {}",
         src1_cb_index,
         in1_single_tile_size,
-        in1_CB_size / in1_single_tile_size,
-        in1_CB_size);
+        use_global_cb ? global_cb->size() / in1_single_tile_size : in1_CB_size / in1_single_tile_size,
+        use_global_cb ? global_cb->size() : in1_CB_size);
 
     uint32_t src2_cb_index = tt::CBIndex::c_2;
     tt::tt_metal::CBHandle cb_src2 = 0;
@@ -5259,6 +5293,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_
             fused_activation,
             in0_tensor,
             in1_tensor,
+            global_cb,
             bias_mesh_tensor,
             output,
             in0_tile,

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -10,6 +10,7 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/dataflow/noc_semaphore.h"
+#include "api/remote_circular_buffer.h"
 #include "api/tensor/noc_traits.h"
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
@@ -181,7 +182,8 @@ void kernel_main() {
     // keep their natural (unpadded) stride.
     constexpr uint32_t in1_aligned_tile_size_bytes =
         (in1_single_tile_size_bytes + (DRAM_ALIGNMENT - 1)) & ~(DRAM_ALIGNMENT - 1);
-#if !defined(IN1_SHARDED) && !defined(IN1_DRAM_WIDTH_SHARDED) && !defined(IN1_DRAM_HEIGHT_SHARDED)
+#if !defined(IN1_SHARDED) && !defined(IN1_DRAM_WIDTH_SHARDED) && !defined(IN1_DRAM_HEIGHT_SHARDED) && \
+    !defined(ENABLE_GLOBAL_CB)
     constexpr uint32_t in1_block_size_bytes = in1_block_num_tiles * in1_aligned_tile_size_bytes;
 #else
     constexpr uint32_t in1_block_size_bytes = in1_block_num_tiles * in1_single_tile_size_bytes;
@@ -204,11 +206,16 @@ void kernel_main() {
 #ifdef IN1_SHARDED
     dfb_in1.reserve_back(in1_block_num_tiles * num_blocks_inner_dim);
     dfb_in1.push_back(in1_block_num_tiles * num_blocks_inner_dim);
-#else
+#elif !defined(ENABLE_GLOBAL_CB)
     uint32_t l1_write_addr_in1;
 
     [[maybe_unused]] const auto s1 = TensorAccessor(in1_args, in1_tensor_addr);
-#endif  // IN1_SHARDED
+#endif  // IN1_SHARDED / ENABLE_GLOBAL_CB
+
+#ifdef ENABLE_GLOBAL_CB
+    constexpr uint32_t remote_cb_id = tt::CBIndex::c_31;
+    const uint32_t in1_fifo_tiles = get_local_cb_interface(dfb_id_in1).fifo_num_pages;
+#endif
 
     //  WRITER
     const auto s = TensorAccessor(out_args, out_tensor_addr);
@@ -294,7 +301,14 @@ void kernel_main() {
                             fused_op_receiver.update_current_block_start_tile_id(
                                 block, in1_tensor_current_inner_dim_block_start_tile_id, in1_batch_tile_id);
                         }
-#if defined(IN1_DRAM_WIDTH_SHARDED)
+#if defined(ENABLE_GLOBAL_CB)
+                        // The tensor prefetcher pushes this receiver's K-blocks in natural order.
+                        // Keep one block of lookahead: publish the current block to compute, then
+                        // wait for the unpack engine to drain the previous block before returning
+                        // its remote-CB credit to the prefetcher.
+                        dfb_in1.reserve_back(in1_block_num_tiles);
+                        experimental::remote_cb_wait_front(remote_cb_id, block == 0 ? 1u : 2u);
+#elif defined(IN1_DRAM_WIDTH_SHARDED)
                         // Operand 1 - DRAM width sharded
                         dfb_in1.reserve_back(in1_block_num_tiles);
 
@@ -327,9 +341,7 @@ void kernel_main() {
                                 uint32_t l1_read_addr_in1_temp = l1_read_addr_in1;
                                 uint32_t l1_write_addr_in1_temp = l1_write_addr_in1;
                                 for (uint32_t w = 0; w < in1_block_w_dram; ++w) {
-                                    noc.async_read_with_state<
-                                        NocOptions::CUSTOM_VC,
-                                        NOC_MAX_BURST_SIZE>(
+                                    noc.async_read_with_state<NocOptions::CUSTOM_VC, NOC_MAX_BURST_SIZE>(
                                         dram_bank,
                                         CoreLocalMem<uint32_t>(l1_write_addr_in1_temp),
                                         in1_single_tile_size_bytes,
@@ -461,7 +473,23 @@ void kernel_main() {
 #ifndef IN1_SHARDED
                         dfb_in1.push_back(in1_block_num_tiles);
 #endif  // IN1_SHARDED
+#ifdef ENABLE_GLOBAL_CB
+                        if (block >= 1) {
+                            while (!dfb_in1.pages_reservable_at_back(in1_fifo_tiles - in1_block_num_tiles)) {
+                                invalidate_l1_cache();
+                            }
+                            experimental::remote_cb_pop_front(remote_cb_id, 1);
+                        }
+#endif
                     }
+#ifdef ENABLE_GLOBAL_CB
+                    if (num_blocks_inner_dim > 0) {
+                        while (!dfb_in1.pages_reservable_at_back(in1_fifo_tiles)) {
+                            invalidate_l1_cache();
+                        }
+                        experimental::remote_cb_pop_front(remote_cb_id, 1);
+                    }
+#endif
 #ifdef FUSE_BIAS
                     // Only read bias on first batch, or we have multiple output blocks
                     if ((b == 0 && bh == 0) || num_blocks_w_dim > 1) {
@@ -687,6 +715,10 @@ void kernel_main() {
 #if OUT_SHARDED
     dfb_out.wait_front(
         batch * out_num_nonzero_subblocks_h * out_num_nonzero_subblocks_w * out_subblock_w * out_subblock_h);
+#endif
+#ifdef ENABLE_GLOBAL_CB
+    experimental::update_remote_cb_config_in_l1(remote_cb_id);
+    noc.async_atomic_barrier();
 #endif
     noc.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -1033,6 +1033,89 @@ void validate_dram_sender_global_cb_gather_in0_geometry_recv_contig(
         ring_size);
 }
 
+void validate_dram_sender_global_cb_mcast_in0_geometry(
+    const tt::tt_metal::experimental::GlobalCircularBuffer& gcb,
+    const Tensor& input_tensor_b,
+    const ttnn::Shape& b_shape_padded,
+    const tt::tt_metal::Tile& in1_tile,
+    const operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig& program_config) {
+    TT_FATAL(
+        tt::tt_metal::experimental::sender_core_type(gcb) == tt::tt_metal::experimental::SenderCoreType::Dram,
+        "mcast_in0 global_cb requires programmable DRAM senders");
+    TT_FATAL(
+        input_tensor_b.buffer() != nullptr && input_tensor_b.buffer()->is_dram(),
+        "mcast_in0 global_cb requires an in1 weight in DRAM");
+    TT_FATAL(
+        input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::ND_SHARDED,
+        "mcast_in0 global_cb requires a receiver-contiguous ND_SHARDED in1 weight, but got {}",
+        input_tensor_b.memory_config().memory_layout());
+    TT_FATAL(
+        !program_config.stream_in1,
+        "mcast_in0 global_cb consumes natural-order K-blocks and requires stream_in1=false");
+    TT_FATAL(program_config.in0_block_w > 0, "mcast_in0 global_cb requires in0_block_w > 0");
+    TT_FATAL(
+        program_config.out_block_h == program_config.per_core_M &&
+            program_config.out_block_w == program_config.per_core_N,
+        "mcast_in0 global_cb requires one output block per worker: out_block_h ({}) must equal per_core_M ({}) "
+        "and out_block_w ({}) must equal per_core_N ({})",
+        program_config.out_block_h,
+        program_config.per_core_M,
+        program_config.out_block_w,
+        program_config.per_core_N);
+
+    const uint32_t receiver_count = gcb.receiver_cores().num_cores();
+    TT_FATAL(receiver_count > 0, "mcast_in0 global_cb has no receivers");
+    const uint32_t weight_K_tiles = b_shape_padded[-2] / in1_tile.get_height();
+    const uint32_t weight_N_tiles = b_shape_padded[-1] / in1_tile.get_width();
+    TT_FATAL(
+        weight_K_tiles % program_config.in0_block_w == 0,
+        "mcast_in0 global_cb weight K ({} tiles) must be divisible by in0_block_w ({}); remainder {}",
+        weight_K_tiles,
+        program_config.in0_block_w,
+        weight_K_tiles % program_config.in0_block_w);
+    TT_FATAL(
+        weight_N_tiles == receiver_count * program_config.per_core_N,
+        "mcast_in0 global_cb weight N ({} tiles) must equal receiver_count ({}) * per_core_N ({}) = {}",
+        weight_N_tiles,
+        receiver_count,
+        program_config.per_core_N,
+        receiver_count * program_config.per_core_N);
+    const uint32_t in1_block_size_bytes =
+        program_config.in0_block_w * program_config.per_core_N *
+        in1_tile.get_tile_size(tt::tt_metal::datatype_to_dataformat_converter(input_tensor_b.dtype()));
+    TT_FATAL(
+        gcb.size() % in1_block_size_bytes == 0,
+        "mcast_in0 global_cb size {} must be a multiple of its in1 K-block page size {}",
+        gcb.size(),
+        in1_block_size_bytes);
+    TT_FATAL(
+        gcb.size() >= 2 * in1_block_size_bytes,
+        "mcast_in0 global_cb requires a two-page streaming window: size {} must be at least {}",
+        gcb.size(),
+        2 * in1_block_size_bytes);
+
+    const auto& nd_shard_spec = input_tensor_b.nd_shard_spec();
+    TT_FATAL(nd_shard_spec.has_value(), "mcast_in0 global_cb weight must have an NdShardSpec");
+    TT_FATAL(
+        nd_shard_spec->shard_shape.rank() == 2,
+        "mcast_in0 global_cb weight shard shape must be 2D, but got rank {}",
+        nd_shard_spec->shard_shape.rank());
+    TT_FATAL(
+        nd_shard_spec->shard_shape[0] == static_cast<uint32_t>(b_shape_padded[-2]) &&
+            nd_shard_spec->shard_shape[1] == static_cast<uint32_t>(program_config.per_core_N) * in1_tile.get_width(),
+        "mcast_in0 global_cb weight shard shape {} must be (K={}, per_core_N*tile_width={})",
+        nd_shard_spec->shard_shape,
+        b_shape_padded[-2],
+        program_config.per_core_N * in1_tile.get_width());
+    const auto& distribution = input_tensor_b.buffer()->buffer_distribution_spec();
+    TT_FATAL(distribution.has_value(), "mcast_in0 global_cb weight must have a BufferDistributionSpec");
+    TT_FATAL(
+        distribution->num_shards() == receiver_count,
+        "mcast_in0 global_cb weight has {} shards but the GCB has {} receivers",
+        distribution->num_shards(),
+        receiver_count);
+}
+
 // Helper: warns if a caller of MatmulDeviceOperation's static API hasn't populated
 // allowed_worker_cores on a program_config variant that supports the field. ttnn::prim::matmul()
 // normalizes its attributes before launch, but direct callers (e.g. CCL fused ops in
@@ -1713,6 +1796,26 @@ void validate_matmul_mcast1d_config(
         "{}: Matmul1D does not support mcast_in0 and gather_in0 at the "
         "same time.",
         config_name);
+    TT_FATAL(
+        program_config.gather_in0 || !program_config.stream_in1,
+        "{}: stream_in1 is the gather_in0 ring-rotation mode and requires gather_in0=true",
+        config_name);
+
+    if (attributes.global_cb.has_value() && !program_config.gather_in0) {
+        TT_FATAL(
+            program_config.mcast_in0,
+            "{}: global_cb without gather_in0 is supported only for mcast_in0=true",
+            config_name);
+        validate_dram_sender_global_cb_mcast_in0_geometry(
+            attributes.global_cb.value(), input_tensor_b, b_shape_padded, in1_tile, program_config);
+        TT_FATAL(
+            program_config.fuse_batch || get_batch_size(a_shape_padded) == 1,
+            "{}: mcast_in0 global_cb requires one effective activation batch, but fuse_batch={} and "
+            "activation batch size={}",
+            config_name,
+            program_config.fuse_batch,
+            get_batch_size(a_shape_padded));
+    }
 
     // Gather in0 specific validation
     if (program_config.gather_in0) {
@@ -1813,7 +1916,9 @@ void validate_matmul_mcast1d_config(
     } else {
         const auto device_grid_1d = input_tensor_a.device()->compute_with_storage_grid_size();
         check_tensor_in_grid(input_tensor_a, device_grid_1d);
-        check_tensor_in_grid(input_tensor_b, device_grid_1d);
+        if (!attributes.global_cb.has_value()) {
+            check_tensor_in_grid(input_tensor_b, device_grid_1d);
+        }
     }
     if (program_config.mcast_in0 || program_config.gather_in0) {
         if (input_tensor_a.is_sharded()) {
@@ -2065,7 +2170,7 @@ MatmulDeviceOperation::program_factory_t MatmulDeviceOperation::select_program_f
     const auto& config = operation_attributes.program_config.value();
 
     return std::visit(
-        [](const auto& c) -> program_factory_t {
+        [&operation_attributes](const auto& c) -> program_factory_t {
             using T = std::decay_t<decltype(c)>;
             if constexpr (std::is_same_v<T, operations::matmul::MatmulMultiCoreProgramConfig>) {
                 return MatmulMultiCoreProgramFactory{};
@@ -2074,8 +2179,9 @@ MatmulDeviceOperation::program_factory_t MatmulDeviceOperation::select_program_f
             } else if constexpr (std::is_same_v<T, operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig>) {
                 return MatmulMultiCoreReuseMcast2DProgramFactory{};
             } else if constexpr (std::is_same_v<T, operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
-                // gather_in0 uses the legacy MeshWorkload path (create_descriptor not yet supported)
-                if (c.gather_in0) {
+                // GCB-backed paths use the legacy MeshWorkload builder because ProgramDescriptor
+                // cannot attach an experimental GlobalCircularBuffer.
+                if (c.gather_in0 || (c.mcast_in0 && operation_attributes.global_cb.has_value())) {
                     return MatmulMeshWorkloadMultiCoreReuseMcast1DProgramFactory{};
                 }
                 return MatmulMultiCoreReuseMcast1DProgramFactory{};

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -11,6 +11,7 @@
 #include "ttnn/operations/matmul/device/utilities/matmul_utilities.hpp"
 #include "tt-metalium/hal_types.hpp"
 #include "tt-metalium/experimental/global_circular_buffer.hpp"
+#include "ttnn/global_circular_buffer.hpp"
 #include "tt-metalium/work_split.hpp"
 #include "tt_stl/reflection.hpp"
 #include "tt_stl/unreachable.hpp"
@@ -1036,23 +1037,11 @@ void validate_dram_sender_global_cb_gather_in0_geometry_recv_contig(
 void validate_dram_sender_global_cb_mcast_in0_geometry(
     const tt::tt_metal::experimental::GlobalCircularBuffer& gcb,
     const Tensor& input_tensor_b,
-    const ttnn::Shape& b_shape_padded,
     const tt::tt_metal::Tile& in1_tile,
     const operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig& program_config) {
     TT_FATAL(
         tt::tt_metal::experimental::sender_core_type(gcb) == tt::tt_metal::experimental::SenderCoreType::Dram,
         "mcast_in0 global_cb requires programmable DRAM senders");
-    TT_FATAL(
-        input_tensor_b.buffer() != nullptr && input_tensor_b.buffer()->is_dram(),
-        "mcast_in0 global_cb requires an in1 weight in DRAM");
-    TT_FATAL(
-        input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::ND_SHARDED,
-        "mcast_in0 global_cb requires a receiver-contiguous ND_SHARDED in1 weight, but got {}",
-        input_tensor_b.memory_config().memory_layout());
-    TT_FATAL(
-        !program_config.stream_in1,
-        "mcast_in0 global_cb consumes natural-order K-blocks and requires stream_in1=false");
-    TT_FATAL(program_config.in0_block_w > 0, "mcast_in0 global_cb requires in0_block_w > 0");
     TT_FATAL(
         program_config.out_block_h == program_config.per_core_M &&
             program_config.out_block_w == program_config.per_core_N,
@@ -1063,23 +1052,14 @@ void validate_dram_sender_global_cb_mcast_in0_geometry(
         program_config.out_block_w,
         program_config.per_core_N);
 
-    const uint32_t receiver_count = gcb.receiver_cores().num_cores();
-    TT_FATAL(receiver_count > 0, "mcast_in0 global_cb has no receivers");
-    const uint32_t weight_K_tiles = b_shape_padded[-2] / in1_tile.get_height();
-    const uint32_t weight_N_tiles = b_shape_padded[-1] / in1_tile.get_width();
-    TT_FATAL(
-        weight_K_tiles % program_config.in0_block_w == 0,
-        "mcast_in0 global_cb weight K ({} tiles) must be divisible by in0_block_w ({}); remainder {}",
-        weight_K_tiles,
-        program_config.in0_block_w,
-        weight_K_tiles % program_config.in0_block_w);
-    TT_FATAL(
-        weight_N_tiles == receiver_count * program_config.per_core_N,
-        "mcast_in0 global_cb weight N ({} tiles) must equal receiver_count ({}) * per_core_N ({}) = {}",
-        weight_N_tiles,
-        receiver_count,
-        program_config.per_core_N,
-        receiver_count * program_config.per_core_N);
+    // The receiver-contiguous weight ↔ matmul cross-checks (DRAM NdShardSpec, one full-K × per_core_N
+    // shard per receiver, num_shards == receiver_count, K % in0_block_w == 0, per_core_N == per-receiver
+    // N, stream_in1 == false) are owned by the shared prefetcher helper. Call it rather than re-deriving
+    // them here, so the recv-contig contract lives in one place.
+    ttnn::global_circular_buffer::tensor_prefetcher_block_count_for_matmul_1d(program_config, input_tensor_b, gcb);
+
+    // GCB-window guards specific to this op: the mcast reader streams K-blocks through a two-page
+    // remote-CB window, so the GCB must be an exact multiple of the in1 K-block page and hold >= 2 pages.
     const uint32_t in1_block_size_bytes =
         program_config.in0_block_w * program_config.per_core_N *
         in1_tile.get_tile_size(tt::tt_metal::datatype_to_dataformat_converter(input_tensor_b.dtype()));
@@ -1093,27 +1073,6 @@ void validate_dram_sender_global_cb_mcast_in0_geometry(
         "mcast_in0 global_cb requires a two-page streaming window: size {} must be at least {}",
         gcb.size(),
         2 * in1_block_size_bytes);
-
-    const auto& nd_shard_spec = input_tensor_b.nd_shard_spec();
-    TT_FATAL(nd_shard_spec.has_value(), "mcast_in0 global_cb weight must have an NdShardSpec");
-    TT_FATAL(
-        nd_shard_spec->shard_shape.rank() == 2,
-        "mcast_in0 global_cb weight shard shape must be 2D, but got rank {}",
-        nd_shard_spec->shard_shape.rank());
-    TT_FATAL(
-        nd_shard_spec->shard_shape[0] == static_cast<uint32_t>(b_shape_padded[-2]) &&
-            nd_shard_spec->shard_shape[1] == static_cast<uint32_t>(program_config.per_core_N) * in1_tile.get_width(),
-        "mcast_in0 global_cb weight shard shape {} must be (K={}, per_core_N*tile_width={})",
-        nd_shard_spec->shard_shape,
-        b_shape_padded[-2],
-        program_config.per_core_N * in1_tile.get_width());
-    const auto& distribution = input_tensor_b.buffer()->buffer_distribution_spec();
-    TT_FATAL(distribution.has_value(), "mcast_in0 global_cb weight must have a BufferDistributionSpec");
-    TT_FATAL(
-        distribution->num_shards() == receiver_count,
-        "mcast_in0 global_cb weight has {} shards but the GCB has {} receivers",
-        distribution->num_shards(),
-        receiver_count);
 }
 
 // Helper: warns if a caller of MatmulDeviceOperation's static API hasn't populated
@@ -1807,7 +1766,7 @@ void validate_matmul_mcast1d_config(
             "{}: global_cb without gather_in0 is supported only for mcast_in0=true",
             config_name);
         validate_dram_sender_global_cb_mcast_in0_geometry(
-            attributes.global_cb.value(), input_tensor_b, b_shape_padded, in1_tile, program_config);
+            attributes.global_cb.value(), input_tensor_b, in1_tile, program_config);
         TT_FATAL(
             program_config.fuse_batch || get_batch_size(a_shape_padded) == 1,
             "{}: mcast_in0 global_cb requires one effective activation batch, but fuse_batch={} and "
@@ -2179,9 +2138,10 @@ MatmulDeviceOperation::program_factory_t MatmulDeviceOperation::select_program_f
             } else if constexpr (std::is_same_v<T, operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig>) {
                 return MatmulMultiCoreReuseMcast2DProgramFactory{};
             } else if constexpr (std::is_same_v<T, operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
-                // GCB-backed paths use the legacy MeshWorkload builder because ProgramDescriptor
-                // cannot attach an experimental GlobalCircularBuffer.
-                if (c.gather_in0 || (c.mcast_in0 && operation_attributes.global_cb.has_value())) {
+                // gather_in0 (create_descriptor not yet supported) and any GCB-backed config
+                // (ProgramDescriptor cannot attach an experimental GlobalCircularBuffer) use the legacy
+                // MeshWorkload builder.
+                if (c.gather_in0 || operation_attributes.global_cb.has_value()) {
                     return MatmulMeshWorkloadMultiCoreReuseMcast1DProgramFactory{};
                 }
                 return MatmulMultiCoreReuseMcast1DProgramFactory{};

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
@@ -522,12 +522,10 @@ void py_module(nb::module_& mod) {
             compute grid. Accepts a ``CoreRangeSet`` describing the exact cores to use.
         )doc")
         .def_rw("stream_in1", &MatmulMultiCoreReuseMultiCast1DProgramConfig::stream_in1, R"doc(
-            Stream in1 weights from the GCB in ring-rotated FIFO order (gather_in0 + DRAM-sender
-            GCB only). When true, each weight block is consumed as it arrives instead of waiting
-            for the whole tensor, so the GCB can be sized to a small live window. The weight MUST
-            be queued for streaming (the ``(weight, block_count, rotation)`` form of
-            ``queue_tensor_prefetcher_request``, passing the per-receiver ring-rotation list) to
-            match, else the matmul deadlocks. Defaults to false.
+            Select ring-rotated FIFO delivery for gather_in0 with a DRAM-sender GCB. The weight
+            MUST be queued with the ``(weight, block_count, rotation)`` request form. GCB-backed
+            mcast_in0 consumes natural FIFO order and requires this flag to remain false.
+            Defaults to false.
         )doc")
         .def("__repr__", [](const MatmulMultiCoreReuseMultiCast1DProgramConfig& config) {
             return fmt::format(

--- a/ttnn/ttnn/_experimental/tensor_prefetcher_matmul.py
+++ b/ttnn/ttnn/_experimental/tensor_prefetcher_matmul.py
@@ -67,8 +67,11 @@ def prefetch_and_linear(
         # Gather consumes one K-block per ring position.
         block_count = global_cb.receiver_cores().num_cores()
 
-    # Streaming gather needs identity ring rotation. Mcast consumes natural FIFO
-    # order and therefore uses the rotation-free request.
+    # Streaming gather needs identity ring rotation (``rotation[r] = r``). That table is
+    # layout-agnostic -- identical for ROUND_ROBIN_1D and CONTIGUOUS_1D receiver-contiguous
+    # weights -- because the kernel slices it by each weight's own global receiver position,
+    # so no distribution-strategy argument is needed here. Mcast consumes natural FIFO order
+    # and therefore uses the rotation-free request.
     if program_config.stream_in1:
         request = (weight, block_count, list(range(block_count)))
     else:

--- a/ttnn/ttnn/_experimental/tensor_prefetcher_matmul.py
+++ b/ttnn/ttnn/_experimental/tensor_prefetcher_matmul.py
@@ -7,19 +7,16 @@
 ``ttnn.experimental.queue_tensor_prefetcher_request`` (fills a DRAM-sender
 GlobalCircularBuffer over NOC, off the command queue) and the ``ttnn.linear``
 that drains that GCB are always issued as a pair, against the *same* GCB and the
-*same* gather_in0 program config. As two separate calls the caller has to (a)
+*same* 1D program config. As two separate calls the caller has to (a)
 hand both the same ``global_cb``, (b) hand both the same ``program_config``, and
 (c) pass a prefetch ``block_count`` that matches what the matmul expects -- three
 couplings nothing enforces.
 
 ``prefetch_and_linear`` issues the pair from one call site so they cannot drift:
-it derives ``block_count`` from ``global_cb``, queues the request, then runs the
-consuming ``ttnn.linear`` with the same GCB and program config. The matmul does
-``wait_front(ring_size)`` per layer, so the only correct ``block_count`` is the
-GCB's receiver count -- which holds for every weight layout (WIDTH_SHARDED and
-receiver-contiguous alike), so the caller never specifies it. The weight↔config
-geometry was already validated when the GCB was built (and ``ttnn.linear``
-re-checks it), so there is nothing left to cross-check here.
+it derives ``block_count``, queues the request, then runs the consuming
+``ttnn.linear`` with the same GCB and program config. Gather-in0 uses one block
+per ring receiver. Mcast-in0 uses ``K_tiles / in0_block_w`` natural-order blocks
+per receiver and requires a receiver-contiguous weight.
 
 This is a host-side composition, not a device-level fusion: the prefetch still
 runs on the DRAM-core (DRISC) path off the command queue while the matmul is
@@ -41,23 +38,19 @@ def prefetch_and_linear(
     **linear_kwargs,
 ):
     """Queue a DRAM-core prefetch of ``weight`` into ``global_cb``, then run the
-    gather_in0 1D matmul (``ttnn.linear``) that consumes it.
+    1D matmul (``ttnn.linear``) that consumes it.
 
-    Batched vs streaming delivery is selected automatically from
-    ``program_config.stream_in1`` -- there is no separate argument. When it is set the
-    prefetch streams the weight's K-blocks in natural ring order (identity rotation) so
-    the matmul can consume them FIFO from a shallow GCB; this works for both
-    ROUND_ROBIN_1D and CONTIGUOUS_1D receiver-contiguous weights. When it is unset the
-    request is batched (the whole per-receiver slab is delivered before the matmul reads).
+    Gather-in0 preserves its existing batched/streaming behavior selected by
+    ``program_config.stream_in1``. Mcast-in0 always uses natural FIFO order with
+    ``stream_in1=False`` and can consume from a shallow GCB without a rotation table.
 
     Args:
-        input_tensor_a: Activation (in0), width-sharded on the receiver cores.
-        weight: DRAM-sharded weight (in1) to prefetch and multiply by. Streaming
-            (``stream_in1``) additionally requires a receiver-contiguous weight layout.
+        input_tensor_a: Activation (in0).
+        weight: DRAM-sharded weight (in1) to prefetch and multiply by. Streaming gather
+            and GCB-backed mcast require a receiver-contiguous weight layout.
         global_cb: DRAM-sender GlobalCircularBuffer shared by the prefetch and
-            the matmul. Its receiver count fixes the prefetch ``block_count``.
-        program_config: gather_in0 1D mcast matmul program config driving the matmul;
-            its ``stream_in1`` flag selects streaming vs batched prefetch delivery.
+            the matmul.
+        program_config: 1D matmul program config driving the matmul.
         cq_id: Command queue for the prefetch request. When that CQ is mid
             trace-capture the request is captured into the trace. Defaults to the
             current command queue.
@@ -68,19 +61,14 @@ def prefetch_and_linear(
         The ``ttnn.linear`` output tensor.
     """
     device = input_tensor_a.device()
-    # block_count == ring_size == total GCB receivers: the matmul does
-    # wait_front(ring_size) per layer, so this is the only value that balances the
-    # page credits, regardless of the weight's shard layout.
-    block_count = global_cb.receiver_cores().num_cores()
-    # Streaming vs batched is decided entirely by the matmul's program config, so the
-    # caller passes no extra argument. With ``stream_in1`` the matmul consumes K-blocks
-    # FIFO as they land (letting the GCB hold only a shallow window), so the prefetch
-    # must deliver them in natural ring order -- an identity rotation table
-    # (``rotation[r] = r``). That table is layout-agnostic: it is identical for
-    # ROUND_ROBIN_1D and CONTIGUOUS_1D weights because the kernel slices it by each
-    # weight's own global receiver position, so no distribution-strategy argument is
-    # needed here. Without ``stream_in1`` the matmul waits for the whole per-receiver
-    # slab, so we queue the batched (rotation-free) request.
+    if program_config.mcast_in0 or program_config.stream_in1:
+        block_count = ttnn.experimental.tensor_prefetcher_block_count_for_matmul_1d(program_config, weight, global_cb)
+    else:
+        # Gather consumes one K-block per ring position.
+        block_count = global_cb.receiver_cores().num_cores()
+
+    # Streaming gather needs identity ring rotation. Mcast consumes natural FIFO
+    # order and therefore uses the rotation-free request.
     if program_config.stream_in1:
         request = (weight, block_count, list(range(block_count)))
     else:


### PR DESCRIPTION
### PR Category
Feature

### Summary
Closes #49425

Enable non-gathering 1D `mcast_in0` matmul workers to consume receiver-contiguous in1 weights directly from a DRAM-sender Global Circular Buffer. The tensor prefetcher uses natural FIFO delivery with `block_count = K_tiles / in0_block_w`, while `stream_in1` remains specific to ring-rotated `gather_in0`.

This change generalizes the GCB validation and sizing contract, routes GCB-backed mcast through the legacy MeshWorkload builder, adds the remote wait/push/engine-ack/pop pipeline to the in1 reader, and documents the second consumer contract.

### Notes for reviewers
- Initial support intentionally requires one output block per worker and one effective activation batch.
- The focused Blackhole PCC test uses a two-page GCB and a block count different from the receiver count. It covers both ROUND_ROBIN_1D and CONTIGUOUS_1D receiver-contiguous weights.
- Verification: `~/bin-metal/build_metal.sh`; 2 focused mcast-in0 PCC cases passed; 2 focused gather-in0 streaming regression cases passed; `pre-commit run --from-ref main --to-ref HEAD` passed.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/stream-gcb-mcast-in0)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/stream-gcb-mcast-in0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/stream-gcb-mcast-in0)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/stream-gcb-mcast-in0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jbauman/stream-gcb-mcast-in0)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jbauman/stream-gcb-mcast-in0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/stream-gcb-mcast-in0)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/stream-gcb-mcast-in0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/stream-gcb-mcast-in0)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/stream-gcb-mcast-in0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/stream-gcb-mcast-in0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/stream-gcb-mcast-in0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/stream-gcb-mcast-in0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/stream-gcb-mcast-in0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/stream-gcb-mcast-in0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/stream-gcb-mcast-in0)