### PR TITLE
[DeepSeek] Fix DRAM leak in shared expert reduce_scatter keepalive

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py
@@ -269,10 +269,6 @@ class TtSharedExpert(LightweightModule):
         self.subdevice_id = subdevice_id
         self.subdevice_cores = subdevice_cores
         self.weight_cache_path = weight_cache_path
-        # Hold the reduce-scatter INPUT alive until the next forward so it is not freed while the
-        # async reduce_scatter is still reading it and reused by the concurrent dispatch op (the
-        # catastrophic use-after-free). See forward().
-        self._rs_input_keepalive = None
         # Shared per-mesh CCL handle. Drives reduce_scatter_minimal_async and owns the shared,
         # stable-address reduce_scatter INTERMEDIATE buffer (one per mesh, reused by all layers'
         # shared experts) — see forward() and TT_CCL.get_shared_rs_intermediate.
@@ -508,7 +504,8 @@ class TtSharedExpert(LightweightModule):
             )
             # Keep the (fresh-per-iter) RS input alive until the next forward so the concurrent
             # dispatch cannot reuse its slot mid-flight. (The intermediate is kept alive by the cache.)
-            self._rs_input_keepalive = output_full
+            # Stored on the shared tt_ccl (one slot for the whole model) rather than on self.
+            self.tt_ccl.set_shared_rs_input_keepalive(output_full)
         else:
             output = output_full
         logger.debug(f"After shared_expert_ffn: {output.shape}")

--- a/models/demos/deepseek_v3_d_p/tt/tt_ccl.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_ccl.py
@@ -115,6 +115,14 @@ class TT_CCL:
         # keeps the memory cost flat. See TtSharedExpert.forward.
         self.shared_rs_intermediate = None
 
+        # Keepalive for the shared-expert reduce_scatter INPUT (output_full). The overlapped
+        # dispatch must not reuse this buffer's DRAM slot mid-flight, so it is held until the next
+        # shared-expert forward. Stored here (one slot, shared across all layers that run
+        # sequentially) rather than on each per-layer TtSharedExpert instance — a per-instance
+        # reference would never be released (every layer object stays alive for the whole model),
+        # leaking one RS input per layer. See set_shared_rs_input_keepalive / TtSharedExpert.forward.
+        self.shared_rs_input_keepalive = None
+
         # Persistent ring-attention buffers shared by every layer's MLA, keyed by their shape
         # signature. One set for the whole model. See get_mla_ring_attention_buffers.
         self.mla_ring_attention_buffers: dict[tuple, dict] = {}
@@ -228,6 +236,15 @@ class TT_CCL:
                 mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
             )
         return self.shared_rs_intermediate
+
+    def set_shared_rs_input_keepalive(self, input_tensor):
+        """Hold the shared-expert reduce_scatter INPUT alive until the next shared-expert forward,
+        so the concurrent (overlapped) dispatch cannot reuse its DRAM slot mid-flight. A single slot
+        shared across all sequentially-run layers: each layer's forward overwrites it, releasing the
+        previous layer's input (its refcount drops to zero and the DRAM is freed). This must live on
+        tt_ccl (one instance for the whole model), NOT on the per-layer TtSharedExpert object — the
+        latter would pin one RS input per layer for the model's lifetime, leaking DRAM every layer."""
+        self.shared_rs_input_keepalive = input_tensor
 
     def get_and_cycle_barrier_semaphore_handle(self, cluster_axis=None):
         semaphore_index = 2 if cluster_axis is None else cluster_axis


### PR DESCRIPTION
## Summary

Fixes a DRAM leak in the DeepSeek V3 prefill shared expert.

The shared-expert `reduce_scatter` **input** must be held alive until the next forward so the concurrent dispatch op cannot reuse its DRAM slot mid-flight. Previously this keepalive was stored **per-instance** on each `TtSharedExpert` (`self._rs_input_keepalive`). Because every layer's `TtSharedExpert` object stays alive for the whole model, each per-layer reference was never released — **leaking one reduce_scatter input buffer per layer**.

This moves the keepalive to a single shared slot on `TT_CCL` (one instance for the whole model). Layers run sequentially, so each forward overwrites the slot and releases the previous layer's input, keeping only one RS input alive at a time.

## Changes

- `tt/tt_ccl.py`: add `shared_rs_input_keepalive` slot + `set_shared_rs_input_keepalive()`.
- `tt/moe/tt_shared_expert.py`: drop the per-instance `_rs_input_keepalive`; route the keepalive through `tt_ccl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fbajraktari/fix_shared_expert_dram_leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fbajraktari/fix_shared_expert_dram_leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fbajraktari/fix_shared_expert_dram_leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fbajraktari/fix_shared_expert_dram_leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=fbajraktari/fix_shared_expert_dram_leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:fbajraktari/fix_shared_expert_dram_leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fbajraktari/fix_shared_expert_dram_leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fbajraktari/fix_shared_expert_dram_leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fbajraktari/fix_shared_expert_dram_leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fbajraktari/fix_shared_expert_dram_leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fbajraktari/fix_shared_expert_dram_leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fbajraktari/fix_shared_expert_dram_leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fbajraktari/fix_shared_expert_dram_leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fbajraktari/fix_shared_expert_dram_leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fbajraktari/fix_shared_expert_dram_leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fbajraktari/fix_shared_expert_dram_leak)