### PR TITLE
Add missing dest-format configs to stop Quasar tests passing by accident.

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/data_format_inference.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/data_format_inference.py
@@ -205,6 +205,12 @@ def infer_unpack_out(
         return DataFormat.Float16  # Tilize to Float16
 
     if unpacking_to_srcs and is_fp32_dest_acc_en == DestAccumulation.Yes:
+        # The HW unpacker has no fp16->Float32 conversion (only fp16->{fp16, fp16_b, Tf32}), so forcing
+        # Float32 for a 16-bit-float input produces an unsupported unpack (all-zero SrcS on Atlas). Tf32
+        # shares Float32's 32-bit footprint and preserves the 8-bit exponent, so it is the correct widened
+        # SrcS format for a 32-bit-accumulation path. Native Float32 input stays Float32 (a direct passthrough).
+        if input_format in (DataFormat.Float16, DataFormat.Float16_b):
+            return DataFormat.Tf32
         return DataFormat.Float32
 
     # For all other cases, we can keep the format the same in L1 and src register or dest register

--- a/tt_metal/tt-llk/tests/python_tests/helpers/data_format_inference.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/data_format_inference.py
@@ -205,10 +205,6 @@ def infer_unpack_out(
         return DataFormat.Float16  # Tilize to Float16
 
     if unpacking_to_srcs and is_fp32_dest_acc_en == DestAccumulation.Yes:
-        # The HW unpacker has no fp16->Float32 conversion (only fp16->{fp16, fp16_b, Tf32}), so forcing
-        # Float32 for a 16-bit-float input produces an unsupported unpack (all-zero SrcS on Atlas). Tf32
-        # shares Float32's 32-bit footprint and preserves the 8-bit exponent, so it is the correct widened
-        # SrcS format for a 32-bit-accumulation path. Native Float32 input stays Float32 (a direct passthrough).
         if input_format in (DataFormat.Float16, DataFormat.Float16_b):
             return DataFormat.Tf32
         return DataFormat.Float32

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_topk_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_topk_quasar_test.cpp
@@ -219,7 +219,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
                     const int stage_index        = static_cast<int>(stage);
                     const DataFormat math_format = static_cast<DataFormat>(math_data_types[stage_index]);
 
-                    _configure_alu_formats_<false /*EN_IMPLIED_MATH_FORMAT*/, is_fp32_dest_acc_en>(math_format, math_format, false /*en_int32_dest_format*/);
+                    _configure_alu_formats_<false /*EN_IMPLIED_MATH_FORMAT*/, is_fp32_dest_acc_en>(
+                        math_format, math_format, false /*en_int32_dest_format*/, DataFormat::Invalid /*no dest-format override*/);
 
                     const int first_tile_in_pair_idx  = stage_index * NUM_TILES_PER_STAGE;
                     const int second_tile_in_pair_idx = first_tile_in_pair_idx + 1;
@@ -232,7 +233,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
 
                 _configure_alu_formats_<false /*EN_IMPLIED_MATH_FORMAT*/, is_fp32_dest_acc_en>(
-                    value_math_format, value_math_format, false /*en_int32_dest_format*/);
+                    value_math_format, value_math_format, false /*en_int32_dest_format*/, DataFormat::Invalid /*no dest-format override*/);
 
                 // Run the topk stages. RC_custom issues one SFPU call per tile (no per-face walk).
                 if (first_iter)

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_common.h
@@ -252,6 +252,9 @@ inline void _configure_default_alu_data_format_state_(DataFormat srcA_format, Da
  * Special ALU data format config state used for: transpose dest.
  * Disables implied math format due to MOV op quirks. Sets en_int32_dest_format = false because ALU_ACC_CTRL_INT8_math_enabled
  * does not work with MOVD2A/B. When unpacking Int32 or Fp32 to dest, the ALU_FORMAT_SPEC SrcA/B cfg registers are set to Int32/Fp32.
+ * @note For EN_32BIT_DEST, this forces the dest-format override (ALU_FORMAT_SPEC_REG_Dstacc_override -> Float32) so MOVD2B/MOVB2D
+ * read DEST via the current 32b path instead of a stale saved dest format (e.g. Int32 left by a prior compute), which would
+ * otherwise select the wrong hi16 datum mux and corrupt face 0. For 16-bit dest no override is applied (DataFormat::Invalid).
  */
 template <bool EN_32BIT_DEST>
 inline void _configure_mov_ops_explicit_alu_data_format_state_(DataFormat srcA_format, DataFormat srcB_format)

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_common.h
@@ -161,10 +161,12 @@ inline bool _is_src_fmt_int32_dest_compatible_(const DataFormat src_reg_fmt)
  * (math_override_saved_dest_format). When not DataFormat::Invalid, the ALU/moves use this format instead of the
  * saved per-bank dest format (the format the last compute op wrote to DEST); DataFormat::Invalid disables the
  * override. Example: used by the 32-bit transpose (passes Float32) so MOVD2B/MOVB2D read DEST via the current 32b path.
+ * Required (no default): every caller must decide explicitly — pass DataFormat::Invalid for compute paths that must
+ * keep the saved/implied DEST format, so a new DEST-reading MOV path cannot silently omit the override and
+ * reproduce the stale-format hi16 corruption.
  */
 template <bool EN_IMPLIED_MATH_FORMAT, bool EN_32BIT_DEST>
-inline void _configure_alu_formats_(
-    DataFormat srcA_format, DataFormat srcB_format, bool en_int32_dest_format, DataFormat dstacc_override_fmt = DataFormat::Invalid)
+inline void _configure_alu_formats_(DataFormat srcA_format, DataFormat srcB_format, bool en_int32_dest_format, DataFormat dstacc_override_fmt)
 {
     TTI_STALLWAIT(p_stall::STALL_CFG, 0, p_stall::WAIT_SFPU, p_stall::MATH);
 
@@ -230,7 +232,8 @@ inline void _configure_default_alu_data_format_state_(DataFormat srcA_format, Da
     }
 
     const bool en_int32_dest_format = _is_src_fmt_int32_dest_compatible_(srcA_format) && _is_src_fmt_int32_dest_compatible_(srcB_format) && EN_32BIT_DEST;
-    _configure_alu_formats_<EN_IMPLIED_MATH_FORMAT, EN_32BIT_DEST>(srcA_format, srcB_format, en_int32_dest_format);
+    // Regular compute path: keep the saved/implied DEST format — no dest-format override.
+    _configure_alu_formats_<EN_IMPLIED_MATH_FORMAT, EN_32BIT_DEST>(srcA_format, srcB_format, en_int32_dest_format, DataFormat::Invalid);
 
     data_format_config_set = DataFormatConfigSet::DEFAULT;
 }

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_common.h
@@ -157,11 +157,14 @@ inline bool _is_src_fmt_int32_dest_compatible_(const DataFormat src_reg_fmt)
  * @param srcB_format: Input srcB format, used to set ALU configs if not implied math format
  * values = Dataformat enum, ex: <Float16/Float16_b/Tf32/Int8/Int16/UInt8>
  * @param en_int32_dest_format: Set to true to use destination register in Int32 format
- * @param en_dstacc_override: Set to true to assert ALU_FORMAT_SPEC_REG_Dstacc_override and pin the dest
- * format to Float32, so MOVD2B/MOVB2D read DEST via the current Float32 32b path (used by 32-bit transpose)
+ * @param dstacc_override_fmt: Dest format to force via ALU_FORMAT_SPEC_REG_Dstacc_override
+ * (math_override_saved_dest_format). When not DataFormat::Invalid, the ALU/moves use this format instead of the
+ * saved per-bank dest format (the format the last compute op wrote to DEST); DataFormat::Invalid disables the
+ * override. Example: used by the 32-bit transpose (passes Float32) so MOVD2B/MOVB2D read DEST via the current 32b path.
  */
 template <bool EN_IMPLIED_MATH_FORMAT, bool EN_32BIT_DEST>
-inline void _configure_alu_formats_(DataFormat srcA_format, DataFormat srcB_format, bool en_int32_dest_format, bool en_dstacc_override = false)
+inline void _configure_alu_formats_(
+    DataFormat srcA_format, DataFormat srcB_format, bool en_int32_dest_format, DataFormat dstacc_override_fmt = DataFormat::Invalid)
 {
     TTI_STALLWAIT(p_stall::STALL_CFG, 0, p_stall::WAIT_SFPU, p_stall::MATH);
 
@@ -183,15 +186,15 @@ inline void _configure_alu_formats_(DataFormat srcA_format, DataFormat srcB_form
     alu_config.f.ALU_ACC_CTRL_SFPU_Fp32_enabled = EN_32BIT_DEST;
     alu_config.f.ALU_ACC_CTRL_INT8_math_enabled = en_int32_dest_format;
 
-    if (en_dstacc_override)
+    if (dstacc_override_fmt != DataFormat::Invalid)
     {
         // MOVD2B/MOVB2D pick the DEST datum mux from the SAVED dest format (the format the last
         // compute op wrote to DEST) unless math_override_saved_dest_format is asserted. Assert it
-        // (ALU_FORMAT_SPEC_REG_Dstacc_override) and pin the dest format so the transpose's hi16
-        // (DEST_NORM) read uses the current Float32 32b path, not a stale Int32 saved format — the
-        // Int32 mux (int8_19b_format) corrupts face-0 hi16 back to the reset fill (0x080F). The
-        // transpose is always the 32-bit (Float32) path, so pin the dest format to Float32.
-        const std::uint8_t DSTACC_FORMAT_MASKED          = masked_data_format(to_underlying(DataFormat::Float32));
+        // (ALU_FORMAT_SPEC_REG_Dstacc_override) and pin the dest format to dstacc_override_fmt so a
+        // dest-format-dependent move reads DEST via the current format, not a stale saved one. The
+        // 32-bit transpose passes Float32: otherwise a stale Int32 saved format selects the wrong
+        // hi16 mux (int8_19b_format), corrupting face-0 hi16 back to the reset fill (0x080F).
+        const std::uint8_t DSTACC_FORMAT_MASKED          = masked_data_format(to_underlying(dstacc_override_fmt));
         alu_config.f.ALU_FORMAT_SPEC_REG_Dstacc_val      = DSTACC_FORMAT_MASKED;
         alu_config.f.ALU_FORMAT_SPEC_REG_Dstacc_override = 1;
         alu_config.f.ALU_FORMAT_SPEC_REG2_Dstacc         = DSTACC_FORMAT_MASKED;
@@ -255,11 +258,11 @@ inline void _configure_mov_ops_explicit_alu_data_format_state_(DataFormat srcA_f
         return;
     }
 
-    // For 32-bit dest, force the dest-format override (Dstacc_override=1) so the transpose MOVD2B/
-    // MOVB2D read the DEST via the current Float32 32b path instead of a stale saved dest format
-    // (e.g. Int32 left by a prior compute), which otherwise selects the wrong hi16 datum mux.
+    // For 32-bit dest, force the dest-format override to Float32 so the transpose MOVD2B/MOVB2D read
+    // the DEST via the current Float32 32b path instead of a stale saved dest format (e.g. Int32 left
+    // by a prior compute), which otherwise selects the wrong hi16 datum mux.
     _configure_alu_formats_<false /* EN_IMPLIED_MATH_FORMAT */, EN_32BIT_DEST>(
-        srcA_format, srcB_format, false /* en_int32_dest_format */, EN_32BIT_DEST /* en_dstacc_override */);
+        srcA_format, srcB_format, false /* en_int32_dest_format */, EN_32BIT_DEST ? DataFormat::Float32 : DataFormat::Invalid);
 
     data_format_config_set = DataFormatConfigSet::MOV_OPS_EXPLICIT_FMT;
 }

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_common.h
@@ -157,9 +157,11 @@ inline bool _is_src_fmt_int32_dest_compatible_(const DataFormat src_reg_fmt)
  * @param srcB_format: Input srcB format, used to set ALU configs if not implied math format
  * values = Dataformat enum, ex: <Float16/Float16_b/Tf32/Int8/Int16/UInt8>
  * @param en_int32_dest_format: Set to true to use destination register in Int32 format
+ * @param en_dstacc_override: Set to true to assert ALU_FORMAT_SPEC_REG_Dstacc_override and pin the dest
+ * format to Float32, so MOVD2B/MOVB2D read DEST via the current Float32 32b path (used by 32-bit transpose)
  */
 template <bool EN_IMPLIED_MATH_FORMAT, bool EN_32BIT_DEST>
-inline void _configure_alu_formats_(DataFormat srcA_format, DataFormat srcB_format, bool en_int32_dest_format)
+inline void _configure_alu_formats_(DataFormat srcA_format, DataFormat srcB_format, bool en_int32_dest_format, bool en_dstacc_override = false)
 {
     TTI_STALLWAIT(p_stall::STALL_CFG, 0, p_stall::WAIT_SFPU, p_stall::MATH);
 
@@ -180,6 +182,20 @@ inline void _configure_alu_formats_(DataFormat srcA_format, DataFormat srcB_form
     alu_config.f.ALU_ACC_CTRL_Fp32_enabled      = EN_32BIT_DEST;
     alu_config.f.ALU_ACC_CTRL_SFPU_Fp32_enabled = EN_32BIT_DEST;
     alu_config.f.ALU_ACC_CTRL_INT8_math_enabled = en_int32_dest_format;
+
+    if (en_dstacc_override)
+    {
+        // MOVD2B/MOVB2D pick the DEST datum mux from the SAVED dest format (the format the last
+        // compute op wrote to DEST) unless math_override_saved_dest_format is asserted. Assert it
+        // (ALU_FORMAT_SPEC_REG_Dstacc_override) and pin the dest format so the transpose's hi16
+        // (DEST_NORM) read uses the current Float32 32b path, not a stale Int32 saved format — the
+        // Int32 mux (int8_19b_format) corrupts face-0 hi16 back to the reset fill (0x080F). The
+        // transpose is always the 32-bit (Float32) path, so pin the dest format to Float32.
+        const std::uint8_t DSTACC_FORMAT_MASKED          = masked_data_format(to_underlying(DataFormat::Float32));
+        alu_config.f.ALU_FORMAT_SPEC_REG_Dstacc_val      = DSTACC_FORMAT_MASKED;
+        alu_config.f.ALU_FORMAT_SPEC_REG_Dstacc_override = 1;
+        alu_config.f.ALU_FORMAT_SPEC_REG2_Dstacc         = DSTACC_FORMAT_MASKED;
+    }
 
     for (std::uint32_t i = 0; i < NUM_WORDS_ALU_FORMAT; i++)
     {
@@ -239,7 +255,11 @@ inline void _configure_mov_ops_explicit_alu_data_format_state_(DataFormat srcA_f
         return;
     }
 
-    _configure_alu_formats_<false /* EN_IMPLIED_MATH_FORMAT */, EN_32BIT_DEST>(srcA_format, srcB_format, false /* en_int32_dest_format */);
+    // For 32-bit dest, force the dest-format override (Dstacc_override=1) so the transpose MOVD2B/
+    // MOVB2D read the DEST via the current Float32 32b path instead of a stale saved dest format
+    // (e.g. Int32 left by a prior compute), which otherwise selects the wrong hi16 datum mux.
+    _configure_alu_formats_<false /* EN_IMPLIED_MATH_FORMAT */, EN_32BIT_DEST>(
+        srcA_format, srcB_format, false /* en_int32_dest_format */, EN_32BIT_DEST /* en_dstacc_override */);
 
     data_format_config_set = DataFormatConfigSet::MOV_OPS_EXPLICIT_FMT;
 }

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_common.h
@@ -157,7 +157,7 @@ inline bool _is_src_fmt_int32_dest_compatible_(const DataFormat src_reg_fmt)
  * @param srcB_format: Input srcB format, used to set ALU configs if not implied math format
  * values = Dataformat enum, ex: <Float16/Float16_b/Tf32/Int8/Int16/UInt8>
  * @param en_int32_dest_format: Set to true to use destination register in Int32 format
- * @param dstacc_override_fmt: Dest format to force via ALU_FORMAT_SPEC_REG_Dstacc_override
+ * @param dest_acc_override_fmt: Dest format to force via ALU_FORMAT_SPEC_REG_Dstacc_override
  * (math_override_saved_dest_format). When not DataFormat::Invalid, the ALU/moves use this format instead of the
  * saved per-bank dest format (the format the last compute op wrote to DEST); DataFormat::Invalid disables the
  * override. Example: used by the 32-bit transpose (passes Float32) so MOVD2B/MOVB2D read DEST via the current 32b path.
@@ -166,7 +166,7 @@ inline bool _is_src_fmt_int32_dest_compatible_(const DataFormat src_reg_fmt)
  * reproduce the stale-format hi16 corruption.
  */
 template <bool EN_IMPLIED_MATH_FORMAT, bool EN_32BIT_DEST>
-inline void _configure_alu_formats_(DataFormat srcA_format, DataFormat srcB_format, bool en_int32_dest_format, DataFormat dstacc_override_fmt)
+inline void _configure_alu_formats_(DataFormat srcA_format, DataFormat srcB_format, bool en_int32_dest_format, DataFormat dest_acc_override_fmt)
 {
     TTI_STALLWAIT(p_stall::STALL_CFG, 0, p_stall::WAIT_SFPU, p_stall::MATH);
 
@@ -188,15 +188,15 @@ inline void _configure_alu_formats_(DataFormat srcA_format, DataFormat srcB_form
     alu_config.f.ALU_ACC_CTRL_SFPU_Fp32_enabled = EN_32BIT_DEST;
     alu_config.f.ALU_ACC_CTRL_INT8_math_enabled = en_int32_dest_format;
 
-    if (dstacc_override_fmt != DataFormat::Invalid)
+    if (dest_acc_override_fmt != DataFormat::Invalid)
     {
         // MOVD2B/MOVB2D pick the DEST datum mux from the SAVED dest format (the format the last
         // compute op wrote to DEST) unless math_override_saved_dest_format is asserted. Assert it
-        // (ALU_FORMAT_SPEC_REG_Dstacc_override) and pin the dest format to dstacc_override_fmt so a
+        // (ALU_FORMAT_SPEC_REG_Dstacc_override) and pin the dest format to dest_acc_override_fmt so a
         // dest-format-dependent move reads DEST via the current format, not a stale saved one. The
         // 32-bit transpose passes Float32: otherwise a stale Int32 saved format selects the wrong
         // hi16 mux (int8_19b_format), corrupting face-0 hi16 back to the reset fill (0x080F).
-        const std::uint8_t DSTACC_FORMAT_MASKED          = masked_data_format(to_underlying(dstacc_override_fmt));
+        const std::uint8_t DSTACC_FORMAT_MASKED          = masked_data_format(to_underlying(dest_acc_override_fmt));
         alu_config.f.ALU_FORMAT_SPEC_REG_Dstacc_val      = DSTACC_FORMAT_MASKED;
         alu_config.f.ALU_FORMAT_SPEC_REG_Dstacc_override = 1;
         alu_config.f.ALU_FORMAT_SPEC_REG2_Dstacc         = DSTACC_FORMAT_MASKED;


### PR DESCRIPTION
### Summary
Two format-configuration gaps let certain Quasar tests pass by acciden. 
The Quasar Verilog model's X-optimism absorbed operand/format-rule violations. 
This PR makes the LLK/test-infra follow the actual rules provided by docs.

**So what is Verilog X-optimism?** In RTL simulation an uninitialized or unconstrained signal holds the value X ("unknown"). When an X reaches a conditional — a mux select, an if, a format-decode — the simulator doesn't stall; it guesses, and often propagates a defined result as if the X had been a convenient 0 or 1. This is "X-optimism": the sim optimistically picks an outcome that lets the path resolve, so an operation the hardware rules actually forbid can still flow through and land on believable-looking data. The bug stays invisible because the test passes.

### Changes
1. `data_format_inference.py` — SrcS→TF32 for 32-bit dest accumulation
When unpacking to source registers with DestAccumulation.Yes, a `Float16/Float16_b` input now infers `Tf32` instead of `Float32`:

The HW unpacker has no fp16→Float32 conversion (only fp16→{fp16, fp16_b, Tf32}). 
Tf32 shares Float32's 32-bit footprint and 8-bit exponent, so it's the correct widened SrcS format for a 32-bit-accumulation path.
Native Float32 input stays Float32 (direct passthrough). 

2.`llk_math_common.h` — force dest format for 32-bit transpose (`Dstacc_override`)
`_configure_alu_formats_` gains a DataFormat dstacc_override_fmt = DataFormat::Invalid parameter. 
When set, it asserts ALU_FORMAT_SPEC_REG_Dstacc_override (math_override_saved_dest_format) and pins the dest format so dest-format-dependent moves (MOVD2B/MOVB2D) use the currently programmed format instead of the saved per-bank format left by the last compute op.

Without this, an Int32 transpose_dest reads its hi16 (DEST_NORM) plane through the stale saved Int32 mux (int8_19b_format), corrupting face 0 back to the reset fill (0x080F). This is a general "force dest format" knob (not transpose-specific).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=uvelimirovic/quasar_add_missing_configs)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:uvelimirovic/quasar_add_missing_configs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=uvelimirovic/quasar_add_missing_configs)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:uvelimirovic/quasar_add_missing_configs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=uvelimirovic/quasar_add_missing_configs)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:uvelimirovic/quasar_add_missing_configs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=uvelimirovic/quasar_add_missing_configs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:uvelimirovic/quasar_add_missing_configs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=uvelimirovic/quasar_add_missing_configs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:uvelimirovic/quasar_add_missing_configs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=uvelimirovic/quasar_add_missing_configs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:uvelimirovic/quasar_add_missing_configs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=uvelimirovic/quasar_add_missing_configs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:uvelimirovic/quasar_add_missing_configs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=uvelimirovic/quasar_add_missing_configs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:uvelimirovic/quasar_add_missing_configs)