### PR TITLE
Update Blackhole SDPA perf targets

### DIFF
--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -3529,7 +3529,7 @@ else:
     RING_JOINT_PERF_CHECK_CONFIGS = [
         # (model_name, q_chunk_size, k_chunk_size, ring_size, expected_util, margin)
         # 4-device ring (QuietBox, sp=4 tp=1)
-        ("wan2_2_1xGLX", 288, 512, 4, 68.9, RING_JOINT_PERF_MARGIN),
+        ("wan2_2_1xGLX", 288, 512, 4, 68.5, RING_JOINT_PERF_MARGIN),
         ("mla_100k", 160, 320, 4, 63.2, RING_JOINT_PERF_MARGIN),
     ]
 

--- a/tests/nightly/blackhole/sdpa/test_scaled_dot_product_attention_sprint.py
+++ b/tests/nightly/blackhole/sdpa/test_scaled_dot_product_attention_sprint.py
@@ -422,7 +422,7 @@ def test_sdpa_create_perf_table(b, nh, s, d):
 
 # === TEST 5: PERFORMANCE CHECK ===
 # Symmetric +/- band — catches both regressions and unexpected speedups.
-SDPA_PERF_MARGIN = 0.01
+SDPA_PERF_MARGIN = 0.015
 
 SDPA_PERF_CHECK_CONFIGS = [
     # (shape_id, q_chunk_size, k_chunk_size, expected_util)


### PR DESCRIPTION
## Summary
- update the WAN ring-joint expected math utilization to 68.5% after several small, necessary correctness and code-size regressions accumulated over time
- keep the analog SDPA target at 57.5%, but widen its margin from +/-1.0% to +/-1.5%; five local runs averaged 57.38%, while CI reached 58.11%, so the center is still accurate but the observed runner variance is wider than the old band

## Testing
- [![Blackhole sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=skrstic/adjust-sdpa-perf-targets)](https://github.com/tenstorrent/tt-metal/actions/runs/29996478402)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/adjust-sdpa-perf-targets)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/adjust-sdpa-perf-targets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/adjust-sdpa-perf-targets)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/adjust-sdpa-perf-targets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=skrstic/adjust-sdpa-perf-targets)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:skrstic/adjust-sdpa-perf-targets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/adjust-sdpa-perf-targets)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/adjust-sdpa-perf-targets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/adjust-sdpa-perf-targets)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/adjust-sdpa-perf-targets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/adjust-sdpa-perf-targets)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/adjust-sdpa-perf-targets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/adjust-sdpa-perf-targets)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/adjust-sdpa-perf-targets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/adjust-sdpa-perf-targets)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/adjust-sdpa-perf-targets)