### PR TITLE
[Bug fix] Gather race barrier

### DIFF
--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -764,7 +764,11 @@ class TTSampling(LightweightModule):
             user_ids=self.user_ids_tt_tensor,
             sub_core_grids=self._sampling_sub_core_grids,
         )
-        # Perform the actual sampling with top-k, top-p, and temperature
+        # Perform the actual sampling with top-k, top-p, and temperature. When the CCL layer provides a
+        # WAR semaphore (llama3_70b_galaxy decode), each sampling core multicast-signals it after its
+        # final read so the next step's SAMPLING_VALUES gather can safely reuse the persistent buffer.
+        war_semaphore = getattr(self.tt_ccl, "war_semaphore", None)
+        war_sem_drain_core = getattr(self.tt_ccl, "war_sem_drain_core", None)
         tt_out_tok = ttnn.sampling(
             topk_values_gathered_bf16_interleaved,
             topk_global_indices_interleaved_untilised,
@@ -773,6 +777,8 @@ class TTSampling(LightweightModule):
             temp=self.temp_tensor,
             sub_core_grids=self._sampling_sub_core_grids,
             output_tensor=tt_out_tok,
+            war_semaphore=war_semaphore,
+            war_sem_drain_core=war_sem_drain_core,
         )
 
         # Compute logprobs if enabled

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -10,10 +10,7 @@ from loguru import logger
 
 import ttnn
 from models.common.lightweightmodule import LightweightModule
-from models.common.sampling._utils import compact_debug_list as _compact_debug_list
-from models.common.sampling._utils import is_default_value, is_llama33_70b_model, is_power_of_2
-from models.common.sampling._utils import log_sampling_debug as _log_sampling_debug
-from models.common.sampling._utils import upper_power_of_2
+from models.common.sampling._utils import is_default_value, is_power_of_2, upper_power_of_2
 from models.common.sampling.tt_log_probs import LogProbsCalculator
 from models.common.sampling.vocab_padding import (
     build_invalid_vocab_mask,
@@ -105,7 +102,6 @@ class TTSampling(LightweightModule):
     ):
         super().__init__()
         self.mesh_device = mesh_device
-        self._sampling_debug_enabled = is_llama33_70b_model(args)
         # Multi-step reduction is supported only on single device
         self.multi_step_reduction = list(mesh_device.shape) == [1, 1]
         self.tt_ccl = tt_ccl
@@ -515,18 +511,6 @@ class TTSampling(LightweightModule):
     ):
         """Update sampling parameters (k, p, temperature, logprobs) dynamically."""
         self._force_argmax_sampling = self._is_force_argmax_sampling(k, p, temp)
-        _log_sampling_debug(
-            self._sampling_debug_enabled,
-            "TTSampling reset params",
-            force_argmax=self._force_argmax_sampling,
-            empty_slots=_compact_debug_list(empty_slots),
-            top_k=_compact_debug_list(k),
-            top_p=_compact_debug_list(p),
-            temperature=_compact_debug_list(temp),
-            enable_log_probs=_compact_debug_list(enable_log_probs),
-            num_logprobs=_compact_debug_list(num_logprobs),
-            sampling_dp=self._sampling_dp,
-        )
         if not self._force_argmax_sampling:
             # When _sampling_dp > 1, create multi-device host tensors so
             # copy_host_to_device_tensor writes per-row shards correctly.
