### PR TITLE
quasar sfpu: add clamp op (end to end)

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -73,6 +73,7 @@ const map<std::string, std::map<std::string, std::string>> sfpu_op_to_op_name = 
     {"mul_unary", {{"SFPU_OP_CHAIN_0", "binop_with_scalar_tile_init(); mul_unary_tile(0, 0x40000000u);"}}},  // 2.0f
     {"square", {{"SFPU_OP_CHAIN_0", "square_tile_init(); square_tile(0);"}}},
     {"negative", {{"SFPU_OP_CHAIN_0", "negative_tile_init(); negative_tile(0);"}}},
+    {"clamp", {{"SFPU_OP_CHAIN_0", "clamp_tile_init(); clamp_tile(0, 0xBF800000u, 0x3F800000u);"}}},
     // Comparison-to-zero family (unary): result = 1.0f if predicate(x, 0) else 0.0f.
     {"eqz", {{"SFPU_OP_CHAIN_0", "eqz_tile_init(); eqz_tile(0);"}}},
     {"nez", {{"SFPU_OP_CHAIN_0", "nez_tile_init(); nez_tile(0);"}}},
@@ -172,6 +173,9 @@ float sfpu_function(const std::string& op_name, float input) {
     }
     if (op_name == "negative") {
         return -input;
+    }
+    if (op_name == "clamp") {
+        return std::clamp(input, -1.0f, 1.0f);
     }
     if (op_name == "eqz") {
         return bfloat16(static_cast<float>(input) == 0.0f ? 1.0f : 0.0f);
@@ -285,6 +289,9 @@ vector<uint32_t> generate_packed_sfpu_input(const unsigned int numel, const std:
         // Include exact zeros so the eqz/nez/lez/gez at-zero branches are exercised.
         auto possible_values = vector<bfloat16>({-1.0f, -0.5f, 0.0f, 0.5f, 1.0f});
         return generate_packed_random_vector_from_vector<uint32_t, bfloat16>(possible_values, numel, seed);
+    }
+    if (op_name == "clamp") {
+        return generate_packed_uniform_random_vector<uint32_t, bfloat16>(-2.0f, 2.0f, numel, seed);
     }
     return generate_packed_uniform_random_vector<uint32_t, bfloat16>(-1.0f, 1.0f, numel, seed);
 }
