### PR TITLE
Feature: Support bank-striped Tensor prefetcher mcast_in1

### DIFF
--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_tensor_large.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_tensor_large.py
@@ -1068,3 +1068,219 @@ def test_tensor_prefetcher_streaming_mcast_in0(device, distribution_strategy):
     passing, output_str = comp_pcc(expected, out_torch, 0.999)
     logger.info(f"[streaming_mcast_in0 {distribution_strategy}] {output_str}")
     assert passing, f"streaming_mcast_in0 PCC failed: {output_str}"
+
+
+@pytest.mark.parametrize("use_bias", [False, True], ids=["no_bias", "bias"])
+def test_tensor_prefetcher_bank_striped_mcast_in1(device, use_bias):
+    """One worker per DRAM bank relays its N stripe; all workers assemble the full in1 block."""
+    num_dram_banks = device.dram_grid_size().x
+    ring_cols = num_dram_banks
+    ring_rows = 2
+    num_workers = ring_cols * ring_rows
+    worker_cores = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(ring_cols - 1, ring_rows - 1))}
+    )
+
+    dtype = ttnn.bfloat16
+    M = num_workers * ttnn.TILE_SIZE
+    k_tiles = 2 * num_dram_banks
+    K = k_tiles * ttnn.TILE_SIZE
+    N = num_dram_banks * ttnn.TILE_SIZE
+    in0_block_w = 1
+    assert k_tiles != num_dram_banks  # Proves the paired helper cannot use GCB receiver_count as block_count.
+
+    torch.manual_seed(zlib.crc32(f"bank_striped_mcast_in1_bias={use_bias}".encode()))
+    pt_weight = torch.randn(1, 1, K, N)
+    dram_core_range_set = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_dram_banks - 1, 0))}
+    )
+    weight_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.DRAM,
+        ttnn.ShardSpec(
+            dram_core_range_set,
+            [K, N // num_dram_banks],
+            ttnn.ShardOrientation.ROW_MAJOR,
+        ),
+    )
+    tt_weight = ttnn.as_tensor(
+        pt_weight,
+        device=device,
+        dtype=dtype,
+        memory_config=weight_mem_config,
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+    pt_act = torch.randn(1, 1, M, K)
+    act_mem_config = ttnn.create_sharded_memory_config(
+        shape=(ttnn.TILE_SIZE, K),
+        core_grid=worker_cores,
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+    tt_act = ttnn.from_torch(
+        pt_act,
+        device=device,
+        dtype=dtype,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=act_mem_config,
+    )
+
+    pt_bias = torch.randn(N) if use_bias else None
+    tt_bias = (
+        ttnn.from_torch(
+            pt_bias.reshape(1, N),
+            device=device,
+            dtype=dtype,
+            layout=ttnn.TILE_LAYOUT,
+        )
+        if use_bias
+        else None
+    )
+
+    n_tiles = N // ttnn.TILE_SIZE
+    out_subblock_w = min(n_tiles, 4)
+    while n_tiles % out_subblock_w != 0:
+        out_subblock_w -= 1
+    program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=(ring_cols, ring_rows),
+        in0_block_w=in0_block_w,
+        out_subblock_h=1,
+        out_subblock_w=out_subblock_w,
+        out_block_h=1,
+        out_block_w=n_tiles,
+        per_core_M=1,
+        per_core_N=n_tiles,
+        fuse_batch=True,
+        fused_activation=None,
+        mcast_in0=False,
+        gather_in0=False,
+        hop_cores=ttnn.CoreRangeSet([]),
+        num_global_cb_receivers=1,
+        untilize_out=False,
+        stream_in1=False,
+    )
+
+    # Bank b unicasts only to relay (b, 0). Row 1 contains ordinary matmul workers, so the
+    # test exercises both the relay-sender and receiver kernels.
+    bank_to_receivers = [
+        (
+            bank,
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(bank, 0), ttnn.CoreCoord(bank, 0))}),
+        )
+        for bank in range(num_dram_banks)
+    ]
+    stripe_page_bytes = in0_block_w * _bytes_per_tile(dtype)
+    gcb = ttnn.experimental.create_global_circular_buffer_for_matmul_1d(
+        device,
+        [program_config],
+        [tt_weight],
+        bank_to_receivers=bank_to_receivers,
+        size=2 * stripe_page_bytes,
+    )
+
+    output_mem_config = ttnn.create_sharded_memory_config(
+        shape=(ttnn.TILE_SIZE, N),
+        core_grid=worker_cores,
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+        dst_full_sync_en=True,
+    )
+
+    with tensor_prefetcher_session(device):
+        tt_out = ttnn.experimental.tensor_prefetcher_matmul.prefetch_and_linear(
+            tt_act,
+            tt_weight,
+            global_cb=gcb,
+            program_config=program_config,
+            memory_config=output_mem_config,
+            compute_kernel_config=compute_kernel_config,
+            dtype=dtype,
+            bias=tt_bias,
+        )
+
+    expected = pt_act.float() @ pt_weight.float()
+    if pt_bias is not None:
+        expected += pt_bias.float()
+    out_torch = ttnn.to_torch(tt_out)
+    passing, output_str = comp_pcc(expected, out_torch, 0.999)
+    logger.info(f"[bank_striped_mcast_in1 bias={use_bias}] {output_str}")
+    assert passing, f"bank_striped_mcast_in1 PCC failed: {output_str}"
+
+
+@pytest.mark.parametrize("invalid_case", ["two_relays_per_bank", "one_page_window"])
+def test_tensor_prefetcher_bank_striped_mcast_in1_rejects_invalid_gcb(device, expect_error, invalid_case):
+    num_dram_banks = device.dram_grid_size().x
+    K = 2 * num_dram_banks * ttnn.TILE_SIZE
+    N = num_dram_banks * ttnn.TILE_SIZE
+    pt_weight = torch.zeros(1, 1, K, N)
+    dram_cores = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_dram_banks - 1, 0))})
+    weight_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.DRAM,
+        ttnn.ShardSpec(
+            dram_cores,
+            [K, N // num_dram_banks],
+            ttnn.ShardOrientation.ROW_MAJOR,
+        ),
+    )
+    tt_weight = ttnn.as_tensor(
+        pt_weight,
+        device=device,
+        dtype=ttnn.bfloat16,
+        memory_config=weight_mem_config,
+        layout=ttnn.TILE_LAYOUT,
+    )
+    program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=(num_dram_banks, 2),
+        in0_block_w=1,
+        out_subblock_h=1,
+        out_subblock_w=1,
+        out_block_h=1,
+        out_block_w=num_dram_banks,
+        per_core_M=1,
+        per_core_N=num_dram_banks,
+        fuse_batch=True,
+        fused_activation=None,
+        mcast_in0=False,
+        gather_in0=False,
+        hop_cores=ttnn.CoreRangeSet([]),
+        num_global_cb_receivers=1,
+        untilize_out=False,
+        stream_in1=False,
+    )
+
+    receivers_per_bank = 2 if invalid_case == "two_relays_per_bank" else 1
+    bank_to_receivers = [
+        (
+            bank,
+            ttnn.CoreRangeSet(
+                {
+                    ttnn.CoreRange(
+                        ttnn.CoreCoord(bank, 0),
+                        ttnn.CoreCoord(bank, receivers_per_bank - 1),
+                    )
+                }
+            ),
+        )
+        for bank in range(num_dram_banks)
+    ]
+    page_bytes = _bytes_per_tile(ttnn.bfloat16)
+    expected_error = "exactly one relay worker" if receivers_per_bank == 2 else "at least two largest stripe pages"
+    with expect_error(RuntimeError, expected_error):
+        ttnn.experimental.create_global_circular_buffer_for_matmul_1d(
+            device,
+            [program_config],
+            [tt_weight],
+            bank_to_receivers=bank_to_receivers,
+            size=2 * page_bytes if receivers_per_bank == 2 else page_bytes,
+        )

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_tensor_large.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_tensor_large.py
@@ -951,3 +951,120 @@ def test_tensor_prefetcher_streaming_matmul(
     passing, output_str = comp_pcc(expected, out_torch, pcc_threshold)
     logger.info(f"[{name} win={window_blocks} {distribution_strategy}] {output_str}")
     assert passing, f"[{name} win={window_blocks} {distribution_strategy}] PCC check failed: {output_str}"
+
+
+@pytest.mark.parametrize(
+    "distribution_strategy",
+    [ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D, ttnn.ShardDistributionStrategy.CONTIGUOUS_1D],
+    ids=["strided", "contiguous"],
+)
+def test_tensor_prefetcher_streaming_mcast_in0(device, distribution_strategy):
+    """Mcast-in0 consumes receiver-contiguous in1 K-blocks in natural FIFO order."""
+    num_dram_banks = device.dram_grid_size().x
+    recv_per_bank = 2
+    receiver_count = num_dram_banks * recv_per_bank
+    ring_cols = num_dram_banks
+    ring_rows = recv_per_bank
+    receiver_cores = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(ring_cols - 1, ring_rows - 1))}
+    )
+
+    dtype = ttnn.bfloat16
+    M = ttnn.TILE_SIZE
+    k_tiles = 2 * receiver_count
+    K = k_tiles * ttnn.TILE_SIZE
+    N = receiver_count * ttnn.TILE_SIZE
+    in0_block_w = 1
+    block_count = k_tiles // in0_block_w
+    assert block_count != receiver_count
+
+    torch.manual_seed(zlib.crc32(f"streaming_mcast_in0_{distribution_strategy}".encode()))
+    pt_weight = torch.randn(1, 1, K, N)
+    tt_weight = _make_recv_contig_weight(
+        device,
+        pt_weight,
+        num_dram_banks=num_dram_banks,
+        ring_size=receiver_count,
+        dtype=dtype,
+        distribution_strategy=distribution_strategy,
+    )
+
+    pt_act = torch.randn(1, 1, M, K)
+    act_mem_config = ttnn.create_sharded_memory_config(
+        shape=(M, K // receiver_count),
+        core_grid=receiver_cores,
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+    tt_act = ttnn.from_torch(pt_act, device=device, dtype=dtype, layout=ttnn.TILE_LAYOUT, memory_config=act_mem_config)
+
+    program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=(ring_cols, ring_rows),
+        in0_block_w=in0_block_w,
+        out_subblock_h=1,
+        out_subblock_w=1,
+        out_block_h=1,
+        out_block_w=1,
+        per_core_M=1,
+        per_core_N=1,
+        fuse_batch=True,
+        fused_activation=None,
+        mcast_in0=True,
+        gather_in0=False,
+        hop_cores=ttnn.CoreRangeSet([]),
+        num_global_cb_receivers=recv_per_bank,
+        untilize_out=False,
+        stream_in1=False,
+    )
+
+    if distribution_strategy == ttnn.ShardDistributionStrategy.CONTIGUOUS_1D:
+        bank_to_receivers = [
+            (b, _bank_receivers_contiguous(b, recv_per_bank, ring_cols=ring_cols)) for b in range(num_dram_banks)
+        ]
+    else:
+        bank_to_receivers = [
+            (b, _bank_receivers_strided(b, recv_per_bank, num_dram_banks, ring_cols=ring_cols))
+            for b in range(num_dram_banks)
+        ]
+
+    page_size_bytes = in0_block_w * program_config.per_core_N * _bytes_per_tile(dtype)
+    gcb = ttnn.experimental.create_global_circular_buffer_for_matmul_1d(
+        device,
+        [program_config],
+        [tt_weight],
+        bank_to_receivers=bank_to_receivers,
+        size=2 * page_size_bytes,
+    )
+    output_mem_config = ttnn.create_sharded_memory_config(
+        shape=(M, N // receiver_count),
+        core_grid=receiver_cores,
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+        dst_full_sync_en=True,
+    )
+
+    with tensor_prefetcher_session(device):
+        tt_out = ttnn.experimental.tensor_prefetcher_matmul.prefetch_and_linear(
+            tt_act,
+            tt_weight,
+            global_cb=gcb,
+            program_config=program_config,
+            memory_config=output_mem_config,
+            compute_kernel_config=compute_kernel_config,
+            dtype=dtype,
+        )
+
+    expected = pt_act.float() @ pt_weight.float()
+    out_torch = ttnn.to_torch(tt_out)
+    passing, output_str = comp_pcc(expected, out_torch, 0.999)
+    logger.info(f"[streaming_mcast_in0 {distribution_strategy}] {output_str}")
+    assert passing, f"streaming_mcast_in0 PCC failed: {output_str}"

--- a/tt_metal/impl/buffers/prefetcher_matmul_design.md
+++ b/tt_metal/impl/buffers/prefetcher_matmul_design.md
@@ -392,6 +392,24 @@ src = bank_local_base[t]
     + sb  * sub_stride_bytes         // sub_stride_bytes = rows_per_sub * n_per_recv * tile_bytes
 ```
 
+#### Matmul consumer contracts
+
+Receiver-contiguous weights support two 1D matmul consumers:
+
+- **Ring gather-in0:** `block_count = receiver_count`. Batched mode uses no rotation and waits for
+  all blocks. `stream_in1=true` uses an identity rotation request so each receiver sees its
+  ring-rotated K-block sequence and can consume from a two-page GCB window.
+- **Mcast-in0:** `block_count = K_tiles / in0_block_w`. Every receiver sees K-blocks
+  `0..block_count-1` in natural FIFO order, so the request has an empty rotation and
+  `stream_in1=false`. The reader still consumes each page as it arrives, allowing the same
+  two-page GCB window. Initially this mode requires one output block per receiver and one effective
+  activation batch, so each prefetched stream is consumed exactly once.
+
+For both contracts one page contains
+`(K_tiles / block_count) * per_core_N` weight tiles for one receiver. The GCB receiver set must
+exactly match the matmul output workers, and the receiver-contiguous NdShardSpec must provide one
+full-K, `per_core_N`-wide shard per receiver.
+
 #### Fit ladder (receiver-contiguous)
 
 The receiver-contiguous path rotates through three stage slots

--- a/tt_metal/impl/buffers/prefetcher_matmul_design.md
+++ b/tt_metal/impl/buffers/prefetcher_matmul_design.md
@@ -1,8 +1,8 @@
 # Matmul + DRAM Prefetcher Design
 
-This document describes the contract between the gather-in0 matmul receiver
-and the two DRAM prefetcher implementations that feed it: the worker-core
-prefetcher (`ttnn.dram_prefetcher`) and the Tensor prefetcher
+This document describes the contract between 1D matmul consumers and the two
+DRAM prefetcher implementations that feed them: the worker-core prefetcher
+(`ttnn.dram_prefetcher`) and the Tensor prefetcher
 (`ttnn.experimental.start_tensor_prefetcher`). It exists so that a future maintainer
 touching either side can read one file and learn what is invariant across the
 two paths, without having to reverse-engineer the kernels.
@@ -409,6 +409,30 @@ For both contracts one page contains
 `(K_tiles / block_count) * per_core_N` weight tiles for one receiver. The GCB receiver set must
 exactly match the matmul output workers, and the receiver-contiguous NdShardSpec must provide one
 full-K, `per_core_N`-wide shard per receiver.
+
+#### Bank-striped worker relay for mcast-in1
+
+The `mcast_in0=false, gather_in0=false` consumer uses the legacy K-row-major WIDTH_SHARDED
+weight layout differently. Each DRAM bank owns a full-K, `N/num_banks` stripe and the GCB maps
+that bank to exactly one relay worker. The Tensor prefetcher still performs its normal unicast:
+
+```
+DRAM bank b -> relay worker b: in0_block_w x (N/num_banks) tiles
+relay workers -> every matmul worker: parallel multicast into disjoint N offsets
+```
+
+All matmul workers first reserve the same full-width local in1 CB block and announce readiness to
+the bank-0 relay. The coordinator releases all relays together. Relay `b` then multicasts each
+K row into column offset `b * (N/num_banks)` on every worker, including itself. A relay executes
+`noc.async_write_barrier()` before returning the source page's remote-CB credit or publishing its
+completion increment. Workers push the local in1 block to compute only after all bank completions
+arrive, so compute never observes a partially assembled weight block.
+
+This mode uses `block_count = K_tiles / in0_block_w`, natural FIFO order, and a two-page GCB
+window per relay. It initially requires one relay per dense DRAM bank, one full output block per
+worker, `per_core_N == N_tiles`, one effective activation batch, and a full rectangular active
+worker set. Bias remains a full-width multicast from the bank-0 relay after the striped weight
+blocks. No DRISC multicast support is added.
 
 #### Fit ladder (receiver-contiguous)
 

--- a/ttnn/api/ttnn/global_circular_buffer.hpp
+++ b/ttnn/api/ttnn/global_circular_buffer.hpp
@@ -37,21 +37,20 @@ GlobalCircularBuffer create_global_circular_buffer_for_tensor_prefetcher(
     BufferType buffer_type = BufferType::L1,
     bool support_multi_receiver_shards = true);
 
-// Build a DRAM-sender GCB shaped to feed one or more gather-in0 or mcast-in0 1D matmuls from the
-// given weight tensors. The caller supplies `bank_to_receivers` (the same layout the low-level
-// `create_global_circular_buffer_for_tensor_prefetcher` takes); this factory validates it against
-// the matmul program configs and weight shapes and sizes the GCB accordingly.
+// Build a DRAM-sender GCB shaped to feed one or more gather-in0, mcast-in0, or bank-striped
+// mcast-in1 1D matmuls from the given weight tensors. The caller supplies `bank_to_receivers`
+// (the same layout the low-level `create_global_circular_buffer_for_tensor_prefetcher` takes);
+// this factory validates it against the matmul program configs and weight shapes and sizes the
+// GCB accordingly.
 //
 // The DRAM layout is detected from the weight allocation, NOT chosen by the caller — the tensor's
 // layout determines what the prefetcher does (mirrors tt_metal detect_layout_mode). All weights
 // sharing one GCB must use the same layout:
-//   * Legacy K-row-major (WIDTH_SHARDED): one shard per bank, K-row-major within the bank, so one
-//     read serves all of a bank's receivers. Always single-sender per bank. Validated: weight K
-//     tile-aligned AND divisible by ring_size (the silent-hang case where the matmul pads K beyond
-//     what the prefetcher pushes); weight N shards evenly across senders and per-bank N splits
-//     evenly across receivers; matmul per_core_N == weight per-receiver N. `bank_to_receivers`
-//     shape is checked: num_senders * num_global_cb_receivers == ring_size, every bank owns exactly
-//     num_global_cb_receivers cores. `size` floor is one full layer (ring_size * largest in1 block).
+//   * Legacy K-row-major (WIDTH_SHARDED): one shard per bank, K-row-major within the bank. Gather-in0
+//     fans each bank out to num_global_cb_receivers ring workers and requires a full-layer GCB.
+//     Bank-striped mcast-in1 instead maps each bank to exactly one relay worker; each relay receives
+//     an in0_block_w x (N/num_banks) stripe and worker-side multicast assembles the full in1 block on
+//     every matmul worker. Its GCB may be a two-page FIFO window. Both are always single-sender per bank.
 //   * Receiver-contiguous (NdShardSpec): num_shards == receiver_count, each shard
 //     (full K, N/receiver_count) owned by one receiver. Gather uses receiver_count K-blocks; mcast
 //     uses K_tiles / in0_block_w natural-order blocks. Validated: exact K divisibility and
@@ -86,14 +85,13 @@ GlobalCircularBuffer create_global_circular_buffer_for_matmul_1d(
     std::optional<bool> support_multi_receiver_shards = std::nullopt);
 
 // Compute the validated `block_count` to pair with `weight` in a TensorPrefetcherInput when feeding a
-// gather-in0 or mcast-in0 1D matmul from a *receiver-contiguous* DRAM weight via `gcb`. Gather returns
-// the receiver/ring count; mcast returns `weight_K_tiles / program_config.in0_block_w`. It validates:
-//   * the weight is an NdShardSpec DRAM tensor with one full-K, N/receiver_count shard per receiver;
+// gather-in0, mcast-in0, or bank-striped mcast-in1 1D matmul via `gcb`. Gather returns the receiver/ring
+// count; both multicast modes return `weight_K_tiles / program_config.in0_block_w`. It validates:
+//   * gather/mcast-in0 use an NdShardSpec DRAM tensor with one full-K, N/receiver_count shard per receiver;
+//   * mcast-in1 uses a K-row-major WIDTH_SHARDED DRAM tensor with one full-K, N/num_banks stripe per relay;
 //   * weight K-tiles divides the consumer's block count exactly;
-//   * the weight's per-receiver N (shard N in tiles) equals program_config.per_core_N — otherwise the
-//     prefetcher's pushed page size and the matmul's in1 remote-CB page size disagree and the page-credit
-//     accounting desyncs.
-// Mcast uses natural FIFO order and therefore requires `stream_in1=false`.
+//   * the pushed page size matches the matmul consumer geometry, preventing remote-CB page-credit desync.
+// Multicast modes use natural FIFO order and therefore require `stream_in1=false`.
 uint32_t tensor_prefetcher_block_count_for_matmul_1d(
     const ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig& program_config,
     const tt::tt_metal::Tensor& weight,

--- a/ttnn/api/ttnn/global_circular_buffer.hpp
+++ b/ttnn/api/ttnn/global_circular_buffer.hpp
@@ -37,7 +37,7 @@ GlobalCircularBuffer create_global_circular_buffer_for_tensor_prefetcher(
     BufferType buffer_type = BufferType::L1,
     bool support_multi_receiver_shards = true);
 
-// Build a DRAM-sender GCB shaped to feed one or more 1D ring matmuls (gather_in0=true) from the
+// Build a DRAM-sender GCB shaped to feed one or more gather-in0 or mcast-in0 1D matmuls from the
 // given weight tensors. The caller supplies `bank_to_receivers` (the same layout the low-level
 // `create_global_circular_buffer_for_tensor_prefetcher` takes); this factory validates it against
 // the matmul program configs and weight shapes and sizes the GCB accordingly.
@@ -52,12 +52,12 @@ GlobalCircularBuffer create_global_circular_buffer_for_tensor_prefetcher(
 //     evenly across receivers; matmul per_core_N == weight per-receiver N. `bank_to_receivers`
 //     shape is checked: num_senders * num_global_cb_receivers == ring_size, every bank owns exactly
 //     num_global_cb_receivers cores. `size` floor is one full layer (ring_size * largest in1 block).
-//   * Receiver-contiguous (NdShardSpec): num_shards == ring_size, each shard (full K, N/ring_size)
-//     owned by one receiver. Validated: num_shards == ring_size, weight K-tiles divisible by
-//     ring_size, per_core_N == per-receiver N. Receivers need NOT be uniform per bank (strided
-//     round-robin). `size` floor is ring_size * largest per-receiver page, relaxed to a
-//     double-buffer window when every config is stream_in1. This layout also permits dual senders
-//     per bank via `support_multi_receiver_shards=false` (see below).
+//   * Receiver-contiguous (NdShardSpec): num_shards == receiver_count, each shard
+//     (full K, N/receiver_count) owned by one receiver. Gather uses receiver_count K-blocks; mcast
+//     uses K_tiles / in0_block_w natural-order blocks. Validated: exact K divisibility and
+//     per_core_N == per-receiver N. Receivers need NOT be uniform per bank. `size` can use a
+//     double-buffer window for streaming gather or mcast FIFO consumers. This layout also permits
+//     dual senders per bank via `support_multi_receiver_shards=false` (see below).
 //
 // All configs must agree on compute_with_storage_grid_size (and, for legacy, num_global_cb_receivers)
 // — the GCB has one receiver rectangle shared across all consumer matmuls. The factory does NOT
@@ -86,19 +86,14 @@ GlobalCircularBuffer create_global_circular_buffer_for_matmul_1d(
     std::optional<bool> support_multi_receiver_shards = std::nullopt);
 
 // Compute the validated `block_count` to pair with `weight` in a TensorPrefetcherInput when feeding a
-// gather_in0 1D matmul (`program_config`) from a *receiver-contiguous* DRAM weight via `gcb`. This is the
-// single place that owns the recv-contig prefetcher↔matmul cross-checks that otherwise have to be
-// reproduced (and have drifted) at every call site. It validates, then returns `block_count`:
-//   * block_count == ring_size (the matmul does wait_front(ring_size) per layer);
-//   * the weight is an NdShardSpec DRAM tensor whose num_shards == ring_size (one shard per receiver),
-//     each shard spanning the full K and N/ring_size columns;
-//   * weight K-tiles is divisible by ring_size — otherwise the prefetcher ceil-rounds the K-block width
-//     and over-reads past the receiver's slab while the matmul waits on pages that never come;
+// gather-in0 or mcast-in0 1D matmul from a *receiver-contiguous* DRAM weight via `gcb`. Gather returns
+// the receiver/ring count; mcast returns `weight_K_tiles / program_config.in0_block_w`. It validates:
+//   * the weight is an NdShardSpec DRAM tensor with one full-K, N/receiver_count shard per receiver;
+//   * weight K-tiles divides the consumer's block count exactly;
 //   * the weight's per-receiver N (shard N in tiles) equals program_config.per_core_N — otherwise the
 //     prefetcher's pushed page size and the matmul's in1 remote-CB page size disagree and the page-credit
 //     accounting desyncs.
-// Throws (TT_FATAL) on any mismatch. Mirrors create_global_circular_buffer_for_matmul_1d's K-row-major
-// guards for the receiver-contiguous layout.
+// Mcast uses natural FIFO order and therefore requires `stream_in1=false`.
 uint32_t tensor_prefetcher_block_count_for_matmul_1d(
     const ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig& program_config,
     const tt::tt_metal::Tensor& weight,

--- a/ttnn/core/global_circular_buffer.cpp
+++ b/ttnn/core/global_circular_buffer.cpp
@@ -276,19 +276,24 @@ bool is_receiver_contiguous_weight(const tt::tt_metal::Tensor& weight) {
     return weight.nd_shard_spec().has_value();
 }
 
-// Shared receiver-contiguous weight ↔ matmul cross-checks, parameterized on ring_size so both the
-// block_count helper (ring_size from the GCB) and the GCB factory (ring_size from bank_to_receivers /
-// the program-config grid) can call it. See the header docs on the two public functions for the
-// rationale behind each guard.
-void validate_recv_contig_weight_for_matmul_1d(
+// Shared receiver-contiguous weight ↔ matmul cross-checks. Returns the number of K-blocks the
+// prefetcher must push per receiver: gather-in0 uses one block per ring position, while mcast-in0
+// uses the configured inner-dimension block width.
+uint32_t validate_recv_contig_weight_for_matmul_1d(
     const ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig& program_config,
     const tt::tt_metal::Tensor& weight,
-    uint32_t ring_size) {
-    TT_FATAL(program_config.gather_in0, "receiver-contiguous Tensor prefetcher requires gather_in0=true");
-    TT_FATAL(ring_size > 0, "ring_size must be > 0");
+    uint32_t receiver_count) {
+    TT_FATAL(
+        program_config.gather_in0 != program_config.mcast_in0,
+        "receiver-contiguous Tensor prefetcher requires exactly one of gather_in0 or mcast_in0 to be true");
+    TT_FATAL(
+        !program_config.mcast_in0 || !program_config.stream_in1,
+        "mcast_in0 consumes GCB blocks in natural FIFO order and requires stream_in1=false");
+    TT_FATAL(receiver_count > 0, "receiver_count must be > 0");
 
-    // The receiver-contiguous weight is an NdShardSpec DRAM tensor: num_shards == ring_size, each shard
-    // (full K, N/ring_size). This is also exactly what the manager's detect_layout_mode keys on.
+    // The receiver-contiguous weight is an NdShardSpec DRAM tensor: num_shards == receiver_count,
+    // each shard (full K, N/receiver_count). This is also exactly what the manager's
+    // detect_layout_mode keys on.
     TT_FATAL(weight.buffer() != nullptr && weight.buffer()->is_dram(), "weight must live in DRAM");
     const auto& nd_opt = weight.nd_shard_spec();
     TT_FATAL(
@@ -325,25 +330,42 @@ void validate_recv_contig_weight_for_matmul_1d(
     const auto& bds = weight.buffer()->buffer_distribution_spec();
     TT_FATAL(bds.has_value(), "receiver-contiguous weight buffer must have a BufferDistributionSpec");
     TT_FATAL(
-        static_cast<uint32_t>(bds->num_shards()) == ring_size,
-        "receiver-contiguous weight has {} shards but global_cb ring_size is {}; num_shards must equal "
-        "ring_size (one shard per receiver)",
+        static_cast<uint32_t>(bds->num_shards()) == receiver_count,
+        "receiver-contiguous weight has {} shards but global_cb has {} receivers; num_shards must equal "
+        "receiver_count (one shard per receiver)",
         bds->num_shards(),
-        ring_size);
-
-    // #1 silent-hang / over-read guard: K must divide evenly into ring_size blocks. Otherwise
-    // compute_tensor_layout_recv_contig ceil-rounds k_block_w_tiles and the kernel reads past the
-    // receiver's slab, and the matmul (which pads K to a multiple of ring_size) waits forever.
-    const uint32_t weight_K_tiles = shard_K / tile_h;
+        receiver_count);
     TT_FATAL(
-        weight_K_tiles % ring_size == 0,
-        "weight K ({} tiles) must be divisible by ring_size ({}) for the receiver-contiguous DRAM-core "
-        "prefetcher; remainder {}",
-        weight_K_tiles,
-        ring_size,
-        weight_K_tiles % ring_size);
+        static_cast<uint64_t>(shard_N) * receiver_count == static_cast<uint64_t>(wp[-1]),
+        "receiver-contiguous shard N ({}) * receiver_count ({}) must equal full weight N ({})",
+        shard_N,
+        receiver_count,
+        wp[-1]);
 
-    // B1 page-size guard: the matmul sizes its in1 remote-CB page from per_core_N; the prefetcher pushes
+    const uint32_t weight_K_tiles = shard_K / tile_h;
+    uint32_t block_count = 0;
+    if (program_config.gather_in0) {
+        // Gather consumes one rotated K-block per ring position.
+        TT_FATAL(
+            weight_K_tiles % receiver_count == 0,
+            "weight K ({} tiles) must be divisible by receiver_count ({}) for gather_in0; remainder {}",
+            weight_K_tiles,
+            receiver_count,
+            weight_K_tiles % receiver_count);
+        block_count = receiver_count;
+    } else {
+        // Mcast consumes the same natural K-block sequence on every output worker.
+        TT_FATAL(program_config.in0_block_w > 0, "mcast_in0 requires in0_block_w > 0");
+        TT_FATAL(
+            weight_K_tiles % program_config.in0_block_w == 0,
+            "weight K ({} tiles) must be divisible by mcast_in0 in0_block_w ({}); remainder {}",
+            weight_K_tiles,
+            program_config.in0_block_w,
+            weight_K_tiles % program_config.in0_block_w);
+        block_count = weight_K_tiles / static_cast<uint32_t>(program_config.in0_block_w);
+    }
+
+    // Page-size guard: the matmul sizes its in1 remote-CB page from per_core_N; the prefetcher pushes
     // pages of n_per_recv tiles. A mismatch desyncs the page-credit accounting (wrong output / hang).
     const uint32_t n_per_recv_tiles = shard_N / tile_w;
     TT_FATAL(
@@ -353,6 +375,7 @@ void validate_recv_contig_weight_for_matmul_1d(
         n_per_recv_tiles,
         shard_N,
         tile_w);
+    return block_count;
 }
 
 }  // namespace
@@ -361,11 +384,9 @@ uint32_t tensor_prefetcher_block_count_for_matmul_1d(
     const ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig& program_config,
     const tt::tt_metal::Tensor& weight,
     const GlobalCircularBuffer& gcb) {
-    // ring_size == total receivers == block_count (the matmul does wait_front(ring_size) per layer).
-    const uint32_t ring_size = gcb.receiver_cores().num_cores();
-    TT_FATAL(ring_size > 0, "global_cb has no receivers");
-    validate_recv_contig_weight_for_matmul_1d(program_config, weight, ring_size);
-    return ring_size;
+    const uint32_t receiver_count = gcb.receiver_cores().num_cores();
+    TT_FATAL(receiver_count > 0, "global_cb has no receivers");
+    return validate_recv_contig_weight_for_matmul_1d(program_config, weight, receiver_count);
 }
 
 // Builds the GCB for a receiver-contiguous (NdShardSpec) weight: num_shards == ring_size, each shard
@@ -382,60 +403,72 @@ static GlobalCircularBuffer build_matmul_1d_gcb_recv_contig(
     TT_FATAL(size > 0, "size must be > 0");
     TT_FATAL(!bank_to_receivers.empty(), "bank_to_receivers must be non-empty");
 
-    // ring_size for the recv-contig layout is the total receiver count (= num_shards). Unlike the
+    // receiver_count for the recv-contig layout is the total receiver count (= num_shards). Unlike the
     // K-row-major builder we do NOT require a uniform per-bank receiver count or a contiguous
     // bank->ring mapping — recv-contig uses a strided round-robin placement, and dual senders split
     // a bank's receivers across two DRISC cores.
-    uint32_t ring_size = 0;
+    uint32_t receiver_count = 0;
     for (const auto& [_bank, receivers] : bank_to_receivers) {
-        ring_size += receivers.num_cores();
+        receiver_count += receivers.num_cores();
     }
-    TT_FATAL(ring_size > 0, "bank_to_receivers has no receivers");
+    TT_FATAL(receiver_count > 0, "bank_to_receivers has no receivers");
 
     // All matmuls share the GCB receiver rectangle, so they must agree on the ring shape, and that
     // ring must match bank_to_receivers' total receiver count.
     uint32_t max_page_bytes = 0;
-    bool all_configs_stream = true;
+    uint32_t max_block_count = 0;
+    bool all_configs_fifo = true;
     for (size_t i = 0; i < program_configs.size(); ++i) {
         const auto& cfg = program_configs[i];
-        all_configs_stream = all_configs_stream && cfg.stream_in1;
         const auto& grid = cfg.compute_with_storage_grid_size;
-        const uint32_t cfg_ring_size = grid.x * grid.y;
-        TT_FATAL(
-            cfg_ring_size == ring_size,
-            "program_configs[{}] grid {}x{} = {} workers, but bank_to_receivers has {} total receivers; "
-            "they must match (one receiver per matmul worker)",
-            i,
-            grid.x,
-            grid.y,
-            cfg_ring_size,
-            ring_size);
+        const uint32_t grid_capacity = grid.x * grid.y;
+        if (cfg.gather_in0) {
+            TT_FATAL(
+                grid_capacity == receiver_count,
+                "gather_in0 program_configs[{}] grid {}x{} = {} workers, but bank_to_receivers has {} total "
+                "receivers; they must match",
+                i,
+                grid.x,
+                grid.y,
+                grid_capacity,
+                receiver_count);
+        } else {
+            TT_FATAL(
+                grid_capacity >= receiver_count,
+                "mcast_in0 program_configs[{}] grid {}x{} has capacity for {} workers, but bank_to_receivers has "
+                "{} receivers",
+                i,
+                grid.x,
+                grid.y,
+                grid_capacity,
+                receiver_count);
+        }
 
-        // Per-(config, weight) recv-contig cross-checks (num_shards == ring_size, K % ring_size == 0,
-        // per_core_N == per-receiver N). Shared with tensor_prefetcher_block_count_for_matmul_1d.
-        validate_recv_contig_weight_for_matmul_1d(cfg, weights[i], ring_size);
+        // Per-(config, weight) recv-contig cross-checks and consumer-specific K-block count.
+        const uint32_t block_count = validate_recv_contig_weight_for_matmul_1d(cfg, weights[i], receiver_count);
+        max_block_count = std::max(max_block_count, block_count);
+        all_configs_fifo = all_configs_fifo && (cfg.mcast_in0 || cfg.stream_in1);
 
-        // page_bytes_per_recv = (K_tiles / ring_size) * per_core_N * tile_bytes — one K-block per receiver.
+        // One GCB page is one consumer K-block for one receiver.
         const auto& w = weights[i];
         const auto& tile = w.tensor_spec().tile();
         const uint32_t weight_K_tiles = static_cast<uint32_t>(w.padded_shape()[-2]) / tile.get_height();
-        const uint32_t k_block_w_tiles = weight_K_tiles / ring_size;
+        const uint32_t k_block_w_tiles = weight_K_tiles / block_count;
         const uint32_t bytes_per_tile = tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(w.dtype()));
         const uint32_t page_bytes = k_block_w_tiles * cfg.per_core_N * bytes_per_tile;
         TT_FATAL(page_bytes > 0, "program_configs[{}] page_bytes computed as 0", i);
         max_page_bytes = std::max(max_page_bytes, page_bytes);
     }
 
-    // A batched matmul does wait_front(ring_size) per layer, so the GCB must hold at least one full
-    // layer's worth of pages. A stream_in1 matmul instead consumes K-blocks FIFO as they land, so a
-    // shallow window is valid -- and shrinking the GCB is the whole point of streaming. Relax the
-    // floor to a double-buffer (one page filling while another drains) when every matmul sharing this
-    // GCB streams; a GCB shared with any batched matmul keeps the full-layer floor. Same cap as the
+    // A batched gather matmul waits for all blocks before consuming. A stream_in1 gather or a
+    // GCB-backed mcast consumes K-blocks FIFO as they land, so a shallow window is valid. Relax the
+    // floor to a double-buffer when every matmul sharing this GCB is a FIFO consumer; otherwise keep
+    // enough space for the largest full tensor. Same cap as the
     // K-row-major builder (see create_global_circular_buffer_for_matmul_1d for why kMaxCbPagesBytes
     // exists); no L1 budget check — callers size to fit their own receiver L1.
     constexpr uint32_t kMaxCbPagesBytes = 131072u * 16u;
-    constexpr uint32_t kStreamMinWindowBlocks = 2;  // double-buffer floor for stream_in1
-    const uint32_t min_blocks = all_configs_stream ? kStreamMinWindowBlocks : ring_size;
+    constexpr uint32_t kFifoMinWindowBlocks = 2;
+    const uint32_t min_blocks = all_configs_fifo ? kFifoMinWindowBlocks : max_block_count;
     const uint32_t min_size = max_page_bytes * min_blocks;
     TT_FATAL(
         size >= min_size,
@@ -444,9 +477,8 @@ static GlobalCircularBuffer build_matmul_1d_gcb_recv_contig(
         min_blocks,
         max_page_bytes,
         min_size,
-        all_configs_stream ? "stream_in1 matmuls consume K-blocks FIFO but still need a double-buffered window."
-                           : "The matmul does wait_front(ring_size), so it needs a full layer buffered before "
-                             "it consumes.");
+        all_configs_fifo ? "FIFO matmuls consume K-blocks as they arrive but still need a double-buffered window."
+                         : "A batched gather matmul needs a full layer buffered before it consumes.");
     TT_FATAL(
         size <= kMaxCbPagesBytes,
         "GCB size ({} B) exceeds the remote-CB page-count cap ({} B). Reduce size.",
@@ -492,6 +524,13 @@ GlobalCircularBuffer create_global_circular_buffer_for_matmul_1d(
         const bool single_sender = support_multi_receiver_shards.value_or(false);
         return build_matmul_1d_gcb_recv_contig(
             mesh_device, program_configs, weights, bank_to_receivers, size, buffer_type, single_sender);
+    }
+
+    for (size_t i = 0; i < program_configs.size(); ++i) {
+        TT_FATAL(
+            program_configs[i].gather_in0,
+            "program_configs[{}] uses mcast_in0, which requires a receiver-contiguous NdShardSpec weight",
+            i);
     }
 
     // Legacy K-row-major is single-sender per bank by construction (a bank's shard feeds all its

--- a/ttnn/core/global_circular_buffer.cpp
+++ b/ttnn/core/global_circular_buffer.cpp
@@ -345,7 +345,10 @@ uint32_t validate_recv_contig_weight_for_matmul_1d(
     const uint32_t weight_K_tiles = shard_K / tile_h;
     uint32_t block_count = 0;
     if (program_config.gather_in0) {
-        // Gather consumes one rotated K-block per ring position.
+        // Gather consumes one rotated K-block per ring position. Silent-hang / over-read guard: K must
+        // divide evenly into receiver_count blocks. Otherwise the K-block width the prefetcher lays out
+        // rounds up, the kernel reads past the receiver's slab, and the matmul (which pads K to a
+        // multiple of receiver_count) waits on pages that never come.
         TT_FATAL(
             weight_K_tiles % receiver_count == 0,
             "weight K ({} tiles) must be divisible by receiver_count ({}) for gather_in0; remainder {}",
@@ -354,7 +357,9 @@ uint32_t validate_recv_contig_weight_for_matmul_1d(
             weight_K_tiles % receiver_count);
         block_count = receiver_count;
     } else {
-        // Mcast consumes the same natural K-block sequence on every output worker.
+        // Mcast consumes the same natural K-block sequence on every output worker. Same silent-hang /
+        // over-read guard, keyed on in0_block_w: an indivisible K rounds the block width up and the
+        // kernel over-reads while the matmul waits forever.
         TT_FATAL(program_config.in0_block_w > 0, "mcast_in0 requires in0_block_w > 0");
         TT_FATAL(
             weight_K_tiles % program_config.in0_block_w == 0,

--- a/ttnn/core/global_circular_buffer.cpp
+++ b/ttnn/core/global_circular_buffer.cpp
@@ -383,15 +383,196 @@ uint32_t validate_recv_contig_weight_for_matmul_1d(
     return block_count;
 }
 
+struct KRowMcastIn1Geometry {
+    uint32_t block_count = 0;
+    uint32_t page_bytes = 0;
+};
+
+KRowMcastIn1Geometry validate_krow_mcast_in1_weight_for_matmul_1d(
+    const ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig& program_config,
+    const tt::tt_metal::Tensor& weight,
+    uint32_t num_banks) {
+    TT_FATAL(
+        !program_config.gather_in0 && !program_config.mcast_in0,
+        "bank-striped Tensor prefetcher mcast-in1 requires gather_in0=false and mcast_in0=false");
+    TT_FATAL(
+        !program_config.stream_in1, "mcast-in1 consumes bank stripes in natural order and requires stream_in1=false");
+    TT_FATAL(
+        program_config.num_global_cb_receivers == 1,
+        "bank-striped mcast-in1 requires num_global_cb_receivers=1 (one relay worker per DRAM bank), got {}",
+        program_config.num_global_cb_receivers);
+    TT_FATAL(num_banks > 0, "bank-striped mcast-in1 requires at least one DRAM bank");
+
+    TT_FATAL(weight.buffer() != nullptr && weight.buffer()->is_dram(), "mcast-in1 weight must live in DRAM");
+    TT_FATAL(
+        weight.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED &&
+            weight.buffer()->has_shard_spec(),
+        "bank-striped mcast-in1 requires a legacy WIDTH_SHARDED DRAM weight with one full-K shard per bank");
+
+    const auto& wp = weight.padded_shape();
+    TT_FATAL(wp.rank() >= 2, "mcast-in1 weight must be at least 2D; got rank {}", wp.rank());
+    const auto& tile = weight.tensor_spec().tile();
+    const uint32_t tile_h = tile.get_height();
+    const uint32_t tile_w = tile.get_width();
+    const uint32_t weight_K = wp[-2];
+    const uint32_t weight_N = wp[-1];
+    TT_FATAL(
+        weight_K % tile_h == 0 && weight_N % tile_w == 0,
+        "mcast-in1 weight shape ({}, {}) must be tile-aligned (tile {}x{})",
+        weight_K,
+        weight_N,
+        tile_h,
+        tile_w);
+    const uint32_t weight_K_tiles = weight_K / tile_h;
+    const uint32_t weight_N_tiles = weight_N / tile_w;
+
+    const auto& shard_shape = weight.buffer()->shard_spec().shape();
+    const uint32_t shard_K = shard_shape[0];
+    const uint32_t shard_N = shard_shape[1];
+    TT_FATAL(shard_K == weight_K, "mcast-in1 weight DRAM shard K ({}) must equal full K ({})", shard_K, weight_K);
+    TT_FATAL(
+        static_cast<uint64_t>(shard_N) * num_banks == weight_N,
+        "mcast-in1 weight DRAM shard N ({}) * num_banks ({}) must equal full N ({})",
+        shard_N,
+        num_banks,
+        weight_N);
+    TT_FATAL(
+        shard_N % tile_w == 0, "mcast-in1 weight per-bank N ({}) must be tile-aligned (tile_w={})", shard_N, tile_w);
+    TT_FATAL(
+        program_config.per_core_N == weight_N_tiles,
+        "mcast-in1 program_config.per_core_N ({}) must equal full weight N ({} tiles); every matmul worker "
+        "receives the assembled full-width in1 block",
+        program_config.per_core_N,
+        weight_N_tiles);
+    TT_FATAL(program_config.in0_block_w > 0, "mcast-in1 requires in0_block_w > 0");
+    TT_FATAL(
+        weight_K_tiles % program_config.in0_block_w == 0,
+        "mcast-in1 weight K ({} tiles) must be divisible by in0_block_w ({})",
+        weight_K_tiles,
+        program_config.in0_block_w);
+
+    const uint32_t block_count = weight_K_tiles / static_cast<uint32_t>(program_config.in0_block_w);
+    const uint32_t stripe_N_tiles = shard_N / tile_w;
+    const uint32_t bytes_per_tile = tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(weight.dtype()));
+    const uint32_t page_bytes = static_cast<uint32_t>(program_config.in0_block_w) * stripe_N_tiles * bytes_per_tile;
+    TT_FATAL(block_count > 0 && page_bytes > 0, "mcast-in1 block_count and page_bytes must be non-zero");
+    return {.block_count = block_count, .page_bytes = page_bytes};
+}
+
 }  // namespace
 
 uint32_t tensor_prefetcher_block_count_for_matmul_1d(
     const ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig& program_config,
     const tt::tt_metal::Tensor& weight,
     const GlobalCircularBuffer& gcb) {
+    if (!program_config.gather_in0 && !program_config.mcast_in0) {
+        TT_FATAL(
+            !is_receiver_contiguous_weight(weight),
+            "bank-striped mcast-in1 requires a legacy WIDTH_SHARDED weight, not a receiver-contiguous NdShardSpec");
+        const auto& mapping = gcb.sender_receiver_core_mapping();
+        const uint32_t num_banks = static_cast<uint32_t>(mapping.size());
+        TT_FATAL(num_banks > 0, "global_cb has no DRAM-bank senders");
+        for (size_t i = 0; i < mapping.size(); ++i) {
+            const auto& [sender, receivers] = mapping[i];
+            TT_FATAL(
+                receivers.num_cores() == 1,
+                "mcast-in1 global_cb requires one relay receiver per bank; sender {} has {} receivers",
+                sender,
+                receivers.num_cores());
+        }
+        const auto geometry = validate_krow_mcast_in1_weight_for_matmul_1d(program_config, weight, num_banks);
+        TT_FATAL(
+            gcb.size() % geometry.page_bytes == 0,
+            "mcast-in1 global_cb size {} must be a multiple of its per-bank stripe page size {}",
+            gcb.size(),
+            geometry.page_bytes);
+        TT_FATAL(
+            gcb.size() >= 2 * geometry.page_bytes,
+            "mcast-in1 global_cb requires a two-page streaming window: size {} must be at least {}",
+            gcb.size(),
+            2 * geometry.page_bytes);
+        return geometry.block_count;
+    }
+
     const uint32_t receiver_count = gcb.receiver_cores().num_cores();
     TT_FATAL(receiver_count > 0, "global_cb has no receivers");
     return validate_recv_contig_weight_for_matmul_1d(program_config, weight, receiver_count);
+}
+
+// Builds the bank-striped mcast-in1 GCB. Each K-row-major DRAM bank owns one N stripe and unicasts
+// it to exactly one relay worker. The relay workers assemble full in1 blocks on all matmul workers
+// with worker-side multicast; the Tensor prefetcher itself remains unicast-only.
+static GlobalCircularBuffer build_matmul_1d_gcb_krow_major_mcast_in1(
+    MeshDevice* mesh_device,
+    const std::vector<ttnn::operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>& program_configs,
+    const std::vector<tt::tt_metal::Tensor>& weights,
+    const std::vector<std::pair<uint32_t, CoreRangeSet>>& bank_to_receivers,
+    uint32_t size,
+    BufferType buffer_type) {
+    TT_FATAL(size > 0, "size must be > 0");
+    TT_FATAL(!bank_to_receivers.empty(), "bank_to_receivers must be non-empty");
+
+    const uint32_t num_banks = static_cast<uint32_t>(bank_to_receivers.size());
+    std::vector<bool> seen_banks(num_banks, false);
+    for (size_t i = 0; i < bank_to_receivers.size(); ++i) {
+        const auto& [bank, receivers] = bank_to_receivers[i];
+        TT_FATAL(
+            bank < num_banks && !seen_banks[bank],
+            "mcast-in1 bank ids must be dense and unique in [0, {}); bank_to_receivers[{}] has bank {}",
+            num_banks,
+            i,
+            bank);
+        seen_banks[bank] = true;
+        TT_FATAL(
+            receivers.num_cores() == 1,
+            "mcast-in1 requires exactly one relay worker per DRAM bank; bank {} has {} receivers",
+            bank,
+            receivers.num_cores());
+    }
+
+    uint32_t max_page_bytes = 0;
+    for (size_t i = 0; i < program_configs.size(); ++i) {
+        const auto& cfg = program_configs[i];
+        const uint32_t grid_capacity = cfg.compute_with_storage_grid_size.x * cfg.compute_with_storage_grid_size.y;
+        TT_FATAL(
+            grid_capacity >= num_banks,
+            "mcast-in1 program_configs[{}] grid {}x{} has {} workers but needs at least one relay for each of {} "
+            "DRAM banks",
+            i,
+            cfg.compute_with_storage_grid_size.x,
+            cfg.compute_with_storage_grid_size.y,
+            grid_capacity,
+            num_banks);
+        const auto geometry = validate_krow_mcast_in1_weight_for_matmul_1d(cfg, weights[i], num_banks);
+        TT_FATAL(
+            size % geometry.page_bytes == 0,
+            "mcast-in1 GCB size {} must be a multiple of program_configs[{}] stripe page size {}",
+            size,
+            i,
+            geometry.page_bytes);
+        max_page_bytes = std::max(max_page_bytes, geometry.page_bytes);
+    }
+
+    constexpr uint32_t kMaxCbPagesBytes = 131072u * 16u;
+    constexpr uint32_t kFifoMinWindowBlocks = 2;
+    TT_FATAL(
+        size >= kFifoMinWindowBlocks * max_page_bytes,
+        "mcast-in1 GCB size ({} B) must hold at least two largest stripe pages (2 * {} B = {} B)",
+        size,
+        max_page_bytes,
+        kFifoMinWindowBlocks * max_page_bytes);
+    TT_FATAL(
+        size <= kMaxCbPagesBytes,
+        "GCB size ({} B) exceeds the remote-CB page-count cap ({} B). Reduce size.",
+        size,
+        kMaxCbPagesBytes);
+
+    auto ordered_bank_to_receivers = bank_to_receivers;
+    std::sort(ordered_bank_to_receivers.begin(), ordered_bank_to_receivers.end(), [](const auto& lhs, const auto& rhs) {
+        return lhs.first < rhs.first;
+    });
+    return tt::tt_metal::experimental::CreateGlobalCircularBufferForTensorPrefetcher(
+        *mesh_device, ordered_bank_to_receivers, size, buffer_type, /*support_multi_receiver_shards=*/true);
 }
 
 // Builds the GCB for a receiver-contiguous (NdShardSpec) weight: num_shards == ring_size, each shard
@@ -519,6 +700,31 @@ GlobalCircularBuffer create_global_circular_buffer_for_matmul_1d(
             "weights[{}] has a different DRAM layout than weights[0]; all weights sharing one GCB must be either "
             "all receiver-contiguous (NdShardSpec) or all legacy K-row-major (WIDTH_SHARDED)",
             i);
+    }
+
+    const bool mcast_in1 = !program_configs.front().gather_in0 && !program_configs.front().mcast_in0;
+    for (size_t i = 0; i < program_configs.size(); ++i) {
+        const bool config_mcast_in1 = !program_configs[i].gather_in0 && !program_configs[i].mcast_in0;
+        TT_FATAL(
+            config_mcast_in1 == mcast_in1,
+            "All program configs sharing one GCB must use the same consumer mode; config[0] mcast-in1={} but "
+            "config[{}] mcast-in1={}",
+            mcast_in1,
+            i,
+            config_mcast_in1);
+    }
+
+    if (mcast_in1) {
+        TT_FATAL(
+            !recv_contig,
+            "bank-striped mcast-in1 requires legacy K-row-major WIDTH_SHARDED weights, not receiver-contiguous "
+            "NdShardSpec weights");
+        TT_FATAL(
+            support_multi_receiver_shards.value_or(true),
+            "bank-striped mcast-in1 uses one K-row-major shard and one relay per bank, so dual DRAM senders are "
+            "not supported");
+        return build_matmul_1d_gcb_krow_major_mcast_in1(
+            mesh_device, program_configs, weights, bank_to_receivers, size, buffer_type);
     }
 
     if (recv_contig) {

--- a/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher_nanobind.cpp
@@ -171,15 +171,14 @@ void bind_tensor_prefetcher(nb::module_& mod) {
     ttnn::bind_function<"create_global_circular_buffer_for_matmul_1d", "ttnn.experimental.">(
         mod,
         R"doc(
-            Build a DRAM-sender GlobalCircularBuffer sized to feed one or more 1D ring matmuls
-            (gather_in0=true) with their weight tensors. The weight's DRAM layout is auto-detected
-            (legacy WIDTH_SHARDED K-row-major vs receiver-contiguous NdShardSpec) and validated/sized
-            accordingly, so callers do not choose a layout-specific factory. See notes in
-            ttnn/api/ttnn/global_circular_buffer.hpp.
+            Build a DRAM-sender GlobalCircularBuffer sized to feed one or more gather_in0 or
+            mcast_in0 1D matmuls with their weight tensors. The weight's DRAM layout is
+            auto-detected (legacy WIDTH_SHARDED K-row-major vs receiver-contiguous NdShardSpec)
+            and validated/sized accordingly.
 
             Args:
                 mesh_device: The mesh device.
-                program_configs: List of 1D mcast matmul program configs (each gather_in0=True).
+                program_configs: List of compatible 1D matmul program configs.
                 weights: List of DRAM in1 tensors, one per program_config. All must share the same
                     DRAM layout (all legacy WIDTH_SHARDED, or all receiver-contiguous NdShardSpec).
                 bank_to_receivers: List of (bank_id, receivers) pairs.
@@ -207,14 +206,12 @@ void bind_tensor_prefetcher(nb::module_& mod) {
         mod,
         R"doc(
             Compute and validate the block_count to pair with a receiver-contiguous DRAM weight
-            in queue_tensor_prefetcher_request, for a gather_in0 1D matmul fed via global_cb.
-            Centralizes the recv-contig prefetcher/matmul cross-checks (num_shards == ring_size,
-            weight K divisible by ring_size, weight per-receiver N == per_core_N) so call sites
-            don't re-derive (and mis-derive) them. Returns the block_count (== ring_size); raises
-            on any mismatch.
+            in queue_tensor_prefetcher_request for a gather_in0 or mcast_in0 1D matmul fed via
+            global_cb. Gather returns the receiver/ring count. Mcast returns
+            weight_K_tiles / in0_block_w and uses natural FIFO order.
 
             Args:
-                program_config: The gather_in0 1D mcast matmul program config that will consume the weight.
+                program_config: The 1D matmul program config that will consume the weight.
                 weight: The receiver-contiguous (NdShardSpec) DRAM weight tensor.
                 global_cb: The DRAM-sender GCB the prefetcher and matmul share.
 

--- a/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher_nanobind.cpp
@@ -171,10 +171,10 @@ void bind_tensor_prefetcher(nb::module_& mod) {
     ttnn::bind_function<"create_global_circular_buffer_for_matmul_1d", "ttnn.experimental.">(
         mod,
         R"doc(
-            Build a DRAM-sender GlobalCircularBuffer sized to feed one or more gather_in0 or
-            mcast_in0 1D matmuls with their weight tensors. The weight's DRAM layout is
-            auto-detected (legacy WIDTH_SHARDED K-row-major vs receiver-contiguous NdShardSpec)
-            and validated/sized accordingly.
+            Build a DRAM-sender GlobalCircularBuffer sized to feed one or more gather_in0,
+            mcast_in0, or bank-striped mcast_in1 1D matmuls with their weight tensors. The
+            weight's DRAM layout is auto-detected (legacy WIDTH_SHARDED K-row-major vs
+            receiver-contiguous NdShardSpec) and validated/sized accordingly.
 
             Args:
                 mesh_device: The mesh device.
@@ -205,14 +205,15 @@ void bind_tensor_prefetcher(nb::module_& mod) {
     ttnn::bind_function<"tensor_prefetcher_block_count_for_matmul_1d", "ttnn.experimental.">(
         mod,
         R"doc(
-            Compute and validate the block_count to pair with a receiver-contiguous DRAM weight
-            in queue_tensor_prefetcher_request for a gather_in0 or mcast_in0 1D matmul fed via
-            global_cb. Gather returns the receiver/ring count. Mcast returns
-            weight_K_tiles / in0_block_w and uses natural FIFO order.
+            Compute and validate the block_count for queue_tensor_prefetcher_request when a
+            gather_in0, mcast_in0, or bank-striped mcast_in1 1D matmul consumes via global_cb.
+            Gather returns the receiver/ring count. Both multicast modes return
+            weight_K_tiles / in0_block_w and use natural FIFO order.
 
             Args:
                 program_config: The 1D matmul program config that will consume the weight.
-                weight: The receiver-contiguous (NdShardSpec) DRAM weight tensor.
+                weight: The receiver-contiguous (gather/mcast_in0) or bank-striped
+                    WIDTH_SHARDED (mcast_in1) DRAM weight tensor.
                 global_cb: The DRAM-sender GCB the prefetcher and matmul share.
 
             Returns:

--- a/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config_types.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config_types.hpp
@@ -66,12 +66,9 @@ struct MatmulMultiCoreReuseMultiCast1DProgramConfig {
     std::size_t num_global_cb_receivers{};
     bool untilize_out{};
     std::optional<CoreRangeSet> allowed_worker_cores = std::nullopt;
-    // Stream in1 from the GCB in ring-rotated FIFO order (gather_in0 + DRAM-sender GCB only):
-    // consume each weight block as it arrives instead of waiting for the whole tensor, so the
-    // GCB can be sized to a small window. The feeding prefetcher request MUST supply a per-receiver
-    // rotation (the `(weight, block_count, rotation)` form of queue_tensor_prefetcher_request) so it
-    // streams in matching ring-rotated FIFO order, else the matmul deadlocks (it waits for
-    // FIFO-order blocks the batched prefetcher delivers in natural order).
+    // Select ring-rotated FIFO delivery for gather_in0 with a DRAM-sender GCB. The feeding prefetcher
+    // request MUST supply a per-receiver rotation. GCB-backed mcast_in0 instead consumes natural FIFO
+    // order and requires this flag to remain false.
     bool stream_in1 = false;
 };
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config_types.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config_types.hpp
@@ -67,8 +67,8 @@ struct MatmulMultiCoreReuseMultiCast1DProgramConfig {
     bool untilize_out{};
     std::optional<CoreRangeSet> allowed_worker_cores = std::nullopt;
     // Select ring-rotated FIFO delivery for gather_in0 with a DRAM-sender GCB. The feeding prefetcher
-    // request MUST supply a per-receiver rotation. GCB-backed mcast_in0 instead consumes natural FIFO
-    // order and requires this flag to remain false.
+    // request MUST supply a per-receiver rotation. GCB-backed mcast-in0 and bank-striped mcast-in1
+    // instead consume natural FIFO order and require this flag to remain false.
     bool stream_in1 = false;
 };
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -1157,6 +1157,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
     std::optional<UnaryWithParam> fused_activation,
     const MeshTensor& in0_tensor,
     const MeshTensor& in1_tensor,
+    const std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer>& global_cb,
     ttsl::optional_reference<const MeshTensor> bias_tensor,
     const MeshTensor& out_tensor,
     const tt::tt_metal::Tile& in0_tile,
@@ -1172,6 +1173,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
     bool untilize_out,
     bool row_broadcast_bias = true,
     CoreCoord sub_device_start_core = {0, 0}) {
+    const bool use_global_cb = global_cb.has_value();
     // currently only support transpose of the full tile
     bool in0_transpose_tile = in0_tile.get_transpose_of_faces() && in0_tile.get_transpose_within_face();
     bool in1_transpose_tile = in1_tile.get_transpose_of_faces() && in1_tile.get_transpose_within_face();
@@ -1228,7 +1230,8 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
     const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
     uint32_t in0_aligned_tile_size =
         in0_is_sharded ? in0_single_tile_size : tt::align(in0_single_tile_size, dram_alignment);
-    uint32_t in1_aligned_tile_size = tt::align(in1_single_tile_size, dram_alignment);
+    uint32_t in1_aligned_tile_size =
+        use_global_cb ? in1_single_tile_size : tt::align(in1_single_tile_size, dram_alignment);
     // Bias CB pages must be padded to the DRAM alignment so the reader's L1 write stride
     // matches the DRAM page stride (e.g. 64B on Blackhole for a 32B (1,16) bf16 bias tile).
     // Mirrors in0/in1 above and the dram_sharded factory. No-op on Wormhole and for
@@ -1310,9 +1313,46 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
     CoreRange in1_mcast_receiver_cores_bounding_box = all_cores.bounding_box();
     uint32_t in1_mcast_receiver_num_cores = in1_mcast_receiver_cores_bounding_box.size();  // always mcast to full grid
 
-    CoreRange in1_mcast_sender(start_core, start_core);
+    TT_FATAL(
+        !use_global_cb || all_cores.num_cores() == in1_mcast_receiver_num_cores,
+        "bank-striped mcast-in1 requires active workers to fill their multicast bounding box; active cores {} have "
+        "bounding-box size {}",
+        all_cores.num_cores(),
+        in1_mcast_receiver_num_cores);
+
+    CoreRangeSet in1_mcast_senders(CoreRange(start_core, start_core));
     CoreRangeSet in1_mcast_receivers;
-    if (in1_mcast_receiver_num_cores > 1) {
+    CoreCoord relay_coordinator_core = start_core;
+    if (use_global_cb) {
+        in1_mcast_senders = global_cb->receiver_cores();
+        TT_FATAL(
+            all_cores.contains(in1_mcast_senders),
+            "All bank-striped mcast-in1 relays must be active matmul workers. Workers: {}; relays: {}",
+            all_cores,
+            in1_mcast_senders);
+        std::vector<CoreRange> receiver_ranges;
+        receiver_ranges.reserve(num_cores - in1_mcast_senders.num_cores());
+        for (const auto& core : corerange_to_cores(all_cores, std::nullopt, row_major)) {
+            if (!in1_mcast_senders.contains(core)) {
+                receiver_ranges.emplace_back(core);
+            }
+        }
+        in1_mcast_receivers = CoreRangeSet(receiver_ranges);
+
+        const auto& sender_mapping = global_cb->sender_receiver_core_mapping();
+        for (size_t relay_index = 0; relay_index < sender_mapping.size(); ++relay_index) {
+            const auto& [sender, receivers] = sender_mapping[relay_index];
+            TT_FATAL(
+                receivers.num_cores() == 1,
+                "bank-striped mcast-in1 requires one relay per DRAM bank; bank {} has {}",
+                sender.x,
+                receivers.num_cores());
+            if (relay_index == 0) {
+                relay_coordinator_core = corerange_to_cores(receivers, std::nullopt, /*row_wise=*/true).front();
+            }
+        }
+        TT_FATAL(!sender_mapping.empty(), "bank-striped mcast-in1 global_cb has no relay coordinator");
+    } else if (in1_mcast_receiver_num_cores > 1) {
         // Check against the actual rectangle width (instead of bare grid_size.x-1) so that
         // sub-devices anchored away from (0, 0) wrap correctly.
         auto receiver_start_core = compute_with_storage_grid_size.x > 1 ? CoreCoord{start_core.x + 1, start_core.y}
@@ -1320,15 +1360,24 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
         in1_mcast_receivers = tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(
             receiver_start_core, num_cores - 1, matmul_core_rect, row_major);
     }
+    const uint32_t num_relay_cores = in1_mcast_senders.num_cores();
+    TT_FATAL(
+        !use_global_cb || (num_relay_cores > 0 && N % num_relay_cores == 0),
+        "bank-striped mcast-in1 full N ({} tiles) must divide evenly across {} relay workers",
+        N,
+        num_relay_cores);
+    const uint32_t relay_stripe_w_tiles = use_global_cb ? N / num_relay_cores : 0;
 
     // Mcast args
     auto in1_mcast_sender_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
     auto in1_mcast_receiver_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    auto in1_mcast_relay_go_semaphore_id = tt_metal::CreateSemaphore(program, all_cores, INVALID);
 
     CoreCoord top_left_core = in1_mcast_receiver_cores_bounding_box.start_coord;
     CoreCoord bottom_right_core = in1_mcast_receiver_cores_bounding_box.end_coord;
     auto top_left_core_physical = device->worker_core_from_logical_core(top_left_core);
     auto bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
+    auto relay_coordinator_core_physical = device->worker_core_from_logical_core(relay_coordinator_core);
 
     const auto& a_padded_shape = operations::matmul::utilities::get_matmul_tensor_padded_shape(a, transpose_a);
     const uint32_t M_per_batch = a_padded_shape[-2] / in0_tile.get_height();
@@ -1522,6 +1571,10 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
         mm_kernel_in1_sender_writer_defines["OUT_SHARDED"] = "1";
         mm_kernel_in1_receiver_writer_defines["OUT_SHARDED"] = "1";
     }
+    if (use_global_cb) {
+        mm_kernel_in1_sender_writer_defines["ENABLE_GLOBAL_CB_MCAST_IN1"] = "1";
+        mm_kernel_in1_receiver_writer_defines["ENABLE_GLOBAL_CB_MCAST_IN1"] = "1";
+    }
 
     mm_kernel_in0_sender_defines["SKIP_MCAST"] = "1";
 
@@ -1571,21 +1624,41 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
                 {"cb_sparsity", tt::CBIndex::c_6},
             }});
 
+    std::unordered_map<std::string, uint32_t> in1_sender_named_compile_args = {
+        {"cb_in1", tt::CBIndex::c_1},
+        {"cb_bias", tt::CBIndex::c_3},
+        {"cb_out", tt::CBIndex::c_4},
+        {"cb_sparsity", tt::CBIndex::c_7},
+    };
+    std::unordered_map<std::string, uint32_t> in1_receiver_named_compile_args = {
+        {"cb_in1", tt::CBIndex::c_1},
+        {"cb_bias", tt::CBIndex::c_3},
+        {"cb_out", tt::CBIndex::c_4},
+    };
+    if (use_global_cb) {
+        const std::initializer_list<std::pair<const std::string, uint32_t>> relay_args = {
+            {"mcast_in1_relay_go_sem", in1_mcast_relay_go_semaphore_id},
+            {"mcast_in1_num_relays", num_relay_cores},
+            {"mcast_in1_num_workers", num_cores},
+            {"mcast_in1_coordinator_noc_x", relay_coordinator_core_physical.x},
+            {"mcast_in1_coordinator_noc_y", relay_coordinator_core_physical.y},
+        };
+        in1_sender_named_compile_args.insert(relay_args);
+        in1_receiver_named_compile_args.insert(relay_args);
+        in1_sender_named_compile_args.emplace("cb_in1_prefetch", tt::CBIndex::c_8);
+        in1_sender_named_compile_args.emplace("mcast_in1_relay_stripe_w", relay_stripe_w_tiles);
+    }
+
     auto mm_kernel_in1_sender_writer_id = tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp",
-        in1_mcast_sender,
+        in1_mcast_senders,
         tt_metal::DataMovementConfig{
             .processor = tt_metal::DataMovementProcessor::RISCV_0,
             .noc = in1_noc,
             .compile_args = in1_sender_writer_compile_time_args,
             .defines = mm_kernel_in1_sender_writer_defines,
-            .named_compile_args = {
-                {"cb_in1", tt::CBIndex::c_1},
-                {"cb_bias", tt::CBIndex::c_3},
-                {"cb_out", tt::CBIndex::c_4},
-                {"cb_sparsity", tt::CBIndex::c_7},
-            }});
+            .named_compile_args = in1_sender_named_compile_args});
 
     tt::tt_metal::KernelHandle mm_kernel_in1_receiver_writer_id = 0;
     if (in1_mcast_receivers.num_cores() > 0) {
@@ -1599,11 +1672,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
                 .noc = in1_noc,
                 .compile_args = in1_receiver_writer_compile_time_args,
                 .defines = mm_kernel_in1_receiver_writer_defines,
-                .named_compile_args = {
-                    {"cb_in1", tt::CBIndex::c_1},
-                    {"cb_bias", tt::CBIndex::c_3},
-                    {"cb_out", tt::CBIndex::c_4},
-                }});
+                .named_compile_args = in1_receiver_named_compile_args});
     }
 
     // Compute kernel compile time args
@@ -1725,7 +1794,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
         tt_metal::CircularBufferConfig(in1_CB_size, {{src1_cb_index, in1_data_format}})
             .set_page_size(src1_cb_index, in1_aligned_tile_size)
             .set_tile_dims(src1_cb_index, in1_tile);
-    tt_metal::CreateCircularBuffer(program, all_cores, src1_cb_config);
+    auto cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, src1_cb_config);
     log_debug(
         LogOp,
         "CB {} :: PS = {}, NP = {}, TOTAL = {}",
@@ -1733,6 +1802,29 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
         in1_single_tile_size,
         in1_CB_size / in1_single_tile_size,
         in1_CB_size);
+
+    tt::tt_metal::CBHandle cb_in1_prefetch = 0;
+    if (use_global_cb) {
+        constexpr uint32_t prefetch_cb_index = tt::CBIndex::c_8;
+        constexpr uint32_t remote_cb_index = tt::CBIndex::c_31;
+        const uint32_t stripe_block_tiles = in0_block_w * relay_stripe_w_tiles;
+        const uint32_t stripe_block_bytes = stripe_block_tiles * in1_single_tile_size;
+        TT_FATAL(
+            global_cb->size() % stripe_block_bytes == 0,
+            "mcast-in1 global_cb size {} must be a multiple of stripe block size {}",
+            global_cb->size(),
+            stripe_block_bytes);
+        tt_metal::CircularBufferConfig remote_cb_config(global_cb->size());
+        remote_cb_config.remote_index(remote_cb_index)
+            .set_page_size(stripe_block_bytes)
+            .set_data_format(in1_data_format);
+        remote_cb_config.index(prefetch_cb_index)
+            .set_page_size(in1_single_tile_size)
+            .set_data_format(in1_data_format)
+            .set_tile_dims(in1_tile);
+        cb_in1_prefetch =
+            tt_metal::experimental::CreateCircularBuffer(program, in1_mcast_senders, remote_cb_config, *global_cb);
+    }
 
     uint32_t output_cb_index = tt::CBIndex::c_4;
     uint32_t interm0_cb_index = tt::CBIndex::c_5;
@@ -1833,18 +1925,32 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
     }
 
     const auto& cores = corerange_to_cores(all_cores, std::nullopt, row_major);
+    const auto relay_index_for_core = [&](const CoreCoord& core) -> uint32_t {
+        const auto& sender_mapping = global_cb->sender_receiver_core_mapping();
+        for (size_t relay_index = 0; relay_index < sender_mapping.size(); ++relay_index) {
+            const auto& receivers = sender_mapping[relay_index].second;
+            if (receivers.contains(core)) {
+                return static_cast<uint32_t>(relay_index);
+            }
+        }
+        TT_FATAL(false, "No DRAM-bank relay index found for mcast-in1 sender core {}", core);
+        return 0u;
+    };
     for (uint32_t i = 0; i < num_cores; ++i) {
         const auto& core = cores[i];
         uint32_t output_idx_x = i / num_blocks_y;
         uint32_t output_idx_y = i % num_blocks_y;
+        const bool is_in1_sender = use_global_cb ? in1_mcast_senders.contains(core) : core == start_core;
 
         // in0 sender and in1 sender
-        if (core == start_core) {
+        if (is_in1_sender) {
+            const uint32_t in1_source_index =
+                use_global_cb ? relay_index_for_core(core) : in1_tensor_start_tile_id_stride * output_idx_x;
             std::vector<uint32_t> mm_in1_sender_writer_args = {
                 // READER
                 // in1 tensor args
                 (std::uint32_t)in1_tensor.address(),
-                (std::uint32_t)in1_tensor_start_tile_id_stride * output_idx_x,  // in1_tensor_start_tile_id
+                in1_source_index,  // in1_tensor_start_tile_id or DRAM-bank relay index
                 // in1 mcast args
                 (std::uint32_t)start_core_noc.x,  // in1_mcast_dest_noc_start_x
                 (std::uint32_t)start_core_noc.y,  // in1_mcast_dest_noc_start_y
@@ -1893,8 +1999,8 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
             std::vector<uint32_t> mm_in1_receiver_writer_args = {
                 // READER
                 // in1 mcast args
-                (std::uint32_t)top_left_core_physical.x,  // in1_mcast_sender_noc_x
-                (std::uint32_t)top_left_core_physical.y,  // in1_mcast_sender_noc_y
+                (std::uint32_t)(use_global_cb ? relay_coordinator_core_physical.x : top_left_core_physical.x),
+                (std::uint32_t)(use_global_cb ? relay_coordinator_core_physical.y : top_left_core_physical.y),
 
                 // WRITER
                 // out tensor args
@@ -1962,7 +2068,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
     }
     return MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t{
         {mm_kernel_in0_sender_id, mm_kernel_in1_sender_writer_id, mm_kernel_in1_receiver_writer_id},
-        {cb_src0, cb_src2, cb_output},
+        {cb_src0, cb_src2, cb_output, cb_src1, cb_in1_prefetch},
         extract_shard_sub_blocks,
         start_core,
         cores,
@@ -2752,6 +2858,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_gather_in0
 inline void override_mcast_in1_program_parameters(
     tt_metal::Program& program,
     const MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t& override_variables,
+    const std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer>& global_cb,
     const ttnn::prim::MatmulInputs& tensor_args,
     const std::vector<ttnn::Tensor>& output_tensors) {
     const auto& input_tensors = tensor_args.input_tensors;
@@ -2782,14 +2889,29 @@ inline void override_mcast_in1_program_parameters(
 
     auto& reader_runtime_args_by_core = GetRuntimeArgs(program, override_variables.kernels.at(0));
 
-    // Manually unroll sender core
-    {
-        // in0 sender
+    auto& receiver_writer_runtime_args_by_core = GetRuntimeArgs(program, override_variables.kernels.at(2));
+
+    if (global_cb.has_value()) {
+        const auto& relay_cores = global_cb->receiver_cores();
+        auto& sender_writer_runtime_args_by_core = GetRuntimeArgs(program, override_variables.kernels.at(1));
+        for (const auto& core : override_variables.cores) {
+            reader_runtime_args_by_core[core.x][core.y][0] = src_a_tensor.address();
+            if (relay_cores.contains(core)) {
+                auto& sender_writer_runtime_args = sender_writer_runtime_args_by_core[core.x][core.y];
+                sender_writer_runtime_args[7] = dst_tensor.address();
+                if (bias_tensor.has_value()) {
+                    sender_writer_runtime_args[18] = bias_mesh_tensor->address();
+                }
+            } else {
+                receiver_writer_runtime_args_by_core[core.x][core.y][2] = dst_tensor.address();
+            }
+        }
+    } else {
+        // Manually unroll the single sender core.
         auto& reader_runtime_args =
             reader_runtime_args_by_core[override_variables.start_core.x][override_variables.start_core.y];
         reader_runtime_args[0] = src_a_tensor.address();
 
-        // in1 sender
         auto& sender_writer_runtime_args =
             GetRuntimeArgs(program, override_variables.kernels.at(1), override_variables.start_core);
         sender_writer_runtime_args[0] = src_b_tensor.address();
@@ -2797,21 +2919,12 @@ inline void override_mcast_in1_program_parameters(
         if (bias_tensor.has_value()) {
             sender_writer_runtime_args[18] = bias_mesh_tensor->address();
         }
-    }
 
-    auto& receiver_writer_runtime_args_by_core = GetRuntimeArgs(program, override_variables.kernels.at(2));
-
-    for (uint32_t i = 1; i < override_variables.cores.size(); ++i) {
-        const CoreCoord& core = override_variables.cores[i];
-
-        auto& reader_runtime_args = reader_runtime_args_by_core[core.x][core.y];
-
-        auto& writer_runtime_args = receiver_writer_runtime_args_by_core[core.x][core.y];
-
-        // in0 sender
-        reader_runtime_args[0] = src_a_tensor.address();
-        // in1 receiver
-        writer_runtime_args[2] = dst_tensor.address();
+        for (uint32_t i = 1; i < override_variables.cores.size(); ++i) {
+            const CoreCoord& core = override_variables.cores[i];
+            reader_runtime_args_by_core[core.x][core.y][0] = src_a_tensor.address();
+            receiver_writer_runtime_args_by_core[core.x][core.y][2] = dst_tensor.address();
+        }
     }
 
     if (src0_sharded) {
@@ -2959,7 +3072,8 @@ void override_program_parameters(
             break;
         }
         case ttnn::prim::Matmul1DType::MCAST_IN1:
-            override_mcast_in1_program_parameters(program, override_variables, tensor_args, tensor_return_value);
+            override_mcast_in1_program_parameters(
+                program, override_variables, global_cb, tensor_args, tensor_return_value);
             break;
     }
 }
@@ -5149,6 +5263,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_
         fused_activation,
         in0_tensor,
         in1_tensor,
+        global_cb,
         bias_mesh_tensor,
         output,
         in0_tile,

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -101,6 +101,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
     std::optional<UnaryWithParam> fused_activation,
     const MeshTensor& in0_tensor,
     const MeshTensor& in1_tensor,
+    const std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer>& global_cb,
     ttsl::optional_reference<const MeshTensor> bias_tensor,
     const MeshTensor& out_tensor,
     const tt::tt_metal::Tile& in0_tile,
@@ -120,6 +121,9 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
     bool row_broadcast_bias = true,
     CoreCoord sub_device_start_core = {0, 0}) {
     using tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids;
+
+    const bool use_global_cb = global_cb.has_value();
+    const bool in1_is_locally_sharded = in1_is_sharded && !use_global_cb;
 
     // currently only support transpose of the full tile
     bool in0_transpose_tile = in0_tile.get_transpose_of_faces() && in0_tile.get_transpose_within_face();
@@ -166,8 +170,9 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
     const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
     uint32_t in0_aligned_tile_size =
         in0_is_sharded ? in0_single_tile_size : tt::align(in0_single_tile_size, dram_alignment);
-    uint32_t in1_aligned_tile_size =
-        in1_is_sharded ? in1_single_tile_size : tt::align(in1_single_tile_size, dram_alignment);
+    uint32_t in1_aligned_tile_size = (in1_is_locally_sharded || use_global_cb)
+                                         ? in1_single_tile_size
+                                         : tt::align(in1_single_tile_size, dram_alignment);
     // Bias CB pages must be padded to the DRAM alignment so the reader's L1 write stride
     // matches the DRAM page stride (e.g. 64B on Blackhole for a 32B (1,16) bf16 bias tile).
     // Mirrors in0/in1 above. Sharded bias is backed by the L1 tensor buffer and keeps its
@@ -192,7 +197,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
     if (B * num_blocks > 1) {
         in1_CB_tiles *= operations::matmul::utilities::MCAST_INPUT_BUFFERING_DEPTH;
     }
-    if (in1_is_sharded) {
+    if (in1_is_locally_sharded) {
         uint32_t in1_shard_height_in_tiles = in1_tensor.shard_spec()->shape[0] / in1_tile.get_height();
         in1_CB_tiles = per_core_N * in1_shard_height_in_tiles;
     }
@@ -256,6 +261,13 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
 
     CoreRangeSet all_cores_with_work =
         num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores_with_work, matmul_core_rect, row_major);
+    if (use_global_cb) {
+        TT_FATAL(
+            global_cb->receiver_cores() == all_cores_with_work,
+            "mcast_in0 global_cb receivers {} must exactly match output worker cores {}",
+            global_cb->receiver_cores(),
+            all_cores_with_work);
+    }
     CoreRange in0_mcast_receiver_cores_bounding_box = all_cores_with_work.bounding_box();
     uint32_t in0_mcast_receiver_num_cores = in0_mcast_receiver_cores_bounding_box.size();  // always mcast to full grid
     uint32_t in0_mcast_receiver_num_dests = std::min(
@@ -531,8 +543,11 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
     ttnn::operations::compute_throttle_utils::throttle_mm_perf(
         device->arch(), num_cores, mm_kernel_defines, throttle_level);
 
-    if (in1_is_sharded) {
+    if (in1_is_locally_sharded) {
         mm_kernel_in1_sender_writer_defines["IN1_SHARDED"] = "1";
+    }
+    if (use_global_cb) {
+        mm_kernel_in1_sender_writer_defines["ENABLE_GLOBAL_CB"] = "1";
     }
 
     if (bias_is_sharded) {
@@ -771,23 +786,42 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
         in0_CB_size);
 
     uint32_t src1_cb_index = tt::CBIndex::c_1;
-    tt_metal::CircularBufferConfig src1_cb_config =
-        tt_metal::CircularBufferConfig(in1_CB_size, {{src1_cb_index, in1_data_format}})
-            .set_page_size(src1_cb_index, in1_aligned_tile_size)
-            .set_tile_dims(src1_cb_index, in1_tile);
-
-    if (in1_is_sharded) {
-        src1_cb_config = src1_cb_config.set_globally_allocated_address(in1_tensor);
+    tt::tt_metal::CBHandle cb_src1 = 0;
+    if (use_global_cb) {
+        const uint32_t remote_cb_index = tt::CBIndex::c_31;
+        const uint32_t in1_block_size_bytes = in1_block_tiles * in1_single_tile_size;
+        TT_FATAL(
+            global_cb->size() % in1_block_size_bytes == 0,
+            "mcast_in0 global_cb size {} must be a multiple of in1 K-block size {}",
+            global_cb->size(),
+            in1_block_size_bytes);
+        tt_metal::CircularBufferConfig remote_cb_config(global_cb->size());
+        remote_cb_config.remote_index(remote_cb_index)
+            .set_page_size(in1_block_size_bytes)
+            .set_data_format(in1_data_format);
+        remote_cb_config.index(src1_cb_index)
+            .set_page_size(in1_single_tile_size)
+            .set_data_format(in1_data_format)
+            .set_tile_dims(in1_tile);
+        cb_src1 =
+            tt_metal::experimental::CreateCircularBuffer(program, all_cores_with_work, remote_cb_config, *global_cb);
+    } else {
+        tt_metal::CircularBufferConfig src1_cb_config =
+            tt_metal::CircularBufferConfig(in1_CB_size, {{src1_cb_index, in1_data_format}})
+                .set_page_size(src1_cb_index, in1_aligned_tile_size)
+                .set_tile_dims(src1_cb_index, in1_tile);
+        if (in1_is_locally_sharded) {
+            src1_cb_config = src1_cb_config.set_globally_allocated_address(in1_tensor);
+        }
+        cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, src1_cb_config);
     }
-
-    auto cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, src1_cb_config);
     log_debug(
         LogOp,
         "CB {} :: PS = {}, NP = {}, TOTAL = {}",
         src1_cb_index,
         in1_single_tile_size,
-        in1_CB_size / in1_single_tile_size,
-        in1_CB_size);
+        use_global_cb ? global_cb->size() / in1_single_tile_size : in1_CB_size / in1_single_tile_size,
+        use_global_cb ? global_cb->size() : in1_CB_size);
 
     uint32_t src2_cb_index = tt::CBIndex::c_2;
     tt::tt_metal::CBHandle cb_src2 = 0;
@@ -4847,10 +4881,10 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_
     auto output_tile = tt::tt_metal::Tile({in0_tile.get_height(), in1_tile.get_width()});
 
     // CB dataformats
-    tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());          // in0
+    tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());  // in0
     const MeshTensor& in1_tensor = b.mesh_tensor();
     tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(in1_tensor.dtype());  // in1
-    tt::DataFormat output_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());  // output
+    tt::DataFormat output_data_format = tt_metal::datatype_to_dataformat_converter(output.dtype());   // output
 
     ttsl::optional_reference<const MeshTensor> bias_mesh_tensor;
     tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;  // bias; doesn't matter if bias=nullptr
@@ -5067,6 +5101,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t matmul_multi_core_
             fused_activation,
             in0_tensor,
             in1_tensor,
+            global_cb,
             bias_mesh_tensor,
             output,
             in0_tile,

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_receiver_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_receiver_writer_padding.cpp
@@ -100,6 +100,9 @@ void kernel_main() {
     CircularBuffer cb_out(cb_id_out0);
     Semaphore<> sender_sem(get_compile_time_arg_val(4));
     Semaphore<> receiver_sem(get_compile_time_arg_val(5));
+#ifdef ENABLE_GLOBAL_CB_MCAST_IN1
+    constexpr uint32_t num_relay_cores = get_named_compile_time_arg_val("mcast_in1_num_relays");
+#endif
 #ifdef FUSE_BIAS
     CircularBuffer cb_in3(cb_id_in3);
 #endif
@@ -119,6 +122,14 @@ void kernel_main() {
                     // Operand 1
                     cb_in1.reserve_back(in1_block_num_tiles);
 
+#ifdef ENABLE_GLOBAL_CB_MCAST_IN1
+                    // Announce that this worker has reserved the full in1 destination block.
+                    sender_sem.up(noc, in1_mcast_sender_noc_x, in1_mcast_sender_noc_y, 1);
+                    // Every relay writes one disjoint N stripe and increments this counter only
+                    // after its writes have landed on all workers.
+                    receiver_sem.wait_min(num_relay_cores);
+                    receiver_sem.set(0);
+#else
                     // Set in1 semaphore value to INVALID
                     receiver_sem.set(INVALID);
 
@@ -127,6 +138,7 @@ void kernel_main() {
 
                     // wait on in1 semaphore value to become VALID (set by mcast sender after it multicasts data)
                     receiver_sem.wait(VALID);
+#endif
 
                     cb_in1.push_back(in1_block_num_tiles);
                 }
@@ -137,6 +149,11 @@ void kernel_main() {
                     // Operand 2
                     cb_in3.reserve_back(in3_block_w);
 
+#ifdef ENABLE_GLOBAL_CB_MCAST_IN1
+                    sender_sem.up(noc, in1_mcast_sender_noc_x, in1_mcast_sender_noc_y, 1);
+                    receiver_sem.wait(VALID);
+                    receiver_sem.set(INVALID);
+#else
                     // Set in1 semaphore value to INVALID
                     receiver_sem.set(INVALID);
 
@@ -145,6 +162,7 @@ void kernel_main() {
 
                     // wait on in1 semaphore value to become VALID (set by mcast sender after it multicasts data)
                     receiver_sem.wait(VALID);
+#endif
 
                     cb_in3.push_back(in3_block_w);
                 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -183,7 +183,7 @@ void kernel_main() {
     constexpr uint32_t in1_aligned_tile_size_bytes =
         (in1_single_tile_size_bytes + (DRAM_ALIGNMENT - 1)) & ~(DRAM_ALIGNMENT - 1);
 #if !defined(IN1_SHARDED) && !defined(IN1_DRAM_WIDTH_SHARDED) && !defined(IN1_DRAM_HEIGHT_SHARDED) && \
-    !defined(ENABLE_GLOBAL_CB)
+    !defined(ENABLE_GLOBAL_CB) && !defined(ENABLE_GLOBAL_CB_MCAST_IN1)
     constexpr uint32_t in1_block_size_bytes = in1_block_num_tiles * in1_aligned_tile_size_bytes;
 #else
     constexpr uint32_t in1_block_size_bytes = in1_block_num_tiles * in1_single_tile_size_bytes;
@@ -198,6 +198,22 @@ void kernel_main() {
     CircularBuffer cb_out(cb_id_out0);
     Semaphore<> sender_sem(get_compile_time_arg_val(10));
     Semaphore<> receiver_sem(get_compile_time_arg_val(11));
+#ifdef ENABLE_GLOBAL_CB_MCAST_IN1
+    constexpr uint32_t relay_go_sem_id = get_named_compile_time_arg_val("mcast_in1_relay_go_sem");
+    constexpr uint32_t num_relay_cores = get_named_compile_time_arg_val("mcast_in1_num_relays");
+    constexpr uint32_t num_mcast_workers = get_named_compile_time_arg_val("mcast_in1_num_workers");
+    constexpr uint32_t relay_coordinator_noc_x = get_named_compile_time_arg_val("mcast_in1_coordinator_noc_x");
+    constexpr uint32_t relay_coordinator_noc_y = get_named_compile_time_arg_val("mcast_in1_coordinator_noc_y");
+    constexpr uint32_t relay_stripe_w = get_named_compile_time_arg_val("mcast_in1_relay_stripe_w");
+    constexpr uint32_t relay_stripe_tiles = relay_stripe_w * in1_block_h;
+    constexpr uint32_t relay_stripe_row_bytes = relay_stripe_w * in1_single_tile_size_bytes;
+    constexpr uint32_t full_in1_row_bytes = in1_block_w * in1_single_tile_size_bytes;
+    constexpr uint32_t prefetch_cb_id = get_named_compile_time_arg_val("cb_in1_prefetch");
+    constexpr uint32_t remote_cb_id = tt::CBIndex::c_31;
+    const uint32_t relay_index = in1_tensor_start_tile_id;
+    Semaphore<> relay_go_sem(relay_go_sem_id);
+    CircularBuffer cb_in1_prefetch(prefetch_cb_id);
+#endif
 #ifdef FUSE_BIAS
     CircularBuffer cb_in3(cb_id_in3);
 #endif
@@ -206,11 +222,11 @@ void kernel_main() {
 #ifdef IN1_SHARDED
     cb_in1.reserve_back(in1_block_num_tiles * num_blocks_inner_dim);
     cb_in1.push_back(in1_block_num_tiles * num_blocks_inner_dim);
-#elif !defined(ENABLE_GLOBAL_CB)
+#elif !defined(ENABLE_GLOBAL_CB) && !defined(ENABLE_GLOBAL_CB_MCAST_IN1)
     uint32_t l1_write_addr_in1;
 
     [[maybe_unused]] const auto s1 = TensorAccessor(in1_args, in1_tensor_addr);
-#endif  // IN1_SHARDED / ENABLE_GLOBAL_CB
+#endif  // IN1_SHARDED / global-CB modes
 
 #ifdef ENABLE_GLOBAL_CB
     constexpr uint32_t remote_cb_id = tt::CBIndex::c_31;
@@ -228,7 +244,7 @@ void kernel_main() {
     CircularBuffer cb_sparsity(cb_id_sparsity);
     const auto s_sparsity = TensorAccessor(sparsity_args, sparsity_addr);
 
-#ifndef SKIP_MCAST
+#if !defined(SKIP_MCAST) && !defined(ENABLE_GLOBAL_CB_MCAST_IN1)
     // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
     receiver_sem.set(VALID);
     // local address that will be atomically incremented by mcast receivers, to know when all receivers are ready
@@ -237,7 +253,7 @@ void kernel_main() {
 #ifdef IN1_SHARDED
     uint64_t in1_start_address = cb_in1.get_write_ptr();
 #endif  // IN1_SHARDED
-#endif  // SKIP_MCAST
+#endif  // !SKIP_MCAST && !ENABLE_GLOBAL_CB_MCAST_IN1
 
     uint32_t l1_write_addr_sparsity = 0;
     if constexpr (batchB > 0) {
@@ -301,7 +317,70 @@ void kernel_main() {
                             fused_op_receiver.update_current_block_start_tile_id(
                                 block, in1_tensor_current_inner_dim_block_start_tile_id, in1_batch_tile_id);
                         }
-#if defined(ENABLE_GLOBAL_CB)
+#if defined(ENABLE_GLOBAL_CB_MCAST_IN1)
+                        static_assert(num_mcast_workers > 1, "bank-striped mcast-in1 requires at least two workers");
+                        cb_in1.reserve_back(in1_block_num_tiles);
+                        cb_in1_prefetch.reserve_back(relay_stripe_tiles);
+                        experimental::remote_cb_wait_front(remote_cb_id, 1);
+                        cb_in1_prefetch.push_back(relay_stripe_tiles);
+
+                        // Use a NoC atomic even for the coordinator's own contribution; a local
+                        // read-modify-write can race remote atomic increments and lose readiness.
+                        sender_sem.up(noc, relay_coordinator_noc_x, relay_coordinator_noc_y, 1);
+                        if (relay_index == 0) {
+                            sender_sem.wait_min(num_mcast_workers);
+                            sender_sem.set(0);
+                            relay_go_sem.set(VALID);
+                            relay_go_sem.set_multicast<NocOptions::MCAST_INCL_SRC>(
+                                noc,
+                                in1_mcast_dest_noc_start_x,
+                                in1_mcast_dest_noc_start_y,
+                                in1_mcast_dest_noc_end_x,
+                                in1_mcast_dest_noc_end_y,
+                                num_mcast_workers);
+                        }
+                        relay_go_sem.wait(VALID);
+                        relay_go_sem.set(INVALID);
+
+                        uint32_t relay_src_addr = cb_in1_prefetch.get_read_ptr();
+                        uint32_t relay_dst_addr = cb_in1.get_write_ptr() + relay_index * relay_stripe_row_bytes;
+                        for (uint32_t h = 0; h < in1_block_h; ++h) {
+                            MulticastEndpoint mcast_dst;
+                            noc.async_write_multicast<NocOptions::MCAST_INCL_SRC>(
+                                CoreLocalMem<uint32_t>(relay_src_addr),
+                                mcast_dst,
+                                relay_stripe_row_bytes,
+                                num_mcast_workers,
+                                {},
+                                {.noc_x_start = in1_mcast_dest_noc_start_x,
+                                 .noc_y_start = in1_mcast_dest_noc_start_y,
+                                 .noc_x_end = in1_mcast_dest_noc_end_x,
+                                 .noc_y_end = in1_mcast_dest_noc_end_y,
+                                 .addr = relay_dst_addr},
+                                false);
+                            relay_src_addr += relay_stripe_row_bytes;
+                            relay_dst_addr += full_in1_row_bytes;
+                        }
+
+                        // The staging page cannot be returned to the DRAM-core prefetcher, and workers
+                        // cannot publish c1, until this relay's stripe has landed everywhere.
+                        noc.async_write_barrier();
+                        cb_in1_prefetch.pop_front(relay_stripe_tiles);
+                        experimental::remote_cb_pop_front(remote_cb_id, 1);
+
+                        const uint32_t noc_id = noc.get_noc_id();
+                        receiver_sem.up(noc, my_x[noc_id], my_y[noc_id], 1);
+                        receiver_sem.inc_multicast(
+                            noc,
+                            in1_mcast_dest_noc_start_x,
+                            in1_mcast_dest_noc_start_y,
+                            in1_mcast_dest_noc_end_x,
+                            in1_mcast_dest_noc_end_y,
+                            1,
+                            num_mcast_workers - 1);
+                        receiver_sem.wait_min(num_relay_cores);
+                        receiver_sem.set(0);
+#elif defined(ENABLE_GLOBAL_CB)
                         // The tensor prefetcher pushes this receiver's K-blocks in natural order.
                         // Keep one block of lookahead: publish the current block to compute, then
                         // wait for the unpack engine to drain the previous block before returning
@@ -426,7 +505,7 @@ void kernel_main() {
                         noc.async_read_barrier();
 #endif  // IN1_DRAM_WIDTH_SHARDED / IN1_DRAM_HEIGHT_SHARDED / IN1_SHARDED
 
-#ifndef SKIP_MCAST
+#if !defined(SKIP_MCAST) && !defined(ENABLE_GLOBAL_CB_MCAST_IN1)
                         // wait until all in1 mcast destinations have atomically incremented the in1 semaphore_addr
                         // (i.e. its value should be in0_mcast_num_dests), then reset the semaphore_addr value back to
                         // zero for the next block
@@ -468,7 +547,7 @@ void kernel_main() {
                             in1_mcast_dest_noc_end_x,
                             in1_mcast_dest_noc_end_y,
                             in1_mcast_num_cores);
-#endif  // SKIP_MCAST
+#endif  // !SKIP_MCAST && !ENABLE_GLOBAL_CB_MCAST_IN1
 
 #ifndef IN1_SHARDED
                         cb_in1.push_back(in1_block_num_tiles);
@@ -502,52 +581,56 @@ void kernel_main() {
                             cb_in3.get_write_ptr();         // copy start address of block, to be used for mcasting
                         uint32_t in3_block_size_bytes = 0;  // can be optimized later, pass it to kernel
 
+#ifdef ENABLE_GLOBAL_CB_MCAST_IN1
+                        if (relay_index == 0) {
+#endif
 #ifdef IN1_DRAM_WIDTH_SHARDED
-                        uint32_t l1_write_addr_in3_offset = 0;
-                        uint32_t next_bank_id_and_dram_stride_index = 0;
+                            uint32_t l1_write_addr_in3_offset = 0;
+                            uint32_t next_bank_id_and_dram_stride_index = 0;
 
-                        AllocatorBank<AllocatorBankType::DRAM> bias_dram_bank;
-                        for (uint32_t i = 0; i < num_dram_shards_to_read; ++i) {
-                            uint32_t bias_shard_bank_id = current_dram_bank_id[next_bank_id_and_dram_stride_index];
-                            uint32_t bias_shard_base_addr = in3_tensor_addr;
-                            if (i == 0) {
-                                // dram_tensor_start_offset is in in1 tile bytes; convert to
-                                // bias tile bytes since bias_dtype may differ from in1_dtype.
-                                bias_shard_base_addr += (dram_tensor_start_offset / in1_single_tile_size_bytes) *
-                                                        bias_single_tile_size_bytes;
-                            }
+                            AllocatorBank<AllocatorBankType::DRAM> bias_dram_bank;
+                            for (uint32_t i = 0; i < num_dram_shards_to_read; ++i) {
+                                uint32_t bias_shard_bank_id = current_dram_bank_id[next_bank_id_and_dram_stride_index];
+                                uint32_t bias_shard_base_addr = in3_tensor_addr;
+                                if (i == 0) {
+                                    // dram_tensor_start_offset is in in1 tile bytes; convert to
+                                    // bias tile bytes since bias_dtype may differ from in1_dtype.
+                                    bias_shard_base_addr += (dram_tensor_start_offset / in1_single_tile_size_bytes) *
+                                                            bias_single_tile_size_bytes;
+                                }
 
-                            noc.set_async_read_state<NocOptions::CUSTOM_VC, NOC_MAX_BURST_SIZE>(
-                                bias_dram_bank,
-                                bias_single_tile_size_bytes,
-                                {.bank_id = bias_shard_bank_id, .addr = bias_shard_base_addr},
-                                NocOptVals{.vc = vc});
-
-                            uint32_t l1_read_addr_in3 = 0;
-                            l1_write_addr_in3 = cb_in3.get_write_ptr() + l1_write_addr_in3_offset;
-                            // in1_block_w_dram_stride_bytes is in in1 tile bytes, so divide
-                            // by in1_single_tile_size_bytes (not bias) to get the tile count.
-                            uint32_t in3_block_w_dram =
-                                in1_block_w_dram_stride_bytes[next_bank_id_and_dram_stride_index] /
-                                in1_single_tile_size_bytes;
-
-                            for (uint32_t w = 0; w < in3_block_w_dram; ++w) {
-                                noc.async_read_with_state<NocOptions::CUSTOM_VC, NOC_MAX_BURST_SIZE>(
+                                noc.set_async_read_state<NocOptions::CUSTOM_VC, NOC_MAX_BURST_SIZE>(
                                     bias_dram_bank,
-                                    CoreLocalMem<uint32_t>(l1_write_addr_in3),
                                     bias_single_tile_size_bytes,
-                                    {.bank_id = bias_shard_bank_id, .addr = bias_shard_base_addr + l1_read_addr_in3},
-                                    {},
+                                    {.bank_id = bias_shard_bank_id, .addr = bias_shard_base_addr},
                                     NocOptVals{.vc = vc});
-                                l1_read_addr_in3 += bias_single_tile_size_bytes;
-                                l1_write_addr_in3 += bias_single_tile_size_bytes;
-                                in3_block_size_bytes += bias_single_tile_size_bytes;
+
+                                uint32_t l1_read_addr_in3 = 0;
+                                l1_write_addr_in3 = cb_in3.get_write_ptr() + l1_write_addr_in3_offset;
+                                // in1_block_w_dram_stride_bytes is in in1 tile bytes, so divide
+                                // by in1_single_tile_size_bytes (not bias) to get the tile count.
+                                uint32_t in3_block_w_dram =
+                                    in1_block_w_dram_stride_bytes[next_bank_id_and_dram_stride_index] /
+                                    in1_single_tile_size_bytes;
+
+                                for (uint32_t w = 0; w < in3_block_w_dram; ++w) {
+                                    noc.async_read_with_state<NocOptions::CUSTOM_VC, NOC_MAX_BURST_SIZE>(
+                                        bias_dram_bank,
+                                        CoreLocalMem<uint32_t>(l1_write_addr_in3),
+                                        bias_single_tile_size_bytes,
+                                        {.bank_id = bias_shard_bank_id,
+                                         .addr = bias_shard_base_addr + l1_read_addr_in3},
+                                        {},
+                                        NocOptVals{.vc = vc});
+                                    l1_read_addr_in3 += bias_single_tile_size_bytes;
+                                    l1_write_addr_in3 += bias_single_tile_size_bytes;
+                                    in3_block_size_bytes += bias_single_tile_size_bytes;
+                                }
+                                // Advance L1 offset in bias tile bytes, not in1 stride bytes.
+                                l1_write_addr_in3_offset += in3_block_w_dram * bias_single_tile_size_bytes;
+                                next_bank_id_and_dram_stride_index += 2;
                             }
-                            // Advance L1 offset in bias tile bytes, not in1 stride bytes.
-                            l1_write_addr_in3_offset += in3_block_w_dram * bias_single_tile_size_bytes;
-                            next_bank_id_and_dram_stride_index += 2;
-                        }
-                        noc.async_read_barrier();
+                            noc.async_read_barrier();
 #else
                         // Copy in1 block into CB, as the default kernel
                         uint32_t in3_tensor_tile_id = in3_tensor_current_w_dim_block_tile_id;
@@ -567,8 +650,44 @@ void kernel_main() {
                         // Barrier! make sure the reads are done
                         noc.async_read_barrier();
 #endif  // IN1_DRAM_WIDTH_SHARDED
+#ifdef ENABLE_GLOBAL_CB_MCAST_IN1
+                        }
+#endif
 
-#ifndef SKIP_MCAST
+#ifdef ENABLE_GLOBAL_CB_MCAST_IN1
+                        sender_sem.up(noc, relay_coordinator_noc_x, relay_coordinator_noc_y, 1);
+                        if (relay_index == 0) {
+                            sender_sem.wait_min(num_mcast_workers);
+                            sender_sem.set(0);
+
+                            MulticastEndpoint mcast_dst;
+                            noc.async_write_multicast(
+                                CoreLocalMem<uint32_t>(static_cast<uint32_t>(in3_start_address)),
+                                mcast_dst,
+                                in3_block_size_bytes,
+                                num_mcast_workers - 1,
+                                {},
+                                {.noc_x_start = in1_mcast_dest_noc_start_x,
+                                 .noc_y_start = in1_mcast_dest_noc_start_y,
+                                 .noc_x_end = in1_mcast_dest_noc_end_x,
+                                 .noc_y_end = in1_mcast_dest_noc_end_y,
+                                 .addr = static_cast<uint32_t>(in3_start_address)},
+                                true);
+#ifdef ARCH_BLACKHOLE
+                            noc.async_writes_flushed();
+#endif
+                            receiver_sem.set(VALID);
+                            receiver_sem.set_multicast(
+                                noc,
+                                in1_mcast_dest_noc_start_x,
+                                in1_mcast_dest_noc_start_y,
+                                in1_mcast_dest_noc_end_x,
+                                in1_mcast_dest_noc_end_y,
+                                num_mcast_workers - 1);
+                        }
+                        receiver_sem.wait(VALID);
+                        receiver_sem.set(INVALID);
+#elif !defined(SKIP_MCAST)
 
                         // wait until all in1 mcast destinations have atomically incremented the in1 semaphore_addr
                         // (i.e. its value should be in0_mcast_num_dests), then reset the semaphore_addr value back to
@@ -609,7 +728,7 @@ void kernel_main() {
                             in1_mcast_dest_noc_end_x,
                             in1_mcast_dest_noc_end_y,
                             in1_mcast_num_cores);
-#endif  // SKIP_MCAST
+#endif  // ENABLE_GLOBAL_CB_MCAST_IN1 / !SKIP_MCAST
 
                         cb_in3.push_back(in1_block_w);
 #else
@@ -716,7 +835,7 @@ void kernel_main() {
     cb_out.wait_front(
         batch * out_num_nonzero_subblocks_h * out_num_nonzero_subblocks_w * out_subblock_w * out_subblock_h);
 #endif
-#ifdef ENABLE_GLOBAL_CB
+#if defined(ENABLE_GLOBAL_CB) || defined(ENABLE_GLOBAL_CB_MCAST_IN1)
     experimental::update_remote_cb_config_in_l1(remote_cb_id);
     noc.async_atomic_barrier();
 #endif

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -10,6 +10,7 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/noc_semaphore.h"
+#include "api/remote_circular_buffer.h"
 #include "api/tensor/noc_traits.h"
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
@@ -181,7 +182,8 @@ void kernel_main() {
     // keep their natural (unpadded) stride.
     constexpr uint32_t in1_aligned_tile_size_bytes =
         (in1_single_tile_size_bytes + (DRAM_ALIGNMENT - 1)) & ~(DRAM_ALIGNMENT - 1);
-#if !defined(IN1_SHARDED) && !defined(IN1_DRAM_WIDTH_SHARDED) && !defined(IN1_DRAM_HEIGHT_SHARDED)
+#if !defined(IN1_SHARDED) && !defined(IN1_DRAM_WIDTH_SHARDED) && !defined(IN1_DRAM_HEIGHT_SHARDED) && \
+    !defined(ENABLE_GLOBAL_CB)
     constexpr uint32_t in1_block_size_bytes = in1_block_num_tiles * in1_aligned_tile_size_bytes;
 #else
     constexpr uint32_t in1_block_size_bytes = in1_block_num_tiles * in1_single_tile_size_bytes;
@@ -204,11 +206,16 @@ void kernel_main() {
 #ifdef IN1_SHARDED
     cb_in1.reserve_back(in1_block_num_tiles * num_blocks_inner_dim);
     cb_in1.push_back(in1_block_num_tiles * num_blocks_inner_dim);
-#else
+#elif !defined(ENABLE_GLOBAL_CB)
     uint32_t l1_write_addr_in1;
 
     [[maybe_unused]] const auto s1 = TensorAccessor(in1_args, in1_tensor_addr);
-#endif  // IN1_SHARDED
+#endif  // IN1_SHARDED / ENABLE_GLOBAL_CB
+
+#ifdef ENABLE_GLOBAL_CB
+    constexpr uint32_t remote_cb_id = tt::CBIndex::c_31;
+    const uint32_t in1_fifo_tiles = get_local_cb_interface(cb_id_in1).fifo_num_pages;
+#endif
 
     //  WRITER
     const auto s = TensorAccessor(out_args, out_tensor_addr);
@@ -294,7 +301,14 @@ void kernel_main() {
                             fused_op_receiver.update_current_block_start_tile_id(
                                 block, in1_tensor_current_inner_dim_block_start_tile_id, in1_batch_tile_id);
                         }
-#if defined(IN1_DRAM_WIDTH_SHARDED)
+#if defined(ENABLE_GLOBAL_CB)
+                        // The tensor prefetcher pushes this receiver's K-blocks in natural order.
+                        // Keep one block of lookahead: publish the current block to compute, then
+                        // wait for the unpack engine to drain the previous block before returning
+                        // its remote-CB credit to the prefetcher.
+                        cb_in1.reserve_back(in1_block_num_tiles);
+                        experimental::remote_cb_wait_front(remote_cb_id, block == 0 ? 1u : 2u);
+#elif defined(IN1_DRAM_WIDTH_SHARDED)
                         // Operand 1 - DRAM width sharded
                         cb_in1.reserve_back(in1_block_num_tiles);
 
@@ -327,9 +341,7 @@ void kernel_main() {
                                 uint32_t l1_read_addr_in1_temp = l1_read_addr_in1;
                                 uint32_t l1_write_addr_in1_temp = l1_write_addr_in1;
                                 for (uint32_t w = 0; w < in1_block_w_dram; ++w) {
-                                    noc.async_read_with_state<
-                                        NocOptions::CUSTOM_VC,
-                                        NOC_MAX_BURST_SIZE>(
+                                    noc.async_read_with_state<NocOptions::CUSTOM_VC, NOC_MAX_BURST_SIZE>(
                                         dram_bank,
                                         CoreLocalMem<uint32_t>(l1_write_addr_in1_temp),
                                         in1_single_tile_size_bytes,
@@ -461,7 +473,23 @@ void kernel_main() {
 #ifndef IN1_SHARDED
                         cb_in1.push_back(in1_block_num_tiles);
 #endif  // IN1_SHARDED
+#ifdef ENABLE_GLOBAL_CB
+                        if (block >= 1) {
+                            while (!cb_in1.pages_reservable_at_back(in1_fifo_tiles - in1_block_num_tiles)) {
+                                invalidate_l1_cache();
+                            }
+                            experimental::remote_cb_pop_front(remote_cb_id, 1);
+                        }
+#endif
                     }
+#ifdef ENABLE_GLOBAL_CB
+                    if (num_blocks_inner_dim > 0) {
+                        while (!cb_in1.pages_reservable_at_back(in1_fifo_tiles)) {
+                            invalidate_l1_cache();
+                        }
+                        experimental::remote_cb_pop_front(remote_cb_id, 1);
+                    }
+#endif
 #ifdef FUSE_BIAS
                     // Only read bias on first batch, or we have multiple output blocks
                     if ((b == 0 && bh == 0) || num_blocks_w_dim > 1) {
@@ -625,8 +653,7 @@ void kernel_main() {
                                 for (uint32_t w = 0; w < out_subblock_w_; ++w) {
                                     if (bw < num_blocks_w_dim_) {
                                         noc.async_write(
-                                            use<CircularBuffer::AddrSelector::READ_PTR>(
-                                                cb_out),
+                                            use<CircularBuffer::AddrSelector::READ_PTR>(cb_out),
                                             s,
                                             output_single_tile_size_bytes,
                                             {.offset_bytes = out_read_offset},
@@ -688,6 +715,10 @@ void kernel_main() {
 #if OUT_SHARDED
     cb_out.wait_front(
         batch * out_num_nonzero_subblocks_h * out_num_nonzero_subblocks_w * out_subblock_w * out_subblock_h);
+#endif
+#ifdef ENABLE_GLOBAL_CB
+    experimental::update_remote_cb_config_in_l1(remote_cb_id);
+    noc.async_atomic_barrier();
 #endif
     noc.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -1033,6 +1033,89 @@ void validate_dram_sender_global_cb_gather_in0_geometry_recv_contig(
         ring_size);
 }
 
+void validate_dram_sender_global_cb_mcast_in0_geometry(
+    const tt::tt_metal::experimental::GlobalCircularBuffer& gcb,
+    const Tensor& input_tensor_b,
+    const ttnn::Shape& b_shape_padded,
+    const tt::tt_metal::Tile& in1_tile,
+    const operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig& program_config) {
+    TT_FATAL(
+        tt::tt_metal::experimental::sender_core_type(gcb) == tt::tt_metal::experimental::SenderCoreType::Dram,
+        "mcast_in0 global_cb requires programmable DRAM senders");
+    TT_FATAL(
+        input_tensor_b.buffer() != nullptr && input_tensor_b.buffer()->is_dram(),
+        "mcast_in0 global_cb requires an in1 weight in DRAM");
+    TT_FATAL(
+        input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::ND_SHARDED,
+        "mcast_in0 global_cb requires a receiver-contiguous ND_SHARDED in1 weight, but got {}",
+        input_tensor_b.memory_config().memory_layout());
+    TT_FATAL(
+        !program_config.stream_in1,
+        "mcast_in0 global_cb consumes natural-order K-blocks and requires stream_in1=false");
+    TT_FATAL(program_config.in0_block_w > 0, "mcast_in0 global_cb requires in0_block_w > 0");
+    TT_FATAL(
+        program_config.out_block_h == program_config.per_core_M &&
+            program_config.out_block_w == program_config.per_core_N,
+        "mcast_in0 global_cb requires one output block per worker: out_block_h ({}) must equal per_core_M ({}) "
+        "and out_block_w ({}) must equal per_core_N ({})",
+        program_config.out_block_h,
+        program_config.per_core_M,
+        program_config.out_block_w,
+        program_config.per_core_N);
+
+    const uint32_t receiver_count = gcb.receiver_cores().num_cores();
+    TT_FATAL(receiver_count > 0, "mcast_in0 global_cb has no receivers");
+    const uint32_t weight_K_tiles = b_shape_padded[-2] / in1_tile.get_height();
+    const uint32_t weight_N_tiles = b_shape_padded[-1] / in1_tile.get_width();
+    TT_FATAL(
+        weight_K_tiles % program_config.in0_block_w == 0,
+        "mcast_in0 global_cb weight K ({} tiles) must be divisible by in0_block_w ({}); remainder {}",
+        weight_K_tiles,
+        program_config.in0_block_w,
+        weight_K_tiles % program_config.in0_block_w);
+    TT_FATAL(
+        weight_N_tiles == receiver_count * program_config.per_core_N,
+        "mcast_in0 global_cb weight N ({} tiles) must equal receiver_count ({}) * per_core_N ({}) = {}",
+        weight_N_tiles,
+        receiver_count,
+        program_config.per_core_N,
+        receiver_count * program_config.per_core_N);
+    const uint32_t in1_block_size_bytes =
+        program_config.in0_block_w * program_config.per_core_N *
+        in1_tile.get_tile_size(tt::tt_metal::datatype_to_dataformat_converter(input_tensor_b.dtype()));
+    TT_FATAL(
+        gcb.size() % in1_block_size_bytes == 0,
+        "mcast_in0 global_cb size {} must be a multiple of its in1 K-block page size {}",
+        gcb.size(),
+        in1_block_size_bytes);
+    TT_FATAL(
+        gcb.size() >= 2 * in1_block_size_bytes,
+        "mcast_in0 global_cb requires a two-page streaming window: size {} must be at least {}",
+        gcb.size(),
+        2 * in1_block_size_bytes);
+
+    const auto& nd_shard_spec = input_tensor_b.nd_shard_spec();
+    TT_FATAL(nd_shard_spec.has_value(), "mcast_in0 global_cb weight must have an NdShardSpec");
+    TT_FATAL(
+        nd_shard_spec->shard_shape.rank() == 2,
+        "mcast_in0 global_cb weight shard shape must be 2D, but got rank {}",
+        nd_shard_spec->shard_shape.rank());
+    TT_FATAL(
+        nd_shard_spec->shard_shape[0] == static_cast<uint32_t>(b_shape_padded[-2]) &&
+            nd_shard_spec->shard_shape[1] == static_cast<uint32_t>(program_config.per_core_N) * in1_tile.get_width(),
+        "mcast_in0 global_cb weight shard shape {} must be (K={}, per_core_N*tile_width={})",
+        nd_shard_spec->shard_shape,
+        b_shape_padded[-2],
+        program_config.per_core_N * in1_tile.get_width());
+    const auto& distribution = input_tensor_b.buffer()->buffer_distribution_spec();
+    TT_FATAL(distribution.has_value(), "mcast_in0 global_cb weight must have a BufferDistributionSpec");
+    TT_FATAL(
+        distribution->num_shards() == receiver_count,
+        "mcast_in0 global_cb weight has {} shards but the GCB has {} receivers",
+        distribution->num_shards(),
+        receiver_count);
+}
+
 // Helper: warns if a caller of MatmulDeviceOperation's static API hasn't populated
 // allowed_worker_cores on a program_config variant that supports the field. ttnn::prim::matmul()
 // normalizes its attributes before launch, but direct callers (e.g. CCL fused ops in
@@ -1713,6 +1796,26 @@ void validate_matmul_mcast1d_config(
         "{}: Matmul1D does not support mcast_in0 and gather_in0 at the "
         "same time.",
         config_name);
+    TT_FATAL(
+        program_config.gather_in0 || !program_config.stream_in1,
+        "{}: stream_in1 is the gather_in0 ring-rotation mode and requires gather_in0=true",
+        config_name);
+
+    if (attributes.global_cb.has_value() && !program_config.gather_in0) {
+        TT_FATAL(
+            program_config.mcast_in0,
+            "{}: global_cb without gather_in0 is supported only for mcast_in0=true",
+            config_name);
+        validate_dram_sender_global_cb_mcast_in0_geometry(
+            attributes.global_cb.value(), input_tensor_b, b_shape_padded, in1_tile, program_config);
+        TT_FATAL(
+            program_config.fuse_batch || get_batch_size(a_shape_padded) == 1,
+            "{}: mcast_in0 global_cb requires one effective activation batch, but fuse_batch={} and "
+            "activation batch size={}",
+            config_name,
+            program_config.fuse_batch,
+            get_batch_size(a_shape_padded));
+    }
 
     // Gather in0 specific validation
     if (program_config.gather_in0) {
@@ -1813,7 +1916,9 @@ void validate_matmul_mcast1d_config(
     } else {
         const auto device_grid_1d = input_tensor_a.device()->compute_with_storage_grid_size();
         check_tensor_in_grid(input_tensor_a, device_grid_1d);
-        check_tensor_in_grid(input_tensor_b, device_grid_1d);
+        if (!attributes.global_cb.has_value()) {
+            check_tensor_in_grid(input_tensor_b, device_grid_1d);
+        }
     }
     if (program_config.mcast_in0 || program_config.gather_in0) {
         if (input_tensor_a.is_sharded()) {
@@ -2065,7 +2170,7 @@ MatmulDeviceOperation::program_factory_t MatmulDeviceOperation::select_program_f
     const auto& config = operation_attributes.program_config.value();
 
     return std::visit(
-        [](const auto& c) -> program_factory_t {
+        [&operation_attributes](const auto& c) -> program_factory_t {
             using T = std::decay_t<decltype(c)>;
             if constexpr (std::is_same_v<T, operations::matmul::MatmulMultiCoreProgramConfig>) {
                 return MatmulMultiCoreProgramFactory{};
@@ -2074,8 +2179,9 @@ MatmulDeviceOperation::program_factory_t MatmulDeviceOperation::select_program_f
             } else if constexpr (std::is_same_v<T, operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig>) {
                 return MatmulMultiCoreReuseMcast2DProgramFactory{};
             } else if constexpr (std::is_same_v<T, operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
-                // gather_in0 uses the legacy MeshWorkload path (create_descriptor not yet supported)
-                if (c.gather_in0) {
+                // GCB-backed paths use the legacy MeshWorkload builder because ProgramDescriptor
+                // cannot attach an experimental GlobalCircularBuffer.
+                if (c.gather_in0 || (c.mcast_in0 && operation_attributes.global_cb.has_value())) {
                     return MatmulMeshWorkloadMultiCoreReuseMcast1DProgramFactory{};
                 }
                 return MatmulMultiCoreReuseMcast1DProgramFactory{};

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -11,6 +11,7 @@
 #include "ttnn/operations/matmul/device/utilities/matmul_utilities.hpp"
 #include "tt-metalium/hal_types.hpp"
 #include "tt-metalium/experimental/global_circular_buffer.hpp"
+#include "ttnn/global_circular_buffer.hpp"
 #include "tt-metalium/work_split.hpp"
 #include "tt_stl/reflection.hpp"
 #include "tt_stl/unreachable.hpp"
@@ -1036,23 +1037,11 @@ void validate_dram_sender_global_cb_gather_in0_geometry_recv_contig(
 void validate_dram_sender_global_cb_mcast_in0_geometry(
     const tt::tt_metal::experimental::GlobalCircularBuffer& gcb,
     const Tensor& input_tensor_b,
-    const ttnn::Shape& b_shape_padded,
     const tt::tt_metal::Tile& in1_tile,
     const operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig& program_config) {
     TT_FATAL(
         tt::tt_metal::experimental::sender_core_type(gcb) == tt::tt_metal::experimental::SenderCoreType::Dram,
         "mcast_in0 global_cb requires programmable DRAM senders");
-    TT_FATAL(
-        input_tensor_b.buffer() != nullptr && input_tensor_b.buffer()->is_dram(),
-        "mcast_in0 global_cb requires an in1 weight in DRAM");
-    TT_FATAL(
-        input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::ND_SHARDED,
-        "mcast_in0 global_cb requires a receiver-contiguous ND_SHARDED in1 weight, but got {}",
-        input_tensor_b.memory_config().memory_layout());
-    TT_FATAL(
-        !program_config.stream_in1,
-        "mcast_in0 global_cb consumes natural-order K-blocks and requires stream_in1=false");
-    TT_FATAL(program_config.in0_block_w > 0, "mcast_in0 global_cb requires in0_block_w > 0");
     TT_FATAL(
         program_config.out_block_h == program_config.per_core_M &&
             program_config.out_block_w == program_config.per_core_N,
@@ -1063,23 +1052,14 @@ void validate_dram_sender_global_cb_mcast_in0_geometry(
         program_config.out_block_w,
         program_config.per_core_N);
 
-    const uint32_t receiver_count = gcb.receiver_cores().num_cores();
-    TT_FATAL(receiver_count > 0, "mcast_in0 global_cb has no receivers");
-    const uint32_t weight_K_tiles = b_shape_padded[-2] / in1_tile.get_height();
-    const uint32_t weight_N_tiles = b_shape_padded[-1] / in1_tile.get_width();
-    TT_FATAL(
-        weight_K_tiles % program_config.in0_block_w == 0,
-        "mcast_in0 global_cb weight K ({} tiles) must be divisible by in0_block_w ({}); remainder {}",
-        weight_K_tiles,
-        program_config.in0_block_w,
-        weight_K_tiles % program_config.in0_block_w);
-    TT_FATAL(
-        weight_N_tiles == receiver_count * program_config.per_core_N,
-        "mcast_in0 global_cb weight N ({} tiles) must equal receiver_count ({}) * per_core_N ({}) = {}",
-        weight_N_tiles,
-        receiver_count,
-        program_config.per_core_N,
-        receiver_count * program_config.per_core_N);
+    // The receiver-contiguous weight ↔ matmul cross-checks (DRAM NdShardSpec, one full-K × per_core_N
+    // shard per receiver, num_shards == receiver_count, K % in0_block_w == 0, per_core_N == per-receiver
+    // N, stream_in1 == false) are owned by the shared prefetcher helper. Call it rather than re-deriving
+    // them here, so the recv-contig contract lives in one place.
+    ttnn::global_circular_buffer::tensor_prefetcher_block_count_for_matmul_1d(program_config, input_tensor_b, gcb);
+
+    // GCB-window guards specific to this op: the mcast reader streams K-blocks through a two-page
+    // remote-CB window, so the GCB must be an exact multiple of the in1 K-block page and hold >= 2 pages.
     const uint32_t in1_block_size_bytes =
         program_config.in0_block_w * program_config.per_core_N *
         in1_tile.get_tile_size(tt::tt_metal::datatype_to_dataformat_converter(input_tensor_b.dtype()));
@@ -1093,27 +1073,6 @@ void validate_dram_sender_global_cb_mcast_in0_geometry(
         "mcast_in0 global_cb requires a two-page streaming window: size {} must be at least {}",
         gcb.size(),
         2 * in1_block_size_bytes);
-
-    const auto& nd_shard_spec = input_tensor_b.nd_shard_spec();
-    TT_FATAL(nd_shard_spec.has_value(), "mcast_in0 global_cb weight must have an NdShardSpec");
-    TT_FATAL(
-        nd_shard_spec->shard_shape.rank() == 2,
-        "mcast_in0 global_cb weight shard shape must be 2D, but got rank {}",
-        nd_shard_spec->shard_shape.rank());
-    TT_FATAL(
-        nd_shard_spec->shard_shape[0] == static_cast<uint32_t>(b_shape_padded[-2]) &&
-            nd_shard_spec->shard_shape[1] == static_cast<uint32_t>(program_config.per_core_N) * in1_tile.get_width(),
-        "mcast_in0 global_cb weight shard shape {} must be (K={}, per_core_N*tile_width={})",
-        nd_shard_spec->shard_shape,
-        b_shape_padded[-2],
-        program_config.per_core_N * in1_tile.get_width());
-    const auto& distribution = input_tensor_b.buffer()->buffer_distribution_spec();
-    TT_FATAL(distribution.has_value(), "mcast_in0 global_cb weight must have a BufferDistributionSpec");
-    TT_FATAL(
-        distribution->num_shards() == receiver_count,
-        "mcast_in0 global_cb weight has {} shards but the GCB has {} receivers",
-        distribution->num_shards(),
-        receiver_count);
 }
 
 // Helper: warns if a caller of MatmulDeviceOperation's static API hasn't populated
@@ -1807,7 +1766,7 @@ void validate_matmul_mcast1d_config(
             "{}: global_cb without gather_in0 is supported only for mcast_in0=true",
             config_name);
         validate_dram_sender_global_cb_mcast_in0_geometry(
-            attributes.global_cb.value(), input_tensor_b, b_shape_padded, in1_tile, program_config);
+            attributes.global_cb.value(), input_tensor_b, in1_tile, program_config);
         TT_FATAL(
             program_config.fuse_batch || get_batch_size(a_shape_padded) == 1,
             "{}: mcast_in0 global_cb requires one effective activation batch, but fuse_batch={} and "
@@ -2179,9 +2138,10 @@ MatmulDeviceOperation::program_factory_t MatmulDeviceOperation::select_program_f
             } else if constexpr (std::is_same_v<T, operations::matmul::MatmulMultiCoreReuseMultiCastProgramConfig>) {
                 return MatmulMultiCoreReuseMcast2DProgramFactory{};
             } else if constexpr (std::is_same_v<T, operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
-                // GCB-backed paths use the legacy MeshWorkload builder because ProgramDescriptor
-                // cannot attach an experimental GlobalCircularBuffer.
-                if (c.gather_in0 || (c.mcast_in0 && operation_attributes.global_cb.has_value())) {
+                // gather_in0 (create_descriptor not yet supported) and any GCB-backed config
+                // (ProgramDescriptor cannot attach an experimental GlobalCircularBuffer) use the legacy
+                // MeshWorkload builder.
+                if (c.gather_in0 || operation_attributes.global_cb.has_value()) {
                     return MatmulMeshWorkloadMultiCoreReuseMcast1DProgramFactory{};
                 }
                 return MatmulMultiCoreReuseMcast1DProgramFactory{};

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -1075,6 +1075,85 @@ void validate_dram_sender_global_cb_mcast_in0_geometry(
         2 * in1_block_size_bytes);
 }
 
+void validate_dram_sender_global_cb_mcast_in1_geometry(
+    const tt::tt_metal::experimental::GlobalCircularBuffer& gcb,
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const ttnn::Shape& a_shape_padded,
+    const tt::tt_metal::Tile& in0_tile,
+    const tt::tt_metal::Tile& in1_tile,
+    const operations::matmul::MatmulMultiCoreReuseMultiCast1DProgramConfig& program_config,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    TT_FATAL(
+        tt::tt_metal::experimental::sender_core_type(gcb) == tt::tt_metal::experimental::SenderCoreType::Dram,
+        "mcast-in1 global_cb requires programmable DRAM senders");
+    TT_FATAL(
+        program_config.out_block_h == program_config.per_core_M &&
+            program_config.out_block_w == program_config.per_core_N,
+        "mcast-in1 global_cb requires one output block per worker: out_block_h ({}) must equal per_core_M ({}) "
+        "and out_block_w ({}) must equal per_core_N ({})",
+        program_config.out_block_h,
+        program_config.per_core_M,
+        program_config.out_block_w,
+        program_config.per_core_N);
+
+    // Own the weight/GCB page contract in one shared helper: one full-K, N/num_banks WIDTH_SHARDED
+    // stripe per relay, one relay per dense bank, exact K blocking, and a two-page FIFO window.
+    ttnn::global_circular_buffer::tensor_prefetcher_block_count_for_matmul_1d(program_config, input_tensor_b, gcb);
+
+    const uint32_t M = operations::matmul::utilities::get_M_dim(a_shape_padded, in0_tile, program_config.fuse_batch);
+    const uint32_t num_workers = tt::div_up(M, static_cast<uint32_t>(program_config.per_core_M));
+    TT_FATAL(num_workers > 1, "bank-striped mcast-in1 requires at least two active matmul workers");
+    const auto& grid = program_config.compute_with_storage_grid_size;
+    const uint32_t grid_capacity = grid.x * grid.y;
+    TT_FATAL(
+        num_workers <= grid_capacity,
+        "mcast-in1 requires {} workers for M={} and per_core_M={}, but compute grid {}x{} has capacity {}",
+        num_workers,
+        M,
+        program_config.per_core_M,
+        grid.x,
+        grid.y,
+        grid_capacity);
+
+    CoreCoord start_core = {0, 0};
+    if (sub_device_id.has_value()) {
+        const auto sub_device_workers =
+            input_tensor_a.device()->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sub_device_id.value());
+        start_core = sub_device_workers.bounding_box().start_coord;
+    }
+    const CoreRangeSet matmul_rect(
+        CoreRange(start_core, CoreCoord(start_core.x + grid.x - 1, start_core.y + grid.y - 1)));
+    const auto active_workers = tt::tt_metal::num_cores_to_corerangeset_in_subcoregrids(
+        start_core, num_workers, matmul_rect, /*row_wise=*/true);
+    const auto active_bbox = active_workers.bounding_box();
+    TT_FATAL(
+        active_workers.num_cores() == active_bbox.size(),
+        "bank-striped mcast-in1 requires the active worker set to fill one rectangle; {} workers in grid {}x{} "
+        "produce a partial rectangle {}",
+        num_workers,
+        grid.x,
+        grid.y,
+        active_bbox);
+    TT_FATAL(
+        active_workers.contains(gcb.receiver_cores()),
+        "Every mcast-in1 GCB relay must be an active matmul worker. Active workers: {}; GCB relays: {}",
+        active_workers,
+        gcb.receiver_cores());
+    TT_FATAL(
+        gcb.receiver_cores().num_cores() <= num_workers,
+        "mcast-in1 has {} relay workers but only {} active matmul workers",
+        gcb.receiver_cores().num_cores(),
+        num_workers);
+
+    const uint32_t weight_N_tiles = static_cast<uint32_t>(input_tensor_b.padded_shape()[-1]) / in1_tile.get_width();
+    TT_FATAL(
+        program_config.per_core_N == weight_N_tiles,
+        "mcast-in1 per_core_N ({}) must equal full weight N ({} tiles)",
+        program_config.per_core_N,
+        weight_N_tiles);
+}
+
 // Helper: warns if a caller of MatmulDeviceOperation's static API hasn't populated
 // allowed_worker_cores on a program_config variant that supports the field. ttnn::prim::matmul()
 // normalizes its attributes before launch, but direct callers (e.g. CCL fused ops in
@@ -1761,15 +1840,24 @@ void validate_matmul_mcast1d_config(
         config_name);
 
     if (attributes.global_cb.has_value() && !program_config.gather_in0) {
-        TT_FATAL(
-            program_config.mcast_in0,
-            "{}: global_cb without gather_in0 is supported only for mcast_in0=true",
-            config_name);
-        validate_dram_sender_global_cb_mcast_in0_geometry(
-            attributes.global_cb.value(), input_tensor_b, in1_tile, program_config);
+        if (program_config.mcast_in0) {
+            validate_dram_sender_global_cb_mcast_in0_geometry(
+                attributes.global_cb.value(), input_tensor_b, in1_tile, program_config);
+        } else {
+            TT_FATAL(!attributes.transpose_b, "{}: mcast-in1 global_cb does not support transpose_b", config_name);
+            validate_dram_sender_global_cb_mcast_in1_geometry(
+                attributes.global_cb.value(),
+                input_tensor_a,
+                input_tensor_b,
+                a_shape_padded,
+                in0_tile,
+                in1_tile,
+                program_config,
+                attributes.sub_device_id);
+        }
         TT_FATAL(
             program_config.fuse_batch || get_batch_size(a_shape_padded) == 1,
-            "{}: mcast_in0 global_cb requires one effective activation batch, but fuse_batch={} and "
+            "{}: GCB-backed multicast requires one effective activation batch, but fuse_batch={} and "
             "activation batch size={}",
             config_name,
             program_config.fuse_batch,
@@ -2052,11 +2140,21 @@ void validate_matmul_mcast1d_config(
                 program_config.out_block_h,
                 per_core_N);
         }
-        TT_FATAL(
-            input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
-            "{}: input B must be INTERLEAVED, got: {}",
-            config_name,
-            input_tensor_b.memory_config().memory_layout());
+        if (attributes.global_cb.has_value()) {
+            TT_FATAL(
+                input_tensor_b.buffer()->buffer_type() == tt_metal::BufferType::DRAM &&
+                    input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED,
+                "{}: GCB-backed mcast-in1 requires a WIDTH_SHARDED DRAM input B, got buffer type {} and layout {}",
+                config_name,
+                input_tensor_b.buffer()->buffer_type(),
+                input_tensor_b.memory_config().memory_layout());
+        } else {
+            TT_FATAL(
+                input_tensor_b.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
+                "{}: input B must be INTERLEAVED, got: {}",
+                config_name,
+                input_tensor_b.memory_config().memory_layout());
+        }
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
@@ -522,12 +522,10 @@ void py_module(nb::module_& mod) {
             compute grid. Accepts a ``CoreRangeSet`` describing the exact cores to use.
         )doc")
         .def_rw("stream_in1", &MatmulMultiCoreReuseMultiCast1DProgramConfig::stream_in1, R"doc(
-            Stream in1 weights from the GCB in ring-rotated FIFO order (gather_in0 + DRAM-sender
-            GCB only). When true, each weight block is consumed as it arrives instead of waiting
-            for the whole tensor, so the GCB can be sized to a small live window. The weight MUST
-            be queued for streaming (the ``(weight, block_count, rotation)`` form of
-            ``queue_tensor_prefetcher_request``, passing the per-receiver ring-rotation list) to
-            match, else the matmul deadlocks. Defaults to false.
+            Select ring-rotated FIFO delivery for gather_in0 with a DRAM-sender GCB. The weight
+            MUST be queued with the ``(weight, block_count, rotation)`` request form. GCB-backed
+            mcast_in0 consumes natural FIFO order and requires this flag to remain false.
+            Defaults to false.
         )doc")
         .def("__repr__", [](const MatmulMultiCoreReuseMultiCast1DProgramConfig& config) {
             return fmt::format(

--- a/ttnn/ttnn/_experimental/tensor_prefetcher_matmul.py
+++ b/ttnn/ttnn/_experimental/tensor_prefetcher_matmul.py
@@ -67,8 +67,11 @@ def prefetch_and_linear(
         # Gather consumes one K-block per ring position.
         block_count = global_cb.receiver_cores().num_cores()
 
-    # Streaming gather needs identity ring rotation. Mcast consumes natural FIFO
-    # order and therefore uses the rotation-free request.
+    # Streaming gather needs identity ring rotation (``rotation[r] = r``). That table is
+    # layout-agnostic -- identical for ROUND_ROBIN_1D and CONTIGUOUS_1D receiver-contiguous
+    # weights -- because the kernel slices it by each weight's own global receiver position,
+    # so no distribution-strategy argument is needed here. Mcast consumes natural FIFO order
+    # and therefore uses the rotation-free request.
     if program_config.stream_in1:
         request = (weight, block_count, list(range(block_count)))
     else:

--- a/ttnn/ttnn/_experimental/tensor_prefetcher_matmul.py
+++ b/ttnn/ttnn/_experimental/tensor_prefetcher_matmul.py
@@ -7,19 +7,16 @@
 ``ttnn.experimental.queue_tensor_prefetcher_request`` (fills a DRAM-sender
 GlobalCircularBuffer over NOC, off the command queue) and the ``ttnn.linear``
 that drains that GCB are always issued as a pair, against the *same* GCB and the
-*same* gather_in0 program config. As two separate calls the caller has to (a)
+*same* 1D program config. As two separate calls the caller has to (a)
 hand both the same ``global_cb``, (b) hand both the same ``program_config``, and
 (c) pass a prefetch ``block_count`` that matches what the matmul expects -- three
 couplings nothing enforces.
 
 ``prefetch_and_linear`` issues the pair from one call site so they cannot drift:
-it derives ``block_count`` from ``global_cb``, queues the request, then runs the
-consuming ``ttnn.linear`` with the same GCB and program config. The matmul does
-``wait_front(ring_size)`` per layer, so the only correct ``block_count`` is the
-GCB's receiver count -- which holds for every weight layout (WIDTH_SHARDED and
-receiver-contiguous alike), so the caller never specifies it. The weight↔config
-geometry was already validated when the GCB was built (and ``ttnn.linear``
-re-checks it), so there is nothing left to cross-check here.
+it derives ``block_count``, queues the request, then runs the consuming
+``ttnn.linear`` with the same GCB and program config. Gather-in0 uses one block
+per ring receiver. Mcast-in0 uses ``K_tiles / in0_block_w`` natural-order blocks
+per receiver and requires a receiver-contiguous weight.
 
 This is a host-side composition, not a device-level fusion: the prefetch still
 runs on the DRAM-core (DRISC) path off the command queue while the matmul is
@@ -41,23 +38,19 @@ def prefetch_and_linear(
     **linear_kwargs,
 ):
     """Queue a DRAM-core prefetch of ``weight`` into ``global_cb``, then run the
-    gather_in0 1D matmul (``ttnn.linear``) that consumes it.
+    1D matmul (``ttnn.linear``) that consumes it.
 
-    Batched vs streaming delivery is selected automatically from
-    ``program_config.stream_in1`` -- there is no separate argument. When it is set the
-    prefetch streams the weight's K-blocks in natural ring order (identity rotation) so
-    the matmul can consume them FIFO from a shallow GCB; this works for both
-    ROUND_ROBIN_1D and CONTIGUOUS_1D receiver-contiguous weights. When it is unset the
-    request is batched (the whole per-receiver slab is delivered before the matmul reads).
+    Gather-in0 preserves its existing batched/streaming behavior selected by
+    ``program_config.stream_in1``. Mcast-in0 always uses natural FIFO order with
+    ``stream_in1=False`` and can consume from a shallow GCB without a rotation table.
 
     Args:
-        input_tensor_a: Activation (in0), width-sharded on the receiver cores.
-        weight: DRAM-sharded weight (in1) to prefetch and multiply by. Streaming
-            (``stream_in1``) additionally requires a receiver-contiguous weight layout.
+        input_tensor_a: Activation (in0).
+        weight: DRAM-sharded weight (in1) to prefetch and multiply by. Streaming gather
+            and GCB-backed mcast require a receiver-contiguous weight layout.
         global_cb: DRAM-sender GlobalCircularBuffer shared by the prefetch and
-            the matmul. Its receiver count fixes the prefetch ``block_count``.
-        program_config: gather_in0 1D mcast matmul program config driving the matmul;
-            its ``stream_in1`` flag selects streaming vs batched prefetch delivery.
+            the matmul.
+        program_config: 1D matmul program config driving the matmul.
         cq_id: Command queue for the prefetch request. When that CQ is mid
             trace-capture the request is captured into the trace. Defaults to the
             current command queue.
@@ -68,19 +61,14 @@ def prefetch_and_linear(
         The ``ttnn.linear`` output tensor.
     """
     device = input_tensor_a.device()
-    # block_count == ring_size == total GCB receivers: the matmul does
-    # wait_front(ring_size) per layer, so this is the only value that balances the
-    # page credits, regardless of the weight's shard layout.
-    block_count = global_cb.receiver_cores().num_cores()
-    # Streaming vs batched is decided entirely by the matmul's program config, so the
-    # caller passes no extra argument. With ``stream_in1`` the matmul consumes K-blocks
-    # FIFO as they land (letting the GCB hold only a shallow window), so the prefetch
-    # must deliver them in natural ring order -- an identity rotation table
-    # (``rotation[r] = r``). That table is layout-agnostic: it is identical for
-    # ROUND_ROBIN_1D and CONTIGUOUS_1D weights because the kernel slices it by each
-    # weight's own global receiver position, so no distribution-strategy argument is
-    # needed here. Without ``stream_in1`` the matmul waits for the whole per-receiver
-    # slab, so we queue the batched (rotation-free) request.
+    if program_config.mcast_in0 or program_config.stream_in1:
+        block_count = ttnn.experimental.tensor_prefetcher_block_count_for_matmul_1d(program_config, weight, global_cb)
+    else:
+        # Gather consumes one K-block per ring position.
+        block_count = global_cb.receiver_cores().num_cores()
+
+    # Streaming gather needs identity ring rotation. Mcast consumes natural FIFO
+    # order and therefore uses the rotation-free request.
     if program_config.stream_in1:
         request = (weight, block_count, list(range(block_count)))
     else:

--- a/ttnn/ttnn/_experimental/tensor_prefetcher_matmul.py
+++ b/ttnn/ttnn/_experimental/tensor_prefetcher_matmul.py
@@ -15,8 +15,10 @@ couplings nothing enforces.
 ``prefetch_and_linear`` issues the pair from one call site so they cannot drift:
 it derives ``block_count``, queues the request, then runs the consuming
 ``ttnn.linear`` with the same GCB and program config. Gather-in0 uses one block
-per ring receiver. Mcast-in0 uses ``K_tiles / in0_block_w`` natural-order blocks
-per receiver and requires a receiver-contiguous weight.
+per ring receiver. Mcast-in0 and bank-striped mcast-in1 use
+``K_tiles / in0_block_w`` natural-order blocks. Mcast-in1 keeps the DRAM-core
+prefetcher unicast-only: one worker relay per DRAM bank receives an N stripe and
+the relay workers assemble the full in1 block with worker-side multicast.
 
 This is a host-side composition, not a device-level fusion: the prefetch still
 runs on the DRAM-core (DRISC) path off the command queue while the matmul is
@@ -41,13 +43,15 @@ def prefetch_and_linear(
     1D matmul (``ttnn.linear``) that consumes it.
 
     Gather-in0 preserves its existing batched/streaming behavior selected by
-    ``program_config.stream_in1``. Mcast-in0 always uses natural FIFO order with
-    ``stream_in1=False`` and can consume from a shallow GCB without a rotation table.
+    ``program_config.stream_in1``. Both multicast modes use natural FIFO order
+    with ``stream_in1=False`` and can consume from a shallow GCB without a
+    rotation table.
 
     Args:
         input_tensor_a: Activation (in0).
-        weight: DRAM-sharded weight (in1) to prefetch and multiply by. Streaming gather
-            and GCB-backed mcast require a receiver-contiguous weight layout.
+        weight: DRAM-sharded weight (in1) to prefetch and multiply by. Streaming
+            gather and mcast-in0 require a receiver-contiguous weight layout;
+            mcast-in1 requires a bank-striped WIDTH_SHARDED layout.
         global_cb: DRAM-sender GlobalCircularBuffer shared by the prefetch and
             the matmul.
         program_config: 1D matmul program config driving the matmul.
@@ -61,7 +65,7 @@ def prefetch_and_linear(
         The ``ttnn.linear`` output tensor.
     """
     device = input_tensor_a.device()
-    if program_config.mcast_in0 or program_config.stream_in1:
+    if not program_config.gather_in0 or program_config.stream_in1:
         block_count = ttnn.experimental.tensor_prefetcher_block_count_for_matmul_1d(program_config, weight, global_cb)
     else:
         # Gather consumes one K-block per ring position.


### PR DESCRIPTION
### PR Category
Feature

### Summary
Closes #49428

Adds GCB-backed Tensor prefetcher support for the 1D matmul `mcast_in1` mode (`mcast_in0=false`, `gather_in0=false`). The Tensor prefetcher remains unicast-only: each DRAM bank sends its full-K, N-striped weight shard to one relay worker, and the relay workers collaboratively multicast disjoint stripes into a complete in1 block on every matmul worker.

This change:
- adds the bank-striped GCB geometry, block-count derivation, topology/window validation, and public API documentation;
- threads `global_cb` through the mcast-in1 factory and preserves program-cache runtime overrides;
- adds synchronized worker-side partial multicast, remote-CB credit handling, and coordinator-driven bias multicast;
- adds Blackhole PCC coverage for bias/no-bias and negative topology/window cases;
- documents why multicast stays on Tensix workers instead of adding DRISC multicast support.

### Notes for reviewers
Please focus on the relay synchronization protocol in the mcast-in1 sender/receiver kernels. Workers announce full-CB readiness to the bank-0 coordinator; each relay returns remote-GCB credit only after its stripe write barrier; workers publish the assembled block only after all relay completion increments arrive.

Verification:
- `~/bin-metal/build_metal.sh`
- new bank-striped mcast-in1 tests: 4 passed
- existing GCB mcast-in0 regressions: 2 passed
- ordinary mcast-in1 regression: 1 passed
- `git clang-format --style=file main`
- `pre-commit run --from-ref main --to-ref HEAD`
