### PR TITLE
[CI] Double Blackhole experimental test timeouts

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -92,8 +92,8 @@ ttnn:
   unit:
     wh_llmbox: 50
     wh_galaxy: 35
-    bh_p100: 780
-    bh_p150b_civ2: 1045
+    bh_p100: 815
+    bh_p150b_civ2: 1080
     wh_n150_civ2: 1185
     wh_n300_civ2: 1175
     bh_p150b_civ2_viommu: 115

--- a/tests/pipeline_reorg/ops_unit_tests.yaml
+++ b/tests/pipeline_reorg/ops_unit_tests.yaml
@@ -94,9 +94,9 @@
   cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/experimental -xv -k "not performance" -m "not requires_host_iommu" --timeout=600'
   skus:
     bh_p100:
-      timeout: 35
+      timeout: 70
     bh_p150b_civ2:
-      timeout: 35
+      timeout: 70
   owner_id: U076Z1JJUQZ # Artem Yerofieiev
   team: ttnn
   category: experimental


### PR DESCRIPTION
Double the L2 nightly experimental-suite budget from 35 to 70 minutes for `bh_p100` and `bh_p150b_civ2`.

The targeted L2 run showed the `bh_p100` command timing out at the configured 35-minute limit while tests were still passing; `bh_p150b_civ2` completed in approximately 35m38s. This prevents the two Blackhole experimental suites from failing due to the current time budget.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/double-experimental-bh-ci-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/double-experimental-bh-ci-timeouts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/double-experimental-bh-ci-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/double-experimental-bh-ci-timeouts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pjosipovic/double-experimental-bh-ci-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pjosipovic/double-experimental-bh-ci-timeouts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/double-experimental-bh-ci-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/double-experimental-bh-ci-timeouts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/double-experimental-bh-ci-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/double-experimental-bh-ci-timeouts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/double-experimental-bh-ci-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/double-experimental-bh-ci-timeouts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/double-experimental-bh-ci-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/double-experimental-bh-ci-timeouts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/double-experimental-bh-ci-timeouts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/double-experimental-bh-ci-timeouts)