### PR TITLE
Clean up Quasar LLK interface API

### DIFF
--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/llk_intf_api.hpp
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/overlay/llk_intf_api.hpp
@@ -4,45 +4,37 @@
 
 /**
  * @file llk_intf_api.hpp
- * @brief Low-Level Kernel (LLK) Interface API for tile counter and buffer management
+ * @brief Quasar low-level kernel interface tile-counter API.
  *
- * This file provides comprehensive API functions for managing LLK interface counters
- * and buffer operations in the overlay system. It includes both fast custom instruction
- * variants and standard memory-mapped register access functions.
+ * Provides direct memory-mapped access and custom-instruction access to the
+ * four LLK interfaces and their tile counters. The legacy custom-instruction
+ * helpers fence each operation; the fast helpers leave fence placement to the
+ * caller so several operations can be grouped behind one fence.
  */
 
 #pragma once
 
+#include <cstdint>
+
 #include "meta/registers/overlay_reg.h"
 #include "rocc_instructions.hpp"
 
+// Retain these macros for compatibility with existing callers.
 #define LLK_REG_SIZE TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_REG_MAP_SIZE
 #define COUNTER_REG_SIZE TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_TILE_COUNTERS_0__REG_FILE_SIZE
 
 namespace overlay {
 
-/**
- * @enum llk_interface_e
- * @brief Enumeration of available LLK interfaces
- *
- * Defines the available Low-Level Kernel interfaces in the system.
- * Each interface can manage multiple tile counters independently.
- */
+/** Available LLK interfaces. */
 enum llk_interface_e {
     LLK_INTERFACE_0 = 0,
     LLK_INTERFACE_1 = 1,
     LLK_INTERFACE_2 = 2,
     LLK_INTERFACE_3 = 3,
-    LLK_INTERFACE_SIZE = 4
+    LLK_INTERFACE_SIZE = 4,
 };
 
-/**
- * @enum llk_intf_counter_id
- * @brief Enumeration of LLK interface counter IDs
- *
- * Defines the available counter indices within each LLK interface.
- * Each interface supports up to 16 independent counters (0-15).
- */
+/** Counter indices within an LLK interface. */
 enum llk_intf_counter_id {
     LLK_INTF_COUNTER_0 = 0,
     LLK_INTF_COUNTER_1 = 1,
@@ -60,163 +52,201 @@ enum llk_intf_counter_id {
     LLK_INTF_COUNTER_13 = 13,
     LLK_INTF_COUNTER_14 = 14,
     LLK_INTF_COUNTER_15 = 15,
-    LLK_INTF_COUNTER_SIZE = 16
+    LLK_INTF_COUNTER_SIZE = 16,
 };
 
-// Legacy(slow) LLK Interface
-inline void llk_reg_write(uint64_t addr, uint64_t data) {
+// Fenced custom-instruction register access.
+
+/** Write an LLK interface register and fence subsequent memory operations. */
+inline void llk_reg_write(std::uint64_t addr, std::uint64_t data) {
     LLK_INTF_WRITE(addr, data);
     asm volatile("fence" : : : "memory");
 }
 
-inline uint64_t llk_reg_read(uint64_t addr) {
-    uint64_t data = LLK_INTF_READ(addr);
+/** Read an LLK interface register and fence subsequent memory operations. */
+inline std::uint64_t llk_reg_read(std::uint64_t addr) {
+    std::uint64_t data = LLK_INTF_READ(addr);
     asm volatile("fence" : : : "memory");
     return data;
 }
 
-// New (fast) LLK Interface
-inline void fast_llk_reg_write(uint64_t addr, uint64_t data) { LLK_INTF_WRITE(addr, data); }
+// Unfenced custom-instruction register access.
 
-inline uint64_t fast_llk_reg_read(uint64_t addr) {
-    uint64_t data = LLK_INTF_READ(addr);
+/** Write an LLK interface register without emitting a memory fence. */
+inline void fast_llk_reg_write(std::uint64_t addr, std::uint64_t data) { LLK_INTF_WRITE(addr, data); }
+
+/** Read an LLK interface register without emitting a memory fence. */
+inline std::uint64_t fast_llk_reg_read(std::uint64_t addr) {
+    std::uint64_t data = LLK_INTF_READ(addr);
     return data;
 }
 
-// -----------------------------------------------------------------------------
-// Legacy(slow) interface API below.
-// -----------------------------------------------------------------------------
+// Direct memory-mapped interface.
 
-inline __attribute__((always_inline)) void llk_intf_reset(uint64_t llk_if, uint64_t counter) {
-    *((volatile uint32_t*)(TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_REG_MAP_BASE_ADDR + llk_if * LLK_REG_SIZE +
-                           counter * COUNTER_REG_SIZE +
-                           TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_TILE_COUNTERS_0__RESET_REG_OFFSET)) = 1;
+/** Reset one tile counter in an LLK interface. */
+inline __attribute__((always_inline)) void llk_intf_reset(std::uint64_t llk_if, std::uint64_t counter) {
+    *reinterpret_cast<volatile std::uint32_t*>(
+        TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_REG_MAP_BASE_ADDR + llk_if * LLK_REG_SIZE +
+        counter * COUNTER_REG_SIZE + TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_TILE_COUNTERS_0__RESET_REG_OFFSET) =
+        1;
 }
 
-inline __attribute__((always_inline)) void llk_intf_inc_posted(uint64_t llk_if, uint64_t counter, uint64_t inc) {
-    *((volatile uint32_t*)(TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_REG_MAP_BASE_ADDR + llk_if * LLK_REG_SIZE +
-                           counter * COUNTER_REG_SIZE +
-                           TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_TILE_COUNTERS_0__POSTED_REG_OFFSET)) = inc;
+/** Increment the posted count for one tile counter. */
+inline __attribute__((always_inline)) void llk_intf_inc_posted(
+    std::uint64_t llk_if, std::uint64_t counter, std::uint64_t inc) {
+    *reinterpret_cast<volatile std::uint32_t*>(
+        TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_REG_MAP_BASE_ADDR + llk_if * LLK_REG_SIZE +
+        counter * COUNTER_REG_SIZE + TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_TILE_COUNTERS_0__POSTED_REG_OFFSET) =
+        inc;
 }
 
-inline __attribute__((always_inline)) void llk_intf_inc_acked(uint64_t llk_if, uint64_t counter, uint64_t inc) {
-    *((volatile uint32_t*)(TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_REG_MAP_BASE_ADDR + llk_if * LLK_REG_SIZE +
-                           counter * COUNTER_REG_SIZE +
-                           TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_TILE_COUNTERS_0__ACKED_REG_OFFSET)) = inc;
+/** Increment the acknowledged count for one tile counter. */
+inline __attribute__((always_inline)) void llk_intf_inc_acked(
+    std::uint64_t llk_if, std::uint64_t counter, std::uint64_t inc) {
+    *reinterpret_cast<volatile std::uint32_t*>(
+        TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_REG_MAP_BASE_ADDR + llk_if * LLK_REG_SIZE +
+        counter * COUNTER_REG_SIZE + TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_TILE_COUNTERS_0__ACKED_REG_OFFSET) =
+        inc;
 }
 
-inline __attribute__((always_inline)) uint64_t llk_intf_get_occupancy(uint64_t llk_if, uint64_t counter) {
-    return *((volatile uint32_t*)(TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_REG_MAP_BASE_ADDR +
-                                  llk_if * LLK_REG_SIZE + counter * COUNTER_REG_SIZE +
-                                  TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_TILE_COUNTERS_0__POSTED_REG_OFFSET));
+/** Return the occupancy value for one tile counter. */
+inline __attribute__((always_inline)) std::uint64_t llk_intf_get_occupancy(
+    std::uint64_t llk_if, std::uint64_t counter) {
+    return *reinterpret_cast<volatile std::uint32_t*>(
+        TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_REG_MAP_BASE_ADDR + llk_if * LLK_REG_SIZE +
+        counter * COUNTER_REG_SIZE + TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_TILE_COUNTERS_0__POSTED_REG_OFFSET);
 }
 
-inline __attribute__((always_inline)) uint64_t llk_intf_get_free_space(uint64_t llk_if, uint64_t counter) {
-    return *((volatile uint32_t*)(TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_REG_MAP_BASE_ADDR +
-                                  llk_if * LLK_REG_SIZE + counter * COUNTER_REG_SIZE +
-                                  TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_TILE_COUNTERS_0__ACKED_REG_OFFSET));
+/** Return the free-space value for one tile counter. */
+inline __attribute__((always_inline)) std::uint64_t llk_intf_get_free_space(
+    std::uint64_t llk_if, std::uint64_t counter) {
+    return *reinterpret_cast<volatile std::uint32_t*>(
+        TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_REG_MAP_BASE_ADDR + llk_if * LLK_REG_SIZE +
+        counter * COUNTER_REG_SIZE + TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_TILE_COUNTERS_0__ACKED_REG_OFFSET);
 }
 
-inline __attribute__((always_inline)) void llk_intf_set_capacity(uint64_t llk_if, uint64_t counter, uint64_t cap) {
-    *((volatile uint32_t*)(TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_REG_MAP_BASE_ADDR + llk_if * LLK_REG_SIZE +
-                           counter * COUNTER_REG_SIZE +
-                           TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_TILE_COUNTERS_0__BUFFER_CAPACITY_REG_OFFSET)) =
-        cap;
+/** Set the capacity for one tile counter. */
+inline __attribute__((always_inline)) void llk_intf_set_capacity(
+    std::uint64_t llk_if, std::uint64_t counter, std::uint64_t cap) {
+    *reinterpret_cast<volatile std::uint32_t*>(
+        TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_REG_MAP_BASE_ADDR + llk_if * LLK_REG_SIZE +
+        counter * COUNTER_REG_SIZE +
+        TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_TILE_COUNTERS_0__BUFFER_CAPACITY_REG_OFFSET) = cap;
 }
 
-inline __attribute__((always_inline)) uint64_t llk_intf_get_capacity(uint64_t llk_if, uint64_t counter) {
-    return *((
-        volatile uint32_t*)(TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_REG_MAP_BASE_ADDR + llk_if * LLK_REG_SIZE +
-                            counter * COUNTER_REG_SIZE +
-                            TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_TILE_COUNTERS_0__BUFFER_CAPACITY_REG_OFFSET));
+/** Return the configured capacity for one tile counter. */
+inline __attribute__((always_inline)) std::uint64_t llk_intf_get_capacity(std::uint64_t llk_if, std::uint64_t counter) {
+    return *reinterpret_cast<volatile std::uint32_t*>(
+        TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_REG_MAP_BASE_ADDR + llk_if * LLK_REG_SIZE +
+        counter * COUNTER_REG_SIZE +
+        TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_TILE_COUNTERS_0__BUFFER_CAPACITY_REG_OFFSET);
 }
 
-inline __attribute__((always_inline)) uint64_t llk_intf_get_posted(uint64_t llk_if, uint64_t counter) {
-    return *(
-        (volatile uint32_t*)(TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_REG_MAP_BASE_ADDR + llk_if * LLK_REG_SIZE +
-                             counter * COUNTER_REG_SIZE +
-                             TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_TILE_COUNTERS_0__READ_POSTED_REG_OFFSET));
+/** Return the current posted count for one tile counter. */
+inline __attribute__((always_inline)) std::uint64_t llk_intf_get_posted(std::uint64_t llk_if, std::uint64_t counter) {
+    return *reinterpret_cast<volatile std::uint32_t*>(
+        TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_REG_MAP_BASE_ADDR + llk_if * LLK_REG_SIZE +
+        counter * COUNTER_REG_SIZE +
+        TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_TILE_COUNTERS_0__READ_POSTED_REG_OFFSET);
 }
 
-inline __attribute__((always_inline)) uint64_t llk_intf_get_acked(uint64_t llk_if, uint64_t counter) {
-    return *(
-        (volatile uint32_t*)(TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_REG_MAP_BASE_ADDR + llk_if * LLK_REG_SIZE +
-                             counter * COUNTER_REG_SIZE +
-                             TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_TILE_COUNTERS_0__READ_ACKED_REG_OFFSET));
+/** Return the current acknowledged count for one tile counter. */
+inline __attribute__((always_inline)) std::uint64_t llk_intf_get_acked(std::uint64_t llk_if, std::uint64_t counter) {
+    return *reinterpret_cast<volatile std::uint32_t*>(
+        TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_REG_MAP_BASE_ADDR + llk_if * LLK_REG_SIZE +
+        counter * COUNTER_REG_SIZE +
+        TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_TILE_COUNTERS_0__READ_ACKED_REG_OFFSET);
 }
 
-inline __attribute__((always_inline)) uint64_t llk_intf_get_error(uint64_t llk_if, uint64_t counter) {
-    return *(
-        (volatile uint32_t*)(TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_REG_MAP_BASE_ADDR + llk_if * LLK_REG_SIZE +
-                             counter * COUNTER_REG_SIZE +
-                             TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_TILE_COUNTERS_0__ERROR_STATUS_REG_OFFSET));
+/** Return the error status for one tile counter. */
+inline __attribute__((always_inline)) std::uint64_t llk_intf_get_error(std::uint64_t llk_if, std::uint64_t counter) {
+    return *reinterpret_cast<volatile std::uint32_t*>(
+        TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_REG_MAP_BASE_ADDR + llk_if * LLK_REG_SIZE +
+        counter * COUNTER_REG_SIZE +
+        TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_TILE_COUNTERS_0__ERROR_STATUS_REG_OFFSET);
 }
 
-// -----------------------------------------------------------------------------
-// Fast interface API below.
-// Implements identical functions as above and expands to use all 4 LLK IFs
-// Important: after bulk of these functions add memory fence
-// -----------------------------------------------------------------------------
+// Unfenced custom-instruction interface. Callers must emit a memory fence after
+// a group of operations when ordering is required.
 
-inline __attribute__((always_inline)) void fast_llk_intf_reset(uint64_t llk_if, uint64_t counter) {
+/** Reset one tile counter without emitting a memory fence. */
+inline __attribute__((always_inline)) void fast_llk_intf_reset(std::uint64_t llk_if, std::uint64_t counter) {
     fast_llk_reg_write(
         llk_if * LLK_REG_SIZE + counter * COUNTER_REG_SIZE +
             TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_TILE_COUNTERS_0__RESET_REG_ADDR,
         1);
 }
 
-inline __attribute__((always_inline)) void fast_llk_intf_inc_posted(uint64_t llk_if, uint64_t counter, uint64_t inc) {
+/** Increment the posted count without emitting a memory fence. */
+inline __attribute__((always_inline)) void fast_llk_intf_inc_posted(
+    std::uint64_t llk_if, std::uint64_t counter, std::uint64_t inc) {
     fast_llk_reg_write(
         llk_if * LLK_REG_SIZE + counter * COUNTER_REG_SIZE +
             TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_TILE_COUNTERS_0__POSTED_REG_ADDR,
         inc);
 }
 
-inline __attribute__((always_inline)) void fast_llk_intf_inc_acked(uint64_t llk_if, uint64_t counter, uint64_t inc) {
+/** Increment the acknowledged count without emitting a memory fence. */
+inline __attribute__((always_inline)) void fast_llk_intf_inc_acked(
+    std::uint64_t llk_if, std::uint64_t counter, std::uint64_t inc) {
     fast_llk_reg_write(
         llk_if * LLK_REG_SIZE + counter * COUNTER_REG_SIZE +
             TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_TILE_COUNTERS_0__ACKED_REG_ADDR,
         inc);
 }
 
-inline __attribute__((always_inline)) uint64_t fast_llk_intf_get_occupancy(uint64_t llk_if, uint64_t counter) {
+/** Return the occupancy value without emitting a memory fence. */
+inline __attribute__((always_inline)) std::uint64_t fast_llk_intf_get_occupancy(
+    std::uint64_t llk_if, std::uint64_t counter) {
     return fast_llk_reg_read(
         llk_if * LLK_REG_SIZE + counter * COUNTER_REG_SIZE +
         TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_TILE_COUNTERS_0__POSTED_REG_ADDR);
 }
 
-inline __attribute__((always_inline)) uint64_t fast_llk_intf_get_free_space(uint64_t llk_if, uint64_t counter) {
+/** Return the free-space value without emitting a memory fence. */
+inline __attribute__((always_inline)) std::uint64_t fast_llk_intf_get_free_space(
+    std::uint64_t llk_if, std::uint64_t counter) {
     return fast_llk_reg_read(
         llk_if * LLK_REG_SIZE + counter * COUNTER_REG_SIZE +
         TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_TILE_COUNTERS_0__ACKED_REG_ADDR);
 }
 
-inline __attribute__((always_inline)) void fast_llk_intf_set_capacity(uint64_t llk_if, uint64_t counter, uint64_t cap) {
+/** Set the capacity without emitting a memory fence. */
+inline __attribute__((always_inline)) void fast_llk_intf_set_capacity(
+    std::uint64_t llk_if, std::uint64_t counter, std::uint64_t cap) {
     fast_llk_reg_write(
         llk_if * LLK_REG_SIZE + counter * COUNTER_REG_SIZE +
             TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_TILE_COUNTERS_0__BUFFER_CAPACITY_REG_ADDR,
         cap);
 }
 
-inline __attribute__((always_inline)) uint64_t fast_llk_intf_get_capacity(uint64_t llk_if, uint64_t counter) {
+/** Return the configured capacity without emitting a memory fence. */
+inline __attribute__((always_inline)) std::uint64_t fast_llk_intf_get_capacity(
+    std::uint64_t llk_if, std::uint64_t counter) {
     return fast_llk_reg_read(
         llk_if * LLK_REG_SIZE + counter * COUNTER_REG_SIZE +
         TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_TILE_COUNTERS_0__BUFFER_CAPACITY_REG_ADDR);
 }
 
-inline __attribute__((always_inline)) uint16_t fast_llk_intf_read_posted(uint64_t llk_if, uint64_t counter) {
+/** Return the 16-bit posted count without emitting a memory fence. */
+inline __attribute__((always_inline)) std::uint16_t fast_llk_intf_read_posted(
+    std::uint64_t llk_if, std::uint64_t counter) {
     return fast_llk_reg_read(
         llk_if * LLK_REG_SIZE + counter * COUNTER_REG_SIZE +
         TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_TILE_COUNTERS_0__READ_POSTED_REG_ADDR);
 }
 
-inline __attribute__((always_inline)) uint16_t fast_llk_intf_read_acked(uint64_t llk_if, uint64_t counter) {
+/** Return the 16-bit acknowledged count without emitting a memory fence. */
+inline __attribute__((always_inline)) std::uint16_t fast_llk_intf_read_acked(
+    std::uint64_t llk_if, std::uint64_t counter) {
     return fast_llk_reg_read(
         llk_if * LLK_REG_SIZE + counter * COUNTER_REG_SIZE +
         TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_TILE_COUNTERS_0__READ_ACKED_REG_ADDR);
 }
 
-inline __attribute__((always_inline)) uint16_t fast_llk_intf_read_error(uint64_t llk_if, uint64_t counter) {
+/** Return the 16-bit error status without emitting a memory fence. */
+inline __attribute__((always_inline)) std::uint16_t fast_llk_intf_read_error(
+    std::uint64_t llk_if, std::uint64_t counter) {
     return fast_llk_reg_read(
         llk_if * LLK_REG_SIZE + counter * COUNTER_REG_SIZE +
         TT_OVERLAY_LLK_TILE_COUNTERS_TT_LLK_INTERFACE_TILE_COUNTERS_0__ERROR_STATUS_REG_ADDR);


### PR DESCRIPTION
## Summary
- document every LLK interface entry point and clarify fenced, memory-mapped, and unfenced access paths
- use C++ fixed-width integer spelling and explicit `reinterpret_cast` for volatile MMIO access
- preserve all existing function names, enums, compatibility macros, register addresses, fence placement, return widths, and operation ordering

## Validation
- Quasar RISC-V cross-compile with `-std=c++17 -O2 -Wall -Wextra -Werror` exercising all 24 entry points
- compared pre- and post-cleanup `.text`; output is byte-for-byte identical
- repository pre-commit hooks pass

## Stack
- stacked on #50747 so this draft contains only `llk_intf_api.hpp`

No functional changes are intended.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vvukomanovic/quasar-llk-intf-api-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vvukomanovic/quasar-llk-intf-api-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vvukomanovic/quasar-llk-intf-api-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vvukomanovic/quasar-llk-intf-api-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=vvukomanovic/quasar-llk-intf-api-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:vvukomanovic/quasar-llk-intf-api-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vvukomanovic/quasar-llk-intf-api-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vvukomanovic/quasar-llk-intf-api-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vvukomanovic/quasar-llk-intf-api-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vvukomanovic/quasar-llk-intf-api-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vvukomanovic/quasar-llk-intf-api-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vvukomanovic/quasar-llk-intf-api-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vvukomanovic/quasar-llk-intf-api-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vvukomanovic/quasar-llk-intf-api-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vvukomanovic/quasar-llk-intf-api-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vvukomanovic/quasar-llk-intf-api-cleanup)