### PR TITLE
tools: cabling_generator: Improve hierarchical descriptor handling

### DIFF
--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -83,6 +83,19 @@ deployment::proto::DeploymentDescriptor load_deployment_descriptor(const std::st
     return load_descriptor_from_textproto<deployment::proto::DeploymentDescriptor>(file_path);
 }
 
+// Load a factory system descriptor and return hostname -> instance_path segments. Used by
+// build_nested_aggregate to recover a child's intra-cluster hierarchy (which a flattened cabling
+// descriptor no longer carries) when composing aggregated instance paths.
+std::unordered_map<std::string, std::vector<std::string>> load_fsd_instance_paths(const std::string& file_path) {
+    auto fsd = load_descriptor_from_textproto<tt::scaleout_tools::fsd::proto::FactorySystemDescriptor>(file_path);
+    std::unordered_map<std::string, std::vector<std::string>> out;
+    for (const auto& host : fsd.hosts()) {
+        out.emplace(
+            host.hostname(), std::vector<std::string>(host.instance_path().begin(), host.instance_path().end()));
+    }
+    return out;
+}
+
 // Build endpoint map for node template inter-board connections (validates conflicts per port type)
 std::map<Node::BoardEndpoint, Node::BoardEndpoint> build_endpoint_map_for_port_type(
     const std::vector<Node::BoardConnection>& connections,
@@ -1488,6 +1501,291 @@ void CablingGenerator::merge(
     merge_other(other, new_file_path, existing_sources);
 }
 
+// Shift every host_id in a resolved graph (nodes + connections) by `base` so that independently
+// resolved child graphs occupy disjoint host_id ranges before a global DFS reassignment.
+static void offset_host_ids(ResolvedGraphInstance& graph, uint32_t base) {
+    for (auto& [name, node] : graph.nodes) {
+        node.host_id = HostId(*node.host_id + base);
+    }
+    for (auto& [port_type, connections] : graph.internal_connections) {
+        for (auto& conn : connections) {
+            std::get<0>(conn.first) = HostId(*std::get<0>(conn.first) + base);
+            std::get<0>(conn.second) = HostId(*std::get<0>(conn.second) + base);
+        }
+    }
+    // Rebuild derived lookups against the shifted ids.
+    graph.endpoint_to_dest.clear();
+    graph.connection_pairs.clear();
+    for (const auto& [port_type, connections] : graph.internal_connections) {
+        for (const auto& conn : connections) {
+            graph.endpoint_to_dest[conn.first] = conn.second;
+            graph.endpoint_to_dest[conn.second] = conn.first;
+            graph.connection_pairs.insert(normalize_graph_connection(conn));
+        }
+    }
+    for (auto& [name, subgraph] : graph.subgraphs) {
+        offset_host_ids(*subgraph, base);
+    }
+}
+
+CablingGenerator CablingGenerator::build_nested_aggregate(
+    const std::string& composite_name,
+    const std::vector<AggregateChild>& children,
+    const std::vector<std::string>& glue_descriptor_paths,
+    const std::string& deployment_descriptor_path) {
+    if (children.empty()) {
+        throw std::runtime_error("build_nested_aggregate requires at least one child");
+    }
+    auto full_deployment = load_deployment_descriptor(deployment_descriptor_path);
+
+    CablingGenerator agg;
+    agg.root_instance_ = std::make_unique<ResolvedGraphInstance>();
+    agg.root_instance_->template_name = composite_name;
+    agg.root_instance_->instance_name = "";
+
+    std::unordered_map<std::string, Host> all_hosts;
+    // Leaf Node* -> hostname. Node objects live in the (re)nested subgraphs owned by agg, so their
+    // addresses stay valid until deployment_hosts_ is rebuilt below.
+    std::unordered_map<const Node*, std::string> node_to_hostname;
+    uint32_t base = 0;
+
+    // Get-or-create a subgraph child by instance name, maintaining children_order.
+    auto get_or_create_subgraph =
+        [](ResolvedGraphInstance& parent, const std::string& key, const std::string& tmpl) -> ResolvedGraphInstance& {
+        if (auto it = parent.subgraphs.find(key); it != parent.subgraphs.end()) {
+            return *it->second;
+        }
+        auto sub = std::make_unique<ResolvedGraphInstance>();
+        sub->template_name = tmpl;
+        sub->instance_name = key;
+        ResolvedGraphInstance& ref = *sub;
+        parent.subgraphs.emplace(key, std::move(sub));
+        parent.children_order.emplace_back(key, false);
+        return ref;
+    };
+
+    std::set<std::string> aggregate_instance_names;
+    for (const auto& [inst_name, cabling_path, fsd_path, deployment_path] : children) {
+        validate_instance_name(inst_name, composite_name);
+        if (!aggregate_instance_names.insert(inst_name).second) {
+            throw std::runtime_error("Duplicate aggregate child instance name: " + inst_name);
+        }
+        // Load each child against its own deployment when provided (host_id-positional). This is what
+        // lets a hierarchical child (whose leaf nodes are instance-named, e.g. "node_0", rather than
+        // hostname-named) load at all, since the composite deployment can only be sliced by hostname.
+        // Fall back to slicing the composite deployment by hostname for flat, hostname-named children.
+        auto load_child = [&]() -> CablingGenerator {
+            if (!deployment_path.empty()) {
+                return CablingGenerator(cabling_path, deployment_path);
+            }
+            auto cluster = load_cluster_descriptor(cabling_path);
+            auto child_deployment = filter_deployment_for_cabling(cluster, full_deployment, cabling_path);
+            return CablingGenerator(cabling_path, child_deployment);
+        };
+        CablingGenerator child = load_child();
+        if (!child.root_instance_) {
+            throw std::runtime_error("Child cabling descriptor produced no root_instance: " + cabling_path);
+        }
+
+        for (const auto& [key, node_template] : child.node_templates_) {
+            agg.node_templates_.emplace(key, node_template);
+        }
+        for (const auto& name : child.explicit_node_descriptors_) {
+            agg.explicit_node_descriptors_.insert(name);
+        }
+        for (const auto& host : child.deployment_hosts_) {
+            all_hosts[host.hostname] = host;
+        }
+
+        uint32_t child_leaf_count = static_cast<uint32_t>(child.host_id_to_node_.size());
+
+        // The child's own intra-cluster hierarchy (e.g. sp4/sp2_0/bh_galaxy_sp_0/...) lives in its
+        // FSD's per-host instance_path; a flattened cabling descriptor no longer carries it. When the
+        // FSD is available we rebuild that hierarchy under the composite, uniquifying the top segment
+        // with the child's directory name. Otherwise we fall back to nesting the child's resolved tree
+        // directly under its directory name (directory hierarchy only).
+        std::unordered_map<std::string, std::vector<std::string>> fsd_paths;
+        if (!fsd_path.empty()) {
+            fsd_paths = load_fsd_instance_paths(fsd_path);
+        }
+
+        if (fsd_paths.empty()) {
+            auto record_hostnames = [&](auto& self, const ResolvedGraphInstance& graph) -> void {
+                for (const auto& [name, node] : graph.nodes) {
+                    if (*node.host_id < child.deployment_hosts_.size()) {
+                        node_to_hostname[&node] = child.deployment_hosts_[*node.host_id].hostname;
+                    }
+                }
+                for (const auto& [name, subgraph] : graph.subgraphs) {
+                    self(self, *subgraph);
+                }
+            };
+            record_hostnames(record_hostnames, *child.root_instance_);
+            offset_host_ids(*child.root_instance_, base);
+            base += child_leaf_count;
+            child.root_instance_->instance_name = inst_name;
+            agg.root_instance_->children_order.emplace_back(inst_name, false);
+            agg.root_instance_->subgraphs.emplace(inst_name, std::move(child.root_instance_));
+            continue;
+        }
+
+        // Collect every leaf node (capturing its hostname before shifting host_ids) and flatten all
+        // connections, offsetting host_ids so each child occupies a disjoint range before the global
+        // DFS reassignment below.
+        std::vector<std::pair<std::string, Node>> leaves;  // (hostname, node with offset host_id)
+        leaves.reserve(child_leaf_count);
+        std::vector<std::pair<PortType, PortConnection>> conns;
+        auto collect = [&](auto& self, ResolvedGraphInstance& graph) -> void {
+            for (auto& [name, node] : graph.nodes) {
+                std::string hostname = (*node.host_id < child.deployment_hosts_.size())
+                                           ? child.deployment_hosts_[*node.host_id].hostname
+                                           : std::string{};
+                node.host_id = HostId(*node.host_id + base);
+                leaves.emplace_back(std::move(hostname), std::move(node));
+            }
+            for (const auto& [port_type, connections] : graph.internal_connections) {
+                for (const auto& conn : connections) {
+                    PortConnection shifted = conn;
+                    std::get<0>(shifted.first) = HostId(*std::get<0>(shifted.first) + base);
+                    std::get<0>(shifted.second) = HostId(*std::get<0>(shifted.second) + base);
+                    conns.emplace_back(port_type, shifted);
+                }
+            }
+            for (const auto& [name, subgraph] : graph.subgraphs) {
+                self(self, *subgraph);
+            }
+        };
+        collect(collect, *child.root_instance_);
+        base += child_leaf_count;
+
+        // Rebuild the nested structure from the FSD instance paths. The top segment is uniquified with
+        // the child's directory name (e.g. "sp4" -> "sp4-120-a29") so identical intra-cluster roots
+        // from different clusters do not collide; a segment already equal to the directory name (a
+        // re-aggregated composite whose root == its own name) is left as-is.
+        std::set<std::string> child_top_keys;
+        for (auto& [hostname, node] : leaves) {
+            auto pit = fsd_paths.find(hostname);
+            // A missing instance_path used to be a hard error, but that breaks backward compatibility with
+            // older FSDs that do not emit one. Downgrade to a warning and fall back to a flat instance path
+            // ("<inst_name>/<hostname>") so aggregation still succeeds.
+            std::vector<std::string> fallback_path;
+            if (pit == fsd_paths.end() || pit->second.empty()) {
+                log_warning(
+                    tt::LogDistributed,
+                    "Child '{}' FSD ({}) is missing an instance_path for host '{}'; falling back to a flat "
+                    "instance path. Please regenerate the FSD with an up-to-date tool.",
+                    inst_name,
+                    fsd_path,
+                    hostname);
+                fallback_path = {inst_name, hostname};
+            }
+            const std::vector<std::string>& path = fallback_path.empty() ? pit->second : fallback_path;
+            std::string key0 = (path.front() == inst_name) ? path.front() : (path.front() + "-" + inst_name);
+            child_top_keys.insert(key0);
+            ResolvedGraphInstance* cur = &get_or_create_subgraph(*agg.root_instance_, key0, path.front());
+            for (size_t i = 1; i + 1 < path.size(); ++i) {
+                cur = &get_or_create_subgraph(*cur, path[i], path[i]);
+            }
+            const std::string& leaf_name = path.back();
+            cur->nodes.emplace(leaf_name, std::move(node));
+            cur->children_order.emplace_back(leaf_name, true);
+            node_to_hostname[&cur->nodes.at(leaf_name)] = hostname;
+        }
+
+        // Attach the child's connections at its single top instance so relative connection paths in the
+        // hierarchical descriptor resolve within the child; fall back to the composite root if a child
+        // unexpectedly spans multiple top segments.
+        ResolvedGraphInstance* conn_target = (child_top_keys.size() == 1)
+                                                 ? agg.root_instance_->subgraphs.at(*child_top_keys.begin()).get()
+                                                 : agg.root_instance_.get();
+        for (const auto& [port_type, conn] : conns) {
+            conn_target->add_connection(port_type, conn);
+        }
+    }
+
+    // Pack host_ids densely in DFS order, remap child connections, and repopulate host_id_to_node_.
+    agg.reassign_host_ids_dfs();
+
+    // Rebuild deployment_hosts_ indexed by the final (DFS) host_id.
+    agg.deployment_hosts_.assign(base, Host{});
+    auto fill_hosts = [&](auto& self, const ResolvedGraphInstance& graph) -> void {
+        for (const auto& [name, is_node] : graph.children_order) {
+            if (is_node) {
+                auto it = graph.nodes.find(name);
+                if (it == graph.nodes.end()) {
+                    continue;
+                }
+                auto hn = node_to_hostname.find(&it->second);
+                if (hn == node_to_hostname.end()) {
+                    throw std::runtime_error("Aggregate leaf missing a hostname mapping: " + name);
+                }
+                auto host_it = all_hosts.find(hn->second);
+                if (host_it == all_hosts.end()) {
+                    throw std::runtime_error("Aggregate host not found in deployment: " + hn->second);
+                }
+                agg.deployment_hosts_[*it->second.host_id] = host_it->second;
+            } else if (auto sit = graph.subgraphs.find(name); sit != graph.subgraphs.end()) {
+                self(self, *sit->second);
+            }
+        }
+    };
+    fill_hosts(fill_hosts, *agg.root_instance_);
+
+    // Wire glue (inter-child) connections at the composite root, mapping hostname -> final host_id.
+    std::unordered_map<std::string, HostId> hostname_to_hid;
+    for (size_t i = 0; i < agg.deployment_hosts_.size(); ++i) {
+        hostname_to_hid[agg.deployment_hosts_[i].hostname] = HostId(static_cast<uint32_t>(i));
+    }
+    for (const auto& glue_path : glue_descriptor_paths) {
+        auto glue_cluster = load_cluster_descriptor(glue_path);
+        auto glue_deployment = filter_deployment_for_cabling(glue_cluster, full_deployment, glue_path);
+        CablingGenerator glue(glue_path, glue_deployment);
+        for (const auto& [key, node_template] : glue.node_templates_) {
+            agg.node_templates_.emplace(key, node_template);
+        }
+        for (const auto& name : glue.explicit_node_descriptors_) {
+            agg.explicit_node_descriptors_.insert(name);
+        }
+        if (!glue.root_instance_) {
+            continue;
+        }
+        auto remap_endpoint = [&](const PortEndpoint& ep) -> PortEndpoint {
+            HostId ghid = std::get<0>(ep);
+            if (*ghid >= glue.deployment_hosts_.size()) {
+                throw std::runtime_error("Glue connection references an unknown host_id in: " + glue_path);
+            }
+            const std::string& hostname = glue.deployment_hosts_[*ghid].hostname;
+            auto it = hostname_to_hid.find(hostname);
+            if (it == hostname_to_hid.end()) {
+                throw std::runtime_error(
+                    "Glue file '" + glue_path + "' references host '" + hostname +
+                    "' that is not part of the aggregated children");
+            }
+            return std::make_tuple(it->second, std::get<1>(ep), std::get<2>(ep));
+        };
+        auto add_glue = [&](auto& self, const ResolvedGraphInstance& graph) -> void {
+            for (const auto& [port_type, connections] : graph.internal_connections) {
+                for (const auto& conn : connections) {
+                    agg.root_instance_->add_connection(
+                        port_type, PortConnection(remap_endpoint(conn.first), remap_endpoint(conn.second)));
+                }
+            }
+            for (const auto& [name, subgraph] : graph.subgraphs) {
+                self(self, *subgraph);
+            }
+        };
+        add_glue(add_glue, *glue.root_instance_);
+    }
+
+    // Reset port availability, then regenerate channel-level connections across the whole tree.
+    agg.recreate_nodes_from_templates(*agg.root_instance_);
+    agg.populate_host_id_to_node();
+    agg.generate_logical_chip_connections();
+    agg.validate_host_id_uniqueness();
+
+    return agg;
+}
+
 // Getters for all data
 const std::vector<Host>& CablingGenerator::get_deployment_hosts() const { return deployment_hosts_; }
 
@@ -1789,6 +2087,113 @@ static void flatten_resolved_graph_to_protobuf(
     }
 }
 
