### PR TITLE
[TTTv2] Fix batched-prefill garbage decode: capture decode trace before prefill trace

### DIFF
--- a/models/common/models/executor.py
+++ b/models/common/models/executor.py
@@ -2386,39 +2386,48 @@ def _compile_prefill_and_decode(
         prefill_page_table.dim() == 2
     ), f"prefill_page_table must be [batch_size, max_blocks], got {prefill_page_table.dim()}D"
 
+    # Capture the DECODE trace BEFORE the prefill trace. The batched-prefill trace's folded buffers are
+    # ~padded_batch× the single-user footprint; when the prefill trace is captured FIRST and the decode
+    # trace is captured immediately after (while the prefill trace is live), the decode capture lands in
+    # a layout that overlaps the large batched-prefill trace and clobbers its replay — every batched user
+    # then decodes garbage from the very first token (single-user prefill survives only by its far smaller
+    # footprint). Capturing decode first — so its buffers are reserved before the large prefill trace is
+    # built, and nothing is captured after prefill to overlap it — removes the overlap. Correctness is
+    # unaffected by the swap: the decode trace is warmed with placeholder tokens, but decode
+    # tokens/positions are refreshed from host (or fed back on device) on every replay, so warmup values
+    # never reach the output; only the capture ORDER changes. (This also removes the reason the sampling
+    # buffers had to be pre-materialised while the prefill trace was live — decode now captures with no
+    # prefill trace active — while _prealloc_sampling_buffers in compile_prefill still guards the prefill
+    # capture.)
     prefill_context = (
         _get_validation_context(executor, mode="prefill") if validate_configs else contextlib.nullcontext()
     )
-    with prefill_context:
-        logits = executor.compile_prefill(
-            tokens=prefill_tokens,
-            page_table=prefill_page_table,
-            kv_cache=kv_cache,
-            prompt_lens=prompt_lens,
-            empty_slots=empty_slots,
-            start_pos=start_pos,
-            sampling_params=sampling_params,
-        )
-
-    # todo)) check these against what is actually running in TTTv1 --> the prefill_forward may run sampling on device!
+    decode_context = _get_validation_context(executor, mode="decode") if validate_configs else contextlib.nullcontext()
     batch_size = prefill_tokens.shape[0]
-    decode_tokens = torch.zeros(batch_size, dtype=torch.long, device=prefill_tokens.device)
-    if logits is not None:
-        decode_tokens = torch.argmax(logits[:, -1:, :], dim=-1).view(-1)
+
     decode_start_pos = torch.full(
         (batch_size,),
         prefill_tokens.shape[-1],
         dtype=torch.long,
         device=prefill_tokens.device,
     )
-
-    decode_context = _get_validation_context(executor, mode="decode") if validate_configs else contextlib.nullcontext()
     with decode_context:
         executor.compile_decode(
-            tokens=decode_tokens,
+            tokens=torch.zeros(batch_size, dtype=torch.long, device=prefill_tokens.device),
             start_pos=decode_start_pos,
             page_table=prefill_page_table,
             kv_cache=kv_cache,
+            sampling_params=sampling_params,
+        )
+
+    with prefill_context:
+        executor.compile_prefill(
+            tokens=prefill_tokens,
+            page_table=prefill_page_table,
+            kv_cache=kv_cache,
+            prompt_lens=prompt_lens,
+            empty_slots=empty_slots,
+            start_pos=start_pos,
             sampling_params=sampling_params,
         )
 


### PR DESCRIPTION
# [TTTv2] Fix batched-prefill garbage decode: capture decode trace before prefill trace

Closes #50704


## Problem
The TTTv2 shared engine's batched (folded) prefill (`supports_batched_prefill=True`, from #49292)
produced **garbage decode for every user** — degenerate tokens from the first decoded token — whenever
it ran through the TTNN trace path. The batched forward math is correct (running it untraced/eager, or
with `DISABLE_BATCHED_PREFILL=1`, is coherent); the corruption is a **coexisting-trace buffer overlap**.

Inside `_compile_prefill_and_decode` (`models/common/models/executor.py`) the capture order was:
1. `compile_prefill(...)` — captures the **large** batched-prefill trace, then
2. `compile_decode(...)` — captures the decode trace immediately after.

