### PR TITLE
quasar sfpu: shared foundation (config_hash + LREG11 reload)

### DIFF
--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -1368,8 +1368,25 @@ std::string_view QuasarComputeKernel::get_linker_opt_level() const { return this
 
 std::string QuasarComputeKernel::config_hash() const {
     // QuasarComputeProcessor values must be sorted to ensure consistent ordering for hash generation
-    TT_ASSERT(std::is_sorted(this->compute_processors_.begin(), this->compute_processors_.end()));
-    return fmt::format("{}", fmt::join(this->compute_processors_, "_"));
+    TT_ASSERT(std::is_sorted(compute_processors_.begin(), compute_processors_.end()));
+
+    std::string unpack_mode_descriptor = "default";
+    const auto& unpack_modes = config_.unpack_to_dest_mode;
+    if (std::ranges::any_of(unpack_modes, [](auto v) { return v != UnpackToDestMode::Default; })) {
+        unpack_mode_descriptor = fmt::format("{}", fmt::join(unpack_modes, "."));
+    }
+
+    return fmt::format(
+        "{}_{}_{}_{}_{}_{}_{}_{}_{}",
+        fmt::join(compute_processors_, "_"),
+        enchantum::to_string(config_.math_fidelity),
+        config_.fp32_dest_acc_en,
+        config_.math_approx_mode,
+        config_.dst_full_sync_en,
+        config_.bfp8_pack_precise,
+        config_.enable_2x_src_format,
+        config_.unpack_to_dest_en,
+        unpack_mode_descriptor);
 }
 
 uint8_t QuasarComputeKernel::expected_num_binaries() const {

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/cmath_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/cmath_common.h
@@ -107,6 +107,10 @@ inline void _sfpu_load_config32_(const std::uint32_t dest, const std::uint32_t u
 inline void _init_sfpu_config_reg_()
 {
     TTI_SFPCONFIG(0, 0xF, 1);
+    // Quasar simulator doesn't apply the SFPU const-lreg reset default at boot.
+    // Reload programmable constant LREG11 = -1.0 (its RTL reset default) each launch: config_dest=0xB,
+    // instr_mod1[0]=1 loads the default. sfpi materializes -1.0 and subtract-based float compares via LREG11.
+    TTI_SFPCONFIG(0, 0xB, 1);
 }
 
 /**


### PR DESCRIPTION
Shared foundation for the Quasar SFPU per-kernel PR stack.

- `QuasarComputeKernel::config_hash` now includes fp32_dest_acc_en / math_approx_mode / sync / pack / unpack so 16- vs 32-bit-Dest (and approx) JIT builds don't collide in the kernel cache.
- `_init_sfpu_config_reg_` reloads programmable constant LREG11 = -1.0 (SFPCONFIG 0xB) per SFPU launch (the Quasar RTL doesn't apply the const-lreg reset default).

Base of the stack: negative → clamp → softplus (→ exp/recip/rsqrt to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=quasar-sfpu-foundation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:quasar-sfpu-foundation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=quasar-sfpu-foundation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:quasar-sfpu-foundation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=quasar-sfpu-foundation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:quasar-sfpu-foundation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=quasar-sfpu-foundation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:quasar-sfpu-foundation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=quasar-sfpu-foundation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:quasar-sfpu-foundation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=quasar-sfpu-foundation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:quasar-sfpu-foundation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=quasar-sfpu-foundation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:quasar-sfpu-foundation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=quasar-sfpu-foundation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:quasar-sfpu-foundation)