@@ -584,16 +568,6 @@ class TTSampling(LightweightModule):
         Returns:
             Sampled token indices tensor
         """
-        _log_sampling_debug(
-            self._sampling_debug_enabled,
-            "TTSampling forward",
-            force_argmax=self._force_argmax_sampling,
-            logits_shape=list(x.shape),
-            tt_out_tok_shape=list(tt_out_tok.shape) if tt_out_tok is not None else None,
-            max_top_k=self.max_top_k,
-            multi_step_reduction=self.multi_step_reduction,
-            sampling_dp=self._sampling_dp,
-        )
         if self._force_argmax_sampling:
             logger.info("Forcing argmax sampling")
             slice_valid_vocab = self._can_slice_valid_vocab_for_argmax()

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -739,10 +739,11 @@ class TTSampling(LightweightModule):
             sub_core_grids=self._sampling_sub_core_grids,
         )
         # Perform the actual sampling with top-k, top-p, and temperature. When the CCL layer provides a
-        # WAR semaphore (llama3_70b_galaxy decode), each sampling core multicast-signals it after its
-        # final read so the next step's SAMPLING_VALUES gather can safely reuse the persistent buffer.
-        war_semaphore = getattr(self.tt_ccl, "war_semaphore", None)
-        war_sem_drain_core = getattr(self.tt_ccl, "war_sem_drain_core", None)
+        # buffer-reuse sync semaphore (llama3_70b_galaxy decode), each sampling core multicast-signals it
+        # after its final read so the next step's SAMPLING_VALUES gather can safely reuse the persistent
+        # buffer (closing the cross-sub-device write-after-read race that only manifests under trace).
+        buffer_reuse_sync_semaphore = getattr(self.tt_ccl, "buffer_reuse_sync_semaphore", None)
+        buffer_reuse_sync_sem_drain_core = getattr(self.tt_ccl, "buffer_reuse_sync_sem_drain_core", None)
         tt_out_tok = ttnn.sampling(
             topk_values_gathered_bf16_interleaved,
             topk_global_indices_interleaved_untilised,
@@ -751,8 +752,8 @@ class TTSampling(LightweightModule):
             temp=self.temp_tensor,
             sub_core_grids=self._sampling_sub_core_grids,
             output_tensor=tt_out_tok,
-            war_semaphore=war_semaphore,
-            war_sem_drain_core=war_sem_drain_core,
+            buffer_reuse_sync_semaphore=buffer_reuse_sync_semaphore,
+            buffer_reuse_sync_sem_drain_core=buffer_reuse_sync_sem_drain_core,
         )
 
         # Compute logprobs if enabled

--- a/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
@@ -81,6 +81,17 @@ class TT_CCL:
             )
         self.weight_cache_path = model_args.weight_cache_path(ttnn.bfloat8_b)
         self.num_cbs = 2
+        # When a persistent output buffer is reused across non-blocking decode
+        # trace replays, line_all_gather normally drops the barrier semaphore
+        # (persistent buffer treated as a substitute for barrier syncing). That
+        # is unsafe for the sampling gathers (SAMPLING_VALUES/SAMPLING_INDICES):
+        # their consumers (ttnn.add offset / ttnn.sampling) run on the sampling
+        # sub-core grid, a different sub-device than the gather worker, so without
+        # a barrier the next step's gather can overwrite the buffer before the
+        # current step finishes reading it -> a few of 32 slots get stale
+        # candidates -> non-deterministic first decode token (flaky for months).
+        # Keep the barrier for these gathers even with a persistent buffer.
+        self._barrier_buffer_keys = {"SAMPLING_VALUES", "SAMPLING_INDICES", "SAMPLING"}
         self.from_remote_semaphore_handles = []
         self.to_remote_semaphore_handles = []
         self.cluster_shape = model_args.cluster_shape
@@ -1255,7 +1266,11 @@ class TT_CCL:
             # Wormhole / prefetcher path uses the experimental async all-gather (identical to main).
             # The Blackhole no-prefetcher bring-up uses the stable public all_gather below.
             barrier_semaphore = None
-            if persistent_buffer is None:
+            if persistent_buffer is None or buffer_key in self._barrier_buffer_keys:
+                # persistent_buffer is None -> normal barrier. buffer_key in the
+                # sampling set -> persistent buffer present but reused cross-step by a
+                # different sub-device consumer, so keep the barrier to enforce
+                # consume-before-overwrite ordering and restore deterministic sampling.
                 barrier_semaphore = self.get_and_cycle_barrier_semaphore_handle(cluster_axis)
             semaphores = (
                 self.gather_semaphore_handles[cluster_axis][self.gather_idx[cluster_axis]][0]

--- a/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
@@ -81,17 +81,6 @@ class TT_CCL:
             )
         self.weight_cache_path = model_args.weight_cache_path(ttnn.bfloat8_b)
         self.num_cbs = 2
-        # When a persistent output buffer is reused across non-blocking decode
-        # trace replays, line_all_gather normally drops the barrier semaphore
-        # (persistent buffer treated as a substitute for barrier syncing). That
-        # is unsafe for the sampling gathers (SAMPLING_VALUES/SAMPLING_INDICES):
-        # their consumers (ttnn.add offset / ttnn.sampling) run on the sampling
-        # sub-core grid, a different sub-device than the gather worker, so without
-        # a barrier the next step's gather can overwrite the buffer before the
-        # current step finishes reading it -> a few of 32 slots get stale
-        # candidates -> non-deterministic first decode token (flaky for months).
-        # Keep the barrier for these gathers even with a persistent buffer.
-        self._barrier_buffer_keys = {"SAMPLING_VALUES", "SAMPLING_INDICES", "SAMPLING"}
         self.from_remote_semaphore_handles = []
         self.to_remote_semaphore_handles = []
         self.cluster_shape = model_args.cluster_shape
@@ -148,6 +137,27 @@ class TT_CCL:
         self.barrier_semaphore_idx = [0, 0]
         self.persistent_buffers = {}
         self.all_gather_buffers = {}
+        # WAR-hazard semaphore for safe reuse of the persistent SAMPLING_VALUES/INDICES all-gather
+        # buffers under decode trace. After its final read, the downstream sampling op increments this
+        # (once per user core) on the SAMPLING_VALUES gather's drain core; that gather waits on it
+        # before overwriting the buffer, closing the cross-sub-device Write-After-Read race that made
+        # the first decode token non-deterministic under trace. Created on sub_device_crs (a superset
+        # of the CCL worker cores, so the drain core's local copy is allocated).
+        #
+        # war_sem_drain_core is the gather's drain core = choose_worker_cores(worker_sub_device_id)[0]
+        # = first row-wise core of worker_cores_range_set (model_config.get_core_ranges), which is
+        # (1, 0). If that worker-core layout ever changes, update this coordinate to match.
+        self.war_semaphore = None
+        self.war_sem_drain_core = None
+        self.war_sem_wait_value = self.max_batch_size
+        if mode == "decode":
+            self.war_sem_drain_core = ttnn.CoreCoord(1, 0)
+            # Init value == wait value so the very first decode step's gather wait passes immediately
+            # (no prior sampling has signalled yet); each step then rebalances (32 signals -> reset 0).
+            self.war_semaphore = ttnn.create_global_semaphore(
+                self.mesh_device, self.sub_device_crs, self.war_sem_wait_value
+            )
+
         if mode == "decode":
             self.persistent_buffers = self.get_persistent_buffers()
             self.all_gather_buffers = self.get_all_gather_buffers()
@@ -1266,11 +1276,7 @@ class TT_CCL:
             # Wormhole / prefetcher path uses the experimental async all-gather (identical to main).
             # The Blackhole no-prefetcher bring-up uses the stable public all_gather below.
             barrier_semaphore = None
-            if persistent_buffer is None or buffer_key in self._barrier_buffer_keys:
-                # persistent_buffer is None -> normal barrier. buffer_key in the
-                # sampling set -> persistent buffer present but reused cross-step by a
-                # different sub-device consumer, so keep the barrier to enforce
-                # consume-before-overwrite ordering and restore deterministic sampling.
+            if persistent_buffer is None:
                 barrier_semaphore = self.get_and_cycle_barrier_semaphore_handle(cluster_axis)
             semaphores = (
                 self.gather_semaphore_handles[cluster_axis][self.gather_idx[cluster_axis]][0]
@@ -1280,6 +1286,11 @@ class TT_CCL:
                     self.gather_semaphore_handles[cluster_axis][(self.gather_idx[cluster_axis] + 1) % self.num_cbs],
                 ]
             )
+            # Only the SAMPLING_VALUES gather (first sampling gather of the decode step) waits on the WAR
+            # semaphore; being first on the worker sub-device it program-orders the whole sampling section
+            # after the previous step's ttnn.sampling, so the later SAMPLING_INDICES gather is safe too.
+            war_semaphore = self.war_semaphore if buffer_key == "SAMPLING_VALUES" else None
+            war_wait_value = self.war_sem_wait_value if buffer_key == "SAMPLING_VALUES" else None
             ttnn_tensor_out = ttnn.experimental.all_gather_async(
                 input_tensor_mesh,
                 dim,
@@ -1293,6 +1304,8 @@ class TT_CCL:
                 memory_config=memory_config,
                 subdevice_id=self.worker_sub_device_id if use_subdevice else None,
                 use_optimal_ccl_for_llama=use_optimal_ccl_for_llama,
+                war_semaphore=war_semaphore,
+                war_wait_value=war_wait_value,
             )
         else:
             # Default to the stable/public all_gather API.

--- a/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_ccl.py
@@ -137,25 +137,25 @@ class TT_CCL:
         self.barrier_semaphore_idx = [0, 0]
         self.persistent_buffers = {}
         self.all_gather_buffers = {}
-        # WAR-hazard semaphore for safe reuse of the persistent SAMPLING_VALUES/INDICES all-gather
+        # buffer-reuse sync semaphore for safe reuse of the persistent SAMPLING_VALUES/INDICES all-gather
         # buffers under decode trace. After its final read, the downstream sampling op increments this
         # (once per user core) on the SAMPLING_VALUES gather's drain core; that gather waits on it
         # before overwriting the buffer, closing the cross-sub-device Write-After-Read race that made
         # the first decode token non-deterministic under trace. Created on sub_device_crs (a superset
         # of the CCL worker cores, so the drain core's local copy is allocated).
         #
-        # war_sem_drain_core is the gather's drain core = choose_worker_cores(worker_sub_device_id)[0]
+        # buffer_reuse_sync_sem_drain_core is the gather's drain core = choose_worker_cores(worker_sub_device_id)[0]
         # = first row-wise core of worker_cores_range_set (model_config.get_core_ranges), which is
         # (1, 0). If that worker-core layout ever changes, update this coordinate to match.
-        self.war_semaphore = None
-        self.war_sem_drain_core = None
-        self.war_sem_wait_value = self.max_batch_size
+        self.buffer_reuse_sync_semaphore = None
+        self.buffer_reuse_sync_sem_drain_core = None
+        self.buffer_reuse_sync_sem_wait_value = self.max_batch_size
         if mode == "decode":
-            self.war_sem_drain_core = ttnn.CoreCoord(1, 0)
+            self.buffer_reuse_sync_sem_drain_core = ttnn.CoreCoord(1, 0)
             # Init value == wait value so the very first decode step's gather wait passes immediately
             # (no prior sampling has signalled yet); each step then rebalances (32 signals -> reset 0).
-            self.war_semaphore = ttnn.create_global_semaphore(
-                self.mesh_device, self.sub_device_crs, self.war_sem_wait_value
+            self.buffer_reuse_sync_semaphore = ttnn.create_global_semaphore(
+                self.mesh_device, self.sub_device_crs, self.buffer_reuse_sync_sem_wait_value
             )
 
         if mode == "decode":
@@ -1286,11 +1286,12 @@ class TT_CCL:
                     self.gather_semaphore_handles[cluster_axis][(self.gather_idx[cluster_axis] + 1) % self.num_cbs],
                 ]
             )
-            # Only the SAMPLING_VALUES gather (first sampling gather of the decode step) waits on the WAR
-            # semaphore; being first on the worker sub-device it program-orders the whole sampling section
-            # after the previous step's ttnn.sampling, so the later SAMPLING_INDICES gather is safe too.
-            war_semaphore = self.war_semaphore if buffer_key == "SAMPLING_VALUES" else None
-            war_wait_value = self.war_sem_wait_value if buffer_key == "SAMPLING_VALUES" else None
+            # Only the SAMPLING_VALUES gather (first sampling gather of the decode step) waits on the
+            # buffer-reuse sync semaphore; being first on the worker sub-device it program-orders the whole
+            # sampling section after the previous step's ttnn.sampling, so the later SAMPLING_INDICES gather
+            # is safe too.
+            buffer_reuse_sync_semaphore = self.buffer_reuse_sync_semaphore if buffer_key == "SAMPLING_VALUES" else None
+            buffer_reuse_sync_sem_wait_value = self.buffer_reuse_sync_sem_wait_value if buffer_key == "SAMPLING_VALUES" else None
             ttnn_tensor_out = ttnn.experimental.all_gather_async(
                 input_tensor_mesh,
                 dim,
@@ -1304,8 +1305,8 @@ class TT_CCL:
                 memory_config=memory_config,
                 subdevice_id=self.worker_sub_device_id if use_subdevice else None,
                 use_optimal_ccl_for_llama=use_optimal_ccl_for_llama,
-                war_semaphore=war_semaphore,
-                war_wait_value=war_wait_value,
+                buffer_reuse_sync_semaphore=buffer_reuse_sync_semaphore,
+                buffer_reuse_sync_sem_wait_value=buffer_reuse_sync_sem_wait_value,
             )
         else:
             # Default to the stable/public all_gather API.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
@@ -210,7 +210,9 @@ ttnn::Tensor all_gather_async(
     bool reverse_order,
     const std::optional<CoreRangeSet>& sub_core_grid,
     std::optional<uint32_t> num_workers_per_link,
-    std::optional<uint32_t> num_buffers_per_channel) {
+    std::optional<uint32_t> num_buffers_per_channel,
+    const std::optional<GlobalSemaphore>& war_semaphore,
+    std::optional<uint32_t> war_wait_value) {
     uint32_t resolved_links =
         num_preferred_links.value_or(ttnn::operations::ccl::common::get_num_links(mesh_device, cluster_axis));
     tt::tt_fabric::Topology usable_topology = ::ttnn::ccl::get_usable_topology(input_tensor, topology, cluster_axis);
@@ -244,7 +246,9 @@ ttnn::Tensor all_gather_async(
         /*num_buffers_per_channel*/ num_buffers_per_channel,
         reverse_order,
         sub_core_grid,
-        &mesh_device);
+        &mesh_device,
+        war_semaphore,
+        war_wait_value);
 }
 
 // Reversed: overload with sub-core grids

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.cpp
@@ -211,8 +211,8 @@ ttnn::Tensor all_gather_async(
     const std::optional<CoreRangeSet>& sub_core_grid,
     std::optional<uint32_t> num_workers_per_link,
     std::optional<uint32_t> num_buffers_per_channel,
-    const std::optional<GlobalSemaphore>& war_semaphore,
-    std::optional<uint32_t> war_wait_value) {
+    const std::optional<GlobalSemaphore>& buffer_reuse_sync_semaphore,
+    std::optional<uint32_t> buffer_reuse_sync_sem_wait_value) {
     uint32_t resolved_links =
         num_preferred_links.value_or(ttnn::operations::ccl::common::get_num_links(mesh_device, cluster_axis));
     tt::tt_fabric::Topology usable_topology = ::ttnn::ccl::get_usable_topology(input_tensor, topology, cluster_axis);
@@ -247,8 +247,8 @@ ttnn::Tensor all_gather_async(
         reverse_order,
         sub_core_grid,
         &mesh_device,
-        war_semaphore,
-        war_wait_value);
+        buffer_reuse_sync_semaphore,
+        buffer_reuse_sync_sem_wait_value);
 }
 
 // Reversed: overload with sub-core grids

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.hpp
@@ -83,7 +83,9 @@ ttnn::Tensor all_gather_async(
     bool reverse_order = false,
     const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt,
     std::optional<uint32_t> num_workers_per_link = std::nullopt,
-    std::optional<uint32_t> num_buffers_per_channel = std::nullopt);
+    std::optional<uint32_t> num_buffers_per_channel = std::nullopt,
+    const std::optional<GlobalSemaphore>& war_semaphore = std::nullopt,
+    std::optional<uint32_t> war_wait_value = std::nullopt);
 
 // Reversed: overload with sub-core grids
 ttnn::Tensor all_gather_async_reversed(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async.hpp
@@ -84,8 +84,8 @@ ttnn::Tensor all_gather_async(
     const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt,
     std::optional<uint32_t> num_workers_per_link = std::nullopt,
     std::optional<uint32_t> num_buffers_per_channel = std::nullopt,
-    const std::optional<GlobalSemaphore>& war_semaphore = std::nullopt,
-    std::optional<uint32_t> war_wait_value = std::nullopt);
+    const std::optional<GlobalSemaphore>& buffer_reuse_sync_semaphore = std::nullopt,
+    std::optional<uint32_t> buffer_reuse_sync_sem_wait_value = std::nullopt);
 
 // Reversed: overload with sub-core grids
 ttnn::Tensor all_gather_async_reversed(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async_nanobind.cpp
@@ -156,7 +156,9 @@ ttnn::Tensor all_gather_async_wrapper_mesh_device(
     const std::optional<GlobalSemaphore>& barrier_semaphore,
     const std::optional<CoreRangeSet>& sub_core_grids,
     std::optional<uint32_t> num_workers_per_link,
-    std::optional<uint32_t> num_buffers_per_channel) {
+    std::optional<uint32_t> num_buffers_per_channel,
+    [[maybe_unused]] const std::optional<GlobalSemaphore>& war_semaphore = std::nullopt,
+    [[maybe_unused]] std::optional<uint32_t> war_wait_value = std::nullopt) {
     if constexpr (Reversed) {
         return ttnn::experimental::all_gather_async_reversed(
             input_tensor,
@@ -194,7 +196,9 @@ ttnn::Tensor all_gather_async_wrapper_mesh_device(
             false,
             sub_core_grids,
             num_workers_per_link,
-            num_buffers_per_channel);
+            num_buffers_per_channel,
+            war_semaphore,
+            war_wait_value);
     }
 }
 
@@ -296,7 +300,9 @@ void bind_all_gather_async(nb::module_& mod) {
             nb::arg("barrier_semaphore") = nb::none(),
             nb::arg("sub_core_grids") = nb::none(),
             nb::arg("num_workers_per_link") = nb::none(),
-            nb::arg("num_buffers_per_channel") = nb::none()));
+            nb::arg("num_buffers_per_channel") = nb::none(),
+            nb::arg("war_semaphore") = nb::none(),
+            nb::arg("war_wait_value") = nb::none()));
 
     const auto* all_gather_async_reversed_doc = R"doc(
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async_nanobind.cpp
@@ -157,8 +157,8 @@ ttnn::Tensor all_gather_async_wrapper_mesh_device(
     const std::optional<CoreRangeSet>& sub_core_grids,
     std::optional<uint32_t> num_workers_per_link,
     std::optional<uint32_t> num_buffers_per_channel,
-    [[maybe_unused]] const std::optional<GlobalSemaphore>& war_semaphore = std::nullopt,
-    [[maybe_unused]] std::optional<uint32_t> war_wait_value = std::nullopt) {
+    [[maybe_unused]] const std::optional<GlobalSemaphore>& buffer_reuse_sync_semaphore = std::nullopt,
+    [[maybe_unused]] std::optional<uint32_t> buffer_reuse_sync_sem_wait_value = std::nullopt) {
     if constexpr (Reversed) {
         return ttnn::experimental::all_gather_async_reversed(
             input_tensor,
@@ -197,8 +197,8 @@ ttnn::Tensor all_gather_async_wrapper_mesh_device(
             sub_core_grids,
             num_workers_per_link,
             num_buffers_per_channel,
-            war_semaphore,
-            war_wait_value);
+            buffer_reuse_sync_semaphore,
+            buffer_reuse_sync_sem_wait_value);
     }
 }
 
@@ -301,8 +301,8 @@ void bind_all_gather_async(nb::module_& mod) {
             nb::arg("sub_core_grids") = nb::none(),
             nb::arg("num_workers_per_link") = nb::none(),
             nb::arg("num_buffers_per_channel") = nb::none(),
-            nb::arg("war_semaphore") = nb::none(),
-            nb::arg("war_wait_value") = nb::none()));
+            nb::arg("buffer_reuse_sync_semaphore") = nb::none(),
+            nb::arg("buffer_reuse_sync_sem_wait_value") = nb::none()));
 
     const auto* all_gather_async_reversed_doc = R"doc(
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation.cpp
@@ -267,7 +267,9 @@ std::tuple<AllGatherAsyncParams, AllGatherAsyncInputs> all_gather_async_build_op
     const std::optional<uint32_t>& num_buffers_per_channel,
     bool reverse_order,
     const std::optional<CoreRangeSet>& sub_core_grid,
-    const MeshDevice* optional_mesh_device) {
+    const MeshDevice* optional_mesh_device,
+    const std::optional<GlobalSemaphore>& war_semaphore,
+    const std::optional<uint32_t>& war_wait_value) {
     // Combine 3 implementations of the old all_gather_async_op.cpp::all_gather_async_impl
     // 1. only input_tensor, no output or optional mesh device
     // 2. has input tensor and output tensor but not optional mesh device
@@ -324,7 +326,9 @@ std::tuple<AllGatherAsyncParams, AllGatherAsyncInputs> all_gather_async_build_op
             num_workers_per_link,
             num_buffers_per_channel,
             reverse_order,
-            sub_core_grid),
+            sub_core_grid,
+            war_semaphore,
+            war_wait_value),
         AllGatherAsyncInputs{.input_tensor = input_tensor, .persistent_output_buffer = persistent_output_buffer}};
 }
 
@@ -467,7 +471,9 @@ Tensor all_gather_async(
     const std::optional<uint32_t>& num_buffers_per_channel,
     bool reverse_order,
     const std::optional<CoreRangeSet>& sub_core_grid,
-    const MeshDevice* optional_mesh_device) {
+    const MeshDevice* optional_mesh_device,
+    const std::optional<GlobalSemaphore>& war_semaphore,
+    const std::optional<uint32_t>& war_wait_value) {
     auto [params, inputs] = experimental::prim::all_gather_async_build_operation_args(
         input_tensor,
         persistent_output_buffer,
@@ -487,7 +493,9 @@ Tensor all_gather_async(
         num_buffers_per_channel,
         reverse_order,
         sub_core_grid,
-        optional_mesh_device);
+        optional_mesh_device,
+        war_semaphore,
+        war_wait_value);
     return ttnn::device_operation::launch<experimental::prim::AllGatherAsyncDeviceOperation>(params, inputs);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation.cpp
@@ -268,8 +268,8 @@ std::tuple<AllGatherAsyncParams, AllGatherAsyncInputs> all_gather_async_build_op
     bool reverse_order,
     const std::optional<CoreRangeSet>& sub_core_grid,
     const MeshDevice* optional_mesh_device,
-    const std::optional<GlobalSemaphore>& war_semaphore,
-    const std::optional<uint32_t>& war_wait_value) {
+    const std::optional<GlobalSemaphore>& buffer_reuse_sync_semaphore,
+    const std::optional<uint32_t>& buffer_reuse_sync_sem_wait_value) {
     // Combine 3 implementations of the old all_gather_async_op.cpp::all_gather_async_impl
     // 1. only input_tensor, no output or optional mesh device
     // 2. has input tensor and output tensor but not optional mesh device
@@ -327,8 +327,8 @@ std::tuple<AllGatherAsyncParams, AllGatherAsyncInputs> all_gather_async_build_op
             num_buffers_per_channel,
             reverse_order,
             sub_core_grid,
-            war_semaphore,
-            war_wait_value),
+            buffer_reuse_sync_semaphore,
+            buffer_reuse_sync_sem_wait_value),
         AllGatherAsyncInputs{.input_tensor = input_tensor, .persistent_output_buffer = persistent_output_buffer}};
 }
 
@@ -472,8 +472,8 @@ Tensor all_gather_async(
     bool reverse_order,
     const std::optional<CoreRangeSet>& sub_core_grid,
     const MeshDevice* optional_mesh_device,
-    const std::optional<GlobalSemaphore>& war_semaphore,
-    const std::optional<uint32_t>& war_wait_value) {
+    const std::optional<GlobalSemaphore>& buffer_reuse_sync_semaphore,
+    const std::optional<uint32_t>& buffer_reuse_sync_sem_wait_value) {
     auto [params, inputs] = experimental::prim::all_gather_async_build_operation_args(
         input_tensor,
         persistent_output_buffer,
@@ -494,8 +494,8 @@ Tensor all_gather_async(
         reverse_order,
         sub_core_grid,
         optional_mesh_device,
-        war_semaphore,
-        war_wait_value);
+        buffer_reuse_sync_semaphore,
+        buffer_reuse_sync_sem_wait_value);
     return ttnn::device_operation::launch<experimental::prim::AllGatherAsyncDeviceOperation>(params, inputs);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation.hpp
@@ -55,7 +55,9 @@ std::tuple<AllGatherAsyncParams, AllGatherAsyncInputs> all_gather_async_build_op
     const std::optional<uint32_t>& num_buffers_per_channel,
     bool reverse_order,
     const std::optional<CoreRangeSet>& sub_core_grid,
-    const MeshDevice* optional_mesh_device);
+    const MeshDevice* optional_mesh_device,
+    const std::optional<GlobalSemaphore>& war_semaphore = std::nullopt,
+    const std::optional<uint32_t>& war_wait_value = std::nullopt);
 
 enum class AllGatherAsyncVersion {
     LLAMA_MINIMAL_SHARDED = 0,
@@ -88,6 +90,8 @@ Tensor all_gather_async(
     const std::optional<uint32_t>& num_buffers_per_channel,
     bool reverse_order,
     const std::optional<CoreRangeSet>& sub_core_grid,
-    const MeshDevice* optional_mesh_device);
+    const MeshDevice* optional_mesh_device,
+    const std::optional<GlobalSemaphore>& war_semaphore = std::nullopt,
+    const std::optional<uint32_t>& war_wait_value = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation.hpp
@@ -56,8 +56,8 @@ std::tuple<AllGatherAsyncParams, AllGatherAsyncInputs> all_gather_async_build_op
     bool reverse_order,
     const std::optional<CoreRangeSet>& sub_core_grid,
     const MeshDevice* optional_mesh_device,
-    const std::optional<GlobalSemaphore>& war_semaphore = std::nullopt,
-    const std::optional<uint32_t>& war_wait_value = std::nullopt);
+    const std::optional<GlobalSemaphore>& buffer_reuse_sync_semaphore = std::nullopt,
+    const std::optional<uint32_t>& buffer_reuse_sync_sem_wait_value = std::nullopt);
 
 enum class AllGatherAsyncVersion {
     LLAMA_MINIMAL_SHARDED = 0,
@@ -91,7 +91,7 @@ Tensor all_gather_async(
     bool reverse_order,
     const std::optional<CoreRangeSet>& sub_core_grid,
     const MeshDevice* optional_mesh_device,
-    const std::optional<GlobalSemaphore>& war_semaphore = std::nullopt,
-    const std::optional<uint32_t>& war_wait_value = std::nullopt);
+    const std::optional<GlobalSemaphore>& buffer_reuse_sync_semaphore = std::nullopt,
+    const std::optional<uint32_t>& buffer_reuse_sync_sem_wait_value = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation_types.hpp
@@ -38,6 +38,11 @@ struct AllGatherAsyncParams {
     std::optional<uint32_t> num_buffers_per_channel;
     bool reverse_order = false;
     std::optional<CoreRangeSet> sub_core_grid;
+    // WAR-hazard semaphore for safe reuse of a persistent output buffer under trace: the drain core
+    // waits until `war_wait_value` increments arrive (one per downstream consumer core, e.g. the
+    // sampling op) before overwriting the persistent buffer. See the llama3_70b_galaxy TT_CCL war_sem.
+    std::optional<GlobalSemaphore> war_semaphore;
+    std::optional<uint32_t> war_wait_value;
 
     AllGatherAsyncParams(
         int32_t dim,
@@ -57,7 +62,9 @@ struct AllGatherAsyncParams {
         std::optional<uint32_t> num_workers_per_link,
         std::optional<uint32_t> num_buffers_per_channel,
         bool reverse_order,
-        const std::optional<CoreRangeSet>& sub_core_grid) :
+        const std::optional<CoreRangeSet>& sub_core_grid,
+        const std::optional<GlobalSemaphore>& war_semaphore = std::nullopt,
+        std::optional<uint32_t> war_wait_value = std::nullopt) :
         dim(dim),
         num_links(num_links),
         ring_size(ring_size),
@@ -75,7 +82,9 @@ struct AllGatherAsyncParams {
         num_workers_per_link(num_workers_per_link),
         num_buffers_per_channel(num_buffers_per_channel),
         reverse_order(reverse_order),
-        sub_core_grid(sub_core_grid) {}
+        sub_core_grid(sub_core_grid),
+        war_semaphore(war_semaphore),
+        war_wait_value(war_wait_value) {}
 
     static constexpr auto attribute_names = std::forward_as_tuple(
         "dim",
@@ -94,7 +103,9 @@ struct AllGatherAsyncParams {
         "num_workers_per_link",
         "num_buffers_per_channel",
         "reverse_order",
-        "sub_core_grid");
+        "sub_core_grid",
+        "war_semaphore_present",
+        "war_wait_value");
     auto attribute_values() const {
         return std::make_tuple(
             dim,
@@ -113,7 +124,9 @@ struct AllGatherAsyncParams {
             num_workers_per_link,
             num_buffers_per_channel,
             reverse_order,
-            sub_core_grid);
+            sub_core_grid,
+            war_semaphore.has_value(),
+            war_wait_value);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_device_operation_types.hpp
@@ -38,11 +38,11 @@ struct AllGatherAsyncParams {
     std::optional<uint32_t> num_buffers_per_channel;
     bool reverse_order = false;
     std::optional<CoreRangeSet> sub_core_grid;
-    // WAR-hazard semaphore for safe reuse of a persistent output buffer under trace: the drain core
-    // waits until `war_wait_value` increments arrive (one per downstream consumer core, e.g. the
-    // sampling op) before overwriting the persistent buffer. See the llama3_70b_galaxy TT_CCL war_sem.
-    std::optional<GlobalSemaphore> war_semaphore;
-    std::optional<uint32_t> war_wait_value;
+    // buffer-reuse sync semaphore for safe reuse of a persistent output buffer under trace: the drain core
+    // waits until `buffer_reuse_sync_sem_wait_value` increments arrive (one per downstream consumer core, e.g. the
+    // sampling op) before overwriting the persistent buffer. See the llama3_70b_galaxy TT_CCL buffer_reuse_sync_sem.
+    std::optional<GlobalSemaphore> buffer_reuse_sync_semaphore;
+    std::optional<uint32_t> buffer_reuse_sync_sem_wait_value;
 
     AllGatherAsyncParams(
         int32_t dim,
@@ -63,8 +63,8 @@ struct AllGatherAsyncParams {
         std::optional<uint32_t> num_buffers_per_channel,
         bool reverse_order,
         const std::optional<CoreRangeSet>& sub_core_grid,
-        const std::optional<GlobalSemaphore>& war_semaphore = std::nullopt,
-        std::optional<uint32_t> war_wait_value = std::nullopt) :
+        const std::optional<GlobalSemaphore>& buffer_reuse_sync_semaphore = std::nullopt,
+        std::optional<uint32_t> buffer_reuse_sync_sem_wait_value = std::nullopt) :
         dim(dim),
         num_links(num_links),
         ring_size(ring_size),
@@ -83,8 +83,8 @@ struct AllGatherAsyncParams {
         num_buffers_per_channel(num_buffers_per_channel),
         reverse_order(reverse_order),
         sub_core_grid(sub_core_grid),
-        war_semaphore(war_semaphore),
-        war_wait_value(war_wait_value) {}
+        buffer_reuse_sync_semaphore(buffer_reuse_sync_semaphore),
+        buffer_reuse_sync_sem_wait_value(buffer_reuse_sync_sem_wait_value) {}
 
     static constexpr auto attribute_names = std::forward_as_tuple(
         "dim",
@@ -104,8 +104,8 @@ struct AllGatherAsyncParams {
         "num_buffers_per_channel",
         "reverse_order",
         "sub_core_grid",
-        "war_semaphore_present",
-        "war_wait_value");
+        "buffer_reuse_sync_semaphore_present",
+        "buffer_reuse_sync_sem_wait_value");
     auto attribute_values() const {
         return std::make_tuple(
             dim,
@@ -125,8 +125,8 @@ struct AllGatherAsyncParams {
             num_buffers_per_channel,
             reverse_order,
             sub_core_grid,
-            war_semaphore.has_value(),
-            war_wait_value);
+            buffer_reuse_sync_semaphore.has_value(),
+            buffer_reuse_sync_sem_wait_value);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_llama_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_llama_sharded_program_factory.cpp
@@ -280,8 +280,16 @@ LlamaShardedMeshWorkloadFactory::cached_program_t LlamaShardedMeshWorkloadFactor
                 ? barrier_semaphore.value().address()
                 : 0,
             barrier_core.x,  // barrier_sem_noc0_x
-            barrier_core.y   // barrier_sem_noc0_y
-        };
+            barrier_core.y,  // barrier_sem_noc0_y
+            // WAR-hazard wait: only the drain core (link 0) waits on the war semaphore before
+            // overwriting the reused persistent buffer. war_sem_addr==0 disables the wait on all
+            // other cores; the drain core's existing out_ready_sem sync fans the release out.
+            (operation_attributes.war_semaphore.has_value() && link == 0)  // war_sem_addr
+                ? static_cast<uint32_t>(operation_attributes.war_semaphore.value().address())
+                : 0,
+            (operation_attributes.war_semaphore.has_value() && link == 0)  // war_wait_value
+                ? operation_attributes.war_wait_value.value_or(0)
+                : 0};
         writer_rt_args.insert(writer_rt_args.end(), output_tensor_cores_x.begin(), output_tensor_cores_x.end());
         writer_rt_args.insert(writer_rt_args.end(), output_tensor_cores_y.begin(), output_tensor_cores_y.end());
         log_trace(tt::LogOp, "Writer Runtime Args:");

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_llama_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_llama_sharded_program_factory.cpp
@@ -163,6 +163,7 @@ LlamaShardedMeshWorkloadFactory::cached_program_t LlamaShardedMeshWorkloadFactor
         ring_size,                        // ring_size
         barrier_semaphore.has_value() &&  // use_barrier_sem
             !using_persistent_buffers,
+        operation_attributes.buffer_reuse_sync_semaphore.has_value(),  // use_buffer_reuse_sync_sem
     };
     writer_kernel_config.compile_args.insert(
         writer_kernel_config.compile_args.end(), forward_args.begin(), forward_args.end());
@@ -281,14 +282,12 @@ LlamaShardedMeshWorkloadFactory::cached_program_t LlamaShardedMeshWorkloadFactor
                 : 0,
             barrier_core.x,  // barrier_sem_noc0_x
             barrier_core.y,  // barrier_sem_noc0_y
-            // WAR-hazard wait: only the drain core (link 0) waits on the war semaphore before
-            // overwriting the reused persistent buffer. war_sem_addr==0 disables the wait on all
-            // other cores; the drain core's existing out_ready_sem sync fans the release out.
-            (operation_attributes.war_semaphore.has_value() && link == 0)  // war_sem_addr
-                ? static_cast<uint32_t>(operation_attributes.war_semaphore.value().address())
+            // buffer_reuse_sync_sem_addr==0 disables the wait on all other cores;
+            (operation_attributes.buffer_reuse_sync_semaphore.has_value() && link == 0)
+                ? static_cast<uint32_t>(operation_attributes.buffer_reuse_sync_semaphore.value().address())
                 : 0,
-            (operation_attributes.war_semaphore.has_value() && link == 0)  // war_wait_value
-                ? operation_attributes.war_wait_value.value_or(0)
+            (operation_attributes.buffer_reuse_sync_semaphore.has_value() && link == 0)
+                ? operation_attributes.buffer_reuse_sync_sem_wait_value.value_or(0)
                 : 0};
         writer_rt_args.insert(writer_rt_args.end(), output_tensor_cores_x.begin(), output_tensor_cores_x.end());
         writer_rt_args.insert(writer_rt_args.end(), output_tensor_cores_y.begin(), output_tensor_cores_y.end());

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_shapes_sharded_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_shapes_sharded_writer.cpp
@@ -62,6 +62,10 @@ void kernel_main() {
     size_t barrier_sem = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t barrier_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t barrier_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
+    // WAR-hazard wait (drain core only; war_sem_addr==0 on all other cores). Blocks until the
+    // downstream sampling op signals it is done reading the reused persistent buffer.
+    const uint32_t war_sem_addr = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t war_wait_value = get_arg_val<uint32_t>(arg_idx++);
     tt_l1_ptr uint32_t* core_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
     arg_idx += num_cores;
     tt_l1_ptr uint32_t* core_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
@@ -123,6 +127,15 @@ void kernel_main() {
 
         noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), ring_size - 1);
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
+    }
+
+    // WAR-hazard wait: on the drain core (war_sem_addr != 0), block until all downstream sampling
+    // consumers of the previous decode step have signalled `war_sem` (>= war_wait_value), then reset
+    // it for the next step. This gates the persistent-buffer overwrite on consume-complete, closing
+    // the cross-sub-device Write-After-Read race that only manifests under trace.
+    if (war_sem_addr != 0) {
+        noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(war_sem_addr), war_wait_value);
+        noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(war_sem_addr), 0);
     }
 
     // 1. mcast via fabric to remote tensor addresses

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_shapes_sharded_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_shapes_sharded_writer.cpp
@@ -32,10 +32,11 @@ constexpr uint32_t num_targets_forward_direction = get_compile_time_arg_val(6);
 constexpr uint32_t num_targets_backward_direction = get_compile_time_arg_val(7);
 constexpr uint32_t ring_size = get_compile_time_arg_val(8);
 constexpr uint32_t use_barrier_sem = get_compile_time_arg_val(9);
+constexpr uint32_t use_buffer_reuse_sync_sem = get_compile_time_arg_val(10);
 constexpr ccl_routing_utils::line_multicast_route_info_t forward_multicast_route_info =
-    ccl_routing_utils::get_line_multicast_route_info_from_args<10>();
+    ccl_routing_utils::get_line_multicast_route_info_from_args<11>();
 constexpr ccl_routing_utils::line_multicast_route_info_t backward_multicast_route_info =
-    ccl_routing_utils::get_line_multicast_route_info_from_args<10 + ccl_routing_utils::num_line_multicast_args>();
+    ccl_routing_utils::get_line_multicast_route_info_from_args<11 + ccl_routing_utils::num_line_multicast_args>();
 
 /*
  * CCL Send will present various operating modes. Although there is only a single send kernel, it may (compile time)
@@ -62,10 +63,8 @@ void kernel_main() {
     size_t barrier_sem = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t barrier_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
     const uint8_t barrier_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
-    // WAR-hazard wait (drain core only; war_sem_addr==0 on all other cores). Blocks until the
-    // downstream sampling op signals it is done reading the reused persistent buffer.
-    const uint32_t war_sem_addr = get_arg_val<uint32_t>(arg_idx++);
-    const uint32_t war_wait_value = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t buffer_reuse_sync_sem_addr = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t buffer_reuse_sync_sem_wait_value = get_arg_val<uint32_t>(arg_idx++);
     tt_l1_ptr uint32_t* core_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
     arg_idx += num_cores;
     tt_l1_ptr uint32_t* core_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
@@ -129,13 +128,14 @@ void kernel_main() {
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(barrier_sem), 0);
     }
 
-    // WAR-hazard wait: on the drain core (war_sem_addr != 0), block until all downstream sampling
-    // consumers of the previous decode step have signalled `war_sem` (>= war_wait_value), then reset
-    // it for the next step. This gates the persistent-buffer overwrite on consume-complete, closing
-    // the cross-sub-device Write-After-Read race that only manifests under trace.
-    if (war_sem_addr != 0) {
-        noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(war_sem_addr), war_wait_value);
-        noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(war_sem_addr), 0);
+    // buffer-reuse sync wait: on the drain core (buffer_reuse_sync_sem_addr != 0), block until all downstream
+    // sampling consumers of the previous decode step have signalled 'buffer_reuse_sync_sem'
+    if constexpr (use_buffer_reuse_sync_sem) {
+        if (buffer_reuse_sync_sem_addr != 0) {
+            noc_semaphore_wait_min(
+                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(buffer_reuse_sync_sem_addr), buffer_reuse_sync_sem_wait_value);
+            noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(buffer_reuse_sync_sem_addr), 0);
+        }
     }
 
     // 1. mcast via fabric to remote tensor addresses

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/writer_interleaved.cpp
@@ -7,6 +7,7 @@
 #include <type_traits>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
@@ -70,6 +71,14 @@ void kernel_main() {
     // Number of running cores / users. The final-indices CB holds one stick per user (no longer
     // hard-coded to 32), so this kernel waits/pops exactly `num_users` sticks.
     constexpr uint32_t num_users = get_compile_time_arg_val(args_base + 17);
+    // WAR-hazard signal: when enabled, increment `war_sem_addr` on the gather's drain core once at
+    // the very end of the op so the next decode step's SAMPLING_VALUES all-gather can safely reuse
+    // the persistent buffer. Closes a cross-sub-device Write-After-Read race that only shows up under
+    // trace (see models/common/sampling and the llama3_70b_galaxy TT_CCL war_sem).
+    constexpr uint32_t signal_war_sem = get_compile_time_arg_val(args_base + 18);
+    constexpr uint32_t war_sem_addr = get_compile_time_arg_val(args_base + 19);
+    constexpr uint32_t war_drain_noc_x = get_compile_time_arg_val(args_base + 20);
+    constexpr uint32_t war_drain_noc_y = get_compile_time_arg_val(args_base + 21);
     constexpr uint32_t k_chunk_size = num_cores * sizeof(uint32_t);     // 4 bytes per uint32_t
     constexpr uint32_t p_chunk_size = num_cores * sizeof(uint16_t);     // 2 bytes per uint16_t
     constexpr uint32_t temp_chunk_size = num_cores * sizeof(uint16_t);  // 2 bytes per uint16_t
@@ -245,4 +254,15 @@ void kernel_main() {
         {.offset_bytes = core_id * 4},
         {.page_id = 0, .offset_bytes = core_id * 4});
     noc.async_write_barrier();
+
+    // Signal WAR completion: this core is done reading the gathered SAMPLING_VALUES/INDICES for this
+    // step. Increment the war semaphore on the gather's drain core; the next step's SAMPLING_VALUES
+    // all-gather waits until all `num_users` sampling cores have signalled before overwriting the
+    // reused persistent buffer.
+    if constexpr (signal_war_sem != 0) {
+        const uint64_t war_noc_addr =
+            get_noc_addr(war_drain_noc_x, war_drain_noc_y, war_sem_addr, noc.get_noc_id());
+        noc_semaphore_inc(war_noc_addr, 1, noc.get_noc_id());
+        noc.async_atomic_barrier();
+    }
 }

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/writer_interleaved.cpp
@@ -71,14 +71,14 @@ void kernel_main() {
     // Number of running cores / users. The final-indices CB holds one stick per user (no longer
     // hard-coded to 32), so this kernel waits/pops exactly `num_users` sticks.
     constexpr uint32_t num_users = get_compile_time_arg_val(args_base + 17);
-    // WAR-hazard signal: when enabled, increment `war_sem_addr` on the gather's drain core once at
+    // buffer-reuse sync signal: when enabled, increment `buffer_reuse_sync_sem_addr` on the gather's drain core once at
     // the very end of the op so the next decode step's SAMPLING_VALUES all-gather can safely reuse
     // the persistent buffer. Closes a cross-sub-device Write-After-Read race that only shows up under
-    // trace (see models/common/sampling and the llama3_70b_galaxy TT_CCL war_sem).
-    constexpr uint32_t signal_war_sem = get_compile_time_arg_val(args_base + 18);
-    constexpr uint32_t war_sem_addr = get_compile_time_arg_val(args_base + 19);
-    constexpr uint32_t war_drain_noc_x = get_compile_time_arg_val(args_base + 20);
-    constexpr uint32_t war_drain_noc_y = get_compile_time_arg_val(args_base + 21);
+    // trace (see models/common/sampling and the llama3_70b_galaxy TT_CCL buffer_reuse_sync_sem).
+    constexpr uint32_t signal_buffer_reuse_sync_sem = get_compile_time_arg_val(args_base + 18);
+    constexpr uint32_t buffer_reuse_sync_sem_addr = get_compile_time_arg_val(args_base + 19);
+    constexpr uint32_t buffer_reuse_sync_drain_noc_x = get_compile_time_arg_val(args_base + 20);
+    constexpr uint32_t buffer_reuse_sync_drain_noc_y = get_compile_time_arg_val(args_base + 21);
     constexpr uint32_t k_chunk_size = num_cores * sizeof(uint32_t);     // 4 bytes per uint32_t
     constexpr uint32_t p_chunk_size = num_cores * sizeof(uint16_t);     // 2 bytes per uint16_t
     constexpr uint32_t temp_chunk_size = num_cores * sizeof(uint16_t);  // 2 bytes per uint16_t
@@ -255,14 +255,12 @@ void kernel_main() {
         {.page_id = 0, .offset_bytes = core_id * 4});
     noc.async_write_barrier();
 
-    // Signal WAR completion: this core is done reading the gathered SAMPLING_VALUES/INDICES for this
-    // step. Increment the war semaphore on the gather's drain core; the next step's SAMPLING_VALUES
-    // all-gather waits until all `num_users` sampling cores have signalled before overwriting the
-    // reused persistent buffer.
-    if constexpr (signal_war_sem != 0) {
-        const uint64_t war_noc_addr =
-            get_noc_addr(war_drain_noc_x, war_drain_noc_y, war_sem_addr, noc.get_noc_id());
-        noc_semaphore_inc(war_noc_addr, 1, noc.get_noc_id());
+    // Signal read-complete: this core is done reading the gathered SAMPLING_VALUES/INDICES for this step.
+    // all-gather waits until all sampling cores have signalled before overwriting the persistent buffer
+    if constexpr (signal_buffer_reuse_sync_sem != 0) {
+        const uint64_t buffer_reuse_sync_noc_addr =
+            get_noc_addr(buffer_reuse_sync_drain_noc_x, buffer_reuse_sync_drain_noc_y, buffer_reuse_sync_sem_addr, noc.get_noc_id());
+        noc_semaphore_inc(buffer_reuse_sync_noc_addr, 1, noc.get_noc_id());
         noc.async_atomic_barrier();
     }
 }

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.cpp
@@ -197,9 +197,15 @@ ttnn::Tensor sampling(
     const Tensor& temp,
     const std::optional<uint32_t>& seed,
     const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids,
-    const std::optional<Tensor>& preallocated_output_tensor) {
+    const std::optional<Tensor>& preallocated_output_tensor,
+    const std::optional<tt::tt_metal::GlobalSemaphore>& war_semaphore,
+    const std::optional<tt::tt_metal::CoreCoord>& war_sem_drain_core) {
     return ttnn::device_operation::launch<SamplingDeviceOperation>(
-        SamplingParams{.seed = seed, .sub_core_grids = sub_core_grids},
+        SamplingParams{
+            .seed = seed,
+            .sub_core_grids = sub_core_grids,
+            .war_semaphore = war_semaphore,
+            .war_sem_drain_core = war_sem_drain_core},
         SamplingInputs{
             .input_values = input_values_tensor,
             .input_indices = input_indices_tensor,

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.cpp
@@ -198,14 +198,14 @@ ttnn::Tensor sampling(
     const std::optional<uint32_t>& seed,
     const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids,
     const std::optional<Tensor>& preallocated_output_tensor,
-    const std::optional<tt::tt_metal::GlobalSemaphore>& war_semaphore,
-    const std::optional<tt::tt_metal::CoreCoord>& war_sem_drain_core) {
+    const std::optional<tt::tt_metal::GlobalSemaphore>& buffer_reuse_sync_semaphore,
+    const std::optional<tt::tt_metal::CoreCoord>& buffer_reuse_sync_sem_drain_core) {
     return ttnn::device_operation::launch<SamplingDeviceOperation>(
         SamplingParams{
             .seed = seed,
             .sub_core_grids = sub_core_grids,
-            .war_semaphore = war_semaphore,
-            .war_sem_drain_core = war_sem_drain_core},
+            .buffer_reuse_sync_semaphore = buffer_reuse_sync_semaphore,
+            .buffer_reuse_sync_sem_drain_core = buffer_reuse_sync_sem_drain_core},
         SamplingInputs{
             .input_values = input_values_tensor,
             .input_indices = input_indices_tensor,

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.hpp
@@ -38,5 +38,7 @@ ttnn::Tensor sampling(
     const Tensor& temp,
     const std::optional<uint32_t>& seed = std::nullopt,
     const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids = std::nullopt,
-    const std::optional<Tensor>& preallocated_output_tensor = std::nullopt);
+    const std::optional<Tensor>& preallocated_output_tensor = std::nullopt,
+    const std::optional<tt::tt_metal::GlobalSemaphore>& war_semaphore = std::nullopt,
+    const std::optional<tt::tt_metal::CoreCoord>& war_sem_drain_core = std::nullopt);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.hpp
@@ -39,6 +39,6 @@ ttnn::Tensor sampling(
     const std::optional<uint32_t>& seed = std::nullopt,
     const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids = std::nullopt,
     const std::optional<Tensor>& preallocated_output_tensor = std::nullopt,
-    const std::optional<tt::tt_metal::GlobalSemaphore>& war_semaphore = std::nullopt,
-    const std::optional<tt::tt_metal::CoreCoord>& war_sem_drain_core = std::nullopt);
+    const std::optional<tt::tt_metal::GlobalSemaphore>& buffer_reuse_sync_semaphore = std::nullopt,
+    const std::optional<tt::tt_metal::CoreCoord>& buffer_reuse_sync_sem_drain_core = std::nullopt);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation_types.hpp
@@ -8,12 +8,23 @@
 #include <optional>
 
 #include "ttnn/tensor/tensor.hpp"
+#include <tt-metalium/global_semaphore.hpp>
+#include <tt-metalium/core_coord.hpp>
 
 namespace ttnn::prim {
 
 struct SamplingParams {
     std::optional<uint32_t> seed;
     std::optional<tt::tt_metal::CoreRangeSet> sub_core_grids;
+    // WAR-hazard semaphore for safe reuse of a persistent all-gather buffer under trace.
+    // When set, each sampling writer core increments `war_semaphore` (at the gather's drain core,
+    // `war_sem_drain_core`) once at the very end of the op, signalling that this step's reads of the
+    // SAMPLING_VALUES/INDICES buffers are complete. The next decode step's SAMPLING_VALUES all-gather
+    // waits on its local copy at that core before overwriting the buffer, closing the cross-sub-device
+    // Write-After-Read race that only manifests under trace. See models/common/sampling and the
+    // llama3_70b_galaxy TT_CCL.
+    std::optional<tt::tt_metal::GlobalSemaphore> war_semaphore;
+    std::optional<tt::tt_metal::CoreCoord> war_sem_drain_core;
 };
 
 struct SamplingInputs {

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation_types.hpp
@@ -16,15 +16,9 @@ namespace ttnn::prim {
 struct SamplingParams {
     std::optional<uint32_t> seed;
     std::optional<tt::tt_metal::CoreRangeSet> sub_core_grids;
-    // WAR-hazard semaphore for safe reuse of a persistent all-gather buffer under trace.
-    // When set, each sampling writer core increments `war_semaphore` (at the gather's drain core,
-    // `war_sem_drain_core`) once at the very end of the op, signalling that this step's reads of the
-    // SAMPLING_VALUES/INDICES buffers are complete. The next decode step's SAMPLING_VALUES all-gather
-    // waits on its local copy at that core before overwriting the buffer, closing the cross-sub-device
-    // Write-After-Read race that only manifests under trace. See models/common/sampling and the
-    // llama3_70b_galaxy TT_CCL.
-    std::optional<tt::tt_metal::GlobalSemaphore> war_semaphore;
-    std::optional<tt::tt_metal::CoreCoord> war_sem_drain_core;
+    // buffer-reuse sync semaphore for safe reuse of a persistent all-gather buffer under trace.
+    std::optional<tt::tt_metal::GlobalSemaphore> buffer_reuse_sync_semaphore;
+    std::optional<tt::tt_metal::CoreCoord> buffer_reuse_sync_sem_drain_core;
 };
 
 struct SamplingInputs {

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
@@ -373,6 +373,24 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
     }
     desc.kernels.push_back(std::move(reader_desc));
 
+    // WAR-hazard signal: when a war_semaphore is provided, each sampling writer core increments it
+    // once at the very end of the op (after its final write) on the gather's drain core. The drain
+    // core of the next decode step's SAMPLING_VALUES all-gather waits on its local copy before
+    // overwriting the reused persistent buffer, closing the cross-sub-device Write-After-Read race
+    // that only manifests under trace.
+    const bool signal_war_sem =
+        operation_attributes.war_semaphore.has_value() && operation_attributes.war_sem_drain_core.has_value();
+    uint32_t war_sem_addr = 0;
+    uint32_t war_drain_noc_x = 0;
+    uint32_t war_drain_noc_y = 0;
+    if (signal_war_sem) {
+        war_sem_addr = static_cast<uint32_t>(operation_attributes.war_semaphore.value().address());
+        const auto war_drain_noc =
+            device->worker_core_from_logical_core(operation_attributes.war_sem_drain_core.value());
+        war_drain_noc_x = static_cast<uint32_t>(war_drain_noc.x);
+        war_drain_noc_y = static_cast<uint32_t>(war_drain_noc.y);
+    }
+
     for (uint32_t i = 0; i < cores.size(); ++i) {
         const auto& core = cores[i];
         CoreRangeSet single_core{CoreRange(core, core)};
@@ -403,6 +421,10 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
                 num_cores,
                 static_cast<uint32_t>(use_32bit_index),
                 num_users,
+                static_cast<uint32_t>(signal_war_sem),
+                war_sem_addr,
+                war_drain_noc_x,
+                war_drain_noc_y,
             });
 
         KernelDescriptor writer_desc;

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
@@ -373,22 +373,20 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
     }
     desc.kernels.push_back(std::move(reader_desc));
 
-    // WAR-hazard signal: when a war_semaphore is provided, each sampling writer core increments it
-    // once at the very end of the op (after its final write) on the gather's drain core. The drain
+    // buffer-reuse sync signal: each sampling writer core increments it on end of op. The drain
     // core of the next decode step's SAMPLING_VALUES all-gather waits on its local copy before
-    // overwriting the reused persistent buffer, closing the cross-sub-device Write-After-Read race
-    // that only manifests under trace.
-    const bool signal_war_sem =
-        operation_attributes.war_semaphore.has_value() && operation_attributes.war_sem_drain_core.has_value();
-    uint32_t war_sem_addr = 0;
-    uint32_t war_drain_noc_x = 0;
-    uint32_t war_drain_noc_y = 0;
-    if (signal_war_sem) {
-        war_sem_addr = static_cast<uint32_t>(operation_attributes.war_semaphore.value().address());
-        const auto war_drain_noc =
-            device->worker_core_from_logical_core(operation_attributes.war_sem_drain_core.value());
-        war_drain_noc_x = static_cast<uint32_t>(war_drain_noc.x);
-        war_drain_noc_y = static_cast<uint32_t>(war_drain_noc.y);
+    // overwriting the persistent buffer
+    const bool signal_buffer_reuse_sync_sem =
+        operation_attributes.buffer_reuse_sync_semaphore.has_value() && operation_attributes.buffer_reuse_sync_sem_drain_core.has_value();
+    uint32_t buffer_reuse_sync_sem_addr = 0;
+    uint32_t buffer_reuse_sync_drain_noc_x = 0;
+    uint32_t buffer_reuse_sync_drain_noc_y = 0;
+    if (signal_buffer_reuse_sync_sem) {
+        buffer_reuse_sync_sem_addr = static_cast<uint32_t>(operation_attributes.buffer_reuse_sync_semaphore.value().address());
+        const auto buffer_reuse_sync_drain_noc =
+            device->worker_core_from_logical_core(operation_attributes.buffer_reuse_sync_sem_drain_core.value());
+        buffer_reuse_sync_drain_noc_x = static_cast<uint32_t>(buffer_reuse_sync_drain_noc.x);
+        buffer_reuse_sync_drain_noc_y = static_cast<uint32_t>(buffer_reuse_sync_drain_noc.y);
     }
 
     for (uint32_t i = 0; i < cores.size(); ++i) {
@@ -421,10 +419,10 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
                 num_cores,
                 static_cast<uint32_t>(use_32bit_index),
                 num_users,
-                static_cast<uint32_t>(signal_war_sem),
-                war_sem_addr,
-                war_drain_noc_x,
-                war_drain_noc_y,
+                static_cast<uint32_t>(signal_buffer_reuse_sync_sem),
+                buffer_reuse_sync_sem_addr,
+                buffer_reuse_sync_drain_noc_x,
+                buffer_reuse_sync_drain_noc_y,
             });
 
         KernelDescriptor writer_desc;

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/sampling.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/sampling.cpp
@@ -16,9 +16,20 @@ Tensor sampling(
     const Tensor& temp,
     const std::optional<uint32_t>& seed,
     const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids,
-    const std::optional<Tensor>& output_tensor) {
+    const std::optional<Tensor>& output_tensor,
+    const std::optional<tt::tt_metal::GlobalSemaphore>& war_semaphore,
+    const std::optional<tt::tt_metal::CoreCoord>& war_sem_drain_core) {
     return ttnn::prim::sampling(
-        input_values_tensor, input_indices_tensor, k, p, temp, seed, sub_core_grids, output_tensor);
+        input_values_tensor,
+        input_indices_tensor,
+        k,
+        p,
+        temp,
+        seed,
+        sub_core_grids,
+        output_tensor,
+        war_semaphore,
+        war_sem_drain_core);
 }
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/sampling.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/sampling.cpp
@@ -17,8 +17,8 @@ Tensor sampling(
     const std::optional<uint32_t>& seed,
     const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids,
     const std::optional<Tensor>& output_tensor,
-    const std::optional<tt::tt_metal::GlobalSemaphore>& war_semaphore,
-    const std::optional<tt::tt_metal::CoreCoord>& war_sem_drain_core) {
+    const std::optional<tt::tt_metal::GlobalSemaphore>& buffer_reuse_sync_semaphore,
+    const std::optional<tt::tt_metal::CoreCoord>& buffer_reuse_sync_sem_drain_core) {
     return ttnn::prim::sampling(
         input_values_tensor,
         input_indices_tensor,
@@ -28,8 +28,8 @@ Tensor sampling(
         seed,
         sub_core_grids,
         output_tensor,
-        war_semaphore,
-        war_sem_drain_core);
+        buffer_reuse_sync_semaphore,
+        buffer_reuse_sync_sem_drain_core);
 }
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/sampling.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/sampling.hpp
@@ -10,6 +10,8 @@
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/types.hpp"
+#include <tt-metalium/global_semaphore.hpp>
+#include <tt-metalium/core_coord.hpp>
 
 namespace ttnn {
 
@@ -21,6 +23,8 @@ Tensor sampling(
     const Tensor& temp,
     const std::optional<uint32_t>& seed = std::nullopt,
     const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids = std::nullopt,
-    const std::optional<Tensor>& output_tensor = std::nullopt);
+    const std::optional<Tensor>& output_tensor = std::nullopt,
+    const std::optional<tt::tt_metal::GlobalSemaphore>& war_semaphore = std::nullopt,
+    const std::optional<tt::tt_metal::CoreCoord>& war_sem_drain_core = std::nullopt);
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/sampling.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/sampling.hpp
@@ -24,7 +24,7 @@ Tensor sampling(
     const std::optional<uint32_t>& seed = std::nullopt,
     const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids = std::nullopt,
     const std::optional<Tensor>& output_tensor = std::nullopt,
-    const std::optional<tt::tt_metal::GlobalSemaphore>& war_semaphore = std::nullopt,
-    const std::optional<tt::tt_metal::CoreCoord>& war_sem_drain_core = std::nullopt);
+    const std::optional<tt::tt_metal::GlobalSemaphore>& buffer_reuse_sync_semaphore = std::nullopt,
+    const std::optional<tt::tt_metal::CoreCoord>& buffer_reuse_sync_sem_drain_core = std::nullopt);
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_nanobind.cpp
@@ -126,7 +126,9 @@ void bind_reduction_sampling_operation(nb::module_& mod) {
         nb::kw_only(),
         nb::arg("seed") = nb::none(),
         nb::arg("sub_core_grids") = nb::none(),
-        nb::arg("output_tensor") = nb::none());
+        nb::arg("output_tensor") = nb::none(),
+        nb::arg("war_semaphore") = nb::none(),
+        nb::arg("war_sem_drain_core") = nb::none());
 }
 
 }  // namespace ttnn::operations::reduction::detail

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_nanobind.cpp
@@ -127,8 +127,8 @@ void bind_reduction_sampling_operation(nb::module_& mod) {
         nb::arg("seed") = nb::none(),
         nb::arg("sub_core_grids") = nb::none(),
         nb::arg("output_tensor") = nb::none(),
-        nb::arg("war_semaphore") = nb::none(),
-        nb::arg("war_sem_drain_core") = nb::none());
+        nb::arg("buffer_reuse_sync_semaphore") = nb::none(),
+        nb::arg("buffer_reuse_sync_sem_drain_core") = nb::none());
 }
 
 }  // namespace ttnn::operations::reduction::detail


### PR DESCRIPTION
## WAR race / barrier fix for sampling all-gather (Llama Galaxy)

Fixes a write-after-read race on the persistent sampling all-gather buffers that
made the first decode token nondeterministic (flaky for months).

### Changes
- **Keep barrier for sampling gathers** (`llama_ccl.py`): `line_all_gather`
  normally drops the barrier semaphore when a persistent output buffer is reused.
  For `SAMPLING_VALUES` / `SAMPLING_INDICES`, the consumers run on a *different*
  sub-device than the gather worker, so without the barrier the next step's gather
  can overwrite the buffer before the current step finishes reading it. Force the
  barrier for these buffer keys even with a persistent buffer.
- **WAR semaphore through the sampling op** (`all_gather_async/*`,
  `sampling*` device op, `tt_sampling.py`): plumb a WAR semaphore + drain core
  through `ttnn.sampling` so each sampling core multicast-signals after its final
  read, letting the next step's gather safely reuse the persistent buffer.

### Impact
Removes the intermittent stale-candidate → nondeterministic first-decode-token
failure. Adds optional `war_semaphore` / `war_sem_drain_core` args to
`ttnn.sampling` (default `None` → unchanged behavior).

> Note: touches `models/common/sampling/tt_sampling.py` and
> `models/demos/llama3_70b_galaxy/tt/llama_ccl.py`, which are also modified by the
> `sampling-topk-kernel` and `ccl-collective-determinism` branches — expect small
> merge-order conflicts.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=gather-race-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:gather-race-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=gather-race-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:gather-race-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=gather-race-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:gather-race-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gather-race-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gather-race-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=gather-race-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:gather-race-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=gather-race-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:gather-race-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=gather-race-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:gather-race-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=gather-race-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:gather-race-barrier)