### PR TITLE
[data_movement] Gate tt_memmove NoC self-copy on non-overlap (#50726)

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice_write_overlap.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice_write_overlap.py
@@ -21,6 +21,7 @@ overlapping writes) so this passes even without the fix; it guards against a
 regression that reroutes overlap onto the raw NoC self-copy. The mechanism is proven
 in the PR via a forced write-before-read ordering (deterministic corruption).
 """
+
 import pytest
 import torch
 import ttnn
@@ -30,7 +31,7 @@ from tests.ttnn.utils_for_testing import assert_equal
 @pytest.mark.parametrize(
     "H, W_in, begin_last",
     [
-        (4, 6000, 8),   # page_offset=16B, row=12000B (multi-packet)
+        (4, 6000, 8),  # page_offset=16B, row=12000B (multi-packet)
         (4, 6000, 16),  # page_offset=32B
         (4, 6000, 24),  # page_offset=48B
         (2, 16000, 8),  # page_offset=16B, row=32000B (~4 packets)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice_write_overlap.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice_write_overlap.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Regression test for the tt_memmove overlapping self-copy hazard
+(ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp).
+
+ttnn.experimental.slice_write on the RM-interleaved LAST_DIM path issues an in-place
+overlapping self-copy: tt_memmove(dst = base + page_offset, src = base, stick_size),
+with dst > src. On the NoC self-copy branch (taken when page_offset % 16 == 0, i.e.
+DRAM input) this has no memmove overlap semantics, so an in-flight write can be read
+back as a later source. The fix routes overlapping regions to the CPU memmove.
+
+The stock slice_write test masks this two ways that this test avoids: it uses a
+constant source (a shifted duplicate of equal values is invisible) and L1 input
+(alignment 16 -> the racy NoC branch is never taken). Here we use DRAM input
+(page_offset in {16,32,48}), a distinct per-element pattern, and >8192B (multi-packet)
+rows, and assert the written region is bit-exact.
+
+Note: on current silicon the buggy path is timing-masked (NoC reads outrun the
+overlapping writes) so this passes even without the fix; it guards against a
+regression that reroutes overlap onto the raw NoC self-copy. The mechanism is proven
+in the PR via a forced write-before-read ordering (deterministic corruption).
+"""
+import pytest
+import torch
+import ttnn
+from tests.ttnn.utils_for_testing import assert_equal
+
+
+@pytest.mark.parametrize(
+    "H, W_in, begin_last",
+    [
+        (4, 6000, 8),   # page_offset=16B, row=12000B (multi-packet)
+        (4, 6000, 16),  # page_offset=32B
+        (4, 6000, 24),  # page_offset=48B
+        (2, 16000, 8),  # page_offset=16B, row=32000B (~4 packets)
+    ],
+)
+def test_slice_write_last_dim_overlap(H, W_in, begin_last, device):
+    torch.manual_seed(1234)
+    W_out = begin_last + W_in + 64
+
+    torch_src = torch.randn(H, W_in).bfloat16().float()
+    begins, ends, strides = [0, begin_last], [H, begin_last + W_in], [1, 1]
+    slices = tuple(slice(b, e, s) for b, e, s in zip(begins, ends, strides))
+
+    torch_out_ref = torch.zeros(H, W_out, dtype=torch.bfloat16).float()
+    torch_out_ref[slices] = torch_src
+
+    # DRAM interleaved RM input (align 64) -> exercises the page_offset%16==0 NoC branch
+    tt_in = ttnn.from_torch(torch_src.bfloat16(), device=device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16)
+    tt_in = ttnn.to_memory_config(tt_in, ttnn.DRAM_MEMORY_CONFIG)
+    tt_out = ttnn.from_torch(
+        torch.zeros(H, W_out, dtype=torch.bfloat16), device=device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16
+    )
+    tt_out = ttnn.to_memory_config(tt_out, ttnn.DRAM_MEMORY_CONFIG)
+
+    ttnn.experimental.slice_write(tt_in, tt_out, begins, ends, strides)
+
+    out_host = ttnn.to_torch(tt_out).float()
+    assert_equal(torch_src, out_host[slices])

--- a/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
@@ -15,6 +15,7 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
+#include "ckernel.h"  // ckernel::load_blocking (store-drain in copy_via_memmove)
 
 constexpr uint64_t ALIGN_REQ_64 = 64;
 constexpr uint64_t MASK_64 = 0xFFFFFFFFFFFFFFC0;