TTNN trace capture records the op stream in bypass mode without executing it; a buffer materialized
*during* a capture can be clobbered by a **later** capture. The batched fold's footprint is
~`padded_batch`× a single user's, so the decode capture overlaps and corrupts the batched-prefill
trace's buffers. On replay the prefill trace returns a corrupted hidden state → wrong first token for
all users → garbage generation. Single-user prefill survived only because its far smaller trace lands
clear of the decode trace.

(Full write-up and device isolation in the companion ISSUE.)

## Fix
Capture the **decode** trace **before** the **prefill** trace — i.e. capture the largest coexisting
trace **last**, so nothing is captured after it to overlap it. Only the capture *order* changes.

`models/common/models/executor.py`, `_compile_prefill_and_decode` — **+27 / −18, one file**:
- `compile_decode(...)` now runs first, warmed with placeholder zero tokens.
- `compile_prefill(...)` runs last (the big batched-prefill trace is now captured last → safe on replay).

Decode semantics are unchanged: a trace records the op **graph**, not input **values** — the real decode
tokens/positions are copied into the trace's input buffers on every `execute_trace`, so the placeholder
zeros used at warmup never reach the output. (`_prealloc_sampling_buffers` still guards the prefill
capture; and decode now captures with no prefill trace live, independently removing the situation that
prealloc guarded against.)

Pure Python, **no kernel/C++ rebuild**.

## Validation (on `main`, before vs after the one-commit fix)
`llama32_1b` `batch-32-ci` (32 users, seq≈128, host argmax), reading the `==USER OUTPUT` text:

| | capture order | decode output | TTFT |
|---|---|---|---|
| **main (unfixed)** | prefill → decode | **32/32 garbage** (`"!!!…`, `""!…`, …) | 6.5 ms |
| **main + this fix** | **decode → prefill** | **32/32 coherent** | 6.3 ms |

After the fix (representative users):
```
USER 0: I'm just a language model, I don't have personal preferences or taste buds…
USER 1: Hello! I'm doing well, thank you for asking. I'm a large language model…
USER 2: Mayonnaise is indeed a versatile ingredient that can be used in many creative ways…
USER 8: I'm glad you asked about Washington, D.C. …
USER 9: …Canada's capital city, Ottawa…
```
The fixed run logs `Captured decode trace` **before** `Captured batched prefill trace`. TTFT is
preserved/slightly better — the trace is kept, so no dispatch overhead is reintroduced.

Additionally validated coherent on Llama-3.2 **1B and 3B**, **N150 and T3K**, **host and on-device
top-k**, **performance and accuracy** recipes; `eval-32` cross-batch determinism intact; `batch-1` and
sequential (`DISABLE_BATCHED_PREFILL=1`) paths unaffected.

## Scope / impact
Shared-engine fix → benefits every TTTv2 model using batched prefill (Llama 1B/3B, Qwen, Mistral, …).
Restores correct batched-prefill decode while keeping the perf trace.

## Note (follow-up, not required for correctness)
This controls capture *order* to side-step a latent tt-metal trace-allocator overlap between coexisting
traces. A future allocator fix (safe placement / lifetime for buffers materialized during capture) would
make capture order irrelevant and is the more general fix.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=apascual/50704-tttv2-batched-prefill-trace-capture-order)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:apascual/50704-tttv2-batched-prefill-trace-capture-order)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=apascual/50704-tttv2-batched-prefill-trace-capture-order)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:apascual/50704-tttv2-batched-prefill-trace-capture-order)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=apascual/50704-tttv2-batched-prefill-trace-capture-order)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:apascual/50704-tttv2-batched-prefill-trace-capture-order)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=apascual/50704-tttv2-batched-prefill-trace-capture-order)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:apascual/50704-tttv2-batched-prefill-trace-capture-order)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=apascual/50704-tttv2-batched-prefill-trace-capture-order)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:apascual/50704-tttv2-batched-prefill-trace-capture-order)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=apascual/50704-tttv2-batched-prefill-trace-capture-order)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:apascual/50704-tttv2-batched-prefill-trace-capture-order)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=apascual/50704-tttv2-batched-prefill-trace-capture-order)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:apascual/50704-tttv2-batched-prefill-trace-capture-order)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=apascual/50704-tttv2-batched-prefill-trace-capture-order)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:apascual/50704-tttv2-batched-prefill-trace-capture-order)