### PR TITLE
[deepseek_prefill][dispatch] fit sender/worker layout across rows — proper fix for #48694 galaxy regression

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
@@ -194,24 +194,19 @@ tt::tt_metal::ProgramDescriptor create_dispatch_program(
     uint32_t num_cores = effective_num_links;
 
     // ==================== Core layout: senders + worker cores ====================
-    // Collect all cores in the first row (y == subdevice_cores[0].y), sorted by x.
-    // Each sender owns num_workers consecutive worker cores (u1..uN): cores are
-    // laid out [sender, u1, ..., uN] consecutively along x per sender group.
-    uint32_t sender_row_y = subdevice_cores.at(0).y;
-    std::vector<CoreCoord> all_row_cores;
-    for (const auto& core : subdevice_cores) {
-        if (core.y == sender_row_y) {
-            all_row_cores.push_back(core);
-        }
-    }
-    std::sort(
-        all_row_cores.begin(), all_row_cores.end(), [](const CoreCoord& a, const CoreCoord& b) { return a.x < b.x; });
+    // Pack sender-groups from ALL sub-device cores (row-major), spanning rows when a
+    // single row is too narrow. Each sender owns num_workers consecutive worker cores
+    // (u1..uN), laid out [sender, u1, ..., uN]. Inter-core comms (sender<->workers and
+    // the worker baton ring) use explicit NOC virtual coords passed as runtime args, so
+    // a sender-group need not be physically contiguous or confined to one row.
+    std::vector<CoreCoord> all_row_cores =
+        corerange_to_cores(worker_core_range_set, std::nullopt, /*row_wise=*/true);
 
     uint32_t total_row_cores = static_cast<uint32_t>(all_row_cores.size());
     uint32_t cores_per_sender = 1 + num_workers;  // 1 sender + N worker cores (u1..uN)
     TT_FATAL(
         total_row_cores >= cores_per_sender * num_cores,
-        "Same-row has only {} cores for {} senders — need {} cores per sender (>= {} required)",
+        "Sub-device has only {} cores for {} senders — need {} cores per sender (>= {} required)",
         total_row_cores,
         num_cores,
         cores_per_sender,


### PR DESCRIPTION
## Proper fix for the GPT-OSS galaxy dispatch regression (keeps num_workers=2)

Companion to the interim workaround #50710 (which forced GPT-OSS to `num_workers_per_sender=1`). This fixes the root cause in the dispatch factory so GPT-OSS keeps the pre-regression **2 workers** with no model retuning.

### Root cause (bisected → #48694)
`#48694` ("Dispatch row major path refactor", `af00262e51d`, @nostojic) gave the row-major dispatch path the tile path's sender+worker fan-out, but packs every sender-group into a **single worker row** (`core.y == subdevice_cores[0].y`). WH galaxy's worker sub-device row is **8 cores**; GPT-OSS prefill needs `num_cores(4) × cores_per_sender(1+2) = 12` → `TT_FATAL: Same-row has only 8 cores for 4 senders`. Pre-#48694 (parent `0a798f1243e`) passed — confirmed by CI (parent PASSES 2/2).

### Fix
Draw the sender/worker cores from the **whole worker sub-device, row-major** (spanning rows) instead of one row. The single-row packing was only a core-selection convenience — all inter-core comms (sender↔workers, worker baton ring) use explicit NOC virtual coords passed as runtime args, with no same-row/adjacency assumption in the kernels (`reader_worker_dispatch.cpp`, `writer_worker`). No kernel change needed. The guard `total_cores >= cores_per_sender*num_cores` is unchanged; only the eligible core set widens.

### Why not just the #50710 workaround?
The workaround (`num_workers=1`) is CI-validated and perf-neutral (29.02 vs 29.08 tok/s/user), but it retunes GPT-OSS to fit a regressed constraint and leaves the single-row limit in place for other 4-link/2-worker galaxy users. This PR restores the intended behavior at the dispatch layer.

### Validation
CI (GPT-OSS 120B [wh_galaxy_perf], with default num_workers=2) — links added below once dispatched. Expect assert gone + perf ≈ 2-worker baseline (~29.08 tok/s/user).

cc @nostojic / @tenstorrent/metalium-developers-ds-prefill

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/gptoss-dispatch-multirow-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/gptoss-dispatch-multirow-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/gptoss-dispatch-multirow-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/gptoss-dispatch-multirow-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mtairum/gptoss-dispatch-multirow-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mtairum/gptoss-dispatch-multirow-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/gptoss-dispatch-multirow-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/gptoss-dispatch-multirow-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/gptoss-dispatch-multirow-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/gptoss-dispatch-multirow-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/gptoss-dispatch-multirow-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/gptoss-dispatch-multirow-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/gptoss-dispatch-multirow-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/gptoss-dispatch-multirow-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/gptoss-dispatch-multirow-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/gptoss-dispatch-multirow-fix)