### PR TITLE
[Bug fix] Fix broken perf tests missing CLAMP_NEGATIVE kernel arg

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/perf_eltwise_unary_sfpu_int32.py
+++ b/tt_metal/tt-llk/tests/python_tests/perf_eltwise_unary_sfpu_int32.py
@@ -19,6 +19,7 @@ from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import calculate_tile_and_face_counts
 from helpers.test_variant_parameters import (
     APPROX_MODE,
+    CLAMP_NEGATIVE,
     FAST_MODE,
     ITERATIONS,
     LOOP_FACTOR,
@@ -66,6 +67,7 @@ def _run_math_isolate(formats, mathop, input_dimensions):
             ITERATIONS(32),
             FAST_MODE(FastMode.No),
             STABLE_SORT(StableSort.No),
+            CLAMP_NEGATIVE(False),
         ],
         runtimes=[
             TILE_COUNT(tile_count_A),

--- a/tt_metal/tt-llk/tests/python_tests/perf_sfpu_erfinv_wh.py
+++ b/tt_metal/tt-llk/tests/python_tests/perf_sfpu_erfinv_wh.py
@@ -34,6 +34,7 @@ from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import calculate_tile_and_face_counts
 from helpers.test_variant_parameters import (
     APPROX_MODE,
+    CLAMP_NEGATIVE,
     FAST_MODE,
     ITERATIONS,
     LOOP_FACTOR,
@@ -66,6 +67,7 @@ def _run(formats, mathop, dest_acc, input_dimensions):
             ITERATIONS(32),
             FAST_MODE(FastMode.No),
             STABLE_SORT(StableSort.No),
+            CLAMP_NEGATIVE(False),
         ],
         runtimes=[
             TILE_COUNT(tile_count_A),


### PR DESCRIPTION
### Summary
The accuracy/perf merge made `CLAMP_NEGATIVE` a required template constant in the
shared `eltwise_unary_sfpu_perf.cpp` kernel. Two perf tests that use this kernel
didn't pass it, so `CLAMP_NEGATIVE` was undeclared and the kernel failed to
compile, breaking the perf CI job.

This adds `CLAMP_NEGATIVE(False)` to the two affected tests:
- `perf_sfpu_erfinv_wh.py`
- `perf_eltwise_unary_sfpu_int32.py`

### Notes for reviewers
- `False` matches pre-merge behavior (no clamping before) and keeps these tests
  perf-neutral — clamping is the only real perf cost. It's also what
  `perf_eltwise_unary_sfpu.py` already passes.
- Chose to pass the arg explicitly (consistent with the five other required
  per-test template consts) rather than add a kernel-side default, since the
  param emits as `constexpr bool` and can't be defaulted via `#ifndef` without
  diverging from its sibling params.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jmacanovic/fix-accuracy-perf-merge)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jmacanovic/fix-accuracy-perf-merge)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jmacanovic/fix-accuracy-perf-merge)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jmacanovic/fix-accuracy-perf-merge)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jmacanovic/fix-accuracy-perf-merge)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jmacanovic/fix-accuracy-perf-merge)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jmacanovic/fix-accuracy-perf-merge)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jmacanovic/fix-accuracy-perf-merge)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jmacanovic/fix-accuracy-perf-merge)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jmacanovic/fix-accuracy-perf-merge)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jmacanovic/fix-accuracy-perf-merge)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jmacanovic/fix-accuracy-perf-merge)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jmacanovic/fix-accuracy-perf-merge)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jmacanovic/fix-accuracy-perf-merge)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jmacanovic/fix-accuracy-perf-merge)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jmacanovic/fix-accuracy-perf-merge)