@@ -878,6 +885,7 @@ bool run_sfpu_all_same_buffer(
     sfpu_defines["SFPU_OP_ERF_ERFC_INCLUDE"] = "1";
     sfpu_defines["SFPU_OP_ELU_INCLUDE"] = "1";
     sfpu_defines["SFPU_OP_NEG_INCLUDE"] = "1";
+    sfpu_defines["SFPU_OP_CLAMP_INCLUDE"] = "1";
     sfpu_defines["SFPU_OP_RELU_FAMILY_INCLUDE"] = "1";
     sfpu_defines["SFPU_OP_COMPUTE_KERNEL_API_INCLUDE"] = "1";
     sfpu_defines["SFPU_OP_BINOP_WITH_SCALAR_INCLUDE"] = "1";
@@ -1559,6 +1567,8 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_tuple(4, "square"),
         std::make_tuple(1, "negative"),
         std::make_tuple(4, "negative"),
+        std::make_tuple(1, "clamp"),
+        std::make_tuple(4, "clamp"),
         std::make_tuple(1, "relu"),
         std::make_tuple(1, "exponential"),
         std::make_tuple(1, "reciprocal"),
@@ -1684,6 +1694,8 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(
         std::make_tuple(1, "negative"),
         std::make_tuple(4, "negative"),
+        std::make_tuple(1, "clamp"),
+        std::make_tuple(4, "clamp"),
         std::make_tuple(1, "relu"),
         std::make_tuple(1, "exponential"),
         std::make_tuple(1, "reciprocal"),

--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -73,7 +73,7 @@ const map<std::string, std::map<std::string, std::string>> sfpu_op_to_op_name = 
     {"mul_unary", {{"SFPU_OP_CHAIN_0", "binop_with_scalar_tile_init(); mul_unary_tile(0, 0x40000000u);"}}},  // 2.0f
     {"square", {{"SFPU_OP_CHAIN_0", "square_tile_init(); square_tile(0);"}}},
     {"negative", {{"SFPU_OP_CHAIN_0", "negative_tile_init(); negative_tile(0);"}}},
-    {"clamp", {{"SFPU_OP_CHAIN_0", "clamp_tile_init(); clamp_tile(0, 0xBF800000u, 0x3F800000u);"}}},
+    {"clamp", {{"SFPU_OP_CHAIN_0", "clamp_tile_init(); clamp_tile(0, 0xBF800000u, 0x3F800000u);"}}},  // [-1.0f, 1.0f]
     // Comparison-to-zero family (unary): result = 1.0f if predicate(x, 0) else 0.0f.
     {"eqz", {{"SFPU_OP_CHAIN_0", "eqz_tile_init(); eqz_tile(0);"}}},
     {"nez", {{"SFPU_OP_CHAIN_0", "nez_tile_init(); nez_tile(0);"}}},

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_clamp.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_clamp.h
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel.h"
+#include "ckernel_trisc_common.h"
+#include "cmath_common.h"
+#include "llk_math_eltwise_unary_sfpu_init.h"
+#include "sfpi.h"
+
+namespace ckernel {
+namespace sfpu {
+
+/**
+ * @brief Element-wise clamp: out = min(max(x, min_val), max_val).
+ *
+ * Bounds are enforced with v_if/v_elseif compares; min_val/max_val are reinterpreted from their raw
+ * 32-bit word to fp32.
+ *
+ * @tparam APPROXIMATION_MODE: accepted for ABI parity but ignored (clamp is exact).
+ * @tparam ITERATIONS: number of SFPU passes over the tile.
+ * @param min_val: lower bound as an fp32 bit pattern.
+ * @param max_val: upper bound as an fp32 bit pattern.
+ * @note The compares lower to SFPMAD against vConstNeg1 (LREG11), so LREG11 must hold -1.0;
+ *       @ref _init_sfpu_config_reg_ re-establishes it per SFPU launch.
+ */
+template <bool APPROXIMATION_MODE, int ITERATIONS = SFPU_ITERATIONS>
+inline void calculate_clamp(std::uint32_t min_val, std::uint32_t max_val) {
+    sfpi::vFloat min_bound = sfpi::as<sfpi::vFloat>(sfpi::vUInt(min_val));
+    sfpi::vFloat max_bound = sfpi::as<sfpi::vFloat>(sfpi::vUInt(max_val));
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat val = sfpi::dst_reg[0];
+
+        v_if (val < min_bound) {
+            val = min_bound;
+        }
+        v_elseif (val >= max_bound) {
+            val = max_bound;
+        }
+        v_endif;
+
+        sfpi::dst_reg[0] = val;
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/clamp.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/clamp.h
@@ -39,6 +39,7 @@ ALWI void clamp_tile(uint32_t idst, uint32_t param0, uint32_t param1) {
         param1));
 }
 
+#ifndef ARCH_QUASAR
 // clang-format off
 /**
  * Performs element-wise clamp operation for int32. The DST
@@ -65,6 +66,7 @@ ALWI void clamp_tile_int32(uint32_t idst, uint32_t param0, uint32_t param1) {
         param0,
         param1));
 }
+#endif  // !ARCH_QUASAR
 
 /**
  * Please refer to documentation for any_init.

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
@@ -16,6 +16,7 @@
 //    call_unary_sfpu_operation_quasar() (and to init_unary_sfpu_operation_quasar()
 //    if the op needs an init step).
 #include "experimental/ckernel_sfpu_abs.h"
+#include "llk_sfpu/ckernel_sfpu_clamp.h"
 #include "llk_sfpu/ckernel_sfpu_comp.h"
 #include "llk_sfpu/ckernel_sfpu_gelu.h"
 #include "llk_sfpu/ckernel_sfpu_negative.h"
@@ -210,6 +211,17 @@ void call_unary_sfpu_operation_quasar(std::uint32_t dst_index, DataFormat sfpu_f
     else if constexpr (OPERATION == SfpuType::negative)
     {
         _llk_math_eltwise_unary_sfpu_params_(_calculate_negative_<false, ITERATIONS>, dst_index);
+    }
+    else if constexpr (OPERATION == SfpuType::clamp)
+    {
+        // Clamp bounds fixed to [-1.0, +1.0] as fp32 bit patterns (matching the UnarySFPUGolden._clamp
+        // reference). Extra args are forwarded to the per-face functor call.
+        _llk_math_eltwise_unary_sfpu_params_(
+            calculate_clamp<false, ITERATIONS>,
+            dst_index,
+            VectorMode::RC,
+            static_cast<std::uint32_t>(0xBF800000),  // min = -1.0 (fp32)
+            static_cast<std::uint32_t>(0x3F800000)); // max = +1.0 (fp32)
     }
     else if constexpr (is_zero_comp_op(OPERATION))
     {

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_sfpu_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_sfpu_quasar.py
@@ -338,6 +338,13 @@ def prepare_inputs_for_operation(
         max_val = 10.0
         src_A = min_val + src_A.to(torch.float32) * (max_val - min_val)
         src_A = src_A.to(torch_format)
+    elif mathop == MathOperation.Clamp:
+        # Clamp bounds are fixed to [-1, 1]; span past both to exercise the lower/upper/pass-through
+        # cases (mirrors sfpu_domains' Clamp spec).
+        min_val = -2.0
+        max_val = 2.0
+        src_A = min_val + src_A.to(torch.float32) * (max_val - min_val)
+        src_A = src_A.to(torch_format)
     elif mathop == MathOperation.Neg:
         # Negation is exact for any representable value; span both signs (mirrors sfpu_domains' Neg spec).
         min_val = -10.0
@@ -589,6 +596,7 @@ OP_CONFIGS = [
     OpConfig(MathOperation.Tanh, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
     OpConfig(MathOperation.Sigmoid, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
     OpConfig(MathOperation.Silu, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
+    OpConfig(MathOperation.Clamp, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
     OpConfig(MathOperation.Neg, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
     OpConfig(MathOperation.Typecast, TENSOR_DIMS, DEST_SYNC_MODES),
 ] + [OpConfig(op, TENSOR_DIMS, DEST_SYNC_MODES) for op in COMP_OPS]


### PR DESCRIPTION
Adds the Quasar `clamp` SFPU op end to end: LLK `_calculate_clamp_`, compute API, harness dispatch, and metal-gtest (per-arch bound re-emit) + python coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=quasar-sfpu-clamp)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:quasar-sfpu-clamp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=quasar-sfpu-clamp)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:quasar-sfpu-clamp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=quasar-sfpu-clamp)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:quasar-sfpu-clamp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=quasar-sfpu-clamp)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:quasar-sfpu-clamp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=quasar-sfpu-clamp)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:quasar-sfpu-clamp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=quasar-sfpu-clamp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:quasar-sfpu-clamp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=quasar-sfpu-clamp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:quasar-sfpu-clamp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=quasar-sfpu-clamp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:quasar-sfpu-clamp)