### PR TITLE
Bug fix: bump vulnerable dependencies to clear Dependabot high + medium alerts

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -11,4 +11,4 @@ pandoc==2.3
 tabulate==0.9.0
 myst-parser==3.0.0
 nbconvert==7.17.1
-setuptools==80.10.2
+setuptools==83.0.0

--- a/models/demos/vision/generative/stable_diffusion/wormhole/demo/web_demo/requirements.txt
+++ b/models/demos/vision/generative/stable_diffusion/wormhole/demo/web_demo/requirements.txt
@@ -1,2 +1,2 @@
-gunicorn==21.2.0
+gunicorn==22.0.0
 streamlit==1.54.0

--- a/models/tt_dit/tests/dataset_eval/reference/requirements.txt
+++ b/models/tt_dit/tests/dataset_eval/reference/requirements.txt
@@ -7,10 +7,10 @@ pytest
 
 # model + tokenizer
 sentencepiece
-transformers==4.46.2
+transformers==5.5.0
 # latest dev version required for SD3.5 model architecture (qk_norm, norm_added_k, etc.)
 git+https://github.com/huggingface/diffusers.git
 open_clip_torch
 
 # vision + utilities
-Pillow>=12.1.1
+Pillow>=12.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "setuptools==80.10.2",
+  "setuptools==83.0.0",
   "setuptools-scm==8.1.0",
   "wheel",
 ]

--- a/tt-train/tools/weight-utils/requirements.txt
+++ b/tt-train/tools/weight-utils/requirements.txt
@@ -3,4 +3,4 @@ msgpack
 msgpack-numpy
 numpy
 tokenizers==0.21.1
-transformers==4.51.3
+transformers==5.5.0

--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -71,7 +71,7 @@ diffusers==0.38.0
 accelerate==1.7.0
 peft==0.18.1
 ftfy==6.1.1
-gitpython==3.1.50
+gitpython==3.1.52
 einops==0.6.1
 # Pin to this because evaluate 0.4.0 will download the latest multiprocess as a
 # transitive dep, which uses dill >=0.3.7, however many packages require
@@ -94,7 +94,7 @@ open_clip_torch==2.26.1 # Required for SDXL accuracy evaluation
 # Needed for various tests
 pyyaml>=5.4
 matplotlib
-Pillow==12.2.0
+Pillow==12.3.0
 jupyterlab==4.5.9
 ipywidgets==8.1.1
 bokeh==3.8.2


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Addresses the top open Dependabot alerts on the default branch by bumping pinned vulnerable dependencies to their patched versions. This change clears all 37 open high-severity alerts plus 3 medium-severity `setuptools` alerts — 40 alerts total — across 5 packages.

| Package | Change | CVEs / GHSAs | Manifests |
|---|---|---|---|
| `gunicorn` | `21.2.0` -> `22.0.0` | CVE-2024-1135, CVE-2024-6827 (HTTP request smuggling) | stable_diffusion web_demo |
| `Pillow` | `12.2.0` -> `12.3.0` | CVE-2026-54058/CVE-2026-54059/CVE-2026-54060/CVE-2026-55379/CVE-2026-55380/CVE-2026-59197/CVE-2026-59199/CVE-2026-59200/CVE-2026-59204/CVE-2026-59205 (heap OOB write, decompression-bomb bypass) | `requirements-dev.txt` (also covers `tests/end_to_end_tests/requirements.txt` via `-r` include) |
| `gitpython` | `3.1.50` -> `3.1.52` | GHSA-v396-v7q4-x2qj, GHSA-2f96-g7mh-g2hx, GHSA-956x-8gvw-wg5v, GHSA-rwj8-pgh3-r573 (command injection, env-var exfil) | `requirements-dev.txt` (also covers `tests/end_to_end_tests/requirements.txt`) |
| `transformers` | `4.46.2` / `4.51.3` -> `5.5.0` | CVE-2024-11392/CVE-2024-11393/CVE-2024-11394 (untrusted data deserialization), CVE-2026-4372 (RCE), CVE-2026-5241 (LightGlue RCE) | `models/tt_dit/.../reference/requirements.txt`, `tt-train/tools/weight-utils/requirements.txt` |
| `setuptools` | `80.10.2` -> `83.0.0` | GHSA path-traversal in package building (medium) | `pyproject.toml` build-system, `docs/requirements-docs.txt` (transitively covers `requirements-dev.txt` and `tests/end_to_end_tests/requirements.txt`) |

Also raises the `Pillow>=12.1.1` floor to `>=12.3.0` in the tt_dit reference requirements to clear the same CVE family.

### Notes for reviewers
- `gunicorn`, `Pillow`, `gitpython`, and `setuptools` are low-risk patch/minor bumps to the exact patched release.
- `transformers` is a **major** version jump (4.x -> 5.5.0) in two files. The dev environment already pins `transformers == 5.12.1` for Qwen3 support, so transformers 5.x is known to work in this repo, but the two affected scripts were pinned to 4.x and may behave differently on 5.x:
  - `models/tt_dit/tests/dataset_eval/reference/` (SD3.5 reference eval)
  - `tt-train/tools/weight-utils/`
  Reviewers/owners of those components should confirm the eval/tool still works on 5.5.0.
- `setuptools` is the build backend; the only validation needed is that the package still builds (verified via an isolated PEP 517 sdist build with `setuptools==83.0.0`).
- This is a dependency-version-only change; no source code is modified.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=gchoudhary/dependabot-high-severity-bumps)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:gchoudhary/dependabot-high-severity-bumps)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=gchoudhary/dependabot-high-severity-bumps)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:gchoudhary/dependabot-high-severity-bumps)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=gchoudhary/dependabot-high-severity-bumps)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:gchoudhary/dependabot-high-severity-bumps)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gchoudhary/dependabot-high-severity-bumps)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gchoudhary/dependabot-high-severity-bumps)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=gchoudhary/dependabot-high-severity-bumps)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:gchoudhary/dependabot-high-severity-bumps)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=gchoudhary/dependabot-high-severity-bumps)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:gchoudhary/dependabot-high-severity-bumps)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=gchoudhary/dependabot-high-severity-bumps)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:gchoudhary/dependabot-high-severity-bumps)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=gchoudhary/dependabot-high-severity-bumps)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:gchoudhary/dependabot-high-severity-bumps)