@@ -85,6 +86,26 @@ FORCE_INLINE noc_traits_t<UnicastEndpoint>::dst_args_type self_l1_dst_args(Noc n
     return {.noc_x = my_x[id], .noc_y = my_y[id], .addr = addr};
 }
 
+// CPU memmove of an L1 region, with the store-visibility drain the NoC datamover paths get for free.
+// A memmove is baby-RISCV stores; a store can retire before its write-request lands in L1, and the RISCV
+// core and the NoC are different L1 clients with no program-order guarantee between them
+// (WormholeB0/TensixTile/BabyRISCV/MemoryOrdering.md). When the copy is not deferred (!copy_async), drain
+// the last written word (blocking load + memory clobber) so the copy is processed before the caller
+// publishes / NoC-reads the destination -- the counterpart of the NoC path's completion barrier.
+template <bool copy_async>
+FORCE_INLINE void copy_via_memmove(const uint32_t dst_l1_addr, const uint32_t src_l1_addr, const uint32_t bytes) {
+    invalidate_l1_cache();
+    memmove((void*)(dst_l1_addr), (void*)(src_l1_addr), (size_t)(bytes));
+    if constexpr (!copy_async) {
+        if (bytes != 0) {
+            // Drain the 4B-aligned word holding the last written byte: in-bounds and aligned for any
+            // size/alignment (dst may be sub-word-aligned on the misaligned path).
+            (void)ckernel::load_blocking(
+                reinterpret_cast<volatile tt_l1_ptr uint32_t*>((dst_l1_addr + bytes - 1) & ~uint32_t{3}));
+        }
+    }
+}
+
 template <bool guaranteed_16B_aligned, bool copy_async, bool use_read_datamover, uint32_t max_transfer_size>
 FORCE_INLINE void tt_memmove(Noc noc, const uint32_t dst_l1_addr, const uint32_t src_l1_addr, const uint32_t bytes) {
     constexpr uint32_t page_size = max_transfer_size == 0 ? NOC_MAX_BURST_SIZE + 1 : max_transfer_size;
@@ -94,8 +115,7 @@ FORCE_INLINE void tt_memmove(Noc noc, const uint32_t dst_l1_addr, const uint32_t
     // to the CPU memmove, which copies in the safe direction. Non-overlapping copies (the common
     // cross-buffer case) are unaffected.
     if ((dst_l1_addr < src_l1_addr + bytes) && (src_l1_addr < dst_l1_addr + bytes)) {
-        invalidate_l1_cache();
-        memmove((void*)(dst_l1_addr), (void*)(src_l1_addr), (size_t)(bytes));
+        copy_via_memmove<copy_async>(dst_l1_addr, src_l1_addr, bytes);
         return;
     }
     if constexpr (use_read_datamover) {
@@ -121,8 +141,7 @@ FORCE_INLINE void tt_memmove(Noc noc, const uint32_t dst_l1_addr, const uint32_t
                     noc.async_read_barrier();
                 }
             } else {
-                invalidate_l1_cache();
-                memmove((void*)(dst_l1_addr), (void*)(src_l1_addr), (size_t)(bytes));
+                copy_via_memmove<copy_async>(dst_l1_addr, src_l1_addr, bytes);
             }
         }
     } else {
@@ -148,8 +167,7 @@ FORCE_INLINE void tt_memmove(Noc noc, const uint32_t dst_l1_addr, const uint32_t
                     noc.async_write_barrier();
                 }
             } else {
-                invalidate_l1_cache();
-                memmove((void*)(dst_l1_addr), (void*)(src_l1_addr), (size_t)(bytes));
+                copy_via_memmove<copy_async>(dst_l1_addr, src_l1_addr, bytes);
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
@@ -88,6 +88,16 @@ FORCE_INLINE noc_traits_t<UnicastEndpoint>::dst_args_type self_l1_dst_args(Noc n
 template <bool guaranteed_16B_aligned, bool copy_async, bool use_read_datamover, uint32_t max_transfer_size>
 FORCE_INLINE void tt_memmove(Noc noc, const uint32_t dst_l1_addr, const uint32_t src_l1_addr, const uint32_t bytes) {
     constexpr uint32_t page_size = max_transfer_size == 0 ? NOC_MAX_BURST_SIZE + 1 : max_transfer_size;
+    // A NoC self-copy is a plain source->dest transfer with no overlap (memmove) semantics: when
+    // [src,src+bytes) and [dst,dst+bytes) overlap, an in-flight write can be read back as a later
+    // source, so the copy is only correct while reads happen to outrun the overlapping writes. Fall
+    // to the CPU memmove, which copies in the safe direction. Non-overlapping copies (the common
+    // cross-buffer case) are unaffected.
+    if ((dst_l1_addr < src_l1_addr + bytes) && (src_l1_addr < dst_l1_addr + bytes)) {
+        invalidate_l1_cache();
+        memmove((void*)(dst_l1_addr), (void*)(src_l1_addr), (size_t)(bytes));
+        return;
+    }
     if constexpr (use_read_datamover) {
         if constexpr (guaranteed_16B_aligned) {
             noc.async_read<NocOptions::DEFAULT, page_size>(


### PR DESCRIPTION
Fixes #50726 (sub-issue of #50154, finding #26).

## Summary
`tt_memmove` (`data_movement/common/kernels/common.hpp`) performed an in-place copy via a **single NoC `async_write`/`async_read` self-copy** that has no overlap (memmove) semantics. When `[src,src+bytes)` and `[dst,dst+bytes)` overlap, an in-flight write can be read back as a later source, so the copy is only correct while the NoC's reads happen to outrun the overlapping writes. The safe CPU `memmove` was used only when the 16B offsets differed.

Reachable via `ttnn.experimental.slice_write` (RM interleaved, LAST_DIM path, `slice_write_reader_interleaved.cpp:43`):
```
tt_memmove<false,false,false,0>(noc, dst = base + page_offset, src = base, stick_size)   // dst > src
```
`dst > src` is the up-shift direction that requires a backward copy. The NoC branch is taken when `page_offset % 16 == 0`, i.e. **DRAM input** (dram_align 64 → `page_offset ∈ {16,32,48}`); L1 input (align 16) always falls to the safe CPU memmove.

## Fix
Gate the NoC self-copy on non-overlap; when the regions overlap, fall to the CPU `memmove` (which copies in the safe direction), matching the misaligned path already present in this function. **Non-overlapping (cross-buffer) copies — the overwhelmingly common case — are unaffected** (zero perf impact).

## Verification (single Blackhole p100a)
Mechanism and fix proven with a forced write-before-read ordering diagnostic (stands in for adverse NoC packet ordering), toggled against the overlap guard only:

| Scenario (`ttnn.experimental.slice_write`, DRAM RM bf16, distinct pattern, >8192B rows) | Result |
|---|---|
| Natural single-shot copy (buggy) | **0 corruption** (reads outrun writes — latent/timing-masked) |
| Forced adverse ordering, **guard disabled** (buggy) | **deterministic corruption** — 5978 / 11953 / 17902 wrong elements for `page_offset` 16 / 32 / 48, first mismatch at the first overlap boundary, count scaling with `page_offset` |
| Forced adverse ordering, **guard active** (this fix) | **0 corruption** — overlapping copy routes to `memmove` before the NoC path |

Same diagnostic, only the guard differs → the fix closes the hazard.

No regression: new `test_slice_write_overlap.py` (DRAM overlapping LAST_DIM, bit-exact) + the full `test_slice_write.py` suite pass (20 passed).

## Why the landed test can't fail-without-fix naturally
On current silicon the buggy path is timing-masked (NoC reads outrun the overlapping writes), so a natural test passes even without the fix — same latent character as the other #50154 timing findings. The landed test guards against a regression that reroutes overlap onto the raw NoC self-copy; the buggy-vs-fixed discrimination above is via the forced-ordering diagnostic (not landed, requires a kernel-side knob).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/tt-memmove-overlap-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/tt-memmove-overlap-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/tt-memmove-overlap-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/tt-memmove-overlap-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/tt-memmove-overlap-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/tt-memmove-overlap-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/tt-memmove-overlap-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/tt-memmove-overlap-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/tt-memmove-overlap-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/tt-memmove-overlap-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/tt-memmove-overlap-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/tt-memmove-overlap-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/tt-memmove-overlap-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/tt-memmove-overlap-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/tt-memmove-overlap-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/tt-memmove-overlap-guard)