+// Find the relative instance path (child instance names) from `graph` down to the leaf node with
+// `target` host_id. Returns true and fills `out` (root..leaf, e.g. {"sp2_0","bh_galaxy_node_0","node_0"})
+// on success. Used to render multi-segment connection paths when emitting a nested descriptor.
+static bool relative_path_to_host(const ResolvedGraphInstance& graph, HostId target, std::vector<std::string>& out) {
+    for (const auto& [name, node] : graph.nodes) {
+        if (node.host_id == target) {
+            out.push_back(name);
+            return true;
+        }
+    }
+    for (const auto& [name, subgraph] : graph.subgraphs) {
+        out.push_back(name);
+        if (relative_path_to_host(*subgraph, target, out)) {
+            return true;
+        }
+        out.pop_back();
+    }
+    return false;
+}
+
+// Recursively serialize a resolved graph instance into a nested ClusterDescriptor, preserving the
+// hierarchy. Each graph instance gets its own graph_template (keyed by its instance path so keys are
+// unique; templates are expanded rather than shared). `inst` is the GraphInstance proto (root_instance
+// or a sub_instance) to populate. Returns the template key assigned to this graph.
+static std::string emit_graph_template_recursive(
+    const ResolvedGraphInstance& graph,
+    const std::vector<std::string>& path,
+    const std::string& root_template_name,
+    cabling_generator::proto::ClusterDescriptor& cluster_desc,
+    cabling_generator::proto::GraphInstance* inst,
+    const std::unordered_map<std::string, Node>& node_templates) {
+    // Root uses the composite/root template name (drives instance_path[0]); deeper graphs use their
+    // unique instance path as the key. '/' is safe here: only child *instance* names are validated.
+    std::string template_key;
+    if (path.empty()) {
+        template_key = root_template_name;
+    } else {
+        for (const auto& seg : path) {
+            template_key += template_key.empty() ? seg : "/" + seg;
+        }
+    }
+    inst->set_template_name(template_key);
+    auto& template_proto = (*cluster_desc.mutable_graph_templates())[template_key];
+
+    for (const auto& [name, is_node] : graph.children_order) {
+        auto* child = template_proto.add_children();
+        child->set_name(name);
+        if (is_node) {
+            auto it = graph.nodes.find(name);
+            if (it == graph.nodes.end()) {
+                continue;
+            }
+            child->mutable_node_ref()->set_node_descriptor(node_descriptor_key_for(name, it->second, node_templates));
+            (*inst->mutable_child_mappings())[name].set_host_id(*it->second.host_id);
+        } else {
+            auto it = graph.subgraphs.find(name);
+            if (it == graph.subgraphs.end()) {
+                continue;
+            }
+            std::vector<std::string> child_path = path;
+            child_path.push_back(name);
+            auto* sub_inst = (*inst->mutable_child_mappings())[name].mutable_sub_instance();
+            std::string sub_key = emit_graph_template_recursive(
+                *it->second, child_path, root_template_name, cluster_desc, sub_inst, node_templates);
+            child->mutable_graph_ref()->set_graph_template(sub_key);
+        }
+    }
+
+    // Emit this level's internal connections with paths relative to this graph.
+    for (const auto& [port_type, connections] : graph.internal_connections) {
+        std::string port_type_str;
+        switch (port_type) {
+            case PortType::QSFP_DD: port_type_str = "QSFP_DD"; break;
+            case PortType::WARP100: port_type_str = "WARP100"; break;
+            case PortType::WARP400: port_type_str = "WARP400"; break;
+            default: continue;
+        }
+
+        auto* port_conns = (*template_proto.mutable_internal_connections())[port_type_str].mutable_connections();
+        for (const auto& conn : connections) {
+            auto* conn_proto = port_conns->Add();
+
+            const auto& [host_a, tray_a, port_a_id] = conn.first;
+            auto* port_a = conn_proto->mutable_port_a();
+            std::vector<std::string> path_a;
+            relative_path_to_host(graph, host_a, path_a);
+            for (const auto& seg : path_a) {
+                port_a->add_path(seg);
+            }
+            port_a->set_tray_id(*tray_a);
+            port_a->set_port_id(*port_a_id);
+
+            const auto& [host_b, tray_b, port_b_id] = conn.second;
+            auto* port_b = conn_proto->mutable_port_b();
+            std::vector<std::string> path_b;
+            relative_path_to_host(graph, host_b, path_b);
+            for (const auto& seg : path_b) {
+                port_b->add_path(seg);
+            }
+            port_b->set_tray_id(*tray_b);
+            port_b->set_port_id(*port_b_id);
+        }
+    }
+
+    return template_key;
+}
+
 // Method to emit deployment descriptor (one host per node in host_id order)
 void CablingGenerator::emit_deployment_descriptor(const std::string& output_path) const {
     deployment::proto::DeploymentDescriptor deployment_desc;
@@ -1832,7 +2237,7 @@ void CablingGenerator::emit_deployment_descriptor(const std::string& output_path
 }
 
 // Method to emit merged cabling descriptor
-void CablingGenerator::emit_cabling_descriptor(const std::string& output_path) const {
+void CablingGenerator::emit_cabling_descriptor(const std::string& output_path, bool hierarchical) const {
     cabling_generator::proto::ClusterDescriptor cluster_desc;
 
     // Only emit node descriptors that were explicitly present in source files
@@ -1855,7 +2260,12 @@ void CablingGenerator::emit_cabling_descriptor(const std::string& output_path) c
     if (root_instance_) {
         auto* root_inst = cluster_desc.mutable_root_instance();
 
-        if (root_instance_->subgraphs.empty()) {
+        if (hierarchical) {
+            // Preserve the nested structure faithfully (one graph_template per graph instance).
+            // Single-level trees naturally produce the same output as the legacy path below.
+            emit_graph_template_recursive(
+                *root_instance_, {}, root_instance_->template_name, cluster_desc, root_inst, node_templates_);
+        } else if (root_instance_->subgraphs.empty()) {
             // Single-level topology: emit node instance names directly (unchanged legacy behavior).
             auto& template_proto = (*cluster_desc.mutable_graph_templates())[root_instance_->template_name];
             root_inst->set_template_name(root_instance_->template_name);

--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -1622,6 +1622,26 @@ tt::scaleout_tools::fsd::proto::FactorySystemDescriptor CablingGenerator::genera
         deployment_hosts_, host_id_to_node_, chip_connections_, host_id_to_instance_path);
 }
 
+// Resolve the node_descriptor key for a node: prefer the descriptor name the child was bound to in
+// its source file, then fall back to a shape-based lookup.
+static std::string node_descriptor_key_for(
+    const std::string& node_name, const Node& node, const std::unordered_map<std::string, Node>& node_templates) {
+    std::optional<std::string> template_key;
+    if (!node.node_descriptor_name.empty() && node_templates.contains(node.node_descriptor_name)) {
+        template_key = node.node_descriptor_name;
+    } else {
+        template_key = find_template_key_for_node(node, node_templates);
+    }
+    if (!template_key) {
+        throw std::runtime_error(fmt::format(
+            "Could not find node descriptor for node '{}' with motherboard '{}' and {} boards",
+            node_name,
+            node.motherboard,
+            node.boards.size()));
+    }
+    return *template_key;
+}
+
 // Helper to convert ResolvedGraphInstance back to GraphTemplate protobuf
 static void resolved_graph_to_protobuf(
     const ResolvedGraphInstance& resolved,
@@ -1639,23 +1659,7 @@ static void resolved_graph_to_protobuf(
         const auto& node = it->second;
         auto* child = template_proto->add_children();
         child->set_name(name);
-        auto* node_ref = child->mutable_node_ref();
-
-        // Prefer the descriptor name the child was bound to in its source file.
-        std::optional<std::string> template_key;
-        if (!node.node_descriptor_name.empty() && node_templates.contains(node.node_descriptor_name)) {
-            template_key = node.node_descriptor_name;
-        } else {
-            template_key = find_template_key_for_node(node, node_templates);
-        }
-        if (!template_key) {
-            throw std::runtime_error(fmt::format(
-                "Could not find node descriptor for node '{}' with motherboard '{}' and {} boards",
-                name,
-                node.motherboard,
-                node.boards.size()));
-        }
-        node_ref->set_node_descriptor(*template_key);
+        child->mutable_node_ref()->set_node_descriptor(node_descriptor_key_for(name, node, node_templates));
     }
 
     // Add internal_connections
@@ -1697,6 +1701,88 @@ static void resolved_graph_to_protobuf(
                 }
             }
             port_b->add_path(node_b_name);
+            port_b->set_tray_id(*tray_b);
+            port_b->set_port_id(*port_b_id);
+        }
+    }
+}
+
+// Flatten a nested ResolvedGraphInstance tree into a single-level GraphTemplate (the shape produced
+// by the CableGen web tool / "extracted_topology" descriptors): every leaf node becomes a direct
+// node_ref child named by its deployment hostname, and every graph-level connection from any depth is
+// rewritten with single-segment (hostname) paths. Connections at every level already reference global
+// HostIds (see reassign_host_ids_dfs), so flattening is a straight collect-and-rename. Children and
+// child_mappings are emitted in host_id order so the DFS host_id reassignment on reload is a no-op.
+static void flatten_resolved_graph_to_protobuf(
+    const ResolvedGraphInstance& root,
+    const std::vector<Host>& deployment_hosts,
+    const std::unordered_map<std::string, Node>& node_templates,
+    cabling_generator::proto::GraphTemplate* template_proto,
+    cabling_generator::proto::GraphInstance* root_inst) {
+    // Stable, unique, delimiter-safe flat name for a leaf: its deployment hostname (fallback host_<id>).
+    auto flat_name_for = [&](HostId hid) -> std::string {
+        if (*hid < deployment_hosts.size() && !deployment_hosts[*hid].hostname.empty()) {
+            return deployment_hosts[*hid].hostname;
+        }
+        return "host_" + std::to_string(*hid);
+    };
+
+    // Collect every leaf node across the whole tree, keyed (and thus ordered) by global host_id.
+    std::map<HostId, const Node*> leaves;
+    auto collect_leaves = [&](auto& self, const ResolvedGraphInstance& graph) -> void {
+        for (const auto& [name, node] : graph.nodes) {
+            leaves[node.host_id] = &node;
+        }
+        for (const auto& [name, subgraph] : graph.subgraphs) {
+            self(self, *subgraph);
+        }
+    };
+    collect_leaves(collect_leaves, root);
+
+    // Emit one node_ref child + one flat child_mapping per leaf, in host_id order.
+    for (const auto& [hid, node_ptr] : leaves) {
+        const std::string name = flat_name_for(hid);
+        auto* child = template_proto->add_children();
+        child->set_name(name);
+        child->mutable_node_ref()->set_node_descriptor(node_descriptor_key_for(name, *node_ptr, node_templates));
+        (*root_inst->mutable_child_mappings())[name].set_host_id(*hid);
+    }
+
+    // Collect internal (graph-level) connections from every level of the tree, grouped by port type.
+    std::map<PortType, std::vector<PortConnection>> all_connections;
+    auto gather_connections = [&](auto& self, const ResolvedGraphInstance& graph) -> void {
+        for (const auto& [port_type, connections] : graph.internal_connections) {
+            auto& dst = all_connections[port_type];
+            dst.insert(dst.end(), connections.begin(), connections.end());
+        }
+        for (const auto& [name, subgraph] : graph.subgraphs) {
+            self(self, *subgraph);
+        }
+    };
+    gather_connections(gather_connections, root);
+
+    for (const auto& [port_type, connections] : all_connections) {
+        std::string port_type_str;
+        switch (port_type) {
+            case PortType::QSFP_DD: port_type_str = "QSFP_DD"; break;
+            case PortType::WARP100: port_type_str = "WARP100"; break;
+            case PortType::WARP400: port_type_str = "WARP400"; break;
+            default: continue;
+        }
+
+        auto* port_conns = (*template_proto->mutable_internal_connections())[port_type_str].mutable_connections();
+        for (const auto& conn : connections) {
+            auto* conn_proto = port_conns->Add();
+
+            const auto& [host_a, tray_a, port_a_id] = conn.first;
+            auto* port_a = conn_proto->mutable_port_a();
+            port_a->add_path(flat_name_for(host_a));
+            port_a->set_tray_id(*tray_a);
+            port_a->set_port_id(*port_a_id);
+
+            const auto& [host_b, tray_b, port_b_id] = conn.second;
+            auto* port_b = conn_proto->mutable_port_b();
+            port_b->add_path(flat_name_for(host_b));
             port_b->set_tray_id(*tray_b);
             port_b->set_port_id(*port_b_id);
         }
@@ -1767,16 +1853,28 @@ void CablingGenerator::emit_cabling_descriptor(const std::string& output_path) c
 
     // Convert root_instance to graph template
     if (root_instance_) {
-        auto& template_proto = (*cluster_desc.mutable_graph_templates())[root_instance_->template_name];
-        resolved_graph_to_protobuf(*root_instance_, &template_proto, node_templates_);
-
-        // Add root_instance with child_mappings
         auto* root_inst = cluster_desc.mutable_root_instance();
-        root_inst->set_template_name(root_instance_->template_name);
 
-        // Add child_mappings for all nodes (map node name -> host_id)
-        for (const auto& [name, node] : root_instance_->nodes) {
-            (*root_inst->mutable_child_mappings())[name].set_host_id(*node.host_id);
+        if (root_instance_->subgraphs.empty()) {
+            // Single-level topology: emit node instance names directly (unchanged legacy behavior).
+            auto& template_proto = (*cluster_desc.mutable_graph_templates())[root_instance_->template_name];
+            root_inst->set_template_name(root_instance_->template_name);
+            resolved_graph_to_protobuf(*root_instance_, &template_proto, node_templates_);
+
+            // Add child_mappings for all nodes (map node name -> host_id)
+            for (const auto& [name, node] : root_instance_->nodes) {
+                (*root_inst->mutable_child_mappings())[name].set_host_id(*node.host_id);
+            }
+        } else {
+            // Nested topology: flatten the whole tree into a single-level, hostname-keyed descriptor.
+            // The legacy path above only serializes the root's direct leaf children, which for a deep
+            // hierarchy (e.g. a SuperPod template) yields an empty/invalid descriptor. Use the same
+            // "extracted_topology" template key that the CableGen web tool emits for flat descriptors.
+            static constexpr const char* kFlatTemplateName = "extracted_topology";
+            auto& template_proto = (*cluster_desc.mutable_graph_templates())[kFlatTemplateName];
+            root_inst->set_template_name(kFlatTemplateName);
+            flatten_resolved_graph_to_protobuf(
+                *root_instance_, deployment_hosts_, node_templates_, &template_proto, root_inst);
         }
     }
 

--- a/tools/scaleout/cabling_generator/cabling_generator.hpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -192,8 +193,39 @@ public:
     // Method to emit cabling guide CSV
     void emit_cabling_guide_csv(const std::string& output_path, bool loc_info = true) const;
 
-    // Method to emit merged cabling descriptor
-    void emit_cabling_descriptor(const std::string& output_path) const;
+    // Method to emit merged cabling descriptor.
+    // When hierarchical=false (default), a nested resolved tree is flattened into a single-level,
+    // hostname-keyed "extracted_topology" descriptor (CableGen shape). When hierarchical=true, the
+    // nested tree is serialized faithfully (one graph_template per graph instance), preserving the
+    // hierarchy so the derived FSD instance_path reflects the full structure.
+    void emit_cabling_descriptor(const std::string& output_path, bool hierarchical = false) const;
+
+    // A child to nest under a composite root. instance_name is the child's directory name (used to
+    // uniquify the child's top instance_path segment). deployment_path, when non-empty, is the child's
+    // own deployment (host_id-indexed); it lets hierarchical children (whose leaf nodes are named by
+    // instance, not hostname) load positionally instead of being sliced from the composite deployment
+    // by hostname. fsd_path, when non-empty, supplies the child's intra-cluster hierarchy.
+    struct AggregateChild {
+        std::string instance_name;
+        std::string cabling_path;
+        std::string fsd_path;         // may be empty
+        std::string deployment_path;  // may be empty
+    };
+
+    // Build a composite generator that nests each child under a root named composite_name, wiring
+    // glue descriptors (inter-child cabling, referencing hosts by hostname) at the composite level.
+    // When a child's fsd_path is non-empty, its intra-cluster hierarchy is taken from that FSD's
+    // per-host instance_path (e.g. sp4/sp2_0/...): each child host lands at
+    //   <composite_name>/<fsd_seg0>-<instance_name>/<fsd_seg1>/.../<fsd_leaf>
+    // so the aggregated FSD combines the directory forest with the descriptor's own hierarchy. When
+    // fsd_path is empty, the child's resolved tree is nested directly under instance_name instead.
+    // Used to aggregate a tree of cluster configs while keeping the hierarchy (see
+    // merge_cluster_configs.py).
+    static CablingGenerator build_nested_aggregate(
+        const std::string& composite_name,
+        const std::vector<AggregateChild>& children,
+        const std::vector<std::string>& glue_descriptor_paths,
+        const std::string& deployment_descriptor_path);
 
     // Method to emit deployment descriptor (one host per node in host_id order; use for merged output)
     void emit_deployment_descriptor(const std::string& output_path) const;

--- a/tools/scaleout/cabling_generator/merge_cluster_configs.py
+++ b/tools/scaleout/cabling_generator/merge_cluster_configs.py
@@ -218,24 +218,27 @@ def staging_dir(keep: bool, prefix: str) -> Iterator[Path]:
 def run_cabling_generator(
     cabling_gen: Path,
     repo_root: Path,
-    cabling_dir: Path,
+    cabling_args: List[str],
     deployment_path: Path,
     suffix: str,
     target_aggregated_dir: Path,
     verbose: bool,
 ) -> ClusterFiles:
-    """Invoke run_cabling_generator and copy its outputs into target_aggregated_dir."""
-    # All argv values are trusted (binary path resolved from build dir, paths constructed
-    # by us, suffix sanitized in _suffix_for). subprocess.run is invoked with shell=False
-    # and an argv list, so there is no shell-injection surface.
+    """Invoke run_cabling_generator and copy its outputs into target_aggregated_dir.
+
+    cabling_args are the mode-specific arguments describing the topology inputs, e.g.
+    ["--cabling", <dir>] for a flat merge or ["--aggregate", "--name", <name>, "--child", ...]
+    for a nested aggregation. All values are constructed by us (directory names / file paths
+    discovered on disk), and subprocess.run is invoked with shell=False, so there is no
+    shell-injection surface.
+    """
     if not cabling_gen.is_file() or cabling_gen.is_symlink():
         raise CablingGeneratorError(f"run_cabling_generator binary missing or symlinked: {cabling_gen}")
     if not re.fullmatch(r"[A-Za-z0-9_.-]+", suffix):
         raise CablingGeneratorError(f"refusing unsafe suffix: {suffix!r}")
     cmd = [
         str(cabling_gen),
-        "--cabling",
-        str(cabling_dir),
+        *cabling_args,
         "--deployment",
         str(deployment_path),
         "--output",
@@ -382,37 +385,36 @@ def aggregate_tree(
 
     try:
         with staging_dir(keep=args.keep_temp, prefix=f"merge_{source_dir.name}_") as staging:
-            staging_cabling = staging / "cabling"
-            staging_cabling.mkdir(parents=True, exist_ok=True)
-
+            # Nest each child under a composite root. The child's directory name uniquifies the top
+            # segment of the child's own intra-cluster hierarchy (taken from its FSD), so the
+            # aggregated FSD combines the directory forest (e.g. "out") with the descriptor's own
+            # hierarchy (e.g. "sp4-120-a29/sp2_0/..."). Glue files wire children together at this
+            # composite's level.
+            cabling_args: List[str] = ["--aggregate", "--name", source_dir.name]
             used_names: set = set()
             for name, cf in children:
-                # Disambiguate by child directory name to keep merged cabling filenames unique.
-                base = re.sub(r"[^A-Za-z0-9_.-]", "_", name)
-                dest_name = f"{base}__cabling.textproto"
+                # Child directory names are unique within a composite; sanitize defensively and
+                # disambiguate in the unlikely event two sanitize to the same instance name.
+                inst = re.sub(r"[^A-Za-z0-9_.-]", "_", name)
+                candidate = inst
                 n = 1
-                while dest_name in used_names:
-                    dest_name = f"{base}__cabling_{n}.textproto"
+                while candidate in used_names:
+                    candidate = f"{inst}_{n}"
                     n += 1
-                used_names.add(dest_name)
-                _safe_copy(cf.cabling, staging_cabling / dest_name, staging_cabling)
+                used_names.add(candidate)
+                cabling_args += ["--child", f"{candidate}={cf.cabling}"]
+                # Supply the child's FSD (when present) so the generator can recover the child's
+                # intra-cluster hierarchy, which a flattened cabling descriptor no longer carries.
+                if cf.fsd is not None:
+                    cabling_args += ["--child-fsd", f"{candidate}={cf.fsd}"]
+                # Supply the child's own deployment so it loads against its host_id-indexed hosts. This
+                # is required for hierarchical (instance-named) children produced by nested composites,
+                # whose leaf nodes are not named by hostname and so cannot be sliced from the composite
+                # deployment.
+                cabling_args += ["--child-deployment", f"{candidate}={cf.deployment}"]
 
             for g in glue:
-                # g.name is the basename (Path.name strips any directory component).
-                # Re-sanitize for defense in depth and to satisfy SAST.
-                base = re.sub(r"[^A-Za-z0-9_.-]", "_", g.name)
-                # Force glue files to sort lexicographically AFTER all child cabling
-                # descriptors. run_cabling_generator constructs the base topology from
-                # the first .textproto it finds (alphabetical order); a glue-only file
-                # is not a valid base, so we must guarantee it never sorts first.
-                stem, ext = Path(base).stem, Path(base).suffix
-                dest_name = f"zz_glue__{stem}{ext}"
-                n = 1
-                while dest_name in used_names:
-                    dest_name = f"zz_glue__{stem}_{n}{ext}"
-                    n += 1
-                used_names.add(dest_name)
-                _safe_copy(g, staging_cabling / dest_name, staging_cabling)
+                cabling_args += ["--glue", str(g)]
 
             staged_deployment = staging / "deployment.textproto"
             concat_deployments([cf.deployment for _, cf in children], staged_deployment, staging)
@@ -420,7 +422,7 @@ def aggregate_tree(
             return run_cabling_generator(
                 cabling_gen=cabling_gen,
                 repo_root=repo_root,
-                cabling_dir=staging_cabling,
+                cabling_args=cabling_args,
                 deployment_path=staged_deployment,
                 suffix=_suffix_for(rel, source_dir.name),
                 target_aggregated_dir=target_aggregated_dir,

--- a/tools/scaleout/src/run_cabling_generator.cpp
+++ b/tools/scaleout/src/run_cabling_generator.cpp
@@ -8,6 +8,8 @@
 #include <string>
 #include <stdexcept>
 #include <iostream>
+#include <map>
+#include <tuple>
 #include <vector>
 #include <google/protobuf/text_format.h>
 #include <cxxopts.hpp>
@@ -27,6 +29,13 @@ struct InputConfig {
     // Opt-in sub-cluster filter: each entry is a path of instance keys (e.g. {"bh_galaxy_sp_0"}).
     std::vector<std::vector<std::string>> include_paths;
     std::vector<std::vector<std::string>> exclude_paths;
+
+    // Nested-aggregation mode: nest each child descriptor as a subgraph under a composite root,
+    // preserving hierarchy in the emitted FSD/cabling descriptor (see merge_cluster_configs.py).
+    bool aggregate = false;
+    std::string composite_name;
+    std::vector<CablingGenerator::AggregateChild> children;
+    std::vector<std::string> glue_paths;
 };
 
 // Split a slash-delimited instance path (e.g. "bh_galaxy_sp_0/bh_galaxy_node_2") into its keys.
@@ -86,6 +95,31 @@ InputConfig parse_arguments(int argc, char** argv) {
         "Opt-in sub-cluster filter: slash-delimited instance path to drop (e.g. --exclude bh_galaxy_node_0). "
         "Repeatable. Applied after --include (removes from the kept set; if no --include is given, keeps "
         "everything except the excluded paths).",
+        cxxopts::value<std::vector<std::string>>())(
+        "aggregate",
+        "Nested aggregation mode: nest each --child descriptor as a subgraph under a composite root "
+        "(named by --name), wiring --glue inter-child cabling at the composite level. Preserves hierarchy "
+        "in the emitted FSD instance_path and cabling descriptor. Requires --name, --deployment, and one or "
+        "more --child; --cabling is ignored.",
+        cxxopts::value<bool>()->default_value("false")->implicit_value("true"))(
+        "name",
+        "Composite root name for --aggregate mode (becomes the first FSD instance_path segment).",
+        cxxopts::value<std::string>())(
+        "child",
+        "Aggregation child as <instance_name>=<cabling_descriptor.textproto>. Repeatable.",
+        cxxopts::value<std::vector<std::string>>())(
+        "child-fsd",
+        "Aggregation child FSD as <instance_name>=<factory_system_descriptor.textproto>, supplying the "
+        "child's intra-cluster hierarchy (per-host instance_path). Repeatable; matched to --child by "
+        "instance_name.",
+        cxxopts::value<std::vector<std::string>>())(
+        "child-deployment",
+        "Aggregation child deployment as <instance_name>=<deployment_descriptor.textproto>, letting the "
+        "child load against its own host_id-indexed deployment (required for hierarchical, "
+        "instance-named children). Repeatable; matched to --child by instance_name.",
+        cxxopts::value<std::vector<std::string>>())(
+        "glue",
+        "Aggregation glue (inter-child) cabling descriptor file. Repeatable.",
         cxxopts::value<std::vector<std::string>>())("h,help", "Print usage information");
 
     try {
@@ -113,19 +147,108 @@ InputConfig parse_arguments(int argc, char** argv) {
             exit(0);
         }
 
-        if (!result.contains("cabling")) {
-            throw std::invalid_argument("Cabling descriptor path is required");
-        }
+        InputConfig config;
+        config.aggregate = result["aggregate"].as<bool>();
 
         if (!result.contains("deployment")) {
             throw std::invalid_argument("Deployment descriptor path is required");
         }
-
-        InputConfig config;
-        config.cabling_descriptor_path = result["cabling"].as<std::string>();
         config.deployment_descriptor_path = result["deployment"].as<std::string>();
         config.output_name = result["output"].as<std::string>();
         config.loc_info = !result["simple"].as<bool>();
+
+        if (config.aggregate) {
+            if (!result.contains("name")) {
+                throw std::invalid_argument("--aggregate requires --name");
+            }
+            if (!result.contains("child")) {
+                throw std::invalid_argument("--aggregate requires at least one --child");
+            }
+            config.composite_name = result["name"].as<std::string>();
+            // Parse repeatable <instance_name>=<path> options into a name->path map with validation.
+            auto parse_name_path_map = [&](const char* opt) -> std::map<std::string, std::string> {
+                std::map<std::string, std::string> out;
+                if (!result.contains(opt)) {
+                    return out;
+                }
+                for (const auto& raw : result[opt].as<std::vector<std::string>>()) {
+                    auto eq = raw.find('=');
+                    if (eq == std::string::npos || eq == 0 || eq + 1 >= raw.size()) {
+                        throw std::invalid_argument(
+                            std::string("--") + opt + " must be <instance_name>=<path>: '" + raw + "'");
+                    }
+                    std::string name = raw.substr(0, eq);
+                    std::string path = raw.substr(eq + 1);
+                    if (!file_exists(path) || !path.ends_with(".textproto")) {
+                        throw std::invalid_argument(
+                            std::string("--") + opt + " descriptor not found or not .textproto: '" + path + "'");
+                    }
+                    out[std::move(name)] = std::move(path);
+                }
+                return out;
+            };
+            // Parse --child-fsd / --child-deployment first so each child can be paired by instance_name.
+            std::map<std::string, std::string> child_fsd_by_name = parse_name_path_map("child-fsd");
+            std::map<std::string, std::string> child_deployment_by_name = parse_name_path_map("child-deployment");
+            for (const auto& raw : result["child"].as<std::vector<std::string>>()) {
+                auto eq = raw.find('=');
+                if (eq == std::string::npos || eq == 0 || eq + 1 >= raw.size()) {
+                    throw std::invalid_argument("--child must be <instance_name>=<path>: '" + raw + "'");
+                }
+                std::string name = raw.substr(0, eq);
+                std::string path = raw.substr(eq + 1);
+                if (!file_exists(path) || !path.ends_with(".textproto")) {
+                    throw std::invalid_argument(
+                        "--child cabling descriptor not found or not .textproto: '" + path + "'");
+                }
+                CablingGenerator::AggregateChild ac;
+                ac.cabling_path = std::move(path);
+                if (auto it = child_fsd_by_name.find(name); it != child_fsd_by_name.end()) {
+                    ac.fsd_path = it->second;
+                }
+                if (auto it = child_deployment_by_name.find(name); it != child_deployment_by_name.end()) {
+                    ac.deployment_path = it->second;
+                }
+                ac.instance_name = std::move(name);
+                config.children.push_back(std::move(ac));
+            }
+            if (result.contains("glue")) {
+                for (const auto& path : result["glue"].as<std::vector<std::string>>()) {
+                    if (!file_exists(path) || !path.ends_with(".textproto")) {
+                        throw std::invalid_argument("--glue descriptor not found or not .textproto: '" + path + "'");
+                    }
+                    config.glue_paths.push_back(path);
+                }
+            }
+            // Validate deployment file (shared with non-aggregate path below).
+            if (!file_exists(config.deployment_descriptor_path)) {
+                throw std::invalid_argument(
+                    "Deployment descriptor file not found: '" + config.deployment_descriptor_path + "'");
+            }
+            if (!config.deployment_descriptor_path.ends_with(".textproto")) {
+                throw std::invalid_argument(
+                    "Deployment descriptor file should have .textproto extension: '" +
+                    config.deployment_descriptor_path + "'");
+            }
+            if (!config.output_name.empty()) {
+                const std::string invalid_chars = "<>:\"/|?*";
+                for (char c : config.output_name) {
+                    if (invalid_chars.find(c) != std::string::npos) {
+                        throw std::invalid_argument(
+                            "Output name contains invalid character '" + std::string(1, c) +
+                            "'. Avoid: " + invalid_chars);
+                    }
+                }
+                config.output_name = "_" + config.output_name;
+            }
+            return config;
+        }
+
+        if (!result.contains("cabling")) {
+            throw std::invalid_argument("Cabling descriptor path is required");
+        }
+
+        config.cabling_descriptor_path = result["cabling"].as<std::string>();
         if (result.contains("include")) {
             for (const auto& raw_path : result["include"].as<std::vector<std::string>>()) {
                 config.include_paths.push_back(split_instance_path("include", raw_path));
@@ -190,6 +313,50 @@ InputConfig parse_arguments(int argc, char** argv) {
 int main(int argc, char** argv) {
     try {
         InputConfig config = parse_arguments(argc, argv);
+
+        if (config.aggregate) {
+            std::cout << "Aggregating cluster configuration (nested)..." << std::endl;
+            std::cout << "  Composite name: " << config.composite_name << std::endl;
+            std::cout << "  Deployment descriptor: " << config.deployment_descriptor_path << std::endl;
+            for (const auto& child : config.children) {
+                std::cout << "  + child: " << child.instance_name << " -> " << child.cabling_path;
+                if (!child.fsd_path.empty()) {
+                    std::cout << " (fsd: " << child.fsd_path << ")";
+                }
+                if (!child.deployment_path.empty()) {
+                    std::cout << " (deployment: " << child.deployment_path << ")";
+                }
+                std::cout << std::endl;
+            }
+            for (const auto& g : config.glue_paths) {
+                std::cout << "  + glue:  " << g << std::endl;
+            }
+
+            CablingGenerator cabling_generator = CablingGenerator::build_nested_aggregate(
+                config.composite_name, config.children, config.glue_paths, config.deployment_descriptor_path);
+
+            std::string factory_output = "out/scaleout/factory_system_descriptor" + config.output_name + ".textproto";
+            std::string cabling_output = "out/scaleout/cabling_guide" + config.output_name + ".csv";
+            std::string cabling_desc_output = "out/scaleout/cabling_descriptor" + config.output_name + ".textproto";
+            std::string deployment_output = "out/scaleout/deployment_descriptor" + config.output_name + ".textproto";
+            std::filesystem::create_directories("out/scaleout");
+
+            std::cout << "Generating factory system descriptor..." << std::endl;
+            cabling_generator.emit_factory_system_descriptor(factory_output);
+            std::cout << "Generating cabling guide CSV..." << std::endl;
+            cabling_generator.emit_cabling_guide_csv(cabling_output, config.loc_info);
+            std::cout << "Generating hierarchical cabling descriptor..." << std::endl;
+            cabling_generator.emit_cabling_descriptor(cabling_desc_output, /*hierarchical=*/true);
+            std::cout << "Generating deployment descriptor..." << std::endl;
+            cabling_generator.emit_deployment_descriptor(deployment_output);
+
+            std::cout << "Successfully generated:" << std::endl;
+            std::cout << "  - " << factory_output << std::endl;
+            std::cout << "  - " << cabling_output << std::endl;
+            std::cout << "  - " << cabling_desc_output << std::endl;
+            std::cout << "  - " << deployment_output << std::endl;
+            return 0;
+        }
 
         std::cout << "Generating cabling configuration..." << std::endl;
         if (config.is_cabling_directory) {


### PR DESCRIPTION
### PR Category
Feature

### Summary
Improve the way that cluster config tooling deals with hierarchical cabling descriptors. This is needed to allow us to use the canonical cabling descriptors, and preserve cabling hierarchy information when generating FSDs.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=p1-0tr/cabling-hierarchy-in-aggregated)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:p1-0tr/cabling-hierarchy-in-aggregated)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=p1-0tr/cabling-hierarchy-in-aggregated)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:p1-0tr/cabling-hierarchy-in-aggregated)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=p1-0tr/cabling-hierarchy-in-aggregated)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:p1-0tr/cabling-hierarchy-in-aggregated)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=p1-0tr/cabling-hierarchy-in-aggregated)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:p1-0tr/cabling-hierarchy-in-aggregated)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=p1-0tr/cabling-hierarchy-in-aggregated)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:p1-0tr/cabling-hierarchy-in-aggregated)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=p1-0tr/cabling-hierarchy-in-aggregated)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:p1-0tr/cabling-hierarchy-in-aggregated)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=p1-0tr/cabling-hierarchy-in-aggregated)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:p1-0tr/cabling-hierarchy-in-aggregated)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=p1-0tr/cabling-hierarchy-in-aggregated)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:p1-0tr/cabling-hierarchy-in-aggregated)