### PR TITLE
[skip ci] [GPT-OSS] fix galaxy prefill dispatch core-grid assert (num_untilizers_per_sender=1)

### DIFF
--- a/models/demos/gpt_oss/tt/experts_throughput/prefill.py
+++ b/models/demos/gpt_oss/tt/experts_throughput/prefill.py
@@ -124,11 +124,11 @@ class DeepSeekPrefillConfig:
             num_links=num_links,
             topology=topology,
             # Galaxy (4x8) worker row has only 8 cores. The dispatch program factory lays
-            # num_cores(=min(num_links,4)=4) senders x cores_per_sender(=1+num_untilizers) in a
-            # single row; the default num_untilizers_per_sender=2 needs 4*3=12 > 8 and asserts
+            # num_cores(=min(num_links,4)=4) senders x cores_per_sender(=1+num_workers_per_sender)
+            # in a single row; the default num_workers_per_sender=2 needs 4*3=12 > 8 and asserts
             # (dispatch_program_factory.cpp: total_row_cores >= cores_per_sender*num_cores). Use 1
             # -> 4*2=8, fits exactly. See GPT-OSS 120B galaxy prefill core-grid mismatch.
-            num_untilizers_per_sender=1,
+            num_workers_per_sender=1,
         )
 
         self.combine_module = TtCombineModule(

--- a/models/demos/gpt_oss/tt/experts_throughput/prefill.py
+++ b/models/demos/gpt_oss/tt/experts_throughput/prefill.py
@@ -123,6 +123,12 @@ class DeepSeekPrefillConfig:
             cluster_axis=0,
             num_links=num_links,
             topology=topology,
+            # Galaxy (4x8) worker row has only 8 cores. The dispatch program factory lays
+            # num_cores(=min(num_links,4)=4) senders x cores_per_sender(=1+num_untilizers) in a
+            # single row; the default num_untilizers_per_sender=2 needs 4*3=12 > 8 and asserts
+            # (dispatch_program_factory.cpp: total_row_cores >= cores_per_sender*num_cores). Use 1
+            # -> 4*2=8, fits exactly. See GPT-OSS 120B galaxy prefill core-grid mismatch.
+            num_untilizers_per_sender=1,
         )
 
         self.combine_module = TtCombineModule(

--- a/models/demos/gpt_oss/tt/experts_throughput/prefill.py
+++ b/models/demos/gpt_oss/tt/experts_throughput/prefill.py
@@ -123,11 +123,6 @@ class DeepSeekPrefillConfig:
             cluster_axis=0,
             num_links=num_links,
             topology=topology,
-            # Galaxy (4x8) worker row has only 8 cores. The dispatch program factory lays
-            # num_cores(=min(num_links,4)=4) senders x cores_per_sender(=1+num_workers_per_sender)
-            # in a single row; the default num_workers_per_sender=2 needs 4*3=12 > 8 and asserts
-            # (dispatch_program_factory.cpp: total_row_cores >= cores_per_sender*num_cores). Use 1
-            # -> 4*2=8, fits exactly. See GPT-OSS 120B galaxy prefill core-grid mismatch.
             num_workers_per_sender=1,
         )
 


### PR DESCRIPTION
## Problem

GPT-OSS 120B galaxy prefill — `test_gpt_oss_demo[wormhole_b0-4x8-batch128]` (Tier-1 E2E [wh_galaxy_perf]) — fails with:

```
TT_FATAL @ .../deepseek_prefill/dispatch/device/dispatch_program_factory.cpp:218:
  total_row_cores >= cores_per_sender * num_cores
  Same-row has only 8 cores for 4 senders — need 3 cores per sender (>= 12 required)
```

The dispatch factory lays `num_cores` senders (each `cores_per_sender = 1 + num_workers_per_sender` cores) in a **single** worker row. GPT-OSS galaxy: `num_links=4 → num_cores=4`, default `num_workers_per_sender=2 → cores_per_sender=3` → needs `4×3=12`, but the galaxy 4×8 worker row has only **8**.

## Root cause — bisected & confirmed: #48694

Scheduled-run history: GPT-OSS galaxy **passed 07-19** (`c162f885`), first **confirmed assert 07-22** (`df36cd6a`); 07-20/07-21 were infra-masked. Window `c162f885..df36cd6a` (122 commits) → only 2 touch the dispatch path; the substantive one:

**#48694 — "Dispatch row major path refactor" (`af00262e51d`, 2026-07-20, @nostojic; codeowner `@tenstorrent/metalium-developers-ds-prefill`).**

Confirmed by CI: GPT-OSS 120B [wh_galaxy_perf] at **#48694's parent `0a798f1243e` PASSES** (2/2, on OM1-01A03-STGWH02 + STGWH01). The assert *text* pre-dates #48694, but its `dispatch_program_factory.cpp` rewrite (1001 lines) changed which cores count as same-row workers, so GPT-OSS galaxy's 12-core need no longer fits the 8-core row.

## This PR (interim workaround)

Pass `num_workers_per_sender=1` where GPT-OSS constructs `TtDispatchModule` → `cores_per_sender=2`, `4×2=8`, fits exactly. Scoped to GPT-OSS (deepseek_v3_d_p default untouched).

**Status: code-correct by inspection, NOT yet CI-validated** — ~9 galaxy runs all died in infra before the test executed (g03glx04 disk-full queue-hog + intermittent D28-D29 eth-link / topology-mapper failures). Needs a healthy galaxy_perf pool to get a clean pass (assert-gone + perf).

**Proper fix** belongs to the dispatch authors (@nostojic / ds-prefill): restore a layout that spans enough cores or relax the single-row constraint. This PR is a draft stopgap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/gptoss-galaxy-dispatch-untilizers-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/gptoss-galaxy-dispatch-untilizers-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/gptoss-galaxy-dispatch-untilizers-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/gptoss-galaxy-dispatch-untilizers-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mtairum/gptoss-galaxy-dispatch-untilizers-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mtairum/gptoss-galaxy-dispatch-untilizers-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/gptoss-galaxy-dispatch-untilizers-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/gptoss-galaxy-dispatch-untilizers-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/gptoss-galaxy-dispatch-untilizers-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/gptoss-galaxy-dispatch-untilizers-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/gptoss-galaxy-dispatch-untilizers-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/gptoss-galaxy-dispatch-untilizers-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/gptoss-galaxy-dispatch-untilizers-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/gptoss-galaxy-dispatch-untilizers-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/gptoss-galaxy-dispatch-untilizers-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/gptoss-galaxy-dispatch-untilizers-fix)